### PR TITLE
Fixes an issue when the FFmpeg packet was consumed, but no output was produced

### DIFF
--- a/libraries/lib-ffmpeg-support/wrappers/AVCodecContextWrapper.cpp
+++ b/libraries/lib-ffmpeg-support/wrappers/AVCodecContextWrapper.cpp
@@ -102,13 +102,18 @@ AVCodecContextWrapper::DecodeAudioPacket(const AVPacketWrapper* packet)
             return data; // Packet decoding has failed
 
          if (gotFrame == 0)
+         {
             /*
              "Note that this field being set to zero does not mean that an
              error has occurred. For decoders with AV_CODEC_CAP_DELAY set, no
              given decode call is guaranteed to produce a frame."
              */
             // (Let's assume this doesn't happen when flushing)
+            // Still, the data was consumed by the decoder, so we need to
+            // offset the packet
+            packetCopy->OffsetPacket(bytesDecoded);
             continue;
+         }
 
          const auto sampleSize =
             static_cast<size_t>(mFFmpeg.av_get_bytes_per_sample(


### PR DESCRIPTION
Resolves: #1811

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
