### PR TITLE
Removed call that would stop project playback when using batch commands.

### DIFF
--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -505,8 +505,8 @@ bool MacroCommands::DoAudacityCommand(
 
    if (flags & EffectManager::kConfigured)
    {
-      ProjectAudioManager::Get( project ).Stop();
-//    SelectAllIfNone();
+      //ProjectAudioManager::Get( project ).Stop();
+//    SelectAllIfNone(); KARL
    }
 
    EffectManager & em = EffectManager::Get();


### PR DESCRIPTION
Removed a call to stop playing the current project when a batch call is sent to Audacity. There are reasons to leave playback (especially looping playback) running while batch commands are being issued. Stop can be a part of someone's batch commands if they need to stop playback of the project.

Resolves: https://github.com/audacity/audacity/issues/961

*I've added a change to prevent the project playback from being automatically stopped when issued a batch command. This allows for commands to be issued while playback of the project is going.*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
