### PR TITLE
Fix bug/enhancement 266. Added progress dialog when changing sample format.

### DIFF
--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -160,6 +160,10 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
 
    // Return true iff there is a change
    bool ConvertToSampleFormat(sampleFormat format);
+   bool ConvertToSampleFormat(sampleFormat format,
+                              ProgressDialog &progress,
+                              sampleCount &converted,
+                              const sampleCount &total);
 
    //
    // Retrieving summary info

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1373,6 +1373,16 @@ void WaveClip::ConvertToSampleFormat(sampleFormat format)
       MarkChanged();
 }
 
+void WaveClip::ConvertToSampleFormat(sampleFormat format,
+                                     ProgressDialog &progress,
+                                     sampleCount &converted,
+                                     const sampleCount &total)
+{
+   auto bChanged = mSequence->ConvertToSampleFormat(format, progress, converted, total);
+   if (bChanged)
+      MarkChanged();
+}
+
 void WaveClip::UpdateEnvelopeTrackLen()
 // NOFAIL-GUARANTEE
 {

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -199,6 +199,11 @@ public:
    virtual ~WaveClip();
 
    void ConvertToSampleFormat(sampleFormat format);
+   void ConvertToSampleFormat(sampleFormat format,
+                              ProgressDialog &progress,
+                              sampleCount &converted,
+                              const sampleCount &total);
+
 
    // Always gives non-negative answer, not more than sample sequence length
    // even if t0 really falls outside that range

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -410,6 +410,15 @@ void WaveTrack::SetWaveColorIndex(int colorIndex)
    mWaveColorIndex = colorIndex;
 }
 
+sampleCount WaveTrack::GetNumSamples() const
+{
+   sampleCount result{ 0 };
+
+   for (const auto &clip : mClips)
+      result += clip->GetNumSamples();
+
+   return result;
+}
 
 void WaveTrack::ConvertToSampleFormat(sampleFormat format)
 // WEAK-GUARANTEE
@@ -417,6 +426,16 @@ void WaveTrack::ConvertToSampleFormat(sampleFormat format)
 {
    for (const auto &clip : mClips)
       clip->ConvertToSampleFormat(format);
+   mFormat = format;
+}
+
+void WaveTrack::ConvertToSampleFormat(sampleFormat format,
+                                      ProgressDialog &progress,
+                                      sampleCount &converted,
+                                      const sampleCount &total)
+{
+   for (const auto &clip : mClips)
+      clip->ConvertToSampleFormat(format, progress, converted, total);
    mFormat = format;
 }
 

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -139,8 +139,14 @@ private:
    int GetWaveColorIndex() const { return mWaveColorIndex; };
    void SetWaveColorIndex(int colorIndex);
 
+   sampleCount GetNumSamples() const;
+
    sampleFormat GetSampleFormat() const { return mFormat; }
    void ConvertToSampleFormat(sampleFormat format);
+   void ConvertToSampleFormat(sampleFormat format,
+      ProgressDialog &progress, 
+      sampleCount &converted,
+      const sampleCount &total); 
 
    const SpectrogramSettings &GetSpectrogramSettings() const;
    SpectrogramSettings &GetSpectrogramSettings();

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -254,8 +254,18 @@ void FormatMenuTable::OnFormatChange(wxCommandEvent & event)
 
    AudacityProject *const project = &mpData->project;
 
+   ProgressDialog progress{ XO("Changing sample format"), 
+                            XO("Processing...   0%%"),
+                            pdlgHideStopButton | pdlgHideCancelButton };
+
+   sampleCount totalSamples{ 0 };
+   for (const auto & channel : TrackList::Channels(pTrack))
+      totalSamples += channel->GetNumSamples();
+   sampleCount processedSamples{ 0 };
+
    for (auto channel : TrackList::Channels(pTrack))
-      channel->ConvertToSampleFormat(newFormat);
+      channel->ConvertToSampleFormat(
+         newFormat, progress, processedSamples, totalSamples);
 
    ProjectHistory::Get( *project )
    /* i18n-hint: The strings name a track and a format */


### PR DESCRIPTION
Here is a fix/enhancement for the Bug 266.
To introduce a progress dialog, CovertToSampleFormat-methods were overloaded in classes WaveTrack, WaveClip, and Sequence.
Class WaveTrack got a small new GetNumSamples method, that helps to estimate the total amount of samples for correct progress display.

