### PR TITLE
Fix building without libid3tag

### DIFF
--- a/src/export/ExportMP2.cpp
+++ b/src/export/ExportMP2.cpp
@@ -322,10 +322,13 @@ wxWindow *ExportMP2::OptionsCreate(wxWindow *parent, int format)
    return safenew ExportMP2Options(parent, format);
 }
 
+
+#ifdef USE_LIBID3TAG
 struct id3_tag_deleter {
    void operator () (id3_tag *p) const { if (p) id3_tag_delete(p); }
 };
 using id3_tag_holder = std::unique_ptr<id3_tag, id3_tag_deleter>;
+#endif
 
 // returns buffer len; caller frees
 int ExportMP2::AddTags(

--- a/src/export/ExportMP3.cpp
+++ b/src/export/ExportMP3.cpp
@@ -2009,10 +2009,12 @@ int ExportMP3::AskResample(int bitrate, int rate, int lowrate, int highrate)
    return wxAtoi(choice->GetStringSelection());
 }
 
+#ifdef USE_LIBID3TAG
 struct id3_tag_deleter {
    void operator () (id3_tag *p) const { if (p) id3_tag_delete(p); }
 };
 using id3_tag_holder = std::unique_ptr<id3_tag, id3_tag_deleter>;
+#endif
 
 // returns buffer len; caller frees
 int ExportMP3::AddTags(AudacityProject *WXUNUSED(project), ArrayOf<char> &buffer, bool *endOfFile, const Tags *tags)

--- a/src/export/ExportPCM.cpp
+++ b/src/export/ExportPCM.cpp
@@ -700,10 +700,12 @@ bool ExportPCM::AddStrings(AudacityProject * WXUNUSED(project), SNDFILE *sf, con
    return true;
 }
 
+#ifdef USE_LIBID3TAG
 struct id3_tag_deleter {
    void operator () (id3_tag *p) const { if (p) id3_tag_delete(p); }
 };
 using id3_tag_holder = std::unique_ptr<id3_tag, id3_tag_deleter>;
+#endif
 
 bool ExportPCM::AddID3Chunk(wxString fName, const Tags *tags, int sf_format)
 {

--- a/src/import/ImportPCM.cpp
+++ b/src/import/ImportPCM.cpp
@@ -335,10 +335,12 @@ static wxString AskCopyOrEdit()
    return oldCopyPref;
 }
 
+#ifdef USE_LIBID3TAG
 struct id3_tag_deleter {
    void operator () (id3_tag *p) const { if (p) id3_tag_delete(p); }
 };
 using id3_tag_holder = std::unique_ptr<id3_tag, id3_tag_deleter>;
+#endif
 
 ProgressResult PCMImportFileHandle::Import(TrackFactory *trackFactory,
                                 TrackHolders &outTracks,


### PR DESCRIPTION
This is a super-set of https://github.com/audacity/audacity/pull/214, because it's sitting in Gentoo's bugzilla here https://bugs.gentoo.org/636722. Evidently some people do compile Audacity without libid3tag, judging by the number of CCs on the bug!

I've built this both ways and it works fine without libid3tag.