### PR TITLE
Bug2800: File>Open should allow non-project from a FAT drive...

### DIFF
--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -870,13 +870,6 @@ AudacityProject *ProjectFileManager::OpenFile( const ProjectChooserFn &chooser,
    // convert these to long file name first.
    auto fileName = PlatformCompatibility::GetLongFileName(fileNameArg);
 
-   if (TempDirectory::FATFilesystemDenied(fileName,
-                                      XO("Project resides on FAT formatted drive.\n"
-                                         "Copy it to another drive to open it.")))
-   {
-      return nullptr;
-   }
-
    // Make sure it isn't already open.
    // Vaughan, 2011-03-25: This was done previously in AudacityProject::OpenFiles()
    //    and AudacityApp::MRUOpen(), but if you open an aup file by double-clicking it
@@ -975,6 +968,15 @@ AudacityProject *ProjectFileManager::OpenFile( const ProjectChooserFn &chooser,
          }
          return nullptr;
       }
+   }
+
+   // Disallow opening of .aup3 project files from FAT drives, but only such
+   // files, not importable types.  (Bug 2800)
+   if (TempDirectory::FATFilesystemDenied(fileName,
+      XO("Project resides on FAT formatted drive.\n"
+        "Copy it to another drive to open it.")))
+   {
+      return nullptr;
    }
 
    auto &project = chooser(true);


### PR DESCRIPTION
... but still disallow it for .aup3 files.

The fix is a simple moving of the check for a FAT filesystem after several
other checks that distinguish types of imported files.

Resolves: https://bugzilla.audacityteam.org/show_bug.cgi?id=2800

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
