### PR TITLE
Compressor.cpp: Allow higher-precision 'Ratio'

### DIFF
--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -57,7 +57,7 @@ enum
 //     Name          Type     Key                  Def      Min      Max      Scale
 Param( Threshold,    double,  XO("Threshold"),     -12.0,   -60.0,   -1.0,    1   );
 Param( NoiseFloor,   double,  XO("NoiseFloor"),    -40.0,   -80.0,   -20.0,   5   );
-Param( Ratio,        double,  XO("Ratio"),         2.0,     1.01,    10.0,    100 );
+Param( Ratio,        double,  XO("Ratio"),         2.0,     1.1,     10.0,    10  );
 Param( AttackTime,   double,  XO("AttackTime"),    0.2,     0.1,     5.0,     100 );
 Param( ReleaseTime,  double,  XO("ReleaseTime"),   1.0,     1.0,     30.0,    10  );
 Param( Normalize,    bool,    XO("Normalize"),     true,    false,   true,    1   );
@@ -633,10 +633,17 @@ void EffectCompressor::UpdateUI()
    mNoiseFloorText->SetLabel(wxString::Format(_("%3d dB"), (int) mNoiseFloorDB));
    mNoiseFloorText->SetName(mNoiseFloorText->GetLabel()); // fix for bug 577 (NVDA/Narrator screen readers do not read static text in dialogs)
 
-   mRatioLabel->SetName(wxString::Format(_("Ratio %.2f to 1"), mRatio));
-   /* i18n-hint: Unless your language has a different convention for ratios,
-    * like 8:1, leave as is.*/
-   mRatioText->SetLabel(wxString::Format(_("%.2f:1"), mRatio));
+   if (mRatioSlider->GetValue() % 10 == 0) {
+     mRatioLabel->SetName(wxString::Format(_("Ratio %.0f to 1"), mRatio));
+     /* i18n-hint: Unless your language has a different convention for ratios,
+      * like 8:1, leave as is.*/
+     mRatioText->SetLabel(wxString::Format(_("%.0f:1"), mRatio));
+   } else {
+     mRatioLabel->SetName(wxString::Format(_("Ratio %.1f to 1"), mRatio));
+    /* i18n-hint: Unless your language has a different convention for ratios,
+      * like 8:1, leave as is.*/
+     mRatioText->SetLabel(wxString::Format(_("%.1f:1"), mRatio));
+   }
    mRatioText->SetName(mRatioText->GetLabel()); // fix for bug 577 (NVDA/Narrator screen readers do not read static text in dialogs)
 
    mAttackLabel->SetName(wxString::Format(_("Attack Time %.2f secs"), mAttackTime));

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -638,7 +638,8 @@ void EffectCompressor::UpdateUI()
      /* i18n-hint: Unless your language has a different convention for ratios,
       * like 8:1, leave as is.*/
      mRatioText->SetLabel(wxString::Format(_("%.0f:1"), mRatio));
-   } else {
+   }
+   else {
      mRatioLabel->SetName(wxString::Format(_("Ratio %.1f to 1"), mRatio));
     /* i18n-hint: Unless your language has a different convention for ratios,
       * like 8:1, leave as is.*/

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -57,7 +57,7 @@ enum
 //     Name          Type     Key                  Def      Min      Max      Scale
 Param( Threshold,    double,  XO("Threshold"),     -12.0,   -60.0,   -1.0,    1   );
 Param( NoiseFloor,   double,  XO("NoiseFloor"),    -40.0,   -80.0,   -20.0,   5   );
-Param( Ratio,        double,  XO("Ratio"),         2.0,     1.5,     10.0,    2   );
+Param( Ratio,        double,  XO("Ratio"),         2.0,     1.01,    10.0,    100 );
 Param( AttackTime,   double,  XO("AttackTime"),    0.2,     0.1,     5.0,     100 );
 Param( ReleaseTime,  double,  XO("ReleaseTime"),   1.0,     1.0,     30.0,    10  );
 Param( Normalize,    bool,    XO("Normalize"),     true,    false,   true,    1   );
@@ -633,18 +633,10 @@ void EffectCompressor::UpdateUI()
    mNoiseFloorText->SetLabel(wxString::Format(_("%3d dB"), (int) mNoiseFloorDB));
    mNoiseFloorText->SetName(mNoiseFloorText->GetLabel()); // fix for bug 577 (NVDA/Narrator screen readers do not read static text in dialogs)
 
-   if (mRatioSlider->GetValue() % 2 == 0) {
-      mRatioLabel->SetName(wxString::Format(_("Ratio %.0f to 1"), mRatio));
-      /* i18n-hint: Unless your language has a different convention for ratios,
-       * like 8:1, leave as is.*/
-      mRatioText->SetLabel(wxString::Format(_("%.0f:1"), mRatio));
-   }
-   else {
-      mRatioLabel->SetName(wxString::Format(_("Ratio %.1f to 1"), mRatio));
-      /* i18n-hint: Unless your language has a different convention for ratios,
-       * like 8:1, leave as is.*/
-      mRatioText->SetLabel(wxString::Format(_("%.1f:1"), mRatio));
-   }
+   mRatioLabel->SetName(wxString::Format(_("Ratio %.2f to 1"), mRatio));
+   /* i18n-hint: Unless your language has a different convention for ratios,
+    * like 8:1, leave as is.*/
+   mRatioText->SetLabel(wxString::Format(_("%.2f:1"), mRatio));
    mRatioText->SetName(mRatioText->GetLabel()); // fix for bug 577 (NVDA/Narrator screen readers do not read static text in dialogs)
 
    mAttackLabel->SetName(wxString::Format(_("Attack Time %.2f secs"), mAttackTime));


### PR DESCRIPTION
Preceding this change, the compression 'Ratio' could only be set to a value within
the Series (1.0, 1.5, 2.0, 2.5 .... 10.0).
Following this change, 'Ratio' can be set with 0.01 precision, to any value between 1.01 and 10.0 (inclusive).
The GUI is also modified to show the specified 'Ratio' with two digits after the decimal point.