### PR TITLE
Fix for building without portmixer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -540,7 +540,7 @@ AC_ARG_WITH(portmixer,
      [compile with PortMixer [default=yes]])],
   use_portmixer=$withval,
   use_portmixer="yes")
-
+AM_CONDITIONAL([USE_PORTMIXER], [test "$use_portmixer" = yes])
 
 AC_CANONICAL_HOST
 

--- a/lib-src/Makefile.am
+++ b/lib-src/Makefile.am
@@ -92,7 +92,6 @@ DIST_SUBDIRS = \
 	libsoxr \
 	lib-widget-extra \
 	lv2 \
-	portmixer \
 	portsmf \
 	sbsms \
 	$(NULL)
@@ -156,8 +155,10 @@ if USE_LOCAL_PORTAUDIO
 SUBDIRS += portaudio-v19
 endif
 
+if USE_PORTMIXER
 # Note: portmixer needs to be linked against (the local or system) portaudio.
 SUBDIRS += portmixer
+endif
 
 if USE_LOCAL_PORTSMF
 SUBDIRS += portsmf


### PR DESCRIPTION
I am not sure the proposed changes are correct, but they allow me to build Audacity both with portmixer enabled and disabled. So I hope, it will work for other people as well.