### PR TITLE
Make exported label tracks locale-independent

### DIFF
--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -36,6 +36,7 @@ for drawing different aspects of the label and its text box.
 #include <stdio.h>
 #include <algorithm>
 #include <limits.h>
+#include <float.h>
 
 #include <wx/bitmap.h>
 #include <wx/brush.h>
@@ -1329,9 +1330,9 @@ LabelStruct LabelStruct::Import(wxTextFile &file, int &index)
 
 void LabelStruct::Export(wxTextFile &file) const
 {
-   file.AddLine(wxString::Format(wxT("%f\t%f\t%s"),
-      getT0(),
-      getT1(), 
+   file.AddLine(wxString::Format(wxT("%s\t%s\t%s"),
+      Internat::ToString(getT0(), FLT_DIG).c_str(),
+      Internat::ToString(getT1(), FLT_DIG).c_str(),
       title.c_str()
    ));
 
@@ -1344,9 +1345,9 @@ void LabelStruct::Export(wxTextFile &file) const
 
    // Write a \ character at the start of a second line,
    // so that earlier versions of Audacity ignore it.
-   file.AddLine(wxString::Format(wxT("\\\t%f\t%f"),
-      f0,
-      f1
+   file.AddLine(wxString::Format(wxT("\\\t%s\t%s"),
+      Internat::ToString(f0, FLT_DIG).c_str(),
+      Internat::ToString(f1, FLT_DIG).c_str()
    ));
 
    // Additional lines in future formats should also start with '\'.


### PR DESCRIPTION
Currently, when Audacity exports labels tracks numbers are formatted
with the "%f" specifier, which relies on the current user locale to pick
up the decimal separator.

This means that the numbers indicating the start and the end of the
labeled interval could end up using a comma as a decimal separator.

This makes the exported file less portable, especially in the case of
parsing the exported file with an external tool.

Audacity is already able to _import_ labels tracks independently of the
locale because it uses Internat::CompatibleToDouble(), so do something
symmetric at _export_ time, using Internat::ToString() to make the
exported data locale-independent (i.e. always using a dot as the decimal
separator).

Proposed in https://sourceforge.net/p/audacity/mailman/message/35534945/

NOTE:

When converting numbers to strings FLT_DIG is passed as the
digitsAfterDecimalPoint argument of Internat::ToString(), this is in
order to preserve the look and the alignment of the previous "%f" format
specifier; without that Internat::ToString() would strip trailing zeros.

Audacity requires C++11, this ensures that FLT_DIG is defined.