### PR TITLE
issue #1780: An unwanted label can be created by typing

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -1352,7 +1352,7 @@ bool LabelTrackView::DoCaptureKey(
        !mLabels.empty())
       return true;
 
-   if (IsValidIndex(mTextEditIndex, project) || IsValidIndex(mNavigationIndex, project)) {
+   if (IsValidIndex(mTextEditIndex, project)) {
       if (IsGoodLabelEditKey(event)) {
          return true;
       }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1780

If a label is selected, then you can type to create a label, even if the "Type to create a label" option is disabled.

This bug was introduced in commit: a0ad72d
I presume that in the following line in LabelTrackView::DoCaptureKey:
if (IsValidIndex(mTextEditIndex, project) || IsValidIndex(mNavigationIndex, project)) {,

IsValidIndex(mNavigationIndex, project) was included to let the hardcoded Enter key be captured. This was not an appropriate way of doing so - the Enter key should have been handled individually, just like the tab key. This introduced the current bug.

Fix: Given that use of the hardcoded Enter key is shortly to be removed, then IsValidIndex(mNavigationIndex, project) can be removed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
