### PR TITLE
Issue2149 again

### DIFF
--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -215,18 +215,18 @@ NewDefaultPlaybackPolicy::GetPlaybackSlice(
 {
    // How many samples to produce for each channel.
    const auto realTimeRemaining = std::max(0.0, schedule.RealTimeRemaining());
-   mRemaining = realTimeRemaining * mRate;
+   mRemaining = realTimeRemaining * mRate / mLastPlaySpeed;
 
-   if (RevertToOldDefault(schedule))
+   if (mLastPlaySpeed == 1.0 && RevertToOldDefault(schedule))
       return PlaybackPolicy::GetPlaybackSlice(schedule, available);
 
    auto frames = available;
    auto toProduce = frames;
-   double deltat = frames / mRate;
+   double deltat = (frames / mRate) * mLastPlaySpeed;
 
    if (deltat > realTimeRemaining)
    {
-      toProduce = frames = mRemaining;
+      toProduce = frames = (realTimeRemaining * mRate) / mLastPlaySpeed;
       schedule.RealTimeAdvance( realTimeRemaining );
    }
    else
@@ -332,7 +332,7 @@ bool NewDefaultPlaybackPolicy::RepositionPlayback(
 
       schedule.RealTimeInit(newTime);
       const auto realTimeRemaining = std::max(0.0, schedule.RealTimeRemaining());
-      mRemaining = realTimeRemaining * mRate;
+      mRemaining = realTimeRemaining * mRate / mLastPlaySpeed;
    }
    else if (speedChange)
       // Don't return early

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -14,7 +14,7 @@
 #include "Envelope.h"
 #include "Mix.h"
 #include "Project.h"
-#include "ProjectSettings.h"
+#include "ProjectAudioIO.h"
 #include "SampleCount.h"
 #include "ViewInfo.h" // for PlayRegionEvent
 
@@ -172,7 +172,7 @@ void NewDefaultPlaybackPolicy::Initialize(
    ViewInfo::Get( mProject ).playRegion.Bind( EVT_PLAY_REGION_CHANGE,
       &NewDefaultPlaybackPolicy::OnPlayRegionChange, this);
    if (mVariableSpeed)
-      mProject.Bind( EVT_PROJECT_SETTINGS_CHANGE,
+      mProject.Bind( EVT_PLAY_SPEED_CHANGE,
          &NewDefaultPlaybackPolicy::OnPlaySpeedChange, this);
 }
 
@@ -397,7 +397,7 @@ void NewDefaultPlaybackPolicy::WriteMessage()
 double NewDefaultPlaybackPolicy::GetPlaySpeed()
 {
    return mVariableSpeed
-      ? ProjectSettings::Get(mProject).GetPlaySpeed()
+      ? ProjectAudioIO::Get(mProject).GetPlaySpeed()
       : 1.0;
 }
 

--- a/src/ProjectAudioIO.cpp
+++ b/src/ProjectAudioIO.cpp
@@ -13,6 +13,8 @@ Paul Licameli split from AudacityProject.cpp
 #include "AudioIOBase.h"
 #include "Project.h"
 
+wxDEFINE_EVENT( EVT_PLAY_SPEED_CHANGE, wxCommandEvent);
+
 static const AudacityProject::AttachedObjects::RegisteredFactory sAudioIOKey{
   []( AudacityProject &parent ){
      return std::make_shared< ProjectAudioIO >( parent );
@@ -87,5 +89,14 @@ void ProjectAudioIO::SetCaptureMeter(
    if (gAudioIO)
    {
       gAudioIO->SetCaptureMeter( project.shared_from_this(), mCaptureMeter );
+   }
+}
+
+void ProjectAudioIO::SetPlaySpeed(double value)
+{
+   if (auto oldValue = GetPlaySpeed(); value != oldValue) {
+      mPlaySpeed.store( value, std::memory_order_relaxed );
+      wxCommandEvent evt{ EVT_PLAY_SPEED_CHANGE };
+      mProject.ProcessEvent(evt);
    }
 }

--- a/src/ProjectSettings.cpp
+++ b/src/ProjectSettings.cpp
@@ -140,14 +140,6 @@ void ProjectSettings::SetBandwidthSelectionFormatName(
    mBandwidthSelectionFormatName = formatName;
 }
 
-void ProjectSettings::SetPlaySpeed(double value)
-{
-   if (auto oldValue = GetPlaySpeed(); value != oldValue) {
-      mPlaySpeed.store( value, std::memory_order_relaxed );
-      Notify( mProject, ChangedPlaySpeed, oldValue );
-   }
-}
-
 void ProjectSettings::SetSelectionFormat(const NumericFormatSymbol & format)
 {
    mSelectionFormat = format;

--- a/src/ProjectSettings.h
+++ b/src/ProjectSettings.h
@@ -66,7 +66,6 @@ public:
    enum EventCode : int {
       ChangedSyncLock,
       ChangedTool,
-      ChangedPlaySpeed,
    };
 
    explicit ProjectSettings( AudacityProject &project );
@@ -102,11 +101,6 @@ public:
 
    void SetOvertones(bool isSelected) { mbOvertones = isSelected; }
    bool IsOvertones() const { return mbOvertones; }
-
-   // Speed play
-   double GetPlaySpeed() const {
-      return mPlaySpeed.load( std::memory_order_relaxed ); }
-   void SetPlaySpeed( double value );
    
    // Selection Format
    void SetSelectionFormat(const NumericFormatSymbol & format);
@@ -141,10 +135,6 @@ private:
    NumericFormatSymbol mAudioTimeFormat;
 
    wxString mSoloPref;
-
-   // This is atomic because scrubber may read it in a separate thread from
-   // the main
-   std::atomic<double> mPlaySpeed{};
 
    int mSnapTo;
 

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -36,8 +36,8 @@
 #include "ImageManipulation.h"
 #include "../KeyboardCapture.h"
 #include "Project.h"
+#include "../ProjectAudioIO.h"
 #include "../ProjectAudioManager.h"
-#include "../ProjectSettings.h"
 #include "../Envelope.h"
 #include "ViewInfo.h"
 #include "../WaveTrack.h"
@@ -156,7 +156,7 @@ void TranscriptionToolBar::Create(wxWindow * parent)
 void TranscriptionToolBar::SetPlaySpeed( double value )
 {
    mPlaySpeed = value;
-   ProjectSettings::Get( mProject ).SetPlaySpeed( GetPlaySpeed() );
+   ProjectAudioIO::Get( mProject ).SetPlaySpeed( GetPlaySpeed() );
 }
 
 /// This is a convenience function that allows for button creation in

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -20,7 +20,6 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../ProjectAudioManager.h"
 #include "../../ProjectHistory.h"
 #include "../../ProjectWindows.h"
-#include "../../ProjectSettings.h"
 #include "ProjectStatus.h"
 #include "../../ScrubState.h"
 #include "../../Track.h"
@@ -599,8 +598,8 @@ void Scrubber::ContinueScrubbingPoll()
       // default speed of 1.3 set, so that we can hear there is a problem
       // when playAtSpeedTB not found.
       double speed = 1.3;
-      const auto &settings = ProjectSettings::Get( *mProject );
-      speed = settings.GetPlaySpeed();
+      const auto &projectAudioIO = ProjectAudioIO::Get( *mProject );
+      speed = projectAudioIO.GetPlaySpeed();
       mOptions.minSpeed = speed -0.01;
       mOptions.maxSpeed = speed +0.01;
       mOptions.adjustStart = false;


### PR DESCRIPTION
Resolves: #2149

Complete the fix for issue 2149:  play-at-speed should also work with a loop region, and you should be able to adust the speed or the region or both during play, without the play head moving incorrectly

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
