### PR TITLE
Handle autosave of recordings even more safely...

### DIFF
--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -874,6 +874,8 @@ void ProjectAudioManager::OnAudioIOStopRecording()
       if (IsTimerRecordCancelled()) {
          // discard recording
          history.RollbackState();
+         // discard the autosaves made during recording
+         projectFileIO.DiscardAutoSaveRow();
          // Reset timer record
          ResetTimerRecordCancelled();
       }
@@ -884,6 +886,10 @@ void ProjectAudioManager::OnAudioIOStopRecording()
          // successully committed to the database, not risking a failure
          history.PushState(XO("Recorded Audio"), XO("Record"),
             UndoPush::NOAUTOSAVE);
+
+         // The autosave that held the state just pushed is now the row that
+         // should be used
+         projectFileIO.NextAutoSaveRow();
 
          // Now, we may add a label track to give information about
          // dropouts.  We allow failure of this.


### PR DESCRIPTION
... This requires multiple rows in the autosave table.

While recording, autosaves happen as samples accumulate, yet the undo history
item for the recording is not yet complete, and meanwhile it is possible to
change the last undo item before the recording, by using mute and solo buttons,
or pan and gain sliders, or any other changes that pass true to
ProjectHistory::ModifyState() (because they change some persistent data in
the project or tracks).

So there are two rows in the autosave table that can be changed.

If a crash should happen, the autosave for the recording will be preferred,
and identified as such by its greater id column.

If the recording either completes or is cancelled, the in-memory member variable
that chooses the row corresponding to the last undo state is updated (or not)
appropriately, and an attempt is made to delete the other row.

This attempt is only to reclaim space and is allowed to fail.

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
