### PR TITLE
Standardize on an rDNS-style AppStream ID

### DIFF
--- a/help/audacity.appdata.xml
+++ b/help/audacity.appdata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <application>
-  <id type="desktop">audacity.desktop</id>
+  <id>org.audacityteam.Audacity</id>
+  <launchable type="desktop">audacity.desktop</launchable>
   <licence>CC-BY</licence>
   <description>
     <p>


### PR DESCRIPTION
Audacity's AppStream file currently defines an AppStream ID equal to the name of its desktop file: `audacity.desktop` (https://github.com/audacity/audacity/blob/master/help/audacity.appdata.xml#L3)

The AppStream folks [recommend using a reverse-DNS-style](url) AppStream ID instead. This patch changes it to `org.audacityproject.Audacity`). If accepted, it will make Audacity's AppStream ID match between Linux distro packages and what's on Flathub, as they actually enforce this requirement and use `org.audacityproject.Audacity` (https://github.com/flathub/org.audacityteam.Audacity/blob/master/org.audacityteam.Audacity.json#L2)

When the AppStream IDs match between versions of Audacity that come from different sources, then Linux software center programs like GNOME Software and KDE Discover can correctly de-duplicate the multiple sources and show the user a nice UI that allows them to choose which source to install from. Without this, the programs confusingly show duplicates. Here's what it looks like in KDE discover:

![two audacities](https://user-images.githubusercontent.com/1097249/34447881-5a0110c8-eca5-11e7-9be9-3405def5c03f.png)

The top one is from Flathub, and the bottom one is from my distro's package repository.

If you accept this patch and use `org.audacityproject.Audacity` as your AppStream ID then Discover and GNOME Software (and similar apps) can perform de-duplication correctly.