### PR TITLE
Check for Updates dialog will not interrupt recordings

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1823,6 +1823,34 @@ int AudioIO::StartStream(const TransportTracks &tracks,
    return mStreamToken;
 }
 
+void AudioIO::CallAfterRecording(PostRecordingAction action)
+{
+   if (!action)
+      return;
+
+   {
+      std::lock_guard<std::mutex> guard{ mPostRecordingActionMutex };
+      if (mPostRecordingAction) {
+         // Enqueue it, even if perhaps not still recording,
+         // but it wasn't cleared yet
+         mPostRecordingAction = [
+            prevAction = std::move(mPostRecordingAction),
+            nextAction = std::move(action)
+         ]{ prevAction(); nextAction(); };
+         return;
+      }
+      else if (mPortStreamV19 && mNumCaptureChannels > 0) {
+         mPostRecordingAction = std::move(action);
+         return;
+      }
+   }
+
+   // Don't delay it except until idle time.
+   // (Recording might start between now and then, but won't go far before
+   // the action is done.  So the system isn't bulletproof yet.)
+   wxTheApp->CallAfter(std::move(action));
+}
+
 bool AudioIO::AllocateBuffers(
    const AudioIOStartStreamOptions &options,
    const TransportTracks &tracks, double t0, double t1, double sampleRate,
@@ -2415,6 +2443,20 @@ void AudioIO::StopStream()
 
    if (pListener && mNumCaptureChannels > 0)
       pListener->OnAudioIOStopRecording();
+
+   wxTheApp->CallAfter([this]{
+      if (mPortStreamV19 && mNumCaptureChannels > 0)
+         // Recording was restarted between StopStream and idle time
+         // So the actions can keep waiting
+         return;
+      // In case some other thread was waiting on the mutex too:
+      std::this_thread::yield();
+      std::lock_guard<std::mutex> guard{ mPostRecordingActionMutex };
+      if (mPostRecordingAction) {
+         mPostRecordingAction();
+         mPostRecordingAction = {};
+      }
+   });
 
    //
    // Only set token to 0 after we're totally finished with everything

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -18,9 +18,9 @@
 #include "AudioIOBase.h" // to inherit
 #include "PlaybackSchedule.h" // member variable
 
-
-
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <wx/atomic.h> // member variable
 
@@ -621,6 +621,12 @@ public:
     * by the specified amount from where it is now */
    void SeekStream(double seconds) { mSeek = seconds; }
 
+   using PostRecordingAction = std::function<void()>;
+   
+   //! Enqueue action for main thread idle time, not before the end of any recording in progress
+   /*! This may be called from non-main threads */
+   void CallAfterRecording(PostRecordingAction action);
+
 #ifdef EXPERIMENTAL_SCRUBBING_SUPPORT
    bool IsScrubbing() const { return IsBusy() && mScrubState != 0; }
 
@@ -787,6 +793,9 @@ private:
      *
      * If bOnlyBuffers is specified, it only cleans up the buffers. */
    void StartStreamCleanup(bool bOnlyBuffers = false);
+
+   std::mutex mPostRecordingActionMutex;
+   PostRecordingAction mPostRecordingAction;
 };
 
 static constexpr unsigned ScrubPollInterval_ms = 50;

--- a/src/update/UpdateManager.cpp
+++ b/src/update/UpdateManager.cpp
@@ -10,6 +10,7 @@
 #include "UpdateManager.h"
 #include "UpdatePopupDialog.h"
 
+#include "AudioIO.h"
 #include "NetworkManager.h"
 #include "IResponse.h"
 #include "Request.h"
@@ -71,9 +72,10 @@ void UpdateManager::GetUpdates()
 
     response->setRequestFinishedCallback([response, this](audacity::network_manager::IResponse*) {
 
+        auto gAudioIO = AudioIO::Get();
         if (response->getError() != audacity::network_manager::NetworkError::NoError)
         {
-            wxTheApp->CallAfter([] {ShowExceptionDialog(nullptr,
+            gAudioIO->CallAfterRecording([] {ShowExceptionDialog(nullptr,
                 XC("Error checking for update", "update dialog"),
                 XC("Unable to connect to Audacity update server.", "update dialog"),
                 wxString());
@@ -84,7 +86,7 @@ void UpdateManager::GetUpdates()
 
         if (!mUpdateDataParser.Parse(response->readAll<VersionPatch::UpdateDataFormat>(), &mVersionPatch))
         {
-            wxTheApp->CallAfter([] {ShowExceptionDialog(nullptr,
+            gAudioIO->CallAfterRecording([] {ShowExceptionDialog(nullptr,
                 XC("Error checking for update", "update dialog"),
                 XC("Update data was corrupted.", "update dialog"),
                 wxString());
@@ -95,7 +97,7 @@ void UpdateManager::GetUpdates()
 
         if (mVersionPatch.version > CurrentBuildVersion())
         {
-            wxTheApp->CallAfter([this] {
+            gAudioIO->CallAfterRecording([this] {
                 UpdatePopupDialog dlg(nullptr, mVersionPatch);
                 const int code = dlg.ShowModal();
 


### PR DESCRIPTION
Resolves: #1048

Check for Updates dialog will (very probably) not unexpectedly interrupt recordings, possibly spoiling them if there is a screen reader.

(There is one slender timing possibility mentioned in code comments where it might yet happen. More thread synchronizations might fix that, but do not seem worth the extra effort now.)

[x]  I signed CLA
[x]  I made sure the code compiles on my machine
[x]  I made sure there are no unnecessary changes in the code
[x]  I made sure the title of the PR reflects the core meaning of the issue you are solving
[x]  I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
