### PR TITLE
Fix manpage install path (CMake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,7 @@ set( _LIBDIR "${CMAKE_INSTALL_LIBDIR}/audacity" )
 set( _RPATH "\$ORIGIN/../${_LIBDIR}" )
 set( _DATADIR "${CMAKE_INSTALL_DATADIR}" )
 set( _PKGDATA "${_DATADIR}/audacity/" )
+set( _MANDIR "${CMAKE_INSTALL_MANDIR}" )
 
 # Precreate the lib and lib64 directories so we can make then the same
 if( NOT EXISTS "${CMAKE_BINARY_DIR}/lib" )

--- a/help/CMakeLists.txt
+++ b/help/CMakeLists.txt
@@ -38,7 +38,7 @@ if( NOT "${CMAKE_GENERATOR}" MATCHES "Xcode|Visual Studio*" )
    install( DIRECTORY "${dst}" OPTIONAL
             DESTINATION "${_DATADIR}/audacity/help" )
    install( FILES "${_SRCDIR}/audacity.1"
-            DESTINATION "${_DATADIR}/man/man.1" )
+            DESTINATION "${_MANDIR}/man1" )
    install( FILES "${_SRCDIR}/audacity.appdata.xml"
             DESTINATION "${_DATADIR}/appdata" )
 endif()


### PR DESCRIPTION
The _GNUInstallDirs_ module will set `CMAKE_INSTALL_MANDIR` to the correct path. 

On OpenBSD for example, it should be like this:
`/usr/local/man/man1/audacity.1`