### PR TITLE
Fix CVE-2020-11867

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1668,7 +1668,7 @@ bool AudacityApp::InitTempDir()
    // The permissions don't always seem to be set on
    // some platforms.  Hopefully this fixes it...
    #ifdef __UNIX__
-   chmod(OSFILENAME(temp), 0755);
+   chmod(OSFILENAME(temp), 0700);
    #endif
 
    FileNames::ResetTempDir();


### PR DESCRIPTION
This fixes CVE-2020-11867 by setting the permissions for the user tmp folder to 700. Closes #699 
