### PR TITLE
Fixes the behavior of Locate FFmpeg dialog. (Bug #2282)

### DIFF
--- a/libraries/lib-ffmpeg-support/FFmpegFunctions.cpp
+++ b/libraries/lib-ffmpeg-support/FFmpegFunctions.cpp
@@ -82,13 +82,13 @@ struct EnvSetter final
    static const wxString VariableName;
    static const wxString Separator;
 
-   EnvSetter()
+   explicit EnvSetter(bool fromUserPathOnly)
    {
       ValueExisted = wxGetEnv(VariableName, &OldValue);
 
       wxString value;
 
-      for (const wxString& path : FFmpegFunctions::GetSearchPaths())
+      for (const wxString& path : FFmpegFunctions::GetSearchPaths(fromUserPathOnly))
       {
          if (!value.empty())
             value += Separator;
@@ -148,7 +148,7 @@ struct FFmpegFunctions::Private final
    AVCodecFactories  CodecFactories;
    AVUtilFactories   UtilFactories;
 
-   std::shared_ptr<wxDynamicLibrary> LibraryWithSymbol(const char* symbol) const
+   std::shared_ptr<wxDynamicLibrary> LibraryWithSymbol(const char* symbol, bool fromUserPathOnly) const
    {
       if (AVFormatLibrary->HasSymbol(symbol))
          return AVFormatLibrary;
@@ -163,21 +163,21 @@ struct FFmpegFunctions::Private final
       if (path.empty())
          return nullptr;
 
-      return LoadLibrary(wxFileNameFromPath(path));
+      return LoadLibrary(wxFileNameFromPath(path), fromUserPathOnly);
    }
 
-   bool Load(FFmpegFunctions& functions, const wxString& path)
+   bool Load(FFmpegFunctions& functions, const wxString& path, bool fromUserPathOnly)
    {
       // We start by loading AVFormat
-      AVFormatLibrary = LoadLibrary(path);
+      AVFormatLibrary = LoadLibrary(path, fromUserPathOnly);
 
       if (AVFormatLibrary == nullptr)
          return false;
 
-      if ((AVCodecLibrary = LibraryWithSymbol("avcodec_version")) == nullptr)
+      if ((AVCodecLibrary = LibraryWithSymbol("avcodec_version", fromUserPathOnly)) == nullptr)
          return false;
 
-      if ((AVUtilLibrary = LibraryWithSymbol("avutil_version")) == nullptr)
+      if ((AVUtilLibrary = LibraryWithSymbol("avutil_version", fromUserPathOnly)) == nullptr)
          return false;
 
       if (
@@ -218,12 +218,12 @@ struct FFmpegFunctions::Private final
       return true;
    }
 
-   std::shared_ptr<wxDynamicLibrary> LoadLibrary(const wxString& libraryName) const
+   std::shared_ptr<wxDynamicLibrary> LoadLibrary(const wxString& libraryName, bool fromUserPathOnly) const
    {
 #if defined(__WXMAC__)
       // On macOS dyld reads environment only when application starts.
       // Let's emulate the process manually
-      for(const wxString& path : FFmpegFunctions::GetSearchPaths())
+      for (const wxString& path : FFmpegFunctions::GetSearchPaths(fromUserPathOnly))
       {
          const wxString fullName = wxFileName(path, libraryName).GetFullPath();
 
@@ -259,7 +259,7 @@ FFmpegFunctions::~FFmpegFunctions()
 {
 }
 
-std::shared_ptr<FFmpegFunctions> FFmpegFunctions::Load()
+std::shared_ptr<FFmpegFunctions> FFmpegFunctions::Load(bool fromUserPathOnly)
 {
    static std::weak_ptr<FFmpegFunctions> weakFunctions;
 
@@ -275,14 +275,14 @@ std::shared_ptr<FFmpegFunctions> FFmpegFunctions::Load()
       FFmpegAPIResolver::Get().GetSuportedAVFormatVersions();
 
 #if !defined(__WXMAC__)
-   EnvSetter envSetter;
+   EnvSetter envSetter(fromUserPathOnly);
 #endif
 
    for (int version : supportedVersions)
    {
       for (const wxString& path : BuildAVFormatPaths(version))
       {
-         if (ffmpeg->mPrivate->Load(*ffmpeg, path))
+         if (ffmpeg->mPrivate->Load(*ffmpeg, path, fromUserPathOnly))
          {
             weakFunctions = ffmpeg;
             return ffmpeg;
@@ -295,14 +295,25 @@ std::shared_ptr<FFmpegFunctions> FFmpegFunctions::Load()
 
 StringSetting AVFormatPath { L"/FFmpeg/FFmpegLibPath", L"" };
 
-std::vector<wxString> FFmpegFunctions::GetSearchPaths()
+std::vector<wxString> FFmpegFunctions::GetSearchPaths(bool fromUserPathOnly)
 {
    std::vector<wxString> paths;
 
    const wxString userAVFormatFullPath = AVFormatPath.Read();
 
    if (!userAVFormatFullPath.empty())
-      paths.emplace_back(wxPathOnly(userAVFormatFullPath));
+   {
+      // For some directories, wxPathOnly will fail.
+      // For example, if path is `c:\ffmpeg-4.4`
+      // wxPathOnly will return `c:\`
+      if (wxDirExists(userAVFormatFullPath))
+         paths.emplace_back(userAVFormatFullPath);
+      else
+         paths.emplace_back(wxPathOnly(userAVFormatFullPath));
+   }
+
+   if (fromUserPathOnly)
+      return paths;
 
 #if defined(__WXMSW__)
    wxRegKey reg(wxT("HKEY_LOCAL_MACHINE\\Software\\FFmpeg for Audacity"));

--- a/libraries/lib-ffmpeg-support/FFmpegFunctions.h
+++ b/libraries/lib-ffmpeg-support/FFmpegFunctions.h
@@ -86,12 +86,12 @@ struct FFMPEG_SUPPORT_API FFmpegFunctions :
    FFmpegFunctions();
    ~FFmpegFunctions();
 
-   static std::shared_ptr<FFmpegFunctions> Load();
+   static std::shared_ptr<FFmpegFunctions> Load(bool fromUserPathOnly = false);
 
    AVCodecIDFwd (*GetAVCodecID)(AudacityAVCodecID) = nullptr;
    AudacityAVCodecID (*GetAudacityCodecID)(AVCodecIDFwd) = nullptr;
 
-   static std::vector<wxString> GetSearchPaths();
+   static std::vector<wxString> GetSearchPaths(bool fromUserPathOnly);
 
    std::unique_ptr<AVIOContextWrapper> CreateAVIOContext() const;
    std::unique_ptr<AVFormatContextWrapper> CreateAVFormatContext() const;

--- a/src/FFmpeg.cpp
+++ b/src/FFmpeg.cpp
@@ -116,7 +116,7 @@ public:
    FindFFmpegDialog(wxWindow *parent, const wxString &path, const wxString &name)
        : wxDialogWrapper(parent, wxID_ANY, XO("Locate FFmpeg"))
        , mName(name)
-       , mFullPath(path, name)
+       , mFullPath(path, {})
    {
       SetName();
 
@@ -183,7 +183,7 @@ public:
 #   if defined(__WXMSW__)
          { XO("Only avformat.dll"), { wxT("avformat-*.dll") } },
 #   elif defined(__WXMAC__)
-         { XO("Only ffmpeg.*.dylib"), { wxT("ffmpeg.*.dylib") } },
+         { XO("Only ffmpeg.*.dylib"), { wxT("ffmpeg.*.dylib"), wxT("libavformat.*.dylib") } },
 #   else
          { XO("Only libavformat.so"), { wxT("libavformat.so.*") } },
 #   endif
@@ -222,7 +222,12 @@ public:
 
    void UpdatePath()
    {
-      mFullPath = mPathText->GetValue();
+      const wxString path = mPathText->GetValue();
+
+      if (wxDirExists(path))
+         mFullPath = wxFileName(path, {}, wxPATH_NATIVE);
+      else
+         mFullPath = mPathText->GetValue();
    }
 
    wxString GetLibPath()
@@ -302,22 +307,53 @@ BEGIN_EVENT_TABLE(FFmpegNotFoundDialog, wxDialogWrapper)
    EVT_BUTTON(wxID_OK, FFmpegNotFoundDialog::OnOk)
 END_EVENT_TABLE()
 
+struct SafeAVFormatPathUpdater final
+{
+   explicit SafeAVFormatPathUpdater(const wxString& newPath)
+   {
+      mHasOldValue = AVFormatPath.Read(&mOldValue);
+
+      AVFormatPath.Write(newPath);
+   }
+
+   ~SafeAVFormatPathUpdater()
+   {
+      if (mRevertToOld)   
+      {
+         if (mHasOldValue)
+            AVFormatPath.Write(mOldValue);
+         else
+            AVFormatPath.Delete();
+      }
+
+      gPrefs->Flush();
+   }
+
+   void CommitValue() noexcept
+   {
+      mRevertToOld = false;
+   }
+
+   wxString mOldValue;
+   bool mHasOldValue;
+   bool mRevertToOld { true };
+};
 
 bool FindFFmpegLibs(wxWindow* parent)
 {
    wxString path;
 
 #if defined(__WXMSW__)
-   const wxString name = wxT("avformat-*.dll");
+   const wxString name = wxT("avformat.dll");
 #elif defined(__WXMAC__)
-   const wxString name = wxT("ffmpeg.*.64bit.dylib");
+   const wxString name = wxT("ffmpeg.64bit.dylib");
 #else
-   const wxString name = wxT("libavformat.so.*");
+   const wxString name = wxT("libavformat.so");
 #endif
 
    wxLogMessage(wxT("Looking for FFmpeg libraries..."));
 
-   auto searchPaths = FFmpegFunctions::GetSearchPaths();
+   auto searchPaths = FFmpegFunctions::GetSearchPaths(false);
 
    if (!searchPaths.empty())
       path = searchPaths.front();
@@ -331,17 +367,25 @@ bool FindFFmpegLibs(wxWindow* parent)
 
    path = fd.GetLibPath();
 
+   const wxFileName fileName(path);
+
+   if (fileName.FileExists())
+      path = fileName.GetPath();
+
    wxLogMessage(wxT("User-specified path = '%s'"), path);
 
-   if (!::wxFileExists(path)) {
-      wxLogError(wxT("User-specified file does not exist. Failed to find FFmpeg libraries."));
+   SafeAVFormatPathUpdater updater(path);
+
+   // Try to load FFmpeg from the user provided path
+   if (!FFmpegFunctions::Load(true))
+   {
+      wxLogError(wxT("User-specified path does not contain FFmpeg libraries."));
       return false;
    }
 
-   wxLogMessage(wxT("User-specified FFmpeg file exists. Success."));
+   updater.CommitValue();
 
-   AVFormatPath.Write(path);
-   gPrefs->Flush();
+   wxLogMessage(wxT("User-specified FFmpeg file exists. Success."));
 
    return true;
 }


### PR DESCRIPTION
The meaning of the "Location of " field became confusing after the support for multiple FFmpeg versions was added. 

This commit changes the way how the content of the dialog is interpreted. 
Both full paths to avformat and to the directory containing avformat are now valid.

Additionally, it fixes the way Audacity checks that FFmpeg works. Audacity will check if it can load the library instead of checking that the file exists.

Resolves: #2282

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
