### PR TITLE
fix asio build on windows

### DIFF
--- a/cmake-proxies/portaudio-v19/CMakeLists.txt
+++ b/cmake-proxies/portaudio-v19/CMakeLists.txt
@@ -7,7 +7,7 @@ set( CMAKE_MODULE_PATH ${TARGET_ROOT}/cmake_support )
 
 # Define the platform specific interface options
 if( CMAKE_SYSTEM_NAME MATCHES "Windows" )
-   if( ENV{ASIOSDK_DIR} )
+   if(DEFINED ENV{ASIOSDK_DIR} )
       cmd_option(
          ${_OPT}use_pa_asio
          "Use the portaudio ASIO interface if available"


### PR DESCRIPTION
ASIO was not getting included in the Windows build, even though the appropriate environment variable was defined, This PR will fix the check for if ASIOSDK_DIR is defined in  cmake-proxies/portaudio-v19/CMakeLists.txt, according to https://cmake.org/cmake/help/latest/variable/ENV.html