### PR TITLE
Reenables Nyquist for the prebuilt Linux binaries

### DIFF
--- a/linux/AppRun.sh
+++ b/linux/AppRun.sh
@@ -9,6 +9,9 @@ fi
 
 export LD_LIBRARY_PATH="${APPDIR}/lib:${LD_LIBRARY_PATH}"
 
+export AUDACITY_PATH="${AUDACITY_PATH}:${APPDIR}/share/audacity"
+export AUDACITY_MODULES_PATH="${APPDIR}/lib/modules"
+
 function help()
 {
     # Normal audacity help

--- a/linux/AppRun.sh
+++ b/linux/AppRun.sh
@@ -10,7 +10,7 @@ fi
 export LD_LIBRARY_PATH="${APPDIR}/lib:${LD_LIBRARY_PATH}"
 
 export AUDACITY_PATH="${AUDACITY_PATH}:${APPDIR}/share/audacity"
-export AUDACITY_MODULES_PATH="${APPDIR}/lib/modules"
+export AUDACITY_MODULES_PATH="${AUDACITY_MODULES_PATH}:${APPDIR}/lib/modules"
 
 function help()
 {

--- a/linux/audacity.sh
+++ b/linux/audacity.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 lib="${0%/*}/lib/audacity"
+share="${0%/*}/share/audacity"
 
 export LD_LIBRARY_PATH="${lib}:${LD_LIBRARY_PATH}"
 export AUDACITY_MODULES_PATH="${lib}/modules"
+export AUDACITY_PATH="${AUDACITY_PATH}:${share}"
 
 exec "${0%/*}/bin/audacity" "$@"

--- a/linux/audacity.sh
+++ b/linux/audacity.sh
@@ -4,7 +4,7 @@ lib="${0%/*}/lib/audacity"
 share="${0%/*}/share/audacity"
 
 export LD_LIBRARY_PATH="${lib}:${LD_LIBRARY_PATH}"
-export AUDACITY_MODULES_PATH="${lib}/modules"
+export AUDACITY_MODULES_PATH="${AUDACITY_MODULES_PATH}:${lib}/modules"
 export AUDACITY_PATH="${AUDACITY_PATH}:${share}"
 
 exec "${0%/*}/bin/audacity" "$@"


### PR DESCRIPTION
A quick fix for Nyquist in Linux binaries: we set `AUDACITY_PATH` to the local `share/audacity` folder.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
