### PR TITLE
Restrictions on the view of wxWidgets through the wxBase target...

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -732,3 +732,29 @@ function( addlib dir name symbol required check )
    endif()
 endfunction()
 
+# Copy named properties from one target to another
+function(copy_target_properties
+  src  # target
+  dest # target
+  # prop1 prop2...
+)
+   foreach(property ${ARGN})
+      get_target_property(value ${src} ${property})
+      if(value)
+         set_target_properties(${dest} PROPERTIES ${property} "${value}")
+      endif()
+   endforeach()
+endfunction()
+
+function(make_interface_library
+   new  # name for new target
+   old   # existing library target
+)
+   add_library(${new} INTERFACE)
+   copy_target_properties(${old} ${new}
+      INTERFACE_COMPILE_DEFINITIONS
+      INTERFACE_COMPILE_OPTIONS
+      INTERFACE_INCLUDE_DIRECTORIES
+      INTERFACE_LINK_DIRECTORIES
+      INTERFACE_LINK_LIBRARIES)
+endfunction()

--- a/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
+++ b/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
@@ -1,3 +1,35 @@
+# Make the wxBase interface target which exposes a limited view of wxWidgets --
+# only the subset of wxBase consistent with "toolkit neutrality"
+function(make_wxBase old)
+   make_interface_library(wxBase ${old})
+
+   # wxBase exposes only the GUI-less subset of full wxWidgets
+   # Also prohibit use of some other headers by pre-defining their include guards
+   # wxUSE_GUI=0 doesn't exclude all of wxCore dependency, and the application
+   # object and event loops are in wxBase, but we want to exclude their use too
+   target_compile_definitions( wxBase INTERFACE
+      "wxUSE_GUI=0"
+ 
+      # Don't use app.h
+      _WX_APP_H_BASE_
+   
+      # Don't use evtloop.h
+      _WX_EVTLOOP_H_
+   
+      # Don't use image.h
+      _WX_IMAGE_H
+   
+      # Don't use colour.h
+      _WX_COLOUR_H_BASE_
+   
+      # Don't use brush.h
+      _WX_BRUSH_H_BASE_
+   
+      # Don't use pen.h
+      _WX_PEN_H_BASE_
+   )
+endfunction()
+   
 if( ${_OPT}use_wxwidgets STREQUAL "system" OR NOT ${_OPT}conan_enabled )
     # DV: find_package will be scoped, as FindwxWidgets.cmake is rather outdated.
     # Still - let's perform the sanity check first.
@@ -42,7 +74,8 @@ if( ${_OPT}use_wxwidgets STREQUAL "system" OR NOT ${_OPT}conan_enabled )
     endif()
 
     if( NOT TARGET wxBase )
-        add_library( wxBase ALIAS wxwidgets::wxwidgets )
+        # add_library( wxBase ALIAS wxwidgets::wxwidgets )
+        make_wxBase(wxwidgets::wxwidgets)
     endif()
 
     if( NOT TARGET wxwidgets::wxwidgets )
@@ -94,7 +127,8 @@ if( ${_OPT}use_wxwidgets STREQUAL "system" OR NOT ${_OPT}conan_enabled )
     endif()
 else()
     set_target_properties(wxwidgets::base PROPERTIES IMPORTED_GLOBAL On)
-    add_library( wxBase ALIAS wxwidgets::base )
+    # add_library( wxBase ALIAS wxwidgets::base )
+    make_wxbase(wxwidgets::base)
 endif()
 
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Windows|Darwin" )

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -7,7 +7,6 @@
 **********************************************************************/
 #include "EffectInterface.h"
 #include <wx/tokenzr.h>
-#include <wx/window.h>
 
 const RegistryPath &EffectSettingsExtra::DurationKey()
 {

--- a/libraries/lib-files/FileNames.cpp
+++ b/libraries/lib-files/FileNames.cpp
@@ -485,7 +485,7 @@ FilePath FileNames::PathFromAddr(void *addr)
 bool FileNames::IsPathAvailable( const FilePath & Path){
    if( Path.IsEmpty() )
       return false;
-#ifndef __WIN32__
+#ifndef _WIN32
    return true;
 #else
    wxFileNameWrapper filePath( Path );
@@ -497,7 +497,7 @@ wxFileNameWrapper FileNames::DefaultToDocumentsFolder(const wxString &preference
 {
    wxFileNameWrapper result;
 
-#ifdef __WIN32__
+#ifdef _WIN32
    wxFileName defaultPath( wxStandardPaths::Get().GetDocumentsDir(), "" );
 
    defaultPath.AppendDir( AppName );

--- a/libraries/lib-module-manager/PluginHost.cpp
+++ b/libraries/lib-module-manager/PluginHost.cpp
@@ -12,12 +12,12 @@
 
 #include "PluginHost.h"
 
-#include <wx/app.h>
 #include <wx/log.h>
 #include <wx/module.h>
 #include <wx/process.h>
 
 #include "BasicUI.h"
+#include "CommandLineArgs.h"
 #include "PathList.h"
 #include "FileNames.h"
 #include "ModuleManager.h"
@@ -205,9 +205,10 @@ bool PluginHost::Start(int connectPort)
    return false;
 }
 
-bool PluginHost::IsHostProcess(int argc, wxChar** argv)
+bool PluginHost::IsHostProcess()
 {
-   return argc >= 3 && wxStrcmp(argv[1], HostArgument) == 0;
+   return CommandLineArgs::argc >= 3 &&
+      wxStrcmp(CommandLineArgs::argv[1], HostArgument) == 0;
 }
 
 class PluginHostModule final :
@@ -218,10 +219,10 @@ public:
 
    bool OnInit() override
    {
-      if(PluginHost::IsHostProcess(wxTheApp->argc, wxTheApp->argv))
+      if(PluginHost::IsHostProcess())
       {
          long connectPort;
-         if(!wxTheApp->argv[2].ToLong(&connectPort))
+         if(!wxString{ CommandLineArgs::argv[2] }.ToLong(&connectPort))
             return false;
 
          //log messages will appear in a separate window
@@ -234,7 +235,7 @@ public:
          //...and terminate app
          return false;
       }
-      //do noting if current process isn't a host process
+      //do nothing if current process isn't a host process
       return true;
    }
    

--- a/libraries/lib-module-manager/PluginHost.h
+++ b/libraries/lib-module-manager/PluginHost.h
@@ -56,7 +56,7 @@ public:
    static bool Start(int connectPort);
 
    ///Returns true if current process is considered to be a plugin host process
-   static bool IsHostProcess(int argc, wxChar** argv);
+   static bool IsHostProcess();
 
    explicit PluginHost(int connectPort);
 

--- a/libraries/lib-utility/CMakeLists.txt
+++ b/libraries/lib-utility/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 A small library defining various constants and utilities
 
-No dependencies on wxWidgets.  Very few if any symbols with linkage.
+No dependencies on wxWidgets.  Few symbols with linkage.  Many templates.
 
 One very important utility is finally() as defined in The C++ Programming
 Language, fourth edition, for describing ad-hoc RAII actions.
@@ -9,15 +9,17 @@ Language, fourth edition, for describing ad-hoc RAII actions.
 Historically, MemoryX.h began as a wrapper of C++11 <memory>, which by itself
 did not yet provide std::make_unique.  That explains the name.
 
-Audacity now uses C++14, and yet, need arose for other anticipations of
-future standards, such as with optional.  It also provides other pervasively
-used utilities that don't correspond to things in the standard.
+Audacity now uses C++17, and yet, need arose for other anticipations of future
+standards.  It also provides other pervasively used utilities that don't
+correspond to things in the standard.
 
 ]]#
 
 set( SOURCES
    BufferedStreamReader.cpp
    BufferedStreamReader.h
+   CommandLineArgs.cpp
+   CommandLineArgs.h
    CFResources.h
    GlobalVariable.h
    MemoryX.cpp

--- a/libraries/lib-utility/CommandLineArgs.cpp
+++ b/libraries/lib-utility/CommandLineArgs.cpp
@@ -11,3 +11,35 @@
 
 int CommandLineArgs::argc;
 const char *const *CommandLineArgs::argv;
+
+#ifdef _WIN32
+#include <windows.h>
+
+#include <locale>
+#include <codecvt>
+
+namespace CommandLineArgs {
+MSWParser::MSWParser()
+{
+   wideArgv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
+   for (size_t ii = 0; ii < argc; ++ii)
+   {
+      auto begin = wideArgv[ii];
+      auto end = begin + wcslen(begin);
+      
+      narrowArgv.emplace_back(
+         std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(
+            begin, end));
+
+      argv.push_back(narrowArgv.back().data());
+   }
+   argv.push_back(nullptr);
+}
+
+MSWParser::~MSWParser()
+{
+   if (wideArgv)
+      ::LocalFree(wideArgv);
+}
+} // namespace CommandLineArgs
+#endif

--- a/libraries/lib-utility/CommandLineArgs.cpp
+++ b/libraries/lib-utility/CommandLineArgs.cpp
@@ -1,0 +1,13 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file CommandLineArgs.cpp
+
+ Paul Licameli
+ 
+**********************************************************************/
+#include "CommandLineArgs.h"
+
+int CommandLineArgs::argc;
+const char *const *CommandLineArgs::argv;

--- a/libraries/lib-utility/CommandLineArgs.h
+++ b/libraries/lib-utility/CommandLineArgs.h
@@ -9,10 +9,35 @@
  Paul Licameli
  
  **********************************************************************/
+#ifdef _WIN32
+#   include <cstddef>
+#   include <vector>
+#   include <string>
+#endif
 
 namespace CommandLineArgs {
 //! A copy of argc; responsibility of application startup to assign it.
 extern UTILITY_API int argc;
 //! A copy of argv; responsibility of application startup to assign it.
 extern UTILITY_API const char *const *argv;
+
+#ifdef _WIN32
+//! Parse process command line
+/*!
+ Convert wide strings to narrow, assuming all characters are ASCII,
+ which is good enough for the sub-processes the application may spawn
+ */
+struct UTILITY_API MSWParser final {
+   int argc{ 0 };
+   std::vector<const char *> argv;
+
+   MSWParser();
+   ~MSWParser();
+
+private:
+   wchar_t **wideArgv{ nullptr };
+   std::vector<std::string> narrowArgv;
+};
+#endif
+
 }

--- a/libraries/lib-utility/CommandLineArgs.h
+++ b/libraries/lib-utility/CommandLineArgs.h
@@ -1,0 +1,18 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file CommandLineArgs.h
+
+ @brief Avoid dependency on argc and argv in wxAppConsoleBase
+
+ Paul Licameli
+ 
+ **********************************************************************/
+
+namespace CommandLineArgs {
+//! A copy of argc; responsibility of application startup to assign it.
+extern UTILITY_API int argc;
+//! A copy of argv; responsibility of application startup to assign it.
+extern UTILITY_API const char *const *argv;
+}

--- a/libraries/lib-utility/MemoryX.h
+++ b/libraries/lib-utility/MemoryX.h
@@ -469,7 +469,7 @@ OutContainer transform_container( InContainer &inContainer, Function &&fn )
  macOS builds under current limitations of the C++17 standard implementation.
  */
 struct UTILITY_API alignas(
-#ifdef __WIN32__
+#ifdef _WIN32
    std::hardware_destructive_interference_size
 #else
    // That constant isn't defined for the other builds yet

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -841,7 +841,7 @@ int main(int argc, char *argv[])
 }
 
 #else
-IMPLEMENT_APP(AudacityApp)
+wxIMPLEMENT_APP(AudacityApp);
 #endif
 
 #ifdef __WXMAC__

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -858,7 +858,15 @@ wxIMPLEMENT_APP_NO_MAIN(AudacityApp);
 #else
 
 wxIMPLEMENT_WX_THEME_SUPPORT
-wxIMPLEMENT_WXWIN_MAIN
+extern "C" int WINAPI WinMain(HINSTANCE hInstance,
+                            HINSTANCE hPrevInstance,
+                            wxCmdLineArgType lpCmdLine,
+                            int nCmdShow)
+{
+   wxDISABLE_DEBUG_SUPPORT();
+
+   return wxEntry(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
+}
 wxIMPLEMENT_APP_NO_MAIN(AudacityApp);
 
 #endif

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -822,6 +822,8 @@ int main(int argc, char *argv[])
 
 #elif defined(__WXGTK__) && defined(NDEBUG)
 
+// Specially define main() for Linux debug
+
 IMPLEMENT_APP_NO_MAIN(AudacityApp)
 IMPLEMENT_WX_THEME_SUPPORT
 
@@ -840,10 +842,25 @@ int main(int argc, char *argv[])
    return wxEntry(argc, argv);
 }
 
+#elif defined(__WXGTK__)
+
+// Linux release build
+
+wxIMPLEMENT_WX_THEME_SUPPORT
+int main(int argc, char *argv[])
+{
+   wxDISABLE_DEBUG_SUPPORT();
+
+   return wxEntry(argc, argv);
+}
+wxIMPLEMENT_APP_NO_MAIN(AudacityApp);
+
 #else
+
 wxIMPLEMENT_WX_THEME_SUPPORT
 wxIMPLEMENT_WXWIN_MAIN
 wxIMPLEMENT_APP_NO_MAIN(AudacityApp);
+
 #endif
 
 #ifdef __WXMAC__

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -842,7 +842,8 @@ int main(int argc, char *argv[])
 
 #else
 wxIMPLEMENT_WX_THEME_SUPPORT
-wxIMPLEMENT_APP_NO_THEMES(AudacityApp);
+wxIMPLEMENT_WXWIN_MAIN
+wxIMPLEMENT_APP_NO_MAIN(AudacityApp);
 #endif
 
 #ifdef __WXMAC__

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -78,6 +78,7 @@ It handles initialization and termination by subclassing wxApp.
 #include "AudioIO.h"
 #include "Benchmark.h"
 #include "Clipboard.h"
+#include "CommandLineArgs.h"
 #include "CrashReport.h" // for HAS_CRASH_REPORT
 #include "commands/CommandHandler.h"
 #include "commands/AppCommandEvent.h"
@@ -808,15 +809,16 @@ int main(int argc, char *argv[])
 {
    wxDISABLE_DEBUG_SUPPORT();
 
-   wxCmdLineArgsArray argsArray;
-   argsArray.Init(argc, argv);
-   if(PluginHost::IsHostProcess(argc, argsArray))
+   CommandLineArgs::argc = argc;
+   CommandLineArgs::argv = argv;
+
+   if(PluginHost::IsHostProcess())
    {
       sOSXIsGUIApplication = false;
       ProcessSerialNumber psn = { 0, kCurrentProcess };
       TransformProcessType(&psn, kProcessTransformToUIElementApplication);
    }
-   
+
    return wxEntry(argc, argv);
 }
 
@@ -829,6 +831,9 @@ IMPLEMENT_WX_THEME_SUPPORT
 
 int main(int argc, char *argv[])
 {
+   CommandLineArgs::argc = argc;
+   CommandLineArgs::argv = argv;
+
    wxDISABLE_DEBUG_SUPPORT();
 
    // Bug #1986 workaround - This doesn't actually reduce the number of 
@@ -849,6 +854,9 @@ int main(int argc, char *argv[])
 wxIMPLEMENT_WX_THEME_SUPPORT
 int main(int argc, char *argv[])
 {
+   CommandLineArgs::argc = argc;
+   CommandLineArgs::argv = argv;
+
    wxDISABLE_DEBUG_SUPPORT();
 
    return wxEntry(argc, argv);
@@ -863,6 +871,10 @@ extern "C" int WINAPI WinMain(HINSTANCE hInstance,
                             wxCmdLineArgType lpCmdLine,
                             int nCmdShow)
 {
+   static CommandLineArgs::MSWParser wxArgs;
+   CommandLineArgs::argc = wxArgs.argc;
+   CommandLineArgs::argv = wxArgs.argv.data();
+
    wxDISABLE_DEBUG_SUPPORT();
 
    return wxEntry(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
@@ -1167,7 +1179,7 @@ AudacityApp::AudacityApp()
 
 bool AudacityApp::Initialize(int& argc, wxChar** argv)
 {
-   if(!PluginHost::IsHostProcess(argc, argv))
+   if(!PluginHost::IsHostProcess())
    {
 #if defined(USE_BREAKPAD)
       InitBreakpad();

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -841,7 +841,8 @@ int main(int argc, char *argv[])
 }
 
 #else
-wxIMPLEMENT_APP(AudacityApp);
+wxIMPLEMENT_WX_THEME_SUPPORT
+wxIMPLEMENT_APP_NO_THEMES(AudacityApp);
 #endif
 
 #ifdef __WXMAC__

--- a/src/widgets/FileDialog/win/FileDialogPrivate.cpp
+++ b/src/widgets/FileDialog/win/FileDialogPrivate.cpp
@@ -57,7 +57,7 @@
 // constants
 // ----------------------------------------------------------------------------
 
-#ifdef __WIN32__
+#ifdef _WIN32
 # define wxMAXPATH   65534
 #else
 # define wxMAXPATH   1024

--- a/src/widgets/numformatter.cpp
+++ b/src/widgets/numformatter.cpp
@@ -27,7 +27,7 @@
     #pragma hdrstop
 #endif
 
-#ifdef __WIN32__
+#ifdef _WIN32
     #include <wx/msw/private.h>
 
 #endif


### PR DESCRIPTION
... First, add some utilities to find and store argc and argv.

Then, rewrite main() and WinMain() to use them.  This removes the dependency
on wx/app.h from PluginHost.cpp.  That is needed before what comes next.

Finally, wxBase is no longer an alias target.  It is an interface target to wxWidgets
that adds some preprocessor definitions that restrict at compile time what
parts of wxWidgets may be used, to general wxBase utilities only.

No graphical interface is allowed, but also none of the main event loop.  So in
fact only a subset of wxBase is good to use, because even that includes an event
loop usable in console programs.  Restrict the use of certain headers by
pre-including their include guards, so that an attempt to include them skips
the definitions they contain and makes compilation fail.

The library targets that depend on wxBase must make it PRIVATE, for otherwise
the restrictions on use of wxWidgets would be propagated to users of those
libraries that do not need to be toolkit-neutral and break their compilation.

Restoring what was defined before at 1f71ef4 but was soon lost at f66381b with
the conan-izing.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
