### PR TITLE
Also remove orphan blocks when an editing operation rolls back...

### DIFF
--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -669,8 +669,13 @@ void ProjectFileIO::LoadedBlock(int64_t sbid)
    }
 }
 
-bool ProjectFileIO::CheckForOrphans()
+bool ProjectFileIO::CheckForOrphans( bool *pDeletedAny )
 {
+   if ( pDeletedAny )
+   {
+      *pDeletedAny = false;
+   }
+
    auto db = DB();
 
    char sql[256];
@@ -702,7 +707,10 @@ bool ProjectFileIO::CheckForOrphans()
    if (changes > 0)
    {
       wxLogInfo(XO("Total orphan blocks deleted %d").Translation(), changes);
-      mRecovered = true;
+      if ( pDeletedAny )
+      {
+         *pDeletedAny = true;
+      }
    }
 
    return true;
@@ -1244,7 +1252,7 @@ bool ProjectFileIO::LoadProject(const FilePath &fileName)
    // Check for orphans blocks...set mRecovered if any deleted
    if (mHighestBlockID > 0)
    {
-      if (!CheckForOrphans())
+      if (!CheckForOrphans( &mRecovered ))
       {
          return false;
       }

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -100,6 +100,11 @@ public:
 
    void LoadedBlock(int64_t blockID);
 
+   // Checks for orphan blocks.  This will go away at a future date
+   // Return value is a success code; optional out argument is assigned true if
+   // any change was made
+   bool CheckForOrphans( bool *pDeletedAny = nullptr );
+
 private:
    // XMLTagHandler callback methods
    bool HandleXMLTag(const wxChar *tag, const wxChar **attrs) override;
@@ -147,9 +152,6 @@ private:
    bool CheckVersion();
    bool InstallSchema();
    bool UpgradeSchema();
-
-   // Checks for orphan blocks.  This will go away at a future date
-   bool CheckForOrphans();
 
    // Return a database connection if successful, which caller must close
    sqlite3 *CopyTo(const FilePath &destpath);


### PR DESCRIPTION
... and that might happen when hitting ESC during a modifying drag operation
(like sample editing), or when recovering from an exception (such as from
failure to add a sample block because of limited space).

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
