### PR TITLE
Effect not dependent on WaveTrackView

### DIFF
--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -40,8 +40,6 @@
 #include "../WaveTrack.h"
 #include "../wxFileNameWrapper.h"
 #include "../widgets/ProgressDialog.h"
-#include "../tracks/playabletrack/wavetrack/ui/WaveTrackView.h"
-#include "../tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.h"
 #include "../widgets/NumericTextCtrl.h"
 #include "../widgets/AudacityMessageBox.h"
 #include "../widgets/ErrorDialog.h"
@@ -2387,8 +2385,6 @@ void Effect::Preview(bool dryOnly)
 
       mixLeft->Offset(-mixLeft->GetStartTime());
       mixLeft->SetSelected(true);
-      WaveTrackView::Get( *mixLeft )
-         .SetDisplay(WaveTrackViewConstants::NoDisplay);
       auto pLeft = mTracks->Add( mixLeft );
       Track *pRight{};
       if (mixRight) {
@@ -2403,8 +2399,6 @@ void Effect::Preview(bool dryOnly)
          if (src->GetSelected() || mPreviewWithNotSelected) {
             auto dest = src->Copy(mT0, t1);
             dest->SetSelected(src->GetSelected());
-            WaveTrackView::Get( *static_cast<WaveTrack*>(dest.get()) )
-               .SetDisplay(WaveTrackViewConstants::NoDisplay);
             mTracks->Add( dest );
          }
       }

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -570,10 +570,15 @@ bool NyquistEffect::Init()
       for ( auto t :
                TrackList::Get( *project ).Selected< const WaveTrack >() ) {
          const auto displays = WaveTrackView::Get(*t).GetDisplays();
-         if (displays.end() != std::find(
-            displays.begin(), displays.end(),
-            WaveTrackSubView::Type{ WaveTrackViewConstants::Spectrum, {} }))
-            hasSpectral = true;
+         // Find() not Get() to avoid creation-on-demand of views in case we are
+         // only previewing
+         auto pView = WaveTrackView::Find( t );
+         if ( pView ) {
+            if (displays.end() != std::find(
+               displays.begin(), displays.end(),
+               WaveTrackSubView::Type{ WaveTrackViewConstants::Spectrum, {} }))
+               hasSpectral = true;
+         }
          if ( hasSpectral &&
              (t->GetSpectrogramSettings().SpectralSelectionEnabled())) {
             bAllowSpectralEditing = true;
@@ -1151,22 +1156,27 @@ bool NyquistEffect::ProcessOne()
          [&](const WaveTrack *wt) {
             type = wxT("wave");
             spectralEditp = mCurTrack[0]->GetSpectrogramSettings().SpectralSelectionEnabled()? wxT("T") : wxT("NIL");
-            auto displays = WaveTrackView::Get( *wt ).GetDisplays();
-            auto format = [&]( decltype(displays[0]) display ) {
-               // Get the English name of the view type, without menu codes,
-               // as a string that Lisp can examine
-               return wxString::Format( wxT("\"%s\""),
-                  display.name.Stripped().Debug() );
-            };
-            if (displays.empty())
-               view = wxT("NIL");
-            else if (displays.size() == 1)
-               view = format( displays[0] );
-            else {
-               view = wxT("(list");
-               for ( auto display : displays )
-                  view += wxString(wxT(" ")) + format( display );
-               view += wxT(")");
+            view = wxT("NIL");
+            // Find() not Get() to avoid creation-on-demand of views in case we are
+            // only previewing
+            if ( const auto pView = WaveTrackView::Find( wt ) ) {
+               auto displays = WaveTrackView::Get( *wt ).GetDisplays();
+               auto format = [&]( decltype(displays[0]) display ) {
+                  // Get the English name of the view type, without menu codes,
+                  // as a string that Lisp can examine
+                  return wxString::Format( wxT("\"%s\""),
+                     display.name.Stripped().Debug() );
+               };
+               if (displays.empty())
+                  ;
+               else if (displays.size() == 1)
+                  view = format( displays[0] );
+               else {
+                  view = wxT("(list");
+                  for ( auto display : displays )
+                     view += wxString(wxT(" ")) + format( display );
+                  view += wxT(")");
+               }
             }
          },
 #if defined(USE_MIDI)

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -778,6 +778,16 @@ const WaveTrackView &WaveTrackView::Get( const WaveTrack &track )
    return Get( const_cast<WaveTrack&>( track ) );
 }
 
+WaveTrackView *WaveTrackView::Find( WaveTrack *pTrack )
+{
+   return static_cast< WaveTrackView* >( TrackView::Find( pTrack ) );
+}
+
+const WaveTrackView *WaveTrackView::Find( const WaveTrack *pTrack )
+{
+   return Find( const_cast<WaveTrack*>( pTrack ) );
+}
+
 WaveTrackView::WaveTrackView( const std::shared_ptr<Track> &pTrack )
    : CommonTrackView{ pTrack }
 {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
@@ -81,6 +81,8 @@ public:
 
    static WaveTrackView &Get( WaveTrack &track );
    static const WaveTrackView &Get( const WaveTrack &track );
+   static WaveTrackView *Find( WaveTrack *pTrack );
+   static const WaveTrackView *Find( const WaveTrack *pTrack );
 
    explicit
    WaveTrackView( const std::shared_ptr<Track> &pTrack );

--- a/src/tracks/ui/TrackView.cpp
+++ b/src/tracks/ui/TrackView.cpp
@@ -74,6 +74,23 @@ const TrackView &TrackView::Get( const Track &track )
    return Get( const_cast< Track& >( track ) );
 }
 
+TrackView *TrackView::Find( Track *pTrack )
+{
+   if (!pTrack)
+      return nullptr;
+   auto &track = *pTrack;
+
+   auto pView = std::static_pointer_cast<TrackView>( track.GetTrackView() );
+   // do not create on demand if it is null
+
+   return pView.get();
+}
+
+const TrackView *TrackView::Find( const Track *pTrack )
+{
+   return Find( const_cast< Track* >( pTrack ) );
+}
+
 void TrackView::SetMinimized(bool isMinimized)
 {
    // Do special changes appropriate to subclass

--- a/src/tracks/ui/TrackView.h
+++ b/src/tracks/ui/TrackView.h
@@ -45,6 +45,8 @@ public:
 
    static TrackView &Get( Track & );
    static const TrackView &Get( const Track & );
+   static TrackView *Find( Track * );
+   static const TrackView *Find( const Track * );
 
    bool GetMinimized() const { return mMinimized; }
    void SetMinimized( bool minimized );


### PR DESCRIPTION
Part of #1179

@lllucius has provided a prototype implementation of stackable real-time effects.  But that implementation creates a large dependency cycle of 41 files.  That would interfere with the extraction of certain libraries.

This dependency-breaking change, cherry-picked from my big experimental branch, would reduce the new cycle to 29.  That's an improvement, but more cycle-breaking work will remain.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
