### PR TITLE
Generate an AppImage for each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ before_install:
 language:
     - cpp
 script:
-    - aclocal --install -I m4 && automake && ./configure && make
+    - aclocal --install -I m4 && automake && ./configure --prefix=/app && make
+    - bash -ex scripts/appimage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ before_install:
 language:
     - cpp
 script:
-    - aclocal --install -I m4 && automake && ./configure --prefix=/app && make
+    - aclocal --install -I m4 && automake && ./configure --prefix=/app && make && sudo make install
     - bash -ex scripts/appimage.sh

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+########################################################################
+# Package the binaries built on Travis-CI as an AppImage
+# By Simon Peter 2016
+# For more information, see http://appimage.org/
+########################################################################
+
+APP=Audacity
+LOWERAPP=${APP,,}
+
+mkdir -p $HOME/$APP/$APP.AppDir/
+
+cd $HOME/$APP/
+
+wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+. ./functions.sh
+
+cd $APP.AppDir
+
+sudo chown -R $USER /app/
+
+cp -r /app ./usr
+BINARY=./usr/bin/audacity
+
+########################################################################
+# Copy desktop and icon file to AppDir for AppRun to pick them up
+########################################################################
+
+get_apprun
+get_desktop
+get_icon
+
+########################################################################
+# Copy in the dependencies that cannot be assumed to be available
+# on all target systems
+########################################################################
+
+copy_deps
+
+########################################################################
+# Delete stuff that should not go into the AppImage
+########################################################################
+
+# Delete dangerous libraries; see
+# https://github.com/probonopd/AppImages/blob/master/excludelist
+delete_blacklisted
+
+rm -rf app/ || true
+
+########################################################################
+# Patch away absolute paths; it would be nice if they were relative
+########################################################################
+
+find usr/ -type f -exec sed -i -e "s|/usr|././|g" {} \;
+find usr/ -type f -exec sed -i -e "s|/app|././|g" {} \;
+
+########################################################################
+# Other application-specific finishing touches
+########################################################################
+
+cp usr/share/icons/hicolor/scalable/apps/audacity.svg .
+sed -i -e 's|^Exec=.*|Exec=audacity|g' audacity.desktop
+rm -rf usr/lib/x86_64-linux-gnu/libpango* # Otherwise, "expect ugly output"
+
+########################################################################
+# desktopintegration asks the user on first run to install a menu item
+########################################################################
+
+get_desktopintegration $LOWERAPP
+
+########################################################################
+# Determine the version of the app; also include needed glibc version
+########################################################################
+
+GLIBC_NEEDED=$(glibc_needed)
+VERSION=travis${TRAVIS_BUILD_NUMBER}-glibc$GLIBC_NEEDED
+echo $VERSION > ../VERSION
+
+########################################################################
+# AppDir complete
+# Now packaging it as an AppImage
+########################################################################
+
+cd .. # Go out of AppImage
+
+mkdir -p ../out/
+generate_type2_appimage
+
+########################################################################
+# Upload the AppDir
+########################################################################
+
+transfer ../out/*
+echo "AppImage has been uploaded to the URL above; use something like GitHub Releases for permanent storage"
+echo "For this, see https://github.com/probonopd/uploadtool"


### PR DESCRIPTION
This PR, when merged, will generate and upload an [AppImage](http://appimage.org/) of each commit. It does so by bundling Audacity and its core dependencies which cannot be expected to be part of each target system (Linux distribution) inside the AppImage.

The URL of the AppImage can be found in the Travis CI build log, it is beginning with `http://bintray...`. Of course you can change this to use the GitHub Releases mechanism for hosting the binaries instead.