### PR TITLE
Adds support for the modern Xcode build system

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,7 +117,7 @@ To enable ASIO support, please select `audacity_has_asio_support=On` in CMake af
 2. Configure Audacity using CMake:
    ```
    $ mkdir build && cd build
-   $ cmake -GXcode -T buildsystem=1 ../audacity
+   $ cmake -GXcode ../audacity
    ```
 
 3. Open Audacity XCode project:
@@ -133,8 +133,17 @@ Alternatively, you can use **CLion**. If you chose to do so, open the directory 
 At the moment we only support **x86_64** builds. It is possible to build using AppleSilicon (AKA M1/arm64) hardware but **mad** and **id3tag** should be disabled:
 
 ```
-cmake -GXcode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=off ../audacity
+cmake -GXcode -Daudacity_use_mad="off" -Daudacity_use_id3tag=off ../audacity
 ```
+
+Before Audacity 3.2 only the XCode "legacy" build system was supported. In order to build older version please use:
+
+```
+   $ mkdir build && cd build
+   $ cmake -GXcode -T buildsystem=1 ../audacity
+```
+
+to configure Audacity. 
 
 ## Linux & Other OS
 

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -32,7 +32,6 @@ elif [[ "${AUDACITY_CMAKE_GENERATOR}" == Xcode* ]]; then
     cmake_args+=(
         # skip unneeded configurations
         -D CMAKE_CONFIGURATION_TYPES="${AUDACITY_BUILD_TYPE}"
-        -T buildsystem=1
     )
 fi
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1239,15 +1239,28 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
    )
 
    # Define the Wrapper target
+   if( CMAKE_CONFIGURATION_TYPES )
+      set( WRAPPER_EXEDIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../Wrapper/${CMAKE_CFG_INTDIR}" )
+   else()
+      set( WRAPPER_EXEDIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../Wrapper/${CMAKE_BUILD_TYPE}" )
+   endif()
+
    set( WRAPPER_ROOT "${TARGET_ROOT}/../mac" )
    set( WRAPPER_SOURCES "${WRAPPER_ROOT}/Wrapper.c" )
 
    add_executable( Wrapper "${WRAPPER_SOURCES}" )
-   add_dependencies( "${TARGET}" Wrapper )
+   add_dependencies( ${TARGET} Wrapper )
 
-   set_target_property_all( "Wrapper" RUNTIME_OUTPUT_DIRECTORY "${_EXEDIR}" )
+   set_target_property_all( Wrapper RUNTIME_OUTPUT_DIRECTORY "${WRAPPER_EXEDIR}" )
    organize_source( "${WRAPPER_ROOT}" "mac" "${WRAPPER_SOURCES}" )
 
+   add_custom_command(
+      TARGET
+         ${TARGET}
+      COMMAND
+         ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Wrapper> "${_EXEDIR}/Wrapper"
+      POST_BUILD
+   )
 else()
    set_target_property_all( ${TARGET} RUNTIME_OUTPUT_DIRECTORY "${_DEST}" )
 


### PR DESCRIPTION
Resolves: #1488 

This PR fixes a conflict with _EXEDIR being created by multiple targets. This worked well with the legacy build system, but the new fails to resolve the dependency graph correctly 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
