### PR TITLE
Fix typos (user facing and non-user facing)

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -24,7 +24,7 @@ env:
   WXREF: audacity-fixes-3.1.3
   WXWIN: ${{ github.workspace }}/wxwin
   # As of 2021/01/01, github is using Xcode 12.2 as the default and
-  # it has a bug in the install_name_tool.  So explicity use 12.3
+  # it has a bug in the install_name_tool.  So explicitly use 12.3
   # instead.
   DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
 
@@ -123,7 +123,7 @@ jobs:
           # Clone the wxWidgets repo
           git clone --depth 1 --recurse-submodules -b "${WXREF}" "${WXURL}" "wxroot"
 
-          # Use cmake since it defines the MSVC enviornment for us
+          # Use cmake since it defines the MSVC environment for us
           cmake -S "wxroot" \
                 -B "wxroot" \
                 -G "${{matrix.config.generator}}" \

--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -18,7 +18,7 @@ cmd_option( ${_OPT}lib_preference
 #     symbol   suffix for the "USE_<symbol>" variable that the Audacity
 #              target uses to include/exclude functionality.
 #
-#     requried Determines if the library is required or not.  If it is,
+#     required Determines if the library is required or not.  If it is,
 #              the user is not given the option of enabling/disabling it.
 #
 #     check    Determines if local/system checks should be performed here

--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -145,7 +145,7 @@ endfunction()
 # project in Visual Studio. Sweet right? Well, not quite...
 #
 # We want the Audacity target to be the startup project to provide
-# eaiser debugging. But, if we do that, the ALL_BUILD target is no
+# easier debugging. But, if we do that, the ALL_BUILD target is no
 # longer "in control" and any dependents of the Audacity target would
 # not get built. So, targets like "nyquist" and "plug-ins" would have
 # to be manually built. This is not what we want since Nyquist would

--- a/cmake-proxies/ffmpeg/CMakeLists.txt
+++ b/cmake-proxies/ffmpeg/CMakeLists.txt
@@ -24,7 +24,7 @@ cmd_option( ${_OPT}use_ffmpeg
             STRINGS "loaded" ${opt} "off"
 )
 
-# Deteremine if it will be turned off, linked to, or loaded
+# Determine if it will be turned off, linked to, or loaded
 if( ${_OPT}use_ffmpeg STREQUAL "off" )
    message( STATUS "Disabling '${name}' library" )
 else()

--- a/cmake-proxies/lame/config.h.in
+++ b/cmake-proxies/lame/config.h.in
@@ -19,7 +19,7 @@
 /* Define to 1 if using `alloca.c'. */
 #cmakedefine C_ALLOCA 1
 
-/* alot of debug output */
+/* a lot of debug output */
 #cmakedefine DEBUG 1
 
 /* allow to compute a more accurate replaygain value */
@@ -286,7 +286,7 @@
 /* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
 #cmakedefine TIME_WITH_SYS_TIME 1
 
-/* faster log implementation with less but enough precission */
+/* faster log implementation with less but enough precision */
 #cmakedefine USE_FAST_LOG 1
 
 /* Enable extensions on AIX 3, Interix.  */

--- a/dox2-src/ShuttleSystem.dox2
+++ b/dox2-src/ShuttleSystem.dox2
@@ -120,7 +120,7 @@ ShuttleGui wraps wxWidget sizers, and the wxWidgets sizer system can sometimes
 itself be confusing.  The most common problem is finding that controls don't
 resize at all for some reason.
 
-Resizing requires that 'stretchiness' propogate all the way down from the 
+Resizing requires that 'stretchiness' propagate all the way down from the 
 ultimate parent window.  Any sizers that is not using \p wxEXPAND will cause
 everything within in it to retain the size it had when the GUI was created,
 i.e. it will not resize when the window does.  A very common idiom is to

--- a/dox2-src/Themability.dox2
+++ b/dox2-src/Themability.dox2
@@ -166,7 +166,7 @@ The current algorithm for determining which image to use is:
   - ELSE use the built in ' ThemeAsCeeCode.h ' defaults.
 
 This is handled in function \ref ThemeBase::LoadThemeAtStartUp().  Once the 
-deprecated XPMs have been removed, we wil switch over to using the built 
+deprecated XPMs have been removed, we will switch over to using the built 
 in 'ThemeAsCeeCode.h' defaults where we currently use the XPM defaults.
 
 

--- a/include/audacity/Types.h
+++ b/include/audacity/Types.h
@@ -210,7 +210,7 @@ public:
 // to one of the operators on Identifiers defined above, but always case
 // sensitive.
 
-// Comparison operators for two TaggedIdentifers, below, require the same tags
+// Comparison operators for two TaggedIdentifiers, below, require the same tags
 // and case sensitivity.
 template< typename Tag1, typename Tag2, bool b1, bool b2 >
 inline bool operator == (

--- a/locale/msgfmt.py
+++ b/locale/msgfmt.py
@@ -222,7 +222,7 @@ class Msgfmt:
             elif l.startswith('msgid_plural'):
                 if section != ID:
                     raise PoSyntaxError(
-                        'msgid_plural not preceeded by '
+                        'msgid_plural not preceded by '
                         'msgid on line %d of po file %s' %
                         (lno, repr(self.name)))
                 l = l[12:]

--- a/mac/cmake_build.txt
+++ b/mac/cmake_build.txt
@@ -1,7 +1,7 @@
 Instructions for building on macOS using CMake.
 
 Building on macOS has been made much simpler with the Audacity 2.4.0
-release. Still, read this document throughly before starting.
+release. Still, read this document thoroughly before starting.
 
 1) Get and install the latest Xcode version available your macOS version:
 

--- a/modules/mod-null/ModNullCallback.cpp
+++ b/modules/mod-null/ModNullCallback.cpp
@@ -21,7 +21,7 @@ added into the standard Audacity Project Menus.
 \class ModNullCommandFunctor
 \brief We create one of these functors for each menu item or 
 command which we register with the Command Manager.  These take the 
-click from the menu into the actaul function to be called.
+click from the menu into the actual function to be called.
 
 *//********************************************************************/
 

--- a/modules/mod-null/ModNullCallback.h
+++ b/modules/mod-null/ModNullCallback.h
@@ -2,7 +2,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the LIBSCRIPT_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see 
-// MOD_NULL_DLL_API functions as being imported from a DLL, wheras this DLL sees symbols
+// MOD_NULL_DLL_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 
 

--- a/modules/mod-script-pipe/ScripterCallback.h
+++ b/modules/mod-script-pipe/ScripterCallback.h
@@ -3,7 +3,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the LIBSCRIPT_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see 
-// SCRIPT_PIPE_DLL_API functions as being imported from a DLL, wheras this DLL sees symbols
+// SCRIPT_PIPE_DLL_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 
 

--- a/nographs.dox
+++ b/nographs.dox
@@ -11,7 +11,7 @@
 ##DOT_IMAGE_FORMAT = svg
 
 ## COMMENT these lines to turn back on certain graphs selectively:
-## (CLASS_GRAPH seems to stil need default YES to draw the basic non-graphViz boxes)
+## (CLASS_GRAPH seems to still need default YES to draw the basic non-graphViz boxes)
 
 ##CLASS_GRAPH = NO
 COLLABORATION_GRAPH = NO

--- a/qa/General.txt
+++ b/qa/General.txt
@@ -56,7 +56,7 @@ III. WINDOW DECOR:
 	B: Open a new Audacity project with a .wav file as a
 				command line argument.
 
-			B1. Title bar should initally say "Audacity".
+			B1. Title bar should initially say "Audacity".
 				After file is imported, title should change to
 				the filename (with extension).
 

--- a/qa/Plugins.txt
+++ b/qa/Plugins.txt
@@ -108,5 +108,5 @@ IV: PLUGINS: WINDOWS (TM)
 		 Pluggo Synth: quit
 		 Pluggo Sync: quit
 		 Resonation: quit
-		 Genereic Effect: lock-up
+		 Generic Effect: lock-up
 		 LFO: works

--- a/src/Diags.h
+++ b/src/Diags.h
@@ -8,7 +8,7 @@
 
   Provides Macros for recording bad events and performance monitoring.
   These macros have such low cost that they can be used in release code.
-  They will take miniscule processing time after the first ten times.
+  They will take minuscule processing time after the first ten times.
 
 **********************************************************************/
 

--- a/src/ProjectSerializer.cpp
+++ b/src/ProjectSerializer.cpp
@@ -39,7 +39,7 @@
 //    name dictionary   dictionary of all names used in the document
 //    data fields       the "encoded" XML document
 //
-// If a subtree is added, it will be preceeded with FT_Push to tell the decoder
+// If a subtree is added, it will be preceded with FT_Push to tell the decoder
 // to preserve the active dictionary.  The decoder will then restore the
 // dictionary when an FT_Pop is encountered.  Nesting is unlimited.
 //

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -1763,7 +1763,7 @@ The repeated choice logic can then be taken out of those
 functions.
 
 JKC: This paves the way for doing data validation too,
-though when we add that we wil need to renumber the
+though when we add that we will need to renumber the
 steps.
 */
 bool ShuttleGuiBase::DoStep( int iStep )

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -137,7 +137,7 @@ void Track::SetOwner
 (const std::weak_ptr<TrackList> &list, TrackNodePointer node)
 {
    // BUG: When using this function to clear an owner, we may need to clear
-   // focussed track too.  Otherwise focus could remain on an invisible (or deleted) track.
+   // focused track too.  Otherwise focus could remain on an invisible (or deleted) track.
    mList = list;
    mNode = node;
 }

--- a/src/Track.h
+++ b/src/Track.h
@@ -484,7 +484,7 @@ private:
    struct Executor{};
 
    //! Helper for recursive case of metafunction implementing Track::TypeSwitch
-   /*! Mutually recursive (in compile time) with tempate Track::Executor. */
+   /*! Mutually recursive (in compile time) with template Track::Executor. */
    struct Dispatcher {
       //! First, recursive case of metafunction, defers generation of operator ()
       template< typename R, typename ConcreteType,

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -239,7 +239,7 @@ private:
    ///
    /// MM: Now that each wave track can contain multiple clips, we don't
    /// have a continuous space of samples anymore, but we simulate it,
-   /// because there are alot of places (e.g. effects) using this interface.
+   /// because there are a lot of places (e.g. effects) using this interface.
    /// This interface makes much sense for modifying samples, but note that
    /// it is not time-accurate, because the "offset" is a double value and
    /// therefore can lie inbetween samples. But as long as you use the

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -321,7 +321,7 @@ void CommandManager::SetMaxList()
    // KeyConfigPrefs::OnImportDefaults(wxCommandEvent & event)
 
    // TODO: At a later date get rid of the maxList entirely and
-   // instead use flags in the menu entrys to indicate whether the default
+   // instead use flags in the menu entries to indicate whether the default
    // shortcut is standard or full.
 
    mMaxListOnly.clear();

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -272,7 +272,7 @@ class AUDACITY_DLL_API CommandManager final
        // parenthesized, after the translated name.
        const ComponentInterfaceSymbol commands[], size_t nCommands) const;
 
-   // Sorted list of the shortcut keys to be exluded from the standard defaults
+   // Sorted list of the shortcut keys to be excluded from the standard defaults
    static const std::vector<NormalizedKeyString> &ExcludedList();
 
 private:

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -298,7 +298,7 @@ bool NyquistEffect::IsDefault()
 bool NyquistEffect::DefineParams( ShuttleParams & S )
 {
    // For now we assume Nyquist can do get and set better than DefineParams can,
-   // And so we ONLY use it for geting the signature.
+   // And so we ONLY use it for getting the signature.
    auto pGa = dynamic_cast<ShuttleGetAutomation*>(&S);
    if( pGa ){
       GetAutomationParameters( *(pGa->mpEap) );

--- a/src/export/ExportMP3.cpp
+++ b/src/export/ExportMP3.cpp
@@ -1592,7 +1592,7 @@ static void dump_config( 	lame_global_flags*	gfp )
       case JOINT_STEREO: wxPrintf(wxT( "Joint-Stereo\n" )); break;
       case DUAL_CHANNEL: wxPrintf(wxT( "Forced Stereo\n" )); break;
       case MONO:         wxPrintf(wxT( "Mono\n" )); break;
-      case NOT_SET:      /* FALLTROUGH */
+      case NOT_SET:      /* FALLTHROUGH */
       default:           wxPrintf(wxT( "Error (unknown)\n" )); break;
    }
 

--- a/src/export/ExportOGG.cpp
+++ b/src/export/ExportOGG.cpp
@@ -249,7 +249,7 @@ ProgressResult ExportOGG::Export(AudacityProject *project,
    //    3. The bitstream codebook.
    //
    // After we create those our responsibility is complete, libvorbis will
-   // take care of any other ogg bistream constraints (again, according
+   // take care of any other ogg bitstream constraints (again, according
    // to the example encoder source)
    ogg_packet bitstream_header;
    ogg_packet comment_header;

--- a/src/import/ImportFLAC.cpp
+++ b/src/import/ImportFLAC.cpp
@@ -35,7 +35,7 @@
 #endif
 
 #include <wx/defs.h>
-#include <wx/intl.h>    // needed for _("translated stings") even if we
+#include <wx/intl.h>    // needed for _("translated strings") even if we
                         // don't have libflac available
 
 #include "Import.h"

--- a/src/import/ImportGStreamer.cpp
+++ b/src/import/ImportGStreamer.cpp
@@ -64,7 +64,7 @@ extern "C"
 
 // Capabilities that Audacity can handle
 //
-// This resolves to: (on little endien)
+// This resolves to: (on little endian)
 //
 //    "audio/x-raw, "
 //    "format = (string) {S16LE, S24_32LE, F32LE}, "

--- a/src/import/ImportOGG.cpp
+++ b/src/import/ImportOGG.cpp
@@ -66,7 +66,7 @@ static Importer::RegisteredUnusableImportPlugin registered{
 #include <wx/utils.h>
 #include <wx/intl.h>
 /* ffile.h must be included AFTER at least one other wx header that includes
- * wx/setup.h, otherwise #ifdefs erronously collapse it to nothing. This is
+ * wx/setup.h, otherwise #ifdefs erroneously collapse it to nothing. This is
  * a bug in wxWidgets (ffile.h should itself include wx/setup.h), and it
  * was a bitch to track down. */
 #include <wx/ffile.h>

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -220,7 +220,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
 
       auto msg = XO("Importing %s").Format( wxFileName::FileName(fileName).GetFullName() );
 
-      /* i18n-hint: 'Raw' means 'unprocessed' here and should usually be tanslated.*/
+      /* i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.*/
       ProgressDialog progress(XO("Import Raw"), msg);
 
       size_t block;

--- a/src/menus/WindowMenus.cpp
+++ b/src/menus/WindowMenus.cpp
@@ -148,7 +148,7 @@ void OnMacZoom(const CommandContext &context)
 
 void OnMacBringAllToFront(const CommandContext &)
 {
-   // Reall this de-miniaturizes all, which is not exactly the standard
+   // Really this de-miniaturizes all, which is not exactly the standard
    // behavior.
    for (const auto project : AllProjects{})
       GetProjectFrame( *project ).Raise();

--- a/src/widgets/Meter.cpp
+++ b/src/widgets/Meter.cpp
@@ -1918,7 +1918,7 @@ void MeterPanel::OnAudioIOStatus(wxCommandEvent &evt)
 }
 
 // SaveState() and RestoreState() exist solely for purpose of recreating toolbars
-// They should really be quering the project for current audio I/O state, but there
+// They should really be querying the project for current audio I/O state, but there
 // isn't a clear way of doing that just yet.  (It should NOT query AudioIO.)
 auto MeterPanel::SaveState() -> State
 {


### PR DESCRIPTION
Found via `codespell v2.1.dev0`  
`codespell -q 3 -S *.po,./lib-src -L parm,parms,toke`