### PR TITLE
CI script fixes (sentry symbols upload)

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -78,11 +78,9 @@ jobs:
         exec bash "scripts/ci/build.sh"
 
     - name: Upload debug symbols
-      if: startsWith(github.ref, 'refs/tags/release-')
+      if: startsWith(github.ref, 'refs/heads/release-')
       env:
-        SENTRY_DSN_KEY: ${{ secrets.SENTRY_DSN_KEY }}
         SENTRY_HOST: ${{ secrets.SENTRY_HOST }}
-        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG_SLUG: ${{ secrets.SENTRY_ORG_SLUG }}
         SENTRY_PROJECT_SLUG: ${{ secrets.SENTRY_PROJECT_SLUG }}

--- a/scripts/ci/upload_debug_symbols.sh
+++ b/scripts/ci/upload_debug_symbols.sh
@@ -11,6 +11,6 @@ curl -sL https://sentry.io/get-cli/ | bash
 
 SYMBOLS=$(find debug | xargs)
 
-${INSTALL_DIR}/sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} --url ${SENTRY_HOST} \
-    --org ${SENTRY_ORG_SLUG}} \
+${INSTALL_DIR}/sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} --url ${SENTRY_HOST} upload-dif \
+    --org ${SENTRY_ORG_SLUG} \
     --project ${SENTRY_PROJECT_SLUG} ${SYMBOLS}


### PR DESCRIPTION
* Fixes typos in a CI script related to a debug symbols upload command
* Debug symbol upload triggered if branch name starts with 'release-' (previously was using tags instead)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
