### PR TITLE
Realtime effect state management

### DIFF
--- a/libraries/lib-utility/MemoryX.h
+++ b/libraries/lib-utility/MemoryX.h
@@ -574,4 +574,28 @@ auto Visit(Visitor &&vis, Variant &&var)
       std::forward<Visitor>(vis), std::forward<Variant>(var) );
 }
 
+//! Atomic unique pointer (for nonarray type only) with a destructor;
+//! It doesn't copy or move
+template<typename T>
+struct AtomicUniquePointer : public std::atomic<T*> {
+   static_assert(AtomicUniquePointer::is_always_lock_free);
+   using std::atomic<T*>::atomic;
+   //! Reassign the pointer with release ordering,
+   //! then destroy any previously held object
+   /*!
+    Like `std::unique_ptr`, does not check for reassignment of the same pointer */
+   void reset(T *p = nullptr) {
+      delete this->exchange(p, std::memory_order_release);
+   }
+   //! reset to a pointer to a new object with given ctor arguments
+   template<typename... Args> void emplace(Args &&... args) {
+      reset(safenew T(std::forward<Args>(args)...));
+   }
+   ~AtomicUniquePointer() { reset(); }
+private:
+   //! Disallow pointer arithmetic
+   using std::atomic<T*>::fetch_add;
+   using std::atomic<T*>::fetch_sub;
+};
+
 #endif // __AUDACITY_MEMORY_X_H__

--- a/libraries/lib-utility/spinlock.h
+++ b/libraries/lib-utility/spinlock.h
@@ -32,6 +32,6 @@ public:
 
    void unlock()
    {
-      flag.clear();
+      flag.clear(std::memory_order_release);
    }
 };

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -348,8 +348,8 @@ AudioIO::~AudioIO()
    mAudioThread.join();
 }
 
-RealtimeEffectState *AudioIO::AddState(AudacityProject &project,
-   Track *pTrack, const PluginID & id)
+std::shared_ptr<RealtimeEffectState>
+AudioIO::AddState(AudacityProject &project, Track *pTrack, const PluginID & id)
 {
    RealtimeEffects::InitializationScope *pInit = nullptr;
    if (mpTransportState)
@@ -359,13 +359,13 @@ RealtimeEffectState *AudioIO::AddState(AudacityProject &project,
 }
 
 void AudioIO::RemoveState(AudacityProject &project,
-   Track *pTrack, RealtimeEffectState &state)
+   Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState)
 {
    RealtimeEffects::InitializationScope *pInit = nullptr;
    if (mpTransportState)
       if (auto pProject = GetOwningProject(); pProject.get() == &project)
          pInit = &*mpTransportState->mpRealtimeInitialization;
-   RealtimeEffectManager::Get(project).RemoveState(pInit, pTrack, state);
+   RealtimeEffectManager::Get(project).RemoveState(pInit, pTrack, pState);
 }
 
 RealtimeEffects::SuspensionScope AudioIO::SuspensionScope()

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -414,12 +414,12 @@ public:
    static AudioIO *Get();
 
    //! Forwards to RealtimeEffectManager::AddState with proper init scope
-   RealtimeEffectState *AddState(AudacityProject &project,
-      Track *pTrack, const PluginID & id);
+   std::shared_ptr<RealtimeEffectState>
+   AddState(AudacityProject &project, Track *pTrack, const PluginID & id);
 
    //! Forwards to RealtimeEffectManager::RemoveState with proper init scope
    void RemoveState(AudacityProject &project,
-      Track *pTrack, RealtimeEffectState &state);
+      Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState);
 
    RealtimeEffects::SuspensionScope SuspensionScope();
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1237,7 +1237,8 @@ void EffectUIHost::CleanupRealtime()
 {
    if (mSupportsRealtime && mInitialized) {
       if (mpState) {
-         AudioIO::Get()->RemoveState(mProject, nullptr, *mpState);
+         AudioIO::Get()->RemoveState(mProject, nullptr, mpState);
+         mpState.reset();
       /*
          ProjectHistory::Get(mProject).PushState(
             XO("Removed %s effect").Format(mpState->GetEffect()->GetName()),

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -103,7 +103,7 @@ private:
    const std::shared_ptr<EffectInstance> mpInstance;
    //! @invariant not null
    const EffectPlugin::EffectSettingsAccessPtr mpAccess;
-   RealtimeEffectState *mpState{ nullptr };
+   std::shared_ptr<RealtimeEffectState> mpState{};
    std::unique_ptr<EffectUIValidator> mpValidator;
 
    RegistryPaths mUserPresets;

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -20,6 +20,7 @@ RealtimeEffectList::~RealtimeEffectList()
 {
 }
 
+// Deep copy of states
 std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
 {
    auto result = std::make_unique<RealtimeEffectList>();
@@ -87,7 +88,10 @@ RealtimeEffectList::AddState(const PluginID &id)
 {
    auto pState = std::make_shared<RealtimeEffectState>(id);
    if (pState->GetEffect() != nullptr) {
-      mStates.emplace_back(pState);
+      auto shallowCopy = mStates;
+      shallowCopy.emplace_back(pState);
+      // Lock for only a short time
+      (LockGuard{ mLock }, swap(shallowCopy, mStates));
 
       Publisher<RealtimeEffectListMessage>::Publish({
          RealtimeEffectListMessage::Type::Insert,
@@ -104,12 +108,17 @@ RealtimeEffectList::AddState(const PluginID &id)
 void RealtimeEffectList::RemoveState(
    const std::shared_ptr<RealtimeEffectState> &pState)
 {
-   auto end = mStates.end(),
-      found = std::find(mStates.begin(), end, pState);
+   auto shallowCopy = mStates;
+   auto end = shallowCopy.end(),
+      found = std::find(shallowCopy.begin(), end, pState);
    if (found != end)
    {
-      const auto index = std::distance(mStates.begin(), found);
-      mStates.erase(found);
+      const auto index = std::distance(shallowCopy.begin(), found);
+      shallowCopy.erase(found);
+
+      // Lock for only a short time
+      (LockGuard{ mLock }, swap(shallowCopy, mStates));
+
       Publisher<RealtimeEffectListMessage>::Publish({
          RealtimeEffectListMessage::Type::Remove,
          static_cast<size_t>(index),
@@ -136,20 +145,24 @@ void RealtimeEffectList::MoveEffect(size_t fromIndex, size_t toIndex)
    assert(fromIndex < mStates.size());
    assert(toIndex < mStates.size());
 
+   auto shallowCopy = mStates;
    if(fromIndex == toIndex)
       return;
    if(fromIndex < toIndex)
    {
-      const auto first = mStates.begin() + fromIndex;
-      const auto last = mStates.begin() + toIndex + 1;
+      const auto first = shallowCopy.begin() + fromIndex;
+      const auto last = shallowCopy.begin() + toIndex + 1;
       std::rotate(first, first + 1, last);
    }
    else
    {
-      const auto first = mStates.rbegin() + (mStates.size() - (fromIndex + 1));
-      const auto last = mStates.rbegin() + (mStates.size() - toIndex);
+      const auto first = shallowCopy.rbegin() + (shallowCopy.size() - (fromIndex + 1));
+      const auto last = shallowCopy.rbegin() + (shallowCopy.size() - toIndex);
       std::rotate(first, first + 1, last);
    }
+   // Lock for only a short time
+   (LockGuard{ mLock }, swap(shallowCopy, mStates));
+
    Publisher<RealtimeEffectListMessage>::Publish({
       RealtimeEffectListMessage::Type::Move,
       fromIndex,
@@ -174,6 +187,8 @@ void RealtimeEffectList::HandleXMLEndTag(const std::string_view &tag)
    if (tag == XMLTag()) {
       // Remove states that fail to load their effects
       auto end = mStates.end();
+      // Assume deserialization is not happening concurrently with realtime
+      // effect processing; don't need a LockGuard
       auto newEnd = std::remove_if( mStates.begin(), end,
          [](const auto &pState){ return pState->GetEffect() == nullptr; });
       mStates.erase(newEnd, end);

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -54,6 +54,8 @@ public:
    RealtimeEffectList();
    virtual ~RealtimeEffectList();
 
+   //! Should be called (for pushing undo states) only from main thread, to
+   //! avoid races
    std::unique_ptr<ClientData::Cloneable<>> Clone() const override;
 
    static RealtimeEffectList &Get(AudacityProject &project);
@@ -71,21 +73,26 @@ public:
    //! Apply the function to all states sequentially.
    void Visit(StateVisitor func);
 
+   //! Use only in the main thread
    //! Returns null if no such effect was found.
    //! Sends Insert message on success.
    std::shared_ptr<RealtimeEffectState> AddState(const PluginID &id);
+   //! Use only in the main thread
    //! On success sends Remove message.
    void RemoveState(const std::shared_ptr<RealtimeEffectState> &pState);
 
+   //! Use only in the main thread, to avoid races
    //! Returns total number of effects in this list
    size_t GetStatesCount() const noexcept;
    //! Returns effect state at given position
+   //! Use only in the main thread, to avoid races
    std::shared_ptr<RealtimeEffectState> GetStateAt(size_t index) noexcept;
 
    /**
-    * \brief Changes effect position in the stack. Does nothing if fromIndex equal
-    * toIndex. Otherwise effects between fromIndex(excluding) and toIndex are shifted
-    * towards fromIndex. Sends Move event.
+    * \brief Use only in the main thread. Changes effect order in the stack.
+    * Does nothing if fromIndex equals toIndex. Otherwise effects between
+    * fromIndex (exclusive) and toIndex are shifted towards fromIndex.
+    * Sends Move event.
     * \param fromIndex Index of the moved effect
     * \param toIndex Final position of the moved effect
     */
@@ -94,8 +101,14 @@ public:
    static const std::string &XMLTag();
    bool HandleXMLTag(
       const std::string_view &tag, const AttributesList &attrs) override;
+
+   //! Use only in the main thread.  May remove a failed state
    void HandleXMLEndTag(const std::string_view &tag) override;
+
+   //! Use only in the main thread.  May add a state while deserializing
    XMLTagHandler *HandleXMLChild(const std::string_view &tag) override;
+
+   //! Use only in the main thread, to avoid races
    void WriteXML(XMLWriter &xmlFile) const;
 
    void RestoreUndoRedoState(AudacityProject &project) noexcept override;

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -49,8 +49,7 @@ class RealtimeEffectList final
    RealtimeEffectList &operator=(const RealtimeEffectList &) = delete;
 
 public:
-   
-   using States = std::vector<std::unique_ptr<RealtimeEffectState>>;
+   using States = std::vector<std::shared_ptr<RealtimeEffectState>>;
 
    RealtimeEffectList();
    virtual ~RealtimeEffectList();
@@ -74,14 +73,14 @@ public:
 
    //! Returns null if no such effect was found.
    //! Sends Insert message on success.
-   RealtimeEffectState *AddState(const PluginID &id);
+   std::shared_ptr<RealtimeEffectState> AddState(const PluginID &id);
    //! On success sends Remove message.
-   void RemoveState(RealtimeEffectState &state);
+   void RemoveState(const std::shared_ptr<RealtimeEffectState> &pState);
 
    //! Returns total number of effects in this list
    size_t GetStatesCount() const noexcept;
-   //! Returns effect state at given position, does not perform bounds check
-   RealtimeEffectState& GetStateAt(size_t index) noexcept;
+   //! Returns effect state at given position
+   std::shared_ptr<RealtimeEffectState> GetStateAt(size_t index) noexcept;
 
    /**
     * \brief Changes effect position in the stack. Does nothing if fromIndex equal

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "PluginProvider.h" // for PluginID
+#include "spinlock.h"
 #include "UndoManager.h"
 #include "XMLTagHandler.h"
 #include "Observer.h"
@@ -49,10 +50,13 @@ class RealtimeEffectList final
    RealtimeEffectList &operator=(const RealtimeEffectList &) = delete;
 
 public:
+   using Lock = spinlock;
    using States = std::vector<std::shared_ptr<RealtimeEffectState>>;
 
    RealtimeEffectList();
    virtual ~RealtimeEffectList();
+
+   Lock &GetLock() const { return mLock; }
 
    //! Should be called (for pushing undo states) only from main thread, to
    //! avoid races
@@ -115,6 +119,9 @@ public:
 
 private:
    States mStates;
+
+   using LockGuard = std::lock_guard<Lock>;
+   mutable Lock mLock;
 };
 
 #endif // __AUDACITY_REALTIMEEFFECTLIST_H__

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -273,8 +273,7 @@ void RealtimeEffectManager::VisitAll(StateVisitor func)
       RealtimeEffectList::Get(*leader).Visit(func);
 }
 
-RealtimeEffectState *
-RealtimeEffectManager::AddState(
+std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
    RealtimeEffects::InitializationScope *pScope,
    Track *pTrack, const PluginID & id)
 {
@@ -321,12 +320,12 @@ RealtimeEffectManager::AddState(
       pLeader ? pLeader->shared_from_this() : nullptr
    });
 
-   return &state;
+   return pState;
 }
 
 void RealtimeEffectManager::RemoveState(
    RealtimeEffects::InitializationScope *pScope,
-   Track *pTrack, RealtimeEffectState &state)
+   Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState)
 {
    auto pLeader = pTrack ? *TrackList::Channels(pTrack).begin() : nullptr;
    RealtimeEffectList &states = pLeader
@@ -344,9 +343,9 @@ void RealtimeEffectManager::RemoveState(
    std::lock_guard<std::mutex> guard(mLock);
 
    if (mActive)
-      state.Finalize();
+      pState->Finalize();
 
-   states.RemoveState(state);
+   states.RemoveState(pState);
 
    Publish({
       RealtimeEffectManagerMessage::Type::EffectRemoved,

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -91,7 +91,8 @@ private:
 
    //! Main thread begins to define a set of tracks for playback
    void Initialize(double rate);
-   //! Main thread adds one track (passing the first of one or more channels)
+   //! Main thread adds one track (passing the first of one or more
+   //! channels), still before playback
    void AddTrack(Track &track, unsigned chans, float rate);
    //! Main thread cleans up after playback
    void Finalize() noexcept;
@@ -135,7 +136,10 @@ private:
    std::atomic<bool> mSuspended{ true };
    std::atomic<bool> mActive{ false };
 
+   // This member is mutated only by Initialize(), AddTrack(), Finalize()
+   // which are to be called only while there is no playback
    std::vector<Track *> mGroupLeaders; //!< all are non-null
+
    std::unordered_map<Track *, unsigned> mChans;
    std::unordered_map<Track *, double> mRates;
 };

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -71,8 +71,9 @@ public:
     @param id identifies the effect
     @return if null, the given id was not found
     */
-   RealtimeEffectState *AddState(RealtimeEffects::InitializationScope *pScope,
-      Track *pTrack, const PluginID & id);
+   std::shared_ptr<RealtimeEffectState> AddState(
+      RealtimeEffects::InitializationScope *pScope, Track *pTrack,
+      const PluginID & id);
 
    //! Main thread removes a global or per-track effect
    /*!
@@ -82,7 +83,7 @@ public:
     */
    /*! No effect if realtime is active but scope is not supplied */
    void RemoveState(RealtimeEffects::InitializationScope *pScope,
-      Track *pTrack, RealtimeEffectState &state);
+      Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState);
 
 private:
    friend RealtimeEffects::InitializationScope;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -24,7 +24,9 @@
 class EffectSettingsAccess;
 class Track;
 
-class RealtimeEffectState : public XMLTagHandler
+class RealtimeEffectState
+   : public XMLTagHandler
+   , public std::enable_shared_from_this<RealtimeEffectState>
 {
 public:
    struct AUDACITY_DLL_API EffectFactory : GlobalHook<EffectFactory,
@@ -71,10 +73,23 @@ public:
    XMLTagHandler *HandleXMLChild(const std::string_view &tag) override;
    void WriteXML(XMLWriter &xmlFile);
 
-   // Expose access so a dialog can be connected to this state
+   //! Expose access so a dialog can be connected to this state
+   //! To be called by the main thread only
    std::shared_ptr<EffectSettingsAccess> GetAccess();
 
 private:
+   struct Access;
+   struct AccessState;
+
+   AccessState *GetAccessState() const
+   {
+      return mpAccessState.load(std::memory_order_relaxed);
+   }
+   AccessState *TestAccessState() const
+   {
+      return mpAccessState.load(std::memory_order_acquire);
+   }
+
    /*! @name Members that are copied
     @{
     */
@@ -94,11 +109,11 @@ private:
    //! Stateful instance made by the plug-in
    std::shared_ptr<EffectInstance> mInstance;
 
-   struct Access;
-   struct AccessState;
-   std::shared_ptr<AccessState> mpAccessState; // Destroy before mSettings
-   std::weak_ptr<EffectSettingsAccess> mwAccess;
-
+   // This must not be reset to nullptr while a worker thread is running.
+   // In fact it is never yet reset to nullptr, before destruction.
+   // Destroy before mSettings:
+   AtomicUniquePointer<AccessState> mpAccessState{ nullptr };
+   
    size_t mCurrentProcessor{ 0 };
    std::unordered_map<Track *, size_t> mGroups;
 


### PR DESCRIPTION
Resolves: #3027

Fix data races on `RealtimeEffectState` 's pointer to its `AccessState`, which entails management of the states by shared and weak pointers.

That change of memory management also allows fixes for the data races on the composition of RealtimeEffectList, done in a way that minimizes the contention time in the audio thread.  The main thread holds a spin lock on the list only long enough to swap one vector.  The audio thread may hold the same lock for a longer scope, making the main thread spin for that duration.

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
