### PR TITLE
Fix linking with non-system compiler on linux

### DIFF
--- a/lib-src/FileDialog/Makefile.in
+++ b/lib-src/FileDialog/Makefile.in
@@ -216,10 +216,6 @@ OBJCXXLINK = $(LIBTOOL) $(AM_V_lt) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) \
 	--mode=link $(OBJCXXLD) $(AM_OBJCXXFLAGS) $(OBJCXXFLAGS) \
 	$(AM_LDFLAGS) $(LDFLAGS) -o $@
 AM_V_OBJCXXLD = $(am__v_OBJCXXLD_@AM_V@)
-# Overwrite C++ variables with values for Objective-C, because in the end there
-# is only one linker command that should be configured correctly.
-@MAC_TRUE@CXXLINK = $(OBJCXXLINK)
-@MAC_TRUE@AM_V_CXXLD = $(AM_V_OBJCXXLD)
 am__v_OBJCXXLD_ = $(am__v_OBJCXXLD_@AM_DEFAULT_V@)
 am__v_OBJCXXLD_0 = @echo "  OBJCXXLD" $@;
 am__v_OBJCXXLD_1 = 
@@ -524,8 +520,8 @@ win/$(DEPDIR)/$(am__dirstamp):
 win/libFileDialog_la-FileDialogPrivate.lo: win/$(am__dirstamp) \
 	win/$(DEPDIR)/$(am__dirstamp)
 
-libFileDialog.la: $(libFileDialog_la_OBJECTS) $(libFileDialog_la_DEPENDENCIES) $(EXTRA_libFileDialog_la_DEPENDENCIES)
-	$(AM_V_CXXLD)$(CXXLINK) -rpath $(libdir) $(libFileDialog_la_OBJECTS) $(libFileDialog_la_LIBADD) $(LIBS)
+libFileDialog.la: $(libFileDialog_la_OBJECTS) $(libFileDialog_la_DEPENDENCIES) $(EXTRA_libFileDialog_la_DEPENDENCIES) 
+	$(AM_V_OBJCXXLD)$(OBJCXXLINK) -rpath $(libdir) $(libFileDialog_la_OBJECTS) $(libFileDialog_la_LIBADD) $(LIBS)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)

--- a/lib-src/FileDialog/configure
+++ b/lib-src/FileDialog/configure
@@ -16275,6 +16275,13 @@ else
 fi
 
 
+if [ "$IMPLEMENTATION" = gtk ]
+then
+	OBJCXX=$CXX
+	AM_OBJCXXFLAGS=$AM_CXXFLAGS
+	OBJCXXFLAGS=$CXXFLAGS
+fi
+
 echo "Implementation to use: $IMPLEMENTATION"
 
 ac_config_files="$ac_config_files Makefile"

--- a/lib-src/FileDialog/configure.ac
+++ b/lib-src/FileDialog/configure.ac
@@ -122,6 +122,16 @@ AM_CONDITIONAL([GTK], test "$IMPLEMENTATION" = "gtk")
 AM_CONDITIONAL([MAC], test "$IMPLEMENTATION" = "mac")
 AM_CONDITIONAL([WINDOWS], test "$IMPLEMENTATION" = "win")
 
+dnl Automake uses the Ojective-C++ linker in any case, so we have to overwrite
+dnl the variables it's using with the correct C++ counterparts (only those used
+dnl for linking).
+if [[ "$IMPLEMENTATION" = gtk ]]
+then
+	OBJCXX=$CXX
+	AM_OBJCXXFLAGS=$AM_CXXFLAGS
+	OBJCXXFLAGS=$CXXFLAGS
+fi
+
 echo "Implementation to use: $IMPLEMENTATION"
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
This replaces the previous fix, which was applied to a generated file.
