### PR TITLE
Preliminaries for lib basic UI (string types)

### DIFF
--- a/libraries/lib-strings/Identifier.h
+++ b/libraries/lib-strings/Identifier.h
@@ -232,5 +232,7 @@ struct CommandIdTag;
 using CommandID = TaggedIdentifier< CommandIdTag, false >;
 using CommandIDs = std::vector<CommandID>;
 
+using ManualPageID = wxString;
+
 #endif
 

--- a/libraries/lib-strings/Identifier.h
+++ b/libraries/lib-strings/Identifier.h
@@ -232,7 +232,8 @@ struct CommandIdTag;
 using CommandID = TaggedIdentifier< CommandIdTag, false >;
 using CommandIDs = std::vector<CommandID>;
 
-using ManualPageID = wxString;
+struct ManualPageIDTag;
+using ManualPageID = TaggedIdentifier< ManualPageIDTag >;
 
 #endif
 

--- a/src/BatchCommandDialog.cpp
+++ b/src/BatchCommandDialog.cpp
@@ -173,7 +173,7 @@ void MacroCommandDialog::OnCancel(wxCommandEvent & WXUNUSED(event))
 
 void MacroCommandDialog::OnHelp(wxCommandEvent & WXUNUSED(event))
 {
-   wxString page = GetHelpPageName();
+   const auto &page = GetHelpPageName();
    HelpSystem::ShowHelp(this, page, true);
 }
 

--- a/src/BatchCommandDialog.h
+++ b/src/BatchCommandDialog.h
@@ -42,7 +42,7 @@ class MacroCommandDialog final : public wxDialogWrapper {
    void OnCancel(wxCommandEvent &event);
    void OnHelp(wxCommandEvent &event);
    void OnItemSelected(wxListEvent &event);
-   wxString GetHelpPageName() { return wxT("Scripting Reference") ; }
+   ManualPageID GetHelpPageName() { return L"Scripting Reference" ; }
 
    void ValidateChoices();
    void PopulateCommandList();

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -222,7 +222,7 @@ void ApplyMacroDialog::PopulateMacros()
 
 void ApplyMacroDialog::OnHelp(wxCommandEvent & WXUNUSED(event))
 {
-   wxString page = GetHelpPageName();
+   const auto &page = GetHelpPageName();
    HelpSystem::ShowHelp(this, page, true);
 }
 

--- a/src/BatchProcessDialog.h
+++ b/src/BatchProcessDialog.h
@@ -41,7 +41,7 @@ class ApplyMacroDialog : public wxDialogWrapper {
    virtual void OnCancel(wxCommandEvent & event);
    virtual void OnHelp(wxCommandEvent & event);
 
-   virtual wxString GetHelpPageName() {return "Apply_Macro";};
+   virtual ManualPageID GetHelpPageName() {return "Apply_Macro";}
 
    void PopulateMacros();
    static CommandID MacroIdOfName( const wxString & MacroName );
@@ -87,9 +87,9 @@ private:
    void OnApplyToFiles(wxCommandEvent & event) override;
    void OnCancel(wxCommandEvent &event) override;
 
-   virtual wxString GetHelpPageName() override {return 
+   virtual ManualPageID GetHelpPageName() override {return 
       mbExpanded ? "Manage_Macros"
-         : "Apply_Macro";};
+         : "Apply_Macro";}
 
    void PopulateList();
    void AddItem(const CommandID &command, wxString const &params);

--- a/src/FFmpeg.cpp
+++ b/src/FFmpeg.cpp
@@ -538,7 +538,7 @@ public:
 
    void OnDownload(wxCommandEvent & WXUNUSED(event))
    {
-      HelpSystem::ShowHelp(this, wxT("FAQ:Installing_the_FFmpeg_Import_Export_Library"));
+      HelpSystem::ShowHelp(this, L"FAQ:Installing_the_FFmpeg_Import_Export_Library");
    }
 
    wxString GetLibPath()

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -550,7 +550,7 @@ void FrequencyPlotDialog::OnGetURL(wxCommandEvent & WXUNUSED(event))
 {
    // Original help page is back on-line (March 2016), but the manual should be more reliable.
    // http://www.eramp.com/WCAG_2_audio_contrast_tool_help.htm
-   HelpSystem::ShowHelp(this, wxT("Plot Spectrum"));
+   HelpSystem::ShowHelp(this, L"Plot Spectrum");
 }
 
 bool FrequencyPlotDialog::Show(bool show)

--- a/src/HelpText.cpp
+++ b/src/HelpText.cpp
@@ -387,12 +387,13 @@ const wxString VerCheckArgs(){
 }
 
 // Text of hyperlink to check versions.
-const wxString VerCheckHtml(){
+const wxString VerCheckHtml()
+{
    wxStringOutputStream o;
    wxTextOutputStream s(o);
    s
       << "<center>[["
-      << VerCheckUrl()
+      << VerCheckUrl().GET()
       << "|"
       << XO("Check Online")
       << "]]</center>\n";
@@ -400,7 +401,8 @@ const wxString VerCheckHtml(){
 }
 
 // Url with Version check args attached.
-const wxString VerCheckUrl(){
+const URLString VerCheckUrl()
+{
    //The version we intend to use for live Audacity.
 #define VER_CHECK_URL "https://www.audacityteam.org/download/?"
 //For testing of our scriptlet.

--- a/src/HelpText.h
+++ b/src/HelpText.h
@@ -13,12 +13,17 @@
 
 class TranslatableString;
 class wxString;
+#include "Identifier.h"
+
+struct URLStringTag;
+//! Distinct type for URLs
+using URLString = TaggedIdentifier< URLStringTag >;
 
 AUDACITY_DLL_API  wxString HelpText( const wxString & Key );
 AUDACITY_DLL_API TranslatableString TitleText( const wxString & Key );
 
 extern AUDACITY_DLL_API const wxString VerCheckArgs();
-extern AUDACITY_DLL_API const wxString VerCheckUrl();
+extern AUDACITY_DLL_API const URLString VerCheckUrl();
 extern AUDACITY_DLL_API const wxString VerCheckHtml();
 extern AUDACITY_DLL_API wxString FormatHtmlText( const wxString & Text );
 

--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -313,7 +313,7 @@ void HistoryDialog::OnCompact(wxCommandEvent & WXUNUSED(event))
 
 void HistoryDialog::OnGetURL(wxCommandEvent & WXUNUSED(event))
 {
-   HelpSystem::ShowHelp(this, wxT("Undo,_Redo_and_History"));
+   HelpSystem::ShowHelp(this, L"Undo,_Redo_and_History");
 }
 
 void HistoryDialog::OnItemSelected(wxListEvent &event)

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -285,7 +285,7 @@ void LabelDialog::PopulateOrExchange( ShuttleGui & S )
 
 void LabelDialog::OnHelp(wxCommandEvent & WXUNUSED(event))
 {
-   wxString page = GetHelpPageName();
+   const auto &page = GetHelpPageName();
    HelpSystem::ShowHelp(this, page, true);
 }
 

--- a/src/LabelDialog.h
+++ b/src/LabelDialog.h
@@ -60,8 +60,8 @@ class LabelDialog final : public wxDialogWrapper
    void Populate();
    void PopulateOrExchange( ShuttleGui & S );
    void PopulateLabels();
-   virtual void OnHelp(wxCommandEvent & event);
-   virtual wxString GetHelpPageName() {return "Labels_Editor";};
+   void OnHelp(wxCommandEvent & event);
+   ManualPageID GetHelpPageName() {return "Labels_Editor";}
 
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -19,6 +19,7 @@ Paul Licameli split from AudacityProject.cpp
 #include <wx/xml/xml.h>
 
 #include "ActiveProjects.h"
+#include "CodeConversions.h"
 #include "DBConnection.h"
 #include "Project.h"
 #include "ProjectFileIORegistry.h"
@@ -2316,7 +2317,8 @@ void ProjectFileIO::ShowError(wxWindow *parent,
                               const TranslatableString &message,
                               const wxString &helpPage)
 {
-   ShowExceptionDialog(parent, dlogTitle, message, helpPage, true, GetLastLog());
+   ShowExceptionDialog(parent, dlogTitle, message, helpPage, true,
+                   audacity::ToWString(GetLastLog()));
 }
 
 const TranslatableString &ProjectFileIO::GetLastError() const

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1362,7 +1362,7 @@ public:
 
    void OnGetURL(wxCommandEvent &WXUNUSED(evt))
    {
-      HelpSystem::ShowHelp(this, wxT("File_Menu:_Compact_Project"), true);
+      HelpSystem::ShowHelp(this, L"File_Menu:_Compact_Project", true);
    }
 };
 }

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -17,6 +17,7 @@ Paul Licameli split from AudacityProject.cpp
 #endif
 
 #include <wx/frame.h>
+#include "CodeConversions.h"
 #include "Legacy.h"
 #include "PlatformCompatibility.h"
 #include "Project.h"
@@ -776,7 +777,7 @@ bool ProjectFileManager::OpenNewProject()
          XO("Error opening a new empty project"), 
          "FAQ:Errors_opening_a_new_empty_project",
          true, 
-         projectFileIO.GetLastLog());
+         audacity::ToWString(projectFileIO.GetLastLog()));
    }
    return bOK;
 }

--- a/src/Screenshot.cpp
+++ b/src/Screenshot.cpp
@@ -559,7 +559,7 @@ void ScreenshotBigDialog::OnClose(wxCommandEvent &  WXUNUSED(event))
 
 void ScreenshotBigDialog::OnGetURL(wxCommandEvent & WXUNUSED(event))
 {
-   HelpSystem::ShowHelp(this, wxT("Screenshot"));
+   HelpSystem::ShowHelp(this, L"Screenshot");
 }
 
 void ScreenshotBigDialog::OnUIUpdate(wxUpdateUIEvent &  WXUNUSED(event))

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -972,7 +972,7 @@ void TagsEditorDialog::OnDontShow( wxCommandEvent & Evt )
 
 void TagsEditorDialog::OnHelp(wxCommandEvent& WXUNUSED(event))
 {
-   HelpSystem::ShowHelp(this, wxT("Metadata_Editor"), true);
+   HelpSystem::ShowHelp(this, L"Metadata_Editor", true);
 }
 
 bool TagsEditorDialog::TransferDataFromWindow()

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -363,7 +363,7 @@ void TimerRecordDialog::OnAutoExportCheckBox_Change(wxCommandEvent& WXUNUSED(eve
 
 void TimerRecordDialog::OnHelpButtonClick(wxCommandEvent& WXUNUSED(event))
 {
-   HelpSystem::ShowHelp(this, wxT("Timer_Record"), true);
+   HelpSystem::ShowHelp(this, L"Timer_Record", true);
 }
 
 void TimerRecordDialog::OnOK(wxCommandEvent& WXUNUSED(event))

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -65,7 +65,7 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
    {wxFAIL_MSG( "Implement a Description for this command");return XO("FAIL");};
 
    // Name of page in the Audacity alpha manual
-   virtual wxString ManualPage(){ return wxEmptyString;};
+   virtual ManualPageID ManualPage(){ return {}; }
    virtual bool IsBatchProcessing(){ return mIsBatch;}
    virtual void SetBatchProcessing(bool start){ mIsBatch = start;};
    

--- a/src/commands/CompareAudioCommand.h
+++ b/src/commands/CompareAudioCommand.h
@@ -35,7 +35,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#compare_Audio");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#compare_Audio";}
    bool Apply(const CommandContext &context) override;
 
 

--- a/src/commands/Demo.h
+++ b/src/commands/Demo.h
@@ -29,7 +29,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I";}
 
 private:
    double delay;

--- a/src/commands/DragCommand.h
+++ b/src/commands/DragCommand.h
@@ -32,7 +32,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#move_mouse");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#move_mouse";}
 
    bool Apply(const CommandContext & context) override;
 

--- a/src/commands/GetInfoCommand.h
+++ b/src/commands/GetInfoCommand.h
@@ -38,7 +38,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#get_info");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#get_info";}
    bool Apply(const CommandContext &context) override;
    bool ApplyInner(const CommandContext &context);
 

--- a/src/commands/GetTrackInfoCommand.h
+++ b/src/commands/GetTrackInfoCommand.h
@@ -32,7 +32,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Tools#get_track_info");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Tools#get_track_info";}
 
    bool Apply(const CommandContext &context ) override;
 public:

--- a/src/commands/HelpCommand.h
+++ b/src/commands/HelpCommand.h
@@ -38,7 +38,7 @@ public:
    bool ApplyInner(const CommandContext & context);
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#help");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#help";}
 public:
    wxString mCommandName;
 };
@@ -58,7 +58,7 @@ public:
       return true;
    };
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#comment");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#comment";}
 public:
    wxString mComment;
 };

--- a/src/commands/ImportExportCommands.h
+++ b/src/commands/ImportExportCommands.h
@@ -36,7 +36,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#import");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#import";}
 public:
    wxString mFileName;
 };
@@ -54,7 +54,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#export");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#export";}
 public:
    wxString mFileName;
    int mnChannels;

--- a/src/commands/MessageCommand.h
+++ b/src/commands/MessageCommand.h
@@ -37,7 +37,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#message");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#message";}
 public:
    wxString mMessage;
 };

--- a/src/commands/OpenSaveCommands.h
+++ b/src/commands/OpenSaveCommands.h
@@ -40,7 +40,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#open_project");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#open_project";}
 public:
    wxString mFileName;
    bool mbAddToHistory;
@@ -60,7 +60,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#save_project");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#save_project";}
 public:
    wxString mFileName;
    bool mbAddToHistory;
@@ -80,7 +80,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#save_copy");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#save_copy";}
 public:
    wxString mFileName;
 };
@@ -98,7 +98,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#save_log");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#save_log";}
 public:
    wxString mFileName;
 };
@@ -116,7 +116,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#Clear_log");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#Clear_log";}
 public:
    wxString mFileName;
 };

--- a/src/commands/PreferenceCommands.h
+++ b/src/commands/PreferenceCommands.h
@@ -39,7 +39,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#get_preference");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#get_preference";}
 
    wxString mName;
 };
@@ -59,7 +59,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#set_preference");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_preference";}
 
    wxString mName;
    wxString mValue;

--- a/src/commands/ScreenshotCommand.h
+++ b/src/commands/ScreenshotCommand.h
@@ -87,7 +87,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#screenshot_short_format");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#screenshot_short_format";}
 
 private:
    int mWhat;

--- a/src/commands/SelectCommand.h
+++ b/src/commands/SelectCommand.h
@@ -37,7 +37,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#select_time");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#select_time";}
 
    bool bHasT0;
    bool bHasT1;
@@ -63,7 +63,7 @@ public:
    bool Apply(const CommandContext & context) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#select_frequencies");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#select_frequencies";}
 
    bool bHasBottom;
    bool bHasTop;
@@ -85,7 +85,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#select_tracks");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#select_tracks";}
 
    bool bHasFirstTrack;
    bool bHasNumTracks;
@@ -123,7 +123,7 @@ public:
          mSelTracks.Apply(context);
    }
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#select");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#select";}
 private:
    SelectTimeCommand mSelTime;
    SelectFrequenciesCommand mSelFreq;

--- a/src/commands/SetClipCommand.h
+++ b/src/commands/SetClipCommand.h
@@ -31,7 +31,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#set_clip");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_clip";}
    bool ApplyInner( const CommandContext & context, Track * t ) override;
 
 public:

--- a/src/commands/SetEnvelopeCommand.h
+++ b/src/commands/SetEnvelopeCommand.h
@@ -31,7 +31,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#set_envelope");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_envelope";}
    bool ApplyInner( const CommandContext & context, Track * t ) override;
 
 public:

--- a/src/commands/SetLabelCommand.h
+++ b/src/commands/SetLabelCommand.h
@@ -32,7 +32,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#set_label");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_label";}
 
    bool Apply(const CommandContext & context) override;
 

--- a/src/commands/SetProjectCommand.h
+++ b/src/commands/SetProjectCommand.h
@@ -33,7 +33,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#set_project");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_project";}
 
    bool Apply(const CommandContext & context) override;
 

--- a/src/commands/SetTrackInfoCommand.h
+++ b/src/commands/SetTrackInfoCommand.h
@@ -54,7 +54,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#set_track_status");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_track_status";}
    bool ApplyInner( const CommandContext & context, Track * t ) override;
 
 public:
@@ -81,7 +81,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#set_track_audio");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_track_audio";}
    bool ApplyInner( const CommandContext & context, Track * t ) override;
 
 public:
@@ -110,7 +110,7 @@ public:
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_I#set_track_visuals");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_track_visuals";}
    bool ApplyInner( const CommandContext & context, Track * t ) override;
 
 public:
@@ -150,7 +150,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
    // AudacityCommand overrides
-   wxString ManualPage() override {return wxT("Extra_Menu:_Scriptables_II#set_track");};
+   ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#set_track";}
 
 public:
 

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -99,9 +99,9 @@ TranslatableString EffectAmplify::GetDescription()
    return XO("Increases or decreases the volume of the audio you have selected");
 }
 
-wxString EffectAmplify::ManualPage()
+ManualPageID EffectAmplify::ManualPage()
 {
-   return wxT("Amplify");
+   return L"Amplify";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -35,7 +35,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -118,9 +118,9 @@ TranslatableString EffectAutoDuck::GetDescription()
    return XO("Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level");
 }
 
-wxString EffectAutoDuck::ManualPage()
+ManualPageID EffectAutoDuck::ManualPage()
 {
-   return wxT("Auto_Duck");
+   return L"Auto_Duck";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -32,7 +32,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -98,9 +98,9 @@ TranslatableString EffectBassTreble::GetDescription()
    return XO("Simple tone control effect");
 }
 
-wxString EffectBassTreble::ManualPage()
+ManualPageID EffectBassTreble::ManualPage()
 {
-   return wxT("Bass_and_Treble");
+   return L"Bass_and_Treble";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -45,7 +45,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -150,9 +150,9 @@ TranslatableString EffectChangePitch::GetDescription()
    return XO("Changes the pitch of a track without changing its tempo");
 }
 
-wxString EffectChangePitch::ManualPage()
+ManualPageID EffectChangePitch::ManualPage()
 {
-   return wxT("Change_Pitch");
+   return L"Change_Pitch";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -46,7 +46,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -123,9 +123,9 @@ TranslatableString EffectChangeSpeed::GetDescription()
    return XO("Changes the speed of a track, also changing its pitch");
 }
 
-wxString EffectChangeSpeed::ManualPage()
+ManualPageID EffectChangeSpeed::ManualPage()
 {
-   return wxT("Change_Speed");
+   return L"Change_Speed";
 }
 
 

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -33,7 +33,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -124,9 +124,9 @@ TranslatableString EffectChangeTempo::GetDescription()
    return XO("Changes the tempo of a selection without changing its pitch");
 }
 
-wxString EffectChangeTempo::ManualPage()
+ManualPageID EffectChangeTempo::ManualPage()
 {
-   return wxT("Change_Tempo");
+   return L"Change_Tempo";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -40,7 +40,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -93,9 +93,9 @@ TranslatableString EffectClickRemoval::GetDescription()
    return XO("Click Removal is designed to remove clicks on audio tracks");
 }
 
-wxString EffectClickRemoval::ManualPage()
+ManualPageID EffectClickRemoval::ManualPage()
 {
-   return wxT("Click_Removal");
+   return L"Click_Removal";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -35,7 +35,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -115,9 +115,9 @@ TranslatableString EffectCompressor::GetDescription()
    return XO("Compresses the dynamic range of audio");
 }
 
-wxString EffectCompressor::ManualPage()
+ManualPageID EffectCompressor::ManualPage()
 {
-   return wxT("Compressor");
+   return L"Compressor";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -31,7 +31,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -361,7 +361,7 @@ void ContrastDialog::OnGetURL(wxCommandEvent & WXUNUSED(event))
 {
    // Original help page is back on-line (March 2016), but the manual should be more reliable.
    // http://www.eramp.com/WCAG_2_audio_contrast_tool_help.htm
-   HelpSystem::ShowHelp(this, wxT("Contrast"));
+   HelpSystem::ShowHelp(this, L"Contrast");
 }
 
 void ContrastDialog::OnClose(wxCommandEvent & WXUNUSED(event))

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -198,9 +198,9 @@ TranslatableString EffectDistortion::GetDescription()
    return XO("Waveshaping distortion effect");
 }
 
-wxString EffectDistortion::ManualPage()
+ManualPageID EffectDistortion::ManualPage()
 {
-   return wxT("Distortion");
+   return L"Distortion";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -65,7 +65,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -110,9 +110,9 @@ TranslatableString EffectDtmf::GetDescription()
    return XO("Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones");
 }
 
-wxString EffectDtmf::ManualPage()
+ManualPageID EffectDtmf::ManualPage()
 {
-   return wxT("DTMF_Tones");
+   return L"DTMF_Tones";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -34,7 +34,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -67,9 +67,9 @@ TranslatableString EffectEcho::GetDescription()
    return XO("Repeats the selected audio again and again");
 }
 
-wxString EffectEcho::ManualPage()
+ManualPageID EffectEcho::ManualPage()
 {
-   return wxT("Echo");
+   return L"Echo";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -28,7 +28,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1168,14 +1168,14 @@ bool Effect::HasFactoryDefaults()
    return HasPrivateConfigGroup(GetFactoryDefaultsGroup());
 }
 
-wxString Effect::ManualPage()
+ManualPageID Effect::ManualPage()
 {
-   return wxEmptyString;
+   return {};
 }
 
-wxString Effect::HelpPage()
+FilePath Effect::HelpPage()
 {
-   return wxEmptyString;
+   return {};
 }
 
 void Effect::SetUIFlags(unsigned flags) {

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -237,9 +237,9 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    virtual bool HasFactoryDefaults();
 
    // Name of page in the Audacity alpha manual
-   virtual wxString ManualPage();
+   virtual ManualPageID ManualPage();
    // Fully qualified local help file name
-   virtual wxString HelpPage();
+   virtual FilePath HelpPage();
 
    virtual void SetUIFlags(unsigned flags);
    virtual unsigned TestUIFlags(unsigned mask);

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -190,7 +190,8 @@ void EffectManager::GetCommandDefinition(const PluginID & ID, const CommandConte
       S.EndArray();
       S.EndField();
    }
-   S.AddItem( GetCommandUrl( ID ), "url" );
+   // use GET() to expose some details to macro programming users
+   S.AddItem( GetCommandUrl( ID ).GET(), "url" );
    // The tip is a translated string!
    S.AddItem( GetCommandTip( ID ).Translation(), "tip" );
    S.EndStruct();

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -135,7 +135,7 @@ TranslatableString EffectManager::GetCommandDescription(const PluginID & ID)
    return {};
 }
 
-wxString EffectManager::GetCommandUrl(const PluginID & ID)
+ManualPageID EffectManager::GetCommandUrl(const PluginID & ID)
 {
    Effect* pEff = GetEffect(ID);
    if( pEff )

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -96,7 +96,7 @@ public:
    TranslatableString GetCommandName(const PluginID & ID);
    CommandID GetCommandIdentifier(const PluginID & ID);
    TranslatableString GetCommandDescription(const PluginID & ID);
-   wxString GetCommandUrl(const PluginID & ID);
+   ManualPageID GetCommandUrl(const PluginID & ID);
    TranslatableString GetCommandTip(const PluginID & ID);
    // flags control which commands are included.
    void GetCommandDefinition(const PluginID & ID, const CommandContext & context, int flags);

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -348,14 +348,14 @@ TranslatableString EffectEqualization::GetDescription()
    return XO("Adjusts the volume levels of particular frequencies");
 }
 
-wxString EffectEqualization::ManualPage()
+ManualPageID EffectEqualization::ManualPage()
 {
    // Bug 2509: Must use _ and not space in names.
    if( mOptions == kEqOptionGraphic )
-      return wxT("Graphic_EQ");
+      return L"Graphic_EQ";
    if( mOptions == kEqOptionCurve )
-      return wxT("Filter_Curve_EQ");
-   return wxT("Equalization");
+      return L"Filter_Curve_EQ";
+   return L"Equalization";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -103,7 +103,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -68,9 +68,9 @@ TranslatableString EffectFindClipping::GetDescription()
    return XO("Creates labels where clipping is detected");
 }
 
-wxString EffectFindClipping::ManualPage()
+ManualPageID EffectFindClipping::ManualPage()
 {
-   return wxT("Find_Clipping");
+   return L"Find_Clipping";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -30,7 +30,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -93,9 +93,9 @@ TranslatableString EffectLoudness::GetDescription()
    return XO("Sets the loudness of one or more tracks");
 }
 
-wxString EffectLoudness::ManualPage()
+ManualPageID EffectLoudness::ManualPage()
 {
-   return wxT("Loudness_Normalization");
+   return L"Loudness_Normalization";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -38,7 +38,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -91,9 +91,9 @@ TranslatableString EffectNoise::GetDescription()
    return XO("Generates one of three different types of noise");
 }
 
-wxString EffectNoise::ManualPage()
+ManualPageID EffectNoise::ManualPage()
 {
-   return wxT("Noise");
+   return L"Noise";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -30,7 +30,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -78,9 +78,9 @@ TranslatableString EffectNormalize::GetDescription()
    return XO("Sets the peak amplitude of one or more tracks");
 }
 
-wxString EffectNormalize::ManualPage()
+ManualPageID EffectNormalize::ManualPage()
 {
-   return wxT("Normalize");
+   return L"Normalize";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -32,7 +32,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -117,9 +117,9 @@ TranslatableString EffectPaulstretch::GetDescription()
    return XO("Paulstretch is only for an extreme time-stretch or \"stasis\" effect");
 }
 
-wxString EffectPaulstretch::ManualPage()
+ManualPageID EffectPaulstretch::ManualPage()
 {
-   return wxT("Paulstretch");
+   return L"Paulstretch";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -26,7 +26,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -115,9 +115,9 @@ TranslatableString EffectPhaser::GetDescription()
    return XO("Combines phase-shifted signals with the original signal");
 }
 
-wxString EffectPhaser::ManualPage()
+ManualPageID EffectPhaser::ManualPage()
 {
-   return wxT("Phaser");
+   return L"Phaser";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -51,7 +51,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -75,9 +75,9 @@ TranslatableString EffectRepeat::GetDescription()
    return XO("Repeats the selection the specified number of times");
 }
 
-wxString EffectRepeat::ManualPage()
+ManualPageID EffectRepeat::ManualPage()
 {
-   return wxT("Repeat");
+   return L"Repeat";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -30,7 +30,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -149,9 +149,9 @@ TranslatableString EffectReverb::GetDescription()
    return XO("Adds ambience or a \"hall effect\"");
 }
 
-wxString EffectReverb::ManualPage()
+ManualPageID EffectReverb::ManualPage()
 {
-   return wxT("Reverb");
+   return L"Reverb";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -47,7 +47,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -192,9 +192,9 @@ TranslatableString EffectScienFilter::GetDescription()
    return XO("Performs IIR filtering that emulates analog filters");
 }
 
-wxString EffectScienFilter::ManualPage()
+ManualPageID EffectScienFilter::ManualPage()
 {
-   return wxT("Classic_Filters");
+   return L"Classic_Filters";
 }
 
 

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -41,7 +41,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -50,9 +50,9 @@ TranslatableString EffectSilence::GetDescription()
    return XO("Creates audio of zero amplitude");
 }
 
-wxString EffectSilence::ManualPage()
+ManualPageID EffectSilence::ManualPage()
 {
-   return wxT("Silence");
+   return L"Silence";
 }
 
 

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -29,7 +29,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -101,9 +101,9 @@ TranslatableString EffectTimeScale::GetDescription()
    return XO("Allows continuous changes to the tempo and/or pitch");
 }
 
-wxString EffectTimeScale::ManualPage()
+ManualPageID EffectTimeScale::ManualPage()
 {
-   return wxT("Sliding_Stretch");
+   return L"Sliding_Stretch";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -33,7 +33,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -139,11 +139,11 @@ TranslatableString EffectToneGen::GetDescription()
       : XO("Generates a constant frequency tone of one of four types");
 }
 
-wxString EffectToneGen::ManualPage()
+ManualPageID EffectToneGen::ManualPage()
 {
    return mChirp
-      ? wxT("Chirp")
-      : wxT("Tone");
+      ? L"Chirp"
+      : L"Tone";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -28,7 +28,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -168,9 +168,9 @@ TranslatableString EffectTruncSilence::GetDescription()
    return XO("Automatically reduces the length of passages where the volume is below a specified level");
 }
 
-wxString EffectTruncSilence::ManualPage()
+ManualPageID EffectTruncSilence::ManualPage()
 {
-   return wxT("Truncate_Silence");
+   return L"Truncate_Silence";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -38,7 +38,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -106,9 +106,9 @@ TranslatableString EffectWahwah::GetDescription()
    return XO("Rapid tone quality variations, like that guitar sound so popular in the 1970's");
 }
 
-wxString EffectWahwah::ManualPage()
+ManualPageID EffectWahwah::ManualPage()
 {
-   return wxT("Wahwah");
+   return L"Wahwah";
 }
 
 // EffectDefinitionInterface implementation

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -48,7 +48,7 @@ public:
 
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString ManualPage() override;
+   ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -239,14 +239,14 @@ TranslatableString NyquistEffect::GetDescription()
    return mCopyright;
 }
 
-wxString NyquistEffect::ManualPage()
+ManualPageID NyquistEffect::ManualPage()
 {
       return mIsPrompt
          ? wxString("Nyquist_Prompt")
          : mManPage;
 }
 
-wxString NyquistEffect::HelpPage()
+FilePath NyquistEffect::HelpPage()
 {
    auto paths = NyquistEffect::GetNyquistSearchPath();
    wxString fileName;

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -79,8 +79,8 @@ public:
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
    
-   wxString ManualPage() override;
-   wxString HelpPage() override;
+   ManualPageID ManualPage() override;
+   FilePath HelpPage() override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -367,7 +367,7 @@ void Exporter::OnExtensionChanged(wxCommandEvent &evt)
 void Exporter::OnHelp(wxCommandEvent& WXUNUSED(evt))
 {
    wxWindow * pWin = FindProjectFrame( mProject );
-   HelpSystem::ShowHelp(pWin, wxT("File_Export_Dialog"), true);
+   HelpSystem::ShowHelp(pWin, L"File_Export_Dialog", true);
 }
 
 void Exporter::SetFileDialogTitle( const TranslatableString & DialogTitle )
@@ -1494,7 +1494,7 @@ void ExportMixerDialog::OnCancel(wxCommandEvent & WXUNUSED(event))
 
 void ExportMixerDialog::OnMixerPanelHelp(wxCommandEvent & WXUNUSED(event))
 {
-   HelpSystem::ShowHelp(this, wxT("Advanced_Mixing_Options"), true);
+   HelpSystem::ShowHelp(this, L"Advanced_Mixing_Options", true);
 }
 
 

--- a/src/export/ExportFFmpegDialogs.cpp
+++ b/src/export/ExportFFmpegDialogs.cpp
@@ -2562,7 +2562,7 @@ void ExportFFmpegOptions::OnOK(wxCommandEvent& WXUNUSED(event))
 
 void ExportFFmpegOptions::OnGetURL(wxCommandEvent & WXUNUSED(event))
 {
-   HelpSystem::ShowHelp(this, wxT("Custom_FFmpeg_Export_Options"));
+   HelpSystem::ShowHelp(this, L"Custom_FFmpeg_Export_Options");
 }
 
 

--- a/src/export/ExportMP3.cpp
+++ b/src/export/ExportMP3.cpp
@@ -674,7 +674,7 @@ public:
 
    void OnDownload(wxCommandEvent & WXUNUSED(event))
    {
-      HelpSystem::ShowHelp(this, wxT("FAQ:Installing_the_LAME_MP3_Encoder"));
+      HelpSystem::ShowHelp(this, L"FAQ:Installing_the_LAME_MP3_Encoder");
    }
 
    wxString GetLibPath()

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -574,7 +574,7 @@ void ExportMultipleDialog::OnCancel(wxCommandEvent& WXUNUSED(event))
 
 void ExportMultipleDialog::OnHelp(wxCommandEvent& WXUNUSED(event))
 {
-   HelpSystem::ShowHelp(this, wxT("Export_Multiple"), true);
+   HelpSystem::ShowHelp(this, L"Export_Multiple", true);
 }
 
 void ExportMultipleDialog::OnExport(wxCommandEvent& WXUNUSED(event))

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -309,7 +309,7 @@ void OnQuickHelp(const CommandContext &context)
    auto &project = context.project;
    HelpSystem::ShowHelp(
       &GetProjectFrame( project ),
-      wxT("Quick_Help"));
+      L"Quick_Help");
 }
 
 void OnManual(const CommandContext &context)
@@ -317,7 +317,7 @@ void OnManual(const CommandContext &context)
    auto &project = context.project;
    HelpSystem::ShowHelp(
       &GetProjectFrame( project ),
-      wxT("Main_Page"));
+      L"Main_Page");
 }
 
 void OnAudioDeviceInfo(const CommandContext &context)

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -100,11 +100,11 @@ public:
    void PopulateOrExchange(ShuttleGui & S);
    void AddStuck( ShuttleGui & S, bool & bBool,
       const PrefSetter &prefSetter,
-      const TranslatableString &Prompt, wxString Help );
+      const TranslatableString &Prompt, const ManualPageID &Help );
 
    void OnOk(wxCommandEvent &event);
    void OnCancel(wxCommandEvent &event);
-   void OnHelp(const wxString &Str);
+   void OnHelp(const ManualPageID &Str);
    void OnFix(const PrefSetter &setter, wxWindowID id);
 
    AudacityProject &mProject;
@@ -154,7 +154,7 @@ QuickFixDialog::QuickFixDialog(wxWindow * pParent, AudacityProject &project) :
 
 void QuickFixDialog::AddStuck( ShuttleGui & S, bool & bBool,
    const PrefSetter &prefSetter,
-   const TranslatableString &Prompt, wxString Help )
+   const TranslatableString &Prompt, const ManualPageID &Help )
 {
    mItem++;
    wxWindowID id = FixButtonID + mItem;
@@ -266,7 +266,7 @@ void QuickFixDialog::OnCancel(wxCommandEvent &event)
    EndModal(wxID_CANCEL);
 }
 
-void QuickFixDialog::OnHelp(const wxString &Str)
+void QuickFixDialog::OnHelp(const ManualPageID &Str)
 {
    HelpSystem::ShowHelp(this, Str, true);
 }

--- a/src/prefs/ApplicationPrefs.cpp
+++ b/src/prefs/ApplicationPrefs.cpp
@@ -47,7 +47,7 @@ TranslatableString ApplicationPrefs::GetDescription()
    return XO("Preferences for Application");
 }
 
-wxString ApplicationPrefs::HelpPageName()
+ManualPageID ApplicationPrefs::HelpPageName()
 {
    return "Application_Preferences";
 }

--- a/src/prefs/ApplicationPrefs.h
+++ b/src/prefs/ApplicationPrefs.h
@@ -27,7 +27,7 @@ class ApplicationPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
 
  private:
    void Populate();

--- a/src/prefs/BatchPrefs.cpp
+++ b/src/prefs/BatchPrefs.cpp
@@ -45,7 +45,7 @@ TranslatableString BatchPrefs::GetDescription()
    return XO("Preferences for Batch");
 }
 
-wxString BatchPrefs::HelpPageName()
+ManualPageID BatchPrefs::HelpPageName()
 {
    return  "Batch_Preferences";
 }

--- a/src/prefs/BatchPrefs.h
+++ b/src/prefs/BatchPrefs.h
@@ -27,7 +27,7 @@ public:
    ~BatchPrefs();
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
 
    bool Commit() override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/prefs/DevicePrefs.cpp
+++ b/src/prefs/DevicePrefs.cpp
@@ -74,7 +74,7 @@ TranslatableString DevicePrefs::GetDescription()
    return XO("Preferences for Device");
 }
 
-wxString DevicePrefs::HelpPageName()
+ManualPageID DevicePrefs::HelpPageName()
 {
    return "Devices_Preferences";
 }

--- a/src/prefs/DevicePrefs.h
+++ b/src/prefs/DevicePrefs.h
@@ -30,7 +30,7 @@ class DevicePrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -163,7 +163,7 @@ TranslatableString DirectoriesPrefs::GetDescription()
    return XO("Preferences for Directories");
 }
 
-wxString DirectoriesPrefs::HelpPageName()
+ManualPageID DirectoriesPrefs::HelpPageName()
 {
    return "Directories_Preferences";
 }

--- a/src/prefs/DirectoriesPrefs.h
+++ b/src/prefs/DirectoriesPrefs.h
@@ -31,7 +31,7 @@ class DirectoriesPrefs final : public PrefsPanel
 
    bool Commit() override;
    bool Validate() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui &S) override;
 
  private:

--- a/src/prefs/EffectsPrefs.cpp
+++ b/src/prefs/EffectsPrefs.cpp
@@ -48,7 +48,7 @@ TranslatableString EffectsPrefs::GetDescription()
    return XO("Preferences for Effects");
 }
 
-wxString EffectsPrefs::HelpPageName()
+ManualPageID EffectsPrefs::HelpPageName()
 {
    return "Effects_Preferences";
 }

--- a/src/prefs/EffectsPrefs.h
+++ b/src/prefs/EffectsPrefs.h
@@ -31,7 +31,7 @@ class EffectsPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/ExtImportPrefs.cpp
+++ b/src/prefs/ExtImportPrefs.cpp
@@ -84,7 +84,7 @@ TranslatableString ExtImportPrefs::GetDescription()
    return XO("Preferences for ExtImport");
 }
 
-wxString ExtImportPrefs::HelpPageName()
+ManualPageID ExtImportPrefs::HelpPageName()
 {
    return "Extended_Import_Preferences";
 }

--- a/src/prefs/ExtImportPrefs.h
+++ b/src/prefs/ExtImportPrefs.h
@@ -55,7 +55,7 @@ class ExtImportPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
    // See bug #2315 for discussion. This should be reviewed

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -56,7 +56,7 @@ TranslatableString GUIPrefs::GetDescription()
    return XO("Preferences for GUI");
 }
 
-wxString GUIPrefs::HelpPageName()
+ManualPageID GUIPrefs::HelpPageName()
 {
    return "Interface_Preferences";
 }

--- a/src/prefs/GUIPrefs.h
+++ b/src/prefs/GUIPrefs.h
@@ -31,7 +31,7 @@ class AUDACITY_DLL_API GUIPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
    static void GetRangeChoices(

--- a/src/prefs/ImportExportPrefs.cpp
+++ b/src/prefs/ImportExportPrefs.cpp
@@ -43,7 +43,7 @@ TranslatableString ImportExportPrefs::GetDescription()
    return XO("Preferences for ImportExport");
 }
 
-wxString ImportExportPrefs::HelpPageName()
+ManualPageID ImportExportPrefs::HelpPageName()
 {
    return "Import_-_Export_Preferences";
 }

--- a/src/prefs/ImportExportPrefs.h
+++ b/src/prefs/ImportExportPrefs.h
@@ -36,7 +36,7 @@ class AUDACITY_DLL_API ImportExportPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/KeyConfigPrefs.cpp
+++ b/src/prefs/KeyConfigPrefs.cpp
@@ -117,7 +117,7 @@ TranslatableString KeyConfigPrefs::GetDescription()
    return XO("Preferences for KeyConfig");
 }
 
-wxString KeyConfigPrefs::HelpPageName()
+ManualPageID KeyConfigPrefs::HelpPageName()
 {
    return "Keyboard_Preferences";
 }

--- a/src/prefs/KeyConfigPrefs.h
+++ b/src/prefs/KeyConfigPrefs.h
@@ -40,7 +40,7 @@ public:
 
    bool Commit() override;
    void Cancel() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
 private:

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -168,7 +168,7 @@ void LibraryPrefs::OnMP3FindButton(wxCommandEvent & WXUNUSED(event))
 void LibraryPrefs::OnMP3DownButton(wxCommandEvent & WXUNUSED(event))
 {
    // Modal help dialogue required here
-   HelpSystem::ShowHelp(this, wxT("FAQ:Installing_the_LAME_MP3_Encoder"), true);
+   HelpSystem::ShowHelp(this, L"FAQ:Installing_the_LAME_MP3_Encoder", true);
 }
 
 void LibraryPrefs::SetFFmpegVersionText()
@@ -217,7 +217,7 @@ void LibraryPrefs::OnFFmpegFindButton(wxCommandEvent & WXUNUSED(event))
 
 void LibraryPrefs::OnFFmpegDownButton(wxCommandEvent & WXUNUSED(event))
 {
-   HelpSystem::ShowHelp(this, wxT("FAQ:Installing_the_FFmpeg_Import_Export_Library"), true);
+   HelpSystem::ShowHelp(this, L"FAQ:Installing_the_FFmpeg_Import_Export_Library", true);
 }
 
 bool LibraryPrefs::Commit()

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -66,7 +66,7 @@ TranslatableString LibraryPrefs::GetDescription()
    return XO("Preferences for Library");
 }
 
-wxString LibraryPrefs::HelpPageName()
+ManualPageID LibraryPrefs::HelpPageName()
 {
    return "Libraries_Preferences";
 }

--- a/src/prefs/LibraryPrefs.h
+++ b/src/prefs/LibraryPrefs.h
@@ -33,7 +33,7 @@ class LibraryPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/MidiIOPrefs.cpp
+++ b/src/prefs/MidiIOPrefs.cpp
@@ -75,7 +75,7 @@ TranslatableString MidiIOPrefs::GetDescription()
    return XO("Preferences for MidiIO");
 }
 
-wxString MidiIOPrefs::HelpPageName()
+ManualPageID MidiIOPrefs::HelpPageName()
 {
    return "MIDI_Devices_Preferences";
 }

--- a/src/prefs/MidiIOPrefs.h
+++ b/src/prefs/MidiIOPrefs.h
@@ -34,7 +34,7 @@ class MidiIOPrefs final : public PrefsPanel
 
    bool Commit() override;
    bool Validate() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/ModulePrefs.cpp
+++ b/src/prefs/ModulePrefs.cpp
@@ -51,7 +51,7 @@ TranslatableString ModulePrefs::GetDescription()
    return XO("Preferences for Module");
 }
 
-wxString ModulePrefs::HelpPageName()
+ManualPageID ModulePrefs::HelpPageName()
 {
    return "Modules_Preferences";
 }

--- a/src/prefs/ModulePrefs.h
+++ b/src/prefs/ModulePrefs.h
@@ -32,7 +32,7 @@ class ModulePrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/MousePrefs.cpp
+++ b/src/prefs/MousePrefs.cpp
@@ -82,7 +82,7 @@ TranslatableString MousePrefs::GetDescription()
    return XO("Preferences for Mouse");
 }
 
-wxString MousePrefs::HelpPageName()
+ManualPageID MousePrefs::HelpPageName()
 {
    return "Mouse_Preferences";
 }

--- a/src/prefs/MousePrefs.h
+++ b/src/prefs/MousePrefs.h
@@ -28,7 +28,7 @@ class MousePrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/PlaybackPrefs.cpp
+++ b/src/prefs/PlaybackPrefs.cpp
@@ -47,7 +47,7 @@ TranslatableString PlaybackPrefs::GetDescription()
    return XO("Preferences for Playback");
 }
 
-wxString PlaybackPrefs::HelpPageName()
+ManualPageID PlaybackPrefs::HelpPageName()
 {
    return "Playback_Preferences";
 }

--- a/src/prefs/PlaybackPrefs.h
+++ b/src/prefs/PlaybackPrefs.h
@@ -29,7 +29,7 @@ class PlaybackPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
    
    static bool GetUnpinnedScrubbingPreference();

--- a/src/prefs/PrefsDialog.cpp
+++ b/src/prefs/PrefsDialog.cpp
@@ -656,7 +656,7 @@ void PrefsDialog::OnPreview(wxCommandEvent & WXUNUSED(event))
 
 void PrefsDialog::OnHelp(wxCommandEvent & WXUNUSED(event))
 {
-   wxString page = GetCurrentPanel()->HelpPageName();
+   const auto &page = GetCurrentPanel()->HelpPageName();
    HelpSystem::ShowHelp(this, page, true);
 }
 

--- a/src/prefs/PrefsPanel.cpp
+++ b/src/prefs/PrefsPanel.cpp
@@ -95,9 +95,9 @@ bool PrefsPanel::ShowsPreviewButton()
    return false;
 }
 
-wxString PrefsPanel::HelpPageName()
+ManualPageID PrefsPanel::HelpPageName()
 {
-   return wxEmptyString;
+   return {};
 }
 
 PrefsPanel::Factories

--- a/src/prefs/PrefsPanel.h
+++ b/src/prefs/PrefsPanel.h
@@ -115,9 +115,9 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
    virtual bool ShowsPreviewButton();
    virtual void PopulateOrExchange( ShuttleGui & WXUNUSED(S) ){};
 
-   // If not empty string, the Help button is added below the panel
-   // Default returns empty string.
-   virtual wxString HelpPageName();
+   //! If not empty string, the Help button is added below the panel
+   /*! Default returns empty string. */
+   virtual ManualPageID HelpPageName();
 
    virtual void Cancel();
 };

--- a/src/prefs/QualityPrefs.cpp
+++ b/src/prefs/QualityPrefs.cpp
@@ -57,7 +57,7 @@ TranslatableString QualityPrefs::GetDescription()
    return XO("Preferences for Quality");
 }
 
-wxString QualityPrefs::HelpPageName()
+ManualPageID QualityPrefs::HelpPageName()
 {
    return "Quality_Preferences";
 }

--- a/src/prefs/QualityPrefs.h
+++ b/src/prefs/QualityPrefs.h
@@ -34,7 +34,7 @@ class AUDACITY_DLL_API QualityPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/RecordingPrefs.cpp
+++ b/src/prefs/RecordingPrefs.cpp
@@ -62,7 +62,7 @@ TranslatableString RecordingPrefs::GetDescription()
    return XO("Preferences for Recording");
 }
 
-wxString RecordingPrefs::HelpPageName()
+ManualPageID RecordingPrefs::HelpPageName()
 {
    return "Recording_Preferences";
 }

--- a/src/prefs/RecordingPrefs.h
+++ b/src/prefs/RecordingPrefs.h
@@ -48,7 +48,7 @@ class RecordingPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
  private:

--- a/src/prefs/SpectrumPrefs.cpp
+++ b/src/prefs/SpectrumPrefs.cpp
@@ -77,7 +77,7 @@ TranslatableString SpectrumPrefs::GetDescription()
    return XO("Preferences for Spectrum");
 }
 
-wxString SpectrumPrefs::HelpPageName()
+ManualPageID SpectrumPrefs::HelpPageName()
 {
    // Currently (May2017) Spectrum Settings is the only preferences
    // we ever display in a dialog on its own without others.

--- a/src/prefs/SpectrumPrefs.h
+++ b/src/prefs/SpectrumPrefs.h
@@ -53,7 +53,7 @@ class SpectrumPrefs final : public PrefsPanel
    void Rollback();
    bool ShowsPreviewButton() override;
    bool Validate() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
 
  private:
    void Populate(size_t windowSize);

--- a/src/prefs/ThemePrefs.cpp
+++ b/src/prefs/ThemePrefs.cpp
@@ -82,7 +82,7 @@ TranslatableString ThemePrefs::GetDescription()
    return XO("Preferences for Theme");
 }
 
-wxString ThemePrefs::HelpPageName()
+ManualPageID ThemePrefs::HelpPageName()
 {
    return "Theme_Preferences";
 }

--- a/src/prefs/ThemePrefs.h
+++ b/src/prefs/ThemePrefs.h
@@ -36,7 +36,7 @@ class ThemePrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
 
    static void ApplyUpdatedImages();
 

--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -41,7 +41,7 @@ TranslatableString TracksBehaviorsPrefs::GetDescription()
    return XO("Preferences for TracksBehaviors");
 }
 
-wxString TracksBehaviorsPrefs::HelpPageName()
+ManualPageID TracksBehaviorsPrefs::HelpPageName()
 {
    return "Tracks_Behaviors_Preferences";
 }

--- a/src/prefs/TracksBehaviorsPrefs.h
+++ b/src/prefs/TracksBehaviorsPrefs.h
@@ -30,7 +30,7 @@ class AUDACITY_DLL_API TracksBehaviorsPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
 
    static const wxChar *ScrollingPreferenceKey();
    static inline bool ScrollingPreferenceDefault() { return false; }

--- a/src/prefs/TracksPrefs.cpp
+++ b/src/prefs/TracksPrefs.cpp
@@ -288,7 +288,7 @@ TranslatableString TracksPrefs::GetDescription()
    return XO("Preferences for Tracks");
 }
 
-wxString TracksPrefs::HelpPageName()
+ManualPageID TracksPrefs::HelpPageName()
 {
    return "Tracks_Preferences";
 }

--- a/src/prefs/TracksPrefs.h
+++ b/src/prefs/TracksPrefs.h
@@ -33,7 +33,7 @@ class AUDACITY_DLL_API TracksPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
 
    static bool GetPinnedHeadPreference();
    static void SetPinnedHeadPreference(bool value, bool flush = false);

--- a/src/prefs/WarningsPrefs.cpp
+++ b/src/prefs/WarningsPrefs.cpp
@@ -47,7 +47,7 @@ TranslatableString WarningsPrefs::GetDescription()
    return XO("Preferences for Warnings");
 }
 
-wxString WarningsPrefs::HelpPageName()
+ManualPageID WarningsPrefs::HelpPageName()
 {
    return "Warnings_Preferences";
 }

--- a/src/prefs/WarningsPrefs.h
+++ b/src/prefs/WarningsPrefs.h
@@ -30,7 +30,7 @@ class WarningsPrefs final : public PrefsPanel
    TranslatableString GetDescription() override;
 
    bool Commit() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
 
  private:
    void Populate();

--- a/src/prefs/WaveformPrefs.cpp
+++ b/src/prefs/WaveformPrefs.cpp
@@ -66,7 +66,7 @@ TranslatableString WaveformPrefs::GetDescription()
    return XO("Preferences for Waveforms");
 }
 
-wxString WaveformPrefs::HelpPageName()
+ManualPageID WaveformPrefs::HelpPageName()
 {
    return "Waveform_Preferences";
 }

--- a/src/prefs/WaveformPrefs.h
+++ b/src/prefs/WaveformPrefs.h
@@ -30,7 +30,7 @@ public:
    virtual ~WaveformPrefs();
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
-   wxString HelpPageName() override;
+   ManualPageID HelpPageName() override;
 
    bool Commit() override;
    bool ShowsPreviewButton() override;

--- a/src/tracks/ui/CommonTrackControls.cpp
+++ b/src/tracks/ui/CommonTrackControls.cpp
@@ -203,7 +203,7 @@ public:
    //bool Apply(const CommandContext & context) override;
 
    // Provide an override, if we want the help button.
-   // wxString ManualPage() override {return wxT("");};
+   // ManualPageID ManualPage() override {return {};}
 public:
    wxString mName;
 };

--- a/src/widgets/ErrorDialog.cpp
+++ b/src/widgets/ErrorDialog.cpp
@@ -133,12 +133,13 @@ void ErrorDialog::OnOk(wxCommandEvent & WXUNUSED(event))
 
 void ErrorDialog::OnHelp(wxCommandEvent & WXUNUSED(event))
 {
-   if( dhelpPage.StartsWith(wxT("innerlink:")) )
+   const auto &str = dhelpPage.GET();
+   if( str.StartsWith(wxT("innerlink:")) )
    {
       HelpSystem::ShowHtmlText(
          this,
-         TitleText(dhelpPage.Mid( 10 ) ),
-         HelpText( dhelpPage.Mid( 10 )),
+         TitleText(str.Mid( 10 ) ),
+         HelpText( str.Mid( 10 )),
          false,
          true );
       return;

--- a/src/widgets/ErrorDialog.cpp
+++ b/src/widgets/ErrorDialog.cpp
@@ -33,6 +33,7 @@
 #include <wx/artprov.h>
 
 #include "../AllThemeResources.h"
+#include "CodeConversions.h"
 #include "../ShuttleGui.h"
 #include "../HelpText.h"
 #include "../Prefs.h"
@@ -53,7 +54,7 @@ ErrorDialog::ErrorDialog(
    const TranslatableString & dlogTitle,
    const TranslatableString & message,
    const ManualPageID & helpPage,
-   const wxString & log,
+   const std::wstring & log,
    const bool Close, const bool modal)
 :  wxDialogWrapper(parent, wxID_ANY, dlogTitle,
                    wxDefaultPosition, wxDefaultSize,
@@ -155,7 +156,7 @@ void ShowErrorDialog(wxWindow *parent,
                      const TranslatableString &message,
                      const ManualPageID &helpPage,
                      const bool Close,
-                     const wxString &log)
+                     const std::wstring &log)
 {
    ErrorDialog dlog(parent, dlogTitle, message, helpPage, log, Close);
    dlog.CentreOnParent();
@@ -169,9 +170,11 @@ void ShowExceptionDialog(
    const wxString& log)
 {
 #ifndef HAS_SENTRY_REPORTING
-   ShowErrorDialog(parent, dlogTitle, message, helpPage, Close, log);
+   ShowErrorDialog(parent, dlogTitle, message, helpPage, Close,
+      audacity::ToWString(log));
 #else
-   ShowErrorReportDialog(parent, dlogTitle, message, helpPage, log);
+   ShowErrorReportDialog(parent, dlogTitle, message, helpPage,
+      audacity::ToWString(log));
 #endif // !HAS_SENTRY_REPORTING
 }
 
@@ -181,7 +184,7 @@ void ShowModelessErrorDialog(wxWindow *parent,
                              const TranslatableString &message,
                              const ManualPageID &helpPage,
                              const bool Close,
-                             const wxString &log)
+                             const std::wstring &log)
 {
    // ensure it has some parent.
    if( !parent )

--- a/src/widgets/ErrorDialog.cpp
+++ b/src/widgets/ErrorDialog.cpp
@@ -52,7 +52,7 @@ ErrorDialog::ErrorDialog(
    wxWindow *parent,
    const TranslatableString & dlogTitle,
    const TranslatableString & message,
-   const wxString & helpPage,
+   const ManualPageID & helpPage,
    const wxString & log,
    const bool Close, const bool modal)
 :  wxDialogWrapper(parent, wxID_ANY, dlogTitle,
@@ -152,7 +152,7 @@ void ErrorDialog::OnHelp(wxCommandEvent & WXUNUSED(event))
 void ShowErrorDialog(wxWindow *parent,
                      const TranslatableString &dlogTitle,
                      const TranslatableString &message,
-                     const wxString &helpPage,
+                     const ManualPageID &helpPage,
                      const bool Close,
                      const wxString &log)
 {
@@ -178,7 +178,7 @@ void ShowExceptionDialog(
 void ShowModelessErrorDialog(wxWindow *parent,
                              const TranslatableString &dlogTitle,
                              const TranslatableString &message,
-                             const wxString &helpPage,
+                             const ManualPageID &helpPage,
                              const bool Close,
                              const wxString &log)
 {

--- a/src/widgets/ErrorDialog.h
+++ b/src/widgets/ErrorDialog.h
@@ -28,14 +28,14 @@ public:
    ErrorDialog(wxWindow *parent,
       const TranslatableString & dlogTitle,
       const TranslatableString & message,
-      const wxString & helpPage,
+      const ManualPageID & helpPage,
       const wxString & log,
       const bool Close = true, const bool modal = true);
 
    virtual ~ErrorDialog(){}
 
 private:
-   wxString dhelpPage;
+   ManualPageID dhelpPage;
    bool dClose;
    bool dModal;
 
@@ -50,7 +50,7 @@ AUDACITY_DLL_API
 void ShowErrorDialog(wxWindow *parent,
                      const TranslatableString &dlogTitle,
                      const TranslatableString &message,
-                     const wxString &helpPage,
+                     const ManualPageID &helpPage,
                      bool Close = true,
                      const wxString &log = {});
 
@@ -65,7 +65,7 @@ void ShowExceptionDialog(
 void ShowModelessErrorDialog(wxWindow *parent,
                      const TranslatableString &dlogTitle,
                      const TranslatableString &message,
-                     const wxString &helpPage,
+                     const ManualPageID &helpPage,
                      bool Close = true,
                      const wxString &log = {});
 

--- a/src/widgets/ErrorDialog.h
+++ b/src/widgets/ErrorDialog.h
@@ -14,6 +14,7 @@
 
 
 
+#include <string>
 #include <wx/defs.h>
 #include <wx/msgdlg.h> // to inherit
 #include "wxPanelWrapper.h" // to inherit
@@ -29,7 +30,7 @@ public:
       const TranslatableString & dlogTitle,
       const TranslatableString & message,
       const ManualPageID & helpPage,
-      const wxString & log,
+      const std::wstring & log,
       const bool Close = true, const bool modal = true);
 
    virtual ~ErrorDialog(){}
@@ -52,7 +53,7 @@ void ShowErrorDialog(wxWindow *parent,
                      const TranslatableString &message,
                      const ManualPageID &helpPage,
                      bool Close = true,
-                     const wxString &log = {});
+                     const std::wstring &log = {});
 
 /// Displays an error dialog, possibly allowing to send error report.
 AUDACITY_DLL_API
@@ -67,7 +68,7 @@ void ShowModelessErrorDialog(wxWindow *parent,
                      const TranslatableString &message,
                      const ManualPageID &helpPage,
                      bool Close = true,
-                     const wxString &log = {});
+                     const std::wstring &log = {});
 
 #include <wx/textdlg.h> // to inherit
 

--- a/src/widgets/HelpSystem.cpp
+++ b/src/widgets/HelpSystem.cpp
@@ -307,7 +307,7 @@ void HelpSystem::ShowHelp(wxWindow *parent,
 }
 
 void HelpSystem::ShowHelp(wxWindow *parent,
-                          const wxString &PageName,
+                          const ManualPageID &PageName,
                           bool bModal)
 {
    FilePath localHelpPage;

--- a/src/widgets/HelpSystem.cpp
+++ b/src/widgets/HelpSystem.cpp
@@ -236,8 +236,8 @@ void HelpSystem::ShowHtmlText(wxWindow *pParent,
 
 // Shows help in browser, or possibly in own dialog.
 void HelpSystem::ShowHelp(wxWindow *parent,
-                    const wxString &localFileName,
-                    const wxString &remoteURL,
+                    const FilePath &localFileName,
+                    const URLString &remoteURL,
                     bool bModal,
                     bool alwaysDefaultBrowser)
 {
@@ -289,7 +289,7 @@ void HelpSystem::ShowHelp(wxWindow *parent,
       // I can't find it'.
       // Use Built-in browser to suggest you use the remote url.
       wxString Text = HelpText( wxT("remotehelp") );
-      Text.Replace( wxT("*URL*"), remoteURL );
+      Text.Replace( wxT("*URL*"), remoteURL.GET() );
       // Always make the 'help on the internet' dialog modal.
       // Fixes Bug 1411.
       ShowHtmlText( parent, XO("Help on the Internet"), Text, false, true );
@@ -297,7 +297,7 @@ void HelpSystem::ShowHelp(wxWindow *parent,
    else if( HelpMode == wxT("Local") || alwaysDefaultBrowser)
    {
       // Local file, External browser
-      OpenInDefaultBrowser( wxString(wxT("file:"))+localFileName );
+      OpenInDefaultBrowser( L"file:" + localFileName );
    }
    else
    {
@@ -310,7 +310,7 @@ void HelpSystem::ShowHelp(wxWindow *parent,
                           const wxString &PageName,
                           bool bModal)
 {
-   wxString localHelpPage;
+   FilePath localHelpPage;
    wxString webHelpPath;
    wxString webHelpPage;
    wxString releasePageName;
@@ -515,9 +515,9 @@ void BrowserDialog::UpdateButtons()
    }
 }
 
-void OpenInDefaultBrowser(const wxHtmlLinkInfo& link)
+void OpenInDefaultBrowser(const URLString& link)
 {
-   wxURI uri(link.GetHref());
+   wxURI uri(link.GET());
    wxLaunchDefaultBrowser(uri.BuildURI());
 }
 
@@ -555,7 +555,7 @@ void LinkingHtmlWindow::OnLinkClicked(const wxHtmlLinkInfo& link)
    }
    else if( href.StartsWith(wxT("mailto:")) || href.StartsWith(wxT("file:")) )
    {
-      OpenInDefaultBrowser( link );
+      OpenInDefaultBrowser( link.GetHref() );
       return;
    }
    else if( !href.StartsWith( wxT("http:"))  && !href.StartsWith( wxT("https:")) )
@@ -564,7 +564,7 @@ void LinkingHtmlWindow::OnLinkClicked(const wxHtmlLinkInfo& link)
    }
    else
    {
-      OpenInDefaultBrowser(link);
+      OpenInDefaultBrowser(link.GetHref());
       return;
    }
    wxFrame * pFrame = GetRelatedFrame();

--- a/src/widgets/HelpSystem.cpp
+++ b/src/widgets/HelpSystem.cpp
@@ -362,7 +362,8 @@ void HelpSystem::ShowHelp(wxWindow *parent,
    else if (releasePageName.StartsWith( "http" ) )
    {
       localHelpPage = "";
-      webHelpPage = releasePageName + anchor;
+      releasePageName += anchor;
+      // webHelpPath remains empty
    }
    else
    {

--- a/src/widgets/HelpSystem.cpp
+++ b/src/widgets/HelpSystem.cpp
@@ -57,7 +57,6 @@ const wxString HelpSystem::HelpServerHomeDir = wxT("/");
 const wxString HelpSystem::HelpServerManDir = wxT("/man/");
 #endif
 const wxString HelpSystem::LocalHelpManDir = wxT("/man/");
-const wxString HelpSystem::ReleaseSuffix = wxT(".html");
 
 namespace {
 
@@ -310,19 +309,24 @@ void HelpSystem::ShowHelp(wxWindow *parent,
                           const ManualPageID &PageName,
                           bool bModal)
 {
+   /// The string which is appended to the development manual page name in order
+   /// obtain the file name in the local and release web copies of the manual
+   const wxString ReleaseSuffix = L".html";
+
    FilePath localHelpPage;
    wxString webHelpPath;
    wxString webHelpPage;
    wxString releasePageName;
    wxString anchor;	// optional part of URL after (and including) the '#'
-   if (PageName.Find('#', true) != wxNOT_FOUND)
+   const auto &PageNameStr = PageName.GET();
+   if (PageNameStr.Find('#', true) != wxNOT_FOUND)
    {	// need to split anchor off into separate variable
-      releasePageName= PageName.BeforeLast('#');
-      anchor = wxT("#") + PageName.AfterLast('#');
+      releasePageName = PageNameStr.BeforeLast('#');
+      anchor = wxT("#") + PageNameStr.AfterLast('#');
    }
    else
    {
-      releasePageName = PageName;
+      releasePageName = PageName.GET();
       anchor = wxT("");
    }
    // The wiki pages are transformed to static HTML by
@@ -338,23 +342,23 @@ void HelpSystem::ShowHelp(wxWindow *parent,
    //
    // The front page and 'quick_help' are treated as special cases and placed in
    // the root of the help directory rather than the "/man/" sub-directory.
-   if (releasePageName == wxT("Main_Page"))
+   if (releasePageName == L"Main_Page")
    {
-      releasePageName = wxT("index") + HelpSystem::ReleaseSuffix + anchor;
+      releasePageName = L"index" + ReleaseSuffix + anchor;
       localHelpPage = wxFileName(FileNames::HtmlHelpDir(), releasePageName).GetFullPath();
-      webHelpPath = wxT("https://")+HelpSystem::HelpHostname+HelpSystem::HelpServerHomeDir;
+      webHelpPath = L"https://" + HelpSystem::HelpHostname + HelpSystem::HelpServerHomeDir;
    }
-   else if (releasePageName == wxT("Quick_Help"))
+   else if (releasePageName == L"Quick_Help")
    {
 // DA: No bundled help, by default, and different quick-help URL.
 #ifdef EXPERIMENTAL_DA
-      releasePageName = wxT("video") + HelpSystem::ReleaseSuffix + anchor;
+      releasePageName = L"video" + ReleaseSuffix + anchor;
       localHelpPage = wxFileName(FileNames::HtmlHelpDir(), releasePageName).GetFullPath();
-      webHelpPath = wxT("http://www.darkaudacity.com/");
+      webHelpPath = L"http://www.darkaudacity.com/";
 #else
-      releasePageName = wxT("quick_help") + HelpSystem::ReleaseSuffix + anchor;
+      releasePageName = L"quick_help" + ReleaseSuffix + anchor;
       localHelpPage = wxFileName(FileNames::HtmlHelpDir(), releasePageName).GetFullPath();
-      webHelpPath = wxT("https://")+HelpSystem::HelpHostname+HelpSystem::HelpServerHomeDir;
+      webHelpPath = L"https://" + HelpSystem::HelpHostname + HelpSystem::HelpServerHomeDir;
 #endif
    }
    // not a page name, but rather a full path (e.g. to wiki)
@@ -390,21 +394,21 @@ void HelpSystem::ShowHelp(wxWindow *parent,
       // Replace "_." with "."
       releasePageName.Replace(wxT("_."), wxT("."), true);
       // Concatenate file name with file extension and anchor.
-      releasePageName = releasePageName + HelpSystem::ReleaseSuffix + anchor;
+      releasePageName = releasePageName + ReleaseSuffix + anchor;
       // Other than index and quick_help, all local pages are in subdirectory 'LocalHelpManDir'.
       localHelpPage = wxFileName(FileNames::HtmlHelpDir() + LocalHelpManDir, releasePageName).GetFullPath();
       // Other than index and quick_help, all on-line pages are in subdirectory 'HelpServerManDir'.
-      webHelpPath = wxT("https://")+HelpSystem::HelpHostname+HelpSystem::HelpServerManDir;
+      webHelpPath = L"https://" + HelpSystem::HelpHostname + HelpSystem::HelpServerManDir;
    }
 
 #ifdef USE_ALPHA_MANUAL
-   webHelpPage = webHelpPath + PageName;
+   webHelpPage = webHelpPath + PageName.GET();
 #else
    webHelpPage = webHelpPath + releasePageName;
 #endif
 
    wxLogMessage(wxT("Help button pressed: PageName %s, releasePageName %s"),
-              PageName, releasePageName);
+              PageName.GET(), releasePageName);
    wxLogMessage(wxT("webHelpPage %s, localHelpPage %s"),
               webHelpPage, localHelpPage);
 
@@ -535,7 +539,7 @@ void LinkingHtmlWindow::OnLinkClicked(const wxHtmlLinkInfo& link)
 
    if( href.StartsWith( wxT("innerlink:help:")))
    {
-      HelpSystem::ShowHelp(this, href.Mid( 15 ), true );
+      HelpSystem::ShowHelp(this, ManualPageID{ href.Mid( 15 ) }, true );
       return;
    }
    else if( href.StartsWith(wxT("innerlink:")) )

--- a/src/widgets/HelpSystem.h
+++ b/src/widgets/HelpSystem.h
@@ -88,7 +88,7 @@ public:
    /// @param bModal Whether the resulting dialogue should be modal or not.
    /// Default is modeless dialogue
    static void ShowHelp(wxWindow *parent,
-                     const wxString &PageName,
+                     const ManualPageID &PageName,
                      bool bModal = false);
 
    /// Hostname (domain name including subdomain) of the server on which the

--- a/src/widgets/HelpSystem.h
+++ b/src/widgets/HelpSystem.h
@@ -110,10 +110,6 @@ public:
    /// Must both start and end with '/' characters.
    static const wxString LocalHelpManDir;
 
-   /// The string which is appended to the development manual page name in order
-   /// obtain the file name in the local and release web copies of the manual
-   static const wxString ReleaseSuffix;
-
 };
 
 class ShuttleGui;

--- a/src/widgets/HelpSystem.h
+++ b/src/widgets/HelpSystem.h
@@ -25,6 +25,7 @@
 
 #include <wx/defs.h>
 #include "wxPanelWrapper.h" // to inherit
+#include "../HelpText.h"
 
 class AudacityProject;
 
@@ -62,21 +63,25 @@ public:
    /// OR else links to the internet. Generally using this outside this class
    /// is depreciated in favour of the "smarter" overload below, unless there
    /// is a good reason for using this form.
+   /// @param parent Parent window for the dialog
    /// @param localFileName Name and path of the file on the local machine
    /// file system to be opened. file.name#anchor syntax is allowed, and therefore
    /// file names containing a '#' are not (on any platform).
+   /// @param remoteURL use instead of file if nonempty, and user preferences specify remote,
+   /// or localFileName is invalid
    /// @param bModal Whether the resulting dialogue should be modal or not.
    /// Default is modeless dialogue
    /// @param alwaysDefaultBrowser Force use of default web browser.
    /// Default allows built in browser for local files.
    static void ShowHelp(wxWindow *parent,
-                     const wxString &localFileName,
-                     const wxString &remoteURL,
+                     const FilePath &localFileName,
+                     const URLString &remoteURL,
                      bool bModal = false,
                      bool alwaysDefaultBrowser = false);
 
    /// Displays a page from the Audacity manual  in your browser, if
    /// it's available locally, OR else links to the internet.
+   /// @param parent Parent window for the dialog
    /// @param PageName The name of the manual page to display as it is in
    /// _development version_ of the manual (i.e. in MediaWiki), _not_ the
    /// converted file name used for offline and released manuals.
@@ -115,7 +120,7 @@ class ShuttleGui;
 
 #include "HtmlWindow.h" // to inherit
 
-AUDACITY_DLL_API void OpenInDefaultBrowser(const wxHtmlLinkInfo& link);
+AUDACITY_DLL_API void OpenInDefaultBrowser(const URLString& link);
 
 
 /// \brief An HtmlWindow that handles linked clicked - usually the

--- a/src/widgets/MultiDialog.cpp
+++ b/src/widgets/MultiDialog.cpp
@@ -145,7 +145,7 @@ MultiDialog::MultiDialog(wxWindow * pParent,
             auto pButton = S.Id(wxID_OK)
                .AddButton(XXO("OK"), wxALIGN_CENTER, !log);
 
-            if (!mHelpPage.IsEmpty()) {
+            if (!mHelpPage.empty()) {
                auto pHelpBtn = S.Id(wxID_HELP)
                   .AddBitmapButton(theTheme.Bitmap(bmpHelpIcon), wxALIGN_CENTER, false);
                pHelpBtn->SetToolTip(XO("Help").Translation());

--- a/src/widgets/MultiDialog.cpp
+++ b/src/widgets/MultiDialog.cpp
@@ -59,7 +59,7 @@ private:
    void OnHelp(wxCommandEvent& event);
 
    wxRadioBox* mRadioBox;
-   wxString mHelpPage;
+   ManualPageID mHelpPage;
 
    DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
Resolves: part of #1059

Make some changes so the type wxString will not be mentioned in the Basic UI header file.

Introduces some proper type distinctions, for URLs and for manual page anchors, with new string wrapper types generated by the class template TaggedIdentifier.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
