### PR TITLE
build: rework everything to use wxString instead of pointer-to-wxChar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+.deps/
+.dirstamp
+stamp-h[0-9]*
+Makefile
+Makefile.in
+*.pc
+config.h
+config.status
+
 # Compiled Object files
 *.slo
 *.lo

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -892,7 +892,7 @@ wxString AboutDialog::GetCreditsByRole(AboutDialog::Role role)
  *
  * Used when creating the build information tab to show if each optional
  * library is enabled or not, and what it does */
-void AboutDialog::AddBuildinfoRow( wxString* htmlstring, const wxChar * libname, const wxChar * libdesc, const wxString &status)
+void AboutDialog::AddBuildinfoRow( wxString* htmlstring, const wxString &libname, const wxString &libdesc, const wxString &status)
 {
    *htmlstring += wxT("<tr><td>");
    *htmlstring += libname;
@@ -907,7 +907,7 @@ void AboutDialog::AddBuildinfoRow( wxString* htmlstring, const wxChar * libname,
  *
  * Used when creating the build information tab to show build dates and
  * file paths */
-void AboutDialog::AddBuildinfoRow( wxString* htmlstring, const wxChar * libname, const wxChar * libdesc)
+void AboutDialog::AddBuildinfoRow( wxString* htmlstring, const wxString &libname, const wxString &libdesc)
 {
    *htmlstring += wxT("<tr><td>");
    *htmlstring += libname;

--- a/src/AboutDialog.h
+++ b/src/AboutDialog.h
@@ -76,8 +76,8 @@ class AboutDialog final : public wxDialog {
    void AddCredit(wxString &&description, Role role);
    wxString GetCreditsByRole(AboutDialog::Role role);
 
-   void AddBuildinfoRow( wxString* htmlstring, const wxChar * libname, const wxChar * libdesc, const wxString &status);
-   void AddBuildinfoRow( wxString* htmlstring, const wxChar * libname, const wxChar * libdesc);
+   void AddBuildinfoRow( wxString* htmlstring, const wxString &libname, const wxString &libdesc, const wxString &status);
+   void AddBuildinfoRow( wxString* htmlstring, const wxString &libname, const wxString &libdesc);
 };
 
 #endif

--- a/src/AutoRecovery.h
+++ b/src/AutoRecovery.h
@@ -45,9 +45,9 @@ class RecordingRecoveryHandler final : public XMLTagHandler
 {
 public:
    RecordingRecoveryHandler(AudacityProject* proj);
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   void HandleXMLEndTag(const wxChar *tag) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   void HandleXMLEndTag(const wxString &tag) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
 
    // This class only knows reading tags
    // void WriteXML(XMLWriter & WXUNUSED(xmlFile)) /* not override */ { wxASSERT(false); }
@@ -84,7 +84,6 @@ public:
    void EndTag(const wxString & name) override;
 
    void WriteAttr(const wxString & name, const wxString &value) override;
-   void WriteAttr(const wxString & name, const wxChar *value) override;
 
    void WriteAttr(const wxString & name, int value) override;
    void WriteAttr(const wxString & name, bool value) override;

--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -427,7 +427,7 @@ wxString BatchCommands::BuildCleanFileName(const wxString &fileName, const wxStr
       int minute = now.GetMinute();
       int second = now.GetSecond();
       justName = wxString::Format(wxT("%d-%s-%02d-%02d-%02d-%02d"),
-           year, monthName.c_str(), dom, hour, minute, second);
+           year, monthName, dom, hour, minute, second);
 
 //      SetName(cleanedFileName);
 //      bool isStereo;
@@ -436,7 +436,7 @@ wxString BatchCommands::BuildCleanFileName(const wxString &fileName, const wxStr
       //OnSelectAll();
       pathName = gPrefs->Read(wxT("/DefaultOpenPath"), ::wxGetCwd());
       ::wxMessageBox(wxString::Format(wxT("Export recording to %s\n/cleaned/%s%s"),
-                                      pathName.c_str(), justName.c_str(), extension.c_str()),
+                                      pathName, justName, extension),
                      wxT("Export recording"),
                   wxOK | wxCENTRE);
       pathName += wxT("/");
@@ -581,7 +581,7 @@ bool BatchCommands::ApplySpecialCommand(int WXUNUSED(iCommand), const wxString &
       return false;
 #endif
    }
-   wxMessageBox(wxString::Format(_("Command %s not implemented yet"),command.c_str()));
+   wxMessageBox(wxString::Format(_("Command %s not implemented yet"),command));
    return false;
 }
 // end CLEANSPEECH remnant
@@ -639,7 +639,7 @@ bool BatchCommands::ApplyCommand(const wxString & command, const wxString & para
 
    wxMessageBox(
       wxString::Format(
-      _("Your batch command of %s was not recognized."), command.c_str() ));
+      _("Your batch command of %s was not recognized."), command ));
 
    return false;
 }
@@ -699,8 +699,8 @@ bool BatchCommands::ApplyChain(const wxString & filename)
    }
    else
    {
-      longDesc = wxString::Format(wxT("Applied batch chain '%s'"), name.c_str());
-      shortDesc = wxString::Format(wxT("Apply '%s'"), name.c_str());
+      longDesc = wxString::Format(wxT("Applied batch chain '%s'"), name);
+      shortDesc = wxString::Format(wxT("Apply '%s'"), name);
    }
 
    if (!proj)
@@ -758,12 +758,12 @@ bool BatchCommands::ReportAndSkip(const wxString & command, const wxString & par
    //TODO: Add a cancel button to these, and add the logic so that we can abort.
    if( params != wxT("") )
    {
-      wxMessageBox( wxString::Format(_("Apply %s with parameter(s)\n\n%s"),command.c_str(), params.c_str()),
+      wxMessageBox( wxString::Format(_("Apply %s with parameter(s)\n\n%s"),command, params),
          _("Test Mode"));
    }
    else
    {
-      wxMessageBox( wxString::Format(_("Apply %s"),command.c_str()),
+      wxMessageBox(wxString::Format(_("Apply %s"), command),
          _("Test Mode"));
    }
    return true;

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -163,7 +163,7 @@ void BatchProcessDialog::OnApplyToProject(wxCommandEvent & WXUNUSED(event))
       {
          S.SetBorder(20);
          S.AddFixedText(wxString::Format(_("Applying '%s' to current project"),
-                                         name.c_str()));
+                                         name));
       }
       S.EndStatic();
    }
@@ -630,7 +630,7 @@ bool EditChainsDialog::ChangeOK()
       wxString msg;
       int id;
 
-      title.Printf(_("%s changed"), mActiveChain.c_str());
+      title.Printf(_("%s changed"), mActiveChain);
       msg = _("Do you want to save the changes?");
 
       id = wxMessageBox(msg, title, wxYES_NO | wxCANCEL);
@@ -821,7 +821,7 @@ void EditChainsDialog::OnRemove(wxCommandEvent & WXUNUSED(event))
    wxString name = mChains->GetItemText(item);
    wxMessageDialog m(this,
    /*i18n-hint: %s will be replaced by the name of a file.*/
-                     wxString::Format(_("Are you sure you want to delete %s?"), name.c_str()),
+                     wxString::Format(_("Are you sure you want to delete %s?"), name),
                      GetTitle(),
                      wxYES_NO | wxICON_QUESTION);
    if (m.ShowModal() == wxID_NO) {

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -57,7 +57,7 @@ private:
    void OnClear( wxCommandEvent &event );
    void OnClose( wxCommandEvent &event );
 
-   void Printf(const wxChar *format, ...);
+   void Printf(const wxString &format, ...);
    void HoldPrint(bool hold);
    void FlushPrint();
 
@@ -266,7 +266,7 @@ void BenchmarkDialog::OnClear(wxCommandEvent & WXUNUSED(event))
    mText->Clear();
 }
 
-void BenchmarkDialog::Printf(const wxChar *format, ...)
+void BenchmarkDialog::Printf(const wxString &format, ...)
 {
    va_list argptr;
    va_start(argptr, format);

--- a/src/BlockFile.cpp
+++ b/src/BlockFile.cpp
@@ -61,7 +61,7 @@ out.
 #ifdef DEBUG_BLOCKFILE
 #define BLOCKFILE_DEBUG_OUTPUT(op, i) \
    wxPrintf(wxT("[BlockFile %x %s] %s: %i\n"), (unsigned)this, \
-            mFileName.GetFullName().c_str(), wxT(op), i);
+            mFileName.GetFullName(), wxT(op), i);
 #else
 #define BLOCKFILE_DEBUG_OUTPUT(op, i)
 #endif
@@ -570,7 +570,7 @@ void AliasBlockFile::WriteSummary()
       // Never silence the Log w.r.t write errors; they always count
       // as NEW errors
       wxLogError(wxT("Unable to write summary data to file %s"),
-                   mFileName.GetFullPath().c_str());
+                   mFileName.GetFullPath());
       // If we can't write, there's nothing to do.
       return;
    }

--- a/src/DirManager.h
+++ b/src/DirManager.h
@@ -52,7 +52,7 @@ class PROFILE_DLL_API DirManager final : public XMLTagHandler {
    // Returns true on success.
    // If SetProject is told NOT to create the directory
    // but it doesn't already exist, SetProject fails and returns false.
-   bool SetProject(wxString& newProjPath, wxString& newProjName, const bool bCreate);
+   bool SetProject(const wxString& newProjPath, const wxString& newProjName, const bool bCreate);
 
    wxString GetProjectDataDir();
    wxString GetProjectName();
@@ -83,7 +83,7 @@ class PROFILE_DLL_API DirManager final : public XMLTagHandler {
    // the BlockFile.
    BlockFile *CopyBlockFile(BlockFile *b);
 
-   BlockFile *LoadBlockFile(const wxChar **attrs, sampleFormat format);
+   BlockFile *LoadBlockFile(const wxArrayString &attrs, sampleFormat format);
    void SaveBlockFile(BlockFile *f, int depth, FILE *fp);
 
 #if LEGACY_PROJECT_FILE_SUPPORT
@@ -113,9 +113,9 @@ class PROFILE_DLL_API DirManager final : public XMLTagHandler {
    // Note: following affects only the loading of block files when opening a project
    void SetLoadingMaxSamples(sampleCount max) { mMaxSamples = max; }
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs);
-   XMLTagHandler *HandleXMLChild(const wxChar * WXUNUSED(tag)) { return NULL; }
-   void WriteXML(XMLWriter & WXUNUSED(xmlFile)) { wxASSERT(false); } // This class only reads tags.
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs);
+   XMLTagHandler *HandleXMLChild(const wxString &WXUNUSED(tag)) { return NULL; }
+   void WriteXML(XMLWriter &WXUNUSED(xmlFile)) { wxASSERT(false); } // This class only reads tags.
    bool AssignFile(wxFileName &filename, const wxString &value, bool check);
 
    // Clean the temp dir. Note that now where we have auto recovery the temp

--- a/src/Envelope.cpp
+++ b/src/Envelope.cpp
@@ -246,7 +246,7 @@ void Envelope::DrawPoints(wxDC & dc, const wxRect & r, const ZoomInfo &zoomInfo,
    }
 }
 
-bool Envelope::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool Envelope::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    // Return unless it's the envelope tag.
    if (wxStrcmp(tag, wxT("envelope")))
@@ -255,12 +255,9 @@ bool Envelope::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    int numPoints = 0;
    long nValue = -1;
 
-   while (*attrs) {
-      const wxChar *attr = *attrs++;
-      const wxChar *value = *attrs++;
-      if (!value)
-         break;
-      const wxString strValue = value;
+   for (size_t i = 0; i < attrs.GetCount() / 2; ++i) {
+      const wxString &attr = attrs[2*i];
+      const wxString &strValue = attrs[2*i+1];;
       if( !wxStrcmp(attr, wxT("numpoints")) &&
             XMLValueChecker::IsGoodInt(strValue) && strValue.ToLong(&nValue))
          numPoints = nValue;
@@ -273,7 +270,7 @@ bool Envelope::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return true;
 }
 
-XMLTagHandler *Envelope::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *Envelope::HandleXMLChild(const wxString &tag)
 {
    if (wxStrcmp(tag, wxT("controlpoint")))
       return NULL;

--- a/src/Envelope.h
+++ b/src/Envelope.h
@@ -43,12 +43,12 @@ public:
    double GetVal() const { return mVal; }
    inline void SetVal(double val);
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
    {
       if (!wxStrcmp(tag, wxT("controlpoint"))) {
-         while (*attrs) {
-            const wxChar *attr = *attrs++;
-            const wxChar *value = *attrs++;
+         for (size_t i = 0; i < attrs.GetCount() / 2; ++i) {
+            const wxString &attr = attrs[2*i];
+            const wxString &value = attrs[2*i+1];
             if (!wxStrcmp(attr, wxT("t")))
                SetT(Internat::CompatibleToDouble(value));
             else if (!wxStrcmp(attr, wxT("val")))
@@ -60,7 +60,7 @@ public:
          return false;
    }
 
-   XMLTagHandler *HandleXMLChild(const wxChar * WXUNUSED(tag))
+   XMLTagHandler *HandleXMLChild(const wxString &WXUNUSED(tag))
    {
       return NULL;
    }
@@ -102,8 +102,8 @@ class Envelope final : public XMLTagHandler {
    bool Save(wxTextFile * out, bool overwrite) override;
 #endif
    // Newfangled XML file I/O
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) const /* not override */;
 
    void DrawPoints(wxDC & dc, const wxRect & r, const ZoomInfo &zoomInfo,

--- a/src/FFT.cpp
+++ b/src/FFT.cpp
@@ -489,7 +489,7 @@ int NumWindowFuncs()
    return eWinFuncCount;
 }
 
-const wxChar *WindowFuncName(int whichFunction)
+wxString WindowFuncName(int whichFunction)
 {
    switch (whichFunction) {
    default:

--- a/src/FFT.h
+++ b/src/FFT.h
@@ -142,7 +142,7 @@ void DerivativeOfWindowFunc(int whichFunction, int NumSamples, bool extraSample,
  * Returns the name of the windowing function (for UI display)
  */
 
-const wxChar *WindowFuncName(int whichFunction);
+wxString WindowFuncName(int whichFunction);
 
 /*
  * Returns the number of windowing functions supported

--- a/src/FFmpeg.h
+++ b/src/FFmpeg.h
@@ -265,7 +265,7 @@ public:
    ///\return libavformat library version or empty string?
    wxString GetLibraryVersion()
    {
-      return wxString::Format(wxT("F(%s),C(%s),U(%s)"),mAVFormatVersion.c_str(),mAVCodecVersion.c_str(),mAVUtilVersion.c_str());
+      return wxString::Format(wxT("F(%s),C(%s),U(%s)"),mAVFormatVersion,mAVCodecVersion,mAVUtilVersion);
    }
 
 #if defined(__WXMSW__)
@@ -392,7 +392,7 @@ FFmpegLibs *PickFFmpegLibs();
 void        DropFFmpegLibs();
 
 int ufile_fopen(AVIOContext **s, const wxString & name, int flags);
-int ufile_fopen_input(AVFormatContext **ic_ptr, wxString & name);
+int ufile_fopen_input(AVFormatContext **ic_ptr, const wxString &name);
 int ufile_close(AVIOContext *pb);
 
 typedef struct _streamContext

--- a/src/FileIO.cpp
+++ b/src/FileIO.cpp
@@ -29,14 +29,14 @@ FileIO::FileIO(const wxString & name, FileIOMode mode)
       if (mMode == FileIO::Input) {
          mInputStream = new wxFFileInputStream(mName);
          if (mInputStream == NULL || !mInputStream->IsOk()) {
-            wxPrintf(wxT("Couldn't get input stream: %s\n"), name.c_str());
+            wxPrintf(wxT("Couldn't get input stream: %s\n"), name);
             return;
          }
       }
       else {
          mOutputStream = new wxFFileOutputStream(mName);
          if (mOutputStream == NULL || !mOutputStream->IsOk()) {
-            wxPrintf(wxT("Couldn't get output stream: %s\n"), name.c_str());
+            wxPrintf(wxT("Couldn't get output stream: %s\n"), name);
             return;
          }
       }

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -67,7 +67,7 @@ void FileNames::MakeNameUnique(wxArrayString &otherNames, wxFileName &newName)
       int i=2;
       wxString orig = newName.GetName();
       do {
-         newName.SetName(wxString::Format(wxT("%s-%d"), orig.c_str(), i));
+         newName.SetName(wxString::Format(wxT("%s-%d"), orig, i));
          i++;
       } while (otherNames.Index(newName.GetFullName(), false) >= 0);
    }

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -925,28 +925,22 @@ void FreqWindow::PlotPaint(wxPaintEvent & event)
       wxString peak;
       wxString xpitch;
       wxString peakpitch;
-      const wxChar *xp;
-      const wxChar *pp;
 
       if (mAlg == SpectrumAnalyst::Spectrum) {
          xpitch = PitchName_Absolute(FreqToMIDInote(xPos));
          peakpitch = PitchName_Absolute(FreqToMIDInote(bestpeak));
-         xp = xpitch.c_str();
-         pp = peakpitch.c_str();
          /* i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#*/
-         cursor.Printf(_("%d Hz (%s) = %d dB"), int (xPos + 0.5), xp, int (value + 0.5));
-         peak.Printf(_("%d Hz (%s) = %.1f dB"), int (bestpeak + 0.5), pp, bestValue);
+         cursor.Printf(_("%d Hz (%s) = %d dB"), int (xPos + 0.5), xpitch, int (value + 0.5));
+         peak.Printf(_("%d Hz (%s) = %.1f dB"), int (bestpeak + 0.5), peakpitch, bestValue);
       } else if (xPos > 0.0 && bestpeak > 0.0) {
          xpitch = PitchName_Absolute(FreqToMIDInote(1.0 / xPos));
          peakpitch = PitchName_Absolute(FreqToMIDInote(1.0 / bestpeak));
-         xp = xpitch.c_str();
-         pp = peakpitch.c_str();
          /* i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
           * the %.4f are numbers, and 'sec' should be an abbreviation for seconds */
          cursor.Printf(_("%.4f sec (%d Hz) (%s) = %f"),
-                     xPos, int (1.0 / xPos + 0.5), xp, value);
+                     xPos, int (1.0 / xPos + 0.5), xpitch, value);
          peak.Printf(_("%.4f sec (%d Hz) (%s) = %.3f"),
-                     bestpeak, int (1.0 / bestpeak + 0.5), pp, bestValue);
+                     bestpeak, int (1.0 / bestpeak + 0.5), peakpitch, bestValue);
       }
       mCursorText->SetValue(cursor);
       mPeakText->SetValue(peak);

--- a/src/Internat.cpp
+++ b/src/Internat.cpp
@@ -178,13 +178,12 @@ char *Internat::VerifyFilename(const wxString &s, bool input)
    wxString name = s;
 
    if (input) {
-      if ((char *) (const char *)name.mb_str() == NULL) {
+      if (name.mb_str().length() == 0)
          name = wxEmptyString;
-      }
    }
    else {
       wxFileName f(name);
-      while ((char *) (const char *)name.mb_str() == NULL) {
+      while (name.mb_str().length() == NULL) {
          wxMessageBox(_("The specified filename could not be converted due to Unicode character use."));
 
          name = FileSelector(_("Specify New Filename:"),
@@ -199,7 +198,7 @@ char *Internat::VerifyFilename(const wxString &s, bool input)
 
    mFilename = name.mb_str();
 
-   return (char *) (const char *) mFilename;
+   return (char *) (const char *) mFilename; /* FUCK IT */
 }
 #endif
 

--- a/src/Internat.h
+++ b/src/Internat.h
@@ -94,11 +94,11 @@ private:
 #define OSINPUT(X) Internat::VerifyFilename(X, true)
 #define OSOUTPUT(X) Internat::VerifyFilename(X, false)
 #elif defined(__WXMAC__)
-#define OSFILENAME(X) ((char *) (const char *)(X).fn_str())
+#define OSFILENAME(X) (X).fn_str()
 #define OSINPUT(X) OSFILENAME(X)
 #define OSOUTPUT(X) OSFILENAME(X)
 #else
-#define OSFILENAME(X) ((char *) (const char *)(X).mb_str())
+#define OSFILENAME(X) (X).utf8_str()
 #define OSINPUT(X) OSFILENAME(X)
 #define OSOUTPUT(X) OSFILENAME(X)
 #endif

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -363,7 +363,7 @@ wxString LabelDialog::TrackName(int & index, const wxString &dflt)
    // Generate a NEW track name if the passed index is out of range
    if (index < 1 || index >= (int)mTrackNames.GetCount()) {
       index = mTrackNames.GetCount();
-      mTrackNames.Add(wxString::Format(wxT("%d - %s"), index, dflt.c_str()));
+      mTrackNames.Add(wxString::Format(wxT("%d - %s"), index, dflt));
    }
 
    // Return the track name
@@ -594,7 +594,7 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
 
    fName = FileSelector(_("Export Labels As:"),
       wxEmptyString,
-      fName.c_str(),
+      fName,
       wxT("txt"),
       wxT("*.txt"),
       wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -2145,7 +2145,7 @@ void LabelTrack::Export(wxTextFile & f)
       f.AddLine(wxString::Format(wxT("%f\t%f\t%s"),
                                  (double)mLabels[i]->getT0(),
                                  (double)mLabels[i]->getT1(),
-                                 mLabels[i]->title.c_str()));
+                                 mLabels[i]->title));
    }
 }
 
@@ -2234,7 +2234,7 @@ void LabelTrack::Import(wxTextFile & in)
    SortLabels();
 }
 
-bool LabelTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool LabelTrack::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (!wxStrcmp(tag, wxT("label"))) {
 
@@ -2243,14 +2243,10 @@ bool LabelTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
 
       // loop through attrs, which is a null-terminated list of
       // attribute-value pairs
-      while(*attrs) {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-            break;
-
-         const wxString strValue = value;
+      for (size_t i = 0; i < attrs.GetCount(); i += 2) {
+         const wxString &attr = attrs[2*i];
+         const wxString &value = attrs[2*i+1];
+         const wxString &strValue = value;
          if (!XMLValueChecker::IsGoodString(strValue))
          {
             return false;
@@ -2277,14 +2273,9 @@ bool LabelTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    }
    else if (!wxStrcmp(tag, wxT("labeltrack"))) {
       long nValue = -1;
-      while (*attrs) {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-            return true;
-
-         const wxString strValue = value;
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i) {
+         const wxString &attr = attrs[2*i];
+         const wxString &strValue = attrs[2*i+1];
          if (!wxStrcmp(attr, wxT("name")) && XMLValueChecker::IsGoodString(strValue))
             mName = strValue;
          else if (!wxStrcmp(attr, wxT("numlabels")) &&
@@ -2315,7 +2306,7 @@ bool LabelTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return false;
 }
 
-XMLTagHandler *LabelTrack::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *LabelTrack::HandleXMLChild(const wxString &tag)
 {
    if (!wxStrcmp(tag, wxT("label")))
       return this;

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -143,8 +143,8 @@ class AUDACITY_DLL_API LabelTrack final : public Track
 
    void SetSelected(bool s) override;
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) override;
 
 #if LEGACY_PROJECT_FILE_SUPPORT

--- a/src/LangChoice.cpp
+++ b/src/LangChoice.cpp
@@ -128,10 +128,10 @@ void LangChoiceDialog::OnOk(wxCommandEvent & WXUNUSED(event))
       /* i18n-hint: The %s's are replaced by translated and untranslated
        * versions of language names. */
       msg.Printf(_("The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."),
-                 mLangNames[ndx].c_str(),
-                 mLang.c_str(),
-                 sname.c_str(),
-                 slang.c_str());
+                 mLangNames[ndx],
+                 mLang,
+                 sname,
+                 slang);
       if (wxMessageBox(msg, _("Confirm"), wxYES_NO) == wxNO) {
          return;
       }

--- a/src/Languages.cpp
+++ b/src/Languages.cpp
@@ -46,18 +46,18 @@ static bool TranslationExists(wxArrayString &audacityPathList, wxString code)
 {
    wxArrayString results;
    wxGetApp().FindFilesInPathList(wxString::Format(wxT("%s/audacity.mo"),
-                                                   code.c_str()),
+                                                   code),
                                   audacityPathList,
                                   results);
 #if defined(__WXMAC__)
    wxGetApp().FindFilesInPathList(wxString::Format(wxT("%s.lproj/audacity.mo"),
-                                                   code.c_str()),
+                                                   code),
                                   audacityPathList,
                                   results);
 #endif
 
    wxGetApp().FindFilesInPathList(wxString::Format(wxT("%s/LC_MESSAGES/audacity.mo"),
-                                                   code.c_str()),
+                                                   code),
                                   audacityPathList,
                                   results);
 
@@ -220,9 +220,9 @@ void GetLanguages(wxArrayString &langCodes, wxArrayString &langNames)
          tempHash[code] = name;
 
 /*         wxLogDebug(wxT("code=%s name=%s fullCode=%s name=%s -> %s"),
-                      code.c_str(), localLanguageName[code].c_str(),
-                      fullCode.c_str(), localLanguageName[fullCode].c_str(),
-                      name.c_str());*/
+                      code, localLanguageName[code],
+                      fullCode, localLanguageName[fullCode],
+                      name);*/
       }
    }
 

--- a/src/Legacy.cpp
+++ b/src/Legacy.cpp
@@ -367,7 +367,7 @@ bool ConvertLegacyProjectFile(wxFileName filename)
 
    renamer.Finished();
 
-   ::wxMessageBox(wxString::Format(_("Converted a 1.0 project file to the new format.\nThe old file has been saved as '%s'"), backupName.c_str()),
+   ::wxMessageBox(wxString::Format(_("Converted a 1.0 project file to the new format.\nThe old file has been saved as '%s'"), backupName),
                   _("Opening Audacity Project"));
 
    return true;

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -783,7 +783,7 @@ void AudacityProject::CreateMenusAndCommands()
       c->AddSeparator();
 
       /* i18n-hint: (verb)*/
-      c->AddItem(wxT("ResetToolbars"), _("&Reset Toolbars"), FN(OnResetToolBars), 0, AlwaysEnabledFlag, AlwaysEnabledFlag);
+      c->AddItem(wxT("ResetToolbars"), _("&Reset Toolbars"), FN(OnResetToolBars), wxEmptyString, AlwaysEnabledFlag, AlwaysEnabledFlag);
 
       c->EndSubMenu();
 
@@ -1017,7 +1017,7 @@ void AudacityProject::CreateMenusAndCommands()
       wxString buildMenuLabel;
       if (!mLastEffect.IsEmpty()) {
          buildMenuLabel.Printf(_("Repeat %s"),
-            EffectManager::Get().GetEffectName(mLastEffect).c_str());
+            EffectManager::Get().GetEffectName(mLastEffect));
       }
       else
          buildMenuLabel.Printf(_("Repeat Last Effect"));
@@ -1605,7 +1605,7 @@ void AudacityProject::ModifyUndoMenuItems()
       GetUndoManager()->GetShortDescription(cur, &desc);
       mCommandManager.Modify(wxT("Undo"),
                              wxString::Format(_("&Undo %s"),
-                                              desc.c_str()));
+                                              desc));
    }
    else {
       mCommandManager.Modify(wxT("Undo"),
@@ -1616,7 +1616,7 @@ void AudacityProject::ModifyUndoMenuItems()
       GetUndoManager()->GetShortDescription(cur+1, &desc);
       mCommandManager.Modify(wxT("Redo"),
                              wxString::Format(_("&Redo %s"),
-                                              desc.c_str()));
+                                              desc));
       mCommandManager.Enable(wxT("Redo"), true);
    }
    else {
@@ -2449,7 +2449,7 @@ void AudacityProject::SortTracks(int flags)
                //compare because 'b' is greater than 'B' in ascii.
                cmpValue = track->GetName().CmpNoCase(((Track *) arr[ndx])->GetName());
                if (cmpValue < 0 ||
-                   (0 == cmpValue && track->GetName().CompareTo(((Track *) arr[ndx])->GetName()) > 0) )
+                   (0 == cmpValue && track->GetName().Cmp(((Track *) arr[ndx])->GetName()) > 0) )
                   break;
             }
             //sort by time otherwise
@@ -3081,9 +3081,9 @@ void AudacityProject::MoveTrack(Track* target, MoveChoice choice)
    /* i18n-hint: The direction of movement will be up, down, to top or to bottom.. */
    wxString shortDesc = (_("Move Track"));
 
-   longDesc = (wxString::Format(wxT("%s '%s' %s"), longDesc.c_str(),
-      target->GetName().c_str(), direction.c_str()));
-   shortDesc = (wxString::Format(wxT("%s %s"), shortDesc.c_str(), direction.c_str()));
+   longDesc = (wxString::Format(wxT("%s '%s' %s"), longDesc,
+      target->GetName(), direction));
+   shortDesc = (wxString::Format(wxT("%s %s"), shortDesc, direction));
 
    PushState(longDesc, shortDesc);
    GetTrackPanel()->Refresh(false);
@@ -3406,7 +3406,7 @@ bool AudacityProject::OnEffect(const PluginID & ID, int flags)
          wxString lastEffectDesc;
          /* i18n-hint: %s will be the name of the effect which will be
           * repeated if this menu item is chosen */
-         lastEffectDesc.Printf(_("Repeat %s"), shortDesc.c_str());
+         lastEffectDesc.Printf(_("Repeat %s"), shortDesc);
          mCommandManager.Modify(wxT("RepeatLastEffect"), lastEffectDesc);
       }
    }
@@ -5507,7 +5507,7 @@ void AudacityProject::OnImportLabels()
       newTrack->SetSelected(true);
 
       PushState(wxString::
-                Format(_("Imported labels from '%s'"), fileName.c_str()),
+                Format(_("Imported labels from '%s'"), fileName),
                 _("Import Labels"));
 
       RedrawProject();
@@ -5541,7 +5541,7 @@ void AudacityProject::OnImportMIDI()
          newTrack->SetSelected(true);
 
          PushState(wxString::Format(_("Imported MIDI from '%s'"),
-                                    fileName.c_str()), _("Import MIDI"));
+                                    fileName), _("Import MIDI"));
 
          RedrawProject();
          mTrackPanel->EnsureVisible(newTrack);
@@ -5657,7 +5657,7 @@ void AudacityProject::HandleMixAndRender(bool toNewTrack)
       // Smart history/undo message
       if (selectedCount==1) {
          wxString msg;
-         msg.Printf(_("Rendered all audio in track '%s'"), firstName.c_str());
+         msg.Printf(_("Rendered all audio in track '%s'"), firstName);
          /* i18n-hint: Convert the audio into a more usable form, so apply
           * panning and amplification and write to some external file.*/
          PushState(msg, _("Render"));
@@ -5938,12 +5938,12 @@ void AudacityProject::HandleAlign(int index, bool moveSel)
 
    if (moveSel) {
       mViewInfo.selectedRegion.move(delta);
-      action = wxString::Format(_("Aligned/Moved %s"), action.c_str());
-      shortAction = wxString::Format(_("Align %s/Move"),shortAction.c_str());
+      action = wxString::Format(_("Aligned/Moved %s"), action);
+      shortAction = wxString::Format(_("Align %s/Move"),shortAction);
       PushState(action, shortAction);
    } else {
-      action = wxString::Format(_("Aligned %s"), action.c_str());
-      shortAction = wxString::Format(_("Align %s"),shortAction.c_str());
+      action = wxString::Format(_("Aligned %s"), action);
+      shortAction = wxString::Format(_("Align %s"),shortAction);
       PushState(action, shortAction);
    }
 
@@ -6019,7 +6019,7 @@ class ASAProgress final : public SAProgress {
          long ms = 0;
          wxDateTime now = wxDateTime::UNow();
          fprintf(mTimeFile, "Phase %d begins at %s\n",
-                 i, now.FormatTime().c_str());
+                 i, now.FormatTime());
          if (i != 0)
             ms = now.Subtract(mStartTime).GetMilliseconds().ToLong();
          mStartTime = now;

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -56,8 +56,7 @@ i.e. an alternative to the usual interface, for Audacity.
 
 typedef wxWindow * pwxWindow;
 typedef int (*tModuleInit)(int);
-//typedef wxString (*tVersionFn)();
-typedef wxChar * (*tVersionFn)();
+typedef wxString (*tVersionFn)();
 typedef pwxWindow (*tPanelFn)(int);
 
 // This variable will hold the address of a subroutine in 
@@ -117,8 +116,8 @@ bool Module::Load()
    tVersionFn versionFn = (tVersionFn)(mLib->GetSymbol(wxT(versionFnName)));
    if (versionFn == NULL){
       wxString ShortName = wxFileName( mName ).GetName();
-      wxMessageBox(wxString::Format(_("The module %s does not provide a version string.\nIt will not be loaded."), ShortName.c_str()), _("Module Unsuitable"));
-      wxLogMessage(wxString::Format(_("The module %s does not provide a version string.  It will not be loaded."), mName.c_str()));
+      wxMessageBox(wxString::Format(_("The module %s does not provide a version string.\nIt will not be loaded."), ShortName), _("Module Unsuitable"));
+      wxLogMessage(wxString::Format(_("The module %s does not provide a version string.  It will not be loaded."), mName));
       mLib->Unload();
       return false;
    }
@@ -126,8 +125,8 @@ bool Module::Load()
    wxString moduleVersion = versionFn();
    if( !moduleVersion.IsSameAs(AUDACITY_VERSION_STRING)) {
       wxString ShortName = wxFileName( mName ).GetName();
-      wxMessageBox(wxString::Format(_("The module %s is matched with Audacity version %s.\n\nIt will not be loaded."), ShortName.c_str(), moduleVersion.c_str()), _("Module Unsuitable"));
-      wxLogMessage(wxString::Format(_("The module %s is matched with Audacity version %s.  It will not be loaded."), mName.c_str(), moduleVersion.c_str()));
+      wxMessageBox(wxString::Format(_("The module %s is matched with Audacity version %s.\n\nIt will not be loaded."), ShortName, moduleVersion), _("Module Unsuitable"));
+      wxLogMessage(wxString::Format(_("The module %s is matched with Audacity version %s.  It will not be loaded."), mName, moduleVersion));
       mLib->Unload();
       return false;
    }
@@ -285,11 +284,11 @@ void ModuleManager::Initialize(CommandHandler &cmdHandler)
       {
          wxString ShortName = wxFileName( files[i] ).GetName();
          wxString msg;
-         msg.Printf(_("Module \"%s\" found."), ShortName.c_str());
+         msg.Printf(_("Module \"%s\" found."), ShortName);
          msg += _("\n\nOnly use modules from trusted sources");
-         const wxChar *buttons[] = {_("Yes"), _("No"), NULL};  // could add a button here for 'yes and remember that', and put it into the cfg file.  Needs more thought.
+         const wxString buttons[] = {_("Yes"), _("No")};  // could add a button here for 'yes and remember that', and put it into the cfg file.  Needs more thought.
          int action;
-         action = ShowMultiDialog(msg, _("Audacity Module Loader"), buttons, _("Try and load this module?"), false);
+         action = ShowMultiDialog(msg, _("Audacity Module Loader"), wxArrayString(WXSIZEOF(buttons), buttons), _("Try and load this module?"), false);
 #ifdef EXPERIMENTAL_MODULE_PREFS
          // If we're not prompting always, accept the answer permanantly
          if( iModuleStatus == kModuleNew ){

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -727,7 +727,7 @@ Alg_seq_ptr NoteTrack::MakeExportableSeq()
 bool NoteTrack::ExportMIDI(const wxString &f)
 {
    Alg_seq_ptr seq = MakeExportableSeq();
-   bool rslt = seq->smf_write(f.mb_str());
+   bool rslt = seq->smf_write(f.utf8_str());
    if (seq != mSeq) delete seq;
    return rslt;
 }
@@ -742,19 +742,16 @@ bool NoteTrack::ExportAllegro(const wxString &f)
    } else {
        mSeq->convert_to_beats();
    }
-   return mSeq->write(f.mb_str(), offset);
+   return mSeq->write(f.utf8_str(), offset);
 }
 
 
-bool NoteTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool NoteTrack::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (!wxStrcmp(tag, wxT("notetrack"))) {
-      while (*attrs) {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-         if (!value)
-            break;
-         const wxString strValue = value;
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i) {
+         const wxString &attr = attrs[2*i];
+         const wxString &strValue = attrs[2*i+1];
          long nValue;
          double dblValue;
          if (!wxStrcmp(attr, wxT("name")) && XMLValueChecker::IsGoodString(strValue))
@@ -789,7 +786,7 @@ bool NoteTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
                   XMLValueChecker::IsGoodInt(strValue) && strValue.ToLong(&nValue))
             SetBottomNote(nValue);
          else if (!wxStrcmp(attr, wxT("data"))) {
-             std::string s(strValue.mb_str(wxConvUTF8));
+             std::string s(strValue.utf8_str());
              std::istringstream data(s);
              mSeq = new Alg_seq(data, false);
          }
@@ -799,7 +796,7 @@ bool NoteTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return false;
 }
 
-XMLTagHandler *NoteTrack::HandleXMLChild(const wxChar * WXUNUSED(tag))
+XMLTagHandler *NoteTrack::HandleXMLChild(const wxString &WXUNUSED(tag))
 {
    return NULL;
 }

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -169,8 +169,8 @@ class AUDACITY_DLL_API NoteTrack final : public Track {
    void SetGainPlacementRect(const wxRect &r) { mGainPlacementRect = r; }
 #endif
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) override;
 
    // channels are numbered as integers 0-15, visible channels

--- a/src/PitchName.cpp
+++ b/src/PitchName.cpp
@@ -53,97 +53,52 @@ int PitchOctave(const double dMIDInote)
    return ((int)((dMIDInote + dRound) / 12.0) - 1);
 }
 
-
-static wxChar gPitchName[10];
-static wxChar * pPitchName;
-
-wxChar * PitchName(const double dMIDInote, const bool bWantFlats /* = false */)
+wxString PitchName(const double dMIDInote, const bool bWantFlats /* = false */)
 {
-   pPitchName = gPitchName;
-
    switch (PitchIndex(dMIDInote)) {
    case 0:
-      *pPitchName++ = wxT('C');
+      return wxT("C");
       break;
    case 1:
-      if (bWantFlats) {
-         *pPitchName++ = wxT('D');
-         *pPitchName++ = wxT('b');
-      } else {
-         *pPitchName++ = wxT('C');
-         *pPitchName++ = wxT('#');
-      }
+      return bWantFlats ? wxT("Db") : wxT("C#");
       break;
    case 2:
-      *pPitchName++ = wxT('D');
+      return wxT("D");
       break;
    case 3:
-      if (bWantFlats) {
-         *pPitchName++ = wxT('E');
-         *pPitchName++ = wxT('b');
-      } else {
-         *pPitchName++ = wxT('D');
-         *pPitchName++ = wxT('#');
-      }
+      return bWantFlats ? wxT("Eb") : wxT("D#");
       break;
    case 4:
-      *pPitchName++ = wxT('E');
+      return wxT("E");
       break;
    case 5:
-      *pPitchName++ = wxT('F');
+      return wxT("F");
       break;
    case 6:
-      if (bWantFlats) {
-         *pPitchName++ = wxT('G');
-         *pPitchName++ = wxT('b');
-      } else {
-         *pPitchName++ = wxT('F');
-         *pPitchName++ = wxT('#');
-      }
+      return bWantFlats ? wxT("Gb") : wxT("F#");
       break;
    case 7:
-      *pPitchName++ = wxT('G');
+      return wxT("G");
       break;
    case 8:
-      if (bWantFlats) {
-         *pPitchName++ = wxT('A');
-         *pPitchName++ = wxT('b');
-      } else {
-         *pPitchName++ = wxT('G');
-         *pPitchName++ = wxT('#');
-      }
+      return bWantFlats ? wxT("Ab") : wxT("G#");
       break;
    case 9:
-      *pPitchName++ = wxT('A');
+      return wxT("A");
       break;
    case 10:
-      if (bWantFlats) {
-         *pPitchName++ = wxT('B');
-         *pPitchName++ = wxT('b');
-      } else {
-         *pPitchName++ = wxT('A');
-         *pPitchName++ = wxT('#');
-      }
+      return bWantFlats ? wxT("Bb") : wxT("A#");
       break;
    case 11:
-      *pPitchName++ = wxT('B');
+      return wxT("B");
       break;
    }
-
-   *pPitchName = wxT('\0');
-
-   return gPitchName;
+   return wxEmptyString;
 }
 
-wxChar * PitchName_Absolute(const double dMIDInote, const bool bWantFlats /* = false */)
+wxString PitchName_Absolute(const double dMIDInote, const bool bWantFlats /* = false */)
 {
-   PitchName(dMIDInote, bWantFlats);
-
-   // PitchName sets pPitchName to the next available char in gPitchName,
-   // so it's ready to append the register number.
-   wxSnprintf(pPitchName, 8, wxT("%d"), PitchOctave(dMIDInote));
-
-   return gPitchName;
+   return wxString::Format("%s%d", PitchName(dMIDInote, bWantFlats), PitchOctave(dMIDInote));
 }
 
 double PitchToMIDInote(const unsigned int nPitchIndex, const int nPitchOctave)

--- a/src/PitchName.h
+++ b/src/PitchName.h
@@ -43,12 +43,12 @@ int PitchOctave(const double dMIDInote);
 // PitchName takes dMIDInote (per result from
 // FreqToMIDInote) and returns a standard pitch/note name [C, C#, etc.).
 // Sharps are the default, unless, bWantFlats is true.
-wxChar * PitchName(const double dMIDInote, const bool bWantFlats = false);
+wxString PitchName(const double dMIDInote, const bool bWantFlats = false);
 
 // PitchName_Absolute does the same thing as PitchName, but appends
 // the octave number, e.g., instead of "C" it will return "C4"
 // if the dMIDInote corresonds to middle C, i.e., is 60.
-wxChar * PitchName_Absolute(const double dMIDInote, const bool bWantFlats = false);
+wxString PitchName_Absolute(const double dMIDInote, const bool bWantFlats = false);
 
 double PitchToMIDInote(const unsigned int nPitchIndex, const int nPitchOctave);
 

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -964,7 +964,7 @@ void PluginRegistrationDialog::OnOK(wxCommandEvent & WXUNUSED(evt))
                     mLongestPath + wxT("\n");
 
    wxString msg;
-   msg.Printf(_("Enabling effects:\n\n%s"), last3.c_str());
+   msg.Printf(_("Enabling effects:\n\n%s"), last3);
 
    // Make sure the progress dialog is deleted before we call EndModal() or
    // we will leave the project window in an unusable state on OSX.
@@ -982,7 +982,7 @@ void PluginRegistrationDialog::OnOK(wxCommandEvent & WXUNUSED(evt))
          if (item.state == STATE_Enabled && item.plugs[0]->GetPluginType() == PluginTypeStub)
          {
             last3 = last3.AfterFirst(wxT('\n')) + item.path + wxT("\n");
-            int status = progress.Update(++i, enableCount, wxString::Format(_("Enabling effect:\n\n%s"), last3.c_str()));
+            int status = progress.Update(++i, enableCount, wxString::Format(_("Enabling effect:\n\n%s"), last3));
             if (!status)
             {
                break;
@@ -2423,31 +2423,31 @@ IdentInterface *PluginManager::GetInstance(const PluginID & ID)
 PluginID PluginManager::GetID(ModuleInterface *module)
 {
    return wxString::Format(wxT("%s_%s_%s_%s_%s"),
-                           GetPluginTypeString(PluginTypeModule).c_str(),
+                           GetPluginTypeString(PluginTypeModule),
                            wxEmptyString,
-                           module->GetVendor().c_str(),
-                           module->GetName().c_str(),
-                           module->GetPath().c_str());
+                           module->GetVendor(),
+                           module->GetName(),
+                           module->GetPath());
 }
 
 PluginID PluginManager::GetID(EffectIdentInterface *effect)
 {
    return wxString::Format(wxT("%s_%s_%s_%s_%s"),
-                           GetPluginTypeString(PluginTypeEffect).c_str(),
-                           effect->GetFamily().c_str(),
-                           effect->GetVendor().c_str(),
-                           effect->GetName().c_str(),
-                           effect->GetPath().c_str());
+                           GetPluginTypeString(PluginTypeEffect),
+                           effect->GetFamily(),
+                           effect->GetVendor(),
+                           effect->GetName(),
+                           effect->GetPath());
 }
 
 PluginID PluginManager::GetID(ImporterInterface *importer)
 {
    return wxString::Format(wxT("%s_%s_%s_%s_%s"),
-                           GetPluginTypeString(PluginTypeImporter).c_str(),
+                           GetPluginTypeString(PluginTypeImporter),
                            wxEmptyString,
-                           importer->GetVendor().c_str(),
-                           importer->GetName().c_str(),
-                           importer->GetPath().c_str());
+                           importer->GetVendor(),
+                           importer->GetName(),
+                           importer->GetPath());
 }
 
 wxString PluginManager::GetPluginTypeString(PluginType type)
@@ -2651,7 +2651,7 @@ bool PluginManager::GetConfig(const wxString & key, sampleCount & value, sampleC
       wxdef.Printf(wxT("%Ld"), defval);
 
       result = GetSettings()->Read(key, &wxval, wxdef);
-      value = wxStrtoll(wxval.c_str(), &endptr, 10);
+      value = wxStrtoll(wxval, &endptr, 10);
    }
    
    return result;
@@ -2663,7 +2663,7 @@ bool PluginManager::SetConfig(const wxString & key, const wxString & value)
 
    if (!key.IsEmpty())
    {
-      wxString wxval = value.c_str();
+      wxString wxval = value;
       result = GetSettings()->Write(key, wxval);
       if (result)
       {
@@ -2853,7 +2853,7 @@ wxString PluginManager::ConvertID(const PluginID & ID)
 ////////////////////////////////////////////////////////////////////////////////
 
 // Lookup table for encoding
-const static wxChar cset[] = wxT("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+static const wxString cset = wxT("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 const static char padc = wxT('=');
 
 wxString PluginManager::b64encode(const void *in, int len)

--- a/src/PluginManager.h
+++ b/src/PluginManager.h
@@ -161,7 +161,6 @@ typedef std::map<PluginID, PluginDescriptor> PluginMap;
 
 typedef wxArrayString PluginIDList;
 
-class ProviderMap;
 class PluginRegistrationDialog;
 
 class PluginManager final : public PluginManagerInterface

--- a/src/Prefs.cpp
+++ b/src/Prefs.cpp
@@ -171,7 +171,7 @@ void InitPreferences()
       if (!gone)
       {
          wxString fileName = fn.GetFullPath();
-         wxMessageBox(wxString::Format( _("Failed to remove %s"), fileName.c_str()), _("Failed!"));
+         wxMessageBox(wxString::Format( _("Failed to remove %s"), fileName), _("Failed!"));
       }
    }
 

--- a/src/Project.h
+++ b/src/Project.h
@@ -133,8 +133,8 @@ class ImportXMLTagHandler final : public XMLTagHandler
  public:
    ImportXMLTagHandler(AudacityProject* pProject) { mProject = pProject; }
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   XMLTagHandler *HandleXMLChild(const wxChar * WXUNUSED(tag))  override { return NULL; }
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   XMLTagHandler *HandleXMLChild(const wxString &WXUNUSED(tag)) override { return NULL; }
 
    // Don't want a WriteXML method because ImportXMLTagHandler is not a WaveTrack.
    // <import> tags are instead written by AudacityProject::WriteXML.
@@ -382,7 +382,7 @@ class AUDACITY_DLL_API AudacityProject final : public wxFrame,
    void FinishAutoScroll();
    void FixScrollbars();
 
-   void SafeDisplayStatusMessage(const wxChar *msg);
+   void SafeDisplayStatusMessage(const wxString &msg);
 
    double ScrollingLowerBoundTime() const;
    // How many pixels are covered by the period from lowermost scrollable time, to the given time:
@@ -467,8 +467,8 @@ public:
 
    // XMLTagHandler callback methods
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) /* not override */;
 
    void WriteXMLHeader(XMLWriter &xmlFile);

--- a/src/SampleFormat.cpp
+++ b/src/SampleFormat.cpp
@@ -58,7 +58,7 @@ void InitDitherers()
    gPrefs->Read(wxT("/Quality/HQDitherAlgorithm"), (long)Dither::shaped);
 }
 
-const wxChar *GetSampleFormatStr(sampleFormat format)
+wxString GetSampleFormatStr(sampleFormat format)
 {
    switch(format) {
    case int16Sample:

--- a/src/SampleFormat.h
+++ b/src/SampleFormat.h
@@ -42,7 +42,7 @@ typedef enum {
 #define SAMPLE_SIZE_DISK(SampleFormat) ((SampleFormat == int24Sample) ? \
    3 : SAMPLE_SIZE(SampleFormat) )
 
-const wxChar *GetSampleFormatStr(sampleFormat format);
+wxString GetSampleFormatStr(sampleFormat format);
 
 //
 // Allocating/Freeing Samples

--- a/src/SelectedRegion.cpp
+++ b/src/SelectedRegion.cpp
@@ -13,17 +13,17 @@ Paul Licameli
 #include "xml/XMLWriter.h"
 
 #include "Experimental.h"
-const wxChar *SelectedRegion::sDefaultT0Name = wxT("selStart");
-const wxChar *SelectedRegion::sDefaultT1Name = wxT("selEnd");
+const wxString SelectedRegion::sDefaultT0Name = wxT("selStart");
+const wxString SelectedRegion::sDefaultT1Name = wxT("selEnd");
 
 namespace {
-const wxChar *sDefaultF0Name = wxT("selLow");
-const wxChar *sDefaultF1Name = wxT("selHigh");
+const wxString sDefaultF0Name = wxT("selLow");
+const wxString sDefaultF1Name = wxT("selHigh");
 }
 
 void SelectedRegion::WriteXMLAttributes
 (XMLWriter &xmlFile,
- const wxChar *legacyT0Name, const wxChar *legacyT1Name) const
+ const wxString &legacyT0Name, const wxString &legacyT1Name) const
 {
    xmlFile.WriteAttr(legacyT0Name, t0(), 10);
    xmlFile.WriteAttr(legacyT1Name, t1(), 10);
@@ -36,8 +36,8 @@ void SelectedRegion::WriteXMLAttributes
 }
 
 bool SelectedRegion::HandleXMLAttribute
-(const wxChar *attr, const wxChar *value,
- const wxChar *legacyT0Name, const wxChar *legacyT1Name)
+(const wxString &attr, const wxString &value,
+ const wxString &legacyT0Name, const wxString &legacyT1Name)
 {
    typedef bool (SelectedRegion::*Setter)(double, bool);
    Setter setter = 0;

--- a/src/SelectedRegion.h
+++ b/src/SelectedRegion.h
@@ -205,22 +205,22 @@ public:
    // as SelectedRegion is extended.  Therefore, this is not an
    // XMLTagHandler.
 
-   static const wxChar *sDefaultT0Name;
-   static const wxChar *sDefaultT1Name;
+   static const wxString sDefaultT0Name;
+   static const wxString sDefaultT1Name;
 
    // Serialize, not with tags of its own, but as attributes within a tag.
    // Don't add more legacy arguments as the structure grows.
    void WriteXMLAttributes
       (XMLWriter &xmlFile,
-       const wxChar *legacyT0Name = sDefaultT0Name,
-       const wxChar *legacyT1Name = sDefaultT1Name) const;
+       const wxString &legacyT0Name = sDefaultT0Name,
+       const wxString &legacyT1Name = sDefaultT1Name) const;
 
    // Return true iff the attribute is recognized.
    // Don't add more legacy arguments as the structure grows.
    bool HandleXMLAttribute
-      (const wxChar *attr, const wxChar *value,
-       const wxChar *legacyT0Name = sDefaultT0Name,
-       const wxChar *legacyT1Name = sDefaultT1Name);
+      (const wxString &attr, const wxString &value,
+       const wxString &legacyT0Name = sDefaultT0Name,
+       const wxString &legacyT1Name = sDefaultT1Name);
 
 private:
    bool ensureOrdering() 

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -136,9 +136,9 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
    // XMLTagHandler callback methods for loading and saving
    //
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   void HandleXMLEndTag(const wxChar *tag) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   void HandleXMLEndTag(const wxString &tag) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) /* not override */;
 
    bool GetErrorOpening() { return mErrorOpening; }
@@ -263,7 +263,7 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
 
    // This function makes sure that the track isn't messed up
    // because of inconsistent block starts & lengths
-   bool ConsistencyCheck(const wxChar *whereStr) const;
+   bool ConsistencyCheck(const wxString &whereStr) const;
 
    // This function prints information to stdout about the blocks in the
    // tracks and indicates if there are inconsistencies.

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -65,7 +65,7 @@
 #include <wx/combobox.h>
 #include <wx/display.h>
 
-static const wxChar *DefaultGenres[] =
+static const wxString DefaultGenres[] =
 {
    wxT("Blues"),
    wxT("Classic Rock"),
@@ -354,7 +354,7 @@ wxString Tags::GetUserGenre(int i)
 
 wxString Tags::GetGenre(int i)
 {
-   int cnt = WXSIZEOF(DefaultGenres);
+   size_t cnt = WXSIZEOF(DefaultGenres);
 
    if (i >= 0 && i < cnt) {
       return DefaultGenres[i];
@@ -365,7 +365,7 @@ wxString Tags::GetGenre(int i)
 
 int Tags::GetGenre(const wxString & name)
 {
-   int cnt = WXSIZEOF(DefaultGenres);
+   size_t cnt = WXSIZEOF(DefaultGenres);
 
    for (int i = 0; i < cnt; i++) {
       if (name.CmpNoCase(DefaultGenres[i])) {
@@ -442,7 +442,7 @@ void Tags::SetTag(const wxString & name, const int & value)
    SetTag(name, wxString::Format(wxT("%d"), value));
 }
 
-bool Tags::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool Tags::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (wxStrcmp(tag, wxT("tags")) == 0) {
       return true;
@@ -451,11 +451,11 @@ bool Tags::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    if (wxStrcmp(tag, wxT("tag")) == 0) {
       wxString n, v;
 
-      while (*attrs) {
-         wxString attr = *attrs++;
+      for (size_t i = 0; i < attrs.GetCount(); i += 2) {
+         const wxString &attr = attrs[i];
          if (attr.IsEmpty())
             break;
-         wxString value = *attrs++;
+         const wxString &value = attrs[i+1];
 
          if (!XMLValueChecker::IsGoodString(attr) ||
              !XMLValueChecker::IsGoodString(value)) {
@@ -483,7 +483,7 @@ bool Tags::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return false;
 }
 
-XMLTagHandler *Tags::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *Tags::HandleXMLChild(const wxString &tag)
 {
    if (wxStrcmp(tag, wxT("tags")) == 0) {
       return this;
@@ -1149,7 +1149,7 @@ void TagsEditor::OnSave(wxCommandEvent & WXUNUSED(event))
    {
       wxMessageBox(wxString::Format(
          _("Couldn't write to file \"%s\": %s"),
-         fn.c_str(), exception.GetMessage().c_str()),
+         fn, exception.GetMessage()),
          _("Error Saving Tags File"), wxICON_ERROR, this);
    }
 }

--- a/src/Tags.h
+++ b/src/Tags.h
@@ -83,8 +83,8 @@ class AUDACITY_DLL_API Tags final : public XMLTagHandler {
 
    bool ShowEditDialog(wxWindow *parent, const wxString &title, bool force = false);
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) /* not override */;
 
    void AllowEditTitle(bool editTitle);

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -577,7 +577,7 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
          // No href in html.  Uses title not alt.
          wxRect R( mFlow.Rect() );
          wxLogDebug( wxT("<area title=\"Bitmap:%s\" shape=rect coords=\"%i,%i,%i,%i\">"),
-            mBitmapNames[i].c_str(),
+            mBitmapNames[i],
             R.GetLeft(), R.GetTop(), R.GetRight(), R.GetBottom() );
 #endif
       }
@@ -607,7 +607,7 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
       // No href in html.  Uses title not alt.
       wxRect R( mFlow.Rect() );
       wxLogDebug( wxT("<area title=\"Colour:%s\" shape=rect coords=\"%i,%i,%i,%i\">"),
-         mColourNames[i].c_str(),
+         mColourNames[i],
          R.GetLeft(), R.GetTop(), R.GetRight(), R.GetBottom() );
 #endif
    }
@@ -629,7 +629,7 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
          wxMessageBox(
             wxString::Format(
             wxT("Theme cache file:\n  %s\nalready exists.\nAre you sure you want to replace it?"),
-               FileName.c_str() ));
+               FileName ));
          return;
       }
 #endif
@@ -638,13 +638,13 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
          wxMessageBox(
             wxString::Format(
             _("Audacity could not write file:\n  %s."),
-               FileName.c_str() ));
+               FileName ));
          return;
       }
       wxMessageBox(
          wxString::Format(
             wxT("Theme written to:\n  %s."),
-            FileName.c_str() ));
+            FileName ));
    }
    // ELSE saving to a C code textual version.
    else
@@ -656,7 +656,7 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
          wxMessageBox(
             wxString::Format(
             _("Audacity could not open file:\n  %s\nfor writing."),
-            FileName.c_str() ));
+            FileName ));
          return;
       }
       if( !ImageCache.SaveFile(OutStream, wxBITMAP_TYPE_PNG ) )
@@ -664,13 +664,13 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
          wxMessageBox(
             wxString::Format(
             _("Audacity could not write images to file:\n  %s."),
-            FileName.c_str() ));
+            FileName ));
          return;
       }
       wxMessageBox(
          wxString::Format(
             wxT("Theme as Cee code written to:\n  %s."),
-            FileName.c_str() ));
+            FileName ));
    }
 }
 
@@ -704,7 +704,7 @@ void ThemeBase::WriteImageMap( )
          wxRect R( mFlow.Rect() );
          File.Write( wxString::Format(
             wxT("<area title=\"Bitmap:%s\" shape=rect coords=\"%i,%i,%i,%i\">\r\n"),
-            mBitmapNames[i].c_str(),
+            mBitmapNames[i],
             R.GetLeft(), R.GetTop(), R.GetRight(), R.GetBottom()) );
       }
    }
@@ -717,7 +717,7 @@ void ThemeBase::WriteImageMap( )
       // No href in html.  Uses title not alt.
       wxRect R( mFlow.Rect() );
       File.Write( wxString::Format( wxT("<area title=\"Colour:%s\" shape=rect coords=\"%i,%i,%i,%i\">\r\n"),
-         mColourNames[i].c_str(),
+         mColourNames[i],
          R.GetLeft(), R.GetTop(), R.GetRight(), R.GetBottom()) );
    }
    File.Write( wxT("</map>\r\n") );
@@ -754,14 +754,14 @@ void ThemeBase::WriteImageDefs( )
          Temp.Replace( wxT("  "), wxT(" | ") );
 
          File.Write( wxString::Format( wxT("\r\n   SET_THEME_FLAGS( %s );\r\n"),
-            Temp.c_str() ));
+            Temp ));
       }
       File.Write( wxString::Format(
          wxT("   DEFINE_IMAGE( bmp%s, wxImage( %i, %i ), wxT(\"%s\"));\r\n"),
-         mBitmapNames[i].c_str(),
+         mBitmapNames[i],
          SrcImage.GetWidth(),
          SrcImage.GetHeight(),
-         mBitmapNames[i].c_str()
+         mBitmapNames[i]
          ));
    }
 }
@@ -799,7 +799,7 @@ bool ThemeBase::ReadImageCache( bool bBinaryRead, bool bOkIfNotFound)
          wxMessageBox(
             wxString::Format(
             _("Audacity could not find file:\n  %s.\nTheme not loaded."),
-               FileName.c_str() ));
+               FileName ));
          return false;
       }
       if( !ImageCache.LoadFile( FileName, wxBITMAP_TYPE_PNG ))
@@ -808,7 +808,7 @@ bool ThemeBase::ReadImageCache( bool bBinaryRead, bool bOkIfNotFound)
          wxMessageBox(
             wxString::Format(
             _("Audacity could not load file:\n  %s.\nBad png format perhaps?"),
-               FileName.c_str() ));
+               FileName ));
          return false;
       }
    }
@@ -898,7 +898,7 @@ void ThemeBase::LoadComponents( bool bOkIfNotFound )
                wxMessageBox(
                   wxString::Format(
                   _("Audacity could not load file:\n  %s.\nBad png format perhaps?"),
-                     FileName.c_str() ));
+                     FileName ));
                return;
             }
             /// JKC: \bug (wxWidgets) A png may have been saved with alpha, but when you
@@ -907,7 +907,7 @@ void ThemeBase::LoadComponents( bool bOkIfNotFound )
             /// and that transfers the mask into the alpha channel, and we're done.
             if( ! mImages[i].HasAlpha() )
             {
-               // wxLogDebug( wxT("File %s lacked alpha"), mBitmapNames[i].c_str() );
+               // wxLogDebug( wxT("File %s lacked alpha"), mBitmapNames[i] );
                mImages[i].InitAlpha();
             }
             mBitmaps[i] = wxBitmap( mImages[i] );
@@ -920,7 +920,7 @@ void ThemeBase::LoadComponents( bool bOkIfNotFound )
       if( bOkIfNotFound )
          return;
       wxMessageBox(wxString::Format(_("None of the expected theme component files\n were found in:\n  %s."),
-                                    FileNames::ThemeComponentsDir().c_str()));
+                                    FileNames::ThemeComponentsDir()));
    }
 }
 
@@ -944,7 +944,7 @@ void ThemeBase::SaveComponents()
          wxMessageBox(
             wxString::Format(
             _("Could not create directory:\n  %s"),
-               FileNames::ThemeComponentsDir().c_str() ));
+               FileNames::ThemeComponentsDir() ));
          return;
       }
    }
@@ -965,7 +965,7 @@ void ThemeBase::SaveComponents()
                wxMessageBox(
                   wxString::Format(
                   _("Audacity could not save file:\n  %s"),
-                     FileName.c_str() ));
+                     FileName ));
                return;
             }
             n++;
@@ -977,13 +977,13 @@ void ThemeBase::SaveComponents()
       wxMessageBox(
          wxString::Format(
          _("All required files in:\n  %s\nwere already present."),
-            FileNames::ThemeComponentsDir().c_str() ));
+            FileNames::ThemeComponentsDir() ));
       return;
    }
    wxMessageBox(
       wxString::Format(
          wxT("Theme written to:\n  %s."),
-         FileNames::ThemeComponentsDir().c_str() ));
+         FileNames::ThemeComponentsDir()));
 }
 
 void ThemeBase::ReadThemeInternal()

--- a/src/TimeTrack.cpp
+++ b/src/TimeTrack.cpp
@@ -139,19 +139,15 @@ double TimeTrack::SolveWarpedLength(double t0, double length)
    return GetEnvelope()->SolveIntegralOfInverse(t0, length);
 }
 
-bool TimeTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool TimeTrack::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (!wxStrcmp(tag, wxT("timetrack"))) {
       mRescaleXMLValues = true; // will be set to false if upper/lower is found
       long nValue;
-      while(*attrs) {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-            break;
-
-         const wxString strValue = value;
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i) {
+         const wxString &attr = attrs[2*i];
+         const wxString &value = attrs[2*i+1];
+         const wxString &strValue = strValue;
          if (!wxStrcmp(attr, wxT("name")) && XMLValueChecker::IsGoodString(strValue))
             mName = strValue;
          else if (!wxStrcmp(attr, wxT("height")) &&
@@ -192,7 +188,7 @@ bool TimeTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return false;
 }
 
-void TimeTrack::HandleXMLEndTag(const wxChar * WXUNUSED(tag))
+void TimeTrack::HandleXMLEndTag(const wxString &WXUNUSED(tag))
 {
    if(mRescaleXMLValues)
    {
@@ -202,7 +198,7 @@ void TimeTrack::HandleXMLEndTag(const wxChar * WXUNUSED(tag))
    }
 }
 
-XMLTagHandler *TimeTrack::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *TimeTrack::HandleXMLChild(const wxString &tag)
 {
    if (!wxStrcmp(tag, wxT("envelope")))
       return mEnvelope;

--- a/src/TimeTrack.h
+++ b/src/TimeTrack.h
@@ -54,9 +54,9 @@ class TimeTrack final : public Track {
 
    // XMLTagHandler callback methods for loading and saving
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   void HandleXMLEndTag(const wxChar *tag) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   void HandleXMLEndTag(const wxString &tag) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) override;
 
    // Lock and unlock the track: you must lock the track before

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -337,7 +337,7 @@ wxString TimerRecordDialog::GetDisplayDate( wxDateTime & dt )
 #endif
 
    // Use default formatting
-wxPrintf(wxT("%s\n"), dt.Format().c_str());
+wxPrintf(wxT("%s\n"), dt.Format());
    return dt.FormatDate() + wxT(" ") + dt.FormatTime();
 }
 
@@ -482,7 +482,7 @@ int TimerRecordDialog::WaitForStart()
    /* i18n-hint: A time specification like "Sunday 28th October 2007 15:16:17 GMT"
     * but hopefully translated by wxwidgets will be inserted into this */
    strMsg.Printf(_("Waiting to start recording at %s.\n"),
-                  GetDisplayDate(m_DateTime_Start).c_str());
+                  GetDisplayDate(m_DateTime_Start));
    wxDateTime startWait_DateTime = wxDateTime::UNow();
    wxTimeSpan waitDuration = m_DateTime_Start - startWait_DateTime;
    TimerProgressDialog

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1849,7 +1849,7 @@ void TrackPanel::SetCursorAndTipWhenSelectTool( Track * t,
       /* i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac */
       tip = wxString::Format(
          _("Multi-Tool Mode: %s for Mouse and Keyboard Preferences."),
-         keyStr.c_str());
+         keyStr);
       // Later in this function we may point to some other string instead.
    }
 
@@ -3833,7 +3833,7 @@ void TrackPanel::HandleSlide(wxMouseEvent & event)
             _("left");
          /* i18n-hint: %s is a direction like left or right */
          msg.Printf(_("Time shifted tracks/clips %s %.02f seconds"),
-                    direction.c_str(), fabs(mHSlideAmount));
+                    direction, fabs(mHSlideAmount));
          consolidate = true;
       }
       MakeParentPushState(msg, _("Time-Shift"),
@@ -5608,8 +5608,8 @@ void TrackPanel::HandleRearrange(wxMouseEvent & event)
          wxString dir;
          dir = mRearrangeCount < 0 ? _("up") : _("down");
          MakeParentPushState(wxString::Format(_("Moved '%s' %s"),
-            mCapturedTrack->GetName().c_str(),
-            dir.c_str()),
+            mCapturedTrack->GetName(),
+            dir),
             _("Move Track"));
       }
 
@@ -7596,7 +7596,7 @@ void TrackPanel::TimerUpdateScrubbing(double playPos)
 #endif
             mMaxScrubSpeed;
 
-      const wxChar *format =
+      const wxString format =
 #ifdef EXPERIMENTAL_SCRUBBING_SMOOTH_SCROLL
          mSmoothScrollingScrub
          ? seeking
@@ -8682,7 +8682,7 @@ static int channels[] = { Track::LeftChannel, Track::RightChannel,
    Track::MonoChannel
 };
 
-static const wxChar *channelmsgs[] = { _("Left Channel"), _("Right Channel"),
+static const wxString channelmsgs[] = { _("Left Channel"), _("Right Channel"),
    _("Mono")
 };
 
@@ -8693,7 +8693,7 @@ void TrackPanel::OnChannelChange(wxCommandEvent & event)
    wxASSERT(mPopupMenuTarget);
    mPopupMenuTarget->SetChannel(channels[id - OnChannelLeftID]);
    MakeParentPushState(wxString::Format(_("Changed '%s' to %s"),
-                        mPopupMenuTarget->GetName().c_str(),
+                        mPopupMenuTarget->GetName(),
                         channelmsgs[id - OnChannelLeftID]),
                         _("Channel"));
    Refresh(false);
@@ -8723,7 +8723,7 @@ void TrackPanel::OnSwapChannels(wxCommandEvent & WXUNUSED(event))
       SetFocusedTrack(partner);
 
    MakeParentPushState(wxString::Format(_("Swapped Channels in '%s'"),
-                                        mPopupMenuTarget->GetName().c_str()),
+                                        mPopupMenuTarget->GetName()),
                        _("Swap Channels"));
 
 }
@@ -8733,7 +8733,7 @@ void TrackPanel::OnSplitStereo(wxCommandEvent & WXUNUSED(event))
 {
    SplitStereo(true);
    MakeParentPushState(wxString::Format(_("Split stereo track '%s'"),
-                                        mPopupMenuTarget->GetName().c_str()),
+                                        mPopupMenuTarget->GetName()),
                        _("Split"));
 }
 
@@ -8742,7 +8742,7 @@ void TrackPanel::OnSplitStereoMono(wxCommandEvent & WXUNUSED(event))
 {
    SplitStereo(false);
    MakeParentPushState(wxString::Format(_("Split Stereo to Mono '%s'"),
-                                        mPopupMenuTarget->GetName().c_str()),
+                                        mPopupMenuTarget->GetName()),
                        _("Split to Mono"));
 }
 
@@ -8837,8 +8837,7 @@ void TrackPanel::OnMergeStereo(wxCommandEvent & WXUNUSED(event))
          }
 
       MakeParentPushState(wxString::Format(_("Made '%s' a stereo track"),
-                                           mPopupMenuTarget->GetName().
-                                           c_str()),
+                                           mPopupMenuTarget->GetName()),
                           _("Make Stereo"));
    } else
       mPopupMenuTarget->SetLinked(false);
@@ -8892,7 +8891,7 @@ void TrackPanel::OnSpectrogramSettings(wxCommandEvent &)
 
 ///  Set the Display mode based on the menu choice in the Track Menu.
 ///  Note that gModes MUST BE IN THE SAME ORDER AS THE MENU CHOICES!!
-///  const wxChar *gModes[] = { wxT("waveform"), wxT("waveformDB"),
+///  const wxString gModes[] = { wxT("waveform"), wxT("waveformDB"),
 ///  wxT("spectrum"), wxT("pitch") };
 void TrackPanel::OnSetDisplay(wxCommandEvent & event)
 {
@@ -8959,7 +8958,7 @@ void TrackPanel::SetRate(Track * pTrack, double rate)
    // Separate conversion of "rate" enables changing the decimals without affecting i18n
    wxString rateString = wxString::Format(wxT("%.3f"), rate);
    MakeParentPushState(wxString::Format(_("Changed '%s' to %s Hz"),
-                                        pTrack->GetName().c_str(), rateString.c_str()),
+                                        pTrack->GetName(), rateString),
                        _("Rate Change"));
 }
 
@@ -9002,8 +9001,7 @@ void TrackPanel::OnFormatChange(wxCommandEvent & event)
    }
 
    MakeParentPushState(wxString::Format(_("Changed '%s' to %s"),
-                                        mPopupMenuTarget->GetName().
-                                        c_str(),
+                                        mPopupMenuTarget->GetName(),
                                         GetSampleFormatStr(newFormat)),
                        _("Format Change"));
 
@@ -9344,8 +9342,8 @@ void TrackPanel::OnSetName(wxCommandEvent & WXUNUSED(event))
             pMixerBoard->UpdateName((WaveTrack*)t);
 
          MakeParentPushState(wxString::Format(_("Renamed '%s' to '%s'"),
-                                              oldName.c_str(),
-                                              newName.c_str()),
+                                              oldName,
+                                              newName),
                              _("Name Change"));
 
          Refresh(false);

--- a/src/ViewInfo.cpp
+++ b/src/ViewInfo.cpp
@@ -152,7 +152,7 @@ void ViewInfo::WriteXMLAttributes(XMLWriter &xmlFile)
    xmlFile.WriteAttr(wxT("zoom"), zoom, 10);
 }
 
-bool ViewInfo::ReadXMLAttribute(const wxChar *attr, const wxChar *value)
+bool ViewInfo::ReadXMLAttribute(const wxString &attr, const wxString &value)
 {
    if (selectedRegion.HandleXMLAttribute(attr, value, wxT("sel0"), wxT("sel1")))
       return true;

--- a/src/ViewInfo.h
+++ b/src/ViewInfo.h
@@ -181,7 +181,7 @@ public:
    bool bScrollBeyondZero;
 
    void WriteXMLAttributes(XMLWriter &xmlFile);
-   bool ReadXMLAttribute(const wxChar *attr, const wxChar *value);
+   bool ReadXMLAttribute(const wxString &attr, const wxString &value);
 };
 
 #endif

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1342,15 +1342,15 @@ bool WaveClip::Flush()
    return success;
 }
 
-bool WaveClip::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool WaveClip::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (!wxStrcmp(tag, wxT("waveclip")))
    {
       double dblValue;
-      while (*attrs)
+      for (size_t i = 0; i < attrs.GetCount(); i += 2)
       {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
+         const wxString &attr = attrs[i];
+         const wxString &value = attrs[i+1];
 
          if (!value)
             break;
@@ -1370,13 +1370,13 @@ bool WaveClip::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return false;
 }
 
-void WaveClip::HandleXMLEndTag(const wxChar *tag)
+void WaveClip::HandleXMLEndTag(const wxString &tag)
 {
    if (!wxStrcmp(tag, wxT("waveclip")))
       UpdateEnvelopeTrackLen();
 }
 
-XMLTagHandler *WaveClip::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *WaveClip::HandleXMLChild(const wxString &tag)
 {
    if (!wxStrcmp(tag, wxT("sequence")))
       return mSequence;

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -367,9 +367,9 @@ public:
    // XMLTagHandler callback methods for loading and saving
    //
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   void HandleXMLEndTag(const wxChar *tag) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   void HandleXMLEndTag(const wxString &tag) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) /* not override */;
 
    // Cache of values to colour pixels of Spectrogram - used by TrackArtist

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1670,19 +1670,14 @@ bool WaveTrack::Flush()
    return RightmostOrNewClip()->Flush();
 }
 
-bool WaveTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool WaveTrack::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (!wxStrcmp(tag, wxT("wavetrack"))) {
       double dblValue;
       long nValue;
-      while(*attrs) {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-            break;
-
-         const wxString strValue = value;
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i) {
+         const wxString &attr = attrs[2*i];
+         const wxString &strValue = attrs[2*i+1];;
          if (!wxStrcmp(attr, wxT("rate")))
          {
             // mRate is an int, but "rate" in the project file is a float.
@@ -1751,14 +1746,14 @@ bool WaveTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return false;
 }
 
-void WaveTrack::HandleXMLEndTag(const wxChar * WXUNUSED(tag))
+void WaveTrack::HandleXMLEndTag(const wxString &WXUNUSED(tag))
 {
    // In case we opened a pre-multiclip project, we need to
    // simulate closing the waveclip tag.
    NewestOrNewClip()->HandleXMLEndTag(wxT("waveclip"));
 }
 
-XMLTagHandler *WaveTrack::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *WaveTrack::HandleXMLChild(const wxString &tag)
 {
    //
    // This is legacy code (1.2 and previous) and is not called for NEW projects!

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -268,9 +268,9 @@ class AUDACITY_DLL_API WaveTrack final : public Track {
    // XMLTagHandler callback methods for loading and saving
    //
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   void HandleXMLEndTag(const wxChar *tag) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   void HandleXMLEndTag(const wxString &tag) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
    void WriteXML(XMLWriter &xmlFile) override;
 
    // Returns true if an error occurred while reading from XML

--- a/src/blockfile/LegacyAliasBlockFile.cpp
+++ b/src/blockfile/LegacyAliasBlockFile.cpp
@@ -81,7 +81,7 @@ void LegacyAliasBlockFile::SaveXML(XMLWriter &xmlFile)
 // BuildFromXML methods should always return a BlockFile, not NULL,
 // even if the result is flawed (e.g., refers to nonexistent file),
 // as testing will be done in DirManager::ProjectFSCK().
-BlockFile *LegacyAliasBlockFile::BuildFromXML(const wxString &projDir, const wxChar **attrs)
+BlockFile *LegacyAliasBlockFile::BuildFromXML(const wxString &projDir, const wxArrayString &attrs)
 {
    wxFileName summaryFileName;
    wxFileName aliasFileName;
@@ -90,14 +90,10 @@ BlockFile *LegacyAliasBlockFile::BuildFromXML(const wxString &projDir, const wxC
    bool noRMS = false;
    long nValue;
 
-   while(*attrs)
+   for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
    {
-      const wxChar *attr =  *attrs++;
-      const wxChar *value = *attrs++;
-      if (!value)
-         break;
-
-      const wxString strValue = value;
+      const wxString &attr = attrs[2*i];
+      const wxString &strValue = attrs[2*i+1];;
       if (!wxStricmp(attr, wxT("name")) && XMLValueChecker::IsGoodFileName(strValue, projDir))
          //v Should this be
          //    dm.AssignFile(summaryFileName, strValue, false);

--- a/src/blockfile/LegacyAliasBlockFile.h
+++ b/src/blockfile/LegacyAliasBlockFile.h
@@ -35,7 +35,7 @@ class LegacyAliasBlockFile final : public PCMAliasBlockFile
    BlockFile *Copy(wxFileName fileName) override;
    void Recover() override;
 
-   static BlockFile *BuildFromXML(const wxString &projDir, const wxChar **attrs);
+   static BlockFile *BuildFromXML(const wxString &projDir, const wxArrayString &attrs);
 };
 
 #endif

--- a/src/blockfile/LegacyBlockFile.cpp
+++ b/src/blockfile/LegacyBlockFile.cpp
@@ -78,7 +78,7 @@ void ComputeLegacySummaryInfo(wxFileName fileName,
 
       if (!summaryFile.IsOpened()) {
          wxLogWarning(wxT("Unable to access summary file %s; substituting silence for remainder of session"),
-            fileName.GetFullPath().c_str());
+            fileName.GetFullPath());
 
          read = info->frames64K * info->bytesPerFrame;
          memset(data.ptr(), 0, read);
@@ -288,7 +288,7 @@ void LegacyBlockFile::SaveXML(XMLWriter &xmlFile)
 // even if the result is flawed (e.g., refers to nonexistent file),
 // as testing will be done in DirManager::ProjectFSCK().
 /// static
-BlockFile *LegacyBlockFile::BuildFromXML(const wxString &projDir, const wxChar **attrs,
+BlockFile *LegacyBlockFile::BuildFromXML(const wxString &projDir, const wxArrayString &attrs,
                                          sampleCount len, sampleFormat format)
 {
    wxFileName fileName;
@@ -296,14 +296,10 @@ BlockFile *LegacyBlockFile::BuildFromXML(const wxString &projDir, const wxChar *
    bool noRMS = false;
    long nValue;
 
-   while(*attrs)
+   for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
    {
-      const wxChar *attr =  *attrs++;
-      const wxChar *value = *attrs++;
-      if (!value)
-         break;
-
-      const wxString strValue = value;
+      const wxString &attr = attrs[2*i];
+      const wxString &strValue = attrs[2*i+1];
       if (!wxStricmp(attr, wxT("name")) && XMLValueChecker::IsGoodFileName(strValue, projDir))
          //v Should this be
          //    dm.AssignFile(fileName, strValue, false);

--- a/src/blockfile/LegacyBlockFile.h
+++ b/src/blockfile/LegacyBlockFile.h
@@ -60,7 +60,7 @@ class LegacyBlockFile final : public BlockFile {
    wxLongLong GetSpaceUsage() override;
    void Recover() override;
 
-   static BlockFile *BuildFromXML(const wxString &dir, const wxChar **attrs,
+   static BlockFile *BuildFromXML(const wxString &dir, const wxArrayString &attrs,
                                   sampleCount len,
                                   sampleFormat format);
 

--- a/src/blockfile/ODDecodeBlockFile.cpp
+++ b/src/blockfile/ODDecodeBlockFile.cpp
@@ -219,7 +219,7 @@ void ODDecodeBlockFile::SaveXML(XMLWriter &xmlFile)
 // BuildFromXML methods should always return a BlockFile, not NULL,
 // even if the result is flawed (e.g., refers to nonexistent file),
 // as testing will be done in DirManager::ProjectFSCK().
-BlockFile *ODDecodeBlockFile::BuildFromXML(DirManager &dm, const wxChar **attrs)
+BlockFile *ODDecodeBlockFile::BuildFromXML(DirManager &dm, const wxArrayString &attrs)
 {
    wxFileName summaryFileName;
    wxFileName audioFileName;
@@ -228,14 +228,10 @@ BlockFile *ODDecodeBlockFile::BuildFromXML(DirManager &dm, const wxChar **attrs)
    long nValue;
    unsigned int   decodeType=0;
 
-   while(*attrs)
+   for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
    {
-      const wxChar *attr =  *attrs++;
-      const wxChar *value = *attrs++;
-      if (!value)
-         break;
-
-      const wxString strValue = value;
+      const wxString &attr = attrs[2*i];
+      const wxString &strValue = attrs[2*i+1];
       if (!wxStricmp(attr, wxT("summaryfile")) &&
             // Can't use XMLValueChecker::IsGoodFileName here, but do part of its test.
             XMLValueChecker::IsGoodFileString(strValue) &&

--- a/src/blockfile/ODDecodeBlockFile.h
+++ b/src/blockfile/ODDecodeBlockFile.h
@@ -83,7 +83,7 @@ class ODDecodeBlockFile final : public SimpleBlockFile
    void SaveXML(XMLWriter &xmlFile) override;
 
    ///Reconstructs from XML a ODPCMAliasBlockFile and reschedules it for OD loading
-   static BlockFile *BuildFromXML(DirManager &dm, const wxChar **attrs);
+   static BlockFile *BuildFromXML(DirManager &dm, const wxArrayString &attrs);
 
    ///Writes the summary file if summary data is available
    void Recover(void) override;

--- a/src/blockfile/ODPCMAliasBlockFile.cpp
+++ b/src/blockfile/ODPCMAliasBlockFile.cpp
@@ -287,7 +287,7 @@ void ODPCMAliasBlockFile::SaveXML(XMLWriter &xmlFile)
 // BuildFromXML methods should always return a BlockFile, not NULL,
 // even if the result is flawed (e.g., refers to nonexistent file),
 // as testing will be done in DirManager::ProjectFSCK().
-BlockFile *ODPCMAliasBlockFile::BuildFromXML(DirManager &dm, const wxChar **attrs)
+BlockFile *ODPCMAliasBlockFile::BuildFromXML(DirManager &dm, const wxArrayString &attrs)
 {
    wxFileName summaryFileName;
    wxFileName aliasFileName;
@@ -295,14 +295,10 @@ BlockFile *ODPCMAliasBlockFile::BuildFromXML(DirManager &dm, const wxChar **attr
    int aliasChannel=0;
    long nValue;
 
-   while(*attrs)
+   for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
    {
-      const wxChar *attr =  *attrs++;
-      const wxChar *value = *attrs++;
-      if (!value)
-         break;
-
-      const wxString strValue = value;
+      const wxString &attr = attrs[2*i];
+      const wxString &strValue = attrs[2*i+1];
       if (!wxStricmp(attr, wxT("summaryfile")) &&
             // Can't use XMLValueChecker::IsGoodFileName here, but do part of its test.
             XMLValueChecker::IsGoodFileString(strValue) &&

--- a/src/blockfile/ODPCMAliasBlockFile.h
+++ b/src/blockfile/ODPCMAliasBlockFile.h
@@ -81,7 +81,7 @@ class ODPCMAliasBlockFile final : public PCMAliasBlockFile
    void SaveXML(XMLWriter &xmlFile) override;
 
    ///Reconstructs from XML a ODPCMAliasBlockFile and reschedules it for OD loading
-   static BlockFile *BuildFromXML(DirManager &dm, const wxChar **attrs);
+   static BlockFile *BuildFromXML(DirManager &dm, const wxArrayString &attrs);
 
    ///Writes the summary file if summary data is available
    void Recover(void) override;

--- a/src/blockfile/PCMAliasBlockFile.cpp
+++ b/src/blockfile/PCMAliasBlockFile.cpp
@@ -185,7 +185,7 @@ void PCMAliasBlockFile::SaveXML(XMLWriter &xmlFile)
 // BuildFromXML methods should always return a BlockFile, not NULL,
 // even if the result is flawed (e.g., refers to nonexistent file),
 // as testing will be done in DirManager::ProjectFSCK().
-BlockFile *PCMAliasBlockFile::BuildFromXML(DirManager &dm, const wxChar **attrs)
+BlockFile *PCMAliasBlockFile::BuildFromXML(DirManager &dm, const wxArrayString &attrs)
 {
    wxFileName summaryFileName;
    wxFileName aliasFileName;
@@ -194,14 +194,10 @@ BlockFile *PCMAliasBlockFile::BuildFromXML(DirManager &dm, const wxChar **attrs)
    double dblValue;
    long nValue;
 
-   while(*attrs)
+   for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
    {
-      const wxChar *attr =  *attrs++;
-      const wxChar *value = *attrs++;
-      if (!value)
-         break;
-
-      const wxString strValue = value;
+      const wxString &attr = attrs[2*i];
+      const wxString &strValue = attrs[2*i+1];
       if (!wxStricmp(attr, wxT("summaryfile")) &&
             // Can't use XMLValueChecker::IsGoodFileName here, but do part of its test.
             XMLValueChecker::IsGoodFileString(strValue) &&

--- a/src/blockfile/PCMAliasBlockFile.h
+++ b/src/blockfile/PCMAliasBlockFile.h
@@ -44,7 +44,7 @@ class PCMAliasBlockFile /* not final */ : public AliasBlockFile
    BlockFile *Copy(wxFileName fileName) override;
    void Recover() override;
 
-   static BlockFile *BuildFromXML(DirManager &dm, const wxChar **attrs);
+   static BlockFile *BuildFromXML(DirManager &dm, const wxArrayString &attrs);
 };
 
 #endif

--- a/src/blockfile/SilentBlockFile.cpp
+++ b/src/blockfile/SilentBlockFile.cpp
@@ -50,19 +50,15 @@ void SilentBlockFile::SaveXML(XMLWriter &xmlFile)
 // even if the result is flawed (e.g., refers to nonexistent file),
 // as testing will be done in DirManager::ProjectFSCK().
 /// static
-BlockFile *SilentBlockFile::BuildFromXML(DirManager & WXUNUSED(dm), const wxChar **attrs)
+BlockFile *SilentBlockFile::BuildFromXML(DirManager & WXUNUSED(dm), const wxArrayString &attrs)
 {
    long nValue;
    sampleCount len = 0;
 
-   while(*attrs)
+   for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
    {
-       const wxChar *attr =  *attrs++;
-       const wxChar *value = *attrs++;
-       if (!value)
-         break;
-
-       const wxString strValue = value;
+       const wxString &attr = attrs[2*i];
+       const wxString &strValue = attrs[2*i+1];
        if (!wxStrcmp(attr, wxT("len")) &&
             XMLValueChecker::IsGoodInt(strValue) &&
             strValue.ToLong(&nValue) &&

--- a/src/blockfile/SilentBlockFile.h
+++ b/src/blockfile/SilentBlockFile.h
@@ -45,7 +45,7 @@ class SilentBlockFile final : public BlockFile {
    wxLongLong GetSpaceUsage() override;
    void Recover() override { };
 
-   static BlockFile *BuildFromXML(DirManager &dm, const wxChar **attrs);
+   static BlockFile *BuildFromXML(DirManager &dm, const wxArrayString &attrs);
 };
 
 #endif

--- a/src/blockfile/SimpleBlockFile.cpp
+++ b/src/blockfile/SimpleBlockFile.cpp
@@ -485,7 +485,7 @@ void SimpleBlockFile::SaveXML(XMLWriter &xmlFile)
 // even if the result is flawed (e.g., refers to nonexistent file),
 // as testing will be done in DirManager::ProjectFSCK().
 /// static
-BlockFile *SimpleBlockFile::BuildFromXML(DirManager &dm, const wxChar **attrs)
+BlockFile *SimpleBlockFile::BuildFromXML(DirManager &dm, const wxArrayString &attrs)
 {
    wxFileName fileName;
    float min = 0.0f, max = 0.0f, rms = 0.0f;
@@ -493,14 +493,10 @@ BlockFile *SimpleBlockFile::BuildFromXML(DirManager &dm, const wxChar **attrs)
    double dblValue;
    long nValue;
 
-   while(*attrs)
+   for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
    {
-      const wxChar *attr =  *attrs++;
-      const wxChar *value = *attrs++;
-      if (!value)
-         break;
-
-      const wxString strValue = value;
+      const wxString &attr = attrs[2*i];
+      const wxString &strValue = attrs[2*i+1];
       if (!wxStricmp(attr, wxT("filename")) &&
             // Can't use XMLValueChecker::IsGoodFileName here, but do part of its test.
             XMLValueChecker::IsGoodFileString(strValue) &&

--- a/src/blockfile/SimpleBlockFile.h
+++ b/src/blockfile/SimpleBlockFile.h
@@ -75,7 +75,7 @@ class PROFILE_DLL_API SimpleBlockFile /* not final */ : public BlockFile {
    wxLongLong GetSpaceUsage() override;
    void Recover() override;
 
-   static BlockFile *BuildFromXML(DirManager &dm, const wxChar **attrs);
+   static BlockFile *BuildFromXML(DirManager &dm, const wxArrayString &attrs);
 
    bool GetNeedWriteCacheToDisk() override;
    void WriteCacheToDisk() override;

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -634,16 +634,16 @@ void CommandManager::InsertItem(const wxString & name,
 
 
 
-void CommandManager::AddCheck(const wxChar *name,
-                              const wxChar *label,
+void CommandManager::AddCheck(const wxString &name,
+                              const wxString &label,
                               const CommandFunctorPointer &callback,
                               int checkmark)
 {
    AddItem(name, label, callback, wxT(""), (unsigned int)NoFlagsSpecifed, (unsigned int)NoFlagsSpecifed, checkmark);
 }
 
-void CommandManager::AddCheck(const wxChar *name,
-                              const wxChar *label,
+void CommandManager::AddCheck(const wxString &name,
+                              const wxString &label,
                               const CommandFunctorPointer &callback,
                               int checkmark,
                               unsigned int flags,
@@ -652,8 +652,8 @@ void CommandManager::AddCheck(const wxChar *name,
    AddItem(name, label, callback, wxT(""), flags, mask, checkmark);
 }
 
-void CommandManager::AddItem(const wxChar *name,
-                             const wxChar *label,
+void CommandManager::AddItem(const wxString &name,
+                             const wxString &label,
                              const CommandFunctorPointer &callback,
                              unsigned int flags,
                              unsigned int mask)
@@ -661,10 +661,10 @@ void CommandManager::AddItem(const wxChar *name,
    AddItem(name, label, callback, wxT(""), flags, mask);
 }
 
-void CommandManager::AddItem(const wxChar *name,
-                             const wxChar *label_in,
+void CommandManager::AddItem(const wxString &name,
+                             const wxString &label_in,
                              const CommandFunctorPointer &callback,
-                             const wxChar *accel,
+                             const wxString &accel,
                              unsigned int flags,
                              unsigned int mask,
                              int checkmark)
@@ -715,8 +715,8 @@ void CommandManager::AddItemList(const wxString & name,
 ///
 /// Add a command that doesn't appear in a menu.  When the key is pressed, the
 /// given function pointer will be called (via the CommandManagerListener)
-void CommandManager::AddCommand(const wxChar *name,
-                                const wxChar *label,
+void CommandManager::AddCommand(const wxString &name,
+                                const wxString &label,
                                 const CommandFunctorPointer &callback,
                                 unsigned int flags,
                                 unsigned int mask)
@@ -724,10 +724,10 @@ void CommandManager::AddCommand(const wxChar *name,
    AddCommand(name, label, callback, wxT(""), flags, mask);
 }
 
-void CommandManager::AddCommand(const wxChar *name,
-                                const wxChar *label_in,
+void CommandManager::AddCommand(const wxString &name,
+                                const wxString &label_in,
                                 const CommandFunctorPointer &callback,
-                                const wxChar *accel,
+                                const wxString &accel,
                                 unsigned int flags,
                                 unsigned int mask)
 {
@@ -738,10 +738,10 @@ void CommandManager::AddCommand(const wxChar *name,
    }
 }
 
-void CommandManager::AddGlobalCommand(const wxChar *name,
-                                      const wxChar *label_in,
+void CommandManager::AddGlobalCommand(const wxString &name,
+                                      const wxString &label_in,
                                       const CommandFunctorPointer &callback,
-                                      const wxChar *accel)
+                                      const wxString &accel)
 {
    CommandListEntry *entry = NewIdentifier(name, label_in, accel, NULL, callback, false, 0, 0);
 
@@ -851,7 +851,7 @@ CommandListEntry *CommandManager::NewIdentifier(const wxString & name,
       // For key bindings for commands with a list, such as effects,
       // the name in prefs is the category name plus the effect name.
       if (multi) {
-         entry->name = wxString::Format(wxT("%s:%s"), name.c_str(), label.c_str());
+         entry->name = wxString::Format(wxT("%s:%s"), name, label);
       }
 
       // Key from preferences overridse the default key given
@@ -878,13 +878,13 @@ CommandListEntry *CommandManager::NewIdentifier(const wxString & name,
       if( prev->label != entry->label )
       {
          wxLogDebug(wxT("Command '%s' defined by '%s' and '%s'"),
-                    entry->name.c_str(),
-                    prev->label.BeforeFirst(wxT('\t')).c_str(),
-                    entry->label.BeforeFirst(wxT('\t')).c_str());
+                    entry->name,
+                    prev->label.BeforeFirst(wxT('\t')),
+                    entry->label.BeforeFirst(wxT('\t')));
          wxFAIL_MSG(wxString::Format(wxT("Command '%s' defined by '%s' and '%s'"),
-                    entry->name.c_str(),
-                    prev->label.BeforeFirst(wxT('\t')).c_str(),
-                    entry->label.BeforeFirst(wxT('\t')).c_str()));
+                    entry->name,
+                    prev->label.BeforeFirst(wxT('\t')),
+                    entry->label.BeforeFirst(wxT('\t'))));
       }
    }
 #endif
@@ -948,7 +948,7 @@ void CommandManager::Enable(CommandListEntry *entry, bool enabled)
             item->Enable(enabled);
          } else {
             wxLogDebug(wxT("Warning: Menu entry with id %i in %s not found"),
-                ID, (const wxChar*)entry->name);
+                ID, entry->name);
          }
          } else {
             wxLogDebug(wxT("Warning: Menu entry with id %i not in hash"), ID);
@@ -961,8 +961,7 @@ void CommandManager::Enable(const wxString &name, bool enabled)
 {
    CommandListEntry *entry = mCommandNameHash[name];
    if (!entry || !entry->menu) {
-      wxLogDebug(wxT("Warning: Unknown command enabled: '%s'"),
-                 (const wxChar*)name);
+      wxLogDebug(wxT("Warning: Unknown command enabled: '%s'"), name);
       return;
    }
 
@@ -988,8 +987,7 @@ bool CommandManager::GetEnabled(const wxString &name)
 {
    CommandListEntry *entry = mCommandNameHash[name];
    if (!entry || !entry->menu) {
-      wxLogDebug(wxT("Warning: command doesn't exist: '%s'"),
-                 (const wxChar*)name);
+      wxLogDebug(wxT("Warning: command doesn't exist: '%s'"), name);
       return false;
    }
    return entry->enabled;
@@ -1333,7 +1331,7 @@ wxString CommandManager::GetDefaultKeyFromName(const wxString &name)
    return entry->defaultKey;
 }
 
-bool CommandManager::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool CommandManager::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (!wxStrcmp(tag, wxT("audacitykeyboard"))) {
       mXMLKeysRead = 0;
@@ -1343,12 +1341,9 @@ bool CommandManager::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
       wxString name;
       wxString key;
 
-      while(*attrs) {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-            break;
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i) {
+         const wxString &attr = attrs[2*i];
+         const wxString &value = attrs[2*i+1];
 
          if (!wxStrcmp(attr, wxT("name")) && XMLValueChecker::IsGoodString(value))
             name = value;
@@ -1367,7 +1362,7 @@ bool CommandManager::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return true;
 }
 
-void CommandManager::HandleXMLEndTag(const wxChar *tag)
+void CommandManager::HandleXMLEndTag(const wxString &tag)
 {
    if (!wxStrcmp(tag, wxT("audacitykeyboard"))) {
       wxMessageBox(wxString::Format(_("Loaded %d keyboard shortcuts\n"),
@@ -1377,7 +1372,7 @@ void CommandManager::HandleXMLEndTag(const wxChar *tag)
    }
 }
 
-XMLTagHandler *CommandManager::HandleXMLChild(const wxChar * WXUNUSED(tag))
+XMLTagHandler *CommandManager::HandleXMLChild(const wxString &WXUNUSED(tag))
 {
    return this;
 }
@@ -1417,16 +1412,14 @@ void CommandManager::SetCommandFlags(const wxString &name,
    }
 }
 
-void CommandManager::SetCommandFlags(const wxChar **names,
+void CommandManager::SetCommandFlags(const wxArrayString &names,
                                      wxUint32 flags, wxUint32 mask)
 {
-   const wxChar **nptr = names;
-   while(*nptr) {
-      SetCommandFlags(wxString(*nptr), flags, mask);
-      nptr++;
-   }
+   for (auto n : names)
+      SetCommandFlags(n, flags, mask);
 }
 
+#if 0000000000000
 void CommandManager::SetCommandFlags(wxUint32 flags, wxUint32 mask, ...)
 {
    va_list list;
@@ -1439,6 +1432,7 @@ void CommandManager::SetCommandFlags(wxUint32 flags, wxUint32 mask, ...)
    }
    va_end(list);
 }
+#endif
 
 #if defined(__WXDEBUG__)
 void CommandManager::CheckDups()
@@ -1461,9 +1455,9 @@ void CommandManager::CheckDups()
          if (mCommandList[i]->key == mCommandList[j]->key) {
             wxString msg;
             msg.Printf(wxT("key combo '%s' assigned to '%s' and '%s'"),
-                       mCommandList[i]->key.c_str(),
-                       mCommandList[i]->label.BeforeFirst(wxT('\t')).c_str(),
-                       mCommandList[j]->label.BeforeFirst(wxT('\t')).c_str());
+                       mCommandList[i]->key,
+                       mCommandList[i]->label.BeforeFirst(wxT('\t')),
+                       mCommandList[j]->label.BeforeFirst(wxT('\t')));
             wxASSERT_MSG(mCommandList[i]->key != mCommandList[j]->key, msg);
          }
       }

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -130,28 +130,28 @@ class AUDACITY_DLL_API CommandManager final : public XMLTagHandler
                     const wxArrayString & labels,
                     const CommandFunctorPointer &callback);
 
-   void AddCheck(const wxChar *name,
-                 const wxChar *label,
+   void AddCheck(const wxString &name,
+                 const wxString &label,
                  const CommandFunctorPointer &callback,
                  int checkmark = 0);
 
-   void AddCheck(const wxChar *name,
-                 const wxChar *label,
+   void AddCheck(const wxString &name,
+                 const wxString &label,
                  const CommandFunctorPointer &callback,
                  int checkmark,
                  unsigned int flags,
                  unsigned int mask);
 
-   void AddItem(const wxChar *name,
-                const wxChar *label,
+   void AddItem(const wxString &name,
+                const wxString &label,
                 const CommandFunctorPointer &callback,
                 unsigned int flags = NoFlagsSpecifed,
                 unsigned int mask = NoFlagsSpecifed);
 
-   void AddItem(const wxChar *name,
-                const wxChar *label_in,
+   void AddItem(const wxString &name,
+                const wxString &label_in,
                 const CommandFunctorPointer &callback,
-                const wxChar *accel,
+                const wxString &accel,
                 unsigned int flags = NoFlagsSpecifed,
                 unsigned int mask = NoFlagsSpecifed,
                 int checkmark = -1);
@@ -160,23 +160,23 @@ class AUDACITY_DLL_API CommandManager final : public XMLTagHandler
 
    // A command doesn't actually appear in a menu but might have a
    // keyboard shortcut.
-   void AddCommand(const wxChar *name,
-                   const wxChar *label,
+   void AddCommand(const wxString &name,
+                   const wxString &label,
                    const CommandFunctorPointer &callback,
                    unsigned int flags = NoFlagsSpecifed,
                    unsigned int mask = NoFlagsSpecifed);
 
-   void AddCommand(const wxChar *name,
-                   const wxChar *label,
+   void AddCommand(const wxString &name,
+                   const wxString &label,
                    const CommandFunctorPointer &callback,
-                   const wxChar *accel,
+                   const wxString &accel,
                    unsigned int flags = NoFlagsSpecifed,
                    unsigned int mask = NoFlagsSpecifed);
 
-   void AddGlobalCommand(const wxChar *name,
-                         const wxChar *label,
+   void AddGlobalCommand(const wxString &name,
+                         const wxString &label,
                          const CommandFunctorPointer &callback,
-                         const wxChar *accel);
+                         const wxString &accel);
    //
    // Command masks
    //
@@ -185,10 +185,10 @@ class AUDACITY_DLL_API CommandManager final : public XMLTagHandler
    void SetDefaultFlags(wxUint32 flags, wxUint32 mask);
 
    void SetCommandFlags(const wxString &name, wxUint32 flags, wxUint32 mask);
-   void SetCommandFlags(const wxChar **names,
+   void SetCommandFlags(const wxArrayString &names,
                         wxUint32 flags, wxUint32 mask);
    // Pass multiple command names as const wxChar *, terminated by NULL
-   void SetCommandFlags(wxUint32 flags, wxUint32 mask, ...);
+   //void SetCommandFlags(wxUint32 flags, wxUint32 mask, ...);
 
    //
    // Modifying menus
@@ -299,9 +299,9 @@ protected:
    // Loading/Saving
    //
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   void HandleXMLEndTag(const wxChar *tag) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   void HandleXMLEndTag(const wxString &tag) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
 
 private:
    MenuBarList  mMenuBarList;

--- a/src/commands/HelpCommand.cpp
+++ b/src/commands/HelpCommand.cpp
@@ -39,7 +39,7 @@ bool HelpCommand::Apply(CommandExecutionContext WXUNUSED(context))
    CommandType *type = CommandDirectory::Get()->LookUp(commandName);
    if (type == NULL)
    {
-      Error(wxString::Format(wxT("Command '%s' does not exist!"), commandName.c_str()));
+      Error(wxString::Format(wxT("Command '%s' does not exist!"), commandName));
       return false;
    }
    Status(type->Describe());

--- a/src/commands/ImportExportCommands.cpp
+++ b/src/commands/ImportExportCommands.cpp
@@ -103,17 +103,17 @@ bool ExportCommand::Apply(CommandExecutionContext context)
    Exporter exporter;
 
    bool exportSuccess = exporter.Process(context.GetProject(), numChannels,
-                                         extension.c_str(), filename,
+                                         extension, filename,
                                          selection, t0, t1);
 
    if (exportSuccess)
    {
       Status(wxString::Format(wxT("Exported to %s format: %s"),
-                              extension.c_str(), filename.c_str()));
+                              extension, filename));
       return true;
    }
 
-   Error(wxString::Format(wxT("Could not export to %s format!"), extension.c_str()));
+   Error(wxString::Format(wxT("Could not export to %s format!"), extension));
    return false;
 }
 

--- a/src/commands/ResponseQueue.h
+++ b/src/commands/ResponseQueue.h
@@ -48,7 +48,7 @@ class Response {
       std::string mMessage;
    public:
       Response(const wxString &response)
-         : mMessage(response.mb_str())
+         : mMessage(response.utf8_str())
       { }
 
       wxString GetMessage()

--- a/src/commands/ScreenshotCommand.cpp
+++ b/src/commands/ScreenshotCommand.cpp
@@ -322,7 +322,7 @@ wxString ScreenshotCommand::MakeFileName(const wxString &path, const wxString &b
    int i = 0;
    do {
       filename.Printf(wxT("%s%s%03d.png"),
-                      prefix.c_str(), basename.c_str(), i);
+                      prefix, basename, i);
       i++;
    } while (::wxFileExists(filename));
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -207,7 +207,7 @@ void EffectChangePitch::PopulateOrExchange(ShuttleGui & S)
          S.AddTitle(_("Change Pitch without Changing Tempo"));
          S.AddTitle(
             wxString::Format(_("Estimated Start Pitch: %s%d (%.3f Hz)"),
-                              pitch[m_nFromPitch].c_str(), m_nFromOctave, m_FromFrequency));
+                              pitch[m_nFromPitch], m_nFromOctave, m_FromFrequency));
       }
       S.EndVerticalLay();
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -50,7 +50,7 @@ enum kVinyl
    kNumVinyl
 };
 
-static const wxChar *kVinylStrings[kNumVinyl] =
+static const wxString kVinylStrings[kNumVinyl] =
 {
    wxT("33 1/3"),
    wxT("45"),

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -489,7 +489,7 @@ void ContrastDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    f.AddLine(wxT("==================================="));
    f.AddLine(_("WCAG 2.0 Success Criteria 1.4.7 Contrast Results"));
    f.AddLine(wxT(""));
-   f.AddLine(wxString::Format(_("Filename = %s."), project->GetFileName().c_str() ));
+   f.AddLine(wxString::Format(_("Filename = %s."), project->GetFileName() ));
    f.AddLine(wxT(""));
    f.AddLine(_("Foreground"));
    float t = (float)mForegroundStartT->GetValue();
@@ -555,7 +555,7 @@ void ContrastDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    int minute = now.GetMinute();
    int second = now.GetSecond();
    sNow = wxString::Format(wxT("%d %s %02d %02dh %02dm %02ds"),
-        dom, monthName.c_str(), year, hour, minute, second);
+        dom, monthName, year, hour, minute, second);
    f.AddLine(sNow);
 
    f.AddLine(wxT("==================================="));

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -42,7 +42,7 @@ Param( Amplitude, double,     XO("Amplitude"),  0.8,              0.001,   1.0, 
 
 static const double kFadeInOut = 250.0; // used for fadein/out needed to remove clicking noise
 
-const static wxChar *kSymbols[] =
+static const wxString kSymbols[] =
 {
    wxT("0"), wxT("1"), wxT("2"), wxT("3"),
    wxT("4"), wxT("5"), wxT("6"), wxT("7"),
@@ -233,7 +233,7 @@ bool EffectDtmf::SetAutomationParameters(EffectAutomationParameters & parms)
    ReadAndVerifyString(Sequence);
 
    wxString symbols;
-   for (unsigned int i = 0; i < WXSIZEOF(kSymbols); i++)
+   for (size_t i = 0; i < WXSIZEOF(kSymbols); i++)
    {
       symbols += kSymbols[i];
    }
@@ -429,7 +429,7 @@ void EffectDtmf::Recalculate()
    }
 }
 
-bool EffectDtmf::MakeDtmfTone(float *buffer, sampleCount len, float fs, wxChar tone, sampleCount last, sampleCount total, float amplitude)
+bool EffectDtmf::MakeDtmfTone(float *buffer, sampleCount len, float fs, char tone, sampleCount last, sampleCount total, float amplitude)
 {
 /*
   --------------------------------------------

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -62,7 +62,7 @@ private:
    // EffectDtmf implementation
 
    bool MakeDtmfTone(float *buffer, sampleCount len, float fs,
-                     wxChar tone, sampleCount last,
+                     char tone, sampleCount last,
                      sampleCount total, float amplitude);
    void Recalculate();
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1081,8 +1081,8 @@ bool Effect::SetAutomationParameters(const wxString & parms)
       wxMessageBox(
          wxString::Format(
             _("Could not update effect \"%s\" with:\n%s"),
-            GetName().c_str(),
-            preset.c_str()
+            GetName(),
+            preset
          )
       );
 
@@ -1241,7 +1241,7 @@ bool Effect::DoEffect(wxWindow *parent,
    if (skipFlag == false)
    {
       ProgressDialog progress(GetName(),
-         wxString::Format(_("Applying %s..."), GetName().c_str()),
+         wxString::Format(_("Applying %s..."), GetName()),
          pdlgHideStopButton);
       SetProgress sp(mProgress, &progress);
       returnVal = Process();
@@ -3286,11 +3286,11 @@ void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
 
    sub = new wxMenu();
 
-   sub->Append(kDummyID, wxString::Format(_("Type: %s"), mEffect->GetFamily().c_str()));
-   sub->Append(kDummyID, wxString::Format(_("Name: %s"), mEffect->GetName().c_str()));
-   sub->Append(kDummyID, wxString::Format(_("Version: %s"), mEffect->GetVersion().c_str()));
-   sub->Append(kDummyID, wxString::Format(_("Vendor: %s"), mEffect->GetVendor().c_str()));
-   sub->Append(kDummyID, wxString::Format(_("Description: %s"), mEffect->GetDescription().c_str()));
+   sub->Append(kDummyID, wxString::Format(_("Type: %s"), mEffect->GetFamily()));
+   sub->Append(kDummyID, wxString::Format(_("Name: %s"), mEffect->GetName()));
+   sub->Append(kDummyID, wxString::Format(_("Version: %s"), mEffect->GetVersion()));
+   sub->Append(kDummyID, wxString::Format(_("Vendor: %s"), mEffect->GetVendor()));
+   sub->Append(kDummyID, wxString::Format(_("Description: %s"), mEffect->GetDescription()));
 
    menu.Append(0, _("About"), sub);
 
@@ -3478,7 +3478,7 @@ void EffectUIHost::OnDeletePreset(wxCommandEvent & evt)
 {
    wxString preset = mUserPresets[evt.GetId() - kDeletePresetID];
 
-   int res = wxMessageBox(wxString::Format(_("Are you sure you want to delete \"%s\"?"), preset.c_str()),
+   int res = wxMessageBox(wxString::Format(_("Are you sure you want to delete \"%s\"?"), preset),
                           _("Delete Preset"),
                           wxICON_QUESTION | wxYES_NO);
    if (res == wxYES)

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -658,14 +658,14 @@ inline long TrapLong(long x, long min, long max)
 // Helper macros for defining, reading and verifying effect parameters
 
 #define Param(name, type, key, def, min, max, scale) \
-   static const wxChar * KEY_ ## name = (key); \
+   static const wxString KEY_ ## name = (key); \
    static const type DEF_ ## name = (def); \
    static const type MIN_ ## name = (min); \
    static const type MAX_ ## name = (max); \
    static const type SCL_ ## name = (scale);
 
 #define PBasic(name, type, key, def) \
-   static const wxChar * KEY_ ## name = (key); \
+   static const wxString KEY_ ## name = (key); \
    static const type DEF_ ## name = (def);
 
 #define PRange(name, type, key, def, min, max) \

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -155,7 +155,7 @@ wxString EffectManager::GetEffectDescription(const PluginID & ID)
 
    if (effect)
    {
-      return wxString::Format(_("Applied effect: %s"), effect->GetName().c_str());
+      return wxString::Format(_("Applied effect: %s"), effect->GetName());
    }
 
    return wxEmptyString;
@@ -752,7 +752,7 @@ Effect *EffectManager::GetEffect(const PluginID & ID)
       }
 
       wxMessageBox(wxString::Format(_("Attempting to initialize the following effect failed:\n\n%s\n\nMore information may be available in Help->Show Log"),
-                                    PluginManager::Get().GetName(ID).c_str()),
+                                    PluginManager::Get().GetName(ID)),
                    _("Effect failed to initialize"));
 
       return NULL;

--- a/src/effects/EffectRack.cpp
+++ b/src/effects/EffectRack.cpp
@@ -148,7 +148,7 @@ EffectRack::EffectRack()
       wxString slot;
       gPrefs->Read(wxString::Format(wxT("/EffectsRack/Slot%02d"), i), &slot);
 
-      Effect *effect = em.GetEffect(slot.AfterFirst(wxT(',')).c_str());
+      Effect *effect = em.GetEffect(slot.AfterFirst(wxT(',')));
       if (effect)
       {
          Add(effect, slot.BeforeFirst(wxT(',')) == wxT("1"), true);
@@ -170,7 +170,7 @@ EffectRack::~EffectRack()
          gPrefs->Write(wxString::Format(wxT("/EffectsRack/Slot%02d"), i),
                        wxString::Format(wxT("%d,%s"),
                                         mPowerState[i],
-                                        effect->GetID().c_str()));
+                                        effect->GetID()));
       }
    }
 }

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -159,7 +159,7 @@ static const double kThirdOct[] =
 //
 //     Name          Type        Key                     Def      Min      Max      Scale
 Param( FilterLength, int,     XO("FilterLength"),        4001,    21,      8191,    0      );
-Param( CurveName,    wxChar*, XO("CurveName"),           wxT("unnamed"), wxT(""), wxT(""), wxT(""));
+Param( CurveName,    wxString, XO("CurveName"),           wxT("unnamed"), wxT(""), wxT(""), wxT(""));
 Param( InterpLin,    bool,    XO("InterpolateLin"),      false,   false,   true,    false  );
 Param( InterpMeth,   int,     XO("InterpolationMethod"), 0,       0,       0,       0      );
 Param( DrawMode,     bool,    wxT(""),                   true,    false,   true,    false  );
@@ -1394,7 +1394,7 @@ void EffectEqualization::LoadCurves(const wxString &fileName, bool append)
       {
          // LLL:  Is there really a need for an error message at all???
          //wxString errorMessage;
-         //errorMessage.Printf(_("EQCurves.xml and EQDefaultCurves.xml were not found on your system.\nPlease press 'help' to visit the download page.\n\nSave the curves at %s"), FileNames::DataDir().c_str());
+         //errorMessage.Printf(_("EQCurves.xml and EQDefaultCurves.xml were not found on your system.\nPlease press 'help' to visit the download page.\n\nSave the curves at %s"), FileNames::DataDir());
          //ShowErrorDialog(mUIParent, _("EQCurves.xml and EQDefaultCurves.xml missing"),
          //   errorMessage, wxT("http://wiki.audacityteam.org/wiki/EQCurvesDownload"), false);
 
@@ -1424,7 +1424,7 @@ void EffectEqualization::LoadCurves(const wxString &fileName, bool append)
    {
       wxString msg;
       /* i18n-hint: EQ stands for 'Equalization'.*/
-      msg.Printf(_("Error Loading EQ Curves from file:\n%s\nError message says:\n%s"), fn.GetFullPath().c_str(), reader.GetErrorStr().c_str());
+      msg.Printf(_("Error Loading EQ Curves from file:\n%s\nError message says:\n%s"), fn.GetFullPath(), reader.GetErrorStr());
       // Inform user of load failure
       wxMessageBox( msg,
          _("Error Loading EQ Curves"),
@@ -1505,7 +1505,7 @@ void EffectEqualization::SaveCurves(const wxString &fileName)
    {
       wxMessageBox(wxString::Format(
          _("Couldn't write to file \"%s\": %s"),
-         fn.GetFullPath().c_str(), exception.GetMessage().c_str()),
+         fn.GetFullPath(), exception.GetMessage()),
          _("Error Saving Equalization Curves"), wxICON_ERROR, mUIParent);
    }
 }
@@ -1749,7 +1749,7 @@ void EffectEqualization::Flatten()
 //
 // Process XML tags and handle the ones we recognize
 //
-bool EffectEqualization::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool EffectEqualization::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    // May want to add a version strings...
    if( !wxStrcmp( tag, wxT("equalizationeffect") ) )
@@ -1761,16 +1761,16 @@ bool EffectEqualization::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    if( !wxStrcmp(tag, wxT("curve") ) )
    {
       // Process the attributes
-      while( *attrs )
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
       {
          // Cache attr/value and bump to next
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
+         const wxString &attr = attrs[2*i];
+         const wxString &value = attrs[2*i+1];
 
          // Create a NEW curve and name it
          if( !wxStrcmp( attr, wxT("name") ) )
          {
-            const wxString strValue = value;
+            const wxString &strValue = value;
             if (!XMLValueChecker::IsGoodString(strValue))
                return false;
             // check for a duplicate name and add (n) if there is one
@@ -1783,7 +1783,7 @@ bool EffectEqualization::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
                for(size_t i=0;i<mCurves.GetCount();i++)
                {
                   if(n>0)
-                     strValueTemp.Printf(wxT("%s (%d)"),strValue.c_str(),n);
+                     strValueTemp.Printf(wxT("%s (%d)"),strValue,n);
                   if(mCurves[i].Name == strValueTemp)
                   {
                      exists = true;
@@ -1811,12 +1811,10 @@ bool EffectEqualization::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
 
       // Process the attributes
       double dblValue;
-      while( *attrs )
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
       {   // Cache attr/value and bump to next
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         const wxString strValue = value;
+         const wxString &attr = attrs[2*i];
+         const wxString &strValue = attrs[2*i+1];
 
          // Get the frequency
          if( !wxStrcmp( attr, wxT("f") ) )
@@ -1850,7 +1848,7 @@ bool EffectEqualization::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
 //
 // Return handler for recognized tags
 //
-XMLTagHandler *EffectEqualization::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *EffectEqualization::HandleXMLChild(const wxString &tag)
 {
    if( !wxStrcmp( tag, wxT("equalizationeffect") ) )
    {
@@ -3375,7 +3373,7 @@ void EditCurvesDialog::OnExport( wxCommandEvent & WXUNUSED(event))
       mEffect->SaveCurves(fileName);
       mEffect->mCurves = temp;
       wxString message;
-      message.Printf(_("%d curves exported to %s"), i, fileName.c_str());
+      message.Printf(_("%d curves exported to %s"), i, fileName);
       wxMessageBox(message, _("Curves exported"));
    }
    else

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -72,7 +72,6 @@ class EQCurve
 {
 public:
    EQCurve( const wxString & name = wxEmptyString ) { Name = name; }
-   EQCurve( const wxChar * name ) { Name = name; }
    wxString Name;
    EQPointArray points;
 };
@@ -149,8 +148,8 @@ private:
    void setCurve(void);
    
    // XMLTagHandler callback methods for loading and saving
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs);
-   XMLTagHandler *HandleXMLChild(const wxChar *tag);
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs);
+   XMLTagHandler *HandleXMLChild(const wxString &tag);
    void WriteXML(XMLWriter &xmlFile);
 
    void UpdateCurves();

--- a/src/effects/Equalization48x.cpp
+++ b/src/effects/Equalization48x.cpp
@@ -498,8 +498,8 @@ bool EffectEqualization48x::Benchmark(EffectEqualization* effectEqualization)
    wxTimeSpan tsDefaultThreaded(0, 0, 0, times[3]);
    wxTimeSpan tsDefault(0, 0, 0, times[4]);
 
-   wxMessageBox(wxString::Format(_("Benchmark times:\nOriginal: %s\nDefault Segmented: %s\nDefault Threaded: %s\nSSE: %s\nSSE Threaded: %s\n"),tsDefault.Format(wxT("%M:%S.%l")).c_str(), 
-      tsDefaultEnhanced.Format(wxT("%M:%S.%l")).c_str(), tsDefaultThreaded.Format(wxT("%M:%S.%l")).c_str(),tsSSE.Format(wxT("%M:%S.%l")).c_str(),tsSSEThreaded.Format(wxT("%M:%S.%l")).c_str()));
+   wxMessageBox(wxString::Format(_("Benchmark times:\nOriginal: %s\nDefault Segmented: %s\nDefault Threaded: %s\nSSE: %s\nSSE Threaded: %s\n"),tsDefault.Format(wxT("%M:%S.%l")), 
+      tsDefaultEnhanced.Format(wxT("%M:%S.%l")), tsDefaultThreaded.Format(wxT("%M:%S.%l")),tsSSE.Format(wxT("%M:%S.%l")),tsSSEThreaded.Format(wxT("%M:%S.%l"))));
    return bBreakLoop;
 }
 

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -166,7 +166,7 @@ enum
 //
 // Create the effect name array
 //
-static const wxChar *kEffectNames[] =
+static const wxString kEffectNames[] =
 {
    EFFECT_LIST
 };
@@ -174,7 +174,7 @@ static const wxChar *kEffectNames[] =
 //
 // Create the effect name array of excluded effects
 //
-static const wxChar *kExcludedNames[] =
+static const wxString kExcludedNames[] =
 {
    EXCLUDE_LIST
 };

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -35,7 +35,7 @@ enum kTypes
    kNumTypes
 };
 
-static const wxChar *kTypeStrings[kNumTypes] =
+static const wxString kTypeStrings[kNumTypes] =
 {
    XO("White"),
    XO("Pink"),

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -94,8 +94,8 @@ enum DiscriminationMethod {
    DM_DEFAULT_METHOD = DM_SECOND_GREATEST,
 };
 
-const struct DiscriminationMethodInfo {
-   const wxChar *name;
+static const struct DiscriminationMethodInfo {
+	wxString name;
 } discriminationMethodInfo[DM_N_METHODS] = {
       { _("Median") },
       { _("Second greatest") },
@@ -104,7 +104,7 @@ const struct DiscriminationMethodInfo {
 
 // magic number used only in the old statistics
 // and the old discrimination
-const float minSignalTime = 0.05f;
+static const float minSignalTime = 0.05f;
 
 enum WindowTypes {
    WT_RECTANGULAR_HANN = 0, // 2.0.6 behavior, requires 1/2 step
@@ -119,8 +119,8 @@ enum WindowTypes {
    WT_DEFAULT_WINDOW_TYPES = WT_HANN_HANN
 };
 
-const struct WindowTypesInfo {
-   const wxChar *name;
+static const struct WindowTypesInfo {
+   wxString name;
    int minSteps;
    double inCoefficients[3];
    double outCoefficients[3];
@@ -484,7 +484,7 @@ namespace {
       typedef FieldType (StructureType::*MemberPointer);
 
       MemberPointer field;
-      const wxChar *name;
+      wxString name;
       FieldType defaultValue;
    };
 
@@ -1439,12 +1439,12 @@ struct ControlInfo {
    double valueMax;
    long sliderMax;
    // (valueMin - valueMax) / sliderMax is the value increment of the slider
-   const wxChar* format;
+   const wxString format;
    bool formatAsInt;
    const wxString textBoxCaption_;  wxString textBoxCaption() const { return wxGetTranslation(textBoxCaption_); }
    const wxString sliderName_;  wxString sliderName() const { return wxGetTranslation(sliderName_); }
 
-   ControlInfo(MemberPointer f, double vMin, double vMax, long sMax, const wxChar* fmt, bool fAsInt,
+   ControlInfo(MemberPointer f, double vMin, double vMax, long sMax, const wxString &fmt, bool fAsInt,
       const wxString &caption, const wxString &name)
       : field(f), valueMin(vMin), valueMax(vMax), sliderMax(sMax), format(fmt), formatAsInt(fAsInt)
       , textBoxCaption_(caption), sliderName_(name)

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -57,7 +57,7 @@ Param( WetOnly,      bool,    XO("WetOnly"),       false,   false,   true, 1  );
 
 static const struct
 {
-   const wxChar *name;
+   wxString name;
    EffectReverb::Params params;
 }
 FactoryPresets[] =
@@ -322,7 +322,7 @@ wxArrayString EffectReverb::GetFactoryPresets()
 
 bool EffectReverb::LoadFactoryPreset(int id)
 {
-   if (id < 0 || id >= (int) WXSIZEOF(FactoryPresets))
+   if (id < 0 || static_cast<size_t>(id) >= WXSIZEOF(FactoryPresets))
    {
       return false;
    }

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -86,7 +86,7 @@ enum kTypes
    kNumTypes
 };
 
-static const wxChar *kTypeStrings[] =
+static const wxString kTypeStrings[] =
 {
    /*i18n-hint: Butterworth is the name of the person after whom the filter type is named.*/
    XO("Butterworth"),
@@ -103,7 +103,7 @@ enum kSubTypes
    kNumSubTypes
 };
 
-static const wxChar *kSubTypeStrings[] =
+static const wxString kSubTypeStrings[] =
 {
    XO("Lowpass"),
    XO("Highpass")

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -43,7 +43,7 @@ enum kActions
    kNumActions
 };
 
-static const wxChar *kActionStrings[kNumActions] =
+static const wxString kActionStrings[kNumActions] =
 {
    XO("Truncate Detected Silence"),
    XO("Compress Excess Silence")

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -468,7 +468,7 @@ bool VSTEffectsModule::RegisterPlugin(PluginManagerInterface & pm, const wxStrin
       wxString effectID = effectTzr.GetNextToken();
 
       wxString cmd;
-      cmd.Printf(wxT("\"%s\" %s \"%s;%s\""), cmdpath.c_str(), VSTCMDKEY, path.c_str(), effectID.c_str());
+      cmd.Printf(wxT("\"%s\" %s \"%s;%s\""), cmdpath, VSTCMDKEY, path, effectID);
 
       VSTSubProcess proc;
       try
@@ -481,7 +481,7 @@ bool VSTEffectsModule::RegisterPlugin(PluginManagerInterface & pm, const wxStrin
       }
       catch (...)
       {
-         wxLogMessage(_("VST plugin registration failed for %s\n"), path.c_str());
+         wxLogMessage(_("VST plugin registration failed for %s\n"), path);
          return false;
       }
 
@@ -518,7 +518,7 @@ bool VSTEffectsModule::RegisterPlugin(PluginManagerInterface & pm, const wxStrin
                if (idCnt > 3)
                {
                   progress.create( _("Scanning Shell VST"),
-                        wxString::Format(_("Registering %d of %d: %-64.64s"), 0, idCnt, proc.GetName().c_str()),
+                        wxString::Format(_("Registering %d of %d: %-64.64s"), 0, idCnt, proc.GetName()),
                         static_cast<int>(idCnt),
                         nullptr,
                         wxPD_APP_MODAL |
@@ -592,7 +592,7 @@ bool VSTEffectsModule::RegisterPlugin(PluginManagerInterface & pm, const wxStrin
                {
                   idNdx++;
                   cont = progress->Update(idNdx,
-                                          wxString::Format(_("Registering %d of %d: %-64.64s"), idNdx, idCnt, proc.GetName().c_str()));
+                                          wxString::Format(_("Registering %d of %d: %-64.64s"), idNdx, idCnt, proc.GetName()));
                }
 
                if (!skip && cont)
@@ -646,7 +646,7 @@ void VSTEffectsModule::DeleteInstance(IdentInterface *instance)
 // static
 //
 // Called from reinvokation of Audacity or DLL to check in a separate process
-void VSTEffectsModule::Check(const wxChar *path)
+void VSTEffectsModule::Check(const wxString &path)
 {
    VSTEffect effect(path);
    if (effect.SetHost(NULL))
@@ -663,16 +663,16 @@ void VSTEffectsModule::Check(const wxChar *path)
             subids += wxString::Format(wxT("%d;"), effectIDs[i]);
          }
 
-         out = wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeySubIDs, subids.RemoveLast().c_str());
+         out = wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeySubIDs, subids.RemoveLast());
       }
       else
       {
          out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyBegin, wxEmptyString);
-         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyPath, effect.GetPath().c_str());
-         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyName, effect.GetName().c_str());
-         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyVendor, effect.GetVendor().c_str());
-         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyVersion, effect.GetVersion().c_str());
-         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyDescription, effect.GetDescription().c_str());
+         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyPath, effect.GetPath());
+         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyName, effect.GetName());
+         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyVendor, effect.GetVendor());
+         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyVersion, effect.GetVersion());
+         out += wxString::Format(wxT("%s%d=%s\n"), OUTPUTKEY, kKeyDescription, effect.GetDescription());
          out += wxString::Format(wxT("%s%d=%d\n"), OUTPUTKEY, kKeyEffectType, effect.GetType());
          out += wxString::Format(wxT("%s%d=%d\n"), OUTPUTKEY, kKeyInteractive, effect.IsInteractive());
          out += wxString::Format(wxT("%s%d=%d\n"), OUTPUTKEY, kKeyAutomatable, effect.SupportsAutomation());
@@ -681,7 +681,7 @@ void VSTEffectsModule::Check(const wxChar *path)
 
       // We want to output info in one chunk to prevent output
       // from the effect intermixing with the info
-      const wxCharBuffer buf = out.ToUTF8();
+      const wxScopedCharBuffer &buf = out.utf8_str();
       fwrite(buf, 1, strlen(buf), stdout);
       fflush(stdout);
    }
@@ -997,9 +997,9 @@ intptr_t VSTEffect::AudioMaster(AEffect * effect,
 
 #if defined(VST_DEBUG)
 #if defined(__WXMSW__)
-         wxLogDebug(wxT("VST canDo: %s"), wxString::FromAscii((char *)ptr).c_str());
+         wxLogDebug(wxT("VST canDo: %s"), wxString::FromAscii(static_cast<const char *>(ptr));
 #else
-         wxPrintf(wxT("VST canDo: %s\n"), wxString::FromAscii((char *)ptr).c_str());
+         wxPrintf(wxT("VST canDo: %s\n"), wxString::FromAscii(static_cast<const char *>(ptr));
 #endif
 #endif
 
@@ -2679,7 +2679,7 @@ void VSTEffect::callSetChunk(bool isPgm, int len, void *buf, VstPatchChunkInfo *
 ////////////////////////////////////////////////////////////////////////////////
 
 // Lookup table for encoding
-const static wxChar cset[] = wxT("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+static const wxString cset[] = wxT("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 const static char padc = wxT('=');
 
 wxString VSTEffect::b64encode(const void *in, int len)
@@ -2746,7 +2746,6 @@ int VSTEffect::b64decode(const wxString &in, void *out)
       }
    }
 
-   //const char *a = in.mb_str();
    //Setup a vector to hold the result
    unsigned long temp = 0; //Holds decoded quanta
    int i = 0;
@@ -2999,14 +2998,14 @@ void VSTEffect::RefreshParameters(int skip)
       {
          text.Printf(wxT("%.5g"),callGetParameter(i));
       }
-      mDisplays[i]->SetLabel(wxString::Format(wxT("%8s"), text.c_str()));
+      mDisplays[i]->SetLabel(wxString::Format(wxT("%8s"), text));
       name += wxT(' ') + text;
 
       text = GetString(effGetParamDisplay, i);
       if (!text.IsEmpty())
       {
-         text.Printf(wxT("%-8s"), GetString(effGetParamLabel, i).c_str());
-         mLabels[i]->SetLabel(wxString::Format(wxT("%8s"), text.c_str()));
+         text.Printf(wxT("%-8s"), GetString(effGetParamLabel, i));
+         mLabels[i]->SetLabel(wxString::Format(wxT("%8s"), text));
          name += wxT(' ') + text;
       }
 
@@ -3480,7 +3479,7 @@ void VSTEffect::SaveFXB(const wxFileName & fn)
    wxFFile f(fn.GetFullPath(), wxT("wb"));
    if (!f.IsOpened())
    {
-      wxMessageBox(wxString::Format(_("Could not open file: \"%s\""), fn.GetFullPath().c_str()),
+      wxMessageBox(wxString::Format(_("Could not open file: \"%s\""), fn.GetFullPath()),
                    _("Error Saving VST Presets"),
                    wxOK | wxCENTRE,
                    mParent);
@@ -3547,7 +3546,7 @@ void VSTEffect::SaveFXB(const wxFileName & fn)
 
    if (f.Error())
    {
-      wxMessageBox(wxString::Format(_("Error writing to file: \"%s\""), fn.GetFullPath().c_str()),
+      wxMessageBox(wxString::Format(_("Error writing to file: \"%s\""), fn.GetFullPath()),
                    _("Error Saving VST Presets"),
                    wxOK | wxCENTRE,
                    mParent);
@@ -3564,7 +3563,7 @@ void VSTEffect::SaveFXP(const wxFileName & fn)
    wxFFile f(fn.GetFullPath(), wxT("wb"));
    if (!f.IsOpened())
    {
-      wxMessageBox(wxString::Format(_("Could not open file: \"%s\""), fn.GetFullPath().c_str()),
+      wxMessageBox(wxString::Format(_("Could not open file: \"%s\""), fn.GetFullPath()),
                    _("Error Saving VST Presets"),
                    wxOK | wxCENTRE,
                    mParent);
@@ -3579,7 +3578,7 @@ void VSTEffect::SaveFXP(const wxFileName & fn)
    f.Write(buf.GetData(), buf.GetDataLen());
    if (f.Error())
    {
-      wxMessageBox(wxString::Format(_("Error writing to file: \"%s\""), fn.GetFullPath().c_str()),
+      wxMessageBox(wxString::Format(_("Error writing to file: \"%s\""), fn.GetFullPath()),
                    _("Error Saving VST Presets"),
                    wxOK | wxCENTRE,
                    mParent);
@@ -3710,21 +3709,14 @@ void VSTEffect::SaveXML(const wxFileName & fn)
    return;
 }
 
-bool VSTEffect::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool VSTEffect::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (wxStrcmp(tag, wxT("vstprogrampersistence")) == 0)
    {
-      while (*attrs)
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
       {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-         {
-            break;
-         }
-
-         const wxString strValue = value;
+         const wxString &attr = attrs[2*i];
+         const wxString &strValue = attrs[2*i+1];
 
          if (wxStrcmp(attr, wxT("version")) == 0)
          {
@@ -3755,17 +3747,11 @@ bool VSTEffect::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
       mXMLInfo.pluginVersion = mAEffect->version;
       mXMLInfo.numElements = mAEffect->numParams;
 
-      while (*attrs)
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
       {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-         {
-            break;
-         }
-
-         const wxString strValue = value;
+         const wxString &attr = attrs[2*i];
+         const wxString &value = attrs[2*i+1];
+         const wxString &strValue = value;
 
          if (wxStrcmp(attr, wxT("name")) == 0)
          {
@@ -3826,17 +3812,10 @@ bool VSTEffect::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
 
    if (wxStrcmp(tag, wxT("program")) == 0)
    {
-      while (*attrs)
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
       {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-         {
-            break;
-         }
-
-         const wxString strValue = value;
+         const wxString &attr = attrs[2*i];
+         const wxString &strValue = attrs[2*i+1];
 
          if (wxStrcmp(attr, wxT("name")) == 0)
          {
@@ -3882,17 +3861,10 @@ bool VSTEffect::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    {
       long ndx = -1;
       double val = -1.0;
-      while (*attrs)
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
       {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-         {
-            break;
-         }
-
-         const wxString strValue = value;
+         const wxString &attr = attrs[2*i];
+         const wxString &strValue = attrs[2*i+1];
 
          if (wxStrcmp(attr, wxT("index")) == 0)
          {
@@ -3950,7 +3922,7 @@ bool VSTEffect::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return false;
 }
 
-void VSTEffect::HandleXMLEndTag(const wxChar *tag)
+void VSTEffect::HandleXMLEndTag(const wxString &tag)
 {
    if (wxStrcmp(tag, wxT("chunk")) == 0)
    {
@@ -3989,7 +3961,7 @@ void VSTEffect::HandleXMLContent(const wxString & content)
    }
 }
 
-XMLTagHandler *VSTEffect::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *VSTEffect::HandleXMLChild(const wxString &tag)
 {
    if (wxStrcmp(tag, wxT("vstprogrampersistence")) == 0)
    {

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -210,10 +210,10 @@ private:
    void SaveXML(const wxFileName & fn);
    void SaveFXProgram(wxMemoryBuffer & buf, int index);
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
-   void HandleXMLEndTag(const wxChar *tag) override;
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) override;
+   void HandleXMLEndTag(const wxString &tag) override;
    void HandleXMLContent(const wxString & content) override;
-   XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
+   XMLTagHandler *HandleXMLChild(const wxString &tag) override;
 
    // Utility methods
 
@@ -360,7 +360,7 @@ public:
 
    // VSTEffectModule implementation
 
-   static void Check(const wxChar *path);
+   static void Check(const wxString &path);
 
 private:
    ModuleManagerInterface *mModMan;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -56,7 +56,7 @@ effects from this one class.
 // ============================================================================
 // List of effects that ship with Audacity.  These will be autoregistered.
 // ============================================================================
-const static wxChar *kShippedEffects[] =
+static const wxString kShippedEffects[] =
 {
    wxT("sc4_1882.dll"),
 };
@@ -159,7 +159,7 @@ bool LadspaEffectsModule::AutoRegisterPlugins(PluginManagerInterface & pm)
    wxArrayString pathList = GetSearchPaths();
    wxArrayString files;
 
-   for (int i = 0; i < WXSIZEOF(kShippedEffects); i++)
+   for (size_t i = 0; i < WXSIZEOF(kShippedEffects); ++i)
    {
       files.Clear();
       pm.FindFilesInPathList(kShippedEffects[i], pathList, files);
@@ -611,7 +611,7 @@ LadspaEffect::~LadspaEffect()
 
 wxString LadspaEffect::GetPath()
 {
-   return wxString::Format(wxT("%s;%d"), mPath.c_str(), mIndex);
+   return wxString::Format(wxT("%s;%d"), mPath, mIndex);
 }
 
 wxString LadspaEffect::GetSymbol()

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -19,7 +19,7 @@
 // ============================================================================
 // List of effects that ship with Audacity.  These will be autoregistered.
 // ============================================================================
-const static wxChar *kShippedEffects[] =
+static const wxString kShippedEffects[] =
 {
    wxT("adjustable-fade.ny"),
    wxT("beat.ny"),
@@ -169,7 +169,7 @@ bool NyquistEffectsModule::AutoRegisterPlugins(PluginManagerInterface & pm)
       RegisterPlugin(pm, NYQUIST_PROMPT_ID);
    }
 
-   for (int i = 0; i < WXSIZEOF(kShippedEffects); i++)
+   for (size_t i = 0; i < WXSIZEOF(kShippedEffects); ++i)
    {
       files.Clear();
       pm.FindFilesInPathList(kShippedEffects[i], pathList, files);

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -90,8 +90,8 @@ enum
 
 #define UNINITIALIZED_CONTROL ((double)99999999.99)
 
-static const wxChar *KEY_Version = XO("Version");
-static const wxChar *KEY_Command = XO("Command");
+static const wxString KEY_Version = XO("Version");
+static const wxString KEY_Command = XO("Command");
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -490,10 +490,10 @@ bool NyquistEffect::Process()
 
       mProps += wxString::Format(wxT("(setf *DECIMAL-SEPARATOR* #\\%c)\n"), wxNumberFormatter::GetDecimalSeparator());
 
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* \"%s\" 'BASE)\n"), EscapeString(FileNames::BaseDir()).c_str());
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* \"%s\" 'DATA)\n"), EscapeString(FileNames::DataDir()).c_str());
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* \"%s\" 'HELP)\n"), EscapeString(FileNames::HtmlHelpDir().RemoveLast()).c_str());
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* \"%s\" 'TEMP)\n"), EscapeString(FileNames::TempDir()).c_str());
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* \"%s\" 'BASE)\n"), EscapeString(FileNames::BaseDir()));
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* \"%s\" 'DATA)\n"), EscapeString(FileNames::DataDir()));
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* \"%s\" 'HELP)\n"), EscapeString(FileNames::HtmlHelpDir().RemoveLast()));
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* \"%s\" 'TEMP)\n"), EscapeString(FileNames::TempDir()));
 
       wxArrayString paths = NyquistEffect::GetNyquistSearchPath();
       wxString list;
@@ -501,7 +501,7 @@ bool NyquistEffect::Process()
       {
          list += wxT("\"") + EscapeString(paths[i]) + wxT("\" ");
       }
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* (list %s) 'PLUGIN)\n"), list.RemoveLast().c_str());
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-DIR* (list %s) 'PLUGIN)\n"), list.RemoveLast());
 
 
       // Date and time:
@@ -517,15 +517,15 @@ bool NyquistEffect::Process()
       mProps += wxString::Format(wxT("(setf *SYSTEM-TIME* (list %d %d %d %d %d))\n"),
                                  year, doy, now.GetHour(), now.GetMinute(), now.GetSecond());
 
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'DATE)\n"), now.FormatDate().c_str());
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'TIME)\n"), now.FormatTime().c_str());
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'ISO-DATE)\n"), now.FormatISODate().c_str());
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'ISO-TIME)\n"), now.FormatISOTime().c_str());
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'DATE)\n"), now.FormatDate());
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'TIME)\n"), now.FormatTime());
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'ISO-DATE)\n"), now.FormatISODate());
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'ISO-TIME)\n"), now.FormatISOTime());
       mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* %d 'YEAR)\n"), year);
       mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* %d 'DAY)\n"), dom);   // day of month
       mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* %d 'MONTH)\n"), month);
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'MONTH-NAME)\n"), now.GetMonthName(month).c_str());
-      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'DAY-NAME)\n"), now.GetWeekDayName(day).c_str());
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'MONTH-NAME)\n"), now.GetMonthName(month));
+      mProps += wxString::Format(wxT("(putprop '*SYSTEM-TIME* \"%s\" 'DAY-NAME)\n"), now.GetWeekDayName(day));
 
 
       TrackListIterator all(project->GetTracks());
@@ -567,7 +567,7 @@ bool NyquistEffect::Process()
       // numbers to Nyquist, whereas using "%g" will use the user's
       // decimal separator which may be a comma in some countries.
       mProps += wxString::Format(wxT("(putprop '*PROJECT* (float %s) 'RATE)\n"),
-                                 Internat::ToString(project->GetRate()).c_str());
+                                 Internat::ToString(project->GetRate()));
       mProps += wxString::Format(wxT("(putprop '*PROJECT* %d 'TRACKS)\n"), numTracks);
       mProps += wxString::Format(wxT("(putprop '*PROJECT* %d 'WAVETRACKS)\n"), numWave);
       mProps += wxString::Format(wxT("(putprop '*PROJECT* %d 'LABELTRACKS)\n"), numLabel);
@@ -577,17 +577,17 @@ bool NyquistEffect::Process()
       double previewLen = 6.0;
       gPrefs->Read(wxT("/AudioIO/EffectsPreviewLen"), &previewLen);
       mProps += wxString::Format(wxT("(putprop '*PROJECT* (float %s) 'PREVIEW-DURATION)\n"),
-                                 Internat::ToString(previewLen).c_str());
+                                 Internat::ToString(previewLen));
 
       // *PREVIEWP* is true when previewing (better than relying on track view).
       wxString isPreviewing = (this->IsPreviewing())? wxT("T") : wxT("NIL");
-      mProps += wxString::Format(wxT("(setf *PREVIEWP* %s)\n"), isPreviewing.c_str());
+      mProps += wxString::Format(wxT("(setf *PREVIEWP* %s)\n"), isPreviewing);
 
       mProps += wxString::Format(wxT("(putprop '*SELECTION* (float %s) 'START)\n"),
-                                 Internat::ToString(mT0).c_str());
+                                 Internat::ToString(mT0));
       mProps += wxString::Format(wxT("(putprop '*SELECTION* (float %s) 'END)\n"),
-                                 Internat::ToString(mT1).c_str());
-      mProps += wxString::Format(wxT("(putprop '*SELECTION* (list %s) 'TRACKS)\n"), waveTrackList.c_str());
+                                 Internat::ToString(mT1));
+      mProps += wxString::Format(wxT("(putprop '*SELECTION* (list %s) 'TRACKS)\n"), waveTrackList);
       mProps += wxString::Format(wxT("(putprop '*SELECTION* %d 'CHANNELS)\n"), mNumSelectedChannels);
    }
 
@@ -663,15 +663,15 @@ bool NyquistEffect::Process()
 
 #if defined(EXPERIMENTAL_SPECTRAL_EDITING)
             if (mF0 >= 0.0) {
-               lowHz.Printf(wxT("(float %s)"), Internat::ToString(mF0).c_str());
+               lowHz.Printf(wxT("(float %s)"), Internat::ToString(mF0));
             }
 
             if (mF1 >= 0.0) {
-               highHz.Printf(wxT("(float %s)"), Internat::ToString(mF1).c_str());
+               highHz.Printf(wxT("(float %s)"), Internat::ToString(mF1));
             }
 
             if ((mF0 >= 0.0) && (mF1 >= 0.0)) {
-               centerHz.Printf(wxT("(float %s)"), Internat::ToString(sqrt(mF0 * mF1)).c_str());
+               centerHz.Printf(wxT("(float %s)"), Internat::ToString(sqrt(mF0 * mF1)));
             }
 
             if ((mF0 > 0.0) && (mF1 >= mF0)) {
@@ -679,15 +679,15 @@ bool NyquistEffect::Process()
                // (Observed on Linux)
                double bw = log(mF1 / mF0) / log(2.0);
                if (!isinf(bw)) {
-                  bandwidth.Printf(wxT("(float %s)"), Internat::ToString(bw).c_str());
+                  bandwidth.Printf(wxT("(float %s)"), Internat::ToString(bw));
                }
             }
 
 #endif
-            mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'LOW-HZ)\n"), lowHz.c_str());
-            mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'CENTER-HZ)\n"), centerHz.c_str());
-            mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'HIGH-HZ)\n"), highHz.c_str());
-            mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'BANDWIDTH)\n"), bandwidth.c_str());
+            mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'LOW-HZ)\n"), lowHz);
+            mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'CENTER-HZ)\n"), centerHz);
+            mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'HIGH-HZ)\n"), highHz);
+            mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'BANDWIDTH)\n"), bandwidth);
          }
 
          success = ProcessOne();
@@ -719,7 +719,7 @@ bool NyquistEffect::Process()
       NyquistOutputDialog dlog(mUIParent, -1,
                                _("Nyquist"),
                                _("Nyquist Output: "),
-                               mDebugOutput.c_str());
+                               mDebugOutput);
       dlog.CentreOnParent();
       dlog.ShowModal();
    }
@@ -876,10 +876,10 @@ bool NyquistEffect::ProcessOne()
       }
 
       cmd += wxString::Format(wxT("(putprop '*TRACK* %d 'INDEX)\n"), ++mTrackIndex);
-      cmd += wxString::Format(wxT("(putprop '*TRACK* \"%s\" 'NAME)\n"), mCurTrack[0]->GetName().c_str());
-      cmd += wxString::Format(wxT("(putprop '*TRACK* \"%s\" 'TYPE)\n"), type.c_str());
+      cmd += wxString::Format(wxT("(putprop '*TRACK* \"%s\" 'NAME)\n"), mCurTrack[0]->GetName());
+      cmd += wxString::Format(wxT("(putprop '*TRACK* \"%s\" 'TYPE)\n"), type);
       // Note: "View" property may change when Audacity's choice of track views has stabilized.
-      cmd += wxString::Format(wxT("(putprop '*TRACK* %s 'VIEW)\n"), view.c_str());
+      cmd += wxString::Format(wxT("(putprop '*TRACK* %s 'VIEW)\n"), view);
       cmd += wxString::Format(wxT("(putprop '*TRACK* %d 'CHANNELS)\n"), mCurNumChannels);
 
       double startTime = 0.0;
@@ -900,15 +900,15 @@ bool NyquistEffect::ProcessOne()
       }
 
       cmd += wxString::Format(wxT("(putprop '*TRACK* (float %s) 'START-TIME)\n"),
-                              Internat::ToString(startTime).c_str());
+                              Internat::ToString(startTime));
       cmd += wxString::Format(wxT("(putprop '*TRACK* (float %s) 'END-TIME)\n"),
-                              Internat::ToString(endTime).c_str());
+                              Internat::ToString(endTime));
       cmd += wxString::Format(wxT("(putprop '*TRACK* (float %s) 'GAIN)\n"),
-                              Internat::ToString(mCurTrack[0]->GetGain()).c_str());
+                              Internat::ToString(mCurTrack[0]->GetGain()));
       cmd += wxString::Format(wxT("(putprop '*TRACK* (float %s) 'PAN)\n"),
-                              Internat::ToString(mCurTrack[0]->GetPan()).c_str());
+                              Internat::ToString(mCurTrack[0]->GetPan()));
       cmd += wxString::Format(wxT("(putprop '*TRACK* (float %s) 'RATE)\n"),
-                              Internat::ToString(mCurTrack[0]->GetRate()).c_str());
+                              Internat::ToString(mCurTrack[0]->GetRate()));
 
       switch (mCurTrack[0]->GetSampleFormat())
       {
@@ -922,7 +922,7 @@ bool NyquistEffect::ProcessOne()
             bitFormat = wxT("32.0");
             break;
       }
-      cmd += wxString::Format(wxT("(putprop '*TRACK* %s 'FORMAT)\n"), bitFormat.c_str());
+      cmd += wxString::Format(wxT("(putprop '*TRACK* %s 'FORMAT)\n"), bitFormat);
 
       float maxPeak = 0.0;
       wxString clips;
@@ -934,8 +934,8 @@ bool NyquistEffect::ProcessOne()
          // Each clip is a list (start-time, end-time)
          for (size_t j = 0; j < ca.GetCount(); j++) {
             clips += wxString::Format(wxT("(list (float %s) (float %s))"),
-                                      Internat::ToString(ca[j]->GetStartTime()).c_str(),
-                                      Internat::ToString(ca[j]->GetEndTime()).c_str());
+                                      Internat::ToString(ca[j]->GetStartTime()),
+                                      Internat::ToString(ca[j]->GetEndTime()));
          }
          if (mCurNumChannels > 1) clips += wxT(" )");
 
@@ -946,9 +946,9 @@ bool NyquistEffect::ProcessOne()
       // A list of clips for mono, or an array of lists for multi-channel.
       cmd += wxString::Format(wxT("(putprop '*TRACK* %s%s ) 'CLIPS)\n"),
                               (mCurNumChannels == 1) ? wxT("(list ") : wxT("(vector "),
-                              clips.c_str());
+                              clips);
       cmd += wxString::Format(wxT("(putprop '*SELECTION* (float %s) 'PEAK-LEVEL)\n"),
-                              Internat::ToString(maxPeak).c_str());
+                              Internat::ToString(maxPeak));
    }
 
    if (GetType() == EffectTypeGenerate) {
@@ -988,20 +988,20 @@ bool NyquistEffect::ProcessOne()
          // numbers to Nyquist, whereas using "%f" will use the user's
          // decimal separator which may be a comma in some countries.
          cmd += wxString::Format(wxT("(setf %s %s)\n"),
-                                 mControls[j].var.c_str(),
-                                 Internat::ToString(mControls[j].val, 14).c_str());
+                                 mControls[j].var,
+                                 Internat::ToString(mControls[j].val, 14));
       }
       else if (mControls[j].type == NYQ_CTRL_INT ||
             mControls[j].type == NYQ_CTRL_INT_TEXT ||
             mControls[j].type == NYQ_CTRL_CHOICE) {
          cmd += wxString::Format(wxT("(setf %s %d)\n"),
-                                 mControls[j].var.c_str(),
+                                 mControls[j].var,
                                  (int)(mControls[j].val));
       }
       else if (mControls[j].type == NYQ_CTRL_STRING) {
          cmd += wxT("(setf ");
          // restrict variable names to 7-bit ASCII:
-         cmd += mControls[j].var.c_str();
+         cmd += mControls[j].var.ToAscii();
          cmd += wxT(" \"");
          cmd += EscapeString(mControls[j].valStr); // unrestricted value will become quoted UTF-8
          cmd += wxT("\")\n");
@@ -1050,7 +1050,7 @@ bool NyquistEffect::ProcessOne()
       mCurBuffer[i] = NULL;
    }
 
-   rval = nyx_eval_expression(cmd.mb_str(wxConvUTF8));
+   rval = nyx_eval_expression(cmd.utf8_str());
 
    // Audacity has no idea how long Nyquist processing will take, but
    // can monitor audio being returned.
@@ -1355,7 +1355,7 @@ void NyquistEffect::Parse(const wxString &line)
    wxString tok = wxT("");
 
    for (i = 1; i < len; i++) {
-      wxChar c = line[i];
+      auto c = line[i];
 
       if (c == wxT('\\')) {
          sl = true;
@@ -1567,7 +1567,7 @@ void NyquistEffect::Parse(const wxString &line)
          {
             wxString str;
             str.Printf(_("Bad Nyquist 'control' type specification: '%s' in plugin file '%s'.\nControl not created."),
-                       tokens[3].c_str(), mFileName.GetFullPath().c_str());
+                       tokens[3], mFileName.GetFullPath());
 
             // Too disturbing to show alert before Audacity frame is up.
             //    wxMessageBox(str, wxT("Nyquist Warning"), wxOK | wxICON_EXCLAMATION);

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -387,7 +387,7 @@ bool Exporter::Process(AudacityProject *project, bool selectedOnly, double t0, d
 }
 
 bool Exporter::Process(AudacityProject *project, int numChannels,
-                       const wxChar *type, const wxString & filename,
+                       const wxString &type, const wxString &filename,
                        bool selectedOnly, double t0, double t1)
 {
    // Save parms
@@ -608,9 +608,9 @@ bool Exporter::GetFilename()
       else if (!ext.IsEmpty() && !mPlugins[mFormat]->IsExtension(ext,mSubFormat) && ext.CmpNoCase(defext)) {
          wxString prompt;
          prompt.Printf(_("You are about to export a %s file with the name \"%s\".\n\nNormally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n\nAre you sure you want to export the file under this name?"),
-                       mPlugins[mFormat]->GetFormat(mSubFormat).c_str(),
-                       mFilename.GetFullName().c_str(),
-                       defext.c_str());
+                       mPlugins[mFormat]->GetFormat(mSubFormat),
+                       mFilename.GetFullName(),
+                       defext);
 
          int action = wxMessageBox(prompt,
                                    _("Warning"),
@@ -654,7 +654,7 @@ If you still wish to export, please choose a different filename or folder."));
          wxString prompt;
 
          prompt.Printf(_("A file named \"%s\" already exists.  Replace?"),
-                       mFilename.GetFullPath().c_str());
+                       mFilename.GetFullPath());
 
          int action = wxMessageBox(prompt,
                                    _("Warning"),

--- a/src/export/Export.h
+++ b/src/export/Export.h
@@ -144,7 +144,7 @@ public:
    bool Process(AudacityProject *project, bool selectedOnly,
                 double t0, double t1);
    bool Process(AudacityProject *project, int numChannels,
-                const wxChar *type, const wxString & filename,
+                const wxString &type, const wxString & filename,
                 bool selectedOnly, double t0, double t1);
 
    void DisplayOptions(int index);

--- a/src/export/ExportCL.cpp
+++ b/src/export/ExportCL.cpp
@@ -342,7 +342,7 @@ int ExportCL::Export(AudacityProject *project,
    wxGetEnv(wxT("PATH"), &opath);
    npath = opath;
 
-   for (int i = 0; i < WXSIZEOF(paths); i++) {
+   for (size_t i = 0; i < WXSIZEOF(paths); ++i) {
       reg.SetName(paths[i]);
 
       if (reg.Exists()) {
@@ -354,7 +354,7 @@ int ExportCL::Export(AudacityProject *project,
       }
    }
 
-   wxSetEnv(wxT("PATH"),npath.c_str());
+   wxSetEnv(wxT("PATH"), npath);
 #endif
 
    // Kick off the command
@@ -363,13 +363,13 @@ int ExportCL::Export(AudacityProject *project,
 
 #if defined(__WXMSW__)
    if (!opath.IsEmpty()) {
-      wxSetEnv(wxT("PATH"),opath.c_str());
+      wxSetEnv(wxT("PATH"), opath);
    }
 #endif
 
    if (!rc) {
       wxMessageBox(wxString::Format(_("Cannot export audio to %s"),
-                                    fName.c_str()));
+                                    fName));
       process.Detach();
       process.CloseOutput();
 

--- a/src/export/ExportFFmpeg.cpp
+++ b/src/export/ExportFFmpeg.cpp
@@ -110,7 +110,7 @@ public:
    bool AddTags(const Tags *metadata);
 
    /// Sets individual metadata values
-   void SetMetadata(const Tags *tags, const char *name, const wxChar *tag);
+   void SetMetadata(const Tags *tags, const char *name, const wxString &tag);
 
    /// Encodes audio
    bool EncodeAudioFrame(int16_t *pFrame, int frameSize);
@@ -193,7 +193,7 @@ ExportFFmpeg::ExportFFmpeg()
       if (newfmt < FMT_OTHER && FFmpegLibsInst->ValidLibsLoaded())
       {
          // Format/Codec support is compiled in?
-         AVOutputFormat *avoformat = av_guess_format(shortname.mb_str(), NULL, NULL);
+         AVOutputFormat *avoformat = av_guess_format(shortname.utf8_str(), NULL, NULL);
          AVCodec *avcodec = avcodec_find_encoder(ExportFFmpegOptions::fmts[newfmt].codecid);
          if (avoformat == NULL || avcodec == NULL)
          {
@@ -270,7 +270,7 @@ bool ExportFFmpeg::Init(const char *shortname, AudacityProject *project, const T
    // and the default video/audio codecs that the format uses.
    if ((mEncFormatDesc = av_guess_format(shortname, OSINPUT(mName), NULL)) == NULL)
    {
-      wxMessageBox(wxString::Format(_("FFmpeg : ERROR - Can't determine format description for file \"%s\"."), mName.c_str()),
+      wxMessageBox(wxString::Format(_("FFmpeg : ERROR - Can't determine format description for file \"%s\"."), mName),
                    _("FFmpeg Error"), wxOK|wxCENTER|wxICON_EXCLAMATION);
       return false;
    }
@@ -290,7 +290,7 @@ bool ExportFFmpeg::Init(const char *shortname, AudacityProject *project, const T
    // At the moment Audacity can export only one audio stream
    if ((mEncAudioStream = avformat_new_stream(mEncFormatCtx, NULL)) == NULL)
    {
-      wxMessageBox(wxString::Format(_("FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."), mName.c_str()),
+      wxMessageBox(wxString::Format(_("FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."), mName),
                    _("FFmpeg Error"), wxOK|wxCENTER|wxICON_EXCLAMATION);
       return false;
    }
@@ -302,7 +302,7 @@ bool ExportFFmpeg::Init(const char *shortname, AudacityProject *project, const T
    {
       if ((err = ufile_fopen(&mEncFormatCtx->pb, mName, AVIO_FLAG_WRITE)) < 0)
       {
-         wxMessageBox(wxString::Format(wxT("FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."), mName.c_str(), err),
+         wxMessageBox(wxString::Format(wxT("FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."), mName, err),
                       _("FFmpeg Error"), wxOK|wxCENTER|wxICON_EXCLAMATION);
          return false;
       }
@@ -326,7 +326,7 @@ bool ExportFFmpeg::Init(const char *shortname, AudacityProject *project, const T
    // Write headers to the output file.
    if ((err = avformat_write_header(mEncFormatCtx, NULL)) < 0)
    {
-      wxMessageBox(wxString::Format(_("FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."), mName.c_str(),err),
+      wxMessageBox(wxString::Format(_("FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."), mName,err),
                    _("FFmpeg Error"), wxOK|wxCENTER|wxICON_EXCLAMATION);
       return false;
    }
@@ -402,7 +402,7 @@ bool ExportFFmpeg::InitCodecs(AudacityProject *project)
       mEncAudioCodecCtx->sample_rate = gPrefs->Read(wxT("/FileFormats/FFmpegSampleRate"),(long)0);
       if (mEncAudioCodecCtx->sample_rate != 0) mSampleRate = mEncAudioCodecCtx->sample_rate;
       mEncAudioCodecCtx->bit_rate = gPrefs->Read(wxT("/FileFormats/FFmpegBitRate"), (long)0);
-      strncpy((char *)&mEncAudioCodecCtx->codec_tag,gPrefs->Read(wxT("/FileFormats/FFmpegTag"),wxT("")).mb_str(wxConvUTF8),4);
+      strncpy((char *)&mEncAudioCodecCtx->codec_tag, gPrefs->Read(wxT("/FileFormats/FFmpegTag"),wxT("")).utf8_str(), 4);
       mEncAudioCodecCtx->global_quality = gPrefs->Read(wxT("/FileFormats/FFmpegQuality"),(long)-99999);
       mEncAudioCodecCtx->cutoff = gPrefs->Read(wxT("/FileFormats/FFmpegCutOff"),(long)0);
       mEncAudioCodecCtx->flags2 = 0;
@@ -898,13 +898,13 @@ bool ExportFFmpeg::AddTags(const Tags *tags)
    return true;
 }
 
-void ExportFFmpeg::SetMetadata(const Tags *tags, const char *name, const wxChar *tag)
+void ExportFFmpeg::SetMetadata(const Tags *tags, const char *name, const wxString &tag)
 {
    if (tags->HasTag(tag))
    {
       wxString value = tags->GetTag(tag);
 
-      av_dict_set(&mEncFormatCtx->metadata, name, mSupportsUTF8 ? value.ToUTF8() : value.mb_str(), 0);
+      av_dict_set(&mEncFormatCtx->metadata, name, mSupportsUTF8 ? value.utf8_str() : value.ToAscii(), 0);
    }
 }
 

--- a/src/export/ExportFFmpegDialogs.cpp
+++ b/src/export/ExportFFmpegDialogs.cpp
@@ -124,7 +124,7 @@ enum FFmpegExportCtrlID {
 #define FFMPEG_EXPORT_CTRL_ID_FIRST_ENTRY(name, num)  wxT(#name)
 #undef FFMPEG_EXPORT_CTRL_ID_ENTRY
 #define FFMPEG_EXPORT_CTRL_ID_ENTRY(name)             wxT(#name)
-static const wxChar *FFmpegExportCtrlIDNames[] = {
+static const wxString FFmpegExportCtrlIDNames[] = {
    FFMPEG_EXPORT_CTRL_ID_ENTRIES
 };
 
@@ -499,7 +499,7 @@ FFmpegPresets::~FFmpegPresets()
    WriteXML(writer);
 }
 
-void FFmpegPresets::ImportPresets(wxString &filename)
+void FFmpegPresets::ImportPresets(const wxString &filename)
 {
    mPreset = NULL;
    mAbortImport = false;
@@ -513,7 +513,7 @@ void FFmpegPresets::ImportPresets(wxString &filename)
    }
 }
 
-void FFmpegPresets::ExportPresets(wxString &filename)
+void FFmpegPresets::ExportPresets(const wxString &filename)
 {
    XMLFileWriter writer;
    // FIXME: Catch XMLFileWriterException
@@ -545,7 +545,7 @@ void FFmpegPresets::DeletePreset(wxString &name)
    }
 }
 
-FFmpegPreset *FFmpegPresets::FindPreset(wxString &name)
+FFmpegPreset *FFmpegPresets::FindPreset(const wxString &name)
 {
    FFmpegPresetMap::iterator iter = mPresets.find(name);
    if (iter != mPresets.end())
@@ -556,14 +556,14 @@ FFmpegPreset *FFmpegPresets::FindPreset(wxString &name)
    return NULL;
 }
 
-void FFmpegPresets::SavePreset(ExportFFmpegOptions *parent, wxString &name)
+void FFmpegPresets::SavePreset(ExportFFmpegOptions *parent, const wxString &name)
 {
    wxString format;
    wxString codec;
    FFmpegPreset *preset = FindPreset(name);
    if (preset)
    {
-      wxString query = wxString::Format(_("Overwrite preset '%s'?"),name.c_str());
+      wxString query = wxString::Format(_("Overwrite preset '%s'?"), name);
       int action = wxMessageBox(query,_("Confirm Overwrite"),wxYES_NO | wxCENTRE);
       if (action == wxNO) return;
    }
@@ -652,12 +652,12 @@ void FFmpegPresets::SavePreset(ExportFFmpegOptions *parent, wxString &name)
    }
 }
 
-void FFmpegPresets::LoadPreset(ExportFFmpegOptions *parent, wxString &name)
+void FFmpegPresets::LoadPreset(ExportFFmpegOptions *parent, const wxString &name)
 {
    FFmpegPreset *preset = FindPreset(name);
    if (!preset)
    {
-      wxMessageBox(wxString::Format(_("Preset '%s' does not exist."),name.c_str()));
+      wxMessageBox(wxString::Format(_("Preset '%s' does not exist."), name));
       return;
    }
 
@@ -731,7 +731,7 @@ void FFmpegPresets::LoadPreset(ExportFFmpegOptions *parent, wxString &name)
    }
 }
 
-bool FFmpegPresets::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
+bool FFmpegPresets::HandleXMLTag(const wxString &tag, const wxArrayString &attrs)
 {
    if (mAbortImport)
    {
@@ -745,20 +745,17 @@ bool FFmpegPresets::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
 
    if (!wxStrcmp(tag,wxT("preset")))
    {
-      while (*attrs)
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
       {
-         const wxChar *attr = *attrs++;
-         wxString value = *attrs++;
-
-         if (!value)
-            break;
+         const wxString &attr = attrs[2*i];
+         const wxString &value = attrs[2*i+1];
 
          if (!wxStrcmp(attr,wxT("name")))
          {
             mPreset = FindPreset(value);
             if (mPreset)
             {
-               wxString query = wxString::Format(_("Replace preset '%s'?"), value.c_str());
+               wxString query = wxString::Format(_("Replace preset '%s'?"), value);
                int action = wxMessageBox(query, _("Confirm Overwrite"), wxYES_NO | wxCANCEL | wxCENTRE);
                if (action == wxCANCEL)
                {
@@ -785,13 +782,10 @@ bool FFmpegPresets::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    if (!wxStrcmp(tag,wxT("setctrlstate")) && mPreset)
    {
       long id = -1;
-      while (*attrs)
+      for (size_t i = 0; i < attrs.GetCount() / 2; ++i)
       {
-         const wxChar *attr = *attrs++;
-         const wxChar *value = *attrs++;
-
-         if (!value)
-            break;
+         const wxString &attr = attrs[2*i];
+         const wxString &value = attrs[2*i+1];
 
          if (!wxStrcmp(attr,wxT("id")))
          {
@@ -811,7 +805,7 @@ bool FFmpegPresets::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    return false;
 }
 
-XMLTagHandler *FFmpegPresets::HandleXMLChild(const wxChar *tag)
+XMLTagHandler *FFmpegPresets::HandleXMLChild(const wxString &tag)
 {
    if (mAbortImport)
    {
@@ -1173,8 +1167,6 @@ CompatibilityEntry ExportFFmpegOptions::CompatibilityList[] =
    { wxT("wav"), AV_CODEC_ID_FLAC },
    { wxT("wav"), AV_CODEC_ID_ADPCM_SWF },
    { wxT("wav"), AV_CODEC_ID_VORBIS },
-
-   { NULL, AV_CODEC_ID_NONE }
 };
 
 /// AAC profiles
@@ -1186,7 +1178,7 @@ int ExportFFmpegOptions::iAACProfileValues[] = {
 };
 
 /// Names of AAC profiles to be displayed
-const wxChar *ExportFFmpegOptions::iAACProfileNames[] = {
+const wxString ExportFFmpegOptions::iAACProfileNames[] = {
    _("LC"),
    _("Main"),
    /*_("SSR"),*/ //SSR is not supported
@@ -1292,7 +1284,7 @@ ApplicableFor ExportFFmpegOptions::apptable[] =
 };
 
 /// Prediction order method - names. Labels are indices of this array.
-const wxChar *ExportFFmpegOptions::PredictionOrderMethodNames[] = { _("Estimate"), _("2-level"), _("4-level"), _("8-level"), _("Full search"), _("Log search")};
+const wxString ExportFFmpegOptions::PredictionOrderMethodNames[] = { _("Estimate"), _("2-level"), _("4-level"), _("8-level"), _("Full search"), _("Log search")};
 
 
 ExportFFmpegOptions::~ExportFFmpegOptions()
@@ -1358,7 +1350,7 @@ void ExportFFmpegOptions::FetchFormatList()
       if (ofmt->audio_codec != AV_CODEC_ID_NONE)
       {
          mFormatNames.Add(wxString::FromUTF8(ofmt->name));
-         mFormatLongNames.Add(wxString::Format(wxT("%s - %s"),mFormatNames.Last().c_str(),wxString::FromUTF8(ofmt->long_name).c_str()));
+         mFormatLongNames.Add(wxString::Format(wxT("%s - %s"), mFormatNames.Last(), wxString::FromUTF8(ofmt->long_name)));
       }
    }
    // Show all formats
@@ -1378,7 +1370,7 @@ void ExportFFmpegOptions::FetchCodecList()
       if (codec->type == AVMEDIA_TYPE_AUDIO && av_codec_is_encoder(codec))
       {
          mCodecNames.Add(wxString::FromUTF8(codec->name));
-         mCodecLongNames.Add(wxString::Format(wxT("%s - %s"),mCodecNames.Last().c_str(),wxString::FromUTF8(codec->long_name).c_str()));
+         mCodecLongNames.Add(wxString::Format(wxT("%s - %s"), mCodecNames.Last(), wxString::FromUTF8(codec->long_name)));
       }
    }
    // Show all codecs
@@ -1561,7 +1553,7 @@ void ExportFFmpegOptions::FindSelectedFormat(wxString **name, wxString **longnam
    wxString selfmt = mFormatList->GetString(selections[0]);
 
    // Find it's index
-   int nFormat = mFormatNames.Index(selfmt.c_str());
+   int nFormat = mFormatNames.Index(selfmt);
    if (nFormat == wxNOT_FOUND) return;
 
    // Return short name and description
@@ -1582,7 +1574,7 @@ void ExportFFmpegOptions::FindSelectedCodec(wxString **name, wxString **longname
    wxString selcdc = mCodecList->GetString(selections[0]);
 
    // Find it's index
-   int nCodec = mCodecNames.Index(selcdc.c_str());
+   int nCodec = mCodecNames.Index(selcdc);
    if (nCodec == wxNOT_FOUND) return;
 
    // Return short name and description
@@ -1592,7 +1584,7 @@ void ExportFFmpegOptions::FindSelectedCodec(wxString **name, wxString **longname
 
 ///
 ///
-int ExportFFmpegOptions::FetchCompatibleCodecList(const wxChar *fmt, AVCodecID id)
+int ExportFFmpegOptions::FetchCompatibleCodecList(const wxString &fmt, AVCodecID id)
 {
    // By default assume that id is not in the list
    int index = -1;
@@ -1604,7 +1596,7 @@ int ExportFFmpegOptions::FetchCompatibleCodecList(const wxChar *fmt, AVCodecID i
    // Zero - format is not found at all
    int found = 0;
    wxString str(fmt);
-   for (int i = 0; CompatibilityList[i].fmt != NULL; i++)
+   for (size_t i = 0; i < WXSIZEOF(CompatibilityList); ++i)
    {
       if (str.Cmp(CompatibilityList[i].fmt) == 0)
       {
@@ -1624,7 +1616,7 @@ int ExportFFmpegOptions::FetchCompatibleCodecList(const wxChar *fmt, AVCodecID i
             // If it was selected - remember it's NEW index
             if ((id >= 0) && codec->id == id) index = mShownCodecNames.GetCount();
             mShownCodecNames.Add(wxString::FromUTF8(codec->name));
-            mShownCodecLongNames.Add(wxString::Format(wxT("%s - %s"),mShownCodecNames.Last().c_str(),wxString::FromUTF8(codec->long_name).c_str()));
+            mShownCodecLongNames.Add(wxString::Format(wxT("%s - %s"), mShownCodecNames.Last(), wxString::FromUTF8(codec->long_name)));
          }
       }
    }
@@ -1640,7 +1632,7 @@ int ExportFFmpegOptions::FetchCompatibleCodecList(const wxChar *fmt, AVCodecID i
             {
                if ((id >= 0) && codec->id == id) index = mShownCodecNames.GetCount();
                mShownCodecNames.Add(wxString::FromUTF8(codec->name));
-               mShownCodecLongNames.Add(wxString::Format(wxT("%s - %s"),mShownCodecNames.Last().c_str(),wxString::FromUTF8(codec->long_name).c_str()));
+               mShownCodecLongNames.Add(wxString::Format(wxT("%s - %s"), mShownCodecNames.Last(), wxString::FromUTF8(codec->long_name)));
             }
          }
       }
@@ -1649,7 +1641,7 @@ int ExportFFmpegOptions::FetchCompatibleCodecList(const wxChar *fmt, AVCodecID i
    // This allows us to provide limited support for NEW formats without modifying the compatibility list
    else if (found == 0)
    {
-      wxCharBuffer buf = str.ToUTF8();
+      wxScopedCharBuffer buf = str.utf8_str();
       AVOutputFormat *format = av_guess_format(buf,NULL,NULL);
       if (format != NULL)
       {
@@ -1658,7 +1650,7 @@ int ExportFFmpegOptions::FetchCompatibleCodecList(const wxChar *fmt, AVCodecID i
          {
             if ((id >= 0) && codec->id == id) index = mShownCodecNames.GetCount();
             mShownCodecNames.Add(wxString::FromUTF8(codec->name));
-            mShownCodecLongNames.Add(wxString::Format(wxT("%s - %s"),mShownCodecNames.Last().c_str(),wxString::FromUTF8(codec->long_name).c_str()));
+            mShownCodecLongNames.Add(wxString::Format(wxT("%s - %s"),mShownCodecNames.Last(), wxString::FromUTF8(codec->long_name)));
          }
       }
    }
@@ -1680,7 +1672,7 @@ int ExportFFmpegOptions::FetchCompatibleFormatList(AVCodecID id, wxString *selfm
    ofmt = NULL;
    wxArrayString FromList;
    // Find all formats compatible to this codec in compatibility list
-   for (int i = 0; CompatibilityList[i].fmt != NULL; i++)
+   for (size_t i = 0; i < WXSIZEOF(CompatibilityList); ++i)
    {
       if (CompatibilityList[i].codec == id || CompatibilityList[i].codec == AV_CODEC_ID_NONE)
       {
@@ -1688,13 +1680,13 @@ int ExportFFmpegOptions::FetchCompatibleFormatList(AVCodecID id, wxString *selfm
          FromList.Add(CompatibilityList[i].fmt);
          mShownFormatNames.Add(CompatibilityList[i].fmt);
          AVOutputFormat *tofmt = av_guess_format(wxString(CompatibilityList[i].fmt).ToUTF8(),NULL,NULL);
-         if (tofmt != NULL) mShownFormatLongNames.Add(wxString::Format(wxT("%s - %s"),CompatibilityList[i].fmt,wxString::FromUTF8(tofmt->long_name).c_str()));
+         if (tofmt != NULL) mShownFormatLongNames.Add(wxString::Format(wxT("%s - %s"), CompatibilityList[i].fmt, wxString::FromUTF8(tofmt->long_name)));
       }
    }
    bool found = false;
    if (selfmt != NULL)
    {
-      for (int i = 0; CompatibilityList[i].fmt != NULL; i++)
+      for (size_t i = 0; i < WXSIZEOF(CompatibilityList); ++i)
       {
          if (!selfmt->Cmp(CompatibilityList[i].fmt))
          {
@@ -1725,7 +1717,7 @@ int ExportFFmpegOptions::FetchCompatibleFormatList(AVCodecID id, wxString *selfm
             {
                if ((selfmt != NULL) && (selfmt->Cmp(wxString::FromUTF8(ofmt->name)) == 0)) index = mShownFormatNames.GetCount();
                mShownFormatNames.Add(wxString::FromUTF8(ofmt->name));
-               mShownFormatLongNames.Add(wxString::Format(wxT("%s - %s"),mShownFormatNames.Last().c_str(),wxString::FromUTF8(ofmt->long_name).c_str()));
+               mShownFormatLongNames.Add(wxString::Format(wxT("%s - %s"), mShownFormatNames.Last(), wxString::FromUTF8(ofmt->long_name)));
             }
          }
       }
@@ -1746,7 +1738,7 @@ void ExportFFmpegOptions::OnDeletePreset(wxCommandEvent& WXUNUSED(event))
       return;
    }
 
-   wxString query = wxString::Format(_("Delete preset '%s'?"),presetname.c_str());
+   wxString query = wxString::Format(_("Delete preset '%s'?"), presetname);
    int action = wxMessageBox(query,_("Confirm Deletion"),wxYES_NO | wxCENTRE);
    if (action == wxNO) return;
 
@@ -1769,7 +1761,7 @@ void ExportFFmpegOptions::OnSavePreset(wxCommandEvent& WXUNUSED(event))
       return;
    }
    mPresets->SavePreset(this,name);
-   int index = mPresetNames->Index(name.c_str(),false);
+   int index = mPresetNames->Index(name, false);
    if (index == -1)
    {
       mPresetNames->Add(name);
@@ -1902,7 +1894,7 @@ void ExportFFmpegOptions::DoOnFormatList()
       mFormatName->SetLabel(wxString(_("Failed to guess format")));
       return;
    }
-   mFormatName->SetLabel(wxString::Format(wxT("%s"),selfmtlong->c_str()));
+   mFormatName->SetLabel(wxString::Format(wxT("%s"), selfmtlong));
    int selcdcid = -1;
 
    if (selcdc != NULL)
@@ -1913,7 +1905,7 @@ void ExportFFmpegOptions::DoOnFormatList()
          selcdcid = cdc->id;
       }
    }
-   int newselcdc = FetchCompatibleCodecList(selfmt->c_str(), (AVCodecID)selcdcid);
+   int newselcdc = FetchCompatibleCodecList(*selfmt, (AVCodecID)selcdcid);
    if (newselcdc >= 0) mCodecList->Select(newselcdc);
 
    AVCodec *cdc = NULL;
@@ -1946,7 +1938,7 @@ void ExportFFmpegOptions::DoOnCodecList()
       mCodecName->SetLabel(wxString(_("Failed to find the codec")));
       return;
    }
-   mCodecName->SetLabel(wxString::Format(wxT("[%d] %s"), (int) cdc->id,selcdclong->c_str()));
+   mCodecName->SetLabel(wxString::Format(wxT("[%d] %s"), static_cast<int>(cdc->id), selcdclong));
 
    if (selfmt != NULL)
    {

--- a/src/export/ExportFFmpegDialogs.h
+++ b/src/export/ExportFFmpegDialogs.h
@@ -37,13 +37,13 @@ enum FFmpegExposedFormat
 struct ExposedFormat
 {
    FFmpegExposedFormat fmtid; //!< one of the FFmpegExposedFormat
-   const wxChar *name;        //!< format name (internal, should be unique; if not - export dialog may show unusual behaviour)
-   const wxChar *extension;   //!< default extension for this format. More extensions may be added later via AddExtension.
-   const wxChar *shortname;   //!< used to guess the format
+   wxString name;        //!< format name (internal, should be unique; if not - export dialog may show unusual behaviour)
+   wxString extension;   //!< default extension for this format. More extensions may be added later via AddExtension.
+   wxString shortname;   //!< used to guess the format
    int maxchannels;           //!< how much channels this format could handle
    int canmetadata;           //!< !=0 if format supports metadata, -1 any avformat version, otherwise version support added
    bool canutf8;              //!< true if format supports metadata in UTF-8, false otherwise
-   const wxChar *description; //!< format description (will be shown in export dialog)
+   wxString description; //!< format description (will be shown in export dialog)
    AVCodecID codecid;         //!< codec ID (see libavcodec/avcodec.h)
    bool compiledIn;           //!< support for this codec/format is compiled in (checked at runtime)
 };
@@ -52,7 +52,7 @@ struct ExposedFormat
 /// Describes format-codec compatibility
 struct CompatibilityEntry
 {
-   const wxChar *fmt; //!< format, recognizeable by guess_format()
+   wxString fmt; //!< format, recognizeable by guess_format()
    AVCodecID codec;   //!< codec ID
 };
 
@@ -198,11 +198,11 @@ public:
    // Static tables
    static CompatibilityEntry CompatibilityList[];
    static int iAACProfileValues[];
-   static const wxChar *iAACProfileNames[];
+   static const wxString iAACProfileNames[];
    static ExposedFormat fmts[];
    static const int iAACSampleRates[];
    static ApplicableFor apptable[];
-   static const wxChar *PredictionOrderMethodNames[];
+   static const wxString PredictionOrderMethodNames[];
 
 private:
 
@@ -287,7 +287,7 @@ private:
    ///\param fmt Format short name
    ///\param id id of the codec selected at the moment
    ///\return index of the id in NEW codec list or -1 if it is not in the list
-   int FetchCompatibleCodecList(const wxChar *fmt, AVCodecID id);
+   int FetchCompatibleCodecList(const wxString &fmt, AVCodecID id);
 
    /// Retreives list of presets from configuration file
    void FetchPresetList();
@@ -324,16 +324,16 @@ public:
    ~FFmpegPresets();
 
    wxArrayString *GetPresetList();
-   void LoadPreset(ExportFFmpegOptions *parent, wxString &name);
-   void SavePreset(ExportFFmpegOptions *parent, wxString &name);
+   void LoadPreset(ExportFFmpegOptions *parent, const wxString &name);
+   void SavePreset(ExportFFmpegOptions *parent, const wxString &name);
    void DeletePreset(wxString &name);
-   FFmpegPreset *FindPreset(wxString &name);
+   FFmpegPreset *FindPreset(const wxString &name);
 
-   void ImportPresets(wxString &filename);
-   void ExportPresets(wxString &filename);
+   void ImportPresets(const wxString &filename);
+   void ExportPresets(const wxString &filename);
 
-   bool HandleXMLTag(const wxChar *tag, const wxChar **attrs);
-   XMLTagHandler *HandleXMLChild(const wxChar *tag);
+   bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs);
+   XMLTagHandler *HandleXMLChild(const wxString &tag);
    void WriteXMLHeader(XMLWriter &xmlFile);
    void WriteXML(XMLWriter &xmlFile);
 

--- a/src/export/ExportFLAC.cpp
+++ b/src/export/ExportFLAC.cpp
@@ -291,7 +291,7 @@ int ExportFLAC::Export(AudacityProject *project,
 #else
    wxFFile f;     // will be closed when it goes out of scope
    if (!f.Open(fName, wxT("w+b"))) {
-      wxMessageBox(wxString::Format(_("FLAC export couldn't open %s"), fName.c_str()));
+      wxMessageBox(wxString::Format(_("FLAC export couldn't open %s"), fName));
       return false;
    }
 
@@ -395,8 +395,8 @@ bool ExportFLAC::GetMetadata(AudacityProject *project, const Tags *tags)
       if (n == TAG_YEAR) {
          n = wxT("DATE");
       }
-      FLAC::Metadata::VorbisComment::Entry entry(n.mb_str(wxConvUTF8),
-                                                 v.mb_str(wxConvUTF8));
+      FLAC::Metadata::VorbisComment::Entry entry(n.utf8_str(),
+                                                 v.utf8_str());
       ::FLAC__metadata_object_vorbiscomment_append_comment(mMetadata,
                                                            entry.get_entry(),
                                                            true);

--- a/src/export/ExportMP2.cpp
+++ b/src/export/ExportMP2.cpp
@@ -415,7 +415,7 @@ void ExportMP2::AddFrame(struct id3_tag *tp, const wxString & n, const wxString 
    }
 
    id3_ucs4_t *ucs4 =
-      id3_utf8_ucs4duplicate((id3_utf8_t *) (const char *) v.mb_str(wxConvUTF8));
+      id3_utf8_ucs4duplicate(reinterpret_cast<const id3_utf8_t *>(static_cast<const char *>(v.utf8_str())));
 
    if (strcmp(name, ID3_FRAME_COMMENT) == 0) {
       // A hack to get around iTunes not recognizing the comment.  The
@@ -431,7 +431,7 @@ void ExportMP2::AddFrame(struct id3_tag *tp, const wxString & n, const wxString 
       id3_field_setstring(id3_frame_field(frame, 2), ucs4);
       free(ucs4);
 
-      ucs4 = id3_utf8_ucs4duplicate((id3_utf8_t *) (const char *) n.mb_str(wxConvUTF8));
+      ucs4 = id3_utf8_ucs4duplicate(reinterpret_cast<const id3_utf8_t *>(static_cast<const char *>(n.utf8_str())));
 
       id3_field_setstring(id3_frame_field(frame, 1), ucs4);
    }

--- a/src/export/ExportMP3.cpp
+++ b/src/export/ExportMP3.cpp
@@ -586,13 +586,13 @@ public:
       S.SetBorder(10);
       S.StartVerticalLay(true);
       {
-         text.Printf(_("Audacity needs the file %s to create MP3s."), mName.c_str());
+         text.Printf(_("Audacity needs the file %s to create MP3s."), mName);
          S.AddTitle(text);
 
          S.SetBorder(3);
          S.StartHorizontalLay(wxALIGN_LEFT, true);
          {
-            text.Printf(_("Location of %s:"), mName.c_str());
+            text.Printf(_("Location of %s:"), mName);
             S.AddTitle(text);
          }
          S.EndHorizontalLay();
@@ -602,7 +602,7 @@ public:
          {
             if (mLibPath.GetFullPath().IsEmpty()) {
                /* i18n-hint: There is a  button to the right of the arrow.*/
-               text.Printf(_("To find %s, click here -->"), mName.c_str());
+               text.Printf(_("To find %s, click here -->"), mName);
                mPathText = S.AddTextBox(wxT(""), text, 0);
             }
             else {
@@ -634,7 +634,7 @@ public:
       /* i18n-hint: It's asking for the location of a file, for
        * example, "Where is lame_enc.dll?" - you could translate
        * "Where would I find the file %s" instead if you want. */
-      question.Printf(_("Where is %s?"), mName.c_str());
+      question.Printf(_("Where is %s?"), mName);
 
       wxString path = FileSelector(question,
                                    mLibPath.GetPath(),
@@ -1045,7 +1045,7 @@ void MP3Exporter::SetChannel(int mode)
 
 bool MP3Exporter::InitLibrary(wxString libpath)
 {
-   wxLogMessage(wxT("Loading LAME from %s"), libpath.c_str());
+   wxLogMessage(wxT("Loading LAME from %s"), libpath);
 
 #ifndef DISABLE_DYNAMIC_LOADING_LAME
    if (!lame_lib.Load(libpath, wxDL_LAZY)) {
@@ -1054,7 +1054,7 @@ bool MP3Exporter::InitLibrary(wxString libpath)
    }
 
    wxLogMessage(wxT("Actual LAME path %s"),
-              FileNames::PathFromAddr(lame_lib.GetSymbol(wxT("lame_init"))).c_str());
+              FileNames::PathFromAddr(lame_lib.GetSymbol(wxT("lame_init"))));
 
    lame_init = (lame_init_t *)
       lame_lib.GetSymbol(wxT("lame_init"));
@@ -1777,13 +1777,13 @@ int ExportMP3::Export(AudacityProject *project,
       title.Printf(selectionOnly ?
                    _("Exporting selected audio with %s preset") :
                    _("Exporting entire file with %s preset"),
-                   FindName(setRates, WXSIZEOF(setRates), brate).c_str());
+                   FindName(setRates, WXSIZEOF(setRates), brate));
    }
    else if (rmode == MODE_VBR) {
       title.Printf(selectionOnly ?
                    _("Exporting selected audio with VBR quality %s") :
                    _("Exporting entire file with VBR quality %s"),
-                   FindName(varRates, WXSIZEOF(varRates), brate).c_str());
+                   FindName(varRates, WXSIZEOF(varRates), brate));
    }
    else {
       title.Printf(selectionOnly ?
@@ -2041,7 +2041,7 @@ void ExportMP3::AddFrame(struct id3_tag *tp, const wxString & n, const wxString 
    }
 
    id3_ucs4_t *ucs4 =
-      id3_utf8_ucs4duplicate((id3_utf8_t *) (const char *) v.mb_str(wxConvUTF8));
+      id3_utf8_ucs4duplicate(reinterpret_cast<const id3_utf8_t *>(static_cast<const char *>(v.utf8_str())));
 
    if (strcmp(name, ID3_FRAME_COMMENT) == 0) {
       // A hack to get around iTunes not recognizing the comment.  The
@@ -2061,7 +2061,7 @@ void ExportMP3::AddFrame(struct id3_tag *tp, const wxString & n, const wxString 
       id3_field_setstring(id3_frame_field(frame, 2), ucs4);
       free(ucs4);
 
-      ucs4 = id3_utf8_ucs4duplicate((id3_utf8_t *) (const char *) n.mb_str(wxConvUTF8));
+      ucs4 = id3_utf8_ucs4duplicate(reinterpret_cast<const id3_utf8_t *>(static_cast<const char *>(n.utf8_str())));
 
       id3_field_setstring(id3_frame_field(frame, 1), ucs4);
    }

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -462,7 +462,7 @@ void ExportMultiple::OnCreate(wxCommandEvent& WXUNUSED(event))
    }
 
    ::wxMessageBox(wxString::Format(_("\"%s\" successfully created."),
-                                   fn.GetPath().c_str()),
+                                   fn.GetPath()),
                   _("Export Multiple"),
                   wxOK | wxCENTRE, this);
 }
@@ -606,7 +606,7 @@ bool ExportMultiple::DirOk()
    wxString prompt;
 
    prompt.Printf(_("\"%s\" doesn't exist.\n\nWould you like to create it?"),
-                 fn.GetFullPath().c_str());
+                 fn.GetFullPath());
 
    int action = wxMessageBox(prompt,
                              wxT("Warning"),
@@ -644,7 +644,7 @@ int ExportMultiple::ExportMultipleByLabel(bool byName,
    setting.destfile.SetPath(mDir->GetValue());
    setting.destfile.SetExt(mPlugins[mPluginIndex]->GetExtension(mSubFormatIndex));
    wxLogDebug(wxT("Plug-in index = %d, Sub-format = %d"), mPluginIndex, mSubFormatIndex);
-   wxLogDebug(wxT("File extension is %s"), setting.destfile.GetExt().c_str());
+   wxLogDebug(wxT("File extension is %s"), setting.destfile.GetExt());
    wxString name;    // used to hold file name whilst we mess with it
    wxString title;   // un-messed-with title of file for tagging with
 
@@ -686,7 +686,7 @@ int ExportMultiple::ExportMultipleByLabel(bool byName,
 
       // Numbering files...
       if (!byName) {
-         name.Printf(wxT("%s-%02d"), prefix.c_str(), l+1);
+         name.Printf(wxT("%s-%02d"), prefix, l+1);
       } else if (addNumber) {
          // Following discussion with GA, always have 2 digits
          // for easy file-name sorting (on Windows)
@@ -823,7 +823,7 @@ int ExportMultiple::ExportMultipleByTrack(bool byName,
          }
       }
       else {
-         name = (wxString::Format(wxT("%s-%02d"), prefix.c_str(), l+1));
+         name = wxString::Format(wxT("%s-%02d"), prefix, l+1);
       }
 
       // store sanitised and user checked name in object
@@ -913,7 +913,7 @@ int ExportMultiple::DoExport(int channels,
                               double t1,
                               const Tags &tags)
 {
-   wxLogDebug(wxT("Doing multiple Export: File name \"%s\""), (name.GetFullName()).c_str());
+   wxLogDebug(wxT("Doing multiple Export: File name \"%s\""), (name.GetFullName()));
    wxLogDebug(wxT("Channels: %i, Start: %lf, End: %lf "), channels, t0, t1);
    if (selectedOnly) wxLogDebug(wxT("Selected Region Only"));
    else wxLogDebug(wxT("Whole Project"));
@@ -928,7 +928,7 @@ int ExportMultiple::DoExport(int channels,
       int i = 2;
       wxString base(name.GetName());
       while (name.FileExists()) {
-         name.SetName(wxString::Format(wxT("%s-%d"), base.c_str(), i++));
+         name.SetName(wxString::Format(wxT("%s-%d"), base, i++));
       }
    }
 
@@ -964,7 +964,7 @@ wxString ExportMultiple::MakeFileName(const wxString &input)
    {  // need to get user to fix file name
       // build the dialog
       wxString msg;
-      msg.Printf(_("Label or track \"%s\" is not a legal file name. You cannot use any of: %s\nUse..."), input.c_str(), wxFileName::GetForbiddenChars().c_str());
+      msg.Printf(_("Label or track \"%s\" is not a legal file name. You cannot use any of: %s\nUse..."), input, wxFileName::GetForbiddenChars());
       wxTextEntryDialog dlg( this, msg, _("Save As..."), newname );
 
       // And tell the validator about excluded chars

--- a/src/export/ExportOGG.cpp
+++ b/src/export/ExportOGG.cpp
@@ -356,9 +356,7 @@ bool ExportOGG::FillComment(AudacityProject *project, vorbis_comment *comment, c
       if (n == TAG_YEAR) {
          n = wxT("DATE");
       }
-      vorbis_comment_add_tag(comment,
-                             (char *) (const char *) n.mb_str(wxConvUTF8),
-                             (char *) (const char *) v.mb_str(wxConvUTF8));
+      vorbis_comment_add_tag(comment, n.utf8_str(), v.utf8_str());
    }
 
    return true;

--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -380,7 +380,7 @@ int Importer::Import(const wxString &fName,
    bool usersSelectionOverrides;
    gPrefs->Read(wxT("/ExtendedImport/OverrideExtendedImportByOpenFileDialogChoice"), &usersSelectionOverrides, false);
 
-   wxLogDebug(wxT("LastOpenType is %s"),type.c_str());
+   wxLogDebug(wxT("LastOpenType is %s"),type);
    wxLogDebug(wxT("OverrideExtendedImportByOpenFileDialogChoice is %i"),usersSelectionOverrides);
 
    if (usersSelectionOverrides)
@@ -389,18 +389,18 @@ int Importer::Import(const wxString &fName,
       while (importPluginNode)
       {
          ImportPlugin *plugin = importPluginNode->GetData();
-         if (plugin->GetPluginFormatDescription().CompareTo(type) == 0)
+         if (plugin->GetPluginFormatDescription().Cmp(type) == 0)
          {
             // This plugin corresponds to user-selected filter, try it first.
-            wxLogDebug(wxT("Inserting %s"),plugin->GetPluginStringID().c_str());
+            wxLogDebug(wxT("Inserting %s"), plugin->GetPluginStringID());
             importPlugins.Insert(plugin);
          }
          importPluginNode = importPluginNode->GetNext();
       }
    }
 
-   wxLogMessage(wxT("File name is %s"),(const char *) fName.c_str());
-   wxLogMessage(wxT("Mime type is %s"),(const char *) mime_type.Lower().c_str());
+   wxLogMessage(wxT("File name is %s"), fName);
+   wxLogMessage(wxT("Mime type is %s"), mime_type.Lower());
 
    for (size_t i = 0; i < mExtImportItems->Count(); i++)
    {
@@ -409,7 +409,7 @@ int Importer::Import(const wxString &fName,
       wxLogDebug(wxT("Testing extensions"));
       for (size_t j = 0; j < item->extensions.Count(); j++)
       {
-         wxLogDebug(wxT("%s"), (const char *) item->extensions[j].Lower().c_str());
+         wxLogDebug(wxT("%s"), item->extensions[j].Lower());
          if (wxMatchWild (item->extensions[j].Lower(),fName.Lower(), false))
          {
             wxLogDebug(wxT("Match!"));
@@ -450,7 +450,7 @@ int Importer::Import(const wxString &fName,
             // is still ffmpeg in prefs from previous --with-ffmpeg builds
             if (!(item->filter_objects[j]))
                continue;
-            wxLogDebug(wxT("Inserting %s"),item->filter_objects[j]->GetPluginStringID().c_str());
+            wxLogDebug(wxT("Inserting %s"),item->filter_objects[j]->GetPluginStringID());
             importPlugins.Append(item->filter_objects[j]);
          }
       }
@@ -472,7 +472,7 @@ int Importer::Import(const wxString &fName,
    {
       ImportPlugin *plugin = importPluginNode->GetData();
       // Make sure its not already in the list
-      if (importPlugins.Find(plugin) == NULL)
+      if (importPlugins.Find(plugin) == 0)
       {
          if (plugin->SupportsExtension(extension))
          {
@@ -487,13 +487,13 @@ int Importer::Import(const wxString &fName,
             if (plugin->GetPluginStringID().IsSameAs(wxT("libmad")))
             {
                // Make sure libsndfile is not already in the list
-               if (importPlugins.Find(libsndfilePlugin) == NULL)
+               if (importPlugins.Find(libsndfilePlugin) == 0)
                {
-                  wxLogDebug(wxT("Appending %s"),libsndfilePlugin->GetPluginStringID().c_str());
+                  wxLogDebug(wxT("Appending %s"),libsndfilePlugin->GetPluginStringID());
                   importPlugins.Append(libsndfilePlugin);
                }
             }
-            wxLogDebug(wxT("Appending %s"),plugin->GetPluginStringID().c_str());
+            wxLogDebug(wxT("Appending %s"),plugin->GetPluginStringID());
             importPlugins.Append(plugin);
          }
       }
@@ -512,9 +512,9 @@ int Importer::Import(const wxString &fName,
       if (!(plugin->GetPluginStringID().IsSameAs(wxT("libmad"))))
       {
          // Make sure its not already in the list
-         if (importPlugins.Find(plugin) == NULL)
+         if (importPlugins.Find(plugin) == 0)
          {
-            wxLogDebug(wxT("Appending %s"),plugin->GetPluginStringID().c_str());
+            wxLogDebug(wxT("Appending %s"),plugin->GetPluginStringID());
             importPlugins.Append(plugin);
          }
       }
@@ -527,11 +527,11 @@ int Importer::Import(const wxString &fName,
    {
       ImportPlugin *plugin = importPluginNode->GetData();
       // Try to open the file with this plugin (probe it)
-      wxLogMessage(wxT("Opening with %s"),plugin->GetPluginStringID().c_str());
+      wxLogMessage(wxT("Opening with %s"),plugin->GetPluginStringID());
       inFile = plugin->Open(fName);
       if ( (inFile != NULL) && (inFile->GetStreamCount() > 0) )
       {
-         wxLogMessage(wxT("Open(%s) succeeded"),(const char *) fName.c_str());
+         wxLogMessage(wxT("Open(%s) succeeded"), fName);
          // File has more than one stream - display stream selector
          if (inFile->GetStreamCount() > 1)
          {
@@ -598,7 +598,7 @@ int Importer::Import(const wxString &fName,
       {
          errorMessage.Printf(_("This version of Audacity was not compiled with %s support."),
                              unusableImportPlugin->
-                             GetPluginFormatDescription().c_str());
+                             GetPluginFormatDescription());
          pProj->mbBusyImporting = false;
          return 0;
       }
@@ -610,7 +610,7 @@ int Importer::Import(const wxString &fName,
 #ifdef USE_MIDI
    // MIDI files must be imported, not opened
    if ((extension.IsSameAs(wxT("midi"), false))||(extension.IsSameAs(wxT("mid"), false))) {
-      errorMessage.Printf(_("\"%s\" \nis a MIDI file, not an audio file. \nAudacity cannot open this type of file for playing, but you can\nedit it by clicking File > Import > MIDI."), fName.c_str());
+      errorMessage.Printf(_("\"%s\" \nis a MIDI file, not an audio file. \nAudacity cannot open this type of file for playing, but you can\nedit it by clicking File > Import > MIDI."), fName);
       pProj->mbBusyImporting = false;
       return 0;
    }
@@ -621,93 +621,93 @@ int Importer::Import(const wxString &fName,
       // if someone has sent us a .cda file, send them away
       if (extension.IsSameAs(wxT("cda"), false)) {
          /* i18n-hint: %s will be the filename */
-         errorMessage.Printf(_("\"%s\" is an audio CD track. \nAudacity cannot open audio CDs directly. \nExtract (rip) the CD tracks to an audio format that \nAudacity can import, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is an audio CD track. \nAudacity cannot open audio CDs directly. \nExtract (rip) the CD tracks to an audio format that \nAudacity can import, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // playlist type files
       if ((extension.IsSameAs(wxT("m3u"), false))||(extension.IsSameAs(wxT("ram"), false))||(extension.IsSameAs(wxT("pls"), false))) {
-         errorMessage.Printf(_("\"%s\" is a playlist file. \nAudacity cannot open this file because it only contains links to other files. \nYou may be able to open it in a text editor and download the actual audio files."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is a playlist file. \nAudacity cannot open this file because it only contains links to other files. \nYou may be able to open it in a text editor and download the actual audio files."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
       //WMA files of various forms
       if ((extension.IsSameAs(wxT("wma"), false))||(extension.IsSameAs(wxT("asf"), false))) {
-         errorMessage.Printf(_("\"%s\" is a Windows Media Audio file. \nAudacity cannot open this type of file due to patent restrictions. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is a Windows Media Audio file. \nAudacity cannot open this type of file due to patent restrictions. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
       //AAC files of various forms (probably not encrypted)
       if ((extension.IsSameAs(wxT("aac"), false))||(extension.IsSameAs(wxT("m4a"), false))||(extension.IsSameAs(wxT("m4r"), false))||(extension.IsSameAs(wxT("mp4"), false))) {
-         errorMessage.Printf(_("\"%s\" is an Advanced Audio Coding file. \nAudacity cannot open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is an Advanced Audio Coding file. \nAudacity cannot open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
       // encrypted itunes files
       if ((extension.IsSameAs(wxT("m4p"), false))) {
-         errorMessage.Printf(_("\"%s\" is an encrypted audio file. \nThese typically are from an online music store. \nAudacity cannot open this type of file due to the encryption. \nTry recording the file into Audacity, or burn it to audio CD then \nextract the CD track to a supported audio format such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is an encrypted audio file. \nThese typically are from an online music store. \nAudacity cannot open this type of file due to the encryption. \nTry recording the file into Audacity, or burn it to audio CD then \nextract the CD track to a supported audio format such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
       // Real Inc. files of various sorts
       if ((extension.IsSameAs(wxT("ra"), false))||(extension.IsSameAs(wxT("rm"), false))||(extension.IsSameAs(wxT("rpm"), false))) {
-         errorMessage.Printf(_("\"%s\" is a RealPlayer media file. \nAudacity cannot open this proprietary format. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is a RealPlayer media file. \nAudacity cannot open this proprietary format. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // Other notes-based formats
       if ((extension.IsSameAs(wxT("kar"), false))||(extension.IsSameAs(wxT("mod"), false))||(extension.IsSameAs(wxT("rmi"), false))) {
-         errorMessage.Printf(_("\"%s\" is a notes-based file, not an audio file. \nAudacity cannot open this type of file. \nTry converting it to an audio file such as WAV or AIFF and \nthen import it, or record it into Audacity."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is a notes-based file, not an audio file. \nAudacity cannot open this type of file. \nTry converting it to an audio file such as WAV or AIFF and \nthen import it, or record it into Audacity."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // MusePack files
       if ((extension.IsSameAs(wxT("mp+"), false))||(extension.IsSameAs(wxT("mpc"), false))||(extension.IsSameAs(wxT("mpp"), false))) {
-         errorMessage.Printf(_("\"%s\" is a Musepack audio file. \nAudacity cannot open this type of file. \nIf you think it might be an mp3 file, rename it to end with \".mp3\" \nand try importing it again. Otherwise you need to convert it to a supported audio \nformat, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is a Musepack audio file. \nAudacity cannot open this type of file. \nIf you think it might be an mp3 file, rename it to end with \".mp3\" \nand try importing it again. Otherwise you need to convert it to a supported audio \nformat, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // WavPack files
       if ((extension.IsSameAs(wxT("wv"), false))||(extension.IsSameAs(wxT("wvc"), false))) {
-         errorMessage.Printf(_("\"%s\" is a Wavpack audio file. \nAudacity cannot open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is a Wavpack audio file. \nAudacity cannot open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // AC3 files
       if ((extension.IsSameAs(wxT("ac3"), false))) {
-         errorMessage.Printf(_("\"%s\" is a Dolby Digital audio file. \nAudacity cannot currently open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is a Dolby Digital audio file. \nAudacity cannot currently open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // Speex files
       if ((extension.IsSameAs(wxT("spx"), false))) {
-         errorMessage.Printf(_("\"%s\" is an Ogg Speex audio file. \nAudacity cannot currently open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is an Ogg Speex audio file. \nAudacity cannot currently open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // Video files of various forms
       if ((extension.IsSameAs(wxT("mpg"), false))||(extension.IsSameAs(wxT("mpeg"), false))||(extension.IsSameAs(wxT("avi"), false))||(extension.IsSameAs(wxT("wmv"), false))||(extension.IsSameAs(wxT("rv"), false))) {
-         errorMessage.Printf(_("\"%s\" is a video file. \nAudacity cannot currently open this type of file. \nYou need to extract the audio to a supported format, such as WAV or AIFF."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is a video file. \nAudacity cannot currently open this type of file. \nYou need to extract the audio to a supported format, such as WAV or AIFF."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // Audacity project
       if (extension.IsSameAs(wxT("aup"), false)) {
-         errorMessage.Printf(_("\"%s\" is an Audacity Project file. \nUse the 'File > Open' command to open Audacity Projects."), fName.c_str());
+         errorMessage.Printf(_("\"%s\" is an Audacity Project file. \nUse the 'File > Open' command to open Audacity Projects."), fName);
          pProj->mbBusyImporting = false;
          return 0;
       }
 
       // we were not able to recognize the file type
-      errorMessage.Printf(_("Audacity did not recognize the type of the file '%s'.\nIf it is uncompressed, try importing it using \"Import Raw\"."),fName.c_str());
+      errorMessage.Printf(_("Audacity did not recognize the type of the file '%s'.\nIf it is uncompressed, try importing it using \"Import Raw\"."),fName);
    }
    else
    {
@@ -725,7 +725,7 @@ int Importer::Import(const wxString &fName,
          importPluginNode = importPluginNode->GetNext();
       }
 
-      errorMessage.Printf(_("Audacity recognized the type of the file '%s'.\nImporters supposedly supporting such files are:\n%s,\nbut none of them understood this file format."),fName.c_str(), pluglist.c_str());
+      errorMessage.Printf(_("Audacity recognized the type of the file '%s'.\nImporters supposedly supporting such files are:\n%s,\nbut none of them understood this file format."),fName, pluglist);
    }
 
    pProj->mbBusyImporting = false;

--- a/src/import/ImportFFmpeg.cpp
+++ b/src/import/ImportFFmpeg.cpp
@@ -38,7 +38,7 @@ Licensed under the GNU General Public License v2 or later
 
 //TODO: remove non-audio extensions
 #if defined(USE_FFMPEG)
-static const wxChar *exts[] =
+static const wxString exts[] =
 {
    wxT("4xm"),
    wxT("MTV"),
@@ -234,7 +234,7 @@ public:
    ///\ tags - Audacity tags object
    ///\ tag - name of tag to set
    ///\ name - name of metadata item to retrieve
-   void GetMetadata(Tags *tags, const wxChar *tag, const char *name);
+   void GetMetadata(Tags *tags, const wxString &tag, const char *name);
 
    ///! Called by Import.cpp
    ///\return number of readable streams in the file
@@ -364,14 +364,14 @@ bool FFmpegImportFileHandle::Init()
    int err = ufile_fopen_input(&mFormatContext, mName);
    if (err < 0)
    {
-      wxLogError(wxT("FFmpeg : av_open_input_file() failed for file %s"),mName.c_str());
+      wxLogError(wxT("FFmpeg : av_open_input_file() failed for file %s"),mName);
       return false;
    }
 
    err = avformat_find_stream_info(mFormatContext, NULL);
    if (err < 0)
    {
-      wxLogError(wxT("FFmpeg: avformat_find_stream_info() failed for file %s"),mName.c_str());
+      wxLogError(wxT("FFmpeg: avformat_find_stream_info() failed for file %s"),mName);
       return false;
    }
 
@@ -439,7 +439,7 @@ bool FFmpegImportFileHandle::InitCodecs()
          {
             lang.FromUTF8(tag->value);
          }
-         strinfo.Printf(_("Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"),sc->m_stream->id,codec->name,lang.c_str(),bitrate.c_str(),sc->m_stream->codec->channels, duration);
+         strinfo.Printf(_("Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"),sc->m_stream->id,codec->name,lang,bitrate,sc->m_stream->codec->channels, duration);
          mStreamInfo->Add(strinfo);
          mScs[mNumStreams++] = sc;
       }
@@ -841,7 +841,7 @@ void FFmpegImportFileHandle::WriteMetadata(Tags *tags)
    GetMetadata(tags, TAG_GENRE, "genre");
 }
 
-void FFmpegImportFileHandle::GetMetadata(Tags *tags, const wxChar *tag, const char *name)
+void FFmpegImportFileHandle::GetMetadata(Tags *tags, const wxString &tag, const char *name)
 {
    AVDictionaryEntry *meta;
 

--- a/src/import/ImportFLAC.cpp
+++ b/src/import/ImportFLAC.cpp
@@ -46,7 +46,7 @@
 
 #define DESC _("FLAC files")
 
-static const wxChar *exts[] =
+static const wxString exts[] =
 {
    wxT("flac"),
    wxT("flc")

--- a/src/import/ImportGStreamer.cpp
+++ b/src/import/ImportGStreamer.cpp
@@ -221,7 +221,7 @@ GetGStreamerImportPlugin(ImportPluginList *importPluginList,
    {
       wxLogMessage(wxT("Failed to initialize GStreamer. Error %d: %s"),
                    error->code,
-                   wxString::FromUTF8(error->message).c_str());
+                   wxString::FromUTF8(error->message));
       g_error_free(error);
       return;
    }
@@ -325,7 +325,7 @@ GStreamerImportPlugin::GetSupportedExtensions()
          for (guint i = 0; extensions[i] != NULL; i++)
          {
             wxString extension = wxString::FromUTF8(extensions[i]);
-            if (mExtensions.Index(extension.c_str(), false) == wxNOT_FOUND)
+            if (mExtensions.Index(extension, false) == wxNOT_FOUND)
             {
                mExtensions.Add(extension);
             }
@@ -343,7 +343,7 @@ GStreamerImportPlugin::GetSupportedExtensions()
    {
       extensions = extensions + wxT(" ") + mExtensions[i];
    }
-   wxLogMessage(wxT("%s"), extensions.c_str());
+   wxLogMessage(wxT("%s"), extensions);
 
    return mExtensions;
 }
@@ -984,7 +984,7 @@ GStreamerImportFileHandle::Init()
       wxString strinfo;
       strinfo.Printf(wxT("Index[%02d], Type[%s], Channels[%d], Rate[%d]"),
                      (unsigned int) i,
-                     wxString::FromUTF8(c->mType).c_str(),
+                     wxString::FromUTF8(c->mType),
                      (int) c->mNumChannels,
                      (int) c->mSampleRate);
       mStreamInfo.Add(strinfo);
@@ -1193,9 +1193,9 @@ GStreamerImportFileHandle::ProcessBusMessage(bool & success)
    }
 
    wxLogMessage(wxT("GStreamer: Got %s%s%s"),
-                wxString::FromUTF8(GST_MESSAGE_TYPE_NAME(msg)).c_str(),
+                wxString::FromUTF8(GST_MESSAGE_TYPE_NAME(msg)),
                 objname ? wxT(" from ") : wxT(""),
-                objname ? wxString::FromUTF8(objname).c_str() : wxT(""));
+                objname ? wxString::FromUTF8(objname) : wxT(""));
 
    if (objname != NULL)
    {
@@ -1218,13 +1218,13 @@ GStreamerImportFileHandle::ProcessBusMessage(bool & success)
             wxString m;
 
             m.Printf(wxT("%s%s%s"),
-               wxString::FromUTF8(err->message).c_str(),
+               wxString::FromUTF8(err->message),
                debug ? wxT("\n") : wxT(""),
-               debug ? wxString::FromUTF8(debug).c_str() : wxT(""));
+               debug ? wxString::FromUTF8(debug) : wxT(""));
 #if defined(_DEBUG)
             wxMessageBox(m, wxT("GStreamer Error:"));
 #else
-            wxLogMessage(wxT("GStreamer Error: %s"), m.c_str());
+            wxLogMessage(wxT("GStreamer Error: %s"), m);
 #endif
             g_error_free(err);
          }
@@ -1250,9 +1250,9 @@ GStreamerImportFileHandle::ProcessBusMessage(bool & success)
          if (err)
          {
             wxLogMessage(wxT("GStreamer Warning: %s%s%s"),
-                         wxString::FromUTF8(err->message).c_str(),
+                         wxString::FromUTF8(err->message),
                          debug ? wxT("\n") : wxT(""),
-                         debug ? wxString::FromUTF8(debug).c_str() : wxT(""));
+                         debug ? wxString::FromUTF8(debug) : wxT(""));
 
             g_error_free(err);
          }
@@ -1274,9 +1274,9 @@ GStreamerImportFileHandle::ProcessBusMessage(bool & success)
          if (err)
          {
             wxLogMessage(wxT("GStreamer Info: %s%s%s"),
-                         wxString::FromUTF8(err->message).c_str(),
+                         wxString::FromUTF8(err->message),
                          debug ? wxT("\n") : wxT(""),
-                         debug ? wxString::FromUTF8(debug).c_str() : wxT(""));
+                         debug ? wxString::FromUTF8(debug) : wxT(""));
 
             g_error_free(err);
          }
@@ -1386,7 +1386,7 @@ GStreamerImportFileHandle::OnTag(GstAppSink * WXUNUSED(appsink), GstTagList *tag
             GstDateTime *dt = (GstDateTime *) g_value_get_boxed(val);
             gchar *str = gst_date_time_to_iso8601_string(dt);
 
-            string = wxString::FromUTF8(str).c_str();
+            string = wxString::FromUTF8(str);
 
             g_free(str);
          }
@@ -1394,15 +1394,15 @@ GStreamerImportFileHandle::OnTag(GstAppSink * WXUNUSED(appsink), GstTagList *tag
          {
             gchar *str = gst_value_serialize(val);
 
-            string = wxString::FromUTF8(str).c_str();
+            string = wxString::FromUTF8(str);
 
             g_free(str);
          }
          else
          {
             wxLogMessage(wxT("Tag %s has unhandled type: %s"),
-                         wxString::FromUTF8(name).c_str(),
-                         wxString::FromUTF8(G_VALUE_TYPE_NAME(val)).c_str());
+                         wxString::FromUTF8(name),
+                         wxString::FromUTF8(G_VALUE_TYPE_NAME(val)));
             continue;
          }
 
@@ -1438,12 +1438,12 @@ GStreamerImportFileHandle::OnTag(GstAppSink * WXUNUSED(appsink), GstTagList *tag
          }
          else
          {
-            tag = wxString::FromUTF8(name).c_str();
+            tag = wxString::FromUTF8(name);
          }
 
          if (jcnt > 1)
          {
-            tag.Printf(wxT("%s:%d"), tag.c_str(), j);
+            tag.Printf(wxT("%s:%d"), tag, j);
          }
 
          // Store the tag

--- a/src/import/ImportLOF.cpp
+++ b/src/import/ImportLOF.cpp
@@ -96,7 +96,7 @@
 
 #define DESC _("List of Files in basic text format")
 
-static const wxChar *exts[] =
+static const wxString exts[] =
 {
    wxT("lof")
 };

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -47,7 +47,7 @@ bool ImportMIDI(const wxString &fName, NoteTrack * dest)
    }
 
    double offset = 0.0;
-   Alg_seq_ptr new_seq = new Alg_seq(fName.mb_str(), is_midi, &offset);
+   Alg_seq_ptr new_seq = new Alg_seq(OSINPUT(fName), is_midi, &offset);
 
    //Should we also check if(seq->tracks() == 0) ?
    if(new_seq->get_read_error() == alg_error_open){

--- a/src/import/ImportMP3.cpp
+++ b/src/import/ImportMP3.cpp
@@ -46,7 +46,7 @@
 
 #define DESC _("MP3 files")
 
-static const wxChar *exts[] =
+static const wxString exts[] =
 {
    wxT("mp3"),
    wxT("mp2"),

--- a/src/import/ImportOGG.cpp
+++ b/src/import/ImportOGG.cpp
@@ -45,7 +45,7 @@
 
 #define DESC _("Ogg Vorbis files")
 
-static const wxChar *exts[] =
+static const wxString exts[] =
 {
    wxT("ogg")
 };
@@ -323,7 +323,7 @@ int OggImportFileHandle::Import(TrackFactory *trackFactory, Track ***outTracks,
       if (bytesRead == OV_HOLE) {
          wxFileName f(mFilename);
          wxLogError(wxT("Ogg Vorbis importer: file %s is malformed, ov_read() reported a hole"),
-                    f.GetFullName().c_str());
+                    f.GetFullName());
          /* http://lists.xiph.org/pipermail/vorbis-dev/2001-February/003223.html
           * is the justification for doing this - best effort for malformed file,
           * hence the message.

--- a/src/import/ImportPlugin.h
+++ b/src/import/ImportPlugin.h
@@ -134,7 +134,7 @@ public:
       wxFileName f(mFilename);
       wxString title;
 
-      title.Printf(_("Importing %s"), GetFileDescription().c_str());
+      title.Printf(_("Importing %s"), GetFileDescription());
       mProgress.create(title, f.GetFullName());
    }
 

--- a/src/import/ImportQT.cpp
+++ b/src/import/ImportQT.cpp
@@ -17,7 +17,7 @@
 
 #define DESC _("QuickTime files")
 
-static const wxChar *exts[] =
+static const wxString exts[] =
 {
    wxT("mov"),
    wxT("aac"),
@@ -409,8 +409,8 @@ done:
 
 static const struct
 {
-   const OSType key;
-   const wxChar *name;
+   OSType key;
+   wxString name;
 }
 names[] =
 {
@@ -445,7 +445,7 @@ void QTImportFileHandle::AddMetadata(Tags *tags)
       return;
    }
 
-   for (int i = 0; i < WXSIZEOF(names); i++) {
+   for (size_t i = 0; i < WXSIZEOF(names); ++i) {
       QTMetaDataItem item = kQTMetaDataItemUninitialized;
       OSType key = names[i].key;
 

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -220,7 +220,7 @@ int ImportRaw(wxWindow *parent, const wxString &fileName,
 
    wxString msg;
 
-   msg.Printf(_("Importing %s"), wxFileName::FileName(fileName).GetFullName().c_str());
+   msg.Printf(_("Importing %s"), wxFileName::FileName(fileName).GetFullName());
 
    /* i18n-hint: 'Raw' means 'unprocessed' here and should usually be tanslated.*/
    ProgressDialog progress(_("Import Raw"), msg);

--- a/src/ondemand/ODComputeSummaryTask.h
+++ b/src/ondemand/ODComputeSummaryTask.h
@@ -44,7 +44,7 @@ class ODComputeSummaryTask final : public ODTask
    ///Return the task name
    const char* GetTaskName() override { return "ODComputeSummaryTask"; }
 
-   const wxChar* GetTip() override { return _("Import complete. Calculating waveform"); }
+   const wxString GetTip() override { return _("Import complete. Calculating waveform"); }
 
    bool UsesCustomWorkUntilPercentage() override { return true; }
    float ComputeNextWorkUntilPercentageComplete() override;

--- a/src/ondemand/ODDecodeTask.h
+++ b/src/ondemand/ODDecodeTask.h
@@ -55,7 +55,7 @@ class ODDecodeTask /* not final */ : public ODTask
    ///Return the task name
    const char* GetTaskName() override { return "ODDecodeTask"; }
 
-   const wxChar* GetTip() override { return _("Decoding Waveform"); }
+   const wxString GetTip() override { return _("Decoding Waveform"); }
 
    ///Subclasses should override to return respective type.
    unsigned int GetODType() override { return eODNone; }

--- a/src/ondemand/ODTask.h
+++ b/src/ondemand/ODTask.h
@@ -115,7 +115,7 @@ class ODTask /* not final */
    bool GetNeedsODUpdate();
    void ResetNeedsODUpdate();
 
-   virtual const wxChar* GetTip()=0;
+   virtual const wxString GetTip() = 0;
 
     ///returns true if the task is associated with the project.
    virtual bool IsTaskAssociatedWithProject(AudacityProject* proj);

--- a/src/ondemand/ODWaveTrackTaskQueue.cpp
+++ b/src/ondemand/ODWaveTrackTaskQueue.cpp
@@ -333,9 +333,9 @@ void ODWaveTrackTaskQueue::FillTipForWaveTrack( WaveTrack * t, wxString &tip )
     //  if(GetNumTasks()==1)
       mTipMsg.Printf(_("%s %2.0f%% complete.  Click to change task focal point."), GetFrontTask()->GetTip(), GetFrontTask()->PercentComplete()*100.0 );
      // else
-       //  msg.Printf(_("%s %d additional tasks remaining."), GetFrontTask()->GetTip().c_str(), GetNumTasks());
+       //  msg.Printf(_("%s %d additional tasks remaining."), GetFrontTask()->GetTip(), GetNumTasks());
 
-      tip = mTipMsg.c_str();
+      tip = mTipMsg;
 
    }
 }

--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -207,7 +207,7 @@ bool DirectoriesPrefs::Validate()
    if( !AudacityApp::IsTempDirectoryNameOK( tempDir.GetPath() ) ) {
       wxMessageBox(
          wxString::Format(_("Directory %s is not suitable (at risk of being cleaned out)"),
-                           tempDir.GetPath().c_str()),
+                           tempDir.GetPath()),
          _("Error"),
          wxOK | wxICON_ERROR);
       return false;
@@ -215,7 +215,7 @@ bool DirectoriesPrefs::Validate()
    if (!tempDir.DirExists()) {
       int ans = wxMessageBox(
          wxString::Format(_("Directory %s does not exist. Create it?"),
-                          tempDir.GetPath().c_str()),
+                          tempDir.GetPath()),
          _("New Temporary Directory"),
          wxYES_NO | wxCENTRE | wxICON_EXCLAMATION);
 
@@ -235,7 +235,7 @@ bool DirectoriesPrefs::Validate()
       if (!tempDir.Mkdir(0755)) {
          wxMessageBox(
             wxString::Format(_("Directory %s is not writable"),
-                             tempDir.GetPath().c_str()),
+                             tempDir.GetPath()),
             _("Error"),
             wxOK | wxICON_ERROR);
          return false;

--- a/src/prefs/KeyConfigPrefs.cpp
+++ b/src/prefs/KeyConfigPrefs.cpp
@@ -551,9 +551,9 @@ void KeyConfigPrefs::OnSet(wxCommandEvent & WXUNUSED(event))
       if (wxMessageBox(
             wxString::Format(
             _("The keyboard shortcut '%s' is already assigned to:\n\n\t'%s'\n\nClick OK to assign the shortcut to\n\n\t'%s'\n\ninstead.  Otherwise, click Cancel."),
-            key.c_str(),
-            oldlabel.c_str(),
-            newlabel.c_str()),
+            key,
+            oldlabel,
+            newlabel),
             _("Error"), wxOK | wxCANCEL | wxICON_STOP | wxCENTRE, this) == wxCANCEL)
       {
          return;
@@ -1051,8 +1051,8 @@ void KeyConfigPrefs::OnSet(wxCommandEvent & WXUNUSED(event))
       wxMessageBox(
          wxString::Format(
             _("The keyboard shortcut '%s' is already assigned to:\n\n'%s'"),
-            newKey.c_str(),
-            alreadyAssignedName.c_str()),
+            newKey,
+            alreadyAssignedName),
          _("Error"), wxICON_STOP | wxCENTRE, this);
       return;
    }

--- a/src/prefs/MidiIOPrefs.cpp
+++ b/src/prefs/MidiIOPrefs.cpp
@@ -199,8 +199,8 @@ void MidiIOPrefs::OnHost(wxCommandEvent & e)
       if (itemAtIndex.IsSameAs(interf)) {
          wxString name = wxSafeConvertMB2WX(info->name);
          wxString device = wxString::Format(wxT("%s: %s"),
-                                            interf.c_str(),
-                                            name.c_str());
+                                            interf,
+                                            name);
          int index;
 
          if (info->output) {
@@ -259,16 +259,16 @@ bool MidiIOPrefs::Apply()
    if (info) {
       gPrefs->Write(wxT("/MidiIO/PlaybackDevice"),
                     wxString::Format(wxT("%s: %s"),
-                                     wxString(wxSafeConvertMB2WX(info->interf)).c_str(),
-                                     wxString(wxSafeConvertMB2WX(info->name)).c_str()));
+                                     wxString(wxSafeConvertMB2WX(info->interf)),
+                                     wxString(wxSafeConvertMB2WX(info->name))));
    }
 #ifdef EXPERIMENTAL_MIDI_IN
    info = (const PmDeviceInfo *) mRecord->GetClientData(mRecord->GetSelection());
    if (info) {
       gPrefs->Write(wxT("/MidiIO/RecordingDevice"),
                     wxString::Format(wxT("%s: %s"),
-                                     wxString(wxSafeConvertMB2WX(info->interf)).c_str(),
-                                     wxString(wxSafeConvertMB2WX(info->name)).c_str()));
+                                     wxString(wxSafeConvertMB2WX(info->interf)),
+                                     wxString(wxSafeConvertMB2WX(info->name))));
    }
 #endif
    return gPrefs->Flush();

--- a/src/prefs/ModulePrefs.cpp
+++ b/src/prefs/ModulePrefs.cpp
@@ -70,7 +70,7 @@ void ModulePrefs::GetAllModuleStatuses(){
             iStatus = kModuleNew;
             gPrefs->Write( str, iStatus );
          }
-         //wxLogDebug( wxT("Entry: %s Value: %i"), str.c_str(), iStatus );
+         //wxLogDebug( wxT("Entry: %s Value: %i"), str, iStatus );
          mModules.Add( str );
          mStatuses.Add( iStatus );
          mPaths.Add( fname );

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -125,7 +125,7 @@ void ControlToolBar::Create(wxWindow * parent)
 AButton *ControlToolBar::MakeButton(teBmps eEnabledUp, teBmps eEnabledDown, teBmps eDisabled,
                                     int id,
                                     bool processdownevents,
-                                    const wxChar *label)
+                                    const wxString &label)
 {
    AButton *r = ToolBar::MakeButton(
       bmpRecoloredUpLarge, bmpRecoloredDownLarge, bmpRecoloredHiliteLarge,

--- a/src/toolbars/ControlToolBar.h
+++ b/src/toolbars/ControlToolBar.h
@@ -97,7 +97,7 @@ class ControlToolBar final : public ToolBar {
    AButton *MakeButton(teBmps eEnabledUp, teBmps eEnabledDown, teBmps eDisabled,
       int id,
       bool processdownevents,
-      const wxChar *label);
+      const wxString &label);
 
    static
    void MakeAlternateImages(AButton &button, int idx,

--- a/src/toolbars/EditToolBar.cpp
+++ b/src/toolbars/EditToolBar.cpp
@@ -100,7 +100,7 @@ void EditToolBar::AddSeparator()
 AButton *EditToolBar::AddButton(
    teBmps eEnabledUp, teBmps eEnabledDown, teBmps eDisabled,
    int id,
-   const wxChar *label,
+   const wxString &label,
    bool toggle)
 {
    AButton *&r = mButtons[id];

--- a/src/toolbars/EditToolBar.h
+++ b/src/toolbars/EditToolBar.h
@@ -77,7 +77,7 @@ class EditToolBar final : public ToolBar {
  private:
 
    AButton *AddButton(teBmps eEnabledUp, teBmps eEnabledDown, teBmps eDisabled,
-      int id, const wxChar *label, bool toggle = false);
+      int id, const wxString &label, bool toggle = false);
 
    void AddSeparator();
 

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -55,7 +55,7 @@ with changes in the SelectionBar.
 
 IMPLEMENT_CLASS(SelectionBar, ToolBar);
 
-const static wxChar *numbers[] =
+static const wxString numbers[] =
 {
    wxT("0"), wxT("1"), wxT("2"), wxT("3"), wxT("4"),
    wxT("5"), wxT("6"), wxT("7"), wxT("8"), wxT("9")
@@ -239,7 +239,7 @@ void SelectionBar::Populate()
    mSnapTo->SetName(_("Snap To"));
    mSnapTo->SetSelection(mListener ? mListener->AS_GetSnapTo() : SNAP_OFF);
    #if wxUSE_TOOLTIPS
-      mSnapTo->SetToolTip(wxString::Format(_("Snap Clicks/Selections to %s"), formatName.c_str()));
+      mSnapTo->SetToolTip(wxString::Format(_("Snap Clicks/Selections to %s"), formatName));
    #endif
 
    mSnapTo->Connect(wxEVT_SET_FOCUS,
@@ -374,7 +374,7 @@ void SelectionBar::OnUpdate(wxCommandEvent &evt)
    mListener->AS_SetSelectionFormat(format);
 
 #if wxUSE_TOOLTIPS
-   mSnapTo->SetToolTip(wxString::Format(_("Snap Clicks/Selections to %s"), format.c_str()));
+   mSnapTo->SetToolTip(wxString::Format(_("Snap Clicks/Selections to %s"), format));
 #endif
 
    // ToolBar::ReCreateButtons() will get rid of our sizers and controls
@@ -459,7 +459,7 @@ double SelectionBar::GetRightTime()
    }
 }
 
-void SelectionBar::SetField(const wxChar *msg, int fieldNum)
+void SelectionBar::SetField(const wxString &msg, int fieldNum)
 {
    if (fieldNum < 0 || fieldNum >= 10)
       return;

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -44,7 +44,7 @@ class SelectionBar final : public ToolBar {
    void SetTimes(double start, double end, double audio);
    double GetLeftTime();
    double GetRightTime();
-   void SetField(const wxChar *msg, int fieldNum);
+   void SetField(const wxString &msg, int fieldNum);
    void SetSnapTo(int);
    void SetSelectionFormat(const wxString & format);
    void SetRate(double rate);

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -296,7 +296,7 @@ ToolBar::~ToolBar()
 wxString ToolBar::GetTitle()
 {
    /* i18n-hint: %s will be replaced by the name of the kind of toolbar.*/
-   return wxString::Format( _("Audacity %s Toolbar"), GetLabel().c_str() );
+   return wxString::Format( _("Audacity %s Toolbar"), GetLabel());
 }
 
 //

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -169,7 +169,7 @@ void ToolsToolBar::UpdatePrefs()
 }
 
 AButton * ToolsToolBar::MakeTool( teBmps eTool,
-   int id, const wxChar *label)
+   int id, const wxString &label)
 {
    AButton *button = ToolBar::MakeButton(
       bmpRecoloredUpSmall, bmpRecoloredDownSmall, bmpRecoloredHiliteSmall,
@@ -274,7 +274,7 @@ int ToolsToolBar::GetDownTool()
    return firstTool;  // Should never happen
 }
 
-const wxChar * ToolsToolBar::GetMessageForTool( int ToolNumber )
+wxString ToolsToolBar::GetMessageForTool(int ToolNumber)
 {
    wxASSERT( ToolNumber >= 0 );
    wxASSERT( ToolNumber < numTools );

--- a/src/toolbars/ToolsToolBar.h
+++ b/src/toolbars/ToolsToolBar.h
@@ -62,7 +62,7 @@ class ToolsToolBar final : public ToolBar {
    bool IsDown(int tool);
    int GetDownTool();
 
-   const wxChar * GetMessageForTool( int ToolNumber );
+   wxString GetMessageForTool(int ToolNumber);
 
    void Populate();
    void Repaint(wxDC * WXUNUSED(dc)) override {};
@@ -72,13 +72,13 @@ class ToolsToolBar final : public ToolBar {
 
    void RegenerateToolsTooltips();
    wxImage *MakeToolImage(wxImage *tool, wxImage *mask, int style);
-   AButton *MakeTool(teBmps eTool, int id, const wxChar *label);
+   AButton *MakeTool(teBmps eTool, int id, const wxString &label);
 
    AButton *mTool[numTools];
    wxGridSizer *mToolSizer;
    int mCurrentTool;
 
-   const wxChar *mMessageOfTool[numTools];
+   wxString mMessageOfTool[numTools];
 
  public:
 

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -148,7 +148,7 @@ void TranscriptionToolBar::Create(wxWindow * parent)
 AButton *TranscriptionToolBar::AddButton(
    teBmps eFore, teBmps eDisabled,
    int id,
-   const wxChar *label)
+   const wxString &label)
 {
    AButton *&r = mButtons[id];
 

--- a/src/toolbars/TranscriptionToolBar.h
+++ b/src/toolbars/TranscriptionToolBar.h
@@ -124,7 +124,7 @@ class TranscriptionToolBar final : public ToolBar {
    AButton *AddButton(
       teBmps eFore, teBmps eDisabled,
       int id,
-      const wxChar *label);
+      const wxString &label);
    void MakeAlternateImages(
       teBmps eFore, teBmps eDisabled,
       int id, unsigned altIdx);

--- a/src/widgets/ASlider.cpp
+++ b/src/widgets/ASlider.cpp
@@ -1045,7 +1045,7 @@ wxString LWSlider::GetTip(float value) const
 #endif
       }
 
-      label.Printf(wxT("%s: %s"), mName.c_str(), val.c_str());
+      label.Printf(wxT("%s: %s"), mName, val);
    }
    else
    {
@@ -1088,7 +1088,7 @@ wxString LWSlider::GetMaxTip() const
 #endif
       }
 
-      label.Printf(wxT("%s: %s"), mName.c_str(), val.c_str());
+      label.Printf(wxT("%s: %s"), mName, val);
    }
    else
    {

--- a/src/widgets/HelpSystem.cpp
+++ b/src/widgets/HelpSystem.cpp
@@ -327,9 +327,9 @@ void HelpSystem::ShowHelpDialog(wxWindow *parent,
 #endif
 
    wxLogMessage(wxT("Help button pressed: PageName %s, releasePageName %s"),
-              PageName.c_str(), releasePageName.c_str());
+              PageName, releasePageName);
    wxLogMessage(wxT("webHelpPage %s, localHelpPage %s"),
-              webHelpPage.c_str(), localHelpPage.c_str());
+              webHelpPage, localHelpPage);
 
    HelpSystem::ShowHelpDialog(
       parent, 

--- a/src/widgets/KeyView.cpp
+++ b/src/widgets/KeyView.cpp
@@ -701,10 +701,10 @@ KeyView::RefreshBindings(const wxArrayString & names,
          node.isparent,
          node.iscat,
          node.ispfx,
-         node.name.c_str(),
-         node.category.c_str(),
-         node.prefix.c_str(),
-         node.label.c_str());
+         node.name,
+         node.category,
+         node.prefix,
+         node.label);
    }
 #endif
 
@@ -942,10 +942,10 @@ KeyView::RefreshLines()
          node.isparent,
          node.iscat,
          node.ispfx,
-         node.name.c_str(),
-         node.category.c_str(),
-         node.prefix.c_str(),
-         node.label.c_str());
+         node.name,
+         node.category,
+         node.prefix,
+         node.label);
    }
 #endif
 
@@ -1545,24 +1545,24 @@ KeyView::CmpKeyNodeByTree(KeyNode ***n1, KeyNode ***n2)
    if (t1->category == _("Command") && !t1->isparent)
    {
       // A "command" node, so prepend the highest hex value
-      k1.Printf(wxT("ffffffff%s"), t1->label.c_str());
+      k1.Printf(wxT("ffffffff%s"), t1->label);
    }
    else
    {
       // A "menu" node, so prepend the line number
-      k1.Printf(wxT("%08x%s"), (unsigned int) t1->line, t1->label.c_str());
+      k1.Printf(wxT("%08x%s"), (unsigned int) t1->line, t1->label);
    }
 
    // See above for explanation
    if (t2->category == _("Command") && !t2->isparent)
    {
       // A "command" node, so prepend the highest hex value
-      k2.Printf(wxT("ffffffff%s"), t2->label.c_str());
+      k2.Printf(wxT("ffffffff%s"), t2->label);
    }
    else
    {
       // A "menu" node, so prepend the line number
-      k2.Printf(wxT("%08x%s"), (unsigned int) t2->line, t2->label.c_str());
+      k2.Printf(wxT("%08x%s"), (unsigned int) t2->line, t2->label);
    }
 
    // See wxWidgets documentation for explanation of comparison results.

--- a/src/widgets/Meter.cpp
+++ b/src/widgets/Meter.cpp
@@ -139,7 +139,7 @@ bool MeterUpdateQueue::Put(MeterUpdateMsg &msg)
    if (len >= mBufferSize-1)
       return false;
 
-   //wxLogDebug(wxT("Put: %s"), msg.toString().c_str());
+   //wxLogDebug(wxT("Put: %s"), msg.toString());
 
    mBuffer[mEnd] = msg;
    mEnd = (mEnd+1)%mBufferSize;
@@ -175,7 +175,7 @@ const static int gap = 2;
 // Event used to notify all meters of preference changes
 DEFINE_EVENT_TYPE(EVT_METER_PREFERENCES_CHANGED);
 
-const static wxChar *PrefStyles[] =
+static const wxString PrefStyles[] =
 {
    wxT("AutomaticStereo"),
    wxT("HorizontalStereo"),

--- a/src/widgets/MultiDialog.cpp
+++ b/src/widgets/MultiDialog.cpp
@@ -39,7 +39,7 @@ public:
    MultiDialog(wxWindow * pParent, 
                wxString message,
                wxString title,
-               const wxChar **buttons, wxString boxMsg, bool log);
+               const wxArrayString &buttons, wxString boxMsg, bool log);
    ~MultiDialog() {};
 
 private:
@@ -61,7 +61,7 @@ END_EVENT_TABLE()
 MultiDialog::MultiDialog(wxWindow * pParent,
                          wxString message,
                          wxString title,
-                         const wxChar **buttons, wxString boxMsg, bool log)
+                         const wxArrayString &buttons, wxString boxMsg, bool log)
    : wxDialog(pParent, wxID_ANY, title,
                wxDefaultPosition, wxDefaultSize,
                wxCAPTION) // not wxDEFAULT_DIALOG_STYLE because we don't want wxCLOSE_BOX and wxSYSTEM_MENU
@@ -91,21 +91,10 @@ MultiDialog::MultiDialog(wxWindow * pParent,
             vSizer->Add(iconAndTextSizer.release(), 0, wxALIGN_LEFT | wxALL, 5);
          }
 
-
-         int count = 0;
-         while (buttons[count])count++;
-         buttonLabels = new wxString[count];
-
-         count = 0;
-         while (buttons[count]){
-            buttonLabels[count] = buttons[count];
-            count++;
-         }
-
          mRadioBox = safenew wxRadioBox(this, -1,
             boxMsg,
             wxDefaultPosition, wxDefaultSize,
-            count, buttonLabels,
+            buttons,
             1, wxRA_SPECIFY_COLS);
          mRadioBox->SetName(boxMsg);
          mRadioBox->SetSelection(0);
@@ -158,7 +147,7 @@ void MultiDialog::OnShowLog(wxCommandEvent & WXUNUSED(event))
 
 int ShowMultiDialog(const wxString &message,
    const wxString &title,
-   const wxChar **buttons, const wxString &boxMsg, bool log)
+   const wxArrayString &buttons, const wxString &boxMsg, bool log)
 {
    wxWindow * pParent = wxGetApp().GetTopWindow();
 

--- a/src/widgets/MultiDialog.h
+++ b/src/widgets/MultiDialog.h
@@ -21,6 +21,6 @@
 // Return the zero-based index of the chosen button.
 int ShowMultiDialog(const wxString &message,
                     const wxString &title,
-                    const wxChar **buttons, const wxString &boxMsg = _("Please select an action"), bool log = true);
+                    const wxArrayString &buttons, const wxString &boxMsg = _("Please select an action"), bool log = true);
 
 #endif // __AUDACITY_MULTIDIALOG__

--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -732,21 +732,21 @@ void NumericConverter::PrintDebugInfo()
 {
    unsigned int i;
 
-   printf("%s", (const char *)mPrefix.mb_str());
+   wxPrintf("%s", mPrefix);
 
    for(i=0; i<mFields.GetCount(); i++) {
       if (mFields[i].frac) {
-         printf("(t * %d) %% %d '%s' ",
+         wxPrintf("(t * %d) %% %d '%s' ",
                 mFields[i].base,
                 mFields[i].range,
-                (const char *)mFields[i].label.mb_str());
+                mFields[i].label);
 
       }
       else {
-         printf("(t / %d) %% %d '%s' ",
+         wxPrintf("(t / %d) %% %d '%s' ",
                 mFields[i].base,
                 mFields[i].range,
-                (const char *)mFields[i].label.mb_str());
+                mFields[i].label);
       }
    }
 

--- a/src/widgets/Ruler.cpp
+++ b/src/widgets/Ruler.cpp
@@ -679,7 +679,7 @@ wxString Ruler::LabelString(double d, bool major)
             wxString t1, t2, format;
             t1.Printf(wxT("%d:%02d:"), secs/3600, (secs/60)%60);
             format.Printf(wxT("%%0%d.%dlf"), mDigits+3, mDigits);
-            t2.Printf(format.c_str(), fmod(d, 60.0));
+            t2.Printf(format, fmod(d, 60.0));
             s += t1 + t2;
          }
          break;
@@ -728,7 +728,7 @@ wxString Ruler::LabelString(double d, bool major)
                format.Printf(wxT("%%%d.%dlf"), mDigits+3, mDigits);
             // The casting to float is working around an issue where 59 seconds
             // would show up as 60 when using g++ (Ubuntu 4.3.3-5ubuntu4) 4.3.3.
-            t2.Printf(format.c_str(), fmod((float)d, (float)60.0));
+            t2.Printf(format, fmod((float)d, (float)60.0));
 
             s += t1 + t2;
          }

--- a/src/widgets/numformatter.cpp
+++ b/src/widgets/numformatter.cpp
@@ -199,7 +199,7 @@ void NumberFormatter::RemoveTrailingZeroes(wxString& s, size_t retain /* = 0 */)
 {
    const size_t posDecSep = s.find(GetDecimalSeparator());
    wxCHECK_RET( posDecSep != wxString::npos,
-               wxString::Format(wxT("No decimal separator in \"%s\""), s.c_str()) );
+               wxString::Format(wxT("No decimal separator in \"%s\""), s) );
    wxCHECK_RET( posDecSep, wxT("Can't start with decimal separator" ));
 
    // Find the last character to keep.

--- a/src/xml/XMLFileReader.cpp
+++ b/src/xml/XMLFileReader.cpp
@@ -43,7 +43,7 @@ bool XMLFileReader::Parse(XMLTagHandler *baseHandler,
 {
    wxFFile theXMLFile(fname, wxT("rb"));
    if (!theXMLFile.IsOpened()) {
-      mErrorStr.Printf(_("Could not open file: \"%s\""), fname.c_str());
+      mErrorStr.Printf(_("Could not open file: \"%s\""), fname);
       return false;
    }
 
@@ -72,7 +72,7 @@ bool XMLFileReader::Parse(XMLTagHandler *baseHandler,
    if (mBaseHandler)
       return true;
    else {
-      mErrorStr.Printf(_("Could not load file: \"%s\""), fname.c_str());
+      mErrorStr.Printf(_("Could not load file: \"%s\""), fname);
       return false;
    }
 }

--- a/src/xml/XMLTagHandler.cpp
+++ b/src/xml/XMLTagHandler.cpp
@@ -213,24 +213,12 @@ bool XMLTagHandler::ReadXMLTag(const char *tag, const char **attrs)
       tmp_attrs.Add(UTF8CTOWX(s));
    }
 
-// JKC: Previously the next line was:
-// const char **out_attrs = NEW char (const char *)[tmp_attrs.GetCount()+1];
-// however MSVC doesn't like the constness in this position, so this is now
-// added by a cast after creating the array of pointers-to-non-const chars.
-   auto out_attrs = std::make_unique<const wxChar *[]>(tmp_attrs.GetCount() + 1);
-   for (size_t i=0; i<tmp_attrs.GetCount(); i++) {
-      out_attrs[i] = tmp_attrs[i].c_str();
-   }
-   out_attrs[tmp_attrs.GetCount()] = 0;
-
-   bool result = HandleXMLTag(UTF8CTOWX(tag).c_str(), out_attrs.get());
-
-   return result;
+   return HandleXMLTag(UTF8CTOWX(tag), tmp_attrs);
 }
 
 void XMLTagHandler::ReadXMLEndTag(const char *tag)
 {
-   HandleXMLEndTag(UTF8CTOWX(tag).c_str());
+   HandleXMLEndTag(UTF8CTOWX(tag));
 }
 
 void XMLTagHandler::ReadXMLContent(const char *s, int len)
@@ -240,5 +228,5 @@ void XMLTagHandler::ReadXMLContent(const char *s, int len)
 
 XMLTagHandler *XMLTagHandler::ReadXMLChild(const char *tag)
 {
-   return HandleXMLChild(UTF8CTOWX(tag).c_str());
+   return HandleXMLChild(UTF8CTOWX(tag));
 }

--- a/src/xml/XMLTagHandler.h
+++ b/src/xml/XMLTagHandler.h
@@ -79,11 +79,11 @@ class AUDACITY_DLL_API XMLTagHandler /* not final */ {
    // tag and the attribute-value pairs (null-terminated), and
    // return true on success, and false on failure.  If you return
    // false, you will not get any calls about children.
-   virtual bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) = 0;
+   virtual bool HandleXMLTag(const wxString &tag, const wxArrayString &attrs) = 0;
 
    // This method will be called when a closing tag is encountered.
    // It is optional to override this method.
-   virtual void HandleXMLEndTag(const wxChar * WXUNUSED(tag)) {}
+   virtual void HandleXMLEndTag(const wxString &WXUNUSED(tag)) {}
 
    // This method will be called when element content has been
    // encountered.
@@ -95,7 +95,7 @@ class AUDACITY_DLL_API XMLTagHandler /* not final */ {
    // object for the child, insert it into your own local data
    // structures, and then return it.  If you do not wish to
    // handle this child, return NULL and it will be ignored.
-   virtual XMLTagHandler *HandleXMLChild(const wxChar *tag) = 0;
+   virtual XMLTagHandler *HandleXMLChild(const wxString &tag) = 0;
 
    // These functions recieve data from expat.  They do charset
    // conversion and then pass the data to the handlers above.

--- a/src/xml/XMLWriter.cpp
+++ b/src/xml/XMLWriter.cpp
@@ -78,7 +78,7 @@ void XMLWriter::StartTag(const wxString &name)
       Write(wxT("\t"));
    }
 
-   Write(wxString::Format(wxT("<%s"), name.c_str()));
+   Write(wxString::Format(wxT("<%s"), name));
 
    mTagstack.Insert(name, 0);
    mHasKids[0] = true;
@@ -101,7 +101,7 @@ void XMLWriter::EndTag(const wxString &name)
                for (i = 0; i < mDepth - 1; i++) {
                   Write(wxT("\t"));
                }
-               Write(wxString::Format(wxT("</%s>\n"), name.c_str()));
+               Write(wxString::Format(wxT("</%s>\n"), name));
             }
          }
          else {
@@ -119,62 +119,57 @@ void XMLWriter::EndTag(const wxString &name)
 void XMLWriter::WriteAttr(const wxString &name, const wxString &value)
 {
    Write(wxString::Format(wxT(" %s=\"%s\""),
-      name.c_str(),
-      XMLEsc(value).c_str()));
-}
-
-void XMLWriter::WriteAttr(const wxString &name, const wxChar *value)
-{
-   WriteAttr(name, wxString(value));
+      name,
+      XMLEsc(value)));
 }
 
 void XMLWriter::WriteAttr(const wxString &name, int value)
 {
    Write(wxString::Format(wxT(" %s=\"%d\""),
-      name.c_str(),
+      name,
       value));
 }
 
 void XMLWriter::WriteAttr(const wxString &name, bool value)
 {
    Write(wxString::Format(wxT(" %s=\"%d\""),
-      name.c_str(),
+      name,
       value));
 }
 
 void XMLWriter::WriteAttr(const wxString &name, long value)
 {
    Write(wxString::Format(wxT(" %s=\"%ld\""),
-      name.c_str(),
+      name,
       value));
 }
 
 void XMLWriter::WriteAttr(const wxString &name, long long value)
 {
    Write(wxString::Format(wxT(" %s=\"%lld\""),
-      name.c_str(),
+      name,
       value));
 }
 
 void XMLWriter::WriteAttr(const wxString &name, size_t value)
 {
    Write(wxString::Format(wxT(" %s=\"%lld\""),
-      name.c_str(),
+      name,
       (long long) value));
 }
 
 void XMLWriter::WriteAttr(const wxString &name, float value, int digits)
 {
    Write(wxString::Format(wxT(" %s=\"%s\""),
-      name.c_str(),
-      Internat::ToString(value, digits).c_str()));
+      name,
+      Internat::ToString(value, digits)));
 }
 
 void XMLWriter::WriteAttr(const wxString &name, double value, int digits)
 {
    Write(wxString::Format(wxT(" %s=\"%s\""),
-      name.c_str(),
-      Internat::ToString(value, digits).c_str()));
+      name,
+      Internat::ToString(value, digits)));
 }
 
 void XMLWriter::WriteData(const wxString &value)
@@ -196,7 +191,7 @@ void XMLWriter::WriteSubTree(const wxString &value)
       mHasKids[0] = true;
    }
 
-   Write(value.c_str());
+   Write(value);
 }
 
 // See http://www.w3.org/TR/REC-xml for reference

--- a/src/xml/XMLWriter.h
+++ b/src/xml/XMLWriter.h
@@ -28,7 +28,6 @@ class AUDACITY_DLL_API XMLWriter /* not final */ {
    virtual void EndTag(const wxString &name);
 
    virtual void WriteAttr(const wxString &name, const wxString &value);
-   virtual void WriteAttr(const wxString &name, const wxChar *value);
 
    virtual void WriteAttr(const wxString &name, int value);
    virtual void WriteAttr(const wxString &name, bool value);


### PR DESCRIPTION
make it build with wx3 --enable-stl and throw out other type sillynesses. That's all. It's not tested.
- abolish reliance on pointer-to-wxChar
- use backend-neutral wxString
- drop all wxString::c_str() calls because they give a pointer to
  the internal representation, which is also bounded by the lifetime
  of the surrounding object.
- drop calls to wxString::mb_str() because they give a
  platform-dependent internal representation; under a Unicode
  wxWidgets build, this is wchar_t, which
  - on Windows: is not usable, because most APIs expect narrow
    locale-specific strings
  - on Linux: is not usable, because most APIs expect narrow
    UTF-8 strings
- drop calls to wx_str, same as mb_str
