### PR TITLE
Bug 1403: Two column Progress Dialog message

### DIFF
--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -568,7 +568,7 @@ int TimerRecordDialog::RunWaitDialog()
          progress(m_TimeSpan_Duration.GetMilliseconds().GetValue(),
                   _("Audacity Timer Record Progress"),
                   strMsg,
-                  pdlgHideCancelButton | pdlgConfirmStopCancel);
+                  pdlgHideCancelButton | pdlgConfirmStopCancel | pdlgTwoColumnDialog);
 
       // Make sure that start and end time are updated, so we always get the full
       // duration, even if there's some delay getting here.
@@ -1039,7 +1039,7 @@ int TimerRecordDialog::WaitForStart()
    TimerProgressDialog progress(waitDuration.GetMilliseconds().GetValue(),
       _("Audacity Timer Record - Waiting for Start"),
       strMsg,
-      pdlgHideStopButton | pdlgConfirmStopCancel | pdlgHideElapsedTime,
+      pdlgHideStopButton | pdlgConfirmStopCancel | pdlgHideElapsedTime | pdlgTwoColumnDialog,
       _("Recording will commence in:"));
 
    int updateResult = eProgressSuccess;
@@ -1076,7 +1076,7 @@ int TimerRecordDialog::PreActionDelay(int iActionIndex, TimerRecordCompletedActi
    TimerProgressDialog dlgAction(tsWait.GetMilliseconds().GetValue(),
                           _("Audacity Timer Record - Waiting"),
                           sMessage,
-                          pdlgHideStopButton | pdlgHideElapsedTime,
+                          pdlgHideStopButton | pdlgHideElapsedTime | pdlgTwoColumnDialog,
                           sCountdownLabel);
 
    int iUpdateResult = eProgressSuccess;

--- a/src/widgets/ProgressDialog.h
+++ b/src/widgets/ProgressDialog.h
@@ -7,6 +7,9 @@
   Copyright
      Leland Lucius
      Vaughan Johnson
+   
+  Modifications
+     Mark Young
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -38,13 +41,14 @@ enum
 
 enum ProgressDialogFlags
 {
-   pdlgEmptyFlags = 0x00000000,
-   pdlgHideStopButton = 0x00000001,
-   pdlgHideCancelButton = 0x00000002,
-   pdlgHideElapsedTime = 0x00000004,
-   pdlgConfirmStopCancel = 0x00000008,
+   pdlgEmptyFlags          = 0,
+   pdlgHideStopButton      = (1 << 0), /* 1 */
+   pdlgHideCancelButton    = (1 << 1), /* 2 */
+   pdlgHideElapsedTime     = (1 << 2), /* 4 */
+   pdlgConfirmStopCancel   = (1 << 3), /* 8 */
+   pdlgTwoColumnDialog     = (1 << 4), /* 16 */
 
-   pdlgDefaultFlags = pdlgEmptyFlags
+   pdlgDefaultFlags        = pdlgEmptyFlags
 };
 
 ////////////////////////////////////////////////////////////
@@ -117,6 +121,9 @@ private:
    wxStaticText *mMessage;
    int mLastW;
    int mLastH;
+
+   wxStaticText *mMessageOne;
+   wxStaticText *mMessageTwo;
 
    DECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
Fix for Bug 1403... Added functionality to ally the progress dialog message to be displayed in two columns.

\t will switch to column 2,
\n will switch to column 1 again with a new line when this flag is set.

Example build: http://audacity.tip2tail.scot/builds/20160630-tip2tail-B.zip