### PR TITLE
Graceful failure saving to thumb drive...

### DIFF
--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1903,6 +1903,12 @@ bool ProjectFileIO::SaveProject(const FilePath &fileName, const std::shared_ptr<
                OpenConnection(savedName);
             }
          }
+         else {
+            // Rename can fail -- if it's to a different device, requiring
+            // real copy of contents, which might exhaust space
+            OpenConnection(savedName);
+            return false;
+         }
       }
    }
 


### PR DESCRIPTION
... If renaming of the file (to a place on a different device) fails,
recover correctly before giving the warning message

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
