### PR TITLE
Fix bug 1856 - Nyquist Progress bar

### DIFF
--- a/lib-src/libnyquist/nyx.c
+++ b/lib-src/libnyquist/nyx.c
@@ -1002,6 +1002,18 @@ int nyx_get_audio(nyx_audio_callback callback, void *userdata)
       goto finish;
    }
 
+   if (nyx_input_length == 0) {
+      LVAL val = getvalue(xlenter("LEN"));
+      if (val != s_unbound) {
+         if (ntype(val) == FLONUM) {
+            nyx_input_length = (int64_t) getflonum(val);
+         }
+         else if (ntype(val) == FIXNUM) {
+            nyx_input_length = (int64_t) getfixnum(val);
+         }
+      }
+   }
+
    // at this point, input sounds which were referenced by symbol S
    // (or nyx_get_audio_name()) could be referenced by nyx_result, but
    // S is now bound to NIL. nyx_result is a protected (garbage


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1856

Partial revert of https://github.com/audacity/audacity/commit/8f41dd7a3 to allow plug-ins to hint at audio length.
This fixes bug [1856](https://github.com/audacity/audacity/issues/1856) but does not close issue [1855](https://github.com/audacity/audacity/issues/1855) which is broader in scope.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
