### PR TITLE
Win: assertions on project close shouldn't crash displaying the dialog

### DIFF
--- a/src/tracks/ui/Scrubbing.h
+++ b/src/tracks/ui/Scrubbing.h
@@ -42,6 +42,7 @@ class Scrubber final
    : public wxEvtHandler
    , public ClientData::Base
    , private PrefsListener
+   , public std::enable_shared_from_this< Scrubber >
 {
 public:   
    static Scrubber &Get( AudacityProject &project );


### PR DESCRIPTION
# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
