### PR TITLE
Fix some compile issues

### DIFF
--- a/include/audacity/Types.h
+++ b/include/audacity/Types.h
@@ -53,7 +53,6 @@
 // For using std::unordered_map on wxString
 namespace std
 {
-   template<typename T> struct hash;
    template<> struct hash< wxString > {
       size_t operator () (const wxString &str) const // noexcept
       {

--- a/lib-src/FileDialog/Makefile.am
+++ b/lib-src/FileDialog/Makefile.am
@@ -1,3 +1,4 @@
+AM_LIBTOOLFLAGS = --tag CC
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libFileDialog.la

--- a/src/Experimental.h
+++ b/src/Experimental.h
@@ -143,7 +143,9 @@
 // RBD, 1 Sep 2008
 // Enables MIDI Output of NoteTrack (MIDI) data during playback
 // USE_MIDI must be defined in order for EXPERIMENTAL_MIDI_OUT to work
+#ifdef USE_MIDI
 #define EXPERIMENTAL_MIDI_OUT
+#endif
 // JKC, 17 Aug 2017
 // Enables the MIDI note stretching feature, which currently
 // a) Is broken on Linux (Bug 1646)


### PR DESCRIPTION
While compiling audacity with clang and libc++ instead of libstdc++ I came across some bugs that prevented compilation to be successful.

This pull request addresses those compilation failures.