### PR TITLE
Replace AC_CHECK_FILE to enable cross build

### DIFF
--- a/m4/audacity_checklib_ffmpeg.m4
+++ b/m4/audacity_checklib_ffmpeg.m4
@@ -35,13 +35,17 @@ AC_DEFUN([AUDACITY_CHECKLIB_FFMPEG], [
 
    dnl see if ffmpeg is available locally, or rather that we have some headers
    dnl in lib-src/ffmpeg/ we can use.
-   AC_CHECK_FILE(${srcdir}/lib-src/ffmpeg/libavcodec/avcodec.h,
-                 avcodec_h_found="yes",
-                 avcodec_h_found="no")
+   if test -f "${srcdir}/lib-src/ffmpeg/libavcodec/avcodec.h"; then
+                 avcodec_h_found="yes"
+   else
+                 avcodec_h_found="no"
+   fi
 
-   AC_CHECK_FILE(${srcdir}/lib-src/ffmpeg/libavformat/avformat.h,
-                 avformat_h_found="yes",
-                 avformat_h_found="no")
+   if test -f "${srcdir}/lib-src/ffmpeg/libavformat/avformat.h"; then
+                 avformat_h_found="yes"
+   else
+                 avformat_h_found="no"
+   fi
 
    if test "$avcodec_h_found" = "yes" -a "$avformat_h_found" = "yes"; then
       FFMPEG_LOCAL_AVAILABLE="yes"

--- a/m4/audacity_checklib_lame.m4
+++ b/m4/audacity_checklib_lame.m4
@@ -33,9 +33,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LAME], [
 
    dnl see if LAME is available in the source dir
 
-   AC_CHECK_FILE(${srcdir}/lib-src/lame/lame/lame.h,
-                 LAME_LOCAL_AVAILABLE="yes",
-                 LAME_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/lame/lame/lame.h"; then
+                 LAME_LOCAL_AVAILABLE="yes"
+   else
+                 LAME_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LAME_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([LAME headers are available in this source tree.])

--- a/m4/audacity_checklib_libexpat.m4
+++ b/m4/audacity_checklib_libexpat.m4
@@ -42,9 +42,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_EXPAT], [
 
    dnl see if expat is available in the local tree
 
-   AC_CHECK_FILE(${srcdir}/lib-src/expat/lib/expat.h,
-                 EXPAT_LOCAL_AVAILABLE="yes",
-                 EXPAT_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/expat/lib/expat.h"; then
+                 EXPAT_LOCAL_AVAILABLE="yes"
+   else
+                 EXPAT_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$EXPAT_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([Expat libraries are available in the local tree])

--- a/m4/audacity_checklib_libflac.m4
+++ b/m4/audacity_checklib_libflac.m4
@@ -38,13 +38,17 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBFLAC], [
 
    dnl see if FLAC is available in the source dir
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libflac/include/FLAC/format.h,
-                 flac_h_available="yes",
-                 flac_h_available="no")
+   if test -f "${srcdir}/lib-src/libflac/include/FLAC/format.h"; then
+                 flac_h_available="yes"
+   else
+                 flac_h_available="no"
+   fi
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libflac/include/FLAC++/decoder.h,
-                 flacpp_h_available="yes",
-                 flacpp_h_available="no")
+   if test -f "${srcdir}/lib-src/libflac/include/FLAC++/decoder.h"; then
+                 flacpp_h_available="yes"
+   else
+                 flacpp_h_available="no"
+   fi
 
    if test "$flac_h_available" = "yes" -a "$flacpp_h_available" = "yes"; then
       LIBFLAC_LOCAL_AVAILABLE="yes"

--- a/m4/audacity_checklib_libid3tag.m4
+++ b/m4/audacity_checklib_libid3tag.m4
@@ -25,9 +25,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBID3TAG], [
 
    dnl see if libid3tag is available in the local tree
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libid3tag/frame.h,
-                 LIBID3TAG_LOCAL_AVAILABLE="yes",
-                 LIBID3TAG_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/libid3tag/frame.h"; then
+                 LIBID3TAG_LOCAL_AVAILABLE="yes"
+   else
+                 LIBID3TAG_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBID3TAG_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([libid3tag libraries are available in the local tree])

--- a/m4/audacity_checklib_libmad.m4
+++ b/m4/audacity_checklib_libmad.m4
@@ -34,9 +34,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBMAD], [
 
    dnl see if libmad is available in the local tree
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libmad/frame.h,
-                 LIBMAD_LOCAL_AVAILABLE="yes",
-                 LIBMAD_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/libmad/frame.h"; then
+                 LIBMAD_LOCAL_AVAILABLE="yes"
+   else
+                 LIBMAD_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBMAD_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([libmad libraries are available in the local tree])

--- a/m4/audacity_checklib_libnyquist.m4
+++ b/m4/audacity_checklib_libnyquist.m4
@@ -17,9 +17,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBNYQUIST], [
 
    dnl see if Nyquist is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libnyquist/nyx.h,
-                 LIBNYQUIST_LOCAL_AVAILABLE="yes",
-                 LIBNYQUIST_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/libnyquist/nyx.h"; then
+                 LIBNYQUIST_LOCAL_AVAILABLE="yes"
+   else
+                 LIBNYQUIST_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBNYQUIST_LOCAL_AVAILABLE" = "yes" ; then
       AC_MSG_NOTICE([nyquist libraries are available in the local tree])

--- a/m4/audacity_checklib_libsbsms.m4
+++ b/m4/audacity_checklib_libsbsms.m4
@@ -25,9 +25,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBSBSMS], [
 
    dnl see if libsbsms is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/sbsms/include/sbsms.h,
-                 LIBSBSMS_LOCAL_AVAILABLE="yes",
-                 LIBSBSMS_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/sbsms/include/sbsms.h"; then
+                 LIBSBSMS_LOCAL_AVAILABLE="yes"
+   else
+                 LIBSBSMS_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBSBSMS_LOCAL_AVAILABLE" = "yes"; then
       dnl do not build programs we don't need

--- a/m4/audacity_checklib_libsndfile.m4
+++ b/m4/audacity_checklib_libsndfile.m4
@@ -25,9 +25,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBSNDFILE], [
 
    dnl see if libsndfile is available in the local tree
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libsndfile/src/sndfile.h.in,
-                 LIBSNDFILE_LOCAL_AVAILABLE="yes",
-                 LIBSNDFILE_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/libsndfile/src/sndfile.h.in"; then
+                 LIBSNDFILE_LOCAL_AVAILABLE="yes"
+   else
+                 LIBSNDFILE_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBSNDFILE_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([libsndfile libraries are available in this source tree])

--- a/m4/audacity_checklib_libsoundtouch.m4
+++ b/m4/audacity_checklib_libsoundtouch.m4
@@ -40,9 +40,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBSOUNDTOUCH], [
 
    dnl see if libsoundtouch is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/soundtouch/include/SoundTouch.h,
-                 LIBSOUNDTOUCH_LOCAL_AVAILABLE="yes",
-                 LIBSOUNDTOUCH_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/soundtouch/include/SoundTouch.h"; then
+                 LIBSOUNDTOUCH_LOCAL_AVAILABLE="yes"
+   else
+                 LIBSOUNDTOUCH_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBSOUNDTOUCH_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([libsoundtouch libraries are available in the local tree])

--- a/m4/audacity_checklib_libsoxr.m4
+++ b/m4/audacity_checklib_libsoxr.m4
@@ -25,9 +25,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBSOXR], [
 
    dnl see if libsoxr is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libsoxr/src/soxr.h,
-                 LIBSOXR_LOCAL_AVAILABLE="yes",
-                 LIBSOXR_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/libsoxr/src/soxr.h"; then
+                 LIBSOXR_LOCAL_AVAILABLE="yes"
+   else
+                 LIBSOXR_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBSOXR_LOCAL_AVAILABLE" = "yes"; then
       # Breaks other other libraries in Audacity tree; but why is ./configure

--- a/m4/audacity_checklib_libtwolame.m4
+++ b/m4/audacity_checklib_libtwolame.m4
@@ -25,9 +25,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBTWOLAME], [
 
    dnl see if libtwolame is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/twolame/libtwolame/twolame.h,
-                 LIBTWOLAME_LOCAL_AVAILABLE="yes",
-                 LIBTWOLAME_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/twolame/libtwolame/twolame.h"; then
+                 LIBTWOLAME_LOCAL_AVAILABLE="yes"
+   else
+                 LIBTWOLAME_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBTWOLAME_LOCAL_AVAILABLE" = "yes"; then
       dnl disable programs we don't need to build

--- a/m4/audacity_checklib_libvamp.m4
+++ b/m4/audacity_checklib_libvamp.m4
@@ -25,9 +25,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBVAMP], [
 
    dnl see if Vamp is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libvamp/vamp-hostsdk/PluginLoader.h,
-                 LIBVAMP_LOCAL_AVAILABLE="yes",
-                 LIBVAMP_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/libvamp/vamp-hostsdk/PluginLoader.h"; then
+                 LIBVAMP_LOCAL_AVAILABLE="yes"
+   else
+                 LIBVAMP_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LIBVAMP_LOCAL_AVAILABLE" = "yes"; then
       LIBVAMP_LOCAL_CONFIGURE_ARGS="--disable-programs"

--- a/m4/audacity_checklib_libvorbis.m4
+++ b/m4/audacity_checklib_libvorbis.m4
@@ -30,13 +30,17 @@ AC_DEFUN([AUDACITY_CHECKLIB_LIBVORBIS], [
 
    dnl see if Vorbis is available in the source dir
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libvorbis/include/vorbis/vorbisenc.h,
-                 vorbisenc_h_available="yes",
-                 vorbisenc_h_available="no")
+   if test -f "${srcdir}/lib-src/libvorbis/include/vorbis/vorbisenc.h"; then
+                 vorbisenc_h_available="yes"
+   else
+                 vorbisenc_h_available="no"
+   fi
 
-   AC_CHECK_FILE(${srcdir}/lib-src/libogg/include/ogg/ogg.h,
-                 ogg_h_available="yes",
-                 ogg_h_available="no")
+   if test -f "${srcdir}/lib-src/libogg/include/ogg/ogg.h"; then
+                 ogg_h_available="yes"
+   else
+                 ogg_h_available="no"
+   fi
 
    if test "$vorbisenc_h_available" = "yes" -a "$ogg_h_available" = "yes"; then
       LIBVORBIS_LOCAL_AVAILABLE="yes"

--- a/m4/audacity_checklib_lv2.m4
+++ b/m4/audacity_checklib_lv2.m4
@@ -25,9 +25,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_LV2], [
 
    dnl see if LV2 is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/lv2/configure,
-                 LV2_LOCAL_AVAILABLE="yes",
-                 LV2_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/lv2/configure"; then
+                 LV2_LOCAL_AVAILABLE="yes"
+   else
+                 LV2_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$LV2_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([LV2 libraries are available in the local tree])

--- a/m4/audacity_checklib_portaudio.m4
+++ b/m4/audacity_checklib_portaudio.m4
@@ -31,9 +31,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_PORTAUDIO], [
 
    dnl see if portaudio is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/portaudio-v19/include/portaudio.h,
-                 PORTAUDIO_LOCAL_AVAILABLE="yes",
-                 PORTAUDIO_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/portaudio-v19/include/portaudio.h"; then
+                 PORTAUDIO_LOCAL_AVAILABLE="yes"
+   else
+                 PORTAUDIO_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$PORTAUDIO_LOCAL_AVAILABLE" = "yes"; then
       dnl We need to override the pkg-config check for portmixer by passing

--- a/m4/audacity_checklib_portmidi.m4
+++ b/m4/audacity_checklib_portmidi.m4
@@ -21,9 +21,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_PORTMIDI], [
       AC_MSG_NOTICE([portmidi library is NOT available as system library])
    fi
 
-   AC_CHECK_FILE(${srcdir}/lib-src/portmidi/pm_common/portmidi.h,
-                 PORTMIDI_LOCAL_AVAILABLE="yes",
-                 PORTMIDI_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/portmidi/pm_common/portmidi.h"; then
+                 PORTMIDI_LOCAL_AVAILABLE="yes"
+   else
+                 PORTMIDI_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$PORTMIDI_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([portmidi library is available in the local tree])

--- a/m4/audacity_checklib_portsmf.m4
+++ b/m4/audacity_checklib_portsmf.m4
@@ -24,9 +24,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_PORTSMF], [
       AC_MSG_NOTICE([portSMF library is NOT available as system library])
    fi
 
-   AC_CHECK_FILE(${srcdir}/lib-src/portsmf/allegro.h,
-                 PORTSMF_LOCAL_AVAILABLE="yes",
-                 PORTSMF_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/portsmf/allegro.h"; then
+                 PORTSMF_LOCAL_AVAILABLE="yes"
+   else
+                 PORTSMF_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$PORTSMF_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([portSMF library is available in the local tree])

--- a/m4/audacity_checklib_widgetextra.m4
+++ b/m4/audacity_checklib_widgetextra.m4
@@ -28,9 +28,11 @@ AC_DEFUN([AUDACITY_CHECKLIB_WIDGETEXTRA], [
 
    dnl see if libwidgetextra is available locally
 
-   AC_CHECK_FILE(${srcdir}/lib-src/lib-widget-extra/NonGuiThread.h,
-                 WIDGETEXTRA_LOCAL_AVAILABLE="yes",
-                 WIDGETEXTRA_LOCAL_AVAILABLE="no")
+   if test -f "${srcdir}/lib-src/lib-widget-extra/NonGuiThread.h"; then
+                 WIDGETEXTRA_LOCAL_AVAILABLE="yes"
+   else
+                 WIDGETEXTRA_LOCAL_AVAILABLE="no"
+   fi
 
    if test "$WIDGETEXTRA_LOCAL_AVAILABLE" = "yes"; then
       AC_MSG_NOTICE([libwidgetextra library is available in the local tree])


### PR DESCRIPTION
The `audacity_checklib_*.m4` macros use AC_CHECK_FILE to test a file’s existence. I don’t know if there is a reason to use this method, but it breaks `configure` when cross compiling for other linux platforms. So my proposal is to just change it into a simple if/else statement. I’m not sure if some further messages should be added.