### PR TITLE
Add option to run chain from the command line

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -91,6 +91,7 @@ It handles initialization and termination by subclassing wxApp.
 #include "ondemand/ODManager.h"
 #include "commands/Keyboard.h"
 #include "widgets/ErrorDialog.h"
+#include "BatchCommands.h"
 
 //temporarilly commented out till it is added to all projects
 //#include "Profiler.h"
@@ -1395,6 +1396,32 @@ Click the 'Help' button for known issue."),
       exit(1);
    }
 
+   wxString chainName;
+   if (parser->Found(wxT("c"), &chainName)) {
+	   InitAudioIO();
+	   Importer::Get().Initialize();
+
+	   AudacityProject * p = CreateNewBackgroundAudacityProject();
+	   mCmdHandler->SetProject(p);
+
+	   BatchCommands cmd;
+	   if (cmd.ReadChain(chainName)) {
+		   size_t paramct = parser->GetParamCount();
+		   for (size_t i = 0; i < paramct; i++) {
+			   p->OnRemoveTracks();
+			   p->Import(parser->GetParam(i));
+			   p->OnSelectAll();
+			   cmd.ApplyChain();
+		   }
+		   p->Close(true);
+		   exit(0);
+	   }
+	   else {
+		   wxPrintf(_("Chain not found\n."));
+		   exit(1);
+	   }
+   }
+
 // No Splash screen on wx3 whislt we sort out the problem
 // with showing a dialog AND a splash screen during inits.
 #if !wxCHECK_VERSION(3, 0, 0)
@@ -1841,6 +1868,8 @@ wxCmdLineParser *AudacityApp::ParseCommandLine()
    /*i18n-hint: This decodes an autosave file */
    parser->AddOption(wxT("d"), wxT("decode"), _("decode an autosave file"),
                      wxCMD_LINE_VAL_STRING);
+
+   parser->AddOption(wxT("c"), wxT("chain"), _("execute chain on input files"), wxCMD_LINE_VAL_STRING);
 
    /*i18n-hint: This displays a list of available options */
    parser->AddSwitch(wxT("h"), wxT("help"), _("this help message"),

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -91,7 +91,7 @@ It handles initialization and termination by subclassing wxApp.
 #include "ondemand/ODManager.h"
 #include "commands/Keyboard.h"
 #include "widgets/ErrorDialog.h"
-#include "BatchCommands.h"
+#include "BatchProcessDialog.h"
 
 //temporarilly commented out till it is added to all projects
 //#include "Profiler.h"
@@ -1400,36 +1400,26 @@ Click the 'Help' button for known issues."),
 
    wxString chainName;
    if (parser->Found(wxT("c"), &chainName)) {
-	   InitAudioIO();
-	   Importer::Get().Initialize();
+       InitAudioIO();
+       Importer::Get().Initialize();
 
-	   AudacityProject * p = CreateNewBackgroundAudacityProject();
-	   mCmdHandler->SetProject(p);
-	   ModuleManager::Get().Dispatch(AppInitialized);
+       AudacityProject * p = CreateNewBackgroundAudacityProject();
+       BatchProcessDialog dlg(NULL);
+       wxPathList pl;
+       wxString path;
+       wxArrayString files;
 
-	   BatchCommands cmd;
-	   if (cmd.ReadChain(chainName)) {
-		   size_t paramct = parser->GetParamCount();
-		   wxString fullpath;
-		   wxFileName file;
-		   for (size_t i = 0; i < paramct; i++) {
-			   p->OnRemoveTracks();
-			   file = wxFileName(wxGetCwd(), parser->GetParam(i));
-			   if (!file.IsOk()) {
-				   file = wxFileName(parser->GetParam(i));
-			   }
-			   p->Import(file.GetFullName());
-			   p->OnSelectAll();
-			   cmd.ApplyChain(file.GetFullName());
-		   }
-		   p->Close(true);
-		   QuitAudacity(true);
-		   exit(0);
-	   }
-	   else {
-		   wxPrintf(_("Chain not found.\n"));
-		   exit(1);
-	   }
+       pl.Add(wxGetCwd());
+
+       for (size_t i = 0; i < parser->GetParamCount(); i++) {
+           path = pl.FindAbsoluteValidPath(parser->GetParam(i));
+           if (path != wxT("")) {
+               files.Add(path);
+           }
+       }
+       dlg.ApplyChainToFiles(chainName, files);
+       QuitAudacity(true);
+       return;
    }
 
 // No Splash screen on wx3 whislt we sort out the problem

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1403,21 +1403,29 @@ Click the 'Help' button for known issue."),
 
 	   AudacityProject * p = CreateNewBackgroundAudacityProject();
 	   mCmdHandler->SetProject(p);
+	   ModuleManager::Get().Dispatch(AppInitialized);
 
 	   BatchCommands cmd;
 	   if (cmd.ReadChain(chainName)) {
 		   size_t paramct = parser->GetParamCount();
+		   wxString fullpath;
+		   wxFileName file;
 		   for (size_t i = 0; i < paramct; i++) {
 			   p->OnRemoveTracks();
-			   p->Import(parser->GetParam(i));
+			   file = wxFileName(wxGetCwd(), parser->GetParam(i));
+			   if (!file.IsOk()) {
+				   file = wxFileName(parser->GetParam(i));
+			   }
+			   p->Import(file.GetFullName());
 			   p->OnSelectAll();
-			   cmd.ApplyChain();
+			   cmd.ApplyChain(file.GetFullName());
 		   }
 		   p->Close(true);
+		   QuitAudacity(true);
 		   exit(0);
 	   }
 	   else {
-		   wxPrintf(_("Chain not found\n."));
+		   wxPrintf(_("Chain not found.\n"));
 		   exit(1);
 	   }
    }

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -187,85 +187,83 @@ void BatchProcessDialog::OnApplyToProject(wxCommandEvent & WXUNUSED(event))
 
 void BatchProcessDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
 {
-    long item = mChains->GetNextItem(-1,
-        wxLIST_NEXT_ALL,
-        wxLIST_STATE_SELECTED);
-    if (item == -1) {
-        wxMessageBox(_("No chain selected"));
-        return;
-    }
+   long item = mChains->GetNextItem(-1,
+                                    wxLIST_NEXT_ALL,
+                                    wxLIST_STATE_SELECTED);
+   if (item == -1) {
+      wxMessageBox(_("No chain selected"));
+      return;
+   }
 
-    wxString name = mChains->GetItemText(item);
-    gPrefs->Write(wxT("/Batch/ActiveChain"), name);
-    gPrefs->Flush();
+   wxString name = mChains->GetItemText(item);
+   gPrefs->Write(wxT("/Batch/ActiveChain"), name);
+   gPrefs->Flush();
 
-    AudacityProject *project = GetActiveProject();
-    if (!project->GetIsEmpty()) {
-        wxMessageBox(_("Please save and close the current project first."));
-        return;
-    }
+   AudacityProject *project = GetActiveProject();
+   if (!project->GetIsEmpty()) {
+      wxMessageBox(_("Please save and close the current project first."));
+      return;
+   }
 
-    wxString path = gPrefs->Read(wxT("/DefaultOpenPath"), ::wxGetCwd());
-    wxString prompt = _("Select file(s) for batch processing...");
+   wxString path = gPrefs->Read(wxT("/DefaultOpenPath"), ::wxGetCwd());
+   wxString prompt =  _("Select file(s) for batch processing...");
 
-    FormatList l;
-    wxString filter;
-    wxString all;
+   FormatList l;
+   wxString filter;
+   wxString all;
 
-    l.DeleteContents(true);
-    Importer::Get().GetSupportedImportFormats(&l);
-    for (FormatList::compatibility_iterator n = l.GetFirst(); n; n = n->GetNext()) {
-        Format *f = n->GetData();
+   l.DeleteContents(true);
+   Importer::Get().GetSupportedImportFormats(&l);
+   for (FormatList::compatibility_iterator n = l.GetFirst(); n; n = n->GetNext()) {
+      Format *f = n->GetData();
 
-        wxString newfilter = f->formatName + wxT("|");
-        for (size_t i = 0; i < f->formatExtensions.size(); i++) {
-            if (!newfilter.Contains(wxT("*.") + f->formatExtensions[i] + wxT(";")))
-                newfilter += wxT("*.") + f->formatExtensions[i] + wxT(";");
-            if (!all.Contains(wxT("*.") + f->formatExtensions[i] + wxT(";")))
-                all += wxT("*.") + f->formatExtensions[i] + wxT(";");
-        }
-        newfilter.RemoveLast(1);
-        filter += newfilter;
-        filter += wxT("|");
-    }
-    all.RemoveLast(1);
-    filter.RemoveLast(1);
+      wxString newfilter = f->formatName + wxT("|");
+      for (size_t i = 0; i < f->formatExtensions.size(); i++) {
+         if (!newfilter.Contains(wxT("*.") + f->formatExtensions[i] + wxT(";")))
+            newfilter += wxT("*.") + f->formatExtensions[i] + wxT(";");
+         if (!all.Contains(wxT("*.") + f->formatExtensions[i] + wxT(";")))
+            all += wxT("*.") + f->formatExtensions[i] + wxT(";");
+      }
+      newfilter.RemoveLast(1);
+      filter += newfilter;
+      filter += wxT("|");
+   }
+   all.RemoveLast(1);
+   filter.RemoveLast(1);
 
-    wxString mask = _("All files|*|All supported files|") +
-        all + wxT("|") +
-        filter;
+   wxString mask = _("All files|*|All supported files|") +
+                   all + wxT("|") +
+                   filter;
 
-    wxString type = gPrefs->Read(wxT("/DefaultOpenType"), mask.BeforeFirst(wxT('|')));
-    // Convert the type to the filter index
-    int index = mask.First(type + wxT("|"));
-    if (index == wxNOT_FOUND) {
-        index = 0;
-    }
-    else {
-        index = mask.Left(index).Freq(wxT('|')) / 2;
-        if (index < 0) {
-            index = 0;
-        }
-    }
+   wxString type = gPrefs->Read(wxT("/DefaultOpenType"),mask.BeforeFirst(wxT('|')));
+   // Convert the type to the filter index
+   int index = mask.First(type + wxT("|"));
+   if (index == wxNOT_FOUND) {
+      index = 0;
+   }
+   else {
+      index = mask.Left(index).Freq(wxT('|')) / 2;
+      if (index < 0) {
+         index = 0;
+      }
+   }
 
-    FileDialog dlog(this,
-        prompt,
-        path,
-        wxT(""),
-        mask,
-        wxFD_OPEN | wxFD_MULTIPLE | wxRESIZE_BORDER);
+   FileDialog dlog(this,
+                   prompt,
+                   path,
+                   wxT(""),
+                   mask,
+                   wxFD_OPEN | wxFD_MULTIPLE | wxRESIZE_BORDER);
 
-    dlog.SetFilterIndex(index);
-    if (dlog.ShowModal() != wxID_OK) {
-        return;
-    }
+   dlog.SetFilterIndex(index);
+   if (dlog.ShowModal() != wxID_OK) {
+      return;
+   }
 
-    wxArrayString files;
-    dlog.GetPaths(files);
+   wxArrayString files;
+   dlog.GetPaths(files);
 
-    files.Sort();
-
-    ApplyChainToFiles(name, files);
+   files.Sort();
 }
 
 void BatchProcessDialog::ApplyChainToFiles(wxString name, const wxArrayString& files) {

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -187,84 +187,87 @@ void BatchProcessDialog::OnApplyToProject(wxCommandEvent & WXUNUSED(event))
 
 void BatchProcessDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
 {
-   long item = mChains->GetNextItem(-1,
-                                    wxLIST_NEXT_ALL,
-                                    wxLIST_STATE_SELECTED);
-   if (item == -1) {
-      wxMessageBox(_("No chain selected"));
-      return;
-   }
+    long item = mChains->GetNextItem(-1,
+        wxLIST_NEXT_ALL,
+        wxLIST_STATE_SELECTED);
+    if (item == -1) {
+        wxMessageBox(_("No chain selected"));
+        return;
+    }
 
-   wxString name = mChains->GetItemText(item);
-   gPrefs->Write(wxT("/Batch/ActiveChain"), name);
-   gPrefs->Flush();
+    wxString name = mChains->GetItemText(item);
+    gPrefs->Write(wxT("/Batch/ActiveChain"), name);
+    gPrefs->Flush();
 
-   AudacityProject *project = GetActiveProject();
-   if (!project->GetIsEmpty()) {
-      wxMessageBox(_("Please save and close the current project first."));
-      return;
-   }
+    AudacityProject *project = GetActiveProject();
+    if (!project->GetIsEmpty()) {
+        wxMessageBox(_("Please save and close the current project first."));
+        return;
+    }
 
-   wxString path = gPrefs->Read(wxT("/DefaultOpenPath"), ::wxGetCwd());
-   wxString prompt =  _("Select file(s) for batch processing...");
+    wxString path = gPrefs->Read(wxT("/DefaultOpenPath"), ::wxGetCwd());
+    wxString prompt = _("Select file(s) for batch processing...");
 
-   FormatList l;
-   wxString filter;
-   wxString all;
+    FormatList l;
+    wxString filter;
+    wxString all;
 
-   l.DeleteContents(true);
-   Importer::Get().GetSupportedImportFormats(&l);
-   for (FormatList::compatibility_iterator n = l.GetFirst(); n; n = n->GetNext()) {
-      Format *f = n->GetData();
+    l.DeleteContents(true);
+    Importer::Get().GetSupportedImportFormats(&l);
+    for (FormatList::compatibility_iterator n = l.GetFirst(); n; n = n->GetNext()) {
+        Format *f = n->GetData();
 
-      wxString newfilter = f->formatName + wxT("|");
-      for (size_t i = 0; i < f->formatExtensions.size(); i++) {
-         if (!newfilter.Contains(wxT("*.") + f->formatExtensions[i] + wxT(";")))
-            newfilter += wxT("*.") + f->formatExtensions[i] + wxT(";");
-         if (!all.Contains(wxT("*.") + f->formatExtensions[i] + wxT(";")))
-            all += wxT("*.") + f->formatExtensions[i] + wxT(";");
-      }
-      newfilter.RemoveLast(1);
-      filter += newfilter;
-      filter += wxT("|");
-   }
-   all.RemoveLast(1);
-   filter.RemoveLast(1);
+        wxString newfilter = f->formatName + wxT("|");
+        for (size_t i = 0; i < f->formatExtensions.size(); i++) {
+            if (!newfilter.Contains(wxT("*.") + f->formatExtensions[i] + wxT(";")))
+                newfilter += wxT("*.") + f->formatExtensions[i] + wxT(";");
+            if (!all.Contains(wxT("*.") + f->formatExtensions[i] + wxT(";")))
+                all += wxT("*.") + f->formatExtensions[i] + wxT(";");
+        }
+        newfilter.RemoveLast(1);
+        filter += newfilter;
+        filter += wxT("|");
+    }
+    all.RemoveLast(1);
+    filter.RemoveLast(1);
 
-   wxString mask = _("All files|*|All supported files|") +
-                   all + wxT("|") +
-                   filter;
+    wxString mask = _("All files|*|All supported files|") +
+        all + wxT("|") +
+        filter;
 
-   wxString type = gPrefs->Read(wxT("/DefaultOpenType"),mask.BeforeFirst(wxT('|')));
-   // Convert the type to the filter index
-   int index = mask.First(type + wxT("|"));
-   if (index == wxNOT_FOUND) {
-      index = 0;
-   }
-   else {
-      index = mask.Left(index).Freq(wxT('|')) / 2;
-      if (index < 0) {
-         index = 0;
-      }
-   }
+    wxString type = gPrefs->Read(wxT("/DefaultOpenType"), mask.BeforeFirst(wxT('|')));
+    // Convert the type to the filter index
+    int index = mask.First(type + wxT("|"));
+    if (index == wxNOT_FOUND) {
+        index = 0;
+    }
+    else {
+        index = mask.Left(index).Freq(wxT('|')) / 2;
+        if (index < 0) {
+            index = 0;
+        }
+    }
 
-   FileDialog dlog(this,
-                   prompt,
-                   path,
-                   wxT(""),
-                   mask,
-                   wxFD_OPEN | wxFD_MULTIPLE | wxRESIZE_BORDER);
+    FileDialog dlog(this,
+        prompt,
+        path,
+        wxT(""),
+        mask,
+        wxFD_OPEN | wxFD_MULTIPLE | wxRESIZE_BORDER);
 
-   dlog.SetFilterIndex(index);
-   if (dlog.ShowModal() != wxID_OK) {
-      return;
-   }
+    dlog.SetFilterIndex(index);
+    if (dlog.ShowModal() != wxID_OK) {
+        return;
+    }
 
-   wxArrayString files;
-   dlog.GetPaths(files);
+    wxArrayString files;
+    dlog.GetPaths(files);
 
-   files.Sort();
+    files.Sort();
+}
 
+void BatchProcessDialog::ApplyChainToFiles(wxString name, const wxArrayString& files) {
+   AudacityProject * project = GetActiveProject();
    wxDialog d(this, wxID_ANY, GetTitle());
    d.SetName(d.GetTitle());
    ShuttleGui S(&d, eIsCreating);

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -264,6 +264,8 @@ void BatchProcessDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
     dlog.GetPaths(files);
 
     files.Sort();
+
+    ApplyChainToFiles(name, files);
 }
 
 void BatchProcessDialog::ApplyChainToFiles(wxString name, const wxArrayString& files) {

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -264,6 +264,8 @@ void BatchProcessDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
    dlog.GetPaths(files);
 
    files.Sort();
+
+   ApplyChainToFiles(name, files);
 }
 
 void BatchProcessDialog::ApplyChainToFiles(wxString name, const wxArrayString& files) {

--- a/src/BatchProcessDialog.h
+++ b/src/BatchProcessDialog.h
@@ -49,6 +49,7 @@ class BatchProcessDialog:public wxDialog {
 
    void OnApplyToProject(wxCommandEvent & event);
    void OnApplyToFiles(wxCommandEvent & event);
+   void ApplyChainToFiles(wxString name, const wxArrayString& files);
    void OnCancel(wxCommandEvent & event);
 
    wxButton *mOK;

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -521,25 +521,11 @@ AudacityProject *CreateNewAudacityProject()
 
 AudacityProject *CreateNewBackgroundAudacityProject()
 {
-	bool bMaximized;
-	wxRect wndRect;
-	bool bIconized;
-	GetNextWindowPlacement(&wndRect, &bMaximized, &bIconized);
-
-	//Create and show a new project
 	AudacityProject *p = new AudacityProject(NULL, -1,
-		wxPoint(wndRect.x, wndRect.y),
-		wxSize(wndRect.width, wndRect.height));
+		wxPoint(0, 0),
+		wxSize(0, 0));
 
 	gAudacityProjects.Add(p);
-
-	if (bMaximized) {
-		p->Maximize(true);
-	}
-	else if (bIconized) {
-		// if the user close down and iconized state we could start back up and iconized state
-		// p->Iconize(TRUE);
-	}
 
 	//Initialise the Listener
 	gAudioIO->SetListener(p);

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -518,6 +518,46 @@ AudacityProject *CreateNewAudacityProject()
    return p;
 }
 
+AudacityProject *CreateNewBackgroundAudacityProject()
+{
+	bool bMaximized;
+	wxRect wndRect;
+	bool bIconized;
+	GetNextWindowPlacement(&wndRect, &bMaximized, &bIconized);
+
+	//Create and show a new project
+	AudacityProject *p = new AudacityProject(NULL, -1,
+		wxPoint(wndRect.x, wndRect.y),
+		wxSize(wndRect.width, wndRect.height));
+
+	gAudacityProjects.Add(p);
+
+	if (bMaximized) {
+		p->Maximize(true);
+	}
+	else if (bIconized) {
+		// if the user close down and iconized state we could start back up and iconized state
+		// p->Iconize(TRUE);
+	}
+
+	//Initialise the Listener
+	gAudioIO->SetListener(p);
+
+	//Set the new project as active:
+	SetActiveProject(p);
+
+	// Okay, GetActiveProject() is ready. Now we can get its CommandManager,
+	// and add the shortcut keys to the tooltips.
+	p->GetControlToolBar()->RegenerateToolsTooltips();
+
+	ModuleManager::Get().Dispatch(ProjectInitialized);
+
+	//p->Show(true);
+	p->Iconize(true);
+
+	return p;
+}
+
 void RedrawAllProjects()
 {
    size_t len = gAudacityProjects.GetCount();

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -553,9 +553,6 @@ AudacityProject *CreateNewBackgroundAudacityProject()
 
 	ModuleManager::Get().Dispatch(ProjectInitialized);
 
-	//p->Show(true);
-	p->Iconize(true);
-
 	return p;
 }
 

--- a/src/Project.h
+++ b/src/Project.h
@@ -86,6 +86,7 @@ class MixerBoardFrame;
 struct AudioIOStartStreamOptions;
 
 AudacityProject *CreateNewAudacityProject();
+AudacityProject *CreateNewBackgroundAudacityProject();
 AUDACITY_DLL_API AudacityProject *GetActiveProject();
 void RedrawAllProjects();
 void RefreshCursorForAllProjects();


### PR DESCRIPTION
Added --chain (-c) option to the list of command line options.

audacity.exe -c "MP3 Conversion" file1.wav file2.wav ...
audacity.exe --chain="MP3 Conversion" file1.wav file2.wav ...

will Normalize/Convert all files passed as arguments

Ensures all files passed are valid paths

It shows the list of files and process dialog for each effect/command same as Apply To Files from BatchProcessDialog.

Opted not to show the primary window since they could just open Audacity and run the chain from there. This would be for more passive application.