### PR TITLE
Allow the application appearance to match the theme on macOS

### DIFF
--- a/libraries/lib-theme/ClassicThemeAsCeeCode.cpp
+++ b/libraries/lib-theme/ClassicThemeAsCeeCode.cpp
@@ -19,5 +19,5 @@ static const std::vector<unsigned char> ImageCacheAsData {
 static ThemeBase::RegisteredTheme theme{
    /* i18n-hint: describing the "classic" or traditional
       appearance of older versions of Audacity */
-   { "classic", XO("Classic") }, ImageCacheAsData
+   { "classic", XO("Classic") }, PreferredSystemAppearance::Light, ImageCacheAsData
 };

--- a/libraries/lib-theme/DarkThemeAsCeeCode.cpp
+++ b/libraries/lib-theme/DarkThemeAsCeeCode.cpp
@@ -17,5 +17,5 @@ static const std::vector<unsigned char> ImageCacheAsData {
 };
 
 static ThemeBase::RegisteredTheme theme{
-   { "dark", XO("Dark") }, ImageCacheAsData
+   { "dark", XO("Dark") }, PreferredSystemAppearance::Dark, ImageCacheAsData
 };

--- a/libraries/lib-theme/HiContrastThemeAsCeeCode.cpp
+++ b/libraries/lib-theme/HiContrastThemeAsCeeCode.cpp
@@ -19,5 +19,7 @@ static const std::vector<unsigned char> ImageCacheAsData {
 static ThemeBase::RegisteredTheme theme{
    /* i18n-hint: greater difference between foreground and
       background colors */
-   { "high-contrast", XO("High Contrast") }, ImageCacheAsData
+   { "high-contrast", XO("High Contrast") },
+   PreferredSystemAppearance::HighContrastDark,
+   ImageCacheAsData
 };

--- a/libraries/lib-theme/LightThemeAsCeeCode.cpp
+++ b/libraries/lib-theme/LightThemeAsCeeCode.cpp
@@ -18,5 +18,5 @@ static const std::vector<unsigned char> ImageCacheAsData {
 
 static ThemeBase::RegisteredTheme theme{
    /* i18n-hint: Light meaning opposite of dark */
-   { "light", XO("Light") }, ImageCacheAsData
+   { "light", XO("Light") }, PreferredSystemAppearance::Light, ImageCacheAsData
 };

--- a/libraries/lib-theme/Theme.h
+++ b/libraries/lib-theme/Theme.h
@@ -25,6 +25,14 @@
 //! A choice of theme such as "Light", "Dark", ...
 using teThemeType = Identifier;
 
+//! A system theme, that matches selected theme best (only works on macOS with builtin themes).
+enum class PreferredSystemAppearance
+{
+    Light,
+    Dark,
+    HighContrastDark
+};
+
 class wxArrayString;
 class wxBitmap;
 class wxColour;
@@ -100,11 +108,15 @@ public:
    // Typically statically constructed:
    struct THEME_API RegisteredTheme {
       RegisteredTheme(EnumValueSymbol symbol,
+         PreferredSystemAppearance preferredSystemAppearance,
          const std::vector<unsigned char> &data /*!<
             A reference to this vector is stored, not a copy of it! */
       );
       ~RegisteredTheme();
+
       const EnumValueSymbol symbol;
+      const PreferredSystemAppearance preferredSystemAppearance;
+      const std::vector<unsigned char>& data;
    };
 
    void LoadTheme( teThemeType Theme );
@@ -144,6 +156,9 @@ public:
    // Utility function that takes a 32 bit bitmap and makes it into an image.
    wxImage MakeImageWithAlpha( wxBitmap & Bmp );
 
+   using OnPreferredSystemAppearanceChanged = std::function<void (PreferredSystemAppearance)>;
+   OnPreferredSystemAppearanceChanged
+   SetOnPreferredSystemAppearanceChanged(OnPreferredSystemAppearanceChanged handler);
 protected:
    // wxImage, wxBitmap copy cheaply using reference counting
    std::vector<wxImage> mImages;
@@ -153,6 +168,9 @@ protected:
 
    std::vector<wxColour> mColours;
    wxArrayString mColourNames;
+
+   PreferredSystemAppearance mPreferredSystemAppearance { PreferredSystemAppearance::Light };
+   OnPreferredSystemAppearanceChanged mOnPreferredSystemAppearanceChanged;
 };
 
 

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1327,6 +1327,10 @@ bool AudacityApp::OnInit()
    this->AssociateFileTypes();
 #endif
 
+   theTheme.SetOnPreferredSystemAppearanceChanged([this](PreferredSystemAppearance appearance){
+       SetPreferredSystemAppearance(appearance);
+   });
+
    theTheme.LoadPreferredTheme();
 
    // AColor depends on theTheme.
@@ -2417,6 +2421,13 @@ void AudacityApp::OnMenuExit(wxCommandEvent & event)
    event.Skip(AllProjects{}.empty());
 
 }
+
+#ifndef __WXMAC__
+void AudacityApp::SetPreferredSystemAppearance(PreferredSystemAppearance)
+{
+   // Currently this is implemented only on macOS
+}
+#endif
 
 //BG: On Windows, associate the aup file type with Audacity
 /* We do this in the Windows installer now,

--- a/src/AudacityApp.h
+++ b/src/AudacityApp.h
@@ -16,8 +16,7 @@
 
 
 #include "Identifier.h"
-
-
+#include "Theme.h"
 
 #include <wx/app.h> // to inherit
 #include <wx/timer.h> // member variable
@@ -88,11 +87,11 @@ class AudacityApp final : public wxApp {
     void AssociateFileTypes();
    #endif
 
-#ifdef __WXMAC__
+   void SetPreferredSystemAppearance(PreferredSystemAppearance appearance);
 
+#ifdef __WXMAC__
    void MacActivateApp();
    void MacFinishLaunching();
-
 #endif
 
 

--- a/src/AudacityApp.mm
+++ b/src/AudacityApp.mm
@@ -25,4 +25,32 @@ void AudacityApp::MacFinishLaunching()
    [NSApp finishLaunching];
 }
 
+void AudacityApp::SetPreferredSystemAppearance(PreferredSystemAppearance appearance)
+{
+   // This API only works 10.14+
+   // Previous versions will always use Light appearance
+   if (@available(macOS 10.14, *))
+   {
+      NSAppearanceName appearanceName;
+
+      switch (appearance)
+      {
+         case PreferredSystemAppearance::Light:
+            appearanceName = NSAppearanceNameAqua;
+            break;
+         case PreferredSystemAppearance::Dark:
+            appearanceName = NSAppearanceNameDarkAqua;
+            break;
+         case PreferredSystemAppearance::HighContrastDark:
+            appearanceName = NSAppearanceNameAccessibilityHighContrastDarkAqua;
+            break;
+      }
+
+      NSAppearance* systemAppearance = [NSAppearance appearanceNamed:appearanceName];
+
+      if (systemAppearance != nil)
+         NSApp.appearance = systemAppearance;
+   }
+}
+
 #endif


### PR DESCRIPTION
Currently, this is implemented for macOS users only.
Windows has not yet published the API, Linux requires GTK3 and we build against GTK2 currently.

Resolves: #1752

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
