### PR TITLE
Export spectrum includes the 0 Hz frequency bin

### DIFF
--- a/libraries/lib-math/FFT.cpp
+++ b/libraries/lib-math/FFT.cpp
@@ -305,21 +305,27 @@ void PowerSpectrum(size_t NumSamples, const float *In, float *Out)
 {
    auto hFFT = GetFFT(NumSamples);
    Floats pFFT{ NumSamples };
+
    // Copy the data into the processing buffer
-   for (size_t i = 0; i<NumSamples; i++)
+   for (size_t i = 0; i < NumSamples; i++)
       pFFT[i] = In[i];
 
    // Perform the FFT
    RealFFTf(pFFT.get(), hFFT.get());
 
-   // Copy the data into the real and imaginary outputs
-   for (size_t i = 1; i<NumSamples / 2; i++) {
-      Out[i]= (pFFT[hFFT->BitReversed[i]  ]*pFFT[hFFT->BitReversed[i]  ])
-         + (pFFT[hFFT->BitReversed[i]+1]*pFFT[hFFT->BitReversed[i]+1]);
+   // Determine the real and imaginary parts for each 
+   // frequency bin (excluding the DC and Fs/2 bins),
+   // and then compute the power.
+   for (size_t i = 1; i < NumSamples/2; i++) {
+      size_t idx = hFFT->BitReversed[i];
+      auto realPart = pFFT[idx];
+      auto imagPart = pFFT[idx + 1];
+      Out[i] = realPart * realPart + imagPart * imagPart;
    }
+
    // Handle the (real-only) DC and Fs/2 bins
    Out[0] = pFFT[0]*pFFT[0]/4;
-   Out[NumSamples / 2] = pFFT[1]*pFFT[1];
+   Out[NumSamples/2] = pFFT[1]*pFFT[1]/4;
 }
 
 /*

--- a/libraries/lib-math/FFT.cpp
+++ b/libraries/lib-math/FFT.cpp
@@ -318,7 +318,7 @@ void PowerSpectrum(size_t NumSamples, const float *In, float *Out)
          + (pFFT[hFFT->BitReversed[i]+1]*pFFT[hFFT->BitReversed[i]+1]);
    }
    // Handle the (real-only) DC and Fs/2 bins
-   Out[0] = pFFT[0]*pFFT[0];
+   Out[0] = pFFT[0]*pFFT[0]/4;
    Out[NumSamples / 2] = pFFT[1]*pFFT[1];
 }
 

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -1081,7 +1081,7 @@ void FrequencyPlotDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    if (mAlgChoice->GetSelection() == 0) {
       ss
          << XO("Frequency (Hz)\tLevel (dB)") << '\n';
-      for (int i = 1; i < processedSize; i++)
+      for (int i = 0; i < processedSize; i++)
          ss
             << wxString::Format(wxT("%f\t%f\n"),
                i * mRate / mWindowSize, processed[i] );

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -1081,7 +1081,9 @@ void FrequencyPlotDialog::OnExport(wxCommandEvent & WXUNUSED(event))
    if (mAlgChoice->GetSelection() == 0) {
       ss
          << XO("Frequency (Hz)\tLevel (dB)") << '\n';
-      for (int i = 0; i < processedSize; i++)
+      // Write out all analysed frequencies, from
+      // DC to half the sampling rate (Fs/2).
+      for (int i = 0; i <= processedSize; i++)
          ss
             << wxString::Format(wxT("%f\t%f\n"),
                i * mRate / mWindowSize, processed[i] );

--- a/src/SpectrumAnalyst.cpp
+++ b/src/SpectrumAnalyst.cpp
@@ -158,8 +158,10 @@ bool SpectrumAnalyst::Calculate(Algorithm alg, int windowFunc,
       switch (alg) {
          case Spectrum:
             PowerSpectrum(mWindowSize, in.get(), out.get());
-
-            for (size_t i = 0; i < half; i++)
+            // Add the contribution from the computed spectrum at 
+            // all frequencies being analysed, from DC to half the
+            // sampling rate (Fs/2).
+            for (size_t i = 0; i <= half; i++)
                mProcessed[i] += out[i];
             break;
 
@@ -243,15 +245,17 @@ bool SpectrumAnalyst::Calculate(Algorithm alg, int windowFunc,
    switch (alg) {
    case Spectrum:
       // Convert to decibels
-      mYMin = 1000000.;
-      mYMax = -1000000.;
+      mYMin = +1000000.0f;
+      mYMax = -1000000.0f;
       scale = wss / (double)windows;
-      for (size_t i = 0; i < half; i++)
+      // Process all of the analysed frequencies,
+      // from DC to half the sampling rate (Fs/2).
+      for (size_t i = 0; i <= half; i++)
       {
          mProcessed[i] = 10 * log10(mProcessed[i] * scale);
-         if(mProcessed[i] > mYMax)
+         if (mProcessed[i] > mYMax)
             mYMax = mProcessed[i];
-         else if(mProcessed[i] < mYMin)
+         else if (mProcessed[i] < mYMin)
             mYMin = mProcessed[i];
       }
       break;


### PR DESCRIPTION
Resolves: Export spectrum does not save the data for the first FFT bin (0 Hz)

The export spectrum command presently does not include the data from the FFT bin corresponding to the 0 Hz frequency (DC). This modification ensures that all the FFT results are saved, as some signals may have a significant DC offset that needs to be measured. This change enables Audacity to be used as a DC-coupled spectrum analyzer.

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
