### PR TITLE
Pins Windows SDK version to overcome a bug in the WRL library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,21 +165,25 @@ jobs:
           arch: x32
           generator: Visual Studio 16 2019
           postfix: '-msvc2019'
+          windows_sdk: '10.0.18362.0'
         - name: Windows MSVC 2019 (x86_64)
           os: windows-2019
           arch: x64
           generator: Visual Studio 16 2019
           postfix: '-msvc2019'
+          windows_sdk: '10.0.18362.0'
         - name: Windows MSVC 2022 (x86)
           os: windows-2022
           arch: x32
           generator: Visual Studio 17 2022
           postfix: '-msvc2022'
+          windows_sdk: '10.0.22000.0'
         - name: Windows MSVC 2022 (x86_64)
           os: windows-2022
           arch: x64
           generator: Visual Studio 17 2022
           postfix: '-msvc2022'
+          windows_sdk: '10.0.22000.0'
     steps:
     - name: Checkout Audacity
       uses: actions/checkout@v2
@@ -195,7 +199,9 @@ jobs:
         build_type: ${{ env.BUILD_TYPE }}
         configuration_types: ${{ env.CONFIGURATION_TYPES }}
         build_level: $${{ env.BUILD_LEVEL }}
-        cmake_options: ${{ env.CONFIGURE_CMAKE_OPTIONS }}
+        cmake_options: |
+          ${{ env.CONFIGURE_CMAKE_OPTIONS }}
+          -DCMAKE_SYSTEM_VERSION=${{ matrix.config.windows_sdk }}
         windows_certificate: ${{ secrets.WINDOWS_CERTIFICATE }}
         windows_certificate_password: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
     - name: Build


### PR DESCRIPTION
This PR is needed as there is a bug in a Windows SDK selected by default on CI for MSVC 2019 builds. This bug prevents us from using WRL::ComPtr which will be needed later on

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
