### PR TITLE
Drop documentation license from <project_license>

### DIFF
--- a/help/audacity.appdata.xml
+++ b/help/audacity.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop">
   <id>org.audacityteam.Audacity</id>
   <launchable type="desktop-id">audacity.desktop</launchable>
-  <project_license>GPL-2.0 and CC-BY-3.0</project_license>
+  <project_license>GPL-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Audacity</name>
   <summary>Record and edit audio files</summary>


### PR DESCRIPTION
The project license is for the project as a whole, and typically refers to the license for the code (which is GPL-2.0).

In SPDX, the `and` operator means that the conditions of both licenses must be adhered to, so the appdata file was previously essentially saying “all code and documentation is subject to a restrictive conjugation of both GPL-2.0 and CC-BY-SA-3.0”. `CC-BY-SA-3.0` is not an FSF or OSI approved license, which resulted in gnome-software interpreting this SPDX phrase as proprietary (see https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1200).

Subject to clarification in the appstream spec (https://github.com/ximion/appstream/issues/312), simplify the project license to reflect the top-level code license only.
