### PR TITLE
Fix German translation for "light" theme

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -12498,7 +12498,7 @@ msgstr "Klassisch"
 #. i18n-hint: Light meaning opposite of dark
 #: src/prefs/GUIPrefs.cpp:97
 msgid "Light"
-msgstr "Leicht"
+msgstr "Hell"
 
 #: src/prefs/GUIPrefs.cpp:98
 msgid "Dark"


### PR DESCRIPTION
Current translation is wrong (means light as in "opposite of heavy" instead of "opposite of dark").