### PR TITLE
Writers of XML sub-objects must execute after attributes...

### DIFF
--- a/libraries/lib-project-rate/ProjectRate.cpp
+++ b/libraries/lib-project-rate/ProjectRate.cpp
@@ -79,7 +79,7 @@ void ProjectRate::SetRate(double rate)
    }
 }
 
-static ProjectFileIORegistry::WriterEntry entry {
+static ProjectFileIORegistry::AttributeWriterEntry entry {
 [](const AudacityProject &project, XMLWriter &xmlFile){
    xmlFile.WriteAttr(wxT("rate"), ProjectRate::Get(project).GetRate());
 }

--- a/libraries/lib-screen-geometry/ViewInfo.cpp
+++ b/libraries/lib-screen-geometry/ViewInfo.cpp
@@ -353,7 +353,7 @@ int ViewInfo::UpdateScrollPrefsID()
    return 10000;
 }
 
-static ProjectFileIORegistry::WriterEntry entry {
+static ProjectFileIORegistry::AttributeWriterEntry entry {
 [](const AudacityProject &project, XMLWriter &xmlFile){
    ViewInfo::Get(project).WriteXMLAttributes(xmlFile);
 }

--- a/libraries/lib-xml/XMLMethodRegistry.cpp
+++ b/libraries/lib-xml/XMLMethodRegistry.cpp
@@ -65,14 +65,29 @@ bool XMLMethodRegistryBase::CallAttributeHandler( const std::string_view &tag,
    return false;
 }
 
-void XMLMethodRegistryBase::Register( TypeErasedWriter writer )
+void XMLMethodRegistryBase::RegisterAttributeWriter( TypeErasedWriter writer )
 {
-   mWriterTable.emplace_back( move( writer ) );
+   mAttributeWriterTable.emplace_back( move( writer ) );
 }
 
-void XMLMethodRegistryBase::CallWriters( const void *p, XMLWriter &writer )
+void XMLMethodRegistryBase::CallAttributeWriters(
+   const void *p, XMLWriter &writer )
 {
-   const auto &table = mWriterTable;
+   const auto &table = mAttributeWriterTable;
+   for ( auto &fn : table )
+      if (fn)
+         fn( p, writer );
+}
+
+void XMLMethodRegistryBase::RegisterObjectWriter( TypeErasedWriter writer )
+{
+   mObjectWriterTable.emplace_back( move( writer ) );
+}
+
+void XMLMethodRegistryBase::CallObjectWriters(
+   const void *p, XMLWriter &writer )
+{
+   const auto &table = mObjectWriterTable;
    for ( auto &fn : table )
       if (fn)
          fn( p, writer );

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1819,7 +1819,8 @@ void ProjectFileIO::WriteXML(XMLWriter &xmlFile,
    xmlFile.WriteAttr(wxT("version"), wxT(AUDACITY_FILE_FORMAT_VERSION));
    xmlFile.WriteAttr(wxT("audacityversion"), AUDACITY_VERSION_STRING);
 
-   ProjectFileIORegistry::Get().CallWriters(proj, xmlFile);
+   ProjectFileIORegistry::Get().CallAttributeWriters(proj, xmlFile);
+   ProjectFileIORegistry::Get().CallObjectWriters(proj, xmlFile);
 
    tracklist.Any().Visit([&](const Track *t)
    {

--- a/src/ProjectSettings.cpp
+++ b/src/ProjectSettings.cpp
@@ -195,7 +195,7 @@ void ProjectSettings::SetSyncLock(bool flag)
    }
 }
 
-static ProjectFileIORegistry::WriterEntry entry {
+static ProjectFileIORegistry::AttributeWriterEntry entry {
 [](const AudacityProject &project, XMLWriter &xmlFile){
    auto &settings = ProjectSettings::Get(project);
    xmlFile.WriteAttr(wxT("snapto"), settings.GetSnapTo() ? wxT("on") : wxT("off"));

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -1529,7 +1529,7 @@ bool TagsEditorDialog::IsWindowRectValid(const wxRect *windowRect) const
    return true;
 }
 
-static ProjectFileIORegistry::WriterEntry entry {
+static ProjectFileIORegistry::ObjectWriterEntry entry {
 [](const AudacityProject &project, XMLWriter &xmlFile){
    Tags::Get(project).WriteXML(xmlFile);
 }


### PR DESCRIPTION
... when they are attached via the registry.  Do not tolerate cross-platform
permutations of the call sequence that violate this requirement!  Still
tolerating permutations that do not violate it.

This system still depends on the registered functions honoring the contract.  It
doesn't check it.

So among existing registered writes, the one for Tags (only) needs to be
guaranteed last.

Resolves: #2216

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
