### PR TITLE
Update defaultTempDir path in AudacityApp.cpp

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1283,8 +1283,15 @@ bool AudacityApp::OnInit()
       * The "share" and "share/doc" directories in their install path */
    wxString home = wxGetHomeDir();
 
-   /* On Unix systems, the default temp dir is in /var/tmp. */
-   defaultTempDir.Printf(wxT("/var/tmp/audacity-%s"), wxGetUserId());
+   wxString envTempDir = wxGetenv(wxT("TMPDIR"));
+   if (envTempDir != wxT("")) {
+      /* On Unix systems, the environment variable TMPDIR may point to
+         an unusual path when /tmp and /var/tmp are not desirable. */
+      defaultTempDir.Printf(wxT("%s/audacity-%s"), envTempDir, wxGetUserId());
+   } else {
+      /* On Unix systems, the default temp dir is in /var/tmp. */
+      defaultTempDir.Printf(wxT("/var/tmp/audacity-%s"), wxGetUserId());
+   }
 
 // DA: Path env variable.
 #ifndef EXPERIMENTAL_DA


### PR DESCRIPTION
- Add a check against the `TMPDIR` environment variable and use it when it is defined to set the `defaultTempDir`.

This is part of my attempt at getting audacity working in [snappy](https://snapcraft.io). There are still more issues to tackle, but this patch gets past the temporary folder restrictions imposed by confined snaps.