### PR TITLE
Make ffmpeg message to locate/download libraries clearer

### DIFF
--- a/src/FFmpeg.cpp
+++ b/src/FFmpeg.cpp
@@ -582,7 +582,7 @@ void FFmpegNotFoundDialog::PopulateOrExchange(ShuttleGui & S)
       S.AddFixedText(_(
 "Audacity attempted to use FFmpeg to import an audio file,\n\
 but the libraries were not found.\n\n\
-To use FFmpeg import, go to Preferences > Libraries\n\
+To use FFmpeg import, go to Edit > Preferences > Libraries\n\
 to download or locate the FFmpeg libraries."
       ));
 


### PR DESCRIPTION
Just a small change to make this particular dialogue box a little clearer. At the moment it implies "Preferences" is a top level menu, when in fact it is an option under the "Edit" menu.