### PR TITLE
Modify cursor colour in Plot Spectrum to make it more visible

### DIFF
--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -931,7 +931,7 @@ void FrequencyPlotDialog::PlotPaint(wxPaintEvent & event)
       else
          px = (int)((bestpeak - xMin) * width / (xMax - xMin));
 
-      dc.SetPen(wxPen(wxColour(160,160,160), 1, wxPENSTYLE_SOLID));
+      dc.SetPen(wxPen(wxColour(255, 32, 32), 1, wxPENSTYLE_SOLID));
       AColor::Line(dc, r.x + 1 + px, r.y, r.x + 1 + px, r.y + r.height);
 
        // print out info about the cursor location


### PR DESCRIPTION
Resolves: Cursor in Plot Spectrum difficult to see

The colour of the cursor in Plot Spectrum has been modified to make it more visible. It is now red in colour, making it much easier to see, especially when the cursor is close to or on top of vertical grid lines.

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
