### PR TITLE
Audacity hangs when turning monitoring off

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -797,6 +797,13 @@ void AudioIO::StartMonitoring( const AudioIOStartStreamOptions &options )
    }
 }
 
+
+void AudioIO::StopMonitoring()
+{
+   StopStream();
+}
+
+
 int AudioIO::StartStream(const TransportTracks &tracks,
    double t0, double t1, double mixerLimit,
    const AudioIOStartStreamOptions &options)

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -800,6 +800,9 @@ void AudioIO::StartMonitoring( const AudioIOStartStreamOptions &options )
 
 void AudioIO::StopMonitoring()
 {
+   // because otherwise the waiting for acknowledgment of stop, will go on forever
+   mAudioThreadAcknowledge.store(Acknowledge::eStop,  std::memory_order::memory_order_release);
+
    StopStream();
 }
 

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -432,6 +432,8 @@ public:
     * the output device in stereo to play the data through */
    void StartMonitoring( const AudioIOStartStreamOptions &options );
 
+   void StopMonitoring();
+
    /** \brief Start recording or playing back audio
     *
     * Allocates buffers for recording and playback, gets the Audio thread to

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -937,6 +937,9 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
          gAudioIO->AILAInitialize();
       #endif
 
+      if (gAudioIO->IsMonitoring())
+         gAudioIO->StopMonitoring();
+
       int token = gAudioIO->StartStream(transportTracks, t0, t1, t1, options);
 
       success = (token != 0);

--- a/src/widgets/MeterPanel.cpp
+++ b/src/widgets/MeterPanel.cpp
@@ -1882,7 +1882,7 @@ void MeterPanel::StartMonitoring()
 
    auto gAudioIO = AudioIO::Get();
    if (gAudioIO->IsMonitoring()){
-      gAudioIO->StopStream();
+      gAudioIO->StopMonitoring();
    } 
 
    if (start && !gAudioIO->IsBusy()){
@@ -1897,13 +1897,6 @@ void MeterPanel::StartMonitoring()
    }
 }
 
-void MeterPanel::StopMonitoring(){
-   mMonitoring = false;
-   auto gAudioIO = AudioIO::Get();
-   if (gAudioIO->IsMonitoring()){
-      gAudioIO->StopStream();
-   } 
-}
 
 void MeterPanel::OnAudioIOStatus(AudioIOEvent evt)
 {

--- a/src/widgets/MeterPanel.h
+++ b/src/widgets/MeterPanel.h
@@ -183,7 +183,7 @@ class AUDACITY_DLL_API MeterPanel final
    bool IsClipping() const override;
 
    void StartMonitoring();
-   void StopMonitoring();
+   //void StopMonitoring();
 
    // These exist solely for the purpose of resetting the toolbars
    struct State{ bool mSaved, mMonitoring, mActive; };


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2861 


The root of the problem is: 
1) turning monitoring on does NOT call `::StartStream`, but 
2) turning monitoring off does call `::StopStream`

(1) means: when monitoring is on, the else branch in `AudioThread::Entry` loop is executed - so the transition of `lastState`can never happen, and when `::StopStream` is called in response to stop monitoring, it will wait forever for the transition.

I understand that the solution I propose, might not be the cleanest one; I think that to have a real clean solution, we'd have to reorganize the code in AudioIO a bit better - for instance, we might want to have a branch in the AudioThread::Entry loop, for the case when monitoring is on.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
