### PR TITLE
Change %Ld to %lld in PluginManager#GetConfig

### DIFF
--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -2662,7 +2662,7 @@ bool PluginManager::GetConfig(const wxString & key, sampleCount & value, sampleC
       wxString wxval = wxEmptyString;
       wxString wxdef;
       wchar_t *endptr;
-      wxdef.Printf(wxT("%Ld"), defval);
+      wxdef.Printf(wxT("%lld"), defval);
 
       result = GetSettings()->Read(key, &wxval, wxdef);
       value = wxStrtoll(wxval.c_str(), &endptr, 10);


### PR DESCRIPTION
As of Visual Studio 2015, calling `wxstring#Printf` with a format `%Ld` throws a fatal exception. This is because the latest MSVC actually implements `snprintf`, and of course they do it differently than GCC. I couldn't find any documentation online regarding the `%Ld` format. It apparently works interchangeably with `%lld` on most compilers, but Microsoft had to be different.