### PR TITLE
Enable OpenMP on Windows

### DIFF
--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1012,7 +1012,7 @@ bool SpecCache::CalculateOneSpectrum
                   // This assignment can race if index reaches into another thread's bins.
                   // The probability of a race very low, so this carries little overhead,
                   // about 5% slower vs allowing it to race.
-                  #pragma omp atomic update
+                  #pragma omp atomic
 #endif
                   out[ind] += power;
                }

--- a/win/Projects/Audacity/Audacity.vcxproj
+++ b/win/Projects/Audacity/Audacity.vcxproj
@@ -66,6 +66,8 @@
       <ForcedIncludeFiles>AudacityHeaders.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>AudacityHeaders.h</PrecompiledHeaderFile>
+      <OpenMPSupport>true</OpenMPSupport>
+      <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -99,6 +101,8 @@
       <CompileAs>Default</CompileAs>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <ForcedIncludeFiles>AudacityHeaders.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+      <OpenMPSupport>true</OpenMPSupport>
+      <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/win/Projects/libsoxr/libsoxr.vcxproj
+++ b/win/Projects/libsoxr/libsoxr.vcxproj
@@ -58,6 +58,8 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
+      <OpenMPSupport>true</OpenMPSupport>
+      <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -70,6 +72,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WarningLevel>Level3</WarningLevel>
       <CompileAs>Default</CompileAs>
+      <OpenMPSupport>true</OpenMPSupport>
+      <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
I've had the first commit sitting around for a while, and I only just now remembered it.

`#pragma omp atomic` is defined in [section 2.6.4](https://www.openmp.org/wp-content/uploads/cspec20.pdf#page=25) of the spec for 2.0, and is the only way it can be used.  It is defined in [section 2.8.5](https://www.openmp.org/wp-content/uploads/OpenMP3.1.pdf#G4.1057349) of the spec for 3.1, and optionally also accepts `read`, `write`, `update`, or `capture`.  If none is specified, it is the same as if update has been specified, so simply getting rid of `update` makes it compatible with 2.0.

The second commit enables OpenMP support in Visual Studio.  Adding [the `/Zc:twoPhase-` option](https://docs.microsoft.com/en-us/cpp/build/reference/zc-twophase?view=vs-2017) is required, as otherwise I get `c1xx : warning C4199: two-phase name lookup is not supported for C++/CLI, C++/CX, or OpenMP; use /Zc:twoPhase-`.  I enable it for both the main code and soxr, as those are the only places where OpenMP is used.