### PR TITLE
Issue 2614: AdornedRulerPanel position fix

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1221,7 +1221,7 @@ AttachedWindows::RegisteredFactory sKey{
    auto &viewInfo = ViewInfo::Get( project );
    auto &window = ProjectWindow::Get( project );
 
-   return safenew AdornedRulerPanel( &project, window.GetTopPanel(),
+   return safenew AdornedRulerPanel( &project, window.GetTrackListWindow(),
       wxID_ANY,
       wxDefaultPosition,
       wxSize( -1, AdornedRulerPanel::GetRulerHeight(false) ),

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -224,11 +224,6 @@ void InitProjectWindow( ProjectWindow &window )
    ToolManager::Get( project ).LayoutToolBars();
 
    //
-   // Create the horizontal ruler
-   //
-   auto &ruler = AdornedRulerPanel::Get( project );
-
-   //
    // Create the TrackPanel and the scrollbars
    //
 
@@ -237,14 +232,8 @@ void InitProjectWindow( ProjectWindow &window )
    {
       auto ubs = std::make_unique<wxBoxSizer>(wxVERTICAL);
       ubs->Add( ToolManager::Get( project ).GetTopDock(), 0, wxEXPAND | wxALIGN_TOP );
-      ubs->Add(&ruler, 0, wxEXPAND);
       topPanel->SetSizer(ubs.release());
    }
-
-   // Ensure that the topdock comes before the ruler in the tab order,
-   // irrespective of the order in which they were created.
-   ToolManager::Get(project).GetTopDock()->MoveBeforeInTabOrder(&ruler);
-
 
    wxBoxSizer *bs;
    {
@@ -269,6 +258,11 @@ void InitProjectWindow( ProjectWindow &window )
 
    const auto trackListWindow = window.GetTrackListWindow();
 
+   //
+   // Create the horizontal ruler
+   //
+   auto &ruler = AdornedRulerPanel::Get( project );
+
    bs = static_cast<wxBoxSizer*>(trackListWindow->GetSizer());
 
    auto vsBar = &window.GetVerticalScrollBar();
@@ -290,6 +284,7 @@ void InitProjectWindow( ProjectWindow &window )
          hs->Add(vs.release(), 0, wxEXPAND | wxALIGN_TOP);
       }
 
+      bs->Add(&ruler, 0, wxEXPAND | wxALIGN_TOP);
       bs->Add(hs.release(), 1, wxEXPAND | wxALIGN_LEFT | wxALIGN_TOP);
    }
 


### PR DESCRIPTION
Resolves: #2614

AdornedRulerPanel was reparented to the track panel list so that when effects panel is shown ruler properly changes it's position

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
