### PR TITLE
issue 1683: Selecting labels does not work wrt cursor position

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -1680,7 +1680,11 @@ bool LabelTrackView::DoKeyDown(
       case WXK_NUMPAD_TAB:
          if (!mLabels.empty()) {
             int len = (int) mLabels.size();
-            if (IsValidIndex(mNavigationIndex, project))
+            // The case where the start of selection is the same as the
+            // start of a label is handled separately so that if some labels
+            // have the same start time, all labels are navigated.
+            if (IsValidIndex(mNavigationIndex, project)
+               && mLabels[mNavigationIndex].getT0() == newSel.t0())
             {
                 if (event.ShiftDown()) {
                     --mNavigationIndex;
@@ -1692,7 +1696,6 @@ bool LabelTrackView::DoKeyDown(
             }
             else
             {
-                // no valid navigation index, then
                 if (event.ShiftDown()) {
                     //search for the first label starting from the end (and before selection)
                     mNavigationIndex = len - 1;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1683

For example:

1. Create a label track with two point labels
2. Tab until the first label is selected.
3. Hold down left arrow key for a short time to move the cursor before the first label.
4. Press tab to select the next label.
5. The second label is selected, whereas the expected behaviour is that the first label is selected.

Note that this issue has arisen since the change that tabbing just "selects" a label rather than also opening its name for editing. Before this change, if the label track remained the focus, then to change the cursor position using keyboard shortcuts then the user would first have to press Enter which closed the editing, and "deselected" the label, and then label selection correctly used the cursor position.

The fix: always use the cursor position, making sure that labels with the same start times are all navigated.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
