### PR TITLE
EBU R128 loudness normalization and normalize progress bar bugfix

### DIFF
--- a/src/effects/Biquad.cpp
+++ b/src/effects/Biquad.cpp
@@ -1,3 +1,14 @@
+/**********************************************************************
+
+Audacity: A Digital Audio Editor
+
+EffectScienFilter.h
+
+Norm C
+Max Maisel
+
+***********************************************************************/
+
 #include "Biquad.h"
 
 #define square(a) ((a)*(a))

--- a/src/effects/Biquad.cpp
+++ b/src/effects/Biquad.cpp
@@ -2,31 +2,30 @@
 
 #define square(a) ((a)*(a))
 
-void Biquad_Process (BiquadStruct* pBQ, int iNumSamples)
+Biquad::Biquad()
 {
-   float* pfIn = pBQ->pfIn;
-   float* pfOut = pBQ->pfOut;
-   float fPrevIn = pBQ->fPrevIn;
-   float fPrevPrevIn = pBQ->fPrevPrevIn;
-   float fPrevOut = pBQ->fPrevOut;
-   float fPrevPrevOut = pBQ->fPrevPrevOut;
+   pfIn = 0;
+   pfOut = 0;
+   fNumerCoeffs[B0] = 1;
+   fNumerCoeffs[B1] = 0;
+   fNumerCoeffs[B2] = 0;
+   fDenomCoeffs[A1] = 0;
+   fDenomCoeffs[A2] = 0;
+   Reset();
+}
+
+void Biquad::Reset()
+{
+   fPrevIn = 0;
+   fPrevPrevIn = 0;
+   fPrevOut = 0;
+   fPrevPrevOut = 0;
+}
+
+void Biquad::Process(int iNumSamples)
+{
    for (int i = 0; i < iNumSamples; i++)
-   {
-      float fIn = *pfIn++;
-      *pfOut = fIn * pBQ->fNumerCoeffs [0] +
-         fPrevIn * pBQ->fNumerCoeffs [1] +
-         fPrevPrevIn * pBQ->fNumerCoeffs [2] -
-         fPrevOut * pBQ->fDenomCoeffs [0] -
-         fPrevPrevOut * pBQ->fDenomCoeffs [1];
-      fPrevPrevIn = fPrevIn;
-      fPrevIn = fIn;
-      fPrevPrevOut = fPrevOut;
-      fPrevOut = *pfOut++;
-   }
-   pBQ->fPrevIn = fPrevIn;
-   pBQ->fPrevPrevIn = fPrevPrevIn;
-   pBQ->fPrevOut = fPrevOut;
-   pBQ->fPrevPrevOut = fPrevPrevOut;
+      *pfOut++ = ProcessOne(*pfIn++);
 }
 
 void ComplexDiv (float fNumerR, float fNumerI, float fDenomR, float fDenomI, float* pfQuotientR, float* pfQuotientI)

--- a/src/effects/Biquad.h
+++ b/src/effects/Biquad.h
@@ -1,3 +1,14 @@
+/**********************************************************************
+
+Audacity: A Digital Audio Editor
+
+EffectScienFilter.h
+
+Norm C
+Max Maisel
+
+***********************************************************************/
+
 #ifndef __BIQUAD_H__
 #define __BIQUAD_H__
 

--- a/src/effects/Biquad.h
+++ b/src/effects/Biquad.h
@@ -1,37 +1,44 @@
 #ifndef __BIQUAD_H__
 #define __BIQUAD_H__
 
-#if 0
-//initialisations not supported in MSVC 2013.
-//Gives error C2905
-// Do not make conditional on compiler.
-typedef struct {
-   float* pfIn {};
-   float* pfOut {};
-   float fNumerCoeffs [3] { 1.0f, 0.0f, 0.0f };	// B0 B1 B2
-   float fDenomCoeffs [2] { 0.0f, 0.0f };	// A1 A2
-   float fPrevIn {};
-   float fPrevPrevIn {};
-   float fPrevOut {};
-   float fPrevPrevOut {};
-} BiquadStruct;
-#else
-// WARNING: This structure may need initialisation.
-typedef struct {
+struct Biquad
+{
+   Biquad();
+   void Reset();
+   void Process(int iNumSamples);
+
+   enum
+   {
+      /// Numerator coefficient indices
+      B0=0, B1, B2,
+      /// Denominator coefficient indices
+      A1=0, A2
+   };
+
+   inline float ProcessOne(float fIn)
+   {
+      float fOut = fIn * fNumerCoeffs[B0] +
+            fPrevIn * fNumerCoeffs[B1] +
+            fPrevPrevIn * fNumerCoeffs[B2] -
+            fPrevOut * fDenomCoeffs[A1] -
+            fPrevPrevOut * fDenomCoeffs[A2];
+      fPrevPrevIn = fPrevIn;
+      fPrevIn = fIn;
+      fPrevPrevOut = fPrevOut;
+      fPrevOut = fOut;
+      return fOut;
+   }
+
    float* pfIn;
    float* pfOut;
-   float fNumerCoeffs [3];	// B0 B1 B2
-   float fDenomCoeffs [2];	// A1 A2
+   float fNumerCoeffs[3]; // B0 B1 B2
+   float fDenomCoeffs[2]; // A1 A2, A0 == 1.0
    float fPrevIn;
    float fPrevPrevIn;
    float fPrevOut;
    float fPrevPrevOut;
-} BiquadStruct;
-#endif
+};
 
-
-
-void Biquad_Process (BiquadStruct* pBQ, int iNumSamples);
 void ComplexDiv (float fNumerR, float fNumerI, float fDenomR, float fDenomI, float* pfQuotientR, float* pfQuotientI);
 bool BilinTransform (float fSX, float fSY, float* pfZX, float* pfZY);
 float Calc2D_DistSqr (float fX1, float fY1, float fX2, float fY2);

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1974,10 +1974,10 @@ void Effect::IncludeNotSelectedPreviewTracks(bool includeNotSelected)
    mPreviewWithNotSelected = includeNotSelected;
 }
 
-bool Effect::TotalProgress(double frac)
+bool Effect::TotalProgress(double frac, const wxString &msg)
 {
    auto updateResult = (mProgress ?
-      mProgress->Update(frac) :
+      mProgress->Update(frac, msg) :
       ProgressResult::Success);
    return (updateResult != ProgressResult::Success);
 }

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -330,7 +330,7 @@ protected:
    // is okay, but don't try to undo).
 
    // Pass a fraction between 0.0 and 1.0
-   bool TotalProgress(double frac);
+   bool TotalProgress(double frac, const wxString & = wxEmptyString);
 
    // Pass a fraction between 0.0 and 1.0, for the current track
    // (when doing one track at a time)

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -59,12 +59,12 @@ private:
    // EffectNormalize implementation
 
    bool ProcessOne(
-      WaveTrack * t, const wxString &msg, int curTrackNum, float offset);
+      WaveTrack * t, const wxString &msg, double& progress, float offset);
    bool AnalyseTrack(const WaveTrack * track, const wxString &msg,
-                     int curTrackNum,
+                     double &progress,
                      float &offset, float &min, float &max);
    void AnalyzeData(float *buffer, size_t len);
-   bool AnalyseDC(const WaveTrack * track, const wxString &msg, int curTrackNum,
+   bool AnalyseDC(const WaveTrack * track, const wxString &msg, double &progress,
                   float &offset);
    void ProcessData(float *buffer, size_t len, float offset);
 

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -61,8 +61,7 @@ private:
    bool ProcessOne(
       WaveTrack * t, const wxString &msg, double& progress, float offset);
    bool AnalyseTrack(const WaveTrack * track, const wxString &msg,
-                     double &progress,
-                     float &offset, float &min, float &max);
+                     double &progress, float &offset, float &extent);
    void AnalyzeData(float *buffer, size_t len);
    bool AnalyseDC(const WaveTrack * track, const wxString &msg, double &progress,
                   float &offset);

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -6,6 +6,7 @@
 
   Dominic Mazzoni
   Vaughan Johnson (Preview)
+  Max Maisel (Loudness)
 
 **********************************************************************/
 
@@ -19,6 +20,7 @@
 #include <wx/textctrl.h>
 
 #include "Effect.h"
+#include "Biquad.h"
 
 class ShuttleGui;
 
@@ -58,14 +60,24 @@ public:
 private:
    // EffectNormalize implementation
 
+   enum AnalyseOperation
+   {
+      ANALYSE_DC, ANALYSE_LOUDNESS, ANALYSE_LOUDNESS_DC
+   };
+
    bool ProcessOne(
       WaveTrack * t, const wxString &msg, double& progress, float offset);
    bool AnalyseTrack(const WaveTrack * track, const wxString &msg,
                      double &progress, float &offset, float &extent);
-   void AnalyzeData(float *buffer, size_t len);
-   bool AnalyseDC(const WaveTrack * track, const wxString &msg, double &progress,
-                  float &offset);
+   bool AnalyseTrackData(const WaveTrack * track, const wxString &msg, double &progress,
+                     AnalyseOperation op, float &offset);
+   void AnalyseDataDC(float *buffer, size_t len);
+   void AnalyseDataLoudness(float *buffer, size_t len);
+   void AnalyseDataLoudnessDC(float *buffer, size_t len);
    void ProcessData(float *buffer, size_t len, float offset);
+
+   void CalcEBUR128HPF(float fs);
+   void CalcEBUR128HSF(float fs);
 
    void OnUpdateUI(wxCommandEvent & evt);
    void UpdateUI();
@@ -75,11 +87,13 @@ private:
    bool   mGain;
    bool   mDC;
    bool   mStereoInd;
+   bool   mUseLoudness;
 
    double mCurT0;
    double mCurT1;
    float  mMult;
    double mSum;
+   double mSqSum;
    sampleCount    mCount;
 
    wxCheckBox *mGainCheckBox;
@@ -87,9 +101,12 @@ private:
    wxTextCtrl *mLevelTextCtrl;
    wxStaticText *mLeveldB;
    wxStaticText *mWarning;
+   wxCheckBox *mUseLoudnessCheckBox;
    wxCheckBox *mStereoIndCheckBox;
 
    bool mCreating;
+   Biquad mR128HSF;
+   Biquad mR128HPF;
 
    DECLARE_EVENT_TABLE()
 };

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -218,12 +218,7 @@ unsigned EffectScienFilter::GetAudioOutCount()
 bool EffectScienFilter::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
 {
    for (int iPair = 0; iPair < (mOrder + 1) / 2; iPair++)
-   {
-      mpBiquad[iPair].fPrevIn = 0;
-      mpBiquad[iPair].fPrevPrevIn = 0;
-      mpBiquad[iPair].fPrevOut = 0;
-      mpBiquad[iPair].fPrevPrevOut = 0;
-   }
+      mpBiquad[iPair].Reset();
 
    return true;
 }
@@ -235,7 +230,7 @@ size_t EffectScienFilter::ProcessBlock(float **inBlock, float **outBlock, size_t
    {
       mpBiquad[iPair].pfIn = ibuf;
       mpBiquad[iPair].pfOut = outBlock[0];
-      Biquad_Process(&mpBiquad[iPair], blockLen);
+      mpBiquad[iPair].Process(blockLen);
       ibuf = outBlock[0];
    }
 

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -102,7 +102,7 @@ private:
    int mFilterSubtype;	// lowpass, highpass
    int mOrder;
    int mOrderIndex;
-   ArrayOf<BiquadStruct> mpBiquad;
+   ArrayOf<Biquad> mpBiquad;
 
    double mdBMax;
    double mdBMin;


### PR DESCRIPTION
This pull request implements EBU R128 loudness normalization in the Normalize effect.

It also refactors some parts of Biquad to allow code reuse in the 
loudness weighting filter implementation and fixes an existing bug in the
Normalize progress bar when normalizing stereo tracks.

More details about the changes can be found in the individual commit messages.