### PR TITLE
Simplify the macro definitions in AttachedVirtualFunction...

### DIFF
--- a/libraries/lib-project/Project.cpp
+++ b/libraries/lib-project/Project.cpp
@@ -109,6 +109,3 @@ void AudacityProject::SetInitialImportPath(const FilePath &path)
       mInitialImportPath = path;
    }
 }
-
-// Generate the needed, linkable registry functions
-DEFINE_XML_METHOD_REGISTRY( ProjectFileIORegistry );

--- a/libraries/lib-project/Project.h
+++ b/libraries/lib-project/Project.h
@@ -130,6 +130,5 @@ private:
 #include "XMLMethodRegistry.h"
 class AudacityProject;
 using ProjectFileIORegistry = XMLMethodRegistry<AudacityProject>;
-DECLARE_XML_METHOD_REGISTRY( PROJECT_API, ProjectFileIORegistry );
 
 #endif

--- a/libraries/lib-xml/XMLMethodRegistry.h
+++ b/libraries/lib-xml/XMLMethodRegistry.h
@@ -209,21 +209,16 @@ void CallWriters( const Host &host, XMLWriter &writer )
 }
 
 //! Get the unique instance
-static XMLMethodRegistry &Get();
+static
+#ifdef _WIN32
+   __declspec(dllexport)
+#endif
+XMLMethodRegistry &Get()
+{
+   static XMLMethodRegistry registry;
+   return registry;
+}
 
 };
-
-/*! Typically follows the `using` declaration of an XMLMethodRegistry
-   specialization; DECLSPEC is for linkage visibility */
-#define DECLARE_XML_METHOD_REGISTRY(DECLSPEC, Name) \
-   template<> auto DECLSPEC Name::Get() -> Name &;
-
-/*! Typically in the companion .cpp file */
-#define DEFINE_XML_METHOD_REGISTRY(Name)  \
-   template<> auto Name::Get() -> Name &  \
-   {                                      \
-      static Name registry;               \
-      return registry;                    \
-   }
 
 #endif


### PR DESCRIPTION
... see commit 48217d5a which introduced them.  Partly they simplify some
difficult syntax, but partly they worked around linkage problems on Windows.

Now I know a better way to avoid the problems:  see this reference
https://docs.microsoft.com/en-us/cpp/cpp/defining-inline-cpp-functions-with-dllexport-and-dllimport?view=msvc-170

It is not contradictory for a function to be dllexport and also inline.

So use dllexport unconditionally for the inline base class constructor and for
GetRegistry(), no matter whether compiling the target declaring the base, or
another target attaching an override.

The article implies that the linker will still coalesce the duplicated
definitions of static local variables in the function bodies, which is important
for correctness.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
