### PR TITLE
A few small mingw fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,12 @@ if( HAVE_LIBM )
    list( APPEND CMAKE_REQUIRED_LIBRARIES -lm )
 endif()
 
+# mingw fails to find math library (used in system libraries), force it here
+if( MINGW )
+    set( LIB_m m )
+    MARK_AS_ADVANCED( FORCE LIB_m )
+endif()
+
 check_library_exists( atomic __atomic_fetch_add_4 "" HAVE_LIBATOMIC )
 if( HAVE_LIBATOMIC )
   list( APPEND CMAKE_REQUIRED_LIBRARIES -latomic )

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 add_subdirectory( mod-script-pipe )
 
 
-if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" )
+if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
    if( NOT "${CMAKE_GENERATOR}" MATCHES "Visual Studio*")
       install( DIRECTORY "${_DEST}/modules"
                DESTINATION "${_PKGLIB}" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1064,6 +1064,11 @@ list( APPEND LIBRARIES
       $<$<PLATFORM_ID:Linux,FreeBSD,OpenBSD,NetBSD,CYGWIN>:pthread>
 )
 
+# mingw needs these too
+if( MINGW )
+    list( APPEND LIBRARIES PUBLIC z pthread)
+endif()
+
 set( BUILDING_AUDACITY YES )
 set( INSTALL_PREFIX "${_PREFIX}" )
 set( PKGLIBDIR "${_PKGLIBDIR}" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1120,14 +1120,16 @@ if( CMAKE_SYSTEM_NAME MATCHES "Windows" )
       POST_BUILD
    )
 
-   # Copy the VC runtime libraries as well
-   add_custom_command(
-      TARGET
-         ${TARGET}
-      COMMAND
-         ${CMAKE_COMMAND} -E copy ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} ${_DEST}
-      POST_BUILD
-   )
+   if(MSVC)
+       # Copy the VC runtime libraries as well
+       add_custom_command(
+          TARGET
+             ${TARGET}
+          COMMAND
+             ${CMAKE_COMMAND} -E copy ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} ${_DEST}
+          POST_BUILD
+       )
+   endif(MSVC)
 elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
    # Bug 2400 workaround
    #
@@ -1327,7 +1329,7 @@ if( NOT "${CMAKE_GENERATOR}" MATCHES "Xcode|Visual Studio*" )
       install( TARGETS ${TARGET}
                DESTINATION "."
                RESOURCE DESTINATION "${_APPDIR}/Resources" )
-   else()
+   elseif(NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
       install( TARGETS ${TARGET} RUNTIME )
       install( DIRECTORY "${_DEST}/${_LIBDIR}/"
                DESTINATION "${_LIBDIR}"

--- a/src/effects/VST/VSTControlMSW.h
+++ b/src/effects/VST/VSTControlMSW.h
@@ -11,7 +11,7 @@
 #ifndef AUDACITY_VSTCONTROLMSW_H
 #define AUDACITY_VSTCONTROLMSW_H
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "VSTControl.h"
 


### PR DESCRIPTION
Here are a few small fixes needed for cross-compiling Audacity with mingw from Linux.
They are pretty much self-explanatory.
Parts of the (existing) cmake setup assume MSVC, which breaks mingw builds specially if the host system is Linux.
