### PR TITLE
Make waveform navigation via mouse pan/zoom simpler

### DIFF
--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -389,7 +389,7 @@ unsigned operator()
       // MM: Scroll left/right when used with Shift key down
       window.TP_ScrollWindow(
          viewInfo.OffsetTimeByPixels(
-            viewInfo.PositionToTime(0), 50.0 * -steps));
+            viewInfo.PositionToTime(0), 25.0 * -steps));
    }
    else if (event.CmdDown())
    {
@@ -457,7 +457,16 @@ unsigned operator()
 #endif
 
       wxCoord xTrackEnd = viewInfo.TimeToPosition( audioEndTime );
-      viewInfo.ZoomBy(pow(2.0, steps));
+
+      const double zoomSpeedFactor = 0.1;
+      double prevZoom = viewInfo.GetZoom();
+      viewInfo.ZoomBy(pow(2.0, steps * zoomSpeedFactor));
+
+      // Clamp zooming-out to fit the screen, unless previous zoom is smaller.
+      // This allows the shortcut keys to zoom out further than the mouse.
+      double minZoom = std::min(prevZoom, window.GetZoomOfToFit());
+      if (viewInfo.GetZoom() < minZoom)
+        window.Zoom(minZoom);
 
       double new_center_h = viewInfo.PositionToTime(xx, trackLeftEdge);
       viewInfo.h += (center_h - new_center_h);


### PR DESCRIPTION
Makes zooming and panning simpler by slowing down the amount of pan (by 50%) and zoom (by 90%) per event. Additionally, it clamps zooming out to fit the screen: once the waveform fits on the screen it will not zoom out any further with the mouse (shortcut keys/zoom commands still zoom out further). This prevents the waveform getting "lost", and makes the zoom and panning more precise and easier to follow.

That is a huge change, so I don't expect it to be merged as is - but it has been a pain-point of mine for many years. I can see in the code that there has been other (commented out) attempts to fix some of the zooming issues, but they have created more issues in certain use cases. I have tried to test this fix in a range of projects, but I'm sure there are cases I didn't think about. 

If you have any feedback, I'd be happy to hear it - and if it's way off target, then feel free to close it.
