### PR TITLE
Save 7-8% of CPU while playing by not refreshing the adorned ruler twice at each timer tick.

### DIFF
--- a/mac/wxMac_additions/eventloops.patch
+++ b/mac/wxMac_additions/eventloops.patch
@@ -1,13 +1,79 @@
+From aed0a3ed0df16f04dc39c8366d9c399fcc172009 Mon Sep 17 00:00:00 2001
+From: Paul Licameli <paul.licameli@audacityteam.org>
+Date: Sun, 31 Jul 2016 11:55:29 -0400
+Subject: [PATCH 1/3] Mac modal loops won't hang when other code uses old
+ Mutiprocessing...
+
+... if you call the new wxEventLoopBase::SetBusyWaiting(true).
+
+But this has the undesirable consequence of high CPU usage while the loop idles,
+so this fix must be turned on only as needed by the application.
+
+See the Audacity bug report that motivated this change:
+
+http://bugzilla.audacityteam.org/show_bug.cgi?id=1338
+---
+ include/wx/evtloop.h        |  9 +++++++++
+ src/common/evtloopcmn.cpp   | 14 ++++++++++++++
+ src/osx/core/evtloop_cf.cpp |  3 ++-
+ 3 files changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/include/wx/evtloop.h b/include/wx/evtloop.h
+index 1133473..db87431 100644
+--- a/include/wx/evtloop.h
++++ b/include/wx/evtloop.h
+@@ -177,6 +177,15 @@ public:
+     // set currently active (running) event loop
+     static void SetActive(wxEventLoopBase* loop);
+ 
++#ifdef __WXMAC__
++    static bool GetBusyWaiting();
++
++    // If the argument is true, cause modal dialogs to busy-wait for events,
++    // which seems to be necessary to avoid hanging when other code is using
++    // the old Multiprocessing API
++    static void SetBusyWaiting(bool busyWaiting);
++#endif
++
+ 
+ protected:
+     // real implementation of Run()
+diff --git a/src/common/evtloopcmn.cpp b/src/common/evtloopcmn.cpp
+index f7b5138..325fd54 100644
+--- a/src/common/evtloopcmn.cpp
++++ b/src/common/evtloopcmn.cpp
+@@ -56,6 +56,20 @@ void wxEventLoopBase::SetActive(wxEventLoopBase* loop)
+         wxTheApp->OnEventLoopEnter(loop);
+ }
+ 
++static bool g_busyWaiting = false;
++
++/* static */
++bool wxEventLoopBase::GetBusyWaiting()
++{
++   return g_busyWaiting;
++}
++
++/* static */
++void wxEventLoopBase::SetBusyWaiting(bool busyWaiting)
++{
++   g_busyWaiting = busyWaiting;
++}
++
+ int wxEventLoopBase::Run()
+ {
+     // event loops are not recursive, you need to create another loop!
 diff --git a/src/osx/core/evtloop_cf.cpp b/src/osx/core/evtloop_cf.cpp
-index 7e70dec..37b22b5 100644
---- src/osx/core/evtloop_cf.cpp
-+++ src/osx/core/evtloop_cf.cpp
-@@ -243,7 +243,7 @@ int wxCFEventLoop::DoProcessEvents()
+index 7e70dec..510af80 100644
+--- a/src/osx/core/evtloop_cf.cpp
++++ b/src/osx/core/evtloop_cf.cpp
+@@ -243,7 +243,8 @@ int wxCFEventLoop::DoProcessEvents()
      }
      else
  #endif
 -        return DispatchTimeout( m_isInsideYield ? 0 : 1000 );
-+        return DispatchTimeout( 0 );
++        return DispatchTimeout
++            (m_isInsideYield || wxEventLoopBase::GetBusyWaiting() ? 0 : 1000 );
  }
  
  bool wxCFEventLoop::Dispatch()

--- a/mac/wxMac_additions/eventloops.patch
+++ b/mac/wxMac_additions/eventloops.patch
@@ -1,4 +1,4 @@
-From aed0a3ed0df16f04dc39c8366d9c399fcc172009 Mon Sep 17 00:00:00 2001
+From 8c9c17ca704f6c2b1469c861497ac7676dd67347 Mon Sep 17 00:00:00 2001
 From: Paul Licameli <paul.licameli@audacityteam.org>
 Date: Sun, 31 Jul 2016 11:55:29 -0400
 Subject: [PATCH 1/3] Mac modal loops won't hang when other code uses old
@@ -13,20 +13,21 @@ See the Audacity bug report that motivated this change:
 
 http://bugzilla.audacityteam.org/show_bug.cgi?id=1338
 ---
- include/wx/evtloop.h        |  9 +++++++++
+ include/wx/evtloop.h        | 10 ++++++++++
  src/common/evtloopcmn.cpp   | 14 ++++++++++++++
  src/osx/core/evtloop_cf.cpp |  3 ++-
- 3 files changed, 25 insertions(+), 1 deletion(-)
+ 3 files changed, 26 insertions(+), 1 deletion(-)
 
 diff --git a/include/wx/evtloop.h b/include/wx/evtloop.h
-index 1133473..db87431 100644
+index 1133473..4b23610 100644
 --- a/include/wx/evtloop.h
 +++ b/include/wx/evtloop.h
-@@ -177,6 +177,15 @@ public:
+@@ -177,6 +177,16 @@ public:
      // set currently active (running) event loop
      static void SetActive(wxEventLoopBase* loop);
  
 +#ifdef __WXMAC__
++#define __WX_EVTLOOP_BUSY_WAITING__
 +    static bool GetBusyWaiting();
 +
 +    // If the argument is true, cause modal dialogs to busy-wait for events,

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -4815,7 +4815,6 @@ void AudacityProject::TP_DisplaySelection()
          // Cause ruler redraw anyway, because we may be zooming or scrolling
          mRuler->Refresh();
    }
-
    if (gAudioIO->IsBusy())
       audioTime = gAudioIO->GetStreamTime();
    else {

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -195,6 +195,7 @@ is time to refresh some aspect of the screen.
 #include "prefs/WaveformPrefs.h"
 
 #include "toolbars/ControlToolBar.h"
+#include "toolbars/SelectionBar.h"
 #include "toolbars/ToolsToolBar.h"
 
 // To do:  eliminate this!
@@ -978,6 +979,8 @@ void TrackPanel::OnTimer(wxTimerEvent& )
       p->GetEventHandler()->ProcessEvent(e);
    }
 
+   p->GetSelectionBar()->SetAudioTime(gAudioIO->GetStreamTime());
+   
    DrawOverlays(false);
    mRuler->DrawOverlays(false);
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -195,7 +195,6 @@ is time to refresh some aspect of the screen.
 #include "prefs/WaveformPrefs.h"
 
 #include "toolbars/ControlToolBar.h"
-#include "toolbars/SelectionBar.h"
 #include "toolbars/ToolsToolBar.h"
 
 // To do:  eliminate this!
@@ -979,8 +978,6 @@ void TrackPanel::OnTimer(wxTimerEvent& )
       p->GetEventHandler()->ProcessEvent(e);
    }
 
-   p->GetSelectionBar()->SetAudioTime(gAudioIO->GetStreamTime());
-   
    DrawOverlays(false);
    mRuler->DrawOverlays(false);
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1787,6 +1787,10 @@ bool VSTEffect::HideUI()
 
 bool VSTEffect::CloseUI()
 {
+#ifdef __WXMAC__
+   wxEventLoop::SetBusyWaiting(false);
+#endif
+
    mParent->RemoveEventHandler(this);
 
    PowerOff();
@@ -2834,6 +2838,10 @@ void VSTEffect::BuildFancy()
    NeedEditIdle(true);
 
    mDialog->Connect(wxEVT_SIZE, wxSizeEventHandler(VSTEffect::OnSize));
+
+#ifdef __WXMAC__
+   wxEventLoop::SetBusyWaiting(true);
+#endif
 
    return;
 }

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1788,7 +1788,9 @@ bool VSTEffect::HideUI()
 bool VSTEffect::CloseUI()
 {
 #ifdef __WXMAC__
+#ifdef __WX_EVTLOOP_BUSY_WAITING__
    wxEventLoop::SetBusyWaiting(false);
+#endif
 #endif
 
    mParent->RemoveEventHandler(this);
@@ -2840,7 +2842,9 @@ void VSTEffect::BuildFancy()
    mDialog->Connect(wxEVT_SIZE, wxSizeEventHandler(VSTEffect::OnSize));
 
 #ifdef __WXMAC__
+#ifdef __WX_EVTLOOP_BUSY_WAITING__
    wxEventLoop::SetBusyWaiting(true);
+#endif
 #endif
 
    return;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1799,7 +1799,9 @@ bool AudioUnitEffect::PopulateUI(wxWindow *parent)
       mParent->SetMinSize(wxDefaultSize);
 
 #ifdef __WXMAC__
+#ifdef __WX_EVTLOOP_BUSY_WAITING__
       wxEventLoop::SetBusyWaiting(true);
+#endif
 #endif
    }
 
@@ -1848,7 +1850,9 @@ bool AudioUnitEffect::HideUI()
 bool AudioUnitEffect::CloseUI()
 {
 #ifdef __WXMAC__
+#ifdef __WX_EVTLOOP_BUSY_WAITING__
    wxEventLoop::SetBusyWaiting(false);
+#endif
 #endif
 
    mParent->RemoveEventHandler(this);

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -22,6 +22,11 @@
 #include <wx/button.h>
 #include <wx/control.h>
 #include <wx/dir.h>
+
+#ifdef __WXMAC__
+#include <wx/evtloop.h>
+#endif
+
 #include <wx/filename.h>
 #include <wx/frame.h>
 #include <wx/listctrl.h>
@@ -1792,6 +1797,10 @@ bool AudioUnitEffect::PopulateUI(wxWindow *parent)
       }
 
       mParent->SetMinSize(wxDefaultSize);
+
+#ifdef __WXMAC__
+      wxEventLoop::SetBusyWaiting(true);
+#endif
    }
 
    mParent->PushEventHandler(this);
@@ -1838,6 +1847,10 @@ bool AudioUnitEffect::HideUI()
 
 bool AudioUnitEffect::CloseUI()
 {
+#ifdef __WXMAC__
+   wxEventLoop::SetBusyWaiting(false);
+#endif
+
    mParent->RemoveEventHandler(this);
 
    mUIHost = NULL;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1139,7 +1139,9 @@ bool LV2Effect::HideUI()
 bool LV2Effect::CloseUI()
 {
 #ifdef __WXMAC__
+#ifdef __WX_EVTLOOP_BUSY_WAITING__
    wxEventLoop::SetBusyWaiting(false);
+#endif
 #endif
 
    mParent->RemoveEventHandler(this);
@@ -1571,7 +1573,9 @@ bool LV2Effect::BuildFancy()
    TransferDataToWindow();
 
 #ifdef __WXMAC__
+#ifdef __WX_EVTLOOP_BUSY_WAITING__
    wxEventLoop::SetBusyWaiting(true);
+#endif
 #endif
 
    return true;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -18,6 +18,11 @@
 #include <wx/dcbuffer.h>
 #include <wx/dialog.h>
 #include <wx/dynarray.h>
+
+#ifdef __WXMAC__
+#include <wx/evtloop.h>
+#endif
+
 #include <wx/math.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
@@ -1133,6 +1138,10 @@ bool LV2Effect::HideUI()
 
 bool LV2Effect::CloseUI()
 {
+#ifdef __WXMAC__
+   wxEventLoop::SetBusyWaiting(false);
+#endif
+
    mParent->RemoveEventHandler(this);
 
    if (mSliders)
@@ -1560,6 +1569,10 @@ bool LV2Effect::BuildFancy()
       suil_instance_extension_data(mSuilInstance, LV2_UI__idleInterface);
 
    TransferDataToWindow();
+
+#ifdef __WXMAC__
+   wxEventLoop::SetBusyWaiting(true);
+#endif
 
    return true;
 }

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -455,6 +455,11 @@ void SelectionBar::SetTimes(double start, double end, double audio)
    ValuesToControls();
 }
 
+void SelectionBar::SetAudioTime(double audio) {
+  mAudio = audio;
+  ValuesToControls();
+}
+
 double SelectionBar::GetLeftTime()
 {
    return mLeftTime->GetValue();

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -42,6 +42,8 @@ class SelectionBar final : public ToolBar {
    void UpdatePrefs() override;
 
    void SetTimes(double start, double end, double audio);
+   // Sets the audio time. Keeps the start and end times unchanged.
+   void SetAudioTime(double audio);
    double GetLeftTime();
    double GetRightTime();
    void SetField(const wxChar *msg, int fieldNum);

--- a/src/tracks/ui/PlayIndicatorOverlay.cpp
+++ b/src/tracks/ui/PlayIndicatorOverlay.cpp
@@ -14,6 +14,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../AColor.h"
 #include "../../AudioIO.h"
 #include "../../Project.h"
+#include "../../toolbars/SelectionBar.h"
 #include "../../TrackPanel.h"
 #include "../../TrackPanelCell.h"
 #include "../../TrackPanelCellIterator.h"
@@ -167,6 +168,8 @@ void PlayIndicatorOverlay::OnTimer(wxCommandEvent &event)
          between_incexc(viewInfo.h,
          playPos,
          mProject->GetScreenEndTime());
+
+      mProject->GetSelectionBar()->SetAudioTime(gAudioIO->GetStreamTime());
 
       // BG: Scroll screen if option is set
       // msmeyer: But only if not playing looped or in one-second mode

--- a/src/tracks/ui/PlayIndicatorOverlay.cpp
+++ b/src/tracks/ui/PlayIndicatorOverlay.cpp
@@ -168,9 +168,6 @@ void PlayIndicatorOverlay::OnTimer(wxCommandEvent &event)
          playPos,
          mProject->GetScreenEndTime());
 
-      // This displays the audio time, too...
-      mProject->TP_DisplaySelection();
-
       // BG: Scroll screen if option is set
       // msmeyer: But only if not playing looped or in one-second mode
       // PRL: and not scrolling with play/record head fixed right


### PR DESCRIPTION
Before, it was updated both directly in TrackPanel::OnTimer() through
the call mRuler->DrawOverlays(), and in
AudacityProject::TP_DisplaySelection() that calls
mRuler->Refresh(). After this change, the adorned ruler is only
updated by the first mechanism.