### PR TITLE
issue #2119: Data loss on joining clips

### DIFF
--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1708,9 +1708,10 @@ void WaveTrack::Join(double t0, double t1)
    if( clipsToDelete.size() == 0 )
       return;
 
-   auto t = clipsToDelete[0]->GetSequenceStartTime();
+   auto t = clipsToDelete[0]->GetPlayStartTime();
    //preserve left trim data if any
-   newClip = CreateClip(t, clipsToDelete[0]->GetName());
+   newClip = CreateClip(clipsToDelete[0]->GetSequenceStartTime(),
+      clipsToDelete[0]->GetName());
    
    for (const auto &clip : clipsToDelete)
    {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2119

Joining clips using the Join command (Ctrl+J) can cause data in preceeding clips to be silenced.

Fix: In WaveTrack::Join(), the initial value of t should be PlayStartTime of the first clip, not SequenceStartTime.

Resolves: https://github.com/audacity/audacity/issues/2119


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
