### PR TITLE
Fix building on musl libc

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2129,6 +2129,9 @@ bool VSTEffect::Load()
    // symbols.
    //
    // Once we define a proper external API, the flags can be removed.
+#ifndef RTLD_DEEPBIND
+#define RTLD_DEEPBIND 0
+#endif
    void *lib = dlopen((const char *)wxString(realPath).ToUTF8(), RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
    if (!lib) 
    {


### PR DESCRIPTION
Without this patch:

```
effects/VST/VSTEffect.cpp: In member function 'bool VSTEffect::Load()':
effects/VST/VSTEffect.cpp:2579:90: error: 'RTLD_DEEPBIND' was not declared in this scope
    void *lib = dlopen((const char *)wxString(realPath).ToUTF8(), RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
                                                                                          ^
```