### PR TITLE
Change default spectrogram settings

### DIFF
--- a/src/Experimental.cmake
+++ b/src/Experimental.cmake
@@ -182,11 +182,6 @@ set( EXPERIMENTAL_OPTIONS_LIST
    #This flag is used only in CrashReport.h; elsewhere use HAS_CRASH_REPORT
    CRASH_REPORT
 
-   # Paul Licameli (PRL) 31 May 2015
-   # Zero-padding factor for spectrograms can smooth the display of spectrograms by
-   # interpolating in frequency domain.
-   ZERO_PADDED_SPECTROGRAMS
-
    # PRL 11 Jul 2017
    # Highlight more things in TrackPanel when the mouse moves over them,
    # using delibrately ugly pens and brushes until there is better cooperation

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -821,11 +821,7 @@ void SpecCache::Populate
       settings.algorithm == SpectrogramSettings::algPitchEAC;
    const bool reassignment =
       settings.algorithm == SpectrogramSettings::algReassignment;
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    const size_t zeroPaddingFactorSetting = settings.ZeroPaddingFactor();
-#else
-   const size_t zeroPaddingFactorSetting = 1;
-#endif
 
    // FFT length may be longer than the window of samples that affect results
    // because of zero padding done for increased frequency resolution

--- a/src/prefs/SpectrogramSettings.cpp
+++ b/src/prefs/SpectrogramSettings.cpp
@@ -28,6 +28,55 @@ Paul Licameli
 
 #include "../widgets/AudacityMessageBox.h"
 
+IntSetting SpectrumMaxFreq{
+   L"/Spectrum/MaxFreq", 8000 };
+
+namespace {
+// Other settings not yet used outside of this file
+
+// To do: migrate these to ChoiceSetting preferences, which will store an
+// Identifier instead of a number in the preference file.
+IntSetting SpectrumAlgorithm{
+   L"/Spectrum/Algorithm", 0 }; // Default to Frequencies
+IntSetting SpectrumScale{
+   L"/Spectrum/ScaleType", 0 }; // Default to Linear
+IntSetting SpectrumWindowFunction{
+   L"/Spectrum/WindowType", eWinFuncHann };
+
+BoolSetting SpectrumEnableSelection{
+   L"/Spectrum/EnableSpectralSelection", true };
+IntSetting SpectrumFFTSize{
+   L"/Spectrum/FFTSize", 1024 };
+IntSetting SpectrumFrequencyGain{
+   L"/Spectrum/FrequencyGain", 0 };
+IntSetting SpectrumGain{
+   L"/Spectrum/Gain", 20 };
+BoolSetting SpectrumGrayscale{
+   L"/Spectrum/Grayscale", false };
+IntSetting SpectrumMinFreq{
+   L"/Spectrum/MinFreq", 0 };
+IntSetting SpectrumRange{
+   L"/Spectrum/Range", 80 };
+IntSetting SpectrumZeroPaddingFactor{
+   L"/Spectrum/ZeroPaddingFactor", 1 };
+
+#ifdef EXPERIMENTAL_FIND_NOTES
+BoolSetting SpectrumFindNotes{
+   L"/Spectrum/FFTFindNotes", false };
+DoubleSetting SpectrumFindNotesMinA{
+   L"/Spectrum/FindNotesMinA", -30.0 };
+IntSetting SpectrumFindNotesN{
+   L"/Spectrum/FindNotesN", 5 };
+BoolSetting SpectrumFindNotesQuantize{
+   L"/Spectrum/FindNotesQuantize", false };
+#endif //EXPERIMENTAL_FIND_NOTES
+
+#ifdef EXPERIMENTAL_FFT_Y_GRID
+BoolSetting SpectrumYGrid{
+   L"/Spectrum/FFTYGrid", false};
+#endif
+}
+
 SpectrogramSettings::Globals::Globals()
 {
    LoadPrefs();
@@ -36,15 +85,14 @@ SpectrogramSettings::Globals::Globals()
 void SpectrogramSettings::Globals::SavePrefs()
 {
 #ifdef SPECTRAL_SELECTION_GLOBAL_SWITCH
-   gPrefs->Write(wxT("/Spectrum/EnableSpectralSelection"), spectralSelection);
+   SpectrumEnableSelection.Write(spectralSelection);
 #endif
 }
 
 void SpectrogramSettings::Globals::LoadPrefs()
 {
 #ifdef SPECTRAL_SELECTION_GLOBAL_SWITCH
-   spectralSelection
-      = (gPrefs->Read(wxT("/Spectrum/EnableSpectralSelection"), 1L) != 0);
+   spectralSelection = SpectrumEnableSelection.Read();
 #endif
 }
 
@@ -176,7 +224,7 @@ const EnumValueSymbols &SpectrogramSettings::GetColorSchemeNames()
 void SpectrogramSettings::ColorSchemeEnumSetting::Migrate(wxString &value)
 {
    // Migrate old grayscale option to Color scheme choice
-   bool isGrayscale = (gPrefs->Read(wxT("/Spectrum/Grayscale"), 0L) != 0);
+   bool isGrayscale = SpectrumGrayscale.Read();
    if (isGrayscale && !gPrefs->Read(wxT("/Spectrum/ColorScheme"), &value)) {
       value = GetColorSchemeNames().at(csGrayscale).Internal();
       Write(value);
@@ -279,39 +327,39 @@ bool SpectrogramSettings::Validate(bool quiet)
 
 void SpectrogramSettings::LoadPrefs()
 {
-   minFreq = gPrefs->Read(wxT("/Spectrum/MinFreq"), 0L);
+   minFreq = SpectrumMinFreq.Read();
 
-   maxFreq = gPrefs->Read(wxT("/Spectrum/MaxFreq"), 8000L);
+   maxFreq = SpectrumMaxFreq.Read();
 
-   range = gPrefs->Read(wxT("/Spectrum/Range"), 80L);
-   gain = gPrefs->Read(wxT("/Spectrum/Gain"), 20L);
-   frequencyGain = gPrefs->Read(wxT("/Spectrum/FrequencyGain"), 0L);
+   range = SpectrumRange.Read();
+   gain = SpectrumGain.Read();
+   frequencyGain = SpectrumFrequencyGain.Read();
 
-   windowSize = gPrefs->Read(wxT("/Spectrum/FFTSize"), 1024);
+   windowSize = SpectrumFFTSize.Read();
 
-   zeroPaddingFactor = gPrefs->Read(wxT("/Spectrum/ZeroPaddingFactor"), 1);
+   zeroPaddingFactor = SpectrumZeroPaddingFactor.Read();
 
-   gPrefs->Read(wxT("/Spectrum/WindowType"), &windowType, eWinFuncHann);
+   windowType = SpectrumWindowFunction.Read();
 
    colorScheme = colorSchemeSetting.ReadEnum();
 
-   scaleType = ScaleType(gPrefs->Read(wxT("/Spectrum/ScaleType"), 0L));
+   scaleType = static_cast<ScaleType>(SpectrumScale.Read());
 
 #ifndef SPECTRAL_SELECTION_GLOBAL_SWITCH
-   spectralSelection = (gPrefs->Read(wxT("/Spectrum/EnableSpectralSelection"), 1L) != 0);
+   spectralSelection = SpectrumEnableSelection.Read();
 #endif
 
-   algorithm = Algorithm(gPrefs->Read(wxT("/Spectrum/Algorithm"), 0L));
+   algorithm = static_cast<Algorithm>(SpectrumAlgorithm.Read());
 
 #ifdef EXPERIMENTAL_FFT_Y_GRID
-   fftYGrid = (gPrefs->Read(wxT("/Spectrum/FFTYGrid"), 0L) != 0);
+   fftYGrid = SpectrumYGrid.Read();
 #endif //EXPERIMENTAL_FFT_Y_GRID
 
 #ifdef EXPERIMENTAL_FIND_NOTES
-   fftFindNotes = (gPrefs->Read(wxT("/Spectrum/FFTFindNotes"), 0L) != 0);
-   findNotesMinA = gPrefs->Read(wxT("/Spectrum/FindNotesMinA"), -30.0);
-   numberOfMaxima = gPrefs->Read(wxT("/Spectrum/FindNotesN"), 5L);
-   findNotesQuantize = (gPrefs->Read(wxT("/Spectrum/FindNotesQuantize"), 0L) != 0);
+   fftFindNotes = SpectrumFindNotes.Read();
+   findNotesMinA = SpectrumFindNotesMinA.Read();
+   numberOfMaxima = SpectrumFindNotesN.Read();
+   findNotesQuantize = SpectrumFindNotesQuantize.Read();
 #endif //EXPERIMENTAL_FIND_NOTES
 
    // Enforce legal values
@@ -322,132 +370,104 @@ void SpectrogramSettings::LoadPrefs()
 
 void SpectrogramSettings::SavePrefs()
 {
-   gPrefs->Write(wxT("/Spectrum/MinFreq"), minFreq);
-   gPrefs->Write(wxT("/Spectrum/MaxFreq"), maxFreq);
+   SpectrumMinFreq.Write(minFreq);
+   SpectrumMaxFreq.Write(maxFreq);
 
    // Nothing wrote these.  They only varied from the linear scale bounds in-session. -- PRL
    // gPrefs->Write(wxT("/SpectrumLog/MaxFreq"), logMinFreq);
    // gPrefs->Write(wxT("/SpectrumLog/MinFreq"), logMaxFreq);
 
-   gPrefs->Write(wxT("/Spectrum/Range"), range);
-   gPrefs->Write(wxT("/Spectrum/Gain"), gain);
-   gPrefs->Write(wxT("/Spectrum/FrequencyGain"), frequencyGain);
+   SpectrumRange.Write(range);
+   SpectrumGain.Write(gain);
+   SpectrumFrequencyGain.Write(frequencyGain);
 
-   gPrefs->Write(wxT("/Spectrum/FFTSize"), windowSize);
+   SpectrumFFTSize.Write(windowSize);
 
-   gPrefs->Write(wxT("/Spectrum/ZeroPaddingFactor"), zeroPaddingFactor);
+   SpectrumZeroPaddingFactor.Write(zeroPaddingFactor);
 
-   gPrefs->Write(wxT("/Spectrum/WindowType"), windowType);
+   SpectrumWindowFunction.Write(windowType);
 
    colorSchemeSetting.WriteEnum(colorScheme);
 
-   gPrefs->Write(wxT("/Spectrum/ScaleType"), (int) scaleType);
+   SpectrumScale.Write(static_cast<int>(scaleType));
 
 #ifndef SPECTRAL_SELECTION_GLOBAL_SWITCH
-   gPrefs->Write(wxT("/Spectrum/EnableSpectralSelection"), spectralSelection);
+   SpectrumEnableSelection.Write(spectralSelection);
 #endif
 
-   gPrefs->Write(wxT("/Spectrum/Algorithm"), (int) algorithm);
+   SpectrumAlgorithm.Write(static_cast<int>(algorithm));
 
 #ifdef EXPERIMENTAL_FFT_Y_GRID
-   gPrefs->Write(wxT("/Spectrum/FFTYGrid"), fftYGrid);
+   SpectrumYGrid.Write(fftYGrid);
 #endif //EXPERIMENTAL_FFT_Y_GRID
 
 #ifdef EXPERIMENTAL_FIND_NOTES
-   gPrefs->Write(wxT("/Spectrum/FFTFindNotes"), fftFindNotes);
-   gPrefs->Write(wxT("/Spectrum/FindNotesMinA"), findNotesMinA);
-   gPrefs->Write(wxT("/Spectrum/FindNotesN"), numberOfMaxima);
-   gPrefs->Write(wxT("/Spectrum/FindNotesQuantize"), findNotesQuantize);
+   SpectrumFindNotes.Write(fftFindNotes);
+   SpectrumFindNotesMinA.Write(findNotesMinA);
+   SpectrumFindNotesN.Write(numberOfMaxima);
+   SpectrumFindNotesQuantize.Write(findNotesQuantize);
 #endif //EXPERIMENTAL_FIND_NOTES
 }
 
 // This is a temporary hack until SpectrogramSettings gets fully integrated
 void SpectrogramSettings::UpdatePrefs()
 {
-   if (minFreq == defaults().minFreq) {
-      gPrefs->Read(wxT("/Spectrum/MinFreq"), &minFreq, 0L);
-   }
+   if (minFreq == defaults().minFreq)
+      minFreq = SpectrumMinFreq.Read();
 
-   if (maxFreq == defaults().maxFreq) {
-      gPrefs->Read(wxT("/Spectrum/MaxFreq"), &maxFreq, 8000L);
-   }
+   if (maxFreq == defaults().maxFreq)
+      maxFreq = SpectrumMaxFreq.Read();
 
-   if (range == defaults().range) {
-      gPrefs->Read(wxT("/Spectrum/Range"), &range, 80L);
-   }
+   if (range == defaults().range)
+      range = SpectrumRange.Read();
 
-   if (gain == defaults().gain) {
-      gPrefs->Read(wxT("/Spectrum/Gain"), &gain, 20L);
-   }
+   if (gain == defaults().gain)
+      gain = SpectrumGain.Read();
 
-   if (frequencyGain == defaults().frequencyGain) {
-      gPrefs->Read(wxT("/Spectrum/FrequencyGain"), &frequencyGain, 0L);
-   }
+   if (frequencyGain == defaults().frequencyGain)
+      frequencyGain = SpectrumFrequencyGain.Read();
 
-   if (windowSize == defaults().windowSize) {
-      gPrefs->Read(wxT("/Spectrum/FFTSize"), &windowSize, 1024);
-   }
+   if (windowSize == defaults().windowSize)
+      windowSize = SpectrumFFTSize.Read();
 
-   if (zeroPaddingFactor == defaults().zeroPaddingFactor) {
-      gPrefs->Read(wxT("/Spectrum/ZeroPaddingFactor"), &zeroPaddingFactor, 1);
-   }
+   if (zeroPaddingFactor == defaults().zeroPaddingFactor)
+      zeroPaddingFactor = SpectrumZeroPaddingFactor.Read();
 
-   if (windowType == defaults().windowType) {
-      gPrefs->Read(wxT("/Spectrum/WindowType"), &windowType, eWinFuncHann);
-   }
+   if (windowType == defaults().windowType)
+      windowType = SpectrumWindowFunction.Read();
 
    if (colorScheme == defaults().colorScheme) {
       colorScheme = colorSchemeSetting.ReadEnum();
    }
 
-   if (scaleType == defaults().scaleType) {
-      int temp;
-      gPrefs->Read(wxT("/Spectrum/ScaleType"), &temp, 0L);
-      scaleType = ScaleType(temp);
-   }
+   if (scaleType == defaults().scaleType)
+      scaleType = static_cast<ScaleType>(SpectrumScale.Read());
 
 #ifndef SPECTRAL_SELECTION_GLOBAL_SWITCH
-   if (spectralSelection == defaults().spectralSelection) {
-      int temp;
-      gPrefs->Read(wxT("/Spectrum/EnableSpectralSelection"), &temp, 1L);
-      spectralSelection = (temp != 0);
-   }
+   if (spectralSelection == defaults().spectralSelection)
+      spectralSelection = SpectrumEnableSelection.Read();
 #endif
 
-   if (algorithm == defaults().algorithm) {
-      int temp;
-      gPrefs->Read(wxT("/Spectrum/Algorithm"), &temp, 0L);
-      algorithm = Algorithm(temp);
-   }
+   if (algorithm == defaults().algorithm)
+      algorithm = static_cast<Algorithm>(SpectrumAlgorithm.Read());
 
 #ifdef EXPERIMENTAL_FFT_Y_GRID
-   if (fftYGrid == defaults().fftYGrid) {
-      int temp;
-      gPrefs->Read(wxT("/Spectrum/FFTYGrid"), &temp, 0L);
-      fftYGrid = (temp != 0);
-   }
+   if (fftYGrid == defaults().fftYGrid)
+      fftYGrid = SpectrumYGrid.Read();
 #endif //EXPERIMENTAL_FFT_Y_GRID
 
 #ifdef EXPERIMENTAL_FIND_NOTES
-   if (fftFindNotes == defaults().fftFindNotes) {
-      int temp;
-      gPrefs->Read(wxT("/Spectrum/FFTFindNotes"), &temp, 0L);
-      fftFindNotes = (temp != 0);
-   }
+   if (fftFindNotes == defaults().fftFindNotes)
+      fftFindNotes = SpectrumFindNotes.Read();
 
-   if (findNotesMinA == defaults().findNotesMinA) {
-      gPrefs->Read(wxT("/Spectrum/FindNotesMinA"), &findNotesMinA, -30.0);
-   }
+   if (findNotesMinA == defaults().findNotesMinA)
+      findNotesMinA = SpectrumFindNotesMinA.Read();
 
-   if (numberOfMaxima == defaults().numberOfMaxima) {
-      numberOfMaxima = gPrefs->Read(wxT("/Spectrum/FindNotesN"), &numberOfMaxima, 5L);
-   }
+   if (numberOfMaxima == defaults().numberOfMaxima)
+      numberOfMaxima = SpectrumFindNotesN.Read();
 
-   if (findNotesQuantize == defaults().findNotesQuantize) {
-      int temp;
-      gPrefs->Read(wxT("/Spectrum/FindNotesQuantize"), &temp, 0L);
-      findNotesQuantize = (temp != 0);
-   }
+   if (findNotesQuantize == defaults().findNotesQuantize)
+      findNotesQuantize = SpectrumFindNotesQuantize.Read();
 #endif //EXPERIMENTAL_FIND_NOTES
 
    // Enforce legal values

--- a/src/prefs/SpectrogramSettings.cpp
+++ b/src/prefs/SpectrogramSettings.cpp
@@ -29,7 +29,7 @@ Paul Licameli
 #include "../widgets/AudacityMessageBox.h"
 
 IntSetting SpectrumMaxFreq{
-   L"/Spectrum/MaxFreq", 8000 };
+   L"/Spectrum/MaxFreq", 20000 };
 
 namespace {
 // Other settings not yet used outside of this file
@@ -39,14 +39,14 @@ namespace {
 IntSetting SpectrumAlgorithm{
    L"/Spectrum/Algorithm", 0 }; // Default to Frequencies
 IntSetting SpectrumScale{
-   L"/Spectrum/ScaleType", 0 }; // Default to Linear
+   L"/Spectrum/ScaleType", 2 }; // Default to Mel
 IntSetting SpectrumWindowFunction{
    L"/Spectrum/WindowType", eWinFuncHann };
 
 BoolSetting SpectrumEnableSelection{
    L"/Spectrum/EnableSpectralSelection", true };
 IntSetting SpectrumFFTSize{
-   L"/Spectrum/FFTSize", 1024 };
+   L"/Spectrum/FFTSize", 2048 };
 IntSetting SpectrumFrequencyGain{
    L"/Spectrum/FrequencyGain", 0 };
 IntSetting SpectrumGain{
@@ -58,7 +58,7 @@ IntSetting SpectrumMinFreq{
 IntSetting SpectrumRange{
    L"/Spectrum/Range", 80 };
 IntSetting SpectrumZeroPaddingFactor{
-   L"/Spectrum/ZeroPaddingFactor", 1 };
+   L"/Spectrum/ZeroPaddingFactor", 2 };
 
 #ifdef EXPERIMENTAL_FIND_NOTES
 BoolSetting SpectrumFindNotes{

--- a/src/prefs/SpectrogramSettings.cpp
+++ b/src/prefs/SpectrogramSettings.cpp
@@ -68,9 +68,7 @@ SpectrogramSettings::SpectrogramSettings(const SpectrogramSettings &other)
    , frequencyGain(other.frequencyGain)
    , windowType(other.windowType)
    , windowSize(other.windowSize)
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    , zeroPaddingFactor(other.zeroPaddingFactor)
-#endif
    , colorScheme(other.colorScheme)
    , scaleType(other.scaleType)
 #ifndef SPECTRAL_SELECTION_GLOBAL_SWITCH
@@ -105,9 +103,7 @@ SpectrogramSettings &SpectrogramSettings::operator= (const SpectrogramSettings &
       frequencyGain = other.frequencyGain;
       windowType = other.windowType;
       windowSize = other.windowSize;
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
       zeroPaddingFactor = other.zeroPaddingFactor;
-#endif
       colorScheme = other.colorScheme;
       scaleType = other.scaleType;
 #ifndef SPECTRAL_SELECTION_GLOBAL_SWITCH
@@ -293,9 +289,7 @@ void SpectrogramSettings::LoadPrefs()
 
    windowSize = gPrefs->Read(wxT("/Spectrum/FFTSize"), 1024);
 
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    zeroPaddingFactor = gPrefs->Read(wxT("/Spectrum/ZeroPaddingFactor"), 1);
-#endif
 
    gPrefs->Read(wxT("/Spectrum/WindowType"), &windowType, eWinFuncHann);
 
@@ -341,9 +335,7 @@ void SpectrogramSettings::SavePrefs()
 
    gPrefs->Write(wxT("/Spectrum/FFTSize"), windowSize);
 
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    gPrefs->Write(wxT("/Spectrum/ZeroPaddingFactor"), zeroPaddingFactor);
-#endif
 
    gPrefs->Write(wxT("/Spectrum/WindowType"), windowType);
 
@@ -396,11 +388,9 @@ void SpectrogramSettings::UpdatePrefs()
       gPrefs->Read(wxT("/Spectrum/FFTSize"), &windowSize, 1024);
    }
 
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    if (zeroPaddingFactor == defaults().zeroPaddingFactor) {
       gPrefs->Read(wxT("/Spectrum/ZeroPaddingFactor"), &zeroPaddingFactor, 1);
    }
-#endif
 
    if (windowType == defaults().windowType) {
       gPrefs->Read(wxT("/Spectrum/WindowType"), &windowType, eWinFuncHann);
@@ -568,7 +558,6 @@ void SpectrogramSettings::ConvertToEnumeratedWindowSizes()
       size >>= 1, ++logarithm;
    windowSize = std::max(0, std::min(NumWindowSizes - 1, logarithm));
 
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    // Choices for zero padding begin at 1
    logarithm = 0;
    size = unsigned(zeroPaddingFactor);
@@ -578,15 +567,12 @@ void SpectrogramSettings::ConvertToEnumeratedWindowSizes()
       std::min(LogMaxWindowSize - (windowSize + LogMinWindowSize),
          logarithm
    ));
-#endif
 }
 
 void SpectrogramSettings::ConvertToActualWindowSizes()
 {
    windowSize = 1 << (windowSize + LogMinWindowSize);
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    zeroPaddingFactor = 1 << zeroPaddingFactor;
-#endif
 }
 
 float SpectrogramSettings::findBin( float frequency, float binUnit ) const
@@ -600,11 +586,11 @@ float SpectrogramSettings::findBin( float frequency, float binUnit ) const
 
 size_t SpectrogramSettings::GetFFTLength() const
 {
-#ifndef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
-   return windowSize;
-#else
+//#ifndef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
+  // return windowSize;
+//#else
    return windowSize * ((algorithm != algPitchEAC) ? zeroPaddingFactor : 1);
-#endif
+//#endif
 }
 
 size_t SpectrogramSettings::NBins() const

--- a/src/prefs/SpectrogramSettings.h
+++ b/src/prefs/SpectrogramSettings.h
@@ -117,14 +117,12 @@ private:
 public:
    size_t WindowSize() const { return windowSize; }
 
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
 private:
    int zeroPaddingFactor;
 public:
    size_t ZeroPaddingFactor() const {
       return algorithm == algPitchEAC ? 1 : zeroPaddingFactor;
    }
-#endif
 
    size_t GetFFTLength() const; // window size (times zero padding, if STFT)
    size_t NBins() const;

--- a/src/prefs/SpectrogramSettings.h
+++ b/src/prefs/SpectrogramSettings.h
@@ -181,4 +181,7 @@ public:
    mutable Floats         tWindow; // Window times time parameter
    mutable Floats         dWindow; // Derivative of window
 };
+
+extern AUDACITY_DLL_API IntSetting SpectrumMaxFreq;
+
 #endif

--- a/src/prefs/SpectrumPrefs.cpp
+++ b/src/prefs/SpectrumPrefs.cpp
@@ -91,7 +91,6 @@ ManualPageID SpectrumPrefs::HelpPageName()
 
 enum {
    ID_WINDOW_SIZE = 10001,
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    ID_WINDOW_TYPE,
    ID_PADDING_SIZE,
    ID_SCALE,
@@ -103,7 +102,6 @@ enum {
    ID_FREQUENCY_GAIN,
    ID_COLOR_SCHEME,
    ID_SPECTRAL_SELECTION,
-#endif
    ID_DEFAULTS,
 };
 
@@ -124,7 +122,6 @@ void SpectrumPrefs::Populate(size_t windowSize)
 
 void SpectrumPrefs::PopulatePaddingChoices(size_t windowSize)
 {
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    mZeroPaddingChoice = 1;
 
    // The choice of window size restricts the choice of padding.
@@ -159,7 +156,6 @@ void SpectrumPrefs::PopulatePaddingChoices(size_t windowSize)
 
    if (pPaddingSizeControl)
       pPaddingSizeControl->SetSelection(mZeroPaddingChoice);
-#endif
 }
 
 void SpectrumPrefs::PopulateOrExchange(ShuttleGui & S)
@@ -267,12 +263,10 @@ void SpectrumPrefs::PopulateOrExchange(ShuttleGui & S)
             mTempSettings.windowType,
             mTypeChoices);
 
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
          mZeroPaddingChoiceCtrl =
             S.Id(ID_PADDING_SIZE).TieChoice(XXO("&Zero padding factor:"),
             mTempSettings.zeroPaddingFactor,
             mZeroPaddingChoices);
-#endif
       }
       S.EndMultiColumn();
    }
@@ -567,9 +561,7 @@ void SpectrumPrefs::EnableDisableSTFTOnlyControls()
    mGain->Enable(STFT);
    mRange->Enable(STFT);
    mFrequencyGain->Enable(STFT);
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
    mZeroPaddingChoiceCtrl->Enable(STFT);
-#endif
 }
 
 BEGIN_EVENT_TABLE(SpectrumPrefs, PrefsPanel)

--- a/src/prefs/SpectrumPrefs.h
+++ b/src/prefs/SpectrumPrefs.h
@@ -78,11 +78,12 @@ class SpectrumPrefs final : public PrefsPanel
    wxTextCtrl *mRange;
    wxTextCtrl *mFrequencyGain;
 
-#ifdef EXPERIMENTAL_ZERO_PADDED_SPECTROGRAMS
+   /*
+    Zero-padding factor for spectrograms can smooth the display of
+    spectrograms by interpolating in frequency domain. */
    int mZeroPaddingChoice;
    wxChoice *mZeroPaddingChoiceCtrl;
    TranslatableStrings mZeroPaddingChoices;
-#endif
 
    TranslatableStrings mTypeChoices;
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
@@ -145,7 +145,7 @@ void SpectrumVZoomHandle::DoZoom(
       scale = (specSettings.GetScale(min, max));
       const auto fftLength = specSettings.GetFFTLength();
       const float binSize = rate / fftLength;
-      maxFreq = gPrefs->Read(wxT("/Spectrum/MaxFreq"), 8000L);
+      maxFreq = SpectrumMaxFreq.Read();
       // JKC:  Following discussions of Bug 1208 I'm allowing zooming in
       // down to one bin.
       //      const int minBins =


### PR DESCRIPTION
Resolves: #1825

Change default settings for scale type to Mel, top of scale to 20000 Hz, window size to 1024, and zero padding to 2.

Also cleaning up a lot of preference usage in Spectrogram settings to avoid repetition of literals for paths and defaults.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
