### PR TITLE
Fix "Scriptables" commands, which broke at 02b6153...

### DIFF
--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1550,6 +1550,11 @@ ComponentInterface *PluginManager::GetInstance(const PluginID & ID)
    }
 }
 
+PluginID PluginManager::GetID(ModuleInterface *module)
+{
+   return ModuleManager::GetID(module);
+}
+
 PluginID PluginManager::GetID(ComponentInterface *command)
 {
    return wxString::Format(wxT("%s_%s_%s_%s_%s"),

--- a/src/PluginManager.h
+++ b/src/PluginManager.h
@@ -236,6 +236,7 @@ public:
 
    static PluginManager & Get();
 
+   static PluginID GetID(ModuleInterface *module);
    static PluginID GetID(ComponentInterface *command);
    static PluginID GetID(EffectDefinitionInterface *effect);
 


### PR DESCRIPTION
... Problem was the loss of an override of PluginManager::GetID() for a more
specific pointer type.

Resolves: #1294
*(short description of the changes and the motivation to make the changes)*

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
