### PR TITLE
Fix awful Polish translation for zero-padding.

### DIFF
--- a/locale/pl.po
+++ b/locale/pl.po
@@ -15302,7 +15302,7 @@ msgstr "&Typ okna:"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Zero padding factor:"
-msgstr "&Zerowe dopełnienie czynnika:"
+msgstr "Współczynnik uzupełnienia &zerami:"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"


### PR DESCRIPTION
I found a very bad Polish translation for the zero padding factor. The translation in the locale file is "zerowe dopełnienie czynnika", which means in English something like "zero-ish complement of a factor". I replaced it with "współczynnik uzupełnienia zerami". "Uzupełnianie zerami" is the Polish term for "zero padding", used in the literature.