### PR TITLE
Macros run on project are inconsistent in their use of Export commands #1288

### DIFF
--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -1303,9 +1303,12 @@ void MacrosWindow::OnDown(wxCommandEvent & WXUNUSED(event))
 
 void MacrosWindow::OnApplyToProject(wxCommandEvent & event)
 {
+   AudacityProject *project = &mProject;
+   project->mApplyToProject = true;
    if( !SaveChanges() )
       return;
    ApplyMacroDialog::OnApplyToProject( event );
+   project->mApplyToProject = false;
 }
 
 void MacrosWindow::OnApplyToFiles(wxCommandEvent & event)

--- a/src/Project.h
+++ b/src/Project.h
@@ -157,6 +157,7 @@ private:
  public:
    bool mbBusyImporting{ false }; // used to fix bug 584
    int mBatchMode{ 0 };// 0 means not, >0 means in batch mode.
+   bool mApplyToProject{ false };// turns true when enters body of OnApplyToProject and to false when it reaches the end.
 
  private:
    wxWeakRef< wxFrame > mFrame{};

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -52,6 +52,7 @@ void DoExport(AudacityProject &project, const FileExtension &format)
 
    // Prompt for file name and/or extension?
    bool bPromptingRequired = !project.mBatchMode ||
+                             project.mApplyToProject||
                              projectName.empty() ||
                              format.empty();
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1288

Add a new variable mApplyToProject to keep track of whether the Macro being applied is on a project or not and adding the same as a condition to the prompt in FileMenus.cpp.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/73242397/130988692-001919d6-83cd-40a6-be8a-f3bd4208de8c.gif)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"