### PR TITLE
Time shift rewrite bug2464 preliminaries

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1900,7 +1900,8 @@ void AdornedRulerPanel::HandleSnapping()
    if (handle) {
       auto &pSnapManager = handle->mSnapManager;
       if (! pSnapManager)
-         pSnapManager = std::make_unique<SnapManager>(mTracks, mViewInfo);
+         pSnapManager =
+            std::make_unique<SnapManager>(*mProject, *mTracks, *mViewInfo);
       
       auto results = pSnapManager->Snap(NULL, mQuickPlayPos, false);
       mQuickPlayPos = results.outTime;

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -84,6 +84,28 @@ LabelTrack::LabelTrack(const LabelTrack &orig) :
    }
 }
 
+template< typename Container >
+static Container MakeIntervals(const LabelArray &labels)
+{
+   Container result;
+   size_t ii = 0;
+   for (const auto &label : labels)
+      result.emplace_back(
+         label.getT0(), label.getT1(),
+         std::make_unique<LabelTrack::IntervalData>( ii++ ) );
+   return result;
+}
+
+auto LabelTrack::GetIntervals() const -> ConstIntervals
+{
+   return MakeIntervals<ConstIntervals>(mLabels);
+}
+
+auto LabelTrack::GetIntervals() -> Intervals
+{
+   return MakeIntervals<Intervals>(mLabels);
+}
+
 void LabelTrack::SetLabel( size_t iLabel, const LabelStruct &newLabel )
 {
    if( iLabel >= mLabels.size() ) {

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -155,6 +155,13 @@ public:
    int FindNextLabel(const SelectedRegion& currentSelection);
    int FindPrevLabel(const SelectedRegion& currentSelection);
 
+   struct IntervalData final : Track::IntervalData {
+      size_t index;
+      explicit IntervalData(size_t index) : index{index} {};
+   };
+   ConstIntervals GetIntervals() const override;
+   Intervals GetIntervals() override;
+
  public:
    void SortLabels();
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -683,6 +683,20 @@ QuantizedTimeAndBeat NoteTrack::NearestBeatTime( double time ) const
    return { seq_time + GetOffset(), beat };
 }
 
+auto NoteTrack::GetIntervals() const -> ConstIntervals
+{
+   ConstIntervals results;
+   results.emplace_back( GetStartTime(), GetEndTime() );
+   return results;
+}
+
+auto NoteTrack::GetIntervals() -> Intervals
+{
+   Intervals results;
+   results.emplace_back( GetStartTime(), GetEndTime() );
+   return results;
+}
+
 void NoteTrack::AddToDuration( double delta )
 {
    auto &seq = GetSeq();

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -185,6 +185,9 @@ public:
          mVisibleChannels = CHANNEL_BIT(c);
    }
 
+   ConstIntervals GetIntervals() const override;
+   Intervals GetIntervals() override;
+
  private:
 
    TrackKind GetKind() const override { return TrackKind::Note; }

--- a/src/Snap.h
+++ b/src/Snap.h
@@ -21,31 +21,9 @@
 
 class AudacityProject;
 class Track;
-using TrackArray = std::vector< Track* >;
-class TrackClipArray;
-class WaveClip;
-class WaveTrack;
 class TrackList;
 class ZoomInfo;
 class wxDC;
-
-class TrackClip
-{
-public:
-   TrackClip(Track *t, WaveClip *c);
-
-   ~TrackClip();
-
-   Track *track;
-   Track *origTrack;
-   WaveClip *clip;
-
-   // These fields are used only during time-shift dragging
-   WaveTrack *dstTrack;
-   std::shared_ptr<WaveClip> holder;
-};
-
-class TrackClipArray : public std::vector < TrackClip > {};
 
 const int kPixelTolerance = 4;
 
@@ -77,12 +55,18 @@ struct SnapResults {
 class SnapManager
 {
 public:
-   SnapManager(const TrackList *tracks,
-               const ZoomInfo *zoomInfo,
-               const TrackClipArray *clipExclusions = NULL,
-               const TrackArray *trackExclusions = NULL,
+   SnapManager(const AudacityProject &project,
+               SnapPointArray candidates,
+               const ZoomInfo &zoomInfo,
                bool noTimeSnap = false,
                int pixelTolerance = kPixelTolerance);
+
+   SnapManager(const AudacityProject &project,
+               const TrackList &tracks,
+               const ZoomInfo &zoomInfo,
+               bool noTimeSnap = false,
+               int pixelTolerance = kPixelTolerance);
+
    ~SnapManager();
 
    // The track may be NULL.
@@ -111,23 +95,22 @@ private:
 private:
 
    const AudacityProject *mProject;
-   const TrackList *mTracks;
-   const TrackClipArray *mClipExclusions;
-   const TrackArray *mTrackExclusions;
    const ZoomInfo *mZoomInfo;
    int mPixelTolerance;
    bool mNoTimeSnap;
    
-   double mEpsilon;
+   //! Two time points closer than this are considered the same
+   double mEpsilon{ 1 / 44100.0 };
+   SnapPointArray mCandidates;
    SnapPointArray mSnapPoints;
 
    // Info for snap-to-time
    NumericConverter mConverter;
-   bool mSnapToTime;
+   bool mSnapToTime{ false };
 
-   int mSnapTo;
-   double mRate;
-   NumericFormatSymbol mFormat;
+   int mSnapTo{ 0 };
+   double mRate{ 0.0 };
+   NumericFormatSymbol mFormat{};
 };
 
 #endif

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -1224,6 +1224,16 @@ std::shared_ptr<const Track> Track::SubstituteOriginalTrack() const
    return SharedPointer();
 }
 
+auto Track::GetIntervals() const -> ConstIntervals
+{
+   return {};
+}
+
+auto Track::GetIntervals() -> Intervals
+{
+   return {};
+}
+
 // Serialize, not with tags of its own, but as attributes within a tag.
 void Track::WriteCommonXMLAttributes(
    XMLWriter &xmlFile, bool includeNameAndSelected) const
@@ -1268,6 +1278,8 @@ void Track::AdjustPositions()
       pList->ResizingEvent(mNode);
    }
 }
+
+TrackIntervalData::~TrackIntervalData() = default;
 
 bool TrackList::HasPendingTracks() const
 {

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -979,11 +979,16 @@ std::shared_ptr<WaveClip> WaveTrack::RemoveAndReturnClip(WaveClip* clip)
       return {};
 }
 
-void WaveTrack::AddClip(std::shared_ptr<WaveClip> &&clip)
+bool WaveTrack::AddClip(const std::shared_ptr<WaveClip> &clip)
 {
+   if (clip->GetSequence()->GetFactory() != this->mpFactory)
+      return false;
+
    // Uncomment the following line after we correct the problem of zero-length clips
    //if (CanInsertClip(clip))
-      mClips.push_back(std::move(clip)); // transfer ownership
+      mClips.push_back(clip); // transfer ownership
+
+   return true;
 }
 
 /*! @excsafety{Strong} */
@@ -2254,7 +2259,8 @@ bool WaveTrack::CanOffsetClip(WaveClip* clip, double amount,
       return true;
 }
 
-bool WaveTrack::CanInsertClip(WaveClip* clip,  double &slideBy, double &tolerance)
+bool WaveTrack::CanInsertClip(
+   WaveClip* clip,  double &slideBy, double &tolerance) const
 {
    for (const auto &c : mClips)
    {

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -323,6 +323,27 @@ int WaveTrack::ZeroLevelYCoordinate(wxRect rect) const
       (int)((mDisplayMax / (mDisplayMax - mDisplayMin)) * rect.height);
 }
 
+template< typename Container >
+static Container MakeIntervals(const std::vector<WaveClipHolder> &clips)
+{
+   Container result;
+   for (const auto &clip: clips) {
+      result.emplace_back( clip->GetStartTime(), clip->GetEndTime(),
+         std::make_unique<WaveTrack::IntervalData>( clip ) );
+   }
+   return result;
+}
+
+auto WaveTrack::GetIntervals() const -> ConstIntervals
+{
+   return MakeIntervals<ConstIntervals>( mClips );
+}
+
+auto WaveTrack::GetIntervals() -> Intervals
+{
+   return MakeIntervals<Intervals>( mClips );
+}
+
 Track::Holder WaveTrack::Clone() const
 {
    return std::make_shared<WaveTrack>( *this );

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -465,11 +465,16 @@ private:
    WaveClipPointers SortedClipArray();
    WaveClipConstPointers SortedClipArray() const;
 
-   // Before calling 'Offset' on a clip, use this function to see if the
-   // offsetting is allowed with respect to the other clips in this track.
-   // This function can optionally return the amount that is allowed for offsetting
-   // in this direction maximally.
-   bool CanOffsetClip(WaveClip* clip, double amount, double *allowedAmount=NULL);
+   //! Decide whether the clips could be offset (and inserted) together without overlapping other clips
+   /*!
+   @return true if possible to offset by `(allowedAmount ? *allowedAmount : amount)`
+    */
+   bool CanOffsetClips(
+      const std::vector<WaveClip*> &clips, //!< not necessarily in this track
+      double amount, //!< signed
+      double *allowedAmount = nullptr /*!<
+         [out] if null, test exact amount only; else, largest (in magnitude) possible offset with same sign */
+   );
 
    // Before moving a clip into a track (or inserting a clip), use this
    // function to see if the times are valid (i.e. don't overlap with

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -523,6 +523,20 @@ private:
    // bottom and top.  Maybe that is out of bounds.
    int ZeroLevelYCoordinate(wxRect rect) const;
 
+   class IntervalData final : public Track::IntervalData {
+   public:
+      explicit IntervalData( const std::shared_ptr<WaveClip> &pClip )
+      : pClip{ pClip }
+      {}
+      std::shared_ptr<const WaveClip> GetClip() const { return pClip; }
+      std::shared_ptr<WaveClip> &GetClip() { return pClip; }
+   private:
+      std::shared_ptr<WaveClip> pClip;
+   };
+
+   ConstIntervals GetIntervals() const override;
+   Intervals GetIntervals() override;
+
  protected:
    //
    // Protected variables

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -474,14 +474,14 @@ private:
    // Before moving a clip into a track (or inserting a clip), use this
    // function to see if the times are valid (i.e. don't overlap with
    // existing clips).
-   bool CanInsertClip(WaveClip* clip, double &slideBy, double &tolerance);
+   bool CanInsertClip(WaveClip* clip, double &slideBy, double &tolerance) const;
 
    // Remove the clip from the track and return a SMART pointer to it.
    // You assume responsibility for its memory!
    std::shared_ptr<WaveClip> RemoveAndReturnClip(WaveClip* clip);
 
-   // Append a clip to the track
-   void AddClip(std::shared_ptr<WaveClip> &&clip); // Call using std::move
+   //! Append a clip to the track; which must have the same block factory as this track; return success
+   bool AddClip(const std::shared_ptr<WaveClip> &clip);
 
    // Merge two clips, that is append data from clip2 to clip1,
    // then remove clip2 from track.

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -201,12 +201,13 @@ bool EffectReverse::ProcessOneWave(int count, WaveTrack * track, sampleCount sta
    // PRL:  I don't think that matters, the sequence of storage of clips in the track
    // is not elsewhere assumed to be by time
    {
-      for (auto it = revClips.rbegin(), revEnd = revClips.rend(); it != revEnd; ++it)
-         track->AddClip(std::move(*it));
+      for (auto it = revClips.rbegin(), revEnd = revClips.rend(); rValue && it != revEnd; ++it)
+         rValue = track->AddClip(*it);
    }
 
    for (auto &clip : otherClips)
-      track->AddClip(std::move(clip));
+      if (!(rValue = track->AddClip(clip)))
+          break;
 
    return rValue;
 }

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -659,8 +659,7 @@ double DoClipMove
       auto desiredT0 = viewInfo.OffsetTimeByPixels( t0, ( right ? 1 : -1 ) );
       auto desiredSlideAmount = pShifter->HintOffsetLarger( desiredT0 - t0 );
 
-      auto hSlideAmount =
-         state.DoSlideHorizontal( desiredSlideAmount, trackList );
+      auto hSlideAmount = state.DoSlideHorizontal( desiredSlideAmount );
 
       // update t0 and t1. There is the possibility that the updated
       // t0 may no longer be within the clip due to rounding errors,

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -627,10 +627,10 @@ void DoCursorClipBoundary
 }
 
 // This function returns the amount moved.  Possibly 0.0.
-double DoClipMove
-   ( ViewInfo &viewInfo, Track *track,
+double DoClipMove( AudacityProject &project, Track *track,
      TrackList &trackList, bool syncLocked, bool right )
 {
+   auto &viewInfo = ViewInfo::Get(project);
    auto &selectedRegion = viewInfo.selectedRegion;
 
    if (track) {
@@ -641,9 +641,11 @@ double DoClipMove
       std::unique_ptr<TrackShifter> uShifter;
 
       // Find the first channel that has a clip at time t0
+      auto hitTestResult = TrackShifter::HitTestResult::Track;
       for (auto channel : TrackList::Channels(track) ) {
-         uShifter = MakeTrackShifter::Call( *track );
-         if( uShifter->HitTest( t0 ) == TrackShifter::HitTestResult::Miss )
+         uShifter = MakeTrackShifter::Call( *track, project );
+         if ( (hitTestResult = uShifter->HitTest( t0, viewInfo )) ==
+             TrackShifter::HitTestResult::Miss )
             uShifter.reset();
          else
             break;
@@ -653,7 +655,7 @@ double DoClipMove
          return 0.0;
       auto pShifter = uShifter.get();
 
-      state.Init( *track, std::move( uShifter ),
+      state.Init( project, *track, hitTestResult, std::move( uShifter ),
          t0, viewInfo, trackList, syncLocked );
 
       auto desiredT0 = viewInfo.OffsetTimeByPixels( t0, ( right ? 1 : -1 ) );
@@ -700,7 +702,7 @@ void DoClipLeftOrRight
    auto &tracks = TrackList::Get( project );
    auto isSyncLocked = settings.IsSyncLocked();
 
-   auto amount = DoClipMove( viewInfo, trackFocus.Get(),
+   auto amount = DoClipMove( project, trackFocus.Get(),
         tracks, isSyncLocked, right );
 
    window.ScrollIntoView(selectedRegion.t0());

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -633,8 +633,7 @@ double DoClipMove
 {
    auto &selectedRegion = viewInfo.selectedRegion;
 
-   // just dealing with clips in wave tracks for the moment. Note tracks??
-   if (track) return track->TypeSwitch<double>( [&]( WaveTrack *wt ) {
+   if (track) {
       ClipMoveState state;
 
       auto t0 = selectedRegion.t0();
@@ -642,8 +641,8 @@ double DoClipMove
       std::unique_ptr<TrackShifter> uShifter;
 
       // Find the first channel that has a clip at time t0
-      for (auto channel : TrackList::Channels(wt) ) {
-         uShifter = MakeTrackShifter::Call( *wt );
+      for (auto channel : TrackList::Channels(track) ) {
+         uShifter = MakeTrackShifter::Call( *track );
          if( uShifter->HitTest( t0 ) == TrackShifter::HitTestResult::Miss )
             uShifter.reset();
          else
@@ -680,7 +679,7 @@ double DoClipMove
       }
 
       return hSlideAmount;
-   } );
+   };
    return 0.0;
 }
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackView.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackView.cpp
@@ -729,4 +729,41 @@ void NoteTrackView::Draw(
    }
    CommonTrackView::Draw( context, rect, iPass );
 }
+
+#include "../../../ui/TimeShiftHandle.h"
+
+class NoteTrackShifter final : public TrackShifter {
+public:
+   NoteTrackShifter( NoteTrack &track )
+      : mpTrack{ track.SharedPointer<NoteTrack>() }
+   {
+      InitIntervals();
+   }
+   ~NoteTrackShifter() override {}
+   Track &GetTrack() const override { return *mpTrack; }
+   
+   HitTestResult HitTest( double ) override
+   {
+      return HitTestResult::Intervals;
+   }
+
+   void SelectInterval( const TrackInterval &interval ) override
+   {
+      CommonSelectInterval( interval );
+   }
+
+   bool SyncLocks() override { return true; }
+
+private:
+   std::shared_ptr<NoteTrack> mpTrack;
+};
+
+using MakeNoteTrackShifter = MakeTrackShifter::Override<NoteTrack>;
+template<> template<> auto MakeNoteTrackShifter::Implementation() -> Function {
+   return [](NoteTrack &track) {
+      return std::make_unique<NoteTrackShifter>(track);
+   };
+}
+static MakeNoteTrackShifter registerMakeNoteTrackShifter;
+
 #endif

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackView.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackView.cpp
@@ -742,9 +742,16 @@ public:
    ~NoteTrackShifter() override {}
    Track &GetTrack() const override { return *mpTrack; }
    
-   HitTestResult HitTest( double ) override
+   HitTestResult HitTest(
+      double time, const ViewInfo &viewInfo, HitTestParams* ) override
    {
-      return HitTestResult::Intervals;
+      UnfixAll();
+      auto t0 = viewInfo.selectedRegion.t0();
+      auto t1 = viewInfo.selectedRegion.t1();
+      if ( mpTrack->IsSelected() && time >= t0 && time < t1 )
+         return HitTestResult::Selection;
+      else
+         return HitTestResult::Intervals;
    }
 
    void SelectInterval( const TrackInterval &interval ) override
@@ -760,7 +767,7 @@ private:
 
 using MakeNoteTrackShifter = MakeTrackShifter::Override<NoteTrack>;
 template<> template<> auto MakeNoteTrackShifter::Implementation() -> Function {
-   return [](NoteTrack &track) {
+   return [](NoteTrack &track, AudacityProject&) {
       return std::make_unique<NoteTrackShifter>(track);
    };
 }

--- a/src/tracks/ui/SelectHandle.cpp
+++ b/src/tracks/ui/SelectHandle.cpp
@@ -432,7 +432,8 @@ SelectHandle::SelectHandle
   const TrackList &trackList,
   const TrackPanelMouseState &st, const ViewInfo &viewInfo )
    : mpView{ pTrackView }
-   , mSnapManager{ std::make_shared<SnapManager>(&trackList, &viewInfo) }
+   , mSnapManager{ std::make_shared<SnapManager>(
+      *trackList.GetOwner(), trackList, viewInfo) }
 {
    const wxMouseState &state = st.state;
    mRect = st.rect;

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -162,13 +162,10 @@ namespace
    // duplication of this logic)
    void AddClipsToCaptured
       ( ClipMoveState &state, const ViewInfo &viewInfo,
-        Track *t, bool withinSelection )
+        Track *t )
    {
-      if (withinSelection)
-         AddClipsToCaptured( state, t, viewInfo.selectedRegion.t0(),
-                            viewInfo.selectedRegion.t1() );
-      else
-         AddClipsToCaptured( state, t, t->GetStartTime(), t->GetEndTime() );
+      AddClipsToCaptured( state, t, viewInfo.selectedRegion.t0(),
+                         viewInfo.selectedRegion.t1() );
    }
 
    WaveTrack *NthChannel(WaveTrack &leader, int nn)
@@ -260,7 +257,7 @@ void TimeShiftHandle::CreateListOfCapturedClips
    // just the clicked-on clip
    if ( state.capturedClipIsSelection )
       for (auto t : trackList.Selected())
-         AddClipsToCaptured( state, viewInfo, t, true );
+         AddClipsToCaptured( state, viewInfo, t );
    else {
       state.capturedClipArray.push_back
          (TrackClip( &capturedTrack, state.capturedClip ));

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -45,9 +45,9 @@ TrackClip::~TrackClip()
 
 TimeShiftHandle::TimeShiftHandle
 ( const std::shared_ptr<Track> &pTrack, bool gripHit )
-   : mCapturedTrack{ pTrack }
-   , mGripHit{ gripHit }
+   : mGripHit{ gripHit }
 {
+   mClipMoveState.mCapturedTrack = pTrack;
 }
 
 void TimeShiftHandle::Enter(bool, AudacityProject *)
@@ -121,11 +121,9 @@ namespace
    void AddClipsToCaptured
       ( ClipMoveState &state, Track *t, double t0, double t1 )
    {
-      bool exclude = true; // to exclude a whole track.
       auto &clips = state.capturedClipArray;
       t->TypeSwitch(
          [&](WaveTrack *wt) {
-            exclude = false;
             for(const auto &clip: wt->GetClips())
                if ( ! clip->IsClipStartAfterClip(t0) && ! clip->BeforeClip(t1) &&
                   // Avoid getting clips that were already captured
@@ -154,8 +152,6 @@ namespace
             }
          }
       );
-      if (exclude)
-         state.trackExclusions.push_back(t);
    }
 
    // Helper for the above, adds a track's clips to capturedClipArray (eliminates
@@ -244,21 +240,132 @@ namespace
    }
 }
 
-void TimeShiftHandle::CreateListOfCapturedClips
-   ( ClipMoveState &state, const ViewInfo &viewInfo, Track &capturedTrack,
-     TrackList &trackList, bool syncLocked, double clickTime )
+TrackShifter::~TrackShifter() = default;
+
+void TrackShifter::UnfixIntervals(
+   std::function< bool( const TrackInterval& ) > pred )
 {
+   for ( auto iter = mFixed.begin(); iter != mFixed.end(); ) {
+      if ( pred( *iter) ) {
+         mMoving.push_back( std::move( *iter ) );
+         iter = mFixed.erase( iter );
+      }
+      else
+         ++iter;
+   }
+}
+
+void TrackShifter::UnfixAll()
+{
+   std::move( mFixed.begin(), mFixed.end(), std::back_inserter(mMoving) );
+   mFixed = Intervals{};
+}
+
+void TrackShifter::SelectInterval( const TrackInterval & )
+{
+   UnfixAll();
+}
+
+void TrackShifter::CommonSelectInterval(const TrackInterval &interval)
+{
+   UnfixIntervals( [&](auto &myInterval){
+      return !(interval.End() < myInterval.Start() ||
+               myInterval.End() < interval.Start());
+   });
+}
+
+double TrackShifter::HintOffsetLarger(double desiredOffset)
+{
+   return desiredOffset;
+}
+
+void TrackShifter::InitIntervals()
+{
+   mMoving.clear();
+   mFixed = GetTrack().GetIntervals();
+}
+
+CoarseTrackShifter::CoarseTrackShifter( Track &track )
+   : mpTrack{ track.SharedPointer() }
+{
+   InitIntervals();
+}
+
+CoarseTrackShifter::~CoarseTrackShifter() = default;
+
+auto CoarseTrackShifter::HitTest( double ) -> HitTestResult
+{
+   return HitTestResult::Track;
+}
+
+bool CoarseTrackShifter::SyncLocks()
+{
+   return false;
+}
+
+template<> auto MakeTrackShifter::Implementation() -> Function {
+   return [](Track &track) {
+      return std::make_unique<CoarseTrackShifter>(track);
+   };
+}
+
+void ClipMoveState::Init(
+   Track &capturedTrack,
+   std::unique_ptr<TrackShifter> pHit,
+   double clickTime,
+   const ViewInfo &viewInfo,
+   TrackList &trackList, bool syncLocked )
+{
+   capturedClipArray.clear();
+   shifters.clear();
+   auto cleanup = finally([&]{
+      // In transition, this class holds two representations of what to shift.
+      // Be sure each is filled only if the other is.
+      wxASSERT( capturedClipArray.empty() == shifters.empty() );
+   });
+
+   auto &state = *this;
+   state.mCapturedTrack = capturedTrack.SharedPointer();
+
+   state.movingSelection = capturedTrack.IsSelected() &&
+      clickTime >= viewInfo.selectedRegion.t0() &&
+      clickTime < viewInfo.selectedRegion.t1();
+
+   if (!pHit)
+      return;
+
+   const bool capturedAClip =
+      pHit && !pHit->MovingIntervals().empty();
+   if ( capturedAClip ) {
+      // There is still some code special to WaveTracks here that
+      // needs to go elsewhere
+      auto &interval = pHit->MovingIntervals()[0];
+      auto pInfo =
+         dynamic_cast<WaveTrack::IntervalData*>(interval.Extra());
+      if ( pInfo )
+         state.capturedClip = pInfo->GetClip().get();
+   }
+
+   state.shifters[&capturedTrack] = std::move( pHit );
+
+   // Collect TrackShifters for the rest of the tracks
+   for ( auto track : trackList.Any() ) {
+      auto &pShifter = state.shifters[track];
+      if (!pShifter)
+         pShifter = MakeTrackShifter::Call( *track );
+   }
+
 // The captured clip is the focus, but we need to create a list
    // of all clips that have to move, also...
 
-   state.capturedClipArray.clear();
-
    // First, if click was in selection, capture selected clips; otherwise
    // just the clicked-on clip
-   if ( state.capturedClipIsSelection )
+   if ( state.movingSelection )
+      // All selected tracks may move some intervals
       for (auto t : trackList.Selected())
          AddClipsToCaptured( state, viewInfo, t );
    else {
+      // Move intervals only of the chosen channel group
       state.capturedClipArray.push_back
          (TrackClip( &capturedTrack, state.capturedClip ));
 
@@ -274,6 +381,7 @@ void TimeShiftHandle::CreateListOfCapturedClips
    // Now, if sync-lock is enabled, capture any clip that's linked to a
    // captured clip.
    if ( syncLocked ) {
+      // Sync lock propagation of unfixing of intervals
       // AWD: capturedClipArray expands as the loop runs, so newly-added
       // clips are considered (the effect is like recursion and terminates
       // because AddClipsToCaptured doesn't add duplicate clips); to remove
@@ -305,11 +413,96 @@ void TimeShiftHandle::CreateListOfCapturedClips
 #endif
       }
    }
+
+   // Analogy of the steps above, but with TrackShifters, follows below
+   
+   if ( state.movingSelection ) {
+      // All selected tracks may move some intervals
+      const TrackInterval interval{
+         viewInfo.selectedRegion.t0(),
+         viewInfo.selectedRegion.t1()
+      };
+      for ( const auto &pair : state.shifters ) {
+         auto &shifter = *pair.second;
+         auto &track = shifter.GetTrack();
+         if ( track.IsSelected() )
+            shifter.SelectInterval( interval );
+      }
+   }
+   else {
+      // Move intervals only of the chosen channel group
+      for ( auto channel : TrackList::Channels( &capturedTrack ) ) {
+         auto &shifter = *state.shifters[channel];
+         if ( capturedAClip ) {
+            if ( channel != &capturedTrack )
+               shifter.SelectInterval(TrackInterval{clickTime, clickTime});
+         }
+         else
+            shifter.UnfixAll();
+      }
+   }
+   
+   // Sync lock propagation of unfixing of intervals
+   if ( syncLocked ) {
+      bool change = true;
+      while( change ) {
+         change = false;
+
+         // Iterate over all unfixed intervals in all shifters
+         // that do propagation...
+         for ( auto &pair : state.shifters ) {
+            auto &shifter = *pair.second.get();
+            if (!shifter.SyncLocks())
+               continue;
+            auto &track = shifter.GetTrack();
+            auto &intervals = shifter.MovingIntervals();
+            for (auto &interval : intervals) {
+
+               // ...and tell all other tracks to select that interval...
+               for ( auto &pair2 : state.shifters ) {
+                  auto &shifter2 = *pair2.second.get();
+                  if (&shifter2.GetTrack() == &track)
+                     continue;
+                  auto size = shifter2.MovingIntervals().size();
+                  shifter2.SelectInterval( interval );
+                  change = change ||
+                     (shifter2.SyncLocks() &&
+                      size != shifter2.MovingIntervals().size());
+               }
+
+            }
+         }
+
+         // ... and repeat if any other interval became unfixed in a
+         // shifter that propagates
+      }
+   }
 }
 
-void TimeShiftHandle::DoSlideHorizontal
-   ( ClipMoveState &state, TrackList &trackList, Track &capturedTrack )
+const TrackInterval *ClipMoveState::CapturedInterval() const
 {
+   auto pTrack = mCapturedTrack.get();
+   if ( pTrack ) {
+      auto iter = shifters.find( pTrack );
+      if ( iter != shifters.end() ) {
+         auto &pShifter = iter->second;
+         if ( pShifter ) {
+            auto &intervals = pShifter->MovingIntervals();
+            if ( !intervals.empty() )
+               return &intervals[0];
+         }
+      }
+   }
+   return nullptr;
+}
+
+double ClipMoveState::DoSlideHorizontal(
+   double desiredSlideAmount, TrackList &trackList )
+{
+   auto &state = *this;
+   auto &capturedTrack = *state.mCapturedTrack;
+   state.hSlideAmount = desiredSlideAmount;
+
    // Given a signed slide distance, move clips, but subject to constraint of
    // non-overlapping with other clips, so the distance may be adjusted toward
    // zero.
@@ -358,62 +551,27 @@ void TimeShiftHandle::DoSlideHorizontal
       // For Shift key down, or
       // For non wavetracks, specifically label tracks ...
       DoOffset( state, &capturedTrack, state.hSlideAmount );
+
+   return state.hSlideAmount;
 }
 
-#include "LabelTrack.h"
 namespace {
 SnapPointArray FindCandidates(
-   const TrackList &tracks,
-   const TrackClipArray &clipExclusions, const TrackArray &trackExclusions )
+   const TrackList &tracks, const ClipMoveState::ShifterMap &shifters )
 {
-   // Special case restricted candidates for time shift
+   // Compare with the other function FindCandidates in Snap
+   // Make the snap manager more selective than it would be if just constructed
+   // from the track list
    SnapPointArray candidates;
-   auto trackRange =
-      tracks.Any()
-         - [&](const Track *pTrack){
-            return
-               make_iterator_range( trackExclusions ).contains( pTrack );
-         };
-   trackRange.Visit(
-      [&](const LabelTrack *labelTrack) {
-         for (const auto &label : labelTrack->GetLabels())
-         {
-            const double t0 = label.getT0();
-            const double t1 = label.getT1();
-            candidates.emplace_back(t0, labelTrack);
-            if (t1 != t0)
-               candidates.emplace_back(t1, labelTrack);
-         }
-      },
-      [&](const WaveTrack *waveTrack) {
-         for (const auto &clip: waveTrack->GetClips())
-         {
-            bool skip = false;
-            for (const auto &exclusion : clipExclusions)
-            {
-               if (exclusion.track == waveTrack &&
-                   exclusion.clip == clip.get())
-               {
-                  skip = true;
-                  break;
-               }
-            }
-
-            if (skip)
-               continue;
-
-            candidates.emplace_back(clip->GetStartTime(), waveTrack);
-            candidates.emplace_back(clip->GetEndTime(), waveTrack);
-         }
+   for ( const auto &pair : shifters ) {
+      auto &shifter = pair.second;
+      auto &track = shifter->GetTrack();
+      for (const auto &interval : shifter->FixedIntervals() ) {
+         candidates.emplace_back( interval.Start(), &track );
+         if ( interval.Start() != interval.End() )
+            candidates.emplace_back( interval.End(), &track );
       }
-#ifdef USE_MIDI
-      ,
-      [&](const NoteTrack *track) {
-         candidates.emplace_back(track->GetStartTime(), track);
-         candidates.emplace_back(track->GetEndTime(), track);
-      }
-#endif
-   );
+   }
    return candidates;
 }
 }
@@ -445,56 +603,53 @@ UIHandle::Result TimeShiftHandle::Click
 
    const double clickTime =
       viewInfo.PositionToTime(event.m_x, rect.x);
-   mClipMoveState.capturedClipIsSelection =
-      (pTrack->GetSelected() &&
-       clickTime >= viewInfo.selectedRegion.t0() &&
-       clickTime < viewInfo.selectedRegion.t1());
 
    mClipMoveState.capturedClip = NULL;
    mClipMoveState.capturedClipArray.clear();
 
-   bool ok = true;
    bool captureClips = false;
 
-   if (!event.ShiftDown())
-      pTrack->TypeSwitch(
-         [&](WaveTrack *wt) {
-            if (nullptr ==
-               (mClipMoveState.capturedClip = wt->GetClipAtX(event.m_x)))
-               ok = false;
-            else
-               captureClips = true;
-#ifdef USE_MIDI
-         },
-         [&](NoteTrack *) {
-            captureClips = true;
-#endif
-         }
-      );
+   auto pShifter = MakeTrackShifter::Call( *pTrack );
 
-   if ( ! ok )
-      return Cancelled;
-   else if ( captureClips )
-      CreateListOfCapturedClips(
-         mClipMoveState, viewInfo, *pTrack, trackList,
-         ProjectSettings::Get( *pProject ).IsSyncLocked(), clickTime );
+   if (!event.ShiftDown()) {
+      switch( pShifter->HitTest( clickTime ) ) {
+      case TrackShifter::HitTestResult::Miss:
+         return Cancelled;
+      case TrackShifter::HitTestResult::Intervals: {
+         captureClips = true;
+         break;
+      }
+      case TrackShifter::HitTestResult::Track:
+      default:
+         break;
+      }
+   }
+   else {
+      // As in the default above: just do shifting of one whole track
+   }
+
+   mClipMoveState.Init( *pTrack,
+      captureClips ? std::move( pShifter ) : nullptr,
+      clickTime,
+
+      viewInfo, trackList,
+      ProjectSettings::Get( *pProject ).IsSyncLocked() );
 
    mSlideUpDownOnly = event.CmdDown() && !multiToolModeActive;
    mRect = rect;
    mClipMoveState.mMouseClickX = event.m_x;
    mSnapManager =
    std::make_shared<SnapManager>(*trackList.GetOwner(),
-       FindCandidates( trackList,
-         mClipMoveState.capturedClipArray, mClipMoveState.trackExclusions),
+       FindCandidates( trackList, mClipMoveState.shifters ),
        viewInfo,
        true, // don't snap to time
        kPixelTolerance);
    mClipMoveState.snapLeft = -1;
    mClipMoveState.snapRight = -1;
-   mSnapPreferRightEdge =
-      mClipMoveState.capturedClip &&
-      (fabs(clickTime - mClipMoveState.capturedClip->GetEndTime()) <
-       fabs(clickTime - mClipMoveState.capturedClip->GetStartTime()));
+   auto pInterval = mClipMoveState.CapturedInterval();
+   mSnapPreferRightEdge = pInterval &&
+      (fabs(clickTime - pInterval->End()) <
+       fabs(clickTime - pInterval->Start()));
 
    return RefreshNone;
 }
@@ -523,11 +678,10 @@ namespace {
 
          // Adjust desiredSlideAmount using SnapManager
          if (pSnapManager) {
-            if (state.capturedClip) {
-               clipLeft = state.capturedClip->GetStartTime()
-                  + desiredSlideAmount;
-               clipRight = state.capturedClip->GetEndTime()
-                  + desiredSlideAmount;
+            auto pInterval = state.CapturedInterval();
+            if (pInterval) {
+               clipLeft = pInterval->Start() + desiredSlideAmount;
+               clipRight = pInterval->End() + desiredSlideAmount;
             }
             else {
                clipLeft = capturedTrack.GetStartTime() + desiredSlideAmount;
@@ -724,7 +878,7 @@ bool TimeShiftHandle::DoSlideVertical
       // Make the offset permanent; start from a "clean slate"
       if( ok ) {
          state.mMouseClickX = xx;
-         if (state.capturedClipIsSelection) {
+         if (state.movingSelection) {
             // Slide the selection, too
             viewInfo.selectedRegion.move( slide );
          }
@@ -765,7 +919,7 @@ UIHandle::Result TimeShiftHandle::Drag
       // within the bounds of the tracks area.
       if (event.m_x >= mRect.GetX() &&
          event.m_x < mRect.GetX() + mRect.GetWidth())
-          track = mCapturedTrack.get();
+          track = mClipMoveState.mCapturedTrack.get();
    }
 
    // May need a shared_ptr to reassign mCapturedTrack below
@@ -776,16 +930,16 @@ UIHandle::Result TimeShiftHandle::Drag
 
    auto &trackList = TrackList::Get( *pProject );
 
-   // GM: DoSlide now implementing snap-to
+   // GM: slide now implementing snap-to
    // samples functionality based on sample rate.
 
    // Start by undoing the current slide amount; everything
    // happens relative to the original horizontal position of
    // each clip...
    DoOffset(
-      mClipMoveState, mCapturedTrack.get(), -mClipMoveState.hSlideAmount );
+      mClipMoveState, mClipMoveState.mCapturedTrack.get(), -mClipMoveState.hSlideAmount );
 
-   if ( mClipMoveState.capturedClipIsSelection ) {
+   if ( mClipMoveState.movingSelection ) {
       // Slide the selection, too
       viewInfo.selectedRegion.move( -mClipMoveState.hSlideAmount );
    }
@@ -794,7 +948,7 @@ UIHandle::Result TimeShiftHandle::Drag
    double desiredSlideAmount =
       FindDesiredSlideAmount( viewInfo, mRect.x, event, mSnapManager.get(),
          mSlideUpDownOnly, mSnapPreferRightEdge, mClipMoveState,
-         *mCapturedTrack, *pTrack );
+         *mClipMoveState.mCapturedTrack, *pTrack );
 
    // Scroll during vertical drag.
    // EnsureVisible(pTrack); //vvv Gale says this has problems on Linux, per bug 393 thread. Revert for 2.0.2.
@@ -804,12 +958,12 @@ UIHandle::Result TimeShiftHandle::Drag
    // decide which tracks the captured clips should go to.
    bool fail = (
       mClipMoveState.capturedClip &&
-       pTrack != mCapturedTrack
+       pTrack != mClipMoveState.mCapturedTrack
        /* && !mCapturedClipIsSelection*/
       && pTrack->TypeSwitch<bool>( [&] (WaveTrack *) {
             if ( DoSlideVertical( viewInfo, event.m_x, mClipMoveState,
-                     trackList, *mCapturedTrack, *pTrack, desiredSlideAmount ) ) {
-               mCapturedTrack = pTrack;
+                     trackList, *mClipMoveState.mCapturedTrack, *pTrack, desiredSlideAmount ) ) {
+               mClipMoveState.mCapturedTrack = pTrack;
                mDidSlideVertically = true;
             }
             else
@@ -827,11 +981,11 @@ UIHandle::Result TimeShiftHandle::Drag
    if (desiredSlideAmount == 0.0)
       return RefreshAll;
 
-   mClipMoveState.hSlideAmount = desiredSlideAmount;
+   // Note that mouse dragging doesn't use TrackShifter::HintOffsetLarger()
 
-   DoSlideHorizontal( mClipMoveState, trackList, *mCapturedTrack );
+   mClipMoveState.DoSlideHorizontal( desiredSlideAmount, trackList );
 
-   if (mClipMoveState.capturedClipIsSelection) {
+   if (mClipMoveState.movingSelection) {
       // Slide the selection, too
       viewInfo.selectedRegion.move( mClipMoveState.hSlideAmount );
    }

--- a/src/tracks/ui/TimeShiftHandle.h
+++ b/src/tracks/ui/TimeShiftHandle.h
@@ -13,10 +13,31 @@ Paul Licameli
 
 #include "../../UIHandle.h"
 
-#include "../../Snap.h"
-
+class SnapManager;
+class Track;
+using TrackArray = std::vector<Track*>;
+class TrackList;
 class ViewInfo;
 class WaveClip;
+class WaveTrack;
+
+class TrackClip
+{
+public:
+   TrackClip(Track *t, WaveClip *c);
+
+   ~TrackClip();
+
+   Track *track;
+   Track *origTrack;
+   WaveClip *clip;
+
+   // These fields are used only during time-shift dragging
+   WaveTrack *dstTrack;
+   std::shared_ptr<WaveClip> holder;
+};
+
+using TrackClipArray = std::vector <TrackClip>;
 
 struct ClipMoveState {
    // non-NULL only if click was in a WaveTrack and without Shift key:

--- a/src/tracks/ui/TimeShiftHandle.h
+++ b/src/tracks/ui/TimeShiftHandle.h
@@ -25,6 +25,8 @@ class TrackList;
 class Track;
 class TrackInterval;
 
+class ViewInfo;
+
 //! Abstract base class for policies to manipulate a track type with the Time Shift tool
 class TrackShifter {
 public:
@@ -35,13 +37,28 @@ public:
    //! Possibilities for HitTest on the clicked track
    enum class HitTestResult {
       Miss,      //!< Don't shift anything
-      Intervals, //<! May shift other tracks' intervals, if clicked in selection
-      Track      //<! Shift selected track only as a whole
+      Selection, //!< Shfit chosen intervals of this track; may shift other tracks' intervals
+      Intervals, //!< Shift intervals only of selected track and sister channels
+      Track      //!< Shift selected track and sister channels only, as a whole
+   };
+
+   //! Optional, more complete information for hit testing
+   struct HitTestParams {
+      wxRect rect;
+      wxCoord xx, yy;
    };
 
    //! Decide how shift behaves, based on the track that is clicked in
-   /*! If the return value is Intervals, then some intervals may be marked moving as a side effect */
-   virtual HitTestResult HitTest( double time ) = 0;
+   /*! If the return value is Intervals or Selection,
+       then some intervals may be marked moving as a side effect */
+   /*!
+    @pre `!pParams || (time == pParams->viewInfo.PositionToTime(pParams->xx, pParams->rect.x))`
+    */
+   virtual HitTestResult HitTest(
+      double time, //!< A time value to test
+      const ViewInfo &viewInfo,
+      HitTestParams *pParams = nullptr //!< Optional extra information
+   ) = 0;
 
    using Intervals = std::vector<TrackInterval>;
 
@@ -158,7 +175,7 @@ public:
    ~CoarseTrackShifter() override;
    Track &GetTrack() const override { return *mpTrack; }
 
-   HitTestResult HitTest( double ) override;
+   HitTestResult HitTest( double, const ViewInfo&, HitTestParams* ) override;
 
    //! Returns false
    bool SyncLocks() override;
@@ -169,7 +186,7 @@ private:
 
 struct MakeTrackShifterTag;
 using MakeTrackShifter = AttachedVirtualFunction<
-   MakeTrackShifterTag, std::unique_ptr<TrackShifter>, Track>;
+   MakeTrackShifterTag, std::unique_ptr<TrackShifter>, Track, AudacityProject&>;
 
 class ViewInfo;
 
@@ -178,9 +195,11 @@ struct ClipMoveState {
    
    //! Will associate a TrackShifter with each track in the list
    void Init(
+      AudacityProject &project,
       Track &capturedTrack, //<! pHit if not null associates with this track
+      TrackShifter::HitTestResult hitTestResult, //!< must not be `Miss`
       std::unique_ptr<TrackShifter> pHit, /*!<
-         If null, only capturedTrack (with any sister channels) shifts, as a whole */
+         If null, implies `Track`, overriding previous argument */
       double clickTime,
       const ViewInfo &viewInfo,
       TrackList &trackList, bool syncLocked );

--- a/src/tracks/ui/TimeShiftHandle.h
+++ b/src/tracks/ui/TimeShiftHandle.h
@@ -11,12 +11,102 @@ Paul Licameli
 #ifndef __AUDACITY_TIMESHIFT_HANDLE__
 #define __AUDACITY_TIMESHIFT_HANDLE__
 
+#include <functional>
+#include <unordered_map>
+
+#include "../../AttachedVirtualFunction.h"
 #include "../../UIHandle.h"
 
 class SnapManager;
 class Track;
 using TrackArray = std::vector<Track*>;
 class TrackList;
+
+class Track;
+class TrackInterval;
+
+//! Abstract base class for policies to manipulate a track type with the Time Shift tool
+class TrackShifter {
+public:
+   virtual ~TrackShifter() = 0;
+   //! There is always an associated track
+   virtual Track &GetTrack() const = 0;
+
+   //! Possibilities for HitTest on the clicked track
+   enum class HitTestResult {
+      Miss,      //!< Don't shift anything
+      Intervals, //<! May shift other tracks' intervals, if clicked in selection
+      Track      //<! Shift selected track only as a whole
+   };
+
+   //! Decide how shift behaves, based on the track that is clicked in
+   /*! If the return value is Intervals, then some intervals may be marked moving as a side effect */
+   virtual HitTestResult HitTest( double time ) = 0;
+
+   using Intervals = std::vector<TrackInterval>;
+
+   //! Return special intervals of the track that will not move
+   const Intervals &FixedIntervals() const { return mFixed; }
+
+   //! Return special intervals of the track that may move
+   const Intervals &MovingIntervals() const { return mMoving; }
+   
+   //! Change intervals satisfying a predicate from fixed to moving
+   void UnfixIntervals(
+      std::function< bool( const TrackInterval& ) > pred );
+
+   //! Change all intervals from fixed to moving
+   void UnfixAll();
+
+   //! Notifies the shifter that a region is selected, so it may update its fixed and moving intervals
+   /*! Default behavior:  if any part of the track is selected, unfix all parts of it. */
+   virtual void SelectInterval( const TrackInterval &interval );
+
+   //! Whether unfixing of an interval should propagate to all overlapping intervals in the sync lock group
+   virtual bool SyncLocks() = 0;
+
+   //! Given amount to shift by horizontally, maybe adjust it from zero to suggest minimum distance
+   /*!
+    Any interval placement constraints, not necessarily met at the suggested offset
+    Default implementation returns the argument
+    @post `fabs(r) >= fabs(desiredOffset)`
+    @post `r * desiredOffset >= 0` (i.e. signs are not opposite)
+    @post (where `r` is return value)
+    */
+   virtual double HintOffsetLarger( double desiredOffset );
+
+protected:
+   /*! Unfix any of the intervals that intersect the given one; may be useful to override `SelectInterval()` */
+   void CommonSelectInterval( const TrackInterval &interval );
+
+   //! Derived class constructor can initialize all intervals reported by the track as fixed, none moving
+   /*! This can't be called by the base class constructor, when GetTrack() isn't yet callable */
+   void InitIntervals();
+
+   Intervals mFixed;
+   Intervals mMoving;
+};
+
+//! Used in default of other reimplementations to shift any track as a whole, invoking Track::Offset()
+class CoarseTrackShifter final : public TrackShifter {
+public:
+   CoarseTrackShifter( Track &track );
+   ~CoarseTrackShifter() override;
+   Track &GetTrack() const override { return *mpTrack; }
+
+   HitTestResult HitTest( double ) override;
+
+   //! Returns false
+   bool SyncLocks() override;
+
+private:
+   std::shared_ptr<Track> mpTrack;
+};
+
+struct MakeTrackShifterTag;
+using MakeTrackShifter = AttachedVirtualFunction<
+   MakeTrackShifterTag, std::unique_ptr<TrackShifter>, Track>;
+
 class ViewInfo;
 class WaveClip;
 class WaveTrack;
@@ -40,12 +130,32 @@ public:
 using TrackClipArray = std::vector <TrackClip>;
 
 struct ClipMoveState {
+   using ShifterMap = std::unordered_map<Track*, std::unique_ptr<TrackShifter>>;
+   
+   //! Will associate a TrackShifter with each track in the list
+   void Init(
+      Track &capturedTrack, //<! pHit if not null associates with this track
+      std::unique_ptr<TrackShifter> pHit, /*!<
+         If null, only capturedTrack (with any sister channels) shifts, as a whole */
+      double clickTime,
+      const ViewInfo &viewInfo,
+      TrackList &trackList, bool syncLocked );
+
+   //! Return pointer to the first fixed interval of the captured track, if there is one
+   /*! Pointer may be invalidated by operations on the associated TrackShifter */
+   const TrackInterval *CapturedInterval() const;
+
+   /*! @return actual slide amount, maybe adjusted toward zero from desired */
+   double DoSlideHorizontal( double desiredSlideAmount, TrackList &trackList );
+
+   std::shared_ptr<Track> mCapturedTrack;
+
    // non-NULL only if click was in a WaveTrack and without Shift key:
    WaveClip *capturedClip {};
 
-   bool capturedClipIsSelection {};
-   TrackArray trackExclusions {};
+   bool movingSelection {};
    double hSlideAmount {};
+   ShifterMap shifters;
    TrackClipArray capturedClipArray {};
    wxInt64 snapLeft { -1 }, snapRight { -1 };
 
@@ -54,9 +164,9 @@ struct ClipMoveState {
    void clear()
    {
       capturedClip = nullptr;
-      capturedClipIsSelection = false;
-      trackExclusions.clear();
+      movingSelection = false;
       hSlideAmount = 0;
+      shifters.clear();
       capturedClipArray.clear();
       snapLeft = snapRight = -1;
       mMouseClickX = 0;
@@ -73,19 +183,10 @@ public:
    explicit TimeShiftHandle
    ( const std::shared_ptr<Track> &pTrack, bool gripHit );
 
-   TimeShiftHandle &operator=(const TimeShiftHandle&) = default;
+   TimeShiftHandle &operator=(TimeShiftHandle&&) = default;
 
    bool IsGripHit() const { return mGripHit; }
-   std::shared_ptr<Track> GetTrack() const { return mCapturedTrack; }
-
-   // A utility function also used by menu commands
-   static void CreateListOfCapturedClips
-      ( ClipMoveState &state, const ViewInfo &viewInfo, Track &capturedTrack,
-        TrackList &trackList, bool syncLocked, double clickTime );
-
-   // A utility function also used by menu commands
-   static void DoSlideHorizontal
-      ( ClipMoveState &state, TrackList &trackList, Track &capturedTrack );
+   std::shared_ptr<Track> GetTrack() const = delete;
 
    // Try to move clips from one WaveTrack to another, before also moving
    // by some horizontal amount, which may be slightly adjusted to fit the
@@ -135,7 +236,6 @@ private:
       TrackPanelDrawingContext &,
       const wxRect &rect, const wxRect &panelRect, unsigned iPass ) override;
 
-   std::shared_ptr<Track> mCapturedTrack;
    wxRect mRect{};
 
    bool mDidSlideVertically{};


### PR DESCRIPTION
Combining previous material with new work.

Sufficient to make TimeShiftHandle.cpp independent of all Track subclasses, defining a sufficient interface in TrackShifter.

At commit 2eab9879a57659d6d94bed363ace5067ae924dd2 the postcondition is better stated.  Otherwise commits up to e2353f3146a47678b3c19f8f403c9c46758b6326 have been reviewed before and are unchanged.


