### PR TITLE
Realtime effect manager rewrite part 3

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -230,7 +230,7 @@ public:
 
    virtual bool RealtimeInitialize() = 0;
    virtual bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) = 0;
-   virtual bool RealtimeFinalize() = 0;
+   virtual bool RealtimeFinalize() noexcept = 0;
    virtual bool RealtimeSuspend() = 0;
    virtual bool RealtimeResume() noexcept = 0;
    virtual bool RealtimeProcessStart() = 0;

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -142,6 +142,9 @@ AudioIO *AudioIO::Get()
    return static_cast< AudioIO* >( AudioIOBase::Get() );
 }
 
+struct AudioIoCallback::TransportState {
+};
+
 // static
 int AudioIoCallback::mNextStreamToken = 0;
 double AudioIoCallback::mCachedBestRateOut;
@@ -938,6 +941,8 @@ int AudioIO::StartStream(const TransportTracks &tracks,
       }
    }
 
+   mpTransportState = std::make_unique<TransportState>();
+
 #ifdef EXPERIMENTAL_AUTOMATED_INPUT_LEVEL_ADJUSTMENT
    AILASetStartTime();
 #endif
@@ -1271,6 +1276,8 @@ void AudioIO::StartStreamCleanup(bool bOnlyBuffers)
          RealtimeEffectManager::Get(*pOwningProject).Finalize();
    }
 
+   mpTransportState.reset();
+
    mPlaybackBuffers.reset();
    mPlaybackMixers.clear();
    mCaptureBuffers.reset();
@@ -1422,6 +1429,8 @@ void AudioIO::StopStream()
       if (auto pOwningProject = mOwningProject.lock())
          RealtimeEffectManager::Get(*pOwningProject).Finalize();
    }
+
+   mpTransportState.reset();
 
    for( auto &ext : Extensions() )
       ext.StopOtherStream();

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1349,13 +1349,6 @@ void AudioIO::StopStream()
 
    wxMutexLocker locker(mSuspendAudioThread);
 
-   // No longer need effects processing
-   if (mNumPlaybackChannels > 0)
-   {
-      if (auto pOwningProject = mOwningProject.lock())
-         RealtimeEffectManager::Get(*pOwningProject).Finalize();
-   }
-
    //
    // We got here in one of two ways:
    //
@@ -1420,6 +1413,14 @@ void AudioIO::StopStream()
       Pa_CloseStream( mPortStreamV19 );
 
       mPortStreamV19 = NULL;
+   }
+
+   // No longer need effects processing. This must be done after the stream is stopped
+   // to prevent the callback from being invoked after the effects are finalized.
+   if (mNumPlaybackChannels > 0)
+   {
+      if (auto pOwningProject = mOwningProject.lock())
+         RealtimeEffectManager::Get(*pOwningProject).Finalize();
    }
 
    for( auto &ext : Extensions() )

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -404,6 +404,27 @@ AudioIO::~AudioIO()
    mThread.reset();
 }
 
+RealtimeEffectState *AudioIO::AddState(AudacityProject &project,
+   Track *pTrack, const PluginID & id)
+{
+   RealtimeEffects::InitializationScope *pInit = nullptr;
+   if (mpTransportState)
+      if (auto pProject = GetOwningProject(); pProject.get() == &project)
+         pInit = &*mpTransportState->mpRealtimeInitialization;
+   return RealtimeEffectManager::Get(project).AddState(pInit, pTrack, id);
+   return nullptr;
+}
+
+void AudioIO::RemoveState(AudacityProject &project,
+   Track *pTrack, RealtimeEffectState &state)
+{
+   RealtimeEffects::InitializationScope *pInit = nullptr;
+   if (mpTransportState)
+      if (auto pProject = GetOwningProject(); pProject.get() == &project)
+         pInit = &*mpTransportState->mpRealtimeInitialization;
+   RealtimeEffectManager::Get(project).RemoveState(pInit, pTrack, state);
+}
+
 void AudioIO::SetMixer(int inputSource, float recordVolume,
                        float playbackVolume)
 {

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -425,6 +425,14 @@ void AudioIO::RemoveState(AudacityProject &project,
    RealtimeEffectManager::Get(project).RemoveState(pInit, pTrack, state);
 }
 
+RealtimeEffects::SuspensionScope AudioIO::SuspensionScope()
+{
+   if (mpTransportState && mpTransportState->mpRealtimeInitialization)
+      return RealtimeEffects::SuspensionScope{
+         *mpTransportState->mpRealtimeInitialization, mOwningProject };
+   return {};
+}
+
 void AudioIO::SetMixer(int inputSource, float recordVolume,
                        float playbackVolume)
 {

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2394,7 +2394,7 @@ bool AudioIoCallback::FillOutputBuffers(
 
 {
    auto pProject = mOwningProject.lock();
-   RealtimeEffectManager::ProcessScope scope{ pProject.get() };
+   RealtimeEffects::ProcessingScope scope{ pProject.get() };
 
    int chanCnt = 0;
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2393,8 +2393,7 @@ bool AudioIoCallback::FillOutputBuffers(
    // ------ End of MEMORY ALLOCATION ---------------
 
 {
-   auto pProject = mOwningProject.lock();
-   RealtimeEffects::ProcessingScope scope{ pProject.get() };
+   RealtimeEffects::ProcessingScope scope{ mOwningProject };
 
    int chanCnt = 0;
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2390,7 +2390,9 @@ bool AudioIoCallback::FillOutputBuffers(
    // ------ End of MEMORY ALLOCATION ---------------
 
 {
-   RealtimeEffects::ProcessingScope scope{ mOwningProject };
+   std::optional<RealtimeEffects::ProcessingScope> pScope;
+   if (mpTransportState && mpTransportState->mpRealtimeInitialization)
+      pScope.emplace( *mpTransportState->mpRealtimeInitialization, mOwningProject );
 
    int chanCnt = 0;
 
@@ -2486,7 +2488,8 @@ bool AudioIoCallback::FillOutputBuffers(
 
       // Do realtime effects
       if( !dropQuickly && len > 0 ) {
-         scope.Process(chans[0], tempBufs, len);
+         if (pScope)
+            pScope->Process(chans[0], tempBufs, len);
 
          // Mix the results with the existing output (software playthrough) and
          // apply panning.  If post panning effects are desired, the panning would

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -53,6 +53,8 @@ struct PaStreamCallbackTimeInfo;
 typedef unsigned long PaStreamCallbackFlags;
 typedef int PaError;
 
+namespace RealtimeEffects { class SuspensionScope; }
+
 bool ValidateDeviceNames();
 
 /*!
@@ -382,6 +384,8 @@ public:
    //! Forwards to RealtimeEffectManager::RemoveState with proper init scope
    void RemoveState(AudacityProject &project,
       Track *pTrack, RealtimeEffectState &state);
+
+   RealtimeEffects::SuspensionScope SuspensionScope();
 
    /** \brief Start up Portaudio for capture and recording as needed for
     * input monitoring and software playthrough only

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -24,6 +24,7 @@
 #include <utility>
 #include <wx/atomic.h> // member variable
 
+#include "ModuleInterface.h" // for PluginID
 #include "Observer.h"
 #include "SampleCount.h"
 #include "SampleFormat.h"
@@ -33,6 +34,7 @@ class AudioIOBase;
 class AudioIO;
 class RingBuffer;
 class Mixer;
+class RealtimeEffectState;
 class Resample;
 class AudioThread;
 
@@ -42,6 +44,7 @@ class PlayableTrack;
 using PlayableTrackConstArray =
    std::vector < std::shared_ptr < const PlayableTrack > >;
 
+class Track;
 class WaveTrack;
 using WaveTrackArray = std::vector < std::shared_ptr < WaveTrack > >;
 using WaveTrackConstArray = std::vector < std::shared_ptr < const WaveTrack > >;
@@ -371,6 +374,14 @@ class AUDACITY_DLL_API AudioIO final
 public:
    // This might return null during application startup or shutdown
    static AudioIO *Get();
+
+   //! Forwards to RealtimeEffectManager::AddState with proper init scope
+   RealtimeEffectState *AddState(AudacityProject &project,
+      Track *pTrack, const PluginID & id);
+
+   //! Forwards to RealtimeEffectManager::RemoveState with proper init scope
+   void RemoveState(AudacityProject &project,
+      Track *pTrack, RealtimeEffectState &state);
 
    /** \brief Start up Portaudio for capture and recording as needed for
     * input monitoring and software playthrough only

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -345,6 +345,10 @@ protected:
    RecordingSchedule mRecordingSchedule{};
    PlaybackSchedule mPlaybackSchedule;
 
+   struct TransportState;
+   //! Holds some state for duration of playback or recording
+   std::unique_ptr<TransportState> mpTransportState;
+
 private:
    /*!
     Privatize the inherited array but give access by Extensions().

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -160,7 +160,7 @@ bool EffectBassTreble::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), floa
    return true;
 }
 
-bool EffectBassTreble::RealtimeFinalize()
+bool EffectBassTreble::RealtimeFinalize() noexcept
 {
    mSlaves.clear();
 

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -62,7 +62,7 @@ public:
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    size_t RealtimeProcess(int group,
                                float **inbuf,
                                float **outbuf,

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -258,7 +258,7 @@ bool EffectDistortion::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), floa
    return true;
 }
 
-bool EffectDistortion::RealtimeFinalize()
+bool EffectDistortion::RealtimeFinalize() noexcept
 {
    mSlaves.clear();
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -84,7 +84,7 @@ public:
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    size_t RealtimeProcess(int group,
                                float **inbuf,
                                float **outbuf,

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -386,7 +386,7 @@ bool Effect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
    return true;
 }
 
-bool Effect::RealtimeFinalize()
+bool Effect::RealtimeFinalize() noexcept
 {
    if (mClient)
    {

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -140,7 +140,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart() override;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -714,7 +714,7 @@ void EffectUIHost::OnEnable(wxCommandEvent & WXUNUSED(evt))
    if (mEnabled)
       mSuspensionScope.reset();
    else
-      mSuspensionScope.emplace(mProject.weak_from_this());
+      mSuspensionScope.emplace(AudioIO::Get()->SuspensionScope());
 
    UpdateControls();
 }

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1138,8 +1138,8 @@ void EffectUIHost::LoadUserPresets()
 void EffectUIHost::InitializeRealtime()
 {
    if (mSupportsRealtime && !mInitialized) {
-      mpState = RealtimeEffectManager::Get(mProject)
-         .AddState(nullptr, PluginManager::GetID(&mEffect));
+      mpState = AudioIO::Get()->AddState(mProject,
+         nullptr, PluginManager::GetID(&mEffect));
       /*
       ProjectHistory::Get(mProject).PushState(
          XO("Added %s effect").Format(mpState->GetEffect()->GetName()),
@@ -1166,9 +1166,7 @@ void EffectUIHost::CleanupRealtime()
 {
    if (mSupportsRealtime && mInitialized) {
       if (mpState) {
-         auto &list = RealtimeEffectList::Get(mProject);
-         RealtimeEffectManager::Get(mProject)
-            .RemoveState(list, *mpState);
+         AudioIO::Get()->RemoveState(mProject, nullptr, *mpState);
       /*
          ProjectHistory::Get(mProject).PushState(
             XO("Removed %s effect").Format(mpState->GetEffect()->GetName()),

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -165,6 +165,7 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
                    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMINIMIZE_BOX | wxMAXIMIZE_BOX)
 , mEffect{ effect }
 , mClient{ client }
+, mProject{ project }
 {
 #if defined(__WXMAC__)
    // Make sure the effect window actually floats above the main window
@@ -176,8 +177,6 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
    
    mParent = parent;
    mClient = client;
-   
-   mProject = &project;
    
    mInitialized = false;
    mSupportsRealtime = false;
@@ -383,7 +382,7 @@ bool EffectUIHost::Initialize()
 {
    {
       auto gAudioIO = AudioIO::Get();
-      mDisableTransport = !gAudioIO->IsAvailable(*mProject);
+      mDisableTransport = !gAudioIO->IsAvailable(mProject);
       mPlaying = gAudioIO->IsStreamActive(); // not exactly right, but will suffice
       mCapturing = gAudioIO->IsStreamActive() && gAudioIO->GetNumCaptureChannels() > 0 && !gAudioIO->IsMonitoring();
    }
@@ -519,7 +518,7 @@ void EffectUIHost::OnClose(wxCloseEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnApply(wxCommandEvent & evt)
 {
-   auto &project = *mProject;
+   auto &project = mProject;
 
    // On wxGTK (wx2.8.12), the default action is still executed even if
    // the button is disabled.  This appears to affect all wxDialogs, not
@@ -715,7 +714,7 @@ void EffectUIHost::OnEnable(wxCommandEvent & WXUNUSED(evt))
    if (mEnabled)
       mSuspensionScope.reset();
    else
-      mSuspensionScope.emplace(mProject->weak_from_this());
+      mSuspensionScope.emplace(mProject.weak_from_this());
 
    UpdateControls();
 }
@@ -738,12 +737,12 @@ void EffectUIHost::OnPlay(wxCommandEvent & WXUNUSED(evt))
    {
       auto gAudioIO = AudioIO::Get();
       mPlayPos = gAudioIO->GetStreamTime();
-      auto &projectAudioManager = ProjectAudioManager::Get( *mProject );
+      auto &projectAudioManager = ProjectAudioManager::Get( mProject );
       projectAudioManager.Stop();
    }
    else
    {
-      auto &viewInfo = ViewInfo::Get( *mProject );
+      auto &viewInfo = ViewInfo::Get( mProject );
       const auto &selectedRegion = viewInfo.selectedRegion;
       const auto &playRegion = viewInfo.playRegion;
       if ( playRegion.Active() )
@@ -763,10 +762,10 @@ void EffectUIHost::OnPlay(wxCommandEvent & WXUNUSED(evt))
          mPlayPos = mRegion.t1();
       }
       
-      auto &projectAudioManager = ProjectAudioManager::Get( *mProject );
+      auto &projectAudioManager = ProjectAudioManager::Get( mProject );
       projectAudioManager.PlayPlayRegion(
                                          SelectedRegion(mPlayPos, mRegion.t1()),
-                                         DefaultPlayOptions( *mProject ),
+                                         DefaultPlayOptions( mProject ),
                                          PlayMode::normalPlay );
    }
 }
@@ -820,7 +819,7 @@ void EffectUIHost::OnPlayback(AudioIOEvent evt)
 {
    if (evt.on)
    {
-      if (evt.pProject != mProject)
+      if (evt.pProject != &mProject)
       {
          mDisableTransport = true;
       }
@@ -837,7 +836,7 @@ void EffectUIHost::OnPlayback(AudioIOEvent evt)
    
    if (mPlaying)
    {
-      mRegion = ViewInfo::Get( *mProject ).selectedRegion;
+      mRegion = ViewInfo::Get( mProject ).selectedRegion;
       mPlayPos = mRegion.t0();
    }
    
@@ -848,7 +847,7 @@ void EffectUIHost::OnCapture(AudioIOEvent evt)
 {
    if (evt.on)
    {
-      if (evt.pProject != mProject)
+      if (evt.pProject != &mProject)
       {
          mDisableTransport = true;
       }
@@ -1139,7 +1138,7 @@ void EffectUIHost::LoadUserPresets()
 void EffectUIHost::InitializeRealtime()
 {
    if (mSupportsRealtime && !mInitialized) {
-      mpState = RealtimeEffectManager::Get(*mProject)
+      mpState = RealtimeEffectManager::Get(mProject)
          .AddState(nullptr, PluginManager::GetID(&mEffect));
       /*
       ProjectHistory::Get(mProject).PushState(
@@ -1167,8 +1166,8 @@ void EffectUIHost::CleanupRealtime()
 {
    if (mSupportsRealtime && mInitialized) {
       if (mpState) {
-         auto &list = RealtimeEffectList::Get(*mProject);
-         RealtimeEffectManager::Get(*mProject)
+         auto &list = RealtimeEffectList::Get(mProject);
+         RealtimeEffectManager::Get(mProject)
             .RemoveState(list, *mpState);
       /*
          ProjectHistory::Get(mProject).PushState(

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -715,7 +715,7 @@ void EffectUIHost::OnEnable(wxCommandEvent & WXUNUSED(evt))
    if (mEnabled)
       mSuspensionScope.reset();
    else
-      mSuspensionScope.emplace(mProject);
+      mSuspensionScope.emplace(mProject->weak_from_this());
 
    UpdateControls();
 }

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -94,7 +94,7 @@ private:
 private:
    Observer::Subscription mSubscription;
 
-   AudacityProject *mProject;
+   AudacityProject &mProject;
    wxWindow *mParent;
    Effect &mEffect;
    EffectUIClientInterface &mClient;

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -132,7 +132,7 @@ private:
    double mPlayPos;
 
    bool mDismissed{};
-   std::optional<RealtimeEffectManager::SuspensionScope> mSuspensionScope;
+   std::optional<RealtimeEffects::SuspensionScope> mSuspensionScope;
 
 #if wxDEBUG_LEVEL
    // Used only in an assertion

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -180,7 +180,7 @@ bool EffectPhaser::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sa
    return true;
 }
 
-bool EffectPhaser::RealtimeFinalize()
+bool EffectPhaser::RealtimeFinalize() noexcept
 {
    mSlaves.clear();
 

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -68,7 +68,7 @@ public:
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    size_t RealtimeProcess(int group,
                                        float **inbuf,
                                        float **outbuf,

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -280,9 +280,13 @@ RealtimeEffectManager::AddState(
       ? RealtimeEffectList::Get(*pLeader)
       : RealtimeEffectList::Get(mProject);
 
-   if (mActive && !pScope)
-      return nullptr;
-   RealtimeEffects::SuspensionScope scope{ mProject.weak_from_this() };
+   std::optional<RealtimeEffects::SuspensionScope> myScope;
+   if (mActive) {
+      if (pScope)
+         myScope.emplace(*pScope, mProject.weak_from_this());
+      else
+         return nullptr;
+   }
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 
@@ -320,9 +324,13 @@ void RealtimeEffectManager::RemoveState(
       ? RealtimeEffectList::Get(*pLeader)
       : RealtimeEffectList::Get(mProject);
 
-   if (mActive && !pScope)
-      return;
-   RealtimeEffects::SuspensionScope scope{ mProject.weak_from_this() };
+   std::optional<RealtimeEffects::SuspensionScope> myScope;
+   if (mActive) {
+      if (pScope)
+         myScope.emplace(*pScope, mProject.weak_from_this());
+      else
+         return;
+   }
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -55,7 +55,7 @@ bool RealtimeEffectManager::IsActive() const noexcept
 void RealtimeEffectManager::Initialize(double rate)
 {
    // The audio thread should not be running yet, but protect anyway
-   SuspensionScope scope{ &mProject };
+   RealtimeEffects::SuspensionScope scope{ &mProject };
 
    // Remember the rate
    mRate = rate;
@@ -278,7 +278,7 @@ RealtimeEffectManager::AddState(Track *pTrack, const PluginID & id)
       ? RealtimeEffectList::Get(*pLeader)
       : RealtimeEffectList::Get(mProject);
 
-   SuspensionScope scope{ &mProject };
+   RealtimeEffects::SuspensionScope scope{ &mProject };
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 
@@ -309,7 +309,7 @@ RealtimeEffectManager::AddState(Track *pTrack, const PluginID & id)
 
 void RealtimeEffectManager::RemoveState(RealtimeEffectList &states, RealtimeEffectState &state)
 {
-   SuspensionScope scope{ &mProject };
+   RealtimeEffects::SuspensionScope scope{ &mProject };
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -55,7 +55,7 @@ bool RealtimeEffectManager::IsActive() const noexcept
 void RealtimeEffectManager::Initialize(double rate)
 {
    // The audio thread should not be running yet, but protect anyway
-   RealtimeEffects::SuspensionScope scope{ &mProject };
+   RealtimeEffects::SuspensionScope scope{ mProject.weak_from_this() };
 
    // Remember the rate
    mRate = rate;
@@ -278,7 +278,7 @@ RealtimeEffectManager::AddState(Track *pTrack, const PluginID & id)
       ? RealtimeEffectList::Get(*pLeader)
       : RealtimeEffectList::Get(mProject);
 
-   RealtimeEffects::SuspensionScope scope{ &mProject };
+   RealtimeEffects::SuspensionScope scope{ mProject.weak_from_this() };
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 
@@ -309,7 +309,7 @@ RealtimeEffectManager::AddState(Track *pTrack, const PluginID & id)
 
 void RealtimeEffectManager::RemoveState(RealtimeEffectList &states, RealtimeEffectState &state)
 {
-   RealtimeEffects::SuspensionScope scope{ &mProject };
+   RealtimeEffects::SuspensionScope scope{ mProject.weak_from_this() };
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -54,9 +54,6 @@ bool RealtimeEffectManager::IsActive() const noexcept
 
 void RealtimeEffectManager::Initialize(double rate)
 {
-   // The audio thread should not be running yet, but protect anyway
-   RealtimeEffects::SuspensionScope scope{ mProject.weak_from_this() };
-
    // Remember the rate
    mRate = rate;
 
@@ -91,10 +88,7 @@ void RealtimeEffectManager::AddTrack(Track *track, unsigned chans, float rate)
 
 void RealtimeEffectManager::Finalize()
 {
-   // Make sure nothing is going on
-   Suspend();
-
-   // It is now safe to clean up
+   // Assume it is now safe to clean up
    mLatency = std::chrono::microseconds(0);
 
    VisitAll([](auto &state, bool){ state.Finalize(); });

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -86,7 +86,7 @@ void RealtimeEffectManager::AddTrack(Track *track, unsigned chans, float rate)
    );
 }
 
-void RealtimeEffectManager::Finalize()
+void RealtimeEffectManager::Finalize() noexcept
 {
    // Assume it is now safe to clean up
    mLatency = std::chrono::microseconds(0);

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -70,6 +70,9 @@ void RealtimeEffectManager::Initialize(double rate)
    VisitGroup(nullptr, [rate](RealtimeEffectState &state, bool){
       state.Initialize(rate);
    });
+
+   // Leave suspended state
+   Resume();
 }
 
 void RealtimeEffectManager::AddTrack(Track *track, unsigned chans, float rate)
@@ -88,6 +91,9 @@ void RealtimeEffectManager::AddTrack(Track *track, unsigned chans, float rate)
 
 void RealtimeEffectManager::Finalize() noexcept
 {
+   // Reenter suspended state
+   Suspend();
+
    // Assume it is now safe to clean up
    mLatency = std::chrono::microseconds(0);
 

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -150,7 +150,9 @@ private:
 class SuspensionScope {
 public:
    SuspensionScope() {}
-   explicit SuspensionScope(std::weak_ptr<AudacityProject> wProject)
+   //! Require a prior InitializationScope to ensure correct nesting
+   explicit SuspensionScope(InitializationScope &,
+      std::weak_ptr<AudacityProject> wProject)
       : mwProject{ move(wProject) }
    {
       if (auto pProject = mwProject.lock()) {

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -161,7 +161,9 @@ private:
 class ProcessingScope {
 public:
    ProcessingScope() {}
-   explicit ProcessingScope(std::weak_ptr<AudacityProject> wProject)
+   //! Require a prior InializationScope to ensure correct nesting
+   explicit ProcessingScope(InitializationScope &,
+      std::weak_ptr<AudacityProject> wProject)
       : mwProject{ move(wProject) }
    {
       if (auto pProject = mwProject.lock())

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -52,7 +52,7 @@ public:
    //! Main thread adds one track (passing the first of one or more channels)
    void AddTrack(Track *track, unsigned chans, float rate);
    //! Main thread cleans up after playback
-   void Finalize();
+   void Finalize() noexcept;
    void Suspend();
    void Resume() noexcept;
    Latency GetLatency() const;

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -74,6 +74,7 @@ public:
 
 private:
    friend RealtimeEffects::InitializationScope;
+   friend RealtimeEffects::SuspensionScope;
 
    //! Main thread begins to define a set of tracks for playback
    void Initialize(double rate);
@@ -152,9 +153,13 @@ public:
    explicit SuspensionScope(std::weak_ptr<AudacityProject> wProject)
       : mwProject{ move(wProject) }
    {
-      
-      if (auto pProject = mwProject.lock())
-         RealtimeEffectManager::Get(*pProject).Suspend();
+      if (auto pProject = mwProject.lock()) {
+         auto &manager = RealtimeEffectManager::Get(*pProject);
+         if (!manager.mSuspended)
+            manager.Suspend();
+         else
+            mwProject.reset();
+      }
    }
    SuspensionScope( SuspensionScope &&other ) = default;
    SuspensionScope& operator=( SuspensionScope &&other ) = default;

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -54,16 +54,27 @@ public:
 
    //! Main thread appends a global or per-track effect
    /*!
+    @param pScope if realtime is active but scope is absent, there is no effect
     @param pTrack if null, then state is added to the global list
+    @param id identifies the effect
     @return if null, the given id was not found
     */
-   RealtimeEffectState *AddState(Track *pTrack, const PluginID & id);
-   //! Main thread safely removes an effect from a list
-   void RemoveState(RealtimeEffectList &states, RealtimeEffectState &state);
+   RealtimeEffectState *AddState(RealtimeEffects::InitializationScope *pScope,
+      Track *pTrack, const PluginID & id);
+
+   //! Main thread removes a global or per-track effect
+   /*!
+    @param pScope if realtime is active but scope is absent, there is no effect
+    @param pTrack if null, then state is added to the global list
+    @param state the state to be removed
+    */
+   /*! No effect if realtime is active but scope is not supplied */
+   void RemoveState(RealtimeEffects::InitializationScope *pScope,
+      Track *pTrack, RealtimeEffectState &state);
 
 private:
-
    friend RealtimeEffects::InitializationScope;
+
    //! Main thread begins to define a set of tracks for playback
    void Initialize(double rate);
    //! Main thread adds one track (passing the first of one or more channels)

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -268,7 +268,7 @@ bool RealtimeEffectState::IsActive() const noexcept
    return mSuspendCount == 0;
 }
 
-bool RealtimeEffectState::Finalize()
+bool RealtimeEffectState::Finalize() noexcept
 {
    mGroups.clear();
 

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -54,7 +54,7 @@ public:
    bool ProcessEnd();
    bool IsActive() const noexcept;
    //! Main thread cleans up playback
-   bool Finalize();
+   bool Finalize() noexcept;
 
    static const std::string &XMLTag();
    bool HandleXMLTag(

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1515,13 +1515,15 @@ bool VSTEffect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
    return slave->ProcessInitialize(0, NULL);
 }
 
-bool VSTEffect::RealtimeFinalize()
+bool VSTEffect::RealtimeFinalize() noexcept
 {
+return GuardedCall<bool>([&]{
    for (const auto &slave : mSlaves)
       slave->ProcessFinalize();
    mSlaves.clear();
 
    return ProcessFinalize();
+});
 }
 
 bool VSTEffect::RealtimeSuspend()

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -149,7 +149,7 @@ class VSTEffect final : public wxEvtHandler,
 
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart() override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -172,7 +172,7 @@ bool EffectWahwah::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sa
    return true;
 }
 
-bool EffectWahwah::RealtimeFinalize()
+bool EffectWahwah::RealtimeFinalize() noexcept
 {
    mSlaves.clear();
 

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -65,7 +65,7 @@ public:
    size_t ProcessBlock(float **inBlock, float **outBlock, size_t blockLen) override;
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    size_t RealtimeProcess(int group,
                                        float **inbuf,
                                        float **outbuf,

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1367,14 +1367,16 @@ bool AudioUnitEffect::RealtimeAddProcessor(unsigned numChannels, float sampleRat
    return pSlave->ProcessInitialize(0);
 }
 
-bool AudioUnitEffect::RealtimeFinalize()
+bool AudioUnitEffect::RealtimeFinalize() noexcept
 {
+return GuardedCall<bool>([&]{
    for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
    {
       mSlaves[i]->ProcessFinalize();
    }
    mSlaves.clear();
    return ProcessFinalize();
+});
 }
 
 bool AudioUnitEffect::RealtimeSuspend()

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -97,7 +97,7 @@ public:
 
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart() override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -55,6 +55,7 @@ effects from this one class.
 #include <wx/scrolwin.h>
 #include <wx/version.h>
 
+#include "AudacityException.h"
 #include "../../EffectHostInterface.h"
 #include "FileNames.h"
 #include "../../ShuttleGui.h"
@@ -1013,8 +1014,9 @@ bool LadspaEffect::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sa
    return true;
 }
 
-bool LadspaEffect::RealtimeFinalize()
+bool LadspaEffect::RealtimeFinalize() noexcept
 {
+return GuardedCall<bool>([&]{
    for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
    {
       FreeInstance(mSlaves[i]);
@@ -1022,6 +1024,7 @@ bool LadspaEffect::RealtimeFinalize()
    mSlaves.clear();
 
    return true;
+});
 }
 
 bool LadspaEffect::RealtimeSuspend()

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -96,7 +96,7 @@ public:
 
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart() override;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1194,8 +1194,9 @@ bool LV2Effect::RealtimeInitialize()
    return true;
 }
 
-bool LV2Effect::RealtimeFinalize()
+bool LV2Effect::RealtimeFinalize() noexcept
 {
+return GuardedCall<bool>([&]{
    for (auto & slave : mSlaves)
    {
       FreeInstance(slave);
@@ -1215,6 +1216,7 @@ bool LV2Effect::RealtimeFinalize()
 
    mMasterIn.reset();
    return true;
+});
 }
 
 bool LV2Effect::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sampleRate)

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -309,7 +309,7 @@ public:
 
    bool RealtimeInitialize() override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() override;
+   bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart() override;


### PR DESCRIPTION
Depends on #2466

Partly Resolves: #2084

Further rewrites of the use of RealtimeEffectManager so that there are RAII scope objects wherever begin and end methods
of the manager must be called in complementary pairs.

A change for safe shutdown of processing that was first identified by Leland Lucius.  noexcept specifiers on steps that must
happen inside destructors.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
