### PR TITLE
Make lib-network-manager an opt-in library

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -112,7 +112,8 @@ jobs:
               -B build \
               -G "${{matrix.config.generator}}" \
               -A ${{matrix.config.platform}} \
-              -D audacity_use_pch=no
+              -D audacity_use_pch=no \
+              -D audacity_has_networking=yes 
 
         # Build Audacity
         cmake --build build --config Release --verbose
@@ -150,7 +151,8 @@ jobs:
               -B build \
               -T buildsystem=1 \
               -G "${{matrix.config.generator}}" \
-              -D audacity_use_pch=no
+              -D audacity_use_pch=no \
+              -D audacity_has_networking=yes 
 
         # Build Audacity
         cmake --build build --config Release
@@ -189,7 +191,8 @@ jobs:
         cmake -S . \
               -B build \
               -G "${{matrix.config.generator}}" \
-              -D audacity_use_pch=no
+              -D audacity_use_pch=no \
+              -D audacity_has_networking=yes 
 
         # Build Audacity
         cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,10 @@ cmd_option( ${_OPT}obey_system_dependencies
             Off
 )
 
+cmd_option( ${_OPT}has_networking 
+   "Build networking features into Audacity"
+   Off)
+
 include( AudacityDependencies )
 
 # Pull all the modules we'll need

--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -104,18 +104,22 @@ add_conan_lib(
    ALWAYS_ALLOW_CONAN_FALLBACK
 )
 
-add_conan_lib(
-   CURL
-   libcurl/7.75.0
-   REQUIRED
-   OPTION_NAME curl
-   PKG_CONFIG "libcurl >= 7.68.0"
-   INTERFACE_NAME CURL::libcurl
-   FIND_PACKAGE_OPTIONS
-   CONAN_OPTIONS
-      libcurl:with_ssl=${curl_ssl}
-      libcurl:shared=True
-)
+if( ${_OPT}has_networking )
+
+   add_conan_lib(
+      CURL
+      libcurl/7.75.0
+      REQUIRED
+      OPTION_NAME curl
+      PKG_CONFIG "libcurl >= 7.68.0"
+      INTERFACE_NAME CURL::libcurl
+      FIND_PACKAGE_OPTIONS
+      CONAN_OPTIONS
+         libcurl:with_ssl=${curl_ssl}
+         libcurl:shared=True
+   )
+
+endif()
 
 set_conan_vars_to_parent()
 

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -4,8 +4,11 @@
 # that it depends on
 set( LIBRARIES
    "lib-string-utils"
-   "lib-network-manager"
 )
+
+if ( ${_OPT}has_networking )
+   list( APPEND LIBRARIES "lib-network-manager")
+endif()
 
 foreach( LIBRARY ${LIBRARIES} )
    add_subdirectory( "${LIBRARY}" )

--- a/libraries/lib-network-manager/CMakeLists.txt
+++ b/libraries/lib-network-manager/CMakeLists.txt
@@ -37,5 +37,7 @@ set ( LIBRARIES PRIVATE
     wxwidgets::base
 )
 
+set ( DEFINES INTERFACE "HAS_NETWORKING" )
 
-audacity_library( ${TARGET} "${SOURCES}" "${LIBRARIES}" "" "" )
+
+audacity_library( ${TARGET} "${SOURCES}" "${LIBRARIES}" "${DEFINES}" "" )

--- a/linux/build-environment/entrypoint.sh
+++ b/linux/build-environment/entrypoint.sh
@@ -38,6 +38,7 @@ cmake_options=(
     -Daudacity_use_sbsms=local # We prefer using the latest version of sbsms
     -Daudacity_use_soundtouch=system
     -Daudacity_use_twolame=system
+    -Daudacity_has_networking=yes 
     -Daudacity_use_curl=system
 )
 

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -112,7 +112,9 @@ It handles initialization and termination by subclassing wxApp.
 #include "widgets/FileConfig.h"
 #include "widgets/FileHistory.h"
 
+#ifdef HAS_NETWORKING
 #include "NetworkManager.h"
+#endif
 
 #ifdef EXPERIMENTAL_EASY_CHANGE_KEY_BINDINGS
 #include "prefs/KeyConfigPrefs.h"
@@ -2202,7 +2204,9 @@ int AudacityApp::OnExit()
    // Terminate the PluginManager (must be done before deleting the locale)
    PluginManager::Get().Terminate();
 
+#ifdef HAS_NETWORKING
    audacity::network_manager::NetworkManager::GetInstance().Terminate();
+#endif
 
    return 0;
 }


### PR DESCRIPTION
After the discussion with @Paul-Licameli, it was decided to make networking completely opt-in.

This is controlled by the `audacity_has_networking` CMake option. 

This option is off by default, but is enabled for CI builds