### PR TITLE
Add menu items to toggle midi channels; fix EXPERIMENTAL_MIDI_OUT

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -3887,7 +3887,7 @@ void AudioIO::FillMidiBuffers()
          break;
       }
    int numMidiPlaybackTracks = gAudioIO->mMidiPlaybackTracks.size();
-   for(t = 0; t < numMidiPlaybackTracks; t++ )
+   for(unsigned t = 0; t < numMidiPlaybackTracks; t++ )
       if( gAudioIO->mMidiPlaybackTracks[t]->GetSolo() ) {
          hasSolo = true;
          break;
@@ -4360,7 +4360,7 @@ int audacityAudioCallback(const void *inputBuffer, void *outputBuffer,
                numSolo++;
 #ifdef EXPERIMENTAL_MIDI_OUT
          int numMidiPlaybackTracks = gAudioIO->mMidiPlaybackTracks.size();
-         for( t = 0; t < numMidiPlaybackTracks; t++ )
+         for(unsigned t = 0; t < numMidiPlaybackTracks; t++ )
             if( gAudioIO->mMidiPlaybackTracks[t]->GetSolo() )
                numSolo++;
 #endif

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -331,6 +331,40 @@ int NoteTrack::DrawLabelControls(wxDC & dc, wxRect & r)
    return box.GetBottom();
 }
 
+#ifdef EXPERIMENTAL_MIDI_OUT
+bool NoteTrack::LabelClick(wxRect & r, int mx, int my, bool right)
+{
+   int wid = 23;
+   int ht = 16;
+
+   if (r.height < ht * 4)
+      return false;
+
+   int x = r.x + (r.width / 2 - wid * 2);
+   int y = r.y + 1;
+   // after adding Mute and Solo buttons, mapping is broken, so hack in the offset
+   y += 12;
+
+   int col = (mx - x) / wid;
+   int row = (my - y) / ht;
+
+   if (row < 0 || row >= 4 || col < 0 || col >= 4)
+      return false;
+
+   int channel = row * 4 + col;
+
+   if (right) {
+      if (mVisibleChannels == CHANNEL_BIT(channel))
+         mVisibleChannels = ALL_CHANNELS;
+      else
+         mVisibleChannels = CHANNEL_BIT(channel);
+   } else
+      ToggleVisibleChan(channel);
+
+   return true;
+}
+#endif
+
 void NoteTrack::SetSequence(std::unique_ptr<Alg_seq> &&seq)
 {
    mSeq = std::move(seq);

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -331,38 +331,6 @@ int NoteTrack::DrawLabelControls(wxDC & dc, wxRect & r)
    return box.GetBottom();
 }
 
-bool NoteTrack::LabelClick(wxRect & r, int mx, int my, bool right)
-{
-   int wid = 23;
-   int ht = 16;
-
-   if (r.height < ht * 4)
-      return false;
-
-   int x = r.x + (r.width / 2 - wid * 2);
-   int y = r.y + 1;
-   // after adding Mute and Solo buttons, mapping is broken, so hack in the offset
-   y += 12;
-
-   int col = (mx - x) / wid;
-   int row = (my - y) / ht;
-
-   if (row < 0 || row >= 4 || col < 0 || col >= 4)
-      return false;
-
-   int channel = row * 4 + col;
-
-   if (right) {
-      if (mVisibleChannels == CHANNEL_BIT(channel))
-         mVisibleChannels = ALL_CHANNELS;
-      else
-         mVisibleChannels = CHANNEL_BIT(channel);
-   } else
-      ToggleVisibleChan(channel);
-
-   return true;
-}
-
 void NoteTrack::SetSequence(std::unique_ptr<Alg_seq> &&seq)
 {
    mSeq = std::move(seq);

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -70,7 +70,6 @@ class AUDACITY_DLL_API NoteTrack final : public Track {
                               const TimeWarper &warper, double semitones);
 
    int DrawLabelControls(wxDC & dc, wxRect & r);
-   bool LabelClick(wxRect & r, int x, int y, bool right);
 
    void SetSequence(std::unique_ptr<Alg_seq> &&seq);
    Alg_seq* GetSequence();

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -70,6 +70,9 @@ class AUDACITY_DLL_API NoteTrack final : public Track {
                               const TimeWarper &warper, double semitones);
 
    int DrawLabelControls(wxDC & dc, wxRect & r);
+#ifdef EXPERIMENTAL_MIDI_OUT
+   bool LabelClick(wxRect & r, int x, int y, bool right);
+#endif
 
    void SetSequence(std::unique_ptr<Alg_seq> &&seq);
    Alg_seq* GetSequence();
@@ -164,11 +167,6 @@ class AUDACITY_DLL_API NoteTrack final : public Track {
    void StartVScroll();
    void VScroll(int start, int end);
 
-#ifdef EXPERIMENTAL_MIDI_OUT
-   wxRect GetGainPlacementRect() const { return mGainPlacementRect; }
-   void SetGainPlacementRect(const wxRect &r) { mGainPlacementRect = r; }
-#endif
-
    bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
    XMLTagHandler *HandleXMLChild(const wxChar *tag) override;
    void WriteXML(XMLWriter &xmlFile) override;
@@ -211,7 +209,6 @@ class AUDACITY_DLL_API NoteTrack final : public Track {
    int mPitchHeight;
    int mVisibleChannels; // bit set of visible channels
    int mLastMidiPosition;
-   wxRect mGainPlacementRect;
 };
 
 #endif // USE_MIDI

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -5093,7 +5093,6 @@ void TrackPanel::HandleLabelClick(wxMouseEvent & event)
       // DM: If it's a NoteTrack, it has special controls
       else if (t->GetKind() == Track::Note)
       {
-         wxRect midiRect;
 #ifdef EXPERIMENTAL_MIDI_OUT
          // this is an awful hack: make a NEW rectangle at an offset because
          // MuteSoloFunc thinks buttons are located below some text, e.g.
@@ -5112,13 +5111,6 @@ void TrackPanel::HandleLabelClick(wxMouseEvent & event)
             event, event.m_x, event.m_y))
             return;
 #endif
-         mTrackInfo.GetTrackControlsRect(rect, midiRect);
-         if (midiRect.Contains(event.m_x, event.m_y) &&
-            ((NoteTrack *)t)->LabelClick(midiRect, event.m_x, event.m_y,
-            event.Button(wxMOUSE_BTN_RIGHT))) {
-            Refresh(false);
-            return;
-         }
       }
 #endif // USE_MIDI
 

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -92,7 +92,7 @@ private:
    void DrawMuteSolo(wxDC * dc, const wxRect & rect, Track * t, bool down, bool solo, bool bHasSoloButton) const;
    void DrawVRuler(wxDC * dc, const wxRect & rect, Track * t) const;
 #ifdef EXPERIMENTAL_MIDI_OUT
-   void DrawVelocitySlider(wxDC * dc, NoteTrack *t, wxRect rect) const ;
+   void DrawVelocitySlider(wxDC * dc, NoteTrack *t, wxRect rect, bool captured) const ;
 #endif
    void DrawSliders(wxDC * dc, WaveTrack *t, wxRect rect, bool captured) const;
 
@@ -105,6 +105,9 @@ private:
    void GetMuteSoloRect(const wxRect & rect, wxRect &dest, bool solo, bool bHasSoloButton) const;
    void GetGainRect(const wxRect & rect, wxRect &dest) const;
    void GetPanRect(const wxRect & rect, wxRect &dest) const;
+#ifdef EXPERIMENTAL_MIDI_OUT
+   void GetVelocityRect(const wxRect & rect, wxRect &dest) const;
+#endif
    void GetMinimizeRect(const wxRect & rect, wxRect &dest) const;
    void GetSyncLockIconRect(const wxRect & rect, wxRect &dest) const;
 
@@ -113,7 +116,7 @@ public:
    LWSlider * PanSlider(WaveTrack *t, bool captured = false) const;
 
 #ifdef EXPERIMENTAL_MIDI_OUT
-   LWSlider *GainSlider(int index) const;
+   LWSlider * VelocitySlider(NoteTrack *t, bool captured = false) const;
 #endif
 
 private:
@@ -123,6 +126,10 @@ private:
    wxFont mFont;
    std::unique_ptr<LWSlider>
       mGainCaptured, mPanCaptured, mGain, mPan;
+#ifdef EXPERIMENTAL_MIDI_OUT
+   std::unique_ptr<LWSlider>
+      mVelocityCaptured, mVelocity;
+#endif
 
    friend class TrackPanel;
 };
@@ -432,6 +439,10 @@ protected:
                  int x, int y);
    virtual bool PanFunc(Track * t, wxRect rect, wxMouseEvent &event,
                 int x, int y);
+#ifdef EXPERIMENTAL_MIDI_OUT
+   virtual bool VelocityFunc(Track * t, wxRect rect, wxMouseEvent &event,
+                 int x, int y);
+#endif
 
 
    virtual void MakeParentRedrawScrollbars();

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -477,6 +477,9 @@ protected:
    virtual void SplitStereo(bool stereo);
    virtual void OnMergeStereo(wxCommandEvent &event);
 
+   virtual void OnToggleAllChannels(wxCommandEvent &event);
+   virtual void OnToggleChannel(wxCommandEvent &event);
+
    // Find track info by coordinate
    virtual Track *FindTrack(int mouseX, int mouseY, bool label, bool link,
                      wxRect * trackRect = NULL);
@@ -780,7 +783,7 @@ protected:
 
    // These sub-menus are owned by parent menus,
    // so not unique_ptrs
-   wxMenu *mRateMenu{}, *mFormatMenu{};
+   wxMenu *mRateMenu{}, *mFormatMenu{}, *mMidiChanMenu{};
 
    Track *mPopupMenuTarget {};
 


### PR DESCRIPTION
Right now, while it _is_ possible to toggle midi channels, the process involves randomly clicking within the midi track panel as the positions you need to click to toggle each channel are unlabeled and there's no indication of what channels are enabled or not.

This PR removes the old toggle system and adds menu items to toggle individual channels, along with an item to show all channels and an item to hide all channels.

I'm not too familiar with the audacity codebase (or C++ in general), so if I've done something wrong (either stylistically or functionally), let me know and I'll try to correct it.