### PR TITLE
Made filename inputbox bigger for Export2 macro - issue:2446

### DIFF
--- a/src/commands/ImportExportCommands.cpp
+++ b/src/commands/ImportExportCommands.cpp
@@ -84,7 +84,7 @@ void ExportCommand::PopulateOrExchange(ShuttleGui & S)
 
    S.StartMultiColumn(2, wxALIGN_CENTER);
    {
-      S.TieTextBox(XXO("File Name:"),mFileName);
+      S.TieTextBox(XXO("File Name:"), mFileName, mFileName.length());
       S.TieTextBox(XXO("Number of Channels:"),mnChannels);
    }
    S.EndMultiColumn();


### PR DESCRIPTION
Resolves: [#2446
](https://github.com/audacity/audacity/issues/2446)
*(Increased inputbox size for the Export2 macro. Same solution can be applied to other macros such as "OpenProject2" and "Import2". If this fix looks acceptable then I will be happy to apply it to any other macros that have this problem too :))*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
