### PR TITLE
Bug2532: should preserve sharing of sample blocks when importing AUP

### DIFF
--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -103,6 +103,11 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
 
    size_t GetIdealAppendLen() const;
    void Append(samplePtr buffer, sampleFormat format, size_t len);
+
+   //! Append data, not coalescing blocks, returning a pointer to the new block.
+   SeqBlock::SampleBlockPtr AppendNewBlock(samplePtr buffer, sampleFormat format, size_t len);
+   //! Append a complete block, not coalescing
+   void AppendSharedBlock(const SeqBlock::SampleBlockPtr &pBlock);
    void Delete(sampleCount start, sampleCount len);
 
    void SetSilence(sampleCount s0, sampleCount len);
@@ -195,6 +200,9 @@ class PROFILE_DLL_API Sequence final : public XMLTagHandler{
    //
 
    int FindBlock(sampleCount pos) const;
+
+   SeqBlock::SampleBlockPtr DoAppend(
+      samplePtr buffer, sampleFormat format, size_t len, bool coalesce);
 
    static void AppendBlock(SampleBlockFactory *pFactory, sampleFormat format,
                            BlockArray &blocks,

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1202,6 +1202,19 @@ void WaveClip::GetDisplayRect(wxRect* r)
    *r = mDisplayRect;
 }
 
+/*! @excsafety{Strong} */
+std::shared_ptr<SampleBlock> WaveClip::AppendNewBlock(
+   samplePtr buffer, sampleFormat format, size_t len)
+{
+   return mSequence->AppendNewBlock( buffer, format, len );
+}
+
+/*! @excsafety{Strong} */
+void WaveClip::AppendSharedBlock(const std::shared_ptr<SampleBlock> &pBlock)
+{
+   mSequence->AppendSharedBlock( pBlock );
+}
+
 /*! @excsafety{Partial}
  -- Some prefix (maybe none) of the buffer is appended,
 and no content already flushed to disk is lost. */

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -26,6 +26,7 @@
 class BlockArray;
 class Envelope;
 class ProgressDialog;
+class SampleBlock;
 class SampleBlockFactory;
 using SampleBlockFactoryPtr = std::shared_ptr<SampleBlockFactory>;
 class Sequence;
@@ -279,6 +280,13 @@ public:
     * of samples (that is, the length of the clip), you will want to call this
     * function to tell the envelope about it. */
    void UpdateEnvelopeTrackLen();
+
+   //! For use in importing pre-version-3 projects to preserve sharing of blocks
+   std::shared_ptr<SampleBlock> AppendNewBlock(
+      samplePtr buffer, sampleFormat format, size_t len);
+
+   //! For use in importing pre-version-3 projects to preserve sharing of blocks
+   void AppendSharedBlock(const std::shared_ptr<SampleBlock> &pBlock);
 
    /// You must call Flush after the last Append
    /// @return true if at least one complete block was created


### PR DESCRIPTION
Bug2532: should preserve sharing of sample blocks when importing AUP
