### PR TITLE
Increased resolution of frequency and dB readouts when plotting spectrum

### DIFF
--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -914,6 +914,7 @@ void FrequencyPlotDialog::PlotPaint(wxPaintEvent & event)
    }
 
    float xPos = xMin;
+   float yPos;
 
    // Find the peak nearest the cursor and plot it
    if ( r.Contains(mMouseX, mMouseY) & (mMouseX!=0) & (mMouseX!=r.width-1) ) {
@@ -934,7 +935,7 @@ void FrequencyPlotDialog::PlotPaint(wxPaintEvent & event)
       dc.SetPen(wxPen(wxColour(160,160,160), 1, wxPENSTYLE_SOLID));
       AColor::Line(dc, r.x + 1 + px, r.y, r.x + 1 + px, r.y + r.height);
 
-       // print out info about the cursor location
+      // Print out info about the cursor location
 
       float value;
 
@@ -950,14 +951,21 @@ void FrequencyPlotDialog::PlotPaint(wxPaintEvent & event)
       TranslatableString peak;
 
       if (mAlg == SpectrumAnalyst::Spectrum) {
+         // Determine the position of the cursor in the plot window.
+         float yRange = mYMax - mYMin;
+         float yTotal = yRange * (float)mZoomSlider->GetValue() / 100.0f;
+         int sTotal = yTotal * 100;
+         int sRange = yRange * 100;
+         int sPos = mPanScroller->GetThumbPosition() + ((mPanScroller->GetThumbSize() - sTotal) / 2);
+         float yMax = mYMax - (float)sPos / 100.0f;
+         float yValue = yMax - float(mMouseY - (r.y + 1)) / (float)r.height * yTotal;
+         // Determine the note corresponding to each frequency.
          auto xp = PitchName_Absolute(FreqToMIDInote(xPos));
          auto pp = PitchName_Absolute(FreqToMIDInote(bestpeak));
-         /* i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#*/
-         cursor = XO("%d Hz (%s) = %d dB")
-            .Format( (int)(xPos + 0.5), xp, (int)(value + 0.5));
-         /* i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#*/
-         peak = XO("%d Hz (%s) = %.1f dB")
-            .Format( (int)(bestpeak + 0.5), pp, bestValue );
+         /* i18n-hint: The %f's are replaced by numbers, the %s by musical notes, e.g. A# */
+         cursor = XO("%.2f Hz (%s) = %.2f dB").Format(xPos, xp, yValue);
+         /* i18n-hint: The %f's are replaced by numbers, the %s by musical notes, e.g. A# */
+         peak = XO("%.2f Hz (%s) = %.2f dB").Format(bestpeak, pp, bestValue);
       } else if (xPos > 0.0 && bestpeak > 0.0) {
          auto xp = PitchName_Absolute(FreqToMIDInote(1.0 / xPos));
          auto pp = PitchName_Absolute(FreqToMIDInote(1.0 / bestpeak));
@@ -977,7 +985,6 @@ void FrequencyPlotDialog::PlotPaint(wxPaintEvent & event)
       mCursorText->SetValue(wxT(""));
       mPeakText->SetValue(wxT(""));
    }
-
 
    // Outline the graph
    dc.SetPen(*wxBLACK_PEN);

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -914,7 +914,6 @@ void FrequencyPlotDialog::PlotPaint(wxPaintEvent & event)
    }
 
    float xPos = xMin;
-   float yPos;
 
    // Find the peak nearest the cursor and plot it
    if ( r.Contains(mMouseX, mMouseY) & (mMouseX!=0) & (mMouseX!=r.width-1) ) {
@@ -951,19 +950,11 @@ void FrequencyPlotDialog::PlotPaint(wxPaintEvent & event)
       TranslatableString peak;
 
       if (mAlg == SpectrumAnalyst::Spectrum) {
-         // Determine the position of the cursor in the plot window.
-         float yRange = mYMax - mYMin;
-         float yTotal = yRange * (float)mZoomSlider->GetValue() / 100.0f;
-         int sTotal = yTotal * 100;
-         int sRange = yRange * 100;
-         int sPos = mPanScroller->GetThumbPosition() + ((mPanScroller->GetThumbSize() - sTotal) / 2);
-         float yMax = mYMax - (float)sPos / 100.0f;
-         float yValue = yMax - float(mMouseY - (r.y + 1)) / (float)r.height * yTotal;
          // Determine the note corresponding to each frequency.
          auto xp = PitchName_Absolute(FreqToMIDInote(xPos));
          auto pp = PitchName_Absolute(FreqToMIDInote(bestpeak));
          /* i18n-hint: The %f's are replaced by numbers, the %s by musical notes, e.g. A# */
-         cursor = XO("%.2f Hz (%s) = %.2f dB").Format(xPos, xp, yValue);
+         cursor = XO("%.2f Hz (%s) = %.2f dB").Format(xPos, xp, value);
          /* i18n-hint: The %f's are replaced by numbers, the %s by musical notes, e.g. A# */
          peak = XO("%.2f Hz (%s) = %.2f dB").Format(bestpeak, pp, bestValue);
       } else if (xPos > 0.0 && bestpeak > 0.0) {


### PR DESCRIPTION
Resolves: Improves the limited resolution of dB and Hz readouts when plotting a spectrum

The dB and Hz readouts when plotting a spectrum and using the cursor are now displayed to 2 decimal places. This improves their usefulness, particularly when analysing low frequency audio signals.

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
