### PR TITLE
Issue #1358: Shortcut Instead Brings Up Keyboard Preferences Dialog...

### DIFF
--- a/src/Experimental.cmake
+++ b/src/Experimental.cmake
@@ -196,7 +196,10 @@ set( EXPERIMENTAL_OPTIONS_LIST
 
    # PRL 5 Jan 2018
    # Easy change of keystroke bindings for menu items
-   EASY_CHANGE_KEY_BINDINGS
+   #
+   # PRL disabled 31 Aug 2021 because, at least on Mac, it misfires the
+   # preference dialog whenever any keystroke shortcuts with Shift+ are used
+   # EASY_CHANGE_KEY_BINDINGS
 
    # PRL 1 Jun 2018
    PUNCH_AND_ROLL


### PR DESCRIPTION
This requires an update to this manual page -- remove the green box near the top: https://manual.audacityteam.org/man/keyboard_shortcut_reference.html

Happened at least on macOS because the easy change of key bindings was
mis-firing in other cases than picks on menu items.

So we just disable that little valued feature.

Disable the easy key rebinding feature

Resolves: #1358

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
