### PR TITLE
Rewrite dtmf

### DIFF
--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -23,12 +23,25 @@ class wxTextCtrl;
 class NumericTextCtrl;
 class ShuttleGui;
 
-class EffectDtmf final : public StatefulPerTrackEffect
+struct DtmfSettings {
+   static constexpr wchar_t DefaultSequence[] = L"audacity";
+   static constexpr double DefaultDutyCycle = 55.0;
+   static constexpr double DefaultAmplitude = 0.8;
+
+   wxString dtmfSequence{DefaultSequence}; // dtmf tone string
+   size_t dtmfNTones = dtmfSequence.length(); // total number of tones to generate
+   double dtmfTone{};               // duration of a single tone in ms
+   double dtmfSilence{};            // duration of silence between tones in ms
+   double dtmfDutyCycle{DefaultDutyCycle}; // ratio of dtmfTone/(dtmfTone+dtmfSilence)
+   double dtmfAmplitude{DefaultAmplitude}; // amplitude of dtmf tone sequence, restricted to (0-1)
+
+   void Recalculate(EffectSettings &settings);
+};
+
+class EffectDtmf final
+   : public EffectWithSettings<DtmfSettings, StatefulPerTrackEffect>
 {
 public:
-   struct Settings;
-   static inline Settings *
-   FetchParameters(EffectDtmf &e, EffectSettings &) { return &e.mSettings; }
    static const ComponentInterfaceSymbol Symbol;
 
    EffectDtmf();
@@ -74,33 +87,17 @@ private:
    int curSeqPos;                   // index into dtmf tone string
 
 public:
-   struct Settings {
-      static constexpr wchar_t DefaultSequence[] = L"audacity";
-      static constexpr double DefaultDutyCycle = 55.0;
-      static constexpr double DefaultAmplitude = 0.8;
-
-      wxString dtmfSequence{DefaultSequence}; // dtmf tone string
-      int    dtmfNTones = dtmfSequence.length(); // total number of tones to generate
-      double dtmfTone{};               // duration of a single tone in ms
-      double dtmfSilence{};            // duration of silence between tones in ms
-      double dtmfDutyCycle{DefaultDutyCycle}; // ratio of dtmfTone/(dtmfTone+dtmfSilence)
-      double dtmfAmplitude{DefaultAmplitude}; // amplitude of dtmf tone sequence, restricted to (0-1)
-
-      void Recalculate(EffectSettings &settings);
-   };
-
    struct Validator;
 
 private:
-   Settings mSettings;
    const EffectParameterMethods& Parameters() const override;
 
-static constexpr EffectParameter Sequence{ &Settings::dtmfSequence,
-   L"Sequence",   Settings::DefaultSequence, L"", L"", L""};
-static constexpr EffectParameter DutyCycle{ &Settings::dtmfDutyCycle,
-   L"Duty Cycle", Settings::DefaultDutyCycle, 0.0,     100.0,   10.0   };
-static constexpr EffectParameter Amplitude{ &Settings::dtmfAmplitude,
-   L"Amplitude",  Settings::DefaultAmplitude, 0.001,   1.0,     1      };
+static constexpr EffectParameter Sequence{ &DtmfSettings::dtmfSequence,
+   L"Sequence",   DtmfSettings::DefaultSequence, L"", L"", L""};
+static constexpr EffectParameter DutyCycle{ &DtmfSettings::dtmfDutyCycle,
+   L"Duty Cycle", DtmfSettings::DefaultDutyCycle, 0.0,     100.0,   10.0   };
+static constexpr EffectParameter Amplitude{ &DtmfSettings::dtmfAmplitude,
+   L"Amplitude",  DtmfSettings::DefaultAmplitude, 0.001,   1.0,     1      };
 };
 
 #endif

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -39,7 +39,7 @@ struct DtmfSettings {
 };
 
 class EffectDtmf final
-   : public EffectWithSettings<DtmfSettings, StatefulPerTrackEffect>
+   : public EffectWithSettings<DtmfSettings, PerTrackEffect>
 {
 public:
    static const ComponentInterfaceSymbol Symbol;
@@ -58,33 +58,22 @@ public:
    EffectType GetType() const override;
 
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
-      sampleCount totalLen, ChannelNames chanMap) override;
-   size_t ProcessBlock(EffectSettings &settings,
-      const float *const *inBlock, float *const *outBlock, size_t blockLen)
-      override;
 
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
 
+   struct Instance;
+   std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
+      const override;
+
 private:
    // EffectDtmf implementation
 
-   bool MakeDtmfTone(float *buffer, size_t len, float fs,
+   static bool MakeDtmfTone(float *buffer, size_t len, float fs,
                      wxChar tone, sampleCount last,
                      sampleCount total, float amplitude);
-
-private:
-   sampleCount numSamplesSequence;  // total number of samples to generate
-   sampleCount numSamplesTone;      // number of samples in a tone block
-   sampleCount numSamplesSilence;   // number of samples in a silence block
-   sampleCount diff;                // number of extra samples to redistribute
-   sampleCount numRemaining;        // number of samples left to produce in the current block
-   sampleCount curTonePos;          // position in tone to start the wave
-   bool isTone;                     // true if block is tone, otherwise silence
-   int curSeqPos;                   // index into dtmf tone string
 
 public:
    struct Validator;


### PR DESCRIPTION
Resolves: #2576

Make DTMF the first effect (generator, to be exact) that externalizes its settings and state.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
