### PR TITLE
Rewrite track link consistency checking...

### DIFF
--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -384,8 +384,18 @@ private:
 public:
    static void FinishCopy (const Track *n, Track *dest);
 
-   // For use when loading a file.  Return true if ok, else make repair
-   virtual bool LinkConsistencyCheck();
+   //! Check consistency of channel groups, and maybe fix it
+   /*!
+    @param doFix whether to make any changes to correct inconsistencies
+    @param completeList whether to assume that the TrackList containing this
+    is completely loaded; if false, skip some of the checks
+    @return true if no inconsistencies were found
+    */
+   virtual bool LinkConsistencyFix(bool doFix = true, bool completeList = true);
+
+   //! Do the non-mutating part of consistency fix only and return status
+   bool LinkConsistencyCheck(bool completeList)
+   { return const_cast<Track*>(this)->LinkConsistencyFix(false, completeList); }
 
    bool HasOwner() const { return static_cast<bool>(GetOwner());}
 
@@ -400,12 +410,18 @@ public:
 
 protected:
    
-   void SetLinkType(LinkType linkType);
+   /*!
+    @param completeList only influences debug build consistency checking
+    */
+   void SetLinkType(LinkType linkType, bool completeList = true);
    void SetChannel(ChannelType c) noexcept;
 
 private:
    ChannelGroupData &MakeGroupData();
-   void DoSetLinkType(LinkType linkType);
+   /*!
+    @param completeList only influences debug build consistency checking
+    */
+   void DoSetLinkType(LinkType linkType, bool completeList = true);
 
    Track* GetLinkedTrack() const;
    //! Returns true for leaders of multichannel groups

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -208,7 +208,7 @@ auto ProjectFileManager::ReadProjectFile(
             err = true;
          }
 
-         err = ( !t->LinkConsistencyCheck() ) || err;
+         err = ( !t->LinkConsistencyFix() ) || err;
 
          mLastSavedTracks->Add(t->Duplicate());
       }

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -112,7 +112,7 @@ private:
    ChannelType GetChannel() const override;
    virtual void SetPanFromChannelType() override;
 
-   bool LinkConsistencyCheck() override;
+   bool LinkConsistencyFix(bool doFix, bool completeList) override;
 
    /** @brief Get the time at which the first clip in the track starts
     *

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -661,7 +661,7 @@ void OnPaste(const CommandContext &context)
       if (ff) {
          TrackFocus::Get(project).Set(ff);
          ff->EnsureVisible();
-         ff->LinkConsistencyCheck();
+         ff->LinkConsistencyFix();
       }
    }
 }

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -982,7 +982,7 @@ UIHandle::Result TimeShiftHandle::Release
       msg = XO("Moved clips to another track");
       consolidate = false;
       for (auto& pair : mClipMoveState.shifters)
-         pair.first->LinkConsistencyCheck();
+         pair.first->LinkConsistencyFix();
    }
    else {
       msg = ( mClipMoveState.hSlideAmount > 0


### PR DESCRIPTION
... Make a non-mutating version that only checks without doing repairs, safe
to use in a debug assertion.

Don't violate the assertion incorrectly when the reloading of the list of tracks
is in progress.

Fixes error from 93be3aeb that could crash debug build when opening a project.

All other uses of LinkConsistencyCheck() predated that commit, and are changed
to call the new name LinkConsistencyFix().

Resolves: #2863

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
