### PR TITLE
Fix typos (user facing and non-user facing)

### DIFF
--- a/locale/audacity.pot
+++ b/locale/audacity.pot
@@ -11542,7 +11542,7 @@ msgstr ""
 msgid "Unable to get fill buffer"
 msgstr ""
 
-#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be tanslated.
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
 #: src/import/ImportRaw.cpp
 msgid "Import Raw"
 msgstr ""

--- a/locale/diagnostics.sh
+++ b/locale/diagnostics.sh
@@ -18,7 +18,7 @@ done | sort -n -k3
 
 echo
 
-# detect whether this sequence occures in any .po file.  It will break
+# detect whether this sequence occurs in any .po file.  It will break
 # msgfmt on Windows.
 echo "Files with illegal comment sequence:"
 fgrep -l '#~|' *.po

--- a/nyquist/aud-do-support.lsp
+++ b/nyquist/aud-do-support.lsp
@@ -8,7 +8,7 @@
 
 
 (defun char-remove (ch str)
-  ;;; Remove all occurances of character from string.
+  ;;; Remove all occurrences of character from string.
   (do ((out "")
        (i 0 (1+ i)))
       ((= i (length str)) out)

--- a/nyquist/dspprims.lsp
+++ b/nyquist/dspprims.lsp
@@ -142,7 +142,7 @@
         (ny:error "ALPASS" 4 '((POSITIVE) "min-hz") min-hz))
       (setf max-delay (/ (float min-hz)))
       ; make sure delay is between 0 and max-delay
-      ; use clip function, which is symetric, with an offset
+      ; use clip function, which is symmetric, with an offset
       (setf delay (snd-offset (clip (snd-offset delay (* max-delay -0.5))
                                     (* max-delay 0.5))
                               (* max-delay 0.5)))

--- a/nyquist/evalenv.lsp
+++ b/nyquist/evalenv.lsp
@@ -7,7 +7,7 @@
 ;; The answer is you can use the evalhook facility. The evalhook function
 ;; will evaluate an expression using an environment given to it as an
 ;; argument. But then the problem is "how do you get the current
-;; environment?" Well the getenv macro, below obtains the environent by
+;; environment?" Well the getenv macro, below obtains the environment by
 ;; using an *evalhook* form.
 ;;
 ;; The following two macros do the job. Insteading of executing (eval <expr>)

--- a/nyquist/nyquist.lsp
+++ b/nyquist/nyquist.lsp
@@ -2346,7 +2346,7 @@ loop
 
 ;; SELECT-IMPLEMENTATION-1-2 -- 1 sound arg, 2 selectors
 ;;
-;; choose implemenation according to args 2 and 3. In this implementation,
+;; choose implementation according to args 2 and 3. In this implementation,
 ;; since we have two arguments to test for types, we return from prog
 ;; if we find good types. That way, we can fall through the decision tree
 ;; and all paths lead to one call to ERROR if good types are not found.

--- a/nyquist/sal-parse.lsp
+++ b/nyquist/sal-parse.lsp
@@ -51,7 +51,7 @@
     (:/ "/" /)
     (:% "%" rem)
     (:^ "^" expt)
-    (:= "=" sal-equal)   ; equality and assigment
+    (:= "=" sal-equal)   ; equality and assignment
     (:!= "!=" not-sal-equal)
     (:< "<" <)
     (:> ">" >)
@@ -62,9 +62,9 @@
     (:-= "-=" -=) ; assignment increment-and-store
     (:*= "*=" *=) ; assignment multiply-and-store
     (:/= "/=" /=) ; assignment multiply-and-store
-    (:&= "&=" &=) ; assigment list collecting
-    (:@= "@=" @=) ; assigment list prepending
-    (:^= "^=" ^=) ; assigment list appending
+    (:&= "&=" &=) ; assignment list collecting
+    (:@= "@=" @=) ; assignment list prepending
+    (:^= "^=" ^=) ; assignment list appending
     (:! "!" not)
     (:& "&" and)
     (:\| "|" or)
@@ -211,7 +211,7 @@
     (setf line-no (pos-to-line beg source))
     ; (display "pperror" beg end (sal-error-start x))
       
-    ;; print the error. include the specfic line of input containing
+    ;; print the error. include the specific line of input containing
     ;; the error as well as a line below it marking the error position
     ;; with an arrow: ^
     (let* ((pos (- (sal-error-start x) beg))
@@ -484,7 +484,7 @@
             (setq end (search-delim input delimit start len))
             (if (equal start end)                ; have a delimiter
                (cond ((char= char +semic+)
-                      ;; comment skips to next line and trys again...
+                      ;; comment skips to next line and try again...
                       (while (and (< start len)
                                   (char/= (char input start) #\newline))
                         (incf start))
@@ -1015,7 +1015,7 @@
 ;; with embedded operator symbols, e.g. x+y results in a warning
 ;; that this is an odd variable name. But if the symbol is declared
 ;; as a local, a parameter, a function name, or a global variable,
-;; then the warning is supressed.
+;; then the warning is suppressed.
 ;;
 (defun token-is (type &optional (suspicious-id-warn t))
   (let ((token-type
@@ -1174,7 +1174,7 @@
   ;; kargs is a flag indicating previous parameter was a keyword (all
   ;;   the following parameters must then also be keyword parameters)
   ;; returns: (<keyword> <default>) or (nil <identifier>)
-  ;;   where <keyword> is a keyward parameter name (nil if not a keyword parm)
+  ;;   where <keyword> is a keyword parameter name (nil if not a keyword parm)
   ;;         <default> is an expression for the default value
   ;;         <identifier> is the parameter name (if not a keyword parm)
   (let (key default-value id)
@@ -1450,7 +1450,7 @@
             ((eq op '^=) (setq expr `(nconc ,vref (append ,expr nil))))
             ((eq op '<=) (setq expr `(min ,vref ,expr)))
             ((eq op '>=) (setq expr `(max ,vref ,expr)))
-            (t (errexit (format nil "unknown assigment operator ~A" op))))
+            (t (errexit (format nil "unknown assignment operator ~A" op))))
       (push (list 'setf vref expr) rslt))
     (setf rslt (add-line-info-to-stmts rslt set-token))
     (if (> (length rslt) 1)

--- a/nyquist/sliders.lsp
+++ b/nyquist/sliders.lsp
@@ -42,7 +42,7 @@
 ;;   
 ;;   This code takes advantage of the fact that dotimes and dolist
 ;;   return nil when they end normally, so we signal that we found
-;;   or did not find i by explictly returning. Note that RETURN
+;;   or did not find i by explicitly returning. Note that RETURN
 ;;   returns from the innermost dotimes or dolist -- they do not
 ;;   return from allocate-slider-num.
 ;;

--- a/nyquist/spectral-analysis.lsp
+++ b/nyquist/spectral-analysis.lsp
@@ -135,7 +135,7 @@
     (:hann        (hann-window len))
     (:none        nil)
     (:hamming     (hamming-window len))
-    (t (print "Warning: invalid window-type paramter: ~A~%" win-type)
+    (t (print "Warning: invalid window-type parameter: ~A~%" win-type)
        (print "    Using :HAMMING instead.~%")
        (hamming-window len))))
   

--- a/src/Dependencies.cpp
+++ b/src/Dependencies.cpp
@@ -23,7 +23,7 @@
 
 \class AliasedFile
 \brief An audio file that is referenced (pointed into) directly from
-an Audacity .aup file rather thna Audacity having its own copies of the
+an Audacity .aup file rather than Audacity having its own copies of the
 data.
 
 *//*****************************************************************//**

--- a/src/SseMathFuncs.h
+++ b/src/SseMathFuncs.h
@@ -364,7 +364,7 @@ _PS_CONST(coscof_p2,  4.166664568298827E-002);
 _PS_CONST(cephes_FOPI, 1.27323954473516); // 4 / M_PI
 
 
-/* evaluation of 4 sines at onces, using only SSE1+MMX intrinsics so
+/* evaluation of 4 sines at once, using only SSE1+MMX intrinsics so
    it runs also on old athlons XPs and the pentium III of your grand
    mother.
 


### PR DESCRIPTION
Found via `codespell`