### PR TITLE
Track factory cleanup

### DIFF
--- a/include/audacity/ImporterInterface.h
+++ b/include/audacity/ImporterInterface.h
@@ -143,7 +143,7 @@ public:
    virtual void SetStreamUsage(int streamID, bool use) = 0;
 
    // do the actual import, creating whatever tracks are necessary with
-   // the TrackFactory and calling the progress callback every iteration
+   // the WaveTrackFactory and calling the progress callback every iteration
    // through the importing loop
    virtual bool Import() = 0;
 };

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -372,11 +372,10 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
 
    HoldPrint(true);
 
-   ZoomInfo zoomInfo(0.0, ZoomInfo::GetDefaultZoom());
    const auto t =
-      TrackFactory{ mSettings,
-                    SampleBlockFactory::New( mProject ),
-                    &zoomInfo }.NewWaveTrack(SampleFormat);
+      WaveTrackFactory{ mSettings,
+                    SampleBlockFactory::New( mProject )  }
+         .NewWaveTrack(SampleFormat);
 
    t->SetRate(1);
 

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -95,7 +95,6 @@ END_EVENT_TABLE()
 
 LabelDialog::LabelDialog(wxWindow *parent,
                          AudacityProject &project,
-                         TrackFactory &factory,
                          TrackList *tracks,
                          LabelTrack *selectedTrack,
                          int index,
@@ -110,7 +109,6 @@ LabelDialog::LabelDialog(wxWindow *parent,
            wxSize(800, 600),
            wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
   , mProject{ project }
-  , mFactory(factory)
   , mTracks(tracks)
   , mSelectedTrack(selectedTrack)
   , mIndex(index)
@@ -402,7 +400,7 @@ bool LabelDialog::TransferDataFromWindow()
       wxString name = mTrackNames[tndx + 1].AfterFirst(wxT('-')).Mid(1);
 
       // Create the NEW track and add to track list
-      auto newTrack = mFactory.NewLabelTrack();
+      auto newTrack = std::make_shared<LabelTrack>();
       newTrack->SetName(name);
       mTracks->Add( newTrack );
       tndx++;
@@ -654,7 +652,7 @@ void LabelDialog::OnImport(wxCommandEvent & WXUNUSED(event))
       else {
          // Create a temporary label track and load the labels
          // into it
-         auto lt = mFactory.NewLabelTrack();
+         auto lt = std::make_shared<LabelTrack>();
          lt->Import(f);
 
          // Add the labels to our collection
@@ -723,7 +721,7 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    }
 
    // Transfer our collection to a temporary label track
-   auto lt = mFactory.NewLabelTrack();
+   auto lt = std::make_shared<LabelTrack>();
    int i;
 
    for (i = 0; i < cnt; i++) {

--- a/src/LabelDialog.h
+++ b/src/LabelDialog.h
@@ -23,7 +23,6 @@ class AudacityProject;
 class ChoiceEditor;
 class Grid;
 class NumericEditor;
-class TrackFactory;
 class TrackList;
 class RowData;
 class EmptyLabelRenderer;
@@ -39,7 +38,6 @@ class LabelDialog final : public wxDialogWrapper
 
    LabelDialog(wxWindow *parent,
                AudacityProject &project,
-               TrackFactory &factory,
                TrackList *tracks,
 
                // if NULL edit all tracks, else this one only:
@@ -104,7 +102,6 @@ class LabelDialog final : public wxDialogWrapper
 
    RowDataArray mData;
 
-   TrackFactory &mFactory;
    TrackList *mTracks;
    LabelTrack *mSelectedTrack {};
    int mIndex { -1 };

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -57,19 +57,13 @@ wxDEFINE_EVENT(EVT_LABELTRACK_SELECTION, LabelTrackEvent);
 static ProjectFileIORegistry::Entry registerFactory{
    wxT( "labeltrack" ),
    []( AudacityProject &project ){
-      auto &trackFactory = TrackFactory::Get( project );
       auto &tracks = TrackList::Get( project );
-      auto result = tracks.Add(trackFactory.NewLabelTrack());
+      auto result = tracks.Add(std::make_shared<LabelTrack>());
       TrackView::Get( *result );
       TrackControls::Get( *result );
       return result;
    }
 };
-
-LabelTrack::Holder TrackFactory::NewLabelTrack()
-{
-   return std::make_shared<LabelTrack>();
-}
 
 LabelTrack::LabelTrack():
    Track(),

--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -40,7 +40,7 @@
 #include "widgets/ProgressDialog.h"
 
 //TODO-MB: wouldn't it make more sense to DELETE the time track after 'mix and render'?
-void MixAndRender(TrackList *tracks, TrackFactory *trackFactory,
+void MixAndRender(TrackList *tracks, WaveTrackFactory *trackFactory,
                   double rate, sampleFormat format,
                   double startTime, double endTime,
                   WaveTrack::Holder &uLeft, WaveTrack::Holder &uRight)

--- a/src/Mix.h
+++ b/src/Mix.h
@@ -25,7 +25,7 @@
 
 class Resample;
 class BoundedEnvelope;
-class TrackFactory;
+class WaveTrackFactory;
 class TrackList;
 class WaveTrack;
 using WaveTrackConstArray = std::vector < std::shared_ptr < const WaveTrack > >;
@@ -43,7 +43,7 @@ class WaveTrackCache;
  * no explicit time range to process, and the whole occupied length of the
  * input tracks is processed.
  */
-void MixAndRender(TrackList * tracks, TrackFactory *factory,
+void MixAndRender(TrackList * tracks, WaveTrackFactory *factory,
                   double rate, sampleFormat format,
                   double startTime, double endTime,
                   std::shared_ptr<WaveTrack> &uLeft,

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -112,19 +112,13 @@ SONFNS(AutoSave)
 static ProjectFileIORegistry::Entry registerFactory{
    wxT( "notetrack" ),
    []( AudacityProject &project ){
-      auto &trackFactory = TrackFactory::Get( project );
       auto &tracks = TrackList::Get( project );
-      auto result = tracks.Add(trackFactory.NewNoteTrack());
+      auto result = tracks.Add( std::make_shared<NoteTrack>());
       TrackView::Get( *result );
       TrackControls::Get( *result );
       return result;
    }
 };
-
-NoteTrack::Holder TrackFactory::NewNoteTrack()
-{
-   return std::make_shared<NoteTrack>();
-}
 
 NoteTrack::NoteTrack()
    : NoteTrackBase()

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -675,7 +675,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
 
          Track *first {};
          for (int c = 0; c < recordingChannels; c++) {
-            auto newTrack = TrackFactory::Get( *p ).NewWaveTrack();
+            auto newTrack = WaveTrackFactory::Get( *p ).NewWaveTrack();
             if (!first)
                first = newTrack.get();
 
@@ -892,7 +892,7 @@ void ProjectAudioManager::OnAudioIOStopRecording()
          auto &intervals = gAudioIO->LostCaptureIntervals();
          if (intervals.size()) {
             // Make a track with labels for recording errors
-            auto uTrack = TrackFactory::Get( project ).NewLabelTrack();
+            auto uTrack = std::make_shared<LabelTrack>();
             auto pTrack = uTrack.get();
             tracks.Add( uTrack );
             /* i18n-hint:  A name given to a track, appearing as its menu button.

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1175,7 +1175,7 @@ bool ProjectFileManager::Import(
       Tags::Set( project, newTags );
 
       bool success = Importer::Get().Import(project, fileName,
-                                            &TrackFactory::Get( project ),
+                                            &WaveTrackFactory::Get( project ),
                                             newTracks,
                                             newTags.get(),
                                             errorMessage);

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -770,7 +770,7 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
 
    window.DestroyChildren();
 
-   TrackFactory::Destroy( project );
+   WaveTrackFactory::Destroy( project );
 
    // Remove self from the global array, but defer destruction of self
    auto pSelf = AllProjects{}.Remove( project );
@@ -918,7 +918,7 @@ void ProjectManager::ResetProjectToEmpty() {
    SelectUtilities::DoSelectAll( project );
    TrackUtilities::DoRemoveTracks( project );
 
-   TrackFactory::Reset( project );
+   WaveTrackFactory::Reset( project );
 
    projectFileManager.Reset();
 

--- a/src/TimeTrack.cpp
+++ b/src/TimeTrack.cpp
@@ -27,6 +27,7 @@
 #include "Project.h"
 #include "ProjectSettings.h"
 #include "ProjectFileIORegistry.h"
+#include "ViewInfo.h"
 
 #include "tracks/ui/TrackView.h"
 #include "tracks/ui/TrackControls.h"
@@ -36,17 +37,12 @@
 #define TIMETRACK_MIN 0.01
 #define TIMETRACK_MAX 10.0
 
-std::shared_ptr<TimeTrack> TrackFactory::NewTimeTrack()
-{
-   return std::make_shared<TimeTrack>(mZoomInfo);
-}
-
 static ProjectFileIORegistry::Entry registerFactory{
    wxT( "timetrack" ),
    []( AudacityProject &project ){
-      auto &trackFactory = TrackFactory::Get( project );
       auto &tracks = TrackList::Get( project );
-      auto result = tracks.Add(trackFactory.NewTimeTrack());
+      auto &viewInfo = ViewInfo::Get( project );
+      auto result = tracks.Add(std::make_shared<TimeTrack>(&viewInfo));
       TrackView::Get( *result );
       TrackControls::Get( *result );
       return result;

--- a/src/TimeTrack.h
+++ b/src/TimeTrack.h
@@ -25,7 +25,7 @@ class TimeTrack final : public Track {
 
  public:
 
-   TimeTrack(const ZoomInfo *zoomInfo);
+   explicit TimeTrack(const ZoomInfo *zoomInfo);
    /** @brief Copy-Constructor - create a NEW TimeTrack:: which is an independent copy of the original
     *
     * Calls TimeTrack::Init() to copy the track metadata, then does a bunch of manipulations on the
@@ -111,8 +111,6 @@ class TimeTrack final : public Track {
 
 private:
    Track::Holder Clone() const override;
-
-   friend class TrackFactory;
 };
 
 

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -1278,38 +1278,3 @@ bool TrackList::HasPendingTracks() const
       return true;
    return false;
 }
-
-#include "SampleBlock.h"
-#include "ViewInfo.h"
-static auto TrackFactoryFactory = []( AudacityProject &project ) {
-   auto &viewInfo = ViewInfo::Get( project );
-   return std::make_shared< TrackFactory >(
-      ProjectSettings::Get( project ),
-      SampleBlockFactory::New( project ), &viewInfo );
-};
-
-static const AudacityProject::AttachedObjects::RegisteredFactory key2{
-   TrackFactoryFactory
-};
-
-TrackFactory &TrackFactory::Get( AudacityProject &project )
-{
-   return project.AttachedObjects::Get< TrackFactory >( key2 );
-}
-
-const TrackFactory &TrackFactory::Get( const AudacityProject &project )
-{
-   return Get( const_cast< AudacityProject & >( project ) );
-}
-
-TrackFactory &TrackFactory::Reset( AudacityProject &project )
-{
-   auto result = TrackFactoryFactory( project );
-   project.AttachedObjects::Assign( key2, result );
-   return *result;
-}
-
-void TrackFactory::Destroy( AudacityProject &project )
-{
-   project.AttachedObjects::Assign( key2, nullptr );
-}

--- a/src/Track.h
+++ b/src/Track.h
@@ -36,12 +36,9 @@ class PlayableTrack;
 class ProjectSettings;
 class LabelTrack;
 class TimeTrack;
-class TrackControls;
-class TrackView;
 class WaveTrack;
 class NoteTrack;
 class AudacityProject;
-class ZoomInfo;
 
 using TrackArray = std::vector< Track* >;
 using WaveTrackArray = std::vector < std::shared_ptr< WaveTrack > > ;
@@ -1557,49 +1554,6 @@ private:
    ListOfTracks mPendingUpdates;
    // This is in correspondence with mPendingUpdates
    std::vector< Updater > mUpdaters;
-};
-
-class SampleBlockFactory;
-using SampleBlockFactoryPtr = std::shared_ptr<SampleBlockFactory>;
-
-class AUDACITY_DLL_API TrackFactory final
-   : public ClientData::Base
-{
- public:
-   static TrackFactory &Get( AudacityProject &project );
-   static const TrackFactory &Get( const AudacityProject &project );
-   static TrackFactory &Reset( AudacityProject &project );
-   static void Destroy( AudacityProject &project );
-
-   TrackFactory( const ProjectSettings &settings,
-      const SampleBlockFactoryPtr &pFactory, const ZoomInfo *zoomInfo)
-      : mSettings{ settings }
-      , mpFactory(pFactory)
-      , mZoomInfo(zoomInfo)
-   {
-   }
-   TrackFactory( const TrackFactory & ) PROHIBITED;
-   TrackFactory &operator=( const TrackFactory & ) PROHIBITED;
-
-   const SampleBlockFactoryPtr &GetSampleBlockFactory() const
-   { return mpFactory; }
-
- private:
-   const ProjectSettings &mSettings;
-   SampleBlockFactoryPtr mpFactory;
-   const ZoomInfo *const mZoomInfo;
-   friend class AudacityProject;
- public:
-   // These methods are defined in WaveTrack.cpp, NoteTrack.cpp,
-   // LabelTrack.cpp, and TimeTrack.cpp respectively
-   std::shared_ptr<WaveTrack> DuplicateWaveTrack(const WaveTrack &orig);
-   std::shared_ptr<WaveTrack> NewWaveTrack(sampleFormat format = (sampleFormat)0,
-                           double rate = 0);
-   std::shared_ptr<LabelTrack> NewLabelTrack();
-   std::shared_ptr<TimeTrack> NewTimeTrack();
-#if defined(USE_MIDI)
-   std::shared_ptr<NoteTrack> NewNoteTrack();
-#endif
 };
 
 #endif

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -21,6 +21,8 @@
 class ProgressDialog;
 
 class SampleBlockFactory;
+using SampleBlockFactoryPtr = std::shared_ptr<SampleBlockFactory>;
+
 class SpectrogramSettings;
 class WaveformSettings;
 class TimeWarper;
@@ -82,7 +84,7 @@ private:
 
    Track::Holder Clone() const override;
 
-   friend class TrackFactory;
+   friend class WaveTrackFactory;
 
  public:
 
@@ -646,3 +648,36 @@ void InspectBlocks(const TrackList &tracks, BlockInspector inspector,
    SampleBlockIDSet *pIDs = nullptr);
 
 #endif // __AUDACITY_WAVETRACK__
+
+class AUDACITY_DLL_API WaveTrackFactory final
+   : public ClientData::Base
+{
+ public:
+   static WaveTrackFactory &Get( AudacityProject &project );
+   static const WaveTrackFactory &Get( const AudacityProject &project );
+   static WaveTrackFactory &Reset( AudacityProject &project );
+   static void Destroy( AudacityProject &project );
+
+   WaveTrackFactory( const ProjectSettings &settings,
+      const SampleBlockFactoryPtr &pFactory)
+      : mSettings{ settings }
+      , mpFactory(pFactory)
+   {
+   }
+   WaveTrackFactory( const WaveTrackFactory & ) PROHIBITED;
+   WaveTrackFactory &operator=( const WaveTrackFactory & ) PROHIBITED;
+
+   const SampleBlockFactoryPtr &GetSampleBlockFactory() const
+   { return mpFactory; }
+
+ private:
+   const ProjectSettings &mSettings;
+   SampleBlockFactoryPtr mpFactory;
+   friend class AudacityProject;
+ public:
+   // These methods are defined in WaveTrack.cpp, NoteTrack.cpp,
+   // LabelTrack.cpp, and TimeTrack.cpp respectively
+   std::shared_ptr<WaveTrack> DuplicateWaveTrack(const WaveTrack &orig);
+   std::shared_ptr<WaveTrack> NewWaveTrack(sampleFormat format = (sampleFormat)0,
+                           double rate = 0);
+};

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1198,7 +1198,7 @@ void Effect::SetBatchProcessing(bool start)
 
 bool Effect::DoEffect(double projectRate,
                       TrackList *list,
-                      TrackFactory *factory,
+                      WaveTrackFactory *factory,
                       NotifyingSelectedRegion &selectedRegion,
                       wxWindow *pParent,
                       const EffectDialogFactory &dialogFactory)
@@ -2106,7 +2106,7 @@ Track *Effect::AddToOutputTracks(const std::shared_ptr<Track> &t)
 Effect::AddedAnalysisTrack::AddedAnalysisTrack(Effect *pEffect, const wxString &name)
    : mpEffect(pEffect)
 {
-   LabelTrack::Holder pTrack{ pEffect->mFactory->NewLabelTrack() };
+   LabelTrack::Holder pTrack{ std::make_shared<LabelTrack>() };
    mpTrack = pTrack.get();
    if (!name.empty())
       pTrack->SetName(name);

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -50,7 +50,7 @@ class SelectedRegion;
 class EffectUIHost;
 class Track;
 class TrackList;
-class TrackFactory;
+class WaveTrackFactory;
 class WaveTrack;
 
 /* i18n-hint: "Nyquist" is an embedded interpreted programming language in
@@ -257,7 +257,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // Audacity's standard UI.
    // Create a user interface only if the supplied function is not null.
    /* not virtual */ bool DoEffect( double projectRate, TrackList *list,
-      TrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
+      WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
       // Prompt the user for input only if these arguments are both not null.
       wxWindow *pParent = nullptr,
       const EffectDialogFactory &dialogFactory = {} );
@@ -458,7 +458,7 @@ protected:
                                // be created with this rate...
    double         mSampleRate;
    wxWeakRef<NotifyingSelectedRegion> mpSelectedRegion{};
-   TrackFactory   *mFactory;
+   WaveTrackFactory   *mFactory;
    const TrackList *inputTracks() const { return mTracks; }
    const AudacityProject *FindProject() const;
    std::shared_ptr<TrackList> mOutputTracks; // used only if CopyInputTracks() is called.

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -27,7 +27,6 @@ class CommandContext;
 class CommandMessageTarget;
 class ComponentInterfaceSymbol;
 class Effect;
-class TrackFactory;
 class TrackList;
 class SelectedRegion;
 class wxString;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1864,7 +1864,7 @@ wxDialog *EffectUI::DialogFactory( wxWindow &parent, EffectHostInterface *pHost,
    const auto &settings = ProjectSettings::Get( project );
    auto &tracks = TrackList::Get( project );
    auto &trackPanel = TrackPanel::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto rate = settings.GetRate();
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
    auto &commandManager = CommandManager::Get( project );

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -268,13 +268,13 @@ public:
    ~Worker();
 
    bool Process(EffectNoiseReduction &effect,
-                Statistics &statistics, TrackFactory &factory,
+                Statistics &statistics, WaveTrackFactory &factory,
                 TrackList &tracks, double mT0, double mT1);
 
 private:
    bool ProcessOne(EffectNoiseReduction &effect,
                    Statistics &statistics,
-                   TrackFactory &factory,
+                   WaveTrackFactory &factory,
                    int count, WaveTrack *track,
                    sampleCount start, sampleCount len);
 
@@ -669,7 +669,7 @@ EffectNoiseReduction::Worker::~Worker()
 }
 
 bool EffectNoiseReduction::Worker::Process
-(EffectNoiseReduction &effect, Statistics &statistics, TrackFactory &factory,
+(EffectNoiseReduction &effect, Statistics &statistics, WaveTrackFactory &factory,
  TrackList &tracks, double inT0, double inT1)
 {
    int count = 0;
@@ -1307,7 +1307,7 @@ void EffectNoiseReduction::Worker::ReduceNoise
 }
 
 bool EffectNoiseReduction::Worker::ProcessOne
-(EffectNoiseReduction &effect,  Statistics &statistics, TrackFactory &factory,
+(EffectNoiseReduction &effect,  Statistics &statistics, WaveTrackFactory &factory,
  int count, WaveTrack * track, sampleCount start, sampleCount len)
 {
    if (track == NULL)

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1504,7 +1504,8 @@ bool NyquistEffect::ProcessOne()
       unsigned int l;
       auto ltrack = * mOutputTracks->Any< LabelTrack >().begin();
       if (!ltrack) {
-         ltrack = static_cast<LabelTrack*>(AddToOutputTracks(mFactory->NewLabelTrack()));
+         ltrack = static_cast<LabelTrack*>(
+            AddToOutputTracks(std::make_shared<LabelTrack>()));
       }
 
       for (l = 0; l < numLabels; l++) {

--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -455,7 +455,7 @@ std::unique_ptr<ExtImportItem> Importer::CreateDefaultImportItem()
 // returns number of tracks imported
 bool Importer::Import( AudacityProject &project,
                      const FilePath &fName,
-                     TrackFactory *trackFactory,
+                     WaveTrackFactory *trackFactory,
                      TrackHolders &tracks,
                      Tags *tags,
                      TranslatableString &errorMessage)

--- a/src/import/Import.h
+++ b/src/import/Import.h
@@ -25,7 +25,7 @@ class wxArrayString;
 class wxListBox;
 class AudacityProject;
 class Tags;
-class TrackFactory;
+class WaveTrackFactory;
 class Track;
 class ImportPlugin;
 class ImportFileHandle;
@@ -167,7 +167,7 @@ public:
    // if false, the import failed and errorMessage will be set.
    bool Import( AudacityProject &project,
               const FilePath &fName,
-              TrackFactory *trackFactory,
+              WaveTrackFactory *trackFactory,
               TrackHolders &tracks,
               Tags *tags,
               TranslatableString &errorMessage);

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -91,7 +91,7 @@ public:
 
    ByteCount GetFileUncompressedBytes() override;
 
-   ProgressResult Import(TrackFactory *trackFactory,
+   ProgressResult Import(WaveTrackFactory *trackFactory,
                          TrackHolders &outTracks,
                          Tags *tags) override;
 
@@ -267,7 +267,7 @@ auto AUPImportFileHandle::GetFileUncompressedBytes() -> ByteCount
    return 0;
 }
 
-ProgressResult AUPImportFileHandle::Import(TrackFactory *WXUNUSED(trackFactory),
+ProgressResult AUPImportFileHandle::Import(WaveTrackFactory *WXUNUSED(trackFactory),
                                            TrackHolders &WXUNUSED(outTracks),
                                            Tags *tags)
 {
@@ -829,8 +829,7 @@ bool AUPImportFileHandle::HandleProject(XMLTagHandler *&handler)
 
 bool AUPImportFileHandle::HandleLabelTrack(XMLTagHandler *&handler)
 {
-   auto &trackFactory = TrackFactory::Get(mProject);
-   mTracks.push_back(trackFactory.NewLabelTrack());
+   mTracks.push_back(std::make_shared<LabelTrack>());
 
    handler = mTracks.back().get();
 
@@ -840,8 +839,7 @@ bool AUPImportFileHandle::HandleLabelTrack(XMLTagHandler *&handler)
 bool AUPImportFileHandle::HandleNoteTrack(XMLTagHandler *&handler)
 {
 #if defined(USE_MIDI)
-   auto &trackFactory = TrackFactory::Get(mProject);
-   mTracks.push_back(trackFactory.NewNoteTrack());
+   mTracks.push_back( std::make_shared<NoteTrack>());
 
    handler = mTracks.back().get();
 
@@ -874,8 +872,8 @@ bool AUPImportFileHandle::HandleTimeTrack(XMLTagHandler *&handler)
       return true;
    }
 
-   auto &trackFactory = TrackFactory::Get(mProject);
-   mTracks.push_back(trackFactory.NewTimeTrack());
+   auto &viewInfo = ViewInfo::Get( mProject );
+   mTracks.push_back( std::make_shared<TimeTrack>(&viewInfo) );
 
    handler = mTracks.back().get();
 
@@ -884,7 +882,7 @@ bool AUPImportFileHandle::HandleTimeTrack(XMLTagHandler *&handler)
 
 bool AUPImportFileHandle::HandleWaveTrack(XMLTagHandler *&handler)
 {
-   auto &trackFactory = TrackFactory::Get(mProject);
+   auto &trackFactory = WaveTrackFactory::Get(mProject);
    mTracks.push_back(trackFactory.NewWaveTrack());
 
    handler = mTracks.back().get();

--- a/src/import/ImportFFmpeg.cpp
+++ b/src/import/ImportFFmpeg.cpp
@@ -200,7 +200,7 @@ public:
 
    ///! Imports audio
    ///\return import status (see Import.cpp)
-   ProgressResult Import(TrackFactory *trackFactory, TrackHolders &outTracks,
+   ProgressResult Import(WaveTrackFactory *trackFactory, TrackHolders &outTracks,
       Tags *tags) override;
 
    ///! Reads next audio frame
@@ -467,7 +467,7 @@ auto FFmpegImportFileHandle::GetFileUncompressedBytes() -> ByteCount
    return 0;
 }
 
-ProgressResult FFmpegImportFileHandle::Import(TrackFactory *trackFactory,
+ProgressResult FFmpegImportFileHandle::Import(WaveTrackFactory *trackFactory,
               TrackHolders &outTracks,
               Tags *tags)
 {

--- a/src/import/ImportFLAC.cpp
+++ b/src/import/ImportFLAC.cpp
@@ -149,7 +149,7 @@ public:
 
    TranslatableString GetFileDescription() override;
    ByteCount GetFileUncompressedBytes() override;
-   ProgressResult Import(TrackFactory *trackFactory, TrackHolders &outTracks,
+   ProgressResult Import(WaveTrackFactory *trackFactory, TrackHolders &outTracks,
               Tags *tags) override;
 
    wxInt32 GetStreamCount() override { return 1; }
@@ -408,7 +408,7 @@ auto FLACImportFileHandle::GetFileUncompressedBytes() -> ByteCount
 }
 
 
-ProgressResult FLACImportFileHandle::Import(TrackFactory *trackFactory,
+ProgressResult FLACImportFileHandle::Import(WaveTrackFactory *trackFactory,
                                  TrackHolders &outTracks,
                                  Tags *tags)
 {

--- a/src/import/ImportLOF.cpp
+++ b/src/import/ImportLOF.cpp
@@ -128,7 +128,7 @@ public:
 
    TranslatableString GetFileDescription() override;
    ByteCount GetFileUncompressedBytes() override;
-   ProgressResult Import(TrackFactory *trackFactory, TrackHolders &outTracks,
+   ProgressResult Import(WaveTrackFactory *trackFactory, TrackHolders &outTracks,
               Tags *tags) override;
 
    wxInt32 GetStreamCount() override { return 1; }
@@ -225,7 +225,7 @@ auto LOFImportFileHandle::GetFileUncompressedBytes() -> ByteCount
 }
 
 ProgressResult LOFImportFileHandle::Import(
-   TrackFactory * WXUNUSED(trackFactory), TrackHolders &outTracks,
+   WaveTrackFactory * WXUNUSED(trackFactory), TrackHolders &outTracks,
    Tags * WXUNUSED(tags))
 {
    // Unlike other ImportFileHandle subclasses, this one never gives any tracks

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -36,7 +36,7 @@
 bool DoImportMIDI( AudacityProject &project, const FilePath &fileName )
 {
    auto &tracks = TrackList::Get( project );
-   auto newTrack = TrackFactory::Get( project ).NewNoteTrack();
+   auto newTrack =  std::make_shared<NoteTrack>();
    
    if (::ImportMIDI(fileName, newTrack.get())) {
       

--- a/src/import/ImportMP3.cpp
+++ b/src/import/ImportMP3.cpp
@@ -110,7 +110,7 @@ public:
 
    TranslatableString GetFileDescription() override;
    ByteCount GetFileUncompressedBytes() override;
-   ProgressResult Import(TrackFactory *trackFactory, TrackHolders &outTracks, Tags *tags) override;
+   ProgressResult Import(WaveTrackFactory *trackFactory, TrackHolders &outTracks, Tags *tags) override;
    wxInt32 GetStreamCount() override;
    const TranslatableStrings &GetStreamInfo() override;
    void SetStreamUsage(wxInt32 StreamID, bool Use) override;
@@ -157,7 +157,7 @@ private:
    unsigned char mInputBuffer[INPUT_BUFFER_SIZE + MAD_BUFFER_GUARD];
    int mInputBufferLen;
 
-   TrackFactory *mTrackFactory;
+   WaveTrackFactory *mTrackFactory;
    NewChannelGroup mChannels;
    unsigned mNumChannels;
 
@@ -252,7 +252,7 @@ void MP3ImportFileHandle::SetStreamUsage(wxInt32 WXUNUSED(StreamID), bool WXUNUS
 {
 }
 
-ProgressResult MP3ImportFileHandle::Import(TrackFactory *trackFactory,
+ProgressResult MP3ImportFileHandle::Import(WaveTrackFactory *trackFactory,
                                            TrackHolders &outTracks,
                                            Tags *tags)
 {

--- a/src/import/ImportOGG.cpp
+++ b/src/import/ImportOGG.cpp
@@ -126,7 +126,7 @@ public:
 
    TranslatableString GetFileDescription() override;
    ByteCount GetFileUncompressedBytes() override;
-   ProgressResult Import(TrackFactory *trackFactory, TrackHolders &outTracks,
+   ProgressResult Import(WaveTrackFactory *trackFactory, TrackHolders &outTracks,
               Tags *tags) override;
 
    wxInt32 GetStreamCount() override
@@ -231,7 +231,7 @@ auto OggImportFileHandle::GetFileUncompressedBytes() -> ByteCount
 }
 
 ProgressResult OggImportFileHandle::Import(
-   TrackFactory *trackFactory, TrackHolders &outTracks,
+   WaveTrackFactory *trackFactory, TrackHolders &outTracks,
    Tags *tags)
 {
    outTracks.clear();

--- a/src/import/ImportPCM.cpp
+++ b/src/import/ImportPCM.cpp
@@ -93,7 +93,7 @@ public:
 
    TranslatableString GetFileDescription() override;
    ByteCount GetFileUncompressedBytes() override;
-   ProgressResult Import(TrackFactory *trackFactory, TrackHolders &outTracks,
+   ProgressResult Import(WaveTrackFactory *trackFactory, TrackHolders &outTracks,
               Tags *tags) override;
 
    wxInt32 GetStreamCount() override { return 1; }
@@ -290,7 +290,7 @@ using id3_tag_holder = std::unique_ptr<id3_tag, id3_tag_deleter>;
 
 using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
 
-ProgressResult PCMImportFileHandle::Import(TrackFactory *trackFactory,
+ProgressResult PCMImportFileHandle::Import(WaveTrackFactory *trackFactory,
                                 TrackHolders &outTracks,
                                 Tags *tags)
 {

--- a/src/import/ImportPlugin.h
+++ b/src/import/ImportPlugin.h
@@ -54,7 +54,7 @@ but little else.
 class AudacityProject;
 class ProgressDialog;
 enum class ProgressResult : unsigned;
-class TrackFactory;
+class WaveTrackFactory;
 class Track;
 class Tags;
 
@@ -133,14 +133,14 @@ public:
    virtual ByteCount GetFileUncompressedBytes() = 0;
 
    // do the actual import, creating whatever tracks are necessary with
-   // the TrackFactory and calling the progress callback every iteration
+   // the WaveTrackFactory and calling the progress callback every iteration
    // through the importing loop
    // The given Tags structure may also be modified.
    // In case of errors or exceptions, it is not necessary to leave outTracks
    // or tags unmodified.
    // If resulting outTracks is not empty,
    // then each member of it must be a nonempty vector.
-   virtual ProgressResult Import(TrackFactory *trackFactory, TrackHolders &outTracks,
+   virtual ProgressResult Import(WaveTrackFactory *trackFactory, TrackHolders &outTracks,
                       Tags *tags) = 0;
 
    // Return number of elements in stream list

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -93,7 +93,7 @@ class ImportRawDialog final : public wxDialogWrapper {
 // but may also throw FileException to make use of the application's
 // user visible error reporting.
 void ImportRaw(wxWindow *parent, const wxString &fileName,
-              TrackFactory *trackFactory, TrackHolders &outTracks)
+              WaveTrackFactory *trackFactory, TrackHolders &outTracks)
 {
    outTracks.clear();
    int encoding = 0; // Guess Format

--- a/src/import/ImportRaw.h
+++ b/src/import/ImportRaw.h
@@ -13,7 +13,7 @@
 
 #include "../MemoryX.h"
 
-class TrackFactory;
+class WaveTrackFactory;
 class WaveTrack;
 class wxString;
 class wxWindow;
@@ -27,6 +27,6 @@ using TrackHolders = std::vector< NewChannelGroup >;
 
 
 void ImportRaw(wxWindow *parent, const wxString &fileName,
-   TrackFactory *trackFactory, TrackHolders &outTracks);
+   WaveTrackFactory *trackFactory, TrackHolders &outTracks);
 
 #endif

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -75,9 +75,10 @@ bool DoPasteText(AudacityProject &project)
 bool DoPasteNothingSelected(AudacityProject &project)
 {
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto &pSampleBlockFactory = trackFactory.GetSampleBlockFactory();
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
+   auto &viewInfo = ViewInfo::Get( project );
    auto &window = ProjectWindow::Get( project );
 
    // First check whether anything's selected.
@@ -101,19 +102,19 @@ bool DoPasteNothingSelected(AudacityProject &project)
             },
 #ifdef USE_MIDI
             [&](const NoteTrack *) {
-               uNewTrack = trackFactory.NewNoteTrack(),
+               uNewTrack = std::make_shared<NoteTrack>(),
                pNewTrack = uNewTrack.get();
             },
 #endif
             [&](const LabelTrack *) {
-               uNewTrack = trackFactory.NewLabelTrack(),
+               uNewTrack = std::make_shared<LabelTrack>(),
                pNewTrack = uNewTrack.get();
             },
             [&](const TimeTrack *) {
                // Maintain uniqueness of the time track!
                pNewTrack = *tracks.Any<TimeTrack>().begin();
                if (!pNewTrack)
-                  uNewTrack = trackFactory.NewTimeTrack(),
+                  uNewTrack = std::make_shared<TimeTrack>( &viewInfo ),
                   pNewTrack = uNewTrack.get();
             }
          );
@@ -374,7 +375,7 @@ void OnPaste(const CommandContext &context)
 {
    auto &project = context.project;
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto &pSampleBlockFactory = trackFactory.GetSampleBlockFactory();
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
    const auto &settings = ProjectSettings::Get( project );

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -511,7 +511,7 @@ void OnImport(const CommandContext &context)
 void OnImportLabels(const CommandContext &context)
 {
    auto &project = context.project;
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto &tracks = TrackList::Get( project );
    auto &window = ProjectWindow::Get( project );
 
@@ -535,7 +535,7 @@ void OnImportLabels(const CommandContext &context)
          return;
       }
 
-      auto newTrack = trackFactory.NewLabelTrack();
+      auto newTrack = std::make_shared<LabelTrack>();
       wxString sTrackName;
       wxFileName::SplitPath(fileName, NULL, NULL, &sTrackName, NULL);
       newTrack->SetName(sTrackName);
@@ -585,7 +585,7 @@ void OnImportMIDI(const CommandContext &context)
 void OnImportRaw(const CommandContext &context)
 {
    auto &project = context.project;
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto &window = ProjectWindow::Get( project );
 
    wxString fileName =

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -51,7 +51,6 @@ int DoAddLabel(
    auto &tracks = TrackList::Get( project );
    auto &trackFocus = TrackFocus::Get( project );
    auto &trackPanel = TrackPanel::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
    auto &window = ProjectWindow::Get( project );
 
    wxString title;      // of label
@@ -75,7 +74,7 @@ int DoAddLabel(
 
    // If none found, start a NEW label track and use it
    if (!lt)
-      lt = tracks.Add( trackFactory.NewLabelTrack() );
+      lt = tracks.Add( std::make_shared<LabelTrack>() );
 
 // LLL: Commented as it seemed a little forceful to remove users
 //      selection when adding the label.  This does not happen if
@@ -315,7 +314,6 @@ void OnPasteNewLabel(const CommandContext &context)
 {
    auto &project = context.project;
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
    auto &trackPanel = TrackPanel::Get( project );
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
    auto &window = ProjectWindow::Get( project );
@@ -334,7 +332,7 @@ void OnPasteNewLabel(const CommandContext &context)
 
          // If no match found, add one
          if (!t)
-            t = tracks.Add( trackFactory.NewLabelTrack() );
+            t = tracks.Add( std::make_shared<LabelTrack>() );
 
          // Select this track so the loop picks it up
          t->SetSelected(true);

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -51,7 +51,7 @@ void DoMixAndRender
 {
    const auto &settings = ProjectSettings::Get( project );
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto rate = settings.GetRate();
    auto defaultFormat = QualityPrefs::SampleFormatChoice();
    auto &trackPanel = TrackPanel::Get( project );
@@ -607,7 +607,7 @@ void OnNewWaveTrack(const CommandContext &context)
    auto &project = context.project;
    const auto &settings = ProjectSettings::Get( project );
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto &window = ProjectWindow::Get( project );
 
    auto defaultFormat = QualityPrefs::SampleFormatChoice();
@@ -631,7 +631,7 @@ void OnNewStereoTrack(const CommandContext &context)
    auto &project = context.project;
    const auto &settings = ProjectSettings::Get( project );
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto &window = ProjectWindow::Get( project );
 
    auto defaultFormat = QualityPrefs::SampleFormatChoice();
@@ -658,10 +658,10 @@ void OnNewLabelTrack(const CommandContext &context)
 {
    auto &project = context.project;
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &trackFactory = WaveTrackFactory::Get( project );
    auto &window = ProjectWindow::Get( project );
 
-   auto t = tracks.Add( trackFactory.NewLabelTrack() );
+   auto t = tracks.Add( std::make_shared<LabelTrack>() );
 
    SelectUtilities::SelectNone( project );
 
@@ -678,7 +678,7 @@ void OnNewTimeTrack(const CommandContext &context)
 {
    auto &project = context.project;
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
+   auto &viewInfo = ViewInfo::Get( project );
    auto &window = ProjectWindow::Get( project );
 
    if ( *tracks.Any<TimeTrack>().begin() ) {
@@ -688,7 +688,7 @@ void OnNewTimeTrack(const CommandContext &context)
       return;
    }
 
-   auto t = tracks.AddToHead( trackFactory.NewTimeTrack() );
+   auto t = tracks.AddToHead( std::make_shared<TimeTrack>(&viewInfo) );
 
    SelectUtilities::SelectNone( project );
 

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -845,7 +845,6 @@ int DoAddLabel(
    auto &tracks = TrackList::Get( project );
    auto &trackFocus = TrackFocus::Get( project );
    auto &trackPanel = TrackPanel::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
    auto &window = ProjectWindow::Get( project );
 
    wxString title;      // of label
@@ -861,7 +860,7 @@ int DoAddLabel(
 
    // If none found, start a NEW label track and use it
    if (!lt)
-      lt = tracks.Add( trackFactory.NewLabelTrack() );
+      lt = tracks.Add( std::make_shared<LabelTrack>() );
 
 // LLL: Commented as it seemed a little forceful to remove users
 //      selection when adding the label.  This does not happen if

--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -2054,12 +2054,11 @@ void LabelTrackView::DoEditLabels
    auto format = settings.GetSelectionFormat(),
       freqFormat = settings.GetFrequencySelectionFormatName();
    auto &tracks = TrackList::Get( project );
-   auto &trackFactory = TrackFactory::Get( project );
    auto rate = ProjectSettings::Get( project ).GetRate();
    auto &viewInfo = ViewInfo::Get( project );
    auto &window = ProjectWindow::Get( project );
 
-   LabelDialog dlg(&window, project, trackFactory, &tracks,
+   LabelDialog dlg(&window, project, &tracks,
                    lt, index,
                    viewInfo, rate,
                    format, freqFormat);


### PR DESCRIPTION
   Simplify obsolete complications related to TrackFactory...
    
    ... There were there only because DirManager was in the base Track object
    (which was unnecessary even before the Unitary project) and had to be set
    properly for the destination project.
    
    Use a factory now only for Wave tracks, not other subclasses.

