### PR TITLE
Fix uninitialised variables

### DIFF
--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -171,8 +171,8 @@ private:
       field(sel0, double);
       field(sel1, double);
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
-      field(selLow, double);
-      field(selHigh, double);
+      field(selLow, double) = SelectedRegion::UndefinedFrequency;
+      field(selHigh, double) = SelectedRegion::UndefinedFrequency;
 #endif
       field(rate, double);
       field(snapto, bool);


### PR DESCRIPTION
When importing an AUP project, selLow and selHigh may not be defined
in the project. If not defined, this causes an error on initialising
Nyquist. See: https://forum.audacityteam.org/viewtopic.php?f=48&t=118940

Resolves: https://github.com/audacity/audacity/issues/1217

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
