### PR TITLE
Effect cleanup part 4

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -93,10 +93,6 @@ public:
    //! Whether the effect sorts "above the line" in the menus
    virtual bool IsDefault() = 0;
 
-   // This will go away when all Effects have been updated to the new
-   // interface.
-   virtual bool IsLegacy() = 0;
-
    //! Whether the effect supports realtime previewing (while audio is playing).
    virtual bool SupportsRealtime() = 0;
 
@@ -192,7 +188,7 @@ typedef enum
 
 \class EffectProcessor 
 
-\brief EffectClientInterface provides the ident interface to Effect, and is what makes
+\brief provides the ident interface to Effect, and is what makes
 Effect into a plug-in command.  It has functions for effect calculations that are not part of
 AudacityCommand.
 

--- a/src/EffectHostInterface.cpp
+++ b/src/EffectHostInterface.cpp
@@ -12,3 +12,8 @@
 EffectHostInterface::~EffectHostInterface() = default;
 
 EffectUIHostInterface::~EffectUIHostInterface() = default;
+
+const wxString EffectUIHostInterface::kUserPresetIdent = wxT("User Preset:");
+const wxString EffectUIHostInterface::kFactoryPresetIdent = wxT("Factory Preset:");
+const wxString EffectUIHostInterface::kCurrentSettingsIdent = wxT("<Current Settings>");
+const wxString EffectUIHostInterface::kFactoryDefaultsIdent = wxT("<Factory Defaults>");

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -55,6 +55,11 @@ using EffectDialogFactory = std::function<
       EffectHostInterface&, EffectUIClientInterface& )
 >;
 
+class TrackList;
+class WaveTrackFactory;
+class NotifyingSelectedRegion;
+class EffectProcessor;
+
 /*************************************************************************************//**
 
 \class EffectUIHostInterface
@@ -74,6 +79,26 @@ public:
       wxWindow &parent, const EffectDialogFactory &factory,
       bool forceModal = false
    ) = 0;
+
+   virtual void Preview(bool dryOnly) = 0;
+   virtual bool GetAutomationParametersAsString(wxString & parms) = 0;
+   virtual bool SetAutomationParametersFromString(const wxString & parms) = 0;
+   virtual bool IsBatchProcessing() = 0;
+   virtual void SetBatchProcessing(bool start) = 0;
+   // Returns true on success.  Will only operate on tracks that
+   // have the "selected" flag set to true, which is consistent with
+   // Audacity's standard UI.
+   // Create a user interface only if the supplied function is not null.
+   virtual bool DoEffect( double projectRate, TrackList *list,
+      WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
+      unsigned flags,
+      // Prompt the user for input only if these arguments are both not null.
+      wxWindow *pParent = nullptr,
+      const EffectDialogFactory &dialogFactory = {} ) = 0;
+   virtual bool Startup(EffectUIClientInterface *client) = 0;
+
+   virtual bool TransferDataToWindow() = 0;
+   virtual bool TransferDataFromWindow() = 0;
 };
 
 #endif

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -69,6 +69,11 @@ class EffectProcessor;
 class AUDACITY_DLL_API EffectUIHostInterface : public EffectHostInterface
 {
 public:
+   const static wxString kUserPresetIdent;
+   const static wxString kFactoryPresetIdent;
+   const static wxString kCurrentSettingsIdent;
+   const static wxString kFactoryDefaultsIdent;
+
    EffectUIHostInterface &operator=(EffectUIHostInterface&) = delete;
    virtual ~EffectUIHostInterface();
 

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -31,6 +31,8 @@ ConfigClientInterface to add Getters/setters for private and shared configs.
 class AUDACITY_DLL_API EffectHostInterface
 {
 public:
+   EffectHostInterface &operator=(EffectHostInterface&) = delete;
+
    virtual ~EffectHostInterface();
 
    virtual EffectDefinitionInterface &GetDefinition() = 0;
@@ -62,6 +64,7 @@ using EffectDialogFactory = std::function<
 class AUDACITY_DLL_API EffectUIHostInterface : public EffectHostInterface
 {
 public:
+   EffectUIHostInterface &operator=(EffectUIHostInterface&) = delete;
    virtual ~EffectUIHostInterface();
 
    /*!

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -12,7 +12,6 @@
 #ifndef __AUDACITY_EFFECTHOSTINTERFACE_H__
 #define __AUDACITY_EFFECTHOSTINTERFACE_H__
 
-#include "ConfigInterface.h"
 #include "ComponentInterfaceSymbol.h"
 
 #include <functional>

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -50,9 +50,10 @@ class wxDialog;
 class wxWindow;
 class EffectUIClientInterface;
 
+class EffectUIHostInterface;
 using EffectDialogFactory = std::function<
    wxDialog* ( wxWindow &parent,
-      EffectHostInterface&, EffectUIClientInterface& )
+      EffectUIHostInterface&, EffectUIClientInterface& )
 >;
 
 class TrackList;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -199,16 +199,6 @@ bool Effect::IsDefault()
    return true;
 }
 
-bool Effect::IsLegacy()
-{
-   if (mClient)
-   {
-      return false;
-   }
-
-   return true;
-}
-
 bool Effect::SupportsRealtime()
 {
    if (mClient)

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -55,11 +55,6 @@ static const int kPlayID = 20102;
 static const int kRewindID = 20103;
 static const int kFFwdID = 20104;
 
-const wxString Effect::kUserPresetIdent = wxT("User Preset:");
-const wxString Effect::kFactoryPresetIdent = wxT("Factory Preset:");
-const wxString Effect::kCurrentSettingsIdent = wxT("<Current Settings>");
-const wxString Effect::kFactoryDefaultsIdent = wxT("<Factory Defaults>");
-
 using t2bHash = std::unordered_map< void*, bool >;
 
 Effect::Effect()

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -476,12 +476,6 @@ private:
    size_t mBufferSize;
    size_t mBlockSize;
    unsigned mNumChannels;
-
-public:
-   const static wxString kUserPresetIdent;
-   const static wxString kFactoryPresetIdent;
-   const static wxString kCurrentSettingsIdent;
-   const static wxString kFactoryDefaultsIdent;
 };
 
 // FIXME:

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -50,7 +50,6 @@ class AudacityProject;
 class LabelTrack;
 class NotifyingSelectedRegion;
 class SelectedRegion;
-class EffectUIHost;
 class Track;
 class TrackList;
 class WaveTrackFactory;
@@ -483,8 +482,6 @@ public:
    const static wxString kFactoryPresetIdent;
    const static wxString kCurrentSettingsIdent;
    const static wxString kFactoryDefaultsIdent;
-
-   friend class EffectUIHost;
 };
 
 // FIXME:

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -151,7 +151,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal = false) override;
 
-
    // EffectUIClientInterface implementation
 
    bool PopulateUI(ShuttleGui &S) final;
@@ -179,12 +178,26 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    RegistryPath GetCurrentSettingsGroup() override;
    RegistryPath GetFactoryDefaultsGroup() override;
 
-   virtual wxString GetSavedStateGroup() /* not override? */;
-
    // EffectUIHostInterface implementation
 
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory, bool forceModal = false) override;
+   // The Effect class fully implements the Preview method for you.
+   // Only override it if you need to do preprocessing or cleanup.
+   void Preview(bool dryOnly) override;
+   bool GetAutomationParametersAsString(wxString & parms) override;
+   bool SetAutomationParametersFromString(const wxString & parms) override;
+   bool IsBatchProcessing() override;
+   void SetBatchProcessing(bool start) override;
+   bool DoEffect( double projectRate, TrackList *list,
+      WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
+      unsigned flags,
+      // Prompt the user for input only if these arguments are both not null.
+      wxWindow *pParent,
+      const EffectDialogFactory &dialogFactory) override;
+   bool Startup(EffectUIClientInterface *client) override;
+   bool TransferDataToWindow() override;
+   bool TransferDataFromWindow() override;
 
    // Effect implementation
 
@@ -194,26 +207,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
       if( Names ) mPresetNames = *Names;
       if( Values ) mPresetValues = *Values;
    }
-
-   // NEW virtuals
-   virtual bool Startup(EffectUIClientInterface *client);
-
-   virtual bool GetAutomationParametersAsString(wxString & parms);
-   virtual bool SetAutomationParametersFromString(const wxString & parms);
-
-   virtual bool IsBatchProcessing();
-   virtual void SetBatchProcessing(bool start);
-
-   // Returns true on success.  Will only operate on tracks that
-   // have the "selected" flag set to true, which is consistent with
-   // Audacity's standard UI.
-   // Create a user interface only if the supplied function is not null.
-   /* not virtual */ bool DoEffect( double projectRate, TrackList *list,
-      WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
-      // Prompt the user for input only if these arguments are both not null.
-      unsigned flags,
-      wxWindow *pParent = nullptr,
-      const EffectDialogFactory &dialogFactory = {} );
 
    bool Delegate( Effect &delegate,
       wxWindow &parent, const EffectDialogFactory &factory );
@@ -274,13 +267,7 @@ protected:
    // effects need to use a different input length, so override this method.
    virtual double CalcPreviewInputLength(double previewLength);
 
-   // The Effect class fully implements the Preview method for you.
-   // Only override it if you need to do preprocessing or cleanup.
-   virtual void Preview(bool dryOnly);
-
    virtual void PopulateOrExchange(ShuttleGui & S);
-   virtual bool TransferDataToWindow() /* not override */;
-   virtual bool TransferDataFromWindow() /* not override */;
 
    // No more virtuals!
 
@@ -441,6 +428,7 @@ protected:
  // Used only by the base Effect class
  //
  private:
+   wxString GetSavedStateGroup();
    double GetDefaultDuration();
 
    void CountWaveTracks();

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -103,7 +103,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    EffectFamilySymbol GetFamily() override;
    bool IsInteractive() override;
    bool IsDefault() override;
-   bool IsLegacy() override;
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -477,21 +477,21 @@ wxString EffectPresetsDialog::GetSelected() const
 void EffectPresetsDialog::SetSelected(const wxString & parms)
 {
    wxString preset = parms;
-   if (preset.StartsWith(Effect::kUserPresetIdent))
+   if (preset.StartsWith(EffectUIHostInterface::kUserPresetIdent))
    {
-      preset.Replace(Effect::kUserPresetIdent, wxEmptyString, false);
+      preset.Replace(EffectUIHostInterface::kUserPresetIdent, wxEmptyString, false);
       SetPrefix(XO("User Presets"), preset);
    }
-   else if (preset.StartsWith(Effect::kFactoryPresetIdent))
+   else if (preset.StartsWith(EffectUIHostInterface::kFactoryPresetIdent))
    {
-      preset.Replace(Effect::kFactoryPresetIdent, wxEmptyString, false);
+      preset.Replace(EffectUIHostInterface::kFactoryPresetIdent, wxEmptyString, false);
       SetPrefix(XO("Factory Presets"), preset);
    }
-   else if (preset.StartsWith(Effect::kCurrentSettingsIdent))
+   else if (preset.StartsWith(EffectUIHostInterface::kCurrentSettingsIdent))
    {
       SetPrefix(XO("Current Settings"), wxEmptyString);
    }
-   else if (preset.StartsWith(Effect::kFactoryDefaultsIdent))
+   else if (preset.StartsWith(EffectUIHostInterface::kFactoryDefaultsIdent))
    {
       SetPrefix(XO("Factory Defaults"), wxEmptyString);
    }
@@ -513,7 +513,8 @@ void EffectPresetsDialog::SetPrefix(
       {
          mPresets->SetSelection(0);
       }
-      mSelection = Effect::kUserPresetIdent + mPresets->GetStringSelection();
+      mSelection = EffectUIHostInterface::kUserPresetIdent
+         + mPresets->GetStringSelection();
    }
    else if (type == XO("Factory Presets"))
    {
@@ -533,19 +534,20 @@ void EffectPresetsDialog::SetPrefix(
       {
          mPresets->SetSelection(0);
       }
-      mSelection = Effect::kFactoryPresetIdent + mPresets->GetStringSelection();
+      mSelection = EffectUIHostInterface::kFactoryPresetIdent
+         + mPresets->GetStringSelection();
    }
    else if (type == XO("Current Settings"))
    {
       mPresets->Clear();
       mPresets->Enable(false);
-      mSelection = Effect::kCurrentSettingsIdent;
+      mSelection = EffectUIHostInterface::kCurrentSettingsIdent;
    }
    else if (type == XO("Factory Defaults"))
    {
       mPresets->Clear();
       mPresets->Enable(false);
-      mSelection = Effect::kFactoryDefaultsIdent;
+      mSelection = EffectUIHostInterface::kFactoryDefaultsIdent;
    }
 }
 
@@ -572,7 +574,8 @@ void EffectPresetsDialog::UpdateUI()
          mPresets->Append(preset);
       mPresets->Enable(true);
       mPresets->SetSelection(selected);
-      mSelection = Effect::kUserPresetIdent + mPresets->GetString(selected);
+      mSelection = EffectUIHostInterface::kUserPresetIdent
+         + mPresets->GetString(selected);
    }
    else if (type == _("Factory Presets"))
    {
@@ -594,19 +597,20 @@ void EffectPresetsDialog::UpdateUI()
       }
       mPresets->Enable(true);
       mPresets->SetSelection(selected);
-      mSelection = Effect::kFactoryPresetIdent + mPresets->GetString(selected);
+      mSelection = EffectUIHostInterface::kFactoryPresetIdent
+         + mPresets->GetString(selected);
    }
    else if (type == _("Current Settings"))
    {
       mPresets->Clear();
       mPresets->Enable(false);
-      mSelection = Effect::kCurrentSettingsIdent;
+      mSelection = EffectUIHostInterface::kCurrentSettingsIdent;
    }
    else if (type == _("Factory Defaults"))
    {
       mPresets->Clear();
       mPresets->Enable(false);
-      mSelection = Effect::kFactoryDefaultsIdent;
+      mSelection = EffectUIHostInterface::kFactoryDefaultsIdent;
    }
 }
 
@@ -688,11 +692,11 @@ wxString EffectManager::GetDefaultPreset(const PluginID & ID)
    wxString preset;
    if (HasCurrentSettings(*effect))
    {
-      preset = Effect::kCurrentSettingsIdent;
+      preset = EffectUIHostInterface::kCurrentSettingsIdent;
    }
    else if (HasFactoryDefaults(*effect))
    {
-      preset = Effect::kFactoryDefaultsIdent;
+      preset = EffectUIHostInterface::kFactoryDefaultsIdent;
    }
 
    if (!preset.empty())

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -25,15 +25,14 @@ class AudacityProject;
 class CommandContext;
 class CommandMessageTarget;
 class ComponentInterfaceSymbol;
-class Effect;
 class TrackList;
 class SelectedRegion;
 class wxString;
 typedef wxString PluginID;
 
-using EffectMap = std::unordered_map<wxString, Effect *>;
+using EffectMap = std::unordered_map<wxString, EffectUIHostInterface *>;
 using AudacityCommandMap = std::unordered_map<wxString, AudacityCommand *>;
-using EffectOwnerMap = std::unordered_map< wxString, std::shared_ptr<Effect> >;
+using EffectOwnerMap = std::unordered_map< wxString, std::shared_ptr<EffectUIHostInterface> >;
 
 class AudacityCommand;
 
@@ -58,7 +57,7 @@ public:
    };
 
    /*! Create a new instance of an effect by its ID. */
-   static std::unique_ptr<Effect> NewEffect(const PluginID &ID);
+   static std::unique_ptr<EffectProcessor> NewEffect(const PluginID &ID);
 
    /** Get the singleton instance of the EffectManager. Probably not safe
        for multi-thread use. */
@@ -75,8 +74,9 @@ public:
    virtual ~EffectManager();
 
    //! Here solely for the purpose of Nyquist Workbench until a better solution is devised.
-   /** Register an effect so it can be executed. */
-   const PluginID & RegisterEffect(std::unique_ptr<Effect> uEffect);
+   /** Register an effect so it can be executed.
+     uEffect is expected to be a self-hosting Nyquist effect */
+   const PluginID & RegisterEffect(std::unique_ptr<EffectUIHostInterface> uEffect);
    //! Used only by Nyquist Workbench module
    void UnregisterEffect(const PluginID & ID);
 
@@ -134,7 +134,7 @@ public:
    const PluginID & GetEffectByIdentifier(const CommandID & strTarget);
 
    /** Return an effect by its ID. */
-   Effect *GetEffect(const PluginID & ID);
+   EffectUIHostInterface *GetEffect(const PluginID & ID);
 
 private:
    AudacityCommand *GetAudacityCommand(const PluginID & ID);

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -163,7 +163,7 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
 :  wxDialogWrapper(parent, wxID_ANY, effect.GetDefinition().GetName(),
                    wxDefaultPosition, wxDefaultSize,
                    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMINIMIZE_BOX | wxMAXIMIZE_BOX)
-, mEffect{ effect }
+, mEffectUIHost{ effect }
 , mClient{ client }
 , mProject{ project }
 {
@@ -199,12 +199,12 @@ EffectUIHost::~EffectUIHost()
 
 bool EffectUIHost::TransferDataToWindow()
 {
-   return mEffect.TransferDataToWindow();
+   return mEffectUIHost.TransferDataToWindow();
 }
 
 bool EffectUIHost::TransferDataFromWindow()
 {
-   return mEffect.TransferDataFromWindow();
+   return mEffectUIHost.TransferDataFromWindow();
 }
 
 // ============================================================================
@@ -242,9 +242,9 @@ int EffectUIHost::ShowModal()
 
 wxPanel *EffectUIHost::BuildButtonBar(wxWindow *parent)
 {
-   mSupportsRealtime = mEffect.GetDefinition().SupportsRealtime();
+   mSupportsRealtime = mEffectUIHost.GetDefinition().SupportsRealtime();
    mIsGUI = mClient.IsGraphicalUI();
-   mIsBatch = mEffect.IsBatchProcessing();
+   mIsBatch = mEffectUIHost.IsBatchProcessing();
 
    int margin = 0;
 #if defined(__WXMAC__)
@@ -293,8 +293,8 @@ wxPanel *EffectUIHost::BuildButtonBar(wxWindow *parent)
                               wxALIGN_CENTER | wxTOP | wxBOTTOM );
             }
             else if (
-               (mEffect.GetDefinition().GetType() != EffectTypeAnalyze) &&
-               (mEffect.GetDefinition().GetType() != EffectTypeTool) )
+               (mEffectUIHost.GetDefinition().GetType() != EffectTypeAnalyze) &&
+               (mEffectUIHost.GetDefinition().GetType() != EffectTypeTool) )
             {
                mPlayToggleBtn = S.Id( kPlayID )
                   .ToolTip(XO("Preview effect"))
@@ -420,7 +420,7 @@ bool EffectUIHost::Initialize()
          const auto bar = BuildButtonBar( S.GetParent() );
 
          long buttons;
-         if ( mEffect.GetDefinition().ManualPage().empty() && mEffect.GetDefinition().HelpPage().empty()) {
+         if ( mEffectUIHost.GetDefinition().ManualPage().empty() && mEffectUIHost.GetDefinition().HelpPage().empty()) {
             buttons = eApplyButton | eCloseButton;
             this->SetAcceleratorTable(wxNullAcceleratorTable);
          }
@@ -436,7 +436,7 @@ bool EffectUIHost::Initialize()
             this->SetAcceleratorTable(accel);
          }
 
-         if (mEffect.GetDefinition().EnablesDebug())
+         if (mEffectUIHost.GetDefinition().EnablesDebug())
             buttons |= eDebugButton;
 
          S.AddStandardButtons(buttons, bar);
@@ -532,14 +532,14 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
    
    // Honor the "select all if none" preference...a little hackish, but whatcha gonna do...
    if (!mIsBatch &&
-       mEffect.GetDefinition().GetType() != EffectTypeGenerate &&
-       mEffect.GetDefinition().GetType() != EffectTypeTool &&
+       mEffectUIHost.GetDefinition().GetType() != EffectTypeGenerate &&
+       mEffectUIHost.GetDefinition().GetType() != EffectTypeTool &&
        ViewInfo::Get( project ).selectedRegion.isPoint())
    {
       auto flags = AlwaysEnabledFlag;
       bool allowed =
       MenuManager::Get( project ).ReportIfActionNotAllowed(
-         mEffect.GetDefinition().GetName(),
+         mEffectUIHost.GetDefinition().GetName(),
          flags,
          WaveTracksSelectedFlag() | TimeSelectedFlag());
       if (!allowed)
@@ -552,7 +552,7 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
    }
    
    // This will take care of calling TransferDataFromWindow() for an effect.
-   if (!mEffect.GetDefinition().SaveUserPreset(mEffect.GetCurrentSettingsGroup()))
+   if (!mEffectUIHost.GetDefinition().SaveUserPreset(mEffectUIHost.GetCurrentSettingsGroup()))
    {
       return;
    }
@@ -577,7 +577,7 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
    // This is absolute hackage...but easy and I can't think of another way just now.
    //
    // It should callback to the EffectManager to kick off the processing
-   EffectUI::DoEffect(GetID(mEffect), context,
+   EffectUI::DoEffect(GetID(mEffectUIHost), context,
       EffectManager::kConfigured);
 }
 
@@ -601,14 +601,14 @@ void EffectUIHost::OnCancel(wxCommandEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnHelp(wxCommandEvent & WXUNUSED(event))
 {
-   if (mEffect.GetDefinition().GetFamily() == NYQUISTEFFECTS_FAMILY && (mEffect.GetDefinition().ManualPage().empty())) {
+   if (mEffectUIHost.GetDefinition().GetFamily() == NYQUISTEFFECTS_FAMILY && (mEffectUIHost.GetDefinition().ManualPage().empty())) {
       // Old ShowHelp required when there is no on-line manual.
       // Always use default web browser to allow full-featured HTML pages.
-      HelpSystem::ShowHelp(FindWindow(wxID_HELP), mEffect.GetDefinition().HelpPage(), wxEmptyString, true, true);
+      HelpSystem::ShowHelp(FindWindow(wxID_HELP), mEffectUIHost.GetDefinition().HelpPage(), wxEmptyString, true, true);
    }
    else {
       // otherwise use the NEW ShowHelp
-      HelpSystem::ShowHelp(FindWindow(wxID_HELP), mEffect.GetDefinition().ManualPage(), true);
+      HelpSystem::ShowHelp(FindWindow(wxID_HELP), mEffectUIHost.GetDefinition().ManualPage(), true);
    }
 }
 
@@ -656,7 +656,7 @@ void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
    
    menu.AppendSeparator();
    
-   auto factory = mEffect.GetDefinition().GetFactoryPresets();
+   auto factory = mEffectUIHost.GetDefinition().GetFactoryPresets();
    
    {
       auto sub = std::make_unique<wxMenu>();
@@ -688,7 +688,7 @@ void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
    {
       auto sub = std::make_unique<wxMenu>();
       
-      auto &definition = mEffect.GetDefinition();
+      auto &definition = mEffectUIHost.GetDefinition();
       sub->Append(kDummyID, wxString::Format(_("Type: %s"),
          ::wxGetTranslation( definition.GetFamily().Translation() )));
       sub->Append(kDummyID, wxString::Format(_("Name: %s"), definition.GetName().Translation()));
@@ -724,12 +724,12 @@ void EffectUIHost::OnPlay(wxCommandEvent & WXUNUSED(evt))
 {
    if (!mSupportsRealtime)
    {
-      if (!mClient.ValidateUI() || !mEffect.TransferDataFromWindow())
+      if (!mClient.ValidateUI() || !mEffectUIHost.TransferDataFromWindow())
       {
          return;
       }
       
-      mEffect.Preview(false);
+      mEffectUIHost.Preview(false);
       
       return;
    }
@@ -870,14 +870,16 @@ void EffectUIHost::OnUserPreset(wxCommandEvent & evt)
 {
    int preset = evt.GetId() - kUserPresetsID;
    
-   mEffect.GetDefinition().LoadUserPreset(mEffect.GetUserPresetsGroup(mUserPresets[preset]));
+   mEffectUIHost.GetDefinition()
+      .LoadUserPreset(mEffectUIHost.GetUserPresetsGroup(mUserPresets[preset]));
    
    return;
 }
 
 void EffectUIHost::OnFactoryPreset(wxCommandEvent & evt)
 {
-   mEffect.GetDefinition().LoadFactoryPreset(evt.GetId() - kFactoryPresetsID);
+   mEffectUIHost.GetDefinition()
+      .LoadFactoryPreset(evt.GetId() - kFactoryPresetsID);
    
    return;
 }
@@ -892,9 +894,9 @@ void EffectUIHost::OnDeletePreset(wxCommandEvent & evt)
                                 wxICON_QUESTION | wxYES_NO);
    if (res == wxYES)
    {
-      RemoveConfigSubgroup(mEffect.GetDefinition(),
+      RemoveConfigSubgroup(mEffectUIHost.GetDefinition(),
          PluginSettings::Private,
-         mEffect.GetUserPresetsGroup(preset));
+         mEffectUIHost.GetUserPresetsGroup(preset));
    }
    
    LoadUserPresets();
@@ -971,7 +973,8 @@ void EffectUIHost::OnSaveAs(wxCommandEvent & WXUNUSED(evt))
          }
       }
       
-      mEffect.GetDefinition().SaveUserPreset(mEffect.GetUserPresetsGroup(name));
+      mEffectUIHost.GetDefinition()
+         .SaveUserPreset(mEffectUIHost.GetUserPresetsGroup(name));
       LoadUserPresets();
       
       break;
@@ -1007,7 +1010,7 @@ void EffectUIHost::OnOptions(wxCommandEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnDefaults(wxCommandEvent & WXUNUSED(evt))
 {
-   mEffect.GetDefinition().LoadFactoryDefaults();
+   mEffectUIHost.GetDefinition().LoadFactoryDefaults();
    
    return;
 }
@@ -1063,8 +1066,8 @@ void EffectUIHost::UpdateControls()
    }
    
    mApplyBtn->Enable(!mCapturing);
-   if ((mEffect.GetDefinition().GetType() != EffectTypeAnalyze) &&
-       (mEffect.GetDefinition().GetType() != EffectTypeTool) )
+   if ((mEffectUIHost.GetDefinition().GetType() != EffectTypeAnalyze) &&
+       (mEffectUIHost.GetDefinition().GetType() != EffectTypeTool) )
    {
       (!mIsGUI ? mPlayToggleBtn : mPlayBtn)->Enable(!(mCapturing || mDisableTransport));
    }
@@ -1128,8 +1131,8 @@ void EffectUIHost::LoadUserPresets()
 {
    mUserPresets.clear();
    
-   GetConfigSubgroups(mEffect.GetDefinition(), PluginSettings::Private,
-      mEffect.GetUserPresetsGroup(wxEmptyString), mUserPresets);
+   GetConfigSubgroups(mEffectUIHost.GetDefinition(), PluginSettings::Private,
+      mEffectUIHost.GetUserPresetsGroup(wxEmptyString), mUserPresets);
    
    std::sort( mUserPresets.begin(), mUserPresets.end() );
    
@@ -1139,7 +1142,8 @@ void EffectUIHost::LoadUserPresets()
 void EffectUIHost::InitializeRealtime()
 {
    if (mSupportsRealtime && !mInitialized) {
-      mpState = AudioIO::Get()->AddState(mProject, nullptr, GetID(mEffect));
+      mpState =
+         AudioIO::Get()->AddState(mProject, nullptr, GetID(mEffectUIHost));
       /*
       ProjectHistory::Get(mProject).PushState(
          XO("Added %s effect").Format(mpState->GetEffect()->GetName()),

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -15,7 +15,7 @@
 #include "EffectUI.h"
 
 #include "widgets/BasicMenu.h"
-#include "Effect.h"
+#include "ConfigInterface.h"
 #include "EffectManager.h"
 #include "PluginManager.h"
 #include "../ProjectHistory.h"
@@ -601,10 +601,18 @@ void EffectUIHost::OnCancel(wxCommandEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnHelp(wxCommandEvent & WXUNUSED(event))
 {
-   if (mEffectUIHost.GetDefinition().GetFamily() == NYQUISTEFFECTS_FAMILY && (mEffectUIHost.GetDefinition().ManualPage().empty())) {
+   if (mEffectUIHost.GetDefinition().ManualPage().empty()) {
+      // No manual page, so use help page
+
+      const auto &helpPage = mEffectUIHost.GetDefinition().HelpPage();
+      // It was guaranteed in Initialize() that there is no help
+      // button when neither manual nor help page is specified, so this
+      // event handler it not reachable in that case.
+      wxASSERT(!helpPage.empty());
+
       // Old ShowHelp required when there is no on-line manual.
       // Always use default web browser to allow full-featured HTML pages.
-      HelpSystem::ShowHelp(FindWindow(wxID_HELP), mEffectUIHost.GetDefinition().HelpPage(), wxEmptyString, true, true);
+      HelpSystem::ShowHelp(FindWindow(wxID_HELP), helpPage, wxEmptyString, true, true);
    }
    else {
       // otherwise use the NEW ShowHelp

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -95,7 +95,7 @@ private:
 
    AudacityProject &mProject;
    wxWindow *mParent;
-   EffectUIHostInterface &mEffect;
+   EffectUIHostInterface &mEffectUIHost;
    EffectUIClientInterface &mClient;
    RealtimeEffectState *mpState{ nullptr };
 

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -33,7 +33,6 @@ struct AudioIOEvent;
 
 class AudacityCommand;
 class AudacityProject;
-class Effect;
 class RealtimeEffectState;
 
 class wxCheckBox;
@@ -45,7 +44,7 @@ public:
    // constructors and destructors
    EffectUIHost(wxWindow *parent,
                 AudacityProject &project,
-                Effect &effect,
+                EffectUIHostInterface &effect,
                 EffectUIClientInterface &client);
    virtual ~EffectUIHost();
 
@@ -96,7 +95,7 @@ private:
 
    AudacityProject &mProject;
    wxWindow *mParent;
-   Effect &mEffect;
+   EffectUIHostInterface &mEffect;
    EffectUIClientInterface &mClient;
    RealtimeEffectState *mpState{ nullptr };
 
@@ -147,7 +146,7 @@ class CommandContext;
 namespace  EffectUI {
 
    AUDACITY_DLL_API
-   wxDialog *DialogFactory( wxWindow &parent, EffectHostInterface &host,
+   wxDialog *DialogFactory( wxWindow &parent, EffectUIHostInterface &host,
       EffectUIClientInterface &client);
 
    /** Run an effect given the plugin ID */

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -796,8 +796,6 @@ VSTEffectOptionsDialog::VSTEffectOptionsDialog(wxWindow * parent,
 , mHost{ host }
 , mEffect{ effect }
 {
-   mHost = host;
-
    GetConfig(mEffect, PluginSettings::Shared, wxT("Options"),
       wxT("BufferSize"), mBufferSize, 8192);
    GetConfig(mEffect, PluginSettings::Shared, wxT("Options"),

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -279,11 +279,6 @@ public:
       return false;
    }
 
-   bool IsLegacy() override
-   {
-      return false;
-   }
-
    bool SupportsRealtime() override
    {
       return mType == EffectTypeProcess;
@@ -1281,11 +1276,6 @@ bool VSTEffect::IsInteractive()
 }
 
 bool VSTEffect::IsDefault()
-{
-   return false;
-}
-
-bool VSTEffect::IsLegacy()
 {
    return false;
 }

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -113,7 +113,6 @@ class VSTEffect final : public wxEvtHandler,
    EffectFamilySymbol GetFamily() override;
    bool IsInteractive() override;
    bool IsDefault() override;
-   bool IsLegacy() override;
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -952,11 +952,6 @@ bool AudioUnitEffect::IsDefault()
    return false;
 }
 
-bool AudioUnitEffect::IsLegacy()
-{
-   return false;
-}
-
 bool AudioUnitEffect::SupportsRealtime()
 {
    return GetType() == EffectTypeProcess;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -21,6 +21,7 @@
 #include "AudacityException.h"
 #include "ModuleManager.h"
 #include "SampleCount.h"
+#include "ConfigInterface.h"
 
 #include <wx/defs.h>
 #include <wx/base64.h>

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -62,7 +62,6 @@ public:
    EffectFamilySymbol GetFamily() override;
    bool IsInteractive() override;
    bool IsDefault() override;
-   bool IsLegacy() override;
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -709,11 +709,6 @@ bool LadspaEffect::IsDefault()
    return false;
 }
 
-bool LadspaEffect::IsLegacy()
-{
-   return false;
-}
-
 bool LadspaEffect::SupportsRealtime()
 {
    return GetType() != EffectTypeGenerate;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -25,6 +25,7 @@ effects from this one class.
 
 #include "LadspaEffect.h"       // This class's header file
 #include "SampleCount.h"
+#include "ConfigInterface.h"
 
 #include <float.h>
 #include <thread>

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -61,7 +61,6 @@ public:
    EffectFamilySymbol GetFamily() override;
    bool IsInteractive() override;
    bool IsDefault() override;
-   bool IsLegacy() override;
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -48,6 +48,7 @@
 #include <wx/scrolwin.h>
 
 #include "AudacityException.h"
+#include "ConfigInterface.h"
 #include "../../EffectHostInterface.h"
 #include "../../ShuttleGui.h"
 #include "../../widgets/valnum.h"

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -504,11 +504,6 @@ bool LV2Effect::IsDefault()
    return false;
 }
 
-bool LV2Effect::IsLegacy()
-{
-   return false;
-}
-
 bool LV2Effect::SupportsRealtime()
 {
    return GetType() == EffectTypeProcess;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -274,7 +274,6 @@ public:
    EffectFamilySymbol GetFamily() override;
    bool IsInteractive() override;
    bool IsDefault() override;
-   bool IsLegacy() override;
    bool SupportsRealtime() override;
    bool SupportsAutomation() override;
 


### PR DESCRIPTION
Partly Resolves: #2084

Make the interfaace EffectUIHostInterface almost sufficient for the needs of EffectManager, so it has less dependency on
fat class Effect.

The remaining exception is the use of Effect::Startup, to be addressed later.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
