### PR TITLE
Bug 2582 - Enh: Repeat last Process, Part 2

### DIFF
--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -253,6 +253,7 @@ const ReservedCommandFlag&
 const ReservedCommandFlag&
    HasLastAnalyzerFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project) {
+         if (MenuManager::Get(project).mLastAnalyzerRegistration == MenuCreator::repeattypeunique) return true;
          return !MenuManager::Get(project).mLastAnalyzer.empty();
       }
    }; return flag;
@@ -260,7 +261,9 @@ const ReservedCommandFlag&
 const ReservedCommandFlag&
    HasLastToolFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project) {
-         return !MenuManager::Get(project).mLastTool.empty();
+      auto& menuManager = MenuManager::Get(project);
+         if (menuManager.mLastToolRegistration == MenuCreator::repeattypeunique) return true;
+         return !menuManager.mLastTool.empty();
       }
    }; return flag;
 }

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -1160,6 +1160,7 @@ struct Handler : CommandHandlerObject {
    void OnPlotSpectrum(const CommandContext &context)
    {
       auto &project = context.project;
+      CommandManager::Get(project).RegisterLastAnalyzer(context);  //Register Plot Spectrum as Last Analyzer
       auto freqWindow =
          &project.AttachedWindows::Get< FrequencyPlotDialog >( sFrequencyWindowKey );
 

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -48,6 +48,8 @@
 
 MenuCreator::MenuCreator()
 {
+   mLastAnalyzerRegistration = repeattypenone;
+   mLastToolRegistration = repeattypenone;
 }
 
 MenuCreator::~MenuCreator()

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -52,8 +52,21 @@ public:
    PluginID mLastGenerator{};
    PluginID mLastEffect{};
    PluginID mLastAnalyzer{};
+   int mLastAnalyzerRegistration;
+   int mLastAnalyzerRegisteredId;
    PluginID mLastTool{};
-   bool mLastToolIsMacro;
+   int mLastToolRegistration;
+   int mLastToolRegisteredId;
+   enum {
+      repeattypenone = 0,
+      repeattypeplugin = 1,
+      repeattypeunique = 2,
+      repeattypeapplymacro = 3
+   };
+   unsigned mRepeatGeneratorFlags;
+   unsigned mRepeatEffectFlags;
+   unsigned mRepeatAnalyzerFlags;
+   unsigned mRepeatToolFlags;
 };
 
 struct ToolbarMenuVisitor;

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -209,6 +209,9 @@ class AUDACITY_DLL_API CommandManager final
    // Lyrics and MixerTrackCluster classes use it.
    bool FilterKeyEvent(AudacityProject *project, const wxKeyEvent & evt, bool permit = false);
    bool HandleMenuID(AudacityProject &project, int id, CommandFlag flags, bool alwaysEnabled);
+   void RegisterLastAnalyzer(const CommandContext& context);
+   void RegisterLastTool(const CommandContext& context);
+   void DoRepeatProcess(const CommandContext& context, int);
 
    enum TextualCommandResult {
       CommandFailure,
@@ -356,6 +359,8 @@ private:
    bool mbSeparatorAllowed; // false at the start of a menu and immediately after a separator.
 
    TranslatableString mCurrentMenuName;
+   TranslatableString mNiceName;
+   int mLastProcessId;
    std::unique_ptr<wxMenu> uCurrentMenu;
    wxMenu *mCurrentMenu {};
 

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -672,6 +672,7 @@ struct Handler : CommandHandlerObject {
    void OnContrast(const CommandContext &context)
    {
       auto &project = context.project;
+      CommandManager::Get(project).RegisterLastAnalyzer(context);  //Register Contrast as Last Analyzer
       auto contrastDialog =
          &project.AttachedWindows::Get< ContrastDialog >( sContrastDialogKey );
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -100,6 +100,7 @@ Effect::Effect()
 
    mUIParent = NULL;
    mUIDialog = NULL;
+   mUIFlags = 0;
 
    mNumAudioIn = 0;
    mNumAudioOut = 0;
@@ -1177,6 +1178,14 @@ wxString Effect::ManualPage()
 wxString Effect::HelpPage()
 {
    return wxEmptyString;
+}
+
+void Effect::SetUIFlags(unsigned flags) {
+   mUIFlags = flags;
+}
+
+unsigned Effect::TestUIFlags(unsigned mask) {
+   return mask & mUIFlags;
 }
 
 bool Effect::IsBatchProcessing()

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -244,6 +244,8 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // Fully qualified local help file name
    virtual wxString HelpPage();
 
+   virtual void SetUIFlags(unsigned flags);
+   virtual unsigned TestUIFlags(unsigned mask);
    virtual bool IsBatchProcessing();
    virtual void SetBatchProcessing(bool start);
 
@@ -476,6 +478,7 @@ protected:
    wxDialog       *mUIDialog;
    wxWindow       *mUIParent;
    int            mUIResultID;
+   unsigned       mUIFlags;
 
    sampleCount    mSampleCnt;
 

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -54,11 +54,13 @@ public:
       // Flag used to disable prompting for configuration parameteres.
       kConfigured = 0x01,
       // Flag used to disable saving the state after processing.
-      kSkipState  = 0x02,
+      kSkipState = 0x02,
       // Flag used to disable "Repeat Last Effect"
       kDontRepeatLast = 0x04,
       // Flag used to disable "Select All during Repeat Generator Effect"
       kRepeatGen = 0x08,
+      // Flag used for repeating Nyquist Prompt
+      kRepeatNyquistPrompt = 0x10,
    };
 
    /** Get the singleton instance of the EffectManager. Probably not safe

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1925,6 +1925,7 @@ wxDialog *EffectUI::DialogFactory( wxWindow &parent, EffectHostInterface *pHost,
          EffectRack::Get( context.project ).Add(effect);
       }
 #endif
+      effect->SetUIFlags(flags);
       success = effect->DoEffect(
          rate,
          &tracks,
@@ -1959,23 +1960,32 @@ wxDialog *EffectUI::DialogFactory( wxWindow &parent, EffectHostInterface *pHost,
          /* i18n-hint: %s will be the name of the effect which will be
           * repeated if this menu item is chosen */
          auto lastEffectDesc = XO("Repeat %s").Format(shortDesc);
+         auto& menuManager = MenuManager::Get(project);
          switch ( type ) {
          case EffectTypeGenerate:
             commandManager.Modify(wxT("RepeatLastGenerator"), lastEffectDesc);
-            MenuManager::Get(project).mLastGenerator = ID;
+            menuManager.mLastGenerator = ID;
+            menuManager.mRepeatGeneratorFlags = EffectManager::kConfigured;
             break;
          case EffectTypeProcess:
             commandManager.Modify(wxT("RepeatLastEffect"), lastEffectDesc);
-            MenuManager::Get(project).mLastEffect = ID;
+            menuManager.mLastEffect = ID;
+            menuManager.mRepeatEffectFlags = EffectManager::kConfigured;
             break;
          case EffectTypeAnalyze:
             commandManager.Modify(wxT("RepeatLastAnalyzer"), lastEffectDesc);
-            MenuManager::Get(project).mLastAnalyzer = ID;
+            menuManager.mLastAnalyzer = ID;
+            menuManager.mLastAnalyzerRegistration = MenuCreator::repeattypeplugin;
+            menuManager.mRepeatAnalyzerFlags = EffectManager::kConfigured;
             break;
          case EffectTypeTool:
             commandManager.Modify(wxT("RepeatLastTool"), lastEffectDesc);
-            MenuManager::Get(project).mLastTool = ID;
-            MenuManager::Get(project).mLastToolIsMacro = false;
+            menuManager.mLastTool = ID;
+            menuManager.mLastToolRegistration = MenuCreator::repeattypeplugin;
+            menuManager.mRepeatToolFlags = EffectManager::kConfigured;
+            if (shortDesc == XO("Nyquist Prompt")) {
+               menuManager.mRepeatToolFlags = EffectManager::kRepeatNyquistPrompt;  //Nyquist Prompt is not configured
+            }
             break;
       }
    }

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1001,8 +1001,12 @@ finish:
 bool NyquistEffect::ShowInterface(
    wxWindow &parent, const EffectDialogFactory &factory, bool forceModal)
 {
-   // Show the normal (prompt or effect) interface
-   bool res = Effect::ShowInterface(parent, factory, forceModal);
+   bool res = true;
+   if (!(Effect::TestUIFlags(EffectManager::kRepeatNyquistPrompt) && mIsPrompt)) {
+      // Show the normal (prompt or effect) interface
+      res = Effect::ShowInterface(parent, factory, forceModal);
+   }
+
 
    // Remember if the user clicked debug
    mDebug = (mUIResultID == eDebugID);


### PR DESCRIPTION
Bug 2582 - Enh: Repeat last Process, Part 2

This commit implementsl features suggested by Peter And Steve and fixes Repeat NyQuist Command Tool.

It should close:
Bug 2582 - Enh: Repeat last Generator, Analyzer or Tool
Bug 2640 - Plot Spectrum and Contrast analyzers are not "Repeatable"
Bug 1019 - Plot Spectrum and Contrast analyzers are not "Repeatable"

(although it does not address the original issue reported in
Bug 1019 - Enh: Contrast and Plot Spectrum cannot be disabled in Plug-In Manager.)

This commit adds Plot Spectrum and Contrast Anaylyzer to the list of repeatable Analyzers;
This commit adds Macros, Palette, Screenshot, Run Benchmark, and Nyquist Prompt to the list of repeatable tools.
