### PR TITLE
[WIN32] mod-script-pipe: fix compile error with GCC

### DIFF
--- a/lib-src/mod-script-pipe/PipeServer.cpp
+++ b/lib-src/mod-script-pipe/PipeServer.cpp
@@ -15,7 +15,7 @@ void PipeServer()
    HANDLE hPipeToSrv;
    HANDLE hPipeFromSrv;
 
-   LPTSTR pipeNameToSrv= _T("\\\\.\\pipe\\ToSrvPipe");
+   static const TCHAR pipeNameToSrv[] = _T("\\\\.\\pipe\\ToSrvPipe");
 
    hPipeToSrv = CreateNamedPipe( 
       pipeNameToSrv ,
@@ -29,7 +29,7 @@ void PipeServer()
    if( hPipeToSrv == INVALID_HANDLE_VALUE)
       return;
 
-   LPTSTR pipeNameFromSrv= __T("\\\\.\\pipe\\FromSrvPipe");
+   static const TCHAR pipeNameFromSrv[] = __T("\\\\.\\pipe\\FromSrvPipe");
 
    hPipeFromSrv = CreateNamedPipe( 
       pipeNameFromSrv ,


### PR DESCRIPTION
When compiling with CMake and MinGW, I got these two errors:

```
audacity/lib-src/mod-script-pipe/PipeServer.cpp:18:29: warning: ISO C++ forbids converting a string constant to 'LPTSTR' {aka 'char*'} [-Wwrite-strings]
   18 |    LPTSTR pipeNameToSrv= _T("\\\\.\\pipe\\ToSrvPipe");
```

```
audacity/lib-src/mod-script-pipe/PipeServer.cpp:32:32: warning: ISO C++ forbids converting a string constant to 'LPTSTR' {aka 'char*'} [-Wwrite-strings]
   32 |    LPTSTR pipeNameFromSrv= __T("\\\\.\\pipe\\FromSrvPipe");
```

The solution is to replace LPTSTR and convert these two pointers into two const objects.
