### PR TITLE
Adds missing preprocessor definitions to the testing frameworks

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -246,7 +246,7 @@ function( audacity_append_common_compiler_options var use_pch )
 
          # This renames a good use of this C++ keyword that we don't need
 	      # to review when hunting for leaks because of naked new and delete.
-	 -DPROHIBITED==delete
+	      -DPROHIBITED==delete
 
          # Reviewed, certified, non-leaky uses of NEW that immediately entrust
 	      # their results to RAII objects.
@@ -268,11 +268,11 @@ function( audacity_append_common_compiler_options var use_pch )
          $<$<CXX_COMPILER_ID:MSVC>:-DNOMINMAX>
 
          # Define/undefine _DEBUG
-	 # Yes, -U to /U too as needed for Windows:
-	 $<IF:$<CONFIG:Debug>,-D_DEBUG=1,-U_DEBUG>
+         # Yes, -U to /U too as needed for Windows:
+         $<IF:$<CONFIG:Debug>,-D_DEBUG=1,-U_DEBUG>
 
          $<$<PLATFORM_ID:Darwin>:-DUSE_AQUA_THEME>
-   )   
+   )
    # Definitions controlled by the AUDACITY_BUILD_LEVEL switch
    if( AUDACITY_BUILD_LEVEL EQUAL 0 )
       list( APPEND ${var} -DIS_ALPHA -DUSE_ALPHA_MANUAL )
@@ -281,7 +281,7 @@ function( audacity_append_common_compiler_options var use_pch )
    else()
       list( APPEND ${var} -DIS_RELEASE )
    endif()
-  
+
    set( ${var} "${${var}}" PARENT_SCOPE )
 endfunction()
 

--- a/cmake-proxies/cmake-modules/AudacityTesting.cmake
+++ b/cmake-proxies/cmake-modules/AudacityTesting.cmake
@@ -51,6 +51,10 @@ if( ${_OPT}has_tests )
       add_executable( ${test_executable_name} ${ADD_UNIT_TEST_SOURCES} "${CMAKE_SOURCE_DIR}/tests/Catch2Main.cpp")
       target_link_libraries( ${test_executable_name} ${ADD_UNIT_TEST_LIBRARIES} Catch2::Catch2 )
 
+      set( OPTIONS )
+      audacity_append_common_compiler_options( OPTIONS NO )
+      target_compile_options( ${test_executable_name} ${OPTIONS} )
+
       set_target_properties(
          ${test_executable_name}
          PROPERTIES


### PR DESCRIPTION
Duplicates some of the preprocessor definitions used to build Audacity and libraries. Adds `UNIT_TEST` preprocessor definition available only for unit tests.

Additionally, fixes some formatting mess on `AudacityFunctions.cmake`

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
