### PR TITLE
Bug 1832: Fix adjusting time track when in logarithmic scale

### DIFF
--- a/src/tracks/ui/EnvelopeHandle.cpp
+++ b/src/tracks/ui/EnvelopeHandle.cpp
@@ -60,7 +60,7 @@ namespace {
       zoomMin = tt.GetRangeLower(), zoomMax = tt.GetRangeUpper();
       if (dB) {
          // MB: silly way to undo the work of GetWaveYPos while still getting a logarithmic scale
-         zoomMin = LINEAR_TO_DB(std::max(1.0e-7, double(dBRange))) / dBRange + 1.0;
+         zoomMin = LINEAR_TO_DB(std::max(1.0e-7, double(zoomMin))) / dBRange + 1.0;
          zoomMax = LINEAR_TO_DB(std::max(1.0e-7, double(zoomMax))) / dBRange + 1.0;
       }
    }


### PR DESCRIPTION
https://bugzilla.audacityteam.org/show_bug.cgi?id=1832

The typo that caused this appears to have been introduced when this code was restructured in 9e0010ec5f.  This ended up causing zoomMin to usually be larger than zoomMax, which caused the hit test to always fail.