### PR TITLE
[WIN32] Correctly read default value of wxRegKey entry.

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -2383,7 +2383,7 @@ void AudacityApp::AssociateFileTypes()
                associateFileTypes.SetName(root_key + wxT("Audacity.Project\\shell\\open\\command"));
                wxString tmpRegAudPath;
                if(associateFileTypes.Exists()) {
-                  tmpRegAudPath = wxString(associateFileTypes).Lower();
+                  tmpRegAudPath = associateFileTypes.QueryDefaultValue().Lower();
                }
                if (!associateFileTypes.Exists() ||
                      (tmpRegAudPath.Find(wxT("audacity.exe")) >= 0)) {


### PR DESCRIPTION
Fix this build error with GCC:

../../audacity/src/AudacityApp.cpp:2347:62: error: call of overloaded 'wxString(wxRegKey&)' is ambiguous.
