### PR TITLE
Possible fix for bug #590

### DIFF
--- a/lib-src/libnyquist/nyquist/cmt/cmtcmd.c
+++ b/lib-src/libnyquist/nyquist/cmt/cmtcmd.c
@@ -14,7 +14,7 @@
 #define HASHELEM(p) ((p).symbol_name)
 #define HASHVAL 50
 #define HASHENTRIES 50
-#define HASHENTER lookup
+#define HASHENTER hash_lookup
 #define HASHNOCOPY
 
 #include "hashrout.h"
@@ -23,7 +23,7 @@ void defvar(name, addr)
   char *name;
   int *addr;
 {
-    int i = lookup(name);
+    int i = hash_lookup(name);
     HASHENTRY(i).symb_type = var_symb_type;
     HASHENTRY(i).ptr.intptr = addr;
 }
@@ -33,7 +33,7 @@ void defun(name, addr)
   char *name;
   int (*addr)();
 {
-    int i = lookup(name);
+    int i = hash_lookup(name);
     HASHENTRY(i).symb_type = fn_symb_type;
     HASHENTRY(i).ptr.routine = addr;
 }
@@ -44,7 +44,7 @@ void defvec(name, addr, size)
   int *addr;
   int size;
 {
-    int i = lookup(name);
+    int i = hash_lookup(name);
     HASHENTRY(i).symb_type = vec_symb_type;
     HASHENTRY(i).size = size;
     HASHENTRY(i).ptr.intptr = addr;

--- a/lib-src/libnyquist/nyquist/cmt/cmtcmd.h
+++ b/lib-src/libnyquist/nyquist/cmt/cmtcmd.h
@@ -25,7 +25,7 @@ typedef struct symb_descr {
     } ptr;
 } symb_descr_node;
 
-int lookup(char *s);
+int hash_lookup(char *s);
 void defvar(char *name, int *addr);
 void defvec(char *name, int *addr, int size);
 typedef int (*defun_type)();

--- a/lib-src/libnyquist/nyquist/cmt/seqread.c
+++ b/lib-src/libnyquist/nyquist/cmt/seqread.c
@@ -471,7 +471,7 @@ private void docall()
         if (fieldx == 1) fferror("Routine name expected");
         else if (token[fieldx] != '(') fferror("Open paren expected");
         else {
-            desc = &HASHENTRY(lookup(symbol));
+            desc = &HASHENTRY(hash_lookup(symbol));
             if (!desc->symb_type) {
                 fieldx = 0;
                 fferror("Function not defined");
@@ -1038,7 +1038,7 @@ private void doset(vec_flag)
     linex += scan();
     if (!token[0]) fferror("Variable name expected");
     else {
-        struct symb_descr *desc = &HASHENTRY(lookup(token));
+        struct symb_descr *desc = &HASHENTRY(hash_lookup(token));
         if (!desc->symb_type) fferror("Called function not defined");
         else if (vec_flag && (desc->symb_type != vec_symb_type)) {
                 fferror("This is not an array");


### PR DESCRIPTION
This change reduces the risk of LADSPA plugins referencing
Audacity symbols by using the RTLD_DEEPBIND flag when loading
the plugins.

It also addresses an issue specific to the "blop" plugins where
they load their own libraries (without RTLD_DEEPBIND).

A much better solution would be to change Audacity's default
symbol visibility to "hidden" which would expose ONLY symbols
specificially marked as visible.
