### PR TITLE
Fix remnant effects on batch command for multiple files

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -91,6 +91,7 @@ It handles initialization and termination by subclassing wxApp.
 #include "ondemand/ODManager.h"
 #include "commands/Keyboard.h"
 #include "widgets/ErrorDialog.h"
+#include "BatchCommands.h"
 
 //temporarilly commented out till it is added to all projects
 //#include "Profiler.h"
@@ -1395,6 +1396,32 @@ Click the 'Help' button for known issue."),
       exit(1);
    }
 
+   wxString chainName;
+   if (parser->Found(wxT("c"), &chainName)) {
+	   InitAudioIO();
+	   Importer::Get().Initialize();
+
+	   AudacityProject * p = CreateNewBackgroundAudacityProject();
+	   mCmdHandler->SetProject(p);
+
+	   BatchCommands cmd;
+	   if (cmd.ReadChain(chainName)) {
+		   size_t paramct = parser->GetParamCount();
+		   for (size_t i = 0; i < paramct; i++) {
+			   p->OnRemoveTracks();
+			   p->Import(parser->GetParam(i));
+			   p->OnSelectAll();
+			   cmd.ApplyChain();
+		   }
+		   p->Close(true);
+		   exit(0);
+	   }
+	   else {
+		   wxPrintf(_("Chain not found\n."));
+		   exit(1);
+	   }
+   }
+
 // No Splash screen on wx3 whislt we sort out the problem
 // with showing a dialog AND a splash screen during inits.
 #if !wxCHECK_VERSION(3, 0, 0)
@@ -1841,6 +1868,8 @@ wxCmdLineParser *AudacityApp::ParseCommandLine()
    /*i18n-hint: This decodes an autosave file */
    parser->AddOption(wxT("d"), wxT("decode"), _("decode an autosave file"),
                      wxCMD_LINE_VAL_STRING);
+
+   parser->AddOption(wxT("c"), wxT("chain"), _("execute chain on input files"), wxCMD_LINE_VAL_STRING);
 
    /*i18n-hint: This displays a list of available options */
    parser->AddSwitch(wxT("h"), wxT("help"), _("this help message"),

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1403,21 +1403,29 @@ Click the 'Help' button for known issue."),
 
 	   AudacityProject * p = CreateNewBackgroundAudacityProject();
 	   mCmdHandler->SetProject(p);
+	   ModuleManager::Get().Dispatch(AppInitialized);
 
 	   BatchCommands cmd;
 	   if (cmd.ReadChain(chainName)) {
 		   size_t paramct = parser->GetParamCount();
+		   wxString fullpath;
+		   wxFileName file;
 		   for (size_t i = 0; i < paramct; i++) {
 			   p->OnRemoveTracks();
-			   p->Import(parser->GetParam(i));
+			   file = wxFileName(wxGetCwd(), parser->GetParam(i));
+			   if (!file.IsOk()) {
+				   file = wxFileName(parser->GetParam(i));
+			   }
+			   p->Import(file.GetFullName());
 			   p->OnSelectAll();
-			   cmd.ApplyChain();
+			   cmd.ApplyChain(file.GetFullName());
 		   }
 		   p->Close(true);
+		   QuitAudacity(true);
 		   exit(0);
 	   }
 	   else {
-		   wxPrintf(_("Chain not found\n."));
+		   wxPrintf(_("Chain not found.\n"));
 		   exit(1);
 	   }
    }

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -336,8 +336,6 @@ void BatchProcessDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
       }
       UndoManager *um = project->GetUndoManager();
       um->ClearStates();
-	  project->OnSelectAll();
-	  project->OnRemoveTracks();
    }
    project->OnRemoveTracks();
 }

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -336,6 +336,8 @@ void BatchProcessDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
       }
       UndoManager *um = project->GetUndoManager();
       um->ClearStates();
+	  project->OnSelectAll();
+	  project->OnRemoveTracks();
    }
    project->OnRemoveTracks();
 }

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -518,6 +518,46 @@ AudacityProject *CreateNewAudacityProject()
    return p;
 }
 
+AudacityProject *CreateNewBackgroundAudacityProject()
+{
+	bool bMaximized;
+	wxRect wndRect;
+	bool bIconized;
+	GetNextWindowPlacement(&wndRect, &bMaximized, &bIconized);
+
+	//Create and show a new project
+	AudacityProject *p = new AudacityProject(NULL, -1,
+		wxPoint(wndRect.x, wndRect.y),
+		wxSize(wndRect.width, wndRect.height));
+
+	gAudacityProjects.Add(p);
+
+	if (bMaximized) {
+		p->Maximize(true);
+	}
+	else if (bIconized) {
+		// if the user close down and iconized state we could start back up and iconized state
+		// p->Iconize(TRUE);
+	}
+
+	//Initialise the Listener
+	gAudioIO->SetListener(p);
+
+	//Set the new project as active:
+	SetActiveProject(p);
+
+	// Okay, GetActiveProject() is ready. Now we can get its CommandManager,
+	// and add the shortcut keys to the tooltips.
+	p->GetControlToolBar()->RegenerateToolsTooltips();
+
+	ModuleManager::Get().Dispatch(ProjectInitialized);
+
+	//p->Show(true);
+	p->Iconize(true);
+
+	return p;
+}
+
 void RedrawAllProjects()
 {
    size_t len = gAudacityProjects.GetCount();

--- a/src/Project.h
+++ b/src/Project.h
@@ -86,6 +86,7 @@ class MixerBoardFrame;
 struct AudioIOStartStreamOptions;
 
 AudacityProject *CreateNewAudacityProject();
+AudacityProject *CreateNewBackgroundAudacityProject();
 AUDACITY_DLL_API AudacityProject *GetActiveProject();
 void RedrawAllProjects();
 void RefreshCursorForAllProjects();


### PR DESCRIPTION
When running a chain on multiple files effects generated by the chain were not properly removed after the execution of the chain. This causes the effects to overlap from one file to the next.

This fix forces the project to clear all tracks between files; however, it may be better to fix ClearStates() to remove added effects.