### PR TITLE
Click-away from TrackPanel (still in Audacity) ends clip name edit...

### DIFF
--- a/src/CellularPanel.cpp
+++ b/src/CellularPanel.cpp
@@ -60,20 +60,42 @@ struct CellularPanel::Filter : wxEventFilter
 
    int FilterEvent( wxEvent &event ) override
    {
-      if ( spActivePanel &&
-         event.GetEventType() == wxEVT_KEY_DOWN &&
-         static_cast< wxKeyEvent& >( event ).GetKeyCode() == WXK_ESCAPE ) {
-         spActivePanel->HandleEscapeKey( true );
-         return Event_Processed;
+      const auto type = event.GetEventType();
+      if (type == wxEVT_KEY_DOWN &&
+          static_cast< wxKeyEvent& >( event ).GetKeyCode() == WXK_ESCAPE ) {
+         bool eatEvent = false;
+         for (const auto &pPanel: {spClickedPanel, spEnteredPanel}) {
+            if (pPanel) {
+               eatEvent = true;
+               // Handle escape either in the clicked panel to abort a drag, or
+               // to switch among hit test candidates before button down in the
+               // entered (but not yet clicked) panel
+               pPanel->HandleEscapeKey( true );
+            }
+         }
+         if (eatEvent)
+            return Event_Processed;
       }
-      else
-         return Event_Skip;
+      else if ((type == wxEVT_LEFT_DOWN ||
+                type == wxEVT_RIGHT_DOWN ||
+                type == wxEVT_MIDDLE_DOWN)) {
+         if ( spClickedPanel &&
+             spClickedPanel != event.GetEventObject() ) {
+            // Clicking away from the panel doesn't necessarily change wxWidgets
+            // focus, so we use this global filter instead
+            spClickedPanel->DoKillFocus();
+            // Don't eat the event
+         }
+      }
+      return Event_Skip;
    }
 
-   static wxWeakRef< CellularPanel > spActivePanel;
+   static wxWeakRef< CellularPanel > spClickedPanel;
+   static wxWeakRef< CellularPanel > spEnteredPanel;
 };
 
-wxWeakRef< CellularPanel > CellularPanel::Filter::spActivePanel = nullptr;
+wxWeakRef< CellularPanel > CellularPanel::Filter::spClickedPanel = nullptr;
+wxWeakRef< CellularPanel > CellularPanel::Filter::spEnteredPanel = nullptr;
 
 struct CellularPanel::State
 {
@@ -152,7 +174,7 @@ void CellularPanel::Uncapture(bool escaping, wxMouseState *pState)
    HandleMotion( *pState );
  
    if ( escaping || !AcceptsFocus() )
-      Filter::spActivePanel = nullptr;
+      Filter::spClickedPanel = nullptr;
 }
 
 bool CellularPanel::CancelDragging( bool escaping )
@@ -733,10 +755,12 @@ try
 
    if (event.Entering())
    {
-      Filter::spActivePanel = this;
+      Filter::spEnteredPanel = this;
    }
    else if (event.Leaving())
    {
+      if (Filter::spEnteredPanel == this)
+         Filter::spEnteredPanel = nullptr;
       Leave();
 
       auto buttons =
@@ -745,7 +769,7 @@ try
          // event.ButtonIsDown(wxMOUSE_BTN_ANY);
          ::wxGetMouseState().ButtonIsDown(wxMOUSE_BTN_ANY);
 
-      if(!buttons) {
+      if (!buttons) {
          CancelDragging( false );
 
 #if defined(__WXMAC__)
@@ -912,7 +936,7 @@ void CellularPanel::HandleClick( const TrackPanelMouseEvent &tpmEvent )
       if (refreshResult & RefreshCode::Cancelled)
          state.mUIHandle.reset(), handle.reset(), ClearTargets();
       else {
-         Filter::spActivePanel = this;
+         Filter::spClickedPanel = this;
 
 #if wxUSE_TOOLTIPS
          // Remove any outstanding tooltip
@@ -965,7 +989,7 @@ void CellularPanel::OnSetFocus(wxFocusEvent &event)
    Refresh( false);
 }
 
-void CellularPanel::OnKillFocus(wxFocusEvent & WXUNUSED(event))
+void CellularPanel::DoKillFocus()
 {
    if (auto pCell = GetFocusedCell()) {
       auto refreshResult = pCell->LoseFocus(GetProject());
@@ -974,11 +998,16 @@ void CellularPanel::OnKillFocus(wxFocusEvent & WXUNUSED(event))
       if (pClickedCell)
          ProcessUIHandleResult( pClickedCell.get(), {}, refreshResult );
    }
+   Refresh( false);
+}
+
+void CellularPanel::OnKillFocus(wxFocusEvent & WXUNUSED(event))
+{
+   DoKillFocus();
    if (KeyboardCapture::IsHandler(this))
    {
       KeyboardCapture::Release(this);
    }
-   Refresh( false);
 }
 
 // Empty out-of-line default functions to fill Visitor's vtable

--- a/src/CellularPanel.h
+++ b/src/CellularPanel.h
@@ -139,6 +139,7 @@ private:
    
    void OnSetFocus(wxFocusEvent & event);
    void OnKillFocus(wxFocusEvent & event);
+   void DoKillFocus();
    
    void OnContextMenu(wxContextMenuEvent & event);
    


### PR DESCRIPTION
Resolves: #1896

... This is unlike the case of loss of focus when clicking outside of Audacity,
which was the case fixed at ec258e0.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
