### PR TITLE
Fix choice settings

### DIFF
--- a/libraries/lib-preferences/Prefs.cpp
+++ b/libraries/lib-preferences/Prefs.cpp
@@ -368,6 +368,10 @@ bool ChoiceSetting::Write( const wxString &value )
 
    auto result = gPrefs->Write( mKey, value );
    mMigrated = true;
+
+   if (mpOtherSettings)
+      mpOtherSettings->Invalidate();
+
    return result;
 }
 

--- a/libraries/lib-preferences/Prefs.cpp
+++ b/libraries/lib-preferences/Prefs.cpp
@@ -371,31 +371,9 @@ bool ChoiceSetting::Write( const wxString &value )
    return result;
 }
 
-EnumSettingBase::EnumSettingBase(
-   const SettingBase &key,
-   EnumValueSymbols symbols,
-   long defaultSymbol,
-
-   std::vector<int> intValues, // must have same size as symbols
-   const wxString &oldKey
-)
-   : ChoiceSetting{ key, std::move( symbols ), defaultSymbol }
-   , mIntValues{ std::move( intValues ) }
-   , mOldKey{ oldKey }
-{
-   auto size = mSymbols.size();
-   if( mIntValues.size() != size ) {
-      wxASSERT( false );
-      mIntValues.resize( size );
-   }
-}
-
 void ChoiceSetting::SetDefault( long value )
 {
-   if ( value < (long)mSymbols.size() )
-      mDefaultSymbol = value;
-   else
-      wxASSERT( false );
+   mDefaultSymbol = value;
 }
 
 int EnumSettingBase::ReadInt() const

--- a/libraries/lib-preferences/Prefs.h
+++ b/libraries/lib-preferences/Prefs.h
@@ -218,11 +218,19 @@ public:
     default-default stored in this object. */
    T ReadWithDefault( const T &defaultValue ) const
    {
+      if (this->mValid)
+         return this->mCurrentValue;
       const auto config = this->GetConfig();
-      return config
-         ? ( this->mValid = true, this->mCurrentValue =
-               config->ReadObject( this->mPath, defaultValue ) )
-         : T{};
+      if (config) {
+         this->mCurrentValue =
+            config->ReadObject(this->mPath, defaultValue);
+         // If config file contains a value that agrees with the default, we
+         // can't detect that, so assume invalidity still
+         this->mValid = (this->mCurrentValue != defaultValue);
+         return this->mCurrentValue;
+      }
+      else
+         return T{};
    }
 
    //! Write value to config and return true if successful

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -2038,7 +2038,7 @@ wxChoice * ShuttleGuiBase::TieNumberAsChoice(const TranslatableString &Prompt,
       defaultIndex = -1;
 
    ChoiceSetting choiceSetting{
-      Setting.GetPath(),
+      Setting,
       {
          ByColumns,
          Choices,

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -1993,7 +1993,7 @@ wxChoice *ShuttleGuiBase::TieChoice(const TranslatableString &Prompt,
    if( DoStep(1) ) TempIndex = TranslateToIndex( TempStr, InternalChoices ); // To an index
    if( DoStep(2) ) pChoice = TieChoice( Prompt, TempIndex, Choices );
    if( DoStep(3) ) TempStr = TranslateFromIndex( TempIndex, InternalChoices ); // To a string
-   if( DoStep(3) ) DoDataShuttle( SettingName, WrappedRef ); // Put into Prefs.
+   if( DoStep(3) ) choiceSetting.Write(TempStr); // Put into Prefs.
    return pChoice;
 }
 
@@ -2023,7 +2023,6 @@ wxChoice * ShuttleGuiBase::TieNumberAsChoice(const TranslatableString &Prompt,
    else
       for ( int ii = 0; ii < (int)Choices.size(); ++ii )
          InternalChoices.push_back( fn( ii ) );
-
 
    const auto Default = Setting.GetDefault();
 

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -2009,9 +2009,8 @@ wxChoice *ShuttleGuiBase::TieChoice(
 ///   @param Choices            An array of choices that appear on screen.
 ///   @param pInternalChoices   The corresponding values (as an integer array)
 ///                             if null, then use 0, 1, 2, ...
-wxChoice * ShuttleGuiBase::TieNumberAsChoice(
-   const TranslatableString &Prompt,
-   const IntSetting & Setting,
+wxChoice * ShuttleGuiBase::TieNumberAsChoice(const TranslatableString &Prompt,
+   IntSetting &Setting,
    const TranslatableStrings & Choices,
    const std::vector<int> * pInternalChoices,
    int iNoMatchSelector)

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -1593,7 +1593,7 @@ wxRadioButton * ShuttleGuiBase::TieRadioButton()
 }
 
 /// Call this before any TieRadioButton calls.
-void ShuttleGuiBase::StartRadioButtonGroup( const ChoiceSetting &Setting )
+void ShuttleGuiBase::StartRadioButtonGroup(ChoiceSetting &Setting)
 {
    mRadioSymbols = Setting.GetSymbols();
 
@@ -1969,9 +1969,8 @@ wxTextCtrl * ShuttleGuiBase::TieNumericTextBox(
 ///   @param Setting            Encapsulates setting name, internal and visible
 ///                             choice strings, and a designation of one of
 ///                             those as default.
-wxChoice *ShuttleGuiBase::TieChoice(
-   const TranslatableString &Prompt,
-   const ChoiceSetting &choiceSetting )
+wxChoice *ShuttleGuiBase::TieChoice(const TranslatableString &Prompt,
+   ChoiceSetting &choiceSetting)
 {
    // Do this to force any needed migrations first
    choiceSetting.Read();
@@ -2048,7 +2047,7 @@ wxChoice * ShuttleGuiBase::TieNumberAsChoice(const TranslatableString &Prompt,
       defaultIndex
    };
 
-   return ShuttleGuiBase::TieChoice( Prompt, choiceSetting );
+   return ShuttleGuiBase::TieChoice(Prompt, choiceSetting);
 }
 
 //------------------------------------------------------------------//

--- a/src/ShuttleGui.h
+++ b/src/ShuttleGui.h
@@ -386,8 +386,7 @@ public:
    wxPanel * StartInvisiblePanel();
    void EndInvisiblePanel();
 
-   // SettingName is a key in Preferences.
-   void StartRadioButtonGroup( const ChoiceSetting &Setting );
+   void StartRadioButtonGroup(ChoiceSetting &Setting);
    void EndRadioButtonGroup();
 
    bool DoStep( int iStep );
@@ -447,9 +446,8 @@ public:
       const TranslatableString &Prompt,
       const BoolSetting &Setting);
 
-   virtual wxChoice *TieChoice(
-      const TranslatableString &Prompt,
-      const ChoiceSetting &choiceSetting );
+   virtual wxChoice *TieChoice(const TranslatableString &Prompt,
+      ChoiceSetting &choiceSetting);
 
    // This overload presents what is really a numerical setting as a choice among
    // commonly used values, but the choice is not necessarily exhaustive.

--- a/src/ShuttleGui.h
+++ b/src/ShuttleGui.h
@@ -456,12 +456,11 @@ public:
    // This behaves just like the previous for building dialogs, but the
    // behavior is different when the call is intercepted for purposes of
    // emitting scripting information about Preferences.
-   virtual wxChoice * TieNumberAsChoice(
-      const TranslatableString &Prompt,
-      const IntSetting &Setting,
+   virtual wxChoice * TieNumberAsChoice(const TranslatableString &Prompt,
+      IntSetting &Setting,
       const TranslatableStrings & Choices,
       const std::vector<int> * pInternalChoices = nullptr,
-      int iNoMatchSelector = 0 );
+      int iNoMatchSelector = 0);
 
    virtual wxTextCtrl * TieTextBox(
       const TranslatableString &Prompt,

--- a/src/commands/GetInfoCommand.cpp
+++ b/src/commands/GetInfoCommand.cpp
@@ -224,11 +224,10 @@ public:
       const TranslatableString &Prompt,
       const ChoiceSetting &choiceSetting ) override;
 
-   wxChoice * TieNumberAsChoice(
-      const TranslatableString &Prompt,
-      const IntSetting &Setting,
+   wxChoice * TieNumberAsChoice(const TranslatableString &Prompt,
+      IntSetting &Setting,
       const TranslatableStrings & Choices,
-      const std::vector<int> * pInternalChoices, int iNoMatchSelector ) override;
+      const std::vector<int> * pInternalChoices, int iNoMatchSelector) override;
 
    wxTextCtrl * TieTextBox(
       const TranslatableString &Prompt,
@@ -312,7 +311,7 @@ wxChoice * ShuttleGuiGetDefinition::TieChoice(
 
 wxChoice * ShuttleGuiGetDefinition::TieNumberAsChoice(
    const TranslatableString &Prompt,
-   const IntSetting &Setting,
+   IntSetting &Setting,
    const TranslatableStrings & Choices,
    const std::vector<int> * pInternalChoices, int iNoMatchSelector)
 {

--- a/src/commands/GetInfoCommand.cpp
+++ b/src/commands/GetInfoCommand.cpp
@@ -220,9 +220,8 @@ public:
       const TranslatableString &Prompt,
       const BoolSetting &Setting) override;
 
-   wxChoice *TieChoice(
-      const TranslatableString &Prompt,
-      const ChoiceSetting &choiceSetting ) override;
+   wxChoice *TieChoice(const TranslatableString &Prompt,
+      ChoiceSetting &choiceSetting) override;
 
    wxChoice * TieNumberAsChoice(const TranslatableString &Prompt,
       IntSetting &Setting,
@@ -290,9 +289,8 @@ wxCheckBox * ShuttleGuiGetDefinition::TieCheckBoxOnRight(
    return ShuttleGui::TieCheckBoxOnRight( Prompt, Setting );
 }
 
-wxChoice * ShuttleGuiGetDefinition::TieChoice(
-   const TranslatableString &Prompt,
-   const ChoiceSetting &choiceSetting  )
+wxChoice * ShuttleGuiGetDefinition::TieChoice(const TranslatableString &Prompt,
+   ChoiceSetting &choiceSetting)
 {
    StartStruct();
    AddItem( choiceSetting.Key(), "id" );

--- a/src/export/ExportFFmpegDialogs.cpp
+++ b/src/export/ExportFFmpegDialogs.cpp
@@ -213,6 +213,8 @@ ExportFFmpegAC3Options::~ExportFFmpegAC3Options()
 ///
 void ExportFFmpegAC3Options::PopulateOrExchange(ShuttleGui & S)
 {
+   IntSetting Setting{ L"/FileFormats/AC3BitRate", 160000 };
+
    S.StartVerticalLay();
    {
       S.StartHorizontalLay(wxCENTER);
@@ -220,12 +222,7 @@ void ExportFFmpegAC3Options::PopulateOrExchange(ShuttleGui & S)
          S.StartMultiColumn(2, wxCENTER);
          {
             S.TieNumberAsChoice(
-               XXO("Bit Rate:"),
-               {wxT("/FileFormats/AC3BitRate"),
-                160000},
-               AC3BitRateNames,
-               &AC3BitRateValues
-            );
+               XXO("Bit Rate:"), Setting, AC3BitRateNames, &AC3BitRateValues);
          }
          S.EndMultiColumn();
       }
@@ -368,19 +365,15 @@ ExportFFmpegAMRNBOptions::~ExportFFmpegAMRNBOptions()
 ///
 void ExportFFmpegAMRNBOptions::PopulateOrExchange(ShuttleGui & S)
 {
+   IntSetting Setting{ L"/FileFormats/AMRNBBitRate", 12200 };
    S.StartVerticalLay();
    {
       S.StartHorizontalLay(wxCENTER);
       {
          S.StartMultiColumn(2, wxCENTER);
          {
-            S.TieNumberAsChoice(
-               XXO("Bit Rate:"),
-               {wxT("/FileFormats/AMRNBBitRate"),
-                12200},
-               AMRNBBitRateNames,
-               &AMRNBBitRateValues
-            );
+            S.TieNumberAsChoice(XXO("Bit Rate:"), Setting,
+               AMRNBBitRateNames, &AMRNBBitRateValues);
          }
          S.EndMultiColumn();
       }
@@ -727,19 +720,15 @@ ExportFFmpegWMAOptions::~ExportFFmpegWMAOptions()
 ///
 void ExportFFmpegWMAOptions::PopulateOrExchange(ShuttleGui & S)
 {
+   IntSetting Setting{ L"/FileFormats/WMABitRate", 128000 };
    S.StartVerticalLay();
    {
       S.StartHorizontalLay(wxCENTER);
       {
          S.StartMultiColumn(2, wxCENTER);
          {
-            S.TieNumberAsChoice(
-               XXO("Bit Rate:"),
-               {wxT("/FileFormats/WMABitRate"),
-                128000},
-               WMABitRateNames,
-               &WMABitRateValues
-            );
+            S.TieNumberAsChoice(XXO("Bit Rate:"),
+               Setting, WMABitRateNames, &WMABitRateValues);
          }
          S.EndMultiColumn();
       }
@@ -1819,6 +1808,9 @@ void ExportFFmpegOptions::FetchCodecList()
 ///
 void ExportFFmpegOptions::PopulateOrExchange(ShuttleGui & S)
 {
+   IntSetting PredictionOrderSetting{ L"/FileFormats/FFmpegPredOrderMethod",
+      4 };  // defaults to Full search
+
    S.StartVerticalLay(1);
    S.StartMultiColumn(1, wxEXPAND);
    {
@@ -1935,8 +1927,7 @@ void ExportFFmpegOptions::PopulateOrExchange(ShuttleGui & S)
                      .MinSize( { 100, -1 } )
                      .TieNumberAsChoice(
                         XXO("PdO Method:"),
-                        {wxT("/FileFormats/FFmpegPredOrderMethod"),
-                         4}, // Full search
+                        PredictionOrderSetting,
                         PredictionOrderMethodNames
                      );
 

--- a/src/export/ExportMP2.cpp
+++ b/src/export/ExportMP2.cpp
@@ -156,19 +156,15 @@ ExportMP2Options::~ExportMP2Options()
 ///
 void ExportMP2Options::PopulateOrExchange(ShuttleGui & S)
 {
+   IntSetting Setting{ L"/FileFormats/MP2Bitrate", 160 };
    S.StartVerticalLay();
    {
       S.StartHorizontalLay(wxCENTER);
       {
          S.StartMultiColumn(2, wxCENTER);
          {
-            S.TieNumberAsChoice(
-               XXO("Bit Rate:"),
-               {wxT("/FileFormats/MP2Bitrate"),
-                160},
-               BitRateNames,
-               &BitRateValues
-            );
+            S.TieNumberAsChoice(XXO("Bit Rate:"), Setting,
+               BitRateNames, &BitRateValues);
          }
          S.EndMultiColumn();
       }

--- a/src/export/ExportMP3.cpp
+++ b/src/export/ExportMP3.cpp
@@ -403,9 +403,11 @@ void ExportMP3Options::PopulateOrExchange(ShuttleGui & S)
                      break;
                }
 
+               IntSetting Setting{ L"/FileFormats/MP3Bitrate", defrate };
+
                mRate = S.Id(ID_QUALITY).TieNumberAsChoice(
                   XXO("Quality"),
-                  { wxT("/FileFormats/MP3Bitrate"), defrate },
+                  Setting,
                   *choices,
                   codes
                );

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -224,6 +224,16 @@ int ExportMultipleDialog::ShowModal()
 
 void ExportMultipleDialog::PopulateOrExchange(ShuttleGui& S)
 {
+   ChoiceSetting NumberingSetting{
+      wxT("/Export/TrackNameWithOrWithoutNumbers"),
+      {
+         { wxT("labelTrack"), XXO("Using Label/Track Name") },
+         { wxT("numberBefore"), XXO("Numbering before Label/Track Name") },
+         { wxT("numberAfter"), XXO("Numbering after File name prefix") },
+      },
+      0 // labelTrack
+   };
+
    wxString name = mProject->GetProjectName();
    wxString defaultFormat = gPrefs->Read(wxT("/Export/Format"), wxT("WAV"));
 
@@ -254,6 +264,14 @@ void ExportMultipleDialog::PopulateOrExchange(ShuttleGui& S)
       }
    }
 
+   ChoiceSetting FormatSetting{ wxT("/Export/MultipleFormat"),
+      {
+         ByColumns,
+         visibleFormats,
+         formats
+      },
+      mFilterIndex
+   };
 
    // Bug 1304: Set the default file path.  It's used if none stored in config.
    auto DefaultPath = FileNames::FindDefaultPath(FileNames::Operation::Export);
@@ -282,15 +300,7 @@ void ExportMultipleDialog::PopulateOrExchange(ShuttleGui& S)
 
             mFormat = S.Id(FormatID)
                .TieChoice( XXO("Format:"),
-               {
-                  wxT("/Export/MultipleFormat"),
-                  {
-                     ByColumns,
-                     visibleFormats,
-                     formats
-                  },
-                  mFilterIndex
-               }
+               FormatSetting
             );
             S.AddVariableText( {}, false);
             S.AddVariableText( {}, false);
@@ -386,15 +396,7 @@ void ExportMultipleDialog::PopulateOrExchange(ShuttleGui& S)
          // on the Mac, VoiceOver will announce as radio buttons.
          S.StartPanel();
          {
-            S.StartRadioButtonGroup({
-               wxT("/Export/TrackNameWithOrWithoutNumbers"),
-               {
-                  { wxT("labelTrack"), XXO("Using Label/Track Name") },
-                  { wxT("numberBefore"), XXO("Numbering before Label/Track Name") },
-                  { wxT("numberAfter"), XXO("Numbering after File name prefix") },
-               },
-               0 // labelTrack
-            });
+            S.StartRadioButtonGroup(NumberingSetting);
             {
                mByName = S.Id(ByNameID).TieRadioButton();
 

--- a/src/prefs/DevicePrefs.cpp
+++ b/src/prefs/DevicePrefs.cpp
@@ -127,6 +127,10 @@ void DevicePrefs::GetNamesAndLabels()
 
 void DevicePrefs::PopulateOrExchange(ShuttleGui & S)
 {
+   ChoiceSetting HostSetting{
+      AudioIOHost,
+      { ByColumns, mHostNames, mHostLabels }
+   };
    S.SetBorder(2);
    S.StartScroller();
 
@@ -136,12 +140,7 @@ void DevicePrefs::PopulateOrExchange(ShuttleGui & S)
       S.StartMultiColumn(2);
       {
          S.Id(HostID);
-         mHost = S.TieChoice( XXO("&Host:"),
-            {
-               AudioIOHost,
-               { ByColumns, mHostNames, mHostLabels }
-            }
-         );
+         mHost = S.TieChoice( XXO("&Host:"), HostSetting);
 
          S.AddPrompt(XXO("Using:"));
          S.AddFixedText( Verbatim(wxSafeConvertMB2WX(Pa_GetVersionText() ) ) );

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -139,6 +139,14 @@ ChoiceSetting GUIManualLocation{
 
 void GUIPrefs::PopulateOrExchange(ShuttleGui & S)
 {
+   ChoiceSetting LanguageSetting{ wxT("/Locale/Language"),
+      { ByColumns, mLangNames, mLangCodes }
+   };
+   ChoiceSetting DBSetting{ DecibelScaleCutoff.GetPath(),
+      { ByColumns, mRangeChoices, mRangeCodes },
+      mDefaultRangeIndex
+   };
+
    S.SetBorder(2);
    S.StartScroller();
 
@@ -146,25 +154,10 @@ void GUIPrefs::PopulateOrExchange(ShuttleGui & S)
    {
       S.StartMultiColumn(2);
       {
-
-         S.TieChoice( XXO("&Language:"),
-            {
-               wxT("/Locale/Language"),
-               { ByColumns, mLangNames, mLangCodes }
-            }
-         );
-
+         S.TieChoice( XXO("&Language:"), LanguageSetting);
          S.TieChoice( XXO("Location of &Manual:"), GUIManualLocation);
-
          S.TieChoice( XXO("Th&eme:"), GUITheme());
-
-         S.TieChoice( XXO("Meter dB &range:"),
-            {
-               DecibelScaleCutoff.GetPath(),
-               { ByColumns, mRangeChoices, mRangeCodes },
-               mDefaultRangeIndex
-            }
-         );
+         S.TieChoice( XXO("Meter dB &range:"), DBSetting);
       }
       S.EndMultiColumn();
 

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -142,7 +142,7 @@ void GUIPrefs::PopulateOrExchange(ShuttleGui & S)
    ChoiceSetting LanguageSetting{ wxT("/Locale/Language"),
       { ByColumns, mLangNames, mLangCodes }
    };
-   ChoiceSetting DBSetting{ DecibelScaleCutoff.GetPath(),
+   ChoiceSetting DBSetting{ DecibelScaleCutoff,
       { ByColumns, mRangeChoices, mRangeCodes },
       mDefaultRangeIndex
    };

--- a/src/prefs/KeyConfigPrefs.cpp
+++ b/src/prefs/KeyConfigPrefs.cpp
@@ -177,6 +177,15 @@ void KeyConfigPrefs::Populate()
 /// so this is only used in populating the panel.
 void KeyConfigPrefs::PopulateOrExchange(ShuttleGui & S)
 {
+   ChoiceSetting Setting{ L"/Prefs/KeyConfig/ViewBy",
+      {
+         { wxT("tree"), XXO("&Tree") },
+         { wxT("name"), XXO("&Name") },
+         { wxT("key"), XXO("&Key") },
+      },
+      0 // tree
+   };
+
    S.SetBorder(2);
 
    S.StartStatic(XO("Key Bindings"), 1);
@@ -191,15 +200,7 @@ void KeyConfigPrefs::PopulateOrExchange(ShuttleGui & S)
          {
             S.StartHorizontalLay();
             {
-               S.StartRadioButtonGroup({
-                  wxT("/Prefs/KeyConfig/ViewBy"),
-                  {
-                     { wxT("tree"), XXO("&Tree") },
-                     { wxT("name"), XXO("&Name") },
-                     { wxT("key"), XXO("&Key") },
-                  },
-                  0 // tree
-               });
+               S.StartRadioButtonGroup(Setting);
                {
                   mViewByTree = S.Id(ViewByTreeID)
                      .Name(XO("View by tree"))

--- a/src/prefs/MidiIOPrefs.cpp
+++ b/src/prefs/MidiIOPrefs.cpp
@@ -130,7 +130,11 @@ void MidiIOPrefs::GetNamesAndLabels() {
    }
 }
 
-void MidiIOPrefs::PopulateOrExchange( ShuttleGui & S ) {
+void MidiIOPrefs::PopulateOrExchange( ShuttleGui & S )
+{
+   ChoiceSetting Setting{ L"/MidiIO/Host",
+      { ByColumns, mHostNames, mHostLabels }
+   };
 
    S.SetBorder(2);
    S.StartScroller();
@@ -142,12 +146,7 @@ void MidiIOPrefs::PopulateOrExchange( ShuttleGui & S ) {
       {
          S.Id(HostID);
          /* i18n-hint: (noun) */
-         mHost = S.TieChoice( XXO("&Host:"),
-            {
-               wxT("/MidiIO/Host"),
-               { ByColumns, mHostNames, mHostLabels }
-            }
-         );
+         mHost = S.TieChoice(XXO("&Host:"), Setting);
 
          S.AddPrompt(XXO("Using: PortMidi"));
       }

--- a/src/prefs/TracksPrefs.cpp
+++ b/src/prefs/TracksPrefs.cpp
@@ -144,7 +144,7 @@ public:
    }
 };
 
-static TracksViewModeEnumSetting viewModeSetting()
+static TracksViewModeEnumSetting ViewModeSetting()
 {
    // Do a delayed computation, so that registration of sub-view types completes
    // first
@@ -168,7 +168,7 @@ static TracksViewModeEnumSetting viewModeSetting()
 
 WaveTrackViewConstants::Display TracksPrefs::ViewModeChoice()
 {
-   return viewModeSetting().ReadEnum();
+   return ViewModeSetting().ReadEnum();
 }
 
 WaveformSettings::ScaleTypeValues TracksPrefs::WaveformScaleChoice()
@@ -314,6 +314,8 @@ void TracksPrefs::Populate()
 
 void TracksPrefs::PopulateOrExchange(ShuttleGui & S)
 {
+   auto viewModeSetting = ViewModeSetting();
+
    S.SetBorder(2);
    S.StartScroller();
 
@@ -353,7 +355,7 @@ void TracksPrefs::PopulateOrExchange(ShuttleGui & S)
 #endif
 
          S.TieChoice(XXO("Default &view mode:"),
-                     viewModeSetting() );
+                     viewModeSetting );
 
          S.TieChoice(XXO("Default Waveform scale:"),
                      waveformScaleSetting );


### PR DESCRIPTION
Resolves: #2948
Resolves: #3017

Fix errors in the system for caching Preference values, where a temporary ChoiceSetting object is used that shares a settings path with a named Setting object.  Make the ChoiceSetting invalidate the other Setting when the ChoiceSetting is
written.

The problem affected these settings, and these only:

Decibel scale cutoff in Interface preferences
Default new project sample rate in Quality preferences
Host choice in Device preferences

Also fix another problem with one overload of `ReadWithDefault`.  This was known to affect other settings in Device 
preferences, although that may not be an exhaustive list of the hidden problems.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
