### PR TITLE
fix bug #2092: new "Basic select at zero crossing" method

### DIFF
--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -103,6 +103,9 @@ void TracksBehaviorsPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(XXO("Advanced &vertical zooming"),
                     {wxT("/GUI/VerticalZooming"),
                      false});
+      S.TieCheckBox(XXO("Basic select at zero crossings"),
+                    {wxT("/GUI/BasicSelectZeroCrossings"),
+                     false});
 
       S.AddSpace(10);
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2092

New "Basic select at zero crossing" method, to be activated in Preferences, that works in any case, and modifies both ends of the selection to the nearest zero crossing

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
