### PR TITLE
Fix Audacity version number in generated Doxygen start page

### DIFF
--- a/audacity.dox.in
+++ b/audacity.dox.in
@@ -38,7 +38,7 @@ PROJECT_NAME           = Audacity
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.3
+PROJECT_NUMBER         = 3.2.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
Resolves: outdated version number on start page (but all the detailed contents were current)

@crsib Please add this small step to the checklist for release procedure

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
