### PR TITLE
Add support for labels in the SubRip and WebVTT formats

### DIFF
--- a/src/Experimental.h
+++ b/src/Experimental.h
@@ -247,4 +247,7 @@
 // Jonatã Bolzan Loss 31 Dec 2019
 #define EXPERIMENTAL_TIMER_TOOLBAR
 
+// Poke 13 Nov 2019
+#define EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+
 #endif

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -635,7 +635,11 @@ void LabelDialog::OnImport(wxCommandEvent & WXUNUSED(event))
          wxEmptyString,     // Path
          wxT(""),       // Name
          wxT("txt"),   // Extension
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+         { FileNames::TextFiles, LabelTrack::SubripFiles, FileNames::AllFiles },
+#else
          { FileNames::TextFiles, FileNames::AllFiles },
+#endif
          wxRESIZE_BORDER, // Flags
          this);    // Parent
 
@@ -686,7 +690,11 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
       wxEmptyString,
       fName,
       wxT("txt"),
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+      { FileNames::TextFiles, LabelTrack::SubripFiles },
+#else
       { FileNames::TextFiles },
+#endif
       wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
       this);
 

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -641,6 +641,8 @@ void LabelDialog::OnImport(wxCommandEvent & WXUNUSED(event))
 
    // They gave us one...
    if (!fileName.empty()) {
+      LabelFormat format = LabelTrack::FormatForFileName(fileName);
+
       wxTextFile f;
 
       // Get at the data
@@ -653,7 +655,7 @@ void LabelDialog::OnImport(wxCommandEvent & WXUNUSED(event))
          // Create a temporary label track and load the labels
          // into it
          auto lt = std::make_shared<LabelTrack>();
-         lt->Import(f);
+         lt->Import(f, format);
 
          // Add the labels to our collection
          AddLabels(lt.get());
@@ -690,6 +692,8 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
 
    if (fName.empty())
       return;
+
+   LabelFormat format = LabelTrack::FormatForFileName(fName);
 
    // Move existing files out of the way.  Otherwise wxTextFile will
    // append to (rather than replace) the current file.
@@ -731,7 +735,7 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    }
 
    // Export them and clean
-   lt->Export(f);
+   lt->Export(f, format);
 
 #ifdef __WXMAC__
    f.Write(wxTextFileType_Mac);

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -691,7 +691,7 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
       fName,
       wxT("txt"),
 #ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
-      { FileNames::TextFiles, LabelTrack::SubripFiles },
+      { FileNames::TextFiles, LabelTrack::SubripFiles, LabelTrack::WebVTTFiles },
 #else
       { FileNames::TextFiles },
 #endif

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -51,6 +51,10 @@ for drawing different aspects of the label and its text box.
 #include "effects/TimeWarper.h"
 #include "widgets/AudacityMessageBox.h"
 
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+const FileNames::FileType LabelTrack::SubripFiles{ XO("SubRip text file"), { wxT("srt") }, true };
+#endif
+
 wxDEFINE_EVENT(EVT_LABELTRACK_ADDITION, LabelTrackEvent);
 wxDEFINE_EVENT(EVT_LABELTRACK_DELETION, LabelTrackEvent);
 wxDEFINE_EVENT(EVT_LABELTRACK_PERMUTED, LabelTrackEvent);
@@ -362,6 +366,20 @@ void LabelStruct::MoveLabel( int iEdge, double fNewTime)
    updated = true;
 }
 
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+static double SubRipTimestampToDouble(const wxString &ts)
+{
+   wxString::const_iterator end;
+   wxDateTime dt;
+
+   if (!dt.ParseFormat(ts, wxT("%H:%M:%S,%l"), &end) || end != ts.end())
+      throw LabelStruct::BadFormatException{};
+
+   return dt.GetHour() * 3600 + dt.GetMinute() * 60 + dt.GetSecond()
+      + dt.GetMillisecond() / 1000.0;
+}
+#endif
+
 LabelStruct LabelStruct::Import(wxTextFile &file, int &index, LabelFormat format)
 {
    SelectedRegion sr;
@@ -436,6 +454,46 @@ LabelStruct LabelStruct::Import(wxTextFile &file, int &index, LabelFormat format
       }
       break;
    }
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+   case LabelFormat::SUBRIP:
+   {
+      if ((int)file.GetLineCount() < index + 2)
+         throw BadFormatException{};
+
+      long identifier;
+      // The first line should be a numeric counter; we can ignore it otherwise
+      if (!firstLine.ToLong(&identifier))
+         throw BadFormatException{};
+
+      wxString timestamp = file.GetLine(index++);
+      // Parsing data of the form 'HH:MM:SS,sss --> HH:MM:SS,sss'
+      // Assume that the line is in exactly that format, with no extra whitespace
+      // and less than 24 hours.
+      if (timestamp.length() != 29)
+         throw BadFormatException{};
+      if (!timestamp.substr(12, 5).IsSameAs(" --> "))
+         throw BadFormatException{};
+
+      double t0 = SubRipTimestampToDouble(timestamp.substr(0, 12));
+      double t1 = SubRipTimestampToDouble(timestamp.substr(17, 12));
+
+      sr.setTimes(t0, t1);
+
+      // Assume that if there is an empty subtitle, there still is a second
+      // blank line after it
+      title = file[index++];
+
+      // Labels in audacity should be only one line, so join multiple lines
+      // with spaces.  This is not reversed on export.
+      while (index < (int)file.GetLineCount() &&
+             !file.GetLine(index).IsEmpty())
+         title += " " + file.GetLine(index);
+
+      index++; // Skip over empty line
+
+      break;
+   }
+#endif
    default:
       throw BadFormatException{};
    }
@@ -443,7 +501,23 @@ LabelStruct LabelStruct::Import(wxTextFile &file, int &index, LabelFormat format
    return LabelStruct{ sr, title };
 }
 
-void LabelStruct::Export(wxTextFile &file, LabelFormat format) const
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+static wxString SubRipTimestampFromDouble(double timestamp)
+{
+   // Note that the SubRip format always uses the comma as its separator...
+   static constexpr auto subripFormat = wxT("%H:%M:%S,%l");
+
+   // dt is the datetime that is timestamp seconds after Jan 1, 1970 UTC.
+   wxDateTime dt { (time_t) timestamp };
+   dt.SetMillisecond(wxRound(timestamp * 1000) % 1000);
+
+   // As such, we need to use UTC when formatting it, or else the time will
+   // be shifted (assuming the user is not in the UTC timezone).
+   return dt.Format(subripFormat, wxDateTime::UTC);
+}
+#endif
+
+void LabelStruct::Export(wxTextFile &file, LabelFormat format, int index) const
 {
    switch (format) {
    case LabelFormat::TEXT:
@@ -473,6 +547,21 @@ void LabelStruct::Export(wxTextFile &file, LabelFormat format) const
       // Additional lines in future formats should also start with '\'.
       break;
    }
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+   case LabelFormat::SUBRIP:
+   {
+      file.AddLine(wxString::Format(wxT("%d"), index + 1));
+
+      file.AddLine(wxString::Format(wxT("%s --> %s"),
+         SubRipTimestampFromDouble(getT0()),
+         SubRipTimestampFromDouble(getT1())));
+
+      file.AddLine(title);
+      file.AddLine(wxT(""));
+
+      break;
+   }
+#endif
    }
 }
 
@@ -546,13 +635,19 @@ auto LabelStruct::RegionRelation(
 void LabelTrack::Export(wxTextFile & f, LabelFormat format) const
 {
    // PRL: to do: export other selection fields
+   int index = 0;
    for (auto &labelStruct: mLabels)
-      labelStruct.Export(f, format);
+      labelStruct.Export(f, format, index++);
 }
 
 LabelFormat LabelTrack::FormatForFileName(const wxString & fileName)
 {
    LabelFormat format = LabelFormat::TEXT;
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+   if (fileName.Right(4).CmpNoCase(wxT(".srt")) == 0) {
+      format = LabelFormat::SUBRIP;
+   }
+#endif
    return format;
 }
 

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -13,6 +13,7 @@
 #ifndef _LABELTRACK_
 #define _LABELTRACK_
 
+#include "Experimental.h"
 #include "SelectedRegion.h"
 #include "Track.h"
 
@@ -25,6 +26,11 @@ class TimeWarper;
 
 struct LabelTrackHit;
 struct TrackPanelDrawingContext;
+
+enum class LabelFormat
+{
+   TEXT,
+};
 
 class LabelStruct
 {
@@ -44,9 +50,9 @@ public:
    void MoveLabel( int iEdge, double fNewTime);
 
    struct BadFormatException {};
-   static LabelStruct Import(wxTextFile &file, int &index);
+   static LabelStruct Import(wxTextFile &file, int &index, LabelFormat format);
 
-   void Export(wxTextFile &file) const;
+   void Export(wxTextFile &file, LabelFormat format) const;
 
    /// Relationships between selection region and labels
    enum TimeRelations
@@ -103,7 +109,7 @@ class AUDACITY_DLL_API LabelTrack final
    double GetEndTime() const override;
 
    using Holder = std::shared_ptr<LabelTrack>;
-   
+
 private:
    Track::Holder Clone() const override;
 
@@ -122,8 +128,9 @@ public:
    void Silence(double t0, double t1) override;
    void InsertSilence(double t, double len) override;
 
-   void Import(wxTextFile & f);
-   void Export(wxTextFile & f) const;
+   static LabelFormat FormatForFileName(const wxString & fileName);
+   void Import(wxTextFile & f, LabelFormat format);
+   void Export(wxTextFile & f, LabelFormat format) const;
 
    int GetNumLabels() const;
    const LabelStruct *GetLabel(int index) const;

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -35,6 +35,7 @@ enum class LabelFormat
    TEXT,
 #ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
    SUBRIP,
+   WEBVTT,
 #endif
 };
 
@@ -118,6 +119,7 @@ class AUDACITY_DLL_API LabelTrack final
 
 #ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
    static const FileNames::FileType SubripFiles;
+   static const FileNames::FileType WebVTTFiles;
 #endif
 
 private:

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -16,6 +16,9 @@
 #include "Experimental.h"
 #include "SelectedRegion.h"
 #include "Track.h"
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+#include "FileNames.h"
+#endif
 
 
 class wxTextFile;
@@ -30,6 +33,9 @@ struct TrackPanelDrawingContext;
 enum class LabelFormat
 {
    TEXT,
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+   SUBRIP,
+#endif
 };
 
 class LabelStruct
@@ -52,7 +58,7 @@ public:
    struct BadFormatException {};
    static LabelStruct Import(wxTextFile &file, int &index, LabelFormat format);
 
-   void Export(wxTextFile &file, LabelFormat format) const;
+   void Export(wxTextFile &file, LabelFormat format, int index) const;
 
    /// Relationships between selection region and labels
    enum TimeRelations
@@ -109,6 +115,10 @@ class AUDACITY_DLL_API LabelTrack final
    double GetEndTime() const override;
 
    using Holder = std::shared_ptr<LabelTrack>;
+
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+   static const FileNames::FileType SubripFiles;
+#endif
 
 private:
    Track::Holder Clone() const override;

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -345,6 +345,8 @@ void OnExportLabels(const CommandContext &context)
    if (fName.empty())
       return;
 
+   LabelFormat format = LabelTrack::FormatForFileName(fName);
+
    // Move existing files out of the way.  Otherwise wxTextFile will
    // append to (rather than replace) the current file.
 
@@ -371,7 +373,7 @@ void OnExportLabels(const CommandContext &context)
    }
 
    for (auto lt : trackRange)
-      lt->Export(f);
+      lt->Export(f, format);
 
    f.Write();
    f.Close();
@@ -525,6 +527,7 @@ void OnImportLabels(const CommandContext &context)
          &window);    // Parent
 
    if (!fileName.empty()) {
+      LabelFormat format = LabelTrack::FormatForFileName(fileName);
       wxTextFile f;
 
       f.Open(fileName);
@@ -539,7 +542,7 @@ void OnImportLabels(const CommandContext &context)
       wxFileName::SplitPath(fileName, NULL, NULL, &sTrackName, NULL);
       newTrack->SetName(sTrackName);
 
-      newTrack->Import(f);
+      newTrack->Import(f, format);
 
       SelectUtilities::SelectNone( project );
       newTrack->SetSelected(true);

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -338,7 +338,11 @@ void OnExportLabels(const CommandContext &context)
       wxEmptyString,
       fName,
       wxT("txt"),
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+      { FileNames::TextFiles, LabelTrack::SubripFiles },
+#else
       { FileNames::TextFiles },
+#endif
       wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
       &window);
 
@@ -521,8 +525,12 @@ void OnImportLabels(const CommandContext &context)
          XO("Select a text file containing labels"),
          wxEmptyString,     // Path
          wxT(""),       // Name
-         wxT("txt"),   // Extension
+         wxT("txt"),    // Extension
+#ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
+         { FileNames::TextFiles, LabelTrack::SubripFiles, FileNames::AllFiles },
+#else
          { FileNames::TextFiles, FileNames::AllFiles },
+#endif
          wxRESIZE_BORDER,        // Flags
          &window);    // Parent
 

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -339,7 +339,7 @@ void OnExportLabels(const CommandContext &context)
       fName,
       wxT("txt"),
 #ifdef EXPERIMENTAL_SUBRIP_LABEL_FORMATS
-      { FileNames::TextFiles, LabelTrack::SubripFiles },
+      { FileNames::TextFiles, LabelTrack::SubripFiles, LabelTrack::WebVTTFiles },
 #else
       { FileNames::TextFiles },
 #endif


### PR DESCRIPTION
Allows exporting labels in the [SubRip](https://en.wikipedia.org/wiki/SubRip) and [WebVTT](https://en.wikipedia.org/wiki/WebVTT) formats (and importing labels in SubRip format as well, but not WebVTT).  This is a resubmission of #383 that has been cleaned up a ton.  There's [a wiki article on the use for this](https://wiki.audacityteam.org/wiki/Movie_subtitles_%28*.SRT%29).

Improvements from before:
* Split into 3 commits to make it easier to review (mainly because of indentation changes)
* The new formats are controlled by `EXPERIMENTAL_SUBRIP_LABEL_FORMATS` (and I've made sure that everything compiles with it enabled and with it disabled)
* Timestamps are parsed using `wxDateTime`, based on what @kempniu did in #170.
* Deciding which format to use now happens in a single method (`LabelTrack::FormatForFileName`) so only one place needs to be modified, instead of 4 locations in 2 files.
* I've fixed all of the references to "WebVVT" and replaced them with "WebVTT" (that took me an embarrassingly long time to notice).  "VTT" stands for "Video Text Tracks".

There are a few known issues:
* WebVTT files cannot be imported.  The format is much more complicated ([see the spec](https://w3c.github.io/webvtt/)) and supports content that does not directly translate into labels (such as comments which are not displayed and do not have a timestamp, and regions that indicate positioning of cues).
* Both SubRip and WebVTT support multiple lines in a cue, but labels do not currently support multiple lines (and the current txt format doesn't have the ability to do it).  When importing SubRip files, I simply join the lines with spaces. (#170 used `|` based on [MicroDVD](https://en.wikipedia.org/wiki/MicroDVD), which I have no experience with.)
* Exporting multiple tracks at the same time leads to an invalid file &mdash; it effectively concatenates what happens if you export each individually.  The identifier (which is just a counter here) is reset to `1` for each file, and the `WEBVTT` header is repeated.  Although both of those are fixable, WebVTT also requires that the start time "must be greater than or equal to the start time offsets of all previous cues in the file" ([§4.1, "WebVTT cue timings"](https://w3c.github.io/webvtt/#webvtt-cue-timings)).  Resolving that requires merging the two files in sorted order and that would require a more substantial rework of how label track I/O works (which would be good eventually, as the labels editor would also be sorted by timestamp instead of track and then timestamp).