### PR TITLE
Internat: use _WIN32 instead of _MSC_VER for DebugBreak()

### DIFF
--- a/src/Internat.h
+++ b/src/Internat.h
@@ -42,7 +42,7 @@ extern AUDACITY_DLL_API const wxString& GetCustomSubstitution(const wxString& st
    // Force a crash if you misuse _ in a static initializer, so that translation
    // is looked up too early and not found.
 
-   #ifdef _WIN32
+   #ifdef __WXMSW__
 
    #define _(s) ((wxTranslations::Get() || (DebugBreak(), true)), \
                 GetCustomTranslation((s)))

--- a/src/Internat.h
+++ b/src/Internat.h
@@ -42,7 +42,7 @@ extern AUDACITY_DLL_API const wxString& GetCustomSubstitution(const wxString& st
    // Force a crash if you misuse _ in a static initializer, so that translation
    // is looked up too early and not found.
 
-   #ifdef _MSC_VER
+   #ifdef _WIN32
 
    #define _(s) ((wxTranslations::Get() || (DebugBreak(), true)), \
                 GetCustomTranslation((s)))


### PR DESCRIPTION
For compiling with MinGW, it is required that it uses the same code of Visual Studio when `__WXDEBUG__` is defined.