### PR TITLE
One bit of gPrefs->Flush() cleanup

### DIFF
--- a/src/ShuttlePrefs.cpp
+++ b/src/ShuttlePrefs.cpp
@@ -43,7 +43,7 @@ bool ShuttlePrefs::TransferBool( const wxString & Name, bool & bValue, const boo
    }
    else
    {
-      return (gPrefs->Write( Name, bValue ) && gPrefs->Flush());
+      return gPrefs->Write( Name, bValue );
    }
    return true;
 }
@@ -57,7 +57,7 @@ bool ShuttlePrefs::TransferDouble( const wxString & Name, double & dValue, const
    }
    else
    {
-      return (gPrefs->Write( Name, dValue ) && gPrefs->Flush());
+      return gPrefs->Write( Name, dValue );
    }
    return true;
 }
@@ -71,7 +71,7 @@ bool ShuttlePrefs::TransferInt( const wxString & Name, int & iValue, const int &
    }
    else
    {
-      return (gPrefs->Write( Name, iValue ) && gPrefs->Flush());
+      return gPrefs->Write( Name, iValue );
    }
    return true;
 }
@@ -85,7 +85,7 @@ bool ShuttlePrefs::TransferString( const wxString & Name, wxString & strValue, c
    }
    else
    {
-      return (gPrefs->Write( Name, strValue ) && gPrefs->Flush());
+      return gPrefs->Write( Name, strValue );
    }
    return true;
 }

--- a/src/SoundActivatedRecord.cpp
+++ b/src/SoundActivatedRecord.cpp
@@ -67,6 +67,9 @@ void SoundActivatedRecord::OnOK(wxCommandEvent & WXUNUSED(event))
 {
    ShuttleGui S( this, eIsSavingToPrefs );
    PopulateOrExchange( S );
+
+   gPrefs->Flush();
+
    EndModal(0);
 }
 

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -3170,8 +3170,6 @@ void TrackArtist::UpdatePrefs()
 {
    mdBrange = gPrefs->Read(ENV_DB_KEY, mdBrange);
    mShowClipping = gPrefs->Read(wxT("/GUI/ShowClipping"), mShowClipping);
-
-   gPrefs->Flush();
 }
 
 // Draws the sync-lock bitmap, tiled; always draws stationary relative to the DC

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -1391,14 +1391,17 @@ void EffectEqualization::LoadCurves(wxString fileName, bool append)
       }
       if( !fn.FileExists() )
       {
-         wxString errorMessage;
-         errorMessage.Printf(_("EQCurves.xml and EQDefaultCurves.xml were not found on your system.\nPlease press 'help' to visit the download page.\n\nSave the curves at %s"), FileNames::DataDir().c_str());
-         ShowErrorDialog(mUIParent, _("EQCurves.xml and EQDefaultCurves.xml missing"),
-            errorMessage, wxT("http://wiki.audacityteam.org/wiki/EQCurvesDownload"), false);
+         // LLL:  Is there really a need for an error message at all???
+         //wxString errorMessage;
+         //errorMessage.Printf(_("EQCurves.xml and EQDefaultCurves.xml were not found on your system.\nPlease press 'help' to visit the download page.\n\nSave the curves at %s"), FileNames::DataDir().c_str());
+         //ShowErrorDialog(mUIParent, _("EQCurves.xml and EQDefaultCurves.xml missing"),
+         //   errorMessage, wxT("http://wiki.audacityteam.org/wiki/EQCurvesDownload"), false);
+
          // Have another go at finding EQCurves.xml in the data dir, in case 'help' helped
          fn = wxFileName( FileNames::DataDir(), wxT("EQDefaultCurves.xml") );
          if( !fn.FileExists() )
          {
+            mCurves.Clear();
             mCurves.Add( _("unnamed") );   // we still need a default curve to use
             return;
          }

--- a/src/export/ExportFFmpegDialogs.cpp
+++ b/src/export/ExportFFmpegDialogs.cpp
@@ -1990,8 +1990,11 @@ void ExportFFmpegOptions::OnOK(wxCommandEvent& WXUNUSED(event))
    if (selcdc > -1) gPrefs->Write(wxT("/FileFormats/FFmpegCodec"),mCodecList->GetString(selcdc));
    if (selfmt > -1) gPrefs->Write(wxT("/FileFormats/FFmpegFormat"),mFormatList->GetString(selfmt));
    gPrefs->Flush();
+
    ShuttleGui S(this, eIsSavingToPrefs);
    PopulateOrExchange(S);
+
+   gPrefs->Flush();
 
    EndModal(wxID_OK);
 

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -522,6 +522,8 @@ void ExportMultiple::OnExport(wxCommandEvent& WXUNUSED(event))
    ShuttleGui S(this, eIsSavingToPrefs);
    PopulateOrExchange(S);
 
+   gPrefs->Flush();
+
    // Make sure the output directory is in good shape
    if (!DirOk()) {
       return;

--- a/src/export/ExportPCM.cpp
+++ b/src/export/ExportPCM.cpp
@@ -216,6 +216,8 @@ bool ExportPCMOptions::TransferDataFromWindow()
    ShuttleGui S(this, eIsSavingToPrefs);
    PopulateOrExchange(S);
 
+   gPrefs->Flush();
+
    WriteExportFormatPref(GetFormat());
 
    return true;

--- a/src/prefs/DevicePrefs.cpp
+++ b/src/prefs/DevicePrefs.cpp
@@ -347,7 +347,6 @@ bool DevicePrefs::Apply()
    }
    if (map) {
       gPrefs->Write(wxT("/AudioIO/PlaybackDevice"), map->deviceString);
-      gPrefs->Flush();
    }
 
    map = NULL;
@@ -368,7 +367,6 @@ bool DevicePrefs::Apply()
       }
       gPrefs->Write(wxT("/AudioIO/RecordChannels"),
                     mChannels->GetSelection() + 1);
-      return gPrefs->Flush();
    }
 
    return true;

--- a/src/prefs/PrefsDialog.cpp
+++ b/src/prefs/PrefsDialog.cpp
@@ -407,6 +407,8 @@ void PrefsDialog::OnOK(wxCommandEvent & WXUNUSED(event))
    else
       mUniquePage->Apply();
 
+   gPrefs->Flush();
+
    SavePreferredPage();
 
 #if USE_PORTMIXER
@@ -443,7 +445,6 @@ void PrefsDialog::OnOK(wxCommandEvent & WXUNUSED(event))
 
    WaveformSettings::defaults().LoadPrefs();
 
-   gPrefs->Flush();
    EndModal(true);
 }
 

--- a/src/prefs/RecordingPrefs.cpp
+++ b/src/prefs/RecordingPrefs.cpp
@@ -189,7 +189,6 @@ bool RecordingPrefs::Apply()
       if (targetpeak + deltapeak > 100.0 || targetpeak - deltapeak < 0.0)
       {
          gPrefs->Write(wxT("/AudioIO/DeltaPeakVolume"), min(100.0 - targetpeak, targetpeak));
-         gPrefs->Flush();
       }
 
       int value;
@@ -201,7 +200,7 @@ bool RecordingPrefs::Apply()
       if (value < 0)
          gPrefs->Write(wxT("/AudioIO/NumberAnalysis"), AILA_DEF_NUMBER_ANALYSIS);
    #endif
-   return gPrefs->Flush();
+   return true;
 }
 
 PrefsPanel *RecordingPrefsFactory::Create(wxWindow *parent)


### PR DESCRIPTION
Remove flushing of preferences in ShuttlePrefs and only flush when all settings have been written.  (Reduces the time it takes to leave the Preferences dialog)