### PR TITLE
Fixes #2568: Correctly copy smart clips to correctly paste audio in new audacity project window

### DIFF
--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -85,6 +85,8 @@ WaveClip::WaveClip(const WaveClip& orig,
    // Copy only a range of the other WaveClip
 
    mSequenceOffset = orig.mSequenceOffset;
+   mTrimLeft = orig.mTrimLeft + (t0 > orig.GetPlayStartTime()? t0 - orig.GetPlayStartTime() : 0);
+   mTrimRight = orig.mTrimRight + (t1 < orig.GetPlayEndTime()? orig.GetPlayEndTime() - t1 : 0);
    
    mRate = orig.mRate;
    mColourIndex = orig.mColourIndex;
@@ -94,13 +96,9 @@ WaveClip::WaveClip(const WaveClip& orig,
    auto s0 = orig.TimeToSequenceSamples(t0);
    auto s1 = orig.TimeToSequenceSamples(t1);
 
-   mSequence = orig.mSequence->Copy(factory, s0, s1);
+   mSequence = std::make_unique<Sequence>(*orig.mSequence, factory);
 
-   mEnvelope = std::make_unique<Envelope>(
-      *orig.mEnvelope,
-      GetSequenceStartTime() + s0.as_double()/mRate,
-      GetSequenceStartTime() + s1.as_double()/mRate
-   );
+   mEnvelope = std::make_unique<Envelope>(*orig.mEnvelope);
 
    if ( copyCutlines )
       // Copy cutline clips that fall in the range


### PR DESCRIPTION
Resolves: #2568 

*(short description of the changes and the motivation to make the changes)*
## Motivation
> Considering that this can ruin a person's work after they have spent a lot of time and effort, and in addition to the many other "smart clip" bugs, I think that fixing smart clips needs to be treated with utmost priority, hence labelling as P1.

## Changes
### Current Behaviour
When parts of clips are selected and copied ( suppose there are 3 clips, and the selection starts from the middle of one clip, includes another clip, and finally ends in the middle of another clip), 2 new incorrect clips and 1 new correct clip are created. The correct clip is the one that is copied from the full clip (the second clip of the selection area). Other clips have the wrong `GetPlayStartTime()` and `GetPlayEndTime()` because the calculations are made assuming that those clips have the number of samples equal to the full original audio (`((numSamples + mAppendBufferLen).as_double()) / mRate `). Whereas, those incorrect clips ( 1st and 3rd clips of the copy ) contains samples only of the selected/copied area. So, in both the cases `GetPlayStartTime()` becomes negative, and then both the clips get adjusted to start from 0.

### Proposed  Behaviour
What my code does is, when a part of a clip is copied, the new clip contains all the samples as the original audio and also its mTrimLeft and mTrimRight are adjusted.
1. 
![audacity_smart_clips_resolved_copy](https://user-images.githubusercontent.com/59690052/163215793-1cc7569c-d7d8-4f47-8f4e-21e35c8cd52a.png)

2. 
![audacity_smart_clips_resolved](https://user-images.githubusercontent.com/59690052/163215845-bee4a70d-14c9-493b-9ea1-3fee04dfafeb.png)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
