### PR TITLE
Bug 1334 - Enh: Add Warning Message if some tracks muted when exporting

### DIFF
--- a/src/export/Export.h
+++ b/src/export/Export.h
@@ -245,6 +245,7 @@ private:
    int mFormat;
    int mSubFormat;
    int mNumSelected;
+   int mNumMute;
    unsigned mNumLeft;
    unsigned mNumRight;
    unsigned mNumMono;


### PR DESCRIPTION
There are warning messages when all tracks are muted. 
However, there was no warning message if some tracks were muted.
This PR adds a warning message with "Do not show this again" check box.