### PR TITLE
Retest for realtime effects

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -204,8 +204,20 @@ public:
    //! Whether the effect sorts "above the line" in the menus
    virtual bool IsDefault() const = 0;
 
+   //! In which versions of Audacity was an effect realtime capable?
+   enum class RealtimeSince : unsigned {
+      Never,
+      Since_3_2,
+      Always,
+   };
+
+   //! Since which version of Audacity has the effect supported realtime?
+   virtual RealtimeSince RealtimeSupport() const = 0;
+
    //! Whether the effect supports realtime previewing (while audio is playing).
-   virtual bool SupportsRealtime() const = 0;
+   //! non-virtual
+   bool SupportsRealtime() const
+   { return RealtimeSupport() != RealtimeSince::Never; }
 
    //! Whether the effect has any automatable controls.
    virtual bool SupportsAutomation() const = 0;

--- a/libraries/lib-module-manager/CMakeLists.txt
+++ b/libraries/lib-module-manager/CMakeLists.txt
@@ -26,6 +26,7 @@ set( SOURCES
    PluginManager.h
 )
 set( LIBRARIES
+   lib-components-interface
    lib-files-interface
    lib-xml-interface
    lib-ipc-interface

--- a/libraries/lib-module-manager/PluginDescriptor.cpp
+++ b/libraries/lib-module-manager/PluginDescriptor.cpp
@@ -161,7 +161,7 @@ bool PluginDescriptor::IsEffectLegacy() const
 
 bool PluginDescriptor::IsEffectRealtime() const
 {
-   return mEffectRealtime;
+   return mEffectRealtime != EffectDefinitionInterface::RealtimeSince::Never;
 }
 
 bool PluginDescriptor::IsEffectAutomatable() const
@@ -195,6 +195,14 @@ void PluginDescriptor::SetEffectLegacy(bool legacy)
 }
 
 void PluginDescriptor::SetEffectRealtime(bool realtime)
+{
+   mEffectRealtime = realtime
+      ? EffectDefinitionInterface::RealtimeSince::Always
+      : EffectDefinitionInterface::RealtimeSince::Never;
+}
+
+void PluginDescriptor::SetRealtimeSupport(
+   EffectDefinitionInterface::RealtimeSince realtime)
 {
    mEffectRealtime = realtime;
 }

--- a/libraries/lib-module-manager/PluginDescriptor.cpp
+++ b/libraries/lib-module-manager/PluginDescriptor.cpp
@@ -194,19 +194,50 @@ void PluginDescriptor::SetEffectLegacy(bool legacy)
    mEffectLegacy = legacy;
 }
 
-void PluginDescriptor::SetEffectRealtime(bool realtime)
-{
-   mEffectRealtime = realtime
-      ? EffectDefinitionInterface::RealtimeSince::Always
-      : EffectDefinitionInterface::RealtimeSince::Never;
-}
-
 void PluginDescriptor::SetRealtimeSupport(
    EffectDefinitionInterface::RealtimeSince realtime)
 {
    mEffectRealtime = realtime;
 }
 
+static constexpr auto Since_3_2_string = "00";
+
+wxString PluginDescriptor::SerializeRealtimeSupport() const
+{
+   // Write a string value that converts to 0 or 1, therefore to a boolean,
+   // when read as a boolean from a config file by Audacity 3.1 or earlier
+   switch (mEffectRealtime) {
+   case EffectDefinitionInterface::RealtimeSince::Never:
+   default:
+      // A value that earlier Audacity interprets as false
+      return "0";
+   case EffectDefinitionInterface::RealtimeSince::Since_3_2:
+      // A different value that earlier Audacity interprets as false
+      return Since_3_2_string;
+   case EffectDefinitionInterface::RealtimeSince::Always:
+      // A value that earlier Audacity interprets as true
+      return "1";
+   }
+}
+ 
+void PluginDescriptor::DeserializeRealtimeSupport(const wxString &value)
+{
+   // Interpret the values stored by SerializeRealtimeSupport, or by previous
+   // versions of Audacity
+   if (value == Since_3_2_string)
+      mEffectRealtime = EffectDefinitionInterface::RealtimeSince::Since_3_2;
+   else {
+      // This leaves some open-endedness for future versions of Audacity to
+      // define other string values they interpret one way, but we interpret
+      // otherwise
+      long number;
+      value.ToLong(&number);
+      mEffectRealtime = number
+         ? EffectDefinitionInterface::RealtimeSince::Always
+         : EffectDefinitionInterface::RealtimeSince::Never;
+   }
+}
+ 
 void PluginDescriptor::SetEffectAutomatable(bool automatable)
 {
    mEffectAutomatable = automatable;
@@ -247,7 +278,7 @@ void PluginDescriptor::WriteXML(XMLWriter& writer) const
       writer.WriteAttr(AttrEffectFamily, GetEffectFamily());
       writer.WriteAttr(AttrEffectType, GetEffectType());
       writer.WriteAttr(AttrEffectDefault, IsEffectDefault());
-      writer.WriteAttr(AttrEffectRealtime, IsEffectRealtime());
+      writer.WriteAttr(AttrEffectRealtime, SerializeRealtimeSupport());
       writer.WriteAttr(AttrEffectAutomatable, IsEffectAutomatable());
       writer.WriteAttr(AttrEffectInteractive, IsEffectInteractive());
    }
@@ -269,7 +300,7 @@ bool PluginDescriptor::HandleXMLTag(const std::string_view& tag, const Attribute
          else if(key == AttrEffectDefault)
             SetEffectDefault(attr.Get<bool>());
          else if(key == AttrEffectRealtime)
-            SetEffectRealtime(attr.Get<bool>());
+            DeserializeRealtimeSupport(attr.ToWString());
          else if(key == AttrEffectAutomatable)
             SetEffectAutomatable(attr.Get<bool>());
          else if(key == AttrEffectInteractive)

--- a/libraries/lib-module-manager/PluginDescriptor.h
+++ b/libraries/lib-module-manager/PluginDescriptor.h
@@ -112,8 +112,13 @@ public:
    void SetEffectDefault(bool dflt);
    void SetEffectInteractive(bool interactive);
    void SetEffectLegacy(bool legacy);
-   void SetEffectRealtime(bool realtime);
    void SetRealtimeSupport(EffectDefinitionInterface::RealtimeSince realtime);
+
+   //! for serialization
+   wxString SerializeRealtimeSupport() const;
+   //! for deserialization
+   void DeserializeRealtimeSupport(const wxString &value);
+
    void SetEffectAutomatable(bool automatable);
 
    void SetImporterIdentifier(const wxString & identifier);

--- a/libraries/lib-module-manager/PluginDescriptor.h
+++ b/libraries/lib-module-manager/PluginDescriptor.h
@@ -11,6 +11,7 @@
 #pragma once
 #include <wx/string.h>
 
+#include "EffectInterface.h"
 #include "PluginInterface.h"
 #include "XMLTagHandler.h"
 #include "wxArrayStringEx.h"
@@ -112,6 +113,7 @@ public:
    void SetEffectInteractive(bool interactive);
    void SetEffectLegacy(bool legacy);
    void SetEffectRealtime(bool realtime);
+   void SetRealtimeSupport(EffectDefinitionInterface::RealtimeSince realtime);
    void SetEffectAutomatable(bool automatable);
 
    void SetImporterIdentifier(const wxString & identifier);
@@ -140,7 +142,8 @@ private:
    bool mEffectInteractive {false};
    bool mEffectDefault {false};
    bool mEffectLegacy {false};
-   bool mEffectRealtime {false};
+   EffectDefinitionInterface::RealtimeSince mEffectRealtime {
+      EffectDefinitionInterface::RealtimeSince::Never };
    bool mEffectAutomatable {false};
 
    // Importers

--- a/libraries/lib-module-manager/PluginInterface.cpp
+++ b/libraries/lib-module-manager/PluginInterface.cpp
@@ -6,5 +6,39 @@
 
 **********************************************************************/
 #include "PluginInterface.h"
+#include <algorithm>
 
 PluginManagerInterface::~PluginManagerInterface() = default;
+
+namespace {
+std::vector<long> Split(const PluginRegistryVersion &regver)
+{
+   std::vector<long> result;
+   auto strings = wxSplit(regver, '.');
+   std::transform(strings.begin(), strings.end(), std::back_inserter(result),
+      [](const wxString &string) {
+         long value;
+         string.ToLong(&value);
+         return value;
+      });
+   return result;
+}
+}
+
+bool Regver_eq(
+   const PluginRegistryVersion &regver1, const PluginRegistryVersion &regver2)
+{
+   auto numbers1 = Split(regver1)
+      , numbers2 = Split(regver2);
+   return std::equal(
+      regver1.begin(), regver1.end(), regver2.begin(), regver2.end());
+}
+
+bool Regver_lt(
+   const PluginRegistryVersion &regver1, const PluginRegistryVersion &regver2)
+{
+   auto numbers1 = Split(regver1)
+      , numbers2 = Split(regver2);
+   return std::lexicographical_compare(
+      regver1.begin(), regver1.end(), regver2.begin(), regver2.end());
+}

--- a/libraries/lib-module-manager/PluginInterface.h
+++ b/libraries/lib-module-manager/PluginInterface.h
@@ -80,6 +80,25 @@ using ConfigConstReference =
 
 }
 
+//! Type of plugin registry version information
+using PluginRegistryVersion = wxString;
+
+MODULE_MANAGER_API
+bool Regver_eq(
+   const PluginRegistryVersion &regver1, const PluginRegistryVersion &regver2);
+
+// Compare registry versions
+MODULE_MANAGER_API
+bool Regver_lt(
+   const PluginRegistryVersion &regver1, const PluginRegistryVersion &regver2);
+
+// Compare registry versions
+inline bool Regver_le(
+   const PluginRegistryVersion &regver1, const PluginRegistryVersion &regver2)
+{
+   return !Regver_lt(regver2, regver1);
+}
+
 class MODULE_MANAGER_API PluginManagerInterface /* not final */
 {
 public:

--- a/libraries/lib-module-manager/PluginInterface.h
+++ b/libraries/lib-module-manager/PluginInterface.h
@@ -152,6 +152,9 @@ public:
       const PluginID & ID, const RegistryPath & group) = 0;
    virtual bool RemoveConfig(ConfigurationType type, const PluginID & ID,
       const RegistryPath & group, const RegistryPath & key) = 0;
+
+   //! What is the plugin registry version number now in the file?
+   virtual const PluginRegistryVersion &GetRegistryVersion() const = 0;
 };
 
 #endif // __AUDACITY_PLUGININTERFACE_H__

--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -46,7 +46,6 @@ for shared and private configs - which need to move out.
 
 // Registry has the list of plug ins
 #define REGVERKEY wxString(wxT("/pluginregistryversion"))
-#define REGVERCUR wxString(wxT("1.1"))
 #define REGROOT wxString(wxT("/pluginregistry/"))
 
 // Settings has the values of the plug in settings.
@@ -557,8 +556,7 @@ void PluginManager::Load()
    // TODO: Should also check for a registry file that is newer than
    // what we can understand.
    wxString regver = registry.Read(REGVERKEY);
-   if (regver < REGVERCUR )
-   {
+   if (Regver_lt(regver, "1.1")) {
       // Conversion code here, for when registry version changes.
 
       // We iterate through the effects, possibly updating their info.
@@ -582,7 +580,7 @@ void PluginManager::Load()
          // For 2.3.0 the plugins we distribute have moved around.
          // So we upped the registry version number to 1.1.
          // These particular config edits were originally written to fix Bug 1914.
-         if (regver <= "1.0") {
+         if (Regver_le(regver, "1.0")) {
             // Nyquist prompt is a built-in that has moved to the tools menu.
             if (effectSymbol == NYQUIST_PROMPT_ID) {
                registry.Write(KEY_EFFECTTYPE, "Tool");

--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -555,8 +555,8 @@ void PluginManager::Load()
    // Check for a registry version that we can understand
    // TODO: Should also check for a registry file that is newer than
    // what we can understand.
-   wxString regver = registry.Read(REGVERKEY);
-   if (Regver_lt(regver, "1.1")) {
+   mRegver = registry.Read(REGVERKEY);
+   if (Regver_lt(mRegver, "1.1")) {
       // Conversion code here, for when registry version changes.
 
       // We iterate through the effects, possibly updating their info.
@@ -580,7 +580,7 @@ void PluginManager::Load()
          // For 2.3.0 the plugins we distribute have moved around.
          // So we upped the registry version number to 1.1.
          // These particular config edits were originally written to fix Bug 1914.
-         if (Regver_le(regver, "1.0")) {
+         if (Regver_le(mRegver, "1.0")) {
             // Nyquist prompt is a built-in that has moved to the tools menu.
             if (effectSymbol == NYQUIST_PROMPT_ID) {
                registry.Write(KEY_EFFECTTYPE, "Tool");
@@ -601,7 +601,6 @@ void PluginManager::Load()
          registry.DeleteGroup(groupsToDelete[i]);
       }
       registry.SetPath("");
-      registry.Write(REGVERKEY, REGVERCUR);
       // Updates done.  Make sure we read the updated data later.
       registry.Flush();
    }
@@ -885,9 +884,6 @@ void PluginManager::Save()
    // Clear pluginregistry.cfg (not audacity.cfg)
    registry.DeleteAll();
 
-   // Write the version string
-   registry.Write(REGVERKEY, REGVERCUR);
-
    // Save the individual groups
    SaveGroup(&registry, PluginTypeEffect);
    SaveGroup(&registry, PluginTypeExporter);
@@ -902,8 +898,18 @@ void PluginManager::Save()
    // And now the providers
    SaveGroup(&registry, PluginTypeModule);
 
+   // Write the version string
+   registry.Write(REGVERKEY, REGVERCUR);
+
    // Just to be safe
    registry.Flush();
+
+   mRegver = REGVERCUR;
+}
+
+const PluginRegistryVersion &PluginManager::GetRegistryVersion() const
+{
+   return mRegver;
 }
 
 void PluginManager::SaveGroup(FileConfig *pRegistry, PluginType type)

--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -408,7 +408,6 @@ void PluginManager::Initialize(FileConfigFactory factory)
 void PluginManager::Terminate()
 {
    // Get rid of all non-module(effects?) plugins first
-   auto iter = mRegisteredPlugins.begin();
    for(auto& p : mRegisteredPlugins)
    {
       auto& desc = p.second;

--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -810,11 +810,11 @@ void PluginManager::LoadGroup(FileConfig *pRegistry, PluginType type)
             plug.SetEffectInteractive(boolVal);
 
             // Is it a realtime capable effect and bypass group if not found
-            if (!pRegistry->Read(KEY_EFFECTREALTIME, &boolVal))
+            if (!pRegistry->Read(KEY_EFFECTREALTIME, &strVal))
             {
                continue;
             }
-            plug.SetEffectRealtime(boolVal);
+            plug.DeserializeRealtimeSupport(strVal);
 
             // Does the effect support automation...bypass group if not found
             if (!pRegistry->Read(KEY_EFFECTAUTOMATABLE, &boolVal))
@@ -968,7 +968,7 @@ void PluginManager::SaveGroup(FileConfig *pRegistry, PluginType type)
             pRegistry->Write(KEY_EFFECTFAMILY, plug.GetEffectFamily());
             pRegistry->Write(KEY_EFFECTDEFAULT, plug.IsEffectDefault());
             pRegistry->Write(KEY_EFFECTINTERACTIVE, plug.IsEffectInteractive());
-            pRegistry->Write(KEY_EFFECTREALTIME, plug.IsEffectRealtime());
+            pRegistry->Write(KEY_EFFECTREALTIME, plug.SerializeRealtimeSupport());
             pRegistry->Write(KEY_EFFECTAUTOMATABLE, plug.IsEffectAutomatable());
          }
          break;

--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -191,7 +191,7 @@ const PluginID & PluginManager::RegisterPlugin(
    plug.SetEffectFamily(effect->GetFamily().Internal());
    plug.SetEffectInteractive(effect->IsInteractive());
    plug.SetEffectDefault(effect->IsDefault());
-   plug.SetEffectRealtime(effect->SupportsRealtime());
+   plug.SetRealtimeSupport(effect->RealtimeSupport());
    plug.SetEffectAutomatable(effect->SupportsAutomation());
 
    plug.SetEnabled(true);
@@ -1007,7 +1007,7 @@ const PluginID & PluginManager::RegisterPlugin(
    plug.SetEffectFamily(effect->GetFamily().Internal());
    plug.SetEffectInteractive(effect->IsInteractive());
    plug.SetEffectDefault(effect->IsDefault());
-   plug.SetEffectRealtime(effect->SupportsRealtime());
+   plug.SetRealtimeSupport(effect->RealtimeSupport());
    plug.SetEffectAutomatable(effect->SupportsAutomation());
    
    plug.SetEffectLegacy(true);

--- a/libraries/lib-module-manager/PluginManager.h
+++ b/libraries/lib-module-manager/PluginManager.h
@@ -170,6 +170,10 @@ public:
    //! Save to preferences
    void Save();
 
+   //! What is the plugin registry version number now in the file?
+   //! (Save() updates it)
+   const PluginRegistryVersion &GetRegistryVersion() const override;
+
 private:
    // private! Use Get()
    PluginManager();
@@ -217,6 +221,7 @@ private:
    PluginMap mRegisteredPlugins;
    std::map<PluginID, std::unique_ptr<ComponentInterface>> mLoadedInterfaces;
 
+   PluginRegistryVersion mRegver;
 };
 
 // Defining these special names in the low-level PluginManager.h

--- a/libraries/lib-module-manager/PluginManager.h
+++ b/libraries/lib-module-manager/PluginManager.h
@@ -226,4 +226,7 @@ private:
 // User-visible name might change in later versions
 #define NYQUIST_PROMPT_NAME XO("Nyquist Prompt")
 
+// Latest version of the plugin registry config
+constexpr auto REGVERCUR = "1.2";
+
 #endif /* __AUDACITY_PLUGINMANAGER_H__ */

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -106,11 +106,11 @@ EffectType EffectBassTreble::GetType() const
    return EffectTypeProcess;
 }
 
-bool EffectBassTreble::SupportsRealtime() const
+auto EffectBassTreble::RealtimeSupport() const -> RealtimeSince
 {
    // TODO reenable after achieving statelessness
-   return false;
-//   return true;
+   return RealtimeSince::Never;
+//   return RealtimeSince::Always;
 }
 
 unsigned EffectBassTreble::GetAudioInCount() const

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -53,7 +53,7 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -186,11 +186,11 @@ EffectType EffectDistortion::GetType() const
    return EffectTypeProcess;
 }
 
-bool EffectDistortion::SupportsRealtime() const
+auto EffectDistortion::RealtimeSupport() const -> RealtimeSince
 {
    // TODO reenable after achieving statelessness
-   return false;
-//   return true;
+   return RealtimeSince::Never;
+//   return RealtimeSince::Always;
 }
 
 unsigned EffectDistortion::GetAudioInCount() const

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -75,7 +75,7 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
    RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
    bool DoLoadFactoryPreset(int id);

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -671,8 +671,10 @@ bool Effect::EnablePreview(bool enable)
          play->Enable(enable);
          if (SupportsRealtime())
          {
-            rewind->Enable(enable);
-            ffwd->Enable(enable);
+            if (rewind)
+               rewind->Enable(enable);
+            if (ffwd)
+               ffwd->Enable(enable);
          }
       }
    }

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -115,9 +115,9 @@ bool Effect::IsDefault() const
    return true;
 }
 
-bool Effect::SupportsRealtime() const
+auto Effect::RealtimeSupport() const -> RealtimeSince
 {
-   return false;
+   return RealtimeSince::Never;
 }
 
 bool Effect::SupportsAutomation() const

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -63,7 +63,7 @@ class AUDACITY_DLL_API Effect /* not final */
    EffectFamilySymbol GetFamily() const override;
    bool IsInteractive() const override;
    bool IsDefault() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
    bool SupportsAutomation() const override;
 
    bool SaveSettings(

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -18,7 +18,7 @@
 
 #include "Effect.h"
 #include "ModuleManager.h"
-#include "PluginInterface.h"
+#include "PluginManager.h"
 
 static bool sInitialized = false;
 
@@ -142,12 +142,18 @@ const FileExtensions &BuiltinEffectsModule::GetFileExtensions()
 
 void BuiltinEffectsModule::AutoRegisterPlugins(PluginManagerInterface & pm)
 {
+   // Assume initial PluginManager::Save is not yet done
+
+   // The set of built-in functions that are realtime capable may differ with
+   // the plugin registry version
+   bool rediscoverAll = !Regver_eq(pm.GetRegistryVersion(), REGVERCUR);
+
    TranslatableString ignoredErrMsg;
-   for (const auto &pair : mEffects)
-   {
+   for (const auto &pair : mEffects) {
       const auto &path = pair.first;
-      if (!pm.IsPluginRegistered(path, &pair.second->name.Msgid()))
-      {
+      if (rediscoverAll ||
+         !pm.IsPluginRegistered(path, &pair.second->name.Msgid())
+      ){
          if ( pair.second->excluded )
             continue;
          // No checking of error ?

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -122,11 +122,11 @@ EffectType EffectPhaser::GetType() const
    return EffectTypeProcess;
 }
 
-bool EffectPhaser::SupportsRealtime() const
+auto EffectPhaser::RealtimeSupport() const -> RealtimeSince
 {
    // TODO reenable after achieving statelessness
-   return false;
-//   return true;
+   return RealtimeSince::Never;
+//   return RealtimeSince::Always;
 }
 
 unsigned EffectPhaser::GetAudioInCount() const

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -59,7 +59,7 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -299,6 +299,11 @@ unsigned EffectReverb::GetAudioOutCount() const
    return 2;
 }
 
+auto EffectReverb::RealtimeSupport() const -> RealtimeSince
+{
+   return RealtimeSince::Since_3_2;
+}
+
 static size_t BLOCK = 16384;
 
 bool EffectReverb::Instance::ProcessInitialize(EffectSettings& settings,

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -69,7 +69,7 @@ public:
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
 
-   bool SupportsRealtime() const override { return true; }
+   RealtimeSince RealtimeSupport() const override;
 
    // Effect implementation
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -925,11 +925,13 @@ bool VSTEffect::IsDefault() const
    return false;
 }
 
-bool VSTEffect::SupportsRealtime() const
+auto VSTEffect::RealtimeSupport() const -> RealtimeSince
 {
    // TODO reenable after achieving statelessness
-   return false;
-   //return GetType() == EffectTypeProcess;
+   return RealtimeSince::Never;
+//   return GetType() == EffectTypeProcess
+//      ? RealtimeSince::Always
+//      : RealtimeSince::Never;
 }
 
 bool VSTEffect::SupportsAutomation() const

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -113,7 +113,7 @@ class VSTEffect final
    EffectFamilySymbol GetFamily() const override;
    bool IsInteractive() const override;
    bool IsDefault() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
    bool SupportsAutomation() const override;
 
    bool SaveSettings(

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -320,13 +320,13 @@ bool VST3Effect::IsDefault() const
    return false;
 }
 
-bool VST3Effect::SupportsRealtime() const
+auto VST3Effect::RealtimeSupport() const -> RealtimeSince
 {
    // TODO reenable after achieving statelessness
    // Also, as with old VST, perhaps only for plug-ins known not to be
    // just generators
-   return false;
-//   return true;
+   return RealtimeSince::Never;
+//   return RealtimeSince::Always;
 }
 
 bool VST3Effect::SupportsAutomation() const

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -107,7 +107,7 @@ public:
    EffectFamilySymbol GetFamily() const override;
    bool IsInteractive() const override;
    bool IsDefault() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
    bool SupportsAutomation() const override;
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -203,9 +203,9 @@ EffectType EffectWahwah::GetType() const
    return EffectTypeProcess;
 }
 
-bool EffectWahwah::SupportsRealtime() const
+auto EffectWahwah::RealtimeSupport() const -> RealtimeSince
 {
-   return true;
+   return RealtimeSince::Always;
 }
 
 unsigned EffectWahwah::GetAudioInCount() const

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -85,7 +85,7 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -182,11 +182,12 @@ bool AudioUnitEffect::IsDefault() const
    return false;
 }
 
-bool AudioUnitEffect::SupportsRealtime() const
+auto AudioUnitEffect::RealtimeSupport() const -> RealtimeSince
 {
-   return true;
-
-//   return GetType() == EffectTypeProcess;
+   return RealtimeSince::Always;
+   // return GetType() == EffectTypeProcess
+      // ? RealtimeSince::Always
+      // : RealtimeSince::Never;
 }
 
 bool AudioUnitEffect::SupportsAutomation() const

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -64,7 +64,7 @@ public:
    EffectFamilySymbol GetFamily() const override;
    bool IsInteractive() const override;
    bool IsDefault() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
    bool SupportsAutomation() const override;
 
    EffectSettings MakeSettings() const override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -719,9 +719,11 @@ bool LadspaEffect::IsDefault() const
    return false;
 }
 
-bool LadspaEffect::SupportsRealtime() const
+auto LadspaEffect::RealtimeSupport() const -> RealtimeSince
 {
-   return GetType() != EffectTypeGenerate;
+   return GetType() == EffectTypeGenerate
+      ? RealtimeSince::Never
+      : RealtimeSince::Always;
 }
 
 bool LadspaEffect::SupportsAutomation() const

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -79,7 +79,7 @@ public:
    EffectFamilySymbol GetFamily() const override;
    bool IsInteractive() const override;
    bool IsDefault() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
    bool SupportsAutomation() const override;
 
    bool SaveSettings(

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -176,11 +176,13 @@ bool LV2Effect::IsDefault() const
    return false;
 }
 
-bool LV2Effect::SupportsRealtime() const
+auto LV2Effect::RealtimeSupport() const -> RealtimeSince
 {
    // TODO reenable after achieving statelessness
-   return false;
-//   return GetType() == EffectTypeProcess;
+   return RealtimeSince::Never;
+//   return GetType() == EffectTypeProcess
+//      ? RealtimeSince::Always
+//      : RealtimeSince::Never;
 }
 
 bool LV2Effect::SupportsAutomation() const

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -77,7 +77,7 @@ public:
    EffectFamilySymbol GetFamily() const override;
    bool IsInteractive() const override;
    bool IsDefault() const override;
-   bool SupportsRealtime() const override;
+   RealtimeSince RealtimeSupport() const override;
    bool SupportsAutomation() const override;
 
    bool SaveSettings(


### PR DESCRIPTION
Resolves: #2928

Bump the version number of the plugin registry config file; use that to decide when a rescan of all built-in effects is needed
at startup for changes of realtime capability of built-in effects.

This will do the right thing either upgrading to 3.2 or later (so that Reverb is considered realtime), or downgrading from a
future Audacity version, with a further changed plugin registry version, to an earlier Audacity, but not before 3.2.

The problem of downgrading from 3.2 to 3.1 may go slightly wrong -- then 3.1 will mistreate Reverb as a realtime effect with
a non-modal dialog.

An automatic fix for this further problem could be devised, but the question is whether it's worth the trouble?  If anyone
really meets this problem, they can be told to delete pluginresgistry.cfg or edit certain lines out of it.

Update:  added three commits that do make the extra effort to avoid surprises in behavior of the Reverb effect, in case of a downgrade from 3.2 back to 3.1.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
