### PR TITLE
Issue2900: fix modulus-by-zero crash mousing over collapsed track...

### DIFF
--- a/src/tracks/ui/EnvelopeHandle.cpp
+++ b/src/tracks/ui/EnvelopeHandle.cpp
@@ -150,7 +150,9 @@ UIHandlePtr EnvelopeHandle::HitEnvelope
    // For amplification using the envelope we introduced the idea of contours.
    // The contours have the same shape as the envelope, which may be partially off-screen.
    // The contours are closer in to the center line.
-   int ContourSpacing = (int)(rect.height / (2 * (zoomMax - zoomMin)));
+   // Beware very short rectangles!  Make this at least 1
+   int ContourSpacing = std::max(1,
+      static_cast<int>(rect.height / (2 * (zoomMax - zoomMin))));
    const int MaxContours = 2;
 
    // Adding ContourSpacing/2 selects a region either side of the contour.


### PR DESCRIPTION
... with no waveform visible because there are drag handles in both channels
of a stereo track make by joining two mono tracks

Resolves: #2900

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
