### PR TITLE
Reduced CPU usage of Audacity when idle.

### DIFF
--- a/src/widgets/OverlayPanel.h
+++ b/src/widgets/OverlayPanel.h
@@ -22,7 +22,7 @@ public:
                 // default as for wxPanel:
                 long style = wxTAB_TRAVERSAL | wxNO_BORDER);
 
-   // Register and unregister overlay objects.
+   // Registers and unregisters overlay objects.
    // The sequence in which they were registered is the sequence in
    // which they are painted.
    // OverlayPanel is not responsible for their memory management.
@@ -31,9 +31,14 @@ public:
    bool RemoveOverlay(Overlay *pOverlay);
    void ClearOverlays();
 
-   // Erase and redraw things like the cursor, cheaply and directly to the
-   // client area, without full refresh.
-   void DrawOverlays(bool repaint, wxDC *pDC = nullptr);
+   // Erases and redraws to the client area the overlays that have
+   // been previously added with AddOverlay(). If "repaint_all" is
+   // true, all overlays will be erased and re-drawn. Otherwise, only
+   // the ones that are out-of-date, as well as the intersecting ones,
+   // will be erased and re-drawn.
+   // pDC can be null, in which case, DrawOverlays() will create a
+   // wxClientDC internally when necessary.
+   void DrawOverlays(bool repaint_all, wxDC *pDC = nullptr);
    
 private:
    std::vector<Overlay*> mOverlays;


### PR DESCRIPTION
Before this change, an idle Audacity on a recent Linux laptop uses 6%
of CPU. This is because DrawOverlays() is called every 50ms through a
timer in TrackPanel, which instanciates a wxClientDC. This is quite
expensive and dominates the profiles: creating wxClientDCs is 84% of
the CPU audacity spends while idle, according to callgrind. With this
change, we avoid creating wxClientDCs when it's not necessary.

After this change, and idle Audacity consumes 1.6% of CPU, and most of
the time is spent in gtk/wxwidgets processing events.

Here are the perf stats of an idle Audacity before the change:

        524.425485      task-clock (msec)         #    0.060 CPUs utilized
               825      context-switches          #    0.002 M/sec
                36      cpu-migrations            #    0.069 K/sec
                 0      page-faults               #    0.000 K/sec
     1,198,433,346      cycles                    #    2.285 GHz
     1,243,329,771      instructions              #    1.04  insn per cycle
       308,073,049      branches                  #  587.449 M/sec
         5,801,494      branch-misses             #    1.88% of all branches

       8.808129958 seconds time elapsed

and after:

        149.110455      task-clock (msec)         #    0.016 CPUs utilized
               908      context-switches          #    0.006 M/sec
                32      cpu-migrations            #    0.215 K/sec
                 0      page-faults               #    0.000 K/sec
       313,372,582      cycles                    #    2.102 GHz
       167,401,770      instructions              #    0.53  insn per cycle
        41,857,947      branches                  #  280.718 M/sec
         1,189,566      branch-misses             #    2.84% of all branches

       9.076940003 seconds time elapsed