### PR TITLE
Fix typo in pipeclient.py

### DIFF
--- a/scripts/piped-work/pipeclient.py
+++ b/scripts/piped-work/pipeclient.py
@@ -272,10 +272,9 @@ def main():
     while True:
         reply = ''
         if sys.version_info[0] < 3:
-            message = input("\nEnter command or 'Q' to quit: ")
+            message = raw_input("\nEnter command or 'Q' to quit: ")
         else:
-            message = input(
-                "\nEnter command or 'Q' to quit: ")
+            message = input("\nEnter command or 'Q' to quit: ")
         start = time.time()
         if message.upper() == 'Q':
             sys.exit(0)


### PR DESCRIPTION
Typo slipped in with commit d31db975ee

Resolves: error in pipeclient.py

Python 2 should use "raw_input"


- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
