### PR TITLE
PlaybackEmulatedVolume setting

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1137,9 +1137,6 @@ void AudioIO::GetMixer(int *recordDevice, float *recordVolume,
 #if defined(USE_PORTMIXER)
 
    PxMixer *mixer = mPortMixer;
-   std::cout << "mMixerOutputVol  = " << mMixerOutputVol << std::endl;
-   gPrefs->Write(wxT("/AudioIO/PlaybackVolume"), mMixerOutputVol);
-   gPrefs->Flush();
 
    if( mixer )
    {
@@ -1150,8 +1147,16 @@ void AudioIO::GetMixer(int *recordDevice, float *recordVolume,
       else
          *recordVolume = 1.0f;
 
-      if (mEmulateMixerOutputVol)
-	  gPrefs->Read(wxT("/AudioIO/PlaybackVolume"), playbackVolume);
+      if (mEmulateMixerOutputVol) {
+	  if (mMixerOutputVol != 1.0) {
+	      std::cout << "mMixerOutputVol  = " << mMixerOutputVol << std::endl;
+	      gPrefs->Write(wxT("/AudioIO/PlaybackEmulatedVolume"), mMixerOutputVol);
+	      gPrefs->Flush();
+	  }
+	  else {
+	      gPrefs->Read(wxT("/AudioIO/PlaybackEmulatedVolume"), playbackVolume);
+	  }
+      }
       else
          *playbackVolume = Px_GetPCMOutputVolume(mixer);
 
@@ -3446,7 +3451,6 @@ void AudioIO::AllNotesOff(bool looping)
 
 void AudioIO::AILAInitialize() {
    gPrefs->Read(wxT("/AudioIO/AutomatedInputLevelAdjustment"), &mAILAActive,         false);
-   gPrefs->Read(wxT("/AudioIO/PlaybackVolume"),        &playbackVolume,      DEFAULT_PLAYBACK_VOLUME);
    gPrefs->Read(wxT("/AudioIO/TargetPeak"),            &mAILAGoalPoint,      AILA_DEF_TARGET_PEAK);
    gPrefs->Read(wxT("/AudioIO/DeltaPeakVolume"),       &mAILAGoalDelta,      AILA_DEF_DELTA_PEAK);
    gPrefs->Read(wxT("/AudioIO/AnalysisTime"),          &mAILAAnalysisTime,   AILA_DEF_ANALYSIS_TIME);

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1149,7 +1149,7 @@ void AudioIO::GetMixer(int *recordDevice, float *recordVolume,
 
       if (mEmulateMixerOutputVol) {
 	  if (mMixerOutputVol != 1.0) {
-	      std::cout << "mMixerOutputVol  = " << mMixerOutputVol << std::endl;
+	      *playbackVolume = mMixerOutputVol;
 	      gPrefs->Write(wxT("/AudioIO/PlaybackEmulatedVolume"), mMixerOutputVol);
 	      gPrefs->Flush();
 	  }

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1115,10 +1115,8 @@ void AudioIO::SetMixer(int inputSource, float recordVolume,
 {
    mMixerOutputVol = playbackVolume;
    if (mEmulateMixerOutputVol) {
-       if (mMixerOutputVol != 1.0) {
-	   gPrefs->Write(wxT("/AudioIO/PlaybackEmulatedVolume"), mMixerOutputVol);
-	   gPrefs->Flush();
-       }
+       gPrefs->Write(wxT("/AudioIO/PlaybackEmulatedVolume"), mMixerOutputVol);
+       gPrefs->Flush();
    }
 
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1154,7 +1154,7 @@ void AudioIO::GetMixer(int *recordDevice, float *recordVolume,
 	      gPrefs->Flush();
 	  }
 	  else {
-	      gPrefs->Read(wxT("/AudioIO/PlaybackEmulatedVolume"), playbackVolume);
+	      gPrefs->Read(wxT("/AudioIO/PlaybackEmulatedVolume"), playbackVolume, DEFAULT_PLAYBACK_EMULATED_VOLUME);
 	  }
       }
       else

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1114,6 +1114,14 @@ void AudioIO::SetMixer(int inputSource, float recordVolume,
                        float playbackVolume)
 {
    mMixerOutputVol = playbackVolume;
+   if (mEmulateMixerOutputVol) {
+       if (mMixerOutputVol != 1.0) {
+	   gPrefs->Write(wxT("/AudioIO/PlaybackEmulatedVolume"), mMixerOutputVol);
+	   gPrefs->Flush();
+       }
+   }
+
+
 #if defined(USE_PORTMIXER)
    PxMixer *mixer = mPortMixer;
    if( !mixer )
@@ -1150,11 +1158,10 @@ void AudioIO::GetMixer(int *recordDevice, float *recordVolume,
       if (mEmulateMixerOutputVol) {
 	  if (mMixerOutputVol != 1.0) {
 	      *playbackVolume = mMixerOutputVol;
-	      gPrefs->Write(wxT("/AudioIO/PlaybackEmulatedVolume"), mMixerOutputVol);
-	      gPrefs->Flush();
 	  }
 	  else {
 	      gPrefs->Read(wxT("/AudioIO/PlaybackEmulatedVolume"), playbackVolume, DEFAULT_PLAYBACK_EMULATED_VOLUME);
+	      mMixerOutputVol = *playbackVolume;
 	  }
       }
       else

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -440,6 +440,7 @@ time warp info and AudioIOListener and whether the playback is looped.
 #include "portmixer.h"
 #endif
 
+#include <iostream>
 #include <wx/app.h>
 #include <wx/frame.h>
 #include <wx/wxcrtvararg.h>
@@ -1136,6 +1137,9 @@ void AudioIO::GetMixer(int *recordDevice, float *recordVolume,
 #if defined(USE_PORTMIXER)
 
    PxMixer *mixer = mPortMixer;
+   std::cout << "mMixerOutputVol  = " << mMixerOutputVol << std::endl;
+   gPrefs->Write(wxT("/AudioIO/PlaybackVolume"), mMixerOutputVol);
+   gPrefs->Flush();
 
    if( mixer )
    {
@@ -1147,7 +1151,7 @@ void AudioIO::GetMixer(int *recordDevice, float *recordVolume,
          *recordVolume = 1.0f;
 
       if (mEmulateMixerOutputVol)
-         *playbackVolume = mMixerOutputVol;
+	  gPrefs->Read(wxT("/AudioIO/PlaybackVolume"), playbackVolume);
       else
          *playbackVolume = Px_GetPCMOutputVolume(mixer);
 
@@ -3442,6 +3446,7 @@ void AudioIO::AllNotesOff(bool looping)
 
 void AudioIO::AILAInitialize() {
    gPrefs->Read(wxT("/AudioIO/AutomatedInputLevelAdjustment"), &mAILAActive,         false);
+   gPrefs->Read(wxT("/AudioIO/PlaybackVolume"),        &playbackVolume,      DEFAULT_PLAYBACK_VOLUME);
    gPrefs->Read(wxT("/AudioIO/TargetPeak"),            &mAILAGoalPoint,      AILA_DEF_TARGET_PEAK);
    gPrefs->Read(wxT("/AudioIO/DeltaPeakVolume"),       &mAILAGoalDelta,      AILA_DEF_DELTA_PEAK);
    gPrefs->Read(wxT("/AudioIO/AnalysisTime"),          &mAILAAnalysisTime,   AILA_DEF_ANALYSIS_TIME);

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -64,6 +64,7 @@ bool ValidateDeviceNames();
 
 #define MAX_MIDI_BUFFER_SIZE 5000
 #define DEFAULT_SYNTH_LATENCY 5
+#define DEFAULT_PLAYBACK_EMULATED_VOLUME 1.0
 
 wxDECLARE_EXPORTED_EVENT(AUDACITY_DLL_API,
                          EVT_AUDIOIO_PLAYBACK, wxCommandEvent);

--- a/src/prefs/PlaybackPrefs.h
+++ b/src/prefs/PlaybackPrefs.h
@@ -12,6 +12,8 @@
 #ifndef __AUDACITY_PLAYBACK_PREFS__
 #define __AUDACITY_PLAYBACK_PREFS__
 
+#define DEFAULT_PLAYBACK_VOLUME 0.5
+
 #include <wx/defs.h>
 
 #include "PrefsPanel.h"

--- a/src/prefs/PlaybackPrefs.h
+++ b/src/prefs/PlaybackPrefs.h
@@ -12,8 +12,6 @@
 #ifndef __AUDACITY_PLAYBACK_PREFS__
 #define __AUDACITY_PLAYBACK_PREFS__
 
-#define DEFAULT_PLAYBACK_VOLUME 0.5
-
 #include <wx/defs.h>
 
 #include "PrefsPanel.h"


### PR DESCRIPTION
Now audacity does not save the sound level if the sound is adjusted as emulated. It is very uncomfortable