### PR TITLE
Adds an option to invoke Conan with `--build`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -244,8 +244,9 @@ This option implies `-Daudacity_obey_system_dependencies=On` and disables `local
 
 ### Disabling pre-built binaries downloads for Conan
 
-It is possible to force Conan to build all the dependencies from the source code without using the pre-built binaries. To do so, please pass `-Daudaicity_conan_allow_prebuilt_binaries=Off` to CMake during the configuration. This option will trigger rebuild every
-time CMake configuration changes.
+It is possible to force Conan to build all the dependencies from the source code without using the pre-built binaries. To do so, please pass `-Daudaicity_conan_allow_prebuilt_binaries=Off` to CMake during the configuration. 
+
+Additionally, passing `-Daudacity_conan_force_build_dependencies=On` will force Conan to rebuild all the packaged during *every* configuration. This can be usefull for the offline builds against the Conan download cache.
 
 ### Troubleshooting Conan issues
 

--- a/CMAKE_OPTIONS.md
+++ b/CMAKE_OPTIONS.md
@@ -1,37 +1,39 @@
-| Name                              | Type   | Default    | Description                                                     |
-| :-------------------------------- | :----- | :--------- | :-------------------------------------------------------------- |
-| CMAKE_BUILD_TYPE                  | STRING | Debug      | Type of the build: Debug, Release, RelWithDebInfo, MinSizeRel   |
-| CMAKE_INSTALL_PREFIX              | PATH   | /usr/local | Install path prefix, prepended onto install directories.        |
-| audacity_lib_preference           | STRING | local      | Library preference [system (if available), local]               |
-| audacity_obey_system_dependencies | BOOL   | Off        | Use only system packages to satisfy dependencies                |
-| audacity_use_expat                | STRING | system     | Use expat library [system (if available), local, off]           |
-| audacity_use_ffmpeg               | STRING | loaded     | Use ffmpeg library [loaded, linked, off]                        |
-| audacity_use_flac                 | STRING | local      | Use flac library [system (if available), local, off]            |
-| audacity_use_id3tag               | STRING | local      | Use id3tag library [system (if available), local, off]          |
-| audacity_use_ladspa               | BOOL   | ON         | Use LADSPA plug-in support [on, off]                            |
-| audacity_use_libmad               | STRING | local      | Use libmad library [system (if available), local, off]          |
-| audacity_use_libmp3lame           | STRING | local      | Use libmp3lame library [system (if available), local, off]      |
-| audacity_use_lv2                  | STRING | local      | Use lv2 library [system (if available), local, off]             |
-| audacity_use_mad                  | STRING | local      | Use mad library [system (if available), local, off]             |
-| audacity_use_midi                 | STRING | local      | Use midi library [system (if available), local, off]            |
-| audacity_use_nyquist              | STRING | local      | Use nyquist library [local, off]                                |
-| audacity_use_ogg                  | STRING | local      | Use ogg library [system (if available), local, off]             |
-| audacity_use_pa_alsa              | BOOL   | YES        | Use the portaudio ALSA interface if available                   |
-| audacity_use_pa_jack              | STRING | linked     | Use the JACK audio interface if available [loaded, linked, off] |
-| audacity_use_pa_oss               | BOOL   | YES        | Use the OSS audio interface if available                        |
-| audacity_use_pch                  | BOOL   | YES        | Use precompiled headers [yes, no]                               |
-| audacity_use_portaudio            | STRING | local      | Use portaudio library [local]                                   |
-| audacity_use_portmixer            | STRING | local      | Use portmixer library [local, off]                              |
-| audacity_use_portsmf              | STRING | local      | Use portsmf library [system (if available), local, off]         |
-| audacity_use_sbsms                | STRING | local      | Use sbsms library [system (if available), local, off]           |
-| audacity_use_sndfile              | STRING | local      | Use sndfile library [system (if available), local]              |
-| audacity_use_soundtouch           | STRING | local      | Use soundtouch library [system (if available), local, off]      |
-| audacity_use_soxr                 | STRING | local      | Use soxr library [system (if available), local]                 |
-| audacity_use_sqlite               | STRING | local      | Use sqlite library [system (if available), local]               |
-| audacity_use_twolame              | STRING | local      | Use twolame library [system (if available), local, off]         |
-| audacity_use_vamp                 | STRING | local      | Use vamp library [system (if available), local, off]            |
-| audacity_use_vorbis               | STRING | local      | Use vorbis library [system (if available), local, off]          |
-| audacity_use_vst                  | BOOL   | ON         | Use VST2 plug-in support [on, off]                              |
-| audacity_use_wxwidgets            | STRING | local      | Use wxwidgets library [system (if available), local, off]       |
-| audacity_use_zlib                 | STRING | local      | Use zlib library [system (if available), local, off]            |
-| audacity_use_curl                 | STRING | local      | Use curl library [system (if available), local]                 |
+| Name                                    | Type   | Default    | Description                                                     |
+| :-------------------------------------- | :----- | :--------- | :-------------------------------------------------------------- |
+| CMAKE_BUILD_TYPE                        | STRING | Debug      | Type of the build: Debug, Release, RelWithDebInfo, MinSizeRel   |
+| CMAKE_INSTALL_PREFIX                    | PATH   | /usr/local | Install path prefix, prepended onto install directories.        |
+| audacity_lib_preference                 | STRING | local      | Library preference [system (if available), local]               |
+| audacity_obey_system_dependencies       | BOOL   | Off        | Use only system packages to satisfy dependencies                |
+| audacity_conan_enabled                  | BOOL   | On         | Use Conan package manager to resolve the 3d party dependencies  |
+| audacity_conan_force_build_dependencies | BOOL   | Off        | Rebuild all dependecies during the CMake configuration          |
+| audacity_use_expat                      | STRING | system     | Use expat library [system (if available), local, off]           |
+| audacity_use_ffmpeg                     | STRING | loaded     | Use ffmpeg library [loaded, linked, off]                        |
+| audacity_use_flac                       | STRING | local      | Use flac library [system (if available), local, off]            |
+| audacity_use_id3tag                     | STRING | local      | Use id3tag library [system (if available), local, off]          |
+| audacity_use_ladspa                     | BOOL   | ON         | Use LADSPA plug-in support [on, off]                            |
+| audacity_use_libmad                     | STRING | local      | Use libmad library [system (if available), local, off]          |
+| audacity_use_libmp3lame                 | STRING | local      | Use libmp3lame library [system (if available), local, off]      |
+| audacity_use_lv2                        | STRING | local      | Use lv2 library [system (if available), local, off]             |
+| audacity_use_mad                        | STRING | local      | Use mad library [system (if available), local, off]             |
+| audacity_use_midi                       | STRING | local      | Use midi library [system (if available), local, off]            |
+| audacity_use_nyquist                    | STRING | local      | Use nyquist library [local, off]                                |
+| audacity_use_ogg                        | STRING | local      | Use ogg library [system (if available), local, off]             |
+| audacity_use_pa_alsa                    | BOOL   | YES        | Use the portaudio ALSA interface if available                   |
+| audacity_use_pa_jack                    | STRING | linked     | Use the JACK audio interface if available [loaded, linked, off] |
+| audacity_use_pa_oss                     | BOOL   | YES        | Use the OSS audio interface if available                        |
+| audacity_use_pch                        | BOOL   | YES        | Use precompiled headers [yes, no]                               |
+| audacity_use_portaudio                  | STRING | local      | Use portaudio library [local]                                   |
+| audacity_use_portmixer                  | STRING | local      | Use portmixer library [local, off]                              |
+| audacity_use_portsmf                    | STRING | local      | Use portsmf library [system (if available), local, off]         |
+| audacity_use_sbsms                      | STRING | local      | Use sbsms library [system (if available), local, off]           |
+| audacity_use_sndfile                    | STRING | local      | Use sndfile library [system (if available), local]              |
+| audacity_use_soundtouch                 | STRING | local      | Use soundtouch library [system (if available), local, off]      |
+| audacity_use_soxr                       | STRING | local      | Use soxr library [system (if available), local]                 |
+| audacity_use_sqlite                     | STRING | local      | Use sqlite library [system (if available), local]               |
+| audacity_use_twolame                    | STRING | local      | Use twolame library [system (if available), local, off]         |
+| audacity_use_vamp                       | STRING | local      | Use vamp library [system (if available), local, off]            |
+| audacity_use_vorbis                     | STRING | local      | Use vorbis library [system (if available), local, off]          |
+| audacity_use_vst                        | BOOL   | ON         | Use VST2 plug-in support [on, off]                              |
+| audacity_use_wxwidgets                  | STRING | local      | Use wxwidgets library [system (if available), local, off]       |
+| audacity_use_zlib                       | STRING | local      | Use zlib library [system (if available), local, off]            |
+| audacity_use_curl                       | STRING | local      | Use curl library [system (if available), local]                 |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,11 @@ cmd_option( ${_OPT}conan_allow_prebuilt_binaries
             On
 )
 
+cmd_option( ${_OPT}conan_force_build_dependencies
+            "Force Conan to rebuild the dependencies every time"
+            Off
+)
+
 # Allow user to globally set the library preference
 cmd_option( ${_OPT}lib_preference
             "Library preference [system (if available), local]"

--- a/cmake-proxies/cmake-modules/AudacityDependencies.cmake
+++ b/cmake-proxies/cmake-modules/AudacityDependencies.cmake
@@ -1,11 +1,15 @@
 # Load Conan
 
 if ( ${_OPT}conan_allow_prebuilt_binaries )
-    set( CONAN_BUILD_MODE BUILD missing )
     set( CONAN_REMOTE https://artifactory.audacityteam.org/artifactory/api/conan/audacity-binaries )
 else()
-    set( CONAN_BUILD_MODE BUILD all )
     set( CONAN_REMOTE https://artifactory.audacityteam.org/artifactory/api/conan/audacity-recipes )
+endif()
+
+if( ${_OPT}conan_force_build_dependencies )
+   set( CONAN_BUILD_MODE BUILD all )
+else()
+   set( CONAN_BUILD_MODE BUILD missing )
 endif()
 
 if( ${_OPT}conan_enabled )
@@ -47,9 +51,9 @@ if( ${_OPT}conan_enabled )
     if( DEFINED OLD_CXX )
         set( ENV{CXX} ${OLD_CXX} )
     endif()
-    
+
     set(ENV{CONAN_REVISIONS_ENABLED} 1)
-     
+
     conan_add_remote(NAME audacity
         URL ${CONAN_REMOTE}
         VERIFY_SSL True
@@ -307,7 +311,6 @@ function ( _conan_install build_type )
         ${CONAN_BUILD_MODE}
         PROFILE_BUILD audacity_build
         SETTINGS_HOST ${settings}
-        #REMOTE audacity
    )
 endfunction()
 

--- a/linux/packages/arch/PKGBUILD
+++ b/linux/packages/arch/PKGBUILD
@@ -33,6 +33,10 @@ depends=(zlib
    libpng
    libjpeg-turbo
    libsm
+   harfbuzz
+   freetype2
+   fontconfig
+   mesa
 )
 
 makedepends=(
@@ -77,6 +81,7 @@ build() {
         -D CMAKE_INSTALL_PREFIX=/usr
 
         -D audacity_conan_allow_prebuilt_binaries=no
+        -D audacity_conan_force_build_dependencies=yes
 
         -D audacity_lib_preference=system # Change the libs default to 'system'
         -D audacity_obey_system_dependencies=On # And force it!
@@ -86,6 +91,8 @@ build() {
         -D audacity_use_wxwidgets=local # wxWidgets 3.1 is not available
 
         -D audacity_use_sbsms=local # sbsms is only available in AUR
+
+        -D audacity_has_vst3=no
     )
 
     sourceDir=$(echo audacity-sources-*/)

--- a/linux/packages/arch/dependencies.sh
+++ b/linux/packages/arch/dependencies.sh
@@ -36,6 +36,10 @@ deps=(
    libjpeg-turbo
    libsm
    ffmpeg
+   harfbuzz
+   freetype2
+   fontconfig
+   mesa
 )
 
 pacman -Syu --noconfirm \

--- a/linux/packages/arch/entrypoint.sh
+++ b/linux/packages/arch/entrypoint.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
-cp /work_dir/*.tar.gz ./
+cp -v /work_dir/*.tar.gz ./
+
+ls -la .
 
 sources=$(ls audacity-sources-*)
 version=$(echo ${sources} | sed -e 's/audacity-sources-//g' -e 's/.tar.gz//g' -e 's/-/./g' -e 's/\.[0-9]\++/.r/g')

--- a/linux/packages/build_packages.sh
+++ b/linux/packages/build_packages.sh
@@ -10,24 +10,24 @@ mkdir -p "$workDir"
 
 pushd "$workDir"
 
+../prepare_offline_dependencies.sh
+
 tar --exclude '.git' \
-    --exclude "audacity-sources.tar.gz" \
+    --exclude "audacity-sources-3.2.0.tar.gz" \
     -C "$audacityLocation/.." \
-    -czf audacity-sources.tar.gz audacity
+    -czf audacity-sources-3.2.0.tar.gz audacity
 
 for distro in "$@"
 do
     echo "Building $distro"
 
     imageName="audacity-packaging-$distro"
-        
+
     docker build -t $imageName "$scriptLocation/$distro"
-    docker run -ti --volume=$workDir:/work_dir --rm  $imageName prepare
-    docker run -ti --volume=$workDir:/work_dir --rm --network none $imageName build
-    docker run -ti --volume=$workDir:/work_dir --rm --network none $imageName package
+    docker run -ti --volume=$workDir:/work_dir --rm --network none $imageName
 done
 
-rm audacity-sources.tar.gz
+rm audacity-sources-3.2.0.tar.gz
 
 popd
 

--- a/linux/packages/fedora34/audacity.spec
+++ b/linux/packages/fedora34/audacity.spec
@@ -57,6 +57,10 @@ BuildRequires: sord-devel >= 0.16.4
 BuildRequires: sratom-devel >= 0.6.4
 BuildRequires: suil-devel  >= 0.10.6
 BuildRequires: flac-devel
+BuildRequires: harfbuzz-devel
+BuildRequires: freetype-devel
+BuildRequires: fontconfig-devel
+BuildRequires: mesa-libEGL-devel
 
 Requires:      portaudio%{?_isa} >= 19-16
 
@@ -79,6 +83,7 @@ supports PulseAudio, OSS and ALSA under Linux.
     -D CMAKE_BUILD_TYPE=Release \
     -D audacity_conan_enabled=Off \
     -D audacity_conan_allow_prebuilt_binaries=no \
+    -D audacity_conan_force_build_dependencies=yes \
     -D audacity_lib_preference=system \
     -D audacity_obey_system_dependencies=On \
     -D audacity_use_pch=no \

--- a/linux/packages/fedora34/dependencies.sh
+++ b/linux/packages/fedora34/dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 build_deps=(
-   fedora-packager 
+   fedora-packager
    @development-tools
    cmake
    gettext-devel
@@ -48,8 +48,12 @@ deps=(
    sratom-devel
    suil-devel
    flac-devel
+   harfbuzz-devel
+   freetype-devel
+   fontconfig-devel
+   mesa-libEGL-devel
 )
 
 dnf install -y \
    "${build_deps[@]}" \
-   "${deps[@]}" 
+   "${deps[@]}"

--- a/linux/packages/prepare_offline_dependencies.sh
+++ b/linux/packages/prepare_offline_dependencies.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# Usage prepare_offline_environment.sh cmake-options... 
+# Usage prepare_offline_environment.sh cmake-options...
 
 set -euxo pipefail
 
-packageName="audacity-offline-dependencies"
+packageName="audacity-dependencies-3.2.0"
 scriptLocation=$(dirname "$(readlink -f "$0")")
 audacityLocation=$(readlink -f "$scriptLocation/../..")
 resultsLocation=$(pwd)
@@ -30,13 +30,13 @@ popd
 
 # Cache all Conan dependencies
 
-mkdir -p temp 
+mkdir -p temp
 
 pushd temp
     python3 -m venv conan_env
 
     source conan_env/bin/activate
-    pip3 install --no-index --find-links "$packageLocation/pip_cache" conan 
+    pip3 install --no-index --find-links "$packageLocation/pip_cache" conan
 
     export CONAN_USER_HOME="$packageLocation/conan_home"
     mkdir -p $CONAN_USER_HOME
@@ -51,7 +51,7 @@ pushd temp
 
     cmake ${@} $audacityLocation
 
-    conan remove "*" --src --builds --packages --force 
+    conan remove "*" --src --builds --packages --force
 popd
 
 rm -R temp

--- a/linux/packages/ubuntu-20.04/debian/control
+++ b/linux/packages/ubuntu-20.04/debian/control
@@ -2,7 +2,7 @@ Source: audacity
 Section: sound
 Priority: optional
 Maintainer:
-Uploaders: 
+Uploaders:
 Standards-Version: 4.5.0
 Build-Depends: cmake,
                debhelper-compat (= 12),
@@ -42,7 +42,11 @@ Build-Depends: cmake,
                libsoundtouch-dev,
                libtwolame-dev,
                libpng-dev,
-               libjpeg-turbo8-dev
+               libjpeg-turbo8-dev,
+               libharfbuzz-dev,
+               libfreetype6-dev,
+               libfontconfig-dev,
+               libegl1-mesa-dev
 Homepage: https://www.audacityteam.org/
 Rules-Requires-Root: no
 
@@ -51,4 +55,4 @@ Architecture: amd64
 Depends: ${misc:Depends},
          ${shlibs:Depends}
 Description: Audacity is a multi-track audio editor for Linux/Unix, MacOS and
- Windows.  
+ Windows.

--- a/linux/packages/ubuntu-20.04/debian/rules
+++ b/linux/packages/ubuntu-20.04/debian/rules
@@ -14,12 +14,13 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 	-DCMAKE_BUILD_TYPE=Release \
 	-Daudacity_conan_allow_prebuilt_binaries=no \
+   -D audacity_conan_force_build_dependencies=yes \
 	-Daudacity_lib_preference=system \
 	-Daudacity_obey_system_dependencies=On \
 	-Daudacity_use_pch=no \
 	-Daudacity_use_wxwidgets=local \
 	-Daudacity_use_vamp=local \
-	-Daudacity_use_sbsms=local 
+	-Daudacity_use_sbsms=local
 
 # tests fails with system portaudio
 override_dh_auto_test:

--- a/linux/packages/ubuntu-20.04/dependencies.sh
+++ b/linux/packages/ubuntu-20.04/dependencies.sh
@@ -4,8 +4,8 @@ export TZ=Europe/London
 ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 build_deps=(
-   build-essential 
-   fakeroot 
+   build-essential
+   fakeroot
    devscripts
    gcc
    g++
@@ -56,9 +56,13 @@ deps=(
    libtwolame-dev
    libpng-dev
    libjpeg-turbo8-dev
+   libharfbuzz-dev
+   libfreetype6-dev
+   libfontconfig-dev
+   libegl1-mesa-dev
 )
 
 apt-get update
 apt-get install -y \
    "${build_deps[@]}" \
-   "${deps[@]}" 
+   "${deps[@]}"


### PR DESCRIPTION
CMake now has two separate options to control how 3d party dependencies are built:

* `audacity_conan_allow_prebuilt_binaries` sets the remote to `audacity-recipes`, so no binaries will be downloaded from the Artifactory.
* `audacity_conan_force_build_dependencies` forces all the dependencies to be rebuilt every time Audacity is configured. We need this behavior for the offline Linux builds.

Linux packaging jobs were updated according to this changes

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
