### PR TITLE
Update the manifest pragma to match the docs.

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -132,7 +132,7 @@ It handles initialization and termination by subclassing wxApp.
 // These lines ensure that Audacity gets WindowsXP themes.
 // Without them we get the old-style Windows98/2000 look under XP.
 #  if !defined(__WXWINCE__)
-#     pragma comment(linker, "\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='X86' publicKeyToken='6595b64144ccf1df'\"")
+#     pragma comment(linker,"\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
 #  endif
 
 // These lines allows conditional inclusion of the various libraries


### PR DESCRIPTION
The language and processorArchitecture are wildcards.
This can be found on the [Enabling Visual Styles](https://msdn.microsoft.com/en-us/library/windows/desktop/bb773175.aspx) page.