### PR TITLE
Bug1213: "Spectrogram" not "Spectrum" in tracks prefs.

### DIFF
--- a/src/prefs/TracksPrefs.cpp
+++ b/src/prefs/TracksPrefs.cpp
@@ -67,7 +67,7 @@ void TracksPrefs::Populate()
    mViewChoices.Add(_("Waveform (dB)"));
    mViewCodes.Add(int(WaveTrack::obsoleteWaveformDBDisplay));
 
-   mViewChoices.Add(_("Spectrum"));
+   mViewChoices.Add(_("Spectrogram"));
    mViewCodes.Add(WaveTrack::Spectrum);
 
    //------------------------- Main section --------------------


### PR DESCRIPTION
This is a string change, however that string should be replicated elsewhere in\
the translation files.