### PR TITLE
Export Multiple substitutes default metadata for user-entered metadata

### DIFF
--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -835,7 +835,6 @@ ProgressResult ExportMultipleDialog::ExportMultipleByLabel(bool byName,
          /* do the metadata for this file */
          // copy project metadata to start with
          setting.filetags = Tags::Get( *mProject );
-         setting.filetags.LoadDefaults();
          if (exportSettings.size()) {
             setting.filetags = exportSettings.back().filetags;
          }
@@ -979,7 +978,6 @@ ProgressResult ExportMultipleDialog::ExportMultipleByTrack(bool byName,
          /* do the metadata for this file */
          // copy project metadata to start with
          setting.filetags = Tags::Get( *mProject );
-         setting.filetags.LoadDefaults();
          if (exportSettings.size()) {
             setting.filetags = exportSettings.back().filetags;
          }


### PR DESCRIPTION
Resolves: https://bugzilla.audacityteam.org/show_bug.cgi?id=2750

Remove the setting.file tags.LoadDefaults(); to avoid being filled up with the Default Metadata by removing the current ones

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
