### PR TITLE
Added a Warnings/Prompts option to disable the save on exit prompt.

### DIFF
--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -2243,9 +2243,14 @@ void AudacityProject::OnCloseWindow(wxCloseEvent & event)
    // MY: Use routine here so other processes can make same check
    bool bHasTracks = ProjectHasTracks();
 
+   // Check to see if the user has opted to prompt for Project Save on Exit
+   // or not
+   bool bAskToSaveOnExit;
+   gPrefs->Read(wxT("/Warnings/ProjectSaveExit"), &bAskToSaveOnExit, true);
+
    // We may not bother to prompt the user to save, if the
    // project is now empty.
-   if (event.CanVeto() && (mEmptyCanBeDirty || bHasTracks)) {
+   if ( bAskToSaveOnExit && event.CanVeto() && (mEmptyCanBeDirty || bHasTracks)) {
       if (GetUndoManager()->UnsavedChanges()) {
 
          wxString Message = _("Save changes before closing?");
@@ -2404,7 +2409,7 @@ void AudacityProject::OnCloseWindow(wxCloseEvent & event)
 
 #if !defined(__WXMAC__)
       if (quitOnClose) {
-         QuitAudacity();
+         QuitAudacity(!bAskToSaveOnExit);
       }
       else {
          wxGetApp().SetWindowRectAlreadySaved(FALSE);

--- a/src/prefs/WarningsPrefs.cpp
+++ b/src/prefs/WarningsPrefs.cpp
@@ -57,6 +57,9 @@ void WarningsPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(_("Saving &projects"),
                     wxT("/Warnings/FirstProjectSave"),
                     true);
+      S.TieCheckBox(_("Saving projects on e&xit"),
+                    wxT("/Warnings/ProjectSaveExit"),
+                    true);
       S.TieCheckBox(_("Saving &empty project"),
                     wxT("/GUI/EmptyCanBeDirty"),
                     true);


### PR DESCRIPTION
I use Audacity trivially and frequently open audio files briefly and then close the program. Audacity lacked a way to disable the save project on exit prompts, so I made that option.

A checkbox is added to the Warnings/Prompts preferences page that allows the user to opt out of the save on exit prompts.