### PR TITLE
OpenMP TrackArtist::DrawSpectrum

### DIFF
--- a/src/AColor.h
+++ b/src/AColor.h
@@ -147,10 +147,9 @@ class AColor {
 inline void GetColorGradient(float value,
                              AColor::ColorGradientChoice selected,
                              bool grayscale,
-                             unsigned char *red,
-                             unsigned char *green, unsigned char *blue) {
-   if (!AColor::gradient_inited)
-      AColor::PreComputeGradient();
+                             unsigned char * __restrict red,
+                             unsigned char * __restrict green,
+                             unsigned char * __restrict blue) {
 
    int idx = value * (AColor::gradientSteps - 1);
 


### PR DESCRIPTION
Much faster drawing function, measured about 300% improvement. Not much to this, there is some minor refactoring to allow loop parallelization.

Additional refactoring to calculate number scale one time, could give a boost to the non-omp version esp when scale involves log(), etc.

Also changed pointless references like "const double& x = y" to "const double x = y", I don't see the point of having a reference to a primitive type, or basic struct like wxRect. This may allow better code generation inside loops.
