### PR TITLE
Upload binaries and sources to Sentry to improve crashes handling

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -30,16 +30,20 @@ mkdir ${SYMBOLS_OUTPUT_DIR}
 if [[ "${OSTYPE}" == msys* ]]; then # Windows
     # copy PDBs to debug folder...
     find ${BIN_OUTPUT_DIR} -name '*.pdb' | xargs -I % cp -v % ${SYMBOLS_OUTPUT_DIR}
+    find ${BIN_OUTPUT_DIR} -name '*.exe' | xargs -I % cp -v % ${SYMBOLS_OUTPUT_DIR}
     find ${SHARED_OUTPUT_DIR} -name '*.pdb' | xargs -I % cp -v % ${SYMBOLS_OUTPUT_DIR}
+    find ${SHARED_OUTPUT_DIR} -name '*.dll' | xargs -I % cp -v % ${SYMBOLS_OUTPUT_DIR}
     find $(cygpath ${CONAN_USER_HOME}) -name '*.pdb' | xargs -I % cp -v % ${SYMBOLS_OUTPUT_DIR}
     # and remove debug symbol files from the file tree before archieving
     find ${BIN_OUTPUT_DIR} -name '*.iobj' -o -name '*.ipdb' -o -name '*.pdb' -o -name '*.ilk' | xargs rm -f
 elif [[ "${OSTYPE}" == darwin* ]]; then # macOS
-    find ${BIN_OUTPUT_DIR} -name '*.dSYM' | xargs -J % mv % ${SYMBOLS_OUTPUT_DIR}
-    find ${SHARED_OUTPUT_DIR} -name '*.dSYM' | xargs -J % mv % ${SYMBOLS_OUTPUT_DIR}
-    find ${CONAN_USER_HOME}/dsyms -name '*.dSYM' | xargs -J % cp -R % ${SYMBOLS_OUTPUT_DIR}
+    find ${BIN_OUTPUT_DIR} -name '*.dSYM' | xargs -J % mv -v % ${SYMBOLS_OUTPUT_DIR}
+    find ${SHARED_OUTPUT_DIR} -name '*.dSYM' | xargs -J % mv -v % ${SYMBOLS_OUTPUT_DIR}
+    find ${CONAN_USER_HOME}/dsyms -name '*.dSYM' | xargs -J % cp -Rv % ${SYMBOLS_OUTPUT_DIR}
+    find ${BIN_OUTPUT_DIR} -type f -perm +ugo+x -o -name '*.dylib' | xargs -I % cp -v % ${SYMBOLS_OUTPUT_DIR}
 else # Linux & others
     chmod +x scripts/ci/linux/split_debug_symbols.sh
     find ${BIN_OUTPUT_DIR} -type f -executable -o -name '*.so' | xargs -n 1 scripts/ci/linux/split_debug_symbols.sh
-    find ${BIN_OUTPUT_DIR} -name '*.debug' | xargs -I % mv % ${SYMBOLS_OUTPUT_DIR}
+    find ${BIN_OUTPUT_DIR} -name '*.debug' | xargs -I % mv -v % ${SYMBOLS_OUTPUT_DIR}
+    find ${BIN_OUTPUT_DIR} -type f -executable -o -name '*.so' | xargs -I % cp -v % ${SYMBOLS_OUTPUT_DIR}
 fi

--- a/scripts/ci/upload_debug_symbols.sh
+++ b/scripts/ci/upload_debug_symbols.sh
@@ -12,5 +12,6 @@ curl -sL https://sentry.io/get-cli/ | bash
 SYMBOLS=$(find debug | xargs)
 
 ${INSTALL_DIR}/sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} --url https://${SENTRY_HOST} upload-dif \
+    --include-sources \
     --org ${SENTRY_ORG_SLUG} \
     --project ${SENTRY_PROJECT_SLUG} ${SYMBOLS}


### PR DESCRIPTION
Resolves: #1489 
Resolves: #1490 

This PR uploads all executables and libraries to Sentry. Additionally, it includes all available sources matching the debug files.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
