### PR TITLE
continuous integration of build for windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+version: 2.1.2-{build}
+shallow_clone: true # reduce traffic
+install:
+    # install gettext tool (only used by target "locale", which is not built at
+    # the moment due to long duration
+    - nuget install Gettext.Tools
+    - set PATH=%PATH%;%AUDACITY_ROOT%\Gettext.Tools.0.19.7.001\tools\bin
+    # download wxWidgets
+    - git clone --branch v3.0.2 --depth 1 https://github.com/wxWidgets/wxWidgets.git %WXWIN%
+    # apply audacity patches
+    - xcopy %AUDACITY_ROOT%\win\wxWidgets_additions\wxWidgets-3.0.2 %WXWIN% /s /y /f
+    - xcopy %WXWIN%\include\wx\setup_redirect.h %WXWIN%\include\wx\setup.h* /f
+    # build wxWidgets
+    - msbuild %WXWIN%\build\msw\wx_vc12.sln /p:Configuration="DLL Release" /target:adv,base,core,html,net,qa,wxexpat,wxjpeg,wxpng,wxtiff,wxzlib /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+environment:
+    WXWIN: c:\wxWidgets-3.0.2
+    AUDACITY_ROOT: c:\projects\audacity
+# replace `build_script` with `build` and `configuration` when complete build
+# does not exceed a duration of 1 hour
+#build:
+    #project: win/audacity.sln
+#configuration:
+    #- Release
+build_script: # build all targets except of `help` and `locale`
+    msbuild win/audacity.sln /p:Configuration=Release /target:expat,filedialog,libflac++,libflac,libid3tag,libmad,libnyquist,libogg,libscorealign,libsndfile,libsoxr,libvamp,libvorbis,lv2,portaudio-v19,portmidi,portmixer,portsmf,sbsms,soundtouch,twolame,help,Audacity /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
Adds a configuration for appVeyor triggering a build of the release
version for each new commit. Needs registering at ci.appveyor.com with
the github account. Debug is not built, due to time limit of the free
version of appVeyor. Release build takes at least 30 minutes and up to
45 minutes. The time limit is 60 minutes.

Uses the undocumented possibility of building wxWidgets as dynamic
library by specifying "DLL Release" as configuration. The method in the
install instructions is impossible to automate as far as I could find
out.

Builds all targets except of "help" and "locale", because locale took
too long for the complete build to succeed the time limit.
This is not satisfying as new targets must be added manually to the
build. If this does not happen, the build will not fail, although the
new target could possibly fail building.
Unfortunately their seems to be no way to build the default targets
while excluding specific ones.
Adding target "help" was not tested.

Possible improvement: Put the complete "install" part into a install
script. That would help people easily building audacity and prevent
outdated install instruction as is the case at the moment.

I am not sure if renaming wx/setup_redirect.h into wx/setup.h is the
correct way, but it seems to work. Following the install instructions
resulted in missing wx/setup.h.