### PR TITLE
OpenMP TrackArtist::DrawSpectrum Take 2

### DIFF
--- a/src/AColor.h
+++ b/src/AColor.h
@@ -148,10 +148,9 @@ class AColor {
 inline void GetColorGradient(float value,
                              AColor::ColorGradientChoice selected,
                              bool grayscale,
-                             unsigned char *red,
-                             unsigned char *green, unsigned char *blue) {
-   if (!AColor::gradient_inited)
-      AColor::PreComputeGradient();
+                             unsigned char * __restrict red,
+                             unsigned char * __restrict green,
+                             unsigned char * __restrict blue) {
 
    int idx = value * (AColor::gradientSteps - 1);
 


### PR DESCRIPTION
Update to PR #163. 

Using vector now instead of dynamic array size. I've never seen where this didn't work in years, but better to keep standard compliant. This is not critical to performance so better to forget using alloca() as well.

Also w0, w1 recalculated every iteration so it can work with new fisheye feature. I did not special case this for the non-openmp as it was before since its very small component of the total and I imagine the compiler can do that for us.

I left the const ref change alone per James' comment. IMO it is just a bizarre thing to do. I think we can be pretty sure the code generated is not any worse as there is nothing to dereference in the loops.
