### PR TITLE
Fix cut preview

### DIFF
--- a/libraries/lib-audio-devices/AudioIOBase.h
+++ b/libraries/lib-audio-devices/AudioIOBase.h
@@ -47,8 +47,6 @@ struct AudioIOStartStreamOptions
       : pProject{ pProject_ }
       , envelope(nullptr)
       , rate(rate_)
-      , cutPreviewGapStart(0.0)
-      , cutPreviewGapLen(0.0)
       , pStartTime(NULL)
       , preRoll(0.0)
    {}
@@ -58,8 +56,6 @@ struct AudioIOStartStreamOptions
    const BoundedEnvelope *envelope; // for time warping
    std::shared_ptr< AudioIOListener > listener;
    double rate;
-   double cutPreviewGapStart;
-   double cutPreviewGapLen;
    double * pStartTime;
    double preRoll;
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -924,12 +924,12 @@ int AudioIO::StartStream(const TransportTracks &tracks,
 
       // Main thread's initialization of mTime
       mPlaybackSchedule.SetTrackTime( time );
+      mPlaybackSchedule.GetPolicy().OffsetTrackTime( mPlaybackSchedule, 0 );
 
       // Reset mixer positions for all playback tracks
       unsigned numMixers = mPlaybackTracks.size();
       for (unsigned ii = 0; ii < numMixers; ++ii)
          mPlaybackMixers[ii]->Reposition( time );
-      mPlaybackSchedule.RealTimeInit( time );
    }
    
    // Now that we are done with SetTrackTime():
@@ -3016,12 +3016,12 @@ int AudioIoCallback::CallbackDoSeek()
    }
 
    // Calculate the NEW time position, in the PortAudio callback
-   const auto time = mPlaybackSchedule.ClampTrackTime(
-      mPlaybackSchedule.GetTrackTime() + mSeek );
+   const auto time =
+      mPlaybackSchedule.GetPolicy().OffsetTrackTime( mPlaybackSchedule, mSeek );
+
    mPlaybackSchedule.SetTrackTime( time );
    mSeek = 0.0;
 
-   mPlaybackSchedule.RealTimeInit( time );
 
    // Reset mixer positions and flush buffers for all tracks
    for (size_t i = 0; i < numPlaybackTracks; i++)

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1801,8 +1801,7 @@ void AudioIO::FillPlayBuffers()
       // consumer side in the PortAudio thread, which reads the time
       // queue after reading the sample queues.  The sample queues use
       // atomic variables, the time queue doesn't.
-      mPlaybackSchedule.mTimeQueue.Producer( mPlaybackSchedule, mRate,
-         frames);
+      mPlaybackSchedule.mTimeQueue.Producer(mPlaybackSchedule, frames);
 
       for (size_t i = 0; i < mPlaybackTracks.size(); i++)
       {

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -15,6 +15,8 @@
 #include "Mix.h"
 #include "SampleCount.h"
 
+#include <cmath>
+
 PlaybackPolicy::~PlaybackPolicy() = default;
 void PlaybackPolicy::Initialize( PlaybackSchedule &, double rate )
 {
@@ -112,9 +114,11 @@ PlaybackPolicy::GetPlaybackSlice(PlaybackSchedule &schedule, size_t available)
    return { available, frames, toProduce };
 }
 
-double PlaybackPolicy::AdvancedTrackTime( PlaybackSchedule &schedule,
-   double trackTime, double realDuration )
+std::pair<double, double>
+PlaybackPolicy::AdvancedTrackTime( PlaybackSchedule &schedule,
+   double trackTime, size_t nSamples )
 {
+   auto realDuration = nSamples / mRate;
    if (schedule.ReversedTime())
       realDuration *= -1.0;
 
@@ -123,8 +127,11 @@ double PlaybackPolicy::AdvancedTrackTime( PlaybackSchedule &schedule,
          schedule.SolveWarpedLength(trackTime, realDuration);
    else
       trackTime += realDuration;
-
-   return trackTime;
+   
+   if ( trackTime >= schedule.mT1 )
+      return { schedule.mT1, std::numeric_limits<double>::infinity() };
+   else
+      return { trackTime, trackTime };
 }
 
 bool PlaybackPolicy::RepositionPlayback(
@@ -175,9 +182,10 @@ LoopingPlaybackPolicy::GetPlaybackSlice(
    auto toProduce = frames;
    double deltat = frames / mRate;
 
+   mRemaining = realTimeRemaining * mRate;
    if (deltat > realTimeRemaining)
    {
-      toProduce = frames = realTimeRemaining * mRate;
+      toProduce = frames = mRemaining;
       schedule.RealTimeAdvance( realTimeRemaining );
    }
    else
@@ -194,60 +202,29 @@ LoopingPlaybackPolicy::GetPlaybackSlice(
    return { available, frames, toProduce };
 }
 
-double LoopingPlaybackPolicy::AdvancedTrackTime(
-   PlaybackSchedule &schedule,
-   double trackTime, double realDuration )
+std::pair<double, double> LoopingPlaybackPolicy::AdvancedTrackTime(
+   PlaybackSchedule &schedule, double trackTime, size_t nSamples )
 {
-   if (schedule.ReversedTime())
-      realDuration *= -1.0;
+   mRemaining -= std::min(mRemaining, nSamples);
+   if ( mRemaining == 0 )
+      // Wrap to start
+      return { schedule.mT1, schedule.mT0 };
 
    // Defense against cases that might cause loops not to terminate
    if ( fabs(schedule.mT0 - schedule.mT1) < 1e-9 )
-      return schedule.mT0;
+      return {schedule.mT0, schedule.mT0};
 
-   if (schedule.mEnvelope) {
-      double total=0.0;
-      bool foundTotal = false;
-      do {
-         auto oldTime = trackTime;
-         if (foundTotal && fabs(realDuration) > fabs(total))
-            // Avoid SolveWarpedLength
-            trackTime = schedule.mT1;
-         else
-            trackTime =
-               schedule.SolveWarpedLength(trackTime, realDuration);
+   auto realDuration = nSamples / mRate;
+   if (schedule.ReversedTime())
+      realDuration *= -1.0;
 
-         if (!schedule.Overruns( trackTime ))
-            break;
-
-         // Bug1922:  The part of the time track outside the loop should not
-         // influence the result
-         double delta;
-         if (foundTotal && oldTime == schedule.mT0)
-            // Avoid integrating again
-            delta = total;
-         else {
-            delta = schedule.ComputeWarpedLength(oldTime, schedule.mT1);
-            if (oldTime == schedule.mT0)
-               foundTotal = true, total = delta;
-         }
-         realDuration -= delta;
-         trackTime = schedule.mT0;
-      } while ( true );
-   }
-   else {
+   if (schedule.mEnvelope)
+      trackTime =
+         schedule.SolveWarpedLength(trackTime, realDuration);
+   else
       trackTime += realDuration;
 
-      // Wrap to start if looping
-      while ( schedule.Overruns( trackTime ) ) {
-         // LL:  This is not exactly right, but I'm at my wits end trying to
-         //      figure it out.  Feel free to fix it.  :-)
-         // MB: it's much easier than you think, mTime isn't warped at all!
-         trackTime -= schedule.mT1 - schedule.mT0;
-      }
-   }
-
-   return trackTime;
+   return { trackTime, trackTime };
 }
 
 bool LoopingPlaybackPolicy::RepositionPlayback(
@@ -326,11 +303,6 @@ double PlaybackSchedule::ClampTrackTime( double trackTime ) const
       return std::max(mT0, std::min(mT1, trackTime));
 }
 
-bool PlaybackSchedule::Overruns( double trackTime ) const
-{
-   return (ReversedTime() ? trackTime <= mT1 : trackTime >= mT1);
-}
-
 double PlaybackSchedule::ComputeWarpedLength(double t0, double t1) const
 {
    if (mEnvelope)
@@ -388,8 +360,7 @@ double RecordingSchedule::ToDiscard() const
 }
 
 void PlaybackSchedule::TimeQueue::Producer(
-   PlaybackSchedule &schedule, double rate,
-   size_t nSamples )
+   PlaybackSchedule &schedule, size_t nSamples )
 {
    auto &policy = schedule.GetPolicy();
 
@@ -405,7 +376,10 @@ void PlaybackSchedule::TimeQueue::Producer(
    auto space = TimeQueueGrainSize - remainder;
 
    while ( nSamples >= space ) {
-      time = policy.AdvancedTrackTime( schedule, time, space / rate );
+      auto times = policy.AdvancedTrackTime( schedule, time, space );
+      time = times.second;
+      if (!std::isfinite(time))
+         time = times.first;
       index = (index + 1) % mSize;
       mData[ index ] = time;
       nSamples -= space;
@@ -414,8 +388,12 @@ void PlaybackSchedule::TimeQueue::Producer(
    }
 
    // Last odd lot
-   if ( nSamples > 0 )
-      time = policy.AdvancedTrackTime( schedule, time, nSamples / rate );
+   if ( nSamples > 0 ) {
+      auto times = policy.AdvancedTrackTime( schedule, time, nSamples );
+      time = times.second;
+      if (!std::isfinite(time))
+         time = times.first;
+   }
 
    mLastTime = time;
    mTail.mRemainder = remainder + nSamples;

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -46,22 +46,10 @@ double PlaybackPolicy::NormalizeTrackTime( PlaybackSchedule &schedule )
    // the current stream time, and this query is not always accurate.
    // Sometimes it's a little behind or ahead, and so this function
    // makes sure that at least we clip it to the selection.
-   //
-   // msmeyer: There is also the possibility that we are using "cut preview"
-   //          mode. In this case, we should jump over a defined "gap" in the
-   //          audio.
 
    // Limit the time between t0 and t1.
    // Should the limiting be necessary in any play mode if there are no bugs?
    double absoluteTime = schedule.LimitTrackTime();
-
-   if (schedule.mCutPreviewGapLen > 0)
-   {
-      // msmeyer: We're in cut preview mode, so if we are on the right
-      // side of the gap, we jump over it.
-      if (absoluteTime > schedule.mCutPreviewGapStart)
-         absoluteTime += schedule.mCutPreviewGapLen;
-   }
 
    return absoluteTime;
 }
@@ -287,9 +275,6 @@ void PlaybackSchedule::Init(
 
    if (options.policyFactory)
       mpPlaybackPolicy = options.policyFactory();
-
-   mCutPreviewGapStart = options.cutPreviewGapStart;
-   mCutPreviewGapLen = options.cutPreviewGapLen;
 
    mWarpedTime = 0.0;
    mWarpedLength = RealDuration(mT1);

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -82,6 +82,15 @@ bool PlaybackPolicy::Done( PlaybackSchedule &schedule,
       outputFrames == 0;
 }
 
+double PlaybackPolicy::OffsetTrackTime(
+   PlaybackSchedule &schedule, double offset )
+{
+   const auto time = schedule.ClampTrackTime(
+      schedule.GetTrackTime() + offset );
+   schedule.RealTimeInit( time );
+   return time;
+}
+
 std::chrono::milliseconds PlaybackPolicy::SleepInterval(PlaybackSchedule &)
 {
    using namespace std::chrono;

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -210,6 +210,12 @@ public:
       unsigned long outputFrames //!< how many playback frames were taken from RingBuffers
    );
 
+   //! Called when the play head needs to jump a certain distance
+   /*! @param offset signed amount requested to be added to schedule::GetTrackTime()
+      @return the new value that will be set as the schedule's track time
+    */
+   virtual double OffsetTrackTime( PlaybackSchedule &schedule, double offset );
+
    //! @section Called by the AudioIO::TrackBufferExchange thread
 
    //! How long to wait between calls to AudioIO::TrackBufferExchange

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -334,9 +334,6 @@ struct AUDACITY_DLL_API PlaybackSchedule {
    PlaybackPolicy &GetPolicy();
    const PlaybackPolicy &GetPolicy() const;
 
-   double              mCutPreviewGapStart;
-   double              mCutPreviewGapLen;
-
    void Init(
       double t0, double t1,
       const AudioIOStartStreamOptions &options,

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -14,6 +14,7 @@ Paul Licameli split from ProjectManager.cpp
 #include <wx/app.h>
 #include <wx/frame.h>
 #include <wx/statusbr.h>
+#include <algorithm>
 
 #include "AudioIO.h"
 #include "BasicUI.h"
@@ -99,7 +100,194 @@ auto ProjectAudioManager::StatusWidthFunction(
    return {};
 }
 
-/*! @excsafety{Strong} -- For state of mCutPreviewTracks */
+namespace {
+// The implementation is general enough to allow backwards play too
+class CutPreviewPlaybackPolicy final : public PlaybackPolicy {
+public:
+   CutPreviewPlaybackPolicy(
+      double gapLeft, //!< Lower bound track time of of elision
+      double gapLength //!< Non-negative track duration
+   );
+   ~CutPreviewPlaybackPolicy() override;
+
+   void Initialize(PlaybackSchedule &schedule, double rate) override;
+
+   bool Done(PlaybackSchedule &schedule, unsigned long) override;
+
+   double OffsetTrackTime( PlaybackSchedule &schedule, double offset ) override;
+
+   PlaybackSlice GetPlaybackSlice(
+      PlaybackSchedule &schedule, size_t available) override;
+
+   std::pair<double, double> AdvancedTrackTime( PlaybackSchedule &schedule,
+      double trackTime, size_t nSamples) override;
+
+   bool RepositionPlayback(
+      PlaybackSchedule &schedule, const Mixers &playbackMixers,
+      size_t frames, size_t available) override;
+
+private:
+   double GapStart() const
+   { return mReversed ? mGapLeft + mGapLength : mGapLeft; }
+   double GapEnd() const
+   { return mReversed ? mGapLeft : mGapLeft + mGapLength; }
+   bool AtOrBefore(double trackTime1, double trackTime2) const
+   { return mReversed ? trackTime1 >= trackTime2 : trackTime1 <= trackTime2; }
+
+   //! Fixed at construction time; these are a track time and duration
+   const double mGapLeft, mGapLength;
+
+   //! Starting and ending track times set in Initialize()
+   double mStart = 0, mEnd = 0;
+
+   // Non-negative real time durations
+   double mDuration1 = 0, mDuration2 = 0;
+   double mInitDuration1 = 0, mInitDuration2 = 0;
+
+   bool mDiscontinuity{ false };
+   bool mReversed{ false };
+};
+
+CutPreviewPlaybackPolicy::CutPreviewPlaybackPolicy(
+   double gapLeft, double gapLength)
+: mGapLeft{ gapLeft }, mGapLength{ gapLength }
+{
+   wxASSERT(gapLength >= 0.0);
+}
+
+CutPreviewPlaybackPolicy::~CutPreviewPlaybackPolicy() = default;
+
+void CutPreviewPlaybackPolicy::Initialize(
+   PlaybackSchedule &schedule, double rate)
+{
+   PlaybackPolicy::Initialize(schedule, rate);
+
+   // Examine mT0 and mT1 in the schedule only now; ignore changes during play
+   double left = mStart = schedule.mT0;
+   double right = mEnd = schedule.mT1;
+   mReversed = left > right;
+   if (mReversed)
+      std::swap(left, right);
+
+   if (left < mGapLeft)
+      mDuration1 = schedule.ComputeWarpedLength(left, mGapLeft);
+   const auto gapEnd = mGapLeft + mGapLength;
+   if (gapEnd < right)
+      mDuration2 = schedule.ComputeWarpedLength(gapEnd, right);
+   if (mReversed)
+      std::swap(mDuration1, mDuration2);
+   if (sampleCount(mDuration2 * rate) == 0)
+      mDuration2 = mDuration1, mDuration1 = 0;
+   mInitDuration1 = mDuration1;
+   mInitDuration2 = mDuration2;
+}
+
+bool CutPreviewPlaybackPolicy::Done(PlaybackSchedule &schedule, unsigned long)
+{
+   //! Called in the PortAudio thread
+   auto diff = schedule.GetTrackTime() - mEnd;
+   if (mReversed)
+      diff *= -1;
+   return sampleCount(diff * mRate) >= 0;
+}
+
+double CutPreviewPlaybackPolicy::OffsetTrackTime(
+   PlaybackSchedule &schedule, double offset )
+{
+   // Compute new time by applying the offset, jumping over the gap
+   auto time = schedule.GetTrackTime();
+   if (offset >= 0) {
+      auto space = std::clamp(mGapLeft - time, 0.0, offset);
+      time += space;
+      offset -= space;
+      if (offset > 0)
+         time = std::max(time, mGapLeft + mGapLength) + offset;
+   }
+   else {
+      auto space = std::clamp(mGapLeft + mGapLength - time, offset, 0.0);
+      time += space;
+      offset -= space;
+      if (offset < 0)
+         time = std::min(time, mGapLeft) + offset;
+   }
+   time = std::clamp(time, std::min(mStart, mEnd), std::max(mStart, mEnd));
+
+   // Reset the durations
+   mDiscontinuity = false;
+   mDuration1 = mInitDuration1;
+   mDuration2 = mInitDuration2;
+   if (AtOrBefore(time, GapStart()))
+      mDuration1 = std::max(0.0,
+         mDuration1 - fabs(schedule.ComputeWarpedLength(mStart, time)));
+   else {
+      mDuration1 = 0;
+      mDuration2 = std::max(0.0,
+         mDuration2 - fabs(schedule.ComputeWarpedLength(GapEnd(), time)));
+   }
+
+   return time;
+}
+
+PlaybackSlice CutPreviewPlaybackPolicy::GetPlaybackSlice(
+   PlaybackSchedule &, size_t available)
+{
+   size_t frames = available;
+   size_t toProduce = frames;
+   sampleCount samples1(mDuration1 * mRate);
+   if (samples1 > 0 && samples1 < frames)
+      // Shorter slice than requested, up to the discontinuity
+      toProduce = frames = samples1.as_size_t();
+   else if (samples1 == 0) {
+      sampleCount samples2(mDuration2 * mRate);
+      if (samples2 < frames) {
+         toProduce = samples2.as_size_t();
+         // Produce some extra silence so that the time queue consumer can
+         // satisfy its end condition
+         frames = std::min(available, toProduce + TimeQueueGrainSize + 1);
+      }
+   }
+   return { available, frames, toProduce };
+}
+
+std::pair<double, double> CutPreviewPlaybackPolicy::AdvancedTrackTime(
+   PlaybackSchedule &schedule, double trackTime, size_t nSamples)
+{
+   auto realDuration = nSamples / mRate;
+   if (mDuration1 > 0) {
+      mDuration1 = std::max(0.0, mDuration1 - realDuration);
+      if (sampleCount(mDuration1 * mRate) == 0) {
+         mDuration1 = 0;
+         mDiscontinuity = true;
+         return { GapStart(), GapEnd() };
+      }
+   }
+   else
+      mDuration2 = std::max(0.0, mDuration2 - realDuration);
+   if (mReversed)
+      realDuration *= -1;
+   const double time = schedule.SolveWarpedLength(trackTime, realDuration);
+
+   if ( mReversed ? time <= mEnd : time >= mEnd )
+      return {mEnd, std::numeric_limits<double>::infinity()};
+   else
+      return {time, time};
+}
+
+bool CutPreviewPlaybackPolicy::RepositionPlayback( PlaybackSchedule &,
+   const Mixers &playbackMixers, size_t, size_t )
+{
+   if (mDiscontinuity) {
+      mDiscontinuity = false;
+      auto newTime = GapEnd();
+      for (auto &pMixer : playbackMixers)
+         pMixer->Reposition(newTime, true);
+      // Tell TrackBufferExchange that we aren't done yet
+      return false;
+   }
+   return true;
+}
+}
+
 int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
                                    const AudioIOStartStreamOptions &options,
                                    PlayMode mode,
@@ -219,23 +407,18 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
          gPrefs->Read(wxT("/AudioIO/CutPreviewBeforeLen"), &beforeLen, 2.0);
          gPrefs->Read(wxT("/AudioIO/CutPreviewAfterLen"), &afterLen, 1.0);
          double tcp0 = tless-beforeLen;
-         double diff = tgreater - tless;
-         double tcp1 = (tgreater+afterLen) - diff;
-         SetupCutPreviewTracks(tcp0, tless, tgreater, tcp1);
+         const double diff = tgreater - tless;
+         double tcp1 = tgreater+afterLen;
          if (backwards)
             std::swap(tcp0, tcp1);
-         if (mCutPreviewTracks)
-         {
-            AudioIOStartStreamOptions myOptions = options;
-            myOptions.cutPreviewGapStart = t0;
-            myOptions.cutPreviewGapLen = t1 - t0;
-            token = gAudioIO->StartStream(
-               GetAllPlaybackTracks(*mCutPreviewTracks, false, nonWaveToo),
-               tcp0, tcp1, myOptions);
-         }
-         else
-            // Cannot create cut preview tracks, clean up and exit
-            return -1;
+         AudioIOStartStreamOptions myOptions = options;
+         myOptions.policyFactory =
+            [tless, diff]() -> std::unique_ptr<PlaybackPolicy> {
+               return std::make_unique<CutPreviewPlaybackPolicy>(tless, diff);
+            };
+         token = gAudioIO->StartStream(
+            GetAllPlaybackTracks(TrackList::Get(*p), false, nonWaveToo),
+            tcp0, tcp1, myOptions);
       }
       else {
          token = gAudioIO->StartStream(
@@ -349,8 +532,6 @@ void ProjectAudioManager::Stop(bool stopStream /* = true*/)
    projectAudioManager.SetPaused( false );
    //Make sure you tell gAudioIO to unpause
    gAudioIO->SetPaused( false );
-
-   ClearCutPreviewTracks();
 
    // So that we continue monitoring after playing or recording.
    // also clean the MeterQueues
@@ -809,38 +990,6 @@ void ProjectAudioManager::OnPause()
    {
       gAudioIO->SetPaused(paused);
    }
-}
-
-/*! @excsafety{Strong} -- For state of mCutPreviewTracks*/
-void ProjectAudioManager::SetupCutPreviewTracks(double WXUNUSED(playStart), double cutStart,
-                                           double cutEnd, double  WXUNUSED(playEnd))
-
-{
-   ClearCutPreviewTracks();
-   AudacityProject *p = &mProject;
-   {
-      auto trackRange = TrackList::Get( *p ).Selected< const PlayableTrack >();
-      if( !trackRange.empty() ) {
-         auto cutPreviewTracks = TrackList::Create( nullptr );
-         for (const auto track1 : trackRange) {
-            // Duplicate and change tracks
-            // Clear has a very small chance of throwing
-
-            auto newTrack = track1->Duplicate();
-            newTrack->Clear(cutStart, cutEnd);
-            cutPreviewTracks->Add( newTrack );
-         }
-         // use No-throw-guarantee:
-         mCutPreviewTracks = cutPreviewTracks;
-      }
-   }
-}
-
-void ProjectAudioManager::ClearCutPreviewTracks()
-{
-   if (mCutPreviewTracks)
-      mCutPreviewTracks->Clear();
-   mCutPreviewTracks.reset();
 }
 
 void ProjectAudioManager::CancelRecording()

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -128,10 +128,6 @@ private:
    void SetCutting( bool value ) { mCutting = value; }
    void SetStopping( bool value ) { mStopping = value; }
 
-   void SetupCutPreviewTracks(double playStart, double cutStart,
-                             double cutEnd, double playEnd);
-   void ClearCutPreviewTracks();
-
    // Cancel the addition of temporary recording tracks into the project
    void CancelRecording();
 
@@ -146,8 +142,6 @@ private:
    void OnCheckpointFailure(wxCommandEvent &evt);
 
    AudacityProject &mProject;
-
-   std::shared_ptr<TrackList> mCutPreviewTracks;
 
    PlayMode mLastPlayMode{ PlayMode::normalPlay };
 

--- a/src/ScrubState.h
+++ b/src/ScrubState.h
@@ -70,8 +70,9 @@ public:
    PlaybackSlice GetPlaybackSlice(
       PlaybackSchedule &schedule, size_t available) override;
 
-   double AdvancedTrackTime( PlaybackSchedule &schedule,
-      double trackTime, double realDuration ) override;
+   std::pair<double, double>
+      AdvancedTrackTime( PlaybackSchedule &schedule,
+         double trackTime, size_t nSamples ) override;
 
    bool RepositionPlayback(
       PlaybackSchedule &schedule, const Mixers &playbackMixers,
@@ -81,9 +82,11 @@ public:
 
 private:
    sampleCount mScrubDuration{ 0 }, mStartSample{ 0 }, mEndSample{ 0 };
+   double mOldEndTime{ 0 }, mNewStartTime{ 0 };
    double mScrubSpeed{ 0 };
    bool mSilentScrub{ false };
    bool mReplenish{ false };
+   size_t mUntilDiscontinuity{ 0 };
 
    const ScrubbingOptions mOptions;
 };


### PR DESCRIPTION
Resolves: #1702
Resolves: #1703
Resolves: #1568
Resolves: #1566

Reimplement the "cut preview" feature (the "C" shortcut key, also ctrl+click on Play button) less special-casely by using another subclass of PlaybackPolicy.  It means cut preview will also interact nicely with the time track and respond like other
playback to changes of mute, solo, gain, and pan controls.

No more temporary tracks in the implementation.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
