### PR TITLE
In VST, AudioUnits, LV2: don't compute mMasterOut...

### DIFF
--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -363,8 +363,6 @@ private:
    VSTEffect *mMaster;     // non-NULL if a slave
    VSTEffectArray mSlaves;
    unsigned mNumChannels;
-   FloatBuffers mMasterIn, mMasterOut;
-   size_t mNumSamples;
 
    // UI
    wxWeakRef<wxDialog> mDialog;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1340,8 +1340,6 @@ size_t AudioUnitEffect::ProcessBlock(float **inBlock, float **outBlock, size_t b
 
 bool AudioUnitEffect::RealtimeInitialize()
 {
-   mMasterIn.reinit(mAudioIns, mBlockSize, true);
-   mMasterOut.reinit(mAudioOuts, mBlockSize);
    return ProcessInitialize(0);
 }
 
@@ -1375,10 +1373,6 @@ bool AudioUnitEffect::RealtimeFinalize()
       mSlaves[i]->ProcessFinalize();
    }
    mSlaves.clear();
-
-   mMasterIn.reset();
-   mMasterOut.reset();
-
    return ProcessFinalize();
 }
 
@@ -1420,13 +1414,6 @@ bool AudioUnitEffect::RealtimeResume()
 
 bool AudioUnitEffect::RealtimeProcessStart()
 {
-   for (size_t i = 0; i < mAudioIns; i++)
-   {
-      memset(mMasterIn[i].get(), 0, mBlockSize * sizeof(float));
-   }
-
-   mNumSamples = 0;
-
    return true;
 }
 
@@ -1436,25 +1423,11 @@ size_t AudioUnitEffect::RealtimeProcess(int group,
                                         size_t numSamples)
 {
    wxASSERT(numSamples <= mBlockSize);
-
-   for (size_t c = 0; c < mAudioIns; c++)
-   {
-      for (decltype(numSamples) s = 0; s < numSamples; s++)
-      {
-         mMasterIn[c][s] += inbuf[c][s];
-      }
-   }
-   mNumSamples = wxMax(numSamples, mNumSamples);
-
    return mSlaves[group]->ProcessBlock(inbuf, outbuf, numSamples);
 }
 
 bool AudioUnitEffect::RealtimeProcessEnd()
 {
-   ProcessBlock(reinterpret_cast<float**>(mMasterIn.get()),
-                reinterpret_cast<float**>(mMasterOut.get()),
-                mNumSamples);
-
    return true;
 }
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -207,8 +207,6 @@ private:
    AudioUnitEffect *mMaster;     // non-NULL if a slave
    AudioUnitEffectArray mSlaves;
    unsigned mNumChannels;
-   ArraysOf<float> mMasterIn, mMasterOut;
-   size_t mNumSamples;
 
    AUEventListenerRef mEventListenerRef;
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1182,8 +1182,6 @@ size_t LV2Effect::ProcessBlock(float **inbuf, float **outbuf, size_t size)
 bool LV2Effect::RealtimeInitialize()
 {
    mMasterIn.reinit(mAudioIn, (unsigned int) mBlockSize);
-   mMasterOut.reinit(mAudioOut, (unsigned int) mBlockSize);
-
    for (auto & port : mCVPorts)
    {
       port->mBuffer.reinit((unsigned) mBlockSize, port->mIsInput);
@@ -1215,8 +1213,6 @@ bool LV2Effect::RealtimeFinalize()
    }
 
    mMasterIn.reset();
-   mMasterOut.reset();
-
    return true;
 }
 
@@ -1418,20 +1414,6 @@ bool LV2Effect::RealtimeProcessEnd()
    if (mNumSamples == 0)
    {
       return true;
-   }
-
-   int i = 0;
-   int o = 0;
-   for (auto & port : mAudioPorts)
-   {
-      lilv_instance_connect_port(mMaster->GetInstance(),
-                                 port->mIndex,
-                                 (port->mIsInput ? mMasterIn[i++].get() : mMasterOut[o++].get()));
-   }
-
-   if (mRolling)
-   {
-      lilv_instance_run(mMaster->GetInstance(), mNumSamples);
    }
 
    for (auto & port : mAtomPorts)

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -490,7 +490,7 @@ private:
    LV2Wrapper *mProcess;
    std::vector<LV2Wrapper *> mSlaves;
 
-   FloatBuffers mMasterIn, mMasterOut;
+   FloatBuffers mMasterIn;
    size_t mNumSamples;
    size_t mFramePos;
 


### PR DESCRIPTION
... This was the effect re-applied to the summation of the input tracks, but
the results were never used, and might not be useful for non-linear effects.

Resolves: overcomplicated implementations of realtime effects

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
