### PR TITLE
Increased max FFT size in Plot Spectrum to enable higher resolution

### DIFF
--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -9,7 +9,7 @@
 *******************************************************************//**
 
 \class FrequencyPlotDialog
-\brief Displays a spectrum plot of the waveform.  Has options for
+\brief Displays a spectrum plot of the waveform. Has options for
 selecting parameters of the plot.
 
 Has a feature that finds peaks and reports their value as you move
@@ -18,7 +18,7 @@ the mouse around.
 *//****************************************************************//**
 
 \class FreqPlot
-\brief Works with FrequencyPlotDialog to dsplay a spectrum plot of the waveform.
+\brief Works with FrequencyPlotDialog to display a spectrum plot of the waveform.
 This class actually does the graph display.
 
 Has a feature that finds peaks and reports their value as you move
@@ -30,8 +30,6 @@ the mouse around.
   Salvo Ventura - November 2006
   Extended range check for additional FFT windows
 */
-
-
 
 #include "FreqWindow.h"
 
@@ -113,7 +111,6 @@ enum {
 #define FREQ_WINDOW_WIDTH 480
 #define FREQ_WINDOW_HEIGHT 330
 
-
 static const char * ZoomIn[] = {
 "16 16 6 1",
 " 	c None",
@@ -138,7 +135,6 @@ static const char * ZoomIn[] = {
 "+++@@           ",
 "@+@@            ",
 " @@             "};
-
 
 static const char * ZoomOut[] = {
 "16 16 6 1",
@@ -243,6 +239,7 @@ void FrequencyPlotDialog::Populate()
       Verbatim( "16384" ) ,
       Verbatim( "32768" ) ,
       Verbatim( "65536" ) ,
+      Verbatim( "131072" ) ,
    };
 
    TranslatableStrings funcChoices;
@@ -400,6 +397,7 @@ void FrequencyPlotDialog::Populate()
       // -------------------------------------------------------------------
       // ROW 3: Spacer
       // -------------------------------------------------------------------
+
       S.AddSpace(5);
       S.AddSpace(5);
       S.AddSpace(5);
@@ -469,7 +467,6 @@ void FrequencyPlotDialog::Populate()
       mExportButton = S.Id(FreqExportButtonID).AddButton(XXO("&Export..."));
 
       S.AddSpace(5);
-
 
       // ----------------------------------------------------------------
       // ROW 7: Function, Axix, Grids, Close

--- a/src/SpectrumAnalyst.cpp
+++ b/src/SpectrumAnalyst.cpp
@@ -22,8 +22,6 @@ and in the spectrogram spectral selection.
   Extended range check for additional FFT windows
 */
 
-
-
 #include "SpectrumAnalyst.h"
 #include "FFT.h"
 
@@ -104,7 +102,7 @@ bool SpectrumAnalyst::Calculate(Algorithm alg, int windowFunc,
    // Validate inputs
    int f = NumWindowFuncs();
 
-   if (!(windowSize >= 32 && windowSize <= 65536 &&
+   if (!(windowSize >= 32 && windowSize <= 131072 &&
          alg >= SpectrumAnalyst::Spectrum &&
          alg < SpectrumAnalyst::NumAlgorithms &&
          windowFunc >= 0 && windowFunc < f)) {


### PR DESCRIPTION
Resolves: Feature enhancement

The maximum FFT size in Plot Spectrum has been increased by a factor of 2 to 131072. This change has been made to allow a higher resolution FFT to be computed. This can be useful when assessing low frequency content of audio waveforms in music. This change gives much better than 1Hz resolution at a sampling frequency of 48kHz. At a sample rate of 192kHz, a 1.47Hz resolution is obtained, which is deemed acceptable.

Also, some minor typos have been corrected, and some of the code formatting adjusted for consistency.

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
