### PR TITLE
Draw selection on the timeline again

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1501,12 +1501,9 @@ void AdornedRulerPanel::DoIdle()
    auto &viewInfo = ViewInfo::Get( project );
    const auto &playRegion = viewInfo.playRegion;
 
-   bool dirtyPlayRegion = mDirtyPlayRegion
-      || ( mLastDrawnPlayRegion != std::pair{
-         playRegion.GetLastActiveStart(), playRegion.GetLastActiveEnd() } );
-
    changed = changed
-     || dirtyPlayRegion
+     || mLastDrawnPlayRegion != std::pair{
+         playRegion.GetLastActiveStart(), playRegion.GetLastActiveEnd() }
      || mLastDrawnH != viewInfo.h
      || mLastDrawnZoom != viewInfo.GetZoom()
      || mLastPlayRegionActive != viewInfo.playRegion.Active()
@@ -1515,8 +1512,6 @@ void AdornedRulerPanel::DoIdle()
       // Cause ruler redraw anyway, because we may be zooming or scrolling,
       // showing or hiding the scrub bar, etc.
       Refresh();
-
-   mDirtyPlayRegion = false;
 }
 
 void AdornedRulerPanel::OnAudioStartStop(wxCommandEvent & evt)
@@ -1551,7 +1546,6 @@ void AdornedRulerPanel::OnPaint(wxPaintEvent & WXUNUSED(evt))
       playRegion.GetLastActiveStart(), playRegion.GetLastActiveEnd() };
    mLastDrawnH = viewInfo.h;
    mLastDrawnZoom = viewInfo.GetZoom();
-   mDirtyPlayRegion = (mLastDrawnPlayRegion != playRegionBounds);
    mLastDrawnPlayRegion = playRegionBounds;
    // To do, note other fisheye state when we have that
 

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1499,9 +1499,11 @@ void AdornedRulerPanel::DoIdle()
 
    auto &project = *mProject;
    auto &viewInfo = ViewInfo::Get( project );
+   const auto &selectedRegion = viewInfo.selectedRegion;
    const auto &playRegion = viewInfo.playRegion;
 
    changed = changed
+     || mLastDrawnSelectedRegion != selectedRegion
      || mLastDrawnPlayRegion != std::pair{
          playRegion.GetLastActiveStart(), playRegion.GetLastActiveEnd() }
      || mLastDrawnH != viewInfo.h
@@ -1547,6 +1549,7 @@ void AdornedRulerPanel::OnPaint(wxPaintEvent & WXUNUSED(evt))
    mLastDrawnH = viewInfo.h;
    mLastDrawnZoom = viewInfo.GetZoom();
    mLastDrawnPlayRegion = playRegionBounds;
+   mLastDrawnSelectedRegion = viewInfo.selectedRegion;
    // To do, note other fisheye state when we have that
 
    wxPaintDC dc(this);

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2364,16 +2364,38 @@ void AdornedRulerPanel::ShowContextMenu(
    }
 }
 
+using ColorId = decltype(clrTrackInfo);
+
+inline ColorId TimelineBackgroundColor()
+{
+   return clrTrackInfo;
+}
+
+inline ColorId TimelineTextColor()
+{
+   return clrTrackPanelText;
+}
+
+inline ColorId TimelineLimitsColor()
+{
+   return TimelineTextColor();
+}
+
+inline ColorId TimelineLoopRegionColor(bool isActive)
+{
+   return isActive ? clrRulerBackground : clrClipAffordanceInactiveBrush;
+}
+
 void AdornedRulerPanel::DoDrawBackground(wxDC * dc)
 {
    // Draw AdornedRulerPanel border
-   AColor::UseThemeColour( dc, clrTrackInfo );
+   AColor::UseThemeColour( dc, TimelineBackgroundColor() );
    dc->DrawRectangle( mInner );
 
    if (ShowingScrubRuler()) {
       // Let's distinguish the scrubbing area by using a themable
       // colour and a line to set it off.  
-      AColor::UseThemeColour(dc, clrScrubRuler, clrTrackPanelText );
+      AColor::UseThemeColour(dc, clrScrubRuler, TimelineTextColor() );
       wxRect ScrubRect = mScrubZone;
       ScrubRect.Inflate( 1,0 );
       dc->DrawRectangle(ScrubRect);
@@ -2402,7 +2424,7 @@ void AdornedRulerPanel::DoDrawMarks(wxDC * dc, bool /*text */ )
    const double max = Pos2Time(mInner.width);
    const double hiddenMax = Pos2Time(mInner.width, true);
 
-   mRuler.SetTickColour( theTheme.Colour( clrTrackPanelText ) );
+   mRuler.SetTickColour( theTheme.Colour( TimelineTextColor() ) );
    mRuler.SetRange( min, max, hiddenMin, hiddenMax );
    mRuler.Draw( *dc );
 }
@@ -2454,8 +2476,7 @@ void AdornedRulerPanel::DoDrawPlayRegion(wxDC * dc, const wxRect &rect)
    const bool isActive = (mLastPlayRegionActive = playRegion.Active());
 
    // Paint the selected region bolder if independently varying, else dim
-   const auto color =
-      isActive ? clrRulerBackground : clrClipAffordanceInactiveBrush;
+   const auto color = TimelineLoopRegionColor(isActive);
    dc->SetBrush( wxBrush( theTheme.Colour( color )) );
    dc->SetPen(   wxPen(   theTheme.Colour( color )) );
 
@@ -2466,7 +2487,7 @@ void AdornedRulerPanel::DoDrawPlayRegionLimits(wxDC * dc, const wxRect &rect)
 {
    // Color the edges of the play region like the ticks and numbers
    ADCChanger cleanup( dc );
-   const auto edgeColour = theTheme.Colour(clrTrackPanelText);
+   const auto edgeColour = theTheme.Colour(TimelineLimitsColor());
    dc->SetPen( { edgeColour } );
    dc->SetBrush( { edgeColour } );
 

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -231,6 +231,7 @@ private:
    struct Subgroup;
    struct MainGroup;
 
+   SelectedRegion mLastDrawnSelectedRegion;
    std::pair<double, double> mLastDrawnPlayRegion{};
    bool mLastPlayRegionActive = false;
    double mLastDrawnH{};

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -95,7 +95,10 @@ private:
    void DoDrawBackground(wxDC * dc);
    void DoDrawEdge(wxDC *dc);
    void DoDrawMarks(wxDC * dc, bool /*text */ );
-   void DoDrawPlayRegion(wxDC * dc);
+   wxRect RegionRectangle(double t0, double t1) const;
+   wxRect PlayRegionRectangle() const;
+   void DoDrawPlayRegion(wxDC * dc, const wxRect &rect);
+   void DoDrawPlayRegionLimits(wxDC * dc, const wxRect &rect);
 
 public:
    void DoDrawScrubIndicator(wxDC * dc, wxCoord xx, int width, bool scrub, bool seek);
@@ -115,8 +118,8 @@ private:
    enum class MenuChoice { QuickPlay, Scrub };
    void ShowContextMenu( MenuChoice choice, const wxPoint *pPosition);
 
-   double Pos2Time(int p, bool ignoreFisheye = false);
-   int Time2Pos(double t, bool ignoreFisheye = false);
+   double Pos2Time(int p, bool ignoreFisheye = false) const;
+   int Time2Pos(double t, bool ignoreFisheye = false) const;
 
    bool IsWithinMarker(int mousePosX, double markerTime);
 

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -98,8 +98,12 @@ private:
    wxRect RegionRectangle(double t0, double t1) const;
    wxRect PlayRegionRectangle() const;
    wxRect SelectedRegionRectangle() const;
-   void DoDrawPlayRegion(wxDC * dc, const wxRect &rect);
+   void DoDrawPlayRegion(wxDC * dc,
+      const wxRect &rectP, const wxRect &rectL, const wxRect &rectR);
    void DoDrawPlayRegionLimits(wxDC * dc, const wxRect &rect);
+   void DoDrawOverlap(wxDC * dc, const wxRect &rect);
+   void DoDrawSelection(wxDC * dc,
+      const wxRect &rectS, const wxRect &rectL, const wxRect &rectR);
 
 public:
    void DoDrawScrubIndicator(wxDC * dc, wxCoord xx, int width, bool scrub, bool seek);

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -235,7 +235,6 @@ private:
    bool mLastPlayRegionActive = false;
    double mLastDrawnH{};
    double mLastDrawnZoom{};
-   bool mDirtyPlayRegion{};
 };
 
 #endif //define __AUDACITY_ADORNED_RULER_PANEL__

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -97,6 +97,7 @@ private:
    void DoDrawMarks(wxDC * dc, bool /*text */ );
    wxRect RegionRectangle(double t0, double t1) const;
    wxRect PlayRegionRectangle() const;
+   wxRect SelectedRegionRectangle() const;
    void DoDrawPlayRegion(wxDC * dc, const wxRect &rect);
    void DoDrawPlayRegionLimits(wxDC * dc, const wxRect &rect);
 


### PR DESCRIPTION
Resolves: #2067

Draw an indication of non-empty selection in the time ruler, again; in each theme, blend the color of the loop region limits with the background, which is either the loop region's color (enabled or diabled), or the ruler background.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
