### PR TITLE
Disable auto format detection of 'Import Raw Data'

### DIFF
--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -60,22 +60,22 @@ and sample size to help you importing data of an unknown format.
 class ImportRawDialog final : public wxDialogWrapper {
 
   public:
-   ImportRawDialog(wxWindow * parent,
-                   int encoding, unsigned channels,
-                   int offset, double rate);
+   ImportRawDialog(wxWindow * parent, const wxString & fileName);
    ~ImportRawDialog();
 
    void OnOK(wxCommandEvent & event);
    void OnCancel(wxCommandEvent & event);
    void OnPlay(wxCommandEvent & event);
+   void OnDetect(wxCommandEvent & event);
    void OnChoice(wxCommandEvent & event);
 
    // in and out
-   int mEncoding;
-   unsigned mChannels;
-   int mOffset;
-   double mRate;
-   double mPercent;
+   // Make static to preserve value for next raw import
+   static int mEncoding;
+   static unsigned mChannels;
+   static int mOffset;
+   static double mRate;
+   static double mPercent;
 
  private:
 
@@ -90,8 +90,18 @@ class ImportRawDialog final : public wxDialogWrapper {
    int         mNumEncodings;
    ArrayOf<int> mEncodingSubtype;
 
+   wxString mFileName;
+
    DECLARE_EVENT_TABLE()
 };
+
+// Initial value for Import Raw dialog
+int ImportRawDialog::mEncoding = SF_FORMAT_RAW | SF_ENDIAN_CPU | SF_FORMAT_PCM_16;
+unsigned ImportRawDialog::mChannels = 1;
+int ImportRawDialog::mOffset = 0;
+double ImportRawDialog::mRate = 0;  // -> project rate
+double ImportRawDialog::mPercent = 100.;
+
 
 // This function leaves outTracks empty as an indication of error,
 // but may also throw FileException to make use of the application's
@@ -100,52 +110,27 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
               WaveTrackFactory *trackFactory, TrackHolders &outTracks)
 {
    outTracks.clear();
-   int encoding = 0; // Guess Format
-   sf_count_t offset = 0;
-   double rate = 44100.0;
-   double percent = 100.0;
+
    TrackHolders results;
    auto updateResult = ProgressResult::Success;
 
    {
-      SF_INFO sndInfo;
-      unsigned numChannels = 0;
+      // On first run, set default sample rate from project rate
+      if (ImportRawDialog::mRate < 100.)
+         ImportRawDialog::mRate = ProjectSettings::Get(project).GetRate();
 
-      try {
-         // Yes, FormatClassifier currently handles filenames in UTF8 format only, that's
-         // a TODO ...
-         FormatClassifier theClassifier(fileName.utf8_str());
-         encoding = theClassifier.GetResultFormatLibSndfile();
-         numChannels = theClassifier.GetResultChannels();
-         offset = 0;
-      } catch (...) {
-         // Something went wrong in FormatClassifier, use defaults instead.
-         encoding = 0;
-      }
-
-      if (encoding <= 0) {
-         // Unable to guess.  Use mono, 16-bit samples with CPU endianness
-         // as the default.
-         encoding = SF_FORMAT_RAW | SF_ENDIAN_CPU | SF_FORMAT_PCM_16;
-         numChannels = 1;
-         offset = 0;
-      }
-
-      rate = ProjectSettings::Get( project ).GetRate();
-
-      numChannels = std::max(1u, numChannels);
-      ImportRawDialog dlog(parent, encoding, numChannels, (int)offset, rate);
+      ImportRawDialog dlog(parent, fileName);
       dlog.ShowModal();
       if (!dlog.GetReturnCode())
          return;
 
-      encoding = dlog.mEncoding;
-      numChannels = dlog.mChannels;
-      rate = dlog.mRate;
-      offset = (sf_count_t)dlog.mOffset;
-      percent = dlog.mPercent;
+      int encoding = dlog.mEncoding;
+      unsigned numChannels = dlog.mChannels;
+      double rate = dlog.mRate;
+      sf_count_t offset = (sf_count_t)dlog.mOffset;
+      double percent = dlog.mPercent;
 
-      memset(&sndInfo, 0, sizeof(SF_INFO));
+      SF_INFO sndInfo = { 0 };
       sndInfo.samplerate = (int)rate;
       sndInfo.channels = (int)numChannels;
       sndInfo.format = encoding | SF_FORMAT_RAW;
@@ -288,28 +273,25 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
 
 enum {
    ChoiceID = 9000,
-   PlayID
+   PlayID,
+   DetectID,
 };
 
 BEGIN_EVENT_TABLE(ImportRawDialog, wxDialogWrapper)
    EVT_BUTTON(wxID_OK, ImportRawDialog::OnOK)
    EVT_BUTTON(wxID_CANCEL, ImportRawDialog::OnCancel)
    EVT_BUTTON(PlayID, ImportRawDialog::OnPlay)
+   EVT_BUTTON(DetectID, ImportRawDialog::OnDetect)
    EVT_CHOICE(ChoiceID, ImportRawDialog::OnChoice)
 END_EVENT_TABLE()
 
-ImportRawDialog::ImportRawDialog(wxWindow * parent,
-                                 int encoding, unsigned channels,
-                                 int offset, double rate)
+ImportRawDialog::ImportRawDialog(wxWindow * parent, const wxString & fileName)
 :  wxDialogWrapper(parent, wxID_ANY, XO("Import Raw Data"),
             wxDefaultPosition, wxDefaultSize,
             wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
-    mEncoding(encoding),
-    mChannels(channels),
-    mOffset(offset),
-    mRate(rate)
+   mFileName(fileName)
 {
-   wxASSERT(channels >= 1);
+   wxASSERT(mChannels >= 1);
 
    SetName();
 
@@ -436,11 +418,20 @@ ImportRawDialog::ImportRawDialog(wxWindow * parent,
       }
       S.EndMultiColumn();
 
-      //
-      // Preview Pane goes here
-      //
+      S.SetBorder(5);
+      S.StartTwoColumn();
+      {
+         /* i18n-hint: Guess format of raw file */
+         S.Id(DetectID).AddButton(XXO("Detect"));
 
-      S.AddStandardButtons();
+         //
+         // Preview Pane goes here
+         //
+
+         S.AddStandardButtons();
+      }
+      S.EndTwoColumn();
+
       // Find the OK button, and change its text to 'Import'.
       // We MUST set mOK because it is used later.
       mOK = (wxButton *)wxWindow::FindWindowById(wxID_OK, this);
@@ -494,6 +485,52 @@ void ImportRawDialog::OnCancel(wxCommandEvent & WXUNUSED(event))
 
 void ImportRawDialog::OnPlay(wxCommandEvent & WXUNUSED(event))
 {
+}
+
+void ImportRawDialog::OnDetect(wxCommandEvent & event)
+{
+   try {
+      // Yes, FormatClassifier currently handles filenames in UTF8 format only, that's a TODO ...
+      FormatClassifier theClassifier(mFileName.utf8_str());
+      mEncoding = theClassifier.GetResultFormatLibSndfile();
+      mChannels = theClassifier.GetResultChannels();
+   } catch (...) {
+      // Something went wrong in FormatClassifier, abort.
+      return;
+   }
+
+   int selection = 0;
+   for (int i = 0; i < mNumEncodings; i++) {
+      int subtype = mEncodingSubtype[i];
+      if ((mEncoding & SF_FORMAT_SUBMASK) == subtype) {
+         selection = i;
+         break;
+      }
+   }
+
+   int endian = 0;
+   switch (mEncoding & SF_FORMAT_ENDMASK)
+   {
+      default:
+      case SF_ENDIAN_FILE:
+         endian = 0;
+         break;
+      case SF_ENDIAN_LITTLE:
+         endian = 1;
+         break;
+      case SF_ENDIAN_BIG:
+         endian = 2;
+         break;
+      case SF_ENDIAN_CPU:
+         endian = 3;
+         break;
+   }
+
+   mEncodingChoice->SetSelection(selection);
+   mEndianChoice->SetSelection(endian);
+   mChannelChoice->SetSelection(mChannels - 1);
+
+   OnChoice(event);
 }
 
 void ImportRawDialog::OnChoice(wxCommandEvent & WXUNUSED(event))

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -88,8 +88,7 @@ class ImportRawDialog final : public wxDialogWrapper {
    wxTextCtrl *mPercentText;
    wxComboBox *mRateText;
 
-   int         mNumEncodings;
-   ArrayOf<int> mEncodingSubtype;
+   std::vector<int> mEncodingSubtype;
 
    wxString mFileName;
 
@@ -268,6 +267,24 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
    }
 }
 
+
+// Get endian choice from SF_FORMAT
+static int getEndianChoice(int sfFormat) {
+   switch (sfFormat & SF_FORMAT_ENDMASK)
+   {
+      default:
+      case SF_ENDIAN_FILE:
+         return 0;
+      case SF_ENDIAN_LITTLE:
+         return 1;
+      case SF_ENDIAN_BIG:
+         return 2;
+      case SF_ENDIAN_CPU:
+         return 3;
+   }
+}
+
+
 //
 // ImportRawDialog
 //
@@ -292,30 +309,23 @@ ImportRawDialog::ImportRawDialog(wxWindow * parent, const wxString & fileName)
             wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
    mFileName(fileName)
 {
-   wxASSERT(mChannels >= 1);
+   wxASSERT(0 < mChannels && mChannels <= 16);
 
    SetName();
 
    // Append filename at window title
    wxFileName wfn{ fileName };
-   wxDialog::SetTitle(GetTitle() + ": " + wfn.GetFullName());
+   wxString windowTitle = XO("%s: %s").Format(GetTitle(), wfn.GetFullName()).Translation();
+   wxDialog::SetTitle(windowTitle);
 
    ShuttleGui S(this, eIsCreating);
    TranslatableStrings encodings;
-   int num;
-   int selection;
-   int endian;
-   int i;
 
-   num = sf_num_encodings();
-   mNumEncodings = 0;
-   mEncodingSubtype.reinit(static_cast<size_t>(num));
+   int num = sf_num_encodings();
 
-   selection = 0;
-   for (i=0; i<num; i++) {
-      SF_INFO info;
-
-      memset(&info, 0, sizeof(SF_INFO));
+   int selection = 0;
+   for (int i = 0; i < num; i++) {
+      SF_INFO info = { 0 };
 
       int subtype = sf_encoding_index_to_subtype(i);
       info.format = SF_FORMAT_RAW + SF_ENDIAN_LITTLE + subtype;
@@ -323,13 +333,11 @@ ImportRawDialog::ImportRawDialog(wxWindow * parent, const wxString & fileName)
       info.samplerate = 44100;
 
       if (sf_format_check(&info)) {
-         mEncodingSubtype[mNumEncodings] = subtype;
+         mEncodingSubtype.push_back(subtype);
          encodings.push_back( Verbatim( sf_encoding_index_name(i) ) );
 
          if ((mEncoding & SF_FORMAT_SUBMASK) == subtype)
-            selection = mNumEncodings;
-
-         mNumEncodings++;
+            selection = mEncodingSubtype.size() - 1;
       }
    }
 
@@ -348,28 +356,13 @@ ImportRawDialog::ImportRawDialog(wxWindow * parent, const wxString & fileName)
       XO("Default endianness") ,
    };
 
-   switch (mEncoding & (SF_FORMAT_ENDMASK))
-   {
-      default:
-      case SF_ENDIAN_FILE:
-         endian = 0;
-         break;
-      case SF_ENDIAN_LITTLE:
-         endian = 1;
-         break;
-      case SF_ENDIAN_BIG:
-         endian = 2;
-         break;
-      case SF_ENDIAN_CPU:
-         endian = 3;
-         break;
-   }
+   int endian = getEndianChoice(mEncoding);
 
    TranslatableStrings chans{
       XO("1 Channel (Mono)") ,
       XO("2 Channels (Stereo)") ,
    };
-   for (i=2; i<16; i++) {
+   for (int i = 2; i < 16; i++) {
       chans.push_back( XO("%d Channels").Format( i + 1 ) );
    }
 
@@ -505,31 +498,11 @@ void ImportRawDialog::OnDetect(wxCommandEvent & event)
    }
 
    int selection = 0;
-   for (int i = 0; i < mNumEncodings; i++) {
-      int subtype = mEncodingSubtype[i];
-      if ((mEncoding & SF_FORMAT_SUBMASK) == subtype) {
-         selection = i;
-         break;
-      }
-   }
+   auto iter = std::find(mEncodingSubtype.begin(), mEncodingSubtype.end(), mEncoding & SF_FORMAT_SUBMASK);
+   if (iter != mEncodingSubtype.end())   // subtype found
+       selection = std::distance(mEncodingSubtype.begin(), iter);
 
-   int endian = 0;
-   switch (mEncoding & SF_FORMAT_ENDMASK)
-   {
-      default:
-      case SF_ENDIAN_FILE:
-         endian = 0;
-         break;
-      case SF_ENDIAN_LITTLE:
-         endian = 1;
-         break;
-      case SF_ENDIAN_BIG:
-         endian = 2;
-         break;
-      case SF_ENDIAN_CPU:
-         endian = 3;
-         break;
-   }
+   int endian = getEndianChoice(mEncoding);
 
    mEncodingChoice->SetSelection(selection);
    mEndianChoice->SetSelection(endian);

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -45,6 +45,7 @@ and sample size to help you importing data of an unknown format.
 #include <wx/button.h>
 #include <wx/choice.h>
 #include <wx/combobox.h>
+#include <wx/filename.h>
 #include <wx/intl.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
@@ -294,6 +295,10 @@ ImportRawDialog::ImportRawDialog(wxWindow * parent, const wxString & fileName)
    wxASSERT(mChannels >= 1);
 
    SetName();
+
+   // Append filename at window title
+   wxFileName wfn{ fileName };
+   wxDialog::SetTitle(GetTitle() + ": " + wfn.GetFullName());
 
    ShuttleGui S(this, eIsCreating);
    TranslatableStrings encodings;


### PR DESCRIPTION
![import raw](https://user-images.githubusercontent.com/8174871/123518042-3169cb00-d6df-11eb-939d-8949aadc4471.png)

Format guessing of 'Import Raw' is not so accurate. Sometimes it's tiresome.

Usually, when I import bunch of raw files, all of them has same format.
But, format guessing keeps change import setting, so I have to manually change it back.

I think this fix fits more on most of use case.
- Disable auto format detection. Instead, add detect button.
- Remember last format setting, and set it as default on next import.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
