### PR TITLE
Prevent heap-use-after-free crash

### DIFF
--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1189,7 +1189,15 @@ void ProjectWindow::HandleResize()
       return;
    }
 
-   CallAfter( [this]{ FixScrollbars(), UpdateLayout(); } );
+   CallAfter( [this]{
+
+   if (mIsDeleting)
+      return;
+
+   FixScrollbars();
+   UpdateLayout();
+
+   });
 }
 
 


### PR DESCRIPTION
Quickly opening and closing windows can trigger a use-after-free memory violation.

I'm able to reliably reproduce on Arch Linux with i3 as the window manager. To understand what happens, I created a debug build with `-fsanitize=address`. The crash happens in `ProjectWindow::FixScrollbars` (more information can be found in the attached stack trace).

[address-sanitizer-report.txt](https://github.com/audacity/audacity/files/3881612/address-sanitizer-report.txt)

I cannot guarantee that the fix will cover all possible races, but in the situation where the callback is executed and deletion is already in progress, it reliably crashes but with the patch, I was no longer able to reproduce it.
