### PR TITLE
Issue2209: Two new timeline looping commands need shortcut keys

### DIFF
--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -1176,10 +1176,11 @@ BaseItemSharedPtr TransportMenu()
                          return IsLoopingEnabled(project);
                      } )),
                Command( wxT("ClearPlayRegion"), XXO("&Clear Loop"),
-                  FN(OnClearPlayRegion), AlwaysEnabledFlag ),
+                  FN(OnClearPlayRegion), AlwaysEnabledFlag, L"Shift+Alt+L" ),
                Command( wxT("SetPlayRegionToSelection"),
                   XXO("&Set Loop to Selection"),
-                  FN(OnSetPlayRegionToSelection), AlwaysEnabledFlag ),
+                  FN(OnSetPlayRegionToSelection), AlwaysEnabledFlag,
+                     L"Shift+L" ),
                Command( wxT("SetPlayRegionIn"),
                   SetLoopInTitle,
                   FN(OnSetPlayRegionIn), AlwaysEnabledFlag ),


### PR DESCRIPTION
Resolves: #2209

Two new looping commands get default shortcut keystrokes.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
