### PR TITLE
VS2013 includes the log2() function, so prevent Nyquist from defining it...

### DIFF
--- a/lib-src/audacity-patches.txt
+++ b/lib-src/audacity-patches.txt
@@ -63,6 +63,7 @@ Digital Audio scripting language, with our own library interface added to it
 Version in Audacity SVN: 3.09
 nyquist.patch  Fix for a couple of memory leaks
 xlisp.patch    Fix build in Windows
+sound.patch    Fix build when using VS2013 (log2 is included in VS2013)
 
 libogg
 ------

--- a/lib-src/libnyquist/nyquist/nyqsrc/sound.c
+++ b/lib-src/libnyquist/nyquist/nyqsrc/sound.c
@@ -1588,12 +1588,14 @@ double step_to_hz(double steps)
 }
 
 #ifdef WIN32
+#ifndef _MSC_VER < 1800
 #define RECIP_LOG_2 1.44269504088895364453
 
 double log2(double x)
 {
   return log(x) * RECIP_LOG_2;
 }
+#endif
 #endif
 
 /*

--- a/lib-src/libnyquist/sound.patch
+++ b/lib-src/libnyquist/sound.patch
@@ -1,0 +1,20 @@
+diff --git a/lib-src/libnyquist/nyquist/nyqsrc/sound.c b/lib-src/libnyquist/nyquist/nyqsrc/sound.c
+index 35de780..d81beb5 100644
+--- a/lib-src/libnyquist/nyquist/nyqsrc/sound.c
++++ b/lib-src/libnyquist/nyquist/nyqsrc/sound.c
+@@ -1588,6 +1588,7 @@ double step_to_hz(double steps)
+ }
+ 
+ #ifdef WIN32
++#ifndef _MSC_VER < 1800
+ #define RECIP_LOG_2 1.44269504088895364453
+ 
+ double log2(double x)
+@@ -1595,6 +1596,7 @@ double log2(double x)
+   return log(x) * RECIP_LOG_2;
+ }
+ #endif
++#endif
+ 
+ /*
+  * from old stuff...


### PR DESCRIPTION
....