### PR TITLE
Set the page_size for aup3 files using PRAGMA

### DIFF
--- a/cmake-proxies/sqlite/CMakeLists.txt
+++ b/cmake-proxies/sqlite/CMakeLists.txt
@@ -23,12 +23,6 @@ list( APPEND DEFINES
       # We need the dbpage table for space calculations.
       #
       SQLITE_ENABLE_DBPAGE_VTAB=1
-
-      # Can't be set after a WAL mode database is initialized, so change
-      # the default here to ensure all project files get the same page 
-      # size.
-      SQLITE_DEFAULT_PAGE_SIZE=65536
-
       #
       # Recommended in SQLite docs
       #

--- a/src/DBConnection.h
+++ b/src/DBConnection.h
@@ -58,7 +58,8 @@ public:
    ) const;
 
    int SafeMode(const char *schema = "main");
-   int FastMode(const char *schema = "main");
+   int FastMode(const char* schema = "main");
+   int SetPageSize(const char* schema = "main");
 
    bool Assign(sqlite3 *handle);
    sqlite3 *Detach();


### PR DESCRIPTION
This change ensures that page size will be 64k even if system SQLite3 was used (mostly relevant for Linux)

Resolves: #1459

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
