### PR TITLE
Module manager changes

### DIFF
--- a/include/audacity/ModuleInterface.h
+++ b/include/audacity/ModuleInterface.h
@@ -136,18 +136,6 @@ public:
 };
 
 // ----------------------------------------------------------------------------
-// The default entry point name and the name that will be searched for during
-// load if the module has been built as a external library.
-// ----------------------------------------------------------------------------
-#define MODULE_ENTRY AudacityModule
-
-// ----------------------------------------------------------------------------
-// If BUILDING_AUDACITY is defined during the current build, it is assumed
-// that the module wishes to be embedded in the Audacity executable.
-// ----------------------------------------------------------------------------
-#if defined(BUILDING_AUDACITY)
-
-// ----------------------------------------------------------------------------
 // Since there may be multiple embedded modules, the module entry function will
 // be declared static so as not to interfere with other modules during link.
 // ----------------------------------------------------------------------------
@@ -184,31 +172,11 @@ static name name ## _instance;
 DECLARE_BUILTIN_MODULE_BASE(name)                     \
 void name::Register()                                 \
 {                                                     \
-   RegisterProvider(MODULE_ENTRY);                    \
+   RegisterProvider(AudacityModule);                  \
 }                                                     \
 void name::Unregister()                               \
 {                                                     \
-   UnregisterProvider(MODULE_ENTRY);                  \
+   UnregisterProvider(AudacityModule);                \
 }
-
-#else
-
-// ----------------------------------------------------------------------------
-// When building as an external module, the entry point must be declared with
-// "C" linkage and whatever method is used to make the function externally
-// visible.
-// ----------------------------------------------------------------------------
-#define DECLARE_MODULE_ENTRY(name)                                            \
-extern "C" __declspec(dllexport)                                              \
-   ModuleInterface * name(const wxString *path)
-
-// ----------------------------------------------------------------------------
-// Define these as empty will effectively remove the embedded registration
-// functionality.
-// ----------------------------------------------------------------------------
-#define DECLARE_BUILTIN_MODULE_BASE(name)
-#define DECLARE_BUILTIN_MODULE(name)
-
-#endif
 
 #endif // __AUDACITY_MODULEINTERFACE_H__

--- a/include/audacity/ModuleInterface.h
+++ b/include/audacity/ModuleInterface.h
@@ -142,11 +142,6 @@ public:
 #define MODULE_ENTRY AudacityModule
 
 // ----------------------------------------------------------------------------
-// The module entry point prototype
-// ----------------------------------------------------------------------------
-typedef ModuleInterface *(*ModuleMain)(const wxString *path);
-
-// ----------------------------------------------------------------------------
 // If BUILDING_AUDACITY is defined during the current build, it is assumed
 // that the module wishes to be embedded in the Audacity executable.
 // ----------------------------------------------------------------------------
@@ -170,7 +165,6 @@ static ModuleInterface * name(const wxString *path)
 // method must be supplied explicitly.
 // ----------------------------------------------------------------------------
 #define DECLARE_BUILTIN_MODULE_BASE(name)             \
-extern void RegisterBuiltinModule(ModuleMain rtn);    \
 class name                                            \
 {                                                     \
 public:                                               \

--- a/include/audacity/ModuleInterface.h
+++ b/include/audacity/ModuleInterface.h
@@ -140,7 +140,7 @@ public:
 // be declared static so as not to interfere with other modules during link.
 // ----------------------------------------------------------------------------
 #define DECLARE_MODULE_ENTRY(name)                    \
-static ModuleInterface * name(const wxString *path)
+static ModuleInterface * name()
 
 // ----------------------------------------------------------------------------
 // This will create a class and instance that will register the module entry

--- a/include/audacity/ModuleInterface.h
+++ b/include/audacity/ModuleInterface.h
@@ -164,12 +164,15 @@ static ModuleInterface * name(const wxString *path)
 // Provides the base for embedded module registration.  If used, a Register()
 // method must be supplied explicitly.
 // ----------------------------------------------------------------------------
+
 #define DECLARE_BUILTIN_MODULE_BASE(name)             \
 class name                                            \
 {                                                     \
 public:                                               \
    name() {Register();}                               \
+   ~name() {Unregister();}                            \
    void Register();                                   \
+   void Unregister();                                 \
 };                                                    \
 static name name ## _instance;
 
@@ -181,7 +184,11 @@ static name name ## _instance;
 DECLARE_BUILTIN_MODULE_BASE(name)                     \
 void name::Register()                                 \
 {                                                     \
-   RegisterBuiltinModule(MODULE_ENTRY);               \
+   RegisterProvider(MODULE_ENTRY);                    \
+}                                                     \
+void name::Unregister()                               \
+{                                                     \
+   UnregisterProvider(MODULE_ENTRY);                  \
 }
 
 #else

--- a/modules/mod-null/ModNullCallback.cpp
+++ b/modules/mod-null/ModNullCallback.cpp
@@ -35,11 +35,6 @@ click from the menu into the actual function to be called.
 
 /*
 There are several functions that can be used in a GUI module.
-
-//#define versionFnName   "GetVersionString"
-If the version is wrong, the module will be rejected.
-That is it will be loaded and then unloaded.
-
 //#define ModuleDispatchName "ModuleDispatch"
 The most useful function.  See the example in this 
 file.  It has several cases/options in it.
@@ -84,18 +79,7 @@ static CommandHandlerObject &ident(AudacityProject&project)
 return project;
 }
 
-// GetVersionString
-// REQUIRED for the module to be accepted by Audacity.
-// Without it Audacity will see a version number mismatch.
-extern DLL_API const wxChar * GetVersionString(); 
-const wxChar * GetVersionString()
-{
-   // Make sure that this version of the module requires the version 
-   // of Audacity it is built with. 
-   // For now, the versions must match exactly for Audacity to 
-   // agree to load the module.
-   return AUDACITY_VERSION_STRING;
-}
+DEFINE_VERSION_CHECK
 
 namespace {
 void RegisterMenuItems()

--- a/modules/mod-null/ModNullCallback.cpp
+++ b/modules/mod-null/ModNullCallback.cpp
@@ -27,8 +27,7 @@ click from the menu into the actual function to be called.
 
 #include <wx/wx.h>
 #include "ModNullCallback.h"
-
-#include "ModuleManager.h"
+#include "ModuleConstants.h"
 #include "ShuttleGui.h"
 #include "Project.h"
 #include "commands/CommandManager.h"
@@ -54,14 +53,6 @@ This function is the hijacking function, to take over Audacity
 and replace the main project window with our own wxFrame.
 
 */
-
-#ifdef _MSC_VER
-   #define DLL_API _declspec(dllexport)
-   #define DLL_IMPORT _declspec(dllimport)
-#else
-   #define DLL_API __attribute__ ((visibility("default")))
-   #define DLL_IMPORT
-#endif
 
 // derived from wxFrame as it needs to be some kind of event handler.
 class ModNullCallback : public wxFrame

--- a/modules/mod-null/ModNullCallback.cpp
+++ b/modules/mod-null/ModNullCallback.cpp
@@ -34,15 +34,8 @@ click from the menu into the actual function to be called.
 #include "CommonCommandFlags.h"
 
 /*
-There are several functions that can be used in a GUI module.
 //#define ModuleDispatchName "ModuleDispatch"
-The most useful function.  See the example in this 
-file.  It has several cases/options in it.
-
-//#define mainPanelFnName "MainPanelFunc"
-This function is the hijacking function, to take over Audacity
-and replace the main project window with our own wxFrame.
-
+See the example in this file.  It has several cases/options in it.
 */
 
 // derived from wxFrame as it needs to be some kind of event handler.

--- a/modules/mod-null/ModNullCallback.cpp
+++ b/modules/mod-null/ModNullCallback.cpp
@@ -39,10 +39,6 @@ There are several functions that can be used in a GUI module.
 The most useful function.  See the example in this 
 file.  It has several cases/options in it.
 
-//#define scriptFnName    "RegScriptServerFunc"
-This function is run from a non gui thread.  It was originally 
-created for the benefit of mod-script-pipe.
-
 //#define mainPanelFnName "MainPanelFunc"
 This function is the hijacking function, to take over Audacity
 and replace the main project window with our own wxFrame.

--- a/modules/mod-null/ModNullCallback.h
+++ b/modules/mod-null/ModNullCallback.h
@@ -4,15 +4,3 @@
 // that uses this DLL. This way any other project whose source files include this file see 
 // MOD_NULL_DLL_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
-
-
-/* Magic for dynamic library import and export. This is unfortunately
- * compiler-specific because there isn't a standard way to do it. Currently it
- * works with the Visual Studio compiler for windows, and for GCC 4+. Anything
- * else gets all symbols made public, which gets messy */
-/* The Visual Studio implementation */
-#ifdef _MSC_VER
-#define DLL_API _declspec(dllexport)
-#else
-#define DLL_API __attribute__ ((visibility("default")))
-#endif

--- a/modules/mod-nyq-bench/NyqBench.cpp
+++ b/modules/mod-nyq-bench/NyqBench.cpp
@@ -96,10 +96,6 @@ There are several functions that can be used in a GUI module.
 The most useful function.  See the example in this 
 file.  It has several cases/options in it.
 
-//#define scriptFnName    "RegScriptServerFunc"
-This function is run from a non gui thread.  It was originally 
-created for the benefit of mod-script-pipe.
-
 //#define mainPanelFnName "MainPanelFunc"
 This function is the hijacking function, to take over Audacity
 and replace the main project window with our own wxFrame.

--- a/modules/mod-nyq-bench/NyqBench.cpp
+++ b/modules/mod-nyq-bench/NyqBench.cpp
@@ -25,7 +25,7 @@
 
 #include "AudioIOBase.h"
 #include "CommonCommandFlags.h"
-#include "ModuleManager.h"
+#include "ModuleConstants.h"
 #include "Prefs.h"
 #include "Project.h"
 #include "ShuttleGui.h"
@@ -133,12 +133,6 @@ void RegisterMenuItems()
 extern "C"
 {
    static NyqBench *gBench = NULL;
-
-   #ifdef _MSC_VER
-      #define DLL_API _declspec(dllexport)
-   #else
-      #define DLL_API __attribute__ ((visibility("default")))
-   #endif
 
    extern DLL_API const wxChar * GetVersionString();
    // GetVersionString

--- a/modules/mod-nyq-bench/NyqBench.cpp
+++ b/modules/mod-nyq-bench/NyqBench.cpp
@@ -92,10 +92,6 @@
 /*
 There are several functions that can be used in a GUI module.
 
-//#define versionFnName   "GetVersionString"
-If the version is wrong, the module will be rejected.
-That is it will be loaded and then unloaded.
-
 //#define ModuleDispatchName "ModuleDispatch"
 The most useful function.  See the example in this 
 file.  It has several cases/options in it.
@@ -130,20 +126,11 @@ void RegisterMenuItems()
 }
 }
 
+DEFINE_VERSION_CHECK
+
 extern "C"
 {
    static NyqBench *gBench = NULL;
-
-   extern DLL_API const wxChar * GetVersionString();
-   // GetVersionString
-   // REQUIRED for the module to be accepted by Audacity.
-   // Without it Audacity will see a version number mismatch.
-   const wxChar * GetVersionString()
-   {
-      // For now, the versions must match exactly for Audacity to 
-      // agree to load the module.
-      return AUDACITY_VERSION_STRING;
-   }
 
    extern int DLL_API ModuleDispatch(ModuleDispatchTypes type);
    // ModuleDispatch

--- a/modules/mod-nyq-bench/NyqBench.cpp
+++ b/modules/mod-nyq-bench/NyqBench.cpp
@@ -90,16 +90,8 @@
 #include "images/media-playback-stop-large.xpm"
 
 /*
-There are several functions that can be used in a GUI module.
-
 //#define ModuleDispatchName "ModuleDispatch"
-The most useful function.  See the example in this 
-file.  It has several cases/options in it.
-
-//#define mainPanelFnName "MainPanelFunc"
-This function is the hijacking function, to take over Audacity
-and replace the main project window with our own wxFrame.
-
+See the example in this file.  It has several cases/options in it.
 */
 
 namespace {

--- a/modules/mod-script-pipe/ScripterCallback.cpp
+++ b/modules/mod-script-pipe/ScripterCallback.cpp
@@ -37,25 +37,7 @@ and replace the main project window with our own wxFrame.
 
 */
 
-#ifdef _MSC_VER
-   #define DLL_API _declspec(dllexport)
-   #define DLL_IMPORT _declspec(dllimport)
-#else
-   #define DLL_API __attribute__ ((visibility("default")))
-   #define DLL_IMPORT
-#endif
-
-
-typedef enum
-{
-   ModuleInitialize,
-   ModuleTerminate,
-   AppInitialized,
-   AppQuiting,
-   ProjectInitialized,
-   ProjectClosing
-} ModuleDispatchTypes;
-
+#include "ModuleConstants.h"
 
 extern void PipeServer();
 typedef DLL_IMPORT int (*tpExecScriptServerFunc)( wxString * pIn, wxString * pOut);

--- a/modules/mod-script-pipe/ScripterCallback.cpp
+++ b/modules/mod-script-pipe/ScripterCallback.cpp
@@ -15,6 +15,7 @@
 
 #include <wx/wx.h>
 #include "ScripterCallback.h"
+#include "commands/ScriptCommandRelay.h"
 
 /*
 There are several functions that can be used in a GUI module.
@@ -22,10 +23,6 @@ There are several functions that can be used in a GUI module.
 //#define ModuleDispatchName "ModuleDispatch"
 The most useful function.  See the example in this 
 file.  It has several cases/options in it.
-
-//#define scriptFnName    "RegScriptServerFunc"
-This function is run from a non gui thread.  It was originally 
-created for the benefit of mod-script-pipe.
 
 //#define mainPanelFnName "MainPanelFunc"
 This function is the hijacking function, to take over Audacity
@@ -39,8 +36,6 @@ extern void PipeServer();
 typedef DLL_IMPORT int (*tpExecScriptServerFunc)( wxString * pIn, wxString * pOut);
 static tpExecScriptServerFunc pScriptServerFn=NULL;
 
-
-DEFINE_MODULE_ENTRIES
 
 extern "C" {
 
@@ -56,6 +51,18 @@ int DLL_API RegScriptServerFunc( tpExecScriptServerFunc pFn )
    return 4;
 }
 
+DEFINE_VERSION_CHECK
+extern "C" DLL_API int ModuleDispatch(ModuleDispatchTypes type)
+{
+   switch (type) {
+   case ModuleInitialize:
+      ScriptCommandRelay::StartScriptServer(RegScriptServerFunc);
+      break;
+   default:
+      break;
+   }
+   return 1;
+}
 
 wxString Str2;
 wxArrayString aStr;

--- a/modules/mod-script-pipe/ScripterCallback.cpp
+++ b/modules/mod-script-pipe/ScripterCallback.cpp
@@ -19,10 +19,6 @@
 /*
 There are several functions that can be used in a GUI module.
 
-//#define versionFnName   "GetVersionString"
-If the version is wrong, the module will be rejected.
-That is it will be loaded and then unloaded.
-
 //#define ModuleDispatchName "ModuleDispatch"
 The most useful function.  See the example in this 
 file.  It has several cases/options in it.
@@ -44,39 +40,9 @@ typedef DLL_IMPORT int (*tpExecScriptServerFunc)( wxString * pIn, wxString * pOu
 static tpExecScriptServerFunc pScriptServerFn=NULL;
 
 
+DEFINE_MODULE_ENTRIES
+
 extern "C" {
-
-
-DLL_API const wxChar * GetVersionString()
-{
-   // Make sure that this version of the module requires the version 
-   // of Audacity it is built with. 
-   // For now the versions must match exactly for Audacity to 
-   // agree to load the module.
-   return AUDACITY_VERSION_STRING;
-}
-
-extern int DLL_API  ModuleDispatch(ModuleDispatchTypes type);
-// ModuleDispatch
-// is called by Audacity to initialize/terminate the module
-// We don't (yet) do anything in this, since we have a special function for the scripter
-// all we need to do is return 1.
-int ModuleDispatch(ModuleDispatchTypes type){
-   switch (type){
-      case AppInitialized:{
-      }
-      break;
-      case AppQuiting: {
-      }
-      break;
-      case ProjectInitialized: {
-      }
-      break;
-      default:
-      break;
-   }
-   return 1;
-}   
 
 // And here is our special registration function.
 int DLL_API RegScriptServerFunc( tpExecScriptServerFunc pFn )

--- a/modules/mod-script-pipe/ScripterCallback.cpp
+++ b/modules/mod-script-pipe/ScripterCallback.cpp
@@ -18,16 +18,8 @@
 #include "commands/ScriptCommandRelay.h"
 
 /*
-There are several functions that can be used in a GUI module.
-
 //#define ModuleDispatchName "ModuleDispatch"
-The most useful function.  See the example in this 
-file.  It has several cases/options in it.
-
-//#define mainPanelFnName "MainPanelFunc"
-This function is the hijacking function, to take over Audacity
-and replace the main project window with our own wxFrame.
-
+See the example in this file.  It has several cases/options in it.
 */
 
 #include "ModuleConstants.h"

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1456,15 +1456,6 @@ bool AudacityApp::InitPart2()
    // seemed to arrive with wx3.
    {
       project = ProjectManager::New();
-      wxWindow * pWnd = MakeHijackPanel();
-      if (pWnd)
-      {
-         auto &window = GetProjectFrame( *project );
-         window.Show(false);
-         pWnd->SetParent( &window );
-         SetTopWindow(pWnd);
-         pWnd->Show(true);
-      }
    }
 
    if( ProjectSettings::Get( *project ).GetShowSplashScreen() ){

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1334,7 +1334,7 @@ bool AudacityApp::InitPart2()
    PluginManager::Get().Initialize();
 
    // Initialize the ModuleManager, including loading found modules
-   ModuleManager::Get().Initialize(*mCmdHandler);
+   ModuleManager::Get().Initialize();
 
    // Parse command line and handle options that might require
    // immediate exit...no need to initialize all of the audio

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1330,11 +1330,11 @@ bool AudacityApp::InitPart2()
    // Initialize the CommandHandler
    InitCommandHandler();
 
-   // Initialize the PluginManager
-   PluginManager::Get().Initialize();
-
    // Initialize the ModuleManager, including loading found modules
    ModuleManager::Get().Initialize();
+
+   // Initialize the PluginManager
+   PluginManager::Get().Initialize();
 
    // Parse command line and handle options that might require
    // immediate exit...no need to initialize all of the audio

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,6 +179,7 @@ list( APPEND SOURCES
       Mix.h
       MixerBoard.cpp
       MixerBoard.h
+      ModuleConstants.h
       ModuleManager.cpp
       ModuleManager.h
       NoteTrack.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,6 +182,8 @@ list( APPEND SOURCES
       ModuleConstants.h
       ModuleManager.cpp
       ModuleManager.h
+      ModuleSettings.cpp
+      ModuleSettings.h
       NoteTrack.cpp
       NoteTrack.h
       NumberScale.h

--- a/src/ModuleConstants.h
+++ b/src/ModuleConstants.h
@@ -31,4 +31,26 @@ enum ModuleDispatchTypes
    ProjectClosing
 };
 
+// Macro generates one of the required entry points of a module
+// GetVersionString
+// REQUIRED for the module to be accepted by Audacity.
+// Without it Audacity will see a version number mismatch.
+#define DEFINE_VERSION_CHECK                                           \
+extern "C" {                                                           \
+   DLL_API const wchar_t * GetVersionString()                          \
+   {                                                                   \
+     /* Make sure that this version of the module requires the version \
+      of Audacity it is built with.                                    \
+      For now, the versions must match exactly for Audacity to         \
+      agree to load the module. */                                     \
+      return AUDACITY_VERSION_STRING;                                  \
+   }                                                                   \
+}
+
+// Macro generates minimal required entry points to load a module
+// Use it when you don't care about event notifications from the application
+#define DEFINE_MODULE_ENTRIES                                          \
+DEFINE_VERSION_CHECK                                                   \
+extern "C" DLL_API int ModuleDispatch(ModuleDispatchTypes type){ return 1; }
+
 #endif

--- a/src/ModuleConstants.h
+++ b/src/ModuleConstants.h
@@ -1,0 +1,34 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ModuleConstants.h
+
+  Paul Licameli split from ModuleManager.h
+
+**********************************************************************/
+
+#ifndef __AUDACITY_MODULE_CONSTANTS__
+#define __AUDACITY_MODULE_CONSTANTS__
+
+#define ModuleDispatchName "ModuleDispatch"
+
+#ifdef _MSC_VER
+   #define DLL_API _declspec(dllexport)
+   #define DLL_IMPORT _declspec(dllimport)
+#else
+   #define DLL_API __attribute__ ((visibility("default")))
+   #define DLL_IMPORT
+#endif
+
+enum ModuleDispatchTypes
+{
+   ModuleInitialize,
+   ModuleTerminate,
+   AppInitialized,
+   AppQuiting,
+   ProjectInitialized,
+   ProjectClosing
+};
+
+#endif

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -36,7 +36,7 @@ i.e. an alternative to the usual interface, for Audacity.
 
 #ifdef EXPERIMENTAL_MODULE_PREFS
 #include "Prefs.h"
-#include "./prefs/ModulePrefs.h"
+#include "ModuleSettings.h"
 #endif
 
 #include "widgets/MultiDialog.h"
@@ -256,7 +256,7 @@ void ModuleManager::TryLoadModules(
          continue;
 
 #ifdef EXPERIMENTAL_MODULE_PREFS
-      int iModuleStatus = ModulePrefs::GetModuleStatus( file );
+      int iModuleStatus = ModuleSettings::GetModuleStatus( file );
       if( iModuleStatus == kModuleDisabled )
          continue;
       if( iModuleStatus == kModuleFailed )
@@ -265,7 +265,7 @@ void ModuleManager::TryLoadModules(
       if( iModuleStatus == kModuleNew ){
          // To ensure it is noted in config file and so
          // appears on modules page.
-         ModulePrefs::SetModuleStatus( file, kModuleNew);
+         ModuleSettings::SetModuleStatus( file, kModuleNew);
          continue;
       }
 
@@ -290,7 +290,7 @@ void ModuleManager::TryLoadModules(
          // If we're not prompting always, accept the answer permanently
          if( iModuleStatus == kModuleNew ){
             iModuleStatus = (action==1)?kModuleDisabled : kModuleEnabled;
-            ModulePrefs::SetModuleStatus( file, iModuleStatus );
+            ModuleSettings::SetModuleStatus( file, iModuleStatus );
          }
 #endif
          if(action == 1){   // "No"
@@ -301,7 +301,7 @@ void ModuleManager::TryLoadModules(
 #ifdef EXPERIMENTAL_MODULE_PREFS
       // Before attempting to load, we set the state to bad.
       // That way, if we crash, we won't try again.
-      ModulePrefs::SetModuleStatus( file, kModuleFailed );
+      ModuleSettings::SetModuleStatus( file, kModuleFailed );
 #endif
 
       wxString Error;
@@ -326,7 +326,7 @@ void ModuleManager::TryLoadModules(
 
 #ifdef EXPERIMENTAL_MODULE_PREFS
             // Loaded successfully, restore the status.
-            ModulePrefs::SetModuleStatus(file, iModuleStatus);
+            ModuleSettings::SetModuleStatus(file, iModuleStatus);
 #endif
          }
       }
@@ -334,7 +334,7 @@ void ModuleManager::TryLoadModules(
          // Module is not yet decided in this pass.
          // Maybe it depends on another which has not yet been loaded.
          // But don't take the kModuleAsk path again in a later pass.
-         ModulePrefs::SetModuleStatus( file, kModuleEnabled );
+         ModuleSettings::SetModuleStatus( file, kModuleEnabled );
          errors.emplace_back( std::move( umodule ), Error );
       }
    }
@@ -363,7 +363,7 @@ void ModuleManager::Initialize()
    for ( const auto &pair : errors ) {
       auto &pModule = pair.first;
       pModule->ShowLoadFailureError(pair.second);
-      ModulePrefs::SetModuleStatus( pModule->GetName(), kModuleFailed );
+      ModuleSettings::SetModuleStatus( pModule->GetName(), kModuleFailed );
    }
 }
 

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -182,11 +182,21 @@ namespace {
    }
 }
 
-void RegisterBuiltinModule(ModuleMain moduleMain)
+void RegisterProvider(ModuleMain moduleMain)
 {
-   builtinModuleList().push_back(moduleMain);
+   auto &list = builtinModuleList();
+   if ( moduleMain )
+      list.push_back(moduleMain);
 
    return;
+}
+
+void UnregisterProvider(ModuleMain moduleMain)
+{
+   auto &list = builtinModuleList();
+   auto end = list.end(), iter = std::find(list.begin(), end, moduleMain);
+   if (iter != end)
+      list.erase(iter);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -458,7 +458,7 @@ void ModuleManager::InitializeBuiltins()
    for (auto moduleMain : builtinModuleList())
    {
       ModuleInterfaceHandle module {
-         moduleMain(nullptr), ModuleInterfaceDeleter{}
+         moduleMain(), ModuleInterfaceDeleter{}
       };
 
       if (module && module->Initialize())

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -485,13 +485,6 @@ void ModuleInterfaceDeleter::operator() (ModuleInterface *pInterface) const
    if (pInterface)
    {
       pInterface->Terminate();
-
-      auto &libs = ModuleManager::Get().mLibs;
-
-      auto iter = libs.find(pInterface);
-      if (iter != libs.end())
-         libs.erase(iter); // This causes unloading in ~wxDynamicLibrary
-
       std::unique_ptr < ModuleInterface > { pInterface }; // DELETE it
    }
 }

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -232,7 +232,7 @@ ModuleManager::~ModuleManager()
 }
 
 // static 
-void ModuleManager::Initialize(CommandHandler &cmdHandler)
+void ModuleManager::Initialize()
 {
    const auto &audacityPathList = FileNames::AudacityPathList();
    FilePaths pathList;

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -109,7 +109,7 @@ bool Module::Load()
 
    auto ShortName = wxFileName(mName).GetName();
 
-   if (!mLib->Load(mName, wxDL_LAZY | wxDL_QUIET)) {
+   if (!mLib->Load(mName, wxDL_NOW | wxDL_QUIET | wxDL_GLOBAL)) {
       auto Error = wxString(wxSysErrorMsg());
       AudacityMessageBox(XO("Unable to load the \"%s\" module.\n\nError: %s").Format(ShortName, Error),
                          XO("Module Unsuitable"));

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -109,7 +109,6 @@ private:
    ModuleManager &operator=(const ModuleManager&) PROHIBITED;
 
    void InitializeBuiltins();
-   ModuleInterface *LoadModule(const PluginPath & path);
 
 private:
    friend ModuleInterfaceDeleter;

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -47,9 +47,10 @@ public:
    bool HasDispatch() { return mDispatch != NULL; };
    int Dispatch(ModuleDispatchTypes type);
    void * GetSymbol(const wxString &name);
+   const FilePath &GetName() const { return mName; }
 
 private:
-   FilePath mName;
+   const FilePath mName;
    std::unique_ptr<wxDynamicLibrary> mLib;
    fnModuleDispatch mDispatch;
 };
@@ -78,7 +79,10 @@ public:
    
 private:
    static void FindModules(FilePaths &files);
-   static void TryLoadModules(const FilePaths &files);
+   using DelayedErrors =
+      std::vector< std::pair< std::unique_ptr<Module>, wxString > >;
+   static void TryLoadModules(
+      const FilePaths &files, FilePaths &decided, DelayedErrors &errors);
 
 public:
    void Initialize();

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -120,10 +120,6 @@ private:
    // ComponentInterface objects for each path:
    ModuleMap mDynModules;
 
-   // Dynamically loaded libraries, each one a factory that makes one of the
-   // (non-built-in) providers:
-   LibraryMap mLibs;
-
    // Other libraries that receive notifications of events described by
    // ModuleDispatchTypes:
    std::vector<std::unique_ptr<Module>> mModules;

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -30,17 +30,8 @@ wxWindow *  MakeHijackPanel();
 //
 // wxPluginManager would be MUCH better, but it's an "undocumented" framework.
 //
-#define ModuleDispatchName "ModuleDispatch"
 
-typedef enum
-{
-   ModuleInitialize,
-   ModuleTerminate,
-   AppInitialized,
-   AppQuiting,
-   ProjectInitialized,
-   ProjectClosing
-} ModuleDispatchTypes;
+#include "ModuleConstants.h"
 
 typedef int (*fnModuleDispatch)(ModuleDispatchTypes type);
 

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -23,8 +23,6 @@ class wxDynamicLibrary;
 class ComponentInterface;
 class ModuleInterface;
 
-wxWindow *  MakeHijackPanel();
-
 //
 // Module Manager
 //

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -20,7 +20,6 @@
 
 class wxArrayString;
 class wxDynamicLibrary;
-class CommandHandler;
 class ComponentInterface;
 class ModuleInterface;
 
@@ -85,7 +84,7 @@ public:
 
    static ModuleManager & Get();
 
-   void Initialize(CommandHandler & cmdHandler);
+   void Initialize();
    int Dispatch(ModuleDispatchTypes type);
 
    // PluginManager use

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -130,9 +130,9 @@ private:
 };
 
 // ----------------------------------------------------------------------------
-// The module entry point prototype
+// The module entry point prototype (a factory of ModuleInterface objects)
 // ----------------------------------------------------------------------------
-using ModuleMain = ModuleInterface *(*)(const wxString *path);
+using ModuleMain = ModuleInterface *(*)();
 
 AUDACITY_DLL_API
 void RegisterProvider(ModuleMain rtn);

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -75,7 +75,12 @@ public:
    // -------------------------------------------------------------------------
 
    static ModuleManager & Get();
+   
+private:
+   static void FindModules(FilePaths &files);
+   static void TryLoadModules(const FilePaths &files);
 
+public:
    void Initialize();
    int Dispatch(ModuleDispatchTypes type);
 

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -130,4 +130,12 @@ private:
    std::vector<std::unique_ptr<Module>> mModules;
 };
 
+// ----------------------------------------------------------------------------
+// The module entry point prototype
+// ----------------------------------------------------------------------------
+using ModuleMain = ModuleInterface *(*)(const wxString *path);
+
+AUDACITY_DLL_API
+void RegisterBuiltinModule(ModuleMain rtn);
+
 #endif /* __AUDACITY_MODULEMANAGER_H__ */

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -136,6 +136,13 @@ private:
 using ModuleMain = ModuleInterface *(*)(const wxString *path);
 
 AUDACITY_DLL_API
-void RegisterBuiltinModule(ModuleMain rtn);
+void RegisterProvider(ModuleMain rtn);
+AUDACITY_DLL_API
+void UnregisterProvider(ModuleMain rtn);
+
+// Guarantee the registry exists before any registrations, so it will
+// be destroyed only after the un-registrations
+static struct Init{
+   Init() { RegisterProvider(nullptr); } } sInitBuiltinModules;
 
 #endif /* __AUDACITY_MODULEMANAGER_H__ */

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -41,7 +41,8 @@ public:
    Module(const FilePath & name);
    virtual ~Module();
 
-   bool Load();
+   void ShowLoadFailureError(const wxString &Error);
+   bool Load(wxString &deferredErrorMessage);
    void Unload();
    bool HasDispatch() { return mDispatch != NULL; };
    int Dispatch(ModuleDispatchTypes type);

--- a/src/ModuleSettings.cpp
+++ b/src/ModuleSettings.cpp
@@ -1,0 +1,242 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ModulePrefs.cpp
+
+  James Crook
+
+*******************************************************************//**
+
+\class ModulePrefs
+\brief A PrefsPanel to enable/disable certain modules.  'Modules' are 
+dynamically linked libraries that modify Audacity.  They are plug-ins 
+with names like mnod-script-pipe that add NEW features.
+
+*//*******************************************************************/
+
+
+#include "ModulePrefs.h"
+
+
+
+#include <wx/defs.h>
+#include <wx/filename.h>
+
+#include "../ShuttleGui.h"
+
+#include "../Prefs.h"
+
+////////////////////////////////////////////////////////////////////////////////
+
+ModulePrefs::ModulePrefs(wxWindow * parent, wxWindowID winid)
+/* i18n-hint: Modules are optional extensions to Audacity that add NEW features.*/
+:  PrefsPanel(parent, winid, XO("Modules"))
+{
+   Populate();
+}
+
+ModulePrefs::~ModulePrefs()
+{
+}
+
+ComponentInterfaceSymbol ModulePrefs::GetSymbol()
+{
+   return MODULE_PREFS_PLUGIN_SYMBOL;
+}
+
+TranslatableString ModulePrefs::GetDescription()
+{
+   return XO("Preferences for Module");
+}
+
+wxString ModulePrefs::HelpPageName()
+{
+   return "Modules_Preferences";
+}
+
+void ModulePrefs::GetAllModuleStatuses(){
+   wxString str;
+   long dummy;
+
+   // Modules could for example be:
+   //    mod-script-pipe
+   //    mod-nyq-bench
+   //    mod-menu-munger
+   //    mod-theming
+
+   // TODO: On an Audacity upgrade we should (?) actually untick modules.
+   // The old modules might be still around, and we do not want to use them.
+   mModules.clear();
+   mStatuses.clear();
+   mPaths.clear();
+
+
+   // Iterate through all Modules listed in prefs.
+   // Get their names and values.
+   gPrefs->SetPath( wxT("Module/") );
+   bool bCont = gPrefs->GetFirstEntry(str, dummy);
+   while ( bCont ) {
+      int iStatus;
+      gPrefs->Read( str, &iStatus, kModuleDisabled );
+      wxString fname;
+      gPrefs->Read( wxString( wxT("/ModulePath/") ) + str, &fname, wxEmptyString );
+      if( !fname.empty() && wxFileExists( fname ) ){
+         if( iStatus > kModuleNew ){
+            iStatus = kModuleNew;
+            gPrefs->Write( str, iStatus );
+         }
+         //wxLogDebug( wxT("Entry: %s Value: %i"), str, iStatus );
+         mModules.push_back( str );
+         mStatuses.push_back( iStatus );
+         mPaths.push_back( fname );
+      }
+      bCont = gPrefs->GetNextEntry(str, dummy);
+   }
+   gPrefs->SetPath( wxT("") );
+}
+
+void ModulePrefs::Populate()
+{
+   GetAllModuleStatuses();
+   //------------------------- Main section --------------------
+   // Now construct the GUI itself.
+   // Use 'eIsCreatingFromPrefs' so that the GUI is
+   // initialised with values from gPrefs.
+   ShuttleGui S(this, eIsCreatingFromPrefs);
+   PopulateOrExchange(S);
+   // ----------------------- End of main section --------------
+}
+
+void ModulePrefs::PopulateOrExchange(ShuttleGui & S)
+{
+   S.SetBorder(2);
+   S.StartScroller();
+
+   S.StartStatic( {} );
+   {
+      S.AddFixedText(XO(
+"These are experimental modules. Enable them only if you've read the Audacity Manual\nand know what you are doing.") );
+      S.AddFixedText(XO(
+/* i18n-hint preserve the leading spaces */
+"  'Ask' means Audacity will ask if you want to load the module each time it starts.") );
+      S.AddFixedText(XO(
+/* i18n-hint preserve the leading spaces */
+"  'Failed' means Audacity thinks the module is broken and won't run it.") );
+      S.AddFixedText(XO(
+/* i18n-hint preserve the leading spaces */
+"  'New' means no choice has been made yet.") );
+      S.AddFixedText(XO(
+"Changes to these settings only take effect when Audacity starts up."));
+      {
+        S.StartMultiColumn( 2 );
+        int i;
+        for(i=0;i<(int)mModules.size();i++)
+           S.TieChoice( Verbatim( mModules[i] ),
+              mStatuses[i],
+              {
+                 XO("Disabled" ) ,
+                 XO("Enabled" ) ,
+                 XO("Ask" ) ,
+                 XO("Failed" ) ,
+                 XO("New" ) ,
+              }
+           );
+        S.EndMultiColumn();
+      }
+      if( mModules.size() < 1 )
+      {
+        S.AddFixedText( XO("No modules were found") );
+      }
+   }
+   S.EndStatic();
+   S.EndScroller();
+}
+
+bool ModulePrefs::Commit()
+{
+   ShuttleGui S(this, eIsSavingToPrefs);
+   PopulateOrExchange(S);
+   int i;
+   for(i=0;i<(int)mPaths.size();i++)
+      SetModuleStatus( mPaths[i], mStatuses[i] );
+   return true;
+}
+
+
+// static function that tells us about a module.
+int ModulePrefs::GetModuleStatus(const FilePath &fname)
+{
+   // Default status is NEW module, and we will ask once.
+   int iStatus = kModuleNew;
+
+   wxFileName FileName( fname );
+   wxString ShortName = FileName.GetName().Lower();
+
+   wxString PathPref = wxString( wxT("/ModulePath/") ) + ShortName;
+   wxString StatusPref = wxString( wxT("/Module/") ) + ShortName;
+   wxString DateTimePref = wxString( wxT("/ModuleDateTime/") ) + ShortName;
+
+   wxString ModulePath = gPrefs->Read( PathPref, wxEmptyString );
+   if( ModulePath.IsSameAs( fname ) )
+   {
+      gPrefs->Read( StatusPref, &iStatus, kModuleNew );
+
+      wxDateTime DateTime = FileName.GetModificationTime();
+      wxDateTime OldDateTime;
+      OldDateTime.ParseISOCombined( gPrefs->Read( DateTimePref, wxEmptyString ) );
+
+      // Some platforms return milliseconds, some do not...level the playing field
+      DateTime.SetMillisecond( 0 );
+      OldDateTime.SetMillisecond( 0 );
+
+      // fix up a bad status or reset for newer module
+      if( iStatus > kModuleNew || !OldDateTime.IsEqualTo( DateTime ) )
+      {
+         iStatus=kModuleNew;
+      }
+   }
+   else
+   {
+      // Remove previously saved since it's no longer valid
+      gPrefs->DeleteEntry( PathPref );
+      gPrefs->DeleteEntry( StatusPref );
+      gPrefs->DeleteEntry( DateTimePref );
+   }
+
+   return iStatus;
+}
+
+void ModulePrefs::SetModuleStatus(const FilePath &fname, int iStatus)
+{
+   wxFileName FileName( fname );
+   wxDateTime DateTime = FileName.GetModificationTime();
+   wxString ShortName = FileName.GetName().Lower();
+
+   wxString PrefName = wxString( wxT("/Module/") ) + ShortName;
+   gPrefs->Write( PrefName, iStatus );
+
+   PrefName = wxString( wxT("/ModulePath/") ) + ShortName;
+   gPrefs->Write( PrefName, fname );
+
+   PrefName = wxString( wxT("/ModuleDateTime/") ) + ShortName;
+   gPrefs->Write( PrefName, DateTime.FormatISOCombined() );
+
+   gPrefs->Flush();
+}
+
+#ifdef EXPERIMENTAL_MODULE_PREFS
+namespace{
+PrefsPanel::Registration sAttachment{ "Module",
+   [](wxWindow *parent, wxWindowID winid, AudacityProject *)
+   {
+      wxASSERT(parent); // to justify safenew
+      return safenew ModulePrefs(parent, winid);
+   },
+   false,
+   // Register with an explicit ordering hint because this one is
+   // only conditionally compiled
+   { "", { Registry::OrderingHint::After, "Mouse" } }
+};
+}
+#endif

--- a/src/ModuleSettings.cpp
+++ b/src/ModuleSettings.cpp
@@ -2,170 +2,20 @@
 
   Audacity: A Digital Audio Editor
 
-  ModulePrefs.cpp
+  @file ModuleSettings.cpp
 
-  James Crook
+  Paul Licameli split from ModulePrefs.cpp
 
-*******************************************************************//**
+**********************************************************************/
 
-\class ModulePrefs
-\brief A PrefsPanel to enable/disable certain modules.  'Modules' are 
-dynamically linked libraries that modify Audacity.  They are plug-ins 
-with names like mnod-script-pipe that add NEW features.
+#include "ModuleSettings.h"
 
-*//*******************************************************************/
+#include "Prefs.h"
 
-
-#include "ModulePrefs.h"
-
-
-
-#include <wx/defs.h>
 #include <wx/filename.h>
 
-#include "../ShuttleGui.h"
-
-#include "../Prefs.h"
-
-////////////////////////////////////////////////////////////////////////////////
-
-ModulePrefs::ModulePrefs(wxWindow * parent, wxWindowID winid)
-/* i18n-hint: Modules are optional extensions to Audacity that add NEW features.*/
-:  PrefsPanel(parent, winid, XO("Modules"))
-{
-   Populate();
-}
-
-ModulePrefs::~ModulePrefs()
-{
-}
-
-ComponentInterfaceSymbol ModulePrefs::GetSymbol()
-{
-   return MODULE_PREFS_PLUGIN_SYMBOL;
-}
-
-TranslatableString ModulePrefs::GetDescription()
-{
-   return XO("Preferences for Module");
-}
-
-wxString ModulePrefs::HelpPageName()
-{
-   return "Modules_Preferences";
-}
-
-void ModulePrefs::GetAllModuleStatuses(){
-   wxString str;
-   long dummy;
-
-   // Modules could for example be:
-   //    mod-script-pipe
-   //    mod-nyq-bench
-   //    mod-menu-munger
-   //    mod-theming
-
-   // TODO: On an Audacity upgrade we should (?) actually untick modules.
-   // The old modules might be still around, and we do not want to use them.
-   mModules.clear();
-   mStatuses.clear();
-   mPaths.clear();
-
-
-   // Iterate through all Modules listed in prefs.
-   // Get their names and values.
-   gPrefs->SetPath( wxT("Module/") );
-   bool bCont = gPrefs->GetFirstEntry(str, dummy);
-   while ( bCont ) {
-      int iStatus;
-      gPrefs->Read( str, &iStatus, kModuleDisabled );
-      wxString fname;
-      gPrefs->Read( wxString( wxT("/ModulePath/") ) + str, &fname, wxEmptyString );
-      if( !fname.empty() && wxFileExists( fname ) ){
-         if( iStatus > kModuleNew ){
-            iStatus = kModuleNew;
-            gPrefs->Write( str, iStatus );
-         }
-         //wxLogDebug( wxT("Entry: %s Value: %i"), str, iStatus );
-         mModules.push_back( str );
-         mStatuses.push_back( iStatus );
-         mPaths.push_back( fname );
-      }
-      bCont = gPrefs->GetNextEntry(str, dummy);
-   }
-   gPrefs->SetPath( wxT("") );
-}
-
-void ModulePrefs::Populate()
-{
-   GetAllModuleStatuses();
-   //------------------------- Main section --------------------
-   // Now construct the GUI itself.
-   // Use 'eIsCreatingFromPrefs' so that the GUI is
-   // initialised with values from gPrefs.
-   ShuttleGui S(this, eIsCreatingFromPrefs);
-   PopulateOrExchange(S);
-   // ----------------------- End of main section --------------
-}
-
-void ModulePrefs::PopulateOrExchange(ShuttleGui & S)
-{
-   S.SetBorder(2);
-   S.StartScroller();
-
-   S.StartStatic( {} );
-   {
-      S.AddFixedText(XO(
-"These are experimental modules. Enable them only if you've read the Audacity Manual\nand know what you are doing.") );
-      S.AddFixedText(XO(
-/* i18n-hint preserve the leading spaces */
-"  'Ask' means Audacity will ask if you want to load the module each time it starts.") );
-      S.AddFixedText(XO(
-/* i18n-hint preserve the leading spaces */
-"  'Failed' means Audacity thinks the module is broken and won't run it.") );
-      S.AddFixedText(XO(
-/* i18n-hint preserve the leading spaces */
-"  'New' means no choice has been made yet.") );
-      S.AddFixedText(XO(
-"Changes to these settings only take effect when Audacity starts up."));
-      {
-        S.StartMultiColumn( 2 );
-        int i;
-        for(i=0;i<(int)mModules.size();i++)
-           S.TieChoice( Verbatim( mModules[i] ),
-              mStatuses[i],
-              {
-                 XO("Disabled" ) ,
-                 XO("Enabled" ) ,
-                 XO("Ask" ) ,
-                 XO("Failed" ) ,
-                 XO("New" ) ,
-              }
-           );
-        S.EndMultiColumn();
-      }
-      if( mModules.size() < 1 )
-      {
-        S.AddFixedText( XO("No modules were found") );
-      }
-   }
-   S.EndStatic();
-   S.EndScroller();
-}
-
-bool ModulePrefs::Commit()
-{
-   ShuttleGui S(this, eIsSavingToPrefs);
-   PopulateOrExchange(S);
-   int i;
-   for(i=0;i<(int)mPaths.size();i++)
-      SetModuleStatus( mPaths[i], mStatuses[i] );
-   return true;
-}
-
-
 // static function that tells us about a module.
-int ModulePrefs::GetModuleStatus(const FilePath &fname)
+int ModuleSettings::GetModuleStatus(const FilePath &fname)
 {
    // Default status is NEW module, and we will ask once.
    int iStatus = kModuleNew;
@@ -207,7 +57,7 @@ int ModulePrefs::GetModuleStatus(const FilePath &fname)
    return iStatus;
 }
 
-void ModulePrefs::SetModuleStatus(const FilePath &fname, int iStatus)
+void ModuleSettings::SetModuleStatus(const FilePath &fname, int iStatus)
 {
    wxFileName FileName( fname );
    wxDateTime DateTime = FileName.GetModificationTime();
@@ -225,18 +75,3 @@ void ModulePrefs::SetModuleStatus(const FilePath &fname, int iStatus)
    gPrefs->Flush();
 }
 
-#ifdef EXPERIMENTAL_MODULE_PREFS
-namespace{
-PrefsPanel::Registration sAttachment{ "Module",
-   [](wxWindow *parent, wxWindowID winid, AudacityProject *)
-   {
-      wxASSERT(parent); // to justify safenew
-      return safenew ModulePrefs(parent, winid);
-   },
-   false,
-   // Register with an explicit ordering hint because this one is
-   // only conditionally compiled
-   { "", { Registry::OrderingHint::After, "Mouse" } }
-};
-}
-#endif

--- a/src/ModuleSettings.h
+++ b/src/ModuleSettings.h
@@ -1,0 +1,58 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ModulePrefs.h
+
+  Brian Gunlogson
+  Joshua Haberman
+  James Crook
+
+**********************************************************************/
+
+#ifndef __AUDACITY_MODULE_PREFS__
+#define __AUDACITY_MODULE_PREFS__
+
+#include <wx/defs.h>
+
+#include "PrefsPanel.h"
+
+
+class wxArrayString;
+class ShuttleGui;
+
+enum {
+   kModuleDisabled = 0,
+   kModuleEnabled = 1,
+   kModuleAsk = 2,     // Will ask, each time, when audacity starts.
+   kModuleFailed = 3,  // Audacity thinks this is a bad module.
+   kModuleNew = 4      // Audacity will ask once, and remember the answer.
+};
+
+
+#define MODULE_PREFS_PLUGIN_SYMBOL ComponentInterfaceSymbol{ XO("Module") }
+
+class ModulePrefs final : public PrefsPanel
+{
+ public:
+   ModulePrefs(wxWindow * parent, wxWindowID winid);
+   ~ModulePrefs();
+   ComponentInterfaceSymbol GetSymbol() override;
+   TranslatableString GetDescription() override;
+
+   bool Commit() override;
+   wxString HelpPageName() override;
+   void PopulateOrExchange(ShuttleGui & S) override;
+
+   static int GetModuleStatus( const FilePath &fname );
+   static void SetModuleStatus( const FilePath &fname, int iStatus );
+
+ private:
+   void GetAllModuleStatuses();
+   void Populate();
+   wxArrayString mModules;
+   std::vector<int> mStatuses;
+   FilePaths mPaths;
+};
+
+#endif

--- a/src/ModuleSettings.h
+++ b/src/ModuleSettings.h
@@ -2,24 +2,16 @@
 
   Audacity: A Digital Audio Editor
 
-  ModulePrefs.h
+  @file ModuleSettings.h
 
-  Brian Gunlogson
-  Joshua Haberman
-  James Crook
+  Paul Licameli split from ModulePrefs.h
 
 **********************************************************************/
 
-#ifndef __AUDACITY_MODULE_PREFS__
-#define __AUDACITY_MODULE_PREFS__
+#ifndef __AUDACITY_MODULE_SETTINGS__
+#define __AUDACITY_MODULE_SETTINGS__
 
-#include <wx/defs.h>
-
-#include "PrefsPanel.h"
-
-
-class wxArrayString;
-class ShuttleGui;
+#include "audacity/Types.h"
 
 enum {
    kModuleDisabled = 0,
@@ -29,30 +21,11 @@ enum {
    kModuleNew = 4      // Audacity will ask once, and remember the answer.
 };
 
+namespace ModuleSettings {
 
-#define MODULE_PREFS_PLUGIN_SYMBOL ComponentInterfaceSymbol{ XO("Module") }
+int GetModuleStatus( const FilePath &fname );
+void SetModuleStatus( const FilePath &fname, int iStatus );
 
-class ModulePrefs final : public PrefsPanel
-{
- public:
-   ModulePrefs(wxWindow * parent, wxWindowID winid);
-   ~ModulePrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
-   TranslatableString GetDescription() override;
-
-   bool Commit() override;
-   wxString HelpPageName() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
-
-   static int GetModuleStatus( const FilePath &fname );
-   static void SetModuleStatus( const FilePath &fname, int iStatus );
-
- private:
-   void GetAllModuleStatuses();
-   void Populate();
-   wxArrayString mModules;
-   std::vector<int> mStatuses;
-   FilePaths mPaths;
-};
+}
 
 #endif

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -56,7 +56,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew BuiltinCommandsModule(path);
+   return safenew BuiltinCommandsModule();
 }
 
 // ============================================================================
@@ -70,17 +70,12 @@ DECLARE_BUILTIN_MODULE(BuiltinsCommandBuiltin);
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-BuiltinCommandsModule::BuiltinCommandsModule(const wxString *path)
+BuiltinCommandsModule::BuiltinCommandsModule()
 {
-   if (path)
-   {
-      mPath = *path;
-   }
 }
 
 BuiltinCommandsModule::~BuiltinCommandsModule()
 {
-   mPath.clear();
 }
 
 // ============================================================================
@@ -89,7 +84,7 @@ BuiltinCommandsModule::~BuiltinCommandsModule()
 
 PluginPath BuiltinCommandsModule::GetPath()
 {
-   return mPath;
+   return {};
 }
 
 ComponentInterfaceSymbol BuiltinCommandsModule::GetSymbol()

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -16,6 +16,7 @@ modelled on BuiltinEffectsModule
 
 #include "LoadCommands.h"
 #include "AudacityCommand.h"
+#include "ModuleManager.h"
 
 #include "../Prefs.h"
 

--- a/src/commands/LoadCommands.h
+++ b/src/commands/LoadCommands.h
@@ -30,7 +30,7 @@ class AudacityCommand;
 class AUDACITY_DLL_API BuiltinCommandsModule final : public ModuleInterface
 {
 public:
-   BuiltinCommandsModule(const wxString *path);
+   BuiltinCommandsModule();
    virtual ~BuiltinCommandsModule();
 
    using Factory = std::function< std::unique_ptr<AudacityCommand> () >;
@@ -82,8 +82,6 @@ private:
 
    static void DoRegistration(
       const ComponentInterfaceSymbol &name, const Factory &factory );
-
-   wxString mPath;
 
    using CommandHash = std::unordered_map< wxString, const Entry* > ;
    CommandHash mCommands;

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -54,7 +54,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew BuiltinEffectsModule(path);
+   return safenew BuiltinEffectsModule();
 }
 
 // ============================================================================
@@ -68,17 +68,12 @@ DECLARE_BUILTIN_MODULE(BuiltinsEffectBuiltin);
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-BuiltinEffectsModule::BuiltinEffectsModule(const wxString *path)
+BuiltinEffectsModule::BuiltinEffectsModule()
 {
-   if (path)
-   {
-      mPath = *path;
-   }
 }
 
 BuiltinEffectsModule::~BuiltinEffectsModule()
 {
-   mPath.clear();
 }
 
 // ============================================================================
@@ -87,7 +82,7 @@ BuiltinEffectsModule::~BuiltinEffectsModule()
 
 PluginPath BuiltinEffectsModule::GetPath()
 {
-   return mPath;
+   return {};
 }
 
 ComponentInterfaceSymbol BuiltinEffectsModule::GetSymbol()

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -17,6 +17,7 @@
 #include "../Prefs.h"
 
 #include "Effect.h"
+#include "ModuleManager.h"
 
 static bool sInitialized = false;
 

--- a/src/effects/LoadEffects.h
+++ b/src/effects/LoadEffects.h
@@ -29,7 +29,7 @@ class Effect;
 class AUDACITY_DLL_API BuiltinEffectsModule final : public ModuleInterface
 {
 public:
-   BuiltinEffectsModule(const wxString *path);
+   BuiltinEffectsModule();
    virtual ~BuiltinEffectsModule();
 
    using Factory = std::function< std::unique_ptr<Effect> () >;
@@ -81,8 +81,6 @@ private:
    static void DoRegistration(
       const ComponentInterfaceSymbol &name, const Factory &factory,
       bool excluded );
-
-   PluginPath mPath;
 
    struct Entry;
    using EffectHash = std::unordered_map< wxString, const Entry* > ;

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -143,7 +143,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 {
    // Create our effects module and register
    // Trust the module manager not to leak this
-   return safenew VSTEffectsModule(path);
+   return safenew VSTEffectsModule();
 }
 
 // ============================================================================
@@ -306,17 +306,12 @@ public:
 // VSTEffectsModule
 //
 // ============================================================================
-VSTEffectsModule::VSTEffectsModule(const wxString *path)
+VSTEffectsModule::VSTEffectsModule()
 {
-   if (path)
-   {
-      mPath = *path;
-   }
 }
 
 VSTEffectsModule::~VSTEffectsModule()
 {
-   mPath = wxEmptyString;
 }
 
 // ============================================================================
@@ -325,7 +320,7 @@ VSTEffectsModule::~VSTEffectsModule()
 
 PluginPath VSTEffectsModule::GetPath()
 {
-   return mPath;
+   return {};
 }
 
 ComponentInterfaceSymbol VSTEffectsModule::GetSymbol()

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -26,6 +26,7 @@
 
 
 #include "VSTEffect.h"
+#include "../../ModuleManager.h"
 
 #include "../../widgets/ProgressDialog.h"
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -403,7 +403,7 @@ private:
 class VSTEffectsModule final : public ModuleInterface
 {
 public:
-   VSTEffectsModule(const wxString *path);
+   VSTEffectsModule();
    virtual ~VSTEffectsModule();
 
    // ComponentInterface implementation
@@ -438,9 +438,6 @@ public:
    // VSTEffectModule implementation
 
    static void Check(const wxChar *path);
-
-private:
-   PluginPath mPath;
 };
 
 #endif // USE_VST

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -18,6 +18,7 @@
 
 #if USE_AUDIO_UNITS
 #include "AudioUnitEffect.h"
+#include "../../ModuleManager.h"
 
 #include <wx/defs.h>
 #include <wx/base64.h>

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -233,7 +233,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew AudioUnitEffectsModule(path);
+   return safenew AudioUnitEffectsModule();
 }
 
 // ============================================================================
@@ -247,17 +247,12 @@ DECLARE_BUILTIN_MODULE(AudioUnitEffectsBuiltin);
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-AudioUnitEffectsModule::AudioUnitEffectsModule(const wxString *path)
+AudioUnitEffectsModule::AudioUnitEffectsModule()
 {
-   if (path)
-   {
-      mPath = *path;
-   }
 }
 
 AudioUnitEffectsModule::~AudioUnitEffectsModule()
 {
-   mPath.clear();
 }
 
 // ============================================================================
@@ -266,7 +261,7 @@ AudioUnitEffectsModule::~AudioUnitEffectsModule()
 
 PluginPath AudioUnitEffectsModule::GetPath()
 {
-   return mPath;
+   return {};
 }
 
 ComponentInterfaceSymbol AudioUnitEffectsModule::GetSymbol()

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -232,7 +232,7 @@ private:
 class AudioUnitEffectsModule final : public ModuleInterface
 {
 public:
-   AudioUnitEffectsModule(const wxString *path);
+   AudioUnitEffectsModule();
    virtual ~AudioUnitEffectsModule();
 
    // ComponentInterface implementation
@@ -271,9 +271,6 @@ public:
 
    wxString FromOSType(OSType type);
    OSType ToOSType(const wxString & type);
-
-private:
-   wxString mPath;
 };
 
 #endif

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -85,7 +85,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew LadspaEffectsModule(path);
+   return safenew LadspaEffectsModule();
 }
 
 // ============================================================================
@@ -99,12 +99,8 @@ DECLARE_BUILTIN_MODULE(LadspaBuiltin);
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-LadspaEffectsModule::LadspaEffectsModule(const wxString *path)
+LadspaEffectsModule::LadspaEffectsModule()
 {
-   if (path)
-   {
-      mPath = *path;
-   }
 }
 
 LadspaEffectsModule::~LadspaEffectsModule()
@@ -117,7 +113,7 @@ LadspaEffectsModule::~LadspaEffectsModule()
 
 PluginPath LadspaEffectsModule::GetPath()
 {
-   return mPath;
+   return {};
 }
 
 ComponentInterfaceSymbol LadspaEffectsModule::GetSymbol()

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -58,6 +58,7 @@ effects from this one class.
 #include "../../widgets/NumericTextCtrl.h"
 #include "../../widgets/valnum.h"
 #include "../../widgets/wxPanelWrapper.h"
+#include "../../ModuleManager.h"
 
 #if wxUSE_ACCESSIBILITY
 #include "../../widgets/WindowAccessible.h"

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -208,7 +208,7 @@ private:
 class LadspaEffectsModule final : public ModuleInterface
 {
 public:
-   LadspaEffectsModule(const wxString *path);
+   LadspaEffectsModule();
    virtual ~LadspaEffectsModule();
 
    // ComponentInterface implementation
@@ -243,8 +243,5 @@ public:
    // LadspaEffectModule implementation
 
    FilePaths GetSearchPaths();
-
-private:
-   wxString mPath;
 };
 

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -60,7 +60,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew LV2EffectsModule(path);
+   return safenew LV2EffectsModule();
 }
 
 // ============================================================================
@@ -77,12 +77,8 @@ using UriHash = std::unordered_map<wxString, LilvNode*>;
 
 LilvWorld *gWorld = NULL;
 
-LV2EffectsModule::LV2EffectsModule(const wxString *path)
+LV2EffectsModule::LV2EffectsModule()
 {
-   if (path)
-   {
-      mPath = *path;
-   }
 }
 
 LV2EffectsModule::~LV2EffectsModule()
@@ -95,7 +91,7 @@ LV2EffectsModule::~LV2EffectsModule()
 
 PluginPath LV2EffectsModule::GetPath()
 {
-   return mPath;
+   return {};
 }
 
 ComponentInterfaceSymbol LV2EffectsModule::GetSymbol()

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -23,6 +23,7 @@ Functions that find and load all LV2 plugins on the system.
 #endif
 
 #include "LoadLV2.h"
+#include "../../ModuleManager.h"
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/effects/lv2/LoadLV2.h
+++ b/src/effects/lv2/LoadLV2.h
@@ -163,7 +163,7 @@
 class LV2EffectsModule final : public ModuleInterface
 {
 public:
-   LV2EffectsModule(const wxString *path);
+   LV2EffectsModule();
    virtual ~LV2EffectsModule();
 
    // ComponentInterface implementation
@@ -199,9 +199,6 @@ public:
 
 private:
    const LilvPlugin *GetPlugin(const PluginPath & path);
-
-private:
-   PluginPath mPath;
 };
 
 extern LilvWorld *gWorld;

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -18,6 +18,7 @@
 
 #include "../../FileNames.h"
 #include "../../PluginManager.h"
+#include "../../ModuleManager.h"
 
 // ============================================================================
 // List of effects that ship with Audacity.  These will be autoregistered.

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -67,7 +67,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew NyquistEffectsModule(path);
+   return safenew NyquistEffectsModule();
 }
 
 // ============================================================================
@@ -81,17 +81,12 @@ DECLARE_BUILTIN_MODULE(NyquistsEffectBuiltin);
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-NyquistEffectsModule::NyquistEffectsModule(const wxString *path)
+NyquistEffectsModule::NyquistEffectsModule()
 {
-   if (path)
-   {
-      mPath = *path;
-   }
 }
 
 NyquistEffectsModule::~NyquistEffectsModule()
 {
-   mPath.clear();
 }
 
 // ============================================================================
@@ -100,7 +95,7 @@ NyquistEffectsModule::~NyquistEffectsModule()
 
 PluginPath NyquistEffectsModule::GetPath()
 {
-   return mPath;
+   return {};
 }
 
 ComponentInterfaceSymbol NyquistEffectsModule::GetSymbol()

--- a/src/effects/nyquist/LoadNyquist.h
+++ b/src/effects/nyquist/LoadNyquist.h
@@ -21,7 +21,7 @@
 class NyquistEffectsModule final : public ModuleInterface
 {
 public:
-   NyquistEffectsModule(const wxString *path);
+   NyquistEffectsModule();
    virtual ~NyquistEffectsModule();
 
    // ComponentInterface implementation
@@ -53,9 +53,4 @@ public:
 
    ComponentInterface *CreateInstance(const PluginPath & path) override;
    void DeleteInstance(ComponentInterface *instance) override;
-
-   // NyquistEffectModule implementation
-
-private:
-   PluginPath mPath;
 };

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -38,7 +38,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew VampEffectsModule(path);
+   return safenew VampEffectsModule();
 }
 
 // ============================================================================
@@ -52,12 +52,8 @@ DECLARE_BUILTIN_MODULE(VampsEffectBuiltin);
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-VampEffectsModule::VampEffectsModule(const wxString *path)
+VampEffectsModule::VampEffectsModule()
 {
-   if (path)
-   {
-      mPath = *path;
-   }
 }
 
 VampEffectsModule::~VampEffectsModule()
@@ -70,7 +66,7 @@ VampEffectsModule::~VampEffectsModule()
 
 PluginPath VampEffectsModule::GetPath()
 {
-   return mPath;
+   return {};
 }
 
 ComponentInterfaceSymbol VampEffectsModule::GetSymbol()

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -12,6 +12,7 @@
 
 #if defined(USE_VAMP)
 #include "LoadVamp.h"
+#include "../../ModuleManager.h"
 
 #include <wx/filename.h>
 

--- a/src/effects/vamp/LoadVamp.h
+++ b/src/effects/vamp/LoadVamp.h
@@ -29,7 +29,7 @@
 class VampEffectsModule final : public ModuleInterface
 {
 public:
-   VampEffectsModule(const wxString *path);
+   VampEffectsModule();
    virtual ~VampEffectsModule();
 
    // ComponentInterface implementation
@@ -67,9 +67,6 @@ private:
    std::unique_ptr<Vamp::Plugin> FindPlugin(const PluginPath & wpath,
                             int & output,
                             bool & hasParameters);
-
-private:
-   PluginPath mPath;
 };
 
 #endif

--- a/src/prefs/ModulePrefs.cpp
+++ b/src/prefs/ModulePrefs.cpp
@@ -11,7 +11,7 @@
 \class ModulePrefs
 \brief A PrefsPanel to enable/disable certain modules.  'Modules' are 
 dynamically linked libraries that modify Audacity.  They are plug-ins 
-with names like mnod-script-pipe that add NEW features.
+with names like mod-script-pipe that add NEW features.
 
 *//*******************************************************************/
 
@@ -26,6 +26,7 @@ with names like mnod-script-pipe that add NEW features.
 #include "../ShuttleGui.h"
 
 #include "../Prefs.h"
+#include "../ModuleSettings.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -159,70 +160,8 @@ bool ModulePrefs::Commit()
    PopulateOrExchange(S);
    int i;
    for(i=0;i<(int)mPaths.size();i++)
-      SetModuleStatus( mPaths[i], mStatuses[i] );
+      ModuleSettings::SetModuleStatus( mPaths[i], mStatuses[i] );
    return true;
-}
-
-
-// static function that tells us about a module.
-int ModulePrefs::GetModuleStatus(const FilePath &fname)
-{
-   // Default status is NEW module, and we will ask once.
-   int iStatus = kModuleNew;
-
-   wxFileName FileName( fname );
-   wxString ShortName = FileName.GetName().Lower();
-
-   wxString PathPref = wxString( wxT("/ModulePath/") ) + ShortName;
-   wxString StatusPref = wxString( wxT("/Module/") ) + ShortName;
-   wxString DateTimePref = wxString( wxT("/ModuleDateTime/") ) + ShortName;
-
-   wxString ModulePath = gPrefs->Read( PathPref, wxEmptyString );
-   if( ModulePath.IsSameAs( fname ) )
-   {
-      gPrefs->Read( StatusPref, &iStatus, kModuleNew );
-
-      wxDateTime DateTime = FileName.GetModificationTime();
-      wxDateTime OldDateTime;
-      OldDateTime.ParseISOCombined( gPrefs->Read( DateTimePref, wxEmptyString ) );
-
-      // Some platforms return milliseconds, some do not...level the playing field
-      DateTime.SetMillisecond( 0 );
-      OldDateTime.SetMillisecond( 0 );
-
-      // fix up a bad status or reset for newer module
-      if( iStatus > kModuleNew || !OldDateTime.IsEqualTo( DateTime ) )
-      {
-         iStatus=kModuleNew;
-      }
-   }
-   else
-   {
-      // Remove previously saved since it's no longer valid
-      gPrefs->DeleteEntry( PathPref );
-      gPrefs->DeleteEntry( StatusPref );
-      gPrefs->DeleteEntry( DateTimePref );
-   }
-
-   return iStatus;
-}
-
-void ModulePrefs::SetModuleStatus(const FilePath &fname, int iStatus)
-{
-   wxFileName FileName( fname );
-   wxDateTime DateTime = FileName.GetModificationTime();
-   wxString ShortName = FileName.GetName().Lower();
-
-   wxString PrefName = wxString( wxT("/Module/") ) + ShortName;
-   gPrefs->Write( PrefName, iStatus );
-
-   PrefName = wxString( wxT("/ModulePath/") ) + ShortName;
-   gPrefs->Write( PrefName, fname );
-
-   PrefName = wxString( wxT("/ModuleDateTime/") ) + ShortName;
-   gPrefs->Write( PrefName, DateTime.FormatISOCombined() );
-
-   gPrefs->Flush();
 }
 
 #ifdef EXPERIMENTAL_MODULE_PREFS

--- a/src/prefs/ModulePrefs.h
+++ b/src/prefs/ModulePrefs.h
@@ -21,15 +21,6 @@
 class wxArrayString;
 class ShuttleGui;
 
-enum {
-   kModuleDisabled = 0,
-   kModuleEnabled = 1,
-   kModuleAsk = 2,     // Will ask, each time, when audacity starts.
-   kModuleFailed = 3,  // Audacity thinks this is a bad module.
-   kModuleNew = 4      // Audacity will ask once, and remember the answer.
-};
-
-
 #define MODULE_PREFS_PLUGIN_SYMBOL ComponentInterfaceSymbol{ XO("Module") }
 
 class ModulePrefs final : public PrefsPanel
@@ -43,9 +34,6 @@ class ModulePrefs final : public PrefsPanel
    bool Commit() override;
    wxString HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
-
-   static int GetModuleStatus( const FilePath &fname );
-   static void SetModuleStatus( const FilePath &fname, int iStatus );
 
  private:
    void GetAllModuleStatuses();


### PR DESCRIPTION
Various things cherry-picked out of my big misc-modules branch, related to the Module Manager.

Among these:

enabling loading of modules that depend on other modules, without any explicit description of those dependencies;

un-cluttering the simple protocol of symbols exposed by the modules, by eliminating special script pipe and track panel hijack hooks (alternative means can be found now for such things);

remove link dependency of ModuleManager on the GUI-heavy ModulePrefs page that interacts with it;

make it possible for plug-in providers to be just another kind of module, so that built-in or non-built-in ones will not need to be implemented differently.

