### PR TITLE
Don't change play region for very short mouse drags

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -120,6 +120,7 @@ public:
       AdornedRulerPanel *pParent, wxCoord xx, MenuChoice menuChoice )
       : mParent(pParent)
       , mX( xx )
+      , mClickedX( xx )
       , mChoice( menuChoice )
    {}
 
@@ -140,6 +141,7 @@ protected:
       const TrackPanelMouseEvent &event, AudacityProject *) override
    {
       mClicked = event.event.LeftIsDown() ? Button::Left : Button::Right;
+      mClickedX = event.event.GetX();
       return RefreshCode::DrawOverlays;
    }
 
@@ -194,6 +196,7 @@ protected:
    wxWeakRef<AdornedRulerPanel> mParent;
 
    wxCoord mX;
+   wxCoord mClickedX;
    
    MenuChoice mChoice;
 
@@ -238,6 +241,9 @@ public:
       ruler.UpdateQuickPlayPos(event.event.m_x);
    
       if (!mDragged) {
+         if (fabs(mX - mClickedX) < SELECT_TOLERANCE_PIXEL)
+            // Don't start a drag yet for a small mouse movement
+            return RefreshNone;
          SavePlayRegion(*pProject);
          const auto time = SnappedTime(*pProject, 0);
          DoStartAdjust(*pProject, time);


### PR DESCRIPTION
Resolves: #2182 

There should be a small but nonzero threshold for mouse movement between click and button-up before drags in the time ruler really change the play region.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
