### PR TITLE
Time Shift left/right commands do not work on the right hand channel of a stereo track when clips are not aligned

### DIFF
--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -643,7 +643,7 @@ double DoClipMove( AudacityProject &project, Track *track,
       // Find the first channel that has a clip at time t0
       auto hitTestResult = TrackShifter::HitTestResult::Track;
       for (auto channel : TrackList::Channels(track) ) {
-         uShifter = MakeTrackShifter::Call( *track, project );
+         uShifter = MakeTrackShifter::Call( *channel, project );
          if ( (hitTestResult = uShifter->HitTest( t0, viewInfo )) ==
              TrackShifter::HitTestResult::Miss )
             uShifter.reset();
@@ -657,7 +657,7 @@ double DoClipMove( AudacityProject &project, Track *track,
       auto desiredT0 = viewInfo.OffsetTimeByPixels( t0, ( right ? 1 : -1 ) );
       auto desiredSlideAmount = pShifter->HintOffsetLarger( desiredT0 - t0 );
 
-      state.Init( project, *track, hitTestResult, std::move( uShifter ),
+      state.Init( project, pShifter->GetTrack(), hitTestResult, std::move( uShifter ),
          t0, viewInfo, trackList, syncLocked );
 
       auto hSlideAmount = state.DoSlideHorizontal( desiredSlideAmount );


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1465

Time Shift left/right commands do not work on the right hand channel of a stereo track when clips are not aligned.
This has been a problem since 3.3.0. Between 2.3.1 and 2.4.2 they moved a clip in the right hand channel more than they should, so moving the clip more than the cursor.

Problems and fixes, both in DoClipMove():
1. The reason for the commands not working at all was the track rather than the channel was been passed in the call MakeTrackShifter::Call( *channel, project )
2. The reason for the clip being moved more than it should, was the left hand channel always being passed as the captured track in the call:
state.Init( project, pShifter->GetTrack(), hitTestResult, std::move( uShifter ),
         t0, viewInfo, trackList, syncLocked )


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
