### PR TITLE
Fix source newlines for translation from \n to ~%

### DIFF
--- a/plug-ins/label-sounds.ny
+++ b/plug-ins/label-sounds.ny
@@ -160,7 +160,7 @@ $control text (_ "Label text") string "" (_ "Sound ##1")
                     snd-list)
               (incf label-count)
               (when (= label-count max-labels)
-                (format t (_ "Too many silences detected.\nOnly the first 10000 labels added."))
+                (format t (_ "Too many silences detected.~%Only the first 10000 labels added."))
                 (return-from find-sounds snd-list))
               (setf snd-count 0)) ;Pushed to list, so reset sound sample counter.
             (when (> snd-count 0) ;Sound is shorter than snd-dur, so keep counting.

--- a/plug-ins/nyquist-plug-in-installer.ny
+++ b/plug-ins/nyquist-plug-in-installer.ny
@@ -185,11 +185,11 @@ $control overwrite (_ "Allow overwriting") choice ((_ "Disallow") (_ "Allow")) 0
   ;; Format results and display in human readable form.
   (cond
     ((isempty install-success)
-      (setf msg (_ "Error.\n")))
+      (setf msg (_ "Error.~%")))
     ((isempty install-fail)
       (setf msg (format nil (_ "Success.~%Files written to:~%~s~%")
                         (get '*system-dir* 'user-plug-in))))
-    (t (setf msg (_ "Warning.\nFailed to copy some files:\n"))))
+    (t (setf msg (_ "Warning.~%Failed to copy some files:~%"))))
   (setf results (append install-success install-fail))
   (setf results (sort-results results))
   (let ((status -1))
@@ -213,7 +213,7 @@ $control overwrite (_ "Allow overwriting") choice ((_ "Disallow") (_ "Allow")) 0
   ;; This allows result messages to be grouped according to installation status.
   (case num
     ;; Success
-    (0 (_ "Plug-ins installed.\n(Use the Plug-in Manager to enable effects):"))
+    (0 (_ "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"))
     (1 (_ "Plug-ins updated:"))
     (2 (_ "Files copied to plug-ins folder:"))
     ;; Fail


### PR DESCRIPTION
Thanks to @Phroneris on Transifex for noticing this
@JamesCrook 