### PR TITLE
Added a few lines to OnNewLabelTrack which try to find the name of th…

### DIFF
--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -6025,12 +6025,21 @@ void AudacityProject::OnNewStereoTrack()
 
 void AudacityProject::OnNewLabelTrack()
 {
-   LabelTrack *t = new LabelTrack(mDirManager);
+	wxString tn = "Label Track";
+	auto firstSelectedTrack = mTrackPanel->GetFirstSelectedTrack();
+	if (firstSelectedTrack != NULL) {
+		tn = firstSelectedTrack->GetName();
+	}
 
-   SelectNone();
 
-   mTracks->Add(t);
-   t->SetSelected(true);
+	LabelTrack *t = new LabelTrack(mDirManager);
+
+	t->SetName(tn);
+
+	SelectNone();
+
+	t->SetSelected(true);
+	
 
    PushState(_("Created new label track"), _("New Track"));
 


### PR DESCRIPTION
…e currently selected track and use that as the name for the new label track.  If unsuccessful then the existing default of LabelTrack is used.When creating a new label track it is generally to make labels that apply to an existing track, and it therefore makes sense to default the name of the label track tobe the same as the name of the currently selected track.  If it needs changing it is no more difficult than changing the existing name of 'Label Track' which is unlikely ever to be helpful.
