### PR TITLE
Fixed uninitialized variable (mFreqSelTrack) in TrackPanel.

### DIFF
--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -2438,7 +2438,7 @@ void TrackPanel::MoveSnappingFreqSelection (int mouseYCoordinate,
 void TrackPanel::StartFreqSelection (int mouseYCoordinate, int trackTopEdge,
                                      int trackHeight, Track *pTrack)
 {
-   mFreqSelTrack = 0;
+   mFreqSelTrack = NULL;
    mFreqSelMode = FREQ_SEL_INVALID;
    mFreqSelPin = SelectedRegion::UndefinedFrequency;
 

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -598,7 +598,7 @@ protected:
    // FREQ_SEL_BOTTOM_FREE,
    // and is ignored otherwise.
    double mFreqSelPin;
-   const WaveTrack *mFreqSelTrack;
+   const WaveTrack *mFreqSelTrack = NULL;
    std::unique_ptr<SpectrumAnalyst> mFrequencySnapper;
 
    // For toggling of spectral seletion


### PR DESCRIPTION
This variable is used in OnTrackListUpdated before it is initialized.

Found with valgrind's memcheck tool.