### PR TITLE
Fix bug 2140

### DIFF
--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -267,7 +267,7 @@ void TrackArtist::UpdatePrefs()
 
    mbShowTrackNameInTrack =
       gPrefs->ReadBool(wxT("/GUI/ShowTrackNameInWaveform"), false);
-   
+
    UpdateSelectedPrefs( ShowClippingPrefsID() );
 
    SetColours(0);

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -37,9 +37,6 @@ struct TrackPanelDrawingContext;
 class ZoomInfo;
 
 namespace TrackArt {
-   
-   void DrawTrackName(TrackPanelDrawingContext &context, 
-                      const Track *t, const wxRect & rect );
 
    // Helper: draws the "sync-locked" watermark tiled to a rectangle
    void DrawSyncLockTiles(
@@ -93,7 +90,7 @@ public:
 
    // Preference values
    float mdBrange;            // "/GUI/EnvdBRange"
-   long mShowClipping;        // "/GUI/ShowClipping"
+   bool mShowClipping;        // "/GUI/ShowClipping"
    int  mSampleDisplay;
    bool mbShowTrackNameInTrack;  // "/GUI/ShowTrackNameInWaveform"
 

--- a/src/tracks/ui/CommonTrackView.cpp
+++ b/src/tracks/ui/CommonTrackView.cpp
@@ -106,7 +106,7 @@ static void DrawTrackName(
    const int kTranslucentHeight = 124;
    int h = rect.GetHeight();
    // f codes the opacity as a number between 0.0 and 1.0
-   float f= wxClip((h -kOpaqueHeight)/(float)(kTranslucentHeight-kOpaqueHeight),0.0,1.0);
+   float f = wxClip((h-kOpaqueHeight)/(float)(kTranslucentHeight-kOpaqueHeight),0.0,1.0);
    // kOpaque is the shield's alpha for tracks that are not tall
    // kTranslucent is the shield's alpha for tracks that are tall.
    const int kOpaque = 255;

--- a/src/tracks/ui/CommonTrackView.cpp
+++ b/src/tracks/ui/CommonTrackView.cpp
@@ -85,6 +85,8 @@ std::vector<UIHandlePtr> CommonTrackView::HitTest
 static void DrawTrackName(
    TrackPanelDrawingContext &context, const Track * t, const wxRect & rect )
 {
+   if( !TrackArtist::Get( context )->mbShowTrackNameInTrack )
+      return;
    auto name = t->GetName();
    if( name.IsEmpty())
       return;


### PR DESCRIPTION
Fixes [bug 2140](https://bugzilla.audacityteam.org/show_bug.cgi?id=2140).  `mbShowTrackNameInTrack` just was not checked anymore after b05acc32daea72018084ded1dccb21884dd5f6ba.

I also tidied up some of the other code I saw while figuring out what caused the bug.

One thing to note is that the show track names as overlay preference is also used in `LabelTrackView::ComputeLayout`, but not via the `TrackArtist` field:

https://github.com/audacity/audacity/blob/68c1637bd334c51991666439e0edae5616842a95/src/tracks/labeltrack/ui/LabelTrackView.cpp#L379-L382

I'm not sure which way is preferable.  I don't think `TrackArtist` can be used for that one since it isn't rendering, but I'm not certain of that.