### PR TITLE
issue 3039: vst3 plain gui: accessibility of sliders

### DIFF
--- a/src/effects/VST3/VST3ParametersWindow.cpp
+++ b/src/effects/VST3/VST3ParametersWindow.cpp
@@ -24,6 +24,9 @@
 
 #include "MemoryX.h"
 #include "VST3Utils.h"
+#if wxUSE_ACCESSIBILITY
+#include "../../widgets/WindowAccessible.h"
+#endif
 
 
 //Interface between wx control and IEditController parameter.
@@ -38,6 +41,8 @@ public:
    virtual void UpdateValue(Steinberg::Vst::IEditController&) = 0;
    //Convert current control value to normalized parameter value
    virtual Steinberg::Vst::ParamValue GetNormalizedValue(Steinberg::Vst::IEditController& editController) const = 0;
+   //Update a control's accessible object if necessary
+   virtual void UpdateAccessible(Steinberg::Vst::IEditController&) {}
 
    Steinberg::Vst::ParamID GetParameterId() const noexcept { return mParameterId; }
 };
@@ -105,23 +110,43 @@ namespace
 
    class VST3ContinuousParameter final : public wxSlider, public VST3ParameterControl
    {
+      const wxString mTitle;
+      const wxString mUnits;
+
    public:
       static constexpr auto Step = 0.01;
 
       VST3ContinuousParameter(wxWindow *parent,
              wxWindowID id,
              Steinberg::Vst::ParamID paramId,
+             const wxString& title,
+             const wxString& units,
              const wxPoint& pos = wxDefaultPosition,
              const wxSize& size = wxDefaultSize,
              long style = wxSL_HORIZONTAL,
              const wxValidator& validator = wxDefaultValidator,
              const wxString& name = wxSliderNameStr)
       : wxSlider(parent, id, 0, 0, static_cast<int>(1.0 / Step), pos, size, style, validator, name)
-      , VST3ParameterControl(paramId) { }
+      , VST3ParameterControl(paramId)
+      , mTitle(title)
+      , mUnits(units)
+      {
+#if wxUSE_ACCESSIBILITY
+         SetAccessible(safenew WindowAccessible(this));
+#endif        
+      }
 
       void UpdateValue(Steinberg::Vst::IEditController& editController) override
       {
          SetValue(editController.getParamNormalized(GetParameterId()) / Step);
+         UpdateAccessible(editController);         
+      }
+
+      void UpdateAccessible(Steinberg::Vst::IEditController& editController) override
+      {
+         Steinberg::Vst::String128 str{};
+         editController.getParamStringByValue(GetParameterId(), editController.getParamNormalized(GetParameterId()), str);
+         SetName(wxString::Format("%s %s %s", mTitle, str, mUnits));
       }
 
       Steinberg::Vst::ParamValue GetNormalizedValue(Steinberg::Vst::IEditController&) const override
@@ -132,24 +157,44 @@ namespace
 
    class VST3DiscreteParameter final : public wxSlider, public VST3ParameterControl
    {
+      const wxString mTitle;
+      const wxString mUnits;
+
    public:
       VST3DiscreteParameter(wxWindow *parent,
              wxWindowID id,
              Steinberg::Vst::ParamID paramId,
              int maxValue,
+             const wxString& title,
+             const wxString& units,
              const wxPoint& pos = wxDefaultPosition,
              const wxSize& size = wxDefaultSize,
              long style = wxSL_HORIZONTAL,
              const wxValidator& validator = wxDefaultValidator,
              const wxString& name = wxSliderNameStr)
       : wxSlider(parent, id, 0, 0, maxValue, pos, size, style, validator, name)
-      , VST3ParameterControl(paramId) { }
+      , VST3ParameterControl(paramId)
+      , mTitle(title)
+      , mUnits(units)
+      {
+#if wxUSE_ACCESSIBILITY
+         SetAccessible(safenew WindowAccessible(this));
+#endif        
+      }
 
       void UpdateValue(Steinberg::Vst::IEditController& editController) override
       {
          const auto paramId = GetParameterId();
          const auto value = editController.getParamNormalized(paramId);
          SetValue(editController.normalizedParamToPlain(paramId, value));
+         UpdateAccessible(editController);
+      }
+
+      void UpdateAccessible(Steinberg::Vst::IEditController& editController) override
+      {
+         Steinberg::Vst::String128 str{};
+         editController.getParamStringByValue(GetParameterId(), editController.getParamNormalized(GetParameterId()), str);
+         SetName(wxString::Format("%s %s %s", mTitle, str, mUnits));
       }
 
       Steinberg::Vst::ParamValue GetNormalizedValue(Steinberg::Vst::IEditController& editController) const override
@@ -274,7 +319,8 @@ VST3ParametersWindow::VST3ParametersWindow(wxWindow *parent,
          //continuous
          if(parameterInfo.stepCount == 0)
          {
-            auto slider = safenew VST3ContinuousParameter(this, wxID_ANY, parameterInfo.id);
+            auto slider = safenew VST3ContinuousParameter(this, wxID_ANY, parameterInfo.id,
+               VST3Utils::ToWxString(parameterInfo.title), VST3Utils::ToWxString(parameterInfo.units));
             slider->UpdateValue(editController);
             sizer->Add(slider, 0, wxEXPAND);
             slider->Bind(wxEVT_SLIDER, &VST3ParametersWindow::OnParameterValueChanged, this);
@@ -284,7 +330,8 @@ VST3ParametersWindow::VST3ParametersWindow(wxWindow *parent,
          //discrete
          else
          {
-            auto slider = safenew VST3DiscreteParameter(this, wxID_ANY, parameterInfo.id, parameterInfo.stepCount);
+            auto slider = safenew VST3DiscreteParameter(this, wxID_ANY, parameterInfo.id, parameterInfo.stepCount,
+               VST3Utils::ToWxString(parameterInfo.title), VST3Utils::ToWxString(parameterInfo.units));
             slider->UpdateValue(editController);
             sizer->Add(slider, 0, wxEXPAND);
             slider->Bind(wxEVT_SLIDER, &VST3ParametersWindow::OnParameterValueChanged, this);
@@ -339,8 +386,10 @@ void VST3ParametersWindow::OnParameterValueChanged(const wxCommandEvent& evt)
          mComponentHandler->performEdit(paramId, normalizedValue);
       }
       auto it = mLabels.find(paramId);
-      if(it != mLabels.end())
+      if (it != mLabels.end()) {
          it->second->UpdateValue(*mEditController);
+         control->UpdateAccessible(*mEditController);
+      }
    }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/3039

Screen readers do not automatically read the the actual values of sliders which is shown in the text to the right of each slider.

Fix:
Set the accessibility name of the slider to be the name of the control followed by the actual value of the slider. This is the same as was done for the vst plain gui.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
