### PR TITLE
Fix ability to load custom theme, which was lost at commit b3cd7a57

### DIFF
--- a/libraries/lib-theme/Theme.cpp
+++ b/libraries/lib-theme/Theme.cpp
@@ -799,7 +799,7 @@ bool ThemeBase::ReadImageCache( teThemeType type, bool bOkIfNotFound)
 
    using namespace BasicUI;
 
-   if( type.empty() )
+   if( type.empty() || type == "custom" )
    {
       mPreferredSystemAppearance = PreferredSystemAppearance::Light;
 


### PR DESCRIPTION
Resolves: #2043

Recent theme rewrites mistakenly eliminated the ability to load custom themes from an image cache file.  One-line fix.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
