### PR TITLE
Improve the performance of project serialization by ~10x

### DIFF
--- a/libraries/lib-utility/CMakeLists.txt
+++ b/libraries/lib-utility/CMakeLists.txt
@@ -20,6 +20,8 @@ set( SOURCES
    MemoryX.h
    ModuleConstants.cpp
    ModuleConstants.h
+   MemoryStream.cpp
+   MemoryStream.h
 )
 audacity_library( lib-utility "${SOURCES}" ""
    "" ""

--- a/libraries/lib-utility/MemoryStream.cpp
+++ b/libraries/lib-utility/MemoryStream.cpp
@@ -1,0 +1,98 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  MemoryStream.cpp
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#include "MemoryStream.h"
+
+#include <algorithm>
+
+void MemoryStream::Clear()
+{
+   mChunks = {};
+   mLinearData = {};
+   mDataSize = 0;
+}
+
+void MemoryStream::AppendByte(char data)
+{
+   AppendData(&data, 1);
+}
+
+void MemoryStream::AppendData(const void* data, const size_t length)
+{
+   if (mChunks.empty())
+      mChunks.emplace_back();
+
+   AppendDataView dataView = { data, length };
+
+   while (mChunks.back().Append(dataView) > 0)
+      mChunks.emplace_back();
+
+   mDataSize += length;
+}
+
+const void* MemoryStream::GetData() const
+{
+   if (!mChunks.empty())
+   {
+      const size_t desiredSize = GetSize();
+
+      mLinearData.reserve(desiredSize);
+
+      for (const Chunk& chunk : mChunks)
+      {
+         auto begin = chunk.Data.begin();
+         auto end = begin + chunk.BytesUsed;
+
+         mLinearData.insert(mLinearData.end(), begin, end);
+      }
+
+      mChunks = {};
+   }
+
+   return mLinearData.data();
+}
+
+const size_t MemoryStream::GetSize() const
+{
+   return mDataSize;
+}
+
+size_t MemoryStream::Chunk::Append(AppendDataView& dataView)
+{
+   const size_t dataSize = dataView.second;
+
+   const size_t bytesToWrite = std::min(ChunkSize - BytesUsed, dataSize);
+   const size_t bytesLeft = dataSize - bytesToWrite;
+
+   const uint8_t* beginData = static_cast<const uint8_t*>(dataView.first);
+   const uint8_t* endData = beginData + bytesToWrite;
+
+   // Some extreme micro optimization for MSVC (at least)
+   // std::copy will generate a call to memmove in any case
+   // which will be slower than just writing the byte
+   if (bytesToWrite == 1)
+   {
+      Data[BytesUsed] = *beginData;
+   }
+   else
+   {
+      // There is a chance for unaligned access, so we do no handle
+      // types as int32_t separately. Unaligned access is slow on x86
+      // and fails horribly on ARM
+      std::copy(beginData, endData, Data.begin() + BytesUsed);
+   }
+
+   dataView.first = endData;
+   dataView.second = bytesLeft;
+
+   BytesUsed += bytesToWrite;
+
+   return bytesLeft;
+}

--- a/libraries/lib-utility/MemoryStream.h
+++ b/libraries/lib-utility/MemoryStream.h
@@ -1,0 +1,63 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  MemoryStream.h
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <list>
+#include <vector>
+
+/*!
+ * @brief A low overhead memory stream with O(1) append, low heap fragmentation and a linear memory view.
+ *
+ * wxMemoryBuffer always appends 1Kb to the end of the buffer, causing severe performance issues
+ * and significant heap fragmentation. There is no possibility to controll the increment value.
+ *
+ * std::vector doubles it's memory size which can be problematic for large projects as well.
+ * Not as bad as wxMemoryBuffer though.
+ * 
+ */
+class UTILITY_API MemoryStream final
+{
+public:
+   using StreamData = std::vector<uint8_t>;
+
+   void Clear();
+
+   void AppendByte(char data);
+   void AppendData(const void* data, const size_t length);
+
+   // This function possibly has O(size) complexity as it may
+   // require copying bytes to a linear chunk
+   const void* GetData() const;
+   const size_t GetSize() const;
+private:
+   static constexpr size_t ChunkSize = 1024 * 1024;
+
+   using AppendDataView = std::pair<const void*, size_t>;
+
+   struct Chunk final
+   {
+      std::array<uint8_t, ChunkSize> Data;
+      size_t BytesUsed { 0 };
+
+      // Returns data size left to append
+      size_t Append(AppendDataView& dataView);
+   };
+
+   using ChunksList = std::list<Chunk>;
+
+   // This structures are lazily updated by get data
+   mutable ChunksList mChunks;
+   mutable StreamData mLinearData;
+
+   size_t mDataSize { 0 };
+};

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1757,14 +1757,14 @@ bool ProjectFileIO::WriteDoc(const char *table,
       return false;
    }
 
-   const wxMemoryBuffer &dict = autosave.GetDict();
-   const wxMemoryBuffer &data = autosave.GetData();
+   const MemoryStream &dict = autosave.GetDict();
+   const MemoryStream& data = autosave.GetData();
 
    // Bind statement parameters
    // Might return SQL_MISUSE which means it's our mistake that we violated
    // preconditions; should return SQL_OK which is 0
-   if (sqlite3_bind_blob(stmt, 1, dict.GetData(), dict.GetDataLen(), SQLITE_STATIC) ||
-       sqlite3_bind_blob(stmt, 2, data.GetData(), data.GetDataLen(), SQLITE_STATIC))
+   if (sqlite3_bind_blob(stmt, 1, dict.GetData(), dict.GetSize(), SQLITE_STATIC) ||
+       sqlite3_bind_blob(stmt, 2, data.GetData(), data.GetSize(), SQLITE_STATIC))
    {
       ADD_EXCEPTION_CONTEXT("sqlite3.query", sql);
       ADD_EXCEPTION_CONTEXT("sqlite3.rc", std::to_string(rc));

--- a/src/ProjectSerializer.cpp
+++ b/src/ProjectSerializer.cpp
@@ -78,7 +78,7 @@ enum FieldTypes
 // contain the envelope name, but that's not a problem.
 
 NameMap ProjectSerializer::mNames;
-wxMemoryBuffer ProjectSerializer::mDict;
+MemoryStream ProjectSerializer::mDict;
 
 TranslatableString ProjectSerializer::FailureMessage( const FilePath &/*filePath*/ )
 {
@@ -128,14 +128,14 @@ namespace {
 
    // Write native little-endian to little-endian file format
    template< typename Number >
-   void WriteLittleEndian( wxMemoryBuffer &out, Number value )
+   void WriteLittleEndian( MemoryStream &out, Number value )
    {
       out.AppendData( &value, sizeof(value) );
    }
 
    // Write native big-endian to little-endian file format
    template< typename Number >
-   void WriteBigEndian( wxMemoryBuffer &out, Number value )
+   void WriteBigEndian( MemoryStream &out, Number value )
    {
       auto begin = static_cast<unsigned char*>( static_cast<void*>( &value ) );
       std::reverse( begin, begin + sizeof( value ) );
@@ -199,9 +199,6 @@ namespace {
 
 ProjectSerializer::ProjectSerializer(size_t allocSize)
 {
-   mDict.SetBufSize(allocSize);
-   mBuffer.SetBufSize(allocSize);
-
    static std::once_flag flag;
    std::call_once(flag, []{
       // Just once per run, store header information in the unique static
@@ -326,8 +323,8 @@ void ProjectSerializer::WriteSubTree(const ProjectSerializer & value)
 {
    mBuffer.AppendByte(FT_Push);
 
-   mBuffer.AppendData(value.mDict.GetData(), value.mDict.GetDataLen());
-   mBuffer.AppendData(value.mBuffer.GetData(), value.mBuffer.GetDataLen());
+   mBuffer.AppendData(value.mDict.GetData(), value.mDict.GetSize());
+   mBuffer.AppendData(value.mBuffer.GetData(), value.mBuffer.GetSize());
 
    mBuffer.AppendByte(FT_Pop);
 }
@@ -362,19 +359,19 @@ void ProjectSerializer::WriteName(const wxString & name)
    WriteUShort( mBuffer, id );
 }
 
-const wxMemoryBuffer &ProjectSerializer::GetDict() const
+const MemoryStream &ProjectSerializer::GetDict() const
 {
    return mDict;
 }
 
-const wxMemoryBuffer &ProjectSerializer::GetData() const
+const MemoryStream& ProjectSerializer::GetData() const
 {
    return mBuffer;
 }
 
 bool ProjectSerializer::IsEmpty() const
 {
-   return mBuffer.GetDataLen() == 0;
+   return mBuffer.GetSize() == 0;
 }
 
 bool ProjectSerializer::DictChanged() const

--- a/src/ProjectSerializer.h
+++ b/src/ProjectSerializer.h
@@ -13,7 +13,8 @@
 
 #include "XMLTagHandler.h"
 
-#include <wx/mstream.h> // member variables
+#include "MemoryStream.h" // member variables
+#include <wx/mstream.h>
 
 #include <unordered_set>
 #include <unordered_map>
@@ -59,8 +60,8 @@ public:
    // Non-override functions
    void WriteSubTree(const ProjectSerializer & value);
 
-   const wxMemoryBuffer &GetDict() const;
-   const wxMemoryBuffer &GetData() const;
+   const MemoryStream& GetDict() const;
+   const MemoryStream& GetData() const;
 
    bool IsEmpty() const;
    bool DictChanged() const;
@@ -72,11 +73,11 @@ private:
    void WriteName(const wxString & name);
 
 private:
-   wxMemoryBuffer mBuffer;
+   MemoryStream mBuffer;
    bool mDictChanged;
 
    static NameMap mNames;
-   static wxMemoryBuffer mDict;
+   static MemoryStream mDict;
 };
 
 #endif


### PR DESCRIPTION
Originally, wxMemoryBuffer was used while generating binary XML data. wxMemoryBuffer grows only by 1Kb, which results in extremely low performance of project serialization (few seconds on Ryzen 5800x for a 100Mb XML file).

This commit introduces a MemoryStream class tuned for high performance and low memory fragmentation.

This issue is related to #2051 but is definitely not enough to fix it.

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
