### PR TITLE
use std::isnan since c++11 provides it and wxIsNan is broken in c++11

### DIFF
--- a/src/BlockFile.cpp
+++ b/src/BlockFile.cpp
@@ -46,13 +46,12 @@ out.
 #include "BlockFile.h"
 
 #include <float.h>
-#include <math.h>
+#include <cmath>
 
 #include <wx/utils.h>
 #include <wx/filefn.h>
 #include <wx/ffile.h>
 #include <wx/log.h>
-#include <wx/math.h>
 
 #include "Internat.h"
 #include "MemoryX.h"
@@ -317,7 +316,7 @@ static void ComputeMinMax256(float *summary256,
          max = summary256[3*i+1];
       else if (!(summary256[3*i+1] <= max))
          bad++;
-      if (wxIsNaN(summary256[3*i+2]))
+      if (std::isnan(summary256[3*i+2]))
          bad++;
       if (summary256[3*i+2] < -1 || summary256[3*i+2] > 1)
          bad++;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -13,6 +13,8 @@
 
 #if defined(USE_LV2)
 
+#include <cmath>
+
 #include <wx/button.h>
 #include <wx/choice.h>
 #include <wx/dcbuffer.h>
@@ -23,7 +25,6 @@
 #include <wx/evtloop.h>
 #endif
 
-#include <wx/math.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/statbox.h>
@@ -561,13 +562,13 @@ bool LV2Effect::SetHost(EffectHostInterface *host)
       lilv_scale_points_free(points);
 
       // Collect the value and range info
-      ctrl.mHasLo = !wxIsNaN(minimumVals[i]);
-      ctrl.mHasHi = !wxIsNaN(maximumVals[i]);
+      ctrl.mHasLo = !std::isnan(minimumVals[i]);
+      ctrl.mHasHi = !std::isnan(maximumVals[i]);
       ctrl.mMin = ctrl.mHasLo ? minimumVals[i] : 0.0;
       ctrl.mMax = ctrl.mHasHi ? maximumVals[i] : 1.0;
       ctrl.mLo = ctrl.mMin;
       ctrl.mHi = ctrl.mMax;
-      ctrl.mDef = !wxIsNaN(defaultValues[i]) ?
+      ctrl.mDef = !std::isnan(defaultValues[i]) ?
                   defaultValues[i] :
                      ctrl.mHasLo ?
                      ctrl.mLo :

--- a/src/widgets/numformatter.cpp
+++ b/src/widgets/numformatter.cpp
@@ -32,7 +32,7 @@
 #include <wx/intl.h>
 
 #include <locale.h> // for setlocale and LC_ALL
-#include <math.h>
+#include <cmath>
 #include <wx/log.h>
 
 // ----------------------------------------------------------------------------
@@ -134,11 +134,11 @@ wxString NumberFormatter::ToString(double val, int precision, int style)
         format.Printf(wxT("%%.%df"), precision);
     }
 
-    if (isnan(val))
+    if (std::isnan(val))
     {
         return _("NaN");
     }
-    if (isinf(val))
+    if (std::isinf(val))
     {
         return _("-Infinity");
     }


### PR DESCRIPTION
wxIsNan() is broken in c++11 and wx devs are not going to be fixing it, they recommend using cmath and std::isnan(). Also replaces bare isinf(), isnan() with std:: versions.

https://github.com/wxWidgets/wxWidgets/pull/283