### PR TITLE
[WIN32] Correct declaration of import/export modifiers.

### DIFF
--- a/src/Audacity.h
+++ b/src/Audacity.h
@@ -147,24 +147,21 @@ class wxWindow;
 #define PLATFORM_MAX_PATH MAX_PATH
 #endif
 
-/* Magic for dynamic library import and export. This is unfortunately
- * compiler-specific because there isn't a standard way to do it. Currently it
- * works with the Visual Studio compiler for windows, and for GCC 4+. Anything
- * else gets all symbols made public, which gets messy */
-/* The Visual Studio implementation */
-#ifdef _MSC_VER
+/* The dynamic library import and export for Microsoft Windows.
+ * Supported by Visual Studio and for GCC 4+ */
+#if defined _WIN32 || (defined __CYGWIN__ && defined __GNUC__)
    #ifndef AUDACITY_DLL_API
       #ifdef BUILDING_AUDACITY
-         #define AUDACITY_DLL_API _declspec(dllexport)
+         #define AUDACITY_DLL_API __declspec(dllexport)
       #else
          #ifdef _DLL
-            #define AUDACITY_DLL_API _declspec(dllimport)
+            #define AUDACITY_DLL_API __declspec(dllimport)
          #else
             #define AUDACITY_DLL_API
          #endif
       #endif
    #endif
-#endif //_MSC_VER
+#endif //_WIN32 || (__CYGWIN__ && __GNUC__)
 
 // Put extra symbol information in the release build, for the purpose of gathering
 // profiling information (as from Windows Process Monitor), when there otherwise
@@ -186,23 +183,6 @@ class wxWindow;
          #define AUDACITY_DLL_API __attribute__((visibility("default")))
       #else
          #define AUDACITY_DLL_API __attribute__((visibility("default")))
-      #endif
-   #endif
-#endif
-
-/* The GCC-win32 implementation */
-// bizzarely, GCC-for-win32 supports Visual Studio style symbol visibility, so
-// we use that if building on Cygwin
-#if defined __CYGWIN__ && defined __GNUC__
-   #ifndef AUDACITY_DLL_API
-      #ifdef BUILDING_AUDACITY
-         #define AUDACITY_DLL_API _declspec(dllexport)
-      #else
-         #ifdef _DLL
-            #define AUDACITY_DLL_API _declspec(dllimport)
-         #else
-            #define AUDACITY_DLL_API
-         #endif
       #endif
    #endif
 #endif


### PR DESCRIPTION
The `_declspec` modifier is deprecated since the migration from Win16 to Win32, the correct modifier to be used for modern code is `__declspec`, with two underscore characters as prefix.
MSVC can recognize both modifiers and `_declspec` has the same effect of `__declspec`, depending on the presence of `/Za` option, which activates/deactivates the language extensions:

https://docs.microsoft.com/it-it/cpp/cpp/declspec?view=vs-2019

Unfortunately, GCC supports only `__declspec`, so I recommend this change for increasing portability. Since Audacity does not compile on anything less than GCC 4.9, it is not a big problem to use the same thing for _WIN32 in general, not only MSVC, and also Cygwin.

