### PR TITLE
Correct atomics in playback

### DIFF
--- a/libraries/lib-audio-devices/AudioIOBase.cpp
+++ b/libraries/lib-audio-devices/AudioIOBase.cpp
@@ -326,7 +326,7 @@ void AudioIOBase::SetPlaybackMeter(
 
 bool AudioIOBase::IsPaused() const
 {
-   return mPaused;
+   return mPaused.load(std::memory_order_relaxed);
 }
 
 bool AudioIOBase::IsBusy() const

--- a/libraries/lib-audio-devices/AudioIOBase.h
+++ b/libraries/lib-audio-devices/AudioIOBase.h
@@ -252,6 +252,7 @@ protected:
    int                 mStreamToken{ 0 };
 
    /// Audio playback rate in samples per second
+   /*! Read by worker threads but unchanging during playback */
    double              mRate;
 
    PaStream           *mPortStreamV19;

--- a/libraries/lib-audio-devices/AudioIOBase.h
+++ b/libraries/lib-audio-devices/AudioIOBase.h
@@ -248,7 +248,8 @@ protected:
    /// True if audio playback is paused
    std::atomic<bool>   mPaused{ false };
 
-   volatile int        mStreamToken;
+   /*! Read by worker threads but unchanging during playback */
+   int                 mStreamToken{ 0 };
 
    /// Audio playback rate in samples per second
    double              mRate;

--- a/libraries/lib-audio-devices/AudioIOBase.h
+++ b/libraries/lib-audio-devices/AudioIOBase.h
@@ -11,6 +11,7 @@ Paul Licameli split from AudioIO.h
 #ifndef __AUDACITY_AUDIO_IO_BASE__
 #define __AUDACITY_AUDIO_IO_BASE__
 
+#include <atomic>
 #include <cfloat>
 #include <chrono>
 #include <functional>
@@ -245,7 +246,7 @@ protected:
    std::weak_ptr<AudacityProject> mOwningProject;
 
    /// True if audio playback is paused
-   bool                mPaused;
+   std::atomic<bool>   mPaused{ false };
 
    volatile int        mStreamToken;
 

--- a/libraries/lib-sample-track/SampleTrack.h
+++ b/libraries/lib-sample-track/SampleTrack.h
@@ -27,6 +27,7 @@ public:
 
    virtual sampleFormat GetSampleFormat() const = 0;
 
+   /*! May be called from a worker thread */
    virtual ChannelType GetChannelIgnoringPan() const = 0;
 
    // Old gain is used in playback in linearly interpolating

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -876,14 +876,14 @@ class TRACK_API PlayableTrack /* not final */ : public AudioTrack
 public:
    PlayableTrack()
       : AudioTrack{} {}
-   PlayableTrack(const Track &orig) : AudioTrack{ orig } {}
+   PlayableTrack(const PlayableTrack &orig) : AudioTrack{ orig } {}
 
    static const TypeInfo &ClassTypeInfo();
 
-   bool GetMute    () const { return mMute;     }
-   bool GetSolo    () const { return mSolo;     }
-   bool GetNotMute () const { return !mMute;     }
-   bool GetNotSolo () const { return !mSolo;     }
+   bool GetMute    () const { return DoGetMute();     }
+   bool GetSolo    () const { return DoGetSolo();     }
+   bool GetNotMute () const { return !DoGetMute();     }
+   bool GetNotSolo () const { return !DoGetSolo();     }
    void SetMute    (bool m);
    void SetSolo    (bool s);
 
@@ -897,8 +897,16 @@ public:
    bool HandleXMLAttribute(const std::string_view &attr, const XMLAttributeValueView &value);
 
 protected:
-   bool                mMute { false };
-   bool                mSolo { false };
+   // These just abbreviate load and store with relaxed memory ordering
+   bool DoGetMute() const;
+   void DoSetMute(bool value);
+   bool DoGetSolo() const;
+   void DoSetSolo(bool value);
+
+   //! Atomic because it may be read by worker threads in playback
+   std::atomic<bool>  mMute { false };
+   //! Atomic because it may be read by worker threads in playback
+   std::atomic<bool>  mSolo { false };
 };
 
 ENUMERATE_TRACK_TYPE(PlayableTrack);

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -2643,7 +2643,8 @@ void AudioIoCallback::DrainInputBuffers(
    // enough from mCaptureBuffers; maybe it's CPU-bound, or maybe the
    // storage device it writes is too slow
    if (mDetectDropouts &&
-         ((mDetectUpstreamDropouts && inputError) ||
+         ((mDetectUpstreamDropouts.load(std::memory_order_relaxed)
+           && inputError) ||
          len < framesPerBuffer) ) {
       // Assume that any good partial buffer should be written leftmost
       // and zeroes will be padded after; label the zeroes.

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -319,7 +319,6 @@ AudioIO::AudioIO()
 #ifdef EXPERIMENTAL_AUTOMATED_INPUT_LEVEL_ADJUSTMENT
    mAILAActive = false;
 #endif
-   mStreamToken = 0;
 
    mLastPaError = paNoError;
 

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -292,7 +292,7 @@ public:
    sampleFormat        mCaptureFormat;
    unsigned long long  mLostSamples{ 0 };
    std::atomic<bool>   mAudioThreadShouldCallTrackBufferExchangeOnce;
-   volatile bool       mAudioThreadTrackBufferExchangeLoopRunning;
+   std::atomic<bool>   mAudioThreadTrackBufferExchangeLoopRunning;
    volatile bool       mAudioThreadTrackBufferExchangeLoopActive;
 
    std::atomic<bool>   mForceFadeOut{ false };

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -299,7 +299,8 @@ public:
 
    wxLongLong          mLastPlaybackTimeMillis;
 
-   volatile double     mLastRecordingOffset;
+   //! Not (yet) used; should perhaps be atomic when it is
+   double              mLastRecordingOffset;
    PaError             mLastPaError;
 
 protected:

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -291,7 +291,7 @@ public:
    unsigned int        mNumPlaybackChannels;
    sampleFormat        mCaptureFormat;
    unsigned long long  mLostSamples{ 0 };
-   volatile bool       mAudioThreadShouldCallTrackBufferExchangeOnce;
+   std::atomic<bool>   mAudioThreadShouldCallTrackBufferExchangeOnce;
    volatile bool       mAudioThreadTrackBufferExchangeLoopRunning;
    volatile bool       mAudioThreadTrackBufferExchangeLoopActive;
 

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -293,7 +293,7 @@ public:
    unsigned long long  mLostSamples{ 0 };
    std::atomic<bool>   mAudioThreadShouldCallTrackBufferExchangeOnce;
    std::atomic<bool>   mAudioThreadTrackBufferExchangeLoopRunning;
-   volatile bool       mAudioThreadTrackBufferExchangeLoopActive;
+   std::atomic<bool>   mAudioThreadTrackBufferExchangeLoopActive;
 
    std::atomic<bool>   mForceFadeOut{ false };
 

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -349,7 +349,7 @@ public:
 
    // Whether to check the error code passed to audacityAudioCallback to
    // detect more dropouts
-   bool mDetectUpstreamDropouts{ true };
+   std::atomic<bool> mDetectUpstreamDropouts{ true };
 
 protected:
    RecordingSchedule mRecordingSchedule{};

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -262,6 +262,7 @@ public:
    ArrayOf<std::unique_ptr<Resample>> mResample;
    ArrayOf<std::unique_ptr<RingBuffer>> mCaptureBuffers;
    WaveTrackArray      mCaptureTracks;
+   /*! Read by worker threads but unchanging during playback */
    ArrayOf<std::unique_ptr<RingBuffer>> mPlaybackBuffers;
    WaveTrackArray      mPlaybackTracks;
 
@@ -271,7 +272,8 @@ public:
    static int          mNextStreamToken;
    double              mFactor;
    unsigned long       mMaxFramesOutput; // The actual number of frames output.
-   bool                mbMicroFades; 
+   /*! Read by a worker thread but unchanging during playback */
+   bool                mbMicroFades;
 
    double              mSeek;
    PlaybackPolicy::Duration mPlaybackRingBufferSecs;
@@ -283,11 +285,15 @@ public:
    size_t              mPlaybackQueueMinimum;
 
    double              mMinCaptureSecsToCopy;
+   /*! Read by a worker thread but unchanging during playback */
    bool                mSoftwarePlaythrough;
    /// True if Sound Activated Recording is enabled
+   /*! Read by a worker thread but unchanging during playback */
    bool                mPauseRec;
    float               mSilenceLevel;
+   /*! Read by a worker thread but unchanging during playback */
    unsigned int        mNumCaptureChannels;
+   /*! Read by a worker thread but unchanging during playback */
    unsigned int        mNumPlaybackChannels;
    sampleFormat        mCaptureFormat;
    unsigned long long  mLostSamples{ 0 };
@@ -313,6 +319,9 @@ protected:
    bool                mUpdateMeters;
    volatile bool       mUpdatingMeters;
 
+   /*! Pointer is read by a worker thread but unchanging during playback.
+    (Whether its overriding methods are race-free is not for AudioIO to ensure.)
+    */
    std::weak_ptr< AudioIOListener > mListener;
 
    friend class AudioThread;
@@ -338,6 +347,7 @@ protected:
       { if (mRecordingException) wxAtomicDec( mRecordingException ); }
 
    std::vector< std::pair<double, double> > mLostCaptureIntervals;
+   /*! Read by a worker thread but unchanging during playback */
    bool mDetectDropouts{ true };
 
 public:

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -267,7 +267,7 @@ public:
 
    std::vector<std::unique_ptr<Mixer>> mPlaybackMixers;
 
-   float               mMixerOutputVol { 1.0 };
+   std::atomic<float>  mMixerOutputVol{ 1.0 };
    static int          mNextStreamToken;
    double              mFactor;
    unsigned long       mMaxFramesOutput; // The actual number of frames output.
@@ -303,6 +303,11 @@ public:
    PaError             mLastPaError;
 
 protected:
+
+   float GetMixerOutputVol() {
+      return mMixerOutputVol.load(std::memory_order_relaxed); }
+   void SetMixerOutputVol(float value) {
+      mMixerOutputVol.store(value, std::memory_order_relaxed); }
 
    bool                mUpdateMeters;
    volatile bool       mUpdatingMeters;

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -129,13 +129,8 @@ NoteTrack::NoteTrack()
    mSeq = NULL;
    mSerializationLength = 0;
 
-#ifdef EXPERIMENTAL_MIDI_OUT
-   mVelocity = 0;
-#endif
    mBottomNote = MinPitch;
    mTopNote = MaxPitch;
-
-   mVisibleChannels = ALL_CHANNELS;
 }
 
 NoteTrack::~NoteTrack()
@@ -196,7 +191,7 @@ Track::Holder NoteTrack::Clone() const
    // copy some other fields here
    duplicate->SetBottomNote(mBottomNote);
    duplicate->SetTopNote(mTopNote);
-   duplicate->mVisibleChannels = mVisibleChannels;
+   duplicate->SetVisibleChannels(GetVisibleChannels());
    duplicate->SetOffset(GetOffset());
 #ifdef EXPERIMENTAL_MIDI_OUT
    duplicate->SetVelocity(GetVelocity());
@@ -638,10 +633,15 @@ void NoteTrack::InsertSilence(double t, double len)
 #ifdef EXPERIMENTAL_MIDI_OUT
 void NoteTrack::SetVelocity(float velocity)
 {
-   if (mVelocity != velocity) {
-      mVelocity = velocity;
+   if (GetVelocity() != velocity) {
+      DoSetVelocity(velocity);
       Notify();
    }
+}
+
+void NoteTrack::DoSetVelocity(float velocity)
+{
+   mVelocity.store(velocity, std::memory_order_relaxed);
 }
 #endif
 
@@ -930,11 +930,11 @@ bool NoteTrack::HandleXMLTag(const std::string_view& tag, const AttributesList &
              if (!value.TryGet(nValue) ||
                  !IsValidVisibleChannels(nValue))
                  return false;
-             mVisibleChannels = nValue;
+             SetVisibleChannels(nValue);
          }
 #ifdef EXPERIMENTAL_MIDI_OUT
          else if (attr == "velocity" && value.TryGet(dblValue))
-            mVelocity = (float) dblValue;
+            DoSetVelocity(static_cast<float>(dblValue));
 #endif
          else if (attr == "bottomnote" && value.TryGet(nValue))
             SetBottomNote(nValue);
@@ -973,10 +973,12 @@ void NoteTrack::WriteXML(XMLWriter &xmlFile) const
    saveme->Track::WriteCommonXMLAttributes( xmlFile );
    this->NoteTrackBase::WriteXMLAttributes(xmlFile);
    xmlFile.WriteAttr(wxT("offset"), saveme->GetOffset());
-   xmlFile.WriteAttr(wxT("visiblechannels"), saveme->mVisibleChannels);
+   xmlFile.WriteAttr(wxT("visiblechannels"),
+      static_cast<int>(saveme->GetVisibleChannels()));
 
 #ifdef EXPERIMENTAL_MIDI_OUT
-   xmlFile.WriteAttr(wxT("velocity"), (double) saveme->mVelocity);
+   xmlFile.WriteAttr(wxT("velocity"),
+      static_cast<double>(saveme->GetVelocity()));
 #endif
    xmlFile.WriteAttr(wxT("bottomnote"), saveme->mBottomNote);
    xmlFile.WriteAttr(wxT("topnote"), saveme->mTopNote);

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -540,8 +540,10 @@ private:
 
    sampleFormat  mFormat;
    int           mRate;
-   float         mGain;
-   float         mPan;
+   //! Atomic because it may be read by worker threads in playback
+   std::atomic<float> mGain{ 1.0f };
+   //! Atomic because it may be read by worker threads in playback
+   std::atomic<float> mPan{ 0.0f };
    int           mWaveColorIndex;
    float         mOldGain[2];
 
@@ -559,17 +561,11 @@ private:
    mutable int           mLastdBRange;
    mutable std::vector <Location> mDisplayLocationsCache;
 
-   //
-   // Protected methods
-   //
-
 private:
+   void DoSetPan(float value);
+   void DoSetGain(float value);
 
    void PasteWaveTrack(double t0, const WaveTrack* other);
-
-   //
-   // Private variables
-   //
 
    SampleBlockFactoryPtr mpFactory;
 

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -545,6 +545,7 @@ private:
    //! Atomic because it may be read by worker threads in playback
    std::atomic<float> mPan{ 0.0f };
    int           mWaveColorIndex;
+   //! A memo used by PortAudio thread, doesn't need atomics:
    float         mOldGain[2];
 
 


### PR DESCRIPTION
Resolves: #2094

Use atomics with relaxed memory order wherever the worker threads for audio playback and recording might read a value
that the main thread can concurrently change, so that all is properly done without "undefined behavior."

Remove all inappropriate `volatile` qualifiers, with one exception (addrressed in #2503).

Comment variables that are set by the main thread but remain unchanged during playback and recording, and so do not
require atomics.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
