### PR TITLE
[CMAKE] Portaudio: do not activate OSS on Windows

### DIFF
--- a/cmake-proxies/portaudio-v19/CMakeLists.txt
+++ b/cmake-proxies/portaudio-v19/CMakeLists.txt
@@ -22,33 +22,35 @@ if( CMAKE_SYSTEM_NAME MATCHES "Windows" )
       "Use the portaudio WMME interface if available"
       YES
    )
-elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
+else()
+   # Look for OSS if the user wants it
    cmd_option(
-      ${_OPT}use_pa_coreaudio
-      "Use the portaudio CoreAudio interface if available"
+      ${_OPT}use_pa_oss
+      "Use the OSS audio interface if available"
       YES
    )
-elseif( CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD" )
-   cmd_option(
-      ${_OPT}use_pa_alsa
-      "Use the portaudio ALSA interface if available"
-      YES
-   )
+   if( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
+      cmd_option(
+         ${_OPT}use_pa_coreaudio
+         "Use the portaudio CoreAudio interface if available"
+         YES
+      )
+   elseif( CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD" )
+      cmd_option(
+         ${_OPT}use_pa_alsa
+         "Use the portaudio ALSA interface if available"
+         YES
+      )
 
-   if( ${_OPT}use_pa_alsa )
-      find_package( ALSA )
-      if( NOT ALSA_FOUND )
-         set_cache_value( ${_OPT}use_pa_alsa NO )
+      if( ${_OPT}use_pa_alsa )
+         find_package( ALSA )
+         if( NOT ALSA_FOUND )
+            set_cache_value( ${_OPT}use_pa_alsa NO )
+         endif()
       endif()
    endif()
 endif()
 
-# Look for OSS if the user wants it
-cmd_option(
-   ${_OPT}use_pa_oss
-   "Use the OSS audio interface if available"
-   YES
-)
 if( ${_OPT}use_pa_oss )
    find_path( OSS_INCLUDE NAMES sys/soundcard.h )
    mark_as_advanced( FORCE OSS_INCLUDE )

--- a/cmake-proxies/portaudio-v19/CMakeLists.txt
+++ b/cmake-proxies/portaudio-v19/CMakeLists.txt
@@ -29,6 +29,27 @@ else()
       "Use the OSS audio interface if available"
       YES
    )
+
+   if( ${_OPT}use_pa_oss )
+      find_path( OSS_INCLUDE NAMES sys/soundcard.h )
+      mark_as_advanced( FORCE OSS_INCLUDE )
+
+      if( OSS_INCLUDE )
+         set( OSS_INCLUDE_DIRS ${OSS_INCLUDE} )
+      endif()
+
+      find_library( OSS_LIBRARY NAMES ossaudio )
+      mark_as_advanced( FORCE OSS_LIBRARY )
+
+      if( OSS_LIBRARY )
+         set( OSS_LIBRARIES ${OSS_LIBRARY} )
+      endif()
+
+      if( NOT OSS_INCLUDE_DIRS )
+         set_cache_value( ${_OPT}use_pa_oss NO )
+      endif()
+   endif()
+
    if( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
       cmd_option(
          ${_OPT}use_pa_coreaudio
@@ -48,26 +69,6 @@ else()
             set_cache_value( ${_OPT}use_pa_alsa NO )
          endif()
       endif()
-   endif()
-endif()
-
-if( ${_OPT}use_pa_oss )
-   find_path( OSS_INCLUDE NAMES sys/soundcard.h )
-   mark_as_advanced( FORCE OSS_INCLUDE )
-
-   if( OSS_INCLUDE )
-      set( OSS_INCLUDE_DIRS ${OSS_INCLUDE} )
-   endif()
-
-   find_library( OSS_LIBRARY NAMES ossaudio )
-   mark_as_advanced( FORCE OSS_LIBRARY )
-
-   if( OSS_LIBRARY )
-      set( OSS_LIBRARIES ${OSS_LIBRARY} )
-   endif()
-
-   if( NOT OSS_INCLUDE_DIRS )
-      set_cache_value( ${_OPT}use_pa_oss NO )
    endif()
 endif()
 


### PR DESCRIPTION
I had a strange error when building the local portaudio library with MinGW under msys2.
The error was caused by the file `sys/soundcard.h` that was found somewhere in the path, because `use_pa_oss` is always activated regardless the platform.
So, in my opinion it is better to not activate this option if the platform is Windows.
Afterall, it is useless in this case.