### PR TITLE
Make echo stateless

### DIFF
--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -21,6 +21,9 @@
 
 
 #include "Echo.h"
+
+#if 0
+
 #include "LoadEffects.h"
 
 #include <wx/intl.h>
@@ -158,3 +161,5 @@ EffectEcho::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
    S.EndMultiColumn();
    return nullptr;
 }
+
+#endif

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -232,12 +232,25 @@ void EffectEcho::Validator::PopulateOrExchange(ShuttleGui& S, const EffectSettin
 }
 
 
-#if 0
-
-std::unique_ptr<EffectUIValidator>
-EffectEcho::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess&)
+// have do-nothing implementations for the time being
+bool EffectEcho::Validator::ValidateUI()
 {
-   // TODO later
+   return true;
 }
 
-#endif
+bool EffectEcho::Validator::UpdateUI()
+{
+   return true;
+}
+
+
+std::unique_ptr<EffectUIValidator>
+EffectEcho::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess& access)
+{
+   auto& settings = access.Get();
+   auto& myEffSettings = GetSettings(settings);
+   auto result = std::make_unique<Validator>(*this, access, myEffSettings);
+   result->PopulateOrExchange(S, settings, mProjectRate);
+   return result;   
+}
+

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -50,7 +50,7 @@ EffectEcho::MakeInstance(EffectSettings& settings) const
 }
 
 
-#if 0
+
 
 #include "LoadEffects.h"
 
@@ -75,7 +75,7 @@ namespace{ BuiltinEffectsModule::Registration< EffectEcho > reg; }
 
 EffectEcho::EffectEcho()
 {
-   Parameters().Reset(*this);
+   //Parameters().Reset(*this);
    SetLinearEffectFlag(true);
 }
 
@@ -116,6 +116,8 @@ unsigned EffectEcho::GetAudioOutCount() const
 {
    return 1;
 }
+
+#if 0
 
 bool EffectEcho::ProcessInitialize(
    EffectSettings &, sampleCount, ChannelNames)

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -188,27 +188,56 @@ size_t EffectEcho::Instance::ProcessBlock(EffectSettings& settings,
 }
 
 
-#if 0
 
-std::unique_ptr<EffectUIValidator>
-EffectEcho::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+struct EffectEcho::Validator
+   : DefaultEffectUIValidator
+{
+   Validator(EffectUIClientInterface& effect,
+      EffectSettingsAccess& access, const EffectEchoSettings& settings)
+      : DefaultEffectUIValidator{ effect, access }
+      // Copy settings
+      , mSettings{ settings }
+   {}
+   virtual ~Validator() = default;
+
+   Effect& GetEffect() const { return static_cast<Effect&>(mEffect); }
+
+   bool ValidateUI() override;
+   bool UpdateUI() override;
+   
+   void PopulateOrExchange(ShuttleGui& S,
+      const EffectSettings& settings, double projectRate);
+
+   EffectEchoSettings mSettings;
+};
+
+
+void EffectEcho::Validator::PopulateOrExchange(ShuttleGui& S, const EffectSettings& settings, double aRate)
 {
    S.AddSpace(0, 5);
 
    S.StartMultiColumn(2, wxALIGN_CENTER);
    {
       S.Validator<FloatingPointValidator<double>>(
-            3, &delay, NumValidatorStyle::NO_TRAILING_ZEROES,
+            3, &(mSettings.delay), NumValidatorStyle::NO_TRAILING_ZEROES,
             Delay.min, Delay.max )
          .AddTextBox(XXO("&Delay time (seconds):"), L"", 10);
 
       S.Validator<FloatingPointValidator<double>>(
-            3, &decay, NumValidatorStyle::NO_TRAILING_ZEROES,
+            3, &(mSettings.decay), NumValidatorStyle::NO_TRAILING_ZEROES,
             Decay.min, Decay.max)
          .AddTextBox(XXO("D&ecay factor:"), L"", 10);
    }
-   S.EndMultiColumn();
-   return nullptr;
+   S.EndMultiColumn();   
+}
+
+
+#if 0
+
+std::unique_ptr<EffectUIValidator>
+EffectEcho::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess&)
+{
+   // TODO later
 }
 
 #endif

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -166,11 +166,12 @@ bool EffectEcho::Instance::ProcessFinalize()
 }
 
 
-#if 0
 
-size_t EffectEcho::ProcessBlock(EffectSettings &,
+size_t EffectEcho::Instance::ProcessBlock(EffectSettings& settings,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
+   auto& echoSettings = GetSettings(settings);
+
    const float *ibuf = inBlock[0];
    float *obuf = outBlock[0];
 
@@ -180,11 +181,14 @@ size_t EffectEcho::ProcessBlock(EffectSettings &,
       {
          histPos = 0;
       }
-      history[histPos] = obuf[i] = ibuf[i] + history[histPos] * decay;
+      history[histPos] = obuf[i] = ibuf[i] + history[histPos] * echoSettings.decay;
    }
 
    return blockLen;
 }
+
+
+#if 0
 
 std::unique_ptr<EffectUIValidator>
 EffectEcho::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -232,14 +232,28 @@ void EffectEcho::Validator::PopulateOrExchange(ShuttleGui& S, const EffectSettin
 }
 
 
-// have do-nothing implementations for the time being
 bool EffectEcho::Validator::ValidateUI()
 {
+   mAccess.ModifySettings
+   (
+      [this](EffectSettings& settings)
+      {
+         // pass back the modified settings to the MessageBuffer
+         EffectEcho::GetSettings(settings) = mSettings;
+      }
+   );
+
    return true;
 }
 
+
+
 bool EffectEcho::Validator::UpdateUI()
 {
+   // get the settings from the MessageBuffer and write them to our local copy
+   const auto& settings = mAccess.Get();      
+   mSettings = GetSettings(settings);
+
    return true;
 }
 

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -22,6 +22,34 @@
 
 #include "Echo.h"
 
+
+struct EffectEcho::Instance
+   : public PerTrackEffect::Instance
+   , public EffectInstanceWithBlockSize
+{
+   Instance(const PerTrackEffect& effect)
+      : PerTrackEffect::Instance{ effect }
+   {}
+
+   void SetSampleRate(double rate) override { mSampleRate = rate; }
+
+   bool ProcessInitialize(EffectSettings& settings,
+      sampleCount totalLen, ChannelNames chanMap) override;
+
+   size_t ProcessBlock(EffectSettings& settings,
+      const float* const* inBlock, float* const* outBlock, size_t blockLen)  override;
+
+   double mSampleRate{};
+};
+
+
+std::shared_ptr<EffectInstance>
+EffectEcho::MakeInstance(EffectSettings& settings) const
+{
+   return std::make_shared<Instance>(*this);
+}
+
+
 #if 0
 
 #include "LoadEffects.h"

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -63,14 +63,7 @@ public:
    struct Validator;
 
 private:
-   // EffectEcho implementation
-
-   double delay;
-   double decay;
-   Floats history;
-   size_t histPos;
-   size_t histLen;
-
+   
    const EffectParameterMethods& Parameters() const override;
 
 

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -58,6 +58,11 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
 
+   std::shared_ptr<EffectInstance> MakeInstance(EffectSettings& settings) const override;
+
+   struct Instance;
+   struct Validator;
+
 private:
    // EffectEcho implementation
 

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -33,8 +33,7 @@ struct EffectEchoSettings
 class EffectEcho final : public EffectWithSettings<EffectEchoSettings, PerTrackEffect>
 {
 public:
-   static inline EffectEcho *
-   FetchParameters(EffectEcho &e, EffectSettings &) { return &e; }
+   
    static const ComponentInterfaceSymbol Symbol;
 
    EffectEcho();

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -20,7 +20,17 @@ class ShuttleGui;
 
 using Floats = ArrayOf<float>;
 
-class EffectEcho final : public StatefulPerTrackEffect
+struct EffectEchoSettings
+{
+   static constexpr double DefaultDelay = 1.0F;
+   static constexpr double DefaultDecay = 0.5F;
+
+   double delay{ DefaultDelay };
+   double decay{ DefaultDecay };
+};
+
+
+class EffectEcho final : public EffectWithSettings<EffectEchoSettings, PerTrackEffect>
 {
 public:
    static inline EffectEcho *
@@ -42,12 +52,7 @@ public:
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
-      sampleCount totalLen, ChannelNames chanMap) override;
-   bool ProcessFinalize() override;
-   size_t ProcessBlock(EffectSettings &settings,
-      const float *const *inBlock, float *const *outBlock, size_t blockLen)
-      override;
+   
 
    // Effect implementation
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
@@ -64,22 +69,10 @@ private:
 
    const EffectParameterMethods& Parameters() const override;
 
-#if 0
-   // TODO simplify like this in C++20
-   using ParametersType = CapturedParameters<EffectEcho,
-        EffectParameter{
-         &EffectEcho::delay, L"Delay",   1.0f, 0.001f,  FLT_MAX, 1.0f }
-      , EffectParameter{
-         &EffectEcho::decay, L"Decay",   0.5f, 0.0f,    FLT_MAX, 1.0f }
-   >;
-#else
 
-static constexpr EffectParameter Delay{ &EffectEcho::delay,
-   L"Delay",   1.0f, 0.001f,  FLT_MAX, 1.0f };
-static constexpr EffectParameter Decay{ &EffectEcho::decay,
-   L"Decay",   0.5f, 0.0f,    FLT_MAX, 1.0f };
+static constexpr EffectParameter Delay{ &EffectEchoSettings::delay, L"Delay", EffectEchoSettings::DefaultDelay, 0.001f,  FLT_MAX, 1.0f };
+static constexpr EffectParameter Decay{ &EffectEchoSettings::decay, L"Decay", EffectEchoSettings::DefaultDecay, 0.0f,    FLT_MAX, 1.0f };
 
-#endif
 };
 
 #endif // __AUDACITY_EFFECT_ECHO__


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2755

Step-by-step conversion of the existing Echo effect into a stateless effect.
The step numbers mentioned in the commit messages, refer to steps in a [guide I am writing](https://github.com/audacity/audacity/files/8441661/how.to.make.effects.stateless.txt)

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
NO - only the last commit preserves original behavior, the other commits will build, but the existing behavior is not preserved there.


