### PR TITLE
fix for P2 "Bug 2769 - Nyquist effects cannot extend length of selected audio"

### DIFF
--- a/lib-src/libnyquist/nyx.c
+++ b/lib-src/libnyquist/nyx.c
@@ -1002,22 +1002,6 @@ int nyx_get_audio(nyx_audio_callback callback, void *userdata)
       goto finish;
    }
 
-   // if LEN is set, we will return LEN samples per channel. If LEN is
-   // unbound, we will compute samples until every channel has terminated
-   // that the samples per channel will match the last termination time,
-   // i.e. it could result in a partial block at the end.
-   if (nyx_input_length == 0) {
-      LVAL val = getvalue(xlenter("LEN"));
-      if (val != s_unbound) {
-         if (ntype(val) == FLONUM) {
-            nyx_input_length = (int64_t) getflonum(val);
-         }
-         else if (ntype(val) == FIXNUM) {
-            nyx_input_length = (int64_t) getfixnum(val);
-         }
-      }
-   }
-
    // at this point, input sounds which were referenced by symbol S
    // (or nyx_get_audio_name()) could be referenced by nyx_result, but
    // S is now bound to NIL. nyx_result is a protected (garbage
@@ -1060,9 +1044,6 @@ int nyx_get_audio(nyx_audio_callback callback, void *userdata)
       bool terminated = true;
       // how many samples to compute before calling callback:
       int64_t togo = max_sample_block_len;
-      if (nyx_input_length > 0 && total + togo > nyx_input_length) {
-         togo = nyx_input_length - total;
-      }
       for (ch = 0; ch < num_channels; ch++) {
          sound_state_type state = &states[ch];
          sound_type snd = getsound(getelement(nyx_result, ch));


### PR DESCRIPTION
Restore old behavior where Nyquist sound effects replace selection with
arbitrary length computed sound. (So as before, sound after the selection
is shifted in time if the replacement sound is shorter or longer than the
original selection.) If stereo is computed and one channel is shorter than
the other, the shorter channel is extended with zeros to match the length
of the longer one.

Resolves: https://bugzilla.audacityteam.org/show_bug.cgi?id=2769

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
