### PR TITLE
Make Audacity build in C++17 ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ set( CMAKE_PREFIX_PATH
 #set( CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF )
 
 # Set the required C++ standard
-set( CMAKE_CXX_STANDARD 14 )
+set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 
 # Use ccache if available

--- a/include/audacity/EffectAutomationParameters.h
+++ b/include/audacity/EffectAutomationParameters.h
@@ -107,7 +107,8 @@ public:
       if (Read(key, &str))
       {
          struct lconv *info = localeconv();
-         wxString dec = info ? wxString::FromUTF8(info->decimal_point) : wxT(".");
+         wxString dec =
+            info ? wxString::FromUTF8(info->decimal_point) : wxString(".");
 
          str.Replace(wxT(","), dec);
          str.Replace(wxT("."), dec);

--- a/libraries/lib-utility/MemoryX.cpp
+++ b/libraries/lib-utility/MemoryX.cpp
@@ -1,5 +1,58 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ MemoryX.cpp
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+
 #include "MemoryX.h"
 
 // Make the symbol table non-empty
 UTILITY_API void lib_utility_dummy_symbol()
 {}
+
+#ifdef __APPLE__
+
+constexpr auto sizeof_align_val = sizeof(std::align_val_t);
+
+void *NonInterferingBase::operator new(std::size_t count, std::align_val_t al)
+{
+   using namespace std;
+   // Get an allocation with sufficient extra space to remember the alignment
+   // (And to do that, adjust the alignment to be not less than the alignment of
+   // an alignment value!).
+   // Also increase the allocation by one entire alignment.
+   al = max( al, static_cast<align_val_t>( alignof(align_val_t) ) );
+   const auto al_as_size = static_cast<size_t>(al);
+   auto ptr = static_cast<char*>(
+      ::operator new( count + sizeof_align_val + al_as_size ) );
+
+   // Adjust the pointer to a properly aligned one, with a space just before it
+   // to remember the adjustment
+   ptr += sizeof_align_val;
+   auto integer = reinterpret_cast<uintptr_t>(ptr);
+   const auto partial = integer % al_as_size;
+   auto adjustment = partial ? al_as_size - partial : 0;
+   integer += adjustment;
+   ptr = reinterpret_cast<char*>(integer);
+
+   // Remember the adjustment
+   *(reinterpret_cast<size_t*>(ptr) - 1) = adjustment;
+
+   return ptr;
+}
+
+void NonInterferingBase::operator delete(void *ptr, std::align_val_t al)
+{
+   // Find the adjustment
+   auto adjustment = *(reinterpret_cast<size_t*>(ptr) - 1);
+   // Apply the adjustment
+   auto p = reinterpret_cast<char*>(ptr) - adjustment - sizeof_align_val;
+   // Call through to default operator
+   ::operator delete(p);
+}
+
+#endif

--- a/src/ActiveProjects.cpp
+++ b/src/ActiveProjects.cpp
@@ -93,6 +93,6 @@ wxString ActiveProjects::Find(const FilePath &path)
 
    gPrefs->SetPath(configPath);
 
-   return found ? key : wxT("");
+   return found ? key : wxString{};
 }
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -541,7 +541,7 @@ constexpr size_t TimeQueueGrainSize = 2000;
 #endif
 
 
-struct AudioIoCallback::ScrubState
+struct AudioIoCallback::ScrubState : NonInterferingBase
 {
    ScrubState(double t0,
               double rate,

--- a/src/AudioIOBase.h
+++ b/src/AudioIOBase.h
@@ -16,10 +16,10 @@ Paul Licameli split from AudioIO.h
 
 #include <cfloat>
 #include <functional>
-#include <memory>
 #include <vector>
 #include <wx/string.h>
 #include <wx/weakref.h> // member variable
+#include "MemoryX.h"
 
 struct PaDeviceInfo;
 typedef void PaStream;
@@ -117,6 +117,7 @@ struct AudioIOStartStreamOptions
 ///\brief A singleton object supporting queries of the state of any active
 /// audio streams, and audio device capabilities
 class AUDACITY_DLL_API AudioIOBase /* not final */
+   : public NonInterferingBase
 {
 public:
    static AudioIOBase *Get();

--- a/src/LyricsWindow.cpp
+++ b/src/LyricsWindow.cpp
@@ -49,7 +49,7 @@ END_EVENT_TABLE()
 const wxSize gSize = wxSize(LYRICS_DEFAULT_WIDTH, LYRICS_DEFAULT_HEIGHT);
 
 LyricsWindow::LyricsWindow(AudacityProject *parent)
-   : wxFrame( &GetProjectFrame( *parent ), -1, {},
+   : wxFrame( &GetProjectFrame( *parent ), -1, wxString{},
             wxPoint(100, 300), gSize,
             //v Bug in wxFRAME_FLOAT_ON_PARENT:
             // If both the project frame and LyricsWindow are minimized and you restore LyricsWindow,

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1408,7 +1408,7 @@ const wxSize kDefaultSize =
    wxSize(MIXER_BOARD_MIN_WIDTH, MIXER_BOARD_MIN_HEIGHT);
 
 MixerBoardFrame::MixerBoardFrame(AudacityProject* parent)
-:  wxFrame( &GetProjectFrame( *parent ), -1, {},
+:  wxFrame( &GetProjectFrame( *parent ), -1, wxString{},
             wxDefaultPosition, kDefaultSize,
             wxDEFAULT_FRAME_STYLE | wxFRAME_FLOAT_ON_PARENT)
    , mProject(parent)

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -3032,7 +3032,7 @@ RegistryPath PluginManager::SettingsPath(const PluginID & ID, bool shared)
                  wxT("_") +
                  plug.GetVendor() +
                  wxT("_") +
-                 (shared ? wxT("") : plug.GetSymbol().Internal());
+                 (shared ? wxString{} : plug.GetSymbol().Internal());
 
    return SETROOT +
           ConvertID(id) +

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1140,7 +1140,7 @@ FilePath ProjectFileIO::SafetyFileName(const FilePath &src)
 
    int nn = 1;
    auto numberString = [](int num) -> wxString {
-      return num == 1 ? "" : wxString::Format(".%d", num);
+      return num == 1 ? wxString{} : wxString::Format(".%d", num);
    };
 
    auto suffixes = AuxiliaryFileSuffixes();

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -14,7 +14,7 @@
 #include "SampleFormat.h"
 #include <atomic>
 
-class RingBuffer {
+class RingBuffer final : public NonInterferingBase {
  public:
    RingBuffer(sampleFormat format, size_t size);
    ~RingBuffer();
@@ -43,16 +43,8 @@ class RingBuffer {
    size_t Filled( size_t start, size_t end );
    size_t Free( size_t start, size_t end );
 
-   enum : size_t { CacheLine = 64 };
-   /*
-    // We will do this in C++17 instead:
-   static constexpr size_t CacheLine =
-      std::hardware_destructive_interference_size;
-    */
-
    // Align the two atomics to avoid false sharing
-   alignas(CacheLine) std::atomic<size_t> mStart { 0 };
-   alignas(CacheLine) std::atomic<size_t> mEnd{ 0 };
+   NonInterfering< std::atomic<size_t> > mStart { 0 }, mEnd{ 0 };
 
    const size_t  mBufferSize;
 

--- a/src/commands/CommandTargets.cpp
+++ b/src/commands/CommandTargets.cpp
@@ -66,7 +66,7 @@ void CommandMessageTarget::EndStruct(){
 void CommandMessageTarget::AddItem(const wxString &value, const wxString &name){
    wxString Padding;
    Padding.Pad( mCounts.size() *2 -2);
-   Padding = (( value.length() < 15 ) || (mCounts.back()<=0))  ? "" : wxString("\n") + Padding;
+   Padding = (( value.length() < 15 ) || (mCounts.back()<=0))  ? wxString{} : wxString("\n") + Padding;
    if( name.empty() )
       Update( wxString::Format( "%s%s\"%s\"", (mCounts.back()>0)?", ":"", Padding, Escaped(value)));
    else

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -242,7 +242,7 @@ TranslatableString NyquistEffect::GetDescription()
 wxString NyquistEffect::ManualPage()
 {
       return mIsPrompt
-         ? wxT("Nyquist_Prompt")
+         ? wxString("Nyquist_Prompt")
          : mManPage;
 }
 
@@ -2183,7 +2183,7 @@ bool NyquistEffect::Parse(
          ctrl.label = tokens[4];
 
          // valStr may or may not be a quoted string
-         ctrl.valStr = len > 5 ? tokens[5] : wxT("");
+         ctrl.valStr = len > 5 ? tokens[5] : wxString{};
          ctrl.val = GetCtrlValue(ctrl.valStr);
          if (ctrl.valStr.length() > 0 &&
                (ctrl.valStr[0] == wxT('(') ||

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -244,7 +244,7 @@ void DeviceToolBar::UpdatePrefs()
 
    int hostSelectionIndex = mHost->GetSelection();
    wxString oldHost = hostSelectionIndex >= 0 ? mHost->GetString(hostSelectionIndex) :
-                                                wxT("");
+                                                wxString{};
    auto hostName = AudioIOHost.Read();
 
    // if the prefs host name doesn't match the one displayed, it changed

--- a/src/widgets/FileConfig.cpp
+++ b/src/widgets/FileConfig.cpp
@@ -23,6 +23,8 @@
 
 #include "FileConfig.h"
 
+#include <cerrno> // for ENOENT
+
 #if !defined(F_OK)
 #define F_OK 0x00
 #endif

--- a/src/widgets/FileHistory.cpp
+++ b/src/widgets/FileHistory.cpp
@@ -115,7 +115,7 @@ void FileHistory::Load(wxConfigBase & config, const wxString & group)
 {
    mHistory.clear();
    mGroup = group.empty()
-      ? wxT("RecentFiles")
+      ? wxString{ "RecentFiles" }
       : group;
 
    config.SetPath(mGroup);

--- a/src/widgets/numformatter.cpp
+++ b/src/widgets/numformatter.cpp
@@ -57,7 +57,7 @@ wxChar NumberFormatter::GetDecimalSeparator()
 {
 #if wxUSE_INTL
    struct lconv *info = localeconv();
-   wxString s = info ? wxString::FromUTF8(info->decimal_point) : wxT(".");
+   wxString s = info ? wxString::FromUTF8(info->decimal_point) : wxString(".");
    if (s.empty())
    {
       // We really must have something for decimal separator, so fall
@@ -75,7 +75,7 @@ bool NumberFormatter::GetThousandsSeparatorIfUsed(wxChar *sep)
 {
 #if wxUSE_INTL
    struct lconv *info = localeconv();
-   wxString s = info ? wxString::FromUTF8(info->thousands_sep) : wxT("");
+   wxString s = info ? wxString::FromUTF8(info->thousands_sep) : wxString{};
 
    if (s.empty())
    {


### PR DESCRIPTION
... Fixing many conditional operators with explicit construction of wxString
instead of simple string literals;

And fixing allocation of more strictly aligned structures on Mac, without need
for 10.14 as the minimum SDK, by means of some class-specific operators new
and delete.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
