### PR TITLE
Fix include path for images/Cursors.h

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -33,7 +33,7 @@
 #include "../../../../SelectionState.h"
 #include "../../../../RefreshCode.h"
 #include "../../../../Theme.h"
-#include "../../../../images/Cursors.h"
+#include "../../../../../images/Cursors.h"
 #include "../../../../HitTestResult.h"
 
 class WaveTrackAffordanceHandle final : public AffordanceHandle


### PR DESCRIPTION
The include file in `src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp` points to
`../../../../images/Cursors.h`, which is `src/images/Cursors.h`, but that file actually resides in `images/Cursors.h`.
Feel free to tell me I'm wrong.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/) (Do I need one since this is a trivial issue?)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
