### PR TITLE
Simplification of logical conditional and small code refactoring

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -418,7 +418,6 @@ RealtimeEffectState *AudioIO::AddState(AudacityProject &project,
       if (auto pProject = GetOwningProject(); pProject.get() == &project)
          pInit = &*mpTransportState->mpRealtimeInitialization;
    return RealtimeEffectManager::Get(project).AddState(pInit, pTrack, id);
-   return nullptr;
 }
 
 void AudioIO::RemoveState(AudacityProject &project,

--- a/src/WrappedType.cpp
+++ b/src/WrappedType.cpp
@@ -74,17 +74,13 @@ int WrappedType::ReadAsInt()
       long l;
       mpStr->ToLong(&l);
       return (int) l;
-      break;
    }
    case eWrappedInt:
       return *mpInt;
-      break;
    case eWrappedDouble:
       return (int)*mpDouble;
-      break;
    case eWrappedBool:
       return (* mpBool) ? 1 : 0;
-      break;
    case eWrappedEnum:
       wxASSERT( false );
       break;

--- a/src/widgets/FileDialog/win/FileDialogPrivate.cpp
+++ b/src/widgets/FileDialog/win/FileDialogPrivate.cpp
@@ -1138,8 +1138,7 @@ int FileDialog::ShowModal()
       //=== Adding the correct extension >>=================================
       m_filterIndex = (int)of.nFilterIndex - 1;
 
-      if ( !of.nFileExtension ||
-            (of.nFileExtension && fileNameBuffer[of.nFileExtension] == wxT('\0')) )
+      if ( !of.nFileExtension || fileNameBuffer[of.nFileExtension] == wxT('\0') )
       {
          // User has typed a filename without an extension:
          const wxChar* extension = filterBuffer;


### PR DESCRIPTION
Resolves: Code Quality Refactoring (no issue number)

1. 92dc29b725b01b59d3dd74c0cc0ba82f09cd1777: There was a return nullptr which was redundant as there was a return statement above it, rendering it unreachable.
2. d75036814d046f63650862fe0b279ad0fe5515c1: While switch cases require a break statement, some cases had a return above the break statement, rendering them unreachable.
3. b899e6417db56d45961516d9f2b3f9e35e39bfdf: Simplified the logic for an if/else statement but removing an redundant validity check.
![image](https://user-images.githubusercontent.com/65039925/159354431-b7d6c557-5abb-4a34-b064-321f6305343d.png)
![image](https://user-images.githubusercontent.com/65039925/159354448-6198e6fd-8c4d-441c-96fa-057f38a00c48.png)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
