### PR TITLE
Issue #1924: starting play with empty selection, loop disabled...

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -759,7 +759,8 @@ void AudioIO::StartMonitoring( const AudioIOStartStreamOptions &options )
 
 int AudioIO::StartStream(const TransportTracks &tracks,
                          double t0, double t1,
-                         const AudioIOStartStreamOptions &options)
+                         const AudioIOStartStreamOptions &options,
+                         double *pStartTime)
 {
    mLostSamples = 0;
    mLostCaptureIntervals.clear();
@@ -951,10 +952,10 @@ int AudioIO::StartStream(const TransportTracks &tracks,
    AILASetStartTime();
 #endif
 
-   if (options.pStartTime)
+   if (pStartTime)
    {
       // Calculate the NEW time position
-      const auto time = mPlaybackSchedule.ClampTrackTime( *options.pStartTime );
+      const auto time = mPlaybackSchedule.ClampTrackTime( *pStartTime );
 
       // Main thread's initialization of mTime
       mPlaybackSchedule.SetTrackTime( time );

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -380,7 +380,8 @@ public:
 
    int StartStream(const TransportTracks &tracks,
                    double t0, double t1,
-                   const AudioIOStartStreamOptions &options);
+                   const AudioIOStartStreamOptions &options,
+                   double *pStartTime);
 
    /** \brief Stop recording, playback or input monitoring.
     *

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -2445,7 +2445,7 @@ void Effect::Preview(bool dryOnly)
       // Start audio playing
       auto options = DefaultPlayOptions(*pProject);
       int token =
-         gAudioIO->StartStream(tracks, mT0, t1, options);
+         gAudioIO->StartStream(tracks, mT0, t1, options, options.pStartTime);
 
       if (token) {
          auto previewing = ProgressResult::Success;


### PR DESCRIPTION
... Do not play a short bit from time zero, do not briefly show play head there.

Use the start time option, which prepares all before the first
TrackBufferExchange call, and not the older "seek" mechanism.  That instead set
a variable and let the portAudio thread to react to it.  Possibly the thread
did not see the change in variable promptly enough, explaining the symptom.

Resolves: #1924

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
