### PR TITLE
Always use "emulated" output volume control instead of hardware

### DIFF
--- a/libraries/lib-audio-devices/AudioIOBase.h
+++ b/libraries/lib-audio-devices/AudioIOBase.h
@@ -260,7 +260,6 @@ protected:
    float               mPreviousHWPlaythrough;
    #endif /* USE_PORTMIXER */
 
-   bool                mEmulateMixerOutputVol;
    /** @brief Can we control the hardware input level?
     *
     * This flag is set to true if using portmixer to control the
@@ -269,7 +268,6 @@ protected:
     * scaled clipping problems when trying to do software emulated input volume
     * control */
    bool                mInputMixerWorks;
-   float               mMixerOutputVol;
 
    // For cacheing supported sample rates
    static int mCachedPlaybackIndex;
@@ -326,6 +324,7 @@ extern AUDIO_DEVICES_API StringSetting AudioIOHost;
 extern AUDIO_DEVICES_API DoubleSetting AudioIOLatencyCorrection;
 extern AUDIO_DEVICES_API DoubleSetting AudioIOLatencyDuration;
 extern AUDIO_DEVICES_API StringSetting AudioIOPlaybackDevice;
+extern AUDIO_DEVICES_API DoubleSetting AudioIOPlaybackVolume;
 extern AUDIO_DEVICES_API IntSetting    AudioIORecordChannels;
 extern AUDIO_DEVICES_API StringSetting AudioIORecordingDevice;
 extern AUDIO_DEVICES_API StringSetting AudioIORecordingSource;

--- a/libraries/lib-math/CMakeLists.txt
+++ b/libraries/lib-math/CMakeLists.txt
@@ -24,6 +24,7 @@ set( SOURCES
    Spectrum.cpp
    Spectrum.h
    float_cast.h
+   Gain.h
 )
 set( LIBRARIES
    libsoxr

--- a/libraries/lib-math/Gain.h
+++ b/libraries/lib-math/Gain.h
@@ -1,0 +1,36 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Gain.h
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#pragma once
+
+#include <type_traits>
+#include <cmath>
+#include <limits>
+
+// Implementation is based on https://www.dr-lex.be/info-stuff/volumecontrols.html
+template<typename Type>
+Type ExpGain(Type gain) noexcept
+{
+   static_assert(std::is_floating_point_v<Type>);
+
+   constexpr Type a(1e-3);
+   constexpr Type b(6.908);
+
+   if (gain < std::numeric_limits<Type>::epsilon())
+      return {};
+
+   const Type expGain = a * std::exp(b * gain);
+
+   if (expGain > Type(1))
+      return Type(1);
+
+   return expGain;
+}
+

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -256,6 +256,8 @@ public:
    WaveTrackArray      mPlaybackTracks;
 
    std::vector<std::unique_ptr<Mixer>> mPlaybackMixers;
+
+   float               mMixerOutputVol { 1.0 };
    static int          mNextStreamToken;
    double              mFactor;
    unsigned long       mMaxFramesOutput; // The actual number of frames output.
@@ -424,14 +426,6 @@ public:
     */
    bool InputMixerWorks();
 
-   /** @brief Find out if the output level control is being emulated via software attenuation
-    *
-    * Checks the mEmulateMixerOutputVol variable, which is set up in
-    * AudioIOBase::HandleDeviceChange(). External classes care, because we want to
-    * modify the UI if it doesn't work.
-    */
-   bool OutputMixerEmulated();
-
    /** \brief Get the list of inputs to the current mixer device
     *
     * Returns an array of strings giving the names of the inputs to the
@@ -565,6 +559,7 @@ private:
 
    std::mutex mPostRecordingActionMutex;
    PostRecordingAction mPostRecordingAction;
+
    bool mDelayingActions{ false };
 };
 

--- a/src/toolbars/MixerToolBar.cpp
+++ b/src/toolbars/MixerToolBar.cpp
@@ -321,9 +321,7 @@ void MixerToolBar::SetToolTips()
    }
 
    if (mOutputSlider->IsEnabled()) {
-      auto format = (AudioIO::Get()->OutputMixerEmulated()
-         ? XO("Playback Volume: %.2f (emulated)")
-         : XO("Playback Volume: %.2f"));
+      auto format = XO("Playback Volume: %.2f");
 
       mOutputSlider->SetToolTipTemplate( format );
    }


### PR DESCRIPTION
Resolves: #1866 

Previously, Audacity used to change interface volume, which is uncommon and unexpected behavior for applications.

We had a report from the user about hearing damage caused by unexpectedly setting his audio interface volume to maximum.

As loudness perception is not linear volume will change exponentially.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
