### PR TITLE
Automatically refresh language files when pushing to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,30 @@
-addons:
-    apt:
-        sources:
-            - ubuntu-toolchain-r-test
-        packages:
-            - g++-4.9
-            - gcc-4.9
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y libwxgtk3.0-dev libgtk2.0-dev gettext autopoint libasound2-dev alsa-utils alsa-oss
-    - git show -s --format="#define REV_LONG \"%H\"%n#define REV_TIME \"%cd\"%n" | tee ./src/RevisionIdent.h
-    - export CXX="g++-4.9" CC="gcc-4.9"
-    - FLAGS="-w -std=gnu++11"
-    - export CFLAGS="$CFLAGS $FLAGS"
-    - export CXXFLAGS="$CXXFLAGS $FLAGS"
-    - g++-4.9 --version
-language:
-    - cpp
-script:
-    - mkdir build
-    - cd build
-    - time ../configure && time make modules && time make -j2
-    - ./.travis/refresh-pot.sh
+matrix:
+    include:
+
+        - name: "Build and tests"
+          addons:
+              apt:
+                  sources:
+                      - ubuntu-toolchain-r-test
+                  packages:
+                      - g++-4.9
+                      - gcc-4.9
+          before_install:
+              - sudo apt-get update -qq
+              - sudo apt-get install -y libwxgtk3.0-dev libgtk2.0-dev gettext autopoint libasound2-dev alsa-utils alsa-oss
+              - git show -s --format="#define REV_LONG \"%H\"%n#define REV_TIME \"%cd\"%n" | tee ./src/RevisionIdent.h
+              - export CXX="g++-4.9" CC="gcc-4.9"
+              - FLAGS="-w -std=gnu++11"
+              - export CFLAGS="$CFLAGS $FLAGS"
+              - export CXXFLAGS="$CXXFLAGS $FLAGS"
+              - g++-4.9 --version
+          language:
+              - cpp
+          script:
+              - mkdir build
+              - cd build
+              - time ../configure && time make modules && time make -j2
+
+        - name: "Localization"
+          script:
+              - ./.travis/refresh-pot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ matrix:
     include:
 
         - name: "Build and tests"
+          language: cpp
           addons:
               apt:
                   sources:
@@ -18,8 +19,6 @@ matrix:
               - export CFLAGS="$CFLAGS $FLAGS"
               - export CXXFLAGS="$CXXFLAGS $FLAGS"
               - g++-4.9 --version
-          language:
-              - cpp
           script:
               - mkdir build
               - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script:
     - mkdir build
     - cd build
     - time ../configure && time make modules && time make -j2
+    - ./.travis/refresh-pot.sh

--- a/.travis/refresh-pot.sh
+++ b/.travis/refresh-pot.sh
@@ -58,22 +58,16 @@ grep -v -E '^"POT-Creation-Date: [0-9]{4}-[0-9]{2}-[0-9]{2}' audacity.pot > "${R
 ./update_po_files.sh
 grep -v -E '^"POT-Creation-Date: [0-9]{4}-[0-9]{2}-[0-9]{2}' audacity.pot > "${RPOT_TMPDIR}/audacity.pot-post"
 
-printf '%s: checking changes\n' "${RPOT_COMMIT_NAME_BASE}"
-RPOT_CHANGES_DETECTED=0
-if test -n "$(diff "${RPOT_TMPDIR}/audacity.pot-pre" "${RPOT_TMPDIR}/audacity.pot-pre")"; then
-    printf -- '- changes detected in audacity.pot\n'
-    git add --all "${TRAVIS_BUILD_DIR}/locale/audacity.pot"
-    RPOT_CHANGES_DETECTED=1
-fi
-
-if test ${RPOT_CHANGES_DETECTED} -eq 0; then
+if test -z "$(diff "${RPOT_TMPDIR}/audacity.pot-pre" "${RPOT_TMPDIR}/audacity.pot-pre")"; then
     printf '%s: skipping because assets are already up-to-date\n' "${RPOT_COMMIT_NAME_BASE}"
     exit 0
 fi
-    
+
 printf '%s: commiting and pushing changes.\n' "${RPOT_COMMIT_NAME_BASE}"
 git config user.name "${RPOT_COMMIT_AUTHOR_NAME}"
 git config user.email "${RPOT_COMMIT_AUTHOR_EMAIL}"
+cd "${TRAVIS_BUILD_DIR}/locale"
+git add --all ./audacity.pot ./*.po
 git commit -m "${RPOT_COMMIT_NAME}"
 git remote add deploy "https://${GITHUB_ACCESS_TOKEN}@github.com/${RPOT_REPOSITORY_OWNER}/${RPOT_REPOSITORY_NAME}.git"
 git push deploy "${RPOT_PROCESS_BRANCH}" -vvv

--- a/.travis/refresh-pot.sh
+++ b/.travis/refresh-pot.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+# We'll refresh the .pot files only when pushing to this branch
+RPOT_PROCESS_BRANCH='master'
+
+RPOT_REPOSITORY_OWNER='audacity'
+RPOT_REPOSITORY_NAME='audacity'
+RPOT_COMMIT_AUTHOR_NAME='Audacity TravisCI Bot'
+RPOT_COMMIT_AUTHOR_EMAIL='travisci-bot@audacityteam.org'
+RPOT_COMMIT_NAME_BASE='Automatic update of .pot files'
+RPOT_COMMIT_NAME="[skip ci] ${RPOT_COMMIT_NAME_BASE}"
+
+if test "${TRAVIS_PULL_REQUEST:-}" != 'false'; then
+    printf '%s: skipping because it''s a pull request.\n' "${RPOT_COMMIT_NAME_BASE}"
+    exit 0
+fi
+
+if test "${TRAVIS_BRANCH:-}" != "${RPOT_PROCESS_BRANCH}"; then
+    printf '%s: skipping because pushing to "%s" instead of "%s".\n' "${RPOT_COMMIT_NAME_BASE}" "${TRAVIS_BRANCH:-}" "${RPOT_PROCESS_BRANCH}"
+    exit 0
+fi
+
+if test "${TRAVIS_REPO_SLUG:-}" != "${RPOT_REPOSITORY_OWNER}/${RPOT_REPOSITORY_NAME}"; then
+    printf '%s: skipping because repository is "%s" instead of "%s/%s".\n' "${RPOT_COMMIT_NAME_BASE}" "${TRAVIS_REPO_SLUG:-}" "${RPOT_REPOSITORY_OWNER}" "${RPOT_REPOSITORY_NAME}"
+    exit 0
+fi
+
+if test -z "${GITHUB_ACCESS_TOKEN:-}"; then
+    printf '%s: skipping because GITHUB_ACCESS_TOKEN is not available
+To create it:
+ - go to https://github.com/settings/tokens/new
+ - create a new token
+ - sudo apt update
+ - sudo apt install -y build-essential ruby ruby-dev
+ - sudo gem install travis
+ - travis encrypt --repo %s/%s GITHUB_ACCESS_TOKEN=<YOUR_ACCESS_TOKEN>
+ - Add to the env setting of:
+   secure: "encrypted string"
+' "${RPOT_COMMIT_NAME_BASE}" "${RPOT_REPOSITORY_OWNER}" "${RPOT_REPOSITORY_NAME}"
+    exit 0
+fi
+
+printf '%s: checking out %s\n' "${RPOT_COMMIT_NAME_BASE}" "${TRAVIS_BRANCH}"
+git checkout -qf "${TRAVIS_BRANCH}"
+
+RPOT_TMPDIR=$(mktemp -d)
+cleanup () {
+    rm -rf "$RPOT_TMPDIR" || true
+}
+trap cleanup EXIT
+
+printf '%s: updating languages\n' "${RPOT_COMMIT_NAME_BASE}"
+cd "${TRAVIS_BUILD_DIR}/locale"
+grep -v -E '^"POT-Creation-Date: [0-9]{4}-[0-9]{2}-[0-9]{2}' audacity.pot > "${RPOT_TMPDIR}/audacity.pot-pre"
+./update_po_files.sh
+grep -v -E '^"POT-Creation-Date: [0-9]{4}-[0-9]{2}-[0-9]{2}' audacity.pot > "${RPOT_TMPDIR}/audacity.pot-post"
+
+printf '%s: checking changes\n' "${RPOT_COMMIT_NAME_BASE}"
+RPOT_CHANGES_DETECTED=0
+if test -n "$(diff "${RPOT_TMPDIR}/audacity.pot-pre" "${RPOT_TMPDIR}/audacity.pot-pre")"; then
+    printf -- '- changes detected in audacity.pot\n'
+    git add --all "${TRAVIS_BUILD_DIR}/locale/audacity.pot"
+    RPOT_CHANGES_DETECTED=1
+fi
+
+if test ${RPOT_CHANGES_DETECTED} -eq 0; then
+    printf '%s: skipping because assets are already up-to-date\n' "${RPOT_COMMIT_NAME_BASE}"
+    exit 0
+fi
+    
+printf '%s: commiting and pushing changes.\n' "${RPOT_COMMIT_NAME_BASE}"
+git config user.name "${RPOT_COMMIT_AUTHOR_NAME}"
+git config user.email "${RPOT_COMMIT_AUTHOR_EMAIL}"
+git commit -m "${RPOT_COMMIT_NAME}"
+git remote add deploy "https://${GITHUB_ACCESS_TOKEN}@github.com/${RPOT_REPOSITORY_OWNER}/${RPOT_REPOSITORY_NAME}.git"
+git push deploy "${RPOT_PROCESS_BRANCH}" -vvv
+printf '%s: repository updated.\n' "${RPOT_COMMIT_NAME_BASE}"

--- a/.travis/refresh-pot.sh
+++ b/.travis/refresh-pot.sh
@@ -10,7 +10,7 @@ RPOT_REPOSITORY_OWNER='audacity'
 RPOT_REPOSITORY_NAME='audacity'
 RPOT_COMMIT_AUTHOR_NAME='Audacity TravisCI Bot'
 RPOT_COMMIT_AUTHOR_EMAIL='travisci-bot@audacityteam.org'
-RPOT_COMMIT_NAME_BASE='Automatic update of .pot files'
+RPOT_COMMIT_NAME_BASE='Automatic update of language files'
 RPOT_COMMIT_NAME="[skip ci] ${RPOT_COMMIT_NAME_BASE}"
 
 if test "${TRAVIS_PULL_REQUEST:-}" != 'false'; then


### PR DESCRIPTION
As discussed in the audacity-translation mailing list, it'd be useful to automatically update the `locale/audacity.pot` language file, so that it's always up-to-date.

This is implemented by executing a script whenever a push to `master` occurs, which updates the .pot file and commits it back to the repository.
This requires to setup an encrypted environment variable named `GITHUB_ACCESS_TOKEN`, containing a GitHub token created at https://github.com/settings/tokens/new with write access to this repository.
This encrypted `GITHUB_ACCESS_TOKEN` variable should then be added to the `.travis.yml` file ([example](https://github.com/punic/punic/blob/3.3.1/.travis.yml#L18)), or to the administration area of the TravisCI project.