### PR TITLE
Make wahwah stateless

### DIFF
--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -261,8 +261,10 @@ class AUDACITY_DLL_API Effect /* not final */
 
    static void IncEffectCounter(){ nEffectsDone++;}
 
- protected:
    bool EnableApply(bool enable = true);
+
+ protected:
+   
    bool EnablePreview(bool enable = true);
 
    //! Default implementation returns false
@@ -383,6 +385,9 @@ protected:
    //! This smart pointer tracks the lifetime of the dialog
    wxWeakRef<wxDialog> mHostUIDialog;
    wxWindow       *mUIParent{};
+
+public:
+   wxWindow* GetUIParent() { return mUIParent; }
 
 private:
    wxString GetSavedStateGroup();

--- a/src/effects/How to make an effect stateless.txt
+++ b/src/effects/How to make an effect stateless.txt
@@ -17,11 +17,17 @@ Let use use EffectEcho as an example.
        Modify FetchParameters: it must now return the address of mSettings, not of the effect
     
        Update pointers-to-members in EffectParameter declarations
+
+       you can remove forward declarations like:
+         class wxCheckBox;
+         class wxSlider;
+         class wxSpinCtrl;
+
     
    In cpp file:
        Insert sufficient auto& echoSettings = mSettings; (which changes later) and echoSettings. (which won't need more change) to fix compilation
         
-       Remove call to Reset() in constructor
+       Remove call to Parameters().Reset(*this); in constructor
         
     
 2) "Define validator"

--- a/src/effects/How to make an effect stateless.txt
+++ b/src/effects/How to make an effect stateless.txt
@@ -126,9 +126,24 @@ Let use use EffectEcho as an example.
            size_t ProcessBlock(EffectSettings& settings,
               const float* const* inBlock, float* const* outBlock, size_t blockLen)  override;
 
-           bool ProcessFinalize(void) override;
+           bool ProcessFinalize(void) override; // not every effect needs this
+           
+           /* you will need these for realtime-capable effects
+           
+           bool RealtimeInitialize(EffectSettings& settings) override;
 
-           << MEMBERS WHICH REPRESENT STATE which you commented out earlier >>
+           bool RealtimeAddProcessor(EffectSettings& settings,
+              unsigned numChannels, float sampleRate) override;
+
+           bool RealtimeFinalize(EffectSettings& settings) noexcept override;
+
+           size_t RealtimeProcess(int group, EffectSettings& settings,
+              const float* const* inbuf, float* const* outbuf, size_t numSamples)
+              override;
+           
+           */
+
+           // << MEMBERS WHICH REPRESENT STATE which you commented out earlier >>
         };
 
 
@@ -143,7 +158,11 @@ Let use use EffectEcho as an example.
     
     - prepending ::Instance where needed
 
-    - adding this at the beginning (may not be needed in all of them)
+    - replacing the lines you added in step 1:
+    
+        auto& echoSettings = mSettings;
+            
+      with this 
     
         // temporary - in the final step this will be replaced by
         // auto& echoSettings = GetSettings(settings);

--- a/src/effects/How to make an effect stateless.txt
+++ b/src/effects/How to make an effect stateless.txt
@@ -18,64 +18,80 @@ Let use use EffectEcho as an example.
     
        Update pointers-to-members in EffectParameter declarations
 
-       you can remove forward declarations like:
-         class wxCheckBox;
-         class wxSlider;
-         class wxSpinCtrl;
+       
 
     
    In cpp file:
        Insert sufficient auto& echoSettings = mSettings; (which changes later) and echoSettings. (which won't need more change) to fix compilation
         
-       Remove call to Parameters().Reset(*this); in constructor
+       Go to the constructor and remove call to
+
+         Parameters().Reset(*this);
+
+       As the initializations it did, now happen in the constructor of EffectEchoSettings because we use in-struct initializers with the same default values as in the EffectParmeters.
         
     
 2) "Define validator"
 
+
     In header file:
-    
-    add line "struct Validator;" in public section
+
+      - you can remove forward declarations like:
+         class wxCheckBox;
+         class wxSlider;
+         class wxSpinCtrl;
+
+      - add line "struct Validator;" in public section
+
+      - if the following is declared, remove it:
+         bool TransferDataToWindow(const EffectSettings &settings) override;
+
 
 
     In cpp file:
-    add class definition in the .cpp with mSettings:
+
+       add class definition in the .cpp with mSettings:
     
-        struct EffectEcho::Validator
-           : DefaultEffectUIValidator
-        {
-           Validator(EffectUIClientInterface& effect,
-              EffectSettingsAccess& access, EffectEchoSettings& settings)
-              : DefaultEffectUIValidator{ effect, access }
-              , mSettings{ settings }
-           {}
-           virtual ~Validator() = default;
-
-           Effect& GetEffect() const { return static_cast<Effect&>(mEffect); }
-
-           bool ValidateUI() override;
-           bool UpdateUI() override;
-
-           void PopulateOrExchange(ShuttleGui& S);
-
-           EffectEchoSettings& mSettings;
-        };
-
-
-        bool EffectEcho::Validator::ValidateUI()
-        {
-           mAccess.ModifySettings
-           (
-              [this](EffectSettings& settings)
+           struct EffectEcho::Validator
+              : EffectUIValidator
            {
-              // pass back the modified settings to the MessageBuffer
+              Validator(EffectUIClientInterface& effect,
+                 EffectSettingsAccess& access, EffectEchoSettings& settings)
+                 : EffectUIValidator{ effect, access }
+                 , mSettings{ settings }
+              {}
+              virtual ~Validator() = default;
 
-              // TODO uncomment at last step
-              //EffectEcho::GetSettings(settings) = mSettings;
+              Effect& GetEffect() const { return static_cast<Effect&>(mEffect); }
+
+              bool ValidateUI() override;
+              bool UpdateUI() override;
+
+              void PopulateOrExchange(ShuttleGui& S);
+
+              EffectEchoSettings& mSettings;
+           };
+
+
+           bool EffectEcho::Validator::ValidateUI()
+           {
+              mAccess.ModifySettings
+              (
+                 [this](EffectSettings& settings)
+              {
+                 // pass back the modified settings to the MessageBuffer
+
+                 // TODO uncomment at last step
+                 //EffectEcho::GetSettings(settings) = mSettings;
+              }
+              );
+
+              return true;
            }
-           );
 
-           return true;
-        }
+
+        If the effect has an override of ::TransferDataFromWindow():
+        copy its steps into the ValidateUI() function above.
 
 
         bool EffectEcho::Validator::UpdateUI()
@@ -89,7 +105,75 @@ Let use use EffectEcho as an example.
            return true;
         }
 
+
+    - modify PopulateOrExchange to make it belong to the Validator
+      -- remove parameter EffectSettings from it, it is not needed anymore
+      -- it should now return void
+
+    - reimplement Effect::PopulateOrExchange:
     
+        std::unique_ptr<EffectUIValidator>
+        EffectEcho::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess& access)
+        {
+           // ENABLE AT LAST STEP
+           // auto& settings = access.Get();
+           // auto& myEffSettings = GetSettings(settings);
+
+           // DISABLE AT LAST STEP
+           auto &myEffSettings = mSettings;
+
+           auto& settings = access.Get();
+           auto& myEffSettings = GetSettings(settings);
+           auto result = std::make_unique<Validator>(*this, access, myEffSettings);
+           result->PopulateOrExchange(S);
+           return result;
+        }
+
+
+    ADDITIONAL STEPS for an effect which has explicitly declared Sliders, Textboxes etc.
+
+    - remove DECLARE_EVENT_TABLE();  (in .h)
+
+    - remove the definition of the enum with ID_***  (in .cpp)
+
+    - remove the section BEGIN_EVENT_TABLE... END_EVENT_TABLE (in .cpp)
+
+    - cut (from .h) all declarations of wxWidgets (wxTextCtrl, wxSlider etc.) and paste them in the validator definition (in .cpp)
+    
+    - cut (from .h) all declarations of handlers like void On***Slider, On***Text and paste them in the validator definition (in .cpp)
+      IMPORTANT: at the end of all the handlers, add a call to ValidateUI();
+
+    - in Validator::PopulateOrExchange
+      -- remove the calls to .Id(...) on the ShuttleGui
+      -- just after every creation of a widget, add a line like:
+      
+            BindTo(*mFreqT, wxEVT_TEXT, &Validator::OnFreqText);
+         
+         where: 
+         1st arg is the just created widget
+         2nd arg is either wxEVT_TEXT or wxEVT_SLIDER according to the widget type
+         3rd arg is the handler which is meant to handle events coming from the widget
+
+    - change
+        bool EffectWahwah::TransferDataToWindow(const EffectSettings &)
+      to
+        bool EffectWahwah::Validator::UpdateUI()
+
+      leaving the contents which is there, but adding at the top:
+         
+         // get the settings from the MessageBuffer and write them to our local copy
+         const auto& settings = mAccess.Get();
+
+         // TODO uncomment at last step
+         //mSettings = GetSettings(settings);
+
+    - in each of the control handlers:
+      -- add  Validator:: just after MyEffect:: in the method definition
+      -- place a call to ValidateUI(); at the end
+
+    - there might be calls to Effect::EnableApply.
+      Solve them by casting down to class Effect the Validator's mEffect member.
+
 
 
 3) "Define the instance"
@@ -100,11 +184,13 @@ Let use use EffectEcho as an example.
     
             struct Instance;
 
-            std::shared_ptr<EffectInstance> MakeInstance(EffectSettings& settings) const;
+            std::shared_ptr<EffectInstance> MakeInstance(EffectSettings& settings) const override;
 
         Identify members that represent state - comment them out 
         
-        remove methods: ProcessInitialize, ProcessFinalize, ProcessBlock
+        remove decls of methods: ProcessInitialize, ProcessFinalize, ProcessBlock
+                                 RealtimeInitialize, RealtimeAddProcessor, RealtimeFinalize,  RealtimeProcess
+
 
     In cpp file,
     
@@ -116,7 +202,7 @@ Let use use EffectEcho as an example.
            , public EffectInstanceWithSampleRate
 
         {
-           Instance(const PerTrackEffect& effect)
+           explicit Instance(const PerTrackEffect& effect)
               : PerTrackEffect::Instance{ effect }
            {}
 
@@ -190,27 +276,24 @@ Let use use EffectEcho as an example.
     
     - go to ProcessInitialize, ProcessBlock, ProcessFinalize, RealtimeInitialize etc.; remove the downcast and enable the commented out GetSettings
     
-    - go to Validator::ValidateUI and Validator::UpdateUI, remove the commenting out on the commented lines
+    - go to Validator::ValidateUI, uncomment the line //EffectEcho::GetSettings(settings) = mSettings;
+
+    - go to Validator::UpdateUI, uncomment the line //mSettings = GetSettings(settings);
     
     - add const to arg EffectEchoSettings& in the Validator constructor
     
     - turn Validator::mSettings from a reference to a non-reference
+
+    - in the effect's ::PopulateOrExchange, uncomment/comment lines as prescribed
     
-    - modify PopulateOrExchange to make it belong to the Validator
-      -- remove parameter EffectSettings from it, it is not needed anymore
-      -- it should now return void
-      
-    - reimplement Effect::PopulateOrExchange:
-    
-        std::unique_ptr<EffectUIValidator>
-        EffectEcho::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess& access)
-        {
-           auto& settings = access.Get();
-           auto& myEffSettings = GetSettings(settings);
-           auto result = std::make_unique<Validator>(*this, access, myEffSettings);
-           result->PopulateOrExchange(S);
-           return result;
-        }
+    - in general, settings are not taken anymore from the effect, like in:
+
+         auto& ms = static_cast<const EffectWahwah&>(mProcessor).mSettings;
+
+      but taking them from the passed ones, like so:
+
+         auto& ms = GetSettings(settings);
+
 
 
 Some notes by Paul Licameli:

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -67,12 +67,10 @@ struct EffectWahwahSettings
 };
 
 
-class EffectWahwah final : public StatefulPerTrackEffect
+class EffectWahwah final : public EffectWithSettings<EffectWahwahSettings, PerTrackEffect>
 {
 public:
-
-   static inline EffectWahwahSettings *
-   FetchParameters(EffectWahwah &e, EffectSettings &) { return &e.mSettings; }
+      
    static const ComponentInterfaceSymbol Symbol;
 
    EffectWahwah();
@@ -103,8 +101,6 @@ public:
 
 private:
    // EffectWahwah implementation
-
-   EffectWahwahSettings mSettings;
 
    const EffectParameterMethods& Parameters() const override;
 

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -37,11 +37,44 @@ public:
    double b0, b1, b2, a0, a1, a2;
 };
 
+
+struct EffectWahwahSettings
+{
+    /* Parameters:
+    mFreq - LFO frequency
+    mPhase - LFO startphase in RADIANS - useful for stereo WahWah
+    mDepth - Wah depth
+    mRes - Resonance
+    mFreqOfs - Wah frequency offset
+    mOutGain - output gain
+
+    !!!!!!!!!!!!! IMPORTANT!!!!!!!!! :
+    mDepth and mFreqOfs should be from 0(min) to 1(max) !
+    mRes should be greater than 0 !  */
+
+   static constexpr double freqDefault = 1.5;
+   static constexpr double phaseDefault = 0.0;
+   static constexpr int    depthDefault = 70;
+   static constexpr double resDefault = 2.5;
+   static constexpr int    freqOfsDefault = 30;
+   static constexpr double outGainDefault = -6.0;
+
+
+   double mFreq   { freqDefault };
+   double mPhase  { phaseDefault };
+   int    mDepth  { depthDefault };
+   double mRes    { resDefault };
+   int    mFreqOfs{ freqOfsDefault };
+   double mOutGain{ outGainDefault };
+};
+
+
 class EffectWahwah final : public StatefulPerTrackEffect
 {
 public:
-   static inline EffectWahwah *
-   FetchParameters(EffectWahwah &e, EffectSettings &) { return &e; }
+
+   static inline EffectWahwahSettings *
+   FetchParameters(EffectWahwah &e, EffectSettings &) { return &e.mSettings; }
    static const ComponentInterfaceSymbol Symbol;
 
    EffectWahwah();
@@ -82,6 +115,8 @@ public:
 private:
    // EffectWahwah implementation
 
+   EffectWahwahSettings mSettings;
+
    void InstanceInit(EffectWahwahState & data, float sampleRate);
    size_t InstanceProcess(EffectSettings &settings, EffectWahwahState & data,
       const float *const *inBlock, float *const *outBlock, size_t blockLen);
@@ -103,25 +138,6 @@ private:
    EffectWahwahState mMaster;
    std::vector<EffectWahwahState> mSlaves;
 
-   /* Parameters:
-   mFreq - LFO frequency
-   mPhase - LFO startphase in RADIANS - useful for stereo WahWah
-   mDepth - Wah depth
-   mRes - Resonance
-   mFreqOfs - Wah frequency offset
-   mOutGain - output gain
-
-   !!!!!!!!!!!!! IMPORTANT!!!!!!!!! :
-   mDepth and mFreqOfs should be from 0(min) to 1(max) !
-   mRes should be greater than 0 !  */
-
-   double mFreq;
-   double mPhase;
-   int mDepth;
-   double mRes;
-   int mFreqOfs;
-   double mOutGain;
-
    wxTextCtrl *mFreqT;
    wxTextCtrl *mPhaseT;
    wxTextCtrl *mDepthT;
@@ -139,18 +155,12 @@ private:
    const EffectParameterMethods& Parameters() const override;
    DECLARE_EVENT_TABLE()
 
-static constexpr EffectParameter Freq{ &EffectWahwah::mFreq,
-   L"Freq",       1.5,     0.1,     4.0,     10  };
-static constexpr EffectParameter Phase{ &EffectWahwah::mPhase,
-   L"Phase",      0.0,     0.0,     360.0,   1   };
-static constexpr EffectParameter Depth{ &EffectWahwah::mDepth,
-   L"Depth",      70,      0,       100,     1   }; // scaled to 0-1 before processing
-static constexpr EffectParameter Res{ &EffectWahwah::mRes,
-   L"Resonance",  2.5,     0.1,     10.0,    10  };
-static constexpr EffectParameter FreqOfs{ &EffectWahwah::mFreqOfs,
-   L"Offset",     30,      0,       100,     1   }; // scaled to 0-1 before processing
-static constexpr EffectParameter OutGain{ &EffectWahwah::mOutGain,
-   L"Gain",      -6.0,    -30.0,    30.0,    1   };
+static constexpr EffectParameter Freq   { &EffectWahwahSettings::mFreq,    L"Freq",       EffectWahwahSettings::freqDefault,      0.1,       4.0,  10  };
+static constexpr EffectParameter Phase  { &EffectWahwahSettings::mPhase,   L"Phase",      EffectWahwahSettings::phaseDefault,     0.0,     360.0,   1  };
+static constexpr EffectParameter Depth  { &EffectWahwahSettings::mDepth,   L"Depth",      EffectWahwahSettings::depthDefault,     0,       100,     1  }; // scaled to 0-1 before processing
+static constexpr EffectParameter Res    { &EffectWahwahSettings::mRes,     L"Resonance",  EffectWahwahSettings::resDefault,       0.1,      10.0,  10  };
+static constexpr EffectParameter FreqOfs{ &EffectWahwahSettings::mFreqOfs, L"Offset",     EffectWahwahSettings::freqOfsDefault,   0,       100,     1  }; // scaled to 0-1 before processing
+static constexpr EffectParameter OutGain{ &EffectWahwahSettings::mOutGain, L"Gain",       EffectWahwahSettings::outGainDefault, -30.0,      30.0,   1  };
 };
 
 #endif

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -19,8 +19,6 @@
 #include "StatefulPerTrackEffect.h"
 #include "../ShuttleAutomation.h"
 
-class wxSlider;
-class wxTextCtrl;
 class ShuttleGui;
 
 class EffectWahwahState
@@ -110,7 +108,8 @@ public:
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access) override;
-   bool TransferDataToWindow(const EffectSettings &settings) override;
+
+   struct Validator;
 
 private:
    // EffectWahwah implementation
@@ -121,39 +120,10 @@ private:
    size_t InstanceProcess(EffectSettings &settings, EffectWahwahState & data,
       const float *const *inBlock, float *const *outBlock, size_t blockLen);
 
-   void OnFreqSlider(wxCommandEvent & evt);
-   void OnPhaseSlider(wxCommandEvent & evt);
-   void OnDepthSlider(wxCommandEvent & evt);
-   void OnResonanceSlider(wxCommandEvent & evt);
-   void OnFreqOffSlider(wxCommandEvent & evt);
-   void OnGainSlider(wxCommandEvent & evt);
-
-   void OnFreqText(wxCommandEvent & evt);
-   void OnPhaseText(wxCommandEvent & evt);
-   void OnDepthText(wxCommandEvent & evt);
-   void OnResonanceText(wxCommandEvent & evt);
-   void OnFreqOffText(wxCommandEvent & evt);
-   void OnGainText(wxCommandEvent & evt);
-
    EffectWahwahState mMaster;
    std::vector<EffectWahwahState> mSlaves;
 
-   wxTextCtrl *mFreqT;
-   wxTextCtrl *mPhaseT;
-   wxTextCtrl *mDepthT;
-   wxTextCtrl *mResT;
-   wxTextCtrl *mFreqOfsT;
-   wxTextCtrl *mOutGainT;
-
-   wxSlider *mFreqS;
-   wxSlider *mPhaseS;
-   wxSlider *mDepthS;
-   wxSlider *mResS;
-   wxSlider *mFreqOfsS;
-   wxSlider *mOutGainS;
-
    const EffectParameterMethods& Parameters() const override;
-   DECLARE_EVENT_TABLE()
 
 static constexpr EffectParameter Freq   { &EffectWahwahSettings::mFreq,    L"Freq",       EffectWahwahSettings::freqDefault,      0.1,       4.0,  10  };
 static constexpr EffectParameter Phase  { &EffectWahwahSettings::mPhase,   L"Phase",      EffectWahwahSettings::phaseDefault,     0.0,     360.0,   1  };

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -91,18 +91,6 @@ public:
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
-      sampleCount totalLen, ChannelNames chanMap) override;
-   size_t ProcessBlock(EffectSettings &settings,
-      const float *const *inBlock, float *const *outBlock, size_t blockLen)
-      override;
-   bool RealtimeInitialize(EffectSettings &settings) override;
-   bool RealtimeAddProcessor(EffectSettings &settings,
-      unsigned numChannels, float sampleRate) override;
-   bool RealtimeFinalize(EffectSettings &settings) noexcept override;
-   size_t RealtimeProcess(int group,  EffectSettings &settings,
-      const float *const *inbuf, float *const *outbuf, size_t numSamples)
-      override;
 
    // Effect implementation
 
@@ -110,18 +98,13 @@ public:
       ShuttleGui & S, EffectSettingsAccess &access) override;
 
    struct Validator;
+   struct Instance;
+   std::shared_ptr<EffectInstance> MakeInstance(EffectSettings&) const override;
 
 private:
    // EffectWahwah implementation
 
    EffectWahwahSettings mSettings;
-
-   void InstanceInit(EffectWahwahState & data, float sampleRate);
-   size_t InstanceProcess(EffectSettings &settings, EffectWahwahState & data,
-      const float *const *inBlock, float *const *outBlock, size_t blockLen);
-
-   EffectWahwahState mMaster;
-   std::vector<EffectWahwahState> mSlaves;
 
    const EffectParameterMethods& Parameters() const override;
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2858

Wahwah was chosen as the next one to make stateless because unlike EffectEcho, it has explicitly declared widgets (and is relatively simple). Explicit widgets require more transformation operations, which were added to the guide in a new section in step 4.


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
