### PR TITLE
Fix for bug 1539

### DIFF
--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -780,7 +780,12 @@ wxString TimerRecordDialog::GetDisplayDate( wxDateTime & dt )
 
    // Use default formatting
 wxPrintf(wxT("%s\n"), dt.Format());
-   return dt.FormatDate() + wxT(" ") + dt.FormatTime();
+   if (wxDateTime::GetCountry() != wxDateTime::USA){
+      return dt.FormatDate() + wxT(" ") + dt.FormatTime();
+
+   } else {
+      return dt.Format(wxS("%m/%d/%Y")) + wxT(" ") + dt.FormatTime();
+   }
 }
 
 TimerRecordPathCtrl * TimerRecordDialog::NewPathControl(wxWindow *wParent, const int iID,


### PR DESCRIPTION
Hi All,
I believe I have a fix for bug 1539. When the system country is set to US, the timed recording will now display the date in mm/dd/yyyy format. I know there has been some discussion on whether or not this is actually an issue, but I thought I would leave it here just incase you want to go through with the change.

Thanks!
Will Held

# Pull Requests

If you are submitting a pull request, read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 


## The key points: 

* Come over talk with us at the audacity devel email list. If you just rely on the GitHub pull request messages, you may find we ignore or close the pull request for what does not seem to you to be a good reason. Please come and talk. 

* Translators should subscribe to audacity translators email list instead.  The translators list is also the right place for most translation discussion. 

There is a bit more on our wiki about how we use the pull requests and the labels that can be attached to pull requests.
