### PR TITLE
I2090 second attempt

### DIFF
--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -18,6 +18,8 @@ Paul Licameli split from ProjectManager.h
 #include "ClientData.h" // to inherit
 #include <wx/event.h> // to declare custom event type
 
+#include <atomic>
+
 constexpr int RATE_NOT_SELECTED{ -1 };
 
 class AudacityProject;
@@ -95,7 +97,7 @@ public:
    void SetTimerRecordCancelled() { mTimerRecordCanceled = true; }
    void ResetTimerRecordCancelled() { mTimerRecordCanceled = false; }
 
-   bool Paused() const { return mPaused; }
+   bool Paused() const;
 
    bool Playing() const;
 
@@ -135,8 +137,6 @@ public:
 
    void OnPause();
    
-   // Pause - used by AudioIO to pause sound activate recording
-   void Pause();
 
    // Stop playing or recording
    void Stop(bool stopStream = true);
@@ -149,7 +149,10 @@ public:
    PlayMode GetLastPlayMode() const { return mLastPlayMode; }
 
 private:
-   void SetPaused( bool value ) { mPaused = value; }
+
+   void TogglePaused();
+   void SetPausedOff();
+
    void SetAppending( bool value ) { mAppending = value; }
    void SetLooping( bool value ) { mLooping = value; }
    void SetCutting( bool value ) { mCutting = value; }
@@ -175,7 +178,10 @@ private:
    //flag for cancellation of timer record.
    bool mTimerRecordCanceled{ false };
 
-   bool mPaused{ false };
+   // Using int as the type for this atomic flag, allows us to toggle its value
+   // with an atomic operation.
+   std::atomic<int> mPaused{ 0 };
+
    bool mAppending{ false };
    bool mLooping{ false };
    bool mCutting{ false };


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2090

This solution consists of running the bare minimum set of code to fix the bug, while preserving existing behavior.

Whenever the sound-activation threshold is crossed (in either direction), all things that must be done in response to that are now all done in the paThread, without deferring anything to the main thread. So far this seems to be the only way to fix the issue - and what is executed in the paThread in response to the crossing is just read/writes of bool variables, without allocations or locks etc.

Changes are presented in a set of commits, to show step-by-step how existing functionality/state-changes are preserved, despite the final code being simpler than before; actually, even the first commit is enough to solve the issue, but I wanted to go on and simplify the code as much as possible.
In case of approval then I would squash commits together.




- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
