### PR TITLE
Issue 2064: reporting Sentry release version on crash

### DIFF
--- a/crashreports/crashreporter/CrashReportApp.cpp
+++ b/crashreports/crashreporter/CrashReportApp.cpp
@@ -122,7 +122,7 @@ namespace
                     throw std::logic_error("malformed parameters string: unexpected identifier");
 
                 int begin = i;
-                while (isalnum(str[i]))
+                while (isalnum(str[i]) || str[i] == '[' || str[i] == ']')
                     ++i;
 
                 key = str.substr(begin, i - begin);

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -407,6 +407,9 @@ void InitBreakpad()
     
     if(databasePath.DirExists())
     {   
+        const auto sentryRelease = wxString::Format(
+           "audacity@%d.%d.%d", AUDACITY_VERSION, AUDACITY_RELEASE, AUDACITY_REVISION
+        );
         BreakpadConfigurer configurer;
         configurer.SetDatabasePathUTF8(databasePath.GetPath().ToUTF8().data())
             .SetSenderPathUTF8(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath().ToUTF8().data())
@@ -414,7 +417,8 @@ void InitBreakpad()
             .SetReportURL(CRASH_REPORT_URL)
     #endif
             .SetParameters({
-                { "version", wxString(AUDACITY_VERSION_STRING).ToUTF8().data() }
+                { "version", wxString(AUDACITY_VERSION_STRING).ToUTF8().data() },
+                { "sentry[release]",  sentryRelease.ToUTF8().data() }
             })
             .Start();
     }


### PR DESCRIPTION
Resolves: #2064

Passes additional parameter on crash reporting, which is recognized by Sentry

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
