### PR TITLE
Don't declare snprintf macro for MSVC 2015 and 2017 in lv2

### DIFF
--- a/cmake-proxies/lv2/CMakeLists.txt
+++ b/cmake-proxies/lv2/CMakeLists.txt
@@ -3,7 +3,7 @@ set( TARGET lv2 )
 set( TARGET_SOURCE ${LIB_SRC_DIRECTORY}${TARGET} )
 project( ${TARGET} )
 
-set( SOURCES 
+set( SOURCES
 #${LIB_SRC_DIRECTORY}lv2/sord/src/sordmm_test.cpp
 #${LIB_SRC_DIRECTORY}lv2/suil/src/gtk2_in_qt4.cpp
 #${LIB_SRC_DIRECTORY}lv2/suil/src/qt4_in_gtk2.cpp
@@ -67,17 +67,19 @@ ${LIB_SRC_DIRECTORY}lv2/suil/src/suil_instance.c
 
 )
 # This defines the #define on both Windows and Linux.
-add_definitions( 
+add_definitions(
 -D_LIB
--Dsnprintf=_snprintf
 -Dinline=__inline # Not needed in non CMake version.
 -DHAVE_FMAX
 -DLILV_INTERNAL
 -D_DEBUG
  )
+if( NOT MSVC OR MSVC_VERSION LESS 1900 )
+    add_definitions(-Dsnprintf=_snprintf)
+endif()
 add_library( ${TARGET} STATIC ${SOURCES})
 add_compile_options(/TP)
-target_include_directories( ${TARGET} PRIVATE 
+target_include_directories( ${TARGET} PRIVATE
 ${TARGET_SOURCE}/windows
 ${TARGET_SOURCE}/sord/src
 ${TARGET_SOURCE}/lilv


### PR DESCRIPTION
That declaring breaks build on MSVC 2015/17 (2013 is ok). There is a note about
changed behaviour of snprintf beginning from VS 2015 here:
https://docs.microsoft.com/ru-ru/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=vs-2017#remarks

# Pull Requests

If you are submitting a pull request, read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 


## The key points: 

* Come over talk with us at the audacity devel email list. If you just rely on the GitHub pull request messages, you may find we ignore or close the pull request for what does not seem to you to be a good reason. Please come and talk. 

* Translators should subscribe to audacity translators email list instead.  The translators list is also the right place for most translation discussion. 

There is a bit more on our wiki about how we use the pull requests and the labels that can be attached to pull requests.

