### PR TITLE
Don't make black corners of control toolbar buttons when blending...

### DIFF
--- a/libraries/lib-theme/ImageManipulation.cpp
+++ b/libraries/lib-theme/ImageManipulation.cpp
@@ -94,6 +94,12 @@ std::unique_ptr<wxImage> ChangeImageColour(wxImage * srcImage,
       c = (c + 1) % 3;
    }
 
+   if (srcImage->HasAlpha()) {
+      // Preserve transparencies
+      dstImage->InitAlpha();
+      memcpy(dstImage->GetAlpha(), srcImage->GetAlpha(), width * height);
+   }
+
    return dstImage;
 }
 


### PR DESCRIPTION
... Though this isn't the only consequence of unwary use of ThemePrefs.  It is
only the more obvious one.

Actually, the bitmaps made by OverlayImage in ImageManipulation.cpp, which
combines a foreground and a background image, are opaque.  But the
transparencies in the given background image are blended with the theme's
clrMedium which is the background color of the toolbar.  This change makes
sure that the background image does not lose its transparencies when it is
recolored.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
