### PR TITLE
Error reporting to Sentry

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -95,6 +95,18 @@ jobs:
         key: host-${{ matrix.config.name }}-${{ hashFiles('cmake-proxies/CMakeLists.txt') }}
         restore-keys: |
           host-${{ matrix.config.name }}-
+    - name: Check Sentry secrets
+      env:
+        SENTRY_DSN_KEY: ${{ secrets.SENTRY_DSN_KEY }}
+        SENTRY_HOST: ${{ secrets.SENTRY_HOST }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      if: ${{ env.SENTRY_DSN_KEY != '' && env.SENTRY_HOST != '' && env.SENTRY_PROJECT != '' }}
+      shell: bash
+      run: |
+        echo "SENTRY_PARAMETERS<<EOF" >> $GITHUB_ENV
+        echo "-DSENTRY_DSN_KEY=${SENTRY_DSN_KEY} -DSENTRY_HOST=${SENTRY_HOST} -DSENTRY_PROJECT=${SENTRY_PROJECT}" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
     # =========================================================================
     # WINDOWS: Build (for all versions of Windows)
     # =========================================================================
@@ -113,7 +125,7 @@ jobs:
               -G "${{matrix.config.generator}}" \
               -A ${{matrix.config.platform}} \
               -D audacity_use_pch=no \
-              -D audacity_has_networking=yes 
+              -D audacity_has_networking=yes ${{ env.SENTRY_PARAMETERS }}
 
         # Build Audacity
         cmake --build build --config Release --verbose
@@ -152,7 +164,7 @@ jobs:
               -T buildsystem=1 \
               -G "${{matrix.config.generator}}" \
               -D audacity_use_pch=no \
-              -D audacity_has_networking=yes 
+              -D audacity_has_networking=yes ${{ env.SENTRY_PARAMETERS }}
 
         # Build Audacity
         cmake --build build --config Release
@@ -192,7 +204,7 @@ jobs:
               -B build \
               -G "${{matrix.config.generator}}" \
               -D audacity_use_pch=no \
-              -D audacity_has_networking=yes 
+              -D audacity_has_networking=yes ${{ env.SENTRY_PARAMETERS }} 
 
         # Build Audacity
         cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,14 @@ include( CMakePushCheckState )
 include( GNUInstallDirs )
 include( TestBigEndian )
 
+cmake_dependent_option(
+   ${_OPT}has_sentry_reporting 
+   "Build support for sending errors to Sentry"
+   On
+   "${_OPT}has_networking;DEFINED SENTRY_DSN_KEY;DEFINED SENTRY_HOST;DEFINED SENTRY_PROJECT"
+   Off
+)
+
 # Determine 32-bit or 64-bit target
 if( CMAKE_C_COMPILER_ID MATCHES "MSVC" AND CMAKE_VS_PLATFORM_NAME MATCHES "Win64|x64" )
    set( IS_64BIT ON )

--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -144,6 +144,12 @@ if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
    )
 endif()
 
+add_conan_lib(
+   RapidJSON
+   rapidjson/1.1.0
+   REQUIRED
+)
+
 set_conan_vars_to_parent()
 
 # Required libraries

--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -229,15 +229,15 @@ function( audacity_append_common_compiler_options var use_pch )
          -DAUDACITY_FILE_VERSION=L"${AUDACITY_VERSION},${AUDACITY_RELEASE},${AUDACITY_REVISION},${AUDACITY_MODLEVEL}"
 
          # This renames a good use of this C++ keyword that we don't need
-	 # to review when hunting for leaks because of naked new and delete.
+	      # to review when hunting for leaks because of naked new and delete.
 	 -DPROHIBITED==delete
 
          # Reviewed, certified, non-leaky uses of NEW that immediately entrust
-	 # their results to RAII objects.
+	      # their results to RAII objects.
          # You may use it in NEW code when constructing a wxWindow subclass
-	 # with non-NULL parent window.
+	      # with non-NULL parent window.
          # You may use it in NEW code when the NEW expression is the
-	 # constructor argument for a standard smart
+	      # constructor argument for a standard smart
          # pointer like std::unique_ptr or std::shared_ptr.
          -Dsafenew=new
 
@@ -246,7 +246,7 @@ function( audacity_append_common_compiler_options var use_pch )
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=return-type>
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=dangling-else>
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=return-stack-address>
-	 # Yes, CMake will change -D to /D as needed for Windows:
+	      # Yes, CMake will change -D to /D as needed for Windows:
          -DWXINTL_NO_GETTEXT_MACRO
          $<$<CXX_COMPILER_ID:MSVC>:-D_USE_MATH_DEFINES>
          $<$<CXX_COMPILER_ID:MSVC>:-DNOMINMAX>
@@ -404,7 +404,7 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
       add_custom_command(
          TARGET "${TARGET}"
          POST_BUILD
-	 COMMAND $<IF:$<CONFIG:Debug>,echo,strip> -x $<TARGET_FILE:${TARGET}>
+         COMMAND $<IF:$<CONFIG:Debug>,echo,strip> -x $<TARGET_FILE:${TARGET}>
       )
    endif()
 
@@ -432,15 +432,15 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
       add_library("${INTERFACE_TARGET}" INTERFACE)
       foreach(PROP
          INTERFACE_INCLUDE_DIRECTORIES
-	 INTERFACE_COMPILE_DEFINITIONS
-	 INTERFACE_LINK_LIBRARIES
+         INTERFACE_COMPILE_DEFINITIONS
+         INTERFACE_LINK_LIBRARIES
       )
          get_target_property( PROPS "${TARGET}" "${PROP}" )
-	 if (PROPS)
+         if (PROPS)
             set_target_properties(
                "${INTERFACE_TARGET}"
-	       PROPERTIES "${PROP}" "${PROPS}" )
-	 endif()
+               PROPERTIES "${PROP}" "${PROPS}" )
+         endif()
       endforeach()
    endif()
 
@@ -505,6 +505,22 @@ macro( audacity_library NAME SOURCES IMPORT_TARGETS
    )
    set( GRAPH_EDGES "${GRAPH_EDGES}" PARENT_SCOPE )
    # Collect list of libraries for the executable to declare dependency on
+   list( APPEND AUDACITY_LIBRARIES "${NAME}" )
+   set( AUDACITY_LIBRARIES "${AUDACITY_LIBRARIES}" PARENT_SCOPE )
+endmacro()
+
+# A special macro for header only libraries
+
+macro( audacity_header_only_library NAME SOURCES IMPORT_TARGETS
+   ADDITIONAL_DEFINES )
+   # ditto comment in the previous macro
+   add_library( ${NAME} INTERFACE )
+
+   target_include_directories ( ${NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} )
+   target_sources( ${NAME} INTERFACE ${SOURCES})
+   target_link_libraries( ${NAME} INTERFACE ${IMPORT_TARGETS} )
+   target_compile_definitions( ${NAME} INTERFACE ${ADDITIONAL_DEFINES} )
+
    list( APPEND AUDACITY_LIBRARIES "${NAME}" )
    set( AUDACITY_LIBRARIES "${AUDACITY_LIBRARIES}" PARENT_SCOPE )
 endmacro()

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -3,15 +3,20 @@
 # The list of modules is ordered so that each library occurs after any others
 # that it depends on
 set( LIBRARIES
-   "lib-string-utils"
+   lib-string-utils
    lib-strings
    lib-utility
    lib-uuid
 )
 
 if ( ${_OPT}has_networking )
-   list( APPEND LIBRARIES "lib-network-manager")
+   list( APPEND LIBRARIES lib-network-manager)
 endif()
+
+# This library depends on lib-network-manager
+# If Sentry reporting is disabled, an INTERFACE library
+# will be defined
+list( APPEND LIBRARIES lib-sentry-reporting)
 
 foreach( LIBRARY ${LIBRARIES} )
    add_subdirectory( "${LIBRARY}" )

--- a/libraries/lib-sentry-reporting/AnonymizedMessage.cpp
+++ b/libraries/lib-sentry-reporting/AnonymizedMessage.cpp
@@ -1,0 +1,91 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file AnonymizedMessage.cpp
+ @brief Define a class to store anonymized messages.
+
+ Dmitry Vedenko
+ **********************************************************************/
+
+#include "AnonymizedMessage.h"
+
+#include <regex>
+
+#include "CodeConversions.h"
+
+namespace audacity
+{
+namespace sentry
+{
+
+AnonymizedMessage::AnonymizedMessage(std::string message)
+    : mMessage(std::move(message))
+{
+   CleanupPaths();
+}
+
+AnonymizedMessage::AnonymizedMessage(const std::wstring& message)
+    : AnonymizedMessage(ToUTF8(message))
+{
+}
+
+AnonymizedMessage::AnonymizedMessage(const wxString& message)
+    : AnonymizedMessage(ToUTF8(message))
+{
+}
+
+AnonymizedMessage::AnonymizedMessage(const char* message)
+    : AnonymizedMessage(std::string(message))
+{
+}
+
+AnonymizedMessage::AnonymizedMessage(const wchar_t* message)
+    : AnonymizedMessage(ToUTF8(message))
+{
+}
+
+bool AnonymizedMessage::Empty() const noexcept
+{
+   return mMessage.empty();
+}
+
+size_t AnonymizedMessage::Length() const noexcept
+{
+   return mMessage.size();
+}
+
+const std::string& AnonymizedMessage::GetString() const noexcept
+{
+   return mMessage;
+}
+
+wxString AnonymizedMessage::ToWXString() const noexcept
+{
+   return audacity::ToWXString(mMessage);
+}
+
+const char* AnonymizedMessage::c_str() const noexcept
+{
+   return mMessage.c_str();
+}
+
+size_t AnonymizedMessage::length() const noexcept
+{
+   return mMessage.length();
+}
+
+void AnonymizedMessage::CleanupPaths()
+{
+   // Finding the path boundary in the arbitrary text is a hard task.
+   // We assume that spaces cannot be a part of the path.
+   // In the worst case - we will get <path> <path>
+   static const std::regex re(
+      R"(\b(?:(?:[a-zA-Z]:)?[\\/]?)?(?:[^<>:"/|\\/?\s*]+[\\/]+)*(?:[^<>:"/|\\/?*\s]+\.\w+)?)");
+
+   mMessage = std::regex_replace(
+      mMessage, re, "<path>", std::regex_constants::match_not_null);
+}
+
+} // namespace sentry
+} // namespace audacity

--- a/libraries/lib-sentry-reporting/AnonymizedMessage.h
+++ b/libraries/lib-sentry-reporting/AnonymizedMessage.h
@@ -17,10 +17,15 @@ namespace audacity
 {
 namespace sentry
 {
-
+//! A class, that stores anonymized message.
+/*!
+    Input message is anonymized by looking for path-like patterns. 
+    Messages are stored in UTF8 format.
+*/
 class SENTRY_REPORTING_API AnonymizedMessage final
 {
 public:
+   //! Creates an empty message
    AnonymizedMessage() = default;
 
    AnonymizedMessage(const AnonymizedMessage&) = default;
@@ -29,21 +34,31 @@ public:
    AnonymizedMessage& operator=(const AnonymizedMessage&) = default;
    AnonymizedMessage& operator=(AnonymizedMessage&&) = default;
 
+   //! Creates a message from std::string
    AnonymizedMessage(std::string message);
+   //! Creates a message from std::wstring
    AnonymizedMessage(const std::wstring& message);
+   //! Creates a message from wxString
    AnonymizedMessage(const wxString& message);
-
+   //! Creates a message from const char*
    AnonymizedMessage(const char* message);
+   //! Creates a message from const wchar_t*
    AnonymizedMessage(const wchar_t* message);
 
+   //! Checks, if the message is empty
    bool Empty() const noexcept;
+   //! Returns the length of the message
    size_t Length() const noexcept;
 
+   //! Returns the UTF8 representation of the message
    const std::string& GetString() const noexcept;
+   //! Convert the message to wxString
    wxString ToWXString() const noexcept;
 
-   // Immitate std::string interface
+   // Imitate std::string interface
+   //! Checks, if the message is empty
    const char* c_str() const noexcept;
+   //! Returns the length of the message
    size_t length() const noexcept;
 private:
    void CleanupPaths();

--- a/libraries/lib-sentry-reporting/AnonymizedMessage.h
+++ b/libraries/lib-sentry-reporting/AnonymizedMessage.h
@@ -1,0 +1,55 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file AnonymizedMessage.h
+ @brief Declare a class to store anonymized messages.
+
+ Dmitry Vedenko
+ **********************************************************************/
+
+#include <string>
+#include <wx/string.h>
+
+#pragma once
+
+namespace audacity
+{
+namespace sentry
+{
+
+class SENTRY_REPORTING_API AnonymizedMessage final
+{
+public:
+   AnonymizedMessage() = default;
+
+   AnonymizedMessage(const AnonymizedMessage&) = default;
+   AnonymizedMessage(AnonymizedMessage&&) = default;
+
+   AnonymizedMessage& operator=(const AnonymizedMessage&) = default;
+   AnonymizedMessage& operator=(AnonymizedMessage&&) = default;
+
+   AnonymizedMessage(std::string message);
+   AnonymizedMessage(const std::wstring& message);
+   AnonymizedMessage(const wxString& message);
+
+   AnonymizedMessage(const char* message);
+   AnonymizedMessage(const wchar_t* message);
+
+   bool Empty() const noexcept;
+   size_t Length() const noexcept;
+
+   const std::string& GetString() const noexcept;
+   wxString ToWXString() const noexcept;
+
+   // Immitate std::string interface
+   const char* c_str() const noexcept;
+   size_t length() const noexcept;
+private:
+   void CleanupPaths();
+
+   std::string mMessage;
+};
+
+} // namespace sentry
+} // namespace audacity

--- a/libraries/lib-sentry-reporting/CMakeLists.txt
+++ b/libraries/lib-sentry-reporting/CMakeLists.txt
@@ -1,0 +1,48 @@
+#[[
+A library, that allows sending error reports to a Sentry server
+using Exception and Message interfaces.
+]]#
+
+set( TARGET lib-sentry-reporting )
+set( TARGET_ROOT ${CMAKE_CURRENT_SOURCE_DIR} )
+
+def_vars()
+
+if(${_OPT}has_sentry_reporting)
+    set( SOURCES
+        SentryHelper.h
+
+        AnonymizedMessage.h
+        AnonymizedMessage.cpp
+
+        SentryReport.h
+        SentryReport.cpp
+
+        SentryRequestBuilder.h
+        SentryRequestBuilder.cpp
+    )
+
+
+    set ( LIBRARIES PRIVATE
+        lib-network-manager # Required for the networking
+        lib-string-utils # ToUtf8
+        lib-uuid # UUIDs are required as an event identifier.
+        RapidJSON::RapidJSON # Protocol is JSON based
+        wxwidgets::base # Required to retreive the OS information
+    )
+
+    set ( DEFINES 
+        INTERFACE
+            HAS_SENTRY_REPORTING=1
+        PRIVATE
+            # The variables below will be used to construct Sentry URL:
+            # https://${SENTRY_DSN_KEY}@${SENTRY_HOST}/api/${SENTRY_PROJECT}/store
+            SENTRY_DSN_KEY="${SENTRY_DSN_KEY}"
+            SENTRY_HOST="${SENTRY_HOST}"
+            SENTRY_PROJECT="${SENTRY_PROJECT}"
+    )
+
+    audacity_library( ${TARGET} "${SOURCES}" "${LIBRARIES}" "${DEFINES}" "" )
+else()
+    audacity_header_only_library( ${TARGET} "SentryHelper.h" "" "" "" )
+endif()

--- a/libraries/lib-sentry-reporting/SentryHelper.h
+++ b/libraries/lib-sentry-reporting/SentryHelper.h
@@ -1,0 +1,25 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  SentryHelper.h
+
+  Defines a macro ADD_EXCEPTION_CONTEXT, that is a no op if Sentry reporting is disabled.
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#ifndef __AUDACITY_SENTRY__
+#define __AUDACITY_SENTRY__
+
+#ifdef HAS_SENTRY_REPORTING
+#	include "SentryReport.h"
+
+#   define ADD_EXCEPTION_CONTEXT(name, value) audacity::sentry::AddExceptionContext(name, value)
+#else
+#   define ADD_EXCEPTION_CONTEXT(name, value)
+#endif // HAS_SENTRY_REPORTING
+
+
+#endif /* __AUDACITY_SENTRY__ */

--- a/libraries/lib-sentry-reporting/SentryReport.cpp
+++ b/libraries/lib-sentry-reporting/SentryReport.cpp
@@ -1,0 +1,428 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file SentryReport.cpp
+ @brief Define a class to report errors to Sentry.
+
+ Dmitry Vedenko
+ **********************************************************************/
+
+#include "SentryReport.h"
+
+#include <chrono>
+#include <cstring>
+#include <mutex>
+
+#include <algorithm>
+#include <cctype>
+#include <regex>
+
+#include <rapidjson/document.h>
+#include <rapidjson/writer.h>
+#include <rapidjson/prettywriter.h>
+
+#include <wx/platinfo.h>
+#include <wx/log.h>
+
+#include "CodeConversions.h"
+#include "Uuid.h"
+
+#include "IResponse.h"
+#include "NetworkManager.h"
+
+#include "SentryRequestBuilder.h"
+
+namespace audacity
+{
+namespace sentry
+{
+namespace
+{
+
+//! Helper class to store additional details about the exception
+/*! This small class is a thread safe store for the information 
+    we want to add to the exception before the exception occurs.
+    For example, we may log SQLite3 return codes here, as otherwise 
+    they wont be available when everything fails
+*/
+class ExceptionContext final
+{
+public:
+    //! Adds a new item to the exception context
+   void Add(std::string parameterName, AnonymizedMessage parameterValue)
+   {
+      std::lock_guard<std::mutex> lock(mDataMutex);
+      mData.emplace_back(std::move(parameterName), std::move(parameterValue));
+   }
+
+   //! Return the current context and reset it
+   std::vector<ExceptionData> MoveParameters()
+   {
+      std::lock_guard<std::mutex> lock(mDataMutex);
+
+      std::vector<ExceptionData> emptyVector;
+
+      std::swap(mData, emptyVector);
+
+      return emptyVector;
+   }
+
+   //! Get an instance of the ExceptionContext
+   static ExceptionContext& Get()
+   {
+      static ExceptionContext instance;
+      return instance;
+   }
+
+private:
+   ExceptionContext() = default;
+
+   std::mutex mDataMutex;
+   std::vector<ExceptionData> mData;
+};
+
+//! Append the data about the operating system to the JSON document
+void AddOSContext(
+   rapidjson::Value& root, rapidjson::Document::AllocatorType& allocator)
+{
+   rapidjson::Value osContext(rapidjson::kObjectType);
+
+   const wxPlatformInfo platformInfo = wxPlatformInfo::Get();
+
+   const std::string osName =
+      ToUTF8(platformInfo.GetOperatingSystemFamilyName());
+
+   osContext.AddMember("type", rapidjson::Value("os", allocator), allocator);
+
+   osContext.AddMember(
+      "name", rapidjson::Value(osName.c_str(), osName.length(), allocator),
+      allocator);
+
+   const std::string osVersion =
+      std::to_string(platformInfo.GetOSMajorVersion()) + "." +
+      std::to_string(platformInfo.GetOSMinorVersion()) + "." +
+      std::to_string(platformInfo.GetOSMicroVersion());
+
+   osContext.AddMember(
+      "version",
+      rapidjson::Value(osVersion.c_str(), osVersion.length(), allocator),
+      allocator);
+
+   root.AddMember("os", std::move(osContext), allocator);
+}
+
+//! Create the minimal required Sentry JSON document
+rapidjson::Document CreateSentryDocument()
+{
+   using namespace std::chrono;
+   rapidjson::Document document;
+
+   document.SetObject();
+
+   document.AddMember(
+      "timestamp",
+      rapidjson::Value(
+         duration_cast<seconds>(system_clock::now().time_since_epoch())
+            .count()),
+      document.GetAllocator());
+
+   std::string eventId = Uuid::Generate().ToHexString();
+
+   document.AddMember(
+      "event_id",
+      rapidjson::Value(
+         eventId.c_str(), eventId.length(), document.GetAllocator()),
+      document.GetAllocator());
+
+   constexpr char platform[] = "native";
+
+   document.AddMember(
+      "platform",
+      rapidjson::Value(platform, sizeof(platform) - 1, document.GetAllocator()),
+      document.GetAllocator());
+
+   document["platform"].SetString(
+      platform, sizeof(platform) - 1, document.GetAllocator());
+
+   const std::string release = std::string("audacity@") +
+                               std::to_string(AUDACITY_VERSION) + "." +
+                               std::to_string(AUDACITY_RELEASE) + "." +
+                               std::to_string(AUDACITY_REVISION);
+
+   document.AddMember(
+      "release",
+      rapidjson::Value(
+         release.c_str(), release.length(), document.GetAllocator()),
+      document.GetAllocator());
+
+   rapidjson::Value contexts = rapidjson::Value(rapidjson::kObjectType);
+
+   AddOSContext(contexts, document.GetAllocator());
+
+   document.AddMember("contexts", contexts, document.GetAllocator());
+
+   return document;
+}
+
+//! Append the ExceptionData to the Exception JSON object
+void AddExceptionDataToJson(
+   rapidjson::Value& value, rapidjson::Document::AllocatorType& allocator,
+   const ExceptionData& data)
+{
+   value.AddMember(
+      rapidjson::Value(data.first.c_str(), data.first.length(), allocator),
+      rapidjson::Value(data.second.c_str(), data.second.length(), allocator),
+      allocator);
+}
+
+//! Serialize the Exception to JSON
+void SerializeException(
+   const Exception& exception, rapidjson::Value& root,
+   rapidjson::Document::AllocatorType& allocator)
+{
+   root.AddMember(
+      "type",
+      rapidjson::Value(
+         exception.Type.c_str(), exception.Type.length(), allocator),
+      allocator);
+
+   root.AddMember(
+      "value",
+      rapidjson::Value(
+         exception.Value.c_str(), exception.Value.length(), allocator),
+      allocator);
+
+   rapidjson::Value mechanismObject(rapidjson::kObjectType);
+
+   mechanismObject.AddMember(
+      "type", rapidjson::Value("runtime_error", allocator), allocator);
+
+   mechanismObject.AddMember(
+      "handled", false, allocator);
+
+   auto contextData = ExceptionContext::Get().MoveParameters();
+
+   if (!exception.Data.empty() || !contextData.empty())
+   {
+      rapidjson::Value dataObject(rapidjson::kObjectType);
+
+      for (const auto& data : contextData)
+         AddExceptionDataToJson(dataObject, allocator, data);
+
+      for (const auto& data : exception.Data)
+         AddExceptionDataToJson(dataObject, allocator, data);
+
+      mechanismObject.AddMember("data", std::move(dataObject), allocator);
+   }
+
+   root.AddMember("mechanism", std::move(mechanismObject), allocator);
+}
+
+} // namespace
+
+Exception Exception::Create(std::string type, AnonymizedMessage value)
+{
+   std::replace_if(type.begin(), type.end(), [](char c) {
+      return  std::isspace(c) != 0;
+   }, '_');
+
+   return { std::move(type), std::move(value) };
+}
+
+Exception Exception::Create(AnonymizedMessage value)
+{
+   return { "runtime_error", std::move(value) };
+}
+
+Exception& Exception::AddData(std::string key, AnonymizedMessage value)
+{
+   Data.emplace_back(std::move(key), std::move(value));
+   return *this;
+}
+
+Message Message::Create(AnonymizedMessage message)
+{
+   return { std::move(message) };
+}
+
+Message& Message::AddParam(AnonymizedMessage value)
+{
+   Params.emplace_back(std::move(value));
+   return *this;
+}
+
+void AddExceptionContext(
+   std::string parameterName, AnonymizedMessage parameterValue)
+{
+    ExceptionContext::Get().Add(std::move (parameterName), std::move (parameterValue));
+}
+
+class Report::ReportImpl
+{
+public:
+   explicit ReportImpl(const Exception& exception);
+   explicit ReportImpl(const Message& message);
+
+   void AddUserComment(const std::string& message);
+
+   std::string ToString(bool pretty) const;
+
+   void Send(CompletionHandler completionHandler) const;
+
+private:
+   rapidjson::Document mDocument;
+};
+
+
+Report::ReportImpl::ReportImpl(const Exception& exception)
+    : mDocument(CreateSentryDocument())
+{
+   rapidjson::Value exceptionObject(rapidjson::kObjectType);
+   rapidjson::Value valuesArray(rapidjson::kArrayType);
+   rapidjson::Value valueObject(rapidjson::kObjectType);
+
+   SerializeException(exception, valueObject, mDocument.GetAllocator());
+
+   valuesArray.PushBack(std::move(valueObject), mDocument.GetAllocator());
+
+   exceptionObject.AddMember(
+      "values", std::move(valuesArray), mDocument.GetAllocator());
+
+   mDocument.AddMember(
+      "exception", std::move(exceptionObject), mDocument.GetAllocator());
+}
+
+Report::ReportImpl::ReportImpl(const Message& message)
+    : mDocument(CreateSentryDocument())
+{
+   rapidjson::Value messageObject(rapidjson::kObjectType);
+
+   messageObject.AddMember(
+      "message",
+      rapidjson::Value(
+         message.Value.c_str(), message.Value.length(),
+         mDocument.GetAllocator()),
+      mDocument.GetAllocator());
+
+   if (!message.Params.empty())
+   {
+      rapidjson::Value paramsArray(rapidjson::kArrayType);
+
+      for (const AnonymizedMessage& param : message.Params)
+      {
+         paramsArray.PushBack(
+            rapidjson::Value(
+               param.c_str(), param.length(), mDocument.GetAllocator()),
+            mDocument.GetAllocator());
+      }
+
+      messageObject.AddMember(
+         "params", std::move(paramsArray), mDocument.GetAllocator());
+   }
+
+   mDocument.AddMember(
+      "message", std::move(messageObject), mDocument.GetAllocator());
+}
+
+void Report::ReportImpl::AddUserComment(const std::string& message)
+{
+   // We only allow adding comment to exceptions now
+   if (!mDocument.HasMember("exception") || message.empty())
+      return;
+
+   rapidjson::Value& topException = mDocument["exception"]["values"][0];
+
+   if (!topException.IsObject())
+      return;
+
+   rapidjson::Value& mechanism = topException["mechanism"];
+
+   // Create a data object if it still does not exist
+   if (!mechanism.HasMember("data"))
+   {
+      mechanism.AddMember(
+         "data", rapidjson::Value(rapidjson::kObjectType),
+         mDocument.GetAllocator());
+   }
+
+   // Add a comment itself
+   mechanism["data"].AddMember(
+      "user_comment",
+      rapidjson::Value(
+         message.data(), message.length(), mDocument.GetAllocator()),
+      mDocument.GetAllocator());
+}
+
+
+void Report::ReportImpl::Send(CompletionHandler completionHandler) const
+{
+   const std::string serializedDocument = ToString(false);
+
+   network_manager::Request request =
+      SentryRequestBuilder::Get().CreateRequest();
+
+   auto response = network_manager::NetworkManager::GetInstance().doPost(
+      request, serializedDocument.data(), serializedDocument.size());
+
+   response->setRequestFinishedCallback(
+      [response, handler = std::move(completionHandler)](network_manager::IResponse*) {
+         const std::string responseData = response->readAll<std::string>();
+
+         wxLogDebug(responseData.c_str());
+
+         if (handler)
+            handler(response->getHTTPCode(), responseData);
+      });
+}
+
+std::string Report::ReportImpl::ToString(bool pretty) const
+{
+   rapidjson::StringBuffer buffer;
+
+   if (pretty)
+   {
+      rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
+      mDocument.Accept(writer);
+   }
+   else
+   {
+      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+      mDocument.Accept(writer);
+   }
+
+   return std::string(buffer.GetString());
+}
+
+Report::~Report()
+{
+}
+
+Report::Report(const Exception& exception)
+    : mImpl(std::make_unique<ReportImpl>(exception))
+{
+}
+
+Report::Report(const Message& message)
+    : mImpl(std::make_unique<ReportImpl>(message))
+{
+}
+
+void Report::AddUserComment(const std::string& comment)
+{
+   mImpl->AddUserComment(comment);
+}
+
+std::string Report::GetReportPreview() const
+{
+   return mImpl->ToString(true);
+}
+
+void Report::Send(CompletionHandler completionHandler) const
+{
+   mImpl->Send(std::move (completionHandler));
+}
+
+
+} // namespace sentry
+} // namespace audacity

--- a/libraries/lib-sentry-reporting/SentryReport.h
+++ b/libraries/lib-sentry-reporting/SentryReport.h
@@ -1,0 +1,95 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file SentryReport.h
+ @brief Declare a class to report errors to Sentry.
+
+ Dmitry Vedenko
+ **********************************************************************/
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+#include <memory>
+#include <functional>
+
+#include "AnonymizedMessage.h"
+
+namespace audacity
+{
+namespace sentry
+{
+
+//! Additional payload to the exception
+using ExceptionData = std::pair<std::string, AnonymizedMessage>;
+
+//! A DTO for the Sentry Exception interface
+struct SENTRY_REPORTING_API Exception final
+{
+   //! Exception type. Should not have spaces.
+   std::string Type;
+   //! Message, associated with the Exception
+   AnonymizedMessage Value;
+   //! Arbitrary payload
+   std::vector<ExceptionData> Data;
+
+   //! Create a new exception
+   static Exception Create(std::string type, AnonymizedMessage value);
+   //! Create a new exception with type runtime_error
+   static Exception Create(AnonymizedMessage value);
+   //! Add a payload to the exception
+   Exception& AddData(std::string key, AnonymizedMessage value);
+};
+
+//! A DTO for the Sentry Message interface
+struct SENTRY_REPORTING_API Message final
+{
+   //! A string, possibly with %s placeholders, containing the message
+   AnonymizedMessage Value;
+   //! Values for the placeholders
+   std::vector<AnonymizedMessage> Params;
+   //! Create a new Message
+   static Message Create(AnonymizedMessage message);
+   //! Add a parameter to the Message
+   Message& AddParam(AnonymizedMessage value);
+};
+
+//! Saves a parameter, that will be appended to the next Exception report
+SENTRY_REPORTING_API void AddExceptionContext(
+   std::string parameterName, AnonymizedMessage parameterValue);
+
+//! A report to Sentry
+class SENTRY_REPORTING_API Report final
+{
+public:
+   //! A callback, that will be called when Send completes
+   using CompletionHandler = std::function<void (int httpCode, std::string responseBody)>;
+
+   //! Create a report from the exception and previously added exception context
+   explicit Report(const Exception& exception);
+
+   //! Create a report with a single log message
+   explicit Report(const Message& message);
+
+   ~Report();
+
+   //! Adds a user comment to the exception report
+   void AddUserComment(const std::string& comment);
+
+   //! Get a pretty printed report preview
+   std::string GetReportPreview() const;
+
+   //! Send the report to Sentry
+   void Send(CompletionHandler completionHandler) const;
+
+private:
+   class ReportImpl;
+
+   std::unique_ptr<ReportImpl> mImpl;
+};
+
+} // namespace sentry
+} // namespace audacity

--- a/libraries/lib-sentry-reporting/SentryRequestBuilder.cpp
+++ b/libraries/lib-sentry-reporting/SentryRequestBuilder.cpp
@@ -1,0 +1,53 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file SentryRequestBuilder.h
+ @brief Define a class to generate the requests to Sentry.
+
+ Dmitry Vedenko
+ **********************************************************************/
+
+#include "SentryRequestBuilder.h"
+
+#include <chrono>
+
+namespace audacity
+{
+namespace sentry
+{
+
+const SentryRequestBuilder& audacity::sentry::SentryRequestBuilder::Get()
+{
+   static SentryRequestBuilder builder;
+
+   return builder;
+}
+
+network_manager::Request SentryRequestBuilder::CreateRequest() const
+{
+    using namespace std::chrono;
+
+   const std::string sentryAuth =
+       std::string("Sentry sentry_version=7,sentry_timestamp=") +
+       std::to_string(
+          duration_cast<seconds>(system_clock::now().time_since_epoch())
+             .count()) +
+       ",sentry_client=sentry-audacity/1.0,sentry_key=" + SENTRY_DSN_KEY;
+
+   network_manager::Request request(mUrl);
+
+   request.setHeader("Content-Type", "application/json");
+   request.setHeader("X-Sentry-Auth", sentryAuth);
+
+   return request;
+}
+
+SentryRequestBuilder::SentryRequestBuilder()
+{
+   mUrl = std::string("https://") + SENTRY_DSN_KEY + "@" + SENTRY_HOST +
+          "/api/" + SENTRY_PROJECT + "/store/";
+}
+
+} // namespace sentry
+} // namespace audacity

--- a/libraries/lib-sentry-reporting/SentryRequestBuilder.h
+++ b/libraries/lib-sentry-reporting/SentryRequestBuilder.h
@@ -1,0 +1,36 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file SentryRequestBuilder.cpp
+ @brief Declare a class to generate the requests to Sentry.
+
+ Dmitry Vedenko
+ **********************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include "Request.h"
+
+namespace audacity
+{
+namespace sentry
+{
+// This is a private class, so it is not exported
+//! A helper, that creates a correct Request to Sentry
+class SentryRequestBuilder final
+{
+public:
+   static const SentryRequestBuilder& Get();
+
+   network_manager::Request CreateRequest() const;
+
+private:
+   SentryRequestBuilder();
+
+   std::string mUrl;
+};
+} // namespace sentry
+} // namespace audacity

--- a/src/AudacityException.h
+++ b/src/AudacityException.h
@@ -17,6 +17,14 @@
 
 #include "Internat.h"
 
+//! A type of an exception
+enum class ExceptionType
+{
+    Internal, //!< Indicates internal failure from Audacity.
+    BadUserAction, //!< Indicates that the user performed an action that is not allowed.
+    BadEnvironment, //!< Indicates problems with environment, such as a full disk
+};
+
 //! Base class for exceptions specially processed by the application
 /*! Objects of this type can be thrown and caught in any thread, stored, and then used by the main
  thread in later idle time to explain the error condition to the user.
@@ -57,7 +65,8 @@ class AUDACITY_DLL_API MessageBoxException /* not final */
 protected:
    //! If default-constructed with empty caption, it makes no message box.
    explicit MessageBoxException(
-      const TranslatableString &caption = {} //!< Shown in message box's frame; not the actual message
+      ExceptionType exceptionType, //!< Exception type
+      const TranslatableString &caption //!< Shown in message box's frame; not the actual message
    );
    ~MessageBoxException() override;
 
@@ -69,6 +78,8 @@ protected:
 
 private:
    TranslatableString caption; //!< Stored caption
+   ExceptionType exceptionType; //!< Exception type
+
    mutable bool moved { false }; //!< Whether @c *this has been the source of a copy
 protected:
    mutable wxString helpUrl{ "" };
@@ -80,11 +91,12 @@ class AUDACITY_DLL_API SimpleMessageBoxException /* not final */
 {
 public:
    explicit SimpleMessageBoxException(
+      ExceptionType exceptionType,        //!< Exception type
       const TranslatableString &message_, //<! Message to show
       const TranslatableString &caption = XO("Message"), //<! Short caption in frame around message
       const wxString &helpUrl_ = "" // Optional URL for help.
    )
-      : MessageBoxException{ caption }
+      : MessageBoxException { exceptionType, caption }
       , message{ message_ }
    {
       helpUrl = helpUrl_;

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1463,7 +1463,7 @@ void AudioIO::StartMonitoring( const AudioIOStartStreamOptions &options )
    if (!success) {
       auto msg = XO("Error opening recording device.\nError code: %s")
          .Format( Get()->LastPaErrorString() );
-      ShowErrorDialog( FindProjectFrame( mOwningProject ),
+      ShowExceptionDialog( FindProjectFrame( mOwningProject ),
          XO("Error"), msg, wxT("Error_opening_sound_device"));
       return;
    }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -956,6 +956,10 @@ list( APPEND SOURCES
       widgets/ReadOnlyText.h
       widgets/Ruler.cpp
       widgets/Ruler.h
+      $<$<BOOL:${${_OPT}has_sentry_reporting}>:
+         widgets/ErrorReportDialog.cpp
+         widgets/ErrorReportDialog.h
+      >
       widgets/Warning.cpp
       widgets/Warning.h
       widgets/WindowAccessible.cpp

--- a/src/DBConnection.cpp
+++ b/src/DBConnection.cpp
@@ -494,8 +494,8 @@ void DBConnection::CheckpointThread(sqlite3 *db, const FilePath &fileName)
 
          // Stop the audio.
          GuardedCall(
-            [&message] {
-            throw SimpleMessageBoxException{
+            [&message, rc] {
+            throw SimpleMessageBoxException{ rc != SQLITE_FULL ? ExceptionType::Internal : ExceptionType::BadEnvironment,
                message, XO("Warning"), "Error:_Disk_full_or_not_writable" }; },
             SimpleGuard<void>{},
             [this](AudacityException * e) {
@@ -596,7 +596,7 @@ TransactionScope::TransactionScope(
    mInTrans = TransactionStart(mName);
    if ( !mInTrans )
       // To do, improve the message
-      throw SimpleMessageBoxException( 
+      throw SimpleMessageBoxException( ExceptionType::Internal,
          XO("Database error.  Sorry, but we don't have more details."), 
          XO("Warning"), 
          "Error:_Disk_full_or_not_writable"

--- a/src/DBConnection.cpp
+++ b/src/DBConnection.cpp
@@ -22,6 +22,7 @@ Paul Licameli -- split from ProjectFileIO.cpp
 #include "Project.h"
 #include "FileException.h"
 #include "wxFileNameWrapper.h"
+#include "SentryHelper.h"
 
 // Configuration to provide "safe" connections
 static const char *SafeConfig =
@@ -162,7 +163,11 @@ int DBConnection::OpenStepByStep(const FilePath fileName)
 
    bool success = false;
    int rc = sqlite3_open(name, &mDB);
-   if (rc != SQLITE_OK) {
+   if (rc != SQLITE_OK) 
+   {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "DBConnection::OpenStepByStep::open");
+
       wxLogMessage("Failed to open primary connection to %s: %d, %s\n",
          fileName,
          rc,
@@ -173,13 +178,18 @@ int DBConnection::OpenStepByStep(const FilePath fileName)
    // Set default mode
    // (See comments in ProjectFileIO::SaveProject() about threading
    rc = SafeMode();
-   if (rc != SQLITE_OK) {
+   if (rc != SQLITE_OK)
+   {
       SetDBError(XO("Failed to set safe mode on primary connection to %s").Format(fileName));
       return rc;
    }
 
    rc = sqlite3_open(name, &mCheckpointDB);
-   if (rc != SQLITE_OK) {
+   if (rc != SQLITE_OK)
+   {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "DBConnection::OpenStepByStep::open_checkpoint");
+
       wxLogMessage("Failed to open checkpoint connection to %s: %d, %s\n",
          fileName,
          rc,
@@ -283,6 +293,9 @@ bool DBConnection::Close()
    rc = sqlite3_close(mCheckpointDB);
    if (rc != SQLITE_OK)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "DBConnection::Close::close_checkpoint");
+
       wxLogMessage("Failed to close checkpoint connection for %s\n"
                    "\tError: %s\n",
                    sqlite3_db_filename(mCheckpointDB, nullptr),
@@ -294,6 +307,9 @@ bool DBConnection::Close()
    rc = sqlite3_close(mDB);
    if (rc != SQLITE_OK)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "DBConnection::OpenStepByStep::close");
+
       wxLogMessage("Failed to close %s\n"
                    "\tError: %s\n",
                    sqlite3_db_filename(mDB, nullptr),
@@ -341,6 +357,10 @@ int DBConnection::ModeConfig(sqlite3 *db, const char *schema, const char *config
    rc = sqlite3_exec(db, sql, nullptr, nullptr, nullptr);
    if (rc != SQLITE_OK)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "DBConnection::ModeConfig");
+      ADD_EXCEPTION_CONTEXT("sqlite3.mode", config);
+
       // Don't store in connection, just report it
       wxLogMessage("Failed to set mode on %s\n"
                    "\tError: %s\n"
@@ -392,6 +412,10 @@ sqlite3_stmt *DBConnection::Prepare(enum StatementID id, const char *sql)
    rc = sqlite3_prepare_v3(mDB, sql, -1, SQLITE_PREPARE_PERSISTENT, &stmt, 0);
    if (rc != SQLITE_OK)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.query", sql);
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "DBConnection::Prepare");
+
       wxLogMessage("Failed to prepare statement for %s\n"
                    "\tError: %s\n"
                    "\tSQL: %s",
@@ -465,6 +489,9 @@ void DBConnection::CheckpointThread(sqlite3 *db, const FilePath &fileName)
 
       if (rc != SQLITE_OK)
       {
+         ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+         ADD_EXCEPTION_CONTEXT("sqlite3.context", "DBConnection::CheckpointThread");
+
          wxLogMessage("Failed to perform checkpoint on %s\n"
                       "\tErrCode: %d\n"
                       "\tErrMsg: %s",
@@ -537,6 +564,9 @@ bool TransactionScope::TransactionStart(const wxString &name)
 
    if (errmsg)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "TransactionScope::TransactionStart");
+
       mConnection.SetDBError(
          XO("Failed to create savepoint:\n\n%s").Format(name)
       );
@@ -558,6 +588,9 @@ bool TransactionScope::TransactionCommit(const wxString &name)
 
    if (errmsg)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "TransactionScope::TransactionCommit");
+
       mConnection.SetDBError(
          XO("Failed to release savepoint:\n\n%s").Format(name)
       );
@@ -579,6 +612,9 @@ bool TransactionScope::TransactionRollback(const wxString &name)
 
    if (errmsg)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "TransactionScope::TransactionRollback");
+
       mConnection.SetDBError(
          XO("Failed to release savepoint:\n\n%s").Format(name)
       );

--- a/src/FileException.h
+++ b/src/FileException.h
@@ -35,7 +35,7 @@ public:
    // DV: We consider a FileException to be internal for now.
    // We used to have some odd cases related to the read-only folder in 3.0.0,
    // so it is good to have a full picture here.
-   // In case we see to many - we will tweak this behavior in the next release.
+   // In case we see too many - we will tweak this behavior in the next release.
    : MessageBoxException{ ExceptionType::Internal, caption }
    , cause{ cause_ }, fileName{ fileName_ }, renameTarget{ renameTarget_ }
    {}

--- a/src/FileException.h
+++ b/src/FileException.h
@@ -32,7 +32,11 @@ public:
       const TranslatableString &caption = XO("File Error"), //!< Shown in message box frame, not the main message
       const wxFileName &renameTarget_ = {} //!< A second file name, only for renaming failure
    )
-   : MessageBoxException{ caption }
+   // DV: We consider a FileException to be internal for now.
+   // We used to have some odd cases related to the read-only folder in 3.0.0,
+   // so it is good to have a full picture here.
+   // In case we see to many - we will tweak this behavior in the next release.
+   : MessageBoxException{ ExceptionType::Internal, caption }
    , cause{ cause_ }, fileName{ fileName_ }, renameTarget{ renameTarget_ }
    {}
 

--- a/src/InconsistencyException.h
+++ b/src/InconsistencyException.h
@@ -23,7 +23,9 @@
 class AUDACITY_DLL_API InconsistencyException final : public MessageBoxException
 {
 public:
-   InconsistencyException() {}
+   InconsistencyException () 
+       : MessageBoxException{ ExceptionType::Internal, XO ("Internal Error") } 
+   {}
 
    //! Don't call this directly but use @ref CONSTRUCT_INCONSISTENCY_EXCEPTION or @ref THROW_INCONSISTENCY_EXCEPTION
    explicit InconsistencyException(
@@ -31,8 +33,8 @@ public:
       const char *f, //!< function name supplied by preprocessor
       unsigned l //!< line number supplied by preprocessor
    )
-         : MessageBoxException{ XO("Internal Error") }
-         , func { fn }, file { f }, line { l }
+       : MessageBoxException { ExceptionType::Internal, XO("Internal Error") }
+       , func { fn }, file { f }, line { l }
    {}
 
    InconsistencyException(InconsistencyException&& that)

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -264,7 +264,7 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
          auto &window = GetProjectFrame( mProject );
          window.CallAfter( [&]{
          // Show error message if stream could not be opened
-         ShowErrorDialog(&window, XO("Error"),
+         ShowExceptionDialog(&window, XO("Error"),
                          XO("Error opening sound device.\nTry changing the audio host, playback device and the project sample rate."),
                          wxT("Error_opening_sound_device"));
          });
@@ -757,7 +757,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
          // Show error message if stream could not be opened
          auto msg = XO("Error opening recording device.\nError code: %s")
             .Format( gAudioIO->LastPaErrorString() );
-         ShowErrorDialog(&GetProjectFrame( mProject ),
+         ShowExceptionDialog(&GetProjectFrame( mProject ),
             XO("Error"), msg, wxT("Error_opening_sound_device"));
       }
    }

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -307,6 +307,7 @@ DBConnection &ProjectFileIO::GetConnection()
       {
          throw SimpleMessageBoxException
          {
+            ExceptionType::Internal,
             XO("Failed to open the project's database"),
             XO("Warning"),
             "Error:_Disk_full_or_not_writable"

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -341,7 +341,7 @@ bool ProjectFileManager::DoSave(const FilePath & fileName, const bool fromSaveAs
       // Show this error only if we didn't fail reconnection in SaveProject
       // REVIEW: Could HasConnection() be true but SaveProject() still have failed?
       if (!projectFileIO.HasConnection())
-         ShowErrorDialog(
+         ShowExceptionDialog(
             &window,
             XO("Error Saving Project"),
             FileException::WriteFailureMessage(fileName),
@@ -770,7 +770,7 @@ bool ProjectFileManager::OpenNewProject()
    bool bOK = OpenProject();
    if( !bOK )
    {
-      ShowErrorDialog(
+      ShowExceptionDialog(
          nullptr,
          XO("Can't open new empty project"),
          XO("Error opening a new empty project"), 

--- a/src/ProjectHistory.cpp
+++ b/src/ProjectHistory.cpp
@@ -79,6 +79,7 @@ namespace {
    {
       if ( !projectFileIO.AutoSave() )
          throw SimpleMessageBoxException{
+            ExceptionType::Internal,
             XO("Automatic database backup failed."),
             XO("Warning"),
             "Error:_Disk_full_or_not_writable"

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -341,6 +341,7 @@ DBConnection *SqliteSampleBlock::Conn() const
    if (!pConnection) {
       throw SimpleMessageBoxException
       {
+         ExceptionType::Internal,
          XO("Connection to project file is null"),
          XO("Warning"),
          "Error:_Disk_full_or_not_writable"

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -18,6 +18,8 @@ Paul Licameli -- split from SampleBlock.cpp and SampleBlock.h
 
 #include "SampleBlock.h" // to inherit
 
+#include "SentryHelper.h"
+
 class SqliteSampleBlockFactory;
 
 ///\brief Implementation of @ref SampleBlock using Sqlite database
@@ -557,6 +559,10 @@ size_t SqliteSampleBlock::GetBlob(void *dest,
    // preconditions; should return SQL_OK which is 0
    if (sqlite3_bind_int64(stmt, 1, mBlockID))
    {
+      ADD_EXCEPTION_CONTEXT(
+         "sqlite3.rc", std::to_string(sqlite3_errcode(Conn()->DB())));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::GetBlob::bind");
+
       wxASSERT_MSG(false, wxT("Binding failed...bug!!!"));
    }
 
@@ -564,6 +570,9 @@ size_t SqliteSampleBlock::GetBlob(void *dest,
    rc = sqlite3_step(stmt);
    if (rc != SQLITE_ROW)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::GetBlob::step");
+
       wxLogDebug(wxT("SqliteSampleBlock::GetBlob - SQLITE error %s"), sqlite3_errmsg(db));
 
       // Clear statement bindings and rewind statement
@@ -675,6 +684,10 @@ void SqliteSampleBlock::Load(SampleBlockID sbid)
    // preconditions; should return SQL_OK which is 0
    if (sqlite3_bind_int64(stmt, 1, sbid))
    {
+
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(sqlite3_errcode(Conn()->DB())));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::Load::bind");
+
       wxASSERT_MSG(false, wxT("Binding failed...bug!!!"));
    }
 
@@ -682,6 +695,11 @@ void SqliteSampleBlock::Load(SampleBlockID sbid)
    rc = sqlite3_step(stmt);
    if (rc != SQLITE_ROW)
    {
+
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::Load::step");
+
+
       wxLogDebug(wxT("SqliteSampleBlock::Load - SQLITE error %s"), sqlite3_errmsg(db));
 
       // Clear statement bindings and rewind statement
@@ -734,6 +752,12 @@ void SqliteSampleBlock::Commit(Sizes sizes)
        sqlite3_bind_blob(stmt, 6, mSummary64k.get(), mSummary64kBytes, SQLITE_STATIC) ||
        sqlite3_bind_blob(stmt, 7, mSamples.get(), mSampleBytes, SQLITE_STATIC))
    {
+
+      ADD_EXCEPTION_CONTEXT(
+         "sqlite3.rc", std::to_string(sqlite3_errcode(Conn()->DB())));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::Commit::bind");
+
+
       wxASSERT_MSG(false, wxT("Binding failed...bug!!!"));
    }
  
@@ -741,6 +765,9 @@ void SqliteSampleBlock::Commit(Sizes sizes)
    rc = sqlite3_step(stmt);
    if (rc != SQLITE_DONE)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::Commit::step");
+
       wxLogDebug(wxT("SqliteSampleBlock::Commit - SQLITE error %s"), sqlite3_errmsg(db));
 
       // Clear statement bindings and rewind statement
@@ -783,6 +810,10 @@ void SqliteSampleBlock::Delete()
    // preconditions; should return SQL_OK which is 0
    if (sqlite3_bind_int64(stmt, 1, mBlockID))
    {
+      ADD_EXCEPTION_CONTEXT(
+         "sqlite3.rc", std::to_string(sqlite3_errcode(Conn()->DB())));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::Delete::bind");
+
       wxASSERT_MSG(false, wxT("Binding failed...bug!!!"));
    }
 
@@ -790,6 +821,9 @@ void SqliteSampleBlock::Delete()
    rc = sqlite3_step(stmt);
    if (rc != SQLITE_DONE)
    {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+      ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::Delete::step");
+
       wxLogDebug(wxT("SqliteSampleBlock::Load - SQLITE error %s"), sqlite3_errmsg(db));
 
       // Clear statement bindings and rewind statement
@@ -995,3 +1029,4 @@ static struct Injector
       );
    }
 } injector;
+ 

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1739,6 +1739,7 @@ void WaveClip::Resample(int rate, ProgressDialog *progress)
 
    if (error)
       throw SimpleMessageBoxException{
+         ExceptionType::Internal,
          XO("Resampling failed."),
          XO("Warning"),
          "Error:_Resampling"

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1284,6 +1284,7 @@ void WaveTrack::Paste(double t0, const Track *src)
                      // Strong-guarantee in case of this path
                      // not that it matters.
                      throw SimpleMessageBoxException{
+                        ExceptionType::BadUserAction,
                         XO("There is not enough room available to paste the selection"),
                         XO("Warning"),
                         "Error:_Insufficient_space_in_track"
@@ -1306,6 +1307,7 @@ void WaveTrack::Paste(double t0, const Track *src)
          // Strong-guarantee in case of this path
          // not that it matters.
          throw SimpleMessageBoxException{
+            ExceptionType::BadUserAction,
             XO("There is not enough room available to paste the selection"),
             XO("Warning"),
             "Error:_Insufficient_space_in_track"
@@ -2422,6 +2424,7 @@ void WaveTrack::ExpandCutLine(double cutLinePosition, double* cutlineStart,
                 clip->GetEndTime() + end - start > clip2->GetStartTime())
                // Strong-guarantee in case of this path
                throw SimpleMessageBoxException{
+                  ExceptionType::BadUserAction,
                   XO("There is not enough room available to expand the cut line"),
                   XO("Warning"),
                   "Error:_Insufficient_space_in_track"

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -2468,7 +2468,7 @@ void Effect::Preview(bool dryOnly)
          }
       }
       else {
-         ShowErrorDialog(FocusDialog, XO("Error"),
+         ShowExceptionDialog(FocusDialog, XO("Error"),
                          XO("Error opening sound device.\nTry changing the audio host, playback device and the project sample rate."),
                          wxT("Error_opening_sound_device"));
       }

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -1519,7 +1519,7 @@ void ShowExportErrorDialog(wxString ErrorCode,
    TranslatableString message,
    const TranslatableString& caption)
 {
-   ShowErrorDialog(nullptr,
+   ShowExceptionDialog(nullptr,
                   caption,
                   message.Format( ErrorCode ),
                   "Error:_Unable_to_export" // URL.

--- a/src/import/RawAudioGuess.cpp
+++ b/src/import/RawAudioGuess.cpp
@@ -210,6 +210,7 @@ static void Extract(bool bits16,
 
    if( dataSizeIn < 1 )
       throw SimpleMessageBoxException{
+         ExceptionType::BadUserAction,
          XO("Bad data size. Could not import audio"),
          XO("Warning"), 
          "Error:_Importing_raw_audio"

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -447,6 +447,7 @@ void OnPaste(const CommandContext &context)
             // Throw, so that any previous changes to the project in this loop
             // are discarded.
             throw SimpleMessageBoxException{
+               ExceptionType::BadUserAction,
                XO("Pasting one type of track into another is not allowed."),
                XO("Warning"), 
                "Error:_Copying_or_Pasting"
@@ -477,6 +478,7 @@ void OnPaste(const CommandContext &context)
                // Throw, so that any previous changes to the project in this
                // loop are discarded.
                throw SimpleMessageBoxException{
+                  ExceptionType::BadUserAction,
                   XO("Copying stereo audio into a mono track is not allowed."),
                   XO("Warning"), 
                   "Error:_Copying_or_Pasting"

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -699,7 +699,7 @@ namespace {
    [[noreturn]] void MigrationFailure() {
       // Tracks may be in an inconsistent state; throw to the application
       // handler which restores consistency from undo history
-      throw SimpleMessageBoxException{
+      throw SimpleMessageBoxException{ ExceptionType::Internal,
          XO("Could not shift between tracks")};
    }
 

--- a/src/widgets/ErrorDialog.cpp
+++ b/src/widgets/ErrorDialog.cpp
@@ -38,6 +38,10 @@
 #include "../Prefs.h"
 #include "HelpSystem.h"
 
+#ifdef HAS_SENTRY_REPORTING
+#   include "ErrorReportDialog.h"
+#endif
+
 BEGIN_EVENT_TABLE(ErrorDialog, wxDialogWrapper)
    EVT_COLLAPSIBLEPANE_CHANGED( wxID_ANY, ErrorDialog::OnPane )
    EVT_BUTTON( wxID_OK, ErrorDialog::OnOk)
@@ -157,6 +161,18 @@ void ShowErrorDialog(wxWindow *parent,
    dlog.ShowModal();
 }
 
+
+void ShowExceptionDialog(
+   wxWindow* parent, const TranslatableString& dlogTitle,
+   const TranslatableString& message, const wxString& helpPage, bool Close,
+   const wxString& log)
+{
+#ifndef HAS_SENTRY_REPORTING
+   ShowErrorDialog(parent, dlogTitle, message, helpPage, Close, log);
+#else
+   ShowErrorReportDialog(parent, dlogTitle, message, helpPage, log);
+#endif // !HAS_SENTRY_REPORTING
+}
 
 // unused.
 void ShowModelessErrorDialog(wxWindow *parent,

--- a/src/widgets/ErrorDialog.h
+++ b/src/widgets/ErrorDialog.h
@@ -54,6 +54,13 @@ void ShowErrorDialog(wxWindow *parent,
                      bool Close = true,
                      const wxString &log = {});
 
+/// Displays an error dialog, possibly allowing to send error report.
+AUDACITY_DLL_API
+void ShowExceptionDialog(
+   wxWindow* parent, const TranslatableString& dlogTitle,
+   const TranslatableString& message, const wxString& helpPage,
+   bool Close = true, const wxString& log = {});
+
 /// Displays a modeless error dialog with a button that offers help
 void ShowModelessErrorDialog(wxWindow *parent,
                      const TranslatableString &dlogTitle,

--- a/src/widgets/ErrorReportDialog.cpp
+++ b/src/widgets/ErrorReportDialog.cpp
@@ -1,0 +1,217 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ErrorReportDialog.cpp
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#include "ErrorReportDialog.h"
+
+#include <wx/app.h>
+#include <wx/artprov.h>
+#include <wx/button.h>
+#include <wx/collpane.h>
+#include <wx/dialog.h>
+#include <wx/html/htmlwin.h>
+#include <wx/icon.h>
+#include <wx/intl.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/statbmp.h>
+#include <wx/stattext.h>
+#include <wx/statusbr.h>
+#include <wx/textctrl.h>
+#include <wx/bmpbuttn.h>
+
+#include "AllThemeResources.h"
+#include "Theme.h"
+#include "HelpText.h"
+#include "Prefs.h"
+#include "ShuttleGui.h"
+#include "HelpSystem.h"
+
+#include "SentryReport.h"
+#include "CodeConversions.h"
+
+constexpr int MaxUserCommentLength = 2000;
+
+BEGIN_EVENT_TABLE(ErrorReportDialog, wxDialogWrapper)
+    EVT_BUTTON(wxID_YES, ErrorReportDialog::OnSend)
+    EVT_BUTTON(wxID_NO, ErrorReportDialog::OnDontSend)
+    EVT_BUTTON(wxID_HELP, ErrorReportDialog::OnHelp)
+END_EVENT_TABLE()
+
+ErrorReportDialog::ErrorReportDialog(
+   wxWindow* parent, const TranslatableString& dlogTitle,
+   const TranslatableString& message, const wxString& helpUrl,
+   const wxString& log, const bool modal)
+    : wxDialogWrapper(
+         parent, wxID_ANY, dlogTitle, wxDefaultPosition, wxDefaultSize,
+         wxDEFAULT_DIALOG_STYLE)
+    , mHelpUrl(helpUrl)
+    , mIsModal(modal)
+{
+   audacity::sentry::Exception ex = audacity::sentry::Exception::Create(
+      audacity::ToUTF8(dlogTitle.Debug()),message.Debug());
+
+   if (!log.empty())
+      ex.AddData("log", log);
+
+   mReport = std::make_unique<audacity::sentry::Report> (ex);
+
+   ShuttleGui S(this, eIsCreating);
+
+   const wxFont headingFont = wxFont(wxFontInfo(12).Bold());
+   const wxFont textFont = wxFont(wxFontInfo(10));
+
+   S.SetBorder(0);
+
+   S.StartHorizontalLay(wxEXPAND, 0);
+   {
+      S.AddSpace(40, 0);
+      S.StartVerticalLay(wxEXPAND, 0);
+      {
+         S.AddSpace(0, 32);
+
+         S.StartHorizontalLay(wxEXPAND, 1);
+         {
+            S.StartVerticalLay(0);
+            {
+               wxBitmap bitmap = wxArtProvider::GetBitmap(
+                  wxART_WARNING, wxART_MESSAGE_BOX, wxSize(24, 24));
+
+               S.Prop(0).AddWindow(
+                  safenew wxStaticBitmap(S.GetParent(), -1, bitmap));
+
+               S.AddSpace(0, 0, 1);
+            }
+            S.EndVerticalLay();
+
+            S.AddSpace(10, 0);
+
+            S.StartVerticalLay(0);
+            {
+               S.AddSpace(0, 7);
+
+               S.Prop(1)
+                  .AddVariableText(message, false, 0, 560)
+                  ->SetFont(headingFont);
+            }
+            S.EndVerticalLay();
+         }
+         S.EndHorizontalLay();
+
+         S.AddSpace(0, 20);
+
+         S.AddVariableText(XO(
+               "Click \"Send\" to submit report to Audacity. This information is collected anonymously."))
+            ->SetFont(textFont);
+
+         S.AddSpace(0, 20);
+
+         S.AddVariableText(XO("Problem details"))->SetFont(textFont);
+
+         S.AddSpace(0, 6);
+
+         S.Style(wxTE_RICH | wxTE_READONLY | wxTE_MULTILINE | wxTE_DONTWRAP).MinSize(wxSize(0,152))
+            .AddTextBox({}, mReport->GetReportPreview(), 0);
+
+         S.AddSpace(0, 20);
+
+         S.AddVariableText(XO("Comments"))->SetFont(textFont);
+
+         S.AddSpace(0, 6);
+
+         mCommentsControl = S.Style(wxTE_MULTILINE)
+            .MinSize(wxSize(0, 76)).AddTextBox({}, {}, 0);
+
+         mCommentsControl->SetMaxLength(MaxUserCommentLength);
+
+         S.AddSpace(0, 20);
+
+         S.StartHorizontalLay(wxEXPAND);
+         {
+            if (!mHelpUrl.empty())
+            {
+               wxBitmapButton* helpButton =
+                  S.Id(wxID_HELP).AddBitmapButton(theTheme.Bitmap(bmpHelpIcon));
+               // For screen readers
+               helpButton->SetToolTip(XO("Help").Translation());
+               helpButton->SetLabel(XO("Help").Translation());
+            }
+            
+            S.AddSpace(0, 0, 1);
+
+            S.Id(wxID_NO).AddButton(XO("Don't send"));
+
+            S.AddSpace(13, 0);
+
+            S.Id(wxID_YES).AddButton(XO("Send"));
+         }
+         S.EndHorizontalLay();
+
+         S.AddSpace(0, 20);
+      }
+      S.EndVerticalLay();
+
+      S.AddSpace(28, 0);
+   }
+   S.EndHorizontalLay();
+
+   S.SetBorder(2);
+
+   Layout();
+   GetSizer()->Fit(this);
+   SetMinSize(GetSize());
+   Center();
+}
+
+ErrorReportDialog::~ErrorReportDialog()
+{
+}
+
+void ErrorReportDialog::OnSend(wxCommandEvent& event)
+{
+   Disable();
+
+   mReport->AddUserComment(audacity::ToUTF8(mCommentsControl->GetValue()));
+
+   mReport->Send(
+      [this](int code, std::string body) { 
+         CallAfter([this]() { 
+             EndModal(true); 
+         });
+   });
+}
+
+void ErrorReportDialog::OnDontSend(wxCommandEvent& event)
+{
+   EndModal(true);
+}
+
+void ErrorReportDialog::OnHelp(wxCommandEvent& event)
+{
+   if (mHelpUrl.StartsWith(wxT("innerlink:")))
+   {
+      HelpSystem::ShowHtmlText(
+         this, TitleText(mHelpUrl.Mid(10)), HelpText(mHelpUrl.Mid(10)), false,
+         true);
+      return;
+   }
+
+   HelpSystem::ShowHelp(this, mHelpUrl, false);
+}
+
+void ShowErrorReportDialog(
+   wxWindow* parent, const TranslatableString& dlogTitle,
+   const TranslatableString& message, const wxString& helpPage,
+   const wxString& log)
+{
+   ErrorReportDialog dlog(parent, dlogTitle, message, helpPage, log);
+
+   dlog.CentreOnParent();
+   dlog.ShowModal();
+}

--- a/src/widgets/ErrorReportDialog.h
+++ b/src/widgets/ErrorReportDialog.h
@@ -1,0 +1,69 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ErrorReportDialog.h
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#ifndef __AUDACITY_SENTRYERRORDIALOG__
+#define __AUDACITY_SENTRYERRORDIALOG__
+
+#include <memory>
+
+#include <wx/defs.h>
+#include <wx/msgdlg.h>
+
+#include "wxPanelWrapper.h" // to inherit
+
+namespace audacity
+{
+namespace sentry
+{
+class Report;
+}
+}
+
+class wxTextCtrl;
+
+//! A dialog, that has "Send", "Don't send" and help buttons.
+/*! This dialog is used in place of error dialogs for Audacity errors
+    when Sentry reporting is enabled.
+*/
+class ErrorReportDialog final : public wxDialogWrapper
+{
+public:
+   ErrorReportDialog(
+      wxWindow* parent, const TranslatableString& dlogTitle,
+      const TranslatableString& message, const wxString& helpUrl,
+      const wxString& log, const bool modal = true);
+
+   ~ErrorReportDialog();
+
+private:
+   void OnSend(wxCommandEvent& event);
+   void OnDontSend(wxCommandEvent& event);
+
+   void OnHelp(wxCommandEvent& event);
+
+   std::unique_ptr<audacity::sentry::Report> mReport;
+
+   wxString mHelpUrl;
+
+   wxTextCtrl* mCommentsControl;
+
+   bool mIsModal;
+
+   DECLARE_EVENT_TABLE()
+};
+
+/// Displays an error dialog that allows to send the error report
+AUDACITY_DLL_API
+void ShowErrorReportDialog(
+   wxWindow* parent, const TranslatableString& dlogTitle,
+   const TranslatableString& message, const wxString& helpPage = {},
+   const wxString& log = {});
+
+#endif // __AUDACITY_SENTRYERRORDIALOG__


### PR DESCRIPTION
This pull request introduces an always-opt-in solution to send non-fatal errors to Sentry, such as errors while opening a project or an audio device. This feature will be only enabled if `audacity_has_networking` is on and `SENTRY_DSN_KEY`, `SENTRY_HOST` and `SENTRY_PROJECT` are defined. The latter will be passed via Secrets, so this functionality will be disabled for builds under the pull request itself.

Optionally, the dialog allows an arbitrary comment to be attached.

When Sentry reporting is enabled `ADD_EXCEPTION_CONTEXT` macro allows adding data before the report is generated. Currently, this is used to pass more information about SQLite return codes to the report, which is not available from the exception itself.

Dialog example:

![image](https://user-images.githubusercontent.com/2660628/120678539-ddcdde00-c4a0-11eb-9d60-800e164a8ea3.png)

Report example:

```
{
    "timestamp": 1622737253,
    "event_id": "619a7f1125e8a74194d18d8148f53897",
    "platform": "native",
    "release": "audacity@3.0.3",
    "contexts": {
        "os": {
            "type": "os",
            "name": "Windows",
            "version": "10.0.19042"
        }
    },
    "exception": {
        "values": [
            {
                "type": "File_Error",
                "value": "Audacity failed to read from a file in <path>.",
                "mechanism": {
                    "type": "runtime_error",
                    "handled": false,
                    "data": {
                        "sqlite3.rc": "11",
                        "sqlite3.context": "SqliteSampleBlock::Load.step"
                    }
                }
            }
        ]
    }
}
```


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
