### PR TITLE
AudacityMessageBox button presses can now be replayed in journal...

### DIFF
--- a/src/Journal.cpp
+++ b/src/Journal.cpp
@@ -253,6 +253,39 @@ void Sync( std::initializer_list< const wxString > strings )
 {
    return Sync( wxArrayStringEx( strings ) );
 }
+
+int IfNotPlaying(
+   const wxString &string, const InteractiveAction &action )
+{
+   // Special journal word
+   Sync(string);
+
+   // Then read or write the return value on another journal line
+   if ( IsReplaying() ) {
+      auto tokens = GetTokens();
+      if ( tokens.size() == 1 ) {
+         try {
+            std::wstring str{ tokens[0].wc_str() };
+            size_t length = 0;
+            auto result = std::stoi(str, &length);
+            if (length == str.length()) {
+               if (IsRecording())
+                  Journal::Output( std::to_wstring(result) );
+               return result;
+            }
+         }
+         catch ( const std::exception& ) {}
+      }
+      throw SyncException{};
+   }
+    else {
+      auto result = action ? action() : 0;
+      if ( IsRecording() )
+         Output( std::to_wstring( result ) );
+      return result;
+   }
+}
+
 int GetExitCode()
 {
    // Unconsumed commands remaining in the input file is also an error condition.

--- a/src/Journal.h
+++ b/src/Journal.h
@@ -64,6 +64,22 @@ namespace Journal
    void Sync( const wxArrayString &strings );
    void Sync( std::initializer_list< const wxString > strings );
 
+   //! Function that returns a value which will be written to the journal
+   /*! In future, might generalize to more return values and of other types */
+   using InteractiveAction = std::function< int() >;
+
+   //! Call action only if not replaying; synchronize on string and int values
+   /*!
+    If not replaying, call the function, and if recording, output the string
+    and the return value.
+
+    If replaying, skip the action; Sync on the string; parse a value from
+    the journal; throw SyncException if the value is ill-formed; otherwise
+    output the value (if also recording), and return it
+    */
+   int IfNotPlaying(
+      const wxString &string, const InteractiveAction &action );
+
    //\brief Get the value that the application will return to the command line
    int GetExitCode();
 

--- a/src/widgets/AudacityMessageBox.cpp
+++ b/src/widgets/AudacityMessageBox.cpp
@@ -10,3 +10,21 @@
 
 #include "AudacityMessageBox.h"
 #include "Internat.h"
+
+#include "Journal.h"
+#include "wxArrayStringEx.h"
+
+int AudacityMessageBox(const TranslatableString& message,
+   const TranslatableString& caption,
+   long style, wxWindow *parent, int x, int y)
+{
+   // wxMessageBox is implemented with native message boxes and does not
+   // use the wxWidgets message machinery.  Therefore the wxEventFilter that
+   // most journal recording relies on fails us here.  So if replaying, don't
+   // really make the modal dialog, but just return the expected value.
+   return Journal::IfNotPlaying( L"MessageBox", [&]{
+      return ::wxMessageBox(
+         message.Translation(), caption.Translation(),
+         style, parent, x, y);
+   } );
+}

--- a/src/widgets/AudacityMessageBox.h
+++ b/src/widgets/AudacityMessageBox.h
@@ -17,14 +17,10 @@
 extern AUDACITY_DLL_API TranslatableString AudacityMessageBoxCaptionStr();
 
 // Do not use wxMessageBox!!  Its default window title does not translate!
-inline int AudacityMessageBox(const TranslatableString& message,
+AUDACITY_DLL_API int AudacityMessageBox(const TranslatableString& message,
    const TranslatableString& caption = XO("Message"),
    long style = wxOK | wxCENTRE,
    wxWindow *parent = NULL,
-   int x = wxDefaultCoord, int y = wxDefaultCoord)
-{
-   return ::wxMessageBox(message.Translation(), caption.Translation(),
-      style, parent, x, y);
-}
+   int x = wxDefaultCoord, int y = wxDefaultCoord);
 
 #endif


### PR DESCRIPTION
... the dialog won't actually reappear but the same value will be returned to
the program.

These message boxes are special native ones that don't use the wxWidgets event
framework.  Therefore the system for journalling of mouse button presses does
not work with them.  Treat them specially.

A generalized facility added to namespace Journal in case this pattern needs to
be repeated for other actions.

Resolves: #1590
*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
