### PR TITLE
Journal toolbar buttons and sliders

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1380,7 +1380,7 @@ void AdornedRulerPanel::ReCreateButtons()
    size.y = std::min(size.y, GetRulerHeight(false));
 
    auto buttonMaker = [&]
-   (wxWindowID id, teBmps bitmap, bool toggle)
+   (wxWindowID id, teBmps bitmap, const TranslatableString &name, bool toggle)
    {
       const auto button =
       ToolBar::MakeButton(
@@ -1388,14 +1388,16 @@ void AdornedRulerPanel::ReCreateButtons()
          bmpRecoloredUpSmall, bmpRecoloredDownSmall, 
          bmpRecoloredUpHiliteSmall, bmpRecoloredHiliteSmall, 
          bitmap, bitmap, bitmap,
-         id, position, toggle, size
+         id, position, name, toggle, size
       );
 
       position.x += size.GetWidth();
       mButtons[iButton++] = button;
       return button;
    };
-   auto button = buttonMaker(OnTogglePinnedStateID, bmpPlayPointerPinned, true);
+   auto button = buttonMaker(OnTogglePinnedStateID, bmpPlayPointerPinned,
+      // i18n-hint "to pin" meaning fix in place
+      XO("Pin Play Head"), true);
    ToolBar::MakeAlternateImages(
 	   *button, 3,
 	   bmpRecoloredUpSmall, bmpRecoloredDownSmall,

--- a/src/AudacityFileConfig.cpp
+++ b/src/AudacityFileConfig.cpp
@@ -85,9 +85,11 @@ void AudacityFileConfig::Warn()
       {
          // Can't use themed bitmap since the theme manager might not be
          // initialized yet and it requires a configuration file.
-         wxButton *b = S.Id(wxID_HELP).AddBitmapButton(wxBitmap(Help_xpm));
-         b->SetToolTip( XO("Help").Translation() );
-         b->SetLabel(XO("Help").Translation());       // for screen readers
+         wxButton *b = S
+            .Id(wxID_HELP)
+            .Name( XO("Help") )
+            .ToolTip( XO("Help") )
+            .AddBitmapButton(wxBitmap(Help_xpm));
 
          b = S.Id(wxID_CANCEL).AddButton(XXO("&Quit Audacity"));
          b = S.Id(wxID_OK).AddButton(XXO("&Retry"));

--- a/src/JournalWindowPaths.cpp
+++ b/src/JournalWindowPaths.cpp
@@ -87,13 +87,13 @@ void FindPathComponents(
    const wxWindow &window, std::pair<wxArrayStringEx, bool> &results )
 {
    bool unique = false;
-   if ( dynamic_cast<const wxTopLevelWindow*>( &window ) )
-      unique = HasUniqueNameAmongPeers( window, wxTopLevelWindows );
-   else if ( auto pParent = window.GetParent() ) {
+   if ( auto pParent = window.GetParent() ) {
       // Recur
       FindPathComponents( *pParent, results );
       unique = HasUniqueNameAmongPeers( window, pParent->GetChildren() );
    }
+   else if ( dynamic_cast<const wxTopLevelWindow*>( &window ) )
+      unique = HasUniqueNameAmongPeers( window, wxTopLevelWindows );
 
    auto &components = results.first;
    components.push_back( window.GetName() );

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -273,7 +273,7 @@ MixerTrackCluster::MixerTrackCluster(wxWindow* parent,
    ctrlSize.Set(mMixerBoard->mMuteSoloWidth, MUTE_SOLO_HEIGHT);
    mToggleButton_Mute =
       safenew AButton(this, ID_TOGGLEBUTTON_MUTE,
-                  ctrlPos, ctrlSize,
+                  ctrlPos, ctrlSize, XO("Mute"),
                   *(mMixerBoard->mImageMuteUp), *(mMixerBoard->mImageMuteOver),
                   *(mMixerBoard->mImageMuteDown), *(mMixerBoard->mImageMuteDown),
                   *(mMixerBoard->mImageMuteDisabled),
@@ -288,7 +288,7 @@ MixerTrackCluster::MixerTrackCluster(wxWindow* parent,
    ctrlPos.y += MUTE_SOLO_HEIGHT;
    mToggleButton_Solo =
       safenew AButton(this, ID_TOGGLEBUTTON_SOLO,
-                  ctrlPos, ctrlSize,
+                  ctrlPos, ctrlSize, XO("Solo"),
                   *(mMixerBoard->mImageSoloUp), *(mMixerBoard->mImageSoloOver),
                   *(mMixerBoard->mImageSoloDown), *(mMixerBoard->mImageSoloDown), 
                   *(mMixerBoard->mImageSoloDisabled),

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -588,7 +588,10 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
       this, wxID_ANY, wxDefaultPosition,
       wxSize{ this->GetSize().GetWidth(), -1 }
    };
-   mTopPanel->SetLabel( "Top Panel" );// Not localised
+   // i18n-hint an area of a graphical window that can contain other windows
+   const auto topPanelName = XO("Top Panel");
+   mTopPanel->SetLabel( topPanelName );
+   mTopPanel->SetName( topPanelName );
    mTopPanel->SetLayoutDirection(wxLayout_LeftToRight);
    mTopPanel->SetAutoLayout(true);
 #ifdef EXPERIMENTAL_DA2
@@ -617,7 +620,10 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
       wxDefaultSize,
       wxNO_BORDER);
    mMainPanel->SetSizer( safenew wxBoxSizer(wxVERTICAL) );
-   mMainPanel->SetLabel("Main Panel");// Not localised.
+   // i18n-hint an area of a graphical window that can contain other windows
+   const auto mainPanelName = XO("Main Panel");
+   mMainPanel->SetLabel( mainPanelName );
+   mMainPanel->SetName( mainPanelName );
    pPage = mMainPanel;
    // Set the colour here to the track panel background to avoid
    // flicker when Audacity starts up.
@@ -1216,6 +1222,16 @@ void ProjectWindow::HandleResize()
 bool ProjectWindow::IsIconized() const
 {
    return mIconized;
+}
+
+wxPanel *ProjectWindow::GetMainPanel()
+{
+   return mMainPanel;
+}
+
+wxPanel *ProjectWindow::GetTopPanel()
+{
+   return mTopPanel;
 }
 
 void ProjectWindow::UpdateStatusWidths()

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -21,6 +21,7 @@ class Track;
 
 class wxScrollBar;
 class wxPanel;
+class wxPanelWrapper;
 
 class ProjectWindow;
 void InitProjectWindow( ProjectWindow &window );
@@ -53,8 +54,8 @@ public:
    void SetIsBeingDeleted() { mIsDeleting = true; }
 
    wxWindow *GetMainPage() { return mMainPage; }
-   wxPanel *GetMainPanel() { return mMainPanel; }
-   wxPanel *GetTopPanel() { return mTopPanel; }
+   wxPanel *GetMainPanel();
+   wxPanel *GetTopPanel();
 
    void UpdateStatusWidths();
 
@@ -182,9 +183,9 @@ public:
 private:
    wxRect mNormalizedWindowState;
 
-   wxPanel *mTopPanel{};
+   wxPanelWrapper *mTopPanel{};
    wxWindow * mMainPage{};
-   wxPanel * mMainPanel{};
+   wxPanelWrapper * mMainPanel{};
    wxScrollBar *mHsbar{};
    wxScrollBar *mVsbar{};
 

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -324,6 +324,7 @@ wxCheckBox * ShuttleGuiBase::AddCheckBox( const TranslatableString &Prompt, bool
    miProp=0;
    mpWind = pCheckBox = safenew wxCheckBox(GetParent(), miId, realPrompt, wxDefaultPosition, wxDefaultSize,
       GetStyle( 0 ));
+   pCheckBox->SetName( wxStripMenuCodes(realPrompt) );
    pCheckBox->SetValue(Selected);
    if (realPrompt.empty()) {
       // NVDA 2018.3 does not read controls which are buttons, check boxes or radio buttons which have
@@ -332,7 +333,7 @@ wxCheckBox * ShuttleGuiBase::AddCheckBox( const TranslatableString &Prompt, bool
       // so that name can be set on a standard control
       pCheckBox->SetAccessible(safenew WindowAccessible(pCheckBox));
 #endif
-      pCheckBox->SetName(wxT("\a"));      // non-empty string which screen readers do not read
+      pCheckBox->SetName(wxT("\a"));
    }
    UpdateSizers();
    return pCheckBox;

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -2356,9 +2356,10 @@ std::unique_ptr<wxSizer> CreateStdButtonSizer(wxWindow *parent, long buttons, wx
       // Replace standard Help button with smaller icon button.
       // bs->AddButton(safenew wxButton(parent, wxID_HELP));
       b = safenew wxBitmapButton(parent, wxID_HELP, theTheme.Bitmap( bmpHelpIcon ));
-      b->SetToolTip( XO("Help").Translation() );
-      b->SetLabel(XO("Help").Translation());       // for screen readers
-      b->SetName( b->GetLabel() );
+      auto name = XO("Help").Translation();
+      b->SetToolTip( name );
+      b->SetLabel( name );       // for screen readers
+      b->SetName( name ); // for journalling
       bs->AddButton( b );
    }
 #endif
@@ -2427,9 +2428,10 @@ std::unique_ptr<wxSizer> CreateStdButtonSizer(wxWindow *parent, long buttons, wx
       // Replace standard Help button with smaller icon button.
       // bs->AddButton(safenew wxButton(parent, wxID_HELP));
       b = safenew wxBitmapButton(parent, wxID_HELP, theTheme.Bitmap( bmpHelpIcon ));
-      b->SetToolTip( XO("Help").Translation() );
-      b->SetLabel(XO("Help").Translation());       // for screen readers
-      b->SetName( b->GetLabel() );
+      auto name = XO("Help").Translation();
+      b->SetToolTip( name );
+      b->SetLabel( name );       // for screen readers
+      b->SetName( name ); // for journalling
       bs->Add( b, 0, wxALIGN_CENTER );
    }
 #endif

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -537,9 +537,11 @@ wxComboBox * ShuttleGuiBase::AddCombo(
       Choices[i] = choices[i];
    }
 
+   auto name = wxStripMenuCodes(translated);
    mpWind = pCombo = safenew wxComboBox(GetParent(), miId, Selected, wxDefaultPosition, wxDefaultSize,
-      n, Choices, GetStyle( 0 ));
-   mpWind->SetName(wxStripMenuCodes(translated));
+      n, Choices, GetStyle( 0 ),
+      wxDefaultValidator,
+      name);
 
    UpdateSizers();
    return pCombo;

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -956,9 +956,17 @@ bool Exporter::ExportTracks()
    return success;
 }
 
+static const auto formatOptionsName = XO("Format Options");
+
 void Exporter::CreateUserPaneCallback(wxWindow *parent, wxUIntPtr userdata)
 {
-   Exporter *self = (Exporter *) userdata;
+   // Rename the parent and grandparent panels for journalling purposes.
+   const auto name = formatOptionsName.Translation();
+   parent->SetName(name);
+   parent->GetParent()->SetName(name);
+
+   Exporter *self =
+      static_cast<Exporter *>( reinterpret_cast<void*>( userdata ) );
    if (self)
    {
       self->CreateUserPane(parent);
@@ -969,18 +977,22 @@ void Exporter::CreateUserPane(wxWindow *parent)
 {
    ShuttleGui S(parent, eIsCreating);
 
-   S.StartStatic(XO("Format Options"), 1);
+   S.StartStatic(formatOptionsName, 1);
    {
       S.StartHorizontalLay(wxEXPAND);
       {
-         mBook = S.Position(wxEXPAND).StartSimplebook();
+         mBook = S
+            .Position(wxEXPAND)
+            .Name(XO("Export Plugins"))
+            .StartSimplebook();
          {
             for (const auto &pPlugin : mPlugins)
             {
                for (int j = 0; j < pPlugin->GetFormatCount(); j++)
                {
                   // Name of simple book page is not displayed
-                  S.StartNotebookPage( {} );
+                  // But needs to be distinct from other pages for journalling
+                  S.StartNotebookPage( pPlugin->GetDescription(j) );
                   {
                      pPlugin->OptionsCreate(S, j);
                   }

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -991,8 +991,10 @@ void Exporter::CreateUserPane(wxWindow *parent)
          S.EndSimplebook();
 
          auto b = safenew wxBitmapButton(S.GetParent(), wxID_HELP, theTheme.Bitmap( bmpHelpIcon ));
-         b->SetToolTip( XO("Help").Translation() );
-         b->SetLabel(XO("Help").Translation());       // for screen readers
+         auto name = XO("Help").Translation();
+         b->SetToolTip( name );
+         b->SetLabel( name );       // for screen readers
+         b->SetName( name ); // for journalling
          S.Position(wxALIGN_BOTTOM | wxRIGHT | wxBOTTOM).AddWindow(b);
       }
       S.EndHorizontalLay();

--- a/src/export/ExportCL.cpp
+++ b/src/export/ExportCL.cpp
@@ -50,6 +50,8 @@
    }
 #endif
 
+static const auto Description = XO("(external program)");
+
 //----------------------------------------------------------------------------
 // ExportCLOptions
 //----------------------------------------------------------------------------
@@ -84,6 +86,7 @@ END_EVENT_TABLE()
 ExportCLOptions::ExportCLOptions(wxWindow *parent, int WXUNUSED(format))
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(Description);
    mHistory.Load(*gPrefs, wxT("/FileFormats/ExternalProgramHistory"));
 
    if (mHistory.empty()) {
@@ -352,7 +355,7 @@ ExportCL::ExportCL()
    AddExtension(wxT(""),0);
    SetMaxChannels(255,0);
    SetCanMetaData(false,0);
-   SetDescription(XO("(external program)"),0);
+   SetDescription(Description,0);
 }
 
 ProgressResult ExportCL::Export(AudacityProject *project,

--- a/src/export/ExportFFmpeg.cpp
+++ b/src/export/ExportFFmpeg.cpp
@@ -1317,37 +1317,43 @@ void ExportFFmpeg::OptionsCreate(ShuttleGui &S, int format)
    if (mSubFormat == FMT_M4A)
    {
       S.AddWindow(
-         safenew ExportFFmpegAACOptions{ S.GetParent(), format } );
+         safenew ExportFFmpegAACOptions{
+            S.GetParent(), format, GetDescription(FMT_M4A) } );
       return;
    }
    else if (mSubFormat == FMT_AC3)
    {
       S.AddWindow(
-         safenew ExportFFmpegAC3Options{ S.GetParent(), format } );
+         safenew ExportFFmpegAC3Options{
+            S.GetParent(), format, GetDescription(FMT_AC3) } );
       return;
    }
    else if (mSubFormat == FMT_AMRNB)
    {
       S.AddWindow(
-         safenew ExportFFmpegAMRNBOptions{ S.GetParent(), format } );
+         safenew ExportFFmpegAMRNBOptions{
+            S.GetParent(), format, GetDescription(FMT_AMRNB) } );
       return;
    }
    else if (mSubFormat == FMT_OPUS)
    {
       S.AddWindow(
-         safenew ExportFFmpegOPUSOptions{ S.GetParent(), format });
+         safenew ExportFFmpegOPUSOptions{
+            S.GetParent(), format, GetDescription(FMT_OPUS) });
       return;
    }
    else if (mSubFormat == FMT_WMA2)
    {
       S.AddWindow(
-         safenew ExportFFmpegWMAOptions{ S.GetParent(), format } );
+         safenew ExportFFmpegWMAOptions{
+            S.GetParent(), format, GetDescription(FMT_WMA2) } );
       return;
    }
    else if (mSubFormat == FMT_OTHER)
    {
       S.AddWindow(
-         safenew ExportFFmpegCustomOptions{ S.GetParent(), format } );
+         safenew ExportFFmpegCustomOptions{
+            S.GetParent(), format, GetDescription(FMT_OTHER) } );
       return;
    }
 

--- a/src/export/ExportFFmpegDialogs.cpp
+++ b/src/export/ExportFFmpegDialogs.cpp
@@ -828,10 +828,10 @@ void ExportFFmpegCustomOptions::PopulateOrExchange(ShuttleGui & S)
          S.Id(OpenID).AddButton(XXO("Open custom FFmpeg format options"));
          S.StartMultiColumn(2, wxCENTER);
          {
-            S.AddPrompt(XXO("Current Format:"));
-            mFormat = S.Style(wxTE_READONLY).AddTextBox({}, wxT(""), 25);
-            S.AddPrompt(XXO("Current Codec:"));
-            mCodec = S.Style(wxTE_READONLY).AddTextBox({}, wxT(""), 25);
+            mFormat = S.Style(wxTE_READONLY)
+               .AddTextBox(XXO("Current Format:"), wxT(""), 25);
+            mCodec = S.Style(wxTE_READONLY)
+               .AddTextBox(XXO("Current Codec:"), wxT(""), 25);
          }
          S.EndMultiColumn();
       }

--- a/src/export/ExportFFmpegDialogs.cpp
+++ b/src/export/ExportFFmpegDialogs.cpp
@@ -195,9 +195,13 @@ const std::vector< int > AC3BitRateValues{
 
 const int ExportFFmpegAC3Options::iAC3SampleRates[] = { 32000, 44100, 48000, 0 };
 
-ExportFFmpegAC3Options::ExportFFmpegAC3Options(wxWindow *parent, int WXUNUSED(format))
+ExportFFmpegAC3Options::ExportFFmpegAC3Options(
+   wxWindow *parent, int WXUNUSED(format),
+   const TranslatableString &description)
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
 
@@ -257,9 +261,13 @@ bool ExportFFmpegAC3Options::TransferDataFromWindow()
 // ExportFFmpegAACOptions Class
 //----------------------------------------------------------------------------
 
-ExportFFmpegAACOptions::ExportFFmpegAACOptions(wxWindow *parent, int WXUNUSED(format))
+ExportFFmpegAACOptions::ExportFFmpegAACOptions(
+   wxWindow *parent, int WXUNUSED(format),
+   const TranslatableString &description)
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
 
@@ -350,9 +358,13 @@ const std::vector< int > AMRNBBitRateValues
 
 }
 
-ExportFFmpegAMRNBOptions::ExportFFmpegAMRNBOptions(wxWindow *parent, int WXUNUSED(format))
+ExportFFmpegAMRNBOptions::ExportFFmpegAMRNBOptions(
+   wxWindow *parent, int WXUNUSED(format),
+   const TranslatableString &description)
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
 
@@ -581,9 +593,13 @@ namespace {
    };
 }
 
-ExportFFmpegOPUSOptions::ExportFFmpegOPUSOptions(wxWindow *parent, int WXUNUSED(format))
+ExportFFmpegOPUSOptions::ExportFFmpegOPUSOptions(
+   wxWindow *parent, int WXUNUSED(format),
+   const TranslatableString &description)
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
 
@@ -709,9 +725,13 @@ const std::vector< int > WMABitRateValues{
 
 }
 
-ExportFFmpegWMAOptions::ExportFFmpegWMAOptions(wxWindow *parent, int WXUNUSED(format))
+ExportFFmpegWMAOptions::ExportFFmpegWMAOptions(
+   wxWindow *parent, int WXUNUSED(format),
+   const TranslatableString &description)
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
 
@@ -777,11 +797,15 @@ BEGIN_EVENT_TABLE(ExportFFmpegCustomOptions, wxPanelWrapper)
    EVT_BUTTON(OpenID, ExportFFmpegCustomOptions::OnOpen)
 END_EVENT_TABLE()
 
-ExportFFmpegCustomOptions::ExportFFmpegCustomOptions(wxWindow *parent, int WXUNUSED(format))
+ExportFFmpegCustomOptions::ExportFFmpegCustomOptions(
+   wxWindow *parent, int WXUNUSED(format),
+   const TranslatableString &description)
 :  wxPanelWrapper(parent, wxID_ANY),
    mFormat(NULL),
    mCodec(NULL)
 {
+   SetName(description);
+
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
 

--- a/src/export/ExportFFmpegDialogs.h
+++ b/src/export/ExportFFmpegDialogs.h
@@ -72,7 +72,8 @@ class ExportFFmpegAC3Options final : public wxPanelWrapper
 {
 public:
 
-   ExportFFmpegAC3Options(wxWindow *parent, int format);
+   ExportFFmpegAC3Options(
+      wxWindow *parent, int format, const TranslatableString &description);
    virtual ~ExportFFmpegAC3Options();
 
    void PopulateOrExchange(ShuttleGui & S);
@@ -93,7 +94,8 @@ class ExportFFmpegAACOptions final : public wxPanelWrapper
 {
 public:
 
-   ExportFFmpegAACOptions(wxWindow *parent, int format);
+   ExportFFmpegAACOptions(
+      wxWindow *parent, int format, const TranslatableString &description);
    virtual ~ExportFFmpegAACOptions();
 
    void PopulateOrExchange(ShuttleGui & S);
@@ -105,7 +107,8 @@ class ExportFFmpegAMRNBOptions final : public wxPanelWrapper
 {
 public:
 
-   ExportFFmpegAMRNBOptions(wxWindow *parent, int format);
+   ExportFFmpegAMRNBOptions(
+      wxWindow *parent, int format, const TranslatableString &description);
    virtual ~ExportFFmpegAMRNBOptions();
 
    void PopulateOrExchange(ShuttleGui & S);
@@ -122,7 +125,8 @@ class ExportFFmpegOPUSOptions final : public wxPanelWrapper
 {
 public:
 
-   ExportFFmpegOPUSOptions(wxWindow *parent, int format);
+   ExportFFmpegOPUSOptions(
+      wxWindow *parent, int format, const TranslatableString &description);
    ~ExportFFmpegOPUSOptions();
 
    void PopulateOrExchange(ShuttleGui & S);
@@ -156,7 +160,8 @@ class ExportFFmpegWMAOptions final : public wxPanelWrapper
 {
 public:
 
-   ExportFFmpegWMAOptions(wxWindow *parent, int format);
+   ExportFFmpegWMAOptions(
+      wxWindow *parent, int format, const TranslatableString &description);
    ~ExportFFmpegWMAOptions();
 
    void PopulateOrExchange(ShuttleGui & S);
@@ -175,7 +180,8 @@ class ExportFFmpegCustomOptions final : public wxPanelWrapper
 {
 public:
 
-   ExportFFmpegCustomOptions(wxWindow *parent, int format);
+   ExportFFmpegCustomOptions(
+      wxWindow *parent, int format, const TranslatableString &description);
    ~ExportFFmpegCustomOptions();
 
    void PopulateOrExchange(ShuttleGui & S);

--- a/src/export/ExportFLAC.cpp
+++ b/src/export/ExportFLAC.cpp
@@ -38,6 +38,8 @@ Joshua Haberman
 #include "../widgets/ProgressDialog.h"
 #include "wxFileNameWrapper.h"
 
+static const auto description = XO("FLAC Files");
+
 //----------------------------------------------------------------------------
 // ExportFLACOptions Class
 //----------------------------------------------------------------------------
@@ -59,6 +61,8 @@ public:
 ExportFLACOptions::ExportFLACOptions(wxWindow *parent, int WXUNUSED(format))
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
 
@@ -237,7 +241,7 @@ ExportFLAC::ExportFLAC()
    AddExtension(wxT("flac"),0);
    SetMaxChannels(FLAC__MAX_CHANNELS,0);
    SetCanMetaData(true,0);
-   SetDescription(XO("FLAC Files"),0);
+   SetDescription(description,0);
 }
 
 ProgressResult ExportFLAC::Export(AudacityProject *project,

--- a/src/export/ExportMP2.cpp
+++ b/src/export/ExportMP2.cpp
@@ -123,6 +123,8 @@ const std::vector< int > BitRateValues {
 
 }
 
+static const auto description = XO("MP2 Files");
+
 class ExportMP2Options final : public wxPanelWrapper
 {
 public:
@@ -139,6 +141,8 @@ public:
 ExportMP2Options::ExportMP2Options(wxWindow *parent, int WXUNUSED(format))
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
 
@@ -237,7 +241,7 @@ ExportMP2::ExportMP2()
    AddExtension(wxT("mp2"),0);
    SetMaxChannels(2,0);
    SetCanMetaData(true,0);
-   SetDescription(XO("MP2 Files"),0);
+   SetDescription(description,0);
 }
 
 ProgressResult ExportMP2::Export(AudacityProject *project,

--- a/src/export/ExportMP3.cpp
+++ b/src/export/ExportMP3.cpp
@@ -273,11 +273,15 @@ BEGIN_EVENT_TABLE(ExportMP3Options, wxPanelWrapper)
    EVT_CHECKBOX(ID_MONO,      ExportMP3Options::OnMono)
 END_EVENT_TABLE()
 
+static const auto description = XO("MP3 Files");
+
 ///
 ///
 ExportMP3Options::ExportMP3Options(wxWindow *parent, int WXUNUSED(format))
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    mSetRate = gPrefs->Read(wxT("/FileFormats/MP3SetRate"), PRESET_STANDARD);
    mVbrRate = gPrefs->Read(wxT("/FileFormats/MP3VbrRate"), QUALITY_2);
    mAbrRate = gPrefs->Read(wxT("/FileFormats/MP3AbrRate"), 192);
@@ -1730,7 +1734,7 @@ ExportMP3::ExportMP3()
    AddExtension(wxT("mp3"),0);
    SetMaxChannels(2,0);
    SetCanMetaData(true,0);
-   SetDescription(XO("MP3 Files"),0);
+   SetDescription(description,0);
 }
 
 bool ExportMP3::CheckFileName(wxFileName & WXUNUSED(filename), int WXUNUSED(format))

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -307,7 +307,8 @@ void ExportMultipleDialog::PopulateOrExchange(ShuttleGui& S)
                   for (int j = 0; j < pPlugin->GetFormatCount(); j++)
                   {
                      // Name of simple book page is not displayed
-                     S.StartNotebookPage( {} );
+                     // But needs to be distinct from other pages for journalling
+                     S.StartNotebookPage( pPlugin->GetDescription(j) );
                      pPlugin->OptionsCreate(S, j);
                      S.EndNotebookPage();
                   }

--- a/src/export/ExportOGG.cpp
+++ b/src/export/ExportOGG.cpp
@@ -54,11 +54,15 @@ private:
    int mOggQualityUnscaled;
 };
 
+static const auto description = XO("Ogg Vorbis Files");
+
 ///
 ///
 ExportOGGOptions::ExportOGGOptions(wxWindow *parent, int WXUNUSED(format))
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    mOggQualityUnscaled = gPrefs->Read(wxT("/FileFormats/OggExportQuality"),50)/10;
 
    ShuttleGui S(this, eIsCreatingFromPrefs);
@@ -153,7 +157,7 @@ ExportOGG::ExportOGG()
    AddExtension(wxT("ogg"),0);
    SetMaxChannels(255,0);
    SetCanMetaData(true,0);
-   SetDescription(XO("Ogg Vorbis Files"),0);
+   SetDescription(description,0);
 }
 
 ProgressResult ExportOGG::Export(AudacityProject *project,

--- a/src/export/ExportPCM.cpp
+++ b/src/export/ExportPCM.cpp
@@ -152,9 +152,13 @@ BEGIN_EVENT_TABLE(ExportPCMOptions, wxPanelWrapper)
    EVT_CHOICE(ID_ENCODING_CHOICE, ExportPCMOptions::OnEncodingChoice)
 END_EVENT_TABLE()
 
+static const auto description = XO("Other uncompressed files");
+
 ExportPCMOptions::ExportPCMOptions(wxWindow *parent, int selformat)
 :  wxPanelWrapper(parent, wxID_ANY)
 {
+   SetName(description);
+
    // Remember the selection format
    mSelFormat = selformat;
 
@@ -432,7 +436,7 @@ ExportPCM::ExportPCM()
    selformat = AddFormat() - 1;     // Matches FMT_OTHER
    SetExtensions(sf_get_all_extensions(), selformat);
    SetFormat(wxT("LIBSNDFILE"), selformat);
-   SetDescription(XO("Other uncompressed files"), selformat);
+   SetDescription(description, selformat);
    SetCanMetaData(true, selformat);
    SetMaxChannels(255, selformat);
 }

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -128,8 +128,10 @@ void QuickFixDialog::AddStuck( ShuttleGui & S, bool & bBool,
      // Replace standard Help button with smaller icon button.
       // bs->AddButton(safenew wxButton(parent, wxID_HELP));
       auto b = safenew wxBitmapButton(S.GetParent(), HelpButtonID+mItem, theTheme.Bitmap( bmpHelpIcon ));
-      b->SetToolTip( _("Help") );
-      b->SetLabel(_("Help"));       // for screen readers
+      auto name = XO("Help").Translation();
+      b->SetToolTip( name );
+      b->SetLabel( name );       // for screen readers
+      b->SetName( name ); // for journalling
       b->Bind( wxEVT_BUTTON, [this, Help](const wxCommandEvent&){
          OnHelp( Help );
       } );

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -20,7 +20,7 @@
   This class, which is a child of Toolbar, creates the
   window containing the Transport (rewind/play/stop/record/ff)
   buttons. The window can be embedded within a
-  normal project window, or within a ToolBarFrame.
+  normal project window, or within a ToolFrame.
 
   All of the controls in this window were custom-written for
   Audacity - they are not native controls on any platform -

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -162,9 +162,8 @@ AButton *ControlToolBar::MakeButton(ControlToolBar *pBar,
       bmpRecoloredUpLarge, bmpRecoloredDownLarge, bmpRecoloredUpHiliteLarge, bmpRecoloredHiliteLarge,
       eEnabledUp, eEnabledDown, eDisabled,
       wxWindowID(id),
-      wxDefaultPosition, processdownevents,
+      wxDefaultPosition, label, processdownevents,
       theTheme.ImageSize( bmpRecoloredUpLarge ));
-   r->SetLabel(label);
    enum { deflation =
 #ifdef __WXMAC__
       6

--- a/src/toolbars/EditToolBar.cpp
+++ b/src/toolbars/EditToolBar.cpp
@@ -112,11 +112,10 @@ AButton *EditToolBar::AddButton(
       bmpRecoloredUpSmall, bmpRecoloredDownSmall, bmpRecoloredUpHiliteSmall, bmpRecoloredHiliteSmall,
       eEnabledUp, eEnabledDown, eDisabled,
       wxWindowID(id+first_ETB_ID),
-      wxDefaultPosition,
+      wxDefaultPosition, label,
       toggle,
       theTheme.ImageSize( bmpRecoloredUpSmall ));
 
-   r->SetLabel(label);
 // JKC: Unlike ControlToolBar, does not have a focus rect.  Shouldn't it?
 // r->SetFocusRect( r->GetRect().Deflate( 4, 4 ) );
 

--- a/src/toolbars/EditToolBar.cpp
+++ b/src/toolbars/EditToolBar.cpp
@@ -19,7 +19,7 @@
   window containing interfaces to commonly-used edit
   functions that are otherwise only available through
   menus. The window can be embedded within a normal project
-  window, or within a ToolBarFrame.
+  window, or within a ToolFrame.
 
   All of the controls in this window were custom-written for
   Audacity - they are not native controls on any platform -

--- a/src/toolbars/ScrubbingToolBar.cpp
+++ b/src/toolbars/ScrubbingToolBar.cpp
@@ -99,11 +99,10 @@ AButton *ScrubbingToolBar::AddButton
     bmpRecoloredUpSmall, bmpRecoloredDownSmall, bmpRecoloredUpHiliteSmall, bmpRecoloredHiliteSmall,
     eEnabledUp, eEnabledDown, eDisabled,
     wxWindowID(id),
-    wxDefaultPosition,
+    wxDefaultPosition, label,
     toggle,
     theTheme.ImageSize( bmpRecoloredUpSmall ));
 
-   r->SetLabel(label);
    // JKC: Unlike ControlToolBar, does not have a focus rect.  Shouldn't it?
    // r->SetFocusRect( r->GetRect().Deflate( 4, 4 ) );
 

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -847,6 +847,7 @@ AButton * ToolBar::MakeButton(wxWindow *parent,
                               teBmps eDisabled,
                               wxWindowID id,
                               wxPoint placement,
+                              const TranslatableString &name,
                               bool processdownevents,
                               wxSize size)
 {
@@ -863,8 +864,8 @@ AButton * ToolBar::MakeButton(wxWindow *parent,
 
    wxASSERT(parent); // to justify safenew
    AButton * button =
-      safenew AButton(parent, id, placement, size, *up2, *hilite2, *down2, *downHi2,
-            *disable2, processdownevents);
+      safenew AButton(parent, id, placement, size, name,
+         *up2, *hilite2, *down2, *downHi2, *disable2, processdownevents);
 
    return button;
 }

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -160,6 +160,7 @@ public:
                        teBmps eDisabled,
                        wxWindowID id,
                        wxPoint placement,
+                       const TranslatableString &name,
                        bool processdownevents,
                        wxSize size);
 

--- a/src/toolbars/ToolDock.cpp
+++ b/src/toolbars/ToolDock.cpp
@@ -375,11 +375,15 @@ END_EVENT_TABLE()
 //
 // Constructor
 //
-ToolDock::ToolDock( wxEvtHandler *manager, wxWindow *parent, int dockid ):
+ToolDock::ToolDock( const TranslatableString &name,
+   wxEvtHandler *manager, wxWindow *parent, int dockid ):
    wxPanelWrapper( parent, dockid, wxDefaultPosition, parent->GetSize() )
 {
-   SetLabel( XO( "ToolDock" ) );
-   SetName( XO( "ToolDock" ) );
+   // I doubt the label is ever shown.  Do we really need it to translate?
+   SetLabel( name );
+   // Do we need to translate the name too?  Maybe, if the screen reader might
+   // pronounce it.
+   SetName( name );
 
    // Init
    mManager = manager;

--- a/src/toolbars/ToolDock.h
+++ b/src/toolbars/ToolDock.h
@@ -290,7 +290,8 @@ class ToolDock final : public wxPanelWrapper
 {
 public:
 
-   ToolDock( wxEvtHandler *manager, wxWindow *parent, int dockid );
+   ToolDock( const TranslatableString &name,
+      wxEvtHandler *manager, wxWindow *parent, int dockid );
    ~ToolDock();
 
    bool AcceptsFocus() const override { return false; };

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -86,6 +86,8 @@ ToolFrame::ToolFrame
           wxFRAME_FLOAT_ON_PARENT )
    , mParent{ parent }
 {
+   SetName( bar->GetName() ); // For journalling
+   
    int width = bar->GetSize().x;
    int border = 1;
 

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -440,8 +440,13 @@ void ToolManager::CreateWindows()
    wxASSERT(topDockParent);
 
    // Create the top and bottom docks
-   mTopDock = safenew ToolDock( this, topDockParent, TopDockID );
-   mBotDock = safenew ToolDock( this, &window, BotDockID );
+   // Distinguish their names for reasons of journalling
+   // i18n-hint A graphical window area that tool bars can be dragged onto
+   mTopDock = safenew ToolDock( XO("Upper Tool Dock"),
+      this, topDockParent, TopDockID );
+   // i18n-hint A graphical window area that tool bars can be dragged onto
+   mBotDock = safenew ToolDock( XO("Lower Tool Dock"),
+      this, &window, BotDockID );
 
    // Create all of the toolbars
    // All have the project as parent window

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -183,9 +183,8 @@ AButton * ToolsToolBar::MakeTool(
       bmpRecoloredDownSmall, // Not bmpRecoloredHiliteSmall as down is inactive.
       eTool, eTool, eTool,
       wxWindowID(id + FirstToolID),
-      wxDefaultPosition, true,
+      wxDefaultPosition, label, true,
       theTheme.ImageSize( bmpRecoloredUpSmall ));
-   button->SetLabel( label );
    pBar->mToolSizer->Add( button );
    return button;
 }

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -175,11 +175,10 @@ AButton *TranscriptionToolBar::AddButton(
       bmpRecoloredUpSmall, bmpRecoloredDownSmall, bmpRecoloredUpHiliteSmall,bmpRecoloredHiliteSmall,
       eFore, eFore, eDisabled,
       wxWindowID(id),
-      wxDefaultPosition,
+      wxDefaultPosition, label,
       false,
       theTheme.ImageSize( bmpRecoloredUpSmall ));
 
-   r->SetLabel(label);
 // JKC: Unlike ControlToolBar, does not have a focus rect.  Shouldn't it?
 // r->SetFocusRect( r->GetRect().Deflate( 4, 4 ) );
 

--- a/src/widgets/AButton.cpp
+++ b/src/widgets/AButton.cpp
@@ -195,6 +195,7 @@ AButton::AButton(wxWindow * parent,
                  wxWindowID id,
                  const wxPoint & pos,
                  const wxSize & size,
+                 const TranslatableString &name,
                  ImageRoll up,
                  ImageRoll over,
                  ImageRoll down,
@@ -203,7 +204,7 @@ AButton::AButton(wxWindow * parent,
                  bool toggle):
    wxWindow()
 {
-   Init(parent, id, pos, size,
+   Init(parent, id, pos, size, name,
         up, over, down, overDown, dis,
         toggle);
 }
@@ -218,6 +219,7 @@ void AButton::Init(wxWindow * parent,
                    wxWindowID id,
                    const wxPoint & pos,
                    const wxSize & size,
+                   const TranslatableString &name,
                    ImageRoll up,
                    ImageRoll over,
                    ImageRoll down,
@@ -230,6 +232,9 @@ void AButton::Init(wxWindow * parent,
    // results in all characters being available in the OnKeyDown function below. Note
    // that OnKeyDown now has to handle navigation.
    Create(parent, id, pos, size, wxWANTS_CHARS);
+   const auto translated = name.Translation();
+   wxWindow::SetLabel( translated );
+   SetName( translated );
 
    mWasShiftDown = false;
    mWasControlDown = false;
@@ -256,7 +261,6 @@ void AButton::Init(wxWindow * parent,
    SetMaxSize(mImages[0].mArr[0].GetMaxSize());
 
 #if wxUSE_ACCESSIBILITY
-   SetName( wxT("") );
    SetAccessible(safenew AButtonAx(this));
 #endif
 }

--- a/src/widgets/AButton.h
+++ b/src/widgets/AButton.h
@@ -34,6 +34,7 @@ class AUDACITY_DLL_API AButton final : public wxWindow {
            wxWindowID id,
            const wxPoint & pos,
            const wxSize & size,
+           const TranslatableString &name, // for journalling and screen reader
            ImageRoll up,
            ImageRoll over,
            ImageRoll down,
@@ -153,6 +154,7 @@ class AUDACITY_DLL_API AButton final : public wxWindow {
              wxWindowID id,
              const wxPoint & pos,
              const wxSize & size,
+             const TranslatableString &name,
              ImageRoll up,
              ImageRoll over,
              ImageRoll down,

--- a/src/widgets/ASlider.cpp
+++ b/src/widgets/ASlider.cpp
@@ -1360,6 +1360,7 @@ void LWSlider::SendUpdate( float newValue )
    int intValue = (int)( ( mCurrentValue - mMinValue ) * 1000.0f /
                          ( mMaxValue - mMinValue ) );
    e.SetInt( intValue );
+   e.SetEventObject( mParent );
    mParent->GetEventHandler()->ProcessEvent(e);
 }
 

--- a/src/widgets/MultiDialog.cpp
+++ b/src/widgets/MultiDialog.cpp
@@ -146,9 +146,9 @@ MultiDialog::MultiDialog(wxWindow * pParent,
 
             if (!mHelpPage.empty()) {
                auto pHelpBtn = S.Id(wxID_HELP)
+                  .Name(XO("Help"))
+                  .ToolTip(XO("Help"))
                   .AddBitmapButton(theTheme.Bitmap(bmpHelpIcon), wxALIGN_CENTER, false);
-               pHelpBtn->SetToolTip(XO("Help").Translation());
-               pHelpBtn->SetLabel(XO("Help").Translation());       // for screen readers
             }
          }
          S.EndHorizontalLay();

--- a/src/widgets/wxPanelWrapper.h
+++ b/src/widgets/wxPanelWrapper.h
@@ -182,7 +182,9 @@ public:
       parent, message.Translation(), defaultDir, defaultFile,
       FileNames::FormatWildcard( fileTypes ),
       style, pos, sz, name.Translation() )
-   {}
+   {
+      SetName(name.Translation());
+   }
 
    // Pseudo ctor
    void Create(
@@ -202,6 +204,7 @@ public:
          FileNames::FormatWildcard( fileTypes ),
          style, pos, sz, name.Translation()
       );
+      SetName(name.Translation());
    }
 };
 


### PR DESCRIPTION
Resolves: #1632

Attempting to record a journal, with presses of buttons or dragging of sliders in the toolbars, will no longer fail with an error message, no matter whether the toolbars are docked above or below or are free-floating.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
