### PR TITLE
Migrate old chains...

### DIFF
--- a/src/BatchCommands.h
+++ b/src/BatchCommands.h
@@ -79,6 +79,7 @@ class MacroCommands final {
    bool IsMono();
 
    // These commands do not depend on the command list.
+   static void MigrateLegacyChains();
    static wxArrayString GetNames();
    static wxArrayString GetNamesOfDefaultMacros();
 

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -190,6 +190,12 @@ wxString FileNames::HtmlHelpDir()
 #endif
 }
 
+wxString FileNames::LegacyChainDir()
+{
+   // Don't force creation of it
+   return wxFileName{ DataDir(), wxT("Chains") }.GetFullPath();
+}
+
 wxString FileNames::MacroDir()
 {
    return FileNames::MkDir( wxFileName( DataDir(), wxT("Macros") ).GetFullPath() );

--- a/src/FileNames.h
+++ b/src/FileNames.h
@@ -44,6 +44,7 @@ public:
    static wxString AutoSaveDir();
    static wxString HtmlHelpDir();
    static wxString HtmlHelpIndexFile(bool quick);
+   static wxString LegacyChainDir();
    static wxString MacroDir();
    static wxString NRPDir();
    static wxString NRPFile();


### PR DESCRIPTION
... Copy old Chains files to Macros, once only per session, never overwriting.

Leave old files in place in case the user downgrades their Audacity.

Please consider this for merge!  A very small amount of extra code that will eliminate a nuisance for established Chains users and keep them happy.

I tested this, and indeed the old Chain file format is (so far) still interpreted by Audacity 2.3.0 once the file is in the right place.
