### PR TITLE
Note track vertical zooming changes (fixes to Bugs 1815, 1819, and 1820)

### DIFF
--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -213,9 +213,11 @@ double NoteTrack::GetEndTime() const
 void NoteTrack::DoSetHeight(int h)
 {
    auto oldHeight = GetHeight();
-   auto oldMargin = GetNoteMargin(oldHeight);
-   PlayableTrack::DoSetHeight(h);
-   auto margin = GetNoteMargin(h);
+   NoteTrackDisplayData oldData = NoteTrackDisplayData(this, wxRect(0, 0, 1, oldHeight));
+   auto oldMargin = oldData.GetNoteMargin();
+   Track::SetHeight(h);
+   NoteTrackDisplayData newData = NoteTrackDisplayData(this, wxRect(0, 0, 1, h));
+   auto margin = newData.GetNoteMargin();
    Zoom(
       wxRect{ 0, 0, 1, h }, // only height matters
       h - margin - 1, // preserve bottom note
@@ -969,17 +971,17 @@ void NoteTrack::Zoom(const wxRect &rect, int y, float multiplier, bool center)
    // Construct track rectangle to map pitch to screen coordinates
    // Only y and height are needed:
    wxRect trackRect(0, rect.GetY(), 1, rect.GetHeight());
-   PrepareIPitchToY(trackRect);
-   int clickedPitch = YToIPitch(y);
+   NoteTrackDisplayData data = NoteTrackDisplayData(this, trackRect);
+   int clickedPitch = data.YToIPitch(y);
    // zoom by changing the pitch height
    SetPitchHeight(rect.height, mPitchHeight * multiplier);
-   PrepareIPitchToY(trackRect); // update because mPitchHeight changed
+   NoteTrackDisplayData newData = NoteTrackDisplayData(this, trackRect); // update because mPitchHeight changed
    if (center) {
-      int newCenterPitch = YToIPitch(rect.GetY() + rect.GetHeight() / 2);
+      int newCenterPitch = newData.YToIPitch(rect.GetY() + rect.GetHeight() / 2);
       // center the pitch that the user clicked on
       SetBottomNote(mBottomNote + (clickedPitch - newCenterPitch));
    } else {
-      int newClickedPitch = YToIPitch(y);
+      int newClickedPitch = newData.YToIPitch(y);
       // align to keep the pitch that the user clicked on in the same place
       SetBottomNote(mBottomNote + (clickedPitch - newClickedPitch));
    }
@@ -989,9 +991,9 @@ void NoteTrack::Zoom(const wxRect &rect, int y, float multiplier, bool center)
 void NoteTrack::ZoomTo(const wxRect &rect, int start, int end)
 {
    wxRect trackRect(0, rect.GetY(), 1, rect.GetHeight());
-   PrepareIPitchToY(trackRect);
-   int topPitch = YToIPitch(start);
-   int botPitch = YToIPitch(end);
+   NoteTrackDisplayData data = NoteTrackDisplayData(this, trackRect);
+   int topPitch = data.YToIPitch(start);
+   int botPitch = data.YToIPitch(end);
    if (topPitch < botPitch) { // swap
       int temp = topPitch; topPitch = botPitch; botPitch = temp;
    }
@@ -1003,7 +1005,20 @@ void NoteTrack::ZoomTo(const wxRect &rect, int start, int end)
    Zoom(rect, (start + end) / 2, trialPitchHeight / mPitchHeight, true);
 }
 
-int NoteTrack::YToIPitch(int y)
+NoteTrackDisplayData::NoteTrackDisplayData(const NoteTrack* track, const wxRect &r)
+{
+   mPitchHeight = track->mPitchHeight;
+   mMargin = std::min(r.height / 4, (GetPitchHeight(1) + 1) / 2);
+
+   mBottom = r.y + r.height - GetNoteMargin() - 1 - GetPitchHeight(1) +
+            (track->GetBottomNote() / 12) * GetOctaveHeight() +
+               GetNotePos(track->GetBottomNote() % 12);
+}
+
+int NoteTrackDisplayData::IPitchToY(int p) const
+{ return mBottom - (p / 12) * GetOctaveHeight() - GetNotePos(p % 12); }
+
+int NoteTrackDisplayData::YToIPitch(int y) const
 {
    y = mBottom - y; // pixels above pitch 0
    int octave = (y / GetOctaveHeight());

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -1037,6 +1037,37 @@ void NoteTrack::ZoomTo(const wxRect &rect, int start, int end)
    SetNoteRange(pitch1, pitch2);
 }
 
+void NoteTrack::ZoomAllNotes()
+{
+   Alg_iterator iterator( &GetSeq(), false );
+   iterator.begin();
+   Alg_event_ptr evt;
+
+   // Go through all of the notes, finding the minimum and maximum value pitches.
+   bool hasNotes = false;
+   int minPitch = MaxPitch;
+   int maxPitch = MinPitch;
+
+   while (NULL != (evt = iterator.next())) {
+      if (evt->is_note()) {
+         int pitch = (int) evt->get_pitch();
+         hasNotes = true;
+         if (pitch < minPitch)
+            minPitch = pitch;
+         if (pitch > maxPitch)
+            maxPitch = pitch;
+      }
+   }
+
+   if (!hasNotes) {
+      // Semi-arbitary default values:
+      minPitch = 48;
+      maxPitch = 72;
+   }
+
+   SetNoteRange(minPitch, maxPitch);
+}
+
 NoteTrackDisplayData::NoteTrackDisplayData(const NoteTrack* track, const wxRect &r)
 {
    auto span = track->GetTopNote() - track->GetBottomNote() + 1; // + 1 to make sure it includes both

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -888,6 +888,9 @@ bool NoteTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
          else if (!wxStrcmp(attr, wxT("bottomnote")) &&
                   XMLValueChecker::IsGoodInt(strValue) && strValue.ToLong(&nValue))
             SetBottomNote(nValue);
+         else if (!wxStrcmp(attr, wxT("topnote")) &&
+                  XMLValueChecker::IsGoodInt(strValue) && strValue.ToLong(&nValue))
+            SetTopNote(nValue);
          else if (!wxStrcmp(attr, wxT("data"))) {
              std::string s(strValue.mb_str(wxConvUTF8));
              std::istringstream data(s);
@@ -930,6 +933,7 @@ void NoteTrack::WriteXML(XMLWriter &xmlFile) const
    xmlFile.WriteAttr(wxT("velocity"), (double) saveme->mVelocity);
 #endif
    xmlFile.WriteAttr(wxT("bottomnote"), saveme->mBottomNote);
+   xmlFile.WriteAttr(wxT("topnote"), saveme->mTopNote);
    xmlFile.WriteAttr(wxT("data"), wxString(data.str().c_str(), wxConvUTF8));
    xmlFile.EndTag(wxT("notetrack"));
 }

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -121,8 +121,8 @@ NoteTrack::NoteTrack(const std::shared_ptr<DirManager> &projDirManager)
 #ifdef EXPERIMENTAL_MIDI_OUT
    mVelocity = 0;
 #endif
-   mBottomNote = 24;
-   mPitchHeight = 5.0f;
+   mBottomNote = MinPitch;
+   mTopNote = MaxPitch;
 
    mVisibleChannels = ALL_CHANNELS;
 }
@@ -184,7 +184,7 @@ Track::Holder NoteTrack::Duplicate() const
    }
    // copy some other fields here
    duplicate->SetBottomNote(mBottomNote);
-   duplicate->mPitchHeight = mPitchHeight;
+   duplicate->SetTopNote(mTopNote);
    duplicate->mVisibleChannels = mVisibleChannels;
    duplicate->SetOffset(GetOffset());
 #ifdef EXPERIMENTAL_MIDI_OUT
@@ -209,24 +209,6 @@ double NoteTrack::GetEndTime() const
 {
    return GetStartTime() + GetSeq().get_real_dur();
 }
-
-void NoteTrack::DoSetHeight(int h)
-{
-   auto oldHeight = GetHeight();
-   NoteTrackDisplayData oldData = NoteTrackDisplayData(this, wxRect(0, 0, 1, oldHeight));
-   auto oldMargin = oldData.GetNoteMargin();
-   Track::SetHeight(h);
-   NoteTrackDisplayData newData = NoteTrackDisplayData(this, wxRect(0, 0, 1, h));
-   auto margin = newData.GetNoteMargin();
-   Zoom(
-      wxRect{ 0, 0, 1, h }, // only height matters
-      h - margin - 1, // preserve bottom note
-      (float)(h - 2 * margin) /
-           std::max(1, oldHeight - 2 * oldMargin),
-      false
-   );
-}
-
 
 void NoteTrack::WarpAndTransposeNotes(double t0, double t1,
                                       const TimeWarper &warper,
@@ -952,6 +934,56 @@ void NoteTrack::WriteXML(XMLWriter &xmlFile) const
    xmlFile.EndTag(wxT("notetrack"));
 }
 
+void NoteTrack::SetBottomNote(int note)
+{
+   if (note < MinPitch)
+      note = MinPitch;
+   else if (note > 96)
+      note = 96;
+
+   wxCHECK(note <= mTopNote, );
+
+   mBottomNote = note;
+}
+
+void NoteTrack::SetTopNote(int note)
+{
+   if (note > MaxPitch)
+      note = MaxPitch;
+
+   wxCHECK(note >= mBottomNote, );
+
+   mTopNote = note;
+}
+
+void NoteTrack::SetNoteRange(int note1, int note2)
+{
+   // Bounds check
+   if (note1 > MaxPitch)
+      note1 = MaxPitch;
+   else if (note1 < MinPitch)
+      note1 = MinPitch;
+   if (note2 > MaxPitch)
+      note2 = MaxPitch;
+   else if (note2 < MinPitch)
+      note2 = MinPitch;
+   // Swap to ensure ordering
+   if (note2 < note1) { auto tmp = note1; note1 = note2; note2 = tmp; }
+
+   mBottomNote = note1;
+   mTopNote = note2;
+}
+
+void NoteTrack::ShiftNoteRange(int offset)
+{
+   // Ensure everything stays in bounds
+   if (mBottomNote + offset < MinPitch || mTopNote + offset > MaxPitch)
+       return;
+
+   mBottomNote += offset;
+   mTopNote += offset;
+}
+
 #if 0
 void NoteTrack::StartVScroll()
 {
@@ -962,29 +994,27 @@ void NoteTrack::VScroll(int start, int end)
 {
     int ph = GetPitchHeight();
     int delta = ((end - start) + ph / 2) / ph;
-    SetBottomNote(mStartBottomNote + delta);
+    ShiftNoteRange(delta);
 }
 #endif
 
 void NoteTrack::Zoom(const wxRect &rect, int y, float multiplier, bool center)
 {
-   // Construct track rectangle to map pitch to screen coordinates
-   // Only y and height are needed:
-   wxRect trackRect(0, rect.GetY(), 1, rect.GetHeight());
-   NoteTrackDisplayData data = NoteTrackDisplayData(this, trackRect);
+   NoteTrackDisplayData data = NoteTrackDisplayData(this, rect);
    int clickedPitch = data.YToIPitch(y);
-   // zoom by changing the pitch height
-   SetPitchHeight(rect.height, mPitchHeight * multiplier);
-   NoteTrackDisplayData newData = NoteTrackDisplayData(this, trackRect); // update because mPitchHeight changed
+   int extent = mTopNote - mBottomNote + 1;
+   int newExtent = (int) (extent / multiplier);
+   float position;
    if (center) {
-      int newCenterPitch = newData.YToIPitch(rect.GetY() + rect.GetHeight() / 2);
       // center the pitch that the user clicked on
-      SetBottomNote(mBottomNote + (clickedPitch - newCenterPitch));
+      position = .5;
    } else {
-      int newClickedPitch = newData.YToIPitch(y);
       // align to keep the pitch that the user clicked on in the same place
-      SetBottomNote(mBottomNote + (clickedPitch - newClickedPitch));
+      position = extent / (clickedPitch - mBottomNote);
    }
+   int newBottomNote = clickedPitch - (newExtent * position);
+   int newTopNote = clickedPitch + (newExtent * (1 - position));
+   SetNoteRange(newBottomNote, newTopNote);
 }
 
 
@@ -992,27 +1022,53 @@ void NoteTrack::ZoomTo(const wxRect &rect, int start, int end)
 {
    wxRect trackRect(0, rect.GetY(), 1, rect.GetHeight());
    NoteTrackDisplayData data = NoteTrackDisplayData(this, trackRect);
-   int topPitch = data.YToIPitch(start);
-   int botPitch = data.YToIPitch(end);
-   if (topPitch < botPitch) { // swap
-      int temp = topPitch; topPitch = botPitch; botPitch = temp;
-   }
-   if (topPitch == botPitch) { // can't divide by zero, do something else
+   int pitch1 = data.YToIPitch(start);
+   int pitch2 = data.YToIPitch(end);
+   if (pitch1 == pitch2) {
+      // Just zoom in instead of zooming to show only one note
       Zoom(rect, start, 1, true);
       return;
    }
-   auto trialPitchHeight = (float)trackRect.height / (topPitch - botPitch);
-   Zoom(rect, (start + end) / 2, trialPitchHeight / mPitchHeight, true);
+   // It's fine for this to be in either order
+   SetNoteRange(pitch1, pitch2);
 }
 
 NoteTrackDisplayData::NoteTrackDisplayData(const NoteTrack* track, const wxRect &r)
 {
-   mPitchHeight = track->mPitchHeight;
-   mMargin = std::min(r.height / 4, (GetPitchHeight(1) + 1) / 2);
+   auto span = track->GetTopNote() - track->GetBottomNote() + 1; // + 1 to make sure it includes both
+
+   mMargin = std::min((int) (r.height / (float)(span)) / 2, r.height / 4);
+
+   // Count the number of dividers between B/C and E/F
+   int numC = 0, numF = 0;
+   auto botOctave = track->GetBottomNote() / 12, botNote = track->GetBottomNote() % 12;
+   auto topOctave = track->GetTopNote() / 12, topNote = track->GetTopNote() % 12;
+   if (topOctave == botOctave)
+   {
+      if (botNote == 0) numC = 1;
+      if (topNote <= 5) numF = 1;
+   }
+   else
+   {
+      numC = topOctave - botOctave;
+      numF = topOctave - botOctave - 1;
+      if (botNote == 0) numC++;
+      if (botNote <= 5) numF++;
+      if (topOctave <= 5) numF++;
+   }
+   // Effective space, excluding the margins and the lines between some notes
+   auto effectiveHeight = r.height - (2 * (mMargin + 1)) - numC - numF;
+   // Guarenteed that both the bottom and top notes will be visible
+   // (assuming that the clamping below does not happen)
+   mPitchHeight = effectiveHeight / ((float) span);
+
+   if (mPitchHeight < MinPitchHeight)
+      mPitchHeight = MinPitchHeight;
+   if (mPitchHeight > MaxPitchHeight)
+      mPitchHeight = MaxPitchHeight;
 
    mBottom = r.y + r.height - GetNoteMargin() - 1 - GetPitchHeight(1) +
-            (track->GetBottomNote() / 12) * GetOctaveHeight() +
-               GetNotePos(track->GetBottomNote() % 12);
+            botOctave * GetOctaveHeight() + GetNotePos(botNote);
 }
 
 int NoteTrackDisplayData::IPitchToY(int p) const
@@ -1025,7 +1081,9 @@ int NoteTrackDisplayData::YToIPitch(int y) const
    y -= octave * GetOctaveHeight();
    // result is approximate because C and G are one pixel taller than
    // mPitchHeight.
-   return (y / GetPitchHeight(1)) + octave * 12;
+   // Poke 1-13-18: However in practice this seems not to be an issue,
+   // as long as we use mPitchHeight and not the rounded version
+   return (y / mPitchHeight) + octave * 12;
 }
 
 const float NoteTrack::ZoomStep = powf( 2.0f, 0.25f );

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -132,6 +132,8 @@ class AUDACITY_DLL_API NoteTrack final
    /// Sets the top and bottom note (both pitches) automatically, swapping them if needed.
    void SetNoteRange(int note1, int note2);
 
+   /// Zooms so that all notes are visible
+   void ZoomAllNotes();
    /// Zooms so that the entire track is visible
    void ZoomMaxExtent() { SetNoteRange(MinPitch, MaxPitch); }
    /// Shifts all notes vertically by the given pitch

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -63,9 +63,12 @@ using QuantizedTimeAndBeat = std::pair< double, double >;
 
 class StretchHandle;
 
+class NoteTrackDisplayData;
+
 class AUDACITY_DLL_API NoteTrack final
    : public NoteTrackBase
 {
+   friend class NoteTrackDisplayData;
  public:
    NoteTrack(const std::shared_ptr<DirManager> &projDirManager);
    virtual ~NoteTrack();
@@ -146,44 +149,6 @@ class AUDACITY_DLL_API NoteTrack final
    /// If center is true, the result will be centered at y.
    void Zoom(const wxRect &rect, int y, float multiplier, bool center);
    void ZoomTo(const wxRect &rect, int start, int end);
-   int GetNoteMargin(int height) const
-   { return std::min(height / 4, (GetPitchHeight(1) + 1) / 2); }
-   int GetOctaveHeight() const { return GetPitchHeight(12) + 2; }
-   // call this once before a series of calls to IPitchToY(). It
-   // sets mBottom to offset of octave 0 so that mBottomNote
-   // is located at r.y + r.height - (GetNoteMargin() + 1 + GetPitchHeight())
-   void PrepareIPitchToY(const wxRect &r) const {
-       mBottom =
-         r.y + r.height - GetNoteMargin(r.height) - 1 - GetPitchHeight(1) +
-             (mBottomNote / 12) * GetOctaveHeight() +
-                GetNotePos(mBottomNote % 12);
-   }
-   // IPitchToY returns Y coordinate of top of pitch p
-   int IPitchToY(int p) const {
-      return mBottom - (p / 12) * GetOctaveHeight() - GetNotePos(p % 12);
-   }
-   // compute the window coordinate of the bottom of an octave: This is
-   // the bottom of the line separating B and C.
-   int GetOctaveBottom(int oct) const {
-      return IPitchToY(oct * 12) + GetPitchHeight(1) + 1;
-   }
-   // Y coordinate for given floating point pitch (rounded to int)
-   int PitchToY(double p) const {
-      return IPitchToY((int) (p + 0.5));
-   }
-   // Integer pitch corresponding to a Y coordinate
-   int YToIPitch(int y);
-   // map pitch class number (0-11) to pixel offset from bottom of octave
-   // (the bottom of the black line between B and C) to the top of the
-   // note. Note extra pixel separates B(11)/C(0) and E(4)/F(5).
-   int GetNotePos(int p) const
-   { return 1 + GetPitchHeight(p + 1) + (p > 4); }
-   // get pixel offset to top of ith black key note
-   int GetBlackPos(int i) const { return GetNotePos(i * 2 + 1 + (i > 1)); }
-   // GetWhitePos tells where to draw lines between keys as an offset from
-   // GetOctaveBottom. GetWhitePos(0) returns 1, which matches the location
-   // of the line separating B and C
-   int GetWhitePos(int i) const { return 1 + (i * GetOctaveHeight()) / 7; }
    void SetBottomNote(int note)
    {
       if (note < 0)
@@ -252,10 +217,11 @@ class AUDACITY_DLL_API NoteTrack final
    float mVelocity; // velocity offset
 #endif
 
-   // mBottom is the Y offset of pitch 0 (normally off screen)
-   mutable int mBottom;
    int mBottomNote;
+#if 0
+   // Also unused from vertical scrolling
    int mStartBottomNote;
+#endif
 
    // Remember continuous variation for zooming,
    // but it is rounded off whenever drawing:
@@ -271,6 +237,47 @@ class AUDACITY_DLL_API NoteTrack final
 protected:
    std::shared_ptr<TrackControls> GetControls() override;
    std::shared_ptr<TrackVRulerControls> GetVRulerControls() override;
+};
+
+class NoteTrackDisplayData {
+private:
+   float mPitchHeight;
+   // mBottom is the Y offset of pitch 0 (normally off screen)
+   // Used so that mBottomNote is located at
+   // mY + mHeight - (GetNoteMargin() + 1 + GetPitchHeight())
+   int mBottom;
+   int mMargin;
+public:
+   NoteTrackDisplayData(const NoteTrack* track, const wxRect &r);
+
+   int GetPitchHeight(int factor) const
+   { return std::max(1, (int)(factor * mPitchHeight)); }
+   int GetNoteMargin() const { return mMargin; };
+   int GetOctaveHeight() const { return GetPitchHeight(12) + 2; }
+   // IPitchToY returns Y coordinate of top of pitch p
+   int IPitchToY(int p) const;
+   // compute the window coordinate of the bottom of an octave: This is
+   // the bottom of the line separating B and C.
+   int GetOctaveBottom(int oct) const {
+      return IPitchToY(oct * 12) + GetPitchHeight(1) + 1;
+   }
+   // Y coordinate for given floating point pitch (rounded to int)
+   int PitchToY(double p) const {
+      return IPitchToY((int) (p + 0.5));
+   }
+   // Integer pitch corresponding to a Y coordinate
+   int YToIPitch(int y) const;
+   // map pitch class number (0-11) to pixel offset from bottom of octave
+   // (the bottom of the black line between B and C) to the top of the
+   // note. Note extra pixel separates B(11)/C(0) and E(4)/F(5).
+   int GetNotePos(int p) const
+   { return 1 + GetPitchHeight(p + 1) + (p > 4); }
+   // get pixel offset to top of ith black key note
+   int GetBlackPos(int i) const { return GetNotePos(i * 2 + 1 + (i > 1)); }
+   // GetWhitePos tells where to draw lines between keys as an offset from
+   // GetOctaveBottom. GetWhitePos(0) returns 1, which matches the location
+   // of the line separating B and C
+   int GetWhitePos(int i) const { return 1 + (i * GetOctaveHeight()) / 7; }
 };
 
 #endif // USE_MIDI

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -63,12 +63,9 @@ using QuantizedTimeAndBeat = std::pair< double, double >;
 
 class StretchHandle;
 
-class NoteTrackDisplayData;
-
 class AUDACITY_DLL_API NoteTrack final
    : public NoteTrackBase
 {
-   friend class NoteTrackDisplayData;
  public:
    NoteTrack(const std::shared_ptr<DirManager> &projDirManager);
    virtual ~NoteTrack();
@@ -86,8 +83,6 @@ class AUDACITY_DLL_API NoteTrack final
    double GetOffset() const override;
    double GetStartTime() const override;
    double GetEndTime() const override;
-
-   void DoSetHeight(int h) override;
 
    Alg_seq &GetSeq() const;
 
@@ -126,21 +121,22 @@ class AUDACITY_DLL_API NoteTrack final
    bool StretchRegion
       ( QuantizedTimeAndBeat t0, QuantizedTimeAndBeat t1, double newDur );
 
+   /// Gets the current bottom note (a pitch)
    int GetBottomNote() const { return mBottomNote; }
-   int GetPitchHeight(int factor) const
-   { return std::max(1, (int)(factor * mPitchHeight)); }
-   void SetPitchHeight(int rectHeight, float h)
-   {
-      // Impose certain zoom limits
-      auto octavePadding = 2 * 10; // 10 octaves times 2 single-pixel seperations per pixel
-      auto availableHeight = rectHeight - octavePadding;
-      auto numNotes = 128.f;
-      auto minSpacePerNote =
-         std::max((float)MinPitchHeight, availableHeight / numNotes);
-      mPitchHeight =
-         std::max(minSpacePerNote,
-                  std::min((float)MaxPitchHeight, h));
-   }
+   /// Gets the current top note (a pitch)
+   int GetTopNote() const { return mTopNote; }
+   /// Sets the bottom note (a pitch), making sure that it is never greater than the top note.
+   void SetBottomNote(int note);
+   /// Sets the top note (a pitch), making sure that it is never less than the bottom note.
+   void SetTopNote(int note);
+   /// Sets the top and bottom note (both pitches) automatically, swapping them if needed.
+   void SetNoteRange(int note1, int note2);
+
+   /// Zooms so that the entire track is visible
+   void ZoomMaxExtent() { SetNoteRange(MinPitch, MaxPitch); }
+   /// Shifts all notes vertically by the given pitch
+   void ShiftNoteRange(int offset);
+
    /// Zooms out a constant factor (subject to zoom limits)
    void ZoomOut(const wxRect &rect, int y) { Zoom(rect, y, 1.0f / ZoomStep, true); }
    /// Zooms in a contant factor (subject to zoom limits)
@@ -149,15 +145,6 @@ class AUDACITY_DLL_API NoteTrack final
    /// If center is true, the result will be centered at y.
    void Zoom(const wxRect &rect, int y, float multiplier, bool center);
    void ZoomTo(const wxRect &rect, int start, int end);
-   void SetBottomNote(int note)
-   {
-      if (note < 0)
-         note = 0;
-      else if (note > 96)
-         note = 96;
-
-      mBottomNote = note;
-   }
 
 #if 0
    // Vertical scrolling is performed by dragging the keyboard at
@@ -217,7 +204,7 @@ class AUDACITY_DLL_API NoteTrack final
    float mVelocity; // velocity offset
 #endif
 
-   int mBottomNote;
+   int mBottomNote, mTopNote;
 #if 0
    // Also unused from vertical scrolling
    int mStartBottomNote;
@@ -227,7 +214,7 @@ class AUDACITY_DLL_API NoteTrack final
    // but it is rounded off whenever drawing:
    float mPitchHeight;
 
-   enum { MinPitchHeight = 1, MaxPitchHeight = 25 };
+   enum { MinPitch = 0, MaxPitch = 127 };
    static const float ZoomStep;
 
    int mVisibleChannels; // bit set of visible channels
@@ -239,6 +226,7 @@ protected:
    std::shared_ptr<TrackVRulerControls> GetVRulerControls() override;
 };
 
+/// Data used to display a note track
 class NoteTrackDisplayData {
 private:
    float mPitchHeight;
@@ -247,6 +235,8 @@ private:
    // mY + mHeight - (GetNoteMargin() + 1 + GetPitchHeight())
    int mBottom;
    int mMargin;
+
+   enum { MinPitchHeight = 1, MaxPitchHeight = 25 };
 public:
    NoteTrackDisplayData(const NoteTrack* track, const wxRect &r);
 
@@ -279,7 +269,6 @@ public:
    // of the line separating B and C
    int GetWhitePos(int i) const { return 1 + (i * GetOctaveHeight()) / 7; }
 };
-
 #endif // USE_MIDI
 
 #ifndef SONIFY

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -233,36 +233,6 @@ namespace {
 }
 #endif
 
-#ifdef USE_MIDI
-/*
-const int octaveHeight = 62;
-const int blackPos[5] = { 6, 16, 32, 42, 52 };
-const int whitePos[7] = { 0, 9, 17, 26, 35, 44, 53 };
-const int notePos[12] = { 1, 6, 11, 16, 21, 27,
-                        32, 37, 42, 47, 52, 57 };
-
-// map pitch number to window coordinate of the *top* of the note
-// Note the "free" variable bottom, which is assumed to be a local
-// variable set to the offset of pitch 0 relative to the window
-#define IPITCH_TO_Y(t, p) (bottom - ((p) / 12) * octaveHeight - \
-                          notePos[(p) % 12] - (t)->GetPitchHeight())
-
-// GetBottom is called from a couple of places to compute the hypothetical
-// coordinate of the bottom of pitch 0 in window coordinates. See
-// IPITCH_TO_Y above, which computes coordinates relative to GetBottom()
-// Note the -NOTE_MARGIN, which leaves a little margin to draw notes that
-// are out of bounds. I'm not sure why the -2 is necessary.
-int TrackArtist::GetBottom(NoteTrack *t, const wxRect &rect)
-{
-   int bottomNote = t->GetBottomNote();
-   int bottom = rect.y + rect.height - 2 - t->GetNoteMargin() +
-          ((bottomNote / 12) * octaveHeight + notePos[bottomNote % 12]);
-   return bottom;
-
-}
-*/
-#endif // USE_MIDI
-
 TrackArtist::TrackArtist()
 {
    mMarginLeft   = 0;
@@ -599,9 +569,8 @@ void TrackArtist::DrawVRuler
       rect.y += 1;
       rect.height -= 1;
 
-      //int bottom = GetBottom((NoteTrack *) t, rect);
       const NoteTrack *track = (NoteTrack *) t;
-      track->PrepareIPitchToY(rect);
+      NoteTrackDisplayData data = NoteTrackDisplayData(track, rect);
 
       wxPen hilitePen;
       hilitePen.SetColour(120, 120, 120);
@@ -619,13 +588,13 @@ void TrackArtist::DrawVRuler
       dc->SetFont(labelFont);
 
       int octave = 0;
-      int obottom = track->GetOctaveBottom(octave);
-      int marg = track->GetNoteMargin(rect.height);
-      //IPITCH_TO_Y(octave * 12) + PITCH_HEIGHT + 1;
+      int obottom = data.GetOctaveBottom(octave);
+      int marg = data.GetNoteMargin();
+
       while (obottom >= rect.y) {
          dc->SetPen(*wxBLACK_PEN);
          for (int white = 0; white < 7; white++) {
-            int pos = track->GetWhitePos(white);
+            int pos = data.GetWhitePos(white);
             if (obottom - pos > rect.y + marg + 1 &&
                 // don't draw too close to margin line -- it's annoying
                 obottom - pos < rect.y + rect.height - marg - 3)
@@ -633,11 +602,11 @@ void TrackArtist::DrawVRuler
                             rect.x + rect.width, obottom - pos);
          }
          wxRect br = rect;
-         br.height = track->GetPitchHeight(1);
+         br.height = data.GetPitchHeight(1);
          br.x++;
          br.width = 17;
          for (int black = 0; black < 5; black++) {
-            br.y = obottom - track->GetBlackPos(black);
+            br.y = obottom - data.GetBlackPos(black);
             if (br.y > rect.y + marg - 2 && br.y + br.height < rect.y + rect.height - marg) {
                dc->SetPen(hilitePen);
                dc->DrawRectangle(br);
@@ -665,7 +634,7 @@ void TrackArtist::DrawVRuler
                             obottom - height + 2);
             }
          }
-         obottom = track->GetOctaveBottom(++octave);
+         obottom = data.GetOctaveBottom(++octave);
       }
       // draw lines delineating the out-of-bounds margins
       dc->SetPen(*wxBLACK_PEN);
@@ -2809,16 +2778,17 @@ void TrackArtist::DrawNoteBackground(const NoteTrack *track, wxDC &dc,
    // need overlap between MIDI data and the background region
    if (left >= right) return;
 
+   NoteTrackDisplayData data = NoteTrackDisplayData(track, rect);
    dc.SetBrush(bb);
    int octave = 0;
    // obottom is the window coordinate of octave divider line
-   int obottom = track->GetOctaveBottom(octave);
+   int obottom = data.GetOctaveBottom(octave);
    // eOffset is for the line between E and F; there's another line
    // between B and C, hence the offset of 2 for two line thicknesses
-   int eOffset = track->GetPitchHeight(5) + 2;
-   while (obottom > rect.y + track->GetNoteMargin(rect.height) + 3) {
+   int eOffset = data.GetPitchHeight(5) + 2;
+   while (obottom > rect.y + data.GetNoteMargin() + 3) {
       // draw a black line separating octaves if this octave botton is visible
-      if (obottom < rect.y + rect.height - track->GetNoteMargin(rect.height)) {
+      if (obottom < rect.y + rect.height - data.GetNoteMargin()) {
          dc.SetPen(*wxBLACK_PEN);
          // obottom - 1 because obottom is at the bottom of the line
          AColor::Line(dc, left, obottom - 1, right, obottom - 1);
@@ -2834,14 +2804,14 @@ void TrackArtist::DrawNoteBackground(const NoteTrack *track, wxDC &dc,
       wxRect br;
       br.x = left;
       br.width = right - left;
-      br.height = track->GetPitchHeight(1);
+      br.height = data.GetPitchHeight(1);
       for (int black = 0; black < 5; black++) {
-         br.y = obottom - track->GetBlackPos(black);
+         br.y = obottom - data.GetBlackPos(black);
          if (br.y > rect.y && br.y + br.height < rect.y + rect.height) {
             dc.DrawRectangle(br); // draw each black key background stripe
          }
       }
-      obottom = track->GetOctaveBottom(++octave);
+      obottom = data.GetOctaveBottom(++octave);
    }
 
    // draw bar lines
@@ -2902,16 +2872,12 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
    if (!track->GetSelected())
       sel0 = sel1 = 0.0;
 
+   NoteTrackDisplayData data = NoteTrackDisplayData(track, rect);
+
    // reserve 1/2 note height at top and bottom of track for
    // out-of-bounds notes
-   int numPitches = (rect.height) / track->GetPitchHeight(1);
+   int numPitches = (rect.height) / data.GetPitchHeight(1);
    if (numPitches < 0) numPitches = 0; // cannot be negative
-
-   // bottom is the hypothetical location of the bottom of pitch 0 relative to
-   // the top of the clipping region rect: rect.height - PITCH_HEIGHT/2 is where the
-   // bottomNote is displayed, and to that
-   // we add the height of bottomNote from the position of pitch 0
-   track->PrepareIPitchToY(rect);
 
 #ifdef EXPERIMENTAL_NOTETRACK_OVERLAY
    DrawBackgroundWithSelection(&dc, rect, track,
@@ -2966,7 +2932,7 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                       selectedBarLinePen);
    SonifyEndNoteBackground();
    SonifyBeginNoteForeground();
-   int marg = track->GetNoteMargin(rect.height);
+   int marg = data.GetNoteMargin();
 
    // NOTE: it would be better to put this in some global initialization
    // function rather than do lookups every time.
@@ -3012,8 +2978,8 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                const char *shape = NULL;
                if (note->loud > 0.0 || 0 == (shape = IsShape(note))) {
                   wxRect nr; // "note rectangle"
-                  nr.y = track->PitchToY(note->pitch);
-                  nr.height = track->GetPitchHeight(1);
+                  nr.y = data.PitchToY(note->pitch);
+                  nr.height = data.GetPitchHeight(1);
 
                   nr.x = TIME_TO_X(xx);
                   nr.width = TIME_TO_X(x1) - nr.x;
@@ -3054,7 +3020,7 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                         else
                            AColor::MIDIChannel(&dc, note->chan + 1);
                         dc.DrawRectangle(nr);
-                        if (track->GetPitchHeight(1) > 2) {
+                        if (data.GetPitchHeight(1) > 2) {
                            AColor::LightMIDIChannel(&dc, note->chan + 1);
                            AColor::Line(dc, nr.x, nr.y, nr.x + nr.width-2, nr.y);
                            AColor::Line(dc, nr.x, nr.y, nr.x, nr.y + nr.height-2);
@@ -3072,7 +3038,7 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                   // add 0.5 to pitch because pitches are plotted with
                   // height = PITCH_HEIGHT; thus, the center is raised
                   // by PITCH_HEIGHT * 0.5
-                  int yy = track->PitchToY(note->pitch);
+                  int yy = data.PitchToY(note->pitch);
                   long linecolor = LookupIntAttribute(note, linecolori, -1);
                   long linethick = LookupIntAttribute(note, linethicki, 1);
                   long fillcolor = -1;
@@ -3098,7 +3064,7 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                               wxSOLID));
                      if (!fillflag) dc.SetBrush(*wxTRANSPARENT_BRUSH);
                   }
-                  int y1 = track->PitchToY(LookupRealAttribute(note, y1r, note->pitch));
+                  int y1 = data.PitchToY(LookupRealAttribute(note, y1r, note->pitch));
                   if (shape == line) {
                      // extreme zooms caues problems under windows, so we have to do some
                      // clipping before calling display routine
@@ -3129,7 +3095,7 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                      points[1].y = y1;
                      points[2].x = TIME_TO_X(LookupRealAttribute(note, x2r, xx));
                      CLIP(points[2].x);
-                     points[2].y = track->PitchToY(LookupRealAttribute(note, y2r, note->pitch));
+                     points[2].y = data.PitchToY(LookupRealAttribute(note, y2r, note->pitch));
                      dc.DrawPolygon(3, points);
                   } else if (shape == polygon) {
                      wxPoint points[20]; // upper bound of 20 sides
@@ -3141,7 +3107,7 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                      points[1].y = y1;
                      points[2].x = TIME_TO_X(LookupRealAttribute(note, x2r, xx));
                      CLIP(points[2].x);
-                     points[2].y = track->PitchToY(LookupRealAttribute(note, y2r, note->pitch));
+                     points[2].y = data.PitchToY(LookupRealAttribute(note, y2r, note->pitch));
                      int n = 3;
                      while (n < 20) {
                         char name[8];
@@ -3155,7 +3121,7 @@ void TrackArtist::DrawNoteTrack(const NoteTrack *track,
                         attr = symbol_table.insert_string(name);
                         double yn = LookupRealAttribute(note, attr, -1000000.0);
                         if (yn == -1000000.0) break;
-                        points[n].y = track->PitchToY(yn);
+                        points[n].y = data.PitchToY(yn);
                         n++;
                      }
                      dc.DrawPolygon(n, points);

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -590,34 +590,44 @@ void TrackArtist::DrawVRuler
       int octave = 0;
       int obottom = data.GetOctaveBottom(octave);
       int marg = data.GetNoteMargin();
+      int top = rect.y + marg;
+      int bottom = rect.y + rect.height - marg;
 
       while (obottom >= rect.y) {
          dc->SetPen(*wxBLACK_PEN);
          for (int white = 0; white < 7; white++) {
             int pos = data.GetWhitePos(white);
-            if (obottom - pos > rect.y + marg + 1 &&
-                // don't draw too close to margin line -- it's annoying
-                obottom - pos < rect.y + rect.height - marg - 3)
-               AColor::Line(*dc, rect.x, obottom - pos,
+            if (obottom - pos > top && obottom - pos < bottom)
+               AColor::Line(*dc, rect.x + 1, obottom - pos,
                             rect.x + rect.width, obottom - pos);
          }
          wxRect br = rect;
-         br.height = data.GetPitchHeight(1);
          br.x++;
          br.width = 17;
          for (int black = 0; black < 5; black++) {
             br.y = obottom - data.GetBlackPos(black);
-            if (br.y > rect.y + marg - 2 && br.y + br.height < rect.y + rect.height - marg) {
-               dc->SetPen(hilitePen);
-               dc->DrawRectangle(br);
-               dc->SetPen(*wxBLACK_PEN);
-               AColor::Line(*dc,
-                            br.x + 1, br.y + br.height - 1,
-                            br.x + br.width - 1, br.y + br.height - 1);
-               AColor::Line(*dc,
-                            br.x + br.width - 1, br.y + 1,
-                            br.x + br.width - 1, br.y + br.height - 1);
+            br.height = data.GetPitchHeight(1);
+            if (br.y + br.height <= top || br.y >= bottom) {
+               continue; // Cannot fit at all
             }
+            // Clip to avoid going into the margins
+            if (br.y < top) {
+               br.height -= top - br.y;
+               br.y = top;
+            }
+            if (br.y + br.height > bottom) {
+               br.height = br.y - bottom;
+            }
+            if (br.height <= 1) continue; // Also cannot fit
+            dc->SetPen(hilitePen);
+            dc->DrawRectangle(br);
+            dc->SetPen(*wxBLACK_PEN);
+            AColor::Line(*dc,
+                           br.x + 1, br.y + br.height - 1,
+                           br.x + br.width - 1, br.y + br.height - 1);
+            AColor::Line(*dc,
+                           br.x + br.width - 1, br.y + 1,
+                           br.x + br.width - 1, br.y + br.height - 1);
          }
 
          if (octave >= 1 && octave <= 10) {

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -110,7 +110,6 @@ class AUDACITY_DLL_API TrackArtist {
                      wxDC & dc, const wxRect & rect,
                      const SelectedRegion &selectedRegion, const ZoomInfo &zoomInfo);
 #ifdef USE_MIDI
-   int GetBottom(NoteTrack *t, const wxRect &rect);
    void DrawNoteBackground(const NoteTrack *track, wxDC &dc,
                            const wxRect &rect, const wxRect &sel,
                            const ZoomInfo &zoomInfo,

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -89,6 +89,7 @@ bool ImportMIDI(const wxString &fName, NoteTrack * dest)
    // then middle pitch class is D. Round mean_pitch to the nearest D:
    int mid_pitch = ((mean_pitch - 2 + 6) / 12) * 12 + 2;
    dest->SetBottomNote(mid_pitch - 14);
+   dest->SetTopNote(mid_pitch + 13);
    return true;
 }
 

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -69,27 +69,8 @@ bool ImportMIDI(const wxString &fName, NoteTrack * dest)
    wxString trackNameBase = fName.AfterLast(wxFILE_SEP_PATH).BeforeLast('.');
    dest->SetName(trackNameBase);
    mf.Close();
-   // the mean pitch should be somewhere in the middle of the display
-   Alg_iterator iterator( &dest->GetSeq(), false );
-   iterator.begin();
-   // for every event
-   Alg_event_ptr evt;
-   int note_count = 0;
-   int pitch_sum = 0;
-   while (NULL != (evt = iterator.next())) {
-      // if the event is a note
-       if (evt->get_type() == 'n') {
-           Alg_note_ptr note = (Alg_note_ptr) evt;
-           pitch_sum += (int) note->pitch;
-           note_count++;
-       }
-   }
-   int mean_pitch = (note_count > 0 ? pitch_sum / note_count : 60);
-   // initial track is about 27 half-steps high; if bottom note is C,
-   // then middle pitch class is D. Round mean_pitch to the nearest D:
-   int mid_pitch = ((mean_pitch - 2 + 6) / 12) * 12 + 2;
-   dest->SetBottomNote(mid_pitch - 14);
-   dest->SetTopNote(mid_pitch + 13);
+
+   dest->ZoomAllNotes();
    return true;
 }
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
@@ -116,7 +116,7 @@ void NoteTrackMenuTable::OnChangeOctave(wxCommandEvent &event)
    pTrack->ShiftNoteRange((bDown) ? -12 : 12);
 
    AudacityProject *const project = ::GetActiveProject();
-   project->ModifyState(true);
+   project->ModifyState(false);
    mpData->result = RefreshCode::RefreshAll;
 }
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
@@ -103,8 +103,7 @@ enum {
    OnDownOctaveID,
 };
 
-/// This only applies to MIDI tracks.  Presumably, it shifts the
-/// whole sequence by an octave.
+/// Scrolls the note track up or down by an octave
 void NoteTrackMenuTable::OnChangeOctave(wxCommandEvent &event)
 {
    NoteTrack *const pTrack = static_cast<NoteTrack*>(mpData->pTrack);
@@ -114,8 +113,7 @@ void NoteTrackMenuTable::OnChangeOctave(wxCommandEvent &event)
    wxASSERT(pTrack->GetKind() == Track::Note);
 
    const bool bDown = (OnDownOctaveID == event.GetId());
-   pTrack->SetBottomNote
-      (pTrack->GetBottomNote() + ((bDown) ? -12 : 12));
+   pTrack->ShiftNoteRange((bDown) ? -12 : 12);
 
    AudacityProject *const project = ::GetActiveProject();
    project->ModifyState(true);

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
@@ -76,7 +76,7 @@ unsigned NoteTrackVRulerControls::HandleWheelRotation
    } else if (!event.CmdDown() && event.ShiftDown()) {
       // Scroll some fixed number of notes, independent of zoom level or track height:
       static const int movement = 6; // 6 semitones is half an octave
-      nt->SetBottomNote(nt->GetBottomNote() + (int) (steps * movement));
+      nt->ShiftNoteRange((int) (steps * movement));
    } else {
       return RefreshNone;
    }

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
@@ -81,7 +81,7 @@ unsigned NoteTrackVRulerControls::HandleWheelRotation
       return RefreshNone;
    }
 
-   pProject->ModifyState(true);
+   pProject->ModifyState(false);
 
    return RefreshCell | UpdateVRuler;
 }

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -196,8 +196,6 @@ private:
    }
 
    virtual void InitMenu(Menu *pMenu, void *pUserData);
-
-   void OnWaveformScaleType(wxCommandEvent &evt);
 };
 
 NoteTrackVRulerMenuTable &NoteTrackVRulerMenuTable::Instance()
@@ -214,8 +212,7 @@ void NoteTrackVRulerMenuTable::InitMenu(Menu *WXUNUSED(pMenu), void *pUserData)
 void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
    switch( iZoomCode ){
    case kZoomReset:
-      mpData->pTrack->SetBottomNote(0);
-      mpData->pTrack->SetPitchHeight(mpData->rect.height, 1);
+      mpData->pTrack->ZoomMaxExtent();
       break;
    case kZoomIn:
       mpData->pTrack->ZoomIn(mpData->rect, mpData->yy);
@@ -300,8 +297,7 @@ UIHandle::Result NoteTrackVZoomHandle::Release
    else if (event.ShiftDown() || event.RightUp()) {
       if (event.ShiftDown() && event.RightUp()) {
          // Zoom out completely
-         pTrack->SetBottomNote(0);
-         pTrack->SetPitchHeight(evt.rect.height, 1);
+         pTrack->ZoomMaxExtent();
       } else {
          // Zoom out
          pTrack->ZoomOut(evt.rect, mZoomEnd);

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -149,6 +149,8 @@ const int kZoomIn = 6;
 const int kZoomOut = 7;
 const int kZoomReset = 8;
 const int kZoomMax = 9;
+const int kUpOctave = 10;
+const int kDownOctave = 11;
 
 enum {
    OnZoomFitVerticalID = 20000,
@@ -168,6 +170,9 @@ enum {
    OnLastSpectrumScaleID = OnFirstSpectrumScaleID + 19,
 
    OnZoomMaxID,
+
+   OnUpOctaveID,
+   OnDownOctaveID,
 };
 ///////////////////////////////////////////////////////////////////////////////
 // Table class
@@ -192,6 +197,8 @@ protected:
    void OnZoomInVertical(wxCommandEvent&){ OnZoom( kZoomIn );};
    void OnZoomOutVertical(wxCommandEvent&){ OnZoom( kZoomOut );};
    void OnZoomMax(wxCommandEvent&){ OnZoom( kZoomMax );};
+   void OnUpOctave(wxCommandEvent&){ OnZoom( kUpOctave );};
+   void OnDownOctave(wxCommandEvent&){ OnZoom( kDownOctave );};
 
 private:
    void DestroyMenu() override
@@ -227,6 +234,12 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
    case kZoomMax:
       mpData->pTrack->ZoomMaxExtent();
       break;
+   case kUpOctave:
+      mpData->pTrack->ShiftNoteRange(12);
+      break;
+   case kDownOctave:
+      mpData->pTrack->ShiftNoteRange(-12);
+      break;
    }
    GetActiveProject()->ModifyState(false);
 }
@@ -240,6 +253,10 @@ BEGIN_POPUP_MENU(NoteTrackVRulerMenuTable)
    POPUP_MENU_SEPARATOR()
    POPUP_MENU_ITEM(OnZoomInVerticalID,  _("Zoom In\tLeft-Click/Left-Drag"),  OnZoomInVertical)
    POPUP_MENU_ITEM(OnZoomOutVerticalID, _("Zoom Out\tShift-Left-Click"),     OnZoomOutVertical)
+
+   POPUP_MENU_SEPARATOR()
+   POPUP_MENU_ITEM(OnUpOctaveID,   _("Up &Octave"),   OnUpOctave)
+   POPUP_MENU_ITEM(OnDownOctaveID, _("Down Octa&ve"), OnDownOctave)
 
 END_POPUP_MENU()
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -222,6 +222,7 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
       break;
 
    }
+   GetActiveProject()->ModifyState(false);
 }
 
 
@@ -308,7 +309,7 @@ UIHandle::Result NoteTrackVZoomHandle::Release
    }
 
    mZoomEnd = mZoomStart = 0;
-   pProject->ModifyState(true);
+   pProject->ModifyState(false);
 
    return RefreshAll;
 }

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -148,6 +148,7 @@ HitTestPreview NoteTrackVZoomHandle::Preview
 const int kZoomIn = 6;
 const int kZoomOut = 7;
 const int kZoomReset = 8;
+const int kZoomMax = 9;
 
 enum {
    OnZoomFitVerticalID = 20000,
@@ -165,6 +166,8 @@ enum {
    // Reserve an ample block of ids for spectrum scale types
    OnFirstSpectrumScaleID,
    OnLastSpectrumScaleID = OnFirstSpectrumScaleID + 19,
+
+   OnZoomMaxID,
 };
 ///////////////////////////////////////////////////////////////////////////////
 // Table class
@@ -188,6 +191,7 @@ protected:
 // void OnZoomHalfWave(wxCommandEvent&){ OnZoom( kZoomHalfWave );};
    void OnZoomInVertical(wxCommandEvent&){ OnZoom( kZoomIn );};
    void OnZoomOutVertical(wxCommandEvent&){ OnZoom( kZoomOut );};
+   void OnZoomMax(wxCommandEvent&){ OnZoom( kZoomMax );};
 
 private:
    void DestroyMenu() override
@@ -212,7 +216,7 @@ void NoteTrackVRulerMenuTable::InitMenu(Menu *WXUNUSED(pMenu), void *pUserData)
 void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
    switch( iZoomCode ){
    case kZoomReset:
-      mpData->pTrack->ZoomMaxExtent();
+      mpData->pTrack->ZoomAllNotes();
       break;
    case kZoomIn:
       mpData->pTrack->ZoomIn(mpData->rect, mpData->yy);
@@ -220,7 +224,9 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
    case kZoomOut:
       mpData->pTrack->ZoomOut(mpData->rect, mpData->yy);
       break;
-
+   case kZoomMax:
+      mpData->pTrack->ZoomMaxExtent();
+      break;
    }
    GetActiveProject()->ModifyState(false);
 }
@@ -229,6 +235,7 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
 BEGIN_POPUP_MENU(NoteTrackVRulerMenuTable)
 
    POPUP_MENU_ITEM(OnZoomResetID,      _("Zoom Reset\tShift-Right-Click"), OnZoomReset)
+   POPUP_MENU_ITEM(OnZoomMaxID,        _("Max Zoom"), OnZoomMax)
 
    POPUP_MENU_SEPARATOR()
    POPUP_MENU_ITEM(OnZoomInVerticalID,  _("Zoom In\tLeft-Click/Left-Drag"),  OnZoomInVertical)
@@ -297,8 +304,15 @@ UIHandle::Result NoteTrackVZoomHandle::Release
    }
    else if (event.ShiftDown() || event.RightUp()) {
       if (event.ShiftDown() && event.RightUp()) {
-         // Zoom out completely
-         pTrack->ZoomMaxExtent();
+         auto oldBotNote = pTrack->GetBottomNote();
+         auto oldTopNote = pTrack->GetTopNote();
+         // Zoom out to show all notes
+         pTrack->ZoomAllNotes();
+         if (pTrack->GetBottomNote() == oldBotNote &&
+               pTrack->GetTopNote() == oldTopNote) {
+            // However if we are already showing all notes, zoom out further
+            pTrack->ZoomMaxExtent();
+         }
       } else {
          // Zoom out
          pTrack->ZoomOut(evt.rect, mZoomEnd);


### PR DESCRIPTION
A rework of how note track vertical zooming internally works, and some other rendering changes.  The commit messages should generally summarize them pretty well.

Includes fixes for the following bugs:

* [Bug 1815](http://bugzilla.audacityteam.org/show_bug.cgi?id=1815): fixed by importing zooming to include all notes; this may need to be reconsidered when MIDI recording is implemented though, although that's far off
* [Bug 1819](http://bugzilla.audacityteam.org/show_bug.cgi?id=1819): fixed by checking the track (as is done with other things)
* [Bug 1820](http://bugzilla.audacityteam.org/show_bug.cgi?id=1820): fixed by saving the top note &mdash; may want to retitle that bug because the pitch height isn't exactly what is saved