### PR TITLE
Issue 1642 Fix by rdb

### DIFF
--- a/lib-src/libnyquist/nyquist/cmupv/src/cmupv.c
+++ b/lib-src/libnyquist/nyquist/cmupv/src/cmupv.c
@@ -129,8 +129,8 @@ typedef enum {
 
 struct position  // each element in the structure array
 {
-    long ana_pos; // the sample number of the center of analysis frame
-    long syn_pos; // the sample number of the center of synthesis frame
+    int64_t ana_pos; // the sample number of the center of analysis frame
+    int64_t syn_pos; // the sample number of the center of synthesis frame
 };
 
 typedef struct {
@@ -153,7 +153,7 @@ typedef struct {
     int mode; // 0 - normal, 1 - phase fix, 2 - robovoice
     float *ana_win; // the window function used on input (analysis)
     float *syn_win; // the window function used on output (synthesis)
-    long input_eff_pos; // input effective position is the sample number
+    int64_t input_eff_pos; // input effective position is the sample number
         // of the input that corresponds to the current output
     float *input_buffer; // used to buffer input samples
     long input_buffer_len; // how many floats can input_buffer hold?
@@ -200,10 +200,10 @@ typedef struct {
         // pos_buffer_rear, the queue is empty. Never points to 
         // pos_buffer + queue_length. It wraps around to pos_buffer.
     long queue_length; // length of the circular queue of corresponding times
-    long input_total; // how many input samples did we get so far?
+    int64_t input_total; // how many input samples did we get so far?
         // initially 0, and incremented upon pv_put_input()
         // so the input_total count corresponds to the input_rear pointer.
-    long output_total; // how many output samples did we produce so far?
+    int64_t output_total; // how many output samples did we produce so far?
         // initially 0, and incremented by block_size after each call to
         // pv_get_output(). Corresponds to out_next.
 } PV;
@@ -218,7 +218,7 @@ typedef struct {
 //
 int round_log_power(int fftsize, int *size_ptr)
 {
-    long double log2_fft = log2l(fftsize);
+    double log2_fft = log2l(fftsize);
     int round_log2_fft = (int) log2_fft;
     if (round_log2_fft < log2_fft) {
         round_log2_fft += 1;
@@ -1052,8 +1052,8 @@ float *pv_get_output2(Phase_vocoder x)
     // addded at frame_next, so we've already computed 
     // out_next - frame_next:
     while (blocksize > (pv->frame_next - out_next)) {
-        long out_cnt = (long) (pv->output_total + (pv->frame_next - out_next) + 
-                       fftsize / 2);
+        int64_t out_cnt = (pv->output_total + (pv->frame_next - out_next) + 
+                           fftsize / 2);
         // if there's no room in the output buffer, shift the samples.
         // This is done here to avoid extra work (sometimes pv_get_output2
         // can be called and the samples are already in the buffer so there's
@@ -1080,7 +1080,7 @@ float *pv_get_output2(Phase_vocoder x)
         /*DBG
         write_pv_frame(out_cnt - fftsize / 2, ana_frame, fftsize, "pvana");
         DBG*/
-	int i;
+        int i;
         for (i = 0; i < fftsize; i++) ana_frame[i] *= ana_win[i];
         compute_one_frame(pv, ana_hopsize);
         pv->first_time = FALSE;

--- a/lib-src/libnyquist/nyquist/cmupv/src/cmupv.h
+++ b/lib-src/libnyquist/nyquist/cmupv/src/cmupv.h
@@ -47,7 +47,7 @@ typedef void *Phase_vocoder; // a phase vocoder
 // len samples should be output at the given output sample count.
 // the hopsize should be returned.
 // Return value is the hopsize used (hop from previous input frame)
-typedef int (*Pv_callback)(long out_count, float *samples, int len, 
+typedef int (*Pv_callback)(int64_t out_count, float *samples, int len, 
                            void *rock);
 
 // create a phase vocoder. Pass in function pointers to allocate

--- a/lib-src/libnyquist/nyquist/nyqsrc/pvshell.c
+++ b/lib-src/libnyquist/nyquist/nyqsrc/pvshell.c
@@ -76,10 +76,12 @@ long pvshell_test_g(pvshell_type susp)
 }
 
 
-/* pvshell_fetch -- computes h(f, g, x, y) where f and g are 
- *  sounds, x and y are doubles, and h implemented via a function 
+/* pvshell_fetch -- computes h(f, g) where f and g are 
+ *  sounds, and h implemented via a function 
  *  pointer. This could certainly be generalized further, but 
- *  maybe we should take this one step at a time.
+ *  maybe we should take this one step at a time. This description
+ *  is incomplete -- there's state attached to the suspension and 
+ *  h is computed incrementally like all Nyquist primitives.
  */
 void pvshell_fetch(snd_susp_type a_susp, snd_list_type snd_list)
 {


### PR DESCRIPTION
Fixes special case where the time warp function maps positive output times
to negative input times (negative input times are now handled by filling
with zeros).
Fixes improper handling of Nyquist's logical stop times and terminate times
which have to get mapped through the time warp function to the output.
Also the cmupv code was using long for sample count instead of int64_t.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
