### PR TITLE
Pass EffectInstance into Effect::PopulateOrExchange overrides...

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -580,6 +580,8 @@ public:
    //! Adds controls to a panel that is given as the parent window of `S`
    /*!
     @param S interface for adding controls to a panel in a dialog
+    @param instance guaranteed to have a lifetime containing that of the returned
+    object
     @param access guaranteed to have a lifetime containing that of the returned
     object
 
@@ -587,8 +589,8 @@ public:
     controls; it might also hold some state needed to implement event handlers
     of the controls; it will exist only while the dialog continues to exist
     */
-   virtual std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) = 0;
+   virtual std::unique_ptr<EffectUIValidator> PopulateUI(ShuttleGui &S,
+      EffectInstance &instance, EffectSettingsAccess &access) = 0;
 
    virtual bool CanExportPresets() = 0;
    virtual void ExportPresets(const EffectSettings &settings) const = 0;

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -22,6 +22,7 @@ class EffectSettingsManager;
 class wxDialog;
 class wxWindow;
 class EffectUIClientInterface;
+class EffectInstance;
 class EffectSettings;
 class EffectSettingsAccess;
 class EffectPlugin;
@@ -30,7 +31,7 @@ class EffectPlugin;
 /*! The dialog may be modal or non-modal */
 using EffectDialogFactory = std::function< wxDialog* (
    wxWindow &parent, EffectPlugin &, EffectUIClientInterface &,
-   EffectSettingsAccess & ) >;
+   EffectInstance &, EffectSettingsAccess & ) >;
 
 class TrackList;
 class WaveTrackFactory;
@@ -61,6 +62,9 @@ public:
    /*!
     But there are a few unusual overrides for historical reasons
 
+    @param instance is only guaranteed to have lifetime suitable for a modal
+    dialog, unless the dialog stores instance.shared_from_this()
+
     @param access is only guaranteed to have lifetime suitable for a modal
     dialog, unless the dialog stores access.shared_from_this()
 
@@ -69,8 +73,8 @@ public:
     */
    virtual int ShowHostInterface(
       wxWindow &parent, const EffectDialogFactory &factory,
-      EffectSettingsAccess &access, bool forceModal = false
-   ) = 0;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      bool forceModal = false) = 0;
 
    virtual void Preview(EffectSettingsAccess &access, bool dryOnly) = 0;
    virtual bool SaveSettingsAsString(

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -205,8 +205,8 @@ void EffectAmplify::Preview(EffectSettingsAccess &access, bool dryOnly)
    Effect::Preview(access, dryOnly);
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectAmplify::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectAmplify::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    enum{ precision = 3 }; // allow (a generous) 3 decimal  places for Amplification (dB)
 

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -57,7 +57,8 @@ public:
    bool Init() override;
    void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -330,8 +330,8 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
    return !cancel;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectAutoDuck::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectAutoDuck::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.StartVerticalLay(true);

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -47,7 +47,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool DoTransferDataToWindow();
 

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -177,8 +177,8 @@ bool EffectBassTreble::CheckWhetherSkipEffect(const EffectSettings &) const
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectBassTreble::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectBassTreble::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -73,7 +73,8 @@ public:
    // Effect Implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -231,8 +231,8 @@ bool EffectChangePitch::CheckWhetherSkipEffect(const EffectSettings &) const
    return (m_dPercentChange == 0.0);
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectChangePitch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectChangePitch::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    DeduceFrequencies(); // Set frequency-related control values based on sample.
 

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -60,7 +60,8 @@ public:
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -237,8 +237,8 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectChangeSpeed::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectChangeSpeed::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    {
       wxString formatId;

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -50,7 +50,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -194,8 +194,8 @@ bool EffectChangeTempo::Process(EffectInstance &, EffectSettings &settings)
    return success;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectChangeTempo::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectChangeTempo::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    enum { precision = 2 };
 

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -58,7 +58,8 @@ public:
    double CalcPreviewInputLength(
       const EffectSettings &settings, double previewLength) const override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -273,8 +273,8 @@ bool EffectClickRemoval::RemoveClicks(size_t len, float *buffer)
    return bResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectClickRemoval::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectClickRemoval::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
    S.SetBorder(10);

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -49,7 +49,8 @@ public:
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
 private:
    bool ProcessOne(int count, WaveTrack * track,

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -156,8 +156,8 @@ TranslatableString RatioLabelFormat( int sliderValue, double value )
 
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectCompressor::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectCompressor::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -49,7 +49,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool DoTransferDataFromWindow();
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -282,8 +282,8 @@ bool EffectDistortion::DoLoadFactoryPreset(int id)
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectDistortion::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectDistortion::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
    S.StartVerticalLay();

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -98,7 +98,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -405,8 +405,8 @@ void EffectDtmf::Validator::PopulateOrExchange(ShuttleGui & S,
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectDtmf::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectDtmf::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    auto &settings = access.Get();
    auto &dtmfSettings = GetSettings(settings);

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -62,7 +62,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
    struct Instance;
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -199,8 +199,8 @@ struct EffectEcho::Validator
 
 
 
-std::unique_ptr<EffectUIValidator>
-EffectEcho::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess& access)
+std::unique_ptr<EffectUIValidator> EffectEcho::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    auto& settings = access.Get();
    auto& myEffSettings = GetSettings(settings);

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -54,7 +54,8 @@ public:
 
    // Effect implementation
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
    struct Validator;
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -174,7 +174,8 @@ int Effect::ShowClientInterface(
 }
 
 int Effect::ShowHostInterface(wxWindow &parent,
-   const EffectDialogFactory &factory, EffectSettingsAccess &access,
+   const EffectDialogFactory &factory,
+   EffectInstance &instance, EffectSettingsAccess &access,
    bool forceModal)
 {
    if (!IsInteractive())
@@ -197,7 +198,7 @@ int Effect::ShowHostInterface(wxWindow &parent,
    // populate it.  That factory function is called indirectly through a
    // std::function to avoid source code dependency cycles.
    EffectUIClientInterface *const client = this;
-   mHostUIDialog = factory(parent, *this, *client, access);
+   mHostUIDialog = factory(parent, *this, *client, instance, access);
    if (!mHostUIDialog)
       return 0;
 
@@ -284,8 +285,8 @@ bool Effect::LoadFactoryDefaults(EffectSettings &settings) const
 
 // EffectUIClientInterface implementation
 
-std::unique_ptr<EffectUIValidator>
-Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> Effect::PopulateUI(ShuttleGui &S,
+   EffectInstance &instance, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mUIParent = parent;
@@ -293,7 +294,7 @@ Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
 //   LoadUserPreset(CurrentSettingsGroup());
 
    // Let the effect subclass provide its own validator if it wants
-   auto result = PopulateOrExchange(S, access);
+   auto result = PopulateOrExchange(S, instance, access);
 
    mUIParent->SetMinSize(mUIParent->GetSizer()->GetMinSize());
 
@@ -594,8 +595,8 @@ bool Effect::Delegate(Effect &delegate, EffectSettings &settings)
       region, mUIFlags, nullptr, nullptr, nullptr);
 }
 
-std::unique_ptr<EffectUIValidator>
-Effect::PopulateOrExchange(ShuttleGui &, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> Effect::PopulateOrExchange(
+   ShuttleGui &, EffectInstance &, EffectSettingsAccess &)
 {
    return nullptr;
 }

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -213,7 +213,8 @@ class AUDACITY_DLL_API Effect /* not final */
    // EffectUIClientInterface implementation
 
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
@@ -233,7 +234,8 @@ class AUDACITY_DLL_API Effect /* not final */
    // EffectPlugin implementation
 
    int ShowHostInterface( wxWindow &parent,
-      const EffectDialogFactory &factory, EffectSettingsAccess &access,
+      const EffectDialogFactory &factory,
+      EffectInstance &instance, EffectSettingsAccess &access,
       bool forceModal = false) override;
    bool SaveSettingsAsString(
       const EffectSettings &settings, wxString & parms) const override;
@@ -280,7 +282,7 @@ class AUDACITY_DLL_API Effect /* not final */
     DefaultEffectUIValidator; default implementation returns null
     */
    virtual std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access);
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access);
 
    // No more virtuals!
 

--- a/src/effects/EffectBase.cpp
+++ b/src/effects/EffectBase.cpp
@@ -168,7 +168,7 @@ bool EffectBase::DoEffect(EffectSettings &settings, double projectRate,
    if ( pParent && dialogFactory && pAccess &&
       IsInteractive()) {
       if (!ShowHostInterface(
-         *pParent, dialogFactory, *pAccess, IsBatchProcessing() ) )
+         *pParent, dialogFactory, *pInstance, *pAccess, IsBatchProcessing() ) )
          return false;
       else
          // Retrieve again after the dialog modified settings

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -332,6 +332,7 @@ bool EffectManager::PromptUser(
       if (pSettings)
          result = effect->ShowHostInterface(
             parent, factory,
+            *effect->MakeInstance(*pSettings), // short-lived object
             *std::make_shared<SimpleEffectSettingsAccess>(*pSettings),
             effect->IsBatchProcessing() ) != 0;
       return result;

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -43,10 +43,11 @@ class EffectUIHost final : public wxDialogWrapper
 public:
    // constructors and destructors
    EffectUIHost(wxWindow *parent,
-                AudacityProject &project,
-                EffectPlugin &effect,
-                EffectUIClientInterface &client,
-                EffectSettingsAccess &access);
+       AudacityProject &project,
+       EffectPlugin &effect,
+       EffectUIClientInterface &client,
+       EffectInstance &instance,
+       EffectSettingsAccess &access);
    virtual ~EffectUIHost();
 
    bool TransferDataToWindow() override;
@@ -98,6 +99,8 @@ private:
    wxWindow *mParent;
    EffectPlugin &mEffectUIHost;
    EffectUIClientInterface &mClient;
+   //! @invariant not null
+   const std::shared_ptr<EffectInstance> mpInstance;
    //! @invariant not null
    const EffectPlugin::EffectSettingsAccessPtr mpAccess;
    RealtimeEffectState *mpState{ nullptr };
@@ -151,7 +154,8 @@ namespace  EffectUI {
 
    AUDACITY_DLL_API
    wxDialog *DialogFactory( wxWindow &parent, EffectPlugin &host,
-      EffectUIClientInterface &client, EffectSettingsAccess &access);
+      EffectUIClientInterface &client, EffectInstance &instance,
+      EffectSettingsAccess &access);
 
    /** Run an effect given the plugin ID */
    // Returns true on success.  Will only operate on tracks that

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -677,9 +677,8 @@ bool EffectEqualization::CloseUI()
    return Effect::CloseUI();
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectEqualization::PopulateOrExchange(
-   ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectEqualization::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    if ( (S.GetMode() == eIsCreating ) && !IsBatchProcessing() )
       access.ModifySettings([&](EffectSettings &settings){

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -137,7 +137,8 @@ public:
 
    bool CloseUI() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -214,9 +214,8 @@ bool EffectFindClipping::ProcessOne(LabelTrack * lt,
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectFindClipping::PopulateOrExchange(
-   ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectFindClipping::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    DoPopulateOrExchange(S, access);
    return nullptr;

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -43,7 +43,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    void DoPopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access);
    bool TransferDataToWindow(const EffectSettings &settings) override;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -212,8 +212,8 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectLoudness::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectLoudness::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.StartVerticalLay(0);
    {

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -59,7 +59,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -169,8 +169,8 @@ size_t EffectNoise::ProcessBlock(EffectSettings &,
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectNoise::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectNoise::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    wxASSERT(nTypes == WXSIZEOF(kTypeStrings));
 

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -47,7 +47,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -445,7 +445,7 @@ EffectType EffectNoiseReduction::GetType() const
  the framework for managing settings of other effects. */
 int EffectNoiseReduction::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &,
-   EffectSettingsAccess &access,
+   EffectInstance &, EffectSettingsAccess &access,
    bool forceModal)
 {
    // to do: use forceModal correctly

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -39,7 +39,8 @@ public:
 
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectSettingsAccess &access, bool forceModal = false) override;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      bool forceModal = false) override;
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
 

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -161,7 +161,7 @@ bool EffectNoiseRemoval::CheckWhetherSkipEffect(const EffectSettings &) const
  the framework for managing settings of other effects. */
 int EffectNoiseRemoval::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &,
-   EffectSettingsAccess &access,
+   EffectInstance &, EffectSettingsAccess &access,
    bool forceModal )
 {
    // to do: use forceModal correctly

--- a/src/effects/NoiseRemoval.h
+++ b/src/effects/NoiseRemoval.h
@@ -55,7 +55,8 @@ public:
 
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectSettingsAccess &access, bool forceModal = false) override;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      bool forceModal = false) override;
    bool Init() override;
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -211,8 +211,8 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectNormalize::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectNormalize::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    mCreating = true;
 

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -46,7 +46,8 @@ public:
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -170,8 +170,8 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
 }
 
 
-std::unique_ptr<EffectUIValidator>
-EffectPaulstretch::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectPaulstretch::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.StartMultiColumn(2, wxALIGN_CENTER);
    {

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -42,7 +42,8 @@ public:
       const EffectSettings &settings, double previewLength) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
 private:
    // EffectPaulstretch implementation

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -191,8 +191,8 @@ size_t EffectPhaser::RealtimeProcess(int group, EffectSettings &settings,
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectPhaser::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectPhaser::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -79,7 +79,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -155,8 +155,8 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
    return bGoodResult;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectRepeat::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectRepeat::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.StartHorizontalLay(wxCENTER, false);
    {

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -43,7 +43,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -294,8 +294,8 @@ bool EffectReverb::DoLoadFactoryPreset(int id)
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectReverb::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectReverb::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.AddSpace(0, 5);
 

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -72,7 +72,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -259,8 +259,8 @@ bool EffectScienFilter::Init()
    return true;
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectScienFilter::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectScienFilter::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.AddSpace(5);
    S.SetSizerProportion(1);

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -64,7 +64,8 @@ public:
 
    bool Init() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -65,8 +65,8 @@ EffectType EffectSilence::GetType() const
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectSilence::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    S.StartVerticalLay();
    {

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -38,7 +38,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -149,8 +149,8 @@ bool EffectTimeScale::Process(
    return EffectSBSMS::Process(instance, settings);
 }
 
-std::unique_ptr<EffectUIValidator>
-EffectTimeScale::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectTimeScale::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -47,7 +47,8 @@ public:
    void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    double CalcPreviewInputLength(
       const EffectSettings &settings, double previewLength) const override;

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -270,8 +270,8 @@ void EffectToneGen::PostSet()
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectToneGen::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> EffectToneGen::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    wxTextCtrl *t;
 

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -48,7 +48,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -662,8 +662,8 @@ bool EffectTruncSilence::Analyze(RegionList& silenceList,
 }
 
 
-std::unique_ptr<EffectUIValidator>
-EffectTruncSilence::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> EffectTruncSilence::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    wxASSERT(nActions == WXSIZEOF(kActionStrings));
 

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -68,7 +68,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1726,8 +1726,8 @@ bool VSTEffect::DoLoadFactoryDefaults(EffectSettings &settings)
 // EffectUIClientInterface implementation
 // ============================================================================
 
-std::unique_ptr<EffectUIValidator>
-VSTEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> VSTEffect::PopulateUI(ShuttleGui &S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mDialog = static_cast<wxDialog *>(wxGetTopLevelParent(parent));

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -178,7 +178,8 @@ class VSTEffect final
       const override;
    std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -858,8 +858,8 @@ bool VST3Effect::IsGraphicalUI()
    return mPlugView != nullptr;
 }
 
-std::unique_ptr<EffectUIValidator>
-VST3Effect::PopulateUI(ShuttleGui& S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> VST3Effect::PopulateUI(ShuttleGui& S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    using namespace Steinberg;
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -150,7 +150,8 @@ public:
    std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    bool IsGraphicalUI() override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;
    bool CanExportPresets() override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -276,8 +276,8 @@ size_t EffectWahwah::Instance::RealtimeProcess(int group, EffectSettings &settin
 
 // Effect implementation
 
-std::unique_ptr<EffectUIValidator>
-EffectWahwah::PopulateOrExchange(ShuttleGui& S, EffectSettingsAccess& access)
+std::unique_ptr<EffectUIValidator> EffectWahwah::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
 {
    auto& settings = access.Get();
    auto& myEffSettings = GetSettings(settings);

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -93,7 +93,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
 
    struct Validator;
    struct Instance;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -1627,8 +1627,8 @@ RegistryPaths AudioUnitEffect::GetFactoryPresets() const
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-std::unique_ptr<EffectUIValidator>
-AudioUnitEffect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> AudioUnitEffect::PopulateUI(ShuttleGui &S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    // OSStatus result;
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -135,7 +135,8 @@ public:
       const override;
    std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1446,7 +1446,8 @@ void LadspaEffect::Validator::PopulateUI(ShuttleGui &S)
 }
 
 std::unique_ptr<EffectUIValidator>
-LadspaEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access)
+LadspaEffect::PopulateOrExchange(ShuttleGui & S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    auto result =
       std::make_unique<Validator>(*this, access, mSampleRate, GetType());

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -113,8 +113,9 @@ public:
    std::shared_ptr<EffectInstance> MakeInstance(EffectSettings &settings)
       const override;
    struct Validator;
-   std::unique_ptr<EffectUIValidator>
-      PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &access) override;
+   std::unique_ptr<EffectUIValidator> PopulateOrExchange(
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1502,8 +1502,8 @@ bool LV2Effect::LoadSettings(
 // EffectUIClientInterface Implementation
 // ============================================================================
 
-std::unique_ptr<EffectUIValidator>
-LV2Effect::PopulateUI(ShuttleGui &S, EffectSettingsAccess &access)
+std::unique_ptr<EffectUIValidator> LV2Effect::PopulateUI(ShuttleGui &S,
+   EffectInstance &, EffectSettingsAccess &access)
 {
    auto parent = S.GetParent();
    mParent = parent;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -330,7 +330,8 @@ public:
       const override;
    std::shared_ptr<EffectInstance> DoMakeInstance(EffectSettings &settings);
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectSettingsAccess &access) override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1052,12 +1052,13 @@ finish:
 
 int NyquistEffect::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &factory,
-   EffectSettingsAccess &access, bool forceModal)
+   EffectInstance &instance, EffectSettingsAccess &access, bool forceModal)
 {
    int res = wxID_APPLY;
    if (!(Effect::TestUIFlags(EffectManager::kRepeatNyquistPrompt) && mIsPrompt)) {
       // Show the normal (prompt or effect) interface
-      res = Effect::ShowHostInterface(parent, factory, access, forceModal);
+      res = Effect::ShowHostInterface(
+         parent, factory, instance, access, forceModal);
    }
 
 
@@ -1076,7 +1077,9 @@ int NyquistEffect::ShowHostInterface(
    effect.SetCommand(mInputCmd);
 
    // Must give effect its own settings to interpret, not those in access
+   // Let's also give it its own instance
    auto newSettings = effect.MakeSettings();
+   auto newInstance = effect.MakeInstance(newSettings);
    auto newAccess = std::make_shared<SimpleEffectSettingsAccess>(newSettings);
 
    if (IsBatchProcessing()) {
@@ -1087,7 +1090,8 @@ int NyquistEffect::ShowHostInterface(
       effect.LoadSettings(cp, newSettings);
 
       // Show the normal (prompt or effect) interface
-      res = effect.ShowHostInterface(parent, factory, *newAccess, forceModal);
+      res = effect.ShowHostInterface(
+         parent, factory, *newInstance, *newAccess, forceModal);
       if (res) {
          CommandParameters cp;
          effect.SaveSettings(newSettings, cp);
@@ -1097,7 +1101,8 @@ int NyquistEffect::ShowHostInterface(
    else {
       if (!factory)
          return 0;
-      res = effect.ShowHostInterface(parent, factory, *newAccess, false );
+      res = effect.ShowHostInterface(
+         parent, factory, *newInstance, *newAccess, false );
       if (!res)
          return 0;
 
@@ -1111,17 +1116,13 @@ int NyquistEffect::ShowHostInterface(
    return res;
 }
 
-std::unique_ptr<EffectUIValidator>
-NyquistEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> NyquistEffect::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    if (mIsPrompt)
-   {
       BuildPromptWindow(S);
-   }
    else
-   {
       BuildEffectWindow(S);
-   }
    return nullptr;
 }
 

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -120,9 +120,11 @@ public:
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectSettingsAccess &access, bool forceModal = false) override;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      bool forceModal = false) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -526,8 +526,8 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
    return true;
 }
 
-std::unique_ptr<EffectUIValidator>
-VampEffect::PopulateOrExchange(ShuttleGui & S, EffectSettingsAccess &)
+std::unique_ptr<EffectUIValidator> VampEffect::PopulateOrExchange(
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
 {
    Vamp::Plugin::ProgramList programs = mPlugin->getPrograms();
 

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -70,7 +70,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectSettingsAccess &access) override;
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
+   override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:


### PR DESCRIPTION
... anticipating the needs of AudioUnit, VST, and VST3 effects, to communicate
changes of controls to the plug-ins.  (Ladspa and LV2 don't need this because
with them, it is the host program that decides where parameter values are in
memory.)

Do all else needed to pass an instance through intermediate levels of stack,
starting at EffectBase::DoEffect().

Make dummy instances in EffectManager and Nyquist, so that ShowHostInterface
can take the instance by reference instead of a possibly null pointer.

Nothing is done yet with the argument.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
