### PR TITLE
The SetClip command can set the clip name

### DIFF
--- a/src/commands/SetClipCommand.cpp
+++ b/src/commands/SetClipCommand.cpp
@@ -71,6 +71,7 @@ void SetClipCommand::PopulateOrExchange(ShuttleGui & S)
       S.Optional( bHasColour      ).TieChoice(          XXO("Color:"),         mColour,
          Msgids( kColourStrings, nColours ) );
       S.Optional( bHasT0          ).TieNumericTextBox(  XXO("Start:"),         mT0 );
+      S.Optional( bHasName        ).TieTextBox(         XXO("Name:"),          mName );
    }
    S.EndMultiColumn();
 }
@@ -97,6 +98,8 @@ bool SetClipCommand::ApplyInner( const CommandContext &, Track * t )
             if( bHasT0 )
                pClip->SetOffset(mT0);
             // \todo Use SetClip to move a clip between tracks too.
+            if( bHasName )
+               pClip->SetName(mName);
 
          }
       }

--- a/src/commands/SetClipCommand.h
+++ b/src/commands/SetClipCommand.h
@@ -38,11 +38,13 @@ public:
    double mContainsTime;
    int mColour;
    double mT0;
+   wxString mName;
 
 // For tracking optional parameters.
    bool bHasContainsTime;
    bool bHasColour;
    bool bHasT0;
+   bool bHasName;
 };
 
 


### PR DESCRIPTION
Resolves: #1644 

The Set Clip macro command now can change a clip name too

The command is also accessible in menus under Extra > Scriptables I (You must first enable the Extra menus in the Interface preferences)

@LWinterberg See this manual page needing update https://manual.audacityteam.org/man/extra_menu_scriptables_i.html#set_clip

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
