### PR TITLE
Second refactor of seekLeftOrRight

### DIFF
--- a/src/Menus.h
+++ b/src/Menus.h
@@ -546,15 +546,19 @@ void OnResample(const CommandContext &context );
 private:
 void OnCursorLeft(bool shift, bool ctrl, bool keyup = false);
 void OnCursorRight(bool shift, bool ctrl, bool keyup = false);
-void OnCursorMove(bool forward, bool jump, bool longjump);
+void OnCursorMove(bool forward, bool longjump);
 void OnBoundaryMove(bool left, bool boundaryContract);
 
 // Handle small cursor and play head movements
 void SeekLeftOrRight
-(bool left, bool shift, bool ctrl, bool keyup,
- int snapToTime, bool mayAccelerateQuiet, bool mayAccelerateAudio,
- double quietSeekStepPositive, bool quietStepIsPixels,
- double audioSeekStepPositive, bool audioStepIsPixels);
+(bool left, bool shift, bool ctrl, bool keyup);
+
+void SeekAudio(double seekStep);
+
+void SeekQuiet
+(double seekStep, bool isPixels, bool snapToTime, bool shift, bool ctrl);
+
+double OffsetTime(double t, double offset, bool isPixels, bool snapToTime);
 
 // Helper for moving by keyboard with snap-to-grid enabled
 double GridMove(double t, int minPix);

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -544,21 +544,33 @@ void NextWindow(const CommandContext &context );
 void OnResample(const CommandContext &context );
 
 private:
-void OnCursorLeft(bool shift, bool ctrl, bool keyup = false);
-void OnCursorRight(bool shift, bool ctrl, bool keyup = false);
-void OnCursorMove(bool forward, bool longjump);
+enum SelectionOperation {
+    SELECTION_EXTEND,
+    SELECTION_CONTRACT,
+    CURSOR_MOVE
+};
+
+enum TimeUnit {
+    TIME_UNIT_SECONDS,
+    TIME_UNIT_PIXELS
+};
+
+void OnCursorLeft(SelectionOperation operation, bool keyup = false);
+void OnCursorRight(SelectionOperation operation, bool keyup = false);
+void OnCursorMove(double seekStep);
 void OnBoundaryMove(bool left, bool boundaryContract);
 
 // Handle small cursor and play head movements
 void SeekLeftOrRight
-(bool left, bool shift, bool ctrl, bool keyup);
+(double direction, SelectionOperation operation, bool keyup);
 
 void SeekAudio(double seekStep);
 
 void SeekQuiet
-(double seekStep, bool isPixels, bool snapToTime, bool shift, bool ctrl);
+(double seekStep, TimeUnit timeUnit, int snapToTime,
+ SelectionOperation operation);
 
-double OffsetTime(double t, double offset, bool isPixels, bool snapToTime);
+double OffsetTime(double t, double offset, TimeUnit timeUnit, int snapToTime);
 
 // Helper for moving by keyboard with snap-to-grid enabled
 double GridMove(double t, int minPix);


### PR DESCRIPTION
Updated version of https://github.com/audacity/audacity/pull/262 using enums instead of bool flags and replacing some else clauses with early returns. I'm just offering this as an alternative to the first refactor to find out whether the team thinks it's a step in the right direction.