### PR TITLE
Revert "Opt in for macOS dark mode support"

### DIFF
--- a/cmake-proxies/cmake-modules/MacOSXBundleInfo.plist.in
+++ b/cmake-proxies/cmake-modules/MacOSXBundleInfo.plist.in
@@ -230,7 +230,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
    <key>NSRequiresAquaSystemAppearance</key>
-   <false/>
+   <true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Audacity version ${AUDACITY_INFO_VERSION}</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
This reverts commit cbb9a34b25fdd3768a6337904d132526bdffd4de.

Enabling a dark theme leads to serious visual problems on macOS 10.14 and 10.15 when rendering is performed outside the paint event. There is no quick fix available, so for this release, we will stick to the old behavior. 

Resolves: #1968

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
