### PR TITLE
Add option to export with silence from the beginning

### DIFF
--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -499,6 +499,14 @@ bool Exporter::ExamineTracks()
    // least one track is selected (if selectedOnly==true)
 
    double earliestBegin = mT1;
+
+   bool silenceAtBeginning = gPrefs->Read(wxT("/AudioFiles/SilenceAtBeginning"),
+                                      false);
+
+   if (silenceAtBeginning) {
+     earliestBegin = 0.0;
+   }
+
    double latestEnd = mT0;
 
    auto &tracks = TrackList::Get( *mProject );

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -500,8 +500,10 @@ bool Exporter::ExamineTracks()
 
    double earliestBegin = mT1;
 
-   bool silenceAtBeginning = gPrefs->Read(wxT("/AudioFiles/SilenceAtBeginning"),
-                                      false);
+   bool silenceAtBeginning;
+
+   gPrefs->Read(wxT("/AudioFiles/SilenceAtBeginning"),
+                                   &silenceAtBeginning, false);
 
    if (silenceAtBeginning) {
      earliestBegin = 0.0;

--- a/src/prefs/ImportExportPrefs.cpp
+++ b/src/prefs/ImportExportPrefs.cpp
@@ -93,6 +93,10 @@ void ImportExportPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(_("S&how Metadata Tags editor before export"),
                     wxT("/AudioFiles/ShowId3Dialog"),
                     true);
+
+      S.TieCheckBox(_("Export with silence at the beginning"),
+                    wxT("/AudioFiles/SilenceAtBeginning"),
+                    false);
    }
    S.EndStatic();
 #ifdef USE_MIDI


### PR DESCRIPTION
This is an option to enable export the audio starting with silence from the beginning of the track (from 0.0s or from the start of selection) and not from the beginning of the audio (from the first sample of the first block).