### PR TITLE
Error message shows up for Notch Filter instead on Lowpass filter 

### DIFF
--- a/plug-ins/SpectralEditMulti.ny
+++ b/plug-ins/SpectralEditMulti.ny
@@ -48,7 +48,7 @@ $copyright (_ "Released under terms of the GNU General Public License version 2"
                   p-err f0)))
       ;; Biqud filter fails if centre frequency is very low and bandwidth very high.
       ;; 'Magic numbers' 10 Hz and 10 octaves are experimental.
-      ((and f0 f1 (< f0 10) (> bw 10))
+      ((and f0 (< f0 10) bw (> bw 10))
         (throw 'error-message
           (format nil (_ "~aNotch filter parameters cannot be applied.~%~
                       Try increasing the low frequency bound~%~

--- a/plug-ins/SpectralEditMulti.ny
+++ b/plug-ins/SpectralEditMulti.ny
@@ -48,7 +48,7 @@ $copyright (_ "Released under terms of the GNU General Public License version 2"
                   p-err f0)))
       ;; Biqud filter fails if centre frequency is very low and bandwidth very high.
       ;; 'Magic numbers' 10 Hz and 10 octaves are experimental.
-      ((and f0 f1 (< f0 10) (or (not bw)(> bw 10)))
+      ((and f0 f1 (< f0 10) (> bw 10))
         (throw 'error-message
           (format nil (_ "~aNotch filter parameters cannot be applied.~%~
                       Try increasing the low frequency bound~%~

--- a/plug-ins/SpectralEditMulti.ny
+++ b/plug-ins/SpectralEditMulti.ny
@@ -48,7 +48,7 @@ $copyright (_ "Released under terms of the GNU General Public License version 2"
                   p-err f0)))
       ;; Biqud filter fails if centre frequency is very low and bandwidth very high.
       ;; 'Magic numbers' 10 Hz and 10 octaves are experimental.
-      ((and f0 (< f0 10) (or (not bw)(> bw 10)))
+      ((and f0 f1 (< f0 10) (or (not bw)(> bw 10)))
         (throw 'error-message
           (format nil (_ "~aNotch filter parameters cannot be applied.~%~
                       Try increasing the low frequency bound~%~


### PR DESCRIPTION
Resolves: #2004

The condition now checks for valid Notch Filter Parameters.

Previously, it was not checking if upper frequency was set or not, resulting in an error message describing the "Notch filter", even when the tool was supposed to act like a Lowpass Filter (upper frequency was not set)
If the upper frequency f1 was undefined (not set), the SpectralEditMulti tool must work like a Lowpass Filter with very low 'lower frequency' `(f0 < 10)`,  which had similar effects compared to the 'Low pass Filter' plug-in on my test audio file. (Hence no problems here)
We need not modify the error message as we don't have to handle the case talked above, and only throw error at a problematic (low central frequency and high bandwith) "Notch Filter" as mentioned in the comments at line 49.

Adding a condition that f1 is not undefined (tool should now work like a notch filter) will fix the problem (Error will only be shown when the case described in comments at line 49 arrives). I have tried the steps for reproducing the problems mentioned in the issue and it is no longer occuring.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
