### PR TITLE
Fix batch ops windows

### DIFF
--- a/lib-src/libsndfile/src/common.h
+++ b/lib-src/libsndfile/src/common.h
@@ -354,10 +354,9 @@ typedef struct
 	void 			*handle, *hsaved ;
 
 	int				use_wchar ;
-#else
+#endif
 	/* These fields can only be used in src/file_io.c. */
 	int 			filedes, savedes ;
-#endif
 
 	int				do_not_close_descriptor ;
 	int				mode ;			/* Open mode : SFM_READ, SFM_WRITE or SFM_RDWR. */

--- a/lib-src/libsndfile/src/file_io.c
+++ b/lib-src/libsndfile/src/file_io.c
@@ -627,10 +627,20 @@ psf_fclose (SF_PRIVATE *psf)
 		return 0 ;
 		} ;
 
-	if ((retval = psf_close_handle (psf->file.handle)) == -1)
+	if (psf->file.filedes != -1)
+	{
+		retval = close(psf->file.filedes);
+	}
+	else
+	{
+		retval = psf_close_handle(psf->file.handle);
+	}
+	
+	if (retval == -1)
 		psf_log_syserr (psf, GetLastError ()) ;
 
 	psf->file.handle = NULL ;
+	psf->file.filedes = -1;
 
 	return retval ;
 } /* psf_fclose */
@@ -874,10 +884,13 @@ psf_set_file (SF_PRIVATE *psf, int fd)
 {	HANDLE handle ;
 	intptr_t osfhandle ;
 
+	// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/get-osfhandle?view=msvc-160
+	// To close a file whose operating system (OS) file handle is obtained by _get_osfhandle, call _close on the file descriptor fd. Never call CloseHandle on the return value of this function.
 	osfhandle = _get_osfhandle (fd) ;
 	handle = (HANDLE) osfhandle ;
 
 	psf->file.handle = handle ;
+	psf->file.filedes = fd;
 } /* psf_set_file */
 
 /* USE_WINDOWS_API */ int

--- a/src/widgets/FileDialog/win/FileDialogPrivate.h
+++ b/src/widgets/FileDialog/win/FileDialogPrivate.h
@@ -35,6 +35,7 @@ public:
       const wxPoint& pos = wxDefaultPosition,
       const wxSize& sz = wxDefaultSize,
       const wxString& name = wxFileDialogNameStr);
+   ~FileDialog();
 
    virtual void GetPaths(wxArrayString& paths) const;
    virtual void GetFilenames(wxArrayString& files) const;
@@ -83,6 +84,8 @@ private:
 
 private:
    wxArrayString m_fileNames;
+   wxChar *fileNameBuffer;
+   size_t szFileNameBufferChars;
 
    // remember if our SetPosition() or Centre() (which requires special
    // treatment) was called


### PR DESCRIPTION
There are two problems with macro operations on Windows. First, the file dialog doesn't handle many filenames, it returns a corrupt path. There needs to be special handling for buffer overflow to handle the first two bytes of the return buffer being used as the required buffer size, not text. Second, a bug in libsndfile left file handles open meaning that the batch process would fail after a varying number of files - around 8000 in my case, depending on the version of Windows. I can submit this separately to libsndfile if you prefer.