### PR TITLE
Issue 1681: Position of New Label dialog is inconvenient

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -2255,9 +2255,8 @@ int LabelTrackView::DialogForLabelName(
       trackPanel.FindTrackRect( trackFocus.Get() ).GetBottomLeft();
    // The start of the text in the text box will be roughly in line with the label's position
    // if it's a point label, or the start of its region if it's a region label.
-   position.x +=
-      + std::max(0, static_cast<int>(viewInfo.TimeToPosition(
-         viewInfo.GetLeftOffset(), region.t0())))
+   position.x += viewInfo.GetLeftOffset()
+      + std::max(0, static_cast<int>(viewInfo.TimeToPosition(region.t0())))
       - 39;
    position.y += 2;  // just below the bottom of the track
    position = trackPanel.ClientToScreen(position);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1681

If the "use dialog for name of new label" check box is checked in the track behaviour page of preferences, then when adding a label at either selection or playback position, a dialog is used for entering the name of the new label. For convenience the horizontal position of the dialog should be such that the initial horizontal position of the cursor in the edit box is roughly the same as the horizontal position of the cursor or playback position respectively.

This behaviour was broken by commit 8f8ec41.
In LabelTrackView::DialogForLabelName(), there was the change from:
   position.x += viewInfo.GetLabelWidth()
      + std::max(0, static_cast<int>(viewInfo.TimeToPosition(region.t0())))
      -40;

to:
   position.x +=
      + std::max(0, static_cast<int>(viewInfo.TimeToPosition(
         viewInfo.GetLeftOffset(), region.t0())))
      - 39;

The change that was causing the most problem is that the arguments passed to viewInfo.TimeToPosition() are the wrong way round. However in addition the original code guarded against the position of the cursor being negative - in that case it was treated as zero (this prevented the dialog from going off the left of Audacity's main window).

The fix: revert to the original structure of the statement.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
