### PR TITLE
Fix source comment typos and source typos

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -124,7 +124,7 @@ Generally, steps 1-5 are only needed the first-time you configure. Then, after y
 
 ### Building with ASIO support on Windows
 
-To enable ASIO support, please select `audacity_has_asio_support=On` in CMake after the intial configuration and then run select **Configure** again as described above. ASIO is only supported on Windows and only for 64-bit builds.
+To enable ASIO support, please select `audacity_has_asio_support=On` in CMake after the initial configuration and then run select **Configure** again as described above. ASIO is only supported on Windows and only for 64-bit builds.
 
 ## macOS
 

--- a/cmake-proxies/cmake-modules/AudacityTesting.cmake
+++ b/cmake-proxies/cmake-modules/AudacityTesting.cmake
@@ -92,7 +92,7 @@ if( ${_OPT}has_tests )
       elseif( APPLE )
          # We target an old version of macOS, disable std::uncaught_exceptions
          target_compile_definitions( ${test_executable_name} PRIVATE CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS )
-         # Similar to Windows, but uses DYLD_FALLBACK_LIBRARY_PATH istead of PATH
+         # Similar to Windows, but uses DYLD_FALLBACK_LIBRARY_PATH instead of PATH
          set_tests_properties(
             ${ADD_UNIT_TEST_NAME}
             PROPERTIES

--- a/cmake-proxies/cmake-modules/conan.cmake
+++ b/cmake-proxies/cmake-modules/conan.cmake
@@ -453,7 +453,7 @@ endmacro()
 
 function(old_conan_cmake_install)
     # Calls "conan install"
-    # Argument BUILD is equivalant to --build={missing, PkgName,...} or
+    # Argument BUILD is equivalent to --build={missing, PkgName,...} or
     # --build when argument is 'BUILD all' (which builds all packages from source)
     # Argument CONAN_COMMAND, to specify the conan path, e.g. in case of running from source
     # cmake does not identify conan as command, even if it is +x and it is in the path

--- a/cmake-proxies/cmake-modules/dependencies/zlib.cmake
+++ b/cmake-proxies/cmake-modules/dependencies/zlib.cmake
@@ -1,5 +1,5 @@
 # ZLib is a very popular library to use.
-# Some of the dependecies do not check for the system libraries,
+# Some of the dependencies do not check for the system libraries,
 # which can be problematic.
 # We need to call find_package once again.
 if (${_OPT}use_zlib STREQUAL "system")

--- a/dox2-src/WidgetMigration.dox2
+++ b/dox2-src/WidgetMigration.dox2
@@ -43,7 +43,7 @@ Some examples of code that is slated for wxWidgets migration:
  
 The migration process is expected to be slow.  It may be several years 
 before we formally offer some of the code to wxWidgets.  We want to 
-contribute mature  well tested code, complete with doucmentation demo 
+contribute mature  well tested code, complete with documentation demo 
 sample code etc.  We  want the code for migration to be of a maturity 
 suitable for inclusion in the default wxWidgets distribution from the 
 start, in the same way that optional sub libraries like the PNG library 

--- a/libraries/lib-module-manager/ModuleManager.cpp
+++ b/libraries/lib-module-manager/ModuleManager.cpp
@@ -87,7 +87,7 @@ bool Module::Load(wxString &deferredErrorMessage)
    auto ShortName = wxFileName(mName).GetName();
 
    if (!mLib->Load(mName, wxDL_NOW | wxDL_QUIET | wxDL_GLOBAL)) {
-      // For this failure path, only, there is a possiblity of retrial
+      // For this failure path, only, there is a possibility of retrial
       // after some other dependency of this module is loaded.  So the
       // error is not immediately reported.
       deferredErrorMessage = wxString(wxSysErrorMsg());

--- a/libraries/lib-network-manager/HeadersList.cpp
+++ b/libraries/lib-network-manager/HeadersList.cpp
@@ -51,7 +51,7 @@ Header Header::Parse (const std::string& header)
 {
     const size_t colonPosition = header.find (": ");
 
-    if (colonPosition == std::string::npos) // This can happen when we receieve the first line of the response
+    if (colonPosition == std::string::npos) // This can happen when we receive the first line of the response
         return { header, std::string () };
 
     return {

--- a/libraries/lib-network-manager/NetworkManager.cpp
+++ b/libraries/lib-network-manager/NetworkManager.cpp
@@ -3,7 +3,7 @@
  Audacity: A Digital Audio Editor
 
  @file NetworkManager.cpp
- @brief Define a class for preforming HTTP requests.
+ @brief Define a class for performing HTTP requests.
 
  Dmitry Vedenko
  **********************************************************************/
@@ -11,7 +11,7 @@
 /*!********************************************************************
 
  @class NetworkManager
- @brief Class for preforming HTTP requests.
+ @brief Class for performing HTTP requests.
 
  **********************************************************************/
 

--- a/libraries/lib-network-manager/NetworkManager.h
+++ b/libraries/lib-network-manager/NetworkManager.h
@@ -3,7 +3,7 @@
  Audacity: A Digital Audio Editor
 
  @file NetworkManager.h
- @brief Declare a class for preforming HTTP requests.
+ @brief Declare a class for performing HTTP requests.
 
  Dmitry Vedenko
  **********************************************************************/

--- a/libraries/lib-network-manager/curl/CurlHandleManager.cpp
+++ b/libraries/lib-network-manager/curl/CurlHandleManager.cpp
@@ -3,7 +3,7 @@
  Audacity: A Digital Audio Editor
 
  @file CurlHandleManager.cpp
- @brief Define a class responsible for reuse of CURL hanldes.
+ @brief Define a class responsible for reuse of CURL handles.
 
  Dmitry Vedenko
  **********************************************************************/

--- a/libraries/lib-network-manager/curl/CurlHandleManager.h
+++ b/libraries/lib-network-manager/curl/CurlHandleManager.h
@@ -3,7 +3,7 @@
  Audacity: A Digital Audio Editor
 
  @file CurlHandleManager.h
- @brief Declare a class responsible for reuse of CURL hanldes.
+ @brief Declare a class responsible for reuse of CURL handles.
 
  Dmitry Vedenko
  **********************************************************************/

--- a/libraries/lib-screen-geometry/ViewInfo.cpp
+++ b/libraries/lib-screen-geometry/ViewInfo.cpp
@@ -294,7 +294,7 @@ void ViewInfo::WriteXMLAttributes(XMLWriter &xmlFile) const
    xmlFile.WriteAttr(wxT("zoom"), zoom, 10);
 }
 
-//! Construct once at static intialization time to hook project file IO
+//! Construct once at static initialization time to hook project file IO
 static struct ViewInfo::ProjectFileIORegistration {
 
 ProjectFileIORegistry::AttributeReaderEntries entries {

--- a/libraries/lib-sentry-reporting/CMakeLists.txt
+++ b/libraries/lib-sentry-reporting/CMakeLists.txt
@@ -28,7 +28,7 @@ if(${_OPT}has_sentry_reporting)
         lib-string-utils # ToUtf8
         lib-uuid # UUIDs are required as an event identifier.
         RapidJSON::RapidJSON # Protocol is JSON based
-        wxwidgets::base # Required to retreive the OS information
+        wxwidgets::base # Required to retrieve the OS information
     )
 
     set ( DEFINES 

--- a/libraries/lib-string-utils/CodeConversions.cpp
+++ b/libraries/lib-string-utils/CodeConversions.cpp
@@ -3,7 +3,7 @@
  Audacity: A Digital Audio Editor
 
  @file CodeConversions.cpp
- @brief Define functions to preform UTF-8 to std::wstring conversions.
+ @brief Define functions to perform UTF-8 to std::wstring conversions.
 
  Dmitry Vedenko
  **********************************************************************/

--- a/libraries/lib-string-utils/CodeConversions.h
+++ b/libraries/lib-string-utils/CodeConversions.h
@@ -3,7 +3,7 @@
  Audacity: A Digital Audio Editor
 
  @file CodeConversions.h
- @brief Declare functions to preform UTF-8 to std::wstring conversions.
+ @brief Declare functions to perform UTF-8 to std::wstring conversions.
 
  Dmitry Vedenko
  **********************************************************************/

--- a/libraries/lib-string-utils/UrlEncode.cpp
+++ b/libraries/lib-string-utils/UrlEncode.cpp
@@ -3,7 +3,7 @@
  Audacity: A Digital Audio Editor
 
  @file UrlEncode.cpp
- @brief Define a function to perfom URL encoding of a string.
+ @brief Define a function to perform URL encoding of a string.
 
  Dmitry Vedenko
  **********************************************************************/

--- a/libraries/lib-string-utils/UrlEncode.h
+++ b/libraries/lib-string-utils/UrlEncode.h
@@ -3,7 +3,7 @@
  Audacity: A Digital Audio Editor
 
  @file UrlEncode.h
- @brief Declare a function to perfom URL encoding of a string.
+ @brief Declare a function to perform URL encoding of a string.
 
  Dmitry Vedenko
  **********************************************************************/

--- a/libraries/lib-theme-resources/LoadThemeResources.cpp
+++ b/libraries/lib-theme-resources/LoadThemeResources.cpp
@@ -14,7 +14,7 @@ void ThemeResources::Load()
 {
    // Nothing!
    // This function merely needs to be called somewhere from the application to
-   // gurantee that loading of the dynamic library is not skipped by the linker.
+   // guarantee that loading of the dynamic library is not skipped by the linker.
    // The real work is then done at static initialization time in other files
    // before this function is reached.
 }

--- a/libraries/lib-utility/Observer.h
+++ b/libraries/lib-utility/Observer.h
@@ -100,7 +100,7 @@ private:
  Intended for single-threaded use only.
  Move-only; allows type-erased custom allocation.
 
- @tparam Message the type of mesage
+ @tparam Message the type of message
  @tparam NotifyAll if true, callback return values are ignored; else, a callback
    returning true causes earlier subscribed callbacks to be skipped
  */

--- a/plug-ins/sample-data-import.ny
+++ b/plug-ins/sample-data-import.ny
@@ -40,11 +40,11 @@ $control bad-data (_ "Invalid data handling") choice (("ThrowError" (_ "Throw Er
         t)))
 
 ;; ':new' creates a new class 'streamreader'
-;; 'filestream' and 'chanel' are its instance variables.
+;; 'filestream' and 'channel' are its instance variables.
 ;; (every object of class 'streamreader' has its own
 ;; copy of these variables)
 (setq streamreader
-  (send class :new '(filestream chanel)))
+  (send class :new '(filestream channel)))
 
 ;; Initialize class 'streamreader'
 (send streamreader :answer :isnew '(stream ch) '(

--- a/scripts/build/macOS/NotarizeMacos.cmake
+++ b/scripts/build/macOS/NotarizeMacos.cmake
@@ -78,7 +78,7 @@ function( notarize path )
             if ( NOT "${notarization_result}" STREQUAL "success" ) 
                 message(FATAL_ERROR "Notarization failed:\n${result}\n")
             else()
-                message(STATUS "Notarization successfull")
+                message(STATUS "Notarization successful")
             endif()
 
             break()

--- a/scripts/build/windows/PfxSign.cmake
+++ b/scripts/build/windows/PfxSign.cmake
@@ -21,8 +21,8 @@ elseif(DEFINED ENV{WINDOWS_CERTIFICATE})
     )
 else()
     message(FATAL_ERROR [[
-        Code signing is skipped, as certifacte is missing. 
+        Code signing is skipped, as certifcate is missing. 
         Please, set the path to PFX file using -DWINDOWS_CERTIFICATE=... 
-        or set the environment variable WINDOWS_CERTIFICATE to base64 encoded PFX certifacte.
+        or set the environment variable WINDOWS_CERTIFICATE to base64 encoded PFX certifcate.
     ]])
 endif()

--- a/scripts/build/windows/PfxSign.ps1
+++ b/scripts/build/windows/PfxSign.ps1
@@ -2,7 +2,7 @@
 # or exe/dll/msi files in a directory using a pfx file.
 # If PFX file is not present, script expects a base64 encode certificate
 # in WINDOWS_CERTIFICATE environment variable.
-# Password can be passed using WINDOWS_CERTIFICATE_PASSWORD environmnet variable.
+# Password can be passed using WINDOWS_CERTIFICATE_PASSWORD environment variable.
 # The script only signs previously unsigned files
 
 [CmdletBinding()]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 
 # Detect, which version of FileDialog to use for
 # We always assume that GTK is used on platforms other than Windows and macOS,
-# as there is no other implementation avalaible now
+# as there is no other implementation available now
 if( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
    set( wxIS_MAC on )
 elseif( CMAKE_SYSTEM_NAME MATCHES "Windows" )

--- a/src/Experimental.cmake
+++ b/src/Experimental.cmake
@@ -39,7 +39,7 @@ set( EXPERIMENTAL_OPTIONS_LIST
    # JKC (effect by Norm C, 02 Oct 2013)
    SCIENCE_FILTERS
 
-   # JKC an experiement to work around bug 2709
+   # JKC an experiment to work around bug 2709
    # disabled.
    #CEE_NUMBERS_OPTION
 
@@ -90,7 +90,7 @@ set( EXPERIMENTAL_OPTIONS_LIST
    # but then the student didn't contribute after that.  It needs a bit of work to finish it off.
    # As a minimum, if this is turned on for a release,
    # it should have an easy mechanism to disable it at run-time, such as a menu item or a pref,
-   # preferrably disabled until other work is done.  Martyn 22/12/2008.
+   # preferably disabled until other work is done.  Martyn 22/12/2008.
    #
 
    # JKC Apr 2015, Menu item to manage effects.
@@ -176,7 +176,7 @@ set( EXPERIMENTAL_OPTIONS_LIST
 
    # PRL 11 Jul 2017
    # Highlight more things in TrackPanel when the mouse moves over them,
-   # using delibrately ugly pens and brushes until there is better cooperation
+   # using deliberately ugly pens and brushes until there is better cooperation
    # with themes
    #TRACK_PANEL_HIGHLIGHTING
 

--- a/src/JournalWindowPaths.cpp
+++ b/src/JournalWindowPaths.cpp
@@ -38,7 +38,7 @@ inline auto HasName( const wxString &name )
       // name as the related control.  Those windows are non-interactive so
       // don't interest us for journalling.
       !dynamic_cast<const wxStaticText *>( pWindow2 ) &&
-      // Also excluse this special window type defined in Audacity.
+      // Also exclude this special window type defined in Audacity.
       !dynamic_cast<const auStaticText *>( pWindow2 ) &&
       pWindow2->GetName() == name; };
 }

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1047,7 +1047,7 @@ bool ProjectFileIO::CopyTo(const FilePath &destpath,
 
          // Rollback transaction in case one was active.
          // If this fails (probably due to memory or disk space), the transaction will
-         // (presumably) stil be active, so further updates to the project file will
+         // (presumably) still be active, so further updates to the project file will
          // fail as well. Not really much we can do about it except tell the user.
          auto result = sqlite3_exec(db, "ROLLBACK;", nullptr, nullptr, nullptr);
 
@@ -1563,7 +1563,7 @@ void ProjectFileIO::Compact(
 
                   if (!wxRenameFile(origName, tempName))
                   {
-                     wxLogWarning(wxT("Compaction failed to rename orignal %s to temp %s"),
+                     wxLogWarning(wxT("Compaction failed to rename original %s to temp %s"),
                                   origName, tempName);
                   }
                }
@@ -1967,7 +1967,7 @@ bool ProjectFileIO::WriteDoc(const char *table,
       return false;
    }
 
-   // Finalize the statement before commiting the transaction
+   // Finalize the statement before committing the transaction
    sqlite3_finalize(stmt);
    stmt = nullptr;
 

--- a/src/TrackArt.cpp
+++ b/src/TrackArt.cpp
@@ -26,7 +26,7 @@ static constexpr int ClipSelectionStrokeSize{ 1 };//px
 
 namespace
 {
-   //Helper funciton that takes affordance rectangle as
+   //Helper function that takes affordance rectangle as
    //argument and returns rectangle to be used for title
    //drawings
    wxRect GetAffordanceTitleRect(const wxRect& rect)
@@ -171,7 +171,7 @@ wxString TrackArt::TruncateText(wxDC& dc, const wxString& text, const int maxWid
       auto strWidth = dc.GetTextExtent(str).GetWidth();
       if (strWidth < maxWidth)
          //if left == right (== middle), then exit loop
-         //with right equals to the last knwon index for which
+         //with right equals to the last known index for which
          //strWidth < maxWidth
          left = middle + 1;
       else if (strWidth > maxWidth)

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -182,9 +182,9 @@ public:
    //! Moves play end position by deltaTime
    void TrimRight(double deltaTime);
 
-   //! Sets the the left trimming to the absoulte time (if that is in bounds)
+   //! Sets the the left trimming to the absolute time (if that is in bounds)
    void TrimLeftTo(double to);
-   //! Sets the the right trimming to the absoulte time (if that is in bounds)
+   //! Sets the the right trimming to the absolute time (if that is in bounds)
    void TrimRightTo(double to);
 
    /*! @excsafety{No-fail} */

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1070,7 +1070,7 @@ void WaveTrack::ClearAndPaste(double t0, // Start of time to clear
             auto trim = src->GetPlayEndTime() - src->GetPlayStartTime();
             target->Paste(target->GetPlayStartTime(), src);
             target->SetTrimLeft(trim);
-            //Play start time needs to be ajusted after 
+            //Play start time needs to be adjusted after 
             //prepending data to the sequence
             target->Offset(-trim);
          };

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -229,7 +229,7 @@ EffectAmplify::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
       }
    }
 
-   // At this point mNewPeak is still uninitialized; this will intialize it
+   // At this point mNewPeak is still uninitialized; this will initialize it
    ClampRatio();
 
    S.AddSpace(0, 5);

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -208,7 +208,7 @@ bool EffectUIHost::TransferDataToWindow()
 {
    // Transfer-to takes const reference to settings
    return mEffectUIHost.TransferDataToWindow(mpAccess->Get()) &&
-      //! Do other apperance updates
+      //! Do other appearance updates
       mpValidator->UpdateUI() &&
       //! Do validators
       wxDialogWrapper::TransferDataToWindow();

--- a/src/effects/VST3/internal/ConnectionProxy.cpp
+++ b/src/effects/VST3/internal/ConnectionProxy.cpp
@@ -30,7 +30,7 @@ Steinberg::tresult internal::ConnectionProxy::connect (IConnectionPoint* other)
    else if(mTarget != nullptr)
       return Steinberg::kResultFalse;
 
-   //Looks a bit awkward, but the souce can send messages to
+   //Looks a bit awkward, but the source can send messages to
    //the target during connection
    mTarget = other;
    auto result = mSource->connect(this);

--- a/src/effects/VST3/internal/ConnectionProxy.h
+++ b/src/effects/VST3/internal/ConnectionProxy.h
@@ -16,7 +16,7 @@
 namespace internal
 {
    //!Host's proxy object between connection points
-   /*! Though it's not neccessary to place proxy, it's recommended to do so.
+   /*! Though it's not necessary to place proxy, it's recommended to do so.
     * Right now the only "useful" task performed by this proxy is ensuring
     * that messages are sent on the same thread on which proxy object itself
     * was created

--- a/src/export/ExportMP3.cpp
+++ b/src/export/ExportMP3.cpp
@@ -926,7 +926,7 @@ MP3Exporter::MP3Exporter()
 // We could use #defines rather than this variable.
 // The idea of the variable is that if we wanted, we could allow
 // a dynamic override of the library, e.g. with a newer faster version,
-// or to fix CVEs in the underlying librray.
+// or to fix CVEs in the underlying library.
 // for now though the 'variable' is a constant.
 #ifdef MP3_EXPORT_BUILT_IN
    mLibIsExternal = false;

--- a/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
@@ -163,7 +163,7 @@ void LabelGlyphHandle::HandleGlyphClick
             // then it's an adjust.
             // In both cases the two points coalesce.
             // 
-            // NOTE: seems that it's not neccessary that hitting the both
+            // NOTE: seems that it's not necessary that hitting the both
             // left and right handles mean that we're dealing with a point, 
             // but the range will be turned into a point on click
             bool isPointLabel = hit.mMouseOverLabelLeft == hit.mMouseOverLabelRight;

--- a/src/tracks/labeltrack/ui/LabelTrackView.h
+++ b/src/tracks/labeltrack/ui/LabelTrackView.h
@@ -186,7 +186,7 @@ private:
    /// Keeps track of the currently selected label (not same as selection region)
    /// used for navigation between labels
    mutable Index mNavigationIndex{ -1 };
-   /// Index of the current label text beeing edited
+   /// Index of the current label text being edited
    mutable Index mTextEditIndex{ -1 };
 
    mutable wxString mUndoLabel;
@@ -226,7 +226,7 @@ public:
    int GetInitialCursorPosition() const { return mInitialCursorPos; }
 
    /// Sets the label with specified index for editing,
-   /// optionaly selection may be specified with [start, end]
+   /// optionally selection may be specified with [start, end]
    void SetTextSelection(int labelIndex, int start = 1, int end = 1);
    int GetTextEditIndex(AudacityProject& project) const;
    void ResetTextSelection();

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
@@ -183,7 +183,7 @@ public:
 
    //FIXME: These functions do not push state to undo history
    //because attempt to do so leads to a focus lose which, in
-   //turn finilizes text editing (state is saved after text
+   //turn finalizes text editing (state is saved after text
    //editing was intentionally finished instead)
 
    bool CutSelectedText(AudacityProject& project);

--- a/src/tracks/ui/BrushHandle.cpp
+++ b/src/tracks/ui/BrushHandle.cpp
@@ -199,7 +199,7 @@ bool BrushHandle::Escape(AudacityProject *project)
    return false;
 }
 
-// Add or remove data accroding to the ctrl key press
+// Add or remove data according to the ctrl key press
 void BrushHandle::HandleHopBinData(int hopNum, int freqBinNum) {
    // Ignore the mouse dragging outside valid area
    // We should also check for the available freq. range that is visible to user

--- a/src/ui/AccessibleLinksFormatter.h
+++ b/src/ui/AccessibleLinksFormatter.h
@@ -20,7 +20,7 @@ class ShuttleGui;
 /*! @brief A class that allows translatable text to have accessible links in it in a way
 *          that is friendly to translators.
 * 
-* This class allows to replace arbitrary placeholders (like %s, %url, {} or anyting of the choice)
+* This class allows to replace arbitrary placeholders (like %s, %url, {} or anything of the choice)
 * with links, that are accessible from the keyboard. 
 * 
 * In case there are multiple placeholders with the same name - they will be replaced in order

--- a/win/Inno_Setup_Wizard/BuildInnoSetupInstaller.cmake
+++ b/win/Inno_Setup_Wizard/BuildInnoSetupInstaller.cmake
@@ -1,7 +1,7 @@
 # This CMake script is invoked to build the InnoSetup installer for Audacity
-# Requiered parameters:
+# Required parameters:
 # BUILD_DIR - should be set to CMAKE_BINARY_DIR by the caller
-# SOURCE_DIR - should be set to CMAKE_SOURCE_DIR by teh caller
+# SOURCE_DIR - should be set to CMAKE_SOURCE_DIR by the caller
 # OUTPUT_DIR - directory, where installer will be built
 # INNO_SETUP_COMPILER - InnoSetup compiler executable
 # BUILDING_64_BIT - Flag, that indicates that we are building a 64-bit installer

--- a/win/Inno_Setup_Wizard/audacity.iss.in
+++ b/win/Inno_Setup_Wizard/audacity.iss.in
@@ -104,7 +104,7 @@ Source: "Package\*.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "Additional\presets\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 ; We include all dll files from the Adacity root directory. This script is now executed as a part of CI build process,
-; so we controll which dll files are present in the directory.
+; so we control which dll files are present in the directory.
 Source: "Package\*.dll"; DestDir: "{app}"; Flags: ignoreversion
 
 Source: "Package\languages\*"; DestDir: "{app}\Languages\"; Flags: ignoreversion recursesubdirs


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.xpm,./lib-src -L ans,ba,clen,fiter,hashi,imagin,inout,levl,nin,ontext,optionaly,pard,parm,parms,pevent,pixelx,screem,siz,sord,strack,thisy,toke`