### PR TITLE
Update copyright headers in ExportOGG.cpp and ExportFLAC.cpp

### DIFF
--- a/src/export/ExportFLAC.cpp
+++ b/src/export/ExportFLAC.cpp
@@ -12,10 +12,6 @@ A copy of this license is included with this source.
 Based on ExportOGG.cpp by:
 Joshua Haberman
 
-Portions from vorbis-tools, copyright 2000-2002 Michael Smith
-<msmith@labyrinth.net.au>; Vorbize, Kenneth Arnold <kcarnold@yahoo.com>;
-and libvorbis examples, Monty <monty@xiph.org>
-
 **********************************************************************/
 
 

--- a/src/export/ExportOGG.cpp
+++ b/src/export/ExportOGG.cpp
@@ -9,10 +9,6 @@
   This program is distributed under the GNU General Public License, version 2.
   A copy of this license is included with this source.
 
-  Portions from vorbis-tools, copyright 2000-2002 Michael Smith
-  <msmith@labyrinth.net.au>; Vorbize, Kenneth Arnold <kcarnold@yahoo.com>;
-  and libvorbis examples, Monty <monty@xiph.org>
-
 **********************************************************************/
 
 


### PR DESCRIPTION
The author statement appears to be from https://github.com/xiph/vorbis-tools/blob/e59564c52837cfd2eba61b398f0b1bd16f1003eb/oggenc/oggenc.c#L6-L9 but we can't see any code used from that file. In any case, Audacity's files have been almost completely rewritten since the statement was added.

A previous version of Audacity's ExportOGG.cpp lacking this statement is available at https://github.com/audacity/audacity-from-svn-5GB/blob/master/audacity-src/branches/audacity-0_9-branch/audacity-old/ExportOGG.cpp