### PR TITLE
Don't use a separate build script for optional files.

### DIFF
--- a/win/Projects/portaudio-v19/portaudio-v19.vcxproj
+++ b/win/Projects/portaudio-v19/portaudio-v19.vcxproj
@@ -36,7 +36,23 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Label="UserMacros">
+    <UseWdmks>
+    </UseWdmks>
+    <UseWasapi>true</UseWasapi>
+    <UseWmme>true</UseWmme>
+    <UseDs>true</UseDs>
+    <UseAsioSdk Condition=" '$(ASIOSDK_DIR)' != '' And Exists('$(ASIOSDK_DIR)')">$(ASIOSDK_DIR)</UseAsioSdk>
+    <UseJackSdk Condition=" '$(JACKSDK_DIR)' != '' And Exists('$(JACKSDK_DIR)')">$(JACKSDK_DIR)</UseJackSdk>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SdkPreprocessorDefinitions Condition=" '$(UseWdmks)' != '' ">PA_USE_WDMKS=1;$(SdkPreprocessorDefinitions)</SdkPreprocessorDefinitions>
+    <SdkPreprocessorDefinitions Condition=" '$(UseWasapi)' != '' ">PA_USE_WASAPI=1;$(SdkPreprocessorDefinitions)</SdkPreprocessorDefinitions>
+    <SdkPreprocessorDefinitions Condition=" '$(UseWmme)' != '' ">PA_USE_WMME=1;$(SdkPreprocessorDefinitions)</SdkPreprocessorDefinitions>
+    <SdkPreprocessorDefinitions Condition=" '$(UseDs)' != '' ">PA_USE_DS=1;$(SdkPreprocessorDefinitions)</SdkPreprocessorDefinitions>
+    <SdkPreprocessorDefinitions Condition=" '$(UseJackSdk)' != '' ">PA_USE_JACK=1;PA_DYNAMIC_JACK=1;$(SdkPreprocessorDefinitions)</SdkPreprocessorDefinitions>
+    <SdkPreprocessorDefinitions Condition=" '$(UseAsioSdk)' != '' ">PA_USE_ASIO=1;$(SdkPreprocessorDefinitions)</SdkPreprocessorDefinitions>
+  </PropertyGroup>
   <PropertyGroup>
     <_ProjectFileVersion>11.0.60610.1</_ProjectFileVersion>
   </PropertyGroup>
@@ -50,24 +66,13 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
-      <Command>echo on
-setlocal EnableDelayedExpansion
-set CFG="$(ProjectDir)/$(IntDir)config.h"
-
-echo // Automatically generated file &gt;!CFG!
-IF NOT "!ASIOSDK_DIR!" == "" echo #define PA_USE_ASIO 1 &gt;&gt;!CFG!
-IF NOT "!JACKSDK_DIR!" == "" echo #define PA_USE_JACK 1 &gt;&gt;!CFG!
-IF NOT "!JACKSDK_DIR!" == "" echo #define PA_DYNAMIC_JACK 1 &gt;&gt;!CFG!
-rem echo #define PA_USE_WDMKS 1 &gt;&gt;!CFG!
-echo #define PA_USE_WASAPI 1 &gt;&gt;!CFG!
-echo #define PA_USE_WMME 1 &gt;&gt;!CFG!
-echo #define PA_USE_DS 1 &gt;&gt;!CFG!
-</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <AdditionalIncludeDirectories>..\..\..\lib-src\portaudio-v19\include;..\..\..\lib-src\portaudio-v19\src\common;..\..\..\lib-src\portaudio-v19\src\os\win;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;$(SdkPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -75,74 +80,21 @@ echo #define PA_USE_DS 1 &gt;&gt;!CFG!
       <WarningLevel>Level3</WarningLevel>
       <CompileAs>Default</CompileAs>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <ForcedIncludeFiles>$(ProjectDir)\$(Configuration)\config.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <PostBuildEvent>
-      <Command>echo on
-setlocal EnableDelayedExpansion
-set BASE="../../../lib-src/portaudio-v19"
-set CFG=$(ProjectDir)$(Configuration)\config.h
-set INTDIR=$(Configuration)
-set CFLAGS=/O2 /GL /I "!BASE!/include" /I "!BASE!/src/common" /I "!BASE!/src/os/win" /D "WIN32" /D "NDEBUG" /D "_LIB" /D "_MBCS" /GF /FD /EHsc /MD /Gy /Fo"!INTDIR!/" /Fd"!INTDIR!/" /W3 /nologo /c /wd4996 /FI "!CFG!" /errorReport:prompt
-set LIBS=
-
-find "PA_USE_WASAPI 1" "!CFG!"
-IF ERRORLEVEL 1 goto NoWASAPI
-
-cl !CFLAGS! "!BASE!/src/hostapi/wasapi/pa_win_wasapi.c"
-
-:NoWASAPI
-
-find "PA_USE_WDMKS 1" "!CFG!"
-IF ERRORLEVEL 1 goto NoWDMKS
-
-cl !CFLAGS! "!BASE!/src/hostapi/wdmks/pa_win_wdmks.c"
-
-:NoWDMKS
-
-find "PA_USE_ASIO 1" "!CFG!"
-IF ERRORLEVEL 1 goto NoASIO
-
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!BASE!/src/hostapi/asio/pa_asio.cpp"
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!BASE!/src/hostapi/asio/iasiothiscallresolver.cpp"
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!ASIOSDK_DIR!/common/asio.cpp"
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!ASIOSDK_DIR!/host/asiodrivers.cpp"
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!ASIOSDK_DIR!/host/pc/asiolist.cpp"
-
-:NoASIO
-
-find "PA_USE_JACK 1" "!CFG!" &gt;NUL
-IF ERRORLEVEL 1 goto NoJACK
-
-cl !CFLAGS! /I "!JACKSDK_DIR!/includes" "!BASE!/src/hostapi/jack/pa_jack.c"
-cl !CFLAGS! /I "!JACKSDK_DIR!/includes" "!BASE!/src/hostapi/jack/pa_jack_dynload.c"
-
-:NoJACK
-
-lib /OUT:"$(TargetPath)" "!INTDIR!/*.obj" !LIBS!
-</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
-      <Command>echo on
-setlocal EnableDelayedExpansion
-set CFG="$(ProjectDir)/$(IntDir)config.h"
-
-echo // Automatically generated file &gt;!CFG!
-IF NOT "!ASIOSDK_DIR!" == "" echo #define PA_USE_ASIO 1 &gt;&gt;!CFG!
-IF NOT "!JACKSDK_DIR!" == "" echo #define PA_USE_JACK 1 &gt;&gt;!CFG!
-IF NOT "!JACKSDK_DIR!" == "" echo #define PA_DYNAMIC_JACK 1 &gt;&gt;!CFG!
-rem echo #define PA_USE_WDMKS 1 &gt;&gt;!CFG!
-echo #define PA_USE_WASAPI 1 &gt;&gt;!CFG!
-echo #define PA_USE_WMME 1 &gt;&gt;!CFG!
-echo #define PA_USE_DS 1 &gt;&gt;!CFG!
-</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\..\lib-src\portaudio-v19\include;..\..\..\lib-src\portaudio-v19\src\common;..\..\..\lib-src\portaudio-v19\src\os\win;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;$(SdkPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -152,52 +104,10 @@ echo #define PA_USE_DS 1 &gt;&gt;!CFG!
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <ForcedIncludeFiles>$(ProjectDir)\$(Configuration)\config.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <PostBuildEvent>
-      <Command>echo on
-setlocal EnableDelayedExpansion
-set BASE=../../../lib-src/portaudio-v19
-set CFG=$(ProjectDir)$(Configuration)\config.h
-set INTDIR=$(Configuration)
-set CFLAGS=/Od /I "!BASE!/include" /I "!BASE!/src/common" /I "!BASE!/src/os/win" /D "WIN32" /D "_DEBUG" /D "_LIB" /D "_MBCS" /GF /FD /EHsc /RTC1 /MDd /Gy /W3 /nologo /c /ZI /wd4996 /Fo"!INTDIR!/" /FI "!CFG!" /errorReport:prompt
-set LIBS=
-
-find "PA_USE_WASAPI 1" "!CFG!"
-IF ERRORLEVEL 1 goto NoWASAPI
-
-cl !CFLAGS! "!BASE!/src/hostapi/wasapi/pa_win_wasapi.c"
-
-:NoWASAPI
-
-find "PA_USE_WDMKS 1" "!CFG!"
-IF ERRORLEVEL 1 goto NoWDMKS
-
-cl !CFLAGS! "!BASE!/src/hostapi/wdmks/pa_win_wdmks.c"
-
-:NoWDMKS
-
-find "PA_USE_ASIO 1" "!CFG!"
-IF ERRORLEVEL 1 goto NoASIO
-
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!BASE!/src/hostapi/asio/pa_asio.cpp"
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!BASE!/src/hostapi/asio/iasiothiscallresolver.cpp"
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!ASIOSDK_DIR!/common/asio.cpp"
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!ASIOSDK_DIR!/host/asiodrivers.cpp"
-cl !CFLAGS! /I "!ASIOSDK_DIR!/common" /I "!ASIOSDK_DIR!/host" /I "!ASIOSDK_DIR!/host/pc" "!ASIOSDK_DIR!/host/pc/asiolist.cpp"
-
-:NoASIO
-
-find "PA_USE_JACK 1" "!CFG!" &gt;NUL
-IF ERRORLEVEL 1 goto NoJACK
-
-cl !CFLAGS! /I "!JACKSDK_DIR!/includes" "!BASE!/src/hostapi/jack/pa_jack.c"
-cl !CFLAGS! /I "!JACKSDK_DIR!/includes" "!BASE!/src/hostapi/jack/pa_jack_dynload.c"
-
-:NoJACK
-
-lib /OUT:"$(TargetPath)" "!INTDIR!/*.obj" !LIBS!
-</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -214,27 +124,38 @@ lib /OUT:"$(TargetPath)" "!INTDIR!/*.obj" !LIBS!
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\common\pa_trace.c" />
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\wmme\pa_win_wmme.c" />
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\wdmks\pa_win_wdmks.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(UseWdmks)'==''">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\dsound\pa_win_ds.c" />
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\dsound\pa_win_ds_dynlink.c" />
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\asio\iasiothiscallresolver.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(UseAsioSdk)'==''">true</ExcludedFromBuild>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(UseAsioSdk)\common;$(UseAsioSdk)\host;$(UseAsioSdk)\host\pc</AdditionalIncludeDirectories>
     </ClCompile>
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\asio\pa_asio.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(UseAsioSdk)'==''">true</ExcludedFromBuild>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(UseAsioSdk)\common;$(UseAsioSdk)\host;$(UseAsioSdk)\host\pc</AdditionalIncludeDirectories>
     </ClCompile>
-    <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\wasapi\pa_win_wasapi.c" />
+    <ClCompile Include="$(UseAsioSdk)\common\asio.cpp">
+      <ExcludedFromBuild Condition="'$(UseAsioSdk)'==''">true</ExcludedFromBuild>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(UseAsioSdk)\common;$(UseAsioSdk)\host;$(UseAsioSdk)\host\pc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ClCompile Include="$(UseAsioSdk)\host\asiodrivers.cpp">
+      <ExcludedFromBuild Condition="'$(UseAsioSdk)'==''">true</ExcludedFromBuild>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(UseAsioSdk)\common;$(UseAsioSdk)\host;$(UseAsioSdk)\host\pc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ClCompile Include="$(UseAsioSdk)\host\pc\asiolist.cpp">
+      <ExcludedFromBuild Condition="'$(UseAsioSdk)'==''">true</ExcludedFromBuild>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(UseAsioSdk)\common;$(UseAsioSdk)\host;$(UseAsioSdk)\host\pc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\wasapi\pa_win_wasapi.c">
+      <ExcludedFromBuild Condition="'$(UseWasapi)'==''">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\jack\pa_jack.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(UseJackSdk)'==''">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\hostapi\jack\pa_jack_dynload.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(UseJackSdk)'==''">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\os\win\pa_win_coinitialize.c" />
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\os\win\pa_win_hostapis.c" />
@@ -261,12 +182,10 @@ lib /OUT:"$(TargetPath)" "!INTDIR!/*.obj" !LIBS!
     <ClInclude Include="..\..\..\lib-src\portaudio-v19\src\common\pa_util.h" />
     <CustomBuild Include="..\..\..\lib-src\portaudio-v19\src\hostapi\dsound\pa_win_ds_dynlink.h" />
     <CustomBuild Include="..\..\..\lib-src\portaudio-v19\src\hostapi\asio\iasiothiscallresolver.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(UseAsioSdk)'==''">true</ExcludedFromBuild>
     </CustomBuild>
     <CustomBuild Include="..\..\..\lib-src\portaudio-v19\src\hostapi\jack\pa_jack_dynload.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(UseJackSdk)'==''">true</ExcludedFromBuild>
     </CustomBuild>
     <ClInclude Include="..\..\..\lib-src\portaudio-v19\src\os\win\pa_win_coinitialize.h" />
     <ClInclude Include="..\..\..\lib-src\portaudio-v19\include\pa_win_waveformat.h" />

--- a/win/Projects/portaudio-v19/portaudio-v19.vcxproj.filters
+++ b/win/Projects/portaudio-v19/portaudio-v19.vcxproj.filters
@@ -117,6 +117,15 @@
     <ClCompile Include="..\..\..\lib-src\portaudio-v19\src\os\win\pa_x86_plain_converters.c">
       <Filter>Source Files\os</Filter>
     </ClCompile>
+    <ClCompile Include="$(UseAsioSdk)\common\asio.cpp">
+      <Filter>Source Files\hostapi\asio</Filter>
+    </ClCompile>
+    <ClCompile Include="$(UseAsioSdk)\host\asiodrivers.cpp">
+      <Filter>Source Files\hostapi\asio</Filter>
+    </ClCompile>
+    <ClCompile Include="$(UseAsioSdk)\host\pc\asiolist.cpp">
+      <Filter>Source Files\hostapi\asio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\lib-src\portaudio-v19\src\common\pa_allocation.h">


### PR DESCRIPTION
The current portaudio-v19.vcxproj does two builds.  First it runs the normal MSBuild to compile and create a static library.  It then runs a second pass to compile additional files and update the static library.  This change adds the optional files to the main MSBuild, using conditional  <ExcludeFromBuild>s to only include these files when needed.

The preprocessor definitions are added directly to the <PreprocessorDefinitions> instead of through a force-included header file.

This exposes the files in the Visual Studio Solution Explorer, makes the compiler flags used to build the optional files default to the same flags as the non-optional files (and editable in the UI), and eliminates the second cl/lib cycle.
