### PR TITLE
Stereo wave track channel resizing

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.h
@@ -19,6 +19,7 @@ class AUDACITY_DLL_API WaveTrackAffordanceControls : public CommonTrackCell
 {
     std::weak_ptr<WaveClip> mFocusClip;
     std::weak_ptr<AffordanceHandle> mAffordanceHandle;
+    std::weak_ptr<UIHandle> mResizeHandle;
 public:
     WaveTrackAffordanceControls(const std::shared_ptr<Track>& pTrack);
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
@@ -54,6 +54,7 @@ protected:
 
 private:
    std::weak_ptr<UIHandle> mCloseHandle;
+   std::weak_ptr<UIHandle> mResizeHandle;
    std::weak_ptr<UIHandle> mAdjustHandle;
    std::weak_ptr<UIHandle> mRearrangeHandle;
    std::weak_ptr<CutlineHandle> mCutlineHandle;
@@ -79,6 +80,8 @@ class AUDACITY_DLL_API WaveTrackView final
    WaveTrackView &operator=( const WaveTrackView& ) = delete;
 
 public:
+   static constexpr int kChannelSeparatorThickness{ 8 };
+
    using Display = WaveTrackViewConstants::Display;
 
    static WaveTrackView &Get( WaveTrack &track );
@@ -130,6 +133,15 @@ public:
 
    std::weak_ptr<WaveClip> GetSelectedClip();
 
+   // Returns a visible subset of subviews, sorted in the same 
+   // order as they are supposed to be displayed
+   
+
+   // Get the visible sub-views,
+   // if rect is provided then result will contain
+   // y coordinate for each subview within this rect
+   Refinement GetSubViews(const wxRect* rect = nullptr);
+
 private:
    void BuildSubViews() const;
    void DoSetDisplay(Display display, bool exclusive = true);
@@ -145,8 +157,7 @@ private:
       override;
 
    // TrackView implementation
-   // Get the visible sub-views with top y coordinates
-   Refinement GetSubViews( const wxRect &rect ) override;
+   Refinement GetSubViews(const wxRect& rect) override;
 
 protected:
    std::shared_ptr<CommonTrackCell> DoGetAffordanceControls() override;


### PR DESCRIPTION
Resolves: #1375 

Resizing area added to the WaveTrackView and WaveTrackAffordanceControl, making possible to have an enlarged resizing area with 1px distance between channels.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
