### PR TITLE
Add support for exporting labels in SubRip format

### DIFF
--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -632,12 +632,19 @@ void LabelDialog::OnImport(wxCommandEvent & WXUNUSED(event))
                     wxEmptyString,     // Path
                     wxT(""),       // Name
                     wxT(".txt"),   // Extension
-                    _("Text files (*.txt)|*.txt|All files|*"),
+                    _("Text files (*.txt)|*.txt|SubRip text file (*.srt)|*.srt|All files|*"),
                     wxRESIZE_BORDER, // Flags
                     this);    // Parent
 
    // They gave us one...
    if (!fileName.empty()) {
+      LabelFormat format = LabelFormat::TEXT;
+      if (fileName.Right(4).CmpNoCase(wxT(".srt")) == 0) {
+         format = LabelFormat::SUBRIP;
+      } else if (fileName.Right(4).CmpNoCase(wxT(".vtt")) == 0) {
+         format = LabelFormat::WEBVVT;
+      }
+
       wxTextFile f;
 
       // Get at the data
@@ -650,7 +657,7 @@ void LabelDialog::OnImport(wxCommandEvent & WXUNUSED(event))
          // Create a temporary label track and load the labels
          // into it
          auto lt = mFactory.NewLabelTrack();
-         lt->Import(f);
+         lt->Import(f, format);
 
          // Add the labels to our collection
          AddLabels(lt.get());
@@ -681,12 +688,19 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
       wxEmptyString,
       fName,
       wxT("txt"),
-      wxT("*.txt"),
+      _("Text files (*.txt)|*.txt|SubRip text file (*.srt)|*.srt|WebVTT file (*.vtt)|*.vtt"),
       wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
       this);
 
    if (fName.empty())
       return;
+
+   LabelFormat format = LabelFormat::TEXT;
+   if (fName.Right(4).CmpNoCase(wxT(".srt")) == 0) {
+      format = LabelFormat::SUBRIP;
+   } else if (fName.Right(4).CmpNoCase(wxT(".vtt")) == 0) {
+      format = LabelFormat::WEBVVT;
+   }
 
    // Move existing files out of the way.  Otherwise wxTextFile will
    // append to (rather than replace) the current file.
@@ -728,7 +742,7 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    }
 
    // Export them and clean
-   lt->Export(f);
+   lt->Export(f, format);
 
 #ifdef __WXMAC__
    f.Write(wxTextFileType_Mac);

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -27,6 +27,13 @@ class TimeWarper;
 struct LabelTrackHit;
 struct TrackPanelDrawingContext;
 
+enum class LabelFormat
+{
+   TEXT,
+   SUBRIP,
+   WEBVVT
+};
+
 class LabelStruct
 {
 public:
@@ -45,9 +52,9 @@ public:
    void MoveLabel( int iEdge, double fNewTime);
 
    struct BadFormatException {};
-   static LabelStruct Import(wxTextFile &file, int &index);
+   static LabelStruct Import(wxTextFile &file, int &index, LabelFormat format);
 
-   void Export(wxTextFile &file) const;
+   void Export(wxTextFile &file, LabelFormat format, int index) const;
 
    /// Relationships between selection region and labels
    enum TimeRelations
@@ -127,8 +134,8 @@ public:
    void Silence(double t0, double t1) override;
    void InsertSilence(double t, double len) override;
 
-   void Import(wxTextFile & f);
-   void Export(wxTextFile & f) const;
+   void Import(wxTextFile & f, LabelFormat format);
+   void Export(wxTextFile & f, LabelFormat format) const;
 
    int GetNumLabels() const;
    const LabelStruct *GetLabel(int index) const;

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -233,12 +233,19 @@ void OnExportLabels(const CommandContext &context)
                         wxEmptyString,
                         fName,
                         wxT("txt"),
-                        wxT("*.txt"),
+                        _("Text files (*.txt)|*.txt|SubRip text file (*.srt)|*.srt|WebVTT file (*.vtt)|*.vtt"),
                         wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
                         &window);
 
    if (fName.empty())
       return;
+
+   LabelFormat format = LabelFormat::TEXT;
+   if (fName.Right(4).CmpNoCase(wxT(".srt")) == 0) {
+      format = LabelFormat::SUBRIP;
+   } else if (fName.Right(4).CmpNoCase(wxT(".vtt")) == 0) {
+      format = LabelFormat::WEBVVT;
+   }
 
    // Move existing files out of the way.  Otherwise wxTextFile will
    // append to (rather than replace) the current file.
@@ -266,7 +273,7 @@ void OnExportLabels(const CommandContext &context)
    }
 
    for (auto lt : trackRange)
-      lt->Export(f);
+      lt->Export(f, format);
 
    f.Write();
    f.Close();
@@ -423,11 +430,17 @@ void OnImportLabels(const CommandContext &context)
                     wxEmptyString,     // Path
                     wxT(""),       // Name
                     wxT(".txt"),   // Extension
-                    _("Text files (*.txt)|*.txt|All files|*"),
+                    _("Text files (*.txt)|*.txt|SubRip text file (*.srt)|*.srt|All files|*"),
                     wxRESIZE_BORDER,        // Flags
                     &window);    // Parent
 
    if (!fileName.empty()) {
+      LabelFormat format = LabelFormat::TEXT;
+      if (fileName.Right(4).CmpNoCase(wxT(".srt")) == 0) {
+         format = LabelFormat::SUBRIP;
+      } else if (fileName.Right(4).CmpNoCase(wxT(".vtt")) == 0) {
+         format = LabelFormat::WEBVVT;
+      }
       wxTextFile f;
 
       f.Open(fileName);
@@ -442,7 +455,7 @@ void OnImportLabels(const CommandContext &context)
       wxFileName::SplitPath(fileName, NULL, NULL, &sTrackName, NULL);
       newTrack->SetName(sTrackName);
 
-      newTrack->Import(f);
+      newTrack->Import(f, format);
 
       SelectUtilities::SelectNone( project );
       newTrack->SetSelected(true);


### PR DESCRIPTION
Not intended for the 2.3.3; this is just something I needed for my own use (for [Wikimedia Commons](https://commons.wikimedia.org/wiki/Commons:Timed_Text)) and now that I've implemented it, I might as well put it out.

This adds support for importing and exporting label track context in the format used by [SubRip](https://en.wikipedia.org/wiki/SubRip) (with some weak documentation [here](http://fileformats.archiveteam.org/wiki/SubRip_text_file_format)), and also exporting in the related [WebVVT](https://en.wikipedia.org/wiki/WebVTT) format (but not importing due to [the increased complexity of that format](https://w3c.github.io/webvtt/)).