### PR TITLE
Don't link against lib-ffmpeg-support-interface when ffmpeg is disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1441,12 +1441,17 @@ set( AUDACITY_LIBRARIES
    lib-uuid-interface
    lib-screen-geometry-interface
    lib-project-rate-interface
-   lib-ffmpeg-support-interface
    lib-theme-resources-interface
    lib-transactions-interface
    lib-sample-track-interface
    lib-module-manager-interface
 )
+
+if (${_OPT}use_ffmpeg)
+   list( APPEND AUDACITY_LIBRARIES
+      lib-ffmpeg-support-interface
+   )
+endif()
 
 if ( ${_OPT}has_networking )
    list( APPEND AUDACITY_LIBRARIES


### PR DESCRIPTION
The lib-ffmpeg-support-interface can be disabled (in which case no library is created with that name). So we shouldn't try to link the application against that library when no ffmpeg support is included.

I found this by trying to compile the master branch with the option `-Daudacity_use_ffmpeg=off`.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
