### PR TITLE
Add missing includes for GCC 11.1.0

### DIFF
--- a/libraries/lib-utility/BufferedStreamReader.h
+++ b/libraries/lib-utility/BufferedStreamReader.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <cstddef>
 #include <type_traits>
 
 /*!

--- a/libraries/lib-xml/XMLAttributeValueView.cpp
+++ b/libraries/lib-xml/XMLAttributeValueView.cpp
@@ -12,6 +12,7 @@
 #include "FromChars.h"
 
 #include <numeric>
+#include <limits>
 
 XMLAttributeValueView::XMLAttributeValueView(bool value) noexcept
     : mInteger(value)


### PR DESCRIPTION
On Arch Linux, I was unable to build the AUR package for audacity-git without these changes.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
  - Not required for trivial changes (added 2 missing includes)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
  - There are two independent fixes, one per commit, but both are required in order to compile and run on my machine.
