### PR TITLE
Track shifters

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1900,7 +1900,8 @@ void AdornedRulerPanel::HandleSnapping()
    if (handle) {
       auto &pSnapManager = handle->mSnapManager;
       if (! pSnapManager)
-         pSnapManager = std::make_unique<SnapManager>(mTracks, mViewInfo);
+         pSnapManager =
+            std::make_unique<SnapManager>(*mProject, *mTracks, *mViewInfo);
       
       auto results = pSnapManager->Snap(NULL, mQuickPlayPos, false);
       mQuickPlayPos = results.outTime;

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -84,6 +84,28 @@ LabelTrack::LabelTrack(const LabelTrack &orig) :
    }
 }
 
+template< typename Container >
+static Container MakeIntervals(const LabelArray &labels)
+{
+   Container result;
+   size_t ii = 0;
+   for (const auto &label : labels)
+      result.emplace_back(
+         label.getT0(), label.getT1(),
+         std::make_unique<LabelTrack::IntervalData>( ii++ ) );
+   return result;
+}
+
+auto LabelTrack::GetIntervals() const -> ConstIntervals
+{
+   return MakeIntervals<ConstIntervals>(mLabels);
+}
+
+auto LabelTrack::GetIntervals() -> Intervals
+{
+   return MakeIntervals<Intervals>(mLabels);
+}
+
 void LabelTrack::SetLabel( size_t iLabel, const LabelStruct &newLabel )
 {
    if( iLabel >= mLabels.size() ) {

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -155,6 +155,13 @@ public:
    int FindNextLabel(const SelectedRegion& currentSelection);
    int FindPrevLabel(const SelectedRegion& currentSelection);
 
+   struct IntervalData final : Track::IntervalData {
+      size_t index;
+      explicit IntervalData(size_t index) : index{index} {};
+   };
+   ConstIntervals GetIntervals() const override;
+   Intervals GetIntervals() override;
+
  public:
    void SortLabels();
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -683,6 +683,20 @@ QuantizedTimeAndBeat NoteTrack::NearestBeatTime( double time ) const
    return { seq_time + GetOffset(), beat };
 }
 
+auto NoteTrack::GetIntervals() const -> ConstIntervals
+{
+   ConstIntervals results;
+   results.emplace_back( GetStartTime(), GetEndTime() );
+   return results;
+}
+
+auto NoteTrack::GetIntervals() -> Intervals
+{
+   Intervals results;
+   results.emplace_back( GetStartTime(), GetEndTime() );
+   return results;
+}
+
 void NoteTrack::AddToDuration( double delta )
 {
    auto &seq = GetSeq();

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -185,6 +185,9 @@ public:
          mVisibleChannels = CHANNEL_BIT(c);
    }
 
+   ConstIntervals GetIntervals() const override;
+   Intervals GetIntervals() override;
+
  private:
 
    TrackKind GetKind() const override { return TrackKind::Note; }

--- a/src/Snap.h
+++ b/src/Snap.h
@@ -21,31 +21,9 @@
 
 class AudacityProject;
 class Track;
-using TrackArray = std::vector< Track* >;
-class TrackClipArray;
-class WaveClip;
-class WaveTrack;
 class TrackList;
 class ZoomInfo;
 class wxDC;
-
-class TrackClip
-{
-public:
-   TrackClip(Track *t, WaveClip *c);
-
-   ~TrackClip();
-
-   Track *track;
-   Track *origTrack;
-   WaveClip *clip;
-
-   // These fields are used only during time-shift dragging
-   WaveTrack *dstTrack;
-   std::shared_ptr<WaveClip> holder;
-};
-
-class TrackClipArray : public std::vector < TrackClip > {};
 
 const int kPixelTolerance = 4;
 
@@ -77,12 +55,18 @@ struct SnapResults {
 class SnapManager
 {
 public:
-   SnapManager(const TrackList *tracks,
-               const ZoomInfo *zoomInfo,
-               const TrackClipArray *clipExclusions = NULL,
-               const TrackArray *trackExclusions = NULL,
+   SnapManager(const AudacityProject &project,
+               SnapPointArray candidates,
+               const ZoomInfo &zoomInfo,
                bool noTimeSnap = false,
                int pixelTolerance = kPixelTolerance);
+
+   SnapManager(const AudacityProject &project,
+               const TrackList &tracks,
+               const ZoomInfo &zoomInfo,
+               bool noTimeSnap = false,
+               int pixelTolerance = kPixelTolerance);
+
    ~SnapManager();
 
    // The track may be NULL.
@@ -111,23 +95,22 @@ private:
 private:
 
    const AudacityProject *mProject;
-   const TrackList *mTracks;
-   const TrackClipArray *mClipExclusions;
-   const TrackArray *mTrackExclusions;
    const ZoomInfo *mZoomInfo;
    int mPixelTolerance;
    bool mNoTimeSnap;
    
-   double mEpsilon;
+   //! Two time points closer than this are considered the same
+   double mEpsilon{ 1 / 44100.0 };
+   SnapPointArray mCandidates;
    SnapPointArray mSnapPoints;
 
    // Info for snap-to-time
    NumericConverter mConverter;
-   bool mSnapToTime;
+   bool mSnapToTime{ false };
 
-   int mSnapTo;
-   double mRate;
-   NumericFormatSymbol mFormat;
+   int mSnapTo{ 0 };
+   double mRate{ 0.0 };
+   NumericFormatSymbol mFormat{};
 };
 
 #endif

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -1224,6 +1224,16 @@ std::shared_ptr<const Track> Track::SubstituteOriginalTrack() const
    return SharedPointer();
 }
 
+auto Track::GetIntervals() const -> ConstIntervals
+{
+   return {};
+}
+
+auto Track::GetIntervals() -> Intervals
+{
+   return {};
+}
+
 // Serialize, not with tags of its own, but as attributes within a tag.
 void Track::WriteCommonXMLAttributes(
    XMLWriter &xmlFile, bool includeNameAndSelected) const
@@ -1268,6 +1278,8 @@ void Track::AdjustPositions()
       pList->ResizingEvent(mNode);
    }
 }
+
+TrackIntervalData::~TrackIntervalData() = default;
 
 bool TrackList::HasPendingTracks() const
 {

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -323,6 +323,27 @@ int WaveTrack::ZeroLevelYCoordinate(wxRect rect) const
       (int)((mDisplayMax / (mDisplayMax - mDisplayMin)) * rect.height);
 }
 
+template< typename Container >
+static Container MakeIntervals(const std::vector<WaveClipHolder> &clips)
+{
+   Container result;
+   for (const auto &clip: clips) {
+      result.emplace_back( clip->GetStartTime(), clip->GetEndTime(),
+         std::make_unique<WaveTrack::IntervalData>( clip ) );
+   }
+   return result;
+}
+
+auto WaveTrack::GetIntervals() const -> ConstIntervals
+{
+   return MakeIntervals<ConstIntervals>( mClips );
+}
+
+auto WaveTrack::GetIntervals() -> Intervals
+{
+   return MakeIntervals<Intervals>( mClips );
+}
+
 Track::Holder WaveTrack::Clone() const
 {
    return std::make_shared<WaveTrack>( *this );

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -523,6 +523,20 @@ private:
    // bottom and top.  Maybe that is out of bounds.
    int ZeroLevelYCoordinate(wxRect rect) const;
 
+   class IntervalData final : public Track::IntervalData {
+   public:
+      explicit IntervalData( const std::shared_ptr<WaveClip> &pClip )
+      : pClip{ pClip }
+      {}
+      std::shared_ptr<const WaveClip> GetClip() const { return pClip; }
+      std::shared_ptr<WaveClip> &GetClip() { return pClip; }
+   private:
+      std::shared_ptr<WaveClip> pClip;
+   };
+
+   ConstIntervals GetIntervals() const override;
+   Intervals GetIntervals() override;
+
  protected:
    //
    // Protected variables

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -633,8 +633,7 @@ double DoClipMove
 {
    auto &selectedRegion = viewInfo.selectedRegion;
 
-   // just dealing with clips in wave tracks for the moment. Note tracks??
-   if (track) return track->TypeSwitch<double>( [&]( WaveTrack *wt ) {
+   if (track) {
       ClipMoveState state;
 
       auto t0 = selectedRegion.t0();
@@ -642,8 +641,8 @@ double DoClipMove
       std::unique_ptr<TrackShifter> uShifter;
 
       // Find the first channel that has a clip at time t0
-      for (auto channel : TrackList::Channels(wt) ) {
-         uShifter = MakeTrackShifter::Call( *wt );
+      for (auto channel : TrackList::Channels(track) ) {
+         uShifter = MakeTrackShifter::Call( *track );
          if( uShifter->HitTest( t0 ) == TrackShifter::HitTestResult::Miss )
             uShifter.reset();
          else
@@ -680,7 +679,7 @@ double DoClipMove
       }
 
       return hSlideAmount;
-   } );
+   };
    return 0.0;
 }
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackView.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackView.cpp
@@ -729,4 +729,38 @@ void NoteTrackView::Draw(
    }
    CommonTrackView::Draw( context, rect, iPass );
 }
+
+#include "../../../ui/TimeShiftHandle.h"
+
+class NoteTrackShifter final : public TrackShifter {
+public:
+   NoteTrackShifter( NoteTrack &track )
+      : mpTrack{ track.SharedPointer<NoteTrack>() }
+   {
+      InitIntervals();
+   }
+   ~NoteTrackShifter() override {}
+   Track &GetTrack() const override { return *mpTrack; }
+   
+   HitTestResult HitTest( double ) override
+   {
+      return HitTestResult::Intervals;
+   }
+
+   // Default implementation of SelectInterval() is correct
+
+   bool SyncLocks() override { return true; }
+
+private:
+   std::shared_ptr<NoteTrack> mpTrack;
+};
+
+using MakeNoteTrackShifter = MakeTrackShifter::Override<NoteTrack>;
+template<> template<> auto MakeNoteTrackShifter::Implementation() -> Function {
+   return [](NoteTrack &track) {
+      return std::make_unique<NoteTrackShifter>(track);
+   };
+}
+static MakeNoteTrackShifter registerMakeNoteTrackShifter;
+
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -1301,3 +1301,71 @@ void WaveTrackView::Draw(
 
    CommonTrackView::Draw( context, rect, iPass );
 }
+
+class WaveTrackShifter final : public TrackShifter {
+public:
+   WaveTrackShifter( WaveTrack &track )
+      : mpTrack{ track.SharedPointer<WaveTrack>() }
+   {
+      InitIntervals();
+   }
+   ~WaveTrackShifter() override {}
+   Track &GetTrack() const override { return *mpTrack; }
+
+   HitTestResult HitTest( double time ) override
+   {
+      auto pClip = mpTrack->GetClipAtTime( time );
+
+      if (!pClip)
+         return HitTestResult::Miss;
+
+      // Make a side-effect on our intervals
+      UnfixIntervals( [&](const auto &interval){
+         return
+            static_cast<WaveTrack::IntervalData*>(interval.Extra())
+               ->GetClip().get() == pClip;
+      } );
+      
+      return HitTestResult::Intervals;
+   }
+
+   void SelectInterval( const TrackInterval &interval ) override
+   {
+      UnfixIntervals( [&](auto &myInterval){
+         // Use a slightly different test from the default, rounding times
+         // to exact samples according to the clip's rate
+         auto data =
+            static_cast<WaveTrack::IntervalData*>( myInterval.Extra() );
+         auto clip = data->GetClip().get();
+         return !(clip->IsClipStartAfterClip(interval.Start()) ||
+            clip->BeforeClip(interval.End()));
+      });
+   }
+
+   bool SyncLocks() override { return true; }
+
+   double HintOffsetLarger(double desiredOffset) override
+   {
+      // set it to a sample point, and minimum of 1 sample point
+      bool positive = (desiredOffset > 0);
+      if (!positive)
+         desiredOffset *= -1;
+      double nSamples = rint(mpTrack->GetRate() * desiredOffset);
+      nSamples = std::max(nSamples, 1.0);
+      desiredOffset = nSamples / mpTrack->GetRate();
+      if (!positive)
+         desiredOffset *= -1;
+      return desiredOffset;
+   }
+
+private:
+   std::shared_ptr<WaveTrack> mpTrack;
+};
+
+using MakeWaveTrackShifter = MakeTrackShifter::Override<WaveTrack>;
+template<> template<> auto MakeWaveTrackShifter::Implementation() -> Function {
+   return [](WaveTrack &track) {
+      return std::make_unique<WaveTrackShifter>(track);
+   };
+}
+static MakeWaveTrackShifter registerMakeWaveTrackShifter;

--- a/src/tracks/ui/SelectHandle.cpp
+++ b/src/tracks/ui/SelectHandle.cpp
@@ -432,7 +432,8 @@ SelectHandle::SelectHandle
   const TrackList &trackList,
   const TrackPanelMouseState &st, const ViewInfo &viewInfo )
    : mpView{ pTrackView }
-   , mSnapManager{ std::make_shared<SnapManager>(&trackList, &viewInfo) }
+   , mSnapManager{ std::make_shared<SnapManager>(
+      *trackList.GetOwner(), trackList, viewInfo) }
 {
    const wxMouseState &state = st.state;
    mRect = st.rect;

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -162,13 +162,10 @@ namespace
    // duplication of this logic)
    void AddClipsToCaptured
       ( ClipMoveState &state, const ViewInfo &viewInfo,
-        Track *t, bool withinSelection )
+        Track *t )
    {
-      if (withinSelection)
-         AddClipsToCaptured( state, t, viewInfo.selectedRegion.t0(),
-                            viewInfo.selectedRegion.t1() );
-      else
-         AddClipsToCaptured( state, t, t->GetStartTime(), t->GetEndTime() );
+      AddClipsToCaptured( state, t, viewInfo.selectedRegion.t0(),
+                         viewInfo.selectedRegion.t1() );
    }
 
    WaveTrack *NthChannel(WaveTrack &leader, int nn)
@@ -260,7 +257,7 @@ void TimeShiftHandle::CreateListOfCapturedClips
    // just the clicked-on clip
    if ( state.capturedClipIsSelection )
       for (auto t : trackList.Selected())
-         AddClipsToCaptured( state, viewInfo, t, true );
+         AddClipsToCaptured( state, viewInfo, t );
    else {
       state.capturedClipArray.push_back
          (TrackClip( &capturedTrack, state.capturedClip ));

--- a/src/tracks/ui/TimeShiftHandle.h
+++ b/src/tracks/ui/TimeShiftHandle.h
@@ -13,10 +13,31 @@ Paul Licameli
 
 #include "../../UIHandle.h"
 
-#include "../../Snap.h"
-
+class SnapManager;
+class Track;
+using TrackArray = std::vector<Track*>;
+class TrackList;
 class ViewInfo;
 class WaveClip;
+class WaveTrack;
+
+class TrackClip
+{
+public:
+   TrackClip(Track *t, WaveClip *c);
+
+   ~TrackClip();
+
+   Track *track;
+   Track *origTrack;
+   WaveClip *clip;
+
+   // These fields are used only during time-shift dragging
+   WaveTrack *dstTrack;
+   std::shared_ptr<WaveClip> holder;
+};
+
+using TrackClipArray = std::vector <TrackClip>;
 
 struct ClipMoveState {
    // non-NULL only if click was in a WaveTrack and without Shift key:


### PR DESCRIPTION
Act II of the TimeShift restructuring eliminates two TypeSwitches and one Visit, and makes the clip-shifting menu items also work for Note tracks.

