### PR TITLE
Fail safe save as

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -86,6 +86,7 @@ It handles initialization and termination by subclassing wxApp.
 #include "Project.h"
 #include "ProjectAudioIO.h"
 #include "ProjectAudioManager.h"
+#include "ProjectFileIO.h"
 #include "ProjectFileManager.h"
 #include "ProjectHistory.h"
 #include "ProjectManager.h"
@@ -1028,6 +1029,15 @@ bool AudacityApp::OnInit()
 
    // Ensure we have an event loop during initialization
    wxEventLoopGuarantor eventLoop;
+
+   // Fire up SQLite
+   if ( !ProjectFileIO::InitializeSQL() )
+      this->CallAfter([]{
+         ::AudacityMessageBox(
+            XO("SQLite library failed to initialize.  Audacity cannot continue.") );
+         QuitAudacity( true );
+      });
+
 
    // cause initialization of wxWidgets' global logger target
    (void) AudacityLogger::Get();

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -118,14 +118,22 @@ class SQLiteIniter
 public:
    SQLiteIniter()
    {
-      sqlite3_initialize();
+      mRc = sqlite3_initialize();
    }
    ~SQLiteIniter()
    {
-      sqlite3_shutdown();
+      // This function must be called single-threaded only
+      // It returns a value, but there's nothing we can do with it
+      (void) sqlite3_shutdown();
    }
+   int mRc;
 };
-static SQLiteIniter sqliteIniter;
+
+bool ProjectFileIO::InitializeSQL()
+{
+   static SQLiteIniter sqliteIniter;
+   return sqliteIniter.mRc == SQLITE_OK;
+}
 
 static void RefreshAllTitles(bool bShowProjectNumbers )
 {

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1281,7 +1281,14 @@ bool ProjectFileIO::SaveProject(const FilePath &fileName)
    // clean and unmodified.  Otherwise, it would be considered "recovered"
    // when next opened.
 
-   AutoSaveDelete();
+   if ( !AutoSaveDelete() )
+      return false;
+
+   // Reaching this point defines success and all the rest are no-fail
+   // operations:
+
+   // Tell the finally block to behave
+   success = true;
 
    // No longer modified
    mModified = false;
@@ -1294,9 +1301,6 @@ bool ProjectFileIO::SaveProject(const FilePath &fileName)
 
    // Adjust the title
    SetProjectTitle();
-
-   // Tell the finally block to behave
-   success = true;
 
    return true;
 }

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -35,6 +35,10 @@ class ProjectFileIO final
    , public std::enable_shared_from_this<ProjectFileIO>
 {
 public:
+   // Call this static function once before constructing any instances of this
+   // class.  Reinvocations have no effect.  Return value is true for success.
+   static bool InitializeSQL();
+
    static ProjectFileIO &Get( AudacityProject &project );
    static const ProjectFileIO &Get( const AudacityProject &project );
 

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -124,6 +124,9 @@ private:
    // Close any current connection and switch back to using the saved
    void RestoreConnection();
 
+   // Use a connection that is already open rather than invoke OpenDB
+   void UseConnection( sqlite3 *db );
+
    sqlite3 *OpenDB(FilePath fileName = {});
    bool CloseDB();
    bool DeleteDB();
@@ -139,7 +142,8 @@ private:
    bool InstallSchema();
    bool UpgradeSchema();
 
-   bool CopyTo(const FilePath &destpath);
+   // Return a database connection if successful, which caller must close
+   sqlite3 *CopyTo(const FilePath &destpath);
 
    void SetError(const TranslatableString & msg);
    void SetDBError(const TranslatableString & msg);

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -114,6 +114,16 @@ private:
    // if opening fails.
    sqlite3 *DB();
 
+   // Put the current database connection aside, keeping it open, so that
+   // another may be opened with OpenDB()
+   void SaveConnection();
+
+   // Close any set-aside connection
+   void DiscardConnection();
+
+   // Close any current connection and switch back to using the saved
+   void RestoreConnection();
+
    sqlite3 *OpenDB(FilePath fileName = {});
    bool CloseDB();
    bool DeleteDB();
@@ -153,6 +163,7 @@ private:
    // Bypass transactions if database will be deleted after close
    bool mBypass;
 
+   sqlite3 *mPrevDB;
    sqlite3 *mDB;
    FilePath mDBPath;
    TranslatableString mLastError;

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -694,7 +694,10 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
 
    // The project is now either saved or the user doesn't want to save it,
    // so there's no need to keep auto save info around anymore
-   projectFileIO.AutoSaveDelete();
+   // PRL:  not clear what to do if the following fails, but the worst should
+   // be, the project may reopen in its present state as a recovery file, not
+   // at the last saved state.
+   (void) projectFileIO.AutoSaveDelete();
 
    // DMM: Save the size of the last window the user closes
    //


### PR DESCRIPTION
When saving-as or saving-copy, open and close databases fewer times.  Open the destination database once at most.  Close the source database for save-as at most once, after success.  (Do not close it, always, then try to reopen it in case of failure -- which would itself risk another failure.)

Also supplied some more checks of formerly ignored error codes, from DeleteAutoSave, binding of query parameters, and initializing SQLite.

This completes my review of error returns in Unitary, until there are more changes in it.
