### PR TITLE
build: Fix bad include path

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTextHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelTextHandle.cpp
@@ -22,7 +22,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../SelectionState.h"
 #include "../../../TrackPanelMouseEvent.h"
 #include "../../../ViewInfo.h"
-#include "../../../images/Cursors.h"
+#include "../../../../images/Cursors.h"
 
 #include <wx/clipbrd.h>
 


### PR DESCRIPTION
```
  tracks/labeltrack/ui/LabelTextHandle.cpp:25:10: fatal error: ../../../images/Cursors.h: No such file or directory
     25 | #include "../../../images/Cursors.h"
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
```
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>

# Pull Requests

If you are submitting a pull request, read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 


## The key points: 

* Come over talk with us at the audacity devel email list. If you just rely on the GitHub pull request messages, you may find we ignore or close the pull request for what does not seem to you to be a good reason. Please come and talk. 

* Translators should subscribe to audacity translators email list instead.  The translators list is also the right place for most translation discussion. 

There is a bit more on our wiki about how we use the pull requests and the labels that can be attached to pull requests.

