### PR TITLE
Fix journal of return key invoking default dialog button on Mac...

### DIFF
--- a/src/KeyboardCapture.cpp
+++ b/src/KeyboardCapture.cpp
@@ -213,6 +213,7 @@ public:
                   if ( auto button =
                      dynamic_cast<wxButton*>( top->GetDefaultItem() ) ) {
                      wxCommandEvent newEvent{ wxEVT_BUTTON, button->GetId() };
+                     newEvent.SetEventObject( button );
                      button->GetEventHandler()->AddPendingEvent( newEvent );
                      return Event_Processed;
                   }

--- a/src/widgets/ASlider.cpp
+++ b/src/widgets/ASlider.cpp
@@ -1323,6 +1323,7 @@ void LWSlider::OnKeyDown(wxKeyEvent & event)
                if (def && def->IsEnabled()) {
                   wxCommandEvent cevent(wxEVT_COMMAND_BUTTON_CLICKED,
                         def->GetId());
+                  cevent.SetEventObject( def );
                   mParent->GetEventHandler()->ProcessEvent(cevent);
                }
             }

--- a/src/widgets/Grid.cpp
+++ b/src/widgets/Grid.cpp
@@ -723,6 +723,7 @@ void Grid::OnKeyDown(wxKeyEvent &event)
             if (def && def->IsEnabled()) {
                wxCommandEvent cevent(wxEVT_COMMAND_BUTTON_CLICKED,
                                      def->GetId());
+               cevent.SetEventObject( def );
                GetParent()->GetEventHandler()->ProcessEvent(cevent);
             }
          }

--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -2024,6 +2024,7 @@ void NumericTextCtrl::OnKeyDown(wxKeyEvent &event)
       if (def && def->IsEnabled()) {
          wxCommandEvent cevent(wxEVT_COMMAND_BUTTON_CLICKED,
                                def->GetId());
+         cevent.SetEventObject( def );
          GetParent()->GetEventHandler()->ProcessEvent(cevent);
       }
    }


### PR DESCRIPTION
... and some other cases.

Wherever Audacity simulates button press events, set the event object to be the
button, so that WindowEventSerialization() in JournalEvents.cpp can determine
a pathname for the window associated with the event.

The change in KeyboardCapture is enough for the default buttons of dialogs. The
other changes are necessary but not sufficient for fixing journalling of some of
Audacity's custom widgets, on any operating system.

Resolves: #1631

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
