### PR TITLE
Issue 1681: Position of New Label dialog is inconvenient

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -2257,7 +2257,7 @@ int LabelTrackView::DialogForLabelName(
    // if it's a point label, or the start of its region if it's a region label.
    position.x +=
       + std::max(0, static_cast<int>(viewInfo.TimeToPosition(
-         viewInfo.GetLeftOffset(), region.t0())))
+         region.t0(), viewInfo.GetLeftOffset())))
       - 39;
    position.y += 2;  // just below the bottom of the track
    position = trackPanel.ClientToScreen(position);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1681

If the "use dialog for name of new label" check box is checked in the track behaviour page of preferences, then when adding a label at either selection or playback position, a dialog is used for entering the name of the new label. For convenience the horizontal position of the dialog should be such that the initial horizontal position of the cursor in the edit box is roughly the same as the horizontal position of the cursor or playback position respectively.

This behaviour was broken by commit 8f8ec41.
In this commit in LabelTrackView::DialogForLabelName(), the two arguments passed to viewInfo.TimeToPosition() are in wrong way round.

The fix: swap the order of these arguments.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
