### PR TITLE
Fix GlobalHook implementation for Windows ...

### DIFF
--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -63,8 +63,9 @@ class SAMPLE_TRACK_API Mixer {
     {
     public:
        //! Hook function for default time warp
-       using DefaultWarp =
-          GlobalHook<WarpOptions, const BoundedEnvelope*(const TrackList&)>;
+       struct SAMPLE_TRACK_API DefaultWarp : GlobalHook<DefaultWarp,
+          const BoundedEnvelope*(const TrackList&)
+       >{};
 
        //! Construct using the default warp function
        explicit WarpOptions(const TrackList &list);

--- a/libraries/lib-transactions/TransactionScope.h
+++ b/libraries/lib-transactions/TransactionScope.h
@@ -28,8 +28,9 @@ class TRANSACTIONS_API TransactionScope
 {
 public:
    //! Type of function supplying implementation of steps
-   using Factory = GlobalHook< TransactionScope,
-      std::unique_ptr<TransactionScopeImpl>(AudacityProject &) >;
+   struct TRANSACTIONS_API Factory : GlobalHook<Factory,
+      std::unique_ptr<TransactionScopeImpl>(AudacityProject &)
+   > {};
 
    //! Construct from a project
    /*!

--- a/src/KeyboardCapture.h
+++ b/src/KeyboardCapture.h
@@ -40,7 +40,9 @@ namespace KeyboardCapture
 
    //! Pre-filter is called before passing the event to the captured window
    /*! If it returns false, then skip the event entirely */
-   using PreFilter = GlobalHook<struct PreFilterTag, bool( wxKeyEvent& )>;
+   struct AUDACITY_DLL_API PreFilter : GlobalHook<PreFilter,
+      bool( wxKeyEvent& )
+   >{};
    
    //! Post-filter is conditionally called after passing the event to the window
    /*!
@@ -50,7 +52,9 @@ namespace KeyboardCapture
        wxKEY_DOWN or a wxKEY_UP event; if it returns false, then the event is
        skipped
     */
-   using PostFilter = GlobalHook<struct PostFilterTag, bool( wxKeyEvent& )>;
+   struct AUDACITY_DLL_API PostFilter : GlobalHook<PostFilter,
+      bool( wxKeyEvent& )
+   >{};
 
    /// \brief a function useful to implement a focus event handler
    /// The window releases the keyboard if the event is for killing focus,

--- a/src/SampleBlock.h
+++ b/src/SampleBlock.h
@@ -105,8 +105,9 @@ class SampleBlockFactory
 {
 public:
    //! Global factory of per-project factories of sample blocks
-   using Factory = GlobalHook<SampleBlockFactory,
-      SampleBlockFactoryPtr( AudacityProject& )>;
+   struct AUDACITY_DLL_API Factory : GlobalHook<Factory,
+      SampleBlockFactoryPtr( AudacityProject& )
+   >{};
 
    // Invoke the installed factory (throw an exception if none was installed)
    static SampleBlockFactoryPtr New( AudacityProject &project );

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -65,7 +65,9 @@ class AUDACITY_DLL_API CommandManager final
 
    // Interception of menu item handling.
    // If it returns true, bypass the usual dispatch of commands.
-   using GlobalMenuHook = GlobalHook<CommandManager, bool(const CommandID&)>;
+   struct AUDACITY_DLL_API GlobalMenuHook : GlobalHook<GlobalMenuHook,
+      bool(const CommandID&)
+   >{};
 
    //
    // Constructor / Destructor

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -56,7 +56,9 @@ class AUDACITY_DLL_API ToolManager final
 
  public:
    // a hook function to break dependency of ToolManager on ProjectWindow
-   using TopPanelHook = GlobalHook< ToolManager, wxWindow*( wxWindow& ) >;
+   struct AUDACITY_DLL_API TopPanelHook : GlobalHook<TopPanelHook,
+      wxWindow*( wxWindow& )
+   >{};
 
    static ToolManager &Get( AudacityProject &project );
    static const ToolManager &Get( const AudacityProject &project );

--- a/src/tracks/ui/CommonTrackPanelCell.h
+++ b/src/tracks/ui/CommonTrackPanelCell.h
@@ -31,9 +31,9 @@ class AUDACITY_DLL_API CommonTrackPanelCell /* not final */
 {
 public:
    // Function to dispatch mouse wheel events
-   using MouseWheelHook = GlobalHook< CommonTrackPanelCell,
+   struct AUDACITY_DLL_API MouseWheelHook : GlobalHook<MouseWheelHook,
       unsigned(const TrackPanelMouseEvent &evt, AudacityProject *pProject)
-   >;
+   >{};
 
    CommonTrackPanelCell()
    {}

--- a/src/widgets/VetoDialogHook.h
+++ b/src/widgets/VetoDialogHook.h
@@ -17,6 +17,8 @@
 class wxDialog;
 
 //! Call before `Show`-ing certain dialogs; don't show if it returns true
-using VetoDialogHook = GlobalHook<struct VetoDialogHookTag, bool( wxDialog* )>;
+struct AUDACITY_DLL_API VetoDialogHook : GlobalHook<VetoDialogHook,
+   bool( wxDialog* )
+> {};
 
 #endif


### PR DESCRIPTION
... Now it works just like subclasses of ClientData::Site :

Use GlobalHook by deriving a struct from it, and give the correct visibility
to the struct, which will guarantee generation of unique non-inline functions in
one library (or the executable), with the needed static local variables.

The first template parameter is thus now another "CRTP" parameter.

Resolves: #2483

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
