### PR TITLE
Issue #483: Add Keywords to .desktop file

### DIFF
--- a/locale/af.po
+++ b/locale/af.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2007-10-27 23:04+0200\n"
 "Last-Translator: F Wolff <friedel@translate.org.za>\n"
 "Language-Team: Afrikaans <translate-discuss-af@lists.sourceforge.net>\n"
@@ -3722,6 +3722,26 @@ msgstr ""
 "Fout met oopmaak van klanktoestel. Gaan asseblief die opstelling vir "
 "afvoertoestel en projektempo na."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "Om die spektrum te teken moet alle bane die selfde monstertempo hê."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3918,9 +3938,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Pas projek"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9684,6 +9709,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10405,7 +10435,8 @@ msgstr "Monsterfrekwensie:"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "kbps"
@@ -11024,7 +11055,6 @@ msgstr "Die seleksie word as FLAC uitgevoer"
 msgid "Exporting the audio as FLAC"
 msgstr "Die seleksie word as FLAC uitgevoer"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12283,7 +12313,7 @@ msgstr "Einde"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14310,13 +14340,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Nuwe oudiobaan gemaak"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Nuwe oudiobaan gemaak"
 
 #: src/menus/TransportMenus.cpp
@@ -18606,7 +18648,7 @@ msgstr "Naam mag nie leeg wees nie"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Naam mag nie leeg wees nie"
 
 #: src/widgets/valnum.cpp
@@ -20469,6 +20511,21 @@ msgstr "Frekwensie (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Stilte"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Opgeneemde oudio"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2018-02-10 16:40+0300\n"
 "Last-Translator: \n"
 "Language-Team: ar@li.org\n"
@@ -3774,6 +3774,26 @@ msgstr ""
 "خطأ في فتح جهاز الصوت.\n"
 "حاول تغيير مضيف الصوت و جهاز التشغيل و معدل عينة المشروع."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "لتطبق مصفياً، يجب أن يكون لجميع المقاطع المختارة نفس معدل العينة."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4015,9 +4035,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "تحذير: مشاكل في الاسترجاع التلقائي"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<غير معنون>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "المشاريع"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9857,6 +9882,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "حجم الصوان (8 إلى 1048576 عينة):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "حجم الصوان (8 إلى 1048576 عينة):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10593,7 +10623,8 @@ msgstr "معدَّلات العينة"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -11283,7 +11314,6 @@ msgstr "أصدر الصوت المختار كـ FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "أصدر الصوت كـ FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12618,7 +12648,7 @@ msgstr "نهاية"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14562,13 +14592,25 @@ msgstr ""
 "من فضلك احفظ أو أغلق هذا المشروع و حاول مرة ثانية."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "من فضلك اختر مقطعاً صوتياً."
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "من فضلك اختر مقطعاً صوتياً."
 
 #: src/menus/TransportMenus.cpp
@@ -18682,8 +18724,8 @@ msgid "Value must not be less than %s"
 msgstr "يجب أن لا تكون القيمة أقل من %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "يجب أن لا تكون القيمة أكبر من %s"
 
 #: src/widgets/valnum.cpp
@@ -20561,6 +20603,21 @@ msgstr "تردد (هرتز)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "اظهر\\اخف المحرر"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "عند استوراد ملفات الصوت"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #~ msgid "incorporating"

--- a/locale/audacity.pot
+++ b/locale/audacity.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3534,6 +3534,25 @@ msgid ""
 "Try changing the audio host, playback device and the project sample rate."
 msgstr ""
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3730,8 +3749,13 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
 msgstr ""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
@@ -9147,6 +9171,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -9822,7 +9851,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -10426,7 +10456,6 @@ msgstr ""
 msgid "Exporting the audio as FLAC"
 msgstr ""
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -11650,7 +11679,7 @@ msgstr ""
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -13451,11 +13480,23 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
@@ -17432,7 +17473,7 @@ msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr ""
 
 #: src/widgets/valnum.cpp
@@ -19123,4 +19164,17 @@ msgstr ""
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+msgid "Sound Editor"
+msgstr ""
+
+#: src/audacity.desktop.in
+msgid "Record and edit audio files"
+msgstr ""
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""

--- a/locale/be.po
+++ b/locale/be.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2010-04-19 16:57+0300\n"
 "Last-Translator: FatCow <zhr@tut.by>\n"
 "Language-Team: Patricia Clausnitzer <by.marcis@gmail.com>\n"
@@ -3807,6 +3807,28 @@ msgstr ""
 "Памылка пры адкрыцці гукавой прылады.\n"
 "Праверце параметры прылады і чашчыню сэмпліравання."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Для пабудовы спектраграмы ўсе абраныя дарожкі\n"
+"павінны мець аднолькавую чашчыню"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4003,9 +4025,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Праекты"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9950,6 +9977,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10665,7 +10697,8 @@ msgstr "Чашчыні сэмпліравання"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "Кбіт/з"
@@ -11296,7 +11329,6 @@ msgstr "Вылучанае экспартуецца ў файл FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Вылучанае экспартуецца ў файл FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12600,7 +12632,7 @@ msgstr "Канец"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14656,13 +14688,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Абярыце дзеянне"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Абярыце дзеянне"
 
 #: src/menus/TransportMenus.cpp
@@ -19017,7 +19061,7 @@ msgstr "Поле імя павінна быць запоўнена"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Значэнне зыходнага і канчатковага парогаў павінна быць больш нуля"
 
 #: src/widgets/valnum.cpp
@@ -20898,6 +20942,21 @@ msgstr "Чашчыня (Гц)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Запаўненне цішынёй"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Пры імпарце гукавых файлаў"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2012-06-19 09:34-0000\n"
 "Last-Translator: Mikhail Balabanov\n"
 "Language-Team: .\n"
@@ -3896,6 +3896,28 @@ msgstr ""
 "Грешка при отваряне на звуковото устройство. Моля, проверете настройките на "
 "изходното устройство и честотата на дискретизация за проекта."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"За чертане на спектър всички избрани писти трябва да са с еднаква честота на "
+"дискретизация."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4146,9 +4168,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Внимание: проблеми при автоматично възстановяване"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<неозаглавено>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Проекти"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -10140,6 +10167,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10893,7 +10925,8 @@ msgstr "Честоти на дискретизация"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i Кб/с"
@@ -11592,7 +11625,6 @@ msgstr "Избраният звук се експортира като FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Избраният звук се експортира като FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12951,7 +12983,7 @@ msgstr "Край"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -15018,13 +15050,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Моля, изберете действие"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Моля, изберете действие"
 
 #: src/menus/TransportMenus.cpp
@@ -19379,7 +19423,7 @@ msgstr "Името не трябва да е празно"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Началото и краят трябва да са по-големи от 0."
 
 #: src/widgets/valnum.cpp
@@ -21256,6 +21300,21 @@ msgstr "Честота (Хц)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Генератор на тишина"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "При импортиране на аудиофайлове"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/bn.po
+++ b/locale/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2005-09-26 13:47-0800\n"
 "Last-Translator: mak <makl10n@yahoo.com>\n"
 "Language-Team: Bangladeshi <makl10n@yahoo.com>\n"
@@ -3601,6 +3601,25 @@ msgid ""
 "Try changing the audio host, playback device and the project sample rate."
 msgstr ""
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3797,9 +3816,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "নির্বাচনের শুরুতে"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9341,6 +9365,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10022,7 +10051,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -10632,7 +10662,6 @@ msgstr ""
 msgid "Exporting the audio as FLAC"
 msgstr ""
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -11859,7 +11888,7 @@ msgstr ""
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -13777,13 +13806,26 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "নির্বাচনের শেষে"
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
-msgstr ""
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
+msgstr "নির্বাচনের শেষে"
 
 #: src/menus/TransportMenus.cpp
 #, c-format
@@ -17905,7 +17947,7 @@ msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr ""
 
 #: src/widgets/valnum.cpp
@@ -19698,6 +19740,20 @@ msgstr ""
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "পুনরাবৃত্তি"
+
+#: src/audacity.desktop.in
+msgid "Record and edit audio files"
+msgstr ""
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/bs.po
+++ b/locale/bs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2008-11-22 21:47-0500\n"
 "Last-Translator: Samir Ribic <megaribi@epn.ba>\n"
 "Language-Team: Bosnian <bhld@lists.linux.org.ba>\n"
@@ -3761,6 +3761,27 @@ msgstr ""
 "Greška pri otvaranju zvučnog uređaja. Molimo provjerite postavke izlaznog "
 "uređaja i brzinu uzimanja uzoraka projekta."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Za crtanje spektra sve izabrane trake moraju imati jednak stepen uzorkovanja."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3958,9 +3979,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Prilagodi projekt"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9814,6 +9840,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10534,7 +10565,8 @@ msgstr "Frekvencije uzimanja uzoraka"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "kb/s"
@@ -11154,7 +11186,6 @@ msgstr "Izvoženje izbranoga zvuka kao FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Izvoženje izbranoga zvuka kao FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12438,7 +12469,7 @@ msgstr "Kraj"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14487,13 +14518,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Stvorena nova zvučna traka"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Stvorena nova zvučna traka"
 
 #: src/menus/TransportMenus.cpp
@@ -18811,7 +18854,7 @@ msgstr "Ime ne smije biti prazno"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Početak i kraj moraju biti veći od 0."
 
 #: src/widgets/valnum.cpp
@@ -20676,6 +20719,21 @@ msgstr "Frekvencija (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Generator tišine"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Stare datoteke automatskog spremanja nije mogoće odstraniti"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2018-09-10 17:16+0200\n"
 "Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -3758,6 +3758,28 @@ msgid ""
 "Try changing the audio host, playback device and the project sample rate."
 msgstr ""
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Per aplicar el filtre cal que totes les pistes seleccionades tinguin la "
+"mateixa freqüència de mostreig."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4015,9 +4037,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Advertència: Hi ha hagut problemes durant la recuperació automàtica"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sense nom>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projecte"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9712,6 +9739,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Mida de la &memòria intermèdia (de 8 a 1.048.576 mostres):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Mida de la &memòria intermèdia (de 8 a 1.048.576 mostres):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10444,7 +10476,8 @@ msgstr "Freqüències de mostreig"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11137,7 +11170,6 @@ msgstr "S'està exportant l'àudio seleccionat com a FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Exportació de l'àudio com a FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12476,7 +12508,7 @@ msgstr "acabament"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14310,12 +14342,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
-msgstr ""
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
+msgstr "Seleccioneu una pista d'àudio."
 
 #: src/menus/TransportMenus.cpp
 #, c-format
@@ -18427,8 +18472,8 @@ msgid "Value must not be less than %s"
 msgstr "El valor no pot ser inferior a %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "El valor no pot ser superior a %s"
 
 #: src/widgets/valnum.cpp
@@ -20172,6 +20217,21 @@ msgstr "Freqüència del tren de polsos (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Error.~%Es requereix la pista estèreo."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Mostra/amaga l'editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Quan s'importen fitxers d'àudio"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "Click to unpin"
 #~ msgstr "Feu clic per desenclavar"

--- a/locale/ca_ES@valencia.po
+++ b/locale/ca_ES@valencia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2019-09-30 13:51+0200\n"
 "Last-Translator: Alfredo vicente <alviboi@gmail.com>\n"
 "Language-Team: Catalan <kde-i18n-ca@kde.org>\n"
@@ -3828,6 +3828,28 @@ msgstr ""
 "Reviseu els paràmetres del servidor d'àudio, del dispositiu de reproducció i "
 "la freqüència de mostreig del projecte."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Per aplicar el filtre, cal que totes les pistes seleccionades tinguen la "
+"mateixa freqüència de mostreig."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4087,9 +4109,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Advertència: Hi ha hagut problemes durant la recuperació automàtica"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<Sense títol>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projecte"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9852,6 +9879,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Mida de la &memòria intermèdia (de 8 a 1048576 mostres):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Mida de la &memòria intermèdia (de 8 a 1048576 mostres):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10625,7 +10657,8 @@ msgstr "Freqüències de mostreig"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11314,7 +11347,6 @@ msgstr "S'està exportant l'àudio seleccionat com a FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "S'està exportant l'àudio com a FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12673,7 +12705,7 @@ msgstr "final"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14500,11 +14532,24 @@ msgstr ""
 "Guardeu o tanqueu aquest projecte i intenteu-ho de nou."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Seleccioneu en una pista mono."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Seleccioneu en una pista estèreo."
 
 #: src/menus/TransportMenus.cpp
@@ -18580,8 +18625,8 @@ msgid "Value must not be less than %s"
 msgstr "El valor no ha de ser menor que %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "El valor no ha de ser major que %s"
 
 #: src/widgets/valnum.cpp
@@ -20407,6 +20452,21 @@ msgstr "Freqüència de les agulles del radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Error.~%Es requereix la pista estèreo."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Mostra o amaga l'editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "En importar els fitxers de so"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "incorporació"

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2018-11-15 11:23+0100\n"
 "Last-Translator: Pavel Fric <pavelfric@seznam.cz>\n"
 "Language-Team: Czech <kde-i18n-doc@kde.org>\n"
@@ -3782,6 +3782,28 @@ msgstr ""
 "Pokuste se změnit hostitele zvuku, přehrávací zařízení a vzorkovací kmitočet "
 "projektu."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Chcete-li použít filtr, musí mít všechny vybrané stopy stejný vzorkovací "
+"kmitočet."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4032,9 +4054,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Varování: Problémy při automatickém zotavení"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<bez názvu>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekt"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9778,6 +9805,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Velikost vyrovnávací paměti (8 až 1048576 vzorků):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Velikost vyrovnávací paměti (8 až 1048576 vzorků):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10533,7 +10565,8 @@ msgstr "Vzorkovací kmitočty"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kb/s"
@@ -11226,7 +11259,6 @@ msgstr "Vybraná zvuková data se ukládají jako FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Zvuk se ukládá jako FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12582,7 +12614,7 @@ msgstr "Konec"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14421,11 +14453,24 @@ msgstr ""
 "Uložte nebo zavřete, prosím, tento projekt a zkuste to znovu."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Vyberte, prosím, v monofonní stopě."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Vyberte, prosím, ve stereofonní stopě."
 
 #: src/menus/TransportMenus.cpp
@@ -18530,8 +18575,8 @@ msgid "Value must not be less than %s"
 msgstr "Hodnota nesmí být menší než %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Hodnota nesmí být větší než %s"
 
 #: src/widgets/valnum.cpp
@@ -20355,6 +20400,21 @@ msgstr "Kmitočet jehel radaru (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Chyba.~%Požadována stopa sterea."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Ukázat/Skrýt editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Při zavádění zvukových souborů"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "začleňování"

--- a/locale/cy.po
+++ b/locale/cy.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2006-03-07 11:16-0000\n"
 "Last-Translator: \n"
 "Language-Team: Audacity Cymru <f00@hushmail.com>\n"
@@ -3682,6 +3682,27 @@ msgstr ""
 "Gwall wrth agor y ddyfais sain. Gwiriwch osodiadau'r ddyfais allbwn a "
 "graddfa samplo y cywaith."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"I blotio'r sbectrwm, rhaid i bob trac dewisiedig fod o'r un graddfa samplo."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3878,9 +3899,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Ca&dw Cywaith"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9579,6 +9605,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10291,7 +10322,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -10907,7 +10939,6 @@ msgstr ""
 msgid "Exporting the audio as FLAC"
 msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12147,7 +12178,7 @@ msgstr ""
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14147,13 +14178,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Crëwyd trac sain newydd"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Crëwyd trac sain newydd"
 
 #: src/menus/TransportMenus.cpp
@@ -18395,7 +18438,7 @@ msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr ""
 
 #: src/widgets/valnum.cpp
@@ -20247,6 +20290,21 @@ msgstr "Amledd LFO (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Distewi"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Sain a Recordwyd"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/da.po
+++ b/locale/da.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-13 11:38+0200\n"
 "Last-Translator: scootergrisen\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -2937,8 +2937,7 @@ msgid ""
 " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, "
 "online."
 msgstr ""
-" [[https://forum.audacityteam.org/|Forum]] - stil dit spørgsmål "
-"online."
+" [[https://forum.audacityteam.org/|Forum]] - stil dit spørgsmål online."
 
 #: src/HelpText.cpp
 msgid ""
@@ -3415,7 +3414,8 @@ msgid ""
 "The module \"%s\" is matched with Audacity version \"%s\". It will not be "
 "loaded."
 msgstr ""
-"Modulet \"%s\" passer til Audacity-versionen \"%s\". Det vil ikke blive indlæst."
+"Modulet \"%s\" passer til Audacity-versionen \"%s\". Det vil ikke blive "
+"indlæst."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3775,6 +3775,28 @@ msgstr ""
 "Fejl ved åbning af lydenhed.\n"
 "Prøv at ændre lydværten, afspilningsenheden og projektets samplingshastighed."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"For at kunne bruge et filter skal alle markerede spor have samme "
+"samplingshastighed."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4021,9 +4043,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Advarsel: der er problemer med automatisk gendannelse"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<uden titel>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9500,9 +9527,9 @@ msgid ""
 "to take effect."
 msgstr ""
 "Vælg \"Fuld\" for at bruge den grafiske brugerflade hvis lydenheden har en. "
-"Vælg \"Generisk\" for at bruge systemets generiske brugerflade. Vælg \"Enkel\" "
-"for en grundlæggende brugerflade kun med tekst. Åbn effekten igen for at det "
-"skal træde i kraft."
+"Vælg \"Generisk\" for at bruge systemets generiske brugerflade. Vælg \"Enkel"
+"\" for en grundlæggende brugerflade kun med tekst. Åbn effekten igen for at "
+"det skal træde i kraft."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -9699,6 +9726,11 @@ msgstr "LV2-effektindstillinger"
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
 msgid "&Buffer Size (8 to %d) samples):"
+msgstr "&Bufferstørrelse (8 til %d datapunkter):"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
 msgstr "&Bufferstørrelse (8 til %d datapunkter):"
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -10153,8 +10185,8 @@ msgstr ""
 "Du forsøger at overskrive en aliasfil, som mangler.\n"
 "Filen kan ikke skrives, fordi stien er nødvendig for at genskabe den "
 "originale lyd i projektet.\n"
-"Vælg Hjælp > Diagnostik > Afhængighedskontrol for at se placeringerne, af alle "
-"manglende filer.\n"
+"Vælg Hjælp > Diagnostik > Afhængighedskontrol for at se placeringerne, af "
+"alle manglende filer.\n"
 "Hvis du stadig ønsker at eksportere, så vælg venligst et andet filnavn eller "
 "en anden mappe."
 
@@ -10451,7 +10483,8 @@ msgstr "Samplingshastigheder"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11126,7 +11159,6 @@ msgstr "Eksporterer den markerede lyd som FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Eksporterer lyden som FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -11936,8 +11968,8 @@ msgstr "FFmpeg-kompatible filer"
 msgid ""
 "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
 msgstr ""
-"Indeks[%02x] Codec[%s], Sprog[%s], Bithastighed[%s], Kanaler[%d], Varighed[%"
-"d]"
+"Indeks[%02x] Codec[%s], Sprog[%s], Bithastighed[%s], Kanaler[%d], "
+"Varighed[%d]"
 
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
@@ -12457,7 +12489,7 @@ msgstr "slutning"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14272,11 +14304,24 @@ msgstr ""
 "Gem venligst eller luk dette projektet og prøv igen."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Vælg venligst i et monospor."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Vælg venligst i et stereospor."
 
 #: src/menus/TransportMenus.cpp
@@ -16205,7 +16250,8 @@ msgid ""
 "image, but is\n"
 "otherwise the same idea."
 msgstr ""
-"At gemme og indlæse særskilte temafiler sker ved at bruge en separat fil for\n"
+"At gemme og indlæse særskilte temafiler sker ved at bruge en separat fil "
+"for\n"
 "hvert billede men er ellers samme ide."
 
 #. i18n-hint: && in here is an escape character to get a single & on screen,
@@ -17862,7 +17908,8 @@ msgid ""
 "the meter affecting audio quality on slower machines."
 msgstr ""
 "Højere opdateringshastigheder får måleren til at vise ændringer hyppigere.\n"
-"En hastighed på 30 i sekundet eller mindre burde hindre måleren i at påvirke\n"
+"En hastighed på 30 i sekundet eller mindre burde hindre måleren i at "
+"påvirke\n"
 "lydkvaliteten på langsomme maskiner."
 
 #: src/widgets/Meter.cpp
@@ -18320,8 +18367,8 @@ msgid "Value must not be less than %s"
 msgstr "Værdien må ikke være mindre end %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Værdien må ikke være større end %s"
 
 #: src/widgets/valnum.cpp
@@ -20115,3 +20162,18 @@ msgstr "Frekvens af radarnåle (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Fejl.~%Stereospor kræves."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Vis/skjul redigeringsprogram"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Når lydfiler importeres"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""

--- a/locale/de.po
+++ b/locale/de.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-11 12:14+0200\n"
 "Last-Translator: Joachim Huffer <joachim.huffer@gmail.com>\n"
 "Language-Team: German\n"
@@ -3819,6 +3819,28 @@ msgstr ""
 "Versuchen Sie den Audiohost, das Wiedergabegerät und die Abtastrate des "
 "Projektes zu ändern."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Um einen Filter anwenden zu können, müssen alle Spuren die gleiche "
+"Abtastrate haben."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4077,9 +4099,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Warnung: Probleme bei der automatischen Wiederherstellung"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<unbenannt>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9798,6 +9825,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Puffergröße (8 bis %d Samples):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Puffergröße (8 bis %d Samples):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10558,7 +10590,8 @@ msgstr "Abtastraten"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11233,7 +11266,6 @@ msgstr "Ausgewähltes Audio wird als FLAC exportiert"
 msgid "Exporting the audio as FLAC"
 msgstr "Exportiere Audio als FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12572,7 +12604,7 @@ msgstr "Ende"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14392,11 +14424,24 @@ msgstr ""
 "erneut."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Bitte in einer Monospur auswählen."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Bitte in einer Stereospur auswählen."
 
 #: src/menus/TransportMenus.cpp
@@ -18450,8 +18495,8 @@ msgid "Value must not be less than %s"
 msgstr "Wert darf nicht kleiner als %s sein"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Wert darf nicht größer als %s sein"
 
 #: src/widgets/valnum.cpp
@@ -20247,6 +20292,21 @@ msgstr "Frequenz der Radarnadeln (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Fehler.~%Stereospur erforderlich."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Editor anzeigen/verstecken"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Beim Importieren von Audiodateien"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "beinhaltet"

--- a/locale/el.po
+++ b/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-11 12:30+0300\n"
 "Last-Translator: Dimitris Spingos (Δημήτρης Σπίγγος) <dmtrs32@gmail.com>\n"
 "Language-Team: team@lists.gnome.gr\n"
@@ -3817,6 +3817,28 @@ msgstr ""
 "Δοκιμάστε να αλλάξετε τον δέκτη του ήχου, τη συσκευή αναπαραγωγής και τον "
 "ρυθμό δειγματοληψίας του έργου."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Για να εφαρμοστεί ένα φίλτρο, όλα τα επιλεγμένα κομμάτια πρέπει να έχουν τον "
+"ίδιο ρυθμό δειγματοληψίας."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4071,9 +4093,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Προειδοποίηση: Προβλήματα στην αυτόματη ανάκτηση"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<χωρίς όνομα>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Έργο %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9799,6 +9826,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Μέγεθος ε&νδιάμεσης μνήμης (8 έως %d δείγματα):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Μέγεθος ε&νδιάμεσης μνήμης (8 έως %d δείγματα):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10570,7 +10602,8 @@ msgstr "Ρυθμοί δειγματοληψίας"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11247,7 +11280,6 @@ msgstr "Εξαγωγή του επιλεγμένου ήχου ως FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Εξαγωγή του ήχου ως FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12605,7 +12637,7 @@ msgstr "τέλος"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14427,11 +14459,24 @@ msgstr ""
 "Παρακαλούμε, αποθηκεύστε ή κλείστε αυτό το έργο και ξαναδοκιμάστε."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Παρακαλούμε, επιλέξτε μονοφωνικό κομμάτι."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Παρακαλούμε, επιλέξτε στερεοφωνικό κομμάτι."
 
 #: src/menus/TransportMenus.cpp
@@ -18498,8 +18543,8 @@ msgid "Value must not be less than %s"
 msgstr "Η τιμή δεν πρέπει να είναι μικρότερη από %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Η τιμή δεν πρέπει να είναι μεγαλύτερη από %s"
 
 #: src/widgets/valnum.cpp
@@ -20305,6 +20350,21 @@ msgstr "Συχνότητα βελονών ραντάρ (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Σφάλμα. Απαιτείται ~%Stereo κομμάτι."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Εμφάνιση/Απόκρυψη επεξεργαστή"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Κατά την εισαγωγή αρχείων ακουστικού σήματος"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "ενσωμάτωση"

--- a/locale/es.po
+++ b/locale/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-13 12:47+0100\n"
 "Last-Translator: Antonio Paniagua Navarro <aplist at gmail.com>\n"
 "Language-Team: Spanish <kde-i18n-doc@kde.org>\n"
@@ -214,7 +214,8 @@ msgstr "(C) 2009 por Leland Lucius"
 msgid ""
 "External Audacity module which provides a simple IDE for writing effects."
 msgstr ""
-"Modulo externo de Audacity que proporciona un IDE sencillo para crear efectos."
+"Modulo externo de Audacity que proporciona un IDE sencillo para crear "
+"efectos."
 
 #: lib-src/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -502,10 +503,9 @@ msgid ""
 "other Unix-like systems)."
 msgstr ""
 "Audacity es una aplicación libre, escrita por un equipo de [[https://www."
-"audacityteam.org/about/credits|voluntarios]]. Audacity está "
-"[[https://www.audacityteam.org/download|disponible]]para Windows, Mac y"
-" GNU/Linux (y "
-"otros sistemas operativos tipo Unix)."
+"audacityteam.org/about/credits|voluntarios]]. Audacity está [[https://www."
+"audacityteam.org/download|disponible]]para Windows, Mac y GNU/Linux (y otros "
+"sistemas operativos tipo Unix)."
 
 #: src/AboutDialog.cpp
 msgid ""
@@ -514,11 +514,10 @@ msgid ""
 "tricks on our [[https://wiki.audacityteam.org/|wiki]] or visit our [[https://"
 "forum.audacityteam.org/|forum]]."
 msgstr ""
-"Si encuentra algún error o tiene alguna sugerencia escríbanos en inglés a"
-" nuestro  "
-"[[https://forum.audacityteam.org/|foro]]. Para obtener ayuda consulte los "
-"consejos y trucos de nuestro [[https://wiki.audacityteam.org/|wiki]] o "
-"visite nuestro [[https://forum.audacityteam.org/|foro]]."
+"Si encuentra algún error o tiene alguna sugerencia escríbanos en inglés a "
+"nuestro  [[https://forum.audacityteam.org/|foro]]. Para obtener ayuda "
+"consulte los consejos y trucos de nuestro [[https://wiki.audacityteam.org/|"
+"wiki]] o visite nuestro [[https://forum.audacityteam.org/|foro]]."
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
@@ -538,8 +537,8 @@ msgid ""
 "Audacity the free, open source, cross-platform software for recording and "
 "editing sounds."
 msgstr ""
-"Audacity es software libre, de código abierto y multiplataforma para"
-" grabación y edición de sonido."
+"Audacity es software libre, de código abierto y multiplataforma para "
+"grabación y edición de sonido."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
@@ -788,8 +787,8 @@ msgstr "Haga clic y arrastre para comenzar la reproducción por desplazamiento"
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr ""
-"Clic y mover para reproducción por desplazamiento. Clic y arrastrar para"
-" buscar."
+"Clic y mover para reproducción por desplazamiento. Clic y arrastrar para "
+"buscar."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
@@ -1185,8 +1184,8 @@ msgid ""
 "Automated Recording Level Adjustment stopped. It was not possible to "
 "optimize it more. Still too high."
 msgstr ""
-"Autoajuste de nivel de grabación detenido. No se pudo optimizar más. Aún es"
-" demasiado alto."
+"Autoajuste de nivel de grabación detenido. No se pudo optimizar más. Aún es "
+"demasiado alto."
 
 #: src/AudioIO.cpp
 #, c-format
@@ -1198,8 +1197,8 @@ msgid ""
 "Automated Recording Level Adjustment stopped. It was not possible to "
 "optimize it more. Still too low."
 msgstr ""
-"Autoajuste de nivel de grabación detenido. No se pudo optimizar más. Aún es"
-" demasiado bajo."
+"Autoajuste de nivel de grabación detenido. No se pudo optimizar más. Aún es "
+"demasiado bajo."
 
 #: src/AudioIO.cpp
 #, c-format
@@ -1431,9 +1430,10 @@ msgid ""
 "Some projects were not saved properly the last time Audacity was run.\n"
 "Fortunately, the following projects can be automatically recovered:"
 msgstr ""
-"Algunos proyectos no se guardaron correctamente la última vez que se ejecutó"
-" Audacity.\n"
-"Afortunadamente, los siguientes proyectos se pueden recuperar automáticamente:"
+"Algunos proyectos no se guardaron correctamente la última vez que se ejecutó "
+"Audacity.\n"
+"Afortunadamente, los siguientes proyectos se pueden recuperar "
+"automáticamente:"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable projects"
@@ -2215,13 +2215,12 @@ msgid ""
 "imported files, it will no longer be self-contained. If you then Save "
 "without copying those files in, you may lose data."
 msgstr ""
-"Ahora el proyecto es independiente; no depende de ningún archivo de audio"
-" externo.\n"
+"Ahora el proyecto es independiente; no depende de ningún archivo de audio "
+"externo.\n"
 "\n"
-"Si cambia el proyecto a un estado que tenga dependencias externas de archivos"
-" importado no seguirá siendo independiente. "
-"Si en ese punto lo guarda sin copiar los archivos en su interior, puede que"
-" pierda información."
+"Si cambia el proyecto a un estado que tenga dependencias externas de "
+"archivos importado no seguirá siendo independiente. Si en ese punto lo "
+"guarda sin copiar los archivos en su interior, puede que pierda información."
 
 #: src/Dependencies.cpp
 msgid ""
@@ -2232,13 +2231,12 @@ msgid ""
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
-"Ahora el proyecto es independiente; no depende de ningún archivo de audio"
-" externo.\n"
+"Ahora el proyecto es independiente; no depende de ningún archivo de audio "
+"externo.\n"
 "\n"
-"Algunos proyectos antiguos de Audacity pueden no ser independientes por que"
-" se debe "
-"tener precaución para mantener las dependencias externas en el lugar"
-" adecuado.\n"
+"Algunos proyectos antiguos de Audacity pueden no ser independientes por que "
+"se debe tener precaución para mantener las dependencias externas en el lugar "
+"adecuado.\n"
 "Los nuevos proyectos serán independientes por lo que se corren menos riegos."
 
 #: src/Dependencies.cpp
@@ -2448,8 +2446,8 @@ msgid ""
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
-"FFmpeg fue configurado en Preferencias y cargado correctamente, pero esta vez"
-" Audacity no logró cargarlo al arrancar\n"
+"FFmpeg fue configurado en Preferencias y cargado correctamente, pero esta "
+"vez Audacity no logró cargarlo al arrancar\n"
 "\n"
 "Acceda a Preferencias > Bibliotecas para configurarlo de nuevo."
 
@@ -2563,8 +2561,8 @@ msgstr ""
 #, c-format
 msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Audacity ha escrito correctamente un archivo en %s pero ha fallado al"
-" renombrarlo como %s."
+"Audacity ha escrito correctamente un archivo en %s pero ha fallado al "
+"renombrarlo como %s."
 
 #: src/FileException.h
 msgid "File Error"
@@ -2579,8 +2577,8 @@ msgstr "Error (el archivo puede no haber sido escrito): %s"
 #: src/FileFormats.cpp
 msgid "&Copy uncompressed files into the project (safer)"
 msgstr ""
-"&Copia el archivo de audio descomprimido dentro del proyecto (método más"
-" seguro)"
+"&Copia el archivo de audio descomprimido dentro del proyecto (método más "
+"seguro)"
 
 #: src/FileFormats.cpp
 msgid "&Read uncompressed files from original location (faster)"
@@ -2640,8 +2638,8 @@ msgstr "Archivos %s"
 msgid ""
 "The specified filename could not be converted due to Unicode character use."
 msgstr ""
-"El nombre de archivo indicado no puede ser convertido por el uso de"
-" caracteres Unicode."
+"El nombre de archivo indicado no puede ser convertido por el uso de "
+"caracteres Unicode."
 
 #: src/FileNames.cpp
 msgid "Specify New Filename:"
@@ -2893,15 +2891,15 @@ msgid ""
 "<br><br>The version of Audacity you are using is an <b>Alpha test version</"
 "b>."
 msgstr ""
-"<br><br>La versión de Audacity que está utilizando es una <b>versión Alpha de"
-" prueba</b>."
+"<br><br>La versión de Audacity que está utilizando es una <b>versión Alpha "
+"de prueba</b>."
 
 #: src/HelpText.cpp
 msgid ""
 "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
 msgstr ""
-"<br><br>La versión de Audacity que está utilizando es una <b>versión Beta de"
-" prueba</b>."
+"<br><br>La versión de Audacity que está utilizando es una <b>versión Beta de "
+"prueba</b>."
 
 #: src/HelpText.cpp
 msgid "Get the Official Released Version of Audacity"
@@ -3262,8 +3260,8 @@ msgstr "El grupo de complementos de %s se ha combinado con el grupo anterior"
 msgid ""
 "Plug-in item at %s conflicts with a previously defined item and was discarded"
 msgstr ""
-"El complemento de %s entra en conflicto con un elemento anterior y se ha"
-" descartado"
+"El complemento de %s entra en conflicto con un elemento anterior y se ha "
+"descartado"
 
 #: src/Menus.cpp
 #, c-format
@@ -3770,8 +3768,8 @@ msgstr "Habilitar nuevos complementos"
 #, c-format
 msgid "Audacity cannot start because the settings file at %s is not writable."
 msgstr ""
-"No se puede iniciar Audacity porque no se puede escribir en el archivo de"
-" configuración %s."
+"No se puede iniciar Audacity porque no se puede escribir en el archivo de "
+"configuración %s."
 
 #: src/Printing.cpp
 msgid "There was a problem printing."
@@ -3794,6 +3792,28 @@ msgstr ""
 "Error al abrir dispositivo de sonido.\n"
 "Pruebe a modificar el servidor de audio, el dispositivo de reproducción \n"
 "y la frecuencia de muestreo del proyecto."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Para aplicar un filtro, todas las pistas seleccionadas deberán tener la "
+"misma frecuencia de muestreo."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
 
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
@@ -4051,9 +4071,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Advertencia: Problemas en la recuperación automática"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sin nombre>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Project %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -4209,8 +4234,8 @@ msgid ""
 "another project.\n"
 "Please try again and select an original name."
 msgstr ""
-"El proyecto no fue guardado porque con el nombre de archivo indicado se"
-" sobrescribiría otro proyecto.\n"
+"El proyecto no fue guardado porque con el nombre de archivo indicado se "
+"sobrescribiría otro proyecto.\n"
 "Inténtelo de nuevo y escoja un nombre diferente."
 
 #: src/ProjectFileManager.cpp
@@ -4336,8 +4361,8 @@ msgid ""
 "\n"
 "Please open the actual Audacity project file instead."
 msgstr ""
-"Está intentado abrir un archivo de copia de seguridad generado"
-" automáticamente.\n"
+"Está intentado abrir un archivo de copia de seguridad generado "
+"automáticamente.\n"
 "Esto puede conllevar una grave perdida de datos.\n"
 "\n"
 "En su lugar, abra el archivo de proyecto de Audacity."
@@ -4372,8 +4397,8 @@ msgid ""
 "Audacity was unable to convert an Audacity 1.0 project to the new project "
 "format."
 msgstr ""
-"Audacity no pudo convertir un proyecto de Audacity 1.0 al nuevo formato de"
-" proyecto."
+"Audacity no pudo convertir un proyecto de Audacity 1.0 al nuevo formato de "
+"proyecto."
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -5452,8 +5477,8 @@ msgid ""
 "Click and drag to adjust relative size of stereo tracks, double-click to "
 "make heights equal"
 msgstr ""
-"Haga clic y arrastre para ajustar el tamaño relativo de las pistas estéreo."
-" Doble clic para igualar sus alturas."
+"Haga clic y arrastre para ajustar el tamaño relativo de las pistas estéreo. "
+"Doble clic para igualar sus alturas."
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to resize the track."
@@ -5575,8 +5600,8 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"%s: No se puede cargar la configuración. Se usarán los valores"
-" predeterminados.\n"
+"%s: No se puede cargar la configuración. Se usarán los valores "
+"predeterminados.\n"
 "\n"
 "%s"
 
@@ -7337,8 +7362,8 @@ msgid ""
 "Generates dual-tone multi-frequency (DTMF) tones like those produced by the "
 "keypad on telephones"
 msgstr ""
-"Genera un tonos duales multifrecuencia (DTMF) como los que se producen"
-" mediante un teclado de un teléfono"
+"Genera un tonos duales multifrecuencia (DTMF) como los que se producen "
+"mediante un teclado de un teléfono"
 
 #: src/effects/DtmfGen.cpp
 msgid ""
@@ -7846,8 +7871,8 @@ msgstr "La ecualización de curva de filtro necesita un nombre diferente"
 msgid ""
 "To apply Equalization, all selected tracks must have the same sample rate."
 msgstr ""
-"Para aplicar Ecualización todas las pistas seleccionadas deben tener la misma"
-" frecuencia de muestreo."
+"Para aplicar Ecualización todas las pistas seleccionadas deben tener la "
+"misma frecuencia de muestreo."
 
 #: src/effects/Equalization.cpp
 msgid "Track sample rate is too low for this effect."
@@ -8361,8 +8386,8 @@ msgstr "Reducción de ruido"
 #: src/effects/NoiseReduction.cpp
 msgid "Removes background noise such as fans, tape noise, or hums"
 msgstr ""
-"Elimina diferentes tipos de ruidos de fondo como ventiladores, ruido de cinta"
-" o zumbidos"
+"Elimina diferentes tipos de ruidos de fondo como ventiladores, ruido de "
+"cinta o zumbidos"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Steps per block are too few for the window types."
@@ -8375,8 +8400,8 @@ msgstr "Los pasos por bloque no pueden exceder el tamaño de ventana."
 #: src/effects/NoiseReduction.cpp
 msgid "Median method is not implemented for more than four steps per window."
 msgstr ""
-"El método de mediana no está implementado para más de cuatro pasos por"
-" ventana."
+"El método de mediana no está implementado para más de cuatro pasos por "
+"ventana."
 
 #: src/effects/NoiseReduction.cpp
 msgid "You must specify the same window size for steps 1 and 2."
@@ -8582,16 +8607,16 @@ msgstr "Reducción de ruido"
 #: src/effects/NoiseRemoval.cpp
 msgid "Removes constant background noise such as fans, tape noise, or hums"
 msgstr ""
-"Elimina diferentes tipos de ruidos de fondo permanentes como ventiladores,"
-" ruido de cinta o zumbidos"
+"Elimina diferentes tipos de ruidos de fondo permanentes como ventiladores, "
+"ruido de cinta o zumbidos"
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
 "Select all of the audio you want filtered, choose how much noise you want\n"
 "filtered out, and then click 'OK' to remove noise.\n"
 msgstr ""
-"Seleccione todo el audio que desea filtrar, elija que porcentaje de ruido"
-" desea filtrar\n"
+"Seleccione todo el audio que desea filtrar, elija que porcentaje de ruido "
+"desea filtrar\n"
 "y luego haga clic en Aceptar para eliminar el ruido.\n"
 
 #: src/effects/NoiseRemoval.cpp
@@ -8690,8 +8715,8 @@ msgstr "Paulstretch"
 #: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr ""
-"Utilice Paulstrech únicamente para estirar el tiempo radicalmente o generar"
-" un efecto \"éxtasis\""
+"Utilice Paulstrech únicamente para estirar el tiempo radicalmente o generar "
+"un efecto \"éxtasis\""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
@@ -9016,8 +9041,8 @@ msgstr "Realiza un filtrado IIR que simula filtros analógicos"
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr ""
-"Para aplicar un filtro, todas las pistas seleccionadas deberán tener la misma"
-" frecuencia de muestreo."
+"Para aplicar un filtro, todas las pistas seleccionadas deberán tener la "
+"misma frecuencia de muestreo."
 
 #: src/effects/ScienFilter.cpp
 msgid "&Filter Type:"
@@ -9282,8 +9307,8 @@ msgid ""
 "Automatically reduces the length of passages where the volume is below a "
 "specified level"
 msgstr ""
-"Reduce automáticamente la duración de los pasajes donde el volumen es menor"
-" que el nivel especificado"
+"Reduce automáticamente la duración de los pasajes donde el volumen es menor "
+"que el nivel especificado"
 
 #: src/effects/TruncSilence.cpp
 msgid ""
@@ -9355,14 +9380,11 @@ msgid ""
 "require 8192 samples or less to work properly. However most effects can "
 "accept large buffers and using them will greatly reduce processing time."
 msgstr ""
-"El tamaño de buffer controla el número de muestras enviadas al efecto en cada"
-" repetición. "
-"Unos valores pequeños provocarán un procesamiento más lento y algunos efectos"
-" necesitan "
-"8192 muestras o menos para funcionar correctamente. No obstante la mayoría de"
-" los efectos "
-"pueden trabajar con buffer mayores y usarlos para reducir notablemente el"
-" tiempo de cálculo."
+"El tamaño de buffer controla el número de muestras enviadas al efecto en "
+"cada repetición. Unos valores pequeños provocarán un procesamiento más lento "
+"y algunos efectos necesitan 8192 muestras o menos para funcionar "
+"correctamente. No obstante la mayoría de los efectos pueden trabajar con "
+"buffer mayores y usarlos para reducir notablemente el tiempo de cálculo."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
@@ -9382,9 +9404,8 @@ msgid ""
 msgstr ""
 "Algunos efectos VST deben retrasar el audio que se devuelve a Audacity como "
 "parte de su procesamiento. Si no se compensa este retardo se pueden provocar "
-"pequeños silencios insertados en el audio. Habilitando esta opción se"
-" compensará "
-"ese problema, aunque puede no funcionar en todos los efectos VST."
+"pequeños silencios insertados en el audio. Habilitando esta opción se "
+"compensará ese problema, aunque puede no funcionar en todos los efectos VST."
 
 #: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
 #: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -9401,10 +9422,9 @@ msgid ""
 "basic text-only method is also available.  Reopen the effect for this to "
 "take effect."
 msgstr ""
-"La mayoría de los efectos VST cuentan con una interfaz gráfica para"
-" establecer los parámetros. "
-"También se cuenta con un método básico sólo de texto. Vuelva a abrir el"
-" efecto para que se aplique el cambio."
+"La mayoría de los efectos VST cuentan con una interfaz gráfica para "
+"establecer los parámetros. También se cuenta con un método básico sólo de "
+"texto. Vuelva a abrir el efecto para que se aplique el cambio."
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &graphical interface"
@@ -9544,12 +9564,11 @@ msgid ""
 "will provide that compensation, but it may not work for all Audio Unit "
 "effects."
 msgstr ""
-"Algunos efectos Audio Unit deben retrasar el audio que se devuelve a Audacity"
-" como "
-"parte de su procesamiento. Si no se compensa este retardo se pueden provocar "
-"pequeños silencios insertados en el audio. Habilitando esta opción se"
-" compensará "
-"ese problema, aunque puede no funcionar en todos los efectos Audio Unit."
+"Algunos efectos Audio Unit deben retrasar el audio que se devuelve a "
+"Audacity como parte de su procesamiento. Si no se compensa este retardo se "
+"pueden provocar pequeños silencios insertados en el audio. Habilitando esta "
+"opción se compensará ese problema, aunque puede no funcionar en todos los "
+"efectos Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9562,11 +9581,10 @@ msgid ""
 "Select \"Basic\" for a basic text-only interface. Reopen the effect for this "
 "to take effect."
 msgstr ""
-"Seleccione \"Completo\" para utilizar el interface gráfico suministrado por"
-" Audio Unit. "
-"\"Genérico\" para usar el interface del sistema. "
-"\"Básico\" para un interface de texto. Vuelva a abrir el efecto para que el"
-" cambio se aplique."
+"Seleccione \"Completo\" para utilizar el interface gráfico suministrado por "
+"Audio Unit. \"Genérico\" para usar el interface del sistema. \"Básico\" para "
+"un interface de texto. Vuelva a abrir el efecto para que el cambio se "
+"aplique."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -9701,8 +9719,8 @@ msgstr ""
 #, c-format
 msgid "Failed to set class info for \"%s\" preset"
 msgstr ""
-"No se ha podido establecer la información de clase para los valores"
-" predefinidos \"%s\""
+"No se ha podido establecer la información de clase para los valores "
+"predefinidos \"%s\""
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -9736,12 +9754,11 @@ msgid ""
 "small silences have been inserted into the audio. Enabling this option will "
 "provide that compensation, but it may not work for all LADSPA effects."
 msgstr ""
-"Algunos efectos LADSPA deben retrasar el audio que se devuelve a Audacity"
-" como "
-"parte de su procesamiento. Si no se compensa este retardo se pueden provocar "
-"pequeños silencios insertados en el audio. Habilitando esta opción se"
-" compensará "
-"ese problema, aunque puede no funcionar en todos los efectos LADSPA."
+"Algunos efectos LADSPA deben retrasar el audio que se devuelve a Audacity "
+"como parte de su procesamiento. Si no se compensa este retardo se pueden "
+"provocar pequeños silencios insertados en el audio. Habilitando esta opción "
+"se compensará ese problema, aunque puede no funcionar en todos los efectos "
+"LADSPA."
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
@@ -9773,6 +9790,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Tamaño de &buffer (8 a  %d) muestras):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Tamaño de &buffer (8 a  %d) muestras):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -9781,9 +9803,8 @@ msgid ""
 msgstr ""
 "Algunos efectos LV2 deben retrasar el audio que se devuelve a Audacity como "
 "parte de su procesamiento. Si no se compensa este retardo se pueden provocar "
-"pequeños silencios insertados en el audio. Habilitando esta opción se"
-" compensará "
-"ese problema, aunque puede no funcionar en todos los efectos LV2."
+"pequeños silencios insertados en el audio. Habilitando esta opción se "
+"compensará ese problema, aunque puede no funcionar en todos los efectos LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid ""
@@ -9791,10 +9812,9 @@ msgid ""
 "basic text-only method is also available.  Reopen the effect for this to "
 "take effect."
 msgstr ""
-"Los efectos LV2 cuentan con una interfaz gráfica para establecer los"
-" parámetros. "
-"También se cuenta con un método básico sólo de texto. Vuelva a abrir el"
-" efecto para que se aplique el cambio."
+"Los efectos LV2 cuentan con una interfaz gráfica para establecer los "
+"parámetros. También se cuenta con un método básico sólo de texto. Vuelva a "
+"abrir el efecto para que se aplique el cambio."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 sequence buffer overflow"
@@ -9982,8 +10002,8 @@ msgstr "Nyquist no devolvió audio.\n"
 msgid ""
 "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
 msgstr ""
-"[Advertencia: Nyquist ha devuelto una secuencia UTF-8 inválida, convertida a"
-" Latin-1]"
+"[Advertencia: Nyquist ha devuelto una secuencia UTF-8 inválida, convertida a "
+"Latin-1]"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -9998,8 +10018,8 @@ msgid ""
 "Bad Nyquist 'control' type specification: '%s' in plug-in file '%s'.\n"
 "Control not created."
 msgstr ""
-"Especificación errónea de tipo de 'control' Nyquist: '%s' en el archivo de"
-" complemento '%s'.\n"
+"Especificación errónea de tipo de 'control' Nyquist: '%s' en el archivo de "
+"complemento '%s'.\n"
 "No se ha creado el control."
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -10015,8 +10035,8 @@ msgid ""
 "\t(mult *track* 0.1)\n"
 " ."
 msgstr ""
-"Su secuencia de código parece tener sintáxis SAL, pero no hay devolución de"
-" valores. \n"
+"Su secuencia de código parece tener sintáxis SAL, pero no hay devolución de "
+"valores. \n"
 "Utilice una sentencia de retorno como \n"
 "\treturn *track* * 0.1\n"
 "de SAL, o para LISP comience con un apertura de paréntesis como:\n"
@@ -10227,12 +10247,12 @@ msgid ""
 "If you still wish to export, please choose a different filename or folder."
 msgstr ""
 "Está intentando sobrescribir un archivo de alias que está perdido.\n"
-"El archivo no puede ser escrito porque se necesita la ruta para restaurar "
-"el archivo de audio original al proyecto.\n"
-"Seleccione Ayuda>Diagnósticos>Comprobar dependencias para revisar "
-"las ubicaciones de todos los archivos perdidos. \n"
-"Si aún desea realizar la exportación, seleccione un nombre de archivo o"
-" carpeta diferente."
+"El archivo no puede ser escrito porque se necesita la ruta para restaurar el "
+"archivo de audio original al proyecto.\n"
+"Seleccione Ayuda>Diagnósticos>Comprobar dependencias para revisar las "
+"ubicaciones de todos los archivos perdidos. \n"
+"Si aún desea realizar la exportación, seleccione un nombre de archivo o "
+"carpeta diferente."
 
 #: src/export/Export.cpp
 #, c-format
@@ -10252,8 +10272,8 @@ msgid ""
 "Your tracks will be mixed down to one exported file according to the encoder "
 "settings."
 msgstr ""
-"Las pistas serán mezcladas en un archivo exportado según la configuración del"
-" codificador."
+"Las pistas serán mezcladas en un archivo exportado según la configuración "
+"del codificador."
 
 #: src/export/Export.cpp
 msgid "Advanced Mixing Options"
@@ -10304,8 +10324,8 @@ msgid ""
 "Data will be piped to standard in. \"%f\" uses the file name in the export "
 "window."
 msgstr ""
-"Los datos serán enviados a la entrada estándar. \"%f\" utiliza el nombre de"
-" archivo en la ventana de exportación."
+"Los datos serán enviados a la entrada estándar. \"%f\" utiliza el nombre de "
+"archivo en la ventana de exportación."
 
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
@@ -10346,8 +10366,8 @@ msgstr "Salida de comando"
 #: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr ""
-"Ha indicado un nombre de archivo sin extensión. ¿Está seguro de que desea"
-" continuar?"
+"Ha indicado un nombre de archivo sin extensión. ¿Está seguro de que desea "
+"continuar?"
 
 #: src/export/ExportCL.cpp
 msgid "Program name appears to be missing."
@@ -10375,8 +10395,8 @@ msgstr ""
 #, c-format
 msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
 msgstr ""
-"FFmpeg : ERROR - No se puede determinar la descripción de formato del archivo"
-" \"%s\"."
+"FFmpeg : ERROR - No se puede determinar la descripción de formato del "
+"archivo \"%s\"."
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
@@ -10390,24 +10410,24 @@ msgstr "FFmpeg : ERROR - No se puede ubicar el contexto del formato de salida."
 #, c-format
 msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
 msgstr ""
-"FFmpeg : ERROR - No se puede agregar el flujo de audio al archivo de salida"
-" \"%s\"."
+"FFmpeg : ERROR - No se puede agregar el flujo de audio al archivo de salida "
+"\"%s\"."
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid ""
 "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
 msgstr ""
-"FFmpeg : ERROR - No se puede abrir el archivo de salida \"%s\" en modo"
-" escritura. El código de error es %d."
+"FFmpeg : ERROR - No se puede abrir el archivo de salida \"%s\" en modo "
+"escritura. El código de error es %d."
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid ""
 "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
 msgstr ""
-"FFmpeg : ERROR - No se pueden escribir las cabeceras en el archivo de salida"
-" \"%s\". El código de error es %d."
+"FFmpeg : ERROR - No se pueden escribir las cabeceras en el archivo de salida "
+"\"%s\". El código de error es %d."
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -10442,7 +10462,8 @@ msgstr ""
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
 msgstr ""
-"FFmpeg : ERROR - No se puede ubicar el buffer para leer dentro del audio FIFO."
+"FFmpeg : ERROR - No se puede ubicar el buffer para leer dentro del audio "
+"FIFO."
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - Could not get sample buffer size"
@@ -10468,8 +10489,8 @@ msgstr "FFmpeg : ERROR - Demasiados datos pendientes."
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
 msgstr ""
-"FFmpeg : ERROR - No se pudo escribir la última trama de audio en el archivo"
-" de salida."
+"FFmpeg : ERROR - No se pudo escribir la última trama de audio en el archivo "
+"de salida."
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
@@ -10490,9 +10511,8 @@ msgid ""
 "Attempted to export %d channels, but maximum number of channels for selected "
 "output format is %d"
 msgstr ""
-"Se intentó exportar %d canales, pero el número máximo de canales para el"
-" formato "
-"de salida seleccionado es de %d"
+"Se intentó exportar %d canales, pero el número máximo de canales para el "
+"formato de salida seleccionado es de %d"
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -10542,7 +10562,8 @@ msgstr "Frecuencias de muestreo"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -10875,8 +10896,8 @@ msgid ""
 "Recommended - 192000"
 msgstr ""
 "Velocidad de transferencia (bits/segundo) - influye en el tamaño y calidad\n"
-"del archivo resultante. Algunos códec pueden aceptar sólo valores específicos"
-" (128k, 192k, 256k, etc.)\n"
+"del archivo resultante. Algunos códec pueden aceptar sólo valores "
+"específicos (128k, 192k, 256k, etc.)\n"
 "0 - automático.\n"
 "Recomendado - 192000"
 
@@ -11215,7 +11236,6 @@ msgstr "Exportando el audio seleccionado como un archivo FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Exportando el audio como FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -11659,8 +11679,8 @@ msgid ""
 "Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
 "Use..."
 msgstr ""
-"La etiqueta o pista \"%s\" no es un nombre de archivo permitido. No puede"
-" utilizar %s.\n"
+"La etiqueta o pista \"%s\" no es un nombre de archivo permitido. No puede "
+"utilizar %s.\n"
 "Utilice..."
 
 #: src/export/ExportMultiple.cpp
@@ -12024,8 +12044,8 @@ msgstr "Archivos compatibles con FFmpeg"
 msgid ""
 "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
 msgstr ""
-"Índice[%02x] Códec[%s], Idioma[%s], Velocidad de transferencia[%s], Canales["
-"%d], Duración[%d]"
+"Índice[%02x] Códec[%s], Idioma[%s], Velocidad de transferencia[%s], "
+"Canales[%d], Duración[%d]"
 
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
@@ -12545,7 +12565,7 @@ msgstr "final"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14055,8 +14075,8 @@ msgstr "Nueva pista de etiqueta creada"
 msgid ""
 "This version of Audacity only allows one time track for each project window."
 msgstr ""
-"Esta versión de Audacity sólo permite una pista de tiempo en cada ventana de"
-" proyecto."
+"Esta versión de Audacity sólo permite una pista de tiempo en cada ventana de "
+"proyecto."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
@@ -14346,7 +14366,8 @@ msgid ""
 "\n"
 "Please close any additional projects and try again."
 msgstr ""
-"La grabación programada no se puede utilizar con más de un proyecto abierto.\n"
+"La grabación programada no se puede utilizar con más de un proyecto "
+"abierto.\n"
 "\n"
 "Cierre cualquier otro proyecto e inténtelo de nuevo."
 
@@ -14356,17 +14377,30 @@ msgid ""
 "\n"
 "Please save or close this project and try again."
 msgstr ""
-"La grabación programada no puede ser usada mientras haya cambios sin"
-" guardar.\n"
+"La grabación programada no puede ser usada mientras haya cambios sin "
+"guardar.\n"
 "\n"
 "Guarde los cambios o cierre este proyecto e inténtelo de nuevo."
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Seleccione una pista de audio mono."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Seleccione una pista de audio estéreo."
 
 #: src/menus/TransportMenus.cpp
@@ -15343,7 +15377,8 @@ msgstr "Error al importar los atajos de teclado"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "The file with the shortcuts contains illegal shortcut duplicates for \""
 msgstr ""
-"El archivo con los atajos de teclado contiene combinaciones duplicadas para \""
+"El archivo con los atajos de teclado contiene combinaciones duplicadas para "
+"\""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "\" and \""
@@ -15369,8 +15404,8 @@ msgid ""
 "their shortcuts removed because of the conflict with other new shortcuts:\n"
 msgstr ""
 "\n"
-"Los comandos siguientes no se encontraban en el archivo importado, pero "
-"se han eliminado sus atajos de teclado por conflictos con otros nuevos:\n"
+"Los comandos siguientes no se encontraban en el archivo importado, pero se "
+"han eliminado sus atajos de teclado por conflictos con otros nuevos:\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -15535,8 +15570,8 @@ msgid ""
 "Manual\n"
 "and know what you are doing."
 msgstr ""
-"Estos son módulos experimentales. Actívelos sólo si ha consultado el manual"
-" de Audacity\n"
+"Estos son módulos experimentales. Actívelos sólo si ha consultado el manual "
+"de Audacity\n"
 "y sabe lo que está haciendo."
 
 #. i18n-hint preserve the leading spaces
@@ -15545,15 +15580,15 @@ msgid ""
 "  'Ask' means Audacity will ask if you want to load the module each time it "
 "starts."
 msgstr ""
-"'Preguntar' significa que Audacity le preguntará si desea cargar el módulo en"
-" cada nuevo inicio."
+"'Preguntar' significa que Audacity le preguntará si desea cargar el módulo "
+"en cada nuevo inicio."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
 msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
 msgstr ""
-"'Fallo' significa que Audacity considera que el módulo está estropeado y no"
-" lo ejecutará."
+"'Fallo' significa que Audacity considera que el módulo está estropeado y no "
+"lo ejecutará."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -15563,8 +15598,8 @@ msgstr "'Nuevo' significa que aún no se ha elegido ninguna opción."
 #: src/prefs/ModulePrefs.cpp
 msgid "Changes to these settings only take effect when Audacity starts up."
 msgstr ""
-"Los cambios de esta configuración sólo tendrán efecto cuando se reinicie"
-" Audacity."
+"Los cambios de esta configuración sólo tendrán efecto cuando se reinicie "
+"Audacity."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -17499,8 +17534,8 @@ msgstr "%.0f%% Derecha"
 msgid ""
 "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr ""
-"Haga clic y arrastre para ajustar el tamaño, doble clic para distribuir"
-" uniformemente"
+"Haga clic y arrastre para ajustar el tamaño, doble clic para distribuir "
+"uniformemente"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
@@ -17686,8 +17721,8 @@ msgstr "Desplazar el puntero del ratón a búsqueda"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr ""
-"Desplazar el puntero del ratón para realizar la reproducción por"
-" desplazamiento"
+"Desplazar el puntero del ratón para realizar la reproducción por "
+"desplazamiento"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scru&bbing"
@@ -17813,8 +17848,8 @@ msgstr "Ctrl+Clic"
 #, c-format
 msgid "%s to select or deselect track. Drag up or down to change track order."
 msgstr ""
-"%s para seleccionar o deseleccionar la pista. Arrastrar arriba o abajo para"
-" cambiar orden."
+"%s para seleccionar o deseleccionar la pista. Arrastrar arriba o abajo para "
+"cambiar orden."
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -18423,8 +18458,8 @@ msgid "Value must not be less than %s"
 msgstr "El valor no debe ser menor que %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "El valor no debe ser mayor que %s"
 
 #: src/widgets/valnum.cpp
@@ -19409,8 +19444,8 @@ msgstr "Advertencia.nNo se ha podido copiar algunos ficheros:n"
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins installed.n(Use the Plug-in Manager to enable effects):"
 msgstr ""
-"Complementos instalados.n(Utilice el Administrador de complementos para"
-" habilitar los efectos):"
+"Complementos instalados.n(Utilice el Administrador de complementos para "
+"habilitar los efectos):"
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -20093,9 +20128,8 @@ msgid ""
 "Pan position: ~a~%The left and right channels are correlated by about ~a %. "
 "This means:~%~a~%"
 msgstr ""
-"Posición panorámica: ~a~%Los canales izquierdo y derecho son correlativos por"
-" ~a %. "
-"Esto significa:~%~a~%"
+"Posición panorámica: ~a~%Los canales izquierdo y derecho son correlativos "
+"por ~a %. Esto significa:~%~a~%"
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20105,8 +20139,8 @@ msgid ""
 msgstr ""
 " - Los dos canales son idénticos, por ejemplo, mono dual.\n"
 "                El centro no puede ser eliminado.\n"
-"                Cualquier otra diferencia puede ser derivada de una"
-" codificación con pérdida."
+"                Cualquier otra diferencia puede ser derivada de una "
+"codificación con pérdida."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20114,8 +20148,8 @@ msgid ""
 "panned.\n"
 "                Most likely, the center extraction will be poor."
 msgstr ""
-" - Los dos canales están fuertemente relacionados, por ejemplo, mono muy"
-" similar o extremadamente panoramizados.\n"
+" - Los dos canales están fuertemente relacionados, por ejemplo, mono muy "
+"similar o extremadamente panoramizados.\n"
 "                La extracción de centro será muy pobre."
 
 #: plug-ins/vocalrediso.ny
@@ -20131,8 +20165,8 @@ msgid ""
 "reverb."
 msgstr ""
 " - Un valor ideal para estéreo.\n"
-"                No obstante, la extracción del centro depende también de la"
-" reverberación empleada."
+"                No obstante, la extracción del centro depende también de la "
+"reverberación empleada."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20142,8 +20176,8 @@ msgid ""
 "                The center extraction can still be good though."
 msgstr ""
 " - Los dos canales no presentan casi relación.\n"
-"                O sólo hay ruido o la pieza original ha sido tomada de una"
-" manera no balanceada.\n"
+"                O sólo hay ruido o la pieza original ha sido tomada de una "
+"manera no balanceada.\n"
 "                La extracción del centro puede ser correcta de todos modos."
 
 #: plug-ins/vocalrediso.ny
@@ -20165,9 +20199,10 @@ msgid ""
 "                  Don't expect good results from a center removal."
 msgstr ""
 " - Los dos canales son prácticamente idénticos.\n"
-"                Obviamente se ha empleado un efecto de simulación de estéreo\n"
-"                para expandir la señal sobre la distancia física entre los"
-" altavoces.\n"
+"                Obviamente se ha empleado un efecto de simulación de "
+"estéreo\n"
+"                para expandir la señal sobre la distancia física entre los "
+"altavoces.\n"
 "                No se esperan buenos resultados de la eliminación del centro."
 
 #: plug-ins/vocalrediso.ny
@@ -20226,6 +20261,21 @@ msgstr "Frecuencia de las agujas del radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Error.~%Se necesita una pista estéreo."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Mostrar/Ocultar editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Al importar archivos de audio"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "incorporando"

--- a/locale/eu.po
+++ b/locale/eu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-18 19:12+0200\n"
 "Last-Translator: EUS_Xabier Aramendi <azpidatziak@gmail.com>\n"
 "Language-Team: (EUS_Xabier Aramendi)\n"
@@ -3781,6 +3781,28 @@ msgstr ""
 "Saiatu audio hostalaria, irakurketa gailua eta egitasmoaren laginketa "
 "neurria aldatzen."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Iragaki bat ezartzeko, hautatutako bide guztiek laginketa neurri berdina "
+"izan behar dute."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4035,9 +4057,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Kontuz: Arazoak Berezgaitasunezko Berreskurapenean"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<izenburugabea>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Egitasmoa %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9736,6 +9763,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Buffer Neurria (8 eta %d) lagin artean):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Buffer Neurria (8 eta %d) lagin artean):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10489,7 +10521,8 @@ msgstr "Lagin Neurriak"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbs-ko"
@@ -11166,7 +11199,6 @@ msgstr "Hautaturiko audioa FLAC bezala esportatzen"
 msgid "Exporting the audio as FLAC"
 msgstr "Audioa FLAC bezala esportatzen"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12496,7 +12528,7 @@ msgstr "amaiera"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14312,11 +14344,24 @@ msgstr ""
 "Mesedez gorde edo itxi egitasmo hau eta saiatu berriro."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Mesedez hautatu bide mono batean."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Mesedez hautatu bide estereo batean."
 
 #: src/menus/TransportMenus.cpp
@@ -18360,8 +18405,8 @@ msgid "Value must not be less than %s"
 msgstr "Balioa ez da izan behar %s baino txikiagoa"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Balioa ez da izan behar %s baino handiagoa"
 
 #: src/widgets/valnum.cpp
@@ -20151,6 +20196,21 @@ msgstr "Erradar Orratz maiztasuna (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Akatsa.~%Estereo bidea beharrezkoa."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Erakutsi/Ezkutatu Editatzailea"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Audio agiriak inportatzerakoan"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "gehitzen"

--- a/locale/eu_ES.po
+++ b/locale/eu_ES.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2017-07-29 09:39+0100E\n"
 "Last-Translator: Osoitz Elkorobarrutia <oelkoro@gmail.com>, 2017\n"
 "Language-Team: Basque (https://www.transifex.com/librezale/teams/76773/eu/)\n"
@@ -3854,6 +3854,28 @@ msgstr ""
 "Saiatu aldatzen audioaren ostalaria, erreprodukzio-gailua eta proiektuaren "
 "lagin-maiztasuna."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Iragazki bat aplikatzeko, hautatutako pista guztiek lagin-maiztasun bera "
+"izan behar dute."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4103,9 +4125,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Kontuz: arazoak berreskuratze automatikoan"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<untitled>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Proiektuak"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -10000,6 +10027,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Bufferraren tamaina (8tik 1048576 laginetara):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Bufferraren tamaina (8tik 1048576 laginetara):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10760,7 +10792,8 @@ msgstr "Lagin-maiztasunak"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -11454,7 +11487,6 @@ msgstr "Hautatutako audioa FLAC gisa esportatzen"
 msgid "Exporting the audio as FLAC"
 msgstr "Hautatutako audioa FLAC gisa esportatzen"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12813,7 +12845,7 @@ msgstr "amaiera"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14777,13 +14809,25 @@ msgstr ""
 "Gorde edo itxi proiektu hau eta saiatu berriro."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Hautatu audio-pista bat."
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Hautatu audio-pista bat."
 
 #: src/menus/TransportMenus.cpp
@@ -18942,8 +18986,8 @@ msgid "Value must not be less than %s"
 msgstr "Balioa ez da %s baino txikiagoa izan behar"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Balioa ez da %s baino handiagoa izan behar"
 
 #: src/widgets/valnum.cpp
@@ -20817,6 +20861,21 @@ msgstr "Maiztasuna (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Erakutsi/ezkutatu editorea"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Audio-fitxategiak inportatzean"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #~ msgid "incorporating"

--- a/locale/fa.po
+++ b/locale/fa.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2012-02-27 19:02-0000\n"
 "Last-Translator: Gale <gale@audacityteam.org>\n"
 "Language-Team: Persian\n"
@@ -3737,6 +3737,27 @@ msgstr ""
 "خطا در هنگام باز کردن دستگاه صدا. لطفاً تنظیمات خروجی دستگاه و نرخ "
 "نمونه‌برداری پروژه را بررسی کنید."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"برای رسم طیف، همهٔ شیارهای انتخاب‌شده باید نرخ نمونه‌برداری یکسان داشته باشند."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3934,9 +3955,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "جادادن پروژه"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9758,6 +9784,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10466,7 +10497,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -11084,7 +11116,6 @@ msgstr "صدور صوت انتخاب‌شده بعنوان FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "صدور صوت انتخاب‌شده بعنوان FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12329,7 +12360,7 @@ msgstr "پایان"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14368,13 +14399,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "ایجاد شیار صوتی جدید"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "ایجاد شیار صوتی جدید"
 
 #: src/menus/TransportMenus.cpp
@@ -18690,7 +18733,7 @@ msgstr "نام نمی‌تواند خالی باشد"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "نام نمی‌تواند خالی باشد"
 
 #: src/widgets/valnum.cpp
@@ -20550,6 +20593,21 @@ msgstr "بسامد (هرتز)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "سکوت‌ساز"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "پروندهٔ ذخیرهٔ خودکار حذف نشد"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2015-09-18 20:53+0300\n"
 "Last-Translator: Heino Keränen\n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -3839,6 +3839,28 @@ msgstr ""
 "Äänilaitteen avausvirhe. Tarkista toistolaiteen asetukset ja projektin "
 "näytteenottotaajuus."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Jotta suodatus voidaan esittää, kaikkilla valituilla raidoilla täytyy olla "
+"sama näytetaajuus."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4085,9 +4107,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Varoitus - Ongelmia automaattisessa palautuksessa"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<nimetön>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projektit"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9951,6 +9978,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Puskurin koko (8 -> 1048576 näytettä)"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Puskurin koko (8 -> 1048576 näytettä)"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10672,7 +10704,8 @@ msgstr "Näyteenottotaajuudet"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -11306,7 +11339,6 @@ msgstr "Viedään valittu audio FLAC-muodossa"
 msgid "Exporting the audio as FLAC"
 msgstr "Viedään valittu audio FLAC-muodossa"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12622,7 +12654,7 @@ msgstr "Loppu"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14653,13 +14685,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Valitse toimenpide"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Valitse toimenpide"
 
 #: src/menus/TransportMenus.cpp
@@ -18874,7 +18918,7 @@ msgstr "Arvo ei voi olla pienempi kuin %.*f"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Arvo ei voi olla suurempi kuin %.*f"
 
 #: src/widgets/valnum.cpp
@@ -20754,6 +20798,21 @@ msgstr "Taajuus (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Näytä/piilota editori"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Tuotaessa äänitiedostoja"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-09 18:02+0100\n"
 "Last-Translator: Olivier Humbert (trebmuh/olinuxx) <trebmuh@tuxfamily.org>\n"
 "Language-Team: French\n"
@@ -3484,7 +3484,7 @@ msgid ""
 "Unable to load the \"%s\" module.\n"
 "\n"
 "Error: %s"
-msgstr 
+msgstr ""
 "Incapable de charger le module \"%s\".\n"
 "\n"
 "Erreur : %s"
@@ -3904,6 +3904,28 @@ msgstr ""
 "Essayez de changer l’hôte audio, le périphérique de lecture, et le taux "
 "d’échantillonnage du projet."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Pour appliquer un filtre, toutes les pistes sélectionnées doivent avoir le "
+"même taux d’échantillonnage."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4165,9 +4187,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Attention : problèmes lors de la récupération automatique"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sans titre>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projet %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -5745,9 +5772,9 @@ msgid ""
 "default shortcut is new or changed, and is the same shortcut that you have "
 "assigned to another command."
 msgstr ""
-"Les commandes suivantes ont vu leurs raccourcis supprimés, car leur raccourci "
-"par défaut est nouveau ou modifié, et est le même que celui que vous avez "
-"attribué à une autre commande."
+"Les commandes suivantes ont vu leurs raccourcis supprimés, car leur "
+"raccourci par défaut est nouveau ou modifié, et est le même que celui que "
+"vous avez attribué à une autre commande."
 
 #: src/commands/CommandManager.cpp
 msgid "Shortcuts have been removed"
@@ -9747,11 +9774,11 @@ msgid ""
 "will provide that compensation, but it may not work for all Audio Unit "
 "effects."
 msgstr ""
-"Dans le cadre de leur traitement, certains effets Audio Unit doivent retarder "
-"le retour audio à Audacity. Lorsque vous ne compensez pas ce retard, vous "
-"remarquerez que de petits silences ont été insérés dans l’audio. En activant "
-"cette option, vous obtiendrez cette compensation, mais il se peut qu'elle ne "
-"fonctionne pas pour tous les effets Audio Unit."
+"Dans le cadre de leur traitement, certains effets Audio Unit doivent "
+"retarder le retour audio à Audacity. Lorsque vous ne compensez pas ce "
+"retard, vous remarquerez que de petits silences ont été insérés dans "
+"l’audio. En activant cette option, vous obtiendrez cette compensation, mais "
+"il se peut qu'elle ne fonctionne pas pour tous les effets Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9764,11 +9791,11 @@ msgid ""
 "Select \"Basic\" for a basic text-only interface. Reopen the effect for this "
 "to take effect."
 msgstr ""
-"Sélectionner \"Complet\" pour utiliser l’interface graphique si elle est fournie "
-"par l’Audio Unit. Sélectionnez \"Générique\" pour utiliser l’interface "
-"générique fournie par le système. Sélectionnez \"Basique\" pour utiliser "
-"l’interface de base en mode texte uniquement. Réouvrez l’effet pour que cela "
-"soit pris en compte."
+"Sélectionner \"Complet\" pour utiliser l’interface graphique si elle est "
+"fournie par l’Audio Unit. Sélectionnez \"Générique\" pour utiliser "
+"l’interface générique fournie par le système. Sélectionnez \"Basique\" pour "
+"utiliser l’interface de base en mode texte uniquement. Réouvrez l’effet pour "
+"que cela soit pris en compte."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -9969,6 +9996,12 @@ msgstr "Paramètres d’effet LV2"
 msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Taille du tampon (8 à %d échantillons) (&b) :"
 
+# trebmuh to check (accélérateur)
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Taille du tampon (8 à %d échantillons) (&b) :"
+
 #: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
@@ -10006,7 +10039,7 @@ msgid "%s requires unsupported feature %s"
 msgstr "%s nécessite une fonction non-supportée %s"
 
 #: src/effects/lv2/LV2Effect.cpp
-#,  c-format
+#, c-format
 msgid "%s requires unsupported feature %s\n"
 msgstr "%s nécessite une fonction non-supportée %s\n"
 
@@ -10126,9 +10159,10 @@ msgstr ""
 msgid "Processing complete."
 msgstr "Traitement terminé."
 
-#. i18n-hint: Don't translate ';type tool’.
+#. i18n-hint: Don't translate ';type tool'.
 #: src/effects/nyquist/Nyquist.cpp
-msgid "';type tool’ effects cannot return audio from Nyquist.\n"
+#, fuzzy
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
 msgstr ""
 "effets de ';type tool' ne peuvent pas retourner de l’audio depuis Nyquist.\n"
 
@@ -10435,8 +10469,8 @@ msgstr ""
 "restaurer l’audio originel dans le projet.\n"
 "Choisissez Aide > Diagnostiques > Vérifier les Dépendances pour voir les "
 "emplacements de tous les fichiers manquants.\n"
-"Si vous souhaitez toujours exporter, veuillez choisir un nom de répertoire ou "
-"de fichier différent."
+"Si vous souhaitez toujours exporter, veuillez choisir un nom de répertoire "
+"ou de fichier différent."
 
 #: src/export/Export.cpp
 #, c-format
@@ -10744,7 +10778,8 @@ msgstr "Taux d’échantillonnage"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11424,7 +11459,6 @@ msgstr "Exportation de la sélection audio en FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Exportation de l’audio en FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12766,7 +12800,7 @@ msgstr "fin"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14669,11 +14703,24 @@ msgstr ""
 "Veuillez sauvegarder ou fermer ce projet et réessayer."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Veuillez sélectionner une piste mono."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Veuillez sélectionner une piste stéréo."
 
 #: src/menus/TransportMenus.cpp
@@ -15723,9 +15770,9 @@ msgid ""
 "their shortcuts removed because of the conflict with other new shortcuts:\n"
 msgstr ""
 "\n"
-"Les commandes suivantes ne sont pas mentionnées dans le fichier importé, mais "
-"leurs raccourcis sont supprimés en raison du conflit avec d’autres nouveaux "
-"raccourcis :\n"
+"Les commandes suivantes ne sont pas mentionnées dans le fichier importé, "
+"mais leurs raccourcis sont supprimés en raison du conflit avec d’autres "
+"nouveaux raccourcis :\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -15902,8 +15949,8 @@ msgid ""
 "  'Ask' means Audacity will ask if you want to load the module each time it "
 "starts."
 msgstr ""
-"  'Demander' signifie qu’Audacity vous demandera si vous souhaitez charger le "
-"module à chaque fois qu’il démarre."
+"  'Demander' signifie qu’Audacity vous demandera si vous souhaitez charger "
+"le module à chaque fois qu’il démarre."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -17905,8 +17952,8 @@ msgstr "%.0f%% droite"
 msgid ""
 "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr ""
-"Cliquer et glisser pour ajuster la taille des vues secondaires, "
-"double-cliquer pour diviser en deux parties égales"
+"Cliquer et glisser pour ajuster la taille des vues secondaires, double-"
+"cliquer pour diviser en deux parties égales"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
@@ -18846,8 +18893,8 @@ msgid "Value must not be less than %s"
 msgstr "La valeur ne doit pas être moindre que %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "La valeur ne doit pas être supérieure à %s"
 
 #: src/widgets/valnum.cpp
@@ -19852,8 +19899,8 @@ msgstr "Attention.nÉchec de la copie de certains fichiers:n"
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins installed.n(Use the Plug-in Manager to enable effects):"
 msgstr ""
-"Greffons installés.n (Utilisez le gestionnaire de greffon pour activer les"
-" effets) :"
+"Greffons installés.n (Utilisez le gestionnaire de greffon pour activer les "
+"effets) :"
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -20605,7 +20652,8 @@ msgid ""
 msgstr ""
 " - Bien que la piste soit stéréo, le champ est évidemment très large.\n"
 "                Ceci peut provoquer des effets étranges.\n"
-"                Spécialement lorsqu’il est joué par seulement un haut-parleur."
+"                Spécialement lorsqu’il est joué par seulement un haut-"
+"parleur."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20617,9 +20665,10 @@ msgid ""
 msgstr ""
 " - Les deux canaux sont presque identiques.\n"
 "                  Évidemment, un effet de pseudo stéréo a été utilisé\n"
-"                  pour étaler le signal sur la distance physique entre les "
-"                  haut-parleurs.\n"
-"                  N’espérez pas de bons résultats d’une suppression de centre."
+"                  pour étaler le signal sur la distance physique entre "
+"les                   haut-parleurs.\n"
+"                  N’espérez pas de bons résultats d’une suppression de "
+"centre."
 
 #: plug-ins/vocalrediso.ny
 msgid "This plug-in works only with stereo tracks."
@@ -20677,6 +20726,21 @@ msgstr "Fréquence des aiguilles de radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Erreur.~%Piste stéréo nécessaire."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Afficher/Cacher l’éditeur"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "À l’importation de fichiers audio"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "incorporation"

--- a/locale/ga.po
+++ b/locale/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2005-11-08 10:53-0000\n"
 "Last-Translator: Riarthóir <micilsheainmhicil@eircom.net>\n"
 "Language-Team: Mícheál Mac Lochlainn <micilsheainmhicil@eircom.net>\n"
@@ -3686,6 +3686,28 @@ msgstr ""
 "Earráid le linn oscailt ghléas fuaime. Deimhnigh socruithe ghléas an "
 "aschuir, is ráta samplaithe an tionscadail."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Chun an speictream a rianadh, ní foláir gach rian roghnaithe a bheith ag an "
+"ráta samplaithe céanna."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3882,9 +3904,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "&Sábháil Tionscadal"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9587,6 +9614,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10296,7 +10328,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -10912,7 +10945,6 @@ msgstr ""
 msgid "Exporting the audio as FLAC"
 msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12153,7 +12185,7 @@ msgstr ""
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14153,13 +14185,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Rian nua fuaime arna cheapadh"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Rian nua fuaime arna cheapadh"
 
 #: src/menus/TransportMenus.cpp
@@ -18400,7 +18444,7 @@ msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr ""
 
 #: src/widgets/valnum.cpp
@@ -20252,6 +20296,21 @@ msgstr "Minicíocht LFO (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Tost"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Fuaim Thaifeadta"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/gl.po
+++ b/locale/gl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2015-02-20 17:07-0000\n"
 "Last-Translator: Miguel Anxo Bouzada <mbouzada@gmail.com>\n"
 "Language-Team: Galician <proxecto@trasno.net>\n"
@@ -3916,6 +3916,28 @@ msgstr ""
 "Produciuse un erro ao abrir o dispositivo de son. Comprobe os axustes do "
 "dispositivo de reprodución e a frecuencia de mostraxe do proxecto."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Para aplicar un filtro, todas as pistas seleccionadas deben ter a mesma "
+"frecuencia de mostraxe."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4174,9 +4196,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Aviso: xurdiron problemas durante a recuperación automática"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sen título>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Proxectos"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -10136,6 +10163,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Tamaño do &búfer (8 de 1048576 mostras):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Tamaño do &búfer (8 de 1048576 mostras):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10901,7 +10933,8 @@ msgstr "Frecuencias de mostraxe"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -11598,7 +11631,6 @@ msgstr "Exportando o son seleccionado como FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Exportando o son seleccionado como FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12958,7 +12990,7 @@ msgstr "Fin"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14992,13 +15024,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Seleccione unha acción"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Seleccione unha acción"
 
 #: src/menus/TransportMenus.cpp
@@ -19301,7 +19345,7 @@ msgstr "O nome non pode quedar baleiro"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Iniciar e deter debe ser maior que cero."
 
 #: src/widgets/valnum.cpp
@@ -21181,6 +21225,21 @@ msgstr "Frecuencia (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Amosar/agochar o editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Cando se importan ficheiros de son"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/he.po
+++ b/locale/he.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2013-01-30 13:38-0000\n"
 "Last-Translator: gale <gale@audacityteam.org>\n"
 "Language-Team: Heb\n"
@@ -3810,6 +3810,28 @@ msgstr ""
 "Error while opening sound device. Please check the output device settings "
 "and the project sample rate."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+".בכדי לצייר את הספקטרום, כלל הרצועות הנבחרות חייבות להיות בעלות אותו קצב "
+"דגימה"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4010,9 +4032,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<ללא שם>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "התאם פרויקט"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9862,6 +9889,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10578,7 +10610,8 @@ msgstr "קצבי דגימה"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -11199,7 +11232,6 @@ msgstr "FLAC מייצא את חלק השמע הנבחר בתור"
 msgid "Exporting the audio as FLAC"
 msgstr "FLAC מייצא את חלק השמע הנבחר בתור"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12471,7 +12503,7 @@ msgstr "סוף"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14532,13 +14564,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "רצועת שמע חדשה נוצרה"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "רצועת שמע חדשה נוצרה"
 
 #: src/menus/TransportMenus.cpp
@@ -18852,7 +18896,7 @@ msgstr "השם לא יכול להשאר ריק"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr ".התחלה וסיום חייבים להיות גדולים מ-0"
 
 #: src/widgets/valnum.cpp
@@ -20720,6 +20764,21 @@ msgstr "(Hz) תדר"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "מייצר שקט"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Could not remove old auto save file"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/hi.po
+++ b/locale/hi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2019-09-11 15:50+0530\n"
 "Last-Translator: bashishtha narayan singh <bashishtha.singh@gmail.com>\n"
 "Language-Team: bashishtha singh <bashishtha.singh@gmail.com>\n"
@@ -3815,6 +3815,26 @@ msgstr ""
 "ध्वनि उपकरण खोलने में त्रुटि.\n"
 "कृपया ऑडियो मेजबान, प्लेबैक यंत्र और परियोजना के नमूना दर बदल कर कोशिश करें."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "फिल्टर लगाने के लिए, सभी चयनित ट्रैकों का नमूना दर एक ही होना चाहिए."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4059,9 +4079,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "चेतावनी: स्वचालित रिकवरी में समस्याएँ"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<बेनामी>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "परियोजना"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9803,6 +9828,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&बफ़र आकार (8 से 1048576 नमूनों तक) :"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&बफ़र आकार (8 से 1048576 नमूनों तक) :"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10537,7 +10567,8 @@ msgstr "सैंपल रेट"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11227,7 +11258,6 @@ msgstr "चयनित ऑडियो का निर्यात FLAC मे
 msgid "Exporting the audio as FLAC"
 msgstr "ऑडियो का निर्यात FLAC में कर रहे हैं"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12563,7 +12593,7 @@ msgstr "अंत"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14402,11 +14432,24 @@ msgstr ""
 "कृपया सहेजें अथवा परियोजना बंद कर पुन: प्रयास करें."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "कृपया एक मोनो ट्रैक चुनें."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "कृपया एक स्टिरियो ट्रैक चुनें."
 
 #: src/menus/TransportMenus.cpp
@@ -18489,8 +18532,8 @@ msgid "Value must not be less than %s"
 msgstr "मान %s से कम नहीं होना चाहिए"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "मूल्य  %s से ज्यादा नहीं होना चाहिए"
 
 #: src/widgets/valnum.cpp
@@ -20298,6 +20341,21 @@ msgstr "रडार सुई की आवृति (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "त्रुटि.~%स्टिरियो ट्रैक चाहिए."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "संपादक दिखाएं/ छिपाएं"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "जब ध्वनी फ़ाईलों का आयात करते हैं"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "को शामिल"

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2013-09-19 05:24-0000\n"
 "Last-Translator: Martin Bagic\n"
 "Language-Team: Martin Srebotnjak <miles@filmsi.net>\n"
@@ -3908,6 +3908,27 @@ msgstr ""
 "Pogrješka pri otvaranju zvučnoga uređaja. Molimo provjeriti postavke "
 "izlaznoga uređaja i (uzorkovnu) brzinu projekta."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Za crtanje spektra svi izabrani zapisi moraju imati istu uzorkovnu brzinu."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4148,9 +4169,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Upozorenje: teškoće sa samoobnovom"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<neimenovano>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekt"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -10131,6 +10157,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10879,7 +10910,8 @@ msgstr "Uzorkovna brzina"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kb/s"
@@ -11576,7 +11608,6 @@ msgstr "Izvoz izabranoga zvuka kao FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Izvoz izabranoga zvuka kao FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12923,7 +12954,7 @@ msgstr "Kraj"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14965,13 +14996,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Molimo izabrati radnju"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Molimo izabrati radnju"
 
 #: src/menus/TransportMenus.cpp
@@ -19316,7 +19359,7 @@ msgstr "Ime ne smije biti prazno"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Početak i kraj moraju biti veći od 0."
 
 #: src/widgets/valnum.cpp
@@ -21193,6 +21236,21 @@ msgstr "Frekvencija (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Stvarač tišine"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Pri uvozu zvučnih datoteka"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2016-11-28 10:08+0100\n"
 "Last-Translator: Balázs Úr <urbalazs@gmail.com>\n"
 "Language-Team: Hungarian <openscope at googlegroups dot com>\n"
@@ -3861,6 +3861,28 @@ msgstr ""
 "Hiba a hangeszköz megnyitásakor. Próbálja meg megváltoztatni a "
 "hangkiszolgálót, a lejátszóeszközt és a projekt mintavételezési gyakoriságát."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Egy szűrő alkalmazásához minden kijelölt sávnak azonos mintavételezési "
+"gyakorisággal kell rendelkeznie."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4111,9 +4133,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Figyelmeztetés: probléma az automatikus helyreállításnál"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<névtelen>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projektek"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9988,6 +10015,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Pufferméret (8-tól 1048576 mintáig):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Pufferméret (8-tól 1048576 mintáig):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10747,7 +10779,8 @@ msgstr "Mintavételezési gyakoriságok"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -11442,7 +11475,6 @@ msgstr "A kijelölt hang exportálása FLAC formátumba"
 msgid "Exporting the audio as FLAC"
 msgstr "A kijelölt hang exportálása FLAC formátumba"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12798,7 +12830,7 @@ msgstr "Befejezés"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14831,13 +14863,25 @@ msgstr ""
 "Mentse el vagy zárja be ezt a projektet, és próbálja újra."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Válasszon egy hangsávot."
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Válasszon egy hangsávot."
 
 #: src/menus/TransportMenus.cpp
@@ -19071,8 +19115,8 @@ msgid "Value must not be less than %s"
 msgstr "Az érték nem lehet kisebb mint %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Az érték nem lehet nagyobb mint %s"
 
 #: src/widgets/valnum.cpp
@@ -20945,6 +20989,21 @@ msgstr "Frekvencia (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Szerkesztő megjelenítése vagy elrejtése"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Hangfájlok importálásakor"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #~ msgid "incorporating"

--- a/locale/hy.po
+++ b/locale/hy.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2014-11-21 21:02-0000\n"
 "Last-Translator: Aram Vardanyan\n"
 "Language-Team: Armenian <aramvardanyan@gmx.com>\n"
@@ -3894,6 +3894,28 @@ msgstr ""
 "Կա սխալ երբ բացվում է ձայնի սարքը: Խնդրում ենք ստուգել նվագարկման սարքի "
 "կարգավորումները և պրոեկտի ձայնային որակի չափը:"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Զտման հաստատման համար, բոլոր նշված ձայնագրությունները պետք է լինեն նույն "
+"ձայնաչափի բաժնի:"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4139,9 +4161,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Ուշադրություն՝ Կա խնդիր ավտոմատ հետ բերման ժամանակ"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<untitled>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Պրոեկտներ"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -10127,6 +10154,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Բուֆեր չափ (8 ից 1048576 նմուշներ)՝"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Բուֆեր չափ (8 ից 1048576 նմուշներ)՝"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10879,7 +10911,8 @@ msgstr "Ձայնի բաժին"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -11576,7 +11609,6 @@ msgstr "Վերցնում նշված աուդիոն որպես FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Վերցնում նշված աուդիոն որպես FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12927,7 +12959,7 @@ msgstr "Ավարտ"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14961,13 +14993,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
 
 #: src/menus/TransportMenus.cpp
@@ -19303,7 +19347,7 @@ msgstr "Անունը չպետք է լինի դատարկ"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Սկիզբն ու դադարը պետք է լինի լավ քան 0:"
 
 #: src/widgets/valnum.cpp
@@ -21182,6 +21226,21 @@ msgstr "Հաճախականություն (Հց)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Լռություն ստեղծող"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Երբ ներմուծվում են աուդիո ֆայլեր"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/id.po
+++ b/locale/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2012-01-16 15:00-0000\n"
 "Last-Translator: Gale <gale@audacityteam.org>\n"
 "Language-Team: \n"
@@ -3875,6 +3875,28 @@ msgstr ""
 "Error ketika membuka perangkat suara. Tolong cek pengaturan perangkat output "
 "dan rate sampel proyek."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Untuk memplot spektrum, semua trek yang dipilih harus mempunyai rate sampel "
+"yang sama."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4099,10 +4121,15 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 #, fuzzy
 msgid "<untitled>"
 msgstr "tak berjudul"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Proyek"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -10131,6 +10158,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10866,7 +10898,8 @@ msgstr "Rate Sampel"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "kbps"
@@ -11565,7 +11598,6 @@ msgstr "Mengekspor audio yang dipilih ke FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Mengekspor audio yang dipilih ke FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12906,7 +12938,7 @@ msgstr "Akhir"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14970,13 +15002,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Silahkan pilih aksinya"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Silahkan pilih aksinya"
 
 #: src/menus/TransportMenus.cpp
@@ -19359,7 +19403,7 @@ msgstr "Nama seharusnya tidak kosong"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Awal dan akhir harus lebih dari 0."
 
 #: src/widgets/valnum.cpp
@@ -21236,6 +21280,21 @@ msgstr "Frekuensi (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Pembuat Diam"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Ketika mengimpor file audio"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/it.po
+++ b/locale/it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2019-04-10 10:36+0200\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: italiano <audacity-translation@lists.sourceforge.net>\n"
@@ -960,9 +960,11 @@ msgid ""
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Non è stato possibile trovare una posizione sicura dove salvare i file "
-"temporanei.\nAudacity ha bisogno di una posizione in cui i programmi "
-"automatici di pulizia non eliminano i file temporanei.\nSpecificare "
-"un'appropriata cartella nella finestra di dialogo delle preferenze."
+"temporanei.\n"
+"Audacity ha bisogno di una posizione in cui i programmi automatici di "
+"pulizia non eliminano i file temporanei.\n"
+"Specificare un'appropriata cartella nella finestra di dialogo delle "
+"preferenze."
 
 #: src/AudacityApp.cpp
 msgid ""
@@ -1577,7 +1579,9 @@ msgstr "Comando di menu (senza parametri)"
 msgid ""
 "Export recording to %s\n"
 "/%s/%s.%s"
-msgstr "Esporta registrazione su %s\n/%s/%s.%s"
+msgstr ""
+"Esporta registrazione su %s\n"
+"/%s/%s.%s"
 
 #: src/BatchCommands.cpp
 msgid "Export recording"
@@ -2447,8 +2451,11 @@ msgid ""
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
 "FFmpeg era già stato configurato nelle preferenze e precedentemente è stato "
-"caricato \ncon successo, tuttavia questa volta Audacity non è riuscito a "
-"caricarlo all'avvio. \n\nTornare in Preferenze > Librerie per riconfigurarlo."
+"caricato \n"
+"con successo, tuttavia questa volta Audacity non è riuscito a caricarlo "
+"all'avvio. \n"
+"\n"
+"Tornare in Preferenze > Librerie per riconfigurarlo."
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg startup failed"
@@ -3252,7 +3259,8 @@ msgstr "&Karaoke..."
 #, c-format
 msgid "Plug-in group at %s was merged with a previously defined group"
 msgstr ""
-"Il gruppo di estensioni in %s è stato unito a un gruppo definito in precedenza"
+"Il gruppo di estensioni in %s è stato unito a un gruppo definito in "
+"precedenza"
 
 #: src/Menus.cpp
 #, c-format
@@ -3384,7 +3392,10 @@ msgid ""
 "Unable to load the \"%s\" module.\n"
 "\n"
 "Error: %s"
-msgstr "Impossibile caricare il modulo \"%s\".\n\nErrore: %s"
+msgstr ""
+"Impossibile caricare il modulo \"%s\".\n"
+"\n"
+"Errore: %s"
 
 #: src/ModuleManager.cpp
 msgid "Module Unsuitable"
@@ -3402,7 +3413,9 @@ msgid ""
 "\n"
 "It will not be loaded."
 msgstr ""
-"Il modulo \"%s\" non fornisce una stringa di versione.\n\nNon verrà caricato."
+"Il modulo \"%s\" non fornisce una stringa di versione.\n"
+"\n"
+"Non verrà caricato."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3418,8 +3431,9 @@ msgid ""
 "\n"
 "It will not be loaded."
 msgstr ""
-"Il modulo \"%s\" è abbinato con la versione \"%s\" di Audacity.\n\nNon verrà "
-"caricato."
+"Il modulo \"%s\" è abbinato con la versione \"%s\" di Audacity.\n"
+"\n"
+"Non verrà caricato."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3437,8 +3451,9 @@ msgid ""
 "\n"
 "It will not be loaded."
 msgstr ""
-"Si è verificato un problema durante l'inizializzazione del modulo "
-"\"%s\".\n\nNon verrà caricato."
+"Si è verificato un problema durante l'inizializzazione del modulo \"%s\".\n"
+"\n"
+"Non verrà caricato."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3446,8 +3461,8 @@ msgid ""
 "The module \"%s\" failed to initialize.\n"
 "It will not be loaded."
 msgstr ""
-"Si è verificato un problema durante l'inizializzazione del modulo "
-"\"%s\".\nNon verrà caricato."
+"Si è verificato un problema durante l'inizializzazione del modulo \"%s\".\n"
+"Non verrà caricato."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3489,8 +3504,9 @@ msgid ""
 "\n"
 "It will not be loaded."
 msgstr ""
-"Il modulo \"%s\" non fornisce alcuna delle funzionalità richieste.\n\nNon "
-"verrà caricato."
+"Il modulo \"%s\" non fornisce alcuna delle funzionalità richieste.\n"
+"\n"
+"Non verrà caricato."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3788,6 +3804,28 @@ msgstr ""
 "Provare a cambiare il sistema audio, il dispositivo di riproduzione e la "
 "frequenza di campionamento del progetto."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Per applicare un filtro, tutte le tracce selezionate devono avere la stessa "
+"frequenza di campionamento."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4047,9 +4085,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Attenzione: problemi nel recupero automatico"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<senza titolo>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Progetto %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -5614,7 +5657,9 @@ msgstr "Comando"
 msgid ""
 "\n"
 "* %s, because you have assigned the shortcut %s to %s"
-msgstr "\n* %s, in quanto hai assegnato la combinazione di tasti %s a %s"
+msgstr ""
+"\n"
+"* %s, in quanto hai assegnato la combinazione di tasti %s a %s"
 
 #: src/commands/CommandManager.cpp
 msgid ""
@@ -7331,7 +7376,8 @@ msgid ""
 "DTMF sequence empty.\n"
 "Check ALL settings for this effect."
 msgstr ""
-"Sequenza DTMF vuota.\nVerificate TUTTE le impostazioni di questo effetto."
+"Sequenza DTMF vuota.\n"
+"Verificate TUTTE le impostazioni di questo effetto."
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -9366,11 +9412,11 @@ msgid ""
 "silences have been inserted into the audio. Enabling this option will "
 "provide that compensation, but it may not work for all VST effects."
 msgstr ""
-"Come parte del loro processo, alcuni effetti VST ritardano l'audio restituito "
-"ad Audacity. Quando questo ritardo non è compensato verranno inseriti dei "
-"silenzi di breve durata nell'audio. Abilitare questa opzione per fornire "
-"questa compensazione; notare che tuttavia potrebbe non funzionare con tutti "
-"gli effetti VST."
+"Come parte del loro processo, alcuni effetti VST ritardano l'audio "
+"restituito ad Audacity. Quando questo ritardo non è compensato verranno "
+"inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione "
+"per fornire questa compensazione; notare che tuttavia potrebbe non "
+"funzionare con tutti gli effetti VST."
 
 #: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
 #: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -9533,9 +9579,9 @@ msgid ""
 msgstr ""
 "Come parte del loro processo, alcuni effetti Audio Unit ritardano l'audio "
 "restituito ad Audacity. Quando questo ritardo non è compensato verranno "
-"inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione per "
-"fornire questa compensazione; notare che tuttavia potrebbe non funzionare con "
-"tutti gli effetti Audio Unit."
+"inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione "
+"per fornire questa compensazione; notare che tuttavia potrebbe non "
+"funzionare con tutti gli effetti Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9611,7 +9657,10 @@ msgid ""
 "Could not import \"%s\" preset\n"
 "\n"
 "%s"
-msgstr "Non è stato pissibile importare la combinazione \"%s\"\n\n%s"
+msgstr ""
+"Non è stato pissibile importare la combinazione \"%s\"\n"
+"\n"
+"%s"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
@@ -9633,7 +9682,10 @@ msgid ""
 "Could not export \"%s\" preset\n"
 "\n"
 "%s"
-msgstr "Non è stato possibile esportare la combinazione \"%s\"\n\n%s"
+msgstr ""
+"Non è stato possibile esportare la combinazione \"%s\"\n"
+"\n"
+"%s"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Export Audio Unit Presets"
@@ -9715,9 +9767,9 @@ msgid ""
 msgstr ""
 "Come parte del loro processo, alcuni effetti LADSPA ritardano l'audio "
 "restituito ad Audacity. Quando questo ritardo non è compensato verranno "
-"inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione per "
-"fornire questa compensazione; notare che tuttavia potrebbe non funzionare con "
-"tutti gli effetti LADSPA."
+"inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione "
+"per fornire questa compensazione; notare che tuttavia potrebbe non "
+"funzionare con tutti gli effetti LADSPA."
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
@@ -9749,17 +9801,22 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Dimensione &buffer (da 8 a %d) campioni):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Dimensione &buffer (da 8 a %d) campioni):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
 "silences have been inserted into the audio. Enabling this setting will "
 "provide that compensation, but it may not work for all LV2 effects."
 msgstr ""
-"Come parte del loro processo, alcuni effetti LV2 ritardano l'audio restituito "
-"ad Audacity. Quando questo ritardo non è compensato verranno inseriti dei "
-"silenzi di breve durata nell'audio. Abilitare questa opzione per fornire "
-"questa compensazione; notare che tuttavia potrebbe non funzionare con tutti "
-"gli effetti LV2."
+"Come parte del loro processo, alcuni effetti LV2 ritardano l'audio "
+"restituito ad Audacity. Quando questo ritardo non è compensato verranno "
+"inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione "
+"per fornire questa compensazione; notare che tuttavia potrebbe non "
+"funzionare con tutti gli effetti LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid ""
@@ -10202,12 +10259,13 @@ msgid ""
 "missing files.\n"
 "If you still wish to export, please choose a different filename or folder."
 msgstr ""
-"Si sta cercando di sovrascrivere un file con alias mancante.\nIl file non può "
-"essere scritto perché il percorso è necessario per ripristinare l'audio "
-"originale nel progetto.\nSelezionare Aiuto > Diagnostica > Controlla "
-"dipendenze per vedere la posizione di tutti i file mancanti.\nPer procedere "
-"comunque con l'esportazione, selezionare un altro nome di file o un'altra "
-"cartella."
+"Si sta cercando di sovrascrivere un file con alias mancante.\n"
+"Il file non può essere scritto perché il percorso è necessario per "
+"ripristinare l'audio originale nel progetto.\n"
+"Selezionare Aiuto > Diagnostica > Controlla dipendenze per vedere la "
+"posizione di tutti i file mancanti.\n"
+"Per procedere comunque con l'esportazione, selezionare un altro nome di file "
+"o un'altra cartella."
 
 #: src/export/Export.cpp
 #, c-format
@@ -10407,7 +10465,10 @@ msgid ""
 "Can't open audio codec \"%s\" (0x%x)\n"
 "\n"
 "%s"
-msgstr "Non è possibile aprire il codec audio \"%s\" (0x%x)\n\n%s"
+msgstr ""
+"Non è possibile aprire il codec audio \"%s\" (0x%x)\n"
+"\n"
+"%s"
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
@@ -10512,7 +10573,8 @@ msgstr "Frequenze di campionamento"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11189,7 +11251,6 @@ msgstr "Esportazione dell'audio selezionato come FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Esportazione dell'audio come FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12524,7 +12585,7 @@ msgstr "fine"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14341,11 +14402,25 @@ msgstr ""
 "Salvare o chiudere questo progetto e riprovare."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Insufficient track selection"
+msgstr "Ritaglia il file nella selezione"
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Selezionare in una traccia audio."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Selezionare in una traccia stereo."
 
 #: src/menus/TransportMenus.cpp
@@ -15297,7 +15372,9 @@ msgstr "Pre&definiti"
 msgid ""
 "\n"
 "   *   \""
-msgstr "\n   *   \""
+msgstr ""
+"\n"
+"   *   \""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "\"  (because the shortcut '"
@@ -15333,7 +15410,9 @@ msgstr "\" e \""
 msgid ""
 "\".\n"
 "Nothing is imported."
-msgstr "\".\nNon è stato importato nulla."
+msgstr ""
+"\".\n"
+"Non è stato importato nulla."
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -15346,7 +15425,8 @@ msgid ""
 "The following commands are not mentioned in the imported file, but have "
 "their shortcuts removed because of the conflict with other new shortcuts:\n"
 msgstr ""
-"\nI comandi seguenti non sono menzionati nel file importato, ma le loro "
+"\n"
+"I comandi seguenti non sono menzionati nel file importato, ma le loro "
 "combinazioni di tasti sono state rimosse in quanto in conflitto con altre "
 "nuove combinazioni di tasti:\n"
 
@@ -17260,8 +17340,8 @@ msgid ""
 "To change Spectrogram Settings, stop any\n"
 " playing or recording first."
 msgstr ""
-"Arrestare la riproduzione e la registrazione prima\ndi cambiare le "
-"impostazioni dello spettrogramma,"
+"Arrestare la riproduzione e la registrazione prima\n"
+"di cambiare le impostazioni dello spettrogramma,"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "Stop the Audio First"
@@ -18399,8 +18479,8 @@ msgid "Value must not be less than %s"
 msgstr "Il valore non deve essere minore di %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Il valore non deve essere maggiore di %s"
 
 #: src/widgets/valnum.cpp
@@ -18492,8 +18572,9 @@ msgid ""
 "Try reducing the silence level and\n"
 "the minimum silence duration."
 msgstr ""
-"Nessun silenzio trovato.\nProvare a ridurre il livello di silenzio\ne la "
-"durata minima del silenzio."
+"Nessun silenzio trovato.\n"
+"Provare a ridurre il livello di silenzio\n"
+"e la durata minima del silenzio."
 
 #: plug-ins/SoundFinder.ny
 msgid "Sound Finder"
@@ -19299,8 +19380,10 @@ msgid ""
 "is too high for selected track.\n"
 "Set the control below ~a kHz."
 msgstr ""
-"Error.\n\"Frequenze del gate superiori: ~s kHz\"\ntroppo elevate per la "
-"traccia selezionata.\nImpostare il controllo sotto ~a kHz."
+"Error.\n"
+"\"Frequenze del gate superiori: ~s kHz\"\n"
+"troppo elevate per la traccia selezionata.\n"
+"Impostare il controllo sotto ~a kHz."
 
 #: plug-ins/noisegate.ny
 #, lisp-format
@@ -19308,8 +19391,8 @@ msgid ""
 "~%Insufficient audio selected.\n"
 "Make the selection longer than ~a ms."
 msgstr ""
-"~%Audio selezionato non sufficiente.\nLa seelzione deve essere più lunga di "
-"~a ms."
+"~%Audio selezionato non sufficiente.\n"
+"La seelzione deve essere più lunga di ~a ms."
 
 #: plug-ins/noisegate.ny
 #, lisp-format
@@ -19317,8 +19400,8 @@ msgid ""
 "Peak based on first ~a seconds ~a dB~%\n"
 "Suggested Threshold Setting ~a dB."
 msgstr ""
-"Picco basato sui primi ~a secondi ~a dB~%\nImpostazione soglia suggerita ~a "
-"dB."
+"Picco basato sui primi ~a secondi ~a dB~%\n"
+"Impostazione soglia suggerita ~a dB."
 
 #: plug-ins/notch.ny
 msgid "Notch Filter"
@@ -20054,11 +20137,14 @@ msgid ""
 "                    Variation of residuals: ~a\n"
 "                    y equals ~a plus ~a times x~%"
 msgstr ""
-"Media x: ~a, y: ~a\n                    Covarianza x y: ~a\n                  "
-"  Varianza media x: ~a, y: ~a\n                    Deviazione standard x: ~a, "
-"y: ~a\n                    Coefficiente di correlazione: ~a\n                 "
-"   Coefficiente di determinazione: ~a\n                    Variazione dei "
-"residui: ~a\n                    y uguale ~a più ~a volta x~%"
+"Media x: ~a, y: ~a\n"
+"                    Covarianza x y: ~a\n"
+"                    Varianza media x: ~a, y: ~a\n"
+"                    Deviazione standard x: ~a, y: ~a\n"
+"                    Coefficiente di correlazione: ~a\n"
+"                    Coefficiente di determinazione: ~a\n"
+"                    Variazione dei residui: ~a\n"
+"                    y uguale ~a più ~a volta x~%"
 
 #: plug-ins/vocalrediso.ny
 #, lisp-format
@@ -20075,9 +20161,10 @@ msgid ""
 "                The center can't be removed.\n"
 "                Any remaining difference may be caused by lossy encoding."
 msgstr ""
-" - I due canali sono identici, cioè doppio mono.\n                Il centro "
-"non può essere rimosso.\n                Qualsiasi differenza residua può "
-"essere causata da una codifica con perdita."
+" - I due canali sono identici, cioè doppio mono.\n"
+"                Il centro non può essere rimosso.\n"
+"                Qualsiasi differenza residua può essere causata da una "
+"codifica con perdita."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20086,8 +20173,8 @@ msgid ""
 "                Most likely, the center extraction will be poor."
 msgstr ""
 " - I due canali sono fortemente correlati, ovvero quasi mono o estremamente "
-"bilanciati.\n                Molto probabilmente, l'estrazione centrale sarà "
-"scarsa."
+"bilanciati.\n"
+"                Molto probabilmente, l'estrazione centrale sarà scarsa."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20101,8 +20188,9 @@ msgid ""
 "                However, the center extraction depends also on the used "
 "reverb."
 msgstr ""
-" - Un valore ideale per lo stereo.\n                Tuttavia, l'estrazione "
-"centrale dipende anche dal riverbero usato."
+" - Un valore ideale per lo stereo.\n"
+"                Tuttavia, l'estrazione centrale dipende anche dal riverbero "
+"usato."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20111,9 +20199,10 @@ msgid ""
 "unbalanced manner.\n"
 "                The center extraction can still be good though."
 msgstr ""
-" - I due canali sono quasi non correlati.\n                Si ha solo rumore "
-"o il pezzo è stato masterizzato in modo sbilanciato.\n                "
-"L'estrazione centrale può comunque essere abbastanza buona."
+" - I due canali sono quasi non correlati.\n"
+"                Si ha solo rumore o il pezzo è stato masterizzato in modo "
+"sbilanciato.\n"
+"                L'estrazione centrale può comunque essere abbastanza buona."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20121,9 +20210,9 @@ msgid ""
 "                This can cause strange effects.\n"
 "                Especially when played by only one speaker."
 msgstr ""
-" - Sebbene la traccia sia stereo, il campo è evidentemente molto ampio.\n     "
-"           Questo può causare strani effetti.\n                Soprattutto se "
-"riprodotto da un solo altoparlante."
+" - Sebbene la traccia sia stereo, il campo è evidentemente molto ampio.\n"
+"                Questo può causare strani effetti.\n"
+"                Soprattutto se riprodotto da un solo altoparlante."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -20133,10 +20222,12 @@ msgid ""
 "the speakers.\n"
 "                  Don't expect good results from a center removal."
 msgstr ""
-" - I due canali sono quasi identici.\n                  Ovviamente, è stato "
-"usato un effetto pseudo-stereo\n                  per diffondere il segnale "
-"sulla distanza fisica tra gli altoparlanti.\n                  Non sono "
-"attesi buoni risultati da una rimozione del centro."
+" - I due canali sono quasi identici.\n"
+"                  Ovviamente, è stato usato un effetto pseudo-stereo\n"
+"                  per diffondere il segnale sulla distanza fisica tra gli "
+"altoparlanti.\n"
+"                  Non sono attesi buoni risultati da una rimozione del "
+"centro."
 
 #: plug-ins/vocalrediso.ny
 msgid "This plug-in works only with stereo tracks."
@@ -20194,6 +20285,21 @@ msgstr "Frequenza degli aghi radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Errore.~%Richiesta traccia stereo."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Mostra/nascondi editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Quando si importano file audio"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "incorporamento"
@@ -23237,6 +23343,3 @@ msgstr "Errore.~%Richiesta traccia stereo."
 
 #~ msgid "Trim"
 #~ msgstr "Ritaglia"
-
-#~ msgid "Trim file to selection"
-#~ msgstr "Ritaglia il file nella selezione"

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2018-11-29 22:46+0900\n"
 "Last-Translator: Phroneris <phroneris@gmail.com>\n"
 "Language-Team: Atsushi YOSHIDA, Phroneris\n"
@@ -3807,6 +3807,28 @@ msgstr ""
 "音声ホスト、再生デバイス、プロジェクトのサンプリング周波数などを変えてみてく"
 "ださい。"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"フィルタを適用するには、すべての選択トラックが同一のサンプリング周波数でなけ"
+"ればなりません。"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4059,9 +4081,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "警告: 自動回復に問題が発生しています"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<無題>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "プロジェクト"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9861,6 +9888,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "バッファーサイズ (8～1048576 サンプル) (&B):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "バッファーサイズ (8～1048576 サンプル) (&B):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10614,7 +10646,8 @@ msgstr "サンプリング周波数"
 #  i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11316,7 +11349,6 @@ msgid "Exporting the audio as FLAC"
 msgstr "音声を FLAC ファイルに書き出し"
 
 #  i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12682,7 +12714,7 @@ msgstr "終わり"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14524,11 +14556,24 @@ msgstr ""
 "このプロジェクトを保存するか閉じるかして、やり直してください。"
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "モノラルトラックを選択してください。"
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "ステレオトラックを選択してください。"
 
 #: src/menus/TransportMenus.cpp
@@ -18628,8 +18673,8 @@ msgid "Value must not be less than %s"
 msgstr "値は %s より小さくてはいけません"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "値は %s より大きくてはいけません"
 
 #: src/widgets/valnum.cpp
@@ -20489,6 +20534,21 @@ msgstr "くし歯の周波数 (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "エラー。~%ステレオトラックが必要です。"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "エディタの表示/非表示"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "非圧縮音声ファイルを取り込む時"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "組込:"

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2009-01-16 03:10-0000\n"
 "Last-Translator: g <g@g>\n"
 "Language-Team:  <en@li.org>\n"
@@ -3771,6 +3771,28 @@ msgstr ""
 "ხმის მოწყობილობის გახსნის შეცდომა. გთხოვთ, შეამოწმოთ გამონატანი მოწყობილობის "
 "პარამეტრები და პროექტის სემპლის კოეფიციენტი."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"სპექტრის აგებისთვის ყველა მონიშნული ტრეკს უნდა ჰქონდეს სემპლის თანაბარი "
+"კოეფიციენტი."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3968,9 +3990,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "პროექტის მორგება"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9878,6 +9905,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10608,7 +10640,8 @@ msgstr "სემპლის კ0ოეფიციენტები"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "კბწ"
@@ -11300,7 +11333,6 @@ msgstr "მონიშნული აუდიოს ექსპორტი 
 msgid "Exporting the audio as FLAC"
 msgstr "მონიშნული აუდიოს ექსპორტი FLAC ფორმატში"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12616,7 +12648,7 @@ msgstr "დასასრული"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14664,13 +14696,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
 
 #: src/menus/TransportMenus.cpp
@@ -19012,7 +19056,7 @@ msgstr "სახელი არ უნდა იყოს ცარიელ�
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "დასაწყისი და დასასრული უნდა იყოს 0-ზე მეტი"
 
 #: src/widgets/valnum.cpp
@@ -20885,6 +20929,21 @@ msgstr "სიხშირე (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "სიჩუმის გენერატორი"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "აუდიოს ფაილების იმპორტისას "
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/km.po
+++ b/locale/km.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2008-07-09 13:48+0700\n"
 "Last-Translator: Khoem Sokhem <khoemsokhem@khmeros.info>\n"
 "Language-Team: Khmer <en@li.org>\n"
@@ -3741,6 +3741,26 @@ msgid ""
 "Try changing the audio host, playback device and the project sample rate."
 msgstr "កំហុស​​ពេល​​កំពុង​​បើក​​ឧបករណ៍​សំឡេង។ សូម​ត្រួតពិនិត្យ​មើល​ការ​កំណត់​ឧបករណ៍​លទ្ធផល និង​​អត្រា​​គំរូ​​គម្រោង"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "ដើម្បី​​គ្រោង​​វិសាលគម បទ​​ដែល​​ជ្រើស​​ទាំងអស់​ត្រូវ​តែ​មាន​អត្រា​​គំរូ​​ដូច​គ្នា ។"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3938,9 +3958,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "ធ្វើ​ឲ្យ​សម​នឹង​​​​គម្រោង"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9774,6 +9799,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10491,7 +10521,8 @@ msgstr "អត្រា​គំរូ"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "kbps"
@@ -11111,7 +11142,6 @@ msgstr "កំពុង​នាំ​អូឌីយ៉ូ​ដែល​បា
 msgid "Exporting the audio as FLAC"
 msgstr "កំពុង​នាំ​អូឌីយ៉ូ​ដែល​បាន​ជ្រើស​ចេញ​ជា FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12365,7 +12395,7 @@ msgstr "ចុង"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14408,13 +14438,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
 
 #: src/menus/TransportMenus.cpp
@@ -18724,7 +18766,7 @@ msgstr "ឈ្មោះ​មិន​អាច​ទទេ​បាន​ទេ
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "ឈ្មោះ​មិន​អាច​ទទេ​បាន​ទេ"
 
 #: src/widgets/valnum.cpp
@@ -20589,6 +20631,21 @@ msgstr "ប្រេកង់ (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "កម្មវិធី​បង្កើត​ស្ងាត់ៗ"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "មិន​អាច​យក​ចេញ​ឯកសារ​រក្សា​ទុក​ស្វ័យ​ប្រវត្តិ​ចាស់"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-21 15:25+0900\n"
 "Last-Translator: Hwanyong Lee <hwan@ajou.ac.kr>\n"
 "Language-Team: Korean (http://www.transifex.com/klyok/audacity/language/"
@@ -3744,6 +3744,26 @@ msgstr ""
 "사운드 장치 열기 중 오류가 발생했습니다.\n"
 "오디오 호스트, 재생 장치와 프로젝트 샘플링 주파수 바꿔 보세요."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "필터를 적용하려면, 모든 선택한 트랙은 같은 샘플링 주파수여야 합니다."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3990,9 +4010,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "경고: 자동 복구에 문제가 있습니다"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<untitled>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[프로젝트 %02i] 오데시티 \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9642,6 +9667,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "버퍼 크기 (8~%d 샘플)(&B):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "버퍼 크기 (8~%d 샘플)(&B):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10381,7 +10411,8 @@ msgstr "샘플링 주파수"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11056,7 +11087,6 @@ msgstr "선택한 오디오를 FLAC로 내보내는 중"
 msgid "Exporting the audio as FLAC"
 msgstr "오디오를 FLAC로 내보내는 중"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12370,7 +12400,7 @@ msgstr "끝"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14182,11 +14212,24 @@ msgstr ""
 "이 프로젝트를 저장하거나 닫고 다시 시도해 보세요."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "모노 트랙에서 선택하십시오."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "스테레오 트랙에서 선택하십시오."
 
 #: src/menus/TransportMenus.cpp
@@ -18213,8 +18256,8 @@ msgid "Value must not be less than %s"
 msgstr "값은 %s보다 더 작으면 안됩니다"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "값은 %s보다 더 크면 안됩니다"
 
 #: src/widgets/valnum.cpp
@@ -19987,6 +20030,21 @@ msgstr "레이더 니들의 주파수 (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "오류.~%스테레오 트랙이 필요합니다."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "편집기 보기/감추기"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "오디오 파일 가져올 때"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "협력"

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2018-03-29 22:12+0100\n"
 "Last-Translator: Zygimantus <zygimantus@gmail.com>\n"
 "Language-Team: Sharunas <Sharunas55387@hotmail.com>\n"
@@ -3846,6 +3846,28 @@ msgstr ""
 "Pabandykite pakeisti garso šeimininką, grojimo prietaisą ir projekto šablono "
 "dažnį."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Kad galėčiau nupiešti grafiką, visi pasirinkti takeliai turi būti to pačio "
+"dažnio."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4103,9 +4125,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Įspėjimas: Problemos Automatiniame Atkūrime"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<be pavadinimo>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekto Pa&baiga"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9961,6 +9988,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10674,7 +10706,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -11296,7 +11329,6 @@ msgstr ""
 msgid "Exporting the audio as FLAC"
 msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12568,7 +12600,7 @@ msgstr "pabaiga"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14511,13 +14543,25 @@ msgstr ""
 "Prašome išsaugoti arba uždaryti ši projektą ir bandyti dar kartą."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Prašome pasirinkti garso takelį."
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Prašome pasirinkti garso takelį."
 
 #: src/menus/TransportMenus.cpp
@@ -18715,9 +18759,9 @@ msgid "Value must not be less than %s"
 msgstr ""
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
-msgstr ""
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
+msgstr "Negali būti be pavadinimo"
 
 #: src/widgets/valnum.cpp
 msgid "e"
@@ -20587,6 +20631,21 @@ msgstr "LFO Dažnis (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Tyla"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "iššifruoti automatiškai išsaugotą failą"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #~ msgid "incorporating"

--- a/locale/mk.po
+++ b/locale/mk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2003-06-23 11:40+0200\n"
 "Last-Translator: Ilija Iliev <strumjan@mol.net.mk>\n"
 "Language-Team: macedonian <mk@li.org>\n"
@@ -3681,6 +3681,26 @@ msgstr ""
 "Грешка при пуштање звук. Молам проверете ги поставките за излезен уред и за "
 "проект рата."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "За цртање на спектар сите селектирани нумери треба да се со иста рата."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3878,9 +3898,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "&Сними проект"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9576,6 +9601,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10284,7 +10314,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -10900,7 +10931,6 @@ msgstr ""
 msgid "Exporting the audio as FLAC"
 msgstr "Експорт на селектираното аудио како Ogg Vorbis"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12144,7 +12174,7 @@ msgstr ""
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14143,13 +14173,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Создадена нова аудио нумера"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Создадена нова аудио нумера"
 
 #: src/menus/TransportMenus.cpp
@@ -18384,7 +18426,7 @@ msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr ""
 
 #: src/widgets/valnum.cpp
@@ -20234,6 +20276,21 @@ msgstr "LFO фрекфенција (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Тишина"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Снимање"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/my.po
+++ b/locale/my.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2010-01-27 06:35-0000\n"
 "Last-Translator: g <g@g>\n"
 "Language-Team: Burmese <my@li.org>\n"
@@ -3781,6 +3781,26 @@ msgid ""
 msgstr ""
 "အသံ ကိရိယာကို ဖွင့်နေစဉ် အမှားအယွင်း။ ကိရိယာ ရလဒ် တပ်ဆင်ချက်များနဲ့ စီမံချက် နမူနာ နှုန်းထားကို စစ်ဆေးပါ။"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "ရောင်စဉ်ကို ရေးမှတ်ဖို့၊ ရွေးထားတဲ့ အသံလမ်းကြောများ အားလုံးဟာ တူညီတဲ့ နမူနာ အဆင့်ဖြစ်ရမယ်။"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3978,9 +3998,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "စီမံချက်များ"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9912,6 +9937,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10641,7 +10671,8 @@ msgstr "နမူနာ နှုန်းထားများ"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "kbps"
@@ -11336,7 +11367,6 @@ msgstr "ရွေးချယ်ထားတဲ့ အသံကို FLAC လ�
 msgid "Exporting the audio as FLAC"
 msgstr "ရွေးချယ်ထားတဲ့ အသံကို FLAC လို တင်ပို့နေခြင်း"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12662,7 +12692,7 @@ msgstr "ပြီးဆုံးမှု"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14715,13 +14745,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
 
 #: src/menus/TransportMenus.cpp
@@ -19066,7 +19108,7 @@ msgstr "အမည်ဟာ ဗလာ မဖြစ်ရဘူး"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "စတင်ခြင်းနဲ့ ရပ်တန့်ခြင်းဟာ ၀ ထက် ကြီးရမယ်။"
 
 #: src/widgets/valnum.cpp
@@ -20939,6 +20981,21 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "တိတ်ဆိတ်တဲ့ ထုတ်လုပ်ကိရိယာ"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "အသံ ဖိုင်များကို တင်သွင်းနေတဲ့ အခါ"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2018-11-29 15:52+0100\n"
 "Last-Translator: Imre Kristoffer Eilertsen <imreeil42@gmail.com>\n"
 "Language-Team: Imre Kristoffer Eilertsen <imreeil42@gmail.com>\n"
@@ -3825,6 +3825,27 @@ msgstr ""
 "Feil ved åpning av lydenheten.\n"
 "Prøv å endre lydverten, opptaksenheten, og datafrekvensen til prosjektet."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"For å bruke et filter, må alle markerte spor være av samme samplingsfrekvens."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4077,9 +4098,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Advarsel: Problemer under automatisk gjenoppretting"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<uten tittel>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Prosjekt"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9831,6 +9857,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Buffertid (8 til 1048576 samplinger):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Buffertid (8 til 1048576 samplinger):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10581,7 +10612,8 @@ msgstr "Datarater"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kb/s"
@@ -11273,7 +11305,6 @@ msgstr "Eksporter den markerte lyden som FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Eksporter lyden som FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12633,7 +12664,7 @@ msgstr "slutt"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14464,11 +14495,24 @@ msgstr ""
 "Vennligst lagre eller lukk dette prosjektet, og prøv igjen."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Vennligst velg i et monospor."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Vennligst velg i et stereospor."
 
 #: src/menus/TransportMenus.cpp
@@ -18580,8 +18624,8 @@ msgid "Value must not be less than %s"
 msgstr "Verdien kan ikke være mindre enn %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Verdien kan ikke være større en %s"
 
 #: src/widgets/valnum.cpp
@@ -20402,6 +20446,21 @@ msgstr "Hyppigheten til radarnåler (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Feil.~%Stereospor er påkrevd."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Vis/skjul redigering"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Ved import av lydfiler"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "inkorporerer"

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2019-09-10 08:52+0000\n"
 "Last-Translator: Thomas De Rocker\n"
 "Language-Team: Dutch (http://www.transifex.com/klyok/audacity/language/nl/)\n"
@@ -3791,6 +3791,27 @@ msgstr ""
 "Probeer de audio-host, het afspeelapparaat en de samplerate van het project "
 "te wijzigen."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Om een filter toe te passen moeten alle tracks dezelfde samplerate hebben."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4043,9 +4064,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Waarschuwing: problemen bij automatisch herstel"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<naamloos>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Project"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9794,6 +9820,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Buffergrootte (8 tot 1048576 samples):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Buffergrootte (8 tot 1048576 samples):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10549,7 +10580,8 @@ msgstr "Samplerates"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11240,7 +11272,6 @@ msgstr "De geselecteerde audio wordt geëxporteerd als FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Audio exporteren als FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12594,7 +12625,7 @@ msgstr "einde"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14419,11 +14450,24 @@ msgstr ""
 "Sla dit project op of sluit het en probeer het opnieuw."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Selecteer in een mono-track."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Selecteer in een stereo-track."
 
 #: src/menus/TransportMenus.cpp
@@ -18489,8 +18533,8 @@ msgid "Value must not be less than %s"
 msgstr "Waarde mag niet kleiner zijn dan %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Waarde mag niet groter zijn dan %s"
 
 #: src/widgets/valnum.cpp
@@ -20307,6 +20351,21 @@ msgstr "Frequentie van radar-needles (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Fout.~%Stereotrack vereist."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Editor weergeven/verbergen"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Bij importeren van audiobestanden"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "bevattend"

--- a/locale/oc.po
+++ b/locale/oc.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2007-01-31 14:28+0100\n"
 "Last-Translator: Felip Joulie <felip.joulie@gmail.com>\n"
 "Language-Team: Occitan <ubuntu-l10n-oci@lists.ubuntu.com>\n"
@@ -3678,6 +3678,25 @@ msgstr ""
 "Error a la dubèrtura del periferic son. Verificatz los reglatges del "
 "periferic e l'escandalhatge del projècte"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3874,9 +3893,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "&Enregistrar lo projècte"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9549,6 +9573,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10258,7 +10287,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -10874,7 +10904,6 @@ msgstr ""
 msgid "Exporting the audio as FLAC"
 msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12115,7 +12144,7 @@ msgstr ""
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14112,13 +14141,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Novèla·pista audiò creada"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Novèla·pista audiò creada"
 
 #: src/menus/TransportMenus.cpp
@@ -18340,7 +18381,7 @@ msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr ""
 
 #: src/widgets/valnum.cpp
@@ -20189,6 +20230,21 @@ msgstr "Frequéncia LFO (Hz) :"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Silenci"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Audio gravat"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Audacity Team
 # This file is distributed under the same license as the audacity package.
-# 
+#
 # Translators:
 # Andrzej Supermocny <blackwhattack@gmail.com>, 2015
 # Aron <aron.plotnikowski@cryptolab.net>, 2013
@@ -18,17 +18,20 @@
 # Aron <aron.plotnikowski@cryptolab.net>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: Audacity\n"
+"Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-14 13:24+0000\n"
 "Last-Translator: Grzegorz Pruchniakowski <gootector@o2.pl>\n"
-"Language-Team: Polish (http://www.transifex.com/klyok/audacity/language/pl/)\n"
+"Language-Team: Polish (http://www.transifex.com/klyok/audacity/language/"
+"pl/)\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
+"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
+"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
 #: lib-src/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
@@ -186,7 +189,8 @@ msgstr "Wczytaj skrypt Nyquista"
 
 #: lib-src/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
-msgstr "Skrypty Nyquista (*.ny)|*.ny|Skrypty Lispa (*.lsp)|*.lsp|Wszystkie pliki|*"
+msgstr ""
+"Skrypty Nyquista (*.ny)|*.ny|Skrypty Lispa (*.lsp)|*.lsp|Wszystkie pliki|*"
 
 #: lib-src/mod-nyq-bench/NyqBench.cpp
 msgid "Script was not saved."
@@ -225,7 +229,8 @@ msgstr "(C) 2009, Leland Lucius"
 #: lib-src/mod-nyq-bench/NyqBench.cpp
 msgid ""
 "External Audacity module which provides a simple IDE for writing effects."
-msgstr "Zewnętrzny moduł Audacity, który zapewnia prosty IDE do pisania efektów."
+msgstr ""
+"Zewnętrzny moduł Audacity, który zapewnia prosty IDE do pisania efektów."
 
 #: lib-src/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -412,92 +417,79 @@ msgstr "Zatrzymaj skrypt"
 msgid "No revision identifier was provided"
 msgstr "Nie podano identyfikatora wersji"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, system administration"
 msgstr "%s, administracja systemem"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, co-founder and developer"
 msgstr "%s, współzałożyciel i deweloper"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer"
 msgstr "%s, deweloper"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, documentation and support"
 msgstr "%s, dokumentacja i wsparcie"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, documentation and support, French"
 msgstr "%s, dokumentacja i wsparcie, francuski"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
 msgstr "%s, gwarancja jakości"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, accessibility advisor"
 msgstr "%s, doradca dostępności"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "%s, grafik"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, composer"
 msgstr "%s, kompozytor"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, tester"
 msgstr "%s, tester"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "%s, wtyczki Nyquista"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, web developer"
 msgstr "%s, twórca stron internetowych"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
-#. name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphics"
@@ -512,8 +504,7 @@ msgstr "%s (obejmuje %s, %s, %s, %s i %s)"
 msgid "About Audacity"
 msgstr "O Audacity"
 
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a
-#. button.
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
 #: src/AboutDialog.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp
 #: src/widgets/MultiDialog.cpp
 msgid "OK"
@@ -521,19 +512,28 @@ msgstr "OK"
 
 #: src/AboutDialog.cpp
 msgid ""
-"Audacity is a free program written by a worldwide team of "
-"[[https://www.audacityteam.org/about/credits|volunteers]]. Audacity is "
-"[[https://www.audacityteam.org/download|available]] for Windows, Mac, and "
-"GNU/Linux (and other Unix-like systems)."
-msgstr "Audacity jest darmowym programem, napisanym przez globalny zespół [[https://www.audacityteam.org/about/credits|programistów-ochotników]]. Audacity jest [[https://www.audacityteam.org/download|dostępny]] na Windows, Maca oraz GNU/Linux (i inne systemy typu Unix)."
+"Audacity is a free program written by a worldwide team of [[https://www."
+"audacityteam.org/about/credits|volunteers]]. Audacity is [[https://www."
+"audacityteam.org/download|available]] for Windows, Mac, and GNU/Linux (and "
+"other Unix-like systems)."
+msgstr ""
+"Audacity jest darmowym programem, napisanym przez globalny zespół [[https://"
+"www.audacityteam.org/about/credits|programistów-ochotników]]. Audacity jest "
+"[[https://www.audacityteam.org/download|dostępny]] na Windows, Maca oraz GNU/"
+"Linux (i inne systemy typu Unix)."
 
 #: src/AboutDialog.cpp
 msgid ""
 "If you find a bug or have a suggestion for us, please write, in English, to "
 "our [[https://forum.audacityteam.org/|forum]]. For help, view the tips and "
-"tricks on our [[https://wiki.audacityteam.org/|wiki]] or visit our "
-"[[https://forum.audacityteam.org/|forum]]."
-msgstr "Jeśli znajdziesz błąd lub masz jakąś sugestię, wyślij e-mail w języku angielskim na nasze [[https://forum.audacityteam.org/|forum]]. Aby uzyskać pomoc, sprawdź porady i wskazówki na naszej stronie [[https://wiki.audacityteam.org/|wiki]] lub odwiedź nasze [[https://forum.audacityteam.org/|forum]]."
+"tricks on our [[https://wiki.audacityteam.org/|wiki]] or visit our [[https://"
+"forum.audacityteam.org/|forum]]."
+msgstr ""
+"Jeśli znajdziesz błąd lub masz jakąś sugestię, wyślij e-mail w języku "
+"angielskim na nasze [[https://forum.audacityteam.org/|forum]]. Aby uzyskać "
+"pomoc, sprawdź porady i wskazówki na naszej stronie [[https://wiki."
+"audacityteam.org/|wiki]] lub odwiedź nasze [[https://forum.audacityteam.org/|"
+"forum]]."
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
@@ -542,7 +542,10 @@ msgstr "Jeśli znajdziesz błąd lub masz jakąś sugestię, wyślij e-mail w j�
 #. *  For example:  "English translation by Dominic Mazzoni."
 #: src/AboutDialog.cpp
 msgid "translator_credits"
-msgstr "Polskie tłumaczenie Audacity: Grzegorz \"Gootector\" Pruchniakowski.\nPozostali tłumacze (nieaktywni): Michał Trzebiatowski, Patryk Małachowski, Aron Płotnikowski i Łukasz Wojniłowicz."
+msgstr ""
+"Polskie tłumaczenie Audacity: Grzegorz \"Gootector\" Pruchniakowski.\n"
+"Pozostali tłumacze (nieaktywni): Michał Trzebiatowski, Patryk Małachowski, "
+"Aron Płotnikowski i Łukasz Wojniłowicz."
 
 #: src/AboutDialog.cpp
 msgid "<h3>Audacity "
@@ -552,7 +555,9 @@ msgstr "<h3>Audacity "
 msgid ""
 "Audacity the free, open source, cross-platform software for recording and "
 "editing sounds."
-msgstr "Audacity jest darmowym, wieloplatformowym oprogramowaniem do nagrywania i edycji dźwięku."
+msgstr ""
+"Audacity jest darmowym, wieloplatformowym oprogramowaniem do nagrywania i "
+"edycji dźwięku."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
@@ -606,13 +611,17 @@ msgstr "Strona internetowa Audacity: "
 msgid ""
 "<p><br>&nbsp; &nbsp; <b>Audacity<sup>&reg;</sup></b> software is copyright "
 "&copy; 1999-2018 Audacity Team.<br>"
-msgstr "<p><br>&nbsp; &nbsp; <b>Oprogramowanie Audacity<sup>&reg;</sup></b> jest chronione prawem autorskim &copy; 1999-2018 Zespół Audacity.<br>"
+msgstr ""
+"<p><br>&nbsp; &nbsp; <b>Oprogramowanie Audacity<sup>&reg;</sup></b> jest "
+"chronione prawem autorskim &copy; 1999-2018 Zespół Audacity.<br>"
 
 #: src/AboutDialog.cpp
 msgid ""
 "&nbsp; &nbsp; The name <b>Audacity</b> is a registered trademark of Dominic "
 "Mazzoni.<br><br>"
-msgstr "&nbsp; &nbsp; Nazwa <b>Audacity</b> jest zarejestrowanym znakiem firmowym Dominica Mazzoniego.<br><br>"
+msgstr ""
+"&nbsp; &nbsp; Nazwa <b>Audacity</b> jest zarejestrowanym znakiem firmowym "
+"Dominica Mazzoniego.<br><br>"
 
 #: src/AboutDialog.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #: src/effects/nyquist/Nyquist.cpp src/prefs/PrefsDialog.cpp plug-ins/beat.ny
@@ -628,8 +637,8 @@ msgstr "Informacje o kompilacji"
 msgid "Enabled"
 msgstr "Włączone"
 
-#: src/AboutDialog.cpp src/PluginManager.cpp
-#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginManager.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Wyłączone"
 
@@ -763,7 +772,9 @@ msgstr "Działania osi czasu są wyłączone podczas nagrywania"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
-msgstr "Kliknij i przeciągnij, aby dostosować, kliknij podwójnie myszką, aby zresetować"
+msgstr ""
+"Kliknij i przeciągnij, aby dostosować, kliknij podwójnie myszką, aby "
+"zresetować"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Record/Play head"
@@ -776,6 +787,7 @@ msgstr "Oś czasu"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Kliknij i przeciągnij, aby rozpocząć szukanie"
@@ -783,6 +795,7 @@ msgstr "Kliknij i przeciągnij, aby rozpocząć szukanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Kliknij i przeciągnij, aby rozpocząć przewijanie"
@@ -790,6 +803,7 @@ msgstr "Kliknij i przeciągnij, aby rozpocząć przewijanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Kliknij i przesuń, aby przewinąć. Kliknij i przeciągnij, aby szukać."
@@ -797,6 +811,7 @@ msgstr "Kliknij i przesuń, aby przewinąć. Kliknij i przeciągnij, aby szukać
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Przesuń, aby szukać"
@@ -804,6 +819,7 @@ msgstr "Przesuń, aby szukać"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Przesuń, aby przewinąć"
@@ -856,7 +872,9 @@ msgstr "Podpięty do głowicy odtwarzania"
 msgid ""
 "Cannot lock region beyond\n"
 "end of project."
-msgstr "Nie można zablokować obszaru poza\nkońcem projektu."
+msgstr ""
+"Nie można zablokować obszaru poza\n"
+"końcem projektu."
 
 #: src/AudacityApp.cpp
 #, c-format
@@ -871,8 +889,13 @@ msgstr "Niepowodzenie!"
 msgid ""
 "Reset Preferences?\n"
 "\n"
-"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
-msgstr "Zresetować ustawienia?\n\nJest to jednorazowe pytanie po 'zainstalowaniu', w którym poprosiłeś o zresetowanie ustawień."
+"This is a one-time question, after an 'install' where you asked to have the "
+"Preferences reset."
+msgstr ""
+"Zresetować ustawienia?\n"
+"\n"
+"Jest to jednorazowe pytanie po 'zainstalowaniu', w którym poprosiłeś o "
+"zresetowanie ustawień."
 
 #: src/AudacityApp.cpp
 msgid "Reset Audacity Preferences"
@@ -884,19 +907,33 @@ msgid ""
 "%s could not be found.\n"
 "\n"
 "It has been removed from the list of recent files."
-msgstr "%s nie może zostać znalezione.\n\nZostało usunięte z listy ostatnich plików."
+msgstr ""
+"%s nie może zostać znalezione.\n"
+"\n"
+"Zostało usunięte z listy ostatnich plików."
 
 #: src/AudacityApp.cpp
 #, c-format
 msgid ""
 "One or more external audio files could not be found.\n"
-"It is possible they were moved, deleted, or the drive they were on was unmounted.\n"
+"It is possible they were moved, deleted, or the drive they were on was "
+"unmounted.\n"
 "Silence is being substituted for the affected audio.\n"
 "The first detected missing file is:\n"
 "%s\n"
 "There may be additional missing files.\n"
-"Choose Help > Diagnostics > Check Dependencies to view a list of locations of the missing files."
-msgstr "Nie można znaleźć jednego lub więcej plików dźwiękowych.\nMożliwe, że zostały one przeniesione, usunięte lub napęd, na którym przebywały został odmontowany.\nBrakujące dźwięki zostały zastąpione ciszą.\nPierwszym wykrytym brakującym plikiem jest:\n%s\nMożliwe, że jest więcej brakujących plików.\nWybierz 'Pomoc > Diagnostyka > Sprawdź zależności...', aby obejrzeć listę lokalizacji brakujących plików."
+"Choose Help > Diagnostics > Check Dependencies to view a list of locations "
+"of the missing files."
+msgstr ""
+"Nie można znaleźć jednego lub więcej plików dźwiękowych.\n"
+"Możliwe, że zostały one przeniesione, usunięte lub napęd, na którym "
+"przebywały został odmontowany.\n"
+"Brakujące dźwięki zostały zastąpione ciszą.\n"
+"Pierwszym wykrytym brakującym plikiem jest:\n"
+"%s\n"
+"Możliwe, że jest więcej brakujących plików.\n"
+"Wybierz 'Pomoc > Diagnostyka > Sprawdź zależności...', aby obejrzeć listę "
+"lokalizacji brakujących plików."
 
 #: src/AudacityApp.cpp
 msgid "Files Missing"
@@ -943,34 +980,48 @@ msgstr "&Plik"
 #: src/AudacityApp.cpp
 msgid ""
 "Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Audacity needs a place where automatic cleanup programs won't delete the "
+"temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
-msgstr "Audacity nie może znaleźć miejsca na przechowywanie plików tymczasowych.\nAudacity potrzebuje miejsca, gdzie automatyczne programy oczyszczania nie usuną plików tymczasowych.\nPodaj odpowiedni katalog w oknie dialogowym Ustawienia."
+msgstr ""
+"Audacity nie może znaleźć miejsca na przechowywanie plików tymczasowych.\n"
+"Audacity potrzebuje miejsca, gdzie automatyczne programy oczyszczania nie "
+"usuną plików tymczasowych.\n"
+"Podaj odpowiedni katalog w oknie dialogowym Ustawienia."
 
 #: src/AudacityApp.cpp
 msgid ""
 "Audacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
-msgstr "Audacity nie może znaleźć miejsca na przechowywanie plików tymczasowych.\nPodaj odpowiedni katalog w oknie dialogowym Ustawienia."
+msgstr ""
+"Audacity nie może znaleźć miejsca na przechowywanie plików tymczasowych.\n"
+"Podaj odpowiedni katalog w oknie dialogowym Ustawienia."
 
 #: src/AudacityApp.cpp
 msgid ""
 "Audacity is now going to exit. Please launch Audacity again to use the new "
 "temporary directory."
-msgstr "Audacity zakończy teraz swoją pracę. Uruchom Audacity ponownie, aby użyć nowego katalogu tymczasowego."
+msgstr ""
+"Audacity zakończy teraz swoją pracę. Uruchom Audacity ponownie, aby użyć "
+"nowego katalogu tymczasowego."
 
 #: src/AudacityApp.cpp
 msgid ""
 "Running two copies of Audacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
-msgstr "Uruchamianie dwóch kopii Audacity równocześnie może spowodować\nutratę danych albo zawieszenie się systemu.\n\n"
+msgstr ""
+"Uruchamianie dwóch kopii Audacity równocześnie może spowodować\n"
+"utratę danych albo zawieszenie się systemu.\n"
+"\n"
 
 #: src/AudacityApp.cpp
 msgid ""
 "Audacity was not able to lock the temporary files directory.\n"
 "This folder may be in use by another copy of Audacity.\n"
-msgstr "Audacity nie był w stanie zablokować katalogu z plikami tymczasowymi.\nFolder ten może być używany przez inną kopię Audacity.\n"
+msgstr ""
+"Audacity nie był w stanie zablokować katalogu z plikami tymczasowymi.\n"
+"Folder ten może być używany przez inną kopię Audacity.\n"
 
 #: src/AudacityApp.cpp
 msgid "Do you still want to start Audacity?"
@@ -988,7 +1039,9 @@ msgstr "System wykrył, że uruchomiona jest jeszcze jedna kopia Audacity.\n"
 msgid ""
 "Use the New or Open commands in the currently running Audacity\n"
 "process to open multiple projects simultaneously.\n"
-msgstr "Użyj poleceń Nowy lub Otwórz w obecnie uruchomionym procesie\nAudacity, aby otworzyć wiele projektów naraz.\n"
+msgstr ""
+"Użyj poleceń Nowy lub Otwórz w obecnie uruchomionym procesie\n"
+"Audacity, aby otworzyć wiele projektów naraz.\n"
 
 #: src/AudacityApp.cpp
 msgid "Audacity is already running"
@@ -1040,7 +1093,12 @@ msgid ""
 "associated with Audacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
-msgstr "Pliki projektu Audacity (.AUP) nie są \nobecnie przypisane do programu Audacity. \n\nPrzypisać je, aby móc otworzyć je programem przez podwójne kliknięcie przyciskiem myszki?"
+msgstr ""
+"Pliki projektu Audacity (.AUP) nie są \n"
+"obecnie przypisane do programu Audacity. \n"
+"\n"
+"Przypisać je, aby móc otworzyć je programem przez podwójne kliknięcie "
+"przyciskiem myszki?"
 
 #: src/AudacityApp.cpp
 msgid "Audacity Project Files"
@@ -1090,7 +1148,9 @@ msgstr "Nie znaleziono żadnych urządzeń dźwiękowych.\n"
 msgid ""
 "You will not be able to play or record audio.\n"
 "\n"
-msgstr "Nie będzie można odtwarzać/nagrywać dźwięku.\n\n"
+msgstr ""
+"Nie będzie można odtwarzać/nagrywać dźwięku.\n"
+"\n"
 
 #: src/AudioIO.cpp
 #, c-format
@@ -1109,7 +1169,9 @@ msgstr "Wystąpił błąd inicjacji warstwy wej./wyj. MIDI.\n"
 msgid ""
 "You will not be able to play midi.\n"
 "\n"
-msgstr "Nie będzie można odtworzyć MIDI.\n\n"
+msgstr ""
+"Nie będzie można odtworzyć MIDI.\n"
+"\n"
 
 #: src/AudioIO.cpp
 msgid "Error Initializing Midi"
@@ -1124,7 +1186,9 @@ msgstr "Dźwięk Audacity"
 msgid ""
 "Error opening recording device.\n"
 "Error code: %s"
-msgstr "Błąd podczas otwierania urządzenia nagrywającego.\nKod błędu: %s"
+msgstr ""
+"Błąd podczas otwierania urządzenia nagrywającego.\n"
+"Kod błędu: %s"
 
 #: src/AudioIO.cpp
 msgid "Out of memory!"
@@ -1134,42 +1198,57 @@ msgstr "Brak pamięci!"
 msgid ""
 "Automated Recording Level Adjustment stopped. It was not possible to "
 "optimize it more. Still too high."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Niemożliwa była jego dalsza optymalizacja. Nadal jest on za wysoki."
+msgstr ""
+"Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Niemożliwa "
+"była jego dalsza optymalizacja. Nadal jest on za wysoki."
 
 #: src/AudioIO.cpp
 #, c-format
 msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Zautomatyzowane dostosowywanie poziomu nagrywania zmniejszyło głośność do %f."
+msgstr ""
+"Zautomatyzowane dostosowywanie poziomu nagrywania zmniejszyło głośność do %f."
 
 #: src/AudioIO.cpp
 msgid ""
 "Automated Recording Level Adjustment stopped. It was not possible to "
 "optimize it more. Still too low."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Niemożliwa była jego dalsza optymalizacja. Nadal jest on za niski."
+msgstr ""
+"Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Niemożliwa "
+"była jego dalsza optymalizacja. Nadal jest on za niski."
 
 #: src/AudioIO.cpp
 #, c-format
 msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Zautomatyzowane dostosowywanie poziomu nagrywania zwiększyło głośność do %.2f."
+msgstr ""
+"Zautomatyzowane dostosowywanie poziomu nagrywania zwiększyło głośność do "
+"%.2f."
 
 #: src/AudioIO.cpp
 msgid ""
 "Automated Recording Level Adjustment stopped. The total number of analyses "
 "has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Całkowita liczba analiz została przekroczona bez znalezienia akceptowalnej głośności. Nadal jest ona za wysoka."
+msgstr ""
+"Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Całkowita "
+"liczba analiz została przekroczona bez znalezienia akceptowalnej głośności. "
+"Nadal jest ona za wysoka."
 
 #: src/AudioIO.cpp
 msgid ""
 "Automated Recording Level Adjustment stopped. The total number of analyses "
 "has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Całkowita liczba analiz została przekroczona bez znalezienia akceptowalnej głośności. Nadal jest ona za niska."
+msgstr ""
+"Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Całkowita "
+"liczba analiz została przekroczona bez znalezienia akceptowalnej głośności. "
+"Nadal jest ona za niska."
 
 #: src/AudioIO.cpp
 #, c-format
 msgid ""
 "Automated Recording Level Adjustment stopped. %.2f seems an acceptable "
 "volume."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. %.2f wydaje się być akceptowalną głośnością."
+msgstr ""
+"Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. %.2f wydaje "
+"się być akceptowalną głośnością."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1266,7 +1345,8 @@ msgstr "Nie znaleziono urządzenia odtwarzającego '%s'.\n"
 
 #: src/AudioIOBase.cpp
 msgid "Cannot check mutual sample rates without both devices.\n"
-msgstr "Nie można sprawdzić wzajemnych częstotliwości próbkowania bez obu urządzeń.\n"
+msgstr ""
+"Nie można sprawdzić wzajemnych częstotliwości próbkowania bez obu urządzeń.\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1351,7 +1431,10 @@ msgstr "Nie znaleziono urządzenia odtwarzającego MIDI '%s'.\n"
 msgid ""
 "This recovery file was saved by Audacity 2.3.0 or before.\n"
 "You need to run that version of Audacity to recover the project."
-msgstr "Ten plik odzyskiwania został zapisany przez Audacity 2.3.0 lub wcześniejszą wersję.\nMusisz uruchomić tę wersję Audacity, aby odzyskać projekt."
+msgstr ""
+"Ten plik odzyskiwania został zapisany przez Audacity 2.3.0 lub wcześniejszą "
+"wersję.\n"
+"Musisz uruchomić tę wersję Audacity, aby odzyskać projekt."
 
 #: src/AutoRecovery.cpp
 msgid "Error Decoding File"
@@ -1365,7 +1448,10 @@ msgstr "Samoczynne przywracanie po awarii"
 msgid ""
 "Some projects were not saved properly the last time Audacity was run.\n"
 "Fortunately, the following projects can be automatically recovered:"
-msgstr "Niektóre projekty nie zostały poprawnie zapisane podczas ostatniego używania Audacity.\nNa szczęście następujące projekty mogą być samoczynnie odzyskane:"
+msgstr ""
+"Niektóre projekty nie zostały poprawnie zapisane podczas ostatniego używania "
+"Audacity.\n"
+"Na szczęście następujące projekty mogą być samoczynnie odzyskane:"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable projects"
@@ -1397,7 +1483,11 @@ msgid ""
 "Are you sure you want to discard all recoverable projects?\n"
 "\n"
 "Choosing \"Yes\" discards all recoverable projects immediately."
-msgstr "Na pewno chcesz porzucić wszystkie możliwe do odzyskania projekty?\n\nWybranie \"Tak\" porzuci natychmiast wszystkie możliwe do odzyskania projekty."
+msgstr ""
+"Na pewno chcesz porzucić wszystkie możliwe do odzyskania projekty?\n"
+"\n"
+"Wybranie \"Tak\" porzuci natychmiast wszystkie możliwe do odzyskania "
+"projekty."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Confirm Discard Projects"
@@ -1507,7 +1597,9 @@ msgstr "Menu poleceń (bez parametrów)"
 msgid ""
 "Export recording to %s\n"
 "/%s/%s.%s"
-msgstr "Eksportuj nagrywanie do %s\n/%s/%s.%s"
+msgstr ""
+"Eksportuj nagrywanie do %s\n"
+"/%s/%s.%s"
 
 #: src/BatchCommands.cpp
 msgid "Export recording"
@@ -1518,7 +1610,9 @@ msgstr "Eksportuj nagrywanie"
 msgid ""
 "Cannot create directory '%s'. \n"
 "File already exists that is not a directory"
-msgstr "Nie można utworzyć katalogu '%s'. \nIstnieje już plik, który nie jest katalogiem"
+msgstr ""
+"Nie można utworzyć katalogu '%s'. \n"
+"Istnieje już plik, który nie jest katalogiem"
 
 #: src/BatchCommands.cpp
 msgid "Ogg Vorbis support is not included in this build of Audacity"
@@ -1564,7 +1658,10 @@ msgid ""
 "Apply %s with parameter(s)\n"
 "\n"
 "%s"
-msgstr "Zastosuj %s z parametrem(ami)\n\n%s"
+msgstr ""
+"Zastosuj %s z parametrem(ami)\n"
+"\n"
+"%s"
 
 #: src/BatchCommands.cpp
 msgid "Test Mode"
@@ -1733,8 +1830,7 @@ msgstr "Nazwa nowego makra"
 msgid "Name must not be blank"
 msgstr "Nazwa nie może być pusta"
 
-#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/'
-#. and '\'.
+#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/' and '\'.
 #: src/BatchProcessDialog.cpp
 #, c-format
 msgid "Names may not contain '%c' and '%c'"
@@ -1857,7 +1953,9 @@ msgstr "Wklej: %ld\n"
 msgid ""
 "Trial %d\n"
 "Failed on Paste.\n"
-msgstr "Próba %d\nNie udało się wkleić.\n"
+msgstr ""
+"Próba %d\n"
+"Nie udało się wkleić.\n"
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1914,7 +2012,9 @@ msgstr "Czas na sprawdzenie wszystkich danych (2): %ld ms\n"
 msgid ""
 "At 44100 Hz, 16-bits per sample, the estimated number of\n"
 " simultaneous tracks that could be played at once: %.1f\n"
-msgstr "Przy 44100 Hz, 16-bitowym próbkowaniu szacowana liczba\njednoczesnych ścieżek, które mogą być odtwarzane od razu: %.1f\n"
+msgstr ""
+"Przy 44100 Hz, 16-bitowym próbkowaniu szacowana liczba\n"
+"jednoczesnych ścieżek, które mogą być odtwarzane od razu: %.1f\n"
 
 #: src/Benchmark.cpp
 msgid "TEST FAILED!!!\n"
@@ -1924,71 +2024,88 @@ msgstr "TEST ZAKOŃCZONY NIEPOWODZENIEM!!!\n"
 msgid "Benchmark completed successfully.\n"
 msgstr "Benchmark został pomyślnie ukończony.\n"
 
-#. i18n-hint: %s will be replaced by the name of an action, such as Normalize,
-#. Cut, Fade.
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid ""
 "You must first select some audio for '%s' to act on.\n"
 "\n"
 "Ctrl + A selects all audio."
-msgstr "Najpierw musisz zaznaczyć dźwięk dla '%s', aby działać na nim.\n\nCtrl+A zaznacza cały dźwięk."
+msgstr ""
+"Najpierw musisz zaznaczyć dźwięk dla '%s', aby działać na nim.\n"
+"\n"
+"Ctrl+A zaznacza cały dźwięk."
 
-#. i18n-hint: %s will be replaced by the name of an action, such as Normalize,
-#. Cut, Fade.
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid ""
-"Select the audio for %s to use (for example, Cmd + A to Select All) then try"
-" again."
-msgstr "Zaznacz dźwięk dla %s, aby użyć (na przykład Cmd+A, aby zaznaczyć wszystko) i spróbuj ponownie."
+"Select the audio for %s to use (for example, Cmd + A to Select All) then try "
+"again."
+msgstr ""
+"Zaznacz dźwięk dla %s, aby użyć (na przykład Cmd+A, aby zaznaczyć wszystko) "
+"i spróbuj ponownie."
 
-#. i18n-hint: %s will be replaced by the name of an action, such as Normalize,
-#. Cut, Fade.
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid ""
 "Select the audio for %s to use (for example, Ctrl + A to Select All) then "
 "try again."
-msgstr "Zaznacz dźwięk dla %s, aby użyć (na przykład Ctrl+A, aby zaznaczyć wszystko) i spróbuj ponownie."
+msgstr ""
+"Zaznacz dźwięk dla %s, aby użyć (na przykład Ctrl+A, aby zaznaczyć wszystko) "
+"i spróbuj ponownie."
 
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Nie zaznaczono dźwięku"
 
-#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise
-#. Reduction'.
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid ""
 "Select the audio for %s to use.\n"
 "\n"
-"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"1. Select audio that represents noise and use %s to get your 'noise "
+"profile'.\n"
 "\n"
-"2. When you have got your noise profile, select the audio you want to change\n"
+"2. When you have got your noise profile, select the audio you want to "
+"change\n"
 "and use %s to change that audio."
-msgstr "Zaznacz dźwięk, z którego ma korzystać %s.\n\n1. Zaznacz dźwięk reprezentujący szum i użyj %s, aby uzyskać swój 'profil szumu'.\n\n2. Po uzyskaniu profilu szumu zaznacz dźwięk, który chcesz zmienić\ni użyj %s, aby zmienić ten dźwięk."
+msgstr ""
+"Zaznacz dźwięk, z którego ma korzystać %s.\n"
+"\n"
+"1. Zaznacz dźwięk reprezentujący szum i użyj %s, aby uzyskać swój 'profil "
+"szumu'.\n"
+"\n"
+"2. Po uzyskaniu profilu szumu zaznacz dźwięk, który chcesz zmienić\n"
+"i użyj %s, aby zmienić ten dźwięk."
 
 #: src/CommonCommandFlags.cpp
 msgid ""
 "You can only do this when playing and recording are\n"
 "stopped. (Pausing is not sufficient.)"
-msgstr "Możesz dokonać tego, gdy odtwarzanie i nagrywanie\nzostaną zatrzymane. (Wstrzymanie nie jest wystarczające.)"
+msgstr ""
+"Możesz dokonać tego, gdy odtwarzanie i nagrywanie\n"
+"zostaną zatrzymane. (Wstrzymanie nie jest wystarczające.)"
 
 #: src/CommonCommandFlags.cpp
 msgid ""
 "You must first select some stereo audio to perform this\n"
 "action. (You cannot use this with mono.)"
-msgstr "Najpierw musisz zaznaczyć dźwięk, aby wykonać to działanie.\n(Nie możesz użyć tego z mono.)"
+msgstr ""
+"Najpierw musisz zaznaczyć dźwięk, aby wykonać to działanie.\n"
+"(Nie możesz użyć tego z mono.)"
 
 #: src/CommonCommandFlags.cpp
 msgid ""
 "You must first select some audio to perform this action.\n"
 "(Selecting other kinds of track won't work.)"
-msgstr "Najpierw musisz zaznaczyć dźwięk, aby wykonać to działanie.\n(Zaznaczenie innych rodzajów ścieżki nie zadziała.)"
+msgstr ""
+"Najpierw musisz zaznaczyć dźwięk, aby wykonać to działanie.\n"
+"(Zaznaczenie innych rodzajów ścieżki nie zadziała.)"
 
-#. i18n-hint: %s will be replaced by the name of an action, such as "Remove
-#. Tracks".
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid "\"%s\" requires one or more tracks to be selected."
@@ -2018,7 +2135,9 @@ msgstr "Projekt zależy od innych plików dźwiękowych"
 msgid ""
 "Copying these files into your project will remove this dependency.\n"
 "This is safer, but needs more disk space."
-msgstr "Skopiowanie tych plików do Twojego projektu usunie ich zależności.\nJest to bezpieczniejsze, ale potrzebuje więcej przestrzeni na dysku."
+msgstr ""
+"Skopiowanie tych plików do Twojego projektu usunie ich zależności.\n"
+"Jest to bezpieczniejsze, ale potrzebuje więcej przestrzeni na dysku."
 
 #: src/Dependencies.cpp
 msgid ""
@@ -2026,7 +2145,12 @@ msgid ""
 "\n"
 "Files shown as MISSING have been moved or deleted and cannot be copied.\n"
 "Restore them to their original location to be able to copy into project."
-msgstr "\n\nPliki pokazane jako BRAKUJĄCE zostały przeniesione lub usunięte i nie mogą zostać skopiowane.\nPrzywróć je do ich pierwotnych położeń, aby móc je skopiować do projektu."
+msgstr ""
+"\n"
+"\n"
+"Pliki pokazane jako BRAKUJĄCE zostały przeniesione lub usunięte i nie mogą "
+"zostać skopiowane.\n"
+"Przywróć je do ich pierwotnych położeń, aby móc je skopiować do projektu."
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -2095,23 +2219,42 @@ msgstr "&Kopiuj nazwy do schowka"
 msgid ""
 "If you proceed, your project will not be saved to disk. Is this what you "
 "want?"
-msgstr "Jeśli będziesz kontynuować, Twój projekt nie zostanie zapisany na dysku. Chcesz to zrobić?"
+msgstr ""
+"Jeśli będziesz kontynuować, Twój projekt nie zostanie zapisany na dysku. "
+"Chcesz to zrobić?"
 
 #: src/Dependencies.cpp
 msgid ""
-"Your project is currently self-contained; it does not depend on any external audio files. \n"
+"Your project is currently self-contained; it does not depend on any external "
+"audio files. \n"
 "\n"
-"If you change the project to a state that has external dependencies on imported files, it will no longer be self-contained. If you then Save without copying those files in, you may lose data."
-msgstr "Twój projekt jest obecnie samowystarczalny; nie zależy on od żadnych zewnętrznych plików dźwiękowych. \n\nJeśli zmienisz projekt do stanu, w którym wystąpią zewnętrzne zależności w skutek zaimportowanych plików, to projekt przestanie być samowystarczalny. Jeśli później zapiszesz go bez skopiowania tych plików, to możesz utracić dane."
+"If you change the project to a state that has external dependencies on "
+"imported files, it will no longer be self-contained. If you then Save "
+"without copying those files in, you may lose data."
+msgstr ""
+"Twój projekt jest obecnie samowystarczalny; nie zależy on od żadnych "
+"zewnętrznych plików dźwiękowych. \n"
+"\n"
+"Jeśli zmienisz projekt do stanu, w którym wystąpią zewnętrzne zależności w "
+"skutek zaimportowanych plików, to projekt przestanie być samowystarczalny. "
+"Jeśli później zapiszesz go bez skopiowania tych plików, to możesz utracić "
+"dane."
 
 #: src/Dependencies.cpp
 msgid ""
-"Your project is self-contained; it does not depend on any external audio files. \n"
+"Your project is self-contained; it does not depend on any external audio "
+"files. \n"
 "\n"
 "Some older Audacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
-msgstr "Twój projekt jest obecnie samowystarczalny; nie zależy on od żadnych zewnętrznych plików dźwiękowych. \n\nNiektóre starsze projekty Audacity mogą być niesamodzielne i należy zachować ostrożność, aby utrzymać ich zewnętrzne zależności we właściwym miejscu.\nNowe projekty będą niezależne i mniej ryzykowne."
+msgstr ""
+"Twój projekt jest obecnie samowystarczalny; nie zależy on od żadnych "
+"zewnętrznych plików dźwiękowych. \n"
+"\n"
+"Niektóre starsze projekty Audacity mogą być niesamodzielne i należy zachować "
+"ostrożność, aby utrzymać ich zewnętrzne zależności we właściwym miejscu.\n"
+"Nowe projekty będą niezależne i mniej ryzykowne."
 
 #: src/Dependencies.cpp
 msgid "Dependency Check"
@@ -2127,7 +2270,9 @@ msgstr "Postęp"
 msgid ""
 "There is very little free disk space left on this volume.\n"
 "Please select another temporary directory in Preferences."
-msgstr "Pozostało bardzo mało wolnej przestrzeni na tym dysku.\nMusisz wybrać inny katalog tymczasowy w Ustawieniach."
+msgstr ""
+"Pozostało bardzo mało wolnej przestrzeni na tym dysku.\n"
+"Musisz wybrać inny katalog tymczasowy w Ustawieniach."
 
 #: src/DirManager.cpp
 msgid "Cleaning project temporary files"
@@ -2157,8 +2302,12 @@ msgstr "Niepowodzenie mkdir w DirManager::MakeBlockFilePath."
 #, c-format
 msgid ""
 "Audacity found an orphan block file: %s. \n"
-"Please consider saving and reloading the project to perform a complete project check."
-msgstr "Audacity znalazł odosobniony plik blokowy: %s. \nRozważ zapisanie i przeładowanie projektu, aby dokonać kompletnego sprawdzenia projektu."
+"Please consider saving and reloading the project to perform a complete "
+"project check."
+msgstr ""
+"Audacity znalazł odosobniony plik blokowy: %s. \n"
+"Rozważ zapisanie i przeładowanie projektu, aby dokonać kompletnego "
+"sprawdzenia projektu."
 
 #. i18n-hint: This is the pattern for filenames that are created
 #. * when a file needs to be backed up to a different name.  For
@@ -2313,7 +2462,12 @@ msgid ""
 "but this time Audacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
-msgstr "FFmpeg został wcześniej skonfigurowany w Ustawieniach i pomyślnie\nwczytany, ale tym razem nie udało się Audacity wczytać go przy starcie.\n\nMożesz rozważyć powrót do 'Ustawienia... > Biblioteki' i ponownie go skonfigurować."
+msgstr ""
+"FFmpeg został wcześniej skonfigurowany w Ustawieniach i pomyślnie\n"
+"wczytany, ale tym razem nie udało się Audacity wczytać go przy starcie.\n"
+"\n"
+"Możesz rozważyć powrót do 'Ustawienia... > Biblioteki' i ponownie go "
+"skonfigurować."
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg startup failed"
@@ -2330,7 +2484,8 @@ msgstr "Ustal położenie FFmpeg"
 #: src/FFmpeg.cpp
 #, c-format
 msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr "Audacity potrzebuje pliku '%s' do importu i eksportu dźwięku przez FFmpeg."
+msgstr ""
+"Audacity potrzebuje pliku '%s' do importu i eksportu dźwięku przez FFmpeg."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2375,7 +2530,12 @@ msgid ""
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
 "to download or locate the FFmpeg libraries."
-msgstr "Audacity usiłował użyć pakietu FFmpeg do zaimportowania\npliku dźwiękowego, ale nie znaleziono bibliotek.\n\nAby użyć importowania FFmpeg, idź do 'Edycja > Ustawienia... > Biblioteki',\naby pobrać lub ustalić położenie bibliotek FFmpeg."
+msgstr ""
+"Audacity usiłował użyć pakietu FFmpeg do zaimportowania\n"
+"pliku dźwiękowego, ale nie znaleziono bibliotek.\n"
+"\n"
+"Aby użyć importowania FFmpeg, idź do 'Edycja > Ustawienia... > Biblioteki',\n"
+"aby pobrać lub ustalić położenie bibliotek FFmpeg."
 
 #: src/FFmpeg.cpp
 msgid "Do not show this warning again"
@@ -2409,20 +2569,20 @@ msgstr "Audacity nie odczytał z pliku %s."
 msgid ""
 "Audacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full."
-msgstr "Audacity nie zapisał do pliku.\nMoże %s nie jest przeznaczony do zapisu lub dysk jest pełen."
+msgstr ""
+"Audacity nie zapisał do pliku.\n"
+"Może %s nie jest przeznaczony do zapisu lub dysk jest pełen."
 
 #: src/FileException.cpp
 #, c-format
-msgid ""
-"Audacity successfully wrote a file in %s but failed to rename it as %s."
+msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity pomyślnie zapisał plik w %s, ale nie zmienił nazwy na %s."
 
 #: src/FileException.h
 msgid "File Error"
 msgstr "Błąd pliku"
 
-#. i18n-hint: %s will be the error message from the libsndfile software
-#. library
+#. i18n-hint: %s will be the error message from the libsndfile software library
 #: src/FileFormats.cpp
 #, c-format
 msgid "Error (file may not have been written): %s"
@@ -2434,7 +2594,8 @@ msgstr "&Kopiuj nieskompresowane pliki do projektu (bezpieczniejsze)"
 
 #: src/FileFormats.cpp
 msgid "&Read uncompressed files from original location (faster)"
-msgstr "&Czytaj nieskompresowane pliki dźwiękowe z oryginalnej lokacji (szybsze)"
+msgstr ""
+"&Czytaj nieskompresowane pliki dźwiękowe z oryginalnej lokacji (szybsze)"
 
 #: src/FileFormats.cpp
 msgid "&Copy all audio into project (safest)"
@@ -2488,7 +2649,9 @@ msgstr "%s plików"
 #: src/FileNames.cpp
 msgid ""
 "The specified filename could not be converted due to Unicode character use."
-msgstr "Podana nazwa pliku nie może zostać przekształcona ze względu na użycie znaku z zestawu Unicode."
+msgstr ""
+"Podana nazwa pliku nie może zostać przekształcona ze względu na użycie znaku "
+"z zestawu Unicode."
 
 #: src/FileNames.cpp
 msgid "Specify New Filename:"
@@ -2598,16 +2761,19 @@ msgid "&Replot..."
 msgstr "&Przerysuj..."
 
 #: src/FreqWindow.cpp
-msgid ""
-"To plot the spectrum, all selected tracks must be the same sample rate."
-msgstr "Aby wykreślić widmo, wszystkie zaznaczone ścieżki muszą mieć tę samą częstotliwość próbkowania."
+msgid "To plot the spectrum, all selected tracks must be the same sample rate."
+msgstr ""
+"Aby wykreślić widmo, wszystkie zaznaczone ścieżki muszą mieć tę samą "
+"częstotliwość próbkowania."
 
 #: src/FreqWindow.cpp
 #, c-format
 msgid ""
 "Too much audio was selected. Only the first %.1f seconds of audio will be "
 "analyzed."
-msgstr "Zaznaczono za dużą próbkę dźwięku. Tylko pierwsze %.1f sekund zostanie przeanalizowane."
+msgstr ""
+"Zaznaczono za dużą próbkę dźwięku. Tylko pierwsze %.1f sekund zostanie "
+"przeanalizowane."
 
 #: src/FreqWindow.cpp
 msgid "Not enough data selected."
@@ -2618,30 +2784,26 @@ msgstr "Za mało zaznaczonych danych."
 msgid "s"
 msgstr "s"
 
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g.
-#. A#
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #: src/FreqWindow.cpp
 #, c-format
 msgid "%d Hz (%s) = %d dB"
 msgstr "%d Hz (%s) = %d dB"
 
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g.
-#. A#
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #: src/FreqWindow.cpp
 #, c-format
 msgid "%d Hz (%s) = %.1f dB"
 msgstr "%d Hz (%s) = %.1f dB"
 
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g.
-#. A#
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
 #, c-format
 msgid "%.4f sec (%d Hz) (%s) = %f"
 msgstr "%.4f sek. (%d Hz) (%s) = %f"
 
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g.
-#. A#
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
 #, c-format
@@ -2738,14 +2900,18 @@ msgstr "Brak lokalnej pomocy"
 
 #: src/HelpText.cpp
 msgid ""
-"<br><br>The version of Audacity you are using is an <b>Alpha test "
-"version</b>."
-msgstr "<br><br>Wersja programu Audacity, którą używasz, to <b>wersja testowa alpha</b>."
+"<br><br>The version of Audacity you are using is an <b>Alpha test version</"
+"b>."
+msgstr ""
+"<br><br>Wersja programu Audacity, którą używasz, to <b>wersja testowa alpha</"
+"b>."
 
 #: src/HelpText.cpp
 msgid ""
 "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
-msgstr "<br><br>Wersja programu Audacity, którą używasz, to <b>wersja testowa beta</b>."
+msgstr ""
+"<br><br>Wersja programu Audacity, którą używasz, to <b>wersja testowa beta</"
+"b>."
 
 #: src/HelpText.cpp
 msgid "Get the Official Released Version of Audacity"
@@ -2753,15 +2919,19 @@ msgstr "Pobierz oficjalną wersję Audacity"
 
 #: src/HelpText.cpp
 msgid ""
-"We strongly recommend that you use our latest stable released version, which"
-" has full documentation and support.<br><br>"
-msgstr "Zdecydowanie zalecamy korzystać z naszej najnowszej stabilnej wersji, która zawiera pełną dokumentację i wsparcie.<br><br>"
+"We strongly recommend that you use our latest stable released version, which "
+"has full documentation and support.<br><br>"
+msgstr ""
+"Zdecydowanie zalecamy korzystać z naszej najnowszej stabilnej wersji, która "
+"zawiera pełną dokumentację i wsparcie.<br><br>"
 
 #: src/HelpText.cpp
 msgid ""
-"You can help us get Audacity ready for release by joining our "
-"[[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr "Możesz pomóc nam stworzyć gotowego do wydania Audacity, dołączając do naszej [[https://www.audacityteam.org/community/|społeczności]].<hr><br><br>"
+"You can help us get Audacity ready for release by joining our [[https://www."
+"audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+"Możesz pomóc nam stworzyć gotowego do wydania Audacity, dołączając do naszej "
+"[[https://www.audacityteam.org/community/|społeczności]].<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2774,61 +2944,85 @@ msgstr "To są nasze metody wsparcia:"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid ""
-"[[help:Quick_Help|Quick Help]] - if not installed locally, "
-"[[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr "[[help:Quick_Help|Quick Help]] - jeśli nie jest zainstalowana lokalnie, [[https://manual.audacityteam.org/quick_help.html|zobacz online]]"
+"[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual."
+"audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+"[[help:Quick_Help|Quick Help]] - jeśli nie jest zainstalowana lokalnie, "
+"[[https://manual.audacityteam.org/quick_help.html|zobacz online]]"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid ""
-" [[help:Main_Page|Manual]] - if not installed locally, "
-"[[https://manual.audacityteam.org/|view online]]"
-msgstr "[[help:Main_Page|Manual]] - jeśli nie jest zainstalowana lokalnie, [[https://manual.audacityteam.org/|zobacz online]]"
+" [[help:Main_Page|Manual]] - if not installed locally, [[https://manual."
+"audacityteam.org/|view online]]"
+msgstr ""
+"[[help:Main_Page|Manual]] - jeśli nie jest zainstalowana lokalnie, [[https://"
+"manual.audacityteam.org/|zobacz online]]"
 
 #: src/HelpText.cpp
 msgid ""
 " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, "
 "online."
-msgstr " [[https://forum.audacityteam.org/|Forum]] - zadaj swoje pytanie bezpośrednio w Internecie"
+msgstr ""
+" [[https://forum.audacityteam.org/|Forum]] - zadaj swoje pytanie "
+"bezpośrednio w Internecie"
 
 #: src/HelpText.cpp
 msgid ""
 "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for "
 "tips, tricks, extra tutorials and effects plug-ins."
-msgstr "Więcej:</b> Odwiedź naszą [[https://wiki.audacityteam.org/index.php|wiki]], gdzie znajdziesz wskazówki, triki, samouczki i wtyczki."
+msgstr ""
+"Więcej:</b> Odwiedź naszą [[https://wiki.audacityteam.org/index.php|wiki]], "
+"gdzie znajdziesz wskazówki, triki, samouczki i wtyczki."
 
 #: src/HelpText.cpp
 msgid ""
-"Audacity can import unprotected files in many other formats (such as M4A and"
-" WMA, compressed WAV files from portable recorders and audio from video "
-"files) if you download and install the optional "
-"[[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign|"
-" FFmpeg library]] to your computer."
-msgstr "Audacity może zaimportować niechronione pliki w wielu formatach (takich jak M4A i WMA, skompresowane pliki WAV z podręcznych dyktafonów i dźwięki z filmów), jeśli tylko na swoim komputerze, pobierzesz i zainstalujesz opcjonalną [[https://manual.audacityteam.org/o/man/faq_opening_and_saving_files.html#foreign|bibliotekę FFmpeg]]."
+"Audacity can import unprotected files in many other formats (such as M4A and "
+"WMA, compressed WAV files from portable recorders and audio from video "
+"files) if you download and install the optional [[https://manual."
+"audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg "
+"library]] to your computer."
+msgstr ""
+"Audacity może zaimportować niechronione pliki w wielu formatach (takich jak "
+"M4A i WMA, skompresowane pliki WAV z podręcznych dyktafonów i dźwięki z "
+"filmów), jeśli tylko na swoim komputerze, pobierzesz i zainstalujesz "
+"opcjonalną [[https://manual.audacityteam.org/o/man/"
+"faq_opening_and_saving_files.html#foreign|bibliotekę FFmpeg]]."
 
 #: src/HelpText.cpp
 msgid ""
-"You can also read our help on importing "
-"[[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI "
-"files]] and tracks from "
-"[[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd|"
-" audio CDs]]."
-msgstr "Możesz także przeczytać naszą pomoc na temat importowania [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|plików MIDI]] i ścieżek z [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd|płyt CD]]."
+"You can also read our help on importing [[https://manual.audacityteam.org/"
+"man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://"
+"manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio "
+"CDs]]."
+msgstr ""
+"Możesz także przeczytać naszą pomoc na temat importowania [[https://manual."
+"audacityteam.org/man/playing_and_recording.html#midi|plików MIDI]] i ścieżek "
+"z [[https://manual.audacityteam.org/man/faq_opening_and_saving_files."
+"html#fromcd|płyt CD]]."
 
 #: src/HelpText.cpp
 msgid ""
 "The Manual does not appear to be installed. Please [[*URL*|view the Manual "
 "online]].<br><br>To always view the Manual online, change \"Location of "
 "Manual\" in Interface Preferences to \"From Internet\"."
-msgstr "Podręcznik wydaje się być niezainstalowany. [[*URL*|Zobacz Podręcznik online]].<br><br>Aby zawsze móc korzystać z Podręcznika online, zmień \"Lokalizację Podręcznika\" w Ustawieniach interfejsu na \"Z Internetu\"."
+msgstr ""
+"Podręcznik wydaje się być niezainstalowany. [[*URL*|Zobacz Podręcznik "
+"online]].<br><br>Aby zawsze móc korzystać z Podręcznika online, zmień "
+"\"Lokalizację Podręcznika\" w Ustawieniach interfejsu na \"Z Internetu\"."
 
 #: src/HelpText.cpp
 msgid ""
 "The Manual does not appear to be installed. Please [[*URL*|view the Manual "
-"online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html|"
-" download the Manual]].<br><br>To always view the Manual online, change "
+"online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| "
+"download the Manual]].<br><br>To always view the Manual online, change "
 "\"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr "Podręcznik wydaje się być niezainstalowany. [[*URL*|Zobacz Podręcznik online]] lub [[https://manual.audacityteam.org/o/man/unzipping_the_manual.html|pobierz Podręcznik]].<br><br>Aby zawsze móc korzystać z Podręcznika online, zmień \"Lokalizację Podręcznika\" w Ustawieniach interfejsu na \"Z Internetu\"."
+msgstr ""
+"Podręcznik wydaje się być niezainstalowany. [[*URL*|Zobacz Podręcznik "
+"online]] lub [[https://manual.audacityteam.org/o/man/unzipping_the_manual."
+"html|pobierz Podręcznik]].<br><br>Aby zawsze móc korzystać z Podręcznika "
+"online, zmień \"Lokalizację Podręcznika\" w Ustawieniach interfejsu na \"Z "
+"Internetu\"."
 
 #: src/HelpText.cpp
 msgid "Check Online"
@@ -2890,14 +3084,18 @@ msgstr "&Historia..."
 msgid ""
 "Internal error in %s at %s line %d.\n"
 "Please inform the Audacity team at https://forum.audacityteam.org/."
-msgstr "Błąd wewnętrzny w %s w %s, linia %d.\nPoinformuj zespół Audacity przez https://forum.audacityteam.org/."
+msgstr ""
+"Błąd wewnętrzny w %s w %s, linia %d.\n"
+"Poinformuj zespół Audacity przez https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
 #, c-format
 msgid ""
 "Internal error at %s line %d.\n"
 "Please inform the Audacity team at https://forum.audacityteam.org/."
-msgstr "Błąd wewnętrzny w %s, linia %d.\nPoinformuj zespół Audacity przez https://forum.audacityteam.org/."
+msgstr ""
+"Błąd wewnętrzny w %s, linia %d.\n"
+"Poinformuj zespół Audacity przez https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -2967,7 +3165,8 @@ msgstr "Nowy..."
 
 #: src/LabelDialog.cpp
 msgid "Press F2 or double click to edit cell contents."
-msgstr "Naciśnij F2 lub kliknij podwójnie myszką, aby edytować zawartość komórek."
+msgstr ""
+"Naciśnij F2 lub kliknij podwójnie myszką, aby edytować zawartość komórek."
 
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Select a text file containing labels"
@@ -3023,7 +3222,9 @@ msgstr "Wybierz język używany w Audacity:"
 msgid ""
 "The language you have chosen, %s (%s), is not the same as the system "
 "language, %s (%s)."
-msgstr "Wybrany przez Ciebie język %s (%s), nie jest taki sam jak język systemowy %s (%s)."
+msgstr ""
+"Wybrany przez Ciebie język %s (%s), nie jest taki sam jak język systemowy %s "
+"(%s)."
 
 #: src/Languages.cpp
 msgid "Simplified"
@@ -3042,7 +3243,9 @@ msgstr "Błąd konwertowania starszego pliku projektu"
 msgid ""
 "Converted a 1.0 project file to the new format.\n"
 "The old file has been saved as '%s'"
-msgstr "Przekształcono projekt w formacie 1.0 do nowego formatu.\nStary plik został zapisany jako '%s'"
+msgstr ""
+"Przekształcono projekt w formacie 1.0 do nowego formatu.\n"
+"Stary plik został zapisany jako '%s'"
 
 #: src/Legacy.cpp
 msgid "Opening Audacity Project"
@@ -3065,9 +3268,10 @@ msgstr "Grupa wtyczki %s została połączona z wcześniej zdefiniowaną grupą"
 #: src/Menus.cpp
 #, c-format
 msgid ""
-"Plug-in item at %s conflicts with a previously defined item and was "
-"discarded"
-msgstr "Element wtyczki %s powoduje konflikt z wcześniej zdefiniowanym elementem i został odrzucony"
+"Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+"Element wtyczki %s powoduje konflikt z wcześniej zdefiniowanym elementem i "
+"został odrzucony"
 
 #: src/Menus.cpp
 #, c-format
@@ -3096,7 +3300,9 @@ msgstr "&Ponów"
 msgid ""
 "There was a problem with your last action. If you think\n"
 "this is a bug, please tell us exactly where it occurred."
-msgstr "Wystąpił problem z Twoim ostatnim działaniem. Jeśli myślisz,\nże jest to błąd, to powiedz nam dokładnie, co się stało."
+msgstr ""
+"Wystąpił problem z Twoim ostatnim działaniem. Jeśli myślisz,\n"
+"że jest to błąd, to powiedz nam dokładnie, co się stało."
 
 #: src/Menus.cpp
 msgid "Disallowed"
@@ -3123,8 +3329,7 @@ msgid "Gain"
 msgstr "Wzmocnienie"
 
 #. i18n-hint: title of the MIDI Velocity slider
-#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note
-#. tracks
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
 #: src/MixerBoard.cpp
 #: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
 #: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
@@ -3190,7 +3395,10 @@ msgid ""
 "Unable to load the \"%s\" module.\n"
 "\n"
 "Error: %s"
-msgstr "Nie można załadować modułu \"%s\".\n\nBłąd: %s"
+msgstr ""
+"Nie można załadować modułu \"%s\".\n"
+"\n"
+"Błąd: %s"
 
 #: src/ModuleManager.cpp
 msgid "Module Unsuitable"
@@ -3207,7 +3415,10 @@ msgid ""
 "The module \"%s\" does not provide a version string.\n"
 "\n"
 "It will not be loaded."
-msgstr "Moduł \"%s\" nie zawiera ciągu wersji.\n\nNie zostanie załadowany."
+msgstr ""
+"Moduł \"%s\" nie zawiera ciągu wersji.\n"
+"\n"
+"Nie zostanie załadowany."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3221,14 +3432,18 @@ msgid ""
 "The module \"%s\" is matched with Audacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
-msgstr "Moduł \"%s\" jest zgodny z wersją \"%s\" Audacity.\n\nNie zostanie załadowany."
+msgstr ""
+"Moduł \"%s\" jest zgodny z wersją \"%s\" Audacity.\n"
+"\n"
+"Nie zostanie załadowany."
 
 #: src/ModuleManager.cpp
 #, c-format
 msgid ""
 "The module \"%s\" is matched with Audacity version \"%s\". It will not be "
 "loaded."
-msgstr "Moduł \"%s\" jest zgodny z wersją \"%s\" Audacity. Nie zostanie załadowany."
+msgstr ""
+"Moduł \"%s\" jest zgodny z wersją \"%s\" Audacity. Nie zostanie załadowany."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3236,14 +3451,19 @@ msgid ""
 "The module \"%s\" failed to initialize.\n"
 "\n"
 "It will not be loaded."
-msgstr "Nie można zainicjować modułu \"%s\".\n\nNie zostanie załadowany."
+msgstr ""
+"Nie można zainicjować modułu \"%s\".\n"
+"\n"
+"Nie zostanie załadowany."
 
 #: src/ModuleManager.cpp
 #, c-format
 msgid ""
 "The module \"%s\" failed to initialize.\n"
 "It will not be loaded."
-msgstr "Nie można zainicjować modułu \"%s\".\nNie zostanie załadowany."
+msgstr ""
+"Nie można zainicjować modułu \"%s\".\n"
+"Nie zostanie załadowany."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -3255,7 +3475,10 @@ msgid ""
 "\n"
 "\n"
 "Only use modules from trusted sources"
-msgstr "\n\nUżywaj modułów tylko z zaufanych źródeł"
+msgstr ""
+"\n"
+"\n"
+"Używaj modułów tylko z zaufanych źródeł"
 
 #: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
 #: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
@@ -3281,14 +3504,19 @@ msgid ""
 "The module \"%s\" does not provide any of the required functions.\n"
 "\n"
 "It will not be loaded."
-msgstr "Moduł \"%s\" nie zapewnia żadnej z wymaganych funkcji.\n\nNie zostanie załadowany."
+msgstr ""
+"Moduł \"%s\" nie zapewnia żadnej z wymaganych funkcji.\n"
+"\n"
+"Nie zostanie załadowany."
 
 #: src/ModuleManager.cpp
 #, c-format
 msgid ""
 "The module \"%s\" does not provide any of the required functions. It will "
 "not be loaded."
-msgstr "Moduł \"%s\" nie zapewnia żadnej z wymaganych funkcji. Nie zostanie załadowany."
+msgstr ""
+"Moduł \"%s\" nie zapewnia żadnej z wymaganych funkcji. Nie zostanie "
+"załadowany."
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -3381,32 +3609,27 @@ msgstr "A♭"
 msgid "B♭"
 msgstr "B♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
-#. scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "C♯/D♭"
 msgstr "C♯/D♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
-#. scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "D♯/E♭"
 msgstr "D♯/E♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
-#. scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "F♯/G♭"
 msgstr "F♯/G♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
-#. scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "G♯/A♭"
 msgstr "G♯/A♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
-#. scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "A♯/B♭"
 msgstr "A♯/B♭"
@@ -3417,7 +3640,9 @@ msgstr "Zarządzaj wtyczkami"
 
 #: src/PluginManager.cpp
 msgid "Select effects, click the Enable or Disable button, then click OK."
-msgstr "Wybierz efekty, kliknij przycisk Włącz lub Wyłącz, a następnie kliknij na przycisk OK."
+msgstr ""
+"Wybierz efekty, kliknij przycisk Włącz lub Wyłącz, a następnie kliknij na "
+"przycisk OK."
 
 #. i18n-hint: This is before radio buttons selecting which effects to show
 #: src/PluginManager.cpp
@@ -3494,7 +3719,10 @@ msgid ""
 "Enabling effects or commands:\n"
 "\n"
 "%s"
-msgstr "Włączone efekty lub polecenia:\n\n%s"
+msgstr ""
+"Włączone efekty lub polecenia:\n"
+"\n"
+"%s"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3502,14 +3730,19 @@ msgid ""
 "Enabling effect or command:\n"
 "\n"
 "%s"
-msgstr "Włączony efekt lub polecenie:\n\n%s"
+msgstr ""
+"Włączony efekt lub polecenie:\n"
+"\n"
+"%s"
 
 #: src/PluginManager.cpp
 #, c-format
 msgid ""
 "Effect or Command at %s failed to register:\n"
 "%s"
-msgstr "Efekt lub polecenie %s nie powiodły się:\n%s"
+msgstr ""
+"Efekt lub polecenie %s nie powiodły się:\n"
+"%s"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3529,7 +3762,9 @@ msgstr "Plik wtyczki jest w użyciu. Nie udało się nadpisać"
 msgid ""
 "Failed to register:\n"
 "%s"
-msgstr "Błąd przy rejestracji:\n%s"
+msgstr ""
+"Błąd przy rejestracji:\n"
+"%s"
 
 #: src/PluginManager.cpp
 msgid "Enable this plug-in?\n"
@@ -3546,7 +3781,9 @@ msgstr "Włącz nowe wtyczki"
 #: src/Prefs.cpp
 #, c-format
 msgid "Audacity cannot start because the settings file at %s is not writable."
-msgstr "Audacity nie może się uruchomić, ponieważ plik ustawień %s nie jest przeznaczony do zapisu."
+msgstr ""
+"Audacity nie może się uruchomić, ponieważ plik ustawień %s nie jest "
+"przeznaczony do zapisu."
 
 #: src/Printing.cpp
 msgid "There was a problem printing."
@@ -3565,7 +3802,32 @@ msgstr "Obecne próbkowanie: %d"
 msgid ""
 "Error opening sound device.\n"
 "Try changing the audio host, playback device and the project sample rate."
-msgstr "Błąd otwierania urządzenia dźwiękowego.\nSpróbuj zmienić host dźwięku, urządzenie odtwarzające dźwięk i częstotliwość próbkowania projektu."
+msgstr ""
+"Błąd otwierania urządzenia dźwiękowego.\n"
+"Spróbuj zmienić host dźwięku, urządzenie odtwarzające dźwięk i częstotliwość "
+"próbkowania projektu."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Aby zastosować filtr, wszystkie wybrane ścieżki muszą mieć tę samą "
+"częstotliwość próbkowania."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
 
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
@@ -3583,7 +3845,12 @@ msgid ""
 "Other applications are competing with Audacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
-msgstr "Nagrany dźwięk zaginął w oznaczonych miejscach. Możliwe przyczyny:\n\nInne aplikacje konkurują z Audacity o czas procesora\n\nZapisujesz bezpośrednio na wolnym zewnętrznym urządzeniu magazynującym\n"
+msgstr ""
+"Nagrany dźwięk zaginął w oznaczonych miejscach. Możliwe przyczyny:\n"
+"\n"
+"Inne aplikacje konkurują z Audacity o czas procesora\n"
+"\n"
+"Zapisujesz bezpośrednio na wolnym zewnętrznym urządzeniu magazynującym\n"
 
 #: src/ProjectAudioManager.cpp
 msgid "Turn off dropout detection"
@@ -3613,9 +3880,12 @@ msgstr "Natychmiast zamknij projekt bez zmian"
 #: src/ProjectFSCK.cpp
 msgid ""
 "Continue with repairs noted in log, and check for more errors. This will "
-"save the project in its current state, unless you \"Close project "
-"immediately\" on further error alerts."
-msgstr "Kontynuuj z naprawami wymienionymi w dzienniku i poszukaj kolejnych błędów. Zapisze to projekt w jego obecnym stanie, chyba że \"Zamkniesz projekt natychmiastowo\" przy przyszłych ostrzeżeniach o błędach."
+"save the project in its current state, unless you \"Close project immediately"
+"\" on further error alerts."
+msgstr ""
+"Kontynuuj z naprawami wymienionymi w dzienniku i poszukaj kolejnych błędów. "
+"Zapisze to projekt w jego obecnym stanie, chyba że \"Zamkniesz projekt "
+"natychmiastowo\" przy przyszłych ostrzeżeniach o błędach."
 
 #: src/ProjectFSCK.cpp
 msgid "Warning - Problems Reading Sequence Tags"
@@ -3639,7 +3909,22 @@ msgid ""
 "If you choose the third option, this will save the \n"
 "project in its current state, unless you \"Close \n"
 "project immediately\" on further error alerts."
-msgstr "Sprawdzanie projektu folderu \"%s\" \nwykryło %lld brakujący(ch) zewnętrzny(ch) plik(ów) dźwiękowy(ch) \n('pliki aliasowe'). Audacity nie ma możliwości \nodzyskania tych plików samoczynnie. \n\nJeśli wybierzesz pierwszą lub drugą opcję poniżej, \nto możesz spróbować znaleźć i przywrócić brakujące pliki \nna ich poprzednie położenia. \n\nZauważ, że dla drugiej opcji, kształt fali \nmoże nie pokazywać ciszy. \n\nJeśli wybierzesz trzecią opcję, to zapiszesz projekt \nw jego obecnym stanie, chyba że \"Zamkniesz \nprojekt natychmiastowo\" przy przyszłych ostrzeżeniach o błędach."
+msgstr ""
+"Sprawdzanie projektu folderu \"%s\" \n"
+"wykryło %lld brakujący(ch) zewnętrzny(ch) plik(ów) dźwiękowy(ch) \n"
+"('pliki aliasowe'). Audacity nie ma możliwości \n"
+"odzyskania tych plików samoczynnie. \n"
+"\n"
+"Jeśli wybierzesz pierwszą lub drugą opcję poniżej, \n"
+"to możesz spróbować znaleźć i przywrócić brakujące pliki \n"
+"na ich poprzednie położenia. \n"
+"\n"
+"Zauważ, że dla drugiej opcji, kształt fali \n"
+"może nie pokazywać ciszy. \n"
+"\n"
+"Jeśli wybierzesz trzecią opcję, to zapiszesz projekt \n"
+"w jego obecnym stanie, chyba że \"Zamkniesz \n"
+"projekt natychmiastowo\" przy przyszłych ostrzeżeniach o błędach."
 
 #: src/ProjectFSCK.cpp
 msgid "Treat missing audio as silence (this session only)"
@@ -3664,7 +3949,11 @@ msgid ""
 "detected %lld missing alias (.auf) blockfile(s). \n"
 "Audacity can fully regenerate these files \n"
 "from the current audio in the project."
-msgstr "Sprawdzanie projektu folderu \"%s\" \nwykryło %lld brakujący(ch) alias(ów) (.auf) pliku(ów) blokowego(ych). \nAudacity może w pełni zregenerować te pliki \nz bieżącego dźwięku w projekcie."
+msgstr ""
+"Sprawdzanie projektu folderu \"%s\" \n"
+"wykryło %lld brakujący(ch) alias(ów) (.auf) pliku(ów) blokowego(ych). \n"
+"Audacity może w pełni zregenerować te pliki \n"
+"z bieżącego dźwięku w projekcie."
 
 #: src/ProjectFSCK.cpp
 msgid "Regenerate alias summary files (safe and recommended)"
@@ -3684,7 +3973,9 @@ msgstr "Ostrzeżenie - Brakuje pliku(ów) podsumowania z aliasami"
 
 #: src/ProjectFSCK.cpp
 msgid "   Project check regenerated missing alias summary file(s)."
-msgstr "Sprawdzanie projektu zregenerowało brakujący(e) plik(i) aliasowy(e) podsumowania."
+msgstr ""
+"Sprawdzanie projektu zregenerowało brakujący(e) plik(i) aliasowy(e) "
+"podsumowania."
 
 #: src/ProjectFSCK.cpp
 #, c-format
@@ -3701,7 +3992,20 @@ msgid ""
 "\n"
 "Note that for the second option, the waveform \n"
 "may not show silence."
-msgstr "Sprawdzanie projektu folderu \"%s\" \nwykryło %lld brakujące(ych) dane(ych) dźwiękowe(ych) (.au) pliku(ów) blokowego(ych), \nprawdopodobnie ze względu na błąd, awarię systemu lub przypadkowe \nusunięcie. Audacity nie może przywrócić tych plików \nsamoczynnie. \n\nJeśli wybierzesz pierwszą lub drugą opcję poniżej, \nto możesz spróbować znaleźć i przywrócić brakujące pliki \nna ich poprzednie położenia. \n\nZauważ, że dla drugiej opcji, kształt fali \nmoże nie pokazywać ciszy."
+msgstr ""
+"Sprawdzanie projektu folderu \"%s\" \n"
+"wykryło %lld brakujące(ych) dane(ych) dźwiękowe(ych) (.au) pliku(ów) "
+"blokowego(ych), \n"
+"prawdopodobnie ze względu na błąd, awarię systemu lub przypadkowe \n"
+"usunięcie. Audacity nie może przywrócić tych plików \n"
+"samoczynnie. \n"
+"\n"
+"Jeśli wybierzesz pierwszą lub drugą opcję poniżej, \n"
+"to możesz spróbować znaleźć i przywrócić brakujące pliki \n"
+"na ich poprzednie położenia. \n"
+"\n"
+"Zauważ, że dla drugiej opcji, kształt fali \n"
+"może nie pokazywać ciszy."
 
 #: src/ProjectFSCK.cpp
 msgid "Replace missing audio with silence (permanent immediately)"
@@ -3714,13 +4018,17 @@ msgstr "Ostrzeżenie - Brakuje pliku(ów) blokowego(ych) danych dźwiękowych"
 #: src/ProjectFSCK.cpp
 msgid ""
 "   Project check replaced missing audio data block file(s) with silence."
-msgstr "Sprawdzanie projektu zastąpiło brakujące dane dźwiękowe pliku(ów) blokowego(ych) ciszą."
+msgstr ""
+"Sprawdzanie projektu zastąpiło brakujące dane dźwiękowe pliku(ów) "
+"blokowego(ych) ciszą."
 
 #: src/ProjectFSCK.cpp
 msgid ""
 "   Project check ignored orphan block file(s). They will be deleted when "
 "project is saved."
-msgstr "Sprawdzanie projektu zignorowało porzucony(e) plik(i) blokowy(e). Zostaną one usunięte, gdy projekt zostanie zapisany."
+msgstr ""
+"Sprawdzanie projektu zignorowało porzucony(e) plik(i) blokowy(e). Zostaną "
+"one usunięte, gdy projekt zostanie zapisany."
 
 #: src/ProjectFSCK.cpp
 #, c-format
@@ -3729,7 +4037,11 @@ msgid ""
 "found %d orphan block file(s). These files are \n"
 "unused by this project, but might belong to other projects. \n"
 "They are doing no harm and are small."
-msgstr "Sprawdzanie projektu folderu \"%s\" \nznalazło %d porzucony(ch) plik(ów) blokowy(ch). Pliki te są nieużywane \nprzez ten projekt, ale mogą należeć do innych projektów. \nNie wadzą one nikomu i są małe."
+msgstr ""
+"Sprawdzanie projektu folderu \"%s\" \n"
+"znalazło %d porzucony(ch) plik(ów) blokowy(ch). Pliki te są nieużywane \n"
+"przez ten projekt, ale mogą należeć do innych projektów. \n"
+"Nie wadzą one nikomu i są małe."
 
 #: src/ProjectFSCK.cpp
 msgid "Continue without deleting; ignore the extra files this session"
@@ -3750,22 +4062,33 @@ msgstr "Usuwanie nieużywanych katalogów w danych projektu"
 #: src/ProjectFSCK.cpp
 msgid ""
 "Project check found file inconsistencies inspecting the loaded project data."
-msgstr "Sprawdzanie projektu wykazało niezgodności przy inspekcji wczytanych danych projektu."
+msgstr ""
+"Sprawdzanie projektu wykazało niezgodności przy inspekcji wczytanych danych "
+"projektu."
 
 #: src/ProjectFSCK.cpp
 msgid ""
 "Project check found file inconsistencies during automatic recovery.\n"
 "\n"
 "Select 'Help > Diagnostics > Show Log...' to see details."
-msgstr "Sprawdzanie projektu znalazło nieciągłości w plikach podczas samoczynnego odzyskiwania.\n\nWybierz 'Pomoc > Diagnostyka > Pokaż dziennik...', aby zobaczyć szczegóły."
+msgstr ""
+"Sprawdzanie projektu znalazło nieciągłości w plikach podczas samoczynnego "
+"odzyskiwania.\n"
+"\n"
+"Wybierz 'Pomoc > Diagnostyka > Pokaż dziennik...', aby zobaczyć szczegóły."
 
 #: src/ProjectFSCK.cpp
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Ostrzeżenie - Problemy z samoczynnym odzyskiwaniem"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<untitled>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -3786,10 +4109,22 @@ msgid ""
 "Audacity can try to open and save this file, but saving it in this \n"
 "version will then prevent any 1.2 or earlier version opening it. \n"
 "\n"
-"Audacity might corrupt the file in opening it, so you should back it up first. \n"
+"Audacity might corrupt the file in opening it, so you should back it up "
+"first. \n"
 "\n"
 "Open this file now?"
-msgstr "Ten plik został zapisany przy użyciu Audacity w wersji %s. Format został zmieniony. \n\nAudacity może spróbować otworzyć i zapisać ten plik, ale zapisanie go w tej wersji \nuniemożliwi otwarcie go w jakiejkolwiek wersji 1.2 lub wcześniejszej. \n\nAudacity może także uszkodzić plik przy jego otwieraniu, tak więc najpierw powinieneś zrobić jego kopię zapasową. \n\nOtworzyć teraz ten plik?"
+msgstr ""
+"Ten plik został zapisany przy użyciu Audacity w wersji %s. Format został "
+"zmieniony. \n"
+"\n"
+"Audacity może spróbować otworzyć i zapisać ten plik, ale zapisanie go w tej "
+"wersji \n"
+"uniemożliwi otwarcie go w jakiejkolwiek wersji 1.2 lub wcześniejszej. \n"
+"\n"
+"Audacity może także uszkodzić plik przy jego otwieraniu, tak więc najpierw "
+"powinieneś zrobić jego kopię zapasową. \n"
+"\n"
+"Otworzyć teraz ten plik?"
 
 #: src/ProjectFileIO.cpp
 msgid "1.0 or earlier"
@@ -3817,8 +4152,12 @@ msgstr "Błąd otwierania projektu"
 #, c-format
 msgid ""
 "This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
-msgstr "Plik został zapisany przy użyciu Audacity %s.\nUżywasz Audacity %s - powinieneś uaktualnić do nowszej wersji, aby otworzyć ten plik."
+"You are using Audacity %s. You may need to upgrade to a newer version to "
+"open this file."
+msgstr ""
+"Plik został zapisany przy użyciu Audacity %s.\n"
+"Używasz Audacity %s - powinieneś uaktualnić do nowszej wersji, aby otworzyć "
+"ten plik."
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
@@ -3848,7 +4187,15 @@ msgid ""
 "are open, then File > Save Project.\n"
 "\n"
 "Save anyway?"
-msgstr "Twój projekt jest pusty.\nJeśli go zapiszesz, nie będzie miał żadnych ścieżek.\n\nAby zapisać poprzednio otwarte ścieżki:\nKliknij 'Nie', 'Edycja > Cofnij', aż wszystkie ścieżki\nbędą otwarte, następnie 'Plik > Zapisz projekt'.\n\nZapisać mimo wszystko?"
+msgstr ""
+"Twój projekt jest pusty.\n"
+"Jeśli go zapiszesz, nie będzie miał żadnych ścieżek.\n"
+"\n"
+"Aby zapisać poprzednio otwarte ścieżki:\n"
+"Kliknij 'Nie', 'Edycja > Cofnij', aż wszystkie ścieżki\n"
+"będą otwarte, następnie 'Plik > Zapisz projekt'.\n"
+"\n"
+"Zapisać mimo wszystko?"
 
 #: src/ProjectFileManager.cpp
 msgid "Warning - Empty Project"
@@ -3859,7 +4206,9 @@ msgstr "Ostrzeżenie - Pusty projekt"
 msgid ""
 "Audacity failed to write file %s.\n"
 "Perhaps disk is full or not writable."
-msgstr "Audacity nie zapisał do pliku %s.\nMoże dysk jest pełen lub nie jest przeznaczony do zapisu."
+msgstr ""
+"Audacity nie zapisał do pliku %s.\n"
+"Może dysk jest pełen lub nie jest przeznaczony do zapisu."
 
 #: src/ProjectFileManager.cpp
 msgid "Error Writing to File"
@@ -3870,7 +4219,9 @@ msgstr "Błąd zapisywania do pliku"
 msgid ""
 "Could not save project. Perhaps %s \n"
 "is not writable or the disk is full."
-msgstr "Nie można zapisać projektu. Może %s \nnie jest przeznaczony do zapisu lub dysk jest pełen."
+msgstr ""
+"Nie można zapisać projektu. Może %s \n"
+"nie jest przeznaczony do zapisu lub dysk jest pełen."
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Project"
@@ -3881,7 +4232,9 @@ msgstr "Błąd zapisywania projektu"
 msgid ""
 "Could not save project. Path not found. Try creating \n"
 "directory \"%s\" before saving project with this name."
-msgstr "Nie można zapisać projektu. Nie znaleziono ścieżki. Spróbuj utworzyć \nkatalog \"%s\" przed zapisaniem projektu pod tą nazwą."
+msgstr ""
+"Nie można zapisać projektu. Nie znaleziono ścieżki. Spróbuj utworzyć \n"
+"katalog \"%s\" przed zapisaniem projektu pod tą nazwą."
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -3890,9 +4243,13 @@ msgstr "Zapisano %s"
 
 #: src/ProjectFileManager.cpp
 msgid ""
-"The project was not saved because the file name provided would overwrite another project.\n"
+"The project was not saved because the file name provided would overwrite "
+"another project.\n"
 "Please try again and select an original name."
-msgstr "Projekt nie został zapisany, ponieważ przy podanej nazwie pliku zastąpiłby on inny projekt.\nSpróbuj ponownie i wybierz niepowtarzalną nazwę."
+msgstr ""
+"Projekt nie został zapisany, ponieważ przy podanej nazwie pliku zastąpiłby "
+"on inny projekt.\n"
+"Spróbuj ponownie i wybierz niepowtarzalną nazwę."
 
 #: src/ProjectFileManager.cpp
 #, c-format
@@ -3901,12 +4258,21 @@ msgstr "%sZapisz bezstratną kopię projektu \"%s\" jako..."
 
 #: src/ProjectFileManager.cpp
 msgid ""
-"'Save Lossless Copy of Project' is for an Audacity project, not an audio file.\n"
+"'Save Lossless Copy of Project' is for an Audacity project, not an audio "
+"file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 "\n"
 "Lossless copies of project are a good way to backup your project, \n"
 "with no loss of quality, but the projects are large.\n"
-msgstr "'Zapisz bezstratną kopię projektu' jest dla projektu Audacity, nie dla pliku dźwiękowego.\nDo pliku dźwiękowego, który zostanie otwarty w innych aplikacjach, użyj 'Eksportuj'.\n\nBezstratne kopie projektu to dobry sposób na wykonanie kopii zapasowej projektu\nbez utraty jakości, ale projekty są duże.\n"
+msgstr ""
+"'Zapisz bezstratną kopię projektu' jest dla projektu Audacity, nie dla pliku "
+"dźwiękowego.\n"
+"Do pliku dźwiękowego, który zostanie otwarty w innych aplikacjach, użyj "
+"'Eksportuj'.\n"
+"\n"
+"Bezstratne kopie projektu to dobry sposób na wykonanie kopii zapasowej "
+"projektu\n"
+"bez utraty jakości, ale projekty są duże.\n"
 
 #: src/ProjectFileManager.cpp
 #, c-format
@@ -3915,12 +4281,21 @@ msgstr "%sZapisz skompresowany projekt \"%s\" jako..."
 
 #: src/ProjectFileManager.cpp
 msgid ""
-"'Save Compressed Copy of Project' is for an Audacity project, not an audio file.\n"
+"'Save Compressed Copy of Project' is for an Audacity project, not an audio "
+"file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 "\n"
 "Compressed project files are a good way to transmit your project online, \n"
 "but they have some loss of fidelity.\n"
-msgstr "'Zapisz skompresowaną kopię projektu' jest dla projektu Audacity, nie dla pliku dźwiękowego.\nDo pliku dźwiękowego, który zostanie otwarty w innych aplikacjach, użyj 'Eksportuj'.\n\nSkompresowane pliki projektu są dobrym sposobem do przekazywania projektu online, \nale mają pewne straty w dokładności.\n"
+msgstr ""
+"'Zapisz skompresowaną kopię projektu' jest dla projektu Audacity, nie dla "
+"pliku dźwiękowego.\n"
+"Do pliku dźwiękowego, który zostanie otwarty w innych aplikacjach, użyj "
+"'Eksportuj'.\n"
+"\n"
+"Skompresowane pliki projektu są dobrym sposobem do przekazywania projektu "
+"online, \n"
+"ale mają pewne straty w dokładności.\n"
 
 #: src/ProjectFileManager.cpp
 #, c-format
@@ -3931,13 +4306,18 @@ msgstr "%sZapisz projekt \"%s\" jako..."
 msgid ""
 "'Save Project' is for an Audacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
-msgstr "'Zapisz projekt' jest dla projektu Audacity, nie dla pliku dźwiękowego.\nDo pliku dźwiękowego, który zostanie otwarty w innych aplikacjach, użyj 'Eksport'.\n"
+msgstr ""
+"'Zapisz projekt' jest dla projektu Audacity, nie dla pliku dźwiękowego.\n"
+"Do pliku dźwiękowego, który zostanie otwarty w innych aplikacjach, użyj "
+"'Eksport'.\n"
 
 #: src/ProjectFileManager.cpp
 msgid ""
 "Saving a copy must not overwrite an existing saved project.\n"
 "Please try again and select an original name."
-msgstr "Zapisanie kopii nie może zastąpić istniejącego zapisanego projektu.\nSpróbuj ponownie i wybierz niepowtarzalną nazwę."
+msgstr ""
+"Zapisanie kopii nie może zastąpić istniejącego zapisanego projektu.\n"
+"Spróbuj ponownie i wybierz niepowtarzalną nazwę."
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -3954,7 +4334,13 @@ msgid ""
 "If you select \"Yes\" the project\n"
 "\"%s\"\n"
 "will be irreversibly overwritten."
-msgstr "Chcesz zastąpić projekt:\n\"%s\"?\n\nJeśli wybierzesz \"Tak\", projekt\n\"%s\"\nzostanie nieodwracalnie nadpisany."
+msgstr ""
+"Chcesz zastąpić projekt:\n"
+"\"%s\"?\n"
+"\n"
+"Jeśli wybierzesz \"Tak\", projekt\n"
+"\"%s\"\n"
+"zostanie nieodwracalnie nadpisany."
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -3963,9 +4349,13 @@ msgstr "Ostrzeżenie zastąpienia projektu"
 
 #: src/ProjectFileManager.cpp
 msgid ""
-"The project will not saved because the selected project is open in another window.\n"
+"The project will not saved because the selected project is open in another "
+"window.\n"
 "Please try again and select an original name."
-msgstr "Projekt nie zostanie zapisany, ponieważ zaznaczony projekt jest otwarty w innym oknie.\nSpróbuj ponownie i wybierz niepowtarzalną nazwę."
+msgstr ""
+"Projekt nie zostanie zapisany, ponieważ zaznaczony projekt jest otwarty w "
+"innym oknie.\n"
+"Spróbuj ponownie i wybierz niepowtarzalną nazwę."
 
 #: src/ProjectFileManager.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Select one or more files"
@@ -3982,7 +4372,11 @@ msgid ""
 "Doing this may result in severe data loss.\n"
 "\n"
 "Please open the actual Audacity project file instead."
-msgstr "Próbujesz otworzyć samoczynnie utworzony plik kopii zapasowej.\nZrobienie tego może skutkować poważną utratą danych.\n\nZamiast tego, musisz otworzyć aktualny projekt Audacity."
+msgstr ""
+"Próbujesz otworzyć samoczynnie utworzony plik kopii zapasowej.\n"
+"Zrobienie tego może skutkować poważną utratą danych.\n"
+"\n"
+"Zamiast tego, musisz otworzyć aktualny projekt Audacity."
 
 #: src/ProjectFileManager.cpp
 msgid "Warning - Backup File Detected"
@@ -4001,7 +4395,9 @@ msgstr "Błąd otwierania pliku"
 msgid ""
 "File may be invalid or corrupted: \n"
 "%s"
-msgstr "Plik może być nieprawidłowy lub uszkodzony: \n%s"
+msgstr ""
+"Plik może być nieprawidłowy lub uszkodzony: \n"
+"%s"
 
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File or Project"
@@ -4011,7 +4407,8 @@ msgstr "Błąd otwierania pliku lub projektu"
 msgid ""
 "Audacity was unable to convert an Audacity 1.0 project to the new project "
 "format."
-msgstr "Audacity nie mógł przekonwertować projektu Audacity 1.0 do nowego formatu."
+msgstr ""
+"Audacity nie mógł przekonwertować projektu Audacity 1.0 do nowego formatu."
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -4047,8 +4444,7 @@ msgstr "Utworzono nowy projekt"
 msgid "Welcome to Audacity version %s"
 msgstr "Witamy w wersji %s Audacity"
 
-#. i18n-hint: The first %s numbers the project, the second %s is the project
-#. name.
+#. i18n-hint: The first %s numbers the project, the second %s is the project name.
 #: src/ProjectManager.cpp
 #, c-format
 msgid "%sSave changes to %s?"
@@ -4066,7 +4462,14 @@ msgid ""
 "To save any previously open tracks:\n"
 "Cancel, Edit > Undo until all tracks\n"
 "are open, then File > Save Project."
-msgstr "\n\nJeśli teraz zapiszesz, to projekt nie będzie miał ścieżek.\n\nAby zapisać ścieżki, które były poprzednio\notwarte, kliknij 'Anuluj', 'Edycja > Cofnij', aż wszystkie\nścieżki będą otwarte i wybierz 'Plik > Zapisz projekt'."
+msgstr ""
+"\n"
+"\n"
+"Jeśli teraz zapiszesz, to projekt nie będzie miał ścieżek.\n"
+"\n"
+"Aby zapisać ścieżki, które były poprzednio\n"
+"otwarte, kliknij 'Anuluj', 'Edycja > Cofnij', aż wszystkie\n"
+"ścieżki będą otwarte i wybierz 'Plik > Zapisz projekt'."
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -4080,16 +4483,19 @@ msgstr "Obliczanie kształtu fali i importu na żądanie ukończone."
 #: src/ProjectManager.cpp
 #, c-format
 msgid ""
-"Import(s) complete. Running %d on-demand waveform calculations. Overall "
-"%2.0f%% complete."
-msgstr "Importowanie(a) ukończone. Uruchomiono %d obliczanie kształtu fali. %2.0f%% ukończone."
+"Import(s) complete. Running %d on-demand waveform calculations. Overall %2.0f"
+"%% complete."
+msgstr ""
+"Importowanie(a) ukończone. Uruchomiono %d obliczanie kształtu fali. %2.0f%% "
+"ukończone."
 
 #: src/ProjectManager.cpp
 #, c-format
 msgid ""
-"Import complete. Running an on-demand waveform calculation. %2.0f%% "
-"complete."
-msgstr "Importowanie ukończone. Uruchomiono obliczanie kształtu fali. %2.0f%% ukończone."
+"Import complete. Running an on-demand waveform calculation. %2.0f%% complete."
+msgstr ""
+"Importowanie ukończone. Uruchomiono obliczanie kształtu fali. %2.0f%% "
+"ukończone."
 
 #: src/ProjectManager.cpp
 msgid "Less than 1 minute"
@@ -4227,7 +4633,8 @@ msgstr "Przechwyć pełny ekran"
 
 #: src/Screenshot.cpp
 msgid "Wait 5 seconds and capture frontmost window/dialog"
-msgstr "Odczekaj 5 sekund i przechwyć najbardziej wysunięte okno/okno dialogowe"
+msgstr ""
+"Odczekaj 5 sekund i przechwyć najbardziej wysunięte okno/okno dialogowe"
 
 #: src/Screenshot.cpp
 msgid "Capture part of a project window"
@@ -4289,8 +4696,7 @@ msgstr "Miernik"
 msgid "Play Meter"
 msgstr "Miernik odtwarzania"
 
-#. i18n-hint: (noun) The meter that shows the loudness of the audio being
-#. recorded.
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
 #: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
 #: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
@@ -4325,8 +4731,7 @@ msgid "Ruler"
 msgstr "Linijka"
 
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
-#. * data associated with a time line, such as sequences of labels, and
-#. musical
+#. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
 #: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
 #: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
@@ -4392,15 +4797,16 @@ msgstr "Przechwytywanie zakończone niepowodzeniem!"
 msgid ""
 "Sequence has block file exceeding maximum %s samples per block.\n"
 "Truncating to this maximum length."
-msgstr "Sekwencja zawiera plik blokowy przekraczający maksymalną %s sampli na blok.\nObcinanie do tej maksymalnej długości."
+msgstr ""
+"Sekwencja zawiera plik blokowy przekraczający maksymalną %s sampli na blok.\n"
+"Obcinanie do tej maksymalnej długości."
 
 #: src/Sequence.cpp
 msgid "Warning - Truncating Overlong Block File"
 msgstr "Ostrzeżenie - Obcinanie wydłużonego pliku blokowego"
 
-#: src/ShuttleGui.cpp src/commands/HelpCommand.cpp
-#: src/effects/Equalization.cpp src/menus/HelpMenus.cpp
-#: src/widgets/MultiDialog.cpp
+#: src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp
+#: src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Pomoc"
 
@@ -4478,7 +4884,8 @@ msgstr "Komentarze"
 
 #: src/Tags.cpp
 msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
-msgstr "Użyj klawiszy strzałek (lub klawisza ENTER po edycji), aby nawigować polami."
+msgstr ""
+"Użyj klawiszy strzałek (lub klawisza ENTER po edycji), aby nawigować polami."
 
 #: src/Tags.cpp
 msgid "Tag"
@@ -4565,11 +4972,12 @@ msgstr "Błąd zapisywania pliku znaczników"
 msgid ""
 "Audacity could not write file:\n"
 "  %s."
-msgstr "Audacity nie mógł zapisać pliku:\n%s."
+msgstr ""
+"Audacity nie mógł zapisać pliku:\n"
+"%s."
 
 #. i18n-hint: A theme is a consistent visual style across an application's
-#. graphical user interface, including choices of colors, and similarity of
-#. images
+#. graphical user interface, including choices of colors, and similarity of images
 #. such as those on button controls.  Audacity can load and save alternative
 #. themes.
 #: src/Theme.cpp
@@ -4577,7 +4985,9 @@ msgstr "Audacity nie mógł zapisać pliku:\n%s."
 msgid ""
 "Theme written to:\n"
 "  %s."
-msgstr "Motyw zapisany do:\n  %s."
+msgstr ""
+"Motyw zapisany do:\n"
+"  %s."
 
 #: src/Theme.cpp
 #, c-format
@@ -4585,14 +4995,19 @@ msgid ""
 "Audacity could not open file:\n"
 "  %s\n"
 "for writing."
-msgstr "Audacity nie mógł otworzyć pliku:\n%s\ndo zapisu."
+msgstr ""
+"Audacity nie mógł otworzyć pliku:\n"
+"%s\n"
+"do zapisu."
 
 #: src/Theme.cpp
 #, c-format
 msgid ""
 "Audacity could not write images to file:\n"
 "  %s."
-msgstr "Audacity nie mógł zapisać obrazów do pliku:\n%s."
+msgstr ""
+"Audacity nie mógł zapisać obrazów do pliku:\n"
+"%s."
 
 #. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
@@ -4600,7 +5015,9 @@ msgstr "Audacity nie mógł zapisać obrazów do pliku:\n%s."
 msgid ""
 "Theme as Cee code written to:\n"
 "  %s."
-msgstr "Motyw jako kod Cee zapisany do:\n  %s."
+msgstr ""
+"Motyw jako kod Cee zapisany do:\n"
+"  %s."
 
 #: src/Theme.cpp
 #, c-format
@@ -4608,7 +5025,10 @@ msgid ""
 "Audacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
-msgstr "Audacity nie mógł znaleźć pliku:\n%s.\nMotyw nie został załadowany."
+msgstr ""
+"Audacity nie mógł znaleźć pliku:\n"
+"%s.\n"
+"Motyw nie został załadowany."
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
@@ -4617,13 +5037,18 @@ msgid ""
 "Audacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
-msgstr "Audacity nie mógł wczytać pliku:\n%s.\nByć może format png jest nieprawidłowy?"
+msgstr ""
+"Audacity nie mógł wczytać pliku:\n"
+"%s.\n"
+"Być może format png jest nieprawidłowy?"
 
 #: src/Theme.cpp
 msgid ""
 "Audacity could not read its default theme.\n"
 "Please report the problem."
-msgstr "Audacity nie mógł odczytać tego domyślnego motywu.\nZgłoś problem."
+msgstr ""
+"Audacity nie mógł odczytać tego domyślnego motywu.\n"
+"Zgłoś problem."
 
 #: src/Theme.cpp
 #, c-format
@@ -4631,14 +5056,19 @@ msgid ""
 "None of the expected theme component files\n"
 " were found in:\n"
 "  %s."
-msgstr "Nie znaleziono żadnego z\nelementów motywu w:\n%s."
+msgstr ""
+"Nie znaleziono żadnego z\n"
+"elementów motywu w:\n"
+"%s."
 
 #: src/Theme.cpp
 #, c-format
 msgid ""
 "Could not create directory:\n"
 "  %s"
-msgstr "Nie udało się utworzyć katalogu:\n%s"
+msgstr ""
+"Nie udało się utworzyć katalogu:\n"
+"%s"
 
 #: src/Theme.cpp
 #, c-format
@@ -4646,27 +5076,28 @@ msgid ""
 "Some required files in:\n"
 "  %s\n"
 "were already present. Overwrite?"
-msgstr "Niektóre wymagane pliki w:\n  %s\nbyły już obecne. Zastąpić?"
+msgstr ""
+"Niektóre wymagane pliki w:\n"
+"  %s\n"
+"były już obecne. Zastąpić?"
 
 #: src/Theme.cpp
 #, c-format
 msgid ""
 "Audacity could not save file:\n"
 "  %s"
-msgstr "Audacity nie mógł zapisać pliku:\n%s"
+msgstr ""
+"Audacity nie mógł zapisać pliku:\n"
+"%s"
 
-#. i18n-hint: This string is used to configure the controls which shows the
-#. recording
-#. * duration. As such it is important that only the alphabetic parts of the
-#. string
+#. i18n-hint: This string is used to configure the controls which shows the recording
+#. * duration. As such it is important that only the alphabetic parts of the string
 #. * are translated, with the numbers left exactly as they are.
-#. * The string 'days' indicates that the first number in the control will be
-#. the number of days,
-#. * then the 'h' indicates the second number displayed is hours, the 'm'
-#. indicates the third
-#. * number displayed is minutes, and the 's' indicates that the fourth number
-#. displayed is
+#. * The string 'days' indicates that the first number in the control will be the number of days,
+#. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
+#. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
+#.
 #: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
 #: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
 #: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
@@ -4693,7 +5124,11 @@ msgid ""
 "The selected file name could not be used\n"
 "for Timer Recording because it would overwrite another project.\n"
 "Please try again and select an original name."
-msgstr "Wybrana nazwa pliku nie może być użyta\ndla nagrywania czasowego, ponieważ zastąpiłaby ona inny projekt.\n\nSpróbuj ponownie i wybierz niepowtarzalną nazwę."
+msgstr ""
+"Wybrana nazwa pliku nie może być użyta\n"
+"dla nagrywania czasowego, ponieważ zastąpiłaby ona inny projekt.\n"
+"\n"
+"Spróbuj ponownie i wybierz niepowtarzalną nazwę."
 
 #: src/TimerRecordDialog.cpp
 msgid "Error Saving Timer Recording Project"
@@ -4726,13 +5161,21 @@ msgstr "Błąd w automatycznym eksporcie"
 #: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
-"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"You may not have enough free disk space to complete this Timer Recording, "
+"based on your current settings.\n"
 "\n"
 "Do you wish to continue?\n"
 "\n"
 "Planned recording duration:   %s\n"
 "Recording time remaining on disk:   %s"
-msgstr "Biorąc pod uwagę bieżące ustawienia, nie masz wystarczająco wolnego miejsca na ukończenie tego nagrywania.\n\nChcesz kontynuować?\n\nPlanowana długość nagrywania:   %s\nPozostała długość nagrywania na dysku:   %s"
+msgstr ""
+"Biorąc pod uwagę bieżące ustawienia, nie masz wystarczająco wolnego miejsca "
+"na ukończenie tego nagrywania.\n"
+"\n"
+"Chcesz kontynuować?\n"
+"\n"
+"Planowana długość nagrywania:   %s\n"
+"Pozostała długość nagrywania na dysku:   %s"
 
 #: src/TimerRecordDialog.cpp
 msgid "Timer Recording Disk Space Warning"
@@ -4785,7 +5228,10 @@ msgid ""
 "%s\n"
 "\n"
 "Recording saved: %s"
-msgstr "%s\n\nNagrywanie zapisane: %s"
+msgstr ""
+"%s\n"
+"\n"
+"Nagrywanie zapisane: %s"
 
 #: src/TimerRecordDialog.cpp
 #, c-format
@@ -4793,7 +5239,10 @@ msgid ""
 "%s\n"
 "\n"
 "Error saving recording."
-msgstr "%s\n\nBłąd zapisywania nagrywania."
+msgstr ""
+"%s\n"
+"\n"
+"Błąd zapisywania nagrywania."
 
 #: src/TimerRecordDialog.cpp
 #, c-format
@@ -4801,7 +5250,10 @@ msgid ""
 "%s\n"
 "\n"
 "Recording exported: %s"
-msgstr "%s\n\nNagranie zostało wyeksportowane: %s"
+msgstr ""
+"%s\n"
+"\n"
+"Nagranie zostało wyeksportowane: %s"
 
 #: src/TimerRecordDialog.cpp
 #, c-format
@@ -4809,7 +5261,10 @@ msgid ""
 "%s\n"
 "\n"
 "Error exporting recording."
-msgstr "%s\n\nBłąd eksportowania nagrywania."
+msgstr ""
+"%s\n"
+"\n"
+"Błąd eksportowania nagrywania."
 
 #: src/TimerRecordDialog.cpp
 #, c-format
@@ -4817,7 +5272,10 @@ msgid ""
 "%s\n"
 "\n"
 "'%s' has been canceled due to the error(s) noted above."
-msgstr "%s\n\n'%s' został anulowany z powodu błędu(ów) wymienionego powyżej."
+msgstr ""
+"%s\n"
+"\n"
+"'%s' został anulowany z powodu błędu(ów) wymienionego powyżej."
 
 #: src/TimerRecordDialog.cpp
 #, c-format
@@ -4825,7 +5283,10 @@ msgid ""
 "%s\n"
 "\n"
 "'%s' has been canceled as the recording was stopped."
-msgstr "%s\n\n'%s' został anulowany, gdy nagranie zostało zatrzymane."
+msgstr ""
+"%s\n"
+"\n"
+"'%s' został anulowany, gdy nagranie zostało zatrzymane."
 
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
@@ -4841,15 +5302,12 @@ msgstr "099 g 060 m 060 s"
 msgid "099 days 024 h 060 m 060 s"
 msgstr "099 dni 024 g 060 m 060 s"
 
-#. i18n-hint: This string is used to configure the controls for times when the
-#. recording is
-#. * started and stopped. As such it is important that only the alphabetic
-#. parts of the string
+#. i18n-hint: This string is used to configure the controls for times when the recording is
+#. * started and stopped. As such it is important that only the alphabetic parts of the string
 #. * are translated, with the numbers left exactly as they are.
-#. * The 'h' indicates the first number displayed is hours, the 'm' indicates
-#. the second number
-#. * displayed is minutes, and the 's' indicates that the third number
-#. displayed is seconds.
+#. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
+#. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data i czas początku"
@@ -4894,8 +5352,8 @@ msgstr "Włączyć automatyczny &eksport?"
 msgid "Export Project As:"
 msgstr "Eksportuj projekt jako:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp
-#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opcje"
 
@@ -5027,7 +5485,9 @@ msgstr "Włączone zaznaczenie"
 msgid ""
 "Click and drag to adjust relative size of stereo tracks, double-click to "
 "make heights equal"
-msgstr "Kliknij i przeciągnij, aby określić relatywny rozmiar ścieżek stereo, kliknij podwójnie myszką, aby wyrównać wysokości"
+msgstr ""
+"Kliknij i przeciągnij, aby określić relatywny rozmiar ścieżek stereo, "
+"kliknij podwójnie myszką, aby wyrównać wysokości"
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to resize the track."
@@ -5103,8 +5563,7 @@ msgstr "Zaznaczenie jest za małe, aby użyć klucza głosowego."
 msgid "Calibration Results\n"
 msgstr "Wyniki kalibracji\n"
 
-#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard
-#. Deviations'
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
 #: src/VoiceKey.cpp
 #, c-format
 msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
@@ -5147,15 +5606,18 @@ msgid ""
 "%s: Could not load settings below. Default settings will be used.\n"
 "\n"
 "%s"
-msgstr "%s: Nie udało się wczytać poniższych ustawień. Zostaną użyte domyślne ustawienia.\n\n%s"
+msgstr ""
+"%s: Nie udało się wczytać poniższych ustawień. Zostaną użyte domyślne "
+"ustawienia.\n"
+"\n"
+"%s"
 
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Stosowanie %s..."
 
-#. i18n-hint: An item name followed by a value, with appropriate separating
-#. punctuation
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
 #: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
@@ -5193,14 +5655,19 @@ msgstr "Polecenie"
 msgid ""
 "\n"
 "* %s, because you have assigned the shortcut %s to %s"
-msgstr "\n* %s, ponieważ masz przypisany skrót %s do %s"
+msgstr ""
+"\n"
+"* %s, ponieważ masz przypisany skrót %s do %s"
 
 #: src/commands/CommandManager.cpp
 msgid ""
 "The following commands have had their shortcuts removed, because their "
 "default shortcut is new or changed, and is the same shortcut that you have "
 "assigned to another command."
-msgstr "Poniższe polecenia zostały usunięte, ponieważ ich domyślny skrót jest nowy lub zmieniony i jest tym samym skrótem, który masz przypisany do innego polecenia."
+msgstr ""
+"Poniższe polecenia zostały usunięte, ponieważ ich domyślny skrót jest nowy "
+"lub zmieniony i jest tym samym skrótem, który masz przypisany do innego "
+"polecenia."
 
 #: src/commands/CommandManager.cpp
 msgid "Shortcuts have been removed"
@@ -5904,27 +6371,31 @@ msgstr "Auto Duck"
 msgid ""
 "Reduces (ducks) the volume of one or more tracks whenever the volume of a "
 "specified \"control\" track reaches a particular level"
-msgstr "Redukuje (ducks) liczbę jednej lub większej liczby ścieżek, gdy objętość określona jako \"kontrola\" ścieżki osiągnie określony poziom"
+msgstr ""
+"Redukuje (ducks) liczbę jednej lub większej liczby ścieżek, gdy objętość "
+"określona jako \"kontrola\" ścieżki osiągnie określony poziom"
 
-#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the
-#. volume)
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
 #: src/effects/AutoDuck.cpp
 msgid ""
-"You selected a track which does not contain audio. AutoDuck can only process"
-" audio tracks."
-msgstr "Zaznaczyłeś ścieżkę, która nie zawiera dźwięku. Auto Duck może tylko przetwarzać ścieżki dźwiękowe."
+"You selected a track which does not contain audio. AutoDuck can only process "
+"audio tracks."
+msgstr ""
+"Zaznaczyłeś ścieżkę, która nie zawiera dźwięku. Auto Duck może tylko "
+"przetwarzać ścieżki dźwiękowe."
 
-#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the
-#. volume)
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
 #: src/effects/AutoDuck.cpp
 msgid ""
 "Auto Duck needs a control track which must be placed below the selected "
 "track(s)."
-msgstr "Auto Duck potrzebuje ścieżki kontrolnej, która ma być umieszczona poniżej zaznaczonej(ych) ścieżki(ek)."
+msgstr ""
+"Auto Duck potrzebuje ścieżki kontrolnej, która ma być umieszczona poniżej "
+"zaznaczonej(ych) ścieżki(ek)."
 
 #: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
 msgid "db"
@@ -6151,8 +6622,7 @@ msgstr "Zmień prędkość ze zmianą tempa i wysokości"
 msgid "&Speed Multiplier:"
 msgstr "Mnożnik &prędkości:"
 
-#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per
-#. minute".
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
 #. "vinyl" refers to old-fashioned phonograph records
 #: src/effects/ChangeSpeed.cpp
 msgid "Standard Vinyl rpm:"
@@ -6228,7 +6698,9 @@ msgstr "Usuwanie stukotu"
 
 #: src/effects/ClickRemoval.cpp
 msgid "Click Removal is designed to remove clicks on audio tracks"
-msgstr "Usuwanie stukotu jest przeznaczone do usuwania kliknięć na ścieżkach dźwiękowych"
+msgstr ""
+"Usuwanie stukotu jest przeznaczone do usuwania kliknięć na ścieżkach "
+"dźwiękowych"
 
 #: src/effects/ClickRemoval.cpp
 msgid "Algorithm not effective on this audio. Nothing changed."
@@ -6334,23 +6806,20 @@ msgid "Attack Time"
 msgstr "Czas narastania"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
-#. * an 'attack' phase where the sound builds up and a 'decay' or 'release'
-#. where the
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "Czas &zanikania:"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
-#. * an 'attack' phase where the sound builds up and a 'decay' or 'release'
-#. where the
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "Release Time"
 msgstr "Czas zanikania"
 
-#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate
-#. it.
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
 #: src/effects/Compressor.cpp
 msgid "Ma&ke-up gain for 0 dB after compressing"
 msgstr "Uczyń ze &wzmocnienia 0 dB po skompresowaniu"
@@ -6393,20 +6862,26 @@ msgstr "Zaznacz ścieżkę dźwiękową"
 msgid ""
 "Invalid audio selection.\n"
 "Please ensure that audio is selected."
-msgstr "Nieprawidłowo zaznaczony dźwięk.\nUpewnij się, że dźwięk jest zaznaczony."
+msgstr ""
+"Nieprawidłowo zaznaczony dźwięk.\n"
+"Upewnij się, że dźwięk jest zaznaczony."
 
 #: src/effects/Contrast.cpp
 msgid ""
 "Nothing to measure.\n"
 "Please select a section of a track."
-msgstr "Nie ma nic do zmierzenia.\nZaznacz odcinek ścieżki."
+msgstr ""
+"Nie ma nic do zmierzenia.\n"
+"Zaznacz odcinek ścieżki."
 
 #. i18n-hint: RMS abbreviates root mean square, a certain averaging method
 #: src/effects/Contrast.cpp
 msgid ""
 "Contrast Analyzer, for measuring RMS volume differences between two "
 "selections of audio."
-msgstr "Analizator kontrastu do pomiaru różnic głośności RMS między dwoma odcinkami dźwięku."
+msgstr ""
+"Analizator kontrastu do pomiaru różnic głośności RMS między dwoma odcinkami "
+"dźwięku."
 
 #. i18n-hint noun
 #: src/effects/Contrast.cpp src/effects/ToneGen.cpp
@@ -6531,8 +7006,7 @@ msgstr "Poziom tła za wysoki"
 msgid "Background higher than foreground"
 msgstr "Tło wyższe niż pierwszy plan"
 
-#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0',
-#. see http://www.w3.org/TR/WCAG20/
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
 msgid "WCAG2 Pass"
 msgstr "Powodzenie WCAG 2"
@@ -6899,7 +7373,9 @@ msgstr "Generuje sygnalizację tonową (DTMF), jak klawiatura w telefonach"
 msgid ""
 "DTMF sequence empty.\n"
 "Check ALL settings for this effect."
-msgstr "Sekwencja DTMF jest pusta.\nSprawdź WSZYSTKIE ustawienia dla tego efektu."
+msgstr ""
+"Sekwencja DTMF jest pusta.\n"
+"Sprawdź WSZYSTKIE ustawienia dla tego efektu."
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -7021,8 +7497,7 @@ msgid "Previewing"
 msgstr "Podglądanie"
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or
-#. Nyqvist).
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
 #. In the translations of this and other strings, you may transliterate the
 #. name into another alphabet.
 #: src/effects/Effect.h
@@ -7071,7 +7546,13 @@ msgid ""
 "%s\n"
 "\n"
 "More information may be available in 'Help > Diagnostics > Show Log'"
-msgstr "Próba zainicjowania następującego efektu zakończona niepowodzeniem:\n\n%s\n\nWięcej informacji może być dostępne w 'Pomoc > Diagnostyka > Pokaż dziennik...'."
+msgstr ""
+"Próba zainicjowania następującego efektu zakończona niepowodzeniem:\n"
+"\n"
+"%s\n"
+"\n"
+"Więcej informacji może być dostępne w 'Pomoc > Diagnostyka > Pokaż "
+"dziennik...'."
 
 #: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
@@ -7085,7 +7566,13 @@ msgid ""
 "%s\n"
 "\n"
 "More information may be available in 'Help > Diagnostics > Show Log'"
-msgstr "Próba zainicjowania następującego polecenia zakończona niepowodzeniem:\n\n%s\n\nWięcej informacji może być dostępne w 'Pomoc > Diagnostyka > Pokaż dziennik...'."
+msgstr ""
+"Próba zainicjowania następującego polecenia zakończona niepowodzeniem:\n"
+"\n"
+"%s\n"
+"\n"
+"Więcej informacji może być dostępne w 'Pomoc > Diagnostyka > Pokaż "
+"dziennik...'."
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -7285,7 +7772,10 @@ msgid ""
 "Preset already exists.\n"
 "\n"
 "Replace?"
-msgstr "Preset już istnieje.\n\nZastąpić?"
+msgstr ""
+"Preset już istnieje.\n"
+"\n"
+"Zastąpić?"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -7372,8 +7862,12 @@ msgstr "Obcięcie sopranów"
 #: src/effects/Equalization.cpp
 msgid ""
 "To use this filter curve in a macro, please choose a new name for it.\n"
-"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
-msgstr "Aby użyć krzywej filtra w makrze, wybierz dla niej nową nazwę.\nNaciśnij przycisk 'Zapisz/zarządzaj krzywymi...' i zmień 'nienazwaną' krzywą, a następnie użyj jej."
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, "
+"then use that one."
+msgstr ""
+"Aby użyć krzywej filtra w makrze, wybierz dla niej nową nazwę.\n"
+"Naciśnij przycisk 'Zapisz/zarządzaj krzywymi...' i zmień 'nienazwaną' "
+"krzywą, a następnie użyj jej."
 
 #: src/effects/Equalization.cpp
 msgid "Filter Curve EQ needs a different name"
@@ -7382,7 +7876,9 @@ msgstr "Krzywa filtra EQ musi mieć inną nazwę"
 #: src/effects/Equalization.cpp
 msgid ""
 "To apply Equalization, all selected tracks must have the same sample rate."
-msgstr "Aby zastosować korekcję, wszystkie wybrane utwory muszą mieć tę samą częstotliwość próbkowania."
+msgstr ""
+"Aby zastosować korekcję, wszystkie wybrane utwory muszą mieć tę samą "
+"częstotliwość próbkowania."
 
 #: src/effects/Equalization.cpp
 msgid "Track sample rate is too low for this effect."
@@ -7423,8 +7919,7 @@ msgstr "%d Hz"
 msgid "%g kHz"
 msgstr "%g kHz"
 
-#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in
-#. translation.
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
 #, c-format
 msgid "%gk"
@@ -7535,7 +8030,11 @@ msgid ""
 "%s\n"
 "Error message says:\n"
 "%s"
-msgstr "Błąd wczytywania krzywych korektora graficznego z pliku:\n%s\nKomunikat o błędzie:\n%s"
+msgstr ""
+"Błąd wczytywania krzywych korektora graficznego z pliku:\n"
+"%s\n"
+"Komunikat o błędzie:\n"
+"%s"
 
 #: src/effects/Equalization.cpp
 msgid "Error Loading EQ Curves"
@@ -7585,7 +8084,9 @@ msgstr "Do&myślnie"
 msgid ""
 "Rename 'unnamed' to save a new entry.\n"
 "'OK' saves all changes, 'Cancel' doesn't."
-msgstr "Zmień nazwę 'nienazwanego', aby zapisać nowy wpis.\n'OK' zapisuje wszystkie zmiany, 'Anuluj' nie zapisuje zmian."
+msgstr ""
+"Zmień nazwę 'nienazwanego', aby zapisać nowy wpis.\n"
+"'OK' zapisuje wszystkie zmiany, 'Anuluj' nie zapisuje zmian."
 
 #: src/effects/Equalization.cpp
 msgid "'unnamed' always stays at the bottom of the list"
@@ -7690,7 +8191,13 @@ msgid ""
 "Default Threaded: %s\n"
 "SSE: %s\n"
 "SSE Threaded: %s\n"
-msgstr "Benchmark razy:\nOryginalny: %s\nDefault Segmented: %s\nDefault Threaded: %s\nSSE: %s\nSSE Threaded: %s\n"
+msgstr ""
+"Benchmark razy:\n"
+"Oryginalny: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -7894,7 +8401,9 @@ msgstr "Kroki na bloku nie mogą przekraczać rozmiaru okna."
 
 #: src/effects/NoiseReduction.cpp
 msgid "Median method is not implemented for more than four steps per window."
-msgstr "Metoda mediany jest niezaimplementowana dla więcej niż czterech kroków na okno."
+msgstr ""
+"Metoda mediany jest niezaimplementowana dla więcej niż czterech kroków na "
+"okno."
 
 #: src/effects/NoiseReduction.cpp
 msgid "You must specify the same window size for steps 1 and 2."
@@ -7902,17 +8411,22 @@ msgstr "Musisz podać ten sam rozmiar okna dla kroków 1 i 2."
 
 #: src/effects/NoiseReduction.cpp
 msgid "Warning: window types are not the same as for profiling."
-msgstr "Ostrzeżenie - Typy okien nie są takie same jak w przypadku profilowania"
+msgstr ""
+"Ostrzeżenie - Typy okien nie są takie same jak w przypadku profilowania"
 
 #: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
-msgstr "Wszystkie dane profilu szumu powinny mieć taką samą częstotliwość próbkowania."
+msgstr ""
+"Wszystkie dane profilu szumu powinny mieć taką samą częstotliwość "
+"próbkowania."
 
 #: src/effects/NoiseReduction.cpp
 msgid ""
 "The sample rate of the noise profile must match that of the sound to be "
 "processed."
-msgstr "Częstotliwość próbkowania profilu szumu musi być zgodna z dźwiękiem do przetwarzania."
+msgstr ""
+"Częstotliwość próbkowania profilu szumu musi być zgodna z dźwiękiem do "
+"przetwarzania."
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -7974,7 +8488,9 @@ msgstr "Krok 1"
 msgid ""
 "Select a few seconds of just noise so Audacity knows what to filter out,\n"
 "then click Get Noise Profile:"
-msgstr "Zaznacz kilka sekund szumu, aby Audacity wiedział, co odfiltrować,\nnastępnie kliknij na Uzyskaj profil szumu:"
+msgstr ""
+"Zaznacz kilka sekund szumu, aby Audacity wiedział, co odfiltrować,\n"
+"następnie kliknij na Uzyskaj profil szumu:"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Get Noise Profile"
@@ -7988,7 +8504,9 @@ msgstr "Krok 2"
 msgid ""
 "Select all of the audio you want filtered, choose how much noise you want\n"
 "filtered out, and then click 'OK' to reduce noise.\n"
-msgstr "Zaznacz cały dźwięk, który chcesz przefiltrować, wybierz ilość szumów do\nprzefiltrowania i kliknij na przycisk OK, aby zredukować szumy.\n"
+msgstr ""
+"Zaznacz cały dźwięk, który chcesz przefiltrować, wybierz ilość szumów do\n"
+"przefiltrowania i kliknij na przycisk OK, aby zredukować szumy.\n"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Noise:"
@@ -8003,8 +8521,7 @@ msgstr "Re&dukuj"
 msgid "&Isolate"
 msgstr "&Izoluj"
 
-#. i18n-hint: Means the difference between effect and original sound.
-#. Translate differently from "Reduce" !
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
 #: src/effects/NoiseReduction.cpp
 msgid "Resid&ue"
 msgstr "Pozos&taw"
@@ -8098,7 +8615,9 @@ msgstr "Usuwa stałe szumy tła, takie jak wentylatory, szumy taśmy lub buczeni
 msgid ""
 "Select all of the audio you want filtered, choose how much noise you want\n"
 "filtered out, and then click 'OK' to remove noise.\n"
-msgstr "Zaznacz cały dźwięk, który chcesz przefiltrować, wybierz ilość szumów do\nprzefiltrowania i kliknij na przycisk OK, aby usunąć szumy.\n"
+msgstr ""
+"Zaznacz cały dźwięk, który chcesz przefiltrować, wybierz ilość szumów do\n"
+"przefiltrowania i kliknij na przycisk OK, aby usunąć szumy.\n"
 
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise re&duction (dB):"
@@ -8195,11 +8714,13 @@ msgstr "Paulstretch"
 
 #: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
-msgstr "Paulstretch jest tylko dla ekstremalnego odcinku czasu lub efektu \"zastój\""
+msgstr ""
+"Paulstretch jest tylko dla ekstremalnego odcinku czasu lub efektu \"zastój\""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "W&spółczynnik rozciągania:"
@@ -8208,8 +8729,7 @@ msgstr "W&spółczynnik rozciągania:"
 msgid "&Time Resolution (seconds):"
 msgstr "Rozdzielczość &czasu (sekundy):"
 
-#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch
-#. effect.
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
 #: src/effects/Paulstretch.cpp
 #, c-format
 msgid ""
@@ -8217,10 +8737,13 @@ msgid ""
 "\n"
 "Try increasing the audio selection to at least %.1f seconds,\n"
 "or reducing the 'Time Resolution' to less than %.1f seconds."
-msgstr "Zaznaczony dźwięk jest za krótki, aby wyświetlić podgląd.\n\nSpróbuj zwiększyć zaznaczony dźwięk do co najmniej %.1f sekund\nlub zredukować 'Rozdzielczość czasu' do mniej niż %.1f sekund."
+msgstr ""
+"Zaznaczony dźwięk jest za krótki, aby wyświetlić podgląd.\n"
+"\n"
+"Spróbuj zwiększyć zaznaczony dźwięk do co najmniej %.1f sekund\n"
+"lub zredukować 'Rozdzielczość czasu' do mniej niż %.1f sekund."
 
-#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch
-#. effect.
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
 #: src/effects/Paulstretch.cpp
 #, c-format
 msgid ""
@@ -8228,10 +8751,13 @@ msgid ""
 "\n"
 "For the current audio selection, the maximum\n"
 "'Time Resolution' is %.1f seconds."
-msgstr "Nie można wyświetlić podglądu.\n\nDla obecnie zaznaczonego dźwięku maksymalna\n'Rozdzielczość czasu' wynosi %.1f sekund."
+msgstr ""
+"Nie można wyświetlić podglądu.\n"
+"\n"
+"Dla obecnie zaznaczonego dźwięku maksymalna\n"
+"'Rozdzielczość czasu' wynosi %.1f sekund."
 
-#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch
-#. effect.
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
 #: src/effects/Paulstretch.cpp
 #, c-format
 msgid ""
@@ -8239,7 +8765,11 @@ msgid ""
 "\n"
 "Try increasing the audio selection to at least %.1f seconds,\n"
 "or reducing the 'Time Resolution' to less than %.1f seconds."
-msgstr "'Rozdzielczość czasu' jest za długa dla zaznaczenia.\n\nSpróbuj zwiększyć zaznaczony dźwięk do co najmniej %.1f sekund\nlub zredukować 'Rozdzielczość czasu' do mniej niż %.1f sekund."
+msgstr ""
+"'Rozdzielczość czasu' jest za długa dla zaznaczenia.\n"
+"\n"
+"Spróbuj zwiększyć zaznaczony dźwięk do co najmniej %.1f sekund\n"
+"lub zredukować 'Rozdzielczość czasu' do mniej niż %.1f sekund."
 
 #: src/effects/Phaser.cpp
 msgid "Phaser"
@@ -8315,10 +8845,15 @@ msgstr "Ustawia amplitudę szczytową jednej lub więcej ścieżek"
 
 #: src/effects/Repair.cpp
 msgid ""
-"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"The Repair effect is intended to be used on very short sections of damaged "
+"audio (up to 128 samples).\n"
 "\n"
 "Zoom in and select a tiny fraction of a second to repair."
-msgstr "Efekt naprawy jest przeznaczony do użytku na bardzo krótkich odcinkach uszkodzonego dźwięku (do 128 sampli).\n\nPrzybliż i zaznacz ułamek sekundy do naprawy."
+msgstr ""
+"Efekt naprawy jest przeznaczony do użytku na bardzo krótkich odcinkach "
+"uszkodzonego dźwięku (do 128 sampli).\n"
+"\n"
+"Przybliż i zaznacz ułamek sekundy do naprawy."
 
 #: src/effects/Repair.cpp
 msgid ""
@@ -8327,7 +8862,12 @@ msgid ""
 "Please select a region that has audio touching at least one side of it.\n"
 "\n"
 "The more surrounding audio, the better it performs."
-msgstr "Napraw dźwięk, używając danych dźwiękowych spoza zaznaczonego obszaru.\n\nZaznacz obszar dotykający dźwięk przynajmniej z jednej strony.\n\nIm więcej otaczającego dźwięku, tym lepiej."
+msgstr ""
+"Napraw dźwięk, używając danych dźwiękowych spoza zaznaczonego obszaru.\n"
+"\n"
+"Zaznacz obszar dotykający dźwięk przynajmniej z jednej strony.\n"
+"\n"
+"Im więcej otaczającego dźwięku, tym lepiej."
 
 #: src/effects/Repeat.cpp
 msgid "Repeat"
@@ -8464,20 +9004,17 @@ msgstr "Odwraca zaznaczony dźwięk"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Czas SBSMS/rozciąganie wysokości"
 
-#. i18n-hint: Butterworth is the name of the person after whom the filter type
-#. is named.
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Butterworth"
 msgstr "Butterworth"
 
-#. i18n-hint: Chebyshev is the name of the person after whom the filter type
-#. is named.
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
 msgstr "Typ Czebyszewa I"
 
-#. i18n-hint: Chebyshev is the name of the person after whom the filter type
-#. is named.
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type II"
 msgstr "Typ Czebyszewa II"
@@ -8501,14 +9038,15 @@ msgstr "Wykonuje filtrowanie IIR, które emuluje filtry analogowe"
 
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
-msgstr "Aby zastosować filtr, wszystkie wybrane ścieżki muszą mieć tę samą częstotliwość próbkowania."
+msgstr ""
+"Aby zastosować filtr, wszystkie wybrane ścieżki muszą mieć tę samą "
+"częstotliwość próbkowania."
 
 #: src/effects/ScienFilter.cpp
 msgid "&Filter Type:"
 msgstr "Typ &filtra:"
 
-#. i18n-hint: 'Order' means the complexity of the filter, and is a number
-#. between 1 and 10.
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
 #: src/effects/ScienFilter.cpp
 msgid "O&rder:"
 msgstr "Ko&lejność:"
@@ -8577,40 +9115,32 @@ msgstr "Próg ciszy:"
 msgid "Silence Threshold"
 msgstr "Próg ciszy"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than
-#. 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the
-#. user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
 msgstr "Wstępnie gładki czas:"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than
-#. 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the
-#. user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time"
 msgstr "Wstępnie gładki czas"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than
-#. 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the
-#. user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Line Time:"
 msgstr "Czas jako linia:"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than
-#. 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the
-#. user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
@@ -8621,10 +9151,8 @@ msgstr "Czas jako linia"
 msgid "Smooth Time:"
 msgstr "Gładki czas:"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than
-#. 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the
-#. user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
@@ -8776,13 +9304,17 @@ msgstr "Obetnij ciszę"
 msgid ""
 "Automatically reduces the length of passages where the volume is below a "
 "specified level"
-msgstr "Automatycznie redukuje długość fragmentów, w których wielkość jest poniżej określonego poziomu"
+msgstr ""
+"Automatycznie redukuje długość fragmentów, w których wielkość jest poniżej "
+"określonego poziomu"
 
 #: src/effects/TruncSilence.cpp
 msgid ""
-"When truncating independently, there may only be one selected audio track in"
-" each Sync-Locked Track Group."
-msgstr "Podczas obcinania niezależnego może być zaznaczona tylko jedna ścieżka dźwiękowa w każdej zsynchronizowanej-zablokowanej grupie ścieżek."
+"When truncating independently, there may only be one selected audio track in "
+"each Sync-Locked Track Group."
+msgstr ""
+"Podczas obcinania niezależnego może być zaznaczona tylko jedna ścieżka "
+"dźwiękowa w każdej zsynchronizowanej-zablokowanej grupie ścieżek."
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -8845,7 +9377,12 @@ msgid ""
 "iteration. Smaller values will cause slower processing and some effects "
 "require 8192 samples or less to work properly. However most effects can "
 "accept large buffers and using them will greatly reduce processing time."
-msgstr "Rozmiar bufora kontroluje liczbę sampli wysyłanych do efektu przy każdej iteracji. Mniejsze wartości spowodują wolniejsze przetwarzanie, a niektóre efekty wymagają 8192 sampli lub mniej, aby działać poprawnie. Jednak większość efektów akceptuje duże bufory, a ich użycie znacznie skraca czas przetwarzania."
+msgstr ""
+"Rozmiar bufora kontroluje liczbę sampli wysyłanych do efektu przy każdej "
+"iteracji. Mniejsze wartości spowodują wolniejsze przetwarzanie, a niektóre "
+"efekty wymagają 8192 sampli lub mniej, aby działać poprawnie. Jednak "
+"większość efektów akceptuje duże bufory, a ich użycie znacznie skraca czas "
+"przetwarzania."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
@@ -8862,7 +9399,11 @@ msgid ""
 "Audacity. When not compensating for this delay, you will notice that small "
 "silences have been inserted into the audio. Enabling this option will "
 "provide that compensation, but it may not work for all VST effects."
-msgstr "W ramach przetwarzania niektóre efekty VST muszą opóźniać powrót dźwięku do Audacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku została wprowadzona mała cisza. Włączenie tej opcji zapewni tę kompensację, ale może nie działać dla wszystkich efektów VST."
+msgstr ""
+"W ramach przetwarzania niektóre efekty VST muszą opóźniać powrót dźwięku do "
+"Audacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku "
+"została wprowadzona mała cisza. Włączenie tej opcji zapewni tę kompensację, "
+"ale może nie działać dla wszystkich efektów VST."
 
 #: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
 #: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -8878,7 +9419,10 @@ msgid ""
 "Most VST effects have a graphical interface for setting parameter values. A "
 "basic text-only method is also available.  Reopen the effect for this to "
 "take effect."
-msgstr "Większość efektów VST ma interfejs graficzny do ustawiania wartości parametrów. Dostępna jest również podstawowa metoda tekstowa. Otwórz ponownie efekt, aby zadziałał."
+msgstr ""
+"Większość efektów VST ma interfejs graficzny do ustawiania wartości "
+"parametrów. Dostępna jest również podstawowa metoda tekstowa. Otwórz "
+"ponownie efekt, aby zadziałał."
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &graphical interface"
@@ -8951,8 +9495,7 @@ msgstr "Nie można wczytać pliku preseta."
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Ten plik parametryczny został zapisany z %s. Kontynuować?"
 
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software
-#. protocol
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
 #. developed by Steinberg GmbH
 #: src/effects/VST/VSTEffect.h
 msgid "VST"
@@ -8966,7 +9509,9 @@ msgstr "Wahwah"
 msgid ""
 "Rapid tone quality variations, like that guitar sound so popular in the "
 "1970's"
-msgstr "Gwałtowne zmiany jakości dźwięku, jak dźwięk gitary bardzo popularny w latach 70."
+msgstr ""
+"Gwałtowne zmiany jakości dźwięku, jak dźwięk gitary bardzo popularny w "
+"latach 70."
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -9016,7 +9561,11 @@ msgid ""
 "that small silences have been inserted into the audio. Enabling this option "
 "will provide that compensation, but it may not work for all Audio Unit "
 "effects."
-msgstr "W ramach przetwarzania niektóre efekty Audio Unit muszą opóźnić powrót dźwięku do Audacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku została wprowadzona mała cisza. Włączenie tej opcji zapewni kompensację, ale może nie działać dla wszystkich efektów Audio Unit."
+msgstr ""
+"W ramach przetwarzania niektóre efekty Audio Unit muszą opóźnić powrót "
+"dźwięku do Audacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do "
+"dźwięku została wprowadzona mała cisza. Włączenie tej opcji zapewni "
+"kompensację, ale może nie działać dla wszystkich efektów Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9026,9 +9575,13 @@ msgstr "Interfejs użytkownika"
 msgid ""
 "Select \"Full\" to use the graphical interface if supplied by the Audio "
 "Unit. Select \"Generic\" to use the system supplied generic interface. "
-"Select \"Basic\" for a basic text-only interface. Reopen the effect for this"
-" to take effect."
-msgstr "Wybierz \"Pełny\", aby użyć interfejsu graficznego, jeśli jest dostarczany przez Audio Unit. Wybierz \"Ogólny\", aby użyć interfejsu ogólnego dostarczonego przez system. Wybierz \"Podstawowy\" dla podstawowego interfejsu tekstowego. Otwórz ponownie efekt, aby zadziałał."
+"Select \"Basic\" for a basic text-only interface. Reopen the effect for this "
+"to take effect."
+msgstr ""
+"Wybierz \"Pełny\", aby użyć interfejsu graficznego, jeśli jest dostarczany "
+"przez Audio Unit. Wybierz \"Ogólny\", aby użyć interfejsu ogólnego "
+"dostarczonego przez system. Wybierz \"Podstawowy\" dla podstawowego "
+"interfejsu tekstowego. Otwórz ponownie efekt, aby zadziałał."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -9087,7 +9640,10 @@ msgid ""
 "Could not import \"%s\" preset\n"
 "\n"
 "%s"
-msgstr "Nie można importować presetu \"%s\"\n\n%s"
+msgstr ""
+"Nie można importować presetu \"%s\"\n"
+"\n"
+"%s"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
@@ -9109,7 +9665,10 @@ msgid ""
 "Could not export \"%s\" preset\n"
 "\n"
 "%s"
-msgstr "Nie można eksportować presetu \"%s\"\n\n%s"
+msgstr ""
+"Nie można eksportować presetu \"%s\"\n"
+"\n"
+"%s"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Export Audio Unit Presets"
@@ -9162,6 +9721,7 @@ msgstr "Jednostka dźwiękowa"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efekty LADSPA"
@@ -9184,12 +9744,14 @@ msgid ""
 "to Audacity. When not compensating for this delay, you will notice that "
 "small silences have been inserted into the audio. Enabling this option will "
 "provide that compensation, but it may not work for all LADSPA effects."
-msgstr "W ramach przetwarzania niektóre efekty LADSPA muszą opóźniać powrót dźwięku do Audacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku została wprowadzona mała cisza. Włączenie tej opcji zapewni tę kompensację, ale może nie działać dla wszystkich efektów LADSPA."
+msgstr ""
+"W ramach przetwarzania niektóre efekty LADSPA muszą opóźniać powrót dźwięku "
+"do Audacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku "
+"została wprowadzona mała cisza. Włączenie tej opcji zapewni tę kompensację, "
+"ale może nie działać dla wszystkich efektów LADSPA."
 
-#. i18n-hint: An item name introducing a value, which is not part of the
-#. string but
-#. appears in a following text box window; translate with appropriate
-#. punctuation
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
 #: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
 #: src/effects/vamp/VampEffect.cpp
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -9203,6 +9765,7 @@ msgstr "Wyjście efektu"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "LADSPA"
@@ -9217,19 +9780,31 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Rozmiar &bufora (8 do %d sampli):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Rozmiar &bufora (8 do %d sampli):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
 "silences have been inserted into the audio. Enabling this setting will "
 "provide that compensation, but it may not work for all LV2 effects."
-msgstr "W ramach przetwarzania niektóre efekty LV2 muszą opóźniać powrót dźwięku do Audacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku została wprowadzona mała cisza. Włączenie tego ustawienia zapewni kompensację, ale może nie działać dla wszystkich efektów LV2."
+msgstr ""
+"W ramach przetwarzania niektóre efekty LV2 muszą opóźniać powrót dźwięku do "
+"Audacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku "
+"została wprowadzona mała cisza. Włączenie tego ustawienia zapewni "
+"kompensację, ale może nie działać dla wszystkich efektów LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "LV2 effects can have a graphical interface for setting parameter values. A "
 "basic text-only method is also available.  Reopen the effect for this to "
 "take effect."
-msgstr "Efekty LV2 mogą mieć interfejs graficzny do ustawiania wartości parametrów. Dostępna jest również podstawowa metoda tekstowa. Otwórz ponownie efekt, aby zadziałał."
+msgstr ""
+"Efekty LV2 mogą mieć interfejs graficzny do ustawiania wartości parametrów. "
+"Dostępna jest również podstawowa metoda tekstowa. Otwórz ponownie efekt, aby "
+"zadziałał."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 sequence buffer overflow"
@@ -9293,8 +9868,7 @@ msgstr "Stosowanie efektu Nyquista..."
 msgid "Nyquist Prompt"
 msgstr "Podpowiedź Nyquista"
 
-#. i18n-hint: It is acceptable to translate this the same as for "Nyquist
-#. Prompt"
+#. i18n-hint: It is acceptable to translate this the same as for "Nyquist Prompt"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist Worker"
 msgstr "Monit Nyquista"
@@ -9308,12 +9882,17 @@ msgid ""
 "To use 'Spectral effects', enable 'Spectral Selection'\n"
 "in the track Spectrogram settings and select the\n"
 "frequency range for the effect to act on."
-msgstr "Aby użyć 'Efektów widma', włącz 'Zaznaczenie widma'\nw ustawieniach toru spektrogramu i wybierz\nzakres częstotliwości efektu."
+msgstr ""
+"Aby użyć 'Efektów widma', włącz 'Zaznaczenie widma'\n"
+"w ustawieniach toru spektrogramu i wybierz\n"
+"zakres częstotliwości efektu."
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
-msgstr "Błąd: Plik \"%s\" jest określony w nagłówku, ale nie można go znaleźć w ścieżce wtyczki.\n"
+msgstr ""
+"Błąd: Plik \"%s\" jest określony w nagłówku, ale nie można go znaleźć w "
+"ścieżce wtyczki.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
@@ -9326,7 +9905,9 @@ msgstr "Błąd Nyquista"
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
 "Sorry, cannot apply effect on stereo tracks where the tracks don't match."
-msgstr "Przykro mi, ale nie można używać efektu na ścieżkach stereo, jeśli ścieżki do siebie nie pasują."
+msgstr ""
+"Przykro mi, ale nie można używać efektu na ścieżkach stereo, jeśli ścieżki "
+"do siebie nie pasują."
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -9334,7 +9915,10 @@ msgid ""
 "Selection too long for Nyquist code.\n"
 "Maximum allowed selection is %ld samples\n"
 "(about %.1f hours at 44100 Hz sample rate)."
-msgstr "Zaznaczenie jest za długie dla kodu Nyquista.\nMaksymalny dopuszczalny wybór wynosi %ld sampli\n(około %.1f godziny na 44100 Hz częstotliwości próbkowania)."
+msgstr ""
+"Zaznaczenie jest za długie dla kodu Nyquista.\n"
+"Maksymalny dopuszczalny wybór wynosi %ld sampli\n"
+"(około %.1f godziny na 44100 Hz częstotliwości próbkowania)."
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
@@ -9346,7 +9930,9 @@ msgstr "Wyjście diagnostyczne:"
 msgid ""
 "'%s' returned:\n"
 "%s"
-msgstr "'%s' zwrócony:\n%s"
+msgstr ""
+"'%s' zwrócony:\n"
+"%s"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
@@ -9405,7 +9991,9 @@ msgstr "Nyquist zwrócił dźwięk nil.\n"
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
 "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
-msgstr "[Ostrzeżenie - Nyquist zwrócił nieprawidłowy ciąg znaków UTF-8, przekształcony tutaj na Łaciński-1]"
+msgstr ""
+"[Ostrzeżenie - Nyquist zwrócił nieprawidłowy ciąg znaków UTF-8, "
+"przekształcony tutaj na Łaciński-1]"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -9417,7 +10005,10 @@ msgstr "Ta wersja Audacity nie obsługuje wersji wtyczki Nyquista %ld"
 msgid ""
 "Bad Nyquist 'control' type specification: '%s' in plug-in file '%s'.\n"
 "Control not created."
-msgstr "Nieprawidłowa specyfikacja typu 'kontrola' Nyquista: '%s' w pliku wtyczki '%s'.\nKontrola nie została utworzona."
+msgstr ""
+"Nieprawidłowa specyfikacja typu 'kontrola' Nyquista: '%s' w pliku wtyczki "
+"'%s'.\n"
+"Kontrola nie została utworzona."
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not open file"
@@ -9431,7 +10022,13 @@ msgid ""
 "or for LISP, begin with an open parenthesis such as:\n"
 "\t(mult *track* 0.1)\n"
 " ."
-msgstr "Twój kod wygląda na składnię SAL, ale brakuje w nim instrukcji 'return'.\nDla SALa użyj instrukcji 'return':\n\treturn *track* * 0.1\nlub dla LISPa rozpocznij z otwartymi nawiasami:\n\t(mult *track* 0.1)\n."
+msgstr ""
+"Twój kod wygląda na składnię SAL, ale brakuje w nim instrukcji 'return'.\n"
+"Dla SALa użyj instrukcji 'return':\n"
+"\treturn *track* * 0.1\n"
+"lub dla LISPa rozpocznij z otwartymi nawiasami:\n"
+"\t(mult *track* 0.1)\n"
+"."
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Error in Nyquist code"
@@ -9453,7 +10050,9 @@ msgstr "\"%s\" nie jest prawidłową ścieżką do pliku."
 msgid ""
 "Mismatched quotes in\n"
 "%s"
-msgstr "Niezgodne kwestie w\n%s"
+msgstr ""
+"Niezgodne kwestie w\n"
+"%s"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -9485,7 +10084,9 @@ msgstr "Skrypty Lispa"
 msgid ""
 "Current program has been modified.\n"
 "Discard changes?"
-msgstr "Bieżący program został zmodyfikowany.\nPorzucić zmiany?"
+msgstr ""
+"Bieżący program został zmodyfikowany.\n"
+"Porzucić zmiany?"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "File could not be loaded"
@@ -9500,7 +10101,9 @@ msgstr "Plik nie może być zapisany"
 msgid ""
 "Value range:\n"
 "%s to %s"
-msgstr "Zakres wartości:\n%s do %s"
+msgstr ""
+"Zakres wartości:\n"
+"%s do %s"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Value Error"
@@ -9510,7 +10113,9 @@ msgstr "Błąd wartości"
 msgid ""
 "Invalid wildcard string in 'path' control.'\n"
 "Using empty string instead."
-msgstr "Nieprawidłowy ciąg znaków wieloznacznych w 'path' control.'\nWykorzystując zamiast tego pustego ciągu."
+msgstr ""
+"Nieprawidłowy ciąg znaków wieloznacznych w 'path' control.'\n"
+"Wykorzystując zamiast tego pustego ciągu."
 
 #: src/effects/nyquist/Nyquist.cpp plug-ins/sample-data-export.ny
 msgid "Select a file"
@@ -9537,7 +10142,9 @@ msgstr "Zapewnia efekty Vamp w Audacity"
 msgid ""
 "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual "
 "channels of the track do not match."
-msgstr "Niestety, wtyczka Vamp nie działa na ścieżkach stereo, gdzie poszczególne kanały nie pasują."
+msgstr ""
+"Niestety, wtyczka Vamp nie działa na ścieżkach stereo, gdzie poszczególne "
+"kanały nie pasują."
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, failed to load Vamp Plug-in."
@@ -9555,8 +10162,7 @@ msgstr "Ustawienia wtyczki"
 msgid "Program"
 msgstr "Program"
 
-#. i18n-hint: Vamp is the proper name of a software protocol for sound
-#. analysis.
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
 #. It is not an abbreviation for anything.  See http://vamp-plugins.org
 #: src/effects/vamp/VampEffect.h
 msgid "Vamp"
@@ -9602,22 +10208,38 @@ msgstr "Na pewno chcesz zapisać plik jako \"%s\"?\n"
 msgid ""
 "You are about to export a %s file with the name \"%s\".\n"
 "\n"
-"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"Normally these files end in \".%s\", and some programs will not open files "
+"with nonstandard extensions.\n"
 "\n"
 "Are you sure you want to export the file under this name?"
-msgstr "Plik %s zostanie zapisany pod nazwą \"%s\".\n\nPliki te zazwyczaj kończą się z \".%s\" i niektóre programy nie otworzą tych plików z niestandardowymi rozszerzeniami.\n\nNa pewno chcesz zapisać ten plik pod tą nazwą?"
+msgstr ""
+"Plik %s zostanie zapisany pod nazwą \"%s\".\n"
+"\n"
+"Pliki te zazwyczaj kończą się z \".%s\" i niektóre programy nie otworzą tych "
+"plików z niestandardowymi rozszerzeniami.\n"
+"\n"
+"Na pewno chcesz zapisać ten plik pod tą nazwą?"
 
 #: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
-msgstr "Przykro mi, ale ścieżki do plików dłuższe niż 256 znaków nie są obsługiwane."
+msgstr ""
+"Przykro mi, ale ścieżki do plików dłuższe niż 256 znaków nie są obsługiwane."
 
 #: src/export/Export.cpp
 msgid ""
 "You are attempting to overwrite an aliased file that is missing.\n"
-"The file cannot be written because the path is needed to restore the original audio to the project.\n"
-"Choose Help > Diagnostics > Check Dependencies to view the locations of all missing files.\n"
+"The file cannot be written because the path is needed to restore the "
+"original audio to the project.\n"
+"Choose Help > Diagnostics > Check Dependencies to view the locations of all "
+"missing files.\n"
 "If you still wish to export, please choose a different filename or folder."
-msgstr "Próbujesz zastąpić brakujący plik aliasu.\nNie można zapisać pliku, ponieważ ścieżka jest potrzebna do przywrócenia oryginalnego dźwięku w projekcie.\nWybierz 'Pomoc > Diagnostyka > Sprawdź zależności...', aby obejrzeć listę lokalizacji brakujących plików.\nJeśli nadal chcesz eksportować, wybierz inną nazwę pliku lub folder."
+msgstr ""
+"Próbujesz zastąpić brakujący plik aliasu.\n"
+"Nie można zapisać pliku, ponieważ ścieżka jest potrzebna do przywrócenia "
+"oryginalnego dźwięku w projekcie.\n"
+"Wybierz 'Pomoc > Diagnostyka > Sprawdź zależności...', aby obejrzeć listę "
+"lokalizacji brakujących plików.\n"
+"Jeśli nadal chcesz eksportować, wybierz inną nazwę pliku lub folder."
 
 #: src/export/Export.cpp
 #, c-format
@@ -9630,13 +10252,16 @@ msgstr "Twoje ścieżki będą zmiksowane i wyeksportowane do jednego pliku mono
 
 #: src/export/Export.cpp
 msgid "Your tracks will be mixed down and exported as one stereo file."
-msgstr "Twoje ścieżki będą zmiksowane i wyeksportowane do jednego pliku stereo."
+msgstr ""
+"Twoje ścieżki będą zmiksowane i wyeksportowane do jednego pliku stereo."
 
 #: src/export/Export.cpp
 msgid ""
-"Your tracks will be mixed down to one exported file according to the encoder"
-" settings."
-msgstr "Twoje ścieżki będą zmiksowane do jednego wyeksportowanego pliku w zależności od ustawień enkodera."
+"Your tracks will be mixed down to one exported file according to the encoder "
+"settings."
+msgstr ""
+"Twoje ścieżki będą zmiksowane do jednego wyeksportowanego pliku w zależności "
+"od ustawień enkodera."
 
 #: src/export/Export.cpp
 msgid "Advanced Mixing Options"
@@ -9679,15 +10304,16 @@ msgstr "Pokaż wyjście"
 #. i18n-hint: Some programmer-oriented terminology here:
 #. "Data" refers to the sound to be exported, "piped" means sent,
 #. and "standard in" means the default input stream that the external program,
-#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually
-#. used
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
 #. in the program as a format string.  Keep %f unchanged.
 #: src/export/ExportCL.cpp
 #, c-format
 msgid ""
 "Data will be piped to standard in. \"%f\" uses the file name in the export "
 "window."
-msgstr "Dane zostaną przekierowane do standardowego wejścia. \"%f\" używa nazwy pliku w oknie eksportu."
+msgstr ""
+"Dane zostaną przekierowane do standardowego wejścia. \"%f\" używa nazwy "
+"pliku w oknie eksportu."
 
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
@@ -9745,7 +10371,9 @@ msgstr "Nie można znaleźć \"%s\" w Twojej ścieżce."
 msgid ""
 "Properly configured FFmpeg is required to proceed.\n"
 "You can configure it at Preferences > Libraries."
-msgstr "Aby kontynuować, niezbędny jest poprawnie skonfigurowany pakiet FFmpeg.\nMożesz go skonfigurować w 'Ustawienia... > Biblioteki'."
+msgstr ""
+"Aby kontynuować, niezbędny jest poprawnie skonfigurowany pakiet FFmpeg.\n"
+"Możesz go skonfigurować w 'Ustawienia... > Biblioteki'."
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -9763,19 +10391,25 @@ msgstr "FFmpeg : BŁĄD - Nie można przydzielić wyjścia kontekstu formatu."
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
-msgstr "FFmpeg : BŁĄD - Nie można dodać strumienia dźwięku do pliku wyjściowego \"%s\"."
-
-#: src/export/ExportFFmpeg.cpp
-#, c-format
-msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
-msgstr "FFmpeg : BŁĄD - Nie można otworzyć pliku wyjściowego \"%s\" do zapisu. Kod błędu %d."
+msgstr ""
+"FFmpeg : BŁĄD - Nie można dodać strumienia dźwięku do pliku wyjściowego \"%s"
+"\"."
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid ""
-"FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is "
-"%d."
-msgstr "FFmpeg : BŁĄD - Nie można zapisać nagłówków do pliku wyjściowego \"%s\". Kod błędu %d."
+"FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+"FFmpeg : BŁĄD - Nie można otworzyć pliku wyjściowego \"%s\" do zapisu. Kod "
+"błędu %d."
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+"FFmpeg : BŁĄD - Nie można zapisać nagłówków do pliku wyjściowego \"%s\". Kod "
+"błędu %d."
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -9783,7 +10417,9 @@ msgstr "FFmpeg : BŁĄD - Nie można zapisać nagłówków do pliku wyjściowego
 msgid ""
 "FFmpeg cannot find audio codec 0x%x.\n"
 "Support for this codec is probably not compiled in."
-msgstr "FFmpeg nie znalazł kodeka dźwięku 0x%x.\nPrawdopodobnie brakuje wsparcia dla tego kodeka."
+msgstr ""
+"FFmpeg nie znalazł kodeka dźwięku 0x%x.\n"
+"Prawdopodobnie brakuje wsparcia dla tego kodeka."
 
 #: src/export/ExportFFmpeg.cpp
 msgid "The codec reported a generic error (EPERM)"
@@ -9800,11 +10436,16 @@ msgid ""
 "Can't open audio codec \"%s\" (0x%x)\n"
 "\n"
 "%s"
-msgstr "Nie można otworzyć kodeka \"%s\" (0x%x)\n\n%s"
+msgstr ""
+"Nie można otworzyć kodeka \"%s\" (0x%x)\n"
+"\n"
+"%s"
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
-msgstr "FFmpeg : BŁĄD - Nie można przydzielić bufora do zapoznania się z dźwiękiem FIFO."
+msgstr ""
+"FFmpeg : BŁĄD - Nie można przydzielić bufora do zapoznania się z dźwiękiem "
+"FIFO."
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - Could not get sample buffer size"
@@ -9828,7 +10469,9 @@ msgstr "FFmpeg : BŁĄD - Pozostało za dużo danych."
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
-msgstr "FFmpeg : BŁĄD - Nie można zapisać ostatniej ramki dźwięku do pliku wyjściowego."
+msgstr ""
+"FFmpeg : BŁĄD - Nie można zapisać ostatniej ramki dźwięku do pliku "
+"wyjściowego."
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
@@ -9845,9 +10488,11 @@ msgstr "FFmpeg : BŁĄD - Nie udało się zapisać ramki dźwięku do pliku."
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid ""
-"Attempted to export %d channels, but maximum number of channels for selected"
-" output format is %d"
-msgstr "Usiłowano eksportować %d kanałów, ale maksymalna liczba kanałów dla wybranego formatu wyjściowego wynosi %d"
+"Attempted to export %d channels, but maximum number of channels for selected "
+"output format is %d"
+msgstr ""
+"Usiłowano eksportować %d kanałów, ale maksymalna liczba kanałów dla "
+"wybranego formatu wyjściowego wynosi %d"
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -9873,14 +10518,18 @@ msgstr "Zmień próbkowanie"
 msgid ""
 "The project sample rate (%d) is not supported by the current output\n"
 "file format. "
-msgstr "Częstotliwość próbkowania (%d) projektu nie jest obsługiwana\nprzez bieżący format pliku wyjściowego."
+msgstr ""
+"Częstotliwość próbkowania (%d) projektu nie jest obsługiwana\n"
+"przez bieżący format pliku wyjściowego."
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid ""
 "The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
 "supported by the current output file format. "
-msgstr "Kombinacja częstotliwości próbkowania (%d) i szybkości transmisji (%d kbps)\nprojektu nie są obsługiwane przez bieżący format pliku wyjściowego."
+msgstr ""
+"Kombinacja częstotliwości próbkowania (%d) i szybkości transmisji (%d kbps)\n"
+"projektu nie są obsługiwane przez bieżący format pliku wyjściowego."
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
 msgid "You may resample to one of the rates below."
@@ -9892,7 +10541,8 @@ msgstr "Częstotliwości próbkowania"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -10164,7 +10814,9 @@ msgstr "Kodek:"
 msgid ""
 "Not all formats and codecs are compatible. Nor are all option combinations "
 "compatible with all codecs."
-msgstr "Nie wszystkie formaty i kodeki są kompatybilne. Tak samo nie wszystkie kombinacje opcji są kompatybilne ze wszystkimi kodekami."
+msgstr ""
+"Nie wszystkie formaty i kodeki są kompatybilne. Tak samo nie wszystkie "
+"kombinacje opcji są kompatybilne ze wszystkimi kodekami."
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Formats"
@@ -10183,7 +10835,10 @@ msgid ""
 "ISO 639 3-letter language code\n"
 "Optional\n"
 "empty - automatic"
-msgstr "ISO 639 3-literowy kod języka\nOpcjonalny\npusty - automatycznie"
+msgstr ""
+"ISO 639 3-literowy kod języka\n"
+"Opcjonalny\n"
+"pusty - automatycznie"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
@@ -10203,7 +10858,10 @@ msgid ""
 "Codec tag (FOURCC)\n"
 "Optional\n"
 "empty - automatic"
-msgstr "Znacznik kodeka (FOURCC)\nOpcjonalny\npusty - automatyczny"
+msgstr ""
+"Znacznik kodeka (FOURCC)\n"
+"Opcjonalny\n"
+"pusty - automatyczny"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Tag:"
@@ -10215,7 +10873,11 @@ msgid ""
 "Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
 "0 - automatic\n"
 "Recommended - 192000"
-msgstr "Szybkość transmisji (bity na sekundę) - wpływa na rozmiar i jakość pliku\nNiektóre kodeki akceptują tylko niektóre wartości (128k, 192k, 256k itp.)\n0 - automatycznie\nZalecane - 192000"
+msgstr ""
+"Szybkość transmisji (bity na sekundę) - wpływa na rozmiar i jakość pliku\n"
+"Niektóre kodeki akceptują tylko niektóre wartości (128k, 192k, 256k itp.)\n"
+"0 - automatycznie\n"
+"Zalecane - 192000"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10223,7 +10885,11 @@ msgid ""
 "Required for vorbis\n"
 "0 - automatic\n"
 "-1 - off (use bitrate instead)"
-msgstr "Ogólna jakość używana różnie przez różne kodeki\nWymagane dla Vorbis\n0 - automatycznie\n-1 - wyłączone (użyj częstotliwości próbkowania)"
+msgstr ""
+"Ogólna jakość używana różnie przez różne kodeki\n"
+"Wymagane dla Vorbis\n"
+"0 - automatycznie\n"
+"-1 - wyłączone (użyj częstotliwości próbkowania)"
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
@@ -10233,7 +10899,9 @@ msgstr "Jakość:"
 msgid ""
 "Sample rate (Hz)\n"
 "0 - don't change sample rate"
-msgstr "Częstotliwość próbkowania (Hz)\n0 - nie zmieniaj częstotliwości próbkowania"
+msgstr ""
+"Częstotliwość próbkowania (Hz)\n"
+"0 - nie zmieniaj częstotliwości próbkowania"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Sample Rate:"
@@ -10244,14 +10912,20 @@ msgid ""
 "Audio cutoff bandwidth (Hz)\n"
 "Optional\n"
 "0 - automatic"
-msgstr "Pasmo odcinania dźwięku (Hz)\nOpcjonalna\n0 - automatyczna"
+msgstr ""
+"Pasmo odcinania dźwięku (Hz)\n"
+"Opcjonalna\n"
+"0 - automatyczna"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "AAC Profile\n"
 "Low Complexity - default\n"
 "Most players won't play anything other than LC"
-msgstr "Profil AAC\nNiska złożoność - domyślna\nWiększość odtwarzaczy nie odtwarza nic poza LC"
+msgstr ""
+"Profil AAC\n"
+"Niska złożoność - domyślna\n"
+"Większość odtwarzaczy nie odtwarza nic poza LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Profile:"
@@ -10268,7 +10942,12 @@ msgid ""
 "-1 - automatic\n"
 "min - 0 (fast encoding, large output file)\n"
 "max - 10 (slow encoding, small output file)"
-msgstr "Poziom kompresji\nWymagany dla FLAC\n-1 - automatyczny\nmin. - 0 (szybkie odkodowanie, duży plik)\nmaks. - 10 (wolne odkodowanie, mały plik)"
+msgstr ""
+"Poziom kompresji\n"
+"Wymagany dla FLAC\n"
+"-1 - automatyczny\n"
+"min. - 0 (szybkie odkodowanie, duży plik)\n"
+"maks. - 10 (wolne odkodowanie, mały plik)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Compression:"
@@ -10281,7 +10960,12 @@ msgid ""
 "0 - default\n"
 "min - 16\n"
 "max - 65535"
-msgstr "Rozmiar klatki\nOpcjonalny\n0 - domyślny\nmin. - 16\nmaks. - 65535"
+msgstr ""
+"Rozmiar klatki\n"
+"Opcjonalny\n"
+"0 - domyślny\n"
+"min. - 16\n"
+"maks. - 65535"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Frame:"
@@ -10294,7 +10978,12 @@ msgid ""
 "0 - default\n"
 "min - 1\n"
 "max - 15"
-msgstr "Precyzja LPC\nOpcjonalna\n0 - domyślne\nmin. - 1\nmaks. - 15"
+msgstr ""
+"Precyzja LPC\n"
+"Opcjonalna\n"
+"0 - domyślne\n"
+"min. - 1\n"
+"maks. - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "LPC"
@@ -10306,7 +10995,11 @@ msgid ""
 "Estimate - fastest, lower compression\n"
 "Log search - slowest, best compression\n"
 "Full search - default"
-msgstr "Metoda zlecenia\nOszacowana - najszybsza, niska kompresja\nSzukany rejestr - najwolniejsza, najlepsza kompresja\nPełny rejestr - domyślna"
+msgstr ""
+"Metoda zlecenia\n"
+"Oszacowana - najszybsza, niska kompresja\n"
+"Szukany rejestr - najwolniejsza, najlepsza kompresja\n"
+"Pełny rejestr - domyślna"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "PdO Method:"
@@ -10319,7 +11012,12 @@ msgid ""
 "-1 - default\n"
 "min - 0\n"
 "max - 32 (with LPC) or 4 (without LPC)"
-msgstr "Minimalne zlecenie\nOpcjonalne\n-1 - domyślne\nmin. - 0\nmaks. - 32 (z LPC) lub 4 (bez LPC)"
+msgstr ""
+"Minimalne zlecenie\n"
+"Opcjonalne\n"
+"-1 - domyślne\n"
+"min. - 0\n"
+"maks. - 32 (z LPC) lub 4 (bez LPC)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Min. PdO"
@@ -10332,7 +11030,12 @@ msgid ""
 "-1 - default\n"
 "min - 0\n"
 "max - 32 (with LPC) or 4 (without LPC)"
-msgstr "Maksymalne zlecenie\nOpcjonalne\n-1 - domyślne\nmin. - 0\nmaks. - 32 (z LPC) lub 4 (bez LPC)"
+msgstr ""
+"Maksymalne zlecenie\n"
+"Opcjonalne\n"
+"-1 - domyślne\n"
+"min. - 0\n"
+"maks. - 32 (z LPC) lub 4 (bez LPC)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Max. PdO"
@@ -10345,7 +11048,12 @@ msgid ""
 "-1 - default\n"
 "min - 0\n"
 "max - 8"
-msgstr "Minimalne zlecenie partycji\nOpcjonalne\n-1 - domyślne\nmin. - 0\nmaks. - 8"
+msgstr ""
+"Minimalne zlecenie partycji\n"
+"Opcjonalne\n"
+"-1 - domyślne\n"
+"min. - 0\n"
+"maks. - 8"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Min. PtO"
@@ -10358,7 +11066,12 @@ msgid ""
 "-1 - default\n"
 "min - 0\n"
 "max - 8"
-msgstr "Maksymalne zlecenie partycji\nOpcjonalne\n-1 - domyślne\nmin. - 0\nmaks. - 8"
+msgstr ""
+"Maksymalne zlecenie partycji\n"
+"Opcjonalne\n"
+"-1 - domyślne\n"
+"min. - 0\n"
+"maks. - 8"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Max. PtO"
@@ -10379,32 +11092,32 @@ msgid ""
 "Maximum bit rate of the multiplexed stream\n"
 "Optional\n"
 "0 - default"
-msgstr "Maksymalna szybkość transmisji multipleksowego strumienia\nOpcjonalna\n0 - domyślna"
+msgstr ""
+"Maksymalna szybkość transmisji multipleksowego strumienia\n"
+"Opcjonalna\n"
+"0 - domyślna"
 
-#. i18n-hint: 'mux' is short for multiplexor, a device that selects between
-#. several inputs
-#. 'Mux Rate' is a parameter that has some bearing on compression ratio for
-#. MPEG
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
 #. it has a hard to predict effect on the degree of compression
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Mux Rate:"
 msgstr "Współczynnik Muks:"
 
-#. i18n-hint: 'Packet Size' is a parameter that has some bearing on
-#. compression ratio for MPEG
-#. compression.  It measures how big a chunk of audio is compressed in one
-#. piece.
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Packet size\n"
 "Optional\n"
 "0 - default"
-msgstr "Rozmiar pakietu\nOpcjonalny\n0 - domyślny"
+msgstr ""
+"Rozmiar pakietu\n"
+"Opcjonalny\n"
+"0 - domyślny"
 
-#. i18n-hint: 'Packet Size' is a parameter that has some bearing on
-#. compression ratio for MPEG
-#. compression.  It measures how big a chunk of audio is compressed in one
-#. piece.
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Packet Size:"
 msgstr "Rozmiar pakietu:"
@@ -10492,7 +11205,9 @@ msgstr "Eksportowanie do FLAC nie mogło otworzyć %s"
 msgid ""
 "FLAC encoder failed to initialize\n"
 "Status: %d"
-msgstr "Nieudana inicjacja enkodera FLAC\nStan: %d"
+msgstr ""
+"Nieudana inicjacja enkodera FLAC\n"
+"Stan: %d"
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
@@ -10502,7 +11217,6 @@ msgstr "Eksportowanie zaznaczonych dźwięków jako FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Eksportuj dźwięk jako FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -10514,7 +11228,9 @@ msgstr "Pliki MP2"
 
 #: src/export/ExportMP2.cpp
 msgid "Cannot export MP2 with this sample rate and bit rate"
-msgstr "Nie można eksportować MP2 z tą częstotliwością próbkowania i szybkością transmisji"
+msgstr ""
+"Nie można eksportować MP2 z tą częstotliwością próbkowania i szybkością "
+"transmisji"
 
 #: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
 msgid "Unable to open target file for writing"
@@ -10634,8 +11350,7 @@ msgid "Bit Rate Mode:"
 msgstr "Tryb szybkości transmisji:"
 
 #. i18n-hint: meaning accuracy in reproduction of sounds
-#: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp
-#: src/prefs/QualityPrefs.h
+#: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "Jakość"
 
@@ -10651,8 +11366,7 @@ msgstr "Tryb kanałów:"
 msgid "Force export to mono"
 msgstr "Wymuś eksport do mono"
 
-#. i18n-hint: LAME is the name of an MP3 converter and should not be
-#. translated
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Ustal położenie LAME"
@@ -10689,9 +11403,13 @@ msgstr "Gdzie jest %s?"
 #: src/export/ExportMP3.cpp
 #, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with "
+"Audacity %d.%d.%d.\n"
 "Please download the latest version of 'LAME for Audacity'."
-msgstr "Łączysz do lame_enc.dll v%d.%d. Ta wersja nie współpracuje z Audacity %d.%d.%d.\nPobierz najnowszą wersję 'LAME dla Audacity'."
+msgstr ""
+"Łączysz do lame_enc.dll v%d.%d. Ta wersja nie współpracuje z Audacity %d.%d."
+"%d.\n"
+"Pobierz najnowszą wersję 'LAME dla Audacity'."
 
 #: src/export/ExportMP3.cpp
 msgid "Only lame_enc.dll"
@@ -10777,14 +11495,18 @@ msgstr "Błąd %ld zwrócony z enkodera MP3"
 msgid ""
 "The project sample rate (%d) is not supported by the MP3\n"
 "file format. "
-msgstr "Częstotliwość próbkowania (%d) nie jest obsługiwana przez\nformat plików MP3."
+msgstr ""
+"Częstotliwość próbkowania (%d) nie jest obsługiwana przez\n"
+"format plików MP3."
 
 #: src/export/ExportMP3.cpp
 #, c-format
 msgid ""
 "The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
 "supported by the MP3 file format. "
-msgstr "Kombinacja częstotliwości próbkowania (%d) i szybkość transmisji (%d kbps)\nprojektu nie są obsługiwane przez format plików MP3."
+msgstr ""
+"Kombinacja częstotliwości próbkowania (%d) i szybkość transmisji (%d kbps)\n"
+"projektu nie są obsługiwane przez format plików MP3."
 
 #: src/export/ExportMP3.cpp
 msgid "MP3 export library not found"
@@ -10806,7 +11528,10 @@ msgstr "Nie można eksportować wielu plików"
 msgid ""
 "You have no unmuted Audio Tracks and no applicable \n"
 "labels, so you cannot export to separate audio files."
-msgstr "Masz tylko jedną niewyciszoną ścieżkę dźwiękową i żadnych zastosowanych etykiet,\nz tego względu nie możesz eksportować do oddzielnych plików dźwiękowych."
+msgstr ""
+"Masz tylko jedną niewyciszoną ścieżkę dźwiękową i żadnych zastosowanych "
+"etykiet,\n"
+"z tego względu nie możesz eksportować do oddzielnych plików dźwiękowych."
 
 #: src/export/ExportMultiple.cpp
 msgid "Export files to:"
@@ -10890,18 +11615,21 @@ msgstr "Coś poszło źle po wyeksportowaniu następującego(ych) pliku(ów) %ll
 #: src/export/ExportMultiple.cpp
 #, c-format
 msgid "Export canceled after exporting the following %lld file(s)."
-msgstr "Anulowano eksportowanie po wyeksportowaniu następującego(ych) pliku(ów) %lld."
+msgstr ""
+"Anulowano eksportowanie po wyeksportowaniu następującego(ych) pliku(ów) %lld."
 
 #: src/export/ExportMultiple.cpp
 #, c-format
 msgid "Export stopped after exporting the following %lld file(s)."
-msgstr "Zatrzymano eksportowanie po wyeksportowaniu następującego(ych) pliku(ów) %lld."
+msgstr ""
+"Zatrzymano eksportowanie po wyeksportowaniu następującego(ych) pliku(ów) "
+"%lld."
 
 #: src/export/ExportMultiple.cpp
 #, c-format
-msgid ""
-"Something went really wrong after exporting the following %lld file(s)."
-msgstr "Coś poszło na pewno źle po wyeksportowaniu następującego(ych) pliku(ów) %lld."
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+"Coś poszło na pewno źle po wyeksportowaniu następującego(ych) pliku(ów) %lld."
 
 #: src/export/ExportMultiple.cpp
 #, c-format
@@ -10909,7 +11637,10 @@ msgid ""
 "\"%s\" doesn't exist.\n"
 "\n"
 "Would you like to create it?"
-msgstr "\"%s\" nie istnieje.\n\nChcesz go utworzyć?"
+msgstr ""
+"\"%s\" nie istnieje.\n"
+"\n"
+"Chcesz go utworzyć?"
 
 #: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
@@ -10921,7 +11652,10 @@ msgstr "Kontynuować eksportowanie pozostałych plików?"
 msgid ""
 "Label or track \"%s\" is not a legal file name. You cannot use any of: %s\n"
 "Use..."
-msgstr "Etykieta lub ścieżka \"%s\" jest niewłaściwą nazwą pliku. Nie możesz użyć żadnego ze znaków: %s\nUżyj..."
+msgstr ""
+"Etykieta lub ścieżka \"%s\" jest niewłaściwą nazwą pliku. Nie możesz użyć "
+"żadnego ze znaków: %s\n"
+"Użyj..."
 
 #. i18n-hint: The second %s gives a letter that can't be used.
 #: src/export/ExportMultiple.cpp
@@ -10929,7 +11663,10 @@ msgstr "Etykieta lub ścieżka \"%s\" jest niewłaściwą nazwą pliku. Nie moż
 msgid ""
 "Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
 "Use..."
-msgstr "Etykieta lub ścieżka \"%s\" jest niewłaściwą nazwą pliku. Nie możesz użyć \"%s\".\nUżyj..."
+msgstr ""
+"Etykieta lub ścieżka \"%s\" jest niewłaściwą nazwą pliku. Nie możesz użyć "
+"\"%s\".\n"
+"Użyj..."
 
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
@@ -10993,9 +11730,12 @@ msgstr "Inne nieskompresowane pliki"
 
 #: src/export/ExportPCM.cpp
 msgid ""
-"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"You have attempted to Export a WAV or AIFF file which would be greater than "
+"4GB.\n"
 "Audacity cannot do this, the Export was abandoned."
-msgstr "Próbowano wyeksportować plik WAV lub AIFF, który był większy niż 4 GB.\nAudacity nie może tego zrobić, eksport został przerwany."
+msgstr ""
+"Próbowano wyeksportować plik WAV lub AIFF, który był większy niż 4 GB.\n"
+"Audacity nie może tego zrobić, eksport został przerwany."
 
 #: src/export/ExportPCM.cpp
 msgid "Error Exporting"
@@ -11005,7 +11745,9 @@ msgstr "Błąd eksportowania"
 msgid ""
 "Your exported WAV file has been truncated as Audacity cannot export WAV\n"
 "files bigger than 4GB."
-msgstr "Wyeksportowany plik WAV został obcięty, ponieważ Audacity nie może eksportować plików WAV większych niż 4 GB."
+msgstr ""
+"Wyeksportowany plik WAV został obcięty, ponieważ Audacity nie może "
+"eksportować plików WAV większych niż 4 GB."
 
 #: src/export/ExportPCM.cpp
 msgid "GSM 6.10 requires mono"
@@ -11032,7 +11774,9 @@ msgstr "Eksportowanie zaznaczonego dźwięku jako %s"
 msgid ""
 "Error while writing %s file (disk full?).\n"
 "Libsndfile says \"%s\""
-msgstr "Błąd przy zapisywaniu pliku %s (pełny dysk?).\nLibsndfile mówi \"%s\""
+msgstr ""
+"Błąd przy zapisywaniu pliku %s (pełny dysk?).\n"
+"Libsndfile mówi \"%s\""
 
 #: src/import/Import.cpp
 msgid "All supported files"
@@ -11045,7 +11789,12 @@ msgid ""
 "is a MIDI file, not an audio file. \n"
 "Audacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
-msgstr "\"%s\" \njest plikiem MIDI, a nie plikiem dźwiękowym. \nAudacity nie może otworzyć tego typu pliku do odtwarzania, ale może go edytować\nprzez kliknięcie na 'Plik > Importuj > MIDI...'."
+msgstr ""
+"\"%s\" \n"
+"jest plikiem MIDI, a nie plikiem dźwiękowym. \n"
+"Audacity nie może otworzyć tego typu pliku do odtwarzania, ale może go "
+"edytować\n"
+"przez kliknięcie na 'Plik > Importuj > MIDI...'."
 
 #: src/import/Import.cpp
 msgid "Select stream(s) to import"
@@ -11064,16 +11813,26 @@ msgid ""
 "Audacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
 "Audacity can import, such as WAV or AIFF."
-msgstr "\"%s\" jest ścieżką Audio CD. \nAudacity nie może otworzyć bezpośrednio ścieżek Audio CD. \nWypakuj ścieżki do formatu, który \nAudacity może importować, takich jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest ścieżką Audio CD. \n"
+"Audacity nie może otworzyć bezpośrednio ścieżek Audio CD. \n"
+"Wypakuj ścieżki do formatu, który \n"
+"Audacity może importować, takich jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
-"You may be able to open it in a text editor and download the actual audio files."
-msgstr "\"%s\" jest plikiem listy.\nAudacity nie może otworzyć tego pliku, ponieważ zawiera on tylko linki do innych plików. \nMożesz otworzyć go w edytorze tekstowym i pobrać aktualne pliki dźwiękowe."
+"Audacity cannot open this file because it only contains links to other "
+"files. \n"
+"You may be able to open it in a text editor and download the actual audio "
+"files."
+msgstr ""
+"\"%s\" jest plikiem listy.\n"
+"Audacity nie może otworzyć tego pliku, ponieważ zawiera on tylko linki do "
+"innych plików. \n"
+"Możesz otworzyć go w edytorze tekstowym i pobrać aktualne pliki dźwiękowe."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11082,16 +11841,27 @@ msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
 "Audacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr "\"%s\" jest plikiem Windows Media Audio. \nAudacity nie może otworzyć tego typu pliku z powodów patentowych. \nMusisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest plikiem Windows Media Audio. \n"
+"Audacity nie może otworzyć tego typu pliku z powodów patentowych. \n"
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
+"AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
-"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr "\"%s\" jest plikiem Advanced Audio Coding.\nBez opcjonalnej biblioteki FFmpeg, Audacity nie może otworzyć tego typu pliku.\nW przeciwnym razie musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
+"Without the optional FFmpeg library, Audacity cannot open this type of "
+"file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV "
+"or AIFF."
+msgstr ""
+"\"%s\" jest plikiem Advanced Audio Coding.\n"
+"Bez opcjonalnej biblioteki FFmpeg, Audacity nie może otworzyć tego typu "
+"pliku.\n"
+"W przeciwnym razie musisz przekonwertować plik do obsługiwanego formatu, "
+"takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11102,7 +11872,12 @@ msgid ""
 "Audacity cannot open this type of file due to the encryption. \n"
 "Try recording the file into Audacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
-msgstr "\"%s\" jest zakodowanym plikiem dźwiękowym. \nPliki te pochodzą zazwyczaj z internetowych sklepów muzycznych. \nAudacity nie może otworzyć tego typu pliku z powodu jego zakodowania. \nSpróbuj zgrać plik w Audacity lub wypal go na płytę, a następnie \nwypakuj ścieżkę do obsługiwanego formatu, takiego jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest zakodowanym plikiem dźwiękowym. \n"
+"Pliki te pochodzą zazwyczaj z internetowych sklepów muzycznych. \n"
+"Audacity nie może otworzyć tego typu pliku z powodu jego zakodowania. \n"
+"Spróbuj zgrać plik w Audacity lub wypal go na płytę, a następnie \n"
+"wypakuj ścieżkę do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11111,7 +11886,11 @@ msgid ""
 "\"%s\" is a RealPlayer media file. \n"
 "Audacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr "\"%s\" jest plikiem RealPlayer. \nAudacity nie może otworzyć tego typu pliku. \nMusisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest plikiem RealPlayer. \n"
+"Audacity nie może otworzyć tego typu pliku. \n"
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
+"AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11121,7 +11900,12 @@ msgid ""
 "Audacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
 "then import it, or record it into Audacity."
-msgstr "\"%s\" jest plikiem opartym o nuty, a nie plikiem dźwiękowym. \nAudacity nie może otworzyć tego typu pliku. \nSpróbuj przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF, \na następnie zaimportuj go lub nagraj go w Audacity."
+msgstr ""
+"\"%s\" jest plikiem opartym o nuty, a nie plikiem dźwiękowym. \n"
+"Audacity nie może otworzyć tego typu pliku. \n"
+"Spróbuj przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
+"AIFF, \n"
+"a następnie zaimportuj go lub nagraj go w Audacity."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11130,9 +11914,16 @@ msgid ""
 "\"%s\" is a Musepack audio file. \n"
 "Audacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
-"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"and try importing it again. Otherwise you need to convert it to a supported "
+"audio \n"
 "format, such as WAV or AIFF."
-msgstr "\"%s\" jest plikiem dźwiękowym Musepack. \nAudacity nie może otworzyć tego typu pliku. \nJeśli myślisz, że może to być plik mp3, to zmień jego nazwę na zakończoną \".mp3\" \ni spróbuj ponownie go zaimportować. W przeciwnym razie musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest plikiem dźwiękowym Musepack. \n"
+"Audacity nie może otworzyć tego typu pliku. \n"
+"Jeśli myślisz, że może to być plik mp3, to zmień jego nazwę na zakończoną \"."
+"mp3\" \n"
+"i spróbuj ponownie go zaimportować. W przeciwnym razie musisz "
+"przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11141,7 +11932,11 @@ msgid ""
 "\"%s\" is a Wavpack audio file. \n"
 "Audacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr "\"%s\" jest plikiem dźwiękowym Wavpack. \nAudacity nie może otworzyć tego typu pliku. \nMusisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest plikiem dźwiękowym Wavpack. \n"
+"Audacity nie może otworzyć tego typu pliku. \n"
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
+"AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11150,7 +11945,11 @@ msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
 "Audacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr "\"%s\" jest plikiem dźwiękowym Dolby Digital. \nAudacity nie może otworzyć tego typu pliku. \nMusisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest plikiem dźwiękowym Dolby Digital. \n"
+"Audacity nie może otworzyć tego typu pliku. \n"
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
+"AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11159,7 +11958,11 @@ msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
 "Audacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr "\"%s\" jest plikiem dźwiękowym Ogg Speex. \nAudacity nie może otworzyć tego typu pliku. \nMusisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest plikiem dźwiękowym Ogg Speex. \n"
+"Audacity nie może otworzyć tego typu pliku. \n"
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
+"AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11168,7 +11971,11 @@ msgid ""
 "\"%s\" is a video file. \n"
 "Audacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
-msgstr "\"%s\" jest plikiem zawierającym film. \nAudacity nie może otworzyć tego typu pliku. \nMusisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
+msgstr ""
+"\"%s\" jest plikiem zawierającym film. \n"
+"Audacity nie może otworzyć tego typu pliku. \n"
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
+"AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
@@ -11176,7 +11983,9 @@ msgstr "\"%s\" jest plikiem zawierającym film. \nAudacity nie może otworzyć t
 msgid ""
 "\"%s\" is an Audacity Project file. \n"
 "Use the 'File > Open' command to open Audacity Projects."
-msgstr "\"%s\" jest plikiem projektu Audacity. \nUżyj polecenia 'Plik > Otwórz...', aby otworzyć Audacity projekty."
+msgstr ""
+"\"%s\" jest plikiem projektu Audacity. \n"
+"Użyj polecenia 'Plik > Otwórz...', aby otworzyć Audacity projekty."
 
 #: src/import/Import.cpp
 #, c-format
@@ -11188,8 +11997,12 @@ msgstr "Nie znaleziono pliku \"%s\"."
 #, c-format
 msgid ""
 "Audacity did not recognize the type of the file '%s'.\n"
-"Try installing FFmpeg. For uncompressed files, also try File > Import > Raw Data."
-msgstr "Audacity nie rozpoznał typu pliku '%s'.\nSpróbuj zainstalować FFmpeg. Dla nieskompresowanych plików spróbuj 'Plik > Importuj > Dane surowe...'."
+"Try installing FFmpeg. For uncompressed files, also try File > Import > Raw "
+"Data."
+msgstr ""
+"Audacity nie rozpoznał typu pliku '%s'.\n"
+"Spróbuj zainstalować FFmpeg. Dla nieskompresowanych plików spróbuj 'Plik > "
+"Importuj > Dane surowe...'."
 
 #: src/import/Import.cpp src/menus/ClipMenus.cpp
 #, c-format
@@ -11204,7 +12017,11 @@ msgid ""
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
-msgstr "Audacity rozpoznał typ pliku '%s'.\nProgramy przypuszczalnie importujące takie pliki to:\n%s,\nale żaden z nich nie odczytał tego formatu pliku."
+msgstr ""
+"Audacity rozpoznał typ pliku '%s'.\n"
+"Programy przypuszczalnie importujące takie pliki to:\n"
+"%s,\n"
+"ale żaden z nich nie odczytał tego formatu pliku."
 
 #: src/import/Import.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11220,7 +12037,9 @@ msgstr "Pliki kompatybilne z FFmpeg"
 #, c-format
 msgid ""
 "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
-msgstr "Indeks[%02x] Kodek[%s], Język[%s], Częstotliwość próbkowania[%s], Kanały[%d], Długość[%d]"
+msgstr ""
+"Indeks[%02x] Kodek[%s], Język[%s], Częstotliwość próbkowania[%s], "
+"Kanały[%d], Długość[%d]"
 
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
@@ -11281,7 +12100,9 @@ msgstr "Nieprawidłowa długość w pliku LOF."
 
 #: src/import/ImportLOF.cpp
 msgid "MIDI tracks cannot be offset individually, only audio files can be."
-msgstr "Ścieżki MIDI nie mogą być przesuwane indywidualnie, mogą to być jedynie pliki dźwiękowe."
+msgstr ""
+"Ścieżki MIDI nie mogą być przesuwane indywidualnie, mogą to być jedynie "
+"pliki dźwiękowe."
 
 #. i18n-hint: You do not need to translate "LOF"
 #: src/import/ImportLOF.cpp
@@ -11528,29 +12349,50 @@ msgstr "Vorbis"
 
 #: src/import/ImportPCM.cpp
 msgid ""
-"When importing uncompressed audio files you can either copy them into the project, or read them directly from their current location (without copying).\n"
+"When importing uncompressed audio files you can either copy them into the "
+"project, or read them directly from their current location (without "
+"copying).\n"
 "\n"
-msgstr "Podczas importowania nieskompresowanych plików dźiękowych możesz je skopiować do projektu lub przeczytać bezpośrednio z ich bieżącej lokalizacji (bez kopiowania).\n\n"
+msgstr ""
+"Podczas importowania nieskompresowanych plików dźiękowych możesz je "
+"skopiować do projektu lub przeczytać bezpośrednio z ich bieżącej lokalizacji "
+"(bez kopiowania).\n"
+"\n"
 
 #: src/import/ImportPCM.cpp
 msgid ""
 "Your current preference is set to copy in.\n"
 "\n"
-msgstr "Twoje bieżące ustawienie jest ustawione na kopiowanie.\n\n"
+msgstr ""
+"Twoje bieżące ustawienie jest ustawione na kopiowanie.\n"
+"\n"
 
 #: src/import/ImportPCM.cpp
 msgid ""
 "Your current preference is set to read directly.\n"
 "\n"
-msgstr "Twoje bieżące ustawienie jest ustawione na czytanie bezpośrednie.\n\n"
+msgstr ""
+"Twoje bieżące ustawienie jest ustawione na czytanie bezpośrednie.\n"
+"\n"
 
 #: src/import/ImportPCM.cpp
 msgid ""
-"Reading the files directly allows you to play or edit them almost immediately. This is less safe than copying in, because you must retain the files with their original names in their original locations.\n"
-"Help > Diagnostics > Check Dependencies will show the original names and locations of any files that you are reading directly.\n"
+"Reading the files directly allows you to play or edit them almost "
+"immediately. This is less safe than copying in, because you must retain the "
+"files with their original names in their original locations.\n"
+"Help > Diagnostics > Check Dependencies will show the original names and "
+"locations of any files that you are reading directly.\n"
 "\n"
 "How do you want to import the current file(s)?"
-msgstr "Bezpośrednie odczytywanie plików pozwala na ich edytowanie i odtwarzanie niemal natychmiastowo. Jest to mniej bezpieczne niż jego skopiowanie, bo musisz zachować pliki z ich oryginalnymi nazwami, w ich oryginalnych miejscach.\n'Pomoc > Diagnostyka > Sprawdź zależności...' pokaże oryginalne nazwy i położenia każdego pliku odczytywanego bezpośrednio.\n\nJak chcesz zaimportować bieżący(e) plik(i)?"
+msgstr ""
+"Bezpośrednie odczytywanie plików pozwala na ich edytowanie i odtwarzanie "
+"niemal natychmiastowo. Jest to mniej bezpieczne niż jego skopiowanie, bo "
+"musisz zachować pliki z ich oryginalnymi nazwami, w ich oryginalnych "
+"miejscach.\n"
+"'Pomoc > Diagnostyka > Sprawdź zależności...' pokaże oryginalne nazwy i "
+"położenia każdego pliku odczytywanego bezpośrednio.\n"
+"\n"
+"Jak chcesz zaimportować bieżący(e) plik(i)?"
 
 #: src/import/ImportPCM.cpp
 msgid "Choose an import method"
@@ -11566,7 +12408,8 @@ msgstr "Czytaj pliki &bezpośrednio z oryginału (szybsze)"
 
 #: src/import/ImportPCM.cpp
 msgid "Don't &warn again and always use my choice above"
-msgstr "Nie &ostrzegaj mnie ponownie i zawsze używaj mojego wyboru podanego powyżej"
+msgstr ""
+"Nie &ostrzegaj mnie ponownie i zawsze używaj mojego wyboru podanego powyżej"
 
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
@@ -11692,6 +12535,7 @@ msgstr "%s prawo"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 msgid "dummyStringClipBoundaryMessage"
 msgstr "dummyStringClipBoundaryMessage"
@@ -11717,10 +12561,11 @@ msgstr "koniec"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 msgid "dummyStringClipBoundaryMessageLong"
 msgstr "dummyStringClipBoundaryMessageLong"
@@ -12106,7 +12951,9 @@ msgstr "Plik Allegro"
 msgid ""
 "You have selected a filename with an unrecognized file extension.\n"
 "Do you want to continue?"
-msgstr "Zaznaczyłeś nazwę pliku z nierozpoznawalnym rozszerzeniem.\nChcesz kontynuować?"
+msgstr ""
+"Zaznaczyłeś nazwę pliku z nierozpoznawalnym rozszerzeniem.\n"
+"Chcesz kontynuować?"
 
 #: src/menus/FileMenus.cpp
 msgid "Export MIDI"
@@ -13016,6 +13863,7 @@ msgstr "Kursor mo&cno w prawo"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Szu&kaj"
@@ -13225,7 +14073,9 @@ msgstr "Utworzono nową etykietę ścieżki"
 #: src/menus/TrackMenus.cpp
 msgid ""
 "This version of Audacity only allows one time track for each project window."
-msgstr "Ta wersja Audacity pozwala tylko na jedną ścieżkę czasową dla każdego okna projektu."
+msgstr ""
+"Ta wersja Audacity pozwala tylko na jedną ścieżkę czasową dla każdego okna "
+"projektu."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
@@ -13263,7 +14113,9 @@ msgstr "Zaznacz co najmniej jedną ścieżkę dźwiękową i jedną ścieżkę M
 msgid ""
 "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f "
 "secs."
-msgstr "Wyrównanie ukończone: MIDI od %.2f do %.2f sekundy, dźwięk od %.2f do %.2f sekundy"
+msgstr ""
+"Wyrównanie ukończone: MIDI od %.2f do %.2f sekundy, dźwięk od %.2f do %.2f "
+"sekundy"
 
 #: src/menus/TrackMenus.cpp
 msgid "Sync MIDI with Audio"
@@ -13274,7 +14126,9 @@ msgstr "Zsynchronizuj MIDI z dźwiękiem"
 msgid ""
 "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from "
 "%.2f to %.2f secs."
-msgstr "Błąd wyrównania: wejście za krótkie: MIDI od %.2f do %.2f sekundy, dźwięk od %.2f do %.2f sekundy"
+msgstr ""
+"Błąd wyrównania: wejście za krótkie: MIDI od %.2f do %.2f sekundy, dźwięk od "
+"%.2f do %.2f sekundy"
 
 #: src/menus/TrackMenus.cpp
 msgid "Internal error reported by alignment process."
@@ -13510,21 +14364,41 @@ msgid ""
 "Timer Recording cannot be used with more than one open project.\n"
 "\n"
 "Please close any additional projects and try again."
-msgstr "Nagrywanie czasowe nie może być użyte z więcej niż jednym otwartym projektem.\n\nZamknij wszystkie dodatkowe projekty i spróbuj ponownie."
+msgstr ""
+"Nagrywanie czasowe nie może być użyte z więcej niż jednym otwartym "
+"projektem.\n"
+"\n"
+"Zamknij wszystkie dodatkowe projekty i spróbuj ponownie."
 
 #: src/menus/TransportMenus.cpp
 msgid ""
 "Timer Recording cannot be used while you have unsaved changes.\n"
 "\n"
 "Please save or close this project and try again."
-msgstr "Nagrywanie czasowe nie może być użyte, gdy masz niezapisane zmiany.\n\nZapisz lub zamknij ten projekt i spróbuj ponownie."
+msgstr ""
+"Nagrywanie czasowe nie może być użyte, gdy masz niezapisane zmiany.\n"
+"\n"
+"Zapisz lub zamknij ten projekt i spróbuj ponownie."
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Zaznacz ścieżkę mono."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Zaznacz ścieżkę stereo."
 
 #: src/menus/TransportMenus.cpp
@@ -13883,8 +14757,7 @@ msgstr "Odtwarzanie"
 msgid "&Device:"
 msgstr "&Urządzenie:"
 
-#. i18n-hint: These are strings for the status bar, and indicate whether
-#. Audacity
+#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
 #: src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h
@@ -13964,7 +14837,9 @@ msgstr "Pamięć podręczna dźwięku"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Play and/or record using &RAM (useful for slow drives)"
-msgstr "Odtwarzaj i/lub nagrywaj, wykorzystując pamięć &RAM (przydatne dla wolnych komputerów)"
+msgstr ""
+"Odtwarzaj i/lub nagrywaj, wykorzystując pamięć &RAM (przydatne dla wolnych "
+"komputerów)"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Mi&nimum Free Memory (MB):"
@@ -13974,7 +14849,9 @@ msgstr "Mi&nimum wolnej pamięci (MB):"
 msgid ""
 "If the available system memory falls below this value, audio will no longer\n"
 "be cached in memory and will be written to disk."
-msgstr "Jeśli dostępna pamięć systemowa spadnie poniżej tej wartości, to dźwięk\nnie będzie już zapisywany do pamięci i będzie zapisywany na dysku."
+msgstr ""
+"Jeśli dostępna pamięć systemowa spadnie poniżej tej wartości, to dźwięk\n"
+"nie będzie już zapisywany do pamięci i będzie zapisywany na dysku."
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location to place the temporary directory"
@@ -14007,7 +14884,9 @@ msgstr "Nie da się zapisać do katalogu %s"
 msgid ""
 "Changes to temporary directory will not take effect until Audacity is "
 "restarted"
-msgstr "Zmiana katalogu tymczasowego będzie nieaktywna aż do zrestartowania programu Audacity"
+msgstr ""
+"Zmiana katalogu tymczasowego będzie nieaktywna aż do zrestartowania programu "
+"Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -14039,6 +14918,7 @@ msgstr "Grupuj według typu"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "&LADSPA"
@@ -14050,23 +14930,20 @@ msgid "LV&2"
 msgstr "LV&2"
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or
-#. Nyqvist).
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
 #. In the translations of this and other strings, you may transliterate the
 #. name into another alphabet.
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "N&yquist"
 
-#. i18n-hint: Vamp is the proper name of a software protocol for sound
-#. analysis.
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
 #. It is not an abbreviation for anything.  See http://vamp-plugins.org
 #: src/prefs/EffectsPrefs.cpp
 msgid "&Vamp"
 msgstr "&Vamp"
 
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software
-#. protocol
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
 #. developed by Steinberg GmbH
 #: src/prefs/EffectsPrefs.cpp
 msgid "V&ST"
@@ -14172,7 +15049,11 @@ msgid ""
 "the items. They are likely to break the pattern matching. Unless you know "
 "what you are doing, it is recommended to trim spaces. Do you want Audacity "
 "to trim spaces for you?"
-msgstr "W jednym z elementów istnieją znaki odstępu (spacje, nowe linie, tabulatory). Na pewno popsują one dopasowywanie do wzorca. Zalecane jest obcięcie spacji, chyba że wiesz, co robisz. Chcesz, aby Audacity obciął spacje za Ciebie?"
+msgstr ""
+"W jednym z elementów istnieją znaki odstępu (spacje, nowe linie, "
+"tabulatory). Na pewno popsują one dopasowywanie do wzorca. Zalecane jest "
+"obcięcie spacji, chyba że wiesz, co robisz. Chcesz, aby Audacity obciął "
+"spacje za Ciebie?"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -14260,8 +15141,7 @@ msgstr "Wysoki kontrast"
 msgid "Custom"
 msgstr "Niestandardowy"
 
-#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp
-#: src/prefs/WaveformPrefs.cpp
+#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
 msgid "Display"
 msgstr "Wyświetlacz"
 
@@ -14452,7 +15332,8 @@ msgstr "&Ustaw"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
-msgstr "Uwaga: Naciśnięcie Cmd+Q spowoduje wyjście. Pozostałe klawisze są prawidłowe."
+msgstr ""
+"Uwaga: Naciśnięcie Cmd+Q spowoduje wyjście. Pozostałe klawisze są prawidłowe."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "&Import..."
@@ -14466,7 +15347,9 @@ msgstr "&Domyślne"
 msgid ""
 "\n"
 "   *   \""
-msgstr "\n   *   \""
+msgstr ""
+"\n"
+"   *   \""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "\"  (because the shortcut '"
@@ -14500,7 +15383,9 @@ msgstr "\" i \""
 msgid ""
 "\".\n"
 "Nothing is imported."
-msgstr "\".\nNic nie importowano."
+msgstr ""
+"\".\n"
+"Nic nie importowano."
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -14510,8 +15395,12 @@ msgstr "Załadowano %d skróty klawiaturowe\n"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid ""
 "\n"
-"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
-msgstr "\nNastępujące polecenia nie są wymienione w importowanym pliku, ale ich skróty zostały usunięte z powodu konfliktu z innymi nowymi skrótami:\n"
+"The following commands are not mentioned in the imported file, but have "
+"their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
+"\n"
+"Następujące polecenia nie są wymienione w importowanym pliku, ale ich skróty "
+"zostały usunięte z powodu konfliktu z innymi nowymi skrótami:\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -14545,7 +15434,16 @@ msgid ""
 "\t'%s'\n"
 "\n"
 "instead. Otherwise, click Cancel."
-msgstr "Skrót klawiaturowy '%s' jest już przypisany do:\n\n\t'%s'\n\nKliknij na przycisk OK, aby przypisać skrót do\n\n\t'%s'\n\nW przeciwnym razie kliknij Anuluj."
+msgstr ""
+"Skrót klawiaturowy '%s' jest już przypisany do:\n"
+"\n"
+"\t'%s'\n"
+"\n"
+"Kliknij na przycisk OK, aby przypisać skrót do\n"
+"\n"
+"\t'%s'\n"
+"\n"
+"W przeciwnym razie kliknij Anuluj."
 
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
@@ -14611,7 +15509,9 @@ msgstr "Zezwalaj na ładowanie na żądanie w &tle"
 msgid ""
 "Audacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
-msgstr "Audacity samoczynnie wykrył prawidłowe biblioteki FFmpeg.\nNadal chcesz ustalić ich położenie ręcznie?"
+msgstr ""
+"Audacity samoczynnie wykrył prawidłowe biblioteki FFmpeg.\n"
+"Nadal chcesz ustalić ich położenie ręcznie?"
 
 #: src/prefs/LibraryPrefs.cpp
 msgid "Success"
@@ -14650,8 +15550,7 @@ msgstr "Opóźnienie syntetyzatora MIDI musi być liczbą całkowitą"
 msgid "Midi IO"
 msgstr "WEJ./WYJ. MIDI"
 
-#. i18n-hint: Modules are optional extensions to Audacity that add NEW
-#. features.
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
 msgstr "Moduły"
@@ -14662,22 +15561,28 @@ msgstr "Ustawienia modułu"
 
 #: src/prefs/ModulePrefs.cpp
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Audacity "
+"Manual\n"
 "and know what you are doing."
-msgstr "To są moduły eksperymentalne. Włącz je, jeśli już\nprzeczytałeś instrukcję i wiesz, co robisz."
+msgstr ""
+"To są moduły eksperymentalne. Włącz je, jeśli już\n"
+"przeczytałeś instrukcję i wiesz, co robisz."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
 msgid ""
 "  'Ask' means Audacity will ask if you want to load the module each time it "
 "starts."
-msgstr "  'Zapytaj' oznacza, że Audacity zapyta, czy chcesz załadować moduł przy każdym uruchomieniu."
+msgstr ""
+"  'Zapytaj' oznacza, że Audacity zapyta, czy chcesz załadować moduł przy "
+"każdym uruchomieniu."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid ""
-"  'Failed' means Audacity thinks the module is broken and won't run it."
-msgstr "  'Niepowodzenie' oznacza, że Audacity sądzi, że moduł jest uszkodzony i nie chce go uruchomić."
+msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+msgstr ""
+"  'Niepowodzenie' oznacza, że Audacity sądzi, że moduł jest uszkodzony i nie "
+"chce go uruchomić."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -14686,7 +15591,8 @@ msgstr "'Nowy' oznacza wybór, który nie został jeszcze wykonany."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Changes to these settings only take effect when Audacity starts up."
-msgstr "Zmiany tych ustawień wejdą w życie tylko po ponownym uruchomieniu Audacity."
+msgstr ""
+"Zmiany tych ustawień wejdą w życie tylko po ponownym uruchomieniu Audacity."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -14986,7 +15892,8 @@ msgstr "Ustawienia projektów"
 
 #: src/prefs/ProjectsPrefs.cpp
 msgid "When saving a project that depends on other audio files"
-msgstr "Podczas zapisywania projektu, który jest zależny od innych plików dźwiękowych"
+msgstr ""
+"Podczas zapisywania projektu, który jest zależny od innych plików dźwiękowych"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "16-bit"
@@ -15029,8 +15936,7 @@ msgstr "Przekształcanie w czasie rzeczywistym"
 msgid "Sample Rate Con&verter:"
 msgstr "Prze&kształcanie częstotliwości próbkowania:"
 
-#. i18n-hint: technical term for randomization to reduce undesirable
-#. resampling artifacts
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
 #: src/prefs/QualityPrefs.cpp
 msgid "&Dither:"
 msgstr "&Dither:"
@@ -15043,8 +15949,7 @@ msgstr "Przekształcanie wysokiej jakości"
 msgid "Sample Rate Conver&ter:"
 msgstr "Przeksz&tałcanie częstotliwości próbkowania:"
 
-#. i18n-hint: technical term for randomization to reduce undesirable
-#. resampling artifacts
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Dit&her:"
@@ -15069,8 +15974,7 @@ msgstr "&Oprogramowanie odtwarzania danych wejściowych"
 msgid "Record on a new track"
 msgstr "Nagrywaj na nowej ścieżce"
 
-#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the
-#. recording
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
 #: src/prefs/RecordingPrefs.cpp
 msgid "Detect dropouts"
 msgstr "Wykryj przerwy"
@@ -15167,14 +16071,12 @@ msgstr "&Przenikanie:"
 msgid "Mel"
 msgstr "Mel"
 
-#. i18n-hint: The name of a frequency scale in psychoacoustics, named for
-#. Heinrich Barkhausen
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Bark"
 msgstr "Bark"
 
-#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates
-#. Equivalent Rectangular Bandwidth
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
 #: src/prefs/SpectrogramSettings.cpp
 msgid "ERB"
 msgstr "ERB"
@@ -15315,8 +16217,7 @@ msgstr "&Włącz zaznaczenie widma"
 msgid "Show a grid along the &Y-axis"
 msgstr "Pokaż siatkę wzdłuż osi &Y"
 
-#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be
-#. translated
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
 #: src/prefs/SpectrumPrefs.cpp
 msgid "FFT Find Notes"
 msgstr "Znajdź nuty FFT"
@@ -15378,8 +16279,7 @@ msgid "The maximum number of notes must be in the range 1..128"
 msgstr "Maksymalna liczba nut musi zawierać się w zakresie 1..128"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
-#. graphical user interface, including choices of colors, and similarity of
-#. images
+#. graphical user interface, including choices of colors, and similarity of images
 #. such as those on button controls.  Audacity can load and save alternative
 #. themes.
 #: src/prefs/ThemePrefs.cpp src/prefs/ThemePrefs.h
@@ -15398,20 +16298,39 @@ msgstr "Info"
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
-"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images "
+"and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into "
+"Audacity.\n"
 "\n"
-"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently "
+"affected, even\n"
 "though the image file shows other icons too.)"
-msgstr "Ubieranie w motywy jest funkcją eksperymentalną.\n\nWypróbuj ją przez kliknięcie na \"Zapisz pamięć podręczną motywu\", a następnie znajdź i zmodyfikuj obrazy i kolory w\nImageCacheVxx.png, wykorzystując edytor obrazów, np. Gimp.\n\nKliknij \"Wczytaj pamięć podręczną motywu\", aby wczytać zmienione obrazy i kolory z powrotem do Audacity.\n\n(Na razie tylko pasek narzędzi transportu i kolory na ścieżce fali są zmieniane, nawet\nw przypadku gdy plik obrazu pokazuje także inne ikony.)"
+msgstr ""
+"Ubieranie w motywy jest funkcją eksperymentalną.\n"
+"\n"
+"Wypróbuj ją przez kliknięcie na \"Zapisz pamięć podręczną motywu\", a "
+"następnie znajdź i zmodyfikuj obrazy i kolory w\n"
+"ImageCacheVxx.png, wykorzystując edytor obrazów, np. Gimp.\n"
+"\n"
+"Kliknij \"Wczytaj pamięć podręczną motywu\", aby wczytać zmienione obrazy i "
+"kolory z powrotem do Audacity.\n"
+"\n"
+"(Na razie tylko pasek narzędzi transportu i kolory na ścieżce fali są "
+"zmieniane, nawet\n"
+"w przypadku gdy plik obrazu pokazuje także inne ikony.)"
 
 #: src/prefs/ThemePrefs.cpp
 msgid ""
-"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"Saving and loading individual theme files uses a separate file for each "
+"image, but is\n"
 "otherwise the same idea."
-msgstr "Zapisywanie i wczytywanie indywidualnych plików motywów używa oddzielnego pliku\ndla każdego obrazu, ale jest pod każdym względem tym samym pomysłem."
+msgstr ""
+"Zapisywanie i wczytywanie indywidualnych plików motywów używa oddzielnego "
+"pliku\n"
+"dla każdego obrazu, ale jest pod każdym względem tym samym pomysłem."
 
 #. i18n-hint: && in here is an escape character to get a single & on screen,
 #. * so keep it as is
@@ -15475,7 +16394,8 @@ msgstr "Edytowanie klipu &może przesunąć inne klipy"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "\"Move track focus\" c&ycles repeatedly through tracks"
-msgstr "\"Przesuń uaktywnienie ścieżki\" przesuwa się c&yklicznie przez ścieżki"
+msgstr ""
+"\"Przesuń uaktywnienie ścieżki\" przesuwa się c&yklicznie przez ścieżki"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "&Type to create a label"
@@ -15696,15 +16616,13 @@ msgstr "Ustawienia kształtów fali"
 msgid "Waveform dB &range:"
 msgstr "&Zakres dB kształtu fali:"
 
-#. i18n-hint: These are strings for the status bar, and indicate whether
-#. Audacity
+#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp
 msgid "Playing"
 msgstr "Odtwarzanie"
 
-#. i18n-hint: These are strings for the status bar, and indicate whether
-#. Audacity
+#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp
 msgid "Stopped"
@@ -15742,8 +16660,7 @@ msgstr "Zaznacz do końca"
 msgid "Select to Start"
 msgstr "Zaznacz do początku"
 
-#. i18n-hint: These are strings for the status bar, and indicate whether
-#. Audacity
+#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
@@ -15870,8 +16787,7 @@ msgstr "Miernik nagrywania"
 msgid "Playback Meter"
 msgstr "Miernik odtwarzania"
 
-#. i18n-hint: (noun) The meter that shows the loudness of the audio being
-#. recorded.
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
 #. This is the name used in screen reader software, where having 'Meter' first
 #. apparently is helpful to partially sighted people.
 #: src/toolbars/MeterToolBar.cpp
@@ -15957,6 +16873,7 @@ msgstr "Przewijanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Zatrzymaj przewijanie"
@@ -15964,6 +16881,7 @@ msgstr "Zatrzymaj przewijanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Rozpocznij przewijanie"
@@ -15971,6 +16889,7 @@ msgstr "Rozpocznij przewijanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Zatrzymaj szukanie"
@@ -15978,6 +16897,7 @@ msgstr "Zatrzymaj szukanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Rozpocznij szukanie"
@@ -16277,9 +17197,11 @@ msgstr "Okta&wa w dół"
 #: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid ""
-"Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom"
-" region."
-msgstr "Kliknij, aby powiększyć w pionie. Kliknij z Shift, aby pomniejszyć. Przeciągnij, aby określić obszar powiększenia."
+"Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom "
+"region."
+msgstr ""
+"Kliknij, aby powiększyć w pionie. Kliknij z Shift, aby pomniejszyć. "
+"Przeciągnij, aby określić obszar powiększenia."
 
 #: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
@@ -16356,7 +17278,8 @@ msgstr "Kliknij i przeciągnij, aby edytować sampel"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "To use Draw, zoom in further until you can see the individual samples."
-msgstr "Aby użyć rysowania, przybliżaj do momentu zobaczenia pojedynczych sampli."
+msgstr ""
+"Aby użyć rysowania, przybliżaj do momentu zobaczenia pojedynczych sampli."
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
@@ -16387,7 +17310,9 @@ msgstr "&Spektrogram"
 msgid ""
 "To change Spectrogram Settings, stop any\n"
 " playing or recording first."
-msgstr "Aby zmienić Ustawienia spektrogramu, najpierw\nzatrzymaj odtwarzanie lub nagrywanie."
+msgstr ""
+"Aby zmienić Ustawienia spektrogramu, najpierw\n"
+"zatrzymaj odtwarzanie lub nagrywanie."
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "Stop the Audio First"
@@ -16402,8 +17327,7 @@ msgid "&Format"
 msgstr "&Format"
 
 #. i18n-hint: The strings name a track and a format
-#. i18n-hint: The strings name a track and a channel choice (mono, left, or
-#. right)
+#. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
@@ -16600,7 +17524,9 @@ msgstr "%.0f%% prawo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid ""
 "Click and drag to adjust sizes of sub-views, double-click to split evenly"
-msgstr "Kliknij i przeciągnij, aby dostosować rozmiary widoków podrzędnych, kliknij podwójnie myszką, aby rozdzielić równomiernie"
+msgstr ""
+"Kliknij i przeciągnij, aby dostosować rozmiary widoków podrzędnych, kliknij "
+"podwójnie myszką, aby rozdzielić równomiernie"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
@@ -16758,6 +17684,7 @@ msgstr "Wyrównana obwiednia."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "Prze&wijaj"
@@ -16769,6 +17696,7 @@ msgstr "Szukanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Linijka przewijania"
@@ -16815,23 +17743,26 @@ msgstr "Kliknij i przeciągnij, aby przesunąć górę zaznaczonej częstotliwo�
 
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to move center selection frequency to a spectral peak."
-msgstr "Kliknij i przeciągnij, aby przesunąć środek zaznaczonej częstotliwości do szczytu widma."
+msgstr ""
+"Kliknij i przeciągnij, aby przesunąć środek zaznaczonej częstotliwości do "
+"szczytu widma."
 
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to move center selection frequency."
-msgstr "Kliknij i przeciągnij, aby przesunąć środek zaznaczonej częstotliwości."
+msgstr ""
+"Kliknij i przeciągnij, aby przesunąć środek zaznaczonej częstotliwości."
 
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to adjust frequency bandwidth."
-msgstr " Kliknij i przeciągnij, aby określić przepustowość pasma częstotliwości."
+msgstr ""
+" Kliknij i przeciągnij, aby określić przepustowość pasma częstotliwości."
 
 #. i18n-hint: These are the names of a menu and a command in that menu
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Edit, Preferences..."
 msgstr "Edycja, Ustawienia..."
 
-#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux,
-#. "Command+," for Mac
+#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac
 #: src/tracks/ui/SelectHandle.cpp
 #, c-format
 msgid "Multi-Tool Mode: %s for Mouse and Keyboard Preferences."
@@ -16845,8 +17776,7 @@ msgstr "Kliknij i przeciągnij, aby ustawić przepustowość pasma częstotliwo�
 msgid "Click and drag to select audio"
 msgstr "Kliknij i przeciągnij, aby zaznaczyć dźwięk."
 
-#. i18n-hint: "Snapping" means automatic alignment of selection edges to any
-#. nearby label or clip boundaries
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
 #: src/tracks/ui/SelectHandle.cpp
 msgid "(snapping)"
 msgstr "(podpinanie)"
@@ -16899,15 +17829,15 @@ msgstr "Polecenie+kliknij"
 msgid "Ctrl+Click"
 msgstr "Ctrl+kliknij"
 
-#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows,
-#. 'Command+Click' on Mac
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track. Drag up or down to change track order."
-msgstr "%s, aby zaznaczyć lub odznaczyć ścieżki. Przeciągnij w górę lub w dół, aby zmienić kolejność ścieżek."
+msgstr ""
+"%s, aby zaznaczyć lub odznaczyć ścieżki. Przeciągnij w górę lub w dół, aby "
+"zmienić kolejność ścieżek."
 
-#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows,
-#. 'Command+Click' on Mac
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track."
@@ -16934,7 +17864,9 @@ msgstr "Kliknij, aby zwiększyć podgląd; kliknij z Shift, aby zmniejszyć"
 
 #: src/tracks/ui/ZoomHandle.cpp
 msgid "Drag to Zoom Into Region, Right-Click to Zoom Out"
-msgstr "Przeciągnij lewym przyciskiem myszki, aby zwiększyć; kliknij z prawym przyciskiem myszki, aby zmniejszyć"
+msgstr ""
+"Przeciągnij lewym przyciskiem myszki, aby zwiększyć; kliknij z prawym "
+"przyciskiem myszki, aby zmniejszyć"
 
 #: src/tracks/ui/ZoomHandle.cpp
 msgid "Left=Zoom In, Right=Zoom Out, Middle=Normal"
@@ -17053,7 +17985,10 @@ msgid ""
 "Higher refresh rates make the meter show more frequent\n"
 "changes. A rate of 30 per second or less should prevent\n"
 "the meter affecting audio quality on slower machines."
-msgstr "Wyższy współczynnik odświeżania sprawia, że miernik częściej pokazuje\nzmiany. Współczynnik 30 na sekundę lub mniej, powinien zapobiec\nwpływowi miernika na jakość dźwięku na słabszych komputerach."
+msgstr ""
+"Wyższy współczynnik odświeżania sprawia, że miernik częściej pokazuje\n"
+"zmiany. Współczynnik 30 na sekundę lub mniej, powinien zapobiec\n"
+"wpływowi miernika na jakość dźwięku na słabszych komputerach."
 
 #: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
@@ -17166,8 +18101,7 @@ msgstr "gg:mm:ss + setne"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
-#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for
-#. seconds
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
 #. * (the hundredths are shown as decimal seconds) . Don't change the numbers
 #. * unless there aren't 60 minutes in an hour in your locale
 #: src/widgets/NumericTextCtrl.cpp
@@ -17181,8 +18115,7 @@ msgid "hh:mm:ss + milliseconds"
 msgstr "gg:mm:ss + milisekundy"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
-#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to
-#. the
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
 #. * abbreviation for minutes and 's' to the abbreviation for seconds (the
 #. * milliseconds are shown as decimal seconds) . Don't change the numbers
 #. * unless there aren't 60 minutes in an hour in your locale
@@ -17208,6 +18141,7 @@ msgstr "0100 g 060 m 060 s+.# sample"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "sample"
@@ -17511,8 +18445,8 @@ msgid "Value must not be less than %s"
 msgstr "Wartość nie może być mniejsza niż %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Wartość nie może być większa niż %s"
 
 #: src/widgets/valnum.cpp
@@ -17603,7 +18537,10 @@ msgid ""
 "No silences found.\n"
 "Try reducing the silence level and\n"
 "the minimum silence duration."
-msgstr "Nie znaleziono ciszy.\nSpróbuj zmniejszyć poziom ciszy\ni jej minimalną długość."
+msgstr ""
+"Nie znaleziono ciszy.\n"
+"Spróbuj zmniejszyć poziom ciszy\n"
+"i jej minimalną długość."
 
 #: plug-ins/SoundFinder.ny
 msgid "Sound Finder"
@@ -17642,7 +18579,9 @@ msgstr "Dodać etykietę na końcu ścieżki? [Nie=0, Tak=1]"
 msgid ""
 "No sounds found. Try reducing the silence~%level and minimum silence "
 "duration."
-msgstr "Nie znaleziono żadnych dźwięków. Spróbuj zmniejszyć poziom ciszy ~% i minimalną długość ciszy."
+msgstr ""
+"Nie znaleziono żadnych dźwięków. Spróbuj zmniejszyć poziom ciszy ~% i "
+"minimalną długość ciszy."
 
 #: plug-ins/SoundFinder.ny
 msgid "[End]"
@@ -17674,7 +18613,10 @@ msgid ""
 "~aBandwidth is zero (the upper and lower~%~\n"
 "                       frequencies are both ~a Hz).~%~\n"
 "                       Please select a frequency range."
-msgstr "~aSzerokość pasma wynosi zero (górna i dolna~%~\n                       częstotliwość wynoszą obie ~a Hz).~%~\n                       Wybierz zakres częstotliwości."
+msgstr ""
+"~aSzerokość pasma wynosi zero (górna i dolna~%~\n"
+"                       częstotliwość wynoszą obie ~a Hz).~%~\n"
+"                       Wybierz zakres częstotliwości."
 
 #: plug-ins/SpectralEditMulti.ny
 #, lisp-format
@@ -17682,7 +18624,10 @@ msgid ""
 "~aNotch filter parameters cannot be applied.~%~\n"
 "                      Try increasing the low frequency bound~%~\n"
 "                      or reduce the filter 'Width'."
-msgstr "~aParametry filtra Notch nie mogą być zastosowane.~%~\n                      Spróbuj zwiększyć granicę niskiej częstotliwości~%~\n                      lub zredukuj filtr 'Szerokość'."
+msgstr ""
+"~aParametry filtra Notch nie mogą być zastosowane.~%~\n"
+"                      Spróbuj zwiększyć granicę niskiej częstotliwości~%~\n"
+"                      lub zredukuj filtr 'Szerokość'."
 
 #: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
 #: plug-ins/SpectralEditShelves.ny
@@ -17717,9 +18662,14 @@ msgstr "~aCzęstotliwość środkowa musi być powyżej 0 Hz."
 #, lisp-format
 msgid ""
 "~aFrequency selection is too high for track sample rate.~%~\n"
-"                        For the current track, the high frequency setting cannot~%~\n"
+"                        For the current track, the high frequency setting "
+"cannot~%~\n"
 "                        be greater than ~a Hz"
-msgstr "~aCzęstotliwość zaznaczenia jest za wysoka dla próbkowania ścieżki.~%~\n                        W przypadku bieżącej ścieżki ustawienie wysokiej częstotliwości nie może~%~\n                        być większe niż ~a Hz"
+msgstr ""
+"~aCzęstotliwość zaznaczenia jest za wysoka dla próbkowania ścieżki.~%~\n"
+"                        W przypadku bieżącej ścieżki ustawienie wysokiej "
+"częstotliwości nie może~%~\n"
+"                        być większe niż ~a Hz"
 
 #: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
 #, lisp-format
@@ -17727,7 +18677,10 @@ msgid ""
 "~aBandwidth is zero (the upper and lower~%~\n"
 "                         frequencies are both ~a Hz).~%~\n"
 "                         Please select a frequency range."
-msgstr "~aSzerokość pasma wynosi zero (górna i dolna~%~\n                         częstotliwość wynoszą obie ~a Hz).~%~\n                         Wybierz zakres częstotliwości."
+msgstr ""
+"~aSzerokość pasma wynosi zero (górna i dolna~%~\n"
+"                         częstotliwość wynoszą obie ~a Hz).~%~\n"
+"                         Wybierz zakres częstotliwości."
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -17871,7 +18824,10 @@ msgid ""
 "~adB values cannot be more than +100 dB.~%~%~\n"
 "                                 Hint: 6 dB doubles the amplitude~%~\n"
 "                                 \t-6 dB halves the amplitude."
-msgstr "~adB wartości nie mogą być większe niż +100 dB.~%~%~\n                                 Wskazówka: 6 dB podwaja amplitudę~%~\n                                 \t-6 dB to połowa amplitudy."
+msgstr ""
+"~adB wartości nie mogą być większe niż +100 dB.~%~%~\n"
+"                                 Wskazówka: 6 dB podwaja amplitudę~%~\n"
+"                                 \t-6 dB to połowa amplitudy."
 
 #: plug-ins/beat.ny
 msgid "Beat Finder"
@@ -17900,7 +18856,9 @@ msgstr "Benjamin Schwartz i Steve Daulton"
 #: plug-ins/clipfix.ny
 msgid ""
 "Licensing confirmed under terms of the GNU General Public License version 2"
-msgstr "Licencjonowanie potwierdzone na warunkach licencji GNU General Public License wersja 2"
+msgstr ""
+"Licencjonowanie potwierdzone na warunkach licencji GNU General Public "
+"License wersja 2"
 
 #: plug-ins/clipfix.ny
 msgid "Threshold of Clipping (%)"
@@ -17921,13 +18879,15 @@ msgstr "Przenikanie..."
 #: plug-ins/crossfadeclips.ny
 #, lisp-format
 msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
-msgstr "Błąd.~%Nieprawidłowe zaznaczenie.~%Zaznaczono więcej niż 2 klipy dźwiękowe."
+msgstr ""
+"Błąd.~%Nieprawidłowe zaznaczenie.~%Zaznaczono więcej niż 2 klipy dźwiękowe."
 
 #: plug-ins/crossfadeclips.ny
 #, lisp-format
-msgid ""
-"Error.~%Invalid selection.~%Empty space at start/ end of the selection."
-msgstr "Błąd.~%Nieprawidłowe zaznaczenie.~%EPusta przestrzeń na początku/końcu zaznaczenia."
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+"Błąd.~%Nieprawidłowe zaznaczenie.~%EPusta przestrzeń na początku/końcu "
+"zaznaczenia."
 
 #: plug-ins/crossfadeclips.ny
 #, lisp-format
@@ -18244,7 +19204,11 @@ msgid ""
 "Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
 "                   Track sample rate is ~a Hz~%~\n"
 "                   Frequency must be less than ~a Hz."
-msgstr "Błąd:~%~%FCzęstotliwość (~a Hz) jest za wysoka dla próbkowania ścieżki.~%.~%~%~\n                   Próbkowanie ścieżki wynosi ~a Hz~%~\n                   Częstotliwość musi być mniejsza niż ~a Hz."
+msgstr ""
+"Błąd:~%~%FCzęstotliwość (~a Hz) jest za wysoka dla próbkowania ścieżki.~%."
+"~%~%~\n"
+"                   Próbkowanie ścieżki wynosi ~a Hz~%~\n"
+"                   Częstotliwość musi być mniejsza niż ~a Hz."
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -18266,8 +19230,7 @@ msgstr "Miękki limit"
 msgid "Hard Limit"
 msgstr "Twardy limit"
 
-#. i18n-hint: clipping of wave peaks and troughs, not division of a track into
-#. clips
+#. i18n-hint: clipping of wave peaks and troughs, not division of a track into clips
 #: plug-ins/limiter.ny
 msgid "Soft Clip"
 msgstr "Miękkie obcięcie"
@@ -18280,13 +19243,17 @@ msgstr "Twarde obcięcie"
 msgid ""
 "Input Gain (dB)\n"
 "mono/Left"
-msgstr "Wzmocnienie wejściowe (dB)\nmono/lewy"
+msgstr ""
+"Wzmocnienie wejściowe (dB)\n"
+"mono/lewy"
 
 #: plug-ins/limiter.ny
 msgid ""
 "Input Gain (dB)\n"
 "Right channel"
-msgstr "Wzmocnienie wejściowe (dB)\nprawy kanał"
+msgstr ""
+"Wzmocnienie wejściowe (dB)\n"
+"prawy kanał"
 
 #: plug-ins/limiter.ny
 msgid "Limit to (dB)"
@@ -18375,21 +19342,29 @@ msgid ""
 "\"Gate frequencies above: ~s kHz\"\n"
 "is too high for selected track.\n"
 "Set the control below ~a kHz."
-msgstr "Błąd.\n\"Częstotliwości bramki powyżej: ~s kHz\"\nsą za wysokie dla zaznaczonej ścieżki.\nUstaw kontrolę poniżej ~a kHz."
+msgstr ""
+"Błąd.\n"
+"\"Częstotliwości bramki powyżej: ~s kHz\"\n"
+"są za wysokie dla zaznaczonej ścieżki.\n"
+"Ustaw kontrolę poniżej ~a kHz."
 
 #: plug-ins/noisegate.ny
 #, lisp-format
 msgid ""
 "~%Insufficient audio selected.\n"
 "Make the selection longer than ~a ms."
-msgstr "~%Zaznaczono niewystarczającą długość dźwięku.\nDokonaj wyboru dłuższego niż ~a ms."
+msgstr ""
+"~%Zaznaczono niewystarczającą długość dźwięku.\n"
+"Dokonaj wyboru dłuższego niż ~a ms."
 
 #: plug-ins/noisegate.ny
 #, lisp-format
 msgid ""
 "Peak based on first ~a seconds ~a dB~%\n"
 "Suggested Threshold Setting ~a dB."
-msgstr "Szczyt oparty na pierwszych ~a sekundach ~a dB~%\nSugerowane ustawienie progu ~a dB."
+msgstr ""
+"Szczyt oparty na pierwszych ~a sekundach ~a dB~%\n"
+"Sugerowane ustawienie progu ~a dB."
 
 #: plug-ins/notch.ny
 msgid "Notch Filter"
@@ -18413,7 +19388,11 @@ msgid ""
 "Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
 "                 Track sample rate is ~a Hz.~%~\n"
 "                 Frequency must be less than ~a Hz."
-msgstr "Błąd:~%~%FCzęstotliwość (~a Hz) jest za wysoka dla próbkowania ścieżki.~%~%~\n                 Próbkowanie ścieżki wynosi ~a Hz.~%~\n                 Częstotliwość musi być mniejsza niż ~a Hz."
+msgstr ""
+"Błąd:~%~%FCzęstotliwość (~a Hz) jest za wysoka dla próbkowania ścieżki."
+"~%~%~\n"
+"                 Próbkowanie ścieżki wynosi ~a Hz.~%~\n"
+"                 Częstotliwość musi być mniejsza niż ~a Hz."
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -18630,7 +19609,9 @@ msgstr "Wysokość MIDI słabego uderzenia"
 msgid ""
 "Set either 'Number of bars' or\n"
 "'Rhythm track duration' to greater than zero."
-msgstr "Ustaw 'Liczbę taktów' lub\n'Długość ścieżki rytmu' na więcej niż zero."
+msgstr ""
+"Ustaw 'Liczbę taktów' lub\n"
+"'Długość ścieżki rytmu' na więcej niż zero."
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -18761,28 +19742,41 @@ msgstr "~aDane zapisane w:~%~a"
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
-msgstr "Częstotliwość próbkowania: ~a Hz. Przykładowe wartości na ~a skali.~%~a~%~a"
+msgstr ""
+"Częstotliwość próbkowania: ~a Hz. Przykładowe wartości na ~a skali.~%~a~%~a"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid ""
 "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
-msgstr "~a   ~a~%~aCzęstotliwość próbkowania: ~a Hz.~%LePrzetworzona długość: ~a sampli ~a sekund.~a"
+msgstr ""
+"~a   ~a~%~aCzęstotliwość próbkowania: ~a Hz.~%LePrzetworzona długość: ~a "
+"sampli ~a sekund.~a"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid ""
 "~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
 "                     Length processed: ~a samples ~a seconds.~a"
-msgstr "~a   ~a~%~aCzęstotliwość próbkowania: ~a Hz. Przykładowe wartości na ~a skali.~%~\n                     Przetworzona długość: ~a sampli ~a sekund.~a"
+msgstr ""
+"~a   ~a~%~aCzęstotliwość próbkowania: ~a Hz. Przykładowe wartości na ~a "
+"skali.~%~\n"
+"                     Przetworzona długość: ~a sampli ~a sekund.~a"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid ""
-"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
-"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: "
+"~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  "
+"Unweighted RMS: ~a dB.~%~\n"
 "                  DC offset: ~a~a"
-msgstr "~a~%Częstotliwość próbkowania: ~a Hz. Przykładowe wartości na ~a skali. ~a.~%~aPrzetworzona długość: ~a ~\n                  sampli, ~a sekund.~%Amplituda szczytowa: ~a (liniowa) ~a dB.  Nieważona RMS: ~a dB.~%~\n                  DC offset: ~a~a"
+msgstr ""
+"~a~%Częstotliwość próbkowania: ~a Hz. Przykładowe wartości na ~a skali. ~a."
+"~%~aPrzetworzona długość: ~a ~\n"
+"                  sampli, ~a sekund.~%Amplituda szczytowa: ~a (liniowa) ~a "
+"dB.  Nieważona RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18817,17 +19811,16 @@ msgstr "<b>Częstotliwość próbkowania:</b> &nbsp;&nbsp;~a Hz."
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
-msgstr "<b>Amplituda szczytowa:</b> &nbsp;&nbsp;~a (liniowa) &nbsp;&nbsp;~a dB."
+msgstr ""
+"<b>Amplituda szczytowa:</b> &nbsp;&nbsp;~a (liniowa) &nbsp;&nbsp;~a dB."
 
-#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a
-#. signal; there also "weighted" versions of it but this isn't that
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
 msgstr "<b>RMS</b> (nieważona): &nbsp;&nbsp;~a dB."
 
-#. i18n-hint: DC derives from "direct current" in electronics, really means
-#. the zero frequency component of a signal
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
@@ -18885,7 +19878,10 @@ msgid ""
 "Produced with <span>Sample Data Export</span> for\n"
 "<a href=\"~a\">Audacity</a> by Steve\n"
 "Daulton"
-msgstr "Stworzone przez Steve'a Daultona\nz <span>Eksportu przykładowych danych</span> dla\n<a href=\"~a\">Audacity</a>"
+msgstr ""
+"Stworzone przez Steve'a Daultona\n"
+"z <span>Eksportu przykładowych danych</span> dla\n"
+"<a href=\"~a\">Audacity</a>"
 
 #: plug-ins/sample-data-export.ny
 msgid "linear"
@@ -18963,7 +19959,10 @@ msgid ""
 "Error~%~\n"
 "                        '~a' could not be opened.~%~\n"
 "                        Check that file exists."
-msgstr "Błąd~%~\n                        '~a' nie mógł zostać otwarty.~%~\n                        Sprawdź, czy plik istnieje."
+msgstr ""
+"Błąd~%~\n"
+"                        '~a' nie mógł zostać otwarty.~%~\n"
+"                        Sprawdź, czy plik istnieje."
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -18971,7 +19970,10 @@ msgid ""
 "Error:~%~\n"
 "              The file must contain only plain ASCII text.~%~\n"
 "              (Invalid byte '~a' at byte number: ~a)"
-msgstr "Błąd:~%~\n              Plik musi zawierać tylko zwykły tekst ASCII.~%~\n              (Błędny bajt '~a' pod numerem bajtu: ~a)"
+msgstr ""
+"Błąd:~%~\n"
+"              Plik musi zawierać tylko zwykły tekst ASCII.~%~\n"
+"              (Błędny bajt '~a' pod numerem bajtu: ~a)"
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -18979,7 +19981,10 @@ msgid ""
 "Error~%~\n"
 "              Data must be numbers in plain ASCII text.~%~\n"
 "              '~a' is not a numeric value."
-msgstr "Błąd~%~\n              Dane muszą być liczbami w prostym tekście ASCII.~%~\n              '~a' nie jest wartością liczbową."
+msgstr ""
+"Błąd~%~\n"
+"              Dane muszą być liczbami w prostym tekście ASCII.~%~\n"
+"              '~a' nie jest wartością liczbową."
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -19090,60 +20095,98 @@ msgid ""
 "                    Coefficient of determination: ~a\n"
 "                    Variation of residuals: ~a\n"
 "                    y equals ~a plus ~a times x~%"
-msgstr "Średnia x: ~a, y: ~a\n                    Kowariancja x y: ~a\n                    Średnia wariancja x: ~a, y: ~a\n                    Odchylenie standardowe x: ~a, y: ~a\n                    Współczynnik korelacji: ~a\n                    Współczynnik determinacji: ~a\n                    Zmiana reszty: ~a\n                    y równa się ~a plus ~a razy x~%"
+msgstr ""
+"Średnia x: ~a, y: ~a\n"
+"                    Kowariancja x y: ~a\n"
+"                    Średnia wariancja x: ~a, y: ~a\n"
+"                    Odchylenie standardowe x: ~a, y: ~a\n"
+"                    Współczynnik korelacji: ~a\n"
+"                    Współczynnik determinacji: ~a\n"
+"                    Zmiana reszty: ~a\n"
+"                    y równa się ~a plus ~a razy x~%"
 
 #: plug-ins/vocalrediso.ny
 #, lisp-format
 msgid ""
 "Pan position: ~a~%The left and right channels are correlated by about ~a %. "
 "This means:~%~a~%"
-msgstr "Pozycja panoramy: ~a~%Kanały lewy i prawy są skorelowane około ~a %. Oznacza to:~%~a~%"
+msgstr ""
+"Pozycja panoramy: ~a~%Kanały lewy i prawy są skorelowane około ~a %. Oznacza "
+"to:~%~a~%"
 
 #: plug-ins/vocalrediso.ny
 msgid ""
 " - The two channels are identical, i.e. dual mono.\n"
 "                The center can't be removed.\n"
 "                Any remaining difference may be caused by lossy encoding."
-msgstr " - Te dwa kanały są identyczne, tj. dual mono.\n                Środkowego nie można usunąć.\n                Wszystkie pozostałe różnice mogą być spowodowane przez stratne kodowanie."
+msgstr ""
+" - Te dwa kanały są identyczne, tj. dual mono.\n"
+"                Środkowego nie można usunąć.\n"
+"                Wszystkie pozostałe różnice mogą być spowodowane przez "
+"stratne kodowanie."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
-" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+" - The two Channels are strongly related, i.e. nearly mono or extremely "
+"panned.\n"
 "                Most likely, the center extraction will be poor."
-msgstr " - Obydwa kanały są silnie powiązane, tj. prawie mono lub ekstremalne panoramowanie.\n                Najprawdopodobniej środek ekstrakcji będzie słaby."
+msgstr ""
+" - Obydwa kanały są silnie powiązane, tj. prawie mono lub ekstremalne "
+"panoramowanie.\n"
+"                Najprawdopodobniej środek ekstrakcji będzie słaby."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
 " - A fairly good value, at least stereo in average and not too wide spread."
-msgstr " - Dość dobra wartość, przynajmniej średnia stereo i nie za szeroka rozpiętość."
+msgstr ""
+" - Dość dobra wartość, przynajmniej średnia stereo i nie za szeroka "
+"rozpiętość."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
 " - An ideal value for Stereo.\n"
-"                However, the center extraction depends also on the used reverb."
-msgstr " - Idealna wartość dla stereo.\n                Jednak ekstrakcja środka zależy również od zastosowanego pogłosu."
+"                However, the center extraction depends also on the used "
+"reverb."
+msgstr ""
+" - Idealna wartość dla stereo.\n"
+"                Jednak ekstrakcja środka zależy również od zastosowanego "
+"pogłosu."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
 " - The two channels are almost not related.\n"
-"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                Either you have only noise or the piece is mastered in a "
+"unbalanced manner.\n"
 "                The center extraction can still be good though."
-msgstr " - Oba kanały są prawie niepowiązane.\n                Albo masz tylko szum, albo utwór jest zmasterowany w niezbalansowany sposób.\n                Ekstrakcja środka może być jednak dobra."
+msgstr ""
+" - Oba kanały są prawie niepowiązane.\n"
+"                Albo masz tylko szum, albo utwór jest zmasterowany w "
+"niezbalansowany sposób.\n"
+"                Ekstrakcja środka może być jednak dobra."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
 " - Although the Track is stereo, the field is obviously extra wide.\n"
 "                This can cause strange effects.\n"
 "                Especially when played by only one speaker."
-msgstr " - Mimo że ścieżka jest stereo, pole jest oczywiście bardzo szerokie.\n                Może to spowodować dziwne efekty.\n                Zwłaszcza gdy gra tylko jeden głośnik."
+msgstr ""
+" - Mimo że ścieżka jest stereo, pole jest oczywiście bardzo szerokie.\n"
+"                Może to spowodować dziwne efekty.\n"
+"                Zwłaszcza gdy gra tylko jeden głośnik."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
 " - The two channels are nearly identical.\n"
 "                  Obviously, a pseudo stereo effect has been used\n"
-"                  to spread the signal over the physical distance between the speakers.\n"
+"                  to spread the signal over the physical distance between "
+"the speakers.\n"
 "                  Don't expect good results from a center removal."
-msgstr " - Dwa kanały są prawie identyczne.\n                  Oczywiście zastosowano efekt pseudo stereo,\n                  aby rozłożyć sygnał na fizyczną odległość między głośnikami.\n                  Nie oczekuj dobrych wyników z usunięcia środka."
+msgstr ""
+" - Dwa kanały są prawie identyczne.\n"
+"                  Oczywiście zastosowano efekt pseudo stereo,\n"
+"                  aby rozłożyć sygnał na fizyczną odległość między "
+"głośnikami.\n"
+"                  Nie oczekuj dobrych wyników z usunięcia środka."
 
 #: plug-ins/vocalrediso.ny
 msgid "This plug-in works only with stereo tracks."
@@ -19201,3 +20244,18 @@ msgstr "Częstotliwość igieł radaru (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Błąd.~%Wymagana ścieżka stereo."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Pokaż/ukryj edytor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Przy importowaniu plików dźwiękowych"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-16 21:40-0300\n"
 "Last-Translator: Cleber Tavano <clebertavano@gmail.com>\n"
 "Language-Team: Cleber Tavano (2002-2020), Victor Westmann, Djavan Fagundes "
@@ -3801,6 +3801,28 @@ msgstr ""
 "Por favor, verifique as configurações do dispositivo de reprodução e a taxa "
 "de amostragem do projeto."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Para aplicar o filtro, todas as faixas selecionadas devem ter a mesma taxa "
+"de amostragem."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4065,9 +4087,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Aviso: Problemas na recuperação automática"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sem-título>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projeto %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9789,6 +9816,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Tamanho do &Buffer (8 a %d amostras):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Tamanho do &Buffer (8 a %d amostras):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10551,7 +10583,8 @@ msgstr "Taxas de amostragem"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11228,7 +11261,6 @@ msgstr "Exportando o áudio selecionado para FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Exportando áudio como  FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12566,7 +12598,7 @@ msgstr "fim"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14387,11 +14419,24 @@ msgstr ""
 "Por favor, salve o projeto ou feche-o e tente novamente."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Por favor, selecione uma faixa de áudio mono."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Por favor, selecione uma faixa de áudio estéreo."
 
 #: src/menus/TransportMenus.cpp
@@ -18448,8 +18493,8 @@ msgid "Value must not be less than %s"
 msgstr "O valor não deve ser inferior a %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "O valor não deve ser superior a %s"
 
 #: src/widgets/valnum.cpp
@@ -20243,6 +20288,21 @@ msgstr "Frequência das agulhas no radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Erro.~%Requer faixa estéreo."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Exibir/Ocultar Editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Ao importar arquivos de áudio"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "incorporando"

--- a/locale/pt_PT.po
+++ b/locale/pt_PT.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-14 22:45+0100\n"
 "Last-Translator: Bruno Ramalhete <bram.512@gmail.com>\n"
 "Language-Team: Bruno Ramalhete <bram.512@gmail.com>\n"
@@ -3802,6 +3802,28 @@ msgstr ""
 "Por favor, verifique as configurações do dispositivo de reprodução e a taxa "
 "de amostragem do projeto."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Para aplicar um filtro, todas as faixas selecionadas devem ter a mesma taxa "
+"de amostragem."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4060,9 +4082,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Aviso: Problemas na Recuperação Automática"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sem-título>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projeto %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9775,6 +9802,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Tamanho da &Memória (8 a %d) amostras):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Tamanho da &Memória (8 a %d) amostras):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10530,7 +10562,8 @@ msgstr "Taxas de Amostragem"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11207,7 +11240,6 @@ msgstr "A exportar o áudio selecionado como FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "A exportar o áudio como FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12538,7 +12570,7 @@ msgstr "fim"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14356,11 +14388,24 @@ msgstr ""
 "Por favor guarde ou feche este projeto e tente de novo."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Por favor selecione uma faixa mono."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Por favor seleciona uma faixa estéreo."
 
 #: src/menus/TransportMenus.cpp
@@ -18405,8 +18450,8 @@ msgid "Value must not be less than %s"
 msgstr "O nome não pode ser menos de %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Valor não deve ser maior do que %s"
 
 #: src/widgets/valnum.cpp
@@ -20202,6 +20247,21 @@ msgstr "Frequência de Agulhas de Radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Erro.~%Requer faixa estéreo."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Mostrar/Ocultar Editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Ao importar ficheiros de áudio"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "incorporando"

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2015-06-28 03:24+0200\n"
 "Last-Translator: Cristian Secară <cristi AT secarica DOT ro>\n"
 "Language-Team: Gnome Romanian Team <gnomero-list@lists.sourceforge.net>\n"
@@ -3745,6 +3745,25 @@ msgid ""
 "Try changing the audio host, playback device and the project sample rate."
 msgstr ""
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3941,9 +3960,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Proiecte"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9629,6 +9653,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10325,7 +10354,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -10943,7 +10973,6 @@ msgstr ""
 msgid "Exporting the audio as FLAC"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12191,7 +12220,7 @@ msgstr "Sfârșit"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14190,13 +14219,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "A fost creată o nouă pistă audio"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "A fost creată o nouă pistă audio"
 
 #: src/menus/TransportMenus.cpp
@@ -18423,7 +18464,7 @@ msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr ""
 
 #: src/widgets/valnum.cpp
@@ -20262,6 +20303,21 @@ msgstr "N&etezire de frecvență (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Liniște"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Sunete înregistrate"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-16 07:50+0500\n"
 "Last-Translator: Alexander Kovalenko <nktch@yandex.ru>\n"
 "Language-Team: \n"
@@ -3771,6 +3771,28 @@ msgstr ""
 "Попробуйте изменить аудиодвижок, устройство проигрывания и частоту "
 "дискретизации проекта."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Для применения фильтра все выбранные треки должны иметь одну частоту "
+"дискретизации."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4019,9 +4041,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Внимание: проблемы автовосстановления"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<без названия>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Проект %02i] Audacity \"%s\""
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9706,6 +9733,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Размер буфера (8 - %d сэмплов):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Размер буфера (8 - %d сэмплов):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10450,7 +10482,8 @@ msgstr "Частоты дискретизации"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d кб/с"
@@ -11128,7 +11161,6 @@ msgstr "Экспорт выделенного фрагмента во FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Экспорт аудиоданных во FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12454,7 +12486,7 @@ msgstr "конец"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14272,11 +14304,24 @@ msgstr ""
 "Cохраните или закройте этот проект и попробуйте снова."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Выберите в монотреке."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Выберите в стереотреке."
 
 #: src/menus/TransportMenus.cpp
@@ -18317,8 +18362,8 @@ msgid "Value must not be less than %s"
 msgstr "Значение не должно быть менее %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Значение не должно быть более %s"
 
 #: src/widgets/valnum.cpp
@@ -20114,3 +20159,18 @@ msgstr "Частота импульсов радара (Гц)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Ошибка.~%Требуется стереотрек."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Показать/скрыть редактор"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "При импорте аудиофайлов"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-11 12:53+0200\n"
 "Last-Translator: Jozef Matta <jozef.m923@gmail.com>\n"
 "Language-Team: jozefM\n"
@@ -1567,9 +1567,6 @@ msgstr "Ponuka Príkaz (bez parametrov)"
 
 #: src/BatchCommands.cpp
 #, c-format
-#| msgid ""
-#| "Export recording to %s\n"
-#| "/%s/%s%s"
 msgid ""
 "Export recording to %s\n"
 "/%s/%s.%s"
@@ -2411,7 +2408,6 @@ msgstr "Blackman-Harris"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
-#| msgid "Welcome!"
 msgid "Welch"
 msgstr "Welch"
 
@@ -3781,6 +3777,28 @@ msgstr ""
 "Skúste zmeniť hostiteľa audia, prehrávacie zariadenie a vzorkovaciu "
 "frekvenciu projektu."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Pre aplikovanie filtra, všetky vybrané stopy musia mať rovnakú vzorkovaciu "
+"rýchlosť."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4029,9 +4047,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Upozornenie: problémy pri automatickej obnove"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<nepomenovaný>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] Audacity „%s“"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -6524,12 +6547,10 @@ msgid "33⅓"
 msgstr "33⅓"
 
 #: src/effects/ChangeSpeed.cpp
-#| msgid "145"
 msgid "45"
 msgstr "45"
 
 #: src/effects/ChangeSpeed.cpp
-#| msgid "8"
 msgid "78"
 msgstr "78"
 
@@ -7337,7 +7358,6 @@ msgstr "Pracovný cyklus:"
 
 #: src/effects/DtmfGen.cpp
 #, c-format
-#| msgid "%.1f secs"
 msgid "%.1f %%"
 msgstr "%.1f %%"
 
@@ -7358,7 +7378,6 @@ msgstr "Trvanie ticha:"
 #. i18n-hint milliseconds
 #: src/effects/DtmfGen.cpp
 #, c-format
-#| msgid "%.0f ms"
 msgid "%0.f ms"
 msgstr "%0.f ms"
 
@@ -7860,7 +7879,6 @@ msgstr "%g kHz"
 #. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
 #, c-format
-#| msgid "%g kHz"
 msgid "%gk"
 msgstr "%gk"
 
@@ -9693,7 +9711,6 @@ msgstr ""
 #: src/effects/vamp/VampEffect.cpp
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
-#| msgid "%s in:"
 msgid "%s:"
 msgstr "%s:"
 
@@ -9715,6 +9732,11 @@ msgstr "Nastavenia efektu LV2"
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
 msgid "&Buffer Size (8 to %d) samples):"
+msgstr "&Veľkosť zásobníka (8 až %d) snímok):"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
 msgstr "&Veľkosť zásobníka (8 až %d) snímok):"
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -10466,7 +10488,8 @@ msgstr "Vzorkovacie frekvencie"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbit/s"
@@ -10486,7 +10509,6 @@ msgid "%.2f kbps"
 msgstr "%.2f kbit/s"
 
 #: src/export/ExportFFmpegDialogs.cpp
-#| msgid "60"
 msgid "0"
 msgstr "0"
 
@@ -10515,12 +10537,10 @@ msgid "7"
 msgstr "7"
 
 #: src/export/ExportFFmpegDialogs.cpp
-#| msgid "96"
 msgid "9"
 msgstr "9"
 
 #: src/export/ExportFFmpegDialogs.cpp
-#| msgid "120"
 msgid "10"
 msgstr "10"
 
@@ -10537,7 +10557,6 @@ msgid "VOIP"
 msgstr "VOIP"
 
 #: src/export/ExportFFmpegDialogs.cpp
-#| msgid "&Audio..."
 msgid "Audio"
 msgstr "Audio"
 
@@ -10678,7 +10697,6 @@ msgid "AMR (narrow band) Files (FFmpeg)"
 msgstr "AMR (úzke pásmo) súbory (FFmpeg)"
 
 #: src/export/ExportFFmpegDialogs.cpp
-#| msgid "M4A (AAC) Files (FFmpeg)"
 msgid "Opus (OggOpus) Files (FFmpeg)"
 msgstr "Opus (OggOpus) súbory (FFmpeg)"
 
@@ -11147,10 +11165,8 @@ msgstr "Exportovanie vybraného audio ako FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Exportovanie audia ako FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
-#| msgid "%d kbps"
 msgid "%d kpbs"
 msgstr "%d kb/s"
 
@@ -11178,7 +11194,6 @@ msgid "Exporting the audio at %ld kbps"
 msgstr "Exportovanie audia pri %ld kbit/s"
 
 #: src/export/ExportMP3.cpp
-#| msgid "%s kbps (Best Quality)"
 msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (najlepšia kvalita)"
 
@@ -12250,12 +12265,10 @@ msgid "12 bit DWVW"
 msgstr "12 bit DWVW"
 
 #: src/import/ImportPCM.cpp
-#| msgid "16 bit"
 msgid "16 bit DWVW"
 msgstr "16 bit DWVW"
 
 #: src/import/ImportPCM.cpp
-#| msgid "24 bit"
 msgid "24 bit DWVW"
 msgstr "24 bit DWVW"
 
@@ -12264,12 +12277,10 @@ msgid "VOX ADPCM"
 msgstr "VOX ADPCM"
 
 #: src/import/ImportPCM.cpp
-#| msgid "16-bit PCM"
 msgid "16 bit DPCM"
 msgstr "16 bit DPCM"
 
 #: src/import/ImportPCM.cpp
-#| msgid "16-bit PCM"
 msgid "8 bit DPCM"
 msgstr "8 bit DPCM"
 
@@ -12488,7 +12499,7 @@ msgstr "koniec"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14276,8 +14287,6 @@ msgstr "žiadna stopa s návesťou tu alebo nižšie pod zameranou stopou"
 
 #: src/menus/TransportMenus.cpp
 #, c-format
-#| msgid "%s %d of %d clip %s"
-#| msgid_plural "%s %d of %d clips %s"
 msgid "%s %d of %d"
 msgstr "%s %d of %d"
 
@@ -14306,11 +14315,24 @@ msgstr ""
 "Uložte, prosím, alebo zavrite tento projekt a skúste to znova."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Vyberte, prosím, vnútri mono stopy."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Vyberte, prosím, vnútri stereo stopy."
 
 #: src/menus/TransportMenus.cpp
@@ -17412,7 +17434,6 @@ msgstr "Pravý, %dHz"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 #: src/widgets/ASlider.cpp
 #, c-format
-#| msgid "%.2f dB"
 msgid "%+.1f dB"
 msgstr "%+.1f dB"
 
@@ -17804,7 +17825,6 @@ msgstr "P"
 #. i18n-hint: "x" suggests a multiplicative factor
 #: src/widgets/ASlider.cpp
 #, c-format
-#| msgid "%.2f"
 msgid "%.2fx"
 msgstr "%.2fx"
 
@@ -18351,8 +18371,8 @@ msgid "Value must not be less than %s"
 msgstr "Hodnota nesmie byť menej než %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Hodnota nesmie byť väčšia než %s"
 
 #: src/widgets/valnum.cpp
@@ -18377,7 +18397,6 @@ msgstr "Dialóg súboru"
 
 #: src/xml/XMLFileReader.cpp
 #, c-format
-#| msgid "Error: %hs at line %lu"
 msgid "Error: %s at line %lu"
 msgstr "Chyba: %s na riadku %lu"
 
@@ -20146,6 +20165,21 @@ msgstr "Frekvencia radarových ihlíc (Hz)"
 msgid "Error.~%Stereo track required."
 msgstr "Chyba.~%Požadovaná stereo stopa."
 
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Zobraziť/skryť editor"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Pri importe audio súborov"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
+
 #~ msgid "incorporating"
 #~ msgstr "začlenenie"
 
@@ -20304,14 +20338,12 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 #~ "Nyquist skripty (*.ny)|*.ny|Lisp skripty (*.lsp)|*.lsp|Textové súbory (*."
 #~ "txt)|*.txt|Všetky súbory|*"
 
-#, c-format
 #~ msgid "%i kbps"
 #~ msgstr "%i kbit/s"
 
 #~ msgid "XML files (*.xml)|*.xml|All files|*"
 #~ msgstr "XML súbory (*.xml)|*.xml|Všetky súbory|*"
 
-#, c-format
 #~ msgid "%s kbps"
 #~ msgstr "%s kbit/s"
 
@@ -20365,7 +20397,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 #~ msgid "F&ocus"
 #~ msgstr "Za&merať"
 
-#, c-format
 #~ msgid "%s - %s"
 #~ msgstr "%s - %s"
 
@@ -20390,11 +20421,9 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 #~ msgid "Alex S. Brown"
 #~ msgstr "Alex S. Brown"
 
-#, lisp-format
 #~ msgid "Error.~%~s is not a supported plug-in.~%"
 #~ msgstr "Chyba.~%~s nie je podporované rozšírenie.~%"
 
-#, lisp-format
 #~ msgid "Error.~%~s is not a valid Nyquist plug-in.~%"
 #~ msgstr "Chyba.~%~s nie je správne rozšírenie Nyquist.~%"
 

--- a/locale/sl.po
+++ b/locale/sl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2017-12-05 23:57+0100\n"
 "Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
 "Language-Team: Martin Srebotnjak <miles@filmsi.net>\n"
@@ -3816,6 +3816,28 @@ msgstr ""
 "Poskusite spremeniti zvočnega gostitelja, snemalno napravo in mero vzorčenja "
 "projekta."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Če želite uveljaviti filter, morajo imeti vse izbrane sledi enako frekvenco "
+"vzorčenja."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4065,9 +4087,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Opozorilo: težave s samodejnim obnavljanjem"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<neimenovano>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekti"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9964,6 +9991,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Velikost &medpomnilnika (8-1048576 vzorcev):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Velikost &medpomnilnika (8-1048576 vzorcev):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10719,7 +10751,8 @@ msgstr "Mere vzorčenja"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kb/s"
@@ -11412,7 +11445,6 @@ msgstr "Izvažanje izbranega zvoka kot FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Izvažanje izbranega zvoka kot FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12756,7 +12788,7 @@ msgstr "konec"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14722,13 +14754,25 @@ msgstr ""
 "Najprej shranite ali zaprite ta projekt in nato poskusite znova."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Izberite zvočno sled."
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Izberite zvočno sled."
 
 #: src/menus/TransportMenus.cpp
@@ -18885,8 +18929,8 @@ msgid "Value must not be less than %s"
 msgstr "Vrednost ne sme biti manjša od %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Vrednost ne sme biti večja od %s"
 
 #: src/widgets/valnum.cpp
@@ -20762,6 +20806,21 @@ msgstr "Frekvenca (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Pokaži/skrij urejevalnik"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Pri uvozu zvočnih datotek"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #~ msgid "incorporating"

--- a/locale/sr_RS.po
+++ b/locale/sr_RS.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2016-11-27 20:07+0200\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: српски <gnome-sr@googlegroups.org>\n"
@@ -3855,6 +3855,27 @@ msgstr ""
 "Грешка отварања звучног уређаја. Покушајте да измените домаћина звука, "
 "уређај пуштања и проток узорка пројекта."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Да примените филтер, све изабране нумере морају бити истог протока узорка."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4102,9 +4123,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Упозорење: Проблем у самосталном опоравку"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<без наслова>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Пројекти"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9972,6 +9998,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Величина међумеморије (од 8 до 1048576 узорка):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Величина међумеморије (од 8 до 1048576 узорка):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10728,7 +10759,8 @@ msgstr "Протоци узорка"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kb/s"
@@ -11423,7 +11455,6 @@ msgstr "Извозим изабрани звук као ФЛАЦ"
 msgid "Exporting the audio as FLAC"
 msgstr "Извозим изабрани звук као ФЛАЦ"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12774,7 +12805,7 @@ msgstr "Крај"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14808,13 +14839,25 @@ msgstr ""
 "Сачувајте или затворите овај пројекат и покушајте опет."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Изаберите звучну нумеру."
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Изаберите звучну нумеру."
 
 #: src/menus/TransportMenus.cpp
@@ -19045,8 +19088,8 @@ msgid "Value must not be less than %s"
 msgstr "Вредност не сме бити мања од %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Вредност не сме бити већа од %s"
 
 #: src/widgets/valnum.cpp
@@ -20919,6 +20962,21 @@ msgstr "Учесталост (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Прикажи/Сакриј уређивач"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Приликом увоза датотека звука"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #~ msgid "incorporating"

--- a/locale/sr_RS@latin.po
+++ b/locale/sr_RS@latin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2014-10-06 05:34-0000\n"
 "Last-Translator: Miroslav Nikolic\n"
 "Language-Team: Serbian <>\n"
@@ -3922,6 +3922,27 @@ msgstr ""
 "Greška prilikom otvaranja zvučnog uređaja. Molim proverite podešavanja "
 "izlaznog uređaja i protok uzorka projekta."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Da primenite propusnik, sve izabrane numere moraju biti istog protoka uzorka."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4169,9 +4190,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Upozorenje: Problem u samostalnom oporavku"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<bez naslova>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekti"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -10172,6 +10198,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Veličina međumemorije (od 8 do 1048576 uzorka):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Veličina međumemorije (od 8 do 1048576 uzorka):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10920,7 +10951,8 @@ msgstr "Protoci uzorka"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kb/s"
@@ -11617,7 +11649,6 @@ msgstr "Izvozim izabrani zvuk kao FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Izvozim izabrani zvuk kao FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12970,7 +13001,7 @@ msgstr "Kraj"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -15004,13 +15035,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Molim izaberite radnju"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Molim izaberite radnju"
 
 #: src/menus/TransportMenus.cpp
@@ -19343,7 +19386,7 @@ msgstr "Naziv ne sme biti prazan"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Pokretanje i zaustavljanje moraju biti veći od 0."
 
 #: src/widgets/valnum.cpp
@@ -21222,6 +21265,21 @@ msgstr "Učestanost (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Stvaralac tišine"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Prilikom uvoza datoteka zvuka"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2018-12-18 20:31+0100\n"
 "Last-Translator: A. Regnander <anton_r_3@hotmail.com>\n"
 "Language-Team: swedish <musselasse@gmail.com, anton_r_3@hotmail.com>\n"
@@ -3792,6 +3792,28 @@ msgstr ""
 "Försök att ändra ljudvärden, uppspelningsenhet och projektets "
 "samplingsfrekvens."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"För att tillämpa ett filter måste alla markerade spår ha samma "
+"samplingsfrekvens."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4039,9 +4061,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Varning: Problem med automatisk återställning"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<namnlös>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekt"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9784,6 +9811,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Buffertstorlek (8 till 1048576 samplingar):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Buffertstorlek (8 till 1048576 samplingar):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10535,7 +10567,8 @@ msgstr "Samplingsfrekvenser"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11228,7 +11261,6 @@ msgstr "Exporterar valt ljud som FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Exporterar ljudet som FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12578,7 +12610,7 @@ msgstr "slutet"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14401,11 +14433,24 @@ msgstr ""
 "Var god spara eller stäng detta projekt och försök igen."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Var god välj i ett monospår."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Var god välj i ett stereospår."
 
 #: src/menus/TransportMenus.cpp
@@ -18505,8 +18550,8 @@ msgid "Value must not be less than %s"
 msgstr "Värdet får inte vara mindre än %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Värdet får inte vara högre än %s"
 
 #: src/widgets/valnum.cpp
@@ -20324,6 +20369,21 @@ msgstr "Frekvens för radarnålar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Fel.~%Stereospår krävs."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Visa/dölj redigerare"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "När ljudfiler importeras"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "innehåller"

--- a/locale/ta.po
+++ b/locale/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2014-09-16 07:40-0000\n"
 "Last-Translator: Arun Kumar\n"
 "Language-Team: தமிழா!-ThamiZha!(www.thamizha.org)\n"
@@ -3839,6 +3839,28 @@ msgid ""
 "Try changing the audio host, playback device and the project sample rate."
 msgstr ""
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"வர்ணப்பட்டையை வரைவதற்கு தெரிவு செய்யப்பட்ட ஒலித்துண்டுகள் அனைத்தும் ஒரே மாதிரி அளவை "
+"கொண்டிருக்க வேண்டும். "
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4075,10 +4097,15 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "எச்சரிக்கை: தானியக்க மீட்பில் பிரச்சினைகள்"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 #, fuzzy
 msgid "<untitled>"
 msgstr "பெயரிடப்படாத"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "திட்டங்கள்"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -10019,6 +10046,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10723,7 +10755,8 @@ msgstr "மாதிரி அளவுகள்"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -11349,7 +11382,6 @@ msgstr "தெரிவு செய்யப்பட்ட ஒலி FLAC ஆ�
 msgid "Exporting the audio as FLAC"
 msgstr "தெரிவு செய்யப்பட்ட ஒலி FLAC ஆக ஏற்றுமதிசெய்கிறது"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12608,7 +12640,7 @@ msgstr "முடிவு"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14626,13 +14658,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
 
 #: src/menus/TransportMenus.cpp
@@ -18991,7 +19035,7 @@ msgstr "பெயரானது காலியாக இருக்க கூ
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "ஆரம்பமும் நிறுத்தமும் 0 இனை விட பெரியதாக இருக்க வேண்டும்."
 
 #: src/widgets/valnum.cpp
@@ -20860,6 +20904,21 @@ msgstr "அதிர்வெண் (hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "அமைதி பிறப்பாக்கி"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "ஒலி அமைவுகளை இறக்கும் போது"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/tg.po
+++ b/locale/tg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2007-08-30 07:25-0400\n"
 "Last-Translator: Victor Ibragimov <youth_opportunities@tajikngo.org>\n"
 "Language-Team: Tajik Language\n"
@@ -3751,6 +3751,28 @@ msgstr ""
 "Хато ҳангоми кушодани афзори савтӣ. Лутфан, насби берунаи афзор ва суръати "
 "намунаи лоиҳаро санҷед."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Барои сохтани спектрум, ҳамаи роҳчаҳои интихобшуда бояд навъи якхела дошта "
+"бошанд."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3949,9 +3971,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Пурракунии лоиҳа"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9788,6 +9815,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10506,7 +10538,8 @@ msgstr ""
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr ""
@@ -11126,7 +11159,6 @@ msgstr "Вуруди аудиоҳои интихобшуда ба монанди
 msgid "Exporting the audio as FLAC"
 msgstr "Вуруди аудиоҳои интихобшуда ба монанди FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12379,7 +12411,7 @@ msgstr "Интиҳо"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14418,13 +14450,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Созиши роҳчаи нави аудиоии нав"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Созиши роҳчаи нави аудиоии нав"
 
 #: src/menus/TransportMenus.cpp
@@ -18741,7 +18785,7 @@ msgstr "Ном набояд ҷои холӣ дошта бошад"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Ном набояд ҷои холӣ дошта бошад"
 
 #: src/widgets/valnum.cpp
@@ -20606,6 +20650,21 @@ msgstr "Басомад (Ҳз)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Муваллиди хомӯшӣ"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Файлҳои қаблии худсабт ҷойиваз карда нашуданд"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2018-01-18 06:39+0000\n"
 "Last-Translator: Kaya Zeren <kayazeren@gmail.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/klyok/audacity/"
@@ -3817,6 +3817,28 @@ msgstr ""
 "Ses sunucusunu, oynatma aygıtını ve proje örnekleme hızını değiştirmeyi "
 "deneyin."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Bir süzgeç uygulayabilmek için, tüm seçili izler aynı örnek hızında "
+"olmalıdır."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4065,9 +4087,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Dikkat: Otomatik Kurtarma Sırasında Sorun Çıktı"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<adsız>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projeler"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9936,6 +9963,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "&Arabellek Boyutu (8 - 1048576 örnek):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "&Arabellek Boyutu (8 - 1048576 örnek):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10686,7 +10718,8 @@ msgstr "Örnekleme Hızları"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -11378,7 +11411,6 @@ msgstr "Seçili ses FLAC olarak dışa aktarılıyor"
 msgid "Exporting the audio as FLAC"
 msgstr "Ses FLAC olarak dışa aktarılıyor"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12729,7 +12761,7 @@ msgstr "bitiş"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14667,13 +14699,25 @@ msgstr ""
 "Lütfen bu projeyi kaydettikten ya da kapattıktan sonra yeniden deneyin."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Lütfen bir ses izi seçin."
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Lütfen bir ses izi seçin."
 
 #: src/menus/TransportMenus.cpp
@@ -18803,8 +18847,8 @@ msgid "Value must not be less than %s"
 msgstr "%s değerinden küçük olamaz"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "%s değerinden büyük olamaz"
 
 #: src/widgets/valnum.cpp
@@ -20677,6 +20721,21 @@ msgstr "Frekans (Hz):"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Düzenleyiciyi Görüntüle/Gizle"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Ses dosyaları içe aktarılırken"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #~ msgid "incorporating"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-04-09 14:02+0300\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
@@ -16,10 +16,10 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11"
-" ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 >"
-" 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n %"
-" 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != "
+"11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % "
+"100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
+"(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 "X-Generator: Lokalize 20.07.70\n"
 
 #: lib-src/FileDialog/gtk/FileDialogPrivate.cpp
@@ -2463,8 +2463,7 @@ msgid ""
 msgstr ""
 "FFmpeg було налаштовано у «Параметрах», бібліотека успішно завантажувалася "
 "раніше, \n"
-"але цього разу Audacity не вдалося завантажити її під час "
-"запуску. \n"
+"але цього разу Audacity не вдалося завантажити її під час запуску. \n"
 "\n"
 "Можливо, вам слід повернутися до сторінки «Параметри > Бібліотеки» і "
 "повторно налаштувати параметри бібліотеки."
@@ -3279,8 +3278,8 @@ msgstr "Групу додатків у %s було об'єднано із ран
 msgid ""
 "Plug-in item at %s conflicts with a previously defined item and was discarded"
 msgstr ""
-"Запис додатка у %s конфліктує із попередньо визначеним записом. Його буде"
-" відкинуто."
+"Запис додатка у %s конфліктує із попередньо визначеним записом. Його буде "
+"відкинуто."
 
 #: src/Menus.cpp
 #, c-format
@@ -3526,8 +3525,7 @@ msgid ""
 "The module \"%s\" does not provide any of the required functions. It will "
 "not be loaded."
 msgstr ""
-"Модуль %s не надає жодної з обов'язкових функцій. Його не буде "
-"завантажено."
+"Модуль %s не надає жодної з обов'язкових функцій. Його не буде завантажено."
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -3818,6 +3816,28 @@ msgstr ""
 "Спробуйте змінити джерело звуку, пристрій відтворення або частоту "
 "дискретизації проєкту."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+"Для застосування фільтра усі позначені доріжки повинні мати однакову частоту "
+"дискретизації."
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -4070,9 +4090,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Попередження: проблеми з автоматичним відновленням"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<без назви>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Проєкт %02i] Audacity «%s»"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -5653,9 +5678,9 @@ msgid ""
 "default shortcut is new or changed, and is the same shortcut that you have "
 "assigned to another command."
 msgstr ""
-"Клавіатурні скорочення для вказаних нижче команд було вилучено, оскільки їхнє"
-" типове клавіатурне скорочення є новим або зміненим, і ви призначили те саме"
-" скорочення для іншої команди."
+"Клавіатурні скорочення для вказаних нижче команд було вилучено, оскільки "
+"їхнє типове клавіатурне скорочення є новим або зміненим, і ви призначили те "
+"саме скорочення для іншої команди."
 
 #: src/commands/CommandManager.cpp
 msgid "Shortcuts have been removed"
@@ -9377,11 +9402,11 @@ msgid ""
 "require 8192 samples or less to work properly. However most effects can "
 "accept large buffers and using them will greatly reduce processing time."
 msgstr ""
-"Розмір буфера керує кількістю фрагментів, які буде надіслано до ефекту на"
-" кожній ітерації. Менші значення уповільнять обробку, а деякі ефекти"
-" вимагають надсилання не більше 8192 фрагментів для належної роботи. Втім,"
-" більшість ефектів здатні обробляти великі буфери даних, а використання таких"
-" буферів значно зменшує час, потрібний для обробки даних."
+"Розмір буфера керує кількістю фрагментів, які буде надіслано до ефекту на "
+"кожній ітерації. Менші значення уповільнять обробку, а деякі ефекти "
+"вимагають надсилання не більше 8192 фрагментів для належної роботи. Втім, "
+"більшість ефектів здатні обробляти великі буфери даних, а використання таких "
+"буферів значно зменшує час, потрібний для обробки даних."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
@@ -9399,11 +9424,11 @@ msgid ""
 "silences have been inserted into the audio. Enabling this option will "
 "provide that compensation, but it may not work for all VST effects."
 msgstr ""
-"У межах частини процедури обробки, деякі ефекти VST мають затримати"
-" повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите,"
-" що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього"
-" пункту надасть змогу компенсувати затримку, але таке компенсування працює не"
-" для усіх ефектів VST."
+"У межах частини процедури обробки, деякі ефекти VST мають затримати "
+"повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите, "
+"що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього "
+"пункту надасть змогу компенсувати затримку, але таке компенсування працює не "
+"для усіх ефектів VST."
 
 #: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
 #: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -9421,8 +9446,8 @@ msgid ""
 "take effect."
 msgstr ""
 "У більшості ефектів VST для встановлення значень параметрів передбачено "
-"графічний інтерфейс. Також можна скористатися базовим текстовим методом. Для"
-" застосування змін слід закрити вікно ефекту, а потім знову його відкрити."
+"графічний інтерфейс. Також можна скористатися базовим текстовим методом. Для "
+"застосування змін слід закрити вікно ефекту, а потім знову його відкрити."
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &graphical interface"
@@ -9563,11 +9588,11 @@ msgid ""
 "will provide that compensation, but it may not work for all Audio Unit "
 "effects."
 msgstr ""
-"У межах частини процедури обробки, деякі ефекти Audio Unit мають затримати"
-" повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите,"
-" що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього"
-" пункту надасть змогу компенсувати затримку, але таке компенсування працює не"
-" для усіх ефектів Audio Unit."
+"У межах частини процедури обробки, деякі ефекти Audio Unit мають затримати "
+"повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите, "
+"що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього "
+"пункту надасть змогу компенсувати затримку, але таке компенсування працює не "
+"для усіх ефектів Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9580,11 +9605,11 @@ msgid ""
 "Select \"Basic\" for a basic text-only interface. Reopen the effect for this "
 "to take effect."
 msgstr ""
-"Виберіть «Повний», щоб скористатися графічним інтерфейсом, якщо такий"
-" надається Audio Unit. Виберіть «Типовий», щоб скористатися інтерфейсом, який"
-" надає система. Виберіть «Базовий», щоб скористатися базовим текстовим"
-" інтерфейсом. Щоб внесені вами зміни набули чинності, вікно ефекту слід"
-" закрити і відкрити знову."
+"Виберіть «Повний», щоб скористатися графічним інтерфейсом, якщо такий "
+"надається Audio Unit. Виберіть «Типовий», щоб скористатися інтерфейсом, який "
+"надає система. Виберіть «Базовий», щоб скористатися базовим текстовим "
+"інтерфейсом. Щоб внесені вами зміни набули чинності, вікно ефекту слід "
+"закрити і відкрити знову."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -9748,11 +9773,11 @@ msgid ""
 "small silences have been inserted into the audio. Enabling this option will "
 "provide that compensation, but it may not work for all LADSPA effects."
 msgstr ""
-"У межах частини процедури обробки, деякі ефекти LADSPA мають затримати"
-" повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите,"
-" що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього"
-" пункту надасть змогу компенсувати затримку, але таке компенсування працює не"
-" для усіх ефектів LADSPA."
+"У межах частини процедури обробки, деякі ефекти LADSPA мають затримати "
+"повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите, "
+"що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього "
+"пункту надасть змогу компенсувати затримку, але таке компенсування працює не "
+"для усіх ефектів LADSPA."
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
@@ -9784,17 +9809,22 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "Розмір &буфера (від 8 до %d семплів):"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "Розмір &буфера (від 8 до %d семплів):"
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
 "silences have been inserted into the audio. Enabling this setting will "
 "provide that compensation, but it may not work for all LV2 effects."
 msgstr ""
-"У межах частини процедури обробки, деякі ефекти LV2 мають затримати"
-" повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите,"
-" що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього"
-" пункту надасть змогу компенсувати затримку, але таке компенсування працює не"
-" для усіх ефектів LV2."
+"У межах частини процедури обробки, деякі ефекти LV2 мають затримати "
+"повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите, "
+"що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього "
+"пункту надасть змогу компенсувати затримку, але таке компенсування працює не "
+"для усіх ефектів LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid ""
@@ -9802,9 +9832,9 @@ msgid ""
 "basic text-only method is also available.  Reopen the effect for this to "
 "take effect."
 msgstr ""
-"У ефектів LV2 може для встановлення значень параметрів передбачено "
-"графічний інтерфейс. Також можна скористатися базовим текстовим методом. Для"
-" застосування змін слід закрити вікно ефекту, а потім знову його відкрити."
+"У ефектів LV2 може для встановлення значень параметрів передбачено графічний "
+"інтерфейс. Також можна скористатися базовим текстовим методом. Для "
+"застосування змін слід закрити вікно ефекту, а потім знову його відкрити."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 sequence buffer overflow"
@@ -10547,7 +10577,8 @@ msgstr "Частоти дискретизації"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d кбіт/с"
@@ -11224,7 +11255,6 @@ msgstr "Експорт вибраного аудіо як FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Експорт звукових даних у форматі FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, c-format
 msgid "%d kpbs"
@@ -12573,7 +12603,7 @@ msgstr "кінець"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14395,11 +14425,24 @@ msgstr ""
 "Будь ласка, збережіть або закрийте цей проєкт і повторіть спробу."
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "Будь ласка, виберіть звукову доріжку моно."
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Будь ласка, виберіть звукову доріжку стерео."
 
 #: src/menus/TransportMenus.cpp
@@ -15402,9 +15445,9 @@ msgid ""
 "their shortcuts removed because of the conflict with other new shortcuts:\n"
 msgstr ""
 "\n"
-"У імпортованому файлів не міститься згадок вказаних нижче команд, але їхні"
-" скорочення було вилучено, оскільки вони конфліктують із іншими новими"
-" скороченнями:\n"
+"У імпортованому файлів не міститься згадок вказаних нижче команд, але їхні "
+"скорочення було вилучено, оскільки вони конфліктують із іншими новими "
+"скороченнями:\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -17530,8 +17573,8 @@ msgstr "%.0f%% правий"
 msgid ""
 "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr ""
-"Клацніть і перетягніть для коригування розмірів підпанелей, двічі клацніть,"
-" щоб поділити рівномірно"
+"Клацніть і перетягніть для коригування розмірів підпанелей, двічі клацніть, "
+"щоб поділити рівномірно"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
@@ -18457,8 +18500,8 @@ msgid "Value must not be less than %s"
 msgstr "Значення має бути не меншим за %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "Значення має бути не більшим за %s"
 
 #: src/widgets/valnum.cpp
@@ -19445,8 +19488,8 @@ msgstr "Увага.nНе вдалося скопіювати деякі файл
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins installed.n(Use the Plug-in Manager to enable effects):"
 msgstr ""
-"Встановлено додатки.n(Скористайтеся керуванням додатками, щоб увімкнути"
-" ефекти):"
+"Встановлено додатки.n(Скористайтеся керуванням додатками, щоб увімкнути "
+"ефекти):"
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -20014,8 +20057,8 @@ msgstr "Спектральне вилучення"
 #, lisp-format
 msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr ""
-"Помилка.~%Підтримки частот дискретизації доріжки, які є нижчими за 100 Гц, не"
-" передбачено."
+"Помилка.~%Підтримки частот дискретизації доріжки, які є нижчими за 100 Гц, "
+"не передбачено."
 
 #: plug-ins/tremolo.ny
 msgid "Tremolo"
@@ -20258,3 +20301,18 @@ msgstr "Частота голок радару (у Гц)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Помилка.~%Потрібна стереодоріжка."
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Показати або приховати редактор"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Під час імпорту аудіофайлів"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""

--- a/locale/update_po_files.sh
+++ b/locale/update_po_files.sh
@@ -27,6 +27,20 @@ xargs xgettext \
 --package-version='2.4.0' \
 --msgid-bugs-address="audacity-translation@lists.sourceforge.net" \
 --add-location=file -L Lisp -j -o audacity.pot 
+echo ";; Adding .desktop file to audacity.pot"
+find ../src -name \*desktop.in | LANG=c sort | \
+sed -E 's/\.\.\///g' |\
+xargs xgettext \
+--default-domain=audacity \
+--directory=.. \
+--keyword --keyword=GenericName --keyword=Comment --keyword=Keywords \
+--add-comments=" i18n" \
+--add-location=file  \
+--copyright-holder='Audacity Team' \
+--package-name="audacity" \
+--package-version='2.4.0' \
+--msgid-bugs-address="audacity-translation@lists.sourceforge.net" \
+--add-location=file -j -o audacity.pot
 echo ";; Updating the .po files - Updating Project-Id-Version"
 for i in *.po; do
     sed -i '/^"Project-Id-Version:/c\"Project-Id-Version: audacity 2.4.0\\n"' $i

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2008-06-26 15:07+0700\n"
 "Last-Translator: Nguyen Dinh Trung <nguyendinhtrung141@gmail.com>\n"
 "Language-Team: \n"
@@ -3753,6 +3753,26 @@ msgstr ""
 "Lỗi mở thiết bị âm thanh. Xin hãy kiểm tra thiết lập đầu ra và tốc độ lấy "
 "mẫu của dự án."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "Để vẽ phổ, tất cả các dải được chọn phải có cùng tốc độ lấy mẫu"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3950,9 +3970,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr ""
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Vừa dự án"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9809,6 +9834,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10534,7 +10564,8 @@ msgstr "Tốc độ lấy mẫu"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, fuzzy, c-format
 msgid "%d kbps"
 msgstr "kbps"
@@ -11154,7 +11185,6 @@ msgstr "Xuất âm thanh đã chọn thành FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "Xuất âm thanh đã chọn thành FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12455,7 +12485,7 @@ msgstr "Kết thúc"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14499,13 +14529,25 @@ msgid ""
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 #, fuzzy
 msgid "Please select in a mono track."
 msgstr "Tạo dải âm mới"
 
 #: src/menus/TransportMenus.cpp
 #, fuzzy
-msgid "Please select in a stereo track."
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "Tạo dải âm mới"
 
 #: src/menus/TransportMenus.cpp
@@ -18826,7 +18868,7 @@ msgstr "Không được để trống phần tên"
 
 #: src/widgets/valnum.cpp
 #, fuzzy, c-format
-msgid "Value must not be greather than %s"
+msgid "Value must not be greater than %s"
 msgstr "Ngưỡng bắt đầu và kết thúc phải lớn hơn 0."
 
 #: src/widgets/valnum.cpp
@@ -20692,6 +20734,21 @@ msgstr "Tần số (Hz)"
 #: plug-ins/vocoder.ny
 #, lisp-format
 msgid "Error.~%Stereo track required."
+msgstr ""
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "Tạo khoảng lặng"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "Khi nhập âm thanh"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
 msgstr ""
 
 #, fuzzy

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2019-09-10 22:44+0900\n"
 "Last-Translator: mkpoli <snowwolf1001@gmail.com>\n"
 "Language-Team: Chinese (http://www.transifex.com/klyok/audacity/language/"
@@ -3734,6 +3734,26 @@ msgstr ""
 "打开声音设备出错。\n"
 "请检查音频主机、播放设备的以及项目采样率。"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "如果想应用过滤器，所有选择的轨道必须拥有相同的采样率。"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3973,9 +3993,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "警告：自动恢复时发生问题"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<untitled>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "项目"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9660,6 +9685,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "缓冲大小（8 到 1048576 个采样）(&B)："
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "缓冲大小（8 到 1048576 个采样）(&B)："
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10393,7 +10423,8 @@ msgstr "采样率"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11074,7 +11105,6 @@ msgstr "正把选中的音频导出为FLAC文件"
 msgid "Exporting the audio as FLAC"
 msgstr "正在导出音频为 FLAC 格式"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12403,7 +12433,7 @@ msgstr "终点"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14213,11 +14243,24 @@ msgid ""
 msgstr "在保存更改时，无法使用定时录音。请保存或关闭此项目，然后重试。"
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "请选择一个单声道音轨。"
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "请选择一个双声道音轨。"
 
 #: src/menus/TransportMenus.cpp
@@ -18258,8 +18301,8 @@ msgid "Value must not be less than %s"
 msgstr "值不能小于 %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "值不能大于 %s"
 
 #: src/widgets/valnum.cpp
@@ -20058,6 +20101,21 @@ msgstr "脉冲列频率（Hz）"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "错误.~%需要立体声轨"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "显示/隐藏编辑器"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "当导入音频文件时"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "incorporating"
 #~ msgstr "包含"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: audacity 2.4.0\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-08 19:39+0100\n"
+"POT-Creation-Date: 2020-04-24 11:45-0600\n"
 "PO-Revision-Date: 2020-01-01 21:55+0800\n"
 "Last-Translator: pan93412 <pan93412@gmail.com>\n"
 "Language-Team: Chinese <zh-l10n@lists.linux.org.tw>\n"
@@ -3720,6 +3720,26 @@ msgstr ""
 "開啟聲音裝置時發生錯誤。\n"
 "請試著變更音訊主機、播放裝置和專案的取樣頻率。"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "如要套用過濾器，所有選擇的軌道必須具有相同的取樣頻率。"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Audacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #. i18n-hint:  A name given to a track, appearing as its menu button.
 #. The translation should be short or else it will not display well.
 #. At most, about 11 Latin characters.
@@ -3960,9 +3980,14 @@ msgstr ""
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "警告：自動復原時發生問題"
 
-#: src/ProjectFileIO.cpp
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<未命名>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "專案"
 
 #. i18n-hint: The %02i is the project number, the %s is the project name.
 #: src/ProjectFileIO.cpp
@@ -9634,6 +9659,11 @@ msgid "&Buffer Size (8 to %d) samples):"
 msgstr "緩衝區大小 (8 到 %d 取樣點)(&B)："
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d samples):"
+msgstr "緩衝區大小 (8 到 %d 取樣點)(&B)："
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid ""
 "As part of their processing, some LV2 effects must delay returning audio to "
 "Audacity. When not compensating for this delay, you will notice that small "
@@ -10351,7 +10381,8 @@ msgstr "取樣頻率"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11039,7 +11070,6 @@ msgstr "正在將選擇的音訊匯出為 FLAC"
 msgid "Exporting the audio as FLAC"
 msgstr "正在將音訊匯出為 FLAC"
 
-#. i18n-hint kbps abbreviates "thousands of bits per second"
 #: src/export/ExportMP2.cpp
 #, fuzzy, c-format
 msgid "%d kpbs"
@@ -12354,7 +12384,7 @@ msgstr "終點"
 #. First two %s are each replaced with the noun "start"
 #. or with "end", identifying and end of a clip,
 #. first and second numbers give the position of those clips in
-#. a seqeunce of clips,
+#. a sequence of clips,
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
@@ -14161,11 +14191,24 @@ msgid ""
 msgstr "在儲存變更時無法使用預約錄製。請儲存或關閉此專案，然後重試。"
 
 #: src/menus/TransportMenus.cpp
+msgid ""
+"TRACK SELECTION PROBLEM:\n"
+"Not enough tracks are selected for recording on non-project rate.\n"
+"(keep in mind that Audacity doesn't allow using only one channel of a stereo "
+"track)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Insufficient track selection"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
 msgstr "請在單聲道軌道內選擇"
 
 #: src/menus/TransportMenus.cpp
-msgid "Please select in a stereo track."
+#, fuzzy
+msgid "Please select in a stereo track or two mono tracks."
 msgstr "請在立體聲軌道內選擇"
 
 #: src/menus/TransportMenus.cpp
@@ -18202,8 +18245,8 @@ msgid "Value must not be less than %s"
 msgstr "值不可小於 %s"
 
 #: src/widgets/valnum.cpp
-#, c-format
-msgid "Value must not be greather than %s"
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
 msgstr "值不可大於 %s"
 
 #: src/widgets/valnum.cpp
@@ -19973,6 +20016,21 @@ msgstr "Radar Needles 頻率 (赫茲)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "錯誤。~%必須是立體聲"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Sound Editor"
+msgstr "顯示/隱藏編輯器"
+
+#: src/audacity.desktop.in
+#, fuzzy
+msgid "Record and edit audio files"
+msgstr "當匯入音訊檔案時"
+
+#: src/audacity.desktop.in
+msgid ""
+"audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;"
+msgstr ""
 
 #~ msgid "Click to unpin"
 #~ msgstr "點選以取消固定"

--- a/src/audacity.desktop.in
+++ b/src/audacity.desktop.in
@@ -1,45 +1,8 @@
 [Desktop Entry]
 Name=Audacity
 GenericName=Sound Editor
-GenericName[ar]=محرر أصوات
-GenericName[ca]=Editor d'àudio
-GenericName[da]=Lydredigeringsprogram
-GenericName[de]=Audio-Editor
-GenericName[el]=Επεξεργαστής ήχου
-GenericName[fr]=Éditeur audio
-GenericName[hi]=ध्वनि संपादक
-GenericName[ja]=オーディオエディタ
-GenericName[ko]=오디오 편집기
-GenericName[lt]=Garsų rengyklė
-GenericName[nl]=Geluidseditor
-GenericName[pt_BR]=Editor de áudio
-GenericName[pt_PT]=Editor de áudio
-GenericName[ru]=Редактор звуковых файлов
-GenericName[sk]=Zvukový Editor
-GenericName[tr]=Ses Düzenleyici
-GenericName[uk]=Редактор звукових файлів
-GenericName[zh_CN]=音频编辑器
-GenericName[zh_TW]=音訊編輯器
 Comment=Record and edit audio files
-Comment[ar]=سجل و حرر ملفات صوت
-Comment[ca]=Enregistreu i editeu els fitxers d'àudio
-Comment[da]=Optag og rediger lydfiler
-Comment[de]=Audio-Dateien aufnehmen und bearbeiten
-Comment[el]=Ηχογράφηση και επεξεργασία αρχείων ήχου
-Comment[fr]=Enregistrer et éditer des fichiers audio
-Comment[hi]=ऑडियो फ़ाइल अंकित व संपादित करता है
-Comment[ja]=録音とオーディオ編集
-Comment[kr]=오디오 파일 녹음과 편집
-Comment[lt]=Įrašyti ir montuoti garso failus
-Comment[nl]=Audiobestanden opnemen en bewerken
-Comment[pt_BR]=Gravar e editar arquivos de áudio
-Comment[pt_PT]=Gravar e editar ficheiros de áudio
-Comment[ru]=Запись и редактирование звуковых файлов
-Comment[sk]=Nahráva a upravuje audio súbory.
-Comment[tr]=Ses dosyalarını kaydetme ve düzenleme
-Comment[uk]=Запис і редагування звукових файлів
-Comment[zh_CN]=录音和编辑音频文件
-Comment[zh_TW]=錄音和編輯音訊檔案
+Keywords=audio;editing;recorder;digital effects;plug-ins;mixing;spectrum analysis;
 
 Icon=@AUDACITY_NAME@
 


### PR DESCRIPTION
Add Keywords entry to .desktop file to improve searches for the software, and add GenericName, Comment, and Keyword fields to .po generation so translation occurs there instead.