### PR TITLE
Sets the sane timeout for the journaling tests

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityTesting.cmake
+++ b/cmake-proxies/cmake-modules/AudacityTesting.cmake
@@ -129,9 +129,10 @@ if( ${_OPT}has_tests )
       )
 
       set_tests_properties(
-         ${ADD_UNIT_TEST_NAME}
+         ${test_name}
          PROPERTIES
             LABELS "journal_tests"
+            TIMEOUT 180
       )
    endfunction()
 else()


### PR DESCRIPTION
Journal tests timeout is now set to 3 minutes, so the job does not run for several hours in case something goes wrong

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
