### PR TITLE
Const'ify xpm

### DIFF
--- a/images/Aqua.xpm
+++ b/images/Aqua.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Background[] = {
+static const char * const Background[] = {
 /* columns rows colors chars-per-pixel */
 "8 8 3 1",
 "  c #e7e7e7",
@@ -16,7 +16,7 @@ static const char *Background[] = {
 "........"
 };
 /* XPM */
-static const char *Div[] = {
+static const char * const Div[] = {
 /* columns rows colors chars-per-pixel */
 "15 48 4 1",
 "  c #909090",
@@ -74,7 +74,7 @@ static const char *Div[] = {
 "XXXXXXXXXXXXXXX"
 };
 /* XPM */
-static const char *IBeamDown[] = {
+static const char * const IBeamDown[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 144 2",
 "   c #17232e",
@@ -251,7 +251,7 @@ static const char *IBeamDown[] = {
 "x.c.j.g.~ T = = * * * * * * * * * * * * * * * * * * * "
 };
 /* XPM */
-static const char *IBeamOver[] = {
+static const char * const IBeamOver[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 35 1",
 "  c #2d2d2d",
@@ -319,7 +319,7 @@ static const char *IBeamOver[] = {
 "qq;1*$#OOOOOOOOOOOOOOOOOOO+"
 };
 /* XPM */
-static const char *IBeamUp[] = {
+static const char * const IBeamUp[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 35 1",
 "  c #2d2d2d",
@@ -387,7 +387,7 @@ static const char *IBeamUp[] = {
 "qq;1*$#OOOOOOOOOOOOOOOOOOO+"
 };
 /* XPM */
-static const char *Loud[] = {
+static const char * const Loud[] = {
 /* columns rows colors chars-per-pixel */
 "27 48 47 1",
 "  c #181818",
@@ -488,7 +488,7 @@ static const char *Loud[] = {
 "ggggggggggggggggggggggggggg"
 };
 /* XPM */
-static const char *MoveDown[] = {
+static const char * const MoveDown[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 129 2",
 "   c #192430",
@@ -650,7 +650,7 @@ static const char *MoveDown[] = {
 "i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i.i."
 };
 /* XPM */
-static const char *MoveOver[] = {
+static const char * const MoveOver[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 29 1",
 "  c Gray18",
@@ -712,7 +712,7 @@ static const char *MoveOver[] = {
 "000000000000000000000000000"
 };
 /* XPM */
-static const char *MoveUp[] = {
+static const char * const MoveUp[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 29 1",
 "  c Gray18",
@@ -774,7 +774,7 @@ static const char *MoveUp[] = {
 "000000000000000000000000000"
 };
 /* XPM */
-static const char *Mute[] = {
+static const char * const Mute[] = {
 /* columns rows colors chars-per-pixel */
 "27 48 47 1",
 "  c #181818",
@@ -875,7 +875,7 @@ static const char *Mute[] = {
 "ggggggggggggggggggggggggggg"
 };
 /* XPM */
-static const char *PlayDisabled[] = {
+static const char * const PlayDisabled[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 191 2",
 "   c #272727",
@@ -1120,7 +1120,7 @@ static const char *PlayDisabled[] = {
 "(.E.(.(.(.(.(.(.(.(.(.E.(.(.(.E.E.E.E.E.E.E.E.E.E.E.E.E.E.E.E.E.E.E.E.(.(.(.(.(.(.(.(.(._.(.(._."
 };
 /* XPM */
-static const char *PlayDown[] = {
+static const char * const PlayDown[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 255 2",
 "   c #033b95",
@@ -1429,7 +1429,7 @@ static const char *PlayDown[] = {
 "MXMXMXMXmXmXmXmXmXmXmXmXMXMXbXcXcXcXcXcXcXcXcXcXcXcXcXcXcXcXcXcXbXbXMXMXMXmXmXmXmXmXmXmXmXmXmXmX"
 };
 /* XPM */
-static const char *PlayOver[] = {
+static const char * const PlayOver[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 256 2",
 "   c #222e33",
@@ -1739,7 +1739,7 @@ static const char *PlayOver[] = {
 "NXNXNXNXMXMXMXMXMXMXMXMXNXNXnXvXvXvXvXvXvXvXvXvXvXvXvXvXvXvXvXvXnXnXNXNXNXMXMXMXMXMXMXMXMXMXMXMX"
 };
 /* XPM */
-static const char *PlayUp[] = {
+static const char * const PlayUp[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 254 2",
 "   c #1f272f",
@@ -2047,7 +2047,7 @@ static const char *PlayUp[] = {
 "mXbXbXmXmXmXmXmXmXmXmXmXmXvXvXvXcXxXxXxXxXxXxXxXxXxXxXxXxXxXcXcXvXvXvXbXmXmXmXmXmXmXmXmXmXmXmXSX"
 };
 /* XPM */
-static const char *RecordDisabled[] = {
+static const char * const RecordDisabled[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 194 2",
 "   c #282828",
@@ -2295,7 +2295,7 @@ static const char *RecordDisabled[] = {
 "`.!.`.`.`.`.`.`.`.`.`.!.`.`.`.!.!.!.!.!.!.!.!.!.!.!.!.!.!.!.!.!.!.!.!.`.`.`.`.`.`.`.`.`.].`.`.]."
 };
 /* XPM */
-static const char *RecordDown[] = {
+static const char * const RecordDown[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 254 2",
 "   c #033b95",
@@ -2603,7 +2603,7 @@ static const char *RecordDown[] = {
 "nXnXnXnXnXbXbXbXbXbXbXbXnXnXcXzXzXzXzXzXzXzXzXzXzXzXzXzXzXzXzXzXcXcXnXnXnXbXbXbXbXbXbXbXbXbXbXbX"
 };
 /* XPM */
-static const char *RecordOver[] = {
+static const char * const RecordOver[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 255 2",
 "   c #232f33",
@@ -2912,7 +2912,7 @@ static const char *RecordOver[] = {
 "mXmXmXmXmXnXnXnXnXnXnXnXmXmXvXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXvXvXmXmXmXnXnXnXnXnXnXnXnXnXnXnX"
 };
 /* XPM */
-static const char *RecordUp[] = {
+static const char * const RecordUp[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 255 2",
 "   c #232a33",
@@ -3221,7 +3221,7 @@ static const char *RecordUp[] = {
 "MXnXnXMXMXMXMXMXMXMXMXMXMXbXbXbXvXcXcXcXcXcXcXcXcXcXcXcXcXcXvXvXbXbXbXnXMXMXMXMXMXMXMXMXMXMXMXDX"
 };
 /* XPM */
-static const char *SelectDown[] = {
+static const char * const SelectDown[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 180 2",
 "   c #17232e",
@@ -3434,7 +3434,7 @@ static const char *SelectDown[] = {
 "3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 4 4 ..+.~.^.`._._."
 };
 /* XPM */
-static const char *SelectOver[] = {
+static const char * const SelectOver[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 64 1",
 "  c #2d2d2d",
@@ -3531,7 +3531,7 @@ static const char *SelectOver[] = {
 "**==******==****===<47auccc"
 };
 /* XPM */
-static const char *SelectUp[] = {
+static const char * const SelectUp[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 64 1",
 "  c #2d2d2d",
@@ -3628,7 +3628,7 @@ static const char *SelectUp[] = {
 "**==******==****===<47auccc"
 };
 /* XPM */
-static const char *Slider[] = {
+static const char * const Slider[] = {
 /* columns rows colors chars-per-pixel */
 "100 28 23 1",
 "  c Gray29",
@@ -3685,7 +3685,7 @@ static const char *Slider[] = {
 "3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333"
 };
 /* XPM */
-static const char *SliderThumb[] = {
+static const char * const SliderThumb[] = {
 /* columns rows colors chars-per-pixel */
 "17 28 117 2",
 "   c #000063",
@@ -3836,7 +3836,7 @@ static const char *SliderThumb[] = {
 "4.4.4.4.4.4.4.4.4.4.4.4.4.4.4.4.4."
 };
 /* XPM */
-static const char *StopDisabled[] = {
+static const char * const StopDisabled[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 187 2",
 "   c #272727",
@@ -4077,7 +4077,7 @@ static const char *StopDisabled[] = {
 "!.U.!.!.!.!.!.!.!.!.!.U.!.!.!.U.U.U.U.U.U.U.U.U.U.U.U.U.U.U.U.U.U.U.U.!.!.!.!.!.!.!.!.!.^.!.!.^."
 };
 /* XPM */
-static const char *StopDown[] = {
+static const char * const StopDown[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 256 2",
 "   c #033b95",
@@ -4387,7 +4387,7 @@ static const char *StopDown[] = {
 "MXMXMXMXMXmXmXmXmXmXmXmXMXMXbXbXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXbXbXMXMXMXmXmXmXmXmXmXmXmXmXmXmX"
 };
 /* XPM */
-static const char *StopOver[] = {
+static const char * const StopOver[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 256 2",
 "   c #222e33",
@@ -4697,7 +4697,7 @@ static const char *StopOver[] = {
 "MXMXMXMXMXmXmXmXmXmXmXmXMXMXbXbXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXbXbXMXMXMXmXmXmXmXmXmXmXmXmXmXmX"
 };
 /* XPM */
-static const char *StopUp[] = {
+static const char * const StopUp[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 256 2",
 "   c #1f272f",
@@ -5007,7 +5007,7 @@ static const char *StopUp[] = {
 "MXbXbXMXMXMXMXMXMXMXMXMXMXvXvXvXcXxXxXxXxXxXxXxXxXxXxXxXxXxXcXcXvXvXvXbXMXMXMXMXMXMXMXMXMXMXMXFX"
 };
 /* XPM */
-static const char *ZoomDown[] = {
+static const char * const ZoomDown[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 208 2",
 "   c #1c272f",
@@ -5248,7 +5248,7 @@ static const char *ZoomDown[] = {
 "5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X"
 };
 /* XPM */
-static const char *ZoomOver[] = {
+static const char * const ZoomOver[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 89 1",
 "  c #2d2d2d",
@@ -5370,7 +5370,7 @@ static const char *ZoomOver[] = {
 "'''''''''''''''''''''''''''"
 };
 /* XPM */
-static const char *ZoomUp[] = {
+static const char * const ZoomUp[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 89 1",
 "  c #2d2d2d",

--- a/images/Aqua/Down.xpm
+++ b/images/Aqua/Down.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Down[] = {
+static const char * const Down[] = {
 "27 27 81 1",
 " 	c None",
 ".	c #949494",

--- a/images/Aqua/DownButtonSquare.xpm
+++ b/images/Aqua/DownButtonSquare.xpm
@@ -1,5 +1,5 @@
 /* XPM */ 
-static const char * DownButton[] = {
+static const char * const DownButton[] = {
 "36 36 69 1",
 " 	c None",
 "!	c #E6E6E6",

--- a/images/Aqua/DownButtonStripes.xpm
+++ b/images/Aqua/DownButtonStripes.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * DownButton[] = {
+static const char * const DownButton[] = {
 "48 48 1141 2",
 "  	c None",
 ". 	c #E7E7E7",

--- a/images/Aqua/DownButtonWhite.xpm
+++ b/images/Aqua/DownButtonWhite.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * DownButton[] = {
+static const char * const DownButton[] = {
 "48 48 1065 2",
 "  	c None",
 ". 	c #FFFFFF",

--- a/images/Aqua/Hilite.xpm
+++ b/images/Aqua/Hilite.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Hilite[] = {
+static const char * const Hilite[] = {
 "27 27 55 1",
 " 	c None",
 ".	c #ADADAD",

--- a/images/Aqua/HiliteButtonSquare.xpm
+++ b/images/Aqua/HiliteButtonSquare.xpm
@@ -1,5 +1,5 @@
 /* XPM */ 
-static const char * HiliteButton[] = {
+static const char * const HiliteButton[] = {
 "36 36 74 1",
 " 	c None",
 "!	c #E6E6E6",

--- a/images/Aqua/HiliteButtonStripes.xpm
+++ b/images/Aqua/HiliteButtonStripes.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * HiliteButton[] = {
+static const char * const HiliteButton[] = {
 "48 48 1141 2",
 "  	c None",
 ". 	c #E7E7E7",

--- a/images/Aqua/HiliteButtonWhite.xpm
+++ b/images/Aqua/HiliteButtonWhite.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * HiliteButton[] = {
+static const char * const HiliteButton[] = {
 "48 48 1065 2",
 "  	c None",
 ". 	c #FFFFFF",

--- a/images/Aqua/Slider.xpm
+++ b/images/Aqua/Slider.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Slider[] = {
+static const char * const Slider[] = {
 /* columns rows colors chars-per-pixel */
 "100 28 23 1",
 "  c Gray29",

--- a/images/Aqua/SliderThumb.xpm
+++ b/images/Aqua/SliderThumb.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *SliderThumb[] = {
+static const char * const SliderThumb[] = {
 /* columns rows colors chars-per-pixel */
 "17 28 117 2",
 "   c #000063",

--- a/images/Aqua/Up.xpm
+++ b/images/Aqua/Up.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Up[] = {
+static const char * const Up[] = {
 "27 27 55 1",
 " 	c None",
 ".	c #ADADAD",

--- a/images/Aqua/UpButtonSquare.xpm
+++ b/images/Aqua/UpButtonSquare.xpm
@@ -1,5 +1,5 @@
 /* XPM */ 
-static const char * UpButton[] = {
+static const char * const UpButton[] = {
 "36 36 75 1",
 " 	c None",
 "!	c white",

--- a/images/Aqua/UpButtonStripes.xpm
+++ b/images/Aqua/UpButtonStripes.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * UpButton[] = {
+static const char * const UpButton[] = {
 "48 48 1223 2",
 "  	c None",
 ". 	c #E7E7E7",

--- a/images/Aqua/UpButtonWhite.xpm
+++ b/images/Aqua/UpButtonWhite.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * UpButton[] = {
+static const char * const UpButton[] = {
 "48 48 1154 2",
 "  	c None",
 ". 	c #FFFFFF",

--- a/images/Arrow.xpm
+++ b/images/Arrow.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * arrow_xpm[] = {
+static const char * const arrow_xpm[] = {
 "9 16 3 1",
 "# c #000000", 
 "+ c #808080",

--- a/images/Arrow15x15.xpm
+++ b/images/Arrow15x15.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * arrow15x15_xpm[] = {
+static const char * const arrow15x15_xpm[] = {
 "15 15 24 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/AudacityLogo.xpm
+++ b/images/AudacityLogo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * AudacityLogo_xpm[] = {
+static const char * const AudacityLogo_xpm[] = {
 "215 190 2218 2",
 "  	c #FFFFFF",
 ". 	c #F4F4F9",

--- a/images/AudacityLogo48x48.xpm
+++ b/images/AudacityLogo48x48.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * AudacityLogo48x48_xpm[] = {
+static const char * const AudacityLogo48x48_xpm[] = {
 "48 48 665 2",
 "  	c #FFFFFF",
 ". 	c #FBFBFD",

--- a/images/AudacityLogoAlpha.xpm
+++ b/images/AudacityLogoAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * AudacityLogoAlpha_xpm[] = {
+static const char * const AudacityLogoAlpha_xpm[] = {
 "48 48 389 2",
 "  	c None",
 ". 	c #000092",

--- a/images/AudacityLogoWithName.xpm
+++ b/images/AudacityLogoWithName.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * AudacityLogoWithName_xpm[] = {
+static const char * const AudacityLogoWithName_xpm[] = {
 "506 200 8358 2",
 "  	c #FFFFFF",
 ". 	c #FFFFFE",

--- a/images/Checked.xpm
+++ b/images/Checked.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * checked_xpm[] = {
+static const char * const checked_xpm[] = {
 "15 15 70 1",
 " 	c #FFFFFF",
 ".	c #8E8F8F",

--- a/images/ControlButtons/Disabled.xpm
+++ b/images/ControlButtons/Disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Disabled[] = {
+static const char * const Disabled[] = {
 "27 27 52 1",
 " 	c None",
 ".	c #AAAAAA",

--- a/images/ControlButtons/Down.xpm
+++ b/images/ControlButtons/Down.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Down[] = {
+static const char * const Down[] = {
 "27 27 7 1",
 " 	c None",
 ".	c #424242",

--- a/images/ControlButtons/DownButton.xpm
+++ b/images/ControlButtons/DownButton.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * DownButton[] = {
+static const char * const DownButton[] = {
 "48 48 108 2",
 "  	c None",
 ". 	c #CCCCCC",

--- a/images/ControlButtons/Draw.xpm
+++ b/images/ControlButtons/Draw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Draw[] = {
+static const char * const Draw[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #D6D6D6",

--- a/images/ControlButtons/DrawAlpha.xpm
+++ b/images/ControlButtons/DrawAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * DrawAlpha[] = {
+static const char * const DrawAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/Envelope.xpm
+++ b/images/ControlButtons/Envelope.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Envelope[] = {
+static const char * const Envelope[] = {
 "27 27 5 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/ControlButtons/EnvelopeAlpha.xpm
+++ b/images/ControlButtons/EnvelopeAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * EnvelopeAlpha[] = {
+static const char * const EnvelopeAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/FFwd.xpm
+++ b/images/ControlButtons/FFwd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * FFwd[] = {
+static const char * const FFwd[] = {
 "16 16 79 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/FFwdAlpha.xpm
+++ b/images/ControlButtons/FFwdAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * FFwdAlpha[] = {
+static const char * const FFwdAlpha[] = {
 "16 16 13 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/FFwdDisabled.xpm
+++ b/images/ControlButtons/FFwdDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * FFwdDisabled[] = {
+static const char * const FFwdDisabled[] = {
 "16 16 61 1",
 " 	c None",
 ".	c #6B6B6B",

--- a/images/ControlButtons/Hilite.xpm
+++ b/images/ControlButtons/Hilite.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Hilite[] = {
+static const char * const Hilite[] = {
 "27 27 85 1",
 " 	c None",
 ".	c #FBFBFB",

--- a/images/ControlButtons/HiliteButton.xpm
+++ b/images/ControlButtons/HiliteButton.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * HiliteButton[] = {
+static const char * const HiliteButton[] = {
 "48 48 113 2",
 "  	c None",
 ". 	c #CCCCCC",

--- a/images/ControlButtons/IBeam.xpm
+++ b/images/ControlButtons/IBeam.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * IBeam[] = {
+static const char * const IBeam[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/ControlButtons/IBeamAlpha.xpm
+++ b/images/ControlButtons/IBeamAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * IBeamAlpha[] = {
+static const char * const IBeamAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/Loop.xpm
+++ b/images/ControlButtons/Loop.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * Loop[] = {
+static const char * const Loop[] = {
 "16 16 6 1",
 " 	c None",
 ".	c #1B1B1B",

--- a/images/ControlButtons/LoopAlpha.xpm
+++ b/images/ControlButtons/LoopAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * LoopAlpha[] = {
+static const char * const LoopAlpha[] = {
 "16 16 11 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/LoopDisabled.xpm
+++ b/images/ControlButtons/LoopDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * LoopDisabled[] = {
+static const char * const LoopDisabled[] = {
 "16 16 3 1",
 " 	c None",
 ".	c #1B1B1B",

--- a/images/ControlButtons/Multi.xpm
+++ b/images/ControlButtons/Multi.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Multi[] = {
+static const char * const Multi[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 3 1",
 ". c #FFFFFF",

--- a/images/ControlButtons/MultiAlpha.xpm
+++ b/images/ControlButtons/MultiAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * MultiAlpha[] = {
+static const char * const MultiAlpha[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 2 1",
 ". c #000000",

--- a/images/ControlButtons/Pause.xpm
+++ b/images/ControlButtons/Pause.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Pause[] = {
+static const char * const Pause[] = {
 "16 16 79 1",
 " 	c None",
 ".	c #F5F5F5",

--- a/images/ControlButtons/PauseAlpha.xpm
+++ b/images/ControlButtons/PauseAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * PauseAlpha[] = {
+static const char * const PauseAlpha[] = {
 "16 16 29 1",
 " 	c None",
 ".	c #010101",

--- a/images/ControlButtons/PauseDisabled.xpm
+++ b/images/ControlButtons/PauseDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * PauseDisabled[] = {
+static const char * const PauseDisabled[] = {
 "16 16 53 1",
 " 	c None",
 ".	c #8D8D8D",

--- a/images/ControlButtons/Play.xpm
+++ b/images/ControlButtons/Play.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Play[] = {
+static const char * const Play[] = {
 "16 16 70 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/PlayAlpha.xpm
+++ b/images/ControlButtons/PlayAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * PlayAlpha[] = {
+static const char * const PlayAlpha[] = {
 "16 16 24 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/PlayDisabled.xpm
+++ b/images/ControlButtons/PlayDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * PlayDisabled[] = {
+static const char * const PlayDisabled[] = {
 "16 16 48 1",
 " 	c None",
 ".	c #6B6B6B",

--- a/images/ControlButtons/Record.xpm
+++ b/images/ControlButtons/Record.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Record[] = {
+static const char * const Record[] = {
 "16 16 82 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/RecordAlpha.xpm
+++ b/images/ControlButtons/RecordAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * RecordAlpha[] = {
+static const char * const RecordAlpha[] = {
 "16 16 28 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/RecordDisabled.xpm
+++ b/images/ControlButtons/RecordDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * RecordDisabled[] = {
+static const char * const RecordDisabled[] = {
 "16 16 50 1",
 " 	c None",
 ".	c #6B6B6B",

--- a/images/ControlButtons/Rewind.xpm
+++ b/images/ControlButtons/Rewind.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Rewind[] = {
+static const char * const Rewind[] = {
 "16 16 82 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/RewindAlpha.xpm
+++ b/images/ControlButtons/RewindAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * RewindAlpha[] = {
+static const char * const RewindAlpha[] = {
 "16 16 13 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/RewindDisabled.xpm
+++ b/images/ControlButtons/RewindDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * RewindDisabled[] = {
+static const char * const RewindDisabled[] = {
 "16 16 63 1",
 " 	c None",
 ".	c #6B6B6B",

--- a/images/ControlButtons/Slider.xpm
+++ b/images/ControlButtons/Slider.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Slider[] = {
+static const char * const Slider[] = {
 /* columns rows colors chars-per-pixel */
 "100 28 60 1",
 "  c #9d9c9a",

--- a/images/ControlButtons/SliderThumb.xpm
+++ b/images/ControlButtons/SliderThumb.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *SliderThumb[] = {
+static const char * const SliderThumb[] = {
 /* columns rows colors chars-per-pixel */
 "10 28 4 1",
 "  c #9a9997",

--- a/images/ControlButtons/Stop.xpm
+++ b/images/ControlButtons/Stop.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Stop[] = {
+static const char * const Stop[] = {
 "16 16 31 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/StopAlpha.xpm
+++ b/images/ControlButtons/StopAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * StopAlpha[] = {
+static const char * const StopAlpha[] = {
 "16 16 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/StopDisabled.xpm
+++ b/images/ControlButtons/StopDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * StopDisabled[] = {
+static const char * const StopDisabled[] = {
 "16 16 26 1",
 " 	c None",
 ".	c #737373",

--- a/images/ControlButtons/TimeShift.xpm
+++ b/images/ControlButtons/TimeShift.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * TimeShift[] = {
+static const char * const TimeShift[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/ControlButtons/TimeShiftAlpha.xpm
+++ b/images/ControlButtons/TimeShiftAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * TimeShiftAlpha[] = {
+static const char * const TimeShiftAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/ControlButtons/Up.xpm
+++ b/images/ControlButtons/Up.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Up[] = {
+static const char * const Up[] = {
 "27 27 15 1",
 " 	c None",
 ".	c #FBFBFB",

--- a/images/ControlButtons/UpButton.xpm
+++ b/images/ControlButtons/UpButton.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * UpButton[] = {
+static const char * const UpButton[] = {
 "48 48 108 2",
 "  	c None",
 ". 	c #CCCCCC",

--- a/images/ControlButtons/Zoom.xpm
+++ b/images/ControlButtons/Zoom.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Zoom[] = {
+static const char * const Zoom[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/ControlButtons/ZoomAlpha.xpm
+++ b/images/ControlButtons/ZoomAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomAlpha[] = {
+static const char * const ZoomAlpha[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #000000",

--- a/images/Cursors.h
+++ b/images/Cursors.h
@@ -54,4 +54,4 @@
 
 #endif
 
-std::unique_ptr<wxCursor> MakeCursor(int WXUNUSED(CursorId), const char * pXpm[36], int HotX, int HotY);
+std::unique_ptr<wxCursor> MakeCursor(int WXUNUSED(CursorId), const char * const pXpm[36], int HotX, int HotY);

--- a/images/Cursors16/BandWidthCursor.xpm
+++ b/images/Cursors16/BandWidthCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * BandWidthCursorXpm[] = {
+static const char * const BandWidthCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/BottomFrequencyCursor.xpm
+++ b/images/Cursors16/BottomFrequencyCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * BottomFrequencyCursorXpm[] = {
+static const char * const BottomFrequencyCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/DisabledCursor.xpm
+++ b/images/Cursors16/DisabledCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * DisabledCursorXpm[] = {
+static const char * const DisabledCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/DrawCursor.xpm
+++ b/images/Cursors16/DrawCursor.xpm
@@ -1,6 +1,6 @@
 /* XPM */
 //Image of a pencil.
-static const char * DrawCursorXpm[] = {
+static const char * const DrawCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/EnvCursor.xpm
+++ b/images/Cursors16/EnvCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * EnvCursorXpm[] = {
+static const char * const EnvCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/IBeamCursor.xpm
+++ b/images/Cursors16/IBeamCursor.xpm
@@ -1,7 +1,7 @@
 /* XPM */
 // Classic optical illusion.
 // the beam looks taller than the arrow.
-static const char * IBeamCursorXpm[] = {
+static const char * const IBeamCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/LabelCursorLeft.xpm
+++ b/images/Cursors16/LabelCursorLeft.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * LabelCursorLeftXpm[] = {
+static const char * const LabelCursorLeftXpm[] = {
 "16 16 4 1",
 " 	c None",
 ".	c #FF0000",

--- a/images/Cursors16/LabelCursorRight.xpm
+++ b/images/Cursors16/LabelCursorRight.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * LabelCursorRightXpm[] = {
+static const char * const LabelCursorRightXpm[] = {
 "16 16 4 1",
 " 	c None",
 ".	c #FF0000",

--- a/images/Cursors16/StretchCursor.xpm
+++ b/images/Cursors16/StretchCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * StretchCursorXpm[] = {
+static const char * const StretchCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/StretchLeftCursor.xpm
+++ b/images/Cursors16/StretchLeftCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * StretchLeftCursorXpm[] = {
+static const char * const StretchLeftCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/StretchRightCursor.xpm
+++ b/images/Cursors16/StretchRightCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * StretchRightCursorXpm[] = {
+static const char * const StretchRightCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/TimeCursor.xpm
+++ b/images/Cursors16/TimeCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * TimeCursorXpm[] = {
+static const char * const TimeCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/TopFrequencyCursor.xpm
+++ b/images/Cursors16/TopFrequencyCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * TopFrequencyCursorXpm[] = {
+static const char * const TopFrequencyCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/ZoomInCursor.xpm
+++ b/images/Cursors16/ZoomInCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomInCursorXpm[] = {
+static const char * const ZoomInCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors16/ZoomOutCursor.xpm
+++ b/images/Cursors16/ZoomOutCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomOutCursorXpm[] = {
+static const char * const ZoomOutCursorXpm[] = {
 "16 16 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/BandWidthCursor.xpm
+++ b/images/Cursors32/BandWidthCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * BandWidthCursorXpm[] = {
+static const char * const BandWidthCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/BottomFrequencyCursor.xpm
+++ b/images/Cursors32/BottomFrequencyCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * BottomFrequencyCursorXpm[] = {
+static const char * const BottomFrequencyCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/DisabledCursor.xpm
+++ b/images/Cursors32/DisabledCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * DisabledCursorXpm[] = {
+static const char * const DisabledCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/DrawCursor.xpm
+++ b/images/Cursors32/DrawCursor.xpm
@@ -1,6 +1,6 @@
 /* XPM */
 //Image of a pencil.
-static const char * DrawCursorXpm[] = {
+static const char * const DrawCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/EnvCursor.xpm
+++ b/images/Cursors32/EnvCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * EnvCursorXpm[] = {
+static const char * const EnvCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/IBeamCursor.xpm
+++ b/images/Cursors32/IBeamCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * IBeamCursorXpm[] = {
+static const char * const IBeamCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/LabelCursorLeft.xpm
+++ b/images/Cursors32/LabelCursorLeft.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * LabelCursorLeftXpm[] = {
+static const char * const LabelCursorLeftXpm[] = {
 "32 32 4 1",
 " 	c None",
 ".	c #FF0000",

--- a/images/Cursors32/LabelCursorRight.xpm
+++ b/images/Cursors32/LabelCursorRight.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * LabelCursorRightXpm[] = {
+static const char * const LabelCursorRightXpm[] = {
 "32 32 4 1",
 " 	c None",
 ".	c #FF0000",

--- a/images/Cursors32/StretchCursor.xpm
+++ b/images/Cursors32/StretchCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * StretchCursorXpm[] = {
+static const char * const StretchCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/StretchLeftCursor.xpm
+++ b/images/Cursors32/StretchLeftCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * StretchLeftCursorXpm[] = {
+static const char * const StretchLeftCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/StretchRightCursor.xpm
+++ b/images/Cursors32/StretchRightCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * StretchRightCursorXpm[] = {
+static const char * const StretchRightCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/TimeCursor.xpm
+++ b/images/Cursors32/TimeCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * TimeCursorXpm[] = {
+static const char * const TimeCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/TopFrequencyCursor.xpm
+++ b/images/Cursors32/TopFrequencyCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * TopFrequencyCursorXpm[] = {
+static const char * const TopFrequencyCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/Cursors32/ZoomInCursor.xpm
+++ b/images/Cursors32/ZoomInCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomInCursorXpm[] = {
+static const char * const ZoomInCursorXpm[] = {
 "32 32 3 1",
 "+	c #FFFFFF",
 ".	c #FF0000", // mask color = RGB:255,0,0

--- a/images/Cursors32/ZoomOutCursor.xpm
+++ b/images/Cursors32/ZoomOutCursor.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomOutCursorXpm[] = {
+static const char * const ZoomOutCursorXpm[] = {
 "32 32 3 1",
 ".	c #FF0000", // mask color = RGB:255,0,0
 "#	c #000000",

--- a/images/DarkAudacityLogoWithName.xpm
+++ b/images/DarkAudacityLogoWithName.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static char * AudacityLogoWithName_xpm[] = {
+static char const * const AudacityLogoWithName_xpm[] = {
 "629 200 21 1",
 " 	c None",
 ".	c #ADADAD",

--- a/images/EditButtons/Copy.xpm
+++ b/images/EditButtons/Copy.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Copy[] = {
+static const char * const const Copy[] = {
 "26 24 11 1",
 " 	c None",
 ".	c #CCCCCC",

--- a/images/EditButtons/CopyAlpha.xpm
+++ b/images/EditButtons/CopyAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * CopyAlpha[] = {
+static const char * const CopyAlpha[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/CopyDisabled.xpm
+++ b/images/EditButtons/CopyDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * CopyDisabled[] = {
+static const char * const CopyDisabled[] = {
 "26 24 11 1",
 " 	c None",
 ".	c #A8A8A8",

--- a/images/EditButtons/Cut.xpm
+++ b/images/EditButtons/Cut.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Cut[] = {
+static const char * const Cut[] = {
 "26 24 6 1",
 " 	c None",
 ".	c #808080",

--- a/images/EditButtons/CutAlpha.xpm
+++ b/images/EditButtons/CutAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * CutAlpha[] = {
+static const char * const CutAlpha[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/CutDisabled.xpm
+++ b/images/EditButtons/CutDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * CutDisabled[] = {
+static const char * const CutDisabled[] = {
 "26 24 6 1",
 " 	c None",
 ".	c #919191",

--- a/images/EditButtons/Disabled.xpm
+++ b/images/EditButtons/Disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Disabled[] = {
+static const char * const Disabled[] = {
 "48 48 165 2",
 "  	c None",
 ". 	c #CACACA",

--- a/images/EditButtons/Down.xpm
+++ b/images/EditButtons/Down.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Down[] = {
+static const char * const Down[] = {
 "27 27 27 1",
 " 	c None",
 ".	c #3B3B3B",

--- a/images/EditButtons/Effects.xpm
+++ b/images/EditButtons/Effects.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Effects_xpm[] = {
+static const char * const Effects_xpm[] = {
 "26 24 78 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/EditButtons/Hilite.xpm
+++ b/images/EditButtons/Hilite.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Hilite[] = {
+static const char * const Hilite[] = {
 "27 27 85 1",
 " 	c None",
 ".	c #FBFBFB",

--- a/images/EditButtons/Paste.xpm
+++ b/images/EditButtons/Paste.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Paste[] = {
+static const char * const Paste[] = {
 "26 24 14 1",
 " 	c None",
 ".	c #222222",

--- a/images/EditButtons/PasteAlpha.xpm
+++ b/images/EditButtons/PasteAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * PasteAlpha[] = {
+static const char * const PasteAlpha[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/PasteDisabled.xpm
+++ b/images/EditButtons/PasteDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * PasteDisabled[] = {
+static const char * const PasteDisabled[] = {
 "26 24 14 1",
 " 	c None",
 ".	c #757575",

--- a/images/EditButtons/Redo.xpm
+++ b/images/EditButtons/Redo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * Redo[] = {
+static const char * const Redo[] = {
 "26 24 4 1",
 " 	c None",
 ".	c #686868",

--- a/images/EditButtons/RedoAlpha.xpm
+++ b/images/EditButtons/RedoAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * RedoAlpha[] = {
+static const char * const RedoAlpha[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/RedoDisabled.xpm
+++ b/images/EditButtons/RedoDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * RedoDisabled[] = {
+static const char * const RedoDisabled[] = {
 "26 24 4 1",
 " 	c None",
 ".	c #A8A8A8",

--- a/images/EditButtons/Silence.xpm
+++ b/images/EditButtons/Silence.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * Silence[] = {
+static const char * const Silence[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/SilenceAlpha.xpm
+++ b/images/EditButtons/SilenceAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SilenceAlpha[] = {
+static const char * const SilenceAlpha[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/SilenceDisabled.xpm
+++ b/images/EditButtons/SilenceDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SilenceDisabled[] = {
+static const char * const SilenceDisabled[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #6B6B6B",

--- a/images/EditButtons/Trim.xpm
+++ b/images/EditButtons/Trim.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * Trim[] = {
+static const char * const Trim[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/TrimAlpha.xpm
+++ b/images/EditButtons/TrimAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * TrimAlpha[] = {
+static const char * const TrimAlpha[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/TrimDisabled.xpm
+++ b/images/EditButtons/TrimDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * TrimDisabled[] = {
+static const char * const TrimDisabled[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #6B6B6B",

--- a/images/EditButtons/Undo.xpm
+++ b/images/EditButtons/Undo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * Undo[] = {
+static const char * const Undo[] = {
 "26 24 4 1",
 " 	c None",
 ".	c #222222",

--- a/images/EditButtons/UndoAlpha.xpm
+++ b/images/EditButtons/UndoAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * UndoAlpha[] = {
+static const char * const UndoAlpha[] = {
 "26 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/UndoDisabled.xpm
+++ b/images/EditButtons/UndoDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * UndoDisabled[] = {
+static const char * const UndoDisabled[] = {
 "26 24 4 1",
 " 	c None",
 ".	c #757575",

--- a/images/EditButtons/Up.xpm
+++ b/images/EditButtons/Up.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Up[] = {
+static const char * const Up[] = {
 "27 27 15 1",
 " 	c None",
 ".	c #FBFBFB",

--- a/images/EditButtons/ZoomFit.xpm
+++ b/images/EditButtons/ZoomFit.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomFit[] = {
+static const char * const ZoomFit[] = {
 "27 27 7 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/EditButtons/ZoomFitAlpha.xpm
+++ b/images/EditButtons/ZoomFitAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomFitAlpha[] = {
+static const char * const ZoomFitAlpha[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/ZoomFitDisabled.xpm
+++ b/images/EditButtons/ZoomFitDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomFitDisabled[] = {
+static const char * const ZoomFitDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #A8A8A8",

--- a/images/EditButtons/ZoomIn.xpm
+++ b/images/EditButtons/ZoomIn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomIn[] = {
+static const char * const ZoomIn[] = {
 "27 27 7 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/EditButtons/ZoomInAlpha.xpm
+++ b/images/EditButtons/ZoomInAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomInAlpha[] = {
+static const char * const ZoomInAlpha[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/ZoomInDisabled.xpm
+++ b/images/EditButtons/ZoomInDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomInDisabled[] = {
+static const char * const ZoomInDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #A8A8A8",

--- a/images/EditButtons/ZoomOut.xpm
+++ b/images/EditButtons/ZoomOut.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomOut[] = {
+static const char * const ZoomOut[] = {
 "27 27 7 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/EditButtons/ZoomOutAlpha.xpm
+++ b/images/EditButtons/ZoomOutAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomOutAlpha[] = {
+static const char * const ZoomOutAlpha[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/ZoomOutDisabled.xpm
+++ b/images/EditButtons/ZoomOutDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomOutDisabled[] = {
+static const char * const ZoomOutDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #A8A8A8",

--- a/images/EditButtons/ZoomSel.xpm
+++ b/images/EditButtons/ZoomSel.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomSel[] = {
+static const char * const ZoomSel[] = {
 "27 27 7 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/EditButtons/ZoomSelAlpha.xpm
+++ b/images/EditButtons/ZoomSelAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomSelAlpha[] = {
+static const char * const ZoomSelAlpha[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/ZoomSelDisabled.xpm
+++ b/images/EditButtons/ZoomSelDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomSelDisabled[] = {
+static const char * const ZoomSelDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #A8A8A8",

--- a/images/EditButtons/ZoomToggle.xpm
+++ b/images/EditButtons/ZoomToggle.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomToggle[] = {
+static const char * const ZoomToggle[] = {
 "27 27 7 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/EditButtons/ZoomToggleAlpha.xpm
+++ b/images/EditButtons/ZoomToggleAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomToggleAlpha[] = {
+static const char * const ZoomToggleAlpha[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #000000",

--- a/images/EditButtons/ZoomToggleDisabled.xpm
+++ b/images/EditButtons/ZoomToggleDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomToggleDisabled[] = {
+static const char * const ZoomToggleDisabled[] = {
 "27 27 7 1",
 " 	c None",
 ".	c #A8A8A8",

--- a/images/Effect.h
+++ b/images/Effect.h
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * effect_menu_xpm[] = {
+static const char * const effect_menu_xpm[] = {
 "16 16 2 1",
 " 	c None",
 ".	c #000000",
@@ -21,7 +21,7 @@ static const char * effect_menu_xpm[] = {
 "                "};
 
 /* XPM */
-static const char * effect_play_xpm[] = {
+static const char * const effect_play_xpm[] = {
 "16 16 70 1",
 " 	c None",
 ".	c #000000",
@@ -111,7 +111,7 @@ static const char * effect_play_xpm[] = {
 " CDE            "};
 
 /* XPM */
-static const char * effect_stop_xpm[] = {
+static const char * const effect_stop_xpm[] = {
 "16 16 31 1",
 " 	c None",
 ".	c #000000",
@@ -162,7 +162,7 @@ static const char * effect_stop_xpm[] = {
 "                "};
 
 /* XPM */
-static const char * effect_rewind_xpm[] = {
+static const char * const effect_rewind_xpm[] = {
 "16 16 82 1",
 " 	c None",
 ".	c #000000",
@@ -263,7 +263,7 @@ static const char * effect_rewind_xpm[] = {
 "        PQ   PQ ",
 "                "};
 /* XPM */
-static const char * effect_ffwd_xpm[] = {
+static const char * const effect_ffwd_xpm[] = {
 "16 16 79 1",
 " 	c None",
 ".	c #000000",
@@ -362,7 +362,7 @@ static const char * effect_ffwd_xpm[] = {
 "                "};
 
 /* XPM */
-static const char * effect_play_disabled_xpm[] = {
+static const char * const effect_play_disabled_xpm[] = {
 "16 16 48 1",
 " 	c None",
 ".	c #6B6B6B",
@@ -430,7 +430,7 @@ static const char * effect_play_disabled_xpm[] = {
 " ((_            "};
 
 /* XPM */
-static const char * effect_stop_disabled_xpm[] = {
+static const char * const effect_stop_disabled_xpm[] = {
 "16 16 26 1",
 " 	c None",
 ".	c #737373",
@@ -476,7 +476,7 @@ static const char * effect_stop_disabled_xpm[] = {
 "                "};
 
 /* XPM */
-static const char * effect_rewind_disabled_xpm[] = {
+static const char * const effect_rewind_disabled_xpm[] = {
 "16 16 63 1",
 " 	c None",
 ".	c #6B6B6B",
@@ -559,7 +559,7 @@ static const char * effect_rewind_disabled_xpm[] = {
 "                "};
 
 /* XPM */
-static const char * effect_ffwd_disabled_xpm[] = {
+static const char * const effect_ffwd_disabled_xpm[] = {
 "16 16 61 1",
 " 	c None",
 ".	c #6B6B6B",

--- a/images/EffectRack/down-9x16.xpm
+++ b/images/EffectRack/down-9x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *down_9x16_xpm[] = {
+static const char * const down_9x16_xpm[] = {
 "9 16 2 1",
 " 	c None",
 ".	c #000000",

--- a/images/EffectRack/fav-down-16x16.xpm
+++ b/images/EffectRack/fav-down-16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *fav_down_16x16_xpm[] = {
+static const char * const fav_down_16x16_xpm[] = {
 "16 16 2 1",
 " 	c None",
 ".	c #000000",

--- a/images/EffectRack/fav-up-16x16.xpm
+++ b/images/EffectRack/fav-up-16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *fav_up_16x16_xpm[] = {
+static const char * const fav_up_16x16_xpm[] = {
 "16 16 2 1",
 " 	c None",
 ".	c #000000",

--- a/images/EffectRack/power-off-16x16.xpm
+++ b/images/EffectRack/power-off-16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *power_off_16x16_xpm[] = {
+static const char * const power_off_16x16_xpm[] = {
 "16 16 4 1",
 " 	c None",
 "a c #FF0000",

--- a/images/EffectRack/power-on-16x16.xpm
+++ b/images/EffectRack/power-on-16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *power_on_16x16_xpm[] = {
+static const char * const power_on_16x16_xpm[] = {
 "16 16 4 1",
 " 	c None",
 "a c #00FF00",

--- a/images/EffectRack/remove-16x16.xpm
+++ b/images/EffectRack/remove-16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *remove_16x16_xpm[] = {
+static const char * const remove_16x16_xpm[] = {
 "16 16 2 1",
 " 	c None",
 ".	c #FF0000",

--- a/images/EffectRack/settings-down-16x16.xpm
+++ b/images/EffectRack/settings-down-16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *settings_down_16x16_xpm[] = {
+static const char * const settings_down_16x16_xpm[] = {
 "16 16 3 1",
 " 	c None",
 ".	c #020202",

--- a/images/EffectRack/settings-up-16x16.xpm
+++ b/images/EffectRack/settings-up-16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *settings_up_16x16_xpm[] = {
+static const char * const settings_up_16x16_xpm[] = {
 "16 16 3 1",
 " 	c None",
 ".	c #020202",

--- a/images/EffectRack/up-9x16.xpm
+++ b/images/EffectRack/up-9x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *up_9x16_xpm[] = {
+static const char * const up_9x16_xpm[] = {
 "9 16 2 1",
 " 	c None",
 ".	c #000000",

--- a/images/Empty9x16.xpm
+++ b/images/Empty9x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * empty9x16_xpm[] = {
+static const char * const empty9x16_xpm[] = {
 "9 16 2 1",
 "# c #000000", 
 ". c #FFFFFF", 

--- a/images/ExpandingToolBar/ToolBarGrabber.xpm
+++ b/images/ExpandingToolBar/ToolBarGrabber.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ToolBarGrabber[] = {
+static const char * const ToolBarGrabber[] = {
 /* columns rows colors chars-per-pixel */
 "17 8 6 1",
 "  c cyan",

--- a/images/ExpandingToolBar/ToolBarTarget.xpm
+++ b/images/ExpandingToolBar/ToolBarTarget.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ToolBarTarget[] = {
+static const char * const ToolBarTarget[] = {
 /* columns rows colors chars-per-pixel */
 "17 26 3 1",
 "  c cyan",

--- a/images/ExpandingToolBar/ToolBarToggle.xpm
+++ b/images/ExpandingToolBar/ToolBarToggle.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ToolBarToggle[] = {
+static const char * const ToolBarToggle[] = {
 /* columns rows colors chars-per-pixel */
 "43 35 14 1",
 "  c #777777",

--- a/images/GlyphImages.h
+++ b/images/GlyphImages.h
@@ -1,4 +1,4 @@
-static const char *Glyph0[] = {
+static const char * const Glyph0[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -34,7 +34,7 @@ static const char *Glyph0[] = {
 "..............."
 };
 
-static const char *Glyph1[] = {
+static const char * const Glyph1[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -70,7 +70,7 @@ static const char *Glyph1[] = {
 "..............."
 };
 
-static const char *Glyph2[] = {
+static const char * const Glyph2[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -106,7 +106,7 @@ static const char *Glyph2[] = {
 "..............."
 };
 
-static const char *Glyph3[] = {
+static const char * const Glyph3[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -142,7 +142,7 @@ static const char *Glyph3[] = {
 "..............."
 };
 
-static const char *Glyph4[] = {
+static const char * const Glyph4[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -178,7 +178,7 @@ static const char *Glyph4[] = {
 "..............."
 };
 
-static const char *Glyph5[] = {
+static const char * const Glyph5[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -215,7 +215,7 @@ static const char *Glyph5[] = {
 };
 
 
-static const char *Glyph6[] = {
+static const char * const Glyph6[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -251,7 +251,7 @@ static const char *Glyph6[] = {
 "..............."
 };
 
-static const char *Glyph7[] = {
+static const char * const Glyph7[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -287,7 +287,7 @@ static const char *Glyph7[] = {
 "..............."
 };
 
-static const char *Glyph8[] = {
+static const char * const Glyph8[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -324,7 +324,7 @@ static const char *Glyph8[] = {
 };
 
 
-static const char *Glyph9[] = {
+static const char * const Glyph9[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -360,7 +360,7 @@ static const char *Glyph9[] = {
 "..............."
 };
 
-static const char *Glyph10[] = {
+static const char * const Glyph10[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",
@@ -396,7 +396,7 @@ static const char *Glyph10[] = {
 "..............."
 };
 
-static const char *Glyph11[] = {
+static const char * const Glyph11[] = {
 /* columns rows colors const chars-per-pixel */
 "15 23 7 1",
 ". c none",

--- a/images/Help.xpm
+++ b/images/Help.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * Help_xpm[] = {
+static const char * const Help_xpm[] = {
 "21 21 31 1",
 " 	c None",
 ".	c #6699FF",

--- a/images/MicMenu.xpm
+++ b/images/MicMenu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * MicMenu_xpm[] = {
+static const char * const MicMenu_xpm[] = {
 "24 19 18 1",
 " 	c None",
 ".	c #000000",
@@ -40,7 +40,7 @@ static const char * MicMenu_xpm[] = {
 ".                   .   "};
 
 /* XPM */
-static const char * MicMenuNarrow_xpm[] = {
+static const char * const MicMenuNarrow_xpm[] = {
 "19 19 18 1",
 " 	c None",
 ".	c #000000",

--- a/images/MixerImages/Mic.xpm
+++ b/images/MixerImages/Mic.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Mic[] = {
+static const char * const Mic[] = {
 "25 25 19 1",
 " 	c None",
 ".	c #DEDEDE",

--- a/images/MixerImages/MicAlpha.xpm
+++ b/images/MixerImages/MicAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * MicAlpha[] = {
+static const char * const MicAlpha[] = {
 "25 25 2 1",
 ".	c #000000",
 "#	c #FFFFFF",

--- a/images/MixerImages/Speaker.xpm
+++ b/images/MixerImages/Speaker.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Speaker[] = {
+static const char * const Speaker[] = {
 "25 25 17 1",
 " 	c None",
 ".	c #DEDEDE",

--- a/images/MixerImages/SpeakerAlpha.xpm
+++ b/images/MixerImages/SpeakerAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * SpeakerAlpha[] = {
+static const char * const SpeakerAlpha[] = {
 "25 25 2 1",
 ".	c #000000",
 "#	c #FFFFFF",

--- a/images/MusicalInstruments/_default_instrument.xpm
+++ b/images/MusicalInstruments/_default_instrument.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * _default_instrument_xpm[] = {
+static const char * const _default_instrument_xpm[] = {
 "48 48 555 2",
 "  	c #969696",
 ". 	c #939395",

--- a/images/MusicalInstruments/acoustic_guitar_gtr.xpm
+++ b/images/MusicalInstruments/acoustic_guitar_gtr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * acoustic_guitar_gtr_xpm[] = {
+static const char * const acoustic_guitar_gtr_xpm[] = {
 "48 48 935 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/acoustic_piano_pno.xpm
+++ b/images/MusicalInstruments/acoustic_piano_pno.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * acoustic_piano_pno_xpm[] = {
+static const char * const acoustic_piano_pno_xpm[] = {
 "48 48 750 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/back_vocal_bg_vox.xpm
+++ b/images/MusicalInstruments/back_vocal_bg_vox.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * back_vocal_bg_vox_xpm[] = {
+static const char * const back_vocal_bg_vox_xpm[] = {
 "48 48 530 2",
 "  	c #969696",
 ". 	c #636A71",

--- a/images/MusicalInstruments/clap.xpm
+++ b/images/MusicalInstruments/clap.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * clap_xpm[] = {
+static const char * const clap_xpm[] = {
 "48 48 587 2",
 "  	c #969696",
 ". 	c #57575F",

--- a/images/MusicalInstruments/drums_dr.xpm
+++ b/images/MusicalInstruments/drums_dr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * drums_dr_xpm[] = {
+static const char * const drums_dr_xpm[] = {
 "48 48 828 2",
 "  	c #969696",
 ". 	c #707477",

--- a/images/MusicalInstruments/electric_bass_guitar_bs_gtr.xpm
+++ b/images/MusicalInstruments/electric_bass_guitar_bs_gtr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * electric_bass_guitar_bs_gtr_xpm[] = {
+static const char * const electric_bass_guitar_bs_gtr_xpm[] = {
 "48 48 866 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/electric_guitar_gtr.xpm
+++ b/images/MusicalInstruments/electric_guitar_gtr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * electric_guitar_gtr_xpm[] = {
+static const char * const electric_guitar_gtr_xpm[] = {
 "48 48 1042 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/electric_piano_pno_key.xpm
+++ b/images/MusicalInstruments/electric_piano_pno_key.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * electric_piano_pno_key_xpm[] = {
+static const char * const electric_piano_pno_key_xpm[] = {
 "48 48 862 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/kick.xpm
+++ b/images/MusicalInstruments/kick.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * kick_xpm[] = {
+static const char * const kick_xpm[] = {
 "48 48 256 2",
 "  	c #FFFFFF",
 ". 	c #636363",

--- a/images/MusicalInstruments/loop.xpm
+++ b/images/MusicalInstruments/loop.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * loop_xpm[] = {
+static const char * const loop_xpm[] = {
 "48 48 958 2",
 "  	c #969696",
 ". 	c #6E4137",

--- a/images/MusicalInstruments/organ_org.xpm
+++ b/images/MusicalInstruments/organ_org.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * organ_org_xpm[] = {
+static const char * const organ_org_xpm[] = {
 "48 48 862 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/perc.xpm
+++ b/images/MusicalInstruments/perc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * perc_xpm[] = {
+static const char * const perc_xpm[] = {
 "48 48 370 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/sax.xpm
+++ b/images/MusicalInstruments/sax.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * sax_xpm[] = {
+static const char * const sax_xpm[] = {
 "48 48 459 2",
 "  	c #969696",
 ". 	c #75797D",

--- a/images/MusicalInstruments/snare.xpm
+++ b/images/MusicalInstruments/snare.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * snare_xpm[] = {
+static const char * const snare_xpm[] = {
 "48 48 1369 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/string_violin_cello.xpm
+++ b/images/MusicalInstruments/string_violin_cello.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * string_violin_cello_xpm[] = {
+static const char * const string_violin_cello_xpm[] = {
 "48 48 599 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/synth.xpm
+++ b/images/MusicalInstruments/synth.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * synth_xpm[] = {
+static const char * const synth_xpm[] = {
 "48 48 363 2",
 "  	c None",
 ". 	c #969696",

--- a/images/MusicalInstruments/tambo.xpm
+++ b/images/MusicalInstruments/tambo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * tambo_xpm[] = {
+static const char * const tambo_xpm[] = {
 "48 48 1133 2",
 "  	c #969696",
 ". 	c #7F8285",

--- a/images/MusicalInstruments/trumpet_horn.xpm
+++ b/images/MusicalInstruments/trumpet_horn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * trumpet_horn_xpm[] = {
+static const char * const trumpet_horn_xpm[] = {
 "48 48 46 1",
 " 	c #969696",
 ".	c #C7A179",

--- a/images/MusicalInstruments/turntable.xpm
+++ b/images/MusicalInstruments/turntable.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * turntable_xpm[] = {
+static const char * const turntable_xpm[] = {
 "48 48 685 2",
 "  	c #969696",
 ". 	c #6A6D70",

--- a/images/MusicalInstruments/vibraphone_vibes.xpm
+++ b/images/MusicalInstruments/vibraphone_vibes.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * vibraphone_vibes_xpm[] = {
+static const char * const vibraphone_vibes_xpm[] = {
 "48 48 714 2",
 "  	c #969696",
 ". 	c #444E59",

--- a/images/MusicalInstruments/vocal_vox.xpm
+++ b/images/MusicalInstruments/vocal_vox.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * vocal_vox_xpm[] = {
+static const char * const vocal_vox_xpm[] = {
 "48 48 699 2",
 "  	c #969696",
 ". 	c #55575C",

--- a/images/PostfishButtons.h
+++ b/images/PostfishButtons.h
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * bar_home_xpm[] = {
+static const char * const bar_home_xpm[] = {
 "19 17 33 1",
 " 	c None",
 ".	c #020202",
@@ -52,7 +52,7 @@ static const char * bar_home_xpm[] = {
 "#*;;*#  >'4*@ >'4*#",
 " #11#    @1#   @1# "};
 /* XPM */
-static const char * bar_bb_xpm[] = {
+static const char * const bar_bb_xpm[] = {
 "17 17 33 1",
 " 	c None",
 ".	c #020202",
@@ -105,7 +105,7 @@ static const char * bar_bb_xpm[] = {
 "      >'4*@ >'4*#",
 "       @1#   @1# "};
 /* XPM */
-static const char * bar_b_xpm[] = {
+static const char * const bar_b_xpm[] = {
 "18 17 33 1",
 " 	c None",
 ".	c #020202",
@@ -158,7 +158,7 @@ static const char * bar_b_xpm[] = {
 "           @2';;*#",
 "             @~1# "};
 /* XPM */
-static const char * bar_p_xpm[] = {
+static const char * const bar_p_xpm[] = {
 "29 17 33 1",
 " 	c None",
 ".	c #020202",
@@ -211,7 +211,7 @@ static const char * bar_p_xpm[] = {
 "#*;;'2@        #1~~~~~~~~~~# ",
 " #1~@                        "};
 /* XPM */
-static const char * bar_f_xpm[] = {
+static const char * const bar_f_xpm[] = {
 "18 17 33 1",
 " 	c None",
 ".	c #020202",
@@ -264,7 +264,7 @@ static const char * bar_f_xpm[] = {
 "#*;;'2@           ",
 " #1~@             "};
 /* XPM */
-static const char * bar_ff_xpm[] = {
+static const char * const bar_ff_xpm[] = {
 "17 17 33 1",
 " 	c None",
 ".	c #020202",
@@ -317,7 +317,7 @@ static const char * bar_ff_xpm[] = {
 "#*4'> @*4'>      ",
 " #1@   #1@       "};
 /* XPM */
-static const char * bar_end_xpm[] = {
+static const char * const bar_end_xpm[] = {
 "19 17 30 1",
 " 	c None",
 ".	c #6682CE",
@@ -367,7 +367,7 @@ static const char * bar_end_xpm[] = {
 ".#$%& @#$%&  .#**#.",
 " .+@   .+@    .++. "};
 /* XPM */
-static const char * bar_l_xpm[] = {
+static const char * const bar_l_xpm[] = {
 "29 17 33 1",
 " 	c None",
 ".	c #020203",

--- a/images/SliderThumb.xpm
+++ b/images/SliderThumb.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * SliderThumb[] = {
+static const char * const SliderThumb[] = {
 "11 14 7 1",
 " 	c None",
 ".	c #DEDEDE",

--- a/images/SliderThumbAlpha.xpm
+++ b/images/SliderThumbAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  *SliderThumbAlpha[] = {
+static const char * const SliderThumbAlpha[] = {
 "11 14 2 1",
 ".  c #000000",
 "#  c #ffffff",

--- a/images/SliderThumbDisabled.xpm
+++ b/images/SliderThumbDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * SliderThumbDisabled[] = {
+static const char * const SliderThumbDisabled[] = {
 "11 14 7 1",
 " 	c None",
 ".	c #DEDEDE",

--- a/images/SliderThumb_Vertical.xpm
+++ b/images/SliderThumb_Vertical.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SliderThumb_Vertical[] = {
+static const char * const SliderThumb_Vertical[] = {
 "14 11 7 1",
 " 	c None",
 ".	c #DEDEDE",

--- a/images/SliderThumb_VerticalAlpha.xpm
+++ b/images/SliderThumb_VerticalAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * SliderThumb_VerticalAlpha[] = {
+static const char * const SliderThumb_VerticalAlpha[] = {
 "14 11 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/SliderThumb_VerticalDisabled.xpm
+++ b/images/SliderThumb_VerticalDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * SliderThumb_VerticalDisabled[] = {
+static const char * const SliderThumb_VerticalDisabled[] = {
 "14 11 7 1",
 " 	c None",
 ".	c #DEDEDE",

--- a/images/SpeakerMenu.xpm
+++ b/images/SpeakerMenu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * SpeakerMenu_xpm[] = {
+static const char * const SpeakerMenu_xpm[] = {
 "24 19 14 1",
 " 	c None",
 ".	c #C1C1C1",
@@ -36,7 +36,7 @@ static const char * SpeakerMenu_xpm[] = {
 "                    $   "};
 
 /* XPM */
-static const char * SpeakerMenuNarrow_xpm[] = {
+static const char * const SpeakerMenuNarrow_xpm[] = {
 "19 19 14 1",
 " 	c None",
 ".	c #C1C1C1",

--- a/images/ToolBarImages/DockDown.xpm
+++ b/images/ToolBarImages/DockDown.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * DockDown[] = {
+static const char * const DockDown[] = {
 "15 55 6 1",
 " 	c None",
 ".	c #8E8E8E",

--- a/images/ToolBarImages/DockDownShort.xpm
+++ b/images/ToolBarImages/DockDownShort.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * DockDownShort[] = {
+static const char * const DockDownShort[] = {
 "15 27 6 1",
 " 	c None",
 ".	c #8E8E8E",

--- a/images/ToolBarImages/DockOver.xpm
+++ b/images/ToolBarImages/DockOver.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * DockOver[] = {
+static const char * const DockOver[] = {
 "15 55 35 1",
 " 	c None",
 ".	c #E2E2DE",

--- a/images/ToolBarImages/DockOverShort.xpm
+++ b/images/ToolBarImages/DockOverShort.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * DockOverShort[] = {
+static const char * const DockOverShort[] = {
 "15 27 35 1",
 " 	c None",
 ".	c #E2E2DE",

--- a/images/ToolBarImages/DockUp.xpm
+++ b/images/ToolBarImages/DockUp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * DockUp[] = {
+static const char * const DockUp[] = {
 "15 55 6 1",
 " 	c None",
 ".	c #E2E2DE",

--- a/images/ToolBarImages/DockUpShort.xpm
+++ b/images/ToolBarImages/DockUpShort.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * DockUpShort[] = {
+static const char * const DockUpShort[] = {
 "15 27 6 1",
 " 	c None",
 ".	c #E2E2DE",

--- a/images/ToolsButtons/Draw.xpm
+++ b/images/ToolsButtons/Draw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Draw[] = {
+static const char * const Draw[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #D6D6D6",

--- a/images/ToolsButtons/DrawAlpha.xpm
+++ b/images/ToolsButtons/DrawAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * DrawAlpha[] = {
+static const char * const DrawAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/ToolsButtons/Envelope.xpm
+++ b/images/ToolsButtons/Envelope.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Envelope[] = {
+static const char * const Envelope[] = {
 "27 27 5 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/ToolsButtons/EnvelopeAlpha.xpm
+++ b/images/ToolsButtons/EnvelopeAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * EnvelopeAlpha[] = {
+static const char * const EnvelopeAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/ToolsButtons/IBeam.xpm
+++ b/images/ToolsButtons/IBeam.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * IBeam[] = {
+static const char * const IBeam[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/ToolsButtons/IBeamAlpha.xpm
+++ b/images/ToolsButtons/IBeamAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * IBeamAlpha[] = {
+static const char * const IBeamAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/ToolsButtons/Multi.xpm
+++ b/images/ToolsButtons/Multi.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Multi[] = {
+static const char * const Multi[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 3 1",
 ". c #FFFFFF",

--- a/images/ToolsButtons/MultiAlpha.xpm
+++ b/images/ToolsButtons/MultiAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * MultiAlpha[] = {
+static const char * const MultiAlpha[] = {
 /* columns rows colors chars-per-pixel */
 "27 27 2 1",
 ". c #000000",

--- a/images/ToolsButtons/TimeShift.xpm
+++ b/images/ToolsButtons/TimeShift.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * TimeShift[] = {
+static const char * const TimeShift[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/ToolsButtons/TimeShiftAlpha.xpm
+++ b/images/ToolsButtons/TimeShiftAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * TimeShiftAlpha[] = {
+static const char * const TimeShiftAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/ToolsButtons/Zoom.xpm
+++ b/images/ToolsButtons/Zoom.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Zoom[] = {
+static const char * const Zoom[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/ToolsButtons/ZoomAlpha.xpm
+++ b/images/ToolsButtons/ZoomAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * ZoomAlpha[] = {
+static const char * const ZoomAlpha[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/Automate.xpm
+++ b/images/TranscriptionImages/Automate.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * EndOn[] = {
+static const char * const EndOn[] = {
 "27 27 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/AutomateSelection.xpm
+++ b/images/TranscriptionImages/AutomateSelection.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * AutomateSelection[] = {
+static const char * const AutomateSelection[] = {
 "27 27 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/AutomateSelectionAlpha.xpm
+++ b/images/TranscriptionImages/AutomateSelectionAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * AutomateSelectionAlpha[] = {
+static const char * const AutomateSelectionAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/AutomateSelectionDisabled.xpm
+++ b/images/TranscriptionImages/AutomateSelectionDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * AutomateSelectionDisabled[] = {
+static const char * const AutomateSelectionDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/CalibrateAlpha.xpm
+++ b/images/TranscriptionImages/CalibrateAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * CalibrateAlpha[] = {
+static const char * const CalibrateAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/CalibrateDisabled.xpm
+++ b/images/TranscriptionImages/CalibrateDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * CalibrateDisabled[] = {
+static const char * const CalibrateDisabled[] = {
 "27 27 13 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/CalibrateUp.xpm
+++ b/images/TranscriptionImages/CalibrateUp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * CalibrateUp[] = {
+static const char * const CalibrateUp[] = {
 "27 27 14 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/Down.xpm
+++ b/images/TranscriptionImages/Down.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Down[] = {
+static const char * const Down[] = {
 "27 27 27 1",
 " 	c None",
 ".	c #3B3B3B",

--- a/images/TranscriptionImages/EndOff.xpm
+++ b/images/TranscriptionImages/EndOff.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * EndOff[] = {
+static const char * const EndOff[] = {
 "27 27 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/EndOffAlpha.xpm
+++ b/images/TranscriptionImages/EndOffAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * EndOffAlpha[] = {
+static const char * const EndOffAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/EndOffDisabled.xpm
+++ b/images/TranscriptionImages/EndOffDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * EndOffDisabled[] = {
+static const char * const EndOffDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/EndOn.xpm
+++ b/images/TranscriptionImages/EndOn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * EndOn[] = {
+static const char * const EndOn[] = {
 "27 27 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/EndOnAlpha.xpm
+++ b/images/TranscriptionImages/EndOnAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * EndOnAlpha[] = {
+static const char * const EndOnAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/EndOnDisabled.xpm
+++ b/images/TranscriptionImages/EndOnDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * EndOnDisabled[] = {
+static const char * const EndOnDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/Hilite.xpm
+++ b/images/TranscriptionImages/Hilite.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Hilite[] = {
+static const char * const Hilite[] = {
 "27 27 85 1",
 " 	c None",
 ".	c #FBFBFB",

--- a/images/TranscriptionImages/MakeTag.xpm
+++ b/images/TranscriptionImages/MakeTag.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * MakeTag[] = {
+static const char * const MakeTag[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/MakeTagAlpha.xpm
+++ b/images/TranscriptionImages/MakeTagAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * MakeTagAlpha[] = {
+static const char * const MakeTagAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/MakeTagDisabled.xpm
+++ b/images/TranscriptionImages/MakeTagDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * MakeTagDisabled[] = {
+static const char * const MakeTagDisabled[] = {
 "27 27 4 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/SelectSilence.xpm
+++ b/images/TranscriptionImages/SelectSilence.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SelectSilence[] = {
+static const char * const SelectSilence[] = {
 "24 24 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/SelectSilenceAlpha.xpm
+++ b/images/TranscriptionImages/SelectSilenceAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SelectSilenceAlpha[] = {
+static const char * const SelectSilenceAlpha[] = {
 "24 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/SelectSilenceDisabled.xpm
+++ b/images/TranscriptionImages/SelectSilenceDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SelectSilenceDisabled[] = {
+static const char * const SelectSilenceDisabled[] = {
 "24 24 6 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/SelectSound.xpm
+++ b/images/TranscriptionImages/SelectSound.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SelectSound[] = {
+static const char * const SelectSound[] = {
 "24 24 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/SelectSoundAlpha.xpm
+++ b/images/TranscriptionImages/SelectSoundAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SelectSoundAlpha[] = {
+static const char * const SelectSoundAlpha[] = {
 "24 24 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/SelectSoundDisabled.xpm
+++ b/images/TranscriptionImages/SelectSoundDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * SelectSoundDisabled[] = {
+static const char * const SelectSoundDisabled[] = {
 "24 24 5 1",
 " 	c None",
 ".	c #777777",

--- a/images/TranscriptionImages/StartOff.xpm
+++ b/images/TranscriptionImages/StartOff.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * StartOff[] = {
+static const char * const StartOff[] = {
 "27 27 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/StartOffAlpha.xpm
+++ b/images/TranscriptionImages/StartOffAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * StartOffAlpha[] = {
+static const char * const StartOffAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/StartOffDisabled.xpm
+++ b/images/TranscriptionImages/StartOffDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * StartOffDisabled[] = {
+static const char * const StartOffDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/StartOn.xpm
+++ b/images/TranscriptionImages/StartOn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * StartOn[] = {
+static const char * const StartOn[] = {
 "27 27 5 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/StartOnAlpha.xpm
+++ b/images/TranscriptionImages/StartOnAlpha.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * StartOnAlpha[] = {
+static const char * const StartOnAlpha[] = {
 "27 27 3 1",
 " 	c None",
 ".	c #000000",

--- a/images/TranscriptionImages/StartOnDisabled.xpm
+++ b/images/TranscriptionImages/StartOnDisabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * StartOnDisabled[] = {
+static const char * const StartOnDisabled[] = {
 "27 27 6 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/TranscriptionImages/Up.xpm
+++ b/images/TranscriptionImages/Up.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Up[] = {
+static const char * const Up[] = {
 "27 27 15 1",
 " 	c None",
 ".	c #FBFBFB",

--- a/images/Unchecked.xpm
+++ b/images/Unchecked.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * unchecked_xpm[] = {
+static const char * const unchecked_xpm[] = {
 "15 15 56 1",
 " 	c None",
 ".	c #FFFFFF",

--- a/images/UploadImages.h
+++ b/images/UploadImages.h
@@ -1,5 +1,5 @@
 
-static const char *file_xpm[] = {
+static const char * const file_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 "  c #040404",
@@ -25,7 +25,7 @@ static const char *file_xpm[] = {
 "oo             o"
 };
 
-static const char *folder_xpm[] = {
+static const char * const folder_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 15 1",
 "  c gray30",
@@ -62,7 +62,7 @@ static const char *folder_xpm[] = {
 ";-=***********=-"
 };
 
-static const char *mp3_xpm[] = {
+static const char * const mp3_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 19 1",
 "  c #040404",
@@ -103,7 +103,7 @@ static const char *mp3_xpm[] = {
 "<<<<<<<<<<<<<<<<"
 };
 
-static const char *up_xpm[] = {
+static const char * const up_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 25 1",
 "  c #040404",

--- a/images/gnome-mime-application-x-audacity-project.xpm
+++ b/images/gnome-mime-application-x-audacity-project.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static char * gnome_mime_application_x_audacity_project_xpm[] = {
+static char * const gnome_mime_application_x_audacity_project_xpm[] = {
 "48 48 476 2",
 "  	c None",
 ". 	c #9D9D9D",

--- a/images/icons/16x16/audacity16.xpm
+++ b/images/icons/16x16/audacity16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * audacity16_xpm[] = {
+static const char * const audacity16_xpm[] = {
 "16 16 95 2",
 "  	c None",
 ". 	c #0000EB",

--- a/images/icons/32x32/audacity32.xpm
+++ b/images/icons/32x32/audacity32.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * audacity32_xpm[] = {
+static const char * const audacity32_xpm[] = {
 "32 32 244 2",
 "  	c None",
 ". 	c #000082",

--- a/images/icons/48x48/audacity.xpm
+++ b/images/icons/48x48/audacity.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char  * AudacityLogo48x48_xpm[] = {
+static const char * const AudacityLogo48x48_xpm[] = {
 "48 48 389 2",
 "  	c None",
 ". 	c #000092",

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1404,7 +1404,7 @@ int MixerBoard::FindMixerTrackCluster(const PlayableTrack* pTrack,
 
 void MixerBoard::LoadMusicalInstruments()
 {
-   const struct Data { const char **bitmap; wxString name; } table[] = {
+   const struct Data { const char * const *bitmap; wxString name; } table[] = {
       {acoustic_guitar_gtr_xpm, wxT("acoustic_guitar_gtr")},
       {acoustic_piano_pno_xpm, wxT("acoustic_piano_pno")},
       {back_vocal_bg_vox_xpm, wxT("back_vocal_bg_vox")},

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -271,7 +271,7 @@ END_EVENT_TABLE()
 
 /// Makes a cursor from an XPM, uses CursorId as a fallback.
 /// TODO:  Move this function to some other source file for reuse elsewhere.
-std::unique_ptr<wxCursor> MakeCursor( int WXUNUSED(CursorId), const char * pXpm[36],  int HotX, int HotY )
+std::unique_ptr<wxCursor> MakeCursor( int WXUNUSED(CursorId), const char * const pXpm[36],  int HotX, int HotY )
 {
 #ifdef CURSORS_SIZE32
    const int HotAdjust =0;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -3784,7 +3784,7 @@ void EffectUIHost::OnDefaults(wxCommandEvent & WXUNUSED(evt))
    return;
 }
 
-wxBitmap EffectUIHost::CreateBitmap(const char *xpm[], bool up, bool pusher)
+wxBitmap EffectUIHost::CreateBitmap(const char * const xpm[], bool up, bool pusher)
 {
    wxMemoryDC dc;
    wxBitmap pic(xpm);

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -638,7 +638,7 @@ private:
    void OnDefaults(wxCommandEvent & evt);
 
    void UpdateControls();
-   wxBitmap CreateBitmap(const char *xpm[], bool up, bool pusher);
+   wxBitmap CreateBitmap(const char * const xpm[], bool up, bool pusher);
    void LoadUserPresets();
 
    void InitializeRealtime();


### PR DESCRIPTION
The arrays storing the pointers to the XPM strings can be const.  This change moves a surprising chunk of data from read/write to read-only memory (several hundred kilobytes on 64-bit builds, presumably about half that for 32-bit builds).