### PR TITLE
Journal popup menus

### DIFF
--- a/libraries/lib-basic-ui/BasicUIPoint.h
+++ b/libraries/lib-basic-ui/BasicUIPoint.h
@@ -1,0 +1,28 @@
+/*!********************************************************************
+
+Audacity: A Digital Audio Editor
+
+@file BasicUIPoint.h
+@brief A pair of screen coordinates for use in toolkit-neutral UI facades
+
+Paul Licameli
+
+**********************************************************************/
+#ifndef __AUDACITY_BASIC_UI_POINT__
+#define __AUDACITY_BASIC_UI_POINT__
+
+namespace BasicUI {
+
+//! A pair of screen coordinates, x increasing rightward, y downward
+/*! Origin is unspecified */
+struct Point{
+   Point() = default;
+   Point( int x, int y ) : x{x}, y{y} {}
+
+   int x = -1;
+   int y = -1;
+};
+
+}
+
+#endif

--- a/libraries/lib-basic-ui/CMakeLists.txt
+++ b/libraries/lib-basic-ui/CMakeLists.txt
@@ -16,6 +16,7 @@ namespace BasicUI are no-ops.
 set( SOURCES
    BasicUI.cpp
    BasicUI.h
+   BasicUIPoint.h
 )
 set( LIBRARIES
    lib-strings-interface

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -28,6 +28,7 @@
 #include "AColor.h"
 #include "AllThemeResources.h"
 #include "AudioIO.h"
+#include "widgets/BasicMenu.h"
 #include "CellularPanel.h"
 #include "HitTestResult.h"
 #include "Menus.h"
@@ -53,6 +54,7 @@
 #include "widgets/AButton.h"
 #include "widgets/AudacityMessageBox.h"
 #include "widgets/Grabber.h"
+#include "widgets/wxWidgetsWindowPlacement.h"
 
 #include <wx/dcclient.h>
 #include <wx/menu.h>
@@ -1864,7 +1866,10 @@ void AdornedRulerPanel::ShowMenu(const wxPoint & pos)
    rulerMenu.AppendCheckItem(OnTogglePinnedStateID, _("Pinned Play Head"))->
       Check(TracksPrefs::GetPinnedHeadPreference());
 
-   PopupMenu(&rulerMenu, pos);
+   BasicMenu::Handle{ &rulerMenu }.Popup(
+      wxWidgetsWindowPlacement{ this },
+      { pos.x, pos.y }
+   );
 }
 
 void AdornedRulerPanel::ShowScrubMenu(const wxPoint & pos)
@@ -1875,7 +1880,10 @@ void AdornedRulerPanel::ShowScrubMenu(const wxPoint & pos)
 
    wxMenu rulerMenu;
    scrubber.PopulatePopupMenu(rulerMenu);
-   PopupMenu(&rulerMenu, pos);
+   BasicMenu::Handle{ &rulerMenu }.Popup(
+      wxWidgetsWindowPlacement{ this },
+      { pos.x, pos.y }
+   );
 }
 
 void AdornedRulerPanel::OnToggleQuickPlay(wxCommandEvent&)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -968,6 +968,8 @@ list( APPEND SOURCES
       widgets/wxTextCtrlWrapper.h
       widgets/wxWidgetsBasicUI.cpp
       widgets/wxWidgetsBasicUI.h
+      widgets/wxWidgetsWindowPlacement.cpp
+      widgets/wxWidgetsWindowPlacement.h
 
       # Update version
       $<$<BOOL:${${_OPT}has_updates_check}>:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -898,6 +898,8 @@ list( APPEND SOURCES
       widgets/AudacityTextEntryDialog.h
       widgets/BackedPanel.cpp
       widgets/BackedPanel.h
+      widgets/BasicMenu.cpp
+      widgets/BasicMenu.h
       widgets/ErrorDialog.cpp
       widgets/ErrorDialog.h
       widgets/ExpandingToolBar.cpp

--- a/src/Journal.cpp
+++ b/src/Journal.cpp
@@ -14,7 +14,6 @@
 *//*******************************************************************/
 
 #include "Journal.h"
-#include "JournalEvents.h"
 #include "JournalOutput.h"
 #include "JournalRegistry.h"
 
@@ -179,13 +178,13 @@ bool Begin( const FilePath &dataDir )
       }
    }
 
-   if ( !GetError() && IsRecording() )
-      // one time installation
-      Events::Watch();
-
-   if ( !GetError() && IsReplaying() )
-      // Be sure event types are registered for dispatch
-      Events::Initialize();
+   // Call other registered initialization steps
+   for (auto &initializer : GetInitializers()) {
+      if (initializer && !initializer()) {
+         SetError();
+         break;
+      }
+   }
 
    return !GetError();
 }

--- a/src/JournalEvents.cpp
+++ b/src/JournalEvents.cpp
@@ -2,13 +2,14 @@
 
   Audacity: A Digital Audio Editor
 
-  @file JournalWindowPaths.cpp
+  @file JournalEvents.cpp
 
   Paul Licameli
 
 *********************************************************************/
 
 #include "JournalEvents.h"
+#include "Journal.h"
 #include "JournalOutput.h"
 #include "JournalRegistry.h"
 #include "JournalWindowPaths.h"
@@ -198,7 +199,7 @@ static Type NullaryCommandType( EventType type, const wxString &code ){
    };
 
    return Type{ type, code, WindowEventSerialization, deserialize };
-};
+}
 
 template<typename Event = wxCommandEvent, typename EventType >
 static Type BooleanCommandType( EventType type, const wxString &code ){
@@ -237,7 +238,7 @@ static Type BooleanCommandType( EventType type, const wxString &code ){
    };
 
    return Type{ type, code, serialize, deserialize };
-};
+}
 
 template<typename Event = wxCommandEvent, typename EventType >
 static Type NumericalCommandType( EventType type, const wxString &code ){
@@ -277,7 +278,7 @@ static Type NumericalCommandType( EventType type, const wxString &code ){
    };
 
    return Type{ type, code, serialize, deserialize };
-};
+}
 
 template<typename Event = wxCommandEvent, typename EventType >
 static Type TextualCommandType( EventType type, const wxString &code ){
@@ -320,7 +321,7 @@ static Type TextualCommandType( EventType type, const wxString &code ){
    };
 
    return Type{ type, code, serialize, deserialize };
-};
+}
 
 const Types &TypeCatalog()
 {
@@ -418,6 +419,8 @@ struct Watcher : wxEventFilter
 
 }
 
+namespace {
+
 void Initialize()
 {
    (void) TypeCatalog();
@@ -426,6 +429,23 @@ void Initialize()
 void Watch()
 {
    static Watcher instance;
+}
+
+// Add a callback for startup of journalling
+RegisteredInitializer initializer{ [](){
+   // Register the event handler for recording
+   // and dictionary items for replaying
+   if ( !GetError() && IsRecording() )
+      // one time installation
+      Watch();
+
+   if ( !GetError() && IsReplaying() )
+      // Be sure event types are registered for dispatch
+      Initialize();
+
+   return true;
+} };
+
 }
 
 }

--- a/src/JournalEvents.h
+++ b/src/JournalEvents.h
@@ -16,6 +16,10 @@ namespace Journal
 {
 namespace Events
 {
-   // Nothing to export yet
+   //\brief Whether events are being recorded to the journal
+   bool IsWatching();
+
+   //\brief Stop watching events, and give the user an error message
+   void FailedEventSerialization();
 }
 }

--- a/src/JournalEvents.h
+++ b/src/JournalEvents.h
@@ -16,10 +16,6 @@ namespace Journal
 {
 namespace Events
 {
-   //\brief Initialization, to be called after wxWidgets has initialized
-   void Initialize();
-
-   //! Install the global event filter for recording
-   void Watch();
+   // Nothing to export yet
 }
 }

--- a/src/JournalRegistry.cpp
+++ b/src/JournalRegistry.cpp
@@ -54,5 +54,21 @@ const Dictionary &GetDictionary()
 {
    return sDictionary();
 }
+ 
+static std::vector<Initializer> &sInitializers()
+{
+   static std::vector<Initializer> sTheFunctions;
+   return sTheFunctions;
+}
+
+RegisteredInitializer::RegisteredInitializer( Initializer initializer )
+{
+   sInitializers().push_back( move(initializer) );
+}
+
+const Initializers &GetInitializers()
+{
+   return sInitializers();
+}
 
 }

--- a/src/JournalRegistry.h
+++ b/src/JournalRegistry.h
@@ -3,7 +3,7 @@
   Audacity: A Digital Audio Editor
 
   @file JournalRegistry.h
-  @brief The journal system's error status and command dictionary
+  @brief Journal system's error status, command dictionary, initializers
 
   Paul Licameli
 
@@ -45,6 +45,22 @@ namespace Journal
 
    //\brief read-only access to the dictionary
    const Dictionary &GetDictionary();
+
+   //\brief Function performing additional initialization steps for journals
+   // Return value is success
+   using Initializer = std::function< bool() >;
+
+   //\brief Registers an initialization step in its constructor.
+   // Typically statically constructed
+   struct RegisteredInitializer{
+      explicit RegisteredInitializer( Initializer initializer );
+   };
+
+   using Initializers = std::vector< Initializer >;
+
+   //\brief Get all registered initializers
+   const Initializers &GetInitializers();
+
 }
 
 #endif

--- a/src/ProjectWindows.cpp
+++ b/src/ProjectWindows.cpp
@@ -10,7 +10,7 @@
 
 #include "ProjectWindows.h"
 #include "Project.h"
-#include "widgets/wxWidgetsBasicUI.h"
+#include "widgets/wxWidgetsWindowPlacement.h"
 
 #include <wx/frame.h>
 

--- a/src/commands/Keyboard.h
+++ b/src/commands/Keyboard.h
@@ -13,7 +13,6 @@
 #define __AUDACITY_KEYBOARD__
 
 #include "Identifier.h"
-#include <wx/defs.h>
 
 class wxKeyEvent;
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -26,7 +26,7 @@
 #include <wx/tokenzr.h>
 
 #include "../AudioIO.h"
-#include "widgets/wxWidgetsBasicUI.h"
+#include "widgets/wxWidgetsWindowPlacement.h"
 #include "../DBConnection.h"
 #include "../LabelTrack.h"
 #include "../Mix.h"

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -14,12 +14,14 @@
 
 #include "EffectUI.h"
 
+#include "widgets/BasicMenu.h"
 #include "Effect.h"
 #include "EffectManager.h"
 #include "../ProjectHistory.h"
 #include "../ProjectWindowBase.h"
 #include "../TrackPanelAx.h"
 #include "RealtimeEffectManager.h"
+#include "widgets/wxWidgetsWindowPlacement.h"
 
 #if defined(EXPERIMENTAL_EFFECTS_RACK)
 
@@ -1337,7 +1339,10 @@ void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
    
    wxWindow *btn = FindWindow(kMenuID);
    wxRect r = btn->GetRect();
-   btn->PopupMenu(&menu, r.GetLeft(), r.GetBottom());
+   BasicMenu::Handle{ &menu }.Popup(
+      wxWidgetsWindowPlacement{ btn },
+      { r.GetLeft(), r.GetBottom() }
+   );
 }
 
 void EffectUIHost::Resume()

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1258,6 +1258,8 @@ void EffectUIHost::OnDebug(wxCommandEvent & evt)
 void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
 {
    wxMenu menu;
+   menu.Bind(wxEVT_MENU, [](auto&){}, kUserPresetsDummyID);
+   menu.Bind(wxEVT_MENU, [](auto&){}, kDeletePresetDummyID);
    if( !mEffect )
       return;
    
@@ -1333,7 +1335,8 @@ void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
       sub->Append(kDummyID, wxString::Format(_("Version: %s"), mEffect->GetVersion()));
       sub->Append(kDummyID, wxString::Format(_("Vendor: %s"), mEffect->GetVendor().Translation()));
       sub->Append(kDummyID, wxString::Format(_("Description: %s"), mEffect->GetDescription().Translation()));
-      
+      sub->Bind(wxEVT_MENU, [](auto&){}, kDummyID);
+
       menu.Append(0, _("About"), sub.release());
    }
    

--- a/src/export/ExportPCM.cpp
+++ b/src/export/ExportPCM.cpp
@@ -34,7 +34,7 @@
 #include "../Track.h"
 #include "../widgets/AudacityMessageBox.h"
 #include "../widgets/ProgressDialog.h"
-#include "../widgets/wxWidgetsBasicUI.h"
+#include "../widgets/wxWidgetsWindowPlacement.h"
 #include "wxFileNameWrapper.h"
 
 #include "Export.h"

--- a/src/prefs/KeyConfigPrefs.cpp
+++ b/src/prefs/KeyConfigPrefs.cpp
@@ -46,8 +46,10 @@ KeyConfigPrefs and MousePrefs use.
 
 #include "FileNames.h"
 
+#include "../widgets/BasicMenu.h"
 #include "../widgets/KeyView.h"
 #include "../widgets/AudacityMessageBox.h"
+#include "../widgets/wxWidgetsWindowPlacement.h"
 
 #if wxUSE_ACCESSIBILITY
 #include "../widgets/WindowAccessible.h"
@@ -599,8 +601,7 @@ void KeyConfigPrefs::OnDefaults(wxCommandEvent & WXUNUSED(event))
    Menu.Append( 1, _("Standard") );
    Menu.Append( 2, _("Full") );
    Menu.Bind( wxEVT_COMMAND_MENU_SELECTED, &KeyConfigPrefs::OnImportDefaults, this );
-   // Pop it up where the mouse is.
-   PopupMenu(&Menu);//, wxPoint(0, 0));
+   BasicMenu::Handle( &Menu ).Popup( wxWidgetsWindowPlacement{ this } );
 }
 
 void KeyConfigPrefs::FilterKeys( std::vector<NormalizedKeyString> & arr )

--- a/src/tracks/labeltrack/ui/LabelTrackControls.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackControls.cpp
@@ -50,11 +50,6 @@ public:
       mpData = static_cast<CommonTrackControls::InitMenuData*>(pUserData);
    }
 
-   void DestroyMenu() override
-   {
-      mpData = nullptr;
-   }
-
    CommonTrackControls::InitMenuData *mpData{};
 
    void OnSetFont(wxCommandEvent &);

--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -18,6 +18,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../LabelTrack.h"
 
 #include "../../../AColor.h"
+#include "../../../widgets/BasicMenu.h"
 #include "../../../AllThemeResources.h"
 #include "../../../HitTestResult.h"
 #include "Project.h"
@@ -35,6 +36,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../UndoManager.h"
 #include "ViewInfo.h"
 #include "../../../widgets/AudacityTextEntryDialog.h"
+#include "../../../widgets/wxWidgetsWindowPlacement.h"
 
 #include <wx/clipbrd.h>
 #include <wx/dcclient.h>
@@ -1904,7 +1906,10 @@ void LabelTrackView::ShowContextMenu( AudacityProject &project )
       // So, workaround it by editing the label AFTER the popup menu is
       // closed. It's really ugly, but it works.  :-(
       mEditIndex = -1;
-      parent->PopupMenu(&menu, x, ls->y + (mIconHeight / 2) - 1);
+      BasicMenu::Handle{ &menu }.Popup(
+         wxWidgetsWindowPlacement{ parent },
+         { x, ls->y + (mIconHeight / 2) - 1 }
+      );
       if (mEditIndex >= 0)
       {
          DoEditLabels( project, FindLabelTrack().get(), mEditIndex );

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
@@ -92,11 +92,6 @@ private:
       mpData = static_cast<NoteTrackControlsBase::InitMenuData*>(pUserData);
    }
 
-   void DestroyMenu() override
-   {
-      mpData = nullptr;
-   }
-
    NoteTrackControlsBase::InitMenuData *mpData{};
 
    void OnChangeOctave(wxCommandEvent &);

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -319,7 +319,7 @@ UIHandle::Result NoteTrackVZoomHandle::Release
           (PopupMenuTable *) &NoteTrackVRulerMenuTable::Instance();
       auto pMenu = PopupMenuTable::BuildMenu(pParent, pTable, &data);
 
-      pParent->PopupMenu(pMenu.get(), event.m_x, event.m_y);
+      pMenu->Popup( *pParent, { event.m_x, event.m_y } );
 
       return data.result;
    }

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -204,11 +204,6 @@ protected:
    void OnDownOctave(wxCommandEvent&){ OnZoom( kDownOctave );};
 
 private:
-   void DestroyMenu() override
-   {
-      mpData = nullptr;
-   }
-
    void InitUserData(void *pUserData) override;
 
    void UpdatePrefs() override
@@ -317,7 +312,7 @@ UIHandle::Result NoteTrackVZoomHandle::Release
 
       PopupMenuTable *const pTable =
           (PopupMenuTable *) &NoteTrackVRulerMenuTable::Instance();
-      auto pMenu = PopupMenuTable::BuildMenu(pParent, pTable, &data);
+      auto pMenu = PopupMenuTable::BuildMenu(pTable, &data);
 
       pMenu->Popup( *pParent, { event.m_x, event.m_y } );
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -910,11 +910,6 @@ struct SpectrogramSettingsHandler : PopupMenuHandler {
    {
       mpData = static_cast< PlayableTrackControls::InitMenuData* >(pUserData);
    }
-
-   void DestroyMenu() override
-   {
-      mpData = nullptr;
-   }
 };
 
 void SpectrogramSettingsHandler::OnSpectrogramSettings(wxCommandEvent &)

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -167,11 +167,6 @@ struct FormatMenuTable :  PopupMenuTable
 
    void InitUserData(void *pUserData) override;
 
-   void DestroyMenu() override
-   {
-      mpData = NULL;
-   }
-
    PlayableTrackControls::InitMenuData *mpData{};
 
    static int IdOfFormat(int format);
@@ -309,11 +304,6 @@ struct RateMenuTable : PopupMenuTable
    static RateMenuTable &Instance();
 
    void InitUserData(void *pUserData) override;
-
-   void DestroyMenu() override
-   {
-      mpData = NULL;
-   }
 
    PlayableTrackControls::InitMenuData *mpData{};
 
@@ -506,11 +496,6 @@ struct WaveTrackMenuTable
    }
 
    void InitUserData(void *pUserData) override;
-
-   void DestroyMenu() override
-   {
-      //mpData = nullptr;
-   }
 
    DECLARE_POPUP_MENU(WaveTrackMenuTable);
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
@@ -119,7 +119,7 @@ UIHandle::Result WaveTrackVZoomHandle::DoRelease(
          *pProject,
          pTrack, rect, RefreshCode::RefreshNone, event.m_y, doZoom };
 
-      auto pMenu = PopupMenuTable::BuildMenu(pParent, &table, &data);
+      auto pMenu = PopupMenuTable::BuildMenu( &table, &data );
       pMenu->Popup( *pParent, { event.m_x, event.m_y } );
 
       return data.result;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
@@ -120,7 +120,7 @@ UIHandle::Result WaveTrackVZoomHandle::DoRelease(
          pTrack, rect, RefreshCode::RefreshNone, event.m_y, doZoom };
 
       auto pMenu = PopupMenuTable::BuildMenu(pParent, &table, &data);
-      pParent->PopupMenu(pMenu.get(), event.m_x, event.m_y);
+      pMenu->Popup( *pParent, { event.m_x, event.m_y } );
 
       return data.result;
    }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.h
@@ -82,12 +82,6 @@ protected:
 
    void InitUserData(void *pUserData) override;
 
-private:
-   void DestroyMenu() override
-   {
-      mpData = nullptr;
-   }
-
 protected:
    InitMenuData *mpData {};
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -1076,11 +1076,6 @@ struct WaveColorMenuTable : PopupMenuTable
 
    void InitUserData(void *pUserData) override;
 
-   void DestroyMenu() override
-   {
-      mpData = NULL;
-   }
-
    PlayableTrackControls::InitMenuData *mpData{};
 
    int IdOfWaveColor(int WaveColor);

--- a/src/tracks/timetrack/ui/TimeTrackControls.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackControls.cpp
@@ -49,11 +49,6 @@ void TimeTrackMenuTable::InitUserData(void *pUserData)
    mpData = static_cast<CommonTrackControls::InitMenuData*>(pUserData);
 }
 
-void TimeTrackMenuTable::DestroyMenu()
-{
-   mpData = nullptr;
-}
-
 void TimeTrackMenuTable::OnSetTimeTrackRange(wxCommandEvent & /*event*/)
 {
    TimeTrack *const pTrack = static_cast<TimeTrack*>(mpData->pTrack);

--- a/src/tracks/timetrack/ui/TimeTrackControls.h
+++ b/src/tracks/timetrack/ui/TimeTrackControls.h
@@ -51,8 +51,6 @@ protected:
    void InitUserData(void *pUserData) override;
 
 private:
-   void DestroyMenu() override;
-
    CommonTrackControls::InitMenuData *mpData{};
 
    void OnSetTimeTrackRange(wxCommandEvent & /*event*/);

--- a/src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
@@ -92,7 +92,7 @@ UIHandle::Result TimeTrackVZoomHandle::Release
       };
 
       auto pMenu = PopupMenuTable::BuildMenu(pParent, &TimeTrackMenuTable::Instance(), &data);
-      pParent->PopupMenu(pMenu.get(), event.m_x, event.m_y);
+      pMenu->Popup( *pParent, { event.m_x, event.m_y } );
    }
 
    return UpdateVRuler | RefreshAll;

--- a/src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
@@ -91,7 +91,8 @@ UIHandle::Result TimeTrackVZoomHandle::Release
          *pProject, pTrack.get(), pParent, RefreshNone
       };
 
-      auto pMenu = PopupMenuTable::BuildMenu(pParent, &TimeTrackMenuTable::Instance(), &data);
+      auto pMenu = PopupMenuTable::BuildMenu(
+         &TimeTrackMenuTable::Instance(), &data);
       pMenu->Popup( *pParent, { event.m_x, event.m_y } );
    }
 

--- a/src/tracks/ui/CommonTrackControls.cpp
+++ b/src/tracks/ui/CommonTrackControls.cpp
@@ -296,8 +296,8 @@ unsigned CommonTrackControls::DoContextMenu(
    if (pExtension)
       PopupMenuTable::ExtendMenu( *pMenu, *pExtension );
 
-   pParent->PopupMenu
-      (pMenu.get(), buttonRect.x + 1, buttonRect.y + buttonRect.height + 1);
+   pMenu->Popup( *pParent,
+      { buttonRect.x + 1, buttonRect.y + buttonRect.height + 1 } );
 
    return data.result;
 }

--- a/src/tracks/ui/CommonTrackControls.cpp
+++ b/src/tracks/ui/CommonTrackControls.cpp
@@ -97,11 +97,6 @@ private:
 
    void InitUserData(void *pUserData) override;
 
-   void DestroyMenu() override
-   {
-      mpData = nullptr;
-   }
-
    CommonTrackControls::InitMenuData *mpData{};
 
    void UpdatePrefs() override
@@ -290,7 +285,7 @@ unsigned CommonTrackControls::DoContextMenu(
    InitMenuData data{ *pProject, track.get(), pParent, RefreshNone };
 
    const auto pTable = &TrackMenuTable::Instance();
-   auto pMenu = PopupMenuTable::BuildMenu(pParent, pTable, &data);
+   auto pMenu = PopupMenuTable::BuildMenu(pTable, &data);
 
    PopupMenuTable *const pExtension = GetMenuExtension(track.get());
    if (pExtension)

--- a/src/tracks/ui/CommonTrackPanelCell.cpp
+++ b/src/tracks/ui/CommonTrackPanelCell.cpp
@@ -14,12 +14,15 @@ Paul Licameli split from TrackPanel.cpp
 #include <wx/event.h>
 #include <wx/menu.h>
 
+#include "../../widgets/BasicMenu.h"
+#include "BasicUI.h"
 #include "../../commands/CommandContext.h"
 #include "../../commands/CommandManager.h"
 #include "../../HitTestResult.h"
 #include "../../RefreshCode.h"
 #include "../../TrackPanelMouseEvent.h"
 #include "ViewInfo.h"
+#include "../../widgets/wxWidgetsWindowPlacement.h"
 
 namespace {
    CommonTrackPanelCell::Hook &GetHook()
@@ -108,7 +111,13 @@ unsigned CommonTrackPanelCell::DoContextMenu( const wxRect &rect,
       ++ii;
    }
    
-   pParent->PopupMenu(&menu, pPoint ? *pPoint : wxDefaultPosition);
+   BasicUI::Point point;
+   if (pPoint)
+      point = { pPoint->x, pPoint->y };
+   BasicMenu::Handle{ &menu }.Popup(
+      wxWidgetsWindowPlacement{ pParent },
+      point
+   );
 
    return RefreshCode::RefreshNone;
 }

--- a/src/widgets/BasicMenu.cpp
+++ b/src/widgets/BasicMenu.cpp
@@ -1,0 +1,23 @@
+/*!********************************************************************
+
+Audacity: A Digital Audio Editor
+
+@file BasicMenu.cpp
+
+Paul Licameli
+
+**********************************************************************/
+
+#include "BasicMenu.h"
+#include "wxWidgetsWindowPlacement.h"
+#include <wx/window.h>
+
+namespace BasicMenu {
+
+void Handle::Popup( const BasicUI::WindowPlacement &window, const Point &pos )
+{
+   if (auto pWindow = wxWidgetsWindowPlacement::GetParent(window))
+      pWindow->PopupMenu( mpMenu, { pos.x, pos.y } );
+}
+
+}

--- a/src/widgets/BasicMenu.cpp
+++ b/src/widgets/BasicMenu.cpp
@@ -9,15 +9,223 @@ Paul Licameli
 **********************************************************************/
 
 #include "BasicMenu.h"
+#include "Journal.h"
+#include "JournalOutput.h"
+#include "JournalRegistry.h"
+#include "JournalEvents.h"
+#include "MemoryX.h"
 #include "wxWidgetsWindowPlacement.h"
+#include "wxArrayStringEx.h"
+#include <wx/eventfilter.h>
+#include <wx/menu.h>
+#include <wx/weakref.h>
 #include <wx/window.h>
+#include <optional>
 
 namespace BasicMenu {
 
+namespace {
+
+const auto JournalCode = L"PopupMenu";
+
+using Menus = std::vector< wxWeakRef< wxMenu > >;
+
+// Each item in this stack lists a menu and all descendant sub-menus
+std::vector< Menus > sMenuStack;
+bool sHandledEvent = false;
+
+Menus FindDescendants( wxMenu &menu )
+{
+   Menus result{ &menu };
+   // We can discover them breadth-first
+   for ( size_t ii = 0; ii < result.size(); ++ii ) {
+      if ( auto pMenu = result[ii] ) {
+         for ( const auto &pItem : pMenu->GetMenuItems() ) {
+            if ( const auto pSubMenu = pItem->GetSubMenu() )
+               result.push_back( pSubMenu );
+         }
+      }
+   }
+   return result;
+}
+
+inline bool ContainsMenu( const Menus &menus, void *pObj )
+{
+   return std::count( menus.begin(), menus.end(), pObj );
+}
+
+// Find a path name for the id in the given menu, but only if it, and
+// each sub-menu above it, is uniquely named among peer items
+std::optional< wxArrayStringEx > FindPathName( wxMenu &theMenu, int id )
+{
+   wxMenuItem *pItem = nullptr;
+   wxMenu *pSubMenu = nullptr;
+   if ( !( pItem = theMenu.FindItem( id, &pSubMenu ) ) )
+      return std::nullopt;
+
+   // Gather path components, checking uniqueness at each level
+   wxArrayStringEx names;
+   for ( ; pSubMenu; pSubMenu = pSubMenu->GetParent() ) {
+      const auto &items = pSubMenu->GetMenuItems();
+      const auto begin = items.begin(), end = items.end();
+      if ( !names.empty() ) {
+         // Update pItem on second and later passes
+         if ( const auto iter = std::find_if( begin, end,
+               [&]( auto pNewItem ){
+                  return pNewItem->GetSubMenu() == pItem->GetMenu(); } );
+             iter == end )
+            return std::nullopt;
+         else
+            pItem = *iter;
+      }
+      auto name = pItem->GetItemLabelText();
+      if ( 1 != std::count_if( begin, end, [&](auto item){
+            return item->GetItemLabelText() == name; } ) )
+         // nonuniqueness
+         return std::nullopt;
+      names.push_back( name );
+   }
+   std::reverse( names.begin(), names.end() );
+   return { names };
+}
+
+//! Singleton object listens to global wxEvent stream
+struct Watcher : wxEventFilter
+{
+   Watcher()
+   {
+      wxEvtHandler::AddFilter( this );
+   }
+
+   ~Watcher()
+   {
+      wxEvtHandler::RemoveFilter( this );
+   }
+
+   int FilterEvent( wxEvent &event ) override
+   {
+      using namespace Journal::Events;
+
+      // Record something only if we are recording events, this is a menu
+      // event, there is an outstanding popup menu, and that or a descendant
+      // is the event object
+      auto pObj = event.GetEventObject();
+      if (!(IsWatching() &&
+            event.GetEventType() == wxEVT_MENU &&
+            !sMenuStack.empty() &&
+            ContainsMenu( sMenuStack.back(), pObj ) ))
+         return Event_Skip;
+
+      // Find a path identifying the object
+      auto pPath = FindPathName( *static_cast<wxMenu*>(pObj), event.GetId() );
+      if ( !pPath ) {
+         FailedEventSerialization();
+         return Event_Skip;
+      }
+
+      // Write a representation to the journal.
+      // Write names, not numerical ids, so the journal is not
+      // fragile if the assignment of ids to commands changes.
+      pPath->insert( pPath->begin(), JournalCode );
+      Journal::Output( *pPath );
+      sHandledEvent = true;
+
+      return Event_Skip;
+   }
+};
+
+void Watch()
+{
+   static Watcher instance;
+}
+
+// Add a callback for startup of journalling
+Journal::RegisteredInitializer initializer{ []{
+   using namespace Journal;
+
+   if ( !GetError() && IsRecording() )
+      // one time installation
+      Watch();
+
+   return true;
+} };
+
+void ReplayPopup( wxMenu *theMenu )
+{
+   // Expect JournalCode and maybe a path.
+   const auto fields = Journal::GetTokens();
+   if ( fields[0] == JournalCode ) {
+      if ( fields.size() == 1)
+         // No command, so just eat the journal line
+         return;
+
+      // Locate the menu item by name in the current popup menu or descendant.
+      auto found = [&]() -> std::pair<wxMenuItem *, wxMenu*> {
+         wxMenuItem *pItem = nullptr;
+         auto pMenu = theMenu;
+         for ( auto pField = fields.begin() + 1, endFields = fields.end();
+              pMenu && pField != endFields; ++pField ) {
+            auto &name = *pField;
+            const auto &list = pMenu->GetMenuItems();
+            const auto pred = [&name](auto &pItem){
+               return pItem->GetItemLabelText() == name; };
+            const auto begin = list.begin(), end = list.end(),
+               iter = std::find_if(begin, end, pred);
+
+            // Check existence and uniqueness
+            if ( auto next = iter;
+                end == next || end != std::find_if(++next, end, pred) )
+               return { nullptr, nullptr };
+
+            pItem = *iter;
+            if ( pField + 1 != endFields )
+               pMenu = pItem->GetSubMenu();
+         }
+         return { pItem, pMenu };
+      }();
+
+      if ( auto [pItem, pMenu] = found; pItem && pMenu ) {
+         // Don't really pop up the menu, which uses native event handling
+         // that we can't filter.  Simulate an event instead.
+         // Require that some event is bound to the item, so it is
+         // handled, or else the journal fails replay.
+         wxCommandEvent event{ wxEVT_MENU, pItem->GetId() };
+         event.SetEventObject( pMenu );
+         if ( pMenu->ProcessEvent( event ) ) {
+            sHandledEvent = true;
+            return;
+         }
+      }
+   }
+
+   // Replay did not find all as expected
+   throw Journal::SyncException{};
+}
+
+}
+
 void Handle::Popup( const BasicUI::WindowPlacement &window, const Point &pos )
 {
-   if (auto pWindow = wxWidgetsWindowPlacement::GetParent(window))
-      pWindow->PopupMenu( mpMenu, { pos.x, pos.y } );
+   wxMenu *const pMenu = mpMenu;
+   if ( !pMenu )
+      return;
+
+   if ( auto pWindow = wxWidgetsWindowPlacement::GetParent( window ) ) {
+      sHandledEvent = false;
+
+      // Put the menu pointers where the event filter can find them
+      sMenuStack.push_back( FindDescendants( *pMenu ) );
+      auto cleanup = finally( []{ sMenuStack.pop_back(); } );
+
+      if ( Journal::IsReplaying() )
+         ReplayPopup( pMenu );
+      else
+         pWindow->PopupMenu( pMenu, { pos.x, pos.y } );
+      
+      if ( !sHandledEvent )
+         // Menu popped but no command was selected.  Record that.
+         Journal::Output( JournalCode );
+   }
 }
 
 }

--- a/src/widgets/BasicMenu.h
+++ b/src/widgets/BasicMenu.h
@@ -1,0 +1,45 @@
+/*!********************************************************************
+
+Audacity: A Digital Audio Editor
+
+@file BasicMenu.h
+@brief Abstractions of menus and their items
+
+Paul Licameli
+
+**********************************************************************/
+
+#ifndef __AUDACITY_BASIC_MENU__
+#define __AUDACITY_BASIC_MENU__
+
+#include "BasicUIPoint.h"
+
+namespace BasicUI{ class WindowPlacement; }
+
+class wxMenu; // To be removed
+
+namespace BasicMenu {
+
+using Point = BasicUI::Point;
+
+class AUDACITY_DLL_API Handle
+{
+public:
+
+   explicit Handle( wxMenu *pMenu ) : mpMenu{ pMenu } {}
+
+   Handle( const Handle &other ) = delete;
+   Handle &operator =( const Handle &other ) = delete;
+
+   //! Display the menu at pos, invoke at most one action, then hide it
+   void Popup( const BasicUI::WindowPlacement &window,
+      const Point &pos = {} );
+
+private:
+   wxMenu *mpMenu;
+};
+
+}
+
+#endif
+

--- a/src/widgets/MeterPanel.cpp
+++ b/src/widgets/MeterPanel.cpp
@@ -61,6 +61,7 @@
 
 #include "../AudioIO.h"
 #include "../AColor.h"
+#include "../widgets/BasicMenu.h"
 #include "../ImageManipulation.h"
 #include "Decibels.h"
 #include "Project.h"
@@ -70,6 +71,7 @@
 #include "Prefs.h"
 #include "../ShuttleGui.h"
 #include "../Theme.h"
+#include "../widgets/wxWidgetsWindowPlacement.h"
 
 #include "../AllThemeResources.h"
 #include "../widgets/valnum.h"
@@ -1973,7 +1975,10 @@ void MeterPanel::ShowMenu(const wxPoint & pos)
 
    mAccSilent = true;      // temporarily make screen readers say (close to) nothing on focus events
 
-   PopupMenu(&menu, pos);
+   BasicMenu::Handle{ &menu }.Popup(
+      wxWidgetsWindowPlacement{ this },
+      { pos.x, pos.y }
+   );
 
    /* if stop/start monitoring was chosen in the menu, then by this point
    OnMonitoring has been called and variables which affect the accessibility

--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -171,8 +171,10 @@ different formats.
 #include "SampleCount.h"
 #include "../AllThemeResources.h"
 #include "../AColor.h"
+#include "BasicMenu.h"
 #include "../KeyboardCapture.h"
 #include "../Theme.h"
+#include "wxWidgetsWindowPlacement.h"
 
 #include <algorithm>
 #include <math.h>
@@ -1771,7 +1773,10 @@ void NumericTextCtrl::OnContext(wxContextMenuEvent &event)
       }
    }
 
-   PopupMenu(&menu, wxPoint(0, 0));
+   BasicMenu::Handle{ &menu }.Popup(
+      wxWidgetsWindowPlacement{ this },
+      { 0, 0 }
+   );
 
    // This used to be in an EVT_MENU() event handler, but GTK
    // is sensitive to what is done within the handler if the

--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -1773,6 +1773,7 @@ void NumericTextCtrl::OnContext(wxContextMenuEvent &event)
       }
    }
 
+   menu.Bind(wxEVT_MENU, [](auto&){});
    BasicMenu::Handle{ &menu }.Popup(
       wxWidgetsWindowPlacement{ this },
       { 0, 0 }

--- a/src/widgets/PopupMenuTable.cpp
+++ b/src/widgets/PopupMenuTable.cpp
@@ -10,6 +10,8 @@ Paul Licameli split from TrackPanel.cpp
 
 
 #include "PopupMenuTable.h"
+#include "widgets/BasicMenu.h"
+#include "widgets/wxWidgetsWindowPlacement.h"
 
 PopupMenuTableEntry::~PopupMenuTableEntry()
 {}
@@ -136,7 +138,9 @@ PopupMenuImpl::~PopupMenuImpl()
 
 void PopupMenuImpl::Popup( wxWindow &window, const wxPoint &pos )
 {
-   window.PopupMenu( this, pos );
+   BasicMenu::Handle{ this }.Popup(
+      wxWidgetsWindowPlacement{ &window }, { pos.x, pos.y }
+   );
 }
 }
 

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -44,6 +44,7 @@ struct AUDACITY_DLL_API PopupMenuTableEntry : Registry::SingleItem
    PopupMenuHandler &handler;
    InitFunction init;
 
+   //! @pre func is not null
    PopupMenuTableEntry( const Identifier &stringId,
       Type type_, int id_, const TranslatableString &caption_,
       wxCommandEventFunction func_, PopupMenuHandler &handler_,
@@ -55,7 +56,9 @@ struct AUDACITY_DLL_API PopupMenuTableEntry : Registry::SingleItem
       , func(func_)
       , handler( handler_ )
       , init( init_ )
-   {}
+   {
+      wxASSERT(func);
+   }
 
    ~PopupMenuTableEntry() override;
 };

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -100,6 +100,14 @@ struct PopupMenuVisitor : public MenuVisitor {
    PopupMenuTable &mTable;
 };
 
+// Opaque structure built by PopupMenuTable::BuildMenu
+class AUDACITY_DLL_API PopupMenu
+{
+public:
+   virtual ~PopupMenu();
+   virtual void Popup( wxWindow &window, const wxPoint &pos ) = 0;
+};
+
 class AUDACITY_DLL_API PopupMenuTable : public PopupMenuHandler
 {
 public:
@@ -114,8 +122,8 @@ public:
 
    // Optional pUserData gets passed to the InitUserData routines of tables.
    // No memory management responsibility is assumed by this function.
-   static std::unique_ptr<wxMenu> BuildMenu
-      (wxEvtHandler *pParent, PopupMenuTable *pTable, void *pUserData = NULL);
+   static std::unique_ptr<PopupMenu> BuildMenu(
+      wxEvtHandler *pParent, PopupMenuTable *pTable, void *pUserData = NULL);
 
    const Identifier &Id() const { return mId; }
    const TranslatableString &Caption() const { return mCaption; }
@@ -130,7 +138,7 @@ public:
 
    // menu must have been built by BuildMenu
    // More items get added to the end of it
-   static void ExtendMenu( wxMenu &menu, PopupMenuTable &otherTable );
+   static void ExtendMenu( PopupMenu &menu, PopupMenuTable &otherTable );
    
    const std::shared_ptr< Registry::GroupItem > &Get( void *pUserData )
    {
@@ -293,7 +301,7 @@ auto pMenu = PopupMenuTable::BuildMenu(pParent, &myTable, &data);
 OtherTable otherTable;
 PopupMenuTable::ExtendMenu( *pMenu, otherTable );
 
-pParent->PopupMenu(pMenu.get(), event.m_x, event.m_y);
+pMenu->Popup( *pParent, { event.m_x, event.m_y } );
 
 That's all!
 */

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -85,14 +85,14 @@ public:
    PopupMenuHandler( const PopupMenuHandler& ) = delete;
    PopupMenuHandler& operator=( const PopupMenuHandler& ) = delete;
 
-   // Called before the menu items are appended.
-   // Store context data, if needed.
-   // May be called more than once before the menu opens.
+   //! Called before the menu items are appended.
+   /*! Store context data, if needed.
+      May be called more than once before the menu opens.
+      Pointer remains valid for the duration of any callback, if
+      PopupMenuTable::BuildMenu() is called and the result's Popup() is called
+      before any other menus are built.
+    */
    virtual void InitUserData(void *pUserData) = 0;
-
-   // Called when menu is destroyed.
-   // May be called more than once.
-   virtual void DestroyMenu() = 0;
 };
 
 struct PopupMenuVisitor : public MenuVisitor {
@@ -123,7 +123,7 @@ public:
    // Optional pUserData gets passed to the InitUserData routines of tables.
    // No memory management responsibility is assumed by this function.
    static std::unique_ptr<PopupMenu> BuildMenu(
-      wxEvtHandler *pParent, PopupMenuTable *pTable, void *pUserData = NULL);
+      PopupMenuTable *pTable, void *pUserData = NULL);
 
    const Identifier &Id() const { return mId; }
    const TranslatableString &Caption() const { return mCaption; }

--- a/src/widgets/wxWidgetsBasicUI.cpp
+++ b/src/widgets/wxWidgetsBasicUI.cpp
@@ -8,6 +8,7 @@ Paul Licameli
 
 **********************************************************************/
 #include "wxWidgetsBasicUI.h"
+#include "wxWidgetsWindowPlacement.h"
 #include "MemoryX.h" // for Destroy_ptr
 #include "widgets/ErrorDialog.h"
 #ifdef HAS_SENTRY_REPORTING
@@ -21,8 +22,6 @@ Paul Licameli
 
 using namespace BasicUI;
 
-wxWidgetsWindowPlacement::~wxWidgetsWindowPlacement() = default;
-
 wxWidgetsBasicUI::~wxWidgetsBasicUI() = default;
 
 void wxWidgetsBasicUI::DoCallAfter(const Action &action)
@@ -35,16 +34,6 @@ void wxWidgetsBasicUI::DoYield()
    wxTheApp->Yield();
 }
 
-namespace {
-wxWindow *GetParent(const BasicUI::WindowPlacement &placement)
-{
-   if (auto *pPlacement =
-       dynamic_cast<const wxWidgetsWindowPlacement*>(&placement))
-      return pPlacement->pWindow;
-   return nullptr;
-}
-}
-
 void wxWidgetsBasicUI::DoShowErrorDialog(
    const BasicUI::WindowPlacement &placement,
    const TranslatableString &dlogTitle,
@@ -54,7 +43,7 @@ void wxWidgetsBasicUI::DoShowErrorDialog(
 {
    using namespace BasicUI;
    bool modal = true;
-   auto parent = GetParent(placement);
+   auto parent = wxWidgetsWindowPlacement::GetParent(placement);
    switch (options.type) {
       case ErrorDialogType::ModalErrorReport: {
 #ifdef HAS_SENTRY_REPORTING
@@ -141,7 +130,9 @@ wxWidgetsBasicUI::DoMessageBox(
    // This calls through to ::wxMessageBox:
    auto wxResult =
       ::AudacityMessageBox(message, options.caption, style,
-         options.parent ? GetParent(*options.parent) : nullptr);
+         options.parent
+           ? wxWidgetsWindowPlacement::GetParent(*options.parent)
+           : nullptr);
    // This switch exhausts all possibilities for the return from::wxMessageBox.
    // see utilscmn.cpp in wxWidgets.
    // Remap to our toolkit-neutral enumeration.
@@ -232,5 +223,5 @@ wxWidgetsBasicUI::DoMakeGenericProgress(
    const TranslatableString &message)
 {
    return std::make_unique<MyGenericProgress>(
-      title, message, GetParent(placement));
+      title, message, wxWidgetsWindowPlacement::GetParent(placement));
 }

--- a/src/widgets/wxWidgetsBasicUI.h
+++ b/src/widgets/wxWidgetsBasicUI.h
@@ -15,18 +15,6 @@ Paul Licameli
 
 class wxWindow;
 
-//! Window placement information for wxWidgetsBasicUI can be constructed from a wxWindow pointer
-struct AUDACITY_DLL_API wxWidgetsWindowPlacement final
-: BasicUI::WindowPlacement {
-   wxWidgetsWindowPlacement() = default;
-   explicit wxWidgetsWindowPlacement( wxWindow *pWindow )
-      : pWindow{ pWindow }
-   {}
-
-   ~wxWidgetsWindowPlacement() override;
-   wxWindow *pWindow{};
-};
-
 //! An implementation of BasicUI::Services in terms of the wxWidgets toolkit
 /*! This is a singleton that doesn't need AUDACITY_DLL_API visibility */
 class wxWidgetsBasicUI final : public BasicUI::Services {

--- a/src/widgets/wxWidgetsWindowPlacement.cpp
+++ b/src/widgets/wxWidgetsWindowPlacement.cpp
@@ -1,0 +1,24 @@
+/*!********************************************************************
+
+Audacity: A Digital Audio Editor
+
+@file wxWidgetsWindowPlacement.cpp
+
+split from wxWidgetsBasicUI.cpp
+
+Paul Licameli
+
+**********************************************************************/
+#include "wxWidgetsWindowPlacement.h"
+
+using namespace BasicUI;
+
+wxWidgetsWindowPlacement::~wxWidgetsWindowPlacement() = default;
+
+wxWindow *wxWidgetsWindowPlacement::GetParent(const WindowPlacement &placement)
+{
+   if (auto *pPlacement =
+       dynamic_cast<const wxWidgetsWindowPlacement*>(&placement))
+      return pPlacement->pWindow;
+   return nullptr;
+}

--- a/src/widgets/wxWidgetsWindowPlacement.h
+++ b/src/widgets/wxWidgetsWindowPlacement.h
@@ -1,0 +1,37 @@
+/*!********************************************************************
+
+Audacity: A Digital Audio Editor
+
+@file wxWidgetsBasicUI.h
+@brief Implementation of BasicUI::WindowPlacement using wxWidgets
+
+split from wxWidgetsBasicUI.h
+
+Paul Licameli
+
+**********************************************************************/
+#ifndef __WXWIDGETS_WINDOW_PLACEMENT__
+#define __WXWIDGETS_WINDOW_PLACEMENT__
+
+#include "BasicUI.h"
+
+class wxWindow;
+
+//! Window placement information for wxWidgetsBasicUI can be constructed from a wxWindow pointer
+struct AUDACITY_DLL_API wxWidgetsWindowPlacement final
+: BasicUI::WindowPlacement {
+   //! Retrieve the pointer to window, if placement is of this type; else null
+   static wxWindow *GetParent(const WindowPlacement &placement);
+
+   wxWidgetsWindowPlacement() = default;
+
+   //! Construct from a pointer to window which may be null
+   explicit wxWidgetsWindowPlacement( wxWindow *pWindow )
+      : pWindow{ pWindow }
+   {}
+
+   ~wxWidgetsWindowPlacement() override;
+   wxWindow *pWindow{};
+};
+
+#endif


### PR DESCRIPTION
Resolves: #1593

Extend journalling so that context menu commands can be recorded and replayed.

Not all context menus can yet be recorded, because that depends on #1633 and others: first a mouse event must be replayed before a journal item is replayed.

But there are examples of context menus without mouse events, such as when pressing the Manage button of an effects dialog.  (Distortion may provide the most interesting examples for testing, with its many built in settings.)

Testing, verify these cases can record and replay:

- Context menu is dismissed with Esc key.
- Item is chosen from a flat context menu.
- Item is chosen from a nested context menu.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
