### PR TITLE
Fixes writability check for the macro output directory

### DIFF
--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -418,8 +418,7 @@ bool DirectoriesPrefs::Validate()
    }
    else {
       /* If the directory already exists, make sure it is writable */
-      if (!FileNames::WritableLocationCheck(mTempText->GetValue()) ||
-          !FileNames::WritableLocationCheck(mMacrosText->GetValue()))
+      if (!FileNames::WritableLocationCheck(mTempText->GetValue()))
       {
           return false;
       }
@@ -446,6 +445,19 @@ bool DirectoriesPrefs::Validate()
 "Changes to temporary directory will not take effect until Audacity is restarted"),
          XO("Temp Directory Update"),
          wxOK | wxCENTRE | wxICON_INFORMATION);
+   }
+
+   const wxString macroPathString = mMacrosText->GetValue();
+
+   if (!macroPathString.empty())
+   {
+      const wxFileName macroPath { macroPathString };
+
+      if (macroPath.DirExists())
+      {
+         if (!FileNames::WritableLocationCheck(macroPathString))
+            return false;
+      }
    }
 
    return true;


### PR DESCRIPTION
The check for macro directory now only happens if directory is selected and exists,

Resolves: #1305
*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
