### PR TITLE
Mac: avoid assertion violations from KeyboardCapture.cpp...

### DIFF
--- a/src/KeyboardCapture.cpp
+++ b/src/KeyboardCapture.cpp
@@ -341,8 +341,9 @@ private:
          // as in the combo box case of bug 1252.  We can't compute it!
          // This makes a difference only when there is a capture handler.
          // It's never the case yet that there is one.
-         wxASSERT(false);
-         return chars;
+
+         // Return just a one-character string.
+         return event.GetUnicodeKey();
       }
 
       NSString *c = [mEvent charactersIgnoringModifiers];


### PR DESCRIPTION
Please do review this.  It's not related to UP but it came to my attention trying to debug 2526.

I wonder if all the unusual stuff manipulating NSEvent, which I don't fully understand, is made unnecessary by changes in more recent versions of wxWidgets.

See source of wxWidgetCocoaImpl::SetupKeyEvent to understand just how the unicode character in the wxKeyEvent is set up.  In some paths to our function GetUnicodeString, it's all the data we have.

The assertion that is removed is a bothersome one that I have been seeing sometimes in debug builds for quite some time, but I don't know for sure what to do about it.
