### PR TITLE
Postpone updates for a GMT calendar day

### DIFF
--- a/src/update/UpdateManager.h
+++ b/src/update/UpdateManager.h
@@ -31,8 +31,7 @@ namespace UpdatesCheckingSettings {
 class UpdateManager final : public wxEvtHandler
 {
 public:
-    UpdateManager();
-    ~UpdateManager();
+    UpdateManager() = default;
 
     static UpdateManager& GetInstance();
     static void Start();
@@ -46,7 +45,6 @@ private:
     VersionPatch mVersionPatch;
 
     wxTimer mTimer;
-    const int mUpdateCheckingInterval;
 
     void OnTimer(wxTimerEvent& event);
 


### PR DESCRIPTION
This PR provides a bit more sensible approach:

1. Updates are checked once a calendar day
2. In the long-running session there will be at least 12 hours between the checks

We can postpone this PR until 3.0.4

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
