### PR TITLE
Bug 2740 - Directories in Directories preferences can be set to unwritable locations

### DIFF
--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -371,6 +371,21 @@ void DirectoriesPrefs::OnBrowse(wxCommandEvent &evt)
       }
    }
 
+   if (evt.GetId() == SaveButtonID || evt.GetId() == ExportButtonID)
+   {
+      bool Status = wxFileName ::IsDirWritable(dlog.GetPath());
+      wxString path{dlog.GetPath()};
+      if (!Status)
+      {
+         AudacityMessageBox(
+             XO("Directory %s does not have write permissions")
+                 .Format(path),
+             XO("Error"),
+             wxOK | wxICON_ERROR);
+         return;
+      }
+   }
+
    tc->SetValue(dlog.GetPath());
 }
 


### PR DESCRIPTION
Resolves: https://bugzilla.audacityteam.org/show_bug.cgi?id=2740

Used IsDirWritable() of wxFileName to check the write permission for the directory at the time of setting the preference for Save and Export in Edit>Preferences>Directories to avoid issues while Saving or Exporting.

![Screenshot from 2021-06-19 19-23-32](https://user-images.githubusercontent.com/73242397/122644672-1540b980-d134-11eb-81c4-1dd725268b43.png)
*Error screen if the directory is unwritable*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
