### PR TITLE
Fix OpenMP build

### DIFF
--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -393,7 +393,7 @@ size_t Mixer::MixVariableRates(int *channelFlags, WaveTrackCache &cache,
                                     int *queueStart, int *queueLen,
                                     Resample * pResample)
 {
-   const WaveTrack *const track = cache.GetTrack();
+   const WaveTrack *const track = cache.GetTrack().get();
    const double trackRate = track->GetRate();
    const double initialWarp = mRate / mSpeed / trackRate;
    const double tstep = 1.0 / trackRate;
@@ -538,7 +538,7 @@ size_t Mixer::MixVariableRates(int *channelFlags, WaveTrackCache &cache,
 size_t Mixer::MixSameRate(int *channelFlags, WaveTrackCache &cache,
                                sampleCount *pos)
 {
-   const WaveTrack *const track = cache.GetTrack();
+   const WaveTrack *const track = cache.GetTrack().get();
    const double t = ( *pos ).as_double() / track->GetRate();
    const double trackEndTime = track->GetEndTime();
    const double trackStartTime = track->GetStartTime();
@@ -611,7 +611,7 @@ size_t Mixer::Process(size_t maxToProcess)
 
    Clear();
    for(size_t i=0; i<mNumInputTracks; i++) {
-      const WaveTrack *const track = mInputTrack[i].GetTrack();
+      const WaveTrack *const track = mInputTrack[i].GetTrack().get();
       for(size_t j=0; j<mNumChannels; j++)
          channelFlags[j] = 0;
 

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -2174,7 +2174,7 @@ void TrackArtist::DrawClipSpectrum(WaveTrackCache &waveTrackCache,
    Profiler profiler;
 #endif
 
-   const WaveTrack *const track = waveTrackCache.GetTrack();
+   const WaveTrack *const track = waveTrackCache.GetTrack().get();
    const SpectrogramSettings &settings = track->GetSpectrogramSettings();
    const bool autocorrelation = (settings.algorithm == SpectrogramSettings::algPitchEAC);
 

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1200,7 +1200,7 @@ bool WaveClip::GetSpectrogram(WaveTrackCache &waveTrackCache,
                               size_t numPixels,
                               double t0, double pixelsPerSecond) const
 {
-   const WaveTrack *const track = waveTrackCache.GetTrack();
+   const WaveTrack *const track = waveTrackCache.GetTrack().get();
    const SpectrogramSettings &settings = track->GetSpectrogramSettings();
 
    bool match =

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -669,7 +669,7 @@ public:
    }
    ~WaveTrackCache();
 
-   const WaveTrack *GetTrack() const { return mPTrack.get(); }
+   const std::shared_ptr<const WaveTrack>& GetTrack() const { return mPTrack; }
    void SetTrack(const std::shared_ptr<const WaveTrack> &pTrack);
 
    // Uses fillZero always


### PR DESCRIPTION
Make WaveTrackCache return smart pointer for GetTrack() so it may be referenced in OpenMP thread context. Propagate this change elsewhere.