### PR TITLE
Fix hot zones for clicks and drags in the ruler...

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -764,7 +764,7 @@ public:
    : PlayRegionAdjustingHandle( pParent, xx, MenuChoice::QuickPlay, *handOpenCursor, 2 )
    {
    }
-   
+
    ~MovePlayRegionHandle()
    {
       mParent->mQuickPlayOffset[0] = 0;
@@ -1045,8 +1045,9 @@ std::vector<UIHandlePtr> AdornedRulerPanel::QPCell::HitTest(
    // High priority hit is a handle to change the existing play region
    bool hitLeft = false;
    const auto &playRegion = ViewInfo::Get(*pProject).playRegion;
-   if ((hitLeft = mParent->IsWithinMarker(xx, playRegion.GetStart())) ||
-       mParent->IsWithinMarker(xx, playRegion.GetEnd()))
+   if ((hitLeft =
+        mParent->IsWithinMarker(xx, playRegion.GetLastActiveStart())) ||
+       mParent->IsWithinMarker(xx, playRegion.GetLastActiveStart()))
    {
       auto result =
          std::make_shared<ResizePlayRegionHandle>( mParent, xx, hitLeft );
@@ -1055,8 +1056,9 @@ std::vector<UIHandlePtr> AdornedRulerPanel::QPCell::HitTest(
    }
 
    // Middle priority hit is a handle to change the existing play region at
-   // both ends
+   // both ends, but only when the play region is active
    if (auto time = mParent->Pos2Time(xx);
+       playRegion.Active() &&
        time >= playRegion.GetStart() &&
        time <= playRegion.GetEnd())
    {


### PR DESCRIPTION
Resolves: #1971

... Make east-west cursor at ends of the loop region, not the selection, whether
looping is off or on.

Make the hand cursor only inside the loop region and only when it is on.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
