### PR TITLE
Fix crash on looping play seen on Windows...

### DIFF
--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -725,6 +725,9 @@ double Mixer::MixGetCurrentTime()
    return mTime;
 }
 
+#if 0
+// Was used before 3.1.0 whenever looping play restarted
+// No longer used
 void Mixer::Restart()
 {
    mTime = mT0;
@@ -742,6 +745,7 @@ void Mixer::Restart()
    // flushed.  Should that be considered a bug in sox?  This works around it:
    MakeResamplers();
 }
+#endif
 
 void Mixer::Reposition(double t, bool bSkipping)
 {

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -254,7 +254,7 @@ bool LoopingPlaybackPolicy::RepositionPlayback(
    if (mRemaining <= 0)
    {
       for (auto &pMixer : playbackMixers)
-         pMixer->SetTimesAndSpeed( schedule.mT0, schedule.mT1, 1.0, mKicked );
+         pMixer->SetTimesAndSpeed( schedule.mT0, schedule.mT1, 1.0, true );
       schedule.RealTimeRestart();
    }
    else if (mKicked)


### PR DESCRIPTION
Resolves: #1822

... A recurrence of bugs 1887 and 2025.  These worked around a bug in the soxr
library.  Recent rearrangements of playback engine sometimes failed to do the
workaround.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
