### PR TITLE
More uses of effect settings

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -163,8 +163,9 @@ EffectProcessor::~EffectProcessor() = default;
 EffectUIValidator::~EffectUIValidator() = default;
 
 DefaultEffectUIValidator::DefaultEffectUIValidator(
-   EffectUIClientInterface &effect)
+   EffectUIClientInterface &effect, EffectSettingsAccess &access)
    : mEffect{effect}
+   , mAccess{access}
 {}
 
 DefaultEffectUIValidator::~DefaultEffectUIValidator()
@@ -174,7 +175,11 @@ DefaultEffectUIValidator::~DefaultEffectUIValidator()
 
 bool DefaultEffectUIValidator::Validate()
 {
-   return mEffect.ValidateUI();
+   bool result {};
+   auto settings = mAccess.Get();
+   result = mEffect.ValidateUI(settings);
+   mAccess.Set(std::move(settings));
+   return result;
 }
 
 EffectUIClientInterface::~EffectUIClientInterface() = default;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -343,7 +343,8 @@ public:
    virtual size_t GetTailSize() = 0;
 
    //! Called for destructive, non-realtime effect computation
-   virtual bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) = 0;
+   virtual bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap = nullptr) = 0;
 
    //! Called for destructive, non-realtime effect computation
    // This may be called during stack unwinding:
@@ -354,7 +355,8 @@ public:
       const float *const *inBlock, float *const *outBlock, size_t blockLen) = 0;
 
    virtual bool RealtimeInitialize(EffectSettings &settings) = 0;
-   virtual bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) = 0;
+   virtual bool RealtimeAddProcessor(
+      EffectSettings &settings, unsigned numChannels, float sampleRate) = 0;
    virtual bool RealtimeFinalize(EffectSettings &settings) noexcept = 0;
    virtual bool RealtimeSuspend() = 0;
    virtual bool RealtimeResume() noexcept = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -401,11 +401,13 @@ public:
 class COMPONENTS_API DefaultEffectUIValidator final : public EffectUIValidator
 {
 public:
-   explicit DefaultEffectUIValidator(EffectUIClientInterface &effect);
+   DefaultEffectUIValidator(
+      EffectUIClientInterface &effect, EffectSettingsAccess &access);
    ~DefaultEffectUIValidator() override;
    bool Validate() override;
 private:
    EffectUIClientInterface &mEffect;
+   EffectSettingsAccess &mAccess;
 };
 
 /*************************************************************************************//**
@@ -456,7 +458,7 @@ public:
 
 protected:
    friend DefaultEffectUIValidator;
-   virtual bool ValidateUI() = 0;
+   virtual bool ValidateUI(EffectSettings &settings) = 0;
    virtual bool CloseUI() = 0;
 };
 

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -131,8 +131,8 @@ public:
    ) = 0;
    virtual bool Startup(EffectUIClientInterface *client) = 0;
 
-   virtual bool TransferDataToWindow() = 0;
-   virtual bool TransferDataFromWindow() = 0;
+   virtual bool TransferDataToWindow(const EffectSettings &settings) = 0;
+   virtual bool TransferDataFromWindow(EffectSettings &settings) = 0;
 };
 
 #endif

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -305,7 +305,7 @@ void EffectAmplify::ClampRatio()
    mNewPeak = LINEAR_TO_DB(mRatio * mPeak);
 }
 
-bool EffectAmplify::TransferDataToWindow()
+bool EffectAmplify::TransferDataToWindow(const EffectSettings &)
 {
    mAmpT->GetValidator()->TransferToWindow();
 
@@ -320,7 +320,7 @@ bool EffectAmplify::TransferDataToWindow()
    return true;
 }
 
-bool EffectAmplify::TransferDataFromWindow()
+bool EffectAmplify::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -180,7 +180,8 @@ bool EffectAmplify::LoadFactoryDefaults()
    }
    mCanClip = false;
 
-   return TransferDataToWindow();
+   ClampRatio();
+   return true;
 }
 
 // Effect implementation
@@ -292,7 +293,7 @@ EffectAmplify::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectAmplify::TransferDataToWindow()
+void EffectAmplify::ClampRatio()
 {
    // limit range of gain
    double dBInit = LINEAR_TO_DB(mRatio);
@@ -301,11 +302,15 @@ bool EffectAmplify::TransferDataToWindow()
       mRatio = DB_TO_LINEAR(dB);
 
    mAmp = LINEAR_TO_DB(mRatio);
+   mNewPeak = LINEAR_TO_DB(mRatio * mPeak);
+}
+
+bool EffectAmplify::TransferDataToWindow()
+{
    mAmpT->GetValidator()->TransferToWindow();
 
    mAmpS->SetValue((int) (mAmp * SCL_Amp + 0.5f));
 
-   mNewPeak = LINEAR_TO_DB(mRatio * mPeak);
    mNewPeakT->GetValidator()->TransferToWindow();
 
    mClip->SetValue(mCanClip);
@@ -330,6 +335,8 @@ bool EffectAmplify::TransferDataFromWindow()
    {
       mRatio = 1.0 / mPeak;
    }
+
+   ClampRatio();
 
    return true;
 }

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -63,6 +63,8 @@ public:
    bool TransferDataFromWindow() override;
 
 private:
+   void ClampRatio();
+
    // EffectAmplify implementation
 
    void OnAmpText(wxCommandEvent & evt);

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -59,8 +59,8 @@ public:
    void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    void ClampRatio();

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -507,7 +507,7 @@ EffectAutoDuck::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectAutoDuck::TransferDataToWindow()
+bool EffectAutoDuck::TransferDataToWindow(const EffectSettings &)
 {
    return DoTransferDataToWindow();
 }
@@ -524,7 +524,7 @@ bool EffectAutoDuck::DoTransferDataToWindow()
    return true;
 }
 
-bool EffectAutoDuck::TransferDataFromWindow()
+bool EffectAutoDuck::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -509,6 +509,11 @@ EffectAutoDuck::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool EffectAutoDuck::TransferDataToWindow()
 {
+   return DoTransferDataToWindow();
+}
+
+bool EffectAutoDuck::DoTransferDataToWindow()
+{
    if (!mUIParent->TransferDataToWindow())
    {
       return false;
@@ -955,7 +960,7 @@ void EffectAutoDuckPanel::OnMotion(wxMouseEvent & evt)
          case none:
             wxASSERT(false); // should not happen
          }
-         mEffect->TransferDataToWindow();
+         mEffect->DoTransferDataToWindow();
          Refresh(false);
       }
    }

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -52,9 +52,9 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
    bool DoTransferDataToWindow();
-   bool TransferDataFromWindow() override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectAutoDuck implementation

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -53,6 +53,7 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
+   bool DoTransferDataToWindow();
    bool TransferDataFromWindow() override;
 
 private:

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -285,7 +285,7 @@ EffectBassTreble::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectBassTreble::TransferDataToWindow()
+bool EffectBassTreble::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -300,7 +300,7 @@ bool EffectBassTreble::TransferDataToWindow()
    return true;
 }
 
-bool EffectBassTreble::TransferDataFromWindow()
+bool EffectBassTreble::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -128,7 +128,8 @@ unsigned EffectBassTreble::GetAudioOutCount()
    return 1;
 }
 
-bool EffectBassTreble::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool EffectBassTreble::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames)
 {
    InstanceInit(mMaster, mSampleRate);
 
@@ -150,7 +151,8 @@ bool EffectBassTreble::RealtimeInitialize(EffectSettings &)
    return true;
 }
 
-bool EffectBassTreble::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sampleRate)
+bool EffectBassTreble::RealtimeAddProcessor(
+   EffectSettings &, unsigned, float sampleRate)
 {
    EffectBassTrebleState slave;
 

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -58,12 +58,14 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    size_t RealtimeProcess(int group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -75,8 +75,8 @@ public:
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
    bool CheckWhetherSkipEffect() override;
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -387,7 +387,7 @@ EffectChangePitch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectChangePitch::TransferDataToWindow()
+bool EffectChangePitch::TransferDataToWindow(const EffectSettings &)
 {
    m_bLoopDetect = true;
 
@@ -416,7 +416,7 @@ bool EffectChangePitch::TransferDataToWindow()
    return true;
 }
 
-bool EffectChangePitch::TransferDataFromWindow()
+bool EffectChangePitch::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -66,8 +66,8 @@ public:
    bool CheckWhetherSkipEffect() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectChangePitch implementation

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -174,7 +174,8 @@ bool EffectChangeSpeed::CheckWhetherSkipEffect()
    return (m_PercentChange == 0.0);
 }
 
-double EffectChangeSpeed::CalcPreviewInputLength(double previewLength)
+double EffectChangeSpeed::CalcPreviewInputLength(
+   const EffectSettings &, double previewLength)
 {
    return previewLength * (100.0 + m_PercentChange) / 100.0;
 }

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -419,7 +419,7 @@ EffectChangeSpeed::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectChangeSpeed::TransferDataToWindow()
+bool EffectChangeSpeed::TransferDataToWindow(const EffectSettings &)
 {
    mbLoopDetect = true;
 
@@ -455,7 +455,7 @@ bool EffectChangeSpeed::TransferDataToWindow()
    return true;
 }
 
-bool EffectChangeSpeed::TransferDataFromWindow()
+bool EffectChangeSpeed::TransferDataFromWindow(EffectSettings &)
 {
    // mUIParent->TransferDataFromWindow() loses some precision, so save and restore it.
    double exactPercent = m_PercentChange;

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -49,7 +49,8 @@ public:
    // Effect implementation
 
    bool CheckWhetherSkipEffect() override;
-   double CalcPreviewInputLength(double previewLength) override;
+   double CalcPreviewInputLength(
+      const EffectSettings &settings, double previewLength) override;
    bool Startup() override;
    bool Init() override;
    bool Process(EffectSettings &settings) override;

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -55,8 +55,8 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataFromWindow() override;
-   bool TransferDataToWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectChangeSpeed implementation

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -332,7 +332,7 @@ EffectChangeTempo::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectChangeTempo::TransferDataToWindow()
+bool EffectChangeTempo::TransferDataToWindow(const EffectSettings &)
 {
    // Reset from length because it can be changed by Preview
    m_FromLength = mT1 - mT0;
@@ -359,7 +359,7 @@ bool EffectChangeTempo::TransferDataToWindow()
    return true;
 }
 
-bool EffectChangeTempo::TransferDataFromWindow()
+bool EffectChangeTempo::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -173,7 +173,8 @@ bool EffectChangeTempo::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-double EffectChangeTempo::CalcPreviewInputLength(double previewLength)
+double EffectChangeTempo::CalcPreviewInputLength(
+   const EffectSettings &, double previewLength)
 {
    return previewLength * (100.0 + m_PercentChange) / 100.0;
 }

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -61,8 +61,8 @@ public:
    double CalcPreviewInputLength(double previewLength) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectChangeTempo implementation

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -58,7 +58,8 @@ public:
    bool Init() override;
    bool CheckWhetherSkipEffect() override;
    bool Process(EffectSettings &settings) override;
-   double CalcPreviewInputLength(double previewLength) override;
+   double CalcPreviewInputLength(
+      const EffectSettings &settings, double previewLength) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -381,7 +381,7 @@ EffectClickRemoval::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectClickRemoval::TransferDataToWindow()
+bool EffectClickRemoval::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -391,7 +391,7 @@ bool EffectClickRemoval::TransferDataToWindow()
    return true;
 }
 
-bool EffectClickRemoval::TransferDataFromWindow()
+bool EffectClickRemoval::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -54,8 +54,8 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    bool ProcessOne(int count, WaveTrack * track,

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -361,7 +361,7 @@ EffectCompressor::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectCompressor::TransferDataToWindow()
+bool EffectCompressor::TransferDataToWindow(const EffectSettings &)
 {
    mThresholdSlider->SetValue(lrint(mThresholdDB));
    mNoiseFloorSlider->SetValue(lrint(mNoiseFloorDB * SCL_NoiseFloor));
@@ -376,7 +376,7 @@ bool EffectCompressor::TransferDataToWindow()
    return true;
 }
 
-bool EffectCompressor::TransferDataFromWindow()
+bool EffectCompressor::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate())
    {

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -382,7 +382,12 @@ bool EffectCompressor::TransferDataFromWindow()
    {
       return false;
    }
+   return DoTransferDataFromWindow();
+}
 
+bool EffectCompressor::DoTransferDataFromWindow()
+{
+   // To do:  eliminate this by using control validators instead
    mThresholdDB = (double) mThresholdSlider->GetValue();
    mNoiseFloorDB = (double) mNoiseFloorSlider->GetValue() / SCL_NoiseFloor;
    mRatio = (double) mRatioSlider->GetValue() / SCL_Ratio;
@@ -664,7 +669,7 @@ float EffectCompressor::DoCompression(float value, double env)
 
 void EffectCompressor::OnSlider(wxCommandEvent & WXUNUSED(evt))
 {
-   TransferDataFromWindow();
+   DoTransferDataFromWindow();
    UpdateUI();
 }
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -51,6 +51,7 @@ public:
    bool Startup() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
+   bool DoTransferDataFromWindow();
    bool TransferDataToWindow() override;
    bool TransferDataFromWindow() override;
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -52,8 +52,8 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool DoTransferDataFromWindow();
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 protected:
    // EffectTwoPassSimpleMono implementation

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -483,7 +483,7 @@ EffectDistortion::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectDistortion::TransferDataToWindow()
+bool EffectDistortion::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -504,7 +504,7 @@ bool EffectDistortion::TransferDataToWindow()
    return true;
 }
 
-bool EffectDistortion::TransferDataFromWindow()
+bool EffectDistortion::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -341,11 +341,6 @@ bool EffectDistortion::LoadFactoryPreset(int id)
    mParams = FactoryPresets[id].params;
    mThreshold = DB_TO_LINEAR(mParams.mThreshold_dB);
 
-   if (mUIDialog)
-   {
-      TransferDataToWindow();
-   }
-
    return true;
 }
 

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -227,7 +227,8 @@ unsigned EffectDistortion::GetAudioOutCount()
    return 1;
 }
 
-bool EffectDistortion::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool EffectDistortion::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    InstanceInit(mMaster, mSampleRate);
    return true;
@@ -248,7 +249,8 @@ bool EffectDistortion::RealtimeInitialize(EffectSettings &)
    return true;
 }
 
-bool EffectDistortion::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sampleRate)
+bool EffectDistortion::RealtimeAddProcessor(
+   EffectSettings &, unsigned, float sampleRate)
 {
    EffectDistortionState slave;
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -96,8 +96,8 @@ public:
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -80,12 +80,14 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    size_t RealtimeProcess(int group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -396,7 +396,7 @@ EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectDtmf::TransferDataToWindow()
+bool EffectDtmf::TransferDataToWindow(const EffectSettings &)
 {
    Recalculate();
 
@@ -414,7 +414,7 @@ bool EffectDtmf::TransferDataToWindow()
    return true;
 }
 
-bool EffectDtmf::TransferDataFromWindow()
+bool EffectDtmf::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -129,7 +129,8 @@ unsigned EffectDtmf::GetAudioOutCount()
    return 1;
 }
 
-bool EffectDtmf::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool EffectDtmf::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    if (dtmfNTones <= 0) {   // Bail if no DTFM sequence.
       ::Effect::MessageBox(

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -57,8 +57,8 @@ public:
    bool Init() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataFromWindow() override;
-   bool TransferDataToWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectDtmf implementation

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -45,7 +45,8 @@ public:
    // EffectProcessor implementation
 
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -91,7 +91,8 @@ unsigned EffectEcho::GetAudioOutCount()
    return 1;
 }
 
-bool EffectEcho::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool EffectEcho::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames)
 {
    if (delay == 0.0)
    {

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -190,7 +190,7 @@ EffectEcho::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectEcho::TransferDataToWindow()
+bool EffectEcho::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -200,7 +200,7 @@ bool EffectEcho::TransferDataToWindow()
    return true;
 }
 
-bool EffectEcho::TransferDataFromWindow()
+bool EffectEcho::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -42,7 +42,8 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -52,8 +52,8 @@ public:
    // Effect implementation
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectEcho implementation

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -923,13 +923,7 @@ bool Effect::SetAutomationParametersFromString(const wxString & parms)
       return true;
       //return false;
    }
-
-   if (!mUIDialog)
-   {
-      return true;
-   }
-
-   return TransferDataToWindow();
+   return true;
 }
 
 unsigned Effect::TestUIFlags(unsigned mask) {

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -584,7 +584,7 @@ Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
       // No custom validator object?  Then use the default, which will pop
       // the event handler when it is destroyed and invokes CloseUI
       mUIParent->PushEventHandler(this);
-      result = std::make_unique<DefaultEffectUIValidator>(*this);
+      result = std::make_unique<DefaultEffectUIValidator>(*this, access);
    }
    return result;
 }
@@ -594,7 +594,7 @@ bool Effect::IsGraphicalUI()
    return false;
 }
 
-bool Effect::ValidateUI()
+bool Effect::ValidateUI(EffectSettings &)
 {
    return mUIParent->Validate();
 }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -851,12 +851,6 @@ bool Effect::Startup()
 bool Effect::GetAutomationParametersAsString(wxString & parms)
 {
    CommandParameters eap;
-
-   if (mUIDialog && !TransferDataFromWindow())
-   {
-      return false;
-   }
-
    ShuttleGetAutomation S;
    S.mpEap = &eap;
    if( DefineParams( S ) ){

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1347,7 +1347,7 @@ bool Effect::ProcessTrack(EffectSettings &settings,
    {
       if (mIsPreview) {
          gPrefs->Read(wxT("/AudioIO/EffectsPreviewLen"), &genDur, 6.0);
-         genDur = wxMin(mDuration, CalcPreviewInputLength(genDur));
+         genDur = std::min(mDuration, CalcPreviewInputLength(settings, genDur));
       }
       else {
          genDur = mDuration;
@@ -2019,7 +2019,8 @@ void Effect::CountWaveTracks()
    mNumGroups = mTracks->SelectedLeaders< const WaveTrack >().size();
 }
 
-double Effect::CalcPreviewInputLength(double previewLength)
+double Effect::CalcPreviewInputLength(
+   const EffectSettings &, double previewLength)
 {
    return previewLength;
 }
@@ -2047,12 +2048,12 @@ void Effect::Preview(EffectSettingsAccess &access, bool dryOnly)
 
    const double rate = mProjectRate;
 
-   if (isNyquist && isGenerator) {
-      previewDuration = CalcPreviewInputLength(previewLen);
-   }
-   else {
-      previewDuration = wxMin(mDuration, CalcPreviewInputLength(previewLen));
-   }
+   const auto &settings = access.Get();
+   if (isNyquist && isGenerator)
+      previewDuration = CalcPreviewInputLength(settings, previewLen);
+   else
+      previewDuration =
+         std::min(mDuration, CalcPreviewInputLength(settings, previewLen));
 
    double t1 = mT0 + previewDuration;
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -318,13 +318,11 @@ size_t Effect::GetTailSize()
    return 0;
 }
 
-bool Effect::ProcessInitialize(sampleCount totalLen, ChannelNames chanMap)
+bool Effect::ProcessInitialize(
+   EffectSettings &settings, sampleCount totalLen, ChannelNames chanMap)
 {
    if (mClient)
-   {
-      return mClient->ProcessInitialize(totalLen, chanMap);
-   }
-
+      return mClient->ProcessInitialize(settings, totalLen, chanMap);
    return true;
 }
 
@@ -359,11 +357,12 @@ bool Effect::RealtimeInitialize(EffectSettings &settings)
    return false;
 }
 
-bool Effect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
+bool Effect::RealtimeAddProcessor(
+   EffectSettings &settings, unsigned numChannels, float sampleRate)
 {
    if (mClient)
    {
-      return mClient->RealtimeAddProcessor(numChannels, sampleRate);
+      return mClient->RealtimeAddProcessor(settings, numChannels, sampleRate);
    }
 
    return true;
@@ -1297,7 +1296,7 @@ bool Effect::ProcessTrack(EffectSettings &settings,
    bool rc = true;
 
    // Give the plugin a chance to initialize
-   if (!ProcessInitialize(len, map))
+   if (!ProcessInitialize(settings, len, map))
    {
       return false;
    }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -1656,12 +1656,12 @@ Effect::PopulateOrExchange(ShuttleGui &, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool Effect::TransferDataToWindow()
+bool Effect::TransferDataToWindow(const EffectSettings &)
 {
    return true;
 }
 
-bool Effect::TransferDataFromWindow()
+bool Effect::TransferDataFromWindow(EffectSettings &)
 {
    return true;
 }

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -276,7 +276,8 @@ protected:
 
    // Most effects just use the previewLength, but time-stretching/compressing
    // effects need to use a different input length, so override this method.
-   virtual double CalcPreviewInputLength(double previewLength);
+   virtual double CalcPreviewInputLength(
+      const EffectSettings &settings, double previewLength);
 
    //! Add controls to effect panel; always succeeds
    /*!

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -159,7 +159,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) final;
    bool IsGraphicalUI() override;
-   bool ValidateUI() override;
+   bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -201,8 +201,8 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
       const EffectSettingsAccessPtr &pAccess //!< Sometimes given; only for UI
    ) override;
    bool Startup(EffectUIClientInterface *client) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
    // Effect implementation
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -132,14 +132,16 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
 
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+         unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -433,8 +433,6 @@ protected:
    // UI
    //! This smart pointer tracks the lifetime of the dialog
    wxWeakRef<wxDialog> mHostUIDialog;
-   //! This weak pointer may be the same as the above, or null
-   wxWeakRef<wxDialog> mUIDialog;
    wxWindow       *mUIParent;
    unsigned       mUIFlags{ 0 };
 
@@ -443,6 +441,9 @@ protected:
  // Used only by the base Effect class
  //
  private:
+   //! This weak pointer may be the same as the above, or null
+   wxWeakRef<wxDialog> mUIDialog;
+
    wxString GetSavedStateGroup();
    double GetDefaultDuration();
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -886,6 +886,7 @@ void EffectUIHost::OnUserPreset(wxCommandEvent & evt)
    auto settings = mpAccess->Get();
    mEffectUIHost.GetDefinition().LoadUserPreset(
       mEffectUIHost.GetUserPresetsGroup(mUserPresets[preset]), settings);
+   TransferDataToWindow();
    // Communicate change of settings
    mpAccess->Set(std::move(settings));
    
@@ -898,9 +899,9 @@ void EffectUIHost::OnFactoryPreset(wxCommandEvent & evt)
    auto settings = mpAccess->Get();
    mEffectUIHost.GetDefinition()
       .LoadFactoryPreset(evt.GetId() - kFactoryPresetsID, settings);
+   TransferDataToWindow();
    // Communicate change of settings
    mpAccess->Set(std::move(settings));
-   
    return;
 }
 
@@ -1006,6 +1007,7 @@ void EffectUIHost::OnSaveAs(wxCommandEvent & WXUNUSED(evt))
 void EffectUIHost::OnImport(wxCommandEvent & WXUNUSED(evt))
 {
    mClient.ImportPresets();
+   TransferDataToWindow();
    
    LoadUserPresets();
    
@@ -1033,6 +1035,7 @@ void EffectUIHost::OnDefaults(wxCommandEvent & WXUNUSED(evt))
    // Make mutable copy
    auto settings = mpAccess->Get();
    mEffectUIHost.GetDefinition().LoadFactoryDefaults(settings);
+   TransferDataToWindow();
    // Communicate change of settings
    mpAccess->Set(std::move(settings));
    return;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -203,12 +203,18 @@ EffectUIHost::~EffectUIHost()
 
 bool EffectUIHost::TransferDataToWindow()
 {
-   return mEffectUIHost.TransferDataToWindow();
+   // Transfer-to takes const reference to settings
+   return mEffectUIHost.TransferDataToWindow(mpAccess->Get());
 }
 
 bool EffectUIHost::TransferDataFromWindow()
 {
-   return mEffectUIHost.TransferDataFromWindow();
+   // Transfer-from takes non-const reference to settings
+   bool result = true;
+   auto settings = mpAccess->Get();
+   result = mEffectUIHost.TransferDataFromWindow(settings);
+   mpAccess->Set(std::move(settings));
+   return result;
 }
 
 // ============================================================================
@@ -734,7 +740,7 @@ void EffectUIHost::OnPlay(wxCommandEvent & WXUNUSED(evt))
 {
    if (!mSupportsRealtime)
    {
-      if (!mpValidator->Validate() || !mEffectUIHost.TransferDataFromWindow())
+      if (!mpValidator->Validate() || !TransferDataFromWindow())
       {
          return;
       }

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -554,12 +554,10 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
       return;
    }
    
-   // This will take care of calling TransferDataFromWindow() for an effect.
-   if (!mEffectUIHost.GetDefinition().SaveUserPreset(
-      mEffectUIHost.GetCurrentSettingsGroup(), mpAccess->Get()))
-   {
+   if (!TransferDataFromWindow() ||
+       !mEffectUIHost.GetDefinition().SaveUserPreset(
+         mEffectUIHost.GetCurrentSettingsGroup(), mpAccess->Get()))
       return;
-   }
 
    if (IsModal())
    {
@@ -994,8 +992,9 @@ void EffectUIHost::OnSaveAs(wxCommandEvent & WXUNUSED(evt))
          }
       }
       
-      mEffectUIHost.GetDefinition().SaveUserPreset(
-         mEffectUIHost.GetUserPresetsGroup(name), mpAccess->Get());
+      if (TransferDataFromWindow())
+         mEffectUIHost.GetDefinition().SaveUserPreset(
+            mEffectUIHost.GetUserPresetsGroup(name), mpAccess->Get());
       LoadUserPresets();
       
       break;
@@ -1018,7 +1017,8 @@ void EffectUIHost::OnExport(wxCommandEvent & WXUNUSED(evt))
 {
    // may throw
    // exceptions are handled in AudacityApp::OnExceptionInMainLoop
-   mClient.ExportPresets();
+   if (TransferDataFromWindow())
+     mClient.ExportPresets();
    
    return;
 }

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -528,12 +528,6 @@ bool EffectEqualization::LoadFactoryPreset(int id)
    ShuttleSetAutomation S;
    S.SetForWriting( &eap );
    DefineParams( S );
-
-   if (mUIDialog)
-   {
-      TransferDataToWindow();
-   }
-
    return true;
 }
 

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -535,7 +535,7 @@ bool EffectEqualization::LoadFactoryPreset(int id)
 
 // EffectUIClientInterface implementation
 
-bool EffectEqualization::ValidateUI()
+bool EffectEqualization::ValidateUI(EffectSettings &)
 {
    // If editing a macro, we don't want to be using the unnamed curve so
    // we offer to save it.

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -1188,7 +1188,7 @@ EffectEqualization::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 //
 // Populate the window with relevant variables
 //
-bool EffectEqualization::TransferDataToWindow()
+bool EffectEqualization::TransferDataToWindow(const EffectSettings &settings)
 {
    // Set log or lin freq scale (affects interpolation as well)
    mLinFreq->SetValue( mLin );

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -1199,13 +1199,9 @@ bool EffectEqualization::TransferDataToWindow()
 
    if( mMSlider )
       mMSlider->SetValue((mM - 1) / 2);
-   mM = 0;                        // force refresh in TransferDataFromWindow()
 
    mdBMinSlider->SetValue((int)mdBMin);
-   mdBMin = 0;                     // force refresh in TransferDataFromWindow()
-
    mdBMaxSlider->SetValue((int)mdBMax);
-   mdBMax = 0;                    // force refresh in TransferDataFromWindow()
 
    // Reload the curve names
    UpdateCurves();
@@ -1233,72 +1229,27 @@ bool EffectEqualization::TransferDataToWindow()
    if (!mDrawMode)
       UpdateGraphic();
 
-   TransferDataFromWindow();
-
    mUIParent->Layout();
    wxGetTopLevelParent(mUIParent)->Layout();
 
    return true;
 }
 
-//
-// Retrieve data from the window
-//
-bool EffectEqualization::TransferDataFromWindow()
+void EffectEqualization::UpdateRuler()
 {
-   wxString tip;
-
-   bool rr = false;
-   float dB = (float) mdBMinSlider->GetValue();
-   if (dB != mdBMin) {
-      rr = true;
-      mdBMin = dB;
-      tip.Printf(_("%d dB"), (int)mdBMin);
-      mdBMinSlider->SetToolTip(tip);
+   // Refresh ruler when values have changed
+   int w1, w2, h;
+   mdBRuler->ruler.GetMaxSize(&w1, &h);
+   mdBRuler->ruler.SetRange(mdBMax, mdBMin);
+   mdBRuler->ruler.GetMaxSize(&w2, &h);
+   if( w1 != w2 )   // Reduces flicker
+   {
+      mdBRuler->SetSize(wxSize(w2,h));
+      mFreqRuler->Refresh(false);
    }
+   mdBRuler->Refresh(false);
 
-   dB = (float) mdBMaxSlider->GetValue();
-   if (dB != mdBMax) {
-      rr = true;
-      mdBMax = dB;
-      tip.Printf(_("%d dB"), (int)mdBMax);
-      mdBMaxSlider->SetToolTip(tip);
-   }
-
-   // Refresh ruler if values have changed
-   if (rr) {
-      int w1, w2, h;
-      mdBRuler->ruler.GetMaxSize(&w1, &h);
-      mdBRuler->ruler.SetRange(mdBMax, mdBMin);
-      mdBRuler->ruler.GetMaxSize(&w2, &h);
-      if( w1 != w2 )   // Reduces flicker
-      {
-         mdBRuler->SetSize(wxSize(w2,h));
-         mFreqRuler->Refresh(false);
-      }
-      mdBRuler->Refresh(false);
-
-      mPanel->Refresh(false);
-   }
-
-   size_t m = DEF_FilterLength; // m must be odd.
-   if (mMSlider )
-      m = 2* mMSlider->GetValue()+1;
-   wxASSERT( (m & 1) ==1 );
-   if (m != mM) {
-      mM = m;
-      ForceRecalc();
-
-      if( mMSlider)
-      {
-         tip.Printf(wxT("%d"), (int)mM);
-         mMText->SetLabel(tip);
-         mMText->SetName(mMText->GetLabel()); // fix for bug 577 (NVDA/Narrator screen readers do not read static text in dialogs)
-         mMSlider->SetToolTip(tip);
-      }
-   }
-
-   return true;
+   mPanel->Refresh(false);
 }
 
 // EffectEqualization implementation
@@ -2886,18 +2837,44 @@ void EffectEqualization::OnGraphicMode(wxCommandEvent & WXUNUSED(event))
 
 void EffectEqualization::OnSliderM(wxCommandEvent & WXUNUSED(event))
 {
-   TransferDataFromWindow();
-   ForceRecalc();
+   size_t m = 2 * mMSlider->GetValue() + 1;
+   // Must be odd
+   wxASSERT( (m & 1) == 1 );
+
+   if (m != mM) {
+      mM = m;
+      wxString tip;
+      tip.Printf(wxT("%d"), (int)mM);
+      mMText->SetLabel(tip);
+      mMText->SetName(mMText->GetLabel()); // fix for bug 577 (NVDA/Narrator screen readers do not read static text in dialogs)
+      mMSlider->SetToolTip(tip);
+
+      ForceRecalc();
+   }
 }
 
 void EffectEqualization::OnSliderDBMIN(wxCommandEvent & WXUNUSED(event))
 {
-   TransferDataFromWindow();
+   float dB = mdBMinSlider->GetValue();
+   if (dB != mdBMin) {
+      mdBMin = dB;
+      wxString tip;
+      tip.Printf(_("%d dB"), (int)mdBMin);
+      mdBMinSlider->SetToolTip(tip);
+      UpdateRuler();
+   }
 }
 
 void EffectEqualization::OnSliderDBMAX(wxCommandEvent & WXUNUSED(event))
 {
-   TransferDataFromWindow();
+   float dB = mdBMaxSlider->GetValue();
+   if (dB != mdBMax) {
+      mdBMax = dB;
+      wxString tip;
+      tip.Printf(_("%d dB"), (int)mdBMax);
+      mdBMaxSlider->SetToolTip(tip);
+      UpdateRuler();
+   }
 }
 
 //

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -132,7 +132,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
 
 private:
    // EffectEqualization implementation
@@ -172,6 +171,7 @@ private:
    void WriteXML(XMLWriter &xmlFile) const;
 
    void UpdateCurves();
+   void UpdateRuler();
    void UpdateDraw();
 
    //void LayoutEQSliders();

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -120,7 +120,7 @@ public:
 
    // EffectUIClientInterface implementation
 
-   bool ValidateUI() override;
+   bool ValidateUI(EffectSettings &) override;
 
    // Effect implementation
 

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -131,7 +131,7 @@ public:
    bool CloseUI() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:
    // EffectEqualization implementation

--- a/src/effects/Fade.cpp
+++ b/src/effects/Fade.cpp
@@ -79,7 +79,8 @@ unsigned EffectFade::GetAudioOutCount()
    return 1;
 }
 
-bool EffectFade::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool EffectFade::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    mSample = 0;
 

--- a/src/effects/Fade.h
+++ b/src/effects/Fade.h
@@ -33,7 +33,8 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -265,7 +265,7 @@ void EffectFindClipping::DoPopulateOrExchange(
    S.EndMultiColumn();
 }
 
-bool EffectFindClipping::TransferDataToWindow()
+bool EffectFindClipping::TransferDataToWindow(const EffectSettings &)
 {
    ShuttleGui S(mUIParent, eIsSettingToDialog);
    // To do: eliminate this and just use validators for controls
@@ -274,7 +274,7 @@ bool EffectFindClipping::TransferDataToWindow()
    return true;
 }
 
-bool EffectFindClipping::TransferDataFromWindow()
+bool EffectFindClipping::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate())
    {

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -49,8 +49,8 @@ public:
       ShuttleGui & S, EffectSettingsAccess &access) override;
    void DoPopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access);
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectFindCliping implementation

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -27,7 +27,7 @@
 
 #include "../widgets/AudacityMessageBox.h"
 
-bool Generator::Process(EffectSettings &)
+bool Generator::Process(EffectSettings &settings)
 {
    if (GetDuration() < 0.0)
       return false;
@@ -71,7 +71,7 @@ bool Generator::Process(EffectSettings &)
             BeforeGenerate();
 
             // Fill it with data
-            if (!GenerateTrack(&*tmp, *track, ntrack))
+            if (!GenerateTrack(settings, &*tmp, *track, ntrack))
                bGoodResult = false;
             else {
                // Transfer the data from the temporary track to the actual one
@@ -116,9 +116,8 @@ bool Generator::Process(EffectSettings &)
    return bGoodResult;
 }
 
-bool BlockGenerator::GenerateTrack(WaveTrack *tmp,
-                                   const WaveTrack &track,
-                                   int ntrack)
+bool BlockGenerator::GenerateTrack(EffectSettings &,
+   WaveTrack *tmp, const WaveTrack &track, int ntrack)
 {
    bool bGoodResult = true;
    numSamples = track.TimeToLongSamples(GetDuration());

--- a/src/effects/Generator.h
+++ b/src/effects/Generator.h
@@ -30,9 +30,8 @@ protected:
    // [ GenerateTrack() must be overridden by the actual generator class ]
    // Precondition:  mDuration > 0.0
    // Postcondition: <tmp> is filled with the data intended for <track>
-   virtual bool GenerateTrack(WaveTrack *tmp,
-                              const WaveTrack &track,
-                              int ntrack) = 0;
+   virtual bool GenerateTrack(EffectSettings &settings,
+      WaveTrack *tmp, const WaveTrack &track, int ntrack) = 0;
 
    bool Init()  override { return true; }
 
@@ -69,7 +68,8 @@ protected:
                               size_t block) = 0;
 
    // Generate the track, one block at a time, & adding the results to tmp
-   bool GenerateTrack(WaveTrack *tmp, const WaveTrack &track, int ntrack) override;
+   bool GenerateTrack(EffectSettings &settings,
+      WaveTrack *tmp, const WaveTrack &track, int ntrack) override;
 };
 
 #endif

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -386,7 +386,7 @@ EffectLoudness::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectLoudness::TransferDataToWindow()
+bool EffectLoudness::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -399,7 +399,7 @@ bool EffectLoudness::TransferDataToWindow()
    return true;
 }
 
-bool EffectLoudness::TransferDataFromWindow()
+bool EffectLoudness::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -57,8 +57,8 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectLoudness implementation

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -262,7 +262,7 @@ EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectNoise::TransferDataToWindow()
+bool EffectNoise::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -274,7 +274,7 @@ bool EffectNoise::TransferDataToWindow()
    return true;
 }
 
-bool EffectNoise::TransferDataFromWindow()
+bool EffectNoise::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -51,8 +51,8 @@ public:
    bool Startup() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectNoise implementation

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -339,7 +339,7 @@ EffectNormalize::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectNormalize::TransferDataToWindow()
+bool EffectNormalize::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -351,7 +351,7 @@ bool EffectNormalize::TransferDataToWindow()
    return true;
 }
 
-bool EffectNormalize::TransferDataFromWindow()
+bool EffectNormalize::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -51,8 +51,8 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectNormalize implementation

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -217,7 +217,7 @@ EffectPaulstretch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 };
 
-bool EffectPaulstretch::TransferDataToWindow()
+bool EffectPaulstretch::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -227,7 +227,7 @@ bool EffectPaulstretch::TransferDataToWindow()
    return true;
 }
 
-bool EffectPaulstretch::TransferDataFromWindow()
+bool EffectPaulstretch::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -157,7 +157,8 @@ bool EffectPaulstretch::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-double EffectPaulstretch::CalcPreviewInputLength(double previewLength)
+double EffectPaulstretch::CalcPreviewInputLength(
+   const EffectSettings &, double previewLength)
 {
    // FIXME: Preview is currently at the project rate, but should really be
    // at the track rate (bugs 1284 and 852).

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -44,8 +44,8 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectPaulstretch implementation

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -40,7 +40,8 @@ public:
 
    // Effect implementation
 
-   double CalcPreviewInputLength(double previewLength) override;
+   double CalcPreviewInputLength(
+      const EffectSettings &settings, double previewLength) override;
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -144,7 +144,8 @@ unsigned EffectPhaser::GetAudioOutCount()
    return 1;
 }
 
-bool EffectPhaser::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames chanMap)
+bool EffectPhaser::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    InstanceInit(mMaster, mSampleRate);
    if (chanMap[0] == ChannelNameFrontRight)
@@ -170,7 +171,8 @@ bool EffectPhaser::RealtimeInitialize(EffectSettings &)
    return true;
 }
 
-bool EffectPhaser::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sampleRate)
+bool EffectPhaser::RealtimeAddProcessor(
+   EffectSettings &, unsigned, float sampleRate)
 {
    EffectPhaserState slave;
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -340,7 +340,7 @@ EffectPhaser::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectPhaser::TransferDataToWindow()
+bool EffectPhaser::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -358,7 +358,7 @@ bool EffectPhaser::TransferDataToWindow()
    return true;
 }
 
-bool EffectPhaser::TransferDataFromWindow()
+bool EffectPhaser::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -64,12 +64,14 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    size_t RealtimeProcess(int group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -80,8 +80,8 @@ public:
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectPhaser implementation

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -238,7 +238,7 @@ bool RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
       }
 
       // Add a NEW processor
-      mEffect->RealtimeAddProcessor(gchans, rate);
+      mEffect->RealtimeAddProcessor(mSettings, gchans, rate);
       mCurrentProcessor++;
    }
 

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -199,7 +199,7 @@ EffectRepeat::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectRepeat::TransferDataToWindow()
+bool EffectRepeat::TransferDataToWindow(const EffectSettings &)
 {
    mRepeatCount->ChangeValue(wxString::Format(wxT("%d"), repeatCount));
 
@@ -208,7 +208,7 @@ bool EffectRepeat::TransferDataToWindow()
    return true;
 }
 
-bool EffectRepeat::TransferDataFromWindow()
+bool EffectRepeat::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate())
    {

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -47,8 +47,8 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectRepeat implementation

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -356,12 +356,6 @@ bool EffectReverb::LoadFactoryPreset(int id)
    }
 
    mParams = FactoryPresets[id].params;
-
-   if (mUIDialog)
-   {
-      TransferDataToWindow();
-   }
-
    return true;
 }
 
@@ -548,12 +542,3 @@ SpinSliderHandlers(DryGain)
 SpinSliderHandlers(StereoWidth)
 
 #undef SpinSliderHandlers
-
-void EffectReverb::SetTitle(const wxString & name)
-{
-   mUIDialog->SetTitle(
-      name.empty()
-         ? _("Reverb")
-         : wxString::Format( _("Reverb: %s"), name )
-   );
-}

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -175,7 +175,8 @@ unsigned EffectReverb::GetAudioOutCount()
 
 static size_t BLOCK = 16384;
 
-bool EffectReverb::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames chanMap)
+bool EffectReverb::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    bool isStereo = false;
    mNumChans = 1;

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -471,7 +471,7 @@ EffectReverb::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectReverb::TransferDataToWindow()
+bool EffectReverb::TransferDataToWindow(const EffectSettings &)
 {
 #define SetSpinSlider(n) \
    m ## n ## S->SetValue((int) mParams.m ## n); \
@@ -494,7 +494,7 @@ bool EffectReverb::TransferDataToWindow()
    return true;
 }
 
-bool EffectReverb::TransferDataFromWindow()
+bool EffectReverb::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate())
    {

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -79,8 +79,6 @@ public:
 private:
    // EffectReverb implementation
 
-   void SetTitle(const wxString & name = {});
-
 #define SpinSliderHandlers(n) \
    void On ## n ## Slider(wxCommandEvent & evt); \
    void On ## n ## Text(wxCommandEvent & evt);

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -61,7 +61,8 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -73,8 +73,8 @@ public:
    bool Startup() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectReverb implementation

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -544,7 +544,7 @@ EffectScienFilter::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 //
 // Populate the window with relevant variables
 //
-bool EffectScienFilter::TransferDataToWindow()
+bool EffectScienFilter::TransferDataToWindow(const EffectSettings &)
 {
    mOrderIndex = mOrder - 1;
 
@@ -564,7 +564,7 @@ bool EffectScienFilter::TransferDataToWindow()
    return TransferGraphLimitsFromWindow();
 }
 
-bool EffectScienFilter::TransferDataFromWindow()
+bool EffectScienFilter::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -217,7 +217,8 @@ unsigned EffectScienFilter::GetAudioOutCount()
    return 1;
 }
 
-bool EffectScienFilter::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool EffectScienFilter::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    for (int iPair = 0; iPair < (mOrder + 1) / 2; iPair++)
       mpBiquad[iPair].Reset();

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -65,8 +65,8 @@ public:
    bool Init() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectScienFilter implementation

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -53,7 +53,8 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -92,14 +92,14 @@ EffectSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectSilence::TransferDataToWindow()
+bool EffectSilence::TransferDataToWindow(const EffectSettings &)
 {
    mDurationT->SetValue(GetDuration());
 
    return true;
 }
 
-bool EffectSilence::TransferDataFromWindow()
+bool EffectSilence::TransferDataFromWindow(EffectSettings &)
 {
    SetDuration(mDurationT->GetValue());
 

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -106,9 +106,8 @@ bool EffectSilence::TransferDataFromWindow(EffectSettings &)
    return true;
 }
 
-bool EffectSilence::GenerateTrack(WaveTrack *tmp,
-                                  const WaveTrack & WXUNUSED(track),
-                                  int WXUNUSED(ntrack))
+bool EffectSilence::GenerateTrack(EffectSettings &,
+   WaveTrack *tmp, const WaveTrack &, int)
 {
    tmp->InsertSilence(0.0, GetDuration());
    return true;

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -45,7 +45,8 @@ public:
 protected:
    // Generator implementation
 
-   bool GenerateTrack(WaveTrack *tmp, const WaveTrack &track, int ntrack) override;
+   bool GenerateTrack(EffectSettings &settings,
+      WaveTrack *tmp, const WaveTrack &track, int ntrack) override;
 
 private:
    NumericTextCtrl *mDurationT;

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -39,8 +39,8 @@ public:
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 protected:
    // Generator implementation

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -310,7 +310,7 @@ EffectTimeScale::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectTimeScale::TransferDataToWindow()
+bool EffectTimeScale::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -323,7 +323,7 @@ bool EffectTimeScale::TransferDataToWindow()
    return true;
 }
 
-bool EffectTimeScale::TransferDataFromWindow()
+bool EffectTimeScale::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -162,7 +162,8 @@ bool EffectTimeScale::Init()
    return true;
 }
 
-double EffectTimeScale::CalcPreviewInputLength(double previewLength)
+double EffectTimeScale::CalcPreviewInputLength(
+   const EffectSettings &, double previewLength)
 {
    double inputLength = Effect::GetDuration();
    if(inputLength == 0.0) {

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -52,8 +52,8 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
    double CalcPreviewInputLength(double previewLength) override;
 
 private:

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -54,7 +54,8 @@ public:
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
-   double CalcPreviewInputLength(double previewLength) override;
+   double CalcPreviewInputLength(
+      const EffectSettings &settings, double previewLength) override;
 
 private:
    // EffectTimeScale implementation

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -162,7 +162,8 @@ unsigned EffectToneGen::GetAudioOutCount()
    return 1;
 }
 
-bool EffectToneGen::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool EffectToneGen::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    mPositionInCycles = 0.0;
    mSample = 0;

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -484,7 +484,7 @@ EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectToneGen::TransferDataToWindow()
+bool EffectToneGen::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -496,7 +496,7 @@ bool EffectToneGen::TransferDataToWindow()
    return true;
 }
 
-bool EffectToneGen::TransferDataFromWindow()
+bool EffectToneGen::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -39,7 +39,8 @@ public:
    // EffectProcessor implementation
 
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -49,8 +49,8 @@ public:
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataFromWindow() override;
-   bool TransferDataToWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectToneGen implementation

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -837,7 +837,7 @@ EffectTruncSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectTruncSilence::TransferDataToWindow()
+bool EffectTruncSilence::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -847,7 +847,7 @@ bool EffectTruncSilence::TransferDataToWindow()
    return true;
 }
 
-bool EffectTruncSilence::TransferDataFromWindow()
+bool EffectTruncSilence::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -243,7 +243,8 @@ bool EffectTruncSilence::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-double EffectTruncSilence::CalcPreviewInputLength(double /* previewLength */)
+double EffectTruncSilence::CalcPreviewInputLength(
+   const EffectSettings &, double /* previewLength */)
 {
    double inputLength = mT1 - mT0;
    double minInputLength = inputLength;

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -52,7 +52,8 @@ public:
 
    // Effect implementation
 
-   double CalcPreviewInputLength(double previewLength) override;
+   double CalcPreviewInputLength(
+      const EffectSettings &settings, double previewLength) override;
    bool Startup() override;
 
    // Analyze a single track to find silences

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -70,8 +70,8 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectTruncSilence implementation

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1729,7 +1729,7 @@ bool VSTEffect::LoadFactoryDefaults()
 // ============================================================================
 
 std::unique_ptr<EffectUIValidator>
-VSTEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
+VSTEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mDialog = static_cast<wxDialog *>(wxGetTopLevelParent(parent));
@@ -1760,7 +1760,7 @@ VSTEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
       BuildPlain();
    }
 
-   return std::make_unique<DefaultEffectUIValidator>(*this);
+   return std::make_unique<DefaultEffectUIValidator>(*this, access);
 }
 
 bool VSTEffect::IsGraphicalUI()
@@ -1768,7 +1768,7 @@ bool VSTEffect::IsGraphicalUI()
    return mGui;
 }
 
-bool VSTEffect::ValidateUI()
+bool VSTEffect::ValidateUI(EffectSettings &)
 {
    if (!mParent->Validate() || !mParent->TransferDataFromWindow())
    {

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -142,14 +142,17 @@ class VSTEffect final : public wxEvtHandler,
    size_t GetBlockSize() const override;
 
    bool IsReady();
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
+   bool DoProcessInitialize(sampleCount totalLen, ChannelNames chanMap);
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -171,7 +171,7 @@ class VSTEffect final : public wxEvtHandler,
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
-   bool ValidateUI() override;
+   bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -854,7 +854,7 @@ bool VST3Effect::IsGraphicalUI()
 }
 
 std::unique_ptr<EffectUIValidator>
-VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &)
+VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &access)
 {
    using namespace Steinberg;
 
@@ -903,12 +903,12 @@ VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &)
          );
       }
 
-      return std::make_unique<DefaultEffectUIValidator>(*this);
+      return std::make_unique<DefaultEffectUIValidator>(*this, access);
    }
    return nullptr;
 }
 
-bool VST3Effect::ValidateUI()
+bool VST3Effect::ValidateUI(EffectSettings &)
 {
    if (mDuration != nullptr)
    {

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -600,7 +600,7 @@ size_t VST3Effect::GetTailSize()
    return 0;
 }
 
-bool VST3Effect::ProcessInitialize(sampleCount, ChannelNames)
+bool VST3Effect::ProcessInitialize(EffectSettings &, sampleCount, ChannelNames)
 {
    using namespace Steinberg;
 
@@ -738,7 +738,8 @@ bool VST3Effect::RealtimeInitialize(EffectSettings &)
    return true;
 }
 
-bool VST3Effect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
+bool VST3Effect::RealtimeAddProcessor(
+   EffectSettings &settings, unsigned numChannels, float sampleRate)
 {
    using namespace Steinberg;
 
@@ -747,7 +748,7 @@ bool VST3Effect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
       auto effect = std::make_unique<VST3Effect>(*this);
       effect->mSetup.processMode = Vst::kRealtime;
       effect->mSetup.sampleRate = sampleRate;
-      if(!effect->ProcessInitialize({0}, nullptr))
+      if(!effect->ProcessInitialize(settings, {0}, nullptr))
          throw std::runtime_error { "VST3 realtime initialization failed" };
 
       mRealtimeGroupProcessors.push_back(std::move(effect));

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -146,7 +146,7 @@ public:
    bool IsGraphicalUI() override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
-   bool ValidateUI() override;
+   bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
    bool CanExportPresets() override;
    void ExportPresets() override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -123,13 +123,15 @@ public:
    size_t GetBlockSize() const override;
    sampleCount GetLatency() override;
    size_t GetTailSize() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -135,7 +135,8 @@ unsigned EffectWahwah::GetAudioOutCount()
    return 1;
 }
 
-bool EffectWahwah::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames chanMap)
+bool EffectWahwah::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    InstanceInit(mMaster, mSampleRate);
 
@@ -162,7 +163,8 @@ bool EffectWahwah::RealtimeInitialize(EffectSettings &)
    return true;
 }
 
-bool EffectWahwah::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sampleRate)
+bool EffectWahwah::RealtimeAddProcessor(
+   EffectSettings &settings, unsigned, float sampleRate)
 {
    EffectWahwahState slave;
 

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -310,7 +310,7 @@ EffectWahwah::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectWahwah::TransferDataToWindow()
+bool EffectWahwah::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -327,7 +327,7 @@ bool EffectWahwah::TransferDataToWindow()
    return true;
 }
 
-bool EffectWahwah::TransferDataFromWindow()
+bool EffectWahwah::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -61,12 +61,14 @@ public:
 
    unsigned GetAudioInCount() override;
    unsigned GetAudioOutCount() override;
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    size_t RealtimeProcess(int group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -77,8 +77,8 @@ public:
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectWahwah implementation

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1659,7 +1659,7 @@ RegistryPaths AudioUnitEffect::GetFactoryPresets() const
 // ============================================================================
 
 std::unique_ptr<EffectUIValidator>
-AudioUnitEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
+AudioUnitEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
 {
    // OSStatus result;
 
@@ -1722,7 +1722,7 @@ AudioUnitEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
       mParent->PushEventHandler(this);
    }
 
-   return std::make_unique<DefaultEffectUIValidator>(*this);
+   return std::make_unique<DefaultEffectUIValidator>(*this, access);
 }
 
 bool AudioUnitEffect::IsGraphicalUI()
@@ -1730,7 +1730,7 @@ bool AudioUnitEffect::IsGraphicalUI()
    return mUIType != wxT("Plain");
 }
 
-bool AudioUnitEffect::ValidateUI()
+bool AudioUnitEffect::ValidateUI(EffectSettings &)
 {
 #if 0
    if (!mParent->Validate())

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1240,7 +1240,8 @@ size_t AudioUnitEffect::GetTailSize()
    return tailTime * mSampleRate;
 }
 
-bool AudioUnitEffect::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool AudioUnitEffect::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    OSStatus result;
 
@@ -1336,12 +1337,13 @@ size_t AudioUnitEffect::ProcessBlock(EffectSettings &,
    return blockLen;
 }
 
-bool AudioUnitEffect::RealtimeInitialize(EffectSettings &)
+bool AudioUnitEffect::RealtimeInitialize(EffectSettings &settings)
 {
-   return ProcessInitialize(0);
+   return ProcessInitialize(settings, 0, nullptr);
 }
 
-bool AudioUnitEffect::RealtimeAddProcessor(unsigned numChannels, float sampleRate)
+bool AudioUnitEffect::RealtimeAddProcessor(
+   EffectSettings &settings, unsigned numChannels, float sampleRate)
 {
    auto slave = std::make_unique<AudioUnitEffect>(mPath, mName, mComponent, this);
    if (!slave->SetHost(NULL))
@@ -1361,7 +1363,7 @@ bool AudioUnitEffect::RealtimeAddProcessor(unsigned numChannels, float sampleRat
    auto pSlave = slave.get();
    mSlaves.push_back(std::move(slave));
 
-   return pSlave->ProcessInitialize(0);
+   return pSlave->ProcessInitialize(settings, 0, nullptr);
 }
 
 bool AudioUnitEffect::RealtimeFinalize(EffectSettings &) noexcept

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -118,7 +118,7 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
-   bool ValidateUI() override;
+   bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -90,14 +90,16 @@ public:
    sampleCount GetLatency() override;
    size_t GetTailSize() override;
 
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1168,7 +1168,7 @@ bool LadspaEffect::LoadFactoryDefaults()
 // ============================================================================
 
 std::unique_ptr<EffectUIValidator>
-LadspaEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
+LadspaEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
 
@@ -1483,7 +1483,7 @@ LadspaEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
    // And let the parent reduce to the NEW minimum if possible
    mParent->SetMinSize({ -1, -1 });
 
-   return std::make_unique<DefaultEffectUIValidator>(*this);
+   return std::make_unique<DefaultEffectUIValidator>(*this, access);
 }
 
 bool LadspaEffect::IsGraphicalUI()
@@ -1491,7 +1491,7 @@ bool LadspaEffect::IsGraphicalUI()
    return false;
 }
 
-bool LadspaEffect::ValidateUI()
+bool LadspaEffect::ValidateUI(EffectSettings &)
 {
    if (!mParent->Validate())
    {

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -942,7 +942,8 @@ size_t LadspaEffect::GetTailSize()
    return 0;
 }
 
-bool LadspaEffect::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool LadspaEffect::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    /* Instantiate the plugin */
    if (!mReady)
@@ -999,7 +1000,8 @@ bool LadspaEffect::RealtimeInitialize(EffectSettings &)
    return true;
 }
 
-bool LadspaEffect::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sampleRate)
+bool LadspaEffect::RealtimeAddProcessor(
+   EffectSettings &, unsigned, float sampleRate)
 {
    LADSPA_Handle slave = InitInstance(sampleRate);
    if (!slave)

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -89,14 +89,16 @@ public:
    sampleCount GetLatency() override;
    size_t GetTailSize() override;
 
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -117,7 +117,7 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
-   bool ValidateUI() override;
+   bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1043,7 +1043,8 @@ size_t LV2Effect::GetTailSize()
    return 0;
 }
 
-bool LV2Effect::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelNames WXUNUSED(chanMap))
+bool LV2Effect::ProcessInitialize(
+   EffectSettings &, sampleCount, ChannelNames chanMap)
 {
    mProcess = InitInstance(mSampleRate);
    if (!mProcess)
@@ -1214,7 +1215,8 @@ return GuardedCall<bool>([&]{
 });
 }
 
-bool LV2Effect::RealtimeAddProcessor(unsigned WXUNUSED(numChannels), float sampleRate)
+bool LV2Effect::RealtimeAddProcessor(
+   EffectSettings &, unsigned, float sampleRate)
 {
    LV2Wrapper *slave = InitInstance(sampleRate);
    if (!slave)

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1522,7 +1522,7 @@ bool LV2Effect::SetAutomationParameters(CommandParameters &parms)
 // ============================================================================
 
 std::unique_ptr<EffectUIValidator>
-LV2Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
+LV2Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mParent = parent;
@@ -1563,7 +1563,7 @@ LV2Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &)
          return nullptr;
    }
 
-   return std::make_unique<DefaultEffectUIValidator>(*this);
+   return std::make_unique<DefaultEffectUIValidator>(*this, access);
 }
 
 bool LV2Effect::IsGraphicalUI()
@@ -1571,7 +1571,7 @@ bool LV2Effect::IsGraphicalUI()
    return mUseGUI;
 }
 
-bool LV2Effect::ValidateUI()
+bool LV2Effect::ValidateUI(EffectSettings &)
 {
    if (!mParent->Validate() || !mParent->TransferDataFromWindow())
    {

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -302,14 +302,16 @@ public:
    sampleCount GetLatency() override;
    size_t GetTailSize() override;
 
-   bool ProcessInitialize(sampleCount totalLen, ChannelNames chanMap = NULL) override;
+   bool ProcessInitialize(EffectSettings &settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
    bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() noexcept override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -330,7 +330,7 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
-   bool ValidateUI() override;
+   bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1093,7 +1093,7 @@ bool NyquistEffect::EnablesDebug()
    return mDebugButton;
 }
 
-bool NyquistEffect::TransferDataToWindow()
+bool NyquistEffect::TransferDataToWindow(const EffectSettings &)
 {
    mUIParent->TransferDataToWindow();
 
@@ -1115,7 +1115,7 @@ bool NyquistEffect::TransferDataToWindow()
    return success;
 }
 
-bool NyquistEffect::TransferDataFromWindow()
+bool NyquistEffect::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -109,8 +109,8 @@ public:
       EffectSettingsAccess &access, bool forceModal = false) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(Settings &settings) override;
 
    // NyquistEffect implementation
    // For Nyquist Workbench support

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -694,7 +694,7 @@ VampEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool VampEffect::TransferDataToWindow()
+bool VampEffect::TransferDataToWindow(const EffectSettings &)
 {
    if (!mUIParent->TransferDataToWindow())
    {
@@ -706,7 +706,7 @@ bool VampEffect::TransferDataToWindow()
    return true;
 }
 
-bool VampEffect::TransferDataFromWindow()
+bool VampEffect::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
    {

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -71,8 +71,8 @@ public:
    void End() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow() override;
-   bool TransferDataFromWindow() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // VampEffect implementation


### PR DESCRIPTION
Resolves: #2629

Pass EffectSettings into still more functions, ultimately to allow elimination of the special setting Effect::mDuration which is common to many effects.  And that will allow elimination of the confusing class EffectHostInterface whose purpose isn't clear.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
