### PR TITLE
Various unitary fixes

### DIFF
--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -107,11 +107,14 @@ static const char *ProjectFileSchema =
    // 'samples' are fixed size blocks of int16, int32 or float32 numbers.
    // The blocks may be partially empty.
    // The quantity of valid data in the blocks is
-   // provided in the project XML.
+   // provided in the project blob.
    // 
    // sampleformat specifies the format of the samples stored.
    //
    // blockID is a 64 bit number.
+   //
+   // Rows are immutable -- never updated after addition, but may be
+   // deleted.
    //
    // summin to summary64K are summaries at 3 distance scales.
    "CREATE TABLE IF NOT EXISTS <schema>.sampleblocks"

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -120,6 +120,10 @@ public:
    bool TransactionCommit(const wxString &name);
    bool TransactionRollback(const wxString &name);
 
+   // Type of function that is given the fields of one row and returns
+   // 0 for success or non-zero to stop the query
+   using ExecCB = std::function<int(int cols, char **vals, char **names)>;
+
 private:
    void WriteXMLHeader(XMLWriter &xmlFile) const;
    void WriteXML(XMLWriter &xmlFile, bool recording = false, const std::shared_ptr<TrackList> &tracks = nullptr) /* not override */;
@@ -130,15 +134,7 @@ private:
 
    void UpdatePrefs() override;
 
-   using ExecResult = std::vector<std::vector<wxString>>;
-   using ExecCB = std::function<int(ExecResult &result, int cols, char **vals, char **names)>;
-   struct ExecParm
-   {
-      ExecCB func;
-      ExecResult &result;
-   };
-   static int ExecCallback(void *data, int cols, char **vals, char **names);
-   int Exec(const char *query, ExecCB callback, ExecResult &result);
+   int Exec(const char *query, const ExecCB &callback);
 
    // The opening of the database may be delayed until demanded.
    // Returns a non-null pointer to an open database, or throws an exception
@@ -165,7 +161,7 @@ private:
    bool CloseDB();
    bool DeleteDB();
 
-   bool Query(const char *sql, ExecResult &result);
+   bool Query(const char *sql, const ExecCB &callback);
 
    bool GetValue(const char *sql, wxString &value);
    bool GetBlob(const char *sql, wxMemoryBuffer &buffer);


### PR DESCRIPTION
Some comments, and a combined bit of exception safety (eliminating some intermediate vector allocations) and efficiency in the callbacks passed to sqlite3_exec.
