### PR TITLE
Sqlite open bugs

### DIFF
--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -235,12 +235,15 @@ ProjectFileIO::~ProjectFileIO()
 
 sqlite3 *ProjectFileIO::DB()
 {
-   if (mDB)
+   if (!mDB)
    {
-      return mDB;
+      OpenDB();
+      if (!mDB)
+         throw SimpleMessageBoxException{
+            XO("Failed to open the project's database") };
    }
 
-   return OpenDB();
+   return mDB;
 }
 
 sqlite3 *ProjectFileIO::OpenDB(FilePath fileName)

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -266,6 +266,9 @@ sqlite3 *ProjectFileIO::OpenDB(FilePath fileName)
    if (rc != SQLITE_OK)
    {
       SetDBError(XO("Failed to open project file"));
+      // sqlite3 docs say you should close anyway to avoid leaks
+      sqlite3_close( mDB );
+      mDB = nullptr;
       return nullptr;
    }
 
@@ -647,6 +650,8 @@ bool ProjectFileIO::CopyTo(const FilePath &destpath)
    }
    else
    {
+      // sqlite3 docs say you should close anyway to avoid leaks
+      sqlite3_close( destdb );
       SetDBError(
          XO("Unable to open the destination project file:\n\n%s").Format(destpath)
       );
@@ -1272,6 +1277,8 @@ bool ProjectFileIO::SaveCopy(const FilePath& fileName)
    rc = sqlite3_open(fileName, &db);
    if (rc != SQLITE_OK)
    {
+      // sqlite3 docs say you should close anyway to avoid leaks
+      sqlite3_close( db );
       SetDBError(XO("Failed to open backup file"));
       return false;
    }

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -109,7 +109,11 @@ private:
    static int ExecCallback(void *data, int cols, char **vals, char **names);
    int Exec(const char *query, ExecCB callback, wxString *result);
 
+   // The opening of the database may be delayed until demanded.
+   // Returns a non-null pointer to an open database, or throws an exception
+   // if opening fails.
    sqlite3 *DB();
+
    sqlite3 *OpenDB(FilePath fileName = {});
    bool CloseDB();
    bool DeleteDB();


### PR DESCRIPTION
If pull request #602 isn't yet reviewed and accepted, please review and merge this smaller one first.

Fix possible memory leaks and crashes when opening of sqlite database fails.

There are now exceptions thrown in some new places with messages for the user that might be improved.
