### PR TITLE
Effects side panel

### DIFF
--- a/libraries/lib-screen-geometry/ViewInfo.h
+++ b/libraries/lib-screen-geometry/ViewInfo.h
@@ -93,6 +93,7 @@ enum : int {
 
 enum : int {
    kTrackInfoBtnSize = 18, // widely used dimension, usually height
+   kTrackEffectsBtnHeight = 28,
    kTrackInfoSliderHeight = 25,
    kTrackInfoSliderWidth = 84,
    kTrackInfoSliderAllowance = 5,

--- a/libraries/lib-theme/AColor.h
+++ b/libraries/lib-theme/AColor.h
@@ -50,6 +50,10 @@ class THEME_API AColor {
    static void Bevel(wxDC & dc, bool up, const wxRect & r);
    static void Bevel2
       (wxDC & dc, bool up, const wxRect & r, bool bSel=false, bool bHighlight = false);
+   /**
+    * \brief Draw a button that fills a given rect
+    */
+   static void ButtonStretch(wxDC& dc, bool up, const wxRect& r, bool selected = false, bool highlight = false);
    static void BevelTrackInfo(wxDC & dc, bool up, const wxRect & r, bool highlight = false);
    static wxColour Blend(const wxColour & c1, const wxColour & c2);
 

--- a/src/Experimental.cmake
+++ b/src/Experimental.cmake
@@ -136,8 +136,6 @@ set( EXPERIMENTAL_OPTIONS_LIST
    # USE_MIDI must be defined in order for SCOREALIGN to work
    #SCOREALIGN
 
-   #NOTEBOOK
-
    #Automatically tries to find an acceptable input volume
    #AUTOMATED_INPUT_LEVEL_ADJUSTMENT
 

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -183,10 +183,6 @@ void ProjectManager::SaveWindowSize()
    sbWindowRectAlreadySaved = true;
 }
 
-#ifdef EXPERIMENTAL_NOTEBOOK
-   extern void AddPages(   AudacityProject * pProj, GuiFactory & Factory,  wxNotebook  * pNotebook );
-#endif
-
 void InitProjectWindow( ProjectWindow &window )
 {
    auto &project = window.GetProject();
@@ -249,14 +245,13 @@ void InitProjectWindow( ProjectWindow &window )
    // irrespective of the order in which they were created.
    ToolManager::Get(project).GetTopDock()->MoveBeforeInTabOrder(&ruler);
 
-   const auto pPage = window.GetMainPage();
 
    wxBoxSizer *bs;
    {
       auto ubs = std::make_unique<wxBoxSizer>(wxVERTICAL);
       bs = ubs.get();
       bs->Add(topPanel, 0, wxEXPAND | wxALIGN_TOP);
-      bs->Add(pPage, 1, wxEXPAND);
+      bs->Add(window.GetContainerWindow(), 1, wxEXPAND);
       bs->Add( ToolManager::Get( project ).GetBotDock(), 0, wxEXPAND );
       window.SetAutoLayout(true);
       window.SetSizer(ubs.release());
@@ -270,9 +265,11 @@ void InitProjectWindow( ProjectWindow &window )
    //      will be given the focus even if we try to SetFocus().  By
    //      making the TrackPanel that first window, we resolve several
    //      keyboard focus problems.
-   pPage->MoveBeforeInTabOrder(topPanel);
+   window.GetContainerWindow()->MoveAfterInTabOrder(topPanel);
 
-   bs = (wxBoxSizer *)pPage->GetSizer();
+   const auto trackListWindow = window.GetTrackListWindow();
+
+   bs = static_cast<wxBoxSizer*>(trackListWindow->GetSizer());
 
    auto vsBar = &window.GetVerticalScrollBar();
    auto hsBar = &window.GetHorizontalScrollBar();
@@ -308,16 +305,8 @@ void InitProjectWindow( ProjectWindow &window )
    }
 
    // Lay it out
-   pPage->SetAutoLayout(true);
-   pPage->Layout();
-
-#ifdef EXPERIMENTAL_NOTEBOOK
-   AddPages(this, Factory, pNotebook);
-#endif
-
-   auto mainPanel = window.GetMainPanel();
-
-   mainPanel->Layout();
+   trackListWindow->SetAutoLayout(true);
+   trackListWindow->Layout();
 
    wxASSERT( trackPanel.GetProject() == &project );
 

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -39,6 +39,7 @@ Paul Licameli split from AudacityProject.cpp
 #include <wx/display.h>
 #include <wx/scrolbar.h>
 #include <wx/sizer.h>
+#include <wx/splitter.h>
 
 // Returns the screen containing a rectangle, or -1 if none does.
 int ScreenContaining( wxRect & r ){
@@ -560,13 +561,6 @@ enum {
    NextID,
 };
 
-//If you want any of these files, ask JKC.  They are not
-//yet checked in to Audacity SVN as of 12-Feb-2010
-#ifdef EXPERIMENTAL_NOTEBOOK
-   #include "GuiFactory.h"
-   #include "APanel.h"
-#endif
-
 ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
                                  const wxPoint & pos,
                                  const wxSize & size, AudacityProject &project)
@@ -595,44 +589,31 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
    mTopPanel->SetBackgroundColour(theTheme.Colour( clrMedium ));
 #endif
 
-   wxWindow    * pPage;
+   auto container = safenew wxSplitterWindow(this, wxID_ANY,
+      wxDefaultPosition,
+      wxDefaultSize,
+      wxNO_BORDER | wxSP_LIVE_UPDATE);
+   container->Bind(wxEVT_SPLITTER_DOUBLECLICKED, [](wxSplitterEvent& event){
+      //"The default behaviour is to unsplit the window"
+      event.Veto();//do noting instead
+   });
+   mContainerWindow = container;
 
-#ifdef EXPERIMENTAL_NOTEBOOK
-   // We are using a notebook (tabbed panel), so we create the notebook and add pages.
-   GuiFactory Factory;
-   wxNotebook  * pNotebook;
-   mMainPanel = Factory.AddPanel(
-      this, wxPoint( left, top ), wxSize( width, height ) );
-   pNotebook  = Factory.AddNotebook( mMainPanel );
-   /* i18n-hint: This is an experimental feature where the main panel in
-      Audacity is put on a notebook tab, and this is the name on that tab.
-      Other tabs in that notebook may have instruments, patch panels etc.*/
-   pPage = Factory.AddPage( pNotebook, _("Main Mix"));
-#else
-   // Not using a notebook, so we place the track panel inside another panel,
-   // this keeps the notebook code and normal code consistent and also
-   // paves the way for adding additional windows inside the track panel.
-   mMainPanel = safenew wxPanelWrapper(this, -1,
+   mTrackListWindow = safenew wxPanelWrapper(mContainerWindow, wxID_ANY,
       wxDefaultPosition,
       wxDefaultSize,
       wxNO_BORDER);
-   mMainPanel->SetSizer( safenew wxBoxSizer(wxVERTICAL) );
-   mMainPanel->SetLabel("Main Panel");// Not localised.
-   pPage = mMainPanel;
-   // Set the colour here to the track panel background to avoid
-   // flicker when Audacity starts up.
-   // However, that leads to areas next to the horizontal scroller
-   // being painted in background colour and not scroller background
-   // colour, so suppress this for now.
-   //pPage->SetBackgroundColour( theTheme.Colour( clrDark ));
-#endif
-   pPage->SetLayoutDirection(wxLayout_LeftToRight);
+   mTrackListWindow->SetSizer( safenew wxBoxSizer(wxVERTICAL) );
+   mTrackListWindow->SetLabel("Main Panel");// Not localized.
+   mTrackListWindow->SetLayoutDirection(wxLayout_LeftToRight);
+
+   mEffectsWindow = safenew wxWindow(mContainerWindow, wxID_ANY, wxDefaultPosition, wxSize(250, 20));
+   mEffectsWindow->Hide();//initially hidden
+   mContainerWindow->Initialize(mTrackListWindow);
 
 #ifdef EXPERIMENTAL_DA2
-   pPage->SetBackgroundColour(theTheme.Colour( clrMedium ));
+   mTrackListWindow->SetBackgroundColour(theTheme.Colour( clrMedium ));
 #endif
-
-   mMainPage = pPage;
 
    mPlaybackScroller = std::make_unique<PlaybackScroller>( &project );
 
@@ -645,8 +626,8 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
    //      creating the scrollbars after the TrackPanel, we resolve
    //      several focus problems.
 
-   mHsbar = safenew ScrollBar(pPage, HSBarID, wxSB_HORIZONTAL);
-   mVsbar = safenew ScrollBar(pPage, VSBarID, wxSB_VERTICAL);
+   mHsbar = safenew ScrollBar(mTrackListWindow, HSBarID, wxSB_HORIZONTAL);
+   mVsbar = safenew ScrollBar(mTrackListWindow, VSBarID, wxSB_VERTICAL);
 #if wxUSE_ACCESSIBILITY
    // so that name can be set on a standard control
    mHsbar->SetAccessible(safenew WindowAccessible(mHsbar));
@@ -1217,6 +1198,28 @@ bool ProjectWindow::IsIconized() const
 {
    return mIconized;
 }
+
+wxWindow* ProjectWindow::GetEffectsWindow() noexcept
+{
+   return mEffectsWindow;
+}
+
+wxWindow* ProjectWindow::GetTrackListWindow() noexcept
+{
+   return mTrackListWindow;
+}
+
+wxWindow* ProjectWindow::GetContainerWindow() noexcept
+{
+   return mContainerWindow;
+}
+
+wxPanel* ProjectWindow::GetTopPanel() noexcept
+{
+   return mTopPanel;
+}
+
+
 
 void ProjectWindow::UpdateStatusWidths()
 {
@@ -1837,6 +1840,27 @@ void ProjectWindow::DoZoomFit()
 
    window.Zoom( window.GetZoomOfToFit() );
    window.TP_ScrollWindow(start);
+}
+
+void ProjectWindow::ShowEffectsPanel(Track* track)
+{
+   if(track == nullptr)
+      return;
+
+   if(mContainerWindow->GetWindow1() != mEffectsWindow)
+   {
+      //Restore previous effects window size
+      mContainerWindow->SplitVertically(
+         mEffectsWindow,
+         mTrackListWindow,
+         mEffectsWindow->GetSize().GetWidth());
+   }
+}
+
+void ProjectWindow::HideEffectsPanel()
+{
+   mContainerWindow->Unsplit(mEffectsWindow);
+   Layout();
 }
 
 static ToolManager::TopPanelHook::Scope scope {

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -21,6 +21,7 @@ class Track;
 
 class wxScrollBar;
 class wxPanel;
+class wxSplitterWindow;
 
 class ProjectWindow;
 void InitProjectWindow( ProjectWindow &window );
@@ -52,9 +53,28 @@ public:
    bool IsBeingDeleted() const { return mIsDeleting; }
    void SetIsBeingDeleted() { mIsDeleting = true; }
 
-   wxWindow *GetMainPage() { return mMainPage; }
-   wxPanel *GetMainPanel() { return mMainPanel; }
-   wxPanel *GetTopPanel() { return mTopPanel; }
+   /**
+    * \brief Effect window contains list off effects assigned to
+    * a selected track.
+    * \return Pointer to an effects side-panel window (not null)
+    */
+   wxWindow* GetEffectsWindow() noexcept;
+   /**
+    * \brief Track list window is the parent container for TrackPanel
+    * \return Pointer to a track list window (not null)
+    */
+   wxWindow* GetTrackListWindow() noexcept;
+   /**
+    * \brief Container is a parent window for both effects panel and
+    * track list windows
+    * \return Pointer to a container window (not null)
+    */
+   wxWindow* GetContainerWindow() noexcept;
+   /**
+    * \brief Top panel contains project-related controls and tools.
+    * \return Pointer to a top panel window (not null)
+    */
+   wxPanel *GetTopPanel() noexcept;
 
    void UpdateStatusWidths();
 
@@ -105,6 +125,9 @@ public:
    void ZoomAfterImport(Track *pTrack);
    double GetZoomOfToFit() const;
    void DoZoomFit();
+
+   void ShowEffectsPanel(Track* track = nullptr);
+   void HideEffectsPanel();
 
    void ApplyUpdatedTheme();
 
@@ -183,8 +206,10 @@ private:
    wxRect mNormalizedWindowState;
 
    wxPanel *mTopPanel{};
-   wxWindow * mMainPage{};
-   wxPanel * mMainPanel{};
+   wxSplitterWindow* mContainerWindow;
+   wxWindow* mEffectsWindow{};
+   wxWindow* mTrackListWindow{};
+   
    wxScrollBar *mHsbar{};
    wxScrollBar *mVsbar{};
 

--- a/src/TrackInfo.h
+++ b/src/TrackInfo.h
@@ -47,6 +47,7 @@ namespace TrackInfo
          kItemMinimize         = 1 << 8,
          kItemSyncLock         = 1 << 9,
          kItemStatusInfo2      = 1 << 10,
+         kItemEffects          = 1 << 11,
 
          kHighestBottomItem = kItemMinimize,
       };

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -205,7 +205,7 @@ AttachedWindows::RegisteredFactory sKey{
       auto &ruler = AdornedRulerPanel::Get( project );
       auto &viewInfo = ViewInfo::Get( project );
       auto &window = ProjectWindow::Get( project );
-      auto mainPage = window.GetMainPage();
+      auto mainPage = window.GetTrackListWindow();
       wxASSERT( mainPage ); // to justify safenew
 
       auto &tracks = TrackList::Get( project );
@@ -346,22 +346,16 @@ void TrackPanel::UpdatePrefs()
 /// goes with this track panel.
 AudacityProject * TrackPanel::GetProject() const
 {
-   //JKC casting away constness here.
-   //Do it in two stages in case 'this' is not a wxWindow.
-   //when the compiler will flag the error.
-   wxWindow const * const pConstWind = this;
-   wxWindow * pWind=(wxWindow*)pConstWind;
-#ifdef EXPERIMENTAL_NOTEBOOK
-   pWind = pWind->GetParent(); //Page
-   wxASSERT( pWind );
-   pWind = pWind->GetParent(); //Notebook
-   wxASSERT( pWind );
-#endif
-   pWind = pWind->GetParent(); //MainPanel
-   wxASSERT( pWind );
-   pWind = pWind->GetParent(); //ProjectWindow
-   wxASSERT( pWind );
-   return &static_cast<ProjectWindow*>( pWind )->GetProject();
+   auto window = GetParent();
+
+   while(window != nullptr)
+   {
+      if(const auto projectWindow = dynamic_cast<ProjectWindow*>(window))
+         return &projectWindow->GetProject();
+
+      window = window->GetParent();
+   }
+   return nullptr;
 }
 
 void TrackPanel::OnSize( wxSizeEvent &evt )

--- a/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
@@ -22,6 +22,8 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../TrackPanelMouseEvent.h"
 #include "../../../TrackUtilities.h"
 
+#include <wx/window.h>
+
 MuteButtonHandle::MuteButtonHandle
 ( const std::shared_ptr<Track> &pTrack, const wxRect &rect )
    : ButtonHandle{ pTrack, rect }
@@ -126,6 +128,66 @@ UIHandlePtr SoloButtonHandle::HitTest
 
    if ( pTrack && buttonRect.Contains(state.m_x, state.m_y) ) {
       auto result = std::make_shared<SoloButtonHandle>( pTrack, buttonRect );
+      result = AssignUIHandlePtr(holder, result);
+      return result;
+   }
+   else
+      return {};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+EffectsButtonHandle::EffectsButtonHandle
+( const std::shared_ptr<Track> &pTrack, const wxRect &rect )
+   : ButtonHandle{ pTrack, rect }
+{}
+
+EffectsButtonHandle::~EffectsButtonHandle()
+{
+}
+
+UIHandle::Result EffectsButtonHandle::CommitChanges
+(const wxMouseEvent &event, AudacityProject *pProject, wxWindow *pParent)
+{
+   // To do
+
+   return RefreshCode::RefreshNone;
+}
+
+TranslatableString EffectsButtonHandle::Tip(
+   const wxMouseState &, AudacityProject &project) const
+{
+   auto name = XO("Effects");
+   auto focused =
+      TrackFocus::Get( project ).Get() == GetTrack().get();
+   if (!focused)
+      return name;
+   else {
+      return name;
+   // Instead supply shortcut when "TrackEffects" is defined
+   /*
+   auto &commandManager = CommandManager::Get( project );
+   ComponentInterfaceSymbol command{ wxT("TrackEffects"), name };
+   return commandManager.DescribeCommandsAndShortcuts( &command, 1u );
+    */
+   }
+}
+
+UIHandlePtr EffectsButtonHandle::HitTest
+(std::weak_ptr<EffectsButtonHandle> &holder,
+ const wxMouseState &state, const wxRect &rect,
+ const AudacityProject *pProject, const std::shared_ptr<Track> &pTrack)
+{
+   wxRect buttonRect;
+   if ( pTrack )
+      PlayableTrackControls::GetEffectsRect(rect, buttonRect,
+         pTrack.get());
+
+   if ( TrackInfo::HideTopItem( rect, buttonRect ) )
+      return {};
+
+   if ( pTrack && buttonRect.Contains(state.m_x, state.m_y) ) {
+      auto result = std::make_shared<EffectsButtonHandle>( pTrack, buttonRect );
       result = AssignUIHandlePtr(holder, result);
       return result;
    }

--- a/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
@@ -24,6 +24,7 @@ Paul Licameli split from TrackPanel.cpp
 
 #include <wx/window.h>
 
+#include "ProjectWindow.h"
 MuteButtonHandle::MuteButtonHandle
 ( const std::shared_ptr<Track> &pTrack, const wxRect &rect )
    : ButtonHandle{ pTrack, rect }
@@ -149,8 +150,7 @@ EffectsButtonHandle::~EffectsButtonHandle()
 UIHandle::Result EffectsButtonHandle::CommitChanges
 (const wxMouseEvent &event, AudacityProject *pProject, wxWindow *pParent)
 {
-   // To do
-
+   ProjectWindow::Get(*pProject).ShowEffectsPanel(mpTrack.lock().get());
    return RefreshCode::RefreshNone;
 }
 

--- a/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.h
+++ b/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.h
@@ -74,4 +74,35 @@ public:
        const AudacityProject *pProject, const std::shared_ptr<Track> &pTrack);
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
+class EffectsButtonHandle final : public ButtonHandle
+{
+   EffectsButtonHandle(const EffectsButtonHandle&) = delete;
+
+public:
+   explicit EffectsButtonHandle
+      ( const std::shared_ptr<Track> &pTrack, const wxRect &rect );
+
+   EffectsButtonHandle &operator=(const EffectsButtonHandle&) = default;
+
+   virtual ~EffectsButtonHandle();
+
+protected:
+   Result CommitChanges
+      (const wxMouseEvent &event, AudacityProject *pProject, wxWindow *pParent)
+      override;
+
+   TranslatableString Tip(
+      const wxMouseState &state, AudacityProject &) const override;
+
+   bool StopsOnKeystroke () override { return true; }
+
+public:
+   static UIHandlePtr HitTest
+      (std::weak_ptr<EffectsButtonHandle> &holder,
+       const wxMouseState &state, const wxRect &rect,
+       const AudacityProject *pProject, const std::shared_ptr<Track> &pTrack);
+};
+
 #endif

--- a/src/tracks/playabletrack/ui/PlayableTrackControls.h
+++ b/src/tracks/playabletrack/ui/PlayableTrackControls.h
@@ -27,6 +27,9 @@ public:
       const wxRect & rect, wxRect & dest, bool solo, bool bHasSoloButton,
       const Track *pTrack);
 
+   static void GetEffectsRect(
+      const wxRect & rect, wxRect & dest, const Track *pTrack);
+
    using CommonTrackControls::CommonTrackControls;
 };
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -67,6 +67,10 @@ std::vector<UIHandlePtr> WaveTrackControls::HitTest
             mSoloHandle, state, rect, pProject, track)))
             return result;
 
+         if (NULL != (result = EffectsButtonHandle::HitTest(
+            mEffectsHandle, state, rect, pProject, track)))
+            return result;
+
          if (NULL != (result = GainSliderHandle::HitTest(
             mGainHandle, state, rect, track)))
             return result;
@@ -553,6 +557,7 @@ BEGIN_POPUP_MENU(WaveTrackMenuTable)
          ProjectAudioIO::Get( project ).IsAudioActive();
    };
 
+
    BeginSection( "SubViews" );
       // Multi-view check mark item, if more than one track sub-view type is
       // known
@@ -943,7 +948,6 @@ void WaveTrackMenuTable::OnSplitStereoMono(wxCommandEvent &)
    mpData->result = RefreshAll | FixScrollbars;
 }
 
-//=============================================================================
 PopupMenuTable *WaveTrackControls::GetMenuExtension(Track * pTrack)
 {
    static Registry::OrderingPreferenceInitializer init{

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.h
@@ -17,6 +17,7 @@ class CellularPanel;
 class LWSlider;
 class MuteButtonHandle;
 class SoloButtonHandle;
+class EffectsButtonHandle;
 class GainSliderHandle;
 class PanSliderHandle;
 class WaveTrack;
@@ -64,6 +65,7 @@ private:
 
    std::weak_ptr<MuteButtonHandle> mMuteHandle;
    std::weak_ptr<SoloButtonHandle> mSoloHandle;
+   std::weak_ptr<EffectsButtonHandle> mEffectsHandle;
    std::weak_ptr<GainSliderHandle> mGainHandle;
    std::weak_ptr<PanSliderHandle> mPanHandle;
 };


### PR DESCRIPTION
Resolves: #2475
Resolves: #2474

Adds an effects panel container, and applies neccessary project window window structure changes, and "Effects" button to the wave tracks that opens panel. There is nothing yet in the panel itself, the example effects UI prototype, which uses that pannel added can be found here: https://github.com/vsverchinsky/audacity/tree/i2474-effects-button

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
