### PR TITLE
Don't expose non-translatable strings for translations

### DIFF
--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -6693,7 +6693,7 @@ void AudacityProject::OnSelectClip(bool next)
          if (message.empty())
             message = str;
          else
-            message = wxString::Format(_("%s, %s"), message, str);
+            message = wxString::Format(wxT("%s, %s"), message, str);
       }
       mTrackPanel->MessageForScreenReader(message);
    }
@@ -7835,7 +7835,7 @@ wxString AudacityProject::ClipBoundaryMessage(const std::vector<FoundClipBoundar
       if (message.empty())
          message = str;
       else
-         message = wxString::Format(_("%s, %s"), message, str);
+         message = wxString::Format(wxT("%s, %s"), message, str);
    }
 
    return message;

--- a/src/effects/ScoreAlignDialog.cpp
+++ b/src/effects/ScoreAlignDialog.cpp
@@ -261,7 +261,7 @@ bool ScoreAlignDialog::TransferDataFromWindow()
    mFramePeriodText->SetLabel(wxString::Format(_("%.2f secs"),
                                                p.mFramePeriod));
    mWindowSizeText->SetLabel(wxString::Format(_("%.2f secs"), p.mWindowSize));
-   mSilenceThresholdText->SetLabel(wxString::Format(_("%.3f"),
+   mSilenceThresholdText->SetLabel(wxString::Format(wxT("%.3f"),
                                                     p.mSilenceThreshold));
    mPresmoothText->SetLabel(p.mPresmoothTime > 0 ?
                             wxString::Format(_("%.2f secs"),

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -807,7 +807,7 @@ void EffectTruncSilence::PopulateOrExchange(ShuttleGui & S)
          vldComp.SetRange(MIN_Compress, MAX_Compress);
          mSilenceCompressPercentT = S.AddTextBox(_("Compress to:"), wxT(""), 12);
          mSilenceCompressPercentT->SetValidator(vldComp);
-         S.AddUnits(_("%"));
+         S.AddUnits(wxT("%"));
       }
       S.EndMultiColumn();
 

--- a/src/export/ExportFLAC.cpp
+++ b/src/export/ExportFLAC.cpp
@@ -82,14 +82,14 @@ ExportFLACOptions::~ExportFLACOptions()
 void ExportFLACOptions::PopulateOrExchange(ShuttleGui & S)
 {
    wxArrayString flacLevelNames, flacLevelLabels;
-   flacLevelLabels.Add(wxT("0")); flacLevelNames.Add(_("0 (fastest)"));
-   flacLevelLabels.Add(wxT("1")); flacLevelNames.Add(_("1"));
-   flacLevelLabels.Add(wxT("2")); flacLevelNames.Add(_("2"));
-   flacLevelLabels.Add(wxT("3")); flacLevelNames.Add(_("3"));
-   flacLevelLabels.Add(wxT("4")); flacLevelNames.Add(_("4"));
-   flacLevelLabels.Add(wxT("5")); flacLevelNames.Add(_("5"));
-   flacLevelLabels.Add(wxT("6")); flacLevelNames.Add(_("6"));
-   flacLevelLabels.Add(wxT("7")); flacLevelNames.Add(_("7"));
+   flacLevelLabels.Add(wxT("0")); flacLevelNames.Add(wxT("0 (fastest)"));
+   flacLevelLabels.Add(wxT("1")); flacLevelNames.Add(wxT("1"));
+   flacLevelLabels.Add(wxT("2")); flacLevelNames.Add(wxT("2"));
+   flacLevelLabels.Add(wxT("3")); flacLevelNames.Add(wxT("3"));
+   flacLevelLabels.Add(wxT("4")); flacLevelNames.Add(wxT("4"));
+   flacLevelLabels.Add(wxT("5")); flacLevelNames.Add(wxT("5"));
+   flacLevelLabels.Add(wxT("6")); flacLevelNames.Add(wxT("6"));
+   flacLevelLabels.Add(wxT("7")); flacLevelNames.Add(wxT("7"));
    flacLevelLabels.Add(wxT("8")); flacLevelNames.Add(_("8 (best)"));
 
    wxArrayString flacBitDepthNames, flacBitDepthLabels;

--- a/src/export/ExportFLAC.cpp
+++ b/src/export/ExportFLAC.cpp
@@ -82,7 +82,7 @@ ExportFLACOptions::~ExportFLACOptions()
 void ExportFLACOptions::PopulateOrExchange(ShuttleGui & S)
 {
    wxArrayString flacLevelNames, flacLevelLabels;
-   flacLevelLabels.Add(wxT("0")); flacLevelNames.Add(wxT("0 (fastest)"));
+   flacLevelLabels.Add(wxT("0")); flacLevelNames.Add(_("0 (fastest)"));
    flacLevelLabels.Add(wxT("1")); flacLevelNames.Add(wxT("1"));
    flacLevelLabels.Add(wxT("2")); flacLevelNames.Add(wxT("2"));
    flacLevelLabels.Add(wxT("3")); flacLevelNames.Add(wxT("3"));

--- a/src/toolbars/ToolDock.cpp
+++ b/src/toolbars/ToolDock.cpp
@@ -376,8 +376,8 @@ END_EVENT_TABLE()
 ToolDock::ToolDock( ToolManager *manager, wxWindow *parent, int dockid ):
    wxPanelWrapper( parent, dockid, wxDefaultPosition, parent->GetSize() )
 {
-   SetLabel( _( "ToolDock" ) );
-   SetName( _( "ToolDock" ) );
+   SetLabel(wxT( "ToolDock" ) );
+   SetName( wxT( "ToolDock" ) );
 
    // Init
    mManager = manager;


### PR DESCRIPTION
There are a few strings that (IMO) probably shouldn't be exposed to translators (things like numbers, pure printf commands, window class names).  I changed the _() macros to wxT().