### PR TITLE
Fix mix-and-render of unaligned stereo channels...

### DIFF
--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -219,13 +219,14 @@ void Track::DoSetLinkType(LinkType linkType, bool completeList)
       // Becoming unlinked
       assert(mpGroupData);
       if (HasLinkedTrack()) {
-         // Make independent copy of group data in the partner, which should
-         // have had none
-         auto partner = GetLinkedTrack();
-         assert(!partner->mpGroupData);
-         partner->mpGroupData =
-            std::make_unique<ChannelGroupData>(*mpGroupData);
-         partner->mpGroupData->mLinkType = LinkType::None;
+         if (auto partner = GetLinkedTrack()) {
+            // Make independent copy of group data in the partner, which should
+            // have had none
+            assert(!partner->mpGroupData);
+            partner->mpGroupData =
+               std::make_unique<ChannelGroupData>(*mpGroupData);
+            partner->mpGroupData->mLinkType = LinkType::None;
+         }
       }
       mpGroupData->mLinkType = LinkType::None;
    }

--- a/src/MixAndRender.cpp
+++ b/src/MixAndRender.cpp
@@ -93,7 +93,10 @@ void MixAndRender(const TrackIterRange<const WaveTrack> &trackRange,
       oneinput = true;
    // only one input track (either 1 mono or one linked stereo pair)
 
-   auto mixLeft = first->EmptyCopy(trackFactory->GetSampleBlockFactory());
+   // EmptyCopy carries over any interesting channel group information
+   // But make sure the left is unlinked before we re-link
+   auto mixLeft =
+      first->EmptyCopy(trackFactory->GetSampleBlockFactory(), false);
    mixLeft->SetRate(rate);
    mixLeft->ConvertToSampleFormat(format);
    if (oneinput)

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -705,11 +705,13 @@ void WaveTrack::Trim (double t0, double t1)
 
 
 WaveTrack::Holder WaveTrack::EmptyCopy(
-   const SampleBlockFactoryPtr &pFactory ) const
+   const SampleBlockFactoryPtr &pFactory, bool keepLink) const
 {
    auto result = std::make_shared<WaveTrack>( pFactory, mFormat, mRate );
    result->Init(*this);
    result->mpFactory = pFactory ? pFactory : mpFactory;
+   if (!keepLink)
+      result->SetLinkType(LinkType::None);
    return result;
 }
 

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -177,13 +177,19 @@ private:
 
    Track::Holder Cut(double t0, double t1) override;
 
-   // Make another track copying format, rate, color, etc. but containing no
-   // clips
-   // It is important to pass the correct factory (that for the project
-   // which will own the copy) in the unusual case that a track is copied from
-   // another project or the clipboard.  For copies within one project, the
-   // default will do.
-   Holder EmptyCopy(const SampleBlockFactoryPtr &pFactory = {} ) const;
+   //! Make another track copying format, rate, color, etc. but containing no
+   //! clips
+   /*!
+    It is important to pass the correct factory (that for the project
+    which will own the copy) in the unusual case that a track is copied from
+    another project or the clipboard.  For copies within one project, the
+    default will do.
+
+    @param keepLink if false, make the new track mono.  But always preserve
+    any other track group data.
+    */
+   Holder EmptyCopy(const SampleBlockFactoryPtr &pFactory = {},
+      bool keepLink = true) const;
 
    // If forClipboard is true,
    // and there is no clip at the end time of the selection, then the result


### PR DESCRIPTION
... so the result has aligned channels, as in version 3.1

Resolves: #2898

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
