### PR TITLE
Use XDG dirs by default on Linux

### DIFF
--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -621,7 +621,10 @@ void AboutDialog::PopulateInformationPage( ShuttleGui & S )
 #endif
 
    // Location of settings
-   AddBuildinfoRow(&informationStr, XO("Settings folder:"), \
+   AddBuildinfoRow(&informationStr, XO("Config folder:"), \
+      FileNames::ConfigDir());
+   // Location of data
+   AddBuildinfoRow(&informationStr, XO("Data folder:"), \
       FileNames::DataDir());
 
    informationStr << wxT("</table>\n"); // end of build info table

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1108,6 +1108,9 @@ bool AudacityApp::OnInit()
    // AddHandler takes ownership
    wxFileSystem::AddHandler(safenew wxZipFSHandler);
 
+   // encouraged by wxwidgets
+   wxStandardPaths::Get().SetFileLayout(wxStandardPaths::FileLayout::FileLayout_XDG);
+
    //
    // Paths: set search path and temp dir path
    //
@@ -1249,7 +1252,7 @@ bool AudacityApp::OnInit()
 
    // Initialize preferences and language
    {
-      wxFileName configFileName(FileNames::DataDir(), wxT("audacity.cfg"));
+      wxFileName configFileName(FileNames::ConfigDir(), wxT("audacity.cfg"));
       auto appName = wxTheApp->GetAppName();
       InitPreferences( AudacityFileConfig::Create(
          appName, wxEmptyString,

--- a/src/CrashReport.cpp
+++ b/src/CrashReport.cpp
@@ -52,7 +52,7 @@ void Generate(wxDebugReport::Context ctx)
       std::atomic_bool done = {false};
       auto thread = std::thread([&]
       {
-         wxFileNameWrapper fn{ FileNames::DataDir(), wxT("audacity.cfg") };
+         wxFileNameWrapper fn{ FileNames::ConfigDir(), wxT("audacity.cfg") };
          rpt.AddFile(fn.GetFullPath(), _TS("Audacity Configuration"));
          rpt.AddFile(FileNames::PluginRegistry(), wxT("Plugin Registry"));
          rpt.AddFile(FileNames::PluginSettings(), wxT("Plugin Settings"));

--- a/src/FileNames.h
+++ b/src/FileNames.h
@@ -84,10 +84,15 @@ namespace FileNames
       FilePaths &otherNames, wxFileName &newName);
 
    wxString LowerCaseAppNameInPath( const wxString & dirIn);
+   /** \brief Audacity user config directory
+    *
+    * Where audacity keeps its settigns squirreled away, by default ~/.config/audacity/
+    * on Unix, Application Data/Audacity on Windows */
+   FilePath ConfigDir();
    /** \brief Audacity user data directory
     *
     * Where audacity keeps its settings and other user data squirreled away,
-    * by default ~/.audacity-data/ on Unix, Application Data/Audacity on
+    * by default ~/.local/share/audacity/ on Unix, Application Data/Audacity on
     * windows system */
    FilePath DataDir();
    FilePath ResourcesDir();


### PR DESCRIPTION
# Notice

The contents of this PR are now licensed under Creative Commons Zero v1.0 Universal, and have been released into the public domain. You may adapt this patch as you wish for any purpose.

# Original Text

This PR is an updated version of #632, which required a rebase against v3.0.x-based Audacity master.

This addresses [issue 2201](https://bugzilla.audacityteam.org/show_bug.cgi?id=2201) on the Bugzilla tracker.

The new behavior is only applicable to Linux. If the `~/.audacity-data` folder doesn't exist (i.e. on a new installation of Audacity) the proper XDG-compliant directories will be used for saving data (configuration files go in `~/.config/audacity`, data files go in `~/.local/share/audacity`). On existing installations of Audacity where `~/.audacity-data` already exists, that directory will continue to be used. This allows for potential downgrade compatibility should Audacity drop the legacy behavior in the future, and doesn't disrupt existing installations.
