### PR TITLE
fixed bug/enh 266

### DIFF
--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -132,7 +132,8 @@ namespace {
    }
 }
 
-bool Sequence::ConvertToSampleFormat(sampleFormat format)
+bool Sequence::ConvertToSampleFormat(sampleFormat format,
+   const std::function<void(size_t)> & progressReport)
 // STRONG-GUARANTEE
 {
    if (format == mSampleFormat)
@@ -199,6 +200,9 @@ bool Sequence::ConvertToSampleFormat(sampleFormat format)
          const auto blockstart = oldSeqBlock.start;
          Blockify(*mpFactory, mMaxSamples, mSampleFormat,
                   newBlockArray, blockstart, bufferNew.ptr(), len);
+
+         if (progressReport)
+            progressReport(len);
       }
    }
 

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -12,6 +12,7 @@
 #define __AUDACITY_SEQUENCE__
 
 #include <vector>
+#include <functional>
 
 #include "SampleFormat.h"
 #include "xml/XMLTagHandler.h"
@@ -135,7 +136,8 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
    sampleFormat GetSampleFormat() const;
 
    // Return true iff there is a change
-   bool ConvertToSampleFormat(sampleFormat format);
+   bool ConvertToSampleFormat(sampleFormat format, 
+      const std::function<void(size_t)> & progressReport = {});
 
    //
    // Retrieving summary info

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -24,7 +24,6 @@
 #include "Experimental.h"
 
 #include <math.h>
-#include <functional>
 #include <vector>
 #include <wx/log.h>
 
@@ -1159,15 +1158,17 @@ float WaveClip::GetRMS(double t0, double t1, bool mayThrow) const
    return mSequence->GetRMS(s0, s1-s0, mayThrow);
 }
 
-void WaveClip::ConvertToSampleFormat(sampleFormat format)
+void WaveClip::ConvertToSampleFormat(sampleFormat format,
+   const std::function<void(size_t)> & progressReport)
 {
    // Note:  it is not necessary to do this recursively to cutlines.
    // They get converted as needed when they are expanded.
 
-   auto bChanged = mSequence->ConvertToSampleFormat(format);
+   auto bChanged = mSequence->ConvertToSampleFormat(format, progressReport);
    if (bChanged)
       MarkChanged();
 }
+
 
 void WaveClip::UpdateEnvelopeTrackLen()
 // NOFAIL-GUARANTEE

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -22,6 +22,7 @@
 #include <wx/longlong.h>
 
 #include <vector>
+#include <functional>
 
 class BlockArray;
 class Envelope;
@@ -197,7 +198,8 @@ public:
 
    virtual ~WaveClip();
 
-   void ConvertToSampleFormat(sampleFormat format);
+   void ConvertToSampleFormat(sampleFormat format,
+      const std::function<void(size_t)> & progressReport = {});
 
    // Always gives non-negative answer, not more than sample sequence length
    // even if t0 really falls outside that range

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -413,15 +413,26 @@ void WaveTrack::SetWaveColorIndex(int colorIndex)
    mWaveColorIndex = colorIndex;
 }
 
+sampleCount WaveTrack::GetNumSamples() const
+{
+   sampleCount result{ 0 };
 
-void WaveTrack::ConvertToSampleFormat(sampleFormat format)
+   for (const auto& clip : mClips)
+      result += clip->GetNumSamples();
+
+   return result;
+}
+
+void WaveTrack::ConvertToSampleFormat(sampleFormat format,
+   const std::function<void(size_t)> & progressReport)
 // WEAK-GUARANTEE
 // might complete on only some clips
 {
-   for (const auto &clip : mClips)
-      clip->ConvertToSampleFormat(format);
+   for (const auto& clip : mClips)
+      clip->ConvertToSampleFormat(format, progressReport);
    mFormat = format;
 }
+
 
 bool WaveTrack::IsEmpty(double t0, double t1) const
 {

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -14,6 +14,7 @@
 #include "Track.h"
 
 #include <vector>
+#include <functional>
 #include <wx/longlong.h>
 
 #include "WaveTrackLocation.h"
@@ -140,8 +141,11 @@ private:
    int GetWaveColorIndex() const { return mWaveColorIndex; };
    void SetWaveColorIndex(int colorIndex);
 
+   sampleCount GetNumSamples() const;
+
    sampleFormat GetSampleFormat() const { return mFormat; }
-   void ConvertToSampleFormat(sampleFormat format);
+   void ConvertToSampleFormat(sampleFormat format,
+      const std::function<void(size_t)> & progressReport = {});
 
    const SpectrogramSettings &GetSpectrogramSettings() const;
    SpectrogramSettings &GetSpectrogramSettings();

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -34,6 +34,9 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../../prefs/PrefsDialog.h"
 #include "../../../../prefs/ThemePrefs.h"
 #include "../../../../widgets/AudacityMessageBox.h"
+#include "widgets/ProgressDialog.h"
+#include "UserException.h"
+#include "audacity/Types.h"
 
 #include <wx/combobox.h>
 #include <wx/frame.h>
@@ -252,9 +255,37 @@ void FormatMenuTable::OnFormatChange(wxCommandEvent & event)
 
    AudacityProject *const project = &mpData->project;
 
-   for (auto channel : TrackList::Channels(pTrack))
-      channel->ConvertToSampleFormat(newFormat);
+   ProgressDialog progress{ XO("Changing sample format"),
+                            XO("Processing...   0%%"),
+                            pdlgHideStopButton };
 
+   sampleCount totalSamples{ 0 };
+   for (const auto& channel : TrackList::Channels(pTrack))
+      totalSamples += channel->GetNumSamples();
+   sampleCount processedSamples{ 0 };
+
+   // Below is the lambda function that is passed along the call chain to
+   // the Sequence::ConvertToSampleFormat. This callback function is used
+   // to report the convertion progress and update the progress dialog.
+   auto progressUpdate = [&progress, &totalSamples, &processedSamples]
+   (size_t newlyProcessedCount)->void
+   {
+      processedSamples += newlyProcessedCount;
+      double d_processed = processedSamples.as_double();
+      double d_total = totalSamples.as_double();
+      int percentage{ static_cast<int>((d_processed / d_total) * 100) };
+
+      auto progressStatus = progress.Update(d_processed, d_total,
+         XO("Processing...   %i%%").Format(percentage));
+
+      if (progressStatus != ProgressResult::Success)
+         throw UserException{};
+   };
+
+   for (auto channel : TrackList::Channels(pTrack))
+      channel->ConvertToSampleFormat(
+         newFormat, progressUpdate);
+         
    ProjectHistory::Get( *project )
    /* i18n-hint: The strings name a track and a format */
       .PushState(XO("Changed '%s' to %s")


### PR DESCRIPTION
Here is a fix/enhancement for the Bug 266.

To introduce a progress dialog, CovertToSampleFormat-methods were overloaded in classes WaveTrack, WaveClip, and Sequence.

Class WaveTrack got a small new GetNumSamples method, that helps to estimate the total amount of samples for correct progress display.
