### PR TITLE
Add a wrapper that retries `hdiutil` with progressive timeout

### DIFF
--- a/cmake-proxies/cmake-modules/Package.cmake
+++ b/cmake-proxies/cmake-modules/Package.cmake
@@ -49,6 +49,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 elseif( CMAKE_SYSTEM_NAME STREQUAL "Darwin" )
    set( CPACK_GENERATOR DragNDrop )
 
+   set( CPACK_COMMAND_HDIUTIL "${CMAKE_SOURCE_DIR}/scripts/build/macOS/hdiutil_wrapper.sh" )
+
    set( CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/mac/Resources/Audacity-DMG-background.png")
    set( CPACK_DMG_DS_STORE_SETUP_SCRIPT "${CMAKE_SOURCE_DIR}/scripts/build/macOS/DMGSetup.scpt")
 

--- a/scripts/build/macOS/hdiutil_wrapper.sh
+++ b/scripts/build/macOS/hdiutil_wrapper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# A special wrapper for hdiutil, that retries hdiutil call with
+# the progressive timeout. 
+# This seems to be the common workaround for the CPack problem
+
+counter=0
+max_retries=10
+
+hdiutil $@
+
+while [ $? -ne 0 ]; do
+    ((counter++))
+
+    if [[ $counter -eq $max_retries ]]; then
+        exit 1
+    fi
+
+    sleep $counter
+    hdiutil $@
+done


### PR DESCRIPTION
This seems to be a common workaround for CPack issue on macOS. 

Script has 10 attempts and in the worst case, it will take 55 seconds for it to fail.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
