### PR TITLE
Fixes a bug where only the first channel is imported when using FFmpeg

### DIFF
--- a/src/import/ImportFFmpeg.cpp
+++ b/src/import/ImportFFmpeg.cpp
@@ -596,7 +596,7 @@ ProgressResult FFmpegImportFileHandle::WriteData(StreamContext *sc, const AVPack
       for (size_t chn = 0; chn < nChannels; ++iter2, ++chn)
       {
          iter2->get()->Append(
-            reinterpret_cast<samplePtr>(data.data()), sc->SampleFormat,
+            reinterpret_cast<samplePtr>(data.data() + chn), sc->SampleFormat,
             samplesPerChannel,
             sc->CodecContext->GetChannels());
       }
@@ -613,7 +613,7 @@ ProgressResult FFmpegImportFileHandle::WriteData(StreamContext *sc, const AVPack
       for (size_t chn = 0; chn < nChannels; ++iter2, ++chn)
       {
          iter2->get()->Append(
-            reinterpret_cast<samplePtr>(data.data()), sc->SampleFormat,
+            reinterpret_cast<samplePtr>(data.data() + chn), sc->SampleFormat,
             samplesPerChannel, sc->CodecContext->GetChannels());
       }
    }


### PR DESCRIPTION
Resolves: #2045 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
