### PR TITLE
Independent effect states

### DIFF
--- a/libraries/lib-components/CMakeLists.txt
+++ b/libraries/lib-components/CMakeLists.txt
@@ -6,9 +6,9 @@ for storing as a configuration file value) with a user-visible translatable
 string.  It serves to "name" various things.
 
 CommandParameters, for write and reading key-value pairs to and from strings.
-]]#
+]]
 
-list( APPEND SOURCES
+set( SOURCES
    ComponentInterface.cpp
    ComponentInterface.h
    ComponentInterfaceSymbol.h
@@ -19,7 +19,12 @@ list( APPEND SOURCES
    ModuleInterface.cpp
    ModuleInterface.h
 )
-audacity_library( lib-components "${SOURCES}"
-   "lib-strings-interface;PRIVATE;wxBase"
+set( LIBRARIES
+   lib-strings-interface
+   lib-utility
+   PRIVATE
+   wxBase
+)
+audacity_library( lib-components "${SOURCES}" "${LIBRARIES}"
    "" ""
 )

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -97,6 +97,46 @@ bool EffectDefinitionInterfaceEx::LoadSettings(
       return false;
 }
 
+bool EffectDefinitionInterfaceEx::LoadUserPreset(
+   const RegistryPath & name, Settings &settings) const
+{
+   if (auto pEffect = FindMe(settings))
+      // Call through to old interface
+      return pEffect->LoadUserPreset(name);
+   else
+      return false;
+}
+
+bool EffectDefinitionInterfaceEx::SaveUserPreset(
+   const RegistryPath & name, const Settings &settings) const
+{
+   if (auto pEffect = FindMe(settings))
+      // Call through to old interface
+      return pEffect->SaveUserPreset(name);
+   else
+      return false;
+}
+
+bool EffectDefinitionInterfaceEx::LoadFactoryPreset(
+   int id, Settings &settings) const
+{
+   if (auto pEffect = FindMe(settings))
+      // Call through to old interface
+      return pEffect->LoadFactoryPreset(id);
+   else
+      return false;
+}
+
+bool EffectDefinitionInterfaceEx::LoadFactoryDefaults(
+   Settings &settings) const
+{
+   if (auto pEffect = FindMe(settings))
+      // Call through to old interface
+      return pEffect->LoadFactoryDefaults();
+   else
+      return false;
+}
+
 EffectDefinitionInterfaceEx *
 EffectDefinitionInterfaceEx::FindMe(const Settings &settings) const
 {

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -56,6 +56,42 @@ bool EffectDefinitionInterface::IsHiddenFromMenus()
    return false;
 }
 
+auto EffectDefinitionInterfaceEx::MakeSettings() const -> Settings
+{
+   // Temporary default implementation just saves self
+   // Cast away const! Capture pointer to self
+   return Settings( const_cast<EffectDefinitionInterfaceEx*>(this) );
+}
+
+bool EffectDefinitionInterfaceEx::SaveSettings(
+   const Settings &settings, CommandParameters & parms) const
+{
+   if (auto pEffect = FindMe(settings))
+      // Call through to old interface
+      return pEffect->GetAutomationParameters(parms);
+   else
+      return false;
+}
+
+bool EffectDefinitionInterfaceEx::LoadSettings(
+   CommandParameters & parms, Settings &settings) const
+{
+   if (auto pEffect = FindMe(settings))
+      // Call through to old interface
+      return pEffect->SetAutomationParameters(parms);
+   else
+      return false;
+}
+
+EffectDefinitionInterfaceEx *
+EffectDefinitionInterfaceEx::FindMe(const Settings &settings) const
+{
+   if (auto ppEffect = settings.cast<EffectDefinitionInterfaceEx*>();
+       ppEffect && *ppEffect == this)
+      return *ppEffect;
+   return nullptr;
+}
+
 //bool EffectDefinitionInterface::DefineParams(ShuttleParams & S)
 //{
 //   return false;

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -1,4 +1,4 @@
-/**********************************************************************
+/*!********************************************************************
 
   Audacity: A Digital Audio Editor
 
@@ -7,6 +7,20 @@
 **********************************************************************/
 #include "EffectInterface.h"
 #include <wx/tokenzr.h>
+
+EffectSettingsAccess::~EffectSettingsAccess() = default;
+
+SimpleEffectSettingsAccess::~SimpleEffectSettingsAccess() = default;
+
+const EffectSettings &SimpleEffectSettingsAccess::Get()
+{
+   return mSettings;
+}
+
+void SimpleEffectSettingsAccess::Set(EffectSettings &&settings)
+{
+   mSettings = std::move(settings);
+}
 
 Identifier EffectDefinitionInterface::GetSquashedName(const Identifier &ident)
 {

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -77,6 +77,13 @@ auto EffectDefinitionInterfaceEx::MakeSettings() const -> Settings
    return Settings( const_cast<EffectDefinitionInterfaceEx*>(this) );
 }
 
+bool EffectDefinitionInterfaceEx::CopySettingsContents(
+   const EffectSettings &src, EffectSettings &dst) const
+{
+   //! No real copy, just a sanity check on common origin
+   return FindMe(src) && FindMe(dst);
+}
+
 bool EffectDefinitionInterfaceEx::SaveSettings(
    const Settings &settings, CommandParameters & parms) const
 {

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -138,9 +138,6 @@ public:
    //! Save current settings as a user-named preset
    virtual bool SaveUserPreset(const RegistryPath & name) = 0;
 
-   //! Report names of factory presets
-   virtual RegistryPaths GetFactoryPresets() = 0;
-
    //! Change settings to the preset whose name is `GetFactoryPresets()[id]`
    virtual bool LoadFactoryPreset(int id) = 0;
    //! Change settings back to "factory default"
@@ -170,6 +167,8 @@ public:
    virtual bool LoadSettings(
       CommandParameters & parms, Settings &settings) const = 0;
 
+   //! Report names of factory presets
+   virtual RegistryPaths GetFactoryPresets() const = 0;
    //! @}
 };
 

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -154,23 +154,6 @@ public:
    // functionality.
    //virtual bool DefineParams( ShuttleParams & S);
 
-   /*! @name Old settings interface
-    Old interface for saving and loading non-externalized settings
-    */
-   //! @{
-
-   //! Change settings to a user-named preset
-   virtual bool LoadUserPreset(const RegistryPath & name) = 0;
-   //! Save current settings as a user-named preset
-   virtual bool SaveUserPreset(const RegistryPath & name) = 0;
-
-   //! Change settings to the preset whose name is `GetFactoryPresets()[id]`
-   virtual bool LoadFactoryPreset(int id) = 0;
-   //! Change settings back to "factory default"
-   virtual bool LoadFactoryDefaults() = 0;
-
-   //! @}
-
    /*! @name settings
     Interface for saving and loading externalized settings.
     All methods are const!
@@ -195,6 +178,18 @@ public:
 
    //! Report names of factory presets
    virtual RegistryPaths GetFactoryPresets() const = 0;
+
+   //! Change settings to a user-named preset
+   virtual bool LoadUserPreset(
+      const RegistryPath & name, Settings &settings) const = 0;
+   //! Save settings in the configuration file as a user-named preset
+   virtual bool SaveUserPreset(
+      const RegistryPath & name, const Settings &settings) const = 0;
+
+   //! Change settings to the preset whose name is `GetFactoryPresets()[id]`
+   virtual bool LoadFactoryPreset(int id, Settings &settings) const = 0;
+   //! Change settings back to "factory default"
+   virtual bool LoadFactoryDefaults(Settings &settings) const = 0;
    //! @}
 };
 
@@ -203,6 +198,8 @@ public:
  (Default implementations of EffectDefinitionInterface methods for settings call
  through to the old interface, violating const correctness.  This is meant to be
  transitional only.)
+
+ This interface is not used by the EffectUIHost dialog.
  */
 class COMPONENTS_API EffectDefinitionInterfaceEx  /* not final */
    : public EffectDefinitionInterface
@@ -216,6 +213,16 @@ public:
    virtual bool GetAutomationParameters(CommandParameters & parms) = 0;
    //! Change settings to those stored in parms
    virtual bool SetAutomationParameters(CommandParameters & parms) = 0;
+
+   //! Change settings to a user-named preset
+   virtual bool LoadUserPreset(const RegistryPath & name) = 0;
+   //! Save current settings as a user-named preset
+   virtual bool SaveUserPreset(const RegistryPath & name) = 0;
+
+   //! Change settings to the preset whose name is `GetFactoryPresets()[id]`
+   virtual bool LoadFactoryPreset(int id) = 0;
+   //! Change settings back to "factory default"
+   virtual bool LoadFactoryDefaults() = 0;
    //! @}
 
    /*! @name settings
@@ -228,6 +235,13 @@ public:
       const Settings &settings, CommandParameters & parms) const override;
    bool LoadSettings(
       CommandParameters & parms, Settings &settings) const override;
+
+   bool LoadUserPreset(
+      const RegistryPath & name, Settings &settings) const override;
+   bool SaveUserPreset(
+      const RegistryPath & name, const Settings &settings) const override;
+   bool LoadFactoryPreset(int id, Settings &settings) const override;
+   bool LoadFactoryDefaults(Settings &settings) const override;
    //! @}
 
 private:

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -162,6 +162,21 @@ public:
    //! Produce an object holding new, independent settings
    virtual Settings MakeSettings() const = 0;
 
+   //! Update one settings object from another
+   /*!
+    This may run in a worker thread, and should avoid memory allocations.
+    Therefore do not copy the underlying std::any, but copy the contents of the
+    contained objects.
+
+    Assume that src and dst were created and previously modified only by `this`
+
+    @param src settings to copy from
+    @param dst settings to copy into
+    @return success
+    */
+   virtual bool CopySettingsContents(
+      const EffectSettings &src, EffectSettings &dst) const = 0;
+
    //! Store settings as keys and values
    /*!
     @return true on success
@@ -231,6 +246,8 @@ public:
     */
    //! @{
    Settings MakeSettings() const override;
+   bool CopySettingsContents(
+      const EffectSettings &src, EffectSettings &dst) const override;
    bool SaveSettings(
       const Settings &settings, CommandParameters & parms) const override;
    bool LoadSettings(

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -374,7 +374,7 @@ public:
    virtual bool IsGraphicalUI() = 0;
 
    //! Adds controls to a panel that is given as the parent window of `S`
-   virtual bool PopulateUI(ShuttleGui &S) = 0;
+   virtual bool PopulateUI(ShuttleGui &S, EffectSettingsAccess &access) = 0;
 
    virtual bool ValidateUI() = 0;
    virtual bool HideUI() = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -1,8 +1,8 @@
-/**********************************************************************
+/*!********************************************************************
 
    Audacity: A Digital Audio Editor
 
-   EffectInterface.h
+   @file EffectInterface.h
 
    Leland Lucius
 
@@ -66,6 +66,30 @@ using EffectFamilySymbol = ComponentInterfaceSymbol;
 //! Externalized state of a plug-in
 struct EffectSettings : audacity::TypedAny<EffectSettings> {
    using TypedAny::TypedAny;
+};
+
+//! Interface for accessing an EffectSettings that may change asynchronously in
+//! another thread; to be used in the main thread, only.
+/*! Updates are communicated atomically both ways.  The address of Get() should
+ not be relied on as unchanging between calls. */
+class COMPONENTS_API EffectSettingsAccess {
+public:
+   virtual ~EffectSettingsAccess();
+   virtual const EffectSettings &Get() = 0;
+   virtual void Set(EffectSettings &&settings) = 0;
+};
+
+//! Implementation of EffectSettings for cases where there is only one thread.
+class COMPONENTS_API SimpleEffectSettingsAccess final
+   : public EffectSettingsAccess {
+public:
+   explicit SimpleEffectSettingsAccess(EffectSettings &settings)
+      : mSettings{settings} {}
+   ~SimpleEffectSettingsAccess() override;
+   const EffectSettings &Get() override;
+   void Set(EffectSettings &&settings) override;
+private:
+   EffectSettings &mSettings;
 };
 
 /*************************************************************************************//**

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -47,6 +47,7 @@
 #include "EffectAutomationParameters.h" // for command automation
 
 #include "TypedAny.h"
+#include <memory>
 
 class ShuttleGui;
 
@@ -72,7 +73,8 @@ struct EffectSettings : audacity::TypedAny<EffectSettings> {
 //! another thread; to be used in the main thread, only.
 /*! Updates are communicated atomically both ways.  The address of Get() should
  not be relied on as unchanging between calls. */
-class COMPONENTS_API EffectSettingsAccess {
+class COMPONENTS_API EffectSettingsAccess
+   : public std::enable_shared_from_this<EffectSettingsAccess> {
 public:
    virtual ~EffectSettingsAccess();
    virtual const EffectSettings &Get() = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -341,10 +341,12 @@ public:
    virtual bool RealtimeFinalize() noexcept = 0;
    virtual bool RealtimeSuspend() = 0;
    virtual bool RealtimeResume() noexcept = 0;
-   virtual bool RealtimeProcessStart() = 0;
+   //! settings are possibly changed, since last call, by an asynchronous dialog
+   virtual bool RealtimeProcessStart(EffectSettings &settings) = 0;
    virtual size_t RealtimeProcess(int group,
       const float *const *inBuf, float *const *outBuf, size_t numSamples) = 0;
-   virtual bool RealtimeProcessEnd() noexcept = 0;
+   //! settings can be updated to let a dialog change appearance at idle
+   virtual bool RealtimeProcessEnd(EffectSettings &settings) noexcept = 0;
 };
 
 /*************************************************************************************//**

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -15,6 +15,7 @@
 #include "ComponentInterfaceSymbol.h"
 
 #include <functional>
+#include <memory>
 
 class EffectDefinitionInterface;
 
@@ -49,12 +50,14 @@ public:
 class wxDialog;
 class wxWindow;
 class EffectUIClientInterface;
-
+class EffectSettingsAccess;
 class EffectUIHostInterface;
-using EffectDialogFactory = std::function<
-   wxDialog* ( wxWindow &parent,
-      EffectUIHostInterface&, EffectUIClientInterface& )
->;
+
+//! Type of function that creates a dialog for an effect
+/*! The dialog may be modal or non-modal */
+using EffectDialogFactory = std::function< wxDialog* (
+   wxWindow &parent, EffectUIHostInterface &, EffectUIClientInterface &,
+   EffectSettingsAccess & ) >;
 
 class TrackList;
 class WaveTrackFactory;
@@ -69,6 +72,8 @@ class EffectProcessor;
 class AUDACITY_DLL_API EffectUIHostInterface : public EffectHostInterface
 {
 public:
+   using EffectSettingsAccessPtr = std::shared_ptr<EffectSettingsAccess>;
+
    const static wxString kUserPresetIdent;
    const static wxString kFactoryPresetIdent;
    const static wxString kCurrentSettingsIdent;
@@ -77,13 +82,19 @@ public:
    EffectUIHostInterface &operator=(EffectUIHostInterface&) = delete;
    virtual ~EffectUIHostInterface();
 
+   //! Usually applies factory to self and given access
    /*!
+    But there are a few unusual overrides for historical reasons
+
+    @param access is only guaranteed to have lifetime suitable for a modal
+    dialog, unless the dialog stores access.shared_from_this()
+
     @return 0 if destructive effect processing should not proceed (and there
     may be a non-modal dialog still opened); otherwise, modal dialog return code
     */
    virtual int ShowHostInterface(
       wxWindow &parent, const EffectDialogFactory &factory,
-      bool forceModal = false
+      EffectSettingsAccess &access, bool forceModal = false
    ) = 0;
 
    virtual void Preview(bool dryOnly) = 0;
@@ -91,16 +102,22 @@ public:
    virtual bool SetAutomationParametersFromString(const wxString & parms) = 0;
    virtual bool IsBatchProcessing() = 0;
    virtual void SetBatchProcessing(bool start) = 0;
-   // Returns true on success.  Will only operate on tracks that
-   // have the "selected" flag set to true, which is consistent with
-   // Audacity's standard UI.
-   // Create a user interface only if the supplied function is not null.
+   //! Create a user interface only if the supplied factory is not null.
+   /*!
+    Factory may be null because we "Repeat last effect" or apply a macro
+
+    Will only operate on tracks that have the "selected" flag set to true,
+    which is consistent with Audacity's standard UI.
+
+    @return true on success
+    */
    virtual bool DoEffect( double projectRate, TrackList *list,
       WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
       unsigned flags,
-      // Prompt the user for input only if these arguments are both not null.
+      // Prompt the user for input only if the next arguments are not all null.
       wxWindow *pParent = nullptr,
-      const EffectDialogFactory &dialogFactory = {} ) = 0;
+      const EffectDialogFactory &dialogFactory = {},
+      const EffectSettingsAccessPtr &pAccess = nullptr) = 0;
    virtual bool Startup(EffectUIClientInterface *client) = 0;
 
    virtual bool TransferDataToWindow() = 0;

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -212,7 +212,7 @@ void EffectAmplify::Preview(bool dryOnly)
    Effect::Preview(dryOnly);
 }
 
-void EffectAmplify::PopulateOrExchange(ShuttleGui & S)
+void EffectAmplify::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    enum{ precision = 3 }; // allow (a generous) 3 decimal  places for Amplification (dB)
 

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -56,7 +56,8 @@ public:
 
    bool Init() override;
    void Preview(bool dryOnly) override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -424,7 +424,7 @@ bool EffectAutoDuck::Process()
    return !cancel;
 }
 
-void EffectAutoDuck::PopulateOrExchange(ShuttleGui & S)
+void EffectAutoDuck::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.StartVerticalLay(true);

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -50,7 +50,8 @@ public:
    bool Init() override;
    void End() override;
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -214,7 +214,7 @@ bool EffectBassTreble::CheckWhetherSkipEffect()
 
 // Effect implementation
 
-void EffectBassTreble::PopulateOrExchange(ShuttleGui & S)
+void EffectBassTreble::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -71,7 +71,8 @@ public:
 
    // Effect Implementation
 
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -219,8 +219,8 @@ bool EffectChangePitch::Process()
       EffectSBSMS proxy;
       proxy.mProxyEffectName = XO("High Quality Pitch Change");
       proxy.setParameters(1.0, pitchRatio);
-
-      return Delegate(proxy, *mUIParent, nullptr);
+      //! Already processing; don't make a dialog
+      return Delegate(proxy, *mUIParent, nullptr, nullptr);
    }
    else
 #endif

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -256,7 +256,7 @@ bool EffectChangePitch::CheckWhetherSkipEffect()
    return (m_dPercentChange == 0.0);
 }
 
-void EffectChangePitch::PopulateOrExchange(ShuttleGui & S)
+void EffectChangePitch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    DeduceFrequencies(); // Set frequency-related control values based on sample.
 

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -64,7 +64,8 @@ public:
    bool Init() override;
    bool Process() override;
    bool CheckWhetherSkipEffect() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -293,7 +293,7 @@ bool EffectChangeSpeed::Process()
    return bGoodResult;
 }
 
-void EffectChangeSpeed::PopulateOrExchange(ShuttleGui & S)
+void EffectChangeSpeed::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    {
       wxString formatId;

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -53,7 +53,8 @@ public:
    bool Startup() override;
    bool Init() override;
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataFromWindow() override;
    bool TransferDataToWindow() override;
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -226,7 +226,7 @@ bool EffectChangeTempo::Process()
    return success;
 }
 
-void EffectChangeTempo::PopulateOrExchange(ShuttleGui & S)
+void EffectChangeTempo::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    enum { precision = 2 };
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -204,7 +204,8 @@ bool EffectChangeTempo::Process()
       EffectSBSMS proxy;
       proxy.mProxyEffectName = XO("High Quality Tempo Change");
       proxy.setParameters(tempoRatio, 1.0);
-      success = Delegate(proxy, *mUIParent, nullptr);
+      //! Already processing; don't make a dialog
+      success = Delegate(proxy, *mUIParent, nullptr, nullptr);
    }
    else
 #endif

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -59,7 +59,8 @@ public:
    bool CheckWhetherSkipEffect() override;
    bool Process() override;
    double CalcPreviewInputLength(double previewLength) override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -335,7 +335,7 @@ bool EffectClickRemoval::RemoveClicks(size_t len, float *buffer)
    return bResult;
 }
 
-void EffectClickRemoval::PopulateOrExchange(ShuttleGui & S)
+void EffectClickRemoval::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
    S.SetBorder(10);

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -52,7 +52,8 @@ public:
    bool CheckWhetherSkipEffect() override;
    bool Startup() override;
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -242,7 +242,7 @@ TranslatableString RatioLabelFormat( int sliderValue, double value )
 
 }
 
-void EffectCompressor::PopulateOrExchange(ShuttleGui & S)
+void EffectCompressor::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.SetBorder(5);
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -49,7 +49,8 @@ public:
    // Effect implementation
 
    bool Startup() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -352,7 +352,7 @@ bool EffectDistortion::LoadFactoryPreset(int id)
 
 // Effect implementation
 
-void EffectDistortion::PopulateOrExchange(ShuttleGui & S)
+void EffectDistortion::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
    S.StartVerticalLay();

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -319,7 +319,7 @@ bool EffectDistortion::SetAutomationParameters(CommandParameters & parms)
    return true;
 }
 
-RegistryPaths EffectDistortion::GetFactoryPresets()
+RegistryPaths EffectDistortion::GetFactoryPresets() const
 {
    RegistryPaths names;
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -92,7 +92,8 @@ public:
 
    // Effect implementation
 
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -73,7 +73,7 @@ public:
    bool SupportsRealtime() override;
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
 
    // EffectProcessor implementation

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -326,7 +326,7 @@ bool EffectDtmf::Init()
    return true;
 }
 
-void EffectDtmf::PopulateOrExchange(ShuttleGui & S)
+void EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    // dialog will be passed values from effect
    // Effect retrieves values from saved config

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -54,7 +54,8 @@ public:
 
    bool Startup() override;
    bool Init() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataFromWindow() override;
    bool TransferDataToWindow() override;
 

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -168,7 +168,7 @@ bool EffectEcho::SetAutomationParameters(CommandParameters & parms)
    return true;
 }
 
-void EffectEcho::PopulateOrExchange(ShuttleGui & S)
+void EffectEcho::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
 

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -49,7 +49,8 @@ public:
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -576,7 +576,7 @@ bool Effect::LoadFactoryDefaults()
 
 // EffectUIClientInterface implementation
 
-bool Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
+bool Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mUIParent = parent;
@@ -584,7 +584,7 @@ bool Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
 
 //   LoadUserPreset(GetCurrentSettingsGroup());
 
-   PopulateOrExchange(S);
+   PopulateOrExchange(S, access);
 
    mUIParent->SetMinSize(mUIParent->GetSizer()->GetMinSize());
 
@@ -1664,7 +1664,7 @@ void Effect::End()
 {
 }
 
-void Effect::PopulateOrExchange(ShuttleGui & WXUNUSED(S))
+void Effect::PopulateOrExchange(ShuttleGui &, EffectSettingsAccess &)
 {
    return;
 }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -576,7 +576,7 @@ bool Effect::LoadFactoryDefaults()
 
 // EffectUIClientInterface implementation
 
-bool Effect::PopulateUI(ShuttleGui &S)
+bool Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
 {
    auto parent = S.GetParent();
    mUIParent = parent;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -543,7 +543,7 @@ bool Effect::SaveUserPreset(const RegistryPath & name)
       name, wxT("Parameters"), parms);
 }
 
-RegistryPaths Effect::GetFactoryPresets()
+RegistryPaths Effect::GetFactoryPresets() const
 {
    if (mClient)
    {

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -398,11 +398,11 @@ bool Effect::RealtimeResume() noexcept
    return true;
 }
 
-bool Effect::RealtimeProcessStart()
+bool Effect::RealtimeProcessStart(EffectSettings &settings)
 {
    if (mClient)
    {
-      return mClient->RealtimeProcessStart();
+      return mClient->RealtimeProcessStart(settings);
    }
 
    return true;
@@ -419,11 +419,11 @@ size_t Effect::RealtimeProcess(int group,
    return 0;
 }
 
-bool Effect::RealtimeProcessEnd() noexcept
+bool Effect::RealtimeProcessEnd(EffectSettings &settings) noexcept
 {
    if (mClient)
    {
-      return mClient->RealtimeProcessEnd();
+      return mClient->RealtimeProcessEnd(settings);
    }
 
    return true;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -152,7 +152,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    // EffectUIClientInterface implementation
 
-   bool PopulateUI(ShuttleGui &S) final;
+   bool PopulateUI(ShuttleGui &S, EffectSettingsAccess &access) final;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
    bool HideUI() override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -142,10 +142,10 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
-   bool RealtimeProcessStart() override;
+   bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(int group, const float *const *inbuf,
       float *const *outbuf, size_t numSamples) override;
-   bool RealtimeProcessEnd() noexcept override;
+   bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal = false) override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -111,7 +111,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    bool LoadUserPreset(const RegistryPath & name) override;
    bool SaveUserPreset(const RegistryPath & name) override;
 
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -270,7 +270,8 @@ protected:
    // effects need to use a different input length, so override this method.
    virtual double CalcPreviewInputLength(double previewLength);
 
-   virtual void PopulateOrExchange(ShuttleGui & S);
+   virtual void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access);
 
    // No more virtuals!
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -180,7 +180,8 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // EffectUIHostInterface implementation
 
    int ShowHostInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, bool forceModal = false) override;
+      const EffectDialogFactory &factory, EffectSettingsAccess &access,
+      bool forceModal = false) override;
    // The Effect class fully implements the Preview method for you.
    // Only override it if you need to do preprocessing or cleanup.
    void Preview(bool dryOnly) override;
@@ -191,9 +192,10 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    bool DoEffect( double projectRate, TrackList *list,
       WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
       unsigned flags,
-      // Prompt the user for input only if these arguments are both not null.
+      // Prompt the user for input only if the next arguments are not all null.
       wxWindow *pParent,
-      const EffectDialogFactory &dialogFactory) override;
+      const EffectDialogFactory &dialogFactory,
+      const EffectSettingsAccessPtr &pAccess) override;
    bool Startup(EffectUIClientInterface *client) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
@@ -207,8 +209,10 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
       if( Values ) mPresetValues = *Values;
    }
 
+   //! Re-invoke DoEffect on another Effect object that implements the work
    bool Delegate( Effect &delegate,
-      wxWindow &parent, const EffectDialogFactory &factory );
+      wxWindow &parent, const EffectDialogFactory &factory,
+      const EffectSettingsAccessPtr &pSettings );
 
    // Display a message box, using effect's (translated) name as the prefix
    // for the title.

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -310,9 +310,14 @@ bool EffectManager::PromptUser(
 {
    bool result = false;
    if (auto effect = GetEffect(ID)) {
-      //! Show the effect dialog, only so that the user can choose settings.
-      result = effect->ShowHostInterface(
-         parent, factory, effect->IsBatchProcessing() ) != 0;
+      //! Show the effect dialog, only so that the user can choose settings,
+      //! for instance to define a macro.
+      auto pSettings = GetDefaultSettings(ID);
+      if (pSettings)
+         result = effect->ShowHostInterface(
+            parent, factory,
+            *std::make_shared<SimpleEffectSettingsAccess>(*pSettings),
+            effect->IsBatchProcessing() ) != 0;
       return result;
    }
 

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -30,7 +30,14 @@ class SelectedRegion;
 class wxString;
 typedef wxString PluginID;
 
-using EffectMap = std::unordered_map<wxString, EffectUIHostInterface *>;
+#include "EffectInterface.h"
+
+struct EffectAndDefaultSettings{
+   EffectUIHostInterface *effect{};
+   EffectSettings settings{};
+};
+
+using EffectMap = std::unordered_map<wxString, EffectAndDefaultSettings>;
 using AudacityCommandMap = std::unordered_map<wxString, AudacityCommand *>;
 using EffectOwnerMap = std::unordered_map< wxString, std::shared_ptr<EffectUIHostInterface> >;
 
@@ -133,10 +140,19 @@ public:
 
    const PluginID & GetEffectByIdentifier(const CommandID & strTarget);
 
-   /** Return an effect by its ID. */
+   /*! Return an effect by its ID. */
    EffectUIHostInterface *GetEffect(const PluginID & ID);
 
+   /*! Get default settings by effect ID. */
+   EffectSettings *GetDefaultSettings(const PluginID & ID);
+
+   /*! Get effect and default settings by effect ID. */
+   std::pair<EffectUIHostInterface *, EffectSettings *>
+   GetEffectAndDefaultSettings(const PluginID & ID);
+
 private:
+   EffectAndDefaultSettings &DoGetEffect(const PluginID & ID);
+
    AudacityCommand *GetAudacityCommand(const PluginID & ID);
 
    EffectMap mEffects;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -556,7 +556,8 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
    }
    
    // This will take care of calling TransferDataFromWindow() for an effect.
-   if (!mEffectUIHost.GetDefinition().SaveUserPreset(mEffectUIHost.GetCurrentSettingsGroup()))
+   if (!mEffectUIHost.GetDefinition().SaveUserPreset(
+      mEffectUIHost.GetCurrentSettingsGroup(), mpAccess->Get()))
    {
       return;
    }
@@ -882,16 +883,24 @@ void EffectUIHost::OnUserPreset(wxCommandEvent & evt)
 {
    int preset = evt.GetId() - kUserPresetsID;
    
-   mEffectUIHost.GetDefinition()
-      .LoadUserPreset(mEffectUIHost.GetUserPresetsGroup(mUserPresets[preset]));
+   // Make mutable copy
+   auto settings = mpAccess->Get();
+   mEffectUIHost.GetDefinition().LoadUserPreset(
+      mEffectUIHost.GetUserPresetsGroup(mUserPresets[preset]), settings);
+   // Communicate change of settings
+   mpAccess->Set(std::move(settings));
    
    return;
 }
 
 void EffectUIHost::OnFactoryPreset(wxCommandEvent & evt)
 {
+   // Make mutable copy
+   auto settings = mpAccess->Get();
    mEffectUIHost.GetDefinition()
-      .LoadFactoryPreset(evt.GetId() - kFactoryPresetsID);
+      .LoadFactoryPreset(evt.GetId() - kFactoryPresetsID, settings);
+   // Communicate change of settings
+   mpAccess->Set(std::move(settings));
    
    return;
 }
@@ -985,8 +994,8 @@ void EffectUIHost::OnSaveAs(wxCommandEvent & WXUNUSED(evt))
          }
       }
       
-      mEffectUIHost.GetDefinition()
-         .SaveUserPreset(mEffectUIHost.GetUserPresetsGroup(name));
+      mEffectUIHost.GetDefinition().SaveUserPreset(
+         mEffectUIHost.GetUserPresetsGroup(name), mpAccess->Get());
       LoadUserPresets();
       
       break;
@@ -1022,8 +1031,11 @@ void EffectUIHost::OnOptions(wxCommandEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnDefaults(wxCommandEvent & WXUNUSED(evt))
 {
-   mEffectUIHost.GetDefinition().LoadFactoryDefaults();
-   
+   // Make mutable copy
+   auto settings = mpAccess->Get();
+   mEffectUIHost.GetDefinition().LoadFactoryDefaults(settings);
+   // Communicate change of settings
+   mpAccess->Set(std::move(settings));
    return;
 }
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -408,7 +408,7 @@ bool EffectUIHost::Initialize()
 
          // Let the client add things to the panel
          ShuttleGui S1{ uw.get(), eIsCreating };
-         if (!mClient.PopulateUI(S1))
+         if (!mClient.PopulateUI(S1, *mpAccess))
          {
             return false;
          }

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -45,7 +45,8 @@ public:
    EffectUIHost(wxWindow *parent,
                 AudacityProject &project,
                 EffectUIHostInterface &effect,
-                EffectUIClientInterface &client);
+                EffectUIClientInterface &client,
+                EffectSettingsAccess &access);
    virtual ~EffectUIHost();
 
    bool TransferDataToWindow() override;
@@ -97,6 +98,7 @@ private:
    wxWindow *mParent;
    EffectUIHostInterface &mEffectUIHost;
    EffectUIClientInterface &mClient;
+   const EffectUIHostInterface::EffectSettingsAccessPtr mpAccess;
    RealtimeEffectState *mpState{ nullptr };
 
    RegistryPaths mUserPresets;
@@ -147,7 +149,7 @@ namespace  EffectUI {
 
    AUDACITY_DLL_API
    wxDialog *DialogFactory( wxWindow &parent, EffectUIHostInterface &host,
-      EffectUIClientInterface &client);
+      EffectUIClientInterface &client, EffectSettingsAccess &access);
 
    /** Run an effect given the plugin ID */
    // Returns true on success.  Will only operate on tracks that

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -767,7 +767,7 @@ bool EffectEqualization::CloseUI()
    return Effect::CloseUI();
 }
 
-void EffectEqualization::PopulateOrExchange(ShuttleGui & S)
+void EffectEqualization::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    if ( (S.GetMode() == eIsCreating ) && !IsBatchProcessing() )
       LoadUserPreset(GetCurrentSettingsGroup());

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -492,7 +492,7 @@ FactoryPresets[] =
 
 
 
-RegistryPaths EffectEqualization::GetFactoryPresets()
+RegistryPaths EffectEqualization::GetFactoryPresets() const
 {
    RegistryPaths names;
 

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -129,7 +129,8 @@ public:
    bool Process() override;
 
    bool CloseUI() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -115,7 +115,7 @@ public:
    bool SetAutomationParameters(CommandParameters & parms) override;
    bool LoadFactoryDefaults() override;
 
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
 
    // EffectUIClientInterface implementation

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -240,8 +240,10 @@ bool EffectFindClipping::ProcessOne(LabelTrack * lt,
    return bGoodResult;
 }
 
-void EffectFindClipping::PopulateOrExchange(ShuttleGui & S)
+void EffectFindClipping::PopulateOrExchange(
+   ShuttleGui & S, EffectSettingsAccess &access)
 {
+   mpAccess = access.shared_from_this();
    S.StartMultiColumn(2, wxALIGN_CENTER);
    {
       S.Validator<IntegerValidator<int>>(
@@ -258,7 +260,8 @@ void EffectFindClipping::PopulateOrExchange(ShuttleGui & S)
 bool EffectFindClipping::TransferDataToWindow()
 {
    ShuttleGui S(mUIParent, eIsSettingToDialog);
-   PopulateOrExchange(S);
+   // To do: eliminate this and just use validators for controls
+   PopulateOrExchange(S, *mpAccess);
 
    return true;
 }
@@ -271,7 +274,8 @@ bool EffectFindClipping::TransferDataFromWindow()
    }
 
    ShuttleGui S(mUIParent, eIsGettingFromDialog);
-   PopulateOrExchange(S);
+   // To do: eliminate this and just use validators for controls
+   PopulateOrExchange(S, *mpAccess);
 
    return true;
 }

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -45,7 +45,8 @@ public:
    // Effect implementation
 
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 
@@ -58,6 +59,8 @@ private:
 private:
    int mStart;   ///< Using int rather than sampleCount because values are only ever small numbers
    int mStop;    ///< Using int rather than sampleCount because values are only ever small numbers
+   // To do: eliminate this
+   EffectSettingsAccessPtr mpAccess;
 };
 
 #endif // __AUDACITY_EFFECT_FINDCLIPPING__

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -288,7 +288,7 @@ bool EffectLoudness::Process()
    return bGoodResult;
 }
 
-void EffectLoudness::PopulateOrExchange(ShuttleGui & S)
+void EffectLoudness::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.StartVerticalLay(0);
    {

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -55,7 +55,8 @@ public:
    bool CheckWhetherSkipEffect() override;
    bool Startup() override;
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -230,7 +230,7 @@ bool EffectNoise::Startup()
    return true;
 }
 
-void EffectNoise::PopulateOrExchange(ShuttleGui & S)
+void EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    wxASSERT(nTypes == WXSIZEOF(kTypeStrings));
 

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -48,7 +48,8 @@ public:
    // Effect implementation
 
    bool Startup() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -447,12 +447,15 @@ bool EffectNoiseReduction::CheckWhetherSkipEffect()
 }
 
 //! An override still here for historical reasons, ignoring the factory
+//! and the access
 /*! We would like to make this effect behave more like others, but it does have
  its unusual two-pass nature.  First choose and analyze an example of noise,
  then apply noise reduction to another selection.  That is difficult to fit into
  the framework for managing settings of other effects. */
 int EffectNoiseReduction::ShowHostInterface(
-   wxWindow &parent, const EffectDialogFactory &, bool forceModal)
+   wxWindow &parent, const EffectDialogFactory &,
+   EffectSettingsAccess &, //!< ignored!
+   bool forceModal)
 {
    // to do: use forceModal correctly
 

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -38,7 +38,8 @@ public:
 //   using Effect::TrackProgress;
 
    int ShowHostInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, bool forceModal = false) override;
+      const EffectDialogFactory &factory,
+      EffectSettingsAccess &access, bool forceModal = false) override;
 
    bool Init() override;
    bool CheckWhetherSkipEffect() override;

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -154,12 +154,15 @@ bool EffectNoiseRemoval::CheckWhetherSkipEffect()
 }
 
 //! An override still here for historical reasons, ignoring the factory
+//! and the access
 /*! We would like to make this effect behave more like others, but it does have
  its unusual two-pass nature.  First choose and analyze an example of noise,
  then apply noise reduction to another selection.  That is difficult to fit into
  the framework for managing settings of other effects. */
 int EffectNoiseRemoval::ShowHostInterface(
-   wxWindow &parent, const EffectDialogFactory &, bool forceModal )
+   wxWindow &parent, const EffectDialogFactory &,
+   EffectSettingsAccess &, //!< ignored!
+   bool forceModal )
 {
    // to do: use forceModal correctly
    NoiseRemovalDialog dlog(this, &parent);

--- a/src/effects/NoiseRemoval.h
+++ b/src/effects/NoiseRemoval.h
@@ -52,7 +52,8 @@ public:
    // Effect implementation
 
    int ShowHostInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, bool forceModal = false) override;
+      const EffectDialogFactory &factory,
+      EffectSettingsAccess &access, bool forceModal = false) override;
    bool Init() override;
    bool CheckWhetherSkipEffect() override;
    bool Process() override;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -285,7 +285,7 @@ bool EffectNormalize::Process()
    return bGoodResult;
 }
 
-void EffectNormalize::PopulateOrExchange(ShuttleGui & S)
+void EffectNormalize::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    mCreating = true;
 

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -49,7 +49,8 @@ public:
    bool CheckWhetherSkipEffect() override;
    bool Startup() override;
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -196,7 +196,7 @@ bool EffectPaulstretch::Process()
 }
 
 
-void EffectPaulstretch::PopulateOrExchange(ShuttleGui & S)
+void EffectPaulstretch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.StartMultiColumn(2, wxALIGN_CENTER);
    {

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -42,7 +42,8 @@ public:
 
    double CalcPreviewInputLength(double previewLength) override;
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -246,7 +246,7 @@ bool EffectPhaser::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-void EffectPhaser::PopulateOrExchange(ShuttleGui & S)
+void EffectPhaser::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -76,7 +76,8 @@ public:
 
    // Effect implementation
 
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -79,14 +79,14 @@ private:
    //! Main thread begins to define a set of tracks for playback
    void Initialize(double rate);
    //! Main thread adds one track (passing the first of one or more channels)
-   void AddTrack(Track *track, unsigned chans, float rate);
+   void AddTrack(Track &track, unsigned chans, float rate);
    //! Main thread cleans up after playback
    void Finalize() noexcept;
 
    friend RealtimeEffects::ProcessingScope;
    void ProcessStart();
    /*! @copydoc ProcessScope::Process */
-   size_t Process(Track *track,
+   size_t Process(Track &track,
       float *const *buffers, float *const *scratch, size_t numSamples);
    void ProcessEnd() noexcept;
 
@@ -97,7 +97,7 @@ private:
       std::function<void(RealtimeEffectState &state, bool bypassed)> ;
 
    //! Visit the per-project states first, then states for leader if not null
-   void VisitGroup(Track *leader, StateVisitor func);
+   void VisitGroup(Track &leader, StateVisitor func);
 
    //! Visit the per-project states first, then all tracks from AddTrack
    /*! Tracks are visited in unspecified order */
@@ -113,7 +113,7 @@ private:
    std::atomic<bool> mSuspended{ true };
    std::atomic<bool> mActive{ false };
 
-   std::vector<Track *> mGroupLeaders;
+   std::vector<Track *> mGroupLeaders; //!< all are non-null
    std::unordered_map<Track *, unsigned> mChans;
    std::unordered_map<Track *, double> mRates;
 };
@@ -138,7 +138,7 @@ public:
          RealtimeEffectManager::Get(*pProject).Finalize();
    }
 
-   void AddTrack(Track *track, unsigned chans, float rate)
+   void AddTrack(Track &track, unsigned chans, float rate)
    {
       if (auto pProject = mwProject.lock())
          RealtimeEffectManager::Get(*pProject).AddTrack(track, chans, rate);
@@ -197,7 +197,7 @@ public:
          RealtimeEffectManager::Get(*pProject).ProcessEnd();
    }
 
-   size_t Process(Track *track,
+   size_t Process(Track &track,
       float *const *buffers, /*!< Assume as many buffers, as channels were
          specified in the AddTrack call */
       float *const *scratch, /*!< As many temporary buffers as in buffers,

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -132,7 +132,7 @@ bool RealtimeEffectState::ProcessStart()
    if (!mEffect)
       return false;
 
-   return mEffect->RealtimeProcessStart();
+   return mEffect->RealtimeProcessStart(mSettings);
 }
 
 //! Visit the effect processors that were added in AddTrack
@@ -264,7 +264,7 @@ bool RealtimeEffectState::ProcessEnd()
    if (!mEffect)
       return false;
 
-   return mEffect->RealtimeProcessEnd();
+   return mEffect->RealtimeProcessEnd(mSettings);
 }
 
 bool RealtimeEffectState::IsActive() const noexcept

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -65,7 +65,7 @@ bool RealtimeEffectState::Initialize(double rate)
 
 //! Set up processors to be visited repeatedly in Process.
 /*! The iteration over channels in AddTrack and Process must be the same */
-bool RealtimeEffectState::AddTrack(Track *track, unsigned chans, float rate)
+bool RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
 {
    if (!mEffect)
       return false;
@@ -74,7 +74,7 @@ bool RealtimeEffectState::AddTrack(Track *track, unsigned chans, float rate)
    auto ochans = chans;
    auto gchans = chans;
 
-   mGroups[track] = mCurrentProcessor;
+   mGroups[&track] = mCurrentProcessor;
 
    const auto numAudioIn = mEffect->GetAudioInCount();
    const auto numAudioOut = mEffect->GetAudioOutCount();
@@ -133,7 +133,7 @@ bool RealtimeEffectState::ProcessStart()
 
 //! Visit the effect processors that were added in AddTrack
 /*! The iteration over channels in AddTrack and Process must be the same */
-size_t RealtimeEffectState::Process(Track *track,
+size_t RealtimeEffectState::Process(Track &track,
    unsigned chans,
    const float *const *inbuf, float *const *outbuf, float *dummybuf,
    size_t numSamples)
@@ -166,7 +166,7 @@ size_t RealtimeEffectState::Process(Track *track,
    unsigned indx = 0;
    unsigned ondx = 0;
 
-   auto processor = mGroups[track];
+   auto processor = mGroups[&track];
 
    // Call the client until we run out of input or output channels
    while (ichans > 0 && ochans > 0)

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -45,11 +45,11 @@ public:
 
    //! Main thread sets up for playback
    bool Initialize(double rate);
-   bool AddTrack(Track *track, unsigned chans, float rate);
+   bool AddTrack(Track &track, unsigned chans, float rate);
    //! Worker thread begins a batch of samples
    bool ProcessStart();
    //! Worker thread processes part of a batch of samples
-   size_t Process(Track *track,
+   size_t Process(Track &track,
       unsigned chans,
       const float *const *inbuf, //!< chans input buffers
       float *const *outbuf, //!< chans output buffers

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -16,6 +16,7 @@
 #include <unordered_map>
 #include <vector>
 #include <cstddef>
+#include "EffectInterface.h"
 #include "GlobalVariable.h"
 #include "ModuleInterface.h" // for PluginID
 #include "XMLTagHandler.h"
@@ -72,6 +73,7 @@ private:
    PluginID mID;
    wxString mParameters;  // Used only during deserialization
    std::unique_ptr<EffectProcessor> mEffect;
+   EffectSettings mSettings;
 
    size_t mCurrentProcessor{ 0 };
    std::unordered_map<Track *, size_t> mGroups;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -22,6 +22,7 @@
 #include "XMLTagHandler.h"
 
 class EffectProcessor;
+class EffectSettingsAccess;
 class Track;
 
 class RealtimeEffectState : public XMLTagHandler
@@ -69,11 +70,19 @@ public:
    XMLTagHandler *HandleXMLChild(const std::string_view &tag) override;
    void WriteXML(XMLWriter &xmlFile);
 
+   // Expose access so a dialog can be connected to this state
+   std::shared_ptr<EffectSettingsAccess> GetAccess();
+
 private:
    PluginID mID;
    wxString mParameters;  // Used only during deserialization
    std::unique_ptr<EffectProcessor> mEffect;
    EffectSettings mSettings;
+
+   struct Access;
+   struct AccessState;
+   std::shared_ptr<AccessState> mpAccessState; // Destroy before mSettings
+   std::weak_ptr<EffectSettingsAccess> mwAccess;
 
    size_t mCurrentProcessor{ 0 };
    std::unordered_map<Track *, size_t> mGroups;

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -176,7 +176,7 @@ bool EffectRepeat::Process()
    return bGoodResult;
 }
 
-void EffectRepeat::PopulateOrExchange(ShuttleGui & S)
+void EffectRepeat::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.StartHorizontalLay(wxCENTER, false);
    {

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -45,7 +45,8 @@ public:
    // Effect implementation
 
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -336,7 +336,7 @@ bool EffectReverb::SetAutomationParameters(CommandParameters & parms)
    return true;
 }
 
-RegistryPaths EffectReverb::GetFactoryPresets()
+RegistryPaths EffectReverb::GetFactoryPresets() const
 {
    RegistryPaths names;
 

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -435,7 +435,7 @@ bool EffectReverb::Startup()
    return true;
 }
 
-void EffectReverb::PopulateOrExchange(ShuttleGui & S)
+void EffectReverb::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
 

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -54,7 +54,7 @@ public:
    EffectType GetType() override;
    bool GetAutomationParameters(CommandParameters & parms) override;
    bool SetAutomationParameters(CommandParameters & parms) override;
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
 
    // EffectProcessor implementation

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -70,7 +70,8 @@ public:
    // Effect implementation
 
    bool Startup() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -370,7 +370,7 @@ bool EffectScienFilter::Init()
    return true;
 }
 
-void EffectScienFilter::PopulateOrExchange(ShuttleGui & S)
+void EffectScienFilter::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.AddSpace(5);
    S.SetSizerProportion(1);

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -62,7 +62,8 @@ public:
 
    bool Startup() override;
    bool Init() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -65,7 +65,7 @@ EffectType EffectSilence::GetType()
 
 // Effect implementation
 
-void EffectSilence::PopulateOrExchange(ShuttleGui & S)
+void EffectSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.StartVerticalLay();
    {

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -37,7 +37,8 @@ public:
 
    // Effect implementation
 
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -200,7 +200,7 @@ bool EffectTimeScale::Process()
    return EffectSBSMS::Process();
 }
 
-void EffectTimeScale::PopulateOrExchange(ShuttleGui & S)
+void EffectTimeScale::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -50,7 +50,8 @@ public:
    bool Init() override;
    void Preview(bool dryOnly) override;
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
    double CalcPreviewInputLength(double previewLength) override;

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -358,7 +358,7 @@ bool EffectToneGen::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-void EffectToneGen::PopulateOrExchange(ShuttleGui & S)
+void EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    wxTextCtrl *t;
 

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -46,7 +46,8 @@ public:
 
    // Effect implementation
 
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataFromWindow() override;
    bool TransferDataToWindow() override;
 

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -754,7 +754,7 @@ bool EffectTruncSilence::Analyze(RegionList& silenceList,
 }
 
 
-void EffectTruncSilence::PopulateOrExchange(ShuttleGui & S)
+void EffectTruncSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    wxASSERT(nActions == WXSIZEOF(kActionStrings));
 

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -68,7 +68,8 @@ public:
                         double* minInputLength = NULL);
 
    bool Process() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1718,7 +1718,7 @@ bool VSTEffect::LoadFactoryDefaults()
 // EffectUIClientInterface implementation
 // ============================================================================
 
-bool VSTEffect::PopulateUI(ShuttleGui &S)
+bool VSTEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
 {
    auto parent = S.GetParent();
    mDialog = static_cast<wxDialog *>(wxGetTopLevelParent(parent));

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -296,7 +296,7 @@ public:
    bool LoadUserPreset(const RegistryPath &) override { return true; }
    bool SaveUserPreset(const RegistryPath &) override { return true; }
 
-   RegistryPaths GetFactoryPresets() override { return {}; }
+   RegistryPaths GetFactoryPresets() const override { return {}; }
    bool LoadFactoryPreset(int) override { return true; }
    bool LoadFactoryDefaults() override { return true; }
 
@@ -1675,7 +1675,7 @@ bool VSTEffect::SaveUserPreset(const RegistryPath & name)
    return SaveParameters(name);
 }
 
-RegistryPaths VSTEffect::GetFactoryPresets()
+RegistryPaths VSTEffect::GetFactoryPresets() const
 {
    RegistryPaths progs;
 
@@ -2512,20 +2512,20 @@ void VSTEffect::SetBufferDelay(int samples)
    return;
 }
 
-int VSTEffect::GetString(wxString & outstr, int opcode, int index)
+int VSTEffect::GetString(wxString & outstr, int opcode, int index) const
 {
    char buf[256];
 
    memset(buf, 0, sizeof(buf));
 
-   callDispatcher(opcode, index, 0, buf, 0.0);
+   const_cast<VSTEffect*>(this)->callDispatcher(opcode, index, 0, buf, 0.0);
 
    outstr = wxString::FromUTF8(buf);
 
    return 0;
 }
 
-wxString VSTEffect::GetString(int opcode, int index)
+wxString VSTEffect::GetString(int opcode, int index) const
 {
    wxString str;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -225,7 +225,7 @@ enum InfoKeys
 //! This object exists in a separate process, to validate a newly seen plug-in.
 /*! It needs to implement EffectDefinitionInterface but mostly just as stubs */
 class VSTSubProcess final : public wxProcess
-   , public EffectDefinitionInterface
+   , public EffectDefinitionInterfaceEx
 {
 public:
    VSTSubProcess()

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1538,7 +1538,7 @@ return GuardedCall<bool>([&]{
 });
 }
 
-bool VSTEffect::RealtimeProcessStart()
+bool VSTEffect::RealtimeProcessStart(EffectSettings &)
 {
    return true;
 }
@@ -1550,7 +1550,7 @@ size_t VSTEffect::RealtimeProcess(int group,
    return mSlaves[group]->ProcessBlock(inbuf, outbuf, numSamples);
 }
 
-bool VSTEffect::RealtimeProcessEnd() noexcept
+bool VSTEffect::RealtimeProcessEnd(EffectSettings &) noexcept
 {
    return true;
 }

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -152,10 +152,10 @@ class VSTEffect final : public wxEvtHandler,
    bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
-   bool RealtimeProcessStart() override;
+   bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(int group, const float *const *inbuf,
       float *const *outbuf, size_t numSamples) override;
-   bool RealtimeProcessEnd() noexcept override;
+   bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -163,7 +163,7 @@ class VSTEffect final : public wxEvtHandler,
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
-   bool PopulateUI(ShuttleGui &S) override;
+   bool PopulateUI(ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
    bool HideUI() override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -122,7 +122,7 @@ class VSTEffect final : public wxEvtHandler,
    bool LoadUserPreset(const RegistryPath & name) override;
    bool SaveUserPreset(const RegistryPath & name) override;
 
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 
@@ -249,8 +249,8 @@ private:
    void PowerOn();
    void PowerOff();
 
-   int GetString(wxString & outstr, int opcode, int index = 0);
-   wxString GetString(int opcode, int index = 0);
+   int GetString(wxString & outstr, int opcode, int index = 0) const;
+   wxString GetString(int opcode, int index = 0) const;
    void SetString(int opcode, const wxString & str, int index = 0);
 
    // VST methods

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -450,7 +450,7 @@ bool VST3Effect::SaveUserPreset(const RegistryPath& name)
    return true;
 }
 
-RegistryPaths VST3Effect::GetFactoryPresets()
+RegistryPaths VST3Effect::GetFactoryPresets() const
 {
    if(!mRescanFactoryPresets)
       return mFactoryPresets;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -792,7 +792,7 @@ bool VST3Effect::RealtimeResume() noexcept
    });
 }
 
-bool VST3Effect::RealtimeProcessStart()
+bool VST3Effect::RealtimeProcessStart(EffectSettings &)
 {
    assert(mPendingChanges == nullptr);
 
@@ -808,7 +808,7 @@ size_t VST3Effect::RealtimeProcess(int group, const float* const* inBuf, float* 
    return VST3ProcessBlock(effect->mEffectComponent.get(), effect->mSetup, inBuf, outBuf, numSamples, mPendingChanges.get());
 }
 
-bool VST3Effect::RealtimeProcessEnd() noexcept
+bool VST3Effect::RealtimeProcessEnd(EffectSettings &) noexcept
 {
    return GuardedCall<bool>([this]()
    {

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -850,7 +850,7 @@ bool VST3Effect::IsGraphicalUI()
    return mPlugView != nullptr;
 }
 
-bool VST3Effect::PopulateUI(ShuttleGui& S)
+bool VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &)
 {
    using namespace Steinberg;
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -71,8 +71,9 @@ class VST3Effect final : public EffectUIClientInterface
 
    std::vector<std::shared_ptr<VST3Effect>> mRealtimeGroupProcessors;
 
-   bool mRescanFactoryPresets { true };
-   RegistryPaths mFactoryPresets;
+   // Mutable cache fields computed once on demand
+   mutable bool mRescanFactoryPresets { true };
+   mutable RegistryPaths mFactoryPresets;
 
    size_t mUserBlockSize { 8192 };
    bool mUseLatency { true };
@@ -109,7 +110,7 @@ public:
    bool SetAutomationParameters(CommandParameters& parms) override;
    bool LoadUserPreset(const RegistryPath& name) override;
    bool SaveUserPreset(const RegistryPath& name) override;
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -138,7 +138,7 @@ public:
    int ShowClientInterface(wxWindow& parent, wxDialog& dialog, bool forceModal) override;
    bool SetHost(EffectHostInterface* host) override;
    bool IsGraphicalUI() override;
-   bool PopulateUI(ShuttleGui& S) override;
+   bool PopulateUI(ShuttleGui& S, EffectSettingsAccess &access) override;
    bool ValidateUI() override;
    bool HideUI() override;
    bool CloseUI() override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -131,9 +131,9 @@ public:
    bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
-   bool RealtimeProcessStart() override;
+   bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(int group, const float* const* inBuf, float* const* outBuf, size_t numSamples) override;
-   bool RealtimeProcessEnd() noexcept override;
+   bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(wxWindow& parent, wxDialog& dialog, bool forceModal) override;
    bool SetHost(EffectHostInterface* host) override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -230,7 +230,7 @@ bool EffectWahwah::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-void EffectWahwah::PopulateOrExchange(ShuttleGui & S)
+void EffectWahwah::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -73,7 +73,8 @@ public:
 
    // Effect implementation
 
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1656,7 +1656,7 @@ RegistryPaths AudioUnitEffect::GetFactoryPresets() const
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-bool AudioUnitEffect::PopulateUI(ShuttleGui &S)
+bool AudioUnitEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
 {
    // OSStatus result;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1414,7 +1414,7 @@ return GuardedCall<bool>([&]{
 });
 }
 
-bool AudioUnitEffect::RealtimeProcessStart()
+bool AudioUnitEffect::RealtimeProcessStart(EffectSettings &)
 {
    return true;
 }
@@ -1426,7 +1426,7 @@ size_t AudioUnitEffect::RealtimeProcess(int group,
    return mSlaves[group]->ProcessBlock(inbuf, outbuf, numSamples);
 }
 
-bool AudioUnitEffect::RealtimeProcessEnd() noexcept
+bool AudioUnitEffect::RealtimeProcessEnd(EffectSettings &) noexcept
 {
    return true;
 }

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1625,7 +1625,7 @@ bool AudioUnitEffect::LoadFactoryDefaults()
    return LoadPreset(mHost->GetFactoryDefaultsGroup());
 }
 
-RegistryPaths AudioUnitEffect::GetFactoryPresets()
+RegistryPaths AudioUnitEffect::GetFactoryPresets() const
 {
    OSStatus result;
    RegistryPaths presets;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -71,7 +71,7 @@ public:
    bool LoadUserPreset(const RegistryPath & name) override;
    bool SaveUserPreset(const RegistryPath & name) override;
 
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -100,10 +100,10 @@ public:
    bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
-   bool RealtimeProcessStart() override;
+   bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(int group, const float *const *inbuf,
       float *const *outbuf, size_t numSamples) override;
-   bool RealtimeProcessEnd() noexcept override;
+   bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -111,7 +111,7 @@ public:
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
-   bool PopulateUI(ShuttleGui &S) override;
+   bool PopulateUI(ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
    bool HideUI() override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1139,7 +1139,7 @@ bool LadspaEffect::SaveUserPreset(const RegistryPath & name)
    return SaveParameters(name);
 }
 
-RegistryPaths LadspaEffect::GetFactoryPresets()
+RegistryPaths LadspaEffect::GetFactoryPresets() const
 {
    return {};
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1035,7 +1035,7 @@ bool LadspaEffect::RealtimeResume() noexcept
    return true;
 }
 
-bool LadspaEffect::RealtimeProcessStart()
+bool LadspaEffect::RealtimeProcessStart(EffectSettings &)
 {
    return true;
 }
@@ -1059,7 +1059,7 @@ size_t LadspaEffect::RealtimeProcess(int group,
    return numSamples;
 }
 
-bool LadspaEffect::RealtimeProcessEnd() noexcept
+bool LadspaEffect::RealtimeProcessEnd(EffectSettings &) noexcept
 {
    return true;
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1165,7 +1165,7 @@ bool LadspaEffect::LoadFactoryDefaults()
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-bool LadspaEffect::PopulateUI(ShuttleGui &S)
+bool LadspaEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
 {
    auto parent = S.GetParent();
 

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -70,7 +70,7 @@ public:
    bool LoadUserPreset(const RegistryPath & name) override;
    bool SaveUserPreset(const RegistryPath & name) override;
 
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -110,7 +110,7 @@ public:
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
-   bool PopulateUI(ShuttleGui &S) override;
+   bool PopulateUI(ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
    bool HideUI() override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -99,10 +99,10 @@ public:
    bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
-   bool RealtimeProcessStart() override;
+   bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(int group, const float *const *inbuf,
       float *const *outbuf, size_t numSamples) override;
-   bool RealtimeProcessEnd() noexcept override;
+   bool RealtimeProcessEnd(EffectSettings &) noexcept override;
 
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1519,7 +1519,7 @@ bool LV2Effect::SetAutomationParameters(CommandParameters &parms)
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-bool LV2Effect::PopulateUI(ShuttleGui &S)
+bool LV2Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
 {
    auto parent = S.GetParent();
    mParent = parent;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -421,8 +421,6 @@ LV2Effect::LV2Effect(const LilvPlugin *plug)
 
    mSupportsNominalBlockLength = false;
    mSupportsSampleRate = false;
-
-   mFactoryPresetsLoaded = false;
 }
 
 LV2Effect::~LV2Effect()
@@ -1651,7 +1649,7 @@ bool LV2Effect::SaveUserPreset(const RegistryPath &name)
    return SaveParameters(name);
 }
 
-RegistryPaths LV2Effect::GetFactoryPresets()
+RegistryPaths LV2Effect::GetFactoryPresets() const
 {
    if (mFactoryPresetsLoaded)
    {

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1248,7 +1248,7 @@ bool LV2Effect::RealtimeResume() noexcept
    return true;
 }
 
-bool LV2Effect::RealtimeProcessStart()
+bool LV2Effect::RealtimeProcessStart(EffectSettings &)
 {
    int i = 0;
    for (auto & port : mAudioPorts)
@@ -1407,7 +1407,7 @@ size_t LV2Effect::RealtimeProcess(int group,
    return numSamples;
 }
 
-bool LV2Effect::RealtimeProcessEnd() noexcept
+bool LV2Effect::RealtimeProcessEnd(EffectSettings &) noexcept
 {
 return GuardedCall<bool>([&]{
    // Nothing to do if we did process any samples

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -283,7 +283,7 @@ public:
    bool LoadUserPreset(const RegistryPath & name) override;
    bool SaveUserPreset(const RegistryPath & name) override;
 
-   RegistryPaths GetFactoryPresets() override;
+   RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id) override;
    bool LoadFactoryDefaults() override;
 
@@ -555,9 +555,10 @@ private:
 
    NumericTextCtrl *mDuration;
 
-   bool mFactoryPresetsLoaded;
-   RegistryPaths mFactoryPresetNames;
-   wxArrayString mFactoryPresetUris;
+   // Mutable cache fields computed once on demand
+   mutable bool mFactoryPresetsLoaded{ false };
+   mutable RegistryPaths mFactoryPresetNames;
+   mutable wxArrayString mFactoryPresetUris;
 
    DECLARE_EVENT_TABLE()
 

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -312,10 +312,10 @@ public:
    bool RealtimeFinalize() noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
-   bool RealtimeProcessStart() override;
+   bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(int group, const float *const *inbuf,
       float *const *outbuf, size_t numSamples) override;
-   bool RealtimeProcessEnd() noexcept override;
+   bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -323,7 +323,7 @@ public:
    // EffectUIClientInterface implementation
 
    bool SetHost(EffectHostInterface *host) override;
-   bool PopulateUI(ShuttleGui &S) override;
+   bool PopulateUI(ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
    bool ValidateUI() override;
    bool HideUI() override;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1017,12 +1017,13 @@ finish:
 }
 
 int NyquistEffect::ShowHostInterface(
-   wxWindow &parent, const EffectDialogFactory &factory, bool forceModal)
+   wxWindow &parent, const EffectDialogFactory &factory,
+   EffectSettingsAccess &access, bool forceModal)
 {
    int res = wxID_APPLY;
    if (!(Effect::TestUIFlags(EffectManager::kRepeatNyquistPrompt) && mIsPrompt)) {
       // Show the normal (prompt or effect) interface
-      res = Effect::ShowHostInterface(parent, factory, forceModal);
+      res = Effect::ShowHostInterface(parent, factory, access, forceModal);
    }
 
 
@@ -1048,7 +1049,7 @@ int NyquistEffect::ShowHostInterface(
       effect.SetAutomationParameters(cp);
 
       // Show the normal (prompt or effect) interface
-      res = effect.ShowHostInterface(parent, factory, forceModal);
+      res = effect.ShowHostInterface(parent, factory, access, forceModal);
       if (res)
       {
          CommandParameters cp;
@@ -1060,7 +1061,9 @@ int NyquistEffect::ShowHostInterface(
    {
       effect.SetCommand(mInputCmd);
       effect.mDebug = (res == eDebugID);
-      res = Delegate(effect, parent, factory);
+      // Delegate to the Nyquist Prompt,
+      // which gets some Lisp from the user to interpret
+      res = Delegate(effect, parent, factory, access.shared_from_this());
       mT0 = effect.mT0;
       mT1 = effect.mT1;
    }

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1071,7 +1071,7 @@ int NyquistEffect::ShowHostInterface(
    return res;
 }
 
-void NyquistEffect::PopulateOrExchange(ShuttleGui & S)
+void NyquistEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    if (mIsPrompt)
    {

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -105,7 +105,8 @@ public:
    bool CheckWhetherSkipEffect() override;
    bool Process() override;
    int ShowHostInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, bool forceModal = false) override;
+      const EffectDialogFactory &factory,
+      EffectSettingsAccess &access, bool forceModal = false) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -107,7 +107,8 @@ public:
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
       EffectSettingsAccess &access, bool forceModal = false) override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -532,7 +532,7 @@ void VampEffect::End()
    mPlugin.reset();
 }
 
-void VampEffect::PopulateOrExchange(ShuttleGui & S)
+void VampEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {
    Vamp::Plugin::ProgramList programs = mPlugin->getPrograms();
 

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -69,7 +69,8 @@ public:
    bool Init() override;
    bool Process() override;
    void End() override;
-   void PopulateOrExchange(ShuttleGui & S) override;
+   void PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 


### PR DESCRIPTION
Resolves: #2538

EffectDefinitionInterface has alternative const methods using externalized settings objects: factory, save, load; but default implementations that just call-through to old functions, violating const-correctness and changing the single state as before.

EffectManager maintains a default settings object with each effect.

Each RealtimeEffectState has its own distinct settings object.

However no effect yet implements really independent settings.  The intent is to migrate existing effects to the new system
incrementally and phase out the old interface.  This branch accomplishes some of the necessary rewriting of other code in
terms of the new interface.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
