### PR TITLE
Effect list mutual exclusion

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -262,6 +262,7 @@ function( audacity_append_common_compiler_options var use_pch )
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=return-type>
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=dangling-else>
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=return-stack-address>
+         $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=defaulted-function-deleted>
 	      # Yes, CMake will change -D to /D as needed for Windows:
          -DWXINTL_NO_GETTEXT_MACRO
          $<$<CXX_COMPILER_ID:MSVC>:-D_USE_MATH_DEFINES>

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -80,9 +80,13 @@ public:
    //! @return value is not negative
    double GetDuration() const { return mDuration; }
    void SetDuration(double value) { mDuration = std::max(0.0, value); }
+
+   bool GetActive() const { return mActive; }
+   void SetActive(bool value) { mActive = value; }
 private:
    NumericFormatSymbol mDurationFormat{};
    double mDuration{}; //!< @invariant non-negative
+   bool mActive{ true };
 };
 
 //! Externalized state of a plug-in

--- a/libraries/lib-utility/MemoryX.h
+++ b/libraries/lib-utility/MemoryX.h
@@ -486,6 +486,27 @@ NonInterferingBase {
 #endif
 };
 
+//! Workaround for std::make_shared not working on macOs with over-alignment
+/*!
+ Defines a static member function to use as an alternative to that in std::
+ */
+template<typename T> // CRTP
+struct SharedNonInterfering : NonInterferingBase
+{
+   template<typename... Args>
+   static std::shared_ptr<T> make_shared(Args &&...args)
+   {
+      return std::
+#ifdef __APPLE__
+         // shared_ptr must be constructed from unique_ptr on Mac
+         make_unique
+#else
+         make_shared
+#endif
+                    <T>(std::forward<Args>(args)...);
+   }
+};
+
 /*! Given a structure type T, derive a structure with sufficient padding so that there is not false sharing of
  cache lines between successive elements of an array of those structures.
  */
@@ -494,6 +515,11 @@ template< typename T > struct NonInterfering
    , T
 {
    using T::T;
+   // Allow assignment from default-aligned base type
+   void Set(const T &other)
+   {
+      T::operator =(other);
+   }
 };
 
 // These macros are used widely, so declared here.

--- a/libraries/lib-utility/spinlock.h
+++ b/libraries/lib-utility/spinlock.h
@@ -32,6 +32,6 @@ public:
 
    void unlock()
    {
-      flag.clear();
+      flag.clear(std::memory_order_release);
    }
 };

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -410,8 +410,8 @@ AudioIO::~AudioIO()
    mThread.reset();
 }
 
-RealtimeEffectState *AudioIO::AddState(AudacityProject &project,
-   Track *pTrack, const PluginID & id)
+std::shared_ptr<RealtimeEffectState>
+AudioIO::AddState(AudacityProject &project, Track *pTrack, const PluginID & id)
 {
    RealtimeEffects::InitializationScope *pInit = nullptr;
    if (mpTransportState)
@@ -421,13 +421,13 @@ RealtimeEffectState *AudioIO::AddState(AudacityProject &project,
 }
 
 void AudioIO::RemoveState(AudacityProject &project,
-   Track *pTrack, RealtimeEffectState &state)
+   Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState)
 {
    RealtimeEffects::InitializationScope *pInit = nullptr;
    if (mpTransportState)
       if (auto pProject = GetOwningProject(); pProject.get() == &project)
          pInit = &*mpTransportState->mpRealtimeInitialization;
-   RealtimeEffectManager::Get(project).RemoveState(pInit, pTrack, state);
+   RealtimeEffectManager::Get(project).RemoveState(pInit, pTrack, pState);
 }
 
 RealtimeEffects::SuspensionScope AudioIO::SuspensionScope()

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -414,12 +414,12 @@ public:
    static AudioIO *Get();
 
    //! Forwards to RealtimeEffectManager::AddState with proper init scope
-   RealtimeEffectState *AddState(AudacityProject &project,
-      Track *pTrack, const PluginID & id);
+   std::shared_ptr<RealtimeEffectState>
+   AddState(AudacityProject &project, Track *pTrack, const PluginID & id);
 
    //! Forwards to RealtimeEffectManager::RemoveState with proper init scope
    void RemoveState(AudacityProject &project,
-      Track *pTrack, RealtimeEffectState &state);
+      Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState);
 
    RealtimeEffects::SuspensionScope SuspensionScope();
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1225,7 +1225,8 @@ void EffectUIHost::CleanupRealtime()
 {
    if (mSupportsRealtime && mInitialized) {
       if (mpState) {
-         AudioIO::Get()->RemoveState(mProject, nullptr, *mpState);
+         AudioIO::Get()->RemoveState(mProject, nullptr, mpState);
+         mpState.reset();
       /*
          ProjectHistory::Get(mProject).PushState(
             XO("Removed %s effect").Format(mpState->GetEffect()->GetName()),

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -103,7 +103,7 @@ private:
    const std::shared_ptr<EffectInstance> mpInstance;
    //! @invariant not null
    const EffectPlugin::EffectSettingsAccessPtr mpAccess;
-   RealtimeEffectState *mpState{ nullptr };
+   std::shared_ptr<RealtimeEffectState> mpState{};
    std::unique_ptr<EffectUIValidator> mpValidator;
 
    RegistryPaths mUserPresets;

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -80,7 +80,7 @@ const RealtimeEffectList &RealtimeEffectList::Get(const Track &track)
 void RealtimeEffectList::Visit(StateVisitor func)
 {
    for (auto &state : mStates)
-      func(*state, !state->IsActive());
+      func(*state);
 }
 
 std::shared_ptr<RealtimeEffectState>

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -150,10 +150,19 @@ const std::string &RealtimeEffectList::XMLTag()
    return result;
 }
 
+static constexpr auto activeAttribute = "active";
+
 bool RealtimeEffectList::HandleXMLTag(
-   const std::string_view &tag, const AttributesList &)
+   const std::string_view &tag, const AttributesList &attrs)
 {
-   return (tag == XMLTag());
+   if (tag == XMLTag()) {
+      for (auto &[attr, value] : attrs) {
+         if (attr == activeAttribute)
+            SetActive(value.Get<bool>());
+      }
+      return true;
+   }
+   return false;
 }
 
 void RealtimeEffectList::HandleXMLEndTag(const std::string_view &tag)
@@ -185,6 +194,7 @@ void RealtimeEffectList::WriteXML(XMLWriter &xmlFile) const
       return;
 
    xmlFile.StartTag(XMLTag());
+   xmlFile.WriteAttr(activeAttribute, IsActive());
 
    for (const auto & state : mStates)
       state->WriteXML(xmlFile);

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -116,11 +116,6 @@ RealtimeEffectState* RealtimeEffectList::GetStateAt(size_t index) noexcept
    return nullptr;
 }
 
-void RealtimeEffectList::Swap(size_t index1, size_t index2)
-{
-   std::swap(mStates[index1], mStates[index2]);
-}
-
 void RealtimeEffectList::Reorder(size_t fromIndex, size_t toIndex)
 {
    assert(fromIndex < mStates.size());

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -25,8 +25,7 @@ std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
 {
    auto result = std::make_unique<RealtimeEffectList>();
    for (auto &pState : mStates)
-      result->mStates.push_back(
-         std::make_shared<RealtimeEffectState>(*pState));
+      result->mStates.push_back(RealtimeEffectState::make_shared(*pState));
    return result;
 }
 
@@ -86,7 +85,7 @@ void RealtimeEffectList::Visit(StateVisitor func)
 std::shared_ptr<RealtimeEffectState>
 RealtimeEffectList::AddState(const PluginID &id)
 {
-   auto pState = std::make_shared<RealtimeEffectState>(id);
+   auto pState = RealtimeEffectState::make_shared(id);
    if (id.empty() || pState->GetEffect() != nullptr) {
       auto shallowCopy = mStates;
       shallowCopy.emplace_back(pState);

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -104,9 +104,37 @@ void RealtimeEffectList::RemoveState(RealtimeEffectState &state)
       mStates.erase(found);
 }
 
+size_t RealtimeEffectList::GetStatesCount() const noexcept
+{
+   return mStates.size();
+}
+
+RealtimeEffectState* RealtimeEffectList::GetStateAt(size_t index) noexcept
+{
+   if (index < mStates.size())
+      return mStates[index].get();
+   return nullptr;
+}
+
 void RealtimeEffectList::Swap(size_t index1, size_t index2)
 {
    std::swap(mStates[index1], mStates[index2]);
+}
+
+void RealtimeEffectList::Reorder(size_t fromIndex, size_t toIndex)
+{
+   assert(fromIndex < mStates.size());
+   assert(toIndex < mStates.size());
+   if(fromIndex != toIndex)
+   {
+      size_t iFirst, iMid, iLast;
+      if (toIndex < fromIndex)
+         iFirst = toIndex, iMid = fromIndex, iLast = fromIndex + 1;
+      else
+         iFirst = fromIndex, iMid = fromIndex + 1, iLast = toIndex + 1;
+      auto begin = mStates.begin();
+      std::rotate(begin + iFirst, begin + iMid, begin + iLast);
+   }
 }
 
 const std::string &RealtimeEffectList::XMLTag()

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -199,6 +199,16 @@ void RealtimeEffectList::RestoreUndoRedoState(AudacityProject &project) noexcept
    Set(project, shared_from_this());
 }
 
+bool RealtimeEffectList::IsActive() const
+{
+   return mActive.load(std::memory_order_relaxed);
+}
+
+void RealtimeEffectList::SetActive(bool value)
+{
+   (LockGuard{ mLock }, mActive.store(value, std::memory_order_relaxed));
+}
+
 static UndoRedoExtensionRegistry::Entry sEntry {
    [](AudacityProject &project) -> std::shared_ptr<UndoStateExtension> {
       return RealtimeEffectList::Get(project).shared_from_this();

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -64,7 +64,7 @@ public:
 
    //! Use only in the main thread
    //! Returns null if the id is nonempty but no such effect was found
-   std::shared_ptr<RealtimeEffectState> AddState(const PluginID &id);
+   bool AddState(const std::shared_ptr<RealtimeEffectState> &pState);
 
    //! Use only in the main thread
    void RemoveState(const std::shared_ptr<RealtimeEffectState> &pState);

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -34,8 +34,7 @@ class RealtimeEffectList final
    RealtimeEffectList &operator=(const RealtimeEffectList &) = delete;
 
 public:
-   
-   using States = std::vector<std::unique_ptr<RealtimeEffectState>>;
+   using States = std::vector<std::shared_ptr<RealtimeEffectState>>;
 
    RealtimeEffectList();
    virtual ~RealtimeEffectList();
@@ -58,10 +57,10 @@ public:
    void Visit(StateVisitor func);
 
    //! Returns null if the id is nonempty but no such effect was found
-   RealtimeEffectState *AddState(const PluginID &id);
-   void RemoveState(RealtimeEffectState &state);
+   std::shared_ptr<RealtimeEffectState> AddState(const PluginID &id);
+   void RemoveState(const std::shared_ptr<RealtimeEffectState> &pState);
    size_t GetStatesCount() const noexcept;
-   RealtimeEffectState* GetStateAt(size_t index) noexcept;
+   std::shared_ptr<RealtimeEffectState> GetStateAt(size_t index) noexcept;
    /**
     * \brief Changes effect order in the stack
     * \param fromIndex Index of the moved effect

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -39,6 +39,8 @@ public:
    RealtimeEffectList();
    virtual ~RealtimeEffectList();
 
+   //! Should be called (for pushing undo states) only from main thread, to
+   //! avoid races
    std::unique_ptr<ClientData::Cloneable<>> Clone() const override;
 
    static RealtimeEffectList &Get(AudacityProject &project);
@@ -56,13 +58,20 @@ public:
    //! Apply the function to all states sequentially.
    void Visit(StateVisitor func);
 
+   //! Use only in the main thread
    //! Returns null if the id is nonempty but no such effect was found
    std::shared_ptr<RealtimeEffectState> AddState(const PluginID &id);
+
+   //! Use only in the main thread
    void RemoveState(const std::shared_ptr<RealtimeEffectState> &pState);
+
+   //! Use only in the main thread, to avoid races
    size_t GetStatesCount() const noexcept;
+
+   //! Use only in the main thread, to avoid races
    std::shared_ptr<RealtimeEffectState> GetStateAt(size_t index) noexcept;
    /**
-    * \brief Changes effect order in the stack
+    * \brief Use only in the main thread. Changes effect order in the stack
     * \param fromIndex Index of the moved effect
     * \param toIndex Desired position of the moved effect
     */
@@ -71,8 +80,14 @@ public:
    static const std::string &XMLTag();
    bool HandleXMLTag(
       const std::string_view &tag, const AttributesList &attrs) override;
+
+   //! Use only in the main thread.  May remove a failed state
    void HandleXMLEndTag(const std::string_view &tag) override;
+
+   //! Use only in the main thread.  May add a state while deserializing
    XMLTagHandler *HandleXMLChild(const std::string_view &tag) override;
+
+   //! Use only in the main thread, to avoid races
    void WriteXML(XMLWriter &xmlFile) const;
 
    void RestoreUndoRedoState(AudacityProject &project) noexcept override;

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -62,7 +62,6 @@ public:
    void RemoveState(RealtimeEffectState &state);
    size_t GetStatesCount() const noexcept;
    RealtimeEffectState* GetStateAt(size_t index) noexcept;
-   void Swap(size_t index1, size_t index2);
    /**
     * \brief Changes effect order in the stack
     * \param fromIndex Index of the moved effect

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -56,8 +56,7 @@ public:
    static RealtimeEffectList &Get(Track &track);
    static const RealtimeEffectList &Get(const Track &track);
 
-   using StateVisitor =
-      std::function<void(RealtimeEffectState &state, bool bypassed)>;
+   using StateVisitor = std::function<void(RealtimeEffectState &state)>;
 
    //! Apply the function to all states sequentially.
    void Visit(StateVisitor func);

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -34,6 +34,9 @@ class RealtimeEffectList final
    RealtimeEffectList &operator=(const RealtimeEffectList &) = delete;
 
 public:
+   
+   using States = std::vector<std::unique_ptr<RealtimeEffectState>>;
+
    RealtimeEffectList();
    virtual ~RealtimeEffectList();
 
@@ -57,9 +60,15 @@ public:
    //! Returns null if the id is nonempty but no such effect was found
    RealtimeEffectState *AddState(const PluginID &id);
    void RemoveState(RealtimeEffectState &state);
+   size_t GetStatesCount() const noexcept;
+   RealtimeEffectState* GetStateAt(size_t index) noexcept;
    void Swap(size_t index1, size_t index2);
-
-   using States = std::vector<std::unique_ptr<RealtimeEffectState>>;
+   /**
+    * \brief Changes effect order in the stack
+    * \param fromIndex Index of the moved effect
+    * \param toIndex Desired position of the moved effect
+    */
+   void Reorder(size_t fromIndex, size_t toIndex);
 
    static const std::string &XMLTag();
    bool HandleXMLTag(

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -9,6 +9,7 @@
 #ifndef __AUDACITY_REALTIMEEFFECTLIST_H__
 #define __AUDACITY_REALTIMEEFFECTLIST_H__
 
+#include <atomic>
 #include <vector>
 
 #include "PluginProvider.h" // for PluginID
@@ -95,11 +96,19 @@ public:
 
    void RestoreUndoRedoState(AudacityProject &project) noexcept override;
 
+   //! Non-blocking atomic boolean load
+   bool IsActive() const;
+
+   //! Done under a lock guard
+   void SetActive(bool value);
+
 private:
    States mStates;
 
    using LockGuard = std::lock_guard<Lock>;
    mutable Lock mLock;
+
+   std::atomic<bool> mActive{ true };
 };
 
 #endif // __AUDACITY_REALTIMEEFFECTLIST_H__

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "PluginProvider.h" // for PluginID
+#include "spinlock.h"
 #include "UndoManager.h"
 #include "XMLTagHandler.h"
 
@@ -34,10 +35,13 @@ class RealtimeEffectList final
    RealtimeEffectList &operator=(const RealtimeEffectList &) = delete;
 
 public:
+   using Lock = spinlock;
    using States = std::vector<std::shared_ptr<RealtimeEffectState>>;
 
    RealtimeEffectList();
    virtual ~RealtimeEffectList();
+
+   Lock &GetLock() const { return mLock; }
 
    //! Should be called (for pushing undo states) only from main thread, to
    //! avoid races
@@ -94,6 +98,9 @@ public:
 
 private:
    States mStates;
+
+   using LockGuard = std::lock_guard<Lock>;
+   mutable Lock mLock;
 };
 
 #endif // __AUDACITY_REALTIMEEFFECTLIST_H__

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -159,15 +159,14 @@ void RealtimeEffectManager::ProcessStart(bool suspended)
    if (!suspended)
    {
       VisitAll([](RealtimeEffectState &state){
-         if (state.IsActive())
-            state.ProcessStart();
+         state.ProcessStart();
       });
    }
 }
 
 //
 
-// This will be called in a different thread than the main GUI thread.
+// This will be called in a thread other than the main GUI thread.
 //
 size_t RealtimeEffectManager::Process(bool suspended, Track &track,
    float *const *buffers, float *const *scratch,

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -273,8 +273,7 @@ void RealtimeEffectManager::VisitAll(StateVisitor func)
       RealtimeEffectList::Get(*leader).Visit(func);
 }
 
-RealtimeEffectState *
-RealtimeEffectManager::AddState(
+std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
    RealtimeEffects::InitializationScope *pScope,
    Track *pTrack, const PluginID & id)
 {
@@ -315,12 +314,12 @@ RealtimeEffectManager::AddState(
          state.AddTrack(*leader, chans, rate);
       }
    }
-   return &state;
+   return pState;
 }
 
 void RealtimeEffectManager::RemoveState(
    RealtimeEffects::InitializationScope *pScope,
-   Track *pTrack, RealtimeEffectState &state)
+   Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState)
 {
    auto pLeader = pTrack ? *TrackList::Channels(pTrack).begin() : nullptr;
    RealtimeEffectList &states = pLeader
@@ -338,9 +337,9 @@ void RealtimeEffectManager::RemoveState(
    std::lock_guard<std::mutex> guard(mLock);
 
    if (mActive)
-      state.Finalize();
+      pState->Finalize();
 
-   states.RemoveState(state);
+   states.RemoveState(pState);
 }
 
 auto RealtimeEffectManager::GetLatency() const -> Latency

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -394,10 +394,11 @@ void RealtimeEffectManager::RemoveState(
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 
+   // Remove the state from processing (under the lock guard) before finalizing
+   states.RemoveState(pState);
+
    if (mActive)
       pState->Finalize();
-
-   states.RemoveState(pState);
 }
 
 auto RealtimeEffectManager::GetLatency() const -> Latency

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -112,17 +112,16 @@ void RealtimeEffectManager::Finalize() noexcept
 
 void RealtimeEffectManager::Suspend()
 {
-   // Protect...
-   std::lock_guard<std::mutex> guard(mLock);
-
    // Already suspended...bail
    if (GetSuspended())
       return;
 
    // Show that we aren't going to be doing anything
+   // (set atomically, before next ProcessingScope)
    SetSuspended(true);
 
    // And make sure the effects don't either
+   // (each RealtimeEffectList has its own, fine-grained lock)
    VisitAll([](RealtimeEffectState &state){
       state.Suspend();
    });
@@ -130,19 +129,18 @@ void RealtimeEffectManager::Suspend()
 
 void RealtimeEffectManager::Resume() noexcept
 {
-   // Protect...
-   std::lock_guard<std::mutex> guard(mLock);
-
    // Already running...bail
    if (!GetSuspended())
       return;
 
    // Tell the effects to get ready for more action
+   // (each RealtimeEffectList has its own, fine-grained lock)
    VisitAll([](RealtimeEffectState &state){
       state.Resume();
    });
 
    // And we should too
+   // (set atomically, before next ProcessingScope)
    SetSuspended(false);
 }
 
@@ -151,9 +149,6 @@ void RealtimeEffectManager::Resume() noexcept
 //
 void RealtimeEffectManager::ProcessStart(bool suspended)
 {
-   // Protect...
-   std::lock_guard<std::mutex> guard(mLock);
-
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended.
    if (!suspended) {
@@ -172,9 +167,6 @@ size_t RealtimeEffectManager::Process(bool suspended, Track &track,
    float *const *buffers, float *const *scratch,
    size_t numSamples)
 {
-   // Protect...
-   std::lock_guard<std::mutex> guard(mLock);
-
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended, so allow the samples to pass as-is.
    if (suspended)
@@ -239,9 +231,6 @@ size_t RealtimeEffectManager::Process(bool suspended, Track &track,
 //
 void RealtimeEffectManager::ProcessEnd(bool suspended) noexcept
 {
-   // Protect...
-   std::lock_guard<std::mutex> guard(mLock);
-
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended.
    if (!suspended)
@@ -347,8 +336,6 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
       else
          return nullptr;
    }
-   // Protect...
-   std::lock_guard<std::mutex> guard(mLock);
 
    auto pState = RealtimeEffectState::make_shared(id);
    auto &state = *pState;
@@ -392,8 +379,6 @@ void RealtimeEffectManager::RemoveState(
       else
          return;
    }
-   // Protect...
-   std::lock_guard<std::mutex> guard(mLock);
 
    // Remove the state from processing (under the lock guard) before finalizing
    states.RemoveState(pState);
@@ -402,7 +387,10 @@ void RealtimeEffectManager::RemoveState(
       pState->Finalize();
 }
 
+// Where is this used?
+#if 0
 auto RealtimeEffectManager::GetLatency() const -> Latency
 {
-   return mLatency;
+   return mLatency; // should this be atomic?
 }
+#endif

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -350,9 +350,7 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 
-   auto pState = states.AddState(id);
-   if (!pState)
-      return nullptr;
+   auto pState = RealtimeEffectState::make_shared(id);
    auto &state = *pState;
    
    if (mActive)
@@ -372,6 +370,9 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
          state.AddTrack(*leader, chans, rate);
       }
    }
+   bool added = states.AddState(pState);
+   if (!added)
+      return nullptr;
    return pState;
 }
 

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -104,11 +104,11 @@ private:
    using StateVisitor = std::function<void(RealtimeEffectState &state)> ;
 
    //! Visit the per-project states first, then states for leader if not null
-   void VisitGroup(Track &leader, StateVisitor func);
+   void VisitGroup(Track &leader, StateVisitor func, bool activeOnly = false);
 
    //! Visit the per-project states first, then all tracks from AddTrack
    /*! Tracks are visited in unspecified order */
-   void VisitAll(StateVisitor func);
+   void VisitAll(StateVisitor func, bool activeOnly = false);
 
    AudacityProject &mProject;
 

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -48,7 +48,7 @@ public:
    bool IsActive() const noexcept;
    void Suspend();
    void Resume() noexcept;
-   Latency GetLatency() const;
+//   Latency GetLatency() const;
 
    //! Main thread appends a global or per-track effect
    /*!
@@ -112,7 +112,6 @@ private:
 
    AudacityProject &mProject;
 
-   std::mutex mLock;
    Latency mLatency{ 0 };
 
    double mRate;

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -101,8 +101,7 @@ private:
    RealtimeEffectManager(const RealtimeEffectManager&) = delete;
    RealtimeEffectManager &operator=(const RealtimeEffectManager&) = delete;
 
-   using StateVisitor =
-      std::function<void(RealtimeEffectState &state, bool bypassed)> ;
+   using StateVisitor = std::function<void(RealtimeEffectState &state)> ;
 
    //! Visit the per-project states first, then states for leader if not null
    void VisitGroup(Track &leader, StateVisitor func);

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -57,8 +57,9 @@ public:
     @param id identifies the effect
     @return if null, the given id was not found
     */
-   RealtimeEffectState *AddState(RealtimeEffects::InitializationScope *pScope,
-      Track *pTrack, const PluginID & id);
+   std::shared_ptr<RealtimeEffectState> AddState(
+      RealtimeEffects::InitializationScope *pScope, Track *pTrack,
+      const PluginID & id);
 
    //! Main thread removes a global or per-track effect
    /*!
@@ -68,7 +69,7 @@ public:
     */
    /*! No effect if realtime is active but scope is not supplied */
    void RemoveState(RealtimeEffects::InitializationScope *pScope,
-      Track *pTrack, RealtimeEffectState &state);
+      Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState);
 
 private:
    friend RealtimeEffects::InitializationScope;

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -172,7 +172,7 @@ const EffectInstanceFactory *RealtimeEffectState::GetEffect()
       mPlugin = EffectFactory::Call(mID);
       if (mPlugin)
          // Also make EffectSettings
-         mSettings = mPlugin->MakeSettings();
+         mSettings.Set(mPlugin->MakeSettings());
    }
    return mPlugin;
 }

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -160,6 +160,12 @@ void RealtimeEffectState::SetID(const PluginID & id)
       assert(empty);
 }
 
+const PluginID& RealtimeEffectState::GetID() const noexcept
+{
+   return mID;
+}
+
+
 const EffectInstanceFactory *RealtimeEffectState::GetEffect()
 {
    if (!mPlugin) {

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -12,12 +12,12 @@
 #define __AUDACITY_REALTIMEEFFECTSTATE_H__
 
 #include <atomic>
-#include <memory>
 #include <unordered_map>
 #include <vector>
 #include <cstddef>
 #include "EffectInterface.h"
 #include "GlobalVariable.h"
+#include "MemoryX.h"
 #include "PluginProvider.h" // for PluginID
 #include "XMLTagHandler.h"
 
@@ -25,6 +25,7 @@ class EffectSettingsAccess;
 class Track;
 
 class RealtimeEffectState : public XMLTagHandler
+   , public SharedNonInterfering<RealtimeEffectState>
 {
 public:
    struct AUDACITY_DLL_API EffectFactory : GlobalHook<EffectFactory,
@@ -87,7 +88,7 @@ private:
    //! Stateless effect object
    const EffectInstanceFactory *mPlugin{};
    
-   EffectSettings mSettings;
+   NonInterfering<EffectSettings> mSettings;
 
    //! @}
 

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -40,6 +40,7 @@ public:
     Call with empty id is ignored.
     Called by the constructor that takes an id */
    void SetID(const PluginID & id);
+   const PluginID& GetID() const noexcept;
    const EffectInstanceFactory *GetEffect();
 
    bool Suspend();

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -60,7 +60,10 @@ public:
       size_t numSamples);
    //! Worker thread finishes a batch of samples
    bool ProcessEnd();
+
+   //! To be tested only in the worker thread
    bool IsActive() const noexcept;
+
    //! Main thread cleans up playback
    bool Finalize() noexcept;
 
@@ -101,8 +104,6 @@ private:
 
    size_t mCurrentProcessor{ 0 };
    std::unordered_map<Track *, size_t> mGroups;
-
-   std::atomic<int> mSuspendCount{ 1 };    // Effects are initially suspended
 };
 
 #endif // __AUDACITY_REALTIMEEFFECTSTATE_H__


### PR DESCRIPTION
Resolves: #2871
Resolves: #2892
Resolves: #2986

Implement the on/off states ro the list as a whole, and for each state within the list, and make them persistent.

Make correctly synchronized, race-free inter-thread communication of changes of the on/off states and the sequence of effects in the list.

Make the saving of copies of the effect stack into undo history race-free.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
