### PR TITLE
point 4 of I2578

### DIFF
--- a/libraries/lib-components/ComponentInterface.h
+++ b/libraries/lib-components/ComponentInterface.h
@@ -82,7 +82,7 @@ public:
    TranslatableString GetName() const;
 
    // Parameters, if defined.  false means no defined parameters.
-   virtual bool DefineParams( ShuttleParams & WXUNUSED(S) ){ return false;};   
+   virtual bool DefineParams( ShuttleParams & WXUNUSED(S) ) { return false;};   
 };
 
 #endif // __AUDACITY_IDENTINTERFACE_H__

--- a/libraries/lib-module-manager/ConfigInterface.cpp
+++ b/libraries/lib-module-manager/ConfigInterface.cpp
@@ -11,7 +11,7 @@
 
 namespace PluginSettings {
 
-bool HasConfigGroup( EffectDefinitionInterface &ident,
+bool HasConfigGroup( const EffectDefinitionInterface &ident,
    PluginSettings::ConfigurationType type,
    const RegistryPath & group)
 {
@@ -20,7 +20,7 @@ bool HasConfigGroup( EffectDefinitionInterface &ident,
    return pluginManager.HasConfigGroup(type, id, group);
 }
 
-bool GetConfigSubgroups( EffectDefinitionInterface &ident,
+bool GetConfigSubgroups( const EffectDefinitionInterface &ident,
    PluginSettings::ConfigurationType type,
    const RegistryPath & group, RegistryPaths &subgroups)
 {
@@ -39,7 +39,7 @@ bool HasConfigValue( EffectDefinitionInterface &ident,
    return pluginManager.HasConfigValue(type, id, group, key);
 }
 
-bool GetConfigValue( EffectDefinitionInterface &ident,
+bool GetConfigValue( const EffectDefinitionInterface& ident,
    PluginSettings::ConfigurationType type,
    const RegistryPath & group, const RegistryPath & key,
    ConfigReference var, ConfigConstReference defval)
@@ -49,7 +49,7 @@ bool GetConfigValue( EffectDefinitionInterface &ident,
    return pluginManager.GetConfigValue(type, id, group, key, var, defval);
 }
 
-bool SetConfigValue( EffectDefinitionInterface &ident,
+bool SetConfigValue( const EffectDefinitionInterface& ident,
    PluginSettings::ConfigurationType type,
    const RegistryPath & group, const RegistryPath & key,
    ConfigConstReference value)
@@ -59,7 +59,7 @@ bool SetConfigValue( EffectDefinitionInterface &ident,
    return pluginManager.SetConfigValue(type, id, group, key, value);
 }
 
-bool RemoveConfigSubgroup( EffectDefinitionInterface &ident,
+bool RemoveConfigSubgroup( const EffectDefinitionInterface &ident,
       PluginSettings::ConfigurationType type,
    const RegistryPath & group)
 {

--- a/libraries/lib-module-manager/ConfigInterface.h
+++ b/libraries/lib-module-manager/ConfigInterface.h
@@ -54,13 +54,13 @@ class EffectDefinitionInterface;
 
 namespace PluginSettings {
 
-MODULE_MANAGER_API bool HasConfigGroup( EffectDefinitionInterface &ident,
+MODULE_MANAGER_API bool HasConfigGroup( const EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group);
-MODULE_MANAGER_API bool GetConfigSubgroups( EffectDefinitionInterface &ident,
+MODULE_MANAGER_API bool GetConfigSubgroups( const EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group,
    RegistryPaths & subgroups);
 
-MODULE_MANAGER_API bool GetConfigValue( EffectDefinitionInterface &ident,
+MODULE_MANAGER_API bool GetConfigValue(const EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group,
    const RegistryPath & key, ConfigReference var, ConfigConstReference value);
 
@@ -70,7 +70,7 @@ MODULE_MANAGER_API bool HasConfigValue( EffectDefinitionInterface &ident,
 
 // GetConfig with default value
 template<typename Value>
-inline bool GetConfig( EffectDefinitionInterface &ident,
+inline bool GetConfig( const EffectDefinitionInterface& ident,
    ConfigurationType type, const RegistryPath & group,
    const RegistryPath & key, Value &var, const Value &defval)
 { return GetConfigValue(ident, type, group, key,
@@ -78,33 +78,33 @@ inline bool GetConfig( EffectDefinitionInterface &ident,
 
 // GetConfig with implicitly converted default value
 template<typename Value, typename ConvertibleToValue>
-inline bool GetConfig( EffectDefinitionInterface &ident,
+inline bool GetConfig( const EffectDefinitionInterface& ident,
    ConfigurationType type, const RegistryPath & group,
    const RegistryPath & key, Value &var, ConvertibleToValue defval)
 { return GetConfig(ident, type, group, key, var, static_cast<Value>(defval)); }
 
 // GetConfig with default value assumed to be Value{}
 template <typename Value>
-inline bool GetConfig( EffectDefinitionInterface &ident,
+inline bool GetConfig( const EffectDefinitionInterface& ident,
    ConfigurationType type, const RegistryPath & group,
    const RegistryPath & key, Value &var)
 {
    return GetConfig(ident, type, group, key, var, Value{});
 }
 
-MODULE_MANAGER_API bool SetConfigValue( EffectDefinitionInterface &ident,
+MODULE_MANAGER_API bool SetConfigValue(const EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group,
    const RegistryPath & key, ConfigConstReference value);
 
 template <typename Value>
-inline bool SetConfig( EffectDefinitionInterface &ident,
+inline bool SetConfig( const EffectDefinitionInterface& ident,
    ConfigurationType type, const RegistryPath & group,
    const RegistryPath & key, const Value &value)
 {
    return SetConfigValue(ident, type, group, key, std::cref(value));
 }
 
-MODULE_MANAGER_API bool RemoveConfigSubgroup( EffectDefinitionInterface &ident,
+MODULE_MANAGER_API bool RemoveConfigSubgroup( const EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group);
 MODULE_MANAGER_API bool RemoveConfig( EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group,

--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -1462,7 +1462,7 @@ PluginID PluginManager::GetID(ComponentInterface *command)
                            command->GetPath());
 }
 
-PluginID PluginManager::GetID(EffectDefinitionInterface *effect)
+PluginID PluginManager::GetID(const EffectDefinitionInterface* effect)
 {
    return wxString::Format(wxT("%s_%s_%s_%s_%s"),
                            GetPluginTypeString(PluginTypeEffect),

--- a/libraries/lib-module-manager/PluginManager.h
+++ b/libraries/lib-module-manager/PluginManager.h
@@ -230,7 +230,7 @@ public:
 
    static PluginID GetID(ModuleInterface *module);
    static PluginID GetID(ComponentInterface *command);
-   static PluginID GetID(EffectDefinitionInterface *effect);
+   static PluginID GetID(const EffectDefinitionInterface* effect);
 
    // This string persists in configuration files
    // So config compatibility will break if it is changed across Audacity versions

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -35,7 +35,7 @@ public:
 
    virtual ~EffectHostInterface();
 
-   virtual EffectDefinitionInterface &GetDefinition() = 0;
+   virtual const EffectDefinitionInterface& GetDefinition() = 0;
 
    virtual double GetDuration() = 0;
    virtual NumericFormatSymbol GetDurationFormat() = 0;

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -35,7 +35,7 @@ public:
 
    virtual ~EffectHostInterface();
 
-   virtual const EffectDefinitionInterface& GetDefinition() = 0;
+   virtual const EffectDefinitionInterface& GetDefinition() const = 0;
 
    virtual double GetDuration() = 0;
    virtual NumericFormatSymbol GetDurationFormat() = 0;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -734,7 +734,7 @@ void Effect::ShowOptions()
 
 // EffectHostInterface implementation
 
-EffectDefinitionInterface &Effect::GetDefinition()
+const EffectDefinitionInterface& Effect::GetDefinition()
 {
    return mClient ? *mClient : *this;
 }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -734,9 +734,12 @@ void Effect::ShowOptions()
 
 // EffectHostInterface implementation
 
-const EffectDefinitionInterface& Effect::GetDefinition()
+const EffectDefinitionInterface& Effect::GetDefinition() const
 {
-   return mClient ? *mClient : *this;
+   if (mClient)
+      return *mClient;
+   else
+      return *this;
 }
 
 double Effect::GetDefaultDuration()

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -171,7 +171,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    // EffectHostInterface implementation
 
-   const EffectDefinitionInterface& GetDefinition() override;
+   const EffectDefinitionInterface& GetDefinition() const override;
    double GetDuration() override;
    NumericFormatSymbol GetDurationFormat() override;
    virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -171,7 +171,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    // EffectHostInterface implementation
 
-   EffectDefinitionInterface &GetDefinition() override;
+   const EffectDefinitionInterface& GetDefinition() override;
    double GetDuration() override;
    NumericFormatSymbol GetDurationFormat() override;
    virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -168,7 +168,8 @@ void EffectManager::GetCommandDefinition(const PluginID & ID, const CommandConte
 {
    ComponentInterface *command = nullptr;
    if (auto effect = GetEffect(ID))
-      command = &effect->GetDefinition();
+      // Fixing this will be a large and difficult thing, so for the time being we only cast the constness away
+      command = const_cast<EffectDefinitionInterface*>(&effect->GetDefinition());
    if( !command )
       command = GetAudacityCommand( ID );
    if( !command )


### PR DESCRIPTION
Resolves: point 4 of https://github.com/audacity/audacity/issues/2578

This is split in two commits - the latter only to highlight a change that may or may not be a temporary solution.

In EffectManager::GetCommandDefinition, a non-const pointer to a ComponentInterface is defined. That can not be turned in a const pointer, because later DefineParams is called on it, and one of the requisites of the original issue (at point 1) is that the latter stays non-const (not that it would be easy to make it const, anyway) - hence the const_cast.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
