### PR TITLE
Fix the build on Linux when system libraries are used

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityDependencies.cmake
+++ b/cmake-proxies/cmake-modules/AudacityDependencies.cmake
@@ -167,13 +167,7 @@ function (add_conan_lib package conan_package_name )
                     add_library( ${interface_name} INTERFACE IMPORTED GLOBAL)
 
                     # Retrieve the package information
-                    get_package_interface( PKG_${package} )
-
-                    # And add it to our target
-                    target_include_directories( ${interface_name} INTERFACE ${INCLUDES} )
-                    target_link_libraries( ${interface_name} INTERFACE ${LIBRARIES} )
-
-                    message(STATUS "Added inteface ${interface_name} ${INCLUDES} ${LIBRARIES}")
+                    get_package_interface( PKG_${package} ${interface_name} )
                     return()
                 endif()
             endforeach()

--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -51,22 +51,29 @@ function( set_dir_folder dir folder)
 endfunction()
 
 # Helper to retrieve the settings returned from pkg_check_modules()
-macro( get_package_interface package )
-   set( INCLUDES
+function( get_package_interface package target )
+   set( package_includes
       ${${package}_INCLUDE_DIRS}
    )
 
-   set( LINKDIRS
+   set( package_linkdirs
       ${${package}_LIBDIR}
    )
 
    # We resolve the full path of each library to ensure the
    # correct one is referenced while linking
+   set( package_libraries )
    foreach( lib ${${package}_LIBRARIES} )
-      find_library( LIB_${lib} ${lib} HINTS ${LINKDIRS} )
-      list( APPEND LIBRARIES ${LIB_${lib}} )
+      find_library( LIB_${lib} ${lib} HINTS ${package_linkdirs} )
+      list( APPEND package_libraries ${LIB_${lib}} )
    endforeach()
-endmacro()
+
+   # And add it to our target
+   target_include_directories( ${target} INTERFACE ${package_includes} )
+   target_link_libraries( ${target} INTERFACE ${package_libraries} )
+
+   message(STATUS "Interface ${target}:\n\tinclude: ${includes}\n\tLibraries: ${LIBRARIES}")
+endfunction()
 
 # Set the cache and context value
 macro( set_cache_value var value )
@@ -263,7 +270,7 @@ function( audacity_append_common_compiler_options var use_pch )
          # Define/undefine _DEBUG
 	 # Yes, -U to /U too as needed for Windows:
 	 $<IF:$<CONFIG:Debug>,-D_DEBUG=1,-U_DEBUG>
-   )   
+   )
    # Definitions controlled by the AUDACITY_BUILD_LEVEL switch
    if( AUDACITY_BUILD_LEVEL EQUAL 0 )
       list( APPEND ${var} -DIS_ALPHA -DUSE_ALPHA_MANUAL )
@@ -408,7 +415,7 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
 
    # compute LIBRARIES
    set( LIBRARIES )
-   
+
    foreach( IMPORT ${IMPORT_TARGETS} )
       list( APPEND LIBRARIES "${IMPORT}" )
    endforeach()
@@ -449,8 +456,8 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
       endif()
 
       add_custom_command(TARGET ${TARGET} POST_BUILD
-         COMMAND ${CMAKE_COMMAND} -E copy 
-            "$<TARGET_FILE:${TARGET}>" 
+         COMMAND ${CMAKE_COMMAND} -E copy
+            "$<TARGET_FILE:${TARGET}>"
             "${REQUIRED_LOCATION}/$<TARGET_FILE_NAME:${TARGET}>"
       )
    endif()
@@ -589,7 +596,7 @@ function( addlib dir name symbol required check )
    set( TARGET_ROOT ${libsrc}/${dir} )
 
    # Define the option name
-   set( use ${_OPT}use_${name} ) 
+   set( use ${_OPT}use_${name} )
 
    # If we're not checking for system or local here, then let the
    # target config handle the rest.
@@ -635,7 +642,7 @@ function( addlib dir name symbol required check )
    if ( TARGET "${TARGET}" )
       return()
    endif()
- 
+
    message( STATUS "========== Configuring ${name} ==========" )
 
    # Check for the system package(s) if the user prefers it
@@ -650,11 +657,7 @@ function( addlib dir name symbol required check )
          add_library( ${TARGET} INTERFACE IMPORTED GLOBAL )
 
          # Retrieve the package information
-         get_package_interface( PKG_${TARGET} )
-
-         # And add it to our target
-         target_include_directories( ${TARGET} INTERFACE ${INCLUDES} )
-         target_link_libraries( ${TARGET} INTERFACE ${LIBRARIES} )
+         get_package_interface( PKG_${TARGET} ${TARGET} )
       else()
          find_package( ${packages} QUIET )
 
@@ -686,7 +689,7 @@ function( addlib dir name symbol required check )
       # Set the folder (for the IDEs) for each one
       foreach( target ${targets} )
          # Skip interface libraries since they don't have any source to
-         # present in the IDEs   
+         # present in the IDEs
          get_target_property( type "${target}" TYPE )
          if( NOT "${type}" STREQUAL "INTERFACE_LIBRARY" )
             set_target_properties( ${target} PROPERTIES FOLDER "lib-src" )

--- a/lib-src/portmixer/CMakeLists.txt
+++ b/lib-src/portmixer/CMakeLists.txt
@@ -130,3 +130,7 @@ target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
 target_link_libraries( ${TARGET} PRIVATE ${LIBRARIES} )
+
+if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
+   target_compile_options( ${TARGET} PRIVATE -fPIC )
+endif()


### PR DESCRIPTION
Fixes a problematic `get_package_interface` which was modifying a global list `LIBRARIES`.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
