### PR TITLE
Use XDG-compliant dirs by default on Unix platforms

### DIFF
--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -797,7 +797,10 @@ void AboutDialog::PopulateInformationPage( ShuttleGui & S )
 #endif
 
    // Location of settings
-   AddBuildinfoRow(&informationStr, XO("Settings folder:"), \
+   AddBuildinfoRow(&informationStr, XO("Config folder:"), \
+      FileNames::ConfigDir());
+   // Location of data
+   AddBuildinfoRow(&informationStr, XO("Data folder:"), \
       FileNames::DataDir());
    // end of table
    informationStr << wxT("</table>\n");

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1102,6 +1102,9 @@ bool AudacityApp::OnInit()
    // AddHandler takes ownership
    wxFileSystem::AddHandler(safenew wxZipFSHandler);
 
+   // encouraged by wxwidgets
+   wxStandardPaths::Get().SetFileLayout(wxStandardPaths::FileLayout::FileLayout_XDG);
+
    //
    // Paths: set search path and temp dir path
    //
@@ -1242,7 +1245,7 @@ bool AudacityApp::OnInit()
 #endif
 
    // Initialize preferences and language
-   wxFileName configFileName(FileNames::DataDir(), wxT("audacity.cfg"));
+   wxFileName configFileName(FileNames::ConfigDir(), wxT("audacity.cfg"));
    InitPreferences( configFileName );
    PopulatePreferences();
    // This test must follow PopulatePreferences, because if an error message

--- a/src/CrashReport.cpp
+++ b/src/CrashReport.cpp
@@ -31,7 +31,7 @@ void Generate(wxDebugReport::Context ctx)
    wxDebugReportCompress rpt;
    rpt.AddAll(ctx);
    
-   wxFileNameWrapper fn{ FileNames::DataDir(), wxT("audacity.cfg") };
+   wxFileNameWrapper fn{ FileNames::ConfigDir(), wxT("audacity.cfg") };
    rpt.AddFile(fn.GetFullPath(), _TS("Audacity Configuration"));
    rpt.AddFile(FileNames::PluginRegistry(), wxT("Plugin Registry"));
    rpt.AddFile(FileNames::PluginSettings(), wxT("Plugin Settings"));

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -47,6 +47,11 @@ used throughout Audacity into this one place.
 #include <windows.h>
 #endif
 
+#if defined(__WXGTK__)
+static wxString gOldUnixDataDir;
+#endif
+
+static wxString gConfigDir;
 static wxString gDataDir;
 
 const FileNames::FileType
@@ -235,8 +240,49 @@ wxString FileNames::LowerCaseAppNameInPath( const wxString & dirIn){
    return dir;
 }
 
+FilePath FileNames::ConfigDir()
+{
+#if defined(__WXGTK__)
+   if (gOldUnixDataDir.empty())
+      gOldUnixDataDir = wxFileName::GetHomeDir() + wxT("/.audacity-data");
+#endif
+
+   if (gConfigDir.empty())
+   {
+      wxFileName exePath(PlatformCompatibility::GetExecutablePath());
+#if defined(__WXMAC__)
+      // Path ends for example in "Audacity.app/Contents/MacOSX"
+      // just remove the MacOSX part.
+      exePath.RemoveLastDir();
+#endif
+      wxFileName portablePrefsPath(exePath.GetPath(), wxT("Portable Settings"));
+      if (::wxDirExists(portablePrefsPath.GetFullPath()))
+      {
+         // Use "Portable Settings" folder
+         gConfigDir = portablePrefsPath.GetFullPath();
+#if defined(__WXGTK__)
+      } else if (::wxDirExists(gOldUnixDataDir))
+      {
+         // Use old user data dir folder
+         gConfigDir = gOldUnixDataDir;
+#endif
+      } else {
+         // Use OS-provided user data dir folder
+         wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("/audacity"));
+         gConfigDir = FileNames::MkDir(configDir);
+      }
+   }
+
+   return gConfigDir;
+}
+
 FilePath FileNames::DataDir()
 {
+#if defined(__WXGTK__)
+   if (gOldUnixDataDir.empty())
+      gOldUnixDataDir = wxFileName::GetHomeDir() + wxT("/.audacity-data");
+#endif
+
    // LLL:  Wouldn't you know that as of WX 2.6.2, there is a conflict
    //       between wxStandardPaths and wxConfig under Linux.  The latter
    //       creates a normal file as "$HOME/.audacity", while the former
@@ -260,12 +306,25 @@ FilePath FileNames::DataDir()
       {
          // Use "Portable Settings" folder
          gDataDir = portablePrefsPath.GetFullPath();
+#if defined(__WXGTK__)
+      } else if (::wxDirExists(gOldUnixDataDir))
+      {
+         // Use old user data dir folder
+         gDataDir = gOldUnixDataDir;
+      } else
+      {
+         wxString dataDir;
+         // see if XDG_DATA_HOME is defined. if it is, use its value. if it isn't, use the default
+         // XDG-specified value
+         if ( !wxGetEnv(wxS("XDG_DATA_HOME"), &dataDir) || dataDir.empty() )
+            dataDir = wxFileName::GetHomeDir() + wxT("/.local/share");
+         
+         dataDir = dataDir + wxT("/audacity");
+#else
       } else
       {
          // Use OS-provided user data dir folder
          wxString dataDir( LowerCaseAppNameInPath( wxStandardPaths::Get().GetUserDataDir() ));
-#if defined( __WXGTK__ )
-         dataDir = dataDir + wxT("-data");
 #endif
          gDataDir = FileNames::MkDir(dataDir);
       }
@@ -326,12 +385,12 @@ FilePath FileNames::PlugInDir()
 
 FilePath FileNames::PluginRegistry()
 {
-   return wxFileName( DataDir(), wxT("pluginregistry.cfg") ).GetFullPath();
+   return wxFileName( ConfigDir(), wxT("pluginregistry.cfg") ).GetFullPath();
 }
 
 FilePath FileNames::PluginSettings()
 {
-   return wxFileName( DataDir(), wxT("pluginsettings.cfg") ).GetFullPath();
+   return wxFileName( ConfigDir(), wxT("pluginsettings.cfg") ).GetFullPath();
 }
 
 FilePath FileNames::BaseDir()

--- a/src/FileNames.h
+++ b/src/FileNames.h
@@ -88,10 +88,15 @@ namespace FileNames
       FilePaths &otherNames, wxFileName &newName);
 
    wxString LowerCaseAppNameInPath( const wxString & dirIn);
+   /** \brief Audacity user config directory
+    *
+    * Where audacity keeps its settigns squirreled away, by default ~/.config/audacity
+    * on Unix, Application Data/Audacity on Windows */
+   FilePath ConfigDir();
    /** \brief Audacity user data directory
     *
     * Where audacity keeps its settings and other user data squirreled away,
-    * by default ~/.audacity-data/ on Unix, Application Data/Audacity on
+    * by default ~/.local/share/audacity on Unix, Application Data/Audacity on
     * windows system */
    FilePath DataDir();
    FilePath ResourcesDir();


### PR DESCRIPTION
This addresses [issue 2201](https://bugzilla.audacityteam.org/show_bug.cgi?id=2201) on the Bugzilla tracker.

The new behavior is only applicable to Unix platforms. If the `~/.audacity-data` folder doesn't exist (i.e. on a new installation of Audacity) the proper XDG-compliant directories will be used for saving data (configuration files go in `~/.config/audacity`, data files go in `~/.local/share/audacity`). On existing installations of Audacity where `~/.audacity-data` already exists, that directory will continue to be used. This allows for potential downgrade compatibility should Audacity drop the legacy behavior in the future, and doesn't disrupt existing installations.