### PR TITLE
Stateless vst3 settings

### DIFF
--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -431,6 +431,14 @@ bool VST3Effect::SaveSettings(
    return true;
 }
 
+
+EffectSettings VST3Effect::MakeSettings() const
+{
+   auto result = EffectSettings::Make<VST3EffectSettings>();
+   return result;
+}
+
+
 bool VST3Effect::LoadSettings(
    const CommandParameters & parms, EffectSettings &settings) const
 {
@@ -461,11 +469,15 @@ bool VST3Effect::LoadSettings(
       } while(parms.GetNextEntry(key, index));
    }
 
+   VST3EffectSettings specificSettings;
+   FetchSettings(specificSettings);
+   GetSettings(settings) = specificSettings;
+
    return true;
 }
 
 bool VST3Effect::LoadUserPreset(
-   const RegistryPath& name, EffectSettings &settings) const
+   const RegistryPath& name, EffectSettings& settings) const
 {
    using namespace Steinberg;
 
@@ -495,6 +507,10 @@ bool VST3Effect::LoadUserPreset(
    }
    SyncParameters(settings);
 
+   VST3EffectSettings specificSettings;
+   FetchSettings(specificSettings);
+   GetSettings(settings) = specificSettings;
+  
    return true;
 }
 
@@ -539,7 +555,7 @@ RegistryPaths VST3Effect::GetFactoryPresets() const
    return mFactoryPresets;
 }
 
-bool VST3Effect::LoadFactoryPreset(int id, EffectSettings &) const
+bool VST3Effect::LoadFactoryPreset(int id, EffectSettings& settings) const
 {
    if(id >= 0 && id < mFactoryPresets.size())
    {
@@ -547,10 +563,15 @@ bool VST3Effect::LoadFactoryPreset(int id, EffectSettings &) const
       // To do: externalize state so const_cast isn't needed
       return const_cast<VST3Effect*>(this)->LoadPreset(filename.GetFullPath());
    }
+
+   VST3EffectSettings specificSettings;
+   FetchSettings(specificSettings);
+   GetSettings(settings) = specificSettings;
+
    return true;
 }
 
-bool VST3Effect::LoadFactoryDefaults(EffectSettings &) const
+bool VST3Effect::LoadFactoryDefaults(EffectSettings& settings) const
 {
    using namespace Steinberg;
    if(mComponentHandler == nullptr)
@@ -574,6 +595,10 @@ bool VST3Effect::LoadFactoryDefaults(EffectSettings &) const
          mEditController->setParamNormalized(parameterInfo.id, parameterInfo.defaultNormalizedValue);
       }
    }
+
+   VST3EffectSettings specificSettings;
+   FetchSettings(specificSettings);
+   GetSettings(settings) = specificSettings;
 
    return true;
 }
@@ -1053,7 +1078,7 @@ void VST3Effect::ExportPresets(const EffectSettings &) const
    }
 }
 
-void VST3Effect::ImportPresets(EffectSettings &)
+void VST3Effect::ImportPresets(EffectSettings& settings)
 {
    using namespace Steinberg;
 
@@ -1072,6 +1097,10 @@ void VST3Effect::ImportPresets(EffectSettings &)
       return;
 
    LoadPreset(path);
+
+   VST3EffectSettings specificSettings;
+   FetchSettings(specificSettings);
+   GetSettings(settings) = specificSettings;
 }
 
 bool VST3Effect::HasOptions()

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -343,11 +343,6 @@ bool VST3Effect::SupportsAutomation() const
    return false;
 }
 
-struct VST3Effect::ParameterInfo
-{
-   Steinberg::Vst::ParameterInfo mVstParamInfo;
-};
-
 
 bool VST3Effect::ForEachParameter(ParameterVisitor visitor) const
 {
@@ -389,7 +384,7 @@ bool VST3Effect::FetchSettings(VST3EffectSettings& settings) const
 
       [&](const ParameterInfo& pi)
       {
-        const auto id = pi.mVstParamInfo.id;
+        const auto id = pi.id;
         settings.mValues[id] = mEditController->getParamNormalized(id);
         return true;
       }
@@ -406,7 +401,7 @@ bool VST3Effect::StoreSettings(const VST3EffectSettings& settings) const
          if (mComponentHandler == nullptr)
             return false;
 
-         const auto id = pi.mVstParamInfo.id;
+         const auto id = pi.id;
 
          auto itr = settings.mValues.find(id);
          if (itr != settings.mValues.end())
@@ -448,8 +443,8 @@ bool VST3Effect::SaveSettings(
       [&](const ParameterInfo& pi)
       {
          parms.Write(
-            VST3Utils::MakeAutomationParameterKey(pi.mVstParamInfo),
-            mEditController->getParamNormalized(pi.mVstParamInfo.id)
+            VST3Utils::MakeAutomationParameterKey(pi),
+            mEditController->getParamNormalized(pi.id)
          );
 
          return true;   

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -359,16 +359,8 @@ bool VST3Effect::ForEachParameter(ParameterVisitor visitor) const
          if (vstParameterInfo.flags & Steinberg::Vst::ParameterInfo::kCanAutomate)
          {
             if (!visitor(ParameterInfo{ vstParameterInfo } ))
-               return false;
+               break;
          }
-         else
-         {
-            return false;
-         }
-      }
-      else
-      {
-         return false;
       }
    }
 

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -383,6 +383,8 @@ bool VST3Effect::ForEachParameter(ParameterVisitor visitor) const
 
 bool VST3Effect::FetchSettings(VST3EffectSettings& settings) const
 {
+   settings.mValues.clear();
+
    return ForEachParameter(
 
       [&](const ParameterInfo& pi)

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -494,9 +494,7 @@ bool VST3Effect::LoadSettings(
       } while(parms.GetNextEntry(key, index));
    }
 
-   VST3EffectSettings specificSettings;
-   FetchSettings(specificSettings);
-   GetSettings(settings) = specificSettings;
+   FetchSettings(GetSettings(settings));
 
    return true;
 }
@@ -532,9 +530,7 @@ bool VST3Effect::LoadUserPreset(
    }
    SyncParameters(settings);
 
-   VST3EffectSettings specificSettings;
-   FetchSettings(specificSettings);
-   GetSettings(settings) = specificSettings;
+   FetchSettings(GetSettings(settings));
   
    return true;
 }
@@ -589,9 +585,7 @@ bool VST3Effect::LoadFactoryPreset(int id, EffectSettings& settings) const
       return const_cast<VST3Effect*>(this)->LoadPreset(filename.GetFullPath());
    }
 
-   VST3EffectSettings specificSettings;
-   FetchSettings(specificSettings);
-   GetSettings(settings) = specificSettings;
+   FetchSettings(GetSettings(settings));
 
    return true;
 }
@@ -621,9 +615,7 @@ bool VST3Effect::LoadFactoryDefaults(EffectSettings& settings) const
       }
    }
 
-   VST3EffectSettings specificSettings;
-   FetchSettings(specificSettings);
-   GetSettings(settings) = specificSettings;
+   FetchSettings(GetSettings(settings));
 
    return true;
 }
@@ -1123,9 +1115,7 @@ void VST3Effect::ImportPresets(EffectSettings& settings)
 
    LoadPreset(path);
 
-   VST3EffectSettings specificSettings;
-   FetchSettings(specificSettings);
-   GetSettings(settings) = specificSettings;
+   FetchSettings(GetSettings(settings));
 }
 
 bool VST3Effect::HasOptions()

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -460,7 +460,30 @@ bool VST3Effect::LoadSettings(
 
    if(mComponentHandler == nullptr)
       return false;
-   
+
+#if 0
+   // new version; will be activated as soon as I find a way to reach this method
+   ForEachParameter(
+
+      [&](const ParameterInfo& pi)
+      {
+         const auto id    = pi.id;
+         const auto value = pi.defaultNormalizedValue;
+
+         if (mComponentHandler->beginEdit(id) == kResultOk)
+         {
+            auto cleanup = finally([&] {
+               mComponentHandler->endEdit(id);
+            });
+            mComponentHandler->performEdit(id, value);
+         }
+         mEditController->setParamNormalized(id, value);
+         return true;
+      }
+   );
+
+#else
+
    long index { };
    wxString key;
    if(parms.GetFirstEntry(key, index))
@@ -482,6 +505,8 @@ bool VST3Effect::LoadSettings(
          }
       } while(parms.GetNextEntry(key, index));
    }
+
+#endif
 
    FetchSettings(GetSettings(settings));
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -183,12 +183,29 @@ private:
 
    bool StoreSettings(const VST3EffectSettings& settings) const;
 
+   VST3EffectSettings mSettings;  // temporary
+
+   //! This function will be rewritten when the effect is really stateless
+   VST3EffectSettings& GetSettings(EffectSettings&) const
+   {
+      return const_cast<VST3Effect*>(this)->mSettings;
+   }
+
+   //! This function will be rewritten when the effect is really stateless
+   const VST3EffectSettings& GetSettings(const EffectSettings&) const
+   {
+      return mSettings;
+   }
+
+   //! This is what ::GetSettings will be when the effect becomes really stateless
+   /*    
    static inline VST3EffectSettings& GetSettings(EffectSettings& settings)
    {
       auto pSettings = settings.cast<VST3EffectSettings>();
       assert(pSettings);
       return *pSettings;
    }
+   */
 
    struct ParameterInfo;
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -38,6 +38,12 @@ namespace Steinberg
 
 class ParameterChangesProvider;
 
+
+struct VST3EffectSettings
+{
+   std::unordered_map<Steinberg::Vst::ParamID, Steinberg::Vst::ParamValue> mValues;
+};
+
 /**
  * \brief Objects of this class connect Audacity with VST3 effects
  */
@@ -169,4 +175,8 @@ private:
    bool LoadPreset(const wxString& path);
 
    void ReloadUserOptions();
+
+   bool FetchSettings(VST3EffectSettings& settings) const;
+
+   bool StoreSettings(const VST3EffectSettings& settings) const;
 };

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -165,6 +165,8 @@ public:
    bool HasOptions() override;
    void ShowOptions() override;
 
+   EffectSettings MakeSettings() const override;
+
 private:
    void OnEffectWindowResize(wxSizeEvent & evt);
 
@@ -179,4 +181,12 @@ private:
    bool FetchSettings(VST3EffectSettings& settings) const;
 
    bool StoreSettings(const VST3EffectSettings& settings) const;
+
+   static inline VST3EffectSettings& GetSettings(EffectSettings& settings)
+   {
+      auto pSettings = settings.cast<VST3EffectSettings>();
+      assert(pSettings);
+      return *pSettings;
+   }
+
 };

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -207,7 +207,7 @@ private:
    }
    */
 
-   struct ParameterInfo;
+   using ParameterInfo = Steinberg::Vst::ParameterInfo;
 
    //! Return value: if true, continue visiting
    using ParameterVisitor =

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -18,6 +18,7 @@
 #include <pluginterfaces/gui/iplugview.h>
 #include <pluginterfaces/vst/ivstaudioprocessor.h>
 #include <public.sdk/source/vst/hosting/module.h>
+#include <unordered_map>
 
 #include "../StatefulPerTrackEffect.h"
 #include "internal/ComponentHandler.h"
@@ -188,5 +189,14 @@ private:
       assert(pSettings);
       return *pSettings;
    }
+
+   struct ParameterInfo;
+
+   //! Return value: if true, continue visiting
+   using ParameterVisitor =
+      std::function< bool(const ParameterInfo& pi) >;
+
+   //! @return false if parameters could not be retrieved at all, else true
+   bool ForEachParameter(ParameterVisitor visitor) const;
 
 };


### PR DESCRIPTION
Resolves: part of https://github.com/audacity/audacity/issues/2969

I am still trying to find my way around the code, so this PR will be a draft.
I defined settings, and operations to store/fetch them, somehow like it was done for AudioUnits.

All points where settings are potentially sent back to the framework are covered, i.e. settings will be fetched and sent back to the framework. This is only one half of the work of course, the next half would be to cover all spots where settings enter from the framework and should be used.

In the process of doing the above, I think I found what looks like a pre-existing bug (probably resulting by copy-paste, please expand the context around the diff to see why I think so) and fixed it in a specific commit - please confirm that either it was indeed a bug, or if not, we'd have to talk about it.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
