### PR TITLE
Minor looping region UI fixes

### DIFF
--- a/libraries/lib-screen-geometry/ViewInfo.cpp
+++ b/libraries/lib-screen-geometry/ViewInfo.cpp
@@ -214,6 +214,18 @@ void PlayRegion::SetAllTimes( double start, double end )
    mLastActiveStart = start, mLastActiveEnd = end;
 }
 
+static constexpr auto invalidValue = std::numeric_limits<double>::min();
+
+void PlayRegion::Clear()
+{
+   SetAllTimes(invalidValue, invalidValue);
+}
+
+bool PlayRegion::IsClear() const
+{
+   return GetStart() == invalidValue && GetEnd() == invalidValue;
+}
+
 void PlayRegion::Order()
 {
    if ( mStart >= 0 && mEnd >= 0 && mStart > mEnd) {

--- a/libraries/lib-screen-geometry/ViewInfo.h
+++ b/libraries/lib-screen-geometry/ViewInfo.h
@@ -181,6 +181,11 @@ public:
    // Set current and last active times the same regardless of activation:
    void SetAllTimes( double start, double end );
 
+   //! Set to an invalid state
+   void Clear();
+   //! Test whether in invalid state
+   bool IsClear() const;
+
    void Order();
 
 private:

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2399,11 +2399,11 @@ void AdornedRulerPanel::DoDrawPlayRegion(wxDC * dc)
    const auto &playRegion = viewInfo.playRegion;
    bool isActive = (mLastPlayRegionActive = playRegion.Active());
 
+   if (playRegion.IsClear())
+      return;
+
    const auto t0 = playRegion.GetLastActiveStart(),
       t1 = playRegion.GetLastActiveEnd();
-   if (t0 < 0 || t1 < 0)
-      // play region is cleared, that is undefined
-      return;
 
    const int p0 = max(1, Time2Pos(t0));
    const int p1 = min(mInner.width, Time2Pos(t1));

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -205,7 +205,7 @@ void ClearPlayRegion(AudacityProject &project)
 {
    auto &viewInfo = ViewInfo::Get( project );
    auto &playRegion = viewInfo.playRegion;
-   playRegion.SetAllTimes(-1, -1);
+   playRegion.Clear();
 }
 
 void SetPlayRegionToSelection(AudacityProject &project)


### PR DESCRIPTION
Resolves: #1999 
(and two other problems)

* Dragging of looping region partly into negative time should not make it disappear
* Yellow snap guideline should be visible at right edge of last clip
* Remove arbitrary restriction on selection of play regions with error message "Cannot lock region beyond end of project."

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
