### PR TITLE
Make settings changes stick

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -262,6 +262,7 @@ function( audacity_append_common_compiler_options var use_pch )
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=return-type>
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=dangling-else>
          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=return-stack-address>
+         $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Werror=defaulted-function-deleted>
 	      # Yes, CMake will change -D to /D as needed for Windows:
          -DWXINTL_NO_GETTEXT_MACRO
          $<$<CXX_COMPILER_ID:MSVC>:-D_USE_MATH_DEFINES>

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -80,9 +80,16 @@ public:
    //! @return value is not negative
    double GetDuration() const { return mDuration; }
    void SetDuration(double value) { mDuration = std::max(0.0, value); }
+
+   //! Versioning counter for detecting echo from worker thread;
+   //! it does not need a large range of values
+   using Counter = unsigned char;
+   Counter GetCounter() const { return mCounter; }
+   void SetCounter(Counter value) { mCounter = value; }
 private:
    NumericFormatSymbol mDurationFormat{};
    double mDuration{}; //!< @invariant non-negative
+   Counter mCounter{ 0 };
 };
 
 //! Externalized state of a plug-in

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -403,6 +403,8 @@ namespace
             return;
          }
          auto access = mEffectState->GetAccess();
+         // Copy settings
+         auto initialSettings = access->Get();
          auto cleanup = EffectManager::Get().SetBatchProcessing(ID);
 
          // Like the call in EffectManager::PromptUser, but access causes
@@ -423,6 +425,10 @@ namespace
                XO("Modify realtime effect")
          );
          }
+         else
+            // Dialog was cancelled.
+            // Reverse any temporary changes made to the state
+            access->Set(std::move(initialSettings));
       }
 
       void OnChangeButtonClicked(wxCommandEvent& event)

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -25,8 +25,7 @@ std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
 {
    auto result = std::make_unique<RealtimeEffectList>();
    for (auto &pState : mStates)
-      result->mStates.push_back(
-         std::make_shared<RealtimeEffectState>(*pState));
+      result->mStates.push_back(RealtimeEffectState::make_shared(*pState));
    return result;
 }
 
@@ -86,7 +85,7 @@ void RealtimeEffectList::Visit(StateVisitor func)
 std::shared_ptr<RealtimeEffectState>
 RealtimeEffectList::AddState(const PluginID &id)
 {
-   auto pState = std::make_shared<RealtimeEffectState>(id);
+   auto pState = RealtimeEffectState::make_shared(id);
    if (pState->GetEffect() != nullptr) {
       auto shallowCopy = mStates;
       shallowCopy.emplace_back(pState);
@@ -185,7 +184,7 @@ bool RealtimeEffectList::HandleXMLTag(
 XMLTagHandler *RealtimeEffectList::HandleXMLChild(const std::string_view &tag)
 {
    if (tag == RealtimeEffectState::XMLTag()) {
-      mStates.push_back(std::make_shared<RealtimeEffectState>(PluginID { }));
+      mStates.push_back(RealtimeEffectState::make_shared(PluginID{}));
       return mStates.back().get();
    }
    return nullptr;

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -82,13 +82,13 @@ void RealtimeEffectList::Visit(StateVisitor func)
       func(*state, !state->IsActive());
 }
 
-std::shared_ptr<RealtimeEffectState>
-RealtimeEffectList::AddState(const PluginID &id)
+bool
+RealtimeEffectList::AddState(std::shared_ptr<RealtimeEffectState> pState)
 {
-   auto pState = RealtimeEffectState::make_shared(id);
+   const auto &id = pState->GetID();
    if (pState->GetEffect() != nullptr) {
       auto shallowCopy = mStates;
-      shallowCopy.emplace_back(pState);
+      shallowCopy.emplace_back(move(pState));
       // Lock for only a short time
       (LockGuard{ mLock }, swap(shallowCopy, mStates));
 
@@ -98,10 +98,11 @@ RealtimeEffectList::AddState(const PluginID &id)
          { }
       });
 
-      return pState;
+      return true;
    }
-   // Effect initialization failed for the id
-   return nullptr;
+   else
+      // Effect initialization failed for the id
+      return false;
 }
 
 void RealtimeEffectList::RemoveState(

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -78,12 +78,13 @@ public:
    void Visit(StateVisitor func);
 
    //! Use only in the main thread
-   //! Returns null if no such effect was found.
+   //! Returns true for success.
    //! Sends Insert message on success.
    /*!
-    @post result: `!result || result->GetEffect() != nullptr`
+    @post result: `!result || pState->GetEffect() != nullptr`
     */
-   std::shared_ptr<RealtimeEffectState> AddState(const PluginID &id);
+   bool AddState(std::shared_ptr<RealtimeEffectState> pState);
+
    //! Use only in the main thread
    //! On success sends Remove message.
    void RemoveState(const std::shared_ptr<RealtimeEffectState> &pState);

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -156,13 +156,9 @@ void RealtimeEffectManager::ProcessStart()
 
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended.
-   if (!mSuspended)
-   {
-      VisitAll([](RealtimeEffectState &state, bool bypassed){
-         if (!bypassed)
-            state.ProcessStart();
-      });
-   }
+   VisitAll([this](RealtimeEffectState &state, bool bypassed){
+      state.ProcessStart(!mSuspended && !bypassed);
+   });
 }
 
 //
@@ -245,13 +241,9 @@ void RealtimeEffectManager::ProcessEnd() noexcept
 
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended.
-   if (!mSuspended)
-   {
-      VisitAll([](RealtimeEffectState &state, bool bypassed){
-         if (!bypassed)
-            state.ProcessEnd();
-      });
-   }
+   VisitAll([this](RealtimeEffectState &state, bool bypassed){
+      state.ProcessEnd(!mSuspended && !bypassed);
+   });
 }
 
 void RealtimeEffectManager::VisitGroup(Track &leader, StateVisitor func)

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -181,7 +181,7 @@ const EffectInstanceFactory *RealtimeEffectState::GetEffect()
       mPlugin = EffectFactory::Call(mID);
       if (mPlugin)
          // Also make EffectSettings
-         mSettings = mPlugin->MakeSettings();
+         mSettings.Set(mPlugin->MakeSettings());
    }
    return mPlugin;
 }

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -12,12 +12,12 @@
 #define __AUDACITY_REALTIMEEFFECTSTATE_H__
 
 #include <atomic>
-#include <memory>
 #include <unordered_map>
 #include <vector>
 #include <cstddef>
 #include "EffectInterface.h"
 #include "GlobalVariable.h"
+#include "MemoryX.h"
 #include "PluginProvider.h" // for PluginID
 #include "XMLTagHandler.h"
 
@@ -27,6 +27,7 @@ class Track;
 class RealtimeEffectState
    : public XMLTagHandler
    , public std::enable_shared_from_this<RealtimeEffectState>
+   , public SharedNonInterfering<RealtimeEffectState>
 {
 public:
    struct AUDACITY_DLL_API EffectFactory : GlobalHook<EffectFactory,
@@ -102,7 +103,7 @@ private:
    //! Stateless effect object
    const EffectInstanceFactory *mPlugin{};
    
-   EffectSettings mSettings;
+   NonInterfering<EffectSettings> mSettings;
 
    //! @}
 

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -55,7 +55,7 @@ public:
    //! Main thread sets up this state before adding it to lists
    bool AddTrack(Track &track, unsigned chans, float rate);
    //! Worker thread begins a batch of samples
-   bool ProcessStart();
+   bool ProcessStart(bool active);
    //! Worker thread processes part of a batch of samples
    size_t Process(Track &track,
       unsigned chans,
@@ -64,7 +64,7 @@ public:
       float *dummybuf, //!< one scratch buffer
       size_t numSamples);
    //! Worker thread finishes a batch of samples
-   bool ProcessEnd();
+   bool ProcessEnd(bool active);
    bool IsActive() const noexcept;
    //! Main thread cleans up playback
    bool Finalize() noexcept;


### PR DESCRIPTION
Resolves: #2985
Resolves: part of #2871

Make changes of per-track effect states from the sidebar really stick.

Also addressing some, but not all, known race conditions in managing the lists of realtime effect states:  races involving
the collection of states in the list, but not yet, certain races involving members of those states and of the RelatimeEffectList.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
