### PR TITLE
Issue2323: white quick play guideline should not show during drags...

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -620,6 +620,15 @@ void AdornedRulerPanel::TrackPanelGuidelineOverlay::Draw(
    mOldPreviewingScrub = mNewPreviewingScrub;
 
    if (mOldQPIndicatorPos >= 0) {
+      if (!mOldPreviewingScrub && mOldIndicatorSnapped < 0) {
+         auto &ruler = AdornedRulerPanel::Get(*mProject);
+         if (auto pHandle =
+             dynamic_cast<PlayRegionAdjustingHandle*>(ruler.Target().get());
+            pHandle->Clicked())
+            // Do not draw the quick-play guideline
+            return;
+      }
+   
       mOldPreviewingScrub
          ? AColor::IndicatorColor(&dc, true) // Draw green line for preview.
          : (mOldIndicatorSnapped >= 0)


### PR DESCRIPTION
... But, do draw the yellow snap guidelines

Resolves: #2323
*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
