### PR TITLE
Simplification in av_log_wx_callback, because wxLogDebug is threadsafe.

### DIFF
--- a/src/FFmpeg.cpp
+++ b/src/FFmpeg.cpp
@@ -150,15 +150,7 @@ void av_log_wx_callback(void* ptr, int level, const char* fmt, va_list vl)
    case 2: cpt = wxT("Debug"); break;
    default: cpt = wxT("Log"); break;
    }
-#ifdef EXPERIMENTAL_OD_FFMPEG
-//if the decoding happens thru OD then this gets called from a non main thread, which means wxLogDebug
-//will crash.
-//TODO:find some workaround for the log.  perhaps use ODManager as a bridge. for now just print
-   if(!wxThread::IsMain())
-      wxPrintf("%s: %s\n",(char*)cpt.char_str(),(char*)printstring.char_str());
-   else
-#endif
-      wxLogDebug(wxT("%s: %s"),cpt,printstring);
+   wxLogDebug(wxT("%s: %s"),cpt,printstring);
 }
 
 //======================= Unicode aware uri protocol for FFmpeg


### PR DESCRIPTION
wxLogDebug is threadsafe since wxWidgets 2.9.1 (releated in 2010)
according to
http://docs.wxwidgets.org/3.0/overview_log.html#overview_log_mt.

Note also that wxLogDebug could already have been called from multiple
threads even with EXPERIMENTAL_OD_FFMPEG unset. According to FFmpeg
doc, the logging callback can be called from multiple threads because
some codecs are multithreaded:
https://ffmpeg.org/doxygen/2.5/group__lavu__log.html#ga14034761faf581a8b9ed6ef19b313708