### PR TITLE
Initialize play region to be invalid region

### DIFF
--- a/libraries/lib-screen-geometry/ViewInfo.cpp
+++ b/libraries/lib-screen-geometry/ViewInfo.cpp
@@ -216,8 +216,6 @@ void PlayRegion::SetAllTimes( double start, double end )
    mLastActiveStart = start, mLastActiveEnd = end;
 }
 
-static constexpr auto invalidValue = std::numeric_limits<double>::min();
-
 void PlayRegion::Clear()
 {
    SetAllTimes(invalidValue, invalidValue);
@@ -226,6 +224,11 @@ void PlayRegion::Clear()
 bool PlayRegion::IsClear() const
 {
    return GetStart() == invalidValue && GetEnd() == invalidValue;
+}
+
+bool PlayRegion::IsLastActiveRegionClear() const
+{
+   return GetLastActiveStart() == invalidValue && GetLastActiveEnd() == invalidValue;
 }
 
 void PlayRegion::Order()

--- a/libraries/lib-screen-geometry/ViewInfo.h
+++ b/libraries/lib-screen-geometry/ViewInfo.h
@@ -185,6 +185,8 @@ public:
    void Clear();
    //! Test whether in invalid state
    bool IsClear() const;
+   //! Test whether last active region is in invalid state
+   bool IsLastActiveRegionClear() const;
 
    void Order();
 
@@ -192,10 +194,12 @@ private:
    void Notify();
 
    // Times:
-   double mStart{ -1.0 };
-   double mEnd{ -1.0 };
-   double mLastActiveStart{ -1.0 };
-   double mLastActiveEnd{ -1.0 };
+   static constexpr auto invalidValue = std::numeric_limits<double>::min();
+
+   double mStart { invalidValue };
+   double mEnd { invalidValue };
+   double mLastActiveStart { invalidValue };
+   double mLastActiveEnd { invalidValue };
 
    bool mActive{ false };
 };

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2397,7 +2397,7 @@ void AdornedRulerPanel::DoDrawPlayRegion(wxDC * dc)
    const auto &playRegion = viewInfo.playRegion;
    bool isActive = (mLastPlayRegionActive = playRegion.Active());
 
-   if (playRegion.IsClear())
+   if (playRegion.IsLastActiveRegionClear())
       return;
 
    const auto t0 = playRegion.GetLastActiveStart(),


### PR DESCRIPTION
This change is required to maintain consistency between default and cleared play regions

Resolves: #2011 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
