### PR TITLE
Add "Toggle Mute Recording Volume" on Extra - Mixer menu

### DIFF
--- a/src/menus/ExtraMenus.cpp
+++ b/src/menus/ExtraMenus.cpp
@@ -62,6 +62,22 @@ void OnInputGain(const CommandContext &context)
    }
 }
 
+void OnInputGainMute(const CommandContext &context)
+{
+   auto &project = context.project;
+   auto tb = &MixerToolBar::Get( project );
+
+   if (tb) {
+      if (tb->GetInputGain() == 0.0f) {
+         tb->SetInputGain(tb->beforeMutedInputVolume);
+      }
+      else {
+         tb->beforeMutedInputVolume = tb->GetInputGain();
+         tb->AdjustInputGain(0);
+      }
+   }
+}
+
 void OnInputGainInc(const CommandContext &context)
 {
    auto &project = context.project;
@@ -203,6 +219,8 @@ MenuTable::BaseItemPtr ExtraMixerMenu( AudacityProject & )
          FN(OnOutputGainDec), AlwaysEnabledFlag ),
       Command( wxT("InputGain"), XXO("Adj&ust Recording Volume..."),
          FN(OnInputGain), AlwaysEnabledFlag ),
+      Command( wxT("InputGainMute"), XXO("T&oggle Mute Recording Volume"),
+           FN(OnInputGainMute), AlwaysEnabledFlag ),
       Command( wxT("InputGainInc"), XXO("I&ncrease Recording Volume"),
          FN(OnInputGainInc), AlwaysEnabledFlag ),
       Command( wxT("InputGainDec"), XXO("D&ecrease Recording Volume"),

--- a/src/toolbars/MixerToolBar.cpp
+++ b/src/toolbars/MixerToolBar.cpp
@@ -282,9 +282,26 @@ void MixerToolBar::AdjustInputGain(int adj)
    if (adj < 0) {
       mInputSlider->Decrease(-adj);
    }
+   else if (adj == 0){
+      mInputSlider->Set(0);
+   }
    else {
       mInputSlider->Increase(adj);
    }
+   wxCommandEvent e;
+   SetMixer(e);
+   UpdateControls();
+}
+
+float MixerToolBar::GetInputGain()
+{
+   return mInputSlider->Get();
+}
+
+void MixerToolBar::SetInputGain(float vol)
+{
+   mInputSlider->Set(vol);
+
    wxCommandEvent e;
    SetMixer(e);
    UpdateControls();

--- a/src/toolbars/MixerToolBar.h
+++ b/src/toolbars/MixerToolBar.h
@@ -52,7 +52,12 @@ class MixerToolBar final : public ToolBar {
    void AdjustOutputGain(int adj);
    void AdjustInputGain(int adj);
 
+   float GetInputGain();
+   void SetInputGain(float vol);
+
    void RegenerateTooltips() override {};
+
+   float beforeMutedInputVolume;
 
  protected:
    float mInputSliderVolume;


### PR DESCRIPTION
This PR implements an option to toggle the recording input volume to mute and back in Extra - Mixer menu.
