### PR TITLE
Use wxWidgets with fixed Win64 accessibility

### DIFF
--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 
 add_conan_lib( 
    wxWidgets 
-   wxwidgets/3.1.3-audacity 
+   wxwidgets/3.1.3.1-audacity 
    REQUIRED 
    ALWAYS_ALLOW_CONAN_FALLBACK
    OPTION_NAME wxwidgets


### PR DESCRIPTION
Resolves: #959 

The fix is in the wxWidgets fork: https://github.com/audacity/wxWidgets/commit/e42d7f73652cf7e40058a48177a86e0f864ec464

The problem was related to the sign extension in 64 bit builds. The approach used by Microsoft in MSDN examples is used now.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
