### PR TITLE
issue #1838: Screen readers should read labels when tabbing

### DIFF
--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -297,6 +297,12 @@ void DoMoveToLabel(AudacityProject &project, bool next)
             window.ScrollIntoView(selectedRegion.t0());
             window.RedrawProject();
          }
+         /* i18n-hint:
+            String is replaced by the name of a label,
+            first number gives the position of that label in a sequence
+            of labels,
+            and the last number is the total number of labels in the sequence.
+         */
          auto message = XO("%s %d of %d")
             .Format( label->title, i + 1, lt->GetNumLabels() );
          trackFocus.MessageForScreenReader(message);

--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -1726,6 +1726,16 @@ bool LabelTrackView::DoKeyDown(
                mInitialCursorPos = mCurrentCursorPos;
                //Set the selection region to be equal to the selection bounds of the tabbed-to label.
                newSel = labelStruct.selectedRegion;
+               // message for screen reader
+               /* i18n-hint:
+                  String is replaced by the name of a label,
+                  first number gives the position of that label in a sequence
+                  of labels,
+                  and the last number is the total number of labels in the sequence.
+               */
+               auto message = XO("%s %d of %d")
+                  .Format(labelStruct.title, mNavigationIndex + 1, pTrack->GetNumLabels());
+               TrackFocus::Get(project).MessageForScreenReader(message);
             }
             else {
                mNavigationIndex = -1;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1838

Now that when a label track is the focus tab and shift+tab only "select" a label, rather than opening it for editing in a custom text box which is not accessible for screen readers, it's useful for the name of the label to be read.

Straightforward fix.
Also added i18n-hint in TransportMenus.cpp where there is the same message for screen readers.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
