### PR TITLE
Fixes build failure when empty RevisionIdent.h is generated

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,9 @@ elseif( GIT_FOUND )
 else()
    # No Git installed and no version data is available.
    # Generate an empty file and let AboutDialog do the rest
-   file( WRITE "${_PRVDIR}/RevisionIdent.h" )
+   # WRITE, unlike TOUCH, will create any directories needed
+   # (see https://github.com/audacity/audacity/issues/2163)
+   file( WRITE "${_PRVDIR}/RevisionIdent.h" "" )
 endif()
 
 # Handle Audio Units option
@@ -1328,7 +1330,7 @@ else()
                           -P ${AUDACITY_MODULE_PATH}/CopyLibs.cmake
       POST_BUILD
    )
-   
+
    add_executable(findlib ../linux/findlib.c)
    target_link_libraries(findlib ${CMAKE_DL_LIBS})
 endif()


### PR DESCRIPTION
Using `file(WRITE)` ensures that all parent directories exist.

Resolves: #2163 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
