### PR TITLE
Issue #2226: Joining multiple clips sometimes time-shifts them

### DIFF
--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1382,8 +1382,10 @@ void WaveClip::InsertSilence( double t, double len, double *pEnvelopeValue )
 {
    if (t == GetPlayStartTime() && t > GetSequenceStartTime())
       ClearSequence(GetSequenceStartTime(), t);
-   else if (t == GetPlayEndTime() && t < GetSequenceEndTime())
+   else if (t == GetPlayEndTime() && t < GetSequenceEndTime()) {
       ClearSequence(t, GetSequenceEndTime());
+      SetTrimRight(.0);
+   }
 
    auto s0 = TimeToSequenceSamples(t);
    auto slen = (sampleCount)floor(len * mRate + 0.5);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2226

Steps to reproduce:

1. Split an audio clip into three clips
2. Move the clips so that there are spaces between the clips.
3. Select all the audio (Ctrl+A)
4. Join the clips (Ctrl+J)
5. Observe that clips are not joined correctly.

Problem:
In  WaveClip::InsertSilence(), the following two lines:

else if (t == GetPlayEndTime() && t < GetSequenceEndTime())
      ClearSequence(t, GetSequenceEndTime());

After ClearSequence is called to remove the data to the end of the sequence, then there is not call to update mTrimRight, as is done in WaveClip::ClearRight(). So when more data is pasted, it's pasted in the wrong place.

Fix:
Update mTrimeRight.

Notes:
1. I don't know why the bug was not always reproduceable.
2. There appears to be a similar issue with the previous two lines:

   if (t == GetPlayStartTime() && t > GetSequenceStartTime())
      ClearSequence(GetSequenceStartTime(), t);

Compare with WaveClip::ClearLeft().
However I have left that unfixed, both because it doesn't affect this bug, and also because I couldn't work out when that call to ClearSequence would get called, and so I couldn't test any fix.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
