### PR TITLE
Effect cleanup part 3

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -6,6 +6,28 @@
 
 **********************************************************************/
 #include "EffectInterface.h"
+#include <wx/tokenzr.h>
+
+Identifier EffectDefinitionInterface::GetSquashedName(const Identifier &ident)
+{
+   // Get rid of leading and trailing white space
+   auto name = ident.GET();
+   name.Trim(true).Trim(false);
+
+   if (name.empty())
+      return {};
+
+   wxStringTokenizer st(name, wxT(" "));
+   wxString id;
+
+   // CamelCase the name
+   while (st.HasMoreTokens()) {
+      wxString tok = st.GetNextToken();
+      id += tok.Left(1).MakeUpper() + tok.Mid(1).MakeLower();
+   }
+
+   return id;
+}
 
 EffectDefinitionInterface::~EffectDefinitionInterface() = default;
 

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -61,6 +61,6 @@ bool EffectDefinitionInterface::IsHiddenFromMenus()
 //   return false;
 //}
 
-EffectClientInterface::~EffectClientInterface() = default;
+EffectProcessor::~EffectProcessor() = default;
 
 EffectUIClientInterface::~EffectUIClientInterface() = default;

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -9,10 +9,35 @@
 
 EffectDefinitionInterface::~EffectDefinitionInterface() = default;
 
+EffectType EffectDefinitionInterface::GetClassification()
+{
+   return GetType();
+}
+
 bool EffectDefinitionInterface::EnablesDebug()
 {
    return false;
 }
+
+ManualPageID EffectDefinitionInterface::ManualPage()
+{
+   return {};
+}
+
+FilePath EffectDefinitionInterface::HelpPage()
+{
+   return {};
+}
+
+bool EffectDefinitionInterface::IsHiddenFromMenus()
+{
+   return false;
+}
+
+//bool EffectDefinitionInterface::DefineParams(ShuttleParams & S)
+//{
+//   return false;
+//}
 
 EffectClientInterface::~EffectClientInterface() = default;
 

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -178,7 +178,6 @@ public:
    virtual sampleCount GetLatency() = 0;
    virtual size_t GetTailSize() = 0;
 
-   virtual bool IsReady() = 0;
    virtual bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) = 0;
    // This may be called during stack unwinding:
    virtual bool ProcessFinalize() /* noexcept */ = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -65,8 +65,9 @@ using EffectFamilySymbol = ComponentInterfaceSymbol;
 
 \class EffectDefinitionInterface 
 
-\brief EffectDefinitionInterface is a ComponentInterface that additionally tracks
-flag-functions for interactivity, play-preview and whether the effect can run without a GUI.
+\brief EffectDefinitionInterface is a ComponentInterface that adds some basic
+read-only information about effect properties, and getting and setting of
+parameters.
 
 *******************************************************************************************/
 class COMPONENTS_API EffectDefinitionInterface  /* not final */ : public ComponentInterface
@@ -74,33 +75,67 @@ class COMPONENTS_API EffectDefinitionInterface  /* not final */ : public Compone
 public:
    virtual ~EffectDefinitionInterface();
 
-   // Type determines how it behaves.
+   //! Type determines how it behaves.
    virtual EffectType GetType() = 0;
-   // Classification determines which menu it appears in.
-   virtual EffectType GetClassification() { return GetType();}
 
+   //! Determines which menu it appears in; default same as GetType().
+   virtual EffectType GetClassification();
+
+   //! Report identifier and user-visible name of the effect protocol
    virtual EffectFamilySymbol GetFamily() = 0;
 
-   // These should move to the "EffectClientInterface" class once all
-   // effects have been converted.
+   //! Whether the effect needs a dialog for entry of settings
    virtual bool IsInteractive() = 0;
 
-   // I don't really like this, but couldn't think of a better way to force the
-   // effect to appear "above the line" in the menus.
+   //! Whether the effect sorts "above the line" in the menus
    virtual bool IsDefault() = 0;
 
    // This will go away when all Effects have been updated to the new
    // interface.
    virtual bool IsLegacy() = 0;
 
-   // Whether the effect supports realtime previewing (while audio is playing).
+   //! Whether the effect supports realtime previewing (while audio is playing).
    virtual bool SupportsRealtime() = 0;
 
-   // Can the effect be used without the UI.
+   //! Whether the effect can be used without the UI, in a macro.
    virtual bool SupportsAutomation() = 0;
 
    //! Whether the effect dialog should have a Debug button; default, always false.
    virtual bool EnablesDebug();
+
+   //! Name of a page in the Audacity alpha manual, default is empty
+   virtual ManualPageID ManualPage();
+
+   //! Fully qualified local help file name, default is empty
+   virtual FilePath HelpPage();
+
+   //! Default is false
+   virtual bool IsHiddenFromMenus();
+
+   // Some effects will use define params to define what parameters they take.
+   // If they do, they won't need to implement Get or SetAutomation parameters.
+   // since the Effect class can do it.  Or at least that is how things happen
+   // in AudacityCommand.  IF we do the same in class Effect, then Effect maybe
+   // should derive by some route from AudacityCommand to pick up that
+   // functionality.
+   //virtual bool DefineParams( ShuttleParams & S);
+
+   //! Save current settings into parms
+   virtual bool GetAutomationParameters(CommandParameters & parms) = 0;
+   //! Change settings to those stored in parms
+   virtual bool SetAutomationParameters(CommandParameters & parms) = 0;
+
+   //! Change settings to a user-named preset
+   virtual bool LoadUserPreset(const RegistryPath & name) = 0;
+   //! Save current settings as a user-named preset
+   virtual bool SaveUserPreset(const RegistryPath & name) = 0;
+
+   //! Report names of factory presets
+   virtual RegistryPaths GetFactoryPresets() = 0;
+   //! Change settings to the preset whose name is `GetFactoryPresets()[id]`
+   virtual bool LoadFactoryPreset(int id) = 0;
+   //! Change settings back to "factory default"
+   virtual bool LoadFactoryDefaults() = 0;
 };
 
 class wxDialog;
@@ -191,23 +226,6 @@ public:
    virtual bool RealtimeProcessStart() = 0;
    virtual size_t RealtimeProcess(int group, float **inBuf, float **outBuf, size_t numSamples) = 0;
    virtual bool RealtimeProcessEnd() = 0;
-
-   // Some effects will use define params to define what parameters they take.
-   // If they do, they won't need to implement Get or SetAutomation parameters.
-   // since the Effect class can do it.  Or at least that is how things happen
-   // in AudacityCommand.  IF we do the same in class Effect, then Effect maybe 
-   // should derive by some route from AudacityCommand to pick up that 
-   // functionality.
-   //virtual bool DefineParams( ShuttleParams & S){ return false;};
-   virtual bool GetAutomationParameters(CommandParameters & parms) = 0;
-   virtual bool SetAutomationParameters(CommandParameters & parms) = 0;
-
-   virtual bool LoadUserPreset(const RegistryPath & name) = 0;
-   virtual bool SaveUserPreset(const RegistryPath & name) = 0;
-
-   virtual RegistryPaths GetFactoryPresets() = 0;
-   virtual bool LoadFactoryPreset(int id) = 0;
-   virtual bool LoadFactoryDefaults() = 0;
 };
 
 /*************************************************************************************//**

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -190,17 +190,18 @@ typedef enum
 
 /*************************************************************************************//**
 
-\class EffectClientInterface 
+\class EffectProcessor 
 
 \brief EffectClientInterface provides the ident interface to Effect, and is what makes
-Effect into a plug-in command.  It has functions for realtime that are not part of 
+Effect into a plug-in command.  It has functions for effect calculations that are not part of
 AudacityCommand.
 
 *******************************************************************************************/
-class COMPONENTS_API EffectClientInterface  /* not final */ : public EffectDefinitionInterface
+class COMPONENTS_API EffectProcessor  /* not final */
+   : public EffectDefinitionInterface
 {
 public:
-   virtual ~EffectClientInterface();
+   virtual ~EffectProcessor();
 
    virtual unsigned GetAudioInCount() = 0;
    virtual unsigned GetAudioOutCount() = 0;
@@ -213,12 +214,18 @@ public:
    virtual size_t SetBlockSize(size_t maxBlockSize) = 0;
    virtual size_t GetBlockSize() const = 0;
 
+   //! Called for destructive, non-realtime effect computation
    virtual sampleCount GetLatency() = 0;
    virtual size_t GetTailSize() = 0;
 
+   //! Called for destructive, non-realtime effect computation
    virtual bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) = 0;
+
+   //! Called for destructive, non-realtime effect computation
    // This may be called during stack unwinding:
    virtual bool ProcessFinalize() /* noexcept */ = 0;
+
+   //! Called for destructive, non-realtime effect computation
    virtual size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) = 0;
 
    virtual bool RealtimeInitialize() = 0;
@@ -240,7 +247,7 @@ values.  It can import and export presets.
 
 *******************************************************************************************/
 class COMPONENTS_API EffectUIClientInterface /* not final */
-   : public EffectClientInterface
+   : public EffectProcessor
 {
 public:
    virtual ~EffectUIClientInterface();

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -73,6 +73,9 @@ parameters.
 class COMPONENTS_API EffectDefinitionInterface  /* not final */ : public ComponentInterface
 {
 public:
+   //! A utility that strips spaces and CamelCases a name.
+   static Identifier GetSquashedName(const Identifier &ident);
+
    virtual ~EffectDefinitionInterface();
 
    //! Type determines how it behaves.

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -35,7 +35,6 @@ public:
 
    virtual EffectDefinitionInterface &GetDefinition() = 0;
 
-   virtual double GetDefaultDuration() = 0;
    virtual double GetDuration() = 0;
    virtual NumericFormatSymbol GetDurationFormat() = 0;
    virtual void SetDuration(double seconds) = 0;

--- a/src/commands/AudacityCommand.cpp
+++ b/src/commands/AudacityCommand.cpp
@@ -135,7 +135,7 @@ wxDialog *AudacityCommand::CreateUI(wxWindow *parent, AudacityCommand * WXUNUSED
    return NULL;
 }
 
-bool AudacityCommand::GetAutomationParameters(wxString & parms)
+bool AudacityCommand::GetAutomationParametersAsString(wxString & parms)
 {
    CommandParameters eap;
 
@@ -153,7 +153,7 @@ bool AudacityCommand::GetAutomationParameters(wxString & parms)
    return eap.GetParameters(parms);
 }
 
-bool AudacityCommand::SetAutomationParameters(const wxString & parms)
+bool AudacityCommand::SetAutomationParametersFromString(const wxString & parms)
 {
    wxString preset = parms;
 

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -74,8 +74,8 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
 
    wxDialog *CreateUI(wxWindow *parent, AudacityCommand *client);
 
-   virtual bool GetAutomationParameters(wxString & parms);
-   virtual bool SetAutomationParameters(const wxString & parms);
+   bool GetAutomationParametersAsString(wxString & parms);
+   bool SetAutomationParametersFromString(const wxString & parms);
 
    bool DoAudacityCommand(wxWindow *parent, const CommandContext & context,bool shouldPrompt = true);
 

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -111,7 +111,7 @@ EffectType EffectAmplify::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectAmplify::GetAudioInCount()
 {

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -40,6 +40,9 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+   bool LoadFactoryDefaults() override;
 
    // EffectClientInterface implementation
 
@@ -47,9 +50,6 @@ public:
    unsigned GetAudioOutCount() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-   bool LoadFactoryDefaults() override;
 
    // Effect implementation
 

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -44,7 +44,7 @@ public:
    bool SetAutomationParameters(CommandParameters & parms) override;
    bool LoadFactoryDefaults() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -130,7 +130,7 @@ EffectType EffectAutoDuck::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectAutoDuck::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM(  mDuckAmountDb, DuckAmountDb);
    S.SHUTTLE_PARAM(  mInnerFadeDownLen, InnerFadeDownLen);

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -37,12 +37,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -40,7 +40,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -120,7 +120,7 @@ bool EffectBassTreble::SupportsRealtime()
 }
 
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectBassTreble::GetAudioInCount()
 {
@@ -353,7 +353,7 @@ void EffectBassTreble::InstanceInit(EffectBassTrebleState & data, float sampleRa
 }
 
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 
 size_t EffectBassTreble::InstanceProcess(EffectBassTrebleState & data,

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -51,6 +51,8 @@ public:
 
    EffectType GetType() override;
    bool SupportsRealtime() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
@@ -66,8 +68,6 @@ public:
                                float **outbuf,
                                size_t numSamples) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
 
    // Effect Implementation

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -54,7 +54,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -162,7 +162,7 @@ EffectType EffectChangePitch::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectChangePitch::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( m_dPercentChange, Percentage );
    S.SHUTTLE_PARAM( mUseSBSMS, UseSBSMS );

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -51,13 +51,13 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+   bool LoadFactoryDefaults() override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-   bool LoadFactoryDefaults() override;
 
    // Effect implementation
 

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -55,7 +55,7 @@ public:
    bool SetAutomationParameters(CommandParameters & parms) override;
    bool LoadFactoryDefaults() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -137,7 +137,7 @@ EffectType EffectChangeSpeed::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectChangeSpeed::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( m_PercentChange, Percentage );
    return true;

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -38,13 +38,13 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+   bool LoadFactoryDefaults() override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-   bool LoadFactoryDefaults() override;
 
    // Effect implementation
 

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -42,7 +42,7 @@ public:
    bool SetAutomationParameters(CommandParameters & parms) override;
    bool LoadFactoryDefaults() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -141,7 +141,7 @@ bool EffectChangeTempo::SupportsAutomation()
    return true;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectChangeTempo::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( m_PercentChange, Percentage );
    S.SHUTTLE_PARAM( mUseSBSMS, UseSBSMS );

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -46,12 +46,12 @@ public:
 
    EffectType GetType() override;
    bool SupportsAutomation() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -49,7 +49,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -105,7 +105,7 @@ EffectType EffectClickRemoval::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectClickRemoval::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mThresholdLevel, Threshold );
    S.SHUTTLE_PARAM( mClickWidth, Width );

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -43,7 +43,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -40,12 +40,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -127,7 +127,7 @@ EffectType EffectCompressor::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectCompressor::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mThresholdDB, Threshold );
    S.SHUTTLE_PARAM( mNoiseFloorDB, NoiseFloor );

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -39,12 +39,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -42,7 +42,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -219,7 +219,7 @@ bool EffectDistortion::SupportsRealtime()
 #endif
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectDistortion::GetAudioInCount()
 {

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -71,6 +71,10 @@ public:
 
    EffectType GetType() override;
    bool SupportsRealtime() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+   RegistryPaths GetFactoryPresets() override;
+   bool LoadFactoryPreset(int id) override;
 
    // EffectClientInterface implementation
 
@@ -86,10 +90,6 @@ public:
                                float **outbuf,
                                size_t numSamples) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-   RegistryPaths GetFactoryPresets() override;
-   bool LoadFactoryPreset(int id) override;
 
    // Effect implementation
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -76,7 +76,7 @@ public:
    RegistryPaths GetFactoryPresets() override;
    bool LoadFactoryPreset(int id) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -122,7 +122,7 @@ EffectType EffectDtmf::GetType()
    return EffectTypeGenerate;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectDtmf::GetAudioOutCount()
 {

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -42,7 +42,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -39,6 +39,8 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
@@ -46,8 +48,6 @@ public:
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -79,7 +79,7 @@ EffectType EffectEcho::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectEcho::GetAudioInCount()
 {

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -35,6 +35,8 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
@@ -44,8 +46,6 @@ public:
    bool ProcessFinalize() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -38,7 +38,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -23,7 +23,6 @@
 
 #include <wx/defs.h>
 #include <wx/sizer.h>
-#include <wx/tokenzr.h>
 
 #include "../AudioIO.h"
 #include "widgets/wxWidgetsWindowPlacement.h"
@@ -669,8 +668,8 @@ void Effect::ExportPresets()
 {
    wxString params;
    GetAutomationParametersAsString(params);
-   wxString commandId = GetSquashedName(GetSymbol().Internal()).GET();
-   params =  commandId + ":" + params;
+   auto commandId = GetSquashedName(GetSymbol().Internal());
+   params =  commandId.GET() + ":" + params;
 
    auto path = SelectFile(FileNames::Operation::Presets,
                                      XO("Export Effect Parameters"),
@@ -735,7 +734,7 @@ void Effect::ImportPresets()
          wxString ident = params.BeforeFirst(':');
          params = params.AfterFirst(':');
 
-         wxString commandId = GetSquashedName(GetSymbol().Internal()).GET();
+         auto commandId = GetSquashedName(GetSymbol().Internal());
 
          if (ident != commandId) {
             // effect identifiers are a sensible length!
@@ -762,30 +761,6 @@ void Effect::ImportPresets()
 
    //SetWindowTitle();
 
-}
-
-CommandID Effect::GetSquashedName(wxString name)
-{
-   // Get rid of leading and trailing white space
-   name.Trim(true).Trim(false);
-
-   if (name.empty())
-   {
-      return name;
-   }
-
-   wxStringTokenizer st(name, wxT(" "));
-   wxString id;
-
-   // CamelCase the name
-   while (st.HasMoreTokens())
-   {
-      wxString tok = st.GetNextToken();
-
-      id += tok.Left(1).MakeUpper() + tok.Mid(1).MakeLower();
-   }
-
-   return id;
 }
 
 bool Effect::HasOptions()

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -528,8 +528,11 @@ int Effect::ShowHostInterface(wxWindow &parent,
    auto result = client->ShowClientInterface(parent, *mHostUIDialog, forceModal);
    if (!mHostUIDialog->IsShown())
       // Client didn't show it, or showed it modally and closed it
-      // So destroy it
-      mHostUIDialog.reset();
+      // So destroy it.
+      // (I think mHostUIDialog only needs to be a local variable in this
+      // function -- that it is always null when the function begins -- but
+      // that may change. PRL)
+      mHostUIDialog->Destroy();
 
    return result;
 }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -560,7 +560,7 @@ bool Effect::LoadUserPreset(const RegistryPath & name)
       return false;
    }
 
-   return SetAutomationParameters(parms);
+   return SetAutomationParametersFromString(parms);
 }
 
 bool Effect::SaveUserPreset(const RegistryPath & name)
@@ -571,10 +571,8 @@ bool Effect::SaveUserPreset(const RegistryPath & name)
    }
 
    wxString parms;
-   if (!GetAutomationParameters(parms))
-   {
+   if (!GetAutomationParametersAsString(parms))
       return false;
-   }
 
    return SetConfig(GetDefinition(), PluginSettings::Private,
       name, wxT("Parameters"), parms);
@@ -670,7 +668,7 @@ static const FileNames::FileTypes &PresetTypes()
 void Effect::ExportPresets()
 {
    wxString params;
-   GetAutomationParameters(params);
+   GetAutomationParametersAsString(params);
    wxString commandId = GetSquashedName(GetSymbol().Internal()).GET();
    params =  commandId + ":" + params;
 
@@ -758,7 +756,7 @@ void Effect::ImportPresets()
             }
             return;
          }
-         SetAutomationParameters(params);
+         SetAutomationParametersFromString(params);
       }
    }
 
@@ -914,7 +912,7 @@ bool Effect::Startup()
    return true;
 }
 
-bool Effect::GetAutomationParameters(wxString & parms)
+bool Effect::GetAutomationParametersAsString(wxString & parms)
 {
    CommandParameters eap;
 
@@ -937,7 +935,7 @@ bool Effect::GetAutomationParameters(wxString & parms)
    return eap.GetParameters(parms);
 }
 
-bool Effect::SetAutomationParameters(const wxString & parms)
+bool Effect::SetAutomationParametersFromString(const wxString & parms)
 {
    wxString preset = parms;
    bool success = false;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -42,8 +42,6 @@
 #include "../WaveTrack.h"
 #include "wxFileNameWrapper.h"
 #include "../widgets/ProgressDialog.h"
-#include "../tracks/playabletrack/wavetrack/ui/WaveTrackView.h"
-#include "../tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.h"
 #include "../widgets/NumericTextCtrl.h"
 #include "../widgets/AudacityMessageBox.h"
 
@@ -2247,8 +2245,6 @@ void Effect::Preview(bool dryOnly)
 
       mixLeft->Offset(-mixLeft->GetStartTime());
       mixLeft->SetSelected(true);
-      WaveTrackView::Get( *mixLeft )
-         .SetDisplay(WaveTrackViewConstants::NoDisplay);
       auto pLeft = mTracks->Add( mixLeft );
       Track *pRight{};
       if (mixRight) {
@@ -2263,8 +2259,6 @@ void Effect::Preview(bool dryOnly)
          if (src->GetSelected() || mPreviewWithNotSelected) {
             auto dest = src->Copy(mT0, t1);
             dest->SetSelected(src->GetSelected());
-            WaveTrackView::Get( *static_cast<WaveTrack*>(dest.get()) )
-               .SetDisplay(WaveTrackViewConstants::NoDisplay);
             mTracks->Add( dest );
          }
       }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -246,7 +246,7 @@ bool Effect::SupportsAutomation()
    return true;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 bool Effect::SetHost(EffectHostInterface *host)
 {

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -996,16 +996,6 @@ bool Effect::SetAutomationParametersFromString(const wxString & parms)
    return TransferDataToWindow();
 }
 
-ManualPageID Effect::ManualPage()
-{
-   return {};
-}
-
-FilePath Effect::HelpPage()
-{
-   return {};
-}
-
 unsigned Effect::TestUIFlags(unsigned mask) {
    return mask & mUIFlags;
 }
@@ -2101,11 +2091,6 @@ void Effect::CountWaveTracks()
 double Effect::CalcPreviewInputLength(double previewLength)
 {
    return previewLength;
-}
-
-bool Effect::IsHidden()
-{
-   return false;
 }
 
 void Effect::Preview(bool dryOnly)

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -205,8 +205,8 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // NEW virtuals
    virtual bool Startup(EffectUIClientInterface *client);
 
-   virtual bool GetAutomationParameters(wxString & parms);
-   virtual bool SetAutomationParameters(const wxString & parms);
+   virtual bool GetAutomationParametersAsString(wxString & parms);
+   virtual bool SetAutomationParametersFromString(const wxString & parms);
 
    // Name of page in the Audacity alpha manual
    virtual ManualPageID ManualPage();

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -170,8 +170,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    void ExportPresets() override;
    void ImportPresets() override;
 
-   static CommandID GetSquashedName(wxString name);
-
    bool HasOptions() override;
    void ShowOptions() override;
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -128,7 +128,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
 
-   bool IsReady() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
@@ -178,7 +177,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // EffectHostInterface implementation
 
    EffectDefinitionInterface &GetDefinition() override;
-   double GetDefaultDuration() override;
    double GetDuration() override;
    NumericFormatSymbol GetDurationFormat() override;
    virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar
@@ -197,31 +195,26 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    // Effect implementation
 
+   unsigned TestUIFlags(unsigned mask);
+
+   void SetPresetParameters( const wxArrayString * Names, const wxArrayString * Values ) {
+      if( Names ) mPresetNames = *Names;
+      if( Values ) mPresetValues = *Values;
+   }
+
    // NEW virtuals
    virtual bool Startup(EffectUIClientInterface *client);
-   virtual bool Startup();
 
    virtual bool GetAutomationParameters(wxString & parms);
    virtual bool SetAutomationParameters(const wxString & parms);
-
-   virtual RegistryPaths GetUserPresets();
-   virtual bool HasCurrentSettings();
-   virtual bool HasFactoryDefaults();
 
    // Name of page in the Audacity alpha manual
    virtual ManualPageID ManualPage();
    // Fully qualified local help file name
    virtual FilePath HelpPage();
 
-   virtual void SetUIFlags(unsigned flags);
-   virtual unsigned TestUIFlags(unsigned mask);
    virtual bool IsBatchProcessing();
    virtual void SetBatchProcessing(bool start);
-
-   /* not virtual */ void SetPresetParameters( const wxArrayString * Names, const wxArrayString * Values ) {
-      if( Names ) mPresetNames = *Names;
-      if( Values ) mPresetValues = *Values;
-   }
 
    // Returns true on success.  Will only operate on tracks that
    // have the "selected" flag set to true, which is consistent with
@@ -230,6 +223,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    /* not virtual */ bool DoEffect( double projectRate, TrackList *list,
       WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
       // Prompt the user for input only if these arguments are both not null.
+      unsigned flags,
       wxWindow *pParent = nullptr,
       const EffectDialogFactory &dialogFactory = {} );
 
@@ -238,7 +232,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    virtual bool IsHidden();
 
-   // Nonvirtual
    // Display a message box, using effect's (translated) name as the prefix
    // for the title.
    enum : long { DefaultMessageBoxStyle = wxOK | wxCENTRE };
@@ -247,6 +240,14 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
                   const TranslatableString& titleStr = {});
 
    static void IncEffectCounter(){ nEffectsDone++;};
+
+ protected:
+   bool EnableApply(bool enable = true);
+   bool EnablePreview(bool enable = true);
+
+ public:
+   // NEW virtuals
+   virtual bool Startup();
 
 //
 // protected virtual methods
@@ -273,7 +274,6 @@ protected:
    virtual bool ProcessPass();
    virtual bool InitPass1();
    virtual bool InitPass2();
-   virtual int GetPass();
 
    // clean up any temporary memory, needed only per invocation of the
    // effect, after either successful or failed or exception-aborted processing.
@@ -291,8 +291,6 @@ protected:
    virtual void PopulateOrExchange(ShuttleGui & S);
    virtual bool TransferDataToWindow() /* not override */;
    virtual bool TransferDataFromWindow() /* not override */;
-   virtual bool EnableApply(bool enable = true);
-   virtual bool EnablePreview(bool enable = true);
 
    // No more virtuals!
 
@@ -447,13 +445,15 @@ protected:
    //! This weak pointer may be the same as the above, or null
    wxWeakRef<wxDialog> mUIDialog;
    wxWindow       *mUIParent;
-   unsigned       mUIFlags;
+   unsigned       mUIFlags{ 0 };
 
    sampleCount    mSampleCnt;
 
  // Used only by the base Effect class
  //
  private:
+   double GetDefaultDuration();
+
    void CountWaveTracks();
 
    // Driver for client effects

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -442,8 +442,8 @@ protected:
    int            mPass;
 
    // UI
-   //! This smart pointer controls the lifetime of the dialog
-   wxWindowPtr<wxDialog> mHostUIDialog;
+   //! This smart pointer tracks the lifetime of the dialog
+   wxWeakRef<wxDialog> mHostUIDialog;
    //! This weak pointer may be the same as the above, or null
    wxWeakRef<wxDialog> mUIDialog;
    wxWindow       *mUIParent;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -121,7 +121,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool SetHost(EffectHostInterface *host) override;
    
@@ -262,6 +262,10 @@ protected:
    virtual bool CheckWhetherSkipEffect() { return false; }
 
    // Actually do the effect here.
+   /*! If Process() is not overridden, it uses ProcessInitialize(),
+    ProcessBlock(), and ProcessFinalize() methods of EffectProcessor,
+    and also GetLatency() to determine how many leading output samples to
+    discard and how many extra samples to produce. */
    virtual bool Process();
    virtual bool ProcessPass();
    virtual bool InitPass1();

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -111,6 +111,16 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+
+   bool LoadUserPreset(const RegistryPath & name) override;
+   bool SaveUserPreset(const RegistryPath & name) override;
+
+   RegistryPaths GetFactoryPresets() override;
+   bool LoadFactoryPreset(int id) override;
+   bool LoadFactoryDefaults() override;
+
    // EffectClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
@@ -147,15 +157,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal = false) override;
 
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-
-   bool LoadUserPreset(const RegistryPath & name) override;
-   bool SaveUserPreset(const RegistryPath & name) override;
-
-   RegistryPaths GetFactoryPresets() override;
-   bool LoadFactoryPreset(int id) override;
-   bool LoadFactoryDefaults() override;
 
    // EffectUIClientInterface implementation
 
@@ -208,11 +209,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    virtual bool GetAutomationParametersAsString(wxString & parms);
    virtual bool SetAutomationParametersFromString(const wxString & parms);
 
-   // Name of page in the Audacity alpha manual
-   virtual ManualPageID ManualPage();
-   // Fully qualified local help file name
-   virtual FilePath HelpPage();
-
    virtual bool IsBatchProcessing();
    virtual void SetBatchProcessing(bool start);
 
@@ -229,8 +225,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    bool Delegate( Effect &delegate,
       wxWindow &parent, const EffectDialogFactory &factory );
-
-   virtual bool IsHidden();
 
    // Display a message box, using effect's (translated) name as the prefix
    // for the title.

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -240,7 +240,7 @@ wxString EffectManager::GetEffectParameters(const PluginID & ID)
    {
       wxString parms;
 
-      effect->GetAutomationParameters(parms);
+      effect->GetAutomationParametersAsString(parms);
 
       // Some effects don't have automatable parameters and will not return
       // anything, so try to get the active preset (current or factory).
@@ -258,7 +258,7 @@ wxString EffectManager::GetEffectParameters(const PluginID & ID)
    {
       wxString parms;
 
-      command->GetAutomationParameters(parms);
+      command->GetAutomationParametersAsString(parms);
 
       // Some effects don't have automatable parameters and will not return
       // anything, so try to get the active preset (current or factory).
@@ -282,10 +282,11 @@ bool EffectManager::SetEffectParameters(const PluginID & ID, const wxString & pa
 
       if (eap.HasEntry(wxT("Use Preset")))
       {
-         return effect->SetAutomationParameters(eap.Read(wxT("Use Preset")));
+         return effect
+            ->SetAutomationParametersFromString(eap.Read(wxT("Use Preset")));
       }
 
-      return effect->SetAutomationParameters(params);
+      return effect->SetAutomationParametersFromString(params);
    }
    AudacityCommand *command = GetAudacityCommand(ID);
    
@@ -297,10 +298,11 @@ bool EffectManager::SetEffectParameters(const PluginID & ID, const wxString & pa
 
       if (eap.HasEntry(wxT("Use Preset")))
       {
-         return command->SetAutomationParameters(eap.Read(wxT("Use Preset")));
+         return command
+            ->SetAutomationParametersFromString(eap.Read(wxT("Use Preset")));
       }
 
-      return command->SetAutomationParameters(params);
+      return command->SetAutomationParametersFromString(params);
    }
    return false;
 }

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -121,8 +121,8 @@ TranslatableString EffectManager::GetVendorName(const PluginID & ID)
 
 CommandID EffectManager::GetCommandIdentifier(const PluginID & ID)
 {
-   wxString name = PluginManager::Get().GetSymbol(ID).Internal();
-   return Effect::GetSquashedName(name);
+   auto name = PluginManager::Get().GetSymbol(ID).Internal();
+   return EffectDefinitionInterface::GetSquashedName(name);
 }
 
 TranslatableString EffectManager::GetCommandDescription(const PluginID & ID)

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -205,7 +205,7 @@ bool EffectManager::IsHidden(const PluginID & ID)
 
    if (effect)
    {
-      return effect->IsHidden();
+      return effect->IsHiddenFromMenus();
    }
 
    return false;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1862,12 +1862,12 @@ wxDialog *EffectUI::DialogFactory( wxWindow &parent, EffectHostInterface &host,
          EffectRack::Get( context.project ).Add(effect);
       }
 #endif
-      effect->SetUIFlags(flags);
       success = effect->DoEffect(
          rate,
          &tracks,
          &trackFactory,
          selectedRegion,
+         flags,
          &window,
          (flags & EffectManager::kConfigured) == 0
             ? DialogFactory

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -370,7 +370,7 @@ EffectType EffectEqualization::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectEqualization::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mM, FilterLength );
    //S.SHUTTLE_PARAM( mCurveName, CurveName);

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -106,14 +106,11 @@ public:
    ComponentInterfaceSymbol GetSymbol() override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
+   bool DefineParams( ShuttleParams & S ) override;
 
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
-
-   // EffectClientInterface implementation
-
-   bool DefineParams( ShuttleParams & S ) override;
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
    bool LoadFactoryDefaults() override;

--- a/src/effects/Fade.cpp
+++ b/src/effects/Fade.cpp
@@ -67,7 +67,7 @@ bool EffectFade::IsInteractive()
    return false;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectFade::GetAudioInCount()
 {

--- a/src/effects/Fade.h
+++ b/src/effects/Fade.h
@@ -29,7 +29,7 @@ public:
    EffectType GetType() override;
    bool IsInteractive() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -80,7 +80,7 @@ EffectType EffectFindClipping::GetType()
    return EffectTypeAnalyze;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectFindClipping::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mStart, Start );
    S.SHUTTLE_PARAM( mStop, Stop );

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -36,7 +36,7 @@ public:
 
    EffectType GetType() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
    bool GetAutomationParameters(CommandParameters & parms) override;

--- a/src/effects/Invert.cpp
+++ b/src/effects/Invert.cpp
@@ -58,7 +58,7 @@ bool EffectInvert::IsInteractive()
    return false;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectInvert::GetAudioInCount()
 {

--- a/src/effects/Invert.h
+++ b/src/effects/Invert.h
@@ -33,7 +33,7 @@ public:
    EffectType GetType() override;
    bool IsInteractive() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -105,7 +105,7 @@ EffectType EffectLoudness::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectLoudness::DefineParams( ShuttleParams & S )
 {
    S.SHUTTLE_PARAM( mStereoInd, StereoInd );

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -43,12 +43,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -46,7 +46,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -103,7 +103,7 @@ EffectType EffectNoise::GetType()
    return EffectTypeGenerate;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectNoise::GetAudioOutCount()
 {

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -35,14 +35,14 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    unsigned GetAudioOutCount() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -38,7 +38,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioOutCount() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -90,7 +90,7 @@ EffectType EffectNormalize::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectNormalize::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mPeakLevel, PeakLevel );
    S.SHUTTLE_PARAM( mGain, ApplyGain );

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -37,12 +37,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -40,7 +40,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -129,7 +129,7 @@ EffectType EffectPaulstretch::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectPaulstretch::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mAmount, Amount );
    S.SHUTTLE_PARAM( mTime_resolution, Time );

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -34,7 +34,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -31,12 +31,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -136,7 +136,7 @@ bool EffectPhaser::SupportsRealtime()
 #endif
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectPhaser::GetAudioInCount()
 {

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -57,6 +57,8 @@ public:
 
    EffectType GetType() override;
    bool SupportsRealtime() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
@@ -72,8 +74,6 @@ public:
                                        float **outbuf,
                                        size_t numSamples) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -60,7 +60,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -20,9 +20,9 @@
 class RealtimeEffectState
 {
 public:
-   explicit RealtimeEffectState( EffectClientInterface &effect );
+   explicit RealtimeEffectState( EffectProcessor &effect );
 
-   EffectClientInterface &GetEffect() const { return mEffect; }
+   EffectProcessor &GetEffect() const { return mEffect; }
 
    bool RealtimeSuspend();
    bool RealtimeResume();
@@ -32,7 +32,7 @@ public:
    bool IsRealtimeActive();
 
 private:
-   EffectClientInterface &mEffect;
+   EffectProcessor &mEffect;
 
    std::vector<int> mGroupProcessor;
    int mCurrentProcessor;
@@ -110,7 +110,7 @@ bool RealtimeEffectManager::RealtimeIsSuspended()
    return mRealtimeSuspended;
 }
 
-void RealtimeEffectManager::RealtimeAddEffect(EffectClientInterface &effect)
+void RealtimeEffectManager::RealtimeAddEffect(EffectProcessor &effect)
 {
    // Block RealtimeProcess()
    RealtimeSuspend();
@@ -137,7 +137,7 @@ void RealtimeEffectManager::RealtimeAddEffect(EffectClientInterface &effect)
    RealtimeResume();
 }
 
-void RealtimeEffectManager::RealtimeRemoveEffect(EffectClientInterface &effect)
+void RealtimeEffectManager::RealtimeRemoveEffect(EffectProcessor &effect)
 {
    // Block RealtimeProcess()
    RealtimeSuspend();
@@ -235,7 +235,7 @@ void RealtimeEffectManager::RealtimeSuspend()
    mRealtimeLock.Leave();
 }
 
-void RealtimeEffectManager::RealtimeSuspendOne( EffectClientInterface &effect )
+void RealtimeEffectManager::RealtimeSuspendOne( EffectProcessor &effect )
 {
    auto begin = mStates.begin(), end = mStates.end();
    auto found = std::find_if( begin, end,
@@ -268,7 +268,7 @@ void RealtimeEffectManager::RealtimeResume()
    mRealtimeLock.Leave();
 }
 
-void RealtimeEffectManager::RealtimeResumeOne( EffectClientInterface &effect )
+void RealtimeEffectManager::RealtimeResumeOne( EffectProcessor &effect )
 {
    auto begin = mStates.begin(), end = mStates.end();
    auto found = std::find_if( begin, end,
@@ -404,7 +404,7 @@ int RealtimeEffectManager::GetRealtimeLatency()
    return mRealtimeLatency;
 }
 
-RealtimeEffectState::RealtimeEffectState( EffectClientInterface &effect )
+RealtimeEffectState::RealtimeEffectState( EffectProcessor &effect )
    : mEffect{ effect }
 {
 }

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -15,13 +15,13 @@
 #include <vector>
 #include <wx/thread.h>
 
-class EffectClientInterface;
+class EffectProcessor;
 class RealtimeEffectState;
 
 class AUDACITY_DLL_API RealtimeEffectManager final
 {
 public:
-   using EffectArray = std::vector <EffectClientInterface*> ;
+   using EffectArray = std::vector <EffectProcessor*> ;
 
    /** Get the singleton instance of the RealtimeEffectManager. **/
    static RealtimeEffectManager & Get();
@@ -29,16 +29,16 @@ public:
    // Realtime effect processing
    bool RealtimeIsActive();
    bool RealtimeIsSuspended();
-   void RealtimeAddEffect(EffectClientInterface &effect);
-   void RealtimeRemoveEffect(EffectClientInterface &effect);
+   void RealtimeAddEffect(EffectProcessor &effect);
+   void RealtimeRemoveEffect(EffectProcessor &effect);
    void RealtimeSetEffects(const EffectArray & mActive);
    void RealtimeInitialize(double rate);
    void RealtimeAddProcessor(int group, unsigned chans, float rate);
    void RealtimeFinalize();
    void RealtimeSuspend();
-   void RealtimeSuspendOne( EffectClientInterface &effect );
+   void RealtimeSuspendOne( EffectProcessor &effect );
    void RealtimeResume();
-   void RealtimeResumeOne( EffectClientInterface &effect );
+   void RealtimeResumeOne( EffectProcessor &effect );
    void RealtimeProcessStart();
    size_t RealtimeProcess(int group, unsigned chans, float **buffers, size_t numSamples);
    void RealtimeProcessEnd();

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -88,7 +88,7 @@ EffectType EffectRepeat::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectRepeat::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( repeatCount, Count );
    return true;

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -38,7 +38,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -35,12 +35,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -161,7 +161,7 @@ EffectType EffectReverb::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectReverb::GetAudioInCount()
 {

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -57,7 +57,7 @@ public:
    RegistryPaths GetFactoryPresets() override;
    bool LoadFactoryPreset(int id) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -52,6 +52,10 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+   RegistryPaths GetFactoryPresets() override;
+   bool LoadFactoryPreset(int id) override;
 
    // EffectClientInterface implementation
 
@@ -61,10 +65,6 @@ public:
    bool ProcessFinalize() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-   RegistryPaths GetFactoryPresets() override;
-   bool LoadFactoryPreset(int id) override;
 
    // Effect implementation
 

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -205,7 +205,7 @@ EffectType EffectScienFilter::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectScienFilter::GetAudioInCount()
 {

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -46,6 +46,8 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
@@ -54,8 +56,6 @@ public:
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -49,7 +49,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -219,7 +219,7 @@ bool EffectStereoToMono::ProcessOne(sampleCount & curTime, sampleCount totalTime
    return bResult;
 }
 
-bool EffectStereoToMono::IsHidden()
+bool EffectStereoToMono::IsHiddenFromMenus()
 {
    return true;
 }

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -62,7 +62,7 @@ bool EffectStereoToMono::IsInteractive()
    return false;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectStereoToMono::GetAudioInCount()
 {

--- a/src/effects/StereoToMono.h
+++ b/src/effects/StereoToMono.h
@@ -39,7 +39,7 @@ public:
    // Effect implementation
 
    bool Process() override;
-   bool IsHidden() override;
+   bool IsHiddenFromMenus() override;
 
 private:
    // EffectStereoToMono implementation

--- a/src/effects/StereoToMono.h
+++ b/src/effects/StereoToMono.h
@@ -31,7 +31,7 @@ public:
    EffectType GetType() override;
    bool IsInteractive() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -113,7 +113,7 @@ EffectType EffectTimeScale::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool EffectTimeScale::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( m_RatePercentChangeStart,  RatePercentStart );
    S.SHUTTLE_PARAM( m_RatePercentChangeEnd,    RatePercentEnd );

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -41,7 +41,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -38,12 +38,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -155,7 +155,7 @@ EffectType EffectToneGen::GetType()
    return EffectTypeGenerate;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectToneGen::GetAudioOutCount()
 {

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -33,6 +33,8 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
@@ -40,8 +42,6 @@ public:
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -36,7 +36,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -181,7 +181,7 @@ EffectType EffectTruncSilence::GetType()
    return EffectTypeProcess;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 bool EffectTruncSilence::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mThresholdDB, Threshold );

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -43,12 +43,12 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -46,7 +46,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1303,7 +1303,7 @@ bool VSTEffect::SupportsAutomation()
 }
 
 // ============================================================================
-// EffectClientInterface Implementation
+// EffectProcessor Implementation
 // ============================================================================
 
 bool VSTEffect::SetHost(EffectHostInterface *host)

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -221,8 +221,10 @@ enum InfoKeys
 /// Information about one VST effect.
 ///
 ///////////////////////////////////////////////////////////////////////////////
-class VSTSubProcess final : public wxProcess,
-                      public EffectDefinitionInterface
+//! This object exists in a separate process, to validate a newly seen plug-in.
+/*! It needs to implement EffectDefinitionInterface but mostly just as stubs */
+class VSTSubProcess final : public wxProcess
+   , public EffectDefinitionInterface
 {
 public:
    VSTSubProcess()
@@ -230,7 +232,7 @@ public:
       Redirect();
    }
 
-   // EffectClientInterface implementation
+   // EffectDefinitionInterface implementation
 
    PluginPath GetPath() override
    {
@@ -291,6 +293,16 @@ public:
    {
       return mAutomatable;
    }
+
+   bool GetAutomationParameters(CommandParameters &) override { return true; }
+   bool SetAutomationParameters(CommandParameters &) override { return true; }
+
+   bool LoadUserPreset(const RegistryPath &) override { return true; }
+   bool SaveUserPreset(const RegistryPath &) override { return true; }
+
+   RegistryPaths GetFactoryPresets() override { return {}; }
+   bool LoadFactoryPreset(int) override { return true; }
+   bool LoadFactoryDefaults() override { return true; }
 
 public:
    wxString mPath;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -86,7 +86,7 @@ DECLARE_LOCAL_EVENT_TYPE(EVT_UPDATEDISPLAY, -1);
 
 ///////////////////////////////////////////////////////////////////////////////
 ///
-/// VSTEffect is an Audacity EffectClientInterface that forwards actual 
+/// VSTEffect is an Audacity EffectProcessor that forwards actual 
 /// audio processing via a VSTEffectLink
 ///
 ///////////////////////////////////////////////////////////////////////////////
@@ -127,7 +127,7 @@ class VSTEffect final : public wxEvtHandler,
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -132,7 +132,7 @@ class VSTEffect final : public wxEvtHandler,
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
 
-   bool IsReady() override;
+   bool IsReady();
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -117,6 +117,16 @@ class VSTEffect final : public wxEvtHandler,
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+
+   bool LoadUserPreset(const RegistryPath & name) override;
+   bool SaveUserPreset(const RegistryPath & name) override;
+
+   RegistryPaths GetFactoryPresets() override;
+   bool LoadFactoryPreset(int id) override;
+   bool LoadFactoryDefaults() override;
+
    // EffectClientInterface implementation
 
    unsigned GetAudioInCount() override;
@@ -151,16 +161,6 @@ class VSTEffect final : public wxEvtHandler,
 
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
-
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-
-   bool LoadUserPreset(const RegistryPath & name) override;
-   bool SaveUserPreset(const RegistryPath & name) override;
-
-   RegistryPaths GetFactoryPresets() override;
-   bool LoadFactoryPreset(int id) override;
-   bool LoadFactoryDefaults() override;
 
    // EffectUIClientInterface implementation
 

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -127,7 +127,7 @@ bool EffectWahwah::SupportsRealtime()
 #endif
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned EffectWahwah::GetAudioInCount()
 {

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -57,7 +57,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -54,6 +54,8 @@ public:
 
    EffectType GetType() override;
    bool SupportsRealtime() override;
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // EffectClientInterface implementation
 
@@ -69,8 +71,6 @@ public:
                                        float **outbuf,
                                        size_t numSamples) override;
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -912,7 +912,7 @@ TranslatableString AudioUnitEffect::GetDescription()
 }
 
 // ============================================================================
-// EffectComponentInterface implementation
+// EffectDefinitionInterface implementation
 // ============================================================================
 
 EffectType AudioUnitEffect::GetType()

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1009,7 +1009,7 @@ bool AudioUnitEffect::SupportsAutomation()
 }
 
 // ============================================================================
-// EffectClientInterface Implementation
+// EffectProcessor Implementation
 // ============================================================================
 
 bool AudioUnitEffect::SetHost(EffectHostInterface *host)

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -854,8 +854,6 @@ AudioUnitEffect::AudioUnitEffect(const PluginPath & path,
    mUnitInitialized = false;
 
    mEventListenerRef = NULL;
-
-   mReady = false;
 }
 
 AudioUnitEffect::~AudioUnitEffect()
@@ -1245,11 +1243,6 @@ size_t AudioUnitEffect::GetTailSize()
    return tailTime * mSampleRate;
 }
 
-bool AudioUnitEffect::IsReady()
-{
-   return mReady;
-}
-
 bool AudioUnitEffect::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
 {
    OSStatus result;
@@ -1298,15 +1291,11 @@ bool AudioUnitEffect::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelN
 
    mLatencyDone = false;
 
-   mReady = true;
-
    return true;
 }
 
 bool AudioUnitEffect::ProcessFinalize()
 {
-   mReady = false;
-
    mOutputList.reset();
    mInputList.reset();
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -81,7 +81,6 @@ public:
    sampleCount GetLatency() override;
    size_t GetTailSize() override;
 
-   bool IsReady() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
@@ -196,7 +195,6 @@ private:
    bool mUseLatency;
 
    AudioTimeStamp mTimeStamp;
-   bool mReady;
 
    ArrayOf<AudioBufferList> mInputList;
    ArrayOf<AudioBufferList> mOutputList;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -56,7 +56,7 @@ public:
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 
-   // EffectComponentInterface implementation
+   // EffectDefinitionInterface implementation
 
    EffectType GetType() override;
    EffectFamilySymbol GetFamily() override;
@@ -65,6 +65,16 @@ public:
    bool IsLegacy() override;
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
+
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+
+   bool LoadUserPreset(const RegistryPath & name) override;
+   bool SaveUserPreset(const RegistryPath & name) override;
+
+   RegistryPaths GetFactoryPresets() override;
+   bool LoadFactoryPreset(int id) override;
+   bool LoadFactoryDefaults() override;
 
    // EffectClientInterface implementation
 
@@ -99,16 +109,6 @@ public:
 
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
-
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-
-   bool LoadUserPreset(const RegistryPath & name) override;
-   bool SaveUserPreset(const RegistryPath & name) override;
-
-   bool LoadFactoryPreset(int id) override;
-   bool LoadFactoryDefaults() override;
-   RegistryPaths GetFactoryPresets() override;
 
    // EffectUIClientInterface implementation
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -76,7 +76,7 @@ public:
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -943,11 +943,6 @@ size_t LadspaEffect::GetTailSize()
    return 0;
 }
 
-bool LadspaEffect::IsReady()
-{
-   return mReady;
-}
-
 bool LadspaEffect::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
 {
    /* Instantiate the plugin */

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -721,7 +721,7 @@ bool LadspaEffect::SupportsAutomation()
 }
 
 // ============================================================================
-// EffectClientInterface Implementation
+// EffectProcessor Implementation
 // ============================================================================
 
 bool LadspaEffect::SetHost(EffectHostInterface *host)

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -75,7 +75,7 @@ public:
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -80,7 +80,6 @@ public:
    sampleCount GetLatency() override;
    size_t GetTailSize() override;
 
-   bool IsReady() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -65,6 +65,16 @@ public:
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+
+   bool LoadUserPreset(const RegistryPath & name) override;
+   bool SaveUserPreset(const RegistryPath & name) override;
+
+   RegistryPaths GetFactoryPresets() override;
+   bool LoadFactoryPreset(int id) override;
+   bool LoadFactoryDefaults() override;
+
    // EffectClientInterface implementation
 
    unsigned GetAudioInCount() override;
@@ -98,16 +108,6 @@ public:
 
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
-
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-
-   bool LoadUserPreset(const RegistryPath & name) override;
-   bool SaveUserPreset(const RegistryPath & name) override;
-
-   RegistryPaths GetFactoryPresets() override;
-   bool LoadFactoryPreset(int id) override;
-   bool LoadFactoryDefaults() override;
 
    // EffectUIClientInterface implementation
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1048,11 +1048,6 @@ size_t LV2Effect::GetTailSize()
    return 0;
 }
 
-bool LV2Effect::IsReady()
-{
-   return mMaster != NULL;
-}
-
 bool LV2Effect::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
 {
    mProcess = InitInstance(mSampleRate);

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -518,7 +518,7 @@ bool LV2Effect::SupportsAutomation()
 }
 
 // ============================================================================
-// EffectClientInterface Implementation
+// EffectProcessor Implementation
 // ============================================================================
 bool LV2Effect::SetHost(EffectHostInterface *host)
 {

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -293,7 +293,6 @@ public:
    sampleCount GetLatency() override;
    size_t GetTailSize() override;
 
-   bool IsReady() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(float **inbuf, float **outbuf, size_t size) override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -288,7 +288,7 @@ public:
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -278,6 +278,16 @@ public:
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+
+   bool LoadUserPreset(const RegistryPath & name) override;
+   bool SaveUserPreset(const RegistryPath & name) override;
+
+   RegistryPaths GetFactoryPresets() override;
+   bool LoadFactoryPreset(int id) override;
+   bool LoadFactoryDefaults() override;
+
    // EffectClientInterface implementation
 
    unsigned GetAudioInCount() override;
@@ -309,9 +319,6 @@ public:
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
-
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
@@ -320,13 +327,6 @@ public:
    bool ValidateUI() override;
    bool HideUI() override;
    bool CloseUI() override;
-
-   bool LoadUserPreset(const RegistryPath & name) override;
-   bool SaveUserPreset(const RegistryPath & name) override;
-
-   RegistryPaths GetFactoryPresets() override;
-   bool LoadFactoryPreset(int id) override;
-   bool LoadFactoryDefaults() override;
 
    bool CanExportPresets() override;
    void ExportPresets() override;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -296,7 +296,7 @@ bool NyquistEffect::IsDefault()
    return mIsPrompt;
 }
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 bool NyquistEffect::DefineParams( ShuttleParams & S )
 {
    // For now we assume Nyquist can do get and set better than DefineParams can,

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -570,11 +570,16 @@ bool NyquistEffect::Init()
 
       for ( auto t :
                TrackList::Get( *project ).Selected< const WaveTrack >() ) {
-         const auto displays = WaveTrackView::Get(*t).GetDisplays();
-         if (displays.end() != std::find(
-            displays.begin(), displays.end(),
-            WaveTrackSubView::Type{ WaveTrackViewConstants::Spectrum, {} }))
-            hasSpectral = true;
+         // Find() not Get() to avoid creation-on-demand of views in case we are
+         // only previewing
+         auto pView = WaveTrackView::Find( t );
+         if ( pView ) {
+            const auto displays = pView->GetDisplays();
+            if (displays.end() != std::find(
+               displays.begin(), displays.end(),
+               WaveTrackSubView::Type{ WaveTrackViewConstants::Spectrum, {} }))
+               hasSpectral = true;
+         }
          if ( hasSpectral &&
              (t->GetSpectrogramSettings().SpectralSelectionEnabled())) {
             bAllowSpectralEditing = true;
@@ -1155,22 +1160,27 @@ bool NyquistEffect::ProcessOne()
          [&](const WaveTrack *wt) {
             type = wxT("wave");
             spectralEditp = mCurTrack[0]->GetSpectrogramSettings().SpectralSelectionEnabled()? wxT("T") : wxT("NIL");
-            auto displays = WaveTrackView::Get( *wt ).GetDisplays();
-            auto format = [&]( decltype(displays[0]) display ) {
-               // Get the English name of the view type, without menu codes,
-               // as a string that Lisp can examine
-               return wxString::Format( wxT("\"%s\""),
-                  display.name.Stripped().Debug() );
-            };
-            if (displays.empty())
-               view = wxT("NIL");
-            else if (displays.size() == 1)
-               view = format( displays[0] );
-            else {
-               view = wxT("(list");
-               for ( auto display : displays )
-                  view += wxString(wxT(" ")) + format( display );
-               view += wxT(")");
+            view = wxT("NIL");
+            // Find() not Get() to avoid creation-on-demand of views in case we are
+            // only previewing
+            if ( const auto pView = WaveTrackView::Find( wt ) ) {
+               auto displays = pView->GetDisplays();
+               auto format = [&]( decltype(displays[0]) display ) {
+                  // Get the English name of the view type, without menu codes,
+                  // as a string that Lisp can examine
+                  return wxString::Format( wxT("\"%s\""),
+                     display.name.Stripped().Debug() );
+               };
+               if (displays.empty())
+                  ;
+               else if (displays.size() == 1)
+                  view = format( displays[0] );
+               else {
+                  view = wxT("(list");
+                  for ( auto display : displays )
+                     view += wxString(wxT(" ")) + format( display );
+                  view += wxT(")");
+               }
             }
          },
 #if defined(USE_MIDI)

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -91,11 +91,12 @@ public:
    bool IsDefault() override;
    bool EnablesDebug() override;
 
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+
    // EffectClientInterface implementation
 
    bool DefineParams( ShuttleParams & S ) override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
    int SetLispVarsFromParameters(CommandParameters & parms, bool bTestOnly);
 
    // Effect implementation

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -94,7 +94,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    bool DefineParams( ShuttleParams & S ) override;
    int SetLispVarsFromParameters(CommandParameters & parms, bool bTestOnly);

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -138,7 +138,7 @@ bool VampEffect::IsDefault()
 }
 
 
-// EffectClientInterface implementation
+// EffectProcessor implementation
 
 unsigned VampEffect::GetAudioInCount()
 {

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -60,7 +60,7 @@ public:
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
 
-   // EffectClientInterface implementation
+   // EffectProcessor implementation
 
    unsigned GetAudioInCount() override;
 

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -57,11 +57,12 @@ public:
    bool IsInteractive() override;
    bool IsDefault() override;
 
+   bool GetAutomationParameters(CommandParameters & parms) override;
+   bool SetAutomationParameters(CommandParameters & parms) override;
+
    // EffectClientInterface implementation
 
    unsigned GetAudioInCount() override;
-   bool GetAutomationParameters(CommandParameters & parms) override;
-   bool SetAutomationParameters(CommandParameters & parms) override;
 
    // Effect implementation
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -865,6 +865,16 @@ const WaveTrackView &WaveTrackView::Get( const WaveTrack &track )
    return Get( const_cast<WaveTrack&>( track ) );
 }
 
+WaveTrackView *WaveTrackView::Find( WaveTrack *pTrack )
+{
+   return static_cast< WaveTrackView* >( TrackView::Find( pTrack ) );
+}
+
+const WaveTrackView *WaveTrackView::Find( const WaveTrack *pTrack )
+{
+   return Find( const_cast<WaveTrack*>( pTrack ) );
+}
+
 WaveTrackView::WaveTrackView( const std::shared_ptr<Track> &pTrack )
    : CommonTrackView{ pTrack }
 {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
@@ -107,6 +107,8 @@ public:
 
    static WaveTrackView &Get( WaveTrack &track );
    static const WaveTrackView &Get( const WaveTrack &track );
+   static WaveTrackView *Find( WaveTrack *pTrack );
+   static const WaveTrackView *Find( const WaveTrack *pTrack );
 
    explicit
    WaveTrackView( const std::shared_ptr<Track> &pTrack );

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.h
@@ -36,8 +36,6 @@ namespace WaveTrackViewConstants
       // Add values here, and update MaxDisplay.
 
       MaxDisplay = Spectrum,
-
-      NoDisplay,            // Preview track has no display
    };
 
    // Only two types of sample display for now, but

--- a/src/tracks/ui/TrackView.cpp
+++ b/src/tracks/ui/TrackView.cpp
@@ -76,6 +76,20 @@ const TrackView &TrackView::Get( const Track &track )
    return Get( const_cast< Track & >( track ) );
 }
 
+TrackView *TrackView::Find( Track *pTrack )
+{
+   if (!pTrack)
+      return nullptr;
+   auto &track = *pTrack;
+   // do not create on demand if it is null
+   return track.AttachedObjects::Find< TrackView >( key );
+}
+
+const TrackView *TrackView::Find( const Track *pTrack )
+{
+   return Find( const_cast< Track* >( pTrack ) );
+}
+
 void TrackView::SetMinimized(bool isMinimized)
 {
    // Do special changes appropriate to subclass

--- a/src/tracks/ui/TrackView.h
+++ b/src/tracks/ui/TrackView.h
@@ -46,6 +46,8 @@ public:
 
    static TrackView &Get( Track & );
    static const TrackView &Get( const Track & );
+   static TrackView *Find( Track * );
+   static const TrackView *Find( const Track * );
 
    bool GetMinimized() const { return mMinimized; }
    void SetMinimized( bool minimized );


### PR DESCRIPTION
Contributes to #2084

Not the end of cleanups yet.  Still simplifying and better documenting the interface class Effect and its sub-classes.

Also fixing a crash recently introduced in Master, and preventing a dependency cycle in the prototype of realtime effects when rebased onto this.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
