### PR TITLE
Issue2149 Fix play-at-speed button

### DIFF
--- a/libraries/lib-audio-devices/AudioIOBase.h
+++ b/libraries/lib-audio-devices/AudioIOBase.h
@@ -70,10 +70,12 @@ struct AudioIOStartStreamOptions
    // The return value is a number of milliseconds to sleep before calling again
    std::function< unsigned long() > playbackStreamPrimer;
 
-   using PolicyFactory = std::function< std::unique_ptr<PlaybackPolicy>() >;
+   using PolicyFactory = std::function<
+      std::unique_ptr<PlaybackPolicy>(const AudioIOStartStreamOptions&) >;
    PolicyFactory policyFactory;
 
    bool loopEnabled{ false };
+   bool variableSpeed{ false };
 };
 
 struct AudioIODiagnostics{

--- a/libraries/lib-screen-geometry/ViewInfo.cpp
+++ b/libraries/lib-screen-geometry/ViewInfo.cpp
@@ -158,7 +158,6 @@ wxDEFINE_EVENT( EVT_PLAY_REGION_CHANGE, PlayRegionEvent );
 PlayRegionEvent::PlayRegionEvent(
    wxEventType commandType, PlayRegion *pReg )
 : wxEvent{ 0, commandType }
-, pRegion{ pReg }
 {}
 
 wxEvent *PlayRegionEvent::Clone() const

--- a/libraries/lib-screen-geometry/ViewInfo.h
+++ b/libraries/lib-screen-geometry/ViewInfo.h
@@ -118,8 +118,6 @@ struct PlayRegionEvent : public wxEvent
 {
    PlayRegionEvent( wxEventType commandType, PlayRegion *pRegion );
    wxEvent *Clone() const override;
-
-   wxWeakRef< PlayRegion > pRegion;
 };
 
 wxDECLARE_EXPORTED_EVENT( SCREEN_GEOMETRY_API,

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -120,7 +120,6 @@ time warp info and AudioIOListener and whether the playback is looped.
 #include "DBConnection.h"
 #include "ProjectFileIO.h"
 #include "ProjectWindows.h"
-#include "ViewInfo.h" // for PlayRegionEvent
 #include "WaveTrack.h"
 
 #include "effects/RealtimeEffectManager.h"
@@ -685,25 +684,11 @@ void AudioIO::SetOwningProject(
    }
 
    mOwningProject = pProject;
-
-   if (pProject)
-      ViewInfo::Get( *pProject ).playRegion.Bind(
-         EVT_PLAY_REGION_CHANGE, AudioIO::LoopPlayUpdate);
 }
 
 void AudioIO::ResetOwningProject()
 {
-   if ( auto pOwningProject = mOwningProject.lock() )
-      ViewInfo::Get( *pOwningProject ).playRegion.Unbind(
-         EVT_PLAY_REGION_CHANGE, AudioIO::LoopPlayUpdate);
-
    mOwningProject.reset();
-}
-
-void AudioIO::LoopPlayUpdate( PlayRegionEvent &evt )
-{
-   evt.Skip();
-   AudioIO::Get()->mPlaybackSchedule.MessageProducer( evt );
 }
 
 void AudioIO::StartMonitoring( const AudioIOStartStreamOptions &options )

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -36,7 +36,6 @@ class RingBuffer;
 class Mixer;
 class Resample;
 class AudioThread;
-class PlayRegionEvent;
 
 class AudacityProject;
 
@@ -513,7 +512,6 @@ private:
 
    void SetOwningProject( const std::shared_ptr<AudacityProject> &pProject );
    void ResetOwningProject();
-   static void LoopPlayUpdate( PlayRegionEvent &evt );
 
    /*!
     Called in a loop from another worker thread that does not have the low-latency constraints

--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -214,8 +214,8 @@ Mixer::WarpOptions::WarpOptions(const BoundedEnvelope *e)
     : envelope(e), minSpeed(0.0), maxSpeed(0.0)
  {}
 
-Mixer::WarpOptions::WarpOptions(double min, double max)
-   : minSpeed(min), maxSpeed(max)
+Mixer::WarpOptions::WarpOptions(double min, double max, double initial)
+   : minSpeed{min}, maxSpeed{max}, initialSpeed{initial}
 {
    if (minSpeed < 0)
    {
@@ -275,7 +275,7 @@ Mixer::Mixer(const WaveTrackConstArray &inputTracks,
    mTime = startTime;
    mBufferSize = outBufferSize;
    mInterleaved = outInterleaved;
-   mSpeed = 1.0;
+   mSpeed = warpOptions.initialSpeed;
    if( mixerSpec && mixerSpec->GetNumChannels() == mNumChannels &&
          mixerSpec->GetNumTracks() == mNumInputTracks )
       mMixerSpec = mixerSpec;

--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -779,12 +779,6 @@ void Mixer::SetTimesAndSpeed(double t0, double t1, double speed, bool bSkipping)
    Reposition(t0, bSkipping);
 }
 
-void Mixer::SetSpeedForPlayAtSpeed(double speed)
-{
-   wxASSERT(std::isfinite(speed));
-   mSpeed = fabs(speed);
-}
-
 void Mixer::SetSpeedForKeyboardScrubbing(double speed, double startTime)
 {
    wxASSERT(std::isfinite(speed));

--- a/src/Mix.h
+++ b/src/Mix.h
@@ -87,12 +87,13 @@ class AUDACITY_DLL_API Mixer {
        explicit WarpOptions(const BoundedEnvelope *e);
 
        //! Construct with no time warp
-       WarpOptions(double min, double max);
+       WarpOptions(double min, double max, double initial = 1.0);
 
     private:
        friend class Mixer;
        const BoundedEnvelope *envelope = nullptr;
        double minSpeed, maxSpeed;
+       double initialSpeed{ 1.0 };
     };
 
     //

--- a/src/Mix.h
+++ b/src/Mix.h
@@ -130,7 +130,6 @@ class AUDACITY_DLL_API Mixer {
    // Used in scrubbing and other nonuniform playback policies.
    void SetTimesAndSpeed(
       double t0, double t1, double speed, bool bSkipping = false);
-   void SetSpeedForPlayAtSpeed(double speed);
    void SetSpeedForKeyboardScrubbing(double speed, double startTime);
 
    /// Current time in seconds (unwarped, i.e. always between startTime and stopTime)

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -175,6 +175,16 @@ void NewDefaultPlaybackPolicy::Initialize(
          &NewDefaultPlaybackPolicy::OnPlaySpeedChange, this);
 }
 
+Mixer::WarpOptions NewDefaultPlaybackPolicy::MixerWarpOptions(
+   PlaybackSchedule &schedule)
+{
+   if (mVariableSpeed)
+      // Enable variable rate mixing
+      return Mixer::WarpOptions(0.01, 32.0, GetPlaySpeed());
+   else
+      return PlaybackPolicy::MixerWarpOptions(schedule);
+}
+
 PlaybackPolicy::BufferTimes
 NewDefaultPlaybackPolicy::SuggestedBufferTimes(PlaybackSchedule &)
 {
@@ -369,6 +379,13 @@ void NewDefaultPlaybackPolicy::WriteMessage()
    mMessageChannel.Write( {
       region.GetStart(), region.GetEnd(), region.Active()
    } );
+}
+
+double NewDefaultPlaybackPolicy::GetPlaySpeed()
+{
+   return mVariableSpeed
+      ? ProjectSettings::Get(mProject).GetPlaySpeed()
+      : 1.0;
 }
 
 void PlaybackSchedule::Init(

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -148,11 +148,13 @@ const PlaybackPolicy &PlaybackSchedule::GetPolicy() const
 }
 
 NewDefaultPlaybackPolicy::NewDefaultPlaybackPolicy( AudacityProject &project,
-   double trackEndTime, double loopEndTime, bool loopEnabled )
+   double trackEndTime, double loopEndTime,
+   bool loopEnabled, bool variableSpeed )
    : mProject{ project }
    , mTrackEndTime{ trackEndTime }
    , mLoopEndTime{ loopEndTime }
    , mLoopEnabled{ loopEnabled }
+   , mVariableSpeed{ variableSpeed }
 {}
 
 NewDefaultPlaybackPolicy::~NewDefaultPlaybackPolicy() = default;
@@ -389,7 +391,7 @@ void PlaybackSchedule::Init(
    SetTrackTime( mT0 );
 
    if (options.policyFactory)
-      mpPlaybackPolicy = options.policyFactory();
+      mpPlaybackPolicy = options.policyFactory(options);
 
    mWarpedTime = 0.0;
    mWarpedLength = RealDuration(mT1);

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -13,6 +13,8 @@
 #include "AudioIOBase.h"
 #include "Envelope.h"
 #include "Mix.h"
+#include "Project.h"
+#include "ProjectSettings.h"
 #include "SampleCount.h"
 #include "ViewInfo.h" // for PlayRegionEvent
 
@@ -168,6 +170,9 @@ void NewDefaultPlaybackPolicy::Initialize(
 
    ViewInfo::Get( mProject ).playRegion.Bind( EVT_PLAY_REGION_CHANGE,
       &NewDefaultPlaybackPolicy::OnPlayRegionChange, this);
+   if (mVariableSpeed)
+      mProject.Bind( EVT_PROJECT_SETTINGS_CHANGE,
+         &NewDefaultPlaybackPolicy::OnPlaySpeedChange, this);
 }
 
 PlaybackPolicy::BufferTimes
@@ -348,6 +353,12 @@ bool NewDefaultPlaybackPolicy::Looping( const PlaybackSchedule & ) const
 void NewDefaultPlaybackPolicy::OnPlayRegionChange( PlayRegionEvent &evt)
 {
    // This executes in the main thread
+   evt.Skip(); // Let other listeners hear the event too
+   WriteMessage();
+}
+
+void NewDefaultPlaybackPolicy::OnPlaySpeedChange(wxCommandEvent &evt)
+{
    evt.Skip(); // Let other listeners hear the event too
    WriteMessage();
 }

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -462,6 +462,7 @@ public:
 private:
    bool RevertToOldDefault( const PlaybackSchedule &schedule ) const;
    void OnPlayRegionChange(PlayRegionEvent &evt);
+   void OnPlaySpeedChange(wxCommandEvent &evt);
    void WriteMessage();
 
    AudacityProject &mProject;

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -473,12 +473,14 @@ private:
    // The main thread writes changes in response to user events, and
    // the audio thread later reads, and changes the playback.
    struct SlotData {
+      double mPlaySpeed;
       double mT0;
       double mT1;
       bool mLoopEnabled;
    };
    MessageBuffer<SlotData> mMessageChannel;
 
+   double mLastPlaySpeed{ 1.0 };
    const double mTrackEndTime;
    double mLoopEndTime;
    size_t mRemaining{ 0 };

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -442,6 +442,8 @@ public:
 
    void Initialize( PlaybackSchedule &schedule, double rate ) override;
 
+   Mixer::WarpOptions MixerWarpOptions(PlaybackSchedule &schedule) override;
+
    BufferTimes SuggestedBufferTimes(PlaybackSchedule &schedule) override;
 
    bool Done( PlaybackSchedule &schedule, unsigned long ) override;
@@ -464,6 +466,7 @@ private:
    void OnPlayRegionChange(PlayRegionEvent &evt);
    void OnPlaySpeedChange(wxCommandEvent &evt);
    void WriteMessage();
+   double GetPlaySpeed();
 
    AudacityProject &mProject;
 

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -436,7 +436,8 @@ class NewDefaultPlaybackPolicy final
 {
 public:
    NewDefaultPlaybackPolicy( AudacityProject &project,
-      double trackEndTime, double loopEndTime, bool loopEnabled);
+      double trackEndTime, double loopEndTime,
+      bool loopEnabled, bool variableSpeed);
    ~NewDefaultPlaybackPolicy() override;
 
    void Initialize( PlaybackSchedule &schedule, double rate ) override;
@@ -479,5 +480,6 @@ private:
    size_t mRemaining{ 0 };
    bool mProgress{ true };
    bool mLoopEnabled{ true };
+   bool mVariableSpeed{ false };
 };
 #endif

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -419,7 +419,7 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
             std::swap(tcp0, tcp1);
          AudioIOStartStreamOptions myOptions = options;
          myOptions.policyFactory =
-            [tless, diff]() -> std::unique_ptr<PlaybackPolicy> {
+            [tless, diff](auto&) -> std::unique_ptr<PlaybackPolicy> {
                return std::make_unique<CutPreviewPlaybackPolicy>(tless, diff);
             };
          token = gAudioIO->StartStream(
@@ -1192,10 +1192,14 @@ DefaultPlayOptions( AudacityProject &project, bool newDefault )
    if (newDefault) {
       const double trackEndTime = TrackList::Get(project).GetEndTime();
       const double loopEndTime = ViewInfo::Get(project).playRegion.GetEnd();
-      options.policyFactory =
-      [&project, trackEndTime, loopEndTime, loopEnabled]() -> std::unique_ptr<PlaybackPolicy> {
+      options.policyFactory = [&project, trackEndTime, loopEndTime](
+         const AudioIOStartStreamOptions &options)
+            -> std::unique_ptr<PlaybackPolicy>
+      {
          return std::make_unique<NewDefaultPlaybackPolicy>( project,
-            trackEndTime, loopEndTime, loopEnabled); };
+            trackEndTime, loopEndTime,
+            options.loopEnabled, options.variableSpeed);
+      };
 
       // Start play from left edge of selection
       options.pStartTime.emplace(ViewInfo::Get(project).selectedRegion.t0());

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1192,8 +1192,9 @@ DefaultPlayOptions( AudacityProject &project, bool newDefault )
    if (newDefault) {
       const double trackEndTime = TrackList::Get(project).GetEndTime();
       const double loopEndTime = ViewInfo::Get(project).playRegion.GetEnd();
-      options.policyFactory = [trackEndTime, loopEndTime, loopEnabled]() -> std::unique_ptr<PlaybackPolicy> {
-         return std::make_unique<NewDefaultPlaybackPolicy>(
+      options.policyFactory =
+      [&project, trackEndTime, loopEndTime, loopEnabled]() -> std::unique_ptr<PlaybackPolicy> {
+         return std::make_unique<NewDefaultPlaybackPolicy>( project,
             trackEndTime, loopEndTime, loopEnabled); };
 
       // Start play from left edge of selection

--- a/src/ProjectSettings.cpp
+++ b/src/ProjectSettings.cpp
@@ -140,6 +140,14 @@ void ProjectSettings::SetBandwidthSelectionFormatName(
    mBandwidthSelectionFormatName = formatName;
 }
 
+void ProjectSettings::SetPlaySpeed(double value)
+{
+   if (auto oldValue = GetPlaySpeed(); value != oldValue) {
+      mPlaySpeed.store( value, std::memory_order_relaxed );
+      Notify( mProject, ChangedPlaySpeed, oldValue );
+   }
+}
+
 void ProjectSettings::SetSelectionFormat(const NumericFormatSymbol & format)
 {
    mSelectionFormat = format;

--- a/src/ProjectSettings.h
+++ b/src/ProjectSettings.h
@@ -65,8 +65,8 @@ public:
    // Values retrievable from GetInt() of the event for settings change
    enum EventCode : int {
       ChangedSyncLock,
-      ChangedProjectRate,
-      ChangedTool
+      ChangedTool,
+      ChangedPlaySpeed,
    };
 
    explicit ProjectSettings( AudacityProject &project );
@@ -106,9 +106,8 @@ public:
    // Speed play
    double GetPlaySpeed() const {
       return mPlaySpeed.load( std::memory_order_relaxed ); }
-   void SetPlaySpeed( double value ) {
-      mPlaySpeed.store( value, std::memory_order_relaxed ); }
-
+   void SetPlaySpeed( double value );
+   
    // Selection Format
    void SetSelectionFormat(const NumericFormatSymbol & format);
    const NumericFormatSymbol & GetSelectionFormat() const;

--- a/src/ScrubState.cpp
+++ b/src/ScrubState.cpp
@@ -55,8 +55,7 @@ struct ScrubQueue : NonInterferingBase
          // Make some initial silence. This is not needed in the case of
          // keyboard scrubbing or play-at-speed, because the initial speed
          // is known when this function is called the first time.
-         if ( !(message.options.isKeyboardScrubbing ||
-            message.options.isPlayingAtSpeed) ) {
+         if ( !(message.options.isKeyboardScrubbing) ) {
             mData.mS0 = mData.mS1 = s0Init;
             mData.mGoal = -1;
             mData.mDuration = duration = inDuration;
@@ -64,8 +63,7 @@ struct ScrubQueue : NonInterferingBase
          }
       }
 
-      if (mStarted || message.options.isKeyboardScrubbing ||
-         message.options.isPlayingAtSpeed) {
+      if (mStarted || message.options.isKeyboardScrubbing) {
          Data newData;
          inDuration += mAccumulatedSeekDuration;
 
@@ -353,11 +351,7 @@ bool ScrubbingPlaybackPolicy::AllowSeek( PlaybackSchedule & )
 bool ScrubbingPlaybackPolicy::Done(
    PlaybackSchedule &schedule, unsigned long )
 {
-   if (mOptions.isPlayingAtSpeed)
-      // some leftover length allowed in this case; ignore outputFrames
-      return PlaybackPolicy::Done(schedule, 0);
-   else
-      return false;
+   return false;
 }
 
 std::chrono::milliseconds
@@ -451,9 +445,7 @@ bool ScrubbingPlaybackPolicy::RepositionPlayback(
          if (!mSilentScrub)
          {
             for (auto &pMixer : playbackMixers) {
-               if (mOptions.isPlayingAtSpeed)
-                  pMixer->SetSpeedForPlayAtSpeed(mScrubSpeed);
-               else if (mOptions.isKeyboardScrubbing)
+               if (mOptions.isKeyboardScrubbing)
                   pMixer->SetSpeedForKeyboardScrubbing(mScrubSpeed, startTime);
                else
                   pMixer->SetTimesAndSpeed(

--- a/src/ScrubState.h
+++ b/src/ScrubState.h
@@ -25,7 +25,6 @@ struct ScrubbingOptions {
    double minTime {};
 
    bool bySpeed {};
-   bool isPlayingAtSpeed{};
    bool isKeyboardScrubbing{};
 
    double delay {};

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -530,7 +530,7 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
    {
       auto options = DefaultPlayOptions( *p, newDefault );
       // No need to set cutPreview options.
-      options.envelope = mEnvelope.get();
+      options.envelope = bFixedSpeedPlay ? mEnvelope.get() : nullptr;
       options.variableSpeed = !bFixedSpeedPlay;
       auto mode =
          cutPreview ? PlayMode::cutPreviewPlay

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -544,7 +544,7 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
 }
 
 // Come here from button clicks only
-void TranscriptionToolBar::OnPlaySpeed(wxCommandEvent & WXUNUSED(event))
+void TranscriptionToolBar::OnPlaySpeed(wxCommandEvent & event)
 {
    auto button = mButtons[TTB_PlaySpeed];
 
@@ -552,6 +552,7 @@ void TranscriptionToolBar::OnPlaySpeed(wxCommandEvent & WXUNUSED(event))
    const bool cutPreview = mButtons[TTB_PlaySpeed]->WasControlDown();
    const bool looped = !cutPreview &&
       !button->WasShiftDown();
+   OnSpeedSlider(event);
    PlayAtSpeed(looped, cutPreview);
 }
 

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -531,6 +531,7 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
       auto options = DefaultPlayOptions( *p, newDefault );
       // No need to set cutPreview options.
       options.envelope = mEnvelope.get();
+      options.variableSpeed = !bFixedSpeedPlay;
       auto mode =
          cutPreview ? PlayMode::cutPreviewPlay
          : newDefault ? PlayMode::loopedPlay

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -490,11 +490,10 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
    if ( TrackList::Get( *p ).Any< NoteTrack >() )
       bFixedSpeedPlay = true;
 
-   // Scrubbing only supports straight through play.
-   // So if newDefault or cutPreview, we have to fall back to fixed speed.
+   // If cutPreview, we have to fall back to fixed speed.
    if (newDefault)
       cutPreview = false;
-   bFixedSpeedPlay = bFixedSpeedPlay || newDefault || cutPreview;
+   bFixedSpeedPlay = bFixedSpeedPlay || cutPreview;
    if (bFixedSpeedPlay)
    {
       // Create a BoundedEnvelope if we haven't done so already
@@ -527,7 +526,7 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
    // Start playing
    if (playRegion.GetStart() < 0)
       return;
-   if (bFixedSpeedPlay)
+
    {
       auto options = DefaultPlayOptions( *p, newDefault );
       // No need to set cutPreview options.
@@ -540,12 +539,6 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
          SelectedRegion(playRegion.GetStart(), playRegion.GetEnd()),
             options,
             mode);
-   }
-   else
-   {
-      auto &scrubber = Scrubber::Get( *p );
-      scrubber.StartSpeedPlay(GetPlaySpeed(),
-         playRegion.GetStart(), playRegion.GetEnd());
    }
 }
 

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -348,7 +348,7 @@ void Scrubber::MarkScrubStart(
 static AudioIOStartStreamOptions::PolicyFactory
 ScrubbingPlaybackPolicyFactory(const ScrubbingOptions &options)
 {
-   return [options]() -> std::unique_ptr<PlaybackPolicy>
+   return [options](auto&) -> std::unique_ptr<PlaybackPolicy>
    {
       return std::make_unique<ScrubbingPlaybackPolicy>(options);
    };

--- a/src/tracks/ui/Scrubbing.h
+++ b/src/tracks/ui/Scrubbing.h
@@ -61,7 +61,6 @@ public:
    // Returns true iff the event should be considered consumed by this:
    // Assume xx is relative to the left edge of TrackPanel!
    bool MaybeStartScrubbing(wxCoord xx);
-   bool StartSpeedPlay(double speed, double time0, double time1);
    bool StartKeyboardScrubbing(double time0, bool backwards);
    double GetKeyboardScrubbingSpeed();
 


### PR DESCRIPTION
Resolves: #2149

Issue2149: Play-at-speed button will work again, when Shift (once-only play) not pressed....

... But now it must also respect loop play bounds and changes of bounds.

This requires total reimplementation of how it works, without reuse of scrubbing code.

The case of Shift + Click needs an additional fix, to come.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
