### PR TITLE
[CMAKE] LAME: fix compilation error.

### DIFF
--- a/cmake-proxies/lame/CMakeLists.txt
+++ b/cmake-proxies/lame/CMakeLists.txt
@@ -53,6 +53,12 @@ list( APPEND DEFINES
       HAVE_CONFIG_H
 )
 
+list( APPEND OPTIONS
+   PRIVATE
+      ${MMX_FLAG}
+      ${SSE_FLAG}
+)
+
 set( HAVE_INT8_T SIZEOF_INT8_T )
 set( HAVE_INT16_T SIZEOF_INT16_T )
 set( HAVE_INT32_T SIZEOF_INT32_T )
@@ -92,5 +98,6 @@ configure_file( lame.h.in public/lame/lame.h )
 target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
+target_compile_options( ${TARGET} PRIVATE ${OPTIONS} )
 target_link_libraries( ${TARGET} PRIVATE ${LIBRARIES} )
 


### PR DESCRIPTION
If you try to build local LAME with CMake for i686, you get many error messages like this one:

```
/audacity/lib-src/libmp3lame/vector/xmm_quantize_sub.c: In function 'init_xrpow_core_sse':
/audacity/lib-src/libmp3lame/vector/xmm_quantize_sub.c:72:18: warning: SSE vector return without SSE enabled changes the ABI [-Wpsabi]
```
The solution is to add the option provided by SSE_FLAGS.
So, I replicated in this PR the same fix made for local soundtouch library.
