### PR TITLE
Fix bug 1571

### DIFF
--- a/libraries/lib-strings/Internat.cpp
+++ b/libraries/lib-strings/Internat.cpp
@@ -135,9 +135,9 @@ bool Internat::CompatibleToDouble(const wxString& stringToConvert, double* resul
 {
    // Regardless of the locale, always respect comma _and_ point
    wxString s = stringToConvert;
-   s.Replace(wxT(","), wxString(GetDecimalSeparator()));
-   s.Replace(wxT("."), wxString(GetDecimalSeparator()));
-   return s.ToDouble(result);
+   // Convert to C locale decimal point for stable parsing.
+   s.Replace(wxString(GetDecimalSeparator()), wxT("."));
+   return s.ToCDouble(result);
 }
 
 double Internat::CompatibleToDouble(const wxString& stringToConvert)

--- a/libraries/lib-strings/Internat.cpp
+++ b/libraries/lib-strings/Internat.cpp
@@ -136,6 +136,7 @@ bool Internat::CompatibleToDouble(const wxString& stringToConvert, double* resul
    // Regardless of the locale, always respect comma _and_ point
    wxString s = stringToConvert;
    // Convert to C locale decimal point for stable parsing.
+   s.Replace(wxT(","), wxT("."));
    s.Replace(wxString(GetDecimalSeparator()), wxT("."));
    return s.ToCDouble(result);
 }


### PR DESCRIPTION
Convert to C locale decimal point for stable parsing. In `Cmd+O` user case, `endptr` (into `wxString::ToDouble`) point to localized decimal point, that means it can't recognize separator char, therefore in result `ToDouble()` return false (`!*endptr`).

Resolves: #1571 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
