### PR TITLE
Do orphan block checking differently...

### DIFF
--- a/src/ProjectSerializer.cpp
+++ b/src/ProjectSerializer.cpp
@@ -383,7 +383,7 @@ bool ProjectSerializer::DictChanged() const
 }
 
 // See ProjectFileIO::LoadProject() for explanation of the blockids arg
-wxString ProjectSerializer::Decode(const wxMemoryBuffer &buffer, BlockIDs &blockids)
+wxString ProjectSerializer::Decode(const wxMemoryBuffer &buffer)
 {
    wxMemoryInputStream in(buffer.GetData(), buffer.GetDataLen());
 
@@ -549,16 +549,6 @@ wxString ProjectSerializer::Decode(const wxMemoryBuffer &buffer, BlockIDs &block
             {
                id = ReadUShort( in );
                long long val = ReadLongLong( in );
-
-               // Look for and save the "blockid" values to support orphan
-               // block checking. This should be removed once serialization
-               // and related blocks become part of the same transaction.
-               const wxString &name = Lookup(id);
-               if (name.IsSameAs(wxT("blockid")))
-               {
-                  blockids.insert(val);
-               }
-
                out.WriteAttr(Lookup(id), val);
             }
             break;

--- a/src/ProjectSerializer.h
+++ b/src/ProjectSerializer.h
@@ -22,9 +22,6 @@
 // From SampleBlock.h
 using SampleBlockID = long long;
 
-// From ProjectFileiIO.h
-using BlockIDs = std::unordered_set<SampleBlockID>;
-
 ///
 /// ProjectSerializer
 ///
@@ -69,7 +66,7 @@ public:
    bool DictChanged() const;
 
    // Returns empty string if decoding fails
-   static wxString Decode(const wxMemoryBuffer &buffer, BlockIDs &blockids);
+   static wxString Decode(const wxMemoryBuffer &buffer);
 
 private:
    void WriteName(const wxString & name);

--- a/src/SampleBlock.h
+++ b/src/SampleBlock.h
@@ -13,6 +13,7 @@ SampleBlock.h
 
 #include <functional>
 #include <memory>
+#include <unordered_set>
 
 class AudacityProject;
 class ProjectFileIO;
@@ -132,6 +133,10 @@ public:
    SampleBlockPtr CreateFromXML(
       sampleFormat srcformat,
       const wxChar **attrs);
+
+   using SampleBlockIDs = std::unordered_set<SampleBlockID>;
+   /*! @return ids of all sample blocks created by this factory and still extant */
+   virtual SampleBlockIDs GetActiveBlockIDs() = 0;
 
 protected:
    // The override should throw more informative exceptions on error than the

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -129,6 +129,8 @@ public:
 
    ~SqliteSampleBlockFactory() override;
 
+   SampleBlockIDs GetActiveBlockIDs() override;
+
    SampleBlockPtr DoGet(SampleBlockID sbid) override;
 
    SampleBlockPtr DoCreate(samplePtr src,
@@ -169,6 +171,21 @@ SampleBlockPtr SqliteSampleBlockFactory::DoCreate(
    // block id has now been assigned
    mAllBlocks[ sb->GetBlockID() ] = sb;
    return sb;
+}
+
+auto SqliteSampleBlockFactory::GetActiveBlockIDs() -> SampleBlockIDs
+{
+   SampleBlockIDs result;
+   for (auto end = mAllBlocks.end(), it = mAllBlocks.begin(); it != end;) {
+      if (it->second.expired())
+         // Tighten up the map
+         it = mAllBlocks.erase(it);
+      else {
+         result.insert( it->first );
+         ++it;
+      }
+   }
+   return result;
 }
 
 SampleBlockPtr SqliteSampleBlockFactory::DoCreateSilent(


### PR DESCRIPTION
... Don't have special knowledge of "blockid" in ProjectSerializer, which should
be very low-level.

Instead, we can deserialize the project first, and use the block ids collected
by the sample block factory since f137a1e.

# Pull Requests

If you are submitting a pull request, please read https://wiki.audacityteam.org/wiki/GitHub_Pull_Requests 
