### PR TITLE
Make amplify stateless

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -393,6 +393,8 @@ list( APPEND SOURCES
 
       effects/Amplify.cpp
       effects/Amplify.h
+      effects/AmplifySL.cpp
+      effects/AmplifySL.h
       effects/AutoDuck.cpp
       effects/AutoDuck.h
       effects/BassTreble.cpp

--- a/src/effects/AmplifySL.cpp
+++ b/src/effects/AmplifySL.cpp
@@ -1,0 +1,406 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Amplify.cpp
+
+  Dominic Mazzoni
+  Vaughan Johnson (Preview)
+
+*******************************************************************//**
+
+\class EffectAmplify
+\brief An Effect that makes a sound louder or softer.
+
+  This rewritten class supports a smart Amplify effect - it calculates
+  the maximum amount of gain that can be applied to all tracks without
+  causing clipping and selects this as the default parameter.
+
+*//*******************************************************************/
+
+
+#include "AmplifySL.h"
+#include "LoadEffects.h"
+
+#include <math.h>
+#include <float.h>
+
+#include <wx/button.h>
+#include <wx/checkbox.h>
+#include <wx/intl.h>
+#include <wx/sizer.h>
+#include <wx/slider.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/valtext.h>
+#include <wx/log.h>
+
+#include "../ShuttleGui.h"
+#include "../WaveTrack.h"
+#include "../widgets/valnum.h"
+
+
+enum
+{
+   ID_Amp = 10000,
+   ID_Peak,
+   ID_Clip
+};
+
+const EffectParameterMethods& EffectAmplifySL::Parameters() const
+{
+   static CapturedParameters<EffectAmplifySL,
+      // Interactive case
+      Ratio, Clipping
+   > parameters;
+
+   static CapturedParameters<EffectAmplifySL,
+      Ratio
+   > batchParameters{
+      // If invoking Amplify from a macro, mCanClip is not a parameter
+      // but is always true
+      [](EffectAmplifySL&, EffectSettings &, EffectAmplifySL&e, bool) {
+         e.mCanClip = true;
+         return true;
+      },
+   };
+
+   // Parameters differ depending on batch mode.  Option to disable clipping
+   // is interactive only.
+   if (IsBatchProcessing())
+      return parameters;
+   else
+      return batchParameters;
+}
+
+//
+// EffectAmplify
+//
+
+const ComponentInterfaceSymbol EffectAmplifySL::Symbol
+{ XO("AmplifySL") };
+
+namespace{ BuiltinEffectsModule::Registration< EffectAmplifySL > reg; }
+
+BEGIN_EVENT_TABLE(EffectAmplifySL, wxEvtHandler)
+   EVT_SLIDER(ID_Amp, EffectAmplifySL::OnAmpSlider)
+   EVT_TEXT(ID_Amp, EffectAmplifySL::OnAmpText)
+   EVT_TEXT(ID_Peak, EffectAmplifySL::OnPeakText)
+   EVT_CHECKBOX(ID_Clip, EffectAmplifySL::OnClipCheckBox)
+END_EVENT_TABLE()
+
+EffectAmplifySL::EffectAmplifySL()
+{
+   mAmp = Amp.def;
+   // Ratio.def == DB_TO_LINEAR(Amp.def)
+   Parameters().Reset(*this);
+   mRatioClip = 0.0;
+   mPeak = 0.0;
+
+   SetLinearEffectFlag(true);
+}
+
+EffectAmplifySL::~EffectAmplifySL()
+{
+}
+
+// ComponentInterface implementation
+
+ComponentInterfaceSymbol EffectAmplifySL::GetSymbol() const
+{
+   return Symbol;
+}
+
+TranslatableString EffectAmplifySL::GetDescription() const
+{
+   // Note: This is useful only after ratio has been set.
+   return XO("Increases or decreases the volume of the audio you have selected");
+}
+
+ManualPageID EffectAmplifySL::ManualPage() const
+{
+   return L"Amplify";
+}
+
+// EffectDefinitionInterface implementation
+
+EffectType EffectAmplifySL::GetType() const
+{
+   return EffectTypeProcess;
+}
+
+// EffectProcessor implementation
+
+unsigned EffectAmplifySL::GetAudioInCount() const
+{
+   return 1;
+}
+
+unsigned EffectAmplifySL::GetAudioOutCount() const
+{
+   return 1;
+}
+
+size_t EffectAmplifySL::ProcessBlock(EffectSettings &,
+   const float *const *inBlock, float *const *outBlock, size_t blockLen)
+{
+   for (decltype(blockLen) i = 0; i < blockLen; i++)
+   {
+      outBlock[0][i] = inBlock[0][i] * mRatio;
+   }
+
+   return blockLen;
+}
+
+bool EffectAmplifySL::LoadFactoryDefaults(EffectSettings &) const
+{
+   // To do: externalize state so const_cast isn't needed
+   return const_cast<EffectAmplifySL&>(*this).DoLoadFactoryDefaults();
+}
+
+bool EffectAmplifySL::DoLoadFactoryDefaults()
+{
+   Init();
+
+   mRatioClip = 0.0;
+   if (mPeak > 0.0)
+   {
+      mRatio = 1.0 / mPeak;
+      mRatioClip = mRatio;
+   }
+   else
+   {
+      mRatio = 1.0;
+   }
+   mCanClip = false;
+
+   ClampRatio();
+   return true;
+}
+
+// Effect implementation
+
+bool EffectAmplifySL::Init()
+{
+   mPeak = 0.0;
+
+   for (auto t : inputTracks()->Selected< const WaveTrack >())
+   {
+      auto pair = t->GetMinMax(mT0, mT1); // may throw
+      const float min = pair.first, max = pair.second;
+      float newpeak = (fabs(min) > fabs(max) ? fabs(min) : fabs(max));
+
+      if (newpeak > mPeak)
+      {
+         mPeak = newpeak;
+      }
+   }
+
+   return true;
+}
+
+void EffectAmplifySL::Preview(EffectSettingsAccess &access, bool dryOnly)
+{
+   auto cleanup1 = valueRestorer( mRatio );
+   auto cleanup2 = valueRestorer( mPeak );
+
+   Effect::Preview(access, dryOnly);
+}
+
+std::unique_ptr<EffectUIValidator>
+EffectAmplifySL::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+{
+   enum{ precision = 3 }; // allow (a generous) 3 decimal  places for Amplification (dB)
+
+   bool batch = IsBatchProcessing();
+   if ( batch )
+   {
+      mCanClip = true;
+      mPeak = 1.0;
+   }
+   else 
+   {
+      if (mPeak > 0.0)
+      {
+         mRatio = 1.0 / mPeak;
+         mRatioClip = mRatio;
+      }
+      else
+      {
+         mRatio = 1.0;
+      }
+   }
+
+   S.AddSpace(0, 5);
+
+   S.StartVerticalLay(0);
+   {
+      // Amplitude
+      S.StartMultiColumn(2, wxCENTER);
+      {
+         mAmpT = S.Id(ID_Amp)
+            .Validator<FloatingPointValidator<double>>(
+               precision, &mAmp, NumValidatorStyle::ONE_TRAILING_ZERO, Amp.min, Amp.max )
+            .AddTextBox(XXO("&Amplification (dB):"), L"", 12);
+      }
+      S.EndMultiColumn();
+
+      // Amplitude
+      S.StartHorizontalLay(wxEXPAND);
+      {
+         mAmpS = S.Id(ID_Amp)
+            .Style(wxSL_HORIZONTAL)
+            .Name(XO("Amplification dB"))
+            .AddSlider( {}, 0, Amp.max * Amp.scale, Amp.min * Amp.scale);
+      }
+      S.EndHorizontalLay();
+
+      // Peak
+      S.StartMultiColumn(2, wxCENTER);
+      {
+         mNewPeakT = S.Id(ID_Peak)
+            .Validator<FloatingPointValidator<double>>(
+               // One extra decimal place so that rounding is visible to user
+               // (see: bug 958)
+               precision + 1,
+               &mNewPeak, NumValidatorStyle::ONE_TRAILING_ZERO,
+               // min and max need same precision as what we're validating (bug 963)
+               RoundValue( precision + 1, Amp.min + LINEAR_TO_DB(mPeak) ),
+               RoundValue( precision + 1, Amp.max + LINEAR_TO_DB(mPeak) ) )
+            .AddTextBox(XXO("&New Peak Amplitude (dB):"), L"", 12);
+      }
+      S.EndMultiColumn();
+
+      // Clipping
+      S.StartHorizontalLay(wxCENTER);
+      {
+
+         mClip = S.Id(ID_Clip).Disable( batch )
+            .AddCheckBox(XXO("Allo&w clipping"), false);
+      }
+      S.EndHorizontalLay();
+   }
+   S.EndVerticalLay();
+
+   return nullptr;
+}
+
+void EffectAmplifySL::ClampRatio()
+{
+   // limit range of gain
+   double dBInit = LINEAR_TO_DB(mRatio);
+   double dB = std::clamp<double>(dBInit, Amp.min, Amp.max);
+   if (dB != dBInit)
+      mRatio = DB_TO_LINEAR(dB);
+
+   mAmp = LINEAR_TO_DB(mRatio);
+   mNewPeak = LINEAR_TO_DB(mRatio * mPeak);
+}
+
+bool EffectAmplifySL::TransferDataToWindow(const EffectSettings &)
+{
+   mAmpT->GetValidator()->TransferToWindow();
+
+   mAmpS->SetValue((int) (mAmp * Amp.scale + 0.5f));
+
+   mNewPeakT->GetValidator()->TransferToWindow();
+
+   mClip->SetValue(mCanClip);
+
+   CheckClip();
+
+   return true;
+}
+
+bool EffectAmplifySL::TransferDataFromWindow(EffectSettings &)
+{
+   mRatio = DB_TO_LINEAR(std::clamp<double>(mAmp * Amp.scale, Amp.min * Amp.scale, Amp.max * Amp.scale) / Amp.scale);
+
+   mCanClip = mClip->GetValue();
+
+   if (!mCanClip && mRatio * mPeak > 1.0)
+   {
+      mRatio = 1.0 / mPeak;
+   }
+
+   ClampRatio();
+
+   return true;
+}
+
+// EffectAmplify implementation
+
+void EffectAmplifySL::CheckClip()
+{
+   EnableApply(mClip->GetValue() || (mPeak > 0.0 && mRatio <= mRatioClip));
+}
+
+void EffectAmplifySL::OnAmpText(wxCommandEvent & WXUNUSED(evt))
+{
+   if (!mAmpT->GetValidator()->TransferFromWindow())
+   {
+      EnableApply(false);
+      return;
+   }
+
+   mRatio = DB_TO_LINEAR(std::clamp<double>(mAmp * Amp.scale, Amp.min * Amp.scale, Amp.max * Amp.scale) / Amp.scale);
+
+   mAmpS->SetValue((int) (LINEAR_TO_DB(mRatio) * Amp.scale + 0.5));
+
+   mNewPeak = LINEAR_TO_DB(mRatio * mPeak);
+   mNewPeakT->GetValidator()->TransferToWindow();
+
+   CheckClip();
+}
+
+void EffectAmplifySL::OnPeakText(wxCommandEvent & WXUNUSED(evt))
+{
+   if (!mNewPeakT->GetValidator()->TransferFromWindow())
+   {
+      EnableApply(false);
+      return;
+   }
+
+   if (mNewPeak == 0.0)
+      mRatio = mRatioClip;
+   else
+      mRatio = DB_TO_LINEAR(mNewPeak) / mPeak;
+
+   double ampInit = LINEAR_TO_DB(mRatio);
+   mAmp = std::clamp<double>(ampInit, Amp.min, Amp.max);
+   if (mAmp != ampInit)
+      mRatio = DB_TO_LINEAR(mAmp);
+
+   mAmpT->GetValidator()->TransferToWindow();
+
+   mAmpS->SetValue((int) (mAmp * Amp.scale + 0.5f));
+
+   CheckClip();
+}
+
+void EffectAmplifySL::OnAmpSlider(wxCommandEvent & evt)
+{
+   double dB = evt.GetInt() / Amp.scale;
+   mRatio = DB_TO_LINEAR(std::clamp<double>(dB, Amp.min, Amp.max));
+
+   double dB2 = (evt.GetInt() - 1) / Amp.scale;
+   double ratio2 = DB_TO_LINEAR(std::clamp<double>(dB2, Amp.min, Amp.max));
+
+   if (!mClip->GetValue() && mRatio * mPeak > 1.0 && ratio2 * mPeak < 1.0)
+   {
+      mRatio = 1.0 / mPeak;
+   }
+
+   mAmp = LINEAR_TO_DB(mRatio);
+   mAmpT->GetValidator()->TransferToWindow();
+
+   mNewPeak = LINEAR_TO_DB(mRatio * mPeak);
+   mNewPeakT->GetValidator()->TransferToWindow();
+
+   CheckClip();
+}
+
+void EffectAmplifySL::OnClipCheckBox(wxCommandEvent & WXUNUSED(evt))
+{
+   CheckClip();
+}

--- a/src/effects/AmplifySL.cpp
+++ b/src/effects/AmplifySL.cpp
@@ -207,6 +207,44 @@ void EffectAmplifySL::Preview(EffectSettingsAccess &access, bool dryOnly)
    Effect::Preview(access, dryOnly);
 }
 
+// Event handler object
+struct EffectAmplifySL::Validator
+   : DefaultEffectUIValidator
+{
+   Validator(EffectUIClientInterface&   effect,
+             EffectSettingsAccess&      access,
+             EffectAmplifySL::Settings& settings)
+
+      : DefaultEffectUIValidator{ effect, access }
+      , mSettings{ settings }
+   {}
+   virtual ~Validator() = default;
+
+   
+   Effect& GetEffect() const { return static_cast<Effect&>(mEffect); }
+
+   bool ValidateUI() override;
+   bool UpdateUI() override;
+   void DoUpdateUI();
+      
+   void PopulateOrExchange(ShuttleGui& S,
+      const EffectSettings& settings, double projectRate);
+
+   void OnAmpSlider(wxCommandEvent& evt);
+   void OnAmpText(wxCommandEvent& evt);
+   void OnPeakText(wxCommandEvent& evt);
+   void OnClipCheckBox(wxCommandEvent& evt);
+
+   EffectAmplifySL::Settings& mSettings;
+
+   wxSlider*   mAmpS;
+   wxTextCtrl* mAmpT;
+   wxTextCtrl* mNewPeakT;
+   wxCheckBox* mClip;
+};
+
+
+
 std::unique_ptr<EffectUIValidator>
 EffectAmplifySL::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
 {

--- a/src/effects/AmplifySL.h
+++ b/src/effects/AmplifySL.h
@@ -84,16 +84,20 @@ public:
       bool   mCanClip;
    };
 
+   struct State
+   {
+      double mPeak;
+      double mRatioClip;   // maximum value of mRatio which does not cause clipping
+      double mNewPeak;
+   };
+
    struct Validator;
 
 private:
 
    Settings mSettings;
 
-   double mPeak;
-
-   double mRatioClip;   // maximum value of mRatio which does not cause clipping
-   double mNewPeak;
+   State mState;   
 
    wxSlider *mAmpS;
    wxTextCtrl *mAmpT;

--- a/src/effects/AmplifySL.h
+++ b/src/effects/AmplifySL.h
@@ -84,6 +84,8 @@ public:
       bool   mCanClip;
    };
 
+   struct Validator;
+
 private:
 
    Settings mSettings;

--- a/src/effects/AmplifySL.h
+++ b/src/effects/AmplifySL.h
@@ -1,0 +1,104 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Amplify.h
+
+  Dominic Mazzoni
+
+  This rewritten class supports a smart Amplify effect - it calculates
+  the maximum amount of gain that can be applied to all tracks without
+  causing clipping and selects this as the default parameter.
+
+**********************************************************************/
+
+#ifndef __AUDACITY_EFFECT_AMPLIFY_SL__
+#define __AUDACITY_EFFECT_AMPLIFY_SL__
+
+#include "Effect.h"
+#include "../ShuttleAutomation.h"
+
+
+class wxSlider;
+class wxCheckBox;
+class wxTextCtrl;
+class ShuttleGui;
+
+class EffectAmplifySL final : public Effect
+{
+public:
+   static inline EffectAmplifySL*
+   FetchParameters(EffectAmplifySL&e, EffectSettings &){ return &e; }
+   static const ComponentInterfaceSymbol Symbol;
+
+   EffectAmplifySL();
+   virtual ~EffectAmplifySL();
+
+   // ComponentInterface implementation
+
+   ComponentInterfaceSymbol GetSymbol() const override;
+   TranslatableString GetDescription() const override;
+   ManualPageID ManualPage() const override;
+
+   // EffectDefinitionInterface implementation
+
+   EffectType GetType() const override;
+   bool LoadFactoryDefaults(EffectSettings &settings) const override;
+   bool DoLoadFactoryDefaults();
+
+   // EffectProcessor implementation
+
+   unsigned GetAudioInCount() const override;
+   unsigned GetAudioOutCount() const override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
+
+   // Effect implementation
+
+   bool Init() override;
+   void Preview(EffectSettingsAccess &access, bool dryOnly) override;
+   std::unique_ptr<EffectUIValidator> PopulateOrExchange(
+      ShuttleGui & S, EffectSettingsAccess &access) override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
+
+private:
+   void ClampRatio();
+
+   // EffectAmplify implementation
+
+   void OnAmpText(wxCommandEvent & evt);
+   void OnPeakText(wxCommandEvent & evt);
+   void OnAmpSlider(wxCommandEvent & evt);
+   void OnClipCheckBox(wxCommandEvent & evt);
+   void CheckClip();
+
+private:
+   double mPeak;
+
+   double mRatio;
+   double mRatioClip;   // maximum value of mRatio which does not cause clipping
+   double mAmp;
+   double mNewPeak;
+   bool mCanClip;
+
+   wxSlider *mAmpS;
+   wxTextCtrl *mAmpT;
+   wxTextCtrl *mNewPeakT;
+   wxCheckBox *mClip;
+
+   const EffectParameterMethods& Parameters() const override;
+
+   DECLARE_EVENT_TABLE()
+
+static constexpr EffectParameter Ratio{ &EffectAmplifySL::mRatio,
+   L"Ratio",            0.9f,       0.003162f,  316.227766f,   1.0f  };
+// Amp is not saved in settings!
+static constexpr EffectParameter Amp{ &EffectAmplifySL::mAmp,
+   L"",                -0.91515f,  -50.0f,     50.0f,         10.0f };
+static constexpr EffectParameter Clipping{ &EffectAmplifySL::mCanClip,
+   L"AllowClipping",    false,    false,  true,    1  };
+};
+
+#endif // __AUDACITY_EFFECT_AMPLIFY__

--- a/src/effects/AmplifySL.h
+++ b/src/effects/AmplifySL.h
@@ -27,8 +27,9 @@ class ShuttleGui;
 class EffectAmplifySL final : public Effect
 {
 public:
-   static inline EffectAmplifySL*
-   FetchParameters(EffectAmplifySL&e, EffectSettings &){ return &e; }
+   struct Settings;
+   static inline Settings*
+   FetchParameters(EffectAmplifySL&e, EffectSettings &){ return &e.mSettings; }
    static const ComponentInterfaceSymbol Symbol;
 
    EffectAmplifySL();
@@ -74,14 +75,23 @@ private:
    void OnClipCheckBox(wxCommandEvent & evt);
    void CheckClip();
 
+public:
+
+   struct Settings
+   {
+      double mRatio;
+      double mAmp;
+      bool   mCanClip;
+   };
+
 private:
+
+   Settings mSettings;
+
    double mPeak;
 
-   double mRatio;
    double mRatioClip;   // maximum value of mRatio which does not cause clipping
-   double mAmp;
    double mNewPeak;
-   bool mCanClip;
 
    wxSlider *mAmpS;
    wxTextCtrl *mAmpT;
@@ -92,12 +102,12 @@ private:
 
    DECLARE_EVENT_TABLE()
 
-static constexpr EffectParameter Ratio{ &EffectAmplifySL::mRatio,
+static constexpr EffectParameter Ratio{ &Settings::mRatio,
    L"Ratio",            0.9f,       0.003162f,  316.227766f,   1.0f  };
 // Amp is not saved in settings!
-static constexpr EffectParameter Amp{ &EffectAmplifySL::mAmp,
+static constexpr EffectParameter Amp{ &Settings::mAmp,
    L"",                -0.91515f,  -50.0f,     50.0f,         10.0f };
-static constexpr EffectParameter Clipping{ &EffectAmplifySL::mCanClip,
+static constexpr EffectParameter Clipping{ &Settings::mCanClip,
    L"AllowClipping",    false,    false,  true,    1  };
 };
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2739

Not a complete solution, but rather a work in progress, aimed at progressively making EffectAmplify to work with a Validator.
Unless otherwise specified, each commit leaves the effect in a working state.


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
