### PR TITLE
Issue 2955: vst fixes

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -360,25 +360,27 @@ unsigned VSTEffectsModule::DiscoverPluginsAtPath(
    const PluginPath & path, TranslatableString &errMsg,
    const RegistrationCallback &callback)
 {
+
    VSTEffect effect(path);
    if(effect.InitializePlugin())
    {
-      const auto effectIDs = effect.GetEffectIDs();
-      if(!effectIDs.empty())
-      {
-         for(auto id : effectIDs)
-         {
-            VSTEffect subeffect(wxString::Format("%s;%d", path, id));
-            if(callback)
-               callback(this, &subeffect);
-         }
-         return effectIDs.size();
-      }
+      auto effectIDs = effect.GetEffectIDs();
+      if(effectIDs.empty())
+         //Each VST plugin path in Audacity should have id(index) part in it
+         effectIDs.push_back(0);
 
-      if(callback)
-         callback(this, &effect);
-      return 1;
+      for(auto id : effectIDs)
+      {
+         //Subsequent VSTEffect::Load may seem like overhead, but we need
+         //to initialize EffectDefinitionInterface part, which includes
+         //properly formatted plugin path
+         VSTEffect subeffect(wxString::Format("%s;%d", path, id), &effect);
+         if(callback)
+            callback(this, &subeffect);
+      }
+      return effectIDs.size();
    }
+   errMsg = XO("Could not load the library");
    return 0;
 }
 


### PR DESCRIPTION
Resolves: #2955 

Fix: invalid plugin path formatting for plugins which contain only one plugin (regression)
Fix: error message was not assigned if plugin module loading has failed (regression)

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
