### PR TITLE
Allow building from the tarball without Git installed

### DIFF
--- a/.github/workflows/generate_source_tarball.yml
+++ b/.github/workflows/generate_source_tarball.yml
@@ -1,0 +1,56 @@
+name: Generate Source Tarball
+
+on:
+  push:
+  workflow_dispatch:
+    
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  Generate:
+    env:
+      CONAN_USER_HOME: "${{ github.workspace }}/conan-home/"
+      CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-home/short"
+      AUDACITY_CMAKE_GENERATOR: "Unix Makefiles"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Dependencies
+        run: |
+          exec bash "scripts/ci/dependencies.sh"
+
+      - name: Environment
+        run: |
+          source "scripts/ci/environment.sh"
+
+      - name: Cache for .conan
+        id: cache-conan
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-conan-modules
+        with:
+          path: ${{ env.CONAN_USER_HOME }}
+          key: host-3-${{ matrix.config.name }}-${{ hashFiles('cmake-proxies/CMakeLists.txt') }}
+          restore-keys: |
+            host-3-${{ matrix.config.name }}-
+
+      - name: Configure
+        run: |
+          exec bash "scripts/ci/configure.sh"
+
+      - name: Package
+        run: |
+          cmake --build build --target package_source
+    
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Audacity_Sources_${{ github.run_id }}_${{ env.GIT_HASH_SHORT }}
+          path: |
+            build/package/*
+            !build/package/_CPack_Packages
+          if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
    message(FATAL_ERROR "Audacity requires at least GCC 4.9")
 endif ()
 
+if( EXISTS "${CMAKE_SOURCE_DIR}/cmake-proxies/cmake-modules/Variables.cmake" )
+   include( "${CMAKE_SOURCE_DIR}/cmake-proxies/cmake-modules/Variables.cmake" )
+endif()
+
 # We only do alpha builds, beta builds, and release versions.
 # Most of the time we're in development, so AUDACITY_BUILD_LEVEL should be
 # defined to 0.
@@ -19,7 +23,9 @@ endif ()
 # still link to the alpha manual online.
 
 # Set this value to 0 for alpha, 1 for beta, 2 for release builds
-set( AUDACITY_BUILD_LEVEL 0 CACHE STRING "0 for alpha, 1 for beta, 2 for release builds" )
+if( NOT DEFINED AUDACITY_BUILD_LEVEL )
+   set( AUDACITY_BUILD_LEVEL 0 CACHE STRING "0 for alpha, 1 for beta, 2 for release builds" )
+endif()
 
 # The Audacity version
 # Increment as appropriate after release of a new version, and set back
@@ -99,10 +105,10 @@ endif()
 # Add our module path
 # CMAKE_BINARY_DIR is required for Conan to work
 set( AUDACITY_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake-proxies/cmake-modules")
-set( CMAKE_MODULE_PATH 
+set( CMAKE_MODULE_PATH
    ${AUDACITY_MODULE_PATH}
    ${CMAKE_BINARY_DIR}
-   ${CMAKE_MODULE_PATH} 
+   ${CMAKE_MODULE_PATH}
 )
 
 set( CMAKE_PREFIX_PATH
@@ -140,11 +146,11 @@ set_from_env(AUDACITY_ARCH_LABEL) # e.g. x86_64
 
 # Allow user to globally set the library preference
 cmd_option( ${_OPT}conan_enabled
-            "Use Conan package manager for 3d party dependencies" 
+            "Use Conan package manager for 3d party dependencies"
             On
 )
 
-cmd_option( ${_OPT}conan_allow_prebuilt_binaries 
+cmd_option( ${_OPT}conan_allow_prebuilt_binaries
             "Allow using the compiled dependencies from the cache or remotes"
             On
 )
@@ -162,7 +168,7 @@ cmd_option( ${_OPT}obey_system_dependencies
             Off
 )
 
-cmd_option( ${_OPT}has_networking 
+cmd_option( ${_OPT}has_networking
    "Build networking features into Audacity"
    Off)
 
@@ -240,7 +246,7 @@ message( STATUS )
 if( CMAKE_GENERATOR MATCHES "Visual Studio" )
    message( STATUS "  MSVC Version: ${MSVC_VERSION}" )
    message( STATUS "  MSVC Toolset: ${MSVC_TOOLSET_VERSION}" )
-   message( STATUS ) 
+   message( STATUS )
 elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
    if( CMAKE_GENERATOR MATCHES "Xcode" )
       message( STATUS "  Xcode Version: ${XCODE_VERSION}" )
@@ -275,6 +281,11 @@ if( GIT_FOUND )
       list( GET git_output 0 GIT_COMMIT_SHORT )
       list( GET git_output 1 GIT_COMMIT_LONG )
       list( GET git_output 2 GIT_COMMIT_TIME )
+
+      file(WRITE
+         "${CMAKE_BINARY_DIR}/Variables.cmake"
+         "set( AUDACITY_BUILD_LEVEL ${AUDACITY_BUILD_LEVEL} )\nset( AUDACITY_REV_LONG \"${GIT_COMMIT_LONG}\" )\nset( AUDACITY_REV_TIME \"${GIT_COMMIT_TIME}\" )\n"
+      )
    endif()
 endif()
 message( STATUS "  Current Commit: ${GIT_COMMIT_SHORT}" )

--- a/cmake-proxies/cmake-modules/CopySourceVariables.cmake
+++ b/cmake-proxies/cmake-modules/CopySourceVariables.cmake
@@ -1,0 +1,8 @@
+if( CPACK_SOURCE_INSTALLED_DIRECTORIES )
+  set( package_directory "${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/${CPACK_SOURCE_TOPLEVEL_TAG}/${CPACK_SOURCE_GENERATOR}/${CPACK_SOURCE_PACKAGE_FILE_NAME}" )
+  
+  file(
+    COPY "${CPACK_AUDACITY_BUILD_DIR}/Variables.cmake"
+    DESTINATION "${package_directory}/cmake-proxies/cmake-modules"
+  )
+endif()

--- a/cmake-proxies/cmake-modules/Package.cmake
+++ b/cmake-proxies/cmake-modules/Package.cmake
@@ -66,4 +66,20 @@ elseif( CMAKE_SYSTEM_NAME STREQUAL "Darwin" )
    endif()
 endif()
 
+if( CMAKE_GENERATOR MATCHES "Makefiles|Ninja" )
+   set( CPACK_SOURCE_GENERATOR "TGZ" )
+   set( CPACK_AUDACITY_BUILD_DIR "${CMAKE_BINARY_DIR}")
+
+   list( APPEND CPACK_PRE_BUILD_SCRIPTS "${CMAKE_SOURCE_DIR}/cmake-proxies/cmake-modules/CopySourceVariables.cmake" )
+
+   set(CPACK_SOURCE_IGNORE_FILES
+      "/.git"
+      "/.vscode"
+      "/.idea"
+      "/.*build.*"
+      "/conan-home"
+      "/\\\\.DS_Store"
+   )
+endif()
+
 include(CPack) # do this last

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -35,7 +35,7 @@ elif [[ "${AUDACITY_CMAKE_GENERATOR}" == Xcode* ]]; then
     )
 fi
 
-if [[ -n "${APPLE_CODESIGN_IDENTITY}" && "${OSTYPE}" == darwin* ]]; then
+if [[ -n "${APPLE_CODESIGN_IDENTITY-}" && "${OSTYPE}" == darwin* ]]; then
     cmake_args+=(
         -D APPLE_CODESIGN_IDENTITY="${APPLE_CODESIGN_IDENTITY}"
         -D audacity_perform_codesign=yes
@@ -48,7 +48,7 @@ if [[ -n "${APPLE_CODESIGN_IDENTITY}" && "${OSTYPE}" == darwin* ]]; then
             -D audacity_perform_notarization=yes
         )
     fi
-elif [[ -n "${WINDOWS_CERTIFICATE}" && "${OSTYPE}" == msys* ]]; then
+elif [[ -n "${WINDOWS_CERTIFICATE-}" && "${OSTYPE}" == msys* ]]; then
     # Windows certificate will be used from the environment
     cmake_args+=(
         -D audacity_perform_codesign=yes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,11 @@ def_vars()
 # Add a target that will provide the git revision info
 # whenever it changes.  (Must be done at build time, not
 # configuration time.)
-if( GIT_FOUND )
+if( DEFINED AUDACITY_REV_LONG AND DEFINED AUDACITY_REV_TIME )
+   file( WRITE "${_PRVDIR}/RevisionIdent.h"
+      "#define REV_LONG \"${AUDACITY_REV_LONG}\"\n#define REV_TIME \"${AUDACITY_REV_TIME}\"\n"
+   )
+elseif( GIT_FOUND )
    add_custom_target(
       version
       COMMAND
@@ -31,6 +35,10 @@ if( GIT_FOUND )
    )
 
    add_dependencies( ${TARGET} version )
+else()
+   # No Git installed and no version data is available.
+   # Generate an empty file and let AboutDialog do the rest
+   file( TOUCH "${_PRVDIR}/RevisionIdent.h" )
 endif()
 
 # Handle Audio Units option


### PR DESCRIPTION
Resolves #1463

This pull request solves the following problems:

* Tarballs on GitHub can be regenerated, changing the hash
* Building from the release tarball will create an "alpha" build
* Build will fail if there is not Git in PATH

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
