### PR TITLE
Vocoder update - fix issue 2230

### DIFF
--- a/plug-ins/vocoder.ny
+++ b/plug-ins/vocoder.ny
@@ -1,19 +1,19 @@
 $nyquist plug-in
-$version 3
+$version 4
 $type process
 $preview enabled
 $name (_ "Vocoder")
 $manpage "Vocoder"
 $action (_ "Processing Vocoder...")
-$author (_ "Edgar-RFT")
-$release 2.3.0
+$author (_ "Edgar-RFT and Steve Daulton")
+$release 3.1.2
 $copyright (_ "Released under terms of the GNU General Public License version 2")
 
-;; vocoder.ny by Edgar-RFT
-;; a bit of code added by David R. Sky
-;; GUI update by Steve Daulton July 2012.
-;; Performance improvement, error message for mono, code cleanup
-;; by Paul Licameli and Steve Daulton October 2014
+;; Based on vocoder.ny by Edgar-RFT
+;;
+;; If selected track is mono, the vocoder uses sine waves as the modulation
+;; carrier, mixed with noise and radar needles according to slider settings.
+;; If selected track is stereo, the right channel is used as the carrier wave.
 
 ;; Released under terms of the GNU General Public License version 2:
 ;; http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -21,122 +21,99 @@ $copyright (_ "Released under terms of the GNU General Public License version 2"
 ;; For information about writing and modifying Nyquist plug-ins:
 ;; https://wiki.audacityteam.org/wiki/Nyquist_Plug-ins_Reference
 
-$control dst (_ "Distance: (1 to 120, default = 20)") real "" 20 1 120
-$control mst (_ "Output choice") choice (
-   ("BothChannels" (_ "Both Channels"))
-   ("RightOnly" (_ "Right Only"))
-) 0
+$control dst (_ "Distance: (1 to 120, default = 20)") float "" 20 1 120
+$control mst (_ "Output choice") choice (("BothChannels" (_ "Both Channels"))
+                                         ("RightOnly" (_ "Right Only"))) 0
 $control bands (_ "Number of vocoder bands") int "" 40 10 240
-$control track-vl (_ "Amplitude of original audio (percent)") real "" 100 0 100
-$control noise-vl (_ "Amplitude of white noise (percent)") real "" 0 0 100
-$control radar-vl (_ "Amplitude of Radar Needles (percent)") real "" 0 0 100
-$control radar-f (_ "Frequency of Radar Needles (Hz)") real "" 30 1 100
+$control track-vl (_ "Amplitude of carrier wave (percent)") float "" 100 0 100
+$control noise-vl (_ "Amplitude of white noise (percent)") float "" 0 0 100
+$control radar-vl (_ "Amplitude of Radar Needles (percent)") float "" 0 0 100
+$control radar-f (_ "Frequency of Radar Needles (Hz)") float "" 30 1 100
 
-; maybe the code once again has to be changed into _one_ local let-binding
-; if you have lots of nyquist "[gc:" messages try this:
-; (expand 100) ; gives Xlisp more memory but I have noticed no speed difference
 
-;; number of octaves between 20hz and 20khz
-(setf octaves (/ (log 1000.0) (log 2.0)))
+;; Return log to base 2 of x.
+(defun log2 (x)
+  (/ (log (float x)) (log 2.0)))
 
-;; convert octaves to number of steps (semitones)
-(setf steps (* octaves 12.0))
+;; number of octaves from 20 Hz.
+;; Maximum number of octaves is: log2(high-hz / low-hz)
+;; "2.205" is for compatibility with older versions of vocoder effect.
+(setf octaves (log2 (/ (/ *sound-srate* 2.205) 20)))
 
-;; interval - number of steps per vocoder band
-(setf interval (/ steps bands))
 
-;;; Some useful calculations but not used in this plugin
+;; interval - number of semitones per vocoder band
+(setf interval (/ (* octaves 12.0) bands))
 
-;; half tone distance in linear
-; (print (exp (/ (log 2.0) 12)))
 
-;; octave distance in linear
-; (print (exp (/ (log 1000.0) 40)))
-
-;;; The Radar Wavetable
-
-;; make *radar-table* a global variable.
-(setf contol-dummy *control-srate*)   ; save old *control-srate*
-(set-control-srate *sound-srate*)  
-(setf *radar-table* (pwl (/ 1.0 *control-srate*) 1.0  ; 1.0 after 1 sample
-                         (/ 2.0 *control-srate*) 0.0  ; 0.0 after 2 samples
-                         (/ 1.0 radar-f))) ; stay 0.0 until end of the period
-(set-control-srate contol-dummy)      ; restore *control-srate*
-;; make *radar-table* become a nyquist wavetable of frequency radar-f
-(setf *radar-table* (list *radar-table* (hz-to-step radar-f) T))
-
-;; increase the volume of the audacity track in the middle of the slider
-;; the sqrt trick is something like an artificial db scaling
-(setf track-vol (sqrt (/ track-vl 100.0)))
-;; decrease the volume of the white noise in the middle of the slider
-;; the expt trick is an inverse db scaling
+;; Scale slider values for better control.
+(setf track-vl (sqrt (/ track-vl 100.0)))
 (setf noise-vol (expt (/ noise-vl 100.0) 2.0))
-;; also increase the volume of the needles in the middle of the slider
 (setf radar-vol (sqrt (/ radar-vl 100.0)))
 
-;;; here you can switch the tracks on and off for bug tracking
 
-;  (setf radar-vol 0)
-;  (setf noise-vol 0)
-;  (setf track-vol 0)
+
+(defun make-radar-table (hz)
+  (let ((one (/ *sound-srate*)) ;one sample period
+        radar-table)
+    (setf radar-table
+        (stretch-abs 1 (sim (snd-const 1 one *sound-srate* one)
+                            (s-rest (/ 1.0 hz)))))
+    (list radar-table (hz-to-step hz) T)))
+
 
 ;;; The Mixer
+(defun mix-noise (sig)
+  (sum (cond ((= track-vl 0) 0)
+             ((< track-vl 1) (mult track-vl sig))
+             (t sig))
+       (if (> radar-vl 0)
+           (let ((r-table (make-radar-table radar-f)))
+             (mult radar-vol
+                   (osc (hz-to-step radar-f) 1 r-table)))
+           0)
+       (if (> noise-vl 0)
+           (mult noise-vol (noise 1))
+           0)))
 
-;; calculate duration of audacity selection
-(setf duration (/ len *sound-srate*))
 
-(defun mix ()
-  ;; if track volume slider is less than 100 percent decrease track volume
-  (if (< track-vl 100)
-      (setf s
-            (vector (aref s 0) (scale track-vol (aref s 1)))))
+;; Raise 'hz' by 'interval' semitones.
+(defmacro next-hz (hz interval)
+  `(let* ((prev-step (hz-to-step ,hz))
+          (next-step (+ prev-step ,interval)))
+    (step-to-hz next-step)))
 
-  ;; if radar volume slider is more than 0 percent add some radar needles
-  (if (> radar-vl 0)
-      (setf s
-            (vector (aref s 0)
-                    (sim (aref s 1)
-                         (scale radar-vol (osc (hz-to-step radar-f)
-                                               duration *radar-table*))))))
 
-  ;; if noise volume slider is more than 0 percent add some white noise
-  (if (> noise-vl 0)
-      (setf s
-            (vector (aref s 0)
-                    (sim (aref s 1) (scale noise-vol (noise duration)))))))
+(defmacro sumto (x y)
+  `(setf ,x (sum ,x ,y)))
 
-;;; The Vocoder
 
-(defun vocoder ()
-  (do* ((i 0 (1+ i))
-        mod-envelope  ; local variable for filtered envelope of left channel.
-        band          ; local variable for band-passed audio.
-        (result 0)    ; result must be initialized because you cannot sum to NIL.
-        (q (/ (sqrt 2.0) (/ octaves bands)))    ; quick approximation of q
-                                                ; for given bandwidth.
-        (p (+ (hz-to-step 20) (/ interval 2.0)) ; midi step of 20 Hz + offset.
-           (+ p interval))
-        (f (step-to-hz p) (step-to-hz p)))
-      ((= i bands) result)        ; DO for each band then return 'result'.
-    (setf band (bandpass2 s f q)) ; intermediate results (2 channels)
-    (setf mod-envelope (lowpass8 (s-abs (aref band 0)) (/ f dst)))
-    (setf result
-          (sum result
-               (bandpass2
-                 (mult mod-envelope (aref band 1))
-                 f q)))))
+;;; Stereo Vocoder - returns mono sound.
+(defun vocoder (sig is-mono-track)
+  (let (mod-envelope
+        band
+        (result 0))
+    (do ((i 0 (1+ i))
+         (q (/ (sqrt 2.0) (/ octaves bands)))  ; quick approximation of q
+         (f (next-hz 20 (/ interval 2.0))
+            (next-hz f interval)))
+        ((= i bands) result)
+      (when is-mono-track
+        (sumto (aref sig 1) (mult 0.5 (/ track-vl bands) (hzosc f))))
+      (setf band (bandpass2 sig f q)) ; intermediate results (2 channels)
+      (setf mod-envelope (lowpass8 (s-abs (aref band 0)) (/ f dst)))
+      (sumto result (bandpass2 (mult mod-envelope (aref band 1)) f q)))))
+
 
 ;;; The Program
-
-(cond
- ((arrayp s)
-  (mix)                     ; changes s
-  (let ((original (or (= mst 0) (aref s 0))))
-    (setf s (vocoder))
-    ;; Now normalize s to 0 db peak
-    (setf s (scale (/ (peak s ny:all)) s))
-    (case mst
-          (0 s)             ; let Audacity coerce back to stereo
-          (1 (vector original s)))))
- (t                         ; this effect isn't meant for mono
-  (format nil (_ "Error.~%Stereo track required."))))
+(if (= (+ track-vl noise-vol radar-vol) 0)
+    (format nil (_ "Error.~%No modulation carrier."))
+    (progn
+      (if (arrayp *track*)
+          (setf sig (vector (aref *track* 0) (mix-noise (aref *track* 1))))
+          (setf sig (vector *track* (mix-noise (s-rest 0)))))
+      (setf sig (vocoder sig (soundp *track*)))
+      ;; Normalize *track* to 0 db peak based on first 10 million samples.
+      (setf sig (scale (/ (peak sig 10000000)) sig))
+      (if (or mst (soundp *track*))
+          sig
+          (vector (aref *track* 0) sig))))


### PR DESCRIPTION
Resolves:  https://github.com/audacity/audacity/issues/2230

*(short description of the changes and the motivation to make the changes)*
Fixes bug 2230.
Update to version 4 syntax.
Maintains compatibility with older versions.
Can be used on long tracks (though rather slow).
Support for mono tracks added:
*  When applied to a mono track, the vocoder generates sine wave carriers.
*  When applied to a stereo track, the vocoder uses the right channel for the carrier waves (as before).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
