### PR TITLE
Adds verbose logging for Journal tests on CI

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityTesting.cmake
+++ b/cmake-proxies/cmake-modules/AudacityTesting.cmake
@@ -101,6 +101,8 @@ if( ${_OPT}has_tests )
       endif()
    endfunction()
 
+   set( JOURNAL_TEST_TIMEOUT_SECONDS 180 )
+
    #[[
       add_journal_test(journal_file)
 
@@ -115,6 +117,14 @@ if( ${_OPT}has_tests )
          # On macOS CMake will generate a placeholder that CTest fails to handle correctly,
          # so we have to setup the path manually
          set( audacity_target "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>/Audacity.app/Contents/MacOS/Audacity" )
+      elseif (WIN32)
+         set( audacity_target
+            powershell
+               -ExecutionPolicy Bypass
+               -File "${CMAKE_SOURCE_DIR}/tests/journals/test_runner.ps1"
+               "$<TARGET_FILE:Audacity>"
+               --timeout ${JOURNAL_TEST_TIMEOUT_SECONDS}
+         )
       else()
          set( audacity_target "$<TARGET_FILE:Audacity>" )
       endif()
@@ -132,7 +142,7 @@ if( ${_OPT}has_tests )
          ${test_name}
          PROPERTIES
             LABELS "journal_tests"
-            TIMEOUT 180
+            TIMEOUT ${JOURNAL_TEST_TIMEOUT_SECONDS}
       )
    endfunction()
 else()

--- a/src/Journal.h
+++ b/src/Journal.h
@@ -86,7 +86,8 @@ namespace Journal
    //\brief thrown when playback of a journal doesn't match the recording
    class SyncException : public AudacityException {
    public:
-      SyncException();
+      //! Constructs an exception with a message; message is logged into the `journallog.txt` file.
+      explicit SyncException(const wxString& message);
       ~SyncException() override;
 
       // The delayed handler action forces the program to quit gracefully,

--- a/src/widgets/BasicMenu.cpp
+++ b/src/widgets/BasicMenu.cpp
@@ -199,7 +199,9 @@ void ReplayPopup( wxMenu *theMenu )
    }
 
    // Replay did not find all as expected
-   throw Journal::SyncException{};
+   throw Journal::SyncException(wxString::Format(
+      "PopupMenu has failed to invoke %s",
+      wxJoin(fields, ',').ToStdString().c_str()));
 }
 
 }
@@ -221,7 +223,7 @@ void Handle::Popup( const BasicUI::WindowPlacement &window, const Point &pos )
          ReplayPopup( pMenu );
       else
          pWindow->PopupMenu( pMenu, { pos.x, pos.y } );
-      
+
       if ( !sHandledEvent )
          // Menu popped but no command was selected.  Record that.
          Journal::Output( JournalCode );

--- a/tests/journals/test_runner.ps1
+++ b/tests/journals/test_runner.ps1
@@ -1,0 +1,48 @@
+$audacityExecutable = $args[0]
+$timeoutInSeconds = [int]$(if($args[1] -eq '--timeout') { $args[2] } else { $args[4] })
+$journalFile = if($args[1] -eq '--timeout') { $args[4] } else { $args[2] }
+
+Write-Host "Audacity Executable: $audacityExecutable"
+Write-Host "Journal File: $journalFile"
+
+if (-not(Test-Path -Path $journalFile -PathType Leaf)) {
+    Write-Host "Journal file does not exist"
+    exit 1
+}
+
+$process = [Diagnostics.Process]::Start("$audacityExecutable", "--journal $journalFile")
+
+$completedInTime = $process.WaitForExit($timeoutInSeconds * 1000)
+
+if (-not $completedInTime) {
+    Write-Host "Timed out waiting for Audacity to finish"
+    exit 1
+}
+
+Write-Host "Audacity finished in $(($process.ExitTime - $process.StartTime).TotalSeconds) seconds"
+Write-Host "Exit code: $($process.ExitCode)"
+
+if ($process.ExitCode -ne 0) {
+   $logDir = "$env:APPDATA\audacity"
+   Write-Host "Audacity exited with an error, gathering data from $logDir"
+
+   if (Test-Path -Path "$logDir\journallog.txt" ) {
+      Get-Content -Path "$logDir\journallog.txt" | Out-Default
+   } else {
+      Write-Host "No journallog.cfg file found"
+   }
+
+   if (Test-Path -Path "$logDir\lastlog.txt" ) {
+      Get-Content -Path "$logDir\lastlog.txt" | Out-Default
+   } else {
+      Write-Host "No lastlog.txt file found"
+   }
+
+   if (Test-Path -Path "$logDir\audacity.cfg" ) {
+      Get-Content -Path "$logDir\audacity.cfg" | Out-Default
+   } else {
+      Write-Host "No audacity.cfg file found"
+   }
+
+   exit 1
+}


### PR DESCRIPTION
It was problematic to determine the reason why the sanity test has failed,
especially on Windows. 

CTest framework does not allow to get the exit code of the application (or there is no easy way to retrieve it at lease).

To simplify the test run analysis the following was added to the journaling system:

* Journal writes every step and sync exception into `journallog.txt` with aggressive flushing
* On Windows - test run is wrapped into a PowerShell script, that outputs the exit code and collects the logs of the test run. It is unclear, if a similar script is needed on *nix systems

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
