### PR TITLE
Fix bug 2482

### DIFF
--- a/src/TagsEditor.cpp
+++ b/src/TagsEditor.cpp
@@ -232,7 +232,8 @@ TagsEditorDialog::TagsEditorDialog(wxWindow * parent,
    Layout();
    Fit();
    Center();
-   SetSizeHints(GetSize());
+   wxSize sz = GetSize();
+   SetSizeHints(sz.x, std::min(sz.y, 600));
 
    // Restore the original tags because TransferDataToWindow() will be called again
    mLocal.Clear();


### PR DESCRIPTION
Always allow Metadata Editor to be resized to reasonable height.

Resolves: https://github.com/audacity/audacity/issues/2482

*(short description of the changes and the motivation to make the changes)*
See bug #2482 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
