### PR TITLE
Travis upgrade gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
     - git show -s --format="wxT(\"<a href=\\\"http://github.com/audacity/audacity/commit/%H\\\">%h</a> of %cd\")"
     - git show -s --format="wxT(\"<a href=\\\"http://github.com/audacity/audacity/commit/%H\\\">%h</a> of %cd\")" > ./src/RevisionIdent.h
     - export CXX="g++-4.8" CC="gcc-4.8"
+    - g++-4.8 --version
 language:
     - cpp
 script:


### PR DESCRIPTION
Use a more recent version of gcc for building on Travis-CI.
This prepares the CI for using C++11 features.