### PR TITLE
Improve 'Import Raw Data' dialog

### DIFF
--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -26,6 +26,7 @@ and sample size to help you importing data of an unknown format.
 
 #include "../FileFormats.h"
 #include "../Prefs.h"
+#include "../ProjectSettings.h"
 #include "../ShuttleGui.h"
 #include "../UserException.h"
 #include "../WaveTrack.h"
@@ -92,7 +93,7 @@ class ImportRawDialog final : public wxDialogWrapper {
 // This function leaves outTracks empty as an indication of error,
 // but may also throw FileException to make use of the application's
 // user visible error reporting.
-void ImportRaw(wxWindow *parent, const wxString &fileName,
+void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString &fileName,
               WaveTrackFactory *trackFactory, TrackHolders &outTracks)
 {
    outTracks.clear();
@@ -127,6 +128,8 @@ void ImportRaw(wxWindow *parent, const wxString &fileName,
          numChannels = 1;
          offset = 0;
       }
+
+      rate = ProjectSettings::Get( project ).GetRate();
 
       numChannels = std::max(1u, numChannels);
       ImportRawDialog dlog(parent, encoding, numChannels, (int)offset, rate);

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -81,7 +81,7 @@ class ImportRawDialog final : public wxDialogWrapper {
    wxChoice   *mChannelChoice;
    wxTextCtrl *mOffsetText;
    wxTextCtrl *mPercentText;
-   wxTextCtrl *mRateText;
+   wxComboBox *mRateText;
 
    int         mNumEncodings;
    ArrayOf<int> mEncodingSubtype;
@@ -418,10 +418,16 @@ ImportRawDialog::ImportRawDialog(wxWindow * parent,
          S.AddUnits(XO("%"));
 
          // Rate text
+         wxArrayStringEx rates;
+         for (int i = 0; i < AudioIOBase::NumStandardRates; i++) {
+            rates.Add(
+               wxString::Format(wxT("%d"), AudioIOBase::StandardRates[i]));
+         }
+
          /* i18n-hint: (noun)*/
-         mRateText = S.AddTextBox(XXO("Sample rate:"),
-                                  wxString::Format(wxT("%d"), (int)mRate),
-                                  12);
+         mRateText = S.AddCombo(XXO("Sample rate:"),
+                                wxString::Format(wxT("%d"), (int)mRate),
+                                rates);
          /* i18n-hint: This is the abbreviation for "Hertz", or
             cycles per second. */
          S.AddUnits(XO("Hz"));

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -24,6 +24,7 @@ and sample size to help you importing data of an unknown format.
 #include "../Audacity.h"
 #include "ImportRaw.h"
 
+#include "../AudioIOBase.h"
 #include "../FileFormats.h"
 #include "../Prefs.h"
 #include "../ProjectSettings.h"
@@ -42,6 +43,7 @@ and sample size to help you importing data of an unknown format.
 #include <wx/defs.h>
 #include <wx/button.h>
 #include <wx/choice.h>
+#include <wx/combobox.h>
 #include <wx/intl.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>

--- a/src/import/ImportRaw.h
+++ b/src/import/ImportRaw.h
@@ -13,6 +13,7 @@
 
 #include "../MemoryX.h"
 
+class AudacityProject;
 class WaveTrackFactory;
 class WaveTrack;
 class wxString;
@@ -26,7 +27,7 @@ using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
 using TrackHolders = std::vector< NewChannelGroup >;
 
 
-void ImportRaw(wxWindow *parent, const wxString &fileName,
+void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString &fileName,
    WaveTrackFactory *trackFactory, TrackHolders &outTracks);
 
 #endif

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -603,7 +603,7 @@ void OnImportRaw(const CommandContext &context)
 
    TrackHolders newTracks;
 
-   ::ImportRaw(&window, fileName, &trackFactory, newTracks);
+   ::ImportRaw(project, &window, fileName, &trackFactory, newTracks);
 
    if (newTracks.size() <= 0)
       return;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8174871/94364525-da5da800-0104-11eb-90af-f697d9aec082.png)

Sample rate text box is replaced by combo box with preset.

Dialog's default rate is received from Project Rate(instead of fixed 44100Hz).