### PR TITLE
Patch for Bug 2452

### DIFF
--- a/src/PluginManager.h
+++ b/src/PluginManager.h
@@ -265,6 +265,9 @@ public:
    const PluginID & RegisterPlugin(EffectDefinitionInterface *effect, PluginType type );
    void UnregisterPlugin(const PluginID & ID);
 
+   void RemoveBadPlugins();
+   bool PluginExists(const PluginPath & path);
+
 private:
    // private! Use Get()
    PluginManager();


### PR DESCRIPTION
[Bug 2452](https://bugzilla.audacityteam.org/show_bug.cgi?id=2452) talks about plugin still being listed in the menu even after being deleted in storage. 

I introduced a function "PluginExists" that takes in a PluginPath and returns true if it exists in storage and false if it doesn't. Then I created a function "RemoveBadPlugins" that will iterate through the plug-ins and remove the one's that don't exist in storage anymore. Finally, I call the RemoveBadPlugins function when the plugin manager menu opens. I also introduced a GUI button on that menu called "Refresh" that will call the RemoveBadPlugins function. I'm not sure if the button is necessary though if the list is refreshed when opening the menu. I also created a function called "RefreshItems" which resets the items of the Dialog to what is in the PluginManager to allow the list to be updated after the bad plugins have been removed. 

I only tested this on Linux since that is what I have. I am open to any comments/suggestions/feedback, so please leave some!