### PR TITLE
Adds an option to force all the dependencies to be build from source

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -156,6 +156,17 @@ cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=of
 
 You can use `cmake -LH` to get a list of the options available (or use CMake GUI or `ccmake`). The list will include the documentation about each option. For convienience, [here is a list](CMAKE_OPTIONS.md) of the most notable options.
 
+### Disabling pre-built binaries downloads for Conan
+
+It is possible to force Conan to build all the dependencies from the source code without using the pre-built binaries. To do so, please pass 
+`-Daudaicity_conan_allow_prebuilt_binaries=Off` to CMake during the configration.
+
+After the configuration, in order to reduce the space used by Conan cache, please run:
+```
+$ conan remove "*" -s -b -f
+```
+It will reduce the disk space usage by 10-20 times.
+
 ### Building using system libraries
 
 On Linux, it is possible to build Audacity using (almost) only the libraries provided by the package manager. Please, see the list of the required libraries [here](linux/required_libraries.md).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,12 @@ project( Audacity )
 # Load our functions/macros
 include( AudacityFunctions )
 
+# Allow using Conan prebuilt binaries
+cmd_option( ${_OPT}conan_allow_prebuilt_binaries
+            "Allow using Conan prebuilt binaries"
+            On
+)
+
 # Allow user to globally set the library preference
 cmd_option( ${_OPT}lib_preference
             "Library preference [system (if available), local]"

--- a/cmake-proxies/cmake-modules/AudacityDependencies.cmake
+++ b/cmake-proxies/cmake-modules/AudacityDependencies.cmake
@@ -13,6 +13,12 @@ set( CONAN_ONLY_DEBUG_RELEASE )
 set( CONAN_CONFIG_OPTIONS )
 set( CONAN_RESOLVE_LIST )
 
+if ( ${_OPT}conan_allow_prebuilt_binaries )
+    set ( CONAN_BUILD_MODE BUILD missing )
+else()
+    set( CONAN_BUILD_MODE BUILD all )
+endif()
+
 # Add a Conan dependency
 # Example usage:
 # add_conan_lib( 
@@ -226,7 +232,7 @@ function ( _conan_install build_type )
 
 
     conan_cmake_install(PATH_OR_REFERENCE .
-        BUILD missing
+        ${CONAN_BUILD_MODE}
         SETTINGS ${settings}
     )
 endfunction()


### PR DESCRIPTION
Adds `audaicity_conan_allow_prebuilt_binaries` that will force all the Conan dependencies to be built from the source

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
