### PR TITLE
Add support for importing/exporting SubRip subtitles

### DIFF
--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -643,8 +643,8 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    fName = FileSelector(_("Export Labels As:"),
       wxEmptyString,
       fName.c_str(),
-      wxT("txt"),
-      wxT("*.txt"),
+      wxT(".txt|.srt"),
+      _("Text files (*.txt)|*.txt|SubRip subtitles (*.srt)|*.srt"),
       wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
       this);
 
@@ -690,7 +690,8 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    }
 
    // Export them and clean
-   lt->Export(f);
+   int sindex = 1;
+   lt->Export(f, sindex);
 
 #ifdef __WXMAC__
    f.Write(wxTextFileType_Mac);

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -592,8 +592,8 @@ void LabelDialog::OnImport(wxCommandEvent & WXUNUSED(event))
        FileSelector(_("Select a text file containing labels..."),
                     path,     // Path
                     wxT(""),       // Name
-                    wxT(".txt"),   // Extension
-                    _("Text files (*.txt)|*.txt|All files|*"),
+                    wxT(".txt|.srt"),   // Extension
+                    _("Text files (*.txt)|*.txt|SubRip subtitles (*.srt)|*.srt|All files|*"),
                     wxRESIZE_BORDER, // Flags
                     this);    // Parent
 

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -64,6 +64,7 @@ public:
 
    struct BadFormatException {};
    static LabelStruct Import(wxTextFile &file, int &index);
+   static LabelStruct ImportSubRip(wxTextFile &file, int &index);
 
    void Export(wxTextFile &file) const;
 

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -67,6 +67,7 @@ public:
    static LabelStruct ImportSubRip(wxTextFile &file, int &index);
 
    void Export(wxTextFile &file) const;
+   void ExportSubRip(wxTextFile &file, int sindex) const;
 
    /// Relationships between selection region and labels
    enum TimeRelations
@@ -190,7 +191,7 @@ class AUDACITY_DLL_API LabelTrack final : public Track
    bool OnChar(SelectedRegion &sel, wxKeyEvent & event);
 
    void Import(wxTextFile & f);
-   void Export(wxTextFile & f) const;
+   void Export(wxTextFile & f, int &sindex) const;
 
    void Unselect();
 

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -5586,8 +5586,8 @@ void AudacityProject::OnImportLabels()
        FileSelector(_("Select a text file containing labels..."),
                     path,     // Path
                     wxT(""),       // Name
-                    wxT(".txt"),   // Extension
-                    _("Text files (*.txt)|*.txt|All files|*"),
+                    wxT(".txt|.srt"),   // Extension
+                    _("Text files (*.txt)|*.txt|SubRip subtitles (*.srt)|*.srt|All files|*"),
                     wxRESIZE_BORDER,        // Flags
                     this);    // Parent
 

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -3683,8 +3683,8 @@ void AudacityProject::OnExportLabels()
    fName = FileSelector(_("Export Labels As:"),
                         wxEmptyString,
                         fName,
-                        wxT("txt"),
-                        wxT("*.txt"),
+                        wxT(".txt|.srt"),
+			_("Text files (*.txt)|*.txt|SubRip subtitles (*.srt)|*.srt"),
                         wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
                         this);
 
@@ -3715,10 +3715,11 @@ void AudacityProject::OnExportLabels()
       return;
    }
 
+   int sindex = 1;
    t = iter.First();
    while (t) {
       if (t->GetKind() == Track::Label)
-         ((LabelTrack *) t)->Export(f);
+         ((LabelTrack *) t)->Export(f, sindex);
 
       t = iter.Next();
    }


### PR DESCRIPTION
As I find Audacity to be a fantastic tool for synchronising text subtitles and there is [apparent community interest](http://wiki.audacityteam.org/wiki/Movie_subtitles_%28*.SRT%29) in adding support for the most common [SubRip format](https://en.wikipedia.org/wiki/SubRip#SubRip_text_file_format), I thought I will give it a shot.

This pull request enables Audacity to both import SubRip subtitles as labels and export labels as SubRip subtitles.

The gotchas I am aware of:
- My way of integrating SubRip code with current label code is pretty heavy-handed, i.e. extending this code with further input/output formats will not be pleasant.  On the other hand, it is not as if there are a dozen of these waiting to be implemented.  If you would like to see this done differently, any pointers will be welcome.
- I had to introduce a variable called `sindex` and pass it to `LabelTrack::Export()` so that a valid SubRip subtitle is produced when multiple label tracks are present in a project.  Audacity's own label format does not treat this case specially because labels are not assigned sequence numbers of any kind, just start and stop times.
- The output format used for label export is determined by the extension of the target filename, not the filter index picked by the user in the file selection dialog.  This can be misleading, e.g. the user might choose to export labels as SubRip subtitles but then supply a filename ending with _.txt_, which will result in exporting labels in Audacity's own format.  Let me know if you would like this corrected as it would require reworking label export actions so that they use something more sophisticated than `FileSelector`, which only returns a filename.
- While it is technically possible for labels to be multi-line, it looks awkward and Audacity is not currently suited for comfortable editing of such subtitles, so I settled for `|` being a line separator for multi-line subtitles.  This should not cause a lot of trouble as `|` serves as a line separator in other subtitle formats, e.g. MicroDVD (in which case I am pretty sure it is not even escapable).

Finally, my C++ skills are lacking, so if you see something fishy, your gut is probably right.
