### PR TITLE
Reverse meanings of "Grayscale" and "Inverse Grayscale" ...

### DIFF
--- a/src/AColor.cpp
+++ b/src/AColor.cpp
@@ -714,7 +714,7 @@ void AColor::PreComputeGradient() {
          gradient_pre[selected][1][i][2] = (unsigned char) (255 * b);
       }
 
-      // colorScheme 2: Grayscale
+      // colorScheme 3: Inverse Grayscale
       for (int i = 0; i < gradientSteps; i++) {
          float r, g, b;
          float value = float(i) / gradientSteps;
@@ -743,12 +743,12 @@ void AColor::PreComputeGradient() {
             b = 1.0f;
             break;
          }
-         gradient_pre[selected][2][i][0] = (unsigned char)(255 * r);
-         gradient_pre[selected][2][i][1] = (unsigned char)(255 * g);
-         gradient_pre[selected][2][i][2] = (unsigned char)(255 * b);
+         gradient_pre[selected][3][i][0] = (unsigned char)(255 * r);
+         gradient_pre[selected][3][i][1] = (unsigned char)(255 * g);
+         gradient_pre[selected][3][i][2] = (unsigned char)(255 * b);
       }
 
-      // colorScheme 3: Inv. Grayscale (=Old grayscale)
+      // colorScheme 2: Grayscale (=Old grayscale)
       for (int i = 0; i<gradientSteps; i++) {
          float r, g, b;
          float value = float(i)/gradientSteps;
@@ -781,9 +781,9 @@ void AColor::PreComputeGradient() {
             b = 1.0f;
             break;
          }
-         gradient_pre[selected][3][i][0] = (unsigned char) (255 * r);
-         gradient_pre[selected][3][i][1] = (unsigned char) (255 * g);
-         gradient_pre[selected][3][i][2] = (unsigned char) (255 * b);
+         gradient_pre[selected][2][i][0] = (unsigned char) (255 * r);
+         gradient_pre[selected][2][i][1] = (unsigned char) (255 * g);
+         gradient_pre[selected][2][i][2] = (unsigned char) (255 * b);
       }
    }
 }

--- a/src/prefs/SpectrogramSettings.cpp
+++ b/src/prefs/SpectrogramSettings.cpp
@@ -182,7 +182,7 @@ void SpectrogramSettings::ColorSchemeEnumSetting::Migrate(wxString &value)
    // Migrate old grayscale option to Color scheme choice
    bool isGrayscale = (gPrefs->Read(wxT("/Spectrum/Grayscale"), 0L) != 0);
    if (isGrayscale && !gPrefs->Read(wxT("/Spectrum/ColorScheme"), &value)) {
-      value = GetColorSchemeNames().at(csInvGrayscale).Internal();
+      value = GetColorSchemeNames().at(csGrayscale).Internal();
       Write(value);
       gPrefs->Flush();
    }


### PR DESCRIPTION
... The first, not the second, will correspond to the old Grayscale.  This
shows higher energy as darker.  That is how monochrome spectrograms have
usually been inked onto paper.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
