### PR TITLE
Implement Linear DB Scale

### DIFF
--- a/src/commands/SetTrackInfoCommand.cpp
+++ b/src/commands/SetTrackInfoCommand.cpp
@@ -287,7 +287,8 @@ static const EnumValueSymbol kColourStrings[nColours] =
 enum kScaleTypes
 {
    kLinear,
-   kDb,
+   kLogarithmic,
+   kLinearDb,
    nScaleTypes
 };
 
@@ -296,7 +297,8 @@ static const EnumValueSymbol kScaleTypeStrings[nScaleTypes] =
    // These are acceptable dual purpose internal/visible names
    { XO("Linear") },
    /* i18n-hint: abbreviates decibels */
-   { XO("dB") },
+   { XO("Logarithmic (dB)") },
+   { XO("Linear (dB)")}
 };
 
 enum kZoomTypes
@@ -422,11 +424,14 @@ bool SetTrackVisualsCommand::ApplyInner(const CommandContext & context, Track * 
          view.SetDisplay( WaveTrackSubViewType::Default(), false );
       }
    }
-   if( wt && bHasScaleType )
-      wt->GetWaveformSettings().scaleType = 
-         (mScaleType==kLinear) ? 
-            WaveformSettings::stLinear
-            : WaveformSettings::stLogarithmic;
+   if( wt && bHasScaleType ){
+      switch( mScaleType ){
+         default:
+         case kLinear: wt->GetWaveformSettings().scaleType = WaveformSettings::stLinear;
+         case kLogarithmic: wt->GetWaveformSettings().scaleType = WaveformSettings::stLogarithmic;
+         case kLinearDb: wt->GetWaveformSettings().scaleType = WaveformSettings::stLinearDb;
+      }
+   }
 
    if( wt && bHasVZoom ){
       switch( mVZoom ){

--- a/src/commands/SetTrackInfoCommand.cpp
+++ b/src/commands/SetTrackInfoCommand.cpp
@@ -288,7 +288,7 @@ enum kScaleTypes
 {
    kLinear,
    kLogarithmic,
-   kLinearDb,
+   kLinearDB,
    nScaleTypes
 };
 
@@ -429,7 +429,7 @@ bool SetTrackVisualsCommand::ApplyInner(const CommandContext & context, Track * 
          default:
          case kLinear: wt->GetWaveformSettings().scaleType = WaveformSettings::stLinear;
          case kLogarithmic: wt->GetWaveformSettings().scaleType = WaveformSettings::stLogarithmic;
-         case kLinearDb: wt->GetWaveformSettings().scaleType = WaveformSettings::stLinearDb;
+         case kLinearDB: wt->GetWaveformSettings().scaleType = WaveformSettings::stLinearDB;
       }
    }
 

--- a/src/prefs/TracksPrefs.cpp
+++ b/src/prefs/TracksPrefs.cpp
@@ -56,6 +56,7 @@ namespace {
 namespace {
    const auto waveformScaleKey = wxT("/GUI/DefaultWaveformScaleChoice");
    const auto dbValueString = wxT("dB");
+   const auto dbLinValueString = wxT("dBLin");
 }
 
 static EnumSetting< WaveformSettings::ScaleTypeValues > waveformScaleSetting{
@@ -63,6 +64,7 @@ static EnumSetting< WaveformSettings::ScaleTypeValues > waveformScaleSetting{
    {
       { XO("Linear") },
       { dbValueString, XO("Logarithmic (dB)") },
+      { dbLinValueString, XO("Linear (dB)") },
    },
 
    0, // linear
@@ -70,6 +72,7 @@ static EnumSetting< WaveformSettings::ScaleTypeValues > waveformScaleSetting{
    {
       WaveformSettings::stLinear,
       WaveformSettings::stLogarithmic,
+      WaveformSettings::stLinearDb
    }
 };
 

--- a/src/prefs/TracksPrefs.cpp
+++ b/src/prefs/TracksPrefs.cpp
@@ -72,7 +72,7 @@ static EnumSetting< WaveformSettings::ScaleTypeValues > waveformScaleSetting{
    {
       WaveformSettings::stLinear,
       WaveformSettings::stLogarithmic,
-      WaveformSettings::stLinearDb
+      WaveformSettings::stLinearDB
    }
 };
 

--- a/src/prefs/WaveformSettings.cpp
+++ b/src/prefs/WaveformSettings.cpp
@@ -164,7 +164,8 @@ const EnumValueSymbols &WaveformSettings::GetScaleNames()
    static const EnumValueSymbols result{
       // Keep in correspondence with ScaleTypeValues:
       XO("Linear"),
-      XO("dB"),
+      XO("dB (Logarithmic)"),
+      XO("dB (Linear)"),
    };
    return result;
 }

--- a/src/prefs/WaveformSettings.h
+++ b/src/prefs/WaveformSettings.h
@@ -58,6 +58,7 @@ public:
    enum ScaleTypeValues : int {
       stLinear,
       stLogarithmic,
+      stLinearDb,
 
       stNumScaleTypes,
    };
@@ -68,6 +69,6 @@ public:
    int dBRange;
 
    // Convenience
-   bool isLinear() const { return stLinear == scaleType; }
+   bool isLinear() const { return stLogarithmic != scaleType; }
 };
 #endif

--- a/src/prefs/WaveformSettings.h
+++ b/src/prefs/WaveformSettings.h
@@ -58,7 +58,7 @@ public:
    enum ScaleTypeValues : int {
       stLinear,
       stLogarithmic,
-      stLinearDb,
+      stLinearDB,
 
       stNumScaleTypes,
    };

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVRulerControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVRulerControls.cpp
@@ -219,11 +219,18 @@ void WaveformVRulerControls::DoUpdateVRuler(
       vruler->SetBounds(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height - 1);
       vruler->SetOrientation(wxVERTICAL);
       vruler->SetRange(max, min);
-      // TODO: Create Ruler for Linear (dB) and set it here
       vruler->SetFormat(Ruler::RealFormat);
       vruler->SetUnits({});
       vruler->SetLabelEdges(false);
       vruler->SetLog(false);
+      if (scaleType == WaveformSettings::stLinearDB)
+      {
+         vruler->SetLinearDB(true);
+      }
+      else
+      {
+         vruler->SetLinearDB(false);
+      }
    }
    else {
       wxASSERT(scaleType == WaveformSettings::stLogarithmic);
@@ -332,6 +339,7 @@ void WaveformVRulerControls::DoUpdateVRuler(
       vruler->SetFormat(Ruler::RealLogFormat);
       vruler->SetLabelEdges(true);
       vruler->SetLog(false);
+      vruler->SetLinearDB(false);
    }
    vruler->GetMaxSize( &wt->vrulerSize.first, &wt->vrulerSize.second );
 }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVRulerControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVRulerControls.cpp
@@ -186,12 +186,12 @@ void WaveformVRulerControls::DoUpdateVRuler(
    WaveformSettings::ScaleType scaleType =
    wt->GetWaveformSettings().scaleType;
    
-   if (scaleType == WaveformSettings::stLinear) {
+   if (wt->GetWaveformSettings().isLinear()) {
       // Waveform
       
       float min, max;
       wt->GetDisplayBounds(&min, &max);
-      if (wt->GetLastScaleType() != scaleType &&
+      if (wt->GetLastScaleType() == WaveformSettings::stLogarithmic &&
           wt->GetLastScaleType() != -1)
       {
          // do a translation into the linear space
@@ -219,6 +219,7 @@ void WaveformVRulerControls::DoUpdateVRuler(
       vruler->SetBounds(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height - 1);
       vruler->SetOrientation(wxVERTICAL);
       vruler->SetRange(max, min);
+      // TODO: Create Ruler for Linear (dB) and set it here
       vruler->SetFormat(Ruler::RealFormat);
       vruler->SetUnits({});
       vruler->SetLabelEdges(false);
@@ -234,7 +235,7 @@ void WaveformVRulerControls::DoUpdateVRuler(
       wt->GetDisplayBounds(&min, &max);
       float lastdBRange;
       
-      if (wt->GetLastScaleType() != scaleType &&
+      if (wt->GetLastScaleType() != WaveformSettings::stLogarithmic &&
           wt->GetLastScaleType() != -1)
       {
          // do a translation into the dB space

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -1001,6 +1001,8 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context,
    highlight = target && target->GetTrack().get() == track;
 #endif
 
+   // TODO: Change name of variable from "dB" to "log"
+   // in all instances where appropriate to accurately express intent
    const bool dB = !track->GetWaveformSettings().isLinear();
 
    const auto &blankSelectedBrush = artist->blankSelectedBrush;

--- a/src/widgets/Ruler.cpp
+++ b/src/widgets/Ruler.cpp
@@ -86,6 +86,7 @@ Ruler::Ruler()
    mFormat = RealFormat;
    mFlip = false;
    mLog = false;
+   mLinearDB = false;
    mLabelEdges = false;
 
    mLeft = -1;
@@ -145,6 +146,17 @@ void Ruler::SetLog(bool log)
 
    if (mLog != log) {
       mLog = log;
+
+      Invalidate();
+   }
+}
+
+void Ruler::SetLinearDB(bool linDB)
+{
+   // Linear DB scale
+
+   if (mLinearDB != linDB) {
+      mLinearDB = linDB;
 
       Invalidate();
    }
@@ -872,6 +884,7 @@ struct Ruler::Updater {
    const bool mCustom = mRuler.mCustom;
    const Fonts &mFonts = *mRuler.mpFonts;
    const bool mLog = mRuler.mLog;
+   const bool mLinearDB = mRuler.mLinearDB;
    const double mHiddenMin = mRuler.mHiddenMin;
    const double mHiddenMax = mRuler.mHiddenMax;
    const bool mLabelEdges = mRuler.mLabelEdges;
@@ -936,6 +949,10 @@ bool Ruler::Updater::Tick( wxDC &dc,
    // But we shouldn't have an array of labels.
    if( outputs.labels.size() >= mLength )
       return false;
+      
+   if (mLinearDB){
+      d = LINEAR_TO_DB(fabs(d));
+   }
 
    Label lab;
    lab.value = d;

--- a/src/widgets/Ruler.cpp
+++ b/src/widgets/Ruler.cpp
@@ -907,7 +907,7 @@ struct Ruler::Updater {
    void UpdateCustom( wxDC &dc, UpdateOutputs &allOutputs ) const;
    void UpdateLinear(
       wxDC &dc, const Envelope *envelope, UpdateOutputs &allOutputs ) const;
-   void UpdateNonlinear( wxDC &dc, UpdateOutputs &allOutputs ) const;
+   void UpdateLogarithmic( wxDC &dc, UpdateOutputs &allOutputs ) const;
 };
 
 struct Ruler::Cache {
@@ -1210,7 +1210,7 @@ void Ruler::Updater::UpdateLinear(
    }
 }
 
-void Ruler::Updater::UpdateNonlinear(
+void Ruler::Updater::UpdateLogarithmic(
     wxDC &dc, UpdateOutputs &allOutputs ) const
 {
    TickOutputs majorOutputs{
@@ -1310,10 +1310,10 @@ void Ruler::Updater::Update(
 
    if ( mCustom )
       UpdateCustom( dc, allOutputs );
-   else if ( !mLog )
-      UpdateLinear( dc, envelope, allOutputs );
+   else if ( mLog )
+      UpdateLogarithmic( dc, allOutputs );
    else
-      UpdateNonlinear( dc, allOutputs );
+      UpdateLinear( dc, envelope, allOutputs );
 
    int displacementx=0, displacementy=0;
    auto &box = allOutputs.box;

--- a/src/widgets/Ruler.h
+++ b/src/widgets/Ruler.h
@@ -80,6 +80,9 @@ class AUDACITY_DLL_API Ruler {
    // Logarithmic
    void SetLog(bool log);
 
+   // Linear DB scale
+   void SetLinearDB(bool linDB);
+
    // Minimum number of pixels between labels
    void SetSpacing(int spacing);
 
@@ -214,6 +217,7 @@ private:
    bool         mLabelEdges;
    RulerFormat  mFormat;
    bool         mLog;
+   bool         mLinearDB;
    bool         mFlip;
    bool         mCustom;
    bool         mbMinor;


### PR DESCRIPTION
Resolves: #2683

Creates a third scale for the waveform ruler, which measures in decibels referencing the linear scale. This scale can be selected in either the context menu or preferences menu. By doing this, users will be able to view their waveforms in decibels without distorting them through the logarithmic dB scale. 

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
