### PR TITLE
issue #2078: tabbing does not ensure selected label is visible

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -1768,6 +1768,7 @@ bool LabelTrackView::DoKeyDown(
                mInitialCursorPos = mCurrentCursorPos;
                //Set the selection region to be equal to the selection bounds of the tabbed-to label.
                newSel = labelStruct.selectedRegion;
+               ProjectWindow::Get(project).ScrollIntoView(labelStruct.selectedRegion.t0());
                // message for screen reader
                /* i18n-hint:
                   String is replaced by the name of a label,


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2078

Problem:
Tabbing used to open the name of the selected label for editing. When this was the case, LabelTrackView::KeyDown() ensured that cursor was visible.
However, this was changed so the the label is selected, and not automatically opened for editing.

Fix:
Add a call to scroll so that the start of the selected label is visible whenever tab or shift + tab is pressed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
