### PR TITLE
Ignore Visual Studio .vcxproj.user files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ mac/tests/
 *.opensdf
 # unsure about the .sal files.  Disable for now.
 *.sal
+*.vcxproj.user
 
 # Precompiled Headers
 *.gch


### PR DESCRIPTION
Visual Studio creates .vcxproj.user files to store local, per-user settings.  These are not under source control, but do clutter the git status.