### PR TITLE
Issue2318: Quick play guidelines should disappear...

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -669,6 +669,7 @@ BEGIN_EVENT_TABLE(AdornedRulerPanel, CellularPanel)
    EVT_IDLE( AdornedRulerPanel::OnIdle )
    EVT_PAINT(AdornedRulerPanel::OnPaint)
    EVT_SIZE(AdornedRulerPanel::OnSize)
+   EVT_LEAVE_WINDOW(AdornedRulerPanel::OnLeave)
 
    // Context menu commands
    EVT_MENU(OnSyncQuickPlaySelID, AdornedRulerPanel::OnSyncSelToQuickPlay)
@@ -1604,6 +1605,14 @@ void AdornedRulerPanel::OnSize(wxSizeEvent &evt)
    UpdateRects();
 
    OverlayPanel::OnSize(evt);
+}
+
+void AdornedRulerPanel::OnLeave(wxMouseEvent& evt)
+{
+   evt.Skip();
+   CallAfter([this]{
+      DrawBothOverlays();
+   });
 }
 
 void AdornedRulerPanel::OnThemeChange(wxCommandEvent& evt)

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -82,6 +82,7 @@ private:
    void OnAudioStartStop(wxCommandEvent & evt);
    void OnPaint(wxPaintEvent &evt);
    void OnSize(wxSizeEvent &evt);
+   void OnLeave(wxMouseEvent &evt);
    void OnThemeChange(wxCommandEvent& evt);
    void OnSelectionChange(SelectedRegionEvent& evt);
    void DoSelectionChange( const SelectedRegion &selectedRegion );


### PR DESCRIPTION
... Whenever the mouse moves from the time ruler into tracks.

Resolves: #2318

Make sure that the white quick-play guideline is erased whenever the mouse leaves the timeline.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
