### PR TITLE
Fix inaccurate rhythmtrack.ny

### DIFF
--- a/plug-ins/rhythmtrack.ny
+++ b/plug-ins/rhythmtrack.ny
@@ -183,18 +183,7 @@ $control low (_ "MIDI pitch of weak beat") int (_ "18 - 116") 80 18 116
   (* val (/ 3.0) (rem (1+ i) 2)))
 
 
-;Make one measure and save it in the global *measure*
-(defun makemeasure ()
-  (setf *measure*
-    (sim
-      (s-rest (* timesig beatlen)) ;required for trailing silence
-      (click click-type 1) ;accented beat
-      (simrep (x (- timesig 1))
-        (at-abs (* beatlen (+ x 1 (swing-adjust x swing)))
-            (cue (click click-type 0))))))) ;unaccented beat
-        
-
-(defun make-click-track (bars mdur)  ; mdur is not used
+(defun make-click-track (bars)
   (setf wave (s-rest (* timesig beatlen bars)))
   (for-range 0 bars 1 (lambda (i)  ; using (for-range) because (simrep) has a maximum of 90 internal recursion... ie (simrep (i 91) => crash)
     (setf wave (sim wave (at-abs (* i timesig beatlen) (cue (click click-type 1))))) ;accented beat
@@ -211,9 +200,6 @@ $control low (_ "MIDI pitch of weak beat") int (_ "18 - 116") 80 18 116
       
 
 (setf beatlen (/ 60.0 tempo))
-
-;call function to make one measure
-(makemeasure)
 
 ; If 'Number of bars' = 0, calculate bars from 'Rhythm track duration'.
 (when (= bars 0)
@@ -236,6 +222,6 @@ $control low (_ "MIDI pitch of weak beat") int (_ "18 - 116") 80 18 116
 'Rhythm track duration' to greater than zero.")
     (if (get '*track* 'view) ;NIL if previewing
         (seq (s-rest offset)
-             (make-click-track bars (* timesig beatlen)))
+             (make-click-track bars))
         ;; Don't preview the offset (silence).
-        (make-click-track bars (* timesig beatlen))))
+        (make-click-track bars)))


### PR DESCRIPTION
Resolves: none (cannot find any issue about this)

When you choose tempo 89.071, 4 beats per bar for 10 minutes
there is a small delay between real-life click and audacity click
(losing around 2ms every 9 minutes).
Tested with different kind of click generator (like FL Studio)
every one have the same accuracy except Audacity.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

NB : The `(for-range ...)` I use is because `(loop ...)` just crash my Audacity (3.0.4 on Windows 10). Perhaps there is a better way to make a dumb loop. Also, I don't know lisp language at all 😉 I just learnt a bit nyquist to fix this plug-in. The `(for-range ...)` allows around 1000 recursion on my machine (10 times less if I remove all `(when ...)` lines. I need it because `(simrep (i bars) ...)` crashes if `bars` is greater than 90. Thanks!