### PR TITLE
Scrubbing rewrite 1

### DIFF
--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -24,7 +24,9 @@ class RingBuffer {
    //
 
    size_t AvailForPut();
-   size_t Put(samplePtr buffer, sampleFormat format, size_t samples);
+   size_t Put(samplePtr buffer, sampleFormat format, size_t samples,
+              // optional number of trailing zeroes
+              size_t padding = 0);
    size_t Clear(sampleFormat format, size_t samples);
 
    //


### PR DESCRIPTION
This includes preliminaries for rewriting scrubbing without the condition variable, by having only two threads left to contend for the relevant mutex -- not three.

It also rewrites the update of play head position drawn during scrubbing, anticipating other developments of improved seeking and adjusting loop play, though these may be seen as irrelevancies to the more immediate problems of 2.3.0.

