### PR TITLE
Bug1169: end the separate treatment of lin vs. log display bounds for…

### DIFF
--- a/src/NumberScale.h
+++ b/src/NumberScale.h
@@ -22,7 +22,7 @@ enum NumberScaleType {
    nstMel,
    nstBark,
    nstErb,
-   nstUndertone,
+   nstPeriod,
 
    nstNumScaleTypes,
 };
@@ -31,6 +31,10 @@ enum NumberScaleType {
 class NumberScale
 {
 public:
+   NumberScale()
+      : mType(nstLinear), mValue0(0), mValue1(1), mUnit(1)
+   {}
+
    NumberScale(NumberScaleType type,
       float value0, float value1, float unit)
       : mType(type)
@@ -71,10 +75,10 @@ public:
          mUnit = unit;
       }
       break;
-      case nstUndertone:
+      case nstPeriod:
       {
-         mValue0 = hzToUndertone(value0);
-         mValue1 = hzToUndertone(value1);
+         mValue0 = hzToPeriod(value0);
+         mValue1 = hzToPeriod(value1);
          mUnit = unit;
       }
       break;
@@ -144,12 +148,12 @@ public:
       return 676170.4 / (47.06538 - exp(0.08950404 * erb)) - 14678.49;
    }
 
-   static inline float hzToUndertone(float hz)
+   static inline float hzToPeriod(float hz)
    {
       return -1.0 / std::max (1.0f, hz);
    }
 
-   static inline float undertoneToHz(float u)
+   static inline float periodToHz(float u)
    {
       return -1.0 / u;
    }
@@ -170,8 +174,8 @@ public:
          return barkToHz(mValue0 + pp * (mValue1 - mValue0)) / mUnit;
       case nstErb:
          return erbToHz(mValue0 + pp * (mValue1 - mValue0)) / mUnit;
-      case nstUndertone:
-         return undertoneToHz(mValue0 + pp * (mValue1 - mValue0)) / mUnit;
+      case nstPeriod:
+         return periodToHz(mValue0 + pp * (mValue1 - mValue0)) / mUnit;
       }
    }
 
@@ -199,8 +203,8 @@ public:
             return barkToHz(mValue) / mUnit;
          case nstErb:
             return erbToHz(mValue) / mUnit;
-         case nstUndertone:
-            return undertoneToHz(mValue) / mUnit;
+         case nstPeriod:
+            return periodToHz(mValue) / mUnit;
          }
       }
 
@@ -211,7 +215,7 @@ public:
          case nstMel:
          case nstBark:
          case nstErb:
-         case nstUndertone:
+         case nstPeriod:
             mValue += mStep;
             break;
          case nstLogarithmic:
@@ -239,7 +243,7 @@ public:
       case nstMel:
       case nstBark:
       case nstErb:
-      case nstUndertone:
+      case nstPeriod:
          return Iterator
             (mType,
              nPositions == 1 ? 0 : (mValue1 - mValue0) / (nPositions - 1),
@@ -268,13 +272,13 @@ public:
          return ((hzToBark(val * mUnit) - mValue0) / (mValue1 - mValue0));
       case nstErb:
          return ((hzToErb(val * mUnit) - mValue0) / (mValue1 - mValue0));
-      case nstUndertone:
-         return ((hzToUndertone(val * mUnit) - mValue0) / (mValue1 - mValue0));
+      case nstPeriod:
+         return ((hzToPeriod(val * mUnit) - mValue0) / (mValue1 - mValue0));
       }
    }
 
 private:
-   const NumberScaleType mType;
+   NumberScaleType mType;
    float mValue0;
    float mValue1;
    float mUnit;

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -441,8 +441,10 @@ class AUDACITY_DLL_API WaveTrack : public Track {
    WaveTrackDisplay GetDisplay() const { return mDisplay; }
    void SetDisplay(WaveTrackDisplay display) { mDisplay = display; }
 
-   void GetDisplayBounds(float *min, float *max);
+   void GetDisplayBounds(float *min, float *max) const;
    void SetDisplayBounds(float min, float max);
+   void GetSpectrumBounds(float *min, float *max) const;
+   void SetSpectrumBounds(float min, float max);
 
 
  protected:
@@ -464,6 +466,9 @@ class AUDACITY_DLL_API WaveTrack : public Track {
    //
    float         mDisplayMin;
    float         mDisplayMax;
+   float         mSpectrumMin;
+   float         mSpectrumMax;
+
    WaveTrackDisplay mDisplay;
    int           mLastScaleType; // last scale type choice
    int           mLastdBRange;

--- a/src/prefs/SpectrogramSettings.h
+++ b/src/prefs/SpectrogramSettings.h
@@ -57,7 +57,7 @@ public:
       stMel,
       stBark,
       stErb,
-      stUndertone,
+      stPeriod,
 
       stNumScaleTypes,
    };
@@ -87,24 +87,12 @@ public:
 
    // If "bins" is false, units are Hz
    NumberScale GetScale
-      (double rate, bool bins) const;
+      (float minFreq, float maxFreq, double rate, bool bins) const;
 
-private:
    int minFreq;
    int maxFreq;
-   int logMinFreq;
-   int logMaxFreq;
-public:
-   int GetMinFreq(double rate) const;
-   int GetMaxFreq(double rate) const;
-   int GetLogMinFreq(double rate) const;
-   int GetLogMaxFreq(double rate) const;
-   bool SpectralSelectionEnabled() const;
 
-   void SetMinFreq(int freq);
-   void SetMaxFreq(int freq);
-   void SetLogMinFreq(int freq);
-   void SetLogMaxFreq(int freq);
+   bool SpectralSelectionEnabled() const;
 
 public:
    int range;

--- a/src/prefs/SpectrumPrefs.cpp
+++ b/src/prefs/SpectrumPrefs.cpp
@@ -376,8 +376,12 @@ bool SpectrumPrefs::Apply()
    if (mWt) {
       if (mDefaulted) {
          mWt->SetSpectrogramSettings(NULL);
-         if (partner)
+         // ... and so that the vertical scale also defaults:
+         mWt->SetSpectrumBounds(-1, -1);
+         if (partner) {
             partner->SetSpectrogramSettings(NULL);
+            partner->SetSpectrumBounds(-1, -1);
+         }
       }
       else {
          SpectrogramSettings *pSettings =


### PR DESCRIPTION
… spectrum...

... also make WaveTrack responsible for storing and validating the bounds
... also let the bounds vary per-track even though other settings are default
... also change some code names to mention "period" not "undertone"