### PR TITLE
Fix timeline hot zones

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1047,7 +1047,7 @@ std::vector<UIHandlePtr> AdornedRulerPanel::QPCell::HitTest(
    const auto &playRegion = ViewInfo::Get(*pProject).playRegion;
    if ((hitLeft =
         mParent->IsWithinMarker(xx, playRegion.GetLastActiveStart())) ||
-       mParent->IsWithinMarker(xx, playRegion.GetLastActiveStart()))
+       mParent->IsWithinMarker(xx, playRegion.GetLastActiveEnd()))
    {
       auto result =
          std::make_shared<ResizePlayRegionHandle>( mParent, xx, hitLeft );


### PR DESCRIPTION
Resolves: #1971 

Make correct hot zones for drags in the timeline when looping is disabled.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
