### PR TITLE
Bug 1403: Two Column Progress Dialogs

### DIFF
--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -550,25 +550,28 @@ int TimerRecordDialog::RunWaitDialog()
       bool bIsRecording = true;
 
       wxString sPostAction = m_pTimerAfterCompleteChoiceCtrl->GetString(m_pTimerAfterCompleteChoiceCtrl->GetSelection());
-      wxString strMsg;
-      strMsg.Printf(_("Recording start:\t\t\t%s\n") +
-         _("Duration:\t\t\t%s\n") +
-         _("Recording end:\t\t\t%s\n\n") +
-         _("Automatic Save enabled:\t\t%s\n") +
-         _("Automatic Export enabled:\t\t%s\n") +
-         _("Action after Timer Recording:\t%s"),
-         GetDisplayDate(m_DateTime_Start).c_str(),
-         m_TimeSpan_Duration.Format(),
-         GetDisplayDate(m_DateTime_End).c_str(),
-         (m_bAutoSaveEnabled ? _("Yes") : _("No")),
-         (m_bAutoExportEnabled ? _("Yes") : _("No")),
-         sPostAction);
+      wxString strMsgCol1 = _("Recording start:\n") +
+         _("Duration:\n") +
+         _("Recording end:\n") +
+         _("\n") +
+         _("Automatic Save enabled:\n") +
+         _("Automatic Export enabled:\n") +
+         _("Action after Timer Recording:");
+
+      wxString strMsgCol2 = GetDisplayDate(m_DateTime_Start) + wxT("\n") +
+         m_TimeSpan_Duration.Format() + wxT("\n") +
+         GetDisplayDate(m_DateTime_End) + wxT("\n") +
+         wxT("\n") +
+         (m_bAutoSaveEnabled ? _("Yes") : _("No")) + wxT("\n") +
+         (m_bAutoExportEnabled ? _("Yes") : _("No")) + wxT("\n") +
+         sPostAction;
 
       TimerProgressDialog
          progress(m_TimeSpan_Duration.GetMilliseconds().GetValue(),
                   _("Audacity Timer Record Progress"),
-                  strMsg,
-                  pdlgHideCancelButton | pdlgConfirmStopCancel);
+                  strMsgCol1,
+                  pdlgHideCancelButton | pdlgConfirmStopCancel | pdlgTwoColumnDialog,
+                  strMsgCol2);
 
       // Make sure that start and end time are updated, so we always get the full
       // duration, even if there's some delay getting here.
@@ -1020,26 +1023,28 @@ int TimerRecordDialog::WaitForStart()
 
    /* i18n-hint: Time specifications like "Sunday 28th October 2007 15:16:17 GMT"
    * but hopefully translated by wxwidgets will be inserted into this */
-   wxString strMsg;
-   strMsg.Printf(_("Waiting to start recording at:\t%s\n") +
-      _("Recording duration:\t\t%s\n") +
-      _("Scheduled to stop at:\t\t%s\n\n") +
-      _("Automatic Save enabled:\t\t%s\n") +
-      _("Automatic Export enabled:\t\t%s\n") +
-      _("Action after Timer Recording:\t%s"),
-      GetDisplayDate(m_DateTime_Start).c_str(),
-      m_TimeSpan_Duration.Format(),
-      GetDisplayDate(m_DateTime_End).c_str(),
-      (m_bAutoSaveEnabled ? _("Yes") : _("No")),
-      (m_bAutoExportEnabled ? _("Yes") : _("No")),
-      sPostAction);
+   wxString strMsgCol1 = _("Waiting to start recording at:\n") +
+      _("Recording duration:\n") +
+      _("Scheduled to stop at:\n") +
+      _("\n") +
+      _("Automatic Save enabled:\n") +
+      _("Automatic Export enabled:\n") +
+      _("Action after Timer Recording:");
+   wxString strMsgCol2 = GetDisplayDate(m_DateTime_Start) + wxT("\n") +
+      m_TimeSpan_Duration.Format() + wxT("\n") +
+      GetDisplayDate(m_DateTime_End) + wxT("\n") +
+      wxT("\n") +
+      (m_bAutoSaveEnabled ? _("Yes") : _("No")) + wxT("\n") + 
+      (m_bAutoExportEnabled ? _("Yes") : _("No")) + wxT("\n") +
+      sPostAction;
 
    wxDateTime startWait_DateTime = wxDateTime::UNow();
    wxTimeSpan waitDuration = m_DateTime_Start - startWait_DateTime;
    TimerProgressDialog progress(waitDuration.GetMilliseconds().GetValue(),
       _("Audacity Timer Record - Waiting for Start"),
-      strMsg,
-      pdlgHideStopButton | pdlgConfirmStopCancel | pdlgHideElapsedTime,
+      strMsgCol1,
+      pdlgHideStopButton | pdlgConfirmStopCancel | pdlgHideElapsedTime | pdlgTwoColumnDialog,
+      strMsgCol2,
       _("Recording will commence in:"));
 
    int updateResult = eProgressSuccess;
@@ -1060,14 +1065,16 @@ int TimerRecordDialog::PreActionDelay(int iActionIndex, TimerRecordCompletedActi
    sCountdownLabel.Printf("%s in:", sAction);
 
    // Build a clearer message...
-   wxString sMessage;
-   sMessage.Printf(_("Timer Recording completed.\n\n") +
-      _("Recording Saved:\t\t\t%s\n") +
-      _("Recording Exported:\t\t%s\n") +
-      _("Action after Timer Recording:\t%s"),
-      ((eCompletedActions & TR_ACTION_SAVED) ? _("Yes") : _("No")),
-      ((eCompletedActions & TR_ACTION_EXPORTED) ? _("Yes") : _("No")),
-      sAction);
+   wxString sMessageCol1 = _("Timer Recording completed.\n") +
+      wxT("\n") +
+      _("Recording Saved:\n") +
+      _("Recording Exported:\n") +
+      _("Action after Timer Recording:");
+   wxString sMessageCol2 = _("") + wxT("\n") +
+      wxT("\n") +
+      ((eCompletedActions & TR_ACTION_SAVED) ? _("Yes") : _("No")) + wxT("\n") +
+      ((eCompletedActions & TR_ACTION_EXPORTED) ? _("Yes") : _("No")) + wxT("\n") + 
+      sAction;
 
    wxDateTime dtNow = wxDateTime::UNow();
    wxTimeSpan tsWait = wxTimeSpan(0, 1, 0, 0);
@@ -1075,8 +1082,9 @@ int TimerRecordDialog::PreActionDelay(int iActionIndex, TimerRecordCompletedActi
 
    TimerProgressDialog dlgAction(tsWait.GetMilliseconds().GetValue(),
                           _("Audacity Timer Record - Waiting"),
-                          sMessage,
-                          pdlgHideStopButton | pdlgHideElapsedTime,
+                          sMessageCol1,
+                          pdlgHideStopButton | pdlgHideElapsedTime | pdlgTwoColumnDialog,
+                          sMessageCol2,
                           sCountdownLabel);
 
    int iUpdateResult = eProgressSuccess;

--- a/src/widgets/ProgressDialog.h
+++ b/src/widgets/ProgressDialog.h
@@ -7,6 +7,9 @@
   Copyright
      Leland Lucius
      Vaughan Johnson
+   
+  Modifications
+     Mark Young
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -38,13 +41,14 @@ enum
 
 enum ProgressDialogFlags
 {
-   pdlgEmptyFlags = 0x00000000,
-   pdlgHideStopButton = 0x00000001,
-   pdlgHideCancelButton = 0x00000002,
-   pdlgHideElapsedTime = 0x00000004,
-   pdlgConfirmStopCancel = 0x00000008,
+   pdlgEmptyFlags          = 0,
+   pdlgHideStopButton      = (1 << 0), /* 1 */
+   pdlgHideCancelButton    = (1 << 1), /* 2 */
+   pdlgHideElapsedTime     = (1 << 2), /* 4 */
+   pdlgConfirmStopCancel   = (1 << 3), /* 8 */
+   pdlgTwoColumnDialog     = (1 << 4), /* 16 */
 
-   pdlgDefaultFlags = pdlgEmptyFlags
+   pdlgDefaultFlags        = pdlgEmptyFlags
 };
 
 ////////////////////////////////////////////////////////////
@@ -58,6 +62,7 @@ public:
    ProgressDialog(const wxString & title,
                   const wxString & message = wxEmptyString,
                   int flags = pdlgDefaultFlags,
+                  const wxString & sCol2Message = wxEmptyString,
                   const wxString & sRemainingLabelText = wxEmptyString);
    virtual ~ProgressDialog();
 
@@ -65,6 +70,7 @@ public:
    virtual bool Create(const wxString & title,
                        const wxString & message = wxEmptyString,
                        int flags = pdlgDefaultFlags,
+                       const wxString & sCol2Message = wxEmptyString,
                        const wxString & sRemainingLabelText = wxEmptyString);
 
    int Update(int value, const wxString & message = wxEmptyString);
@@ -95,6 +101,7 @@ protected:
    // MY: Booleans to hold the flag values
    bool m_bShowElapsedTime = true;
    bool m_bConfirmAction = false;
+   bool m_bTwoColumns = false;
 
 private:
    void Init();
@@ -108,15 +115,19 @@ private:
                       const wxString & sTitle,
                       int iButtonID = -1);
 
+   wxStaticText* NewMessageStaticTextControl(const wxString & sText);
+
 private:
    // This guarantees we have an active event loop...possible during OnInit()
    wxEventLoopGuarantor mLoop;
 
    wxWindowDisabler *mDisable;
 
-   wxStaticText *mMessage;
    int mLastW;
    int mLastH;
+
+   wxStaticText *mMessageOne;
+   wxStaticText *mMessageTwo;
 
    DECLARE_EVENT_TABLE();
 };
@@ -128,6 +139,7 @@ public:
                        const wxString & title,
                        const wxString & message = wxEmptyString,
                        int flags = pdlgDefaultFlags,
+                       const wxString & sCol2Message = wxEmptyString,
                        const wxString & sRemainingLabelText = wxEmptyString);
    int Update(const wxString & message = wxEmptyString);
 


### PR DESCRIPTION
Bug 1403: Amended ProgressDialog and TimerProgressDialog classes to allow

for a two column message.  The text for each column is created with a separate
parameter when a given flag is set.
Amendments made to Timer Record to take advantage of this new layout.

Code redesigned to better reflect accepted Audacity coding standards.