### PR TITLE
Bug 2782 - 8-bit FLAC samples are not imported correctly

### DIFF
--- a/src/import/ImportFLAC.cpp
+++ b/src/import/ImportFLAC.cpp
@@ -247,9 +247,15 @@ FLAC__StreamDecoderWriteStatus MyFLACFile::write_callback(const FLAC__Frame *fra
 
       auto iter = mFile->mChannels.begin();
       for (unsigned int chn=0; chn<mFile->mNumChannels; ++iter, ++chn) {
-         if (frame->header.bits_per_sample == 16) {
-            for (unsigned int s=0; s<frame->header.blocksize; s++) {
-               tmp[s]=buffer[chn][s];
+         if (frame->header.bits_per_sample <= 16) {
+            if (frame->header.bits_per_sample == 8) {
+               for (unsigned int s = 0; s < frame->header.blocksize; s++) {
+                  tmp[s] = buffer[chn][s] << 8;
+               }
+            } else /* if (frame->header.bits_per_sample == 16) */ {
+               for (unsigned int s = 0; s < frame->header.blocksize; s++) {
+                  tmp[s] = buffer[chn][s];
+               }
             }
 
             iter->get()->Append((samplePtr)tmp.get(),


### PR DESCRIPTION
Originally reported on 18Sep20  as GitHub Issue #672
https://github.com/audacity/audacity/issues/670

The OP sagamusix wrote
>It seems like 8-bit FLAC samples are imported with a wrong amplification factor 
>to me it looks like the raw 8-bit values are interpreted as if they are from a 
>16-bit sample, so only the low 8 of 16 bits are ever used.
