### PR TITLE
Add Directory permission check for Open, Import, Macro Output, and Temporary directory in Directory Preference

### DIFF
--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -267,6 +267,22 @@ void DirectoriesPrefs::PopulateOrExchange(ShuttleGui &S)
    S.EndScroller();
 }
 
+bool WritableLocationCheck(const FilePath &path)
+{
+   bool Status = wxFileName ::IsDirWritable(path);
+   if (!Status)
+   {
+      AudacityMessageBox(
+         XO("Directory %s does not have write permissions")
+            .Format(path),
+         XO("Error"),
+            wxOK | wxICON_ERROR);
+      return true;
+   }
+
+   return false;
+}
+
 void DirectoriesPrefs::OnTempBrowse(wxCommandEvent &evt)
 {
    wxString oldTemp = gPrefs->Read(PreferenceKey(Operation::Open, PathType::_None),
@@ -292,6 +308,11 @@ void DirectoriesPrefs::OnTempBrowse(wxCommandEvent &evt)
 
       if (FATFilesystemDenied(tmpDirPath.GetFullPath(),
           XO("Temporary files directory cannot be on a FAT drive."))) {
+         return;
+      }
+
+      if (WritableLocationCheck(dlog.GetPath())) 
+      {
          return;
       }
 
@@ -371,19 +392,9 @@ void DirectoriesPrefs::OnBrowse(wxCommandEvent &evt)
       }
    }
 
-   if (evt.GetId() == SaveButtonID || evt.GetId() == ExportButtonID)
+   if (WritableLocationCheck(dlog.GetPath())) 
    {
-      bool Status = wxFileName ::IsDirWritable(dlog.GetPath());
-      wxString path{dlog.GetPath()};
-      if (!Status)
-      {
-         AudacityMessageBox(
-             XO("Directory %s does not have write permissions")
-                 .Format(path),
-             XO("Error"),
-             wxOK | wxICON_ERROR);
-         return;
-      }
+      return;
    }
 
    tc->SetValue(dlog.GetPath());


### PR DESCRIPTION
Resolves: https://bugzilla.audacityteam.org/show_bug.cgi?id=2740

This is an improvement on PR https://github.com/audacity/audacity/pull/1033 which now imposes a block with an error message for Open, Import, Macro Output, and Temporary directory if it is not writable. A new function WritableLocationCheck() has been added and is called whenever a user tries to set a preference for the above-said fields and the unnecessary code from the previous PR has also been removed.

![Screenshot from 2021-06-28 22-15-32](https://user-images.githubusercontent.com/73242397/123673707-68b2b600-d85e-11eb-97c9-829fd9a9e992.png)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
