### PR TITLE
Fixes issue with track length mismatch after resample

### DIFF
--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1808,7 +1808,7 @@ sampleCount WaveClip::GetSequenceSamplesCount() const
 
 double WaveClip::GetPlayStartTime() const noexcept
 {
-    return mSequenceOffset + mTrimLeft;
+    return mSequenceOffset + SamplesToTime(TimeToSamples(mTrimLeft));
 }
 
 void WaveClip::SetPlayStartTime(double time)
@@ -1820,7 +1820,8 @@ double WaveClip::GetPlayEndTime() const
 {
     auto numSamples = mSequence->GetNumSamples();
 
-    double maxLen = GetSequenceStartTime() + ((numSamples + mAppendBufferLen).as_double()) / mRate - mTrimRight;
+    double maxLen = GetSequenceStartTime() + ((numSamples + mAppendBufferLen).as_double()) / mRate 
+       - SamplesToTime(TimeToSamples(mTrimRight));
     // JS: calculated value is not the length;
     // it is a maximum value and can be negative; no clipping to 0
 


### PR DESCRIPTION
It could happen so that after resampling number of samples contained in `GetPlayEndTime() - GetPlayStartTime()`
didn't match to number of samples in `GetPlayEndSample() - GetPlayStartSample()`

Resolves: #2113 

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
