### PR TITLE
Replace call to a deprecated WINAPI function in VST3Effect

### DIFF
--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -45,7 +45,7 @@
 #include "VST3OptionsDialog.h"
 
 #ifdef __WXMSW__
-#include <ShlObj_core.h>
+#include <shlobj.h>
 #elif __WXGTK__
 #include "internal/x11/SocketWindow.h"
 #endif
@@ -99,11 +99,10 @@ void ActivateDefaultBuses(Steinberg::Vst::IComponent* component, const Steinberg
 wxString GetFactoryPresetsBasePath()
 {
 #ifdef __WXMSW__
-   WCHAR commonFolderPath[MAX_PATH];
-   if(SHGetFolderPathW(NULL, CSIDL_COMMON_APPDATA, NULL, 0, commonFolderPath) == S_OK)
-   {
+   PWSTR commonFolderPath { nullptr };
+   auto cleanup = finally([&](){ CoTaskMemFree(commonFolderPath); });
+   if(SHGetKnownFolderPath(FOLDERID_ProgramData, KF_FLAG_DEFAULT , NULL, &commonFolderPath) == S_OK)
       return wxString(commonFolderPath) + "\\VST3 Presets\\";
-   }
    return {};
 #elif __WXMAC__
    return wxString("Library/Audio/Presets/");


### PR DESCRIPTION
An obsolete `SHGetFolderPathW` was used to retrieve system folder path, replaced with `SHGetKnownFolderPath`, also fixes wrong `#include`

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
