### PR TITLE
[CMAKE] SBSMS: fix compilation error.

### DIFF
--- a/cmake-proxies/sbsms/CMakeLists.txt
+++ b/cmake-proxies/sbsms/CMakeLists.txt
@@ -28,6 +28,8 @@ list( APPEND INCLUDES
 list( APPEND OPTIONS
    PRIVATE
       $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-enum-compare>
+      ${MMX_FLAG}
+      ${SSE_FLAG}
 )
 
 find_package( Threads )


### PR DESCRIPTION
If you try to build local SBSMS with CMake for i686, you get many error messages like this one:

`audacity/lib-src/sbsms/src/fft.h:346:29: warning: SSE vector return without SSE enabled changes the ABI [-Wpsabi]`

The solution is to add the option provided by SSE_FLAGS.
So, I replicated in this PR the same fix made for local Soundtouch and LAME libraries.

