### PR TITLE
Cosmetic changes to help build from scratch

### DIFF
--- a/linux/build.txt
+++ b/linux/build.txt
@@ -21,7 +21,7 @@ sudo apt-get install build-essential cmake
 
 - Auto-tools are also needed.
 
-sudo apt-get install libasound libgtk2.0-dev libgtk-3-dev
+sudo apt-get install libasound2-dev libgtk2.0-dev libgtk-3-dev
 sudo apt-get install autoconf automake
 
 - Since you will be fetching code from git repositories you 

--- a/win/audacity.iss
+++ b/win/audacity.iss
@@ -296,7 +296,7 @@ Name: "ta"; MessagesFile: "{#Dummy('Tamil', '0449')}"
 Name: "tg"; MessagesFile: "{#Dummy('Tajik', '0428')}"
 Name: "tr"; MessagesFile: "compiler:Languages\Turkish.isl"
 Name: "uk"; MessagesFile: "compiler:Languages\Ukrainian.isl"
-Name: "vi"; MessagesFile: "{#Get('Vietnamese.isl')}"
+Name: "vi"; MessagesFile: "{#Get('Vietnamese.islu')}"
 Name: "zh_CN"; MessagesFile: "{#Get('ChineseSimplified.isl')}"
 Name: "zh_TW"; MessagesFile: "{#Get('ChineseTraditional.isl')}"
 


### PR DESCRIPTION
When building audacity from scratch (following the instructions of course),
I ran into two minor problems:
1. In Ubuntu 16.04: Not all header files was installed.
2. In Windows, when creating the installer the file Vietnamese.isl is missing ,
but I installed the files from the repository https://github.com/jrsoftware/issrc/tree/master/Files/Languages/Unofficial as recommended.
