### PR TITLE
Label edit refactoring

### DIFF
--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -58,12 +58,6 @@ bool DoPasteText(AudacityProject &project)
             ProjectHistory::Get( project )
                .PushState(XO("Pasted text from the clipboard"), XO("Paste"));
 
-            // Make sure caret is in view
-            int x;
-            if (view.CalcCursorX( project, &x )) {
-               window.ScrollIntoView(x);
-            }
-
             return true;
          }
       }

--- a/src/tracks/labeltrack/ui/LabelTextHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelTextHandle.cpp
@@ -17,11 +17,14 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../LabelTrack.h"
 #include "ProjectAudioIO.h"
 #include "ProjectHistory.h"
+#include "UndoManager.h"
 #include "../../../RefreshCode.h"
 #include "../../../SelectionState.h"
 #include "../../../TrackPanelMouseEvent.h"
 #include "ViewInfo.h"
 #include "../../../../images/Cursors.h"
+
+#include "../../ui/TextEditHelper.h"
 
 #include <wx/clipbrd.h>
 
@@ -80,55 +83,31 @@ void LabelTextHandle::HandleTextClick(AudacityProject &project, const wxMouseEve
    if (evt.ButtonDown())
    {
       const auto selIndex = LabelTrackView::OverATextBox( *pTrack, evt.m_x, evt.m_y );
-      if ( selIndex != -1 ) {
-         if (evt.LeftDown()) {
-            mRightDragging = false;
-            // Find the NEW drag end
-            auto position = view.FindCursorPosition(selIndex, evt.m_x );
-
-            // Anchor shift-drag at the farther end of the previous highlight
-            // that is farther from the click, on Mac, for consistency with
-            // its text editors, but on the others, re-use the previous
-            // anchor.
-            auto initial = view.GetInitialCursorPosition();
-            if (evt.ShiftDown()) {
-#ifdef __WXMAC__
-               // Set the drag anchor at the end of the previous selection
-               // that is farther from the NEW drag end
-               const auto current = view.GetCurrentCursorPosition();
-               if ( abs( position - current ) > abs( position - initial ) )
-                  initial = current;
-#else
-               // initial position remains as before
-#endif
+      if ((evt.LeftDown() || evt.RightDown()) && selIndex != -1 ) 
+      {
+         auto useDialog{false};
+         gPrefs->Read(wxT("/GUI/DialogForNameNewLabel"), &useDialog, false);
+         auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
+         if (useDialog) {
+            wxString title;
+            auto label = *pTrack->GetLabel(selIndex);
+            if (LabelTrackView::DialogForLabelName(
+               project, selectedRegion, label.title, title) ==
+                wxID_CANCEL) {
+               return;
             }
-            else
-               initial = position;
-
-            view.SetTextSelection(selIndex, initial, position );
-         }
-         else
-         {
-            if (!view.IsTextSelected(project))
+            if(label.title != title)
             {
-               auto position = view.FindCursorPosition(selIndex, evt.m_x);
-               view.SetTextSelection(selIndex, position, position);
+               ProjectHistory::Get(project).PushState(XO("Modified Label"),
+                  XO("Label Edit"),
+                  UndoPush::CONSOLIDATE);
+               label.title = title;
+               pTrack->SetLabel(selIndex, label);
             }
-            // Actually this might be right or middle down
-            mRightDragging = true;
+            return;
          }
-         // Middle click on GTK: paste from primary selection
-#if defined(__WXGTK__) && (HAVE_GTK)
-         if (evt.MiddleDown()) {
-            // Check for a click outside of the selected label's text box; in this
-            // case PasteSelectedText() will start a NEW label at the click
-            // location
-            if (!LabelTrackView::OverTextBox(&labelStruct, evt.m_x, evt.m_y))
-               view.ResetTextSelection();
-            double t = zoomInfo.PositionToTime(evt.m_x, r.x);
-            newSel = SelectedRegion(t, t);
-         }
-#endif
+         mTextEditHelper = view.StartLabelTextEdit(selIndex, &project);
+         mTextEditHelper->OnClick(evt, &project);
       }
 #if defined(__WXGTK__) && (HAVE_GTK)
       if (evt.MiddleDown()) {
@@ -163,91 +142,14 @@ UIHandle::Result LabelTextHandle::Click
    return result | RefreshCode::RefreshCell;
 }
 
-void LabelTextHandle::HandleTextDragRelease(
-   AudacityProject &project, const wxMouseEvent & evt)
-{
-   auto pTrack = mpLT.lock();
-   if (!pTrack)
-      return;
-   auto &view = LabelTrackView::Get( *pTrack );
-
-   if(evt.LeftUp())
-   {
-#if 0
-      // AWD: Due to wxWidgets bug #7491 (fix not ported to 2.8 branch) we
-      // should never write the primary selection. We can enable this block
-      // when we move to the 3.0 branch (or if a fixed 2.8 version is released
-      // and we can do a runtime version check)
-#if defined (__WXGTK__) && defined (HAVE_GTK)
-      // On GTK, if we just dragged out a text selection, set the primary
-      // selection
-      if (mInitialCursorPos != mCurrentCursorPos) {
-         wxTheClipboard->UsePrimarySelection(true);
-         CopySelectedText();
-         wxTheClipboard->UsePrimarySelection(false);
-      }
-#endif
-#endif
-
-      return;
-   }
-
-   if(evt.Dragging())
-   {
-      auto index = view.GetTextEditIndex(project);
-      if (!mRightDragging && index != -1)
-         // Update drag end
-         view.SetCurrentCursorPosition(view.FindCursorPosition(index, evt.m_x ));
-      return;
-   }
-
-   if (evt.RightUp())
-   {
-      auto index = view.GetTextEditIndex(project);
-      if(index != -1 &&
-         LabelTrackView::OverTextBox(pTrack->GetLabel(index), evt.m_x, evt.m_y)) 
-      {
-         // popup menu for editing
-         // TODO: handle context menus via CellularPanel?
-         view.ShowContextMenu( project );
-      }
-   }
-
-   return;
-}
-
 UIHandle::Result LabelTextHandle::Drag
 (const TrackPanelMouseEvent &evt, AudacityProject *pProject)
 {
    auto &project = *pProject;
    using namespace RefreshCode;
    auto result = LabelDefaultClickHandle::Drag( evt, pProject );
-
-   const wxMouseEvent &event = evt.event;
-   auto pLT = TrackList::Get( *pProject ).Lock(mpLT);
-   if(pLT)
-      HandleTextDragRelease( project, event );
-
-   // locate the initial mouse position
-   if (event.LeftIsDown()) {
-      if (mLabelTrackStartXPos == -1) {
-         mLabelTrackStartXPos = event.m_x;
-         mLabelTrackStartYPos = event.m_y;
-
-         auto pView = pLT ? &LabelTrackView::Get( *pLT ) : nullptr;
-         if (pLT && (pView->GetTextEditIndex( project ) != -1) &&
-             LabelTrackView::OverTextBox(
-               pLT->GetLabel(pView->GetTextEditIndex( project )),
-               mLabelTrackStartXPos,
-               mLabelTrackStartYPos))
-            mLabelTrackStartYPos = -1;
-      }
-      // if initial mouse position in the text box
-      // then only drag text
-      if (mLabelTrackStartYPos == -1)
-         result |= RefreshCell;
-   }
-
+   if (mTextEditHelper && mTextEditHelper->OnDrag(evt.event, pProject))
+       result |= RefreshCode::RefreshCell;
    return result;
 }
 
@@ -262,20 +164,10 @@ UIHandle::Result LabelTextHandle::Release
  wxWindow *pParent)
 {
    auto result = LabelDefaultClickHandle::Release( evt, pProject, pParent );
+   if (mTextEditHelper && mTextEditHelper->OnRelease(evt.event, pProject))
+       result |= RefreshCode::RefreshCell;
 
-   // Only selected a part of a text string and changed track selectedness.
-   // No undoable effects.
-
-   const wxMouseEvent &event = evt.event;
-   auto pLT = TrackList::Get( *pProject ).Lock(mpLT);
-   if (pLT)
-      HandleTextDragRelease( *pProject, event );
-
-   // handle mouse left button up
-   if (event.LeftUp())
-      mLabelTrackStartXPos = -1;
-
-   return result | RefreshCode::RefreshNone;
+   return result;
 }
 
 UIHandle::Result LabelTextHandle::Cancel( AudacityProject *pProject )

--- a/src/tracks/labeltrack/ui/LabelTextHandle.h
+++ b/src/tracks/labeltrack/ui/LabelTextHandle.h
@@ -18,6 +18,7 @@ class wxMouseState;
 class LabelTrack;
 class SelectionStateChanger;
 class ZoomInfo;
+class TextEditHelper;
 
 class LabelTextHandle final : public LabelDefaultClickHandle
 {
@@ -60,8 +61,6 @@ public:
 private:
    void HandleTextClick
       (AudacityProject &project, const wxMouseEvent & evt);
-   void HandleTextDragRelease(
-      AudacityProject &project, const wxMouseEvent & evt);
 
    std::weak_ptr<LabelTrack> mpLT {};
    int mLabelNum{ -1 };
@@ -70,6 +69,8 @@ private:
 
    /// flag to tell if it's a valid dragging
    bool mRightDragging{ false };
+
+   std::shared_ptr<TextEditHelper> mTextEditHelper;
 };
 
 #endif

--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -15,6 +15,8 @@ Paul Licameli split from TrackPanel.cpp
 #include "LabelGlyphHandle.h"
 #include "LabelTextHandle.h"
 
+#include "../../ui/TextEditHelper.h"
+
 #include "../../../LabelTrack.h"
 
 #include "AColor.h"
@@ -147,11 +149,28 @@ void LabelTrackView::CopyTo( Track &track ) const
 
    if ( const auto pOther = dynamic_cast< const LabelTrackView* >( &other ) ) {
       pOther->mNavigationIndex = mNavigationIndex;
-      pOther->mInitialCursorPos = mInitialCursorPos;
-      pOther->mCurrentCursorPos = mCurrentCursorPos;
       pOther->mTextEditIndex = mTextEditIndex;
       pOther->mUndoLabel = mUndoLabel;
    }
+}
+
+std::shared_ptr<TextEditHelper> LabelTrackView::MakeTextEditHelper(const LabelStruct& label)
+{
+   auto lock = std::static_pointer_cast<LabelTrackView>(shared_from_this());
+   auto textEdit = std::make_unique<TextEditHelper>(lock, label.title, msFont);
+   textEdit->SetTextColor(theTheme.Colour(clrLabelTrackText));
+   textEdit->SetTextSelectionColor(theTheme.Colour(clrLabelTrackTextSelection));
+   return std::move(textEdit);
+}
+
+wxRect LabelTrackView::MakeTextEditHelperRect(const LabelStruct& label)
+{
+   const int yFrameHeight = mTextHeight + TextFramePadding * 2;
+   return {
+      label.xText,
+      label.y + TextFrameYOffset - (LabelBarHeight + yFrameHeight) / 2,
+      label.width + 1,
+      yFrameHeight };
 }
 
 LabelTrackView &LabelTrackView::Get( LabelTrack &track )
@@ -188,10 +207,16 @@ std::vector<UIHandlePtr> LabelTrackView::DetailedHitTest
    if (result)
       results.push_back(result);
 
-   result = LabelTextHandle::HitTest(
-      mTextHandle, state, pTrack);
-   if (result)
-      results.push_back(result);
+   if(!state.ControlDown())
+   {
+      auto index = LabelTrackView::OverATextBox(*pTrack.get(), state.GetX(), state.GetY());
+      if (index != -1)
+      {
+         results.push_back(
+            AssignUIHandlePtr(mTextHandle,
+               std::make_shared<LabelTextHandle>(pTrack, index)));
+      }
+   }
 
    return results;
 }
@@ -215,26 +240,25 @@ int LabelTrackView::mFontHeight=-1;
 
 void LabelTrackView::ResetFlags()
 {
-   mInitialCursorPos = 1;
-   mCurrentCursorPos = 1;
+   mTextEditHelper.reset();
    mTextEditIndex = -1;
    mNavigationIndex = -1;
 }
 
 LabelTrackView::Flags LabelTrackView::SaveFlags() const
 {
+   auto selection 
+      = mTextEditHelper ? mTextEditHelper->GetSelection() : std::pair<int, int>();
    return {
-      mInitialCursorPos, mCurrentCursorPos, mNavigationIndex,
+      selection.first, selection.second, mNavigationIndex,
       mTextEditIndex, mUndoLabel
    };
 }
 
 void LabelTrackView::RestoreFlags( const Flags& flags )
 {
-   mInitialCursorPos = flags.mInitialCursorPos;
-   mCurrentCursorPos = flags.mCurrentCursorPos;
    mNavigationIndex = flags.mNavigationIndex;
-   mTextEditIndex = flags.mTextEditIndex;
+   SetTextSelection(flags.mTextEditIndex, flags.mInitialCursorPos, flags.mCurrentCursorPos);
 }
 
 wxFont LabelTrackView::GetFont(const wxString &faceName, int size)
@@ -681,78 +705,6 @@ void LabelTrackView::DrawBar(wxDC& dc, const LabelStruct& ls, const wxRect& r)
    }
 }
 
-/// Draws text-selected region within the label
-void LabelTrackView::DrawHighlight( wxDC & dc, const LabelStruct &ls,
-   int xPos1, int xPos2, int charHeight)
-{
-   const int yFrameHeight = mTextHeight + TextFramePadding * 2;
-   
-   dc.SetPen(*wxTRANSPARENT_PEN);
-   wxBrush curBrush = dc.GetBrush();
-   curBrush.SetColour(wxString(wxT("BLUE")));
-   auto top = ls.y + TextFrameYOffset - (LabelBarHeight + yFrameHeight) / 2 + (yFrameHeight - charHeight) / 2;
-   if (xPos1 < xPos2)
-      dc.DrawRectangle(xPos1-1, top, xPos2-xPos1+1, charHeight);
-   else
-      dc.DrawRectangle(xPos2-1, top, xPos1-xPos2+1, charHeight);
-}
-
-namespace {
-void getXPos( const LabelStruct &ls, wxDC & dc, int * xPos1, int cursorPos)
-{
-   *xPos1 = ls.xText;
-   if( cursorPos > 0)
-   {
-      int partWidth;
-      // Calculate the width of the substring and add it to Xpos
-      dc.GetTextExtent(ls.title.Left(cursorPos), &partWidth, NULL);
-      *xPos1 += partWidth;
-   }
-}
-}
-
-bool LabelTrackView::CalcCursorX( AudacityProject &project, int * x) const
-{
-   if (IsValidIndex(mTextEditIndex, project)) {
-      wxMemoryDC dc;
-
-      if (msFont.Ok()) {
-         dc.SetFont(msFont);
-      }
-
-      const auto pTrack = FindLabelTrack();
-      const auto &mLabels = pTrack->GetLabels();
-
-      getXPos(mLabels[mTextEditIndex], dc, x, mCurrentCursorPos);
-      *x += mIconWidth / 2;
-      return true;
-   }
-
-   return false;
-}
-
-void LabelTrackView::CalcHighlightXs(int *x1, int *x2) const
-{
-   wxMemoryDC dc;
-
-   if (msFont.Ok()) {
-      dc.SetFont(msFont);
-   }
-
-   int pos1 = mInitialCursorPos, pos2 = mCurrentCursorPos;
-   if (pos1 > pos2)
-      std::swap(pos1, pos2);
-
-   const auto pTrack = FindLabelTrack();
-   const auto &mLabels = pTrack->GetLabels();
-   const auto &labelStruct = mLabels[mTextEditIndex];
-
-   // find the left X pos of highlighted area
-   getXPos(labelStruct, dc, x1, pos1);
-   // find the right X pos of highlighted area
-   getXPos(labelStruct, dc, x2, pos2);
-}
-
 #include "LabelGlyphHandle.h"
 namespace {
    LabelTrackHit *findHit( TrackPanel *pPanel )
@@ -877,46 +829,20 @@ void LabelTrackView::Draw
       }
    }
 
-   // Draw highlights
-   if ( (mInitialCursorPos != mCurrentCursorPos) && IsValidIndex(mTextEditIndex, project))
-   {
-      int xpos1, xpos2;
-      CalcHighlightXs(&xpos1, &xpos2);
-      DrawHighlight(dc, mLabels[mTextEditIndex],
-         xpos1, xpos2, dc.GetFontMetrics().ascent + dc.GetFontMetrics().descent);
-   }
-
    // Draw the text and the label boxes.
-   { int i = -1; for (const auto &labelStruct : mLabels) { ++i;
-      if(mTextEditIndex == i )
-         dc.SetBrush(AColor::labelTextEditBrush);
-      DrawText( dc, labelStruct, r );
-      if(mTextEditIndex == i )
-         dc.SetBrush(AColor::labelTextNormalBrush);
-   }}
-
-   // Draw the cursor, if there is one.
-   if(mInitialCursorPos == mCurrentCursorPos && IsValidIndex(mTextEditIndex, project))
+   int i = 0;
+   for (auto label : mLabels)
    {
-      const auto &labelStruct = mLabels[mTextEditIndex];
-      int xPos = labelStruct.xText;
-
-      if( mCurrentCursorPos > 0)
+      if ((i == mTextEditIndex) && mTextEditHelper)
       {
-         // Calculate the width of the substring and add it to Xpos
-         int partWidth;
-         dc.GetTextExtent(labelStruct.title.Left(mCurrentCursorPos), &partWidth, NULL);
-         xPos += partWidth;
+         mTextEditHelper->Draw(dc, LabelTrackView::MakeTextEditHelperRect(label));
       }
-
-      wxPen currentPen = dc.GetPen();
-      const int CursorWidth=2;
-      currentPen.SetWidth(CursorWidth);
-      const auto top = labelStruct.y - (LabelBarHeight + yFrameHeight) / 2 + (yFrameHeight - mFontHeight) / 2 + TextFrameYOffset;
-      AColor::Line(dc,
-                   xPos-1, top,
-                   xPos-1, top + mFontHeight);
-      currentPen.SetWidth(1);
+      else
+      {
+         dc.SetBrush(AColor::labelTextNormalBrush);
+         DrawText(dc, label, r);
+      }
+      ++i;
    }
 }
 
@@ -929,72 +855,6 @@ void LabelTrackView::Draw(
    CommonTrackView::Draw( context, rect, iPass );
 }
 
-/// uses GetTextExtent to find the character position
-/// corresponding to the x pixel position.
-int LabelTrackView::FindCursorPosition(int labelIndex, wxCoord xPos)
-{
-   int result = -1;
-   wxMemoryDC dc;
-   if(msFont.Ok())
-      dc.SetFont(msFont);
-
-   // A bool indicator to see if set the cursor position or not
-   bool finished = false;
-   int charIndex = 1;
-   int partWidth;
-   int oneWidth;
-   double bound;
-   wxString subString;
-
-   const auto pTrack = FindLabelTrack();
-   const auto &mLabels = pTrack->GetLabels();
-   const auto &labelStruct = mLabels[labelIndex];
-   const auto &title = labelStruct.title;
-   const int length = title.length();
-   while (!finished && (charIndex < length + 1))
-   {
-      int unichar = (int)title.at( charIndex-1 );
-      if( (0xDC00 <= unichar) && (unichar <= 0xDFFF)){
-         charIndex++;
-         continue;
-      }
-      subString = title.Left(charIndex);
-      // Get the width of substring
-      dc.GetTextExtent(subString, &partWidth, NULL);
-
-      // Get the width of the last character
-      dc.GetTextExtent(subString.Right(1), &oneWidth, NULL);
-      bound = labelStruct.xText + partWidth - oneWidth * 0.5;
-
-      if (xPos <= bound)
-      {
-         // Found
-         result = charIndex - 1;
-         finished = true;
-      }
-      else
-      {
-         // Advance
-         charIndex++;
-      }
-   }
-   if (!finished)
-      // Cursor should be in the last position
-      result = length;
-
-   return result;
-}
-
-void LabelTrackView::SetCurrentCursorPosition(int pos)
-{
-   mCurrentCursorPos = pos;
-}
-void LabelTrackView::SetTextSelection(int labelIndex, int start, int end)
-{
-    mTextEditIndex = labelIndex;
-    mInitialCursorPos = start;
-    mCurrentCursorPos = end;
-}
 int LabelTrackView::GetTextEditIndex(AudacityProject& project) const
 {
     if (IsValidIndex(mTextEditIndex, project))
@@ -1004,8 +864,7 @@ int LabelTrackView::GetTextEditIndex(AudacityProject& project) const
 void LabelTrackView::ResetTextSelection()
 {
     mTextEditIndex = -1;
-    mCurrentCursorPos = 1;
-    mInitialCursorPos = 1;
+    mTextEditHelper.reset();
 }
 void LabelTrackView::SetNavigationIndex(int index)
 {
@@ -1047,95 +906,22 @@ bool LabelTrackView::IsValidIndex(const Index& index, AudacityProject& project) 
     return false;
 }
 
-bool LabelTrackView::IsTextSelected( AudacityProject &project ) const
-{
-   return mCurrentCursorPos != mInitialCursorPos && IsValidIndex(mTextEditIndex, project);
-}
-
 /// Cut the selected text in the text box
 ///  @return true if text is selected in text box, false otherwise
 bool LabelTrackView::CutSelectedText( AudacityProject &project )
 {
-   if (!IsTextSelected( project ))
+   if (!mTextEditHelper)
       return false;
-
-   const auto pTrack = FindLabelTrack();
-   const auto &mLabels = pTrack->GetLabels();
-
-   wxString left, right;
-   auto labelStruct = mLabels[mTextEditIndex];
-   auto &text = labelStruct.title;
-
-   if (!mTextEditIndex.IsModified()) {
-      mUndoLabel = text;
-   }
-
-   int init = mInitialCursorPos;
-   int cur = mCurrentCursorPos;
-   if (init > cur)
-      std::swap(init, cur);
-
-   // data for cutting
-   wxString data = text.Mid(init, cur - init);
-
-   // get left-remaining text
-   if (init > 0)
-      left = text.Left(init);
-
-   // get right-remaining text
-   if (cur < (int)text.length())
-      right = text.Mid(cur);
-
-   // set title to the combination of the two remainders
-   text = left + right;
-
-   pTrack->SetLabel( mTextEditIndex, labelStruct );
-
-   // copy data onto clipboard
-   if (wxTheClipboard->Open()) {
-      // Clipboard owns the data you give it
-      wxTheClipboard->SetData(safenew wxTextDataObject(data));
-      wxTheClipboard->Close();
-   }
-
-   // set cursor positions
-   mInitialCursorPos = mCurrentCursorPos = left.length();
-
-   mTextEditIndex.SetModified(true);
-   return true;
+   return mTextEditHelper->CutSelectedText(project);
 }
 
 /// Copy the selected text in the text box
 ///  @return true if text is selected in text box, false otherwise
 bool LabelTrackView::CopySelectedText( AudacityProject &project )
 {
-   if (!IsTextSelected(project))
+   if (!mTextEditHelper)
       return false;
-
-   const auto pTrack = FindLabelTrack();
-   const auto &mLabels = pTrack->GetLabels();
-
-   const auto &labelStruct = mLabels[mTextEditIndex];
-
-   int init = mInitialCursorPos;
-   int cur = mCurrentCursorPos;
-   if (init > cur)
-      std::swap(init, cur);
-
-   if (init == cur)
-      return false;
-
-   // data for copying
-   wxString data = labelStruct.title.Mid(init, cur-init);
-
-   // copy the data on clipboard
-   if (wxTheClipboard->Open()) {
-      // Clipboard owns the data you give it
-      wxTheClipboard->SetData(safenew wxTextDataObject(data));
-      wxTheClipboard->Close();
-   }
-
-   return true;
+   return mTextEditHelper->CopySelectedText(project);
 }
 
 // PRL:  should this set other fields of the label selection?
@@ -1144,69 +930,27 @@ bool LabelTrackView::CopySelectedText( AudacityProject &project )
 bool LabelTrackView::PasteSelectedText(
    AudacityProject &project, double sel0, double sel1 )
 {
-   const auto pTrack = FindLabelTrack();
-
-   if (!IsValidIndex(mTextEditIndex, project))
-      SetTextSelection(AddLabel(SelectedRegion(sel0, sel1)));
-
-   wxString text, left, right;
-
-   // if text data is available
-   if (IsTextClipSupported()) {
-      if (wxTheClipboard->Open()) {
-         wxTextDataObject data;
-         wxTheClipboard->GetData(data);
-         wxTheClipboard->Close();
-         text = data.GetText();
-      }
-
-      if (!mTextEditIndex.IsModified()) {
-         mUndoLabel = text;
-      }
-
-      // Convert control characters to blanks
-      for (int i = 0; i < (int)text.length(); i++) {
-         if (wxIscntrl(text[i])) {
-            text[i] = wxT(' ');
-         }
-      }
+   if (!mTextEditHelper)
+      StartLabelTextEdit(AddLabel(SelectedRegion(sel0, sel1)), &project);
+   if (mTextEditHelper->PasteSelectedText(project))
+   {
+      // Make sure caret is in view
+      int x{ 0 };
+      if (mTextEditHelper->GetCharPositionX(mTextEditHelper->GetSelection().second, &x))
+         ProjectWindow::Get(project).ScrollIntoView(x);
+      return true;
    }
-
-   const auto &mLabels = pTrack->GetLabels();
-   auto labelStruct = mLabels[mTextEditIndex];
-   auto &title = labelStruct.title;
-   int cur = mCurrentCursorPos, init = mInitialCursorPos;
-   if (init > cur)
-      std::swap(init, cur);
-   left = title.Left(init);
-   if (cur < (int)title.length())
-      right = title.Mid(cur);
-
-   title = left + text + right;
-
-   pTrack->SetLabel(mTextEditIndex, labelStruct );
-
-   mInitialCursorPos =  mCurrentCursorPos = left.length() + text.length();
-
-   mTextEditIndex.SetModified(true);
-   return true;
+   return false;
 }
 
 bool LabelTrackView::SelectAllText(AudacityProject& project)
 {
-    if (!IsValidIndex(mTextEditIndex, project))
-        return false;
-
-    const auto pTrack = FindLabelTrack();
-
-    const auto& mLabels = pTrack->GetLabels();
-    auto labelStruct = mLabels[mTextEditIndex];
-    auto& title = labelStruct.title;
-
-    mInitialCursorPos = 0;
-    mCurrentCursorPos = title.Length();
-
-    return true;
+   if(mTextEditHelper)
+   {
+      mTextEditHelper->SelectAll();
+      return true;
+   }
+   return false;
 }
 
 /// @return true if the text data is available in the clipboard, false otherwise
@@ -1325,27 +1069,6 @@ static bool IsGoodLabelFirstKey(const wxKeyEvent & evt)
           (keyCode > WXK_WINDOWS_MENU);
 }
 
-/// This returns true for keys we capture for label editing.
-static bool IsGoodLabelEditKey(const wxKeyEvent & evt)
-{
-   int keyCode = evt.GetKeyCode();
-
-   // Accept everything outside of WXK_START through WXK_COMMAND, plus the keys
-   // within that range that are usually printable, plus the ones we use for
-   // keyboard navigation.
-   return keyCode < WXK_START ||
-          (keyCode >= WXK_END && keyCode < WXK_UP) ||
-          (keyCode == WXK_RIGHT) ||
-          (keyCode >= WXK_NUMPAD0 && keyCode <= WXK_DIVIDE) ||
-          (keyCode >= WXK_NUMPAD_SPACE && keyCode <= WXK_NUMPAD_ENTER) ||
-          (keyCode >= WXK_NUMPAD_HOME && keyCode <= WXK_NUMPAD_END) ||
-          (keyCode >= WXK_NUMPAD_DELETE && keyCode <= WXK_NUMPAD_DIVIDE) ||
-#if defined(__WXMAC__)
-          (keyCode > WXK_RAW_CONTROL) ||
-#endif
-          (keyCode > WXK_WINDOWS_MENU);
-}
-
 // Check for keys that we will process
 bool LabelTrackView::DoCaptureKey(
    AudacityProject &project, wxKeyEvent & event )
@@ -1372,7 +1095,7 @@ bool LabelTrackView::DoCaptureKey(
       return true;
 
    if (IsValidIndex(mTextEditIndex, project)) {
-      if (IsGoodLabelEditKey(event)) {
+      if (TextEditHelper::IsGoodEditKeyCode(code)) {
          return true;
       }
    }
@@ -1430,32 +1153,9 @@ unsigned LabelTrackView::KeyDown(
    double bkpSel0 = viewInfo.selectedRegion.t0(),
       bkpSel1 = viewInfo.selectedRegion.t1();
 
-   if (IsValidIndex(mTextEditIndex, *project) && !mTextEditIndex.IsModified()) {
-      const auto pTrack = FindLabelTrack();
-      const auto &mLabels = pTrack->GetLabels();
-      auto labelStruct = mLabels[mTextEditIndex];
-      auto &title = labelStruct.title;
-      mUndoLabel = title;
-   }
-
    // Pass keystroke to labeltrack's handler and add to history if any
    // updates were done
-   if (DoKeyDown( *project, viewInfo.selectedRegion, event )) {
-      ProjectHistory::Get( *project ).PushState(XO("Modified Label"),
-         XO("Label Edit"),
-         mTextEditIndex.IsModified() ? UndoPush::CONSOLIDATE : UndoPush::NONE);
-
-      mTextEditIndex.SetModified(true);
-   }
-
-   if (!mTextEditIndex.IsModified()) {
-      mUndoLabel.clear();
-   }
-
-   // Make sure caret is in view
-   int x;
-   if (CalcCursorX( *project, &x ))
-      ProjectWindow::Get( *project ).ScrollIntoView(x);
+   DoKeyDown(*project, viewInfo.selectedRegion, event);
 
    // If selection modified, refresh
    // Otherwise, refresh track display if the keystroke was handled
@@ -1473,28 +1173,8 @@ unsigned LabelTrackView::Char(
 {
    double bkpSel0 = viewInfo.selectedRegion.t0(),
       bkpSel1 = viewInfo.selectedRegion.t1();
-   // Pass keystroke to labeltrack's handler and add to history if any
-   // updates were done
 
-   if (IsValidIndex(mTextEditIndex, *project) && !mTextEditIndex.IsModified()) {
-      const auto pTrack = FindLabelTrack();
-      const auto &mLabels = pTrack->GetLabels();
-      auto labelStruct = mLabels[mTextEditIndex];
-      auto &title = labelStruct.title;
-      mUndoLabel = title;
-   }
-
-   if (DoChar( *project, viewInfo.selectedRegion, event )) {
-      ProjectHistory::Get( *project ).PushState(XO("Modified Label"),
-         XO("Label Edit"),
-          mTextEditIndex.IsModified() ? UndoPush::CONSOLIDATE : UndoPush::NONE);
-
-      mTextEditIndex.SetModified(true);
-   }
-
-   if (!mTextEditIndex.IsModified()) {
-      mUndoLabel.clear();
-   }
+   DoChar( *project, viewInfo.selectedRegion, event );
 
    // If selection modified, refresh
    // Otherwise, refresh track display if the keystroke was handled
@@ -1508,12 +1188,9 @@ unsigned LabelTrackView::Char(
 }
 
 /// KeyEvent is called for every keypress when over the label track.
-bool LabelTrackView::DoKeyDown(
+void LabelTrackView::DoKeyDown(
    AudacityProject &project, NotifyingSelectedRegion &newSel, wxKeyEvent & event)
 {
-   // Only track true changes to the label
-   bool updated = false;
-
    // Cache the keycode
    int keyCode = event.GetKeyCode();
    const int mods = event.GetModifiers();
@@ -1524,7 +1201,7 @@ bool LabelTrackView::DoKeyDown(
    if ((keyCode != WXK_F2 && mods != wxMOD_NONE && mods != wxMOD_SHIFT)
       || (keyCode == WXK_F2 && mods != wxMOD_CONTROL)) {
       event.Skip();
-      return updated;
+      return;
    }
 
    // All editing keys are only active if we're currently editing a label
@@ -1532,179 +1209,37 @@ bool LabelTrackView::DoKeyDown(
    const auto &mLabels = pTrack->GetLabels();
    if (IsValidIndex(mTextEditIndex, project)) {
       // Do label text changes
-      auto labelStruct = mLabels[mTextEditIndex];
-      auto &title = labelStruct.title;
-      wxUniChar wchar;
-      bool more=true;
+       if (auto editHelper = mTextEditHelper)
+       {
+           // Make sure caret is in view
+           int x{ 0 };
+           if (editHelper->GetCharPositionX(editHelper->GetSelection().second, &x))
+               ProjectWindow::Get(project).ScrollIntoView(x);
 
-      switch (keyCode) {
-
-      case WXK_BACK:
-         {
-            int len = title.length();
-
-            //IF the label is not blank THEN get rid of a letter or letters according to cursor position
-            if (len > 0)
-            {
-               // IF there are some highlighted letters, THEN DELETE them
-               if (mInitialCursorPos != mCurrentCursorPos)
-                  RemoveSelectedText();
-               else
+           if (!editHelper->OnKeyDown(keyCode, mods, &project))
+           {
+               switch (keyCode)
                {
-                  // DELETE one codepoint leftwards
-                  while ((mCurrentCursorPos > 0) && more) {
-                     wchar = title.at( mCurrentCursorPos-1 );
-                     title.erase(mCurrentCursorPos-1, 1);
-                     mCurrentCursorPos--;
-                     if( ((int)wchar > 0xDFFF) || ((int)wchar <0xDC00)){
-                        pTrack->SetLabel(mTextEditIndex, labelStruct);
-                        more = false;
-                     }
-                  }
-               }
-            }
-            else
-            {
-               // ELSE no text in text box, so DELETE whole label.
-               pTrack->DeleteLabel(mTextEditIndex);
-               ResetTextSelection();
-            }
-            mInitialCursorPos = mCurrentCursorPos;
-            updated = true;
-         }
-         break;
-
-      case WXK_DELETE:
-      case WXK_NUMPAD_DELETE:
-         {
-            int len = title.length();
-
-            //If the label is not blank get rid of a letter according to cursor position
-            if (len > 0)
-            {
-               // if there are some highlighted letters, DELETE them
-               if (mInitialCursorPos != mCurrentCursorPos)
-                  RemoveSelectedText();
-               else
+               case WXK_BACK:
+               case WXK_DELETE:
+               case WXK_NUMPAD_DELETE:
+                   pTrack->DeleteLabel(mTextEditIndex);
+                   ResetTextSelection();
+                   break;
+               case '\x10':   // OSX
+               case WXK_MENU:
+               case WXK_WINDOWS_MENU:
                {
-                  // DELETE one codepoint rightwards
-                  while ((mCurrentCursorPos < len) && more) {
-                     wchar = title.at( mCurrentCursorPos );
-                     title.erase(mCurrentCursorPos, 1);
-                     if( ((int)wchar > 0xDBFF) || ((int)wchar <0xD800)){
-                        pTrack->SetLabel(mTextEditIndex, labelStruct);
-                        more = false;
-                     }
-                  }
+                   int x{ 0 };
+                   if (editHelper->GetCharPositionX(editHelper->GetSelection().second, &x))
+                       ShowContextMenu(project, { x, editHelper->GetBBox().GetBottom() });
+               } break;
+               default:
+                   if (!TextEditHelper::IsGoodEditKeyCode(keyCode))
+                       event.Skip();
                }
-            }
-            else
-            {
-               // DELETE whole label if no text in text box
-               pTrack->DeleteLabel(mTextEditIndex);
-               ResetTextSelection();
-            }
-            mInitialCursorPos = mCurrentCursorPos;
-            updated = true;
-         }
-         break;
-
-      case WXK_HOME:
-      case WXK_NUMPAD_HOME:
-         // Move cursor to beginning of label
-         mCurrentCursorPos = 0;
-         if (mods == wxMOD_SHIFT)
-            ;
-         else
-            mInitialCursorPos = mCurrentCursorPos;
-         break;
-
-      case WXK_END:
-      case WXK_NUMPAD_END:
-         // Move cursor to end of label
-         mCurrentCursorPos = (int)title.length();
-         if (mods == wxMOD_SHIFT)
-            ;
-         else
-            mInitialCursorPos = mCurrentCursorPos;
-         break;
-
-      case WXK_LEFT:
-      case WXK_NUMPAD_LEFT:
-         // Moving cursor left
-         if (mods != wxMOD_SHIFT && mCurrentCursorPos != mInitialCursorPos)
-            //put cursor to the left edge of selection
-            mInitialCursorPos = mCurrentCursorPos =
-               std::min(mInitialCursorPos, mCurrentCursorPos);
-         else
-         {
-            while ((mCurrentCursorPos > 0) && more) {
-               wchar = title.at(mCurrentCursorPos - 1);
-               more = !(((int)wchar > 0xDFFF) || ((int)wchar < 0xDC00));
-
-               --mCurrentCursorPos;
-            }
-            if (mods != wxMOD_SHIFT)
-               mInitialCursorPos = mCurrentCursorPos;
-         }
-         
-         break;
-
-      case WXK_RIGHT:
-      case WXK_NUMPAD_RIGHT:
-         // Moving cursor right
-         if(mods != wxMOD_SHIFT && mCurrentCursorPos != mInitialCursorPos)
-            //put cursor to the right edge of selection
-            mInitialCursorPos = mCurrentCursorPos =
-               std::max(mInitialCursorPos, mCurrentCursorPos);
-         else
-         {
-            while ((mCurrentCursorPos < (int)title.length()) && more) {
-               wchar = title.at(mCurrentCursorPos);
-               more = !(((int)wchar > 0xDBFF) || ((int)wchar < 0xD800));
-
-               ++mCurrentCursorPos;
-            }
-            if (mods != wxMOD_SHIFT)
-               mInitialCursorPos = mCurrentCursorPos;
-         }
-         break;
-
-      case WXK_ESCAPE:
-         if (mTextEditIndex.IsModified()) {
-            title = mUndoLabel;
-            pTrack->SetLabel(mTextEditIndex, labelStruct);
-
-            ProjectHistory::Get( project ).PushState(XO("Modified Label"),
-               XO("Label Edit"),
-               mTextEditIndex.IsModified() ? UndoPush::CONSOLIDATE : UndoPush::NONE);
-         }
-
-      case WXK_RETURN:
-      case WXK_NUMPAD_ENTER:
-      case WXK_TAB:
-         if (mRestoreFocus >= 0) {
-            auto track = *TrackList::Get( project ).Any()
-               .begin().advance(mRestoreFocus);
-            if (track)
-               TrackFocus::Get( project ).Set(track);
-            mRestoreFocus = -2;
-         }
-         SetNavigationIndex(mTextEditIndex);
-         ResetTextSelection();
-         break;
-      case '\x10':   // OSX
-      case WXK_MENU:
-      case WXK_WINDOWS_MENU:
-         ShowContextMenu( project );
-         break;
-
-      default:
-         if (!IsGoodLabelEditKey(event)) {
-            event.Skip();
-         }
-         break;
-      }
+           }
+       }
    }
    else
    {
@@ -1758,8 +1293,6 @@ bool LabelTrackView::DoKeyDown(
 
             if (mNavigationIndex >= 0 && mNavigationIndex < len) {
                const auto &labelStruct = mLabels[mNavigationIndex];
-               mCurrentCursorPos = labelStruct.title.length();
-               mInitialCursorPos = mCurrentCursorPos;
                //Set the selection region to be equal to the selection bounds of the tabbed-to label.
                newSel = labelStruct.selectedRegion;
                ProjectWindow::Get(project).ScrollIntoView(labelStruct.selectedRegion.t0());
@@ -1783,7 +1316,7 @@ bool LabelTrackView::DoKeyDown(
          // Hardcoded Ctrl+F2 activates editing of the label
          // pointed to by mNavigationIndex (if valid)
          if (IsValidIndex(mNavigationIndex, project)) {
-             SetTextSelection(mNavigationIndex);
+             StartLabelTextEdit(mNavigationIndex, &project);
          }
          break;
       default:
@@ -1793,13 +1326,11 @@ bool LabelTrackView::DoKeyDown(
          break;
       }
    }
-
-   return updated;
 }
 
 /// OnChar is called for incoming characters -- that's any keypress not handled
 /// by OnKeyDown.
-bool LabelTrackView::DoChar(
+void LabelTrackView::DoChar(
    AudacityProject &project, NotifyingSelectedRegion &WXUNUSED(newSel),
    wxKeyEvent & event)
 {
@@ -1810,7 +1341,7 @@ bool LabelTrackView::DoChar(
    const int mods = event.GetModifiers();
    if (mods != wxMOD_NONE && mods != wxMOD_SHIFT) {
       event.Skip();
-      return false;
+      return;
    }
 
    // Only track true changes to the label
@@ -1822,7 +1353,7 @@ bool LabelTrackView::DoChar(
    // Skip if it's not a valid unicode character or a control character
    if (charCode == 0 || wxIscntrl(charCode)) {
       event.Skip();
-      return false;
+      return;
    }
    
    // If we've reached this point and aren't currently editing, add NEW label
@@ -1831,7 +1362,7 @@ bool LabelTrackView::DoChar(
       // Don't create a NEW label for a space
       if (wxIsspace(charCode)) {
          event.Skip();
-         return false;
+         return;
       }
       bool useDialog;
       gPrefs->Read(wxT("/GUI/DialogForNameNewLabel"), &useDialog, false);
@@ -1841,13 +1372,13 @@ bool LabelTrackView::DoChar(
          if (DialogForLabelName(
             project, selectedRegion, charCode, title) ==
              wxID_CANCEL) {
-            return false;
+            return;
          }
          pTrack->SetSelected(true);
          pTrack->AddLabel(selectedRegion, title);
          ProjectHistory::Get( project )
             .PushState(XO("Added label"), XO("Label"));
-         return false;
+         return;
       }
       else {
          pTrack->SetSelected(true);
@@ -1857,41 +1388,10 @@ bool LabelTrackView::DoChar(
       }
    }
 
-   if (!IsValidIndex(mTextEditIndex, project))
-      return false;
+   if (!IsValidIndex(mTextEditIndex, project) || !mTextEditHelper)
+      return;
 
-   //
-   // Now we are definitely in a label; append the incoming character
-   //
-
-   // Test if cursor is in the end of string or not
-   if (mInitialCursorPos != mCurrentCursorPos)
-      RemoveSelectedText();
-
-   const auto& mLabels = pTrack->GetLabels();
-   auto labelStruct = mLabels[mTextEditIndex];
-   auto& title = labelStruct.title;
-
-   if (mCurrentCursorPos < (int)title.length()) {
-      // Get substring on the righthand side of cursor
-      wxString rightPart = title.Mid(mCurrentCursorPos);
-      // Set title to substring on the lefthand side of cursor
-      title = title.Left(mCurrentCursorPos);
-      //append charcode
-      title += charCode;
-      //append the right part substring
-      title += rightPart;
-   }
-   else
-      //append charCode
-      title += charCode;
-
-   pTrack->SetLabel(mTextEditIndex, labelStruct );
-
-   //moving cursor position forward
-   mInitialCursorPos = ++mCurrentCursorPos;
-   
-   return true;
+   mTextEditHelper->OnChar(charCode, &project);
 }
 
 enum
@@ -1903,7 +1403,7 @@ enum
    OnEditSelectedLabelID,
 };
 
-void LabelTrackView::ShowContextMenu( AudacityProject &project )
+void LabelTrackView::ShowContextMenu( AudacityProject &project, const wxPoint& position )
 {
    wxWindow *parent = wxWindow::FindFocus();
 
@@ -1925,8 +1425,8 @@ void LabelTrackView::ShowContextMenu( AudacityProject &project )
       menu.Append(OnDeleteSelectedLabelID, _("&Delete Label"));
       menu.Append(OnEditSelectedLabelID, _("&Edit Label..."));
 
-      menu.Enable(OnCutSelectedTextID, IsTextSelected( project ));
-      menu.Enable(OnCopySelectedTextID, IsTextSelected( project ));
+      menu.Enable(OnCutSelectedTextID, mTextEditHelper && !mTextEditHelper->IsSelectionEmpty());
+      menu.Enable(OnCopySelectedTextID, mTextEditHelper && !mTextEditHelper->IsSelectionEmpty());
       menu.Enable(OnPasteSelectedTextID, IsTextClipSupported());
       menu.Enable(OnDeleteSelectedLabelID, true);
       menu.Enable(OnEditSelectedLabelID, true);
@@ -1945,20 +1445,17 @@ void LabelTrackView::ShowContextMenu( AudacityProject &project )
          dc.SetFont(msFont);
       }
 
-      int x = 0;
-      bool success = CalcCursorX( project, &x );
-      wxASSERT(success);
-      static_cast<void>(success); // Suppress unused variable warning if debug mode is disabled
+      //int x = 0;
+      //bool success = CalcCursorX( project, &x );
+      //wxASSERT(success);
+      //static_cast<void>(success); // Suppress unused variable warning if debug mode is disabled
 
       // Bug #2571: Hackage alert! For some reason wxGTK does not like
       // displaying the LabelDialog from within the PopupMenu "context".
       // So, workaround it by editing the label AFTER the popup menu is
       // closed. It's really ugly, but it works.  :-(
       mEditIndex = -1;
-      BasicMenu::Handle{ &menu }.Popup(
-         wxWidgetsWindowPlacement{ parent },
-         { x, ls->y + (mIconHeight / 2) - 1 }
-      );
+      parent->PopupMenu(&menu, position.x, position.y);
       if (mEditIndex >= 0)
       {
          DoEditLabels( project, FindLabelTrack().get(), mEditIndex );
@@ -2021,30 +1518,6 @@ void LabelTrackView::OnContextMenu(
    }
 }
 
-void LabelTrackView::RemoveSelectedText()
-{
-   wxString left, right;
-
-   int init = mInitialCursorPos;
-   int cur = mCurrentCursorPos;
-   if (init > cur)
-      std::swap(init, cur);
-
-   const auto pTrack = FindLabelTrack();
-   const auto &mLabels = pTrack->GetLabels();
-   auto labelStruct = mLabels[mTextEditIndex];
-   auto &title = labelStruct.title;
-
-   if (init > 0)
-      left = title.Left(init);
-
-   if (cur < (int)title.length())
-      right = title.Mid(cur);
-
-   title = left + right;
-   pTrack->SetLabel( mTextEditIndex, labelStruct );
-   mInitialCursorPos = mCurrentCursorPos = left.length();
-}
 /*
 bool LabelTrackView::HasSelectedLabel( AudacityProject &project ) const
 {
@@ -2087,6 +1560,81 @@ int LabelTrackView::AddLabel(const SelectedRegion &selectedRegion,
    return pos;
 }
 
+void LabelTrackView::OnTextEditFinished(AudacityProject* project, const wxString& text)
+{
+    if (mRestoreFocus >= 0) {
+        auto& trackList = TrackList::Get(*project);
+        auto track = *trackList.Any()
+            .begin().advance(mRestoreFocus);
+        if (track)
+            TrackFocus::Get(*project).Set(track);
+        mRestoreFocus = -2;
+    }
+    SetNavigationIndex(mTextEditIndex);
+    ResetTextSelection();
+}
+
+void LabelTrackView::OnTextEditCancelled(AudacityProject* project)
+{
+    if (IsValidIndex(mTextEditIndex, *project)) 
+    {
+        mTextEditIndex.SetModified(true);
+        auto track = FindLabelTrack();
+        auto& labels = track->GetLabels();
+        auto label = labels[mTextEditIndex];
+        label.title = mUndoLabel;
+
+        track->SetLabel(mTextEditIndex, label);
+
+        ProjectHistory::Get(*project).PushState(XO("Modified Label"),
+            XO("Label Edit"),
+            mTextEditIndex.IsModified() ? UndoPush::CONSOLIDATE : UndoPush::NONE);
+        ResetTextSelection();
+    }
+}
+
+void LabelTrackView::OnTextModified(AudacityProject* project, const wxString& text)
+{
+    if (IsValidIndex(mTextEditIndex, *project))
+    {
+        auto track = FindLabelTrack();
+        auto& labels = track->GetLabels();
+        auto label = labels[mTextEditIndex];
+        label.title = text;
+
+        track->SetLabel(mTextEditIndex, label);
+
+        ProjectHistory::Get(*project).PushState(XO("Modified Label"),
+            XO("Label Edit"),
+            mTextEditIndex.IsModified() ? UndoPush::CONSOLIDATE : UndoPush::NONE);
+
+        mTextEditIndex.SetModified(true);
+    }
+}
+
+void LabelTrackView::OnTextContextMenu(AudacityProject* project, const wxPoint& position)
+{
+    ShowContextMenu(*project, position);
+}
+
+std::shared_ptr<TextEditHelper> LabelTrackView::StartLabelTextEdit(int labelIndex, AudacityProject* project)
+{
+   if (mTextEditIndex == labelIndex && mTextEditHelper)
+      return mTextEditHelper;
+
+   auto labelTrack = std::static_pointer_cast<LabelTrack>(FindTrack());
+   if (labelIndex < labelTrack->GetNumLabels())
+   {
+      auto label = labelTrack->GetLabel(labelIndex);
+      
+      mUndoLabel = label->title;
+      mTextEditIndex = labelIndex;
+      mTextEditHelper = MakeTextEditHelper(*label);
+      return mTextEditHelper;
+   }
+   return { };
+}
+
 void LabelTrackView::OnLabelAdded( const LabelTrackEvent &e )
 {
    if ( e.mpTrack.lock() != FindTrack() )
@@ -2095,15 +1643,12 @@ void LabelTrackView::OnLabelAdded( const LabelTrackEvent &e )
    const auto &title = e.mTitle;
    const auto pos = e.mPresentPosition;
 
-   mInitialCursorPos = mCurrentCursorPos = title.length();
-
    // restoreFocus is -2 e.g. from Nyquist label creation, when we should not
    // even lose the focus and open the label to edit in the first place.
    // -1 means we don't need to restore it to anywhere.
    // 0 or above is the track to restore to after editing the label is complete.
-   if( mRestoreFocus >= -1 )
-       mTextEditIndex = pos;
-
+   if (mRestoreFocus >= -1)
+      SetTextSelection(pos, title.Length(), title.Length());
    if( mRestoreFocus < 0 )
       mRestoreFocus = -2;
 }
@@ -2339,6 +1884,41 @@ int LabelTrackView::DialogForLabelName(
    }
 
    return status;
+}
+
+bool LabelTrackView::IsTextSelected(AudacityProject& project) const
+{
+   if (IsValidIndex(mTextEditIndex, project) && mTextEditHelper)
+      return !mTextEditHelper->IsSelectionEmpty();
+   return false;
+}
+
+
+void LabelTrackView::SetTextSelection(int labelIndex, const std::pair<int, int>& selection)
+{
+    SetTextSelection(labelIndex, selection.first, selection.second);
+}
+
+void LabelTrackView::SetTextSelection(int labelIndex, int start, int end)
+{
+    if (labelIndex < 0)
+        return;
+
+    if ((mTextEditIndex == labelIndex) && mTextEditHelper)
+        mTextEditHelper->SetSelection(start, end);
+    else
+    {
+        auto labelTrack = std::static_pointer_cast<LabelTrack>(FindTrack());
+        if (labelIndex >= labelTrack->GetNumLabels())
+            return;
+
+        auto label = labelTrack->GetLabel(labelIndex);
+
+        mUndoLabel = label->title;
+
+        mTextEditIndex = labelIndex;
+        mTextEditHelper = MakeTextEditHelper(*label);
+    }
 }
 
 using DoGetLabelTrackView = DoGetView::Override< LabelTrack >;


### PR DESCRIPTION
With LabelTextHelper introduced in #1258, which is basically wraps text editing logic from LabelTrackView and LabelTextHandle into a separete reusable object, it's possible now to remove extracted code from LabelTrackView and use TextEditHelper instead.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
