### PR TITLE
Simplify effect initialization

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -8,6 +8,12 @@
 #include "EffectInterface.h"
 #include <wx/tokenzr.h>
 
+const RegistryPath &EffectSettingsExtra::DurationKey()
+{
+   static wxString key("LastUsedDuration");
+   return key;
+}
+
 EffectSettingsAccess::~EffectSettingsAccess() = default;
 
 SimpleEffectSettingsAccess::~SimpleEffectSettingsAccess() = default;

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -88,27 +88,15 @@ bool EffectDefinitionInterface::VisitSettings(
    return false;
 }
 
-auto EffectDefinitionInterfaceEx::MakeSettings() const -> Settings
+auto EffectDefinitionInterface::MakeSettings() const -> Settings
 {
-   // Temporary default implementation just saves self
-   // Cast away const! Capture pointer to self
-   return Settings( const_cast<EffectDefinitionInterfaceEx*>(this) );
+   return {};
 }
 
-bool EffectDefinitionInterfaceEx::CopySettingsContents(
-   const EffectSettings &src, EffectSettings &dst) const
+bool EffectDefinitionInterface::CopySettingsContents(
+   const EffectSettings &, EffectSettings &) const
 {
-   //! No real copy, just a sanity check on common origin
-   return FindMe(src) && FindMe(dst);
-}
-
-EffectDefinitionInterfaceEx *
-EffectDefinitionInterfaceEx::FindMe(const Settings &settings) const
-{
-   if (auto ppEffect = settings.cast<EffectDefinitionInterfaceEx*>();
-       ppEffect && *ppEffect == this)
-      return *ppEffect;
-   return nullptr;
+   return true;
 }
 
 EffectProcessor::~EffectProcessor() = default;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -282,9 +282,6 @@ class wxWindow;
 
 class EffectUIClientInterface;
 
-// Incomplete type not defined in libraries -- TODO clean that up:
-class EffectHostInterface;
-
 class sampleCount;
 
 // ----------------------------------------------------------------------------
@@ -468,8 +465,7 @@ public:
    /*!
     @return true if successful
     */
-   virtual bool InitializeInstance(
-      EffectHostInterface *host, EffectSettings &settings) = 0;
+   virtual bool InitializeInstance(EffectSettings &settings) = 0;
 
    virtual bool IsGraphicalUI() = 0;
 

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -76,8 +76,13 @@ public:
       { return mDurationFormat; }
    void SetDurationFormat(const NumericFormatSymbol &durationFormat)
       { mDurationFormat = durationFormat; }
+
+   //! @return value is not negative
+   double GetDuration() const { return mDuration; }
+   void SetDuration(double value) { mDuration = std::max(0.0, value); }
 private:
    NumericFormatSymbol mDurationFormat{};
+   double mDuration{}; //!< @invariant non-negative
 };
 
 //! Externalized state of a plug-in

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -194,7 +194,10 @@ public:
     */
    //! @{
    //! Produce an object holding new, independent settings
-   virtual Settings MakeSettings() const = 0;
+   /*!
+    Default implementation returns an empty `any`
+    */
+   virtual Settings MakeSettings() const;
 
    //! Update one settings object from another
    /*!
@@ -204,12 +207,14 @@ public:
 
     Assume that src and dst were created and previously modified only by `this`
 
+    Default implementation does nothing and returns true
+
     @param src settings to copy from
     @param dst settings to copy into
     @return success
     */
    virtual bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst) const = 0;
+      const EffectSettings &src, EffectSettings &dst) const;
 
    //! Store settings as keys and values
    /*!
@@ -249,32 +254,6 @@ public:
    //! Default implementation returns false
    virtual bool VisitSettings(
       ConstSettingsVisitor &visitor, const EffectSettings &settings) const;
-};
-
-//! Extension of EffectDefinitionInterface with old system for settings
-/*!
- (Default implementations of EffectDefinitionInterface methods for settings call
- through to the old interface, violating const correctness.  This is meant to be
- transitional only.)
-
- This interface is not used by the EffectUIHost dialog.
- */
-class COMPONENTS_API EffectDefinitionInterfaceEx  /* not final */
-   : public EffectDefinitionInterface
-{
-public:
-   /*! @name settings
-    Default implementation of the nominally const methods call through to the
-    old non-const interface
-    */
-   //! @{
-   Settings MakeSettings() const override;
-   bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst) const override;
-   //! @}
-
-private:
-   EffectDefinitionInterfaceEx *FindMe(const Settings &settings) const;
 };
 
 class wxDialog;
@@ -331,7 +310,7 @@ AudacityCommand.
 
 *******************************************************************************************/
 class COMPONENTS_API EffectProcessor  /* not final */
-   : public EffectDefinitionInterfaceEx
+   : public EffectDefinitionInterface
 {
 public:
    virtual ~EffectProcessor();

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -69,8 +69,9 @@ typedef enum EffectType : int
 using EffectFamilySymbol = ComponentInterfaceSymbol;
 
 //! Non-polymorphic package of settings values common to many effects
-class EffectSettingsExtra final {
+class COMPONENTS_API EffectSettingsExtra final {
 public:
+   static const RegistryPath &DurationKey();
    const NumericFormatSymbol& GetDurationFormat() const
       { return mDurationFormat; }
    void SetDurationFormat(const NumericFormatSymbol &durationFormat)

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -462,11 +462,6 @@ public:
       wxWindow &parent, wxDialog &dialog, bool forceModal = false
    ) = 0;
 
-   /*!
-    @return true if successful
-    */
-   virtual bool InitializeInstance(EffectSettings &settings) = 0;
-
    virtual bool IsGraphicalUI() = 0;
 
    //! Adds controls to a panel that is given as the parent window of `S`

--- a/src/EffectHostInterface.cpp
+++ b/src/EffectHostInterface.cpp
@@ -9,8 +9,6 @@
 **********************************************************************/
 #include "EffectHostInterface.h"
 
-EffectHostInterface::~EffectHostInterface() = default;
-
 EffectUIHostInterface::~EffectUIHostInterface() = default;
 
 const wxString EffectUIHostInterface::kUserPresetIdent = wxT("User Preset:");

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -19,25 +19,6 @@
 
 class EffectDefinitionInterface;
 
-/*************************************************************************************//**
-
-\class EffectHostInterface 
-
-\brief EffectHostInterface is a decorator of a EffectUIClientInterface.  It adds 
-virtual (abstract) functions to get presets and actually apply the effect.  It uses
-ConfigClientInterface to add Getters/setters for private and shared configs. 
-
-*******************************************************************************************/
-class AUDACITY_DLL_API EffectHostInterface
-{
-public:
-   EffectHostInterface &operator=(EffectHostInterface&) = delete;
-
-   virtual ~EffectHostInterface();
-
-   virtual const EffectDefinitionInterface& GetDefinition() const = 0;
-};
-
 class wxDialog;
 class wxWindow;
 class EffectUIClientInterface;
@@ -59,9 +40,9 @@ class EffectProcessor;
 /*************************************************************************************//**
 
 \class EffectUIHostInterface
-@brief extends EffectHostInterface with UI-related services
+@brief UI-related services
 *******************************************************************************************/
-class AUDACITY_DLL_API EffectUIHostInterface : public EffectHostInterface
+class AUDACITY_DLL_API EffectUIHostInterface
 {
 public:
    using EffectSettingsAccessPtr = std::shared_ptr<EffectSettingsAccess>;
@@ -73,6 +54,8 @@ public:
 
    EffectUIHostInterface &operator=(EffectUIHostInterface&) = delete;
    virtual ~EffectUIHostInterface();
+
+   virtual const EffectDefinitionInterface& GetDefinition() const = 0;
 
    //! Usually applies factory to self and given access
    /*!

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -36,9 +36,6 @@ public:
    virtual ~EffectHostInterface();
 
    virtual const EffectDefinitionInterface& GetDefinition() const = 0;
-
-   virtual double GetDuration() = 0;
-   virtual void SetDuration(double seconds) = 0;
 };
 
 class wxDialog;

--- a/src/EffectHostInterface.h
+++ b/src/EffectHostInterface.h
@@ -106,14 +106,17 @@ public:
       const EffectSettingsAccessPtr &pAccess = nullptr
          //!< Sometimes given; only for UI
    ) = 0;
-   virtual bool Startup(
-      EffectUIClientInterface *client, EffectSettings &settings) = 0;
 
    //! Update controls for the settings
    virtual bool TransferDataToWindow(const EffectSettings &settings) = 0;
 
    //! Update the given settings from controls
    virtual bool TransferDataFromWindow(EffectSettings &settings) = 0;
+
+   /*!
+    @return true if successful
+    */
+   virtual bool InitializeInstance(EffectSettings &settings) = 0;
 };
 
 #endif

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -88,7 +88,7 @@ public:
       double dtmfDutyCycle{DefaultDutyCycle}; // ratio of dtmfTone/(dtmfTone+dtmfSilence)
       double dtmfAmplitude{DefaultAmplitude}; // amplitude of dtmf tone sequence, restricted to (0-1)
 
-      void Recalculate(Effect &effect);
+      void Recalculate(EffectSettings &settings);
    };
 
    struct Validator;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -212,11 +212,10 @@ bool Effect::SupportsAutomation() const
 
 // EffectProcessor implementation
 
-bool Effect::InitializeInstance(
-   EffectHostInterface *host, EffectSettings &settings)
+bool Effect::InitializeInstance(EffectSettings &settings)
 {
    if (mClient)
-      return mClient->InitializeInstance(host, settings);
+      return mClient->InitializeInstance(settings);
    return true;
 }
 
@@ -746,7 +745,7 @@ void Effect::ShowOptions()
 {
 }
 
-// EffectHostInterface implementation
+// EffectUIHostInterface implementation
 
 const EffectDefinitionInterface& Effect::GetDefinition() const
 {
@@ -781,7 +780,7 @@ bool Effect::Startup(EffectUIClientInterface *client, EffectSettings &settings)
    mClient = client;
 
    // Set host so client startup can use our services
-   if (!InitializeInstance(this, settings))
+   if (!InitializeInstance(settings))
    {
       // Bail if the client startup fails
       mClient = NULL;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -59,8 +59,6 @@ using t2bHash = std::unordered_map< void*, bool >;
 
 Effect::Effect()
 {
-   mClient = NULL;
-
    mTracks = NULL;
    mT0 = 0.0;
    mT1 = 0.0;
@@ -96,75 +94,42 @@ Effect::~Effect()
       mHostUIDialog->Close();
 }
 
-// EffectDefinitionInterface implementation
-
-EffectType Effect::GetType() const
-{
-   if (mClient)
-   {
-      return mClient->GetType();
-   }
-
-   return EffectTypeNone;
-}
+// ComponentInterface implementation
 
 PluginPath Effect::GetPath() const
 {
-   if (mClient)
-   {
-      return mClient->GetPath();
-   }
-
    return BUILTIN_EFFECT_PREFIX + GetSymbol().Internal();
 }
 
 ComponentInterfaceSymbol Effect::GetSymbol() const
 {
-   if (mClient)
-   {
-      return mClient->GetSymbol();
-   }
-
    return {};
 }
 
 VendorSymbol Effect::GetVendor() const
 {
-   if (mClient)
-   {
-      return mClient->GetVendor();
-   }
-
    return XO("Audacity");
 }
 
 wxString Effect::GetVersion() const
 {
-   if (mClient)
-   {
-      return mClient->GetVersion();
-   }
-
    return AUDACITY_VERSION_STRING;
 }
 
 TranslatableString Effect::GetDescription() const
 {
-   if (mClient)
-   {
-      return mClient->GetDescription();
-   }
-
    return {};
+}
+
+// EffectDefinitionInterface implementation
+
+EffectType Effect::GetType() const
+{
+   return EffectTypeNone;
 }
 
 EffectFamilySymbol Effect::GetFamily() const
 {
-   if (mClient)
-   {
-      return mClient->GetFamily();
-   }
-
    // Unusually, the internal and visible strings differ for the built-in
    // effect family.
    return { wxT("Audacity"), XO("Built-in") };
@@ -172,41 +137,21 @@ EffectFamilySymbol Effect::GetFamily() const
 
 bool Effect::IsInteractive() const
 {
-   if (mClient)
-   {
-      return mClient->IsInteractive();
-   }
-
    return true;
 }
 
 bool Effect::IsDefault() const
 {
-   if (mClient)
-   {
-      return mClient->IsDefault();
-   }
-
    return true;
 }
 
 bool Effect::SupportsRealtime() const
 {
-   if (mClient)
-   {
-      return mClient->SupportsRealtime();
-   }
-
    return false;
 }
 
 bool Effect::SupportsAutomation() const
 {
-   if (mClient)
-   {
-      return mClient->SupportsAutomation();
-   }
-
    return true;
 }
 
@@ -214,100 +159,52 @@ bool Effect::SupportsAutomation() const
 
 bool Effect::InitializeInstance(EffectSettings &settings)
 {
-   if (mClient)
-      return mClient->InitializeInstance(settings);
    return true;
 }
 
 unsigned Effect::GetAudioInCount() const
 {
-   if (mClient)
-   {
-      return mClient->GetAudioInCount();
-   }
-
    return 0;
 }
 
 unsigned Effect::GetAudioOutCount() const
 {
-   if (mClient)
-   {
-      return mClient->GetAudioOutCount();
-   }
-
    return 0;
 }
 
 int Effect::GetMidiInCount()
 {
-   if (mClient)
-   {
-      return mClient->GetMidiInCount();
-   }
-
    return 0;
 }
 
 int Effect::GetMidiOutCount()
 {
-   if (mClient)
-   {
-      return mClient->GetMidiOutCount();
-   }
-
    return 0;
 }
 
 void Effect::SetSampleRate(double rate)
 {
-   if (mClient)
-   {
-      mClient->SetSampleRate(rate);
-   }
-
    mSampleRate = rate;
 }
 
 size_t Effect::SetBlockSize(size_t maxBlockSize)
 {
-   if (mClient)
-   {
-      return mClient->SetBlockSize(maxBlockSize);
-   }
-
    mBlockSize = maxBlockSize;
-
    return mBlockSize;
 }
 
 size_t Effect::GetBlockSize() const
 {
-   if (mClient)
-   {
-      return mClient->GetBlockSize();
-   }
-
    return mBlockSize;
 }
 
 sampleCount Effect::GetLatency()
 {
-   if (mClient)
-   {
-      return mClient->GetLatency();
-   }
-
    return 0;
 }
 
 size_t Effect::GetTailSize()
 {
-   if (mClient)
-   {
-      return mClient->GetTailSize();
-   }
-
    return 0;
 }
 
@@ -320,96 +217,59 @@ const EffectParameterMethods &Effect::Parameters() const
 bool Effect::ProcessInitialize(
    EffectSettings &settings, sampleCount totalLen, ChannelNames chanMap)
 {
-   if (mClient)
-      return mClient->ProcessInitialize(settings, totalLen, chanMap);
    return true;
 }
 
 bool Effect::ProcessFinalize()
 {
-   if (mClient)
-   {
-      return mClient->ProcessFinalize();
-   }
-
    return true;
 }
 
 size_t Effect::ProcessBlock(EffectSettings &settings,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
-   if (mClient)
-      return mClient->ProcessBlock(settings, inBlock, outBlock, blockLen);
    return 0;
 }
 
 bool Effect::RealtimeInitialize(EffectSettings &settings)
 {
-   if (mClient)
-      return mClient->RealtimeInitialize(settings);
    return false;
 }
 
 bool Effect::RealtimeAddProcessor(
    EffectSettings &settings, unsigned numChannels, float sampleRate)
 {
-   if (mClient)
-   {
-      return mClient->RealtimeAddProcessor(settings, numChannels, sampleRate);
-   }
-
    return true;
 }
 
 bool Effect::RealtimeFinalize(EffectSettings &settings) noexcept
 {
-   if (mClient)
-      return mClient->RealtimeFinalize(settings);
    return false;
 }
 
 bool Effect::RealtimeSuspend()
 {
-   if (mClient)
-      return mClient->RealtimeSuspend();
-
    return true;
 }
 
 bool Effect::RealtimeResume() noexcept
 {
-   if (mClient)
-      return mClient->RealtimeResume();
-
    return true;
 }
 
 bool Effect::RealtimeProcessStart(EffectSettings &settings)
 {
-   if (mClient)
-   {
-      return mClient->RealtimeProcessStart(settings);
-   }
-
    return true;
 }
 
 size_t Effect::RealtimeProcess(int group, EffectSettings &settings,
    const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
-   if (mClient)
-      return mClient->
-         RealtimeProcess(group, settings, inbuf, outbuf, numSamples);
    return 0;
 }
 
 bool Effect::RealtimeProcessEnd(EffectSettings &settings) noexcept
 {
-   if (mClient)
-   {
-      return mClient->RealtimeProcessEnd(settings);
-   }
-
    return true;
 }
 
@@ -458,7 +318,7 @@ int Effect::ShowHostInterface(wxWindow &parent,
    // The usual factory lets the client (which is this, when self-hosting)
    // populate it.  That factory function is called indirectly through a
    // std::function to avoid source code dependency cycles.
-   const auto client = mClient ? mClient : this;
+   EffectUIClientInterface *const client = this;
    mHostUIDialog = factory(parent, *this, *client, access);
    if (!mHostUIDialog)
       return 0;
@@ -478,8 +338,6 @@ int Effect::ShowHostInterface(wxWindow &parent,
 
 bool Effect::VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
 {
-   if (mClient)
-      return mClient->VisitSettings(visitor, settings);
    Parameters().Visit(*this, visitor, settings);
    return true;
 }
@@ -487,8 +345,6 @@ bool Effect::VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
 bool Effect::VisitSettings(
    ConstSettingsVisitor &visitor, const EffectSettings &settings) const
 {
-   if (mClient)
-      return mClient->VisitSettings(visitor, settings);
    Parameters().Visit(*this, visitor, settings);
    return true;
 }
@@ -496,8 +352,6 @@ bool Effect::VisitSettings(
 bool Effect::SaveSettings(
    const EffectSettings &settings, CommandParameters & parms) const
 {
-   if (mClient)
-      return mClient->SaveSettings(settings, parms);
    Parameters().Get( *this, settings, parms );
    return true;
 }
@@ -505,8 +359,6 @@ bool Effect::SaveSettings(
 bool Effect::LoadSettings(
    const CommandParameters & parms, Settings &settings) const
 {
-   if (mClient)
-      return mClient->LoadSettings(parms, settings);
    // The first argument, and with it the const_cast, will disappear when
    // all built-in effects are stateless.
    return Parameters().Set( *const_cast<Effect*>(this), parms, settings );
@@ -515,10 +367,6 @@ bool Effect::LoadSettings(
 bool Effect::LoadUserPreset(
    const RegistryPath & name, EffectSettings &settings) const
 {
-   if (mClient)
-      // Call through to third party effects
-      return mClient->LoadUserPreset(name, settings);
-
    // Find one string in the registry and then reinterpret it
    // as complete settings
    wxString parms;
@@ -532,10 +380,6 @@ bool Effect::LoadUserPreset(
 bool Effect::SaveUserPreset(
    const RegistryPath & name, const EffectSettings &settings) const
 {
-   if (mClient)
-      // Call through to third party effects
-      return mClient->SaveUserPreset(name, settings);
-
    // Save all settings as a single string value in the registry
    wxString parms;
    if (!SaveSettingsAsString(settings, parms))
@@ -547,28 +391,16 @@ bool Effect::SaveUserPreset(
 
 RegistryPaths Effect::GetFactoryPresets() const
 {
-   if (mClient)
-   {
-      return mClient->GetFactoryPresets();
-   }
-
    return {};
 }
 
 bool Effect::LoadFactoryPreset(int id, EffectSettings &settings) const
 {
-   if (mClient)
-      return mClient->LoadFactoryPreset(id, settings);
    return true;
 }
 
 bool Effect::LoadFactoryDefaults(Settings &settings) const
 {
-   if (mClient)
-   {
-      return mClient->LoadFactoryDefaults(settings);
-   }
-
    return LoadUserPreset(FactoryDefaultsGroup(), settings);
 }
 
@@ -743,10 +575,7 @@ void Effect::ShowOptions()
 
 const EffectDefinitionInterface& Effect::GetDefinition() const
 {
-   if (mClient)
-      return *mClient;
-   else
-      return *this;
+   return *this;
 }
 
 double Effect::GetDefaultDuration()
@@ -767,22 +596,6 @@ wxString Effect::GetSavedStateGroup()
 }
 
 // Effect implementation
-
-bool Effect::Startup(EffectUIClientInterface *client, EffectSettings &settings)
-{
-   // Let destructor know we need to be shutdown
-   mClient = client;
-
-   // Set host so client startup can use our services
-   if (!InitializeInstance(settings))
-   {
-      // Bail if the client startup fails
-      mClient = NULL;
-      return false;
-   }
-
-   return true;
-}
 
 bool Effect::SaveSettingsAsString(
    const EffectSettings &settings, wxString & parms) const

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -420,11 +420,10 @@ Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
    mUIParent->SetMinSize(mUIParent->GetSizer()->GetMinSize());
 
    if (!result) {
-      // No custom validator object?  Then use the default, which will pop
-      // the event handler when it is destroyed and invokes CloseUI
-      mUIParent->PushEventHandler(this);
+      // No custom validator object?  Then use the default
       result = std::make_unique<DefaultEffectUIValidator>(*this, access);
    }
+   mUIParent->PushEventHandler(this);
    return result;
 }
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -786,12 +786,6 @@ void Effect::SetDuration(double seconds)
       seconds = 0.0;
    }
 
-   if (GetType() == EffectTypeGenerate)
-   {
-      SetConfig(GetDefinition(), PluginSettings::Private,
-         CurrentSettingsGroup(), wxT("LastUsedDuration"), seconds);
-   }
-
    mDuration = seconds;
 
    return;
@@ -969,11 +963,9 @@ bool Effect::DoEffect(EffectSettings &settings, double projectRate,
 
    mDuration = 0.0;
    if (GetType() == EffectTypeGenerate)
-   {
       GetConfig(GetDefinition(), PluginSettings::Private,
          CurrentSettingsGroup(),
-         wxT("LastUsedDuration"), mDuration, GetDefaultDuration());
-   }
+         EffectSettingsExtra::DurationKey(), mDuration, GetDefaultDuration());
 
    WaveTrack *newTrack{};
    bool success = false;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -346,13 +346,7 @@ size_t Effect::ProcessBlock(EffectSettings &settings,
 bool Effect::RealtimeInitialize(EffectSettings &settings)
 {
    if (mClient)
-   {
-      mBlockSize = mClient->SetBlockSize(512);
       return mClient->RealtimeInitialize(settings);
-   }
-
-   mBlockSize = 512;
-
    return false;
 }
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -130,8 +130,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
 
    // EffectProcessor implementation
 
-   bool InitializeInstance(
-      EffectHostInterface *host, EffectSettings &settings) override;
+   bool InitializeInstance(EffectSettings &settings) override;
    
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
@@ -188,7 +187,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    bool HasOptions() override;
    void ShowOptions() override;
 
-   // EffectHostInterface implementation
+   // EffectUIHostInterface implementation
 
    const EffectDefinitionInterface& GetDefinition() const override;
    virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -175,7 +175,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // EffectUIClientInterface implementation
 
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access);
+      ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
@@ -216,8 +216,6 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
       const EffectDialogFactory &dialogFactory,
       const EffectSettingsAccessPtr &pAccess //!< Sometimes given; only for UI
    ) override;
-   bool Startup(
-      EffectUIClientInterface *client, EffectSettings &settings) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 
@@ -496,9 +494,6 @@ private:
 
    int mNumTracks; //v This is really mNumWaveTracks, per CountWaveTracks() and GetNumWaveTracks().
    int mNumGroups;
-
-   // For client driver
-   EffectUIClientInterface *mClient;
 
    size_t mBufferSize;
    size_t mBlockSize;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -191,9 +191,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // EffectHostInterface implementation
 
    const EffectDefinitionInterface& GetDefinition() const override;
-   double GetDuration() override;
    virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar
-   void SetDuration(double duration) override;
 
    // EffectUIHostInterface implementation
 
@@ -491,8 +489,6 @@ private:
    bool mIsLinearEffect;
    bool mPreviewWithNotSelected;
    bool mPreviewFullSelection;
-
-   double mDuration;
 
    bool mIsPreview;
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -175,7 +175,7 @@ class AUDACITY_DLL_API Effect /* not final */ : public wxEvtHandler,
    // EffectUIClientInterface implementation
 
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) final;
+      ShuttleGui &S, EffectSettingsAccess &access);
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -775,7 +775,7 @@ EffectManager::GetEffectAndDefaultSettings(const PluginID & ID)
 
 namespace {
 void InitializePreset(
-   EffectDefinitionInterfaceEx &definition, EffectSettings &settings) {
+   EffectDefinitionInterface &definition, EffectSettings &settings) {
    bool haveDefaults;
    GetConfig(definition, PluginSettings::Private, FactoryDefaultsGroup(),
       wxT("Initialized"), haveDefaults, false);
@@ -791,7 +791,7 @@ void InitializePreset(
 std::pair<ComponentInterface *, EffectSettings>
 LoadComponent(const PluginID &ID)
 {
-   if (auto result = dynamic_cast<EffectDefinitionInterfaceEx*>(
+   if (auto result = dynamic_cast<EffectDefinitionInterface*>(
       PluginManager::Get().Load(ID))) {
       auto settings = result->MakeSettings();
       InitializePreset(*result, settings);

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -352,19 +352,19 @@ bool EffectManager::PromptUser(
    return result;
 }
 
-static bool HasCurrentSettings(EffectHostInterface &host)
+static bool HasCurrentSettings(EffectUIHostInterface &host)
 {
    return HasConfigGroup(host.GetDefinition(), PluginSettings::Private,
       CurrentSettingsGroup());
 }
 
-static bool HasFactoryDefaults(EffectHostInterface &host)
+static bool HasFactoryDefaults(EffectUIHostInterface &host)
 {
    return HasConfigGroup(host.GetDefinition(), PluginSettings::Private,
       FactoryDefaultsGroup());
 }
 
-static RegistryPaths GetUserPresets(EffectHostInterface &host)
+static RegistryPaths GetUserPresets(EffectUIHostInterface &host)
 {
    RegistryPaths presets;
    GetConfigSubgroups(host.GetDefinition(), PluginSettings::Private,

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -64,7 +64,7 @@ public:
    };
 
    /*! Create a new instance of an effect by its ID. */
-   static std::unique_ptr<EffectProcessor> NewEffect(const PluginID &ID);
+   static EffectProcessor *NewEffect(const PluginID &ID);
 
    /** Get the singleton instance of the EffectManager. Probably not safe
        for multi-thread use. */

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -236,7 +236,7 @@ bool EffectUIHost::TransferDataFromWindow()
       if (result) {
          auto &definition = mEffectUIHost.GetDefinition();
          if (definition.GetType() == EffectTypeGenerate) {
-            const auto seconds = mEffectUIHost.GetDuration();
+            const auto seconds = settings.extra.GetDuration();
             SetConfig(definition, PluginSettings::Private,
                CurrentSettingsGroup(), EffectSettingsExtra::DurationKey(),
                seconds);

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -212,7 +212,6 @@ bool EffectUIHost::TransferDataToWindow()
       mpValidator->UpdateUI() &&
       //! Do validators
       wxDialogWrapper::TransferDataToWindow();
- 
 }
 
 bool EffectUIHost::TransferDataFromWindow()
@@ -234,6 +233,15 @@ bool EffectUIHost::TransferDataFromWindow()
    mpAccess->ModifySettings([&](EffectSettings &settings){
       // Allow other transfers, and reassignment of settings
       result = mEffectUIHost.TransferDataFromWindow(settings);
+      if (result) {
+         auto &definition = mEffectUIHost.GetDefinition();
+         if (definition.GetType() == EffectTypeGenerate) {
+            const auto seconds = mEffectUIHost.GetDuration();
+            SetConfig(definition, PluginSettings::Private,
+               CurrentSettingsGroup(), EffectSettingsExtra::DurationKey(),
+               seconds);
+         }
+      }
    });
    return result;
 }

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -29,9 +29,7 @@
 
 bool Generator::Process(EffectSettings &settings)
 {
-   if (GetDuration() < 0.0)
-      return false;
-
+   const auto duration = settings.extra.GetDuration();
 
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
@@ -51,7 +49,8 @@ bool Generator::Process(EffectSettings &settings)
          //make sure there's room.
          if (!editClipCanMove &&
              track->IsEmpty(mT0, mT1+1.0/track->GetRate()) &&
-             !track->IsEmpty(mT0, mT0+GetDuration()-(mT1-mT0)-1.0/track->GetRate()))
+             !track->IsEmpty(mT0,
+               mT0 + duration - (mT1 - mT0) - 1.0 / track->GetRate()))
          {
             Effect::MessageBox(
                XO("There is not enough room available to generate the audio"),
@@ -62,7 +61,7 @@ bool Generator::Process(EffectSettings &settings)
             return;
          }
 
-         if (GetDuration() > 0.0)
+         if (duration > 0.0)
          {
             auto pProject = FindProject();
             // Create a temporary track
@@ -76,7 +75,7 @@ bool Generator::Process(EffectSettings &settings)
             else {
                // Transfer the data from the temporary track to the actual one
                tmp->Flush();
-               PasteTimeWarper warper{ mT1, mT0+GetDuration() };
+               PasteTimeWarper warper{ mT1, mT0 + duration };
                const auto &selectedRegion =
                   ViewInfo::Get( *pProject ).selectedRegion;
                track->ClearAndPaste(
@@ -100,7 +99,7 @@ bool Generator::Process(EffectSettings &settings)
       },
       [&](Track *t) {
          if (SyncLock::IsSyncLockSelected(t)) {
-            t->SyncLockAdjust(mT1, mT0 + GetDuration());
+            t->SyncLockAdjust(mT1, mT0 + duration);
          }
       }
    );
@@ -110,17 +109,17 @@ bool Generator::Process(EffectSettings &settings)
 
       this->ReplaceProcessedTracks(bGoodResult);
 
-      mT1 = mT0 + GetDuration(); // Update selection.
+      mT1 = mT0 + duration; // Update selection.
    }
 
    return bGoodResult;
 }
 
-bool BlockGenerator::GenerateTrack(EffectSettings &,
+bool BlockGenerator::GenerateTrack(EffectSettings &settings,
    WaveTrack *tmp, const WaveTrack &track, int ntrack)
 {
    bool bGoodResult = true;
-   numSamples = track.TimeToLongSamples(GetDuration());
+   numSamples = track.TimeToLongSamples(settings.extra.GetDuration());
    decltype(numSamples) i = 0;
    Floats data{ tmp->GetMaxBlockSize() };
 

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -192,7 +192,7 @@ EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
          NumericTextCtrl(S.GetParent(), wxID_ANY,
                          NumericConverter::TIME,
                          extra.GetDurationFormat(),
-                         GetDuration(),
+                         extra.GetDuration(),
                          mProjectRate,
                          NumericTextCtrl::Options{}
                             .AutoPos(true));
@@ -204,15 +204,15 @@ EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
    return nullptr;
 }
 
-bool EffectNoise::TransferDataToWindow(const EffectSettings &)
+bool EffectNoise::TransferDataToWindow(const EffectSettings &settings)
 {
-   mNoiseDurationT->SetValue(GetDuration());
+   mNoiseDurationT->SetValue(settings.extra.GetDuration());
 
    return true;
 }
 
-bool EffectNoise::TransferDataFromWindow(EffectSettings &)
+bool EffectNoise::TransferDataFromWindow(EffectSettings &settings)
 {
-   SetDuration(mNoiseDurationT->GetValue());
+   settings.extra.SetDuration(mNoiseDurationT->GetValue());
    return true;
 }

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -161,7 +161,7 @@ EffectProcessor *RealtimeEffectState::GetEffect()
          // Also make EffectSettings
          mSettings = mEffect->MakeSettings();
    }
-   return mEffect.get();
+   return mEffect;
 }
 
 bool RealtimeEffectState::Suspend()
@@ -441,7 +441,7 @@ bool RealtimeEffectState::HandleXMLTag(
 {
    if (tag == XMLTag()) {
       mParameters.clear();
-      mEffect.reset();
+      mEffect = nullptr;
       mID.clear();
 
       for (auto pair : attrs) {
@@ -508,7 +508,8 @@ void RealtimeEffectState::WriteXML(XMLWriter &xmlFile)
       return;
 
    xmlFile.StartTag(XMLTag());
-   xmlFile.WriteAttr(idAttribute, XMLWriter::XMLEsc(PluginManager::GetID(mEffect.get())));
+   xmlFile.WriteAttr(
+      idAttribute, XMLWriter::XMLEsc(PluginManager::GetID(mEffect)));
    xmlFile.WriteAttr(versionAttribute, XMLWriter::XMLEsc(mEffect->GetVersion()));
 
    CommandParameters cmdParms;

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -185,6 +185,11 @@ bool RealtimeEffectState::Initialize(double rate)
    mCurrentProcessor = 0;
    mGroups.clear();
    mEffect->SetSampleRate(rate);
+
+   // PRL: conserving pre-3.2.0 behavior, but I don't know why this arbitrary
+   // number was important
+   mEffect->SetBlockSize(512);
+
    return mEffect->RealtimeInitialize(mSettings);
 }
 

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -29,7 +29,7 @@ class RealtimeEffectState : public XMLTagHandler
 {
 public:
    struct AUDACITY_DLL_API EffectFactory : GlobalHook<EffectFactory,
-      std::unique_ptr<EffectProcessor>(const PluginID &)
+      EffectProcessor*(const PluginID &)
    >{};
 
    explicit RealtimeEffectState(const PluginID & id);
@@ -76,7 +76,7 @@ public:
 private:
    PluginID mID;
    wxString mParameters;  // Used only during deserialization
-   std::unique_ptr<EffectProcessor> mEffect;
+   EffectProcessor *mEffect;
    EffectSettings mSettings;
 
    struct Access;

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -78,7 +78,7 @@ EffectSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
             NumericTextCtrl(S.GetParent(), wxID_ANY,
                               NumericConverter::TIME,
                               extra.GetDurationFormat(),
-                              GetDuration(),
+                              extra.GetDuration(),
                                mProjectRate,
                                NumericTextCtrl::Options{}
                                   .AutoPos(true));
@@ -93,23 +93,23 @@ EffectSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
    return nullptr;
 }
 
-bool EffectSilence::TransferDataToWindow(const EffectSettings &)
+bool EffectSilence::TransferDataToWindow(const EffectSettings &settings)
 {
-   mDurationT->SetValue(GetDuration());
+   mDurationT->SetValue(settings.extra.GetDuration());
 
    return true;
 }
 
-bool EffectSilence::TransferDataFromWindow(EffectSettings &)
+bool EffectSilence::TransferDataFromWindow(EffectSettings &settings)
 {
-   SetDuration(mDurationT->GetValue());
+   settings.extra.SetDuration(mDurationT->GetValue());
 
    return true;
 }
 
-bool EffectSilence::GenerateTrack(EffectSettings &,
+bool EffectSilence::GenerateTrack(EffectSettings &settings,
    WaveTrack *tmp, const WaveTrack &, int)
 {
-   tmp->InsertSilence(0.0, GetDuration());
+   tmp->InsertSilence(0.0, settings.extra.GetDuration());
    return true;
 }

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -114,9 +114,9 @@ bool EffectTimeScale::Init()
 }
 
 double EffectTimeScale::CalcPreviewInputLength(
-   const EffectSettings &, double previewLength)
+   const EffectSettings &settings, double previewLength)
 {
-   double inputLength = Effect::GetDuration();
+   double inputLength = settings.extra.GetDuration();
    if(inputLength == 0.0) {
       return 0.0;
    } else {
@@ -130,7 +130,7 @@ double EffectTimeScale::CalcPreviewInputLength(
 
 void EffectTimeScale::Preview(EffectSettingsAccess &access, bool dryOnly)
 {
-   previewSelectedDuration = Effect::GetDuration();
+   previewSelectedDuration = access.Get().extra.GetDuration();
    auto cleanup = valueRestorer( bPreview, true );
    Effect::Preview(access, dryOnly);
 }

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -380,7 +380,7 @@ EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
          NumericTextCtrl(S.GetParent(), wxID_ANY,
                          NumericConverter::TIME,
                          extra.GetDurationFormat(),
-                         GetDuration(),
+                         extra.GetDuration(),
                          mProjectRate,
                          NumericTextCtrl::Options{}
                             .AutoPos(true));
@@ -393,13 +393,13 @@ EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
    return nullptr;
 }
 
-bool EffectToneGen::TransferDataToWindow(const EffectSettings &)
+bool EffectToneGen::TransferDataToWindow(const EffectSettings &settings)
 {
-   mToneDurationT->SetValue(GetDuration());
+   mToneDurationT->SetValue(settings.extra.GetDuration());
    return true;
 }
 
-bool EffectToneGen::TransferDataFromWindow(EffectSettings &)
+bool EffectToneGen::TransferDataFromWindow(EffectSettings &settings)
 {
    if (!mChirp)
    {
@@ -407,7 +407,7 @@ bool EffectToneGen::TransferDataFromWindow(EffectSettings &)
       mAmplitude1 = mAmplitude0;
    }
 
-   SetDuration(mToneDurationT->GetValue());
+   settings.extra.SetDuration(mToneDurationT->GetValue());
 
    return true;
 }

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -224,7 +224,7 @@ enum InfoKeys
 //! This object exists in a separate process, to validate a newly seen plug-in.
 /*! It needs to implement EffectDefinitionInterface but mostly just as stubs */
 class VSTSubProcess final : public wxProcess
-   , public EffectDefinitionInterfaceEx
+   , public EffectDefinitionInterface
 {
 public:
    VSTSubProcess()

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1794,12 +1794,10 @@ bool VSTEffect::IsGraphicalUI()
    return mGui;
 }
 
-bool VSTEffect::ValidateUI(EffectSettings &)
+bool VSTEffect::ValidateUI(EffectSettings &settings)
 {
    if (GetType() == EffectTypeGenerate)
-   {
-      mHost->SetDuration(mDuration->GetValue());
-   }
+      settings.extra.SetDuration(mDuration->GetValue());
 
    return true;
 }
@@ -2770,7 +2768,7 @@ void VSTEffect::BuildPlain(EffectSettingsAccess &access)
                NumericTextCtrl(scroller, ID_Duration,
                   NumericConverter::TIME,
                   extra.GetDurationFormat(),
-                  mHost->GetDuration(),
+                  extra.GetDuration(),
                   mSampleRate,
                   NumericTextCtrl::Options{}
                      .AutoPos(true));

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -12,7 +12,7 @@
 
 #if USE_VST
 
-#include "EffectInterface.h"
+#include "../Effect.h"
 #include "PluginProvider.h"
 #include "PluginInterface.h"
 
@@ -90,10 +90,10 @@ DECLARE_LOCAL_EVENT_TYPE(EVT_UPDATEDISPLAY, -1);
 /// audio processing via a VSTEffectLink
 ///
 ///////////////////////////////////////////////////////////////////////////////
-class VSTEffect final : public wxEvtHandler,
-                  public EffectUIClientInterface,
-                  public XMLTagHandler,
-                  public VSTEffectLink
+class VSTEffect final
+   : public Effect
+   , public XMLTagHandler
+   , public VSTEffectLink
 {
  public:
    VSTEffect(const PluginPath & path, VSTEffect *master = NULL);

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -176,8 +176,7 @@ class VSTEffect final : public wxEvtHandler,
 
    // EffectUIClientInterface implementation
 
-   bool InitializeInstance(
-      EffectHostInterface *host, EffectSettings &settings) override;
+   bool InitializeInstance(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
@@ -294,7 +293,6 @@ private:
    using ModuleHandle = std::unique_ptr < char, ModuleDeleter > ;
 #endif
 
-   EffectHostInterface *mHost{};
    PluginID mID;
    PluginPath mPath;
    unsigned mAudioIns;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -893,7 +893,7 @@ VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &access)
                parent, wxID_ANY,
                NumericConverter::TIME,
                extra.GetDurationFormat(),
-               mEffectHost->GetDuration(),
+               extra.GetDuration(),
                mSetup.sampleRate,
                NumericTextCtrl::Options{}
                   .AutoPos(true)
@@ -924,12 +924,10 @@ VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &access)
    return nullptr;
 }
 
-bool VST3Effect::ValidateUI(EffectSettings &)
+bool VST3Effect::ValidateUI(EffectSettings &settings)
 {
    if (mDuration != nullptr)
-   {
-      mEffectHost->SetDuration(mDuration->GetValue());
-   }
+      settings.extra.SetDuration(mDuration->GetValue());
    return true;
 }
 

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -13,7 +13,6 @@
 #include "VST3Effect.h"
 
 #include "AudacityException.h"
-#include "EffectHostInterface.h"
 
 #include "Base64.h"
 
@@ -846,17 +845,11 @@ bool VST3Effect::InitializePlugin()
    return true;
 }
 
-bool VST3Effect::InitializeInstance(
-   EffectHostInterface* host, EffectSettings &settings)
+bool VST3Effect::InitializeInstance(EffectSettings &settings)
 {
-   mEffectHost = host;
-
-   if(host)
-   {
-      ReloadUserOptions();
-      if(!LoadUserPreset(CurrentSettingsGroup(), settings))
-         LoadFactoryDefaults(settings);
-   }
+   ReloadUserOptions();
+   if(!LoadUserPreset(CurrentSettingsGroup(), settings))
+      LoadFactoryDefaults(settings);
    return true;
 }
 
@@ -1026,13 +1019,10 @@ bool VST3Effect::HasOptions()
 
 void VST3Effect::ShowOptions()
 {
-   if(mEffectHost)
+   VST3OptionsDialog dlg(mParent, *this);
+   if (dlg.ShowModal())
    {
-      VST3OptionsDialog dlg(mParent, *this);
-      if (dlg.ShowModal())
-      {
-         ReloadUserOptions();
-      }
+      ReloadUserOptions();
    }
 }
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -62,7 +62,6 @@ class VST3Effect final : public EffectUIClientInterface
    Steinberg::IPtr<Steinberg::Vst::IEditController> mEditController;
    Steinberg::IPtr<internal::ComponentHandler> mComponentHandler;
    wxWindow* mParent { nullptr };
-   EffectHostInterface *mEffectHost{};
    NumericTextCtrl* mDuration { nullptr };
 
    //Holds pending parameter changes to be applied to multiple realtime effects.
@@ -147,8 +146,7 @@ public:
 
    int ShowClientInterface(wxWindow& parent, wxDialog& dialog, bool forceModal) override;
    bool InitializePlugin();
-   bool InitializeInstance(
-      EffectHostInterface *host, EffectSettings &settings) override;
+   bool InitializeInstance(EffectSettings &settings) override;
    bool IsGraphicalUI() override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -19,7 +19,7 @@
 #include <pluginterfaces/vst/ivstaudioprocessor.h>
 #include <public.sdk/source/vst/hosting/module.h>
 
-#include "EffectInterface.h"
+#include "../Effect.h"
 #include "internal/ComponentHandler.h"
 
 #include "SampleCount.h"
@@ -41,7 +41,7 @@ class ParameterChangesProvider;
 /**
  * \brief Objects of this class connect Audacity with VST3 effects
  */
-class VST3Effect final : public EffectUIClientInterface
+class VST3Effect final : public Effect
 {
    //Keep strong reference to a module while effect is alive
    std::shared_ptr<VST3::Hosting::Module> mModule;

--- a/src/effects/VST3/VST3OptionsDialog.h
+++ b/src/effects/VST3/VST3OptionsDialog.h
@@ -11,8 +11,8 @@
 #pragma once
 
 #include "widgets/wxPanelWrapper.h"
-#include "EffectHostInterface.h"
 
+class EffectDefinitionInterface;
 class ShuttleGui;
 
 class VST3OptionsDialog final : public wxDialogWrapper

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -46,7 +46,6 @@
 #include <wx/tokenzr.h>
 
 #include "../../SelectFile.h"
-#include "../../EffectHostInterface.h"
 #include "../../ShuttleGui.h"
 #include "../../widgets/AudacityMessageBox.h"
 #include "../../widgets/valnum.h"
@@ -1039,19 +1038,17 @@ bool AudioUnitEffect::InitializePlugin()
    return MakeListener();
 }
 
-bool AudioUnitEffect::InitializeInstance(
-   EffectHostInterface *host, EffectSettings &settings)
+bool AudioUnitEffect::InitializeInstance(EffectSettings &settings)
 {
    OSStatus result;
-
-   mHost = host;
 
    if (mMaster)
       // Do common steps
       InitializePlugin();
 
-   if (mHost)
-   {
+   if (!mMaster) {
+      // Don't HAVE a master -- this IS the master.
+
       GetConfig(*this, PluginSettings::Shared, wxT("Options"),
          wxT("UseLatency"), mUseLatency, true);
       GetConfig(*this, PluginSettings::Shared, wxT("Options"),
@@ -1366,7 +1363,7 @@ bool AudioUnitEffect::RealtimeAddProcessor(
    EffectSettings &settings, unsigned numChannels, float sampleRate)
 {
    auto slave = std::make_unique<AudioUnitEffect>(mPath, mName, mComponent, this);
-   if (!slave->InitializeInstance(nullptr, settings))
+   if (!slave->InitializeInstance(settings))
    {
       return false;
    }

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1757,13 +1757,11 @@ bool AudioUnitEffect::IsGraphicalUI()
    return mUIType != wxT("Plain");
 }
 
-bool AudioUnitEffect::ValidateUI(EffectSettings &)
+bool AudioUnitEffect::ValidateUI([[maybe_unused]] EffectSettings &settings)
 {
 #if 0
    if (GetType() == EffectTypeGenerate)
-   {
-      mHost->SetDuration(mDuration->GetValue());
-   }
+      settings.extra.SetDuration(mDuration->GetValue());
 #endif
    return true;
 }

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -21,7 +21,7 @@
 #include <AudioUnit/AudioUnit.h>
 #include <AudioUnit/AudioUnitProperties.h>
 
-#include "EffectInterface.h"
+#include "../Effect.h"
 #include "PluginProvider.h"
 #include "PluginInterface.h"
 
@@ -38,8 +38,7 @@ using AudioUnitEffectArray = std::vector<std::unique_ptr<AudioUnitEffect>>;
 class AudioUnitEffectExportDialog;
 class AudioUnitEffectImportDialog;
 
-class AudioUnitEffect : public wxEvtHandler,
-                        public EffectUIClientInterface
+class AudioUnitEffect final : public Effect
 {
 public:
    AudioUnitEffect(const PluginPath & path,

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -121,8 +121,7 @@ public:
 
    // EffectUIClientInterface implementation
 
-   bool InitializeInstance(
-      EffectHostInterface *host, EffectSettings &settings) override;
+   bool InitializeInstance(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
@@ -193,7 +192,6 @@ private:
    bool mSupportsMono;
    bool mSupportsStereo;
 
-   EffectHostInterface *mHost{};
    unsigned mAudioIns;
    unsigned mAudioOuts;
    bool mInteractive;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1241,7 +1241,7 @@ LadspaEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
                NumericTextCtrl(w, ID_Duration,
                   NumericConverter::TIME,
                   extra.GetDurationFormat(),
-                  mHost->GetDuration(),
+                  extra.GetDuration(),
                   mSampleRate,
                   NumericTextCtrl::Options{}
                      .AutoPos(true));
@@ -1508,12 +1508,10 @@ bool LadspaEffect::IsGraphicalUI()
    return false;
 }
 
-bool LadspaEffect::ValidateUI(EffectSettings &)
+bool LadspaEffect::ValidateUI(EffectSettings &settings)
 {
    if (GetType() == EffectTypeGenerate)
-   {
-      mHost->SetDuration(mDuration->GetValue());
-   }
+      settings.extra.SetDuration(mDuration->GetValue());
 
    return true;
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -57,7 +57,6 @@ effects from this one class.
 #include <wx/version.h>
 
 #include "AudacityException.h"
-#include "../../EffectHostInterface.h"
 #include "FileNames.h"
 #include "../../ShuttleGui.h"
 #include "../../widgets/NumericTextCtrl.h"
@@ -862,29 +861,23 @@ bool LadspaEffect::InitializePlugin()
    return true;
 }
 
-bool LadspaEffect::InitializeInstance(
-   EffectHostInterface *host, EffectSettings &settings)
+bool LadspaEffect::InitializeInstance(EffectSettings &settings)
 {
-   mHost = host;
+   GetConfig(*this, PluginSettings::Shared, wxT("Options"),
+      wxT("UseLatency"), mUseLatency, true);
 
-   if (mHost)
+   bool haveDefaults;
+   GetConfig(*this, PluginSettings::Private,
+      FactoryDefaultsGroup(), wxT("Initialized"), haveDefaults,
+      false);
+   if (!haveDefaults)
    {
-      GetConfig(*this, PluginSettings::Shared, wxT("Options"),
-         wxT("UseLatency"), mUseLatency, true);
-
-      bool haveDefaults;
-      GetConfig(*this, PluginSettings::Private,
-         FactoryDefaultsGroup(), wxT("Initialized"), haveDefaults,
-         false);
-      if (!haveDefaults)
-      {
-         SaveParameters(FactoryDefaultsGroup(), settings);
-         SetConfig(*this, PluginSettings::Private,
-            FactoryDefaultsGroup(), wxT("Initialized"), true);
-      }
-
-      LoadParameters(CurrentSettingsGroup(), settings);
+      SaveParameters(FactoryDefaultsGroup(), settings);
+      SetConfig(*this, PluginSettings::Private,
+         FactoryDefaultsGroup(), wxT("Initialized"), true);
    }
+
+   LoadParameters(CurrentSettingsGroup(), settings);
    return true;
 }
 

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -120,8 +120,7 @@ public:
 
    // EffectUIClientInterface implementation
 
-   bool InitializeInstance(
-      EffectHostInterface *host, EffectSettings &settings) override;
+   bool InitializeInstance(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
@@ -157,7 +156,6 @@ private:
 
    wxString mPath;
    int mIndex;
-   EffectHostInterface *mHost{};
 
    wxDynamicLibrary mLib;
    const LADSPA_Descriptor *mData;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -19,7 +19,7 @@ class NumericTextCtrl;
 #include <wx/event.h> // to inherit
 #include <wx/weakref.h>
 
-#include "EffectInterface.h"
+#include "../Effect.h"
 #include "PluginProvider.h"
 #include "PluginInterface.h"
 
@@ -40,8 +40,7 @@ class NumericTextCtrl;
 
 class LadspaEffectMeter;
 
-class LadspaEffect final : public wxEvtHandler,
-                     public EffectUIClientInterface
+class LadspaEffect final : public Effect
 {
 public:
    LadspaEffect(const wxString & path, int index);

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -49,7 +49,6 @@
 
 #include "AudacityException.h"
 #include "ConfigInterface.h"
-#include "../../EffectHostInterface.h"
 #include "../../ShuttleGui.h"
 #include "../../widgets/valnum.h"
 #include "../../widgets/AudacityMessageBox.h"
@@ -352,7 +351,6 @@ LV2Effect::LV2Effect(const LilvPlugin *plug)
 {
    mPlug = plug;
 
-   mHost = NULL;
    mMaster = NULL;
    mProcess = NULL;
    mSuilInstance = NULL;
@@ -910,36 +908,31 @@ bool LV2Effect::InitializePlugin()
    return true;
 }
 
-bool LV2Effect::InitializeInstance(
-   EffectHostInterface *host, EffectSettings &settings)
+bool LV2Effect::InitializeInstance(EffectSettings &settings)
 {
-   mHost = host;
-   if (mHost)
+   int userBlockSize;
+   GetConfig(*this, PluginSettings::Shared, wxT("Settings"),
+      wxT("BufferSize"), userBlockSize, 8192);
+   mUserBlockSize = std::max(1, userBlockSize);
+   GetConfig(*this, PluginSettings::Shared, wxT("Settings"),
+      wxT("UseLatency"), mUseLatency, true);
+   GetConfig(*this, PluginSettings::Shared, wxT("Settings"), wxT("UseGUI"),
+      mUseGUI, true);
+
+   mBlockSize = mUserBlockSize;
+
+   bool haveDefaults;
+   GetConfig(*this, PluginSettings::Private,
+      FactoryDefaultsGroup(), wxT("Initialized"), haveDefaults,
+      false);
+   if (!haveDefaults)
    {
-      int userBlockSize;
-      GetConfig(*this, PluginSettings::Shared, wxT("Settings"),
-         wxT("BufferSize"), userBlockSize, 8192);
-      mUserBlockSize = std::max(1, userBlockSize);
-      GetConfig(*this, PluginSettings::Shared, wxT("Settings"),
-         wxT("UseLatency"), mUseLatency, true);
-      GetConfig(*this, PluginSettings::Shared, wxT("Settings"), wxT("UseGUI"),
-         mUseGUI, true);
-
-      mBlockSize = mUserBlockSize;
-
-      bool haveDefaults;
-      GetConfig(*this, PluginSettings::Private,
-         FactoryDefaultsGroup(), wxT("Initialized"), haveDefaults,
-         false);
-      if (!haveDefaults)
-      {
-         SaveParameters(FactoryDefaultsGroup(), settings);
-         SetConfig(*this, PluginSettings::Private,
-            FactoryDefaultsGroup(), wxT("Initialized"), true);
-      }
-
-      LoadParameters(CurrentSettingsGroup(), settings);
+      SaveParameters(FactoryDefaultsGroup(), settings);
+      SetConfig(*this, PluginSettings::Private,
+         FactoryDefaultsGroup(), wxT("Initialized"), true);
    }
+
+   LoadParameters(CurrentSettingsGroup(), settings);
 
    lv2_atom_forge_init(&mForge, &mURIDMapFeature);
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1560,12 +1560,10 @@ bool LV2Effect::IsGraphicalUI()
    return mUseGUI;
 }
 
-bool LV2Effect::ValidateUI(EffectSettings &)
+bool LV2Effect::ValidateUI(EffectSettings &settings)
 {
    if (GetType() == EffectTypeGenerate)
-   {
-      mHost->SetDuration(mDuration->GetValue());
-   }
+      settings.extra.SetDuration(mDuration->GetValue());
 
    return true;
 }
@@ -2320,7 +2318,7 @@ bool LV2Effect::BuildPlain(EffectSettingsAccess &access)
                NumericTextCtrl(w, ID_Duration,
                                NumericConverter::TIME,
                                extra.GetDurationFormat(),
-                               mHost->GetDuration(),
+                               extra.GetDuration(),
                                mSampleRate,
                                NumericTextCtrl::Options {}
             .AutoPos(true));

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -35,7 +35,7 @@ class wxArrayString;
 #include <suil/suil.h>
 #include "lv2_external_ui.h"
 
-#include "EffectInterface.h"
+#include "../Effect.h"
 #include "../../ShuttleGui.h"
 #include "SampleFormat.h"
 
@@ -248,8 +248,7 @@ using LV2ControlPortArray = std::vector<LV2ControlPortPtr>;
 class LV2EffectSettingsDialog;
 class LV2Wrapper;
 
-class LV2Effect final : public wxEvtHandler,
-                        public EffectUIClientInterface
+class LV2Effect final : public Effect
 {
 public:
    LV2Effect(const LilvPlugin *plug);

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -330,8 +330,7 @@ public:
 
    // EffectUIClientInterface implementation
 
-   bool InitializeInstance(
-      EffectHostInterface *host, EffectSettings &settings) override;
+   bool InitializeInstance(EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
@@ -442,8 +441,6 @@ private:
    LV2Symbols::URIDMap mURIDMap;
 
    const LilvPlugin *mPlug;
-
-   EffectHostInterface *mHost;
 
    float mSampleRate;
    int mBlockSize;


### PR DESCRIPTION
Resolves: #2630
Resolves: #2646

Clear up confusing things in management of effects:  the host/client distinction that was hard to explain.  All effects,
including third-party, implement all of the "host" and the "client" interfaces.  Third party effects don't need a "host"
shell Effect to forward certain method calls to them.

To achieve this, required also resolving the confusions about management of the duration setting of generators.  That is
now part of the non-polymorphic part of EffectSettings.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
