### PR TITLE
Populated Audacity Log after Preferences Update

### DIFF
--- a/src/LogWindow.cpp
+++ b/src/LogWindow.cpp
@@ -111,7 +111,10 @@ void LogWindow::Show(bool show)
       S.StartVerticalLay(true);
       {
          sText = S.Style(wxTE_MULTILINE | wxHSCROLL | wxTE_READONLY | wxTE_RICH)
-            .AddTextWindow({}); // Populate this text window below
+            .AddTextWindow({});
+         
+         // Populated TextWindow created above
+         if (pLogger) *sText << pLogger->GetBuffer();
 
          S.AddSpace(0, 5);
          S.StartHorizontalLay(wxALIGN_CENTER, 0);


### PR DESCRIPTION
Resolves: #2180 

The window (which will be created after the PrefUpdate) is created with `LogWindow::Show()` 
(Previous window deleted with `sFrame.reset()`):
https://github.com/audacity/audacity/blob/3d42d454750df2111e9573349577781faddffa7e/src/LogWindow.cpp#L236

Updated `sText` with Log Buffer.
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
