### PR TITLE
Same custom over-aligned allocation routine on all platforms...

### DIFF
--- a/libraries/lib-utility/MemoryX.cpp
+++ b/libraries/lib-utility/MemoryX.cpp
@@ -14,8 +14,6 @@
 UTILITY_API void lib_utility_dummy_symbol()
 {}
 
-#ifdef __APPLE__
-
 constexpr auto sizeof_align_val = sizeof(std::align_val_t);
 
 void *NonInterferingBase::operator new(std::size_t count, std::align_val_t al)
@@ -54,5 +52,3 @@ void NonInterferingBase::operator delete(void *ptr, std::align_val_t al)
    // Call through to default operator
    ::operator delete(p);
 }
-
-#endif

--- a/libraries/lib-utility/MemoryX.h
+++ b/libraries/lib-utility/MemoryX.h
@@ -594,10 +594,21 @@ struct UTILITY_API alignas(
    64 /* ? */
 #endif
 )
+
 NonInterferingBase {
-#ifdef __APPLE__
    static void *operator new(std::size_t count, std::align_val_t al);
    static void operator delete(void *ptr, std::align_val_t al);
+
+#if defined (_MSC_VER) && defined(_DEBUG)
+   // Versions that work in the presence of the DEBUG_NEW macro.
+   // Ignore the arguments supplied by the macro and forward to the
+   // other overloads.
+   static void *operator new(
+      std::size_t count, std::align_val_t al, int, const char *, int)
+   { return operator new(count, al); }
+   static void operator delete(
+      void *ptr, std::align_val_t al, int, const char *, int)
+   { return operator delete(ptr, al); }
 #endif
 };
 


### PR DESCRIPTION
... in particular so that warnings on exit in the debug build on Windows are
suppressed.

Maybe it's not important to suppress them.  Or maybe they suggest all is not
correct in the MSVC implementation of this C++17 feature?

Resolves: #1042

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
