### PR TITLE
Fix building with wxWidgets 3.1.2

### DIFF
--- a/src/prefs/PrefsDialog.cpp
+++ b/src/prefs/PrefsDialog.cpp
@@ -34,6 +34,7 @@
 #include <wx/listbook.h>
 
 #include <wx/treebook.h>
+#include <wx/treectrl.h>
 
 #include "../AudioIOBase.h"
 #include "../Prefs.h"


### PR DESCRIPTION
From changelog:
- wx/treebook.h doesn't include wx/treectrl.h (and, via it, wx/textctrl.h) any
  more, include these headers explicitly from your code if necessary.