### PR TITLE
Unit testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,11 @@ jobs:
         cmake_options: ${{ env.CONFIGURE_CMAKE_OPTIONS }}
     - name: Build
       uses: audacity/audacity-actions/build@v1
+    - name: Test
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        run: ctest -C ${{ env.BUILD_TYPE }} --verbose
+        working-directory: ./.build.x64/
     - name: Package
       uses: audacity/audacity-actions/package@v1
       with:
@@ -195,6 +200,12 @@ jobs:
         windows_certificate_password: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
     - name: Build
       uses: audacity/audacity-actions/build@v1
+    - name: Test
+      shell: pwsh
+      run: |
+        pushd .build.${{ matrix.config.arch }}
+        ctest -C ${{ env.BUILD_TYPE }} --verbose
+        popd
     - name: Package
       uses: audacity/audacity-actions/package@v1
       with:
@@ -220,6 +231,12 @@ jobs:
         arch: x64
     - name: Build x86_64
       uses: audacity/audacity-actions/build@v1
+    - name: Test
+      shell: bash
+      run: |
+        pushd .build.x64
+        ctest -C ${{ env.BUILD_TYPE }} --verbose
+        popd
     - name: 'Tar files'
       shell: bash
       run: tar cf macos_intel.tar .build.x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,18 @@ cmd_option( ${_OPT}has_networking
    "Build networking features into Audacity"
    Off)
 
+include( CMakeDependentOption )
+
+cmake_dependent_option(
+   ${_OPT}has_tests
+   "Enables automated testing support"
+   On
+   "${_OPT}conan_enabled"
+   Off
+)
+
 include( AudacityDependencies )
+include( AudacityTesting )
 
 # Pull all the modules we'll need
 include( CheckCXXCompilerFlag )
@@ -202,7 +213,6 @@ include( CheckIncludeFiles )
 include( CheckLibraryExists )
 include( CheckSymbolExists )
 include( CheckTypeSize )
-include( CMakeDependentOption )
 include( CMakeDetermineASM_NASMCompiler )
 include( CMakePushCheckState )
 include( GNUInstallDirs )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,6 +624,8 @@ if(${_OPT}has_crashreports)
    add_subdirectory( "crashreports" )
 endif()
 
+add_subdirectory( "tests/journals" )
+
 # Generate config file
 if( CMAKE_SYSTEM_NAME MATCHES "Windows" )
    configure_file( src/audacity_config.h.in src/private/configwin.h )

--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -518,6 +518,11 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
       list( APPEND GRAPH_EDGES "\"${TARGET}\" -> \"${IMPORT}\"" )
    endforeach()
    set( GRAPH_EDGES "${GRAPH_EDGES}" PARENT_SCOPE )
+
+   # collect unit test targets if they are present
+   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests")
+      add_subdirectory(tests)
+   endif()
 endfunction()
 
 # Set up for defining a module target.

--- a/cmake-proxies/cmake-modules/AudacityTesting.cmake
+++ b/cmake-proxies/cmake-modules/AudacityTesting.cmake
@@ -1,0 +1,144 @@
+if( ${_OPT}has_tests )
+
+   set( TESTS_DIR "${CMAKE_BINARY_DIR}/tests" )
+
+   if( CMAKE_CONFIGURATION_TYPES )
+      set( TESTS_DEST_DIR "${CMAKE_BINARY_DIR}/tests/${CMAKE_CFG_INTDIR}" )
+   else()
+      set( TESTS_DEST_DIR "${CMAKE_BINARY_DIR}/tests/${CMAKE_BUILD_TYPE}" )
+   endif()
+
+   # Install Catch2 framework
+
+   add_conan_lib(
+      Catch2
+      catch2/2.13.8
+      REQUIRED
+      ALWAYS_ALLOW_CONAN_FALLBACK
+   )
+
+   # Setup default CTest arguments when running from IDE
+
+   set(CMAKE_CTEST_ARGUMENTS "--output-on-failure;--verbose;${CMAKE_CTEST_ARGUMENTS}")
+
+   enable_testing()
+
+   #[[
+      add_unit_test(NAME name SOURCES file1 ... LIBRARIES lib1 ...)
+
+      Creates an executable called ${name}-test from the source files ${file1}, ... and linked
+      to libraries ${lib1}, ... Catch2 is linked implicitly.
+
+      Create a CTest test called ${name}, that expects 0 code on success
+   ]]
+   function( add_unit_test )
+      cmake_parse_arguments(
+         ADD_UNIT_TEST # Prefix
+         "" # Options
+         "NAME" # One value keywords
+         "SOURCES;LIBRARIES"
+         ${ARGN}
+      )
+
+      if( NOT ADD_UNIT_TEST_NAME )
+         message( FATAL_ERROR "Missing required NAME parameter for the add_unit_test")
+      endif()
+
+      set( test_executable_name "${ADD_UNIT_TEST_NAME}-test" )
+
+      # Create test executable
+
+      add_executable( ${test_executable_name} ${ADD_UNIT_TEST_SOURCES} "${CMAKE_SOURCE_DIR}/tests/Catch2Main.cpp")
+      target_link_libraries( ${test_executable_name} ${ADD_UNIT_TEST_LIBRARIES} Catch2::Catch2 )
+
+      set_target_properties(
+         ${test_executable_name}
+         PROPERTIES
+            FOLDER "tests" # for IDE organization
+            RUNTIME_OUTPUT_DIRECTORY ${TESTS_DIR}
+            BUILD_RPATH ${_SHARED_PROXY_PATH}
+            # Allow running tests from Visual Studio by setting up the proper PATH
+            VS_DEBUGGER_ENVIRONMENT "PATH=${_SHARED_PROXY_PATH};%PATH%"
+      )
+
+      # Register unit test with CTest
+
+      add_test(
+         NAME
+            ${ADD_UNIT_TEST_NAME}
+         COMMAND
+            ${test_executable_name}
+      )
+
+      set_tests_properties(
+         ${ADD_UNIT_TEST_NAME}
+         PROPERTIES
+            LABELS "unit_tests"
+      )
+
+      if( WIN32 )
+         # On Windows, set the PATH so it points to the DLL location
+         # This is required to avoid invoking CopyLibs.
+
+         # CTest expects that ENVIRONMENT is a CMake list.
+         # Escape ';' so PATH is handled correctly
+         string(REPLACE ";" "\\;" escaped_path "$ENV{PATH}")
+
+         set_tests_properties(
+            ${ADD_UNIT_TEST_NAME}
+            PROPERTIES
+               ENVIRONMENT "PATH=$<SHELL_PATH:${_SHARED_PROXY_BASE_PATH}/$<CONFIG>>\\;${escaped_path}"
+         )
+      elseif( APPLE )
+         # We target an old version of macOS, disable std::uncaught_exceptions
+         target_compile_definitions( ${test_executable_name} PRIVATE CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS )
+         # Similar to Windows, but uses DYLD_FALLBACK_LIBRARY_PATH istead of PATH
+         set_tests_properties(
+            ${ADD_UNIT_TEST_NAME}
+            PROPERTIES
+               ENVIRONMENT "DYLD_FALLBACK_LIBRARY_PATH=$<SHELL_PATH:${_SHARED_PROXY_BASE_PATH}/$<CONFIG>>"
+         )
+      endif()
+   endfunction()
+
+   #[[
+      add_journal_test(journal_file)
+
+      Adds a test, that runs Audacity with the journal ${journal_file}.
+
+      Test name is based on the name component of the ${journal_file}
+   ]]
+   function( add_journal_test journal_file )
+      get_filename_component(test_name ${journal_file} NAME_WE)
+
+      if( APPLE )
+         # On macOS CMake will generate a placeholder that CTest fails to handle correctly,
+         # so we have to setup the path manually
+         set( audacity_target "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>/Audacity.app/Contents/MacOS/Audacity" )
+      else()
+         set( audacity_target "$<TARGET_FILE:Audacity>" )
+      endif()
+
+      # Adds a test that invokes Audacity with the given journal file
+
+      add_test(
+         NAME
+            ${test_name}
+         COMMAND
+            ${audacity_target} --journal ${journal_file}
+      )
+
+      set_tests_properties(
+         ${ADD_UNIT_TEST_NAME}
+         PROPERTIES
+            LABELS "journal_tests"
+      )
+   endfunction()
+else()
+   # Just a placeholder for the cases unit testing is disabled
+   function(add_unit_test)
+   endfunction()
+
+   function( add_journal_test journal_file )
+   endfunction()
+endif()

--- a/libraries/lib-string-utils/FromChars.h
+++ b/libraries/lib-string-utils/FromChars.h
@@ -17,7 +17,7 @@ struct STRING_UTILS_API FromCharsResult final
 {
    const char* ptr; //! A pointer to the first character not matching the pattern
 
-   //! std::errc::invalid_argument, if there is no pattern mactch,
+   //! std::errc::invalid_argument, if there is no pattern match,
    //! std::errc::result_out_of_range if the value parsed is too large,
    //! std::errc() on success
    std::errc ec; 

--- a/libraries/lib-string-utils/tests/CMakeLists.txt
+++ b/libraries/lib-string-utils/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_unit_test(
+   NAME
+      lib-string-utils
+   SOURCES
+      FromCharsTests.cpp
+   LIBRARIES
+      lib-string-utils
+)

--- a/libraries/lib-string-utils/tests/FromCharsTests.cpp
+++ b/libraries/lib-string-utils/tests/FromCharsTests.cpp
@@ -1,0 +1,123 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file FromCharsTests.cpp
+ @brief Tests for the FromChars functions
+
+ Dmitry Vedenko
+ **********************************************************************/
+
+#include <catch2/catch.hpp>
+
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include "FromChars.h"
+
+template <typename T>
+void TestFromChars(std::string_view input, T expectedValue, std::errc errc = {})
+{
+   T value;
+
+   const auto result =
+      FromChars(input.data(), input.data() + input.length(), value);
+
+   REQUIRE(errc == result.ec);
+
+   if (errc == std::errc {})
+   {
+      if constexpr (std::is_floating_point_v<std::decay_t<T>>)
+         REQUIRE(Approx(expectedValue) == value);
+      else
+         REQUIRE(expectedValue == value);
+
+      REQUIRE(result.ptr == input.data() + input.length());
+   }
+}
+
+TEMPLATE_TEST_CASE(
+   "FromChars/signed integers", "", short, int, long, long long)
+{
+   TestFromChars<TestType>("0", 0, {});
+   TestFromChars<TestType>("1", 1, {});
+   TestFromChars<TestType>("-1", -1, {});
+   TestFromChars<TestType>("127", 127, {});
+   TestFromChars<TestType>("-12", -12, {});
+
+   TestFromChars<TestType>("", {}, std::errc::invalid_argument);
+   TestFromChars<TestType>("a", {}, std::errc::invalid_argument);
+
+   TestFromChars<TestType>(
+      std::to_string(std::numeric_limits<TestType>::min()),
+      std::numeric_limits<TestType>::min(), {});
+
+   TestFromChars<TestType>(
+      std::to_string(std::numeric_limits<TestType>::max()),
+      std::numeric_limits<TestType>::max(), {});
+
+   TestFromChars<TestType>(
+      std::to_string(std::numeric_limits<TestType>::min()) + "0",
+      std::numeric_limits<TestType>::min(), std::errc::result_out_of_range);
+
+   TestFromChars<TestType>(
+      std::to_string(std::numeric_limits<TestType>::max()) + "0",
+      std::numeric_limits<TestType>::max(), std::errc::result_out_of_range);
+}
+
+TEMPLATE_TEST_CASE(
+   "FromChars/unsigned integers", "", unsigned short, unsigned int,
+   unsigned long, unsigned long long)
+{
+   TestFromChars<TestType>("0", 0, {});
+   TestFromChars<TestType>("1", 1, {});
+   TestFromChars<TestType>("-1", -1, std::errc::invalid_argument);
+   TestFromChars<TestType>("127", 127, {});
+   TestFromChars<TestType>("-12", -12, std::errc::invalid_argument);
+
+   TestFromChars<TestType>("", {}, std::errc::invalid_argument);
+   TestFromChars<TestType>("a", {}, std::errc::invalid_argument);
+
+   TestFromChars<TestType>(
+      std::to_string(std::numeric_limits<TestType>::min()),
+      std::numeric_limits<TestType>::min(), {});
+
+   TestFromChars<TestType>(
+      std::to_string(std::numeric_limits<TestType>::max()),
+      std::numeric_limits<TestType>::max(), {});
+
+   TestFromChars<TestType>(
+      std::to_string(std::numeric_limits<TestType>::max()) + "0",
+      std::numeric_limits<TestType>::max(), std::errc::result_out_of_range);
+}
+
+TEMPLATE_TEST_CASE("FromChars/floats", "", float, double)
+{
+   TestFromChars<TestType>("0", 0, {});
+   TestFromChars<TestType>("0.0", 0, {});
+   TestFromChars<TestType>(".0", 0, {});
+   TestFromChars<TestType>("1", 1, {});
+   TestFromChars<TestType>("-1", -1, {});
+   TestFromChars<TestType>("127", 127, {});
+   TestFromChars<TestType>("-12", -12, {});
+   TestFromChars<TestType>("-12.5", -12.5, {});
+   TestFromChars<TestType>("3.1415", 3.1415, {});
+   TestFromChars<TestType>("3.14159265359", 3.14159265359, {});
+
+   for (auto magnitude = std::numeric_limits<TestType>::min_exponent10;
+        magnitude <= std::numeric_limits<TestType>::max_exponent10; ++magnitude)
+   {
+      TestFromChars(
+         "1e" + std::to_string(magnitude), std::pow(10, magnitude), {});
+
+      TestFromChars(
+         "-1e" + std::to_string(magnitude), -std::pow(10, magnitude), {});
+   }
+
+   TestFromChars<TestType>("", {}, std::errc::invalid_argument);
+   TestFromChars<TestType>("a", {}, std::errc::invalid_argument);
+
+   TestFromChars<TestType>(
+      "1e1000", std::numeric_limits<TestType>::infinity(), {});
+}

--- a/src/update/UpdateManager.cpp
+++ b/src/update/UpdateManager.cpp
@@ -57,12 +57,12 @@ UpdateManager& UpdateManager::GetInstance()
     return updateManager;
 }
 
-void UpdateManager::Start()
+void UpdateManager::Start(bool suppressModal)
 {
     auto& instance = GetInstance();
 
     // Show the dialog only once. 
-    if (!prefUpdatesNoticeShown.Read())
+    if (!suppressModal && !prefUpdatesNoticeShown.Read())
     {
         // DefaultUpdatesCheckingFlag survives the "Reset Preferences"
         // action, so check, if the updates were previously disabled as well.

--- a/src/update/UpdateManager.h
+++ b/src/update/UpdateManager.h
@@ -36,7 +36,7 @@ public:
     UpdateManager() = default;
 
     static UpdateManager& GetInstance();
-    static void Start();
+    static void Start(bool suppressModal);
 
     void GetUpdates(bool ignoreNetworkErrors, bool configurableNotification);
 

--- a/tests/Catch2Main.cpp
+++ b/tests/Catch2Main.cpp
@@ -1,0 +1,9 @@
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/tests/journals/CMakeLists.txt
+++ b/tests/journals/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_journal_test( "${CMAKE_CURRENT_SOURCE_DIR}/journal_sanity.txt" )

--- a/tests/journals/journal_sanity.txt
+++ b/tests/journals/journal_sanity.txt
@@ -1,0 +1,3 @@
+#Journal recorded by veden on 08/02/2022 14:08:54
+Version,1
+CM,Exit


### PR DESCRIPTION
Resolves: #2478 

This PR introduces a framework for automated testing in Audacity. It is now possible to define the following types of tests:

### Unit Tests

`add_unit_test(NAME name SOURCES file1 ... LIBRARIES lib1 ...)`

This function creates an executable called `${name}-test` from the sources files (`${file1}`, ...). and linked to libraries (`${lib1}`, ...).

Catch2 is linked implicitly. There is no need to define a main function in the unit test.

### Journal Tests

`add_journal_test(journal_file)`

Adds a test, that runs Audacity with the journal `${journal_file}`. The test name is based on the name component of the `${journal_file}`.

---

Both unit and journal tests are registered with the CTest framework. This PR implements unit tests for FromChars set of functions and a journal test that checks that we can run Audacity at all. 

To be able to run journal tests Audacity now suppresses a few modal dialogs, shown during the startup:

* update permission dialog,
* auto-recovery dialog,
* extension registration on Windows.

For libraries, if the `libraries/(name)/tests` directory is present - CMake will include the unit tests for the library automatically. 

The `Build Audacity` workflow will run both unit and journal tests for each build. In the future, journal tests can be separated into a different nightly workflow. 

### Examples

Adding a unit test:

```
add_unit_test(
   NAME
      lib-string-utils
   SOURCES
      FromCharsTests.cpp
   LIBRARIES
      lib-string-utils
)
```

Adding a journal test:

```
add_journal_test( "journal_sanity.txt" )
```

Running tests:

```
$ ctest -C Debug
```

---------------------------------------------------------------------------------------------------------------

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
