### PR TITLE
Block on setting the Directory Preference

### DIFF
--- a/libraries/lib-files/FileNames.cpp
+++ b/libraries/lib-files/FileNames.cpp
@@ -649,7 +649,8 @@ void FileNames::FindFilesInPathList(const wxString & pattern,
    }
 }
 
-bool FileNames::WritableLocationCheck(const FilePath& path)
+bool FileNames::WritableLocationCheck(const FilePath& path,
+                                    const TranslatableString & message)
 {
     bool status = wxFileName::IsDirWritable(path);
 
@@ -657,7 +658,8 @@ bool FileNames::WritableLocationCheck(const FilePath& path)
     {
         using namespace BasicUI;
         ShowMessageBox(
-            XO("Directory %s does not have write permissions").Format(path),
+            message +
+            XO("\n%s does not have write permissions.").Format(path),
             MessageBoxOptions{}
                 .Caption(XO("Error"))
                 .IconStyle(Icon::Error)

--- a/libraries/lib-files/FileNames.h
+++ b/libraries/lib-files/FileNames.h
@@ -204,7 +204,9 @@ namespace FileNames
 
 
    //! Check location on writable access and return true if checked successfully.
-   FILES_API bool WritableLocationCheck(const FilePath& path);
+   // message is the explanation that is to be displayed to the user if the location is unwritable.
+   FILES_API bool WritableLocationCheck(const FilePath& path,
+                                       const TranslatableString & message);
 
    // wxString compare function for sorting case, which is needed to load correctly.
    FILES_API int CompareNoCase(const wxString& first, const wxString& second);

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -66,7 +66,7 @@ void DoExport(AudacityProject &project, const FileExtension &format)
       // or we use the default documents folder - just as for exports.
       FilePath pathName = FileNames::FindDefaultPath(FileNames::Operation::MacrosOut);
 
-      if (!FileNames::WritableLocationCheck(pathName))
+      if (!FileNames::WritableLocationCheck(pathName, XO("Cannot proceed to export.")))
       {
           return;
       }

--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -296,7 +296,8 @@ void DirectoriesPrefs::OnTempBrowse(wxCommandEvent &evt)
          return;
       }
 
-      if (!FileNames::WritableLocationCheck(dlog.GetPath()))
+      //Checks if the temporary directory has write permissions(via Browse Button)
+      if (!FileNames::WritableLocationCheck(dlog.GetPath(), XO("Cannot set the preference.")))
       {
          return;
       }
@@ -377,12 +378,44 @@ void DirectoriesPrefs::OnBrowse(wxCommandEvent &evt)
       }
    }
 
-   if (!FileNames::WritableLocationCheck(dlog.GetPath()))
+   //Checks if the location for Open,Save.Import,Export and Macro Output has write permissions(Browse Buttons)
+   if (!FileNames::WritableLocationCheck(dlog.GetPath(), XO("Cannot set the preference.")))
    {
       return;
    }
 
    tc->SetValue(dlog.GetPath());
+}
+
+// Offers the user a dialog with an option to create a directory if it does not exist.
+// message is the explanation given to the user to show for which case is the directory creation is prompted.
+bool CreateDirectory(const wxString pathString, const TranslatableString & message) {
+   const wxFileName path { pathString };
+   int ans = AudacityMessageBox(
+      message +
+      XO("\nDirectory %s does not exist. Create it?")
+         .Format( pathString ),
+      XO("Warning"),
+      wxYES_NO | wxCENTRE | wxICON_EXCLAMATION);
+
+   if (ans != wxYES) {
+      return false;
+   }
+
+   if (!path.Mkdir(0755, wxPATH_MKDIR_FULL)) {
+      /* wxWidgets throws up a decent looking dialog */
+      using namespace BasicUI;
+        ShowMessageBox(
+            XO("Directory creation failed.") + 
+            XO("\n%s").Format(message),
+            MessageBoxOptions{}
+                .Caption(XO("Error"))
+                .IconStyle(Icon::Error)
+                .ButtonStyle(Button::Ok)
+        );
+      return false;
+   }
+   return true;
 }
 
 bool DirectoriesPrefs::Validate()
@@ -401,26 +434,15 @@ bool DirectoriesPrefs::Validate()
    }
 
    if (!Temp.DirExists()) {
-      int ans = AudacityMessageBox(
-         XO("Directory %s does not exist. Create it?")
-            .Format( path ),
-         XO("New Temporary Directory"),
-         wxYES_NO | wxCENTRE | wxICON_EXCLAMATION);
-
-      if (ans != wxYES) {
+      if(CreateDirectory(path, XO("'Temporary Directory' cannot be set.")) == false)
          return false;
-      }
-
-      if (!Temp.Mkdir(0755, wxPATH_MKDIR_FULL)) {
-         /* wxWidgets throws up a decent looking dialog */
-         return false;
-      }
    }
    else {
       /* If the directory already exists, make sure it is writable */
-      if (!FileNames::WritableLocationCheck(mTempText->GetValue()))
+      if (!FileNames::WritableLocationCheck(mTempText->GetValue(), 
+                                          XO("'Temporary files' directory cannot be set.")))
       {
-          return false;
+         return false;
       }
       wxLogNull logNo;
       Temp.AppendDir(wxT("canicreate"));
@@ -447,18 +469,42 @@ bool DirectoriesPrefs::Validate()
          wxOK | wxCENTRE | wxICON_INFORMATION);
    }
 
+   const wxString openPathString = mOpenText->GetValue();
+   const wxString savePathString = mSaveText->GetValue();
+   const wxString importPathString = mImportText->GetValue();
+   const wxString exportPathString = mExportText->GetValue();
    const wxString macroPathString = mMacrosText->GetValue();
+   //error messages if the directories could not be set.
+   const std::initializer_list<TranslatableString> messagesPreference{
+      XO("'Open' directory cannot be set.") ,
+      XO("'Save' directory cannot be set.") ,
+      XO("'Import' directory cannot be set.") ,
+      XO("'Export' directory cannot be set.") ,
+      XO("'Macro Output' directory cannot be set.") ,
+   };
 
-   if (!macroPathString.empty())
-   {
-      const wxFileName macroPath { macroPathString };
-
-      if (macroPath.DirExists())
-      {
-         if (!FileNames::WritableLocationCheck(macroPathString))
-            return false;
+   //flag for checking if at least one directory write protected 
+   //will not be 0 if any of the paths are not writable
+   int flag = 0;
+   //id for indexing error messages to the initializer_list.
+   int id = 0;
+   //Checks if the location for Open,Save,Import,Export and Macro Output has write permissions(When OK is clicked)
+   for (auto &string : { openPathString, savePathString, importPathString, exportPathString, macroPathString} ) {
+      const wxFileName currentPath { string };
+      const auto & message = *(messagesPreference.begin() + id);
+      if(!string.empty()){
+         if (currentPath.DirExists()){
+            if(!FileNames::WritableLocationCheck(string, message))
+               flag++;
+         }
+         else {
+            return CreateDirectory(string, message);
+         }
       }
+      id++;
    }
+   if (flag != 0)
+      return false;
 
    return true;
 }


### PR DESCRIPTION
Resolves: https://bugzilla.audacityteam.org/show_bug.cgi?id=2740

Blocks all the possibilities of setting the Directory Preference to locations without write permissions via the Browse button or manually typing as pressing the OK button

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
