### PR TITLE
Settings in destructive effects

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -353,14 +353,14 @@ public:
    virtual size_t ProcessBlock(
       const float *const *inBlock, float *const *outBlock, size_t blockLen) = 0;
 
-   virtual bool RealtimeInitialize() = 0;
+   virtual bool RealtimeInitialize(EffectSettings &settings) = 0;
    virtual bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) = 0;
-   virtual bool RealtimeFinalize() noexcept = 0;
+   virtual bool RealtimeFinalize(EffectSettings &settings) noexcept = 0;
    virtual bool RealtimeSuspend() = 0;
    virtual bool RealtimeResume() noexcept = 0;
    //! settings are possibly changed, since last call, by an asynchronous dialog
    virtual bool RealtimeProcessStart(EffectSettings &settings) = 0;
-   virtual size_t RealtimeProcess(int group,
+   virtual size_t RealtimeProcess(int group, EffectSettings &settings,
       const float *const *inBuf, float *const *outBuf, size_t numSamples) = 0;
    //! settings can be updated to let a dialog change appearance at idle
    virtual bool RealtimeProcessEnd(EffectSettings &settings) noexcept = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -350,7 +350,7 @@ public:
    virtual bool ProcessFinalize() /* noexcept */ = 0;
 
    //! Called for destructive, non-realtime effect computation
-   virtual size_t ProcessBlock(
+   virtual size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen) = 0;
 
    virtual bool RealtimeInitialize(EffectSettings &settings) = 0;

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -50,6 +50,7 @@ public:
 class wxDialog;
 class wxWindow;
 class EffectUIClientInterface;
+class EffectSettings;
 class EffectSettingsAccess;
 class EffectUIHostInterface;
 
@@ -97,13 +98,19 @@ public:
       EffectSettingsAccess &access, bool forceModal = false
    ) = 0;
 
-   virtual void Preview(bool dryOnly) = 0;
+   virtual void Preview(EffectSettingsAccess &access, bool dryOnly) = 0;
    virtual bool GetAutomationParametersAsString(wxString & parms) = 0;
    virtual bool SetAutomationParametersFromString(const wxString & parms) = 0;
    virtual bool IsBatchProcessing() = 0;
    virtual void SetBatchProcessing(bool start) = 0;
-   //! Create a user interface only if the supplied factory is not null.
+
+   //! Unfortunately complicated dual-use function
    /*!
+    Sometimes this is invoked only to do effect processing, as a delegate for
+    another effect, but sometimes also to put up a dialog prompting the user for
+    settings first.
+
+    Create a user interface only if the supplied factory is not null.
     Factory may be null because we "Repeat last effect" or apply a macro
 
     Will only operate on tracks that have the "selected" flag set to true,
@@ -111,13 +118,17 @@ public:
 
     @return true on success
     */
-   virtual bool DoEffect( double projectRate, TrackList *list,
+   virtual bool DoEffect(
+      EffectSettings &settings, //!< Always given; only for processing
+      double projectRate, TrackList *list,
       WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
       unsigned flags,
       // Prompt the user for input only if the next arguments are not all null.
       wxWindow *pParent = nullptr,
       const EffectDialogFactory &dialogFactory = {},
-      const EffectSettingsAccessPtr &pAccess = nullptr) = 0;
+      const EffectSettingsAccessPtr &pAccess = nullptr
+         //!< Sometimes given; only for UI
+   ) = 0;
    virtual bool Startup(EffectUIClientInterface *client) = 0;
 
    virtual bool TransferDataToWindow() = 0;

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -123,7 +123,7 @@ unsigned EffectAmplify::GetAudioOutCount()
    return 1;
 }
 
-size_t EffectAmplify::ProcessBlock(
+size_t EffectAmplify::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    for (decltype(blockLen) i = 0; i < blockLen; i++)

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -204,12 +204,12 @@ bool EffectAmplify::Init()
    return true;
 }
 
-void EffectAmplify::Preview(bool dryOnly)
+void EffectAmplify::Preview(EffectSettingsAccess &access, bool dryOnly)
 {
    auto cleanup1 = valueRestorer( mRatio );
    auto cleanup2 = valueRestorer( mPeak );
 
-   Effect::Preview(dryOnly);
+   Effect::Preview(access, dryOnly);
 }
 
 void EffectAmplify::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -48,8 +48,9 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -55,7 +55,7 @@ public:
    // Effect implementation
 
    bool Init() override;
-   void Preview(bool dryOnly) override;
+   void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -269,7 +269,7 @@ void EffectAutoDuck::End()
    mControlTrack = NULL;
 }
 
-bool EffectAutoDuck::Process()
+bool EffectAutoDuck::Process(EffectSettings &)
 {
    if (GetNumWaveTracks() == 0 || !mControlTrack)
       return false;

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -49,7 +49,7 @@ public:
    bool Startup() override;
    bool Init() override;
    void End() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -135,7 +135,7 @@ bool EffectBassTreble::ProcessInitialize(sampleCount WXUNUSED(totalLen), Channel
    return true;
 }
 
-size_t EffectBassTreble::ProcessBlock(
+size_t EffectBassTreble::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    return InstanceProcess(mMaster, inBlock, outBlock, blockLen);

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -135,10 +135,10 @@ bool EffectBassTreble::ProcessInitialize(sampleCount WXUNUSED(totalLen), Channel
    return true;
 }
 
-size_t EffectBassTreble::ProcessBlock(EffectSettings &,
+size_t EffectBassTreble::ProcessBlock(EffectSettings &settings,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
-   return InstanceProcess(mMaster, inBlock, outBlock, blockLen);
+   return InstanceProcess(settings, mMaster, inBlock, outBlock, blockLen);
 }
 
 bool EffectBassTreble::RealtimeInitialize(EffectSettings &)
@@ -168,11 +168,12 @@ bool EffectBassTreble::RealtimeFinalize(EffectSettings &) noexcept
    return true;
 }
 
-size_t EffectBassTreble::RealtimeProcess(int group, EffectSettings &,
+size_t EffectBassTreble::RealtimeProcess(int group, EffectSettings &settings,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
-   return InstanceProcess(mSlaves[group], inbuf, outbuf, numSamples);
+   return InstanceProcess(settings, mSlaves[group], inbuf, outbuf, numSamples);
 }
+
 bool EffectBassTreble::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mBass, Bass );
    S.SHUTTLE_PARAM( mTreble, Treble );
@@ -351,7 +352,8 @@ void EffectBassTreble::InstanceInit(EffectBassTrebleState & data, float sampleRa
 // EffectProcessor implementation
 
 
-size_t EffectBassTreble::InstanceProcess(EffectBassTrebleState & data,
+size_t EffectBassTreble::InstanceProcess(EffectSettings &settings,
+   EffectBassTrebleState & data,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ibuf = inBlock[0];

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -141,7 +141,7 @@ size_t EffectBassTreble::ProcessBlock(
    return InstanceProcess(mMaster, inBlock, outBlock, blockLen);
 }
 
-bool EffectBassTreble::RealtimeInitialize()
+bool EffectBassTreble::RealtimeInitialize(EffectSettings &)
 {
    SetBlockSize(512);
 
@@ -161,14 +161,14 @@ bool EffectBassTreble::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), floa
    return true;
 }
 
-bool EffectBassTreble::RealtimeFinalize() noexcept
+bool EffectBassTreble::RealtimeFinalize(EffectSettings &) noexcept
 {
    mSlaves.clear();
 
    return true;
 }
 
-size_t EffectBassTreble::RealtimeProcess(int group,
+size_t EffectBassTreble::RealtimeProcess(int group, EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    return InstanceProcess(mSlaves[group], inbuf, outbuf, numSamples);

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -59,8 +59,9 @@ public:
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -84,7 +84,8 @@ private:
    // EffectBassTreble implementation
 
    void InstanceInit(EffectBassTrebleState & data, float sampleRate);
-   size_t InstanceProcess(EffectBassTrebleState & data,
+   size_t InstanceProcess(EffectSettings &settings,
+      EffectBassTrebleState & data,
       const float *const *inBlock, float *const *outBlock, size_t blockLen);
 
    void Coefficients(double hz, double slope, double gain, double samplerate, int type,

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -61,11 +61,12 @@ public:
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -210,7 +210,7 @@ bool EffectChangePitch::Init()
    return true;
 }
 
-bool EffectChangePitch::Process()
+bool EffectChangePitch::Process(EffectSettings &settings)
 {
 #if USE_SBSMS
    if (mUseSBSMS)
@@ -220,7 +220,7 @@ bool EffectChangePitch::Process()
       proxy.mProxyEffectName = XO("High Quality Pitch Change");
       proxy.setParameters(1.0, pitchRatio);
       //! Already processing; don't make a dialog
-      return Delegate(proxy, *mUIParent, nullptr, nullptr);
+      return Delegate(proxy, settings, *mUIParent, nullptr, nullptr);
    }
    else
 #endif

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -62,7 +62,7 @@ public:
    // Effect implementation
 
    bool Init() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    bool CheckWhetherSkipEffect() override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -230,7 +230,7 @@ bool EffectChangeSpeed::Init()
    return true;
 }
 
-bool EffectChangeSpeed::Process()
+bool EffectChangeSpeed::Process(EffectSettings &)
 {
    // Similar to EffectSoundTouch::Process()
 

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -52,7 +52,7 @@ public:
    double CalcPreviewInputLength(double previewLength) override;
    bool Startup() override;
    bool Init() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataFromWindow() override;

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -193,7 +193,7 @@ bool EffectChangeTempo::Init()
    return true;
 }
 
-bool EffectChangeTempo::Process()
+bool EffectChangeTempo::Process(EffectSettings &settings)
 {
    bool success = false;
 
@@ -205,7 +205,7 @@ bool EffectChangeTempo::Process()
       proxy.mProxyEffectName = XO("High Quality Tempo Change");
       proxy.setParameters(tempoRatio, 1.0);
       //! Already processing; don't make a dialog
-      success = Delegate(proxy, *mUIParent, nullptr, nullptr);
+      success = Delegate(proxy, settings, *mUIParent, nullptr, nullptr);
    }
    else
 #endif

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -57,7 +57,7 @@ public:
 
    bool Init() override;
    bool CheckWhetherSkipEffect() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    double CalcPreviewInputLength(double previewLength) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -174,7 +174,7 @@ bool EffectClickRemoval::Startup()
    return true;
 }
 
-bool EffectClickRemoval::Process()
+bool EffectClickRemoval::Process(EffectSettings &)
 {
    this->CopyInputTracks(); // Set up mOutputTracks.
    bool bGoodResult = true;

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -51,7 +51,7 @@ public:
 
    bool CheckWhetherSkipEffect() override;
    bool Startup() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -233,7 +233,7 @@ bool EffectDistortion::ProcessInitialize(sampleCount WXUNUSED(totalLen), Channel
    return true;
 }
 
-size_t EffectDistortion::ProcessBlock(
+size_t EffectDistortion::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    return InstanceProcess(mMaster, inBlock, outBlock, blockLen);

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -239,7 +239,7 @@ size_t EffectDistortion::ProcessBlock(
    return InstanceProcess(mMaster, inBlock, outBlock, blockLen);
 }
 
-bool EffectDistortion::RealtimeInitialize()
+bool EffectDistortion::RealtimeInitialize(EffectSettings &)
 {
    SetBlockSize(512);
 
@@ -259,14 +259,14 @@ bool EffectDistortion::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), floa
    return true;
 }
 
-bool EffectDistortion::RealtimeFinalize() noexcept
+bool EffectDistortion::RealtimeFinalize(EffectSettings &) noexcept
 {
    mSlaves.clear();
 
    return true;
 }
 
-size_t EffectDistortion::RealtimeProcess(int group,
+size_t EffectDistortion::RealtimeProcess(int group, EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
 

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -233,10 +233,10 @@ bool EffectDistortion::ProcessInitialize(sampleCount WXUNUSED(totalLen), Channel
    return true;
 }
 
-size_t EffectDistortion::ProcessBlock(EffectSettings &,
+size_t EffectDistortion::ProcessBlock(EffectSettings &settings,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
-   return InstanceProcess(mMaster, inBlock, outBlock, blockLen);
+   return InstanceProcess(settings, mMaster, inBlock, outBlock, blockLen);
 }
 
 bool EffectDistortion::RealtimeInitialize(EffectSettings &)
@@ -266,12 +266,12 @@ bool EffectDistortion::RealtimeFinalize(EffectSettings &) noexcept
    return true;
 }
 
-size_t EffectDistortion::RealtimeProcess(int group, EffectSettings &,
+size_t EffectDistortion::RealtimeProcess(int group, EffectSettings &settings,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
-
-   return InstanceProcess(mSlaves[group], inbuf, outbuf, numSamples);
+   return InstanceProcess(settings, mSlaves[group], inbuf, outbuf, numSamples);
 }
+
 bool EffectDistortion::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_ENUM_PARAM( mParams.mTableChoiceIndx, TableTypeIndx,
       kTableTypeStrings, nTableTypes );
@@ -544,7 +544,8 @@ void EffectDistortion::InstanceInit(EffectDistortionState & data, float sampleRa
    return;
 }
 
-size_t EffectDistortion::InstanceProcess(EffectDistortionState& data,
+size_t EffectDistortion::InstanceProcess(EffectSettings &settings,
+   EffectDistortionState& data,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ibuf = inBlock[0];

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -81,8 +81,9 @@ public:
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -114,7 +114,8 @@ private:
    // EffectDistortion implementation
 
    void InstanceInit(EffectDistortionState & data, float sampleRate);
-   size_t InstanceProcess(EffectDistortionState & data,
+   size_t InstanceProcess(EffectSettings &settings,
+      EffectDistortionState & data,
       const float *const *inBlock, float *const *outBlock, size_t blockLen);
 
    // Control Handlers

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -83,11 +83,12 @@ public:
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -179,7 +179,7 @@ bool EffectDtmf::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames 
    return true;
 }
 
-size_t EffectDtmf::ProcessBlock(
+size_t EffectDtmf::ProcessBlock(EffectSettings &,
    const float *const *, float *const *outbuf, size_t size)
 {
    float *buffer = outbuf[0];

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -46,8 +46,9 @@ public:
 
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -124,7 +124,7 @@ bool EffectEcho::ProcessFinalize()
    return true;
 }
 
-size_t EffectEcho::ProcessBlock(
+size_t EffectEcho::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ibuf = inBlock[0];

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -44,8 +44,9 @@ public:
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -349,12 +349,12 @@ size_t Effect::ProcessBlock(
    return 0;
 }
 
-bool Effect::RealtimeInitialize()
+bool Effect::RealtimeInitialize(EffectSettings &settings)
 {
    if (mClient)
    {
       mBlockSize = mClient->SetBlockSize(512);
-      return mClient->RealtimeInitialize();
+      return mClient->RealtimeInitialize(settings);
    }
 
    mBlockSize = 512;
@@ -372,13 +372,10 @@ bool Effect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
    return true;
 }
 
-bool Effect::RealtimeFinalize() noexcept
+bool Effect::RealtimeFinalize(EffectSettings &settings) noexcept
 {
    if (mClient)
-   {
-      return mClient->RealtimeFinalize();
-   }
-
+      return mClient->RealtimeFinalize(settings);
    return false;
 }
 
@@ -408,14 +405,12 @@ bool Effect::RealtimeProcessStart(EffectSettings &settings)
    return true;
 }
 
-size_t Effect::RealtimeProcess(int group,
+size_t Effect::RealtimeProcess(int group, EffectSettings &settings,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    if (mClient)
-   {
-      return mClient->RealtimeProcess(group, inbuf, outbuf, numSamples);
-   }
-
+      return mClient->
+         RealtimeProcess(group, settings, inbuf, outbuf, numSamples);
    return 0;
 }
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -134,8 +134,9 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
@@ -262,7 +263,7 @@ protected:
     and also GetLatency() to determine how many leading output samples to
     discard and how many extra samples to produce. */
    virtual bool Process(EffectSettings &settings);
-   virtual bool ProcessPass();
+   virtual bool ProcessPass(EffectSettings &settings);
    virtual bool InitPass1();
    virtual bool InitPass2();
 
@@ -443,16 +444,17 @@ protected:
    void CountWaveTracks();
 
    // Driver for client effects
-   bool ProcessTrack(int count,
-                     ChannelNames map,
-                     WaveTrack *left,
-                     WaveTrack *right,
-                     sampleCount start,
-                     sampleCount len,
-                     FloatBuffers &inBuffer,
-                     FloatBuffers &outBuffer,
-                     ArrayOf< float * > &inBufPos,
-                     ArrayOf< float *> &outBufPos);
+   bool ProcessTrack(EffectSettings &settings,
+      int count,
+      ChannelNames map,
+      WaveTrack *left,
+      WaveTrack *right,
+      sampleCount start,
+      sampleCount len,
+      FloatBuffers &inBuffer,
+      FloatBuffers &outBuffer,
+      ArrayOf< float * > &inBufPos,
+      ArrayOf< float *> &outBufPos);
 
  //
  // private data

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -185,18 +185,20 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
       bool forceModal = false) override;
    // The Effect class fully implements the Preview method for you.
    // Only override it if you need to do preprocessing or cleanup.
-   void Preview(bool dryOnly) override;
+   void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    bool GetAutomationParametersAsString(wxString & parms) override;
    bool SetAutomationParametersFromString(const wxString & parms) override;
    bool IsBatchProcessing() override;
    void SetBatchProcessing(bool start) override;
-   bool DoEffect( double projectRate, TrackList *list,
+   bool DoEffect(EffectSettings &settings, //!< Always given; only for processing
+      double projectRate, TrackList *list,
       WaveTrackFactory *factory, NotifyingSelectedRegion &selectedRegion,
       unsigned flags,
       // Prompt the user for input only if the next arguments are not all null.
       wxWindow *pParent,
       const EffectDialogFactory &dialogFactory,
-      const EffectSettingsAccessPtr &pAccess) override;
+      const EffectSettingsAccessPtr &pAccess //!< Sometimes given; only for UI
+   ) override;
    bool Startup(EffectUIClientInterface *client) override;
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
@@ -212,8 +214,10 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    //! Re-invoke DoEffect on another Effect object that implements the work
    bool Delegate( Effect &delegate,
+      EffectSettings &settings, //!< Always given; only for processing
       wxWindow &parent, const EffectDialogFactory &factory,
-      const EffectSettingsAccessPtr &pSettings );
+      const EffectSettingsAccessPtr &pSettings //!< Sometimes given; only for UI
+   );
 
    // Display a message box, using effect's (translated) name as the prefix
    // for the title.
@@ -257,7 +261,7 @@ protected:
     ProcessBlock(), and ProcessFinalize() methods of EffectProcessor,
     and also GetLatency() to determine how many leading output samples to
     discard and how many extra samples to produce. */
-   virtual bool Process();
+   virtual bool Process(EffectSettings &settings);
    virtual bool ProcessPass();
    virtual bool InitPass1();
    virtual bool InitPass2();

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -137,14 +137,15 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
 
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -742,7 +742,7 @@ void EffectUIHost::OnPlay(wxCommandEvent & WXUNUSED(evt))
          return;
       }
       
-      mEffectUIHost.Preview(false);
+      mEffectUIHost.Preview(*mpAccess, false);
       
       return;
    }
@@ -1305,24 +1305,24 @@ wxDialog *EffectUI::DialogFactory( wxWindow &parent,
    EffectManager & em = EffectManager::Get();
 
    em.SetSkipStateFlag( false );
+   success = false;
    if (auto effect = em.GetEffect(ID)) {
-      auto pSettings = em.GetDefaultSettings(ID);
-      const auto pAccess = pSettings
-         ? std::make_shared<SimpleEffectSettingsAccess>(*pSettings) : nullptr;
-      success = effect->DoEffect(
-         rate,
-         &tracks,
-         &trackFactory,
-         selectedRegion,
-         flags,
-         &window,
-         (flags & EffectManager::kConfigured) == 0
-            ? DialogFactory
-            : nullptr,
-         pAccess);
+      if (auto pSettings = em.GetDefaultSettings(ID)) {
+         const auto pAccess =
+            std::make_shared<SimpleEffectSettingsAccess>(*pSettings);
+         success = effect->DoEffect(*pSettings,
+            rate,
+            &tracks,
+            &trackFactory,
+            selectedRegion,
+            flags,
+            &window,
+            (flags & EffectManager::kConfigured) == 0
+               ? DialogFactory
+               : nullptr,
+            pAccess);
+      }
    }
-   else
-      success = false;
 
    if (!success)
       return false;

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -98,6 +98,7 @@ private:
    wxWindow *mParent;
    EffectUIHostInterface &mEffectUIHost;
    EffectUIClientInterface &mClient;
+   //! @invariant not null
    const EffectUIHostInterface::EffectSettingsAccessPtr mpAccess;
    RealtimeEffectState *mpState{ nullptr };
 

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -717,7 +717,7 @@ bool EffectEqualization::Init()
    return(true);
 }
 
-bool EffectEqualization::Process()
+bool EffectEqualization::Process(EffectSettings &)
 {
 #ifdef EXPERIMENTAL_EQ_SSE_THREADED
    if(mEffectEqualization48x) {

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -126,7 +126,7 @@ public:
 
    bool Startup() override;
    bool Init() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
 
    bool CloseUI() override;
    void PopulateOrExchange(

--- a/src/effects/Fade.cpp
+++ b/src/effects/Fade.cpp
@@ -86,7 +86,7 @@ bool EffectFade::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames 
    return true;
 }
 
-size_t EffectFade::ProcessBlock(
+size_t EffectFade::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ibuf = inBlock[0];

--- a/src/effects/Fade.h
+++ b/src/effects/Fade.h
@@ -34,8 +34,9 @@ public:
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
 
 private:
    // EffectFade implementation

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -108,7 +108,7 @@ bool EffectFindClipping::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-bool EffectFindClipping::Process()
+bool EffectFindClipping::Process(EffectSettings &)
 {
    std::shared_ptr<AddedAnalysisTrack> addedTrack;
    std::optional<ModifiedAnalysisTrack> modifiedTrack;

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -44,7 +44,7 @@ public:
 
    // Effect implementation
 
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -27,7 +27,7 @@
 
 #include "../widgets/AudacityMessageBox.h"
 
-bool Generator::Process()
+bool Generator::Process(EffectSettings &)
 {
    if (GetDuration() < 0.0)
       return false;

--- a/src/effects/Generator.h
+++ b/src/effects/Generator.h
@@ -51,7 +51,7 @@ protected:
    // Postcondition:
    // If mDuration was valid (>= 0), then the tracks are replaced by the
    // generated results and true is returned. Otherwise, return false.
-   AUDACITY_DLL_API bool Process() override;
+   AUDACITY_DLL_API bool Process(EffectSettings &settings) override;
 };
 
 // Abstract generator which creates the sound in discrete blocks, whilst

--- a/src/effects/Invert.cpp
+++ b/src/effects/Invert.cpp
@@ -70,7 +70,7 @@ unsigned EffectInvert::GetAudioOutCount()
    return 1;
 }
 
-size_t EffectInvert::ProcessBlock(
+size_t EffectInvert::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ibuf = inBlock[0];

--- a/src/effects/Invert.h
+++ b/src/effects/Invert.h
@@ -37,8 +37,9 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
 };
 
 #endif

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -170,7 +170,7 @@ bool EffectLoudness::Startup()
    return true;
 }
 
-bool EffectLoudness::Process()
+bool EffectLoudness::Process(EffectSettings &)
 {
    if(mNormalizeTo == kLoudness)
       // LU use 10*log10(...) instead of 20*log10(...)

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -54,7 +54,7 @@ public:
 
    bool CheckWhetherSkipEffect() override;
    bool Startup() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -110,7 +110,7 @@ unsigned EffectNoise::GetAudioOutCount()
    return 1;
 }
 
-size_t EffectNoise::ProcessBlock(
+size_t EffectNoise::ProcessBlock(EffectSettings &,
    const float *const *, float *const *outbuf, size_t size)
 {
    float *buffer = outbuf[0];

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -41,8 +41,9 @@ public:
    // EffectProcessor implementation
 
    unsigned GetAudioOutCount() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -43,7 +43,7 @@ public:
 
    bool Init() override;
    bool CheckWhetherSkipEffect() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
 
    class Settings;
    class Statistics;

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -46,8 +46,8 @@
 #include "LoadEffects.h"
 
 #include "../WaveTrack.h"
-#include "../Prefs.h"
-#include "../FileNames.h"
+#include "Prefs.h"
+#include "FileNames.h"
 #include "../ShuttleGui.h"
 
 #include <math.h>
@@ -73,7 +73,7 @@
 #include <wx/valtext.h>
 
 
-#include "../PlatformCompatibility.h"
+#include "PlatformCompatibility.h"
 
 const ComponentInterfaceSymbol EffectNoiseRemoval::Symbol
 { XO("Noise Removal") };
@@ -161,11 +161,11 @@ bool EffectNoiseRemoval::CheckWhetherSkipEffect()
  the framework for managing settings of other effects. */
 int EffectNoiseRemoval::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &,
-   EffectSettingsAccess &, //!< ignored!
+   EffectSettingsAccess &access,
    bool forceModal )
 {
    // to do: use forceModal correctly
-   NoiseRemovalDialog dlog(this, &parent);
+   NoiseRemovalDialog dlog(this, access, &parent);
    dlog.mSensitivity = mSensitivity;
    dlog.mGain = -mNoiseGain;
    dlog.mFreq = mFreqSmoothingHz;
@@ -213,7 +213,7 @@ int EffectNoiseRemoval::ShowHostInterface(
    return returnCode;
 }
 
-bool EffectNoiseRemoval::Process()
+bool EffectNoiseRemoval::Process(EffectSettings &)
 {
    Initialize();
 
@@ -644,9 +644,10 @@ BEGIN_EVENT_TABLE(NoiseRemovalDialog,wxDialogWrapper)
    EVT_TEXT(ID_TIME_TEXT, NoiseRemovalDialog::OnTimeText)
 END_EVENT_TABLE()
 
-NoiseRemovalDialog::NoiseRemovalDialog(EffectNoiseRemoval * effect,
-                                       wxWindow *parent)
+NoiseRemovalDialog::NoiseRemovalDialog(
+   EffectNoiseRemoval * effect, EffectSettingsAccess &access, wxWindow *parent)
    : EffectDialog( parent, XO("Noise Removal"), EffectTypeProcess)
+   , mAccess{ access }
 {
    m_pEffect = effect;
 
@@ -701,7 +702,7 @@ void NoiseRemovalDialog::OnPreview(wxCommandEvent & WXUNUSED(event))
       m_pEffect->mDoProfile = oldDoProfile;
    } );
 
-   m_pEffect->Preview( false );
+   m_pEffect->Preview(mAccess, false);
 }
 
 void NoiseRemovalDialog::OnRemoveNoise( wxCommandEvent & WXUNUSED(event))

--- a/src/effects/NoiseRemoval.h
+++ b/src/effects/NoiseRemoval.h
@@ -24,12 +24,14 @@ class wxSizer;
 class wxSlider;
 
 class Envelope;
+class EffectSettingsAccess;
 class WaveTrack;
 
 class wxRadioButton;
 class wxTextCtrl;
 
-#include "../RealFFTf.h"
+#include "RealFFTf.h"
+#include "SampleFormat.h"
 
 class EffectNoiseRemoval final : public Effect
 {
@@ -56,7 +58,7 @@ public:
       EffectSettingsAccess &access, bool forceModal = false) override;
    bool Init() override;
    bool CheckWhetherSkipEffect() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void End() override;
 
 private:
@@ -135,7 +137,7 @@ class NoiseRemovalDialog final : public EffectDialog
 {
 public:
    // constructors and destructors
-   NoiseRemovalDialog(EffectNoiseRemoval * effect,
+   NoiseRemovalDialog(EffectNoiseRemoval * effect, EffectSettingsAccess &access,
                       wxWindow *parent);
 
    wxSizer *MakeNoiseRemovalDialog(bool call_fit = true,
@@ -165,6 +167,7 @@ private:
  public:
 
    EffectNoiseRemoval * m_pEffect;
+   EffectSettingsAccess &mAccess;
 
    wxButton * m_pButton_GetProfile;
    wxButton * m_pButton_Preview;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -166,7 +166,7 @@ bool EffectNormalize::Startup()
    return true;
 }
 
-bool EffectNormalize::Process()
+bool EffectNormalize::Process(EffectSettings &)
 {
    if (mGain == false && mDC == false)
       return true;

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -48,7 +48,7 @@ public:
 
    bool CheckWhetherSkipEffect() override;
    bool Startup() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -170,7 +170,7 @@ double EffectPaulstretch::CalcPreviewInputLength(double previewLength)
 }
 
 
-bool EffectPaulstretch::Process()
+bool EffectPaulstretch::Process(EffectSettings &)
 {
    CopyInputTracks();
    m_t1=mT1;

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -41,7 +41,7 @@ public:
    // Effect implementation
 
    double CalcPreviewInputLength(double previewLength) override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -155,7 +155,7 @@ bool EffectPhaser::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelName
    return true;
 }
 
-size_t EffectPhaser::ProcessBlock(
+size_t EffectPhaser::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    return InstanceProcess(mMaster, inBlock, outBlock, blockLen);

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -161,7 +161,7 @@ size_t EffectPhaser::ProcessBlock(
    return InstanceProcess(mMaster, inBlock, outBlock, blockLen);
 }
 
-bool EffectPhaser::RealtimeInitialize()
+bool EffectPhaser::RealtimeInitialize(EffectSettings &)
 {
    SetBlockSize(512);
 
@@ -181,14 +181,14 @@ bool EffectPhaser::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sa
    return true;
 }
 
-bool EffectPhaser::RealtimeFinalize() noexcept
+bool EffectPhaser::RealtimeFinalize(EffectSettings &) noexcept
 {
    mSlaves.clear();
 
    return true;
 }
 
-size_t EffectPhaser::RealtimeProcess(int group,
+size_t EffectPhaser::RealtimeProcess(int group, EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -155,10 +155,10 @@ bool EffectPhaser::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelName
    return true;
 }
 
-size_t EffectPhaser::ProcessBlock(EffectSettings &,
+size_t EffectPhaser::ProcessBlock(EffectSettings &settings,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
-   return InstanceProcess(mMaster, inBlock, outBlock, blockLen);
+   return InstanceProcess(settings, mMaster, inBlock, outBlock, blockLen);
 }
 
 bool EffectPhaser::RealtimeInitialize(EffectSettings &)
@@ -188,12 +188,12 @@ bool EffectPhaser::RealtimeFinalize(EffectSettings &) noexcept
    return true;
 }
 
-size_t EffectPhaser::RealtimeProcess(int group, EffectSettings &,
+size_t EffectPhaser::RealtimeProcess(int group, EffectSettings &settings,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
-
-   return InstanceProcess(mSlaves[group], inbuf, outbuf, numSamples);
+   return InstanceProcess(settings, mSlaves[group], inbuf, outbuf, numSamples);
 }
+
 bool EffectPhaser::DefineParams( ShuttleParams & S ){
    S.SHUTTLE_PARAM( mStages,    Stages );
    S.SHUTTLE_PARAM( mDryWet,    DryWet );
@@ -392,7 +392,8 @@ void EffectPhaser::InstanceInit(EffectPhaserState & data, float sampleRate)
    return;
 }
 
-size_t EffectPhaser::InstanceProcess(EffectPhaserState & data,
+size_t EffectPhaser::InstanceProcess(EffectSettings &settings,
+   EffectPhaserState & data,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ibuf = inBlock[0];

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -67,11 +67,12 @@ public:
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -65,8 +65,9 @@ public:
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -87,7 +87,7 @@ private:
    // EffectPhaser implementation
 
    void InstanceInit(EffectPhaserState & data, float sampleRate);
-   size_t InstanceProcess(EffectPhaserState & data,
+   size_t InstanceProcess(EffectSettings &settings, EffectPhaserState & data,
       const float *const *inBlock, float *const *outBlock, size_t blockLen);
 
    void OnStagesSlider(wxCommandEvent & evt);

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -182,7 +182,7 @@ bool RealtimeEffectState::Initialize(double rate)
    mCurrentProcessor = 0;
    mGroups.clear();
    mEffect->SetSampleRate(rate);
-   return mEffect->RealtimeInitialize();
+   return mEffect->RealtimeInitialize(mSettings);
 }
 
 //! Set up processors to be visited repeatedly in Process.
@@ -364,7 +364,8 @@ size_t RealtimeEffectState::Process(Track &track,
       for (decltype(numSamples) block = 0; block < numSamples; block += blockSize)
       {
          auto cnt = std::min(numSamples - block, blockSize);
-         len += mEffect->RealtimeProcess(processor, clientIn, clientOut, cnt);
+         len += mEffect->RealtimeProcess(processor,
+            mSettings, clientIn, clientOut, cnt);
 
          for (size_t i = 0 ; i < numAudioIn; i++)
          {
@@ -411,7 +412,7 @@ bool RealtimeEffectState::Finalize() noexcept
    if (!mEffect)
       return false;
 
-   return mEffect->RealtimeFinalize();
+   return mEffect->RealtimeFinalize(mSettings);
 }
 
 const std::string &RealtimeEffectState::XMLTag()

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -73,7 +73,7 @@ bool EffectRepair::IsInteractive()
 
 // Effect implementation
 
-bool EffectRepair::Process()
+bool EffectRepair::Process(EffectSettings &)
 {
    //v This may be too much copying for EffectRepair. To support Cancel, may be able to copy much less.
    //  But for now, Cancel isn't supported without this.

--- a/src/effects/Repair.h
+++ b/src/effects/Repair.h
@@ -35,7 +35,7 @@ public:
 
    // Effect implementation
 
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
 
 private:
    // EffectRepair implementation

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -112,7 +112,7 @@ bool EffectRepeat::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-bool EffectRepeat::Process()
+bool EffectRepeat::Process(EffectSettings &)
 {
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -44,7 +44,7 @@ public:
 
    // Effect implementation
 
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -218,7 +218,7 @@ bool EffectReverb::ProcessFinalize()
    return true;
 }
 
-size_t EffectReverb::ProcessBlock(
+size_t EffectReverb::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ichans[2] = {NULL, NULL};

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -63,8 +63,9 @@ public:
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -70,7 +70,7 @@ bool EffectReverse::IsInteractive()
 
 // Effect implementation
 
-bool EffectReverse::Process()
+bool EffectReverse::Process(EffectSettings &)
 {
    //all needed because Reverse should move the labels too
    this->CopyInputTracks(true); // Set up mOutputTracks.

--- a/src/effects/Reverse.h
+++ b/src/effects/Reverse.h
@@ -35,7 +35,7 @@ public:
 
    // Effect implementation
 
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
 
 private:
    // EffectReverse implementation

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -210,7 +210,7 @@ double EffectSBSMS::getRate(double rateStart, double rateEnd, SlideType slideTyp
    return slide.getRate(t);
 }
 
-bool EffectSBSMS::Process()
+bool EffectSBSMS::Process(EffectSettings &)
 {
    bool bGoodResult = true;
 

--- a/src/effects/SBSMSEffect.h
+++ b/src/effects/SBSMSEffect.h
@@ -29,7 +29,7 @@ class TimeWarper;
 class EffectSBSMS /* not final */ : public Effect
 {
 public:
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void setParameters(double rateStart, double rateEnd, double pitchStart, double pitchEnd,
                       SlideType rateSlideType, SlideType pitchSlideType,
                       bool bLinkRatePitch, bool bRateReferenceInput, bool bPitchReferenceInput);

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -225,7 +225,7 @@ bool EffectScienFilter::ProcessInitialize(sampleCount WXUNUSED(totalLen), Channe
    return true;
 }
 
-size_t EffectScienFilter::ProcessBlock(
+size_t EffectScienFilter::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ibuf = inBlock[0];

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -54,8 +54,9 @@ public:
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/SimpleMono.cpp
+++ b/src/effects/SimpleMono.cpp
@@ -26,7 +26,7 @@
 
 #include <math.h>
 
-bool EffectSimpleMono::Process()
+bool EffectSimpleMono::Process(EffectSettings &)
 {
    //Iterate over each track
    this->CopyInputTracks(); // Set up mOutputTracks.

--- a/src/effects/SimpleMono.h
+++ b/src/effects/SimpleMono.h
@@ -24,7 +24,7 @@ class WaveTrack;
 class EffectSimpleMono /* not final */ : public Effect
 {
 public:
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
 
 protected:
 

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -76,7 +76,7 @@ unsigned EffectStereoToMono::GetAudioOutCount()
 
 // Effect implementation
 
-bool EffectStereoToMono::Process()
+bool EffectStereoToMono::Process(EffectSettings &)
 {
    // Do not use mWaveTracks here.  We will possibly DELETE tracks,
    // so we must use the "real" tracklist.

--- a/src/effects/StereoToMono.h
+++ b/src/effects/StereoToMono.h
@@ -38,7 +38,7 @@ public:
 
    // Effect implementation
 
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    bool IsHiddenFromMenus() override;
 
 private:

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -176,14 +176,14 @@ double EffectTimeScale::CalcPreviewInputLength(double previewLength)
    }
 }
 
-void EffectTimeScale::Preview(bool dryOnly)
+void EffectTimeScale::Preview(EffectSettingsAccess &access, bool dryOnly)
 {
    previewSelectedDuration = Effect::GetDuration();
    auto cleanup = valueRestorer( bPreview, true );
-   Effect::Preview(dryOnly);
+   Effect::Preview(access, dryOnly);
 }
 
-bool EffectTimeScale::Process()
+bool EffectTimeScale::Process(EffectSettings &settings)
 {
    double pitchStart1 = PercentChangeToRatio(m_PitchPercentChangeStart);
    double pitchEnd1 = PercentChangeToRatio(m_PitchPercentChangeEnd);
@@ -197,7 +197,7 @@ bool EffectTimeScale::Process()
    }
    
    EffectSBSMS::setParameters(rateStart1,rateEnd1,pitchStart1,pitchEnd1,slideTypeRate,slideTypePitch,false,false,false);
-   return EffectSBSMS::Process();
+   return EffectSBSMS::Process(settings);
 }
 
 void EffectTimeScale::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -48,8 +48,8 @@ public:
    // Effect implementation
 
    bool Init() override;
-   void Preview(bool dryOnly) override;
-   bool Process() override;
+   void Preview(EffectSettingsAccess &access, bool dryOnly) override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -170,7 +170,7 @@ bool EffectToneGen::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNam
    return true;
 }
 
-size_t EffectToneGen::ProcessBlock(
+size_t EffectToneGen::ProcessBlock(EffectSettings &,
    const float *const *, float *const *outBlock, size_t blockLen)
 {
    float *buffer = outBlock[0];

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -40,8 +40,9 @@ public:
 
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -321,7 +321,7 @@ bool EffectTruncSilence::Startup()
    return true;
 }
 
-bool EffectTruncSilence::Process()
+bool EffectTruncSilence::Process(EffectSettings &)
 {
    const bool success =
       mbIndependent

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -67,7 +67,7 @@ public:
                         double* inputLength = NULL,
                         double* minInputLength = NULL);
 
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -23,7 +23,7 @@ doing the second pass over all selected tracks.
 
 #include "../WaveTrack.h"
 
-bool EffectTwoPassSimpleMono::Process()
+bool EffectTwoPassSimpleMono::Process(EffectSettings &)
 {
    mPass = 0;
    mSecondPassDisabled = false;

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -23,7 +23,7 @@ doing the second pass over all selected tracks.
 
 #include "../WaveTrack.h"
 
-bool EffectTwoPassSimpleMono::Process(EffectSettings &)
+bool EffectTwoPassSimpleMono::Process(EffectSettings &settings)
 {
    mPass = 0;
    mSecondPassDisabled = false;
@@ -42,13 +42,13 @@ bool EffectTwoPassSimpleMono::Process(EffectSettings &)
    mTrackLists[0] = &mOutputTracks;
    mTrackLists[1] = mSecondPassDisabled ? &mOutputTracks : &mWorkTracks;
 
-   bool bGoodResult = ProcessPass();
+   bool bGoodResult = ProcessPass(settings);
 
    if (bGoodResult && !mSecondPassDisabled)
    {
       mPass = 1;
       if (InitPass2())
-         bGoodResult = ProcessPass();
+         bGoodResult = ProcessPass(settings);
    }
 
    mWorkTracks->Clear();
@@ -58,7 +58,7 @@ bool EffectTwoPassSimpleMono::Process(EffectSettings &)
    return bGoodResult;
 }
 
-bool EffectTwoPassSimpleMono::ProcessPass()
+bool EffectTwoPassSimpleMono::ProcessPass(EffectSettings &settings)
 {
    //Iterate over each track
    mCurTrackNum = 0;

--- a/src/effects/TwoPassSimpleMono.h
+++ b/src/effects/TwoPassSimpleMono.h
@@ -81,7 +81,7 @@ protected:
 private:
    bool ProcessOne(WaveTrack * t, WaveTrack * outTrack,
                    sampleCount start, sampleCount end);
-   bool ProcessPass() override;
+   bool ProcessPass(EffectSettings &settings) override;
 };
 
 #endif

--- a/src/effects/TwoPassSimpleMono.h
+++ b/src/effects/TwoPassSimpleMono.h
@@ -22,7 +22,7 @@ class AUDACITY_DLL_API EffectTwoPassSimpleMono /* not final */ : public Effect
 public:
    // Effect implementation
 
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
 
 protected:
    // EffectTwoPassSimpleMono implementation

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1438,7 +1438,7 @@ bool VSTEffect::ProcessFinalize()
    return true;
 }
 
-size_t VSTEffect::ProcessBlock(
+size_t VSTEffect::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    // Only call the effect if there's something to do...some do not like zero-length block
@@ -1543,11 +1543,11 @@ bool VSTEffect::RealtimeProcessStart(EffectSettings &)
    return true;
 }
 
-size_t VSTEffect::RealtimeProcess(int group, EffectSettings &,
+size_t VSTEffect::RealtimeProcess(int group, EffectSettings &settings,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    wxASSERT(numSamples <= mBlockSize);
-   return mSlaves[group]->ProcessBlock(inbuf, outbuf, numSamples);
+   return mSlaves[group]->ProcessBlock(settings, inbuf, outbuf, numSamples);
 }
 
 bool VSTEffect::RealtimeProcessEnd(EffectSettings &) noexcept

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1464,7 +1464,7 @@ void VSTEffect::SetChannelCount(unsigned numChannels)
    mNumChannels = numChannels;
 }
 
-bool VSTEffect::RealtimeInitialize()
+bool VSTEffect::RealtimeInitialize(EffectSettings &)
 {
    return ProcessInitialize(0, NULL);
 }
@@ -1505,7 +1505,7 @@ bool VSTEffect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
    return slave->ProcessInitialize(0, NULL);
 }
 
-bool VSTEffect::RealtimeFinalize() noexcept
+bool VSTEffect::RealtimeFinalize(EffectSettings &) noexcept
 {
 return GuardedCall<bool>([&]{
    for (const auto &slave : mSlaves)
@@ -1543,7 +1543,7 @@ bool VSTEffect::RealtimeProcessStart(EffectSettings &)
    return true;
 }
 
-size_t VSTEffect::RealtimeProcess(int group,
+size_t VSTEffect::RealtimeProcess(int group, EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    wxASSERT(numSamples <= mBlockSize);

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -147,14 +147,15 @@ class VSTEffect final : public wxEvtHandler,
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
 
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -144,8 +144,9 @@ class VSTEffect final : public wxEvtHandler,
    bool IsReady();
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -722,7 +722,8 @@ namespace
    }
 }
 
-size_t VST3Effect::ProcessBlock(const float* const* inBlock, float* const* outBlock, size_t blockLen)
+size_t VST3Effect::ProcessBlock(EffectSettings &,
+   const float* const* inBlock, float* const* outBlock, size_t blockLen)
 {
    internal::ComponentHandler::PendingChangesPtr pendingChanges { nullptr };
    if(mComponentHandler)

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -730,7 +730,7 @@ size_t VST3Effect::ProcessBlock(const float* const* inBlock, float* const* outBl
    return VST3ProcessBlock(mEffectComponent.get(), mSetup, inBlock, outBlock, blockLen, pendingChanges.get());
 }
 
-bool VST3Effect::RealtimeInitialize()
+bool VST3Effect::RealtimeInitialize(EffectSettings &)
 {
    //reload current parameters form the editor into parameter queues
    SyncParameters();
@@ -761,7 +761,7 @@ bool VST3Effect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
    return false;
 }
 
-bool VST3Effect::RealtimeFinalize() noexcept
+bool VST3Effect::RealtimeFinalize(EffectSettings &) noexcept
 {
    return GuardedCall<bool>([this]()
    {
@@ -802,7 +802,8 @@ bool VST3Effect::RealtimeProcessStart(EffectSettings &)
    return true;
 }
 
-size_t VST3Effect::RealtimeProcess(int group, const float* const* inBuf, float* const* outBuf, size_t numSamples)
+size_t VST3Effect::RealtimeProcess(int group, EffectSettings &,
+   const float* const* inBuf, float* const* outBuf, size_t numSamples)
 {
    auto& effect = mRealtimeGroupProcessors[group];
    return VST3ProcessBlock(effect->mEffectComponent.get(), effect->mSetup, inBuf, outBuf, numSamples, mPendingChanges.get());

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -125,7 +125,9 @@ public:
    size_t GetTailSize() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
-   size_t ProcessBlock(const float* const* inBlock, float* const* outBlock, size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -126,13 +126,15 @@ public:
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(const float* const* inBlock, float* const* outBlock, size_t blockLen) override;
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
-   size_t RealtimeProcess(int group, const float* const* inBuf, float* const* outBuf, size_t numSamples) override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(wxWindow& parent, wxDialog& dialog, bool forceModal) override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -147,10 +147,10 @@ bool EffectWahwah::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelName
    return true;
 }
 
-size_t EffectWahwah::ProcessBlock(EffectSettings &,
+size_t EffectWahwah::ProcessBlock(EffectSettings &settings,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
-   return InstanceProcess(mMaster, inBlock, outBlock, blockLen);
+   return InstanceProcess(settings, mMaster, inBlock, outBlock, blockLen);
 }
 
 bool EffectWahwah::RealtimeInitialize(EffectSettings &)
@@ -180,11 +180,10 @@ bool EffectWahwah::RealtimeFinalize(EffectSettings &) noexcept
    return true;
 }
 
-size_t EffectWahwah::RealtimeProcess(int group, EffectSettings &,
+size_t EffectWahwah::RealtimeProcess(int group, EffectSettings &settings,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
-
-   return InstanceProcess(mSlaves[group], inbuf, outbuf, numSamples);
+   return InstanceProcess(settings, mSlaves[group], inbuf, outbuf, numSamples);
 }
 
 bool EffectWahwah::DefineParams( ShuttleParams & S ){
@@ -360,7 +359,8 @@ void EffectWahwah::InstanceInit(EffectWahwahState & data, float sampleRate)
    data.outgain = DB_TO_LINEAR(mOutGain);
 }
 
-size_t EffectWahwah::InstanceProcess(EffectWahwahState & data,
+size_t EffectWahwah::InstanceProcess(EffectSettings &settings,
+   EffectWahwahState & data,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    const float *ibuf = inBlock[0];

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -147,7 +147,7 @@ bool EffectWahwah::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelName
    return true;
 }
 
-size_t EffectWahwah::ProcessBlock(
+size_t EffectWahwah::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    return InstanceProcess(mMaster, inBlock, outBlock, blockLen);

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -153,7 +153,7 @@ size_t EffectWahwah::ProcessBlock(
    return InstanceProcess(mMaster, inBlock, outBlock, blockLen);
 }
 
-bool EffectWahwah::RealtimeInitialize()
+bool EffectWahwah::RealtimeInitialize(EffectSettings &)
 {
    SetBlockSize(512);
 
@@ -173,14 +173,14 @@ bool EffectWahwah::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sa
    return true;
 }
 
-bool EffectWahwah::RealtimeFinalize() noexcept
+bool EffectWahwah::RealtimeFinalize(EffectSettings &) noexcept
 {
    mSlaves.clear();
 
    return true;
 }
 
-size_t EffectWahwah::RealtimeProcess(int group,
+size_t EffectWahwah::RealtimeProcess(int group, EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
 

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -84,7 +84,7 @@ private:
    // EffectWahwah implementation
 
    void InstanceInit(EffectWahwahState & data, float sampleRate);
-   size_t InstanceProcess(EffectWahwahState & data,
+   size_t InstanceProcess(EffectSettings &settings, EffectWahwahState & data,
       const float *const *inBlock, float *const *outBlock, size_t blockLen);
 
    void OnFreqSlider(wxCommandEvent & evt);

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -64,11 +64,12 @@ public:
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool DefineParams( ShuttleParams & S ) override;
 
    // Effect implementation

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -62,8 +62,9 @@ public:
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1299,7 +1299,7 @@ bool AudioUnitEffect::ProcessFinalize()
    return true;
 }
 
-size_t AudioUnitEffect::ProcessBlock(
+size_t AudioUnitEffect::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    for (size_t i = 0; i < mAudioIns; i++)
@@ -1419,11 +1419,11 @@ bool AudioUnitEffect::RealtimeProcessStart(EffectSettings &)
    return true;
 }
 
-size_t AudioUnitEffect::RealtimeProcess(int group, EffectSettings &,
+size_t AudioUnitEffect::RealtimeProcess(int group, EffectSettings &settings,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    wxASSERT(numSamples <= mBlockSize);
-   return mSlaves[group]->ProcessBlock(inbuf, outbuf, numSamples);
+   return mSlaves[group]->ProcessBlock(settings, inbuf, outbuf, numSamples);
 }
 
 bool AudioUnitEffect::RealtimeProcessEnd(EffectSettings &) noexcept

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1336,7 +1336,7 @@ size_t AudioUnitEffect::ProcessBlock(
    return blockLen;
 }
 
-bool AudioUnitEffect::RealtimeInitialize()
+bool AudioUnitEffect::RealtimeInitialize(EffectSettings &)
 {
    return ProcessInitialize(0);
 }
@@ -1364,7 +1364,7 @@ bool AudioUnitEffect::RealtimeAddProcessor(unsigned numChannels, float sampleRat
    return pSlave->ProcessInitialize(0);
 }
 
-bool AudioUnitEffect::RealtimeFinalize() noexcept
+bool AudioUnitEffect::RealtimeFinalize(EffectSettings &) noexcept
 {
 return GuardedCall<bool>([&]{
    for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
@@ -1419,7 +1419,7 @@ bool AudioUnitEffect::RealtimeProcessStart(EffectSettings &)
    return true;
 }
 
-size_t AudioUnitEffect::RealtimeProcess(int group,
+size_t AudioUnitEffect::RealtimeProcess(int group, EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    wxASSERT(numSamples <= mBlockSize);

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -95,14 +95,15 @@ public:
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
 
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -92,8 +92,9 @@ public:
 
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -973,7 +973,7 @@ bool LadspaEffect::ProcessFinalize()
    return true;
 }
 
-size_t LadspaEffect::ProcessBlock(
+size_t LadspaEffect::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
    for (int i = 0; i < (int)mAudioIns; i++)

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -994,7 +994,7 @@ size_t LadspaEffect::ProcessBlock(
    return blockLen;
 }
 
-bool LadspaEffect::RealtimeInitialize()
+bool LadspaEffect::RealtimeInitialize(EffectSettings &)
 {
    return true;
 }
@@ -1012,7 +1012,7 @@ bool LadspaEffect::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sa
    return true;
 }
 
-bool LadspaEffect::RealtimeFinalize() noexcept
+bool LadspaEffect::RealtimeFinalize(EffectSettings &) noexcept
 {
 return GuardedCall<bool>([&]{
    for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
@@ -1040,7 +1040,7 @@ bool LadspaEffect::RealtimeProcessStart(EffectSettings &)
    return true;
 }
 
-size_t LadspaEffect::RealtimeProcess(int group,
+size_t LadspaEffect::RealtimeProcess(int group, EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    for (int i = 0; i < (int)mAudioIns; i++)

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -91,8 +91,9 @@ public:
 
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -94,14 +94,15 @@ public:
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
 
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool RealtimeProcessEnd(EffectSettings &) noexcept override;
 
    int ShowClientInterface(

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1075,7 +1075,7 @@ bool LV2Effect::ProcessFinalize()
    return true;
 }
 
-size_t LV2Effect::ProcessBlock(
+size_t LV2Effect::ProcessBlock(EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t size)
 {
    wxASSERT(size <= ( size_t) mBlockSize);

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1175,7 +1175,7 @@ size_t LV2Effect::ProcessBlock(
    return size;
 }
 
-bool LV2Effect::RealtimeInitialize()
+bool LV2Effect::RealtimeInitialize(EffectSettings &)
 {
    mMasterIn.reinit(mAudioIn, (unsigned int) mBlockSize);
    for (auto & port : mCVPorts)
@@ -1189,7 +1189,7 @@ bool LV2Effect::RealtimeInitialize()
    return true;
 }
 
-bool LV2Effect::RealtimeFinalize() noexcept
+bool LV2Effect::RealtimeFinalize(EffectSettings &) noexcept
 {
 return GuardedCall<bool>([&]{
    for (auto & slave : mSlaves)
@@ -1335,7 +1335,7 @@ bool LV2Effect::RealtimeProcessStart(EffectSettings &)
    return true;
 }
 
-size_t LV2Effect::RealtimeProcess(int group,
+size_t LV2Effect::RealtimeProcess(int group, EffectSettings &,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    wxASSERT(group >= 0 && group < (int) mSlaves.size());

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -304,8 +304,9 @@ public:
 
    bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
    bool ProcessFinalize() override;
-   size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
-      size_t blockLen) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -307,14 +307,15 @@ public:
    size_t ProcessBlock( const float *const *inBlock, float *const *outBlock,
       size_t blockLen) override;
 
-   bool RealtimeInitialize() override;
+   bool RealtimeInitialize(EffectSettings &settings) override;
    bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize() noexcept override;
+   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
-   size_t RealtimeProcess(int group, const float *const *inbuf,
-      float *const *outbuf, size_t numSamples) override;
+   size_t RealtimeProcess(int group,  EffectSettings &settings,
+      const float *const *inbuf, float *const *outbuf, size_t numSamples)
+      override;
    bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
    int ShowClientInterface(

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -641,7 +641,7 @@ bool NyquistEffect::CheckWhetherSkipEffect()
 
 static void RegisterFunctions();
 
-bool NyquistEffect::Process()
+bool NyquistEffect::Process(EffectSettings &)
 {
    // Check for reentrant Nyquist commands.
    // I'm choosing to mark skipped Nyquist commands as successful even though
@@ -1063,7 +1063,10 @@ int NyquistEffect::ShowHostInterface(
       effect.mDebug = (res == eDebugID);
       // Delegate to the Nyquist Prompt,
       // which gets some Lisp from the user to interpret
-      res = Delegate(effect, parent, factory, access.shared_from_this());
+      auto settings = access.Get();
+      res = Delegate(effect, settings,
+         parent, factory, access.shared_from_this());
+      access.Set(std::move(settings));
       mT0 = effect.mT0;
       mT1 = effect.mT1;
    }

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -103,7 +103,7 @@ public:
 
    bool Init() override;
    bool CheckWhetherSkipEffect() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
       EffectSettingsAccess &access, bool forceModal = false) override;

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -341,7 +341,7 @@ bool VampEffect::Init()
    return true;
 }
 
-bool VampEffect::Process()
+bool VampEffect::Process(EffectSettings &)
 {
    if (!mPlugin)
    {

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -67,7 +67,7 @@ public:
    // Effect implementation
 
    bool Init() override;
-   bool Process() override;
+   bool Process(EffectSettings &settings) override;
    void End() override;
    void PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;


### PR DESCRIPTION
Resolves: #2577

The last batch of changes passed around EffectSettings into enough places to implement the inter-thread communication of
changing settings.  This batch passes EffectSettings into yet more places, including those on the path of destructive
effect processing (which does not have the same inter-thread problems), and to low levels of block processing that are
common to destructive and real-time processing.

Still nothing is ever in EffectSettings but a pointer to the EffectDefinitionInterfaceEx object.

Also still to do is break inheritance of EffectProcessor from EffectDefinitionInterface, and instead let EffectDefinitionInterface be a factory of EffectProcessor objects.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
