### PR TITLE
Bug2763: Certain Scriptable commands should push Undo stack...

### DIFF
--- a/src/commands/SetEnvelopeCommand.cpp
+++ b/src/commands/SetEnvelopeCommand.cpp
@@ -19,7 +19,10 @@
 
 #include "SetEnvelopeCommand.h"
 
+#include "CommandContext.h"
 #include "LoadCommands.h"
+#include "../ProjectHistory.h"
+#include "../UndoManager.h"
 #include "../WaveClip.h"
 #include "../WaveTrack.h"
 #include "../Envelope.h"
@@ -57,7 +60,7 @@ void SetEnvelopeCommand::PopulateOrExchange(ShuttleGui & S)
    S.EndMultiColumn();
 }
 
-bool SetEnvelopeCommand::ApplyInner( const CommandContext &, Track * t )
+bool SetEnvelopeCommand::ApplyInner( const CommandContext &context, Track * t )
 {
    // if no time is specified, then
    //   - delete deletes any envelope in selected tracks.
@@ -75,10 +78,19 @@ bool SetEnvelopeCommand::ApplyInner( const CommandContext &, Track * t )
          {
             // Inside this IF is where we actually apply the command
             Envelope* pEnv = pClip->GetEnvelope();
+            bool didSomething = false;
             if( bHasDelete && mbDelete )
-               pEnv->Clear();
+               pEnv->Clear(), didSomething = true;
             if( bHasT && bHasV )
-               pEnv->InsertOrReplace( mT, pEnv->ClampValue( mV ) );
+               pEnv->InsertOrReplace( mT, pEnv->ClampValue( mV ) ),
+               didSomething = true;
+
+            if (didSomething)
+               // Consolidate, because this ApplyInner() function may be
+               // visited multiple times in one command invocation
+               ProjectHistory::Get(context.project).PushState(
+                  XO("Edited Envelope"), XO("Envelope"),
+                  UndoPush::CONSOLIDATE);
          }
       }
    } );

--- a/src/commands/SetLabelCommand.cpp
+++ b/src/commands/SetLabelCommand.cpp
@@ -23,6 +23,7 @@
 #include "../ViewInfo.h"
 #include "../WaveTrack.h"
 #include "../LabelTrack.h"
+#include "../ProjectHistory.h"
 #include "../Shuttle.h"
 #include "../ShuttleGui.h"
 #include "CommandContext.h"
@@ -123,5 +124,9 @@ bool SetLabelCommand::Apply(const CommandContext & context)
    }
 
    labelTrack->SortLabels();
+
+   ProjectHistory::Get(context.project).PushState(
+      XO("Edited Label"), XO("Label"));
+
    return true;
 }


### PR DESCRIPTION
Fixes for Bug 2763.  The best text for the user-visible strings might be debated.

Certain Scriptable commands in the Extra menu ought to push distinct undo states that do not merge with the previous state.
