### PR TITLE
Fix for AppImage issues, related to conflicts with system libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,7 @@ win/xaudacity.ico
 
 .idea/
 .vscode/
+
+# AppImage
+linuxdeploy/*
+appimagetool/*

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -195,7 +195,7 @@ This option implies `-Daudacity_obey_system_dependencies=On` and disables `local
 
 ### Disabling pre-built binaries downloads for Conan
 
-It is possible to force Conan to build all the dependencies from the source code without using the pre-built binaries. To do so, please pass `-Daudaicity_conan_allow_prebuilt_binaries=Off` to CMake during the configration. This option will trigger rebuild every
+It is possible to force Conan to build all the dependencies from the source code without using the pre-built binaries. To do so, please pass `-Daudaicity_conan_allow_prebuilt_binaries=Off` to CMake during the configuration. This option will trigger rebuild every
 time CMake configuration changes.
 
 ### Reducing Conan cache size

--- a/cmake-proxies/cmake-modules/Package.cmake
+++ b/cmake-proxies/cmake-modules/Package.cmake
@@ -46,6 +46,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
       # Enable updates. See https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
       set(CPACK_AUDACITY_APPIMAGE_UPDATE_INFO "gh-releases-zsync|audacity|audacity|latest|${zsync_name}.AppImage.zsync")
    endif()
+   get_property(CPACK_AUDACITY_FINDLIB_LOCATION TARGET findlib PROPERTY RUNTIME_OUTPUT_DIRECTORY)
 elseif( CMAKE_SYSTEM_NAME STREQUAL "Darwin" )
    set( CPACK_GENERATOR DragNDrop )
 

--- a/libraries/lib-ffmpeg-support/FFmpegFunctions.cpp
+++ b/libraries/lib-ffmpeg-support/FFmpegFunctions.cpp
@@ -172,10 +172,7 @@ struct FFmpegFunctions::Private final
       AVFormatLibrary = LoadLibrary(path);
 
       if (AVFormatLibrary == nullptr)
-      {
-         wxLogSysError("Failed to load %s", path.c_str());
          return false;
-      }
 
       if ((AVCodecLibrary = LibraryWithSymbol("avcodec_version")) == nullptr)
          return false;
@@ -241,6 +238,14 @@ struct FFmpegFunctions::Private final
       if (library->IsLoaded())
          return library;
 
+      // Loading has failed.
+      // wxLogSysError doesn't report errors correctly on *NIX
+#if defined(_WIN32)
+      wxLogSysError("Failed to load %s", libraryName.c_str());
+#else
+      const char* errorString = dlerror();
+      wxLogError("Failed to load %s (%s)", libraryName.c_str(), errorString);
+#endif
       return {};
    }
 };

--- a/linux/AppRun.sh
+++ b/linux/AppRun.sh
@@ -7,7 +7,19 @@ if [[ ! "${APPIMAGE}" || ! "${APPDIR}" ]]; then
     export APPDIR="$(dirname "${APPIMAGE}")"
 fi
 
-export LD_LIBRARY_PATH="${APPDIR}/lib:${LD_LIBRARY_PATH}"
+# Check system libraries and load a fallback if necessary
+fallback_libs="" # start empty
+for fb_dir in "${APPDIR}/fallback"/*; do
+  if [[ -d "${fb_dir}" ]]; then
+    library="${fb_dir##*/}" # library named like directory
+    if ! "${APPDIR}/bin/findlib" "${library}" >&2; then
+      echo "${APPIMAGE}: Using fallback for library '${library}'" >&2
+      fallback_libs="${fallback_libs}:${fb_dir}" # append path
+    fi
+  fi
+done
+
+export LD_LIBRARY_PATH="${APPDIR}/lib:${LD_LIBRARY_PATH}${fallback_libs}"
 
 export AUDACITY_PATH="${AUDACITY_PATH}:${APPDIR}/share/audacity"
 export AUDACITY_MODULES_PATH="${AUDACITY_MODULES_PATH}:${APPDIR}/lib/modules"

--- a/linux/findlib.c
+++ b/linux/findlib.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+/* findlib.c
+* Dynamically load a shared object file and print its full path.
+* Part of library-utls - https://github.com/shoogle/library-utils
+* Copyright (c) 2020 Peter Jonas
+*/
+#define _GNU_SOURCE
+#include <link.h>
+#include <dlfcn.h>
+#include <libgen.h>
+#include <string.h>
+#include <stdio.h>
+
+char *help =
+"Usage: %s LIBRARY\n"
+"Print the full path to LIBRARY if it is dynamically loadable by this program.\n"
+"\n"
+"Exit status codes:\n"
+"  0 - Success!\n"
+"  1 - Failed to load LIBRARY (or one of its dependencies).\n"
+"  2 - Other error(s) occurred.\n"
+"\n"
+"LIBRARY will fail to load if any of the following are true:\n"
+"  - The file is corrupt.\n"
+"  - It is not found in any of the library search paths (see `man ld.so`).\n"
+"  - It was compiled for a different architecture to that of this program.\n"
+"  - It depends (via DT_NEEDED) on another library that fails to load.\n"
+"\n"
+"Hint: You can use the `file` command to show the processor architecture that\n"
+"any ELF library or executable (including this program) was compiled for.\n";
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, help, basename(argv[0]));
+        return 2;
+    }
+
+    if ((strcmp(argv[1], "-h") == 0) || (strcmp(argv[1], "--help") == 0)) {
+        printf(help, basename(argv[0]));
+        return 0;
+    }
+
+    // dlopen enables us to load shared objects during execution
+    void *lib = dlopen(argv[1], RTLD_LAZY);
+
+    if (lib == NULL) {
+        fprintf(stderr, "%s: %s\n", basename(argv[0]), dlerror());
+        return 1;
+    }
+
+    struct link_map * map;
+
+    // dlinfo can return information about objects loaded with dlopen
+    if (dlinfo(lib, RTLD_DI_LINKMAP, &map) == -1) {
+        fprintf(lib, "%s: %s\n", basename(argv[0]), dlerror());
+        return 2;
+    }
+
+    printf("%s\n", map->l_name);
+    return 0;
+}

--- a/linux/package_appimage.cmake
+++ b/linux/package_appimage.cmake
@@ -15,6 +15,7 @@ endif()
 configure_file("${CPACK_AUDACITY_SOURCE_DIR}/linux/AppRun.sh" "${appdir}/AppRun" ESCAPE_QUOTES @ONLY)
 configure_file("${CPACK_AUDACITY_SOURCE_DIR}/linux/check_dependencies.sh" "${appdir}/bin/check_dependencies" ESCAPE_QUOTES @ONLY)
 configure_file("${CPACK_AUDACITY_SOURCE_DIR}/linux/ldd_recursive.pl" "${appdir}/bin/ldd_recursive" COPYONLY)
+file(COPY "${CPACK_AUDACITY_FINDLIB_LOCATION}/findlib" DESTINATION "${appdir}/bin/")
 
 execute_process(
    COMMAND "linux/create_appimage.sh" "${appdir}" "${appimage}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1296,6 +1296,9 @@ else()
                           -P ${AUDACITY_MODULE_PATH}/CopyLibs.cmake
       POST_BUILD
    )
+   
+   add_executable(findlib ../linux/findlib.c)
+   target_link_libraries(findlib ${CMAKE_DL_LIBS})
 endif()
 
 if(CRASH_REPORT_URL)


### PR DESCRIPTION
Resolves: #1201 (FFmpeg failed to load because of `libcairo` being packaged)

Resolves a recent crash on Arch/Manjaro due to a conflict between bundled `gmodule`  and system `glib2`. 

The PR implements an approach, used by MuseScore, that allows defining a set of libraries that we prefer to be system.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
