### PR TITLE
Effect cleanup part 2

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -9,6 +9,11 @@
 
 EffectDefinitionInterface::~EffectDefinitionInterface() = default;
 
+bool EffectDefinitionInterface::EnablesDebug()
+{
+   return false;
+}
+
 EffectClientInterface::~EffectClientInterface() = default;
 
 EffectUIClientInterface::~EffectUIClientInterface() = default;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -164,14 +164,7 @@ AudacityCommand.
 class COMPONENTS_API EffectClientInterface  /* not final */ : public EffectDefinitionInterface
 {
 public:
-   using EffectDialogFactory = std::function<
-      wxDialog* ( wxWindow &parent,
-         EffectHostInterface*, EffectUIClientInterface* )
-   >;
-
    virtual ~EffectClientInterface();
-
-   virtual bool SetHost(EffectHostInterface *host) = 0;
 
    virtual unsigned GetAudioInCount() = 0;
    virtual unsigned GetAudioOutCount() = 0;
@@ -202,10 +195,6 @@ public:
    virtual size_t RealtimeProcess(int group, float **inBuf, float **outBuf, size_t numSamples) = 0;
    virtual bool RealtimeProcessEnd() = 0;
 
-   virtual bool ShowInterface(
-      wxWindow &parent, const EffectDialogFactory &factory,
-      bool forceModal = false
-   ) = 0;
    // Some effects will use define params to define what parameters they take.
    // If they do, they won't need to implement Get or SetAutomation parameters.
    // since the Effect class can do it.  Or at least that is how things happen
@@ -224,6 +213,11 @@ public:
    virtual bool LoadFactoryDefaults() = 0;
 };
 
+using EffectDialogFactory = std::function<
+   wxDialog* ( wxWindow &parent,
+      EffectHostInterface*, EffectUIClientInterface* )
+>;
+
 /*************************************************************************************//**
 
 \class EffectUIClientInterface
@@ -233,10 +227,17 @@ values.  It can import and export presets.
 
 *******************************************************************************************/
 class COMPONENTS_API EffectUIClientInterface /* not final */
+   : public EffectClientInterface
 {
 public:
    virtual ~EffectUIClientInterface();
 
+   virtual bool ShowInterface(
+      wxWindow &parent, const EffectDialogFactory &factory,
+      bool forceModal = false
+   ) = 0;
+
+   virtual bool SetHost(EffectHostInterface *host) = 0;
    virtual void SetHostUI(EffectUIHostInterface *host) = 0;
    virtual bool IsGraphicalUI() = 0;
    virtual bool PopulateUI(ShuttleGui &S) = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -105,9 +105,6 @@ public:
 class wxDialog;
 class wxWindow;
 
-// Incomplete type not defined in libraries -- TODO clean that up:
-class EffectUIHostInterface;
-
 class EffectUIClientInterface;
 
 // Incomplete type not defined in libraries -- TODO clean that up:
@@ -238,7 +235,7 @@ public:
    ) = 0;
 
    virtual bool SetHost(EffectHostInterface *host) = 0;
-   virtual void SetHostUI(EffectUIHostInterface *host) = 0;
+
    virtual bool IsGraphicalUI() = 0;
    virtual bool PopulateUI(ShuttleGui &S) = 0;
    virtual bool ValidateUI() = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -98,6 +98,9 @@ public:
 
    // Can the effect be used without the UI.
    virtual bool SupportsAutomation() = 0;
+
+   //! Whether the effect dialog should have a Debug button; default, always false.
+   virtual bool EnablesDebug();
 };
 
 class wxDialog;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -42,8 +42,6 @@
 #ifndef __AUDACITY_EFFECTINTERFACE_H__
 #define __AUDACITY_EFFECTINTERFACE_H__
 
-#include <functional>
-
 #include "ComponentInterface.h"
 #include "ComponentInterfaceSymbol.h"
 #include "EffectAutomationParameters.h" // for command automation
@@ -210,11 +208,6 @@ public:
    virtual bool LoadFactoryDefaults() = 0;
 };
 
-using EffectDialogFactory = std::function<
-   wxDialog* ( wxWindow &parent,
-      EffectHostInterface&, EffectUIClientInterface& )
->;
-
 /*************************************************************************************//**
 
 \class EffectUIClientInterface
@@ -229,15 +222,21 @@ class COMPONENTS_API EffectUIClientInterface /* not final */
 public:
    virtual ~EffectUIClientInterface();
 
-   virtual bool ShowInterface(
-      wxWindow &parent, const EffectDialogFactory &factory,
-      bool forceModal = false
+   /*!
+    @return true if destructive effect processing should proceed; if false,
+    there may be a non-modal dialog still opened
+    */
+   virtual bool ShowClientInterface(
+      wxWindow &parent, wxDialog &dialog, bool forceModal = false
    ) = 0;
 
    virtual bool SetHost(EffectHostInterface *host) = 0;
 
    virtual bool IsGraphicalUI() = 0;
+
+   //! Adds controls to a panel that is given as the parent window of `S`
    virtual bool PopulateUI(ShuttleGui &S) = 0;
+
    virtual bool ValidateUI() = 0;
    virtual bool HideUI() = 0;
    virtual bool CloseUI() = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -223,10 +223,10 @@ public:
    virtual ~EffectUIClientInterface();
 
    /*!
-    @return true if destructive effect processing should proceed; if false,
-    there may be a non-modal dialog still opened
+    @return 0 if destructive effect processing should not proceed (and there
+    may be a non-modal dialog still opened); otherwise, modal dialog return code
     */
-   virtual bool ShowClientInterface(
+   virtual int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal = false
    ) = 0;
 

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -212,7 +212,7 @@ public:
 
 using EffectDialogFactory = std::function<
    wxDialog* ( wxWindow &parent,
-      EffectHostInterface*, EffectUIClientInterface* )
+      EffectHostInterface&, EffectUIClientInterface& )
 >;
 
 /*************************************************************************************//**

--- a/src/ConfigInterface.h
+++ b/src/ConfigInterface.h
@@ -46,38 +46,13 @@
 #include <functional>
 #include <tuple>
 #include <type_traits>
-#include <variant>
 #include <vector>
 
 class EffectDefinitionInterface;
 
+#include "PluginInterface.h"
+
 namespace PluginSettings {
-
-enum ConfigurationType : unsigned {
-   Shared, Private
-};
-
-//! Supported types for settings
-using ConfigValueTypes = std::tuple<
-     wxString
-   , int
-   , bool
-   , float
-   , double
->;
-
-//! Define a reference to a variable of one of the types in ConfigValueTypes
-/*! Avoid repetition of the list of types */
-template<bool is_const, typename> struct ConfigReferenceGenerator;
-template<bool is_const, typename... Types>
-struct ConfigReferenceGenerator<is_const, std::tuple<Types...>> {
-   using type = std::variant< std::reference_wrapper<
-      std::conditional_t<is_const, const Types, Types> >... >;
-};
-using ConfigReference =
-   ConfigReferenceGenerator<false, ConfigValueTypes>::type;
-using ConfigConstReference =
-   ConfigReferenceGenerator<true, ConfigValueTypes>::type;
 
 AUDACITY_DLL_API bool HasConfigGroup( EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group);

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -66,10 +66,10 @@ public:
    virtual ~EffectUIHostInterface();
 
    /*!
-    @return true if destructive effect processing should proceed; if false,
-    there may be a non-modal dialog still opened
+    @return 0 if destructive effect processing should not proceed (and there
+    may be a non-modal dialog still opened); otherwise, modal dialog return code
     */
-   virtual bool ShowHostInterface(
+   virtual int ShowHostInterface(
       wxWindow &parent, const EffectDialogFactory &factory,
       bool forceModal = false
    ) = 0;

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -15,6 +15,8 @@
 #include "ConfigInterface.h"
 #include "ComponentInterfaceSymbol.h"
 
+#include <functional>
+
 class EffectDefinitionInterface;
 
 /*************************************************************************************//**
@@ -44,19 +46,33 @@ public:
    virtual RegistryPath GetFactoryDefaultsGroup() = 0;
 };
 
+class wxDialog;
+class wxWindow;
+class EffectUIClientInterface;
+
+using EffectDialogFactory = std::function<
+   wxDialog* ( wxWindow &parent,
+      EffectHostInterface&, EffectUIClientInterface& )
+>;
+
 /*************************************************************************************//**
 
 \class EffectUIHostInterface
-
-\brief EffectUIHostInterface has nothing in it.  It is provided so that an Effect
-can call SetHostUI passing in a pointer to an EffectUIHostInterface.  It contains no
-functionality and is provided, apparently, for type checking.  Since only EffectUIHost
-uses it, EffectUIHost could be used instead.
+@brief extends EffectHostInterface with UI-related services
 *******************************************************************************************/
-class AUDACITY_DLL_API EffectUIHostInterface
+class AUDACITY_DLL_API EffectUIHostInterface : public EffectHostInterface
 {
 public:
    virtual ~EffectUIHostInterface();
+
+   /*!
+    @return true if destructive effect processing should proceed; if false,
+    there may be a non-modal dialog still opened
+    */
+   virtual bool ShowHostInterface(
+      wxWindow &parent, const EffectDialogFactory &factory,
+      bool forceModal = false
+   ) = 0;
 };
 
 #endif

--- a/src/PluginInterface.h
+++ b/src/PluginInterface.h
@@ -42,15 +42,43 @@
 #ifndef __AUDACITY_PLUGININTERFACE_H__
 #define __AUDACITY_PLUGININTERFACE_H__
 
-#include "ConfigInterface.h"
 #include "EffectInterface.h"
 #include "ComponentInterface.h"
 #include "Identifier.h"
 #include "ModuleInterface.h"
+#include <variant>
 
 class ModuleInterface;
 
-namespace PluginSettings { enum ConfigurationType : unsigned; }
+namespace PluginSettings {
+
+enum ConfigurationType : unsigned {
+   Shared, Private
+};
+
+//! Supported types for settings
+using ConfigValueTypes = std::tuple<
+     wxString
+   , int
+   , bool
+   , float
+   , double
+>;
+
+//! Define a reference to a variable of one of the types in ConfigValueTypes
+/*! Avoid repetition of the list of types */
+template<bool is_const, typename> struct ConfigReferenceGenerator;
+template<bool is_const, typename... Types>
+struct ConfigReferenceGenerator<is_const, std::tuple<Types...>> {
+   using type = std::variant< std::reference_wrapper<
+      std::conditional_t<is_const, const Types, Types> >... >;
+};
+using ConfigReference =
+   ConfigReferenceGenerator<false, ConfigValueTypes>::type;
+using ConfigConstReference =
+   ConfigReferenceGenerator<true, ConfigValueTypes>::type;
+
+}
 
 class AUDACITY_DLL_API PluginManagerInterface /* not final */
 {

--- a/src/commands/AudacityCommand.cpp
+++ b/src/commands/AudacityCommand.cpp
@@ -69,7 +69,6 @@ AudacityCommand::AudacityCommand()
    mProgress = NULL;
    mUIParent = NULL;
    mUIDialog = NULL;
-   mUIDebug = false;
    mIsBatch = false;
    mNeedsInit = true;
 }

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -32,7 +32,6 @@ class ShuttleGui;
 class AudacityCommand;
 class AudacityProject;
 class CommandContext;
-class EffectUIHostInterface;
 class ProgressDialog;
 
 
@@ -72,7 +71,6 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
    virtual bool Apply(const CommandContext & WXUNUSED(context) ) {return false;};
 
    bool ShowInterface(wxWindow *parent, bool forceModal = false);
-   virtual void SetHostUI(EffectUIHostInterface * WXUNUSED(host)){;};
 
    wxDialog *CreateUI(wxWindow *parent, AudacityCommand *client);
 

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -127,7 +127,6 @@ protected:
    // UI
    wxDialog       *mUIDialog;
    wxWindow       *mUIParent;
-   int             mUIResultID;
 
 private:
    bool mIsBatch;

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -130,7 +130,6 @@ protected:
 
 private:
    bool mIsBatch;
-   bool mUIDebug;
    bool mNeedsInit;
 };
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -617,10 +617,6 @@ bool Effect::LoadFactoryDefaults()
 
 // EffectUIClientInterface implementation
 
-void Effect::SetHostUI(EffectUIHostInterface *WXUNUSED(host))
-{
-}
-
 bool Effect::PopulateUI(ShuttleGui &S)
 {
    auto parent = S.GetParent();

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -502,7 +502,7 @@ bool Effect::ShowInterface(wxWindow &parent,
    auto cleanup = valueRestorer( mUIDialog );
    
    if ( factory )
-      mUIDialog = factory(parent, this, this);
+      mUIDialog = factory(parent, *this, *this);
    if (!mUIDialog)
    {
       return false;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -478,7 +478,7 @@ bool Effect::RealtimeProcessEnd()
    return true;
 }
 
-bool Effect::ShowClientInterface(
+int Effect::ShowClientInterface(
    wxWindow &parent, wxDialog &dialog, bool forceModal)
 {
    // Remember the dialog with a weak pointer, but don't control its lifetime
@@ -489,24 +489,24 @@ bool Effect::ShowClientInterface(
 
    auto hook = GetVetoDialogHook();
    if( hook && hook( mUIDialog ) )
-      return false;
+      return 0;
 
    if( SupportsRealtime() && !forceModal )
    {
       mUIDialog->Show();
       // Return false to bypass effect processing
-      return false;
+      return 0;
    }
 
-   return mUIDialog->ShowModal() != 0;
+   return mUIDialog->ShowModal();
 }
 
-bool Effect::ShowHostInterface(wxWindow &parent,
+int Effect::ShowHostInterface(wxWindow &parent,
    const EffectDialogFactory &factory, bool forceModal)
 {
    if (!IsInteractive())
       // Effect without UI just proceeds quietly to apply it destructively.
-      return true;
+      return wxID_APPLY;
 
    if (mHostUIDialog)
    {
@@ -514,7 +514,7 @@ bool Effect::ShowHostInterface(wxWindow &parent,
       // nothing else.
       if ( mHostUIDialog->Close(true) )
          mHostUIDialog = nullptr;
-      return false;
+      return 0;
    }
 
    // Create the dialog
@@ -526,7 +526,7 @@ bool Effect::ShowHostInterface(wxWindow &parent,
    const auto client = mClient ? mClient : this;
    mHostUIDialog = factory(parent, *this, *client);
    if (!mHostUIDialog)
-      return false;
+      return 0;
 
    // Let the client show the dialog and decide whether to keep it open
    auto result = client->ShowClientInterface(parent, *mHostUIDialog, forceModal);

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -888,7 +888,7 @@ wxString Effect::GetSavedStateGroup()
 
 // Effect implementation
 
-bool Effect::Startup(EffectClientInterface *client)
+bool Effect::Startup(EffectUIClientInterface *client)
 {
    // Let destructor know we need to be shutdown
    mClient = client;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -108,8 +108,6 @@ Effect::Effect()
    mBlockSize = 0;
    mNumChannels = 0;
 
-   mUIDebug = false;
-
    // PRL:  I think this initialization of mProjectRate doesn't matter
    // because it is always reassigned in DoEffect before it is used
    // STF: but can't call AudioIOBase::GetOptimalSupportedSampleRate() here.
@@ -1858,11 +1856,6 @@ bool Effect::EnablePreview(bool enable)
    }
 
    return enable;
-}
-
-void Effect::EnableDebug(bool enable)
-{
-   mUIDebug = enable;
 }
 
 void Effect::SetLinearEffectFlag(bool linearEffectFlag)

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -143,7 +143,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
                                        size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowClientInterface(
+   int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal = false) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;
@@ -190,7 +190,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    // EffectUIHostInterface implementation
 
-   bool ShowHostInterface( wxWindow &parent,
+   int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory, bool forceModal = false) override;
 
    // Effect implementation
@@ -446,7 +446,6 @@ protected:
    //! This weak pointer may be the same as the above, or null
    wxWeakRef<wxDialog> mUIDialog;
    wxWindow       *mUIParent;
-   int            mUIResultID;
    unsigned       mUIFlags;
 
    sampleCount    mSampleCnt;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -67,7 +67,6 @@ class WaveTrack;
 // TODO:  can't be done until after all effects are using the NEW API.
 
 class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
-                                public EffectClientInterface,
                                 public EffectUIClientInterface,
                                 public EffectHostInterface
 {
@@ -190,7 +189,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // Effect implementation
 
    // NEW virtuals
-   virtual bool Startup(EffectClientInterface *client);
+   virtual bool Startup(EffectUIClientInterface *client);
    virtual bool Startup();
 
    virtual bool GetAutomationParameters(wxString & parms);
@@ -487,7 +486,7 @@ private:
    int mNumGroups;
 
    // For client driver
-   EffectClientInterface *mClient;
+   EffectUIClientInterface *mClient;
    size_t mNumAudioIn;
    size_t mNumAudioOut;
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -291,7 +291,6 @@ protected:
    virtual bool TransferDataFromWindow() /* not override */;
    virtual bool EnableApply(bool enable = true);
    virtual bool EnablePreview(bool enable = true);
-   virtual void EnableDebug(bool enable = true);
 
    // No more virtuals!
 
@@ -484,8 +483,6 @@ private:
    NumericFormatSymbol mDurationFormat;
 
    bool mIsPreview;
-
-   bool mUIDebug;
 
    std::vector<Track*> mIMap;
    std::vector<Track*> mOMap;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -156,7 +156,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    // EffectUIClientInterface implementation
 
-   void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) final;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -319,7 +319,7 @@ bool EffectManager::PromptUser(
    {
       //! Show the effect dialog, only so that the user can choose settings.
       result = effect->ShowHostInterface(
-         parent, factory, effect->IsBatchProcessing() );
+         parent, factory, effect->IsBatchProcessing() ) != 0;
       return result;
    }
 

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -305,6 +305,10 @@ bool EffectManager::SetEffectParameters(const PluginID & ID, const wxString & pa
    return false;
 }
 
+//! Shows an effect or command dialog so the user can specify settings for later
+/*!
+ It is used when defining a macro.  It does not invoke the effect or command.
+ */
 bool EffectManager::PromptUser(
    const PluginID & ID, const EffectDialogFactory &factory, wxWindow &parent)
 {
@@ -313,7 +317,8 @@ bool EffectManager::PromptUser(
 
    if (effect)
    {
-      result = effect->ShowInterface(
+      //! Show the effect dialog, only so that the user can choose settings.
+      result = effect->ShowHostInterface(
          parent, factory, effect->IsBatchProcessing() );
       return result;
    }

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -306,8 +306,7 @@ bool EffectManager::SetEffectParameters(const PluginID & ID, const wxString & pa
 }
 
 bool EffectManager::PromptUser(
-   const PluginID & ID,
-   const EffectClientInterface::EffectDialogFactory &factory, wxWindow &parent)
+   const PluginID & ID, const EffectDialogFactory &factory, wxWindow &parent)
 {
    bool result = false;
    Effect *effect = GetEffect(ID);
@@ -735,7 +734,7 @@ Effect *EffectManager::GetEffect(const PluginID & ID)
       auto effect = std::make_shared<Effect>(); // TODO: use make_unique and store in std::unordered_map
       if (effect)
       {
-         EffectClientInterface *client = dynamic_cast<EffectClientInterface *>(ident);
+         const auto client = dynamic_cast<EffectUIClientInterface *>(ident);
          if (client && effect->Startup(client))
          {
             auto pEffect = effect.get();

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -106,8 +106,7 @@ public:
    bool SupportsAutomation(const PluginID & ID);
    wxString GetEffectParameters(const PluginID & ID);
    bool SetEffectParameters(const PluginID & ID, const wxString & params);
-   bool PromptUser( const PluginID & ID,
-      const EffectClientInterface::EffectDialogFactory &factory,
+   bool PromptUser( const PluginID & ID, const EffectDialogFactory &factory,
       wxWindow &parent );
    bool HasPresets(const PluginID & ID);
    wxString GetPreset(const PluginID & ID, const wxString & params, wxWindow * parent);

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -17,6 +17,7 @@
 
 #include <unordered_map>
 #include "EffectInterface.h"
+#include "EffectHostInterface.h" // for EffectDialogFactory
 #include "Identifier.h"
 
 class AudacityCommand;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -753,7 +753,6 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
    mEnabled = true;
    
    mPlayPos = 0.0;
-   mClient->SetHostUI(this);
 }
 
 EffectUIHost::EffectUIHost(wxWindow *parent,
@@ -787,7 +786,6 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
    mEnabled = true;
    
    mPlayPos = 0.0;
-   mClient->SetHostUI(this);
 }
 
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1006,9 +1006,8 @@ bool EffectUIHost::Initialize()
             this->SetAcceleratorTable(accel);
          }
 
-         if (mEffect.mUIDebug) {
+         if (mEffect.EnablesDebug())
             buttons |= eDebugButton;
-         }
 
          S.AddStandardButtons(buttons, bar);
       }

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -382,7 +382,7 @@ void EffectRack::OnEditor(wxCommandEvent & evt)
    }
 
    auto pEffect = mEffects[index];
-   pEffect->ShowInterface( *GetParent(), EffectUI::DialogFactory,
+   pEffect->ShowHostInterface( *GetParent(), EffectUI::DialogFactory,
       pEffect->IsBatchProcessing() );
 }
 
@@ -957,11 +957,14 @@ bool EffectUIHost::Initialize()
       mCapturing = gAudioIO->IsStreamActive() && gAudioIO->GetNumCaptureChannels() > 0 && !gAudioIO->IsMonitoring();
    }
 
+   // Build a "host" dialog, framing a panel that the client fills in.
+   // The frame includes buttons to preview, apply, load and save presets, etc.
    EffectPanel *w {};
    ShuttleGui S{ this, eIsCreating };
    {
       S.StartHorizontalLay( wxEXPAND );
       {
+         // Make the panel for the client
          Destroy_ptr<EffectPanel> uw{ safenew EffectPanel( S.GetParent() ) };
          RTL_WORKAROUND(uw.get());
 
@@ -969,6 +972,7 @@ bool EffectUIHost::Initialize()
          uw->SetMinSize(wxSize(wxMax(600, mParent->GetSize().GetWidth() * 2 / 3),
             mParent->GetSize().GetHeight() / 2));
 
+         // Let the client add things to the panel
          ShuttleGui S1{ uw.get(), eIsCreating };
          if (!mClient.PopulateUI(S1))
          {

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1126,13 +1126,11 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
       return;
    }
    
-   mEffect.mUIResultID = evt.GetId();
-   
    if (IsModal())
    {
       mDismissed = true;
       
-      EndModal(true);
+      EndModal(evt.GetId());
       
       Close();
       
@@ -1155,10 +1153,8 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
 void EffectUIHost::DoCancel()
 {
    if (!mDismissed) {
-      mEffect.mUIResultID = wxID_CANCEL;
-      
       if (IsModal())
-         EndModal(false);
+         EndModal(0);
       else
          Hide();
       
@@ -1188,7 +1184,6 @@ void EffectUIHost::OnHelp(wxCommandEvent & WXUNUSED(event))
 void EffectUIHost::OnDebug(wxCommandEvent & evt)
 {
    OnApply(evt);
-   mEffect.mUIResultID = evt.GetId();
 }
 
 void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
@@ -2059,7 +2054,7 @@ void EffectDialog::OnOk(wxCommandEvent & WXUNUSED(evt))
    // been corrected in wx3.
    if (FindWindow(wxID_OK)->IsEnabled() && Validate() && TransferDataFromWindow())
    {
-      EndModal(true);
+      EndModal(wxID_OK);
    }
 
    return;

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -118,8 +118,7 @@ class Effect;
 class wxCheckBox;
 
 //
-class EffectUIHost final : public wxDialogWrapper,
-                     public EffectUIHostInterface
+class EffectUIHost final : public wxDialogWrapper
 {
 public:
    // constructors and destructors

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -124,12 +124,8 @@ public:
    // constructors and destructors
    EffectUIHost(wxWindow *parent,
                 AudacityProject &project,
-                Effect *effect,
-                EffectUIClientInterface *client);
-   EffectUIHost(wxWindow *parent,
-                AudacityProject &project,
-                AudacityCommand *command,
-                EffectUIClientInterface *client);
+                Effect &effect,
+                EffectUIClientInterface &client);
    virtual ~EffectUIHost();
 
    bool TransferDataToWindow() override;
@@ -178,9 +174,8 @@ private:
 private:
    AudacityProject *mProject;
    wxWindow *mParent;
-   Effect *mEffect;
-   AudacityCommand * mCommand;
-   EffectUIClientInterface *mClient;
+   Effect &mEffect;
+   EffectUIClientInterface &mClient;
 
    RegistryPaths mUserPresets;
    bool mInitialized;
@@ -224,8 +219,8 @@ class CommandContext;
 namespace  EffectUI {
 
    AUDACITY_DLL_API
-   wxDialog *DialogFactory( wxWindow &parent, EffectHostInterface *pHost,
-      EffectUIClientInterface *client);
+   wxDialog *DialogFactory( wxWindow &parent, EffectHostInterface &host,
+      EffectUIClientInterface &client);
 
    /** Run an effect given the plugin ID */
    // Returns true on success.  Will only operate on tracks that

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -446,7 +446,12 @@ bool EffectNoiseReduction::CheckWhetherSkipEffect()
    return false;
 }
 
-bool EffectNoiseReduction::ShowInterface(
+//! An override still here for historical reasons, ignoring the factory
+/*! We would like to make this effect behave more like others, but it does have
+ its unusual two-pass nature.  First choose and analyze an example of noise,
+ then apply noise reduction to another selection.  That is difficult to fit into
+ the framework for managing settings of other effects. */
+bool EffectNoiseReduction::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &, bool forceModal)
 {
    // to do: use forceModal correctly

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -211,7 +211,7 @@ public:
    Settings();
    ~Settings() {}
 
-   bool PromptUser(EffectNoiseReduction *effect,
+   int PromptUser(EffectNoiseReduction *effect,
       wxWindow &parent, bool bHasProfile, bool bAllowTwiddleSettings);
    bool PrefsIO(bool read);
    bool Validate(EffectNoiseReduction *effect) const;
@@ -451,7 +451,7 @@ bool EffectNoiseReduction::CheckWhetherSkipEffect()
  its unusual two-pass nature.  First choose and analyze an example of noise,
  then apply noise reduction to another selection.  That is difficult to fit into
  the framework for managing settings of other effects. */
-bool EffectNoiseReduction::ShowHostInterface(
+int EffectNoiseReduction::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &, bool forceModal)
 {
    // to do: use forceModal correctly
@@ -464,7 +464,7 @@ bool EffectNoiseReduction::ShowHostInterface(
       bool(mStatistics), forceModal);
 }
 
-bool EffectNoiseReduction::Settings::PromptUser
+int EffectNoiseReduction::Settings::PromptUser
 (EffectNoiseReduction *effect, wxWindow &parent,
  bool bHasProfile, bool bAllowTwiddleSettings)
 {
@@ -474,13 +474,16 @@ bool EffectNoiseReduction::Settings::PromptUser
    dlog.CentreOnParent();
    dlog.ShowModal();
 
-   if (dlog.GetReturnCode() == 0)
+   const auto returnCode = dlog.GetReturnCode();
+   if (!returnCode)
       return false;
 
    *this = dlog.GetTempSettings();
-   mDoProfile = (dlog.GetReturnCode() == 1);
+   mDoProfile = (returnCode == 1);
 
-   return PrefsIO(false);
+   if (!PrefsIO(false))
+      return 0;
+   return returnCode;
 }
 
 namespace {

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -37,7 +37,7 @@ public:
 
 //   using Effect::TrackProgress;
 
-   bool ShowHostInterface( wxWindow &parent,
+   int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory, bool forceModal = false) override;
 
    bool Init() override;

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -37,7 +37,7 @@ public:
 
 //   using Effect::TrackProgress;
 
-   bool ShowInterface( wxWindow &parent,
+   bool ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory, bool forceModal = false) override;
 
    bool Init() override;

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -153,7 +153,12 @@ bool EffectNoiseRemoval::CheckWhetherSkipEffect()
    return (mLevel == 0);
 }
 
-bool EffectNoiseRemoval::ShowInterface(
+//! An override still here for historical reasons, ignoring the factory
+/*! We would like to make this effect behave more like others, but it does have
+ its unusual two-pass nature.  First choose and analyze an example of noise,
+ then apply noise reduction to another selection.  That is difficult to fit into
+ the framework for managing settings of other effects. */
+bool EffectNoiseRemoval::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &, bool forceModal )
 {
    // to do: use forceModal correctly

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -158,7 +158,7 @@ bool EffectNoiseRemoval::CheckWhetherSkipEffect()
  its unusual two-pass nature.  First choose and analyze an example of noise,
  then apply noise reduction to another selection.  That is difficult to fit into
  the framework for managing settings of other effects. */
-bool EffectNoiseRemoval::ShowHostInterface(
+int EffectNoiseRemoval::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &, bool forceModal )
 {
    // to do: use forceModal correctly
@@ -188,9 +188,9 @@ bool EffectNoiseRemoval::ShowHostInterface(
    dlog.CentreOnParent();
    dlog.ShowModal();
 
-   if (dlog.GetReturnCode() == 0) {
-      return false;
-   }
+   const auto returnCode = dlog.GetReturnCode();
+   if (!returnCode)
+      return 0;
 
    mSensitivity = dlog.mSensitivity;
    mNoiseGain = -dlog.mGain;
@@ -205,7 +205,9 @@ bool EffectNoiseRemoval::ShowHostInterface(
    gPrefs->Write(wxT("/Effects/NoiseRemoval/NoiseLeaveNoise"), mbLeaveNoise);
 
    mDoProfile = (dlog.GetReturnCode() == 1);
-   return gPrefs->Flush();
+   if (!gPrefs->Flush())
+      return 0;
+   return returnCode;
 }
 
 bool EffectNoiseRemoval::Process()

--- a/src/effects/NoiseRemoval.h
+++ b/src/effects/NoiseRemoval.h
@@ -51,7 +51,7 @@ public:
 
    // Effect implementation
 
-   bool ShowHostInterface( wxWindow &parent,
+   int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory, bool forceModal = false) override;
    bool Init() override;
    bool CheckWhetherSkipEffect() override;

--- a/src/effects/NoiseRemoval.h
+++ b/src/effects/NoiseRemoval.h
@@ -51,7 +51,7 @@ public:
 
    // Effect implementation
 
-   bool ShowInterface( wxWindow &parent,
+   bool ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory, bool forceModal = false) override;
    bool Init() override;
    bool CheckWhetherSkipEffect() override;

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -110,20 +110,20 @@ bool RealtimeEffectManager::RealtimeIsSuspended()
    return mRealtimeSuspended;
 }
 
-void RealtimeEffectManager::RealtimeAddEffect(EffectClientInterface *effect)
+void RealtimeEffectManager::RealtimeAddEffect(EffectClientInterface &effect)
 {
    // Block RealtimeProcess()
    RealtimeSuspend();
 
    // Add to list of active effects
-   mStates.emplace_back( std::make_unique< RealtimeEffectState >( *effect ) );
+   mStates.emplace_back( std::make_unique< RealtimeEffectState >( effect ) );
    auto &state = mStates.back();
 
    // Initialize effect if realtime is already active
    if (mRealtimeActive)
    {
       // Initialize realtime processing
-      effect->RealtimeInitialize();
+      effect.RealtimeInitialize();
 
       // Add the required processors
       for (size_t i = 0, cnt = mRealtimeChans.size(); i < cnt; i++)
@@ -137,7 +137,7 @@ void RealtimeEffectManager::RealtimeAddEffect(EffectClientInterface *effect)
    RealtimeResume();
 }
 
-void RealtimeEffectManager::RealtimeRemoveEffect(EffectClientInterface *effect)
+void RealtimeEffectManager::RealtimeRemoveEffect(EffectClientInterface &effect)
 {
    // Block RealtimeProcess()
    RealtimeSuspend();
@@ -145,14 +145,14 @@ void RealtimeEffectManager::RealtimeRemoveEffect(EffectClientInterface *effect)
    if (mRealtimeActive)
    {
       // Cleanup realtime processing
-      effect->RealtimeFinalize();
+      effect.RealtimeFinalize();
    }
       
    // Remove from list of active effects
    auto end = mStates.end();
    auto found = std::find_if( mStates.begin(), end,
       [&](const decltype(mStates)::value_type &state){
-         return &state->GetEffect() == effect;
+         return &state->GetEffect() == &effect;
       }
    );
    if (found != end)

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -29,8 +29,8 @@ public:
    // Realtime effect processing
    bool RealtimeIsActive();
    bool RealtimeIsSuspended();
-   void RealtimeAddEffect(EffectClientInterface *effect);
-   void RealtimeRemoveEffect(EffectClientInterface *effect);
+   void RealtimeAddEffect(EffectClientInterface &effect);
+   void RealtimeRemoveEffect(EffectClientInterface &effect);
    void RealtimeSetEffects(const EffectArray & mActive);
    void RealtimeInitialize(double rate);
    void RealtimeAddProcessor(int group, unsigned chans, float rate);

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1633,7 +1633,7 @@ bool VSTEffect::ShowInterface(
    }
 
    if ( factory )
-      mDialog = factory(parent, mHost, this);
+      mDialog = factory(parent, *mHost, *this);
    if (!mDialog)
    {
       return false;

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1763,11 +1763,6 @@ bool VSTEffect::LoadFactoryDefaults()
 // EffectUIClientInterface implementation
 // ============================================================================
 
-void VSTEffect::SetHostUI(EffectUIHostInterface *host)
-{
-   mUIHost = host;
-}
-
 bool VSTEffect::PopulateUI(ShuttleGui &S)
 {
    auto parent = S.GetParent();
@@ -1849,7 +1844,6 @@ bool VSTEffect::CloseUI()
    mDisplays.reset();
    mLabels.reset();
 
-   mUIHost = NULL;
    mParent = NULL;
    mDialog = NULL;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1602,7 +1602,7 @@ bool VSTEffect::RealtimeProcessEnd()
 /// provided by the effect, so it will not work with all effects since they don't
 /// all provide the information (kn0ck0ut is one).
 ///
-bool VSTEffect::ShowClientInterface(
+int VSTEffect::ShowClientInterface(
    wxWindow &parent, wxDialog &dialog, bool forceModal)
 {
    //   mProcessLevel = 1;      // in GUI thread
@@ -1623,10 +1623,10 @@ bool VSTEffect::ShowClientInterface(
    if (SupportsRealtime() && !forceModal)
    {
       mDialog->Show();
-      return false;
+      return 0;
    }
 
-   return mDialog->ShowModal() != 0;
+   return mDialog->ShowModal();
 }
 
 bool VSTEffect::GetAutomationParameters(CommandParameters & parms)

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1144,7 +1144,6 @@ VSTEffect::VSTEffect(const PluginPath & path, VSTEffect *master)
    mHost = NULL;
    mModule = NULL;
    mAEffect = NULL;
-   mDialog = NULL;
 
    mTimer = std::make_unique<VSTEffectTimer>(this);
    mTimerGuard = 0;
@@ -1187,11 +1186,6 @@ VSTEffect::VSTEffect(const PluginPath & path, VSTEffect *master)
 
 VSTEffect::~VSTEffect()
 {
-   if (mDialog)
-   {
-      mDialog->Close();
-   }
-
    Unload();
 }
 
@@ -1608,19 +1602,9 @@ bool VSTEffect::RealtimeProcessEnd()
 /// provided by the effect, so it will not work with all effects since they don't
 /// all provide the information (kn0ck0ut is one).
 ///
-bool VSTEffect::ShowInterface(
-   wxWindow &parent, const EffectDialogFactory &factory, bool forceModal)
+bool VSTEffect::ShowClientInterface(
+   wxWindow &parent, wxDialog &dialog, bool forceModal)
 {
-   if (mDialog)
-   {
-      if ( mDialog->Close(true) )
-         mDialog = nullptr;
-      return false;
-   }
-
-   // mDialog is null
-   auto cleanup = valueRestorer( mDialog );
-
    //   mProcessLevel = 1;      // in GUI thread
 
    // Set some defaults since some VSTs need them...these will be reset when
@@ -1632,25 +1616,17 @@ bool VSTEffect::ShowInterface(
       ProcessInitialize(0, NULL);
    }
 
-   if ( factory )
-      mDialog = factory(parent, *mHost, *this);
-   if (!mDialog)
-   {
-      return false;
-   }
+   // Remember the dialog with a weak pointer, but don't control its lifetime
+   mDialog = &dialog;
    mDialog->CentreOnParent();
 
    if (SupportsRealtime() && !forceModal)
    {
       mDialog->Show();
-      cleanup.release();
-
       return false;
    }
 
-   bool res = mDialog->ShowModal() != 0;
-
-   return res;
+   return mDialog->ShowModal() != 0;
 }
 
 bool VSTEffect::GetAutomationParameters(CommandParameters & parms)

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -149,7 +149,7 @@ class VSTEffect final : public wxEvtHandler,
                                        size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowClientInterface(
+   int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -18,6 +18,7 @@
 
 #include "SampleFormat.h"
 #include "XMLTagHandler.h"
+#include <wx/weakref.h>
 
 class wxSizerItem;
 class wxSlider;
@@ -148,8 +149,8 @@ class VSTEffect final : public wxEvtHandler,
                                        size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, bool forceModal = false) override;
+   bool ShowClientInterface(
+      wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
@@ -366,7 +367,7 @@ private:
    size_t mNumSamples;
 
    // UI
-   wxDialog *mDialog;
+   wxWeakRef<wxDialog> mDialog;
    wxWindow *mParent;
    wxSizerItem *mContainer;
    bool mGui;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -164,7 +164,6 @@ class VSTEffect final : public wxEvtHandler,
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
-   void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) override;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
@@ -369,7 +368,6 @@ private:
    // UI
    wxDialog *mDialog;
    wxWindow *mParent;
-   EffectUIHostInterface *mUIHost;
    wxSizerItem *mContainer;
    bool mGui;
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -90,7 +90,6 @@ DECLARE_LOCAL_EVENT_TYPE(EVT_UPDATEDISPLAY, -1);
 ///
 ///////////////////////////////////////////////////////////////////////////////
 class VSTEffect final : public wxEvtHandler,
-                  public EffectClientInterface,
                   public EffectUIClientInterface,
                   public XMLTagHandler,
                   public VSTEffectLink
@@ -118,8 +117,6 @@ class VSTEffect final : public wxEvtHandler,
    bool SupportsAutomation() override;
 
    // EffectClientInterface implementation
-
-   bool SetHost(EffectHostInterface *host) override;
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
@@ -166,6 +163,7 @@ class VSTEffect final : public wxEvtHandler,
 
    // EffectUIClientInterface implementation
 
+   bool SetHost(EffectHostInterface *host) override;
    void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) override;
    bool IsGraphicalUI() override;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -849,7 +849,6 @@ AudioUnitEffect::AudioUnitEffect(const PluginPath & path,
    mInteractive = false;
    mIsGraphical = false;
 
-   mUIHost = NULL;
    mDialog = NULL;
    mParent = NULL;
 
@@ -1721,11 +1720,6 @@ RegistryPaths AudioUnitEffect::GetFactoryPresets()
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-void AudioUnitEffect::SetHostUI(EffectUIHostInterface *host)
-{
-   mUIHost = host;
-}
-
 bool AudioUnitEffect::PopulateUI(ShuttleGui &S)
 {
    // OSStatus result;
@@ -1847,7 +1841,6 @@ bool AudioUnitEffect::CloseUI()
    }
 #endif
 
-   mUIHost = NULL;
    mParent = NULL;
    mDialog = NULL;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -849,7 +849,6 @@ AudioUnitEffect::AudioUnitEffect(const PluginPath & path,
    mInteractive = false;
    mIsGraphical = false;
 
-   mDialog = NULL;
    mParent = NULL;
 
    mUnitInitialized = false;
@@ -1470,43 +1469,18 @@ bool AudioUnitEffect::RealtimeProcessEnd()
    return true;
 }
 
-bool AudioUnitEffect::ShowInterface(wxWindow &parent,
-                                    const EffectDialogFactory &factory,
-                                    bool forceModal)
+bool AudioUnitEffect::ShowClientInterface(
+   wxWindow &parent, wxDialog &dialog, bool forceModal)
 {
-   if (mDialog)
-   {
-      if (mDialog->Close(true))
-      {
-         mDialog = nullptr;
-      }
-      return false;
-   }
-
-   // mDialog is null
-   auto cleanup = valueRestorer(mDialog);
-
-   if (factory)
-   {
-      mDialog = factory(parent, *mHost, *this);
-   }
-
-   if (!mDialog)
-   {
-      return false;
-   }
-
+   // Remember the dialog with a weak pointer, but don't control its lifetime
+   mDialog = &dialog;
    if ((SupportsRealtime() || GetType() == EffectTypeAnalyze) && !forceModal)
    {
       mDialog->Show();
-      cleanup.release();
-
       return false;
    }
 
-   bool res = mDialog->ShowModal() != 0;
-
-   return res;
+   return mDialog->ShowModal() != 0;
 }
 
 bool AudioUnitEffect::GetAutomationParameters(CommandParameters & parms)

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1488,7 +1488,7 @@ bool AudioUnitEffect::ShowInterface(wxWindow &parent,
 
    if (factory)
    {
-      mDialog = factory(parent, mHost, this);
+      mDialog = factory(parent, *mHost, *this);
    }
 
    if (!mDialog)

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1469,7 +1469,7 @@ bool AudioUnitEffect::RealtimeProcessEnd()
    return true;
 }
 
-bool AudioUnitEffect::ShowClientInterface(
+int AudioUnitEffect::ShowClientInterface(
    wxWindow &parent, wxDialog &dialog, bool forceModal)
 {
    // Remember the dialog with a weak pointer, but don't control its lifetime
@@ -1477,10 +1477,10 @@ bool AudioUnitEffect::ShowClientInterface(
    if ((SupportsRealtime() || GetType() == EffectTypeAnalyze) && !forceModal)
    {
       mDialog->Show();
-      return false;
+      return 0;
    }
 
-   return mDialog->ShowModal() != 0;
+   return mDialog->ShowModal();
 }
 
 bool AudioUnitEffect::GetAutomationParameters(CommandParameters & parms)

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -98,7 +98,7 @@ public:
                                        size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowClientInterface(
+   int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -38,7 +38,6 @@ class AudioUnitEffectExportDialog;
 class AudioUnitEffectImportDialog;
 
 class AudioUnitEffect : public wxEvtHandler,
-                        public EffectClientInterface,
                         public EffectUIClientInterface
 {
 public:
@@ -67,8 +66,6 @@ public:
    bool SupportsAutomation() override;
 
    // EffectClientInterface implementation
-
-   bool SetHost(EffectHostInterface *host) override;
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
@@ -115,6 +112,7 @@ public:
 
    // EffectUIClientInterface implementation
 
+   bool SetHost(EffectHostInterface *host) override;
    void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) override;
    bool IsGraphicalUI() override;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -113,7 +113,6 @@ public:
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
-   void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) override;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
@@ -201,7 +200,6 @@ private:
    ArrayOf<AudioBufferList> mInputList;
    ArrayOf<AudioBufferList> mOutputList;
 
-   EffectUIHostInterface *mUIHost;
    wxWindow *mParent;
    wxDialog *mDialog;
    wxString mUIType; // NOT translated, "Full", "Generic", or "Basic"

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -26,6 +26,7 @@
 #include "PluginInterface.h"
 
 #include "AUControl.h"
+#include <wx/weakref.h>
 
 #define AUDIOUNITEFFECTS_VERSION wxT("1.0.0.0")
 /* i18n-hint: the name of an Apple audio software protocol */
@@ -97,8 +98,8 @@ public:
                                        size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, bool forceModal = false) override;
+   bool ShowClientInterface(
+      wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
@@ -201,7 +202,7 @@ private:
    ArrayOf<AudioBufferList> mOutputList;
 
    wxWindow *mParent;
-   wxDialog *mDialog;
+   wxWeakRef<wxDialog> mDialog;
    wxString mUIType; // NOT translated, "Full", "Generic", or "Basic"
    bool mIsGraphical;
 

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1188,11 +1188,6 @@ bool LadspaEffect::LoadFactoryDefaults()
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-void LadspaEffect::SetHostUI(EffectUIHostInterface *host)
-{
-   mUIHost = host;
-}
-
 bool LadspaEffect::PopulateUI(ShuttleGui &S)
 {
    auto parent = S.GetParent();
@@ -1545,7 +1540,6 @@ bool LadspaEffect::CloseUI()
    mFields.reset();
    mLabels.reset();
 
-   mUIHost = NULL;
    mParent = NULL;
    mDialog = NULL;
 

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1067,7 +1067,7 @@ bool LadspaEffect::RealtimeProcessEnd()
    return true;
 }
 
-bool LadspaEffect::ShowClientInterface(
+int LadspaEffect::ShowClientInterface(
    wxWindow &parent, wxDialog &dialog, bool forceModal)
 {
    // Remember the dialog with a weak pointer, but don't control its lifetime
@@ -1079,10 +1079,10 @@ bool LadspaEffect::ShowClientInterface(
    if ((SupportsRealtime() || GetType() == EffectTypeAnalyze) && !forceModal)
    {
       mDialog->Show();
-      return false;
+      return 0;
    }
 
-   return mDialog->ShowModal() != 0;
+   return mDialog->ShowModal();
 }
 
 bool LadspaEffect::GetAutomationParameters(CommandParameters & parms)

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1082,7 +1082,7 @@ bool LadspaEffect::ShowInterface(
    auto cleanup = valueRestorer( mDialog );
 
    if ( factory )
-      mDialog = factory(parent, mHost, this);
+      mDialog = factory(parent, *mHost, *this);
    if (!mDialog)
    {
       return false;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -40,7 +40,6 @@ class NumericTextCtrl;
 class LadspaEffectMeter;
 
 class LadspaEffect final : public wxEvtHandler,
-                     public EffectClientInterface,
                      public EffectUIClientInterface
 {
 public:
@@ -66,8 +65,6 @@ public:
    bool SupportsAutomation() override;
 
    // EffectClientInterface implementation
-
-   bool SetHost(EffectHostInterface *host) override;
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
@@ -114,6 +111,7 @@ public:
 
    // EffectUIClientInterface implementation
 
+   bool SetHost(EffectHostInterface *host) override;
    void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) override;
    bool IsGraphicalUI() override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -17,6 +17,7 @@ class NumericTextCtrl;
 
 #include <wx/dynlib.h> // member variable
 #include <wx/event.h> // to inherit
+#include <wx/weakref.h>
 
 #include "EffectInterface.h"
 #include "ModuleInterface.h"
@@ -96,8 +97,8 @@ public:
                                        size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, bool forceModal = false) override;
+   bool ShowClientInterface(
+      wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
@@ -181,7 +182,7 @@ private:
    std::vector<LADSPA_Handle> mSlaves;
 
    NumericTextCtrl *mDuration;
-   wxDialog *mDialog;
+   wxWeakRef<wxDialog> mDialog;
    wxWindow *mParent;
    ArrayOf<wxSlider*> mSliders;
    ArrayOf<wxTextCtrl*> mFields;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -97,7 +97,7 @@ public:
                                        size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowClientInterface(
+   int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -112,7 +112,6 @@ public:
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
-   void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) override;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
@@ -180,8 +179,6 @@ private:
 
    // Realtime processing
    std::vector<LADSPA_Handle> mSlaves;
-
-   EffectUIHostInterface *mUIHost;
 
    NumericTextCtrl *mDuration;
    wxDialog *mDialog;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1563,11 +1563,6 @@ bool LV2Effect::SetAutomationParameters(CommandParameters &parms)
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-void LV2Effect::SetHostUI(EffectUIHostInterface *host)
-{
-   mUIHost = host;
-}
-
 bool LV2Effect::PopulateUI(ShuttleGui &S)
 {
    auto parent = S.GetParent();
@@ -1677,7 +1672,6 @@ bool LV2Effect::CloseUI()
       mMaster = NULL;
    }
 
-   mUIHost = NULL;
    mParent = NULL;
    mDialog = NULL;
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1475,7 +1475,7 @@ bool LV2Effect::ShowInterface(
    auto cleanup = valueRestorer(mDialog);
 
    if ( factory )
-      mDialog = factory(parent, mHost, this);
+      mDialog = factory(parent, *mHost, *this);
    if (!mDialog)
    {
       return false;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1457,7 +1457,7 @@ bool LV2Effect::RealtimeProcessEnd()
    return true;
 }
 
-bool LV2Effect::ShowClientInterface(
+int LV2Effect::ShowClientInterface(
    wxWindow &parent, wxDialog &dialog, bool forceModal)
 {
    // Remember the dialog with a weak pointer, but don't control its lifetime
@@ -1475,10 +1475,10 @@ bool LV2Effect::ShowClientInterface(
    if ((SupportsRealtime() || GetType() == EffectTypeAnalyze) && !forceModal)
    {
       mDialog->Show();
-      return false;
+      return 0;
    }
 
-   return mDialog->ShowModal() != 0;
+   return mDialog->ShowModal();
 }
 
 bool LV2Effect::GetAutomationParameters(CommandParameters &parms)

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -253,7 +253,6 @@ class LV2Wrapper;
 using URIDMap = std::vector<MallocString<>>;
 
 class LV2Effect final : public wxEvtHandler,
-                        public EffectClientInterface,
                         public EffectUIClientInterface
 {
 public:
@@ -279,8 +278,6 @@ public:
    bool SupportsAutomation() override;
 
    // EffectClientInterface implementation
-
-   bool SetHost(EffectHostInterface *host) override;
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
@@ -317,6 +314,7 @@ public:
 
    // EffectUIClientInterface implementation
 
+   bool SetHost(EffectHostInterface *host) override;
    void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) override;
    bool IsGraphicalUI() override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -21,6 +21,7 @@ class wxArrayString;
 #include <wx/msgqueue.h>
 #include <wx/thread.h>
 #include <wx/timer.h>
+#include <wx/weakref.h>
 
 #include "lv2/atom/forge.h"
 #include "lv2/data-access/data-access.h"
@@ -306,8 +307,8 @@ public:
    size_t RealtimeProcess(int group, float **inbuf, float **outbuf, size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, bool forceModal = false) override;
+   bool ShowClientInterface(
+      wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
@@ -505,7 +506,7 @@ private:
 
    wxTimer mTimer;
 
-   wxDialog *mDialog;
+   wxWeakRef<wxDialog> mDialog;
    wxWindow *mParent;
 
    bool mUseGUI;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -307,7 +307,7 @@ public:
    size_t RealtimeProcess(int group, float **inbuf, float **outbuf, size_t numSamples) override;
    bool RealtimeProcessEnd() override;
 
-   bool ShowClientInterface(
+   int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool GetAutomationParameters(CommandParameters & parms) override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -315,7 +315,6 @@ public:
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
-   void SetHostUI(EffectUIHostInterface *host) override;
    bool PopulateUI(ShuttleGui &S) override;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
@@ -508,7 +507,6 @@ private:
 
    wxDialog *mDialog;
    wxWindow *mParent;
-   EffectUIHostInterface *mUIHost;
 
    bool mUseGUI;
 

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1009,13 +1009,13 @@ finish:
    return success;
 }
 
-bool NyquistEffect::ShowInterface(
+bool NyquistEffect::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &factory, bool forceModal)
 {
    bool res = true;
    if (!(Effect::TestUIFlags(EffectManager::kRepeatNyquistPrompt) && mIsPrompt)) {
       // Show the normal (prompt or effect) interface
-      res = Effect::ShowInterface(parent, factory, forceModal);
+      res = Effect::ShowHostInterface(parent, factory, forceModal);
    }
 
 
@@ -1041,7 +1041,7 @@ bool NyquistEffect::ShowInterface(
       effect.SetAutomationParameters(cp);
 
       // Show the normal (prompt or effect) interface
-      res = effect.ShowInterface(parent, factory, forceModal);
+      res = effect.ShowHostInterface(parent, factory, forceModal);
       if (res)
       {
          CommandParameters cp;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1071,8 +1071,11 @@ void NyquistEffect::PopulateOrExchange(ShuttleGui & S)
    {
       BuildEffectWindow(S);
    }
+}
 
-   EnableDebug(mDebugButton);
+bool NyquistEffect::EnablesDebug()
+{
+   return mDebugButton;
 }
 
 bool NyquistEffect::TransferDataToWindow()

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1009,10 +1009,10 @@ finish:
    return success;
 }
 
-bool NyquistEffect::ShowHostInterface(
+int NyquistEffect::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &factory, bool forceModal)
 {
-   bool res = true;
+   int res = wxID_APPLY;
    if (!(Effect::TestUIFlags(EffectManager::kRepeatNyquistPrompt) && mIsPrompt)) {
       // Show the normal (prompt or effect) interface
       res = Effect::ShowHostInterface(parent, factory, forceModal);
@@ -1020,7 +1020,7 @@ bool NyquistEffect::ShowHostInterface(
 
 
    // Remember if the user clicked debug
-   mDebug = (mUIResultID == eDebugID);
+   mDebug = (res == eDebugID);
 
    // We're done if the user clicked "Close", we are not the Nyquist Prompt,
    // or the program currently loaded into the prompt doesn't have a UI.
@@ -1052,7 +1052,7 @@ bool NyquistEffect::ShowHostInterface(
    else
    {
       effect.SetCommand(mInputCmd);
-      effect.mDebug = (mUIResultID == eDebugID);
+      effect.mDebug = (res == eDebugID);
       res = Delegate(effect, parent, factory);
       mT0 = effect.mT0;
       mT1 = effect.mT1;

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -102,7 +102,7 @@ public:
    bool Init() override;
    bool CheckWhetherSkipEffect() override;
    bool Process() override;
-   bool ShowHostInterface( wxWindow &parent,
+   int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory, bool forceModal = false) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool TransferDataToWindow() override;

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -89,6 +89,7 @@ public:
    EffectFamilySymbol GetFamily() override;
    bool IsInteractive() override;
    bool IsDefault() override;
+   bool EnablesDebug() override;
 
    // EffectClientInterface implementation
 

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -102,7 +102,7 @@ public:
    bool Init() override;
    bool CheckWhetherSkipEffect() override;
    bool Process() override;
-   bool ShowInterface( wxWindow &parent,
+   bool ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory, bool forceModal = false) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool TransferDataToWindow() override;


### PR DESCRIPTION
Resolves: Restructure more legacy code related to effects

Better separation of responsibilities between the common "host" dialog in EffectUI.cpp, and the "client" plug-ins that only decorate a panel on the dialog.  The "client" can tell the host whether the dialog should be modal, but leave it to the host to create and destroy the dialog.

Also remove some special member variables of Effect that existed only for the use of Nyquist.  Instead the public member function iterfaces allow Nyquist to specify the special case behavior.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
