### PR TITLE
Error Dialog UI

### DIFF
--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -575,7 +575,7 @@ bool Exporter::ExamineTracks()
          message = XO("All audio is muted.");
       ShowExportErrorDialog(
          ":576",
-         message);
+         message, AudacityExportCaptionStr(), false);
       return false;
    }
 
@@ -1518,14 +1518,15 @@ TranslatableString AudacityExportMessageStr()
 // we need from them is that they be distinct.
 void ShowExportErrorDialog(wxString ErrorCode,
    TranslatableString message,
-   const TranslatableString& caption)
+   const TranslatableString& caption,
+   bool allowReporting)
 {
    using namespace BasicUI;
    ShowErrorDialog( {},
       caption,
       message.Format( ErrorCode ),
       "Error:_Unable_to_export", // URL.
-      ErrorDialogOptions{ ErrorDialogType::ModalErrorReport } );
+      ErrorDialogOptions { allowReporting ? ErrorDialogType::ModalErrorReport : ErrorDialogType::ModalError });
 }
 
 void ShowDiskFullExportErrorDialog(const wxFileNameWrapper &fileName)

--- a/src/export/Export.h
+++ b/src/export/Export.h
@@ -332,7 +332,8 @@ AUDACITY_DLL_API TranslatableString AudacityExportMessageStr();
 /// Rather than repeat the code, we have it just once.
 AUDACITY_DLL_API void ShowExportErrorDialog(wxString ErrorCode,
    TranslatableString message = AudacityExportMessageStr(),
-   const TranslatableString& caption = AudacityExportCaptionStr());
+   const TranslatableString& caption = AudacityExportCaptionStr(),
+   bool allowReporting = true);
 
 AUDACITY_DLL_API
 void ShowDiskFullExportErrorDialog(const wxFileNameWrapper &fileName);


### PR DESCRIPTION
Resolves: #2178 

This PR fixes two issues:

1. ErrorReportDialog is now smaller and looks different from the crash reporter.
2. "Audio is muted" is considered to be a user error, i. e. it no longer can be reported to Sentry

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
