### PR TITLE
[WIN32] Fix CONST redefinition error

### DIFF
--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -236,13 +236,6 @@ void TrackArt::DrawNegativeOffsetTrackArrows(
 }
 
 
-#ifdef __GNUC__
-#define CONST
-#else
-#define CONST const
-#endif
-
-
 #ifdef USE_MIDI
 #endif // USE_MIDI
 


### PR DESCRIPTION
On Windows, the `CONST` macro is already defined by system include files.
MSVC tolerates that, but this is fatal for GCC.
The `CONST` macro is unused in this source anyways, so it would be worth to remove it.
