### PR TITLE
Audacity fails to compile with VS2019 16.9.0 (lrint, lrintf)

### DIFF
--- a/src/float_cast.h
+++ b/src/float_cast.h
@@ -56,6 +56,7 @@
    /*	Win32 doesn't seem to have these functions.
 	**	Therefore implement inline versions of these functions here.
 	*/
+#if _MSC_VER < 1928
 	__inline long int
 	lrint (double flt)
 	{	int intgr;
@@ -79,7 +80,7 @@
 
 		return intgr ;
 	}
-
+#endif
 	__inline long long int
 	llrint (double flt)
 	{	long long int intgr;


### PR DESCRIPTION
While prior releases of Windows VS2019 seemed to work with the new build instructions (see prior pull request), the very latest release 16.9.0 of VS2019, seems to have a problem with the intrinsic functions lrint and lrintf, and generates 68 compile errors.
Specifically, the build fails with an error: error C2169: 'lrint': intrinsic function, cannot be defined
and error C2169: 'lrintf': intrinsic function, cannot be defined while compiling AudioIO.cpp and other modules.

This patch removes the lrint and lrintf definitions using conditional compilation instructions depending on the value of "_MSC_VER".  I am sure there are other, perhaps more valid, approaches.

Note: the value of _MSC_VER is 1928 in 16.9.0. (_MSC_VER is also 1928 in 16.8.0, but _MSC_VER is 1927 in 16.7.0)
_MSC_FULL_VER happens to be 192829910 in my copy of 16.9.0, which has the problem.

I do not have _MSC_VER numbers of all prior successful Audacity builds, but it is reported that 16.3.8 builds OK (corresponding to _MSC_VER of 1923).  See this forum report: https://forum.audacityteam.org/viewtopic.php?p=418872#p418872
