### PR TITLE
issue i2911: wrong duration in built-in Generators (Turkish)

### DIFF
--- a/locale/tr.po
+++ b/locale/tr.po
@@ -18140,7 +18140,7 @@ msgstr "sa:dd:ss + örnekler"
 #. * to '>' if your language uses a '.'.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060 s+># samples"
-msgstr "0100 sa 060 da 060 sn+>örnek sayısı"
+msgstr "0100 sa 060 da 060 sn+># örnek sayısı"
 
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2911

When Audacity is set to use Turkish, the built-in "Generate" effects fail to set their default duration to match the selection.

Caused by typo in tr.po
Note: This after this fix the duration is set correctly. However, following the steps to reproduce, there is a problem with the length of the resulting first and second clips being the wrong length. This is a separate bug and also occurs when the language is set to English (and I presume others).


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
