### PR TITLE
[CMAKE] Portmidi: add missing Unix files in Cygwin

### DIFF
--- a/cmake-proxies/portmidi/CMakeLists.txt
+++ b/cmake-proxies/portmidi/CMakeLists.txt
@@ -23,7 +23,7 @@ list( APPEND SOURCES
          ${TARGET_ROOT}/porttime/ptmacosx_mach.c
       >
 
-      $<$<PLATFORM_ID:Linux,FreeBSD>:
+      $<$<PLATFORM_ID:Linux,FreeBSD,CYGWIN>:
          ${TARGET_ROOT}/pm_linux/finddefault.c
          ${TARGET_ROOT}/pm_linux/pmlinux.c
          ${TARGET_ROOT}/porttime/ptlinux.c


### PR DESCRIPTION
When doing the final link of Audacity executable on Cygwin, many errors similar to this one were printed on the console:

ld: ../lib/audacity/libportmidi.a(portmidi.c.o):portmidi.c:(.text+0x3f): undefined reference to `pm_alloc'

This happened because some files were missing since Cygwin name was not included together with other unix platforms.

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
