### PR TITLE
Audio unit cleanup 2

### DIFF
--- a/libraries/lib-utility/CMakeLists.txt
+++ b/libraries/lib-utility/CMakeLists.txt
@@ -29,6 +29,7 @@ set( SOURCES
    MemoryStream.h
    Observer.cpp
    Observer.h
+   PackedArray.h
    spinlock.h
    TypedAny.h
 )

--- a/libraries/lib-utility/PackedArray.h
+++ b/libraries/lib-utility/PackedArray.h
@@ -1,0 +1,181 @@
+/*!********************************************************************
+
+ Audacity: A Digital Audio Editor
+
+ @file PackedArray.h
+
+ @brief Deleter for a header contiguous with an array holding a
+ dynamically determined number of elements
+
+ Paul Licameli
+
+ **********************************************************************/
+
+#ifndef __AUDACITY_PACKED_ARRAY__
+#define __AUDACITY_PACKED_ARRAY__
+
+#include <type_traits>
+
+//! Primary template used in PackedArrayDeleter that can be specialized
+template<typename T> struct PackedArrayTraits{
+   // Default assumption is that there is no header and no need to overlay
+   // the element with a type that performs nontrivial destruction
+   struct header_type {};
+   using element_type = T;
+   using iterated_type = T;
+};
+
+//! Deleter for a header structure contiguous with an array of elements
+/*!
+ @tparam Type is the type pointed to, and an explicit specialization of
+ PackedArrayTraits<Type> may redefine the nested types for a non-empty header:
+  - header_type, which overlays the members of Type except the last member;
+   may be non-empty and define a destructor
+  - element_type must be such that the last member of Type is Element[1]; may
+    define a destructor
+ @tparam BaseDeleter manages the main deallocation
+ */
+template<typename Type,
+   template<typename> typename BaseDeleter = std::default_delete>
+struct PackedArrayDeleter : BaseDeleter<Type> {
+   using managed_type = Type;
+   using base_type = BaseDeleter<managed_type>;
+   using traits_type = PackedArrayTraits<managed_type>;
+   using header_type = typename traits_type::header_type;
+   using element_type = typename traits_type::element_type;
+
+   // Check our assumptions about alignments
+   // Imitation of the layout of the managed type.  Be sure to use
+   // empty base class optimization in case header_type is zero-sized.
+   struct Overlay : header_type { element_type elements[1]; };
+   static_assert(sizeof(Overlay) == sizeof(managed_type));
+   // Another sanity check.  Note sizeof() an empty type is nonzero
+   static_assert(offsetof(Overlay, elements) ==
+      std::is_empty_v<header_type> ? 0 : sizeof(header_type));
+
+   //! Nontrivial, implicit constructor of the deleter takes a size, which
+   //! defaults to 0 to allow default contruction of the unique_ptr
+   PackedArrayDeleter(size_t size = 0) noexcept
+      : mCount{ (size - sizeof(header_type)) / sizeof(element_type) } {}
+
+   void operator()(Type *p) const noexcept(noexcept(
+      (void)std::declval<element_type>().~element_type(),
+      (void)std::declval<header_type>().~header_type(),
+      (void)std::declval<base_type>()(p)
+   )) {
+      if (!p)
+         return;
+      auto pOverlay = reinterpret_cast<Overlay*>(p);
+      auto pE = pOverlay->elements + mCount;
+      for (auto count = mCount; count--;)
+         // Do nested deallocations for elements by decreasing subscript
+         (--pE)->~element_type();
+      // Do nested deallocations for main structure
+      pOverlay->~header_type();
+      // main deallocation
+      ((base_type&)*this)(p);
+   }
+
+   size_t GetCount() const { return mCount; }
+private:
+   size_t mCount = 0;
+};
+
+//! Smart pointer type that deallocates with PackedArrayDeleter
+template<typename Type,
+   template<typename> typename BaseDeleter = std::default_delete>
+struct PackedArrayPtr
+   : std::unique_ptr<Type, PackedArrayDeleter<Type, BaseDeleter>>
+{
+   using
+      std::unique_ptr<Type, PackedArrayDeleter<Type, BaseDeleter>>::unique_ptr;
+
+   //! Enables subscripting, if PackedArrayTraits<Type>::iterated_type is
+   //! defined.  Does not check for null!
+   auto &operator[](size_t ii) const
+   {
+      return *(begin(*this) + ii);
+   }
+};
+
+//! Find out how many elements were allocated with a PackedArrayPtr
+template<typename Type, template<typename> typename BaseDeleter>
+inline size_t PackedArrayCount(const PackedArrayPtr<Type, BaseDeleter> &p)
+{
+   return p.get_deleter().GetCount();
+}
+
+//! Enables range-for, if PackedArrayTraits<Type>::iterated_type is defined
+template<typename Type, template<typename> typename BaseDeleter>
+inline auto begin(const PackedArrayPtr<Type, BaseDeleter> &p)
+{
+   void *ptr = p.get();
+   using header_type = typename PackedArrayTraits<Type>::header_type;
+   return reinterpret_cast<typename PackedArrayTraits<Type>::iterated_type *>(
+      ptr
+         ? static_cast<char*>(ptr) +
+            (std::is_empty_v<header_type> ? 0 : sizeof(header_type))
+         : nullptr
+   );
+}
+
+//! Enables range-for, if PackedArrayTraits<Type>::iterated_type is defined
+template<typename Type, template<typename> typename BaseDeleter>
+inline auto end(const PackedArrayPtr<Type, BaseDeleter> &p)
+{
+   auto result = begin(p);
+   if (result)
+      result += PackedArrayCount(p);
+   return result;
+}
+
+struct PackedArray_t{};
+//! Tag argument to distinguish an overload of ::operator new
+static constexpr inline PackedArray_t PackedArray;
+
+//! Allocator for objects managed by PackedArrayPtr enlarges the size request
+//! that the compiler makes
+inline void *operator new(size_t size, PackedArray_t, size_t enlarged) {
+   return ::operator new(std::max(size, enlarged));
+}
+
+//! Complementary operator delete in case of exceptions in a new-expression
+inline void operator delete(void *p, PackedArray_t, size_t) {
+   ::operator delete(p);
+}
+
+//! Allocate a PackedArrayPtr<Type> holding at least `enlarged` bytes
+/*!
+ Usage: PackedArrayAllocateBytes<Type>(bytes)(constructor arguments for Type)
+ Meant to resemble placement-new syntax with separation of allocator and
+ constructor arguments
+ */
+template<typename Type> auto PackedArrayAllocateBytes(size_t enlarged)
+{
+   return [enlarged](auto &&...args) {
+      return PackedArrayPtr<Type>{
+         safenew(PackedArray, enlarged)
+            Type{ std::forward<decltype(args)>(args)... },
+         std::max(sizeof(Type), enlarged) // Deleter's constructor argument
+      };
+   };
+}
+
+//! Allocate a PackedArrayPtr<Type> holding `count` elements
+/*!
+ Usage: PackedArrayAllocateCount<Type>(count)(constructor arguments for Type)
+ Meant to resemble placement-new syntax with separation of allocator and
+ constructor arguments
+
+ If PackedArrayTraits<Type> defines a nonempty header, the result always holds
+ at least one element
+ */
+template<typename Type> auto PackedArrayAllocateCount(size_t count)
+{
+   using header_type = typename PackedArrayTraits<Type>::header_type;
+   size_t bytes = (std::is_empty_v<header_type> ? 0 : sizeof(header_type))
+      + count * sizeof(typename PackedArrayTraits<Type>::element_type);
+   return PackedArrayAllocateBytes<Type>(bytes);
+}
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -567,6 +567,8 @@ list( APPEND SOURCES
          effects/audiounits/AUControl.mm
          effects/audiounits/AudioUnitEffect.cpp
          effects/audiounits/AudioUnitEffect.h
+         effects/audiounits/AudioUnitUtils.cpp
+         effects/audiounits/AudioUnitUtils.h
       >
 
       # Ladspa Effects

--- a/src/effects/audiounits/AUControl.mm
+++ b/src/effects/audiounits/AUControl.mm
@@ -32,6 +32,7 @@
 #endif
 
 #include "MemoryX.h"
+#include "AudioUnitUtils.h"
 
 class AUControlImpl final : public wxWidgetCocoaImpl
 {
@@ -275,35 +276,9 @@ void AUControl::OnSize(wxSizeEvent & evt)
 
 void AUControl::CreateCocoa()
 {
-   OSStatus result;
-   UInt32 dataSize;
-
-   result = AudioUnitGetPropertyInfo(mUnit,
-                                     kAudioUnitProperty_CocoaUI,
-                                     kAudioUnitScope_Global, 
-                                     0,
-                                     &dataSize,
-                                     NULL);
-   if (result != noErr)
-      return;
-
-   int cnt = (dataSize - sizeof(CFURLRef)) / sizeof(CFStringRef);
-   if (cnt == 0)
-      return;
-
-   ArrayOf<char> buffer{ dataSize };
-   auto viewInfo = (AudioUnitCocoaViewInfo *) buffer.get();
-   if (viewInfo == NULL)
-      return;
-
-   // Get the view info
-   result = AudioUnitGetProperty(mUnit,
-                                 kAudioUnitProperty_CocoaUI,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 viewInfo,
-                                 &dataSize);
-   if (result == noErr) {
+   PackedArrayPtr<AudioUnitCocoaViewInfo> viewInfo;
+   if (!AudioUnitUtils::GetVariableSizeProperty(mUnit,
+      kAudioUnitProperty_CocoaUI, viewInfo)) {
       // Looks like the AU has a Cocoa UI, so load the factory class
       auto bundleLoc =
          static_cast<NSURL *>(viewInfo->mCocoaAUViewBundleLocation);
@@ -314,22 +289,15 @@ void AUControl::CreateCocoa()
             // Load the class from the bundle
             if (auto factoryClass = [bundle classNamed:viewClass])
                // Create an instance of the class
-               if (id factoryInst = [[[factoryClass alloc] init] autorelease])
+               if (id factoryInst = [[[factoryClass alloc] init] autorelease]) {
                   // Create the view, suggesting a reasonable size
-                  mView = [factoryInst uiViewForAudioUnit:mUnit
-                                                 withSize:NSSize{800, 600}];
-
-      if (viewInfo->mCocoaAUViewBundleLocation != nil)
-         CFRelease(viewInfo->mCocoaAUViewBundleLocation);
-
-      for (int i = 0; i < cnt; i++)
-         CFRelease(viewInfo->mCocoaAUViewClass[i]);
+                  if ((mView = [factoryInst uiViewForAudioUnit:mUnit
+                                                 withSize:NSSize{800, 600}]))
+                     [mView retain];
+                  else
+                     return;
+               }
    }
-
-   if (!mView)
-      return;
-
-   [mView retain];
 
    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
    [center addObserver:mAUView
@@ -427,42 +395,16 @@ void AUControl::ForceRedraw()
 
 void AUControl::CreateCarbon()
 {
-   OSStatus result;
-   UInt32 dataSize;
-
-   result = AudioUnitGetPropertyInfo(mUnit,
-                                     kAudioUnitProperty_GetUIComponentList,
-                                     kAudioUnitScope_Global, 
-                                     0,
-                                     &dataSize,
-                                     NULL);
-   if (result != noErr)
-      return;
-
-   int cnt = (dataSize - sizeof(CFURLRef)) / sizeof(CFStringRef);
-   if (cnt == 0)
-      return;
-
-   ArrayOf<char> buffer{ dataSize };
-   auto compList = (AudioComponentDescription *) buffer.get();
-   if (compList == NULL)
-      return;
-
-   // Get the view info
-   result = AudioUnitGetProperty(mUnit,
-                                 kAudioUnitProperty_GetUIComponentList,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 compList,
-                                 &dataSize);
-   if (result != noErr)
+   PackedArrayPtr<AudioComponentDescription> compList;
+   if (AudioUnitUtils::GetVariableSizeProperty(mUnit,
+      kAudioUnitProperty_GetUIComponentList, compList))
       return;
 
    // Get the component
    AudioComponent comp = AudioComponentFindNext(nullptr, &compList[0]);
 
    // Try to create an instance
-   result = AudioComponentInstanceNew(comp, &mInstance);
+   auto result = AudioComponentInstanceNew(comp, &mInstance);
 
    if (result != noErr)
       return;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1638,34 +1638,9 @@ bool AudioUnitEffect::LoadPreset(
    }
    
    // Decode it, complementary to what SaveBlobToConfig did
-   wxMemoryBuffer buf = wxBase64Decode(parms);
-   size_t bufLen = buf.GetDataLen();
-   if (!bufLen) {
-      wxLogError(wxT("Failed to decode \"%s\" preset"), group);
-      return false;
-   }
-   const uint8_t *bufPtr = static_cast<uint8_t *>(buf.GetData());
-
-   // Create a CFData object that references the decoded preset
-   CF_ptr<CFDataRef> data{
-      CFDataCreateWithBytesNoCopy(kCFAllocatorDefault,
-         bufPtr, bufLen, kCFAllocatorNull)
-   };
-   if (!data) {
-      wxLogError(wxT("Failed to convert \"%s\" preset to internal format"),
-         group);
-      return false;
-   }
-
-   // Convert it back to a property list.
-   CF_ptr<CFPropertyListRef> content{
-      CFPropertyListCreateWithData(kCFAllocatorDefault,
-         data.get(), kCFPropertyListImmutable, nullptr,
-         // TODO might retrieve more error information
-         nullptr)
-   };
-   if (!content) {
-      wxLogError(wxT("Failed to create property list for \"%s\" preset"), group);
+   auto error = InterpretBlob(group, wxBase64Decode(parms));
+   if (!error.empty()) {
+      wxLogError(error.Debug());
       return false;
    }
 
@@ -1673,15 +1648,42 @@ bool AudioUnitEffect::LoadPreset(
    if (mpControl)
       mpControl->ForceRedraw();
 
-   // Finally, update the properties and parameters
-   if (SetProperty(kAudioUnitProperty_ClassInfo, content)) {
-      wxLogError(wxT("Failed to set class info for \"%s\" preset"), group);
-      return false;
-   }
-
    // Notify interested parties of change and propagate to slaves
    Notify(mUnit.get(), kAUParameterListener_AnyParameter);
    return true;
+}
+
+TranslatableString AudioUnitEffect::InterpretBlob(
+   const RegistryPath &group, const wxMemoryBuffer &buf) const
+{
+   size_t bufLen = buf.GetDataLen();
+   if (!bufLen)
+      return XO("Failed to decode \"%s\" preset").Format(group);
+
+   // Create a CFData object that references the decoded preset
+   const auto bufPtr = static_cast<const uint8_t *>(buf.GetData());
+   CF_ptr<CFDataRef> data{ CFDataCreateWithBytesNoCopy(kCFAllocatorDefault,
+      bufPtr, bufLen, kCFAllocatorNull)
+   };
+   if (!data)
+      return XO("Failed to convert \"%s\" preset to internal format")
+         .Format(group);
+
+   // Convert it back to a property list
+   CF_ptr<CFPropertyListRef> content{
+      CFPropertyListCreateWithData(kCFAllocatorDefault,
+      data.get(), kCFPropertyListImmutable, nullptr,
+      // TODO might retrieve more error information
+      nullptr)
+   };
+   if (!content)
+      return XO("Failed to create property list for \"%s\" preset")
+         .Format(group);
+
+   // Finally, update the properties and parameters
+   if (SetProperty(kAudioUnitProperty_ClassInfo, content.get()))
+      return XO("Failed to set class info for \"%s\" preset").Format(group);
+   return {};
 }
 
 bool AudioUnitEffect::SavePreset(const RegistryPath & group) const
@@ -1858,27 +1860,9 @@ TranslatableString AudioUnitEffect::Import(const wxString & path)
    if (f.Read(buf.GetData(), len) != len || f.Error())
       return XO("Unable to read the preset from \"%s\"").Format(path);
 
-   // Create a CFData object that references the decoded preset
-   CF_ptr<CFDataRef> data{
-      CFDataCreateWithBytesNoCopy(kCFAllocatorDefault,
-         static_cast<const UInt8 *>(buf.GetData()), len, kCFAllocatorNull)
-   };
-   if (!data)
-      return XO("Failed to convert preset to internal format");
-
-   // Convert it back to a property list.
-   CF_ptr<CFPropertyListRef> content{
-      CFPropertyListCreateWithData(kCFAllocatorDefault,
-         data.get(), kCFPropertyListImmutable, nullptr,
-         // TODO might retrieve more error information
-         nullptr)
-   };
-   if (!content)
-      return XO("Failed to create property list for preset");
-
-   // Finally, update the properties and parameters
-   if (SetProperty(kAudioUnitProperty_ClassInfo, content))
-      return XO("Failed to set class info for \"%s\" preset");
+   const auto error = InterpretBlob(path, buf);
+   if (!error.empty())
+      return error;
 
    // Notify interested parties of change and propagate to slaves
    Notify(mUnit.get(), kAUParameterListener_AnyParameter);

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1016,6 +1016,7 @@ bool AudioUnitEffect::InitializePlugin()
    if (!InitializeInstance())
       return false;
 
+
    // Consult preferences
    // Decide mUseLatency, which affects GetLatency(), which is actually used
    // so far only in destructive effect processing
@@ -1037,7 +1038,6 @@ bool AudioUnitEffect::InitializePlugin()
       SetConfig(*this, PluginSettings::Private,
          FactoryDefaultsGroup(), InitializedKey, true);
    }
-
    return true;
 }
 
@@ -1234,8 +1234,6 @@ size_t AudioUnitEffect::GetTailSize() const
 bool AudioUnitEffect::ProcessInitialize(
    EffectSettings &, sampleCount, ChannelNames chanMap)
 {
-   OSStatus result;
-
    mInputList.reinit(mAudioIns);
    mInputList[0].mNumberBuffers = mAudioIns;
    
@@ -1248,33 +1246,22 @@ bool AudioUnitEffect::ProcessInitialize(
    mTimeStamp.mFlags = kAudioTimeStampSampleTimeValid;
 
    if (!SetRateAndChannels())
-   {
       return false;
-   }
 
-   AURenderCallbackStruct callbackStruct;
-   callbackStruct.inputProc = RenderCallback;
-   callbackStruct.inputProcRefCon = this;
-   result = AudioUnitSetProperty(mUnit.get(),
-                                 kAudioUnitProperty_SetRenderCallback,
-                                 kAudioUnitScope_Input,
-                                 0,
-                                 &callbackStruct,
-                                 sizeof(AURenderCallbackStruct));
-   if (result != noErr) {
+   if (SetProperty(kAudioUnitProperty_SetRenderCallback,
+      AURenderCallbackStruct{ RenderCallback, this },
+      kAudioUnitScope_Input)) {
       wxLogError("Setting input render callback failed.\n");
       return false;
    }
 
-   result = AudioUnitReset(mUnit.get(), kAudioUnitScope_Global, 0);
-   if (result != noErr)
+   if (AudioUnitReset(mUnit.get(), kAudioUnitScope_Global, 0))
       return false;
 
    if (!BypassEffect(false))
       return false;
 
    mLatencyDone = false;
-
    return true;
 }
 
@@ -1576,22 +1563,13 @@ bool AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &) const
    if (result != noErr || id < 0 || id >= CFArrayGetCount(array.get()))
       return false;
 
-   const AUPreset *preset =
-      static_cast<const AUPreset*>(CFArrayGetValueAtIndex(array.get(), id));
-
-   result = AudioUnitSetProperty(mUnit.get(),
-                                 kAudioUnitProperty_PresentPreset,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 preset,
-                                 sizeof(AUPreset));
-   if (result == noErr)
-   {
+   if (!SetProperty(kAudioUnitProperty_PresentPreset,
+      *static_cast<const AUPreset*>(CFArrayGetValueAtIndex(array.get(), id)))) {
       // Notify interested parties of change and propagate to slaves
       Notify(mUnit.get(), kAUParameterListener_AnyParameter);
+      return true;
    }
-
-   return result == noErr;
+   return false;
 }
 
 bool AudioUnitEffect::LoadFactoryDefaults(EffectSettings &settings) const
@@ -1854,30 +1832,20 @@ bool AudioUnitEffect::LoadPreset(
    wxString parms;
 
    // Attempt to load old preset parameters and resave using new method
-   if (GetConfig(*this,
-      PluginSettings::Private, group, wxT("Parameters"),
-      parms, wxEmptyString))
-   {
+   if (GetConfig(*this, PluginSettings::Private, group, wxT("Parameters"),
+      parms, wxEmptyString)) {
       CommandParameters eap;
       if (eap.SetParameters(parms))
-      {
          if (LoadSettings(eap, settings))
-         {
             if (SavePreset(group))
-            {
                RemoveConfig(*this, PluginSettings::Private,
                   group, wxT("Parameters"));
-            }
-         }
-      }
       return true;
    }
 
    // Retrieve the preset
-   if (!GetConfig(*this,
-      PluginSettings::Private, group, PRESET_KEY, parms,
-      wxEmptyString))
-   {
+   if (!GetConfig(*this, PluginSettings::Private, group, PRESET_KEY, parms,
+      wxEmptyString)) {
       // Commented "CurrentSettings" gets tried a lot and useless messages appear
       // in the log
       //wxLogError(wxT("Preset key \"%s\" not found in group \"%s\""), PRESET_KEY, group);
@@ -1887,8 +1855,7 @@ bool AudioUnitEffect::LoadPreset(
    // Decode it
    wxMemoryBuffer buf = wxBase64Decode(parms);
    size_t bufLen = buf.GetDataLen();
-   if (!bufLen)
-   {
+   if (!bufLen) {
       wxLogError(wxT("Failed to decode \"%s\" preset"), group);
       return false;
    }
@@ -1897,22 +1864,20 @@ bool AudioUnitEffect::LoadPreset(
    // Create a CFData object that references the decoded preset
    CF_ptr<CFDataRef> data{
       CFDataCreateWithBytesNoCopy(kCFAllocatorDefault,
-                                  bufPtr,
-                                  bufLen,
-                                  kCFAllocatorNull)
+         bufPtr, bufLen, kCFAllocatorNull)
    };
    if (!data) {
-      wxLogError(wxT("Failed to convert \"%s\" preset to internal format"), group);
+      wxLogError(wxT("Failed to convert \"%s\" preset to internal format"),
+         group);
       return false;
    }
 
    // Convert it back to a property list.
    CF_ptr<CFPropertyListRef> content{
       CFPropertyListCreateWithData(kCFAllocatorDefault,
-                                   data.get(),
-                                   kCFPropertyListImmutable,
-                                   NULL,
-                                   NULL)
+         data.get(), kCFPropertyListImmutable, nullptr,
+         // TODO might retrieve more error information
+         nullptr)
    };
    if (!content) {
       wxLogError(wxT("Failed to create property list for \"%s\" preset"), group);
@@ -1924,21 +1889,13 @@ bool AudioUnitEffect::LoadPreset(
       mpControl->ForceRedraw();
 
    // Finally, update the properties and parameters
-   OSStatus result;
-   result = AudioUnitSetProperty(mUnit.get(),
-                                 kAudioUnitProperty_ClassInfo,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &content,
-                                 sizeof(content));
-   if (result != noErr) {
+   if (SetProperty(kAudioUnitProperty_ClassInfo, content)) {
       wxLogError(wxT("Failed to set class info for \"%s\" preset"), group);
       return false;
    }
 
    // Notify interested parties of change and propagate to slaves
    Notify(mUnit.get(), kAUParameterListener_AnyParameter);
-
    return true;
 }
 
@@ -1947,18 +1904,10 @@ bool AudioUnitEffect::SavePreset(const RegistryPath & group) const
    // First set the name of the preset
    wxCFStringRef cfname(wxFileNameFromPath(group));
 
-   // Define the preset property
-   AUPreset preset;
-   preset.presetNumber = -1; // indicates user preset
-   preset.presetName = cfname;
-
-   // And set it in the audio unit
-   AudioUnitSetProperty(mUnit.get(),
-                        kAudioUnitProperty_PresentPreset,
-                        kAudioUnitScope_Global,
-                        0,
-                        &preset,
-                        sizeof(preset));
+   // Define the preset property and set it in the audio unit
+   if (SetProperty(kAudioUnitProperty_PresentPreset,
+         AUPreset{ -1 /* indicates user preset */, cfname }))
+      return false;
 
    // Now retrieve the preset content
    CF_ptr<CFPropertyListRef> content;
@@ -1973,38 +1922,29 @@ bool AudioUnitEffect::SavePreset(const RegistryPath & group) const
    // And convert it to serialized binary data
    CF_ptr<CFDataRef> data{
       CFPropertyListCreateData(kCFAllocatorDefault,
-                               content.get(),
-                               PRESET_FORMAT,
-                               0,
-                               NULL)
+         content.get(), PRESET_FORMAT, 0,
+         // TODO might retrieve more error information
+         nullptr)
    };
    if (!data)
-   {
       return false;
-   }
 
    // Nothing to do if we don't have any data
-   SInt32 length = CFDataGetLength(data.get());
-   if (length)
-   {
+   if (const auto length = CFDataGetLength(data.get())) {
       // Base64 encode the returned binary property list
-      wxString parms = wxBase64Encode(CFDataGetBytePtr(data.get()), length);
-
+      auto parms = wxBase64Encode(CFDataGetBytePtr(data.get()), length);
       // And write it to the config
       if (!SetConfig(*this,
          PluginSettings::Private, group, PRESET_KEY, parms))
-      {
          return false;
-      }
    }
-
    return true;
 }
 
 bool AudioUnitEffect::SetRateAndChannels()
 {
    mInitialization.reset();
-   AudioStreamBasicDescription streamFormat {
+   AudioStreamBasicDescription streamFormat{
       // Float64 mSampleRate;
       mSampleRate,
 
@@ -2045,8 +1985,7 @@ bool AudioUnitEffect::SetRateAndChannels()
    };
    for (const auto &[nChannels, scope, msg] : infos) {
       if (nChannels) {
-         if (AudioUnitSetProperty(mUnit.get(), kAudioUnitProperty_SampleRate,
-            scope, 0, &mSampleRate, sizeof(mSampleRate))) {
+         if (SetProperty(kAudioUnitProperty_SampleRate, mSampleRate, scope)) {
             wxLogError("%ls Didn't accept sample rate on %s\n",
                // Exposing internal name only in logging
                GetSymbol().Internal().wx_str(), msg);
@@ -2054,9 +1993,8 @@ bool AudioUnitEffect::SetRateAndChannels()
          }
          if (scope != kAudioUnitScope_Global) {
             streamFormat.mChannelsPerFrame = nChannels;
-            if (AudioUnitSetProperty(mUnit.get(),
-               kAudioUnitProperty_StreamFormat,
-               scope, 0, &streamFormat, sizeof(streamFormat))) {
+            if (SetProperty(kAudioUnitProperty_StreamFormat,
+               streamFormat, scope)) {
                wxLogError("%ls didn't accept stream format on %s\n",
                   // Exposing internal name only in logging
                   GetSymbol().Internal().wx_str(), msg);
@@ -2092,16 +2030,9 @@ bool AudioUnitEffect::CopyParameters(AudioUnit srcUnit, AudioUnit dstUnit)
       return false;
 
    // Set the destination AUs state from the source AU's content
-   result = AudioUnitSetProperty(dstUnit,
-                                 kAudioUnitProperty_ClassInfo,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &content,
-                                 sizeof(content));
-   if (result != noErr)
-   {
+   if (AudioUnitUtils::SetProperty(dstUnit,
+      kAudioUnitProperty_ClassInfo, content))
       return false;
-   }
 
    // Notify interested parties
    Notify(dstUnit, kAUParameterListener_AnyParameter);
@@ -2114,35 +2045,20 @@ TranslatableString AudioUnitEffect::Export(const wxString & path) const
    // Create the file
    wxFFile f(path, wxT("wb"));
    if (!f.IsOpened())
-   {
       return XO("Couldn't open \"%s\"").Format(path);
-   }
 
    // First set the name of the preset
    wxCFStringRef cfname(wxFileName(path).GetName());
 
-   // Define the preset property
-   AUPreset preset;
-   preset.presetNumber = -1; // indicates user preset
-   preset.presetName = cfname;
-
-   // And set it in the audio unit
-   OSStatus result;
-   result = AudioUnitSetProperty(mUnit.get(),
-                                 kAudioUnitProperty_PresentPreset,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &preset,
-                                 sizeof(preset));
-   if (result != noErr)
-   {
+   // Define the preset property and set it in the audio unit
+   if (SetProperty(kAudioUnitProperty_PresentPreset,
+      AUPreset{ -1 /* indicates user preset */, cfname }))
       return XO("Failed to set preset name");
-   }
 
    // Now retrieve the preset content
    CF_ptr<CFPropertyListRef> content;
    UInt32 size = sizeof(content);
-   result = AudioUnitGetProperty(mUnit.get(),
+   auto result = AudioUnitGetProperty(mUnit.get(),
                                  kAudioUnitProperty_ClassInfo,
                                  kAudioUnitScope_Global,
                                  0,
@@ -2154,10 +2070,9 @@ TranslatableString AudioUnitEffect::Export(const wxString & path) const
    // And convert it to serialized XML data
    CF_ptr<CFDataRef> data{
       CFPropertyListCreateData(kCFAllocatorDefault,
-                               content.get(),
-                               kCFPropertyListXMLFormat_v1_0,
-                               0,
-                               NULL)
+         content.get(), kCFPropertyListXMLFormat_v1_0, 0,
+         // TODO might retrieve more error information
+         nullptr)
    };
    if (!data)
       return XO("Failed to convert property list to XML data");
@@ -2165,18 +2080,13 @@ TranslatableString AudioUnitEffect::Export(const wxString & path) const
    // Nothing to do if we don't have any data
    SInt32 length = CFDataGetLength(data.get());
    if (!length)
-   {
       return XO("XML data is empty after conversion");
-   }
 
    // Write XML data
    if (f.Write(CFDataGetBytePtr(data.get()), length) != length || f.Error())
-   {
       return XO("Failed to write XML preset to \"%s\"").Format(path);
-   }
 
    f.Close();
-
    return {};
 }
 
@@ -2185,17 +2095,13 @@ TranslatableString AudioUnitEffect::Import(const wxString & path)
    // Open the preset
    wxFFile f(path, wxT("r"));
    if (!f.IsOpened())
-   {
       return XO("Couldn't open \"%s\"").Format(path);
-   }
 
    // Load it into the buffer
    size_t len = f.Length();
    wxMemoryBuffer buf(len);
    if (f.Read(buf.GetData(), len) != len || f.Error())
-   {
       return XO("Unable to read the preset from \"%s\"").Format(path);
-   }
 
    // Create a CFData object that references the decoded preset
    CF_ptr<CFDataRef> data{
@@ -2203,30 +2109,20 @@ TranslatableString AudioUnitEffect::Import(const wxString & path)
          static_cast<const UInt8 *>(buf.GetData()), len, kCFAllocatorNull)
    };
    if (!data)
-   {
       return XO("Failed to convert preset to internal format");
-   }
 
    // Convert it back to a property list.
    CF_ptr<CFPropertyListRef> content{
       CFPropertyListCreateWithData(kCFAllocatorDefault,
-                                   data.get(),
-                                   kCFPropertyListImmutable,
-                                   NULL,
-                                   NULL)
+         data.get(), kCFPropertyListImmutable, nullptr,
+         // TODO might retrieve more error information
+         nullptr)
    };
    if (!content)
       return XO("Failed to create property list for preset");
 
    // Finally, update the properties and parameters
-   OSStatus result;
-   result = AudioUnitSetProperty(mUnit.get(),
-                                 kAudioUnitProperty_ClassInfo,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &content,
-                                 sizeof(content));
-   if (result != noErr)
+   if (SetProperty(kAudioUnitProperty_ClassInfo, content))
       return XO("Failed to set class info for \"%s\" preset");
 
    // Notify interested parties of change and propagate to slaves
@@ -2478,22 +2374,8 @@ void AudioUnitEffect::GetChannelCounts()
 
 bool AudioUnitEffect::BypassEffect(bool bypass)
 {
-   OSStatus result;
-
    UInt32 value = (bypass ? 1 : 0);
-
-   result = AudioUnitSetProperty(mUnit.get(),
-                                 kAudioUnitProperty_BypassEffect,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 &value,
-                                 sizeof(value));
-   if (result != noErr)
-   {
-      return false;
-   }
-
-   return true;
+   return !SetProperty(kAudioUnitProperty_BypassEffect, value);
 }
 
 #endif

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -23,7 +23,6 @@
 #include "ModuleManager.h"
 #include "SampleCount.h"
 #include "ConfigInterface.h"
-#include "CFResources.h"
 
 #include <wx/defs.h>
 #include <wx/base64.h>
@@ -867,49 +866,16 @@ bool AudioUnitEffect::SupportsRealtime() const
 
 bool AudioUnitEffect::SupportsAutomation() const
 {
-   OSStatus result;
-   UInt32 dataSize;
-   Boolean isWritable;
-
-   result = AudioUnitGetPropertyInfo(mUnit.get(),
-                                     kAudioUnitProperty_ParameterList,
-                                     kAudioUnitScope_Global,
-                                     0,
-                                     &dataSize,
-                                     &isWritable);
-   if (result != noErr)
-   {
+   PackedArrayPtr<AudioUnitParameterID> array;
+   if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
       return false;
-   }
-
-   UInt32 cnt = dataSize / sizeof(AudioUnitParameterID);
-   ArrayOf<AudioUnitParameterID> array{cnt};
-
-   result = AudioUnitGetProperty(mUnit.get(),
-                                 kAudioUnitProperty_ParameterList,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 array.get(),
-                                 &dataSize);  
-   if (result != noErr)
-   {
-      return false;
-   }
-
-   for (int i = 0; i < cnt; i++)
-   {
+   for (const auto &ID : array) {
       ParameterInfo pi;
-
-      if (pi.Get(mUnit.get(), array[i]))
-      {
+      if (pi.Get(mUnit.get(), ID))
          if (pi.info.flags & kAudioUnitParameterFlag_IsWritable)
-         {
             // All we need is one
             return true;
-         }
-      }
    }
-
    return false;
 }
 
@@ -1031,50 +997,16 @@ bool AudioUnitEffect::MakeListener()
       event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
       event.mArgument.mParameter.mElement = 0;
 
-      UInt32 dataSize;
-      Boolean isWritable;
-
       // Retrieve the list of parameters
-      result = AudioUnitGetPropertyInfo(mUnit.get(),
-                                        kAudioUnitProperty_ParameterList,
-                                        kAudioUnitScope_Global,
-                                        0,
-                                        &dataSize,
-                                        &isWritable);
-      if (result != noErr)
-      {
+      PackedArrayPtr<AudioUnitParameterID> array;
+      if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
          return false;
-      }
 
-      // And get them
-      UInt32 cnt = dataSize / sizeof(AudioUnitParameterID);
-      if (cnt != 0)
-      {
-         ArrayOf<AudioUnitParameterID> array {cnt};
-
-         result = AudioUnitGetProperty(mUnit.get(),
-                                       kAudioUnitProperty_ParameterList,
-                                       kAudioUnitScope_Global,
-                                       0,
-                                       array.get(),
-                                       &dataSize);  
-         if (result != noErr)
-         {
+      // Register them as something we're interested in
+      for (const auto &ID : array) {
+         event.mArgument.mParameter.mParameterID = ID;
+         if (AUEventListenerAddEventType(mEventListenerRef.get(), this, &event))
             return false;
-         }
-
-         // Register them as something we're interested in
-         for (int i = 0; i < cnt; i++)
-         {
-            event.mArgument.mParameter.mParameterID = array[i];
-            result = AUEventListenerAddEventType(mEventListenerRef.get(),
-                                                 this,
-                                                 &event);
-            if (result != noErr)
-            {
-               return false;
-            }
-         }
       }
 
       event.mEventType = kAudioUnitEvent_PropertyChange;
@@ -1104,7 +1036,7 @@ bool AudioUnitEffect::MakeListener()
       bool hasCarbon =
          !GetFixedSizeProperty(kAudioUnitProperty_GetUIComponentList, compDesc);
 
-      mInteractive = (cnt > 0) || hasCocoa || hasCarbon;
+      mInteractive = (PackedArrayCount(array) > 0) || hasCocoa || hasCarbon;
    }
 
    return true;
@@ -1358,118 +1290,49 @@ int AudioUnitEffect::ShowClientInterface(
 bool AudioUnitEffect::SaveSettings(
    const EffectSettings &, CommandParameters & parms) const
 {
-   OSStatus result;
-   UInt32 dataSize;
-   Boolean isWritable;
-
-   result = AudioUnitGetPropertyInfo(mUnit.get(),
-                                     kAudioUnitProperty_ParameterList,
-                                     kAudioUnitScope_Global,
-                                     0,
-                                     &dataSize,
-                                     &isWritable);
-   if (result != noErr)
-   {
+   PackedArrayPtr<AudioUnitParameterID> array;
+   if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
       return false;
-   }
-
-   UInt32 cnt = dataSize / sizeof(AudioUnitParameterID);
-   ArrayOf<AudioUnitParameterID> array {cnt};
-
-   result = AudioUnitGetProperty(mUnit.get(),
-                                 kAudioUnitProperty_ParameterList,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 array.get(),
-                                 &dataSize);  
-   if (result != noErr)
-   {
-      return false;
-   }
-
-   for (int i = 0; i < cnt; i++)
-   {
+   for (const auto &ID : array) {
       ParameterInfo pi;
-
-      if (!pi.Get(mUnit.get(), array[i]))
-      {
+      if (!pi.Get(mUnit.get(), ID))
          // Probably failed because of invalid parameter which can happen
          // if a plug-in is in a certain mode that doesn't contain the
          // parameter.  In any case, just ignore it.
          continue;
-      }
-
       AudioUnitParameterValue value;
-      result = AudioUnitGetParameter(mUnit.get(), array[i],
-         kAudioUnitScope_Global, 0, &value);
-      if (result != noErr)
-      {
+      if (AudioUnitGetParameter(mUnit.get(), ID, kAudioUnitScope_Global, 0,
+         &value))
          // Probably failed because of invalid parameter which can happen
          // if a plug-in is in a certain mode that doesn't contain the
          // parameter.  In any case, just ignore it.
          continue;
-      }
-
       parms.Write(pi.name, value);
    }
-
    return true;
 }
 
 bool AudioUnitEffect::LoadSettings(
    const CommandParameters & parms, EffectSettings &settings) const
 {
-   OSStatus result;
-   UInt32 dataSize;
-   Boolean isWritable;
-
-   result = AudioUnitGetPropertyInfo(mUnit.get(),
-                                     kAudioUnitProperty_ParameterList,
-                                     kAudioUnitScope_Global,
-                                     0,
-                                     &dataSize,
-                                     &isWritable);
-   if (result != noErr)
-   {
+   PackedArrayPtr<AudioUnitParameterID> array;
+   if (GetVariableSizeProperty(kAudioUnitProperty_ParameterList, array))
       return false;
-   }
-
-   UInt32 cnt = dataSize / sizeof(AudioUnitParameterID);
-   ArrayOf<AudioUnitParameterID> array {cnt};
-
-   result = AudioUnitGetProperty(mUnit.get(),
-                                 kAudioUnitProperty_ParameterList,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 array.get(),
-                                 &dataSize);  
-   if (result != noErr)
-   {
-      return false;
-   }
-
-   for (int i = 0; i < cnt; i++)
-   {
+   for (const auto &ID : array) {
       ParameterInfo pi;
-
-      if (!pi.Get(mUnit.get(), array[i]))
-      {
+      if (!pi.Get(mUnit.get(), ID))
          // Probably failed because of invalid parameter which can happen
          // if a plug-in is in a certain mode that doesn't contain the
          // parameter.  In any case, just ignore it.
          continue;
-      }
-
       double d = 0.0;
-      if (parms.Read(pi.name, &d))
-      {
-         AudioUnitParameterValue value = d;
-         AudioUnitSetParameter(mUnit.get(), array[i], kAudioUnitScope_Global,
-            0, value, 0);
-         Notify(mUnit.get(), array[i]);
+      if (parms.Read(pi.name, &d)) {
+         if (AudioUnitSetParameter(mUnit.get(), ID, kAudioUnitScope_Global,
+            0, d, 0))
+            return false;
+         Notify(mUnit.get(), ID);
       }
    }
-
    return true;
 }
 
@@ -2114,19 +1977,9 @@ void AudioUnitEffect::EventListenerCallback(void *inCallbackRefCon,
 
 void AudioUnitEffect::GetChannelCounts()
 {
-   Boolean isWritable = 0;
-   UInt32  dataSize = 0;
-   OSStatus result;
-
    // Does AU have channel info
-   result = AudioUnitGetPropertyInfo(mUnit.get(),
-                                     kAudioUnitProperty_SupportedNumChannels,
-                                     kAudioUnitScope_Global,
-                                     0,
-                                     &dataSize,
-                                     &isWritable);
-   if (result)
-   {
+   PackedArrayPtr<AUChannelInfo> info;
+   if (GetVariableSizeProperty(kAudioUnitProperty_SupportedNumChannels, info)) {
       // None supplied.  Apparently all FX type units can do any number of INs
       // and OUTs as long as they are the same number.  In this case, we'll
       // just say stereo.
@@ -2134,25 +1987,6 @@ void AudioUnitEffect::GetChannelCounts()
       // We should probably check to make sure we're dealing with an FX type.
       mAudioIns = 2;
       mAudioOuts = 2;
-      return;
-   }
-
-   ArrayOf<char> buffer{ dataSize };
-   auto info = (AUChannelInfo *) buffer.get();
-
-   // Retrieve the channel info
-   result = AudioUnitGetProperty(mUnit.get(),
-                                 kAudioUnitProperty_SupportedNumChannels,
-                                 kAudioUnitScope_Global,
-                                 0,
-                                 info,
-                                 &dataSize);
-   if (result)
-   {
-      // Oh well, not much we can do out this case
-      mAudioIns = 2;
-      mAudioOuts = 2;
-
       return;
    }
 
@@ -2173,98 +2007,66 @@ void AudioUnitEffect::GetChannelCounts()
    mAudioOuts = 2;
 
    // Look only for exact channel constraints
-   for (int i = 0; i < dataSize / sizeof(AUChannelInfo); i++)
-   {
-      AUChannelInfo *ci = &info[i];
-
-      int ic = ci->inChannels;
-      int oc = ci->outChannels;
+   for (auto &ci : info) {
+      int ic = ci.inChannels;
+      int oc = ci.outChannels;
 
       if (ic < 0 && oc >= 0)
-      {
          ic = 2;
-      }
       else if (ic >= 0 && oc < 0)
-      {
          oc = 2;
-      }
-      else if (ic < 0 && oc < 0)
-      {
+      else if (ic < 0 && oc < 0) {
          ic = 2;
          oc = 2;
       }
 
       if (ic == 2 && oc == 2)
-      {
          haves2s = true;
-      }
       else if (ic == 1 && oc == 1)
-      {
          havem2m = true;
-      }   
       else if (ic == 1 && oc == 2)
-      {
          havem2s = true;
-      }
       else if (ic == 2 && oc == 1)
-      {
          haves2m = true;
-      }
       else if (ic == 0 && oc == 2)
-      {
          haven2s = true;
-      }
       else if (ic == 0 && oc == 1)
-      {
          haven2m = true;
-      }
       else if (ic == 1 && oc == 0)
-      {
          havem2n = true;
-      }
       else if (ic == 2 && oc == 0)
-      {
          haves2n = true;
-      }
    }
 
-   if (haves2s)
-   {
+   if (haves2s) {
       mAudioIns = 2;
       mAudioOuts = 2;
    }
-   else if (havem2m)
-   {
+   else if (havem2m) {
       mAudioIns = 1;
       mAudioOuts = 1;
    }
-   else if (havem2s)
-   {
+   else if (havem2s) {
       mAudioIns = 1;
       mAudioOuts = 2;
    }
-   else if (haves2m)
-   {
+   else if (haves2m) {
       mAudioIns = 2;
       mAudioOuts = 1;
    }
-   else if (haven2m)
-   {
+   else if (haven2m) {
       mAudioIns = 0;
       mAudioOuts = 1;
    }
-   else if (haven2s)
-   {
+   else if (haven2s) {
       mAudioIns = 0;
       mAudioOuts = 2;
    }
-   else if (haves2n)
-   {
+   else if (haves2n) {
       mAudioIns = 2;
       mAudioOuts = 0;
    }
-   else if (havem2n)
-   {
+   else if (havem2n) {
       mAudioIns = 1;
       mAudioOuts = 0;
    }

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -803,10 +803,10 @@ AudioUnitEffect::AudioUnitEffect(const PluginPath & path,
                                  const wxString & name,
                                  AudioComponent component,
                                  AudioUnitEffect *master)
-   : mPath{ path }
+   : AudioUnitWrapper{ component }
+   , mPath{ path }
    , mName{ name.AfterFirst(wxT(':')).Trim(true).Trim(false) }
    , mVendor{ name.BeforeFirst(wxT(':')).Trim(true).Trim(false) }
-   , mComponent{ component }
    , mMaster{ master }
 {
 }
@@ -944,7 +944,7 @@ bool AudioUnitEffect::SupportsAutomation() const
    return false;
 }
 
-bool AudioUnitEffect::CreateAudioUnit()
+bool AudioUnitWrapper::CreateAudioUnit()
 {
    AudioUnit unit{};
    auto result = AudioComponentInstanceNew(mComponent, &unit);

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include <AudioToolbox/AudioUnitUtilities.h>
-#include <AudioUnit/AudioUnit.h>
+#include "AudioUnitUtils.h"
 #include <AudioUnit/AudioUnitProperties.h>
 
 #include "../StatefulPerTrackEffect.h"
@@ -59,6 +59,17 @@ struct AudioUnitWrapper
    explicit AudioUnitWrapper(AudioComponent component)
       : mComponent{ component }
    {}
+
+   // Supply most often used values as defaults for scope and element
+   template<typename T>
+   OSStatus SetProperty(AudioUnitPropertyID inID, const T &property,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0) const
+   {
+      // Supply mUnit.get() to the non-member function
+      return AudioUnitUtils::SetProperty(mUnit.get(),
+         inID, property, inScope, inElement);
+   }
 
    bool CreateAudioUnit();
 
@@ -208,7 +219,6 @@ private:
    bool BypassEffect(bool bypass);
 
 private:
-
    const PluginPath mPath;
    const wxString mName;
    const wxString mVendor;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -52,6 +52,17 @@ struct AudioUnitWrapper
 
    // Supply most often used values as defaults for scope and element
    template<typename T>
+   OSStatus GetFixedSizeProperty(AudioUnitPropertyID inID, T &property,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0) const
+   {
+      // Supply mUnit.get() to the non-member function
+      return AudioUnitUtils::GetFixedSizeProperty(mUnit.get(),
+         inID, property, inScope, inElement);
+   }
+
+   // Supply most often used values as defaults for scope and element
+   template<typename T>
    OSStatus SetProperty(AudioUnitPropertyID inID, const T &property,
       AudioUnitScope inScope = kAudioUnitScope_Global,
       AudioUnitElement inElement = 0) const

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -251,8 +251,8 @@ private:
 
    AudioTimeStamp mTimeStamp{};
 
-   ArrayOf<AudioBufferList> mInputList;
-   ArrayOf<AudioBufferList> mOutputList;
+   PackedArrayPtr<AudioBufferList> mInputList;
+   PackedArrayPtr<AudioBufferList> mOutputList;
 
    wxWindow *mParent{};
    wxWeakRef<wxDialog> mDialog;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -38,6 +38,7 @@ using AudioUnitEffectArray = std::vector<std::unique_ptr<AudioUnitEffect>>;
 class AudioUnitEffectExportDialog;
 class AudioUnitEffectImportDialog;
 class AUControl;
+class wxCFStringRef;
 
 //! Common base class for AudioUnitEffect and its Instance
 /*!
@@ -195,6 +196,16 @@ private:
    bool SetRateAndChannels();
 
    bool CopyParameters(AudioUnit srcUnit, AudioUnit dstUnit);
+
+   //! Obtain dump of the setting state of an AudioUnit instance
+   /*!
+    @param binary if false, then produce XML serialization instead; but
+    AudioUnits does not need to be told the format again to reinterpret the blob
+    @return smart pointer to data, and an error message
+    */
+   std::pair<CF_ptr<CFDataRef>, TranslatableString>
+   MakeBlob(const wxCFStringRef &cfname, bool binary) const;
+
    TranslatableString Export(const wxString & path) const;
    TranslatableString Import(const wxString & path);
    void Notify(AudioUnit unit, AudioUnitParameterID parm) const;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -63,6 +63,17 @@ struct AudioUnitWrapper
 
    // Supply most often used values as defaults for scope and element
    template<typename T>
+   OSStatus GetVariableSizeProperty(AudioUnitPropertyID inID,
+      PackedArrayPtr<T> &pObject,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0) const
+   {
+      return AudioUnitUtils::GetVariableSizeProperty(mUnit.get(),
+         inID, pObject, inScope, inElement);
+   }
+
+   // Supply most often used values as defaults for scope and element
+   template<typename T>
    OSStatus SetProperty(AudioUnitPropertyID inID, const T &property,
       AudioUnitScope inScope = kAudioUnitScope_Global,
       AudioUnitElement inElement = 0) const

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -49,7 +49,26 @@ template<typename Ptr, OSStatus(*fn)(Ptr),
    typename T = std::remove_pointer_t<Ptr> /* deduced */ >
 using AudioUnitCleanup = std::unique_ptr<T, AudioUnitCleaner<T, fn>>;
 
-class AudioUnitEffect final : public StatefulPerTrackEffect
+//! Common base class for AudioUnitEffect and its Instance
+/*!
+ Maintains a smart handle to an AudioUnit (also called AudioComponentInstance)
+ in the SDK and defines some utility functions
+ */
+struct AudioUnitWrapper
+{
+   explicit AudioUnitWrapper(AudioComponent component)
+      : mComponent{ component }
+   {}
+
+   bool CreateAudioUnit();
+
+   const AudioComponent mComponent;
+   AudioUnitCleanup<AudioUnit, AudioComponentInstanceDispose> mUnit;
+};
+
+class AudioUnitEffect final
+   : public StatefulPerTrackEffect
+   , private AudioUnitWrapper
 {
 public:
    AudioUnitEffect(const PluginPath & path,
@@ -125,7 +144,6 @@ public:
       wxWindow &parent, wxDialog &dialog, bool forceModal) override;
 
    bool MakeListener();
-   bool CreateAudioUnit();
    bool InitializeInstance();
    bool InitializePlugin();
 
@@ -194,10 +212,7 @@ private:
    const PluginPath mPath;
    const wxString mName;
    const wxString mVendor;
-   const AudioComponent mComponent;
 
-   // The sequence of these three members matters in the destructor
-   AudioUnitCleanup<AudioUnit, AudioComponentInstanceDispose> mUnit;
    AudioUnitCleanup<AUEventListenerRef, AUListenerDispose> mEventListenerRef;
    AudioUnitCleanup<AudioUnit, AudioUnitUninitialize> mInitialization;
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -208,6 +208,13 @@ private:
 
    TranslatableString Export(const wxString & path) const;
    TranslatableString Import(const wxString & path);
+   /*!
+    @param path only for formatting error messages
+    @return error message
+    */
+   TranslatableString SaveBlobToConfig(const RegistryPath &group,
+      const wxString &path, const void *blob, size_t len,
+      bool allowEmpty = true) const;
    void Notify(AudioUnit unit, AudioUnitParameterID parm) const;
 
    static OSStatus RenderCallback(void *inRefCon,

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -39,16 +39,6 @@ class AudioUnitEffectExportDialog;
 class AudioUnitEffectImportDialog;
 class AUControl;
 
-//! Generates deleters for std::unique_ptr that clean up AU plugin state
-template<typename T, OSStatus(*fn)(T*)> struct AudioUnitCleaner {
-   // Let this have non-void return type, though ~unique_ptr() will ignore it
-   auto operator () (T *p) noexcept { return fn(p); }
-};
-//! RAII for cleaning up AU plugin state
-template<typename Ptr, OSStatus(*fn)(Ptr),
-   typename T = std::remove_pointer_t<Ptr> /* deduced */ >
-using AudioUnitCleanup = std::unique_ptr<T, AudioUnitCleaner<T, fn>>;
-
 //! Common base class for AudioUnitEffect and its Instance
 /*!
  Maintains a smart handle to an AudioUnit (also called AudioComponentInstance)

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -39,6 +39,7 @@ class AudioUnitEffectExportDialog;
 class AudioUnitEffectImportDialog;
 class AUControl;
 class wxCFStringRef;
+class wxMemoryBuffer;
 
 //! Common base class for AudioUnitEffect and its Instance
 /*!
@@ -240,6 +241,15 @@ private:
    void GetChannelCounts();
 
    bool LoadPreset(const RegistryPath & group, EffectSettings &settings) const;
+
+   //! Interpret the dump made before by MakeBlob
+   /*!
+    @param group only for formatting error messages
+    @return an error message
+    */
+   TranslatableString InterpretBlob(
+      const wxString &group, const wxMemoryBuffer &buf) const;
+
    bool SavePreset(const RegistryPath & group) const;
 
 #if defined(HAVE_AUDIOUNIT_BASIC_SUPPORT)

--- a/src/effects/audiounits/AudioUnitUtils.cpp
+++ b/src/effects/audiounits/AudioUnitUtils.cpp
@@ -1,0 +1,19 @@
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file AudioUnitUtils.cpp
+
+  Paul Licameli
+
+***********************************************************************/
+
+#include "AudioUnitUtils.h"
+
+OSStatus AudioUnitUtils::SetPropertyPtr(AudioUnit unit,
+   AudioUnitPropertyID inID, const void *pProperty, UInt32 size,
+   AudioUnitScope inScope, AudioUnitElement inElement)
+{
+   return AudioUnitSetProperty(unit, inID, inScope, inElement,
+      pProperty, size);
+}

--- a/src/effects/audiounits/AudioUnitUtils.cpp
+++ b/src/effects/audiounits/AudioUnitUtils.cpp
@@ -9,6 +9,7 @@
 ***********************************************************************/
 
 #include "AudioUnitUtils.h"
+#include "MemoryX.h"
 
 OSStatus AudioUnitUtils::GetFixedSizePropertyPtr(AudioUnit unit,
    AudioUnitPropertyID inID, void *pProperty, const UInt32 size,
@@ -18,6 +19,44 @@ OSStatus AudioUnitUtils::GetFixedSizePropertyPtr(AudioUnit unit,
    auto result = AudioUnitGetProperty(unit, inID, inScope, inElement,
       pProperty, &newSize);
    assert(newSize <= size);
+   return result;
+}
+
+OSStatus AudioUnitUtils::GetVariableSizePropertyPtr(AudioUnit unit,
+   AudioUnitElement inElement, const size_t minSize,
+   void *&pObject, size_t &size,
+   AudioUnitPropertyID inID, AudioUnitScope inScope)
+{
+   size = 0;
+
+   // Query for statically unknown size of the property first
+   UInt32 dataSize;
+   auto result = AudioUnitGetPropertyInfo(unit, inID, inScope, inElement,
+      &dataSize, nullptr);
+   if (result)
+      return result;
+
+   // Allocate
+   auto newSize = std::max<size_t>(minSize, dataSize);
+   auto pObj = ::operator new(newSize);
+   auto cleanup = finally([&]{
+      // In case AudioUnitGetProperty fails
+      if (!pObject)
+         ::operator delete(pObj);
+   });
+
+   // Try to get the property
+   dataSize = newSize;
+   result =
+      AudioUnitGetProperty(unit, inID, inScope, inElement, pObj, &dataSize);
+   if (result) {
+      pObject = nullptr;
+      return result;
+   }
+
+   // Success
+   pObject = pObj;
+   size = newSize;
    return result;
 }
 

--- a/src/effects/audiounits/AudioUnitUtils.cpp
+++ b/src/effects/audiounits/AudioUnitUtils.cpp
@@ -10,6 +10,17 @@
 
 #include "AudioUnitUtils.h"
 
+OSStatus AudioUnitUtils::GetFixedSizePropertyPtr(AudioUnit unit,
+   AudioUnitPropertyID inID, void *pProperty, const UInt32 size,
+   AudioUnitScope inScope, AudioUnitElement inElement)
+{
+   auto newSize = size;
+   auto result = AudioUnitGetProperty(unit, inID, inScope, inElement,
+      pProperty, &newSize);
+   assert(newSize <= size);
+   return result;
+}
+
 OSStatus AudioUnitUtils::SetPropertyPtr(AudioUnit unit,
    AudioUnitPropertyID inID, const void *pProperty, UInt32 size,
    AudioUnitScope inScope, AudioUnitElement inElement)

--- a/src/effects/audiounits/AudioUnitUtils.h
+++ b/src/effects/audiounits/AudioUnitUtils.h
@@ -111,6 +111,15 @@ namespace AudioUnitUtils {
     */
    //! @{
 
+   struct Buffer : AudioBuffer {
+      Buffer(UInt32 numberChannels, UInt32 dataByteSize, void *data)
+      : AudioBuffer{} {
+         mNumberChannels = numberChannels;
+         mDataByteSize = dataByteSize;
+         mData = data;
+      }
+   };
+
    struct RenderCallback : AURenderCallbackStruct {
       RenderCallback(AURenderCallback inProc, void *inProcRefCon)
       : AURenderCallbackStruct{} {
@@ -176,6 +185,14 @@ namespace AudioUnitUtils {
  @name Traits attached to SDK structures, in the global namespace
  */
 //! @{
+
+template<> struct PackedArrayTraits<AudioBufferList> {
+   struct header_type { UInt32 mNumberBuffers; };
+   // Overlay the element type with the wrapper type
+   using element_type = AudioUnitUtils::Buffer;
+   using iterated_type = element_type;
+   static_assert(sizeof(element_type) == sizeof(AudioBuffer));
+};
 
 template<> struct PackedArrayTraits<AudioUnitCocoaViewInfo> {
    struct header_type {

--- a/src/effects/audiounits/AudioUnitUtils.h
+++ b/src/effects/audiounits/AudioUnitUtils.h
@@ -27,6 +27,23 @@ using AudioUnitCleanup = std::unique_ptr<T, AudioUnitCleaner<T, fn>>;
 /*! @namespace AudioUnitUtils
  */
 namespace AudioUnitUtils {
+   //! Type-erased function to get an AudioUnit property of fixed size
+   OSStatus GetFixedSizePropertyPtr(AudioUnit unit, AudioUnitPropertyID inID,
+      void *pProperty, UInt32 size, AudioUnitScope inScope,
+      AudioUnitElement inElement);
+
+   //! Get an AudioUnit property of deduced type and fixed size,
+   //! supplying most often used values as defaults for scope and element
+   template<typename T>
+   OSStatus GetFixedSizeProperty(AudioUnit unit, AudioUnitPropertyID inID,
+      T &property,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0)
+   {
+      return GetFixedSizePropertyPtr(unit, inID,
+         &property, sizeof(property), inScope, inElement);
+   }
+
    //! Type-erased function to set an AudioUnit property
    OSStatus SetPropertyPtr(AudioUnit unit, AudioUnitPropertyID inID,
       const void *pProperty, UInt32 size, AudioUnitScope inScope,

--- a/src/effects/audiounits/AudioUnitUtils.h
+++ b/src/effects/audiounits/AudioUnitUtils.h
@@ -1,0 +1,36 @@
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file AudioUnitUtils.h
+
+  Paul Licameli
+
+***********************************************************************/
+
+#ifndef __AUDACITY_AUDIO_UNIT_UTILS__
+#define __AUDACITY_AUDIO_UNIT_UTILS__
+
+#include <algorithm>
+#include <AudioUnit/AudioUnit.h>
+
+namespace AudioUnitUtils {
+   //! Type-erased function to set an AudioUnit property
+   OSStatus SetPropertyPtr(AudioUnit unit, AudioUnitPropertyID inID,
+      const void *pProperty, UInt32 size, AudioUnitScope inScope,
+      AudioUnitElement inElement);
+
+   //! Set an AudioUnit property of deduced type,
+   //! supplying most often used values as defaults for scope and element
+   template<typename T>
+   OSStatus SetProperty(AudioUnit unit, AudioUnitPropertyID inID,
+      const T &property,
+      AudioUnitScope inScope = kAudioUnitScope_Global,
+      AudioUnitElement inElement = 0)
+   {
+      return SetPropertyPtr(unit, inID,
+         &property, sizeof(property), inScope, inElement);
+   }
+}
+
+#endif


### PR DESCRIPTION
Resolves: #2841

Much code in AudioUnits calling into the SDK was too repetitious.

Define many utilities to factor out repeated patterns and greatly shorten AudioUnit.cpp, making many individual functions
more easily comprehensible.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
