### PR TITLE
Adds an ability to change project's user_version based on features used

### DIFF
--- a/libraries/lib-project/CMakeLists.txt
+++ b/libraries/lib-project/CMakeLists.txt
@@ -12,6 +12,10 @@ and formatter functions, and emitting events when changed.
 set( SOURCES
    Project.cpp
    Project.h
+   ProjectFormatExtensionsRegistry.cpp
+   ProjectFormatExtensionsRegistry.h
+   ProjectFormatVersion.cpp
+   ProjectFormatVersion.h
    ProjectStatus.cpp
    ProjectStatus.h
 )
@@ -19,7 +23,7 @@ set( LIBRARIES
    lib-registries-interface
    lib-xml-interface
    PRIVATE
-   wxBase   
+   wxBase
 )
 audacity_library( lib-project "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-project/ProjectFormatExtensionsRegistry.cpp
+++ b/libraries/lib-project/ProjectFormatExtensionsRegistry.cpp
@@ -1,0 +1,59 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ProjectFormatExtensionRegistry.cpp
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+
+#include "ProjectFormatExtensionsRegistry.h"
+
+#include <algorithm>
+
+#include "Project.h"
+
+ProjectFormatExtensionsRegistry& GetProjectFormatExtensionsRegistry()
+{
+   static ProjectFormatExtensionsRegistry instance;
+   return instance;
+}
+
+const ProjectFormatExtensionsRegistry& ProjectFormatExtensionsRegistry::Get()
+{
+   return GetProjectFormatExtensionsRegistry();
+}
+
+void ProjectFormatExtensionsRegistry::Register(
+   ProjectVersionResolver formatExtension)
+{
+   mRegisteredExtensions.emplace_back(std::move(formatExtension));
+}
+
+ProjectFormatVersion ProjectFormatExtensionsRegistry::GetRequiredVersion(
+   const AudacityProject& project) const
+{
+   ProjectFormatVersion minVersion = BaseProjectFormatVersion;
+
+   for (auto formatExtension : mRegisteredExtensions)
+   {
+      if (!formatExtension)
+         continue;
+      
+      const auto formatExtensionVersion = formatExtension(project);
+
+      if (minVersion < formatExtensionVersion)
+         minVersion = formatExtensionVersion;
+   }
+
+   return minVersion;
+}
+
+ProjectFormatExtensionsRegistry::Extension::Extension(
+   ProjectVersionResolver resolver)
+{
+   if (resolver)
+      GetProjectFormatExtensionsRegistry().Register(std::move(resolver));
+}

--- a/libraries/lib-project/ProjectFormatExtensionsRegistry.h
+++ b/libraries/lib-project/ProjectFormatExtensionsRegistry.h
@@ -1,0 +1,43 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ProjectFormatExtensionsRegistry.h
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#pragma once
+
+#include <mutex>
+#include <functional>
+
+#include "ClientData.h"
+#include "ProjectFormatVersion.h"
+
+class AudacityProject;
+
+//! The class that allows evaluating the minimum version of Audacity required to support the project
+class PROJECT_API ProjectFormatExtensionsRegistry final
+   : public ClientData::Base
+{
+public:
+   using ProjectVersionResolver = ProjectFormatVersion (*)(const AudacityProject&);
+
+   static const ProjectFormatExtensionsRegistry& Get();
+
+   //! Returns the minimum possible version that can be used to save the project
+   ProjectFormatVersion GetRequiredVersion(const AudacityProject& project) const;
+
+   //! A struct to register the project extension that requires a different project version
+   struct PROJECT_API Extension final
+   {
+      Extension(ProjectVersionResolver resolver);
+   };
+
+private:
+   void Register(ProjectVersionResolver resolver);
+
+   std::vector<ProjectVersionResolver> mRegisteredExtensions;
+};

--- a/libraries/lib-project/ProjectFormatVersion.cpp
+++ b/libraries/lib-project/ProjectFormatVersion.cpp
@@ -1,0 +1,56 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ProjectFormatVersion.cpp
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#include "ProjectFormatVersion.h"
+
+#include <tuple>
+
+bool operator == (ProjectFormatVersion lhs, ProjectFormatVersion rhs) noexcept
+{
+   return std::tie(lhs.Major, lhs.Minor, lhs.Revision, lhs.ModLevel) ==
+          std::tie(rhs.Major, rhs.Minor, rhs.Revision, rhs.ModLevel);
+}
+
+bool operator != (ProjectFormatVersion lhs, ProjectFormatVersion rhs) noexcept
+{
+   return !(lhs == rhs);
+}
+
+bool operator < (ProjectFormatVersion lhs, ProjectFormatVersion rhs) noexcept
+{
+   return std::tie(lhs.Major, lhs.Minor, lhs.Revision, lhs.ModLevel) <
+          std::tie(rhs.Major, rhs.Minor, rhs.Revision, rhs.ModLevel);
+}
+
+ProjectFormatVersion ProjectFormatVersion::FromPacked(uint32_t packedVersion) noexcept
+{
+   return {
+      static_cast<uint8_t>((packedVersion >> 24) & 0xFF),
+      static_cast<uint8_t>((packedVersion >> 16) & 0xFF),
+      static_cast<uint8_t>((packedVersion >> 8 ) & 0xFF),
+      static_cast<uint8_t>((packedVersion      ) & 0xFF),
+   };
+}
+
+uint32_t ProjectFormatVersion::GetPacked() const noexcept
+{
+   return (Major << 24) | (Minor << 16) | (Revision << 8) | ModLevel;
+}
+
+bool ProjectFormatVersion::IsValid() const noexcept
+{
+   return Major != 0;
+}
+
+const ProjectFormatVersion SupportedProjectFormatVersion = {
+   AUDACITY_VERSION, AUDACITY_RELEASE, AUDACITY_REVISION, AUDACITY_MODLEVEL
+};
+
+const ProjectFormatVersion BaseProjectFormatVersion = { 3, 0, 0, 0 };

--- a/libraries/lib-project/ProjectFormatVersion.h
+++ b/libraries/lib-project/ProjectFormatVersion.h
@@ -1,0 +1,44 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ProjectFormatVersion.h
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+/*!
+   @brief A structure that holds the project version.
+
+   aup3 file format stores version as a 32 bit integer. This class is used for easier interop
+   with the user_version field of the project file.
+*/
+struct PROJECT_API ProjectFormatVersion final
+{
+   uint8_t Major { 0 };
+   uint8_t Minor { 0 };
+   uint8_t Revision { 0 };
+   uint8_t ModLevel { 0 };
+
+   // Create ProjectFormatVersion from the uint32_t value 
+   static ProjectFormatVersion FromPacked(uint32_t) noexcept;
+   //! Returns a version packed to 32-bit integer.
+   uint32_t GetPacked() const noexcept;
+
+   //! Returns true if version is valid, i.e. Major != 0
+   bool IsValid() const noexcept;
+};
+
+PROJECT_API bool operator==(ProjectFormatVersion lhs, ProjectFormatVersion rhs) noexcept;
+PROJECT_API bool operator!=(ProjectFormatVersion lhs, ProjectFormatVersion rhs) noexcept;
+PROJECT_API bool operator<(ProjectFormatVersion lhs, ProjectFormatVersion rhs) noexcept;
+
+//! This constant represents the current version of Audacity
+PROJECT_API extern const ProjectFormatVersion SupportedProjectFormatVersion;
+//! This is a helper constant for the "most compatible" project version with the value (3, 0, 0, 0). 
+PROJECT_API extern const ProjectFormatVersion BaseProjectFormatVersion;

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -244,7 +244,6 @@ private:
 
    bool CheckVersion();
    bool InstallSchema(sqlite3 *db, const char *schema = "main");
-   bool UpgradeSchema();
 
    // Write project or autosave XML (binary) documents
    bool WriteDoc(const char *table, const ProjectSerializer &autosave, const char *schema = "main");

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -80,7 +80,6 @@ public:
    // overwrite data excluding the sample sequence but including display
    // settings
    void Reinit(const WaveTrack &orig);
-
 private:
    void Init(const WaveTrack &orig);
 
@@ -577,7 +576,6 @@ private:
 
    //! Returns nullptr if clip with such name was not found
    const WaveClip* FindClipByName(const wxString& name) const;
-
  protected:
    //
    // Protected variables
@@ -717,10 +715,11 @@ class AUDACITY_DLL_API WaveTrackFactory final
    static WaveTrackFactory &Reset( AudacityProject &project );
    static void Destroy( AudacityProject &project );
 
-   WaveTrackFactory( const ProjectRate &rate,
+   WaveTrackFactory(
+      const ProjectRate& rate,
       const SampleBlockFactoryPtr &pFactory)
-      : mRate{ rate }
-      , mpFactory(pFactory)
+       : mRate{ rate }
+       , mpFactory(pFactory)
    {
    }
    WaveTrackFactory( const WaveTrackFactory & ) PROHIBITED;


### PR DESCRIPTION
This commit introduces a new mechanism to allow projects components to specify the Audacity version they require to be loaded. 

It is possible to set the version based on the features that are currently in use. 

Smart Clips use this new approach to require at least Audacity 3.1 if there are trimmed clips in the project.

Resolves: #1903

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
