### PR TITLE
Properly handle supplementary characters when saving XML files

### DIFF
--- a/src/xml/XMLWriter.cpp
+++ b/src/xml/XMLWriter.cpp
@@ -52,7 +52,7 @@ static int charXMLCompatiblity[] =
 
 // These are used by XMLEsc to handle surrogate pairs and filter invalid characters outside the ASCII range.
 #define MIN_HIGH_SURROGATE static_cast<wxUChar>(0xD800)
-#define MAX_HIGH_SURROGATE static_cast<wxUChar>(0xDCFF)
+#define MAX_HIGH_SURROGATE static_cast<wxUChar>(0xDBFF)
 #define MIN_LOW_SURROGATE static_cast<wxUChar>(0xDC00)
 #define MAX_LOW_SURROGATE static_cast<wxUChar>(0xDFFF)
 


### PR DESCRIPTION
This fixes the problem experienced by a number of users, including [this one](http://forum.audacityteam.org/viewtopic.php?f=46&t=95866), where supplementary characters (which includes many emoji) are written as pairs of escaped surrogate code points.

 Note that the problem only affects platforms like Windows where `wchar_t` is 2 bytes.