### PR TITLE
Opt in for macOS dark mode support

### DIFF
--- a/cmake-proxies/cmake-modules/MacOSXBundleInfo.plist.in
+++ b/cmake-proxies/cmake-modules/MacOSXBundleInfo.plist.in
@@ -230,7 +230,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
    <key>NSRequiresAquaSystemAppearance</key>
-   <true/>
+   <false/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Audacity version ${AUDACITY_INFO_VERSION}</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/404

A bunch of UI components doesn't support dark mode on macOS. Like window frame, scrollbars, dropdowns, settings, etc.
This fixes it by opting in for dark mode support.
[NSRequiresAquaSystemAppearance](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_macos_app) should be set to false to support dark mode when targeting macOS before 10.14. 

This is how Audacity looks today with dark mode enabled on macOS
<img width="1792" alt="audacity_currently" src="https://user-images.githubusercontent.com/4034956/133247667-f76e530f-ecc0-4fcb-be6a-d3b6e1aa907f.png">

And this is how it looks with this fix
<img width="1792" alt="audacity_dark_mode" src="https://user-images.githubusercontent.com/4034956/133247743-d04cb1c3-faa5-4396-bd1e-b6771198e87d.png">


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
