### PR TITLE
Fix horizontal scrolling also scrolling track vrulers

### DIFF
--- a/src/CellularPanel.cpp
+++ b/src/CellularPanel.cpp
@@ -497,8 +497,7 @@ void CellularPanel::HandleWheelRotation( TrackPanelMouseEvent &tpmEvent )
    }
 
    if(event.GetWheelAxis() == wxMOUSE_WHEEL_HORIZONTAL) {
-      // Two-fingered horizontal swipe on mac is treated like shift-mousewheel
-      event.SetShiftDown(true);
+      tpmEvent.horizontal = true;
       // This makes the wave move in the same direction as the fingers, and the scrollbar
       // thumb moves oppositely
       steps *= -1;

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -380,7 +380,7 @@ unsigned operator()
    auto &window = ProjectWindow::Get( *pProject );
    const auto steps = evt.steps;
 
-   if (event.ShiftDown()
+   if ((event.ShiftDown() || evt.horizontal)
        // Don't pan during smooth scrolling.  That would conflict with keeping
        // the play indicator centered.
        && !scrubber.IsScrollScrubbing()

--- a/src/TrackPanelMouseEvent.h
+++ b/src/TrackPanelMouseEvent.h
@@ -52,6 +52,7 @@ struct TrackPanelMouseEvent
       , whole{ whole_ }
       , pCell{ pCell_ }
       , steps{ 0 }
+      , horizontal{ false }
    {
    }
 
@@ -60,6 +61,7 @@ struct TrackPanelMouseEvent
    const wxSize &whole;
    std::shared_ptr<TrackPanelCell> pCell; // may be NULL
    double steps;  // for mouse wheel rotation
+   bool horizontal;  // true for horizontal mouse wheel motion
 };
 
 #endif

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
@@ -61,7 +61,7 @@ unsigned NoteTrackVRulerControls::HandleWheelRotation
    using namespace RefreshCode;
    const wxMouseEvent &event = evt.event;
 
-   if (!(event.ShiftDown() || event.CmdDown()))
+   if (evt.horizontal || !(event.ShiftDown() || event.CmdDown()))
       return RefreshNone;
 
    // Always stop propagation even if the ruler didn't change.  The ruler

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVRulerControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVRulerControls.cpp
@@ -63,7 +63,7 @@ unsigned WaveformVRulerControls::DoHandleWheelRotation(
    using namespace RefreshCode;
    const wxMouseEvent &event = evt.event;
 
-   if (!(event.ShiftDown() || event.CmdDown()))
+   if (evt.horizontal || !(event.ShiftDown() || event.CmdDown()))
       return RefreshNone;
 
    // Always stop propagation even if the ruler didn't change.  The ruler


### PR DESCRIPTION
See [discussion on audacity-quality](https://sourceforge.net/p/audacity/mailman/message/36448760/).

Basically, just separates the logic for shift-based horizontal scrolling and real horizontal scrolling, and tests for both in the cases where both should be used (scrolling a track horizontally) and only tests for shift when only shift should work.

Test cases:
* Scrolling a wave/note track vruler vertically without <kbd>shift</kbd> &rarr; nothing happens
* Scrolling a wave/note track vruler vertically while holding <kbd>shift</kbd> &rarr; scrolls the track
* Scrolling a wave/note track vruler horizontally without <kbd>shift</kbd> &rarr; nothing happens
* Scrolling a wave/note track vruler horizontally while holding <kbd>shift</kbd> &rarr; nothing happens
* Scrolling the track list vertically without holding <kbd>shift</kbd> &rarr; scrolls vertically
* Scrolling the track list vertically while holding <kbd>shift</kbd> &rarr; scrolls horizontally
* Scrolling the track list horizontally without holding <kbd>shift</kbd> &rarr; scrolls horizontally
* Scrolling the track list horizontally while holding <kbd>shift</kbd> &rarr; scrolls horizontally

I haven't touched the code in `ASlider` and `NumericTextCtrl` (and the scrubbing code), which might also benefit from not using horizontal scrolls (but I think enabling horizontal scrolling on those is probably fine, especially given that many of the sliders are horizontal in the first place).