### PR TITLE
Sqlite errors

### DIFF
--- a/src/AutoRecovery.cpp
+++ b/src/AutoRecovery.cpp
@@ -280,7 +280,7 @@ wxString AutoSaveFile::Decode(const wxMemoryBuffer &buffer)
 
    mIds.clear();
 
-   struct Error{};
+   struct Error{}; // exception type for short-range try/catch
    auto Lookup = [&mIds]( short id ) -> const wxString &
    {
       auto iter = mIds.find( id );
@@ -318,7 +318,7 @@ wxString AutoSaveFile::Decode(const wxMemoryBuffer &buffer)
       return str;
    };
 
-   while (!in.Eof())
+   try { while (!in.Eof())
    {
       short id;
 
@@ -495,6 +495,10 @@ wxString AutoSaveFile::Decode(const wxMemoryBuffer &buffer)
             wxASSERT(true);
          break;
       }
+   } } catch( const Error& ) {
+      // Autosave was corrupt, or platform differences in size or endianness
+      // were not well canonicalized
+      return {};
    }
 
    return out;

--- a/src/AutoRecovery.h
+++ b/src/AutoRecovery.h
@@ -61,6 +61,7 @@ public:
    bool IsEmpty() const;
    bool DictChanged() const;
 
+   // Returns empty string if decoding fails
    static wxString Decode(const wxMemoryBuffer &buffer);
 
 private:

--- a/src/SampleBlock.cpp
+++ b/src/SampleBlock.cpp
@@ -8,6 +8,7 @@ SampleBlock.cpp
 
 #include "Audacity.h"
 #include "SampleBlock.h"
+#include "SampleFormat.h"
 
 #include <wx/defs.h>
 
@@ -37,4 +38,39 @@ SampleBlockFactoryPtr SampleBlockFactory::New( AudacityProject &project )
 SampleBlockFactory::~SampleBlockFactory() = default;
 
 SampleBlock::~SampleBlock() = default;
+
+size_t SampleBlock::GetSamples(samplePtr dest,
+                   sampleFormat destformat,
+                   size_t sampleoffset,
+                   size_t numsamples, bool mayThrow)
+{
+   try{ return DoGetSamples(dest, destformat, sampleoffset, numsamples); }
+   catch( ... ) {
+      if( mayThrow )
+         throw;
+      ClearSamples( dest, destformat, 0, numsamples );
+      return 0;
+   }
+}
+ 
+ MinMaxRMS SampleBlock::GetMinMaxRMS(
+                        size_t start, size_t len, bool mayThrow)
+{
+   try{ return DoGetMinMaxRMS(start, len); }
+   catch( ... ) {
+      if( mayThrow )
+         throw;
+      return {};
+   }
+}
+ 
+ MinMaxRMS SampleBlock::GetMinMaxRMS(bool mayThrow) const
+{
+   try{ return DoGetMinMaxRMS(); }
+   catch( ... ) {
+      if( mayThrow )
+         throw;
+      return {};
+   }
+}
 

--- a/src/SampleBlock.cpp
+++ b/src/SampleBlock.cpp
@@ -37,6 +37,44 @@ SampleBlockFactoryPtr SampleBlockFactory::New( AudacityProject &project )
 
 SampleBlockFactory::~SampleBlockFactory() = default;
 
+SampleBlockPtr SampleBlockFactory::Get(SampleBlockID sbid)
+{
+   auto result = DoGet(sbid);
+   if (!result)
+      THROW_INCONSISTENCY_EXCEPTION;
+   return result;
+}
+
+SampleBlockPtr SampleBlockFactory::Create(samplePtr src,
+   size_t numsamples,
+   sampleFormat srcformat)
+{
+   auto result = DoCreate(src, numsamples, srcformat);
+   if (!result)
+      THROW_INCONSISTENCY_EXCEPTION;
+   return result;
+}
+
+SampleBlockPtr SampleBlockFactory::CreateSilent(
+   size_t numsamples,
+   sampleFormat srcformat)
+{
+   auto result = DoCreateSilent(numsamples, srcformat);
+   if (!result)
+      THROW_INCONSISTENCY_EXCEPTION;
+   return result;
+}
+
+SampleBlockPtr SampleBlockFactory::CreateFromXML(
+   sampleFormat srcformat,
+   const wxChar **attrs)
+{
+   auto result = DoCreateFromXML(srcformat, attrs);
+   if (!result)
+      THROW_INCONSISTENCY_EXCEPTION;
+   return result;
+}
+
 SampleBlock::~SampleBlock() = default;
 
 size_t SampleBlock::GetSamples(samplePtr dest,

--- a/src/SampleBlock.h
+++ b/src/SampleBlock.h
@@ -107,17 +107,44 @@ public:
 
    virtual ~SampleBlockFactory();
 
-   virtual SampleBlockPtr Get(SampleBlockID sbid) = 0;
+   // Returns a non-null pointer or else throws an exception
+   SampleBlockPtr Get(SampleBlockID sbid);
 
-   virtual SampleBlockPtr Create(samplePtr src,
+   // Returns a non-null pointer or else throws an exception
+   SampleBlockPtr Create(samplePtr src,
+      size_t numsamples,
+      sampleFormat srcformat);
+
+   // Returns a non-null pointer or else throws an exception
+   SampleBlockPtr CreateSilent(
+      size_t numsamples,
+      sampleFormat srcformat);
+
+   // Returns a non-null pointer or else throws an exception
+   SampleBlockPtr CreateFromXML(
+      sampleFormat srcformat,
+      const wxChar **attrs);
+
+protected:
+   // The override should throw more informative exceptions on error than the
+   // default InconsistencyException thrown by Create
+   virtual SampleBlockPtr DoGet(SampleBlockID sbid) = 0;
+
+   // The override should throw more informative exceptions on error than the
+   // default InconsistencyException thrown by Create
+   virtual SampleBlockPtr DoCreate(samplePtr src,
       size_t numsamples,
       sampleFormat srcformat) = 0;
 
-   virtual SampleBlockPtr CreateSilent(
+   // The override should throw more informative exceptions on error than the
+   // default InconsistencyException thrown by CreateSilent
+   virtual SampleBlockPtr DoCreateSilent(
       size_t numsamples,
       sampleFormat srcformat) = 0;
 
-   virtual SampleBlockPtr CreateFromXML(
+   // The override should throw more informative exceptions on error than the
+   // default InconsistencyException thrown by CreateFromXML
+   virtual SampleBlockPtr DoCreateFromXML(
       sampleFormat srcformat,
       const wxChar **attrs) = 0;
 };

--- a/src/SampleBlock.h
+++ b/src/SampleBlock.h
@@ -31,9 +31,9 @@ using SampleBlockID = long long;
 class MinMaxRMS
 {
 public:
-   float min;
-   float max;
-   float RMS;
+   float min = 0;
+   float max = 0;
+   float RMS = 0;
 };
 
 class SqliteSampleBlockFactory;
@@ -52,10 +52,12 @@ public:
    
    virtual SampleBlockID GetBlockID() = 0;
 
-   virtual size_t GetSamples(samplePtr dest,
+   // If !mayThrow and there is an error, ignores it and returns zero.
+   // That may be appropriate when only attempting to display samples, not edit.
+   size_t GetSamples(samplePtr dest,
                      sampleFormat destformat,
                      size_t sampleoffset,
-                     size_t numsamples) = 0;
+                     size_t numsamples, bool mayThrow = true);
 
    virtual size_t GetSampleCount() const = 0;
 
@@ -65,14 +67,29 @@ public:
       GetSummary64k(float *dest, size_t frameoffset, size_t numframes) = 0;
 
    /// Gets extreme values for the specified region
-   virtual MinMaxRMS GetMinMaxRMS(size_t start, size_t len) = 0;
+   // If !mayThrow and there is an error, ignores it and returns zeroes.
+   // That may be appropriate when only attempting to display samples, not edit.
+   MinMaxRMS GetMinMaxRMS(
+      size_t start, size_t len, bool mayThrow = true);
 
    /// Gets extreme values for the entire block
-   virtual MinMaxRMS GetMinMaxRMS() const = 0;
+   // If !mayThrow and there is an error, ignores it and returns zeroes.
+   // That may be appropriate when only attempting to display samples, not edit.
+   MinMaxRMS GetMinMaxRMS(bool mayThrow = true) const;
 
    virtual size_t GetSpaceUsage() const = 0;
 
    virtual void SaveXML(XMLWriter &xmlFile) = 0;
+
+protected:
+   virtual size_t DoGetSamples(samplePtr dest,
+                     sampleFormat destformat,
+                     size_t sampleoffset,
+                     size_t numsamples) = 0;
+
+   virtual MinMaxRMS DoGetMinMaxRMS(size_t start, size_t len) = 0;
+
+   virtual MinMaxRMS DoGetMinMaxRMS() const = 0;
 };
 
 ///\brief abstract base class with methods to produce @ref SampleBlock objects

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -255,7 +255,7 @@ std::pair<float, float> Sequence::GetMinMax(
    // already in memory.
 
    for (unsigned b = block0 + 1; b < block1; ++b) {
-      auto results = mBlock[b].sb->GetMinMaxRMS();
+      auto results = mBlock[b].sb->GetMinMaxRMS(mayThrow);
 
       if (results.min < min)
          min = results.min;
@@ -270,7 +270,7 @@ std::pair<float, float> Sequence::GetMinMax(
    {
       const SeqBlock &theBlock = mBlock[block0];
       const auto &theFile = theBlock.sb;
-      auto results = theFile->GetMinMaxRMS();
+      auto results = theFile->GetMinMaxRMS(mayThrow);
 
       if (results.min < min || results.max > max) {
          // start lies within theBlock:
@@ -282,7 +282,7 @@ std::pair<float, float> Sequence::GetMinMax(
          wxASSERT(maxl0 <= mMaxSamples); // Vaughan, 2011-10-19
          const auto l0 = limitSampleBufferSize ( maxl0, len );
 
-         results = theFile->GetMinMaxRMS(s0, l0);
+         results = theFile->GetMinMaxRMS(s0, l0, mayThrow);
          if (results.min < min)
             min = results.min;
          if (results.max > max)
@@ -294,7 +294,7 @@ std::pair<float, float> Sequence::GetMinMax(
    {
       const SeqBlock &theBlock = mBlock[block1];
       const auto &theFile = theBlock.sb;
-      auto results = theFile->GetMinMaxRMS();
+      auto results = theFile->GetMinMaxRMS(mayThrow);
 
       if (results.min < min || results.max > max) {
 
@@ -302,7 +302,7 @@ std::pair<float, float> Sequence::GetMinMax(
          const auto l0 = ( start + len - theBlock.start ).as_size_t();
          wxASSERT(l0 <= mMaxSamples); // Vaughan, 2011-10-19
 
-         results = theFile->GetMinMaxRMS(0, l0);
+         results = theFile->GetMinMaxRMS(0, l0, mayThrow);
          if (results.min < min)
             min = results.min;
          if (results.max > max)
@@ -332,7 +332,7 @@ float Sequence::GetRMS(sampleCount start, sampleCount len, bool mayThrow) const
    for (unsigned b = block0 + 1; b < block1; b++) {
       const SeqBlock &theBlock = mBlock[b];
       const auto &sb = theBlock.sb;
-      auto results = sb->GetMinMaxRMS();
+      auto results = sb->GetMinMaxRMS(mayThrow);
 
       const auto fileLen = sb->GetSampleCount();
       const auto blockRMS = results.RMS;
@@ -354,7 +354,7 @@ float Sequence::GetRMS(sampleCount start, sampleCount len, bool mayThrow) const
       wxASSERT(maxl0 <= mMaxSamples); // Vaughan, 2011-10-19
       const auto l0 = limitSampleBufferSize( maxl0, len );
 
-      auto results = sb->GetMinMaxRMS(s0, l0);
+      auto results = sb->GetMinMaxRMS(s0, l0, mayThrow);
       const auto partialRMS = results.RMS;
       sumsq += partialRMS * partialRMS * l0;
       length += l0;
@@ -368,7 +368,7 @@ float Sequence::GetRMS(sampleCount start, sampleCount len, bool mayThrow) const
       const auto l0 = ( start + len - theBlock.start ).as_size_t();
       wxASSERT(l0 <= mMaxSamples); // PRL: I think Vaughan missed this
 
-      auto results = sb->GetMinMaxRMS(0, l0);
+      auto results = sb->GetMinMaxRMS(0, l0, mayThrow);
       const auto partialRMS = results.RMS;
       sumsq += partialRMS * partialRMS * l0;
       length += l0;
@@ -1036,7 +1036,7 @@ bool Sequence::Read(samplePtr buffer, sampleFormat format,
    wxASSERT(blockRelativeStart + len <= sb->GetSampleCount());
 
    // Either throws, or of !mayThrow, tells how many were really read
-   auto result = sb->GetSamples(buffer, format, blockRelativeStart, len);
+   auto result = sb->GetSamples(buffer, format, blockRelativeStart, len, mayThrow);
 
    if (result != len)
    {

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -148,14 +148,8 @@ SampleBlockPtr SqliteSampleBlockFactory::Create(
    samplePtr src, size_t numsamples, sampleFormat srcformat )
 {
    auto sb = std::make_shared<SqliteSampleBlock>(&mProject);
-
-   if (sb)
-   {
-      if (sb->SetSamples(src, numsamples, srcformat))
-      {
-         return sb;
-      }
-   }
+   if (sb->SetSamples(src, numsamples, srcformat))
+      return sb;
 
    return nullptr;
 }
@@ -164,14 +158,8 @@ SampleBlockPtr SqliteSampleBlockFactory::CreateSilent(
    size_t numsamples, sampleFormat srcformat )
 {
    auto sb = std::make_shared<SqliteSampleBlock>(&mProject);
-
-   if (sb)
-   {
-      if (sb->SetSilent(numsamples, srcformat))
-      {
-         return sb;
-      }
-   }
+   if (sb->SetSilent(numsamples, srcformat))
+      return sb;
 
    return nullptr;
 }
@@ -249,14 +237,8 @@ SampleBlockPtr SqliteSampleBlockFactory::CreateFromXML(
 SampleBlockPtr SqliteSampleBlockFactory::Get( SampleBlockID sbid )
 {
    auto sb = std::make_shared<SqliteSampleBlock>(&mProject);
-
-   if (sb)
-   {
-      if (!sb->Load(sbid))
-      {
-         return nullptr;
-      }
-   }
+   if (!sb->Load(sbid))
+      return nullptr;
 
    return sb;
 }

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -39,7 +39,7 @@ public:
 
    SampleBlockID GetBlockID() override;
 
-   size_t GetSamples(samplePtr dest,
+   size_t DoGetSamples(samplePtr dest,
                      sampleFormat destformat,
                      size_t sampleoffset,
                      size_t numsamples) override;
@@ -53,10 +53,10 @@ public:
    double GetSumRms() const;
 
    /// Gets extreme values for the specified region
-   MinMaxRMS GetMinMaxRMS(size_t start, size_t len) override;
+   MinMaxRMS DoGetMinMaxRMS(size_t start, size_t len) override;
 
    /// Gets extreme values for the entire block
-   MinMaxRMS GetMinMaxRMS() const override;
+   MinMaxRMS DoGetMinMaxRMS() const override;
 
    size_t GetSpaceUsage() const override;
    void SaveXML(XMLWriter &xmlFile) override;
@@ -302,7 +302,7 @@ size_t SqliteSampleBlock::GetSampleCount() const
    return mSampleCount;
 }
 
-size_t SqliteSampleBlock::GetSamples(samplePtr dest,
+size_t SqliteSampleBlock::DoGetSamples(samplePtr dest,
                                      sampleFormat destformat,
                                      size_t sampleoffset,
                                      size_t numsamples)
@@ -395,7 +395,7 @@ double SqliteSampleBlock::GetSumRms() const
 ///
 /// @param start The offset in this block where the region should begin
 /// @param len   The number of samples to include in the region
-MinMaxRMS SqliteSampleBlock::GetMinMaxRMS(size_t start, size_t len)
+MinMaxRMS SqliteSampleBlock::DoGetMinMaxRMS(size_t start, size_t len)
 {
    float min = FLT_MAX;
    float max = -FLT_MAX;
@@ -444,7 +444,7 @@ MinMaxRMS SqliteSampleBlock::GetMinMaxRMS(size_t start, size_t len)
 /// Retrieves the minimum, maximum, and maximum RMS of this entire
 /// block.  This is faster than the other GetMinMax function since
 /// these values are already computed.
-MinMaxRMS SqliteSampleBlock::GetMinMaxRMS() const
+MinMaxRMS SqliteSampleBlock::DoGetMinMaxRMS() const
 {
    return { (float) mSumMin, (float) mSumMax, (float) mSumRms };
 }


### PR DESCRIPTION
Add throw statements where needed in SqliteSampleBlock when database operations fail; necessary but maybe not sufficient to handle, once again, failures to record or edit because of limited space on the drive.

(What remains to do is confirm that restoration of the project to its state as of the last push of the undo stack, or last successful appending of recorded samples, works correctly after the exceptions are caught.)

Restore the logic in Sequence that ignores some read-only exceptions from SampleBlock when only attempting to draw the project.

Make it safe again for Sequence to assume, as it has, that calls to create new blocks either succeed with a non-null block or don't return (throw).

All return values from sqlite functions in SqliteSampleBlock are now correctly accounted for.  (But other calls must yet be examined elsewhere in ProjectFileIO.)

Update at 357650c1519fd76a715d510c8c3b037c29ca5f32: Also restore the try/catch in AutoSaveFile::Decode

