### PR TITLE
Construction of PrefsListener "hub" later than file-scope statics.

### DIFF
--- a/libraries/lib-preferences/Prefs.cpp
+++ b/libraries/lib-preferences/Prefs.cpp
@@ -89,20 +89,24 @@ struct PrefsListener::Impl : wxEvtHandler
    PrefsListener &mOwner;
 };
 
-static wxEvtHandler hub;
+static wxEvtHandler &hub()
+{
+   static wxEvtHandler theHub;
+   return theHub;
+}
 
 void PrefsListener::Broadcast(int id)
 {
    BasicUI::CallAfter([id]{
       MyEvent event{ id };
-      hub.ProcessEvent(event);
+      hub().ProcessEvent(event);
    });
 }
 
 PrefsListener::Impl::Impl( PrefsListener &owner )
    : mOwner{ owner }
 {
-   hub.Bind(EVT_PREFS_UPDATE, &PrefsListener::Impl::OnEvent, this);
+   hub().Bind(EVT_PREFS_UPDATE, &PrefsListener::Impl::OnEvent, this);
 }
 
 PrefsListener::Impl::~Impl()


### PR DESCRIPTION
Resolves:  #1369

Changing of theme didn't work promptly on Windows after commit a2f109de2e43890217c57ea14d3cb8a45463521c

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
