### PR TITLE
Note track vertical zooming changes redux

### DIFF
--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -898,6 +898,9 @@ bool NoteTrack::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
          else if (!wxStrcmp(attr, wxT("bottomnote")) &&
                   XMLValueChecker::IsGoodInt(strValue) && strValue.ToLong(&nValue))
             SetBottomNote(nValue);
+         else if (!wxStrcmp(attr, wxT("topnote")) &&
+                  XMLValueChecker::IsGoodInt(strValue) && strValue.ToLong(&nValue))
+            SetTopNote(nValue);
          else if (!wxStrcmp(attr, wxT("data"))) {
              std::string s(strValue.mb_str(wxConvUTF8));
              std::istringstream data(s);
@@ -940,6 +943,7 @@ void NoteTrack::WriteXML(XMLWriter &xmlFile) const
    xmlFile.WriteAttr(wxT("velocity"), (double) saveme->mVelocity);
 #endif
    xmlFile.WriteAttr(wxT("bottomnote"), saveme->mBottomNote);
+   xmlFile.WriteAttr(wxT("topnote"), saveme->mTopNote);
    xmlFile.WriteAttr(wxT("data"), wxString(data.str().c_str(), wxConvUTF8));
    xmlFile.EndTag(wxT("notetrack"));
 }

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -1047,6 +1047,37 @@ void NoteTrack::ZoomTo(const wxRect &rect, int start, int end)
    SetNoteRange(pitch1, pitch2);
 }
 
+void NoteTrack::ZoomAllNotes()
+{
+   Alg_iterator iterator( &GetSeq(), false );
+   iterator.begin();
+   Alg_event_ptr evt;
+
+   // Go through all of the notes, finding the minimum and maximum value pitches.
+   bool hasNotes = false;
+   int minPitch = MaxPitch;
+   int maxPitch = MinPitch;
+
+   while (NULL != (evt = iterator.next())) {
+      if (evt->is_note()) {
+         int pitch = (int) evt->get_pitch();
+         hasNotes = true;
+         if (pitch < minPitch)
+            minPitch = pitch;
+         if (pitch > maxPitch)
+            maxPitch = pitch;
+      }
+   }
+
+   if (!hasNotes) {
+      // Semi-arbitary default values:
+      minPitch = 48;
+      maxPitch = 72;
+   }
+
+   SetNoteRange(minPitch, maxPitch);
+}
+
 NoteTrackDisplayData::NoteTrackDisplayData(const NoteTrack* track, const wxRect &r)
 {
    auto span = track->GetTopNote() - track->GetBottomNote() + 1; // + 1 to make sure it includes both

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -214,9 +214,11 @@ double NoteTrack::GetEndTime() const
 void NoteTrack::DoSetHeight(int h)
 {
    auto oldHeight = GetHeight();
-   auto oldMargin = GetNoteMargin(oldHeight);
+   NoteTrackDisplayData oldData = NoteTrackDisplayData(this, wxRect(0, 0, 1, oldHeight));
+   auto oldMargin = oldData.GetNoteMargin();
    PlayableTrack::DoSetHeight(h);
-   auto margin = GetNoteMargin(h);
+   NoteTrackDisplayData newData = NoteTrackDisplayData(this, wxRect(0, 0, 1, h));
+   auto margin = newData.GetNoteMargin();
    Zoom(
       wxRect{ 0, 0, 1, h }, // only height matters
       h - margin - 1, // preserve bottom note
@@ -979,17 +981,17 @@ void NoteTrack::Zoom(const wxRect &rect, int y, float multiplier, bool center)
    // Construct track rectangle to map pitch to screen coordinates
    // Only y and height are needed:
    wxRect trackRect(0, rect.GetY(), 1, rect.GetHeight());
-   PrepareIPitchToY(trackRect);
-   int clickedPitch = YToIPitch(y);
+   NoteTrackDisplayData data = NoteTrackDisplayData(this, trackRect);
+   int clickedPitch = data.YToIPitch(y);
    // zoom by changing the pitch height
    SetPitchHeight(rect.height, mPitchHeight * multiplier);
-   PrepareIPitchToY(trackRect); // update because mPitchHeight changed
+   NoteTrackDisplayData newData = NoteTrackDisplayData(this, trackRect); // update because mPitchHeight changed
    if (center) {
-      int newCenterPitch = YToIPitch(rect.GetY() + rect.GetHeight() / 2);
+      int newCenterPitch = newData.YToIPitch(rect.GetY() + rect.GetHeight() / 2);
       // center the pitch that the user clicked on
       SetBottomNote(mBottomNote + (clickedPitch - newCenterPitch));
    } else {
-      int newClickedPitch = YToIPitch(y);
+      int newClickedPitch = newData.YToIPitch(y);
       // align to keep the pitch that the user clicked on in the same place
       SetBottomNote(mBottomNote + (clickedPitch - newClickedPitch));
    }
@@ -999,9 +1001,9 @@ void NoteTrack::Zoom(const wxRect &rect, int y, float multiplier, bool center)
 void NoteTrack::ZoomTo(const wxRect &rect, int start, int end)
 {
    wxRect trackRect(0, rect.GetY(), 1, rect.GetHeight());
-   PrepareIPitchToY(trackRect);
-   int topPitch = YToIPitch(start);
-   int botPitch = YToIPitch(end);
+   NoteTrackDisplayData data = NoteTrackDisplayData(this, trackRect);
+   int topPitch = data.YToIPitch(start);
+   int botPitch = data.YToIPitch(end);
    if (topPitch < botPitch) { // swap
       int temp = topPitch; topPitch = botPitch; botPitch = temp;
    }
@@ -1013,7 +1015,20 @@ void NoteTrack::ZoomTo(const wxRect &rect, int start, int end)
    Zoom(rect, (start + end) / 2, trialPitchHeight / mPitchHeight, true);
 }
 
-int NoteTrack::YToIPitch(int y)
+NoteTrackDisplayData::NoteTrackDisplayData(const NoteTrack* track, const wxRect &r)
+{
+   mPitchHeight = track->mPitchHeight;
+   mMargin = std::min(r.height / 4, (GetPitchHeight(1) + 1) / 2);
+
+   mBottom = r.y + r.height - GetNoteMargin() - 1 - GetPitchHeight(1) +
+            (track->GetBottomNote() / 12) * GetOctaveHeight() +
+               GetNotePos(track->GetBottomNote() % 12);
+}
+
+int NoteTrackDisplayData::IPitchToY(int p) const
+{ return mBottom - (p / 12) * GetOctaveHeight() - GetNotePos(p % 12); }
+
+int NoteTrackDisplayData::YToIPitch(int y) const
 {
    y = mBottom - y; // pixels above pitch 0
    int octave = (y / GetOctaveHeight());

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -131,6 +131,8 @@ class AUDACITY_DLL_API NoteTrack final
    /// Sets the top and bottom note (both pitches) automatically, swapping them if needed.
    void SetNoteRange(int note1, int note2);
 
+   /// Zooms so that all notes are visible
+   void ZoomAllNotes();
    /// Zooms so that the entire track is visible
    void ZoomMaxExtent() { SetNoteRange(MinPitch, MaxPitch); }
    /// Shifts all notes vertically by the given pitch

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -64,9 +64,12 @@ using QuantizedTimeAndBeat = std::pair< double, double >;
 
 class StretchHandle;
 
+class NoteTrackDisplayData;
+
 class AUDACITY_DLL_API NoteTrack final
    : public NoteTrackBase
 {
+   friend class NoteTrackDisplayData;
  public:
    NoteTrack(const std::shared_ptr<DirManager> &projDirManager);
    virtual ~NoteTrack();
@@ -145,44 +148,6 @@ class AUDACITY_DLL_API NoteTrack final
    /// If center is true, the result will be centered at y.
    void Zoom(const wxRect &rect, int y, float multiplier, bool center);
    void ZoomTo(const wxRect &rect, int start, int end);
-   int GetNoteMargin(int height) const
-   { return std::min(height / 4, (GetPitchHeight(1) + 1) / 2); }
-   int GetOctaveHeight() const { return GetPitchHeight(12) + 2; }
-   // call this once before a series of calls to IPitchToY(). It
-   // sets mBottom to offset of octave 0 so that mBottomNote
-   // is located at r.y + r.height - (GetNoteMargin() + 1 + GetPitchHeight())
-   void PrepareIPitchToY(const wxRect &r) const {
-       mBottom =
-         r.y + r.height - GetNoteMargin(r.height) - 1 - GetPitchHeight(1) +
-             (mBottomNote / 12) * GetOctaveHeight() +
-                GetNotePos(mBottomNote % 12);
-   }
-   // IPitchToY returns Y coordinate of top of pitch p
-   int IPitchToY(int p) const {
-      return mBottom - (p / 12) * GetOctaveHeight() - GetNotePos(p % 12);
-   }
-   // compute the window coordinate of the bottom of an octave: This is
-   // the bottom of the line separating B and C.
-   int GetOctaveBottom(int oct) const {
-      return IPitchToY(oct * 12) + GetPitchHeight(1) + 1;
-   }
-   // Y coordinate for given floating point pitch (rounded to int)
-   int PitchToY(double p) const {
-      return IPitchToY((int) (p + 0.5));
-   }
-   // Integer pitch corresponding to a Y coordinate
-   int YToIPitch(int y);
-   // map pitch class number (0-11) to pixel offset from bottom of octave
-   // (the bottom of the black line between B and C) to the top of the
-   // note. Note extra pixel separates B(11)/C(0) and E(4)/F(5).
-   int GetNotePos(int p) const
-   { return 1 + GetPitchHeight(p + 1) + (p > 4); }
-   // get pixel offset to top of ith black key note
-   int GetBlackPos(int i) const { return GetNotePos(i * 2 + 1 + (i > 1)); }
-   // GetWhitePos tells where to draw lines between keys as an offset from
-   // GetOctaveBottom. GetWhitePos(0) returns 1, which matches the location
-   // of the line separating B and C
-   int GetWhitePos(int i) const { return 1 + (i * GetOctaveHeight()) / 7; }
    void SetBottomNote(int note)
    {
       if (note < 0)
@@ -254,10 +219,11 @@ class AUDACITY_DLL_API NoteTrack final
    float mVelocity; // velocity offset
 #endif
 
-   // mBottom is the Y offset of pitch 0 (normally off screen)
-   mutable int mBottom;
    int mBottomNote;
+#if 0
+   // Also unused from vertical scrolling
    int mStartBottomNote;
+#endif
 
    // Remember continuous variation for zooming,
    // but it is rounded off whenever drawing:
@@ -273,6 +239,47 @@ class AUDACITY_DLL_API NoteTrack final
 protected:
    std::shared_ptr<TrackControls> DoGetControls() override;
    std::shared_ptr<TrackVRulerControls> DoGetVRulerControls() override;
+};
+
+class NoteTrackDisplayData {
+private:
+   float mPitchHeight;
+   // mBottom is the Y offset of pitch 0 (normally off screen)
+   // Used so that mBottomNote is located at
+   // mY + mHeight - (GetNoteMargin() + 1 + GetPitchHeight())
+   int mBottom;
+   int mMargin;
+public:
+   NoteTrackDisplayData(const NoteTrack* track, const wxRect &r);
+
+   int GetPitchHeight(int factor) const
+   { return std::max(1, (int)(factor * mPitchHeight)); }
+   int GetNoteMargin() const { return mMargin; };
+   int GetOctaveHeight() const { return GetPitchHeight(12) + 2; }
+   // IPitchToY returns Y coordinate of top of pitch p
+   int IPitchToY(int p) const;
+   // compute the window coordinate of the bottom of an octave: This is
+   // the bottom of the line separating B and C.
+   int GetOctaveBottom(int oct) const {
+      return IPitchToY(oct * 12) + GetPitchHeight(1) + 1;
+   }
+   // Y coordinate for given floating point pitch (rounded to int)
+   int PitchToY(double p) const {
+      return IPitchToY((int) (p + 0.5));
+   }
+   // Integer pitch corresponding to a Y coordinate
+   int YToIPitch(int y) const;
+   // map pitch class number (0-11) to pixel offset from bottom of octave
+   // (the bottom of the black line between B and C) to the top of the
+   // note. Note extra pixel separates B(11)/C(0) and E(4)/F(5).
+   int GetNotePos(int p) const
+   { return 1 + GetPitchHeight(p + 1) + (p > 4); }
+   // get pixel offset to top of ith black key note
+   int GetBlackPos(int i) const { return GetNotePos(i * 2 + 1 + (i > 1)); }
+   // GetWhitePos tells where to draw lines between keys as an offset from
+   // GetOctaveBottom. GetWhitePos(0) returns 1, which matches the location
+   // of the line separating B and C
+   int GetWhitePos(int i) const { return 1 + (i * GetOctaveHeight()) / 7; }
 };
 
 #endif // USE_MIDI

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -92,7 +92,6 @@ namespace TrackArt {
                      const WaveTrack *track,
                      const wxRect & rect);
 #ifdef USE_MIDI
-   int GetBottom(NoteTrack *t, const wxRect &rect);
    void DrawNoteBackground(TrackPanelDrawingContext &context,
                            const NoteTrack *track,
                            const wxRect &rect, const wxRect &sel,

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -89,6 +89,7 @@ bool ImportMIDI(const FilePath &fName, NoteTrack * dest)
    // then middle pitch class is D. Round mean_pitch to the nearest D:
    int mid_pitch = ((mean_pitch - 2 + 6) / 12) * 12 + 2;
    dest->SetBottomNote(mid_pitch - 14);
+   dest->SetTopNote(mid_pitch + 13);
    return true;
 }
 

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -69,27 +69,8 @@ bool ImportMIDI(const FilePath &fName, NoteTrack * dest)
    wxString trackNameBase = fName.AfterLast(wxFILE_SEP_PATH).BeforeLast('.');
    dest->SetName(trackNameBase);
    mf.Close();
-   // the mean pitch should be somewhere in the middle of the display
-   Alg_iterator iterator( &dest->GetSeq(), false );
-   iterator.begin();
-   // for every event
-   Alg_event_ptr evt;
-   int note_count = 0;
-   int pitch_sum = 0;
-   while (NULL != (evt = iterator.next())) {
-      // if the event is a note
-       if (evt->get_type() == 'n') {
-           Alg_note_ptr note = (Alg_note_ptr) evt;
-           pitch_sum += (int) note->pitch;
-           note_count++;
-       }
-   }
-   int mean_pitch = (note_count > 0 ? pitch_sum / note_count : 60);
-   // initial track is about 27 half-steps high; if bottom note is C,
-   // then middle pitch class is D. Round mean_pitch to the nearest D:
-   int mid_pitch = ((mean_pitch - 2 + 6) / 12) * 12 + 2;
-   dest->SetBottomNote(mid_pitch - 14);
-   dest->SetTopNote(mid_pitch + 13);
+
+   dest->ZoomAllNotes();
    return true;
 }
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
@@ -104,8 +104,7 @@ enum {
    OnDownOctaveID,
 };
 
-/// This only applies to MIDI tracks.  Presumably, it shifts the
-/// whole sequence by an octave.
+/// Scrolls the note track up or down by an octave
 void NoteTrackMenuTable::OnChangeOctave(wxCommandEvent &event)
 {
    NoteTrack *const pTrack = static_cast<NoteTrack*>(mpData->pTrack);
@@ -114,8 +113,7 @@ void NoteTrackMenuTable::OnChangeOctave(wxCommandEvent &event)
       || event.GetId() == OnDownOctaveID);
 
    const bool bDown = (OnDownOctaveID == event.GetId());
-   pTrack->SetBottomNote
-      (pTrack->GetBottomNote() + ((bDown) ? -12 : 12));
+   pTrack->ShiftNoteRange((bDown) ? -12 : 12);
 
    AudacityProject *const project = ::GetActiveProject();
    project->ModifyState(true);

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
@@ -116,7 +116,7 @@ void NoteTrackMenuTable::OnChangeOctave(wxCommandEvent &event)
    pTrack->ShiftNoteRange((bDown) ? -12 : 12);
 
    AudacityProject *const project = ::GetActiveProject();
-   project->ModifyState(true);
+   project->ModifyState(false);
    mpData->result = RefreshCode::RefreshAll;
 }
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
@@ -76,7 +76,7 @@ unsigned NoteTrackVRulerControls::HandleWheelRotation
    } else if (!event.CmdDown() && event.ShiftDown()) {
       // Scroll some fixed number of notes, independent of zoom level or track height:
       static const int movement = 6; // 6 semitones is half an octave
-      nt->SetBottomNote(nt->GetBottomNote() + (int) (steps * movement));
+      nt->ShiftNoteRange((int) (steps * movement));
    } else {
       return RefreshNone;
    }

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVRulerControls.cpp
@@ -81,7 +81,7 @@ unsigned NoteTrackVRulerControls::HandleWheelRotation
       return RefreshNone;
    }
 
-   pProject->ModifyState(true);
+   pProject->ModifyState(false);
 
    return RefreshCell | UpdateVRuler;
 }

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -147,6 +147,7 @@ HitTestPreview NoteTrackVZoomHandle::Preview
 const int kZoomIn = 6;
 const int kZoomOut = 7;
 const int kZoomReset = 8;
+const int kZoomMax = 9;
 
 enum {
    OnZoomFitVerticalID = 20000,
@@ -164,6 +165,8 @@ enum {
    // Reserve an ample block of ids for spectrum scale types
    OnFirstSpectrumScaleID,
    OnLastSpectrumScaleID = OnFirstSpectrumScaleID + 19,
+
+   OnZoomMaxID,
 };
 ///////////////////////////////////////////////////////////////////////////////
 // Table class
@@ -187,6 +190,7 @@ protected:
 // void OnZoomHalfWave(wxCommandEvent&){ OnZoom( kZoomHalfWave );};
    void OnZoomInVertical(wxCommandEvent&){ OnZoom( kZoomIn );};
    void OnZoomOutVertical(wxCommandEvent&){ OnZoom( kZoomOut );};
+   void OnZoomMax(wxCommandEvent&){ OnZoom( kZoomMax );};
 
 private:
    void DestroyMenu() override
@@ -211,7 +215,7 @@ void NoteTrackVRulerMenuTable::InitMenu(Menu *WXUNUSED(pMenu), void *pUserData)
 void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
    switch( iZoomCode ){
    case kZoomReset:
-      mpData->pTrack->ZoomMaxExtent();
+      mpData->pTrack->ZoomAllNotes();
       break;
    case kZoomIn:
       mpData->pTrack->ZoomIn(mpData->rect, mpData->yy);
@@ -219,7 +223,9 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
    case kZoomOut:
       mpData->pTrack->ZoomOut(mpData->rect, mpData->yy);
       break;
-
+   case kZoomMax:
+      mpData->pTrack->ZoomMaxExtent();
+      break;
    }
    GetActiveProject()->ModifyState(false);
 }
@@ -228,6 +234,7 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
 BEGIN_POPUP_MENU(NoteTrackVRulerMenuTable)
 
    POPUP_MENU_ITEM(OnZoomResetID,      _("Zoom Reset\tShift-Right-Click"), OnZoomReset)
+   POPUP_MENU_ITEM(OnZoomMaxID,        _("Max Zoom"), OnZoomMax)
 
    POPUP_MENU_SEPARATOR()
    POPUP_MENU_ITEM(OnZoomInVerticalID,  _("Zoom In\tLeft-Click/Left-Drag"),  OnZoomInVertical)
@@ -296,8 +303,15 @@ UIHandle::Result NoteTrackVZoomHandle::Release
    }
    else if (event.ShiftDown() || event.RightUp()) {
       if (event.ShiftDown() && event.RightUp()) {
-         // Zoom out completely
-         pTrack->ZoomMaxExtent();
+         auto oldBotNote = pTrack->GetBottomNote();
+         auto oldTopNote = pTrack->GetTopNote();
+         // Zoom out to show all notes
+         pTrack->ZoomAllNotes();
+         if (pTrack->GetBottomNote() == oldBotNote &&
+               pTrack->GetTopNote() == oldTopNote) {
+            // However if we are already showing all notes, zoom out further
+            pTrack->ZoomMaxExtent();
+         }
       } else {
          // Zoom out
          pTrack->ZoomOut(evt.rect, mZoomEnd);

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -148,6 +148,8 @@ const int kZoomIn = 6;
 const int kZoomOut = 7;
 const int kZoomReset = 8;
 const int kZoomMax = 9;
+const int kUpOctave = 10;
+const int kDownOctave = 11;
 
 enum {
    OnZoomFitVerticalID = 20000,
@@ -167,6 +169,9 @@ enum {
    OnLastSpectrumScaleID = OnFirstSpectrumScaleID + 19,
 
    OnZoomMaxID,
+
+   OnUpOctaveID,
+   OnDownOctaveID,
 };
 ///////////////////////////////////////////////////////////////////////////////
 // Table class
@@ -191,6 +196,8 @@ protected:
    void OnZoomInVertical(wxCommandEvent&){ OnZoom( kZoomIn );};
    void OnZoomOutVertical(wxCommandEvent&){ OnZoom( kZoomOut );};
    void OnZoomMax(wxCommandEvent&){ OnZoom( kZoomMax );};
+   void OnUpOctave(wxCommandEvent&){ OnZoom( kUpOctave );};
+   void OnDownOctave(wxCommandEvent&){ OnZoom( kDownOctave );};
 
 private:
    void DestroyMenu() override
@@ -226,6 +233,12 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
    case kZoomMax:
       mpData->pTrack->ZoomMaxExtent();
       break;
+   case kUpOctave:
+      mpData->pTrack->ShiftNoteRange(12);
+      break;
+   case kDownOctave:
+      mpData->pTrack->ShiftNoteRange(-12);
+      break;
    }
    GetActiveProject()->ModifyState(false);
 }
@@ -239,6 +252,10 @@ BEGIN_POPUP_MENU(NoteTrackVRulerMenuTable)
    POPUP_MENU_SEPARATOR()
    POPUP_MENU_ITEM(OnZoomInVerticalID,  _("Zoom In\tLeft-Click/Left-Drag"),  OnZoomInVertical)
    POPUP_MENU_ITEM(OnZoomOutVerticalID, _("Zoom Out\tShift-Left-Click"),     OnZoomOutVertical)
+
+   POPUP_MENU_SEPARATOR()
+   POPUP_MENU_ITEM(OnUpOctaveID,   _("Up &Octave"),   OnUpOctave)
+   POPUP_MENU_ITEM(OnDownOctaveID, _("Down Octa&ve"), OnDownOctave)
 
 END_POPUP_MENU()
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -195,8 +195,6 @@ private:
    }
 
    virtual void InitMenu(Menu *pMenu, void *pUserData) override;
-
-   void OnWaveformScaleType(wxCommandEvent &evt);
 };
 
 NoteTrackVRulerMenuTable &NoteTrackVRulerMenuTable::Instance()
@@ -213,8 +211,7 @@ void NoteTrackVRulerMenuTable::InitMenu(Menu *WXUNUSED(pMenu), void *pUserData)
 void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
    switch( iZoomCode ){
    case kZoomReset:
-      mpData->pTrack->SetBottomNote(0);
-      mpData->pTrack->SetPitchHeight(mpData->rect.height, 1);
+      mpData->pTrack->ZoomMaxExtent();
       break;
    case kZoomIn:
       mpData->pTrack->ZoomIn(mpData->rect, mpData->yy);
@@ -299,8 +296,7 @@ UIHandle::Result NoteTrackVZoomHandle::Release
    else if (event.ShiftDown() || event.RightUp()) {
       if (event.ShiftDown() && event.RightUp()) {
          // Zoom out completely
-         pTrack->SetBottomNote(0);
-         pTrack->SetPitchHeight(evt.rect.height, 1);
+         pTrack->ZoomMaxExtent();
       } else {
          // Zoom out
          pTrack->ZoomOut(evt.rect, mZoomEnd);

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -221,6 +221,7 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
       break;
 
    }
+   GetActiveProject()->ModifyState(false);
 }
 
 
@@ -307,7 +308,7 @@ UIHandle::Result NoteTrackVZoomHandle::Release
    }
 
    mZoomEnd = mZoomStart = 0;
-   pProject->ModifyState(true);
+   pProject->ModifyState(false);
 
    return RefreshAll;
 }


### PR DESCRIPTION
An updated version of #232.  Contains fixes for [bug 1820](https://bugzilla.audacityteam.org/show_bug.cgi?id=1820), [bug 1815](https://bugzilla.audacityteam.org/show_bug.cgi?id=1815), and [bug 2093](https://bugzilla.audacityteam.org/show_bug.cgi?id=2093) (the fix for [bug 1819](https://bugzilla.audacityteam.org/show_bug.cgi?id=1819) was cherry-picked separately a while back).

Each commit should be relatively self-explanatory.  Do note that I removed the the two rendering-only commits ([1](https://github.com/audacity/audacity/pull/232/commits/e2d4b0424e1e55fb162f08bf1784829884faaafe), [2](https://github.com/audacity/audacity/pull/232/commits/d0ffdeb24a4e9ea37d429b7a7621499f8d087c56)), since I'm not completely sure their implementation is correct and the things they address are fairly minor.