### PR TITLE
bug1197: Correct horizontal scrollbar position at extreme zoom-in

### DIFF
--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -1529,7 +1529,7 @@ void AudacityProject::SetHorizontalThumb(double scrollto)
 {
    wxInt64 max = mHsbar->GetRange() - mHsbar->GetThumbSize();
    int pos = std::min(max, std::max(wxInt64(0), PixelWidthBeforeTime(scrollto)));
-   mHsbar->SetThumbPosition(pos);
+   mHsbar->SetThumbPosition(pos * mViewInfo.sbarScale);
 }
 
 //


### PR DESCRIPTION
I see this one is ranked P2.  A regression from 2.1.1 and my fault.
