### PR TITLE
Issue #2912: incorrect location of focused track for AT

### DIFF
--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -319,7 +319,7 @@ wxAccStatus TrackPanelAx::GetLocation( wxRect& rect, int elementId )
 
    if( elementId == wxACC_SELF )
    {
-      rect = GetWindow()->GetRect();
+      rect = GetWindow()->GetScreenRect();
    }
    else
    {
@@ -339,9 +339,8 @@ wxAccStatus TrackPanelAx::GetLocation( wxRect& rect, int elementId )
       const int dx = 1;
 #endif
       rect.Inflate(dx, dx);
+      rect.SetPosition(GetWindow()->ClientToScreen(rect.GetPosition()));
    }
-
-   rect.SetPosition( GetWindow()->GetParent()->ClientToScreen( rect.GetPosition() ) );
 
    return wxACC_OK;
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2912

Problem:
Location of focused track provided for assistive technology is incorrect - it should be roughly the same as the yellow outline.

In TrackPanelAx::GetLocation(), in the call rect.SetPosition(), in the case of a focused track the Track Panel's parent (the Main Panel) is incorrectly being used. This didn't cause a problem as the top left corner of the Track Panel and the Main panel used to be the same. However, during 3.2.0 development, a change was made so that the Main panel now includes the Timeline, and so the top left hand corners no longer coincide.

Fix:
For a focused track, don't use the Track Panel's parent in the call rect.SetPosition()

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
