### PR TITLE
Issue 871: Let Audacity compile with unmodified portaudio sources...

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@
 set( TARGET Audacity )
 set( TARGET_ROOT ${topdir}/src )
 
+include (CheckFunctionExists)
+
 message( STATUS "========== Configuring ${TARGET} ==========" )
 
 # Allow modules to link against the Audacity executable
@@ -1314,6 +1316,12 @@ source_group(
 import_symbol_define( import_symbol AUDACITY_DLL )
 export_symbol_define( export_symbol AUDACITY_DLL )
 list( APPEND DEFINES PRIVATE "${export_symbol}" INTERFACE "${import_symbol}" )
+
+# see AudioIO.cpp
+check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
+if(HAVE_CLOCK_GETTIME)
+   list( APPEND DEFINES HAVE_CLOCK_GETTIME )
+endif()
 
 target_sources( ${TARGET} PRIVATE ${HEADERS} ${SOURCES} ${RESOURCES} ${MAC_RESOURCES} ${WIN_RESOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/871

... This may allow upgrade to the latest version of portaudio, which is
desirable for fixes and improvements, including the fixing of build warnings on
Mac about use of deprecated SDK functions.

The function PaUtil_GetTime() cannot be called.

To make a conservative fix that doesn't affect the fine tuning of timing,
replicate the implementation of that function directly in AudioIO.cpp, with
all necessary conditional compilation branches.

Don't attempt a fix with std::chrono, although that would be more nicely
platform independent.

Testing should confirm that MIDI playback doesn't suffer any jittery timing,
such as it did especially on Linux with ALSA, when the playback feature was
under development in 2017.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
