### PR TITLE
Sqlite resources

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -264,6 +264,7 @@ list( APPEND SOURCES
       SplashDialog.cpp
       SplashDialog.h
       SqliteSampleBlock.cpp
+      Sqlite3Wrappers.h
       SseMathFuncs.cpp
       SseMathFuncs.h
       Tags.cpp

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -576,15 +576,29 @@ bool ProjectFileIO::CopyTo(const FilePath &destpath)
 {
    auto db = DB();
    int rc;
-   bool success = true;
+   bool success = false;
+   bool opened = false;
+   auto cleanup = finally([&]{
+      if (opened && !success)
+      {
+         wxRemoveFile(destpath);
+      }
+   });
    ProgressResult res = ProgressResult::Success;
-
    sqlite3 *destdb = nullptr;
 
-   /* Open the database file identified by zFilename. */
+   /* Open the database file identified by destpath. */
    rc = sqlite3_open(destpath, &destdb);
-   if (rc == SQLITE_OK)
+   if (rc != SQLITE_OK)
    {
+      SetDBError(
+         XO("Unable to open the destination project file:\n\n%s").Format(destpath)
+      );
+      return false;
+   }
+   else
+   {
+      opened = true;
       if( auto ubackup = sqlite3_backup_ptr{
          sqlite3_backup_init(destdb, "main", db, "main"),
          { &rc }
@@ -602,12 +616,11 @@ bool ProjectFileIO::CopyTo(const FilePath &destpath)
             int remaining = sqlite3_backup_remaining(backup);
             int total = sqlite3_backup_pagecount(backup);
 
-            if (progress.Update(total - remaining, total) != ProgressResult::Success)
+            if ((res = progress.Update(total - remaining, total)) != ProgressResult::Success)
             {
                SetError(
                   XO("Copy process cancelled.")
                );
-               success = false;
                break;
             }
 
@@ -621,6 +634,7 @@ bool ProjectFileIO::CopyTo(const FilePath &destpath)
          SetDBError(
             XO("Unable to initiate the backup process.")
          );
+         return false;
       }
 
       // Test rc from destroying uBackup, which has any errors from
@@ -630,33 +644,22 @@ bool ProjectFileIO::CopyTo(const FilePath &destpath)
          SetDBError(
             XO("The copy process failed for:\n\n%s").Format(destpath)
          );
-         success = false;
-      }
-
-      // Close the DB
-      rc = sqlite3_close(destdb);
-      if (rc != SQLITE_OK)
-      {
-         SetDBError(
-            XO("Failed to successfully close the destination project file:\n\n%s")
-         );
-         success = false;
-      }
-
-      if (!success)
-      {
-         wxRemoveFile(destpath);
+         return false;
       }
    }
-   else
+
+   // Close the DB
+   rc = sqlite3_close(destdb);
+   if (rc != SQLITE_OK)
    {
       // sqlite3 docs say you should close anyway to avoid leaks
       sqlite3_close( destdb );
       SetDBError(
-         XO("Unable to open the destination project file:\n\n%s").Format(destpath)
+         XO("Failed to successfully close the destination project file:\n\n%s")
       );
-      success = false;
    }
+   else
+      success = (res == ProgressResult::Success);
 
    return success;
 }

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -338,7 +338,7 @@ bool ProjectFileIO::DeleteDB()
 
 bool ProjectFileIO::TransactionStart(const wxString &name)
 {
-   char* errmsg = nullptr;
+   sqlite3_message_ptr errmsg;
 
    int rc = sqlite3_exec(DB(),
                          wxT("SAVEPOINT ") + name + wxT(";"),
@@ -351,7 +351,6 @@ bool ProjectFileIO::TransactionStart(const wxString &name)
       SetDBError(
          XO("Failed to create savepoint:\n\n%s").Format(name)
       );
-      sqlite3_free(errmsg);
    }
 
    return rc == SQLITE_OK;
@@ -359,7 +358,7 @@ bool ProjectFileIO::TransactionStart(const wxString &name)
 
 bool ProjectFileIO::TransactionCommit(const wxString &name)
 {
-   char* errmsg = nullptr;
+   sqlite3_message_ptr errmsg;
 
    int rc = sqlite3_exec(DB(),
                          wxT("SAVEPOINT ") + name + wxT(";"),
@@ -372,7 +371,6 @@ bool ProjectFileIO::TransactionCommit(const wxString &name)
       SetDBError(
          XO("Failed to release savepoint:\n\n%s").Format(name)
       );
-      sqlite3_free(errmsg);
    }
 
    return rc == SQLITE_OK;
@@ -380,7 +378,7 @@ bool ProjectFileIO::TransactionCommit(const wxString &name)
 
 bool ProjectFileIO::TransactionRollback(const wxString &name)
 {
-   char* errmsg = nullptr;
+   sqlite3_message_ptr errmsg;
 
    int rc = sqlite3_exec(DB(),
                          wxT("RELEASE ") + name + wxT(";"),
@@ -393,7 +391,6 @@ bool ProjectFileIO::TransactionRollback(const wxString &name)
       SetDBError(
          XO("Failed to release savepoint:\n\n%s").Format(name)
       );
-      sqlite3_free(errmsg);
    }
 
    return rc == SQLITE_OK;
@@ -408,7 +405,7 @@ int ProjectFileIO::ExecCallback(void *data, int cols, char **vals, char **names)
 
 int ProjectFileIO::Exec(const char *query, ExecCB callback, wxString *result)
 {
-   char *errmsg = nullptr;
+   sqlite3_message_ptr errmsg;
    ExecParm ep = {callback, result};
 
    int rc = sqlite3_exec(DB(), query, ExecCallback, &ep, &errmsg);
@@ -418,8 +415,7 @@ int ProjectFileIO::Exec(const char *query, ExecCB callback, wxString *result)
       SetDBError(
          XO("Failed to execute a project file command:\n\n%s").Format(query)
       );
-      mLibraryError = Verbatim(errmsg);
-      sqlite3_free(errmsg);
+      mLibraryError = Verbatim(errmsg.get());
    }
 
    return rc;

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1244,29 +1244,26 @@ bool ProjectFileIO::SaveCopy(const FilePath& fileName)
       return false;
    }
 
-   sqlite3 *db = nullptr;
    int rc;
    bool success = false;
 
    auto cleanup = finally([&]
    {
-      if (db)
-      {
-         sqlite3_close(db);
-      }
-
       if (!success)
       {
          wxRemoveFile(fileName);
       }
    });
 
-   rc = sqlite3_open(fileName, &db);
+   sqlite3_ptr udb;
+
+   rc = sqlite3_open(fileName, &udb);
    if (rc != SQLITE_OK)
    {
       SetDBError(XO("Failed to open backup file"));
       return false;
    }
+   auto db = udb.get();
 
    XMLStringWriter doc;
    WriteXMLHeader(doc);

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -17,6 +17,7 @@ Paul Licameli split from AudacityProject.h
 #include "xml/XMLTagHandler.h" // to inherit
 
 struct sqlite3;
+struct sqlite3_wrapper;
 
 class AudacityProject;
 class AutoCommitTransaction;
@@ -109,12 +110,14 @@ private:
    static int ExecCallback(void *data, int cols, char **vals, char **names);
    int Exec(const char *query, ExecCB callback, wxString *result);
 
-   // The opening of the database may be delayed until demanded.
-   // Returns a non-null pointer to an open database, or throws an exception
-   // if opening fails.
-   sqlite3 *DB();
+   // Just get the pointer; for my use only, not for friends
+   sqlite3 *DBptr();
 
-   sqlite3 *OpenDB(FilePath fileName = {});
+   // The opening of the database may be delayed until demanded.
+   // Throws an exception if opening fails.
+   const sqlite3_wrapper &DB();
+
+   bool OpenDB(FilePath fileName = {});
    bool CloseDB();
    bool DeleteDB();
 
@@ -153,8 +156,9 @@ private:
    // Bypass transactions if database will be deleted after close
    bool mBypass;
 
-   sqlite3 *mDB;
+   std::unique_ptr< sqlite3_wrapper > mpImpl;
    FilePath mDBPath;
+   int mLastRC = 0;
    TranslatableString mLastError;
    TranslatableString mLibraryError;
 

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -63,6 +63,7 @@ public:
 
    void Reset();
 
+   // AutoSave sets GetLastError() if it fails.
    bool AutoSave(const WaveTrackArray *tracks = nullptr);
    bool AutoSave(const AutoSaveFile &autosave);
    bool AutoSaveDelete();

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -694,7 +694,7 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
 
    // The project is now either saved or the user doesn't want to save it,
    // so there's no need to keep auto save info around anymore
-   projectFileIO.AutoSaveDelete();
+   projectFileIO.AutoSaveDelete(); //?
 
    // DMM: Save the size of the last window the user closes
    //

--- a/src/Sqlite3Wrappers.h
+++ b/src/Sqlite3Wrappers.h
@@ -1,0 +1,56 @@
+/**********************************************************************
+
+Audacity: A Digital Audio Editor
+
+Sqlite3Wrappers.h
+
+Paul Licameli
+
+Some C++ RAII around the structures of the sqlite3 library
+
+**********************************************************************/
+
+#ifndef __AUDACITY_SQLITE3_WRAPPERS__
+#define __AUDACITY_SQLITE3_WRAPPERS__
+
+#include <memory>
+#include <sqlite3.h>
+
+///\brief parameterized type alias for functions that free sqlite resources
+/// and return an error code
+template< typename Object > using sqlite_deleter_fn = int (*)(Object *);
+
+///\brief template that generates deleter classes, to be used as the second
+/// parameter of std::unique_ptr, and may be constructed with an optional
+/// pointer to integer that receives the error code from invocation of the
+/// deleter function
+template< typename Object, sqlite_deleter_fn<Object> fn >
+struct sqlite3_object_deleter {
+   int *pRc = nullptr;
+   void operator () (Object *p) {
+      auto rc = fn(p);
+      if ( pRc )
+         *pRc = rc;
+   }
+};
+
+///\brief A smart pointer to sqlite3_stmt
+using sqlite3_stmt_ptr = std::unique_ptr< sqlite3_stmt,
+   sqlite3_object_deleter< sqlite3_stmt, sqlite3_finalize > >;
+
+///\brief a C++ overload of the sqlite3 library function, it assigns a
+/// smart @ref sqlite3_stmt_ptr
+inline int sqlite3_prepare_v2(
+  sqlite3 *db,              /* Database handle. */
+  const char *zSql,         /* UTF-8 encoded SQL statement. */
+  int nBytes,               /* Length of zSql in bytes. */
+  sqlite3_stmt_ptr *ppStmt, /* OUT: A pointer to the prepared statement */
+  const char **pzTail       /* OUT: End of parsed string */
+){
+   sqlite3_stmt *ptr = nullptr;
+   auto result = ::sqlite3_prepare_v2(db, zSql, nBytes, &ptr, pzTail);
+   ppStmt->reset( ptr );
+   return result;
+}
+
+#endif

--- a/src/Sqlite3Wrappers.h
+++ b/src/Sqlite3Wrappers.h
@@ -57,4 +57,43 @@ inline int sqlite3_prepare_v2(
 using sqlite3_backup_ptr = std::unique_ptr< sqlite3_backup,
    sqlite3_object_deleter< sqlite3_backup, sqlite3_backup_finish > >;
 
+///\brief A type for use as the second parameter of std::unique_ptr
+struct sqlite3_message_deleter{
+   void operator () (void *p) const {
+      sqlite3_free( p ); // void return
+   }
+};
+
+///\brief A smart pointer to a character string that must be freed with
+/// sqlite3_free, which returns void
+using sqlite3_message_ptr = std::unique_ptr< char[], sqlite3_message_deleter >;
+
+///\brief a C++ overload of the sqlite3 library function, it assigns a
+/// smart @ref sqlite_message_ptr
+inline int sqlite3_exec(
+  sqlite3 *db,                /* The database on which the SQL executes */
+  const char *zSql,           /* The SQL to be executed */
+  sqlite3_callback xCallback, /* Invoke this callback routine */
+  void *pArg,                 /* First argument to xCallback() */
+  sqlite3_message_ptr *pzErrMsg /* Write error messages here */
+){
+   char *errMsg = nullptr;
+   auto result = ::sqlite3_exec(db, zSql, xCallback, pArg, &errMsg );
+   pzErrMsg->reset( errMsg );
+   return result;
+}
+
+///\brief another C++ overload of the sqlite3 library function, needed to
+/// disambiguate overloads
+inline int sqlite3_exec(
+  sqlite3 *db,                /* The database on which the SQL executes */
+  const char *zSql,           /* The SQL to be executed */
+  sqlite3_callback xCallback, /* Invoke this callback routine */
+  void *pArg,                 /* First argument to xCallback() */
+  std::nullptr_t
+){
+   char **p = nullptr;
+   return ::sqlite3_exec(db, zSql, xCallback, pArg, p);
+}
+
 #endif

--- a/src/Sqlite3Wrappers.h
+++ b/src/Sqlite3Wrappers.h
@@ -115,4 +115,16 @@ inline int sqlite3_open(
    return result;
 }
 
+///\brief Holds a pointer to a sqlite3 database connection
+struct sqlite3_wrapper
+{
+   explicit sqlite3_wrapper( sqlite3_ptr pDB )
+      : mDB{ std::move(pDB) }
+   {}
+
+   sqlite3_ptr mDB;
+
+   operator sqlite3* () const { return mDB.get(); }
+};
+
 #endif

--- a/src/Sqlite3Wrappers.h
+++ b/src/Sqlite3Wrappers.h
@@ -53,4 +53,8 @@ inline int sqlite3_prepare_v2(
    return result;
 }
 
+///\brief A smart pointer to sqlite3_backup
+using sqlite3_backup_ptr = std::unique_ptr< sqlite3_backup,
+   sqlite3_object_deleter< sqlite3_backup, sqlite3_backup_finish > >;
+
 #endif

--- a/src/Sqlite3Wrappers.h
+++ b/src/Sqlite3Wrappers.h
@@ -96,4 +96,23 @@ inline int sqlite3_exec(
    return ::sqlite3_exec(db, zSql, xCallback, pArg, p);
 }
 
+///\brief A smart pointer to sqlite3
+using sqlite3_ptr = std::unique_ptr< sqlite3,
+   sqlite3_object_deleter< sqlite3, sqlite3_close > >;
+
+///\brief a C++ overload of the sqlite3 library function, it assigns a
+/// smart @ref sqlite3_ptr
+/// Note that sqlite3 documentation says that there may be memory resources
+/// to clean up, even if sqlite3_open returns an error
+inline int sqlite3_open(
+  const char *zFilename,
+  sqlite3_ptr *ppDb
+)
+{
+   sqlite3 *ptr = nullptr;
+   auto result = ::sqlite3_open(zFilename, &ptr);
+   ppDb->reset( ptr );
+   return result;
+}
+
 #endif

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -458,7 +458,7 @@ size_t SqliteSampleBlock::GetBlob(void *dest,
                                   size_t srcoffset,
                                   size_t srcbytes)
 {
-   auto db = mIO.DB();
+   auto &db = mIO.DB();
 
    wxASSERT(mBlockID > 0);
 
@@ -529,7 +529,7 @@ size_t SqliteSampleBlock::GetBlob(void *dest,
 
 bool SqliteSampleBlock::Load(SampleBlockID sbid)
 {
-   auto db = mIO.DB();
+   auto &db = mIO.DB();
 
    wxASSERT(sbid > 0);
 
@@ -588,7 +588,7 @@ bool SqliteSampleBlock::Load(SampleBlockID sbid)
 
 void SqliteSampleBlock::Commit()
 {
-   auto db = mIO.DB();
+   auto &db = mIO.DB();
    int rc;
 
    char sql[256];
@@ -643,7 +643,7 @@ void SqliteSampleBlock::Commit()
 
 void SqliteSampleBlock::Delete()
 {
-   auto db = mIO.DB();
+   auto &db = mIO.DB();
 
    if (mBlockID)
    {


### PR DESCRIPTION
Note that this pull request is failing Linux builds for reasons unrelated to these changes.

Use C++ style smart pointers to hold resources allocated by sqlite3 and guarantee their cleanup.

This simplifies some usage.

Update at 8c8aed092923b868a12303c1bbbc7c178a350ca7: rebased onto pull request #603 which should be merged first, and now waiting to pass make builds

