### PR TITLE
Optimize the refresh of the selection bar while Audacity is playing.

### DIFF
--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -1814,8 +1814,19 @@ void NumericTextCtrl::Updated(bool keyup /* = false */)
 
 void NumericTextCtrl::ValueToControls()
 {
+   const wxString previousValueString = mValueString;
    NumericConverter::ValueToControls(mValue);
-   Refresh(false);
+   if (mValueString != previousValueString) {
+      // Doing this only when needed is an optimization.
+      // NumerixTextCtrls are used in the selection bar at the bottom
+      // of Audacity, and are updated at high frequency through
+      // SetValue() when Audacity is playing. This consumes a
+      // significant amount of CPU. Typically, when a track is
+      // playing, only one of the NumericTextCtrl actually changes
+      // (the audio position). We save CPU by updating the control
+      // only when needed.
+      Refresh(false);
+   }
 }
 
 

--- a/src/widgets/NumericTextCtrl.h
+++ b/src/widgets/NumericTextCtrl.h
@@ -65,9 +65,16 @@ public:
 
    virtual ~NumericConverter();
 
+   // ValueToControls() formats a raw value (either provided as
+   // argument, or mValue, depending on the version of the function
+   // called). The result is stored to mValueString.
    virtual void ValueToControls();
    virtual void ValueToControls(double rawValue, bool nearest = true);
+
+   // Converts the stored formatted string (mValueString) back to a
+   // raw value (mValue).
    virtual void ControlsToValue();
+
    virtual void ParseFormatString(const wxString & format);
 
    void PrintDebugInfo();
@@ -114,6 +121,7 @@ protected:
    wxString       mPrefix;
    wxString       mValueTemplate;
    wxString       mValueMask;
+   // Formatted mValue, by ValueToControls().
    wxString       mValueString;
 
    double         mScalingFactor;
@@ -180,6 +188,9 @@ private:
    void OnFocus(wxFocusEvent &event);
    void OnContext(wxContextMenuEvent &event);
 
+   // Formats mValue into mValueString, using the method of the base class.
+   // Triggers a refresh of the wx window only when the value actually
+   // changed since last time a refresh was triggered.
    void ValueToControls() override;
    void ControlsToValue() override;
 


### PR DESCRIPTION
This saves 3-4% CPU while Audacity is playing on Linux/64bits. This is
done by avoiding the update of NumerixTextCtrls that stay unchanged.