### PR TITLE
Let users update audacity.pot only

### DIFF
--- a/locale/update_po_files.sh
+++ b/locale/update_po_files.sh
@@ -28,6 +28,9 @@ xargs xgettext \
 --package-version='2.4.2' \
 --msgid-bugs-address="audacity-translation@lists.sourceforge.net" \
 --add-location=file -L Lisp -j -o audacity.pot 
+if test "${AUDACITY_ONLY_POT:-}" = 'y'; then
+    return 0
+fi
 echo ";; Updating the .po files - Updating Project-Id-Version"
 for i in *.po; do
     sed -i '/^"Project-Id-Version:/c\"Project-Id-Version: audacity 2.4.2\\n"' $i

--- a/locale/update_po_files.sh
+++ b/locale/update_po_files.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -o errexit
 echo ";; Recreating audacity.pot using .h, .cpp and .mm files"
 for path in ../modules/mod-script* ../modules/mod-nyq* ../include ../src ; do find $path -name \*.h -o -name \*.cpp -o -name \*.mm ; done | LANG=c sort | \
 sed -E 's/\.\.\///g' |\


### PR DESCRIPTION
Commit 748aa05495819660384998ecc182c207c97de7a6 allows people to easily update the `audacity.pot` file, without touching the `.po` files.

This can be done by calling
```sh
AUDACITY_ONLY_POT=y ./update_po_files.sh
```

If the `AUDACITY_ONLY_POT` environment variable is not set, or if its value is not `y`, nothing changes.

I also added commit 9e8618dd880455ece8b1e62295415ace61a9d99f: with that change the script exits as soon as an error occurs (for example, if the gettext tools are not available).