### PR TITLE
This will change the autosave file to a binary representation of the XML

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2924,7 +2924,7 @@ void AudioIO::FillBuffers()
       {
          // Append captured samples to the end of the WaveTracks.
          // The WaveTracks have their own buffering for efficiency.
-         XMLStringWriter blockFileLog;
+         AutoSaveFile blockFileLog;
          int numChannels = mCaptureTracks.GetCount();
 
          for( i = 0; (int)i < numChannels; i++ )
@@ -2932,7 +2932,7 @@ void AudioIO::FillBuffers()
             int avail = commonlyAvail;
             sampleFormat trackFormat = mCaptureTracks[i]->GetSampleFormat();
 
-            XMLStringWriter appendLog;
+            AutoSaveFile appendLog;
 
             if( mFactor == 1.0 )
             {

--- a/src/AudioIOListener.h
+++ b/src/AudioIOListener.h
@@ -15,6 +15,8 @@
 
 #include <wx/string.h>
 
+#include "AutoRecovery.h"
+
 class AUDACITY_DLL_API AudioIOListener {
 public:
    AudioIOListener() {}
@@ -23,7 +25,7 @@ public:
    virtual void OnAudioIORate(int rate) = 0;
    virtual void OnAudioIOStartRecording() = 0;
    virtual void OnAudioIOStopRecording() = 0;
-   virtual void OnAudioIONewBlockFiles(const wxString& blockFileLog) = 0;
+   virtual void OnAudioIONewBlockFiles(const AutoSaveFile & blockFileLog) = 0;
 };
 
 #endif

--- a/src/AutoRecovery.h
+++ b/src/AutoRecovery.h
@@ -12,9 +12,15 @@
 #define __AUDACITY_AUTORECOVERY__
 
 #include "Project.h"
+
 #include "xml/XMLTagHandler.h"
+#include "xml/XMLWriter.h"
 
 #include <wx/debug.h>
+#include <wx/dynarray.h>
+#include <wx/ffile.h>
+#include <wx/hashmap.h>
+#include <wx/mstream.h>
 
 //
 // Show auto recovery dialog if there are projects to recover. Should be
@@ -50,5 +56,60 @@ private:
    int mChannel;
    int mNumChannels;
 };
+
+///
+/// AutoSaveFile
+///
+
+// Should be plain ASCII
+#define AutoSaveIdent "<?xml autosave>"
+
+WX_DECLARE_STRING_HASH_MAP_WITH_DECL(short, NameMap, class AUDACITY_DLL_API);
+WX_DECLARE_HASH_MAP(short, wxString, wxIntegerHash, wxIntegerEqual, IdMap);
+
+class AUDACITY_DLL_API AutoSaveFile : public XMLWriter
+{
+public:
+
+   AutoSaveFile(size_t allocSize = 1024 * 1024);
+   virtual ~AutoSaveFile();
+
+   virtual void StartTag(const wxString &name);
+   virtual void EndTag(const wxString &name);
+
+   virtual void WriteAttr(const wxString &name, const wxString &value);
+   virtual void WriteAttr(const wxString &name, const wxChar *value);
+
+   virtual void WriteAttr(const wxString &name, int value);
+   virtual void WriteAttr(const wxString &name, bool value);
+   virtual void WriteAttr(const wxString &name, long value);
+   virtual void WriteAttr(const wxString &name, long long value);
+   virtual void WriteAttr(const wxString &name, size_t value);
+   virtual void WriteAttr(const wxString &name, float value, int digits = -1);
+   virtual void WriteAttr(const wxString &name, double value, int digits = -1);
+
+   virtual void WriteData(const wxString &value);
+
+   virtual void WriteSubTree(const AutoSaveFile &value);
+
+   virtual void Write(const wxString &data);
+   virtual bool Write(wxFFile & file) const;
+
+   virtual bool IsEmpty() const;
+
+   virtual bool Decode(const wxString & fileName);
+
+private:
+   void WriteName(const wxString & name);
+   void CheckSpace(wxMemoryOutputStream & buf);
+
+private:
+   wxMemoryOutputStream mBuffer;
+   wxMemoryOutputStream mDict;
+   NameMap mNames;
+   IdMap mIds;
+   size_t mAllocSize;
+};
+
 
 #endif

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -2469,19 +2469,17 @@ void AudacityProject::OpenFile(wxString fileName, bool addtohistory)
       return;
    }
 
-   // We want to open projects using wxTextFile, but if it's NOT a project
-   // file (but actually a WAV file, for example), then wxTextFile will spin
-   // for a long time searching for line breaks.  So, we look for our
-   // signature at the beginning of the file first:
-
-   wxString firstLine = wxT("AudacityProject");
-
    if (!::wxFileExists(fileName)) {
       wxMessageBox(_("Could not open file: ") + fileName,
                    _("Error Opening File"),
                    wxOK | wxCENTRE, this);
       return;
    }
+
+   // We want to open projects using wxTextFile, but if it's NOT a project
+   // file (but actually a WAV file, for example), then wxTextFile will spin
+   // for a long time searching for line breaks.  So, we look for our
+   // signature at the beginning of the file first:
 
    wxFFile *ff = new wxFFile(fileName, wxT("rb"));
    if (!ff->IsOpened()) {
@@ -2495,9 +2493,9 @@ void AudacityProject::OpenFile(wxString fileName, bool addtohistory)
       wxMessageBox(wxString::Format(_("File may be invalid or corrupted: \n%s"),
                    (const wxChar*)fileName), _("Error Opening File or Project"),
                    wxOK | wxCENTRE, this);
-     ff->Close();
-     delete ff;
-     return;
+      ff->Close();
+      delete ff;
+      return;
    }
    buf[15] = 0;
    ff->Close();
@@ -2549,31 +2547,13 @@ void AudacityProject::OpenFile(wxString fileName, bool addtohistory)
    if (mFileName.Length() >= autoSaveExt.Length() &&
        mFileName.Right(autoSaveExt.Length()) == autoSaveExt)
    {
-      // This is an auto-save file, add </project> tag, if necessary
-      wxFile f(fileName, wxFile::read_write);
-      if (f.IsOpened())
+      AutoSaveFile asf;
+      if (!asf.Decode(fileName))
       {
-         // Read the last 16 bytes of the file and check if they contain
-         // "</project>" somewhere.
-         const int bufsize = 16;
-         char buf[bufsize];
-         bool seekOk, readOk;
-         seekOk = f.SeekEnd(-bufsize) != wxInvalidOffset;
-         if (seekOk)
-            readOk = (f.Read(buf, bufsize) == bufsize);
-         else
-            readOk = false;
-         if (readOk && !strstr(buf, "</project>"))
-         {
-            // End of file does not contain closing </project> tag, so add it
-            if (f.Seek(0, wxFromEnd) != wxInvalidOffset)
-            {
-               strcpy(buf, "</project>\n");
-               f.Write(buf, strlen(buf));
-            }
-         }
-
-         f.Close();
+         wxMessageBox(_("Could not decode file: ") + fileName,
+                      _("Error decoding file"),
+                      wxOK | wxCENTRE, this);
+         return;
       }
    }
 
@@ -4641,20 +4621,16 @@ void AudacityProject::AutoSave()
 
    try
    {
-      XMLStringWriter buffer(1024 * 1024);
       VarSetter<bool> setter(&mAutoSaving, true, false);
+
+      AutoSaveFile buffer;
       WriteXMLHeader(buffer);
       WriteXML(buffer);
 
-      XMLFileWriter saveFile;
+      wxFFile saveFile;
       saveFile.Open(fn + wxT(".tmp"), wxT("wb"));
-      saveFile.WriteSubTree(buffer);
-
-      // JKC Calling XMLFileWriter::Close will close the <project> scope.
-      // We certainly don't want to do that, if we're doing recordingrecovery,
-      // because the recordingrecovery tags need to be inside <project></project>.
-      // So instead we do not call Close() but CloseWithoutEndingTags().
-      saveFile.CloseWithoutEndingTags();
+      buffer.Write(saveFile);
+      saveFile.Close();
    }
    catch (XMLFileWriterException* pException)
    {
@@ -4736,13 +4712,7 @@ void AudacityProject::OnAudioIOStartRecording()
 {
    // Before recording is started, auto-save the file. The file will have
    // empty tracks at the bottom where the recording will be put into
-   //
-   // When block files are cached, auto recovery is disabled while recording,
-   // since no block files are written during recording that could be
-   // recovered.
-   //
-   if (!GetCacheBlockFiles())
-      AutoSave();
+   AutoSave();
 }
 
 // This is called after recording has stopped and all tracks have flushed.
@@ -4773,28 +4743,17 @@ void AudacityProject::OnAudioIOStopRecording()
    AutoSave();
 }
 
-void AudacityProject::OnAudioIONewBlockFiles(const wxString& blockFileLog)
+void AudacityProject::OnAudioIONewBlockFiles(const AutoSaveFile & blockFileLog)
 {
    // New blockfiles have been created, so add them to the auto-save file
-   if (!GetCacheBlockFiles() &&
-       !mAutoSaveFileName.IsEmpty())
+   if (!mAutoSaveFileName.IsEmpty())
    {
-      wxFFile f(mAutoSaveFileName, wxT("at"));
+      wxFFile f(mAutoSaveFileName, wxT("ab"));
       if (!f.IsOpened())
          return; // Keep recording going, there's not much we can do here
-      f.Write(blockFileLog);
+      blockFileLog.Write(f);
       f.Close();
    }
-}
-
-bool AudacityProject::GetCacheBlockFiles()
-{
-   bool cacheBlockFiles = false;
-#ifdef DEPRECATED_AUDIO_CACHE
-   // See http://bugzilla.audacityteam.org/show_bug.cgi?id=545.
-   gPrefs->Read(wxT("/Directories/CacheBlockFiles"), &cacheBlockFiles);
-#endif
-   return cacheBlockFiles;
 }
 
 void AudacityProject::SetSnapTo(int snap)

--- a/src/Project.h
+++ b/src/Project.h
@@ -433,7 +433,7 @@ class AUDACITY_DLL_API AudacityProject:  public wxFrame,
    virtual void OnAudioIORate(int rate);
    virtual void OnAudioIOStartRecording();
    virtual void OnAudioIOStopRecording();
-   virtual void OnAudioIONewBlockFiles(const wxString& blockFileLog);
+   virtual void OnAudioIONewBlockFiles(const AutoSaveFile & blockFileLog);
 
    // Command Handling
    bool TryToMakeActionAllowed( wxUint32 & flags, wxUint32 flagsRqd, wxUint32 mask );
@@ -460,8 +460,6 @@ class AUDACITY_DLL_API AudacityProject:  public wxFrame,
 
    void AutoSave();
    void DeleteCurrentAutoSaveFile();
-
-   static bool GetCacheBlockFiles();
 
  public:
    bool IsSoloSimple() { return mSoloPref == wxT("Simple"); }

--- a/src/xml/XMLWriter.cpp
+++ b/src/xml/XMLWriter.cpp
@@ -33,7 +33,6 @@ the general functionality for creating XML in UTF8 encoding.
 
 #include "../Internat.h"
 #include "XMLWriter.h"
-#include "XMLTagHandler.h"
 
 //table for xml encoding compatibility with expat decoding
 //see wxWidgets-2.8.12/src/expat/lib/xmltok_impl.h

--- a/src/xml/XMLWriter.h
+++ b/src/xml/XMLWriter.h
@@ -10,8 +10,9 @@
 #ifndef __AUDACITY_XML_XML_FILE_WRITER__
 #define __AUDACITY_XML_XML_FILE_WRITER__
 
-#include <wx/ffile.h>
+#include <wx/arrstr.h>
 #include <wx/dynarray.h>
+#include <wx/ffile.h>
 
 ///
 /// XMLWriter
@@ -23,23 +24,23 @@ class AUDACITY_DLL_API XMLWriter {
    XMLWriter();
    virtual ~XMLWriter();
 
-   void StartTag(const wxString &name);
-   void EndTag(const wxString &name);
+   virtual void StartTag(const wxString &name);
+   virtual void EndTag(const wxString &name);
 
-   void WriteAttr(const wxString &name, const wxString &value);
-   void WriteAttr(const wxString &name, const wxChar *value);
+   virtual void WriteAttr(const wxString &name, const wxString &value);
+   virtual void WriteAttr(const wxString &name, const wxChar *value);
 
-   void WriteAttr(const wxString &name, int value);
-   void WriteAttr(const wxString &name, bool value);
-   void WriteAttr(const wxString &name, long value);
-   void WriteAttr(const wxString &name, long long value);
-   void WriteAttr(const wxString &name, size_t value);
-   void WriteAttr(const wxString &name, float value, int digits = -1);
-   void WriteAttr(const wxString &name, double value, int digits = -1);
+   virtual void WriteAttr(const wxString &name, int value);
+   virtual void WriteAttr(const wxString &name, bool value);
+   virtual void WriteAttr(const wxString &name, long value);
+   virtual void WriteAttr(const wxString &name, long long value);
+   virtual void WriteAttr(const wxString &name, size_t value);
+   virtual void WriteAttr(const wxString &name, float value, int digits = -1);
+   virtual void WriteAttr(const wxString &name, double value, int digits = -1);
 
-   void WriteData(const wxString &value);
+   virtual void WriteData(const wxString &value);
 
-   void WriteSubTree(const wxString &value);
+   virtual void WriteSubTree(const wxString &value);
 
    virtual void Write(const wxString &data) = 0;
 


### PR DESCRIPTION
file. By doing this, all of the processing required to convert values to
a textual format (float, doubles, int, strings) is now moved to recovery
instead. This gets it out of the autosave path and improves responsiveness
quite a bit.

Edits in large projects are considerably faster after this change.