### PR TITLE
[CMAKE] PCH: wxWidgets must be included first

### DIFF
--- a/src/AudacityHeaders.h
+++ b/src/AudacityHeaders.h
@@ -17,18 +17,6 @@
 
 **********************************************************************/
 
-#include "Audacity.h"
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
-#ifdef __WXMSW__
-#include <initializer_list>
-#endif
-
-
-
 #include <wx/wx.h>
 #include <wx/bitmap.h>
 #include <wx/filedlg.h>
@@ -40,6 +28,16 @@
 #include <wx/textfile.h>
 #include <wx/thread.h>
 #include <wx/tooltip.h>
+
+#include "Audacity.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#ifdef __WXMSW__
+#include <initializer_list>
+#endif
 
 #include "audacity/Types.h"
 


### PR DESCRIPTION
To make working the support of precompiled headers, it is required that wxWidgets headers are included before all others. This is required because they can activate some options before the inclusion of standard libc files. Otherwise, if you include other files before those options are activated, the build process may crash or the application may crash during runtime. I noticed this behavior when building on Cygwin, that requires the presence of macro _GNU_SOURCE to be defined. Without that, the build process will fail with these errors:

```
src/AudioIO.cpp: In function 'double SystemTime(bool)':
src/AudioIO.cpp:817:21: error: 'CLOCK_MONOTONIC_RAW' was not declared
in this scope; did you mean 'CLOCK_MONOTONIC'?
  817 |       clock_gettime(CLOCK_MONOTONIC_RAW, &now);

```
```
src/FileNames.cpp: In function 'FilePath FileNames::PathFromAddr(void*)':
src/FileNames.cpp:428:4: error: 'Dl_info' was not declared in this scope
  428 |    Dl_info info;

```
For Reference, this is the message sent to the mailing list:

https://sourceforge.net/p/audacity/mailman/message/36938976/
