### PR TITLE
Opt-out of check for updates persists after preference resets...

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -241,7 +241,7 @@ void PopulatePreferences()
          wxYES_NO, NULL);
       if (action == wxYES)   // reset
       {
-         gPrefs->DeleteAll();
+         ResetPreferences();
          writeLang = true;
       }
    }

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1943,6 +1943,9 @@ void PluginManager::Load()
    if (!registry.HasGroup(REGROOT))
    {
       // Must start over
+      // This DeleteAll affects pluginregistry.cfg only, not audacity.cfg
+      // That is, the memory of on/off states of effect (and generator,
+      // analyzer, and tool) plug-ins
       registry.DeleteAll();
       registry.Flush();
       return;
@@ -2286,7 +2289,7 @@ void PluginManager::Save()
       {}, {}, FileNames::PluginRegistry());
    auto &registry = *pRegistry;
 
-   // Clear it out
+   // Clear pluginregistry.cfg (not audacity.cfg)
    registry.DeleteAll();
 
    // Write the version string

--- a/src/Prefs.cpp
+++ b/src/Prefs.cpp
@@ -63,6 +63,9 @@
 #include "MemoryX.h"
 #include <memory>
 
+BoolSetting DefaultUpdatesCheckingFlag{
+    L"/Update/DefaultUpdatesChecking", true };
+
 std::unique_ptr<FileConfig> ugPrefs {};
 
 FileConfig *gPrefs = nullptr;
@@ -177,6 +180,25 @@ void InitPreferences( std::unique_ptr<FileConfig> uPrefs )
    gPrefs = uPrefs.get();
    ugPrefs = std::move(uPrefs);
    wxConfigBase::Set(gPrefs);
+}
+
+void ResetPreferences()
+{
+   // Future:  make this a static registry table, so the settings objects
+   // don't need to be defined in this source code file to avoid dependency
+   // cycles
+   std::pair<BoolSetting &, bool> stickyBoolSettings[] {
+      {DefaultUpdatesCheckingFlag, 0},
+      // ... others?
+   };
+   for (auto &pair : stickyBoolSettings)
+      pair.second = pair.first.Read();
+
+   bool savedValue = DefaultUpdatesCheckingFlag.Read();
+   gPrefs->DeleteAll();
+
+   for (auto &pair : stickyBoolSettings)
+      pair.first.Write(pair.second);
 }
 
 void FinishPreferences()

--- a/src/Prefs.h
+++ b/src/Prefs.h
@@ -48,6 +48,12 @@
 class wxFileName;
 
 void InitPreferences( std::unique_ptr<FileConfig> uPrefs );
+//! Call this to reset preferences to an (almost)-"new" default state
+/*!
+ There is at least one exception to that: user preferences we want to make
+ more "sticky."  Notably, whether automatic update checking is preferred.
+ */
+void ResetPreferences();
 void FinishPreferences();
 
 extern AUDACITY_DLL_API FileConfig *gPrefs;
@@ -422,5 +428,8 @@ struct AUDACITY_DLL_API PreferenceInitializer {
 
    static void ReinitializeAll();
 };
+
+// Special extra-sticky settings
+extern AUDACITY_DLL_API BoolSetting DefaultUpdatesCheckingFlag;
 
 #endif

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -647,6 +647,7 @@ wxString EffectManager::GetPreset(const PluginID & ID, const wxString & params, 
       return preset;
    }
 
+   // This cleans a config "file" backed by a string in memory.
    eap.DeleteAll();
    
    eap.Write(wxT("Use Preset"), preset);

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -384,7 +384,7 @@ void OnResetConfig(const CommandContext &context)
    menuManager.mLastAnalyzer = "";
    menuManager.mLastTool = "";
 
-   gPrefs->DeleteAll();
+   ResetPreferences();
 
    // Directory will be reset on next restart.
    FileNames::UpdateDefaultPath(FileNames::Operation::Temp, TempDirectory::DefaultTempDir());

--- a/src/prefs/ApplicationPrefs.cpp
+++ b/src/prefs/ApplicationPrefs.cpp
@@ -72,7 +72,7 @@ void ApplicationPrefs::PopulateOrExchange(ShuttleGui & S)
    {
       S.TieCheckBox(
           XO("&Check for Updates...").Stripped(TranslatableString::Ellipses | TranslatableString::MenuCodes),
-          UpdatesCheckingSettings::DefaultUpdatesCheckingFlag);
+          DefaultUpdatesCheckingFlag);
    }
    S.EndStatic();
    S.EndScroller();

--- a/src/update/UpdateManager.cpp
+++ b/src/update/UpdateManager.cpp
@@ -24,9 +24,6 @@
 #include <mutex>
 #include <cstdint>
 
-BoolSetting UpdatesCheckingSettings::DefaultUpdatesCheckingFlag{
-    L"/Update/DefaultUpdatesChecking", true };
-
 static const char* prefsUpdateScheduledTime = "/Update/UpdateScheduledTime";
 
 
@@ -127,7 +124,7 @@ void UpdateManager::GetUpdates(bool ignoreNetworkErrors)
 
 void UpdateManager::OnTimer(wxTimerEvent& WXUNUSED(event))
 {
-    bool updatesCheckingEnabled = UpdatesCheckingSettings::DefaultUpdatesCheckingFlag.Read();
+    bool updatesCheckingEnabled = DefaultUpdatesCheckingFlag.Read();
 
     if (updatesCheckingEnabled && IsTimeForUpdatesChecking())
         GetUpdates(true);

--- a/src/update/UpdateManager.h
+++ b/src/update/UpdateManager.h
@@ -18,10 +18,6 @@
 #include <wx/event.h>
 #include <wx/timer.h>
 
-namespace UpdatesCheckingSettings {
-    extern AUDACITY_DLL_API BoolSetting DefaultUpdatesCheckingFlag;
-}
-
 /// A class that managing of updates.
 /**
     Opt-in request and show update dialog by the scheduled time.

--- a/src/update/UpdatePopupDialog.cpp
+++ b/src/update/UpdatePopupDialog.cpp
@@ -45,7 +45,7 @@ UpdatePopupDialog::UpdatePopupDialog (wxWindow* parent, const VersionPatch& vers
 
             S.Id (DontShowID).AddCheckBox (
                 XO ("Don't show this again at start up"),
-                !UpdatesCheckingSettings::DefaultUpdatesCheckingFlag.Read());
+                !DefaultUpdatesCheckingFlag.Read());
 
             S.Prop(1).AddSpace(1, 0, 1);
 
@@ -80,7 +80,7 @@ void UpdatePopupDialog::OnSkip (wxCommandEvent&)
 
 void UpdatePopupDialog::OnDontShow (wxCommandEvent& event)
 {
-    UpdatesCheckingSettings::DefaultUpdatesCheckingFlag.Write(!event.IsChecked());
+    DefaultUpdatesCheckingFlag.Write(!event.IsChecked());
 }
 
 HtmlWindow* UpdatePopupDialog::AddHtmlContent (wxWindow* parent)


### PR DESCRIPTION
Resolves: #1191 

... These can happen in only two ways, using the application: from the Tools
menu, or using the Windows intaller program.

A review of all uses of wxFileConfig::DeleteAll() proves this.

The one special BoolSetting object was moved from UpdateManager to Prefs.cpp to
avoid a dependency cycle among source code files.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
