### PR TITLE
Midi looping preliminaries

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2959,7 +2959,7 @@ int AudioIoCallback::AudioCallback(
       mNumPauseFrames += framesPerBuffer;
 
    for( auto &ext : Extensions() ) {
-      ext.ComputeOtherTimings(mRate,
+      ext.ComputeOtherTimings(mRate, IsPaused(),
          timeInfo,
          framesPerBuffer);
       ext.FillOtherBuffers(

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1840,15 +1840,16 @@ void AudioIO::FillPlayBuffers()
    // user interface.
    bool done = false;
    do {
-      const auto [frames, toProduce] =
+      const auto slice =
          policy.GetPlaybackSlice(mPlaybackSchedule, available);
+      const auto &[frames, toProduce] = slice;
 
       // Update the time queue.  This must be done before writing to the
       // ring buffers of samples, for proper synchronization with the
       // consumer side in the PortAudio thread, which reads the time
       // queue after reading the sample queues.  The sample queues use
       // atomic variables, the time queue doesn't.
-      mPlaybackSchedule.mTimeQueue.Producer(mPlaybackSchedule, frames);
+      mPlaybackSchedule.mTimeQueue.Producer(mPlaybackSchedule, slice);
 
       for (size_t i = 0; i < mPlaybackTracks.size(); i++)
       {

--- a/src/AudioIOExt.h
+++ b/src/AudioIOExt.h
@@ -42,7 +42,7 @@ public:
    virtual ~AudioIOExt();
 
    // Formerly in AudioIoCallback
-   virtual void ComputeOtherTimings(double rate,
+   virtual void ComputeOtherTimings(double rate, bool paused,
       const PaStreamCallbackTimeInfo *timeInfo,
       unsigned long framesPerBuffer) = 0;
    virtual void SignalOtherCompletion() = 0;

--- a/src/MIDIPlay.cpp
+++ b/src/MIDIPlay.cpp
@@ -611,34 +611,35 @@ PmTimestamp MidiTime(void *pInfo)
 // Sends MIDI control changes up to the starting point mT0
 // if send is true. Output is delayed by offset to facilitate
 // looping (each iteration is delayed more).
-void MIDIPlay::PrepareMidiIterator(bool send, double offset)
+void MIDIPlay::PrepareMidiIterator(bool send, double startTime, double offset)
 {
-   int i;
-   int nTracks = mMidiPlaybackTracks.size();
+   mIterator.emplace(mPlaybackSchedule, *this,
+      mMidiPlaybackTracks, startTime, offset, send);
+}
+
+Iterator::Iterator(
+   const PlaybackSchedule &schedule, MIDIPlay &midiPlay,
+   NoteTrackConstArray &midiPlaybackTracks,
+   double startTime, double offset, bool send )
+   : mPlaybackSchedule{ schedule }
+   , mMIDIPlay{ midiPlay }
+{
    // instead of initializing with an Alg_seq, we use begin_seq()
    // below to add ALL Alg_seq's.
-   mIterator.emplace(mPlaybackSchedule, *this);
    // Iterator not yet initialized, must add each track...
-   for (i = 0; i < nTracks; i++) {
-      const auto t = mMidiPlaybackTracks[i].get();
+   for (auto &t : midiPlaybackTracks) {
       Alg_seq_ptr seq = &t->GetSeq();
       // mark sequence tracks as "in use" since we're handing this
       // off to another thread and want to make sure nothing happens
       // to the data until playback finishes. This is just a sanity check.
       seq->set_in_use(true);
-      mIterator->it.begin_seq(seq,
-         // casting away const, but allegro just uses the pointer as an opaque "cookie"
-         const_cast<NoteTrack*>(t),
-         t->GetOffset() + offset);
+      const void *cookie = t.get();
+      it.begin_seq(seq,
+         // casting away const, but allegro just uses the pointer opaquely
+         const_cast<void*>(cookie), t->GetOffset() + offset);
    }
-   mIterator->Prime(send, mPlaybackSchedule.mT0 + offset);
+   Prime(send, startTime + offset);
 }
-
-Iterator::Iterator(
-   const PlaybackSchedule &schedule, MIDIPlay &midiPlay )
-   : mPlaybackSchedule{ schedule }
-   , mMIDIPlay{ midiPlay }
-{}
 
 Iterator::~Iterator()
 {
@@ -724,7 +725,7 @@ bool MIDIPlay::StartPortMidiStream(double rate)
       mMidiLoopPasses = 0;
       mMidiOutputComplete = false;
       mMaxMidiTimestamp = 0;
-      PrepareMidiIterator(true, 0);
+      PrepareMidiIterator(true, mPlaybackSchedule.mT0, 0);
 
       // It is ok to call this now, but do not send timestamped midi
       // until after the first audio callback, which provides necessary
@@ -1012,7 +1013,7 @@ void MIDIPlay::FillOtherBuffers(
          if (mPlaybackSchedule.GetPolicy().Looping(mPlaybackSchedule)) {
             // jump back to beginning of loop
             ++mMidiLoopPasses;
-            PrepareMidiIterator(false, MidiLoopOffset());
+            PrepareMidiIterator(false, mPlaybackSchedule.mT0, MidiLoopOffset());
          }
          else
             mIterator.reset();

--- a/src/MIDIPlay.cpp
+++ b/src/MIDIPlay.cpp
@@ -973,18 +973,9 @@ void MIDIPlay::FillOtherBuffers(
    if (!mMidiStream)
       return;
 
-   // Keep track of time paused. If not paused, fill buffers.
-   if (paused) {
-      if (!mMidiPaused) {
-         mMidiPaused = true;
-         AllNotesOff(); // to avoid hanging notes during pause
-      }
+   // If not paused, fill buffers.
+   if (paused)
       return;
-   }
-
-   if (mMidiPaused) {
-      mMidiPaused = false;
-   }
 
    // If we compute until mNextEventTime > current audio time,
    // we would have a built-in compute-ahead of mAudioOutLatency, and
@@ -1101,7 +1092,7 @@ void MIDIPlay::AllNotesOff(bool looping)
    }
 }
 
-void MIDIPlay::ComputeOtherTimings(double rate,
+void MIDIPlay::ComputeOtherTimings(double rate, bool paused,
    const PaStreamCallbackTimeInfo *timeInfo,
    unsigned long framesPerBuffer
    )
@@ -1165,6 +1156,16 @@ void MIDIPlay::ComputeOtherTimings(double rate,
 
    mAudioFramesPerBuffer = framesPerBuffer;
    mNumFrames += framesPerBuffer;
+
+   // Keep track of time paused.
+   if (paused) {
+      if (!mMidiPaused) {
+         mMidiPaused = true;
+         AllNotesOff(); // to avoid hanging notes during pause
+      }
+   }
+   else if (mMidiPaused)
+      mMidiPaused = false;
 }
 
 unsigned MIDIPlay::CountOtherSoloTracks() const

--- a/src/MIDIPlay.cpp
+++ b/src/MIDIPlay.cpp
@@ -617,7 +617,7 @@ void MIDIPlay::PrepareMidiIterator(bool send, double offset)
    int nTracks = mMidiPlaybackTracks.size();
    // instead of initializing with an Alg_seq, we use begin_seq()
    // below to add ALL Alg_seq's.
-   mIterator.emplace();
+   mIterator.emplace(mPlaybackSchedule, *this);
    // Iterator not yet initialized, must add each track...
    for (i = 0; i < nTracks; i++) {
       const auto t = mMidiPlaybackTracks[i].get();
@@ -631,11 +631,27 @@ void MIDIPlay::PrepareMidiIterator(bool send, double offset)
          const_cast<NoteTrack*>(t),
          t->GetOffset() + offset);
    }
+   mIterator->Prime(send, mPlaybackSchedule.mT0 + offset);
+}
+
+Iterator::Iterator(
+   const PlaybackSchedule &schedule, MIDIPlay &midiPlay )
+   : mPlaybackSchedule{ schedule }
+   , mMIDIPlay{ midiPlay }
+{}
+
+Iterator::~Iterator()
+{
+   it.end();
+}
+
+void Iterator::Prime(bool send, double startTime)
+{
    GetNextEvent(); // prime the pump for FillOtherBuffers
 
    // Start MIDI from current cursor position
    while (mNextEvent &&
-          mNextEventTime < mPlaybackSchedule.mT0 + offset) {
+          GetNextEventTime() < startTime) {
       if (send)
          /*
           hasSolo argument doesn't matter because midiStateOnly is true.
@@ -646,6 +662,13 @@ void MIDIPlay::PrepareMidiIterator(bool send, double offset)
          OutputEvent(0, true, false);
       GetNextEvent();
    }
+}
+
+double Iterator::GetNextEventTime() const
+{
+   if (mNextEvent == &gAllNotesOff)
+      return mNextEventTime - ALG_EPS;
+   return mNextEventTime;
 }
 
 bool MIDIPlay::StartPortMidiStream(double rate)
@@ -750,24 +773,22 @@ void MIDIPlay::StopOtherStream()
    mMidiPlaybackTracks.clear();
 }
 
-static Alg_update gAllNotesOff; // special event for loop ending
-// the fields of this event are never used, only the address is important
-
-double MIDIPlay::UncorrectedMidiEventTime(double pauseTime)
+double Iterator::UncorrectedMidiEventTime(double pauseTime)
 {
    double time;
    if (mPlaybackSchedule.mEnvelope)
       time =
-         mPlaybackSchedule.RealDuration(mNextEventTime - MidiLoopOffset())
-         + mPlaybackSchedule.mT0 + (mMidiLoopPasses *
-                                    mPlaybackSchedule.mWarpedLength);
+         mPlaybackSchedule.RealDuration(
+            GetNextEventTime() - mMIDIPlay.MidiLoopOffset())
+         + mPlaybackSchedule.mT0 +
+           (mMIDIPlay.mMidiLoopPasses * mPlaybackSchedule.mWarpedLength);
    else
-      time = mNextEventTime;
+      time = GetNextEventTime();
 
    return time + pauseTime;
 }
 
-bool MIDIPlay::Unmuted(bool hasSolo) const
+bool Iterator::Unmuted(bool hasSolo) const
 {
    int channel = (mNextEvent->chan) & 0xF; // must be in [0..15]
    if (!mNextEventTrack->IsVisibleChan(channel))
@@ -778,7 +799,7 @@ bool MIDIPlay::Unmuted(bool hasSolo) const
    return !channelIsMute;
 }
 
-bool MIDIPlay::OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo)
+bool Iterator::OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo)
 {
    int channel = (mNextEvent->chan) & 0xF; // must be in [0..15]
    int command = -1;
@@ -789,7 +810,7 @@ bool MIDIPlay::OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo)
 
    // 0.0005 is for rounding
    double time = eventTime + 0.0005 -
-                 (mSynthLatency * 0.001);
+                 (mMIDIPlay.mSynthLatency * 0.001);
 
    time += 1; // MidiTime() has a 1s offset
    // state changes have to go out without delay because the
@@ -803,7 +824,7 @@ bool MIDIPlay::OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo)
    // all notes off on all channels"
    if (mNextEvent == &gAllNotesOff) {
       bool looping = mPlaybackSchedule.GetPolicy().Looping(mPlaybackSchedule);
-      AllNotesOff(looping);
+      mMIDIPlay.AllNotesOff(looping);
       return true;
    }
 
@@ -860,20 +881,20 @@ bool MIDIPlay::OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo)
             // clip velocity to insure a legal note-on value
             data2 = (data2 < 1 ? 1 : (data2 > 127 ? 127 : data2));
             // since we are going to play this note, we need to get a note_off
-            mIterator->it.request_note_off();
+            it.request_note_off();
 
 #ifdef AUDIO_IO_GB_MIDI_WORKAROUND
-            mPendingNotesOff.push_back(std::make_pair(channel, data1));
+            mMIDIPlay.mPendingNotesOff.push_back(std::make_pair(channel, data1));
 #endif
          }
          else {
             data2 = 0; // 0 velocity means "note off"
 #ifdef AUDIO_IO_GB_MIDI_WORKAROUND
-            auto end = mPendingNotesOff.end();
+            auto end = mMIDIPlay.mPendingNotesOff.end();
             auto iter = std::find(
-               mPendingNotesOff.begin(), end, std::make_pair(channel, data1) );
+               mMIDIPlay.mPendingNotesOff.begin(), end, std::make_pair(channel, data1) );
             if (iter != end)
-               mPendingNotesOff.erase(iter);
+               mMIDIPlay.mPendingNotesOff.erase(iter);
 #endif
          }
          command = 0x90; // MIDI NOTE ON (or OFF when velocity == 0)
@@ -925,10 +946,10 @@ bool MIDIPlay::OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo)
       }
       if (command != -1) {
          // keep track of greatest timestamp used
-         if (timestamp > mMaxMidiTimestamp) {
-            mMaxMidiTimestamp = timestamp;
+         if (timestamp > mMIDIPlay.mMaxMidiTimestamp) {
+            mMIDIPlay.mMaxMidiTimestamp = timestamp;
          }
-         Pm_WriteShort(mMidiStream, timestamp,
+         Pm_WriteShort(mMIDIPlay.mMidiStream, timestamp,
                     Pm_Message((int) (command + channel),
                                   (long) data1, (long) data2));
          /* wxPrintf("Pm_WriteShort %lx (%p) @ %d, advance %d\n",
@@ -940,17 +961,13 @@ bool MIDIPlay::OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo)
    return false;
 }
 
-void MIDIPlay::GetNextEvent()
+void Iterator::GetNextEvent()
 {
    mNextEventTrack = nullptr; // clear it just to be safe
    // now get the next event and the track from which it came
    double nextOffset;
-   if (!mIterator) {
-        mNextEvent = nullptr;
-        return;
-   }
-   auto midiLoopOffset = MidiLoopOffset();
-   mNextEvent = mIterator->it.next(&mNextIsNoteOn,
+   auto midiLoopOffset = mMIDIPlay.MidiLoopOffset();
+   mNextEvent = it.next(&mNextIsNoteOn,
       // Allegro retrieves the "cookie" for the event, which is a NoteTrack
       reinterpret_cast<void **>(&mNextEventTrack),
       &nextOffset, mPlaybackSchedule.mT1 + midiLoopOffset);
@@ -962,7 +979,7 @@ void MIDIPlay::GetNextEvent()
    }
    if (mNextEventTime > (mPlaybackSchedule.mT1 + midiLoopOffset)){ // terminate playback at mT1
       mNextEvent = &gAllNotesOff;
-      mNextEventTime = mPlaybackSchedule.mT1 + midiLoopOffset - ALG_EPS;
+      mNextEventTime = mPlaybackSchedule.mT1 + midiLoopOffset;
       mNextIsNoteOn = true; // do not look at duration
    }
 }
@@ -977,7 +994,7 @@ void MIDIPlay::FillOtherBuffers(
    if (paused)
       return;
 
-   // If we compute until mNextEventTime > current audio time,
+   // If we compute until GetNextEventTime() > current audio time,
    // we would have a built-in compute-ahead of mAudioOutLatency, and
    // it's probably good to compute MIDI when we compute audio (so when
    // we stop, both stop about the same time).
@@ -988,20 +1005,20 @@ void MIDIPlay::FillOtherBuffers(
    if (actual_latency > mAudioOutLatency) {
        time += actual_latency - mAudioOutLatency;
    }
-   while (mNextEvent &&
-          UncorrectedMidiEventTime(PauseTime(rate, pauseFrames)) < time) {
-      if (OutputEvent(PauseTime(rate, pauseFrames), false, hasSolo)) {
+   while (mIterator &&
+          mIterator->mNextEvent &&
+          mIterator->UncorrectedMidiEventTime(PauseTime(rate, pauseFrames)) < time) {
+      if (mIterator->OutputEvent(PauseTime(rate, pauseFrames), false, hasSolo)) {
          if (mPlaybackSchedule.GetPolicy().Looping(mPlaybackSchedule)) {
             // jump back to beginning of loop
             ++mMidiLoopPasses;
             PrepareMidiIterator(false, MidiLoopOffset());
-         } else {
-            mIterator.reset();
-            mNextEvent = NULL;
          }
+         else
+            mIterator.reset();
       }
-      else
-         GetNextEvent();
+      else if (mIterator)
+         mIterator->GetNextEvent();
    }
 }
 

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -123,6 +123,8 @@ struct MIDIPlay : AudioIOExt
    // synth latency.
    double UncorrectedMidiEventTime(double pauseTime);
 
+   bool Unmuted() const;
+
    // Returns true after outputting all-notes-off
    /// when true, midiStateOnly means send only updates, not note-ons,
    /// used to send state changes that precede the selected notes

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -33,6 +33,12 @@ class AudioThread;
 
 namespace {
 
+struct Iterator {
+   Alg_iterator it{ nullptr, false };
+
+   ~Iterator() { it.end(); }
+};
+
 struct MIDIPlay : AudioIOExt
 {
    explicit MIDIPlay(const PlaybackSchedule &schedule);
@@ -94,7 +100,7 @@ struct MIDIPlay : AudioIOExt
 
    double mSystemMinusAudioTimePlusLatency = 0.0;
 
-   std::optional<Alg_iterator> mIterator;
+   std::optional<Iterator> mIterator;
    /// The next event to play (or null)
    Alg_event    *mNextEvent = nullptr;
 

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -126,7 +126,8 @@ struct MIDIPlay : AudioIOExt
    // synth latency.
    double UncorrectedMidiEventTime(double pauseTime);
 
-   void OutputEvent(double pauseTime);
+   // Returns true after outputting all-notes-off
+   bool OutputEvent(double pauseTime);
    void GetNextEvent();
    double PauseTime(double rate, unsigned long pauseFrames);
    void AllNotesOff(bool looping = false);

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -123,12 +123,12 @@ struct MIDIPlay : AudioIOExt
    // synth latency.
    double UncorrectedMidiEventTime(double pauseTime);
 
-   bool Unmuted() const;
+   bool Unmuted(bool hasSolo) const;
 
    // Returns true after outputting all-notes-off
    /// when true, midiStateOnly means send only updates, not note-ons,
    /// used to send state changes that precede the selected notes
-   bool OutputEvent(double pauseTime, bool midiStateOnly);
+   bool OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo);
    void GetNextEvent();
    double PauseTime(double rate, unsigned long pauseFrames);
    void AllNotesOff(bool looping = false);
@@ -138,21 +138,6 @@ struct MIDIPlay : AudioIOExt
     * This is used by PortMidi to synchronize midi time to audio samples
     */
    PmTimestamp MidiTime();
-
-   // Note: audio code solves the problem of soloing/muting tracks by scanning
-   // all playback tracks on every call to the audio buffer fill routine.
-   // We do the same for Midi, but it seems wasteful for at least two
-   // threads to be frequently polling to update status. This could be
-   // eliminated (also with a reduction in code I think) by updating mHasSolo
-   // each time a solo button is activated or deactivated. For now, I'm
-   // going to do this polling in the FillMidiBuffer routine to localize
-   // changes for midi to the midi code, but I'm declaring the variable
-   // here so possibly in the future, Audio code can use it too. -RBD
- private:
-   bool  mHasSolo = false; // is any playback solo button pressed?
- public:
-   bool SetHasSolo(bool hasSolo);
-   bool GetHasSolo() { return mHasSolo; }
 
    bool mUsingAlsa = false;
 

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -144,7 +144,7 @@ struct MIDIPlay : AudioIOExt
    static bool IsActive();
    bool IsOtherStreamActive() const override;
 
-   void ComputeOtherTimings(double rate,
+   void ComputeOtherTimings(double rate, bool paused,
       const PaStreamCallbackTimeInfo *timeInfo,
       unsigned long framesPerBuffer) override;
    void SignalOtherCompletion() override;

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -13,7 +13,6 @@ Paul Licameli split from AudIOBase.h
 #define __AUDACITY_MIDI_PLAY__
 
 #include "AudioIOExt.h"
-#include "NoteTrack.h"
 #include <optional>
 #include "../lib-src/header-substitutes/allegro.h"
 
@@ -21,6 +20,7 @@ typedef void PmStream;
 typedef int32_t PmTimestamp;
 class Alg_event;
 class Alg_iterator;
+class NoteTrack;
 using NoteTrackConstArray = std::vector < std::shared_ptr< const NoteTrack > >;
 
 class AudioThread;
@@ -29,6 +29,7 @@ class AudioThread;
 // which seems not to implement the notes-off message correctly.
 #define AUDIO_IO_GB_MIDI_WORKAROUND
 
+#include "NoteTrack.h"
 #include "PlaybackSchedule.h"
 
 namespace {
@@ -40,7 +41,9 @@ Alg_update gAllNotesOff; // special event for loop ending
 
 struct Iterator {
    Iterator(
-      const PlaybackSchedule &schedule, MIDIPlay &midiPlay );
+      const PlaybackSchedule &schedule, MIDIPlay &midiPlay,
+      NoteTrackConstArray &midiPlaybackTracks,
+      double startTime, double offset, bool send );
    ~Iterator();
 
    void Prime(bool send, double startTime);
@@ -146,7 +149,7 @@ struct MIDIPlay : AudioIOExt
    std::vector< std::pair< int, int > > mPendingNotesOff;
 #endif
 
-   void PrepareMidiIterator(bool send, double offset);
+   void PrepareMidiIterator(bool send, double startTime, double offset);
    bool StartPortMidiStream(double rate);
    double PauseTime(double rate, unsigned long pauseFrames);
    void AllNotesOff(bool looping = false);

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -115,9 +115,6 @@ struct MIDIPlay : AudioIOExt
    NoteTrack        *mNextEventTrack = nullptr;
    /// Is the next event a note-on?
    bool             mNextIsNoteOn = false;
-   /// when true, mSendMidiState means send only updates, not note-on's,
-   /// used to send state changes that precede the selected notes
-   bool             mSendMidiState = false;
 
    void PrepareMidiIterator(bool send, double offset);
    bool StartPortMidiStream(double rate);
@@ -127,7 +124,9 @@ struct MIDIPlay : AudioIOExt
    double UncorrectedMidiEventTime(double pauseTime);
 
    // Returns true after outputting all-notes-off
-   bool OutputEvent(double pauseTime);
+   /// when true, midiStateOnly means send only updates, not note-ons,
+   /// used to send state changes that precede the selected notes
+   bool OutputEvent(double pauseTime, bool midiStateOnly);
    void GetNextEvent();
    double PauseTime(double rate, unsigned long pauseFrames);
    void AllNotesOff(bool looping = false);

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -440,7 +440,7 @@ void PlaybackSchedule::TimeQueue::Resize(size_t size)
 }
 
 void PlaybackSchedule::TimeQueue::Producer(
-   PlaybackSchedule &schedule, size_t nSamples )
+   PlaybackSchedule &schedule, PlaybackSlice slice )
 {
    auto &policy = schedule.GetPolicy();
 
@@ -456,28 +456,41 @@ void PlaybackSchedule::TimeQueue::Producer(
    auto space = TimeQueueGrainSize - remainder;
    const auto size = mData.size();
 
-   while ( nSamples >= space ) {
+   // Produce advancing times
+   auto frames = slice.toProduce;
+   while ( frames >= space ) {
       auto times = policy.AdvancedTrackTime( schedule, time, space );
       time = times.second;
       if (!std::isfinite(time))
          time = times.first;
       index = (index + 1) % size;
       mData[ index ].timeValue = time;
-      nSamples -= space;
+      frames -= space;
+      remainder = 0;
+      space = TimeQueueGrainSize;
+   }
+   // Last odd lot
+   if ( frames > 0 ) {
+      auto times = policy.AdvancedTrackTime( schedule, time, frames );
+      time = times.second;
+      if (!std::isfinite(time))
+         time = times.first;
+      remainder += frames;
+      space -= frames;
+   }
+
+   // Produce constant times if there is also some silence in the slice
+   frames = slice.frames - slice.toProduce;
+   while ( frames > 0 && frames >= space ) {
+      index = (index + 1) % size;
+      mData[ index ].timeValue = time;
+      frames -= space;
       remainder = 0;
       space = TimeQueueGrainSize;
    }
 
-   // Last odd lot
-   if ( nSamples > 0 ) {
-      auto times = policy.AdvancedTrackTime( schedule, time, nSamples );
-      time = times.second;
-      if (!std::isfinite(time))
-         time = times.first;
-   }
-
    mLastTime = time;
-   mTail.mRemainder = remainder + nSamples;
+   mTail.mRemainder = remainder + frames;
    mTail.mIndex = index;
 }
 

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -322,7 +322,7 @@ bool NewDefaultPlaybackPolicy::RepositionPlayback(
 
 bool NewDefaultPlaybackPolicy::Looping( const PlaybackSchedule & ) const
 {
-   return true;
+   return mLoopEnabled;
 }
 
 void PlaybackSchedule::Init(

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -316,8 +316,8 @@ struct AUDACITY_DLL_API PlaybackSchedule {
 
       //! @section Called by the AudioIO::TrackBufferExchange thread
 
-      //! Enqueue track time value advanced by `nSamples` according to `schedule`'s PlaybackPolicy
-      void Producer( PlaybackSchedule &schedule, size_t nSamples );
+      //! Enqueue track time value advanced by the slice according to `schedule`'s PlaybackPolicy
+      void Producer( PlaybackSchedule &schedule, PlaybackSlice slice );
 
       //! Return the last time saved by Producer
       double GetLastTime() const;


### PR DESCRIPTION
Prepares for the fixes for #2081 

Some preliminary refactorings before the real fix for adjusting bounds of looping play of MIDI (and also, enabling scrubbing of MIDI).  Not the complete fix .  Minor behavior changes, as described in commit comments.

* Small corrections of play head position
* Don't briefly sound the notes at the starting position again at the ending position when not playing looped (recent bug)
* Always send the correct update events for muted channels, in case they become un-muted during play (old bug)

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
