### PR TITLE
fixed bug 2128

### DIFF
--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -17,6 +17,8 @@ Paul Licameli split from ProjectManager.h
 #include "AudioIOListener.h" // to inherit
 #include "ClientData.h" // to inherit
 
+constexpr int RATE_NOT_SELECTED{ -1 };
+
 class AudacityProject;
 struct AudioIOStartStreamOptions;
 class TrackList;
@@ -47,7 +49,8 @@ public:
 
    // Find suitable tracks to record into, or return an empty array.
    static WaveTrackArray ChooseExistingRecordingTracks(
-      AudacityProject &proj, bool selectedOnly);
+      AudacityProject &proj, bool selectedOnly,
+      double targetRate = RATE_NOT_SELECTED);
 
    static bool UseDuplex();
 
@@ -160,6 +163,15 @@ private:
 
 AudioIOStartStreamOptions DefaultPlayOptions( AudacityProject &project );
 AudioIOStartStreamOptions DefaultSpeedPlayOptions( AudacityProject &project );
+
+struct PropertiesOfSelected
+{
+   bool allSameRate{ false };
+   int rateOfSelected{ RATE_NOT_SELECTED };
+   int numberOfSelected{ 0 };
+};
+
+PropertiesOfSelected GetPropertiesOfSelected(const AudacityProject &proj);
 
 #include "commands/CommandFlag.h"
 

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -270,6 +270,39 @@ void OnTimerRecord(const CommandContext &context)
          wxICON_INFORMATION | wxOK);
       return;
    }
+
+   // We check the selected tracks to see if there is enough of them to accomodate
+   // all input channels and all of them have the same sampling rate.
+   // Those checks will be later performed by recording function anyway,
+   // but we want to warn the user about potential problems from the very start.
+   const auto selectedTracks{ GetPropertiesOfSelected(project) };
+   const int rateOfSelected{ selectedTracks.rateOfSelected };
+   const int numberOfSelected{ selectedTracks.numberOfSelected };
+   const bool allSameRate{ selectedTracks.allSameRate };
+
+   if (!allSameRate) {
+      AudacityMessageBox(XO("TRACK SELECTION PROBLEM:\nthe tracks selected "
+         "for recording must all have the same sampling rate"),
+         XO("Unfitting track selection"),
+         wxICON_ERROR | wxCENTRE);
+
+      return;
+   }
+
+   const auto existingTracks{ ProjectAudioManager::ChooseExistingRecordingTracks(project, true, rateOfSelected) };
+   if (existingTracks.empty()) {
+      if (numberOfSelected > 0 && rateOfSelected != settings.GetRate()) {
+         AudacityMessageBox(XO("TRACK SELECTION PROBLEM:\n"
+            "Not enough tracks are selected for recording on non-project rate.\n"
+            "(keep in mind that Audacity doesn\'t allow "
+            "using only one channel of a stereo track)"),
+            XO("Insufficient track selection"),
+            wxICON_ERROR | wxCENTRE);
+
+         return;
+      }
+   }
+   
    // We use this variable to display "Current Project" in the Timer Recording
    // save project field
    bool bProjectSaved = ProjectFileIO::Get( project ).IsProjectSaved();
@@ -355,9 +388,23 @@ void OnPunchAndRoll(const CommandContext &context)
    viewInfo.selectedRegion.collapseToT0();
    double t1 = std::max(0.0, viewInfo.selectedRegion.t1());
 
+   // Checking the selected tracks: making sure they all have the same rate
+   const auto selectedTracks{ GetPropertiesOfSelected(project) };
+   const int rateOfSelected{ selectedTracks.rateOfSelected };
+   const bool allSameRate{ selectedTracks.allSameRate };
+
+   if (!allSameRate) {
+      AudacityMessageBox(XO("TRACK SELECTION PROBLEM:\nthe tracks selected "
+         "for recording must all have the same sampling rate"),
+         XO("Unfitting track selection"),
+         wxICON_ERROR | wxCENTRE);
+
+      return;
+   }
+
    // Decide which tracks to record in.
    auto tracks =
-      ProjectAudioManager::ChooseExistingRecordingTracks(project, true);
+      ProjectAudioManager::ChooseExistingRecordingTracks(project, true, rateOfSelected);
    if (tracks.empty()) {
       int recordingChannels =
          std::max(0L, gPrefs->Read(wxT("/AudioIO/RecordChannels"), 2));
@@ -365,7 +412,7 @@ void OnPunchAndRoll(const CommandContext &context)
          (recordingChannels == 1)
          ? XO("Please select in a mono track.")
          : (recordingChannels == 2)
-         ? XO("Please select in a stereo track.")
+         ? XO("Please select in a stereo track or two mono tracks.")
          : XO("Please select at least %d channels.").Format( recordingChannels );
       ShowErrorDialog(&window, XO("Error"), message, url);
       return;
@@ -452,6 +499,7 @@ void OnPunchAndRoll(const CommandContext &context)
 
    // Try to start recording
    auto options = DefaultPlayOptions( project );
+   options.rate = rateOfSelected;
    options.preRoll = std::max(0L,
       gPrefs->Read(AUDIO_PRE_ROLL_KEY, DEFAULT_PRE_ROLL_SECONDS));
    options.pCrossfadeData = &crossfadeData;


### PR DESCRIPTION
This is a fix for Bug 2128. It is pretty minimalistic and preserves the existing Audacity behavior.

- When recording is initiated, Audacity compares the sampling rates of the selected tracks. If the rates don’t match, Audacity outputs an error message and stops recording. If all selected tracks have the same rate, that rate becomes the recording rate.

- If the selected tracks have a non-project rate, there should be enough tracks selected to accommodate all input channels (to avoid automatic creation of non-project-rate new tracks). If not enough non-project-rate tracks are selected, the recording is stopped and the error message appears. 

The following functionality modified:
1. Standard recording
2. Punch-and-Roll recording
3. Timer recording. Timer recording performs the selected tracks checks from the very start. It is somewhat redundant but needed to let the user know about a bad selection before the timer expires.
