### PR TITLE
Fix auto clip naming

### DIFF
--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1299,6 +1299,7 @@ void WaveTrack::PasteWaveTrack(double t0, const WaveTrack* other)
 
     //wxPrintf("Check if we need to make room for the pasted data\n");
 
+    auto pastingFromTempTrack = !other->GetOwner();
     bool editClipCanMove = GetEditClipsCanMove();
 
     // Make room for the pasted data
@@ -1405,7 +1406,12 @@ void WaveTrack::PasteWaveTrack(double t0, const WaveTrack* other)
             newClip->Resample(mRate);
             newClip->Offset(t0);
             newClip->MarkChanged();
-            newClip->SetName(MakeClipCopyName(clip->GetName()));
+            if (pastingFromTempTrack)
+                //Clips from the tracks which aren't bound to any TrackList are 
+                //considered to be new entities, thus named using "new" name template
+                newClip->SetName(MakeNewClipName());
+            else
+                newClip->SetName(MakeClipCopyName(clip->GetName()));
             mClips.push_back(std::move(newClip)); // transfer ownership
         }
     }


### PR DESCRIPTION
Resolves: #1651 

Also fixes wrong name assigned to a clip when recording to a new track.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
