### PR TITLE
Visiting effect settings

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -90,7 +90,7 @@ bool EffectDefinitionInterfaceEx::CopySettingsContents(
 }
 
 bool EffectDefinitionInterfaceEx::LoadSettings(
-   CommandParameters & parms, Settings &settings) const
+   const CommandParameters & parms, Settings &settings) const
 {
    if (auto pEffect = FindMe(settings))
       // Call through to old interface

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -77,7 +77,7 @@ bool EffectDefinitionInterface::VisitSettings(
 }
 
 bool EffectDefinitionInterface::VisitSettings(
-   ConstSettingsVisitor &, const EffectSettings &)
+   ConstSettingsVisitor &, const EffectSettings &) const
 {
    return false;
 }

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -89,16 +89,6 @@ bool EffectDefinitionInterfaceEx::CopySettingsContents(
    return FindMe(src) && FindMe(dst);
 }
 
-bool EffectDefinitionInterfaceEx::SaveSettings(
-   const Settings &settings, CommandParameters & parms) const
-{
-   if (auto pEffect = FindMe(settings))
-      // Call through to old interface
-      return pEffect->GetAutomationParameters(parms);
-   else
-      return false;
-}
-
 bool EffectDefinitionInterfaceEx::LoadSettings(
    CommandParameters & parms, Settings &settings) const
 {

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -70,7 +70,14 @@ bool EffectDefinitionInterface::IsHiddenFromMenus() const
    return false;
 }
 
-bool EffectDefinitionInterface::VisitSettings( SettingsVisitor & )
+bool EffectDefinitionInterface::VisitSettings(
+   SettingsVisitor &, EffectSettings &)
+{
+   return false;
+}
+
+bool EffectDefinitionInterface::VisitSettings(
+   ConstSettingsVisitor &, const EffectSettings &)
 {
    return false;
 }

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -89,16 +89,6 @@ bool EffectDefinitionInterfaceEx::CopySettingsContents(
    return FindMe(src) && FindMe(dst);
 }
 
-bool EffectDefinitionInterfaceEx::LoadSettings(
-   const CommandParameters & parms, Settings &settings) const
-{
-   if (auto pEffect = FindMe(settings))
-      // Call through to old interface
-      return pEffect->SetAutomationParameters(parms);
-   else
-      return false;
-}
-
 EffectDefinitionInterfaceEx *
 EffectDefinitionInterfaceEx::FindMe(const Settings &settings) const
 {

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -138,7 +138,8 @@ read-only information about effect properties, and getting and setting of
 parameters.
 
 *******************************************************************************************/
-class COMPONENTS_API EffectDefinitionInterface  /* not final */ : public ComponentInterface
+class COMPONENTS_API EffectDefinitionInterface  /* not final */
+   : public ComponentInterface
 {
 public:
    using Settings = EffectSettings;
@@ -241,7 +242,7 @@ public:
    //! Visit settings, if defined.  false means no defined settings.
    //! Default implementation returns false
    virtual bool VisitSettings(
-      ConstSettingsVisitor &visitor, const EffectSettings &settings);
+      ConstSettingsVisitor &visitor, const EffectSettings &settings) const;
 };
 
 //! Extension of EffectDefinitionInterface with old system for settings

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -216,7 +216,7 @@ public:
     @return true on success
     */
    virtual bool LoadSettings(
-      CommandParameters & parms, Settings &settings) const = 0;
+      const CommandParameters & parms, Settings &settings) const = 0;
 
    //! Report names of factory presets
    virtual RegistryPaths GetFactoryPresets() const = 0;
@@ -267,7 +267,7 @@ public:
    bool CopySettingsContents(
       const EffectSettings &src, EffectSettings &dst) const override;
    bool LoadSettings(
-      CommandParameters & parms, Settings &settings) const override;
+      const CommandParameters & parms, Settings &settings) const override;
    //! @}
 
 private:

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -44,7 +44,7 @@
 
 #include "ComponentInterface.h"
 #include "ComponentInterfaceSymbol.h"
-#include "EffectAutomationParameters.h" // for command automation
+#include "EffectAutomationParameters.h"
 
 #include "TypedAny.h"
 #include <memory>

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -251,13 +251,6 @@ class COMPONENTS_API EffectDefinitionInterfaceEx  /* not final */
    : public EffectDefinitionInterface
 {
 public:
-   /*! @name Old settings interface
-    Old interface for saving and loading non-externalized settings
-    */
-   //! @{
-   virtual bool SetAutomationParameters(const CommandParameters & parms) = 0;
-   //! @}
-
    /*! @name settings
     Default implementation of the nominally const methods call through to the
     old non-const interface
@@ -266,8 +259,6 @@ public:
    Settings MakeSettings() const override;
    bool CopySettingsContents(
       const EffectSettings &src, EffectSettings &dst) const override;
-   bool LoadSettings(
-      const CommandParameters & parms, Settings &settings) const override;
    //! @}
 
 private:

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -236,7 +236,12 @@ public:
 
    //! Visit settings, if defined.  false means no defined settings.
    //! Default implementation returns false
-   virtual bool VisitSettings( SettingsVisitor & );
+   virtual bool VisitSettings(
+      SettingsVisitor &visitor, EffectSettings &settings);
+   //! Visit settings, if defined.  false means no defined settings.
+   //! Default implementation returns false
+   virtual bool VisitSettings(
+      ConstSettingsVisitor &visitor, const EffectSettings &settings);
 };
 
 //! Extension of EffectDefinitionInterface with old system for settings

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -255,9 +255,6 @@ public:
     Old interface for saving and loading non-externalized settings
     */
    //! @{
-   //! Save current settings into parms
-   virtual bool GetAutomationParameters(CommandParameters & parms) const = 0;
-   //! Change settings to those stored in parms
    virtual bool SetAutomationParameters(const CommandParameters & parms) = 0;
    //! @}
 
@@ -269,8 +266,6 @@ public:
    Settings MakeSettings() const override;
    bool CopySettingsContents(
       const EffectSettings &src, EffectSettings &dst) const override;
-   bool SaveSettings(
-      const Settings &settings, CommandParameters & parms) const override;
    bool LoadSettings(
       CommandParameters & parms, Settings &settings) const override;
    //! @}

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -93,9 +93,9 @@ public:
    ) = 0;
 
    virtual void Preview(EffectSettingsAccess &access, bool dryOnly) = 0;
-   virtual bool GetAutomationParametersAsString(
+   virtual bool SaveSettingsAsString(
       const EffectSettings &settings, wxString & parms) const = 0;
-   virtual bool SetAutomationParametersFromString(
+   virtual bool LoadSettingsFromString(
       const wxString & parms, EffectSettings &settings) const = 0;
    virtual bool IsBatchProcessing() const = 0;
    virtual void SetBatchProcessing() = 0;

--- a/src/ShuttleAutomation.cpp
+++ b/src/ShuttleAutomation.cpp
@@ -9,7 +9,7 @@
 **********************************************************************/
 
 #include "ShuttleAutomation.h"
-#include "EffectAutomationParameters.h" // for command automation
+#include "EffectAutomationParameters.h"
 
 EffectParameterMethods::~EffectParameterMethods() = default;
 
@@ -79,7 +79,7 @@ SettingsVisitor & ShuttleSetAutomation::Optional( bool & var ){
 // Tests for parameter being optional.
 // Prepares for next parameter by clearing the pointer.
 // If the parameter is optional, finds out if it was actually provided.
-// i.e. could it be got from automation?
+// i.e. could it be got from a macro?
 // The result goes into the flag variable, so we typically ignore the result.
 bool ShuttleSetAutomation::CouldGet( const wxString &key ){
    // Not optional?  Can get as we will get the default, at worst.

--- a/src/ShuttleAutomation.cpp
+++ b/src/ShuttleAutomation.cpp
@@ -14,56 +14,64 @@
 EffectParameterMethods::~EffectParameterMethods() = default;
 
 // ShuttleGetAutomation gets from the shuttle into typically a string.
-SettingsVisitor & ShuttleGetAutomation::Optional( bool & var ){
+ConstSettingsVisitor & ShuttleGetAutomation::Optional(const bool & var) {
    pOptionalFlag = &var;
    return *this;
 };
 
-void ShuttleGetAutomation::Define( bool & var,     const wxChar * key, const bool vdefault, const bool vmin, const bool vmax, const bool vscl )
+void ShuttleGetAutomation::Define(bool var, const wxChar * key,
+   bool, bool, bool, bool)
 {
    if( !ShouldSet() ) return;
    mpEap->Write(key, var);
 }
 
-void ShuttleGetAutomation::Define( int & var,      const wxChar * key, const int vdefault, const int vmin, const int vmax, const int vscl )
+void ShuttleGetAutomation::Define(int var, const wxChar * key,
+   int, int, int, int)
 {
    if( !ShouldSet() ) return;
    mpEap->Write(key, var);
 }
 
-void ShuttleGetAutomation::Define( size_t & var,      const wxChar * key, const int vdefault, const int vmin, const int vmax, const int vscl )
+void ShuttleGetAutomation::Define(size_t var, const wxChar * key,
+   int, int, int, int)
 {
    if( !ShouldSet() ) return;
    mpEap->Write(key, (int) var);
 }
 
-void ShuttleGetAutomation::Define( double & var,   const wxChar * key, const float vdefault, const float vmin, const float vmax, const float vscl )
+void ShuttleGetAutomation::Define(double var, const wxChar * key,
+   float, float, float, float)
 {
    if( !ShouldSet() ) return;
    mpEap->WriteFloat(key, var);
 }
 
-void ShuttleGetAutomation::Define( float & var,   const wxChar * key, const float vdefault, const float vmin, const float vmax, const float vscl )
+void ShuttleGetAutomation::Define(float var, const wxChar * key,
+   float, float, float, float)
 {
    if( !ShouldSet() ) return;
    mpEap->WriteFloat(key, var);
 }
 
-void ShuttleGetAutomation::Define( double & var,   const wxChar * key, const double vdefault, const double vmin, const double vmax, const double vscl )
+void ShuttleGetAutomation::Define(double var, const wxChar * key,
+   double, double, double, double)
 {
    if( !ShouldSet() ) return;
    mpEap->Write(key, var);
 }
 
 
-void ShuttleGetAutomation::Define( wxString &var, const wxChar * key, const wxString vdefault, const wxString vmin, const wxString vmax, const wxString vscl )
+void ShuttleGetAutomation::Define(const wxString &var, const wxChar * key,
+   wxString, wxString, wxString, wxString)
 {
    if( !ShouldSet() ) return;
    mpEap->Write(key, var);
 }
 
 
-void ShuttleGetAutomation::DefineEnum( int &var, const wxChar * key, const int vdefault, const EnumValueSymbol strings[], size_t nStrings )
+void ShuttleGetAutomation::DefineEnum(int var, const wxChar * key,
+   int, const EnumValueSymbol strings[], size_t)
 {
    if( !ShouldSet() ) return;
    mpEap->Write(key, strings[var].Internal());

--- a/src/ShuttleGetDefinition.cpp
+++ b/src/ShuttleGetDefinition.cpp
@@ -18,17 +18,18 @@ bool ShuttleGetDefinition::IsOptional(){
 }
 
 // Definition distinguishes optional from not.
-SettingsVisitor & ShuttleGetDefinition::Optional( bool & var ){
+ConstSettingsVisitor & ShuttleGetDefinition::Optional(const bool & var){
    pOptionalFlag = &var;
    return *this;
 };
 
-ShuttleGetDefinition::ShuttleGetDefinition( CommandMessageTarget & target ) : CommandMessageTargetDecorator( target )
+ShuttleGetDefinition::ShuttleGetDefinition(CommandMessageTarget & target) : CommandMessageTargetDecorator{ target }
 {
 }
 
 // JSON definitions.
-void ShuttleGetDefinition::Define( bool & var,     const wxChar * key, const bool vdefault, const bool vmin, const bool vmax, const bool vscl )
+void ShuttleGetDefinition::Define(bool, const wxChar * key,
+   bool vdefault, bool, bool, bool)
 {
    StartStruct();
    AddItem( wxString(key), "key" );
@@ -40,7 +41,8 @@ void ShuttleGetDefinition::Define( bool & var,     const wxChar * key, const boo
    EndStruct();
 }
 
-void ShuttleGetDefinition::Define( int & var,      const wxChar * key, const int vdefault, const int vmin, const int vmax, const int vscl )
+void ShuttleGetDefinition::Define(int, const wxChar * key,
+   int vdefault, int, int, int)
 {
    StartStruct();
    AddItem( wxString(key), "key" );
@@ -52,7 +54,8 @@ void ShuttleGetDefinition::Define( int & var,      const wxChar * key, const int
    EndStruct();
 }
 
-void ShuttleGetDefinition::Define( size_t & var,      const wxChar * key, const int vdefault, const int vmin, const int vmax, const int vscl )
+void ShuttleGetDefinition::Define(size_t, const wxChar * key,
+   int vdefault, int, int, int)
 {
    StartStruct();
    AddItem( wxString(key), "key" );
@@ -65,7 +68,8 @@ void ShuttleGetDefinition::Define( size_t & var,      const wxChar * key, const 
    
 }
 
-void ShuttleGetDefinition::Define( float & var,   const wxChar * key, const float vdefault, const float vmin, const float vmax, const float vscl )
+void ShuttleGetDefinition::Define(float, const wxChar * key,
+   float vdefault, float, float, float)
 {
    StartStruct();
    AddItem( wxString(key), "key" );
@@ -77,7 +81,8 @@ void ShuttleGetDefinition::Define( float & var,   const wxChar * key, const floa
    EndStruct();
 }
 
-void ShuttleGetDefinition::Define( double & var,   const wxChar * key, const float vdefault, const float vmin, const float vmax, const float vscl )
+void ShuttleGetDefinition::Define(double, const wxChar * key,
+   float vdefault, float, float, float)
 {
    StartStruct();
    AddItem( wxString(key), "key" );
@@ -89,7 +94,8 @@ void ShuttleGetDefinition::Define( double & var,   const wxChar * key, const flo
    EndStruct();
 }
 
-void ShuttleGetDefinition::Define( double & var,   const wxChar * key, const double vdefault, const double vmin, const double vmax, const double vscl )
+void ShuttleGetDefinition::Define(double, const wxChar * key,
+   double vdefault, double, double, double)
 {
    StartStruct();
    AddItem( wxString(key), "key" );
@@ -102,7 +108,8 @@ void ShuttleGetDefinition::Define( double & var,   const wxChar * key, const dou
 }
 
 
-void ShuttleGetDefinition::Define( wxString &var, const wxChar * key, const wxString vdefault, const wxString vmin, const wxString vmax, const wxString vscl )
+void ShuttleGetDefinition::Define(const wxString &, const wxChar * key,
+   wxString vdefault, wxString, wxString, wxString)
 {
    StartStruct();
    AddItem( wxString(key), "key" );
@@ -115,9 +122,8 @@ void ShuttleGetDefinition::Define( wxString &var, const wxChar * key, const wxSt
 }
 
 
-void ShuttleGetDefinition::DefineEnum( int &var,
-                                      const wxChar * key, const int vdefault,
-                                      const EnumValueSymbol strings[], size_t nStrings )
+void ShuttleGetDefinition::DefineEnum(int, const wxChar * key,
+   int vdefault, const EnumValueSymbol strings[], size_t nStrings )
 {
    StartStruct();
    AddItem( wxString(key), "key" );

--- a/src/ShuttleGetDefinition.h
+++ b/src/ShuttleGetDefinition.h
@@ -18,29 +18,29 @@
 \brief SettingsVisitor that retrieves a JSON format definition of a command's parameters.
 ********************************************************************************/
 class AUDACITY_DLL_API ShuttleGetDefinition final
-   : public SettingsVisitor, public CommandMessageTargetDecorator
+   : public ConstSettingsVisitor, public CommandMessageTargetDecorator
 {
 public:
    ShuttleGetDefinition( CommandMessageTarget & target );
    wxString Result;
    bool IsOptional();
-   SettingsVisitor & Optional( bool & var ) override;
-   void Define( bool & var, const wxChar * key, bool vdefault,
-      bool vmin, bool vmax, bool vscl ) override;
-   void Define( int & var, const wxChar * key, int vdefault,
-      int vmin, int vmax, int vscl ) override;
-   void Define( size_t & var, const wxChar * key, int vdefault,
-      int vmin, int vmax, int vscl ) override;
-   void Define( float & var, const wxChar * key, float vdefault,
-      float vmin, float vmax, float vscl ) override;
-   void Define( double & var, const wxChar * key, float vdefault,
-      float vmin, float vmax, float vscl ) override;
-   void Define( double & var, const wxChar * key, double vdefault,
-      double vmin, double vmax, double vscl ) override;
-   void Define( wxString &var,  const wxChar * key, wxString vdefault,
-      wxString vmin, wxString vmax, wxString vscl ) override;
-   void DefineEnum( int &var, const wxChar * key, int vdefault,
-      const EnumValueSymbol strings[], size_t nStrings ) override;
+   ConstSettingsVisitor & Optional( const bool & var ) override;
+   void Define(bool var, const wxChar * key, bool vdefault,
+      bool vmin, bool vmax, bool vscl) override;
+   void Define(int var, const wxChar * key, int vdefault,
+      int vmin, int vmax, int vscl) override;
+   void Define(size_t var, const wxChar * key, int vdefault,
+      int vmin, int vmax, int vscl) override;
+   void Define(float var, const wxChar * key, float vdefault,
+      float vmin, float vmax, float vscl) override;
+   void Define(double var, const wxChar * key, float vdefault,
+      float vmin, float vmax, float vscl) override;
+   void Define(double var, const wxChar * key, double vdefault,
+      double vmin, double vmax, double vscl) override;
+   void Define(const wxString &var,  const wxChar * key, wxString vdefault,
+      wxString vmin, wxString vmax, wxString vscl) override;
+   void DefineEnum( int var, const wxChar * key, int vdefault,
+      const EnumValueSymbol strings[], size_t nStrings) override;
 };
 
 #endif

--- a/src/commands/AudacityCommand.cpp
+++ b/src/commands/AudacityCommand.cpp
@@ -117,7 +117,7 @@ wxDialog *AudacityCommand::CreateUI(wxWindow *parent, AudacityCommand * WXUNUSED
    return NULL;
 }
 
-bool AudacityCommand::GetAutomationParametersAsString(wxString & parms)
+bool AudacityCommand::SaveSettingsAsString(wxString & parms)
 {
    CommandParameters eap;
 
@@ -135,7 +135,7 @@ bool AudacityCommand::GetAutomationParametersAsString(wxString & parms)
    return eap.GetParameters(parms);
 }
 
-bool AudacityCommand::SetAutomationParametersFromString(const wxString & parms)
+bool AudacityCommand::LoadSettingsFromString(const wxString & parms)
 {
    wxString preset = parms;
 

--- a/src/commands/AudacityCommand.h
+++ b/src/commands/AudacityCommand.h
@@ -21,7 +21,7 @@
 #include "../widgets/wxPanelWrapper.h" // to inherit
 
 #include "ComponentInterface.h"
-#include "EffectAutomationParameters.h" // for command automation
+#include "EffectAutomationParameters.h"
 #include "EffectInterface.h" // for SettingsVisitor type alias
 
 #include "Registrar.h"
@@ -70,8 +70,8 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
 
    wxDialog *CreateUI(wxWindow *parent, AudacityCommand *client);
 
-   bool GetAutomationParametersAsString(wxString & parms);
-   bool SetAutomationParametersFromString(const wxString & parms);
+   bool SaveSettingsAsString(wxString & parms);
+   bool LoadSettingsFromString(const wxString & parms);
 
    bool DoAudacityCommand(wxWindow *parent, const CommandContext & context,bool shouldPrompt = true);
 
@@ -103,7 +103,7 @@ class AUDACITY_DLL_API AudacityCommand /* not final */ : public wxEvtHandler,
    virtual bool PromptUser(wxWindow *parent);
 
    // Check whether command should be skipped
-   // Typically this is only useful in automation, for example
+   // Typically this is only useful in macros, for example
    // detecting that zero noise reduction is to be done,
    // or that normalisation is being done without Dc bias shift
    // or amplitude modification

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -59,7 +59,7 @@ const EffectParameterMethods& EffectAmplify::Parameters() const
    > batchParameters{
       // If invoking Amplify from a macro, mCanClip is not a parameter
       // but is always true
-      [](EffectAmplify &, EffectAmplify &e, bool) {
+      [](EffectAmplify &, EffectSettings &, EffectAmplify &e, bool) {
          e.mCanClip = true;
          return true;
       },

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -77,7 +77,8 @@ const EffectParameterMethods& EffectChangePitch::Parameters() const
       // PRL 2022: but that is so only when USE_SBSMS is not defined
       Percentage, UseSBSMS
    > parameters{
-      [](EffectChangePitch &, EffectChangePitch &e, bool updating){
+      [](EffectChangePitch &, EffectSettings &,
+         EffectChangePitch &e, bool updating){
          if (updating)
             e.Calc_SemitonesChange_fromPercentChange();
          return true;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -64,7 +64,8 @@ const EffectParameterMethods& EffectDistortion::Parameters() const
    static CapturedParameters<EffectDistortion,
       TableTypeIndx, DCBlock, Threshold_dB, NoiseFloor, Param1, Param2, Repeats
    > parameters{
-      [](EffectDistortion &e, Params &p, bool updating) {
+      [](EffectDistortion &e, EffectSettings &settings, Params &p,
+         bool updating) {
          if (!updating)
             e.mThreshold = DB_TO_LINEAR(p.mThreshold_dB);
          return true;

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -37,7 +37,7 @@ const EffectParameterMethods& EffectDtmf::Parameters() const
    static CapturedParameters<EffectDtmf,
       Sequence, DutyCycle, Amplitude
    > parameters{
-      [](EffectDtmf &effect, Settings &s, bool updating){
+      [](EffectDtmf &effect, EffectSettings &, Settings &s, bool updating){
          if (updating) {
             if (s.dtmfSequence.find_first_not_of(AllSymbols())
                 != wxString::npos)

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -484,11 +484,20 @@ int Effect::ShowHostInterface(wxWindow &parent,
    return result;
 }
 
-bool Effect::VisitSettings( SettingsVisitor &S )
+bool Effect::VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
 {
    if (mClient)
-      return mClient->VisitSettings( S );
-   Parameters().Visit( *this, S );
+      return mClient->VisitSettings(visitor, settings);
+   Parameters().Visit(*this, visitor);
+   return true;
+}
+
+bool Effect::VisitSettings(
+   ConstSettingsVisitor &visitor, const EffectSettings &settings)
+{
+   if (mClient)
+      return mClient->VisitSettings(visitor, settings);
+   Parameters().Visit(*this, visitor);
    return true;
 }
 
@@ -818,7 +827,7 @@ bool Effect::SaveSettingsAsString(
    ShuttleGetAutomation S;
    S.mpEap = &eap;
    // To do: fix const_cast in use of VisitSettings, and pass settings
-   if( const_cast<Effect*>(this)->VisitSettings( S ) ){
+   if( const_cast<Effect*>(this)->VisitSettings( S, settings ) ){
       ;// got eap value using VisitSettings.
    }
    // Won't be needed in future
@@ -874,7 +883,7 @@ bool Effect::LoadSettingsFromString(
       S.SetForValidating( &eap );
       // VisitSettings returns false if not defined for this effect.
       // To do: fix const_cast in use of VisitSettings
-      if ( !const_cast<Effect*>(this)->VisitSettings( S ) )
+      if ( !const_cast<Effect*>(this)->VisitSettings(S, settings) )
          // the old method...
          success = LoadSettings(eap, settings);
       else if( !S.bOK )
@@ -882,7 +891,7 @@ bool Effect::LoadSettingsFromString(
       else{
          success = true;
          S.SetForWriting( &eap );
-         const_cast<Effect*>(this)->VisitSettings( S );
+         const_cast<Effect*>(this)->VisitSettings(S, settings);
       }
    }
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -488,7 +488,7 @@ bool Effect::VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
 {
    if (mClient)
       return mClient->VisitSettings(visitor, settings);
-   Parameters().Visit(*this, visitor);
+   Parameters().Visit(*this, visitor, settings);
    return true;
 }
 
@@ -497,7 +497,7 @@ bool Effect::VisitSettings(
 {
    if (mClient)
       return mClient->VisitSettings(visitor, settings);
-   Parameters().Visit(*this, visitor);
+   Parameters().Visit(*this, visitor, settings);
    return true;
 }
 
@@ -506,7 +506,7 @@ bool Effect::SaveSettings(
 {
    if (mClient)
       return mClient->SaveSettings(settings, parms);
-   Parameters().Get( *this, parms );
+   Parameters().Get( *this, settings, parms );
    return true;
 }
 
@@ -517,7 +517,7 @@ bool Effect::LoadSettings(
       return mClient->LoadSettings(parms, settings);
    // The first argument, and with it the const_cast, will disappear when
    // all built-in effects are stateless.
-   return Parameters().Set( *const_cast<Effect*>(this), parms );
+   return Parameters().Set( *const_cast<Effect*>(this), parms, settings );
 }
 
 bool Effect::LoadUserPreset(

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -493,7 +493,7 @@ bool Effect::VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
 }
 
 bool Effect::VisitSettings(
-   ConstSettingsVisitor &visitor, const EffectSettings &settings)
+   ConstSettingsVisitor &visitor, const EffectSettings &settings) const
 {
    if (mClient)
       return mClient->VisitSettings(visitor, settings);
@@ -826,8 +826,7 @@ bool Effect::SaveSettingsAsString(
    CommandParameters eap;
    ShuttleGetAutomation S;
    S.mpEap = &eap;
-   // To do: fix const_cast in use of VisitSettings, and pass settings
-   if( const_cast<Effect*>(this)->VisitSettings( S, settings ) ){
+   if( VisitSettings( S, settings ) ){
       ;// got eap value using VisitSettings.
    }
    // Won't be needed in future

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -492,10 +492,11 @@ bool Effect::VisitSettings( SettingsVisitor &S )
    return true;
 }
 
-bool Effect::GetAutomationParameters(CommandParameters & parms) const
+bool Effect::SaveSettings(
+   const EffectSettings &settings, CommandParameters & parms) const
 {
    if (mClient)
-      return mClient->GetAutomationParameters(parms);
+      return mClient->SaveSettings(settings, parms);
    Parameters().Get( *this, parms );
    return true;
 }
@@ -808,7 +809,7 @@ bool Effect::Startup(EffectUIClientInterface *client, EffectSettings &settings)
 }
 
 bool Effect::GetAutomationParametersAsString(
-   const EffectSettings &, wxString & parms) const
+   const EffectSettings &settings, wxString & parms) const
 {
    CommandParameters eap;
    ShuttleGetAutomation S;
@@ -818,7 +819,7 @@ bool Effect::GetAutomationParametersAsString(
       ;// got eap value using VisitSettings.
    }
    // Won't be needed in future
-   else if (!GetAutomationParameters(eap))
+   else if (!SaveSettings(settings, eap))
    {
       return false;
    }
@@ -864,7 +865,7 @@ bool Effect::SetAutomationParametersFromString(
       // If the string did not start with any of the significant substrings,
       // then use VisitSettings or SetAutomationParameters to reinterpret it,
       // or use SetAutomationParameters.
-      // This interprets what was written by GetAutomationParameters, above.
+      // This interprets what was written by SaveSettings, above.
       CommandParameters eap(parms);
       ShuttleSetAutomation S;
       S.SetForValidating( &eap );

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -525,7 +525,7 @@ bool Effect::LoadUserPreset(
       name, wxT("Parameters"), parms))
       return false;
 
-   return SetAutomationParametersFromString(parms, settings);
+   return LoadSettingsFromString(parms, settings);
 }
 
 bool Effect::SaveUserPreset(
@@ -537,7 +537,7 @@ bool Effect::SaveUserPreset(
 
    // Save all settings as a single string value in the registry
    wxString parms;
-   if (!GetAutomationParametersAsString(settings, parms))
+   if (!SaveSettingsAsString(settings, parms))
       return false;
 
    return SetConfig(GetDefinition(), PluginSettings::Private,
@@ -633,7 +633,7 @@ static const FileNames::FileTypes &PresetTypes()
 void Effect::ExportPresets(const EffectSettings &settings) const
 {
    wxString params;
-   GetAutomationParametersAsString(settings, params);
+   SaveSettingsAsString(settings, params);
    auto commandId = GetSquashedName(GetSymbol().Internal());
    params =  commandId.GET() + ":" + params;
 
@@ -721,7 +721,7 @@ void Effect::ImportPresets(EffectSettings &settings)
             }
             return;
          }
-         SetAutomationParametersFromString(params, settings);
+         LoadSettingsFromString(params, settings);
       }
    }
 
@@ -811,7 +811,7 @@ bool Effect::Startup(EffectUIClientInterface *client, EffectSettings &settings)
    return true;
 }
 
-bool Effect::GetAutomationParametersAsString(
+bool Effect::SaveSettingsAsString(
    const EffectSettings &settings, wxString & parms) const
 {
    CommandParameters eap;
@@ -830,7 +830,7 @@ bool Effect::GetAutomationParametersAsString(
    return eap.GetParameters(parms);
 }
 
-bool Effect::SetAutomationParametersFromString(
+bool Effect::LoadSettingsFromString(
    const wxString & parms, EffectSettings &settings) const
 {
    // If the string starts with one of certain significant substrings,

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -501,11 +501,14 @@ bool Effect::SaveSettings(
    return true;
 }
 
-bool Effect::SetAutomationParameters(const CommandParameters & parms)
+bool Effect::LoadSettings(
+   const CommandParameters & parms, Settings &settings) const
 {
    if (mClient)
-      return mClient->SetAutomationParameters(parms);
-   return Parameters().Set( *this, parms );
+      return mClient->LoadSettings(parms, settings);
+   // The first argument, and with it the const_cast, will disappear when
+   // all built-in effects are stateless.
+   return Parameters().Set( *const_cast<Effect*>(this), parms );
 }
 
 bool Effect::LoadUserPreset(
@@ -863,8 +866,8 @@ bool Effect::SetAutomationParametersFromString(
    else
    {
       // If the string did not start with any of the significant substrings,
-      // then use VisitSettings or SetAutomationParameters to reinterpret it,
-      // or use SetAutomationParameters.
+      // then use VisitSettings or LoadSettings to reinterpret it,
+      // or use LoadSettings.
       // This interprets what was written by SaveSettings, above.
       CommandParameters eap(parms);
       ShuttleSetAutomation S;
@@ -873,7 +876,7 @@ bool Effect::SetAutomationParametersFromString(
       // To do: fix const_cast in use of VisitSettings
       if ( !const_cast<Effect*>(this)->VisitSettings( S ) )
          // the old method...
-         success = const_cast<Effect*>(this)->SetAutomationParameters(eap);
+         success = LoadSettings(eap, settings);
       else if( !S.bOK )
          success = false;
       else{

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -93,7 +93,11 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // ComponentInterface implementation
 
    PluginPath GetPath() const override;
-   bool VisitSettings( SettingsVisitor & ) override;
+   bool VisitSettings(
+      SettingsVisitor &visitor, EffectSettings &settings) override;
+   bool VisitSettings(
+      ConstSettingsVisitor &visitor, const EffectSettings &settings)
+      override;
 
    ComponentInterfaceSymbol GetSymbol() const override;
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -110,7 +110,8 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    bool SupportsRealtime() const override;
    bool SupportsAutomation() const override;
 
-   bool GetAutomationParameters(CommandParameters & parms) const override;
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
    bool SetAutomationParameters(const CommandParameters & parms) override;
 
    bool LoadUserPreset(
@@ -140,7 +141,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
 
-   // VisitSettings(), GetAutomationParameters(), and SetAutomationParameters()
+   // VisitSettings(), SaveSettings(), and SetAutomationParameters()
    // use the functions of EffectParameterMethods.  By default, this function
    // defines an empty list of parameters.
    virtual const EffectParameterMethods &Parameters() const;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -199,9 +199,9 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // The Effect class fully implements the Preview method for you.
    // Only override it if you need to do preprocessing or cleanup.
    void Preview(EffectSettingsAccess &access, bool dryOnly) override;
-   bool GetAutomationParametersAsString(
+   bool SaveSettingsAsString(
       const EffectSettings &settings, wxString & parms) const override;
-   bool SetAutomationParametersFromString(
+   bool LoadSettingsFromString(
       const wxString & parms, EffectSettings &settings) const override;
    bool IsBatchProcessing() const override;
    void SetBatchProcessing() override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -97,7 +97,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
       SettingsVisitor &visitor, EffectSettings &settings) override;
    bool VisitSettings(
       ConstSettingsVisitor &visitor, const EffectSettings &settings)
-      override;
+      const override;
 
    ComponentInterfaceSymbol GetSymbol() const override;
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -112,7 +112,8 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
-   bool SetAutomationParameters(const CommandParameters & parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
 
    bool LoadUserPreset(
       const RegistryPath & name, Settings &settings) const override;
@@ -139,9 +140,9 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    void SetSampleRate(double rate) override;
    size_t SetBlockSize(size_t maxBlockSize) override;
-   size_t GetBlockSize() const override;
+   size_t GetBlockSize() const override;  
 
-   // VisitSettings(), SaveSettings(), and SetAutomationParameters()
+   // VisitSettings(), SaveSettings(), and LoadSettings()
    // use the functions of EffectParameterMethods.  By default, this function
    // defines an empty list of parameters.
    virtual const EffectParameterMethods &Parameters() const;

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -248,7 +248,7 @@ wxString EffectManager::GetEffectParameters(const PluginID & ID)
       assert(pair.second);
       wxString parms;
 
-      effect->GetAutomationParametersAsString(*pair.second, parms);
+      effect->SaveSettingsAsString(*pair.second, parms);
 
       // Some effects don't have automatable parameters and will not return
       // anything, so try to get the active preset (current or factory).
@@ -266,7 +266,7 @@ wxString EffectManager::GetEffectParameters(const PluginID & ID)
    {
       wxString parms;
 
-      command->GetAutomationParametersAsString(parms);
+      command->SaveSettingsAsString(parms);
 
       // Some effects don't have automatable parameters and will not return
       // anything, so try to get the active preset (current or factory).
@@ -292,11 +292,11 @@ bool EffectManager::SetEffectParameters(
       // Check first for what GetDefaultPreset() might have written
       if (eap.HasEntry(wxT("Use Preset")))
       {
-         return effect->SetAutomationParametersFromString(
+         return effect->LoadSettingsFromString(
             eap.Read(wxT("Use Preset")), settings);
       }
 
-      return effect->SetAutomationParametersFromString(params, settings);
+      return effect->LoadSettingsFromString(params, settings);
    }
    AudacityCommand *command = GetAudacityCommand(ID);
    
@@ -310,10 +310,10 @@ bool EffectManager::SetEffectParameters(
       if (eap.HasEntry(wxT("Use Preset")))
       {
          return command
-            ->SetAutomationParametersFromString(eap.Read(wxT("Use Preset")));
+            ->LoadSettingsFromString(eap.Read(wxT("Use Preset")));
       }
 
-      return command->SetAutomationParametersFromString(params);
+      return command->LoadSettingsFromString(params);
    }
    return false;
 }

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -166,13 +166,12 @@ TranslatableString EffectManager::GetCommandTip(const PluginID & ID)
 
 void EffectManager::GetCommandDefinition(const PluginID & ID, const CommandContext & context, int flags)
 {
-   EffectDefinitionInterface *effect = nullptr;
+   const EffectDefinitionInterface *effect = nullptr;
    const EffectSettings *settings;
    AudacityCommand *command = nullptr;
 
    if (auto [edi, pSettings] = GetEffectAndDefaultSettings(ID); edi) {
-      // Fixing this will be a large and difficult thing, so for the time being we only cast the constness away
-      effect = const_cast<EffectDefinitionInterface*>(&edi->GetDefinition());
+      effect = &edi->GetDefinition();
       assert(settings);
       settings = pSettings;
    }

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -178,7 +178,8 @@ const EffectParameterMethods& EffectEqualization::Parameters() const
       // specified in chains, but must keep it that way for compatibility.
       InterpMeth
    > parameters {
-      [](EffectEqualization &, EffectEqualization &effect, bool updating){
+      [](EffectEqualization &, EffectSettings &, EffectEqualization &effect,
+         bool updating){
          if (updating) {
             if (effect.mInterp >= nInterpolations)
                effect.mInterp -= nInterpolations;

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -374,7 +374,7 @@ EffectType EffectEqualization::GetType() const
 
 // EffectProcessor implementation
 bool EffectEqualization::VisitSettings(
-   ConstSettingsVisitor &visitor, const EffectSettings &settings)
+   ConstSettingsVisitor &visitor, const EffectSettings &settings) const
 {
    Effect::VisitSettings(visitor, settings);
 

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -373,25 +373,34 @@ EffectType EffectEqualization::GetType() const
 }
 
 // EffectProcessor implementation
-bool EffectEqualization::VisitSettings( SettingsVisitor &S )
+bool EffectEqualization::VisitSettings(
+   ConstSettingsVisitor &visitor, const EffectSettings &settings)
 {
-   Effect::VisitSettings(S);
+   Effect::VisitSettings(visitor, settings);
 
-   // if saving the preferences...
-   if( dynamic_cast<ShuttleGetAutomation*>(&S))
-   {
+   // Curve point parameters -- how many isn't known statically
+   if( dynamic_cast<ShuttleGetAutomation*>(&visitor)) {
       int numPoints = mCurves[ 0 ].points.size();
       int point;
       for( point = 0; point < numPoints; point++ )
       {
          const wxString nameFreq = wxString::Format("f%i",point);
          const wxString nameVal = wxString::Format("v%i",point);
-         S.Define( mCurves[ 0 ].points[ point ].Freq,  nameFreq, 0.0,  0.0, 0.0, 0.0 );
-         S.Define( mCurves[ 0 ].points[ point ].dB,    nameVal,  0.0, 0.0, 0.0, 0.0 );
+         visitor.Define( mCurves[ 0 ].points[ point ].Freq, nameFreq,
+            0.0, 0.0, 0.0, 0.0 );
+         visitor.Define( mCurves[ 0 ].points[ point ].dB, nameVal,
+            0.0, 0.0, 0.0, 0.0 );
       }
-
    }
-   else
+   return true;
+}
+
+bool EffectEqualization::VisitSettings(
+   SettingsVisitor &visitor, EffectSettings &settings)
+{
+   Effect::VisitSettings(visitor, settings);
+
+   // Curve point parameters -- how many isn't known statically
    {
       mCurves[0].points.clear();
    
@@ -401,15 +410,14 @@ bool EffectEqualization::VisitSettings( SettingsVisitor &S )
          const wxString nameVal = wxString::Format("v%i",i);
          double f = -1000.0;
          double d = 0.0;
-         S.Define( f,  nameFreq, 0.0,  -10000.0, 1000000.0, 0.0 );
-         S.Define( d, nameVal,  0.0, -10000.0, 10000.0, 0.0 );
+         visitor.Define( f, nameFreq, 0.0,  -10000.0, 1000000.0, 0.0 );
+         visitor.Define( d, nameVal,  0.0, -10000.0, 10000.0, 0.0 );
          if( f <= 0.0 )
             break;
          mCurves[0].points.push_back( EQPoint( f,d ));
       }
       setCurve( 0 );
    }
-
    return true;
 }
 
@@ -476,7 +484,7 @@ RegistryPaths EffectEqualization::GetFactoryPresets() const
    return names;
 }
 
-bool EffectEqualization::LoadFactoryPreset(int id, EffectSettings &) const
+bool EffectEqualization::LoadFactoryPreset(int id, EffectSettings &settings) const
 {
    int index = -1;
    for (size_t i = 0; i < WXSIZEOF(FactoryPresets); i++)
@@ -498,7 +506,7 @@ bool EffectEqualization::LoadFactoryPreset(int id, EffectSettings &) const
    ShuttleSetAutomation S;
    S.SetForWriting( &eap );
    // To do: externalize state so const_cast isn't needed
-   const_cast<EffectEqualization*>(this)->VisitSettings( S );
+   const_cast<EffectEqualization*>(this)->VisitSettings(S, settings);
    return true;
 }
 

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -113,7 +113,7 @@ public:
       override;
    bool VisitSettings(
       ConstSettingsVisitor &visitor, const EffectSettings &settings)
-      override;
+      const override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -109,7 +109,11 @@ public:
    ComponentInterfaceSymbol GetSymbol() const override;
    TranslatableString GetDescription() const override;
    ManualPageID ManualPage() const override;
-   bool VisitSettings(SettingsVisitor & S) override;
+   bool VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
+      override;
+   bool VisitSettings(
+      ConstSettingsVisitor &visitor, const EffectSettings &settings)
+      override;
 
    // EffectDefinitionInterface implementation
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -463,7 +463,7 @@ int EffectNoiseReduction::ShowHostInterface(
    // Doesn't use the factory but substitutes its own dialog
 
    // We may want to twiddle the levels if we are setting
-   // from an automation dialog
+   // from a macro editing dialog
    return mSettings->PromptUser(this, access, parent,
       bool(mStatistics), forceModal);
 }

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -175,7 +175,7 @@ int EffectNoiseRemoval::ShowHostInterface(
    dlog.mKeepNoise->SetValue(mbLeaveNoise);
 
    // We may want to twiddle the levels if we are setting
-   // from an automation dialog
+   // from a macro editing dialog
    bool bAllowTwiddleSettings = forceModal;
 
    if (mHasProfile || bAllowTwiddleSettings) {

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -47,7 +47,7 @@ const EffectParameterMethods& EffectPhaser::Parameters() const
    static CapturedParameters<EffectPhaser,
       Stages, DryWet, Freq, Phase, Depth, Feedback, OutGain
    > parameters{
-      [](EffectPhaser &, EffectPhaser &e, bool updating){
+      [](EffectPhaser &, EffectSettings &, EffectPhaser &e, bool updating){
          if (updating)
             e.mStages &= ~1; // must be even, but don't complain about it
          return true;

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -106,7 +106,8 @@ const EffectParameterMethods& EffectScienFilter::Parameters() const
    static CapturedParameters<EffectScienFilter,
       Type, Subtype, Order, Cutoff, Passband, Stopband
    > parameters{
-      [](EffectScienFilter &, EffectScienFilter &e, bool updating){
+      [](EffectScienFilter &, EffectSettings &, EffectScienFilter &e,
+         bool updating){
          if (updating) {
             e.mOrderIndex = e.mOrder - 1;
             e.CalcFilter();

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -53,7 +53,7 @@ const EnumValueSymbol EffectToneGen::kWaveStrings[nWaveforms] =
 const EffectParameterMethods& EffectToneGen::Parameters() const
 {
    static const auto postSet =
-   [](EffectToneGen &, EffectToneGen &e, bool updating) {
+   [](EffectToneGen &, EffectSettings &, EffectToneGen &e, bool updating) {
       if (updating)
          e.PostSet();
       return true;

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -160,9 +160,10 @@ EffectType EffectTruncSilence::GetType() const
 
 // EffectProcessor implementation
 
-bool EffectTruncSilence::SetAutomationParameters(const CommandParameters & parms)
+bool EffectTruncSilence::LoadSettings(
+   const CommandParameters & parms, Settings &settings) const
 {
-   Effect::SetAutomationParameters(parms);
+   Effect::LoadSettings(parms, settings);
 
    // A bit of special treatment for two parameters
 
@@ -191,9 +192,12 @@ bool EffectTruncSilence::SetAutomationParameters(const CommandParameters & parms
       if (!parms.ReadAndVerify( ActIndex.key, &temp, ActIndex.def,
          kActionStrings, nActions, kObsoleteActions, nObsoleteActions))
          return false;
-      mActionIndex = temp;
+   
+      // TODO:  fix this when settings are really externalized
+      const_cast<int&>(mActionIndex) = temp;
    }
-   mThresholdDB = myThreshold;
+   // TODO:  fix this when settings are really externalized
+   const_cast<double&>(mThresholdDB) = myThreshold;
    return true;
 }
 

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -46,7 +46,8 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool SetAutomationParameters(const CommandParameters & parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
 
    // Effect implementation
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -290,7 +290,8 @@ public:
       return mAutomatable;
    }
 
-   bool GetAutomationParameters(CommandParameters &) const override { return true; }
+   bool SaveSettings(const EffectSettings &, CommandParameters &) const override
+      { return true; }
    bool SetAutomationParameters(const CommandParameters &) override { return true; }
 
    bool LoadUserPreset(const RegistryPath &, Settings &) const override
@@ -1315,7 +1316,8 @@ bool VSTEffect::InitializePlugin()
    return true;
 }
 
-bool VSTEffect::InitializeInstance(EffectHostInterface *host, EffectSettings &)
+bool VSTEffect::InitializeInstance(
+   EffectHostInterface *host, EffectSettings &settings)
 {
    mHost = host;
    if (mHost)
@@ -1335,7 +1337,7 @@ bool VSTEffect::InitializeInstance(EffectHostInterface *host, EffectSettings &)
          false);
       if (!haveDefaults)
       {
-         SaveParameters(FactoryDefaultsGroup());
+         SaveParameters(FactoryDefaultsGroup(), settings);
          SetConfig(*this, PluginSettings::Private,
             FactoryDefaultsGroup(), wxT("Initialized"), true);
       }
@@ -1620,7 +1622,8 @@ int VSTEffect::ShowClientInterface(
    return mDialog->ShowModal();
 }
 
-bool VSTEffect::GetAutomationParameters(CommandParameters & parms) const
+bool VSTEffect::SaveSettings(
+   const EffectSettings &, CommandParameters & parms) const
 {
    for (int i = 0; i < mAEffect->numParams; i++)
    {
@@ -1689,9 +1692,9 @@ bool VSTEffect::DoLoadUserPreset(const RegistryPath & name)
 }
 
 bool VSTEffect::SaveUserPreset(
-   const RegistryPath & name, const EffectSettings &) const
+   const RegistryPath & name, const EffectSettings &settings) const
 {
-   return SaveParameters(name);
+   return SaveParameters(name, settings);
 }
 
 RegistryPaths VSTEffect::GetFactoryPresets() const
@@ -2354,7 +2357,8 @@ bool VSTEffect::LoadParameters(const RegistryPath & group)
    return SetAutomationParameters(eap);
 }
 
-bool VSTEffect::SaveParameters(const RegistryPath & group) const
+bool VSTEffect::SaveParameters(
+   const RegistryPath & group, const EffectSettings &settings) const
 {
    SetConfig(*this, PluginSettings::Private, group, wxT("UniqueID"),
       mAEffect->uniqueID);
@@ -2378,7 +2382,7 @@ bool VSTEffect::SaveParameters(const RegistryPath & group) const
    }
 
    CommandParameters eap;
-   if (!GetAutomationParameters(eap))
+   if (!SaveSettings(settings, eap))
    {
       return false;
    }

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -118,11 +118,12 @@ class VSTEffect final : public wxEvtHandler,
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
-   bool SetAutomationParameters(const CommandParameters & parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
 
    bool LoadUserPreset(
       const RegistryPath & name, Settings &settings) const override;
-   bool DoLoadUserPreset(const RegistryPath & name);
+   bool DoLoadUserPreset(const RegistryPath & name, EffectSettings &settings);
    bool SaveUserPreset(
       const RegistryPath & name, const Settings &settings) const override;
 
@@ -130,7 +131,7 @@ class VSTEffect final : public wxEvtHandler,
    bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
    bool DoLoadFactoryPreset(int id);
    bool LoadFactoryDefaults(EffectSettings &settings) const override;
-   bool DoLoadFactoryDefaults();
+   bool DoLoadFactoryDefaults(EffectSettings &settings);
 
    // EffectProcessor implementation
 
@@ -209,7 +210,7 @@ private:
    std::vector<int> GetEffectIDs();
 
    // Parameter loading and saving
-   bool LoadParameters(const RegistryPath & group);
+   bool LoadParameters(const RegistryPath & group, EffectSettings &settings);
    bool SaveParameters(
        const RegistryPath & group, const EffectSettings &settings) const;
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -116,7 +116,8 @@ class VSTEffect final : public wxEvtHandler,
    bool SupportsRealtime() const override;
    bool SupportsAutomation() const override;
 
-   bool GetAutomationParameters(CommandParameters & parms) const override;
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
    bool SetAutomationParameters(const CommandParameters & parms) override;
 
    bool LoadUserPreset(
@@ -209,7 +210,8 @@ private:
 
    // Parameter loading and saving
    bool LoadParameters(const RegistryPath & group);
-   bool SaveParameters(const RegistryPath & group) const;
+   bool SaveParameters(
+       const RegistryPath & group, const EffectSettings &settings) const;
 
    // Realtime
    unsigned GetChannelCount();

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -340,7 +340,8 @@ bool VST3Effect::SupportsAutomation() const
    return false;
 }
 
-bool VST3Effect::GetAutomationParameters(CommandParameters& parms) const
+bool VST3Effect::SaveSettings(
+   const EffectSettings &, CommandParameters & parms) const
 {
    if(mEditController == nullptr)
       return false;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -366,7 +366,8 @@ bool VST3Effect::SaveSettings(
    return true;
 }
 
-bool VST3Effect::SetAutomationParameters(const CommandParameters& parms)
+bool VST3Effect::LoadSettings(
+   const CommandParameters & parms, Settings &settings) const
 {
    using namespace Steinberg;
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -108,7 +108,8 @@ public:
    bool SupportsAutomation() const override;
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
-   bool SetAutomationParameters(const CommandParameters& parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
    bool LoadUserPreset(
       const RegistryPath & name, Settings &settings) const override;
    bool SaveUserPreset(

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -106,7 +106,8 @@ public:
    bool IsDefault() const override;
    bool SupportsRealtime() const override;
    bool SupportsAutomation() const override;
-   bool GetAutomationParameters(CommandParameters& parms) const override;
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
    bool SetAutomationParameters(const CommandParameters& parms) override;
    bool LoadUserPreset(
       const RegistryPath & name, Settings &settings) const override;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1467,7 +1467,8 @@ int AudioUnitEffect::ShowClientInterface(
    return mDialog->ShowModal();
 }
 
-bool AudioUnitEffect::GetAutomationParameters(CommandParameters & parms) const
+bool AudioUnitEffect::SaveSettings(
+   const EffectSettings &, CommandParameters & parms) const
 {
    OSStatus result;
    UInt32 dataSize;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1040,7 +1040,7 @@ bool AudioUnitEffect::InitializePlugin()
 }
 
 bool AudioUnitEffect::InitializeInstance(
-   EffectHostInterface *host, EffectSettings &)
+   EffectHostInterface *host, EffectSettings &settings)
 {
    OSStatus result;
 
@@ -1067,7 +1067,7 @@ bool AudioUnitEffect::InitializeInstance(
             FactoryDefaultsGroup(), wxT("Initialized"), true);
       }
 
-      LoadPreset(CurrentSettingsGroup());
+      LoadPreset(CurrentSettingsGroup(), settings);
    }
 
    return true;
@@ -1531,7 +1531,8 @@ bool AudioUnitEffect::SaveSettings(
    return true;
 }
 
-bool AudioUnitEffect::SetAutomationParameters(const CommandParameters & parms)
+bool AudioUnitEffect::LoadSettings(
+   const CommandParameters & parms, Settings &settings) const
 {
    OSStatus result;
    UInt32 dataSize;
@@ -1593,10 +1594,10 @@ bool AudioUnitEffect::SetAutomationParameters(const CommandParameters & parms)
 }
 
 bool AudioUnitEffect::LoadUserPreset(
-   const RegistryPath & name, EffectSettings &) const
+   const RegistryPath & name, EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
-   return const_cast<AudioUnitEffect*>(this)->LoadPreset(name);
+   return const_cast<AudioUnitEffect*>(this)->LoadPreset(name, settings);
 }
 
 bool AudioUnitEffect::SaveUserPreset(
@@ -1646,10 +1647,11 @@ bool AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &) const
    return result == noErr;
 }
 
-bool AudioUnitEffect::LoadFactoryDefaults(EffectSettings &) const
+bool AudioUnitEffect::LoadFactoryDefaults(EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
-   return const_cast<AudioUnitEffect*>(this)->LoadPreset(FactoryDefaultsGroup());
+   return const_cast<AudioUnitEffect*>(this)
+      ->LoadPreset(FactoryDefaultsGroup(), settings);
 }
 
 RegistryPaths AudioUnitEffect::GetFactoryPresets() const
@@ -1912,7 +1914,8 @@ void AudioUnitEffect::ShowOptions()
 // AudioUnitEffect Implementation
 // ============================================================================
 
-bool AudioUnitEffect::LoadPreset(const RegistryPath & group)
+bool AudioUnitEffect::LoadPreset(
+   const RegistryPath & group, EffectSettings &settings)
 {
    wxString parms;
 
@@ -1924,7 +1927,7 @@ bool AudioUnitEffect::LoadPreset(const RegistryPath & group)
       CommandParameters eap;
       if (eap.SetParameters(parms))
       {
-         if (SetAutomationParameters(eap))
+         if (LoadSettings(eap, settings))
          {
             if (SavePreset(group))
             {

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -67,7 +67,8 @@ public:
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
-   bool SetAutomationParameters(const CommandParameters & parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
 
    bool LoadUserPreset(
       const RegistryPath & name, Settings &settings) const override;
@@ -171,7 +172,7 @@ private:
 
    void GetChannelCounts();
 
-   bool LoadPreset(const RegistryPath & group);
+   bool LoadPreset(const RegistryPath & group, EffectSettings &settings);
    bool SavePreset(const RegistryPath & group) const;
 
 #if defined(HAVE_AUDIOUNIT_BASIC_SUPPORT)

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -65,7 +65,8 @@ public:
    bool SupportsRealtime() const override;
    bool SupportsAutomation() const override;
 
-   bool GetAutomationParameters(CommandParameters & parms) const override;
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
    bool SetAutomationParameters(const CommandParameters & parms) override;
 
    bool LoadUserPreset(

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -883,9 +883,8 @@ bool LadspaEffect::InitializeInstance(
             FactoryDefaultsGroup(), wxT("Initialized"), true);
       }
 
-      LoadParameters(CurrentSettingsGroup());
+      LoadParameters(CurrentSettingsGroup(), settings);
    }
-
    return true;
 }
 
@@ -1103,7 +1102,8 @@ bool LadspaEffect::SaveSettings(
    return true;
 }
 
-bool LadspaEffect::SetAutomationParameters(const CommandParameters & parms)
+bool LadspaEffect::LoadSettings(
+   const CommandParameters & parms, Settings &settings) const
 {
    for (unsigned long p = 0; p < mData->PortCount; p++)
    {
@@ -1126,15 +1126,16 @@ bool LadspaEffect::SetAutomationParameters(const CommandParameters & parms)
 }
 
 bool LadspaEffect::LoadUserPreset(
-   const RegistryPath & name, EffectSettings &) const
+   const RegistryPath & name, EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
-   return const_cast<LadspaEffect*>(this)->DoLoadUserPreset(name);
+   return const_cast<LadspaEffect*>(this)->DoLoadUserPreset(name, settings);
 }
 
-bool LadspaEffect::DoLoadUserPreset(const RegistryPath & name)
+bool LadspaEffect::DoLoadUserPreset(
+   const RegistryPath & name, EffectSettings &settings)
 {
-   if (!LoadParameters(name))
+   if (!LoadParameters(name, settings))
    {
       return false;
    }
@@ -1160,15 +1161,15 @@ bool LadspaEffect::LoadFactoryPreset(int, EffectSettings &) const
    return true;
 }
 
-bool LadspaEffect::LoadFactoryDefaults(EffectSettings &) const
+bool LadspaEffect::LoadFactoryDefaults(EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
-   return const_cast<LadspaEffect*>(this)->DoLoadFactoryDefaults();
+   return const_cast<LadspaEffect*>(this)->DoLoadFactoryDefaults(settings);
 }
 
-bool LadspaEffect::DoLoadFactoryDefaults()
+bool LadspaEffect::DoLoadFactoryDefaults(EffectSettings &settings)
 {
-   if (!LoadParameters(FactoryDefaultsGroup()))
+   if (!LoadParameters(FactoryDefaultsGroup(), settings))
    {
       return false;
    }
@@ -1612,7 +1613,8 @@ void LadspaEffect::Unload()
    }
 }
 
-bool LadspaEffect::LoadParameters(const RegistryPath & group)
+bool LadspaEffect::LoadParameters(
+   const RegistryPath & group, EffectSettings &settings)
 {
    wxString parms;
    if (!GetConfig(*this, PluginSettings::Private, group, wxT("Parameters"),
@@ -1627,7 +1629,7 @@ bool LadspaEffect::LoadParameters(const RegistryPath & group)
       return false;
    }
 
-   return SetAutomationParameters(eap);
+   return LoadSettings(eap, settings);
 }
 
 bool LadspaEffect::SaveParameters(

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -863,7 +863,7 @@ bool LadspaEffect::InitializePlugin()
 }
 
 bool LadspaEffect::InitializeInstance(
-   EffectHostInterface *host, EffectSettings &)
+   EffectHostInterface *host, EffectSettings &settings)
 {
    mHost = host;
 
@@ -878,7 +878,7 @@ bool LadspaEffect::InitializeInstance(
          false);
       if (!haveDefaults)
       {
-         SaveParameters(FactoryDefaultsGroup());
+         SaveParameters(FactoryDefaultsGroup(), settings);
          SetConfig(*this, PluginSettings::Private,
             FactoryDefaultsGroup(), wxT("Initialized"), true);
       }
@@ -1084,7 +1084,8 @@ int LadspaEffect::ShowClientInterface(
    return mDialog->ShowModal();
 }
 
-bool LadspaEffect::GetAutomationParameters(CommandParameters & parms) const
+bool LadspaEffect::SaveSettings(
+   const EffectSettings &, CommandParameters & parms) const
 {
    for (unsigned long p = 0; p < mData->PortCount; p++)
    {
@@ -1144,9 +1145,9 @@ bool LadspaEffect::DoLoadUserPreset(const RegistryPath & name)
 }
 
 bool LadspaEffect::SaveUserPreset(
-   const RegistryPath & name, const EffectSettings &) const
+   const RegistryPath & name, const EffectSettings &settings) const
 {
-   return SaveParameters(name);
+   return SaveParameters(name, settings);
 }
 
 RegistryPaths LadspaEffect::GetFactoryPresets() const
@@ -1629,10 +1630,11 @@ bool LadspaEffect::LoadParameters(const RegistryPath & group)
    return SetAutomationParameters(eap);
 }
 
-bool LadspaEffect::SaveParameters(const RegistryPath & group) const
+bool LadspaEffect::SaveParameters(
+   const RegistryPath & group, const EffectSettings &settings) const
 {
    CommandParameters eap;
-   if (!GetAutomationParameters(eap))
+   if (!SaveSettings(settings, eap))
    {
       return false;
    }

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -64,7 +64,8 @@ public:
    bool SupportsRealtime() const override;
    bool SupportsAutomation() const override;
 
-   bool GetAutomationParameters(CommandParameters & parms) const override;
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
    bool SetAutomationParameters(const CommandParameters & parms) override;
 
    bool LoadUserPreset(
@@ -140,7 +141,8 @@ private:
    void Unload();
 
    bool LoadParameters(const RegistryPath & group);
-   bool SaveParameters(const RegistryPath & group) const;
+   bool SaveParameters(
+      const RegistryPath & group, const EffectSettings &settings) const;
 
    LADSPA_Handle InitInstance(float sampleRate);
    void FreeInstance(LADSPA_Handle handle);

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -66,18 +66,19 @@ public:
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
-   bool SetAutomationParameters(const CommandParameters & parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
 
    bool LoadUserPreset(
       const RegistryPath & name, Settings &settings) const override;
-   bool DoLoadUserPreset(const RegistryPath & name);
+   bool DoLoadUserPreset(const RegistryPath & name, Settings &settings);
    bool SaveUserPreset(
       const RegistryPath & name, const Settings &settings) const override;
 
    RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
    bool LoadFactoryDefaults(EffectSettings &settings) const override;
-   bool DoLoadFactoryDefaults();
+   bool DoLoadFactoryDefaults(EffectSettings &settings);
 
    // EffectProcessor implementation
 
@@ -140,7 +141,7 @@ private:
    bool Load();
    void Unload();
 
-   bool LoadParameters(const RegistryPath & group);
+   bool LoadParameters(const RegistryPath & group, EffectSettings &settings);
    bool SaveParameters(
       const RegistryPath & group, const EffectSettings &settings) const;
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -929,7 +929,8 @@ bool LV2Effect::InitializePlugin()
    return true;
 }
 
-bool LV2Effect::InitializeInstance(EffectHostInterface *host, EffectSettings &)
+bool LV2Effect::InitializeInstance(
+   EffectHostInterface *host, EffectSettings &settings)
 {
    mHost = host;
    if (mHost)
@@ -951,7 +952,7 @@ bool LV2Effect::InitializeInstance(EffectHostInterface *host, EffectSettings &)
          false);
       if (!haveDefaults)
       {
-         SaveParameters(FactoryDefaultsGroup());
+         SaveParameters(FactoryDefaultsGroup(), settings);
          SetConfig(*this, PluginSettings::Private,
             FactoryDefaultsGroup(), wxT("Initialized"), true);
       }
@@ -1464,7 +1465,8 @@ int LV2Effect::ShowClientInterface(
    return mDialog->ShowModal();
 }
 
-bool LV2Effect::GetAutomationParameters(CommandParameters &parms) const
+bool LV2Effect::SaveSettings(
+   const EffectSettings &, CommandParameters & parms) const
 {
    for (auto & port : mControlPorts)
    {
@@ -1646,9 +1648,9 @@ bool LV2Effect::DoLoadUserPreset(const RegistryPath &name)
 }
 
 bool LV2Effect::SaveUserPreset(
-   const RegistryPath &name, const EffectSettings &) const
+   const RegistryPath &name, const EffectSettings &settings) const
 {
-   return SaveParameters(name);
+   return SaveParameters(name, settings);
 }
 
 RegistryPaths LV2Effect::GetFactoryPresets() const
@@ -1797,10 +1799,11 @@ bool LV2Effect::LoadParameters(const RegistryPath &group)
    return SetAutomationParameters(eap);
 }
 
-bool LV2Effect::SaveParameters(const RegistryPath &group) const
+bool LV2Effect::SaveParameters(
+   const RegistryPath &group, const EffectSettings &settings) const
 {
    CommandParameters eap;
-   if (!GetAutomationParameters(eap))
+   if (!SaveSettings(settings, eap))
    {
       return false;
    }

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -277,7 +277,8 @@ public:
    bool SupportsRealtime() const override;
    bool SupportsAutomation() const override;
 
-   bool GetAutomationParameters(CommandParameters & parms) const override;
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
    bool SetAutomationParameters(const CommandParameters & parms) override;
 
    bool LoadUserPreset(
@@ -352,7 +353,8 @@ public:
 
 private:
    bool LoadParameters(const RegistryPath & group);
-   bool SaveParameters(const RegistryPath & group) const;
+   bool SaveParameters(
+      const RegistryPath & group, const EffectSettings &settings) const;
 
    LV2Wrapper *InitInstance(float sampleRate);
    void FreeInstance(LV2Wrapper *wrapper);

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -279,11 +279,12 @@ public:
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
-   bool SetAutomationParameters(const CommandParameters & parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
 
    bool LoadUserPreset(
       const RegistryPath & name, Settings &settings) const override;
-   bool DoLoadUserPreset(const RegistryPath & name);
+   bool DoLoadUserPreset(const RegistryPath & name, EffectSettings &settings);
    bool SaveUserPreset(
       const RegistryPath & name, const Settings &settings) const override;
 
@@ -291,7 +292,7 @@ public:
    bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
    bool DoLoadFactoryPreset(int id);
    bool LoadFactoryDefaults(EffectSettings &settings) const override;
-   bool DoLoadFactoryDefaults();
+   bool DoLoadFactoryDefaults(EffectSettings &settings);
 
    // EffectProcessor implementation
 
@@ -352,7 +353,7 @@ public:
    // LV2Effect implementation
 
 private:
-   bool LoadParameters(const RegistryPath & group);
+   bool LoadParameters(const RegistryPath & group, EffectSettings &settings);
    bool SaveParameters(
       const RegistryPath & group, const EffectSettings &settings) const;
 

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -314,7 +314,7 @@ bool NyquistEffect::VisitSettings(
 }
 
 bool NyquistEffect::VisitSettings(
-   ConstSettingsVisitor &visitor, const EffectSettings &settings)
+   ConstSettingsVisitor &visitor, const EffectSettings &settings) const
 {
    // For now we assume Nyquist can do get and set better than VisitSettings can,
    // And so we ONLY use it for getting the signature.

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -307,11 +307,13 @@ bool NyquistEffect::IsDefault() const
 // EffectProcessor implementation
 bool NyquistEffect::VisitSettings(SettingsVisitor & S)
 {
+   EffectSettings DUMMY;
+
    // For now we assume Nyquist can do get and set better than VisitSettings can,
    // And so we ONLY use it for getting the signature.
    auto pGa = dynamic_cast<ShuttleGetAutomation*>(&S);
    if( pGa ){
-      GetAutomationParameters( *(pGa->mpEap) );
+      SaveSettings(DUMMY, *pGa->mpEap);
       return true;
    }
    auto pSa = dynamic_cast<ShuttleSetAutomation*>(&S);
@@ -372,7 +374,8 @@ bool NyquistEffect::VisitSettings(SettingsVisitor & S)
    return true;
 }
 
-bool NyquistEffect::GetAutomationParameters(CommandParameters & parms) const
+bool NyquistEffect::SaveSettings(
+   const EffectSettings &, CommandParameters & parms) const
 {
    if (mIsPrompt)
    {
@@ -1058,6 +1061,9 @@ int NyquistEffect::ShowHostInterface(
 
    if (IsBatchProcessing())
    {
+      // Must give effect its own settings to interpret, not those in access
+      auto newSettings = effect.MakeSettings();
+
       effect.SetBatchProcessing();
       effect.SetCommand(mInputCmd);
 
@@ -1070,7 +1076,7 @@ int NyquistEffect::ShowHostInterface(
       if (res)
       {
          CommandParameters cp;
-         effect.GetAutomationParameters(cp);
+         effect.SaveSettings(newSettings, cp);
          cp.GetParameters(mParameters);
       }
    }

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -93,7 +93,10 @@ public:
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
-   bool SetAutomationParameters(const CommandParameters & parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
+   bool DoLoadSettings(
+      const CommandParameters & parms, Settings &settings);
 
    // EffectProcessor implementation
 

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -100,7 +100,11 @@ public:
 
    // EffectProcessor implementation
 
-   bool VisitSettings( SettingsVisitor & S ) override;
+   bool VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
+      override;
+   bool VisitSettings(
+      ConstSettingsVisitor &visitor, const EffectSettings &settings)
+      override;
    int SetLispVarsFromParameters(const CommandParameters & parms, bool bTestOnly);
 
    // Effect implementation

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -91,7 +91,8 @@ public:
    bool IsDefault() const override;
    bool EnablesDebug() const override;
 
-   bool GetAutomationParameters(CommandParameters & parms) const override;
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
    bool SetAutomationParameters(const CommandParameters & parms) override;
 
    // EffectProcessor implementation

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -104,7 +104,7 @@ public:
       override;
    bool VisitSettings(
       ConstSettingsVisitor &visitor, const EffectSettings &settings)
-      override;
+      const override;
    int SetLispVarsFromParameters(const CommandParameters & parms, bool bTestOnly);
 
    // Effect implementation

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -192,7 +192,8 @@ bool VampEffect::SaveSettings(
    return true;
 }
 
-bool VampEffect::SetAutomationParameters(const CommandParameters & parms)
+bool VampEffect::LoadSettings(
+   const CommandParameters & parms, Settings &settings) const
 {
    // First pass verifies values
    for (size_t p = 0, paramCount = mParameters.size(); p < paramCount; p++)

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -145,7 +145,8 @@ unsigned VampEffect::GetAudioInCount() const
    return mPlugin->getMaxChannelCount();
 }
 
-bool VampEffect::GetAutomationParameters(CommandParameters & parms) const
+bool VampEffect::SaveSettings(
+   const EffectSettings &, CommandParameters & parms) const
 {
    for (size_t p = 0, paramCount = mParameters.size(); p < paramCount; p++)
    {

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -59,7 +59,8 @@ public:
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
-   bool SetAutomationParameters(const CommandParameters & parms) override;
+   bool LoadSettings(
+      const CommandParameters & parms, Settings &settings) const override;
 
    // EffectProcessor implementation
 

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -57,7 +57,8 @@ public:
    bool IsInteractive() const override;
    bool IsDefault() const override;
 
-   bool GetAutomationParameters(CommandParameters & parms) const override;
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
    bool SetAutomationParameters(const CommandParameters & parms) override;
 
    // EffectProcessor implementation


### PR DESCRIPTION
Resolves: #2682

Distinguish const from non-const visting of effect settings, and make one of the overlods of VisitSettings const; making
the other overload const -- must wait until much later, when all built-in effect subclasses are rewritten to be stateless.

So this completes for now the changes for const correctness !

Also, pass EffectSettings into EffectParameterMethods, eliminating some dummy EffectSettings objects that were added
temporarily.  (The exception remains in the Reset() function, but that too may disappear when all built-ins are stateless.)

So this also completes the passing-around of EffectSettings !

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
