### PR TITLE
Bug2104: Mac: don't get trapped in radio button group when TABbing...

### DIFF
--- a/src/widgets/wxPanelWrapper.cpp
+++ b/src/widgets/wxPanelWrapper.cpp
@@ -9,7 +9,10 @@
 #include "../Audacity.h"
 #include "wxPanelWrapper.h"
 
+#ifdef __WXMAC__
 #include <wx/grid.h>
+#include <wx/radiobut.h>
+#endif
 
 void wxTabTraversalWrapperCharHook(wxKeyEvent &event)
 {
@@ -26,6 +29,9 @@ void wxTabTraversalWrapperCharHook(wxKeyEvent &event)
          event.Skip();
          return;
       }
+      else if (dynamic_cast<wxRadioButton*>(focus))
+         // Bug 2104, don't get trapped in radio button cycle
+         event.Skip();
       focus->Navigate(
          event.ShiftDown()
          ? wxNavigationKeyEvent::IsBackward


### PR DESCRIPTION
... This is a fix for something mentioned already in the comment at
7d25dedafd3827340d4e8c54dfc8c3c7848be72d before 2.1.3

As also mentioned there:  the reason we still need this hook function, is that
without it, you can't tab between the panes of the Preference dialog, although
without it, this bug would not have happened

# Pull Requests

If you are submitting a pull request, read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 


## The key points: 

* Come over talk with us at the audacity devel email list. If you just rely on the GitHub pull request messages, you may find we ignore or close the pull request for what does not seem to you to be a good reason. Please come and talk. 

* Translators should subscribe to audacity translators email list instead.  The translators list is also the right place for most translation discussion. 

There is a bit more on our wiki about how we use the pull requests and the labels that can be attached to pull requests.

