### PR TITLE
Windows build instructions fail

### DIFF
--- a/cmake-proxies/portaudio-v19/CMakeLists.txt
+++ b/cmake-proxies/portaudio-v19/CMakeLists.txt
@@ -88,7 +88,7 @@ cmd_option( ${_OPT}use_pa_jack
 
 if( NOT ${_OPT}use_pa_jack STREQUAL "off" )
    # Find it
-   find_package( Jack )
+   find_package( jack )
    if( NOT JACK_FOUND)
       set_cache_value( ${_OPT}use_pa_jack "off" )
    endif()

--- a/win/build.txt
+++ b/win/build.txt
@@ -9,107 +9,103 @@ can be found on our wiki at http://wiki.audacityteam.org/wiki/Building_On_Window
 
 1. MSVC 2019: Download and install Microsoft Visual Studio 2019
 
- https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=16
+  https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=16
+  be sure to include the Desktop Development with C++ Workflow
+  this build was testing using VS 16.8.5
 
 2. Git: Download and install Git, for example by installing:
 
   Git for Windows: https://git-scm.com/download/win
   and optionally GitExtensions: http://gitextensions.github.io/
 
- download and run the .msi installer.  GitExtensions has a GUI interface, includes Git for
- Windows and has a Git bash command line in the bottom panel of the screen.
+  download and run the .msi installer.  GitExtensions has a GUI interface, includes Git for
+  Windows and has a Git bash command line in the bottom panel of the screen.
 
 3. Python
-  We currently depend on Python 2.7.18 during the build.  We are working on a switch to a Python 3.
-  At the time of writing, Python 2.7.18 must be on your path.
+
+  We no longer use Python 2.7.18 during the build. Instead we must use Python 3.
+  You can download Python 3.9.1 from https://www.python.org/downloads/windows/
+  Select the Python 3.9.1 Windows Installer (32-bit)
 
 4. wxWidgets:
 
- 1) Clone wxWidgets and checkout 3.1.3 from the Audacity fork of the 
+ a) Clone wxWidgets and checkout 3.1.3 from the Audacity fork of the 
     wxWidgets project: 
        https://github.com/audacity/wxWidgets/
 
     for example, in the git-bash command line
-      mkdir ./wxWidgets
-      cd ./wxWidgets
+      mkdir wxWidgets
       git clone --recurse-submodules https://github.com/audacity/wxWidgets/
       
     IF you forgot the --recurse-submodules, you can correct that later by:
       git submodule update --init
 
-  2) Follow instructions for building at 
+    It is instructive to review but do NOT follow the instructions for building at 
     https://github.com/audacity/wxWidgets/blob/audacity-fixes-3.1.3/README-GIT.md
     https://github.com/audacity/wxWidgets/blob/audacity-fixes-3.1.3/docs/msw/install.md
-
-    We (currently) build the 32 bit DLL version, 
+ 
+ b) We (currently) build the 32 bit DLL version, 
     and Audacity is built 32 bit too.
 
     Set WXWIN environment variable to the appropriate directory where you installed 
     wxWidgets. This will tell CMake where to find wxWidgets later.
 
     To set WXWIN, click on Settings (the cogwheel icon from the start menu)
-    Then in the 'find settings' search box type 'env'.
+    Then in the 'find a setting' search box type 'env'.
     Choose 'Edit the system environment variables'
     Then the 'Environment Variables' button 
     Then in system variables, for variable and value,  add (for example)     
-        WXWIN         C:\wxWidgets-3.1.3
+    ==> WXWIN         C:\aud300\wxWidgets
 
     You will be building a dll version with MSVC2019 IDE, so...
-
-    In MSVC 2019 open wx_vc15.sln, and select dll, release.
-    Then build.
-
-  3) Having got this far, it is well worth trying out building some wxWidgets
-    examples to confirm that building has worked OK
+	==> In Windows File Manager, right-click on ../wxWidgets/build/msw/wx_vc16.sln,
+	==> select Visual Studio 2019,
+	==> in the solutions configurations drop-down list, change "Debug" to "DLL Release",
+	==> then select Build > Build Solution.
+	
+	When the build completed, you will get the message:
+	========= Build: 24 succeeded, 0 failed, 0 up-to-date, 0 skipped ============
+	Close Visuual Studio.
 
 5. Audacity
 
- 1) Clone Audacity from the Audacity GitHub project.
+ a) Clone Audacity from the Audacity GitHub project.
        https://github.com/audacity/audacity/
 
     for example, in the git-bash command line
-      mkdir ./audacity
-      cd ./audacity
+      mkdir audacity
       git clone https://github.com/audacity/audacity/
 
-    Audacity itself does not use/need git submodules.
+ b) Open the CMake GUI
+     ==> Open VS 2019 > "continue without code" > File > Open > CMake
+     ==> Open CMakeLists.txt in root of audacity source folder you cloned
+	 ==> Wait for the CMake Overview Pages tab to appear (be patient)
+	 ==> Click "Open the CMake Settings Editor" in this new tab
+	 ==> Scroll up to the top of the window and settings
+	 ==> In the Configurations window, click the green "+", then select x86-Release
+	 ==> Set Configuration type: Release
+	 ==> Verify Toolset: msvc_86
+	 ==> Keep Build Root: ${projectDir}\out\build\${name} (default, you can change it)
+	     (this corresponds to CMAKE_BINARY_DIR)
+     ==> Click on "Show advanced settings" (scroll down).
+	 ==> Change CMake generator: VS 16 2019 (was Ninja)
+	 ==> Click "Save and Generate CMake cache to load variables" once, then
+	 ==> Click "Save and Generate CMake cache to load variables" a second time
+	     or select Project > Generate CMake Cache
+	 
+  c) Switch to the Ouput tab
+     ==> Wait for "CMake generation finished".
+	 ==> Check the Error List window:
+	     you should have 0 Errors and 0 Warnings.
+		 
+  d) Return to the CMakeSettings.json window
+     ==> Review CMake variables and cache
+	 ==> Note that:
+	 wxWidgets_LIB_DIR > 'C:/aud300/wxWidgets/lib/vc_dll' (your path may be slightly different)
 
-  2) Open the CMake GUI
-    - Open VS 2019 > "continue without code" > File > Open > CMake
-    - Pick CMakeLists.txt in root of audacity source folder you cloned
-    - Click "Open the CMake Settings Editor"
-
-  4) Check "Show advanced variables", click "Show advanced settings"
-  5) Set CMake Settings:
-    - configuration type > Release
-    - toolset > msvc_x86_x86 or msvc_x86_x64
-    - CMake generator > VS 16 2019
-
-  6) Set CMake variables:
-    - wxWidgets_LIB_DIR > 'C:/wxWidgets/lib/vc_dll' (your path may be slightly different)
-    - CMAKE_BINARY_DIR > `${projectDir}\out\install\${name}` (default, you can change it)
-
-  7) Save (should automatically generate CMake file)
-    - if it doesn't, Project > Generate CMake Cache
-
-  8) Build > Build All
-
-    Check the output directory indicated in step 6 to find `Audacity.exe`
+  e) Build
+     ==> Select Build > Build All
+     ==> Click on the Output tab and wait for the message "Build All succeeded" 
+	 ==> Check the Error List tab.  There should be 0 Errors and 17 Warnings.
+     ==> Check the output directory indicated in step 6 to find `../bin/Release/Audacity.exe`
     
-
- Old VS 2017 instructions: 
-
- 2) Open the CMake GUI.
-
-     Set the 'Where is the source code' location to where your copy of the git repo is.
-     Set the 'Where to build the binaries' to where you want the results.
-
- 3) Click on Generate.
-
- 4) Click on Open Project.
-
-    From here on you should be able to use the project.
-
- 5)
-    Choose Release or Debug.
-    Click compile.


### PR DESCRIPTION
Windows build instructions fail:

1) CMake requires Python 3 NOT 2.7
2) Ninja, Windows default builder fails.
3) git commands clone to wrong directory
4) (2017 not 2019) solution file specified for wxWidgets build
5) CMake GUI instructions are confusing and incorrect
6) Incorrect CMake toolset specified
7) Jack program name is case-sensitive (portaudio-v19\CMakeLists.txt)
8) These instructions overcome inconsistencies and timing issues with CMake
