### PR TITLE
Proposal Auto Detect Audio Device Changes #2409

### DIFF
--- a/src/prefs/DevicePrefs.cpp
+++ b/src/prefs/DevicePrefs.cpp
@@ -83,6 +83,8 @@ void DevicePrefs::Populate()
 {
    // First any pre-processing for constructing the GUI.
    GetNamesAndLabels();
+   
+   Bind(wxEVT_ENTER_WINDOW, &DevicePrefs::OnToolbarEntry, this);
 
    // Get current setting for devices
    mPlayDevice = AudioIOPlaybackDevice.Read();
@@ -207,6 +209,11 @@ void DevicePrefs::PopulateOrExchange(ShuttleGui & S)
    S.EndStatic();
    S.EndScroller();
 
+}
+
+void DevicePrefs::OnToolbarEntry(wxMouseEvent &event)
+{
+   DeviceManager::Instance()->Rescan();
 }
 
 void DevicePrefs::OnHost(wxCommandEvent & e)

--- a/src/prefs/DevicePrefs.h
+++ b/src/prefs/DevicePrefs.h
@@ -39,6 +39,7 @@ class DevicePrefs final : public PrefsPanel
 
    void OnHost(wxCommandEvent & e);
    void OnDevice(wxCommandEvent & e);
+   void OnToolbarEntry(wxMouseEvent & event);
 
    TranslatableStrings mHostNames;
    wxArrayStringEx mHostLabels;

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -207,6 +207,9 @@ void DeviceToolBar::Populate()
    mInputChannels->Bind(wxEVT_KILL_FOCUS,
                  &DeviceToolBar::OnFocus,
                  this);
+   Bind(wxEVT_ENTER_WINDOW,
+                 &DeviceToolBar::OnToolbarEntry,
+                 this);
 
    SetNames();
 
@@ -216,6 +219,11 @@ void DeviceToolBar::Populate()
 void DeviceToolBar::OnFocus(wxFocusEvent &event)
 {
    KeyboardCapture::OnFocus( *this, event );
+}
+
+void DeviceToolBar::OnToolbarEntry(wxMouseEvent &event)
+{
+   DeviceManager::Instance()->Rescan();
 }
 
 void DeviceToolBar::OnCaptureKey(wxCommandEvent &event)
@@ -707,6 +715,7 @@ void DeviceToolBar::ShowChannelsDialog()
 
 void DeviceToolBar::ShowComboDialog(wxChoice *combo, const TranslatableString &title)
 {
+   DeviceManager::Instance()->Rescan();
    if (!combo || combo->GetCount() == 0) {
       AudacityMessageBox( XO("Device information is not available.") );
       return;

--- a/src/toolbars/DeviceToolBar.h
+++ b/src/toolbars/DeviceToolBar.h
@@ -47,6 +47,7 @@ class DeviceToolBar final : public ToolBar {
    void OnCaptureKey(wxCommandEvent &event);
 
    void OnChoice(wxCommandEvent & event);
+   void OnToolbarEntry(wxMouseEvent &event);
 
    /// When the prefs don't exist this value is used.
    /// 883 takes a complete row in the default initial size of Audacity.


### PR DESCRIPTION
Trigger Device Rescans whenever a user moves his mouse to the Audacity Device Toolbar or usethe Selection window via the keyboard shortcut or tries to move the mouse inside the Edit>Preferences>Devices
Dialog for device choices. Use Bind() with wxEVT_ENTER_WINDOW mouse event for the DeviceToolbar window and
DevicePrefs window.

Resolves: https://github.com/audacity/audacity/issues/2409

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
