### PR TITLE
Try to import as Raw Data when Audacity did not recognize the type of the file(Drag file into audacity case)

### DIFF
--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -337,10 +337,10 @@ public:
                DoImportMIDI( *mProject, name );
             else
 #endif
-               ProjectFileManager::Get( *mProject ).Import(name);
+               ProjectFileManager::Get(*mProject).Import(name);
          }
 
-         auto &window = ProjectWindow::Get( *mProject );
+         auto &window = ProjectWindow::Get(*mProject);
          window.ZoomAfterImport(nullptr);
 
          return true;

--- a/src/import/Import.h
+++ b/src/import/Import.h
@@ -165,10 +165,13 @@ public:
     * Allocates NEW ExtImportItem, fills it with default data
     * and returns a pointer to it.
     */
-    std::unique_ptr<ExtImportItem> CreateDefaultImportItem();
+   std::unique_ptr<ExtImportItem> CreateDefaultImportItem();
 
-   // if false, the import failed and errorMessage will be set.
-   bool Import( AudacityProject &project,
+   /**
+    * if first tuple item is false, the import failed and errorMessage will be set.
+    * if second tuple item is true, means format is not supported, can try to import it as raw data.
+    */
+   std::tuple<bool, bool> Import( AudacityProject &project,
               const FilePath &fName,
               WaveTrackFactory *trackFactory,
               TrackHolders &tracks,


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

I'm on windows audio processing related work, and there is a lot of raw audio data is dumped in processing pipe line.
When I want to import those raw data files into audacity, I have to go to file-import-raw data, but I prefer to just drag it into audacity window to parse raw data. so I request this pull-request.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
