### PR TITLE
Issue2545: exception dialog box on Mac would not respond to button

### DIFF
--- a/src/widgets/wxWidgetsBasicUI.cpp
+++ b/src/widgets/wxWidgetsBasicUI.cpp
@@ -35,6 +35,17 @@ void wxWidgetsBasicUI::DoYield()
    wxTheApp->Yield();
 }
 
+static void DoYieldOnMac()
+{
+#ifdef __WXMAC__
+   // Issue2545: First yield to destroy progress dialogs that (since
+   // 881ee94) now have delayed destruction.  Otherwise, modal dialog
+   // event loops on Mac are messed up and the message box can't be
+   // dismissed.
+   wxTheApp->Yield();
+#endif
+}
+
 void wxWidgetsBasicUI::DoShowErrorDialog(
    const BasicUI::WindowPlacement &placement,
    const TranslatableString &dlogTitle,
@@ -42,6 +53,8 @@ void wxWidgetsBasicUI::DoShowErrorDialog(
    const ManualPageID &helpPage,
    const BasicUI::ErrorDialogOptions &options)
 {
+   DoYieldOnMac();
+
    using namespace BasicUI;
    bool modal = true;
    auto parent = wxWidgetsWindowPlacement::GetParent(placement);
@@ -88,6 +101,8 @@ wxWidgetsBasicUI::DoMessageBox(
    const TranslatableString &message,
    MessageBoxOptions options)
 {
+   DoYieldOnMac();
+
    // Compute the style argument to pass to wxWidgets
    long style = 0;
    switch (options.iconStyle) {
@@ -184,6 +199,7 @@ wxWidgetsBasicUI::DoMakeProgress(const TranslatableString & title,
    unsigned flags,
    const TranslatableString &remainingLabelText)
 {
+   DoYieldOnMac();
    unsigned options = 0;
    if (~(flags & ProgressShowStop))
       options |= pdlgHideStopButton;
@@ -227,6 +243,7 @@ wxWidgetsBasicUI::DoMakeGenericProgress(
    const TranslatableString &title,
    const TranslatableString &message)
 {
+   DoYieldOnMac();
    return std::make_unique<MyGenericProgress>(
       title, message, wxWidgetsWindowPlacement::GetParent(placement));
 }
@@ -237,5 +254,6 @@ int wxWidgetsBasicUI::DoMultiDialog(const TranslatableString &message,
    const ManualPageID &helpPage,
    const TranslatableString &boxMsg, bool log)
 {
+   DoYieldOnMac();
    return ::ShowMultiDialog(message, title, buttons, helpPage, boxMsg, log);
 }


### PR DESCRIPTION
Resolves: #2545

Fix hanging dialog box on macOS.  See code comments for explanation.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
