### PR TITLE
Be more careful when handling grid keyboard navigation.

### DIFF
--- a/src/widgets/Grid.cpp
+++ b/src/widgets/Grid.cpp
@@ -539,29 +539,39 @@ void Grid::OnKeyDown(wxKeyEvent &event)
       {
          int rows = GetNumberRows();
          int cols = GetNumberCols();
-         int crow = GetGridCursorRow();
-         int ccol = GetGridCursorCol();
 
-         if (event.GetKeyCode() == WXK_LEFT) {
-            if (crow == 0 && ccol == 0) {
-               // do nothing
+         const bool has_cells = rows > 0 && cols > 0;
+
+         if (has_cells) {
+            int crow = GetGridCursorRow();
+            int ccol = GetGridCursorCol();
+
+            const bool has_no_selection = crow == wxGridNoCellCoords.GetRow() || ccol == wxGridNoCellCoords.GetCol();
+
+            if (has_no_selection) {
+               SetGridCursor(0, 0);
             }
-            else if (ccol == 0) {
-               SetGridCursor(crow - 1, cols - 1);
+            else if (event.GetKeyCode() == WXK_LEFT) {
+               if (crow == 0 && ccol == 0) {
+                  // do nothing
+               }
+               else if (ccol == 0) {
+                  SetGridCursor(crow - 1, cols - 1);
+               }
+               else {
+                  SetGridCursor(crow, ccol - 1);
+               }
             }
             else {
-               SetGridCursor(crow, ccol - 1);
-            }
-         }
-         else {
-            if (crow == rows - 1 && ccol == cols - 1) {
-               // do nothing
-            }
-            else if (ccol == cols - 1) {
-               SetGridCursor(crow + 1, 0);
-            }
-            else {
-               SetGridCursor(crow, ccol + 1);
+               if (crow == rows - 1 && ccol == cols - 1) {
+                  // do nothing
+               }
+               else if (ccol == cols - 1) {
+                  SetGridCursor(crow + 1, 0);
+               }
+               else {
+                  SetGridCursor(crow, ccol + 1);
+               }
             }
          }
 
@@ -574,11 +584,6 @@ void Grid::OnKeyDown(wxKeyEvent &event)
 
       case WXK_TAB:
       {
-         int rows = GetNumberRows();
-         int cols = GetNumberCols();
-         int crow = GetGridCursorRow();
-         int ccol = GetGridCursorCol();
-
          if (event.ControlDown()) {
             int flags = wxNavigationKeyEvent::FromTab |
                         ( event.ShiftDown() ?
@@ -587,9 +592,17 @@ void Grid::OnKeyDown(wxKeyEvent &event)
             Navigate(flags);
             return;
          }
-         else if (event.ShiftDown()) {
-            // Empty grid?
-            if (crow == -1 && ccol == -1) {
+
+         int rows = GetNumberRows();
+         int cols = GetNumberCols();
+         int crow = GetGridCursorRow();
+         int ccol = GetGridCursorCol();
+
+         const auto is_empty = rows <= 0 || cols <= 0;
+         const auto has_no_selection = crow == wxGridNoCellCoords.GetRow() || ccol == wxGridNoCellCoords.GetCol();
+
+         if (event.ShiftDown()) {
+            if (is_empty) {
                Navigate(wxNavigationKeyEvent::FromTab | wxNavigationKeyEvent::IsBackward);
                return;
             }
@@ -597,6 +610,10 @@ void Grid::OnKeyDown(wxKeyEvent &event)
             if (crow == 0 && ccol == 0) {
                Navigate(wxNavigationKeyEvent::FromTab | wxNavigationKeyEvent::IsBackward);
                return;
+            }
+
+            if (has_no_selection) {
+               SetGridCursor(rows -1, cols - 1);
             }
             else if (ccol == 0) {
                SetGridCursor(crow - 1, cols - 1);
@@ -606,8 +623,7 @@ void Grid::OnKeyDown(wxKeyEvent &event)
             }
          }
          else {
-            // Empty grid?
-            if (crow == -1 && ccol == -1) {
+            if (is_empty) {
                Navigate(wxNavigationKeyEvent::FromTab | wxNavigationKeyEvent::IsForward);
                return;
             }
@@ -615,6 +631,10 @@ void Grid::OnKeyDown(wxKeyEvent &event)
             if (crow == rows - 1 && ccol == cols - 1) {
                Navigate(wxNavigationKeyEvent::FromTab | wxNavigationKeyEvent::IsForward);
                return;
+            }
+
+            if (has_no_selection) {
+               SetGridCursor(0, 0);
             }
             else if (ccol == cols - 1) {
                SetGridCursor(crow + 1, 0);


### PR DESCRIPTION
If the grid is empty or does not have a selected cell, the current
row and column must still maintain these class invariants:
   -1 <= current_row < rows
   -1 <= current_column < columns
    if either current_row or current_column is -1, then the other
       shall also be -1

wxGrid uses wxGridNoCellCoords to test for current_row == -1 &&
current_column == -1.  We treat the case where only one
of the coordinates is -1 as if both are -1.

This should resolve the problem described by  "David Engebretson Jr." <accessible.engineering@gmail.com> in the devel thread "extended import in properties dialog still crashes" (was it on Bugzilla? I didn't see it).  It has not been tested with a screen reader.

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
