### PR TITLE
Check for updates will not interrupt the Timer Record wait dialog

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1823,6 +1823,16 @@ int AudioIO::StartStream(const TransportTracks &tracks,
    return mStreamToken;
 }
 
+void AudioIO::DelayActions(bool recording)
+{
+   mDelayingActions = recording;
+}
+
+bool AudioIO::DelayingActions() const
+{
+   return mDelayingActions || (mPortStreamV19 && mNumCaptureChannels > 0);
+}
+
 void AudioIO::CallAfterRecording(PostRecordingAction action)
 {
    if (!action)
@@ -1839,7 +1849,7 @@ void AudioIO::CallAfterRecording(PostRecordingAction action)
          ]{ prevAction(); nextAction(); };
          return;
       }
-      else if (mPortStreamV19 && mNumCaptureChannels > 0) {
+      else if (DelayingActions()) {
          mPostRecordingAction = std::move(action);
          return;
       }
@@ -2456,6 +2466,7 @@ void AudioIO::StopStream()
          mPostRecordingAction();
          mPostRecordingAction = {};
       }
+      DelayActions(false);
    });
 
    //

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -739,14 +739,17 @@ public:
    static void Init();
    static void Deinit();
 
-
+   /*! For purposes of CallAfterRecording, treat time from now as if
+    recording (when argument is true) or not necessarily so (false) */
+   void DelayActions(bool recording);
 
 private:
+
+   bool DelayingActions() const;
 
    /** \brief Set the current VU meters - this should be done once after
     * each call to StartStream currently */
    void SetMeters();
-
 
    /** \brief Opens the portaudio stream(s) used to do playback or recording
     * (or both) through.
@@ -796,6 +799,7 @@ private:
 
    std::mutex mPostRecordingActionMutex;
    PostRecordingAction mPostRecordingAction;
+   bool mDelayingActions{ false };
 };
 
 static constexpr unsigned ScrubPollInterval_ms = 50;


### PR DESCRIPTION
Resolves: #1164

Check for Updates has been fixed so that its modal dialog will wait until any recording-in-progress finishes.  But that was not enough.  It should also not interrupt the timer recording wait dialog.  This commit fixes that too.  I have tested it with a
modified build making more frequent checks.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
