### PR TITLE
Extract lib audio io part 1

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2483,7 +2483,7 @@ void AudioIoCallback::AddToOutputChannel( unsigned int chan,
 // Limit values to -1.0..+1.0
 void ClampBuffer(float * pBuffer, unsigned long len){
    for(unsigned i = 0; i < len; i++)
-      pBuffer[i] = wxClip( pBuffer[i], -1.0f, 1.0f);
+      pBuffer[i] = std::clamp(pBuffer[i], -1.0f, 1.0f);
 };
 
 
@@ -2809,7 +2809,7 @@ void AudioIoCallback::DrainInputBuffers(
             short *tempShorts = (short *)tempFloats;
             for( unsigned i = 0; i < len; i++) {
                float tmp = inputShorts[numCaptureChannels*i+t];
-               tmp = wxClip( -32768, tmp, 32767 );
+               tmp = std::clamp(tmp, -32768.0f, 32767.0f);
                tempShorts[i] = (short)(tmp);
             }
          } break;

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -98,11 +98,9 @@ time warp info and AudioIOListener and whether the playback is looped.
 #include "portmixer.h"
 #endif
 
-#include <wx/app.h>
 #include <wx/frame.h>
 #include <wx/wxcrtvararg.h>
 #include <wx/log.h>
-#include <wx/textctrl.h>
 #include <wx/timer.h>
 #include <wx/intl.h>
 #include <wx/debug.h>
@@ -1123,7 +1121,7 @@ void AudioIO::CallAfterRecording(PostRecordingAction action)
    // Don't delay it except until idle time.
    // (Recording might start between now and then, but won't go far before
    // the action is done.  So the system isn't bulletproof yet.)
-   wxTheApp->CallAfter(std::move(action));
+   BasicUI::CallAfter(move(action));
 }
 
 bool AudioIO::AllocateBuffers(
@@ -1573,7 +1571,7 @@ void AudioIO::StopStream()
    if (pListener && mNumCaptureChannels > 0)
       pListener->OnAudioIOStopRecording();
 
-   wxTheApp->CallAfter([this]{
+   BasicUI::CallAfter([this]{
       if (mPortStreamV19 && mNumCaptureChannels > 0)
          // Recording was restarted between StopStream and idle time
          // So the actions can keep waiting

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -124,7 +124,6 @@ time warp info and AudioIOListener and whether the playback is looped.
 #include "effects/RealtimeEffectManager.h"
 #include "QualitySettings.h"
 #include "SampleTrack.h"
-#include "widgets/AudacityMessageBox.h"
 #include "BasicUI.h"
 
 #include "Gain.h"
@@ -344,10 +343,13 @@ AudioIO::AudioIO()
          errStr += XO("Error: %s").Format( paErrStr );
       // XXX: we are in libaudacity, popping up dialogs not allowed!  A
       // long-term solution will probably involve exceptions
-      AudacityMessageBox(
+      using namespace BasicUI;
+      ShowMessageBox(
          errStr,
-         XO("Error Initializing Audio"),
-         wxICON_ERROR|wxOK);
+         MessageBoxOptions{}
+            .Caption(XO("Error Initializing Audio"))
+            .IconStyle(Icon::Error)
+            .ButtonStyle(Button::Ok));
 
       // Since PortAudio is not initialized, all calls to PortAudio
       // functions will fail.  This will give reasonable behavior, since
@@ -1064,7 +1066,7 @@ int AudioIO::StartStream(const TransportTracks &tracks,
             pListener->OnAudioIOStopRecording();
          StartStreamCleanup();
          // PRL: PortAudio error messages are sadly not internationalized
-         AudacityMessageBox(
+         BasicUI::ShowMessageBox(
             Verbatim( LAT1CTOWX(Pa_GetErrorText(err)) ) );
          return 0;
       }
@@ -1269,7 +1271,7 @@ bool AudioIO::AllocateBuffers(
             // 100 samples, just give up.
             if(captureBufferSize < 100)
             {
-               AudacityMessageBox( XO("Out of memory!") );
+               BasicUI::ShowMessageBox( XO("Out of memory!") );
                return false;
             }
 
@@ -1304,7 +1306,7 @@ bool AudioIO::AllocateBuffers(
             (size_t)lrint(mRate * mPlaybackRingBufferSecs.count());
          if(playbackBufferSize < 100 || mPlaybackSamplesToCopy < 100)
          {
-            AudacityMessageBox( XO("Out of memory!") );
+            BasicUI::ShowMessageBox( XO("Out of memory!") );
             return false;
          }
       }

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -45,9 +45,13 @@ using PlayableTrackConstArray =
    std::vector < std::shared_ptr < const PlayableTrack > >;
 
 class Track;
-class WaveTrack;
-using WaveTrackArray = std::vector < std::shared_ptr < WaveTrack > >;
-using WaveTrackConstArray = std::vector < std::shared_ptr < const WaveTrack > >;
+class SampleTrack;
+using SampleTrackArray = std::vector < std::shared_ptr < SampleTrack > >;
+using SampleTrackConstArray = std::vector < std::shared_ptr < const SampleTrack > >;
+
+class WritableSampleTrack;
+using WritableSampleTrackArray =
+   std::vector < std::shared_ptr < WritableSampleTrack > >;
 
 struct PaStreamCallbackTimeInfo;
 typedef unsigned long PaStreamCallbackFlags;
@@ -74,12 +78,12 @@ struct AudioIOEvent {
 };
 
 struct TransportTracks {
-   WaveTrackArray playbackTracks;
-   WaveTrackArray captureTracks;
+   WritableSampleTrackArray playbackTracks;
+   WritableSampleTrackArray captureTracks;
    PlayableTrackConstArray otherPlayableTracks;
 
    // This is a subset of playbackTracks
-   WaveTrackConstArray prerollTracks;
+   SampleTrackConstArray prerollTracks;
 };
 
 /** brief The function which is called from PortAudio's callback thread
@@ -187,8 +191,8 @@ public:
    int mCallbackReturn;
    // Helpers to determine if tracks have already been faded out.
    unsigned  CountSoloingTracks();
-   bool TrackShouldBeSilent( const WaveTrack &wt );
-   bool TrackHasBeenFadedOut( const WaveTrack &wt );
+   bool TrackShouldBeSilent( const SampleTrack &wt );
+   bool TrackHasBeenFadedOut( const SampleTrack &wt );
    bool AllTracksAlreadySilent();
 
    void CheckSoundActivatedRecordingLevel(
@@ -201,7 +205,7 @@ public:
       const float * tempBuf,
       bool drop,
       unsigned long len,
-      WaveTrack *vt
+      WritableSampleTrack *vt
       );
    bool FillOutputBuffers(
       float *outputBuffer,
@@ -263,10 +267,11 @@ public:
 
    ArrayOf<std::unique_ptr<Resample>> mResample;
    ArrayOf<std::unique_ptr<RingBuffer>> mCaptureBuffers;
-   WaveTrackArray      mCaptureTracks;
+   WritableSampleTrackArray      mCaptureTracks;
    /*! Read by worker threads but unchanging during playback */
    ArrayOf<std::unique_ptr<RingBuffer>> mPlaybackBuffers;
-   WaveTrackArray      mPlaybackTracks;
+   WritableSampleTrackArray      mPlaybackTracks;
+
    // Temporary buffers, each as large as the playback buffers
    std::vector<SampleBuffer> mScratchBuffers;
    std::vector<float *> mScratchPointers; //!< pointing into mScratchBuffers

--- a/src/AudioIOListener.h
+++ b/src/AudioIOListener.h
@@ -15,9 +15,9 @@
 
 
 
-class WaveTrack;
-using WaveTrackArray =
-   std::vector < std::shared_ptr < WaveTrack > >;
+class WritableSampleTrack;
+using WritableSampleTrackArray =
+   std::vector < std::shared_ptr < WritableSampleTrack > >;
 
 class AUDACITY_DLL_API AudioIOListener /* not final */ {
 public:
@@ -29,7 +29,7 @@ public:
 
    virtual void OnAudioIOStartRecording() = 0;
    virtual void OnAudioIOStopRecording() = 0;
-   virtual void OnAudioIONewBlocks(const WaveTrackArray *tracks) = 0;
+   virtual void OnAudioIONewBlocks(const WritableSampleTrackArray *tracks) = 0;
 
    // Commit the addition of temporary recording tracks into the project
    virtual void OnCommitRecording() = 0;

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -170,11 +170,11 @@ void NewDefaultPlaybackPolicy::Initialize(
    mMessageChannel.Write( { mLastPlaySpeed,
       schedule.mT0, mLoopEndTime, mLoopEnabled } );
 
-   mSubscription = ViewInfo::Get( mProject ).playRegion.Subscribe(
-      *this, &NewDefaultPlaybackPolicy::OnPlayRegionChange);
+   auto callback = [this](auto&){ WriteMessage(); };
+   mRegionSubscription =
+       ViewInfo::Get(mProject).playRegion.Subscribe(callback);
    if (mVariableSpeed)
-      mProject.Bind( EVT_PLAY_SPEED_CHANGE,
-         &NewDefaultPlaybackPolicy::OnPlaySpeedChange, this);
+      mSpeedSubscription = ProjectAudioIO::Get(mProject).Subscribe(callback);
 }
 
 Mixer::WarpOptions NewDefaultPlaybackPolicy::MixerWarpOptions(
@@ -384,18 +384,6 @@ bool NewDefaultPlaybackPolicy::RepositionPlayback(
 bool NewDefaultPlaybackPolicy::Looping( const PlaybackSchedule & ) const
 {
    return mLoopEnabled;
-}
-
-void NewDefaultPlaybackPolicy::OnPlayRegionChange(Observer::Message)
-{
-   // This executes in the main thread
-   WriteMessage();
-}
-
-void NewDefaultPlaybackPolicy::OnPlaySpeedChange(wxCommandEvent &evt)
-{
-   evt.Skip(); // Let other listeners hear the event too
-   WriteMessage();
 }
 
 void NewDefaultPlaybackPolicy::WriteMessage()

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -363,8 +363,6 @@ public:
 
 private:
    bool RevertToOldDefault( const PlaybackSchedule &schedule ) const;
-   void OnPlayRegionChange(Observer::Message);
-   void OnPlaySpeedChange(wxCommandEvent &evt);
    void WriteMessage();
    double GetPlaySpeed();
 
@@ -380,7 +378,8 @@ private:
    };
    MessageBuffer<SlotData> mMessageChannel;
 
-   Observer::Subscription mSubscription;
+   Observer::Subscription mRegionSubscription,
+      mSpeedSubscription;
 
    double mLastPlaySpeed{ 1.0 };
    const double mTrackEndTime;

--- a/src/ProjectAudioIO.cpp
+++ b/src/ProjectAudioIO.cpp
@@ -13,8 +13,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "AudioIOBase.h"
 #include "Project.h"
 
-wxDEFINE_EVENT( EVT_PLAY_SPEED_CHANGE, wxCommandEvent);
-
 static const AudacityProject::AttachedObjects::RegisteredFactory sAudioIOKey{
   []( AudacityProject &parent ){
      return std::make_shared< ProjectAudioIO >( parent );
@@ -96,7 +94,6 @@ void ProjectAudioIO::SetPlaySpeed(double value)
 {
    if (auto oldValue = GetPlaySpeed(); value != oldValue) {
       mPlaySpeed.store( value, std::memory_order_relaxed );
-      wxCommandEvent evt{ EVT_PLAY_SPEED_CHANGE };
-      mProject.ProcessEvent(evt);
+      Publish({});
    }
 }

--- a/src/ProjectAudioIO.h
+++ b/src/ProjectAudioIO.h
@@ -12,6 +12,7 @@ Paul Licameli split from AudacityProject.h
 #define __PROJECT_AUDIO_IO__
 
 #include "ClientData.h" // to inherit
+#include "Observer.h" // to inherit
 #include <wx/weakref.h>
 #include <wx/event.h> // to declare custom event type
 
@@ -20,14 +21,13 @@ Paul Licameli split from AudacityProject.h
 class AudacityProject;
 class Meter;
 
-// Sent to the project when the play speed changes
-wxDECLARE_EXPORTED_EVENT(AUDACITY_DLL_API,
-   EVT_PLAY_SPEED_CHANGE, wxCommandEvent);
+struct SpeedChangeMessage {};
 
 ///\ brief Holds per-project state needed for interaction with AudioIO,
 /// including the audio stream token and pointers to meters
 class AUDACITY_DLL_API ProjectAudioIO final
    : public ClientData::Base
+   , public Observer::Publisher<SpeedChangeMessage>
 {
 public:
    static ProjectAudioIO &Get( AudacityProject &project );

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -573,7 +573,7 @@ void ProjectAudioManager::Pause()
    }
 }
 
-WaveTrackArray ProjectAudioManager::ChooseExistingRecordingTracks(
+WritableSampleTrackArray ProjectAudioManager::ChooseExistingRecordingTracks(
    AudacityProject &proj, bool selectedOnly, double targetRate)
 {
    auto p = &proj;
@@ -602,7 +602,7 @@ WaveTrackArray ProjectAudioManager::ChooseExistingRecordingTracks(
 
    auto &trackList = TrackList::Get( *p );
    std::vector<unsigned> channelCounts;
-   WaveTrackArray candidates;
+   WritableSampleTrackArray candidates;
    const auto range = trackList.Leaders<WaveTrack>();
    for ( auto candidate : selectedOnly ? range + &Track::IsSelected : range ) {
       if (targetRate != RATE_NOT_SELECTED && candidate->GetRate() != targetRate)
@@ -667,7 +667,7 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
          t1 = DBL_MAX;
 
       auto options = DefaultPlayOptions(*p);
-      WaveTrackArray existingTracks;
+      WritableSampleTrackArray existingTracks;
 
       // Checking the selected tracks: counting them and
       // making sure they all have the same rate
@@ -1074,7 +1074,8 @@ void ProjectAudioManager::OnAudioIOStopRecording()
    }
 }
 
-void ProjectAudioManager::OnAudioIONewBlocks(const WaveTrackArray *tracks)
+void ProjectAudioManager::OnAudioIONewBlocks(
+   const WritableSampleTrackArray *tracks)
 {
    auto &project = mProject;
    auto &projectFileIO = ProjectFileIO::Get( project );

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -24,9 +24,9 @@ class AudacityProject;
 struct AudioIOStartStreamOptions;
 class TrackList;
 class SelectedRegion;
-
-class WaveTrack;
-using WaveTrackArray = std::vector < std::shared_ptr < WaveTrack > >;
+class WritableSampleTrack;
+using WritableSampleTrackArray =
+   std::vector< std::shared_ptr< WritableSampleTrack > >;
 
 enum class PlayMode : int {
    normalPlay,
@@ -75,7 +75,7 @@ public:
    static const ProjectAudioManager &Get( const AudacityProject &project );
 
    // Find suitable tracks to record into, or return an empty array.
-   static WaveTrackArray ChooseExistingRecordingTracks(
+   static WritableSampleTrackArray ChooseExistingRecordingTracks(
       AudacityProject &proj, bool selectedOnly,
       double targetRate = RATE_NOT_SELECTED);
 
@@ -162,7 +162,7 @@ private:
    void OnAudioIORate(int rate) override;
    void OnAudioIOStartRecording() override;
    void OnAudioIOStopRecording() override;
-   void OnAudioIONewBlocks(const WaveTrackArray *tracks) override;
+   void OnAudioIONewBlocks(const WritableSampleTrackArray *tracks) override;
    void OnCommitRecording() override;
    void OnSoundActivationThreshold() override;
 

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -2315,20 +2315,6 @@ void WaveTrack::GetEnvelopeValues(double *buffer, size_t bufferLen,
    }
 }
 
-WaveClip* WaveTrack::GetClipAtSample(sampleCount sample)
-{
-   for (const auto &clip: mClips)
-   {
-      auto start = clip->GetPlayStartSample();
-      auto len   = clip->GetPlaySamplesCount();
-
-      if (sample >= start && sample < start + len)
-         return clip.get();
-   }
-
-   return NULL;
-}
-
 // When the time is both the end of a clip and the start of the next clip, the
 // latter clip is returned.
 WaveClip* WaveTrack::GetClipAtTime(double time)

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -282,7 +282,6 @@ private:
    Sequence* GetSequenceAtTime(double time);
    Envelope* GetEnvelopeAtTime(double time);
 
-   WaveClip* GetClipAtSample(sampleCount sample);
    WaveClip* GetClipAtTime(double time);
 
    //


### PR DESCRIPTION
Resolves most of #1136

Break dependencies of AudioIO on WaveTrack.  It and WaveTrack will depend on SampleTrack but not on each other.

Break most of the dependencies of AudioIO on wxCore.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
