### PR TITLE
Fixed capitalisation of "Audacity" in TimerRecord

### DIFF
--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -918,7 +918,7 @@ void TimerRecordDialog::PopulateOrExchange(ShuttleGui& S)
 
             wxArrayString arrayOptions;
             arrayOptions.Add(_("Do nothing"));
-            arrayOptions.Add(_("Exit audacity"));
+            arrayOptions.Add(_("Exit Audacity"));
             arrayOptions.Add(_("Restart system"));
             arrayOptions.Add(_("Shutdown system"));
 


### PR DESCRIPTION
The word "audacity" in the Post Timer Recording action dropdown has been fixed to read "Audacity" as a proper noun.