### PR TITLE
Bug 2739 - If Temporary files directory is set to be unwritable then …

### DIFF
--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -775,7 +775,7 @@ bool ProjectFileManager::OpenNewProject()
       ShowErrorDialog(
          nullptr,
          XO("Can't open new empty project"),
-         XO("Error opening a new empty project"), 
+         XO("Error opening a new empty project.\nPerhaps Audacity's Temporary files directory is write protected."),
          "FAQ:Errors_opening_a_new_empty_project",
          true, 
          projectFileIO.GetLastLog());


### PR DESCRIPTION
…Audacity has a catalog of cryptic unhelpful errors

This Pull Request expands the current error message from:

     "Error opening a new empty project"
to:
     "Error opening a new empty project.
      Perhaps Audacity's Temporary files directory is write protected."
