### PR TITLE
Fix for FFmpeg loading on macOS

### DIFF
--- a/src/FFmpeg.cpp
+++ b/src/FFmpeg.cpp
@@ -183,9 +183,9 @@ public:
 #   if defined(__WXMSW__)
          { XO("Only avformat.dll"), { wxT("avformat-*.dll") } },
 #   elif defined(__WXMAC__)
-         { XO("Only avformat.dll"), { wxT("ffmpeg.*.64bit.dylib") } },
+         { XO("Only ffmpeg.*.dylib"), { wxT("ffmpeg.*.dylib") } },
 #   else
-         { XO("Only avformat.dll"), { wxT("libavformat.so.*") } },
+         { XO("Only libavformat.so"), { wxT("libavformat.so.*") } },
 #   endif
          FileNames::DynamicLibraries,
          FileNames::AllFiles


### PR DESCRIPTION
Resolves: #1751 

On macOS - the dynamic library loader behaves differently.
All DYLD_* environment variables are read only during the application startup. This PR"emulates" the behavior of other OS by manually trying to load every library from every directory listed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
