### PR TITLE
Realtime effects use effect instance

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -103,6 +103,8 @@ bool EffectSettingsManager::CopySettingsContents(
 
 EffectInstance::~EffectInstance() = default;
 
+EffectInstanceFactory::~EffectInstanceFactory() = default;
+
 EffectProcessor::~EffectProcessor() = default;
 
 EffectUIValidator::~EffectUIValidator() = default;

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -99,6 +99,8 @@ bool EffectDefinitionInterface::CopySettingsContents(
    return true;
 }
 
+EffectInstance::~EffectInstance() = default;
+
 EffectProcessor::~EffectProcessor() = default;
 
 EffectUIValidator::~EffectUIValidator() = default;

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -76,24 +76,26 @@ bool EffectDefinitionInterface::IsHiddenFromMenus() const
    return false;
 }
 
-bool EffectDefinitionInterface::VisitSettings(
+EffectSettingsManager::~EffectSettingsManager() = default;
+
+bool EffectSettingsManager::VisitSettings(
    SettingsVisitor &, EffectSettings &)
 {
    return false;
 }
 
-bool EffectDefinitionInterface::VisitSettings(
+bool EffectSettingsManager::VisitSettings(
    ConstSettingsVisitor &, const EffectSettings &) const
 {
    return false;
 }
 
-auto EffectDefinitionInterface::MakeSettings() const -> EffectSettings
+auto EffectSettingsManager::MakeSettings() const -> EffectSettings
 {
    return {};
 }
 
-bool EffectDefinitionInterface::CopySettingsContents(
+bool EffectSettingsManager::CopySettingsContents(
    const EffectSettings &, EffectSettings &) const
 {
    return true;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -384,7 +384,9 @@ public:
 /***************************************************************************//**
 \class EffectInstanceFactory
 *******************************************************************************/
-class COMPONENTS_API EffectInstanceFactory {
+class COMPONENTS_API EffectInstanceFactory
+   : public EffectSettingsManager
+{
 public:
    virtual ~EffectInstanceFactory();
 
@@ -399,6 +401,15 @@ public:
     */
    virtual std::shared_ptr<EffectInstance>
    MakeInstance(EffectSettings &settings) const = 0;
+
+   //! How many input buffers to allocate at once
+   /*!
+    If the effect ALWAYS processes channels independently, this can return 1
+    */
+   virtual unsigned GetAudioInCount() const = 0;
+
+   //! How many output buffers to allocate at once
+   virtual unsigned GetAudioOutCount() const = 0;
 };
 
 /*************************************************************************************//**
@@ -411,13 +422,9 @@ AudacityCommand.
 
 *******************************************************************************************/
 class COMPONENTS_API EffectProcessor  /* not final */
-   : public EffectSettingsManager
 {
 public:
    virtual ~EffectProcessor();
-
-   virtual unsigned GetAudioInCount() const = 0;
-   virtual unsigned GetAudioOutCount() const = 0;
 
    virtual int GetMidiInCount() = 0;
    virtual int GetMidiOutCount() = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -381,6 +381,26 @@ public:
    virtual bool RealtimeFinalize(EffectSettings &settings) noexcept = 0;
 };
 
+/***************************************************************************//**
+\class EffectInstanceFactory
+*******************************************************************************/
+class COMPONENTS_API EffectInstanceFactory {
+public:
+   virtual ~EffectInstanceFactory();
+
+   //! Make an object maintaining short-term state of an Effect
+   /*!
+    One effect may have multiple instances extant simultaneously.
+    Instances have state, may be implemented in foreign code, and are temporary,
+    whereas EffectSettings represents persistent effect state that can be saved
+    and reloaded from files.
+
+    @param settings may be assumed to have a lifetime enclosing the instance's
+    */
+   virtual std::shared_ptr<EffectInstance>
+   MakeInstance(EffectSettings &settings) = 0;
+};
+
 /*************************************************************************************//**
 
 \class EffectProcessor 

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -319,6 +319,29 @@ typedef enum
    ChannelNameBottomFrontRight,
 } ChannelName, *ChannelNames;
 
+/***************************************************************************//**
+\class EffectInstance
+@brief Performs effect computation
+*******************************************************************************/
+class COMPONENTS_API EffectInstance
+   : public std::enable_shared_from_this<EffectInstance>
+{
+public:
+   virtual ~EffectInstance();
+
+   //! Call once to set up state for whole list of tracks to be processed
+   /*!
+    @return success
+    */
+   virtual bool Init() = 0;
+
+   //! Actually do the effect here.
+   /*!
+    @return success
+    */
+   virtual bool Process(EffectSettings &settings) = 0;
+};
+
 /*************************************************************************************//**
 
 \class EffectProcessor 

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -398,7 +398,7 @@ public:
     @param settings may be assumed to have a lifetime enclosing the instance's
     */
    virtual std::shared_ptr<EffectInstance>
-   MakeInstance(EffectSettings &settings) = 0;
+   MakeInstance(EffectSettings &settings) const = 0;
 };
 
 /*************************************************************************************//**

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -340,6 +340,26 @@ public:
     @return success
     */
    virtual bool Process(EffectSettings &settings) = 0;
+
+   virtual void SetSampleRate(double rate) = 0;
+
+   virtual size_t GetBlockSize() const = 0;
+
+   // Suggest a block size, but the return is the size that was really set:
+   virtual size_t SetBlockSize(size_t maxBlockSize) = 0;
+
+   virtual bool RealtimeInitialize(EffectSettings &settings) = 0;
+   virtual bool RealtimeAddProcessor(
+      EffectSettings &settings, unsigned numChannels, float sampleRate) = 0;
+   virtual bool RealtimeSuspend() = 0;
+   virtual bool RealtimeResume() noexcept = 0;
+   //! settings are possibly changed, since last call, by an asynchronous dialog
+   virtual bool RealtimeProcessStart(EffectSettings &settings) = 0;
+   virtual size_t RealtimeProcess(int group, EffectSettings &settings,
+      const float *const *inBuf, float *const *outBuf, size_t numSamples) = 0;
+   //! settings can be updated to let a dialog change appearance at idle
+   virtual bool RealtimeProcessEnd(EffectSettings &settings) noexcept = 0;
+   virtual bool RealtimeFinalize(EffectSettings &settings) noexcept = 0;
 };
 
 /*************************************************************************************//**

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -206,6 +206,22 @@ public:
 
    //! Default is false
    virtual bool IsHiddenFromMenus() const;
+};
+
+/*************************************************************************************//**
+
+\class EffectSettingsManager
+
+\brief EffectSettingsManager is an EffectDefinitionInterface that adds a
+factory function for EffectSettings, and const functions for manipulating those
+settings.  This externalizes certain effect state.
+
+*******************************************************************************************/
+class COMPONENTS_API EffectSettingsManager  /* not final */
+   : public EffectDefinitionInterface
+{
+public:
+   virtual ~EffectSettingsManager();
 
    /*! @name settings
     Interface for saving and loading externalized settings.
@@ -265,11 +281,14 @@ public:
    virtual bool LoadFactoryDefaults(EffectSettings &settings) const = 0;
    //! @}
 
-   //! Visit settings, if defined.  false means no defined settings.
+   //! Visit settings (and maybe change them), if defined.
+   //! false means no defined settings.
    //! Default implementation returns false
    virtual bool VisitSettings(
-      SettingsVisitor &visitor, EffectSettings &settings);
-   //! Visit settings, if defined.  false means no defined settings.
+      SettingsVisitor &visitor, EffectSettings &settings); // TODO const
+
+   //! Visit settings (read-only), if defined.
+   //! false means no defined settings.
    //! Default implementation returns false
    virtual bool VisitSettings(
       ConstSettingsVisitor &visitor, const EffectSettings &settings) const;
@@ -372,7 +391,7 @@ AudacityCommand.
 
 *******************************************************************************************/
 class COMPONENTS_API EffectProcessor  /* not final */
-   : public EffectDefinitionInterface
+   : public EffectSettingsManager
 {
 public:
    virtual ~EffectProcessor();

--- a/libraries/lib-module-manager/ConfigInterface.cpp
+++ b/libraries/lib-module-manager/ConfigInterface.cpp
@@ -68,7 +68,7 @@ bool RemoveConfigSubgroup( const EffectDefinitionInterface &ident,
    return pluginManager.RemoveConfigSubgroup(type, id, group);
 }
 
-bool RemoveConfig( EffectDefinitionInterface &ident,
+bool RemoveConfig( const EffectDefinitionInterface &ident,
    PluginSettings::ConfigurationType type,
    const RegistryPath & group, const RegistryPath & key)
 {

--- a/libraries/lib-module-manager/ConfigInterface.h
+++ b/libraries/lib-module-manager/ConfigInterface.h
@@ -106,7 +106,7 @@ inline bool SetConfig( const EffectDefinitionInterface& ident,
 
 MODULE_MANAGER_API bool RemoveConfigSubgroup( const EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group);
-MODULE_MANAGER_API bool RemoveConfig( EffectDefinitionInterface &ident,
+MODULE_MANAGER_API bool RemoveConfig( const EffectDefinitionInterface &ident,
    ConfigurationType type, const RegistryPath & group,
    const RegistryPath & key);
 

--- a/src/EffectPlugin.cpp
+++ b/src/EffectPlugin.cpp
@@ -15,5 +15,3 @@ const wxString EffectPlugin::kUserPresetIdent = wxT("User Preset:");
 const wxString EffectPlugin::kFactoryPresetIdent = wxT("Factory Preset:");
 const wxString EffectPlugin::kCurrentSettingsIdent = wxT("<Current Settings>");
 const wxString EffectPlugin::kFactoryDefaultsIdent = wxT("<Factory Defaults>");
-
-EffectInstance::~EffectInstance() = default;

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -125,26 +125,4 @@ public:
    MakeInstance(EffectSettings &settings) = 0;
 };
 
-/***************************************************************************//**
-\class EffectInstance
-@brief Performs effect computation
-*******************************************************************************/
-class EffectInstance : public std::enable_shared_from_this<EffectInstance>
-{
-public:
-   virtual ~EffectInstance();
-
-   //! Call once to set up state for whole list of tracks to be processed
-   /*!
-    @return success
-    */
-   virtual bool Init() = 0;
-
-   //! Actually do the effect here.
-   /*!
-    @return success
-    */
-   virtual bool Process(EffectSettings &settings) = 0;
-};
-
 #endif

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -12,7 +12,7 @@
 #ifndef __AUDACITY_EFFECTPLUGIN_H__
 #define __AUDACITY_EFFECTPLUGIN_H__
 
-#include "ComponentInterfaceSymbol.h"
+#include "EffectInterface.h"
 
 #include <functional>
 #include <memory>
@@ -42,6 +42,7 @@ class EffectInstance;
 @brief Factory of instances of an effect and of dialogs to control them
 *******************************************************************************/
 class AUDACITY_DLL_API EffectPlugin
+   : public EffectInstanceFactory
 {
 public:
    using EffectSettingsAccessPtr = std::shared_ptr<EffectSettingsAccess>;
@@ -111,18 +112,6 @@ public:
 
    //! Update the given settings from controls
    virtual bool TransferDataFromWindow(EffectSettings &settings) = 0;
-
-   //! Make an object maintaining short-term state of an Effect
-   /*!
-    One effect may have multiple instances extant simultaneously.
-    Instances have state, may be implemented in foreign code, and are temporary,
-    whereas EffectSettings represents persistent effect state that can be saved
-    and reloaded from files.
-
-    @param settings may be assumed to have a lifetime enclosing the instance's
-    */
-   virtual std::shared_ptr<EffectInstance>
-   MakeInstance(EffectSettings &settings) = 0;
 };
 
 #endif

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -17,7 +17,7 @@
 #include <functional>
 #include <memory>
 
-class EffectDefinitionInterface;
+class EffectSettingsManager;
 
 class wxDialog;
 class wxWindow;
@@ -54,7 +54,7 @@ public:
    EffectPlugin &operator=(EffectPlugin&) = delete;
    virtual ~EffectPlugin();
 
-   virtual const EffectDefinitionInterface& GetDefinition() const = 0;
+   virtual const EffectSettingsManager& GetDefinition() const = 0;
 
    //! Usually applies factory to self and given access
    /*!

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -617,7 +617,7 @@ void Effect::ShowOptions()
 
 // EffectPlugin implementation
 
-const EffectDefinitionInterface& Effect::GetDefinition() const
+const EffectSettingsManager& Effect::GetDefinition() const
 {
    return *this;
 }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -46,19 +46,19 @@ static const int kFFwdID = 20104;
 
 using t2bHash = std::unordered_map< void*, bool >;
 
-Effect::Instance::Instance(Effect &effect)
+StatefulEffectBase::Instance::Instance(StatefulEffectBase &effect)
    : mEffect{ effect }
 {
 }
 
-Effect::Instance::~Instance() = default;
+StatefulEffectBase::Instance::~Instance() = default;
 
-bool Effect::Instance::Init()
+bool StatefulEffectBase::Instance::Init()
 {
    return mEffect.Init();
 }
 
-bool Effect::Instance::Process(EffectSettings &settings)
+bool StatefulEffectBase::Instance::Process(EffectSettings &settings)
 {
    return mEffect.Process(*this, settings);
 }
@@ -699,7 +699,7 @@ bool Effect::Delegate(Effect &delegate, EffectSettings &settings)
       region, mUIFlags, nullptr, nullptr, nullptr);
 }
 
-bool Effect::Init()
+bool StatefulEffectBase::Init()
 {
    return true;
 }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -202,9 +202,13 @@ bool Effect::SupportsAutomation() const
 // EffectProcessor implementation
 
 std::shared_ptr<EffectInstance>
-Effect::MakeInstance(EffectSettings &settings)
+Effect::MakeInstance(EffectSettings &settings) const
 {
-   return std::make_shared<Effect::Instance>(*this);
+   // Cheat with const-cast to return an object that calls through to
+   // non-const methods of a stateful effect.
+   // Stateless effects should override this function and be really const
+   // correct.
+   return std::make_shared<Effect::Instance>(const_cast<Effect&>(*this));
 }
 
 unsigned Effect::GetAudioInCount() const

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -53,14 +53,76 @@ StatefulEffectBase::Instance::Instance(StatefulEffectBase &effect)
 
 StatefulEffectBase::Instance::~Instance() = default;
 
+Effect &StatefulEffectBase::Instance::GetEffect() const
+{
+   return dynamic_cast<Effect&>(mEffect);
+}
+
 bool StatefulEffectBase::Instance::Init()
 {
-   return mEffect.Init();
+   return GetEffect().Init();
 }
 
 bool StatefulEffectBase::Instance::Process(EffectSettings &settings)
 {
-   return mEffect.Process(*this, settings);
+   return GetEffect().Process(*this, settings);
+}
+
+void StatefulEffectBase::Instance::SetSampleRate(double rate)
+{
+   GetEffect().SetSampleRate(rate);
+}
+
+bool StatefulEffectBase::Instance::RealtimeInitialize(EffectSettings &settings)
+{
+   return GetEffect().RealtimeInitialize(settings);
+}
+
+bool StatefulEffectBase::Instance::RealtimeAddProcessor(EffectSettings &settings,
+   unsigned numChannels, float sampleRate)
+{
+   return GetEffect().RealtimeAddProcessor(settings, numChannels, sampleRate);
+}
+
+bool StatefulEffectBase::Instance::RealtimeSuspend()
+{
+   return GetEffect().RealtimeSuspend();
+}
+
+bool StatefulEffectBase::Instance::RealtimeResume() noexcept
+{
+   return GetEffect().RealtimeResume();
+}
+
+bool StatefulEffectBase::Instance::RealtimeProcessStart(EffectSettings &settings)
+{
+   return GetEffect().RealtimeProcessStart(settings);
+}
+
+size_t StatefulEffectBase::Instance::RealtimeProcess(int group, EffectSettings &settings,
+   const float *const *inBuf, float *const *outBuf, size_t numSamples)
+{
+   return GetEffect().RealtimeProcess(group, settings, inBuf, outBuf, numSamples);
+}
+
+bool StatefulEffectBase::Instance::RealtimeProcessEnd(EffectSettings &settings) noexcept
+{
+   return GetEffect().RealtimeProcessEnd(settings);
+}
+
+bool StatefulEffectBase::Instance::RealtimeFinalize(EffectSettings &settings) noexcept
+{
+   return GetEffect().RealtimeFinalize(settings);
+}
+
+size_t StatefulEffectBase::Instance::GetBlockSize() const
+{
+   return GetEffect().GetBlockSize();
+}
+
+size_t StatefulEffectBase::Instance::SetBlockSize(size_t maxBlockSize)
+{
+   return GetEffect().SetBlockSize(maxBlockSize);
 }
 
 Effect::Effect()

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -190,7 +190,7 @@ class AUDACITY_DLL_API Effect /* not final */
 
    // EffectPlugin implementation
 
-   const EffectDefinitionInterface& GetDefinition() const override;
+   const EffectSettingsManager& GetDefinition() const override;
    virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar
 
    // EffectPlugin implementation

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -131,7 +131,7 @@ class AUDACITY_DLL_API Effect /* not final */
    // EffectProcessor implementation
 
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
-      override;
+      const override;
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -22,6 +22,7 @@ class EffectParameterMethods;
 class LabelTrack;
 class WaveTrack;
 
+class Effect;
 //! A mix-in class for effects that are not yet migrated to statelessness.
 //! To be eliminated when all effects are migrated
 class AUDACITY_DLL_API StatefulEffectBase {
@@ -35,8 +36,26 @@ public:
       bool Init() override;
       bool Process(EffectSettings &settings) override;
 
+      void SetSampleRate(double rate) override;
+   
+      size_t GetBlockSize() const override;
+      size_t SetBlockSize(size_t maxBlockSize) override;
+   
+      bool RealtimeInitialize(EffectSettings &settings) override;
+      bool RealtimeAddProcessor(EffectSettings &settings,
+         unsigned numChannels, float sampleRate) override;
+      bool RealtimeSuspend() override;
+      bool RealtimeResume() noexcept override;
+      bool RealtimeProcessStart(EffectSettings &settings) override;
+      size_t RealtimeProcess(int group, EffectSettings &settings,
+         const float *const *inBuf, float *const *outBuf, size_t numSamples)
+      override;
+      bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
+      bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    protected:
       StatefulEffectBase &mEffect;
+   private:
+      Effect &GetEffect() const;
    };
 
    /*!

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -61,13 +61,8 @@ const PluginID & EffectManager::RegisterEffect(
    std::unique_ptr<EffectPlugin> uEffect)
 {
    auto pEffect = uEffect.get();
-   // Change the "grip" on the object
-   // uEffect is expected to be a self-hosting Nyquist effect
-   auto uDefinition = std::unique_ptr<EffectDefinitionInterface>(
-      dynamic_cast<EffectUIClientInterface*>(uEffect.release()));
-   wxASSERT(uDefinition);
    const PluginID & ID =
-      PluginManager::Get().RegisterPlugin(std::move(uDefinition), PluginTypeEffect);
+      PluginManager::Get().RegisterPlugin(std::move(uEffect), PluginTypeEffect);
    mEffects[ID] = { pEffect, {} };
    return ID;
 }
@@ -894,14 +889,8 @@ const PluginID & EffectManager::GetEffectByIdentifier(const CommandID & strTarge
    return empty;
 }
 
-/* TODO:  fix the effect management so that repeated calls with the same ID
- give Effect objects with independent state for effect settings.
- */
-EffectProcessor *
-EffectManager::NewEffect(const PluginID & ID)
+const EffectInstanceFactory *
+EffectManager::GetInstanceFactory(const PluginID &ID)
 {
-   // Must have a "valid" ID
-   if (ID.empty())
-      return nullptr;
-   return dynamic_cast<EffectUIClientInterface *>(Get().GetEffect(ID));
+   return Get().GetEffect(ID);
 }

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -167,7 +167,7 @@ TranslatableString EffectManager::GetCommandTip(const PluginID & ID)
 
 void EffectManager::GetCommandDefinition(const PluginID & ID, const CommandContext & context, int flags)
 {
-   const EffectDefinitionInterface *effect = nullptr;
+   const EffectSettingsManager *effect = nullptr;
    const EffectSettings *settings;
    AudacityCommand *command = nullptr;
 
@@ -776,23 +776,23 @@ EffectManager::GetEffectAndDefaultSettings(const PluginID & ID)
 
 namespace {
 void InitializePreset(
-   EffectDefinitionInterface &definition, EffectSettings &settings) {
+   EffectSettingsManager &manager, EffectSettings &settings) {
    bool haveDefaults;
-   GetConfig(definition, PluginSettings::Private, FactoryDefaultsGroup(),
+   GetConfig(manager, PluginSettings::Private, FactoryDefaultsGroup(),
       wxT("Initialized"), haveDefaults, false);
    if (!haveDefaults)
    {
-      definition.SaveUserPreset(FactoryDefaultsGroup(), settings);
-      SetConfig(definition, PluginSettings::Private, FactoryDefaultsGroup(),
+      manager.SaveUserPreset(FactoryDefaultsGroup(), settings);
+      SetConfig(manager, PluginSettings::Private, FactoryDefaultsGroup(),
          wxT("Initialized"), true);
    }
-   definition.LoadUserPreset(CurrentSettingsGroup(), settings);
+   manager.LoadUserPreset(CurrentSettingsGroup(), settings);
 }
 
 std::pair<ComponentInterface *, EffectSettings>
 LoadComponent(const PluginID &ID)
 {
-   if (auto result = dynamic_cast<EffectDefinitionInterface*>(
+   if (auto result = dynamic_cast<EffectSettingsManager*>(
       PluginManager::Get().Load(ID))) {
       auto settings = result->MakeSettings();
       InitializePreset(*result, settings);

--- a/src/effects/EffectManager.h
+++ b/src/effects/EffectManager.h
@@ -63,8 +63,9 @@ public:
       kRepeatNyquistPrompt = 0x10,
    };
 
-   /*! Create a new instance of an effect by its ID. */
-   static EffectProcessor *NewEffect(const PluginID &ID);
+   /*! Find the singleton EffectInstanceFactory for ID. */
+   static
+   const EffectInstanceFactory *GetInstanceFactory(const PluginID &ID);
 
    /** Get the singleton instance of the EffectManager. Probably not safe
        for multi-thread use. */

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1531,10 +1531,10 @@ void EffectDialog::OnOk(wxCommandEvent & WXUNUSED(evt))
    return;
 }
 
-//! Inject a factory for realtime effect states
+//! Inject a factory for realtime effects
 #include "RealtimeEffectState.h"
-static
-RealtimeEffectState::EffectFactory::Scope scope{ &EffectManager::NewEffect };
+static RealtimeEffectState::EffectFactory::Scope
+scope{ &EffectManager::GetInstanceFactory };
 
 /* The following registration objects need a home at a higher level to avoid
  dependency either way between WaveTrack or RealtimeEffectList, which need to

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -164,11 +164,11 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
             mSampleCnt = left->TimeToLongSamples(duration);
 
          // Let the client know the sample rate
-         SetSampleRate(left->GetRate());
+         instance.SetSampleRate(left->GetRate());
 
          // Get the block size the client wants to use
          auto max = left->GetMaxBlockSize() * 2;
-         blockSize = SetBlockSize(max);
+         blockSize = instance.SetBlockSize(max);
 
          // Calculate the buffer size to be at least the max rounded up to the clients
          // selected block size.

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -58,9 +58,14 @@ sampleCount PerTrackEffect::Instance::GetLatency()
 PerTrackEffect::~PerTrackEffect() = default;
 
 std::shared_ptr<EffectInstance>
-PerTrackEffect::MakeInstance(EffectSettings &settings)
+PerTrackEffect::MakeInstance(EffectSettings &settings) const
 {
-   return std::make_shared<Instance>(*this);
+   // Cheat with const-cast to return an object that calls through to
+   // non-const methods of a stateful effect.
+   // Stateless effects should override this function and be really const
+   // correct.
+   return std::make_shared<Instance>(
+      const_cast<PerTrackEffect&>(*this));
 }
 
 size_t PerTrackEffect::SetBlockSize(size_t maxBlockSize)

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -77,7 +77,7 @@ public:
    };
 
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
-      override;
+      const override;
 
 protected:
    // These were overridables but the generality wasn't used yet

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -99,7 +99,7 @@ void RealtimeEffectManager::Finalize() noexcept
    // Assume it is now safe to clean up
    mLatency = std::chrono::microseconds(0);
 
-   VisitAll([](auto &state, bool){ state.Finalize(); });
+   VisitAll([](RealtimeEffectState &state, bool){ state.Finalize(); });
 
    // Reset processor parameters
    mGroupLeaders.clear();

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -17,7 +17,7 @@
 //! Mediator of two-way inter-thread communication of changes of settings
 class RealtimeEffectState::AccessState : public NonInterferingBase {
 public:
-   AccessState(EffectProcessor &effect, EffectSettings &settings)
+   AccessState(const EffectSettingsManager &effect, EffectSettings &settings)
       : mEffect{effect}
       , mSettings{settings}
    {
@@ -42,7 +42,7 @@ public:
    }
 
    struct EffectAndSettings{
-      EffectProcessor &effect; const EffectSettings &settings; };
+      const EffectSettingsManager &effect; const EffectSettings &settings; };
    void WorkerRead() {
       // Worker thread avoids memory allocation.  It copies the contents of any
       mChannelFromMain.Read<FromMainSlot::Reader>(mEffect, mSettings);
@@ -97,7 +97,7 @@ private:
 
       // Worker thread reads the slot
       struct Reader { Reader(FromMainSlot &&slot,
-         EffectProcessor &effect, EffectSettings &settings) {
+         const EffectSettingsManager &effect, EffectSettings &settings) {
             // This happens during MessageBuffer's busying of the slot
             effect.CopySettingsContents(slot.mSettings, settings);
             settings.extra = slot.mSettings.extra;
@@ -107,7 +107,7 @@ private:
    };
    MessageBuffer<FromMainSlot> mChannelFromMain;
 
-   EffectProcessor &mEffect;
+   const EffectSettingsManager &mEffect;
    EffectSettings &mSettings;
    EffectSettings mMainThreadCache;
 };

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -29,7 +29,7 @@ class RealtimeEffectState : public XMLTagHandler
 {
 public:
    struct AUDACITY_DLL_API EffectFactory : GlobalHook<EffectFactory,
-      EffectProcessor*(const PluginID &)
+      const EffectInstanceFactory *(const PluginID &)
    >{};
 
    explicit RealtimeEffectState(const PluginID & id);
@@ -40,7 +40,7 @@ public:
     Call with empty id is ignored.
     Called by the constructor that takes an id */
    void SetID(const PluginID & id);
-   EffectProcessor *GetEffect();
+   const EffectInstanceFactory *GetEffect();
 
    bool Suspend();
    bool Resume() noexcept;
@@ -76,7 +76,11 @@ public:
 private:
    PluginID mID;
    wxString mParameters;  // Used only during deserialization
-   EffectProcessor *mEffect{};
+
+   //! Stateless effect object
+   const EffectInstanceFactory *mPlugin{};
+   //! Stateful instance made by the plug-in
+   std::shared_ptr<EffectInstance> mInstance;
    EffectSettings mSettings;
 
    struct Access;

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -149,12 +149,12 @@ EffectType EffectReverb::GetType() const
 
 unsigned EffectReverb::GetAudioInCount() const
 {
-   return mParams.mStereoWidth ? 2 : 1;
+   return 2;
 }
 
 unsigned EffectReverb::GetAudioOutCount() const
 {
-   return mParams.mStereoWidth ? 2 : 1;
+   return 2;
 }
 
 static size_t BLOCK = 16384;

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1303,7 +1303,13 @@ bool VSTEffect::InitializePlugin()
 }
 
 std::shared_ptr<EffectInstance>
-VSTEffect::MakeInstance(EffectSettings &settings)
+VSTEffect::MakeInstance(EffectSettings &settings) const
+{
+   return const_cast<VSTEffect*>(this)->DoMakeInstance(settings);
+}
+
+std::shared_ptr<EffectInstance>
+VSTEffect::DoMakeInstance(EffectSettings &settings)
 {
    int userBlockSize;
    GetConfig(*this, PluginSettings::Shared, wxT("Options"),

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1340,7 +1340,7 @@ VSTEffect::MakeInstance(EffectSettings &settings)
    }
 
    LoadParameters(CurrentSettingsGroup(), settings);
-   return std::make_shared<Effect::Instance>(*this);
+   return std::make_shared<Instance>(*this);
 }
 
 unsigned VSTEffect::GetAudioInCount() const

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -289,20 +289,6 @@ public:
       return mAutomatable;
    }
 
-   bool SaveSettings(const EffectSettings &, CommandParameters &) const override
-      { return true; }
-   bool LoadSettings(const CommandParameters &, EffectSettings &) const override
-      { return true; }
-
-   bool LoadUserPreset(const RegistryPath &, EffectSettings &) const override
-      { return true; }
-   bool SaveUserPreset(const RegistryPath &, const EffectSettings &) const override
-      { return true; }
-
-   RegistryPaths GetFactoryPresets() const override { return {}; }
-   bool LoadFactoryPreset(int, EffectSettings &) const override { return true; }
-   bool LoadFactoryDefaults(EffectSettings &) const override { return true; }
-
 public:
    wxString mPath;
    wxString mName;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -177,7 +177,8 @@ class VSTEffect final
    // EffectUIClientInterface implementation
 
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
-      override;
+      const override;
+   std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -804,7 +804,7 @@ bool VST3Effect::RealtimeProcessStart(EffectSettings &)
    assert(mPendingChanges == nullptr);
 
    if(mComponentHandler != nullptr)
-      //Same parameter changes are used among all of the relatime processors
+      //Same parameter changes are used among all of the realtime processors
       mPendingChanges = mComponentHandler->getPendingChanges();
    return true;
 }

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -851,7 +851,7 @@ VST3Effect::MakeInstance(EffectSettings &settings)
    ReloadUserOptions();
    if(!LoadUserPreset(CurrentSettingsGroup(), settings))
       LoadFactoryDefaults(settings);
-   return std::make_shared<Effect::Instance>(*this);
+   return std::make_shared<Instance>(*this);
 }
 
 bool VST3Effect::IsGraphicalUI()

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -846,7 +846,13 @@ bool VST3Effect::InitializePlugin()
 }
    
 std::shared_ptr<EffectInstance>
-VST3Effect::MakeInstance(EffectSettings &settings)
+VST3Effect::MakeInstance(EffectSettings &settings) const
+{
+   return const_cast<VST3Effect*>(this)->DoMakeInstance(settings);
+}
+   
+std::shared_ptr<EffectInstance>
+VST3Effect::DoMakeInstance(EffectSettings &settings)
 {
    ReloadUserOptions();
    if(!LoadUserPreset(CurrentSettingsGroup(), settings))

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -147,7 +147,8 @@ public:
    int ShowClientInterface(wxWindow& parent, wxDialog& dialog, bool forceModal) override;
    bool InitializePlugin();
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
-      override;
+      const override;
+   std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    bool IsGraphicalUI() override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1039,7 +1039,13 @@ bool AudioUnitEffect::InitializePlugin()
 }
 
 std::shared_ptr<EffectInstance>
-AudioUnitEffect::MakeInstance(EffectSettings &settings)
+AudioUnitEffect::MakeInstance(EffectSettings &settings) const
+{
+   return const_cast<AudioUnitEffect*>(this)->DoMakeInstance(settings);
+}
+
+std::shared_ptr<EffectInstance>
+AudioUnitEffect::DoMakeInstance(EffectSettings &settings)
 {
    OSStatus result;
 
@@ -1911,7 +1917,7 @@ void AudioUnitEffect::ShowOptions()
 // ============================================================================
 
 bool AudioUnitEffect::LoadPreset(
-   const RegistryPath & group, EffectSettings &settings)
+   const RegistryPath & group, EffectSettings &settings) const
 {
    wxString parms;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1068,7 +1068,7 @@ AudioUnitEffect::MakeInstance(EffectSettings &settings)
       LoadPreset(CurrentSettingsGroup(), settings);
    }
 
-   return std::make_shared<Effect::Instance>(*this);
+   return std::make_shared<Instance>(*this);
 }
 
 bool AudioUnitEffect::MakeListener()

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -121,7 +121,8 @@ public:
    // EffectUIClientInterface implementation
 
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
-      override;
+      const override;
+   std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;
@@ -171,7 +172,7 @@ private:
 
    void GetChannelCounts();
 
-   bool LoadPreset(const RegistryPath & group, EffectSettings &settings);
+   bool LoadPreset(const RegistryPath & group, EffectSettings &settings) const;
    bool SavePreset(const RegistryPath & group) const;
 
 #if defined(HAVE_AUDIOUNIT_BASIC_SUPPORT)

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -879,7 +879,7 @@ LadspaEffect::MakeInstance(EffectSettings &settings)
    }
 
    LoadParameters(CurrentSettingsGroup(), settings);
-   return std::make_shared<Effect::Instance>(*this);
+   return std::make_shared<Instance>(*this);
 }
 
 unsigned LadspaEffect::GetAudioInCount() const

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -862,7 +862,13 @@ bool LadspaEffect::InitializePlugin()
 }
 
 std::shared_ptr<EffectInstance>
-LadspaEffect::MakeInstance(EffectSettings &settings)
+LadspaEffect::MakeInstance(EffectSettings &settings) const
+{
+   return const_cast<LadspaEffect *>(this)->MakeInstance(settings);
+}
+
+std::shared_ptr<EffectInstance>
+LadspaEffect::DoMakeInstance(EffectSettings &settings)
 {
    GetConfig(*this, PluginSettings::Shared, wxT("Options"),
       wxT("UseLatency"), mUseLatency, true);

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -120,7 +120,8 @@ public:
    // EffectUIClientInterface implementation
 
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
-      override;
+      const override;
+   std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -909,7 +909,13 @@ bool LV2Effect::InitializePlugin()
 }
 
 std::shared_ptr<EffectInstance>
-LV2Effect::MakeInstance(EffectSettings &settings)
+LV2Effect::MakeInstance(EffectSettings &settings) const
+{
+   return const_cast<LV2Effect*>(this)->DoMakeInstance(settings);
+}
+
+std::shared_ptr<EffectInstance>
+LV2Effect::DoMakeInstance(EffectSettings &settings)
 {
    int userBlockSize;
    GetConfig(*this, PluginSettings::Shared, wxT("Settings"),

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -937,7 +937,7 @@ LV2Effect::MakeInstance(EffectSettings &settings)
 
    lv2_atom_forge_init(&mForge, &mURIDMapFeature);
 
-   return std::make_shared<Effect::Instance>(*this);
+   return std::make_shared<Instance>(*this);
 }
 
 unsigned LV2Effect::GetAudioInCount() const

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -330,7 +330,8 @@ public:
    // EffectUIClientInterface implementation
 
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
-      override;
+      const override;
+   std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
       ShuttleGui &S, EffectSettingsAccess &access) override;
    bool IsGraphicalUI() override;


### PR DESCRIPTION
Resolves: #2754

All is in place for different occurrences of an effect in (the same, or different) effect stacks can have independent state.

But work remains to rewrite each subclass of effect so it is really stateless and really makes independent instances.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
