### PR TITLE
Normalize fixes and improvements

### DIFF
--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -239,6 +239,11 @@ bool EffectNormalize::Process()
                mMult = ratio / extent;
             else
                mMult = 1.0;
+
+            if(mUseLoudness)
+               // LUFS is defined as -0.691 dB + 10*log10(sum(channels))
+               extent *= 0.8529037031;
+
             msg =
                topMsg + wxString::Format( _("Processing: %s"), trackName );
             if(track->GetLinked() || prevTrack->GetLinked())  // only get here if there is a linked track but we are processing independently
@@ -267,9 +272,13 @@ bool EffectNormalize::Process()
                 break;
 
             if (mUseLoudness)
+            {
                // Loudness: use sum of both tracks.
                // As a result, stereo tracks appear about 3 LUFS louder, as specified.
                extent = extent + extent2;
+               // LUFS is defined as -0.691 dB + 10*log10(sum(channels))
+               extent *= 0.8529037031;
+            }
             else
                // Peak: use maximum of both tracks.
                extent = fmax(extent, extent2);

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -414,7 +414,6 @@ bool EffectNormalize::AnalyseTrack(const WaveTrack * track, const wxString &msg,
 
          if(mDC)
          {
-            min = -1.0, max = 1.0;   // sensible defaults?
             result = AnalyseTrackData(track, msg, progress, ANALYSE_DC, offset);
             min += offset;
             max += offset;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -260,8 +260,9 @@ bool EffectNormalize::Process()
                 break;
 
             if (mUseLoudness)
-               // Loudness: use mean of both tracks.
-               extent = (extent + extent2) / 2;
+               // Loudness: use sum of both tracks.
+               // As a result, stereo tracks appear about 3 LUFS louder, as specified.
+               extent = extent + extent2;
             else
                // Peak: use maximum of both tracks.
                extent = fmax(extent, extent2);

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -615,7 +615,11 @@ void EffectNormalize::ProcessData(float *buffer, size_t len, float offset)
    }
 }
 
-// after Juha, https://hydrogenaud.io/index.php/topic,76394.0.html
+// EBU R128 parameter sampling rate adaption after
+// Mansbridge, Stuart, Saoirse Finn, and Joshua D. Reiss.
+// "Implementation and Evaluation of Autonomous Multi-track Fader Control."
+// Paper presented at the 132nd Audio Engineering Society Convention,
+// Budapest, Hungary, 2012."
 void EffectNormalize::CalcEBUR128HPF(float fs)
 {
    double f0 = 38.13547087602444;
@@ -632,7 +636,11 @@ void EffectNormalize::CalcEBUR128HPF(float fs)
    mR128HPF.fDenomCoeffs[Biquad::A2] = (1.0 - K / Q + K * K) / (1.0 + K / Q + K * K);
 }
 
-// after Juha, https://hydrogenaud.io/index.php/topic,76394.0.html
+// EBU R128 parameter sampling rate adaption after
+// Mansbridge, Stuart, Saoirse Finn, and Joshua D. Reiss.
+// "Implementation and Evaluation of Autonomous Multi-track Fader Control."
+// Paper presented at the 132nd Audio Engineering Society Convention,
+// Budapest, Hungary, 2012."
 void EffectNormalize::CalcEBUR128HSF(float fs)
 {
    double db =    3.999843853973347;

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -83,11 +83,13 @@ private:
    void UpdateUI();
 
 private:
-   double mLevel;
+   double mPeakLevel;
+   double mLUFSLevel;
    bool   mGain;
    bool   mDC;
    bool   mStereoInd;
    bool   mUseLoudness;
+   bool   mGUIUseLoudness;
 
    double mCurT0;
    double mCurT1;


### PR DESCRIPTION
This Pull Request fixes an regression introduced by Normalize effect refactoring and
separates user preset values for LUFS and peak normalization.
It also improves the EBU R128 sample rate adaption source references.