### PR TITLE
Fix Issue #2239: crash cancelling Nyquist prompt...

### DIFF
--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -757,10 +757,7 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
 
 EffectUIHost::~EffectUIHost()
 {
-   CleanupRealtime();
-   if (mNeedsResume)
-      Resume();
-   mClient.CloseUI();
+   wxASSERT(mClosed);
 }
 
 // ============================================================================
@@ -1082,6 +1079,9 @@ void EffectUIHost::OnClose(wxCloseEvent & WXUNUSED(evt))
    mClient.CloseUI();
 
    Destroy();
+#if wxDEBUG_LEVEL
+   mClosed = true;
+#endif
 }
 
 void EffectUIHost::OnApply(wxCommandEvent & evt)

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -211,6 +211,11 @@ private:
    bool mDismissed{};
    bool mNeedsResume{};
 
+#if wxDEBUG_LEVEL
+   // Used only in an assertion
+   bool mClosed{ false };
+#endif
+
    DECLARE_EVENT_TABLE()
 };
 


### PR DESCRIPTION
... To reproduce:

* Generate a tone
* Open the Nyquist Prompt and enter the code:

```
;control test "Test" float "" 5 0 10
(print test)
```

* Click the "OK" button
* Click the "Cancel" button
* Observe crash

Bug was introduced at b1e988e4f50ff19050d00c8c5685d43a9fc8a62b
The nulling-out of a pointer to the Effect in the Close routine was deleted,
but the destructor is still called later.

To fix it, don't unnecessarily repeat in the destructor of the modal dialog
(which may be delayed until an event loop) what was already done when closing
it.

Resolves: #2239

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
