### PR TITLE
Call Invalidate() instead of calling SetFlip to set the flip to false and then back to true.

### DIFF
--- a/lib-src/FileDialog/FileDialog.cpp
+++ b/lib-src/FileDialog/FileDialog.cpp
@@ -145,6 +145,7 @@ wxString FileSelectorEx(const wxString& title,
     {
         if ( defaultFilterIndex )
             *defaultFilterIndex = fileDialog.GetFilterIndex();
+
         filename = fileDialog.GetPath();
     }
 

--- a/lib-src/FileDialog/FileDialog.cpp
+++ b/lib-src/FileDialog/FileDialog.cpp
@@ -145,7 +145,6 @@ wxString FileSelectorEx(const wxString& title,
     {
         if ( defaultFilterIndex )
             *defaultFilterIndex = fileDialog.GetFilterIndex();
-
         filename = fileDialog.GetPath();
     }
 

--- a/src/tracks/timetrack/ui/TimeTrackView.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackView.cpp
@@ -99,12 +99,7 @@ void DrawHorzRulerAndCurve
    // Draw the Ruler
    ruler.SetBounds(r.x, r.y, r.x + r.width - 1, r.y + r.height - 1);
    ruler.SetRange(min, max);
-   ruler.SetFlip(false);  // If we don't do this, the Ruler doesn't redraw itself when the envelope is modified.
-   // I have no idea why!
-   //
-   // LL:  It's because the ruler only Invalidate()s when the NEW value is different
-   //      than the current value.
-   ruler.SetFlip(TrackView::Get( track ).GetHeight() > 75 ? true : true); // MB: so why don't we just call Invalidate()? :)
+   ruler.Invalidate(); //So the ruler can redraw itself.
    ruler.SetTickColour( theTheme.Colour( clrTrackPanelText ));
    ruler.Draw(dc, track.GetEnvelope());
    


### PR DESCRIPTION
# Pull Requests
In the TimeTrackView, one of the comments notes that setting the Flip to false and then back to true causes the ruler to redraw.

However, this is because the Invalidate method in the SetFlip method is called when the flip has changed. There is no need to set the flip at all. Just call Invalidate().

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
