### PR TITLE
Not move clip on insertion by default

### DIFF
--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -85,7 +85,7 @@ void TracksBehaviorsPrefs::PopulateOrExchange(ShuttleGui & S)
                      true});
       S.TieCheckBox(XXO("Editing a clip can &move other clips"),
                     {wxT("/GUI/EditClipCanMove"),
-                     true});
+                     false});
       S.TieCheckBox(XXO("\"Move track focus\" c&ycles repeatedly through tracks"),
                     {wxT("/GUI/CircularTrackNavigation"),
                      false});
@@ -147,6 +147,6 @@ bool GetEditClipsCanMove()
    if( mIsSyncLocked )
       return true;
    bool editClipsCanMove;
-   gPrefs->Read(wxT("/GUI/EditClipCanMove"), &editClipsCanMove, true);
+   gPrefs->Read(wxT("/GUI/EditClipCanMove"), &editClipsCanMove, false);
    return editClipsCanMove;
 }


### PR DESCRIPTION
Changing "Editing a clip can move other clips" option default value to false

Resolves: #1333

Changing "Editing a clip can move other clips" option default value to false

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
