### PR TITLE
comment out extra tokens at end of #endif directive to avoid compiler warnings [-Wextra-tokens]

### DIFF
--- a/lib-src/libnyquist/nyquist/nyqsrc/nfilterkit.h
+++ b/lib-src/libnyquist/nyquist/nyqsrc/nfilterkit.h
@@ -11,10 +11,10 @@ typedef unsigned int   UWORD;
 
 #ifdef DEBUG
 #define INLINE
-#else DEBUG
+#else /* DEBUG */
 /* #define INLINE inline */
 #define INLINE
-#endif DEBUG
+#endif /* DEBUG */
 
 /*
  * FilterUp() - Applies a filter to a given sample when up-converting.

--- a/lib-src/libnyquist/nyquist/nyqsrc/sound.h
+++ b/lib-src/libnyquist/nyquist/nyqsrc/sound.h
@@ -459,7 +459,7 @@ double step_to_hz(double);
 
 #ifdef WIN32
 double log2(double x);
-#endif WIN32
+#endif /* WIN32 */
 
 /* macros for access to samples within a suspension */
 /* NOTE: assume suspension structure is named "susp" */


### PR DESCRIPTION
My compiler keeps complaining about:
`````
./nyquist/nyqsrc/sound.h:462:8: warning: extra tokens at end of #endif directive [-Wextra-tokens]
#endif WIN32
       ^
       //
1 warning generated.
`````
so I'm attaching a trivial patch to comment out the extra tokens. (One could just as well delete them, but I didn't want to modify the code too much.)