### PR TITLE
Canonicalize integers in binary blob format, BREAKING COMPATIBILITY...

### DIFF
--- a/src/ProjectSerializer.h
+++ b/src/ProjectSerializer.h
@@ -29,8 +29,8 @@ using BlockIDs = std::set<SampleBlockID>;
 /// ProjectSerializer
 ///
 
-using NameMap = std::unordered_map<wxString, short>;
-using IdMap = std::unordered_map<short, wxString>;
+using NameMap = std::unordered_map<wxString, unsigned short>;
+using IdMap = std::unordered_map<unsigned short, wxString>;
 
 // This class's overrides do NOT throw AudacityException.
 class AUDACITY_DLL_API ProjectSerializer final : public XMLWriter


### PR DESCRIPTION
... with .aup3 projects saved earlier in 3.0.0 development, except for 32 bit
Windows builds.

Use fixed-width integer types when writing the binary format blobs, not
bool, short, int, size_t, ..., which might vary among machines and so make
.aup3 files non-portable.

Choose the widths to write whatever is narrowest among the four builds; this
makes a difference only for long and size_t which are 32 bits in the 32 bit
Windows build.  (long is also 32 bits on the 64 bit Windows build.)

Also normalize the endianness to little, in case that ever matters on other
future processors.

Didn't attempt the same for the floating point types.

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
