### PR TITLE
Link with -latomic if using clang on Linux.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -204,6 +204,14 @@ if test x$enable_universal_binary = xyes; then
    esac
 fi
 
+dnl Check if $CXX is clang by evaluating the version string because
+dnl $ax_cv_cxx_compiler_vendor seems not to work (it is either "gnu" or just empty).
+dnl If $CXX is clang (string is found), grep returns 0 and the if is executed.
+dnl Use /dev/null to suppress grep output to shell.
+if ($CXX --version | grep 'clang version' > /dev/null); then
+    LDFLAGS="${LDFLAGS} -latomic"
+fi
+
 if test x$enable_sse = xyes; then
 
    if test "${ax_cv_cxx_compiler_vendor}" = "gnu"; then


### PR DESCRIPTION
Clang (tested with v7.0 on Arch Linux) needs to link with -latomic on Linux. Otherwise there will be linker errors about undefined references.
This can be easily fixed by checking if we are using clang and conditionally adding "-latomic" to LDFLAGS in configure.ac.