### PR TITLE
Add missing #include for wxTreeCtrl.

### DIFF
--- a/src/prefs/PrefsDialog.cpp
+++ b/src/prefs/PrefsDialog.cpp
@@ -33,6 +33,7 @@
 #include <wx/listbook.h>
 
 #include <wx/treebook.h>
+#include <wx/treectrl.h>
 
 #include "../AudioIO.h"
 #include "../Project.h"


### PR DESCRIPTION
Building with wxwidgets 3.1.2 results in the following error:

```
In file included from /gar/include/wx-3.1/wx/treebook.h:20,
                 from prefs/PrefsDialog.cpp:35:
/gar/include/wx-3.1/wx/treebase.h:57:35: note: forward declaration of ‘class wxTreeCtrl’                                                                        
prefs/PrefsDialog.cpp:659:75: error: invalid use of incomplete type ‘class wxTreeCtrl’                                                                          
In file included from /gar/include/wx-3.1/wx/treebook.h:20,                     
                 from prefs/PrefsDialog.cpp:35:                                 
/gar/include/wx-3.1/wx/treebase.h:57:35: note: forward declaration of ‘class wxTreeCtrl’                                                                        
```

This is the result of [this commit in wxwidgets](https://github.com/wxWidgets/wxWidgets/commit/bb492b99bd969629a52235fb8abbeb88d487a93a). Adding the `#include` explicitly fixes it.
