### PR TITLE
Add missing template instantiation

### DIFF
--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -877,6 +877,7 @@ template Track *TrackList::Add<NoteTrack>(std::unique_ptr<NoteTrack> &&);
 #endif
 template Track *TrackList::Add<WaveTrack>(std::unique_ptr<WaveTrack> &&);
 template Track *TrackList::Add<LabelTrack>(std::unique_ptr<LabelTrack> &&);
+template Track *TrackList::Add<Track>(std::unique_ptr<Track> &&);
 
 template<typename TrackKind>
 Track *TrackList::AddToHead(std::unique_ptr<TrackKind> &&t)


### PR DESCRIPTION
This is needed on Linux GCC 5.4 to fix a link error.