### PR TITLE
Fixes an unexpected performance regression in SpectrumView

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -32,6 +32,8 @@ Paul Licameli split from WaveTrackView.cpp
 #include <wx/dcmemory.h>
 #include <wx/graphics.h>
 
+#include "float_cast.h"
+
 class BrushHandle;
 class SpectralData;
 
@@ -700,7 +702,12 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context,
       const double p = double(yy) / hiddenMid.height;
       float convertedFreq = numberScale.PositionToValue(p);
       float convertedFreqBinNum = convertedFreq / (sr / windowSize);
-      return static_cast<int>(std::round(convertedFreqBinNum));
+
+      // By default lrintf will round to nearest by default, rounding to even on tie.
+      // std::round that was used here before rounds halfway cases away from zero.
+      // However, we can probably tolerate rounding issues here, as this will only slightly affect
+      // the visuals.
+      return static_cast<int>(lrintf(convertedFreqBinNum));
    };
 
    for (int xx = 0; xx < mid.width; ++xx) {
@@ -745,7 +752,7 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context,
          if(hitHopNum) {
             pSelectedBins = &hopBinMap[convertedHopNum];
             freqBinIter = pSelectedBins->begin();
-            advanceFreqBinIter(std::round(yyToFreqBin(0)));
+            advanceFreqBinIter(yyToFreqBin(0));
          }
       }
    
@@ -754,8 +761,8 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context,
             maybeSelected = false;
          const float bin     = bins[yy];
          const float nextBin = bins[yy+1];
-         auto binRounded = std::round(yyToFreqBin(yy));
-         auto nextBinRounded = std::round(yyToFreqBin(yy + 1));
+         auto binRounded = yyToFreqBin(yy);
+         auto nextBinRounded = yyToFreqBin(yy + 1);
 
          if(hitHopNum
             && freqBinIter != pSelectedBins->end()


### PR DESCRIPTION
After merging the spectrum brush branch - a new hot path was accidentally added to spectrum rendering.

1. std::round is expensive as is. The implementation is complex and designed to handle different situations.
2. By mistake the following chain was introduced: round(float)->int->double->round(double)->int

The new implementation uses `lrintf`. By default, it rounds to nearest, and ties are rounded to even. This does not match the behavior `std::round` entirely, but given that it only slightly affects the visuals, that shouldn't be a problem

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
