### PR TITLE
Change shortcut for renaming label to hardcoded Ctrl+F2

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -1338,21 +1338,28 @@ static bool IsGoodLabelEditKey(const wxKeyEvent & evt)
 bool LabelTrackView::DoCaptureKey(
    AudacityProject &project, wxKeyEvent & event )
 {
-   // Check for modifiers and only allow shift
    int mods = event.GetModifiers();
+   auto code = event.GetKeyCode();
+   const auto pTrack = FindLabelTrack();
+   const auto& mLabels = pTrack->GetLabels();
+
+   // Allow hardcoded Ctrl+F2 for renaming the selected label,
+   // if we have any labels
+   if (code == WXK_F2 && mods == wxMOD_CONTROL && !mLabels.empty()) {
+      return true;
+   }
+
+   // Check for modifiers and only allow shift
    if (mods != wxMOD_NONE && mods != wxMOD_SHIFT) {
       return false;
    }
 
    // Always capture the navigation keys, if we have any labels
-   auto code = event.GetKeyCode();
-   const auto pTrack = FindLabelTrack();
-   const auto &mLabels = pTrack->GetLabels();
    if ((code == WXK_TAB || code == WXK_NUMPAD_TAB) &&
        !mLabels.empty())
       return true;
 
-   if (IsValidIndex(mTextEditIndex, project) || IsValidIndex(mNavigationIndex, project)) {
+   if (IsValidIndex(mTextEditIndex, project)) {
       if (IsGoodLabelEditKey(event)) {
          return true;
       }
@@ -1500,7 +1507,9 @@ bool LabelTrackView::DoKeyDown(
    const int mods = event.GetModifiers();
 
    // Check for modifiers and only allow shift
-   if (mods != wxMOD_NONE && mods != wxMOD_SHIFT) {
+   // except in the case of F2, so hardcoded Ctrl+F2 can
+   // be used for renaming a label
+   if (keyCode != WXK_F2 && mods != wxMOD_NONE && mods != wxMOD_SHIFT) {
       event.Skip();
       return updated;
    }
@@ -1747,11 +1756,10 @@ bool LabelTrackView::DoKeyDown(
             }
          }
          break;
-      case WXK_RETURN:
-      case WXK_NUMPAD_ENTER:
-         //pressing Enter key activates editing of the label
-         //pointed to by mNavigationIndex (if valid)
-         if (IsValidIndex(mNavigationIndex, project)) {
+      case WXK_F2:
+         // Hardcoded Ctrl+F2 activates editing of the label
+         // pointed to by mNavigationIndex (if valid)
+         if ((mods == wxMOD_CONTROL) && IsValidIndex(mNavigationIndex, project)) {
              SetTextSelection(mNavigationIndex);
          }
          break;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/1710
Resolves: https://github.com/audacity/audacity/issues/1780

Problem: For label tracks Enter (hardcoded) for renaming the selected label, is the same shortcut used by default by the command for toggling the selectedness of the track.

Fix: Use the shortcut Ctrl+F2 for renaming the selected label.
WARNING: This has been implemented by hardcoding this shortcut, rather than providing a context sensitive command for renaming both clips and labels. This was done due to a shortage of time. This hardcoded shortcut should be removed after the release of 3.1.0

In changing the shortcut from Enter to Ctrl+F2, in LabelTrackView::DoCaptureKey(), in the line:
if (IsValidIndex(mTextEditIndex, project) || IsValidIndex(mNavigationIndex, project)) {

the case IsValidIndex(mNavigationIndex, project) was removed. This had been added in commit a0ad72d, presumably to capture the Enter key. This was an incorrect change and caused issue #1780:A label can be created by typing regardless of option setting.
So this commit also fixes that issue.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
