### PR TITLE
Realtime effect manager rewrite part 2

### DIFF
--- a/libraries/lib-xml/XMLMethodRegistry.h
+++ b/libraries/lib-xml/XMLMethodRegistry.h
@@ -202,13 +202,9 @@ struct ObjectWriterEntry {
    }
 };
 
-void CallAttributeWriters( const Host &host, XMLWriter &writer )
+void CallWriters( const Host &host, XMLWriter &writer )
 {
    XMLMethodRegistryBase::CallAttributeWriters( &host, writer );
-}
-
-void CallObjectWriters( const Host &host, XMLWriter &writer )
-{
    XMLMethodRegistryBase::CallObjectWriters( &host, writer );
 }
 

--- a/libraries/lib-xml/XMLWriter.h
+++ b/libraries/lib-xml/XMLWriter.h
@@ -58,7 +58,7 @@ class XML_API XMLWriter /* not final */ {
 
    // Escape a string, replacing certain characters with their
    // XML encoding, i.e. '<' becomes '&lt;'
-   wxString XMLEsc(const wxString & s);
+   static wxString XMLEsc(const wxString & s);
 
  protected:
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -921,7 +921,7 @@ int AudioIO::StartStream(const TransportTracks &tracks,
          auto & em = RealtimeEffectManager::Get(*pOwningProject);
          // Setup for realtime playback at the rate of the realtime
          // stream, not the rate of the track.
-         em.RealtimeInitialize(mRate);
+         em.Initialize(mRate);
 
          // The following adds a NEW effect processor for each logical track and the
          // group determination should mimic what is done in audacityAudioCallback()
@@ -937,7 +937,7 @@ int AudioIO::StartStream(const TransportTracks &tracks,
 
             // Setup for realtime playback at the rate of the realtime
             // stream, not the rate of the track.
-            em.RealtimeAddProcessor(group++, std::min(2u, chanCnt), mRate);
+            em.AddTrack(group++, std::min(2u, chanCnt), mRate);
          }
       }
    }
@@ -1272,7 +1272,7 @@ void AudioIO::StartStreamCleanup(bool bOnlyBuffers)
    if (mNumPlaybackChannels > 0)
    {
       if (auto pOwningProject = mOwningProject.lock())
-         RealtimeEffectManager::Get(*pOwningProject).RealtimeFinalize();
+         RealtimeEffectManager::Get(*pOwningProject).Finalize();
    }
 
    mPlaybackBuffers.reset();
@@ -1357,7 +1357,7 @@ void AudioIO::StopStream()
    if (mNumPlaybackChannels > 0)
    {
       if (auto pOwningProject = mOwningProject.lock())
-         RealtimeEffectManager::Get(*pOwningProject).RealtimeFinalize();
+         RealtimeEffectManager::Get(*pOwningProject).Finalize();
    }
 
    //
@@ -1596,9 +1596,9 @@ void AudioIO::SetPaused(bool state)
       if (auto pOwningProject = mOwningProject.lock()) {
          auto &em = RealtimeEffectManager::Get(*pOwningProject);
          if (state)
-            em.RealtimeSuspend();
+            em.Suspend();
          else
-            em.RealtimeResume();
+            em.Resume();
       }
    }
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -919,25 +919,21 @@ int AudioIO::StartStream(const TransportTracks &tracks,
    {
       if (auto pOwningProject = mOwningProject.lock()) {
          auto & em = RealtimeEffectManager::Get(*pOwningProject);
+
          // Setup for realtime playback at the rate of the realtime
          // stream, not the rate of the track.
          em.Initialize(mRate);
 
-         // The following adds a NEW effect processor for each logical track and the
-         // group determination should mimic what is done in audacityAudioCallback()
-         // when calling RealtimeProcess().
-         int group = 0;
+         // The following adds a new effect processor for each logical track.
          for (size_t i = 0, cnt = mPlaybackTracks.size(); i < cnt;)
          {
-            const WaveTrack *vt = mPlaybackTracks[i].get();
-
-            // TODO: more-than-two-channels
+            auto vt = mPlaybackTracks[i].get();
             unsigned chanCnt = TrackList::Channels(vt).size();
             i += chanCnt;
 
             // Setup for realtime playback at the rate of the realtime
             // stream, not the rate of the track.
-            em.AddTrack(group++, std::min(2u, chanCnt), mRate);
+            em.AddTrack(vt, std::min(mNumPlaybackChannels, chanCnt), mRate);
          }
       }
    }
@@ -2400,8 +2396,6 @@ bool AudioIoCallback::FillOutputBuffers(
    auto pProject = mOwningProject.lock();
    RealtimeEffectManager::ProcessScope scope{ pProject.get() };
 
-   bool selected = false;
-   int group = 0;
    int chanCnt = 0;
 
    // Choose a common size to take from all ring buffers
@@ -2441,7 +2435,6 @@ bool AudioIoCallback::FillOutputBuffers(
 
       if ( firstChannel )
       {
-         selected = vt->GetSelected();
          // IF mono THEN clear 'the other' channel.
          if ( lastChannel && (numPlaybackChannels>1)) {
             // TODO: more-than-two-channels
@@ -2495,38 +2488,45 @@ bool AudioIoCallback::FillOutputBuffers(
       // Last channel of a track seen now
       len = mMaxFramesOutput;
 
-      if( !dropQuickly && selected )
-         len = scope.Process(group, chanCnt, tempBufs, len);
-      group++;
+      // Do realtime effects
+      if( !dropQuickly && len > 0 ) {
+         scope.Process(chans[0], tempBufs, len);
+
+         // Mix the results with the existing output (software playthrough) and
+         // apply panning.  If post panning effects are desired, the panning would
+         // need to be be split out from the mixing and applied in a separate step.
+         for (auto c = 0; c < chanCnt; ++c)
+         {
+            // Our channels aren't silent.  We need to pass their data on.
+            //
+            // Note that there are two kinds of channel count.
+            // c and chanCnt are counting channels in the Tracks.
+            // chan (and numPlayBackChannels) is counting output channels on the device.
+            // chan = 0 is left channel
+            // chan = 1 is right channel.
+            //
+            // Each channel in the tracks can output to more than one channel on the device.
+            // For example mono channels output to both left and right output channels.
+            if (len > 0) for (int c = 0; c < chanCnt; c++)
+            {
+               vt = chans[c];
+
+               if (vt->GetChannelIgnoringPan() == Track::LeftChannel ||
+                     vt->GetChannelIgnoringPan() == Track::MonoChannel )
+                  AddToOutputChannel( 0, outputMeterFloats, outputFloats,
+                     tempBufs[c], drop, len, vt);
+
+               if (vt->GetChannelIgnoringPan() == Track::RightChannel ||
+                     vt->GetChannelIgnoringPan() == Track::MonoChannel  )
+                  AddToOutputChannel( 1, outputMeterFloats, outputFloats,
+                     tempBufs[c], drop, len, vt);
+            }
+         }
+      }
 
       CallbackCheckCompletion(mCallbackReturn, len);
       if (dropQuickly) // no samples to process, they've been discarded
          continue;
-
-      // Our channels aren't silent.  We need to pass their data on.
-      //
-      // Note that there are two kinds of channel count.
-      // c and chanCnt are counting channels in the Tracks.
-      // chan (and numPlayBackChannels) is counting output channels on the device.
-      // chan = 0 is left channel
-      // chan = 1 is right channel.
-      //
-      // Each channel in the tracks can output to more than one channel on the device.
-      // For example mono channels output to both left and right output channels.
-      if (len > 0) for (int c = 0; c < chanCnt; c++)
-      {
-         vt = chans[c];
-
-         if (vt->GetChannelIgnoringPan() == Track::LeftChannel ||
-               vt->GetChannelIgnoringPan() == Track::MonoChannel )
-            AddToOutputChannel( 0, outputMeterFloats, outputFloats,
-               tempBufs[c], drop, len, vt);
-
-         if (vt->GetChannelIgnoringPan() == Track::RightChannel ||
-               vt->GetChannelIgnoringPan() == Track::MonoChannel  )
-            AddToOutputChannel( 1, outputMeterFloats, outputFloats,
-               tempBufs[c], drop, len, vt);
-      }
 
       chanCnt = 0;
    }

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1821,8 +1821,7 @@ void ProjectFileIO::WriteXML(XMLWriter &xmlFile,
    xmlFile.WriteAttr(wxT("version"), wxT(AUDACITY_FILE_FORMAT_VERSION));
    xmlFile.WriteAttr(wxT("audacityversion"), AUDACITY_VERSION_STRING);
 
-   ProjectFileIORegistry::Get().CallAttributeWriters(proj, xmlFile);
-   ProjectFileIORegistry::Get().CallObjectWriters(proj, xmlFile);
+   ProjectFileIORegistry::Get().CallWriters(proj, xmlFile);
 
    tracklist.Any().Visit([&](const Track *t)
    {

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1918,6 +1918,10 @@ void WaveTrack::HandleXMLEndTag(const std::string_view&  WXUNUSED(tag))
 
 XMLTagHandler *WaveTrack::HandleXMLChild(const std::string_view& tag)
 {
+   if ( auto pChild = WaveTrackIORegistry::Get()
+          .CallObjectAccessor(tag, *this) )
+      return pChild;
+
    //
    // This is legacy code (1.2 and previous) and is not called for NEW projects!
    //
@@ -1948,8 +1952,8 @@ XMLTagHandler *WaveTrack::HandleXMLChild(const std::string_view& tag)
    //
    if (tag == "waveclip")
       return CreateClip();
-   else
-      return NULL;
+
+   return nullptr;
 }
 
 void WaveTrack::WriteXML(XMLWriter &xmlFile) const
@@ -1965,6 +1969,8 @@ void WaveTrack::WriteXML(XMLWriter &xmlFile) const
    xmlFile.WriteAttr(wxT("pan"), (double)mPan);
    xmlFile.WriteAttr(wxT("colorindex"), mWaveColorIndex );
    xmlFile.WriteAttr(wxT("sampleformat"), static_cast<long>(mFormat) );
+
+   WaveTrackIORegistry::Get().CallWriters(*this, xmlFile);
 
    for (const auto &clip : mClips)
    {
@@ -2856,3 +2862,5 @@ bool GetEditClipsCanMove()
    gPrefs->Read(wxT("/GUI/EditClipCanMove"), &editClipsCanMove, false);
    return editClipsCanMove;
 }
+
+DEFINE_XML_METHOD_REGISTRY( WaveTrackIORegistry );

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -640,4 +640,9 @@ extern AUDACITY_DLL_API StringSetting AudioTrackNameSetting;
 
 AUDACITY_DLL_API bool GetEditClipsCanMove();
 
+// Generate a registry for serialized data
+#include "XMLMethodRegistry.h"
+using WaveTrackIORegistry = XMLMethodRegistry<WaveTrack>;
+DECLARE_XML_METHOD_REGISTRY( AUDACITY_DLL_API, WaveTrackIORegistry );
+
 #endif // __AUDACITY_WAVETRACK__

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -864,3 +864,24 @@ const PluginID & EffectManager::GetEffectByIdentifier(const CommandID & strTarge
    return empty;
 }
 
+/* TODO:  fix the effect management so that repeated calls with the same ID
+ give Effect objects with independent state for effect settings.
+ */
+std::unique_ptr<Effect> EffectManager::NewEffect(const PluginID & ID)
+{
+   // Must have a "valid" ID
+   if (ID.empty())
+      return nullptr;
+
+   // This will instantiate the effect client if it hasn't already been done
+   // But it only makes a unique object for a given ID
+   auto ident = dynamic_cast<EffectDefinitionInterface *>(
+      PluginManager::Get().GetInstance(ID));
+
+   auto effect = std::make_unique<Effect>();
+   auto client = dynamic_cast<EffectUIClientInterface *>(ident);
+   if (client && effect->Startup(client))
+      return effect;
+   else
+      return nullptr;
+}

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -57,6 +57,9 @@ public:
       kRepeatNyquistPrompt = 0x10,
    };
 
+   /*! Create a new instance of an effect by its ID. */
+   static std::unique_ptr<Effect> NewEffect(const PluginID &ID);
+
    /** Get the singleton instance of the EffectManager. Probably not safe
        for multi-thread use. */
    static EffectManager & Get();

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1462,3 +1462,32 @@ void EffectDialog::OnOk(wxCommandEvent & WXUNUSED(evt))
 #include "RealtimeEffectState.h"
 static
 RealtimeEffectState::EffectFactory::Scope scope{ &EffectManager::NewEffect };
+
+/* The following registration objects need a home at a higher level to avoid
+ dependency either way between WaveTrack or RealtimeEffectList, which need to
+ be in different libraries that do not depend either on the other.
+
+ WaveTrack, like AudacityProject, has a registry for attachment of serializable
+ data.  RealtimeEffectList exposes an interface for serialization.  This is
+ where we connect them.
+ */
+#include "RealtimeEffectList.h"
+static ProjectFileIORegistry::ObjectReaderEntry projectAccessor {
+   RealtimeEffectList::XMLTag(),
+   [](AudacityProject &project) { return &RealtimeEffectList::Get(project); }
+};
+
+static ProjectFileIORegistry::ObjectWriterEntry projectWriter {
+[](const AudacityProject &project, XMLWriter &xmlFile){
+   RealtimeEffectList::Get(project).WriteXML(xmlFile);
+} };
+
+static WaveTrackIORegistry::ObjectReaderEntry waveTrackAccessor {
+   RealtimeEffectList::XMLTag(),
+   [](WaveTrack &track) { return &RealtimeEffectList::Get(track); }
+};
+
+static WaveTrackIORegistry::ObjectWriterEntry waveTrackWriter {
+[](const WaveTrack &track, auto &xmlFile) {
+   RealtimeEffectList::Get(track).WriteXML(xmlFile);
+} };

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1137,10 +1137,7 @@ void EffectUIHost::LoadUserPresets()
 
 void EffectUIHost::InitializeRealtime()
 {
-   if (mSupportsRealtime && !mInitialized)
-   {
-      RealtimeEffectManager::Get(*mProject).RealtimeAddEffect(mEffect);
-      
+   if (mSupportsRealtime && !mInitialized) {
       AudioIO::Get()->Subscribe([this](AudioIOEvent event){
          switch (event.type) {
          case AudioIOEvent::PLAYBACK:
@@ -1158,10 +1155,7 @@ void EffectUIHost::InitializeRealtime()
 
 void EffectUIHost::CleanupRealtime()
 {
-   if (mSupportsRealtime && mInitialized)
-   {
-      RealtimeEffectManager::Get(*mProject).RealtimeRemoveEffect(mEffect);
-      
+   if (mSupportsRealtime && mInitialized) {
       mInitialized = false;
    }
 }

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -21,6 +21,7 @@
 #include "../ProjectHistory.h"
 #include "../ProjectWindowBase.h"
 #include "../TrackPanelAx.h"
+#include "RealtimeEffectList.h"
 #include "RealtimeEffectManager.h"
 #include "widgets/wxWidgetsWindowPlacement.h"
 
@@ -1138,6 +1139,15 @@ void EffectUIHost::LoadUserPresets()
 void EffectUIHost::InitializeRealtime()
 {
    if (mSupportsRealtime && !mInitialized) {
+      mpState = RealtimeEffectManager::Get(*mProject)
+         .AddState(nullptr, PluginManager::GetID(&mEffect));
+      /*
+      ProjectHistory::Get(mProject).PushState(
+         XO("Added %s effect").Format(mpState->GetEffect()->GetName()),
+         XO("Added Effect"),
+         UndoPush::NONE
+      );
+       */
       AudioIO::Get()->Subscribe([this](AudioIOEvent event){
          switch (event.type) {
          case AudioIOEvent::PLAYBACK:
@@ -1156,6 +1166,18 @@ void EffectUIHost::InitializeRealtime()
 void EffectUIHost::CleanupRealtime()
 {
    if (mSupportsRealtime && mInitialized) {
+      if (mpState) {
+         auto &list = RealtimeEffectList::Get(*mProject);
+         RealtimeEffectManager::Get(*mProject)
+            .RemoveState(list, *mpState);
+      /*
+         ProjectHistory::Get(mProject).PushState(
+            XO("Removed %s effect").Format(mpState->GetEffect()->GetName()),
+            XO("Removed Effect"),
+            UndoPush::NONE
+         );
+       */
+      }
       mInitialized = false;
    }
 }

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1457,3 +1457,8 @@ void EffectDialog::OnOk(wxCommandEvent & WXUNUSED(evt))
 
    return;
 }
+
+//! Inject a factory for realtime effect states
+#include "RealtimeEffectState.h"
+static
+RealtimeEffectState::EffectFactory::Scope scope{ &EffectManager::NewEffect };

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -16,10 +16,13 @@
 
 #include <wx/bitmap.h> // member variables
 
+#include <optional>
+
 #include "Identifier.h"
 #include "EffectHostInterface.h"
 #include "Observer.h"
 #include "PluginInterface.h"
+#include "effects/RealtimeEffectManager.h"
 
 struct AudioIOEvent;
 
@@ -86,7 +89,6 @@ private:
 
    void InitializeRealtime();
    void CleanupRealtime();
-   void Resume();
 
 private:
    Observer::Subscription mSubscription;
@@ -128,7 +130,7 @@ private:
    double mPlayPos;
 
    bool mDismissed{};
-   bool mNeedsResume{};
+   std::optional<RealtimeEffectManager::SuspensionScope> mSuspensionScope;
 
 #if wxDEBUG_LEVEL
    // Used only in an assertion

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -34,6 +34,7 @@ struct AudioIOEvent;
 class AudacityCommand;
 class AudacityProject;
 class Effect;
+class RealtimeEffectState;
 
 class wxCheckBox;
 
@@ -97,6 +98,7 @@ private:
    wxWindow *mParent;
    Effect &mEffect;
    EffectUIClientInterface &mClient;
+   RealtimeEffectState *mpState{ nullptr };
 
    RegistryPaths mUserPresets;
    bool mInitialized;

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -75,6 +75,20 @@ RealtimeEffectState *RealtimeEffectList::AddState(const PluginID &id)
       return nullptr;
 }
 
+void RealtimeEffectList::RemoveState(RealtimeEffectState &state)
+{
+   auto end = mStates.end(),
+      found = std::find_if(mStates.begin(), end,
+         [&](const auto &item) { return item.get() == &state; } );
+   if (found != end)
+      mStates.erase(found);
+}
+
+void RealtimeEffectList::Swap(size_t index1, size_t index2)
+{
+   std::swap(mStates[index1], mStates[index2]);
+}
+
 const std::string &RealtimeEffectList::XMLTag()
 {
    static const std::string result{"effects"};

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -7,6 +7,7 @@
  *********************************************************************/
 
 #include "RealtimeEffectList.h"
+#include "RealtimeEffectState.h"
 
 #include "Project.h"
 #include "Track.h"
@@ -53,4 +54,10 @@ RealtimeEffectList &RealtimeEffectList::Get(Track &track)
 const RealtimeEffectList &RealtimeEffectList::Get(const Track &track)
 {
    return Get(const_cast<Track &>(track));
+}
+
+void RealtimeEffectList::Visit(StateVisitor func)
+{
+   for (auto &state : mStates)
+      func(*state, !state->IsActive());
 }

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -61,3 +61,62 @@ void RealtimeEffectList::Visit(StateVisitor func)
    for (auto &state : mStates)
       func(*state, !state->IsActive());
 }
+
+RealtimeEffectState *RealtimeEffectList::AddState(const PluginID &id)
+{
+   auto pState = std::make_unique<RealtimeEffectState>(id);
+   if (id.empty() || pState->GetEffect() != nullptr) {
+      auto result = pState.get();
+      mStates.emplace_back(move(pState));
+      return result;
+   }
+   else
+      // Effect initialization failed for the id
+      return nullptr;
+}
+
+const std::string &RealtimeEffectList::XMLTag()
+{
+   static const std::string result{"effects"};
+   return result;
+}
+
+bool RealtimeEffectList::HandleXMLTag(
+   const std::string_view &tag, const AttributesList &)
+{
+   return (tag == XMLTag());
+}
+
+void RealtimeEffectList::HandleXMLEndTag(const std::string_view &tag)
+{
+   if (tag == XMLTag()) {
+      // Remove states that fail to load their effects
+      auto end = mStates.end();
+      auto newEnd = std::remove_if( mStates.begin(), end,
+         [](const auto &pState){ return pState->GetEffect() == nullptr; });
+      mStates.erase(newEnd, end);
+   }
+}
+
+XMLTagHandler *RealtimeEffectList::HandleXMLChild(const std::string_view &tag)
+{
+   if (tag == RealtimeEffectState::XMLTag()) {
+      auto pState = AddState({});
+      assert(pState); // Should succeed always for empty id
+      return pState;
+   }
+   return nullptr;
+}
+
+void RealtimeEffectList::WriteXML(XMLWriter &xmlFile) const
+{
+   if (mStates.size() == 0)
+      return;
+
+   xmlFile.StartTag(XMLTag());
+
+   for (const auto & state : mStates)
+      state->WriteXML(xmlFile);
+   
+   xmlFile.EndTag(XMLTag());
+}

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -9,9 +9,13 @@
 #ifndef __AUDACITY_REALTIMEEFFECTLIST_H__
 #define __AUDACITY_REALTIMEEFFECTLIST_H__
 
+#include <vector>
+
 #include "TrackAttachment.h"
 
 class AudacityProject;
+
+class RealtimeEffectState;
 
 class Track;
 
@@ -29,6 +33,17 @@ public:
 
    static RealtimeEffectList &Get(Track &track);
    static const RealtimeEffectList &Get(const Track &track);
+
+   using StateVisitor =
+      std::function<void(RealtimeEffectState &state, bool bypassed)>;
+
+   //! Apply the function to all states sequentially.
+   void Visit(StateVisitor func);
+
+   using States = std::vector<std::unique_ptr<RealtimeEffectState>>;
+
+private:
+   States mStates;
 };
 
 #endif // __AUDACITY_REALTIMEEFFECTLIST_H__

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -12,6 +12,8 @@
 #include <vector>
 
 #include "TrackAttachment.h"
+#include "ModuleInterface.h" // for PluginID
+#include "XMLTagHandler.h"
 
 class AudacityProject;
 
@@ -19,7 +21,7 @@ class RealtimeEffectState;
 
 class Track;
 
-class RealtimeEffectList final : public TrackAttachment
+class RealtimeEffectList final : public TrackAttachment, public XMLTagHandler
 {
    RealtimeEffectList(const RealtimeEffectList &) = delete;
    RealtimeEffectList &operator=(const RealtimeEffectList &) = delete;
@@ -40,7 +42,17 @@ public:
    //! Apply the function to all states sequentially.
    void Visit(StateVisitor func);
 
+   //! Returns null if the id is nonempty but no such effect was found
+   RealtimeEffectState *AddState(const PluginID &id);
+
    using States = std::vector<std::unique_ptr<RealtimeEffectState>>;
+
+   static const std::string &XMLTag();
+   bool HandleXMLTag(
+      const std::string_view &tag, const AttributesList &attrs) override;
+   void HandleXMLEndTag(const std::string_view &tag) override;
+   XMLTagHandler *HandleXMLChild(const std::string_view &tag) override;
+   void WriteXML(XMLWriter &xmlFile) const;
 
 private:
    States mStates;

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -44,6 +44,8 @@ public:
 
    //! Returns null if the id is nonempty but no such effect was found
    RealtimeEffectState *AddState(const PluginID &id);
+   void RemoveState(RealtimeEffectState &state);
+   void Swap(size_t index1, size_t index2);
 
    using States = std::vector<std::unique_ptr<RealtimeEffectState>>;
 

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -167,18 +167,6 @@ void RealtimeEffectManager::RealtimeSuspend()
       state->RealtimeSuspend();
 }
 
-void RealtimeEffectManager::RealtimeSuspendOne( EffectProcessor &effect )
-{
-   auto begin = mStates.begin(), end = mStates.end();
-   auto found = std::find_if( begin, end,
-      [&effect]( const decltype( mStates )::value_type &state ){
-         return state && &state->GetEffect() == &effect;
-      }
-   );
-   if ( found != end )
-      (*found)->RealtimeSuspend();
-}
-
 void RealtimeEffectManager::RealtimeResume() noexcept
 {
    // Protect...
@@ -194,18 +182,6 @@ void RealtimeEffectManager::RealtimeResume() noexcept
 
    // And we should too
    mSuspended = false;
-}
-
-void RealtimeEffectManager::RealtimeResumeOne( EffectProcessor &effect )
-{
-   auto begin = mStates.begin(), end = mStates.end();
-   auto found = std::find_if( begin, end,
-      [&effect]( const decltype( mStates )::value_type &state ){
-         return state && &state->GetEffect() == &effect;
-      }
-   );
-   if ( found != end )
-      (*found)->RealtimeResume();
 }
 
 //

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -56,51 +56,6 @@ bool RealtimeEffectManager::RealtimeIsSuspended() const noexcept
    return mSuspended;
 }
 
-void RealtimeEffectManager::RealtimeAddEffect(EffectProcessor &effect)
-{
-   // Block RealtimeProcess()
-   SuspensionScope scope{ &mProject };
-
-   // Add to list of active effects
-   mStates.emplace_back( std::make_unique< RealtimeEffectState >( effect ) );
-   auto &state = mStates.back();
-
-   // Initialize effect if realtime is already active
-   if (mActive)
-   {
-      // Initialize realtime processing
-      effect.RealtimeInitialize();
-
-      // Add the required processors
-      for (size_t i = 0, cnt = mRealtimeChans.size(); i < cnt; i++)
-      {
-         state->RealtimeAddProcessor(i, mRealtimeChans[i], mRealtimeRates[i]);
-      }
-   }
-}
-
-void RealtimeEffectManager::RealtimeRemoveEffect(EffectProcessor &effect)
-{
-   // Block RealtimeProcess()
-   SuspensionScope scope{ &mProject };
-
-   if (mActive)
-   {
-      // Cleanup realtime processing
-      effect.RealtimeFinalize();
-   }
-      
-   // Remove from list of active effects
-   auto end = mStates.end();
-   auto found = std::find_if( mStates.begin(), end,
-      [&](const decltype(mStates)::value_type &state){
-         return &state->GetEffect() == &effect;
-      }
-   );
-   if (found != end)
-      mStates.erase(found);
-}
-
 void RealtimeEffectManager::RealtimeInitialize(double rate)
 {
    // The audio thread should not be running yet, but protect anyway

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -10,6 +10,7 @@
 
 
 #include "RealtimeEffectManager.h"
+#include "RealtimeEffectList.h"
 #include "RealtimeEffectState.h"
 
 #include "EffectInterface.h"
@@ -48,7 +49,7 @@ RealtimeEffectManager::~RealtimeEffectManager()
 
 bool RealtimeEffectManager::IsActive() const noexcept
 {
-   return mStates.size() != 0;
+   return mActive;
 }
 
 void RealtimeEffectManager::Initialize(double rate)
@@ -65,16 +66,17 @@ void RealtimeEffectManager::Initialize(double rate)
    mActive = true;
 
    // Tell each effect to get ready for action
-   for (auto &state : mStates) {
-      state->GetEffect().SetSampleRate(rate);
-      state->GetEffect().RealtimeInitialize();
-   }
+   VisitGroup(nullptr, [rate](RealtimeEffectState &state, bool){
+      state.GetEffect().SetSampleRate(rate);
+      state.GetEffect().RealtimeInitialize();
+   });
 }
 
 void RealtimeEffectManager::AddTrack(int group, unsigned chans, float rate)
 {
-   for (auto &state : mStates)
-      state->AddTrack(group, chans, rate);
+   VisitGroup(nullptr, [&](RealtimeEffectState &state, bool){
+      state.AddTrack(group, chans, rate);
+   });
 
    mChans.push_back(chans);
    mRates.push_back(rate);
@@ -89,8 +91,9 @@ void RealtimeEffectManager::Finalize()
    mLatency = std::chrono::microseconds(0);
 
    // Tell each effect to clean up as well
-   for (auto &state : mStates)
-      state->GetEffect().RealtimeFinalize();
+   VisitGroup(nullptr, [](RealtimeEffectState &state, bool){
+      state.GetEffect().RealtimeFinalize();
+   });
 
    // Reset processor parameters
    mChans.clear();
@@ -113,8 +116,9 @@ void RealtimeEffectManager::Suspend()
    mSuspended = true;
 
    // And make sure the effects don't either
-   for (auto &state : mStates)
-      state->Suspend();
+   VisitGroup(nullptr, [](RealtimeEffectState &state, bool){
+      state.Suspend();
+   });
 }
 
 void RealtimeEffectManager::Resume() noexcept
@@ -127,8 +131,9 @@ void RealtimeEffectManager::Resume() noexcept
       return;
 
    // Tell the effects to get ready for more action
-   for (auto &state : mStates)
-      state->Resume();
+   VisitGroup(nullptr, [](RealtimeEffectState &state, bool){
+      state.Resume();
+   });
 
    // And we should too
    mSuspended = false;
@@ -146,11 +151,10 @@ void RealtimeEffectManager::ProcessStart()
    // have been suspended.
    if (!mSuspended)
    {
-      for (auto &state : mStates)
-      {
-         if (state->IsActive())
-            state->GetEffect().RealtimeProcessStart();
-      }
+      VisitGroup(nullptr, [](RealtimeEffectState &state, bool bypassed){
+         if (!bypassed)
+            state.GetEffect().RealtimeProcessStart();
+      });
    }
 }
 
@@ -164,10 +168,8 @@ size_t RealtimeEffectManager::Process(int group, unsigned chans, float **buffers
 
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended, so allow the samples to pass as-is.
-   if (mSuspended || mStates.empty())
-   {
+   if (mSuspended)
       return numSamples;
-   }
 
    // Remember when we started so we can calculate the amount of latency we
    // are introducing
@@ -188,11 +190,9 @@ size_t RealtimeEffectManager::Process(int group, unsigned chans, float **buffers
    // Now call each effect in the chain while swapping buffer pointers to feed the
    // output of one effect as the input to the next effect
    size_t called = 0;
-   for (auto &state : mStates)
-   {
-      if (state->IsActive())
-      {
-         state->Process(group, chans, ibuf, obuf, numSamples);
+   VisitGroup(nullptr, [&](RealtimeEffectState &state, bool bypassed){
+      if (!bypassed) {
+         state.Process(group, chans, ibuf, obuf, numSamples);
          called++;
       }
 
@@ -203,7 +203,7 @@ size_t RealtimeEffectManager::Process(int group, unsigned chans, float **buffers
          ibuf[j] = obuf[j];
          obuf[j] = temp;
       }
-   }
+   });
 
    // Once we're done, we might wind up with the last effect storing its results
    // in the temporary buffers.  If that's the case, we need to copy it over to
@@ -239,12 +239,22 @@ void RealtimeEffectManager::ProcessEnd() noexcept
    // have been suspended.
    if (!mSuspended)
    {
-      for (auto &state : mStates)
-      {
-         if (state->IsActive())
-            state->GetEffect().RealtimeProcessEnd();
-      }
+      VisitGroup(nullptr, [](RealtimeEffectState &state, bool bypassed){
+         if (!bypassed)
+            state.GetEffect().RealtimeProcessEnd();
+      });
    }
+}
+
+void RealtimeEffectManager::VisitGroup(Track *leader,
+   std::function<void(RealtimeEffectState &state, bool bypassed)> func)
+{
+   // Call the function for each effect on the master list
+   RealtimeEffectList::Get(mProject).Visit(func);
+
+   // Call the function for each effect on the track list
+   if (leader)
+     RealtimeEffectList::Get(*leader).Visit(func);
 }
 
 auto RealtimeEffectManager::GetLatency() const -> Latency

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -51,11 +51,6 @@ bool RealtimeEffectManager::RealtimeIsActive() const noexcept
    return mStates.size() != 0;
 }
 
-bool RealtimeEffectManager::RealtimeIsSuspended() const noexcept
-{
-   return mSuspended;
-}
-
 void RealtimeEffectManager::RealtimeInitialize(double rate)
 {
    // The audio thread should not be running yet, but protect anyway

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -67,8 +67,7 @@ void RealtimeEffectManager::Initialize(double rate)
 
    // Tell each effect to get ready for action
    VisitGroup(nullptr, [rate](RealtimeEffectState &state, bool){
-      state.GetEffect().SetSampleRate(rate);
-      state.GetEffect().RealtimeInitialize();
+      state.Initialize(rate);
    });
 }
 
@@ -92,7 +91,7 @@ void RealtimeEffectManager::Finalize()
 
    // Tell each effect to clean up as well
    VisitGroup(nullptr, [](RealtimeEffectState &state, bool){
-      state.GetEffect().RealtimeFinalize();
+      state.Finalize();
    });
 
    // Reset processor parameters
@@ -153,7 +152,7 @@ void RealtimeEffectManager::ProcessStart()
    {
       VisitGroup(nullptr, [](RealtimeEffectState &state, bool bypassed){
          if (!bypassed)
-            state.GetEffect().RealtimeProcessStart();
+            state.ProcessStart();
       });
    }
 }
@@ -241,7 +240,7 @@ void RealtimeEffectManager::ProcessEnd() noexcept
    {
       VisitGroup(nullptr, [](RealtimeEffectState &state, bool bypassed){
          if (!bypassed)
-            state.GetEffect().RealtimeProcessEnd();
+            state.ProcessEnd();
       });
    }
 }

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -46,19 +46,19 @@ RealtimeEffectManager::~RealtimeEffectManager()
 {
 }
 
-bool RealtimeEffectManager::RealtimeIsActive() const noexcept
+bool RealtimeEffectManager::IsActive() const noexcept
 {
    return mStates.size() != 0;
 }
 
-void RealtimeEffectManager::RealtimeInitialize(double rate)
+void RealtimeEffectManager::Initialize(double rate)
 {
    // The audio thread should not be running yet, but protect anyway
    SuspensionScope scope{ &mProject };
 
    // (Re)Set processor parameters
-   mRealtimeChans.clear();
-   mRealtimeRates.clear();
+   mChans.clear();
+   mRates.clear();
 
    // RealtimeAdd/RemoveEffect() needs to know when we're active so it can
    // initialize newly added effects
@@ -71,19 +71,19 @@ void RealtimeEffectManager::RealtimeInitialize(double rate)
    }
 }
 
-void RealtimeEffectManager::RealtimeAddProcessor(int group, unsigned chans, float rate)
+void RealtimeEffectManager::AddTrack(int group, unsigned chans, float rate)
 {
    for (auto &state : mStates)
-      state->RealtimeAddProcessor(group, chans, rate);
+      state->AddTrack(group, chans, rate);
 
-   mRealtimeChans.push_back(chans);
-   mRealtimeRates.push_back(rate);
+   mChans.push_back(chans);
+   mRates.push_back(rate);
 }
 
-void RealtimeEffectManager::RealtimeFinalize()
+void RealtimeEffectManager::Finalize()
 {
    // Make sure nothing is going on
-   RealtimeSuspend();
+   Suspend();
 
    // It is now safe to clean up
    mLatency = std::chrono::microseconds(0);
@@ -93,14 +93,14 @@ void RealtimeEffectManager::RealtimeFinalize()
       state->GetEffect().RealtimeFinalize();
 
    // Reset processor parameters
-   mRealtimeChans.clear();
-   mRealtimeRates.clear();
+   mChans.clear();
+   mRates.clear();
 
    // No longer active
    mActive = false;
 }
 
-void RealtimeEffectManager::RealtimeSuspend()
+void RealtimeEffectManager::Suspend()
 {
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
@@ -114,10 +114,10 @@ void RealtimeEffectManager::RealtimeSuspend()
 
    // And make sure the effects don't either
    for (auto &state : mStates)
-      state->RealtimeSuspend();
+      state->Suspend();
 }
 
-void RealtimeEffectManager::RealtimeResume() noexcept
+void RealtimeEffectManager::Resume() noexcept
 {
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
@@ -128,7 +128,7 @@ void RealtimeEffectManager::RealtimeResume() noexcept
 
    // Tell the effects to get ready for more action
    for (auto &state : mStates)
-      state->RealtimeResume();
+      state->Resume();
 
    // And we should too
    mSuspended = false;
@@ -137,7 +137,7 @@ void RealtimeEffectManager::RealtimeResume() noexcept
 //
 // This will be called in a different thread than the main GUI thread.
 //
-void RealtimeEffectManager::RealtimeProcessStart()
+void RealtimeEffectManager::ProcessStart()
 {
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
@@ -148,7 +148,7 @@ void RealtimeEffectManager::RealtimeProcessStart()
    {
       for (auto &state : mStates)
       {
-         if (state->IsRealtimeActive())
+         if (state->IsActive())
             state->GetEffect().RealtimeProcessStart();
       }
    }
@@ -157,7 +157,7 @@ void RealtimeEffectManager::RealtimeProcessStart()
 //
 // This will be called in a different thread than the main GUI thread.
 //
-size_t RealtimeEffectManager::RealtimeProcess(int group, unsigned chans, float **buffers, size_t numSamples)
+size_t RealtimeEffectManager::Process(int group, unsigned chans, float **buffers, size_t numSamples)
 {
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
@@ -190,9 +190,9 @@ size_t RealtimeEffectManager::RealtimeProcess(int group, unsigned chans, float *
    size_t called = 0;
    for (auto &state : mStates)
    {
-      if (state->IsRealtimeActive())
+      if (state->IsActive())
       {
-         state->RealtimeProcess(group, chans, ibuf, obuf, numSamples);
+         state->Process(group, chans, ibuf, obuf, numSamples);
          called++;
       }
 
@@ -230,7 +230,7 @@ size_t RealtimeEffectManager::RealtimeProcess(int group, unsigned chans, float *
 //
 // This will be called in a different thread than the main GUI thread.
 //
-void RealtimeEffectManager::RealtimeProcessEnd() noexcept
+void RealtimeEffectManager::ProcessEnd() noexcept
 {
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
@@ -241,13 +241,13 @@ void RealtimeEffectManager::RealtimeProcessEnd() noexcept
    {
       for (auto &state : mStates)
       {
-         if (state->IsRealtimeActive())
+         if (state->IsActive())
             state->GetEffect().RealtimeProcessEnd();
       }
    }
 }
 
-auto RealtimeEffectManager::GetRealtimeLatency() const -> Latency
+auto RealtimeEffectManager::GetLatency() const -> Latency
 {
    return mLatency;
 }

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -39,8 +39,6 @@ public:
    // Realtime effect processing
    bool RealtimeIsActive() const noexcept;
    bool RealtimeIsSuspended() const noexcept;
-   void RealtimeAddEffect(EffectProcessor &effect);
-   void RealtimeRemoveEffect(EffectProcessor &effect);
    void RealtimeInitialize(double rate);
    void RealtimeAddProcessor(int group, unsigned chans, float rate);
    void RealtimeFinalize();

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -38,7 +38,6 @@ public:
 
    // Realtime effect processing
    bool RealtimeIsActive() const noexcept;
-   bool RealtimeIsSuspended() const noexcept;
    void RealtimeInitialize(double rate);
    void RealtimeAddProcessor(int group, unsigned chans, float rate);
    void RealtimeFinalize();

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -19,9 +19,11 @@
 #include <vector>
 
 #include "ClientData.h"
+#include "ModuleInterface.h" // for PluginID
 
 class AudacityProject;
 class EffectProcessor;
+class RealtimeEffectList;
 class RealtimeEffectState;
 class Track;
 
@@ -121,6 +123,15 @@ public:
       AudacityProject *mpProject = nullptr;
    };
 
+   //! Main thread appends a global or per-track effect
+   /*!
+    @param pTrack if null, then state is added to the global list
+    @return if null, the given id was not found
+    */
+   RealtimeEffectState *AddState(Track *pTrack, const PluginID & id);
+   //! Main thread safely removes an effect from a list
+   void RemoveState(RealtimeEffectList &states, RealtimeEffectState &state);
+
 private:
    void ProcessStart();
    size_t Process(Track *track, float **buffers, size_t numSamples);
@@ -143,6 +154,9 @@ private:
 
    std::mutex mLock;
    Latency mLatency{ 0 };
+
+   double mRate;
+
    std::atomic<bool> mSuspended{ true };
    std::atomic<bool> mActive{ false };
 

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -37,13 +37,13 @@ public:
    static const RealtimeEffectManager & Get(const AudacityProject &project);
 
    // Realtime effect processing
-   bool RealtimeIsActive() const noexcept;
-   void RealtimeInitialize(double rate);
-   void RealtimeAddProcessor(int group, unsigned chans, float rate);
-   void RealtimeFinalize();
-   void RealtimeSuspend();
-   void RealtimeResume() noexcept;
-   Latency GetRealtimeLatency() const;
+   bool IsActive() const noexcept;
+   void Initialize(double rate);
+   void AddTrack(int group, unsigned chans, float rate);
+   void Finalize();
+   void Suspend();
+   void Resume() noexcept;
+   Latency GetLatency() const;
 
    //! Object whose lifetime encompasses one suspension of processing in one thread
    class SuspensionScope {
@@ -52,7 +52,7 @@ public:
          : mpProject{ pProject }
       {
          if (mpProject)
-            Get(*mpProject).RealtimeSuspend();
+            Get(*mpProject).Suspend();
       }
       SuspensionScope( SuspensionScope &&other )
          : mpProject{ other.mpProject }
@@ -69,7 +69,7 @@ public:
       ~SuspensionScope()
       {
          if (mpProject)
-            Get(*mpProject).RealtimeResume();
+            Get(*mpProject).Resume();
       }
 
    private:
@@ -83,7 +83,7 @@ public:
          : mpProject{ pProject }
       {
          if (mpProject)
-            Get(*mpProject).RealtimeProcessStart();
+            Get(*mpProject).ProcessStart();
       }
       ProcessScope( ProcessScope &&other )
          : mpProject{ other.mpProject }
@@ -100,7 +100,7 @@ public:
       ~ProcessScope()
       {
          if (mpProject)
-            Get(*mpProject).RealtimeProcessEnd();
+            Get(*mpProject).ProcessEnd();
       }
 
       size_t Process( int group,
@@ -108,7 +108,7 @@ public:
       {
          if (mpProject)
             return Get(*mpProject)
-               .RealtimeProcess(group, chans, buffers, numSamples);
+               .Process(group, chans, buffers, numSamples);
          else
             return numSamples; // consider them trivially processed
       }
@@ -118,9 +118,9 @@ public:
    };
 
 private:
-   void RealtimeProcessStart();
-   size_t RealtimeProcess(int group, unsigned chans, float **buffers, size_t numSamples);
-   void RealtimeProcessEnd() noexcept;
+   void ProcessStart();
+   size_t Process(int group, unsigned chans, float **buffers, size_t numSamples);
+   void ProcessEnd() noexcept;
 
    RealtimeEffectManager(const RealtimeEffectManager&) = delete;
    RealtimeEffectManager &operator=(const RealtimeEffectManager&) = delete;
@@ -132,8 +132,8 @@ private:
    Latency mLatency{ 0 };
    std::atomic<bool> mSuspended{ true };
    std::atomic<bool> mActive{ false };
-   std::vector<unsigned> mRealtimeChans;
-   std::vector<double> mRealtimeRates;
+   std::vector<unsigned> mChans;
+   std::vector<double> mRates;
 };
 
 #endif

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -22,6 +22,7 @@
 class AudacityProject;
 class EffectProcessor;
 class RealtimeEffectState;
+class Track;
 
 class AUDACITY_DLL_API RealtimeEffectManager final
    : public ClientData::Base
@@ -125,10 +126,15 @@ private:
    RealtimeEffectManager(const RealtimeEffectManager&) = delete;
    RealtimeEffectManager &operator=(const RealtimeEffectManager&) = delete;
 
+   using StateVisitor =
+      std::function<void(RealtimeEffectState &state, bool bypassed)> ;
+
+   //! Visit the per-project states first, then states for leader if not null
+   void VisitGroup(Track *leader, StateVisitor func);
+
    AudacityProject &mProject;
 
    std::mutex mLock;
-   std::vector< std::unique_ptr<RealtimeEffectState> > mStates;
    Latency mLatency{ 0 };
    std::atomic<bool> mSuspended{ true };
    std::atomic<bool> mActive{ false };

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -45,9 +45,7 @@ public:
    void RealtimeAddProcessor(int group, unsigned chans, float rate);
    void RealtimeFinalize();
    void RealtimeSuspend();
-   void RealtimeSuspendOne( EffectProcessor &effect );
    void RealtimeResume() noexcept;
-   void RealtimeResumeOne( EffectProcessor &effect );
    Latency GetRealtimeLatency() const;
 
    //! Object whose lifetime encompasses one suspension of processing in one thread

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -17,28 +17,27 @@ RealtimeEffectState::RealtimeEffectState( EffectProcessor &effect )
 {
 }
 
-bool RealtimeEffectState::RealtimeSuspend()
+bool RealtimeEffectState::Suspend()
 {
    auto result = mEffect.RealtimeSuspend();
    if ( result ) {
-      mRealtimeSuspendCount++;
+      mSuspendCount++;
    }
    return result;
 }
 
-bool RealtimeEffectState::RealtimeResume() noexcept
+bool RealtimeEffectState::Resume() noexcept
 {
    auto result = mEffect.RealtimeResume();
    if ( result ) {
-      mRealtimeSuspendCount--;
+      mSuspendCount--;
    }
    return result;
 }
 
-// RealtimeAddProcessor and RealtimeProcess use the same method of
-// determining the current processor index, so updates to one should
-// be reflected in the other.
-bool RealtimeEffectState::RealtimeAddProcessor(int group, unsigned chans, float rate)
+//! Set up processors to be visited repeatedly in Process.
+/*! The iteration over channels in AddTrack and Process must be the same */
+bool RealtimeEffectState::AddTrack(int group, unsigned chans, float rate)
 {
    auto ichans = chans;
    auto ochans = chans;
@@ -103,10 +102,9 @@ bool RealtimeEffectState::RealtimeAddProcessor(int group, unsigned chans, float 
    return true;
 }
 
-// RealtimeAddProcessor and RealtimeProcess use the same method of
-// determining the current processor group, so updates to one should
-// be reflected in the other.
-size_t RealtimeEffectState::RealtimeProcess(int group,
+//! Visit the effect processors that were added in AddTrack
+/*! The iteration over channels in AddTrack and Process must be the same */
+size_t RealtimeEffectState::Process(int group,
                                     unsigned chans,
                                     float **inbuf,
                                     float **outbuf,
@@ -225,8 +223,8 @@ size_t RealtimeEffectState::RealtimeProcess(int group,
    return len;
 }
 
-bool RealtimeEffectState::IsRealtimeActive() const noexcept
+bool RealtimeEffectState::IsActive() const noexcept
 {
-   return mRealtimeSuspendCount == 0;
+   return mSuspendCount == 0;
 }
 

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -11,6 +11,7 @@
 #include "RealtimeEffectState.h"
 
 #include "EffectInterface.h"
+#include "PluginManager.h"
 
 RealtimeEffectState::RealtimeEffectState(const PluginID & id)
 {
@@ -283,4 +284,118 @@ bool RealtimeEffectState::Finalize()
       return false;
 
    return mEffect->RealtimeFinalize();
+}
+
+const std::string &RealtimeEffectState::XMLTag()
+{
+   static const std::string result{"effect"};
+   return result;
+}
+
+static const auto idAttribute = "id";
+static const auto versionAttribute = "version";
+static const auto parametersAttribute = "parameters";
+static const auto parameterAttribute = "parameter";
+static const auto nameAttribute = "name";
+static const auto valueAttribute = "value";
+
+bool RealtimeEffectState::HandleXMLTag(
+   const std::string_view &tag, const AttributesList &attrs)
+{
+   if (tag == XMLTag()) {
+      mParameters.clear();
+      mEffect.reset();
+      mID.clear();
+
+      for (auto pair : attrs) {
+         auto attr = pair.first;
+         auto value = pair.second;
+
+         if (attr == idAttribute) {
+            SetID(value.ToWString());
+            if (!mEffect) {
+               // TODO - complain!!!!
+            }
+         }
+         else if (attr == versionAttribute) {
+         }
+      }
+
+      return true;
+   }
+   else if (tag == parametersAttribute)
+      return true;
+   else if (tag == parameterAttribute) {
+      wxString n;
+      wxString v;
+
+      for (auto pair : attrs) {
+         auto attr = pair.first;
+         auto value = pair.second;
+
+         if (attr == nameAttribute)
+            n = value.ToWString();
+         else if (attr == valueAttribute)
+            v = value.ToWString();
+      }
+
+      mParameters += wxString::Format(wxT("\"%s=%s\" "), n, v);
+
+      return true;
+   }
+   else
+      return false;
+}
+
+void RealtimeEffectState::HandleXMLEndTag(const std::string_view &tag)
+{
+   if (tag == XMLTag()) {
+      if (mEffect && !mParameters.empty()) {
+         CommandParameters parms(mParameters);
+         mEffect->SetAutomationParameters(parms);
+      }
+      mParameters.clear();
+   }
+}
+
+XMLTagHandler *RealtimeEffectState::HandleXMLChild(const std::string_view &tag)
+{
+   // Tag may be for the state, or the list of parameters, or for one parameter.
+   // See the writing method below.  All are handled by this
+   return this;
+}
+
+void RealtimeEffectState::WriteXML(XMLWriter &xmlFile)
+{
+   if (!mEffect)
+      return;
+
+   xmlFile.StartTag(XMLTag());
+   xmlFile.WriteAttr(idAttribute, XMLWriter::XMLEsc(PluginManager::GetID(mEffect.get())));
+   xmlFile.WriteAttr(versionAttribute, XMLWriter::XMLEsc(mEffect->GetVersion()));
+
+   CommandParameters cmdParms;
+   if (mEffect->GetAutomationParameters(cmdParms)) {
+      xmlFile.StartTag(parametersAttribute);
+
+      wxString entryName;
+      long entryIndex;
+      bool entryKeepGoing;
+
+      entryKeepGoing = cmdParms.GetFirstEntry(entryName, entryIndex);
+      while (entryKeepGoing) {
+         wxString entryValue = cmdParms.Read(entryName, "");
+
+         xmlFile.StartTag(parameterAttribute);
+         xmlFile.WriteAttr(nameAttribute, XMLWriter::XMLEsc(entryName));
+         xmlFile.WriteAttr(valueAttribute, XMLWriter::XMLEsc(entryValue));
+         xmlFile.EndTag(parameterAttribute);
+
+         entryKeepGoing = cmdParms.GetNextEntry(entryName, entryIndex);
+      }
+
+      xmlFile.EndTag(parametersAttribute);
+   }
+
+   xmlFile.EndTag(XMLTag());
 }

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -12,14 +12,21 @@
 #define __AUDACITY_REALTIMEEFFECTSTATE_H__
 
 #include <atomic>
+#include <memory>
 #include <vector>
 #include <cstddef>
+#include "GlobalVariable.h"
+#include "ModuleInterface.h" // for PluginID
 
 class EffectProcessor;
 
 class RealtimeEffectState
 {
 public:
+   struct AUDACITY_DLL_API EffectFactory : GlobalHook<EffectFactory,
+      std::unique_ptr<EffectProcessor>(const PluginID &)
+   >{};
+
    explicit RealtimeEffectState( EffectProcessor &effect );
 
    EffectProcessor &GetEffect() const { return mEffect; }

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -27,22 +27,39 @@ public:
       std::unique_ptr<EffectProcessor>(const PluginID &)
    >{};
 
-   explicit RealtimeEffectState( EffectProcessor &effect );
+   explicit RealtimeEffectState(const PluginID & id);
+   ~RealtimeEffectState();
 
-   EffectProcessor &GetEffect() const { return mEffect; }
+   //! May be called with nonempty id at most once in the lifetime of a state
+   /*!
+    Call with empty id is ignored.
+    Called by the constructor that takes an id */
+   void SetID(const PluginID & id);
+   EffectProcessor *GetEffect();
 
    bool Suspend();
    bool Resume() noexcept;
+
+   //! Main thread sets up for playback
+   bool Initialize(double rate);
    bool AddTrack(int group, unsigned chans, float rate);
+   //! Worker thread begins a batch of samples
+   bool ProcessStart();
+   //! Worker thread processes part of a batch of samples
    size_t Process(int group,
       unsigned chans, float **inbuf, float **outbuf, size_t numSamples);
+   //! Worker thread finishes a batch of samples
+   bool ProcessEnd();
    bool IsActive() const noexcept;
+   //! Main thread cleans up playback
+   bool Finalize();
 
 private:
-   EffectProcessor &mEffect;
+   PluginID mID;
+   std::unique_ptr<EffectProcessor> mEffect;
 
    std::vector<int> mGroupProcessor;
-   int mCurrentProcessor;
+   size_t mCurrentProcessor{ 0 };
 
    std::atomic<int> mSuspendCount{ 1 };    // Effects are initially suspended
 };

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -24,12 +24,12 @@ public:
 
    EffectProcessor &GetEffect() const { return mEffect; }
 
-   bool RealtimeSuspend();
-   bool RealtimeResume() noexcept;
-   bool RealtimeAddProcessor(int group, unsigned chans, float rate);
-   size_t RealtimeProcess(int group,
+   bool Suspend();
+   bool Resume() noexcept;
+   bool AddTrack(int group, unsigned chans, float rate);
+   size_t Process(int group,
       unsigned chans, float **inbuf, float **outbuf, size_t numSamples);
-   bool IsRealtimeActive() const noexcept;
+   bool IsActive() const noexcept;
 
 private:
    EffectProcessor &mEffect;
@@ -37,7 +37,7 @@ private:
    std::vector<int> mGroupProcessor;
    int mCurrentProcessor;
 
-   std::atomic<int> mRealtimeSuspendCount{ 1 };    // Effects are initially suspended
+   std::atomic<int> mSuspendCount{ 1 };    // Effects are initially suspended
 };
 
 #endif // __AUDACITY_REALTIMEEFFECTSTATE_H__

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -17,10 +17,11 @@
 #include <cstddef>
 #include "GlobalVariable.h"
 #include "ModuleInterface.h" // for PluginID
+#include "XMLTagHandler.h"
 
 class EffectProcessor;
 
-class RealtimeEffectState
+class RealtimeEffectState : public XMLTagHandler
 {
 public:
    struct AUDACITY_DLL_API EffectFactory : GlobalHook<EffectFactory,
@@ -54,8 +55,16 @@ public:
    //! Main thread cleans up playback
    bool Finalize();
 
+   static const std::string &XMLTag();
+   bool HandleXMLTag(
+      const std::string_view &tag, const AttributesList &attrs) override;
+   void HandleXMLEndTag(const std::string_view &tag) override;
+   XMLTagHandler *HandleXMLChild(const std::string_view &tag) override;
+   void WriteXML(XMLWriter &xmlFile);
+
 private:
    PluginID mID;
+   wxString mParameters;  // Used only during deserialization
    std::unique_ptr<EffectProcessor> mEffect;
 
    std::vector<int> mGroupProcessor;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 #include <cstddef>
 #include "GlobalVariable.h"
@@ -20,6 +21,7 @@
 #include "XMLTagHandler.h"
 
 class EffectProcessor;
+class Track;
 
 class RealtimeEffectState : public XMLTagHandler
 {
@@ -43,12 +45,11 @@ public:
 
    //! Main thread sets up for playback
    bool Initialize(double rate);
-   bool AddTrack(int group, unsigned chans, float rate);
+   bool AddTrack(Track *track, unsigned chans, float rate);
    //! Worker thread begins a batch of samples
    bool ProcessStart();
    //! Worker thread processes part of a batch of samples
-   size_t Process(int group,
-      unsigned chans, float **inbuf, float **outbuf, size_t numSamples);
+   size_t Process(Track *track, unsigned chans, float **inbuf,  float **outbuf, size_t numSamples);
    //! Worker thread finishes a batch of samples
    bool ProcessEnd();
    bool IsActive() const noexcept;
@@ -67,8 +68,8 @@ private:
    wxString mParameters;  // Used only during deserialization
    std::unique_ptr<EffectProcessor> mEffect;
 
-   std::vector<int> mGroupProcessor;
    size_t mCurrentProcessor{ 0 };
+   std::unordered_map<Track *, size_t> mGroups;
 
    std::atomic<int> mSuspendCount{ 1 };    // Effects are initially suspended
 };

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -910,7 +910,7 @@ BaseItemSharedPtr GenerateMenu()
 static const ReservedCommandFlag
 &IsRealtimeNotActiveFlag() { static ReservedCommandFlag flag{
    [](const AudacityProject &project){
-      return !RealtimeEffectManager::Get(project).RealtimeIsActive();
+      return !RealtimeEffectManager::Get(project).IsActive();
    }
 }; return flag; }  //lll
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -549,7 +549,7 @@ BEGIN_POPUP_MENU(WaveTrackMenuTable)
    []( PopupMenuHandler &handler ) -> bool {
       auto &project =
          static_cast< WaveTrackMenuTable& >( handler ).mpData->project;
-      return RealtimeEffectManager::Get(project).RealtimeIsActive() &&
+      return RealtimeEffectManager::Get(project).IsActive() &&
          ProjectAudioIO::Get( project ).IsAudioActive();
    };
 


### PR DESCRIPTION
Resolves: #2458 

Merge parts of the work of @lllucius that reorganize the realtime effects into separate per-project and per-track stacks, and
include the persistency of effect settings in the .aup3 project file.

The user interface to access realtime effects is temporarily removed in the intermediate commits, then restored in the last
one, but this restored version is only provisional pending further release 3.2 developments.  It still applies only one effect
per-project, while that effect's non-modal dialog is open.

As mentioned in other code and commit comments, still unresolved problems are
* allowing independent settings for multiple occurrences of an effect in stacks
* undo and redo of changes to effect stacks

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
