### PR TITLE
Bug 2809 - Label Sounds fails when track sample rate is 22050 Hz

### DIFF
--- a/plug-ins/label-sounds.ny
+++ b/plug-ins/label-sounds.ny
@@ -8,7 +8,7 @@ $debugbutton false
 ;; As this is a new plug-in (Jan2021), display errors if they occur.
 $debugflags trace
 $author (_ "Steve Daulton")
-$release 3.0.0
+$release 3.0.2
 $copyright (_ "Released under terms of the GNU General Public License version 2 or later.")
 
 ;; Released under terms of the GNU General Public License version 2 or later:
@@ -153,7 +153,7 @@ $control text (_ "Label text") string "" (_ "Sound ##1")
         ((not val) snd-list)
       (cond
         ((< val threshold)
-            (when (and (= sil-count sil-dur)(>= snd-count snd-dur))
+            (when (and (>= sil-count sil-dur)(>= snd-count snd-dur))
               ;convert sample counts to seconds and push to list.
               (push (list (/ snd-start srate)
                           (/ (- sample-count sil-count) srate))


### PR DESCRIPTION
Fix incorrect equality comparison between int and float and
bump plug-in release number.

Resolves: https://bugzilla.audacityteam.org/show_bug.cgi?id=2809
Resolves: https://github.com/audacity/audacity/issues/1032

When sample rate is not divisible by 100, the low sample rate copy has a fractional sample rate, so the calculated minimum silence duration in samples is a floating point number. Replace equality comparison with greater or equal so that we don't miss adding the label.

Also bumped plug-in release number to signify that plug-in has been updated.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
