### PR TITLE
Shift+Drag of clips between tracks was never allowed up to 2.4.2...

### DIFF
--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -601,6 +601,10 @@ namespace {
       TrackList &trackList, Track &capturedTrack, Track &track,
       ClipMoveState &state)
    {
+      if (state.shifters.empty())
+         // Shift + Dragging hasn't yet supported vertical movement
+         return false;
+
       // Accumulate new pairs for the correspondence, and merge them
       // into the given correspondence only on success
       Correspondence newPairs;


### PR DESCRIPTION
... and in 3.0.0 started crashing instead.  Just disallow it again, no
functionality lost.

Resolves: #1329

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
