### PR TITLE
Yet more module preliminaries

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -330,9 +330,17 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
    set( DEFINES )
    list( APPEND DEFINES ${ADDITIONAL_DEFINES} )
 
+   # send the file to the proper place in the build tree, by setting the
+   # appropriate property for the platform
+   if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+      set( DIRECTORY_PROPERTY RUNTIME_OUTPUT_DIRECTORY )
+   else ()
+      set( DIRECTORY_PROPERTY LIBRARY_OUTPUT_DIRECTORY )
+   endif ()
+
    if (LIBTYPE STREQUAL "MODULE")
       set( SHAPE "box" )
-      set_target_property_all( ${TARGET} LIBRARY_OUTPUT_DIRECTORY "${_MODDIR}" )
+      set_target_property_all( ${TARGET} ${DIRECTORY_PROPERTY} "${_MODDIR}" )
       set_target_properties( ${TARGET}
          PROPERTIES
             PREFIX ""
@@ -340,7 +348,7 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
       )
    else()
       set( SHAPE "octagon" )
-      set_target_property_all( ${TARGET} LIBRARY_OUTPUT_DIRECTORY "${_EXEDIR}" )
+      set_target_property_all( ${TARGET} ${DIRECTORY_PROPERTY} "${_EXEDIR}" )
       set_target_properties( ${TARGET}
          PROPERTIES
             PREFIX ""

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,12 +1,20 @@
 # Include the modules that we'll build
 
+# The list of modules is ordered so that each module occurs after any others
+# that it depends on
+set( MODULES
+   mod-script-pipe
+)
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Windows" )
-add_subdirectory( mod-null )
-add_subdirectory( mod-nyq-bench )
+   list( APPEND MODULES
+      mod-null
+      mod-nyq-bench
+   )
 endif()
 
-add_subdirectory( mod-script-pipe )
-
+foreach( MODULE ${MODULES} )
+   add_subdirectory("${MODULE}")
+endforeach()
 
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" )
    if( NOT "${CMAKE_GENERATOR}" MATCHES "Visual Studio*")

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1149,6 +1149,8 @@ bool AudacityApp::OnInit()
 
    wxString progPath = wxPathOnly(argv[0]);
    FileNames::AddUniquePathToPathList(progPath, audacityPathList);
+   // Add the path to modules:
+   FileNames::AddUniquePathToPathList(progPath + L"/lib/audacity", audacityPathList);
 
    FileNames::AddUniquePathToPathList(FileNames::DataDir(), audacityPathList);
 

--- a/src/ModuleSettings.cpp
+++ b/src/ModuleSettings.cpp
@@ -12,7 +12,17 @@
 
 #include "Prefs.h"
 
+#include <unordered_set>
 #include <wx/filename.h>
+
+static const std::unordered_set<wxString> &autoEnabledModules()
+{
+   // Add names to this list, of modules that are expected to ship
+   // with Audacity and enable automatically.
+   static std::unordered_set<wxString> modules{
+   };
+   return modules;
+}
 
 // static function that tells us about a module.
 int ModuleSettings::GetModuleStatus(const FilePath &fname)
@@ -52,6 +62,11 @@ int ModuleSettings::GetModuleStatus(const FilePath &fname)
       gPrefs->DeleteEntry( PathPref );
       gPrefs->DeleteEntry( StatusPref );
       gPrefs->DeleteEntry( DateTimePref );
+   }
+
+   if (iStatus == kModuleNew) {
+      if (autoEnabledModules().count(ShortName))
+         iStatus = kModuleEnabled;
    }
 
    return iStatus;


### PR DESCRIPTION
List of modules in modules/CMakeLists.txt, to be lengthened;

List of shipped modules to auto-enable in ModuleSettings.cpp, for now empty;

Correction to Windows build procedure, to put modules in the expected subdirectory;

Correction to the code of Audacity, as built by GitHub Actions for Linux, so that it finds and loads modules without need
of any change in environment variables.
