### PR TITLE
Fix crash in new binary AutoSave

### DIFF
--- a/src/AutoRecovery.cpp
+++ b/src/AutoRecovery.cpp
@@ -457,7 +457,7 @@ void AutoSaveFile::WriteAttr(const wxString & name, const wxString & value)
    mBuffer.PutC(FT_String);
    WriteName(name);
 
-   short len = value.Length() * sizeof(wxChar);
+   int len = value.Length() * sizeof(wxChar);
 
    mBuffer.Write(&len, sizeof(len));
    mBuffer.Write(value.c_str(), len);
@@ -525,7 +525,7 @@ void AutoSaveFile::WriteData(const wxString & value)
 {
    mBuffer.PutC(FT_Data);
 
-   short len = value.Length() * sizeof(wxChar);
+   int len = value.Length() * sizeof(wxChar);
 
    mBuffer.Write(&len, sizeof(len));
    mBuffer.Write(value.c_str(), len);
@@ -535,7 +535,7 @@ void AutoSaveFile::Write(const wxString & value)
 {
    mBuffer.PutC(FT_Raw);
 
-   short len = value.Length() * sizeof(wxChar);
+   int len = value.Length() * sizeof(wxChar);
 
    mBuffer.Write(&len, sizeof(len));
    mBuffer.Write(value.c_str(), len);
@@ -595,6 +595,7 @@ void AutoSaveFile::CheckSpace(wxMemoryOutputStream & os)
 
 void AutoSaveFile::WriteName(const wxString & name)
 {
+   wxASSERT(name.Length() * sizeof(wxChar) <= SHRT_MAX);
    short len = name.Length() * sizeof(wxChar);
    short id;
 
@@ -771,7 +772,7 @@ bool AutoSaveFile::Decode(const wxString & fileName)
 
          case FT_String:
          {
-            short len;
+            int len;
 
             in.Read(&id, sizeof(id));
             in.Read(&len, sizeof(len));
@@ -866,7 +867,7 @@ bool AutoSaveFile::Decode(const wxString & fileName)
 
          case FT_Data:
          {
-            short len;
+            int len;
 
             in.Read(&len, sizeof(len));
             wxChar *val = new wxChar[len / sizeof(wxChar)];
@@ -879,7 +880,7 @@ bool AutoSaveFile::Decode(const wxString & fileName)
 
          case FT_Raw:
          {
-            short len;
+            int len;
 
             in.Read(&len, sizeof(len));
             wxChar *val = new wxChar[len / sizeof(wxChar)];


### PR DESCRIPTION
Would happen when writing tags with a value whose length was greater
than 65535 due to the use of shorts.  Now uses int instead.