### PR TITLE
Issue 2198: fix clip rename

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -295,8 +295,6 @@ bool WaveTrackAffordanceControls::StartEditClipName(AudacityProject* project)
                 clip->SetName(Command.mName);
                 ProjectHistory::Get(*project).PushState(XO("Modified Clip Name"),
                     XO("Clip Name Edit"));
-
-                return true;
             }
         }
         else
@@ -306,8 +304,8 @@ bool WaveTrackAffordanceControls::StartEditClipName(AudacityProject* project)
 
             mEditedClip = lock;
             mTextEditHelper = MakeTextEditHelper(clip->GetName());
-            return true;
         }
+        return true;
     }
     return false;
 }
@@ -540,8 +538,8 @@ unsigned WaveTrackAffordanceControls::OnAffordanceClick(const TrackPanelMouseEve
             if (affordanceRect.Contains(event.event.GetPosition()) &&
                 StartEditClipName(project))
             {
-                event.event.Skip();
-                return RefreshCode::RefreshCell | RefreshCode::Cancelled;
+                event.event.Skip(false);
+                return RefreshCode::RefreshCell;
             }
         }
     }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp
@@ -32,8 +32,8 @@ UIHandle::Result WaveTrackAffordanceHandle::Click(const TrackPanelMouseEvent& ev
       if (affordanceControl)
       {
          result |= affordanceControl->OnAffordanceClick(event, project);
-         if (!event.event.GetSkipped())
-            return result;
+         if (!event.event.GetSkipped())//event is "consumed"
+            return result | RefreshCode::Cancelled;
          event.event.Skip(false);
       }
    }

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -999,8 +999,12 @@ UIHandle::Result TimeShiftHandle::Release
 
 UIHandle::Result TimeShiftHandle::Cancel(AudacityProject *pProject)
 {
-   ProjectHistory::Get( *pProject ).RollbackState();
-   return RefreshCode::RefreshAll;
+   if(mClipMoveState.initialized)
+   {
+      ProjectHistory::Get( *pProject ).RollbackState();
+      return RefreshCode::RefreshAll;
+   }
+   return RefreshCode::RefreshNone;
 }
 
 void TimeShiftHandle::Draw(


### PR DESCRIPTION
Resolves: #2198
Resolves: #2199

Interaction with modal dialog causes Cancel event to be dispatched before dialog itself is finished (easily reproducible in MacOS). Then ProjectHistory::Rollback in TimeShiftHandle::Cancel replaces all tracks in the current track list, so that track captured by TimeShiftHandle becomes orphaned. Another issue is that returning RefreshCode::Cancelled from WaveTrackAffordanceHandle::Click also causes ProjectHistory::Rollback and as a result tracks changes made to the clip name reverted. 

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
