### PR TITLE
[CMAKE] LV2: Fix conflict with main()

### DIFF
--- a/cmake-proxies/lv2/CMakeLists.txt
+++ b/cmake-proxies/lv2/CMakeLists.txt
@@ -37,7 +37,6 @@ list( APPEND SOURCES
       # sord
 
       ${TARGET_ROOT}/sord/src/sord.c
-      ${TARGET_ROOT}/sord/src/sord_validate.c
       ${TARGET_ROOT}/sord/src/syntax.c
       ${TARGET_ROOT}/sord/src/zix/btree.c
       ${TARGET_ROOT}/sord/src/zix/digest.c


### PR DESCRIPTION
After compiling Audacity with MinGW, a strange message appeared on the console after the executable was launched:

```
# ./Audacity.exe
Usage: C:\msys64\home\Carlo\a\bin\Audacity.exe [OPTION]... INPUT...
Validate RDF data

  -h  Display this help and exit
  -l  Print errors on a single line.
  -v  Display version information and exit
Validate RDF data.  This is a simple validator which checks
that all used properties are actually defined.  It does not do
any fancy file retrieval, the files passed on the command line
are the only data that is read.  In other words, you must pass
the definition of all vocabularies used on the command line.
```
The problem happens because the file `lv2/sord/src/sord_validate.c` contains a `main()` function that was called by crt startup code instead of the one in the main sources of Audacity. The solution is to not include this unneeded file.
