### PR TITLE
Fix issue #2846 by removing the addition of a silent clip when copying clips

### DIFF
--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -751,8 +751,7 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
       }
       else if (t1 > clip->GetPlayStartTime() && t0 < clip->GetPlayEndTime())
       {
-         // Clip is affected by command, but the entire clip is not contained
-         // in the selection
+         // Clip is affected by command
          //wxPrintf("copy: clip %i is affected by command\n", (int)clip);
 
          const double clip_t0 = std::max(t0, clip->GetPlayStartTime());
@@ -764,19 +763,9 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
 
          //wxPrintf("copy: clip_t0=%f, clip_t1=%f\n", clip_t0, clip_t1);
 
-         // If we are in the case with an audio clip on the right side with blank space to its left,
-         // we need to calculate the offset slightly differently:
-         //  |    [-----CLIP--|--]             [-|----CLIP----]      |
-         // t0                t1       VS.       t0                  t1
-         //  |----|                            |-|
-         //  OFFSET = clip_t0 - t0            OFFSET = 0
-         if (t0 < clip->GetPlayStartTime() && t1 < clip->GetPlayEndTime()) {
-            wxASSERT(clip_t0 - t0 >= 0); //debugging
-            newClip->SetPlayStartTime(clip_t0-t0); //not sure why Offset doesn't work for this; may want to modify
-         }
-         else {
+         newClip->Offset(-t0);
+         if (newClip->GetPlayStartTime() < 0)
             newClip->SetPlayStartTime(0);
-         }
 
          newTrack->mClips.push_back(std::move(newClip)); // transfer ownership
       }

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -763,6 +763,9 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
 
          //wxPrintf("copy: clip_t0=%f, clip_t1=%f\n", clip_t0, clip_t1);
 
+         if (newClip->GetPlayStartTime() < 0)
+            newClip->SetPlayStartTime(0);
+
          newClip->SetPlayStartTime(clip_t0);
 
          newTrack->mClips.push_back(std::move(newClip)); // transfer ownership

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -771,13 +771,12 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
          //  |----|                            |-|
          //  OFFSET = clip_t0 - t0            OFFSET = -t0
          if (t0 < clip->GetPlayStartTime() && t1 < clip->GetPlayEndTime()) {
+            wxASSERT(clip_t0 - t0 >= 0); //debugging
             newClip->SetPlayStartTime(clip_t0-t0); //not sure why Offset doesn't work for this; may want to modify
          }
          else {
-            newClip->SetPlayStartTime(-t0);
-         }
-         if (newClip->GetPlayStartTime() < 0)
             newClip->SetPlayStartTime(0);
+         }
 
          newTrack->mClips.push_back(std::move(newClip)); // transfer ownership
       }

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -733,8 +733,6 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
    auto result = EmptyCopy();
    WaveTrack *newTrack = result.get();
 
-   double prev_t1 = 0;
-
    // PRL:  Why shouldn't cutlines be copied and pasted too?  I don't know, but
    // that was the old behavior.  But this function is also used by the
    // Duplicate command and I changed its behavior in that case.

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -768,10 +768,13 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
          // we need to calculate the offset slightly differently:
          //  |    [-----CLIP--|--]             [-|----CLIP----]      |
          // t0                t1       VS.       t0                  t1
-         //  |----|                              ||
-         //  OFFSET = clip_t0 - t0            OFFSET = 0
+         //  |----|                            |-|
+         //  OFFSET = clip_t0 - t0            OFFSET = -t0
          if (t0 < clip->GetPlayStartTime() && t1 < clip->GetPlayEndTime()) {
             newClip->SetPlayStartTime(clip_t0-t0); //not sure why Offset doesn't work for this; may want to modify
+         }
+         else {
+            newClip->SetPlayStartTime(-t0);
          }
          if (newClip->GetPlayStartTime() < 0)
             newClip->SetPlayStartTime(0);

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -763,7 +763,7 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
 
          //wxPrintf("copy: clip_t0=%f, clip_t1=%f\n", clip_t0, clip_t1);
 
-         newClip->Offset(-t0);
+         newClip->Offset(clip_t0-t0);
          if (newClip->GetPlayStartTime() < 0)
             newClip->SetPlayStartTime(0);
 

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -763,10 +763,14 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
 
          //wxPrintf("copy: clip_t0=%f, clip_t1=%f\n", clip_t0, clip_t1);
 
-         if (newClip->GetPlayStartTime() < 0)
+         if (clip_t0 < 0)
+         {
             newClip->SetPlayStartTime(0);
-
-         newClip->SetPlayStartTime(clip_t0);
+         }
+         else
+         {
+            newClip->SetPlayStartTime(clip_t0);
+         }
 
          newTrack->mClips.push_back(std::move(newClip)); // transfer ownership
       }

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -769,7 +769,7 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
          //  |    [-----CLIP--|--]             [-|----CLIP----]      |
          // t0                t1       VS.       t0                  t1
          //  |----|                            |-|
-         //  OFFSET = clip_t0 - t0            OFFSET = -t0
+         //  OFFSET = clip_t0 - t0            OFFSET = 0
          if (t0 < clip->GetPlayStartTime() && t1 < clip->GetPlayEndTime()) {
             wxASSERT(clip_t0 - t0 >= 0); //debugging
             newClip->SetPlayStartTime(clip_t0-t0); //not sure why Offset doesn't work for this; may want to modify

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -751,7 +751,8 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
       }
       else if (t1 > clip->GetPlayStartTime() && t0 < clip->GetPlayEndTime())
       {
-         // Clip is affected by command
+         // Clip is affected by command, but the entire clip is not contained
+         // in the selection
          //wxPrintf("copy: clip %i is affected by command\n", (int)clip);
 
          const double clip_t0 = std::max(t0, clip->GetPlayStartTime());

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -890,8 +890,6 @@ void OnSplitNew(const CommandContext &context)
          [&](WaveTrack *wt) {
             // Clips must be aligned to sample positions or the NEW clip will
             // not fit in the gap where it came from
-            double offset = wt->GetOffset();
-            offset = wt->LongSamplesToTime(wt->TimeToLongSamples(offset));
             double newt0 = wt->LongSamplesToTime(wt->TimeToLongSamples(
                selectedRegion.t0()));
             double newt1 = wt->LongSamplesToTime(wt->TimeToLongSamples(

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -903,7 +903,7 @@ void OnSplitNew(const CommandContext &context)
             if (dest) {
                // The copy function normally puts the clip at time 0
                // This offset lines it up with the original track's timing
-               dest->SetOffset(wxMax(newt0, offset));
+               dest->Offset(wxMax(newt0, offset));
                FinishCopy(wt, dest, tracks);
             }
          }

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -903,7 +903,7 @@ void OnSplitNew(const CommandContext &context)
             if (dest) {
                // The copy function normally puts the clip at time 0
                // This offset lines it up with the original track's timing
-               dest->Offset(wxMax(newt0, offset));
+               dest->Offset(newt0);
                FinishCopy(wt, dest, tracks);
             }
          }

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -896,7 +896,8 @@ void OnSplitNew(const CommandContext &context)
                selectedRegion.t0()));
             double newt1 = wt->LongSamplesToTime(wt->TimeToLongSamples(
                selectedRegion.t1()));
-            dest = wt->SplitCut(newt0, newt1);
+            dest = wt->Copy(newt0, newt1, false);
+            wt->SplitDelete(newt0, newt1);
             if (dest) {
                dest->SetOffset(wxMax(newt0, offset));
                FinishCopy(wt, dest, tracks);

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -896,9 +896,13 @@ void OnSplitNew(const CommandContext &context)
                selectedRegion.t0()));
             double newt1 = wt->LongSamplesToTime(wt->TimeToLongSamples(
                selectedRegion.t1()));
+            // Fix issue 2846 by calling copy with forClipboard = false.
+            // This avoids creating the blank placeholder clips
             dest = wt->Copy(newt0, newt1, false);
             wt->SplitDelete(newt0, newt1);
             if (dest) {
+               // The copy function normally puts the clip at time 0
+               // This offset lines it up with the original track's timing
                dest->SetOffset(wxMax(newt0, offset));
                FinishCopy(wt, dest, tracks);
             }


### PR DESCRIPTION
Resolves: [https://github.com/audacity/audacity/issues/2846](https://github.com/audacity/audacity/issues/2846)

This changes the way copy (and by extension, split new) works in two ways:
1. No longer adds an unwanted silent clip
2. Fixes some lingering issues with copying clips over to the right time in the new track

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
