### PR TITLE
Added project name on filename when exporting tracks

### DIFF
--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -674,8 +674,10 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    }
 
    // Extract the actual name.
-   wxString fName = mTrackNames[mTrackNames.size() - 1].AfterFirst(wxT('-')).Mid(1);
-
+   wxString fName = GetActiveProject()->GetProjectName()
+      + wxT(" - ")
+      + mTrackNames[mTrackNames.size() - 1].AfterFirst(wxT('-')).Mid(1);
+      
    fName = FileNames::SelectFile(FileNames::Operation::Export,
       _("Export Labels As:"),
       wxEmptyString,

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -226,7 +226,9 @@ void OnExportLabels(const CommandContext &context)
       return;
    }
    else
-      fName = (*trackRange.rbegin())->GetName();
+      fName = project.GetProjectName()
+         + wxT(" - ")
+         + (*trackRange.rbegin())->GetName();
 
    fName = FileNames::SelectFile(FileNames::Operation::Export,
                         _("Export Labels As:"),


### PR DESCRIPTION
https://sourceforge.net/p/audacity/mailman/message/36757390/

This add the project name + the label track name on the suggested txt filename field of the Export dialog.