### PR TITLE
[WIP] Note track pitch bend display

### DIFF
--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -1003,6 +1003,12 @@ void NoteTrack::ZoomTo(const wxRect &rect, int start, int end)
    Zoom(rect, (start + end) / 2, trialPitchHeight / mPitchHeight, true);
 }
 
+int NoteTrack::PitchToY(double p) const {
+   int ip = (int)p;
+   double offset = p - ip;
+   return IPitchToY(ip) - (int)(GetPitchHeight(1) * offset);
+}
+
 int NoteTrack::YToIPitch(int y)
 {
    y = mBottom - y; // pixels above pitch 0

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -1021,4 +1021,87 @@ int NoteTrack::YToIPitch(int y)
 
 const float NoteTrack::ZoomStep = powf( 2.0f, 0.25f );
 
+std::unordered_map<int, std::map<double, double>> NoteTrack::GetPitchOffsets() const
+{
+   std::unordered_map<int, std::map<double, double>> pitchBendChanges;
+   // Current reserved parameter number
+   char rpnMSB[17];
+   char rpnLSB[17];
+   // Measured in semitones
+   char pitchRangeMSB[17];
+   // Measured in cents
+   char pitchRangeLSB[17];
+   // From -1 to 1
+   double curRawBend[17];
+   for (int i = 0; i < 17; i++)
+   {
+      pitchBendChanges[i][0] = 0;
+      rpnMSB[i] = 127;
+      rpnLSB[i] = 127;
+      pitchRangeMSB[i] = 2;
+      pitchRangeLSB[i] = 0;
+      curRawBend[i] = 0;
+   }
+   Alg_seq_ptr seq = &GetSeq();
+   Alg_iterator iterator(seq, false);
+   iterator.begin();
+
+   Alg_event_ptr evt;
+   while (0 != (evt = iterator.next())) {
+      if (evt->is_update()) {
+         Alg_update_ptr update = (Alg_update_ptr) evt;
+         auto typeCode = update->get_type_code();
+
+         int channel = update->chan;
+         if (channel < 0 || channel >= 16) {
+            channel = 16;
+         }
+
+         if (typeCode == ALG_BEND) {
+            double bend = update->get_real_value();
+
+            // The spec (https://www.midi.org/specifications/item/table-3-control-change-messages-data-bytes-2)
+            // doesn't make it clear what should happen if LSB (cents) is greater than 100, so just don't worry
+            // about that case
+            curRawBend[channel] = bend;
+            double pitchRange = pitchRangeMSB[channel] + .01 * pitchRangeLSB[channel];
+            pitchBendChanges[channel][update->time] = bend * pitchRange;
+         } else if (typeCode == ALG_CONTROL) {
+            double pitchRange;
+
+            const char *name = update->get_attribute();
+            // The number of the controller being changed is embedded
+            // in the parameter name.
+            char controller = atoi(name + 7);
+            // Allegro normalizes controller values
+            char value = (int)((update->parameter.r * 127) + .5);
+
+            switch (controller) {
+               case 101: // MSB
+                  rpnMSB[channel] = value;
+                  break;
+               case 100: // LSB
+                  rpnLSB[channel] = value;
+                  break;
+               case 6:
+                  pitchRangeMSB[channel] = value;
+                  pitchRange = value + .01 * pitchRangeLSB[channel];
+                  pitchBendChanges[channel][update->time] = curRawBend[channel] * pitchRange;
+                  break;
+               case 38:
+                  pitchRangeLSB[channel] = value;
+                  pitchRange = pitchRangeMSB[channel] + .01 * value;
+                  pitchBendChanges[channel][update->time] = curRawBend[channel] * pitchRange;
+                  break;
+
+               default: break;
+            }
+         }
+      }
+   }
+   iterator.end();
+
+   return pitchBendChanges;
+}
+
 #endif // USE_MIDI

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -167,10 +167,8 @@ class AUDACITY_DLL_API NoteTrack final
    int GetOctaveBottom(int oct) const {
       return IPitchToY(oct * 12) + GetPitchHeight(1) + 1;
    }
-   // Y coordinate for given floating point pitch (rounded to int)
-   int PitchToY(double p) const {
-      return IPitchToY((int) (p + 0.5));
-   }
+   // Y coordinate for given floating point pitch, offset from lines as needed for non-integer pitches
+   int PitchToY(double p) const;
    // Integer pitch corresponding to a Y coordinate
    int YToIPitch(int y);
    // map pitch class number (0-11) to pixel offset from bottom of octave

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -13,6 +13,8 @@
 
 #include <utility>
 #include <wx/string.h>
+#include <map>
+#include <unordered_map>
 #include "Audacity.h"
 #include "Experimental.h"
 #include "Track.h"
@@ -191,6 +193,14 @@ class AUDACITY_DLL_API NoteTrack final
 
       mBottomNote = note;
    }
+
+   // Creates a map that contains pitch offsets by channel.
+   // The first map is keyed by channel ID (0-15, and 16 for unknown);
+   // the inner map goes from the timestamp to the pitch offset in semitones.
+   // The second map will never be empty - instead it will contain
+   // a mapping from 0 to 0.
+   // This is calculated from scratch each time and not cached.
+   std::unordered_map<int, std::map<double, double>> GetPitchOffsets() const;
 
 #if 0
    // Vertical scrolling is performed by dragging the keyboard at

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -3023,12 +3023,14 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
    // We want to draw in seconds, so we need to convert to seconds
    seq->convert_to_seconds();
 
+   std::unordered_map<int, std::map<double, double>> pitchBendChanges = track->GetPitchOffsets();
+
    Alg_iterator iterator(seq, false);
    iterator.begin();
    //for every event
    Alg_event_ptr evt;
    while (0 != (evt = iterator.next())) {
-      if (evt->get_type() == 'n') { // 'n' means a note
+      if (evt->is_note()) {
          Alg_note_ptr note = (Alg_note_ptr) evt;
          // if the note's channel is visible
          if (track->IsVisibleChan(evt->chan)) {
@@ -3037,52 +3039,37 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
             if (xx < h1 && x1 > h) { // omit if outside box
                const char *shape = NULL;
                if (note->loud > 0.0 || 0 == (shape = IsShape(note))) {
-                  wxRect nr; // "note rectangle"
-                  nr.y = track->PitchToY(note->pitch);
-                  nr.height = track->GetPitchHeight(1);
-
-                  nr.x = TIME_TO_X(xx);
-                  nr.width = TIME_TO_X(x1) - nr.x;
-
-                  if (nr.y + nr.height < rect.y + marg + 3) {
-                        // too high for window
-                        nr.y = rect.y;
-                        nr.height = marg;
-                        dc.SetBrush(*wxBLACK_BRUSH);
-                        dc.SetPen(*wxBLACK_PEN);
-                        dc.DrawRectangle(nr);
-                  } else if (nr.y >= rect.y + rect.height - marg - 1) {
-                        // too low for window
-                        nr.y = rect.y + rect.height - marg;
-                        nr.height = marg;
-                        dc.SetBrush(*wxBLACK_BRUSH);
-                        dc.SetPen(*wxBLACK_PEN);
-                        dc.DrawRectangle(nr);
-                  } else {
-                     if (nr.y + nr.height > rect.y + rect.height - marg)
-                        nr.height = rect.y + rect.height - nr.y;
-                     if (nr.y < rect.y + marg) {
-                        int offset = rect.y + marg - nr.y;
-                        nr.height -= offset;
-                        nr.y += offset;
-                     }
-
-                     if (muted)
-                        AColor::LightMIDIChannel(&dc, note->chan + 1);
-                     else
-                        AColor::MIDIChannel(&dc, note->chan + 1);
-                     dc.DrawRectangle(nr);
-                     if (track->GetPitchHeight(1) > 2) {
-                        AColor::LightMIDIChannel(&dc, note->chan + 1);
-                        AColor::Line(dc, nr.x, nr.y, nr.x + nr.width-2, nr.y);
-                        AColor::Line(dc, nr.x, nr.y, nr.x, nr.y + nr.height-2);
-                        AColor::DarkMIDIChannel(&dc, note->chan + 1);
-                        AColor::Line(dc, nr.x+nr.width-1, nr.y,
-                              nr.x+nr.width-1, nr.y+nr.height-1);
-                        AColor::Line(dc, nr.x, nr.y+nr.height-1,
-                              nr.x+nr.width-1, nr.y+nr.height-1);
-                     }
+                  // Look for pitch bends
+                  int channel = evt->chan;
+                  if (channel < 0 || channel >= 16) {
+                     channel = 16;
                   }
+                  // Using upper_bound-- rather than lower_bound allows us to get the current pitch
+                  // We know that there is always a bend at time 0 set to 0 (manually added)
+                  // so decrementing upper_bound at 0 will return that (rather than being undefined)
+                  auto start = pitchBendChanges[channel].upper_bound(note->time);
+                  wxASSERT(start != pitchBendChanges[channel].begin());
+                  start--;
+                  auto end = pitchBendChanges[channel].upper_bound(note->time + note->dur);
+
+                  int y = track->PitchToY(note->pitch + start->second);
+                  int pitchHeight = track->GetPitchHeight(1);
+
+                  int x = TIME_TO_X(xx);
+
+                  bool first = true;
+
+                  for (auto itr = start; ++itr != end; ) {
+                     int x2 = TIME_TO_X(itr->first + track->GetOffset());
+
+                     DrawNoteSegment(dc, rect, x, x2, y, pitchHeight, marg, first, false, note->chan + 1, muted);
+
+                     x = x2;
+                     y = track->PitchToY(note->pitch + itr->second);
+                     first = false;
+                  }
+
+                  DrawNoteSegment(dc, rect, x, TIME_TO_X(x1), y, pitchHeight, marg, first, true, note->chan + 1, muted);
                } else if (shape) {
                   // draw a shape according to attributes
                   // add 0.5 to pitch because pitches are plotted with
@@ -3258,6 +3245,60 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
    SonifyEndNoteForeground();
 }
 #endif // USE_MIDI
+
+void TrackArtist::DrawNoteSegment(wxDC & dc, const wxRect & rect, int x1, int x2, int y, int pitchHeight, int marg, bool first, bool last, int chan, bool muted)
+{
+   int width = x2 - x1;
+
+   bool drawLines = (pitchHeight > 2);
+
+   if (y + pitchHeight < rect.y + marg + 3) {
+      // too high for window
+      dc.SetBrush(*wxBLACK_BRUSH);
+      dc.SetPen(*wxBLACK_PEN);
+      dc.DrawRectangle(x1, rect.y, width, marg);
+   } else if (y >= rect.y + rect.height - marg - 1) {
+      // too low for window
+      dc.SetBrush(*wxBLACK_BRUSH);
+      dc.SetPen(*wxBLACK_PEN);
+      dc.DrawRectangle(x1, rect.y + rect.height - marg, width, marg);
+   } else {
+      int height = pitchHeight;
+      if (y + height > rect.y + rect.height - marg)
+         height = rect.y + rect.height - y;
+      if (y < rect.y + marg) {
+         int offset = rect.y + marg - y;
+         height -= offset;
+         y += offset;
+      }
+      if (muted)
+         AColor::LightMIDIChannel(&dc, chan);
+      else
+         AColor::MIDIChannel(&dc, chan);
+      dc.DrawRectangle(x1, y, width, height);
+      if (drawLines) {
+         AColor::LightMIDIChannel(&dc, chan);
+         if (first) {
+            // Vertical starting line
+            AColor::Line(dc, x1, y, x1, y + height - 1);
+         }
+         if (width >= 1) {
+            AColor::Line(dc, x1, y, x2 - 1, y);
+         }
+         AColor::DarkMIDIChannel(&dc, chan);
+         if (width >= 1) {
+            AColor::Line(dc, x1, y + height - 1,
+                  x2 - 1, y + height - 1);
+         }
+
+         if (last) {
+            // Vertical end line
+            AColor::Line(dc, x2 - 1, y,
+                  x2 - 1, y + height - 1);
+         }
+      }
+   }
+}
 
 
 void TrackArtist::DrawLabelTrack(TrackPanelDrawingContext &context,

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -588,6 +588,12 @@ void TrackArtist::DrawVRuler
    if (kind == Track::Note) {
       UpdateVRuler(t, rect);
 
+      // Vertical lines on the sides
+      // While these areas are initially black, they aren't repainted as black elsewhere, so
+      // the color gets messed up over time if they aren't redrawn
+      AColor::Line(*dc, rect.x, rect.y, rect.x, rect.y + rect.height);
+      AColor::Line(*dc, rect.x + rect.width, rect.y, rect.x + rect.width, rect.y + rect.height);
+
       dc->SetPen(highlight ? AColor::uglyPen : *wxTRANSPARENT_PEN);
       dc->SetBrush(*wxWHITE_BRUSH);
       wxRect bev = rect;

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -598,7 +598,6 @@ void TrackArtist::DrawVRuler
       rect.y += 1;
       rect.height -= 1;
 
-      //int bottom = GetBottom((NoteTrack *) t, rect);
       const NoteTrack *track = (NoteTrack *) t;
       track->PrepareIPitchToY(rect);
 

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -3038,53 +3038,43 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                   nr.x = TIME_TO_X(xx);
                   nr.width = TIME_TO_X(x1) - nr.x;
 
-                  if (nr.x + nr.width >= rect.x && nr.x < rect.x + rect.width) {
-                     if (nr.x < rect.x) {
-                        nr.width -= (rect.x - nr.x);
-                        nr.x = rect.x;
-                     }
-                     if (nr.x + nr.width > rect.x + rect.width) // clip on right
-                        nr.width = rect.x + rect.width - nr.x;
-
-                     if (nr.y + nr.height < rect.y + marg + 3) {
-                         // too high for window
-                         nr.y = rect.y;
-                         nr.height = marg;
-                         dc.SetBrush(*wxBLACK_BRUSH);
-                         dc.SetPen(*wxBLACK_PEN);
-                         dc.DrawRectangle(nr);
-                     } else if (nr.y >= rect.y + rect.height - marg - 1) {
-                         // too low for window
-                         nr.y = rect.y + rect.height - marg;
-                         nr.height = marg;
-                         dc.SetBrush(*wxBLACK_BRUSH);
-                         dc.SetPen(*wxBLACK_PEN);
-                         dc.DrawRectangle(nr);
-                     } else {
-                        if (nr.y + nr.height > rect.y + rect.height - marg)
-                           nr.height = rect.y + rect.height - nr.y;
-                        if (nr.y < rect.y + marg) {
-                           int offset = rect.y + marg - nr.y;
-                           nr.height -= offset;
-                           nr.y += offset;
-                        }
-                        // nr.y += rect.y;
-                        if (muted)
-                           AColor::LightMIDIChannel(&dc, note->chan + 1);
-                        else
-                           AColor::MIDIChannel(&dc, note->chan + 1);
+                  if (nr.y + nr.height < rect.y + marg + 3) {
+                        // too high for window
+                        nr.y = rect.y;
+                        nr.height = marg;
+                        dc.SetBrush(*wxBLACK_BRUSH);
+                        dc.SetPen(*wxBLACK_PEN);
                         dc.DrawRectangle(nr);
-                        if (track->GetPitchHeight(1) > 2) {
-                           AColor::LightMIDIChannel(&dc, note->chan + 1);
-                           AColor::Line(dc, nr.x, nr.y, nr.x + nr.width-2, nr.y);
-                           AColor::Line(dc, nr.x, nr.y, nr.x, nr.y + nr.height-2);
-                           AColor::DarkMIDIChannel(&dc, note->chan + 1);
-                           AColor::Line(dc, nr.x+nr.width-1, nr.y,
-                                 nr.x+nr.width-1, nr.y+nr.height-1);
-                           AColor::Line(dc, nr.x, nr.y+nr.height-1,
-                                 nr.x+nr.width-1, nr.y+nr.height-1);
-                        }
-//                        }
+                  } else if (nr.y >= rect.y + rect.height - marg - 1) {
+                        // too low for window
+                        nr.y = rect.y + rect.height - marg;
+                        nr.height = marg;
+                        dc.SetBrush(*wxBLACK_BRUSH);
+                        dc.SetPen(*wxBLACK_PEN);
+                        dc.DrawRectangle(nr);
+                  } else {
+                     if (nr.y + nr.height > rect.y + rect.height - marg)
+                        nr.height = rect.y + rect.height - nr.y;
+                     if (nr.y < rect.y + marg) {
+                        int offset = rect.y + marg - nr.y;
+                        nr.height -= offset;
+                        nr.y += offset;
+                     }
+
+                     if (muted)
+                        AColor::LightMIDIChannel(&dc, note->chan + 1);
+                     else
+                        AColor::MIDIChannel(&dc, note->chan + 1);
+                     dc.DrawRectangle(nr);
+                     if (track->GetPitchHeight(1) > 2) {
+                        AColor::LightMIDIChannel(&dc, note->chan + 1);
+                        AColor::Line(dc, nr.x, nr.y, nr.x + nr.width-2, nr.y);
+                        AColor::Line(dc, nr.x, nr.y, nr.x, nr.y + nr.height-2);
+                        AColor::DarkMIDIChannel(&dc, note->chan + 1);
+                        AColor::Line(dc, nr.x+nr.width-1, nr.y,
+                              nr.x+nr.width-1, nr.y+nr.height-1);
+                        AColor::Line(dc, nr.x, nr.y+nr.height-1,
+                              nr.x+nr.width-1, nr.y+nr.height-1);
                      }
                   }
                } else if (shape) {

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -120,6 +120,7 @@ class AUDACITY_DLL_API TrackArtist {
                       wxDC & dc, const wxRect & rect,
                       const SelectedRegion &selectedRegion, const ZoomInfo &zoomInfo,
                       bool muted);
+   void DrawNoteSegment(wxDC & dc, const wxRect & rect, int x1, int x2, int y, int pitchHeight, int marg, bool first, bool last, int chan, bool muted);
 #endif // USE_MIDI
 
    void DrawLabelTrack(TrackPanelDrawingContext &context,

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -110,7 +110,6 @@ class AUDACITY_DLL_API TrackArtist {
                      wxDC & dc, const wxRect & rect,
                      const SelectedRegion &selectedRegion, const ZoomInfo &zoomInfo);
 #ifdef USE_MIDI
-   int GetBottom(NoteTrack *t, const wxRect &rect);
    void DrawNoteBackground(const NoteTrack *track, wxDC &dc,
                            const wxRect &rect, const wxRect &sel,
                            const ZoomInfo &zoomInfo,


### PR DESCRIPTION
This pull request adds support for displaying pitch bends in note tracks, and fixes a rendering issues with them as well.

<dl>
<dt>8a01491 &mdash; Stop rounding in NoteTrack::PitchToY</dt>
<dd>Initial setup that was needed to implement pitch bends.</dd>
<dt>d09530d &mdash; Remove unused (and unimplemented) TrackArtist::GetBottom</dt>
<dd>Removes some old method signatures that were unused.</dd>
<dt>da4c6a3 &mdash; Get rid of redundant horizontal note clipping</dt>
<dd>The first commit that has actual rendering changes.  Basically note rects were shortened so that they wouldn't go outside of the track area, but this meant that there would also be vertical lines on the edge that make it look as if the note ends there.  By getting rid of this shortening, the edge is gone, so it is clear that the note doesn't actually start/stop right at the edge of the track.

I've got a sample image of the changes at Pokechu22/general-test-repo@9393dc4 (abusing GitHub's image diff tool for this).</dd>
<dt>9f1db7b &mdash; Fix edges of the note track vruler not redrawing</dt>
<dd>This fixes a small rendering issue with the note track vruler (the piano).  Basically, it originally wasn't redrawing the rightmost edge, which would occasionally get overwritten by the blue measure lines (more common when using pinned playback).  Then the horizontal lines between piano keys would draw over that, and to make things worse it'd move those lines if you resized the track, but not redraw the now blue area.  Check [this image](https://alphamanual.audacityteam.org/m/images/b/b2/TCP_and_VS_-_Note_Track.png) (from the manual) for an example.

The fix is to just always draw both of them black.</dd>
<dt>67983b0 &mdash; Add support for displaying pitch bends</dt>
<dd>The actual main event.  Pitch bends are now rendered correctly.

Before:

![Image without pitch bend (BFD id $58)](https://user-images.githubusercontent.com/8334194/32139403-1e3a8a8a-bbfc-11e7-9460-2363403e4f13.PNG)

After:

![Image showing pitch bend successfully (BFD id $58)](https://user-images.githubusercontent.com/8334194/32139402-1df03b9c-bbfc-11e7-9822-5129d064b589.PNG)


The way this is done is by calculating, for each channel, the location all pitch bend changes, and the new value at that point.  Then for each note I get the current offset, and any changes in the middle of the note, drawing the starting line once and the end line only on the last segment.

I also handle the pitch bend range RPN, so taller pitch bends are correctly handled.  I might not be handling it correctly in 100% of the cases though (there is the data increment controller, which I haven't implemented).  Here's a simple file I used to test this: [PitchBendRPN.zip](https://github.com/audacity/audacity/files/1424696/PitchBendRPN.zip).
</dl>

This is a WIP as I'm not entirely happy with the quality of the code I've written.  I'm sure it could be written better with fancier C++ stuff, but I'm not completely experienced with C++ yet.  Also ideally I'd cache the pitch bend offsets, but doing that seems complicated (since I don't know when the backing sequence is changed).

(Also, obviously this is intended for being merged after 2.2.0 is released)