### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,28 +5,42 @@
 #if you want to work on this, please talk with us on
 # https://lists.sourceforge.net/lists/listinfo/audacity-devel
 #build time is circa 50 mins.
-version: 2.1.2-{build}
+version: 2.2.0-alpha-{build}
+image: Visual Studio 2013
 shallow_clone: true # reduce traffic
 install:
+    - 'echo #define REV_LONG "%APPVEYOR_REPO_COMMIT%" > src\RevisionIdent.h'
+    - 'echo #define REV_TIME "%APPVEYOR_REPO_COMMIT_TIMESTAMP%" >> src\RevisionIdent.h'
     # install gettext tool (only used by target "locale", which is not built at
     # the moment due to long duration
-    - nuget install Gettext.Tools
-    - set PATH=%PATH%;%AUDACITY_ROOT%\Gettext.Tools.0.19.7.001\tools\bin
+    - nuget install Gettext.Tools -Version 0.19.8.1 -OutputDirectory %AUDACITY_ROOT%\win\packages
     # download wxWidgets
     - git clone --branch v3.0.2 --depth 1 https://github.com/wxWidgets/wxWidgets.git %WXWIN%
     # apply audacity patches
     - xcopy %AUDACITY_ROOT%\win\wxWidgets_additions\wxWidgets-3.0.2 %WXWIN% /s /y /f
     - xcopy %WXWIN%\include\wx\setup_redirect.h %WXWIN%\include\wx\setup.h* /f
     # build wxWidgets
-    - msbuild %WXWIN%\build\msw\wx_vc12.sln /p:Configuration="DLL Release" /target:adv,base,core,html,net,qa,wxexpat,wxjpeg,wxpng,wxtiff,wxzlib /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild /m %WXWIN%\build\msw\wx_vc12.sln "/p:Configuration=DLL Release;PlatformToolset=v120_xp" /target:adv,base,core,html,net,qa,wxexpat,wxjpeg,wxpng,wxtiff,wxzlib /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 environment:
-    WXWIN: c:\wxWidgets-3.0.2
-    AUDACITY_ROOT: c:\projects\audacity
+    WXWIN: '%APPVEYOR_BUILD_FOLDER%\..\wxWidgets'
+    AUDACITY_ROOT: '%APPVEYOR_BUILD_FOLDER%'
 # replace `build_script` with `build` and `configuration` when complete build
 # does not exceed a duration of 1 hour
 #build:
     #project: win/audacity.sln
 #configuration:
     #- Release
-build_script: # build all targets except of `help` and `locale`
-    msbuild win/audacity.sln /p:Configuration=Release /target:expat,filedialog,libflac++,libflac,libid3tag,libmad,libnyquist,libogg,libscorealign,libsndfile,libsoxr,libvamp,libvorbis,lv2,portaudio-v19,portmidi,portmixer,portsmf,sbsms,soundtouch,twolame,help,Audacity /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+build_script: # build all targets except `help`
+- cmd: >-
+    set PATH=%PATH%;%AUDACITY_ROOT%\win\packages\Gettext.Tools.0.19.8.1\tools\bin &&
+    msbuild /m win/audacity.sln /p:Configuration=Release;PlatformToolset=v120_xp /target:expat,filedialog,libflac++,libflac,libid3tag,libmad,libnyquist,libogg,libscorealign,libsndfile,libsoxr,libvamp,libvorbis,lv2,portaudio-v19,portmidi,portmixer,portsmf,sbsms,soundtouch,twolame,Audacity /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
+    del /S win\Release\*.ipdb &&
+    del /S win\Release\*.iobj &&
+    del /S win\Release\*.lib &&
+    del /S win\Release\*.pdb &&
+    del /S win\Release\*.exp &&
+    copy %WXWIN%\lib\vc_dll\*.dll win\Release\
+artifacts:
+- path: win\Release
+  name: 'audacity-%APPVEYOR_BUILD_VERSION%-%APPVEYOR_REPO_COMMIT%'
+


### PR DESCRIPTION
Fix the appveyor.yml project path and produce a basic build artifact.
RevisionIdent.h is updated so the about dialog can show where the file came from.