### PR TITLE
VS2013 needs <functional> for mem_fun_ref

### DIFF
--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -20,6 +20,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../toolbars/ControlToolBar.h"
 
 #include <algorithm>
+#include <functional>
 
 #include <wx/dc.h>
 


### PR DESCRIPTION
The VS2013 build is broken with an undefined mem_fun_ref.  It needs <functional>.