### PR TITLE
ESC key can abort some dragging actions

### DIFF
--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1468,6 +1468,21 @@ void TrackPanel::MakeParentResize()
    mListener->TP_HandleResize();
 }
 
+void TrackPanel::HandleEscapeKey()
+{
+   switch (mMouseCapture)
+   {
+   case IsZooming:
+   case IsVZooming:
+      SetCapturedTrack(NULL, IsUncaptured);
+      if (HasCapture())
+         ReleaseCapture();
+      return;
+   default:
+      return;
+   }
+}
+
 void TrackPanel::HandleAltKey(bool down)
 {
    mLastMouseEvent.m_altDown = down;
@@ -5962,6 +5977,11 @@ void TrackPanel::OnCaptureKey(wxCommandEvent & event)
 void TrackPanel::OnKeyDown(wxKeyEvent & event)
 {
    Track *t = GetFocusedTrack();
+
+   if (event.GetKeyCode() == WXK_ESCAPE) {
+      HandleEscapeKey();
+      return;
+   }
 
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
 #ifdef SPECTRAL_EDITING_ESC_KEY

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -208,6 +208,7 @@ class AUDACITY_DLL_API TrackPanel:public wxPanel {
    //virtual void SetSelectionFormat(int iformat)
    //virtual void SetSnapTo(int snapto)
 
+   void HandleEscapeKey();
    virtual void HandleAltKey(bool down);
    virtual void HandleShiftKey(bool down);
    virtual void HandleControlKey(bool down);


### PR DESCRIPTION
Track panel does nothing special when ESC goes down.

It would be consistent with other applications to let it abort mouse dragging actions.

I have found it a minor nuisance that I can't abort zooming (horizontally, but especially vertically) when I start it by mistake.  It used to be that I had to complete a zoom in, then zoom out again to find my place.

With this, I can ESC from it.

It would make sense to abort other kinds of drags too, but they might need more work.  For instance, to abort time shift, I would expect not just to stop shifting a clip, but also to return it to its original position.  With zooming there is no extra trouble restoring state, because state does not change until button-up.
