### PR TITLE
Issue #2909: Export Multiple dialog: focus issue on Windows

### DIFF
--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -219,6 +219,13 @@ int ExportMultipleDialog::ShowModal()
 
    EnableControls();
 
+   // This is a work around for issue #2909, and ensures that
+   // when the dialog opens, the first control is the focus.
+   // The work around is only needed on Windows.
+#if defined(__WXMSW__)
+   mDir->SetFocus();
+#endif
+
    return wxDialogWrapper::ShowModal();
 }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2909

Problem:
When the Export Multiple dialog opens on Windows, the first control is not the focus.

This bug was introduced between Audacity 2.4.1 and 2.4.2. During this period there were no significant changes to the code of this dialog. However the version of wxWidgets changed from 3.1.1 to 3.1.3, so this is probably a wxWidgets bug.

Fix:
Explicitly setting the first control to be the focus, as a work around for the assumed wxWidgets bug.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
