### PR TITLE
Remove the requirement for the SQLITE_ENABLE_DBPAGE_VTAB

### DIFF
--- a/cmake-proxies/sqlite/CMakeLists.txt
+++ b/cmake-proxies/sqlite/CMakeLists.txt
@@ -20,10 +20,6 @@ list( APPEND INCLUDES
 list( APPEND DEFINES
    PRIVATE
       #
-      # We need the dbpage table for space calculations.
-      #
-      SQLITE_ENABLE_DBPAGE_VTAB=1
-      #
       # Recommended in SQLite docs
       #
       SQLITE_DQS=0

--- a/src/DBConnection.h
+++ b/src/DBConnection.h
@@ -77,8 +77,8 @@ public:
       LoadSampleBlock,
       InsertSampleBlock,
       DeleteSampleBlock,
-      GetRootPage,
-      GetDBPage
+      GetSampleBlockSize,
+      GetAllSampleBlocksSize
    };
    sqlite3_stmt *Prepare(enum StatementID id, const char *sql);
 

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -33,6 +33,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "wxFileNameWrapper.h"
 #include "XMLFileReader.h"
 #include "SentryHelper.h"
+#include "MemoryX.h"`
 
 // Don't change this unless the file format changes
 // in an irrevocable way
@@ -2364,258 +2365,80 @@ int64_t ProjectFileIO::GetTotalUsage()
 }
 
 //
-// Returns the amount of disk space used by the specified sample blockid or all
-// of the sample blocks if the blockid is 0.  It does this by using the raw SQLite
-// pages available from the "sqlite_dbpage" virtual table to traverse the SQLite
-// table b-tree described here:  https://www.sqlite.org/fileformat.html
+// Returns the estimation of disk space used by the specified sample blockid or all
+// of the sample blocks if the blockid is 0. This does not include small overhead
+// of the internal SQLite structures, only the size used by the data
 //
 int64_t ProjectFileIO::GetDiskUsage(DBConnection &conn, SampleBlockID blockid /* = 0 */)
 {
-   // Information we need to track our travels through the b-tree
-   typedef struct
+   sqlite3_stmt* stmt = nullptr;
+
+   if (blockid == 0)
    {
-      int64_t pgno;
-      int currentCell;
-      int numCells;
-      unsigned char data[65536];
-   } page;
-   std::vector<page> stack;
+      static const char* statement =
+R"(SELECT 
+	sum(length(blockid) + length(sampleformat) + 
+	length(summin) + length(summax) + length(sumrms) + 
+	length(summary256) + length(summary64k) +
+	length(samples))
+FROM sampleblocks;)";
 
-   int64_t total = 0;
-   int64_t found = 0;
-   int64_t right = 0;
-   int rc;
-
-   // Get the rootpage for the sampleblocks table.
-   sqlite3_stmt *stmt =
-      conn.Prepare(DBConnection::GetRootPage,
-                    "SELECT rootpage FROM sqlite_master WHERE tbl_name = 'sampleblocks';");
-   if (stmt == nullptr || sqlite3_step(stmt) != SQLITE_ROW)
+      stmt = conn.Prepare(DBConnection::GetAllSampleBlocksSize, statement);
+   }
+   else
    {
-      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(sqlite3_errcode(conn.DB())));
-      ADD_EXCEPTION_CONTEXT("sqlite3.context", "ProjectGileIO::GetDiskUsage");
+      static const char* statement =
+R"(SELECT 
+	length(blockid) + length(sampleformat) + 
+	length(summin) + length(summax) + length(sumrms) + 
+	length(summary256) + length(summary64k) +
+	length(samples)
+FROM sampleblocks WHERE blockid = ?1;)";
 
-      return 0;
+      stmt = conn.Prepare(DBConnection::GetSampleBlockSize, statement);
    }
 
-   // And store it in our first stack frame
-   stack.push_back({sqlite3_column_int64(stmt, 0)});
+   auto cleanup = finally(
+      [stmt]() {
+         // Clear statement bindings and rewind statement
+         if (stmt != nullptr)
+         {
+            sqlite3_clear_bindings(stmt);
+            sqlite3_reset(stmt);
+         }
+      });
 
-   // All done with the statement
-   sqlite3_clear_bindings(stmt);
-   sqlite3_reset(stmt);
-
-   // Prepare/retrieve statement to read raw database page
-   stmt = conn.Prepare(DBConnection::GetDBPage,
-      "SELECT data FROM sqlite_dbpage WHERE pgno = ?1;");
-   if (stmt == nullptr)
+   if (blockid != 0)
    {
-      return 0;
-   }
+      int rc = sqlite3_bind_int64(stmt, 1, blockid);
 
-   // Traverse the b-tree until we've visited all of the leaf pages or until
-   // we find the one corresponding to the passed in sample blockid. Because we
-   // use an integer primary key for the sampleblocks table, the traversal will
-   // be in ascending blockid sequence.
-   do
-   {
-      // Acces the top stack frame
-      page &pg = stack.back();
-
-      // Read the page from the sqlite_dbpage table if it hasn't yet been loaded
-      if (pg.numCells == 0)
+      if (rc != SQLITE_OK)
       {
-         // Bind the page number
-         sqlite3_bind_int64(stmt, 1, pg.pgno);
+         ADD_EXCEPTION_CONTEXT(
+            "sqlite3.rc", std::to_string(rc));
 
-         // And retrieve the page
-         if (sqlite3_step(stmt) != SQLITE_ROW)
-         {
-            // REVIEW: Likely harmless failure - says size is zero on
-            // this error.
-            // LLL: Yea, but not much else we can do.
-            return 0;
-         }
+         ADD_EXCEPTION_CONTEXT(
+            "sqlite3.context", "ProjectFileIO::GetDiskUsage::bind");
 
-         // Copy the page content to the stack frame
-         memcpy(&pg.data,
-                sqlite3_column_blob(stmt, 0),
-                sqlite3_column_bytes(stmt, 0));
-
-         // And retrieve the total number of cells within it
-         pg.numCells = get2(&pg.data[3]);
-
-         // Reset statement for next usage
-         sqlite3_clear_bindings(stmt);
-         sqlite3_reset(stmt);
-      }
-
-      //wxLogDebug("%*.*spgno %lld currentCell %d numCells %d", (stack.size() - 1) * 2, (stack.size() - 1) * 2, "", pg.pgno, pg.currentCell, pg.numCells);
-
-      // Process an interior table b-tree page
-      if (pg.data[0] == 0x05)
-      {
-         // Process the next cell if we haven't examined all of them yet
-         if (pg.currentCell < pg.numCells)
-         {
-            // Remember the right-most leaf page number.
-            right = get4(&pg.data[8]);
-
-            // Iterate over the cells.
-            //
-            // If we're not looking for a specific blockid, then we always push the
-            // target page onto the stack and leave the loop after a single iteration.
-            //
-            // Otherwise, we match the blockid against the highest integer key contained
-            // within the cell and if the blockid falls within the cell, we stack the
-            // page and stop the iteration.
-            //
-            // In theory, we could do a binary search for a specific blockid here, but
-            // because our sample blocks are always large, we will get very few cells
-            // per page...usually 6 or less.
-            //
-            // In both cases, the stacked page can be either an internal or leaf page.
-            bool stacked = false;
-            while (pg.currentCell < pg.numCells)
-            {
-               // Get the offset to this cell using the offset in the cell pointer
-               // array.
-               //
-               // The cell pointer array starts immediately after the page header
-               // at offset 12 and the retrieved offset is from the beginning of
-               // the page.
-               int celloff = get2(&pg.data[12 + (pg.currentCell * 2)]);
-
-               // Bump to the next cell for the next iteration.
-               pg.currentCell++;
-
-               // Get the page number this cell describes
-               int pagenum = get4(&pg.data[celloff]);
-
-               // And the highest integer key, which starts at offset 4 within the cell.
-               int64_t intkey = 0;
-               get_varint(&pg.data[celloff + 4], &intkey);
-
-               //wxLogDebug("%*.*sinternal - right %lld celloff %d pagenum %d intkey %lld", (stack.size() - 1) * 2, (stack.size() - 1) * 2, " ", right, celloff, pagenum, intkey);
-
-               // Stack the described page if we're not looking for a specific blockid
-               // or if this page contains the given blockid.
-               if (!blockid || blockid <= intkey)
-               {
-                  stack.push_back({pagenum, 0, 0});
-                  stacked = true;
-                  break;
-               }
-            }
-
-            // If we pushed a new page onto the stack, we need to jump back up
-            // to read the page
-            if (stacked)
-            {
-               continue;
-            }
-         }
-
-         // We've exhausted all the cells with this page, so we stack the right-most
-         // leaf page.  Ensure we only process it once.
-         if (right)
-         {
-            stack.push_back({right, 0, 0});
-            right = 0;
-            continue;
-         }
-      }
-      // Process a leaf table b-tree page
-      else if (pg.data[0] == 0x0d)
-      {
-         // Iterate over the cells
-         //
-         // If we're not looking for a specific blockid, then just accumulate the
-         // payload sizes. We will be reading every leaf page in the sampleblocks
-         // table.
-         //
-         // Otherwise we break out when we find the matching blockid. In this case,
-         // we only ever look at 1 leaf page.
-         bool stop = false;
-         for (int i = 0; i < pg.numCells; i++)
-         {
-            // Get the offset to this cell using the offset in the cell pointer
-            // array.
-            //
-            // The cell pointer array starts immediately after the page header
-            // at offset 8 and the retrieved offset is from the beginning of
-            // the page.
-            int celloff = get2(&pg.data[8 + (i * 2)]);
-
-            // Get the total payload size in bytes of the described row.
-            int64_t payload = 0;
-            int digits = get_varint(&pg.data[celloff], &payload);
-
-            // Get the integer key for this row.
-            int64_t intkey = 0;
-            get_varint(&pg.data[celloff + digits], &intkey);
-
-            //wxLogDebug("%*.*sleaf - celloff %4d intkey %lld payload %lld", (stack.size() - 1) * 2, (stack.size() - 1) * 2, " ", celloff, intkey, payload);
-
-            // Add this payload size to the total if we're not looking for a specific
-            // blockid
-            if (!blockid)
-            {
-               total += payload;
-            }
-            // Otherwise, return the payload size for a matching row
-            else if (blockid == intkey)
-            {
-               return payload;
-            }
-         }
-      }
-
-      // Done with the current branch, so pop back up to the previous one (if any)
-      stack.pop_back();
-   } while (!stack.empty());
-
-   // Return the total used for all sample blocks
-   return total;
-}
-
-// Retrieves a 2-byte big-endian integer from the page data
-unsigned int ProjectFileIO::get2(const unsigned char *ptr)
-{
-   return (ptr[0] << 8) | ptr[1];
-}
-
-// Retrieves a 4-byte big-endian integer from the page data
-unsigned int ProjectFileIO::get4(const unsigned char *ptr)
-{
-   return ((unsigned int) ptr[0] << 24) |
-          ((unsigned int) ptr[1] << 16) |
-          ((unsigned int) ptr[2] << 8)  |
-          ((unsigned int) ptr[3]);
-}
-
-// Retrieves a variable length integer from the page data. Returns the
-// number of digits used to encode the integer and the stores the
-// value at the given location.
-int ProjectFileIO::get_varint(const unsigned char *ptr, int64_t *out)
-{
-   int64_t val = 0;
-   int i;
-
-   for (i = 0; i < 8; ++i)
-   {
-      val = (val << 7) + (ptr[i] & 0x7f);
-      if ((ptr[i] & 0x80) == 0)
-      {
-         *out = val;
-         return i + 1;
+         conn.ThrowException(false);
       }
    }
 
-   val = (val << 8) + (ptr[i] & 0xff);
-   *out = val;
+   int rc = sqlite3_step(stmt);
 
-   return 9;
+   if (rc != SQLITE_ROW)
+   {
+      ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));
+
+      ADD_EXCEPTION_CONTEXT(
+         "sqlite3.context", "ProjectFileIO::GetDiskUsage::step");
+
+      conn.ThrowException(false);
+   }
+
+   const int64_t size = sqlite3_column_int64(stmt, 0);
+
+   return size;
 }
 
 InvisibleTemporaryProject::InvisibleTemporaryProject()


### PR DESCRIPTION
Resolves: #1460

This PR introduces a different approach to estimating the SampleBlock size on disk. It does not account for the SQLite3 internal structures size so well, but the difference is relatively negligible. 

We use this estimation to decide if we need to compact the database on disk, as we do not allow database vacuuming (for performance reasons?). The performance of the heuristic can be further improved, as `used_blocks`/`total_blocks` should work just fine. However, this would require more changes to the code.

`ProjectFileIO::GetTotalUsage()` and `ProjectFileIO::GetCurrentUsage()` are also used in now disabled compaction dialog. However using `GetTotalUsage()` was probably not the idea anyway (because it never accounted for the project and autosave tables). `GetCurrentUsage()` still gives a very good estimate of how much disk space is used.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
