### PR TITLE
Fix bug 1507

### DIFF
--- a/src/Project.h
+++ b/src/Project.h
@@ -541,6 +541,7 @@ public:
    bool IsSoloNone() { return mSoloPref == wxT("None"); }
 
  private:
+    bool mProjectNamedFromImport;
 
    // The project's name and file info
    wxString mFileName;


### PR DESCRIPTION
Set flag mProjectNamedFromImport when Audacity automatically
names a new project from the name of an imported file.

This fixes the bug as described, but obscure and fringe ways of saving projects should be tested.
I'd like this fix to be reviewed by a senior developer in case there is a better way to fix it.