### PR TITLE
Context menus

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -425,7 +425,7 @@ public:
 
    unsigned DoContextMenu
       (const wxRect &rect,
-       wxWindow *pParent, wxPoint *pPosition, AudacityProject*) final override
+       wxWindow *pParent, const wxPoint *pPosition, AudacityProject*) final
    {
       (void)pParent;// Compiler food
       (void)rect;// Compiler food

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -460,6 +460,8 @@ public:
    }
 
 protected:
+   bool HandlesRightClick() override { return true; }
+
    Result Click
       (const TrackPanelMouseEvent &event, AudacityProject *) override
    {

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1710,7 +1710,7 @@ std::vector<wxRect> TrackPanel::FindRulerRects( const Track *target )
 TrackPanelCell *TrackPanel::GetFocusedCell()
 {
    auto pTrack = TrackFocus::Get( *GetProject() ).Get();
-   return pTrack ? &TrackView::Get( *pTrack ) : nullptr;
+   return pTrack ? &TrackView::Get( *pTrack ) : GetBackgroundCell().get();
 }
 
 void TrackPanel::SetFocusedCell()

--- a/src/TrackPanelCell.cpp
+++ b/src/TrackPanelCell.cpp
@@ -47,7 +47,7 @@ unsigned TrackPanelCell::HandleWheelRotation
 }
 
 unsigned TrackPanelCell::DoContextMenu
-   (const wxRect &, wxWindow*, wxPoint *, AudacityProject*)
+   (const wxRect &, wxWindow*, const wxPoint *, AudacityProject*)
 {
    return RefreshCode::RefreshNone;
 }

--- a/src/TrackPanelCell.h
+++ b/src/TrackPanelCell.h
@@ -109,7 +109,7 @@ public:
    // Default implementation does nothing
    virtual unsigned DoContextMenu
       (const wxRect &rect,
-       wxWindow *pParent, wxPoint *pPosition, AudacityProject *pProject);
+       wxWindow *pParent, const wxPoint *pPosition, AudacityProject *pProject);
 
    // Return value is a bitwise OR of RefreshCode values
    // Default skips the event and does nothing

--- a/src/UIHandle.cpp
+++ b/src/UIHandle.cpp
@@ -41,6 +41,11 @@ bool UIHandle::Escape(AudacityProject *)
    return false;
 }
 
+bool UIHandle::HandlesRightClick()
+{
+   return false;
+}
+
 bool UIHandle::StopsOnKeystroke()
 {
    return false;

--- a/src/UIHandle.h
+++ b/src/UIHandle.h
@@ -65,6 +65,11 @@ public:
    // Default does nothing and returns false
    virtual bool Escape(AudacityProject *pProject);
 
+   //! Whether the handle has any special right-button handling
+   /*! If not, then Click() will not be called for right click.
+       Default is always false */
+   virtual bool HandlesRightClick();
+
    // Assume hit test (implemented in other classes) was positive.
    // May return Cancelled, overriding the hit test decision and stopping drag.
    // Otherwise the framework will later call Release or Cancel after

--- a/src/commands/CommandContext.h
+++ b/src/commands/CommandContext.h
@@ -19,6 +19,18 @@ class wxEvent;
 class CommandOutputTargets;
 using CommandParameter = CommandID;
 
+class SelectedRegion;
+class Track;
+
+struct TemporarySelection {
+   TemporarySelection() = default;
+   TemporarySelection(const TemporarySelection&) = default;
+   TemporarySelection &operator= (const TemporarySelection&) = default;
+
+   SelectedRegion *pSelectedRegion = nullptr;
+   Track *pTrack = nullptr;
+};
+
 class AUDACITY_DLL_API CommandContext {
 public:
    CommandContext(
@@ -54,5 +66,8 @@ public:
    const wxEvent *pEvt;
    int index;
    CommandParameter parameter;
+
+   // This might depend on a point picked with a context menu
+   TemporarySelection temporarySelection;
 };
 #endif

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -1244,7 +1244,8 @@ Journal::RegisteredCommand sCommand{ JournalCode,
 ///with the command's flags.
 bool CommandManager::HandleCommandEntry(AudacityProject &project,
    const CommandListEntry * entry,
-   CommandFlag flags, bool alwaysEnabled, const wxEvent * evt)
+   CommandFlag flags, bool alwaysEnabled, const wxEvent * evt,
+   const CommandContext *pGivenContext)
 {
    if (!entry )
       return false;
@@ -1273,7 +1274,9 @@ bool CommandManager::HandleCommandEntry(AudacityProject &project,
 
    Journal::Output({ JournalCode, entry->name.GET() });
 
-   const CommandContext context{ project, evt, entry->index, entry->parameter };
+   CommandContext context{ project, evt, entry->index, entry->parameter };
+   if (pGivenContext)
+      context.temporarySelection = pGivenContext->temporarySelection;
    auto &handler = entry->finder(project);
    (handler.*(entry->callback))(context);
    mLastProcessId = 0;
@@ -1355,7 +1358,8 @@ CommandManager::HandleTextualCommand(const CommandID & Str,
             Str == entry->labelPrefix.Translation() )
          {
             return HandleCommandEntry(
-               context.project, entry.get(), flags, alwaysEnabled)
+               context.project, entry.get(), flags, alwaysEnabled,
+               nullptr, &context)
                ? CommandSuccess : CommandFailure;
          }
       }
@@ -1365,7 +1369,8 @@ CommandManager::HandleTextualCommand(const CommandID & Str,
          if( Str == entry->name )
          {
             return HandleCommandEntry(
-               context.project, entry.get(), flags, alwaysEnabled)
+               context.project, entry.get(), flags, alwaysEnabled,
+               nullptr, &context)
                ? CommandSuccess : CommandFailure;
          }
       }

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -820,13 +820,37 @@ CommandListEntry *CommandManager::NewIdentifier(const CommandID & nameIn,
    return entry;
 }
 
+wxString CommandManager::FormatLabelForMenu(
+   const CommandID &id, const TranslatableString *pLabel) const
+{
+   NormalizedKeyString keyStr;
+   if (auto iter = mCommandNameHash.find(id); iter != mCommandNameHash.end()) {
+      if (auto pEntry = iter->second) {
+         keyStr = pEntry->key;
+         if (!pLabel)
+            pLabel = &pEntry->label;
+      }
+   }
+   if (pLabel)
+      return FormatLabelForMenu(*pLabel, keyStr);
+   return {};
+}
+
 wxString CommandManager::FormatLabelForMenu(const CommandListEntry *entry) const
 {
-   auto label = entry->label.Translation();
-   if (!entry->key.empty())
+   return FormatLabelForMenu( entry->label, entry->key );
+}
+
+wxString CommandManager::FormatLabelForMenu(
+   const TranslatableString &translatableLabel,
+   const NormalizedKeyString &keyStr) const
+{
+   auto label = translatableLabel.Translation();
+   auto key = keyStr.GET();
+   if (!key.empty())
    {
       // using GET to compose menu item name for wxWidgets
-      label += wxT("\t") + entry->key.GET();
+      label += wxT("\t") + key;
    }
 
    return label;

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -312,7 +312,8 @@ private:
 
    bool HandleCommandEntry(AudacityProject &project,
       const CommandListEntry * entry, CommandFlag flags,
-      bool alwaysEnabled, const wxEvent * evt = NULL);
+      bool alwaysEnabled, const wxEvent * evt = nullptr,
+      const CommandContext *pGivenContext = nullptr );
 
    //
    // Modifying

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -335,8 +335,20 @@ public:
    wxMenu * CurrentMenu() const;
 
    void UpdateCheckmarks( AudacityProject &project );
+
+   //! Format a string appropriate for insertion in a menu
+   /*!
+    @param pLabel if not null, use this instead of the manager's
+    stored label
+    */
+   wxString FormatLabelForMenu(
+      const CommandID &id, const TranslatableString *pLabel) const;
+
 private:
    wxString FormatLabelForMenu(const CommandListEntry *entry) const;
+   wxString FormatLabelForMenu(
+      const TranslatableString &translatableLabel,
+      const NormalizedKeyString &keyStr) const;
    wxString FormatLabelWithDisabledAccel(const CommandListEntry *entry) const;
 
    //

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -355,13 +355,16 @@ std::pair<double, double> FindSelection(const CommandContext &context)
 {
    double sel0 = 0.0, sel1 = 0.0;
    
+#if 0
    // Use the overriding selection if any was given in the context
    if (auto *pRegion = context.temporarySelection.pSelectedRegion) {
       auto &selectedRegion = *pRegion;
       sel0 = selectedRegion.t0();
       sel1 = selectedRegion.t1();
    }
-   else {
+   else
+#endif
+   {
       auto &selectedRegion = ViewInfo::Get(context.project).selectedRegion;
       sel0 = selectedRegion.t0();
       sel1 = selectedRegion.t1();
@@ -780,7 +783,8 @@ void OnSplit(const CommandContext &context)
    
    if (auto *pTrack = context.temporarySelection.pTrack) {
       if (auto pWaveTrack = dynamic_cast<WaveTrack*>(pTrack))
-         pWaveTrack->Split( sel0, sel1 );
+         for (auto pChannel : TrackList::Channels(pWaveTrack))
+            pChannel->Split( sel0, sel1 );
       else
          // Did nothing, don't push history
          return;

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -1175,7 +1175,11 @@ void OnTrackMute(const CommandContext &context)
 {
    auto &project = context.project;
 
-   const auto track = TrackFocus::Get( project ).Get();
+   // Use the temporary selection if it is specified, else the track focus
+   auto track = context.temporarySelection.pTrack;
+   if (!track)
+      track = TrackFocus::Get( project ).Get();
+
    if (track) track->TypeSwitch( [&](PlayableTrack *t) {
       TrackUtilities::DoTrackMute(project, t, false);
    });

--- a/src/tracks/labeltrack/ui/LabelTextHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelTextHandle.cpp
@@ -141,6 +141,11 @@ void LabelTextHandle::HandleTextClick(AudacityProject &project, const wxMouseEve
    }
 }
 
+bool LabelTextHandle::HandlesRightClick()
+{
+   return true;
+}
+
 UIHandle::Result LabelTextHandle::Click
 (const TrackPanelMouseEvent &evt, AudacityProject *pProject)
 {

--- a/src/tracks/labeltrack/ui/LabelTextHandle.h
+++ b/src/tracks/labeltrack/ui/LabelTextHandle.h
@@ -40,6 +40,8 @@ public:
 
    void Enter(bool forward, AudacityProject *) override;
 
+   bool HandlesRightClick() override;
+
    Result Click
       (const TrackPanelMouseEvent &event, AudacityProject *pProject) override;
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -105,6 +105,11 @@ NoteTrackVZoomHandle::~NoteTrackVZoomHandle()
 {
 }
 
+bool NoteTrackVZoomHandle::HandlesRightClick()
+{
+   return true;
+}
+
 UIHandle::Result NoteTrackVZoomHandle::Click
 (const TrackPanelMouseEvent &, AudacityProject *)
 {

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.h
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.h
@@ -38,6 +38,8 @@ public:
 
    void Enter(bool forward, AudacityProject *) override;
 
+   bool HandlesRightClick() override;
+
    Result Click
       (const TrackPanelMouseEvent &event, AudacityProject *pProject) override;
 

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
@@ -116,6 +116,11 @@ CutlineHandle::~CutlineHandle()
 {
 }
 
+bool CutlineHandle::HandlesRightClick()
+{
+   return true;
+}
+
 UIHandle::Result CutlineHandle::Click
 (const TrackPanelMouseEvent &evt, AudacityProject *pProject)
 {

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
@@ -45,6 +45,8 @@ public:
 
    void Enter(bool forward, AudacityProject *) override;
 
+   bool HandlesRightClick() override;
+
    Result Click
       (const TrackPanelMouseEvent &event, AudacityProject *pProject) override;
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
@@ -37,6 +37,11 @@ void SpectrumVZoomHandle::Enter( bool, AudacityProject* )
 #endif
 }
 
+bool SpectrumVZoomHandle::HandlesRightClick()
+{
+   return true;
+}
+
 UIHandle::Result SpectrumVZoomHandle::Click
 (const TrackPanelMouseEvent &, AudacityProject *)
 {

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.h
@@ -38,6 +38,8 @@ public:
 
    void Enter(bool forward, AudacityProject*) override;
 
+   bool HandlesRightClick() override;
+
    Result Click
       (const TrackPanelMouseEvent &event, AudacityProject *pProject) override;
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -812,6 +812,32 @@ std::weak_ptr<WaveTrackView> WaveTrackSubView::GetWaveTrackView() const
    return mwWaveTrackView;
 }
 
+std::vector<ComponentInterfaceSymbol> WaveTrackSubView::GetMenuItems(
+   const wxRect &rect, const wxPoint *pPosition, AudacityProject *pProject )
+{
+   const WaveClip *pClip = nullptr;
+   auto pTrack = static_cast<WaveTrack*>(FindTrack().get());
+   if (pTrack && pPosition) {
+      auto &viewInfo = ViewInfo::Get(*pProject);
+      auto time = viewInfo.PositionToTime( pPosition->x, rect.x );
+      pClip = pTrack->GetClipAtTime( time );
+   }
+
+   if (pClip)
+      return {
+         { L"Cut", XO("Cut") },
+         { L"Copy", XO("Copy") },
+         { L"Paste", XO("Paste")  },
+         {},
+         { L"Split", XO("Split Clip") },
+         { L"TrackMute", XO("Mute/Unmute Track") },
+         // {},
+         // { L"", XO("Rename clip...") },
+      };
+   else
+      return {};
+}
+
 WaveTrackView &WaveTrackView::Get( WaveTrack &track )
 {
    return static_cast< WaveTrackView& >( TrackView::Get( track ) );

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
@@ -52,6 +52,10 @@ protected:
 
    std::weak_ptr<WaveTrackView> GetWaveTrackView() const;
 
+   std::vector<ComponentInterfaceSymbol> GetMenuItems(
+      const wxRect &rect, const wxPoint *pPosition, AudacityProject *pProject )
+   override;
+
 private:
    std::weak_ptr<UIHandle> mCloseHandle;
    std::weak_ptr<UIHandle> mResizeHandle;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
@@ -37,6 +37,11 @@ void WaveformVZoomHandle::Enter( bool, AudacityProject* )
 #endif
 }
 
+bool WaveformVZoomHandle::HandlesRightClick()
+{
+   return true;
+}
+
 UIHandle::Result WaveformVZoomHandle::Click
 (const TrackPanelMouseEvent &, AudacityProject *)
 {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.h
@@ -38,6 +38,8 @@ public:
 
    void Enter( bool forward, AudacityProject * ) override;
 
+   bool HandlesRightClick() override;
+
    Result Click
       (const TrackPanelMouseEvent &event, AudacityProject *pProject) override;
 

--- a/src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
@@ -36,6 +36,11 @@ void TimeTrackVZoomHandle::Enter( bool, AudacityProject* )
 #endif
 }
 
+bool TimeTrackVZoomHandle::HandlesRightClick()
+{
+   return true;
+}
+
 UIHandle::Result TimeTrackVZoomHandle::Click
 (const TrackPanelMouseEvent &, AudacityProject *)
 {

--- a/src/tracks/timetrack/ui/TimeTrackVZoomHandle.h
+++ b/src/tracks/timetrack/ui/TimeTrackVZoomHandle.h
@@ -29,6 +29,8 @@ public:
 
    void Enter( bool forward, AudacityProject * ) override;
 
+   bool HandlesRightClick() override;
+
    Result Click
       (const TrackPanelMouseEvent &event, AudacityProject *pProject) override;
 

--- a/src/tracks/ui/BackgroundCell.cpp
+++ b/src/tracks/ui/BackgroundCell.cpp
@@ -149,3 +149,20 @@ wxRect BackgroundCell::DrawingArea(
    else
       return rect;
 }
+
+std::vector<ComponentInterfaceSymbol> BackgroundCell::GetMenuItems(
+   const wxRect &, const wxPoint *, AudacityProject * )
+{
+   // These commands exist in toolbar menus too, but maybe with other labels
+   // TODO: devise a system of registration so that BackgroundCell has no
+   // special knowledge about track sub-types
+   return {
+      { L"NewMonoTrack", XO("Add Mono Track")},
+      { L"NewStereoTrack", XO("Add Stereo Track") },
+      { L"NewLabelTrack", XO("Add Label Track"),  },
+      {},
+      { L"Export", XO("Export Audio..."),  },
+      {},
+      { L"SelectAll", XO("Select All") },
+   };
+}

--- a/src/tracks/ui/BackgroundCell.h
+++ b/src/tracks/ui/BackgroundCell.h
@@ -53,6 +53,10 @@ private:
    wxRect DrawingArea(
       TrackPanelDrawingContext &,
       const wxRect &rect, const wxRect &panelRect, unsigned iPass ) override;
+
+   std::vector<ComponentInterfaceSymbol> GetMenuItems(
+      const wxRect &rect, const wxPoint *pPosition, AudacityProject *pProject )
+   override;
    
    AudacityProject *mpProject;
 

--- a/src/tracks/ui/CommonTrackControls.cpp
+++ b/src/tracks/ui/CommonTrackControls.cpp
@@ -276,7 +276,8 @@ void TrackMenuTable::OnMoveTrack(wxCommandEvent &event)
 }
 
 unsigned CommonTrackControls::DoContextMenu(
-   const wxRect &rect, wxWindow *pParent, wxPoint *, AudacityProject *pProject)
+   const wxRect &rect, wxWindow *pParent, const wxPoint *,
+   AudacityProject *pProject)
 {
    using namespace RefreshCode;
    wxRect buttonRect;

--- a/src/tracks/ui/CommonTrackControls.h
+++ b/src/tracks/ui/CommonTrackControls.h
@@ -54,7 +54,7 @@ protected:
        const AudacityProject *) override = 0;
 
    unsigned DoContextMenu
-      (const wxRect &rect, wxWindow *pParent, wxPoint *pPosition,
+      (const wxRect &rect, wxWindow *pParent, const wxPoint *pPosition,
        AudacityProject *pProject) override;
    virtual PopupMenuTable *GetMenuExtension(Track *pTrack) = 0;
 

--- a/src/tracks/ui/CommonTrackPanelCell.h
+++ b/src/tracks/ui/CommonTrackPanelCell.h
@@ -18,6 +18,7 @@ Paul Licameli split from TrackPanel.cpp
 #include <memory>
 #include <functional>
 
+class ComponentInterfaceSymbol;
 class Track;
 class XMLWriter;
 
@@ -45,8 +46,23 @@ public:
    std::shared_ptr<const Track> FindTrack() const
       { return const_cast<CommonTrackPanelCell*>(this)->DoFindTrack(); }
 
+   //! Return a list of items for DoContextMenu() (empties for separators)
+   /*! If the vector is empty (as in the default), there is no context menu.
+
+    Commands are invoked with temporary selection fields of CommandContext
+    set to a point selected region at the mouse pick, and the cell's
+    track.
+    */
+   virtual std::vector<ComponentInterfaceSymbol> GetMenuItems(
+      const wxRect &rect, const wxPoint *pPosition, AudacityProject *pProject );
+
 protected:
    virtual std::shared_ptr<Track> DoFindTrack() = 0;
+
+   unsigned DoContextMenu(
+      const wxRect &rect,
+      wxWindow *pParent, const wxPoint *pPosition, AudacityProject *pProject)
+   override;
 
    unsigned HandleWheelRotation
       (const TrackPanelMouseEvent &event,

--- a/src/tracks/ui/ZoomHandle.cpp
+++ b/src/tracks/ui/ZoomHandle.cpp
@@ -83,6 +83,11 @@ ZoomHandle::~ZoomHandle()
 {
 }
 
+bool ZoomHandle::HandlesRightClick()
+{
+   return true;
+}
+
 UIHandle::Result ZoomHandle::Click
 (const TrackPanelMouseEvent &evt, AudacityProject *)
 {

--- a/src/tracks/ui/ZoomHandle.h
+++ b/src/tracks/ui/ZoomHandle.h
@@ -34,6 +34,8 @@ public:
 
    virtual ~ZoomHandle();
 
+   bool HandlesRightClick() override;
+
    Result Click
       (const TrackPanelMouseEvent &event, AudacityProject *pProject) override;
 


### PR DESCRIPTION
Resolves: #998
Resolves: #1518

Working context menus for background area and audio clips.

Notes about some details where the issue description differs from this implementation or is underspecified:

* All important words are capitalized, consistent with other menu items (for instance "Split Clip")
* Split Clip will split only the picked clip (whether or not the track is selected), at the pick point.  This is unlike the toolbar menu, which splits all selected tracks, at the selection.
* Paste will paste at the pick point, ignoring the selection, unlike the other ways of invoking Paste
* Mute/Unmute Track has Shift+U as its default keystroke.  See Extra > Tracks sub-menu (and see Interface preferences to enable the Extra menu). The popup menu command will do that to the track you pick in, ignoring which tracks are in selected state.
* "Export Audio..." rather than "Export Project" because that agrees with the toolbar menu and the convention that commands bringing up modal dialogs need ellipsis in the name.
* The clip context menu appears only when clicking on the wave (or spectrogram) areas, not on the drag bar or in voids between clips.
* The accelerator keys appear not necessarily as the defaults in the pictures, of course, but are consistent with whatever keystrokes have been chosen in preferences.
* Context menu items will be grayed out and disabled in the same cases that the corresponding toolbar menus would be.  For instance, adding new tracks is not permitted during recording or playback.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
