### PR TITLE
Removing unused/obsolete libraries from lib-src

### DIFF
--- a/configure
+++ b/configure
@@ -689,18 +689,6 @@ USE_LOCAL_SBSMS_FALSE
 USE_LOCAL_SBSMS_TRUE
 USE_SBSMS_FALSE
 USE_SBSMS_TRUE
-USE_LOCAL_LIBSAMPLERATE_FALSE
-USE_LOCAL_LIBSAMPLERATE_TRUE
-USE_LIBSAMPLERATE_FALSE
-USE_LIBSAMPLERATE_TRUE
-SAMPLERATE_LIBS
-SAMPLERATE_CFLAGS
-USE_LOCAL_LIBRESAMPLE_FALSE
-USE_LOCAL_LIBRESAMPLE_TRUE
-USE_LIBRESAMPLE_FALSE
-USE_LIBRESAMPLE_TRUE
-LIBRESAMPLE_LIBS
-LIBRESAMPLE_CFLAGS
 USE_LOCAL_LIBNYQUIST_FALSE
 USE_LOCAL_LIBNYQUIST_TRUE
 USE_LIBNYQUIST_FALSE
@@ -759,8 +747,6 @@ SNDFILE_LIBS
 SNDFILE_CFLAGS
 SBSMS_LIBS
 SBSMS_CFLAGS
-LIBSAMPLERATE_SYSTEM_LIBS
-LIBSAMPLERATE_SYSTEM_CFLAGS
 LIBMAD_LIBS
 LIBMAD_CFLAGS
 ID3TAG_LIBS
@@ -964,8 +950,6 @@ with_libflac
 with_libid3tag
 with_libmad
 enable_nyquist
-with_libresample
-with_libsamplerate
 with_sbsms
 with_libsndfile
 with_soundtouch
@@ -1011,8 +995,6 @@ ID3TAG_CFLAGS
 ID3TAG_LIBS
 LIBMAD_CFLAGS
 LIBMAD_LIBS
-LIBSAMPLERATE_SYSTEM_CFLAGS
-LIBSAMPLERATE_SYSTEM_LIBS
 SBSMS_CFLAGS
 SBSMS_LIBS
 SNDFILE_CFLAGS
@@ -1045,8 +1027,6 @@ lib-src/libflac
 lib-src/libid3tag
 lib-src/libmad
 lib-src/libnyquist
-lib-src/libresample
-lib-src/libsamplerate
 lib-src/sbsms
 lib-src/libsndfile
 lib-src/soundtouch
@@ -1732,8 +1712,6 @@ Optional Packages:
   --with-libflac          use libFLAC for FLAC support
   --with-libid3tag        use libid3tag for mp3 id3 tag support
   --with-libmad           use libmad for mp2/3 decoding support
-  --with-libresample      use libresample for sample rate conversion
-  --with-libsamplerate    use libsamplerate for sample rate conversion
   --with-sbsms            use libsbsms for pitch and tempo changing
   --with-libsndfile       which libsndfile to use (required): [system,local]
   --with-soundtouch       use libSoundTouch for pitch and tempo changing
@@ -1783,10 +1761,6 @@ Some influential environment variables:
   LIBMAD_CFLAGS
               C compiler flags for LIBMAD, overriding pkg-config
   LIBMAD_LIBS linker flags for LIBMAD, overriding pkg-config
-  LIBSAMPLERATE_SYSTEM_CFLAGS
-              C compiler flags for LIBSAMPLERATE_SYSTEM, overriding pkg-config
-  LIBSAMPLERATE_SYSTEM_LIBS
-              linker flags for LIBSAMPLERATE_SYSTEM, overriding pkg-config
   SBSMS_CFLAGS
               C compiler flags for SBSMS, overriding pkg-config
   SBSMS_LIBS  linker flags for SBSMS, overriding pkg-config
@@ -2916,7 +2890,7 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
 
-am__api_version='1.13'
+am__api_version='1.14'
 
 # Find a good install program.  We prefer a C program (faster),
 # so one script is as good as another.  But avoid the broken or
@@ -3088,8 +3062,8 @@ test "$program_suffix" != NONE &&
 ac_script='s/[\\$]/&&/g;s/;s,x,x,$//'
 program_transform_name=`$as_echo "$program_transform_name" | sed "$ac_script"`
 
-# expand $ac_aux_dir to an absolute path
-am_aux_dir=`cd $ac_aux_dir && pwd`
+# Expand $ac_aux_dir to an absolute path.
+am_aux_dir=`cd "$ac_aux_dir" && pwd`
 
 if test x"${MISSING+set}" != xset; then
   case $am_aux_dir in
@@ -3568,6 +3542,48 @@ $as_echo "$am_cv_prog_tar_ustar" >&6; }
 
 
 
+
+# POSIX will say in a future version that running "rm -f" with no argument
+# is OK; and we want to be able to make that assumption in our Makefile
+# recipes.  So use an aggressive probe to check that the usage we want is
+# actually supported "in the wild" to an acceptable degree.
+# See automake bug#10828.
+# To make any issue more visible, cause the running configure to be aborted
+# by default if the 'rm' program in use doesn't match our expectations; the
+# user can still override this though.
+if rm -f && rm -fr && rm -rf; then : OK; else
+  cat >&2 <<'END'
+Oops!
+
+Your 'rm' program seems unable to run without file operands specified
+on the command line, even when the '-f' option is present.  This is contrary
+to the behaviour of most rm programs out there, and not conforming with
+the upcoming POSIX standard: <http://austingroupbugs.net/view.php?id=542>
+
+Please tell bug-automake@gnu.org about your system, including the value
+of your $PATH and any error possibly output before this message.  This
+can help us improve future automake versions.
+
+END
+  if test x"$ACCEPT_INFERIOR_RM_PROGRAM" = x"yes"; then
+    echo 'Configuration will proceed anyway, since you have set the' >&2
+    echo 'ACCEPT_INFERIOR_RM_PROGRAM variable to "yes"' >&2
+    echo >&2
+  else
+    cat >&2 <<'END'
+Aborting the configuration process, to ensure you take notice of the issue.
+
+You can download and install GNU coreutils to get an 'rm' implementation
+that behaves properly: <http://www.gnu.org/software/coreutils/>.
+
+If you want to complete the configuration process using your problematic
+'rm' anyway, export the environment variable ACCEPT_INFERIOR_RM_PROGRAM
+to "yes", and re-run configure.
+
+END
+    as_fn_error $? "Your 'rm' program is bad, sorry." "$LINENO" 5
+  fi
+fi
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
@@ -4768,6 +4784,65 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC understands -c and -o together" >&5
+$as_echo_n "checking whether $CC understands -c and -o together... " >&6; }
+if ${am_cv_prog_cc_c_o+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+  # Make sure it works both with $CC and with simple cc.
+  # Following AC_PROG_CC_C_O, we do the test twice because some
+  # compilers refuse to overwrite an existing .o file with -o,
+  # though they will create one.
+  am_cv_prog_cc_c_o=yes
+  for am_i in 1 2; do
+    if { echo "$as_me:$LINENO: $CC -c conftest.$ac_ext -o conftest2.$ac_objext" >&5
+   ($CC -c conftest.$ac_ext -o conftest2.$ac_objext) >&5 2>&5
+   ac_status=$?
+   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+   (exit $ac_status); } \
+         && test -f conftest2.$ac_objext; then
+      : OK
+    else
+      am_cv_prog_cc_c_o=no
+      break
+    fi
+  done
+  rm -f core conftest*
+  unset am_i
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_prog_cc_c_o" >&5
+$as_echo "$am_cv_prog_cc_c_o" >&6; }
+if test "$am_cv_prog_cc_c_o" != yes; then
+   # Losing compiler, so override with the script.
+   # FIXME: It is wrong to rewrite CC.
+   # But if we don't then we get into trouble of one sort or another.
+   # A longer-term fix would be to have automake use am__CC in this case,
+   # and then we could set am__CC="\$(top_srcdir)/compile \$(CC)"
+   CC="$am_aux_dir/compile $CC"
+fi
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
 
 depcc="$CC"   am_compiler_list=
 
@@ -7518,6 +7593,65 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC understands -c and -o together" >&5
+$as_echo_n "checking whether $CC understands -c and -o together... " >&6; }
+if ${am_cv_prog_cc_c_o+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+  # Make sure it works both with $CC and with simple cc.
+  # Following AC_PROG_CC_C_O, we do the test twice because some
+  # compilers refuse to overwrite an existing .o file with -o,
+  # though they will create one.
+  am_cv_prog_cc_c_o=yes
+  for am_i in 1 2; do
+    if { echo "$as_me:$LINENO: $CC -c conftest.$ac_ext -o conftest2.$ac_objext" >&5
+   ($CC -c conftest.$ac_ext -o conftest2.$ac_objext) >&5 2>&5
+   ac_status=$?
+   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+   (exit $ac_status); } \
+         && test -f conftest2.$ac_objext; then
+      : OK
+    else
+      am_cv_prog_cc_c_o=no
+      break
+    fi
+  done
+  rm -f core conftest*
+  unset am_i
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_prog_cc_c_o" >&5
+$as_echo "$am_cv_prog_cc_c_o" >&6; }
+if test "$am_cv_prog_cc_c_o" != yes; then
+   # Losing compiler, so override with the script.
+   # FIXME: It is wrong to rewrite CC.
+   # But if we don't then we get into trouble of one sort or another.
+   # A longer-term fix would be to have automake use am__CC in this case,
+   # and then we could set am__CC="\$(top_srcdir)/compile \$(CC)"
+   CC="$am_aux_dir/compile $CC"
+fi
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
 depcc="$CC"   am_compiler_list=
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking dependency style of $depcc" >&5
@@ -8174,7 +8308,6 @@ CFLAGS="$cflags_save"
 CPPFLAGS="$cppflags_save"
 CXXFLAGS="$cxxflags_save"
 
-
 if test -n "$ac_tool_prefix"; then
   for ac_prog in ar lib "link -lib"
   do
@@ -8282,12 +8415,18 @@ $as_echo_n "checking the archiver ($AR) interface... " >&6; }
 if ${am_cv_ar_interface+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  am_cv_ar_interface=ar
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   am_cv_ar_interface=ar
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 int some_variable = 0;
 _ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
+if ac_fn_c_try_compile "$LINENO"; then :
   am_ar_try='$AR cru libconftest.a conftest.$ac_objext >&5'
       { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$am_ar_try\""; } >&5
   (eval $am_ar_try) 2>&5
@@ -8313,6 +8452,11 @@ if ac_fn_cxx_try_compile "$LINENO"; then :
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+   ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_ar_interface" >&5
@@ -9718,6 +9862,7 @@ fi
 $as_echo "$lt_cv_sharedlib_from_linklib_cmd" >&6; }
 sharedlib_from_linklib_cmd=$lt_cv_sharedlib_from_linklib_cmd
 test -z "$sharedlib_from_linklib_cmd" && sharedlib_from_linklib_cmd=$ECHO
+
 
 
 
@@ -20968,173 +21113,8 @@ $as_echo "$as_me: nyquist libraries are available in the local tree" >&6;}
 $as_echo "$as_me: nyquist libraries are NOT available in the local tree" >&6;}
    fi
 
-
-
-
-# Check whether --with-libresample was given.
-if test "${with_libresample+set}" = set; then :
-  withval=$with_libresample; LIBRESAMPLE_ARGUMENT=$withval
-else
-  LIBRESAMPLE_ARGUMENT="unspecified"
-fi
-
-
-
-
-   LIBRESAMPLE_SYSTEM_AVAILABLE="no"
-
-
-   as_ac_File=`$as_echo "ac_cv_file_${srcdir}/lib-src/libresample/include/libresample.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${srcdir}/lib-src/libresample/include/libresample.h" >&5
-$as_echo_n "checking for ${srcdir}/lib-src/libresample/include/libresample.h... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "${srcdir}/lib-src/libresample/include/libresample.h"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-  LIBRESAMPLE_LOCAL_AVAILABLE="yes"
-else
-  LIBRESAMPLE_LOCAL_AVAILABLE="no"
-fi
-
-
-   if test "$LIBRESAMPLE_LOCAL_AVAILABLE" = "yes"; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: libresample libraries are available in the local tree" >&5
-$as_echo "$as_me: libresample libraries are available in the local tree" >&6;}
-   else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: libresample libraries are NOT available in the local tree" >&5
-$as_echo "$as_me: libresample libraries are NOT available in the local tree" >&6;}
-   fi
-
-
-
-
-# Check whether --with-libsamplerate was given.
-if test "${with_libsamplerate+set}" = set; then :
-  withval=$with_libsamplerate; LIBSAMPLERATE_ARGUMENT=$withval
-else
-  LIBSAMPLERATE_ARGUMENT="unspecified"
-fi
-
-
-
-pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for LIBSAMPLERATE_SYSTEM" >&5
-$as_echo_n "checking for LIBSAMPLERATE_SYSTEM... " >&6; }
-
-if test -n "$LIBSAMPLERATE_SYSTEM_CFLAGS"; then
-    pkg_cv_LIBSAMPLERATE_SYSTEM_CFLAGS="$LIBSAMPLERATE_SYSTEM_CFLAGS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"samplerate >= 0.1.2\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "samplerate >= 0.1.2") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_LIBSAMPLERATE_SYSTEM_CFLAGS=`$PKG_CONFIG --cflags "samplerate >= 0.1.2" 2>/dev/null`
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-if test -n "$LIBSAMPLERATE_SYSTEM_LIBS"; then
-    pkg_cv_LIBSAMPLERATE_SYSTEM_LIBS="$LIBSAMPLERATE_SYSTEM_LIBS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"samplerate >= 0.1.2\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "samplerate >= 0.1.2") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_LIBSAMPLERATE_SYSTEM_LIBS=`$PKG_CONFIG --libs "samplerate >= 0.1.2" 2>/dev/null`
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-
-
-
-if test $pkg_failed = yes; then
-
-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
-        _pkg_short_errors_supported=yes
-else
-        _pkg_short_errors_supported=no
-fi
-        if test $_pkg_short_errors_supported = yes; then
-	        LIBSAMPLERATE_SYSTEM_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors "samplerate >= 0.1.2" 2>&1`
-        else
-	        LIBSAMPLERATE_SYSTEM_PKG_ERRORS=`$PKG_CONFIG --print-errors "samplerate >= 0.1.2" 2>&1`
-        fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$LIBSAMPLERATE_SYSTEM_PKG_ERRORS" >&5
-
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-                LIBSAMPLERATE_SYSTEM_AVAILABLE="no"
-elif test $pkg_failed = untried; then
-	LIBSAMPLERATE_SYSTEM_AVAILABLE="no"
-else
-	LIBSAMPLERATE_SYSTEM_CFLAGS=$pkg_cv_LIBSAMPLERATE_SYSTEM_CFLAGS
-	LIBSAMPLERATE_SYSTEM_LIBS=$pkg_cv_LIBSAMPLERATE_SYSTEM_LIBS
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-	LIBSAMPLERATE_SYSTEM_AVAILABLE="yes"
-fi
-            if test "$LIBSAMPLERATE_SYSTEM_AVAILABLE" = "yes" ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: Libsamplerate libraries are available as system libraries" >&5
-$as_echo "$as_me: Libsamplerate libraries are available as system libraries" >&6;}
-   else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: Libsamplerate libraries are NOT available as system libraries" >&5
-$as_echo "$as_me: Libsamplerate libraries are NOT available as system libraries" >&6;}
-   fi
-
-
-   as_ac_File=`$as_echo "ac_cv_file_${srcdir}/lib-src/libsamplerate/src/samplerate.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${srcdir}/lib-src/libsamplerate/src/samplerate.h" >&5
-$as_echo_n "checking for ${srcdir}/lib-src/libsamplerate/src/samplerate.h... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "${srcdir}/lib-src/libsamplerate/src/samplerate.h"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-  LIBSAMPLERATE_LOCAL_AVAILABLE="yes"
-else
-  LIBSAMPLERATE_LOCAL_AVAILABLE="no"
-fi
-
-
-   if test "$LIBSAMPLERATE_LOCAL_AVAILABLE" = "yes" ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: libsamplerate libraries are available in the local tree" >&5
-$as_echo "$as_me: libsamplerate libraries are available in the local tree" >&6;}
-   else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: libsamplerate libraries are NOT available in the local tree" >&5
-$as_echo "$as_me: libsamplerate libraries are NOT available in the local tree" >&6;}
-   fi
-
+AUDACITY_CHECKLIB_LIBRESAMPLE
+AUDACITY_CHECKLIB_LIBSAMPLERATE
 
 
 # Check whether --with-sbsms was given.
@@ -23066,74 +23046,8 @@ $as_echo "#define USE_NYQUIST 1" >>confdefs.h
 
    fi
 
-
-   if test "$LIBRESAMPLE_USE_LOCAL" = yes; then
-      LIBRESAMPLE_CFLAGS='-I$(top_srcdir)/lib-src/libresample/include'
-      LIBRESAMPLE_LIBS='$(top_builddir)/lib-src/libresample/libresample.a'
-      subdirs="$subdirs lib-src/libresample"
-
-   fi
-
-
-
-
-    if test "$LIBRESAMPLE_USE_LOCAL" = yes -o "$LIBRESAMPLE_USE_SYSTEM" = yes; then
-  USE_LIBRESAMPLE_TRUE=
-  USE_LIBRESAMPLE_FALSE='#'
-else
-  USE_LIBRESAMPLE_TRUE='#'
-  USE_LIBRESAMPLE_FALSE=
-fi
-
-    if test "$LIBRESAMPLE_USE_LOCAL" = yes; then
-  USE_LOCAL_LIBRESAMPLE_TRUE=
-  USE_LOCAL_LIBRESAMPLE_FALSE='#'
-else
-  USE_LOCAL_LIBRESAMPLE_TRUE='#'
-  USE_LOCAL_LIBRESAMPLE_FALSE=
-fi
-
-
-   if test "$LIBRESAMPLE_USE_LOCAL" = yes -o "$LIBRESAMPLE_USE_SYSTEM" = yes; then
-
-$as_echo "#define USE_LIBRESAMPLE 1" >>confdefs.h
-
-   fi
-
-
-   if test "$LIBSAMPLERATE_USE_LOCAL" = yes; then
-      SAMPLERATE_CFLAGS='-I$(top_srcdir)/lib-src/libsamplerate/src'
-      SAMPLERATE_LIBS='$(top_builddir)/lib-src/libsamplerate/libsamplerate.a'
-      subdirs="$subdirs lib-src/libsamplerate"
-
-   fi
-
-
-
-
-    if test "$LIBSAMPLERATE_USE_LOCAL" = yes -o "$LIBSAMPLERATE_USE_SYSTEM" = yes; then
-  USE_LIBSAMPLERATE_TRUE=
-  USE_LIBSAMPLERATE_FALSE='#'
-else
-  USE_LIBSAMPLERATE_TRUE='#'
-  USE_LIBSAMPLERATE_FALSE=
-fi
-
-    if test "$LIBSAMPLERATE_USE_LOCAL" = yes; then
-  USE_LOCAL_LIBSAMPLERATE_TRUE=
-  USE_LOCAL_LIBSAMPLERATE_FALSE='#'
-else
-  USE_LOCAL_LIBSAMPLERATE_TRUE='#'
-  USE_LOCAL_LIBSAMPLERATE_FALSE=
-fi
-
-
-   if test "$LIBSAMPLERATE_USE_LOCAL" = yes -o "$LIBSAMPLERATE_USE_SYSTEM" = yes; then
-
-$as_echo "#define USE_LIBSAMPLERATE 1" >>confdefs.h
-
-   fi
-
+AUDACITY_CONFIG_LIBRESAMPLE
+AUDACITY_CONFIG_LIBSAMPLERATE
 
    if test "$LIBSBSMS_USE_LOCAL" = yes; then
       SBSMS_CFLAGS='-I$(top_srcdir)/lib-src/sbsms/include'
@@ -24458,22 +24372,6 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${USE_LOCAL_LIBNYQUIST_TRUE}" && test -z "${USE_LOCAL_LIBNYQUIST_FALSE}"; then
   as_fn_error $? "conditional \"USE_LOCAL_LIBNYQUIST\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${USE_LIBRESAMPLE_TRUE}" && test -z "${USE_LIBRESAMPLE_FALSE}"; then
-  as_fn_error $? "conditional \"USE_LIBRESAMPLE\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${USE_LOCAL_LIBRESAMPLE_TRUE}" && test -z "${USE_LOCAL_LIBRESAMPLE_FALSE}"; then
-  as_fn_error $? "conditional \"USE_LOCAL_LIBRESAMPLE\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${USE_LIBSAMPLERATE_TRUE}" && test -z "${USE_LIBSAMPLERATE_FALSE}"; then
-  as_fn_error $? "conditional \"USE_LIBSAMPLERATE\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${USE_LOCAL_LIBSAMPLERATE_TRUE}" && test -z "${USE_LOCAL_LIBSAMPLERATE_FALSE}"; then
-  as_fn_error $? "conditional \"USE_LOCAL_LIBSAMPLERATE\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${USE_SBSMS_TRUE}" && test -z "${USE_SBSMS_FALSE}"; then


### PR DESCRIPTION
Libs removed:

id3lib
libresample
libsamplerate
portburn
taglib (can always put it back in if needed)

This effectively makes libsoxr THE resampling lib for Audacity and
changes were made to include it in the minsrc tarball.