### PR TITLE
AudioIOBase: add missing #include <portaudio.h>

### DIFF
--- a/src/AudioIOBase.cpp
+++ b/src/AudioIOBase.cpp
@@ -11,7 +11,7 @@ Paul Licameli split from AudioIO.cpp
 
 #include "AudioIOBase.h"
 
-
+#include <portaudio.h>
 
 #include <wx/sstream.h>
 #include <wx/txtstrm.h>


### PR DESCRIPTION
Building with the system portaudio does not work without this.