### PR TITLE
Stateless audio unit effects

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -580,6 +580,8 @@ public:
    //! Adds controls to a panel that is given as the parent window of `S`
    /*!
     @param S interface for adding controls to a panel in a dialog
+    @param instance guaranteed to have a lifetime containing that of the returned
+    object
     @param access guaranteed to have a lifetime containing that of the returned
     object
 
@@ -587,8 +589,8 @@ public:
     controls; it might also hold some state needed to implement event handlers
     of the controls; it will exist only while the dialog continues to exist
     */
-   virtual std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) = 0;
+   virtual std::unique_ptr<EffectUIValidator> PopulateUI(ShuttleGui &S,
+      EffectInstance &instance, EffectSettingsAccess &access) = 0;
 
    virtual bool CanExportPresets() = 0;
    virtual void ExportPresets(const EffectSettings &settings) const = 0;

--- a/libraries/lib-utility/CMakeLists.txt
+++ b/libraries/lib-utility/CMakeLists.txt
@@ -29,6 +29,7 @@ set( SOURCES
    MemoryStream.h
    Observer.cpp
    Observer.h
+   PackedArray.h
    spinlock.h
    TypedAny.h
 )

--- a/libraries/lib-utility/PackedArray.h
+++ b/libraries/lib-utility/PackedArray.h
@@ -1,0 +1,182 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file PackedArray.h
+
+ @brief Deleter for a header contiguous with an array holding a
+ dynamically determined number of elements
+
+ Paul Licameli
+
+ **********************************************************************/
+
+#ifndef __AUDACITY_PACKED_ARRAY__
+#define __AUDACITY_PACKED_ARRAY__
+
+#include <type_traits>
+
+//! Primary template used in PackedArrayDeleter that can be specialized
+template<typename T> struct PackedArrayTraits{
+   // Default assumption is that there is no header and no need to overlay
+   // the element with a type that performs nontrivial destruction
+   struct header_type {};
+   using element_type = T;
+   using iterated_type = T;
+};
+
+//! Deleter for a header structure contiguous with an array of elements
+/*!
+ @tparam Type is the type pointed to, and any explicit specialization of
+ PackedArrayTraits<Type> is expected to define nested member types:
+  - header_type, which overlays the members of Type except the last member;
+   may define a destructor
+  - element_type, such that the last member of Type is Element[1]; may
+    define a destructor
+ @tparam BaseDeleter manages the main deallocation
+ */
+template<typename Type,
+   template<typename> typename BaseDeleter = std::default_delete>
+struct PackedArrayDeleter : BaseDeleter<Type> {
+   using managed_type = Type;
+   using base_type = BaseDeleter<managed_type>;
+   using traits_type = PackedArrayTraits<managed_type>;
+   using header_type = typename traits_type::header_type;
+   using element_type = typename traits_type::element_type;
+
+   // Check our assumptions about alignments
+   // Imitation of the layout of the managed type.  Be sure to use
+   // empty base class optimization in case header_type is zero-sized.
+   struct Overlay : header_type { element_type elements[1]; };
+   static_assert(sizeof(Overlay) == sizeof(managed_type));
+   // Another sanity check.  Note sizeof() an empty type is nonzero
+   static_assert(offsetof(Overlay, elements) ==
+      std::is_empty_v<header_type> ? 0 : sizeof(header_type));
+
+   //! Nontrivial, implicit constructor of the deleter takes a size, which
+   //! defaults to 0 to allow default contruction of the unique_ptr
+   PackedArrayDeleter(size_t size = 0) noexcept
+      : mCount{ (size - sizeof(header_type)) / sizeof(element_type) } {}
+
+   void operator()(Type *p) const noexcept(noexcept(
+      (void)std::declval<element_type>().~element_type(),
+      (void)std::declval<header_type>().~header_type(),
+      (void)std::declval<base_type>()(p)
+   )) {
+      if (!p)
+         return;
+      auto pOverlay = reinterpret_cast<Overlay*>(p);
+      auto pE = pOverlay->elements + mCount;
+      for (auto count = mCount; count--;)
+         // Do nested deallocations for elements by decreasing subscript
+         (--pE)->~element_type();
+      // Do nested deallocations for main structure
+      pOverlay->~header_type();
+      // main deallocation
+      ((base_type&)*this)(p);
+   }
+
+   size_t GetCount() const { return mCount; }
+private:
+   size_t mCount = 0;
+};
+
+//! Smart pointer type that deallocates with PackedArrayDeleter
+template<typename Type,
+   template<typename> typename BaseDeleter = std::default_delete>
+struct PackedArrayPtr
+   : std::unique_ptr<Type, PackedArrayDeleter<Type, BaseDeleter>>
+{
+   using
+      std::unique_ptr<Type, PackedArrayDeleter<Type, BaseDeleter>>::unique_ptr;
+
+   //! Enables subscripting, if PackedArrayTraits<Type>::iterated_type is
+   //! defined.  Does not check for null!
+   auto &operator[](size_t ii) const
+   {
+      return *(begin(*this) + ii);
+   }
+};
+
+//! Find out how many elements were allocated with a PackedArrayPtr
+template<typename Type, template<typename> typename BaseDeleter>
+inline size_t PackedArrayCount(const PackedArrayPtr<Type, BaseDeleter> &p)
+{
+   return p.get_deleter().GetCount();
+}
+
+//! Enables range-for, if PackedArrayTraits<Type>::iterated_type is defined
+template<typename Type, template<typename> typename BaseDeleter>
+inline auto begin(const PackedArrayPtr<Type, BaseDeleter> &p)
+{
+   void *ptr = p.get();
+   using header_type = typename PackedArrayTraits<Type>::header_type;
+   return reinterpret_cast<typename PackedArrayTraits<Type>::iterated_type *>(
+      ptr
+         ? static_cast<char*>(ptr) +
+            (std::is_empty_v<header_type> ? 0 : sizeof(header_type))
+         : nullptr
+   );
+}
+
+//! Enables range-for, if PackedArrayTraits<Type>::iterated_type is defined
+template<typename Type, template<typename> typename BaseDeleter>
+inline auto end(const PackedArrayPtr<Type, BaseDeleter> &p)
+{
+   auto result = begin(p);
+   if (result)
+      result += PackedArrayCount(p);
+   return result;
+}
+
+struct PackedArray_t{};
+//! Tag argument to distinguish an overload of ::operator new
+static constexpr inline PackedArray_t PackedArray;
+
+//! Allocator for objects managed by PackedArrayPtr enlarges the size request
+//! that the compiler makes
+inline void *operator new(size_t size, PackedArray_t, size_t enlarged) {
+   return ::operator new(std::max(size, enlarged));
+}
+
+//! Complementary operator delete in case of exceptions in a new-expression
+inline void operator delete(void *p, PackedArray_t, size_t) {
+   ::operator delete(p);
+}
+
+//! Allocate a PackedArrayPtr<Type> holding at least `enlarged` bytes
+/*!
+ Usage: PackedArrayAllocateBytes<Type>(bytes)(constructor arguments for Type)
+ Meant to resemble placement-new syntax with separation of allocator and
+ constructor arguments
+ */
+template<typename Type>
+auto PackedArrayAllocateBytes(size_t enlarged)
+{
+   return [enlarged](auto &&...args) {
+      return PackedArrayPtr<Type>{
+         safenew(PackedArray, enlarged)
+            Type{ std::forward<decltype(args)>(args)... },
+         std::max(sizeof(Type), enlarged) // Deleter's constructor argument
+      };
+   };
+}
+
+//! Allocate a PackedArrayPtr<Type> holding `count` elements
+/*!
+ Usage: PackedArrayAllocateCount<Type>(count)(constructor arguments for Type)
+ Meant to resemble placement-new syntax with separation of allocator and
+ constructor arguments
+
+ If PackedArrayTraits<Type> is explicitly specialized, the result always holds
+ at least one element
+ */
+template<typename Type> auto PackedArrayAllocateCount(size_t count)
+{
+   using header_type = typename PackedArrayTraits<Type>::header_type;
+   size_t bytes = (std::is_empty_v<header_type> ? 0 : sizeof(header_type))
+      + count * sizeof(typename PackedArrayTraits<Type>::element_type);
+   return PackedArrayAllocateBytes<Type>(bytes);
+}
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -567,6 +567,8 @@ list( APPEND SOURCES
          effects/audiounits/AUControl.mm
          effects/audiounits/AudioUnitEffect.cpp
          effects/audiounits/AudioUnitEffect.h
+         effects/audiounits/AudioUnitUtils.cpp
+         effects/audiounits/AudioUnitUtils.h
       >
 
       # Ladspa Effects

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -22,6 +22,7 @@ class EffectSettingsManager;
 class wxDialog;
 class wxWindow;
 class EffectUIClientInterface;
+class EffectInstance;
 class EffectSettings;
 class EffectSettingsAccess;
 class EffectPlugin;
@@ -30,7 +31,7 @@ class EffectPlugin;
 /*! The dialog may be modal or non-modal */
 using EffectDialogFactory = std::function< wxDialog* (
    wxWindow &parent, EffectPlugin &, EffectUIClientInterface &,
-   EffectSettingsAccess & ) >;
+   EffectInstance &, EffectSettingsAccess & ) >;
 
 class TrackList;
 class WaveTrackFactory;
@@ -61,6 +62,9 @@ public:
    /*!
     But there are a few unusual overrides for historical reasons
 
+    @param instance is only guaranteed to have lifetime suitable for a modal
+    dialog, unless the dialog stores instance.shared_from_this()
+
     @param access is only guaranteed to have lifetime suitable for a modal
     dialog, unless the dialog stores access.shared_from_this()
 
@@ -69,8 +73,8 @@ public:
     */
    virtual int ShowHostInterface(
       wxWindow &parent, const EffectDialogFactory &factory,
-      EffectSettingsAccess &access, bool forceModal = false
-   ) = 0;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      bool forceModal = false) = 0;
 
    virtual void Preview(EffectSettingsAccess &access, bool dryOnly) = 0;
    virtual bool SaveSettingsAsString(

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -205,8 +205,8 @@ void EffectAmplify::Preview(EffectSettingsAccess &access, bool dryOnly)
    Effect::Preview(access, dryOnly);
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectAmplify::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectAmplify::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    enum{ precision = 3 }; // allow (a generous) 3 decimal  places for Amplification (dB)
 

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -57,7 +57,8 @@ public:
    bool Init() override;
    void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -330,8 +330,8 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
    return !cancel;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectAutoDuck::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectAutoDuck::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.StartVerticalLay(true);

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -47,7 +47,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool DoTransferDataToWindow();
 

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -177,8 +177,8 @@ bool EffectBassTreble::CheckWhetherSkipEffect(const EffectSettings &) const
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectBassTreble::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectBassTreble::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -73,7 +73,8 @@ public:
    // Effect Implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -231,8 +231,8 @@ bool EffectChangePitch::CheckWhetherSkipEffect(const EffectSettings &) const
    return (m_dPercentChange == 0.0);
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectChangePitch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectChangePitch::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    DeduceFrequencies(); // Set frequency-related control values based on sample.
 

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -60,7 +60,8 @@ public:
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -237,8 +237,8 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectChangeSpeed::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectChangeSpeed::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    {
       wxString formatId;

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -50,7 +50,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -194,8 +194,8 @@ bool EffectChangeTempo::Process(EffectInstance &, EffectSettings &settings)
    return success;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectChangeTempo::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectChangeTempo::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    enum { precision = 2 };
 

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -58,7 +58,8 @@ public:
    double CalcPreviewInputLength(
       const EffectSettings &settings, double previewLength) const override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -273,8 +273,8 @@ bool EffectClickRemoval::RemoveClicks(size_t len, float *buffer)
    return bResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectClickRemoval::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectClickRemoval::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
    S.SetBorder(10);

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -49,7 +49,8 @@ public:
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
 private:
    bool ProcessOne(int count, WaveTrack * track,

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -156,8 +156,8 @@ TranslatableString RatioLabelFormat( int sliderValue, double value )
 
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectCompressor::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectCompressor::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -49,7 +49,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool DoTransferDataFromWindow();
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -282,8 +282,8 @@ bool EffectDistortion::DoLoadFactoryPreset(int id)
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectDistortion::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectDistortion::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
    S.StartVerticalLay();

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -98,7 +98,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -405,8 +405,8 @@ void EffectDtmf::Validator::PopulateOrExchange(ShuttleGui & S,
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectDtmf::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    auto &settings = access.Get();
    auto &dtmfSettings = GetSettings(settings);

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -62,7 +62,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
    struct Instance;
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -199,8 +199,8 @@ struct EffectEcho::Validator
 
 
 
-std::unique_ptr<EffectUIValidator>
-EffectEcho::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess& access)
+std::unique_ptr<EffectUIValidator> EffectEcho::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    auto& settings = access.Get();
    auto& myEffSettings = GetSettings(settings);

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -54,7 +54,8 @@ public:
 
    // Effect implementation
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
    struct Validator;
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -174,7 +174,8 @@ int Effect::ShowClientInterface(
 }
 
 int Effect::ShowHostInterface(wxWindow &parent,
-   const EffectDialogFactory &factory, EffectSettingsAccess &access,
+   const EffectDialogFactory &factory,
+   EffectInstance &instance, EffectSettingsAccess &access,
    bool forceModal)
 {
    if (!IsInteractive())
@@ -197,7 +198,7 @@ int Effect::ShowHostInterface(wxWindow &parent,
    // populate it.  That factory function is called indirectly through a
    // std::function to avoid source code dependency cycles.
    EffectUIClientInterface *const client = this;
-   mHostUIDialog = factory(parent, *this, *client, access);
+   mHostUIDialog = factory(parent, *this, *client, instance, access);
    if (!mHostUIDialog)
       return 0;
 
@@ -284,8 +285,8 @@ bool Effect::LoadFactoryDefaults(EffectSettings &settings) const
 
 // EffectUIClientInterface implementation
 
-std::unique_ptr<EffectUIValidator>
-Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> Effect::PopulateUI(ShuttleGui &S,
+   EffectInstance &instance, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mUIParent = parent;
@@ -293,7 +294,7 @@ Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
 //   LoadUserPreset(CurrentSettingsGroup());
 
    // Let the effect subclass provide its own validator if it wants
-   auto result = PopulateOrExchange(S, access);
+   auto result = PopulateOrExchange(S, instance, access);
 
    mUIParent->SetMinSize(mUIParent->GetSizer()->GetMinSize());
 
@@ -594,8 +595,8 @@ bool Effect::Delegate(Effect &delegate, EffectSettings &settings)
       region, mUIFlags, nullptr, nullptr, nullptr);
 }
 
-std::unique_ptr<EffectUIValidator>
-Effect::PopulateOrExchange(ShuttleGui &, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> Effect::PopulateOrExchange(
+   ShuttleGui &, EffectInstance &, EffectSettingsAccess &)
 {
    return nullptr;
 }

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -213,7 +213,8 @@ class AUDACITY_DLL_API Effect /* not final */
    // EffectUIClientInterface implementation
 
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
@@ -233,7 +234,8 @@ class AUDACITY_DLL_API Effect /* not final */
    // EffectPlugin implementation
 
    int ShowHostInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, EffectSettingsAccess &access,
+      const EffectDialogFactory &factory,
+      EffectInstance &instance, EffectSettingsAccess &access,
       bool forceModal = false) override;
    bool SaveSettingsAsString(
       const EffectSettings &settings, wxString & parms) const override;
@@ -280,7 +282,7 @@ class AUDACITY_DLL_API Effect /* not final */
     DefaultEffectUIValidator; default implementation returns null
     */
    virtual std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access);
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access);
 
    // No more virtuals!
 

--- a/src/effects/EffectBase.cpp
+++ b/src/effects/EffectBase.cpp
@@ -168,7 +168,7 @@ bool EffectBase::DoEffect(EffectSettings &settings, double projectRate,
    if ( pParent && dialogFactory && pAccess &&
       IsInteractive()) {
       if (!ShowHostInterface(
-         *pParent, dialogFactory, *pAccess, IsBatchProcessing() ) )
+         *pParent, dialogFactory, *pInstance, *pAccess, IsBatchProcessing() ) )
          return false;
       else
          // Retrieve again after the dialog modified settings

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -332,6 +332,7 @@ bool EffectManager::PromptUser(
       if (pSettings)
          result = effect->ShowHostInterface(
             parent, factory,
+            *effect->MakeInstance(*pSettings), // short-lived object
             *std::make_shared<SimpleEffectSettingsAccess>(*pSettings),
             effect->IsBatchProcessing() ) != 0;
       return result;

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -43,10 +43,11 @@ class EffectUIHost final : public wxDialogWrapper
 public:
    // constructors and destructors
    EffectUIHost(wxWindow *parent,
-                AudacityProject &project,
-                EffectPlugin &effect,
-                EffectUIClientInterface &client,
-                EffectSettingsAccess &access);
+       AudacityProject &project,
+       EffectPlugin &effect,
+       EffectUIClientInterface &client,
+       EffectInstance &instance,
+       EffectSettingsAccess &access);
    virtual ~EffectUIHost();
 
    bool TransferDataToWindow() override;
@@ -98,6 +99,8 @@ private:
    wxWindow *mParent;
    EffectPlugin &mEffectUIHost;
    EffectUIClientInterface &mClient;
+   //! @invariant not null
+   const std::shared_ptr<EffectInstance> mpInstance;
    //! @invariant not null
    const EffectPlugin::EffectSettingsAccessPtr mpAccess;
    RealtimeEffectState *mpState{ nullptr };
@@ -151,7 +154,8 @@ namespace  EffectUI {
 
    AUDACITY_DLL_API
    wxDialog *DialogFactory( wxWindow &parent, EffectPlugin &host,
-      EffectUIClientInterface &client, EffectSettingsAccess &access);
+      EffectUIClientInterface &client, EffectInstance &instance,
+      EffectSettingsAccess &access);
 
    /** Run an effect given the plugin ID */
    // Returns true on success.  Will only operate on tracks that

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -677,9 +677,8 @@ bool EffectEqualization::CloseUI()
    return Effect::CloseUI();
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectEqualization::PopulateOrExchange(
-   ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectEqualization::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    if ( (S.GetMode() == eIsCreating ) && !IsBatchProcessing() )
       access.ModifySettings([&](EffectSettings &settings){

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -137,7 +137,8 @@ public:
 
    bool CloseUI() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -214,9 +214,8 @@ bool EffectFindClipping::ProcessOne(LabelTrack * lt,
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectFindClipping::PopulateOrExchange(
-   ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectFindClipping::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    DoPopulateOrExchange(S, access);
    return nullptr;

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -43,7 +43,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    void DoPopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access);
    bool TransferDataToWindow(const EffectSettings &settings) override;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -212,8 +212,8 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectLoudness::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectLoudness::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.StartVerticalLay(0);
    {

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -59,7 +59,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -169,8 +169,8 @@ size_t EffectNoise::ProcessBlock(EffectSettings &,
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectNoise::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    wxASSERT(nTypes == WXSIZEOF(kTypeStrings));
 

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -47,7 +47,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -445,7 +445,7 @@ EffectType EffectNoiseReduction::GetType() const
  the framework for managing settings of other effects. */
 int EffectNoiseReduction::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &,
-   EffectSettingsAccess &access,
+   EffectInstance &, EffectSettingsAccess &access,
    bool forceModal)
 {
    // to do: use forceModal correctly

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -39,7 +39,8 @@ public:
 
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectSettingsAccess &access, bool forceModal = false) override;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      bool forceModal = false) override;
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
 

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -161,7 +161,7 @@ bool EffectNoiseRemoval::CheckWhetherSkipEffect(const EffectSettings &) const
  the framework for managing settings of other effects. */
 int EffectNoiseRemoval::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &,
-   EffectSettingsAccess &access,
+   EffectInstance &, EffectSettingsAccess &access,
    bool forceModal )
 {
    // to do: use forceModal correctly

--- a/src/effects/NoiseRemoval.h
+++ b/src/effects/NoiseRemoval.h
@@ -55,7 +55,8 @@ public:
 
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectSettingsAccess &access, bool forceModal = false) override;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      bool forceModal = false) override;
    bool Init() override;
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -211,8 +211,8 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectNormalize::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectNormalize::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    mCreating = true;
 

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -46,7 +46,8 @@ public:
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -170,8 +170,8 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
 }
 
 
-std::unique_ptr<EffectUIValidator>
-EffectPaulstretch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectPaulstretch::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.StartMultiColumn(2, wxALIGN_CENTER);
    {

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -42,7 +42,8 @@ public:
       const EffectSettings &settings, double previewLength) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
 private:
    // EffectPaulstretch implementation

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -191,8 +191,8 @@ size_t EffectPhaser::RealtimeProcess(int group, EffectSettings &settings,
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectPhaser::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectPhaser::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -79,7 +79,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -155,8 +155,8 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectRepeat::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectRepeat::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.StartHorizontalLay(wxCENTER, false);
    {

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -43,7 +43,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -294,8 +294,8 @@ bool EffectReverb::DoLoadFactoryPreset(int id)
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectReverb::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectReverb::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
 

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -72,7 +72,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -259,8 +259,8 @@ bool EffectScienFilter::Init()
    return true;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectScienFilter::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectScienFilter::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.AddSpace(5);
    S.SetSizerProportion(1);

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -64,7 +64,8 @@ public:
 
    bool Init() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -65,8 +65,8 @@ EffectType EffectSilence::GetType() const
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectSilence::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    S.StartVerticalLay();
    {

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -38,7 +38,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -149,8 +149,8 @@ bool EffectTimeScale::Process(
    return EffectSBSMS::Process(instance, settings);
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectTimeScale::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectTimeScale::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -47,7 +47,8 @@ public:
    void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    double CalcPreviewInputLength(
       const EffectSettings &settings, double previewLength) const override;

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -270,8 +270,8 @@ void EffectToneGen::PostSet()
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectToneGen::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    wxTextCtrl *t;
 

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -48,7 +48,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -662,8 +662,8 @@ bool EffectTruncSilence::Analyze(RegionList& silenceList,
 }
 
 
-std::unique_ptr<EffectUIValidator>
-EffectTruncSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectTruncSilence::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    wxASSERT(nActions == WXSIZEOF(kActionStrings));
 

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -68,7 +68,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1726,8 +1726,8 @@ bool VSTEffect::DoLoadFactoryDefaults(EffectSettings &settings)
 // EffectUIClientInterface implementation
 // ============================================================================
 
-std::unique_ptr<EffectUIValidator>
-VSTEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> VSTEffect::PopulateUI(ShuttleGui &S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mDialog = static_cast<wxDialog *>(wxGetTopLevelParent(parent));

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -178,7 +178,8 @@ class VSTEffect final
       const override;
    std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -858,8 +858,8 @@ bool VST3Effect::IsGraphicalUI()
    return mPlugView != nullptr;
 }
 
-std::unique_ptr<EffectUIValidator>
-VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> VST3Effect::PopulateUI(ShuttleGui& S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    using namespace Steinberg;
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -150,7 +150,8 @@ public:
    std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    bool IsGraphicalUI() override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
    bool CanExportPresets() override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -276,8 +276,8 @@ size_t EffectWahwah::Instance::RealtimeProcess(int group, EffectSettings &settin
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectWahwah::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess& access)
+std::unique_ptr<EffectUIValidator> EffectWahwah::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    auto& settings = access.Get();
    auto& myEffSettings = GetSettings(settings);

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -93,7 +93,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
    struct Validator;
    struct Instance;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1184,10 +1184,8 @@ bool AudioUnitEffect::RealtimeAddProcessor(
    slave->SetBlockSize(mBlockSize);
    slave->SetSampleRate(sampleRate);
 
-   if (!CopyParameters(mUnit.get(), slave->mUnit.get()))
-   {
+   if (!slave->StoreSettings(GetSettings(settings)))
       return false;
-   }
 
    auto pSlave = slave.get();
    mSlaves.push_back(std::move(slave));
@@ -1814,25 +1812,6 @@ bool AudioUnitEffect::SetRateAndChannels()
    }
 
    mInitialization.reset(mUnit.get());
-   return true;
-}
-
-bool AudioUnitEffect::CopyParameters(AudioUnit srcUnit, AudioUnit dstUnit)
-{
-   // Retrieve the class state from the source AU
-   CFPropertyListRef content;
-   if (AudioUnitUtils::GetFixedSizeProperty(srcUnit,
-      kAudioUnitProperty_ClassInfo, content))
-      return false;
-
-   // Set the destination AUs state from the source AU's content
-   if (AudioUnitUtils::SetProperty(dstUnit,
-      kAudioUnitProperty_ClassInfo, content))
-      return false;
-
-   // Notify interested parties
-   Notify(dstUnit, kAUParameterListener_AnyParameter);
-
    return true;
 }
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -941,7 +941,6 @@ bool AudioUnitEffect::InitializePlugin()
    if (!InitializeInstance())
       return false;
 
-
    // Consult preferences
    // Decide mUseLatency, which affects GetLatency(), which is actually used
    // so far only in destructive effect processing
@@ -959,9 +958,11 @@ bool AudioUnitEffect::InitializePlugin()
    GetConfig(*this, PluginSettings::Private,
       FactoryDefaultsGroup(), InitializedKey, haveDefaults, false);
    if (!haveDefaults) {
-      SavePreset(FactoryDefaultsGroup());
-      SetConfig(*this, PluginSettings::Private,
-         FactoryDefaultsGroup(), InitializedKey, true);
+      auto &settings = mSettings;
+      FetchSettings(settings);
+      if (SavePreset(FactoryDefaultsGroup(), settings))
+         SetConfig(*this, PluginSettings::Private,
+            FactoryDefaultsGroup(), InitializedKey, true);
    }
    return true;
 }
@@ -1294,6 +1295,28 @@ bool AudioUnitEffect::FetchSettings(AudioUnitEffectSettings &settings) const
    });
 }
 
+bool AudioUnitEffect::StoreSettings(
+   const AudioUnitEffectSettings &settings) const
+{
+   // Update parameter values in the AudioUnit from const
+   // AudioUnitEffectSettings
+   bool success = true;
+   return ForEachParameter(
+   [this, &settings, &success](const ParameterInfo &pi, AudioUnitParameterID ID)
+   {
+      if (auto iter = settings.values.find(pi.name);
+          iter != settings.values.end()) {
+         if (AudioUnitSetParameter(mUnit.get(), ID,
+            kAudioUnitScope_Global, 0, iter->second, 0)) {
+            // Probably failed because of invalid parameter which can happen
+            // if a plug-in is in a certain mode that doesn't contain the
+            // parameter.  In any case, just ignore it.
+         }
+      }
+      return true;
+   });
+}
+
 bool AudioUnitEffect::SaveSettings(
    const EffectSettings &settings, CommandParameters & parms) const
 {
@@ -1332,9 +1355,9 @@ bool AudioUnitEffect::LoadUserPreset(
 }
 
 bool AudioUnitEffect::SaveUserPreset(
-   const RegistryPath & name, const EffectSettings &) const
+   const RegistryPath & name, const EffectSettings &settings) const
 {
-   return SavePreset(name);
+   return SavePreset(name, GetSettings(settings));
 }
 
 bool AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &settings) const
@@ -1494,7 +1517,7 @@ bool AudioUnitEffect::CanExportPresets()
    return true;
 }
 
-void AudioUnitEffect::ExportPresets(const EffectSettings &) const
+void AudioUnitEffect::ExportPresets(const EffectSettings &settings) const
 {
    // Generate the user domain path
    wxFileName fn;
@@ -1504,8 +1527,7 @@ void AudioUnitEffect::ExportPresets(const EffectSettings &) const
    fn.Normalize();
    FilePath path = fn.GetFullPath();
 
-   if (!fn.Mkdir(fn.GetFullPath(), 0755, wxPATH_MKDIR_FULL))
-   {
+   if (!fn.Mkdir(fn.GetFullPath(), 0755, wxPATH_MKDIR_FULL)) {
       wxLogError(wxT("Couldn't create the \"%s\" directory"), fn.GetPath());
       return;
    }
@@ -1527,19 +1549,15 @@ void AudioUnitEffect::ExportPresets(const EffectSettings &) const
 
    // User canceled...
    if (path.empty())
-   {
       return;
-   }
 
-   auto msg = Export(path);
+   auto msg = Export(GetSettings(settings), path);
    if (!msg.empty())
-   {
       AudacityMessageBox(
          XO("Could not export \"%s\" preset\n\n%s").Format(path, msg),
          XO("Export Audio Unit Presets"),
          wxOK | wxCENTRE,
          mParent);
-   }
 }
 
 void AudioUnitEffect::ImportPresets(EffectSettings &settings)
@@ -1598,24 +1616,34 @@ void AudioUnitEffect::ShowOptions()
 // AudioUnitEffect Implementation
 // ============================================================================
 
-bool AudioUnitEffect::LoadPreset(
+bool AudioUnitEffect::MigrateOldConfigFile(
    const RegistryPath & group, EffectSettings &settings) const
 {
-   wxString parms;
-
+   // Migration of very old format configuration file, should not normally
+   // happen and perhaps this code can be abandoned
    // Attempt to load old preset parameters and resave using new method
-   if (GetConfig(*this, PluginSettings::Private, group, wxT("Parameters"),
-      parms, wxEmptyString)) {
+   constexpr auto oldKey = L"Parameters";
+   wxString parms;
+   if (GetConfig(*this, PluginSettings::Private,
+      group, oldKey, parms, wxEmptyString)) {
       CommandParameters eap;
       if (eap.SetParameters(parms))
          if (LoadSettings(eap, settings))
-            if (SavePreset(group))
-               RemoveConfig(*this, PluginSettings::Private,
-                  group, wxT("Parameters"));
+            if (SavePreset(group, GetSettings(settings)))
+               RemoveConfig(*this, PluginSettings::Private, group, oldKey);
       return true;
    }
+   return false;
+}
+
+bool AudioUnitEffect::LoadPreset(
+   const RegistryPath & group, EffectSettings &settings) const
+{
+   if (MigrateOldConfigFile(group, settings))
+      return true;
 
    // Retrieve the preset
+   wxString parms;
    if (!GetConfig(*this, PluginSettings::Private, group, PRESET_KEY, parms,
       wxEmptyString)) {
       // Commented "CurrentSettings" gets tried a lot and useless messages appear
@@ -1681,10 +1709,11 @@ TranslatableString AudioUnitEffect::InterpretBlob(
    return {};
 }
 
-bool AudioUnitEffect::SavePreset(const RegistryPath & group) const
+bool AudioUnitEffect::SavePreset(
+   const RegistryPath & group, const AudioUnitEffectSettings &settings) const
 {
    wxCFStringRef cfname(wxFileNameFromPath(group));
-   const auto &[data, _] = MakeBlob(cfname, true);
+   const auto &[data, _] = MakeBlob(settings, cfname, true);
    if (!data)
       return false;
 
@@ -1807,7 +1836,8 @@ bool AudioUnitEffect::CopyParameters(AudioUnit srcUnit, AudioUnit dstUnit)
    return true;
 }
 
-TranslatableString AudioUnitEffect::Export(const wxString & path) const
+TranslatableString AudioUnitEffect::Export(
+   const AudioUnitEffectSettings &settings, const wxString & path) const
 {
    // Create the file
    wxFFile f(path, wxT("wb"));
@@ -1817,7 +1847,7 @@ TranslatableString AudioUnitEffect::Export(const wxString & path) const
    // First set the name of the preset
    wxCFStringRef cfname(wxFileName(path).GetName());
 
-   const auto &[data, message] = MakeBlob(cfname, false);
+   const auto &[data, message] = MakeBlob(settings, cfname, false);
    if (!data || !message.empty())
       return message;
 
@@ -1831,8 +1861,12 @@ TranslatableString AudioUnitEffect::Export(const wxString & path) const
 }
 
 std::pair<CF_ptr<CFDataRef>, TranslatableString>
-AudioUnitEffect::MakeBlob(const wxCFStringRef &cfname, bool binary) const
+AudioUnitEffect::MakeBlob(const AudioUnitEffectSettings &settings,
+   const wxCFStringRef &cfname, bool binary) const
 {
+   // Update state of the unit from settings
+   StoreSettings(settings);
+
    CF_ptr<CFDataRef> data;
    TranslatableString message;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -770,10 +770,10 @@ AudioUnitEffect::AudioUnitEffect(const PluginPath & path,
                                  const wxString & name,
                                  AudioComponent component,
                                  AudioUnitEffect *master)
-   : mPath{ path }
+   : AudioUnitWrapper{ component }
+   , mPath{ path }
    , mName{ name.AfterFirst(wxT(':')).Trim(true).Trim(false) }
    , mVendor{ name.BeforeFirst(wxT(':')).Trim(true).Trim(false) }
-   , mComponent{ component }
    , mMaster{ master }
 {
 }
@@ -875,7 +875,7 @@ bool AudioUnitEffect::SupportsAutomation() const
    }) && supports;
 }
 
-bool AudioUnitEffect::CreateAudioUnit()
+bool AudioUnitWrapper::CreateAudioUnit()
 {
    AudioUnit unit{};
    auto result = AudioComponentInstanceNew(mComponent, &unit);

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -953,6 +953,26 @@ bool AudioUnitEffect::InitializePlugin()
    if (!InitializeInstance())
       return false;
 
+   {
+      PackedArrayPtr<AudioUnitParameterID> array;
+      GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array);
+   
+      // Check for a Cocoa UI
+      // This could retrieve a variable-size property, but we only look at
+      // the first element.
+      AudioUnitCocoaViewInfo cocoaViewInfo;
+      bool hasCocoa =
+         !GetFixedSizeProperty(kAudioUnitProperty_CocoaUI, cocoaViewInfo);
+
+      // Check for a Carbon UI
+      // This could retrieve a variable sized array but we only need the first
+      AudioComponentDescription compDesc;
+      bool hasCarbon =
+         !GetFixedSizeProperty(kAudioUnitProperty_GetUIComponentList, compDesc);
+
+      mInteractive = (PackedArrayCount(array) > 0) || hasCocoa || hasCarbon;
+   }
+
    // Consult preferences
    // Decide mUseLatency, which affects GetLatency(), which is actually used
    // so far only in destructive effect processing
@@ -1041,21 +1061,6 @@ bool AudioUnitEffect::MakeListener()
       {
          return false;
       }
-   
-      // Check for a Cocoa UI
-      // This could retrieve a variable-size property, but we only look at
-      // the first element.
-      AudioUnitCocoaViewInfo cocoaViewInfo;
-      bool hasCocoa =
-         !GetFixedSizeProperty(kAudioUnitProperty_CocoaUI, cocoaViewInfo);
-
-      // Check for a Carbon UI
-      // This could retrieve a variable sized array but we only need the first
-      AudioComponentDescription compDesc;
-      bool hasCarbon =
-         !GetFixedSizeProperty(kAudioUnitProperty_GetUIComponentList, compDesc);
-
-      mInteractive = (PackedArrayCount(array) > 0) || hasCocoa || hasCarbon;
    }
 
    return true;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -896,11 +896,7 @@ bool AudioUnitEffect::InitializeInstance()
    // Retrieve the desired number of frames per slice
    mBlockSize = 512;
    GetFixedSizeProperty(kAudioUnitProperty_MaximumFramesPerSlice, mBlockSize);
-
-   // Is this really needed here or can it be done in MakeInstance()
-   // only?  I think it can, but this is more a conservative change for now,
-   // preserving what SetHost() did
-   return MakeListener();
+   return true;
 }
 
 struct AudioUnitEffect::Instance
@@ -913,6 +909,12 @@ struct AudioUnitEffect::Instance
    {
       CreateAudioUnit();
    }
+
+   static void EventListenerCallback(void *inCallbackRefCon,
+      void *inObject, const AudioUnitEvent *inEvent,
+      UInt64 inEventHostTime, AudioUnitParameterValue inParameterValue);
+   void EventListener(const AudioUnitEvent *inEvent,
+      AudioUnitParameterValue inParameterValue);
 };
 
 std::shared_ptr<EffectInstance>
@@ -1004,66 +1006,65 @@ struct AudioUnitEffect::Validator : DefaultEffectUIValidator {
       Instance &instance)
    : DefaultEffectUIValidator{ effect, access }
    , mUnit{ instance.mUnit.get() }
-   {}
+   , mEventListenerRef{ MakeListener(instance) }
+   {
+   }
+
+   using EventListenerPtr =
+      AudioUnitCleanup<AUEventListenerRef, AUListenerDispose>;
+
+   const AudioUnitEffect &GetEffect() const
+      { return static_cast<const AudioUnitEffect &>(mEffect); }
+   static EventListenerPtr MakeListener(Instance &instance);
 
    // Just a pointer to an AudioUnit.  The lifetime guarantee is assumed to be
    // provided by the instance.  See contract of PopulateUI
    const AudioUnit mUnit;
+   const EventListenerPtr mEventListenerRef;
 };
 
-bool AudioUnitEffect::MakeListener()
+auto AudioUnitEffect::Validator::MakeListener(Instance &instance)
+   -> EventListenerPtr
 {
-   if (!mMaster)
-   {
-      // Don't have a master -- so this IS the master.
-      OSStatus result;
-      AUEventListenerRef eventListenerRef{};
-      result = AUEventListenerCreate(AudioUnitEffect::EventListenerCallback,
-                                    this,
-                                    (CFRunLoopRef)GetCFRunLoopFromEventLoop(GetCurrentEventLoop()),
-                                    kCFRunLoopDefaultMode,
-                                    0.0,
-                                    0.0,
-                                    &eventListenerRef);
-      if (result != noErr)
-         return false;
-      mEventListenerRef.reset(eventListenerRef);
+   const auto unit = instance.mUnit.get();
+   EventListenerPtr result;
 
-      AudioUnitEvent event;
- 
-      event.mEventType = kAudioUnitEvent_ParameterValueChange;
-      event.mArgument.mParameter.mAudioUnit = mUnit.get();
-      event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
-      event.mArgument.mParameter.mElement = 0;
+   // Register a callback with the audio unit
+   AUEventListenerRef eventListenerRef{};
+   if (AUEventListenerCreate(AudioUnitEffect::Instance::EventListenerCallback,
+      &instance,
+      static_cast<CFRunLoopRef>( const_cast<void*>(
+         GetCFRunLoopFromEventLoop(GetCurrentEventLoop()))),
+      kCFRunLoopDefaultMode, 0.0, 0.0, &eventListenerRef))
+      return nullptr;
+   result.reset(eventListenerRef);
 
-      // Retrieve the list of parameters
-      PackedArrayPtr<AudioUnitParameterID> array;
-      if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
-         return false;
+   // AudioUnitEvent is a struct with a discriminator field and a union
+   AudioUnitEvent event{ kAudioUnitEvent_ParameterValueChange };
+   // Initialize union member -- the ID (second field) reassigned later
+   auto &parameter = event.mArgument.mParameter;
+   parameter = {unit, 0, kAudioUnitScope_Global, 0};
 
-      // Register them as something we're interested in
-      for (const auto &ID : array) {
-         event.mArgument.mParameter.mParameterID = ID;
-         if (AUEventListenerAddEventType(mEventListenerRef.get(), this, &event))
-            return false;
-      }
+   // Retrieve the list of parameters
+   PackedArrayPtr<AudioUnitParameterID> array;
+   if (instance
+      .GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
+      return nullptr;
 
-      event.mEventType = kAudioUnitEvent_PropertyChange;
-      event.mArgument.mProperty.mAudioUnit = mUnit.get();
-      event.mArgument.mProperty.mPropertyID = kAudioUnitProperty_Latency;
-      event.mArgument.mProperty.mScope = kAudioUnitScope_Global;
-      event.mArgument.mProperty.mElement = 0;
-
-      result = AUEventListenerAddEventType(mEventListenerRef.get(),
-                                           this,
-                                           &event);
-      if (result != noErr)
-      {
-         return false;
-      }
+   // Register them as something we're interested in
+   for (const auto &ID : array) {
+      parameter.mParameterID = ID;
+      if (AUEventListenerAddEventType(result.get(), &instance, &event))
+         return nullptr;
    }
 
-   return true;
+   // Now set up the other union member
+   event = { kAudioUnitEvent_PropertyChange };
+   event.mArgument.mProperty = {
+      unit, kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0 };
+   if (AUEventListenerAddEventType(result.get(), &instance, &event))
+      return nullptr;
+   return result;
 }
 
 unsigned AudioUnitEffect::GetAudioInCount() const
@@ -1967,49 +1968,36 @@ OSStatus AudioUnitEffect::RenderCallback(void *inRefCon,
       inTimeStamp, inBusNumber, inNumFrames, ioData);
 }
 
-void AudioUnitEffect::EventListener(const AudioUnitEvent *inEvent,
-                                    AudioUnitParameterValue inParameterValue)
+void AudioUnitEffect::Instance::EventListener(const AudioUnitEvent *inEvent,
+   AudioUnitParameterValue inParameterValue)
 {
    // Handle property changes
-   if (inEvent->mEventType == kAudioUnitEvent_PropertyChange)
-   {
+   if (inEvent->mEventType == kAudioUnitEvent_PropertyChange) {
       // Handle latency changes
-      if (inEvent->mArgument.mProperty.mPropertyID == kAudioUnitProperty_Latency)
-      {
+      if (inEvent->mArgument.mProperty.mPropertyID ==
+          kAudioUnitProperty_Latency) {
          // Allow change to be used
          //mLatencyDone = false;
       }
-
       return;
    }
 
    // Only parameter changes at this point
-
-   if (mMaster)
-   {
-      // We're a slave, so just set the parameter
-      AudioUnitSetParameter(mUnit.get(),
+   // Propagate the parameter
+   // TODO stores slaves in the instance
+   auto &slaves = static_cast<AudioUnitEffect&>(GetEffect()).mSlaves;
+   for (auto &worker : slaves)
+      AudioUnitSetParameter(worker->mUnit.get(),
          inEvent->mArgument.mParameter.mParameterID,
          kAudioUnitScope_Global, 0, inParameterValue, 0);
-   }
-   else
-   {
-      // We're the master, so propagate 
-      for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
-      {
-         mSlaves[i]->EventListener(inEvent, inParameterValue);
-      }
-   }
 }
 
 // static
-void AudioUnitEffect::EventListenerCallback(void *inCallbackRefCon,
-                                            void *inObject,
-                                            const AudioUnitEvent *inEvent,
-                                            UInt64 inEventHostTime,
-                                            AudioUnitParameterValue inParameterValue)
+void AudioUnitEffect::Instance::EventListenerCallback(void *inCallbackRefCon,
+   void *inObject, const AudioUnitEvent *inEvent, UInt64 inEventHostTime,
+   AudioUnitParameterValue inParameterValue)
 {
-   static_cast<AudioUnitEffect *>(inCallbackRefCon)
+   static_cast<AudioUnitEffect::Instance *>(inCallbackRefCon)
       ->EventListener(inEvent, inParameterValue);
 }
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -118,30 +118,19 @@ public:
 
    bool Get(AudioUnit mUnit, AudioUnitParameterID parmID)
    {
-      OSStatus result;
       UInt32 dataSize;
 
       info = {};
-      dataSize = sizeof(info);
-      result = AudioUnitGetProperty(mUnit,
-                                    kAudioUnitProperty_ParameterInfo,
-                                    kAudioUnitScope_Global,
-                                    parmID,
-                                    &info,
-                                    &dataSize);  
-      if (result != noErr)
-      {
+      // Note non-default element parameter, parmID
+      if (AudioUnitUtils::GetFixedSizeProperty(mUnit,
+         kAudioUnitProperty_ParameterInfo, info,
+         kAudioUnitScope_Global, parmID))
          return false;
-      }
 
       if (info.flags & kAudioUnitParameterFlag_HasCFNameString)
-      {
          name = wxCFStringRef::AsString(info.cfNameString);
-      }
       else
-      {
          name = wxString(info.name);
-      }
 
 #if defined(USE_EXTENDED_NAMES)
       // If the parameter has a non-empty name, then the final parameter name will
@@ -182,16 +171,9 @@ public:
          } clumpInfo{
             info.clumpID, kAudioUnitParameterName_Full, nullptr
          };
-         dataSize = sizeof(clumpInfo);
 
-         result = AudioUnitGetProperty(mUnit,
-                                       kAudioUnitProperty_ParameterClumpName,
-                                       kAudioUnitScope_Global,
-                                       0,
-                                       &clumpInfo,
-                                       &dataSize);  
-         if (result == noErr)
-         {
+         if (!AudioUnitUtils::GetFixedSizeProperty(mUnit,
+            kAudioUnitProperty_ParameterClumpName, clumpInfo)) {
             clumpName =  wxCFStringRef::AsString(clumpInfo.outName);
             clumpName.Replace(idBeg, wxT('_'));
             clumpName.Replace(idSep, wxT('_'));
@@ -963,14 +945,8 @@ bool AudioUnitEffect::InitializeInstance()
    SetRateAndChannels();
 
    // Retrieve the desired number of frames per slice
-   UInt32 dataSize = sizeof(mBlockSize);
    mBlockSize = 512;
-   AudioUnitGetProperty(mUnit.get(),
-                        kAudioUnitProperty_MaximumFramesPerSlice,
-                        kAudioUnitScope_Global,
-                        0,
-                        &mBlockSize,
-                        &dataSize);
+   GetFixedSizeProperty(kAudioUnitProperty_MaximumFramesPerSlice, mBlockSize);
 
    // Is this really needed here or can it be done in MakeInstance()
    // only?  I think it can, but this is more a conservative change for now,
@@ -1125,30 +1101,19 @@ bool AudioUnitEffect::MakeListener()
       {
          return false;
       }
-
-      AudioUnitCocoaViewInfo cocoaViewInfo;
-      dataSize = sizeof(AudioUnitCocoaViewInfo);
    
       // Check for a Cocoa UI
-      result = AudioUnitGetProperty(mUnit.get(),
-                                    kAudioUnitProperty_CocoaUI,
-                                    kAudioUnitScope_Global,
-                                    0,
-                                    &cocoaViewInfo,
-                                    &dataSize);
-
-      bool hasCocoa = result == noErr;
+      // This could retrieve a variable-size property, but we only look at
+      // the first element.
+      AudioUnitCocoaViewInfo cocoaViewInfo;
+      bool hasCocoa =
+         !GetFixedSizeProperty(kAudioUnitProperty_CocoaUI, cocoaViewInfo);
 
       // Check for a Carbon UI
+      // This could retrieve a variable sized array but we only need the first
       AudioComponentDescription compDesc;
-      dataSize = sizeof(compDesc);
-      result = AudioUnitGetProperty(mUnit.get(),
-                                    kAudioUnitProperty_GetUIComponentList,
-                                    kAudioUnitScope_Global,
-                                    0,
-                                    &compDesc,
-                                    &dataSize);
-      bool hasCarbon = result == noErr;
+      bool hasCarbon =
+         !GetFixedSizeProperty(kAudioUnitProperty_GetUIComponentList, compDesc);
 
       mInteractive = (cnt > 0) || hasCocoa || hasCarbon;
    }
@@ -1194,22 +1159,13 @@ size_t AudioUnitEffect::GetBlockSize() const
 sampleCount AudioUnitEffect::GetLatency()
 {
    // Retrieve the latency (can be updated via an event)
-   if (mUseLatency && !mLatencyDone)
-   {
-      mLatencyDone = true;
-
+   if (mUseLatency && !mLatencyDone) {
       Float64 latency = 0.0;
-      UInt32 dataSize = sizeof(latency);
-      AudioUnitGetProperty(mUnit.get(),
-                           kAudioUnitProperty_Latency,
-                           kAudioUnitScope_Global,
-                           0,
-                           &latency,
-                           &dataSize);  
-
-      return sampleCount(latency * mSampleRate);
+      if (!GetFixedSizeProperty(kAudioUnitProperty_Latency, latency)) {
+         mLatencyDone = true;
+         return sampleCount(latency * mSampleRate);
+      }
    }
-
    return 0;
 }
 
@@ -1219,15 +1175,9 @@ size_t AudioUnitEffect::GetTailSize() const
 {
    // Retrieve the tail time
    Float64 tailTime = 0.0;
-   UInt32 dataSize = sizeof(tailTime);
-   AudioUnitGetProperty(mUnit,
-                        kAudioUnitProperty_TailTime,
-                        kAudioUnitScope_Global,
-                        0,
-                        &tailTime,
-                        &dataSize);  
-
-   return tailTime * mSampleRate;
+   if (!GetFixedSizeProperty(kAudioUnitProperty_TailTime, tailTime))
+      return tailTime * mSampleRate;
+   return 0;
 }
 #endif
 
@@ -1549,23 +1499,14 @@ bool AudioUnitEffect::SaveUserPreset(
 
 bool AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &) const
 {
-   OSStatus result;
-
    // Retrieve the list of factory presets
    CF_ptr<CFArrayRef> array;
-   UInt32 dataSize = sizeof(CFArrayRef);
-   result = AudioUnitGetProperty(mUnit.get(),
-                                 kAudioUnitProperty_FactoryPresets,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &array,
-                                 &dataSize);
-   if (result != noErr || id < 0 || id >= CFArrayGetCount(array.get()))
+   if (GetFixedSizeProperty(kAudioUnitProperty_FactoryPresets, array) ||
+       id < 0 || id >= CFArrayGetCount(array.get()))
       return false;
 
    if (!SetProperty(kAudioUnitProperty_PresentPreset,
-      *static_cast<const AUPreset *>(
-         CFArrayGetValueAtIndex(array.get(), id)))) {
+      *static_cast<const AUPreset*>(CFArrayGetValueAtIndex(array.get(), id)))) {
       // Notify interested parties of change and propagate to slaves
       Notify(mUnit.get(), kAUParameterListener_AnyParameter);
       return true;
@@ -1582,19 +1523,11 @@ bool AudioUnitEffect::LoadFactoryDefaults(EffectSettings &settings) const
 
 RegistryPaths AudioUnitEffect::GetFactoryPresets() const
 {
-   OSStatus result;
    RegistryPaths presets;
 
    // Retrieve the list of factory presets
    CF_ptr<CFArrayRef> array;
-   UInt32 dataSize = sizeof(CFArrayRef);
-   result = AudioUnitGetProperty(mUnit.get(),
-                                 kAudioUnitProperty_FactoryPresets,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &array,
-                                 &dataSize);
-   if (result == noErr)
+   if (!GetFixedSizeProperty(kAudioUnitProperty_FactoryPresets, array))
       for (CFIndex i = 0, cnt = CFArrayGetCount(array.get()); i < cnt; ++i)
          presets.push_back(wxCFStringRef::AsString(
             static_cast<const AUPreset*>(CFArrayGetValueAtIndex(array.get(), i))
@@ -1912,13 +1845,7 @@ bool AudioUnitEffect::SavePreset(const RegistryPath & group) const
 
    // Now retrieve the preset content
    CF_ptr<CFPropertyListRef> content;
-   UInt32 size = sizeof(content);
-   AudioUnitGetProperty(mUnit.get(),
-                        kAudioUnitProperty_ClassInfo,
-                        kAudioUnitScope_Global,
-                        0,
-                        &content,
-                        &size);
+   GetFixedSizeProperty(kAudioUnitProperty_ClassInfo, content);
 
    // And convert it to serialized binary data
    CF_ptr<CFDataRef> data{
@@ -2016,18 +1943,10 @@ bool AudioUnitEffect::SetRateAndChannels()
 
 bool AudioUnitEffect::CopyParameters(AudioUnit srcUnit, AudioUnit dstUnit)
 {
-   OSStatus result;
-
    // Retrieve the class state from the source AU
-   CF_ptr<CFPropertyListRef> content;
-   UInt32 size = sizeof(content);
-   result = AudioUnitGetProperty(srcUnit,
-                                 kAudioUnitProperty_ClassInfo,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &content,
-                                 &size);
-   if (result != noErr)
+   CFPropertyListRef content;
+   if (AudioUnitUtils::GetFixedSizeProperty(srcUnit,
+      kAudioUnitProperty_ClassInfo, content))
       return false;
 
    // Set the destination AUs state from the source AU's content
@@ -2058,14 +1977,7 @@ TranslatableString AudioUnitEffect::Export(const wxString & path) const
 
    // Now retrieve the preset content
    CF_ptr<CFPropertyListRef> content;
-   UInt32 size = sizeof(content);
-   auto result = AudioUnitGetProperty(mUnit.get(),
-                                 kAudioUnitProperty_ClassInfo,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &content,
-                                 &size);
-   if (result)
+   if (GetFixedSizeProperty(kAudioUnitProperty_ClassInfo, content))
       return XO("Failed to retrieve preset content");
 
    // And convert it to serialized XML data

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1398,8 +1398,8 @@ RegistryPaths AudioUnitEffect::GetFactoryPresets() const
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-std::unique_ptr<EffectUIValidator>
-AudioUnitEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> AudioUnitEffect::PopulateUI(ShuttleGui &S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    // OSStatus result;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -940,10 +940,7 @@ bool AudioUnitEffect::InitializePlugin()
    // third party effect families that distinguish the notions of plug-in and
    // instance.
 
-   // When AudioUnitEffect implements its own proper Instance class, this
-   // should call CreateAudioUnit() directly and not do the rest of
-   // InitializeInstance.
-   if (!InitializeInstance())
+   if (!CreateAudioUnit())
       return false;
 
    {

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1275,11 +1275,12 @@ int AudioUnitEffect::ShowClientInterface(
    return mDialog->ShowModal();
 }
 
-bool AudioUnitEffect::SaveSettings(
-   const EffectSettings &, CommandParameters & parms) const
+bool AudioUnitEffect::FetchSettings(AudioUnitEffectSettings &settings) const
 {
+   // Fetch Settings values from the AudioUnit
+   settings.values.clear();
    return ForEachParameter(
-   [this, &parms](const ParameterInfo &pi, AudioUnitParameterID ID) {
+   [this, &settings](const ParameterInfo &pi, AudioUnitParameterID ID) {
       AudioUnitParameterValue value;
       if (AudioUnitGetParameter(mUnit.get(), ID, kAudioUnitScope_Global, 0,
          &value))
@@ -1288,14 +1289,26 @@ bool AudioUnitEffect::SaveSettings(
          // parameter.  In any case, just ignore it.
          {}
       else
-         parms.Write(pi.name, value);
+         settings.values[pi.name] = value;
       return true;
    });
+}
+
+bool AudioUnitEffect::SaveSettings(
+   const EffectSettings &settings, CommandParameters & parms) const
+{
+   // Assume parameter values were fetched after latest change in the instance
+   auto &mySettings = GetSettings(settings);
+   for (auto &[key, value] : mySettings.values)
+      parms.Write(key, value);
+   return true;
 }
 
 bool AudioUnitEffect::LoadSettings(
    const CommandParameters & parms, EffectSettings &settings) const
 {
+   // Update parameter values in AudioUnit from const CommandParameters and
+   // update them too in EffectSettings
    bool success = true;
    return ForEachParameter(
    [this, &parms, &success](const ParameterInfo &pi, AudioUnitParameterID ID) {
@@ -1308,7 +1321,7 @@ bool AudioUnitEffect::LoadSettings(
             Notify(mUnit.get(), ID);
       }
       return success;
-   }) && success;
+   }) && success && FetchSettings(GetSettings(settings));
 }
 
 bool AudioUnitEffect::LoadUserPreset(
@@ -1324,7 +1337,7 @@ bool AudioUnitEffect::SaveUserPreset(
    return SavePreset(name);
 }
 
-bool AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &) const
+bool AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &settings) const
 {
    // Retrieve the list of factory presets
    CF_ptr<CFArrayRef> array;
@@ -1334,6 +1347,10 @@ bool AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &) const
 
    if (!SetProperty(kAudioUnitProperty_PresentPreset,
       *static_cast<const AUPreset*>(CFArrayGetValueAtIndex(array.get(), id)))) {
+      // Repopulate the AudioUnitEffectSettings from the change of state in
+      // the AudioUnit
+      FetchSettings(GetSettings(settings));
+
       // Notify interested parties of change and propagate to slaves
       Notify(mUnit.get(), kAUParameterListener_AnyParameter);
       return true;
@@ -1525,7 +1542,7 @@ void AudioUnitEffect::ExportPresets(const EffectSettings &) const
    }
 }
 
-void AudioUnitEffect::ImportPresets(EffectSettings &)
+void AudioUnitEffect::ImportPresets(EffectSettings &settings)
 {
    // Generate the user domain path
    wxFileName fn;
@@ -1541,30 +1558,24 @@ void AudioUnitEffect::ImportPresets(EffectSettings &)
    // upon returning from the SelectFile().
    path = SelectFile(FileNames::Operation::_None,
       XO("Import Audio Unit Preset As %s:").Format(fn.GetFullPath()),
-      fn.GetFullPath(),
-      wxEmptyString,
-      wxT("aupreset"),
+      fn.GetFullPath(), wxEmptyString, wxT("aupreset"),
       {
         { XO("Standard Audio Unit preset file"), { wxT("aupreset") }, true },
       },
       wxFD_OPEN | wxRESIZE_BORDER,
-      NULL);
+      nullptr);
 
    // User canceled...
    if (path.empty())
-   {
       return;
-   }
 
-   auto msg = Import(path);
+   auto msg = Import(GetSettings(settings), path);
    if (!msg.empty())
-   {
       AudacityMessageBox(
          XO("Could not import \"%s\" preset\n\n%s").Format(path, msg),
          XO("Import Audio Unit Presets"),
          wxOK | wxCENTRE,
          mParent);
-   }
 }
 
 bool AudioUnitEffect::HasOptions()
@@ -1614,7 +1625,8 @@ bool AudioUnitEffect::LoadPreset(
    }
    
    // Decode it, complementary to what SaveBlobToConfig did
-   auto error = InterpretBlob(group, wxBase64Decode(parms));
+   auto error =
+      InterpretBlob(GetSettings(settings), group, wxBase64Decode(parms));
    if (!error.empty()) {
       wxLogError(error.Debug());
       return false;
@@ -1630,6 +1642,7 @@ bool AudioUnitEffect::LoadPreset(
 }
 
 TranslatableString AudioUnitEffect::InterpretBlob(
+   AudioUnitEffectSettings &settings,
    const RegistryPath &group, const wxMemoryBuffer &buf) const
 {
    size_t bufLen = buf.GetDataLen();
@@ -1659,6 +1672,12 @@ TranslatableString AudioUnitEffect::InterpretBlob(
    // Finally, update the properties and parameters
    if (SetProperty(kAudioUnitProperty_ClassInfo, content.get()))
       return XO("Failed to set class info for \"%s\" preset").Format(group);
+
+   // Repopulate the AudioUnitEffectSettings from the change of state in
+   // the AudioUnit
+   if (!FetchSettings(settings))
+      return XO("Failed to get parameters for for \"%s\" preset").Format(group);
+
    return {};
 }
 
@@ -1844,7 +1863,8 @@ AudioUnitEffect::MakeBlob(const wxCFStringRef &cfname, bool binary) const
    return { move(data), message };
 }
 
-TranslatableString AudioUnitEffect::Import(const wxString & path)
+TranslatableString AudioUnitEffect::Import(
+   AudioUnitEffectSettings &settings, const wxString & path) const
 {
    // Open the preset
    wxFFile f(path, wxT("r"));
@@ -1857,7 +1877,7 @@ TranslatableString AudioUnitEffect::Import(const wxString & path)
    if (f.Read(buf.GetData(), len) != len || f.Error())
       return XO("Unable to read the preset from \"%s\"").Format(path);
 
-   const auto error = InterpretBlob(path, buf);
+   const auto error = InterpretBlob(settings, path, buf);
    if (!error.empty())
       return error;
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -826,20 +826,11 @@ TranslatableString AudioUnitEffect::GetDescription() const
 EffectType AudioUnitEffect::GetType() const
 {
    if (mAudioIns == 0 && mAudioOuts == 0)
-   {
       return EffectTypeNone;
-   }
-
    if (mAudioIns == 0)
-   {
       return EffectTypeGenerate;
-   }
-
    if (mAudioOuts == 0)
-   {
       return EffectTypeAnalyze;
-   }
-
    return EffectTypeProcess;
 }
 
@@ -931,7 +922,7 @@ AudioUnitEffect::DoMakeInstance(EffectSettings &settings)
       InitializeInstance();
    else
       // Don't HAVE a master -- this IS the master.
-      LoadPreset(CurrentSettingsGroup(), settings);
+      LoadPreset(CurrentSettingsGroup(), settings); // StoreSettings?
    return std::make_shared<Instance>(*this);
 }
 
@@ -1135,7 +1126,7 @@ bool AudioUnitEffect::ProcessInitialize(
    mOutputList =
       PackedArrayAllocateCount<AudioBufferList>(mAudioOuts)(mAudioOuts);
 
-   memset(&mTimeStamp, 0, sizeof(AudioTimeStamp));
+   mTimeStamp = {};
    mTimeStamp.mSampleTime = 0; // This is a double-precision number that should
                                // accumulate the number of frames processed so far
    mTimeStamp.mFlags = kAudioTimeStampSampleTimeValid;
@@ -1226,10 +1217,8 @@ bool AudioUnitEffect::RealtimeAddProcessor(
 bool AudioUnitEffect::RealtimeFinalize(EffectSettings &) noexcept
 {
 return GuardedCall<bool>([&]{
-   for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
-   {
+   for (size_t i = 0, cnt = mSlaves.size(); i < cnt; ++i)
       mSlaves[i]->ProcessFinalize();
-   }
    mSlaves.clear();
    return ProcessFinalize();
 });
@@ -1238,18 +1227,10 @@ return GuardedCall<bool>([&]{
 bool AudioUnitEffect::RealtimeSuspend()
 {
    if (!BypassEffect(true))
-   {
       return false;
-   }
-
-   for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
-   {
+   for (size_t i = 0, cnt = mSlaves.size(); i < cnt; ++i)
       if (!mSlaves[i]->BypassEffect(true))
-      {
          return false;
-      }
-   }
-
    return true;
 }
 
@@ -1257,18 +1238,10 @@ bool AudioUnitEffect::RealtimeResume() noexcept
 {
 return GuardedCall<bool>([&]{
    if (!BypassEffect(false))
-   {
       return false;
-   }
-
-   for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
-   {
+   for (size_t i = 0, cnt = mSlaves.size(); i < cnt; ++i)
       if (!mSlaves[i]->BypassEffect(false))
-      {
          return false;
-      }
-   }
-
    return true;
 });
 }
@@ -1295,12 +1268,10 @@ int AudioUnitEffect::ShowClientInterface(
 {
    // Remember the dialog with a weak pointer, but don't control its lifetime
    mDialog = &dialog;
-   if ((SupportsRealtime() || GetType() == EffectTypeAnalyze) && !forceModal)
-   {
+   if ((SupportsRealtime() || GetType() == EffectTypeAnalyze) && !forceModal) {
       mDialog->Show();
       return 0;
    }
-
    return mDialog->ShowModal();
 }
 
@@ -1369,7 +1340,7 @@ bool AudioUnitEffect::LoadSettings(
             0, d, 0))
             success = false;
          else
-            Notify(mUnit.get(), ID);
+            Notify(mUnit.get(), ID);//
       }
       return success;
    }) && success && FetchSettings(GetSettings(settings));
@@ -1447,11 +1418,9 @@ std::unique_ptr<EffectUIValidator> AudioUnitEffect::PopulateUI(ShuttleGui &S,
    wxPanel *container;
    {
       auto mainSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
-
       wxASSERT(mParent); // To justify safenew
       container = safenew wxPanelWrapper(mParent, wxID_ANY);
       mainSizer->Add(container, 1, wxEXPAND);
-
       mParent->SetSizer(mainSizer.release());
    }
 
@@ -1465,9 +1434,7 @@ std::unique_ptr<EffectUIValidator> AudioUnitEffect::PopulateUI(ShuttleGui &S,
    {
       auto pControl = Destroy_ptr<AUControl>(safenew AUControl);
       if (!pControl)
-      {
          return nullptr;
-      }
 
       if (!pControl->Create(container, mComponent, mUnit.get(),
          mUIType == FullValue.MSGID().GET()))
@@ -1475,7 +1442,6 @@ std::unique_ptr<EffectUIValidator> AudioUnitEffect::PopulateUI(ShuttleGui &S,
 
       {
          auto innerSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
-
          innerSizer->Add((mpControl = pControl.release()), 1, wxEXPAND);
          container->SetSizer(innerSizer.release());
       }
@@ -1524,18 +1490,15 @@ bool AudioUnitEffect::CloseUI()
 #ifdef __WX_EVTLOOP_BUSY_WAITING__
    wxEventLoop::SetBusyWaiting(false);
 #endif
-   if (mpControl)
-   {
+   if (mpControl) {
       mParent->RemoveEventHandler(this);
-
       mpControl->Close();
       mpControl = nullptr;
    }
 #endif
 
-   mParent = NULL;
-   mDialog = NULL;
-
+   mParent = nullptr;
+   mDialog = nullptr;
    return true;
 }
 
@@ -1958,11 +1921,8 @@ OSStatus AudioUnitEffect::Render(AudioUnitRenderActionFlags *inActionFlags,
 
 // static
 OSStatus AudioUnitEffect::RenderCallback(void *inRefCon,
-                                         AudioUnitRenderActionFlags *inActionFlags,
-                                         const AudioTimeStamp *inTimeStamp,
-                                         UInt32 inBusNumber,
-                                         UInt32 inNumFrames,
-                                         AudioBufferList *ioData)
+   AudioUnitRenderActionFlags *inActionFlags, const AudioTimeStamp *inTimeStamp,
+   UInt32 inBusNumber, UInt32 inNumFrames, AudioBufferList *ioData)
 {
    return static_cast<AudioUnitEffect *>(inRefCon)->Render(inActionFlags,
       inTimeStamp, inBusNumber, inNumFrames, ioData);
@@ -1975,7 +1935,7 @@ void AudioUnitEffect::Instance::EventListener(const AudioUnitEvent *inEvent,
    if (inEvent->mEventType == kAudioUnitEvent_PropertyChange) {
       // Handle latency changes
       if (inEvent->mArgument.mProperty.mPropertyID ==
-          kAudioUnitProperty_Latency) {
+         kAudioUnitProperty_Latency) {
          // Allow change to be used
          //mLatencyDone = false;
       }

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -865,17 +865,14 @@ bool AudioUnitEffect::SupportsRealtime() const
 
 bool AudioUnitEffect::SupportsAutomation() const
 {
-   PackedArrayPtr<AudioUnitParameterID> array;
-   if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
-      return false;
-   for (const auto &ID : array) {
-      ParameterInfo pi;
-      if (pi.Get(mUnit.get(), ID))
-         if (pi.info.flags & kAudioUnitParameterFlag_IsWritable)
-            // All we need is one
-            return true;
-   }
-   return false;
+   bool supports = false;
+   return ForEachParameter(
+   [&supports](const ParameterInfo &pi, AudioUnitParameterID) {
+      if (pi.info.flags & kAudioUnitParameterFlag_IsWritable)
+         supports = true;
+      // Search only until we find one, that's all we need to know
+      return !supports;
+   }) && supports;
 }
 
 bool AudioUnitEffect::CreateAudioUnit()
@@ -1281,50 +1278,37 @@ int AudioUnitEffect::ShowClientInterface(
 bool AudioUnitEffect::SaveSettings(
    const EffectSettings &, CommandParameters & parms) const
 {
-   PackedArrayPtr<AudioUnitParameterID> array;
-   if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
-      return false;
-   for (const auto &ID : array) {
-      ParameterInfo pi;
-      if (!pi.Get(mUnit.get(), ID))
-         // Probably failed because of invalid parameter which can happen
-         // if a plug-in is in a certain mode that doesn't contain the
-         // parameter.  In any case, just ignore it.
-         continue;
+   return ForEachParameter(
+   [this, &parms](const ParameterInfo &pi, AudioUnitParameterID ID) {
       AudioUnitParameterValue value;
       if (AudioUnitGetParameter(mUnit.get(), ID, kAudioUnitScope_Global, 0,
          &value))
          // Probably failed because of invalid parameter which can happen
          // if a plug-in is in a certain mode that doesn't contain the
          // parameter.  In any case, just ignore it.
-         continue;
-      parms.Write(pi.name, value);
-   }
-   return true;
+         {}
+      else
+         parms.Write(pi.name, value);
+      return true;
+   });
 }
 
 bool AudioUnitEffect::LoadSettings(
    const CommandParameters & parms, EffectSettings &settings) const
 {
-   PackedArrayPtr<AudioUnitParameterID> array;
-   if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
-      return false;
-   for (const auto &ID : array) {
-      ParameterInfo pi;
-      if (!pi.Get(mUnit.get(), ID))
-         // Probably failed because of invalid parameter which can happen
-         // if a plug-in is in a certain mode that doesn't contain the
-         // parameter.  In any case, just ignore it.
-         continue;
+   bool success = true;
+   return ForEachParameter(
+   [this, &parms, &success](const ParameterInfo &pi, AudioUnitParameterID ID) {
       double d = 0.0;
       if (parms.Read(pi.name, &d)) {
          if (AudioUnitSetParameter(mUnit.get(), ID, kAudioUnitScope_Global,
             0, d, 0))
-            return false;
-         Notify(mUnit.get(), ID);
+            success = false;
+         else
+            Notify(mUnit.get(), ID);
       }
-   }
-   return true;
+      return success;
+   }) && success;
 }
 
 bool AudioUnitEffect::LoadUserPreset(
@@ -1691,6 +1675,24 @@ bool AudioUnitEffect::SavePreset(const RegistryPath & group) const
          SaveBlobToConfig(group, {}, CFDataGetBytePtr(data.get()), length);
       if (!error.empty())
          return false;
+   }
+   return true;
+}
+
+bool AudioUnitEffect::ForEachParameter(ParameterVisitor visitor) const
+{
+   PackedArrayPtr<AudioUnitParameterID> array;
+   if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
+      return false;
+   for (const auto &ID : array) {
+      ParameterInfo pi;
+      if (!pi.Get(mUnit.get(), ID))
+         // Probably failed because of invalid parameter which can happen
+         // if a plug-in is in a certain mode that doesn't contain the
+         // parameter.  In any case, just ignore it.
+         continue;
+      if (!visitor(pi, ID))
+         break;
    }
    return true;
 }

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1117,11 +1117,10 @@ size_t AudioUnitEffect::GetTailSize() const
 bool AudioUnitEffect::ProcessInitialize(
    EffectSettings &, sampleCount, ChannelNames chanMap)
 {
-   mInputList.reinit(mAudioIns);
-   mInputList[0].mNumberBuffers = mAudioIns;
-   
-   mOutputList.reinit(mAudioOuts);
-   mOutputList[0].mNumberBuffers = mAudioOuts;
+   mInputList =
+      PackedArrayAllocateCount<AudioBufferList>(mAudioIns)(mAudioIns);
+   mOutputList =
+      PackedArrayAllocateCount<AudioBufferList>(mAudioOuts)(mAudioOuts);
 
    memset(&mTimeStamp, 0, sizeof(AudioTimeStamp));
    mTimeStamp.mSampleTime = 0; // This is a double-precision number that should
@@ -1152,26 +1151,21 @@ bool AudioUnitEffect::ProcessFinalize()
 {
    mOutputList.reset();
    mInputList.reset();
-
    return true;
 }
 
 size_t AudioUnitEffect::ProcessBlock(EffectSettings &,
    const float *const *inBlock, float *const *outBlock, size_t blockLen)
 {
-   for (size_t i = 0; i < mAudioIns; i++)
-   {
-      mInputList[0].mBuffers[i].mNumberChannels = 1;
-      mInputList[0].mBuffers[i].mData = const_cast<float*>(inBlock[i]);
-      mInputList[0].mBuffers[i].mDataByteSize = sizeof(float) * blockLen;
-   }
+   assert(PackedArrayCount(mInputList) >= mAudioIns);
+   for (size_t i = 0; i < mAudioIns; ++i)
+      mInputList[i] = { 1, static_cast<UInt32>(sizeof(float) * blockLen),
+         const_cast<float*>(inBlock[i]) };
 
-   for (size_t i = 0; i < mAudioOuts; i++)
-   {
-      mOutputList[0].mBuffers[i].mNumberChannels = 1;
-      mOutputList[0].mBuffers[i].mData = outBlock[i];
-      mOutputList[0].mBuffers[i].mDataByteSize = sizeof(float) * blockLen;
-   }
+   assert(PackedArrayCount(mOutputList) >= mAudioOuts);
+   for (size_t i = 0; i < mAudioOuts; ++i)
+      mOutputList[i] = { 1, static_cast<UInt32>(sizeof(float) * blockLen),
+         outBlock[i] };
 
    AudioUnitRenderActionFlags flags = 0;
    OSStatus result;
@@ -1925,9 +1919,13 @@ OSStatus AudioUnitEffect::Render(AudioUnitRenderActionFlags *inActionFlags,
                                  UInt32 inNumFrames,
                                  AudioBufferList *ioData)
 {
-   for (int i = 0; i < ioData->mNumberBuffers; i++)
-      ioData->mBuffers[i].mData = mInputList[0].mBuffers[i].mData;
-
+   size_t i = 0;
+   auto size =
+      std::min<size_t>(ioData->mNumberBuffers, PackedArrayCount(mInputList));
+   for (; i < size; ++i)
+      ioData->mBuffers[i].mData = mInputList[i].mData;
+   for (; i < ioData->mNumberBuffers; ++i)
+      ioData->mBuffers[i].mData = nullptr;
    return 0;
 }
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -98,7 +98,7 @@ BlackList[] =
 // at runtime by scanning an effects parameters to determine if dups are present
 // and, if so, enable the clump and parameter IDs.
 #define USE_EXTENDED_NAMES
-class ParameterInfo
+class AudioUnitEffect::ParameterInfo
 {
 public:
    ParameterInfo()
@@ -133,37 +133,26 @@ public:
          name = wxString(info.name);
 
 #if defined(USE_EXTENDED_NAMES)
-      // If the parameter has a non-empty name, then the final parameter name will
-      // be either:
+      // Parameter name may or may not be present.  The modified name will be:
       //
-      //    <parmID,ParameterName>
+      //    <[ParameterName,]parmID>
       //
-      // or (if the name isn't available):
-      //
-      //    <parmID>
-      if (!name.empty())
-      {
+      // (where the [ ] meta-characters denote optionality)
+      // (And any of the characters < , > in ParameterName are replaced with _)
+      if (!name.empty()) {
          name.Replace(idBeg, wxT('_'));
          name.Replace(idSep, wxT('_'));
          name.Replace(idEnd, wxT('_'));
          name.Append(idSep);
       }
-      name = wxString::Format(wxT("%c%s%x%c"),
-                              idBeg,
-                              name,
-                              parmID,
-                              idEnd);
+      name = wxString::Format(wxT("%c%s%x%c"), idBeg, name, parmID, idEnd);
 
-      // If the parameter has a clumpID, then the final parameter name will be
-      // either:
+      // If the parameter has a clumpID, then the final modified name will be:
       //
-      //    <clumpID,clumpName><parmID,ParameterName>
+      //    <[clumpName,]clumpId><[ParameterName,]parmID>
       //
-      // or (if the clumpName isn't available):
-      //
-      //    <clumpID><parmID,ParameterName>
-      if (info.flags & kAudioUnitParameterFlag_HasClump)
-      {
+      // (And any of the characters < , > in clumpName are replaced with _)
+      if (info.flags & kAudioUnitParameterFlag_HasClump) {
          wxString clumpName;
 
          struct AudioUnitParameterNameInfoEx : AudioUnitParameterNameInfo {
@@ -181,20 +170,15 @@ public:
             clumpName.Append(idSep);
          }
          name = wxString::Format(wxT("%c%s%x%c%s"),
-                                 idBeg,
-                                 clumpName,
-                                 info.clumpID,
-                                 idEnd,
-                                 name);
+            idBeg, clumpName, info.clumpID, idEnd, name);
       }
 #endif
-
       return true;
    }
 
-   static const char idBeg = wxT('<');
-   static const char idSep = wxT(',');
-   static const char idEnd = wxT('>');
+   static constexpr char idBeg = wxT('<');
+   static constexpr char idSep = wxT(',');
+   static constexpr char idEnd = wxT('>');
 
    wxString name;
    AudioUnitParameterInfo info;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -53,9 +53,10 @@
 #include "../../widgets/wxPanelWrapper.h"
 
 //
-// When a plug-ins state is saved to the settings file (as a preset),
-// it can be one of two formats, binary or XML.  In either case, it
-// gets base64 encoded before storing.
+// When a plug-in's state is saved to the settings file (as a preset),
+// it is in binary and gets base64 encoded before storing.
+//
+// When exporting, save as XML without base64 encoding.
 //
 // The advantages of XML format is less chance of failures occurring
 // when exporting.  But, it can take a bit more space per preset int
@@ -724,21 +725,22 @@ TranslatableString AudioUnitEffectImportDialog::Import(
       return XO("Unable to read the preset from \"%s\"").Format(fullPath);
    }
 
-   wxString parms = wxBase64Encode(buf.GetData(), len);
-   if (parms.IsEmpty())
-   {
-      return XO("Failed to encode preset from \"%s\"").Format(fullPath);
-   }
+   return mEffect->SaveBlobToConfig(UserPresetsGroup(name),
+      fullPath, buf.GetData(), len, false);
+}
+
+TranslatableString AudioUnitEffect::SaveBlobToConfig(
+   const RegistryPath &group, const wxString &path,
+   const void *blob, size_t len, bool allowEmpty) const
+{
+   // Base64 encode the returned binary property list
+   wxString parms = wxBase64Encode(blob, len);
+   if (!allowEmpty && parms.IsEmpty())
+      return XO("Failed to encode preset from \"%s\"").Format(path);
 
    // And write it to the config
-   wxString group = UserPresetsGroup(name);
-   if (!SetConfig(*mEffect,
-      PluginSettings::Private, group, PRESET_KEY,
-      parms))
-   {
+   if (!SetConfig(*this, PluginSettings::Private, group, PRESET_KEY, parms))
       return XO("Unable to store preset in config file");
-   }
-
    return {};
 }
 
@@ -1643,7 +1645,7 @@ bool AudioUnitEffect::LoadPreset(
       return false;
    }
    
-   // Decode it
+   // Decode it, complementary to what SaveBlobToConfig did
    wxMemoryBuffer buf = wxBase64Decode(parms);
    size_t bufLen = buf.GetDataLen();
    if (!bufLen) {
@@ -1699,11 +1701,9 @@ bool AudioUnitEffect::SavePreset(const RegistryPath & group) const
 
    // Nothing to do if we don't have any data
    if (const auto length = CFDataGetLength(data.get())) {
-      // Base64 encode the returned binary property list
-      auto parms = wxBase64Encode(CFDataGetBytePtr(data.get()), length);
-      // And write it to the config
-      if (!SetConfig(*this,
-         PluginSettings::Private, group, PRESET_KEY, parms))
+      auto error =
+         SaveBlobToConfig(group, {}, CFDataGetBytePtr(data.get()), length);
+      if (!error.empty())
          return false;
    }
    return true;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -23,6 +23,7 @@
 #include <AudioUnit/AudioUnitProperties.h>
 
 #include "../StatefulPerTrackEffect.h"
+#include "CFResources.h"
 #include "PluginProvider.h"
 #include "PluginInterface.h"
 
@@ -38,6 +39,7 @@ using AudioUnitEffectArray = std::vector<std::unique_ptr<AudioUnitEffect>>;
 class AudioUnitEffectExportDialog;
 class AudioUnitEffectImportDialog;
 class AUControl;
+class wxCFStringRef;
 
 //! Generates deleters for std::unique_ptr that clean up AU plugin state
 template<typename T, OSStatus(*fn)(T*)> struct AudioUnitCleaner {
@@ -159,6 +161,16 @@ private:
    bool SetRateAndChannels();
 
    bool CopyParameters(AudioUnit srcUnit, AudioUnit dstUnit);
+
+   //! Obtain dump of the setting state of an AudioUnit instance
+   /*!
+    @param binary if false, then produce XML serialization instead; but
+    AudioUnits does not need to be told the format again to reinterpret the blob
+    @return smart pointer to data, and an error message
+    */
+   std::pair<CF_ptr<CFDataRef>, TranslatableString>
+   MakeBlob(const wxCFStringRef &cfname, bool binary) const;
+
    TranslatableString Export(const wxString & path) const;
    TranslatableString Import(const wxString & path);
    void Notify(AudioUnit unit, AudioUnitParameterID parm) const;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -160,6 +160,8 @@ public:
    // AudioUnitEffect implementation
    
 private:
+   class ParameterInfo;
+
    bool SetRateAndChannels();
 
    bool CopyParameters(AudioUnit srcUnit, AudioUnit dstUnit);

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -202,6 +202,16 @@ private:
 
    // Supply most often used values as defaults for scope and element
    template<typename T>
+   OSStatus GetVariableSizeProperty(AudioUnitPropertyID inID,
+      PackedArrayPtr<T> &pObject,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0) const
+   {
+      return AudioUnitUtils::GetVariableSizeProperty(mUnit.get(),
+         inID, pObject, inScope, inElement);
+   }
+
+   template<typename T>
    OSStatus SetProperty(AudioUnitPropertyID inID, const T &property,
       AudioUnitScope inScope = kAudioUnitScope_Global,
       AudioUnitElement inElement = 0) const

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -289,6 +289,9 @@ private:
    bool BypassEffect(bool bypass);
 
 private:
+   struct Instance;
+   struct Validator;
+
    AudioUnitEffectSettings mSettings;
    //! This function will be rewritten when the effect is really stateless
    AudioUnitEffectSettings &GetSettings(EffectSettings &) const

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -173,6 +173,13 @@ private:
 
    TranslatableString Export(const wxString & path) const;
    TranslatableString Import(const wxString & path);
+   /*!
+    @param path only for formatting error messages
+    @return error message
+    */
+   TranslatableString SaveBlobToConfig(const RegistryPath &group,
+      const wxString &path, const void *blob, size_t len,
+      bool allowEmpty = true) const;
    void Notify(AudioUnit unit, AudioUnitParameterID parm) const;
 
    static OSStatus RenderCallback(void *inRefCon,

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -177,8 +177,6 @@ private:
 
    bool SetRateAndChannels();
 
-   bool CopyParameters(AudioUnit srcUnit, AudioUnit dstUnit);
-
    //! Obtain dump of the setting state of an AudioUnit instance
    /*!
     @param binary if false, then produce XML serialization instead; but

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -191,6 +191,17 @@ private:
 private:
    // Supply most often used values as defaults for scope and element
    template<typename T>
+   OSStatus GetFixedSizeProperty(AudioUnitPropertyID inID, T &property,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0) const
+   {
+      // Supply mUnit.get() to the non-member function
+      return AudioUnitUtils::GetFixedSizeProperty(mUnit.get(),
+         inID, property, inScope, inElement);
+   }
+
+   // Supply most often used values as defaults for scope and element
+   template<typename T>
    OSStatus SetProperty(AudioUnitPropertyID inID, const T &property,
       AudioUnitScope inScope = kAudioUnitScope_Global,
       AudioUnitElement inElement = 0) const

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -144,7 +144,8 @@ public:
       const override;
    std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include <AudioToolbox/AudioUnitUtilities.h>
-#include <AudioUnit/AudioUnit.h>
+#include "AudioUnitUtils.h"
 #include <AudioUnit/AudioUnitProperties.h>
 
 #include "../StatefulPerTrackEffect.h"
@@ -189,6 +189,16 @@ private:
    bool BypassEffect(bool bypass);
 
 private:
+   // Supply most often used values as defaults for scope and element
+   template<typename T>
+   OSStatus SetProperty(AudioUnitPropertyID inID, const T &property,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0) const
+   {
+      // Supply mUnit.get() to the non-member function
+      return AudioUnitUtils::SetProperty(mUnit.get(),
+         inID, property, inScope, inElement);
+   }
 
    const PluginPath mPath;
    const wxString mName;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -187,7 +187,6 @@ public:
    int ShowClientInterface(
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
-   bool MakeListener();
    bool InitializeInstance();
    bool InitializePlugin();
 
@@ -257,14 +256,6 @@ private:
                    UInt32 inNumFrames,
                    AudioBufferList *ioData);
 
-   static void EventListenerCallback(void *inCallbackRefCon,
-                                     void *inObject,
-                                     const AudioUnitEvent *inEvent,
-                                     UInt64 inEventHostTime,
-                                     AudioUnitParameterValue inParameterValue);
-   void EventListener(const AudioUnitEvent *inEvent,
-                      AudioUnitParameterValue inParameterValue);
-
    void GetChannelCounts();
 
    bool MigrateOldConfigFile(
@@ -304,7 +295,6 @@ private:
    const wxString mName;
    const wxString mVendor;
 
-   AudioUnitCleanup<AUEventListenerRef, AUListenerDispose> mEventListenerRef;
    AudioUnitCleanup<AudioUnit, AudioUnitUninitialize> mInitialization;
 
    // Initialized in GetChannelCounts()

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -91,6 +91,7 @@ public:
    bool SupportsAutomation() const override;
 
    bool FetchSettings(AudioUnitEffectSettings &settings) const;
+   bool StoreSettings(const AudioUnitEffectSettings &settings) const;
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
    bool LoadSettings(
@@ -185,9 +186,11 @@ private:
     @return smart pointer to data, and an error message
     */
    std::pair<CF_ptr<CFDataRef>, TranslatableString>
-   MakeBlob(const wxCFStringRef &cfname, bool binary) const;
+   MakeBlob(const AudioUnitEffectSettings &settings,
+      const wxCFStringRef &cfname, bool binary) const;
 
-   TranslatableString Export(const wxString & path) const;
+   TranslatableString Export(
+      const AudioUnitEffectSettings &settings, const wxString & path) const;
    TranslatableString Import(
       AudioUnitEffectSettings &settings, const wxString & path) const;
    /*!
@@ -221,6 +224,8 @@ private:
 
    void GetChannelCounts();
 
+   bool MigrateOldConfigFile(
+      const RegistryPath & group, EffectSettings &settings) const;
    bool LoadPreset(const RegistryPath & group, EffectSettings &settings) const;
 
    //! Interpret the dump made before by MakeBlob
@@ -231,7 +236,8 @@ private:
    TranslatableString InterpretBlob(AudioUnitEffectSettings &settings,
       const wxString &group, const wxMemoryBuffer &buf) const;
 
-   bool SavePreset(const RegistryPath & group) const;
+   bool SavePreset(const RegistryPath & group,
+      const AudioUnitEffectSettings &settings) const;
 
 #if defined(HAVE_AUDIOUNIT_BASIC_SUPPORT)
    bool CreatePlain(wxWindow *parent);

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -15,6 +15,7 @@
 #if USE_AUDIO_UNITS
 
 #include "MemoryX.h"
+#include <functional>
 #include <type_traits>
 #include <vector>
 
@@ -161,6 +162,11 @@ public:
    
 private:
    class ParameterInfo;
+   //! Return value: if true, continue visiting
+   using ParameterVisitor =
+      std::function< bool(const ParameterInfo &pi, AudioUnitParameterID ID) >;
+   //! @return false if parameters could not be retrieved at all, else true
+   bool ForEachParameter(ParameterVisitor visitor) const;
 
    bool SetRateAndChannels();
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -40,6 +40,7 @@ class AudioUnitEffectExportDialog;
 class AudioUnitEffectImportDialog;
 class AUControl;
 class wxCFStringRef;
+class wxMemoryBuffer;
 
 //! Generates deleters for std::unique_ptr that clean up AU plugin state
 template<typename T, OSStatus(*fn)(T*)> struct AudioUnitCleaner {
@@ -205,6 +206,15 @@ private:
    void GetChannelCounts();
 
    bool LoadPreset(const RegistryPath & group, EffectSettings &settings) const;
+
+   //! Interpret the dump made before by MakeBlob
+   /*!
+    @param group only for formatting error messages
+    @return an error message
+    */
+   TranslatableString InterpretBlob(
+      const wxString &group, const wxMemoryBuffer &buf) const;
+
    bool SavePreset(const RegistryPath & group) const;
 
 #if defined(HAVE_AUDIOUNIT_BASIC_SUPPORT)

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -49,6 +49,12 @@ template<typename Ptr, OSStatus(*fn)(Ptr),
    typename T = std::remove_pointer_t<Ptr> /* deduced */ >
 using AudioUnitCleanup = std::unique_ptr<T, AudioUnitCleaner<T, fn>>;
 
+template<> struct PackedArrayTraits<AudioBufferList> {
+   struct header_type { UInt32 mNumberBuffers; };
+   using element_type = AudioBuffer;
+   using iterated_type = element_type;
+};
+
 class AudioUnitEffect final : public StatefulPerTrackEffect
 {
 public:
@@ -244,8 +250,8 @@ private:
 
    AudioTimeStamp mTimeStamp{};
 
-   ArrayOf<AudioBufferList> mInputList;
-   ArrayOf<AudioBufferList> mOutputList;
+   PackedArrayPtr<AudioBufferList> mInputList;
+   PackedArrayPtr<AudioBufferList> mOutputList;
 
    wxWindow *mParent{};
    wxWeakRef<wxDialog> mDialog;

--- a/src/effects/audiounits/AudioUnitUtils.cpp
+++ b/src/effects/audiounits/AudioUnitUtils.cpp
@@ -1,0 +1,19 @@
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file AudioUnitUtils.cpp
+
+  Paul Licameli
+
+***********************************************************************/
+
+#include "AudioUnitUtils.h"
+
+OSStatus AudioUnitUtils::SetPropertyPtr(AudioUnit unit,
+   AudioUnitPropertyID inID, const void *pProperty, UInt32 size,
+   AudioUnitScope inScope, AudioUnitElement inElement)
+{
+   return AudioUnitSetProperty(unit, inID, inScope, inElement,
+      pProperty, size);
+}

--- a/src/effects/audiounits/AudioUnitUtils.cpp
+++ b/src/effects/audiounits/AudioUnitUtils.cpp
@@ -10,6 +10,17 @@
 
 #include "AudioUnitUtils.h"
 
+OSStatus AudioUnitUtils::GetFixedSizePropertyPtr(AudioUnit unit,
+   AudioUnitPropertyID inID, void *pProperty, UInt32 size,
+   AudioUnitScope inScope, AudioUnitElement inElement)
+{
+   auto newSize = size;
+   auto result = AudioUnitGetProperty(unit, inID, inScope, inElement,
+      pProperty, &newSize);
+   assert(newSize <= size);
+   return result;
+}
+
 OSStatus AudioUnitUtils::SetPropertyPtr(AudioUnit unit,
    AudioUnitPropertyID inID, const void *pProperty, UInt32 size,
    AudioUnitScope inScope, AudioUnitElement inElement)

--- a/src/effects/audiounits/AudioUnitUtils.h
+++ b/src/effects/audiounits/AudioUnitUtils.h
@@ -15,6 +15,23 @@
 #include <AudioUnit/AudioUnit.h>
 
 namespace AudioUnitUtils {
+   //! Type-erased function to get an AudioUnit property of fixed size
+   OSStatus GetFixedSizePropertyPtr(AudioUnit unit, AudioUnitPropertyID inID,
+      void *pProperty, UInt32 size, AudioUnitScope inScope,
+      AudioUnitElement inElement);
+
+   //! Get an AudioUnit property of deduced type and fixed size,
+   //! supplying most often used values as defaults for scope and element
+   template<typename T>
+   OSStatus GetFixedSizeProperty(AudioUnit unit, AudioUnitPropertyID inID,
+      T &property,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0)
+   {
+      return GetFixedSizePropertyPtr(unit, inID,
+         &property, sizeof(property), inScope, inElement);
+   }
+
    //! Type-erased function to set an AudioUnit property
    OSStatus SetPropertyPtr(AudioUnit unit, AudioUnitPropertyID inID,
       const void *pProperty, UInt32 size, AudioUnitScope inScope,

--- a/src/effects/audiounits/AudioUnitUtils.h
+++ b/src/effects/audiounits/AudioUnitUtils.h
@@ -1,0 +1,36 @@
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file AudioUnitUtils.h
+
+  Paul Licameli
+
+***********************************************************************/
+
+#ifndef __AUDACITY_AUDIO_UNIT_UTILS__
+#define __AUDACITY_AUDIO_UNIT_UTILS__
+
+#include <algorithm>
+#include <AudioUnit/AudioUnit.h>
+
+namespace AudioUnitUtils {
+   //! Type-erased function to set an AudioUnit property
+   OSStatus SetPropertyPtr(AudioUnit unit, AudioUnitPropertyID inID,
+      const void *pProperty, UInt32 size, AudioUnitScope inScope,
+      AudioUnitElement inElement);
+
+   //! Set an AudioUnit property of deduced type,
+   //! supplying most often used values as defaults for scope and element
+   template<typename T>
+   OSStatus SetProperty(AudioUnit unit, AudioUnitPropertyID inID,
+      const T &property,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0)
+   {
+      return SetPropertyPtr(unit, inID,
+         &property, sizeof(property), inScope, inElement);
+   }
+}
+
+#endif

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1446,7 +1446,8 @@ void LadspaEffect::Validator::PopulateUI(ShuttleGui &S)
 }
 
 std::unique_ptr<EffectUIValidator>
-LadspaEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+LadspaEffect::PopulateOrExchange(ShuttleGui & S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    auto result =
       std::make_unique<Validator>(*this, access, mSampleRate, GetType());

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -113,8 +113,9 @@ public:
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
       const override;
    struct Validator;
-   std::unique_ptr<EffectUIValidator>
-      PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access) override;
+   std::unique_ptr<EffectUIValidator> PopulateOrExchange(
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1502,8 +1502,8 @@ bool LV2Effect::LoadSettings(
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-std::unique_ptr<EffectUIValidator>
-LV2Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> LV2Effect::PopulateUI(ShuttleGui &S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mParent = parent;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -330,7 +330,8 @@ public:
       const override;
    std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1052,12 +1052,13 @@ finish:
 
 int NyquistEffect::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &factory,
-   EffectSettingsAccess &access, bool forceModal)
+   EffectInstance &instance, EffectSettingsAccess &access, bool forceModal)
 {
    int res = wxID_APPLY;
    if (!(Effect::TestUIFlags(EffectManager::kRepeatNyquistPrompt) && mIsPrompt)) {
       // Show the normal (prompt or effect) interface
-      res = Effect::ShowHostInterface(parent, factory, access, forceModal);
+      res = Effect::ShowHostInterface(
+         parent, factory, instance, access, forceModal);
    }
 
 
@@ -1076,7 +1077,9 @@ int NyquistEffect::ShowHostInterface(
    effect.SetCommand(mInputCmd);
 
    // Must give effect its own settings to interpret, not those in access
+   // Let's also give it its own instance
    auto newSettings = effect.MakeSettings();
+   auto newInstance = effect.MakeInstance(newSettings);
    auto newAccess = std::make_shared<SimpleEffectSettingsAccess>(newSettings);
 
    if (IsBatchProcessing()) {
@@ -1087,7 +1090,8 @@ int NyquistEffect::ShowHostInterface(
       effect.LoadSettings(cp, newSettings);
 
       // Show the normal (prompt or effect) interface
-      res = effect.ShowHostInterface(parent, factory, *newAccess, forceModal);
+      res = effect.ShowHostInterface(
+         parent, factory, *newInstance, *newAccess, forceModal);
       if (res) {
          CommandParameters cp;
          effect.SaveSettings(newSettings, cp);
@@ -1097,7 +1101,8 @@ int NyquistEffect::ShowHostInterface(
    else {
       if (!factory)
          return 0;
-      res = effect.ShowHostInterface(parent, factory, *newAccess, false );
+      res = effect.ShowHostInterface(
+         parent, factory, *newInstance, *newAccess, false );
       if (!res)
          return 0;
 
@@ -1111,17 +1116,13 @@ int NyquistEffect::ShowHostInterface(
    return res;
 }
 
-std::unique_ptr<EffectUIValidator>
-NyquistEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> NyquistEffect::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    if (mIsPrompt)
-   {
       BuildPromptWindow(S);
-   }
    else
-   {
       BuildEffectWindow(S);
-   }
    return nullptr;
 }
 

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -120,9 +120,11 @@ public:
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectSettingsAccess &access, bool forceModal = false) override;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      bool forceModal = false) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -526,8 +526,8 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
    return true;
 }
 
-std::unique_ptr<EffectUIValidator>
-VampEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> VampEffect::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    Vamp::Plugin::ProgramList programs = mPlugin->getPrograms();
 

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -70,7 +70,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:


### PR DESCRIPTION
Resolves: #2813

For AudioUnitEffect, do lots of preliminary cleanups, and then change the effects to be stateless

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
