### PR TITLE
Update SpectrogramSettings.cpp so only one semicolon ends the line (avoiding warnings)

### DIFF
--- a/src/prefs/SpectrogramSettings.cpp
+++ b/src/prefs/SpectrogramSettings.cpp
@@ -465,8 +465,9 @@ size_t SpectrogramSettings::GetFFTLength() const
    return windowSize
 #ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
       * ((algorithm != algPitchEAC) ? zeroPaddingFactor : 1);
-#endif
+#else
    ;
+#endif
 }
 
 size_t SpectrogramSettings::NBins() const


### PR DESCRIPTION
There is currently a macro that states if it is experimenting with something, it finishes the return statement. However, when that macro is false, there is no semicolon at the end, so I added and else clause to that macro.