### PR TITLE
Use noinst_SCRIPTS for toplevel audacity script.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = help images lib-src po src tests
 
 ACLOCAL_AMFLAGS = -I m4
 
-bin_SCRIPTS = audacity$(EXEEXT)
+noinst_SCRIPTS = audacity$(EXEEXT)
 
 dist_doc_DATA = LICENSE.txt README.txt
 dist_pkgdata_DATA = presets/EQDefaultCurves.xml


### PR DESCRIPTION
When using libtool, this file is a copy of a shell script
and will be installed instead of the real executable.
