### PR TITLE
Missing <wx/sizer.h> include

### DIFF
--- a/lib-src/FileDialog/win/FileDialogPrivate.cpp
+++ b/lib-src/FileDialog/win/FileDialogPrivate.cpp
@@ -44,6 +44,7 @@
 #include <wx/dynlib.h>
 #include <wx/filename.h>
 #include <wx/scopeguard.h>
+#include <wx/sizer.h>
 #include <wx/tokenzr.h>
 #include <wx/modalhook.h>
 


### PR DESCRIPTION
Without it build on my Windows host fails

# Pull Requests

If you are submitting a pull request, read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 


## The key points: 

* Come over talk with us at the audacity devel email list. If you just rely on the GitHub pull request messages, you may find we ignore or close the pull request for what does not seem to you to be a good reason. Please come and talk. 

* Translators should subscribe to audacity translators email list instead.  The translators list is also the right place for most translation discussion. 

There is a bit more on our wiki about how we use the pull requests and the labels that can be attached to pull requests.

