### PR TITLE
Eliminate Effect::mDurationFormat; New event handling for DTMF generator

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -176,9 +176,9 @@ DefaultEffectUIValidator::~DefaultEffectUIValidator()
 bool DefaultEffectUIValidator::Validate()
 {
    bool result {};
-   auto settings = mAccess.Get();
-   result = mEffect.ValidateUI(settings);
-   mAccess.Set(std::move(settings));
+   mAccess.ModifySettings([&](EffectSettings &settings){
+      result = mEffect.ValidateUI(settings);
+   });
    return result;
 }
 

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -173,7 +173,7 @@ DefaultEffectUIValidator::~DefaultEffectUIValidator()
    mEffect.CloseUI();
 }
 
-bool DefaultEffectUIValidator::Validate()
+bool DefaultEffectUIValidator::ValidateUI()
 {
    bool result {};
    mAccess.ModifySettings([&](EffectSettings &settings){

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -162,6 +162,11 @@ EffectProcessor::~EffectProcessor() = default;
 
 EffectUIValidator::~EffectUIValidator() = default;
 
+bool EffectUIValidator::UpdateUI()
+{
+   return true;
+}
+
 DefaultEffectUIValidator::DefaultEffectUIValidator(
    EffectUIClientInterface &effect, EffectSettingsAccess &access)
    : mEffect{effect}

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -414,7 +414,7 @@ public:
    /*!
     @return true only if panel settings are acceptable
     */
-   virtual bool Validate() = 0;
+   virtual bool ValidateUI() = 0;
 };
 
 /*************************************************************************************//**
@@ -435,7 +435,8 @@ public:
    DefaultEffectUIValidator(
       EffectUIClientInterface &effect, EffectSettingsAccess &access);
    ~DefaultEffectUIValidator() override;
-   bool Validate() override;
+   //! Calls mEffect.ValidateUI()
+   bool ValidateUI() override;
 private:
    EffectUIClientInterface &mEffect;
    EffectSettingsAccess &mAccess;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -64,9 +64,20 @@ typedef enum EffectType : int
 
 using EffectFamilySymbol = ComponentInterfaceSymbol;
 
+//! Non-polymorphic package of settings values common to many effects
+class EffectSettingsExtra final {
+};
+
 //! Externalized state of a plug-in
 struct EffectSettings : audacity::TypedAny<EffectSettings> {
    using TypedAny::TypedAny;
+   EffectSettingsExtra extra;
+
+   void swap(EffectSettings &other)
+   {
+      TypedAny::swap(other);
+      std::swap(extra, other.extra);
+   }
 };
 
 //! Interface for accessing an EffectSettings that may change asynchronously in

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -410,11 +410,20 @@ class COMPONENTS_API EffectUIValidator /* not final */
 {
 public:
    virtual ~EffectUIValidator();
+
    //! Get settings data from the panel; may make error dialogs and return false
    /*!
     @return true only if panel settings are acceptable
     */
    virtual bool ValidateUI() = 0;
+
+   //! Update appearance of the panel for changes in settings
+   /*!
+    Default implementation does nothing, returns true
+
+    @return true if successful
+    */
+   virtual bool UpdateUI();
 };
 
 /*************************************************************************************//**

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -79,6 +79,19 @@ public:
    virtual ~EffectSettingsAccess();
    virtual const EffectSettings &Get() = 0;
    virtual void Set(EffectSettings &&settings) = 0;
+
+   //! Do a correct read-modify-write of settings
+   /*!
+    @param function takes EffectSettings & and its return is ignored.
+    If it throws an exception, then the settings will not be updated.
+    Thus, a strong exception safety guarantee.
+    */
+   template<typename Function>
+   void ModifySettings(Function &&function) {
+      auto settings = this->Get();
+      std::forward<Function>(function)(settings);
+      this->Set(std::move(settings));
+   }
 };
 
 //! Implementation of EffectSettings for cases where there is only one thread.

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -48,6 +48,7 @@
 
 #include "TypedAny.h"
 #include <memory>
+#include <wx/event.h>
 
 class ShuttleGui;
 
@@ -438,7 +439,10 @@ public:
  state only for the lifetime of a dialog, so the effect object need not hold it
 
 *******************************************************************************************/
-class COMPONENTS_API DefaultEffectUIValidator final : public EffectUIValidator
+class COMPONENTS_API DefaultEffectUIValidator
+   : public EffectUIValidator
+   // Inherit wxEvtHandler so that Un-Bind()-ing is automatic in the destructor
+   , wxEvtHandler
 {
 public:
    DefaultEffectUIValidator(
@@ -446,7 +450,15 @@ public:
    ~DefaultEffectUIValidator() override;
    //! Calls mEffect.ValidateUI()
    bool ValidateUI() override;
-private:
+protected:
+   // Convenience function template for binding event handler functions
+   template<typename EventTag, typename Class, typename Event>
+   void BindTo(
+      wxEvtHandler &src, const EventTag& eventType, void (Class::*pmf)(Event &))
+   {
+      src.Bind(eventType, pmf, static_cast<Class *>(this));
+   }
+
    EffectUIClientInterface &mEffect;
    EffectSettingsAccess &mAccess;
 };

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -66,6 +66,13 @@ using EffectFamilySymbol = ComponentInterfaceSymbol;
 
 //! Non-polymorphic package of settings values common to many effects
 class EffectSettingsExtra final {
+public:
+   const NumericFormatSymbol& GetDurationFormat() const
+      { return mDurationFormat; }
+   void SetDurationFormat(const NumericFormatSymbol &durationFormat)
+      { mDurationFormat = durationFormat; }
+private:
+   NumericFormatSymbol mDurationFormat{};
 };
 
 //! Externalized state of a plug-in

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -126,6 +126,8 @@ public:
    virtual bool Startup(EffectUIClientInterface *client) = 0;
 
    virtual bool TransferDataToWindow(const EffectSettings &settings) = 0;
+
+   //! Update the given settings from controls
    virtual bool TransferDataFromWindow(EffectSettings &settings) = 0;
 };
 

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -38,7 +38,6 @@ public:
    virtual const EffectDefinitionInterface& GetDefinition() const = 0;
 
    virtual double GetDuration() = 0;
-   virtual NumericFormatSymbol GetDurationFormat() = 0;
    virtual void SetDuration(double seconds) = 0;
 };
 

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -125,6 +125,7 @@ public:
    ) = 0;
    virtual bool Startup(EffectUIClientInterface *client) = 0;
 
+   //! Update controls for the settings
    virtual bool TransferDataToWindow(const EffectSettings &settings) = 0;
 
    //! Update the given settings from controls

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -322,11 +322,6 @@ bool EffectAmplify::TransferDataToWindow(const EffectSettings &)
 
 bool EffectAmplify::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    mRatio = DB_TO_LINEAR(std::clamp<double>(
       mAmp * SCL_Amp, MIN_Amp * SCL_Amp, MAX_Amp * SCL_Amp) / SCL_Amp);
 

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -297,7 +297,7 @@ void EffectAmplify::ClampRatio()
 {
    // limit range of gain
    double dBInit = LINEAR_TO_DB(mRatio);
-   double dB = TrapDouble(dBInit, MIN_Amp, MAX_Amp);
+   double dB = std::clamp<double>(dBInit, MIN_Amp, MAX_Amp);
    if (dB != dBInit)
       mRatio = DB_TO_LINEAR(dB);
 
@@ -327,7 +327,8 @@ bool EffectAmplify::TransferDataFromWindow(EffectSettings &)
       return false;
    }
 
-   mRatio = DB_TO_LINEAR(TrapDouble(mAmp * SCL_Amp, MIN_Amp * SCL_Amp, MAX_Amp * SCL_Amp) / SCL_Amp);
+   mRatio = DB_TO_LINEAR(std::clamp<double>(
+      mAmp * SCL_Amp, MIN_Amp * SCL_Amp, MAX_Amp * SCL_Amp) / SCL_Amp);
 
    mCanClip = mClip->GetValue();
 
@@ -356,7 +357,8 @@ void EffectAmplify::OnAmpText(wxCommandEvent & WXUNUSED(evt))
       return;
    }
 
-   mRatio = DB_TO_LINEAR(TrapDouble(mAmp * SCL_Amp, MIN_Amp * SCL_Amp, MAX_Amp * SCL_Amp) / SCL_Amp);
+   mRatio = DB_TO_LINEAR(std::clamp<double>(
+      mAmp * SCL_Amp, MIN_Amp * SCL_Amp, MAX_Amp * SCL_Amp) / SCL_Amp);
 
    mAmpS->SetValue((int) (LINEAR_TO_DB(mRatio) * SCL_Amp + 0.5));
 
@@ -380,7 +382,7 @@ void EffectAmplify::OnPeakText(wxCommandEvent & WXUNUSED(evt))
       mRatio = DB_TO_LINEAR(mNewPeak) / mPeak;
 
    double ampInit = LINEAR_TO_DB(mRatio);
-   mAmp = TrapDouble(ampInit, MIN_Amp, MAX_Amp);
+   mAmp = std::clamp<double>(ampInit, MIN_Amp, MAX_Amp);
    if (mAmp != ampInit)
       mRatio = DB_TO_LINEAR(mAmp);
 
@@ -394,10 +396,10 @@ void EffectAmplify::OnPeakText(wxCommandEvent & WXUNUSED(evt))
 void EffectAmplify::OnAmpSlider(wxCommandEvent & evt)
 {
    double dB = evt.GetInt() / SCL_Amp;
-   mRatio = DB_TO_LINEAR(TrapDouble(dB, MIN_Amp, MAX_Amp));
+   mRatio = DB_TO_LINEAR(std::clamp<double>(dB, MIN_Amp, MAX_Amp));
 
    double dB2 = (evt.GetInt() - 1) / SCL_Amp;
-   double ratio2 = DB_TO_LINEAR(TrapDouble(dB2, MIN_Amp, MAX_Amp));
+   double ratio2 = DB_TO_LINEAR(std::clamp<double>(dB2, MIN_Amp, MAX_Amp));
 
    if (!mClip->GetValue() && mRatio * mPeak > 1.0 && ratio2 * mPeak < 1.0)
    {

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -906,23 +906,28 @@ void EffectAutoDuckPanel::OnMotion(wxMouseEvent & evt)
          {
          case outerFadeDown:
             newValue = ((double)(FADE_DOWN_START - evt.GetX())) / FADE_SCALE;
-            mEffect->mOuterFadeDownLen = TrapDouble(newValue, MIN_OuterFadeDownLen, MAX_OuterFadeDownLen);
+            mEffect->mOuterFadeDownLen =
+               std::clamp<double>(newValue, MIN_OuterFadeDownLen, MAX_OuterFadeDownLen);
             break;
          case outerFadeUp:
             newValue = ((double)(evt.GetX() - FADE_UP_START)) / FADE_SCALE;
-            mEffect->mOuterFadeUpLen = TrapDouble(newValue, MIN_OuterFadeUpLen, MAX_OuterFadeUpLen);
+            mEffect->mOuterFadeUpLen =
+               std::clamp<double>(newValue, MIN_OuterFadeUpLen, MAX_OuterFadeUpLen);
             break;
          case innerFadeDown:
             newValue = ((double)(evt.GetX() - FADE_DOWN_START)) / FADE_SCALE;
-            mEffect->mInnerFadeDownLen = TrapDouble(newValue, MIN_InnerFadeDownLen, MAX_InnerFadeDownLen);
+            mEffect->mInnerFadeDownLen =
+               std::clamp<double>(newValue, MIN_InnerFadeDownLen, MAX_InnerFadeDownLen);
             break;
          case innerFadeUp:
             newValue = ((double)(FADE_UP_START - evt.GetX())) / FADE_SCALE;
-            mEffect->mInnerFadeUpLen = TrapDouble(newValue, MIN_InnerFadeUpLen, MAX_InnerFadeUpLen);
+            mEffect->mInnerFadeUpLen =
+               std::clamp<double>(newValue, MIN_InnerFadeUpLen, MAX_InnerFadeUpLen);
             break;
          case duckAmount:
             newValue = ((double)(DUCK_AMOUNT_START - evt.GetY())) / DUCK_AMOUNT_SCALE;
-            mEffect->mDuckAmountDb = TrapDouble(newValue, MIN_DuckAmountDb, MAX_DuckAmountDb);
+            mEffect->mDuckAmountDb =
+               std::clamp<double>(newValue, MIN_DuckAmountDb, MAX_DuckAmountDb);
             break;
          case none:
             wxASSERT(false); // should not happen

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -491,16 +491,6 @@ bool EffectAutoDuck::DoTransferDataToWindow()
    return true;
 }
 
-bool EffectAutoDuck::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 // EffectAutoDuck implementation
 
 // this currently does an exponential fade

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -481,13 +481,7 @@ bool EffectAutoDuck::TransferDataToWindow(const EffectSettings &)
 
 bool EffectAutoDuck::DoTransferDataToWindow()
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mPanel->Refresh(false);
-
    return true;
 }
 

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -53,7 +53,6 @@ public:
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool DoTransferDataToWindow();
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectAutoDuck implementation

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -302,17 +302,6 @@ bool EffectBassTreble::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectBassTreble::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
-
 // EffectBassTreble implementation
 
 void EffectBassTreble::InstanceInit(EffectBassTrebleState & data, float sampleRate)

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -289,16 +289,10 @@ EffectBassTreble::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool EffectBassTreble::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mBassS->SetValue((int) (mBass * SCL_Bass));
    mTrebleS->SetValue((int) mTreble *SCL_Treble);
    mGainS->SetValue((int) mGain * SCL_Gain);
    mLinkCheckBox->SetValue(mLink);
-
    return true;
 }
 

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -78,7 +78,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
    bool CheckWhetherSkipEffect() override;
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -418,11 +418,6 @@ bool EffectChangePitch::TransferDataToWindow(const EffectSettings &)
 
 bool EffectChangePitch::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    // from/to pitch controls
    m_nFromPitch = m_pChoice_FromPitch->GetSelection();
    m_nFromOctave = m_pSpin_FromOctave->GetValue();

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -391,11 +391,6 @@ bool EffectChangePitch::TransferDataToWindow(const EffectSettings &)
 {
    m_bLoopDetect = true;
 
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    Calc_SemitonesChange_fromPercentChange();
    Calc_ToPitch(); // Call *after* m_dSemitonesChange is updated.
    Calc_ToFrequency();

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -381,11 +381,6 @@ bool EffectChangeSpeed::TransferDataToWindow(const EffectSettings &)
 {
    mbLoopDetect = true;
 
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    if (mFromVinyl == kVinyl_NA)
    {
       mFromVinyl = kVinyl_33AndAThird;

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -417,10 +417,6 @@ bool EffectChangeSpeed::TransferDataFromWindow(EffectSettings &)
 {
    // mUIParent->TransferDataFromWindow() loses some precision, so save and restore it.
    double exactPercent = m_PercentChange;
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
    m_PercentChange = exactPercent;
 
    SetConfig(GetDefinition(), PluginSettings::Private,

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -789,7 +789,7 @@ void EffectChangeSpeed::Update_TimeCtrl_ToLength()
    // Negative times do not make sense.
    // 359999 = 99h:59m:59s which is a little less disturbing than overflow characters
    // though it may still look a bit strange with some formats.
-   mToLength = TrapDouble(mToLength, 0.0, 359999.0);
+   mToLength = std::clamp<double>(mToLength, 0.0, 359999.0);
    mpToLengthCtrl->SetValue(mToLength);
 }
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -340,11 +340,6 @@ bool EffectChangeTempo::TransferDataToWindow(const EffectSettings &)
 
    m_bLoopDetect = true;
 
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    // percent change controls
    Update_Slider_PercentChange();
    Update_Text_ToBPM();

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -360,16 +360,6 @@ bool EffectChangeTempo::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectChangeTempo::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 // handler implementations for EffectChangeTempo
 
 void EffectChangeTempo::OnText_PercentChange(wxCommandEvent & WXUNUSED(evt))

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -63,7 +63,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectChangeTempo implementation

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -345,16 +345,6 @@ EffectClickRemoval::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectClickRemoval::TransferDataToWindow(const EffectSettings &)
-{
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 void EffectClickRemoval::OnWidthText(wxCommandEvent & WXUNUSED(evt))
 {
    mWidthT->GetValidator()->TransferFromWindow();

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -355,16 +355,6 @@ bool EffectClickRemoval::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectClickRemoval::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 void EffectClickRemoval::OnWidthText(wxCommandEvent & WXUNUSED(evt))
 {
    mWidthT->GetValidator()->TransferFromWindow();

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -54,7 +54,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    bool ProcessOne(int count, WaveTrack * track,

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -53,7 +53,6 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:
    bool ProcessOne(int count, WaveTrack * track,

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -345,10 +345,6 @@ bool EffectCompressor::TransferDataToWindow(const EffectSettings &)
 
 bool EffectCompressor::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate())
-   {
-      return false;
-   }
    return DoTransferDataFromWindow();
 }
 

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -487,11 +487,6 @@ EffectDistortion::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool EffectDistortion::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mThresholdS->SetValue((int) (mThreshold * SCL_Threshold_dB + 0.5));
    mDCBlockCheckBox->SetValue(mParams.mDCBlock);
    mNoiseFloorS->SetValue((int) mParams.mNoiseFloor + 0.5);

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -508,13 +508,7 @@ bool EffectDistortion::TransferDataToWindow(const EffectSettings &)
 
 bool EffectDistortion::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    mThreshold = DB_TO_LINEAR(mParams.mThreshold_dB);
-
    return true;
 }
 

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -388,11 +388,6 @@ bool EffectDtmf::TransferDataToWindow(const EffectSettings &)
 bool EffectDtmf::TransferDataFromWindow(EffectSettings &)
 {
    auto &dtmfSettings = mSettings;
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    dtmfSettings.dtmfDutyCycle =
       (double) mDtmfDutyCycleS->GetValue() / SCL_DutyCycle;
    SetDuration(mDtmfDurationT->GetValue());

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -80,7 +80,6 @@ namespace{ BuiltinEffectsModule::Registration< EffectDtmf > reg; }
 
 BEGIN_EVENT_TABLE(EffectDtmf, wxEvtHandler)
     EVT_TEXT(ID_Sequence, EffectDtmf::OnSequence)
-    EVT_TEXT(ID_DutyCycle, EffectDtmf::OnAmplitude)
     EVT_TEXT(ID_Duration, EffectDtmf::OnDuration)
     EVT_SLIDER(ID_DutyCycle, EffectDtmf::OnDutyCycle)
 END_EVENT_TABLE()
@@ -291,13 +290,6 @@ bool EffectDtmf::SetAutomationParameters(CommandParameters & parms)
 
 // Effect implementation
 
-bool EffectDtmf::Init()
-{
-   Recalculate();
-
-   return true;
-}
-
 std::unique_ptr<EffectUIValidator>
 EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 {
@@ -373,8 +365,6 @@ EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 
 bool EffectDtmf::TransferDataToWindow(const EffectSettings &)
 {
-   Recalculate();
-
    if (!mUIParent->TransferDataToWindow())
    {
       return false;
@@ -408,6 +398,8 @@ bool EffectDtmf::TransferDataFromWindow(EffectSettings &)
 
 // EffectDtmf implementation
 
+// Updates dtmfNTones, dtmfTone, dtmfSilence, and sometimes duration
+// They depend on dtmfSequence, dtmfDutyCycle, and duration
 void EffectDtmf::Recalculate()
 {
    // remember that dtmfDutyCycle is in range (0.0-100.0)
@@ -595,15 +587,6 @@ void EffectDtmf::OnSequence(wxCommandEvent & WXUNUSED(evt))
    UpdateUI();
 }
 
-void EffectDtmf::OnAmplitude(wxCommandEvent & WXUNUSED(evt))
-{
-   if (!mDtmfAmplitudeT->GetValidator()->TransferFromWindow())
-   {
-      return;
-   }
-   Recalculate();
-   UpdateUI();
-}
 void EffectDtmf::OnDuration(wxCommandEvent & WXUNUSED(evt))
 {
    SetDuration(mDtmfDurationT->GetValue());

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -299,8 +299,10 @@ bool EffectDtmf::Init()
 }
 
 std::unique_ptr<EffectUIValidator>
-EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 {
+   auto &settings = access.Get();
+
    // dialog will be passed values from effect
    // Effect retrieves values from saved config
    // Dialog will take care of using them to initialize controls
@@ -326,10 +328,11 @@ EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
          .AddTextBox(XXO("&Amplitude (0-1):"), wxT(""), 10);
 
       S.AddPrompt(XXO("&Duration:"));
+      auto &extra = settings.extra;
       mDtmfDurationT = safenew
          NumericTextCtrl(S.GetParent(), ID_Duration,
                          NumericConverter::TIME,
-                         GetDurationFormat(),
+                         extra.GetDurationFormat(),
                          GetDuration(),
                          mProjectRate,
                          NumericTextCtrl::Options{}

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -370,12 +370,6 @@ EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 bool EffectDtmf::TransferDataToWindow(const EffectSettings &)
 {
    auto &dtmfSettings = mSettings;
-
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mDtmfDutyCycleS->SetValue(dtmfSettings.dtmfDutyCycle * SCL_DutyCycle);
 
    mDtmfDurationT->SetValue(GetDuration());

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -65,7 +65,6 @@ private:
    bool MakeDtmfTone(float *buffer, size_t len, float fs,
                      wxChar tone, sampleCount last,
                      sampleCount total, float amplitude);
-   void Recalculate();
 
    void UpdateUI();
 
@@ -83,12 +82,24 @@ private:
    bool isTone;                     // true if block is tone, otherwise silence
    int curSeqPos;                   // index into dtmf tone string
 
-   wxString dtmfSequence;             // dtmf tone string
-   int    dtmfNTones;               // total number of tones to generate
-   double dtmfTone;                 // duration of a single tone in ms
-   double dtmfSilence;              // duration of silence between tones in ms
-   double dtmfDutyCycle;            // ratio of dtmfTone/(dtmfTone+dtmfSilence)
-   double dtmfAmplitude;            // amplitude of dtmf tone sequence, restricted to (0-1)
+public:
+   struct Settings {
+      static constexpr auto DefaultSequence = "audacity";
+      static constexpr double DefaultDutyCycle = 55.0;
+      static constexpr double DefaultAmplitude = 0.8;
+
+      wxString dtmfSequence{DefaultSequence}; // dtmf tone string
+      int    dtmfNTones = dtmfSequence.length(); // total number of tones to generate
+      double dtmfTone{};               // duration of a single tone in ms
+      double dtmfSilence{};            // duration of silence between tones in ms
+      double dtmfDutyCycle{DefaultDutyCycle}; // ratio of dtmfTone/(dtmfTone+dtmfSilence)
+      double dtmfAmplitude{DefaultAmplitude}; // amplitude of dtmf tone sequence, restricted to (0-1)
+
+      void Recalculate(Effect &effect);
+   };
+
+private:
+   Settings mSettings;
 
    wxTextCtrl *mDtmfSequenceT;
    wxSlider   *mDtmfDutyCycleS;

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -56,8 +56,6 @@ public:
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectDtmf implementation
@@ -65,12 +63,6 @@ private:
    bool MakeDtmfTone(float *buffer, size_t len, float fs,
                      wxChar tone, sampleCount last,
                      sampleCount total, float amplitude);
-
-   void UpdateUI();
-
-   void OnSequence(wxCommandEvent & evt);
-   void OnDuration(wxCommandEvent & evt);
-   void OnDutyCycle(wxCommandEvent & evt);
 
 private:
    sampleCount numSamplesSequence;  // total number of samples to generate
@@ -100,15 +92,6 @@ public:
 
 private:
    Settings mSettings;
-
-   wxTextCtrl *mDtmfSequenceT;
-   wxSlider   *mDtmfDutyCycleS;
-   NumericTextCtrl *mDtmfDurationT;
-   wxStaticText *mDtmfToneT;
-   wxStaticText *mDtmfSilenceT;
-   wxStaticText *mDtmfDutyT;
-
-   DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -54,7 +54,6 @@ public:
 
    // Effect implementation
 
-   bool Init() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
@@ -71,7 +70,6 @@ private:
    void UpdateUI();
 
    void OnSequence(wxCommandEvent & evt);
-   void OnAmplitude(wxCommandEvent & evt);
    void OnDuration(wxCommandEvent & evt);
    void OnDutyCycle(wxCommandEvent & evt);
 
@@ -93,7 +91,6 @@ private:
    double dtmfAmplitude;            // amplitude of dtmf tone sequence, restricted to (0-1)
 
    wxTextCtrl *mDtmfSequenceT;
-   wxTextCtrl *mDtmfAmplitudeT;
    wxSlider   *mDtmfDutyCycleS;
    NumericTextCtrl *mDtmfDurationT;
    wxStaticText *mDtmfToneT;

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -190,13 +190,3 @@ EffectEcho::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    S.EndMultiColumn();
    return nullptr;
 }
-
-bool EffectEcho::TransferDataToWindow(const EffectSettings &)
-{
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
-   return true;
-}

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -200,14 +200,3 @@ bool EffectEcho::TransferDataToWindow(const EffectSettings &)
 
    return true;
 }
-
-bool EffectEcho::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -53,7 +53,6 @@ public:
    // Effect implementation
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:
    // EffectEcho implementation

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -54,7 +54,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectEcho implementation

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -590,7 +590,7 @@ bool Effect::IsGraphicalUI()
 
 bool Effect::ValidateUI(EffectSettings &)
 {
-   return mUIParent->Validate();
+   return true;
 }
 
 bool Effect::CloseUI()

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -2118,9 +2118,9 @@ void Effect::Preview(EffectSettingsAccess &access, bool dryOnly)
 
       auto vr2 = valueRestorer( mIsPreview, true );
 
-      auto settings = access.Get();
-      success = Process(settings);
-      access.Set(std::move(settings));
+      access.ModifySettings([&](EffectSettings &settings){
+         success = Process(settings);
+      });
    }
 
    if (success)

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -751,11 +751,6 @@ double Effect::GetDuration()
    return mDuration;
 }
 
-NumericFormatSymbol Effect::GetDurationFormat()
-{
-   return mDurationFormat;
-}
-
 NumericFormatSymbol Effect::GetSelectionFormat()
 {
    if( !IsBatchProcessing() && FindProject() )
@@ -978,9 +973,10 @@ bool Effect::DoEffect(EffectSettings &settings, double projectRate,
       mT1 = mT0 + mDuration;
    }
 
-   mDurationFormat = isSelection
+   // This is happening inside EffectSettingsAccess::ModifySettings
+   settings.extra.SetDurationFormat( isSelection
       ? NumericConverter::TimeAndSampleFormat()
-      : NumericConverter::DefaultSelectionFormat();
+      : NumericConverter::DefaultSelectionFormat() );
 
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
    mF0 = selectedRegion.f0();

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -508,17 +508,6 @@ inline float TrapFloat(float x, float min, float max)
    return x;
 }
 
-inline double TrapDouble(double x, double min, double max)
-{
-   if (x <= min)
-      return min;
-
-   if (x >= max)
-      return max;
-
-   return x;
-}
-
 inline long TrapLong(long x, long min, long max)
 {
    if (x <= min)

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -173,7 +173,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    const EffectDefinitionInterface& GetDefinition() const override;
    double GetDuration() override;
-   NumericFormatSymbol GetDurationFormat() override;
    virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar
    void SetDuration(double duration) override;
 
@@ -471,7 +470,6 @@ private:
    bool mPreviewFullSelection;
 
    double mDuration;
-   NumericFormatSymbol mDurationFormat;
 
    bool mIsPreview;
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -207,7 +207,12 @@ EffectUIHost::~EffectUIHost()
 bool EffectUIHost::TransferDataToWindow()
 {
    // Transfer-to takes const reference to settings
-   return mEffectUIHost.TransferDataToWindow(mpAccess->Get());
+   return mEffectUIHost.TransferDataToWindow(mpAccess->Get()) &&
+      //! Do other apperance updates
+      mpValidator->UpdateUI() &&
+      //! Do validators
+      wxDialogWrapper::TransferDataToWindow();
+ 
 }
 
 bool EffectUIHost::TransferDataFromWindow()

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -276,11 +276,6 @@ bool EffectFindClipping::TransferDataToWindow(const EffectSettings &)
 
 bool EffectFindClipping::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate())
-   {
-      return false;
-   }
-
    ShuttleGui S(mUIParent, eIsGettingFromDialog);
    // To do: eliminate this and just use validators for controls
    DoPopulateOrExchange(S, *mpAccess);

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -156,9 +156,11 @@ bool EffectLoudness::Process(EffectSettings &)
    if(mNormalizeTo == kLoudness)
       // LU use 10*log10(...) instead of 20*log10(...)
       // so multiply level by 2 and use standard DB_TO_LINEAR macro.
-      mRatio = DB_TO_LINEAR(TrapDouble(mLUFSLevel*2, MIN_LUFSLevel, MAX_LUFSLevel));
+      mRatio = DB_TO_LINEAR(std::clamp<double>(
+         mLUFSLevel*2, MIN_LUFSLevel, MAX_LUFSLevel));
    else // RMS
-      mRatio = DB_TO_LINEAR(TrapDouble(mRMSLevel, MIN_RMSLevel, MAX_RMSLevel));
+      mRatio = DB_TO_LINEAR(std::clamp<double>(
+         mRMSLevel, MIN_RMSLevel, MAX_RMSLevel));
 
    // Iterate over each track
    this->CopyInputTracks(); // Set up mOutputTracks.

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -382,15 +382,6 @@ bool EffectLoudness::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectLoudness::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-   return true;
-}
-
 // EffectLoudness implementation
 
 /// Get required buffer size for the largest whole track and allocate buffers.

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -371,11 +371,6 @@ EffectLoudness::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool EffectLoudness::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    // adjust controls which depend on mchoice
    wxCommandEvent dummy;
    OnChoice(dummy);

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -57,7 +57,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectLoudness implementation

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -237,11 +237,6 @@ EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 
 bool EffectNoise::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mNoiseDurationT->SetValue(GetDuration());
 
    return true;

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -203,7 +203,7 @@ bool EffectNoise::SetAutomationParameters(CommandParameters & parms)
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator>
-EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 {
    wxASSERT(nTypes == WXSIZEOF(kTypeStrings));
 
@@ -218,10 +218,11 @@ EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
          .AddTextBox(XXO("&Amplitude (0-1):"), wxT(""), 12);
 
       S.AddPrompt(XXO("&Duration:"));
+      auto &extra = access.Get().extra;
       mNoiseDurationT = safenew
          NumericTextCtrl(S.GetParent(), wxID_ANY,
                          NumericConverter::TIME,
-                         GetDurationFormat(),
+                         extra.GetDurationFormat(),
                          GetDuration(),
                          mProjectRate,
                          NumericTextCtrl::Options{}

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -249,12 +249,6 @@ bool EffectNoise::TransferDataToWindow(const EffectSettings &)
 
 bool EffectNoise::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    SetDuration(mNoiseDurationT->GetValue());
-
    return true;
 }

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -1644,10 +1644,6 @@ void EffectNoiseReduction::Dialog::PopulateOrExchange(ShuttleGui & S)
 
 bool EffectNoiseReduction::Dialog::TransferDataToWindow()
 {
-   // Do the choice controls:
-   if (!EffectDialog::TransferDataToWindow())
-      return false;
-
    for (int id = FIRST_SLIDER; id < END_OF_SLIDERS; id += 2) {
       wxSlider* slider =
          static_cast<wxSlider*>(wxWindow::FindWindowById(id, this));

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -140,7 +140,8 @@ bool EffectNormalize::Process(EffectSettings &)
    if( mGain )
    {
       // same value used for all tracks
-      ratio = DB_TO_LINEAR(TrapDouble(mPeakLevel, MIN_PeakLevel, MAX_PeakLevel));
+      ratio = DB_TO_LINEAR(std::clamp<double>(
+         mPeakLevel, MIN_PeakLevel, MAX_PeakLevel));
    }
    else {
       ratio = 1.0;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -307,13 +307,7 @@ EffectNormalize::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool EffectNormalize::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    UpdateUI();
-
    return true;
 }
 

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -317,16 +317,6 @@ bool EffectNormalize::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectNormalize::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 // EffectNormalize implementation
 
 bool EffectNormalize::AnalyseTrack(const WaveTrack * track, const TranslatableString &msg,

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -51,7 +51,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectNormalize implementation

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -218,16 +218,6 @@ EffectPaulstretch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 };
 
-bool EffectPaulstretch::TransferDataToWindow(const EffectSettings &)
-{
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 // EffectPaulstretch implementation
 
 void EffectPaulstretch::OnText(wxCommandEvent & WXUNUSED(evt))

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -228,16 +228,6 @@ bool EffectPaulstretch::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectPaulstretch::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 // EffectPaulstretch implementation
 
 void EffectPaulstretch::OnText(wxCommandEvent & WXUNUSED(evt))

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -45,7 +45,6 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:
    // EffectPaulstretch implementation

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -46,7 +46,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectPaulstretch implementation

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -362,11 +362,6 @@ bool EffectPhaser::TransferDataToWindow(const EffectSettings &)
 
 bool EffectPhaser::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    if (mStages & 1)    // must be even
    {
       mStages &= ~1;

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -344,11 +344,6 @@ EffectPhaser::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool EffectPhaser::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mStagesS->SetValue((int) (mStages * SCL_Stages));
    mDryWetS->SetValue((int) (mDryWet * SCL_DryWet));
    mFreqS->SetValue((int) (mFreq * SCL_Freq));

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -66,10 +66,12 @@ private:
       ToMainSlot& operator=(EffectAndSettings &&arg) {
          // This happens during MessageBuffer's busying of the slot
          arg.effect.CopySettingsContents(arg.settings, mSettings);
+         mSettings.extra = arg.settings.extra;
          return *this;
       }
 
       // Main thread doesn't move out of the slot, but copies std::any
+      // and extra fields
       struct Reader { Reader(ToMainSlot &&slot, EffectSettings &settings) {
          settings = slot.mSettings;
       } };
@@ -98,6 +100,7 @@ private:
          EffectProcessor &effect, EffectSettings &settings) {
             // This happens during MessageBuffer's busying of the slot
             effect.CopySettingsContents(slot.mSettings, settings);
+            settings.extra = slot.mSettings.extra;
       } };
 
       EffectSettings mSettings;

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -210,11 +210,6 @@ bool EffectRepeat::TransferDataToWindow(const EffectSettings &)
 
 bool EffectRepeat::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate())
-   {
-      return false;
-   }
-
    long l;
 
    mRepeatCount->GetValue().ToLong(&l);

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -429,11 +429,6 @@ bool EffectReverb::TransferDataToWindow(const EffectSettings &)
 
 bool EffectReverb::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate())
-   {
-      return false;
-   }
-
    mParams.mRoomSize = mRoomSizeS->GetValue();
    mParams.mPreDelay = mPreDelayS->GetValue();
    mParams.mReverberance = mReverberanceS->GetValue();

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -519,11 +519,6 @@ bool EffectScienFilter::TransferDataToWindow(const EffectSettings &)
 
 bool EffectScienFilter::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    mOrder = mOrderIndex + 1;
 
    CalcFilter();

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -501,11 +501,6 @@ bool EffectScienFilter::TransferDataToWindow(const EffectSettings &)
 {
    mOrderIndex = mOrder - 1;
 
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mdBMinSlider->SetValue((int) mdBMin);
    mdBMin = 0.0;                     // force refresh in TransferGraphLimitsFromWindow()
 

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -66,17 +66,18 @@ EffectType EffectSilence::GetType() const
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator>
-EffectSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+EffectSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 {
    S.StartVerticalLay();
    {
       S.StartHorizontalLay();
       {
          S.AddPrompt(XXO("&Duration:"));
+         auto &extra = access.Get().extra;
          mDurationT = safenew
             NumericTextCtrl(S.GetParent(), wxID_ANY,
                               NumericConverter::TIME,
-                              GetDurationFormat(),
+                              extra.GetDurationFormat(),
                               GetDuration(),
                                mProjectRate,
                                NumericTextCtrl::Options{}

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -324,16 +324,6 @@ bool EffectTimeScale::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectTimeScale::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 inline double EffectTimeScale::PercentChangeToRatio(double percentChange)
 {
    return 1.0 + percentChange / 100.0;

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -313,11 +313,6 @@ EffectTimeScale::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool EffectTimeScale::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    Update_Slider_RatePercentChangeStart();
    Update_Slider_RatePercentChangeEnd();
 

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -53,7 +53,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
    double CalcPreviewInputLength(
       const EffectSettings &settings, double previewLength) override;
 

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -360,7 +360,7 @@ bool EffectToneGen::SetAutomationParameters(CommandParameters & parms)
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator>
-EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 {
    wxTextCtrl *t;
 
@@ -468,10 +468,11 @@ EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
       }
 
       S.AddPrompt(XXO("&Duration:"));
+      auto &extra = access.Get().extra;
       mToneDurationT = safenew
          NumericTextCtrl(S.GetParent(), wxID_ANY,
                          NumericConverter::TIME,
-                         GetDurationFormat(),
+                         extra.GetDurationFormat(),
                          GetDuration(),
                          mProjectRate,
                          NumericTextCtrl::Options{}

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -500,11 +500,6 @@ bool EffectToneGen::TransferDataToWindow(const EffectSettings &)
 
 bool EffectToneGen::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    if (!mChirp)
    {
       mFrequency[1] = mFrequency[0];

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -292,7 +292,7 @@ bool EffectToneGen::DefineParams( ShuttleParams & S ){
 
 
 //   double freqMax = (FindProject() ? FindProject()->GetRate() : 44100.0) / 2.0;
-//   mFrequency[1] = TrapDouble(mFrequency[1], MIN_EndFreq, freqMax);
+//   mFrequency[1] = std::clamp<double>(mFrequency[1], MIN_EndFreq, freqMax);
 
 
    return true;
@@ -352,7 +352,7 @@ bool EffectToneGen::SetAutomationParameters(CommandParameters & parms)
          ? ProjectRate::Get( *FindProject() ).GetRate()
          : 44100.0)
       / 2.0;
-   mFrequency[1] = TrapDouble(mFrequency[1], MIN_EndFreq, freqMax);
+   mFrequency[1] = std::clamp<double>(mFrequency[1], MIN_EndFreq, freqMax);
 
    return true;
 }

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -488,13 +488,7 @@ EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
 
 bool EffectToneGen::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mToneDurationT->SetValue(GetDuration());
-
    return true;
 }
 

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -799,13 +799,7 @@ bool EffectTruncSilence::TransferDataToWindow(const EffectSettings &)
 
 bool EffectTruncSilence::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    mbIndependent = mIndependent->IsChecked();
-
    return true;
 }
 

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -787,16 +787,6 @@ EffectTruncSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    return nullptr;
 }
 
-bool EffectTruncSilence::TransferDataToWindow(const EffectSettings &)
-{
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 bool EffectTruncSilence::TransferDataFromWindow(EffectSettings &)
 {
    mbIndependent = mIndependent->IsChecked();

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -70,7 +70,6 @@ public:
    bool Process(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1770,11 +1770,6 @@ bool VSTEffect::IsGraphicalUI()
 
 bool VSTEffect::ValidateUI(EffectSettings &)
 {
-   if (!mParent->Validate() || !mParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    if (GetType() == EffectTypeGenerate)
    {
       mHost->SetDuration(mDuration->GetValue());

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1757,7 +1757,7 @@ VSTEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
    }
    else
    {
-      BuildPlain();
+      BuildPlain(access);
    }
 
    return std::make_unique<DefaultEffectUIValidator>(*this, access);
@@ -2691,7 +2691,7 @@ void VSTEffect::BuildFancy()
    return;
 }
 
-void VSTEffect::BuildPlain()
+void VSTEffect::BuildPlain(EffectSettingsAccess &access)
 {
    wxASSERT(mParent); // To justify safenew
    wxScrolledWindow *const scroller = safenew wxScrolledWindow(mParent,
@@ -2733,10 +2733,11 @@ void VSTEffect::BuildPlain()
          {
             wxControl *item = safenew wxStaticText(scroller, 0, _("Duration:"));
             gridSizer->Add(item, 0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT | wxALL, 5);
+            auto &extra = access.Get().extra;
             mDuration = safenew
                NumericTextCtrl(scroller, ID_Duration,
                   NumericConverter::TIME,
-                  mHost->GetDurationFormat(),
+                  extra.GetDurationFormat(),
                   mHost->GetDuration(),
                   mSampleRate,
                   NumericTextCtrl::Options{}

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -222,7 +222,7 @@ private:
    void OnSave(wxCommandEvent & evt);
    void OnSettings(wxCommandEvent & evt);
 
-   void BuildPlain();
+   void BuildPlain(EffectSettingsAccess &access);
    void BuildFancy();
    wxSizer *BuildProgramBar();
    void RefreshParameters(int skip = -1);

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -878,10 +878,11 @@ VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &access)
             VST3Utils::BuildPlainUI(controlsRoot, mEditController, mComponentHandler);
          vSizer->Add(controlsRoot);
 
+         auto &extra = access.Get().extra;
          mDuration = safenew NumericTextCtrl(
                parent, wxID_ANY,
                NumericConverter::TIME,
-               mEffectHost->GetDurationFormat(),
+               extra.GetDurationFormat(),
                mEffectHost->GetDuration(),
                mSetup.sampleRate,
                NumericTextCtrl::Options{}

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -329,16 +329,6 @@ bool EffectWahwah::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectWahwah::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 // EffectWahwah implementation
 
 void EffectWahwah::InstanceInit(EffectWahwahState & data, float sampleRate)

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -314,11 +314,6 @@ EffectWahwah::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool EffectWahwah::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    mFreqS->SetValue((int) (mFreq * SCL_Freq));
    mPhaseS->SetValue((int) (mPhase * SCL_Phase));
    mDepthS->SetValue((int) (mDepth * SCL_Depth));

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -80,7 +80,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectWahwah implementation

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1752,11 +1752,6 @@ bool AudioUnitEffect::IsGraphicalUI()
 bool AudioUnitEffect::ValidateUI(EffectSettings &)
 {
 #if 0
-   if (!mParent->Validate())
-   {
-      return false;
-   }
-
    if (GetType() == EffectTypeGenerate)
    {
       mHost->SetDuration(mDuration->GetValue());

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1219,10 +1219,11 @@ LadspaEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
          {
             item = safenew wxStaticText(w, 0, _("Duration:"));
             gridSizer->Add(item, 0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT | wxALL, 5);
+            auto &extra = access.Get().extra;
             mDuration = safenew
                NumericTextCtrl(w, ID_Duration,
                   NumericConverter::TIME,
-                  mHost->GetDurationFormat(),
+                  extra.GetDurationFormat(),
                   mHost->GetDuration(),
                   mSampleRate,
                   NumericTextCtrl::Options{}

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1493,11 +1493,6 @@ bool LadspaEffect::IsGraphicalUI()
 
 bool LadspaEffect::ValidateUI(EffectSettings &)
 {
-   if (!mParent->Validate())
-   {
-      return false;
-   }
-
    if (GetType() == EffectTypeGenerate)
    {
       mHost->SetDuration(mDuration->GetValue());

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1562,7 +1562,7 @@ LV2Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
 
    if (!mUseGUI)
    {
-      if (!BuildPlain())
+      if (!BuildPlain(access))
          return nullptr;
    }
 
@@ -2276,7 +2276,7 @@ bool LV2Effect::BuildFancy()
    return true;
 }
 
-bool LV2Effect::BuildPlain()
+bool LV2Effect::BuildPlain(EffectSettingsAccess &access)
 {
    int numCols = 5;
    wxSizer *innerSizer;
@@ -2312,10 +2312,11 @@ bool LV2Effect::BuildPlain()
 
             wxWindow *item = safenew wxStaticText(w, 0, _("&Duration:"));
             sizer->Add(item, 0, wxALIGN_CENTER | wxALL, 5);
+            auto &extra = access.Get().extra;
             mDuration = safenew
                NumericTextCtrl(w, ID_Duration,
                                NumericConverter::TIME,
-                               mHost->GetDurationFormat(),
+                               extra.GetDurationFormat(),
                                mHost->GetDuration(),
                                mSampleRate,
                                NumericTextCtrl::Options {}

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1576,11 +1576,6 @@ bool LV2Effect::IsGraphicalUI()
 
 bool LV2Effect::ValidateUI(EffectSettings &)
 {
-   if (!mParent->Validate() || !mParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    if (GetType() == EffectTypeGenerate)
    {
       mHost->SetDuration(mDuration->GetValue());
@@ -2649,16 +2644,6 @@ bool LV2Effect::TransferDataToWindow()
    }
 
    if (mParent && !mParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
-bool LV2Effect::TransferDataFromWindow()
-{
-   if (!mParent->Validate() || !mParent->TransferDataFromWindow())
    {
       return false;
    }

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -388,7 +388,6 @@ private:
    bool BuildPlain(EffectSettingsAccess &access);
 
    bool TransferDataToWindow() /* not override */;
-   bool TransferDataFromWindow() /* not override */;
    void SetSlider(const LV2ControlPortPtr & port);
 
    void OnTrigger(wxCommandEvent & evt);

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -385,7 +385,7 @@ private:
    bool CheckFeatures(const LilvNode *subject, const LilvNode *predicate, bool required);
 
    bool BuildFancy();
-   bool BuildPlain();
+   bool BuildPlain(EffectSettingsAccess &access);
 
    bool TransferDataToWindow() /* not override */;
    bool TransferDataFromWindow() /* not override */;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1125,11 +1125,6 @@ bool NyquistEffect::TransferDataToWindow(const EffectSettings &)
 
 bool NyquistEffect::TransferDataFromWindow(EffectSettings &)
 {
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
    if (mIsPrompt)
    {
       return TransferDataFromPromptWindow();

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1103,8 +1103,6 @@ bool NyquistEffect::EnablesDebug() const
 
 bool NyquistEffect::TransferDataToWindow(const EffectSettings &)
 {
-   mUIParent->TransferDataToWindow();
-
    bool success;
    if (mIsPrompt)
    {

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1070,10 +1070,11 @@ int NyquistEffect::ShowHostInterface(
       effect.mDebug = (res == eDebugID);
       // Delegate to the Nyquist Prompt,
       // which gets some Lisp from the user to interpret
-      auto settings = access.Get();
-      res = Delegate(effect, settings,
-         parent, factory, access.shared_from_this());
-      access.Set(std::move(settings));
+
+      access.ModifySettings([&](EffectSettings &settings){
+         res = Delegate(effect, settings,
+            parent, factory, access.shared_from_this());
+      });
       mT0 = effect.mT0;
       mT1 = effect.mT1;
    }

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -696,13 +696,7 @@ VampEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 
 bool VampEffect::TransferDataToWindow(const EffectSettings &)
 {
-   if (!mUIParent->TransferDataToWindow())
-   {
-      return false;
-   }
-
    UpdateFromPlugin();
-
    return true;
 }
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -706,16 +706,6 @@ bool VampEffect::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool VampEffect::TransferDataFromWindow(EffectSettings &)
-{
-   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
-   {
-      return false;
-   }
-
-   return true;
-}
-
 // VampEffect implementation
 
 void VampEffect::AddFeatures(LabelTrack *ltrack,

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -72,7 +72,6 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // VampEffect implementation


### PR DESCRIPTION
Resolves: #2673
Resolves: #2674

To eliminate EffectHostInterface and state variables in Effect that it accessed and modified has involved some unusual twists and turns...  The dependencies among the necessary tasks are becoming surprising on closer look.  This big PR gives
necessary solutions to various sub-sub-tasks.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
