### PR TITLE
Fixes double free with InconsistencyException on Windows

### DIFF
--- a/libraries/lib-exceptions/InconsistencyException.h
+++ b/libraries/lib-exceptions/InconsistencyException.h
@@ -37,8 +37,8 @@ public:
        , func { fn }, file { f }, line { l }
    {}
 
-   InconsistencyException(InconsistencyException&& that)
-      : MessageBoxException(std::move(that))
+   InconsistencyException(const InconsistencyException& that)
+      : MessageBoxException(that)
       , func{ that.func }
       , file{ that.file }
       , line{ that.line }


### PR DESCRIPTION
C++ standard actually requires an exception to be copyable.  http://eel.is/c++draft/except.throw#5

However, it only affects MSVC implementation of the exceptions, so it was unnoticed for quite some time

This PR is only a partial fix for the symptoms of #2072 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
