### PR TITLE
Update nl.po

### DIFF
--- a/locale/nl.po
+++ b/locale/nl.po
@@ -3056,7 +3056,7 @@ msgstr "&Van stereo naar mono"
 
 #: src/Menus.cpp:839
 msgid "Mi&x and Render"
-msgstr "Mi&xen en doorrekenen"
+msgstr "Mi&xen en renderen"
 
 #: src/Menus.cpp:842
 msgid "Mix and Render to Ne&w Track"


### PR DESCRIPTION
Doorrekenen is a weird Dutch word in this context and also not consistent with the menu item below it: "Mixen en naar nieuw spoor renderen". So I propose to change "doorrekenen" to "renderen" to be more logical and consistent.