### PR TITLE
Types: fix missing #include <limits>

### DIFF
--- a/include/audacity/Types.h
+++ b/include/audacity/Types.h
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <type_traits>
 #include <vector>
 #include <wx/debug.h> // for wxASSERT


### PR DESCRIPTION
This is required to build on Fedora 34.