### PR TITLE
Solve a problem where the dock icon gets duplicated in the flatpak builds

### DIFF
--- a/src/audacity.desktop.in
+++ b/src/audacity.desktop.in
@@ -46,6 +46,7 @@ Comment[zh_CN]=录音和编辑音频文件
 Comment[zh_TW]=錄音和編輯音訊檔案
 
 Icon=@AUDACITY_NAME@
+StartupWMClass=Audacity
 
 Type=Application
 Categories=AudioVideo;Audio;AudioVideoEditing;


### PR DESCRIPTION
Resolves: [Dock icon is duplicated on elementaryOS when run as flatpak](https://github.com/audacity/audacity/issues/2292)

By explicitly specifying the StartupWMClass, the elementaryOS Dock is now able to associate Audacity's window with the flatpak-launcher icon so that it does not spawn a second icon for Audacity.

I also contributed this [as a patch](https://github.com/flathub/org.audacityteam.Audacity/pull/87) to the flathub maintainer, but since there are no negative effects of explicitly stating the StartupWMClass in the .desktop file, it would be nice to have this in the upstream code as well.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
