### PR TITLE
Issue2822: Switching user presets for DTMF or Echo ...

### DIFF
--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -911,8 +911,8 @@ void EffectUIHost::OnUserPreset(wxCommandEvent & evt)
    mpAccess->ModifySettings([&](EffectSettings &settings){
       mEffectUIHost.GetDefinition()
          .LoadUserPreset(UserPresetsGroup(mUserPresets[preset]), settings);
-      TransferDataToWindow();
    });
+   TransferDataToWindow();
    return;
 }
 
@@ -921,8 +921,8 @@ void EffectUIHost::OnFactoryPreset(wxCommandEvent & evt)
    mpAccess->ModifySettings([&](EffectSettings &settings){
       mEffectUIHost.GetDefinition()
          .LoadFactoryPreset(evt.GetId() - kFactoryPresetsID, settings);
-      TransferDataToWindow();
    });
+   TransferDataToWindow();
    return;
 }
 
@@ -1029,8 +1029,8 @@ void EffectUIHost::OnImport(wxCommandEvent & WXUNUSED(evt))
 {
    mpAccess->ModifySettings([&](EffectSettings &settings){
       mClient.ImportPresets(settings);
-      TransferDataToWindow();
    });
+   TransferDataToWindow();
    LoadUserPresets();
 
    return;
@@ -1057,8 +1057,8 @@ void EffectUIHost::OnDefaults(wxCommandEvent & WXUNUSED(evt))
 {
    mpAccess->ModifySettings([&](EffectSettings &settings){
       mEffectUIHost.GetDefinition().LoadFactoryDefaults(settings);
-      TransferDataToWindow();
    });
+   TransferDataToWindow();
    return;
 }
 


### PR DESCRIPTION
... Not only that, but Factory Presets > Defaults, and Import under the
Manage menu had a problem, that is now fixed.

Problem was that TransferDataToWindow() did not see the modified settings.
Moving it out of the scope of the ModifySettings() call properly delays the
call after the reassignment of EffectSettings.

Resolves: #2822

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
