### PR TITLE
Fix bug 2472

### DIFF
--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -703,7 +703,7 @@ bool AUPImportFileHandle::HandleProject(XMLTagHandler *&handler)
       // Viewinfo.SelectedRegion
       else if (attr == "sel0")
       {
-         if (!value.TryGet(dValue) || (dValue < 0.0))
+         if (!value.TryGet(dValue))
          {
             return SetError(XO("Invalid project 'sel0' attribute."));
          }
@@ -712,7 +712,7 @@ bool AUPImportFileHandle::HandleProject(XMLTagHandler *&handler)
       }
       else if (attr == "sel1")
       {
-         if (!value.TryGet(dValue) || (dValue < 0.0))
+         if (!value.TryGet(dValue))
          {
             return SetError(XO("Invalid project 'sel1' attribute."));
          }


### PR DESCRIPTION
Selection before zero is legal in both Audacity 2.x and 3.x

Resolves: https://github.com/audacity/audacity/issues/2472

*Don't error on negative selection times*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
