### PR TITLE
Fix remnant effects on batch command for multiple files

### DIFF
--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -336,8 +336,6 @@ void BatchProcessDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
       }
       UndoManager *um = project->GetUndoManager();
       um->ClearStates();
-	  project->OnSelectAll();
-	  project->OnRemoveTracks();
    }
    project->OnRemoveTracks();
 }

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -336,6 +336,8 @@ void BatchProcessDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
       }
       UndoManager *um = project->GetUndoManager();
       um->ClearStates();
+	  project->OnSelectAll();
+	  project->OnRemoveTracks();
    }
    project->OnRemoveTracks();
 }


### PR DESCRIPTION
Recreating pull request. Forgot to switch branches before making further changes.

This is for a simple change to clear the current project before moving on to the next file. UndoManager ClearStates() was not removing tracks generated by some effects (like SilenceFinder). State was not completely cleared between files resulting in unexpected behavior.