### PR TITLE
cppcheck: fix 2 reports

### DIFF
--- a/lib-src/libnyquist/nyquist/nyqsrc/f0.cpp
+++ b/lib-src/libnyquist/nyquist/nyqsrc/f0.cpp
@@ -134,6 +134,6 @@ float best_f0(float *samples, int n, int m, float threshold, int Tmax)
       best_f0=f0;
     }
   }
-  delete(results);
+  delete[] results;
   return best_f0;
 }

--- a/lib-src/libnyquist/nyquist/nyqsrc/sndwritepa.c
+++ b/lib-src/libnyquist/nyquist/nyqsrc/sndwritepa.c
@@ -246,7 +246,7 @@ long lookup_format(long format, long mode, long bits, long swap)
         sf_format |= (swap ? SF_ENDIAN_LITTLE : SF_ENDIAN_BIG);
 #endif
 #ifdef XL_LITTLE_ENDIAN
-        sf_format |= (swap ? SF_ENDIAN_LITTLE : SF_ENDIAN_LITTLE);
+        sf_format |= (swap ? SF_ENDIAN_BIG : SF_ENDIAN_LITTLE);
 #endif        
         break;
     default: 


### PR DESCRIPTION
[lib-src/libnyquist/nyquist/nyqsrc/sndwritepa.c:249]: (style) Same expression in both branches of ternary operator
[lib-src/libnyquist/nyquist/nyqsrc/f0.cpp:137]: (error) Mismatching allocation and deallocation: results