### PR TITLE
Fixes performance regression in Win64 bit build

### DIFF
--- a/src/float_cast.h
+++ b/src/float_cast.h
@@ -106,16 +106,39 @@
 
 		return intgr ;
 	}
-#elif (defined (WIN32) || defined (_WIN32)) && defined(_M_3X64)
+#elif (defined (WIN32) || defined (_WIN32)) && defined(_M_X64)
 
 	#include <math.h>
 	#include <immintrin.h>
+	#include <emmintrin.h>
 
-	__inline long int
-	lrintf (float flt)
+	#ifdef _MSC_VER
+		#pragma function(lrint, lrintf)
+	#endif
+
+	__inline 
+	long int lrint(double flt)
 	{
-		return _mm_cvt_ss2si(_mm_set_ss(flt));
+       return _mm_cvtsd_si32(_mm_set_sd(flt));
+    }
+
+	__inline 
+	long int lrintf (float flt)
+	{
+		return _mm_cvtss_si32(_mm_set_ss(flt));
 	}
+
+	__inline 
+	long long int llrint(double flt)
+    {
+        return _mm_cvtsd_si64(_mm_set_sd(flt));
+    }
+
+    __inline 
+    long long int llrintf(float flt)
+    {
+       return _mm_cvtss_si64(_mm_set_ss(flt));
+    }
 
 #elif (HAVE_LRINT && HAVE_LRINTF)
 
@@ -146,6 +169,6 @@
    #include	<math.h>
 
    #define	lrint(dbl)		((int)rint(dbl))
-	#define	lrintf(flt)		((int)rint(flt))
+   #define	lrintf(flt)		((int)rint(flt))
 
 #endif


### PR DESCRIPTION
Resolves: #1188

Adds an SSE2 version of `lrint` family. For some reason, MSVC built-in functions have extremely low performance.

I have checked, that the builtins and SSE2 generate exactly the same result, however, I think that relying on functions, that behavior can be changed by the CPU state can be potentially dangerous.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
