### PR TITLE
Minor build warning fixes

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -546,8 +546,9 @@ struct AudioIoCallback::ScrubState
    ScrubState(double t0,
               double rate,
               const ScrubbingOptions &options)
-      : mRate(rate)
-      , mStartTime( t0 )
+      : mStartTime( t0 )
+      , mRate(rate)
+
    {
       const double t1 = options.bySpeed ? options.initSpeed : t0;
       Update( t1, options );

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -189,8 +189,8 @@ FrequencyPlotDialog::FrequencyPlotDialog(wxWindow * parent, wxWindowID id,
                            const wxPoint & pos)
 :  wxDialogWrapper(parent, id, title, pos, wxDefaultSize,
             wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX),
+   mProject{ &project },
    mAnalyst(std::make_unique<SpectrumAnalyst>())
-,  mProject{ &project }
 {
    SetName();
 

--- a/src/Printing.cpp
+++ b/src/Printing.cpp
@@ -47,8 +47,8 @@ class AudacityPrintout final : public wxPrintout
    AudacityPrintout(wxString title,
                     TrackList *tracks, TrackPanel &panel):
       wxPrintout(title),
-      mTracks(tracks)
-      , mPanel(panel)
+      mPanel(panel)
+      , mTracks(tracks)
    {
    }
    bool OnPrintPage(int page);

--- a/src/ProjectSettings.cpp
+++ b/src/ProjectSettings.cpp
@@ -53,10 +53,6 @@ ProjectSettings::ProjectSettings(AudacityProject &project)
       NumericConverter::TIME,
       gPrefs->Read(wxT("/SelectionFormat"), wxT("")))
 }
-, mAudioTimeFormat{ NumericTextCtrl::LookupFormat(
-   NumericConverter::TIME,
-   gPrefs->Read(wxT("/AudioTimeFormat"), wxT("hh:mm:ss")))
-}
 , mFrequencySelectionFormatName{ NumericTextCtrl::LookupFormat(
    NumericConverter::FREQUENCY,
    gPrefs->Read(wxT("/FrequencySelectionFormatName"), wxT("")) )
@@ -64,6 +60,10 @@ ProjectSettings::ProjectSettings(AudacityProject &project)
 , mBandwidthSelectionFormatName{ NumericTextCtrl::LookupFormat(
    NumericConverter::BANDWIDTH,
    gPrefs->Read(wxT("/BandwidthSelectionFormatName"), wxT("")) )
+}
+, mAudioTimeFormat{ NumericTextCtrl::LookupFormat(
+   NumericConverter::TIME,
+   gPrefs->Read(wxT("/AudioTimeFormat"), wxT("hh:mm:ss")))
 }
 , mSnapTo( gPrefs->Read(wxT("/SnapTo"), SNAP_OFF) )
 {

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -28,8 +28,8 @@
 #include "RingBuffer.h"
 
 RingBuffer::RingBuffer(sampleFormat format, size_t size)
-   : mFormat{ format }
-   , mBufferSize{ std::max<size_t>(size, 64) }
+   : mBufferSize{ std::max<size_t>(size, 64) }
+   , mFormat{ format }
    , mBuffer{ mBufferSize, mFormat }
 {
 }

--- a/src/ViewInfo.cpp
+++ b/src/ViewInfo.cpp
@@ -155,7 +155,7 @@ static const AudacityProject::AttachedObjects::RegisteredFactory key{
       project.Bind(EVT_TRACK_PANEL_TIMER,
          &ViewInfo::OnTimer,
          result.get());
-      return std::move( result );
+      return result;
    }
 };
 

--- a/src/commands/CommandTargets.h
+++ b/src/commands/CommandTargets.h
@@ -229,9 +229,9 @@ private:
    wxString mBuffer;
 public:
    ResponseTarget()
-      : mBuffer(wxEmptyString),
-        mSemaphore(0, 1)
-   { 
+      : mSemaphore(0, 1),
+        mBuffer(wxEmptyString)
+   {
       // Cater for handling long responses quickly.
       mBuffer.Alloc(40000);
    }

--- a/src/effects/Biquad.cpp
+++ b/src/effects/Biquad.cpp
@@ -134,7 +134,7 @@ ArrayOf<Biquad> Biquad::CalcButterworthFilter(int order, double fn, double fc, i
    pBiquad[0].fNumerCoeffs [B1] *= fDCPoleDistSqr / (1 << order);
    pBiquad[0].fNumerCoeffs [B2] *= fDCPoleDistSqr / (1 << order);
 
-   return std::move(pBiquad);
+   return pBiquad;
 }
 
 // order: filter order
@@ -216,7 +216,7 @@ ArrayOf<Biquad> Biquad::CalcChebyshevType1Filter(int order, double fn, double fc
       pBiquad[(order-1)/2].fDenomCoeffs [A1] = -fZPoleX;
       pBiquad[(order-1)/2].fDenomCoeffs [A2] = 0;
    }
-   return std::move(pBiquad);
+   return pBiquad;
 }
 
 // order: filter order
@@ -301,7 +301,7 @@ ArrayOf<Biquad> Biquad::CalcChebyshevType2Filter(int order, double fn, double fc
       pBiquad[iPair].fDenomCoeffs [A1] = -fZPoleX;
       pBiquad[iPair].fDenomCoeffs [A2] = 0;
    }
-   return std::move(pBiquad);
+   return pBiquad;
 }
 
 void Biquad::ComplexDiv (double fNumerR, double fNumerI, double fDenomR, double fDenomI,

--- a/src/effects/EBUR128.cpp
+++ b/src/effects/EBUR128.cpp
@@ -82,7 +82,7 @@ ArrayOf<Biquad> EBUR128::CalcWeightingFilter(double fs)
    pBiquad[1].fDenomCoeffs[Biquad::A1] = 2.0 * (K * K - 1.0) / (1.0 + K / Q + K * K);
    pBiquad[1].fDenomCoeffs[Biquad::A2] = (1.0 - K / Q + K * K) / (1.0 + K / Q + K * K);
 
-   return std::move(pBiquad);
+   return pBiquad;
 }
 
 void EBUR128::ProcessSampleFromChannel(float x_in, size_t channel)

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -209,11 +209,13 @@ const Scrubber &Scrubber::Get( const AudacityProject &project )
 
 Scrubber::Scrubber(AudacityProject *project)
    : mScrubToken(-1)
-   , mPaused(true)
    , mScrubSpeedDisplayCountdown(0)
    , mScrubStartPosition(-1)
 #ifdef EXPERIMENTAL_SCRUBBING_SCROLL_WHEEL
    , mSmoothScrollingScrub(false)
+#endif
+   , mPaused(true)
+#ifdef EXPERIMENTAL_SCRUBBING_SCROLL_WHEEL
    , mLogMaxScrubSpeed(0)
 #endif
 


### PR DESCRIPTION
Minor changes to fix build warnings for `-Wreorder` and `-Wpessimize-move` on GCC 10 (seen when building the Fedora package, since these flags get turned on in their build system).

The first commit just rearranges the initialization list for classes so that the elements are in the same order as the class members (since that is how the initialization is done anyway).

The second commit removes unneeded `std::move` calls from return statements that would prevent compilers from perform any move/copy elision optimizations on the values being returned (https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c/).