### PR TITLE
Less laggy response of looping playback to change of region bounds...

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1870,8 +1870,8 @@ void AudioIO::FillPlayBuffers()
       available -= frames;
       // wxASSERT(available >= 0); // don't assert on this thread
 
-      // Poll for selection change events
-      mPlaybackSchedule.MessageConsumer();
+      // Poll for play region change events
+      policy.MessageConsumer(mPlaybackSchedule);
 
       done = policy.RepositionPlayback( mPlaybackSchedule, mPlaybackMixers,
          frames, available );

--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -766,13 +766,13 @@ void Mixer::Reposition(double t, bool bSkipping)
       MakeResamplers();
 }
 
-void Mixer::SetTimesAndSpeed(double t0, double t1, double speed)
+void Mixer::SetTimesAndSpeed(double t0, double t1, double speed, bool bSkipping)
 {
    wxASSERT(std::isfinite(speed));
    mT0 = t0;
    mT1 = t1;
    mSpeed = fabs(speed);
-   Reposition(t0);
+   Reposition(t0, bSkipping);
 }
 
 void Mixer::SetSpeedForPlayAtSpeed(double speed)

--- a/src/Mix.h
+++ b/src/Mix.h
@@ -127,8 +127,9 @@ class AUDACITY_DLL_API Mixer {
    /// Process() is called.
    void Reposition(double t, bool bSkipping = false);
 
-   // Used in scrubbing.
-   void SetTimesAndSpeed(double t0, double t1, double speed);
+   // Used in scrubbing and other nonuniform playback policies.
+   void SetTimesAndSpeed(
+      double t0, double t1, double speed, bool bSkipping = false);
    void SetSpeedForPlayAtSpeed(double speed);
    void SetSpeedForKeyboardScrubbing(double speed, double startTime);
 

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -236,6 +236,15 @@ public:
       AdvancedTrackTime( PlaybackSchedule &schedule,
          double trackTime, size_t nSamples );
 
+   //! May be called between AdvancedTrackTime() and RepositionPlayback()
+   /*!
+    Receive notifications from the main thread of changes of parameters
+    affecting the policy
+
+    Default implementation ignores all messages
+    */
+   virtual void MessageConsumer( PlaybackSchedule &schedule );
+
    using Mixers = std::vector<std::unique_ptr<Mixer>>;
 
    //! AudioIO::FillPlayBuffers calls this to update its cursors into tracks for changes of position or speed
@@ -322,6 +331,8 @@ struct AUDACITY_DLL_API PlaybackSchedule {
       //! Return the last time saved by Producer
       double GetLastTime() const;
 
+      void SetLastTime(double time);
+
       //! @section called by PortAudio callback thread
 
       //! Find the track time value `nSamples` after the last consumed sample
@@ -386,7 +397,6 @@ struct AUDACITY_DLL_API PlaybackSchedule {
    double SolveWarpedLength(double t0, double length) const;
 
    void MessageProducer( PlayRegionEvent &evt );
-   void MessageConsumer();
 
    /** \brief True if the end time is before the start time */
    bool ReversedTime() const
@@ -452,6 +462,8 @@ public:
       AdvancedTrackTime( PlaybackSchedule &schedule,
          double trackTime, size_t nSamples ) override;
 
+   void MessageConsumer( PlaybackSchedule &schedule ) override;
+
    bool RepositionPlayback(
       PlaybackSchedule &schedule, const Mixers &playbackMixers,
       size_t frames, size_t available ) override;
@@ -461,5 +473,6 @@ public:
 private:
    size_t mRemaining{ 0 };
    bool mProgress{ true };
+   bool mKicked{ false };
 };
 #endif


### PR DESCRIPTION
Resolves: #1890 

... Some lagginess has to be tolerated, because there must be a queue of some
length between the TrackBufferExchange thread and the PortAudio thread.   But
how short can it be?

In case of playback looping, that lag is now set to an arbitrary hard-coded
1/2 second in LoopingPlaybackPolicy::SuggestedBufferTimes; which is less than
the old default latency of 4 seconds (see PlaybackPolicy::SuggestedBufferTimes),
which perhaps was a value motivated by older generations of hardware.

So, if you adjust looping play bounds while the play head is within 1/2 second
of the end of the loop (that's 1/2 second of real time, not track time, in case
you also have a time-warping Time Track) -- then you might yet notice the play
head not doing quite what you want.

(Should we make that latency user-tunable?  Or, more challengingly for us,
detect hardware limitations and make it adaptive?)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
