### PR TITLE
Don't destroy auto-save file written by different architecture...

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1520,7 +1520,7 @@ bool AudacityApp::OnInit()
       }
       else
       {
-         wxPrintf(_("Decoding failed\n"));
+         wxPrintf( AutoSaveFile::FailureMessage( fileName ) );
       }
       exit(1);
    }

--- a/src/AutoRecovery.h
+++ b/src/AutoRecovery.h
@@ -75,6 +75,8 @@ class AUDACITY_DLL_API AutoSaveFile final : public XMLWriter
 {
 public:
 
+   static wxString FailureMessage( const FilePath &filePath );
+
    AutoSaveFile(size_t allocSize = 1024 * 1024);
    virtual ~AutoSaveFile();
 

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -3070,10 +3070,13 @@ void AudacityProject::OpenFile(const FilePath &fileNameArg, bool addtohistory)
       AutoSaveFile asf;
       if (!asf.Decode(fileName))
       {
+         auto message = AutoSaveFile::FailureMessage( fileName );
          AudacityMessageBox(
-            wxString::Format( _("Could not decode file: %s"), fileName ),
+            message,
             _("Error decoding file"),
             wxOK | wxCENTRE, this);
+         // Important: Prevent deleting any temporary files!
+         DirManager::SetDontDeleteTempFiles();
          return;
       }
    }


### PR DESCRIPTION
... the error checking might not be complete, but it is sufficient for the
observed cases, where switching between 32 and 64 bit Mac builds causes
auto-recovery in one build to destroy the data saved by the other build.

Now instead, you will see the (previously existing) message
"Could not decode file: %s" which comes from AudacityProject::OpenFile.

# Pull Requests

If you are submitting a pull request, read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 


## The key points: 

* Come over talk with us at the audacity devel email list. If you just rely on the GitHub pull request messages, you may find we ignore or close the pull request for what does not seem to you to be a good reason. Please come and talk. 

* Translators should subscribe to audacity translators email list instead.  The translators list is also the right place for most translation discussion. 

There is a bit more on our wiki about how we use the pull requests and the labels that can be attached to pull requests.

