### PR TITLE
point 1 of i2578 - const correctness

### DIFF
--- a/libraries/lib-components/ComponentInterface.h
+++ b/libraries/lib-components/ComponentInterface.h
@@ -70,7 +70,7 @@ public:
    // So config compatibility will break if it is changed across Audacity versions
    virtual ComponentInterfaceSymbol GetSymbol() const = 0;
 
-   virtual VendorSymbol GetVendor() = 0;
+   virtual VendorSymbol GetVendor() const = 0;
 
    virtual wxString GetVersion() = 0;
 

--- a/libraries/lib-components/ComponentInterface.h
+++ b/libraries/lib-components/ComponentInterface.h
@@ -64,7 +64,7 @@ public:
    virtual ~ComponentInterface();
 
    // These should return an untranslated value
-   virtual PluginPath GetPath() = 0;
+   virtual PluginPath GetPath() const = 0;
 
    // The internal string persists in configuration files
    // So config compatibility will break if it is changed across Audacity versions

--- a/libraries/lib-components/ComponentInterface.h
+++ b/libraries/lib-components/ComponentInterface.h
@@ -76,7 +76,7 @@ public:
 
    // This returns a translated string
    // Any verb should be present tense indicative, not imperative
-   virtual TranslatableString GetDescription() = 0;
+   virtual TranslatableString GetDescription() const = 0;
 
    // non-virtual convenience function
    TranslatableString GetName() const;

--- a/libraries/lib-components/ComponentInterface.h
+++ b/libraries/lib-components/ComponentInterface.h
@@ -68,7 +68,7 @@ public:
 
    // The internal string persists in configuration files
    // So config compatibility will break if it is changed across Audacity versions
-   virtual ComponentInterfaceSymbol GetSymbol() = 0;
+   virtual ComponentInterfaceSymbol GetSymbol() const = 0;
 
    virtual VendorSymbol GetVendor() = 0;
 

--- a/libraries/lib-components/ComponentInterface.h
+++ b/libraries/lib-components/ComponentInterface.h
@@ -72,7 +72,7 @@ public:
 
    virtual VendorSymbol GetVendor() const = 0;
 
-   virtual wxString GetVersion() = 0;
+   virtual wxString GetVersion() const = 0;
 
    // This returns a translated string
    // Any verb should be present tense indicative, not imperative

--- a/libraries/lib-components/ComponentInterface.h
+++ b/libraries/lib-components/ComponentInterface.h
@@ -79,7 +79,7 @@ public:
    virtual TranslatableString GetDescription() = 0;
 
    // non-virtual convenience function
-   TranslatableString GetName();
+   TranslatableString GetName() const;
 
    // Parameters, if defined.  false means no defined parameters.
    virtual bool DefineParams( ShuttleParams & WXUNUSED(S) ){ return false;};   

--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -1716,7 +1716,7 @@ wxString PluginManager::ConvertID(const PluginID & ID)
 
 // This is defined out-of-line here, to keep ComponentInterface free of other
 // #include directives.
-TranslatableString ComponentInterface::GetName()
+TranslatableString ComponentInterface::GetName() const
 {
    return GetSymbol().Msgid();
 }

--- a/src/commands/AudacityCommand.cpp
+++ b/src/commands/AudacityCommand.cpp
@@ -64,7 +64,7 @@ AudacityCommand::~AudacityCommand()
 
 
 PluginPath AudacityCommand::GetPath() const {        return BUILTIN_GENERIC_COMMAND_PREFIX + GetSymbol().Internal(); }
-VendorSymbol AudacityCommand::GetVendor(){      return XO("Audacity");}
+VendorSymbol AudacityCommand::GetVendor() const {      return XO("Audacity");}
 wxString AudacityCommand::GetVersion(){     return AUDACITY_VERSION_STRING;}
 
 

--- a/src/commands/AudacityCommand.cpp
+++ b/src/commands/AudacityCommand.cpp
@@ -65,7 +65,7 @@ AudacityCommand::~AudacityCommand()
 
 PluginPath AudacityCommand::GetPath() const {        return BUILTIN_GENERIC_COMMAND_PREFIX + GetSymbol().Internal(); }
 VendorSymbol AudacityCommand::GetVendor() const {      return XO("Audacity");}
-wxString AudacityCommand::GetVersion(){     return AUDACITY_VERSION_STRING;}
+wxString AudacityCommand::GetVersion()  const {     return AUDACITY_VERSION_STRING;}
 
 
 bool AudacityCommand::Init(){

--- a/src/commands/AudacityCommand.cpp
+++ b/src/commands/AudacityCommand.cpp
@@ -63,7 +63,7 @@ AudacityCommand::~AudacityCommand()
 }
 
 
-PluginPath AudacityCommand::GetPath(){        return BUILTIN_GENERIC_COMMAND_PREFIX + GetSymbol().Internal(); }
+PluginPath AudacityCommand::GetPath() const {        return BUILTIN_GENERIC_COMMAND_PREFIX + GetSymbol().Internal(); }
 VendorSymbol AudacityCommand::GetVendor(){      return XO("Audacity");}
 wxString AudacityCommand::GetVersion(){     return AUDACITY_VERSION_STRING;}
 

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -50,7 +50,7 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
    //These four can be defaulted....
    PluginPath GetPath() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    //  virtual wxString GetFamily();
 
    //These two must be implemented by instances.

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -48,7 +48,7 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
    // ComponentInterface implementation
 
    //These four can be defaulted....
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    //  virtual wxString GetFamily();

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -49,7 +49,7 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
 
    //These four can be defaulted....
    PluginPath GetPath() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    //  virtual wxString GetFamily();
 

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -54,7 +54,7 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
    //  virtual wxString GetFamily();
 
    //These two must be implemented by instances.
-   ComponentInterfaceSymbol GetSymbol() override = 0;
+   ComponentInterfaceSymbol GetSymbol() const override = 0;
    virtual TranslatableString GetDescription() override
    {wxFAIL_MSG( "Implement a Description for this command");return XO("FAIL");};
 

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -55,7 +55,7 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
 
    //These two must be implemented by instances.
    ComponentInterfaceSymbol GetSymbol() const override = 0;
-   virtual TranslatableString GetDescription() override
+   virtual TranslatableString GetDescription() const override
    {wxFAIL_MSG( "Implement a Description for this command");return XO("FAIL");};
 
    // Name of page in the Audacity alpha manual

--- a/src/commands/BatchEvalCommand.cpp
+++ b/src/commands/BatchEvalCommand.cpp
@@ -24,7 +24,7 @@ static CommandDirectory::RegisterType sRegisterType{
    std::make_unique<BatchEvalCommandType>()
 };
 
-ComponentInterfaceSymbol BatchEvalCommandType::BuildName()
+ComponentInterfaceSymbol BatchEvalCommandType::BuildName() const
 {
    return { wxT("BatchCommand"), XO("Batch Command") };
 }

--- a/src/commands/BatchEvalCommand.h
+++ b/src/commands/BatchEvalCommand.h
@@ -31,7 +31,7 @@ class AudacityProject;
 class BatchEvalCommandType final : public OldStyleCommandType
 {
 public:
-   ComponentInterfaceSymbol BuildName() override;
+   ComponentInterfaceSymbol BuildName() const override;
    void BuildSignature(CommandSignature &signature) override;
    OldStyleCommandPointer Create( AudacityProject &project,
       std::unique_ptr<CommandOutputTargets> &&target) override;

--- a/src/commands/CommandType.cpp
+++ b/src/commands/CommandType.cpp
@@ -23,18 +23,17 @@ Also acts as a factory.
 #include <wx/string.h>
 
 OldStyleCommandType::OldStyleCommandType()
-   : mSymbol{}, mSignature{}
-{ }
+   : mSignature{}
+{
+}
 
 OldStyleCommandType::~OldStyleCommandType()
 {
 }
 
-ComponentInterfaceSymbol OldStyleCommandType::GetSymbol()
+ComponentInterfaceSymbol OldStyleCommandType::GetSymbol() const
 {
-   if (mSymbol.empty())
-      mSymbol = BuildName();
-   return mSymbol;
+   return BuildName();
 }
 
 CommandSignature &OldStyleCommandType::GetSignature()

--- a/src/commands/CommandType.h
+++ b/src/commands/CommandType.h
@@ -44,13 +44,12 @@ class wxString;
 class AUDACITY_DLL_API OldStyleCommandType : public AudacityCommand
 {
 private:
-   ComponentInterfaceSymbol mSymbol;
    std::optional<CommandSignature> mSignature;
 
 public:
    OldStyleCommandType();
    virtual ~OldStyleCommandType();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    CommandSignature &GetSignature();
    wxString Describe(); // for debugging only ?
 
@@ -58,7 +57,7 @@ public:
    // =========================================
 
    // Return the name of the command type
-   virtual ComponentInterfaceSymbol BuildName() = 0;
+   virtual ComponentInterfaceSymbol BuildName() const = 0;
 
    /// Postcondition: signature is a 'signature' map containing parameter
    // names, validators and default values.

--- a/src/commands/CompareAudioCommand.h
+++ b/src/commands/CompareAudioCommand.h
@@ -29,7 +29,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;}
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;}
    TranslatableString  GetDescription() override {return XO("Compares a range on two tracks.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/CompareAudioCommand.h
+++ b/src/commands/CompareAudioCommand.h
@@ -30,7 +30,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;}
-   TranslatableString  GetDescription() override {return XO("Compares a range on two tracks.");};
+   TranslatableString  GetDescription() const override {return XO("Compares a range on two tracks.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/Demo.h
+++ b/src/commands/Demo.h
@@ -22,7 +22,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Does the demo action.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/Demo.h
+++ b/src/commands/Demo.h
@@ -23,7 +23,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Does the demo action.");};
+   TranslatableString GetDescription() const override {return XO("Does the demo action.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;

--- a/src/commands/DragCommand.h
+++ b/src/commands/DragCommand.h
@@ -26,7 +26,7 @@ public:
 
    DragCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Drags mouse from one place to another.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/DragCommand.h
+++ b/src/commands/DragCommand.h
@@ -27,7 +27,7 @@ public:
    DragCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Drags mouse from one place to another.");};
+   TranslatableString GetDescription() const override {return XO("Drags mouse from one place to another.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/GetInfoCommand.h
+++ b/src/commands/GetInfoCommand.h
@@ -32,7 +32,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Gets information in JSON format.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/GetInfoCommand.h
+++ b/src/commands/GetInfoCommand.h
@@ -33,7 +33,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Gets information in JSON format.");};
+   TranslatableString GetDescription() const override {return XO("Gets information in JSON format.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/GetTrackInfoCommand.h
+++ b/src/commands/GetTrackInfoCommand.h
@@ -27,7 +27,7 @@ public:
    GetTrackInfoCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Gets track values as JSON.");};
+   TranslatableString GetDescription() const override {return XO("Gets track values as JSON.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/GetTrackInfoCommand.h
+++ b/src/commands/GetTrackInfoCommand.h
@@ -26,7 +26,7 @@ public:
 
    GetTrackInfoCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Gets track values as JSON.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/HelpCommand.h
+++ b/src/commands/HelpCommand.h
@@ -31,7 +31,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Gives help on a command.");};
+   TranslatableString GetDescription() const override {return XO("Gives help on a command.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -51,7 +51,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("For comments in a macro.");};
+   TranslatableString GetDescription() const override {return XO("For comments in a macro.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override {

--- a/src/commands/HelpCommand.h
+++ b/src/commands/HelpCommand.h
@@ -30,7 +30,7 @@ public:
    int mFormat;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Gives help on a command.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -50,7 +50,7 @@ public:
    int mFormat;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("For comments in a macro.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/ImportExportCommands.h
+++ b/src/commands/ImportExportCommands.h
@@ -29,7 +29,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Imports from a file.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -47,7 +47,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Exports to a file.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/ImportExportCommands.h
+++ b/src/commands/ImportExportCommands.h
@@ -30,7 +30,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Imports from a file.");};
+   TranslatableString GetDescription() const override {return XO("Imports from a file.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -48,7 +48,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Exports to a file.");};
+   TranslatableString GetDescription() const override {return XO("Exports to a file.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -98,7 +98,7 @@ VendorSymbol BuiltinCommandsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString BuiltinCommandsModule::GetVersion()
+wxString BuiltinCommandsModule::GetVersion() const
 {
    // This "may" be different if this were to be maintained as a separate DLL
    return AUDACITY_VERSION_STRING;

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -88,7 +88,7 @@ PluginPath BuiltinCommandsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol BuiltinCommandsModule::GetSymbol()
+ComponentInterfaceSymbol BuiltinCommandsModule::GetSymbol() const
 {
    return XO("Builtin Commands");
 }

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -83,7 +83,7 @@ BuiltinCommandsModule::~BuiltinCommandsModule()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath BuiltinCommandsModule::GetPath()
+PluginPath BuiltinCommandsModule::GetPath() const
 {
    return {};
 }

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -93,7 +93,7 @@ ComponentInterfaceSymbol BuiltinCommandsModule::GetSymbol() const
    return XO("Builtin Commands");
 }
 
-VendorSymbol BuiltinCommandsModule::GetVendor()
+VendorSymbol BuiltinCommandsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -104,7 +104,7 @@ wxString BuiltinCommandsModule::GetVersion() const
    return AUDACITY_VERSION_STRING;
 }
 
-TranslatableString BuiltinCommandsModule::GetDescription()
+TranslatableString BuiltinCommandsModule::GetDescription() const
 {
    return XO("Provides builtin commands to Audacity");
 }

--- a/src/commands/LoadCommands.h
+++ b/src/commands/LoadCommands.h
@@ -47,7 +47,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/commands/LoadCommands.h
+++ b/src/commands/LoadCommands.h
@@ -45,7 +45,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/commands/LoadCommands.h
+++ b/src/commands/LoadCommands.h
@@ -48,7 +48,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // ModuleInterface implementation

--- a/src/commands/LoadCommands.h
+++ b/src/commands/LoadCommands.h
@@ -49,7 +49,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // ModuleInterface implementation
 

--- a/src/commands/LoadCommands.h
+++ b/src/commands/LoadCommands.h
@@ -46,7 +46,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/commands/MessageCommand.h
+++ b/src/commands/MessageCommand.h
@@ -31,7 +31,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Echos a message.");};
+   TranslatableString GetDescription() const override {return XO("Echos a message.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;

--- a/src/commands/MessageCommand.h
+++ b/src/commands/MessageCommand.h
@@ -30,7 +30,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Echos a message.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/OpenSaveCommands.h
+++ b/src/commands/OpenSaveCommands.h
@@ -34,7 +34,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Opens a project.");};
+   TranslatableString GetDescription() const override {return XO("Opens a project.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -54,7 +54,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Saves a project.");};
+   TranslatableString GetDescription() const override {return XO("Saves a project.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -74,7 +74,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Saves a copy of current project.");};
+   TranslatableString GetDescription() const override {return XO("Saves a copy of current project.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -92,7 +92,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Saves the log contents.");};
+   TranslatableString GetDescription() const override {return XO("Saves the log contents.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -110,7 +110,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Clears the log contents.");};
+   TranslatableString GetDescription() const override {return XO("Clears the log contents.");};
    bool DefineParams( ShuttleParams & S ) override;
    bool PromptUser(wxWindow *parent) override;
    bool Apply(const CommandContext & context) override;

--- a/src/commands/OpenSaveCommands.h
+++ b/src/commands/OpenSaveCommands.h
@@ -33,7 +33,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Opens a project.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -53,7 +53,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Saves a project.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -73,7 +73,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Saves a copy of current project.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -91,7 +91,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Saves the log contents.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -109,7 +109,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Clears the log contents.");};
    bool DefineParams( ShuttleParams & S ) override;
    bool PromptUser(wxWindow *parent) override;

--- a/src/commands/PreferenceCommands.h
+++ b/src/commands/PreferenceCommands.h
@@ -33,7 +33,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Gets the value of a single preference.");};
+   TranslatableString GetDescription() const override {return XO("Gets the value of a single preference.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -53,7 +53,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets the value of a single preference.");};
+   TranslatableString GetDescription() const override {return XO("Sets the value of a single preference.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;

--- a/src/commands/PreferenceCommands.h
+++ b/src/commands/PreferenceCommands.h
@@ -32,7 +32,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Gets the value of a single preference.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -52,7 +52,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets the value of a single preference.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/ScreenshotCommand.h
+++ b/src/commands/ScreenshotCommand.h
@@ -82,7 +82,7 @@ public:
    ScreenshotCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Takes screenshots.");};
+   TranslatableString GetDescription() const override {return XO("Takes screenshots.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/ScreenshotCommand.h
+++ b/src/commands/ScreenshotCommand.h
@@ -81,7 +81,7 @@ public:
 
    ScreenshotCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Takes screenshots.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/SelectCommand.h
+++ b/src/commands/SelectCommand.h
@@ -30,7 +30,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Selects a time range.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -56,7 +56,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Selects a frequency range.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -79,7 +79,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Selects a range of tracks.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -103,7 +103,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Selects Audio.");};
    bool DefineParams( ShuttleParams & S ) override { 
       return 

--- a/src/commands/SelectCommand.h
+++ b/src/commands/SelectCommand.h
@@ -31,7 +31,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Selects a time range.");};
+   TranslatableString GetDescription() const override {return XO("Selects a time range.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -57,7 +57,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Selects a frequency range.");};
+   TranslatableString GetDescription() const override {return XO("Selects a frequency range.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -80,7 +80,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Selects a range of tracks.");};
+   TranslatableString GetDescription() const override {return XO("Selects a range of tracks.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
    bool Apply(const CommandContext & context) override;
@@ -104,7 +104,7 @@ public:
 
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Selects Audio.");};
+   TranslatableString GetDescription() const override {return XO("Selects Audio.");};
    bool DefineParams( ShuttleParams & S ) override { 
       return 
          mSelTime.DefineParams(S) &&  

--- a/src/commands/SetClipCommand.h
+++ b/src/commands/SetClipCommand.h
@@ -25,7 +25,7 @@ public:
 
    SetClipCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets various values for a clip.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/SetClipCommand.h
+++ b/src/commands/SetClipCommand.h
@@ -26,7 +26,7 @@ public:
    SetClipCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets various values for a clip.");};
+   TranslatableString GetDescription() const override {return XO("Sets various values for a clip.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/SetEnvelopeCommand.h
+++ b/src/commands/SetEnvelopeCommand.h
@@ -26,7 +26,7 @@ public:
    SetEnvelopeCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets an envelope point position.");};
+   TranslatableString GetDescription() const override {return XO("Sets an envelope point position.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/SetEnvelopeCommand.h
+++ b/src/commands/SetEnvelopeCommand.h
@@ -25,7 +25,7 @@ public:
 
    SetEnvelopeCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets an envelope point position.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/SetLabelCommand.h
+++ b/src/commands/SetLabelCommand.h
@@ -26,7 +26,7 @@ public:
 
    SetLabelCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets various values for a label.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/SetLabelCommand.h
+++ b/src/commands/SetLabelCommand.h
@@ -27,7 +27,7 @@ public:
    SetLabelCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets various values for a label.");};
+   TranslatableString GetDescription() const override {return XO("Sets various values for a label.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/SetProjectCommand.h
+++ b/src/commands/SetProjectCommand.h
@@ -27,7 +27,7 @@ public:
 
    SetProjectCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets various values for a project.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;

--- a/src/commands/SetProjectCommand.h
+++ b/src/commands/SetProjectCommand.h
@@ -28,7 +28,7 @@ public:
    SetProjectCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets various values for a project.");};
+   TranslatableString GetDescription() const override {return XO("Sets various values for a project.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 

--- a/src/commands/SetTrackInfoCommand.h
+++ b/src/commands/SetTrackInfoCommand.h
@@ -49,7 +49,7 @@ public:
    //SetTrackStatusCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
+   TranslatableString GetDescription() const override {return XO("Sets various values for a track.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
@@ -76,7 +76,7 @@ public:
    //SetTrackAudioCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
+   TranslatableString GetDescription() const override {return XO("Sets various values for a track.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
@@ -105,7 +105,7 @@ public:
    //SetTrackVisualsCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
+   TranslatableString GetDescription() const override {return XO("Sets various values for a track.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
@@ -148,7 +148,7 @@ public:
    SetTrackCommand();
    // ComponentInterface overrides
    ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
-   TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
+   TranslatableString GetDescription() const override {return XO("Sets various values for a track.");};
    // AudacityCommand overrides
    ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#set_track";}
 

--- a/src/commands/SetTrackInfoCommand.h
+++ b/src/commands/SetTrackInfoCommand.h
@@ -48,7 +48,7 @@ public:
 
    //SetTrackStatusCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -75,7 +75,7 @@ public:
 
    //SetTrackAudioCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -104,7 +104,7 @@ public:
 
    //SetTrackVisualsCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
    bool DefineParams( ShuttleParams & S ) override;
    void PopulateOrExchange(ShuttleGui & S) override;
@@ -147,7 +147,7 @@ public:
 
    SetTrackCommand();
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override {return Symbol;};
+   ComponentInterfaceSymbol GetSymbol() const override {return Symbol;};
    TranslatableString GetDescription() override {return XO("Sets various values for a track.");};
    // AudacityCommand overrides
    ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_II#set_track";}

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -88,7 +88,7 @@ EffectAmplify::~EffectAmplify()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectAmplify::GetSymbol()
+ComponentInterfaceSymbol EffectAmplify::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -93,7 +93,7 @@ ComponentInterfaceSymbol EffectAmplify::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectAmplify::GetDescription()
+TranslatableString EffectAmplify::GetDescription() const
 {
    // Note: This is useful only after ratio has been set.
    return XO("Increases or decreases the volume of the audio you have selected");

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -33,7 +33,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -34,7 +34,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -113,7 +113,7 @@ ComponentInterfaceSymbol EffectAutoDuck::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectAutoDuck::GetDescription()
+TranslatableString EffectAutoDuck::GetDescription() const
 {
    return XO("Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level");
 }

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -108,7 +108,7 @@ EffectAutoDuck::~EffectAutoDuck()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectAutoDuck::GetSymbol()
+ComponentInterfaceSymbol EffectAutoDuck::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -31,7 +31,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -30,7 +30,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -88,7 +88,7 @@ EffectBassTreble::~EffectBassTreble()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectBassTreble::GetSymbol()
+ComponentInterfaceSymbol EffectBassTreble::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -93,7 +93,7 @@ ComponentInterfaceSymbol EffectBassTreble::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectBassTreble::GetDescription()
+TranslatableString EffectBassTreble::GetDescription() const
 {
    return XO("Simple tone control effect");
 }

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -44,7 +44,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -43,7 +43,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -145,7 +145,7 @@ ComponentInterfaceSymbol EffectChangePitch::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectChangePitch::GetDescription()
+TranslatableString EffectChangePitch::GetDescription() const
 {
    return XO("Changes the pitch of a track without changing its tempo");
 }

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -140,7 +140,7 @@ EffectChangePitch::~EffectChangePitch()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectChangePitch::GetSymbol()
+ComponentInterfaceSymbol EffectChangePitch::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -45,7 +45,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -44,7 +44,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -114,7 +114,7 @@ EffectChangeSpeed::~EffectChangeSpeed()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectChangeSpeed::GetSymbol()
+ComponentInterfaceSymbol EffectChangeSpeed::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -119,7 +119,7 @@ ComponentInterfaceSymbol EffectChangeSpeed::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectChangeSpeed::GetDescription()
+TranslatableString EffectChangeSpeed::GetDescription() const
 {
    return XO("Changes the speed of a track, also changing its pitch");
 }

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -32,7 +32,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -31,7 +31,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -114,7 +114,7 @@ EffectChangeTempo::~EffectChangeTempo()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectChangeTempo::GetSymbol()
+ComponentInterfaceSymbol EffectChangeTempo::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -119,7 +119,7 @@ ComponentInterfaceSymbol EffectChangeTempo::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectChangeTempo::GetDescription()
+TranslatableString EffectChangeTempo::GetDescription() const
 {
    return XO("Changes the tempo of a selection without changing its pitch");
 }

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -39,7 +39,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -38,7 +38,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -83,7 +83,7 @@ EffectClickRemoval::~EffectClickRemoval()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectClickRemoval::GetSymbol()
+ComponentInterfaceSymbol EffectClickRemoval::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -88,7 +88,7 @@ ComponentInterfaceSymbol EffectClickRemoval::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectClickRemoval::GetDescription()
+TranslatableString EffectClickRemoval::GetDescription() const
 {
    return XO("Click Removal is designed to remove clicks on audio tracks");
 }

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -33,7 +33,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -34,7 +34,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -105,7 +105,7 @@ EffectCompressor::~EffectCompressor()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectCompressor::GetSymbol()
+ComponentInterfaceSymbol EffectCompressor::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -110,7 +110,7 @@ ComponentInterfaceSymbol EffectCompressor::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectCompressor::GetDescription()
+TranslatableString EffectCompressor::GetDescription() const
 {
    return XO("Compresses the dynamic range of audio");
 }

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -32,7 +32,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -33,7 +33,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription()  const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -193,7 +193,7 @@ ComponentInterfaceSymbol EffectDistortion::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectDistortion::GetDescription()
+TranslatableString EffectDistortion::GetDescription() const
 {
    return XO("Waveshaping distortion effect");
 }

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -188,7 +188,7 @@ EffectDistortion::~EffectDistortion()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectDistortion::GetSymbol()
+ComponentInterfaceSymbol EffectDistortion::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -63,7 +63,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -64,7 +64,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -105,7 +105,7 @@ ComponentInterfaceSymbol EffectDtmf::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectDtmf::GetDescription()
+TranslatableString EffectDtmf::GetDescription() const
 {
    return XO("Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones");
 }

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -100,7 +100,7 @@ EffectDtmf::~EffectDtmf()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectDtmf::GetSymbol()
+ComponentInterfaceSymbol EffectDtmf::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -32,7 +32,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -33,7 +33,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -57,7 +57,7 @@ EffectEcho::~EffectEcho()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectEcho::GetSymbol()
+ComponentInterfaceSymbol EffectEcho::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -62,7 +62,7 @@ ComponentInterfaceSymbol EffectEcho::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectEcho::GetDescription()
+TranslatableString EffectEcho::GetDescription() const
 {
    return XO("Repeats the selected audio again and again");
 }

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -28,7 +28,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -29,7 +29,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -122,7 +122,7 @@ PluginPath Effect::GetPath()
    return BUILTIN_EFFECT_PREFIX + GetSymbol().Internal();
 }
 
-ComponentInterfaceSymbol Effect::GetSymbol()
+ComponentInterfaceSymbol Effect::GetSymbol() const
 {
    if (mClient)
    {

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -142,7 +142,7 @@ VendorSymbol Effect::GetVendor() const
    return XO("Audacity");
 }
 
-wxString Effect::GetVersion()
+wxString Effect::GetVersion() const
 {
    if (mClient)
    {

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -132,7 +132,7 @@ ComponentInterfaceSymbol Effect::GetSymbol() const
    return {};
 }
 
-VendorSymbol Effect::GetVendor()
+VendorSymbol Effect::GetVendor() const
 {
    if (mClient)
    {

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -112,7 +112,7 @@ EffectType Effect::GetType()
    return EffectTypeNone;
 }
 
-PluginPath Effect::GetPath()
+PluginPath Effect::GetPath() const
 {
    if (mClient)
    {

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -152,7 +152,7 @@ wxString Effect::GetVersion() const
    return AUDACITY_VERSION_STRING;
 }
 
-TranslatableString Effect::GetDescription()
+TranslatableString Effect::GetDescription() const
 {
    if (mClient)
    {

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -94,7 +94,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -92,7 +92,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    ComponentInterfaceSymbol GetSymbol() const override;
 
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -93,7 +93,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    ComponentInterfaceSymbol GetSymbol() const override;
 
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -90,7 +90,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    PluginPath GetPath() override;
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
 
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -88,7 +88,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
 
    ComponentInterfaceSymbol GetSymbol() const override;
 

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -339,7 +339,7 @@ EffectEqualization::~EffectEqualization()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectEqualization::GetSymbol()
+ComponentInterfaceSymbol EffectEqualization::GetSymbol() const
 {
    if( mOptions == kEqOptionGraphic )
       return EffectEqualizationGraphic::Symbol;

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -348,7 +348,7 @@ ComponentInterfaceSymbol EffectEqualization::GetSymbol() const
    return EffectEqualization::Symbol;
 }
 
-TranslatableString EffectEqualization::GetDescription()
+TranslatableString EffectEqualization::GetDescription() const
 {
    return XO("Adjusts the volume levels of particular frequencies");
 }

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -103,7 +103,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
    bool DefineParams( ShuttleParams & S ) override;

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -104,7 +104,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
    bool DefineParams( ShuttleParams & S ) override;
 

--- a/src/effects/Fade.cpp
+++ b/src/effects/Fade.cpp
@@ -48,7 +48,7 @@ ComponentInterfaceSymbol EffectFade::GetSymbol() const
       : EffectFadeOut::Symbol;
 }
 
-TranslatableString EffectFade::GetDescription()
+TranslatableString EffectFade::GetDescription() const
 {
    return mFadeIn
       ? XO("Applies a linear fade-in to the selected audio")

--- a/src/effects/Fade.cpp
+++ b/src/effects/Fade.cpp
@@ -41,7 +41,7 @@ EffectFade::~EffectFade()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectFade::GetSymbol()
+ComponentInterfaceSymbol EffectFade::GetSymbol() const
 {
    return mFadeIn
       ? EffectFadeIn::Symbol

--- a/src/effects/Fade.h
+++ b/src/effects/Fade.h
@@ -21,7 +21,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Fade.h
+++ b/src/effects/Fade.h
@@ -22,7 +22,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -58,7 +58,7 @@ EffectFindClipping::~EffectFindClipping()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectFindClipping::GetSymbol()
+ComponentInterfaceSymbol EffectFindClipping::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -63,7 +63,7 @@ ComponentInterfaceSymbol EffectFindClipping::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectFindClipping::GetDescription()
+TranslatableString EffectFindClipping::GetDescription() const
 {
    return XO("Creates labels where clipping is detected");
 }

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -28,7 +28,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -29,7 +29,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Invert.cpp
+++ b/src/effects/Invert.cpp
@@ -41,7 +41,7 @@ ComponentInterfaceSymbol EffectInvert::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectInvert::GetDescription()
+TranslatableString EffectInvert::GetDescription() const
 {
    return XO("Flips the audio samples upside-down, reversing their polarity");
 }

--- a/src/effects/Invert.cpp
+++ b/src/effects/Invert.cpp
@@ -36,7 +36,7 @@ EffectInvert::~EffectInvert()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectInvert::GetSymbol()
+ComponentInterfaceSymbol EffectInvert::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Invert.h
+++ b/src/effects/Invert.h
@@ -26,7 +26,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Invert.h
+++ b/src/effects/Invert.h
@@ -25,7 +25,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -86,7 +86,7 @@ PluginPath BuiltinEffectsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol BuiltinEffectsModule::GetSymbol()
+ComponentInterfaceSymbol BuiltinEffectsModule::GetSymbol() const
 {
    return XO("Builtin Effects");
 }

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -91,7 +91,7 @@ ComponentInterfaceSymbol BuiltinEffectsModule::GetSymbol() const
    return XO("Builtin Effects");
 }
 
-VendorSymbol BuiltinEffectsModule::GetVendor()
+VendorSymbol BuiltinEffectsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -96,7 +96,7 @@ VendorSymbol BuiltinEffectsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString BuiltinEffectsModule::GetVersion()
+wxString BuiltinEffectsModule::GetVersion() const
 {
    // This "may" be different if this were to be maintained as a separate DLL
    return AUDACITY_VERSION_STRING;

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -102,7 +102,7 @@ wxString BuiltinEffectsModule::GetVersion() const
    return AUDACITY_VERSION_STRING;
 }
 
-TranslatableString BuiltinEffectsModule::GetDescription()
+TranslatableString BuiltinEffectsModule::GetDescription() const
 {
    return XO("Provides builtin effects to Audacity");
 }

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -81,7 +81,7 @@ BuiltinEffectsModule::~BuiltinEffectsModule()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath BuiltinEffectsModule::GetPath()
+PluginPath BuiltinEffectsModule::GetPath() const
 {
    return {};
 }

--- a/src/effects/LoadEffects.h
+++ b/src/effects/LoadEffects.h
@@ -47,7 +47,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/LoadEffects.h
+++ b/src/effects/LoadEffects.h
@@ -45,7 +45,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/LoadEffects.h
+++ b/src/effects/LoadEffects.h
@@ -48,7 +48,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // ModuleInterface implementation

--- a/src/effects/LoadEffects.h
+++ b/src/effects/LoadEffects.h
@@ -49,7 +49,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // ModuleInterface implementation
 

--- a/src/effects/LoadEffects.h
+++ b/src/effects/LoadEffects.h
@@ -46,7 +46,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -88,7 +88,7 @@ ComponentInterfaceSymbol EffectLoudness::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectLoudness::GetDescription()
+TranslatableString EffectLoudness::GetDescription() const
 {
    return XO("Sets the loudness of one or more tracks");
 }

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -83,7 +83,7 @@ EffectLoudness::~EffectLoudness()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectLoudness::GetSymbol()
+ComponentInterfaceSymbol EffectLoudness::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -37,7 +37,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol  GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -36,7 +36,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol  GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -86,7 +86,7 @@ ComponentInterfaceSymbol EffectNoise::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectNoise::GetDescription()
+TranslatableString EffectNoise::GetDescription() const
 {
    return XO("Generates one of three different types of noise");
 }

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -81,7 +81,7 @@ EffectNoise::~EffectNoise()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectNoise::GetSymbol()
+ComponentInterfaceSymbol EffectNoise::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -28,7 +28,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -29,7 +29,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -420,7 +420,7 @@ EffectNoiseReduction::~EffectNoiseReduction()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectNoiseReduction::GetSymbol()
+ComponentInterfaceSymbol EffectNoiseReduction::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -425,7 +425,7 @@ ComponentInterfaceSymbol EffectNoiseReduction::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectNoiseReduction::GetDescription()
+TranslatableString EffectNoiseReduction::GetDescription() const
 {
    return XO("Removes background noise such as fans, tape noise, or hums");
 }

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -27,7 +27,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -26,7 +26,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -118,7 +118,7 @@ ComponentInterfaceSymbol EffectNoiseRemoval::GetSymbol()
    return Symbol;
 }
 
-TranslatableString EffectNoiseRemoval::GetDescription()
+TranslatableString EffectNoiseRemoval::GetDescription() const
 {
    return XO("Removes constant background noise such as fans, tape noise, or hums");
 }

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -73,7 +73,7 @@ ComponentInterfaceSymbol EffectNormalize::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectNormalize::GetDescription()
+TranslatableString EffectNormalize::GetDescription() const
 {
    return XO("Sets the peak amplitude of one or more tracks");
 }

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -68,7 +68,7 @@ EffectNormalize::~EffectNormalize()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectNormalize::GetSymbol()
+ComponentInterfaceSymbol EffectNormalize::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -31,7 +31,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -30,7 +30,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -107,7 +107,7 @@ EffectPaulstretch::~EffectPaulstretch()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectPaulstretch::GetSymbol()
+ComponentInterfaceSymbol EffectPaulstretch::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -112,7 +112,7 @@ ComponentInterfaceSymbol EffectPaulstretch::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectPaulstretch::GetDescription()
+TranslatableString EffectPaulstretch::GetDescription() const
 {
    return XO("Paulstretch is only for an extreme time-stretch or \"stasis\" effect");
 }

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -25,7 +25,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -24,7 +24,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -110,7 +110,7 @@ ComponentInterfaceSymbol EffectPhaser::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectPhaser::GetDescription()
+TranslatableString EffectPhaser::GetDescription() const
 {
    return XO("Combines phase-shifted signals with the original signal");
 }

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -105,7 +105,7 @@ EffectPhaser::~EffectPhaser()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectPhaser::GetSymbol()
+ComponentInterfaceSymbol EffectPhaser::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -50,7 +50,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -49,7 +49,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -54,7 +54,7 @@ ComponentInterfaceSymbol EffectRepair::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectRepair::GetDescription()
+TranslatableString EffectRepair::GetDescription() const
 {
    return XO("Sets the peak amplitude of a one or more tracks");
 }

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -49,7 +49,7 @@ EffectRepair::~EffectRepair()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectRepair::GetSymbol()
+ComponentInterfaceSymbol EffectRepair::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Repair.h
+++ b/src/effects/Repair.h
@@ -26,7 +26,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Repair.h
+++ b/src/effects/Repair.h
@@ -25,7 +25,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -66,7 +66,7 @@ EffectRepeat::~EffectRepeat()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectRepeat::GetSymbol()
+ComponentInterfaceSymbol EffectRepeat::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -71,7 +71,7 @@ ComponentInterfaceSymbol EffectRepeat::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectRepeat::GetDescription()
+TranslatableString EffectRepeat::GetDescription() const
 {
    return XO("Repeats the selection the specified number of times");
 }

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -28,7 +28,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -29,7 +29,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -144,7 +144,7 @@ ComponentInterfaceSymbol EffectReverb::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectReverb::GetDescription()
+TranslatableString EffectReverb::GetDescription() const
 {
    return XO("Adds ambience or a \"hall effect\"");
 }

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -139,7 +139,7 @@ EffectReverb::~EffectReverb()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectReverb::GetSymbol()
+ComponentInterfaceSymbol EffectReverb::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -46,7 +46,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -45,7 +45,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -46,7 +46,7 @@ EffectReverse::~EffectReverse()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectReverse::GetSymbol()
+ComponentInterfaceSymbol EffectReverse::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -51,7 +51,7 @@ ComponentInterfaceSymbol EffectReverse::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectReverse::GetDescription()
+TranslatableString EffectReverse::GetDescription() const
 {
    return XO("Reverses the selected audio");
 }

--- a/src/effects/Reverse.h
+++ b/src/effects/Reverse.h
@@ -26,7 +26,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Reverse.h
+++ b/src/effects/Reverse.h
@@ -25,7 +25,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/SBSMSEffect.h
+++ b/src/effects/SBSMSEffect.h
@@ -42,7 +42,7 @@ protected:
    // This supplies the abstract virtual function, but in fact this symbol
    // does not get used:  this class is either a temporary helper, or else
    // GetSymbol() is overridden further in derived classes.
-   ComponentInterfaceSymbol GetSymbol() override { return mProxyEffectName; }
+   ComponentInterfaceSymbol GetSymbol() const override { return mProxyEffectName; }
 
 private:
    bool ProcessLabelTrack(LabelTrack *track);

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -181,7 +181,7 @@ EffectScienFilter::~EffectScienFilter()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectScienFilter::GetSymbol()
+ComponentInterfaceSymbol EffectScienFilter::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -186,7 +186,7 @@ ComponentInterfaceSymbol EffectScienFilter::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectScienFilter::GetDescription()
+TranslatableString EffectScienFilter::GetDescription() const
 {
    /* i18n-hint: "infinite impulse response" */
    return XO("Performs IIR filtering that emulates analog filters");

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -39,7 +39,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -40,7 +40,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -40,7 +40,7 @@ EffectSilence::~EffectSilence()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectSilence::GetSymbol()
+ComponentInterfaceSymbol EffectSilence::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -45,7 +45,7 @@ ComponentInterfaceSymbol EffectSilence::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectSilence::GetDescription()
+TranslatableString EffectSilence::GetDescription() const
 {
    return XO("Creates audio of zero amplitude");
 }

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -28,7 +28,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -27,7 +27,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -39,7 +39,7 @@ EffectStereoToMono::~EffectStereoToMono()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectStereoToMono::GetSymbol()
+ComponentInterfaceSymbol EffectStereoToMono::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -44,7 +44,7 @@ ComponentInterfaceSymbol EffectStereoToMono::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectStereoToMono::GetDescription()
+TranslatableString EffectStereoToMono::GetDescription() const
 {
    return XO("Converts stereo tracks to mono");
 }

--- a/src/effects/StereoToMono.h
+++ b/src/effects/StereoToMono.h
@@ -24,7 +24,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/StereoToMono.h
+++ b/src/effects/StereoToMono.h
@@ -23,7 +23,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -96,7 +96,7 @@ ComponentInterfaceSymbol EffectTimeScale::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectTimeScale::GetDescription()
+TranslatableString EffectTimeScale::GetDescription() const
 {
    return XO("Allows continuous changes to the tempo and/or pitch");
 }

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -91,7 +91,7 @@ EffectTimeScale::~EffectTimeScale()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectTimeScale::GetSymbol()
+ComponentInterfaceSymbol EffectTimeScale::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -32,7 +32,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -31,7 +31,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -127,7 +127,7 @@ EffectToneGen::~EffectToneGen()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectToneGen::GetSymbol()
+ComponentInterfaceSymbol EffectToneGen::GetSymbol() const
 {
    return mChirp
       ? EffectChirp::Symbol

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -134,7 +134,7 @@ ComponentInterfaceSymbol EffectToneGen::GetSymbol() const
       : EffectTone::Symbol;
 }
 
-TranslatableString EffectToneGen::GetDescription()
+TranslatableString EffectToneGen::GetDescription() const
 {
    return mChirp
       ? XO("Generates an ascending or descending tone of one of four types")

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -26,7 +26,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -27,7 +27,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -161,7 +161,7 @@ EffectTruncSilence::~EffectTruncSilence()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectTruncSilence::GetSymbol()
+ComponentInterfaceSymbol EffectTruncSilence::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -166,7 +166,7 @@ ComponentInterfaceSymbol EffectTruncSilence::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectTruncSilence::GetDescription()
+TranslatableString EffectTruncSilence::GetDescription() const
 {
    return XO("Automatically reduces the length of passages where the volume is below a specified level");
 }

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -37,7 +37,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -36,7 +36,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -250,7 +250,7 @@ public:
       return { mVendor };
    }
 
-   wxString GetVersion() override
+   wxString GetVersion() const override
    {
       return mVersion;
    }
@@ -343,7 +343,7 @@ VendorSymbol VSTEffectsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString VSTEffectsModule::GetVersion()
+wxString VSTEffectsModule::GetVersion() const
 {
    // This "may" be different if this were to be maintained as a separate DLL
    return AUDACITY_VERSION_STRING;
@@ -1214,7 +1214,7 @@ VendorSymbol VSTEffect::GetVendor() const
    return { mVendor };
 }
 
-wxString VSTEffect::GetVersion()
+wxString VSTEffect::GetVersion() const
 {
    wxString version;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -240,7 +240,7 @@ public:
       return mPath;
    }
 
-   ComponentInterfaceSymbol GetSymbol() override
+   ComponentInterfaceSymbol GetSymbol() const override
    {
       return mName;
    }
@@ -333,7 +333,7 @@ PluginPath VSTEffectsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol VSTEffectsModule::GetSymbol()
+ComponentInterfaceSymbol VSTEffectsModule::GetSymbol() const
 {
    return XO("VST Effects");
 }
@@ -1204,7 +1204,7 @@ PluginPath VSTEffect::GetPath()
    return mPath;
 }
 
-ComponentInterfaceSymbol VSTEffect::GetSymbol()
+ComponentInterfaceSymbol VSTEffect::GetSymbol() const
 {
    return mName;
 }

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -235,7 +235,7 @@ public:
 
    // EffectDefinitionInterface implementation
 
-   PluginPath GetPath() override
+   PluginPath GetPath() const override
    {
       return mPath;
    }
@@ -328,7 +328,7 @@ VSTEffectsModule::~VSTEffectsModule()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath VSTEffectsModule::GetPath()
+PluginPath VSTEffectsModule::GetPath() const
 {
    return {};
 }
@@ -1199,7 +1199,7 @@ VSTEffect::~VSTEffect()
 // ComponentInterface Implementation
 // ============================================================================
 
-PluginPath VSTEffect::GetPath()
+PluginPath VSTEffect::GetPath() const
 {
    return mPath;
 }

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -255,7 +255,7 @@ public:
       return mVersion;
    }
 
-   TranslatableString GetDescription() override
+   TranslatableString GetDescription() const override
    {
       return mDescription;
    }
@@ -349,7 +349,7 @@ wxString VSTEffectsModule::GetVersion() const
    return AUDACITY_VERSION_STRING;
 }
 
-TranslatableString VSTEffectsModule::GetDescription()
+TranslatableString VSTEffectsModule::GetDescription() const
 {
    return XO("Adds the ability to use VST effects in Audacity.");
 }
@@ -1233,7 +1233,7 @@ wxString VSTEffect::GetVersion() const
    return version;
 }
 
-TranslatableString VSTEffect::GetDescription()
+TranslatableString VSTEffect::GetDescription() const
 {
    // VST does have a product string opcode and some effects return a short
    // description, but most do not or they just return the name again.  So,

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -245,7 +245,7 @@ public:
       return mName;
    }
 
-   VendorSymbol GetVendor() override
+   VendorSymbol GetVendor() const override
    {
       return { mVendor };
    }
@@ -338,7 +338,7 @@ ComponentInterfaceSymbol VSTEffectsModule::GetSymbol() const
    return XO("VST Effects");
 }
 
-VendorSymbol VSTEffectsModule::GetVendor()
+VendorSymbol VSTEffectsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }
@@ -1209,7 +1209,7 @@ ComponentInterfaceSymbol VSTEffect::GetSymbol() const
    return mName;
 }
 
-VendorSymbol VSTEffect::GetVendor()
+VendorSymbol VSTEffect::GetVendor() const
 {
    return { mVendor };
 }

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -103,7 +103,7 @@ class VSTEffect final : public wxEvtHandler,
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 
@@ -402,7 +402,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -104,7 +104,7 @@ class VSTEffect final : public wxEvtHandler,
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation
@@ -403,7 +403,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // ModuleInterface implementation

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -105,7 +105,7 @@ class VSTEffect final : public wxEvtHandler,
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 
@@ -404,7 +404,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // ModuleInterface implementation
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -101,7 +101,7 @@ class VSTEffect final : public wxEvtHandler,
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
@@ -400,7 +400,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -102,7 +102,7 @@ class VSTEffect final : public wxEvtHandler,
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
@@ -401,7 +401,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -281,7 +281,7 @@ wxString VST3Effect::GetVersion() const
    return mEffectClassInfo.version();
 }
 
-TranslatableString VST3Effect::GetDescription()
+TranslatableString VST3Effect::GetDescription() const
 {
    //i18n-hint VST3 effect description string
    return XO("SubCategories: %s").Format( mEffectClassInfo.subCategoriesString() );

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -261,7 +261,7 @@ VST3Effect::VST3Effect(
 }
 
 
-PluginPath VST3Effect::GetPath()
+PluginPath VST3Effect::GetPath() const
 {
    return VST3Utils::MakePluginPathString( { mModule->getPath() }, mEffectClassInfo.ID().toString());
 }

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -271,7 +271,7 @@ ComponentInterfaceSymbol VST3Effect::GetSymbol() const
    return wxString { mEffectClassInfo.name() };
 }
 
-VendorSymbol VST3Effect::GetVendor()
+VendorSymbol VST3Effect::GetVendor() const
 {
    return wxString { mEffectClassInfo.vendor() };
 }

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -266,7 +266,7 @@ PluginPath VST3Effect::GetPath()
    return VST3Utils::MakePluginPathString( { mModule->getPath() }, mEffectClassInfo.ID().toString());
 }
 
-ComponentInterfaceSymbol VST3Effect::GetSymbol()
+ComponentInterfaceSymbol VST3Effect::GetSymbol() const
 {
    return wxString { mEffectClassInfo.name() };
 }

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -276,7 +276,7 @@ VendorSymbol VST3Effect::GetVendor() const
    return wxString { mEffectClassInfo.vendor() };
 }
 
-wxString VST3Effect::GetVersion()
+wxString VST3Effect::GetVersion() const
 {
    return mEffectClassInfo.version();
 }

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -95,7 +95,7 @@ public:
    ~VST3Effect() override;
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -94,7 +94,7 @@ public:
 
    ~VST3Effect() override;
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -98,7 +98,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    EffectType GetType() override;
    EffectFamilySymbol GetFamily() override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -96,7 +96,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -97,7 +97,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    EffectType GetType() override;

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -97,7 +97,7 @@ ComponentInterfaceSymbol VST3EffectsModule::GetSymbol() const
    return XO("VST3 Effects");
 }
 
-VendorSymbol VST3EffectsModule::GetVendor()
+VendorSymbol VST3EffectsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -92,7 +92,7 @@ PluginPath VST3EffectsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol VST3EffectsModule::GetSymbol()
+ComponentInterfaceSymbol VST3EffectsModule::GetSymbol() const
 {
    return XO("VST3 Effects");
 }

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -107,7 +107,7 @@ wxString VST3EffectsModule::GetVersion() const
    return AUDACITY_VERSION_STRING;
 }
 
-TranslatableString VST3EffectsModule::GetDescription()
+TranslatableString VST3EffectsModule::GetDescription() const
 {
    return XO("Adds the ability to use VST3 effects in Audacity.");
 }

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -102,7 +102,7 @@ VendorSymbol VST3EffectsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString VST3EffectsModule::GetVersion()
+wxString VST3EffectsModule::GetVersion() const
 {
    return AUDACITY_VERSION_STRING;
 }

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -87,7 +87,7 @@ std::shared_ptr<VST3::Hosting::Module> VST3EffectsModule::GetModule(const wxStri
    return module;
 }
 
-PluginPath VST3EffectsModule::GetPath()
+PluginPath VST3EffectsModule::GetPath() const
 {
    return {};
 }

--- a/src/effects/VST3/VST3EffectsModule.h
+++ b/src/effects/VST3/VST3EffectsModule.h
@@ -40,7 +40,7 @@ class VST3EffectsModule final : public ModuleInterface
 
 public:
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/VST3/VST3EffectsModule.h
+++ b/src/effects/VST3/VST3EffectsModule.h
@@ -42,7 +42,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/VST3/VST3EffectsModule.h
+++ b/src/effects/VST3/VST3EffectsModule.h
@@ -41,7 +41,7 @@ class VST3EffectsModule final : public ModuleInterface
 public:
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/VST3/VST3EffectsModule.h
+++ b/src/effects/VST3/VST3EffectsModule.h
@@ -44,7 +44,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Initialize() override;
    void Terminate() override;

--- a/src/effects/VST3/VST3EffectsModule.h
+++ b/src/effects/VST3/VST3EffectsModule.h
@@ -43,7 +43,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    bool Initialize() override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -96,7 +96,7 @@ EffectWahwah::~EffectWahwah()
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectWahwah::GetSymbol()
+ComponentInterfaceSymbol EffectWahwah::GetSymbol() const
 {
    return Symbol;
 }

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -101,7 +101,7 @@ ComponentInterfaceSymbol EffectWahwah::GetSymbol() const
    return Symbol;
 }
 
-TranslatableString EffectWahwah::GetDescription()
+TranslatableString EffectWahwah::GetDescription() const
 {
    return XO("Rapid tone quality variations, like that guitar sound so popular in the 1970's");
 }

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -46,7 +46,7 @@ public:
 
    // ComponentInterface implementation
 
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID ManualPage() override;
 

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -47,7 +47,7 @@ public:
    // ComponentInterface implementation
 
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID ManualPage() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -269,7 +269,7 @@ PluginPath AudioUnitEffectsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol AudioUnitEffectsModule::GetSymbol()
+ComponentInterfaceSymbol AudioUnitEffectsModule::GetSymbol() const
 {
    /* i18n-hint: Audio Unit is the name of an Apple audio software protocol */
    return XO("Audio Unit Effects");
@@ -885,7 +885,7 @@ PluginPath AudioUnitEffect::GetPath()
    return mPath;
 }
 
-ComponentInterfaceSymbol AudioUnitEffect::GetSymbol()
+ComponentInterfaceSymbol AudioUnitEffect::GetSymbol() const
 {
    return mName;
 }

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -264,7 +264,7 @@ AudioUnitEffectsModule::~AudioUnitEffectsModule()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath AudioUnitEffectsModule::GetPath()
+PluginPath AudioUnitEffectsModule::GetPath() const
 {
    return {};
 }
@@ -880,7 +880,7 @@ AudioUnitEffect::~AudioUnitEffect()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath AudioUnitEffect::GetPath()
+PluginPath AudioUnitEffect::GetPath() const
 {
    return mPath;
 }

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -280,7 +280,7 @@ VendorSymbol AudioUnitEffectsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString AudioUnitEffectsModule::GetVersion()
+wxString AudioUnitEffectsModule::GetVersion() const
 {
    // This "may" be different if this were to be maintained as a separate DLL
    return AUDIOUNITEFFECTS_VERSION;
@@ -895,7 +895,7 @@ VendorSymbol AudioUnitEffect::GetVendor() const
    return { mVendor };
 }
 
-wxString AudioUnitEffect::GetVersion()
+wxString AudioUnitEffect::GetVersion() const
 {
    UInt32 version;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -286,7 +286,7 @@ wxString AudioUnitEffectsModule::GetVersion() const
    return AUDIOUNITEFFECTS_VERSION;
 }
 
-TranslatableString AudioUnitEffectsModule::GetDescription()
+TranslatableString AudioUnitEffectsModule::GetDescription() const
 {
    return XO("Provides Audio Unit Effects support to Audacity");
 }
@@ -907,7 +907,7 @@ wxString AudioUnitEffect::GetVersion() const
                            version & 0xff);
 }
 
-TranslatableString AudioUnitEffect::GetDescription()
+TranslatableString AudioUnitEffect::GetDescription() const
 {
    /* i18n-hint: Can mean "not available," "not applicable," "no answer" */
    return XO("n/a");

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -275,7 +275,7 @@ ComponentInterfaceSymbol AudioUnitEffectsModule::GetSymbol() const
    return XO("Audio Unit Effects");
 }
 
-VendorSymbol AudioUnitEffectsModule::GetVendor()
+VendorSymbol AudioUnitEffectsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }
@@ -890,7 +890,7 @@ ComponentInterfaceSymbol AudioUnitEffect::GetSymbol() const
    return mName;
 }
 
-VendorSymbol AudioUnitEffect::GetVendor()
+VendorSymbol AudioUnitEffect::GetVendor() const
 {
    return { mVendor };
 }

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -50,7 +50,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
@@ -230,7 +230,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -51,7 +51,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
@@ -231,7 +231,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -53,7 +53,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation
@@ -233,7 +233,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // ModuleInterface implementation

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -54,7 +54,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 
@@ -234,7 +234,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // ModuleInterface implementation
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -52,7 +52,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 
@@ -232,7 +232,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -129,7 +129,7 @@ ComponentInterfaceSymbol LadspaEffectsModule::GetSymbol() const
    return XO("LADSPA Effects");
 }
 
-VendorSymbol LadspaEffectsModule::GetVendor()
+VendorSymbol LadspaEffectsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }
@@ -655,7 +655,7 @@ ComponentInterfaceSymbol LadspaEffect::GetSymbol() const
    return LAT1CTOWX(mData->Name);
 }
 
-VendorSymbol LadspaEffect::GetVendor()
+VendorSymbol LadspaEffect::GetVendor() const
 {
    return { LAT1CTOWX(mData->Maker) };
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -134,7 +134,7 @@ VendorSymbol LadspaEffectsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString LadspaEffectsModule::GetVersion()
+wxString LadspaEffectsModule::GetVersion() const
 {
    // This "may" be different if this were to be maintained as a separate DLL
    return LADSPAEFFECTS_VERSION;
@@ -660,7 +660,7 @@ VendorSymbol LadspaEffect::GetVendor() const
    return { LAT1CTOWX(mData->Maker) };
 }
 
-wxString LadspaEffect::GetVersion()
+wxString LadspaEffect::GetVersion() const
 {
    return _("n/a");
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -121,7 +121,7 @@ PluginPath LadspaEffectsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol LadspaEffectsModule::GetSymbol()
+ComponentInterfaceSymbol LadspaEffectsModule::GetSymbol() const
 {
    /* i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
       (Application programming interface)
@@ -650,7 +650,7 @@ PluginPath LadspaEffect::GetPath()
    return wxString::Format(wxT("%s;%d"), mPath, mIndex);
 }
 
-ComponentInterfaceSymbol LadspaEffect::GetSymbol()
+ComponentInterfaceSymbol LadspaEffect::GetSymbol() const
 {
    return LAT1CTOWX(mData->Name);
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -140,7 +140,7 @@ wxString LadspaEffectsModule::GetVersion() const
    return LADSPAEFFECTS_VERSION;
 }
 
-TranslatableString LadspaEffectsModule::GetDescription()
+TranslatableString LadspaEffectsModule::GetDescription() const
 {
    return XO("Provides LADSPA Effects");
 }
@@ -665,7 +665,7 @@ wxString LadspaEffect::GetVersion() const
    return _("n/a");
 }
 
-TranslatableString LadspaEffect::GetDescription()
+TranslatableString LadspaEffect::GetDescription() const
 {
    return Verbatim( LAT1CTOWX(mData->Copyright) );
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -116,7 +116,7 @@ LadspaEffectsModule::~LadspaEffectsModule()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath LadspaEffectsModule::GetPath()
+PluginPath LadspaEffectsModule::GetPath() const
 {
    return {};
 }
@@ -645,7 +645,7 @@ LadspaEffect::~LadspaEffect()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath LadspaEffect::GetPath()
+PluginPath LadspaEffect::GetPath() const
 {
    return wxString::Format(wxT("%s;%d"), mPath, mIndex);
 }

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -53,7 +53,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 
@@ -212,7 +212,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // ModuleInterface implementation
 

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -52,7 +52,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation
@@ -211,7 +211,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // ModuleInterface implementation

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -51,7 +51,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 
@@ -210,7 +210,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -49,7 +49,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
@@ -208,7 +208,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -50,7 +50,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
@@ -209,7 +209,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -436,7 +436,7 @@ PluginPath LV2Effect::GetPath()
    return LilvString(lilv_plugin_get_uri(mPlug));
 }
 
-ComponentInterfaceSymbol LV2Effect::GetSymbol()
+ComponentInterfaceSymbol LV2Effect::GetSymbol() const
 {
    return LilvString(lilv_plugin_get_name(mPlug), true);
 }

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -441,7 +441,7 @@ ComponentInterfaceSymbol LV2Effect::GetSymbol() const
    return LilvString(lilv_plugin_get_name(mPlug), true);
 }
 
-VendorSymbol LV2Effect::GetVendor()
+VendorSymbol LV2Effect::GetVendor() const
 {
    wxString vendor = LilvString(lilv_plugin_get_author_name(mPlug), true);
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -431,7 +431,7 @@ LV2Effect::~LV2Effect()
 // ComponentInterface Implementation
 // ============================================================================
 
-PluginPath LV2Effect::GetPath()
+PluginPath LV2Effect::GetPath() const
 {
    return LilvString(lilv_plugin_get_uri(mPlug));
 }

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -458,7 +458,7 @@ wxString LV2Effect::GetVersion() const
    return wxT("1.0");
 }
 
-TranslatableString LV2Effect::GetDescription()
+TranslatableString LV2Effect::GetDescription() const
 {
    return XO("n/a");
 }

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -453,7 +453,7 @@ VendorSymbol LV2Effect::GetVendor() const
    return {vendor};
 }
 
-wxString LV2Effect::GetVersion()
+wxString LV2Effect::GetVersion() const
 {
    return wxT("1.0");
 }

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -265,7 +265,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -266,7 +266,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -263,7 +263,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -262,7 +262,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -264,7 +264,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -111,7 +111,7 @@ wxString LV2EffectsModule::GetVersion() const
    return LV2EFFECTS_VERSION;
 }
 
-TranslatableString LV2EffectsModule::GetDescription()
+TranslatableString LV2EffectsModule::GetDescription() const
 {
    return XO("Provides LV2 Effects support to Audacity");
 }

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -95,7 +95,7 @@ PluginPath LV2EffectsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol LV2EffectsModule::GetSymbol()
+ComponentInterfaceSymbol LV2EffectsModule::GetSymbol() const
 {
    return XO("LV2 Effects");
 }

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -90,7 +90,7 @@ LV2EffectsModule::~LV2EffectsModule()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath LV2EffectsModule::GetPath()
+PluginPath LV2EffectsModule::GetPath() const
 {
    return {};
 }

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -105,7 +105,7 @@ VendorSymbol LV2EffectsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString LV2EffectsModule::GetVersion()
+wxString LV2EffectsModule::GetVersion() const
 {
    // This "may" be different if this were to be maintained as a separate DLL
    return LV2EFFECTS_VERSION;

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -100,7 +100,7 @@ ComponentInterfaceSymbol LV2EffectsModule::GetSymbol() const
    return XO("LV2 Effects");
 }
 
-VendorSymbol LV2EffectsModule::GetVendor()
+VendorSymbol LV2EffectsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }

--- a/src/effects/lv2/LoadLV2.h
+++ b/src/effects/lv2/LoadLV2.h
@@ -170,7 +170,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/lv2/LoadLV2.h
+++ b/src/effects/lv2/LoadLV2.h
@@ -171,7 +171,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // ModuleInterface implementation

--- a/src/effects/lv2/LoadLV2.h
+++ b/src/effects/lv2/LoadLV2.h
@@ -172,7 +172,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // ModuleInterface implementation
 

--- a/src/effects/lv2/LoadLV2.h
+++ b/src/effects/lv2/LoadLV2.h
@@ -169,7 +169,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/lv2/LoadLV2.h
+++ b/src/effects/lv2/LoadLV2.h
@@ -168,7 +168,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -108,7 +108,7 @@ VendorSymbol NyquistEffectsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString NyquistEffectsModule::GetVersion()
+wxString NyquistEffectsModule::GetVersion() const
 {
    // This "may" be different if this were to be maintained as a separate DLL
    return NYQUISTEFFECTS_VERSION;

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -93,7 +93,7 @@ NyquistEffectsModule::~NyquistEffectsModule()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath NyquistEffectsModule::GetPath()
+PluginPath NyquistEffectsModule::GetPath() const
 {
    return {};
 }

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -103,7 +103,7 @@ ComponentInterfaceSymbol NyquistEffectsModule::GetSymbol() const
    return XO("Nyquist Effects");
 }
 
-VendorSymbol NyquistEffectsModule::GetVendor()
+VendorSymbol NyquistEffectsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -114,7 +114,7 @@ wxString NyquistEffectsModule::GetVersion() const
    return NYQUISTEFFECTS_VERSION;
 }
 
-TranslatableString NyquistEffectsModule::GetDescription()
+TranslatableString NyquistEffectsModule::GetDescription() const
 {
    return XO("Provides Nyquist Effects support to Audacity");
 }

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -98,7 +98,7 @@ PluginPath NyquistEffectsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol NyquistEffectsModule::GetSymbol()
+ComponentInterfaceSymbol NyquistEffectsModule::GetSymbol() const
 {
    return XO("Nyquist Effects");
 }

--- a/src/effects/nyquist/LoadNyquist.h
+++ b/src/effects/nyquist/LoadNyquist.h
@@ -28,7 +28,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/nyquist/LoadNyquist.h
+++ b/src/effects/nyquist/LoadNyquist.h
@@ -27,7 +27,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/nyquist/LoadNyquist.h
+++ b/src/effects/nyquist/LoadNyquist.h
@@ -29,7 +29,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // ModuleInterface implementation

--- a/src/effects/nyquist/LoadNyquist.h
+++ b/src/effects/nyquist/LoadNyquist.h
@@ -30,7 +30,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // ModuleInterface implementation
 

--- a/src/effects/nyquist/LoadNyquist.h
+++ b/src/effects/nyquist/LoadNyquist.h
@@ -26,7 +26,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -211,7 +211,7 @@ PluginPath NyquistEffect::GetPath()
    return mFileName.GetFullPath();
 }
 
-ComponentInterfaceSymbol NyquistEffect::GetSymbol()
+ComponentInterfaceSymbol NyquistEffect::GetSymbol() const
 {
    if (mIsPrompt)
       return { NYQUIST_PROMPT_ID, NYQUIST_PROMPT_NAME };

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -229,7 +229,7 @@ VendorSymbol NyquistEffect::GetVendor() const
    return mAuthor;
 }
 
-wxString NyquistEffect::GetVersion()
+wxString NyquistEffect::GetVersion() const
 {
    // Are Nyquist version strings really supposed to be translatable?
    // See commit a06e561 which used XO for at least one of them

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -236,7 +236,7 @@ wxString NyquistEffect::GetVersion() const
    return mReleaseVersion.Translation();
 }
 
-TranslatableString NyquistEffect::GetDescription()
+TranslatableString NyquistEffect::GetDescription() const
 {
    return mCopyright;
 }

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -203,7 +203,7 @@ NyquistEffect::~NyquistEffect()
 
 // ComponentInterface implementation
 
-PluginPath NyquistEffect::GetPath()
+PluginPath NyquistEffect::GetPath() const
 {
    if (mIsPrompt)
       return NYQUIST_PROMPT_ID;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -219,7 +219,7 @@ ComponentInterfaceSymbol NyquistEffect::GetSymbol() const
    return mName;
 }
 
-VendorSymbol NyquistEffect::GetVendor()
+VendorSymbol NyquistEffect::GetVendor() const
 {
    if (mIsPrompt)
    {

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -76,7 +76,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
    
    ManualPageID ManualPage() override;

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -74,7 +74,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -75,7 +75,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
    

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -77,7 +77,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    
    ManualPageID ManualPage() override;
    FilePath HelpPage() override;

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -73,7 +73,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -85,7 +85,7 @@ wxString VampEffectsModule::GetVersion() const
    return VAMPEFFECTS_VERSION;
 }
 
-TranslatableString VampEffectsModule::GetDescription()
+TranslatableString VampEffectsModule::GetDescription() const
 {
    return XO("Provides Vamp Effects support to Audacity");
 }

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -69,7 +69,7 @@ PluginPath VampEffectsModule::GetPath()
    return {};
 }
 
-ComponentInterfaceSymbol VampEffectsModule::GetSymbol()
+ComponentInterfaceSymbol VampEffectsModule::GetSymbol() const
 {
    return XO("Vamp Effects");
 }

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -74,7 +74,7 @@ ComponentInterfaceSymbol VampEffectsModule::GetSymbol() const
    return XO("Vamp Effects");
 }
 
-VendorSymbol VampEffectsModule::GetVendor()
+VendorSymbol VampEffectsModule::GetVendor() const
 {
    return XO("The Audacity Team");
 }

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -64,7 +64,7 @@ VampEffectsModule::~VampEffectsModule()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath VampEffectsModule::GetPath()
+PluginPath VampEffectsModule::GetPath() const
 {
    return {};
 }

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -79,7 +79,7 @@ VendorSymbol VampEffectsModule::GetVendor() const
    return XO("The Audacity Team");
 }
 
-wxString VampEffectsModule::GetVersion()
+wxString VampEffectsModule::GetVersion() const
 {
    // This "may" be different if this were to be maintained as a separate DLL
    return VAMPEFFECTS_VERSION;

--- a/src/effects/vamp/LoadVamp.h
+++ b/src/effects/vamp/LoadVamp.h
@@ -34,7 +34,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/vamp/LoadVamp.h
+++ b/src/effects/vamp/LoadVamp.h
@@ -38,7 +38,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // ModuleInterface implementation
 

--- a/src/effects/vamp/LoadVamp.h
+++ b/src/effects/vamp/LoadVamp.h
@@ -37,7 +37,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // ModuleInterface implementation

--- a/src/effects/vamp/LoadVamp.h
+++ b/src/effects/vamp/LoadVamp.h
@@ -35,7 +35,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/vamp/LoadVamp.h
+++ b/src/effects/vamp/LoadVamp.h
@@ -36,7 +36,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -102,7 +102,7 @@ VendorSymbol VampEffect::GetVendor() const
    return { wxString::FromUTF8(mPlugin->getMaker().c_str()) };
 }
 
-wxString VampEffect::GetVersion()
+wxString VampEffect::GetVersion() const
 {
    return wxString::Format(wxT("%d"), mPlugin->getPluginVersion());
 }

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -92,7 +92,7 @@ PluginPath VampEffect::GetPath()
    return mPath;
 }
 
-ComponentInterfaceSymbol VampEffect::GetSymbol()
+ComponentInterfaceSymbol VampEffect::GetSymbol() const
 {
    return mName;
 }

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -107,7 +107,7 @@ wxString VampEffect::GetVersion() const
    return wxString::Format(wxT("%d"), mPlugin->getPluginVersion());
 }
 
-TranslatableString VampEffect::GetDescription()
+TranslatableString VampEffect::GetDescription() const
 {
    return Verbatim(
       wxString::FromUTF8(mPlugin->getCopyright().c_str()) );

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -97,7 +97,7 @@ ComponentInterfaceSymbol VampEffect::GetSymbol() const
    return mName;
 }
 
-VendorSymbol VampEffect::GetVendor()
+VendorSymbol VampEffect::GetVendor() const
 {
    return { wxString::FromUTF8(mPlugin->getMaker().c_str()) };
 }

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -87,7 +87,7 @@ VampEffect::~VampEffect()
 // ComponentInterface implementation
 // ============================================================================
 
-PluginPath VampEffect::GetPath()
+PluginPath VampEffect::GetPath() const
 {
    return mPath;
 }

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -47,7 +47,7 @@ public:
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
-   wxString GetVersion() override;
+   wxString GetVersion() const override;
    TranslatableString GetDescription() override;
 
    // EffectDefinitionInterface implementation

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -44,7 +44,7 @@ public:
 
    // ComponentInterface implementation
 
-   PluginPath GetPath() override;
+   PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -45,7 +45,7 @@ public:
    // ComponentInterface implementation
 
    PluginPath GetPath() override;
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -46,7 +46,7 @@ public:
 
    PluginPath GetPath() const override;
    ComponentInterfaceSymbol GetSymbol() const override;
-   VendorSymbol GetVendor() override;
+   VendorSymbol GetVendor() const override;
    wxString GetVersion() override;
    TranslatableString GetDescription() override;
 

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -48,7 +48,7 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    VendorSymbol GetVendor() const override;
    wxString GetVersion() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/prefs/ApplicationPrefs.cpp
+++ b/src/prefs/ApplicationPrefs.cpp
@@ -45,7 +45,7 @@ ComponentInterfaceSymbol ApplicationPrefs::GetSymbol() const
    return s_ComponentInterfaceSymbol;
 }
 
-TranslatableString ApplicationPrefs::GetDescription()
+TranslatableString ApplicationPrefs::GetDescription() const
 {
    return XO("Preferences for Application");
 }

--- a/src/prefs/ApplicationPrefs.cpp
+++ b/src/prefs/ApplicationPrefs.cpp
@@ -40,7 +40,7 @@ ApplicationPrefs::~ApplicationPrefs()
 {
 }
 
-ComponentInterfaceSymbol ApplicationPrefs::GetSymbol()
+ComponentInterfaceSymbol ApplicationPrefs::GetSymbol() const
 {
    return s_ComponentInterfaceSymbol;
 }

--- a/src/prefs/ApplicationPrefs.h
+++ b/src/prefs/ApplicationPrefs.h
@@ -24,7 +24,7 @@ class ApplicationPrefs final : public PrefsPanel
    ApplicationPrefs(wxWindow * parent, wxWindowID winid);
    ~ApplicationPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/ApplicationPrefs.h
+++ b/src/prefs/ApplicationPrefs.h
@@ -23,7 +23,7 @@ class ApplicationPrefs final : public PrefsPanel
  public:
    ApplicationPrefs(wxWindow * parent, wxWindowID winid);
    ~ApplicationPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/BatchPrefs.cpp
+++ b/src/prefs/BatchPrefs.cpp
@@ -40,7 +40,7 @@ ComponentInterfaceSymbol BatchPrefs::GetSymbol() const
    return BATCH_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString BatchPrefs::GetDescription()
+TranslatableString BatchPrefs::GetDescription() const
 {
    return XO("Preferences for Batch");
 }

--- a/src/prefs/BatchPrefs.cpp
+++ b/src/prefs/BatchPrefs.cpp
@@ -35,7 +35,7 @@ BatchPrefs::BatchPrefs(wxWindow * parent, wxWindowID winid):
    Populate();
 }
 
-ComponentInterfaceSymbol BatchPrefs::GetSymbol()
+ComponentInterfaceSymbol BatchPrefs::GetSymbol() const
 {
    return BATCH_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/BatchPrefs.h
+++ b/src/prefs/BatchPrefs.h
@@ -25,7 +25,7 @@ class BatchPrefs final : public PrefsPanel
 public:
    BatchPrefs(wxWindow * parent, wxWindowID winid);
    ~BatchPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID HelpPageName() override;
 

--- a/src/prefs/BatchPrefs.h
+++ b/src/prefs/BatchPrefs.h
@@ -26,7 +26,7 @@ public:
    BatchPrefs(wxWindow * parent, wxWindowID winid);
    ~BatchPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID HelpPageName() override;
 
    bool Commit() override;

--- a/src/prefs/DevicePrefs.cpp
+++ b/src/prefs/DevicePrefs.cpp
@@ -69,7 +69,7 @@ ComponentInterfaceSymbol DevicePrefs::GetSymbol() const
    return DEVICE_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString DevicePrefs::GetDescription()
+TranslatableString DevicePrefs::GetDescription() const
 {
    return XO("Preferences for Device");
 }

--- a/src/prefs/DevicePrefs.cpp
+++ b/src/prefs/DevicePrefs.cpp
@@ -64,7 +64,7 @@ DevicePrefs::~DevicePrefs()
 }
 
 
-ComponentInterfaceSymbol DevicePrefs::GetSymbol()
+ComponentInterfaceSymbol DevicePrefs::GetSymbol() const
 {
    return DEVICE_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/DevicePrefs.h
+++ b/src/prefs/DevicePrefs.h
@@ -27,7 +27,7 @@ class DevicePrefs final : public PrefsPanel
    DevicePrefs(wxWindow * parent, wxWindowID winid);
    virtual ~DevicePrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/DevicePrefs.h
+++ b/src/prefs/DevicePrefs.h
@@ -26,7 +26,7 @@ class DevicePrefs final : public PrefsPanel
  public:
    DevicePrefs(wxWindow * parent, wxWindowID winid);
    virtual ~DevicePrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -159,7 +159,7 @@ ComponentInterfaceSymbol DirectoriesPrefs::GetSymbol() const
    return DIRECTORIES_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString DirectoriesPrefs::GetDescription()
+TranslatableString DirectoriesPrefs::GetDescription() const
 {
    return XO("Preferences for Directories");
 }

--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -154,7 +154,7 @@ DirectoriesPrefs::~DirectoriesPrefs()
 {
 }
 
-ComponentInterfaceSymbol DirectoriesPrefs::GetSymbol()
+ComponentInterfaceSymbol DirectoriesPrefs::GetSymbol() const
 {
    return DIRECTORIES_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/DirectoriesPrefs.h
+++ b/src/prefs/DirectoriesPrefs.h
@@ -27,7 +27,7 @@ class DirectoriesPrefs final : public PrefsPanel
    DirectoriesPrefs(wxWindow * parent, wxWindowID winid);
    ~DirectoriesPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    bool Validate() override;

--- a/src/prefs/DirectoriesPrefs.h
+++ b/src/prefs/DirectoriesPrefs.h
@@ -26,7 +26,7 @@ class DirectoriesPrefs final : public PrefsPanel
  public:
    DirectoriesPrefs(wxWindow * parent, wxWindowID winid);
    ~DirectoriesPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/EffectsPrefs.cpp
+++ b/src/prefs/EffectsPrefs.cpp
@@ -38,7 +38,7 @@ EffectsPrefs::~EffectsPrefs()
 {
 }
 
-ComponentInterfaceSymbol EffectsPrefs::GetSymbol()
+ComponentInterfaceSymbol EffectsPrefs::GetSymbol() const
 {
    return EFFECTS_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/EffectsPrefs.cpp
+++ b/src/prefs/EffectsPrefs.cpp
@@ -43,7 +43,7 @@ ComponentInterfaceSymbol EffectsPrefs::GetSymbol() const
    return EFFECTS_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString EffectsPrefs::GetDescription()
+TranslatableString EffectsPrefs::GetDescription() const
 {
    return XO("Preferences for Effects");
 }

--- a/src/prefs/EffectsPrefs.h
+++ b/src/prefs/EffectsPrefs.h
@@ -27,7 +27,7 @@ class EffectsPrefs final : public PrefsPanel
  public:
    EffectsPrefs(wxWindow * parent, wxWindowID winid);
    ~EffectsPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/EffectsPrefs.h
+++ b/src/prefs/EffectsPrefs.h
@@ -28,7 +28,7 @@ class EffectsPrefs final : public PrefsPanel
    EffectsPrefs(wxWindow * parent, wxWindowID winid);
    ~EffectsPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/ExtImportPrefs.cpp
+++ b/src/prefs/ExtImportPrefs.cpp
@@ -74,7 +74,7 @@ ExtImportPrefs::~ExtImportPrefs()
 {
 }
 
-ComponentInterfaceSymbol ExtImportPrefs::GetSymbol()
+ComponentInterfaceSymbol ExtImportPrefs::GetSymbol() const
 {
    return EXT_IMPORT_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/ExtImportPrefs.cpp
+++ b/src/prefs/ExtImportPrefs.cpp
@@ -79,7 +79,7 @@ ComponentInterfaceSymbol ExtImportPrefs::GetSymbol() const
    return EXT_IMPORT_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString ExtImportPrefs::GetDescription()
+TranslatableString ExtImportPrefs::GetDescription() const
 {
    return XO("Preferences for ExtImport");
 }

--- a/src/prefs/ExtImportPrefs.h
+++ b/src/prefs/ExtImportPrefs.h
@@ -52,7 +52,7 @@ class ExtImportPrefs final : public PrefsPanel
    ExtImportPrefs(wxWindow * parent, wxWindowID winid);
    ~ExtImportPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/ExtImportPrefs.h
+++ b/src/prefs/ExtImportPrefs.h
@@ -51,7 +51,7 @@ class ExtImportPrefs final : public PrefsPanel
  public:
    ExtImportPrefs(wxWindow * parent, wxWindowID winid);
    ~ExtImportPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -50,7 +50,7 @@ ComponentInterfaceSymbol GUIPrefs::GetSymbol() const
    return GUI_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString GUIPrefs::GetDescription()
+TranslatableString GUIPrefs::GetDescription() const
 {
    return XO("Preferences for GUI");
 }

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -45,7 +45,7 @@ GUIPrefs::~GUIPrefs()
 {
 }
 
-ComponentInterfaceSymbol GUIPrefs::GetSymbol()
+ComponentInterfaceSymbol GUIPrefs::GetSymbol() const
 {
    return GUI_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/GUIPrefs.h
+++ b/src/prefs/GUIPrefs.h
@@ -27,7 +27,7 @@ class AUDACITY_DLL_API GUIPrefs final : public PrefsPanel
  public:
    GUIPrefs(wxWindow * parent, wxWindowID winid);
    ~GUIPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/GUIPrefs.h
+++ b/src/prefs/GUIPrefs.h
@@ -28,7 +28,7 @@ class AUDACITY_DLL_API GUIPrefs final : public PrefsPanel
    GUIPrefs(wxWindow * parent, wxWindowID winid);
    ~GUIPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/ImportExportPrefs.cpp
+++ b/src/prefs/ImportExportPrefs.cpp
@@ -33,7 +33,7 @@ ImportExportPrefs::~ImportExportPrefs()
 {
 }
 
-ComponentInterfaceSymbol ImportExportPrefs::GetSymbol()
+ComponentInterfaceSymbol ImportExportPrefs::GetSymbol() const
 {
    return IMPORT_EXPORT_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/ImportExportPrefs.cpp
+++ b/src/prefs/ImportExportPrefs.cpp
@@ -38,7 +38,7 @@ ComponentInterfaceSymbol ImportExportPrefs::GetSymbol() const
    return IMPORT_EXPORT_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString ImportExportPrefs::GetDescription()
+TranslatableString ImportExportPrefs::GetDescription() const
 {
    return XO("Preferences for ImportExport");
 }

--- a/src/prefs/ImportExportPrefs.h
+++ b/src/prefs/ImportExportPrefs.h
@@ -33,7 +33,7 @@ class AUDACITY_DLL_API ImportExportPrefs final : public PrefsPanel
    ImportExportPrefs(wxWindow * parent, wxWindowID winid);
    ~ImportExportPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/ImportExportPrefs.h
+++ b/src/prefs/ImportExportPrefs.h
@@ -32,7 +32,7 @@ class AUDACITY_DLL_API ImportExportPrefs final : public PrefsPanel
 
    ImportExportPrefs(wxWindow * parent, wxWindowID winid);
    ~ImportExportPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/KeyConfigPrefs.cpp
+++ b/src/prefs/KeyConfigPrefs.cpp
@@ -117,7 +117,7 @@ ComponentInterfaceSymbol KeyConfigPrefs::GetSymbol() const
    return KEY_CONFIG_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString KeyConfigPrefs::GetDescription()
+TranslatableString KeyConfigPrefs::GetDescription() const
 {
    return XO("Preferences for KeyConfig");
 }

--- a/src/prefs/KeyConfigPrefs.cpp
+++ b/src/prefs/KeyConfigPrefs.cpp
@@ -112,7 +112,7 @@ KeyConfigPrefs::KeyConfigPrefs(
    Bind(wxEVT_SHOW, &KeyConfigPrefs::OnShow, this);
 }
 
-ComponentInterfaceSymbol KeyConfigPrefs::GetSymbol()
+ComponentInterfaceSymbol KeyConfigPrefs::GetSymbol() const
 {
    return KEY_CONFIG_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/KeyConfigPrefs.h
+++ b/src/prefs/KeyConfigPrefs.h
@@ -36,7 +36,7 @@ public:
       AudacityProject *pProject,
       const CommandID &name);
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    void Cancel() override;

--- a/src/prefs/KeyConfigPrefs.h
+++ b/src/prefs/KeyConfigPrefs.h
@@ -35,7 +35,7 @@ public:
    KeyConfigPrefs(wxWindow * parent, wxWindowID winid,
       AudacityProject *pProject,
       const CommandID &name);
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -61,7 +61,7 @@ ComponentInterfaceSymbol LibraryPrefs::GetSymbol() const
    return LIBRARY_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString LibraryPrefs::GetDescription()
+TranslatableString LibraryPrefs::GetDescription() const
 {
    return XO("Preferences for Library");
 }

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -56,7 +56,7 @@ LibraryPrefs::~LibraryPrefs()
 {
 }
 
-ComponentInterfaceSymbol LibraryPrefs::GetSymbol()
+ComponentInterfaceSymbol LibraryPrefs::GetSymbol() const
 {
    return LIBRARY_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/LibraryPrefs.h
+++ b/src/prefs/LibraryPrefs.h
@@ -29,7 +29,7 @@ class LibraryPrefs final : public PrefsPanel
  public:
    LibraryPrefs(wxWindow * parent, wxWindowID winid);
    ~LibraryPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/LibraryPrefs.h
+++ b/src/prefs/LibraryPrefs.h
@@ -30,7 +30,7 @@ class LibraryPrefs final : public PrefsPanel
    LibraryPrefs(wxWindow * parent, wxWindowID winid);
    ~LibraryPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/MidiIOPrefs.cpp
+++ b/src/prefs/MidiIOPrefs.cpp
@@ -69,7 +69,7 @@ ComponentInterfaceSymbol MidiIOPrefs::GetSymbol() const
    return MIDI_IO_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString MidiIOPrefs::GetDescription()
+TranslatableString MidiIOPrefs::GetDescription() const
 {
    return XO("Preferences for MidiIO");
 }

--- a/src/prefs/MidiIOPrefs.cpp
+++ b/src/prefs/MidiIOPrefs.cpp
@@ -64,7 +64,7 @@ MidiIOPrefs::~MidiIOPrefs()
 {
 }
 
-ComponentInterfaceSymbol MidiIOPrefs::GetSymbol()
+ComponentInterfaceSymbol MidiIOPrefs::GetSymbol() const
 {
    return MIDI_IO_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/MidiIOPrefs.h
+++ b/src/prefs/MidiIOPrefs.h
@@ -30,7 +30,7 @@ class MidiIOPrefs final : public PrefsPanel
    MidiIOPrefs(wxWindow * parent, wxWindowID winid);
    virtual ~MidiIOPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    bool Validate() override;

--- a/src/prefs/MidiIOPrefs.h
+++ b/src/prefs/MidiIOPrefs.h
@@ -29,7 +29,7 @@ class MidiIOPrefs final : public PrefsPanel
  public:
    MidiIOPrefs(wxWindow * parent, wxWindowID winid);
    virtual ~MidiIOPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/ModulePrefs.cpp
+++ b/src/prefs/ModulePrefs.cpp
@@ -41,7 +41,7 @@ ModulePrefs::~ModulePrefs()
 {
 }
 
-ComponentInterfaceSymbol ModulePrefs::GetSymbol()
+ComponentInterfaceSymbol ModulePrefs::GetSymbol() const
 {
    return MODULE_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/ModulePrefs.cpp
+++ b/src/prefs/ModulePrefs.cpp
@@ -46,7 +46,7 @@ ComponentInterfaceSymbol ModulePrefs::GetSymbol() const
    return MODULE_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString ModulePrefs::GetDescription()
+TranslatableString ModulePrefs::GetDescription() const
 {
    return XO("Preferences for Module");
 }

--- a/src/prefs/ModulePrefs.h
+++ b/src/prefs/ModulePrefs.h
@@ -29,7 +29,7 @@ class ModulePrefs final : public PrefsPanel
    ModulePrefs(wxWindow * parent, wxWindowID winid);
    ~ModulePrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/ModulePrefs.h
+++ b/src/prefs/ModulePrefs.h
@@ -28,7 +28,7 @@ class ModulePrefs final : public PrefsPanel
  public:
    ModulePrefs(wxWindow * parent, wxWindowID winid);
    ~ModulePrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/MousePrefs.cpp
+++ b/src/prefs/MousePrefs.cpp
@@ -72,7 +72,7 @@ MousePrefs::~MousePrefs()
 {
 }
 
-ComponentInterfaceSymbol MousePrefs::GetSymbol()
+ComponentInterfaceSymbol MousePrefs::GetSymbol() const
 {
    return MOUSE_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/MousePrefs.cpp
+++ b/src/prefs/MousePrefs.cpp
@@ -77,7 +77,7 @@ ComponentInterfaceSymbol MousePrefs::GetSymbol() const
    return MOUSE_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString MousePrefs::GetDescription()
+TranslatableString MousePrefs::GetDescription() const
 {
    return XO("Preferences for Mouse");
 }

--- a/src/prefs/MousePrefs.h
+++ b/src/prefs/MousePrefs.h
@@ -24,7 +24,7 @@ class MousePrefs final : public PrefsPanel
  public:
    MousePrefs(wxWindow * parent, wxWindowID winid);
    ~MousePrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/MousePrefs.h
+++ b/src/prefs/MousePrefs.h
@@ -25,7 +25,7 @@ class MousePrefs final : public PrefsPanel
    MousePrefs(wxWindow * parent, wxWindowID winid);
    ~MousePrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/PlaybackPrefs.cpp
+++ b/src/prefs/PlaybackPrefs.cpp
@@ -42,7 +42,7 @@ ComponentInterfaceSymbol PlaybackPrefs::GetSymbol() const
    return PLAYBACK_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString PlaybackPrefs::GetDescription()
+TranslatableString PlaybackPrefs::GetDescription() const
 {
    return XO("Preferences for Playback");
 }

--- a/src/prefs/PlaybackPrefs.cpp
+++ b/src/prefs/PlaybackPrefs.cpp
@@ -37,7 +37,7 @@ PlaybackPrefs::~PlaybackPrefs()
 {
 }
 
-ComponentInterfaceSymbol PlaybackPrefs::GetSymbol()
+ComponentInterfaceSymbol PlaybackPrefs::GetSymbol() const
 {
    return PLAYBACK_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/PlaybackPrefs.h
+++ b/src/prefs/PlaybackPrefs.h
@@ -26,7 +26,7 @@ class PlaybackPrefs final : public PrefsPanel
    PlaybackPrefs(wxWindow * parent, wxWindowID winid);
    virtual ~PlaybackPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/PlaybackPrefs.h
+++ b/src/prefs/PlaybackPrefs.h
@@ -25,7 +25,7 @@ class PlaybackPrefs final : public PrefsPanel
  public:
    PlaybackPrefs(wxWindow * parent, wxWindowID winid);
    virtual ~PlaybackPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/PrefsPanel.cpp
+++ b/src/prefs/PrefsPanel.cpp
@@ -65,7 +65,7 @@ struct PrefsItemVisitor final : Registry::Visitor {
 };
 }
 
-PluginPath PrefsPanel::GetPath()
+PluginPath PrefsPanel::GetPath() const
 { return BUILTIN_PREFS_PANEL_PREFIX + GetSymbol().Internal(); }
 
 VendorSymbol PrefsPanel::GetVendor()

--- a/src/prefs/PrefsPanel.cpp
+++ b/src/prefs/PrefsPanel.cpp
@@ -68,7 +68,7 @@ struct PrefsItemVisitor final : Registry::Visitor {
 PluginPath PrefsPanel::GetPath() const
 { return BUILTIN_PREFS_PANEL_PREFIX + GetSymbol().Internal(); }
 
-VendorSymbol PrefsPanel::GetVendor()
+VendorSymbol PrefsPanel::GetVendor() const
 {  return XO("Audacity");}
 
 wxString PrefsPanel::GetVersion()

--- a/src/prefs/PrefsPanel.cpp
+++ b/src/prefs/PrefsPanel.cpp
@@ -71,7 +71,7 @@ PluginPath PrefsPanel::GetPath() const
 VendorSymbol PrefsPanel::GetVendor() const
 {  return XO("Audacity");}
 
-wxString PrefsPanel::GetVersion()
+wxString PrefsPanel::GetVersion() const
 {     return AUDACITY_VERSION_STRING;}
 
 PrefsPanel::Registration::Registration( const wxString &name,

--- a/src/prefs/PrefsPanel.h
+++ b/src/prefs/PrefsPanel.h
@@ -104,7 +104,7 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
 
    virtual PluginPath GetPath() const;
    virtual VendorSymbol GetVendor() const;
-   virtual wxString GetVersion();
+   virtual wxString GetVersion() const;
 
    //virtual ComponentInterfaceSymbol GetSymbol();
    //virtual wxString GetDescription();

--- a/src/prefs/PrefsPanel.h
+++ b/src/prefs/PrefsPanel.h
@@ -102,9 +102,9 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
    virtual bool Commit() = 0; // used to be called "Apply"
 
 
-   virtual PluginPath GetPath() const;
-   virtual VendorSymbol GetVendor() const;
-   virtual wxString GetVersion() const;
+   virtual PluginPath GetPath() const override;
+   virtual VendorSymbol GetVendor() const override;
+   virtual wxString GetVersion() const override;
 
    //virtual ComponentInterfaceSymbol GetSymbol();
    //virtual wxString GetDescription();

--- a/src/prefs/PrefsPanel.h
+++ b/src/prefs/PrefsPanel.h
@@ -102,7 +102,7 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
    virtual bool Commit() = 0; // used to be called "Apply"
 
 
-   virtual PluginPath GetPath();
+   virtual PluginPath GetPath() const;
    virtual VendorSymbol GetVendor();
    virtual wxString GetVersion();
 

--- a/src/prefs/PrefsPanel.h
+++ b/src/prefs/PrefsPanel.h
@@ -103,7 +103,7 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
 
 
    virtual PluginPath GetPath() const;
-   virtual VendorSymbol GetVendor();
+   virtual VendorSymbol GetVendor() const;
    virtual wxString GetVersion();
 
    //virtual ComponentInterfaceSymbol GetSymbol();

--- a/src/prefs/QualityPrefs.cpp
+++ b/src/prefs/QualityPrefs.cpp
@@ -52,7 +52,7 @@ ComponentInterfaceSymbol QualityPrefs::GetSymbol() const
    return QUALITY_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString QualityPrefs::GetDescription()
+TranslatableString QualityPrefs::GetDescription() const
 {
    return XO("Preferences for Quality");
 }

--- a/src/prefs/QualityPrefs.cpp
+++ b/src/prefs/QualityPrefs.cpp
@@ -47,7 +47,7 @@ QualityPrefs::~QualityPrefs()
 {
 }
 
-ComponentInterfaceSymbol QualityPrefs::GetSymbol()
+ComponentInterfaceSymbol QualityPrefs::GetSymbol() const
 {
    return QUALITY_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/QualityPrefs.h
+++ b/src/prefs/QualityPrefs.h
@@ -30,7 +30,7 @@ class AUDACITY_DLL_API QualityPrefs final : public PrefsPanel
  public:
    QualityPrefs(wxWindow * parent, wxWindowID winid);
    virtual ~QualityPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/QualityPrefs.h
+++ b/src/prefs/QualityPrefs.h
@@ -31,7 +31,7 @@ class AUDACITY_DLL_API QualityPrefs final : public PrefsPanel
    QualityPrefs(wxWindow * parent, wxWindowID winid);
    virtual ~QualityPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/RecordingPrefs.cpp
+++ b/src/prefs/RecordingPrefs.cpp
@@ -58,7 +58,7 @@ ComponentInterfaceSymbol RecordingPrefs::GetSymbol() const
    return RECORDING_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString RecordingPrefs::GetDescription()
+TranslatableString RecordingPrefs::GetDescription() const
 {
    return XO("Preferences for Recording");
 }

--- a/src/prefs/RecordingPrefs.cpp
+++ b/src/prefs/RecordingPrefs.cpp
@@ -53,7 +53,7 @@ RecordingPrefs::~RecordingPrefs()
 {
 }
 
-ComponentInterfaceSymbol RecordingPrefs::GetSymbol()
+ComponentInterfaceSymbol RecordingPrefs::GetSymbol() const
 {
    return RECORDING_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/RecordingPrefs.h
+++ b/src/prefs/RecordingPrefs.h
@@ -46,7 +46,7 @@ class RecordingPrefs final : public PrefsPanel
    RecordingPrefs(wxWindow * parent, wxWindowID winid);
    virtual ~RecordingPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/RecordingPrefs.h
+++ b/src/prefs/RecordingPrefs.h
@@ -45,7 +45,7 @@ class RecordingPrefs final : public PrefsPanel
  public:
    RecordingPrefs(wxWindow * parent, wxWindowID winid);
    virtual ~RecordingPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/SpectrumPrefs.cpp
+++ b/src/prefs/SpectrumPrefs.cpp
@@ -72,7 +72,7 @@ ComponentInterfaceSymbol SpectrumPrefs::GetSymbol() const
    return SPECTRUM_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString SpectrumPrefs::GetDescription()
+TranslatableString SpectrumPrefs::GetDescription() const
 {
    return XO("Preferences for Spectrum");
 }

--- a/src/prefs/SpectrumPrefs.cpp
+++ b/src/prefs/SpectrumPrefs.cpp
@@ -67,7 +67,7 @@ SpectrumPrefs::~SpectrumPrefs()
       Rollback();
 }
 
-ComponentInterfaceSymbol SpectrumPrefs::GetSymbol()
+ComponentInterfaceSymbol SpectrumPrefs::GetSymbol() const
 {
    return SPECTRUM_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/SpectrumPrefs.h
+++ b/src/prefs/SpectrumPrefs.h
@@ -44,7 +44,7 @@ class SpectrumPrefs final : public PrefsPanel
    SpectrumPrefs(wxWindow * parent, wxWindowID winid,
       AudacityProject *pProject, WaveTrack *wt);
    virtual ~SpectrumPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    void Preview() override;

--- a/src/prefs/SpectrumPrefs.h
+++ b/src/prefs/SpectrumPrefs.h
@@ -45,7 +45,7 @@ class SpectrumPrefs final : public PrefsPanel
       AudacityProject *pProject, WaveTrack *wt);
    virtual ~SpectrumPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    void Preview() override;
    bool Commit() override;

--- a/src/prefs/ThemePrefs.cpp
+++ b/src/prefs/ThemePrefs.cpp
@@ -88,7 +88,7 @@ ThemePrefs::~ThemePrefs(void)
 {
 }
 
-ComponentInterfaceSymbol ThemePrefs::GetSymbol()
+ComponentInterfaceSymbol ThemePrefs::GetSymbol() const
 {
    return THEME_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/ThemePrefs.cpp
+++ b/src/prefs/ThemePrefs.cpp
@@ -93,7 +93,7 @@ ComponentInterfaceSymbol ThemePrefs::GetSymbol() const
    return THEME_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString ThemePrefs::GetDescription()
+TranslatableString ThemePrefs::GetDescription() const
 {
    return XO("Preferences for Theme");
 }

--- a/src/prefs/ThemePrefs.h
+++ b/src/prefs/ThemePrefs.h
@@ -32,7 +32,7 @@ class ThemePrefs final : public PrefsPanel
  public:
    ThemePrefs(wxWindow * parent, wxWindowID winid);
    ~ThemePrefs(void);
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/ThemePrefs.h
+++ b/src/prefs/ThemePrefs.h
@@ -33,7 +33,7 @@ class ThemePrefs final : public PrefsPanel
    ThemePrefs(wxWindow * parent, wxWindowID winid);
    ~ThemePrefs(void);
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    void Cancel() override;

--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -37,7 +37,7 @@ ComponentInterfaceSymbol TracksBehaviorsPrefs::GetSymbol() const
    return TRACKS_BEHAVIORS_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString TracksBehaviorsPrefs::GetDescription()
+TranslatableString TracksBehaviorsPrefs::GetDescription() const
 {
    return XO("Preferences for TracksBehaviors");
 }

--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -32,7 +32,7 @@ TracksBehaviorsPrefs::~TracksBehaviorsPrefs()
 {
 }
 
-ComponentInterfaceSymbol TracksBehaviorsPrefs::GetSymbol()
+ComponentInterfaceSymbol TracksBehaviorsPrefs::GetSymbol() const
 {
    return TRACKS_BEHAVIORS_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/TracksBehaviorsPrefs.h
+++ b/src/prefs/TracksBehaviorsPrefs.h
@@ -26,7 +26,7 @@ class AUDACITY_DLL_API TracksBehaviorsPrefs final : public PrefsPanel
  public:
    TracksBehaviorsPrefs(wxWindow * parent, wxWindowID winid);
    ~TracksBehaviorsPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/TracksBehaviorsPrefs.h
+++ b/src/prefs/TracksBehaviorsPrefs.h
@@ -27,7 +27,7 @@ class AUDACITY_DLL_API TracksBehaviorsPrefs final : public PrefsPanel
    TracksBehaviorsPrefs(wxWindow * parent, wxWindowID winid);
    ~TracksBehaviorsPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/TracksPrefs.cpp
+++ b/src/prefs/TracksPrefs.cpp
@@ -279,7 +279,7 @@ TracksPrefs::~TracksPrefs()
 {
 }
 
-ComponentInterfaceSymbol TracksPrefs::GetSymbol()
+ComponentInterfaceSymbol TracksPrefs::GetSymbol() const
 {
    return TRACKS_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/TracksPrefs.cpp
+++ b/src/prefs/TracksPrefs.cpp
@@ -284,7 +284,7 @@ ComponentInterfaceSymbol TracksPrefs::GetSymbol() const
    return TRACKS_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString TracksPrefs::GetDescription()
+TranslatableString TracksPrefs::GetDescription() const
 {
    return XO("Preferences for Tracks");
 }

--- a/src/prefs/TracksPrefs.h
+++ b/src/prefs/TracksPrefs.h
@@ -29,7 +29,7 @@ class AUDACITY_DLL_API TracksPrefs final : public PrefsPanel
  public:
    TracksPrefs(wxWindow * parent, wxWindowID winid);
    ~TracksPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/TracksPrefs.h
+++ b/src/prefs/TracksPrefs.h
@@ -30,7 +30,7 @@ class AUDACITY_DLL_API TracksPrefs final : public PrefsPanel
    TracksPrefs(wxWindow * parent, wxWindowID winid);
    ~TracksPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/WarningsPrefs.cpp
+++ b/src/prefs/WarningsPrefs.cpp
@@ -42,7 +42,7 @@ ComponentInterfaceSymbol WarningsPrefs::GetSymbol() const
    return WARNINGS_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString WarningsPrefs::GetDescription()
+TranslatableString WarningsPrefs::GetDescription() const
 {
    return XO("Preferences for Warnings");
 }

--- a/src/prefs/WarningsPrefs.cpp
+++ b/src/prefs/WarningsPrefs.cpp
@@ -37,7 +37,7 @@ WarningsPrefs::~WarningsPrefs()
 {
 }
 
-ComponentInterfaceSymbol WarningsPrefs::GetSymbol()
+ComponentInterfaceSymbol WarningsPrefs::GetSymbol() const
 {
    return WARNINGS_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/WarningsPrefs.h
+++ b/src/prefs/WarningsPrefs.h
@@ -26,7 +26,7 @@ class WarningsPrefs final : public PrefsPanel
  public:
    WarningsPrefs(wxWindow * parent, wxWindowID winid);
    ~WarningsPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
 
    bool Commit() override;

--- a/src/prefs/WarningsPrefs.h
+++ b/src/prefs/WarningsPrefs.h
@@ -27,7 +27,7 @@ class WarningsPrefs final : public PrefsPanel
    WarningsPrefs(wxWindow * parent, wxWindowID winid);
    ~WarningsPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
 
    bool Commit() override;
    ManualPageID HelpPageName() override;

--- a/src/prefs/WaveformPrefs.cpp
+++ b/src/prefs/WaveformPrefs.cpp
@@ -61,7 +61,7 @@ ComponentInterfaceSymbol WaveformPrefs::GetSymbol() const
    return WAVEFORM_PREFS_PLUGIN_SYMBOL;
 }
 
-TranslatableString WaveformPrefs::GetDescription()
+TranslatableString WaveformPrefs::GetDescription() const
 {
    return XO("Preferences for Waveforms");
 }

--- a/src/prefs/WaveformPrefs.cpp
+++ b/src/prefs/WaveformPrefs.cpp
@@ -56,7 +56,7 @@ WaveformPrefs::~WaveformPrefs()
 {
 }
 
-ComponentInterfaceSymbol WaveformPrefs::GetSymbol()
+ComponentInterfaceSymbol WaveformPrefs::GetSymbol() const
 {
    return WAVEFORM_PREFS_PLUGIN_SYMBOL;
 }

--- a/src/prefs/WaveformPrefs.h
+++ b/src/prefs/WaveformPrefs.h
@@ -29,7 +29,7 @@ public:
       AudacityProject *pProject, WaveTrack *wt);
    virtual ~WaveformPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
-   TranslatableString GetDescription() override;
+   TranslatableString GetDescription() const override;
    ManualPageID HelpPageName() override;
 
    bool Commit() override;

--- a/src/prefs/WaveformPrefs.h
+++ b/src/prefs/WaveformPrefs.h
@@ -28,7 +28,7 @@ public:
    WaveformPrefs(wxWindow * parent, wxWindowID winid,
       AudacityProject *pProject, WaveTrack *wt);
    virtual ~WaveformPrefs();
-   ComponentInterfaceSymbol GetSymbol() override;
+   ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() override;
    ManualPageID HelpPageName() override;
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -57,7 +57,7 @@ class SetWaveClipNameCommand : public AudacityCommand
 public:
     static const ComponentInterfaceSymbol Symbol;
 
-    ComponentInterfaceSymbol GetSymbol() override
+    ComponentInterfaceSymbol GetSymbol() const override
     {
         return Symbol;
     }

--- a/src/tracks/ui/CommonTrackControls.cpp
+++ b/src/tracks/ui/CommonTrackControls.cpp
@@ -191,7 +191,7 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    // ComponentInterface overrides
-   ComponentInterfaceSymbol GetSymbol() override
+   ComponentInterfaceSymbol GetSymbol() const override
    { return Symbol; }
    //TranslatableString GetDescription() override {return XO("Sets the track name.");};
    //bool DefineParams( ShuttleParams & S ) override;


### PR DESCRIPTION
Resolves: point 1 of https://github.com/audacity/audacity/issues/2578

Adding const-ness to methods of ComponentsInterface had very extended ripple effects - hundreds of files had to be changed.
Changes were trivial (just adding "const" in the right places), except one case in which I had to declare a member as mutable - but without changing functionality.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
