### PR TITLE
Issue #1870: feedback for screen readers when tabbing to clips

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -37,6 +37,7 @@
 #include "../../../../Theme.h"
 #include "../../../../../images/Cursors.h"
 #include "../../../../HitTestResult.h"
+#include "../../../../TrackPanelAx.h"
 
 #include "WaveClipTrimHandle.h"
 
@@ -511,6 +512,26 @@ bool WaveTrackAffordanceControls::SelectNextClip(ViewInfo& viewInfo, AudacityPro
 
     viewInfo.selectedRegion.setTimes(clip->GetPlayStartTime(), clip->GetPlayEndTime());
     ProjectHistory::Get(*project).ModifyState(false);
+
+    // create and send message to screen reader
+    auto it = std::find(clips.begin(), clips.end(), clip);
+    auto index = std::distance(clips.begin(), it);
+    
+    auto message = XP(
+    /* i18n-hint:
+        string is the name of a clip
+        first number is the position of that clip in a sequence of clips,
+        second number counts the clips */
+        "%s, %d of %d clip",
+        "%s, %d of %d clips",
+        2
+     )(
+        clip->GetName(),
+        static_cast<int>(index + 1),
+        static_cast<int>(clips.size())
+    );
+
+    TrackFocus::Get(*project).MessageForScreenReader(message);
     return true;
 }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1870

When a user presses tab or shift+tab to select the next/previous clip, a message is sent to any screen reader.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
