### PR TITLE
Do not multiply the latency of LADSPA effects by two

### DIFF
--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -896,7 +896,7 @@ sampleCount LadspaEffect::GetLatency()
    if (mUseLatency && mLatencyPort >= 0 && !mLatencyDone)
    {
       mLatencyDone = true;
-      return mOutputControls[mLatencyPort] * 2;
+      return mOutputControls[mLatencyPort];
    }
 
    return 0;


### PR DESCRIPTION
With the multiplication, Audacity appears to overcompensate.

I am not sure why it is done, as LV2Effect and VSTEffect return the latency as reported by the plugin.