### PR TITLE
Exit editing of clip a name and redraw when a TrackPanel loses focus

### DIFF
--- a/src/CellularPanel.cpp
+++ b/src/CellularPanel.cpp
@@ -963,6 +963,13 @@ void CellularPanel::OnSetFocus(wxFocusEvent &event)
 
 void CellularPanel::OnKillFocus(wxFocusEvent & WXUNUSED(event))
 {
+   if (auto pCell = GetFocusedCell()) {
+      auto refreshResult = pCell->LoseFocus(GetProject());
+      auto &state = *mState;
+      auto pClickedCell = state.mpClickedCell.lock();
+      if (pClickedCell)
+         ProcessUIHandleResult( pClickedCell.get(), {}, refreshResult );
+   }
    if (KeyboardCapture::IsHandler(this))
    {
       KeyboardCapture::Release(this);

--- a/src/TrackPanelCell.cpp
+++ b/src/TrackPanelCell.cpp
@@ -79,3 +79,8 @@ unsigned TrackPanelCell::Char(
    event.Skip();
    return RefreshCode::RefreshNone;
 }
+
+unsigned TrackPanelCell::LoseFocus(AudacityProject *)
+{
+   return RefreshCode::RefreshNone;
+}

--- a/src/TrackPanelCell.h
+++ b/src/TrackPanelCell.h
@@ -134,6 +134,11 @@ public:
    virtual unsigned Char
       (wxKeyEvent & event, ViewInfo &viewInfo, wxWindow *pParent,
        AudacityProject *project);
+
+   // Return value is a bitwise OR of RefreshCode values
+   // Notification to the focused cell that the CellularPanel is losing focus
+   // Default does nothing, returns RefreshCode::RefreshNone
+   virtual unsigned LoseFocus(AudacityProject *project);
 };
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -114,6 +114,10 @@ public:
     WaveClipTitleEditHandle(const std::shared_ptr<TextEditHelper>& helper)
         : mHelper(helper)
     { }
+   
+   ~WaveClipTitleEditHandle()
+   {
+   }
 
     Result Click(const TrackPanelMouseEvent& event, AudacityProject* project) override
     {
@@ -423,6 +427,11 @@ unsigned WaveTrackAffordanceControls::Char(wxKeyEvent& event, ViewInfo& viewInfo
     return RefreshCode::RefreshNone;
 }
 
+unsigned WaveTrackAffordanceControls::LoseFocus(AudacityProject *)
+{
+   return ExitTextEditing();
+}
+
 void WaveTrackAffordanceControls::OnTextEditFinished(AudacityProject* project, const wxString& text)
 {
     if (auto lock = mFocusClip.lock())
@@ -454,7 +463,12 @@ void WaveTrackAffordanceControls::OnTextContextMenu(AudacityProject* project, co
 void WaveTrackAffordanceControls::OnTrackChanged(TrackListEvent& evt)
 {
     evt.Skip();
+    ExitTextEditing();
+}
 
+unsigned WaveTrackAffordanceControls::ExitTextEditing()
+{
+    using namespace RefreshCode;
     if (mTextEditHelper)
     {
         auto trackList = FindTrack()->GetOwner();
@@ -463,7 +477,9 @@ void WaveTrackAffordanceControls::OnTrackChanged(TrackListEvent& evt)
             mTextEditHelper->Finish(trackList->GetOwner());
         }
         mTextEditHelper.reset();
+        return RefreshCell;
     }
+    return RefreshNone;
 }
 
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.h
@@ -72,6 +72,8 @@ public:
     (wxKeyEvent& event, ViewInfo& viewInfo, wxWindow* pParent,
         AudacityProject* project) override;
 
+    unsigned LoseFocus(AudacityProject *project) override;
+
     void OnTextEditFinished(AudacityProject* project, const wxString& text) override;
     void OnTextEditCancelled(AudacityProject* project) override;
     void OnTextModified(AudacityProject* project, const wxString& text) override;
@@ -84,6 +86,8 @@ public:
 
 private:
     void OnTrackChanged(TrackListEvent& evt);
+
+    unsigned ExitTextEditing();
 
     bool SelectNextClip(ViewInfo& viewInfo, AudacityProject* project, bool forward);
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -1226,6 +1226,16 @@ unsigned WaveTrackView::Char(wxKeyEvent& event, ViewInfo& viewInfo, wxWindow* pP
    return result;
 }
 
+unsigned WaveTrackView::LoseFocus(AudacityProject *project)
+{
+   unsigned result = RefreshCode::RefreshNone;
+   if (auto delegate = mKeyEventDelegate.lock()) {
+      result = delegate->LoseFocus(project);
+      mKeyEventDelegate.reset();
+   }
+   return result;
+}
+
 std::vector< std::shared_ptr< WaveTrackSubView > >
 WaveTrackView::GetAllSubViews()
 {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
@@ -172,6 +172,8 @@ public:
    (wxKeyEvent& event, ViewInfo& viewInfo, wxWindow* pParent,
        AudacityProject* project) override;
 
+   unsigned LoseFocus(AudacityProject *project) override;
+
 private:
    void BuildSubViews() const;
    void DoSetDisplay(Display display, bool exclusive = true);

--- a/src/tracks/ui/TextEditHelper.h
+++ b/src/tracks/ui/TextEditHelper.h
@@ -65,6 +65,10 @@ public:
     static bool IsGoodEditKeyCode(int keyCode);
 
     TextEditHelper(const std::weak_ptr<TextEditDelegate>& delegate, const wxString& text, const wxFont& font);
+   
+   ~TextEditHelper()
+   {
+   }
 
     void SetTextColor(const wxColor& textColor);
     void SetTextSelectionColor(const wxColor& textSelectionColor);


### PR DESCRIPTION
Resolves: #1858

Exit clip name editing when a mouse click causes the TrackPanel to lose focus.

Note that this implementation commits any unfinished text edit with a Undo history item -- it doesn't cancel it as if by the Escape key.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
