### PR TITLE
Fixes detach at silences by trimming unnecessary silence #2312

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ appimagetool/*
 .build.arm64/
 .conan/
 .debug/
+/out/build/x64-Debug

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1288,7 +1288,7 @@ void WaveTrack::HandleClear(double t0, double t1,
                   // guarantee, and might modify another clip
                   clipsToDelete.push_back( clip.get() );
                   auto newClip = std::make_unique<WaveClip>( *clip, mpFactory, true );
-                  newClip->TrimLeft(t1 - clip->GetPlayStartTime());
+                  newClip->ClearLeft(t1);
                   clipsToAdd.push_back( std::move( newClip ) );
                }
                else if (clip->AfterPlayEndTime(t1)) {
@@ -1298,7 +1298,7 @@ void WaveTrack::HandleClear(double t0, double t1,
                   // guarantee, and might modify another clip
                   clipsToDelete.push_back( clip.get() );
                   auto newClip = std::make_unique<WaveClip>( *clip, mpFactory, true );
-                  newClip->TrimRight(clip->GetPlayEndTime() - t0);
+                  newClip->ClearRight(t0);
 
                   clipsToAdd.push_back( std::move( newClip ) );
                }
@@ -1307,11 +1307,11 @@ void WaveTrack::HandleClear(double t0, double t1,
                   // NEW clips out of the left and right halves...
 
                   auto leftClip = std::make_unique<WaveClip>(*clip, mpFactory, true);
-                  leftClip->TrimRight(clip->GetPlayEndTime() - t0);
+                  leftClip->ClearRight(t0);
                   clipsToAdd.push_back(std::move(leftClip));
 
                   auto rightClip = std::make_unique<WaveClip>(*clip, mpFactory, true);
-                  rightClip->TrimLeft(t1 - rightClip->GetPlayStartTime());
+                  rightClip->ClearLeft(t1);
                   clipsToAdd.push_back(std::move(rightClip));
 
                   clipsToDelete.push_back(clip.get());

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1288,7 +1288,7 @@ void WaveTrack::HandleClear(double t0, double t1,
                   // guarantee, and might modify another clip
                   clipsToDelete.push_back( clip.get() );
                   auto newClip = std::make_unique<WaveClip>( *clip, mpFactory, true );
-                  newClip->ClearLeft(t1);
+                  newClip->TrimLeft(t1 - clip->GetPlayStartTime());
                   clipsToAdd.push_back( std::move( newClip ) );
                }
                else if (clip->AfterPlayEndTime(t1)) {
@@ -1298,7 +1298,7 @@ void WaveTrack::HandleClear(double t0, double t1,
                   // guarantee, and might modify another clip
                   clipsToDelete.push_back( clip.get() );
                   auto newClip = std::make_unique<WaveClip>( *clip, mpFactory, true );
-                  newClip->ClearRight(t0);
+                  newClip->TrimRight(clip->GetPlayEndTime() - t0);
 
                   clipsToAdd.push_back( std::move( newClip ) );
                }
@@ -1307,11 +1307,11 @@ void WaveTrack::HandleClear(double t0, double t1,
                   // NEW clips out of the left and right halves...
 
                   auto leftClip = std::make_unique<WaveClip>(*clip, mpFactory, true);
-                  leftClip->ClearRight(t0);
+                  leftClip->TrimRight(clip->GetPlayEndTime() - t0);
                   clipsToAdd.push_back(std::move(leftClip));
 
                   auto rightClip = std::make_unique<WaveClip>(*clip, mpFactory, true);
-                  rightClip->ClearLeft(t1);
+                  rightClip->TrimLeft(t1 - rightClip->GetPlayStartTime());
                   clipsToAdd.push_back(std::move(rightClip));
 
                   clipsToDelete.push_back(clip.get());

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1711,7 +1711,6 @@ void WaveTrack::Disjoin(double t0, double t1)
          // the region spans to the end of the clip, so we can just delete it
          if (region.clip->GetPlayEndSample() == region.end) {
             WaveClipHolder toRemove = RemoveAndReturnClip(region.clip.get());
-            toRemove.~shared_ptr();
             continue;
          }
       }
@@ -1725,8 +1724,7 @@ void WaveTrack::Disjoin(double t0, double t1)
             newClip = CopyToNewClip(region.clip, region.end, region.clip->GetPlayEndSample());
          }
          //remove the remainder of the clip
-         WaveClipHolder toRemove = RemoveAndReturnClip(region.clip.get());
-         toRemove.~shared_ptr();
+         WaveClipHolder toRemove = RemoveAndReturnClip(region.clip.get());        
       }
       lastEndPos=region.end;
    }

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1700,6 +1700,7 @@ void WaveTrack::Disjoin(double t0, double t1)
     * than remove the original clip when it is no longer has impacted regions
     */
    
+   WaveClipHolder lastClip = NULL;
    WaveClip *newClip;
    for( unsigned int i = 0; i < clipRegions.size(); i++ )
    {
@@ -1719,10 +1720,15 @@ void WaveTrack::Disjoin(double t0, double t1)
          newClip->Append((samplePtr)buffer.get(), floatSample, numSamples, 1);
          len -= numSamples;
       }
+      // Remove the original track if the next element is different, than the current
       if (i < clipRegions.size() - 1 && clipRegions.at(i).clip != clipRegions.at(i + 1).clip) {
          // we assume the regions are sequential, and they should be (!)
          // we can remove the original clip if the next one has a different clip
-         this->RemoveAndReturnClip(region.clip.get());
+         WaveClipHolder clipToRemove = RemoveAndReturnClip(region.clip.get());
+         clipToRemove.~shared_ptr();
+      } else if (i == clipRegions.size() - 1) {
+         // Remove the original clip if the end matches the end of the clip
+         Flush();
       }
    }
 

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -75,13 +75,13 @@ public:
    using Regions = std::vector < Region >;
 
    /// \brief Structure to hold region of a wavetrack along with the
-   /// clip in it
+   /// clip in it. Uses the sequence within the clip for start and end
    struct ClipRegion
    {
       ClipRegion() : start(0), end(0), clip(NULL) {}
-      ClipRegion(double start_, double end_, WaveClipHolder clip_) : start(start_), end(end_), clip(clip_) {}
+      ClipRegion(sampleCount start_, sampleCount end_, WaveClipHolder clip_) : start(start_), end(end_), clip(clip_) {}
 
-      double start, end;
+      sampleCount start, end;
       WaveClipHolder clip;
    };
 
@@ -230,11 +230,12 @@ private:
    // May assume precondition: t0 <= t1
    void Disjoin(double t0, double t1) /* not override */;
 
+   
    // May assume precondition: t0 <= t1
    /*  Internal function to create a copy of the part of an existing clip
    *   Will cause clip overlap, that needs to be taken care of by the caller!
    */
-   WaveClip* CopyToNewClip(WaveClipHolder clip, double startTime, double endTime);
+   WaveClip* CopyToNewClip(WaveClipHolder clip, sampleCount start, sampleCount end);
 
    // May assume precondition: t0 <= t1
    void Trim(double t0, double t1) /* not override */;

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -231,6 +231,12 @@ private:
    void Disjoin(double t0, double t1) /* not override */;
 
    // May assume precondition: t0 <= t1
+   /*  Internal function to create a copy of the part of an existing clip
+   *   Will cause clip overlap, that needs to be taken care of by the caller!
+   */
+   WaveClip* CopyToNewClip(WaveClipHolder clip, double startTime, double endTime);
+
+   // May assume precondition: t0 <= t1
    void Trim(double t0, double t1) /* not override */;
 
    // May assume precondition: t0 <= t1

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -74,6 +74,19 @@ public:
 
    using Regions = std::vector < Region >;
 
+   /// \brief Structure to hold region of a wavetrack along with the
+   /// clip in it
+   struct ClipRegion
+   {
+      ClipRegion() : start(0), end(0), clip(NULL) {}
+      ClipRegion(double start_, double end_, WaveClipHolder clip_) : start(start_), end(end_), clip(clip_) {}
+
+      double start, end;
+      WaveClipHolder clip;
+   };
+
+   using ClipRegions = std::vector < ClipRegion >;
+
    static wxString GetDefaultAudioTrackNamePreference();
 
    //


### PR DESCRIPTION
HandleSplit in 3.x.x is using the new Trim features, instead of Clear. When using the noise gate and detach silence for tracks, this results in full copies of the orginal track, with enormous files.

When HandleSplit is modified to use Clear, the operation falls back to the intended way.

As a side effect, when using this modifications, there are no unintentional copies of invisible data are created, e.g. spliting a clip actually splits, does not create copies.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
