### PR TITLE
Use std thread

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -361,7 +361,7 @@ AudioIO::~AudioIO()
    // This causes reentrancy issues during application shutdown
    // wxTheApp->Yield();
 
-   mThread->Delete();
+   mThread->Delete(); // joins the thread
    mThread.reset();
 }
 
@@ -1695,9 +1695,8 @@ AudioThread::ExitCode AudioThread::Entry()
 {
    enum class State { eUndefined, eOnce, eLoopRunning, eDoNothing, eMonitoring } lastState = State::eUndefined;
 
-   AudioIO *gAudioIO;
-   while( !TestDestroy() &&
-      nullptr != ( gAudioIO = AudioIO::Get() ) )
+   AudioIO *const gAudioIO = AudioIO::Get();
+   while (!TestDestroy())
    {
       using Clock = std::chrono::steady_clock;
       auto loopPassStart = Clock::now();

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <utility>
 #include <wx/atomic.h> // member variable
 
@@ -36,7 +37,6 @@ class RingBuffer;
 class Mixer;
 class RealtimeEffectState;
 class Resample;
-class AudioThread;
 
 class AudacityProject;
 
@@ -259,7 +259,8 @@ public:
    unsigned short mAILALastChangeType;  //0 - no change, 1 - increase change, 2 - decrease change
 #endif
 
-   std::unique_ptr<AudioThread> mThread;
+   std::thread mAudioThread;
+   std::atomic<bool> mFinishAudioThread{ false };
 
    ArrayOf<std::unique_ptr<Resample>> mResample;
    ArrayOf<std::unique_ptr<RingBuffer>> mCaptureBuffers;
@@ -343,8 +344,6 @@ protected:
     (Whether its overriding methods are race-free is not for AudioIO to ensure.)
     */
    std::weak_ptr< AudioIOListener > mListener;
-
-   friend class AudioThread;
 
    bool mUsingAlsa { false };
 
@@ -540,7 +539,7 @@ public:
     */
    double GetStreamTime();
 
-   friend class AudioThread;
+   static void AudioThread(std::atomic<bool> &finish);
 
    static void Init();
    static void Deinit();

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -23,8 +23,6 @@ class Alg_iterator;
 class NoteTrack;
 using NoteTrackConstArray = std::vector < std::shared_ptr< const NoteTrack > >;
 
-class AudioThread;
-
 // This workaround makes pause and stop work when output is to GarageBand,
 // which seems not to implement the notes-off message correctly.
 #define AUDIO_IO_GB_MIDI_WORKAROUND

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -17,11 +17,11 @@
 
 class wxArrayString;
 
+#include <thread>
 #include <vector>
 
 #include <wx/event.h> // to inherit
 #include <wx/msgqueue.h>
-#include <wx/thread.h>
 #include <wx/timer.h>
 #include <wx/weakref.h>
 
@@ -573,14 +573,13 @@ inline wxString LilvString(LilvNode *node, bool free)
    return str;
 };
 
-class LV2Wrapper : public wxThreadHelper
+class LV2Wrapper
 {
 public:
-   typedef struct LV2Work
-   {
-      uint32_t size;
-      const void *data;
-   } LV2Work;
+   struct LV2Work {
+      uint32_t size{};
+      const void *data{};
+   };
 
 public:
    LV2Wrapper(LV2Effect *effect);
@@ -590,7 +589,7 @@ public:
                              double sampleRrate,
                              std::vector<std::unique_ptr<LV2_Feature>> & features);
 
-   void *Entry();
+   void ThreadFunction();
 
    LilvInstance *GetInstance();
    
@@ -620,6 +619,8 @@ public:
    LV2_Worker_Status Respond(uint32_t size, const void *data);
 
 private:
+   std::thread mThread;
+
    LV2Effect *mEffect;
    LilvInstance *mInstance;
    LV2_Handle mHandle;

--- a/src/tracks/ui/Scrubbing.h
+++ b/src/tracks/ui/Scrubbing.h
@@ -11,8 +11,7 @@ Paul Licameli split from TrackPanel.cpp
 #ifndef __AUDACITY_SCRUBBING__
 #define __AUDACITY_SCRUBBING__
 
-
-
+#include <thread>
 #include <vector>
 #include <wx/longlong.h>
 
@@ -149,10 +148,14 @@ public:
 private:
    void UpdatePrefs() override;
 
+   //! @pre `!mThread.joinable()` (when defined(USE_SCRUB_THREAD))
    void StartPolling();
    void StopPolling();
    void DoScrub(bool seek);
    void OnActivateOrDeactivateApp(wxActivateEvent & event);
+
+   void ScrubPollerThread();
+   void JoinThread();
 
 private:
    int mScrubToken;
@@ -182,8 +185,8 @@ private:
 #ifdef USE_SCRUB_THREAD
    // Course corrections in playback are done in a helper thread, unhindered by
    // the complications of the main event dispatch loop
-   class ScrubPollerThread;
-   ScrubPollerThread *mpThread {};
+   std::thread mThread;
+   std::atomic<bool> mFinishThread{ false };
 #endif
 
    // Other periodic update of the UI must be done in the main thread,


### PR DESCRIPTION
Resolves: #3014

Eliminate remaning uses of `wxThread`, using `std::thread` instead.

Changes in AudioIO.cpp are known to be necessary to unblock #2941 .  The other two (in LV2Effect and Scrubbing) are not known to be needed, but modernized here too.

Textual scan of the code will still show `wxThread` in Equalization48x, but that is a lot of experimental code that was never improved to be production ready.  I didn't bother.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
