### PR TITLE
Allow use of wxPowerResource if wxWidgets is 3.1.x

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1418,7 +1418,7 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions &options,
    }
 #endif
 
-#if defined(__WXMAC__) || defined(__WXMSW__)
+#if (defined(__WXMAC__) || defined(__WXMSW__)) && wxCHECK_VERSION(3,1,0)
    // Don't want the system to sleep while audio I/O is active
    if (mPortStreamV19 != NULL && mLastPaError == paNoError) {
       wxPowerResource::Acquire(wxPOWER_RESOURCE_SCREEN, _("Audacity Audio"));
@@ -2171,7 +2171,7 @@ void AudioIO::StopStream()
      )
       return;
 
-#if defined(__WXMAC__) || defined(__WXMSW__)
+#if (defined(__WXMAC__) || defined(__WXMSW__)) && wxCHECK_VERSION(3,1,0)
    // Re-enable system sleep
    wxPowerResource::Release(wxPOWER_RESOURCE_SCREEN);
 #endif


### PR DESCRIPTION
I got an error when compiling with wxWidgets 3.0.4, because wxPowerResource is undefined.
It seems to me that wxPowerResource has been introduced with wxWidgets 3.1.x branch:

https://github.com/wxWidgets/wxWidgets/commit/51d715e46d3899f12161f8966db5b9f7f8050bf2#diff-93a9bace734a8065b203ebd2f670cbe8

so, it would be worth to check if the feature is supported at compile time.

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
