### PR TITLE
Bug2105: Enable TAB to sliders on Mac...

### DIFF
--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -338,7 +338,7 @@ FreqWindow::FreqWindow(wxWindow * parent, wxWindowID id,
 
             S.AddSpace(5);
 
-            mZoomSlider = safenew wxSlider(this, FreqZoomSliderID, 100, 1, 100,
+            mZoomSlider = safenew wxSliderWrapper(this, FreqZoomSliderID, 100, 1, 100,
                wxDefaultPosition, wxDefaultSize, wxSL_VERTICAL);
             S.Prop(1);
             S.AddWindow(mZoomSlider, wxALIGN_CENTER_HORIZONTAL);

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -515,6 +515,15 @@ wxRadioButton * ShuttleGuiBase::AddRadioButtonToGroup(const wxString &Prompt)
    return pRad;
 }
 
+#ifdef __WXMAC__
+void wxSliderWrapper::SetFocus()
+{
+   // bypassing the override in wxCompositeWindow<wxSliderBase> which ends up
+   // doing nothing
+   return wxSliderBase::SetFocus();
+}
+#endif
+
 wxSlider * ShuttleGuiBase::AddSlider(const wxString &Prompt, int pos, int Max, int Min)
 {
    HandleOptionality( Prompt );
@@ -523,7 +532,7 @@ wxSlider * ShuttleGuiBase::AddSlider(const wxString &Prompt, int pos, int Max, i
    if( mShuttleMode != eIsCreating )
       return wxDynamicCast(wxWindow::FindWindowById( miId, mpDlg), wxSlider);
    wxSlider * pSlider;
-   mpWind = pSlider = safenew wxSlider(GetParent(), miId,
+   mpWind = pSlider = safenew wxSliderWrapper(GetParent(), miId,
       pos, Min, Max,
       wxDefaultPosition, wxDefaultSize,
       Style( wxSL_HORIZONTAL | wxSL_LABELS | wxSL_AUTOTICKS )

--- a/src/ShuttleGui.h
+++ b/src/ShuttleGui.h
@@ -17,6 +17,7 @@
 #include "Audacity.h"
 
 #include <vector>
+#include <wx/slider.h> // to inherit
 #include "MemoryX.h"
 
 #include "WrappedType.h"
@@ -75,6 +76,19 @@ class wxGrid;
 class Shuttle;
 
 class WrappedType;
+
+#ifdef __WXMAC__
+/// Fix a defect in TAB key navigation to sliders, known to happen in wxWidgets
+/// 3.1.1 and maybe in earlier versions
+class wxSliderWrapper : public wxSlider
+{
+public:
+   using wxSlider::wxSlider;
+   void SetFocus() override;
+};
+#else
+using wxSliderWrapper = wxSlider;
+#endif
 
 class AUDACITY_DLL_API ShuttleGuiBase /* not final */
 {

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -737,7 +737,7 @@ void EffectEqualization::PopulateOrExchange(ShuttleGui & S)
 
          for (int i = 0; (i < NUMBER_OF_BANDS) && (kThirdOct[i] <= mHiFreq); ++i)
          {
-            mSliders[i] = safenew wxSlider(mGraphicPanel, ID_Slider + i, 0, -20, +20,
+            mSliders[i] = safenew wxSliderWrapper(mGraphicPanel, ID_Slider + i, 0, -20, +20,
                wxDefaultPosition, wxDefaultSize, wxSL_VERTICAL | wxSL_INVERSE);
 
             mSliders[i]->Bind(wxEVT_ERASE_BACKGROUND,

--- a/src/effects/ScoreAlignDialog.cpp
+++ b/src/effects/ScoreAlignDialog.cpp
@@ -83,7 +83,7 @@ ScoreAlignDialog::ScoreAlignDialog(ScoreAlignParams &params)
 
    //wxButton *ok = safenew wxButton(this, wxID_OK, _("OK"));
    //wxButton *cancel = safenew wxButton(this, wxID_CANCEL, _("Cancel"));
-   //wxSlider *sl = safenew wxSlider(this, ID_SLIDER, 0, 0, 100,
+   //wxSlider *sl = safenew wxSliderWrapper(this, ID_SLIDER, 0, 0, 100,
    //                     wxDefaultPosition, wxSize(20, 124),
    //                     wxSL_HORIZONTAL);
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2909,7 +2909,7 @@ void VSTEffect::BuildPlain()
                wxALIGN_RIGHT | wxST_NO_AUTORESIZE);
             gridSizer->Add(mNames[i], 0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT | wxALL, 5);
 
-            mSliders[i] = safenew wxSlider(scroller,
+            mSliders[i] = safenew wxSliderWrapper(scroller,
                ID_Sliders + i,
                0,
                0,

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1313,7 +1313,7 @@ bool LadspaEffect::PopulateUI(wxWindow *parent)
                gridSizer->Add(1, 1, 0);
             }
 
-            mSliders[p] = safenew wxSlider(w, ID_Sliders + p,
+            mSliders[p] = safenew wxSliderWrapper(w, ID_Sliders + p,
                0, 0, 1000,
                wxDefaultPosition,
                wxSize(200, -1));

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1714,7 +1714,7 @@ bool LV2Effect::BuildPlain()
                      gridSizer->Add(1, 1, 0);
                   }
 
-                  mSliders[p] = safenew wxSlider(w, ID_Sliders + p,
+                  mSliders[p] = safenew wxSliderWrapper(w, ID_Sliders + p,
                      0, 0, 1000,
                      wxDefaultPosition,
                      wxSize(150, -1));

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -1356,7 +1356,7 @@ ExportMixerDialog::ExportMixerDialog( const TrackList *tracks, bool selectedOnly
          mChannelsText = safenew wxStaticText(this, -1, label);
          horSizer->Add(mChannelsText, 0, wxALIGN_LEFT | wxALL, 5);
 
-         wxSlider *channels = safenew wxSlider(this, ID_SLIDER_CHANNEL,
+         wxSlider *channels = safenew wxSliderWrapper(this, ID_SLIDER_CHANNEL,
             mMixerSpec->GetNumChannels(), 1, mMixerSpec->GetMaxNumChannels(),
             wxDefaultPosition, wxSize(300, -1));
          channels->SetName(label);


### PR DESCRIPTION
... I think this is a defect in wxWidgets, but one we can work around with a
simple wrapper class around wxSlider overriding one method.

To make the fix complete, change all occurrences of "safenew wxSlider"
but the one in ShuttleGui.cpp covers most cases

# Pull Requests

If you are submitting a pull request, read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 


## The key points: 

* Come over talk with us at the audacity devel email list. If you just rely on the GitHub pull request messages, you may find we ignore or close the pull request for what does not seem to you to be a good reason. Please come and talk. 

* Translators should subscribe to audacity translators email list instead.  The translators list is also the right place for most translation discussion. 

There is a bit more on our wiki about how we use the pull requests and the labels that can be attached to pull requests.

