### PR TITLE
Cross project copy data loss

### DIFF
--- a/src/SampleBlock.h
+++ b/src/SampleBlock.h
@@ -46,8 +46,6 @@ class SampleBlock
 public:
    virtual ~SampleBlock();
 
-   virtual void Lock() = 0;
-   virtual void Unlock() = 0;
    virtual void CloseLock() = 0;
    
    virtual SampleBlockID GetBlockID() = 0;

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -364,12 +364,20 @@ float Sequence::GetRMS(sampleCount start, sampleCount len, bool mayThrow) const
    return sqrt(sumsq / length.as_double() );
 }
 
-std::unique_ptr<Sequence> Sequence::Copy(sampleCount s0, sampleCount s1) const
+// Must pass in the correct factory for the result.  If it's not the same
+// as in this, then block contents must be copied.
+std::unique_ptr<Sequence> Sequence::Copy( const SampleBlockFactoryPtr &pFactory,
+   sampleCount s0, sampleCount s1) const
 {
-   auto dest = std::make_unique<Sequence>(mpFactory, mSampleFormat);
+   // Make a new Sequence object for the specified factory:
+   auto dest = std::make_unique<Sequence>(pFactory, mSampleFormat);
    if (s0 >= s1 || s0 >= mNumSamples || s1 < 0) {
       return dest;
    }
+
+   // Decide whether to share sample blocks or make new copies, when whole block
+   // contents are used -- must copy if factories are different:
+   auto pUseFactory = (pFactory == mpFactory) ? nullptr : pFactory.get();
 
    int numBlocks = mBlock.size();
 
@@ -388,7 +396,7 @@ std::unique_ptr<Sequence> Sequence::Copy(sampleCount s0, sampleCount s1) const
 
    int blocklen;
 
-   // Do the first block
+   // Do any initial partial block
 
    const SeqBlock &block0 = mBlock[b0];
    if (s0 != block0.start) {
@@ -405,13 +413,15 @@ std::unique_ptr<Sequence> Sequence::Copy(sampleCount s0, sampleCount s1) const
    else
       --b0;
 
-   // If there are blocks in the middle, copy the blockfiles directly
+   // If there are blocks in the middle, use the blockfiles whole
    for (int bb = b0 + 1; bb < b1; ++bb)
-      AppendBlock(dest->mBlock, dest->mNumSamples, mBlock[bb]);
+      AppendBlock(pUseFactory, mSampleFormat,
+         dest->mBlock, dest->mNumSamples, mBlock[bb]);
       // Increase ref count or duplicate file
 
    // Do the last block
    if (b1 > b0) {
+      // Probable case of a partial block
       const SeqBlock &block = mBlock[b1];
       const auto &sb = block.sb;
       // s1 is within block:
@@ -423,8 +433,9 @@ std::unique_ptr<Sequence> Sequence::Copy(sampleCount s0, sampleCount s1) const
          dest->Append(buffer.ptr(), mSampleFormat, blocklen);
       }
       else
-         // Special case, copy exactly
-         AppendBlock(dest->mBlock, dest->mNumSamples, block);
+         // Special case of a whole block
+         AppendBlock(pUseFactory, mSampleFormat,
+            dest->mBlock, dest->mNumSamples, block);
          // Increase ref count or duplicate file
    }
 
@@ -438,13 +449,27 @@ namespace {
    {
       return numSamples > wxLL(9223372036854775807);
    }
+
+   SampleBlockPtr ShareOrCopySampleBlock(
+      SampleBlockFactory *pFactory, sampleFormat format, SampleBlockPtr sb )
+   {
+      if ( pFactory ) {
+         // must copy contents to a fresh SampleBlock object in another database
+         auto sampleCount = sb->GetSampleCount();
+         SampleBuffer buffer{ sampleCount, format };
+         sb->GetSamples( buffer.ptr(), format, 0, sampleCount );
+         sb = pFactory->Create( buffer.ptr(), sampleCount, format );
+      }
+      else
+         // Can just share
+         ;
+      return sb;
+   }
 }
 
 void Sequence::Paste(sampleCount s, const Sequence *src)
 // STRONG-GUARANTEE
 {
-   auto &factory = *mpFactory;
-
    if ((s < 0) || (s > mNumSamples))
    {
       wxLogError(
@@ -485,6 +510,11 @@ void Sequence::Paste(sampleCount s, const Sequence *src)
 
    const size_t numBlocks = mBlock.size();
 
+   // Decide whether to share sample blocks or make new copies, when whole block
+   // contents are used -- must copy if factories are different:
+   auto pUseFactory =
+      (src->mpFactory == mpFactory) ? nullptr : mpFactory.get();
+
    if (numBlocks == 0 ||
        (s == mNumSamples && mBlock.back().sb->GetSampleCount() >= mMinSamples)) {
       // Special case: this track is currently empty, or it's safe to append
@@ -497,8 +527,8 @@ void Sequence::Paste(sampleCount s, const Sequence *src)
       for (unsigned int i = 0; i < srcNumBlocks; i++)
          // AppendBlock may throw for limited disk space, if pasting from
          // one project into another.
-         AppendBlock(newBlock, samples, srcBlock[i]);
-         // Increase ref count or duplicate file
+         AppendBlock(pUseFactory, mSampleFormat,
+            newBlock, samples, srcBlock[i]);
 
       CommitChangesIfConsistent
          (newBlock, samples, wxT("Paste branch one"));
@@ -533,7 +563,7 @@ void Sequence::Paste(sampleCount s, const Sequence *src)
            splitPoint, length - splitPoint, true);
 
       // largerBlockLen is not more than mMaxSamples...
-      block.sb = factory.Create(
+      block.sb = mpFactory->Create(
          buffer.ptr(),
          largerBlockLen.as_size_t(),
          mSampleFormat);
@@ -589,7 +619,7 @@ void Sequence::Paste(sampleCount s, const Sequence *src)
       // The final case is that we're inserting at least five blocks.
       // We divide these into three groups: the first two get merged
       // with the first half of the split block, the middle ones get
-      // copied in as is, and the last two get merged with the last
+      // used whole, and the last two get merged with the last
       // half of the split block.
 
       const auto srcFirstTwoLen =
@@ -614,7 +644,9 @@ void Sequence::Paste(sampleCount s, const Sequence *src)
 
       for (i = 2; i < srcNumBlocks - 2; i++) {
          const SeqBlock &block = srcBlock[i];
-         newBlock.push_back(SeqBlock(block.sb, block.start + s));
+         auto sb = ShareOrCopySampleBlock(
+            pUseFactory, mSampleFormat, block.sb );
+         newBlock.push_back(SeqBlock(sb, block.start + s));
       }
 
       auto lastStart = penultimate.start;
@@ -694,14 +726,15 @@ void Sequence::InsertSilence(sampleCount s0, sampleCount len)
    Paste(s0, &sTrack);
 }
 
-void Sequence::AppendBlock(BlockArray &mBlock, sampleCount &mNumSamples, const SeqBlock &b)
+void Sequence::AppendBlock( SampleBlockFactory *pFactory, sampleFormat format,
+   BlockArray &mBlock, sampleCount &mNumSamples, const SeqBlock &b)
 {
    // Quick check to make sure that it doesn't overflow
    if (Overflows((mNumSamples.as_double()) + ((double)b.sb->GetSampleCount())))
       THROW_INCONSISTENCY_EXCEPTION;
 
-   // Bump ref count
-   SeqBlock newBlock(b.sb, mNumSamples);
+   auto sb = ShareOrCopySampleBlock( pFactory, format, b.sb );
+   SeqBlock newBlock(sb, mNumSamples);
 
    // We can assume newBlock.sb is not null
 

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -83,26 +83,10 @@ size_t Sequence::GetIdealBlockSize() const
    return mMaxSamples;
 }
 
-bool Sequence::Lock()
-{
-   for (unsigned int i = 0; i < mBlock.size(); i++)
-      mBlock[i].sb->Lock();
-
-   return true;
-}
-
 bool Sequence::CloseLock()
 {
    for (unsigned int i = 0; i < mBlock.size(); i++)
       mBlock[i].sb->CloseLock();
-
-   return true;
-}
-
-bool Sequence::Unlock()
-{
-   for (unsigned int i = 0; i < mBlock.size(); i++)
-      mBlock[i].sb->Unlock();
 
    return true;
 }

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -95,7 +95,10 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
                        size_t len, const sampleCount *where) const;
 
    // Return non-null, or else throw!
-   std::unique_ptr<Sequence> Copy(sampleCount s0, sampleCount s1) const;
+   // Must pass in the correct factory for the result.  If it's not the same
+   // as in this, then block contents must be copied.
+   std::unique_ptr<Sequence> Copy( const SampleBlockFactoryPtr &pFactory,
+      sampleCount s0, sampleCount s1) const;
    void Paste(sampleCount s0, const Sequence *src);
 
    size_t GetIdealAppendLen() const;
@@ -196,7 +199,8 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
 
    int FindBlock(sampleCount pos) const;
 
-   static void AppendBlock(BlockArray &blocks,
+   static void AppendBlock(SampleBlockFactory *pFactory, sampleFormat format,
+                           BlockArray &blocks,
                            sampleCount &numSamples,
                            const SeqBlock &b);
 

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -125,10 +125,7 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
    // for details.
    //
 
-   bool Lock();
-   bool Unlock();
-
-   bool CloseLock();//similar to Lock but should be called upon project close.
+   bool CloseLock();//should be called upon project close.
    // not balanced by unlocking calls.
 
    //

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -22,7 +22,7 @@ class SqliteSampleBlock final : public SampleBlock
 {
 public:
 
-   explicit SqliteSampleBlock(AudacityProject *project);
+   explicit SqliteSampleBlock(ProjectFileIO &io);
    ~SqliteSampleBlock() override;
 
    void CloseLock() override;
@@ -129,13 +129,11 @@ public:
       const wxChar **attrs) override;
 
 private:
-   AudacityProject &mProject;
    std::shared_ptr<ProjectFileIO> mpIO;
 };
 
 SqliteSampleBlockFactory::SqliteSampleBlockFactory( AudacityProject &project )
-   : mProject{ project }
-   , mpIO{ ProjectFileIO::Get(project).shared_from_this() }
+   : mpIO{ ProjectFileIO::Get(project).shared_from_this() }
 {
    
 }
@@ -145,7 +143,7 @@ SqliteSampleBlockFactory::~SqliteSampleBlockFactory() = default;
 SampleBlockPtr SqliteSampleBlockFactory::DoCreate(
    samplePtr src, size_t numsamples, sampleFormat srcformat )
 {
-   auto sb = std::make_shared<SqliteSampleBlock>(&mProject);
+   auto sb = std::make_shared<SqliteSampleBlock>(*mpIO);
    sb->SetSamples(src, numsamples, srcformat);
    return sb;
 }
@@ -153,7 +151,7 @@ SampleBlockPtr SqliteSampleBlockFactory::DoCreate(
 SampleBlockPtr SqliteSampleBlockFactory::DoCreateSilent(
    size_t numsamples, sampleFormat srcformat )
 {
-   auto sb = std::make_shared<SqliteSampleBlock>(&mProject);
+   auto sb = std::make_shared<SqliteSampleBlock>(*mpIO);
    sb->SetSilent(numsamples, srcformat);
    return sb;
 }
@@ -162,7 +160,7 @@ SampleBlockPtr SqliteSampleBlockFactory::DoCreateSilent(
 SampleBlockPtr SqliteSampleBlockFactory::DoCreateFromXML(
    sampleFormat srcformat, const wxChar **attrs )
 {
-   auto sb = std::make_shared<SqliteSampleBlock>(&mProject);
+   auto sb = std::make_shared<SqliteSampleBlock>(*mpIO);
    sb->mSampleFormat = srcformat;
 
    int found = 0;
@@ -228,13 +226,13 @@ SampleBlockPtr SqliteSampleBlockFactory::DoCreateFromXML(
 
 SampleBlockPtr SqliteSampleBlockFactory::DoGet( SampleBlockID sbid )
 {
-   auto sb = std::make_shared<SqliteSampleBlock>(&mProject);
+   auto sb = std::make_shared<SqliteSampleBlock>(*mpIO);
    sb->Load(sbid);
    return sb;
 }
 
-SqliteSampleBlock::SqliteSampleBlock(AudacityProject *project)
-:  mIO(ProjectFileIO::Get(*project))
+SqliteSampleBlock::SqliteSampleBlock(ProjectFileIO &io)
+:  mIO(io)
 {
    mValid = false;
    mSilent = false;

--- a/src/Track.h
+++ b/src/Track.h
@@ -1581,6 +1581,9 @@ class AUDACITY_DLL_API TrackFactory final
    TrackFactory( const TrackFactory & ) PROHIBITED;
    TrackFactory &operator=( const TrackFactory & ) PROHIBITED;
 
+   const SampleBlockFactoryPtr &GetSampleBlockFactory() const
+   { return mpFactory; }
+
  private:
    const ProjectSettings &mSettings;
    SampleBlockFactoryPtr mpFactory;

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1652,25 +1652,11 @@ void WaveClip::OffsetCutLines(double t0, double len)
    }
 }
 
-void WaveClip::Lock()
-{
-   GetSequence()->Lock();
-   for (const auto &cutline: mCutLines)
-      cutline->Lock();
-}
-
 void WaveClip::CloseLock()
 {
    GetSequence()->CloseLock();
    for (const auto &cutline: mCutLines)
       cutline->CloseLock();
-}
-
-void WaveClip::Unlock()
-{
-   GetSequence()->Unlock();
-   for (const auto &cutline: mCutLines)
-      cutline->Unlock();
 }
 
 void WaveClip::SetRate(int rate)

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -182,7 +182,7 @@ WaveClip::WaveClip(const WaveClip& orig,
    orig.TimeToSamplesClip(t0, &s0);
    orig.TimeToSamplesClip(t1, &s1);
 
-   mSequence = orig.mSequence->Copy(s0, s1);
+   mSequence = orig.mSequence->Copy(factory, s0, s1);
 
    mEnvelope = std::make_unique<Envelope>(
       *orig.mEnvelope,

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -328,12 +328,7 @@ public:
    /// Offset cutlines right to time 't0' by time amount 'len'
    void OffsetCutLines(double t0, double len);
 
-   /// Lock all blockfiles
-   void Lock();
-   /// Unlock all blockfiles
-   void Unlock();
-
-   void CloseLock(); //similar to Lock but should be called when the project closes.
+   void CloseLock(); //should be called when the project closes.
    // not balanced by unlocking calls.
 
    ///Delete the wave cache - force redraw.  Thread-safe

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1699,27 +1699,10 @@ bool WaveTrack::GetErrorOpening()
    return false;
 }
 
-bool WaveTrack::Lock() const
-{
-   for (const auto &clip : mClips)
-      clip->Lock();
-
-   return true;
-}
-
 bool WaveTrack::CloseLock()
 {
    for (const auto &clip : mClips)
       clip->CloseLock();
-
-   return true;
-}
-
-
-bool WaveTrack::Unlock() const
-{
-   for (const auto &clip : mClips)
-      clip->Unlock();
 
    return true;
 }

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -304,31 +304,7 @@ private:
    // doing a copy and paste between projects.
    //
 
-   bool Lock() const;
-   bool Unlock() const;
-
-   struct WaveTrackLockDeleter {
-      inline void operator () (const WaveTrack *pTrack) { pTrack->Unlock(); }
-   };
-   using LockerBase = std::unique_ptr<
-      const WaveTrack, WaveTrackLockDeleter
-   >;
-
-   // RAII object for locking.
-   struct Locker : private LockerBase
-   {
-      friend LockerBase;
-      Locker (const WaveTrack *pTrack)
-         : LockerBase{ pTrack }
-      { pTrack->Lock(); }
-      Locker(Locker &&that) : LockerBase{std::move(that)} {}
-      Locker &operator= (Locker &&that) {
-         (LockerBase&)(*this) = std::move(that);
-         return *this;
-      }
-   };
-
-   bool CloseLock(); //similar to Lock but should be called when the project closes.
+   bool CloseLock(); //should be called when the project closes.
    // not balanced by unlocking calls.
 
    /** @brief Convert correctly between an (absolute) time in seconds and a number of samples.

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -76,6 +76,7 @@ bool DoPasteNothingSelected(AudacityProject &project)
 {
    auto &tracks = TrackList::Get( project );
    auto &trackFactory = TrackFactory::Get( project );
+   auto &pSampleBlockFactory = trackFactory.GetSampleBlockFactory();
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
    auto &window = ProjectWindow::Get( project );
 
@@ -95,7 +96,7 @@ bool DoPasteNothingSelected(AudacityProject &project)
          Track *pNewTrack;
          pClip->TypeSwitch(
             [&](const WaveTrack *wc) {
-               uNewTrack = wc->EmptyCopy();
+               uNewTrack = wc->EmptyCopy( pSampleBlockFactory );
                pNewTrack = uNewTrack.get();
             },
 #ifdef USE_MIDI
@@ -374,6 +375,7 @@ void OnPaste(const CommandContext &context)
    auto &project = context.project;
    auto &tracks = TrackList::Get( project );
    auto &trackFactory = TrackFactory::Get( project );
+   auto &pSampleBlockFactory = trackFactory.GetSampleBlockFactory();
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
    const auto &settings = ProjectSettings::Get( project );
    auto &window = ProjectWindow::Get( project );
@@ -578,7 +580,7 @@ void OnPaste(const CommandContext &context)
                wt->ClearAndPaste(t0, t1, wc, true, true);
             }
             else {
-               auto tmp = wt->EmptyCopy();
+               auto tmp = wt->EmptyCopy( pSampleBlockFactory );
                tmp->InsertSilence( 0.0,
                   // MJS: Is this correct?
                   clipboard.Duration() );


### PR DESCRIPTION
Fixes for known cases of data loss when copying wave tracks between projects.

Restore logic analogous to what was done with block files, when source and destination of paste were not under the same DirManager.

Copy contents of a SampleBlock into a new block when pasting to a different database; rather than just making a shared_ptr to an existing SampleBlock.

