### PR TITLE
Rewrite commit 1bc0f0f without further changes to lib-src...

### DIFF
--- a/lib-src/libnyquist/nyquist/nyqsrc/audacityfnintdefs.h
+++ b/lib-src/libnyquist/nyquist/nyqsrc/audacityfnintdefs.h
@@ -1,1 +1,0 @@
-extern LVAL xlc_aud_do(void);

--- a/lib-src/libnyquist/nyquist/nyqsrc/audacityfnintptrs.h
+++ b/lib-src/libnyquist/nyquist/nyqsrc/audacityfnintptrs.h
@@ -1,1 +1,0 @@
-  { "AUD-DO",  S, xlc_aud_do}, 

--- a/lib-src/libnyquist/nyquist/nyqsrc/local.c
+++ b/lib-src/libnyquist/nyquist/nyqsrc/local.c
@@ -3,7 +3,6 @@
 /* CHANGE LOG
  * --------------------------------------------------------------------
  * 28Apr03  dm  changes for portability and fix compiler warnings
- * 12Feb18  jkc added aud-do function, that is only available in Audacity.
  */
 
 #include "xlisp.h"
@@ -54,50 +53,3 @@ void print_local_gc_info(void)
              max_sample_block_len) / 1024);
     stdputstr(buf);
 }
-
-
-
-
-/*--------------------Audacity Automation -------------------------*/
-/* These functions may later move to their own source file. */
-extern void * ExecForLisp( char * pIn );
-extern void * nyq_make_opaque_string( int size, unsigned char *src );
-
-
-void * nyq_make_opaque_string( int size, unsigned char *src ){
-    LVAL dst;
-    unsigned char * dstp;
-    dst = new_string((int)(size+2));
-    dstp = getstring(dst);
-
-    /* copy the source to the destination */
-    while (size-- > 0)
-        *dstp++ = *src++;
-    *dstp = '\0';
-
-    return (void*)dst;
-}
-
-/* xlc_aud_do -- interface to C routine aud_do */
-/**/
-LVAL xlc_aud_do(void)
-{
-// Based on string-trim...
-    unsigned char *leftp,*rightp;
-    LVAL src,dst;
-
-    /* get the string */
-    src = xlgastring();
-    xllastarg();
-
-    /* setup the string pointers */
-    leftp = getstring(src);
-    rightp = leftp + getslength(src) - 2;
-
-    // Go call my real function here...
-    dst = (LVAL)ExecForLisp( leftp );
-
-    /* return the new string */
-    return (dst);
-}
-

--- a/lib-src/libnyquist/nyquist/nyqsrc/localdefs.h
+++ b/lib-src/libnyquist/nyquist/nyqsrc/localdefs.h
@@ -1,4 +1,3 @@
 /* include actual local file headers: */
 #include "sndfnintdefs.h"
 #include "seqfnintdefs.h"
-#include "audacityfnintdefs.h"

--- a/lib-src/libnyquist/nyquist/nyqsrc/localptrs.h
+++ b/lib-src/libnyquist/nyquist/nyqsrc/localptrs.h
@@ -2,11 +2,8 @@
  *
  * CHANGE LOG
  * 28-Apr-03  rbd  Removed "include switches.h" -- already included
- * 12-Feb-18  jkc  Added "include audacityfnintptrs.h" -- for internal Audacity commands
  */
  
 /* extension to xlisp */
 #include "sndfnintptrs.h"
 #include "seqfnintptrs.h"
-#include "audacityfnintptrs.h"
-

--- a/src/commands/ScriptCommandRelay.cpp
+++ b/src/commands/ScriptCommandRelay.cpp
@@ -138,15 +138,9 @@ int ExecCommand2(wxString *pIn, wxString *pOut)
 
 
 
-#ifdef __cplusplus
-extern "C" {
 // The void * return is actually a Lisp LVAL and will be cast to such as needed.
 extern void * ExecForLisp( char * pIn );
 extern void * nyq_make_opaque_string( int size, unsigned char *src );
-};
-
-
-#endif
 
 void * ExecForLisp( char * pIn ){
    wxString Str1( pIn );

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -3159,6 +3159,49 @@ static LVAL ngettext()
       wxGetTranslation(string1, string2, number).mb_str(wxConvUTF8));
 }
 
+/*--------------------Audacity Automation -------------------------*/
+/* These functions may later move to their own source file. */
+extern void * ExecForLisp( char * pIn );
+extern void * nyq_make_opaque_string( int size, unsigned char *src );
+
+
+void * nyq_make_opaque_string( int size, unsigned char *src ){
+    LVAL dst;
+    unsigned char * dstp;
+    dst = new_string((int)(size+2));
+    dstp = getstring(dst);
+
+    /* copy the source to the destination */
+    while (size-- > 0)
+        *dstp++ = *src++;
+    *dstp = '\0';
+
+    return (void*)dst;
+}
+
+/* xlc_aud_do -- interface to C routine aud_do */
+/**/
+LVAL xlc_aud_do(void)
+{
+// Based on string-trim...
+    unsigned char *leftp,*rightp;
+    LVAL src,dst;
+
+    /* get the string */
+    src = xlgastring();
+    xllastarg();
+
+    /* setup the string pointers */
+    leftp = getstring(src);
+    rightp = leftp + getslength(src) - 2;
+
+    // Go call my real function here...
+    dst = (LVAL)ExecForLisp( (char *)leftp );
+
+    /* return the new string */
+    return (dst);
+}
+
 static void RegisterFunctions()
 {
    // Add functions to XLisp.  Do this only once,
@@ -3170,8 +3213,9 @@ static void RegisterFunctions()
       static const FUNDEF functions[] = {
          { "_", SUBR, gettext },
          { "ngettext", SUBR, ngettext },
-      };
+         { "AUD-DO",  SUBR, xlc_aud_do },
+       };
 
-      xlbindfunctions( functions, sizeof(functions)/sizeof(*functions) );
+      xlbindfunctions( functions, WXSIZEOF( functions ) );
    }
 }


### PR DESCRIPTION
... Reuse the external function registration added earlier in 2.3.0
development, for support of internationalization in Nyquist.

This way, we avoid making cyclic static linkage dependencies between the
library and the application.