### PR TITLE
Prevent stereo->mono effects from causing a crash.

### DIFF
--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1749,7 +1749,14 @@ bool Effect::ProcessTrack(int count,
             left->Set((samplePtr) mOutBuffer[0], floatSample, outLeftPos, outputBufferCnt);
             if (right)
             {
-               right->Set((samplePtr) mOutBuffer[1], floatSample, outRightPos, outputBufferCnt);
+               if (chans >= 2)
+               {
+                  right->Set((samplePtr) mOutBuffer[1], floatSample, outRightPos, outputBufferCnt);
+               }
+               else
+               {
+                  right->Set((samplePtr) mOutBuffer[0], floatSample, outRightPos, outputBufferCnt);
+               }
             }
          }
          else if (isGenerator)
@@ -1799,7 +1806,14 @@ bool Effect::ProcessTrack(int count,
          left->Set((samplePtr) mOutBuffer[0], floatSample, outLeftPos, outputBufferCnt);
          if (right)
          {
-            right->Set((samplePtr) mOutBuffer[1], floatSample, outRightPos, outputBufferCnt);
+            if (chans >= 2)
+            {
+               right->Set((samplePtr) mOutBuffer[1], floatSample, outRightPos, outputBufferCnt);
+            }
+            else
+            {
+               right->Set((samplePtr) mOutBuffer[0], floatSample, outRightPos, outputBufferCnt);
+            }
          }
       }
       else if (isGenerator)


### PR DESCRIPTION
If an effect has two input channels but only one output channel, we cannot read from the second output buffer, as there isn’t one.

This hopefully fixes [#946](http://bugzilla.audacityteam.org/show_bug.cgi?id=946).