### PR TITLE
Fix CMake build of modules

### DIFF
--- a/cmake-proxies/mod-null/CMakeLists.txt
+++ b/cmake-proxies/mod-null/CMakeLists.txt
@@ -14,11 +14,13 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/ModNullCallback.h
 )
 
+get_target_property( INCLUDES wxWidgets INTERFACE_INCLUDE_DIRECTORIES )
 list( APPEND INCLUDES
    PUBLIC
       ${TARGET_ROOT}
 )
 
+get_target_property( DEFINES wxWidgets INTERFACE_COMPILE_DEFINITIONS )
 list( APPEND DEFINES
    PRIVATE
       # This is needed until the transition to cmake is complete and
@@ -29,10 +31,14 @@ list( APPEND DEFINES
       wxDEBUG_LEVEL=0
 )
 
+list( APPEND LOPTS
+   PRIVATE
+      $<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>
+)
+
 list( APPEND LIBRARIES
    PRIVATE
       Audacity
-      wxWidgets
 )
 
 set_target_property_all( ${TARGET} LIBRARY_OUTPUT_DIRECTORY "${_DEST}/modules" )
@@ -46,5 +52,6 @@ organize_source( "${TARGET_ROOT}" "" "${SOURCES}" )
 target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
+target_link_options( ${TARGET} PRIVATE ${LOPTS} )
 target_link_libraries( ${TARGET} PRIVATE ${LIBRARIES} )
 

--- a/cmake-proxies/mod-null/CMakeLists.txt
+++ b/cmake-proxies/mod-null/CMakeLists.txt
@@ -39,6 +39,8 @@ list( APPEND LOPTS
 list( APPEND LIBRARIES
    PRIVATE
       Audacity
+      $<$<PLATFORM_ID:Windows>:wxWidgets>
+      $<$<PLATFORM_ID:Windows>:FileDialog>
 )
 
 set_target_property_all( ${TARGET} LIBRARY_OUTPUT_DIRECTORY "${_DEST}/modules" )

--- a/cmake-proxies/mod-nyq-bench/CMakeLists.txt
+++ b/cmake-proxies/mod-nyq-bench/CMakeLists.txt
@@ -14,11 +14,18 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/NyqBench.h
 )
 
+get_target_property( wx_INCLUDES wxWidgets INTERFACE_INCLUDE_DIRECTORIES )
+get_target_property( pa_INCLUDES portaudio-v19 INTERFACE_INCLUDE_DIRECTORIES )
+get_target_property( ny_INCLUDES libnyquist INTERFACE_INCLUDE_DIRECTORIES )
 list( APPEND INCLUDES
    PUBLIC
+      ${wx_INCLUDES}
+      ${pa_INCLUDES}
+      ${ny_INCLUDES}
       ${TARGET_ROOT}
 )
 
+get_target_property( DEFINES wxWidgets INTERFACE_COMPILE_DEFINITIONS )
 list( APPEND DEFINES
    PRIVATE
       # This is needed until the transition to cmake is complete and
@@ -29,12 +36,14 @@ list( APPEND DEFINES
       wxDEBUG_LEVEL=0
 )
 
+list( APPEND LOPTS
+   PRIVATE
+      $<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>
+)
+
 list( APPEND LIBRARIES
    PRIVATE
       Audacity
-      libnyquist
-      portaudio-v19
-      wxWidgets
 )
 
 set_target_property_all( ${TARGET} LIBRARY_OUTPUT_DIRECTORY "${_DEST}/modules" )
@@ -48,5 +57,6 @@ organize_source( "${TARGET_ROOT}" "" "${SOURCES}" )
 target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
+target_link_options( ${TARGET} PRIVATE ${LOPTS} )
 target_link_libraries( ${TARGET} PRIVATE ${LIBRARIES} )
 

--- a/cmake-proxies/mod-nyq-bench/CMakeLists.txt
+++ b/cmake-proxies/mod-nyq-bench/CMakeLists.txt
@@ -44,6 +44,8 @@ list( APPEND LOPTS
 list( APPEND LIBRARIES
    PRIVATE
       Audacity
+      $<$<PLATFORM_ID:Windows>:wxWidgets>
+      $<$<PLATFORM_ID:Windows>:FileDialog>
 )
 
 set_target_property_all( ${TARGET} LIBRARY_OUTPUT_DIRECTORY "${_DEST}/modules" )

--- a/cmake-proxies/mod-script-pipe/CMakeLists.txt
+++ b/cmake-proxies/mod-script-pipe/CMakeLists.txt
@@ -14,11 +14,13 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/ScripterCallback.cpp
 )
 
+get_target_property( INCLUDES wxWidgets INTERFACE_INCLUDE_DIRECTORIES )
 list( APPEND INCLUDES
    PUBLIC
       ${TARGET_ROOT}
 )
 
+get_target_property( DEFINES wxWidgets INTERFACE_COMPILE_DEFINITIONS )
 list( APPEND DEFINES
    PRIVATE
       BUILDING_SCRIPT_PIPE
@@ -31,10 +33,14 @@ list( APPEND DEFINES
       wxDEBUG_LEVEL=0
 )
 
+list( APPEND LOPTS
+   PRIVATE
+      $<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>
+)
+
 list( APPEND LIBRARIES
    PRIVATE
       Audacity
-      wxWidgets
 )
 
 set_target_property_all( ${TARGET} LIBRARY_OUTPUT_DIRECTORY "${_DEST}/modules" )
@@ -48,5 +54,6 @@ organize_source( "${TARGET_ROOT}" "" "${SOURCES}" )
 target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
+target_link_options( ${TARGET} PRIVATE ${LOPTS} )
 target_link_libraries( ${TARGET} PRIVATE ${LIBRARIES} )
 

--- a/cmake-proxies/mod-script-pipe/CMakeLists.txt
+++ b/cmake-proxies/mod-script-pipe/CMakeLists.txt
@@ -41,6 +41,7 @@ list( APPEND LOPTS
 list( APPEND LIBRARIES
    PRIVATE
       Audacity
+      $<$<PLATFORM_ID:Windows>:wxWidgets>      
 )
 
 set_target_property_all( ${TARGET} LIBRARY_OUTPUT_DIRECTORY "${_DEST}/modules" )

--- a/cmake-proxies/wxWidgets/CMakeLists.txt
+++ b/cmake-proxies/wxWidgets/CMakeLists.txt
@@ -122,17 +122,30 @@ else()
       WXUSINGDLL
    )
 
+   # For all required libs, gather all of the interface target
+   # properties and merge them into the wxWidgets target
+   foreach( lib adv base core html net qa xml )
+      get_target_property( value ${lib} INTERFACE_INCLUDE_DIRECTORIES )
+      list( APPEND INCLUDES ${value} )
+      list( REMOVE_DUPLICATES INCLUDES )
+
+      get_target_property( value ${lib} INTERFACE_COMPILE_DEFINITIONS )
+      list( APPEND DEFINES ${value} )
+      list( REMOVE_DUPLICATES DEFINES )
+
+      get_target_property( value ${lib} INTERFACE_COMPILE_OPTIONS )
+      list( APPEND COPTS ${value} )
+      list( REMOVE_DUPLICATES COPTS )
+
+      get_target_property( value ${lib} INTERFACE_LINK_LIBRARIES )
+      list( APPEND LIBRARIES ${lib} ${value} )
+      list( REMOVE_DUPLICATES LIBRARIES )
+   endforeach()
+
    # Do NOT split the generator expressions across multiple lines here.
    # CMake appears to have a bug and doesn't seem to handle it correctly
    # for target link libraries.
-   set( LIBRARIES
-      adv
-      base
-      core
-      html
-      net
-      qa
-      xml
+   list( APPEND LIBRARIES
       $<$<STREQUAL:"${wxUSE_EXPAT}","builtin">:wxexpat>
       $<$<STREQUAL:"${wxUSE_LIBJPEG}","builtin">:wxjpeg>
       $<$<STREQUAL:"${wxUSE_LIBPNG}","builtin">:wxpng>
@@ -184,7 +197,9 @@ endif()
 
 target_include_directories( ${TARGET} INTERFACE ${INCLUDES} )
 target_compile_definitions( ${TARGET} INTERFACE ${DEFINES} )
+target_compile_options( ${TARGET} INTERFACE ${COPTS} )
 target_link_directories( ${TARGET} INTERFACE ${LINKDIRS} )
 target_link_libraries( ${TARGET} INTERFACE ${LIBRARIES} )
 
-INSTALL( TARGETS ${TARGET} DESTINATION ${_LIBDIR} )
+install( TARGETS ${TARGET} DESTINATION ${_LIBDIR} )
+


### PR DESCRIPTION
They must not be linked against any libraries as build time.  The
symbols will be resovled at runtime.

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
