### PR TITLE
Context menu for picks in wave tracks between clips

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -835,7 +835,11 @@ std::vector<ComponentInterfaceSymbol> WaveTrackSubView::GetMenuItems(
          // { L"", XO("Rename clip...") },
       };
    else
-      return {};
+      return {
+         { L"Paste", XO("Paste")  },
+         {},
+         { L"TrackMute", XO("Mute/Unmute Track") },
+      };
 }
 
 WaveTrackView &WaveTrackView::Get( WaveTrack &track )


### PR DESCRIPTION
These changes are very simple, after previous context menu work.

Right-click between clips brings up a small context menu with Paste and Mute/Unmute.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
