### PR TITLE
Fix loading of LV2 effects that have Event ports (Calf Plugins)

### DIFF
--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -429,7 +429,16 @@ bool LV2Effect::SetHost(EffectHostInterface *host)
       if (!lilv_port_is_a(mPlug, port, gAudio) &&
           !lilv_port_is_a(mPlug, port, gControl))
       {
-         return false;
+         LilvNode* name = lilv_port_get_name(mPlug, port);
+         if (!name)
+            return false;
+
+         if (strcmp(lilv_node_as_string(name), "Events") != 0)
+         {
+            lilv_node_free(name);
+            return false;
+         }
+         lilv_node_free(name);
       }
    }
 


### PR DESCRIPTION
The Calf plugin suite exposes Event ports which is currently not supported or defined in `liblilv`, so instead of flat rejecting the filter, test the port name for `Events` and allow them to load.