### PR TITLE
Make the "Warning" about saving project less alarming - issue:2588

### DIFF
--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -445,8 +445,9 @@ bool ProjectFileManager::SaveAs(bool allowOverwrite /* = false */)
    TranslatableString message = XO("\
 'Save Project' is for an Audacity project, not an audio file.\n\
 For an audio file that will open in other apps, use 'Export'.\n");
+   TranslatableString footer = XXO("Don't show this infomation again");
 
-   if (ShowWarningDialog(&window, wxT("FirstProjectSave"), message, true) != wxID_OK) {
+   if (ShowWarningDialog(&window, wxT("FirstProjectSave"), message, true, footer) != wxID_OK) {
       return false;
    }
 

--- a/src/widgets/Warning.cpp
+++ b/src/widgets/Warning.cpp
@@ -36,7 +36,8 @@ class WarningDialog final : public wxDialogWrapper
    WarningDialog(wxWindow *parent,
                  const TranslatableString &message,
                  const TranslatableString &footer,
-                 bool showCancelButton);
+                 bool showCancelButton,
+                 bool isInfoDlog = false);
 
  private:
    void OnOK(wxCommandEvent& event);
@@ -58,8 +59,10 @@ const TranslatableString &DefaultWarningFooter()
 
 WarningDialog::WarningDialog(wxWindow *parent, const TranslatableString &message,
                              const TranslatableString &footer,
-                             bool showCancelButton)
-:  wxDialogWrapper(parent, wxID_ANY, XO("Warning"),
+                             bool showCancelButton,
+                             bool isInfoDlog)
+:  wxDialogWrapper(parent, wxID_ANY, 
+            (isInfoDlog ? XO("Infomation") : XO("Warning")),
             wxDefaultPosition, wxDefaultSize,
             (showCancelButton ? wxDEFAULT_DIALOG_STYLE : wxCAPTION | wxSYSTEM_MENU)) // Unlike wxDEFAULT_DIALOG_STYLE, no wxCLOSE_BOX.
 {
@@ -100,7 +103,8 @@ int ShowWarningDialog(wxWindow *parent,
       return wxID_OK;
    }
 
-   WarningDialog dlog(parent, message, footer, showCancelButton);
+   bool isInfoDlog = internalDialogName == wxT("FirstProjectSave");
+   WarningDialog dlog(parent, message, footer, showCancelButton, isInfoDlog);
 
    int retCode = dlog.ShowModal();
    if (retCode == wxID_CANCEL)

--- a/src/widgets/Warning.cpp
+++ b/src/widgets/Warning.cpp
@@ -68,7 +68,7 @@ WarningDialog::WarningDialog(wxWindow *parent, const TranslatableString &message
 {
    SetName();
 
-   SetIcon(wxArtProvider::GetIcon(wxART_WARNING, wxART_MESSAGE_BOX));
+   SetIcon(wxArtProvider::GetIcon((isInfoDlog ? wxART_INFORMATION : wxART_WARNING), wxART_MESSAGE_BOX));
    ShuttleGui S(this, eIsCreating);
 
    S.SetBorder(10);


### PR DESCRIPTION
Resolves: #2588

Add boolean parameter to WarningDialog to check if the title should be "Information" or not.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
