### PR TITLE
Issue 2543: wave track naming

### DIFF
--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -66,7 +66,6 @@ void Track::Init(const Track &orig)
 {
    mId = orig.mId;
 
-   mDefaultName = orig.mDefaultName;
    mName = orig.mName;
 
    mSelected = orig.mSelected;

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -450,6 +450,27 @@ TrackList::~TrackList()
    Clear(false);
 }
 
+wxString TrackList::MakeUniqueTrackName(const wxString& baseTrackName) const
+{
+   int n = 1;
+   while(true)
+   {
+      auto name = wxString::Format("%s %d", baseTrackName, n++);
+
+      bool found {false};
+      for(const auto track : Any())
+      {
+         if(track->GetName() == name)
+         {
+            found = true;
+            break;
+         }
+      }
+      if(!found)
+         return name;
+   }
+}
+
 void TrackList::RecalcPositions(TrackNodePointer node)
 {
    if ( isNull( node ) )

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1329,6 +1329,14 @@ class TRACK_API TrackList final
    AudacityProject *GetOwner() { return mOwner; }
    const AudacityProject *GetOwner() const { return mOwner; }
 
+   /**
+    * \brief Returns string that contains baseTrackName,
+    * but is guaranteed to be unique among other tracks in that list.
+    * \param baseTrackName String to be put into the template
+    * \return Formatted string: "[baseTrackName] [N]"
+    */
+   wxString MakeUniqueTrackName(const wxString& baseTrackName) const;
+
    // Iteration
 
    // Hide the inherited begin() and end()

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -247,7 +247,6 @@ private:
    TrackNodePointer mNode{};
    int            mIndex; //!< 0-based position of this track in its TrackList
    wxString       mName;
-   wxString       mDefaultName;
 
  private:
    bool           mSelected;
@@ -423,8 +422,6 @@ private:
 
    wxString GetName() const { return mName; }
    void SetName( const wxString &n );
-   wxString GetDefaultName() const { return mDefaultName; }
-   void SetDefaultName( const wxString &n ) { mDefaultName = n; }
 
    bool GetSelected() const { return mSelected; }
 

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -376,7 +376,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
    const auto t =
       WaveTrackFactory{ mRate,
                     SampleBlockFactory::New( mProject )  }
-         .NewWaveTrack(SampleFormat);
+         .Create(SampleFormat, mRate.GetRate());
 
    t->SetRate(1);
 

--- a/src/DropoutDetector.cpp
+++ b/src/DropoutDetector.cpp
@@ -24,16 +24,14 @@ static AudacityProject::AttachedObjects::RegisteredFactory sKey {
       [&project](RecordingDropoutEvent &evt){
          evt.Skip();
          // Make a track with labels for recording errors
-         auto uTrack = std::make_shared<LabelTrack>();
-         auto pTrack = uTrack.get();
          auto &tracks = TrackList::Get( project );
-         tracks.Add( uTrack );
+
          /* i18n-hint:  A name given to a track, appearing as its menu button.
           The translation should be short or else it will not display well.
           At most, about 11 Latin characters.
           Dropout is a loss of a short sequence of audio sample data from the
           recording */
-         pTrack->SetName(_("Dropouts"));
+         auto pTrack = LabelTrack::Create(tracks, tracks.MakeUniqueTrackName(_("Dropouts")));
          long counter = 1;
          for (auto &interval : evt.intervals)
             pTrack->AddLabel(

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -55,6 +55,11 @@ static ProjectFileIORegistry::ObjectReaderEntry readerEntry{
    LabelTrack::New
 };
 
+wxString LabelTrack::GetDefaultName()
+{
+   return _("Labels");
+}
+
 LabelTrack *LabelTrack::New( AudacityProject &project )
 {
    auto &tracks = TrackList::Get( project );
@@ -63,12 +68,24 @@ LabelTrack *LabelTrack::New( AudacityProject &project )
    return result;
 }
 
+LabelTrack* LabelTrack::Create(TrackList& trackList, const wxString& name)
+{
+   auto track = std::make_shared<LabelTrack>();
+   track->SetName(name);
+   trackList.Add(track);
+   return track.get();
+}
+
+LabelTrack* LabelTrack::Create(TrackList& trackList)
+{
+   return Create(trackList, trackList.MakeUniqueTrackName(GetDefaultName()));
+}
+
 LabelTrack::LabelTrack():
    Track(),
    mClipLen(0.0),
    miLastLabel(-1)
 {
-   SetName(_("Label Track"));
 }
 
 LabelTrack::LabelTrack(const LabelTrack &orig) :

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -68,8 +68,7 @@ LabelTrack::LabelTrack():
    mClipLen(0.0),
    miLastLabel(-1)
 {
-   SetDefaultName(_("Label Track"));
-   SetName(GetDefaultName());
+   SetName(_("Label Track"));
 }
 
 LabelTrack::LabelTrack(const LabelTrack &orig) :

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -88,8 +88,22 @@ class AUDACITY_DLL_API LabelTrack final
    , public wxEvtHandler
 {
  public:
+   static wxString GetDefaultName();
+
    // Construct and also build all attachments
    static LabelTrack *New(AudacityProject &project);
+
+   /**
+    * \brief Create a new LabelTrack with specified @p name and append it to the @p trackList
+    * \return New LabelTrack with custom name
+    */
+   static LabelTrack* Create(TrackList& trackList, const wxString& name);
+
+   /**
+    * \brief Create a new LabelTrack with unique default name and append it to the @p trackList
+    * \return New LabelTrack with unique default name
+    */
+   static LabelTrack* Create(TrackList& trackList);
 
    LabelTrack();
    LabelTrack(const LabelTrack &orig);

--- a/src/MixAndRender.cpp
+++ b/src/MixAndRender.cpp
@@ -87,18 +87,18 @@ void MixAndRender(TrackList *tracks, WaveTrackFactory *trackFactory,
       oneinput = true;
    // only one input track (either 1 mono or one linked stereo pair)
 
-   auto mixLeft = trackFactory->NewWaveTrack(format, rate);
+   auto mixLeft = trackFactory->Create(format, rate);
    if (oneinput)
       mixLeft->SetName(first->GetName()); /* set name of output track to be the same as the sole input track */
    else
       /* i18n-hint: noun, means a track, made by mixing other tracks */
-      mixLeft->SetName(_("Mix"));
+      mixLeft->SetName(tracks->MakeUniqueTrackName(_("Mix")));
    mixLeft->SetOffset(mixStartTime);
 
    // TODO: more-than-two-channels
    decltype(mixLeft) mixRight{};
    if ( !mono ) {
-      mixRight = trackFactory->NewWaveTrack(format, rate);
+      mixRight = trackFactory->Create(format, rate);
       if (oneinput) {
          auto channels = TrackList::Channels(first);
          if (channels.size() > 1)
@@ -107,7 +107,7 @@ void MixAndRender(TrackList *tracks, WaveTrackFactory *trackFactory,
             mixRight->SetName(first->GetName());   /* set name to that of sole input channel */
       }
       else
-         mixRight->SetName(_("Mix"));
+         mixRight->SetName(tracks->MakeUniqueTrackName(_("Mix")));
       mixRight->SetOffset(mixStartTime);
    }
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -123,8 +123,7 @@ NoteTrack *NoteTrack::New( AudacityProject &project )
 NoteTrack::NoteTrack()
    : NoteTrackBase()
 {
-   SetDefaultName(_("Note Track"));
-   SetName(GetDefaultName());
+   SetName(_("Note Track"));
 
    mSeq = NULL;
    mSerializationLength = 0;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -874,14 +874,14 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
          gPrefs->Read(wxT("/GUI/TrackNames/TrackNumber"), &useTrackNumber, false);
          gPrefs->Read(wxT("/GUI/TrackNames/DateStamp"), &useDateStamp, false);
          gPrefs->Read(wxT("/GUI/TrackNames/TimeStamp"), &useTimeStamp, false);
-         defaultTrackName = WaveTrack::GetDefaultAudioTrackNamePreference();
+         defaultTrackName = trackList.MakeUniqueTrackName(WaveTrack::GetDefaultAudioTrackNamePreference());
          gPrefs->Read(wxT("/GUI/TrackNames/RecodingTrackName"), &defaultRecordingTrackName, defaultTrackName);
 
          wxString baseTrackName = recordingNameCustom? defaultRecordingTrackName : defaultTrackName;
 
          Track *first {};
          for (int c = 0; c < recordingChannels; c++) {
-            auto newTrack = WaveTrackFactory::Get( *p ).NewWaveTrack();
+            auto newTrack = WaveTrackFactory::Get( *p ).Create();
             if (!first)
                first = newTrack.get();
 

--- a/src/TimeTrack.cpp
+++ b/src/TimeTrack.cpp
@@ -38,6 +38,11 @@ static ProjectFileIORegistry::ObjectReaderEntry readerEntry{
    TimeTrack::New
 };
 
+wxString TimeTrack::GetDefaultName()
+{
+   return _("Time Track");
+}
+
 TimeTrack *TimeTrack::New( AudacityProject &project )
 {
    auto &tracks = TrackList::Get( project );
@@ -65,7 +70,7 @@ void TimeTrack::CleanState()
    mEnvelope->SetTrackLen(DBL_MAX);
    mEnvelope->SetOffset(0);
 
-   SetDefaultName(_("Time Track"));
+   //Time track is always unique
    SetName(GetDefaultName());
 
    mRuler = std::make_unique<Ruler>();
@@ -105,7 +110,6 @@ TimeTrack::TimeTrack(const TimeTrack &orig, double *pT0, double *pT1)
 void TimeTrack::Init(const TimeTrack &orig)
 {
    Track::Init(orig);
-   SetDefaultName(orig.GetDefaultName());
    SetName(orig.GetName());
    SetDisplayLog(orig.GetDisplayLog());
 }

--- a/src/TimeTrack.h
+++ b/src/TimeTrack.h
@@ -25,6 +25,8 @@ class AUDACITY_DLL_API TimeTrack final : public Track {
 
  public:
 
+   static wxString GetDefaultName();
+
    // Construct and also build all attachments
    static TimeTrack *New(AudacityProject &project);
 
@@ -41,7 +43,6 @@ class AUDACITY_DLL_API TimeTrack final : public Track {
    TimeTrack(const TimeTrack &orig, double *pT0 = nullptr, double *pT1 = nullptr);
 
    virtual ~TimeTrack();
-
 
    const TypeInfo &GetTypeInfo() const override;
    static const TypeInfo &ClassTypeInfo();

--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -36,8 +36,6 @@
 #include "LabelTrack.h"
 #include "NoteTrack.h"
 #include "TimeTrack.h"
-#include "WaveTrack.h"
-
 
 wxDEFINE_EVENT(EVT_TRACK_FOCUS_CHANGE, wxCommandEvent);
 
@@ -363,74 +361,70 @@ wxAccStatus TrackPanelAx::GetName( int childId, wxString* name )
          auto t = FindTrack( childId );
 
          if( t == NULL )
-         {
             return wxACC_FAIL;
-         }
-         else
+
+         name->Printf("%d %s", TrackNum(t), t->GetName());
+
+         if(dynamic_cast<LabelTrack*>(t.get()))
          {
-            *name = t->GetName();
-            if( *name == t->GetDefaultName() )
-            {
-               /* i18n-hint: The %d is replaced by the number of the track.*/
-               name->Printf(_("Track %d"), TrackNum( t ) );
-            }
-
-            t->TypeSwitch(
-               [&](const LabelTrack *) {
-                  /* i18n-hint: This is for screen reader software and indicates that
-                     this is a Label track.*/
-                  name->Append( wxT(" ") + wxString(_("Label Track")));
-               },
-               [&](const TimeTrack *) {
-                  /* i18n-hint: This is for screen reader software and indicates that
-                     this is a Time track.*/
-                  name->Append( wxT(" ") + wxString(_("Time Track")));
-               }
+            const auto trackNameLower = t->GetName().Lower();
+            //Prior to version 3.2 "Label Track" was the default
+            //name for label tracks, don't append type part to the
+            //text to avoid verbosity.
+            if(trackNameLower.Find(wxString(_("Label Track")).Lower()) == wxNOT_FOUND &&
+               trackNameLower.Find(LabelTrack::GetDefaultName().Lower()) == wxNOT_FOUND)
+               /* i18n-hint: This is for screen reader software and indicates that
+                  this is a Label track.*/
+               name->Append( wxT(" ") + wxString(_("Label Track")));
+         }
+         else if(dynamic_cast<TimeTrack*>(t.get()))
+         {
+            if(t->GetName().Lower().Find(TimeTrack::GetDefaultName().Lower()) == wxNOT_FOUND)
+               /* i18n-hint: This is for screen reader software and indicates that
+                  this is a Time track.*/
+               name->Append(wxT(" ") + wxString(_("Time Track")));
+         }
 #ifdef USE_MIDI
-                ,
-               [&](const NoteTrack *) {
-                  /* i18n-hint: This is for screen reader software and indicates that
-                     this is a Note track.*/
-                  name->Append( wxT(" ") + wxString(_("Note Track")));
-               }
+         else if(dynamic_cast<NoteTrack*>(t.get()))
+            /* i18n-hint: This is for screen reader software and indicates that
+               this is a Note track.*/
+            name->Append( wxT(" ") + wxString(_("Note Track")));
 #endif
-            );
 
-            // LLL: Remove these during "refactor"
-            auto pt = dynamic_cast<PlayableTrack *>(t.get());
-            if( pt && pt->GetMute() )
-            {
-               // The following comment also applies to the solo, selected,
-               // and synclockselected states.
-               // Many of translations of the strings with a leading space omitted
-               // the leading space. Therefore a space has been added using wxT(" ").
-               // Because screen readers won't be affected by multiple spaces, the
-               // leading spaces have not been removed, so that no NEW translations are needed.
-               /* i18n-hint: This is for screen reader software and indicates that
-                  this track is muted. (The mute button is on.)*/
-               name->Append( wxT(" ") + wxString(_( " Muted" )) );
-            }
+         // LLL: Remove these during "refactor"
+         auto pt = dynamic_cast<PlayableTrack *>(t.get());
+         if( pt && pt->GetMute() )
+         {
+            // The following comment also applies to the solo, selected,
+            // and synclockselected states.
+            // Many of translations of the strings with a leading space omitted
+            // the leading space. Therefore a space has been added using wxT(" ").
+            // Because screen readers won't be affected by multiple spaces, the
+            // leading spaces have not been removed, so that no NEW translations are needed.
+            /* i18n-hint: This is for screen reader software and indicates that
+               this track is muted. (The mute button is on.)*/
+            name->Append( wxT(" ") + wxString(_( " Muted" )) );
+         }
 
-            if( pt && pt->GetSolo() )
-            {
-               /* i18n-hint: This is for screen reader software and indicates that
-                  this track is soloed. (The Solo button is on.)*/
-               name->Append( wxT(" ") + wxString(_( " Soloed" )) );
-            }
-            if( t->GetSelected() )
-            {
-               /* i18n-hint: This is for screen reader software and indicates that
-                  this track is selected.*/
-               name->Append( wxT(" ") + wxString(_( " Selected" )) );
-            }
-            if (SyncLock::IsSyncLockSelected(t.get()))
-            {
-               /* i18n-hint: This is for screen reader software and indicates that
-                  this track is shown with a sync-locked icon.*/
-               // The absence of a dash between Sync and Locked is deliberate -
-               // if present, Jaws reads it as "dash".
-               name->Append( wxT(" ") + wxString(_( " Sync Locked" )) );
-            }
+         if( pt && pt->GetSolo() )
+         {
+            /* i18n-hint: This is for screen reader software and indicates that
+               this track is soloed. (The Solo button is on.)*/
+            name->Append( wxT(" ") + wxString(_( " Soloed" )) );
+         }
+         if( t->GetSelected() )
+         {
+            /* i18n-hint: This is for screen reader software and indicates that
+               this track is selected.*/
+            name->Append( wxT(" ") + wxString(_( " Selected" )) );
+         }
+         if (SyncLock::IsSyncLockSelected(t.get()))
+         {
+            /* i18n-hint: This is for screen reader software and indicates that
+               this track is shown with a sync-locked icon.*/
+            // The absence of a dash between Sync and Locked is deliberate -
+            // if present, Jaws reads it as "dash".
+            name->Append( wxT(" ") + wxString(_( " Sync Locked" )) );
          }
       }
    }
@@ -575,11 +569,9 @@ wxAccStatus TrackPanelAx::GetValue( int WXUNUSED(childId), wxString* WXUNUSED(st
       }
       else
       {
-         *strValue = t->GetName();
-         if( *strValue == t->GetDefaultName() )
-         {
-            strValue->Printf(_("Track %d"), TrackNum( t ) );
-         }
+         /* i18n-hint: The %d is replaced by the number of the track.*/
+         strValue->Printf(_("Track %d"), TrackNum(t));
+         strValue->Append(" " + t->GetName());
 
          // LLL: Remove these during "refactor"
          auto pt = dynamic_cast<PlayableTrack *>(t.get());

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -95,7 +95,7 @@ Track::LinkType ToLinkType(int value)
 
 }
 
-static auto DefaultName = XO("Audio Track");
+static auto DefaultName = XO("Audio");
 
 wxString WaveTrack::GetDefaultAudioTrackNamePreference()
 {

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -156,8 +156,7 @@ WaveTrack::WaveTrack( const SampleBlockFactoryPtr &pFactory,
    mOldGain[0] = 0.0;
    mOldGain[1] = 0.0;
    mWaveColorIndex = 0;
-   SetDefaultName(GetDefaultAudioTrackNamePreference());
-   SetName(GetDefaultName());
+   SetName(GetDefaultAudioTrackNamePreference());
    mDisplayMin = -1.0;
    mDisplayMax = 1.0;
    mSpectrumMin = mSpectrumMax = -1; // so values will default to settings
@@ -202,7 +201,6 @@ void WaveTrack::Init(const WaveTrack &orig)
    DoSetPan(orig.GetPan());
    mOldGain[0] = 0.0;
    mOldGain[1] = 0.0;
-   SetDefaultName(orig.GetDefaultName());
    SetName(orig.GetName());
    mDisplayMin = orig.mDisplayMin;
    mDisplayMax = orig.mDisplayMax;

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -115,31 +115,21 @@ static ProjectFileIORegistry::ObjectReaderEntry readerEntry{
    WaveTrack::New
 };
 
-WaveTrack::Holder WaveTrackFactory::DuplicateWaveTrack(const WaveTrack &orig)
+std::shared_ptr<WaveTrack> WaveTrackFactory::Create()
 {
-   auto waveTrack = std::static_pointer_cast<WaveTrack>( orig.Duplicate() );
-
-   return waveTrack;
+   return Create(QualitySettings::SampleFormatChoice(), mRate.GetRate());
 }
 
-
-WaveTrack::Holder WaveTrackFactory::NewWaveTrack(sampleFormat format, double rate)
+std::shared_ptr<WaveTrack> WaveTrackFactory::Create(sampleFormat format, double rate)
 {
-   if (format == (sampleFormat)0)
-      format = QualitySettings::SampleFormatChoice();
-   if (rate == 0)
-      rate = mRate.GetRate();
-
-   auto waveTrack = std::make_shared<WaveTrack> ( mpFactory, format, rate );
-
-   return waveTrack;
+   return std::make_shared<WaveTrack>(mpFactory, format, rate);
 }
 
 WaveTrack *WaveTrack::New( AudacityProject &project )
 {
    auto &trackFactory = WaveTrackFactory::Get( project );
    auto &tracks = TrackList::Get( project );
-   auto result = tracks.Add(trackFactory.NewWaveTrack());
+   auto result = tracks.Add(trackFactory.Create());
    result->AttachedTrackObjects::BuildAll();
    return result;
 }
@@ -156,7 +146,6 @@ WaveTrack::WaveTrack( const SampleBlockFactoryPtr &pFactory,
    mOldGain[0] = 0.0;
    mOldGain[1] = 0.0;
    mWaveColorIndex = 0;
-   SetName(GetDefaultAudioTrackNamePreference());
    mDisplayMin = -1.0;
    mDisplayMax = 1.0;
    mSpectrumMin = mSpectrumMax = -1; // so values will default to settings
@@ -201,7 +190,6 @@ void WaveTrack::Init(const WaveTrack &orig)
    DoSetPan(orig.GetPan());
    mOldGain[0] = 0.0;
    mOldGain[1] = 0.0;
-   SetName(orig.GetName());
    mDisplayMin = orig.mDisplayMin;
    mDisplayMax = orig.mDisplayMax;
    mSpectrumMin = orig.mSpectrumMin;

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -105,7 +105,7 @@ private:
    using Holder = std::shared_ptr<WaveTrack>;
 
    virtual ~WaveTrack();
-
+   
    double GetOffset() const override;
    void SetOffset(double o) override;
    ChannelType GetChannelIgnoringPan() const override;

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -623,14 +623,23 @@ class AUDACITY_DLL_API WaveTrackFactory final
    const SampleBlockFactoryPtr &GetSampleBlockFactory() const
    { return mpFactory; }
 
+   /**
+    * \brief Creates an unnamed empty WaveTrack with default sample format and default rate
+    * \return Orphaned WaveTrack
+    */
+   std::shared_ptr<WaveTrack> Create();
+
+   /**
+    * \brief Creates an unnamed empty WaveTrack with custom sample format and custom rate
+    * \param format Desired sample format
+    * \param rate Desired sample rate
+    * \return Orphaned WaveTrack
+    */
+   std::shared_ptr<WaveTrack> Create(sampleFormat format, double rate);
+
  private:
    const ProjectRate &mRate;
    SampleBlockFactoryPtr mpFactory;
- public:
-   std::shared_ptr<WaveTrack> DuplicateWaveTrack(const WaveTrack &orig);
-   std::shared_ptr<WaveTrack> NewWaveTrack(
-      sampleFormat format = (sampleFormat)0,
-      double rate = 0);
 };
 
 extern AUDACITY_DLL_API StringSetting AudioTrackNameSetting;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1016,7 +1016,9 @@ bool Effect::DoEffect(double projectRate,
    // We don't yet know the effect type for code in the Nyquist Prompt, so
    // assume it requires a track and handle errors when the effect runs.
    if ((GetType() == EffectTypeGenerate || GetPath() == NYQUIST_PROMPT_ID) && (mNumTracks == 0)) {
-      newTrack = mTracks->Add(mFactory->NewWaveTrack());
+      auto track = mFactory->Create();
+      track->SetName(mTracks->MakeUniqueTrackName(WaveTrack::GetDefaultAudioTrackNamePreference()));
+      newTrack = mTracks->Add(track);
       newTrack->SetSelected(true);
    }
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1854,11 +1854,10 @@ Track *Effect::AddToOutputTracks(const std::shared_ptr<Track> &t)
 Effect::AddedAnalysisTrack::AddedAnalysisTrack(Effect *pEffect, const wxString &name)
    : mpEffect(pEffect)
 {
-   LabelTrack::Holder pTrack{ std::make_shared<LabelTrack>() };
-   mpTrack = pTrack.get();
-   if (!name.empty())
-      pTrack->SetName(name);
-   pEffect->mTracks->Add( pTrack );
+   if(!name.empty())
+      mpTrack = LabelTrack::Create(*pEffect->mTracks, name);
+   else
+      mpTrack = LabelTrack::Create(*pEffect->mTracks);
 }
 
 Effect::AddedAnalysisTrack::AddedAnalysisTrack(AddedAnalysisTrack &&that)

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1530,8 +1530,11 @@ bool NyquistEffect::ProcessOne()
       unsigned int l;
       auto ltrack = * mOutputTracks->Any< LabelTrack >().begin();
       if (!ltrack) {
+         auto newTrack = std::make_shared<LabelTrack>();
+         //new track name should be unique among the names in the list of input tracks, not output
+         newTrack->SetName(inputTracks()->MakeUniqueTrackName(LabelTrack::GetDefaultName()));
          ltrack = static_cast<LabelTrack*>(
-            AddToOutputTracks(std::make_shared<LabelTrack>()));
+            AddToOutputTracks(newTrack));
       }
 
       for (l = 0; l < numLabels; l++) {

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -901,7 +901,7 @@ bool AUPImportFileHandle::HandleWaveTrack(XMLTagHandler *&handler)
 {
    auto &trackFactory = WaveTrackFactory::Get(mProject);
    handler = mWaveTrack =
-      TrackList::Get(mProject).Add(trackFactory.NewWaveTrack());
+      TrackList::Get(mProject).Add(trackFactory.Create());
 
    // No active clip.  In early versions of Audacity, there was a single
    // implied clip so we'll create a clip when the first "sequence" is

--- a/src/import/ImportPlugin.cpp
+++ b/src/import/ImportPlugin.cpp
@@ -69,5 +69,5 @@ sampleFormat ImportFileHandle::ChooseFormat(sampleFormat effectiveFormat)
 std::shared_ptr<WaveTrack> ImportFileHandle::NewWaveTrack(
    WaveTrackFactory &trackFactory, sampleFormat effectiveFormat, double rate)
 {
-   return trackFactory.NewWaveTrack(ChooseFormat(effectiveFormat), rate);
+   return trackFactory.Create(ChooseFormat(effectiveFormat), rate);
 }

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -190,7 +190,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
          // iter not used outside this scope.
          auto iter = channels.begin();
          for (decltype(numChannels) c = 0; c < numChannels; ++iter, ++c)
-            *iter = trackFactory->NewWaveTrack(format, rate);
+            *iter = trackFactory->Create(format, rate);
       }
       const auto firstChannel = channels.begin()->get();
       auto maxBlockSize = firstChannel->GetMaxBlockSize();

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -19,24 +19,20 @@ struct FoundTrack {
    int trackNum{};
    bool channel{};
 
-   TranslatableString ComposeTrackName() const
+   wxString ComposeTrackName() const
    {
-      auto name = waveTrack->GetName();
-      auto shortName = name == waveTrack->GetDefaultName()
-         /* i18n-hint: compose a name identifying an unnamed track by number */
-         ? XO("Track %d").Format( trackNum )
-         : Verbatim(name);
-      auto longName = shortName;
+      /* i18n-hint: The %d is replaced by the number of the track.*/
+      auto shortName = wxString::Format(_("Track %d"), trackNum).Append(" " + waveTrack->GetName());
       if (channel) {
          // TODO: more-than-two-channels-message
          if ( waveTrack->IsLeader() )
          /* i18n-hint: given the name of a track, specify its left channel */
-            longName = XO("%s left").Format(shortName);
+            return XO("%s left").Translation().Format(shortName);
          else
          /* i18n-hint: given the name of a track, specify its right channel */
-            longName = XO("%s right").Format(shortName);
+            return XO("%s right").Translation().Format(shortName);
       }
-      return longName;
+      return shortName;
    }
 };
 

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -79,7 +79,7 @@ int DoAddLabel(
 
    // If none found, start a NEW label track and use it
    if (!lt)
-      lt = tracks.Add( std::make_shared<LabelTrack>() );
+      lt = LabelTrack::Create(tracks);
 
 // LLL: Commented as it seemed a little forceful to remove users
 //      selection when adding the label.  This does not happen if
@@ -339,7 +339,7 @@ void OnPasteNewLabel(const CommandContext &context)
 
          // If no match found, add one
          if (!t)
-            t = tracks.Add( std::make_shared<LabelTrack>() );
+            t = LabelTrack::Create(tracks);
 
          // Select this track so the loop picks it up
          t->SetSelected(true);
@@ -681,19 +681,18 @@ void OnNewLabelTrack(const CommandContext &context)
 {
    auto &project = context.project;
    auto &tracks = TrackList::Get( project );
-   auto &window = ProjectWindow::Get( project );
 
-   auto t = tracks.Add( std::make_shared<LabelTrack>() );
+   auto track = LabelTrack::Create(tracks);
 
    SelectUtilities::SelectNone( project );
 
-   t->SetSelected(true);
+   track->SetSelected(true);
 
    ProjectHistory::Get( project )
       .PushState(XO("Created new label track"), XO("New Track"));
 
-   TrackFocus::Get(project).Set(t);
-   t->EnsureVisible();
+   TrackFocus::Get(project).Set(track);
+   track->EnsureVisible();
 }
 
 }; // struct Handler

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackMenuItems.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackMenuItems.cpp
@@ -35,16 +35,18 @@ void OnNewWaveTrack(const CommandContext &context)
 
    auto rate = ProjectRate::Get(project).GetRate();
 
-   auto t = tracks.Add( trackFactory.NewWaveTrack( defaultFormat, rate ) );
+   auto track = trackFactory.Create(defaultFormat, rate);
+   track->SetName(tracks.MakeUniqueTrackName(WaveTrack::GetDefaultAudioTrackNamePreference()));
+   tracks.Add(track);
    SelectUtilities::SelectNone( project );
 
-   t->SetSelected(true);
+   track->SetSelected(true);
 
    ProjectHistory::Get( project )
       .PushState(XO("Created new audio track"), XO("New Track"));
 
-   TrackFocus::Get(project).Set(t);
-   t->EnsureVisible();
+   TrackFocus::Get(project).Set(track.get());
+   track->EnsureVisible();
 }
 
 void OnNewStereoTrack(const CommandContext &context)
@@ -59,10 +61,14 @@ void OnNewStereoTrack(const CommandContext &context)
 
    SelectUtilities::SelectNone( project );
 
-   auto left = tracks.Add( trackFactory.NewWaveTrack( defaultFormat, rate ) );
+   auto left = trackFactory.Create(defaultFormat, rate);
+   left->SetName(tracks.MakeUniqueTrackName(WaveTrack::GetDefaultAudioTrackNamePreference()));
+   tracks.Add(left);
    left->SetSelected(true);
 
-   auto right = tracks.Add( trackFactory.NewWaveTrack( defaultFormat, rate ) );
+   auto right = trackFactory.Create(defaultFormat, rate);
+   right->SetName(left->GetName());
+   tracks.Add(right);
    right->SetSelected(true);
 
    tracks.MakeMultiChannelTrack(*left, 2, true);
@@ -70,7 +76,7 @@ void OnNewStereoTrack(const CommandContext &context)
    ProjectHistory::Get( project )
       .PushState(XO("Created new stereo audio track"), XO("New Track"));
 
-   TrackFocus::Get(project).Set(left);
+   TrackFocus::Get(project).Set(left.get());
    left->EnsureVisible();
 }
 


### PR DESCRIPTION
Resolves: #2543 

Note that the logic of the name assignment behind track copying wasn't changed at all (copy will always receive the name of the original track).

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
