### PR TITLE
[WIP] Add travis CI for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,19 @@ addons:
         packages:
             - g++-4.9
             - gcc-4.9
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y libwxgtk3.0-dev libgtk2.0-dev gettext autopoint libasound2-dev alsa-utils alsa-oss
-    - git show -s --format="#define REV_LONG \"%H\"%n#define REV_TIME \"%cd\"%n" | tee ./src/RevisionIdent.h
-    - export CXX="g++-4.9" CC="gcc-4.9"
-    - FLAGS="-w -std=gnu++11"
-    - export CFLAGS="$CFLAGS $FLAGS"
-    - export CXXFLAGS="$CXXFLAGS $FLAGS"
-    - g++-4.9 --version
+matrix:
+  include:
+    - os: linux
+      before_install:
+        - sudo apt-get update -qq
+        - sudo apt-get install -y libwxgtk3.0-dev libgtk2.0-dev gettext autopoint libasound2-dev alsa-utils alsa-oss
+        - git show -s --format="#define REV_LONG \"%H\"%n#define REV_TIME \"%cd\"%n" | tee ./src/RevisionIdent.h
+        - export CXX="g++-4.9" CC="gcc-4.9"
+        - FLAGS="-w -std=gnu++11"
+        - export CFLAGS="$CFLAGS $FLAGS"
+        - export CXXFLAGS="$CXXFLAGS $FLAGS"
+        - g++-4.9 --version
+
 language:
     - cpp
 script:

--- a/README.txt
+++ b/README.txt
@@ -69,7 +69,7 @@ Improvements
 
  * New feature - "Punch and Roll Recording".
  * Pinned-play-head can now be repositioned by dragging
- * Play-at-speed now can be adjusted whilst playing.
+ * Play-at-Speed now can be adjusted whilst playing.
  * Toolbars controlling volume and speed can now be resized for greater precision
  * Macros (formerly 'Chains') substantially extended
    * New Macro palette

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -313,7 +313,15 @@ wxCheckBox * ShuttleGuiBase::AddCheckBox( const wxString &Prompt, const wxString
    mpWind = pCheckBox = safenew wxCheckBox(GetParent(), miId, realPrompt, wxDefaultPosition, wxDefaultSize,
       Style( 0 ));
    pCheckBox->SetValue(Selected == wxT("true"));
-   pCheckBox->SetName(wxStripMenuCodes(Prompt));
+   if (realPrompt.IsEmpty()) {
+      // NVDA 2018.3 does not read controls which are buttons, check boxes or radio buttons which have
+      // an accessibility name which is empty. Bug 1980.
+#if wxUSE_ACCESSIBILITY
+      // so that name can be set on a standard control
+      pCheckBox->SetAccessible(safenew WindowAccessible(pCheckBox));
+#endif
+      pCheckBox->SetName(wxT("\a"));      // non-empty string which screen readers do not read
+   }
    UpdateSizers();
    return pCheckBox;
 }

--- a/src/widgets/ASlider.cpp
+++ b/src/widgets/ASlider.cpp
@@ -641,6 +641,16 @@ void LWSlider::DrawToBitmap(wxDC & paintDC)
    wxColour backgroundColour = theTheme.Colour(clrTrackInfo);
    if( mHW )
       backgroundColour = mParent->GetBackgroundColour();
+
+   // Bug 1981 workaround.
+   // On Mac the colour may end up being the system background colour.
+   // For some reason (not yet known) the mask does not work in that case.
+   // So perturb the colour very slightly to work around that.
+   // (we can actually perterb it a lot before the anti-aliassing starts 
+   // to look bad)
+   backgroundColour = wxColour( backgroundColour.Red(), 
+      backgroundColour.Green(), 
+      backgroundColour.Blue() ^1 );
    dc.SetBackground(wxBrush(backgroundColour));
    dc.Clear();
 


### PR DESCRIPTION
Here is what I plan to achieve in this PR:

- [ ] Use a build matrix to support linux and osx
- [ ] Compile wxWidget with a SDK support by travis (no Xcode 4.3.3 unfortunately)
- [ ] Compile Audacity

Here is a link to a helpful article: https://wiki.audacityteam.org/wiki/Building_On_Mac

What could benefit if this PR is a success would be posting a compiled DMG here: https://github.com/audacity/audacity/releases