### PR TITLE
Lower CPU usage by doing less display updates

### DIFF
--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -287,7 +287,6 @@ TrackPanel::TrackPanel(wxWindow * parent, wxWindowID id,
 
    mTrackArtist = std::make_unique<TrackArtist>( this );
 
-   mTimeCount = 0;
    mTimer.parent = this;
    // Timer is started after the window is visible
    ProjectWindow::Get( *GetProject() ).Bind(wxEVT_IDLE,
@@ -397,8 +396,6 @@ void TrackPanel::OnIdle(wxIdleEvent& event)
 /// AS: This gets called on our wx timer events.
 void TrackPanel::OnTimer(wxTimerEvent& )
 {
-   mTimeCount++;
-
    AudacityProject *const p = GetProject();
    auto &window = ProjectWindow::Get( *p );
 
@@ -434,20 +431,6 @@ void TrackPanel::OnTimer(wxTimerEvent& )
 
    DrawOverlays(false);
    mRuler->DrawOverlays(false);
-
-   if(IsAudioActive() && gAudioIO->GetNumCaptureChannels()) {
-
-      // Periodically update the display while recording
-
-      if ((mTimeCount % 5) == 0) {
-         // Must tell OnPaint() to recreate the backing bitmap
-         // since we've not done a full refresh.
-         mRefreshBacking = true;
-         Refresh( false );
-      }
-   }
-   if(mTimeCount > 1000)
-      mTimeCount = 0;
 }
 
 void TrackPanel::OnProjectSettingsChange( wxCommandEvent &event )

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -210,8 +210,6 @@ protected:
      TrackPanel *parent;
    } mTimer;
 
-   int mTimeCount;
-
    bool mRefreshBacking;
 
 


### PR DESCRIPTION
**TL;DR:** Lowers CPU usage from 40-50% to 10-15% while recording.

Currently Audacity consumes ~90% CPU when recording on my 2019 Macbook Pro with 2,3 GHz 8-Core Intel Core i9 running macOS 11.6. That will kick the fans into jet engine mode which will be audible if you have the computer in the same room.
One trick is to toggle off "update display while playing" but it will still use 40-50%.

By removing this code (and having update display while playing toggled off) I'm able to get it to 10-15%.
I haven't noticed any artifacts or components not updating correctly, so to me this forced update seems to be done needlessly. But I'm expecting to be told otherwise in this PR :)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
