### PR TITLE
Don't capture the mouse if it's already captured.

### DIFF
--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -6126,7 +6126,8 @@ void TrackPanel::OnMouseEvent(wxMouseEvent & event)
 
    if (event.ButtonDown()) {
       SetFocus();
-      CaptureMouse();
+      if (!HasCapture())
+         CaptureMouse();
    }
    else if (event.ButtonUp()) {
       if (HasCapture())


### PR DESCRIPTION
Otherwise the following assertion gets triggered:
../src/common/wincmn.cpp(3271): assert "!wxMouseCapture::IsInCaptureStack(this)" failed in CaptureMouse(): Recapturing the mouse in the same window?

Based on the fix provided for an identical assertion triggered elsewhere,
described here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=765779