### PR TITLE
Implementing 2347 and 2348 (Loop Play with Labels)

### DIFF
--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -158,7 +158,8 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
 #if defined(EXPERIMENTAL_SEEK_BEHIND_CURSOR)
    double init_seek = 0.0;
 #endif
-double loop_offset = 0.0;
+
+   double loop_offset = 0.0;
 
    if (t1 == t0) {
       if (looped) {

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -1,5 +1,4 @@
 #include "../Audacity.h"
-
 #include "../Experimental.h"
 
 #include "../AdornedRulerPanel.h"
@@ -184,7 +183,7 @@ void DoMoveToLabel(AudacityProject &project, bool next)
             window.RedrawProject();
          }
          auto message = XO("%s %d of %d")
-             .Format( label->title, i + 1, lt->GetNumLabels() );
+            .Format( label->title, i + 1, lt->GetNumLabels() );
          trackFocus.MessageForScreenReader(message);
       }
       else {


### PR DESCRIPTION

This enhances the usefulness of Previous/Next label because you can loop for instance sentences and jump ahead while loop play is still on. For point labels, it will begin at the label position and not the project start as it is currently the case.