### PR TITLE
Add alpha-build-only crash-me buttons, for testing of crash reporting

### DIFF
--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -360,6 +360,31 @@ void OnCrashReport(const CommandContext &WXUNUSED(context) )
 }
 #endif
 
+#ifdef IS_ALPHA
+void OnSegfault(const CommandContext &)
+{
+   unsigned *p = nullptr;
+   *p = 0xDEADBEEF;
+}
+   
+void OnException(const CommandContext &)
+{
+   // Throw an exception that can be caught only as (...)
+   // The intent is to exercise detection of unhandled exceptions by the
+   // crash reporter
+   struct Unique{};
+   throw Unique{};
+}
+   
+void OnAssertion(const CommandContext &)
+{
+   // We don't use assert() much directly, but Breakpad does detect it
+   // This may crash the program only in debug builds
+   // See also wxSetAssertHandler, and wxApp::OnAssertFailure()
+   assert(false);
+}
+#endif
+
 void OnMenuTree(const CommandContext &context)
 {
    auto &project = context.project;
@@ -523,13 +548,25 @@ BaseItemSharedPtr HelpMenu()
                FN(OnCrashReport), AlwaysEnabledFlag )
       #endif
 
-   #ifdef IS_ALPHA
+      #ifdef IS_ALPHA
             ,
+            // alpha-only items don't need to internationalize, so use
+            // Verbatim for labels
+
+            Command( wxT("RaiseSegfault"), Verbatim("Test segfault report"),
+               FN(OnSegfault), AlwaysEnabledFlag ),
+
+            Command( wxT("ThrowException"), Verbatim("Test exception report"),
+               FN(OnException), AlwaysEnabledFlag ),
+
+            Command( wxT("ViolateAssertion"), Verbatim("Test assertion report"),
+               FN(OnAssertion), AlwaysEnabledFlag ),
+
             // Menu explorer.  Perhaps this should become a macro command
-            Command( wxT("MenuTree"), XXO("Menu Tree..."),
+            Command( wxT("MenuTree"), Verbatim("Menu Tree..."),
                FN(OnMenuTree),
                AlwaysEnabledFlag )
-   #endif
+      #endif
          )
    #ifndef __WXMAC__
       ),


### PR DESCRIPTION
To assist the testing of https://github.com/audacity/audacity/pull/836

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
