### PR TITLE
Issue 1389: Autoduck can miss sections below threshold

### DIFF
--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -301,7 +301,7 @@ bool EffectAutoDuck::Process()
    threshold = threshold * threshold * kRMSWindowSize;
 
    int rmsPos = 0;
-   float rmsSum = 0;
+   double rmsSum = 0;
    // to make the progress bar appear more natural, we first look for all
    // duck regions and apply them all at once afterwards
    std::vector<AutoDuckRegion> regions;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1389

Problem: the running average rmsSum can be higher than it should be due to rounding errors. This can lead to sections of the audio which should be below the threshold, being measured to be above the threshold.

Fix: make rmsSum a double, rather than a float, to greatly reduce rounding errors.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
