### PR TITLE
issue #1934: Renaming clip using the keyboard

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -592,7 +592,7 @@ bool WaveTrackAffordanceControls::StartEditNameOfMatchingClip(
       [&](auto pClip){ return pClip && test && test(*pClip); });
     if (it != clips.end())
     {
-        mEditedClip = *it;
+        mFocusClip = *it;
         return StartEditClipName(&project);
     }
     return false;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1934

Using the keyboard to rename a clip in an audio track, regardless of which clip is selected, the same clip in the audio track is always renamed.

Fix:
In WaveTrackAffordanceControls::StartEditNameOfMatchingClip(), the call to StartEditClipName() edits the name of mFocusClip, so set the value of mFocusClip, not mEditedClip.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
