### PR TITLE
Fix precompiled headers

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -205,15 +205,18 @@ macro( check_for_platform_version )
 endmacro()
 
 # To be used to compile all C++ in the application and modules
-function( audacity_append_common_compiler_options var )
+function( audacity_append_common_compiler_options var use_pch )
+   if( NOT use_pch )
+      list( APPEND ${var}
+         PRIVATE
+            # include the correct config file; give absolute path to it, so
+            # that this works whether in src, modules, libraries
+            $<$<PLATFORM_ID:Windows>:/FI${CMAKE_BINARY_DIR}/src/private/configwin.h>
+            $<$<PLATFORM_ID:Darwin>:-include ${CMAKE_BINARY_DIR}/src/private/configmac.h>
+            $<$<NOT:$<PLATFORM_ID:Windows,Darwin>>:-include ${CMAKE_BINARY_DIR}/src/private/configunix.h>
+      )
+   endif()
    list( APPEND ${var}
-      PRIVATE
-         # include the correct config file; give absolute path to it, so
-         # that this works whether in src, modules, libraries
-         $<$<PLATFORM_ID:Windows>:/FI${CMAKE_BINARY_DIR}/src/private/configwin.h>
-         $<$<PLATFORM_ID:Darwin>:-include ${CMAKE_BINARY_DIR}/src/private/configmac.h>
-         $<$<NOT:$<PLATFORM_ID:Windows,Darwin>>:-include ${CMAKE_BINARY_DIR}/src/private/configunix.h>
-
          -DAUDACITY_VERSION=${AUDACITY_VERSION}
          -DAUDACITY_RELEASE=${AUDACITY_RELEASE}
          -DAUDACITY_REVISION=${AUDACITY_REVISION}
@@ -346,7 +349,7 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
    # Compute compilation options.
    # Perhaps a another function argument in future to customize this too.
    set( OPTIONS )
-   audacity_append_common_compiler_options( OPTIONS )
+   audacity_append_common_compiler_options( OPTIONS NO )
 
    organize_source( "${TARGET_ROOT}" "" "${SOURCES}" )
    target_sources( ${TARGET} PRIVATE ${SOURCES} )

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -23,10 +23,6 @@
 #include <utility>
 #include <wx/atomic.h> // member variable
 
-#ifdef USE_MIDI
-
-// TODO: Put the relative paths into automake.
-
 #ifdef EXPERIMENTAL_MIDI_OUT
 typedef void PmStream;
 typedef int32_t PmTimestamp;
@@ -40,8 +36,6 @@ using NoteTrackArray = std::vector < std::shared_ptr< NoteTrack > >;
 using NoteTrackConstArray = std::vector < std::shared_ptr< const NoteTrack > >;
 
 #endif // EXPERIMENTAL_MIDI_OUT
-
-#endif // USE_MIDI
 
 #include <wx/event.h> // to declare custom event types
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1022,7 +1022,18 @@ list( APPEND DEFINES
       >
 )
 
-audacity_append_common_compiler_options( OPTIONS )
+# If we have cmake 3.16 or higher, we can use precompiled headers, but
+# only use them if ccache is not available and the user hasn't disabled
+# it.
+if( CMAKE_VERSION VERSION_GREATER_EQUAL "3.16" AND NOT CCACHE_PROGRAM )
+   cmd_option(
+      ${_OPT}use_pch
+      "Use precompiled headers [yes, no]"
+      YES
+   )
+endif()
+
+audacity_append_common_compiler_options( OPTIONS "${${_OPT}use_pch}" )
 
 list( APPEND LDFLAGS
    PRIVATE
@@ -1304,19 +1315,15 @@ target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
 target_link_options( ${TARGET} PRIVATE ${LDFLAGS} )
 target_link_libraries( ${TARGET} ${LIBRARIES} )
 
-# If was have cmake 3.16 or higher, we can use precompiled headers, but
-# only use them if ccache is not available and the user hasn't disabled
-# it.
 if( CMAKE_VERSION VERSION_GREATER_EQUAL "3.16" AND NOT CCACHE_PROGRAM )
-   cmd_option(
-      ${_OPT}use_pch
-      "Use precompiled headers [yes, no]"
-      YES
-   )
-
    if( ${_OPT}use_pch )
       message( STATUS "Using precompiled headers" )
-      target_precompile_headers( ${TARGET} PRIVATE AudacityHeaders.h )
+      target_precompile_headers( ${TARGET} PRIVATE
+         $<$<PLATFORM_ID:Windows>:{CMAKE_BINARY_DIR}/src/private/configwin.h>
+         $<$<PLATFORM_ID:Darwin>:${CMAKE_BINARY_DIR}/src/private/configmac.h>
+         $<$<NOT:$<PLATFORM_ID:Windows,Darwin>>:${CMAKE_BINARY_DIR}/src/private/configunix.h>
+         AudacityHeaders.h
+      )
    else()
       message( STATUS "Not using precompiled headers" )
    endif()


### PR DESCRIPTION
   Fix builds with precompiled headers, which broke at 794f4e5
