### PR TITLE
Sequence of AudioIO and NetworkManager shutdowns fixes crash at exit

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -2236,16 +2236,16 @@ int AudacityApp::OnExit()
 
    DeinitFFT();
 
+#ifdef HAS_NETWORKING
+   audacity::network_manager::NetworkManager::GetInstance().Terminate();
+#endif
+
    AudioIO::Deinit();
 
    MenuTable::DestroyRegistry();
 
    // Terminate the PluginManager (must be done before deleting the locale)
    PluginManager::Get().Terminate();
-
-#ifdef HAS_NETWORKING
-   audacity::network_manager::NetworkManager::GetInstance().Terminate();
-#endif
 
    return 0;
 }


### PR DESCRIPTION
Resolves: #1298

Stack trace showed main thread was shutting down network manager, which was waiting to join a response thread, which was executing the lambda in UpdateManager, which was using the global AudioIO object -- which was destroyed before that, at least on the main thread.

This is a simple fix: destroy AudioIO after that, not before.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
