### PR TITLE
Save CPU while playing by optimizing refreshes of the adorned ruler.

### DIFF
--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -455,6 +455,11 @@ void SelectionBar::SetTimes(double start, double end, double audio)
    ValuesToControls();
 }
 
+void SelectionBar::SetAudioTime(double audio) {
+  mAudio = audio;
+  ValuesToControls();
+}
+
 double SelectionBar::GetLeftTime()
 {
    return mLeftTime->GetValue();

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -42,6 +42,8 @@ class SelectionBar final : public ToolBar {
    void UpdatePrefs() override;
 
    void SetTimes(double start, double end, double audio);
+   // Sets the audio time. Keeps the start and end times unchanged.
+   void SetAudioTime(double audio);
    double GetLeftTime();
    double GetRightTime();
    void SetField(const wxChar *msg, int fieldNum);

--- a/src/tracks/ui/PlayIndicatorOverlay.cpp
+++ b/src/tracks/ui/PlayIndicatorOverlay.cpp
@@ -14,6 +14,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../AColor.h"
 #include "../../AudioIO.h"
 #include "../../Project.h"
+#include "../../toolbars/SelectionBar.h"
 #include "../../TrackPanel.h"
 #include "../../TrackPanelCell.h"
 #include "../../TrackPanelCellIterator.h"
@@ -168,8 +169,7 @@ void PlayIndicatorOverlay::OnTimer(wxCommandEvent &event)
          playPos,
          mProject->GetScreenEndTime());
 
-      // This displays the audio time, too...
-      mProject->TP_DisplaySelection();
+      mProject->GetSelectionBar()->SetAudioTime(gAudioIO->GetStreamTime());
 
       // BG: Scroll screen if option is set
       // msmeyer: But only if not playing looped or in one-second mode


### PR DESCRIPTION
On Linux 64 bits, I measured the CPU savings to be 7-8%.

Before, the adorned ruler was updated both directly in
TrackPanel::OnTimer() through the call mRuler->DrawOverlays(), and in
AudacityProject::TP_DisplaySelection() that calls
mRuler->Refresh(). After this change, it is only updated by the first
mechanism.