### PR TITLE
Break dependency cycle

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -277,6 +277,8 @@ list( APPEND SOURCES
       TrackArtist.h
       TrackInfo.cpp
       TrackInfo.h
+      TrackAttachment.h
+      TrackAttachment.cpp
       TrackPanel.cpp
       TrackPanel.h
       TrackPanelAx.cpp

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -31,12 +31,6 @@ for drawing different aspects of the label and its text box.
 
 #include "LabelTrack.h"
 
-#include "tracks/ui/TrackView.h"
-#include "tracks/ui/TrackControls.h"
-
-
-
-#include <stdio.h>
 #include <algorithm>
 #include <limits.h>
 #include <float.h>
@@ -58,14 +52,16 @@ wxDEFINE_EVENT(EVT_LABELTRACK_SELECTION, LabelTrackEvent);
 
 static ProjectFileIORegistry::ObjectReaderEntry readerEntry{
    "labeltrack",
-   []( AudacityProject &project ){
-      auto &tracks = TrackList::Get( project );
-      auto result = tracks.Add(std::make_shared<LabelTrack>());
-      TrackView::Get( *result );
-      TrackControls::Get( *result );
-      return result;
-   }
+   LabelTrack::New
 };
+
+LabelTrack *LabelTrack::New( AudacityProject &project )
+{
+   auto &tracks = TrackList::Get( project );
+   auto result = tracks.Add(std::make_shared<LabelTrack>());
+   result->AttachedTrackObjects::BuildAll();
+   return result;
+}
 
 LabelTrack::LabelTrack():
    Track(),

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -87,6 +87,9 @@ class AUDACITY_DLL_API LabelTrack final
    , public wxEvtHandler
 {
  public:
+   // Construct and also build all attachments
+   static LabelTrack *New(AudacityProject &project);
+
    LabelTrack();
    LabelTrack(const LabelTrack &orig);
 
@@ -103,7 +106,7 @@ class AUDACITY_DLL_API LabelTrack final
    double GetEndTime() const override;
 
    using Holder = std::shared_ptr<LabelTrack>;
-   
+
 private:
    Track::Holder Clone() const override;
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -40,8 +40,6 @@
 #include "InconsistencyException.h"
 
 #include "effects/TimeWarper.h"
-#include "tracks/ui/TrackView.h"
-#include "tracks/ui/TrackControls.h"
 
 #include "AllThemeResources.h"
 #include "Theme.h"
@@ -111,14 +109,16 @@ SONFNS(AutoSave)
 
 static ProjectFileIORegistry::ObjectReaderEntry readerEntry{
    "notetrack",
-   []( AudacityProject &project ){
-      auto &tracks = TrackList::Get( project );
-      auto result = tracks.Add( std::make_shared<NoteTrack>());
-      TrackView::Get( *result );
-      TrackControls::Get( *result );
-      return result;
-   }
+   NoteTrack::New
 };
+
+NoteTrack *NoteTrack::New( AudacityProject &project )
+{
+   auto &tracks = TrackList::Get( project );
+   auto result = tracks.Add( std::make_shared<NoteTrack>());
+   result->AttachedTrackObjects::BuildAll();
+   return result;
+}
 
 NoteTrack::NoteTrack()
    : NoteTrackBase()

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -66,6 +66,9 @@ class AUDACITY_DLL_API NoteTrack final
    : public NoteTrackBase
 {
 public:
+   // Construct and also build all attachments
+   static NoteTrack *New(AudacityProject &project);
+
    NoteTrack();
    virtual ~NoteTrack();
 

--- a/src/TimeTrack.cpp
+++ b/src/TimeTrack.cpp
@@ -27,9 +27,6 @@
 #include "ProjectRate.h"
 #include "ViewInfo.h"
 
-#include "tracks/ui/TrackView.h"
-#include "tracks/ui/TrackControls.h"
-
 
 //TODO-MB: are these sensible values?
 #define TIMETRACK_MIN 0.01
@@ -37,15 +34,17 @@
 
 static ProjectFileIORegistry::ObjectReaderEntry readerEntry{
    "timetrack",
-   []( AudacityProject &project ){
-      auto &tracks = TrackList::Get( project );
-      auto &viewInfo = ViewInfo::Get( project );
-      auto result = tracks.Add(std::make_shared<TimeTrack>(&viewInfo));
-      TrackView::Get( *result );
-      TrackControls::Get( *result );
-      return result;
-   }
+   TimeTrack::New
 };
+
+TimeTrack *TimeTrack::New( AudacityProject &project )
+{
+   auto &tracks = TrackList::Get( project );
+   auto &viewInfo = ViewInfo::Get( project );
+   auto result = tracks.Add(std::make_shared<TimeTrack>(&viewInfo));
+   result->AttachedTrackObjects::BuildAll();
+   return result;
+}
 
 TimeTrack::TimeTrack(const ZoomInfo *zoomInfo):
    Track()

--- a/src/TimeTrack.h
+++ b/src/TimeTrack.h
@@ -25,6 +25,9 @@ class AUDACITY_DLL_API TimeTrack final : public Track {
 
  public:
 
+   // Construct and also build all attachments
+   static TimeTrack *New(AudacityProject &project);
+
    explicit TimeTrack(const ZoomInfo *zoomInfo);
    /** @brief Copy-Constructor - create a NEW TimeTrack:: which is an independent copy of the original
     *

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -35,7 +35,6 @@ and TimeTrack.
 #include <wx/textfile.h>
 #include <wx/log.h>
 
-#include "tracks/ui/CommonTrackPanelCell.h"
 #include "Project.h"
 #include "ProjectSettings.h"
 
@@ -141,22 +140,22 @@ void Track::SetOwner
    mNode = node;
 }
 
-const std::shared_ptr<CommonTrackCell> &Track::GetTrackView()
+const std::shared_ptr<TrackAttachment> &Track::GetTrackView()
 {
    return mpView;
 }
 
-void Track::SetTrackView( const std::shared_ptr<CommonTrackCell> &pView )
+void Track::SetTrackView( const std::shared_ptr<TrackAttachment> &pView )
 {
    mpView = pView;
 }
 
-const std::shared_ptr<CommonTrackCell> &Track::GetTrackControls()
+const std::shared_ptr<TrackAttachment> &Track::GetTrackControls()
 {
    return mpControls;
 }
 
-void Track::SetTrackControls( const std::shared_ptr<CommonTrackCell> &pControls )
+void Track::SetTrackControls( const std::shared_ptr<TrackAttachment> &pControls )
 {
    mpControls = pControls;
 }

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -113,9 +113,10 @@ Track::Holder Track::Duplicate() const
    // invoke "virtual constructor" to copy track object proper:
    auto result = Clone();
 
-   if (mpView)
+   AttachedTrackObjects::ForEach([&](auto &attachment){
       // Copy view state that might be important to undo/redo
-      mpView->CopyTo( *result );
+      attachment.CopyTo( *result );
+   });
 
    return result;
 }
@@ -138,26 +139,6 @@ void Track::SetOwner
    // focused track too.  Otherwise focus could remain on an invisible (or deleted) track.
    mList = list;
    mNode = node;
-}
-
-const std::shared_ptr<TrackAttachment> &Track::GetTrackView()
-{
-   return mpView;
-}
-
-void Track::SetTrackView( const std::shared_ptr<TrackAttachment> &pView )
-{
-   mpView = pView;
-}
-
-const std::shared_ptr<TrackAttachment> &Track::GetTrackControls()
-{
-   return mpControls;
-}
-
-void Track::SetTrackControls( const std::shared_ptr<TrackAttachment> &pControls )
-{
-   mpControls = pControls;
 }
 
 int Track::GetIndex() const
@@ -1045,8 +1026,7 @@ TrackList::RegisterPendingChangedTrack( Updater updater, Track *src )
       pTrack = src->Clone(); // not duplicate
       // Share the satellites with the original, though they do not point back
       // to the pending track
-      pTrack->mpView = src->mpView;
-      pTrack->mpControls = src->mpControls;
+      ((AttachedTrackObjects&)*pTrack) = *src; // shallow copy
    }
 
    if (pTrack) {
@@ -1145,10 +1125,9 @@ bool TrackList::ApplyPendingTracks()
 
    for (auto &pendingTrack : updates) {
       if (pendingTrack) {
-         if (pendingTrack->mpView)
-            pendingTrack->mpView->Reparent( pendingTrack );
-         if (pendingTrack->mpControls)
-            pendingTrack->mpControls->Reparent( pendingTrack );
+         pendingTrack->AttachedTrackObjects::ForEach([&](auto &attachment){
+            attachment.Reparent( pendingTrack );
+         });
          auto src = FindById( pendingTrack->GetId() );
          if (src)
             this->Replace(src, pendingTrack), result = true;
@@ -1256,10 +1235,9 @@ void Track::WriteCommonXMLAttributes(
       xmlFile.WriteAttr(wxT("name"), GetName());
       xmlFile.WriteAttr(wxT("isSelected"), this->GetSelected());
    }
-   if ( mpView )
-      mpView->WriteXMLAttributes( xmlFile );
-   if ( mpControls )
-      mpControls->WriteXMLAttributes( xmlFile );
+   AttachedTrackObjects::ForEach([&](auto &attachment){
+      attachment.WriteXMLAttributes( xmlFile );
+   });
 }
 
 // Return true iff the attribute is recognized.
@@ -1268,10 +1246,12 @@ bool Track::HandleCommonXMLAttribute(
 {
    long nValue = -1;
 
-   if (mpView && mpView->HandleXMLAttribute(attr, valueView))
-      return true;
-   else if (mpControls && mpControls->HandleXMLAttribute(attr, valueView))
-      return true;
+   bool handled = false;
+   AttachedTrackObjects::ForEach([&](auto &attachment){
+      handled = handled || attachment.HandleXMLAttribute( attr, valueView );
+   });
+   if (handled)
+      ;
    else if (attr == "name") {
       SetName(valueView.ToWString());
       return true;

--- a/src/Track.h
+++ b/src/Track.h
@@ -24,6 +24,9 @@
 
 #include "ClientData.h"
 #include "SampleFormat.h"
+// TrackAttachment needs to be a complete type for the Windows build, though
+// not the others, so there is a nested include here:
+#include "TrackAttachment.h"
 #include "XMLTagHandler.h"
 
 #ifdef __WXMSW__
@@ -31,7 +34,6 @@
 #endif
 
 class wxTextFile;
-class CommonTrackCell;
 class Track;
 class AudioTrack;
 class PlayableTrack;
@@ -355,13 +357,13 @@ private:
 
    // These are exposed only for the purposes of the TrackView class, to
    // initialize the pointer on demand
-   const std::shared_ptr<CommonTrackCell> &GetTrackView();
-   void SetTrackView( const std::shared_ptr<CommonTrackCell> &pView );
+   const std::shared_ptr<TrackAttachment> &GetTrackView();
+   void SetTrackView( const std::shared_ptr<TrackAttachment> &pView );
 
    // These are exposed only for the purposes of the TrackControls class, to
    // initialize the pointer on demand
-   const std::shared_ptr<CommonTrackCell> &GetTrackControls();
-   void SetTrackControls( const std::shared_ptr<CommonTrackCell> &pControls );
+   const std::shared_ptr<TrackAttachment> &GetTrackControls();
+   void SetTrackControls( const std::shared_ptr<TrackAttachment> &pControls );
 
    // Return another, associated TrackPanelCell object that implements the
 
@@ -829,8 +831,8 @@ public:
    bool HandleCommonXMLAttribute(const std::string_view& attr, const XMLAttributeValueView& valueView);
 
 protected:
-   std::shared_ptr<CommonTrackCell> mpView;
-   std::shared_ptr<CommonTrackCell> mpControls;
+   std::shared_ptr<TrackAttachment> mpView;
+   std::shared_ptr<TrackAttachment> mpControls;
 };
 
 //! Track subclass holding data representing sound (as notes, or samples, or ...)

--- a/src/Track.h
+++ b/src/Track.h
@@ -230,7 +230,7 @@ public:
 
 //! Template generated base class for Track lets it host opaque UI related objects
 using AttachedTrackObjects = ClientData::Site<
-   Track, ClientData::Base, ClientData::SkipCopying, std::shared_ptr
+   Track, TrackAttachment, ClientData::ShallowCopying, std::shared_ptr
 >;
 
 //! Abstract base class for an object holding data associated with points on a time axis
@@ -354,18 +354,6 @@ private:
 
  public:
    mutable wxSize vrulerSize;
-
-   // These are exposed only for the purposes of the TrackView class, to
-   // initialize the pointer on demand
-   const std::shared_ptr<TrackAttachment> &GetTrackView();
-   void SetTrackView( const std::shared_ptr<TrackAttachment> &pView );
-
-   // These are exposed only for the purposes of the TrackControls class, to
-   // initialize the pointer on demand
-   const std::shared_ptr<TrackAttachment> &GetTrackControls();
-   void SetTrackControls( const std::shared_ptr<TrackAttachment> &pControls );
-
-   // Return another, associated TrackPanelCell object that implements the
 
    int GetIndex() const;
    void SetIndex(int index);
@@ -829,10 +817,6 @@ public:
 
    // Return true iff the attribute is recognized.
    bool HandleCommonXMLAttribute(const std::string_view& attr, const XMLAttributeValueView& valueView);
-
-protected:
-   std::shared_ptr<TrackAttachment> mpView;
-   std::shared_ptr<TrackAttachment> mpControls;
 };
 
 //! Track subclass holding data representing sound (as notes, or samples, or ...)

--- a/src/TrackAttachment.cpp
+++ b/src/TrackAttachment.cpp
@@ -1,0 +1,32 @@
+/*!********************************************************************
+
+Audacity: A Digital Audio Editor
+
+@file TrackAttachment.cpp
+@brief implements TrackAttachment
+
+Paul Licameli split from CommonTrackPanelCell.cpp
+
+**********************************************************************/
+
+#include "TrackAttachment.h"
+
+TrackAttachment::~TrackAttachment() = default;
+
+void TrackAttachment::CopyTo( Track& ) const
+{
+}
+
+void TrackAttachment::Reparent( const std::shared_ptr<Track> & )
+{
+}
+
+void TrackAttachment::WriteXMLAttributes( XMLWriter & ) const
+{
+}
+
+bool TrackAttachment::HandleXMLAttribute(
+   const std::string_view&, const XMLAttributeValueView& )
+{
+   return false;
+}

--- a/src/TrackAttachment.h
+++ b/src/TrackAttachment.h
@@ -1,0 +1,48 @@
+/*!********************************************************************
+
+Audacity: A Digital Audio Editor
+
+@file TrackAttachment.h
+@brief abstract base class for structures that user interface associates with tracks
+
+Paul Licameli split from CommonTrackPanelCell.h
+
+**********************************************************************/
+
+#ifndef __AUDACITY_TRACK_ATTACHMENT__
+#define __AUDACITY_TRACK_ATTACHMENT__
+
+#include <wx/chartype.h>
+
+#include <memory>
+
+#include "ClientData.h"
+
+class Track;
+class XMLAttributeValueView;
+class XMLWriter;
+
+class AUDACITY_DLL_API TrackAttachment /* not final */ : public ClientData::Base
+{
+public:
+   virtual ~TrackAttachment();
+
+   //! Copy state, for undo/redo purposes
+   //*! The default does nothing */
+   virtual void CopyTo( Track &track ) const;
+
+   //! Object may be shared among tracks but hold a special back-pointer to one of them; reassign it
+   /*! default does nothing */
+   virtual void Reparent( const std::shared_ptr<Track> &parent );
+
+   //! Serialize persistent attributes
+   /*! default does nothing */
+   virtual void WriteXMLAttributes( XMLWriter & ) const;
+
+   //! Deserialize an attribute, returning true if recognized
+   /*! default recognizes no attributes, and returns false */
+   virtual bool HandleXMLAttribute(
+      const std::string_view& attr, const XMLAttributeValueView& valueView );
+};
+
+#endif

--- a/src/TrackPanelResizerCell.cpp
+++ b/src/TrackPanelResizerCell.cpp
@@ -26,7 +26,7 @@ Paul Licameli split from TrackPanel.cpp
 
 TrackPanelResizerCell::TrackPanelResizerCell(
    const std::shared_ptr<Track> &pTrack )
-   : mwTrack{ pTrack }
+   : CommonTrackCell{ pTrack }
 {}
 
 std::vector<UIHandlePtr> TrackPanelResizerCell::HitTest
@@ -42,11 +42,6 @@ std::vector<UIHandlePtr> TrackPanelResizerCell::HitTest
       results.push_back(result);
    }
    return results;
-}
-
-std::shared_ptr<Track> TrackPanelResizerCell::DoFindTrack()
-{
-   return mwTrack.lock();
 }
 
 void TrackPanelResizerCell::Draw(

--- a/src/TrackPanelResizerCell.h
+++ b/src/TrackPanelResizerCell.h
@@ -18,7 +18,7 @@ class Track;
 class TrackPanelResizeHandle;
 
 class TrackPanelResizerCell
-   : public CommonTrackPanelCell
+   : public CommonTrackCell
    , public std::enable_shared_from_this< TrackPanelResizerCell >
    , public ClientData::Base
 {
@@ -35,12 +35,7 @@ public:
    std::vector<UIHandlePtr> HitTest
       (const TrackPanelMouseState &, const AudacityProject *) override;
 
-protected:
-   std::shared_ptr<Track> DoFindTrack() override;
-
 private:
-   // back-pointer is weak to break a cycle
-   std::weak_ptr<Track> mwTrack;
 
    // TrackPanelDrawable implementation
    void Draw(

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -61,9 +61,6 @@ from the project that will own the track.
 
 #include "InconsistencyException.h"
 
-#include "tracks/ui/TrackView.h"
-#include "tracks/ui/TrackControls.h"
-
 #include "ProjectFormatExtensionsRegistry.h"
 
 using std::max;
@@ -102,14 +99,7 @@ Track::LinkType ToLinkType(int value)
 
 static ProjectFileIORegistry::ObjectReaderEntry readerEntry{
    "wavetrack",
-   []( AudacityProject &project ){
-      auto &trackFactory = WaveTrackFactory::Get( project );
-      auto &tracks = TrackList::Get( project );
-      auto result = tracks.Add(trackFactory.NewWaveTrack());
-      TrackView::Get( *result );
-      TrackControls::Get( *result );
-      return result;
-   }
+   WaveTrack::New
 };
 
 WaveTrack::Holder WaveTrackFactory::DuplicateWaveTrack(const WaveTrack &orig)
@@ -130,6 +120,15 @@ WaveTrack::Holder WaveTrackFactory::NewWaveTrack(sampleFormat format, double rat
    auto waveTrack = std::make_shared<WaveTrack> ( mpFactory, format, rate );
 
    return waveTrack;
+}
+
+WaveTrack *WaveTrack::New( AudacityProject &project )
+{
+   auto &trackFactory = WaveTrackFactory::Get( project );
+   auto &tracks = TrackList::Get( project );
+   auto result = tracks.Add(trackFactory.NewWaveTrack());
+   result->AttachedTrackObjects::BuildAll();
+   return result;
 }
 
 WaveTrack::WaveTrack( const SampleBlockFactoryPtr &pFactory,

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -73,6 +73,9 @@ public:
    // Constructor / Destructor / Duplicator
    //
 
+   // Construct and also build all attachments
+   static WaveTrack *New( AudacityProject &project );
+
    WaveTrack(
       const SampleBlockFactoryPtr &pFactory, sampleFormat format, double rate);
    WaveTrack(const WaveTrack &orig);

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackAffordanceControls.cpp
@@ -91,7 +91,8 @@ std::vector<UIHandlePtr> NoteTrackAffordanceControls::HitTest(const TrackPanelMo
     {
         results.push_back(
             SelectHandle::HitTest(
-                mSelectHandle, state, pProject, std::static_pointer_cast<TrackView>(track->GetTrackView())
+                mSelectHandle, state, pProject,
+                TrackView::Get(*track).shared_from_this()
             )
         );
     }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -219,7 +219,8 @@ std::vector<UIHandlePtr> WaveTrackAffordanceControls::HitTest(const TrackPanelMo
     {
         results.push_back(
             SelectHandle::HitTest(
-                mSelectHandle, state, pProject, std::static_pointer_cast<TrackView>(track->GetTrackView())
+                mSelectHandle, state, pProject,
+                TrackView::Get(*track).shared_from_this()
             )
         );
     }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -937,10 +937,10 @@ WaveTrackView::DoDetailedHitTest
       if (!WaveTrackView::ClipDetailsVisible(*clip, viewInfo, st.rect)
          && HitTest(*clip, viewInfo, st.rect, st.state.GetPosition()))
       {
-         auto waveTrackView = std::static_pointer_cast<WaveTrackView>(pTrack->GetTrackView());
+         auto &waveTrackView = WaveTrackView::Get(*pTrack);
          results.push_back(
             AssignUIHandlePtr(
-               waveTrackView->mAffordanceHandle,
+               waveTrackView.mAffordanceHandle,
                std::make_shared<WaveTrackAffordanceHandle>(pTrack, clip)
             )
          );

--- a/src/tracks/ui/CommonTrackPanelCell.cpp
+++ b/src/tracks/ui/CommonTrackPanelCell.cpp
@@ -135,10 +135,6 @@ CommonTrackCell::CommonTrackCell( const std::shared_ptr< Track > &parent )
 
 CommonTrackCell::~CommonTrackCell() = default;
 
-void CommonTrackCell::CopyTo( Track& ) const
-{
-}
-
 void CommonTrackCell::Reparent( const std::shared_ptr<Track> &parent )
 {
    mwTrack = parent;
@@ -147,14 +143,4 @@ void CommonTrackCell::Reparent( const std::shared_ptr<Track> &parent )
 std::shared_ptr<Track> CommonTrackCell::DoFindTrack()
 {
    return mwTrack.lock();
-}
-
-void CommonTrackCell::WriteXMLAttributes( XMLWriter & ) const
-{
-}
-
-bool CommonTrackCell::HandleXMLAttribute(
-   const std::string_view& attr, const XMLAttributeValueView& valueView)
-{
-   return false;
 }

--- a/src/tracks/ui/CommonTrackPanelCell.h
+++ b/src/tracks/ui/CommonTrackPanelCell.h
@@ -11,8 +11,8 @@ Paul Licameli split from TrackPanel.cpp
 #ifndef __AUDACITY_COMMON_TRACK_PANEL_CELL__
 #define __AUDACITY_COMMON_TRACK_PANEL_CELL__
 
-
 #include "../../TrackPanelCell.h"
+#include "../../TrackAttachment.h" // to inherit
 
 #include <stdlib.h>
 #include <memory>
@@ -97,27 +97,16 @@ protected:
 };
 
 class AUDACITY_DLL_API CommonTrackCell /* not final */
-   : public CommonTrackPanelCell
+   : public CommonTrackPanelCell, public TrackAttachment
 {
 public:
    explicit CommonTrackCell( const std::shared_ptr<Track> &pTrack );
 
   ~CommonTrackCell();
 
-   // Copy state, for undo/redo purposes
-   // The default does nothing
-   virtual void CopyTo( Track &track ) const;
-
    std::shared_ptr<Track> DoFindTrack() override;
 
-   virtual void Reparent( const std::shared_ptr<Track> &parent );
-
-   // default does nothing
-   virtual void WriteXMLAttributes( XMLWriter & ) const;
-
-   // default recognizes no attributes, and returns false
-   virtual bool HandleXMLAttribute(
-      const std::string_view& attr, const XMLAttributeValueView& valueView);
+   void Reparent( const std::shared_ptr<Track> &parent ) override;
 
 private:
    std::weak_ptr< Track > mwTrack;

--- a/src/tracks/ui/TrackControls.cpp
+++ b/src/tracks/ui/TrackControls.cpp
@@ -22,19 +22,20 @@ TrackControls::~TrackControls()
 {
 }
 
+static const AttachedTrackObjects::RegisteredFactory key{
+   []( Track &track ){
+      return DoGetControls::Call( track );
+   }
+};
+
 TrackControls &TrackControls::Get( Track &track )
 {
-   auto pControls =
-      std::static_pointer_cast<TrackControls>( track.GetTrackControls() );
-   if (!pControls)
-      // create on demand
-      track.SetTrackControls( pControls = DoGetControls::Call( track ) );
-   return *pControls;
+   return track.AttachedObjects::Get< TrackControls >( key );
 }
 
 const TrackControls &TrackControls::Get( const Track &track )
 {
-   return Get( const_cast< Track& >( track ) );
+   return Get( const_cast< Track & >( track ) );
 }
 
 DEFINE_ATTACHED_VIRTUAL(DoGetControls) {

--- a/src/tracks/ui/TrackView.cpp
+++ b/src/tracks/ui/TrackView.cpp
@@ -60,18 +60,20 @@ void TrackView::CopyTo( Track &track ) const
    other.mHeight = mHeight;
 }
 
+static const AttachedTrackObjects::RegisteredFactory key{
+   []( Track &track ){
+      return DoGetView::Call( track );
+   }
+};
+
 TrackView &TrackView::Get( Track &track )
 {
-   auto pView = std::static_pointer_cast<TrackView>( track.GetTrackView() );
-   if (!pView)
-      // create on demand
-      track.SetTrackView( pView = DoGetView::Call( track ) );
-   return *pView;
+   return track.AttachedObjects::Get< TrackView >( key );
 }
 
 const TrackView &TrackView::Get( const Track &track )
 {
-   return Get( const_cast< Track& >( track ) );
+   return Get( const_cast< Track & >( track ) );
 }
 
 void TrackView::SetMinimized(bool isMinimized)

--- a/src/tracks/ui/TrackView.h
+++ b/src/tracks/ui/TrackView.h
@@ -91,7 +91,9 @@ public:
    virtual std::shared_ptr<CommonTrackCell> GetAffordanceControls();
 
    void WriteXMLAttributes( XMLWriter & ) const override;
-   bool HandleXMLAttribute( const std::string_view& attr, const XMLAttributeValueView& valueView ) override;
+   bool HandleXMLAttribute(
+      const std::string_view& attr, const XMLAttributeValueView& valueView )
+   override;
 
    // New virtual function.  The default just returns a one-element array
    // containing this.  Overrides might refine the Y axis.


### PR DESCRIPTION
Resolves: #2125

Shrink the source code dependency cycle mentioned in the issue, to only six files, not worse than in 3.0.3.  Untangling commands, toolbars, and menus is work for the future, but keep WaveTrack and others out of the cycle.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
