### PR TITLE
Enable the DEP and ASLR flags.

### DIFF
--- a/win/Projects/Audacity/Audacity.vcxproj
+++ b/win/Projects/Audacity/Audacity.vcxproj
@@ -78,8 +78,6 @@
       <AdditionalLibraryDirectories>$(OutDir);$(WXWIN)\lib\vc_dll;$(GSTREAMER_SDK)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
       <StackReserveSize>8388608</StackReserveSize>
-      <RandomizedBaseAddress>false</RandomizedBaseAddress>
-      <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
@@ -114,8 +112,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <StackReserveSize>8388608</StackReserveSize>
-      <RandomizedBaseAddress>false</RandomizedBaseAddress>
-      <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
More precisely, /DYNAMICBASE and /NXCOMPAT are set unless explicitly disabled.  More info: [Windows ISV Software Security Defenses](https://msdn.microsoft.com/en-us/library/bb430720.aspx).  Unless they have been set deliberately, the flags are likely left over from when Visual Studio upgraded the project file.