### PR TITLE
Transportstate fix - part 1

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -999,10 +999,10 @@ int AudioIO::StartStream(const TransportTracks &tracks,
    // audio thread call TrackBufferExchange here makes the code more predictable, since
    // TrackBufferExchange will ALWAYS get called from the Audio thread.
    mAudioThreadShouldCallTrackBufferExchangeOnce
-      .store(true, std::memory_order_relaxed);
+      .store(true, std::memory_order_release);
 
    while( mAudioThreadShouldCallTrackBufferExchangeOnce
-      .load(std::memory_order_relaxed)) {
+      .load(std::memory_order_acquire)) {
       using namespace std::chrono;
       auto interval = 50ms;
       if (options.playbackStreamPrimer) {
@@ -1751,11 +1751,11 @@ AudioThread::ExitCode AudioThread::Entry()
       gAudioIO->mAudioThreadTrackBufferExchangeLoopActive
          .store(true, std::memory_order_relaxed);
       if( gAudioIO->mAudioThreadShouldCallTrackBufferExchangeOnce
-         .load(std::memory_order_relaxed) )
+         .load(std::memory_order_acquire) )
       {
          gAudioIO->TrackBufferExchange();
          gAudioIO->mAudioThreadShouldCallTrackBufferExchangeOnce
-            .store(false, std::memory_order_relaxed);
+            .store(false, std::memory_order_release);
       }
       else if( gAudioIO->mAudioThreadTrackBufferExchangeLoopRunning
          .load(std::memory_order_relaxed))
@@ -3138,9 +3138,9 @@ int AudioIoCallback::CallbackDoSeek()
 
    // Reload the ring buffers
    mAudioThreadShouldCallTrackBufferExchangeOnce
-      .store(true, std::memory_order_relaxed);
+      .store(true, std::memory_order_release);
    while( mAudioThreadShouldCallTrackBufferExchangeOnce
-      .load(std::memory_order_relaxed) )
+      .load(std::memory_order_acquire) )
    {
       using namespace std::chrono;
       std::this_thread::sleep_for(50ms);

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1447,9 +1447,7 @@ void AudioIO::StopStream()
       mPortStreamV19 = NULL;
    }
 
-   // No longer need effects processing. This must be done after the stream is stopped
-   // to prevent the callback from being invoked after the effects are finalized.
-   mpTransportState.reset();
+   
 
    for( auto &ext : Extensions() )
       ext.StopOtherStream();
@@ -1553,6 +1551,12 @@ void AudioIO::StopStream()
             pListener->OnCommitRecording();
       }
    }
+
+
+   // No longer need effects processing. This must be done after the stream is stopped
+   // to prevent the callback from being invoked after the effects are finalized.
+   mpTransportState.reset();
+
 
    if (auto pInputMeter = mInputMeter.lock())
       pInputMeter->Reset(mRate, false);


### PR DESCRIPTION
Alone this simple moving resolved the issue, because:
in all instances where mpTransportState was found to be empty during ::TransformBuffers, the call stack
showed that the call was originated in response to a request to process "once", and never in response to process "LoopRunning".

In ::StopStream, a call to process "once" is always requested, because `if (mStreamToken > 0)` will always
be satisfied - I can not seem to reproduce a case when it is not (but somebody else might know better!)

As long as `if (mStreamToken > 0)` always happens, there is no point in introducing what we discussed earlier,
(i.e. a new atomic and a waiting loop on that in order to signal that "LoopRunning" processing is really stopped)
it would be an unnecessary complication, because as the atomic to process "once" is later set to true and then
waited for until it is "false", this will always happen after the last processing coming from "LoopRunning".

However, if there are ever cases when `if (mStreamToken > 0)` is false, then we need this extra atomic, to wait
to be sure that "LoopRunning" processing came to a stop, before resetting mpTransportState. I have all this extra
things ready into a stash anyway - first we must decide if this extra complication is necessary.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
