### PR TITLE
bool AudacityApp::OnInit() {    // Ensure we have an event loop durin…

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1403,7 +1403,7 @@ bool AudacityApp::OnInit()
          wxID_ANY,
          wxDefaultPosition,
          wxDefaultSize,
-         wxSTAY_ON_TOP);
+		 0); // wxSTAY_ON_TOP);
       temporarywindow.SetTitle(_("Audacity is starting up..."));
       SetTopWindow(&temporarywindow);
       wxEventLoopBase::GetActive()->YieldFor(wxEVT_CATEGORY_UI);
@@ -1444,29 +1444,10 @@ bool AudacityApp::OnInit()
 
 #endif //__WXMAC__
 
-      project = CreateNewAudacityProject();
-      mCmdHandler->SetProject(project);
-      wxWindow * pWnd = MakeHijackPanel();
-      if (pWnd)
-      {
-         project->Show(false);
-         pWnd->SetParent(project);
-         SetTopWindow(pWnd);
-         pWnd->Show(true);
-      }
+ 
+	  temporarywindow.Show(false);
 
-      temporarywindow.Show(false);
    }
-
-   if( project->mShowSplashScreen )
-      project->OnHelpWelcome();
-
-   // JKC 10-Sep-2007: Enable monitoring from the start.
-   // (recommended by lprod.org).
-   // Monitoring stops again after any
-   // PLAY or RECORD completes.
-   // So we also call StartMonitoring when STOP is called.
-   project->MayStartMonitoring();
 
    #ifdef USE_FFMPEG
    FFmpegStartup();
@@ -1507,7 +1488,32 @@ bool AudacityApp::OnInit()
 #endif
    }
 
+   wxWindow * pWnd = MakeHijackPanel();
+   if (pWnd)
+   {
+	   project->Show(false);
+	   pWnd->SetParent(project);
+	   SetTopWindow(pWnd);
+	   pWnd->Show(true);
+   }
+
+
+
    gInited = true;
+
+   project = CreateNewAudacityProject();
+   mCmdHandler->SetProject(project);
+   if (project->mShowSplashScreen)
+	   project->OnHelpWelcome();
+
+   // JKC 10-Sep-2007: Enable monitoring from the start.
+   // (recommended by lprod.org).
+   // Monitoring stops again after any
+   // PLAY or RECORD completes.
+   // So we also call StartMonitoring when STOP is called.
+   project->MayStartMonitoring();
+
+
 
    ModuleManager::Get().Dispatch(AppInitialized);
 
@@ -1517,8 +1523,7 @@ bool AudacityApp::OnInit()
    mTimer.Start(200);
 
    return TRUE;
-}
-
+} 
 void AudacityApp::InitCommandHandler()
 {
    mCmdHandler = new CommandHandler(*this);


### PR DESCRIPTION
…g initialization    wxEventLoopGuarantor eventLoop;    std::unique_ptr < wxLog > { wxLog::SetActiveTarget(new AudacityLogger) }; // DELETE    mLocale = NULL;    m_aliasMissingWarningShouldShow = true;    m_LastMissingBlockFile = NULL;    mChecker = NULL;    mIPCServ = NULL; #if defined(__WXMAC__)    // Disable window animation    wxSystemOptions::SetOption(wxMAC_WINDOW_PLAIN_TRANSITION, 1); #endif #ifdef AUDACITY_NAME    wxString appName = wxT(AUDACITY_NAME); #else    wxString appName = wxT("Audacity"); #endif    wxTheApp->SetAppName(appName);    // Explicitly set since OSX will use it for the "Quit" menu item    wxTheApp->SetAppDisplayName(wxT("Audacity"));    wxTheApp->SetVendorName(wxT("Audacity"));    // Unused strings that we want to be translated, even though    // we're not using them yet...    wxString future1 = _("Master Gain Control");    ::wxInitAllImageHandlers();    wxFileSystem::AddHandler(new wxZipFSHandler);    //    // Paths: set search path and temp dir path    // #ifdef __WXGTK__    /* Search path (for plug-ins, translations etc) is (in this order):       * The AUDACITY_PATH environment variable       * The current directory       * The user's .audacity-files directory in their home directory       * The "share" and "share/doc" directories in their install path */    wxString home = wxGetHomeDir();    /* On Unix systems, the default temp dir is in /var/tmp. */    defaultTempDir.Printf(wxT("/var/tmp/audacity-%s"), wxGetUserId().c_str());    wxString pathVar = wxGetenv(wxT("AUDACITY_PATH"));    if (pathVar != wxT(""))       AddMultiPathsToPathList(pathVar, audacityPathList);    AddUniquePathToPathList(::wxGetCwd(), audacityPathList); #ifdef AUDACITY_NAME    AddUniquePathToPathList(wxString::Format(wxT("%s/.%s-files"),       home.c_str(), wxT(AUDACITY_NAME)),       audacityPathList);    AddUniquePathToPathList(wxString::Format(wxT("%s/share/%s"),       wxT(INSTALL_PREFIX), wxT(AUDACITY_NAME)),       audacityPathList);    AddUniquePathToPathList(wxString::Format(wxT("%s/share/doc/%s"),       wxT(INSTALL_PREFIX), wxT(AUDACITY_NAME)),       audacityPathList); #else //AUDACITY_NAME    AddUniquePathToPathList(wxString::Format(wxT("%s/.audacity-files"),       home.c_str()),       audacityPathList);    AddUniquePathToPathList(wxString::Format(wxT("%s/share/audacity"),       wxT(INSTALL_PREFIX)),       audacityPathList);    AddUniquePathToPathList(wxString::Format(wxT("%s/share/doc/audacity"),       wxT(INSTALL_PREFIX)),       audacityPathList); #endif //AUDACITY_NAME    AddUniquePathToPathList(wxString::Format(wxT("%s/share/locale"),       wxT(INSTALL_PREFIX)),       audacityPathList);    AddUniquePathToPathList(wxString::Format(wxT("./locale")),       audacityPathList); #endif //__WXGTK__    wxFileName tmpFile;    tmpFile.AssignTempFileName(wxT("nn"));    wxString tmpDirLoc = tmpFile.GetPath(wxPATH_GET_VOLUME);    ::wxRemoveFile(tmpFile.GetFullPath());    // On Mac and Windows systems, use the directory which contains Audacity. #ifdef __WXMSW__    // On Windows, the path to the Audacity program is in argv[0]    wxString progPath = wxPathOnly(argv[0]);    AddUniquePathToPathList(progPath, audacityPathList);    AddUniquePathToPathList(progPath + wxT("\\Languages"), audacityPathList);    // See bug #1271 for explanation of location    tmpDirLoc = FileNames::MkDir(wxStandardPaths::Get().GetUserLocalDataDir());    defaultTempDir.Printf(wxT("%s\\SessionData"),       tmpDirLoc.c_str()); #endif //__WXWSW__ #ifdef __WXMAC__    // On Mac OS X, the path to the Audacity program is in argv[0]    wxString progPath = wxPathOnly(argv[0]);    AddUniquePathToPathList(progPath, audacityPathList);    // If Audacity is a "bundle" package, then the root directory is    // the great-great-grandparent of the directory containing the executable.    AddUniquePathToPathList(progPath + wxT("/../../../"), audacityPathList);    // These allow for searching the "bundle"    AddUniquePathToPathList(progPath + wxT("/../"), audacityPathList);    AddUniquePathToPathList(progPath + wxT("/../Resources"), audacityPathList);    defaultTempDir.Printf(wxT("%s/audacity-%s"),       tmpDirLoc.c_str(),       wxGetUserId().c_str()); #endif //__WXMAC__    // Define languanges for which we have translations, but that are not yet    // supported by wxWidgets.    //    // TODO:  The whole Language initialization really need to be reworked.    //        It's all over the place. #if !wxCHECK_VERSION(3, 0, 1)    for (size_t i = 0, cnt = WXSIZEOF(userLangs); i < cnt; i++)    {       wxLocale::AddLanguage(userLangs[i]);    } #endif    // Initialize preferences and language    InitPreferences(); #if defined(__WXMSW__) && !defined(__WXUNIVERSAL__) && !defined(__CYGWIN__)    this->AssociateFileTypes(); #endif    // TODO - read the number of files to store in history from preferences    mRecentFiles = new FileHistory(ID_RECENT_LAST - ID_RECENT_FIRST + 1, ID_RECENT_CLEAR);    mRecentFiles->Load(*gPrefs, wxT("RecentFiles"));    theTheme.EnsureInitialised();    // AColor depends on theTheme.    AColor::Init();    // Init DirManager, which initializes the temp directory    // If this fails, we must exit the program.    if (!InitTempDir()) {       FinishPreferences();       return false;    }    //<<<< Try to avoid dialogs before this point.    // The reason is that InitTempDir starts the single instance checker.    // If we're waiitng in a dialog before then we can very easily    // start multiple instances, defeating the single instance checker.    // Initialize the CommandHandler    InitCommandHandler();    // Initialize the PluginManager    PluginManager::Get().Initialize();    // Initialize the ModuleManager, including loading found modules    ModuleManager::Get().Initialize(*mCmdHandler);    // Parse command line and handle options that might require    // immediate exit...no need to initialize all of the audio    // stuff to display the version string.    auto parser = ParseCommandLine();    if (!parser)    {       // Either user requested help or a parsing error occured       exit(1);    }    if (parser->Found(wxT("v")))    {       wxFprintf(stderr, wxT("Audacity v%s\n"), AUDACITY_VERSION_STRING);       exit(0);    }    long lval;    if (parser->Found(wxT("b"), &lval))    {       if (lval < 256 || lval > 100000000)       {          wxPrintf(_("Block size must be within 256 to 100000000\n"));          exit(1);       }       Sequence::SetMaxDiskBlockSize(lval);    }    wxString fileName;    if (parser->Found(wxT("d"), &fileName))    {       AutoSaveFile asf;       if (asf.Decode(fileName))       {          wxPrintf(_("File decoded successfully\n"));       }       else       {          wxPrintf(_("Decoding failed\n"));       }       exit(1);    }    // BG: Create a temporary window to set as the top window    wxImage logoimage((const char **)AudacityLogoWithName_xpm);    logoimage.Rescale(logoimage.GetWidth() / 2, logoimage.GetHeight() / 2);    wxBitmap logo(logoimage);    AudacityProject *project;    {       wxSplashScreen temporarywindow(          logo,          wxSPLASH_CENTRE_ON_SCREEN | wxSPLASH_NO_TIMEOUT,          0,          NULL,          wxID_ANY,          wxDefaultPosition,          wxDefaultSize, 		 0); // wxSTAY_ON_TOP);       temporarywindow.SetTitle(_("Audacity is starting up..."));       SetTopWindow(&temporarywindow);       wxEventLoopBase::GetActive()->YieldFor(wxEVT_CATEGORY_UI);       //JKC: Would like to put module loading here.       // More initialization       InitDitherers();       InitAudioIO(); #ifdef __WXMAC__       // On the Mac, users don't expect a program to quit when you close the last window.       // Create a menubar that will show when all project windows are closed.       wxMenu *fileMenu = new wxMenu();       wxMenu *recentMenu = new wxMenu();       fileMenu->Append(wxID_NEW, wxString(_("&New")) + wxT("\tCtrl+N"));       fileMenu->Append(wxID_OPEN, wxString(_("&Open...")) + wxT("\tCtrl+O"));       fileMenu->AppendSubMenu(recentMenu, _("Open &Recent..."));       fileMenu->Append(wxID_ABOUT, _("&About Audacity..."));       fileMenu->Append(wxID_PREFERENCES, wxString(_("&Preferences...")) + wxT("\tCtrl+,"));       {          auto menuBar = std::make_unique<wxMenuBar>();          menuBar->Append(fileMenu, _("&File"));          // PRL:  Are we sure wxWindows will not leak this menuBar?          // The online documentation is not explicit.          wxMenuBar::MacSetCommonMenuBar(menuBar.release());       }       mRecentFiles->UseMenu(recentMenu);       mRecentFiles->AddFilesToMenu(recentMenu);       SetExitOnFrameDelete(false); #endif //__WXMAC__   	  temporarywindow.Show(false);    }    #ifdef USE_FFMPEG    FFmpegStartup();    #endif    Importer::Get().Initialize();    //    // Auto-recovery    //    bool didRecoverAnything = false;    if (!ShowAutoRecoveryDialogIfNeeded(&project, &didRecoverAnything))    {       // Important: Prevent deleting any temporary files!       DirManager::SetDontDeleteTempFiles();       QuitAudacity(true);       return false;    }    //    // Remainder of command line parsing, but only if we didn't recover    //    if (!didRecoverAnything)    {       if (parser->Found(wxT("t")))       {          RunBenchmark(NULL);          return false;       } // As of wx3, there's no need to process the filename arguments as they // will be sent view the MacOpenFile() method. #if !defined(__WXMAC__)       for (size_t i = 0, cnt = parser->GetParamCount(); i < cnt; i++)       {          MRUOpen(parser->GetParam(i));       } #endif    }    wxWindow * pWnd = MakeHijackPanel();    if (pWnd)    { 	   project->Show(false); 	   pWnd->SetParent(project); 	   SetTopWindow(pWnd); 	   pWnd->Show(true);    }    gInited = true;    project = CreateNewAudacityProject();    mCmdHandler->SetProject(project);    if (project->mShowSplashScreen) 	   project->OnHelpWelcome();    // JKC 10-Sep-2007: Enable monitoring from the start.    // (recommended by lprod.org).    // Monitoring stops again after any    // PLAY or RECORD completes.    // So we also call StartMonitoring when STOP is called.    project->MayStartMonitoring();    ModuleManager::Get().Dispatch(AppInitialized);    mWindowRectAlreadySaved = FALSE;    mTimer.SetOwner(this, kAudacityAppTimerID);    mTimer.Start(200);    return TRUE; }