### PR TITLE
PortMIDI build changes + use Pa_GetStreamTime instead of PaUtil_GetTime

### DIFF
--- a/configure
+++ b/configure
@@ -23500,7 +23500,7 @@ $as_echo "#define USE_MIDI 1" >>confdefs.h
 
 
    if test "$PORTMIDI_USE_LOCAL" = yes; then
-      PORTMIDI_CFLAGS='-I$(top_srcdir)/lib-src/portmidi'
+      PORTMIDI_CFLAGS='-I$(top_srcdir)/lib-src/portmidi/pm_common'
       PORTMIDI_LIBS='$(top_builddir)/lib-src/portmidi/libportmidi_s.a'
       subdirs="$subdirs lib-src/portmidi"
 

--- a/lib-src/portmidi/Makefile.am
+++ b/lib-src/portmidi/Makefile.am
@@ -22,8 +22,8 @@ libportmidi_s_a_SOURCES = pm_common/portmidi.c \
 # but that would mean re-organising them here (a subdirectory called portSMF to
 # keep headers in, add -I$(srcdir)/portSMF/ to AM_CXXFLAGS, change the paths
 # to the headers here and change the name of the variable to nobase_include_...
-#include_HEADERS = portmidi/portmidi.h \
-#	porttime/porttime.h
+include_HEADERS = pm_common/portmidi.h \
+	porttime/porttime.h
 
 
 AM_CFLAGS = -I$(top_srcdir)/pm_common -I$(top_srcdir)/porttime

--- a/lib-src/portmidi/Makefile.in
+++ b/lib-src/portmidi/Makefile.in
@@ -19,6 +19,7 @@
 # Written by Richard Ash following Gary Vaughan's Autobook
 
 
+
 VPATH = @srcdir@
 am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
 am__make_running_with_option = \
@@ -86,8 +87,9 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/configure $(am__configure_deps) \
 	$(srcdir)/portmidi.pc.in $(srcdir)/portmidi-uninstalled.pc.in \
 	$(top_srcdir)/autotools/depcomp $(dist_doc_DATA) \
-	autotools/compile autotools/depcomp autotools/install-sh \
-	autotools/missing $(top_srcdir)/autotools/compile \
+	$(include_HEADERS) autotools/compile autotools/depcomp \
+	autotools/install-sh autotools/missing \
+	$(top_srcdir)/autotools/compile \
 	$(top_srcdir)/autotools/install-sh \
 	$(top_srcdir)/autotools/missing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -131,7 +133,8 @@ am__uninstall_files_from_dir = { \
     || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
          $(am__cd) "$$dir" && rm -f $$files; }; \
   }
-am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(docdir)"
+am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(docdir)" \
+	"$(DESTDIR)$(includedir)"
 LIBRARIES = $(lib_LIBRARIES)
 AR = ar
 ARFLAGS = cru
@@ -185,6 +188,7 @@ am__can_run_installinfo = \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
 DATA = $(dist_doc_DATA)
+HEADERS = $(include_HEADERS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 # Read a list of newline-separated strings from the standard input,
 # and print each of them once, without duplicates.  Input order is
@@ -338,8 +342,9 @@ libportmidi_s_a_SOURCES = pm_common/portmidi.c \
 # but that would mean re-organising them here (a subdirectory called portSMF to
 # keep headers in, add -I$(srcdir)/portSMF/ to AM_CXXFLAGS, change the paths
 # to the headers here and change the name of the variable to nobase_include_...
-#include_HEADERS = portmidi/portmidi.h \
-#	porttime/porttime.h
+include_HEADERS = pm_common/portmidi.h \
+	porttime/porttime.h
+
 AM_CFLAGS = -I$(top_srcdir)/pm_common -I$(top_srcdir)/porttime
 
 # files that only really viscous cleans remove
@@ -568,6 +573,27 @@ uninstall-dist_docDATA:
 	@list='$(dist_doc_DATA)'; test -n "$(docdir)" || list=; \
 	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
 	dir='$(DESTDIR)$(docdir)'; $(am__uninstall_files_from_dir)
+install-includeHEADERS: $(include_HEADERS)
+	@$(NORMAL_INSTALL)
+	@list='$(include_HEADERS)'; test -n "$(includedir)" || list=; \
+	if test -n "$$list"; then \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(includedir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(includedir)" || exit 1; \
+	fi; \
+	for p in $$list; do \
+	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; \
+	done | $(am__base_list) | \
+	while read files; do \
+	  echo " $(INSTALL_HEADER) $$files '$(DESTDIR)$(includedir)'"; \
+	  $(INSTALL_HEADER) $$files "$(DESTDIR)$(includedir)" || exit $$?; \
+	done
+
+uninstall-includeHEADERS:
+	@$(NORMAL_UNINSTALL)
+	@list='$(include_HEADERS)'; test -n "$(includedir)" || list=; \
+	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
+	dir='$(DESTDIR)$(includedir)'; $(am__uninstall_files_from_dir)
 
 ID: $(am__tagged_files)
 	$(am__define_uniq_tagged_files); mkid -fID $$unique
@@ -793,9 +819,9 @@ distcleancheck: distclean
 	       exit 1; } >&2
 check-am: all-am
 check: check-am
-all-am: Makefile $(LIBRARIES) $(DATA)
+all-am: Makefile $(LIBRARIES) $(DATA) $(HEADERS)
 installdirs:
-	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(docdir)"; do \
+	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(docdir)" "$(DESTDIR)$(includedir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -852,7 +878,7 @@ info: info-am
 
 info-am:
 
-install-data-am: install-dist_docDATA
+install-data-am: install-dist_docDATA install-includeHEADERS
 
 install-dvi: install-dvi-am
 
@@ -899,7 +925,8 @@ ps: ps-am
 
 ps-am:
 
-uninstall-am: uninstall-dist_docDATA uninstall-libLIBRARIES
+uninstall-am: uninstall-dist_docDATA uninstall-includeHEADERS \
+	uninstall-libLIBRARIES
 
 .MAKE: install-am install-strip
 
@@ -912,13 +939,14 @@ uninstall-am: uninstall-dist_docDATA uninstall-libLIBRARIES
 	dvi-am html html-am info info-am install install-am \
 	install-data install-data-am install-dist_docDATA install-dvi \
 	install-dvi-am install-exec install-exec-am install-html \
-	install-html-am install-info install-info-am \
-	install-libLIBRARIES install-man install-pdf install-pdf-am \
-	install-ps install-ps-am install-strip installcheck \
-	installcheck-am installdirs maintainer-clean \
+	install-html-am install-includeHEADERS install-info \
+	install-info-am install-libLIBRARIES install-man install-pdf \
+	install-pdf-am install-ps install-ps-am install-strip \
+	installcheck installcheck-am installdirs maintainer-clean \
 	maintainer-clean-generic mostlyclean mostlyclean-compile \
 	mostlyclean-generic pdf pdf-am ps ps-am tags tags-am uninstall \
-	uninstall-am uninstall-dist_docDATA uninstall-libLIBRARIES
+	uninstall-am uninstall-dist_docDATA uninstall-includeHEADERS \
+	uninstall-libLIBRARIES
 
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.

--- a/m4/audacity_checklib_portmidi.m4
+++ b/m4/audacity_checklib_portmidi.m4
@@ -1,5 +1,5 @@
 dnl I frankly don't know what's supposed to go there
-# audacity_checklib_portsmf.m4 serial 1
+# audacity_checklib_portsmf.m4 serial 2
 
 AC_DEFUN([AUDACITY_CHECKLIB_PORTMIDI], [
 
@@ -9,7 +9,7 @@ AC_DEFUN([AUDACITY_CHECKLIB_PORTMIDI], [
                PORTMIDI_ARGUMENT=$withval,
                PORTMIDI_ARGUMENT="unspecified")
 
-   dnl see if libportsmf is installed on the system
+   dnl see if libportmidi is installed on the system
 
    PKG_CHECK_MODULES(PORTMIDI, portmidi,
                      PORTMIDI_SYSTEM_AVAILABLE="yes",
@@ -34,7 +34,7 @@ AC_DEFUN([AUDACITY_CHECKLIB_PORTMIDI], [
 
 AC_DEFUN([AUDACITY_CONFIG_PORTMIDI], [
    if test "$PORTMIDI_USE_LOCAL" = yes; then
-      PORTMIDI_CFLAGS='-I$(top_srcdir)/lib-src/portmidi'
+      PORTMIDI_CFLAGS='-I$(top_srcdir)/lib-src/portmidi/pm_common'
       PORTMIDI_LIBS='$(top_builddir)/lib-src/portmidi/libportmidi_s.a'
       AC_CONFIG_SUBDIRS([lib-src/portmidi])
    fi
@@ -47,6 +47,6 @@ AC_DEFUN([AUDACITY_CONFIG_PORTMIDI], [
 
    if test "$PORTMIDI_USE_LOCAL" = yes -o "$PORTMIDI_USE_SYSTEM" = yes; then
       AC_DEFINE(USE_PORTMIDI, 1,
-                [Define if midi support should be enabled])
+                [Define if MIDI playback support using PortMIDI should be enabled])
    fi
 ])

--- a/mac/config/i386/src/configunix.h
+++ b/mac/config/i386/src/configunix.h
@@ -162,6 +162,9 @@
 /* Define if Nyquist support should be enabled */
 #define USE_NYQUIST 1
 
+/* Define if MIDI playback support using PortMIDI should be enabled */
+#define USE_PORTMIDI 1
+
 /* Define if PortMixer support should be enabled */
 #define USE_PORTMIXER 1
 

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -168,7 +168,7 @@ It handles initialization and termination by subclassing wxApp.
 #     pragma comment(lib, "portsmf")
 #     endif
 
-#  if defined(EXPERIMENTAL_MIDI_OUT)
+#  if defined(USE_PORTMIDI)
 #     pragma comment(lib, "portmidi")
 #  endif
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -464,8 +464,11 @@ TimeTrack and AudioIOListener and whether the playback is looped.
    #endif
    #define ROUND(x) (int) ((x)+0.5)
 
-   #include "portmidi.h"
    #include "NoteTrack.h"
+#endif
+#ifdef USE_PORTMIDI
+   // Since PortMidi methods are used in diagnostics, we want this even if EXPERIMENTAL_MIDI_OUT isn't defined
+   #include "portmidi.h"
 #endif
 
 #ifdef EXPERIMENTAL_AUTOMATED_INPUT_LEVEL_ADJUSTMENT
@@ -3704,8 +3707,7 @@ wxString AudioIO::GetDeviceInfo()
    return o.GetString();
 }
 
-#ifdef EXPERIMENTAL_MIDI_OUT
-// FIXME: When EXPERIMENTAL_MIDI_IN is added (eventually) this should also be enabled -- Poke
+#ifdef USE_PORTMIDI
 wxString AudioIO::GetMidiDeviceInfo()
 {
    wxStringOutputStream o;

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -463,8 +463,9 @@ TimeTrack and AudioIOListener and whether the playback is looped.
       #define THREAD_LATENCY 0 /* milliseconds */
    #endif
    #define ROUND(x) (int) ((x)+0.5)
-   //#include <string.h>
-   #include "../lib-src/portmidi/pm_common/portmidi.h"
+
+   #include "portmidi.h"
+   // PaUtil_GetTime is not part of the public API, so we hardcode a path to the header
    #include "../lib-src/portaudio-v19/src/common/pa_util.h"
    #include "NoteTrack.h"
 #endif

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2036,8 +2036,10 @@ int AudioIO::StartStream(const WaveTrackConstArray &playbackTracks,
    unsigned int captureChannels = 0;
    sampleFormat captureFormat = floatSample;
 
-   if (playbackTracks.size() > 0 
+   if (playbackTracks.size() > 0
 #ifdef EXPERIMENTAL_MIDI_OUT
+// We want to always start a portaudio stream if there is a note track
+// so that we can sync with it, even if we aren't playing anything to the stream
       || midiPlaybackTracks.size() > 0
 #endif
       )
@@ -2838,7 +2840,7 @@ void AudioIO::StopStream()
 
    mPlaybackTracks.clear();
    mCaptureTracks.clear();
-#ifdef HAVE_MIDI
+#ifdef EXPERIMENTAL_MIDI_OUT
    mMidiPlaybackTracks.clear();
 #endif
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -4688,9 +4688,6 @@ int audacityAudioCallback(const void *inputBuffer, void *outputBuffer,
        // later, mStartTime - mSystemMinusAudioTime will tell us latency
    }
 
-   /* GSW: Save timeInfo in case MidiPlayback needs it */
-   gAudioIO->mAudioCallbackClockTime = PaUtil_GetTime();
-
    /* for Linux, estimate a smooth audio time as a slowly-changing
       offset from system time */
    // rnow is system time as a double to simplify math

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -25,11 +25,8 @@
 
 #ifdef USE_MIDI
 
-// TODO: Put the relative paths into automake.
-
 #ifdef EXPERIMENTAL_MIDI_OUT
-#include "../lib-src/portmidi/pm_common/portmidi.h"
-#include "../lib-src/portmidi/porttime/porttime.h"
+#include "portmidi.h"
 #include <cstring> // Allegro include fails if this header isn't included do to no memcpy
 #include "../lib-src/header-substitutes/allegro.h"
 
@@ -41,7 +38,7 @@ using NoteTrackArray = std::vector < std::shared_ptr< NoteTrack > >;
 #endif // USE_MIDI
 
 #if USE_PORTMIXER
-#include "../lib-src/portmixer/include/portmixer.h"
+#include "portmixer.h"
 #endif
 
 #include <wx/event.h>

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -242,6 +242,15 @@ class AUDACITY_DLL_API AudioIO final {
  public:
    bool SetHasSolo(bool hasSolo);
    bool GetHasSolo() { return mHasSolo; }
+
+ private:
+   double streamStartTime = 0;
+
+ public:
+   // Used to bias system time to a small number
+   void ResetSystemTime();
+   // Returns the system time as a double
+   double SystemTime();
 #endif
 
    /** \brief Returns true if the stream is active, or even if audio I/O is

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -395,7 +395,7 @@ class AUDACITY_DLL_API AudioIO final {
     */
    wxString GetDeviceInfo();
 
-#ifdef EXPERIMENTAL_MIDI_OUT
+#ifdef USE_PORTMIDI
    /** \brief Get diagnostic information on all the available MIDI I/O devices */
    wxString GetMidiDeviceInfo();
 #endif

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -545,9 +545,6 @@ private:
 
    // These fields are used to synchronize MIDI with audio:
 
-   /// PortAudio's clock time
-   volatile double  mAudioCallbackClockTime;
-
    /// Number of frames output, including pauses
    volatile long    mNumFrames;
    /// How many frames of zeros were output due to pauses?

--- a/src/Experimental.h
+++ b/src/Experimental.h
@@ -144,11 +144,16 @@
 // Paul Licameli (PRL) 29 Nov 2014
 // #define EXPERIMENTAL_IMPROVED_SEEKING
 
-#ifdef USE_MIDI
 // RBD, 1 Sep 2008
 // Enables MIDI Output of NoteTrack (MIDI) data during playback
-// USE_MIDI must be defined in order for EXPERIMENTAL_MIDI_OUT to work
+// USE_MIDI and USE_PORTMIDI must be defined in order for EXPERIMENTAL_MIDI_OUT to work
+#ifdef USE_MIDI
+#ifdef USE_PORTMIDI
 #define EXPERIMENTAL_MIDI_OUT
+#endif
+#endif
+
+#ifdef USE_MIDI
 // JKC, 17 Aug 2017
 // Enables the MIDI note stretching feature, which currently
 // a) Is broken on Linux (Bug 1646)

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -1265,7 +1265,7 @@ void AudacityProject::CreateMenusAndCommands()
       c->AddItem(wxT("DeviceInfo"), _("Au&dio Device Info..."), FN(OnAudioDeviceInfo),
          AudioIONotBusyFlag,
          AudioIONotBusyFlag);
-#ifdef EXPERIMENTAL_MIDI_OUT
+#ifdef USE_PORTMIDI
       c->AddItem(wxT("MidiDeviceInfo"), _("&MIDI Device Info..."), FN(OnMidiDeviceInfo),
          AudioIONotBusyFlag,
          AudioIONotBusyFlag);
@@ -8473,7 +8473,7 @@ void AudacityProject::OnAudioDeviceInfo(const CommandContext &WXUNUSED(context) 
    }
 }
 
-#ifdef EXPERIMENTAL_MIDI_OUT
+#ifdef USE_PORTMIDI
 void AudacityProject::OnMidiDeviceInfo(const CommandContext &WXUNUSED(context) )
 {
    wxString info = gAudioIO->GetMidiDeviceInfo();

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -520,7 +520,7 @@ void OnSimulateRecordingErrors(const CommandContext &context );
 void OnDetectUpstreamDropouts(const CommandContext &context );
 void OnScreenshot(const CommandContext &context );
 void OnAudioDeviceInfo(const CommandContext &context );
-#ifdef EXPERIMENTAL_MIDI_OUT
+#ifdef USE_PORTMIDI
 void OnMidiDeviceInfo(const CommandContext &context );
 #endif
 

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -400,12 +400,14 @@ void OnRescanDevices(const CommandContext &context );
 // Import Submenu
 void OnImport(const CommandContext &context );
 void OnImportLabels(const CommandContext &context );
+#ifdef USE_MIDI
 void OnImportMIDI(const CommandContext &context );
 
 // return null on failure; if success, return the given project, or a NEW
 // one, if the given was null; create no NEW project if failure
 static AudacityProject *DoImportMIDI(
    AudacityProject *pProject, const wxString &fileName);
+#endif
 
 void OnImportRaw(const CommandContext &context );
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -214,7 +214,7 @@ void NoteTrack::DoSetHeight(int h)
 {
    auto oldHeight = GetHeight();
    auto oldMargin = GetNoteMargin(oldHeight);
-   PlayableTrack::DoSetHeight(h);
+   NoteTrackBase::DoSetHeight(h);
    auto margin = GetNoteMargin(h);
    Zoom(
       wxRect{ 0, 0, 1, h }, // only height matters

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -40,7 +40,7 @@
 #include "AllThemeResources.h"
 
 #ifdef SONIFY
-#include "../lib-src/portmidi/pm_common/portmidi.h"
+#include "portmidi.h"
 
 #define SON_PROGRAM 0
 #define SON_AutoSave 67

--- a/src/configtemplate.h
+++ b/src/configtemplate.h
@@ -161,7 +161,7 @@
 /* Define if Nyquist support should be enabled */
 #undef USE_NYQUIST
 
-/* Define if midi support should be enabled */
+/* Define if MIDI playback support using PortMIDI should be enabled */
 #undef USE_PORTMIDI
 
 /* Define if PortMixer support should be enabled */

--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -327,6 +327,7 @@ movable_ptr<ExtImportItem> Importer::CreateDefaultImportItem()
    return new_item;
 }
 
+#ifdef USE_MIDI
 bool Importer::IsMidi(const wxString &fName)
 {
    const auto extension = fName.AfterLast(wxT('.'));
@@ -335,6 +336,7 @@ bool Importer::IsMidi(const wxString &fName)
       extension.IsSameAs(wxT("midi"), false) ||
       extension.IsSameAs(wxT("mid"), false);
 }
+#endif
 
 // returns number of tracks imported
 bool Importer::Import(const wxString &fName,

--- a/src/import/Import.h
+++ b/src/import/Import.h
@@ -136,7 +136,9 @@ public:
     */
     movable_ptr<ExtImportItem> CreateDefaultImportItem();
 
+#ifdef USE_MIDI
    static bool IsMidi(const wxString &fName);
+#endif
 
    // if false, the import failed and errorMessage will be set.
    bool Import(const wxString &fName,

--- a/src/prefs/MidiIOPrefs.cpp
+++ b/src/prefs/MidiIOPrefs.cpp
@@ -32,7 +32,7 @@ other settings.
 #include <wx/choice.h>
 #include <wx/intl.h>
 
-#include "../../lib-src/portmidi/pm_common/portmidi.h"
+#include "portmidi.h"
 
 #include "../AudioIO.h"
 #include "../Internat.h"

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackButtonHandle.h
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackButtonHandle.h
@@ -11,6 +11,9 @@ Paul Licameli split from TrackPanel.cpp
 #ifndef __AUDACITY_NOTE_TRACK_BUTTON_HANDLE__
 #define __AUDACITY_NOTE_TRACK_BUTTON_HANDLE__
 
+#include "../../../../Audacity.h"
+#ifdef USE_MIDI
+
 class wxMouseState;
 class NoteTrack;
 
@@ -71,4 +74,5 @@ protected:
    wxRect mRect{};
 };
 
+#endif
 #endif

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.h
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.h
@@ -11,6 +11,8 @@ Paul Licameli split from TrackPanel.cpp
 #ifndef __AUDACITY_NOTE_TRACK_CONTROLS__
 #define __AUDACITY_NOTE_TRACK_CONTROLS__
 
+#include "../../../../Audacity.h"
+#ifdef USE_MIDI
 #include "../../../ui/TrackControls.h"
 #include "../../../../MemoryX.h"
 class MuteButtonHandle;
@@ -42,4 +44,5 @@ public:
    PopupMenuTable *GetMenuExtension(Track *pTrack) override;
 };
 
+#endif
 #endif

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.h
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.h
@@ -11,6 +11,9 @@ Paul Licameli split from TrackPanel.cpp
 #ifndef __AUDACITY_NOTE_TRACK_VRULER_CONTROLS__
 #define __AUDACITY_NOTE_TRACK_VRULER_CONTROLS__
 
+#include "../../../../Audacity.h"
+#ifdef USE_MIDI
+
 #include "../../../ui/TrackVRulerControls.h"
 
 class NoteTrackVZoomHandle;
@@ -38,4 +41,5 @@ private:
    std::weak_ptr<NoteTrackVZoomHandle> mVZoomHandle;
 };
 
+#endif
 #endif

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.h
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.h
@@ -11,6 +11,9 @@ Paul Licameli split from TrackPanel.cpp
 #ifndef __AUDACITY_NOTE_TRACK_VZOOM_HANDLE__
 #define __AUDACITY_NOTE_TRACK_VZOOM_HANDLE__
 
+#include "../../../../Audacity.h"
+#ifdef USE_MIDI
+
 class wxMouseState;
 class NoteTrack;
 
@@ -68,4 +71,5 @@ private:
    wxRect mRect;
 };
 
+#endif
 #endif

--- a/src/tracks/playabletrack/notetrack/ui/StretchHandle.h
+++ b/src/tracks/playabletrack/notetrack/ui/StretchHandle.h
@@ -11,6 +11,9 @@ Paul Licameli split from TrackPanel.cpp
 #ifndef __AUDACITY_STRETCH_HANDLE__
 #define __AUDACITY_STRETCH_HANDLE__
 
+#include "../../../../Audacity.h"
+#ifdef USE_MIDI
+
 #include "../../../../UIHandle.h"
 
 #include "../../../../MemoryX.h"
@@ -102,4 +105,5 @@ private:
    StretchState mStretchState{};
 };
 
+#endif
 #endif

--- a/win/configwin.h
+++ b/win/configwin.h
@@ -13,23 +13,57 @@
 
 *//*******************************************************************/
 
+/* Define if ffmpeg (multi-format import and export) support should be enabled
+   */
+#define USE_FFMPEG 1
 
-#define USE_FFMPEG 1	//define this to build with ffmpeg import/export
+/* Define if GStreamer 1 is present */
+/* #undef USE_GSTREAMER */
+
+/* Define if LADSPA plug-ins are enabled */
 #define USE_LADSPA 1
+
+/* Define if the FLAC library is present */
 #define USE_LIBFLAC 1
+
+/* Define if libid3tag is present */
 #define USE_LIBID3TAG 1
-#define USE_LV2 1
+
+/* Define if mp3 support is implemented with the libmad library */
 #define USE_LIBMAD 1
-//#define USE_GSTREAMER 1
+
+/* Define if libtwolame (MP2 export) support should be enabled */
 #define USE_LIBTWOLAME 1
+
+/* Define if the ogg vorbis decoding library is present */
 #define USE_LIBVORBIS 1
+
+/* Define if LV2 support should be enabled */
+#define USE_LV2 1
+
+/* Define if midi support should be enabled */
+#define USE_MIDI 1
+
+/* Define if Nyquist support should be enabled */
 #define USE_NYQUIST 1
+
+/* Define if MIDI playback support using PortMIDI should be enabled */
+#define USE_PORTMIDI 1
+
+/* Define if PortMixer support should be enabled */
 #define USE_PORTMIXER 1
+
+/* Define if SBSMS support should be enabled */
 #define USE_SBSMS 1
+
+/* Define if SoundTouch support should be enabled */
 #define USE_SOUNDTOUCH 1
+
+/* Define if Vamp analysis plugin support should be enabled */
 #define USE_VAMP 1
+
+/* Define if VST plug-in support is enabled */
 #define USE_VST 1
-#define USE_MIDI 1 // define this to use portSMF and PortMidi for midi file support
 
 #define INSTALL_PREFIX "."
 

--- a/win/configwin.h
+++ b/win/configwin.h
@@ -48,7 +48,7 @@
 #define USE_NYQUIST 1
 
 /* Define if MIDI playback support using PortMIDI should be enabled */
-#define USE_PORTMIDI 1
+//#define USE_PORTMIDI 1
 
 /* Define if PortMixer support should be enabled */
 #define USE_PORTMIXER 1


### PR DESCRIPTION
These changes adjust building, fix a few compile errors when features are disabled, and most importantly, switches to `Pa_GetStreamTime` instead of `PaUtil_GetTime`.

<dl>
<dt>1d32b0306 &mdash; Fix PortMidi automake files and update PortMidi's m4</dt>
<dd>Corrections of some typos and other mistakes needed to use includes correctly that I made earlier.</dd>
<dt>ed5bc5b04 &mdash; Include headers via automake instead of via hardcoded paths</dt>
<dd>Replaces e.g. <code>#include "../lib-src/portmidi/pm_common/portmidi.h"</code> with just <code>#include "portmidi.h"</code>, which is possible due to the above change.</dd>
<dt>f5f29d886 &mdash; Manually regenerate windows and mac configs</dt>
<dd>I manually updated the mac and windows configs to match the new template (which was generated in the first commit) - they were both missing <code>USE_PORTMIDI</code>.</dd>
<dt>0495ed56d &mdash; Check for both <code>USE_MIDI</code> and <code>USE_PORTMIDI</code> for <code>EXPERIMENTAL_MIDI_OUT</code></dt>
<dd>Allows compiling <code>--without-portmidi</code> without manually editing <code>Experimental.h</code>.</dd>
<dt>0c51ba734 &mdash;  Fix more missing checks for USE_MIDI</dt>
<dd>Adds more missing checks relating to USE_MIDI (those that were missed in #257 since they didn't break compilation).</dd>
<dt>ab9429c8a &mdash; Remove unused mAudioCallbackClockTime</dt>
<dd>Removes a now-unused field (and one use of <code>PaUtil_GetTime</code>).</dd>
<dt>21e55934d &mdash; Completely replace <code>PaUtil_GetTime</code> with <code>Pa_GetStreamTime</code></dt>
<dd>This change is probably the most important in terms of building.  It means that <code>PaUtil_GetTime</code> is no longer directly linked by audacity, which means that the <code>extern "C"</code> change in portaudio is no longer necessary (and thus system portaudio should be usable again!).</dd>
<dd>The change basically just uses <code>Pa_GetStreamTime</code> with <code>mPortStreamV19</code> &ndash; but since that requires a non-null stream, some logic needs to be reordered to ensure that the stream isn't <code>NULL</code>.</dd>
<dt>15f82ff &mdash; Check <code>USE_PORTMIDI</code> instead of <code>EXPERIMENTAL_MIDI_OUT</code> for MIDI device info</dt>
<dd>Since <code>USE_PORTMIDI</code> now exists, it makes more sense to use that to govern the MIDI device info option &ndash; especially since the option reports the status of that experimental flag.</dd>
</dl>