### PR TITLE
Perform the libraries related magic for modules on all platforms

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -379,12 +379,34 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
       )
       if( CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" )
          add_custom_command(
-	    TARGET ${TARGET}
+	         TARGET ${TARGET}
             COMMAND ${CMAKE_COMMAND}
-	       -D SRC="${_MODDIR}/${TARGET}.so"
+	            -D SRC="${_MODDIR}/${TARGET}.so"
                -D WXWIN="${_SHARED_PROXY_BASE_PATH}/$<CONFIG>"
                -P ${AUDACITY_MODULE_PATH}/CopyLibs.cmake
             POST_BUILD )
+      elseif( CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+         add_custom_command(
+            TARGET
+               ${TARGET}
+            COMMAND
+               ${CMAKE_COMMAND} -D SRC="${_MODDIR}/${TARGET}.dll"
+                              -D DST="${_EXEDIR}"
+                              -D WXWIN="${_SHARED_PROXY_BASE_PATH}/$<CONFIG>/"
+                              -P ${AUDACITY_MODULE_PATH}/CopyLibs.cmake
+            POST_BUILD
+         )
+      else()
+         add_custom_command(
+            TARGET
+               ${TARGET}
+            COMMAND
+               ${CMAKE_COMMAND} -D SRC="${_MODDIR}/${TARGET}.so"
+                              -D DST="${_PKGLIB}"
+                              -D WXWIN="${_SHARED_PROXY_BASE_PATH}/$<CONFIG>"
+                              -P ${AUDACITY_MODULE_PATH}/CopyLibs.cmake
+            POST_BUILD
+         )
       endif()
    else()
       set( ATTRIBUTES "shape=octagon" )


### PR DESCRIPTION
CopyLibs was invoked for modules only on macOS.

However, if the module depends on different set of libraries - Audacity will fail to load it.

Resolves: #2042

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
