### PR TITLE
cmake: check for system portsmf via correct pkg-config name

### DIFF
--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -148,7 +148,7 @@ addlib( libflac            flac        LIBFLAC     NO    YES   "flac >= 1.3.1" "
 addlib( lv2                lv2         LV2         NO    YES   "lilv-0 >= 0.24.6" "lv2 >= 1.16.0" "serd-0 >= 0.30.2" "sord-0 >= 0.16.4" "sratom-0 >= 0.6.4" "suil-0 >= 0.10.6" )
 addlib( portmidi           midi        MIDI        NO    YES   "portmidi >= 0.1" )
 addlib( portmixer          portmixer   PORTMIXER   NO    YES   "" )
-addlib( portsmf            portsmf     PORTSMF     NO    YES   "portsmf >= 0.1" )
+addlib( portsmf            portsmf     PORTSMF     NO    YES   "portSMF >= 0.1" )
 addlib( sbsms              sbsms       SBSMS       NO    YES   "" )
 addlib( soundtouch         soundtouch  SOUNDTOUCH  NO    YES   "soundtouch >= 1.7.1" )
 addlib( twolame            twolame     LIBTWOLAME  NO    YES   "twolame >= 0.3.13" )


### PR DESCRIPTION
Even if portsmf is installed system-wide, it is not found. pkg-config package name comparison is case-sensitive and portsmf installs portSMF.pc, so check for portSMF.
