### PR TITLE
[CMAKE] Portaudio: x86_plain_converters is MSVC only

### DIFF
--- a/cmake-proxies/portaudio-v19/CMakeLists.txt
+++ b/cmake-proxies/portaudio-v19/CMakeLists.txt
@@ -104,7 +104,9 @@ list( APPEND SOURCES
          ${TARGET_ROOT}/src/os/win/pa_win_util.c
          ${TARGET_ROOT}/src/os/win/pa_win_waveformat.c
          ${TARGET_ROOT}/src/os/win/pa_win_wdmks_utils.c
-         ${TARGET_ROOT}/src/os/win/pa_x86_plain_converters.c
+         $<$<C_COMPILER_ID:MSVC>:
+            ${TARGET_ROOT}/src/os/win/pa_x86_plain_converters.c
+         >
       >
 
       $<$<PLATFORM_ID:Darwin>:


### PR DESCRIPTION
As you can see from the original CMakeLists.txt into the sources of Portaudio, the file pa_x86_plain_converters.c can be compiled only with Visual C++, so it should not be include if there is not the Microsoft Compiler.