### PR TITLE
Observers

### DIFF
--- a/libraries/lib-audio-devices/DeviceManager.cpp
+++ b/libraries/lib-audio-devices/DeviceManager.cpp
@@ -27,8 +27,6 @@
 
 #include "DeviceChange.h" // for HAVE_DEVICE_CHANGE
 
-wxDEFINE_EVENT(EVT_RESCANNED_DEVICES, wxEvent);
-
 DeviceManager DeviceManager::dm;
 
 /// Gets the singleton instance
@@ -235,13 +233,6 @@ static void AddSources(int deviceIndex, int rate, std::vector<DeviceSourceMap> *
    }
 }
 
-namespace {
-struct MyEvent : wxEvent {
-   using wxEvent::wxEvent;
-   wxEvent *Clone() const override { return new MyEvent{*this}; }
-};
-}
-
 /// Gets a NEW list of devices by terminating and restarting portaudio
 /// Assumes that DeviceManager is only used on the main thread.
 void DeviceManager::Rescan()
@@ -295,10 +286,8 @@ void DeviceManager::Rescan()
    }
 
    // If this was not an initial scan update each device toolbar.
-   if ( m_inited ) {
-      MyEvent e{ 0, EVT_RESCANNED_DEVICES };
-      this->ProcessEvent( e );
-   }
+   if ( m_inited )
+      Publish(DeviceChangeMessage::Rescan);
 
    m_inited = true;
    mRescanTime = std::chrono::steady_clock::now();

--- a/libraries/lib-audio-devices/DeviceManager.h
+++ b/libraries/lib-audio-devices/DeviceManager.h
@@ -21,16 +21,9 @@
 #include <chrono>
 #include <vector>
 
-#include <wx/event.h> // to declare a custom event type
 #include <wx/string.h> // member variables
 
-#if defined(EXPERIMENTAL_DEVICE_CHANGE_HANDLER)
 #include "DeviceChange.h"
-#endif
-
-// Event sent to the application
-wxDECLARE_EXPORTED_EVENT(AUDIO_DEVICES_API,
-                         EVT_RESCANNED_DEVICES, wxEvent);
 
 typedef struct DeviceSourceMap {
    int deviceIndex;
@@ -50,7 +43,7 @@ class AUDIO_DEVICES_API DeviceManager final
 #if defined(EXPERIMENTAL_DEVICE_CHANGE_HANDLER) && defined(HAVE_DEVICE_CHANGE)
 : public DeviceChangeHandler
 #else
-: public wxEvtHandler
+: public DeviceChangeMessagePublisher
 #endif
 {
  public:

--- a/libraries/lib-ffmpeg-support/FFmpegFunctions.cpp
+++ b/libraries/lib-ffmpeg-support/FFmpegFunctions.cpp
@@ -13,6 +13,7 @@
 #include <wx/string.h>
 #include <wx/dynlib.h>
 #include <wx/log.h>
+#include <wx/utils.h>
 
 #if defined(__WXMSW__)
 #  include <wx/buffer.h>

--- a/libraries/lib-preferences/Prefs.h
+++ b/libraries/lib-preferences/Prefs.h
@@ -41,7 +41,6 @@
 #include "FileConfig.h"
 
 #include <memory>
-#include <wx/event.h> // to declare custom event types
 
 class wxFileName;
 

--- a/libraries/lib-project-rate/ProjectRate.cpp
+++ b/libraries/lib-project-rate/ProjectRate.cpp
@@ -17,21 +17,6 @@ Paul Licameli split from ProjectSettings.cpp
 #include "XMLWriter.h"
 #include "XMLAttributeValueView.h"
 
-wxDEFINE_EVENT(EVT_PROJECT_RATE_CHANGE, wxEvent);
-
-namespace {
-   struct MyEvent : wxEvent {
-      MyEvent() : wxEvent{ 0, EVT_PROJECT_RATE_CHANGE } {}
-      wxEvent *Clone() const override { return new MyEvent{*this}; }
-   };
-
-   void Notify( AudacityProject &project )
-   {
-      MyEvent e;
-      project.ProcessEvent( e );
-   }
-}
-
 static const AudacityProject::AttachedObjects::RegisteredFactory
 sKey{
   []( AudacityProject &project ){
@@ -51,7 +36,6 @@ const ProjectRate &ProjectRate::Get( const AudacityProject &project )
 }
 
 ProjectRate::ProjectRate(AudacityProject &project)
-   : mProject{ project }
 {
    int intRate = 0;
    bool wasDefined = QualitySettings::DefaultSampleRate.Read( &intRate );
@@ -75,7 +59,7 @@ void ProjectRate::SetRate(double rate)
 {
    if (rate != mRate) {
       mRate = rate;
-      Notify(mProject);
+      Publish(rate);
    }
 }
 

--- a/libraries/lib-project-rate/ProjectRate.h
+++ b/libraries/lib-project-rate/ProjectRate.h
@@ -15,15 +15,12 @@ Paul Licameli split from ProjectSettings.h
 class AudacityProject;
 
 #include "ClientData.h"
-#include <wx/event.h> // to declare custom event type
-
-// Sent to the project when the rate changes
-wxDECLARE_EXPORTED_EVENT(PROJECT_RATE_API,
-   EVT_PROJECT_RATE_CHANGE, wxEvent);
+#include "Observer.h"
 
 ///\brief Holds project sample rate
 class PROJECT_RATE_API ProjectRate final
    : public ClientData::Base
+   , public Observer::Publisher<double>
 {
 public:
    static ProjectRate &Get( AudacityProject &project );
@@ -37,7 +34,6 @@ public:
    double GetRate() const;
 
 private:
-   AudacityProject &mProject;
    double mRate;
 };
 

--- a/libraries/lib-project/Project.cpp
+++ b/libraries/lib-project/Project.cpp
@@ -14,8 +14,6 @@
 #include <wx/display.h>
 #include <wx/filename.h>
 
-wxDEFINE_EVENT(EVT_TRACK_PANEL_TIMER, wxCommandEvent);
-
 size_t AllProjects::size() const
 {
    return gAudacityProjects.size();

--- a/libraries/lib-project/Project.h
+++ b/libraries/lib-project/Project.h
@@ -76,9 +76,6 @@ using AttachedProjectObjects = ClientData::Site<
    AudacityProject, ClientData::Base, ClientData::SkipCopying, std::shared_ptr
 >;
 
-wxDECLARE_EXPORTED_EVENT(PROJECT_API,
-                         EVT_TRACK_PANEL_TIMER, wxCommandEvent);
-
 ///\brief The top-level handle to an Audacity project.  It serves as a source
 /// of events that other objects can bind to, and a container of associated
 /// sub-objects that it treats opaquely.  It stores a filename and a status

--- a/libraries/lib-project/ProjectStatus.cpp
+++ b/libraries/lib-project/ProjectStatus.cpp
@@ -12,20 +12,6 @@ Paul Licameli
 
 #include "Project.h"
 
-ProjectStatusEvent::ProjectStatusEvent( StatusBarField field )
-   : wxEvent{ -1, EVT_PROJECT_STATUS_UPDATE }
-   , mField{ field }
-{}
-
-ProjectStatusEvent::~ProjectStatusEvent() = default;
-
-wxEvent *ProjectStatusEvent::Clone() const
-{
-   return safenew ProjectStatusEvent{*this};
-}
-
-wxDEFINE_EVENT(EVT_PROJECT_STATUS_UPDATE, ProjectStatusEvent);
-
 static const AudacityProject::AttachedObjects::RegisteredFactory key{
   []( AudacityProject &parent ){
      return std::make_shared< ProjectStatus >( parent );
@@ -81,16 +67,13 @@ void ProjectStatus::Set(const TranslatableString &msg, StatusBarField field )
    // compare full translations not msgids!
    if ( msg.Translation() != lastMessage.Translation() ) {
       lastMessage = msg;
-      ProjectStatusEvent evt{ field };
-      project.ProcessEvent( evt );
+      Publish(field);
    }
 }
 
 void ProjectStatus::UpdatePrefs()
 {
    auto &project = mProject;
-   for (auto field = 1; field <= nStatusBarFields; field++) {
-      ProjectStatusEvent evt{ StatusBarField(field) };
-      project.ProcessEvent( evt );
-   }
+   for (auto field = 1; field <= nStatusBarFields; ++field)
+      Publish(static_cast<StatusBarField>(field));
 }

--- a/libraries/lib-project/ProjectStatus.h
+++ b/libraries/lib-project/ProjectStatus.h
@@ -14,9 +14,9 @@ Paul Licameli
 
 #include <utility>
 #include <vector>
-#include <wx/event.h> // to declare custom event type
 #include "ClientData.h" // to inherit
 #include "Prefs.h"
+#include "Observer.h"
 
 class AudacityProject;
 class wxWindow;
@@ -29,20 +29,10 @@ enum StatusBarField : int {
    nStatusBarFields = 3
 };
 
-struct PROJECT_API ProjectStatusEvent final : wxEvent{
-   explicit ProjectStatusEvent( StatusBarField field );
-   ~ProjectStatusEvent() override;
-   wxEvent *Clone() const override;
-   StatusBarField mField;
-};
-
-// Type of event emitted by the project when its status message is set
-wxDECLARE_EXPORTED_EVENT(PROJECT_API,
-                         EVT_PROJECT_STATUS_UPDATE, ProjectStatusEvent);
-
 class PROJECT_API ProjectStatus final
    : public ClientData::Base
    , public PrefsListener
+   , public Observer::Publisher<StatusBarField>
 {
 public:
    static ProjectStatus &Get( AudacityProject &project );

--- a/libraries/lib-sample-track/Mix.cpp
+++ b/libraries/lib-sample-track/Mix.cpp
@@ -23,7 +23,7 @@
 
 #include "Mix.h"
 
-#include <math.h>
+#include <cmath>
 
 #include "Envelope.h"
 #include "SampleTrack.h"

--- a/libraries/lib-sample-track/SampleTrack.cpp
+++ b/libraries/lib-sample-track/SampleTrack.cpp
@@ -10,6 +10,8 @@ Paul Licameli split from WaveTrack.cpp
 
 #include "SampleTrack.h"
 
+#include <cmath>
+
 SampleTrack::~SampleTrack() = default;
 
 static const Track::TypeInfo &typeInfo()

--- a/libraries/lib-screen-geometry/ViewInfo.h
+++ b/libraries/lib-screen-geometry/ViewInfo.h
@@ -13,34 +13,21 @@
 
 #include <utility>
 #include <vector>
-#include <wx/event.h> // inherit wxEvtHandler
 #include <wx/weakref.h> // member variable
 #include "SelectedRegion.h"
 #include <memory>
+#include "Observer.h"
 #include "Prefs.h"
 #include "XMLMethodRegistry.h"
 #include "ZoomInfo.h" // to inherit
 
-
-class NotifyingSelectedRegion;
-
-struct SelectedRegionEvent : public wxEvent
-{
-   SelectedRegionEvent( wxEventType commandType,
-                       NotifyingSelectedRegion *pRegion );
-
-   wxEvent *Clone() const override;
-
-   wxWeakRef< NotifyingSelectedRegion > pRegion;
-};
-
-// To do:  distinguish time changes from frequency changes perhaps?
-wxDECLARE_EXPORTED_EVENT( SCREEN_GEOMETRY_API,
-                          EVT_SELECTED_REGION_CHANGE, SelectedRegionEvent );
+struct NotifyingSelectedRegionMessage : Observer::Message {};
 
 // This heavyweight wrapper of the SelectedRegion structure emits events
 // on mutating operations, that other classes can listen for.
-class SCREEN_GEOMETRY_API NotifyingSelectedRegion : public wxEvtHandler
+class SCREEN_GEOMETRY_API NotifyingSelectedRegion
+   : public Observer::Publisher<NotifyingSelectedRegionMessage>
+   , public wxTrackable
 {
 public:
    // Expose SelectedRegion's const accessors
@@ -112,18 +99,10 @@ enum : int {
    kTrackInfoSliderExtra = 5,
 };
 
-class PlayRegion;
+struct PlayRegionMessage : Observer::Message {};
 
-struct PlayRegionEvent : public wxEvent
-{
-   PlayRegionEvent( wxEventType commandType, PlayRegion *pRegion );
-   wxEvent *Clone() const override;
-};
-
-wxDECLARE_EXPORTED_EVENT( SCREEN_GEOMETRY_API,
-   EVT_PLAY_REGION_CHANGE, PlayRegionEvent );
-
-class SCREEN_GEOMETRY_API PlayRegion : public wxEvtHandler
+class SCREEN_GEOMETRY_API PlayRegion
+   : public Observer::Publisher<PlayRegionMessage>
 {
 public:
    PlayRegion() = default;
@@ -205,7 +184,7 @@ private:
 extern SCREEN_GEOMETRY_API const TranslatableString LoopToggleText;
 
 class SCREEN_GEOMETRY_API ViewInfo final
-   : public wxEvtHandler, public ZoomInfo
+   : public ZoomInfo
 {
 public:
    static ViewInfo &Get( AudacityProject &project );

--- a/libraries/lib-screen-geometry/ZoomInfo.cpp
+++ b/libraries/lib-screen-geometry/ZoomInfo.cpp
@@ -11,6 +11,8 @@
 #include "ZoomInfo.h"
 #include "Decibels.h"
 
+#include <cmath>
+
 namespace {
 static const double gMaxZoom = 6000000;
 static const double gMinZoom = 0.001;

--- a/libraries/lib-utility/CMakeLists.txt
+++ b/libraries/lib-utility/CMakeLists.txt
@@ -24,6 +24,8 @@ set( SOURCES
    ModuleConstants.h
    MemoryStream.cpp
    MemoryStream.h
+   Observer.cpp
+   Observer.h
 )
 audacity_library( lib-utility "${SOURCES}" ""
    "" ""

--- a/libraries/lib-utility/Observer.cpp
+++ b/libraries/lib-utility/Observer.cpp
@@ -1,0 +1,108 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file Observer.cpp
+  @brief Publisher-subscriber pattern, also known as Observer
+
+  Paul Licameli
+
+**********************************************************************/
+#include "Observer.h"
+
+namespace Observer {
+
+namespace detail {
+
+void RecordBase::Unlink() noexcept
+{
+   auto pPrev = prev.lock();
+   assert(pPrev); // See RecordList constructor and PushFront
+   // Do not move from next, see Visit
+   if (auto &pNext = (pPrev->next = next))
+      pNext->prev = move(prev);
+}
+
+RecordList::RecordList( ExceptionPolicy *pPolicy, Visitor visitor )
+   : m_pPolicy{ pPolicy }
+   , m_visitor{ visitor }
+{
+   assert(m_visitor); // precondition
+}
+
+RecordList::~RecordList() noexcept
+{
+   //! Non-defaulted destructor.  Beware stack growth
+   auto pRecord = move(next);
+   while (pRecord)
+      pRecord = move(pRecord->next);
+}
+
+Subscription RecordList::Subscribe(std::shared_ptr<RecordBase> pRecord)
+{
+   assert(pRecord); // precondition
+   auto result = Subscription{ pRecord };
+   if (auto &pNext = (pRecord->next = move(next)))
+      pNext->prev = pRecord;
+   pRecord->prev = weak_from_this();
+   next = move(pRecord);
+   return result;
+}
+
+bool RecordList::Visit(const void *arg)
+{
+   assert(m_visitor); // See constructor
+   if (m_pPolicy)
+      m_pPolicy->OnBeginPublish();
+   bool result = false;
+   for (auto pRecord = next; pRecord; pRecord = pRecord->next) {
+      try {
+         if (m_visitor(*pRecord, arg)) {
+            result = true;
+            break;
+         }
+         // pRecord might have been removed from the list by the callback,
+         // but pRecord->next is unchanged.  We won't see callbacks added by
+         // the callback, because they are earlier in the list.
+      }
+      catch (...) {
+         if (m_pPolicy && m_pPolicy->OnEachFailedCallback()) {
+            result = true;
+            break;
+         }
+      }
+   }
+   // Intentionally not in a finally():
+   if (m_pPolicy)
+      m_pPolicy->OnEndPublish();
+   return result;
+}
+
+}
+
+ExceptionPolicy::~ExceptionPolicy() noexcept = default;
+
+Subscription::Subscription() = default;
+Subscription::Subscription(std::weak_ptr<detail::RecordBase> pRecord)
+   : m_wRecord{ move(pRecord) } {}
+Subscription::Subscription(Subscription &&) = default;
+Subscription &Subscription::operator=(Subscription &&other)
+{
+   const bool inequivalent =
+      m_wRecord.owner_before(other.m_wRecord) ||
+      other.m_wRecord.owner_before(m_wRecord);
+   if (inequivalent) {
+      Reset();
+      m_wRecord = move(other.m_wRecord);
+   }
+   return *this;
+}
+
+void Subscription::Reset() noexcept
+{
+   if (auto pRecord = m_wRecord.lock())
+      pRecord->Unlink();
+   m_wRecord.reset();
+}
+
+}

--- a/libraries/lib-utility/Observer.h
+++ b/libraries/lib-utility/Observer.h
@@ -1,0 +1,216 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file Observer.h
+  @brief Publisher-subscriber pattern, also known as Observer
+
+  Paul Licameli
+
+**********************************************************************/
+#ifndef __AUDACITY_OBSERVER__
+#define __AUDACITY_OBSERVER__
+
+#include <cassert>
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+namespace Observer {
+
+// See below
+template<typename Message, bool NotifyAll>
+class Publisher;
+
+//! Default message type for Publisher
+struct Message {};
+
+//! May be supplied to constructor of Publisher to customize exception handling
+struct UTILITY_API ExceptionPolicy {
+   virtual ~ExceptionPolicy() noexcept;
+   //! Called at the start of each publication
+   virtual void OnBeginPublish() = 0;
+   // In a catch block, can rethrow or store std::current_exception()
+   /*! @return if true, then skip remaining callbacks */
+   virtual bool OnEachFailedCallback() noexcept(false) = 0;
+   //! Called at the end of each publication, if exiting normally; may throw
+   virtual void OnEndPublish() noexcept(false) = 0;
+};
+
+class Subscription;
+
+//! Type-erased implementation helpers for Publisher
+namespace detail {
+struct RecordBase;
+struct RecordLink{
+   std::shared_ptr<RecordBase> next;
+};
+//! doubly-linked list cell using shared and weak pointers
+struct UTILITY_API RecordBase : RecordLink {
+   std::weak_ptr<RecordLink> prev;
+   void Unlink() noexcept;
+};
+struct UTILITY_API RecordList
+   : RecordLink, std::enable_shared_from_this<RecordLink> {
+   //! Type of function visiting the list; stop visit on true return
+   using Visitor = bool(*)(const RecordBase &record, const void *arg);
+   //! @pre `visitor != nullptr`
+   explicit RecordList(ExceptionPolicy *pPolicy, Visitor visitor);
+   ~RecordList() noexcept;
+   //! @pre `pRecord != nullptr`
+   Subscription Subscribe(std::shared_ptr<RecordBase> pRecord);
+   bool Visit(const void *arg);
+private:
+   ExceptionPolicy *const m_pPolicy;
+   const Visitor m_visitor;
+};
+}
+
+//! A move-only handle representing a connection to a Publisher
+class UTILITY_API Subscription {
+public:
+   Subscription();
+   Subscription(Subscription &&);
+   Subscription &operator=(Subscription &&);
+
+   //! Calls Reset
+   ~Subscription() noexcept { Reset(); }
+
+   //! Breaks the connection (constant time)
+   void Reset() noexcept;
+
+   /*!
+      @return true iff there is no connection
+      (Publisher was destroyed, or this was not reassigned since it was last
+      Reset(), default-constructed, or moved from)
+    */
+   bool Expired() const { return m_wRecord.expired(); }
+
+   //! @return not expired
+   explicit operator bool() const { return !Expired(); }
+
+private:
+   friend detail::RecordList;
+   explicit Subscription(std::weak_ptr<detail::RecordBase> pRecord);
+   std::weak_ptr<detail::RecordBase> m_wRecord;
+};
+
+//! An object that sends messages to an open-ended list of subscribed callbacks
+/*!
+ Intended for single-threaded use only.
+ Move-only; allows type-erased custom allocation.
+
+ @tparam Message the type of mesage
+ @tparam NotifyAll if true, callback return values are ignored; else, a callback
+   returning true causes earlier subscribed callbacks to be skipped
+ */
+template<typename Message = Message, bool NotifyAll = true>
+class Publisher {
+public:
+   //! An implementation class, public so it can be your custom allocator's template parameter
+   struct Record;
+
+   static constexpr bool notifies_all = NotifyAll;
+   using message_type = Message;
+
+   //! Constructor supporting type-erased custom allocation/deletion
+   /*!
+    @param pPolicy if null, exceptions from callbacks are caught and ignored;
+    else, *pPolicy must have a lifetime encompassing the Publisher's
+    */
+   template<typename Alloc = std::allocator<Record>>
+   explicit Publisher(ExceptionPolicy *pPolicy = nullptr, Alloc a = {});
+
+   Publisher(Publisher&&) = default;
+   Publisher& operator=(Publisher&&) = default;
+
+   using CallbackReturn = std::conditional_t<NotifyAll, void, bool>;
+
+   //! Type of functions that can be connected to the Publisher
+   using Callback = std::function< CallbackReturn(const Message&) >;
+
+   //! Connect a callback to the Publisher; later-connected are called earlier
+   /*!
+    During Publish(), the callback may have the side-effect of adding or
+    removing other Subscriptions.  Added subscriptions will not be called,
+    and removed ones, if not called already, will not be called after.
+
+    @pre `callback != nullptr`
+    */
+   Subscription Subscribe(Callback callback);
+
+   //! Overload of Subscribe takes an object and pointer-to-member-function
+   template<typename Object, typename Return, typename... Args>
+   Subscription Subscribe(
+      Object &obj, Return (Object::*callback)(Args...))
+   {
+      return Subscribe( [&obj, callback](const Message &message){
+         return (obj.*callback)(message);
+      } );
+   }
+
+   //! Send a message to connected callbacks
+   /*! Later-connected are called earlier; if !NotifyAll, any callback may
+     return true, to stop the notification; see also class ExceptionPolicy
+
+    @return if `NotifyAll`, then void; else, whether the visit was stopped
+    (either because a callback returned true, or the exception policy consumed
+    an exception, and ordered a stop)
+    */
+   CallbackReturn Publish(const Message &message);
+
+   struct Record : detail::RecordBase {
+      explicit Record(Callback callback) : callback{ move(callback) } {}
+      Callback callback;
+   };
+
+private:
+   // RecordList needs to be non-relocating but the Publisher object is movable
+   std::shared_ptr<detail::RecordList> m_list;
+   std::function<std::shared_ptr<detail::RecordBase>(Callback)> m_factory;
+};
+
+template<typename Message, bool NotifyAll>
+template<typename Alloc> inline
+Publisher<Message, NotifyAll>::Publisher(ExceptionPolicy *pPolicy, Alloc a)
+: m_list{ std::allocate_shared<detail::RecordList>( a, pPolicy,
+    []( // The visitor.  Lambda with no capture converts to pointer-to-function
+      const detail::RecordBase &recordBase, const void *arg){
+      auto &record = static_cast<const Record&>(recordBase);
+      assert(arg);
+      auto &message = *static_cast<const Message*>(arg);
+      assert(record.callback);
+      // Calling foreign code!  Which is why we have an exception policy.
+      if constexpr (NotifyAll)
+         return (record.callback(message), false);
+      else
+         return record.callback(message);
+   }
+) }
+, m_factory( [a = move(a)](Callback callback) {
+   return std::allocate_shared<Record>(a, move(callback));
+} )
+{}
+
+// Thin wrappers of type-erased worker functions:
+
+template<typename Message, bool NotifyAll>
+auto Publisher<Message, NotifyAll>::Subscribe(Callback callback)
+   -> Subscription
+{
+   assert(callback); // precondition
+   return m_list->Subscribe(m_factory(move(callback)));
+}
+
+template<typename Message, bool NotifyAll> inline
+auto Publisher<Message, NotifyAll>::Publish(const Message &message)
+   -> CallbackReturn
+{
+   bool result = m_list->Visit(&message);
+   if constexpr (!NotifyAll)
+      return result;
+}
+
+}
+
+#endif

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1295,12 +1295,8 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
    wxToolTip::Enable(true);
 #endif
 
-   wxTheApp->Bind(EVT_AUDIOIO_CAPTURE,
-                     &AdornedRulerPanel::OnAudioStartStop,
-                     this);
-   wxTheApp->Bind(EVT_AUDIOIO_PLAYBACK,
-                     &AdornedRulerPanel::OnAudioStartStop,
-                     this);
+   mAudioIOSubscription = AudioIO::Get()
+      ->Subscribe(*this, &AdornedRulerPanel::OnAudioStartStop);
 
    // Delay until after CommandManager has been populated:
    this->CallAfter( &AdornedRulerPanel::UpdatePrefs );
@@ -1308,7 +1304,7 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
    wxTheApp->Bind(EVT_THEME_CHANGE, &AdornedRulerPanel::OnThemeChange, this);
 
    // Bind event that updates the play region
-   mSubscription = mViewInfo->selectedRegion.Subscribe(
+   mPlayRegionSubscription = mViewInfo->selectedRegion.Subscribe(
       *this, &AdornedRulerPanel::OnSelectionChange);
 
    // And call it once to initialize it
@@ -1526,12 +1522,12 @@ void AdornedRulerPanel::DoIdle()
       Refresh();
 }
 
-void AdornedRulerPanel::OnAudioStartStop(wxCommandEvent & evt)
+void AdornedRulerPanel::OnAudioStartStop(AudioIOEvent evt)
 {
-   evt.Skip();
-
-   if ( evt.GetEventType() == EVT_AUDIOIO_CAPTURE ) {
-      if (evt.GetInt() != 0)
+   if (evt.type == AudioIOEvent::MONITOR)
+      return;
+   if ( evt.type == AudioIOEvent::CAPTURE ) {
+      if (evt.on)
       {
          mIsRecording = true;
          this->CellularPanel::CancelDragging( false );
@@ -1545,7 +1541,7 @@ void AdornedRulerPanel::OnAudioStartStop(wxCommandEvent & evt)
       }
    }
 
-   if ( evt.GetInt() == 0 )
+   if ( !evt.on )
       // So that the play region is updated
       DoSelectionChange( mViewInfo->selectedRegion );
 }

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1308,8 +1308,8 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
    wxTheApp->Bind(EVT_THEME_CHANGE, &AdornedRulerPanel::OnThemeChange, this);
 
    // Bind event that updates the play region
-   mViewInfo->selectedRegion.Bind(EVT_SELECTED_REGION_CHANGE,
-      &AdornedRulerPanel::OnSelectionChange, this);
+   mSubscription = mViewInfo->selectedRegion.Subscribe(
+      *this, &AdornedRulerPanel::OnSelectionChange);
 
    // And call it once to initialize it
    DoSelectionChange( mViewInfo->selectedRegion );
@@ -1630,12 +1630,9 @@ void AdornedRulerPanel::OnThemeChange(wxCommandEvent& evt)
    ReCreateButtons();
 }
 
-void AdornedRulerPanel::OnSelectionChange(SelectedRegionEvent& evt)
+void AdornedRulerPanel::OnSelectionChange(Observer::Message)
 {
-   evt.Skip();
-   if (!evt.pRegion)
-      return;
-   auto &selectedRegion = *evt.pRegion;
+   auto &selectedRegion = mViewInfo->selectedRegion;
    DoSelectionChange( selectedRegion );
 }
 

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -13,6 +13,7 @@
 
 #include "CellularPanel.h"
 #include "widgets/Ruler.h" // member variable
+#include "Observer.h"
 #include "Prefs.h"
 #include "ViewInfo.h" // for PlayRegion
 
@@ -84,7 +85,7 @@ private:
    void OnSize(wxSizeEvent &evt);
    void OnLeave(wxMouseEvent &evt);
    void OnThemeChange(wxCommandEvent& evt);
-   void OnSelectionChange(SelectedRegionEvent& evt);
+   void OnSelectionChange(Observer::Message);
    void DoSelectionChange( const SelectedRegion &selectedRegion );
    bool UpdateRects();
    void HandleQPClick(wxMouseEvent &event, wxCoord mousePosX);
@@ -235,6 +236,8 @@ private:
    
    class ScrubbingCell;
    std::shared_ptr<ScrubbingCell> mScrubbingCell;
+
+   Observer::Subscription mSubscription;
 
    // classes implementing subdivision for CellularPanel
    struct Subgroup;

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -18,6 +18,7 @@
 #include "ViewInfo.h" // for PlayRegion
 
 class AudacityProject;
+struct AudioIOEvent;
 struct SelectedRegionEvent;
 class TrackList;
 
@@ -80,7 +81,7 @@ public:
 private:
    void DoIdle();
    void OnIdle( wxIdleEvent &evt );
-   void OnAudioStartStop(wxCommandEvent & evt);
+   void OnAudioStartStop(AudioIOEvent);
    void OnPaint(wxPaintEvent &evt);
    void OnSize(wxSizeEvent &evt);
    void OnLeave(wxMouseEvent &evt);
@@ -237,7 +238,8 @@ private:
    class ScrubbingCell;
    std::shared_ptr<ScrubbingCell> mScrubbingCell;
 
-   Observer::Subscription mSubscription;
+   Observer::Subscription mAudioIOSubscription,
+      mPlayRegionSubscription;
 
    // classes implementing subdivision for CellularPanel
    struct Subgroup;

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2849,8 +2849,7 @@ void AudioIoCallback::SendVuOutputMeterData(
       //    The problem there occurs if Software Playthrough is on.
       //    Could conditionally do the update here if Software Playthrough is off,
       //    and in TrackPanel::OnTimer() if Software Playthrough is on, but not now.
-      // PRL 12 Jul 2015: and what was in TrackPanel::OnTimer is now handled by means of event
-      // type EVT_TRACK_PANEL_TIMER
+      // PRL 12 Jul 2015: and what was in TrackPanel::OnTimer is now handled by means of track panel timer events
       //MixerBoard* pMixerBoard = mOwningProject->GetMixerBoard();
       //if (pMixerBoard)
       //   pMixerBoard->UpdateMeters(GetStreamTime(),

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -24,8 +24,7 @@
 #include <utility>
 #include <wx/atomic.h> // member variable
 
-#include <wx/event.h> // to declare custom event types
-
+#include "Observer.h"
 #include "SampleCount.h"
 #include "SampleFormat.h"
 
@@ -53,12 +52,19 @@ typedef int PaError;
 
 bool ValidateDeviceNames();
 
-wxDECLARE_EXPORTED_EVENT(AUDACITY_DLL_API,
-                         EVT_AUDIOIO_PLAYBACK, wxCommandEvent);
-wxDECLARE_EXPORTED_EVENT(AUDACITY_DLL_API,
-                         EVT_AUDIOIO_CAPTURE, wxCommandEvent);
-wxDECLARE_EXPORTED_EVENT(AUDACITY_DLL_API,
-                         EVT_AUDIOIO_MONITOR, wxCommandEvent);
+/*!
+ Emitted by the global AudioIO object when play, recording, or monitoring
+ starts or stops
+*/
+struct AudioIOEvent {
+   AudacityProject *pProject;
+   enum Type {
+      PLAYBACK,
+      CAPTURE,
+      MONITOR,
+   } type;
+   bool on;
+};
 
 struct TransportTracks {
    WaveTrackArray playbackTracks;
@@ -352,6 +358,7 @@ struct PaStreamInfo;
 
 class AUDACITY_DLL_API AudioIO final
    : public AudioIoCallback
+   , public Observer::Publisher<AudioIOEvent>
 {
 
    AudioIO();

--- a/src/HistoryWindow.h
+++ b/src/HistoryWindow.h
@@ -11,6 +11,7 @@
 #ifndef __AUDACITY_HISTORY_WINDOW__
 #define __AUDACITY_HISTORY_WINDOW__
 
+#include "Observer.h"
 #include "Prefs.h"
 #include "widgets/wxPanelWrapper.h" // to inherit
 
@@ -19,6 +20,7 @@ class wxListCtrl;
 class wxListEvent;
 class wxSpinCtrl;
 class wxTextCtrl;
+struct AudioIOEvent;
 class AudacityProject;
 class ShuttleGui;
 class UndoManager;
@@ -37,7 +39,7 @@ class HistoryDialog final : public wxDialogWrapper,
  private:
    void Populate(ShuttleGui & S);
 
-   void OnAudioIO(wxCommandEvent & evt);
+   void OnAudioIO(AudioIOEvent);
    void DoUpdate();
    void UpdateLevels();
 
@@ -53,6 +55,8 @@ class HistoryDialog final : public wxDialogWrapper,
 
    // PrefsListener implementation
    void UpdatePrefs() override;
+
+   Observer::Subscription mSubscription;
 
    AudacityProject   *mProject;
    UndoManager       *mManager;

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -21,7 +21,6 @@
 class wxTextFile;
 
 class AudacityProject;
-class NotifyingSelectedRegion;
 class TimeWarper;
 
 class LabelTrack;

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -16,6 +16,7 @@
 #include "SelectedRegion.h"
 #include "Track.h"
 
+#include <wx/event.h> // to inherit
 
 class wxTextFile;
 
@@ -187,7 +188,7 @@ public:
 
 ENUMERATE_TRACK_TYPE(LabelTrack);
 
-struct LabelTrackEvent : TrackListEvent
+struct LabelTrackEvent : public wxEvent
 {
    explicit
    LabelTrackEvent(
@@ -196,7 +197,8 @@ struct LabelTrackEvent : TrackListEvent
       int formerPosition,
       int presentPosition
    )
-   : TrackListEvent{ commandType, pTrack }
+   : wxEvent{ 0, commandType }
+   , mpTrack{ pTrack }
    , mTitle{ title }
    , mFormerPosition{ formerPosition }
    , mPresentPosition{ presentPosition }
@@ -206,6 +208,8 @@ struct LabelTrackEvent : TrackListEvent
    wxEvent *Clone() const override {
       // wxWidgets will own the event object
       return safenew LabelTrackEvent(*this); }
+
+   const std::weak_ptr<Track> mpTrack;
 
    // invalid for selection events
    wxString mTitle;

--- a/src/Lyrics.h
+++ b/src/Lyrics.h
@@ -18,8 +18,10 @@
 #include <wx/textctrl.h> // to inherit
 #include "commands/CommandManagerWindowClasses.h"
 #include "widgets/wxPanelWrapper.h" // to inherit
+#include "Observer.h"
 
 class AudacityProject;
+struct AudioIOEvent;
 class LabelTrack;
 
 
@@ -101,8 +103,9 @@ class LyricsPanel final
 
    void Update(double t);
    void UpdateLyrics(wxEvent &e);
+   void UpdateLyrics();
    void OnShow(wxShowEvent& e);
-   void OnStartStop(wxCommandEvent &e);
+   void OnStartStop(AudioIOEvent);
 
    //
    // Event handlers
@@ -138,6 +141,8 @@ private:
    void GetKaraokePosition(double t, int *outX, double *outY);
 
 private:
+   Observer::Subscription mSubscription;
+
    int            mWidth;  // client width
    int            mHeight; // client height
 

--- a/src/LyricsWindow.cpp
+++ b/src/LyricsWindow.cpp
@@ -18,6 +18,7 @@
 #include "Project.h"
 #include "ProjectAudioIO.h"
 #include "ProjectFileIO.h"
+#include "ProjectWindow.h"
 #include "ProjectWindows.h"
 #include "ViewInfo.h"
 
@@ -139,9 +140,9 @@ LyricsWindow::LyricsWindow(AudacityProject *parent)
    //}
 
    // Events from the project don't propagate directly to this other frame, so...
-   pProject->Bind(EVT_TRACK_PANEL_TIMER,
-      &LyricsWindow::OnTimer,
-      this);
+   if (pProject)
+      mSubscription = ProjectWindow::Get( *pProject ).GetPlaybackScroller()
+         .Subscribe(*this, &LyricsWindow::OnTimer);
    Center();
 }
 
@@ -160,7 +161,7 @@ void LyricsWindow::OnStyle_Highlight(wxCommandEvent & WXUNUSED(event))
    mLyricsPanel->SetLyricsStyle(LyricsPanel::kHighlightLyrics);
 }
 
-void LyricsWindow::OnTimer(wxCommandEvent &event)
+void LyricsWindow::OnTimer(Observer::Message)
 {
    if (auto pProject = mProject.lock()) {
       if (ProjectAudioIO::Get( *pProject ).IsAudioActive())
@@ -175,9 +176,6 @@ void LyricsWindow::OnTimer(wxCommandEvent &event)
          GetLyricsPanel()->Update(selectedRegion.t0());
       }
    }
-
-   // Let other listeners get the notification
-   event.Skip();
 }
 
 void LyricsWindow::SetWindowTitle()

--- a/src/LyricsWindow.h
+++ b/src/LyricsWindow.h
@@ -15,6 +15,7 @@
 #include <wx/frame.h> // to inherit
 #include <memory>
 
+#include "Observer.h"
 #include "Prefs.h"
 
 class AudacityProject;
@@ -34,7 +35,7 @@ class LyricsWindow final : public wxFrame,
 
    void OnStyle_BouncingBall(wxCommandEvent &evt);
    void OnStyle_Highlight(wxCommandEvent &evt);
-   void OnTimer(wxCommandEvent &event);
+   void OnTimer(Observer::Message);
 
    void SetWindowTitle();
 
@@ -43,6 +44,7 @@ class LyricsWindow final : public wxFrame,
 
    std::weak_ptr<AudacityProject> mProject;
    LyricsPanel *mLyricsPanel;
+   Observer::Subscription mSubscription;
 
  public:
    DECLARE_EVENT_TABLE()

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -941,10 +941,8 @@ MixerBoard::MixerBoard(AudacityProject* pProject,
       }
    });
 
-   wxTheApp->Connect(EVT_AUDIOIO_PLAYBACK,
-      wxCommandEventHandler(MixerBoard::OnStartStop),
-      NULL,
-      this);
+   mAudioIOSubscription =
+      AudioIO::Get()->Subscribe(*this, &MixerBoard::OnStartStop);
 }
 
 
@@ -1384,11 +1382,10 @@ void MixerBoard::OnTrackSetChanged()
    Refresh();
 }
 
-void MixerBoard::OnStartStop(wxCommandEvent &evt)
+void MixerBoard::OnStartStop(AudioIOEvent evt)
 {
-   evt.Skip();
-   bool start = evt.GetInt();
-   ResetMeters( start );
+   if (evt.type == AudioIOEvent::PLAYBACK)
+      ResetMeters( evt.on );
 }
 
 // class MixerBoardFrame

--- a/src/MixerBoard.h
+++ b/src/MixerBoard.h
@@ -20,6 +20,7 @@
 #include "widgets/ASlider.h" // to inherit
 #include "commands/CommandManagerWindowClasses.h"
 
+#include "Observer.h"
 #include "Prefs.h"
 
 class wxArrayString;
@@ -234,8 +235,8 @@ private:
    void OnPaint(wxPaintEvent& evt);
    void OnSize(wxSizeEvent &evt);
    void OnTimer(wxCommandEvent &event);
-   void OnTrackSetChanged(wxEvent &event);
-   void OnTrackChanged(TrackListEvent &event);
+   void OnTrackSetChanged();
+   void OnTrackChanged(const TrackListEvent &event);
    void OnStartStop(wxCommandEvent &event);
 
 public:
@@ -247,6 +248,8 @@ public:
    int mMuteSoloWidth;
 
 private:
+   Observer::Subscription mSubscription;
+
    // Track clusters are maintained in the same order as the WaveTracks.
    std::vector<MixerTrackCluster*> mMixerTrackClusters;
 

--- a/src/MixerBoard.h
+++ b/src/MixerBoard.h
@@ -234,7 +234,7 @@ private:
    // event handlers
    void OnPaint(wxPaintEvent& evt);
    void OnSize(wxSizeEvent &evt);
-   void OnTimer(wxCommandEvent &event);
+   void OnTimer(Observer::Message);
    void OnTrackSetChanged();
    void OnTrackChanged(const TrackListEvent &event);
    void OnStartStop(wxCommandEvent &event);
@@ -248,7 +248,8 @@ public:
    int mMuteSoloWidth;
 
 private:
-   Observer::Subscription mSubscription;
+   Observer::Subscription mPlaybackScrollerSubscription,
+      mTrackPanelSubscription;
 
    // Track clusters are maintained in the same order as the WaveTracks.
    std::vector<MixerTrackCluster*> mMixerTrackClusters;

--- a/src/MixerBoard.h
+++ b/src/MixerBoard.h
@@ -28,6 +28,7 @@ class wxBitmapButton;
 class wxImage;
 class wxMemoryDC;
 class AButton;
+struct AudioIOEvent;
 struct TrackListEvent;
 
 // containment hierarchy:
@@ -237,7 +238,7 @@ private:
    void OnTimer(Observer::Message);
    void OnTrackSetChanged();
    void OnTrackChanged(const TrackListEvent &event);
-   void OnStartStop(wxCommandEvent &event);
+   void OnStartStop(AudioIOEvent);
 
 public:
    // mute & solo button images: Create once and store on MixerBoard for use in all MixerTrackClusters.
@@ -249,7 +250,8 @@ public:
 
 private:
    Observer::Subscription mPlaybackScrollerSubscription,
-      mTrackPanelSubscription;
+      mTrackPanelSubscription,
+      mAudioIOSubscription;
 
    // Track clusters are maintained in the same order as the WaveTracks.
    std::vector<MixerTrackCluster*> mMixerTrackClusters;

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -170,8 +170,8 @@ void NewDefaultPlaybackPolicy::Initialize(
    mMessageChannel.Write( { mLastPlaySpeed,
       schedule.mT0, mLoopEndTime, mLoopEnabled } );
 
-   ViewInfo::Get( mProject ).playRegion.Bind( EVT_PLAY_REGION_CHANGE,
-      &NewDefaultPlaybackPolicy::OnPlayRegionChange, this);
+   mSubscription = ViewInfo::Get( mProject ).playRegion.Subscribe(
+      *this, &NewDefaultPlaybackPolicy::OnPlayRegionChange);
    if (mVariableSpeed)
       mProject.Bind( EVT_PLAY_SPEED_CHANGE,
          &NewDefaultPlaybackPolicy::OnPlaySpeedChange, this);
@@ -386,10 +386,9 @@ bool NewDefaultPlaybackPolicy::Looping( const PlaybackSchedule & ) const
    return mLoopEnabled;
 }
 
-void NewDefaultPlaybackPolicy::OnPlayRegionChange( PlayRegionEvent &evt)
+void NewDefaultPlaybackPolicy::OnPlayRegionChange(Observer::Message)
 {
    // This executes in the main thread
-   evt.Skip(); // Let other listeners hear the event too
    WriteMessage();
 }
 

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -13,6 +13,7 @@
 
 #include "MemoryX.h"
 #include "Mix.h"
+#include "Observer.h"
 #include <atomic>
 #include <chrono>
 #include <vector>
@@ -465,7 +466,7 @@ public:
 
 private:
    bool RevertToOldDefault( const PlaybackSchedule &schedule ) const;
-   void OnPlayRegionChange(PlayRegionEvent &evt);
+   void OnPlayRegionChange(Observer::Message);
    void OnPlaySpeedChange(wxCommandEvent &evt);
    void WriteMessage();
    double GetPlaySpeed();
@@ -481,6 +482,8 @@ private:
       bool mLoopEnabled;
    };
    MessageBuffer<SlotData> mMessageChannel;
+
+   Observer::Subscription mSubscription;
 
    double mLastPlaySpeed{ 1.0 };
    const double mTrackEndTime;

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -14,6 +14,8 @@ Paul Licameli split from AudacityProject.h
 #include <memory>
 #include <unordered_set>
 
+#include <wx/event.h>
+
 #include "ClientData.h" // to inherit
 #include "Prefs.h" // to inherit
 #include "XMLTagHandler.h" // to inherit

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -81,8 +81,8 @@ ProjectManager::ProjectManager( AudacityProject &project )
 {
    auto &window = ProjectWindow::Get( mProject );
    window.Bind( wxEVT_CLOSE_WINDOW, &ProjectManager::OnCloseWindow, this );
-   mProject.Bind(EVT_PROJECT_STATUS_UPDATE,
-      &ProjectManager::OnStatusChange, this);
+   mSubscription = ProjectStatus::Get(mProject)
+      .Subscribe(*this, &ProjectManager::OnStatusChange);
    project.Bind( EVT_RECONNECTION_FAILURE,
       &ProjectManager::OnReconnectionFailure, this );
 }
@@ -846,10 +846,8 @@ void ProjectManager::OnTimer(wxTimerEvent& WXUNUSED(event))
    RestartTimer();
 }
 
-void ProjectManager::OnStatusChange( ProjectStatusEvent &evt )
+void ProjectManager::OnStatusChange(StatusBarField field)
 {
-   evt.Skip();
-
    auto &project = mProject;
 
    // Be careful to null-check the window.  We might get to this function
@@ -862,7 +860,6 @@ void ProjectManager::OnStatusChange( ProjectStatusEvent &evt )
 
    window.UpdateStatusWidths();
 
-   auto field = evt.mField;
    const auto &msg = ProjectStatus::Get( project ).Get( field );
    SetStatusText( msg, field );
    

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -16,6 +16,7 @@ Paul Licameli split from AudacityProject.h
 #include <wx/event.h> // to inherit
 #include "ClientData.h" // to inherit
 #include "Identifier.h"
+#include "Observer.h"
 
 class wxTimer;
 class wxTimerEvent;
@@ -24,6 +25,8 @@ class AudacityProject;
 struct AudioIOStartStreamOptions;
 
 struct ProjectStatusEvent;
+
+enum StatusBarField : int;
 
 ///\brief Object associated with a project for high-level management of the
 /// project's lifetime, including creation, destruction, opening from file,
@@ -118,7 +121,7 @@ private:
    void OnCloseWindow(wxCloseEvent & event);
    void OnTimer(wxTimerEvent & event);
    void OnOpenAudioFile(wxCommandEvent & event);
-   void OnStatusChange( ProjectStatusEvent& );
+   void OnStatusChange(StatusBarField field);
 
    void RestartTimer();
 
@@ -126,6 +129,8 @@ private:
    AudacityProject &mProject;
 
    std::unique_ptr<wxTimer> mTimer;
+
+   Observer::Subscription mSubscription;
 
    DECLARE_EVENT_TABLE()
 

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1664,9 +1664,6 @@ void ProjectWindow::TP_HandleResize()
 ProjectWindow::PlaybackScroller::PlaybackScroller(AudacityProject *project)
 : mProject(project)
 {
-   mProject->Bind(EVT_TRACK_PANEL_TIMER,
-      &PlaybackScroller::OnTimer,
-      this);
 }
 
 void ProjectWindow::PlaybackScroller::OnTimer(wxCommandEvent &event)

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1679,7 +1679,7 @@ void ProjectWindow::PlaybackScroller::OnTimer(wxCommandEvent &event)
 
    auto cleanup = finally([&]{
       // Propagate the message to other listeners bound to this
-      this->SafelyProcessEvent( event );
+      this->Publish({});
    });
 
    if(!ProjectAudioIO::Get( *mProject ).IsAudioActive())

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -58,8 +58,10 @@ public:
 
    void UpdateStatusWidths();
 
-   class PlaybackScroller final : public wxEvtHandler
-      , public Observer::Publisher<>
+   struct PlaybackScrollerMessage : Observer::Message {};
+
+   class PlaybackScroller final
+      : public Observer::Publisher<PlaybackScrollerMessage>
    {
    public:
       explicit PlaybackScroller(AudacityProject *project);

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -15,6 +15,7 @@ Paul Licameli split from AudacityProject.h
 #include "ProjectWindowBase.h" // to inherit
 #include "TrackPanelListener.h" // to inherit
 #include "Prefs.h"
+#include "Observer.h"
 
 class Track;
 
@@ -58,6 +59,7 @@ public:
    void UpdateStatusWidths();
 
    class PlaybackScroller final : public wxEvtHandler
+      , public Observer::Publisher<>
    {
    public:
       explicit PlaybackScroller(AudacityProject *project);

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -429,10 +429,7 @@ void TrackPanel::OnTimer(wxTimerEvent& )
    }
 
    // Notify listeners for timer ticks
-   {
-      wxCommandEvent e(EVT_TRACK_PANEL_TIMER);
-      p->ProcessEvent(e);
-   }
+   window.GetPlaybackScroller().Publish({});
 
    DrawOverlays(false);
    mRuler->DrawOverlays(false);

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -23,6 +23,7 @@
 #include "SelectedRegion.h"
 
 #include "CellularPanel.h"
+#include "Observer.h"
 
 #include "commands/CommandManagerWindowClasses.h"
 
@@ -84,9 +85,9 @@ class AUDACITY_DLL_API TrackPanel final
    void OnMouseEvent(wxMouseEvent & event);
    void OnKeyDown(wxKeyEvent & event);
 
-   void OnTrackListResizing(TrackListEvent & event);
-   void OnTrackListDeletion(wxEvent & event);
-   void OnEnsureVisible(TrackListEvent & event);
+   void OnTrackListResizing(const TrackListEvent &event);
+   void OnTrackListDeletion();
+   void OnEnsureVisible(const TrackListEvent & event);
    void UpdateViewIfNoTracks(); // Call this to update mViewInfo, etc, after track(s) removal, before Refresh().
 
    double GetMostRecentXPos();
@@ -181,6 +182,8 @@ public:
 public:
 
 protected:
+   Observer::Subscription mSubscription;
+
    TrackPanelListener *mListener;
 
    std::shared_ptr<TrackList> mTracks;

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -30,6 +30,8 @@
 
 class wxRect;
 
+struct AudioIOEvent;
+
 // All cells of the TrackPanel are subclasses of this
 class CommonTrackPanelCell;
 
@@ -79,7 +81,7 @@ class AUDACITY_DLL_API TrackPanel final
 
    void UpdatePrefs() override;
 
-   void OnAudioIO(wxCommandEvent & evt);
+   void OnAudioIO(AudioIOEvent);
 
    void OnPaint(wxPaintEvent & event);
    void OnMouseEvent(wxMouseEvent & event);
@@ -182,7 +184,8 @@ public:
 public:
 
 protected:
-   Observer::Subscription mSubscription;
+   Observer::Subscription mTrackListScubscription,
+      mAudioIOScubscription;
 
    TrackPanelListener *mListener;
 

--- a/src/TrackPanelResizeHandle.cpp
+++ b/src/TrackPanelResizeHandle.cpp
@@ -12,6 +12,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "TrackPanelResizeHandle.h"
 
 #include <wx/cursor.h>
+#include <wx/event.h>
 #include <wx/translation.h>
 
 #include "HitTestResult.h"

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -18,7 +18,11 @@
 
 #include <vector>
 #include <functional>
+#include <wx/thread.h>
 #include <wx/longlong.h>
+
+class wxRect;
+
 #include "WaveTrackLocation.h"
 
 namespace BasicUI{ class ProgressDialog; }

--- a/src/commands/CommandFunctors.h
+++ b/src/commands/CommandFunctors.h
@@ -12,7 +12,11 @@
 class AudacityProject;
 class AudacityApp;
 class CommandContext;
-class wxEvtHandler;
+
+// Forward-declaring this type before including wx/event.h causes strange
+// compilation failures with MSVC.
+// class wxEvtHandler;
+#include <wx/event.h>
 
 // Base class for objects, to whose member functions, the CommandManager will
 // dispatch.

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -29,6 +29,7 @@
 
 #include <unordered_map>
 
+class wxEvent;
 class wxMenu;
 class wxMenuBar;
 using CommandParameter = CommandID;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -989,7 +989,6 @@ bool Effect::DoEffect(double projectRate,
 
    mOutputTracks.reset();
 
-   mpSelectedRegion = &selectedRegion;
    mFactory = factory;
    mProjectRate = projectRate;
    mTracks = list;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -416,7 +416,6 @@ protected:
    double         mProjectRate; // Sample rate of the project - NEW tracks should
                                // be created with this rate...
    double         mSampleRate;
-   wxWeakRef<NotifyingSelectedRegion> mpSelectedRegion{};
    WaveTrackFactory   *mFactory;
    const TrackList *inputTracks() const { return mTracks; }
    const AudacityProject *FindProject() const;

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -41,8 +41,6 @@ class EffectRack;
 class AudacityCommand;
 
 
-class NotifyingSelectedRegion;
-
 class AUDACITY_DLL_API EffectManager
 {
 public:

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -665,7 +665,6 @@ private:
 #include "../widgets/AudacityMessageBox.h"
 #include "../widgets/HelpSystem.h"
 
-#include <wx/app.h>
 #include <wx/bmpbuttn.h>
 #include <wx/checkbox.h>
 #include <wx/dcclient.h>
@@ -1403,13 +1402,11 @@ void EffectUIHost::OnFFwd(wxCommandEvent & WXUNUSED(evt))
    }
 }
 
-void EffectUIHost::OnPlayback(wxCommandEvent & evt)
+void EffectUIHost::OnPlayback(AudioIOEvent evt)
 {
-   evt.Skip();
-   
-   if (evt.GetInt() != 0)
+   if (evt.on)
    {
-      if (evt.GetEventObject() != mProject)
+      if (evt.pProject != mProject)
       {
          mDisableTransport = true;
       }
@@ -1433,13 +1430,11 @@ void EffectUIHost::OnPlayback(wxCommandEvent & evt)
    UpdateControls();
 }
 
-void EffectUIHost::OnCapture(wxCommandEvent & evt)
+void EffectUIHost::OnCapture(AudioIOEvent evt)
 {
-   evt.Skip();
-   
-   if (evt.GetInt() != 0)
+   if (evt.on)
    {
-      if (evt.GetEventObject() != mProject)
+      if (evt.pProject != mProject)
       {
          mDisableTransport = true;
       }
@@ -1733,13 +1728,16 @@ void EffectUIHost::InitializeRealtime()
    {
       RealtimeEffectManager::Get().RealtimeAddEffect(mEffect);
       
-      wxTheApp->Bind(EVT_AUDIOIO_PLAYBACK,
-                     &EffectUIHost::OnPlayback,
-                     this);
-      
-      wxTheApp->Bind(EVT_AUDIOIO_CAPTURE,
-                     &EffectUIHost::OnCapture,
-                     this);
+      AudioIO::Get()->Subscribe([this](AudioIOEvent event){
+         switch (event.type) {
+         case AudioIOEvent::PLAYBACK:
+            OnPlayback(event); break;
+         case AudioIOEvent::CAPTURE:
+            OnCapture(event); break;
+         default:
+            break;
+         }
+      });
       
       mInitialized = true;
    }

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -18,7 +18,10 @@
 
 #include "Identifier.h"
 #include "EffectHostInterface.h"
+#include "Observer.h"
 #include "PluginInterface.h"
+
+struct AudioIOEvent;
 
 #if defined(EXPERIMENTAL_EFFECTS_RACK)
 
@@ -152,8 +155,8 @@ private:
    void OnPlay(wxCommandEvent & evt);
    void OnRewind(wxCommandEvent & evt);
    void OnFFwd(wxCommandEvent & evt);
-   void OnPlayback(wxCommandEvent & evt);
-   void OnCapture(wxCommandEvent & evt);
+   void OnPlayback(AudioIOEvent);
+   void OnCapture(AudioIOEvent);
    void OnUserPreset(wxCommandEvent & evt);
    void OnFactoryPreset(wxCommandEvent & evt);
    void OnDeletePreset(wxCommandEvent & evt);
@@ -172,6 +175,8 @@ private:
    void Resume();
 
 private:
+   Observer::Subscription mSubscription;
+
    AudacityProject *mProject;
    wxWindow *mParent;
    Effect &mEffect;

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -77,8 +77,8 @@ static int DeviceToolbarPrefsID()
 DeviceToolBar::DeviceToolBar( AudacityProject &project )
 : ToolBar( project, DeviceBarID, XO("Device"), wxT("Device"), true )
 {
-   DeviceManager::Instance()->Bind( EVT_RESCANNED_DEVICES,
-      &DeviceToolBar::OnRescannedDevices, this );
+   mSubscription = DeviceManager::Instance()->Subscribe(
+      *this, &DeviceToolBar::OnRescannedDevices );
 }
 
 DeviceToolBar::~DeviceToolBar()
@@ -555,11 +555,11 @@ void DeviceToolBar::FillInputChannels()
    mInputChannels->SetMinSize(wxSize(50, wxDefaultCoord));
 }
 
-void DeviceToolBar::OnRescannedDevices( wxEvent &event )
+void DeviceToolBar::OnRescannedDevices(DeviceChangeMessage m)
 {
-   event.Skip();
    // Hosts may have disappeared or appeared so a complete repopulate is needed.
-   RefillCombos();
+   if (m == DeviceChangeMessage::Rescan)
+      RefillCombos();
 }
 
 //return 1 if host changed, 0 otherwise.

--- a/src/toolbars/DeviceToolBar.h
+++ b/src/toolbars/DeviceToolBar.h
@@ -13,6 +13,9 @@
 
 #include <vector>
 #include "ToolBar.h"
+#include "Observer.h"
+
+enum class DeviceChangeMessage : char;
 
 class wxSize;
 class wxPoint;
@@ -56,7 +59,7 @@ class DeviceToolBar final : public ToolBar {
    void ShowChannelsDialog();
 
  private:
-   void OnRescannedDevices( wxEvent& );
+   void OnRescannedDevices(DeviceChangeMessage);
 
    int  ChangeHost();
    void ChangeDevice(bool isInput);
@@ -73,6 +76,8 @@ class DeviceToolBar final : public ToolBar {
    wxChoice *mOutput;
    wxChoice *mInputChannels;
    wxChoice *mHost;
+
+   Observer::Subscription mSubscription;
 
  public:
 

--- a/src/toolbars/MixerToolBar.cpp
+++ b/src/toolbars/MixerToolBar.cpp
@@ -23,7 +23,6 @@
 #include <wx/wxprec.h>
 
 #ifndef WX_PRECOMP
-#include <wx/app.h>
 #include <wx/choice.h>
 #include <wx/event.h>
 #include <wx/intl.h>
@@ -132,19 +131,15 @@ void MixerToolBar::Populate()
    Add(2, -1);
 
    // Listen for capture events
-   wxTheApp->Bind(EVT_AUDIOIO_CAPTURE,
-                  &MixerToolBar::OnAudioCapture,
-                  this);
+   mSubscription = AudioIO::Get()
+      ->Subscribe(*this, &MixerToolBar::OnAudioCapture);
 }
 
-void MixerToolBar::OnAudioCapture(wxCommandEvent & event)
+void MixerToolBar::OnAudioCapture(AudioIOEvent event)
 {
-   event.Skip();
-
-   AudacityProject *p = &mProject;
-   if ((AudacityProject *) event.GetEventObject() != p)
+   if (event.type == AudioIOEvent::CAPTURE && event.pProject != &mProject)
    {
-      mEnabled = !event.GetInt();
+      mEnabled = !event.on;
       mInputSlider->Enable(mEnabled);
       mOutputSlider->Enable(mEnabled);
    }

--- a/src/toolbars/MixerToolBar.h
+++ b/src/toolbars/MixerToolBar.h
@@ -11,6 +11,7 @@
 #ifndef __AUDACITY_MIXER_TOOLBAR__
 #define __AUDACITY_MIXER_TOOLBAR__
 
+#include "Observer.h"
 #include "ToolBar.h"
 
 class wxSize;
@@ -18,6 +19,7 @@ class wxPoint;
 
 class ASlider;
 class AudacityProject;
+struct AudioIOEvent;
 
 class MixerToolBar final : public ToolBar {
 
@@ -46,7 +48,7 @@ class MixerToolBar final : public ToolBar {
 
    void OnSlider(wxCommandEvent & event);
 
-   void OnAudioCapture(wxCommandEvent & event);
+   void OnAudioCapture(AudioIOEvent);
 
    void ShowOutputGainDialog();
    void ShowInputGainDialog();
@@ -64,6 +66,8 @@ class MixerToolBar final : public ToolBar {
 
    void InitializeMixerToolBar();
    void SetToolTips();
+
+   Observer::Subscription mSubscription;
 
    ASlider *mInputSlider;
    ASlider *mOutputSlider;

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -54,7 +54,8 @@ TimeToolBar::TimeToolBar(AudacityProject &project)
    mListener(NULL),
    mAudioTime(NULL)
 {
-   project.Bind(EVT_PROJECT_RATE_CHANGE, &TimeToolBar::OnRateChanged, this);
+   mSubscription =
+      ProjectRate::Get(project).Subscribe(*this, &TimeToolBar::OnRateChanged);
 }
 
 TimeToolBar::~TimeToolBar()
@@ -263,13 +264,10 @@ void TimeToolBar::SetResizingLimits()
 }
 
 // Called when the project rate changes
-void TimeToolBar::OnRateChanged(wxEvent &evt)
+void TimeToolBar::OnRateChanged(double rate)
 {
-   evt.Skip();
-
-   if (mAudioTime) {
-      mAudioTime->SetSampleRate(ProjectRate::Get(mProject).GetRate());
-   }
+   if (mAudioTime)
+      mAudioTime->SetSampleRate(rate);
 }
 
 // Called when the format drop downs is changed.

--- a/src/toolbars/TimeToolBar.h
+++ b/src/toolbars/TimeToolBar.h
@@ -15,6 +15,7 @@
 
 #include "ToolBar.h"
 #include "../widgets/NumericTextCtrl.h"
+#include "Observer.h"
 
 class NumericTextCtrl;
 class TimeToolBarListener;
@@ -46,7 +47,7 @@ private:
    void SetResizingLimits();
    wxSize ComputeSizing(int digitH);
 
-   void OnRateChanged(wxEvent &evt);
+   void OnRateChanged(double);
    void OnUpdate(wxCommandEvent &evt);
    void OnSize(wxSizeEvent &evt);
    void OnIdle(wxIdleEvent &evt);
@@ -58,6 +59,8 @@ private:
 
    static const int minDigitH = 17;
    static const int maxDigitH = 100;
+
+   Observer::Subscription mSubscription;
 
 public:
    

--- a/src/tracks/labeltrack/ui/LabelTextHandle.h
+++ b/src/tracks/labeltrack/ui/LabelTextHandle.h
@@ -16,7 +16,6 @@ Paul Licameli split from TrackPanel.cpp
 
 class wxMouseState;
 class LabelTrack;
-class NotifyingSelectedRegion;
 class SelectionStateChanger;
 class ZoomInfo;
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackButtonHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackButtonHandle.cpp
@@ -21,6 +21,8 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../../RefreshCode.h"
 #include "../../../../TrackInfo.h"
 
+#include <wx/event.h>
+
 NoteTrackButtonHandle::NoteTrackButtonHandle
 ( const std::shared_ptr<NoteTrack> &pTrack,
   int channel, const wxRect &rect )

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -139,9 +139,8 @@ WaveTrackAffordanceControls::WaveTrackAffordanceControls(const std::shared_ptr<T
 {
     if (auto trackList = pTrack->GetOwner())
     {
-        trackList->Bind(EVT_TRACKLIST_SELECTION_CHANGE,
-            &WaveTrackAffordanceControls::OnTrackChanged,
-            this);
+        mSubscription = trackList->Subscribe(
+            *this, &WaveTrackAffordanceControls::OnTrackChanged);
     }
 }
 
@@ -439,10 +438,10 @@ void WaveTrackAffordanceControls::ResetClipNameEdit()
     mEditedClip.reset();
 }
 
-void WaveTrackAffordanceControls::OnTrackChanged(TrackListEvent& evt)
+void WaveTrackAffordanceControls::OnTrackChanged(const TrackListEvent& evt)
 {
-    evt.Skip();
-    ExitTextEditing();
+    if (evt.mType == TrackListEvent::SELECTION_CHANGE)
+       ExitTextEditing();
 }
 
 unsigned WaveTrackAffordanceControls::ExitTextEditing()

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.h
@@ -11,8 +11,8 @@
 #pragma once
 
 #include <wx/font.h>
-#include <wx/event.h>
 
+#include "Observer.h"
 #include "../../../ui/CommonTrackPanelCell.h"
 #include "../../../ui/TextEditHelper.h"
 
@@ -33,7 +33,6 @@ class TrackList;
 class AUDACITY_DLL_API WaveTrackAffordanceControls : 
     public CommonTrackCell,
     public TextEditDelegate,
-    public wxEvtHandler,
     public std::enable_shared_from_this<WaveTrackAffordanceControls>
 {
     std::weak_ptr<WaveClip> mFocusClip;
@@ -95,9 +94,11 @@ public:
 private:
     void ResetClipNameEdit();
 
-    void OnTrackChanged(TrackListEvent& evt);
+    void OnTrackChanged(const TrackListEvent& evt);
 
     unsigned ExitTextEditing();
 
     std::shared_ptr<TextEditHelper> MakeTextEditHelper(const wxString& text);
+
+    Observer::Subscription mSubscription;
 };

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp
@@ -18,6 +18,8 @@
 #include "../../../../TrackPanelMouseEvent.h"
 #include "../../../../ProjectHistory.h"
 
+#include <wx/event.h>
+
 WaveTrackAffordanceHandle::WaveTrackAffordanceHandle(const std::shared_ptr<Track>& track, const std::shared_ptr<WaveClip>& target)
    : AffordanceHandle(track), mTarget(target)
 { }

--- a/src/tracks/ui/AffordanceHandle.cpp
+++ b/src/tracks/ui/AffordanceHandle.cpp
@@ -19,6 +19,8 @@
 #include "Track.h"
 #include "../../../images/Cursors.h"
 
+#include <wx/cursor.h>
+
 HitTestPreview AffordanceHandle::HitPreview(const AudacityProject*, bool unsafe, bool moving)
 {
     static auto disabledCursor =

--- a/src/tracks/ui/ButtonHandle.cpp
+++ b/src/tracks/ui/ButtonHandle.cpp
@@ -16,6 +16,8 @@ Paul Licameli
 #include "Track.h"
 #include "../../TrackPanelMouseEvent.h"
 
+#include <wx/event.h>
+
 ButtonHandle::ButtonHandle
 ( const std::shared_ptr<Track> &pTrack, const wxRect &rect )
    : mpTrack{ pTrack }

--- a/src/tracks/ui/EnvelopeHandle.cpp
+++ b/src/tracks/ui/EnvelopeHandle.cpp
@@ -27,6 +27,8 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../WaveTrack.h"
 #include "../../../images/Cursors.h"
 
+#include <wx/event.h>
+
 EnvelopeHandle::EnvelopeHandle( Envelope *pEnvelope )
    : mEnvelope{ pEnvelope }
 {

--- a/src/tracks/ui/PlayIndicatorOverlay.cpp
+++ b/src/tracks/ui/PlayIndicatorOverlay.cpp
@@ -145,17 +145,12 @@ static const AudacityProject::AttachedObjects::RegisteredFactory sOverlayKey{
 PlayIndicatorOverlay::PlayIndicatorOverlay(AudacityProject *project)
 : PlayIndicatorOverlayBase(project, true)
 {
-   ProjectWindow::Get( *mProject ).GetPlaybackScroller().Bind(
-      EVT_TRACK_PANEL_TIMER,
-      &PlayIndicatorOverlay::OnTimer,
-      this);
+   mSubscription = ProjectWindow::Get( *mProject )
+      .GetPlaybackScroller().Subscribe( *this, &PlayIndicatorOverlay::OnTimer );
 }
 
-void PlayIndicatorOverlay::OnTimer(wxCommandEvent &event)
+void PlayIndicatorOverlay::OnTimer(Observer::Message)
 {
-   // Let other listeners get the notification
-   event.Skip();
-
    // Ensure that there is an overlay attached to the ruler
    if (!mPartner) {
       auto &ruler = AdornedRulerPanel::Get( *mProject );

--- a/src/tracks/ui/PlayIndicatorOverlay.h
+++ b/src/tracks/ui/PlayIndicatorOverlay.h
@@ -11,18 +11,17 @@ Paul Licameli split from TrackPanel.cpp
 #ifndef __AUDACITY_PLAY_INDICATOR_OVERLAY__
 #define __AUDACITY_PLAY_INDICATOR_OVERLAY__
 
-#include <wx/event.h> // to inherit
 #include <memory>
 #include "ClientData.h"
 #include "../../widgets/Overlay.h" // to inherit
+#include "Observer.h"
 
 class AudacityProject;
 
 
 // Common class for overlaying track panel or ruler
 class PlayIndicatorOverlayBase
-   : public wxEvtHandler
-   , public Overlay
+   : public Overlay
    , public ClientData::Base
 {
 public:
@@ -54,9 +53,10 @@ public:
    PlayIndicatorOverlay(AudacityProject *project);
 
 private:
-   void OnTimer(wxCommandEvent &event);
+   void OnTimer(Observer::Message);
 
    std::shared_ptr<PlayIndicatorOverlayBase> mPartner;
+   Observer::Subscription mSubscription;
 };
 
 #endif

--- a/src/tracks/ui/ScrubUI.cpp
+++ b/src/tracks/ui/ScrubUI.cpp
@@ -20,7 +20,6 @@
 #include "../../TrackPanel.h"
 
 #include <wx/dcclient.h>
-#include <wx/event.h>
 #include <wx/windowptr.h>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -28,8 +27,7 @@
 
 // Specialist in drawing the scrub speed, and listening for certain events
 class ScrubbingOverlay final
-   : public wxEvtHandler
-   , public Overlay
+   : public Overlay
    , public ClientData::Base
 {
 public:
@@ -41,12 +39,13 @@ private:
    std::pair<wxRect, bool> DoGetRectangle(wxSize size) override;
    void Draw(OverlayPanel &panel, wxDC &dc) override;
 
-   void OnTimer(wxCommandEvent &event);
+   void OnTimer(Observer::Message);
 
    const Scrubber &GetScrubber() const;
    Scrubber &GetScrubber();
 
    AudacityProject *mProject;
+   Observer::Subscription mSubscription;
 
    wxRect mLastScrubRect, mNextScrubRect;
    wxString mLastScrubSpeedText, mNextScrubSpeedText;
@@ -59,9 +58,8 @@ ScrubbingOverlay::ScrubbingOverlay(AudacityProject *project)
    , mLastScrubSpeedText()
    , mNextScrubSpeedText()
 {
-   mProject->Bind(EVT_TRACK_PANEL_TIMER,
-      &ScrubbingOverlay::OnTimer,
-      this);
+   mSubscription = ProjectWindow::Get( *mProject ).GetPlaybackScroller()
+      .Subscribe(*this, &ScrubbingOverlay::OnTimer);
 }
 
 unsigned ScrubbingOverlay::SequenceNumber() const
@@ -108,11 +106,8 @@ void ScrubbingOverlay::Draw(OverlayPanel &, wxDC &dc)
    dc.DrawText(mLastScrubSpeedText, mLastScrubRect.GetX(), mLastScrubRect.GetY());
 }
 
-void ScrubbingOverlay::OnTimer(wxCommandEvent &event)
+void ScrubbingOverlay::OnTimer(Observer::Message)
 {
-   // Let other listeners get the notification
-   event.Skip();
-
    Scrubber &scrubber = GetScrubber();
    const auto isScrubbing = scrubber.IsScrubbing();
    auto &ruler = AdornedRulerPanel::Get( *mProject );

--- a/src/tracks/ui/SelectHandle.cpp
+++ b/src/tracks/ui/SelectHandle.cpp
@@ -37,8 +37,6 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../prefs/SpectrogramSettings.h"
 #include "../../../images/Cursors.h"
 
-#include <wx/event.h>
-
 // Only for definition of SonifyBeginModifyState:
 //#include "../../NoteTrack.h"
 
@@ -1055,7 +1053,7 @@ void SelectHandle::Connect(AudacityProject *pProject)
    mTimerHandler = std::make_shared<TimerHandler>( this, pProject );
 }
 
-class SelectHandle::TimerHandler : public wxEvtHandler
+class SelectHandle::TimerHandler
 {
 public:
    TimerHandler( SelectHandle *pParent, AudacityProject *pProject )
@@ -1063,23 +1061,21 @@ public:
       , mConnectedProject{ pProject }
    {
       if (mConnectedProject)
-         mConnectedProject->Bind(EVT_TRACK_PANEL_TIMER,
-            &SelectHandle::TimerHandler::OnTimer,
-            this);
+         mSubscription = ProjectWindow::Get( *mConnectedProject )
+            .GetPlaybackScroller().Subscribe( *this, &SelectHandle::TimerHandler::OnTimer);
    }
 
    // Receives timer event notifications, to implement auto-scroll
-   void OnTimer(wxCommandEvent &event);
+   void OnTimer(Observer::Message);
 
 private:
    SelectHandle *mParent;
    AudacityProject *mConnectedProject;
+   Observer::Subscription mSubscription;
 };
 
-void SelectHandle::TimerHandler::OnTimer(wxCommandEvent &event)
+void SelectHandle::TimerHandler::OnTimer(Observer::Message)
 {
-   event.Skip();
-
    // AS: If the user is dragging the mouse and there is a track that
    //  has captured the mouse, then scroll the screen, as necessary.
 

--- a/src/widgets/MeterPanel.cpp
+++ b/src/widgets/MeterPanel.cpp
@@ -43,7 +43,6 @@
 #include <algorithm>
 #include <wx/setup.h> // for wxUSE_* macros
 #include <wx/wxcrtvararg.h>
-#include <wx/app.h>
 #include <wx/defs.h>
 #include <wx/dialog.h>
 #include <wx/dcbuffer.h>
@@ -348,14 +347,10 @@ MeterPanel::MeterPanel(AudacityProject *project,
    mPeakPeakPen = wxPen(theTheme.Colour( clrMeterPeak),        1, wxPENSTYLE_SOLID);
    mDisabledPen = wxPen(theTheme.Colour( clrMeterDisabledPen), 1, wxPENSTYLE_SOLID);
 
-   if (mIsInput) {
-      wxTheApp->Bind(EVT_AUDIOIO_MONITOR,
-                        &MeterPanel::OnAudioIOStatus,
-                        this);
-      wxTheApp->Bind(EVT_AUDIOIO_CAPTURE,
-                        &MeterPanel::OnAudioIOStatus,
-                        this);
+   mSubscription = AudioIO::Get()
+      ->Subscribe(*this, &MeterPanel::OnAudioIOStatus);
 
+   if (mIsInput) {
       mPen       = wxPen(   theTheme.Colour( clrMeterInputPen         ), 1, wxPENSTYLE_SOLID);
       mBrush     = wxBrush( theTheme.Colour( clrMeterInputBrush       ), wxBRUSHSTYLE_SOLID);
       mRMSBrush  = wxBrush( theTheme.Colour( clrMeterInputRMSBrush    ), wxBRUSHSTYLE_SOLID);
@@ -364,11 +359,6 @@ MeterPanel::MeterPanel(AudacityProject *project,
 //      mDarkPen   = wxPen(   theTheme.Colour( clrMeterInputDarkPen     ), 1, wxSOLID);
    }
    else {
-      // Register for AudioIO events
-      wxTheApp->Bind(EVT_AUDIOIO_PLAYBACK,
-                        &MeterPanel::OnAudioIOStatus,
-                        this);
-
       mPen       = wxPen(   theTheme.Colour( clrMeterOutputPen        ), 1, wxPENSTYLE_SOLID);
       mBrush     = wxBrush( theTheme.Colour( clrMeterOutputBrush      ), wxBRUSHSTYLE_SOLID);
       mRMSBrush  = wxBrush( theTheme.Colour( clrMeterOutputRMSBrush   ), wxBRUSHSTYLE_SOLID);
@@ -1912,16 +1902,16 @@ void MeterPanel::StopMonitoring(){
    } 
 }
 
-void MeterPanel::OnAudioIOStatus(wxCommandEvent &evt)
+void MeterPanel::OnAudioIOStatus(AudioIOEvent evt)
 {
-   evt.Skip();
-   AudacityProject *p = (AudacityProject *) evt.GetEventObject();
+   if (!mIsInput != (evt.type == AudioIOEvent::PLAYBACK))
+      return;
 
-   mActive = (evt.GetInt() != 0) && (p == mProject);
-
+   AudacityProject *p = evt.pProject;
+   mActive = evt.on && (p == mProject);
    if( mActive ){
       mTimer.Start(1000 / mMeterRefreshRate);
-      if (evt.GetEventType() == EVT_AUDIOIO_MONITOR)
+      if (evt.type == AudioIOEvent::MONITOR)
          mMonitoring = mActive;
    } else {
       mTimer.Stop();

--- a/src/widgets/MeterPanel.h
+++ b/src/widgets/MeterPanel.h
@@ -24,9 +24,11 @@
 #include "SampleFormat.h"
 #include "Prefs.h"
 #include "MeterPanelBase.h" // to inherit
+#include "Observer.h"
 #include "Ruler.h" // member variable
 
 class AudacityProject;
+struct AudioIOEvent;
 
 // Increase this when we add support for multichannel meters
 // (most of the code is already there)
@@ -205,7 +207,7 @@ class AUDACITY_DLL_API MeterPanel final
    void OnSetFocus(wxFocusEvent &evt);
    void OnKillFocus(wxFocusEvent &evt);
 
-   void OnAudioIOStatus(wxCommandEvent &evt);
+   void OnAudioIOStatus(AudioIOEvent);
 
    void OnMeterUpdate(wxTimerEvent &evt);
 
@@ -225,6 +227,8 @@ class AUDACITY_DLL_API MeterPanel final
    void OnPreferences(wxCommandEvent &evt);
 
    wxString Key(const wxString & key) const;
+
+   Observer::Subscription mSubscription;
 
    AudacityProject *mProject;
    MeterUpdateQueue mQueue;


### PR DESCRIPTION
Add an implementation of Observer pattern to lib-utility; eliminate all custom wxEvent classes now in libraries in favor of this simpler alternative.

The older pattern was to use wxEvtHandler as the publisher, `Bind()` to subscribe, usually wxEvtHandler as the subscriber too (or else `Unbind()` needed an explicit call), and wxEvent subclasses for messages.  (Event handling is not necessarily done by the event loop, but can be invoked directly on the object publishing the event.)

"Platform neutrality" doesn't strictly require this, becuase wxEvtHandler is in wxBase, but the examples show that it really is more convenient.  Any structure or even any scalar type can be the message sent by a publisher, without the bother of overriding wxEvent::Clone() in a new class, or making the subscriber inherit wxEvtHandler too for automatic cleanup.  (Instead, the class Observer::Subscription acts as a smart pointer for the connection to a publisher; the handle can also expire before it is destroyed, like a std::weak_ptr, in case the Publisher is destroyed first.)

However the class wxCommandEvent is in wxCore not wxBase, so cannot be used as a base class of custom events in libraries.  Therefore some rewriting must be done so that lib-audioio and others can be extracted.  Do this preliminary now, so that those rewrites can also use the nicer interface.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
