### PR TITLE
Fixes a crash when trying to work with clipboard after running macro

### DIFF
--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -445,6 +445,13 @@ void ApplyMacroDialog::OnApplyToFiles(wxCommandEvent & WXUNUSED(event))
       // Move global clipboard contents aside temporarily
       Clipboard tempClipboard;
       auto &globalClipboard = Clipboard::Get();
+
+      // DV: Macro invocation on file will reset the project to the
+      // initial state. There is a possibility, that clipboard will contain
+      // references to the data removed
+      if (globalClipboard.Project().lock().get() == project)
+         globalClipboard.Clear();
+
       globalClipboard.Swap(tempClipboard);
       auto cleanup = finally([&]{
          globalClipboard.Swap(tempClipboard);

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -981,9 +981,9 @@ void ProjectManager::ResetProjectToEmpty() {
 
    WaveTrackFactory::Reset( project );
 
-   projectHistory.SetDirty( false );
-   auto &undoManager = UndoManager::Get( project );
-   undoManager.ClearStates();
+   // InitialState will reset UndoManager
+   projectHistory.InitialState();
+   projectHistory.SetDirty(false);
 
    projectFileManager.CloseProject();
    projectFileManager.OpenProject();


### PR DESCRIPTION
Resolves: #2021

1. Fixes ResetProjectToEmpty that left UndoManager in an inconsistent state.
2. Resets the clipboard if the project used to run macro matches the clipboard data owner. This is a corner case, as you need to remove all the tracks after putting the data into the clipboard
3. 
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
