### PR TITLE
Bug 2808 Nyquist GATE function limits floor level to -60 dB

### DIFF
--- a/nyquist/nyquist.lsp
+++ b/nyquist/nyquist.lsp
@@ -1501,10 +1501,10 @@ loop
          (format t "WARNING: ~A ~A function; setting falltime to 0.01.\n"
                  "falltime must be greater than zero in" source)
          (setf falltime 0.01)))
-  (cond ((< floor 0.001)
-         (format t "WARNING: ~A ~A function; setting floor to 0.001.\n"
+  (cond ((< floor 0.00001)
+         (format t "WARNING: ~A ~A function; setting floor to 0.00001.\n"
                  "floor must be greater than zero in" source)
-         (setf floor 0.001)))
+         (setf floor 0.00001)))
   (let (s) ;; s becomes sound after collapsing to one channel
     (cond ((arrayp sound)           ;; use s-max over all channels so that
            (setf s (aref sound 0))  ;; ANY channel opens the gate

--- a/plug-ins/noisegate.ny
+++ b/plug-ins/noisegate.ny
@@ -134,24 +134,6 @@ Suggested Threshold Setting ~a dB.")
 ;;; Gate Functions
 
 
-;; Override Nyquist GATE function (from nyquist.lsp)
-;; The default version has minimum floor of -60dB, which is not low enough here.
-(defun gate (sound lookahead risetime falltime floor threshold 
-             &optional (source "GATE"))
-  (let (s) ;; s becomes sound after collapsing to one channel
-    (cond ((arrayp sound)           ;; use s-max over all channels so that
-           (setf s (aref sound 0))  ;; ANY channel opens the gate
-           (dotimes (i (1- (length sound)))
-             (setf s (s-max s (aref sound (1+ i))))))
-          (t (setf s sound)))
-    (setf s (snd-gate (seq (cue s)
-                           (stretch-abs 1.0 (s-rest lookahead)))
-                      lookahead risetime falltime floor threshold))
-    (prog1 (snd-xform s (snd-srate s) (snd-t0 s)
-                      (+ (snd-t0 s) lookahead) MAX-STOP-TIME 1.0)
-           (setf s nil) (setf sound nil))))
-
-
 (defun noisegate (sig follow)
   ;; Takes a sound and a 'follow' sound as arguments.
   ;; Returns the gated audio.


### PR DESCRIPTION
Resolves: https://bugzilla.audacityteam.org/show_bug.cgi?id=2808

A recent update to Audacity's Nyquist library introduced a -60 dB limit to the "floor" parameter in the  GATE function. This created errors in several existing plug-ins, including Audacity's shipped "Noise Gate" (bug 2733) and the popular "Hum Remover" plug-in

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
