### PR TITLE
Timer Recording Improvements

### DIFF
--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -144,6 +144,17 @@ enum {
    kAlignTogether
 };
 
+// Post Timer Recording Actions
+// Ensure this matches the enum in TimerRecordDialog.cpp
+enum {
+	POST_TIMER_RECORD_CANCEL_WAIT = -2,
+	POST_TIMER_RECORD_CANCEL,
+	POST_TIMER_RECORD_NOTHING,
+	POST_TIMER_RECORD_CLOSE,
+	POST_TIMER_RECORD_RESTART,
+	POST_TIMER_RECORD_SHUTDOWN
+};
+
 // Define functor subclasses that dispatch to the correct call sequence on
 // member functions of AudacityProject
 
@@ -6329,30 +6340,37 @@ void AudacityProject::OnTimerRecord()
    {
 	   int iTimerRecordingOutcome = dialog.RunWaitDialog();
 	   switch (iTimerRecordingOutcome) {
-	   case -2: {
+	   case POST_TIMER_RECORD_CANCEL_WAIT:
 		   // Canceled on the wait dialog
 		   // No action required
-	   } break;
-	   case -1: {
+	   break;
+	   case POST_TIMER_RECORD_CANCEL:
 		   // RunWaitDialog() shows the "wait for start" as well as "recording" dialog
-		   // if it returned -1 it means the user cancelled while the recording, so throw out the fresh track.
+		   // if it returned POST_TIMER_RECORD_CANCEL it means the user cancelled while the recording, so throw out the fresh track.
 		   // However, we can't undo it here because the PushState() is called in TrackPanel::OnTimer(),
 		   // which is blocked by this function.
 		   // so instead we mark a flag to undo it there.
 		   mTimerRecordCanceled = true;
-	   } break;
-	   case 0: {
+	   break;
+	   case POST_TIMER_RECORD_NOTHING:
 		   // No action required
-	   } break;
-	   case 1: {
+	   break;
+	   case POST_TIMER_RECORD_CLOSE:
 		   // Quit Audacity
-	   } break;
-	   case 2: {
+		   exit(0);
+	   break;
+	   case POST_TIMER_RECORD_RESTART:
 		   // Restart System
-	   } break;
-	   case 3: {
+#ifdef __WINDOWS__
+		   system("shutdown /r /f /t 30");
+#endif
+	   break;
+	   case POST_TIMER_RECORD_SHUTDOWN:
 		   // Shutdown System
-	   } break;
+#ifdef __WINDOWS__
+		   system("shutdown /s /f /t 30");
+#endif
+	   break;
 	   }
    }
 }

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -147,7 +147,8 @@ enum {
 // Post Timer Recording Actions
 // Ensure this matches the enum in TimerRecordDialog.cpp
 enum {
-	POST_TIMER_RECORD_CANCEL_WAIT = -2,
+	POST_TIMER_RECORD_STOPPED = -3,
+	POST_TIMER_RECORD_CANCEL_WAIT,
 	POST_TIMER_RECORD_CANCEL,
 	POST_TIMER_RECORD_NOTHING,
 	POST_TIMER_RECORD_CLOSE,

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -6325,14 +6325,35 @@ void AudacityProject::OnTimerRecord()
    {
       // Cancelled before recording - don't need to do anyting.
    }
-   else if(!dialog.RunWaitDialog())
+   else
    {
-      //RunWaitDialog() shows the "wait for start" as well as "recording" dialog
-      //if it returned false it means the user cancelled while the recording, so throw out the fresh track.
-      //However, we can't undo it here because the PushState() is called in TrackPanel::OnTimer(),
-      //which is blocked by this function.
-      //so instead we mark a flag to undo it there.
-      mTimerRecordCanceled = true;
+	   int iTimerRecordingOutcome = dialog.RunWaitDialog();
+	   switch (iTimerRecordingOutcome) {
+	   case -2: {
+		   // Canceled on the wait dialog
+		   // No action required
+	   } break;
+	   case -1: {
+		   // RunWaitDialog() shows the "wait for start" as well as "recording" dialog
+		   // if it returned -1 it means the user cancelled while the recording, so throw out the fresh track.
+		   // However, we can't undo it here because the PushState() is called in TrackPanel::OnTimer(),
+		   // which is blocked by this function.
+		   // so instead we mark a flag to undo it there.
+		   mTimerRecordCanceled = true;
+	   } break;
+	   case 0: {
+		   // No action required
+	   } break;
+	   case 1: {
+		   // Quit Audacity
+	   } break;
+	   case 2: {
+		   // Restart System
+	   } break;
+	   case 3: {
+		   // Shutdown System
+	   } break;
+	   }
    }
 }
 

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -189,6 +189,16 @@ const int sbarHjump = 30;       //STM: This is how far the thumb jumps when the 
 #include "AllThemeResources.h"
 #endif
 
+// Post Timer Recording Actions
+enum {
+	POST_TIMER_RECORD_CANCEL_WAIT = -2,
+	POST_TIMER__RECORD_CANCEL,
+	POST_TIMER__RECORD_NOTHING,
+	POST_TIMER__RECORD_CLOSE,
+	POST_TIMER__RECORD_RESTART,
+	POST_TIMER__RECORD_SHUTDOWN
+};
+
 ////////////////////////////////////////////////////////////
 /// Custom events
 ////////////////////////////////////////////////////////////

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -5247,3 +5247,239 @@ void AudacityProject::ReleaseKeyboard(wxWindow * /* handler */)
 
    return;
 }
+
+bool AudacityProject::ExportFromTimed(wxFileName fnFile, int iFormat, int iSubFormat, int iFilterIndex)
+{
+	Exporter e;
+
+	wxGetApp().SetMissingAliasedFileWarningShouldShow(true);
+	return e.ProcessFromTimed(this, false, 0.0, mTracks->GetEndTime(), fnFile, iFormat, iSubFormat, iFilterIndex);
+}
+
+bool AudacityProject::SaveFromTimed(wxFileName fnPath, bool overwrite /* = true */,
+	bool fromSaveAs /* = true */,
+	bool bWantSaveCompressed /*= false*/)
+{
+
+
+	if (!fnPath.DirExists()) {
+		// Directory does not exist - FAIL
+		wxString sMessage;
+		sMessage.Printf("%s\n%s", _T("Please create the following directory:"), fnPath.GetPath());
+		wxMessageBox(sMessage, _T("Error"), wxICON_EXCLAMATION | wxOK);
+		return false;
+	}
+
+	mFileName = fnPath.GetFullPath();
+	SetProjectTitle();
+
+	if (bWantSaveCompressed)
+		wxASSERT(fromSaveAs);
+	else
+	{
+		TrackListIterator iter(mTracks);
+		bool bHasTracks = (iter.First() != NULL);
+		if (!bHasTracks)
+		{
+			if (mUndoManager.UnsavedChanges() && mEmptyCanBeDirty) {
+				int result = wxMessageBox(_("Your project is now empty.\nIf saved, the project will have no tracks.\n\nTo save any previously open tracks:\nClick 'No', Edit > Undo until all tracks\nare open, then File > Save Project.\n\nSave anyway?"),
+					_("Warning - Empty Project"),
+					wxYES_NO | wxICON_QUESTION, this);
+				if (result == wxNO)
+					return false;
+			}
+		}
+
+		if (!fromSaveAs && mDirManager->GetProjectName() == wxT(""))
+			return SaveAs();
+
+		// If the user has recently imported dependencies, show
+		// a dialog where the user can see audio files that are
+		// aliased by this project.  The user may make the project
+		// self-contained during this dialog, it modifies the project!
+		if (mImportedDependencies)
+		{
+			bool bSuccess = ShowDependencyDialogIfNeeded(this, true);
+			if (!bSuccess)
+				return false;
+			mImportedDependencies = false; // do not show again
+		}
+	}
+
+	//
+	// Always save a backup of the original project file
+	//
+
+	wxString safetyFileName = wxT("");
+	if (wxFileExists(mFileName)) {
+
+#ifdef __WXGTK__
+		safetyFileName = mFileName + wxT("~");
+#else
+		safetyFileName = mFileName + wxT(".bak");
+#endif
+
+		if (wxFileExists(safetyFileName))
+			wxRemoveFile(safetyFileName);
+
+		wxRename(mFileName, safetyFileName);
+	}
+
+	if (fromSaveAs || mDirManager->GetProjectName() == wxT("")) {
+		// Write the tracks.
+
+		// This block of code is duplicated in WriteXML, for now...
+		wxString project = mFileName;
+		if (project.Len() > 4 && project.Mid(project.Len() - 4) == wxT(".aup"))
+			project = project.Mid(0, project.Len() - 4);
+		wxString projName = wxFileNameFromPath(project) + wxT("_data");
+		wxString projPath = wxPathOnly(project);
+
+		mWantSaveCompressed = bWantSaveCompressed;
+		bool success = false;
+
+		if (!wxDir::Exists(projPath)){
+			if (safetyFileName != wxT(""))
+				wxRename(safetyFileName, mFileName);
+			wxMessageBox(wxString::Format(
+				_("Could not save project. Path not found.  Try creating \ndirectory \"%s\" before saving project with this name."),
+				projPath.c_str()),
+				_("Error Saving Project"),
+				wxICON_ERROR, this);
+			return false;
+		}
+
+		if (bWantSaveCompressed)
+		{
+			//v Move this condition into SaveCompressedWaveTracks() if want to support other formats.
+#ifdef USE_LIBVORBIS
+			success = this->SaveCompressedWaveTracks(project);
+#endif
+		}
+		else
+		{
+			// We are about to move files from the current directory to
+			// the new directory.  We need to make sure files that belonged
+			// to the last saved project don't get erased, so we "lock" them, so that
+			// SetProject() copies instead of moves the files.
+			// (Otherwise the new project would be fine, but the old one would
+			// be empty of all of its files.)
+
+			if (mLastSavedTracks && !overwrite)
+				LockAllBlocks();
+
+			// This renames the project directory, and moves or copies
+			// all of our block files over.
+			success = mDirManager->SetProject(projPath, projName, !overwrite);
+
+			if (mLastSavedTracks && !overwrite)
+				UnlockAllBlocks();
+		}
+
+		if (!success) {
+			if (safetyFileName != wxT(""))
+				wxRename(safetyFileName, mFileName);
+			wxMessageBox(wxString::Format(_("Could not save project. Perhaps %s \nis not writable or the disk is full."),
+				project.c_str()),
+				_("Error Saving Project"),
+				wxICON_ERROR, this);
+			return false;
+		}
+	}
+
+	// Write the AUP file.
+	XMLFileWriter saveFile;
+
+	try
+	{
+		saveFile.Open(mFileName, wxT("wb"));
+
+		WriteXMLHeader(saveFile);
+		WriteXML(saveFile);
+
+		saveFile.Close();
+	}
+	catch (XMLFileWriterException* pException)
+	{
+		wxMessageBox(wxString::Format(
+			_("Couldn't write to file \"%s\": %s"),
+			mFileName.c_str(), pException->GetMessage().c_str()),
+			_("Error Saving Project"), wxICON_ERROR);
+
+		delete pException;
+
+		// When XMLWriter throws an exception, it tries to close it before,
+		// so we can at least try to delete the incomplete file and move the
+		// backup file over.
+		if (safetyFileName != wxT(""))
+		{
+			wxRemove(mFileName);
+			wxRename(safetyFileName, mFileName);
+		}
+
+		return false;
+	}
+
+	if (bWantSaveCompressed)
+		mWantSaveCompressed = false; // Don't want this mode for AudacityProject::WriteXML() any more.
+	else
+	{
+		// Now that we have saved the file, we can delete the auto-saved version
+		DeleteCurrentAutoSaveFile();
+
+		if (mIsRecovered)
+		{
+			// This was a recovered file, that is, we have just overwritten the
+			// old, crashed .aup file. There may still be orphaned blockfiles in
+			// this directory left over from the crash, so we delete them now
+			mDirManager->RemoveOrphanBlockfiles();
+
+			// Before we saved this, this was a recovered project, but now it is
+			// a regular project, so remember this.
+			mIsRecovered = false;
+			mRecoveryAutoSaveDataDir = wxT("");
+			SetProjectTitle();
+		}
+		else if (fromSaveAs)
+		{
+			// On save as, always remove orphaned blockfiles that may be left over
+			// because the user is trying to overwrite another project
+			mDirManager->RemoveOrphanBlockfiles();
+		}
+
+		if (mLastSavedTracks) {
+			mLastSavedTracks->Clear(true);
+			delete mLastSavedTracks;
+		}
+
+		mLastSavedTracks = new TrackList();
+
+		TrackListIterator iter(mTracks);
+		Track *t = iter.First();
+		Track *dupT;
+		while (t) {
+			dupT = t->Duplicate();
+			mLastSavedTracks->Add(dupT);
+
+			//only after the xml has been saved we can mark it saved.
+			//thus is because the OD blockfiles change on  background thread while this is going on.
+			//         if(dupT->GetKind() == Track::Wave)
+			//         ((WaveTrack*)dupT)->MarkSaved();
+
+			t = iter.Next();
+		}
+
+		mUndoManager.StateSaved();
+	}
+
+	// If we get here, saving the project was successful, so we can delete
+	// the .bak file (because it now does not fit our block files anymore
+	// anyway).
+	if (safetyFileName != wxT(""))
+		wxRemoveFile(safetyFileName);
+
+	mStatusBar->SetStatusText(wxString::Format(_("Saved %s"),
+		mFileName.c_str()), mainStatusBarField);
+
+	return true;
+}

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -5281,7 +5281,7 @@ bool AudacityProject::SaveFromTimed(wxFileName fnPath, bool overwrite /* = true 
 		bool bHasTracks = (iter.First() != NULL);
 		if (!bHasTracks)
 		{
-			if (mUndoManager.UnsavedChanges() && mEmptyCanBeDirty) {
+			if (GetUndoManager()->UnsavedChanges() && mEmptyCanBeDirty) {
 				int result = wxMessageBox(_("Your project is now empty.\nIf saved, the project will have no tracks.\n\nTo save any previously open tracks:\nClick 'No', Edit > Undo until all tracks\nare open, then File > Save Project.\n\nSave anyway?"),
 					_("Warning - Empty Project"),
 					wxYES_NO | wxICON_QUESTION, this);
@@ -5469,7 +5469,7 @@ bool AudacityProject::SaveFromTimed(wxFileName fnPath, bool overwrite /* = true 
 			t = iter.Next();
 		}
 
-		mUndoManager.StateSaved();
+		GetUndoManager()->StateSaved();
 	}
 
 	// If we get here, saving the project was successful, so we can delete

--- a/src/Project.h
+++ b/src/Project.h
@@ -30,6 +30,7 @@
 #include "xml/XMLTagHandler.h"
 #include "toolbars/SelectionBarListener.h"
 #include "toolbars/SpectralSelectionBarListener.h"
+#include "export\Export.h";
 
 #include <wx/defs.h>
 #include <wx/event.h>
@@ -268,6 +269,10 @@ class AUDACITY_DLL_API AudacityProject final : public wxFrame,
    /** \brief returns a pointer to the wxDialog if it is displayed, NULL otherwise.
      */
    wxDialog *GetMissingAliasFileDialog();
+
+   // Timer Record Auto Save/Export Routines
+   bool SaveFromTimed(wxFileName fnPath, bool overwrite = false, bool fromSaveAs = true, bool bWantSaveCompressed = false);
+   bool ExportFromTimed(wxFileName fnFile, int iFormat, int iSubFormat, int iFilterIndex);
 
 #include "Menus.h"
 

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -345,7 +345,7 @@ void TimerRecordDialog::EnableDisableAutoControls(bool bEnable, int iControlGoup
 		}
 	}
 
-	// Enable or disable the Choice box
+	// Enable or disable the Choice box - if there is no Save or Export then this will be disabled
 	if (m_pTimerAutoSaveCheckBoxCtrl->GetValue() || m_pTimerAutoExportCheckBoxCtrl->GetValue()) {
 		m_pTimerAfterCompleteChoiceCtrl->Enable();
 	}

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -40,11 +40,20 @@
 #define TIMER_ID 7000
 
 enum { // control IDs
-   ID_DATEPICKER_START = 10000,
-   ID_TIMETEXT_START,
-   ID_DATEPICKER_END,
-   ID_TIMETEXT_END,
-   ID_TIMETEXT_DURATION
+	ID_DATEPICKER_START = 10000,
+	ID_TIMETEXT_START,
+	ID_DATEPICKER_END,
+	ID_TIMETEXT_END,
+	ID_TIMETEXT_DURATION,
+	ID_AUTOSAVEPATH_BUTTON,
+	ID_AUTOEXPORTPATH_BUTTON,
+	ID_AUTOSAVE_CHECKBOX,
+	ID_AUTOEXPORT_CHECKBOX
+};
+
+enum {
+	CONTROL_GROUP_SAVE,
+	CONTROL_GROUP_EXPORT
 };
 
 const int kTimerInterval = 50; // ms
@@ -66,6 +75,13 @@ BEGIN_EVENT_TABLE(TimerRecordDialog, wxDialog)
    EVT_BUTTON(wxID_OK, TimerRecordDialog::OnOK)
 
    EVT_TIMER(TIMER_ID, TimerRecordDialog::OnTimer)
+
+   EVT_BUTTON(ID_AUTOSAVEPATH_BUTTON, TimerRecordDialog::OnAutoSavePathButton_Click)
+   EVT_BUTTON(ID_AUTOEXPORTPATH_BUTTON, TimerRecordDialog::OnAutoExportPathButton_Click)
+
+   EVT_CHECKBOX(ID_AUTOSAVE_CHECKBOX, TimerRecordDialog::OnAutoSaveCheckBox_Change)
+   EVT_CHECKBOX(ID_AUTOEXPORT_CHECKBOX, TimerRecordDialog::OnAutoExportCheckBox_Change)
+
 END_EVENT_TABLE()
 
 TimerRecordDialog::TimerRecordDialog(wxWindow* parent)
@@ -210,6 +226,55 @@ void TimerRecordDialog::OnTimeText_Duration(wxCommandEvent& WXUNUSED(event))
    this->UpdateEnd(); // Keep Start constant and update End for changed Duration.
 }
 
+// New events for timer recording automation
+void TimerRecordDialog::OnAutoSavePathButton_Click(wxCommandEvent& WXUNUSED(event))
+{
+	// JKC: I removed 'wxFD_OVERWRITE_PROMPT' because we are checking
+	// for overwrite ourselves later, and we disallow it.
+	// We disallow overwrite because we would have to delete the many
+	// smaller files too, or prompt to move them.
+	wxString fName = FileSelector(_T("Save Timer Recording As"),
+		m_fnAutoSaveFile.GetPath(),
+		m_fnAutoSaveFile.GetFullName(),
+		wxT("aup"),
+		_("Audacity projects") + wxT(" (*.aup)|*.aup"),
+		wxFD_SAVE | wxRESIZE_BORDER | wxFD_OVERWRITE_PROMPT,
+		this);
+
+	if (fName == wxT(""))
+		return;
+
+	m_fnAutoSaveFile = fName;
+	m_fnAutoSaveFile.SetExt(wxT("aup"));
+	this->UpdateTextBoxControls();
+}
+
+void TimerRecordDialog::OnAutoExportPathButton_Click(wxCommandEvent& WXUNUSED(event))
+{
+	AudacityProject* pProject = GetActiveProject();
+	Exporter eExporter;
+
+	// Call the Exporter to set the options required
+	if (eExporter.SetAutoExportOptions(pProject)) {
+		// Populate the options so that we can destroy this instance of the Exporter
+		m_fnAutoExportFile = eExporter.GetAutoExportFileName();
+		m_iAutoExportFormat = eExporter.GetAutoExportFormat();
+		m_iAutoExportSubFormat = eExporter.GetAutoExportSubFormat();
+		m_iAutoExportFilterIndex = eExporter.GetAutoExportFilterIndex();
+
+		// Update the text controls
+		this->UpdateTextBoxControls();
+	}
+}
+
+void TimerRecordDialog::OnAutoSaveCheckBox_Change(wxCommandEvent& WXUNUSED(event)) {
+	EnableDisableAutoControls(m_pTimerAutoSaveCheckBoxCtrl->GetValue(), CONTROL_GROUP_SAVE);
+}
+
+void TimerRecordDialog::OnAutoExportCheckBox_Change(wxCommandEvent& WXUNUSED(event)) {
+	EnableDisableAutoControls(m_pTimerAutoExportCheckBoxCtrl->GetValue(), CONTROL_GROUP_EXPORT);
+}
+
 void TimerRecordDialog::OnOK(wxCommandEvent& WXUNUSED(event))
 {
    this->TransferDataFromWindow();
@@ -220,12 +285,61 @@ void TimerRecordDialog::OnOK(wxCommandEvent& WXUNUSED(event))
       return;
    }
 
+   // Validate that we have a Save and/or Export path setup if the appropriate check box is ticked
+   wxString sTemp = m_fnAutoSaveFile.GetFullPath();
+   if (m_pTimerAutoSaveCheckBoxCtrl->IsChecked()) {
+	   if (!m_fnAutoSaveFile.IsOk() || m_fnAutoSaveFile.IsDir()) {
+		   wxMessageBox(_("Auto save path is invalid."),
+			   _("Error in Auto Save"), wxICON_EXCLAMATION | wxOK);
+		   return;
+	   }
+   }
+   if (m_pTimerAutoExportCheckBoxCtrl->IsChecked()) {
+
+	   if (!m_fnAutoExportFile.IsOk() || m_fnAutoExportFile.IsDir()) {
+		   wxMessageBox(_("Auto export path is invalid."),
+			   _("Error in Auto Export"), wxICON_EXCLAMATION | wxOK);
+		   return;
+	   }
+   }
+
    m_timer.Stop(); // Don't need to keep updating m_DateTime_Start to prevent backdating.
    this->EndModal(wxID_OK);
    wxLongLong duration = m_TimeSpan_Duration.GetSeconds();
    // this will assert if the duration won't fit in a long
    gPrefs->Write(wxT("/TimerRecord/LastDuration"), duration.ToLong());
    gPrefs->Flush();
+}
+
+void TimerRecordDialog::EnableDisableAutoControls(bool bEnable, int iControlGoup) {
+	if (iControlGoup == CONTROL_GROUP_EXPORT) {
+		// Enables or disables a control group based on the params
+		if (bEnable) {
+			m_pTimerExportPathTextCtrl->Enable();
+			m_pTimerExportPathButtonCtrl->Enable();
+		}
+		else {
+			m_pTimerExportPathTextCtrl->Disable();
+			m_pTimerExportPathButtonCtrl->Disable();
+		}
+	}
+	else if (iControlGoup == CONTROL_GROUP_SAVE) {
+		// Enables or disables a control group based on the params
+		if (bEnable) {
+			m_pTimerSavePathTextCtrl->Enable();
+			m_pTimerSavePathButtonCntrl->Enable();
+		}
+		else {
+			m_pTimerSavePathTextCtrl->Disable();
+			m_pTimerSavePathButtonCntrl->Disable();
+		}
+	}
+}
+
+void TimerRecordDialog::UpdateTextBoxControls() {
+	// Will update the text box controls
+	m_pTimerSavePathTextCtrl->SetValue(m_fnAutoSaveFile.GetFullPath());
+	m_pTimerExportPathTextCtrl->SetValue(m_fnAutoExportFile.GetFullPath());
 }
 
 ///Runs the wait for start dialog.  Returns false if the user clicks stop while we are recording
@@ -284,10 +398,32 @@ bool TimerRecordDialog::RunWaitDialog()
    if (updateResult == eProgressCancelled || updateResult == eProgressFailed)
       return false;
 
-   // Success, so let's automatically save it, for safety's sake. 
-   // If user hadn't saved it before, they'll see the Save As dialog.
-   // If user had saved it before, it will safely be saved, automatically. 
-   pProject->Save();
+   // Auto Save and Auto Export routines...
+   bool bOK = false;
+   wxString sErrorMessage = "";
+
+   // Do Auto Save?
+   if (m_bAutoSaveEnabled) {
+	   bOK = pProject->SaveFromTimed(m_fnAutoSaveFile);
+	   if (!bOK) {
+		   // Failed to save
+		   sErrorMessage = _T("Unable to automatically save the timer recording.");
+	   }
+   }
+
+   // Do Auto Export?
+   if (m_bAutoExportEnabled) {
+	   bOK = pProject->ExportFromTimed(m_fnAutoExportFile, m_iAutoExportFormat, m_iAutoExportSubFormat, m_iAutoExportFilterIndex);
+	   if (!bOK) {
+		   sErrorMessage = _T("Unable to automatically export the timer recording.");
+	   }
+   }
+
+   if (sErrorMessage != "") {
+	   // Any errors
+	   wxMessageBox(sErrorMessage, _T("Error"), wxICON_EXCLAMATION | wxOK);
+	   return false;
+   }
 
    return true;
 }
@@ -343,89 +479,133 @@ wxPrintf(wxT("%s\n"), dt.Format().c_str());
 
 void TimerRecordDialog::PopulateOrExchange(ShuttleGui& S)
 {
-   S.SetBorder(5);
-   S.StartVerticalLay(true);
-   {
-      /* i18n-hint: This string is used to configure the controls for times when the recording is
-       * started and stopped. As such it is important that only the alphabetic parts of the string
-       * are translated, with the numbers left exactly as they are.
-       * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
-       * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
-       */
-      wxString strFormat = _("099 h 060 m 060 s");
-      S.StartStatic(_("Start Date and Time"), true);
-      {
-         m_pDatePickerCtrl_Start =
-            safenew wxDatePickerCtrl(this, // wxWindow *parent,
-                                 ID_DATEPICKER_START, // wxWindowID id,
-                                 m_DateTime_Start); // const wxDateTime& dt = wxDefaultDateTime,
-                                 // const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDP_DEFAULT | wxDP_SHOWCENTURY, const wxValidator& validator = wxDefaultValidator, const wxString& name = "datectrl")
-         m_pDatePickerCtrl_Start->SetName(_("Start Date"));
-         m_pDatePickerCtrl_Start->SetRange(wxDateTime::Today(), wxInvalidDateTime); // No backdating.
-         S.AddWindow(m_pDatePickerCtrl_Start);
+	S.SetBorder(5);
+	S.StartTwoColumn();
+	{
+		S.StartVerticalLay(true);
+		{
+			/* i18n-hint: This string is used to configure the controls for times when the recording is
+			* started and stopped. As such it is important that only the alphabetic parts of the string
+			* are translated, with the numbers left exactly as they are.
+			* The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
+			* displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+			*/
+			wxString strFormat = _("099 h 060 m 060 s");
+			S.StartStatic(_("Start Date and Time"), true);
+			{
+				m_pDatePickerCtrl_Start =
+					new wxDatePickerCtrl(this, // wxWindow *parent,
+					ID_DATEPICKER_START, // wxWindowID id,
+					m_DateTime_Start); // const wxDateTime& dt = wxDefaultDateTime,
+				// const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDP_DEFAULT | wxDP_SHOWCENTURY, const wxValidator& validator = wxDefaultValidator, const wxString& name = "datectrl")
+				m_pDatePickerCtrl_Start->SetName(_("Start Date"));
+				m_pDatePickerCtrl_Start->SetRange(wxDateTime::Today(), wxInvalidDateTime); // No backdating.
+				S.AddWindow(m_pDatePickerCtrl_Start);
 
-         m_pTimeTextCtrl_Start = safenew NumericTextCtrl(
-            NumericConverter::TIME, this, ID_TIMETEXT_START);
-         m_pTimeTextCtrl_Start->SetName(_("Start Time"));
-         m_pTimeTextCtrl_Start->SetFormatString(strFormat);
-         m_pTimeTextCtrl_Start->
-            SetValue(wxDateTime_to_AudacityTime(m_DateTime_Start));
-         S.AddWindow(m_pTimeTextCtrl_Start);
-         m_pTimeTextCtrl_Start->EnableMenu(false);
-      }
-      S.EndStatic();
+				m_pTimeTextCtrl_Start = new NumericTextCtrl(
+					NumericConverter::TIME, this, ID_TIMETEXT_START);
+				m_pTimeTextCtrl_Start->SetName(_("Start Time"));
+				m_pTimeTextCtrl_Start->SetFormatString(strFormat);
+				m_pTimeTextCtrl_Start->
+					SetValue(wxDateTime_to_AudacityTime(m_DateTime_Start));
+				S.AddWindow(m_pTimeTextCtrl_Start);
+				m_pTimeTextCtrl_Start->EnableMenu(false);
+			}
+			S.EndStatic();
 
-      S.StartStatic(_("End Date and Time"), true);
-      {
-         m_pDatePickerCtrl_End =
-            safenew wxDatePickerCtrl(this, // wxWindow *parent,
-                                 ID_DATEPICKER_END, // wxWindowID id,
-                                 m_DateTime_End); // const wxDateTime& dt = wxDefaultDateTime,
-                                 // const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDP_DEFAULT | wxDP_SHOWCENTURY, const wxValidator& validator = wxDefaultValidator, const wxString& name = "datectrl")
-         m_pDatePickerCtrl_End->SetRange(m_DateTime_Start, wxInvalidDateTime); // No backdating.
-         m_pDatePickerCtrl_End->SetName(_("End Date"));
-         S.AddWindow(m_pDatePickerCtrl_End);
+			S.StartStatic(_("End Date and Time"), true);
+			{
+				m_pDatePickerCtrl_End =
+					new wxDatePickerCtrl(this, // wxWindow *parent,
+					ID_DATEPICKER_END, // wxWindowID id,
+					m_DateTime_End); // const wxDateTime& dt = wxDefaultDateTime,
+				// const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDP_DEFAULT | wxDP_SHOWCENTURY, const wxValidator& validator = wxDefaultValidator, const wxString& name = "datectrl")
+				m_pDatePickerCtrl_End->SetRange(m_DateTime_Start, wxInvalidDateTime); // No backdating.
+				m_pDatePickerCtrl_End->SetName(_("End Date"));
+				S.AddWindow(m_pDatePickerCtrl_End);
 
-         m_pTimeTextCtrl_End = safenew NumericTextCtrl(
-            NumericConverter::TIME, this, ID_TIMETEXT_END);
-         m_pTimeTextCtrl_End->SetName(_("End Time"));
-         m_pTimeTextCtrl_End->SetFormatString(strFormat);
-         m_pTimeTextCtrl_End->SetValue(wxDateTime_to_AudacityTime(m_DateTime_End));
-         S.AddWindow(m_pTimeTextCtrl_End);
-         m_pTimeTextCtrl_End->EnableMenu(false);
-      }
-      S.EndStatic();
+				m_pTimeTextCtrl_End = new NumericTextCtrl(
+					NumericConverter::TIME, this, ID_TIMETEXT_END);
+				m_pTimeTextCtrl_End->SetName(_("End Time"));
+				m_pTimeTextCtrl_End->SetFormatString(strFormat);
+				m_pTimeTextCtrl_End->SetValue(wxDateTime_to_AudacityTime(m_DateTime_End));
+				S.AddWindow(m_pTimeTextCtrl_End);
+				m_pTimeTextCtrl_End->EnableMenu(false);
+			}
+			S.EndStatic();
 
-      S.StartStatic(_("Duration"), true);
-      {
-         /* i18n-hint: This string is used to configure the controls which shows the recording
-          * duration. As such it is important that only the alphabetic parts of the string
-          * are translated, with the numbers left exactly as they are.
-          * The string 'days' indicates that the first number in the control will be the number of days,
-          * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
-          * number displayed is minutes, and the 's' indicates that the fourth number displayed is
-          * seconds.
-          */
-         wxString strFormat1 = _("099 days 024 h 060 m 060 s");
-         m_pTimeTextCtrl_Duration = safenew NumericTextCtrl(
-            NumericConverter::TIME, this, ID_TIMETEXT_DURATION);
-         m_pTimeTextCtrl_Duration->SetName(_("Duration"));
-         m_pTimeTextCtrl_Duration->SetFormatString(strFormat1);
-         m_pTimeTextCtrl_Duration->
-            SetValue(m_TimeSpan_Duration.GetSeconds().ToDouble());
-         S.AddWindow(m_pTimeTextCtrl_Duration);
-         m_pTimeTextCtrl_Duration->EnableMenu(false);
-      }
-      S.EndStatic();
-   }
-   S.EndVerticalLay();
+			S.StartStatic(_("Duration"), true);
+			{
+				/* i18n-hint: This string is used to configure the controls which shows the recording
+				* duration. As such it is important that only the alphabetic parts of the string
+				* are translated, with the numbers left exactly as they are.
+				* The string 'days' indicates that the first number in the control will be the number of days,
+				* then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
+				* number displayed is minutes, and the 's' indicates that the fourth number displayed is
+				* seconds.
+				*/
+				wxString strFormat1 = _("099 days 024 h 060 m 060 s");
+				m_pTimeTextCtrl_Duration = new NumericTextCtrl(
+					NumericConverter::TIME, this, ID_TIMETEXT_DURATION);
+				m_pTimeTextCtrl_Duration->SetName(_("Duration"));
+				m_pTimeTextCtrl_Duration->SetFormatString(strFormat1);
+				m_pTimeTextCtrl_Duration->
+					SetValue(m_TimeSpan_Duration.GetSeconds().ToDouble());
+				S.AddWindow(m_pTimeTextCtrl_Duration);
+				m_pTimeTextCtrl_Duration->EnableMenu(false);
+			}
+			S.EndStatic();
+		}
+		S.EndVerticalLay();
 
-   S.AddStandardButtons();
+		S.StartVerticalLay(true);
+		{
+			bool bAutoSave = gPrefs->ReadBool("/TimerRecord/AutoSave", false);
+			bool bAutoExport = gPrefs->ReadBool("/TimerRecord/AutoExport", false);
 
-   Layout();
-   Fit();
-   SetMinSize(GetSize());
-   Center();
+			S.StartStatic(_T("Auto Save"), true);
+			{
+
+				// If checked, the project will be saved when the recording is completed
+				m_pTimerAutoSaveCheckBoxCtrl = S.Id(ID_AUTOSAVE_CHECKBOX).AddCheckBox(_T("Enable Auto Save?"), (bAutoSave ? "true" : "false"));
+
+				S.StartHorizontalLay(true);
+				{
+					m_pTimerSavePathTextCtrl = S.AddTextBox(_T("Save Project As:"), "", 50);
+					m_pTimerSavePathTextCtrl->SetEditable(false);
+					m_pTimerSavePathButtonCntrl = S.Id(ID_AUTOSAVEPATH_BUTTON).AddButton(_T("Select"));
+				}
+				S.EndHorizontalLay();
+				this->EnableDisableAutoControls(bAutoSave, CONTROL_GROUP_SAVE);
+			}
+			S.EndStatic();
+
+			S.StartStatic(_T("Auto Export"), true);
+			{
+				m_pTimerAutoExportCheckBoxCtrl = S.Id(ID_AUTOEXPORT_CHECKBOX).AddCheckBox(_T("Enable Auto Export?"), (bAutoExport ? "true" : "false"));
+				S.StartHorizontalLay(true);
+				{
+					m_pTimerExportPathTextCtrl = S.AddTextBox(_T("Export Project As:"), "", 50);
+					m_pTimerExportPathTextCtrl->SetEditable(false);
+					m_pTimerExportPathButtonCtrl = S.Id(ID_AUTOEXPORTPATH_BUTTON).AddButton(_T("Select"));
+				}
+				S.EndHorizontalLay();
+				this->EnableDisableAutoControls(bAutoExport, CONTROL_GROUP_EXPORT);
+			}
+			S.EndStatic();
+
+			S.AddSpace(120);
+
+		}
+		S.EndVerticalLay();
+	}
+
+	S.AddStandardButtons();
+
+	Layout();
+	Fit();
+	SetMinSize(GetSize());
+	Center();
 }
 
 bool TimerRecordDialog::TransferDataFromWindow()
@@ -454,6 +634,14 @@ bool TimerRecordDialog::TransferDataFromWindow()
    m_DateTime_End.SetSecond(sec);
 
    m_TimeSpan_Duration = m_DateTime_End - m_DateTime_Start;
+
+   // Pull the settings from the auto save/export controls and write to the pref file
+   m_bAutoSaveEnabled = m_pTimerAutoSaveCheckBoxCtrl->GetValue();
+   m_bAutoExportEnabled = m_pTimerAutoExportCheckBoxCtrl->GetValue();
+
+   // Save the options back to the prefs file
+   gPrefs->Write("/TimerRecord/AutoSave", m_bAutoSaveEnabled);
+   gPrefs->Write("/TimerRecord/AutoExport", m_bAutoExportEnabled);
 
    return true;
 }

--- a/src/TimerRecordDialog.h
+++ b/src/TimerRecordDialog.h
@@ -20,6 +20,8 @@
 #include <wx/datectrl.h>
 #include <wx/calctrl.h>
 #include <wx/timer.h>
+#include <wx/checkbox.h>
+#include "export/Export.h"
 
 class wxTimerEvent;
 
@@ -54,6 +56,15 @@ private:
    void UpdateEnd(); // Update m_DateTime_End and ctrls based on m_DateTime_Start and m_TimeSpan_Duration.
    int WaitForStart();
 
+   // Timer Recording Automation Control Events
+   void OnAutoSavePathButton_Click(wxCommandEvent& event);
+   void OnAutoExportPathButton_Click(wxCommandEvent& event);
+   void OnAutoSaveCheckBox_Change(wxCommandEvent& event);
+   void OnAutoExportCheckBox_Change(wxCommandEvent& event);
+   // Timer Recording Automation Routines
+   void EnableDisableAutoControls(bool bEnable, int iControlGoup);
+   void UpdateTextBoxControls();
+
 private:
    wxDateTime m_DateTime_Start;
    wxDateTime m_DateTime_End;
@@ -69,6 +80,23 @@ private:
    NumericTextCtrl* m_pTimeTextCtrl_Duration;
 
    wxTimer m_timer;
+
+   // New Controls for Auto Save/Export
+   wxCheckBox *m_pTimerAutoSaveCheckBoxCtrl;
+   wxTextCtrl *m_pTimerSavePathTextCtrl;
+   wxButton *m_pTimerSavePathButtonCntrl;
+   wxCheckBox *m_pTimerAutoExportCheckBoxCtrl;
+   wxTextCtrl *m_pTimerExportPathTextCtrl;
+   wxButton *m_pTimerExportPathButtonCtrl;
+
+   // New variables for the Auto Save/Export
+   bool m_bAutoSaveEnabled;
+   wxFileName m_fnAutoSaveFile;
+   bool m_bAutoExportEnabled;
+   wxFileName m_fnAutoExportFile;
+   int m_iAutoExportFormat;
+   int m_iAutoExportSubFormat;
+   int m_iAutoExportFilterIndex;
 
    DECLARE_EVENT_TABLE();
 };

--- a/src/TimerRecordDialog.h
+++ b/src/TimerRecordDialog.h
@@ -36,7 +36,7 @@ public:
 
    void OnTimer(wxTimerEvent& event);
    ///Runs the wait for start dialog.  Returns false if the user clicks stop.
-   bool RunWaitDialog();
+   int RunWaitDialog();
 
 private:
    void OnDatePicker_Start(wxDateEvent& event);
@@ -65,6 +65,8 @@ private:
    void EnableDisableAutoControls(bool bEnable, int iControlGoup);
    void UpdateTextBoxControls();
 
+   int TimerRecordDialog::ExecutePostRecordActions();
+
 private:
    wxDateTime m_DateTime_Start;
    wxDateTime m_DateTime_End;
@@ -81,15 +83,18 @@ private:
 
    wxTimer m_timer;
 
-   // New Controls for Auto Save/Export
+   // Controls for Auto Save/Export
    wxCheckBox *m_pTimerAutoSaveCheckBoxCtrl;
    wxTextCtrl *m_pTimerSavePathTextCtrl;
-   wxButton *m_pTimerSavePathButtonCntrl;
+   wxButton *m_pTimerSavePathButtonCtrl;
    wxCheckBox *m_pTimerAutoExportCheckBoxCtrl;
    wxTextCtrl *m_pTimerExportPathTextCtrl;
    wxButton *m_pTimerExportPathButtonCtrl;
 
-   // New variables for the Auto Save/Export
+   // After Timer Record Options Choice
+   wxChoice *m_pTimerAfterCompleteChoiceCtrl;
+
+   // Variables for the Auto Save/Export
    bool m_bAutoSaveEnabled;
    wxFileName m_fnAutoSaveFile;
    bool m_bAutoExportEnabled;
@@ -97,6 +102,10 @@ private:
    int m_iAutoExportFormat;
    int m_iAutoExportSubFormat;
    int m_iAutoExportFilterIndex;
+
+   // Variables for After Timer Recording Option
+   wxString m_sTimerAfterCompleteOption;
+   wxArrayString m_sTimerAfterCompleteOptionsArray;
 
    DECLARE_EVENT_TABLE();
 };

--- a/src/TimerRecordDialog.h
+++ b/src/TimerRecordDialog.h
@@ -65,7 +65,7 @@ private:
    void EnableDisableAutoControls(bool bEnable, int iControlGoup);
    void UpdateTextBoxControls();
 
-   int TimerRecordDialog::ExecutePostRecordActions();
+   int TimerRecordDialog::ExecutePostRecordActions(bool bWasStopped);
 
 private:
    wxDateTime m_DateTime_Start;

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -1114,7 +1114,7 @@ bool Exporter::SetAutoExportOptions(AudacityProject *project) {
 
 	// Let user edit MetaData
 	if (mPlugins[mFormat]->GetCanMetaData(mSubFormat)) {
-		if (!(mProject->GetTags()->ShowEditDialog(mProject, _("Edit Metadata Tags"), mProject->GetShowId3Dialog()))) {
+		if (!(project->DoEditMetadata(_("Edit Metadata Tags for Export"), _("Exported Tags"), mProject->GetShowId3Dialog()))) {
 			return false;
 		}
 	}

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -886,6 +886,242 @@ void Exporter::OnFilterChanged(wxFileCtrlEvent & evt)
    mBook->ChangeSelection(index);
 }
 
+bool Exporter::ProcessFromTimed(AudacityProject *project, bool selectedOnly, double t0, double t1, wxFileName fnFile, int iFormat, int iSubFormat, int iFilterIndex)
+{
+	// Save parms
+	mProject = project;
+	mSelectedOnly = selectedOnly;
+	mT0 = t0;
+	mT1 = t1;
+
+	// Auto Export Parameters
+	mFilename = fnFile;
+	mFormat = iFormat;
+	mSubFormat = iSubFormat;
+	mFilterIndex = iFilterIndex;
+
+	// Gather track information
+	if (!ExamineTracks()) {
+		return false;
+	}
+
+	// Check for down mixing
+	if (!CheckMix()) {
+		return false;
+	}
+
+	// Ensure filename doesn't interfere with project files.
+	if (!CheckFilename()) {
+		return false;
+	}
+
+	// Export the tracks
+	bool success = ExportTracks();
+
+	// Get rid of mixerspec
+	if (mMixerSpec) {
+		delete mMixerSpec;
+		mMixerSpec = NULL;
+	}
+
+	return success;
+}
+
+int Exporter::GetAutoExportFormat() {
+	return mFormat;
+}
+
+int Exporter::GetAutoExportSubFormat() {
+	return mSubFormat;
+}
+
+int Exporter::GetAutoExportFilterIndex() {
+	return mFormat;
+}
+
+wxFileName Exporter::GetAutoExportFileName() {
+	return mFilename;
+}
+
+bool Exporter::SetAutoExportOptions(AudacityProject *project) {
+	mFormat = -1;
+	mProject = project;
+
+	wxString maskString;
+	wxString defaultFormat = gPrefs->Read(wxT("/Export/Format"),
+		wxT("WAV"));
+
+	mFilterIndex = 0;
+
+	for (size_t i = 0; i < mPlugins.GetCount(); i++) {
+		for (int j = 0; j < mPlugins[i]->GetFormatCount(); j++)
+		{
+			maskString += mPlugins[i]->GetMask(j) + wxT("|");
+			if (mPlugins[i]->GetFormat(j) == defaultFormat) {
+				mFormat = i;
+				mSubFormat = j;
+			}
+			if (mFormat == -1) mFilterIndex++;
+		}
+	}
+	if (mFormat == -1)
+	{
+		mFormat = 0;
+		mFilterIndex = 0;
+	}
+	maskString.RemoveLast();
+
+	mFilename.SetPath(gPrefs->Read(wxT("/Export/Path"), ::wxGetCwd()));
+	mFilename.SetName(mProject->GetName());
+	while (true) {
+		// Must reset each iteration
+		mBook = NULL;
+
+		FileDialog fd(mProject,
+			mFileDialogTitle,
+			mFilename.GetPath(),
+			mFilename.GetFullName(),
+			maskString,
+			wxFD_SAVE | wxRESIZE_BORDER);
+		mDialog = &fd;
+		mDialog->PushEventHandler(this);
+
+		fd.SetUserPaneCreator(CreateUserPaneCallback, (wxUIntPtr) this);
+		fd.SetFilterIndex(mFilterIndex);
+
+		int result = fd.ShowModal();
+
+		mDialog->PopEventHandler();
+
+		if (result == wxID_CANCEL) {
+			return false;
+		}
+
+		mFilename = fd.GetPath();
+		if (mFilename == wxT("")) {
+			return false;
+		}
+
+		mFormat = fd.GetFilterIndex();
+		mFilterIndex = fd.GetFilterIndex();
+
+		int c = 0;
+		for (size_t i = 0; i < mPlugins.GetCount(); i++)
+		{
+			for (int j = 0; j < mPlugins[i]->GetFormatCount(); j++)
+			{
+				if (mFilterIndex == c)
+				{
+					mFormat = i;
+					mSubFormat = j;
+				}
+				c++;
+			}
+		}
+
+		wxString ext = mFilename.GetExt();
+		wxString defext = mPlugins[mFormat]->GetExtension(mSubFormat).Lower();
+
+		//
+		// Check the extension - add the default if it's not there,
+		// and warn user if it's abnormal.
+		//
+		if (ext.IsEmpty()) {
+			//
+			// Make sure the user doesn't accidentally save the file
+			// as an extension with no name, like just plain ".wav".
+			//
+			if (mFilename.GetName().Left(1) == wxT(".")) {
+				wxString prompt = _("Are you sure you want to export the file as \"") +
+					mFilename.GetFullName() +
+					wxT("\"?\n");
+
+				int action = wxMessageBox(prompt,
+					_("Warning"),
+					wxYES_NO | wxICON_EXCLAMATION);
+				if (action != wxYES) {
+					continue;
+				}
+			}
+
+			mFilename.SetExt(defext);
+		}
+		else if (!mPlugins[mFormat]->CheckFileName(mFilename, mSubFormat))
+		{
+			continue;
+		}
+		else if (!ext.IsEmpty() && !mPlugins[mFormat]->IsExtension(ext, mSubFormat) && ext.CmpNoCase(defext)) {
+			wxString prompt;
+			prompt.Printf(_("You are about to export a %s file with the name \"%s\".\n\nNormally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n\nAre you sure you want to export the file under this name?"),
+				mPlugins[mFormat]->GetFormat(mSubFormat).c_str(),
+				mFilename.GetFullName().c_str(),
+				defext.c_str());
+
+			int action = wxMessageBox(prompt,
+				_("Warning"),
+				wxYES_NO | wxICON_EXCLAMATION);
+			if (action != wxYES) {
+				continue;
+			}
+		}
+
+		if (mFilename.GetFullPath().Length() >= 256) {
+			wxMessageBox(_("Sorry, pathnames longer than 256 characters not supported."));
+			continue;
+		}
+
+		// Check to see if we are writing to a path that a missing aliased file existed at.
+		// This causes problems for the exporter, so we don't allow it.
+		// Overwritting non-missing aliased files is okay.
+		// Also, this can only happen for uncompressed audio.
+		bool overwritingMissingAlias;
+		overwritingMissingAlias = false;
+		for (size_t i = 0; i < gAudacityProjects.GetCount(); i++) {
+			AliasedFileArray aliasedFiles;
+			FindDependencies(gAudacityProjects[i], &aliasedFiles);
+			size_t j;
+			for (j = 0; j< aliasedFiles.GetCount(); j++) {
+				if (mFilename.GetFullPath() == aliasedFiles[j].mFileName.GetFullPath() &&
+					!mFilename.FileExists()) {
+					// Warn and return to the dialog
+					wxMessageBox(_("You are attempting to overwrite an aliased file that is missing.\n\
+								   								   								   								   The file cannot be written because the path is needed to restore the original audio to the project.\n\
+																																   																								   																   								   Choose File > Check Dependencies to view the locations of all missing files.\n\
+																																																																																   																																																   																								   								   If you still wish to export, please choose a different filename or folder."));
+					overwritingMissingAlias = true;
+				}
+			}
+		}
+		if (overwritingMissingAlias)
+			continue;
+
+		if (mFilename.FileExists()) {
+			wxString prompt;
+
+			prompt.Printf(_("A file named \"%s\" already exists.  Replace?"),
+				mFilename.GetFullPath().c_str());
+
+			int action = wxMessageBox(prompt,
+				_("Warning"),
+				wxYES_NO | wxICON_EXCLAMATION);
+			if (action != wxYES) {
+				continue;
+			}
+		}
+
+		break;
+	}
+
+	// Let user edit MetaData
+	if (mPlugins[mFormat]->GetCanMetaData(mSubFormat)) {
+		if (!(mProject->GetTags()->ShowEditDialog(mProject, _("Edit Metadata Tags"), mProject->GetShowId3Dialog()))) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 //----------------------------------------------------------------------------
 // ExportMixerPanel
 //----------------------------------------------------------------------------

--- a/src/export/Export.h
+++ b/src/export/Export.h
@@ -152,6 +152,14 @@ public:
 
    const ExportPluginArray GetPlugins();
 
+   // Auto Export from Timer Recording
+   bool ProcessFromTimed(AudacityProject *project, bool selectedOnly, double t0, double t1, wxFileName fnFile, int iFormat, int iSubFormat, int iFilterIndex);
+   bool SetAutoExportOptions(AudacityProject *project);
+   int GetAutoExportFormat();
+   int GetAutoExportSubFormat();
+   int GetAutoExportFilterIndex();
+   wxFileName GetAutoExportFileName();
+
 private:
 
    bool ExamineTracks();


### PR DESCRIPTION
Hi,

This PR contains the following changes to the Timer Recording process:
- Ability to automatically save project after recording completed
- Ability to automatically export recording when completed
- Option to Close Audacity after timer recording competed.
- WINDOWS ONLY: Ability to shutdown/restart the PC after recording is completed

I look forward to having discussion about this, and hope it can be integrated into Audacity soon.