### PR TITLE
Bug 2750 export multiple default metadata

### DIFF
--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -834,7 +834,7 @@ ProgressResult ExportMultipleDialog::ExportMultipleByLabel(bool byName,
          /* do the metadata for this file */
          // copy project metadata to start with
          setting.filetags = Tags::Get( *mProject );
-         setting.filetags.LoadDefaults();
+         //setting.filetags.LoadDefaults();
          if (exportSettings.size()) {
             setting.filetags = exportSettings.back().filetags;
          }
@@ -978,7 +978,7 @@ ProgressResult ExportMultipleDialog::ExportMultipleByTrack(bool byName,
          /* do the metadata for this file */
          // copy project metadata to start with
          setting.filetags = Tags::Get( *mProject );
-         setting.filetags.LoadDefaults();
+         //setting.filetags.LoadDefaults();
          if (exportSettings.size()) {
             setting.filetags = exportSettings.back().filetags;
          }

--- a/src/prefs/ExtImportPrefs.h
+++ b/src/prefs/ExtImportPrefs.h
@@ -42,8 +42,24 @@ public:
    wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def);
    void OnLeave();
    void SetPrefs (ExtImportPrefs *prefs);
+   ExtImportPrefs* GetPrefs() { return mPrefs; }
 private:
    ExtImportPrefs *mPrefs;
+};
+
+class extImpWxDropSource : public wxDropSource {
+public:
+   extImpWxDropSource(wxWindow*) {}
+   wxDropTarget* SourceTable = NULL;
+   wxDropTarget* CurrentTable = NULL;
+   bool GiveFeedback(wxDragResult effect)
+   {
+      return (SourceTable != CurrentTable);
+   }
+   void SetSourceTable(wxDropTarget* source) { SourceTable = source; }
+   //wxDropTarget* GetSourceTable() { return SourceTable; }
+   //wxDropTarget* GetCurrentTable() { return CurrentTable; }
+   void SetCurrentTable(wxDropTarget* current) { CurrentTable = current; }
 };
 
 class ExtImportPrefs final : public PrefsPanel
@@ -83,8 +99,11 @@ class ExtImportPrefs final : public PrefsPanel
 
    Grid *GetRuleTable() { return RuleTable; }
    wxListCtrl *GetPluginList() { return PluginList; }
+   wxDropTarget *dropRuleTable;
+   wxDropTarget *dropPluginList;
 
    wxWindow *GetDragFocus() { return mDragFocus; }
+   extImpWxDropSource *GetDropSource() { return mDropSource; }
 
  private:
 
@@ -97,6 +116,7 @@ class ExtImportPrefs final : public PrefsPanel
    wxButton *MoveRuleDown;
    wxButton *MoveFilterUp;
    wxButton *MoveFilterDown;
+   extImpWxDropSource *mDropSource;
 
    wxTextDataObject *dragtext1 {};
    wxTextDataObject *dragtext2 {};


### PR DESCRIPTION
Bug 2750 - Export Multiple substitutes default metadata for user-entered metadata 

Well, this was a cherry pick if I've ever seen one.  One might think it was deliberately designed to take the defaults.
