### PR TITLE
Add TransportOSC feature that sends OSC message on transport button triggering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
             - gcc-4.9
 before_install:
     - sudo apt-get update -qq
-    - sudo apt-get install -y libwxgtk3.0-dev libgtk2.0-dev gettext autopoint libasound2-dev alsa-utils alsa-oss
+    - sudo apt-get install -y libwxgtk3.0-dev libgtk2.0-dev gettext autopoint libasound2-dev alsa-utils alsa-oss liblo-dev
     - git show -s --format="#define REV_LONG \"%H\"%n#define REV_TIME \"%cd\"%n" | tee ./src/RevisionIdent.h
     - export CXX="g++-4.9" CC="gcc-4.9"
     - FLAGS="-w -std=gnu++11"

--- a/Makefile.in
+++ b/Makefile.in
@@ -104,6 +104,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_c99_func_lrint.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libexpat.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libflac.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libid3tag.m4 \
+	$(top_srcdir)/m4/audacity_checklib_liblo.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libmad.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libnyquist.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libsbsms.m4 \
@@ -380,6 +381,8 @@ LD = @LD@
 LDFLAGS = @LDFLAGS@
 LIBICONV = @LIBICONV@
 LIBINTL = @LIBINTL@
+LIBLO_CFLAGS = @LIBLO_CFLAGS@
+LIBLO_LIBS = @LIBLO_LIBS@
 LIBMAD_CFLAGS = @LIBMAD_CFLAGS@
 LIBMAD_LIBS = @LIBMAD_LIBS@
 LIBNYQUIST_CFLAGS = @LIBNYQUIST_CFLAGS@

--- a/configure
+++ b/configure
@@ -651,6 +651,8 @@ GTK_CFLAGS
 HAVE_GTK
 USE_LADSPA_FALSE
 USE_LADSPA_TRUE
+USE_LIBLO_FALSE
+USE_LIBLO_TRUE
 USE_LOCAL_WIDGETEXTRA_FALSE
 USE_LOCAL_WIDGETEXTRA_TRUE
 USE_LOCAL_PORTMIDI_FALSE
@@ -727,6 +729,8 @@ FFMPEG_LIBS
 FFMPEG_CFLAGS
 USE_LOCAL_EXPAT_FALSE
 USE_LOCAL_EXPAT_TRUE
+LIBLO_LIBS
+LIBLO_CFLAGS
 WIDGETEXTRA_LIBS
 WIDGETEXTRA_CFLAGS
 PORTMIDI_LIBS
@@ -965,6 +969,7 @@ with_portaudio
 with_midi
 with_portmidi
 with_widgetextra
+with_liblo
 enable_audiounits
 enable_ladspa
 enable_quicktime
@@ -1025,6 +1030,8 @@ PORTMIDI_CFLAGS
 PORTMIDI_LIBS
 WIDGETEXTRA_CFLAGS
 WIDGETEXTRA_LIBS
+LIBLO_CFLAGS
+LIBLO_LIBS
 GTK_CFLAGS
 GTK_LIBS
 JACK_CFLAGS
@@ -1734,6 +1741,7 @@ Optional Packages:
   --with-portmidi         use PortMIDI for MIDI playback support
   --with-widgetextra      which libwidgetextra to use (required):
                           [system,local]
+  --with-liblo            use liblo for OSC(Open Sound Control) support
   --with-portmixer        compile with PortMixer [default=yes]
   --with-mod-script-pipe  compile with mod-script-pipe [default=no]
   --with-mod-nyq-bench    compile with mod-nyq-bench [default=no]
@@ -1814,6 +1822,9 @@ Some influential environment variables:
               C compiler flags for WIDGETEXTRA, overriding pkg-config
   WIDGETEXTRA_LIBS
               linker flags for WIDGETEXTRA, overriding pkg-config
+  LIBLO_CFLAGS
+              C compiler flags for LIBLO, overriding pkg-config
+  LIBLO_LIBS  linker flags for LIBLO, overriding pkg-config
   GTK_CFLAGS  C compiler flags for GTK, overriding pkg-config
   GTK_LIBS    linker flags for GTK, overriding pkg-config
   JACK_CFLAGS C compiler flags for JACK, overriding pkg-config
@@ -19936,7 +19947,7 @@ CXXFLAGS="$CXXFLAGS -I\$(top_srcdir)/lib-src/FileDialog"
 FILEDIALOG_LIBS='$(top_builddir)/lib-src/FileDialog/libFileDialog.la'
 
 
-LIBRARIES="EXPAT FFMPEG LAME LIBFLAC LIBID3TAG LIBMAD LIBNYQUIST LIBSBSMS LIBSNDFILE LIBSOUNDTOUCH LIBSOXR LIBTWOLAME LIBVAMP LIBVORBIS LV2 PORTAUDIO PORTSMF PORTMIDI WIDGETEXTRA"
+LIBRARIES="EXPAT FFMPEG LAME LIBFLAC LIBID3TAG LIBMAD LIBNYQUIST LIBSBSMS LIBSNDFILE LIBSOUNDTOUCH LIBSOXR LIBTWOLAME LIBVAMP LIBVORBIS LV2 PORTAUDIO PORTSMF PORTMIDI WIDGETEXTRA LIBLO"
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: Determining what libraries are available in this tree and on the system" >&5
 $as_echo "$as_me: Determining what libraries are available in this tree and on the system" >&6;}
@@ -22834,6 +22845,93 @@ $as_echo "$as_me: libwidgetextra library is NOT available in the local tree" >&6
 
 
 
+# Check whether --with-liblo was given.
+if test "${with_liblo+set}" = set; then :
+  withval=$with_liblo; LIBLO_ARGUMENT=$withval
+else
+  LIBLO_ARGUMENT="unspecified"
+fi
+
+
+
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for LIBLO" >&5
+$as_echo_n "checking for LIBLO... " >&6; }
+
+if test -n "$LIBLO_CFLAGS"; then
+    pkg_cv_LIBLO_CFLAGS="$LIBLO_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"liblo >= 0.26\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "liblo >= 0.26") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_LIBLO_CFLAGS=`$PKG_CONFIG --cflags "liblo >= 0.26" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$LIBLO_LIBS"; then
+    pkg_cv_LIBLO_LIBS="$LIBLO_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"liblo >= 0.26\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "liblo >= 0.26") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_LIBLO_LIBS=`$PKG_CONFIG --libs "liblo >= 0.26" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        LIBLO_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors "liblo >= 0.26" 2>&1`
+        else
+	        LIBLO_PKG_ERRORS=`$PKG_CONFIG --print-errors "liblo >= 0.26" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$LIBLO_PKG_ERRORS" >&5
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+                LIBLO_SYSTEM_AVAILABLE="no"
+elif test $pkg_failed = untried; then
+	LIBLO_SYSTEM_AVAILABLE="no"
+else
+	LIBLO_CFLAGS=$pkg_cv_LIBLO_CFLAGS
+	LIBLO_LIBS=$pkg_cv_LIBLO_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	LIBLO_SYSTEM_AVAILABLE="yes"
+fi
+
+   if test "$LIBLO_SYSTEM_AVAILABLE" = "yes"; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: LIBLO libraries are available as system libraries" >&5
+$as_echo "$as_me: LIBLO libraries are available as system libraries" >&6;}
+      LIBLO_SYSTEM_LIBS=$LIBLO_LIBS
+   else
+      as_fn_error $? "LIBLO libraries are NOT available as system libraries" "$LINENO" 5
+   fi
+
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: Figuring out what libraries to enable" >&5
 $as_echo "$as_me: Figuring out what libraries to enable" >&6;}
 
@@ -23555,6 +23653,22 @@ else
   USE_LOCAL_WIDGETEXTRA_FALSE=
 fi
 
+
+
+    if test "$LIBLO_USE_SYSTEM" = yes; then
+  USE_LIBLO_TRUE=
+  USE_LIBLO_FALSE='#'
+else
+  USE_LIBLO_TRUE='#'
+  USE_LIBLO_FALSE=
+fi
+
+
+   if test "$LIBLO_USE_SYSTEM" = yes; then
+
+$as_echo "#define USE_LIBLO 1" >>confdefs.h
+
+   fi
 
 
 
@@ -24541,6 +24655,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${USE_LOCAL_WIDGETEXTRA_TRUE}" && test -z "${USE_LOCAL_WIDGETEXTRA_FALSE}"; then
   as_fn_error $? "conditional \"USE_LOCAL_WIDGETEXTRA\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${USE_LIBLO_TRUE}" && test -z "${USE_LIBLO_FALSE}"; then
+  as_fn_error $? "conditional \"USE_LIBLO\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${USE_LADSPA_TRUE}" && test -z "${USE_LADSPA_FALSE}"; then

--- a/configure
+++ b/configure
@@ -1741,7 +1741,8 @@ Optional Packages:
   --with-portmidi         use PortMIDI for MIDI playback support
   --with-widgetextra      which libwidgetextra to use (required):
                           [system,local]
-  --with-liblo            use liblo for OSC(Open Sound Control) support
+  --without-liblo         disable support for liblo, OSC (Open Sound Control)
+                          support
   --with-portmixer        compile with PortMixer [default=yes]
   --with-mod-script-pipe  compile with mod-script-pipe [default=no]
   --with-mod-nyq-bench    compile with mod-nyq-bench [default=no]
@@ -22849,11 +22850,11 @@ $as_echo "$as_me: libwidgetextra library is NOT available in the local tree" >&6
 if test "${with_liblo+set}" = set; then :
   withval=$with_liblo; LIBLO_ARGUMENT=$withval
 else
-  LIBLO_ARGUMENT="unspecified"
+  LIBLO_ARGUMENT=yes
 fi
 
 
-
+      if test "x$LIBLO_ARGUMENT" = "xyes"; then
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for LIBLO" >&5
@@ -22922,12 +22923,13 @@ $as_echo "yes" >&6; }
 	LIBLO_SYSTEM_AVAILABLE="yes"
 fi
 
-   if test "$LIBLO_SYSTEM_AVAILABLE" = "yes"; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: LIBLO libraries are available as system libraries" >&5
+      if test "$LIBLO_SYSTEM_AVAILABLE" = "yes"; then
+         { $as_echo "$as_me:${as_lineno-$LINENO}: LIBLO libraries are available as system libraries" >&5
 $as_echo "$as_me: LIBLO libraries are available as system libraries" >&6;}
-      LIBLO_SYSTEM_LIBS=$LIBLO_LIBS
-   else
-      as_fn_error $? "LIBLO libraries are NOT available as system libraries" "$LINENO" 5
+         LIBLO_SYSTEM_LIBS=$LIBLO_LIBS
+      else
+         as_fn_error $? "LIBLO libraries are NOT available as system libraries" "$LINENO" 5
+      fi
    fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -351,7 +351,7 @@ dnl Optional library support. Lots of things we could use, but
 dnl can do without if they aren't available.
 dnl-------------------------------------------------------------
 dnl GSTREAMER removed for 2.0.6 release
-LIBRARIES="EXPAT FFMPEG LAME LIBFLAC LIBID3TAG LIBMAD LIBNYQUIST LIBSBSMS LIBSNDFILE LIBSOUNDTOUCH LIBSOXR LIBTWOLAME LIBVAMP LIBVORBIS LV2 PORTAUDIO PORTSMF PORTMIDI WIDGETEXTRA"
+LIBRARIES="EXPAT FFMPEG LAME LIBFLAC LIBID3TAG LIBMAD LIBNYQUIST LIBSBSMS LIBSNDFILE LIBSOUNDTOUCH LIBSOXR LIBTWOLAME LIBVAMP LIBVORBIS LV2 PORTAUDIO PORTSMF PORTMIDI WIDGETEXTRA LIBLO"
 
 AC_MSG_NOTICE([Determining what libraries are available in this tree and on the system])
 
@@ -375,6 +375,7 @@ AUDACITY_CHECKLIB_PORTAUDIO
 AUDACITY_CHECKLIB_PORTSMF
 AUDACITY_CHECKLIB_PORTMIDI
 AUDACITY_CHECKLIB_WIDGETEXTRA
+AUDACITY_CHECKLIB_LIBLO
 
 dnl Decide what libraries to build with, and whether to use system or local libraries
 dnl Set variables based on choices.
@@ -504,6 +505,7 @@ AUDACITY_CONFIG_PORTAUDIO
 AUDACITY_CONFIG_PORTSMF
 AUDACITY_CONFIG_PORTMIDI
 AUDACITY_CONFIG_WIDGETEXTRA
+AUDACITY_CONFIG_LIBLO
 
 dnl--------------------------------------------------------------------------
 dnl Optional features (which don't use libraries - just compile-time on/off)

--- a/help/Makefile.in
+++ b/help/Makefile.in
@@ -90,6 +90,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_c99_func_lrint.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libexpat.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libflac.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libid3tag.m4 \
+	$(top_srcdir)/m4/audacity_checklib_liblo.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libmad.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libnyquist.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libsbsms.m4 \
@@ -258,6 +259,8 @@ LD = @LD@
 LDFLAGS = @LDFLAGS@
 LIBICONV = @LIBICONV@
 LIBINTL = @LIBINTL@
+LIBLO_CFLAGS = @LIBLO_CFLAGS@
+LIBLO_LIBS = @LIBLO_LIBS@
 LIBMAD_CFLAGS = @LIBMAD_CFLAGS@
 LIBMAD_LIBS = @LIBMAD_LIBS@
 LIBNYQUIST_CFLAGS = @LIBNYQUIST_CFLAGS@

--- a/images/Makefile.in
+++ b/images/Makefile.in
@@ -92,6 +92,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_c99_func_lrint.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libexpat.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libflac.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libid3tag.m4 \
+	$(top_srcdir)/m4/audacity_checklib_liblo.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libmad.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libnyquist.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libsbsms.m4 \
@@ -262,6 +263,8 @@ LD = @LD@
 LDFLAGS = @LDFLAGS@
 LIBICONV = @LIBICONV@
 LIBINTL = @LIBINTL@
+LIBLO_CFLAGS = @LIBLO_CFLAGS@
+LIBLO_LIBS = @LIBLO_LIBS@
 LIBMAD_CFLAGS = @LIBMAD_CFLAGS@
 LIBMAD_LIBS = @LIBMAD_LIBS@
 LIBNYQUIST_CFLAGS = @LIBNYQUIST_CFLAGS@

--- a/lib-src/Makefile.in
+++ b/lib-src/Makefile.in
@@ -109,6 +109,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_c99_func_lrint.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libexpat.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libflac.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libid3tag.m4 \
+	$(top_srcdir)/m4/audacity_checklib_liblo.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libmad.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libnyquist.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libsbsms.m4 \
@@ -304,6 +305,8 @@ LD = @LD@
 LDFLAGS = @LDFLAGS@
 LIBICONV = @LIBICONV@
 LIBINTL = @LIBINTL@
+LIBLO_CFLAGS = @LIBLO_CFLAGS@
+LIBLO_LIBS = @LIBLO_LIBS@
 LIBMAD_CFLAGS = @LIBMAD_CFLAGS@
 LIBMAD_LIBS = @LIBMAD_LIBS@
 LIBNYQUIST_CFLAGS = @LIBNYQUIST_CFLAGS@

--- a/m4/audacity_checklib_liblo.m4
+++ b/m4/audacity_checklib_liblo.m4
@@ -1,0 +1,35 @@
+dnl add audacity / liblo license?
+dnl
+dnl Please increment the serial number below whenever you alter this macro
+dnl for the benefit of automatic macro update systems
+# audacity_checklib_liblo.m4 serial 1
+
+AC_DEFUN([AUDACITY_CHECKLIB_LIBLO], [
+   AC_ARG_WITH(liblo,
+               [AS_HELP_STRING([--with-liblo],
+                               [use liblo for OSC(Open Sound Control) support])],
+               LIBLO_ARGUMENT=$withval,
+               LIBLO_ARGUMENT="unspecified")
+
+   dnl See if LIBLO is installed in the system and use it
+
+   PKG_CHECK_MODULES([LIBLO], [liblo >= 0.26],
+                     [LIBLO_SYSTEM_AVAILABLE="yes"],
+                     [LIBLO_SYSTEM_AVAILABLE="no"])
+
+   if test "$LIBLO_SYSTEM_AVAILABLE" = "yes"; then
+      AC_MSG_NOTICE([LIBLO libraries are available as system libraries])
+      LIBLO_SYSTEM_LIBS=$LIBLO_LIBS
+   else
+      AC_MSG_ERROR([LIBLO libraries are NOT available as system libraries])
+   fi
+])
+
+AC_DEFUN([AUDACITY_CONFIG_LIBLO], [
+   AM_CONDITIONAL([USE_LIBLO], [test "$LIBLO_USE_SYSTEM" = yes])
+
+   if test "$LIBLO_USE_SYSTEM" = yes; then
+      AC_DEFINE(USE_LIBLO, 1,
+                [Define if the LIBLO library is present])
+   fi
+])

--- a/m4/audacity_checklib_liblo.m4
+++ b/m4/audacity_checklib_liblo.m4
@@ -6,22 +6,23 @@ dnl for the benefit of automatic macro update systems
 
 AC_DEFUN([AUDACITY_CHECKLIB_LIBLO], [
    AC_ARG_WITH(liblo,
-               [AS_HELP_STRING([--with-liblo],
-                               [use liblo for OSC(Open Sound Control) support])],
-               LIBLO_ARGUMENT=$withval,
-               LIBLO_ARGUMENT="unspecified")
+               [AS_HELP_STRING([--without-liblo],
+                               [disable support for liblo, OSC (Open Sound Control) support])],
+               [LIBLO_ARGUMENT=$withval],
+               [LIBLO_ARGUMENT=yes])
 
    dnl See if LIBLO is installed in the system and use it
+   if test "x$LIBLO_ARGUMENT" = "xyes"; then
+      PKG_CHECK_MODULES([LIBLO], [liblo >= 0.26],
+                        [LIBLO_SYSTEM_AVAILABLE="yes"],
+                        [LIBLO_SYSTEM_AVAILABLE="no"])
 
-   PKG_CHECK_MODULES([LIBLO], [liblo >= 0.26],
-                     [LIBLO_SYSTEM_AVAILABLE="yes"],
-                     [LIBLO_SYSTEM_AVAILABLE="no"])
-
-   if test "$LIBLO_SYSTEM_AVAILABLE" = "yes"; then
-      AC_MSG_NOTICE([LIBLO libraries are available as system libraries])
-      LIBLO_SYSTEM_LIBS=$LIBLO_LIBS
-   else
-      AC_MSG_ERROR([LIBLO libraries are NOT available as system libraries])
+      if test "$LIBLO_SYSTEM_AVAILABLE" = "yes"; then
+         AC_MSG_NOTICE([LIBLO libraries are available as system libraries])
+         LIBLO_SYSTEM_LIBS=$LIBLO_LIBS
+      else
+         AC_MSG_ERROR([LIBLO libraries are NOT available as system libraries])
+      fi
    fi
 ])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -536,6 +536,8 @@ audacity_SOURCES = \
 	prefs/TracksBehaviorsPrefs.h \
 	prefs/TracksPrefs.cpp \
 	prefs/TracksPrefs.h \
+	prefs/TransportOSCPrefs.cpp \
+	prefs/TransportOSCPrefs.h \
 	prefs/WarningsPrefs.cpp \
 	prefs/WarningsPrefs.h \
 	prefs/WaveformPrefs.cpp \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -202,6 +202,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_c99_func_lrint.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libexpat.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libflac.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libid3tag.m4 \
+	$(top_srcdir)/m4/audacity_checklib_liblo.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libmad.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libnyquist.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libsbsms.m4 \
@@ -445,6 +446,7 @@ am__audacity_SOURCES_DIST = BlockFile.cpp BlockFile.h DirManager.cpp \
 	prefs/SpectrumPrefs.h prefs/ThemePrefs.cpp prefs/ThemePrefs.h \
 	prefs/TracksBehaviorsPrefs.cpp prefs/TracksBehaviorsPrefs.h \
 	prefs/TracksPrefs.cpp prefs/TracksPrefs.h \
+	prefs/TransportOSCPrefs.cpp prefs/TransportOSCPrefs.h \
 	prefs/WarningsPrefs.cpp prefs/WarningsPrefs.h \
 	prefs/WaveformPrefs.cpp prefs/WaveformPrefs.h \
 	prefs/WaveformSettings.cpp prefs/WaveformSettings.h \
@@ -780,6 +782,7 @@ am_audacity_OBJECTS = $(am__objects_1) audacity-AboutDialog.$(OBJEXT) \
 	prefs/audacity-ThemePrefs.$(OBJEXT) \
 	prefs/audacity-TracksBehaviorsPrefs.$(OBJEXT) \
 	prefs/audacity-TracksPrefs.$(OBJEXT) \
+	prefs/audacity-TransportOSCPrefs.$(OBJEXT) \
 	prefs/audacity-WarningsPrefs.$(OBJEXT) \
 	prefs/audacity-WaveformPrefs.$(OBJEXT) \
 	prefs/audacity-WaveformSettings.$(OBJEXT) \
@@ -1086,6 +1089,8 @@ LD = @LD@
 LDFLAGS = @LDFLAGS@
 LIBICONV = @LIBICONV@
 LIBINTL = @LIBINTL@
+LIBLO_CFLAGS = @LIBLO_CFLAGS@
+LIBLO_LIBS = @LIBLO_LIBS@
 LIBMAD_CFLAGS = @LIBMAD_CFLAGS@
 LIBMAD_LIBS = @LIBMAD_LIBS@
 LIBNYQUIST_CFLAGS = @LIBNYQUIST_CFLAGS@
@@ -1467,6 +1472,7 @@ audacity_SOURCES = $(libaudacity_la_SOURCES) AboutDialog.cpp \
 	prefs/SpectrumPrefs.h prefs/ThemePrefs.cpp prefs/ThemePrefs.h \
 	prefs/TracksBehaviorsPrefs.cpp prefs/TracksBehaviorsPrefs.h \
 	prefs/TracksPrefs.cpp prefs/TracksPrefs.h \
+	prefs/TransportOSCPrefs.cpp prefs/TransportOSCPrefs.h \
 	prefs/WarningsPrefs.cpp prefs/WarningsPrefs.h \
 	prefs/WaveformPrefs.cpp prefs/WaveformPrefs.h \
 	prefs/WaveformSettings.cpp prefs/WaveformSettings.h \
@@ -2043,6 +2049,8 @@ prefs/audacity-ThemePrefs.$(OBJEXT): prefs/$(am__dirstamp) \
 prefs/audacity-TracksBehaviorsPrefs.$(OBJEXT): prefs/$(am__dirstamp) \
 	prefs/$(DEPDIR)/$(am__dirstamp)
 prefs/audacity-TracksPrefs.$(OBJEXT): prefs/$(am__dirstamp) \
+	prefs/$(DEPDIR)/$(am__dirstamp)
+prefs/audacity-TransportOSCPrefs.$(OBJEXT): prefs/$(am__dirstamp) \
 	prefs/$(DEPDIR)/$(am__dirstamp)
 prefs/audacity-WarningsPrefs.$(OBJEXT): prefs/$(am__dirstamp) \
 	prefs/$(DEPDIR)/$(am__dirstamp)
@@ -2651,6 +2659,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@prefs/$(DEPDIR)/audacity-ThemePrefs.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@prefs/$(DEPDIR)/audacity-TracksBehaviorsPrefs.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@prefs/$(DEPDIR)/audacity-TracksPrefs.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@prefs/$(DEPDIR)/audacity-TransportOSCPrefs.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@prefs/$(DEPDIR)/audacity-WarningsPrefs.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@prefs/$(DEPDIR)/audacity-WaveformPrefs.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@prefs/$(DEPDIR)/audacity-WaveformSettings.Po@am__quote@
@@ -5988,6 +5997,20 @@ prefs/audacity-TracksPrefs.obj: prefs/TracksPrefs.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='prefs/TracksPrefs.cpp' object='prefs/audacity-TracksPrefs.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(audacity_CPPFLAGS) $(CPPFLAGS) $(audacity_CXXFLAGS) $(CXXFLAGS) -c -o prefs/audacity-TracksPrefs.obj `if test -f 'prefs/TracksPrefs.cpp'; then $(CYGPATH_W) 'prefs/TracksPrefs.cpp'; else $(CYGPATH_W) '$(srcdir)/prefs/TracksPrefs.cpp'; fi`
+
+prefs/audacity-TransportOSCPrefs.o: prefs/TransportOSCPrefs.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(audacity_CPPFLAGS) $(CPPFLAGS) $(audacity_CXXFLAGS) $(CXXFLAGS) -MT prefs/audacity-TransportOSCPrefs.o -MD -MP -MF prefs/$(DEPDIR)/audacity-TransportOSCPrefs.Tpo -c -o prefs/audacity-TransportOSCPrefs.o `test -f 'prefs/TransportOSCPrefs.cpp' || echo '$(srcdir)/'`prefs/TransportOSCPrefs.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) prefs/$(DEPDIR)/audacity-TransportOSCPrefs.Tpo prefs/$(DEPDIR)/audacity-TransportOSCPrefs.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='prefs/TransportOSCPrefs.cpp' object='prefs/audacity-TransportOSCPrefs.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(audacity_CPPFLAGS) $(CPPFLAGS) $(audacity_CXXFLAGS) $(CXXFLAGS) -c -o prefs/audacity-TransportOSCPrefs.o `test -f 'prefs/TransportOSCPrefs.cpp' || echo '$(srcdir)/'`prefs/TransportOSCPrefs.cpp
+
+prefs/audacity-TransportOSCPrefs.obj: prefs/TransportOSCPrefs.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(audacity_CPPFLAGS) $(CPPFLAGS) $(audacity_CXXFLAGS) $(CXXFLAGS) -MT prefs/audacity-TransportOSCPrefs.obj -MD -MP -MF prefs/$(DEPDIR)/audacity-TransportOSCPrefs.Tpo -c -o prefs/audacity-TransportOSCPrefs.obj `if test -f 'prefs/TransportOSCPrefs.cpp'; then $(CYGPATH_W) 'prefs/TransportOSCPrefs.cpp'; else $(CYGPATH_W) '$(srcdir)/prefs/TransportOSCPrefs.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) prefs/$(DEPDIR)/audacity-TransportOSCPrefs.Tpo prefs/$(DEPDIR)/audacity-TransportOSCPrefs.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='prefs/TransportOSCPrefs.cpp' object='prefs/audacity-TransportOSCPrefs.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(audacity_CPPFLAGS) $(CPPFLAGS) $(audacity_CXXFLAGS) $(CXXFLAGS) -c -o prefs/audacity-TransportOSCPrefs.obj `if test -f 'prefs/TransportOSCPrefs.cpp'; then $(CYGPATH_W) 'prefs/TransportOSCPrefs.cpp'; else $(CYGPATH_W) '$(srcdir)/prefs/TransportOSCPrefs.cpp'; fi`
 
 prefs/audacity-WarningsPrefs.o: prefs/WarningsPrefs.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(audacity_CPPFLAGS) $(CPPFLAGS) $(audacity_CXXFLAGS) $(CXXFLAGS) -MT prefs/audacity-WarningsPrefs.o -MD -MP -MF prefs/$(DEPDIR)/audacity-WarningsPrefs.Tpo -c -o prefs/audacity-WarningsPrefs.o `test -f 'prefs/WarningsPrefs.cpp' || echo '$(srcdir)/'`prefs/WarningsPrefs.cpp

--- a/src/configtemplate.h
+++ b/src/configtemplate.h
@@ -143,6 +143,9 @@
 /* Define if libid3tag is present */
 #undef USE_LIBID3TAG
 
+/* Define if the LIBLO library is present */
+#undef USE_LIBLO
+
 /* Define if mp3 support is implemented with the libmad library */
 #undef USE_LIBMAD
 

--- a/src/prefs/PrefsDialog.cpp
+++ b/src/prefs/PrefsDialog.cpp
@@ -52,6 +52,9 @@
 #include "ModulePrefs.h"
 #endif
 #include "PlaybackPrefs.h"
+#ifdef USE_LIBLO
+#include "TransportOSCPrefs.h"
+#endif
 #include "ProjectsPrefs.h"
 #include "QualityPrefs.h"
 #include "RecordingPrefs.h"
@@ -158,6 +161,9 @@ PrefsDialog::Factories
    // class... and thus allowing a plug-in protocol
    static DevicePrefsFactory devicePrefsFactory;
    static PlaybackPrefsFactory playbackPrefsFactory;
+#ifdef USE_LIBLO
+   static TransportOSCPrefsFactory transportOSCPrefsFactory;
+#endif
    static RecordingPrefsFactory recordingPrefsFactory;
 #ifdef EXPERIMENTAL_MIDI_OUT
    static MidiIOPrefsFactory midiIOPrefsFactory;
@@ -190,6 +196,9 @@ PrefsDialog::Factories
    static PrefsNode nodes[] = {
       &devicePrefsFactory,
       &playbackPrefsFactory,
+#ifdef USE_LIBLO
+      &transportOSCPrefsFactory,
+#endif
       &recordingPrefsFactory,
 #ifdef EXPERIMENTAL_MIDI_OUT
       &midiIOPrefsFactory,

--- a/src/prefs/TransportOSCPrefs.cpp
+++ b/src/prefs/TransportOSCPrefs.cpp
@@ -1,0 +1,285 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  TransportOSCPrefs.cpp
+
+  2018 - Grégory David <groolot@groolot.net>
+
+  Based on PalybackPrefs.cpp by:
+   - Joshua Haberman
+   - Dominic Mazzoni
+   - James Crook
+
+*******************************************************************//**
+
+\class TransportOSCPrefs
+\brief A PrefsPanel used to select TransportOSC options.
+
+  Presents interface for user to update the various TransportOSC options
+  like the host, port and OSC paths used when transport buttons are
+  triggered.
+
+*//********************************************************************/
+
+#include "../Audacity.h"
+#include "../Experimental.h"
+#ifdef USE_LIBLO
+
+#include <wx/defs.h>
+#include <wx/textctrl.h>
+#include <wx/regex.h>
+
+#include "../ShuttleGui.h"
+#include "../Prefs.h"
+#include "../Internat.h"
+
+#include "TransportOSCPrefs.h"
+
+TransportOSCPrefs::TransportOSCPrefs(wxWindow * parent, wxWindowID winid)
+:  PrefsPanel(parent, winid, _("Transport OSC"))
+{
+   Populate();
+}
+
+TransportOSCPrefs::~TransportOSCPrefs()
+{
+}
+
+void TransportOSCPrefs::Populate()
+{
+   //------------------------- Main section --------------------
+   // Now construct the GUI itself.
+   // Use 'eIsCreatingFromPrefs' so that the GUI is
+   // initialised with values from gPrefs.
+   ShuttleGui S(this, eIsCreatingFromPrefs);
+   PopulateOrExchange(S);
+   // ----------------------- End of main section --------------
+}
+
+void TransportOSCPrefs::PopulateOrExchange(ShuttleGui & S)
+{
+   S.StartScroller();
+   S.SetBorder(2);
+
+   S.StartStatic(_("Target OSC configuration"));
+   {
+      S.StartMultiColumn(2,wxEXPAND);
+      {
+         S.SetStretchyCol( 0 );
+         S.SetStretchyCol( 1 );
+         mOSCDestinationHost =
+               S.TieTextBox(_("&Host:"),
+                            wxT("/TransportOSC/Host"),
+                            wxT("localhost"),
+                            50);
+         mOSCDestinationPort =
+               S.TieNumericTextBox(_("&Port:"),
+                                   wxT("/TransportOSC/Port"),
+                                   wxT("9876"),
+                                   5);
+         S.AddFixedText(_("Protocol:"));
+         S.StartMultiColumn(2, wxEXPAND);
+         {
+            S.StartRadioButtonGroup(wxT("/TransportOSC/Protocol"), LO_UDP);
+            {
+               S.TieRadioButton(wxT("TCP"), LO_TCP);
+               S.TieRadioButton(wxT("UDP"), LO_UDP);
+            }
+            S.EndRadioButtonGroup();
+         }
+         S.EndMultiColumn();
+      }
+      S.EndMultiColumn();
+   }
+   S.EndStatic();
+   S.StartStatic(_("Transport triggering"));
+   {
+      S.AddFixedText(_("IMPORTANT: Each message sends, as its lonely argument, the trigger state: 'T' if ON, 'F' else."));
+      S.StartMultiColumn(2,wxEXPAND);
+      {
+         S.SetStretchyCol( 0 );
+         S.SetStretchyCol( 1 );
+         S.StartStatic(_("Record trigger"));
+         {
+            S.TieCheckBox(_("Enable RECORD triggering"),
+                          wxT("/TransportOSC/Record/Triggering"),
+                          true);
+            mOSCRecordAddress =
+                  S.TieTextBox(_("Address:"),
+                               wxT("/TransportOSC/Record/Address"),
+                               wxT("/record"),
+                               50);
+         }
+         S.EndStatic();
+         S.StartStatic(_("Play trigger"));
+         {
+            S.TieCheckBox(_("Enable PLAY triggering"),
+                          wxT("/TransportOSC/Play/Triggering"),
+                          true);
+            mOSCPlayAddress =
+                  S.TieTextBox(_("Address:"),
+                               wxT("/TransportOSC/Play/Address"),
+                               wxT("/play"),
+                               50);
+         }
+         S.EndStatic();
+      }
+      S.EndMultiColumn();
+      S.StartMultiColumn(2,wxEXPAND);
+      {
+         S.SetStretchyCol( 0 );
+         S.SetStretchyCol( 1 );
+         S.StartStatic(_("Stop trigger"));
+         {
+            S.TieCheckBox(_("Enable STOP triggering"),
+                          wxT("/TransportOSC/Stop/Triggering"),
+                          true);
+            mOSCStopAddress =
+                  S.TieTextBox(_("Address:"),
+                               wxT("/TransportOSC/Stop/Address"),
+                               wxT("/stop"),
+                               50);
+         }
+         S.EndStatic();
+         S.StartStatic(_("Pause trigger"));
+         {
+            S.TieCheckBox(_("Enable PAUSE triggering"),
+                          wxT("/TransportOSC/Pause/Triggering"),
+                          true);
+            mOSCPauseAddress =
+                  S.TieTextBox(_("Address:"),
+                               wxT("/TransportOSC/Pause/Address"),
+                               wxT("/pause"),
+                               50);
+         }
+         S.EndStatic();
+      }
+      S.EndMultiColumn();
+      S.StartMultiColumn(2,wxEXPAND);
+      {
+         S.SetStretchyCol( 0 );
+         S.SetStretchyCol( 1 );
+         S.StartStatic(_("Rewind trigger"));
+         {
+            S.TieCheckBox(_("Enable REWIND triggering"),
+                          wxT("/TransportOSC/Rewind/Triggering"),
+                          true);
+            mOSCRewindAddress =
+                  S.TieTextBox(_("Address:"),
+                               wxT("/TransportOSC/Rewind/Address"),
+                               wxT("/rewind"),
+                               50);
+         }
+         S.EndStatic();
+         S.StartStatic(_("FastForward trigger"));
+         {
+            S.TieCheckBox(_("Enable FastForward triggering"),
+                          wxT("/TransportOSC/FastForward/Triggering"),
+                          true);
+            mOSCFastForwardAddress =
+                  S.TieTextBox(_("Address:"),
+                               wxT("/TransportOSC/FastForward/Address"),
+                               wxT("/fastforward"),
+                               50);
+         }
+         S.EndStatic();
+      }
+      S.EndMultiColumn();
+   }
+   S.EndStatic();
+   S.EndScroller();
+}
+
+bool TransportOSCPrefs::Commit()
+{
+   if (!Validate())
+      return false;
+
+   ShuttleGui S(this, eIsSavingToPrefs);
+   PopulateOrExchange(S);
+
+   return true;
+}
+
+bool TransportOSCPrefs::Validate()
+{
+   bool output = true;
+   wxString messageBoxCaption(_("Validation error"));
+
+#ifdef wxUSE_REGEX
+   // Validate the OSC destination host
+   // FQDN host RegExp taken from https://www.regextester.com/23 and set case insensitive
+   wxRegEx reOSCHost(wxString("^(([a-z0-9]|[a-z0-9][-a-z0-9]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][-a-z0-9]*[a-z0-9])$"),
+                     wxRE_EXTENDED|wxRE_ICASE);
+   // IPv4 RegExp available at https://regexr.com/3pjnh
+   wxRegEx reOSCIPv4(wxString("^((25[0-5]|(2[0-4]|1?[1-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[1-9])?[0-9])$"),
+                     wxRE_EXTENDED);
+   if (!reOSCHost.Matches(mOSCDestinationHost->GetValue())
+       && !reOSCIPv4.Matches(mOSCDestinationHost->GetValue()))
+   {
+      AudacityMessageBox(_("OSC host must be a Fully Qualified Domain Name or an IPv4 address"),
+                         messageBoxCaption,
+                         wxOK|wxCENTER|wxICON_ERROR);
+      output = false;
+   }
+
+   // Validate the OSC destination port (TCP or UDP)
+   unsigned long OSCDestinationPort;
+   if (!mOSCDestinationPort->GetValue().ToULong(&OSCDestinationPort))
+   {
+      AudacityMessageBox(_("The destination OSC port (TCP/UDP) must be an unsigned integer"),
+                         messageBoxCaption,
+                         wxOK|wxCENTER|wxICON_ERROR);
+      output = false;
+   }
+   else if (OSCDestinationPort > 65535)
+   {
+      AudacityMessageBox(_("The destination OSC port number (TCP/UDP) must be positive and less or equal than 65535"),
+                         messageBoxCaption,
+                         wxOK|wxCENTER|wxICON_ERROR);
+      output = false;
+   }
+
+   // Validate the triggers addresses
+   wxString errorMessage;
+   // OSC Address pattern available at https://regexr.com/3pkc5
+   wxRegEx reOSCAddress(wxString("^(\\/[a-z0-9?*]*(\\[!?([a-z0-9]|[a-z0-9]-[a-z0-9])+]|\\{([a-z0-9]+,)*[a-z0-9]+\\})*)+$"),
+                        wxRE_EXTENDED|wxRE_ICASE);
+
+   OSCAddresses[wxString("Record")] = mOSCRecordAddress;
+   OSCAddresses[wxString("Play")] = mOSCPlayAddress;
+   OSCAddresses[wxString("Stop")] = mOSCStopAddress;
+   OSCAddresses[wxString("Pause")] = mOSCPauseAddress;
+   OSCAddresses[wxString("Rewind")] = mOSCRewindAddress;
+   OSCAddresses[wxString("FastForward")] = mOSCFastForwardAddress;
+   for (auto &OSCAddress : OSCAddresses)
+   {
+      if (!reOSCAddress.Matches(OSCAddress.second->GetValue()))
+      {
+         errorMessage.Printf(_("The OSC %s trigger address \"%s\" is not valid"),
+                             OSCAddress.first,
+                             OSCAddress.second->GetValue());
+         AudacityMessageBox(errorMessage,
+                            messageBoxCaption,
+                            wxOK|wxCENTER|wxICON_ERROR);
+         output = false;
+      }
+   }
+
+#endif
+   return output;
+}
+
+wxString TransportOSCPrefs::HelpPageName()
+{
+   return "TransportOSC_Preferences";
+}
+
+PrefsPanel *TransportOSCPrefsFactory::operator () (wxWindow *parent, wxWindowID winid)
+{
+   wxASSERT(parent); // to justify safenew
+   return safenew TransportOSCPrefs(parent, winid);
+}
+
+#endif

--- a/src/prefs/TransportOSCPrefs.h
+++ b/src/prefs/TransportOSCPrefs.h
@@ -1,0 +1,63 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  TransportOSCPrefs.h by Grégory David <groolot@groolot.net>
+
+  Based on PalybackPrefs.h by:
+   - Joshua Haberman
+   - James Crook
+
+**********************************************************************/
+
+#include "../Experimental.h"
+
+#ifdef USE_LIBLO
+
+#ifndef __AUDACITY_TRANSPORT_OSC_PREFS__
+#define __AUDACITY_TRANSPORT_OSC_PREFS__
+
+class ShuttleGui;
+class wxTextCtrl;
+
+#include <map>
+
+#include <wx/defs.h>
+#include <lo/lo.h>
+
+#include "PrefsPanel.h"
+
+class TransportOSCPrefs final : public PrefsPanel
+{
+ public:
+   TransportOSCPrefs(wxWindow * parent, wxWindowID winid);
+   virtual ~TransportOSCPrefs();
+   bool Commit() override;
+   bool Validate();
+   wxString HelpPageName() override;
+   void PopulateOrExchange(ShuttleGui & S) override;
+
+ private:
+   void Populate();
+
+   wxTextCtrl *mOSCDestinationHost;
+   wxTextCtrl *mOSCDestinationPort;
+   wxTextCtrl *mOSCRecordAddress;
+   wxTextCtrl *mOSCPlayAddress;
+   wxTextCtrl *mOSCStopAddress;
+   wxTextCtrl *mOSCPauseAddress;
+   wxTextCtrl *mOSCRewindAddress;
+   wxTextCtrl *mOSCFastForwardAddress;
+
+   std::map<wxString, wxTextCtrl *> OSCAddresses;
+};
+
+class TransportOSCPrefsFactory final : public PrefsPanelFactory
+{
+public:
+   PrefsPanel *operator () (wxWindow *parent, wxWindowID winid) override;
+};
+
+#endif // __AUDACITY_TRANSPORT_OSC_PREFS__
+
+#endif // USE_LIBLO

--- a/src/toolbars/ControlToolBar.h
+++ b/src/toolbars/ControlToolBar.h
@@ -18,6 +18,11 @@
 #include "ToolBar.h"
 #include "../Theme.h"
 
+#ifdef USE_LIBLO
+#include <lo/lo.h>
+#include <lo/lo_cpp.h>
+#endif
+
 class wxBoxSizer;
 class wxCommandEvent;
 class wxDC;
@@ -49,6 +54,10 @@ class ControlToolBar final : public ToolBar {
    void Create(wxWindow *parent) override;
 
    void UpdatePrefs() override;
+   void LoadPrefs();
+#ifdef USE_LIBLO
+   void LoadPrefsOSC(bool init=false);
+#endif
    void OnKeyEvent(wxKeyEvent & event);
 
    // msmeyer: These are public, but it's far better to
@@ -176,6 +185,27 @@ class ControlToolBar final : public ToolBar {
    wxString mStateStop;
    wxString mStateRecord;
    wxString mStatePause;
+
+#ifdef USE_LIBLO
+   // OSC configuration
+   lo::Address *mOSCAddress;
+   wxString mOSCDestinationHost;
+   wxString mOSCDestinationPort;
+   int mOSCDestinationProtocol;
+   // Triggers
+   bool mOSCRecordTriggering;
+   bool mOSCPlayTriggering;
+   bool mOSCStopTriggering;
+   bool mOSCPauseTriggering;
+   bool mOSCRewindTriggering;
+   bool mOSCFastForwardTriggering;
+   wxString mOSCRecordAddress;
+   wxString mOSCPlayAddress;
+   wxString mOSCStopAddress;
+   wxString mOSCPauseAddress;
+   wxString mOSCRewindAddress;
+   wxString mOSCFastForwardAddress;
+#endif
 
  public:
 

--- a/src/toolbars/ControlToolBar.h
+++ b/src/toolbars/ControlToolBar.h
@@ -20,7 +20,6 @@
 
 #ifdef USE_LIBLO
 #include <lo/lo.h>
-#include <lo/lo_cpp.h>
 #endif
 
 class wxBoxSizer;
@@ -188,7 +187,7 @@ class ControlToolBar final : public ToolBar {
 
 #ifdef USE_LIBLO
    // OSC configuration
-   lo::Address *mOSCAddress;
+   lo_address mOSCAddress;
    wxString mOSCDestinationHost;
    wxString mOSCDestinationPort;
    int mOSCDestinationProtocol;

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -91,6 +91,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_c99_func_lrint.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libexpat.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libflac.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libid3tag.m4 \
+	$(top_srcdir)/m4/audacity_checklib_liblo.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libmad.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libnyquist.m4 \
 	$(top_srcdir)/m4/audacity_checklib_libsbsms.m4 \
@@ -485,6 +486,8 @@ LD = @LD@
 LDFLAGS = @LDFLAGS@
 LIBICONV = @LIBICONV@
 LIBINTL = @LIBINTL@
+LIBLO_CFLAGS = @LIBLO_CFLAGS@
+LIBLO_LIBS = @LIBLO_LIBS@
 LIBMAD_CFLAGS = @LIBMAD_CFLAGS@
 LIBMAD_LIBS = @LIBMAD_LIBS@
 LIBNYQUIST_CFLAGS = @LIBNYQUIST_CFLAGS@


### PR DESCRIPTION
# Description
Based on the Transport buttons triggering, OSC messages are sent to a configurable (through Preferences settings) target.

Each button is configurable seperatly.

# Goal
The aim of this feature is to help, in a school webradio studio, drive a Raspberry PI light switch to advise people outside the studio that RECORDING is ON.

By simply send an OSC message when triggering button, no more switch handling is necessary.