### PR TITLE
Bug2764 Open Project... (under Scriptables in Extra menus) can corrupt a project

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1487,7 +1487,8 @@ bool AudacityApp::InitPart2()
       // Auto-recovery
       //
       bool didRecoverAnything = false;
-      if (!ShowAutoRecoveryDialogIfNeeded(&project, &didRecoverAnything))
+      // This call may reassign project (passed by reference)
+      if (!ShowAutoRecoveryDialogIfNeeded(project, &didRecoverAnything))
       {
          QuitAudacity(true);
       }
@@ -1495,7 +1496,7 @@ bool AudacityApp::InitPart2()
       //
       // Remainder of command line parsing, but only if we didn't recover
       //
-      if (!didRecoverAnything)
+      if (project && !didRecoverAnything)
       {
          if (parser->Found(wxT("t")))
          {

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -815,7 +815,8 @@ bool AudacityApp::MRUOpen(const FilePath &fullPathStr) {
 
          if (proj && !ProjectManager::SafeToOpenProjectInto(*proj))
             proj = nullptr;
-         ( void ) ProjectManager::OpenProject( proj, fullPathStr );
+         ( void ) ProjectManager::OpenProject( proj, fullPathStr,
+               true /* addtohistory */, false /* reuseNonemptyProject */ );
       }
       else {
          // File doesn't exist - remove file from history

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -813,24 +813,8 @@ bool AudacityApp::MRUOpen(const FilePath &fullPathStr) {
          if (ProjectFileManager::IsAlreadyOpen(fullPathStr))
             return false;
 
-         // DMM: If the project is dirty, that means it's been touched at
-         // all, and it's not safe to open a NEW project directly in its
-         // place.  Only if the project is brand-NEW clean and the user
-         // hasn't done any action at all is it safe for Open to take place
-         // inside the current project.
-         //
-         // If you try to Open a NEW project inside the current window when
-         // there are no tracks, but there's an Undo history, etc, then
-         // bad things can happen, including data files moving to the NEW
-         // project directory, etc.
-         if (proj && (
-            ProjectHistory::Get( *proj ).GetDirty() ||
-            !TrackList::Get( *proj ).empty()
-         ) )
+         if (proj && !ProjectManager::SafeToOpenProjectInto(*proj))
             proj = nullptr;
-         // This project is clean; it's never been touched.  Therefore
-         // all relevant member variables are in their initial state,
-         // and it's okay to open a NEW project inside this window.
          ( void ) ProjectManager::OpenProject( proj, fullPathStr );
       }
       else {

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -813,8 +813,6 @@ bool AudacityApp::MRUOpen(const FilePath &fullPathStr) {
          if (ProjectFileManager::IsAlreadyOpen(fullPathStr))
             return false;
 
-         if (proj && !ProjectManager::SafeToOpenProjectInto(*proj))
-            proj = nullptr;
          ( void ) ProjectManager::OpenProject( proj, fullPathStr,
                true /* addtohistory */, false /* reuseNonemptyProject */ );
       }

--- a/src/AutoRecoveryDialog.cpp
+++ b/src/AutoRecoveryDialog.cpp
@@ -430,7 +430,7 @@ static bool RecoverAllProjects(const FilePaths &files,
       std::swap(proj, pproj);
 
       // Open project.
-      if (ProjectManager::OpenProject(proj, file, false) == nullptr)
+      if (ProjectManager::OpenProject(proj, file, false, true) == nullptr)
       {
          return false;
       }

--- a/src/AutoRecoveryDialog.cpp
+++ b/src/AutoRecoveryDialog.cpp
@@ -421,6 +421,7 @@ static bool RecoverAllProjects(const FilePaths &files,
 {
    // Open a project window for each auto save file
    wxString filename;
+   bool result = true;
 
    for (auto &file: files)
    {
@@ -432,11 +433,11 @@ static bool RecoverAllProjects(const FilePaths &files,
       // Open project.
       if (ProjectManager::OpenProject(proj, file, false, true) == nullptr)
       {
-         return false;
+         result = false;
       }
    }
 
-   return true;
+   return result;
 }
 
 static void DiscardAllProjects(const FilePaths &files)

--- a/src/AutoRecoveryDialog.h
+++ b/src/AutoRecoveryDialog.h
@@ -26,7 +26,7 @@ class AudacityProject;
 // The didRecoverAnything param is strictly for a return value.
 // Any value passed in is ignored.
 //
-bool ShowAutoRecoveryDialogIfNeeded(AudacityProject** pproj,
+bool ShowAutoRecoveryDialogIfNeeded(AudacityProject*& pproj,
                                     bool *didRecoverAnything);
 
 #endif

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -864,13 +864,10 @@ bool ProjectFileManager::IsAlreadyOpen(const FilePath &projPathName)
 
 // FIXME:? TRAP_ERR This should return a result that is checked.
 //    See comment in AudacityApp::MRUOpen().
-void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory)
+AudacityProject *ProjectFileManager::OpenFile(
+   const FilePath &fileNameArg, bool addtohistory)
 {
    auto &project = mProject;
-   auto &history = ProjectHistory::Get( project );
-   auto &projectFileIO = ProjectFileIO::Get( project );
-   auto &tracks = TrackList::Get( project );
-   auto &trackPanel = TrackPanel::Get( project );
    auto &window = ProjectWindow::Get( project );
 
    // On Win32, we may be given a short (DOS-compatible) file name on rare
@@ -882,7 +879,7 @@ void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory
                                       XO("Project resides on FAT formatted drive.\n"
                                          "Copy it to another drive to open it.")))
    {
-      return;
+      return nullptr;
    }
 
    // Make sure it isn't already open.
@@ -893,7 +890,7 @@ void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory
    //    This was reported in http://bugzilla.audacityteam.org/show_bug.cgi?id=137#c17,
    //    but is not really part of that bug. Anyway, prevent it!
    if (IsAlreadyOpen(fileName))
-      return;
+      return nullptr;
 
    // Data loss may occur if users mistakenly try to open ".aup3.bak" files
    // left over from an unsuccessful save or by previous versions of Audacity.
@@ -906,7 +903,7 @@ void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory
          XO("Warning - Backup File Detected"),
          wxOK | wxCENTRE,
          &window);
-      return;
+      return nullptr;
    }
 
    if (!::wxFileExists(fileName)) {
@@ -915,9 +912,10 @@ void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory
          XO("Error Opening File"),
          wxOK | wxCENTRE,
          &window);
-      return;
+      return nullptr;
    }
 
+   // Following block covers cases other than a project file:
    {
       wxFFile ff(fileName, wxT("rb"));
 
@@ -935,7 +933,7 @@ void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory
             XO("Error opening file"),
             wxOK | wxCENTRE,
             &window);
-         return;
+         return nullptr;
       }
 
       char buf[7];
@@ -946,39 +944,55 @@ void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory
             XO("Error Opening File or Project"),
             wxOK | wxCENTRE,
             &window);
-         return;
+         return nullptr;
       }
 
       if (wxStrncmp(buf, "SQLite", 6) != 0)
       {
+         // Not a database
 #ifdef EXPERIMENTAL_DRAG_DROP_PLUG_INS
          // Is it a plug-in?
-         if (PluginManager::Get().DropFile(fileName))
-         {
+         if (PluginManager::Get().DropFile(fileName)) {
             MenuCreator::RebuildAllMenuBars();
+            // Plug-in installation happened, not really opening of a file,
+            // so return null
+            return nullptr;
          }
-         else
 #endif
 #ifdef USE_MIDI
-         if (FileNames::IsMidi(fileName))
-         {
-            DoImportMIDI(project, fileName);
+         if (FileNames::IsMidi(fileName)) {
+            // If this succeeds, indo history is incremented, and it also does
+            // ZoomAfterImport:
+            if(DoImportMIDI(project, fileName))
+               return &project;
+            return nullptr;
          }
-         else
 #endif
-         {
-            Import(fileName);
+         // Undo history is incremented inside this:
+         if (Import(fileName)) {
+            // Bug 2743: Don't zoom with lof.
+            if (!fileName.AfterLast('.').IsSameAs(wxT("lof"), false))
+               window.ZoomAfterImport(nullptr);
+            return &project;
          }
-         // Bug 2743: Don't zoom with lof.
-         if (!fileName.AfterLast('.').IsSameAs(wxT("lof"), false))
-            window.ZoomAfterImport(nullptr);
-
-         return;
+         return nullptr;
       }
    }
 
+   return OpenProjectFile(fileName, addtohistory);
+}
+
+AudacityProject *ProjectFileManager::OpenProjectFile(
+   const FilePath &fileName, bool addtohistory)
+{
+   auto &project = mProject;
+   auto &history = ProjectHistory::Get( project );
+   auto &tracks = TrackList::Get( project );
+   auto &trackPanel = TrackPanel::Get( project );
+   auto &projectFileIO = ProjectFileIO::Get( project );
+   auto &window = ProjectWindow::Get( project );
+
    auto results = ReadProjectFile( fileName );
- 
    const bool bParseSuccess = results.parseSuccess;
    const auto &errorStr = results.errorString;
    const bool err = results.trackError;
@@ -1020,6 +1034,7 @@ void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory
          // PushState calls AutoSave(), so no longer need to do so here.
          history.PushState(XO("Project was recovered"), XO("Recover"));
       }
+      return &project;
    }
    else {
       // Vaughan, 2011-10-30:
@@ -1044,6 +1059,8 @@ void ProjectFileManager::OpenFile(const FilePath &fileNameArg, bool addtohistory
          XO("Error Opening Project"),
          errorStr,
          results.helpUrl);
+
+      return nullptr;
    }
 }
 
@@ -1292,7 +1309,7 @@ bool ProjectFileManager::Import(
 
       history.PushState(XO("Imported '%s'").Format( fileName ), XO("Import"));
 
-      return false;
+      return true;
    }
 
    // PRL: Undo history is incremented inside this:

--- a/src/ProjectFileManager.h
+++ b/src/ProjectFileManager.h
@@ -43,16 +43,6 @@ public:
    ProjectFileManager &operator=( const ProjectFileManager & ) PROHIBITED;
    ~ProjectFileManager();
 
-   struct ReadProjectResults
-   {
-      bool parseSuccess;
-      bool trackError;
-      const TranslatableString errorString;
-      wxString helpUrl;
-   };
-   ReadProjectResults ReadProjectFile(
-      const FilePath &fileName, bool discardAutosave = false );
-
    bool OpenProject();
    void CloseProject();
    bool OpenNewProject();
@@ -91,7 +81,14 @@ public:
 
    static bool IsAlreadyOpen(const FilePath &projPathName);
 
-   void OpenFile(const FilePath &fileName, bool addtohistory = true);
+   /*!
+    Opens files of many kinds.  In case of import (sound, MIDI, or .aup), the undo history is pushed.
+    @param fileName the name and contents are examined to decide a type and open appropriately
+    @param addtohistory whether to add .aup3 files to the MRU list (but always done for imports)
+    @return if something was successfully opened, the project containing it; else null
+    */
+   AudacityProject *OpenFile(
+      const FilePath &fileName, bool addtohistory = true);
 
    bool Import(const FilePath &fileName,
                bool addToHistory = true);
@@ -105,6 +102,24 @@ public:
    void SetMenuClose(bool value) { mMenuClose = value; }
 
 private:
+   /*!
+    @param fileName a path assumed to exist and contain an .aup3 project
+    @param addtohistory whether to add the file to the MRU list
+    @return if something was successfully opened, the project containing it; else null
+    */
+   AudacityProject *OpenProjectFile(
+      const FilePath &fileName, bool addtohistory);
+
+   struct ReadProjectResults
+   {
+      bool parseSuccess;
+      bool trackError;
+      const TranslatableString errorString;
+      wxString helpUrl;
+   };
+   ReadProjectResults ReadProjectFile(
+      const FilePath &fileName, bool discardAutosave = false );
+
    bool DoSave(const FilePath & fileName, bool fromSaveAs);
 
    AudacityProject &mProject;

--- a/src/ProjectFileManager.h
+++ b/src/ProjectFileManager.h
@@ -11,6 +11,7 @@ Paul Licameli split from AudacityProject.h
 #ifndef __AUDACITY_PROJECT_FILE_MANAGER__
 #define __AUDACITY_PROJECT_FILE_MANAGER__
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -81,13 +82,17 @@ public:
 
    static bool IsAlreadyOpen(const FilePath &projPathName);
 
+   //! A function that returns a project to use for opening a file; argument is true if opening a project file
+   using ProjectChooserFn = std::function<AudacityProject&(bool)>;
+
    /*!
     Opens files of many kinds.  In case of import (sound, MIDI, or .aup), the undo history is pushed.
+    @param chooser told whether opening a project file; decides which project to open into
     @param fileName the name and contents are examined to decide a type and open appropriately
     @param addtohistory whether to add .aup3 files to the MRU list (but always done for imports)
     @return if something was successfully opened, the project containing it; else null
     */
-   AudacityProject *OpenFile(
+   static AudacityProject *OpenFile( const ProjectChooserFn &chooser,
       const FilePath &fileName, bool addtohistory = true);
 
    bool Import(const FilePath &fileName,

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -838,17 +838,15 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
 
 // PRL: I preserve this handler function for an event that was never sent, but
 // I don't know the intention.
-
 void ProjectManager::OnOpenAudioFile(wxCommandEvent & event)
 {
-   auto &project = mProject;
-   auto &window = GetProjectFrame( project );
    const wxString &cmd = event.GetString();
-
-   if (!cmd.empty())
-      ProjectFileManager::Get( mProject ).OpenFile(cmd);
-
-   window.RequestUserAttention();
+   if (!cmd.empty()) {
+      if (auto project = ProjectFileManager::Get( mProject ).OpenFile(cmd)) {
+         auto &window = GetProjectFrame( *project );
+         window.RequestUserAttention();
+      }
+   }
 }
 
 // static method, can be called outside of a project

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -868,9 +868,7 @@ void ProjectManager::OpenFiles(AudacityProject *proj)
       Importer::SetLastOpenType({});
    } );
 
-   for (size_t ff = 0; ff < selectedFiles.size(); ff++) {
-      const wxString &fileName = selectedFiles[ff];
-
+   for (const auto &fileName : selectedFiles) {
       // Make sure it isn't already open.
       if (ProjectFileManager::IsAlreadyOpen(fileName))
          continue; // Skip ones that are already open.
@@ -912,7 +910,7 @@ AudacityProject *ProjectManager::OpenProject(
          // Ensure that it happens here: don't wait for the application level
          // exception handler, because the exception may be intercepted
          ProjectHistory::Get(*pProject).RollbackState();
-      // Any exception now continues propagating
+         // Any exception now continues propagating
    } );
    ProjectFileManager::Get( *pProject ).OpenFile( fileNameArg, addtohistory );
 

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -873,7 +873,8 @@ void ProjectManager::OpenFiles(AudacityProject *proj)
 
       if (proj && !SafeToOpenProjectInto(*proj))
          proj = nullptr;
-      proj = OpenProject( proj, fileName );
+      proj = OpenProject( proj, fileName,
+         true /* addtohistory */, false /* reuseNonemptyProject */ );
    }
 }
 
@@ -901,7 +902,8 @@ bool ProjectManager::SafeToOpenProjectInto(AudacityProject &proj)
 }
 
 AudacityProject *ProjectManager::OpenProject(
-   AudacityProject *pProject, const FilePath &fileNameArg, bool addtohistory)
+   AudacityProject *pProject, const FilePath &fileNameArg,
+   bool addtohistory, bool)
 {
    bool success = false;
    AudacityProject *pNewProject = nullptr;

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -48,17 +48,52 @@ public:
    //! False when it is unsafe to overwrite proj with contents of an .aup3 file
    static bool SafeToOpenProjectInto(AudacityProject &proj);
 
+   //! Callable object that supplies the `chooser` argument of ProjectFileManager::OpenFile
+   /*!
+    Its operator(), called lower down in ProjectFileManager, decides which project to put new file data into,
+    using file type information deduced there.  It may have the side effect of creating a project.
+
+    At the higher level where it is constructed, it provides conditional RAII.
+    One indicates there that the file opening succeeded by calling Commit().  But if that is never
+    called, creation of projects, or changes to a preexisting project, are undone.
+    */
+   class ProjectChooser {
+   public:
+       /*!
+       @param pProject if not null, an existing project to reuse if possible
+       @param reuseNonemptyProject if true, may reuse the given project when nonempty,
+       but only if importing (not for a project file)
+       */
+      ProjectChooser( AudacityProject *pProject, bool reuseNonemptyProject )
+         : mpGivenProject{ pProject }
+         , mReuseNonemptyProject{ reuseNonemptyProject }
+      {}
+      //! Don't copy.  Use std::ref to pass it to ProjectFileManager
+      ProjectChooser( const ProjectChooser& ) PROHIBITED;
+      //! Destroy any fresh project, or rollback the existing project, unless committed
+      ~ProjectChooser();
+      //! May create a fresh project
+      AudacityProject &operator() ( bool openingProjectFile );
+      //! Commit the creation of any fresh project or changes to the existing project
+      void Commit();
+
+   private:
+      AudacityProject *mpGivenProject;
+      AudacityProject *mpUsedProject = nullptr;
+      bool mReuseNonemptyProject;
+   };
+
    //! Open a file into an AudacityProject, returning the project, or nullptr for failure
    /*!
     If an exception escapes this function, no projects are created.
-    @param pProject if not null, a project that may be reused
+    @param pGivenProject if not null, a project that may be reused
     @param fileNameArg path to the file to open; not always an Audacity project file, may be an import
     @param addtohistory whether to add .aup3 files to the MRU list (but always done for imports)
     @param reuseNonemptyProject if true, may reuse the given project when nonempty,
        but only if importing (not for a project file)
     */
    static AudacityProject *OpenProject(
-      AudacityProject *pProject,
+      AudacityProject *pGivenProject,
       const FilePath &fileNameArg, bool addtohistory, bool reuseNonemptyProject);
 
    void ResetProjectToEmpty();

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -48,12 +48,18 @@ public:
    //! False when it is unsafe to overwrite proj with contents of an .aup3 file
    static bool SafeToOpenProjectInto(AudacityProject &proj);
 
-   // Return the given project if that is not NULL, else create a project.
-   // Then open the given project path.
-   // But if an exception escapes this function, create no NEW project.
+   //! Open a file into an AudacityProject, returning the project, or nullptr for failure
+   /*!
+    If an exception escapes this function, no projects are created.
+    @param pProject if not null, a project that may be reused
+    @param fileNameArg path to the file to open; not always an Audacity project file, may be an import
+    @param addtohistory whether to add .aup3 files to the MRU list (but always done for imports)
+    @param reuseNonemptyProject if true, may reuse the given project when nonempty,
+       but only if importing (not for a project file)
+    */
    static AudacityProject *OpenProject(
       AudacityProject *pProject,
-      const FilePath &fileNameArg, bool addtohistory = true);
+      const FilePath &fileNameArg, bool addtohistory, bool reuseNonemptyProject);
 
    void ResetProjectToEmpty();
 

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -45,6 +45,9 @@ public:
    // reason remains in this class, not in ProjectFileManager
    static void OpenFiles(AudacityProject *proj);
 
+   //! False when it is unsafe to overwrite proj with contents of an .aup3 file
+   static bool SafeToOpenProjectInto(AudacityProject &proj);
+
    // Return the given project if that is not NULL, else create a project.
    // Then open the given project path.
    // But if an exception escapes this function, create no NEW project.

--- a/src/commands/OpenSaveCommands.cpp
+++ b/src/commands/OpenSaveCommands.cpp
@@ -65,8 +65,10 @@ bool OpenProjectCommand::Apply(const CommandContext & context){
    }
    else
    {
-      ProjectFileManager::Get( context.project )
-         .OpenFile(mFileName, mbAddToHistory);
+      ProjectManager::ProjectChooser chooser{ &context.project, true };
+      if(ProjectFileManager::OpenFile(
+         std::ref(chooser), mFileName, mbAddToHistory))
+         chooser.Commit();
    }
    const auto &newFileName = projectFileIO.GetFileName();
 

--- a/src/commands/OpenSaveCommands.cpp
+++ b/src/commands/OpenSaveCommands.cpp
@@ -59,6 +59,7 @@ bool OpenProjectCommand::Apply(const CommandContext & context){
    auto oldFileName = projectFileIO.GetFileName();
    if(mFileName.empty())
    {
+      // This path queries the user for files to open
       auto project = &context.project;
       ProjectManager::OpenFiles(project);
    }

--- a/src/import/ImportLOF.cpp
+++ b/src/import/ImportLOF.cpp
@@ -410,7 +410,8 @@ void LOFImportFileHandle::lofOpenFiles(wxString* ln)
           * audio file. TODO: Some sort of message here? */
 
 #endif // USE_MIDI
-         mProject = ProjectManager::OpenProject( mProject, targetfile );
+         mProject = ProjectManager::OpenProject( mProject, targetfile,
+            true /* addtohistory */, true /* reuseNonemptyProject */ );
 
       // Set tok to right after filename
       temptok2.SetString(targettoken);


### PR DESCRIPTION
Fixing Bug2764 (Open Project... under Scriptables can corrupt a project) by causing the Open Project... command to open a new project window when an .aup3 file is specified.

But also carefully implemented so that behavior of the command changes only in that case.  In other cases, which invoke
import code, still import the file into the existing project and add items to its undo history.
