### PR TITLE
Dont delete sample blocks prematurely

### DIFF
--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -2435,7 +2435,7 @@ int ProjectFileIO::get_varint(const unsigned char *ptr, int64_t *out)
    return 9;
 }
 
-AutoCommitTransaction::AutoCommitTransaction(ProjectFileIO &projectFileIO,
+TransactionScope::TransactionScope(ProjectFileIO &projectFileIO,
                                              const char *name)
 :  mIO(projectFileIO),
    mName(name)
@@ -2446,7 +2446,7 @@ AutoCommitTransaction::AutoCommitTransaction(ProjectFileIO &projectFileIO,
       throw SimpleMessageBoxException( XO("Database error") );
 }
 
-AutoCommitTransaction::~AutoCommitTransaction()
+TransactionScope::~TransactionScope()
 {
    if (mInTrans)
    {
@@ -2462,7 +2462,7 @@ AutoCommitTransaction::~AutoCommitTransaction()
    }
 }
 
-bool AutoCommitTransaction::Commit()
+bool TransactionScope::Commit()
 {
    if ( !mInTrans )
       // Misuse of this class

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -2450,7 +2450,7 @@ AutoCommitTransaction::~AutoCommitTransaction()
 {
    if (mInTrans)
    {
-      if (!mIO.TransactionCommit(mName))
+      if (!mIO.TransactionRollback(mName))
       {
          // Do not throw from a destructor!
          // This has to be a no-fail cleanup that does the best that it can.
@@ -2458,13 +2458,13 @@ AutoCommitTransaction::~AutoCommitTransaction()
    }
 }
 
-bool AutoCommitTransaction::Rollback()
+bool AutoCommitTransaction::Commit()
 {
    if ( !mInTrans )
       // Misuse of this class
       THROW_INCONSISTENCY_EXCEPTION;
 
-   mInTrans = !mIO.TransactionRollback(mName);
+   mInTrans = !mIO.TransactionCommit(mName);
 
    return mInTrans;
 }

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -2450,7 +2450,11 @@ AutoCommitTransaction::~AutoCommitTransaction()
 {
    if (mInTrans)
    {
-      if (!mIO.TransactionRollback(mName))
+      // Rollback AND REMOVE the transaction
+      // -- must do both; rolling back a savepoint only rewinds it
+      // without removing it, unlike the ROLLBACK command
+      if (!(mIO.TransactionRollback(mName) &&
+            mIO.TransactionCommit(mName) ) )
       {
          // Do not throw from a destructor!
          // This has to be a no-fail cleanup that does the best that it can.

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -24,7 +24,7 @@ struct sqlite3_stmt;
 struct sqlite3_value;
 
 class AudacityProject;
-class AutoCommitTransaction;
+class TransactionScope;
 class DBConnection;
 class ProjectSerializer;
 class SqliteSampleBlock;
@@ -242,11 +242,11 @@ private:
 // roll it back at destruction time, unless an explicit Commit() happened first.
 // Commit() must not be called again after one successful call.
 // An exception is thrown from the constructor if the transaction cannot open.
-class AutoCommitTransaction
+class TransactionScope
 {
 public:
-   AutoCommitTransaction(ProjectFileIO &projectFileIO, const char *name);
-   ~AutoCommitTransaction();
+   TransactionScope(ProjectFileIO &projectFileIO, const char *name);
+   ~TransactionScope();
 
    bool Commit();
 

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -239,6 +239,8 @@ private:
 };
 
 // Make a savepoint (a transaction, possibly nested) with the given name;
+// roll it back at destruction time, unless an explicit Commit() happened first.
+// Commit() must not be called again after one successful call.
 // An exception is thrown from the constructor if the transaction cannot open.
 class AutoCommitTransaction
 {
@@ -246,7 +248,7 @@ public:
    AutoCommitTransaction(ProjectFileIO &projectFileIO, const char *name);
    ~AutoCommitTransaction();
 
-   bool Rollback();
+   bool Commit();
 
 private:
    ProjectFileIO &mIO;

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -748,6 +748,8 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
 
       // Delete all the tracks to free up memory
       tracks.Clear();
+
+      trans.Commit();
    }
 
    // We're all done with the project file, so close it now

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -740,7 +740,7 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    projectFileIO.SetBypass();
 
    {
-      AutoCommitTransaction trans(projectFileIO, "Shutdown");
+      TransactionScope trans(projectFileIO, "Shutdown");
 
       // This can reduce reference counts of sample blocks in the project's
       // tracks.

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1240,6 +1240,9 @@ bool Effect::DoEffect(double projectRate,
          // LastUsedDuration may have been modified by Preview.
          SetDuration(oldDuration);
       }
+      else
+         trans.Commit();
+
       End();
       ReplaceProcessedTracks( false );
    } );

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1215,7 +1215,7 @@ bool Effect::DoEffect(double projectRate,
    // This is for performance purposes only, no additional recovery implied
    auto &pProject = *const_cast<AudacityProject*>(FindProject()); // how to remove this const_cast?
    auto &pIO = ProjectFileIO::Get(pProject);
-   AutoCommitTransaction trans(pIO, "Effect");
+   TransactionScope trans(pIO, "Effect");
 
    // Update track/group counts
    CountWaveTracks();


### PR DESCRIPTION
Re-fixes an old problem more simply.

Also restores AutoCommitTransaction as I think it should be, consistent with these principles: https://doxy.audacityteam.org/exception-safety.html#Strong-guarantee-compound

MAY have relation to the disk exhaustion troubles -- I'm not certain of that yet.

But I believe this is also a right thing to do on its own merits.
