### PR TITLE
Include portaudio.h in AudioIOBase.cpp

### DIFF
--- a/src/AudioIOBase.cpp
+++ b/src/AudioIOBase.cpp
@@ -21,6 +21,8 @@ Paul Licameli split from AudioIO.cpp
 #include "prefs/RecordingPrefs.h"
 #include "widgets/MeterPanelBase.h"
 
+#include "portaudio.h"
+
 #if USE_PORTMIXER
 #include "portmixer.h"
 #endif


### PR DESCRIPTION
This fixes the following compilation error on OpenBSD/clang (using 'system' version of portaudio):
```
/tmp/audacity-Audacity-2.4.2/src/AudioIOBase.cpp:80:47: error: member access into incomplete type 'const PaDeviceInfo'
   wxString infoName = wxSafeConvertMB2WX(info->name);
                                              ^
/tmp/audacity-Audacity-2.4.2/src/AudioIOBase.h:25:8: note: forward declaration of 'PaDeviceInfo'
struct PaDeviceInfo;
```
