### PR TITLE
Grouped block deletion

### DIFF
--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -262,7 +262,7 @@ void HistoryDialog::OnDiscard(wxCommandEvent & WXUNUSED(event))
    int i = mLevels->GetValue();
 
    mSelected -= i;
-   mManager->RemoveStates(i);
+   mManager->RemoveOldStates(i);
    ProjectHistory::Get( *mProject ).SetStateTo(mSelected);
 
    while(--i >= 0)

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -2137,7 +2137,7 @@ void ProjectFileIO::SetDBError(const TranslatableString &msg)
    wxASSERT(false);
 }
 
-void ProjectFileIO::SetBypass()
+void ProjectFileIO::SetBypass( bool bypass )
 {
    auto &currConn = CurrConn();
    if (!currConn)
@@ -2150,7 +2150,7 @@ void ProjectFileIO::SetBypass()
    // deletions since the new file doesn't have the blocks that the
    // Sequences expect to be there.
 
-   currConn->SetBypass( true );
+   currConn->SetBypass( bypass );
 
    // Only permanent project files need cleaning at shutdown
    if (!IsTemporary() && !WasCompacted())

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -120,7 +120,7 @@ public:
    // For it's usage, see:
    //    SqliteSampleBlock::~SqliteSampleBlock()
    //    ProjectManager::OnCloseWindow()
-   void SetBypass();
+   void SetBypass( bool bypass = true );
 
    // Remove all unused space within a project file
    void Compact(const std::shared_ptr<TrackList> &tracks, bool force = false);

--- a/src/ProjectHistory.cpp
+++ b/src/ProjectHistory.cpp
@@ -43,10 +43,13 @@ ProjectHistory::~ProjectHistory() = default;
 void ProjectHistory::InitialState()
 {
    auto &project = mProject;
+   auto &projectFileIO = ProjectFileIO::Get( project );
    auto &tracks = TrackList::Get( project );
    auto &viewInfo = ViewInfo::Get( project );
    auto &undoManager = UndoManager::Get( project );
    auto &tags = Tags::Get( project );
+
+   projectFileIO.TransactionStart({});
 
    undoManager.ClearStates();
 

--- a/src/ProjectHistory.cpp
+++ b/src/ProjectHistory.cpp
@@ -49,9 +49,9 @@ void ProjectHistory::InitialState()
    auto &undoManager = UndoManager::Get( project );
    auto &tags = Tags::Get( project );
 
-   projectFileIO.TransactionStart({});
-
    undoManager.ClearStates();
+
+   projectFileIO.TransactionStart({});
 
    undoManager.PushState(
       &tracks, viewInfo.selectedRegion, tags.shared_from_this(),

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -901,7 +901,7 @@ AudacityProject *ProjectManager::OpenProject(
       window.Zoom( window.GetZoomOfToFit() );
       // "Project was recovered" replaces "Create new project" in Undo History.
       auto &undoManager = UndoManager::Get( *pProject );
-      undoManager.RemoveStates(1);
+      undoManager.RemoveOldStates(1);
    }
 
    return pProject;
@@ -910,10 +910,8 @@ AudacityProject *ProjectManager::OpenProject(
 // This is done to empty out the tracks, but without creating a new project.
 void ProjectManager::ResetProjectToEmpty() {
    auto &project = mProject;
-   auto &projectFileIO = ProjectFileIO::Get( project );
    auto &projectFileManager = ProjectFileManager::Get( project );
    auto &projectHistory = ProjectHistory::Get( project );
-   auto &viewInfo = ViewInfo::Get( project );
 
    SelectUtilities::DoSelectAll( project );
    TrackUtilities::DoRemoveTracks( project );
@@ -923,8 +921,7 @@ void ProjectManager::ResetProjectToEmpty() {
    projectFileManager.Reset();
 
    projectHistory.SetDirty( false );
-   auto &undoManager = UndoManager::Get( project );
-   undoManager.ClearStates();
+   projectHistory.InitialState();
 }
 
 void ProjectManager::RestartTimer()

--- a/src/UndoManager.h
+++ b/src/UndoManager.h
@@ -131,6 +131,7 @@ class AUDACITY_DLL_API UndoManager final
                     const SelectedRegion &selectedRegion, const std::shared_ptr<Tags> &tags);
    void ClearStates();
    void RemoveStates(int num);  // removes the 'num' oldest states
+   void RemoveNewStates( int num ); // remove all but the 'num' oldest states
    unsigned int GetNumStates();
    unsigned int GetCurrentState();
 

--- a/src/UndoManager.h
+++ b/src/UndoManager.h
@@ -130,8 +130,8 @@ class AUDACITY_DLL_API UndoManager final
    void ModifyState(const TrackList * l,
                     const SelectedRegion &selectedRegion, const std::shared_ptr<Tags> &tags);
    void ClearStates();
-   void RemoveStates(int num);  // removes the 'num' oldest states
-   void RemoveNewStates( int num ); // remove all but the 'num' oldest states
+   void RemoveOldStates(int num);  // removes the 'num' oldest states
+   void RemoveNewStates( int num ); // removes all but the 'num' oldest states
    unsigned int GetNumStates();
    unsigned int GetCurrentState();
 
@@ -168,6 +168,9 @@ class AUDACITY_DLL_API UndoManager final
    // void Debug(); // currently unused
 
  private:
+   void DeleteBlocksExcept(
+      UndoStack::const_iterator begin,
+      UndoStack::const_iterator end );
    void RemoveStateAt(int n);
 
    AudacityProject &mProject;

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -599,6 +599,8 @@ static CommandHandlerObject &findCommandHandler(AudacityProject &) {
 
 // Menu definitions
 
+#define EXPERIMENTAL_RESET
+
 #define FN(X) (& FileActions::Handler :: X)
 
 namespace {


### PR DESCRIPTION
THIS IS STILL A DRAFT.  But I'm inviting review of work so far.

There are three places where SampleBlock objects may be destroyed:
1) Losing Redo states, when you create a new state in Undo history
2) Purging old Undo states, using the history dialog
3) Closing the project and destroying all Undo history

In all of these, I want to hoist the associated database operation to delete from the SampleBlock table, which is possibly failing, out of the destructor of SqliteSampleBlock, which gives no opportunity to stop the destruction and is a place where you can't let exceptions escape.

The deletions of blocks are also grouped into just one SQL command, which means just one transaction (even if an autocommit), with the possible efficiency gains there.

So far I've only completed the first of the three.  See how that works.
