### PR TITLE
Multi tool shortcut is again F6 not F5

### DIFF
--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -370,7 +370,7 @@ BaseItemSharedPtr ExtraToolsMenu()
       Command( wxT("ZoomTool"), XXO("&Zoom Tool"), FN(OnZoomTool),
          AlwaysEnabledFlag, wxT("F4") ),
       Command( wxT("MultiTool"), XXO("&Multi Tool"), FN(OnMultiTool),
-         AlwaysEnabledFlag, wxT("F5") ),
+         AlwaysEnabledFlag, wxT("F6") ),
       Command( wxT("PrevTool"), XXO("&Previous Tool"), FN(OnPrevTool),
          AlwaysEnabledFlag, wxT("A") ),
       Command( wxT("NextTool"), XXO("&Next Tool"), FN(OnNextTool),


### PR DESCRIPTION
Resolves: #1803 

Make the shortcut key for multi-tool again f6, as in 3.0.3 and "forever" before that.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
