### PR TITLE
Fix VST time info samplePos units

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1436,7 +1436,7 @@ size_t VSTEffect::ProcessBlock(float **inBlock, float **outBlock, size_t blockLe
       callProcessReplacing(inBlock, outBlock, blockLen);
 
       // And track the position
-      mTimeInfo.samplePos += ((double) blockLen / mTimeInfo.sampleRate);
+      mTimeInfo.samplePos += (double) blockLen;
    }
 
    return blockLen;


### PR DESCRIPTION
Resolves: *(https://github.com/audacity/audacity/issues/1628)*

*VST time info samplePos should be a value in number of samples, not in seconds*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
