### PR TITLE
Enable some C++11 features in Travis, which now uses 4.6.3...

### DIFF
--- a/src/FreqWindow.h
+++ b/src/FreqWindow.h
@@ -213,7 +213,7 @@ private:
    int mMouseX;
    int mMouseY;
 
-   std::auto_ptr<SpectrumAnalyst> mAnalyst;
+   std::unique_ptr<SpectrumAnalyst> mAnalyst;
 
    DECLARE_EVENT_TABLE();
 

--- a/src/InterpolateAudio.cpp
+++ b/src/InterpolateAudio.cpp
@@ -11,6 +11,7 @@
 #include <math.h>
 #include <stdlib.h>
 
+#include <memory>
 #include <wx/defs.h>
 
 #include "InterpolateAudio.h"
@@ -97,13 +98,13 @@ void InterpolateAudio(float *buffer, int len,
       // performs poorly when interpolating to the left.  If
       // we're asked to interpolate the left side of a buffer,
       // we just reverse the problem and try it that way.
-      float *buffer2 = new float[len];
+      std::unique_ptr<float> buffer2Array(new float[len]);
+      float *const buffer2 = buffer2Array.get();
       for(i=0; i<len; i++)
          buffer2[len-1-i] = buffer[i];
       InterpolateAudio(buffer2, len, len-numBad, numBad);
       for(i=0; i<len; i++)
          buffer[len-1-i] = buffer2[i];
-      delete[] buffer2;
       return;
    }
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,7 @@ libaudacity_la_SOURCES = \
 	$(NULL)
 
 audacity_CPPFLAGS = \
+	-std=c++0x \
 	-Wno-deprecated-declarations \
 	-D__STDC_CONSTANT_MACROS \
 	-DLIBDIR=\"$(libdir)\" \

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -3204,7 +3204,8 @@ double AudacityProject::NearestZeroCrossing(double t0)
 {
    // Window is 1/100th of a second.
    int windowSize = (int)(GetRate() / 100);
-   float *dist = new float[windowSize];
+   std::unique_ptr<float[]> distArray(new float[windowSize]);
+   float *const dist = distArray.get();
    int i, j;
 
    for(i=0; i<windowSize; i++)
@@ -3219,7 +3220,8 @@ double AudacityProject::NearestZeroCrossing(double t0)
       }
       WaveTrack *one = (WaveTrack *)track;
       int oneWindowSize = (int)(one->GetRate() / 100);
-      float *oneDist = new float[oneWindowSize];
+      std::unique_ptr<float> oneDistArray(new float[oneWindowSize]);
+      float *const oneDist = oneDistArray.get();
       sampleCount s = one->TimeToLongSamples(t0);
       // fillTwo to ensure that missing values are treated as 2, and hence do not
       // get used as zero crossings.
@@ -3260,7 +3262,6 @@ double AudacityProject::NearestZeroCrossing(double t0)
          dist[i] += 0.1 * (abs(i - windowSize/2)) / float(windowSize/2);
       }
 
-      delete [] oneDist;
       track = iter.Next();
    }
 
@@ -3273,8 +3274,6 @@ double AudacityProject::NearestZeroCrossing(double t0)
          min = dist[i];
       }
    }
-
-   delete [] dist;
 
    return t0 + (argmin - windowSize/2)/GetRate();
 }

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -14,6 +14,7 @@
 *//*******************************************************************/
 
 #include <algorithm>
+#include <memory>
 
 #include "Audacity.h"
 
@@ -2833,9 +2834,9 @@ wxString PluginManager::ConvertID(const PluginID & ID)
    if (ID.StartsWith(wxT("base64:")))
    {
       wxString id = ID.Mid(7);
-      char *buf = new char[id.Length() / 4 * 3];
+      std::unique_ptr<char[]> bufArray(new char[id.Length() / 4 * 3]);
+      char *const buf = bufArray.get();
       id =  wxString::FromUTF8(buf, b64decode(id, buf));
-      delete [] buf;
       return id;
    }
 

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -342,7 +342,8 @@ public:
             Size dataSize = 0;
             GetFlavorDataSize((DragReference)m_currentDrag, theItem, theType, &dataSize);
 
-            Ptr theData = new char[dataSize];
+            std::unique_ptr<char[]> theDataArray(new char[dataSize]);
+            const Ptr theData = theDataArray.get();
             GetFlavorData((DragReference)m_currentDrag, theItem, theType, (void*) theData, &dataSize, 0L);
 
             wxString name;
@@ -352,8 +353,6 @@ public:
             else if (theType == kDragFlavorTypeHFS) {
                name = wxMacFSSpec2MacFilename(&((HFSFlavor *)theData)->fileSpec);
             }
-
-            delete[] theData;
 
             if (!firstFileAdded) {
                // reset file list

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -31,6 +31,7 @@
 #include "Audacity.h"
 
 #include <algorithm>
+#include <memory>
 #include <float.h>
 #include <math.h>
 
@@ -1311,7 +1312,8 @@ bool Sequence::GetWaveDisplay(float *min, float *max, float *rms, int* bl,
    // ... unless the mNumSamples ceiling applies, and then there are other defenses
    const sampleCount s1 =
       std::min(mNumSamples, std::max(1 + where[len - 1], where[len]));
-   float *temp = new float[mMaxSamples];
+   std::unique_ptr<float[]> tempArray(new float[mMaxSamples]);
+   float *const temp = tempArray.get();
 
    int pixel = 0;
 
@@ -1488,8 +1490,6 @@ bool Sequence::GetWaveDisplay(float *min, float *max, float *rms, int* bl,
    } // for each block file
 
    wxASSERT(pixel == len);
-
-   delete[] temp;
 
    return true;
 }

--- a/src/TimeTrack.cpp
+++ b/src/TimeTrack.cpp
@@ -16,6 +16,7 @@
 #include "Audacity.h"
 #include "TimeTrack.h"
 
+#include <memory>
 #include <wx/intl.h>
 #include "AColor.h"
 #include "widgets/Ruler.h"
@@ -257,7 +258,8 @@ void TimeTrack::Draw(wxDC & dc, const wxRect & r, const ZoomInfo &zoomInfo)
    mRuler->SetFlip(GetHeight() > 75 ? true : true); // MB: so why don't we just call Invalidate()? :)
    mRuler->Draw(dc, this);
 
-   double *envValues = new double[mid.width];
+   std::unique_ptr<double[]> envValuesArray(new double[mid.width]);
+   double *const envValues = envValuesArray.get();
    GetEnvelope()->GetValues(envValues, mid.width, 0, zoomInfo);
 
    dc.SetPen(AColor::envelopePen);
@@ -273,9 +275,6 @@ void TimeTrack::Draw(wxDC & dc, const wxRect & r, const ZoomInfo &zoomInfo)
          int thisy = r.y + (int)y;
          AColor::Line(dc, mid.x + x, thisy - 1, mid.x + x, thisy+2);
       }
-
-   if (envValues)
-      delete[]envValues;
 }
 
 void TimeTrack::testMe()

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -5007,8 +5007,10 @@ void TrackPanel::HandleSampleEditingClick( wxMouseEvent & event )
 
       //Get the region of samples around the selected point
       int sampleRegionSize = 1 + 2 * (SMOOTHING_KERNEL_RADIUS + SMOOTHING_BRUSH_RADIUS);
-      float *sampleRegion = new float[sampleRegionSize];
-      float * newSampleRegion = new float[1 + 2 * SMOOTHING_BRUSH_RADIUS];
+      std::unique_ptr<float[]> sampleRegionArray(new float[sampleRegionSize]);
+      float *const sampleRegion = sampleRegionArray.get();
+      std::unique_ptr<float[]> newSampleRegionArray(new float[1 + 2 * SMOOTHING_BRUSH_RADIUS]);
+      float *const newSampleRegion = newSampleRegionArray.get();
 
       //Get a sample  from the track to do some tricks on.
       mDrawingTrack->Get((samplePtr)sampleRegion, floatSample,
@@ -5054,10 +5056,6 @@ void TrackPanel::HandleSampleEditingClick( wxMouseEvent & event )
       }
       //Set the sample to the point of the mouse event
       mDrawingTrack->Set((samplePtr)newSampleRegion, floatSample, mDrawingStartSample - SMOOTHING_BRUSH_RADIUS, 1 + 2 * SMOOTHING_BRUSH_RADIUS);
-
-      //Clean this up right away to avoid a memory leak
-      delete[] sampleRegion;
-      delete[] newSampleRegion;
 
       mDrawingLastDragSampleValue = 0;
    }

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -636,7 +636,7 @@ protected:
    // and is ignored otherwise.
    double mFreqSelPin;
    const WaveTrack *mFreqSelTrack;
-   std::auto_ptr<SpectrumAnalyst> mFrequencySnapper;
+   std::unique_ptr<SpectrumAnalyst> mFrequencySnapper;
 
    // For toggling of spectral seletion
    double mLastF0;

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -560,7 +560,7 @@ bool WaveClip::GetWaveDisplay(WaveDisplay &display, double t0,
          return true;
       }
 
-      std::auto_ptr<WaveCache> oldCache(mWaveCache);
+      std::unique_ptr<WaveCache> oldCache(mWaveCache);
       mWaveCache = 0;
 
       int oldX0 = 0;
@@ -599,7 +599,7 @@ bool WaveClip::GetWaveDisplay(WaveDisplay &display, double t0,
       // with the current one, re-use as much of the cache as
       // possible
 
-      if (oldCache.get()) {
+      if (oldCache) {
 
          //TODO: only load inval regions if
          //necessary.  (usually is the case, so no rush.)
@@ -1111,7 +1111,7 @@ bool WaveClip::GetSpectrogram(WaveTrackCache &waveTrackCache,
       // a complete hit, because of the complications of time reassignment
       match = false;
 
-   std::auto_ptr<SpecCache> oldCache(mSpecCache);
+   std::unique_ptr<SpecCache> oldCache(mSpecCache);
    mSpecCache = 0;
 
    const double tstep = 1.0 / pixelsPerSecond;
@@ -1149,7 +1149,7 @@ bool WaveClip::GetSpectrogram(WaveTrackCache &waveTrackCache,
    // Optimization: if the old cache is good and overlaps
    // with the current one, re-use as much of the cache as
    // possible
-   if (oldCache.get()) {
+   if (oldCache) {
       memcpy(&mSpecCache->freq[half * copyBegin],
          &oldCache->freq[half * (copyBegin + oldX0)],
          half * (copyEnd - copyBegin) * sizeof(float));
@@ -1437,7 +1437,7 @@ bool WaveClip::Paste(double t0, const WaveClip* other)
    const bool clipNeedsResampling = other->mRate != mRate;
    const bool clipNeedsNewFormat =
       other->mSequence->GetSampleFormat() != mSequence->GetSampleFormat();
-   std::auto_ptr<WaveClip> newClip;
+   std::unique_ptr<WaveClip> newClip;
    const WaveClip* pastedClip;
 
    if (clipNeedsResampling || clipNeedsNewFormat)

--- a/src/blockfile/LegacyBlockFile.cpp
+++ b/src/blockfile/LegacyBlockFile.cpp
@@ -21,6 +21,7 @@
 #include <float.h>
 #include <math.h>
 
+#include <memory>
 #include <wx/filefn.h>
 #include <wx/file.h>
 #include <wx/ffile.h>
@@ -65,7 +66,8 @@ void ComputeLegacySummaryInfo(wxFileName fileName,
    // 64K summary data
    //
 
-   float *summary = new float[info->frames64K * fields];
+   std::unique_ptr<float[]> summaryArray(new float[info->frames64K * fields]);
+   float *const summary = summaryArray.get();
    SampleBuffer data(info->frames64K * fields,
       info->format);
 
@@ -110,8 +112,6 @@ void ComputeLegacySummaryInfo(wxFileName fileName,
       (*rms) = sqrt(sumsq / count);
    else
       (*rms) = 0;
-
-   delete[] summary;
 }
 
 /// Construct a LegacyBlockFile memory structure that will point to an

--- a/src/blockfile/ODDecodeBlockFile.cpp
+++ b/src/blockfile/ODDecodeBlockFile.cpp
@@ -342,9 +342,6 @@ int ODDecodeBlockFile::WriteODDecodeBlockFile()
 
    mFileNameMutex.Unlock();
 
-//   delete [] (char *) summaryData;
-
-
    mDataAvailableMutex.Lock();
    mDataAvailable=true;
    mDataAvailableMutex.Unlock();

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -22,6 +22,7 @@
 #include "../Audacity.h"
 #include "FindClipping.h"
 
+#include <memory>
 #include <math.h>
 
 #include <wx/intl.h>
@@ -161,7 +162,8 @@ bool EffectFindClipping::ProcessOne(LabelTrack * l,
       return true;
    }
 
-   float *buffer = new float[blockSize];
+   std::unique_ptr<float[]> bufferArray(new float[blockSize]);
+   float *const buffer = bufferArray.get();
 
    float *ptr = buffer;
 
@@ -218,8 +220,6 @@ bool EffectFindClipping::ProcessOne(LabelTrack * l,
       s++;
       block--;
    }
-
-   delete [] buffer;
 
    return bGoodResult;
 }

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -65,7 +65,7 @@ bool Generator::Process()
          {
             AudacityProject *p = GetActiveProject();
             // Create a temporary track
-            std::auto_ptr<WaveTrack> tmp(
+            std::unique_ptr<WaveTrack> tmp(
                mFactory->NewWaveTrack(track->GetSampleFormat(),
                track->GetRate())
             );

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -120,7 +120,8 @@ bool BlockGenerator::GenerateTrack(WaveTrack *tmp,
    bool bGoodResult = true;
    numSamples = track.TimeToLongSamples(GetDuration());
    sampleCount i = 0;
-   float *data = new float[tmp->GetMaxBlockSize()];
+   std::unique_ptr<float[]> dataArray(new float[tmp->GetMaxBlockSize()]);
+   float *const data = dataArray.get();
    sampleCount block = 0;
 
    while ((i < numSamples) && bGoodResult) {
@@ -138,6 +139,5 @@ bool BlockGenerator::GenerateTrack(WaveTrack *tmp,
       if (TrackProgress(ntrack, (double)i / numSamples))
          bGoodResult = false;
    }
-   delete[] data;
    return bGoodResult;
 }

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -456,7 +456,7 @@ bool EffectNoiseReduction::PromptUser(wxWindow *parent)
    // from an automation dialog, the only case in which we can
    // get here without any wavetracks.
    return mSettings->PromptUser(this, parent,
-      (mStatistics.get() != 0), (GetNumWaveTracks() == 0));
+      bool(mStatistics), (GetNumWaveTracks() == 0));
 }
 
 bool EffectNoiseReduction::Settings::PromptUser
@@ -1291,7 +1291,7 @@ bool EffectNoiseReduction::Worker::ProcessOne
 
    StartNewTrack();
 
-   std::auto_ptr<WaveTrack> outputTrack(
+   std::unique_ptr<WaveTrack> outputTrack(
       mDoProfile ? NULL
       : factory.NewWaveTrack(track->GetSampleFormat(), track->GetRate()));
 

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -54,8 +54,8 @@ private:
    class Worker;
    friend class Dialog;
 
-   std::auto_ptr<Settings> mSettings;
-   std::auto_ptr<Statistics> mStatistics;
+   std::unique_ptr<Settings> mSettings;
+   std::unique_ptr<Statistics> mStatistics;
 };
 
 #endif

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -23,6 +23,7 @@ the audio, rather than actually finding the clicks.
 
 #include "../Audacity.h"
 
+#include <memory>
 #include <math.h>
 
 #include <wx/intl.h>
@@ -144,11 +145,11 @@ bool EffectRepair::ProcessOne(int count, WaveTrack * track,
                               sampleCount len,
                               sampleCount repairStart, sampleCount repairLen)
 {
-   float *buffer = new float[len];
+   std::unique_ptr<float[]> bufferArray(new float[len]);
+   float *const buffer = bufferArray.get();
    track->Get((samplePtr) buffer, floatSample, start, len);
    InterpolateAudio(buffer, len, repairStart, repairLen);
    track->Set((samplePtr)&buffer[repairStart], floatSample,
               start + repairStart, repairLen);
-   delete[] buffer;
    return !TrackProgress(count, 1.0); // TrackProgress returns true on Cancel.
 }

--- a/src/import/ImportQT.cpp
+++ b/src/import/ImportQT.cpp
@@ -317,8 +317,9 @@ int QTImportFileHandle::Import(TrackFactory *trackFactory,
       AudioBufferList *abl = (AudioBufferList *)
          calloc(1, offsetof(AudioBufferList, mBuffers) + (sizeof(AudioBuffer) * numchan));
       abl->mNumberBuffers = numchan;
-   
-      WaveTrack **channels = new WaveTrack *[numchan];
+
+      std::unique_ptr<WaveTrack*[]> channelsArray(new WaveTrack*[numchan]);
+      WaveTrack **const channels = channelsArray.get();
    
       int c;
       for (c = 0; c < numchan; c++) {
@@ -381,8 +382,6 @@ int QTImportFileHandle::Import(TrackFactory *trackFactory,
          for (c = 0; c < numchan; c++) {
             delete channels[c];
          }
-   
-         delete [] channels;
       }
    
       for (c = 0; c < numchan; c++) {

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -700,7 +700,7 @@ AButton * ToolBar::MakeButton(teBmps eUp,
    int xoff = (size.GetWidth() - theTheme.Image(eStandardUp).GetWidth())/2;
    int yoff = (size.GetHeight() - theTheme.Image(eStandardUp).GetHeight())/2;
 
-   typedef std::auto_ptr<wxImage> wxImagePtr;
+   typedef std::unique_ptr<wxImage> wxImagePtr;
    wxImagePtr up2        (OverlayImage(eUp,     eStandardUp, xoff, yoff));
    wxImagePtr hilite2    (OverlayImage(eHilite, eStandardUp, xoff, yoff));
    wxImagePtr down2      (OverlayImage(eDown,   eStandardDown, xoff + 1, yoff + 1));
@@ -726,7 +726,7 @@ void ToolBar::MakeAlternateImages(AButton &button, int idx,
    int xoff = (size.GetWidth() - theTheme.Image(eStandardUp).GetWidth())/2;
    int yoff = (size.GetHeight() - theTheme.Image(eStandardUp).GetHeight())/2;
 
-   typedef std::auto_ptr<wxImage> wxImagePtr;
+   typedef std::unique_ptr<wxImage> wxImagePtr;
    wxImagePtr up        (OverlayImage(eUp,     eStandardUp, xoff, yoff));
    wxImagePtr hilite    (OverlayImage(eHilite, eStandardUp, xoff, yoff));
    wxImagePtr down      (OverlayImage(eDown,   eStandardDown, xoff + 1, yoff + 1));

--- a/src/widgets/AButton.cpp
+++ b/src/widgets/AButton.cpp
@@ -280,7 +280,7 @@ void AButton::SetAlternateIdx(unsigned idx)
 
 void AButton::FollowModifierKeys()
 {
-   if(!mListener.get())
+   if(!mListener)
       mListener.reset(new Listener(this));
 }
 

--- a/src/widgets/AButton.h
+++ b/src/widgets/AButton.h
@@ -164,7 +164,7 @@ class AButton: public wxWindow {
    wxRect mFocusRect;
    bool mForceFocusRect;
 
-   std::auto_ptr<Listener> mListener;
+   std::unique_ptr<Listener> mListener;
 
 public:
 

--- a/src/widgets/MultiDialog.cpp
+++ b/src/widgets/MultiDialog.cpp
@@ -23,6 +23,7 @@ for each problem encountered, since there can be many orphans.
 
 #include "MultiDialog.h"
 
+#include <memory>
 #include <wx/button.h>
 #include <wx/dialog.h>
 #include <wx/intl.h>
@@ -86,7 +87,8 @@ MultiDialog::MultiDialog(wxWindow * pParent,
 
    int count=0;
    while(buttons[count])count++;
-   wxString *buttonLabels = new wxString[count];
+   std::unique_ptr<wxString[]> buttonLabelsArray(new wxString[count]);
+   wxString *const buttonLabels = buttonLabelsArray.get();
 
    count=0;
    while(buttons[count]){
@@ -129,7 +131,6 @@ MultiDialog::MultiDialog(wxWindow * pParent,
    SetSizer(mainSizer);
    mainSizer->Fit(this);
    mainSizer->SetSizeHints(this);
-   delete[] buttonLabels;
 }
 
 void MultiDialog::OnOK(wxCommandEvent & WXUNUSED(event))

--- a/src/xml/XMLTagHandler.cpp
+++ b/src/xml/XMLTagHandler.cpp
@@ -26,6 +26,8 @@
 #include "../Audacity.h"
 #include "../Internat.h"
 
+#include <memory>
+
 #ifdef _WIN32
    #include <windows.h>
    #include <wx/msw/winundef.h>
@@ -217,7 +219,8 @@ bool XMLTagHandler::ReadXMLTag(const char *tag, const char **attrs)
 // const char **out_attrs = new char (const char *)[tmp_attrs.GetCount()+1];
 // however MSVC doesn't like the constness in this position, so this is now
 // added by a cast after creating the array of pointers-to-non-const chars.
-   const wxChar **out_attrs = (const wxChar**)new wxChar *[tmp_attrs.GetCount()+1];
+   std::unique_ptr<const wxChar*[]> out_attrsArray(new const wxChar*[tmp_attrs.GetCount()+1]);
+   const wxChar **const out_attrs = out_attrsArray.get();
    for (size_t i=0; i<tmp_attrs.GetCount(); i++) {
       out_attrs[i] = tmp_attrs[i].c_str();
    }
@@ -225,7 +228,6 @@ bool XMLTagHandler::ReadXMLTag(const char *tag, const char **attrs)
 
    bool result = HandleXMLTag(UTF8CTOWX(tag).c_str(), out_attrs);
 
-   delete[] out_attrs;
    return result;
 }
 


### PR DESCRIPTION
... See here for supported features: https://gcc.gnu.org/projects/cxx0x.html

If later versions of gcc are used, the option should be changed to
-std=c++11