### PR TITLE
Issue 1889: fix clip name corrupt

### DIFF
--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1453,6 +1453,25 @@ void WaveClip::Clear(double t0, double t1)
         Offset(offset);        
 }
 
+void WaveClip::ClearLeft(double t)
+{
+   if (t > GetPlayStartTime() && t < GetPlayEndTime())
+   {
+      ClearSequence(GetSequenceStartTime(), t);
+      SetTrimLeft(.0);
+      SetSequenceStartTime(t);
+   }
+}
+
+void WaveClip::ClearRight(double t)
+{
+   if (t > GetPlayStartTime() && t < GetPlayEndTime())
+   {
+      ClearSequence(t, GetSequenceEndTime());
+      SetTrimRight(.0);
+   }
+}
+
 void WaveClip::ClearSequence(double t0, double t1)
 {
     auto clip_t0 = std::max(t0, GetSequenceStartTime());

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -329,6 +329,16 @@ public:
    /// operation (but without putting the cut audio to the clipboard)
    void Clear(double t0, double t1);
 
+   /// Removes samples starting from the left boundary of the clip till
+   /// t, if it's inside the play region. Also removes trimmed (hidden)
+   /// data, if present. Changes offset to make remaining samples stay
+   /// at their old place. Destructive operation.
+   void ClearLeft(double t);
+   /// Removes samples starting from t (if it's inside the clip),
+   /// till the right boundary. Also removes trimmed (hidden)
+   /// data, if present. Destructive operation.
+   void ClearRight(double t);
+
    /// Clear, and add cut line that starts at t0 and contains everything until t1.
    void ClearAndAddCutLine(double t0, double t1);
 


### PR DESCRIPTION
Resolves: #1889

Also partly resolves #2051: applying the Nyquist effect to a range that contained splits resulted in multiple copies of the same data received from the effect being created but with different offsets and trims, and, at the same time, old trimmed data was lost. This fix is aimed to resolve both issues: preserve old trimmed data at split points and eliminate data duplication.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
