### PR TITLE
Fix #984 - ErrorReportingDialog does not support screen readers

### DIFF
--- a/src/widgets/ErrorReportDialog.cpp
+++ b/src/widgets/ErrorReportDialog.cpp
@@ -116,7 +116,9 @@ ErrorReportDialog::ErrorReportDialog(
 
          S.AddSpace(0, 6);
 
-         S.Style(wxTE_RICH | wxTE_READONLY | wxTE_MULTILINE | wxTE_DONTWRAP).MinSize(wxSize(0,152))
+         S.Style(wxTE_RICH | wxTE_READONLY | wxTE_MULTILINE | wxTE_DONTWRAP)
+            .MinSize(wxSize(0, 152))
+            .Name(XO("Problem details"))
             .AddTextBox({}, mReport->GetReportPreview(), 0);
 
          S.AddSpace(0, 20);
@@ -126,7 +128,9 @@ ErrorReportDialog::ErrorReportDialog(
          S.AddSpace(0, 6);
 
          mCommentsControl = S.Style(wxTE_MULTILINE)
-            .MinSize(wxSize(0, 76)).AddTextBox({}, {}, 0);
+                               .MinSize(wxSize(0, 76))
+                               .Name(XO("Comments"))
+                               .AddTextBox({}, {}, 0);
 
          mCommentsControl->SetMaxLength(MaxUserCommentLength);
 


### PR DESCRIPTION
Resolves: #984

Fix uses the approach proposed by David Bailes

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
