### PR TITLE
Use expat version that builds with autotools

### DIFF
--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -11,7 +11,7 @@ add_conan_lib(
 
 add_conan_lib(
    expat
-   expat/2.2.9
+   expat/2.2.9@audacity/stable
    REQUIRED
    PKG_CONFIG "expat >= 2.1.0"
    CONAN_OPTIONS 


### PR DESCRIPTION
Expat has an issue when building with CMake on BSD systems: https://github.com/libexpat/libexpat/issues/55

The workaround is an updated Conan recipe, that uses autotools on all platforms, except Windows