### PR TITLE
Au instance

### DIFF
--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -364,7 +364,8 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
          // should now be treated the same way.
          return false;
       }
-      wxASSERT(processed == curBlockSize);
+      if (processed != curBlockSize)
+         return false;
       wxUnusedVar(processed);
 
       // Bump to next input buffer position

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -233,7 +233,6 @@ bool AudioUnitEffect::InitializeInstance()
       return false;
 
    mSampleRate = 44100;
-   GetChannelCounts();
    SetRateAndChannels();
 
    // Retrieve the desired number of frames per slice
@@ -270,6 +269,8 @@ bool AudioUnitEffect::InitializePlugin()
    // It's not just for implementing EffectInstance.  AudioUnits is unlike other
    // third party effect families that distinguish the notions of plug-in and
    // instance.
+
+   GetChannelCounts();
 
    // When AudioUnitEffect implements its own proper Instance class, this
    // should call CreateAudioUnit() directly and not do the rest of

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -524,13 +524,13 @@ size_t AudioUnitEffect::ProcessBlock(EffectSettings &,
 {
    // mAudioIns and mAudioOuts don't change after plugin initialization,
    // so ProcessInitialize() made sufficient allocations
-   assert(PackedArray::Count(mInputList) >= mAudioIns);
+   assert(Count(mInputList) >= mAudioIns);
    for (size_t i = 0; i < mAudioIns; ++i)
       mInputList[i] = { 1, static_cast<UInt32>(sizeof(float) * blockLen),
          const_cast<float*>(inBlock[i]) };
 
    // See previous comment
-   assert(PackedArray::Count(mOutputList) >= mAudioOuts);
+   assert(Count(mOutputList) >= mAudioOuts);
    for (size_t i = 0; i < mAudioOuts; ++i)
       mOutputList[i] = { 1, static_cast<UInt32>(sizeof(float) * blockLen),
          outBlock[i] };
@@ -1182,8 +1182,7 @@ OSStatus AudioUnitEffect::Render(AudioUnitRenderActionFlags *inActionFlags,
                                  AudioBufferList *ioData)
 {
    size_t i = 0;
-   auto size =
-      std::min<size_t>(ioData->mNumberBuffers, PackedArray::Count(mInputList));
+   auto size = std::min<size_t>(ioData->mNumberBuffers, Count(mInputList));
    for (; i < size; ++i)
       ioData->mBuffers[i].mData = mInputList[i].mData;
    // Some defensive code here just in case SDK requests from us an unexpectedly

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -223,6 +223,8 @@ private:
 
    AudioUnitEffect *const mMaster;     // non-NULL if a slave
 public:
+   //! Whether the master instance is now allocated to a group number
+   bool mRecruited{ false };
    AudioUnitEffectArray mSlaves;
    mutable bool mInitialFetchDone{ false };
 };


### PR DESCRIPTION
Resolves: #2939
Partly resolves: #3069

Define the Instance class for AudioUnit effects.

Incidentally, ouput monitoring as with AUDymamicProcessing works again in the non-modal dialog (ALTHOUGH, it is actually reflecting only the first track, not the mix).

However, I anticipate that after full statelessness, and use of such effects in the per-track effect stacks -- there will remain other problems with slow rate of update.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
