### PR TITLE
For GTK builds - use wxStaticText instead of wxHyperlinkCtrl.

### DIFF
--- a/src/ui/AccessibleLinksFormatter.cpp
+++ b/src/ui/AccessibleLinksFormatter.cpp
@@ -15,8 +15,11 @@
 #include <unordered_map>
 #include <algorithm>
 
+#ifndef __WXGTK__
 #include <wx/hyperlink.h>
-
+#else
+#include <wx/stattext.h>
+#endif
 
 namespace
 {    
@@ -108,7 +111,7 @@ void AccessibleLinksFormatter::Populate(ShuttleGui& S) const
             }
 
             // Add hyperlink
-
+#ifndef __WXGTK__
             wxHyperlinkCtrl* hyperlink = safenew wxHyperlinkCtrl(
                S.GetParent(), wxID_ANY, argument->Value.Translation(),
                argument->TargetURL);
@@ -122,7 +125,18 @@ void AccessibleLinksFormatter::Populate(ShuttleGui& S) const
             }
 
             S.AddWindow(hyperlink, wxALIGN_TOP | wxALIGN_LEFT);
+#else
+            wxStaticText* hyperlink = S.AddVariableText(argument->Value);
 
+            hyperlink->SetFont(hyperlink->GetFont().Underlined());
+            hyperlink->SetCursor(wxCURSOR_HAND);
+            hyperlink->Bind(wxEVT_LEFT_UP, [handler = argument->Handler, url = argument->TargetURL](wxEvent&) {
+                if (handler)
+                    handler();
+                else if (!url.empty())
+                    wxLaunchDefaultBrowser(url);
+            });
+#endif
             // Update the currentPostion to the first symbol after the
             // Placeholder
 

--- a/src/update/UpdateNoticeDialog.cpp
+++ b/src/update/UpdateNoticeDialog.cpp
@@ -39,6 +39,7 @@ static const auto thirdParagraph =
 
 BEGIN_EVENT_TABLE(UpdateNoticeDialog, wxDialogWrapper)
     EVT_BUTTON(wxID_OK, UpdateNoticeDialog::OnOk)
+    EVT_SIZE(UpdateNoticeDialog::OnSize)
 END_EVENT_TABLE()
 
 IMPLEMENT_CLASS(UpdateNoticeDialog, wxDialogWrapper)
@@ -55,7 +56,7 @@ UpdateNoticeDialog::UpdateNoticeDialog(wxWindow* parent)
    {
       S.AddSpace(0, 16);
 
-      S.StartHorizontalLay();
+      S.StartHorizontalLay(wxEXPAND, 0);
       {
          S.AddSpace(24, 0);
 
@@ -104,7 +105,7 @@ UpdateNoticeDialog::UpdateNoticeDialog(wxWindow* parent)
       }
       S.EndHorizontalLay();
 
-      S.StartHorizontalLay(wxEXPAND, 0);
+      S.StartHorizontalLay(wxEXPAND);
       {
          S.AddSpace(1, 0, 1);
 
@@ -117,12 +118,19 @@ UpdateNoticeDialog::UpdateNoticeDialog(wxWindow* parent)
 
    S.EndVerticalLay();
 
-   Layout();
    Fit();
+   Layout();
+
    Center();
 }
 
 void UpdateNoticeDialog::OnOk(wxCommandEvent&)
 {
    EndModal(wxOK);
+}
+
+void UpdateNoticeDialog::OnSize(wxSizeEvent&)
+{
+    Fit();
+    Layout();
 }

--- a/src/update/UpdateNoticeDialog.h
+++ b/src/update/UpdateNoticeDialog.h
@@ -24,7 +24,8 @@ public:
     explicit UpdateNoticeDialog (wxWindow* parent);
 
  private:
-    void OnOk (wxCommandEvent& event);
+    void OnOk (wxCommandEvent&);
+    void OnSize(wxSizeEvent&);
 
     DECLARE_EVENT_TABLE ()
 };


### PR DESCRIPTION
It turns out, that wxHyperlinkCtrl has a dramatically different size with the GTK backend. This commit makes the link to be only clickable using a mouse, but AFAIK accessibility is not implemented for the GTK backend anyway.

Resolves the report from Steve:

![image](https://user-images.githubusercontent.com/2660628/126675444-60280ee6-a176-46f2-9e74-c303335218b0.png)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
