### PR TITLE
macOS builds: otool -D should not give absolute path of libraries

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -353,6 +353,8 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
          PROPERTIES
             PREFIX ""
             FOLDER "libraries" # for IDE organization
+            INSTALL_NAME_DIR ""
+            BUILD_WITH_INSTALL_NAME_DIR YES
       )
    endif()
 


### PR DESCRIPTION
A small modification to build procedures
