### PR TITLE
Fix warnings found during Fedora package build

### DIFF
--- a/libraries/lib-exceptions/AudacityException.h
+++ b/libraries/lib-exceptions/AudacityException.h
@@ -214,7 +214,7 @@ R GuardedCall(
          // At this point, e is the "current" exception, but not "uncaught"
          // unless it was rethrown by handler.  handler might also throw some
          // other exception object.
-         if (!std::uncaught_exception()) {
+         if (std::uncaught_exceptions() == 0) {
             auto pException = std::current_exception(); // This points to e
             AudacityException::EnqueueAction(
                pException, std::move(delayedHandler));

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -190,8 +190,8 @@ FrequencyPlotDialog::FrequencyPlotDialog(wxWindow * parent, wxWindowID id,
                            const wxPoint & pos)
 :  wxDialogWrapper(parent, id, title, pos, wxDefaultSize,
             wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX),
-   mAnalyst(std::make_unique<SpectrumAnalyst>())
-,  mProject{ &project }
+   mProject{ &project }
+,  mAnalyst(std::make_unique<SpectrumAnalyst>())
 {
    SetName();
 

--- a/src/Printing.cpp
+++ b/src/Printing.cpp
@@ -48,8 +48,8 @@ class AudacityPrintout final : public wxPrintout
    AudacityPrintout(wxString title,
                     TrackList *tracks, TrackPanel &panel):
       wxPrintout(title),
-      mTracks(tracks)
-      , mPanel(panel)
+        mPanel(panel)
+      , mTracks(tracks)
    {
    }
    bool OnPrintPage(int page);

--- a/src/ProjectSettings.cpp
+++ b/src/ProjectSettings.cpp
@@ -59,10 +59,6 @@ ProjectSettings::ProjectSettings(AudacityProject &project)
       NumericConverter::TIME,
       gPrefs->Read(wxT("/SelectionFormat"), wxT("")))
 }
-, mAudioTimeFormat{ NumericTextCtrl::LookupFormat(
-   NumericConverter::TIME,
-   gPrefs->Read(wxT("/AudioTimeFormat"), wxT("hh:mm:ss")))
-}
 , mFrequencySelectionFormatName{ NumericTextCtrl::LookupFormat(
    NumericConverter::FREQUENCY,
    gPrefs->Read(wxT("/FrequencySelectionFormatName"), wxT("")) )
@@ -70,6 +66,10 @@ ProjectSettings::ProjectSettings(AudacityProject &project)
 , mBandwidthSelectionFormatName{ NumericTextCtrl::LookupFormat(
    NumericConverter::BANDWIDTH,
    gPrefs->Read(wxT("/BandwidthSelectionFormatName"), wxT("")) )
+}
+, mAudioTimeFormat{ NumericTextCtrl::LookupFormat(
+   NumericConverter::TIME,
+   gPrefs->Read(wxT("/AudioTimeFormat"), wxT("hh:mm:ss")))
 }
 , mSnapTo( gPrefs->Read(wxT("/SnapTo"), SNAP_OFF) )
 , mCurrentBrushRadius ( 5 )

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -29,8 +29,8 @@
 #include "Dither.h"
 
 RingBuffer::RingBuffer(sampleFormat format, size_t size)
-   : mFormat{ format }
-   , mBufferSize{ std::max<size_t>(size, 64) }
+   : mBufferSize{ std::max<size_t>(size, 64) }
+   , mFormat{ format }
    , mBuffer{ mBufferSize, mFormat }
 {
 }

--- a/src/commands/CommandTargets.h
+++ b/src/commands/CommandTargets.h
@@ -230,8 +230,8 @@ private:
    wxString mBuffer;
 public:
    ResponseTarget()
-      : mBuffer(wxEmptyString),
-        mSemaphore(0, 1)
+      : mSemaphore(0, 1),
+        mBuffer(wxEmptyString)
    { 
       // Cater for handling long responses quickly.
       mBuffer.Alloc(40000);

--- a/src/effects/Biquad.cpp
+++ b/src/effects/Biquad.cpp
@@ -135,7 +135,7 @@ ArrayOf<Biquad> Biquad::CalcButterworthFilter(int order, double fn, double fc, i
    pBiquad[0].fNumerCoeffs [B1] *= fDCPoleDistSqr / (1 << order);
    pBiquad[0].fNumerCoeffs [B2] *= fDCPoleDistSqr / (1 << order);
 
-   return std::move(pBiquad);
+   return pBiquad;
 }
 
 // order: filter order
@@ -217,7 +217,7 @@ ArrayOf<Biquad> Biquad::CalcChebyshevType1Filter(int order, double fn, double fc
       pBiquad[(order-1)/2].fDenomCoeffs [A1] = -fZPoleX;
       pBiquad[(order-1)/2].fDenomCoeffs [A2] = 0;
    }
-   return std::move(pBiquad);
+   return pBiquad;
 }
 
 // order: filter order
@@ -302,7 +302,7 @@ ArrayOf<Biquad> Biquad::CalcChebyshevType2Filter(int order, double fn, double fc
       pBiquad[iPair].fDenomCoeffs [A1] = -fZPoleX;
       pBiquad[iPair].fDenomCoeffs [A2] = 0;
    }
-   return std::move(pBiquad);
+   return pBiquad;
 }
 
 void Biquad::ComplexDiv (double fNumerR, double fNumerI, double fDenomR, double fDenomI,

--- a/src/effects/EBUR128.cpp
+++ b/src/effects/EBUR128.cpp
@@ -83,7 +83,7 @@ ArrayOf<Biquad> EBUR128::CalcWeightingFilter(double fs)
    pBiquad[1].fDenomCoeffs[Biquad::A1] = 2.0 * (K * K - 1.0) / (1.0 + K / Q + K * K);
    pBiquad[1].fDenomCoeffs[Biquad::A2] = (1.0 - K / Q + K * K) / (1.0 + K / Q + K * K);
 
-   return std::move(pBiquad);
+   return pBiquad;
 }
 
 void EBUR128::ProcessSampleFromChannel(float x_in, size_t channel)

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -1476,7 +1476,7 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
 
          // If we are unwinding for an exception, don't do another
          // potentially throwing operation
-         if (!std::uncaught_exception())
+         if (std::uncaught_exceptions() == 0)
             // If this does throw, let that propagate, don't guard the call
             AddSilence(len);
       }

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.h
@@ -32,11 +32,11 @@ private:
 public:
     SpectralData(double sr)
     :mSampleRate(sr)
+    ,mWindowSize( 2048 )
+    ,mHopSize ( mWindowSize / 4 )
     // Set start and end in reverse for comparison during data addition
     ,mStartSample(std::numeric_limits<long long>::max())
     ,mEndSample( 0 )
-    ,mWindowSize( 2048 )
-    ,mHopSize ( mWindowSize / 4 )
     {}
     SpectralData(const SpectralData& src) = delete;
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -48,8 +48,6 @@ Paul Licameli split from TrackPanel.cpp
 #include "WaveTrackAffordanceHandle.h"
 #include "WaveClipTrimHandle.h"
 
-namespace {
-
 constexpr int kClipDetailedViewMinimumWidth{ 3 };
 
 using WaveTrackSubViewPtrs = std::vector< std::shared_ptr< WaveTrackSubView > >;
@@ -691,7 +689,6 @@ private:
    size_t mMySubView{};
 };
 
-}
 
 std::pair<
    bool, // if true, hit-testing is finished

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
@@ -29,11 +29,9 @@ class ZoomInfo;
 class TrackPanelResizeHandle;
 class WaveTrackAffordanceHandle;
 
-namespace {
-   class SubViewCloseHandle;
-   class SubViewAdjustHandle;
-   class SubViewRearrangeHandle;
-}
+class SubViewCloseHandle;
+class SubViewAdjustHandle;
+class SubViewRearrangeHandle;
 
 class wxDC;
 

--- a/src/tracks/ui/BrushHandle.cpp
+++ b/src/tracks/ui/BrushHandle.cpp
@@ -147,8 +147,8 @@ BrushHandle::BrushHandle
         const std::shared_ptr<SpectralData> &pSpectralData,
         const ProjectSettings &pSettings)
       : mpStateSaver{ move(pStateSaver) }
-      , mpView{ pTrackView }
       , mpSpectralData(pSpectralData)
+      , mpView{ pTrackView }
 {
    const wxMouseState &state = st.state;
    auto pTrack = pTrackView->FindTrack().get();

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -210,9 +210,9 @@ const Scrubber &Scrubber::Get( const AudacityProject &project )
 
 Scrubber::Scrubber(AudacityProject *project)
    : mScrubToken(-1)
-   , mPaused(true)
    , mScrubSpeedDisplayCountdown(0)
    , mScrubStartPosition(-1)
+   , mPaused(true)
 #ifdef EXPERIMENTAL_SCRUBBING_SCROLL_WHEEL
    , mSmoothScrollingScrub(false)
    , mLogMaxScrubSpeed(0)

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -212,9 +212,9 @@ Scrubber::Scrubber(AudacityProject *project)
    : mScrubToken(-1)
    , mScrubSpeedDisplayCountdown(0)
    , mScrubStartPosition(-1)
+   , mSmoothScrollingScrub(false)
    , mPaused(true)
 #ifdef EXPERIMENTAL_SCRUBBING_SCROLL_WHEEL
-   , mSmoothScrollingScrub(false)
    , mLogMaxScrubSpeed(0)
 #endif
 

--- a/src/tracks/ui/TextEditHelper.cpp
+++ b/src/tracks/ui/TextEditHelper.cpp
@@ -42,10 +42,10 @@ bool TextEditHelper::IsGoodEditKeyCode(int keyCode)
 }
 
 TextEditHelper::TextEditHelper(const std::weak_ptr<TextEditDelegate>& delegate, const wxString& text, const wxFont& font)
-    : mFont(font), 
-    mDelegate(delegate), 
-    mText(text),
-    mInitialCursorPos(0)
+    : mText(text),
+    mFont(font),
+    mInitialCursorPos(0),
+    mDelegate(delegate)
 {
     mCurrentCursorPos = text.Length();
 }

--- a/src/widgets/OverlayPanel.cpp
+++ b/src/widgets/OverlayPanel.cpp
@@ -57,7 +57,7 @@ void OverlayPanel::DrawOverlays(bool repaint_all, wxDC *pDC)
 
    // Find out the rectangles and outdatedness for each overlay
    wxSize size(GetBackingDC().GetSize());
-   for (const auto pOverlay : mOverlays)
+   for (const auto& pOverlay : mOverlays)
       pairs.push_back( pOverlay.lock()->GetRectangle(size) );
 
    // See what requires redrawing.  If repainting, all.


### PR DESCRIPTION
In the process of updating the Fedora package to 3.1.2 I noticed a lot of warnings. Many were harmless unused variable warnings, but there were others that are easy to fix and that do provide better compatibility/code quality. Specifically, the following are fixed:

* Replace the deprecated `std::uncaught_exception` with `std::uncaught_exceptions`.
`std::uncaught_exception` was deprecated in C++17 and removed in C++20 and replaced with `std::uncaught_exceptions` starting in C++17. Since the Audacity code is C++17 minimum, this was a simple change in the two places it is used.

* Cleanup initializer list ordering.
This makes the initializer list actually follow the same order as the order the variables will be initialized in, since in C++ they are initialized in the order they are declared in the class instead of in the list. These warnings can be found using the `-Wreorder` flag.
As part of this there was a small change to move a variable initialization out of the conditional compilation. That variable is not declared in the conditional compilation, so it was just being unset by default instead of getting a value.

* Don't force the use of `std::move` on return values since these will prevent the compiler form performing move/copy ellision optimization (developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c).

* Don't create a copy of an object when iterating over it.

* Fix a violation of the one definition rule by de-anonymizing a few classes so that the main `WaveTrackSubView` will have only one definition across all the compilation units.
Previously it would have a different definition in each compilation unit it was in because the `weak_ptr` on anonymous classes prevented that.
  

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior


Note, this now replaces https://github.com/audacity/audacity/pull/816.
