### PR TITLE
CI: macOS: Unblock Xcode version

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -23,10 +23,6 @@ env:
   WXURL: https://github.com/audacity/wxWidgets
   WXREF: audacity-fixes-3.1.3
   WXWIN: ${{ github.workspace }}/wxwin
-  # As of 2021/01/01, github is using Xcode 12.2 as the default and
-  # it has a bug in the install_name_tool.  So explicitly use 12.3
-  # instead.
-  DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
   CONAN_USER_HOME: "${{ github.workspace }}/conan-home/"
   CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-home/short"
 #
@@ -70,7 +66,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     #  with:
-    #    ref: master   
+    #    ref: master
     # =========================================================================
     # SHARED: Checkout source
     # =========================================================================
@@ -204,7 +200,7 @@ jobs:
               -B build \
               -G "${{matrix.config.generator}}" \
               -D audacity_use_pch=no \
-              -D audacity_has_networking=yes ${{ env.SENTRY_PARAMETERS }} 
+              -D audacity_has_networking=yes ${{ env.SENTRY_PARAMETERS }}
 
         # Build Audacity
         cmake --build build --config Release
@@ -237,4 +233,3 @@ jobs:
       with:
         name: ${{ matrix.config.name }}_${{ env.SHORTHASH }}
         path: ${{ github.sha }}.zip
-


### PR DESCRIPTION
Unblocks the Xcode version in the macOS CI build, since the default is now 12.4.

Practically reverts ef88cb17 now that the GitHub environment was updated, as was intended.