### PR TITLE
Bug765 - Delays using Edit commands and Draw Tool in long projects

### DIFF
--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -117,14 +117,7 @@ HistoryWindow::HistoryWindow(AudacityProject *parent, UndoManager *manager):
    S.EndVerticalLay();
    // ----------------------- End of main section --------------
 
-   // Vaughan, 2010-07-30: AudacityProject::OnHistory always calls Show()
-   //    then HistoryWindow::UpdateDisplay, so no need to do it here.
-   // Vaughan, 2010-10-16: Not on Windows, anyway.
-   //    But Steve reported that on Ubuntu, View > History now crashes,
-   //    so restore it for non-Windows.
-   #ifdef __WXGTK__
-      DoUpdate();
-   #endif
+   DoUpdate();
    mList->SetMinSize(mList->GetSize());
    Fit();
    SetMinSize(GetSize());
@@ -146,6 +139,8 @@ void HistoryWindow::UpdateDisplay()
 void HistoryWindow::DoUpdate()
 {
    int i;
+
+   mManager->CalculateSpaceUsage();
 
    mList->DeleteAllItems();
 

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -5133,7 +5133,6 @@ void AudacityProject::OnHistory()
       mHistoryWindow = new HistoryWindow(this, &mUndoManager);
    mHistoryWindow->Show();
    mHistoryWindow->Raise();
-   mHistoryWindow->UpdateDisplay();
 }
 
 void AudacityProject::OnKaraoke()

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -4625,17 +4625,16 @@ void AudacityProject::AutoSave()
    wxString fn = wxFileName(FileNames::AutoSaveDir(),
       projName + wxString(wxT(" - ")) + CreateUniqueName()).GetFullPath();
 
-   XMLFileWriter saveFile;
-
    try
    {
-      saveFile.Open(fn + wxT(".tmp"), wxT("wb"));
+      XMLStringWriter buffer(1024 * 1024);
+      VarSetter<bool> setter(&mAutoSaving, true, false);
+      WriteXMLHeader(buffer);
+      WriteXML(buffer);
 
-      {
-         VarSetter<bool> setter(&mAutoSaving, true, false);
-         WriteXMLHeader(saveFile);
-         WriteXML(saveFile);
-      }
+      XMLFileWriter saveFile;
+      saveFile.Open(fn + wxT(".tmp"), wxT("wb"));
+      saveFile.WriteSubTree(buffer);
 
       // JKC Calling XMLFileWriter::Close will close the <project> scope.
       // We certainly don't want to do that, if we're doing recordingrecovery,

--- a/src/Project.h
+++ b/src/Project.h
@@ -443,7 +443,7 @@ class AUDACITY_DLL_API AudacityProject:  public wxFrame,
    static void AllProjectsDeleteUnlock();
 
    void PushState(wxString desc, wxString shortDesc,
-                  int flags = PUSH_AUTOSAVE | PUSH_CALC_SPACE);
+                  int flags = PUSH_AUTOSAVE);
 
  private:
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -3033,7 +3033,7 @@ void TrackPanel::Stretch(int mouseXCoordinate, int trackLeftEdge,
       break;
    }
    MakeParentPushState(_("Stretch Note Track"), _("Stretch"),
-      PUSH_CONSOLIDATE | PUSH_AUTOSAVE | PUSH_CALC_SPACE);
+      PUSH_CONSOLIDATE | PUSH_AUTOSAVE);
    mStretched = true;
    Refresh(false);
 }
@@ -3620,7 +3620,7 @@ void TrackPanel::HandleSlide(wxMouseEvent & event)
          consolidate = true;
       }
       MakeParentPushState(msg, _("Time-Shift"),
-         consolidate ? (PUSH_CONSOLIDATE) : (PUSH_AUTOSAVE|PUSH_CALC_SPACE));
+         consolidate ? (PUSH_CONSOLIDATE) : (PUSH_AUTOSAVE));
    }
 }
 
@@ -4886,7 +4886,7 @@ void TrackPanel::HandleSampleEditingButtonUp( wxMouseEvent & WXUNUSED(event))
    mDrawingTrack=NULL;       //Set this to NULL so it will catch improper drag events.
    MakeParentPushState(_("Moved Sample"),
                        _("Sample Edit"),
-                       PUSH_CONSOLIDATE|PUSH_AUTOSAVE|PUSH_CALC_SPACE);
+                       PUSH_CONSOLIDATE|PUSH_AUTOSAVE);
 }
 
 
@@ -6259,7 +6259,7 @@ bool TrackPanel::HandleTrackLocationMouseEvent(WaveTrack * track, wxRect &r, wxM
                   !linked->MergeClips(mCapturedTrackLocation.clipidx1, mCapturedTrackLocation.clipidx2))
                      return false;
 
-            MakeParentPushState(_("Merged Clips"),_("Merge"), PUSH_CONSOLIDATE|PUSH_CALC_SPACE);
+            MakeParentPushState(_("Merged Clips"),_("Merge"), PUSH_CONSOLIDATE);
             handled = true;
          }
       }

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -437,7 +437,7 @@ protected:
 
    // AS: Pushing the state preserves state for Undo operations.
    virtual void MakeParentPushState(wxString desc, wxString shortDesc,
-                            int flags = PUSH_AUTOSAVE | PUSH_CALC_SPACE);
+                            int flags = PUSH_AUTOSAVE);
    virtual void MakeParentModifyState(bool bWantsAutoSave);    // if true, writes auto-save file. Should set only if you really want the state change restored after
                                                                // a crash, as it can take many seconds for large (eg. 10 track-hours) projects
    virtual void MakeParentResize();

--- a/src/TrackPanelListener.h
+++ b/src/TrackPanelListener.h
@@ -29,7 +29,7 @@ class AUDACITY_DLL_API TrackPanelListener {
 
    virtual void TP_OnPlayKey() = 0;
    virtual void TP_PushState(wxString shortDesc, wxString longDesc,
-                            int flags = PUSH_AUTOSAVE | PUSH_CALC_SPACE) = 0;
+                            int flags = PUSH_AUTOSAVE) = 0;
    virtual void TP_ModifyState(bool bWantsAutoSave) = 0;    // if true, writes auto-save file. Should set only if you really want the state change restored after
                                                             // a crash, as it can take many seconds for large (eg. 10 track-hours) projects
    virtual void TP_RedrawScrollbars() = 0;

--- a/src/UndoManager.h
+++ b/src/UndoManager.h
@@ -61,18 +61,17 @@ struct UndoStackElem {
    wxString description;
    wxString shortDescription;
    SelectedRegion selectedRegion;
-   wxLongLong spaceUsage;
 };
 
 WX_DEFINE_USER_EXPORTED_ARRAY(UndoStackElem *, UndoStack, class AUDACITY_DLL_API);
+WX_DEFINE_USER_EXPORTED_ARRAY_SIZE_T(size_t, SpaceArray, class AUDACITY_DLL_API);
 
 // These flags control what extra to do on a PushState
-// Default is PUSH_AUTOSAVE | PUSH_CALC_SPACE
+// Default is PUSH_AUTOSAVE
 // Frequent/faster actions use PUSH_CONSOLIDATE
 const int PUSH_MINIMAL = 0;
 const int PUSH_CONSOLIDATE = 1;
-const int PUSH_CALC_SPACE = 2;
-const int PUSH_AUTOSAVE = 4;
+const int PUSH_AUTOSAVE = 2;
 
 class AUDACITY_DLL_API UndoManager {
  public:
@@ -82,7 +81,7 @@ class AUDACITY_DLL_API UndoManager {
    void PushState(TrackList * l,
                   const SelectedRegion &selectedRegion,
                   wxString longDescription, wxString shortDescription,
-                  int flags = PUSH_CALC_SPACE|PUSH_AUTOSAVE );
+                  int flags = PUSH_AUTOSAVE);
    void ModifyState(TrackList * l,
                     const SelectedRegion &selectedRegion);
    void ClearStates();
@@ -105,6 +104,8 @@ class AUDACITY_DLL_API UndoManager {
    bool UnsavedChanges();
    void StateSaved();
 
+   void CalculateSpaceUsage();
+
    // void Debug(); // currently unused
 
    ///to mark as unsaved changes without changing the state/tracks.
@@ -113,14 +114,14 @@ class AUDACITY_DLL_API UndoManager {
    void ResetODChangesFlag();
 
  private:
-   wxLongLong CalculateSpaceUsage(int index);
-
    int current;
    int saved;
    UndoStack stack;
 
    wxString lastAction;
    int consolidationCount;
+
+   SpaceArray space;
 
    bool mODChanges;
    ODLock mODChangesMutex;//mODChanges is accessed from many threads.

--- a/src/blockfile/SimpleBlockFile.cpp
+++ b/src/blockfile/SimpleBlockFile.cpp
@@ -543,8 +543,7 @@ wxLongLong SimpleBlockFile::GetSpaceUsage()
       return 0;
    } else
    {
-      wxFFile dataFile(mFileName.GetFullPath());
-      return dataFile.Length();
+      return sizeof(auHeader) + mSummaryInfo.totalSummaryBytes + (GetLength() * SAMPLE_SIZE(floatSample));
    }
 }
 

--- a/src/xml/XMLWriter.cpp
+++ b/src/xml/XMLWriter.cpp
@@ -310,8 +310,12 @@ void XMLFileWriter::Write(const wxString &data)
 ///
 /// XMLStringWriter class
 ///
-XMLStringWriter::XMLStringWriter()
+XMLStringWriter::XMLStringWriter(size_t initialSize)
 {
+   if (initialSize)
+   {
+      Alloc(initialSize);
+   }
 }
 
 XMLStringWriter::~XMLStringWriter()

--- a/src/xml/XMLWriter.h
+++ b/src/xml/XMLWriter.h
@@ -103,7 +103,7 @@ class XMLStringWriter:public wxString, public XMLWriter {
 
  public:
 
-   XMLStringWriter();
+   XMLStringWriter(size_t initialSize = 0);
    virtual ~XMLStringWriter();
 
    void Write(const wxString &data);


### PR DESCRIPTION
A 4hr track used to take about 20s to cut a few samples.  This is now significantly improved, to around 3s.  Leland did this by 

(a) moving the size calculation to when we examine the undo history, so it isn't slowing down the edits.
(b) in size calculation, using sizes that are cached rather than going to disk to find the sizes.
(c) writing the autosave file which is to an FFIle to a string first, i.e. using XMLStringWriter as a buffer for XMLFileWriter.

Step (c) may also make autosave marginally safer, as the risk of a partially updated autosave file is reduced.
