### PR TITLE
Fixes a corner case when formatting number very close to 0

### DIFF
--- a/libraries/lib-string-utils/ToChars.cpp
+++ b/libraries/lib-string-utils/ToChars.cpp
@@ -1020,12 +1020,7 @@ bool grisu2(char* buf, char* last, int& len, int& decimal_exponent, FloatType va
 */
 inline ToCharsResult append_exponent(char* buf, char* last, int e)
 {
-   auto k = static_cast<std::uint32_t>(e);
-
-   const int requiredSymbolsCount = k < 100 ? 3 : 4;
-   char* requiredLast = buf + requiredSymbolsCount + 1;
-
-   if (requiredLast > last)
+   if (buf >= last)
       return { last, std::errc::value_too_large };
 
    if (e < 0)
@@ -1037,6 +1032,14 @@ inline ToCharsResult append_exponent(char* buf, char* last, int e)
    {
       *buf++ = '+';
    }
+
+   auto k = static_cast<std::uint32_t>(e);
+
+   const int requiredSymbolsCount = k < 100 ? 2 : 3;
+   char* requiredLast = buf + requiredSymbolsCount + 1;
+
+   if (requiredLast > last)
+      return { last, std::errc::value_too_large };
 
    if (k < 10)
    {
@@ -1206,10 +1209,9 @@ ToCharsResult float_to_chars(
    // for a consistent behavior
    if (digitsAfterDecimalPoint >= 0)
    {
-      if (len > digitsAfterDecimalPoint && -decimal_exponent > digitsAfterDecimalPoint)
+      if (len + decimal_exponent > 0 && -decimal_exponent > digitsAfterDecimalPoint)
       {
          const int difference = digitsAfterDecimalPoint + decimal_exponent;
-
          decimal_exponent = -digitsAfterDecimalPoint;
          len += difference;
       }


### PR DESCRIPTION
If digitsAfterDecimalPoint was set, Audacity would crash if |decimal_exponent| is larger than length.

Resolves: #2127 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
