### PR TITLE
Issue 887: Some strings didn't translate, though in catalogs...

### DIFF
--- a/include/audacity/Types.h
+++ b/include/audacity/Types.h
@@ -373,7 +373,10 @@ public:
             default: {
                bool debug = request == Request::DebugFormat;
                return wxString::Format(
-                  TranslatableString::DoSubstitute( prevFormatter, str, debug ),
+                  TranslatableString::DoSubstitute(
+                     prevFormatter,
+                     str, TranslatableString::DoGetContext( prevFormatter ),
+                     debug ),
                   TranslatableString::TranslateArgument( args, debug )...
                );
             }
@@ -399,8 +402,11 @@ public:
          switch ( request ) {
             case Request::Context:
                return context;
+            case Request::DebugFormat:
+               return DoSubstitute( {}, str, context, true );
+            case Request::Format:
             default:
-               return str;
+               return DoSubstitute( {}, str, context, false );
          }
       };
       return *this;
@@ -477,9 +483,11 @@ private:
 
    static wxString DoGetContext( const Formatter &formatter );
    static wxString DoSubstitute(
-      const Formatter &formatter, const wxString &format, bool debug );
+      const Formatter &formatter,
+      const wxString &format, const wxString &context, bool debug );
    wxString DoFormat( bool debug ) const
-   {  return DoSubstitute( mFormatter, mMsgid, debug ); }
+   {  return DoSubstitute(
+      mFormatter, mMsgid, DoGetContext(mFormatter), debug ); }
 
    static wxString DoChooseFormat(
       const Formatter &formatter,

--- a/src/Internat.cpp
+++ b/src/Internat.cpp
@@ -334,7 +334,10 @@ TranslatableString &TranslatableString::Strip( unsigned codes ) &
          default: {
             bool debug = request == Request::DebugFormat;
             auto result =
-               TranslatableString::DoSubstitute( prevFormatter, str, debug );
+               TranslatableString::DoSubstitute(
+                  prevFormatter,
+                  str, TranslatableString::DoGetContext( prevFormatter ),
+                  debug );
             if ( codes & MenuCodes )
                result = wxStripMenuCodes( result );
             if ( codes & Ellipses ) {
@@ -357,13 +360,13 @@ wxString TranslatableString::DoGetContext( const Formatter &formatter )
    return formatter ? formatter( {}, Request::Context ) : wxString{};
 }
 
-wxString TranslatableString::DoSubstitute(
-   const Formatter &formatter, const wxString &format, bool debug )
+wxString TranslatableString::DoSubstitute( const Formatter &formatter,
+   const wxString &format, const wxString &context, bool debug )
 {
    return formatter
       ? formatter( format, debug ? Request::DebugFormat : Request::Format )
       : // come here for most translatable strings, which have no formatting
-         ( debug ? format : wxGetTranslation( format ) );
+         ( debug ? format : wxGetTranslation( format, wxString{}, context ) );
 }
 
 wxString TranslatableString::DoChooseFormat(
@@ -404,7 +407,9 @@ TranslatableString &TranslatableString::Join(
          default: {
             bool debug = request == Request::DebugFormat;
             return
-               TranslatableString::DoSubstitute( prevFormatter, str, debug )
+               TranslatableString::DoSubstitute( prevFormatter,
+                  str, TranslatableString::DoGetContext( prevFormatter ),
+                  debug )
                   + separator
                   + arg.DoFormat( debug );
          }


### PR DESCRIPTION
All examples were uses of the XC macro for strings with disambiguating contexts and this had never been correctly implemented.
