### PR TITLE
Enh 2752 - Enh: Import Label Tracks - Allow HH:MM:SS time spec

### DIFF
--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -368,6 +368,27 @@ void LabelStruct::MoveLabel( int iEdge, double fNewTime)
    updated = true;
 }
 
+bool LabelStruct::GetHHMMSS(wxString firstline, double *t0) {
+   bool result = TRUE;
+   wxChar colon = ':';
+   unsigned long hh = 0;
+   unsigned long mm = 0;
+   wxStringTokenizer toker{ firstline, colon };
+   wxString token = toker.GetNextToken();
+   int hhmmcnt = 0;
+   while (result && toker.GetLastDelimiter() == colon) {
+      result = token.ToCULong(&mm);
+      hh += mm; hh *= 60;
+      hhmmcnt++; if (hhmmcnt > 2) result = FALSE;
+      token = toker.GetNextToken();
+   }
+   if (result) {
+      result = Internat::CompatibleToDouble(token, t0);
+      *t0 += hh;
+   }
+   return result;
+}
+
 LabelStruct LabelStruct::Import(wxTextFile &file, int &index)
 {
    SelectedRegion sr;
@@ -386,13 +407,13 @@ LabelStruct LabelStruct::Import(wxTextFile &file, int &index)
       auto token = toker.GetNextToken();
 
       double t0;
-      if (!Internat::CompatibleToDouble(token, &t0))
+      if (!GetHHMMSS(token, &t0))
          throw BadFormatException{};
 
       token = toker.GetNextToken();
 
       double t1;
-      if (!Internat::CompatibleToDouble(token, &t1))
+      if (!GetHHMMSS(token, &t1))
          //s1 is not a number.
          t1 = t0;  //This is a one-sided label; t1 == t0.
       else

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -45,6 +45,7 @@ public:
 
    struct BadFormatException {};
    static LabelStruct Import(wxTextFile &file, int &index);
+   static bool GetHHMMSS(wxString token, double* t0);
 
    void Export(wxTextFile &file) const;
 


### PR DESCRIPTION
This patch allows Import > Labels to load text files that have label times specified in HH:MM:SS format, not just SECONDS format.

Most audio players and editors including Windows Media Player and including Audacity, display the current time position in a HH:MM:SS format not in a second format.  And, unfortunately, converting from this format into the seconds only format required by Import Labels, is not straight-forward and can be a daunting task for some users.

This fix to Import Labels allows label time specs to be in HH:MM:SS format in addition to previous seconds format.

To understand the nature of the problem, see these forum threads:
https://forum.audacityteam.org/viewtopic.php?t=99721 - Importing Labels
https://forum.audacityteam.org/viewtopic.php?p=420509#p420509 - Export Adobe Audition markers
https://forum.audacityteam.org/viewtopic.php?p=419894#p419894 - Split Audio into separate files based on timestamps
