### PR TITLE
Updated layout of the structures used in Audacity waveform painting code

### DIFF
--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -42,21 +42,30 @@ using WaveClipHolder = std::shared_ptr< WaveClip >;
 using WaveClipHolders = std::vector < WaveClipHolder >;
 using WaveClipConstHolders = std::vector < std::shared_ptr< const WaveClip > >;
 
+
+// Data for sample blocks related to the column
+struct WaveDisplayColumn final
+{
+   float min;
+   float max;
+   float rms;
+};
 // A bundle of arrays needed for drawing waveforms.  The object may or may not
 // own the storage for those arrays.  If it does, it destroys them.
 class WaveDisplay
 {
 public:
-   int width;
-   sampleCount *where;
-   float *min, *max, *rms;
-
+   int width { 0 };
+   WaveDisplayColumn* columns { nullptr };
+   sampleCount* where { nullptr };
+   // Index of the first sample in the sequence (not in a block!)
    std::vector<sampleCount> ownWhere;
-   std::vector<float> ownMin, ownMax, ownRms;
+   std::vector<WaveDisplayColumn> ownColums;
+
 
 public:
    WaveDisplay(int w)
-      : width(w), where(0), min(0), max(0), rms(0)
+      : width(w)
    {
    }
 
@@ -64,19 +73,12 @@ public:
    void Allocate()
    {
       ownWhere.resize(width + 1);
-      ownMin.resize(width);
-      ownMax.resize(width);
-      ownRms.resize(width);
+      ownColums.resize(width);
 
-      where = &ownWhere[0];
-      if (width > 0) {
-         min = &ownMin[0];
-         max = &ownMax[0];
-         rms = &ownRms[0];
-      }
-      else {
-         min = max = rms = 0;
-      }
+      where = ownWhere.data();
+
+      if (width > 0)
+         columns = ownColums.data();
    }
 
    ~WaveDisplay()

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -19,6 +19,8 @@
 #include "XMLTagHandler.h"
 #include "SampleCount.h"
 
+#include "tracks/playabletrack/wavetrack/ui/WaveClipUtilities.h"
+
 #include <wx/longlong.h>
 
 #include <vector>
@@ -57,12 +59,10 @@ class WaveDisplay
 public:
    int width { 0 };
    WaveDisplayColumn* columns { nullptr };
-   sampleCount* where { nullptr };
-   // Index of the first sample in the sequence (not in a block!)
-   std::vector<sampleCount> ownWhere;
+   PixelSampleMapper mapper;
+
+private:
    std::vector<WaveDisplayColumn> ownColums;
-
-
 public:
    WaveDisplay(int w)
       : width(w)
@@ -72,10 +72,7 @@ public:
    // Create "own" arrays.
    void Allocate()
    {
-      ownWhere.resize(width + 1);
       ownColums.resize(width);
-
-      where = ownWhere.data();
 
       if (width > 0)
          columns = ownColums.data();

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -50,15 +50,13 @@ public:
    int width;
    sampleCount *where;
    float *min, *max, *rms;
-   int* bl;
 
    std::vector<sampleCount> ownWhere;
    std::vector<float> ownMin, ownMax, ownRms;
-   std::vector<int> ownBl;
 
 public:
    WaveDisplay(int w)
-      : width(w), where(0), min(0), max(0), rms(0), bl(0)
+      : width(w), where(0), min(0), max(0), rms(0)
    {
    }
 
@@ -69,18 +67,15 @@ public:
       ownMin.resize(width);
       ownMax.resize(width);
       ownRms.resize(width);
-      ownBl.resize(width);
 
       where = &ownWhere[0];
       if (width > 0) {
          min = &ownMin[0];
          max = &ownMax[0];
          rms = &ownRms[0];
-         bl = &ownBl[0];
       }
       else {
          min = max = rms = 0;
-         bl = 0;
       }
    }
 

--- a/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.cpp
@@ -62,7 +62,7 @@ struct MinMaxSumsq
 }
 
 bool GetWaveDisplay(const Sequence &sequence,
-   float *min, float *max, float *rms, int* bl,
+   float *min, float *max, float *rms,
    size_t len, const sampleCount *where)
 {
    wxASSERT(len > 0);
@@ -141,8 +141,6 @@ bool GetWaveDisplay(const Sequence &sequence,
          : (samplesPerPixel >= 256) ? 256
          : 1;
 
-      int blockStatus = b;
-
       // How many samples or triples are needed?
 
       const size_t startPosition =
@@ -159,7 +157,6 @@ bool GetWaveDisplay(const Sequence &sequence,
          // Do some defense against this case anyway
          while (pixel < nextPixel) {
             min[pixel] = max[pixel] = rms[pixel] = 0;
-            bl[pixel] = blockStatus;//MC
             ++pixel;
          }
          continue;
@@ -243,7 +240,6 @@ bool GetWaveDisplay(const Sequence &sequence,
          // Assign results
          std::fill(&min[pixel], &min[pixelX], values.min);
          std::fill(&max[pixel], &max[pixelX], values.max);
-         std::fill(&bl[pixel], &bl[pixelX], blockStatus);
          std::fill(&rms[pixel], &rms[pixelX], (float)sqrt(values.sumsq / rmsDenom));
 
          pixel = pixelX;

--- a/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.cpp
@@ -63,10 +63,10 @@ struct MinMaxSumsq
 }
 
 bool GetWaveDisplay(
-   const Sequence& sequence, const sampleCount* where, WaveDisplayColumn* columns, size_t len)
+   const Sequence& sequence, const PixelSampleMapper& mapper, WaveDisplayColumn* columns, size_t len)
 {
    wxASSERT(len > 0);
-   const auto s0 = std::max(sampleCount(0), where[0]);
+   const auto s0 = std::max(sampleCount(0), mapper.GetFirstSample(0));
    const auto numSamples = sequence.GetNumSamples();
    if (s0 >= numSamples)
       // None of the samples asked for are in range. Abandon.
@@ -75,7 +75,7 @@ bool GetWaveDisplay(
    // In case where[len - 1] == where[len], raise the limit by one,
    // so we load at least one pixel for column len - 1
    // ... unless the mNumSamples ceiling applies, and then there are other defenses
-   const auto s1 = std::clamp(where[len], 1 + where[len - 1], numSamples);
+   const auto s1 = std::clamp(mapper.GetFirstSample(len), 1 + mapper.GetFirstSample(len - 1), numSamples);
    const auto maxSamples = sequence.GetMaxBlockSize();
    Floats temp{ maxSamples };
 
@@ -85,7 +85,7 @@ bool GetWaveDisplay(
    decltype(srcX) nextSrcX = 0;
    int lastRmsDenom = 0;
    int lastDivisor = 0;
-   auto whereNow = std::min(s1 - 1, where[0]);
+   auto whereNow = std::min(s1 - 1, mapper.GetFirstSample(0));
    decltype(whereNow) whereNext = 0;
    // Loop over block files, opening and reading and closing each
    // not more than once
@@ -118,7 +118,7 @@ bool GetWaveDisplay(
          // Taking min with s1 - 1, here and elsewhere, is another defense
          // to be sure the last pixel column gets at least one sample
          while (nextPixel < len &&
-                (whereNext = std::min(s1 - 1, where[nextPixel])) < nextSrcX)
+                (whereNext = std::min(s1 - 1, mapper.GetFirstSample(nextPixel))) < nextSrcX)
             ++nextPixel;
       }
       if (nextPixel == pixel)
@@ -229,7 +229,7 @@ bool GetWaveDisplay(
             filePosition ==
                (positionX = (
                   // s1 - 1 or where[pixelX] and start are in the same block
-                  (std::min(s1 - 1, where[pixelX]) - start) / divisor).as_size_t() )
+                  (std::min(s1 - 1, mapper.GetFirstSample(pixelX)) - start) / divisor).as_size_t() )
          )
             ++pixelX;
          if (pixelX >= nextPixel)

--- a/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.h
+++ b/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.h
@@ -13,6 +13,7 @@
 
 #include <cstddef>
 class Sequence;
+struct WaveDisplayColumn;
 class sampleCount;
 
 // where is input, assumed to be nondecreasing, and its size is len + 1.
@@ -20,10 +21,9 @@ class sampleCount;
 // Each position in the output arrays corresponds to one column of pixels.
 // The column for pixel p covers samples from
 // where[p] up to (but excluding) where[p + 1].
-// bl is negative wherever data are not yet available.
 // Return true if successful.
-bool GetWaveDisplay(const Sequence &sequence,
-   float *min, float *max, float *rms,
-   size_t len, const sampleCount *where);
+bool GetWaveDisplay(
+   const Sequence& sequence, const sampleCount* where,
+   WaveDisplayColumn* columns, size_t len);
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.h
+++ b/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.h
@@ -16,14 +16,14 @@ class Sequence;
 class sampleCount;
 
 // where is input, assumed to be nondecreasing, and its size is len + 1.
-// min, max, rms, bl are outputs, and their lengths are len.
+// min, max, rms are outputs, and their lengths are len.
 // Each position in the output arrays corresponds to one column of pixels.
 // The column for pixel p covers samples from
 // where[p] up to (but excluding) where[p + 1].
 // bl is negative wherever data are not yet available.
 // Return true if successful.
 bool GetWaveDisplay(const Sequence &sequence,
-   float *min, float *max, float *rms, int* bl,
+   float *min, float *max, float *rms,
    size_t len, const sampleCount *where);
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.h
+++ b/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.h
@@ -14,7 +14,7 @@
 #include <cstddef>
 class Sequence;
 struct WaveDisplayColumn;
-class sampleCount;
+class PixelSampleMapper;
 
 // where is input, assumed to be nondecreasing, and its size is len + 1.
 // min, max, rms are outputs, and their lengths are len.
@@ -23,7 +23,7 @@ class sampleCount;
 // where[p] up to (but excluding) where[p + 1].
 // Return true if successful.
 bool GetWaveDisplay(
-   const Sequence& sequence, const sampleCount* where,
+   const Sequence& sequence, const PixelSampleMapper& mapper,
    WaveDisplayColumn* columns, size_t len);
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.cpp
@@ -11,8 +11,11 @@
 #include "WaveClipUtilities.h"
 
 #include <cmath>
+#include <cassert>
+
 #include <wx/debug.h>
 #include "SampleCount.h"
+#include "MemoryX.h"
 
 void findCorrection(const std::vector<sampleCount> &oldWhere, size_t oldLen,
    size_t newLen, double t0, double rate, double samplesPerPixel,
@@ -63,6 +66,122 @@ void fillWhere(
    // Be careful to make the first value non-negative
    const double w0 = 0.5 + correction + bias + t0 * rate;
    where[0] = sampleCount( std::max(0.0, floor(w0)) );
+   // DV: Note, that the loop below potentially makes where to be non monotonic
    for (decltype(len) x = 1; x < len + 1; x++)
       where[x] = sampleCount( floor(w0 + double(x) * samplesPerPixel) );
+}
+
+PixelSampleMapper::PixelSampleMapper(
+   double t0, double rate, double samplesPerPixel) noexcept
+    : mMapper(LinearMapper { (0.5 + t0 * rate), samplesPerPixel })
+{
+   assert((0.5 + t0 * rate) >= 0.0);
+}
+
+void PixelSampleMapper::applyBias(double bias) noexcept
+{
+   if (mMapper.index() == 0)
+      std::get_if<0>(&mMapper)->mInitialValue += bias;
+}
+
+double PixelSampleMapper::applyCorrection(
+   const PixelSampleMapper& oldMapper, size_t oldLen, size_t newLen)
+{
+   assert(mMapper.index() == 0);
+   assert(oldMapper.mMapper.index() == 0);
+
+   LinearMapper* currentMapper = std::get_if<LinearMapper>(&mMapper);
+
+   if (currentMapper == nullptr)
+      return {};
+
+   const LinearMapper* oldLinearMapper =
+      std::get_if<LinearMapper>(&oldMapper.mMapper);
+
+   if (oldLinearMapper == nullptr)
+      return {};
+
+   // Find the sample position that is the origin in the old cache.
+   const double oldWhere0 =
+      (*oldLinearMapper)(1).as_double() - currentMapper->mSamplesPerPixel;
+   const double oldWhereLast =
+      oldWhere0 + oldLen * currentMapper->mSamplesPerPixel;
+   // Find the length in samples of the old cache.
+   const double denom = oldWhereLast - oldWhere0;
+
+   // What sample would go in where[0] with no correction?
+   const double guessWhere0 =
+      currentMapper->mInitialValue - 0.5; // Why do we ignore initial bias?
+
+   if ( // Skip if old and NEW are disjoint:
+      oldWhereLast <= guessWhere0 ||
+      guessWhere0 + newLen * currentMapper->mSamplesPerPixel <= oldWhere0 ||
+      // Skip unless denom rounds off to at least 1.
+      denom < 0.5)
+   {
+      // The computation of oldX0 in the other branch
+      // may underflow and the assertion would be violated.
+      return oldLen;
+   }
+   else
+   {
+      // What integer position in the old cache array does that map to?
+      // (even if it is out of bounds)
+      const auto oldX0 = std::floor(0.5 + oldLen * (guessWhere0 - oldWhere0) / denom);
+      // What sample count would the old cache have put there?
+      const double where0 =
+         oldWhere0 + double(oldX0) * currentMapper->mSamplesPerPixel;
+      // What correction is needed to align the NEW cache with the old?
+      const double correction0 = where0 - guessWhere0;
+      const double correction = std::max(
+         -currentMapper->mSamplesPerPixel,
+         std::min(currentMapper->mSamplesPerPixel, correction0));
+
+      wxASSERT(correction == correction0);
+
+      currentMapper->mInitialValue += correction;
+
+      return oldX0;
+   }
+}
+
+sampleCount PixelSampleMapper::GetFirstSample(uint32_t column) const
+{
+   return Visit([column](const auto& mapper) {
+      return mapper(column);
+   }, mMapper);
+}
+
+sampleCount PixelSampleMapper::GetLastSample(uint32_t column) const
+{
+   return GetFirstSample(column + 1);
+}
+
+std::pair<sampleCount, sampleCount>
+PixelSampleMapper::GetSampleRange(uint32_t column) const
+{
+   return { GetFirstSample(column), GetLastSample(column) };
+}
+
+void PixelSampleMapper::setCustomMapper(CustomMapper mapper)
+{
+   mMapper = std::move(mapper);
+}
+
+bool PixelSampleMapper::IsValid() const
+{
+   return Visit([](const auto& mapper) { return !!mapper; }, mMapper);
+}
+
+sampleCount PixelSampleMapper::LinearMapper::operator()(uint32_t column) const noexcept
+{
+   // Previous code used floor, but "required" mInitialValue to be positive.
+   // For positive values, let's just trunc the value, as it is at least twice
+   // as fast.
+   return sampleCount(mInitialValue + column * mSamplesPerPixel);
+}
+
+PixelSampleMapper::LinearMapper::operator bool() const noexcept
+{
+   return mSamplesPerPixel > 0.0;
 }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.h
@@ -13,8 +13,67 @@
 
 #include <vector>
 #include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <variant>
 
-class sampleCount;
+// Clang will fail to instantiate a variant if sampleCount is forward declared
+// It tries to instantiate std::invoke_result for some reason
+#include "SampleCount.h"
+
+class PixelSampleMapper final
+{
+public:
+   PixelSampleMapper() = default;
+   PixelSampleMapper(const PixelSampleMapper&) = default;
+   PixelSampleMapper(PixelSampleMapper&&) = default;
+   PixelSampleMapper& operator=(const PixelSampleMapper&) = default;
+   PixelSampleMapper& operator=(PixelSampleMapper&&) = default;
+
+   PixelSampleMapper(double t0, double rate, double samplesPerPixel) noexcept;
+
+   void applyBias(double bias) noexcept;
+
+   double applyCorrection(
+      const PixelSampleMapper& oldMapper, size_t oldLen, size_t newLen);
+
+   sampleCount GetFirstSample(uint32_t column) const;
+   sampleCount GetLastSample(uint32_t column) const;
+   std::pair<sampleCount, sampleCount> GetSampleRange(uint32_t column) const;
+
+   using CustomMapper = std::function<sampleCount(uint32_t)>;
+   void setCustomMapper(CustomMapper mapper);
+
+   bool IsValid() const;
+   bool IsLinear() const noexcept;
+
+private:
+   struct LinearMapper final
+   {
+      // Fixes GCC7 build issues (constructor required before non-static data
+      // member)
+      LinearMapper() noexcept
+      {
+      }
+
+      LinearMapper(double initialValue, double samplesPerPixel) noexcept
+          : mInitialValue(initialValue)
+          , mSamplesPerPixel(samplesPerPixel)
+      {
+      }
+
+      LinearMapper(const LinearMapper&) = default;
+
+      double mInitialValue {};
+      double mSamplesPerPixel {};
+
+      sampleCount operator()(uint32_t column) const noexcept;
+
+      explicit operator bool() const noexcept;
+   };
+   // GCC 9.3.0 fails horribly if you do not initialize variant explicitly here
+   std::variant<LinearMapper, CustomMapper> mMapper { LinearMapper {} };
+};
 
 AUDACITY_DLL_API
 void findCorrection(const std::vector<sampleCount> &oldWhere, size_t oldLen,

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -26,7 +26,6 @@ public:
       , min(0)
       , max(0)
       , rms(0)
-      , bl(0)
    {
    }
 
@@ -40,7 +39,6 @@ public:
       , min(len)
       , max(len)
       , rms(len)
-      , bl(len)
    {
    }
 
@@ -57,7 +55,6 @@ public:
    std::vector<float> min;
    std::vector<float> max;
    std::vector<float> rms;
-   std::vector<int> bl;
 };
 
 //
@@ -81,7 +78,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
    float *min;
    float *max;
    float *rms;
-   int *bl;
    std::vector<sampleCount> *pWhere;
 
    if (allocated) {
@@ -89,7 +85,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       min = &display.min[0];
       max = &display.max[0];
       rms = &display.rms[0];
-      bl = &display.bl[0];
       pWhere = &display.ownWhere;
    }
    else {
@@ -117,7 +112,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          display.min = &mWaveCache->min[0];
          display.max = &mWaveCache->max[0];
          display.rms = &mWaveCache->rms[0];
-         display.bl = &mWaveCache->bl[0];
          display.where = &mWaveCache->where[0];
          return true;
       }
@@ -146,7 +140,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       min = &mWaveCache->min[0];
       max = &mWaveCache->max[0];
       rms = &mWaveCache->rms[0];
-      bl = &mWaveCache->bl[0];
       pWhere = &mWaveCache->where;
 
       fillWhere(*pWhere, numPixels, 0.0, correction,
@@ -169,7 +162,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          memcpy(&min[copyBegin], &oldCache->min[srcIdx], sizeFloats);
          memcpy(&max[copyBegin], &oldCache->max[srcIdx], sizeFloats);
          memcpy(&rms[copyBegin], &oldCache->rms[srcIdx], sizeFloats);
-         memcpy(&bl[copyBegin], &oldCache->bl[srcIdx], length * sizeof(int));
       }
    }
 
@@ -239,7 +231,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
                min[i] = theMin;
                max[i] = theMax;
                rms[i] = (float)sqrt(sumsq / len);
-               bl[i] = 1; //for now just fake it.
 
                didUpdate=true;
             }
@@ -256,7 +247,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          if (!::GetWaveDisplay(*sequence, &min[p0],
                                         &max[p0],
                                         &rms[p0],
-                                        &bl[p0],
                                         p1-p0,
                                         &where[p0]))
          {
@@ -270,7 +260,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       display.min = min;
       display.max = max;
       display.rms = rms;
-      display.bl = bl;
       display.where = &(*pWhere)[0];
    }
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -27,7 +27,7 @@ public:
       , start(t0)
       , pps(pixelsPerSecond)
       , rate(rate_)
-      , where(1 + len)
+      , mapper(t0, rate, rate / pps)
       , columns(len)
    {
    }
@@ -42,7 +42,7 @@ public:
    const double pps { -0.0 };
    const int rate { -1 };
 
-   std::vector<sampleCount> where;
+   PixelSampleMapper mapper;
    std::vector<WaveDisplayColumn> columns;
 };
 
@@ -57,7 +57,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 {
    t0 += clip.GetTrimLeft();
 
-   const bool allocated = (display.where != nullptr);
+   const bool allocated = display.mapper.IsValid();
 
    const size_t numPixels = (int)display.width;
 
@@ -65,12 +65,12 @@ bool WaveClipWaveformCache::GetWaveDisplay(
    size_t p1 = numPixels; // greatest column requiring computation, plus one
 
    WaveDisplayColumn* columns = nullptr;
-   sampleCount* where = nullptr;
+   PixelSampleMapper* mapper = nullptr;
 
    if (allocated) {
       // assume ownWhere is filled.
       columns = display.columns;
-      where = display.where;
+      mapper = &display.mapper;
    }
    else {
       const double tstep = 1.0 / pixelsPerSecond;
@@ -95,18 +95,23 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 
          // Satisfy the request completely from the cache
          display.columns = mWaveCache->columns.data();
+         display.mapper = mWaveCache->mapper;
+
          return true;
       }
 
       std::unique_ptr<WaveCache> oldCache(std::move(mWaveCache));
 
+      mWaveCache = std::make_unique<WaveCache>(
+         numPixels, pixelsPerSecond, rate, t0, mDirty);
+
       int oldX0 = 0;
       double correction = 0.0;
       size_t copyBegin = 0, copyEnd = 0;
       if (match) {
-         findCorrection(oldCache->where, oldCache->len, numPixels,
-            t0, rate, samplesPerPixel,
-            oldX0, correction);
+         oldX0 = mWaveCache->mapper.applyCorrection(
+            oldCache->mapper, oldCache->len, numPixels);
+
          // Remember our first pixel maps to oldX0 in the old cache,
          // possibly out of bounds.
          // For what range of pixels can data be copied?
@@ -115,16 +120,12 @@ bool WaveClipWaveformCache::GetWaveDisplay(
             (int)oldCache->len - oldX0
          ));
       }
+
       if (!(copyEnd > copyBegin))
          oldCache.reset(0);
 
-      mWaveCache = std::make_unique<WaveCache>(numPixels, pixelsPerSecond, rate, t0, mDirty);
       columns = mWaveCache->columns.data();
-      where = mWaveCache->where.data();
-
-      fillWhere(
-         mWaveCache->where, numPixels, 0.0, correction,
-         t0, rate, samplesPerPixel);
+      mapper = &mWaveCache->mapper;
 
       // The range of pixels we must fetch from the Sequence:
       p0 = (copyBegin > 0) ? 0 : copyEnd;
@@ -156,7 +157,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       // Not all of the required columns might be in the sequence.
       // Some might be in the append buffer.
       for (; a < p1; ++a) {
-         if (where[a + 1] > numSamples)
+         if (mapper->GetFirstSample(a + 1) > numSamples)
             break;
       }
 
@@ -168,9 +169,9 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          sampleFormat seqFormat = sequence->GetSampleFormat();
          bool didUpdate = false;
          for(auto i = a; i < p1; i++) {
-            auto left = std::max(sampleCount { 0 }, where[i] - numSamples);
+            auto left = std::max(sampleCount { 0 }, mapper->GetFirstSample(i) - numSamples);
             auto right = std::min(
-               sampleCount { appendBufferLen }, where[i + 1] - numSamples);
+               sampleCount { appendBufferLen }, mapper->GetFirstSample(i + 1) - numSamples);
 
             //wxCriticalSectionLocker locker(mAppendCriticalSection);
 
@@ -222,7 +223,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       // Done with append buffer, now fetch the rest of the cache miss
       // from the sequence
       if (p1 > p0) {
-         if (!::GetWaveDisplay(*sequence, &where[p0], &columns[p0], p1 - p0))
+         if (!::GetWaveDisplay(*sequence, *mapper, &columns[p0], p1 - p0))
          {
             return false;
          }
@@ -231,7 +232,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 
    if (!allocated) {
       // Now report the results
-      display.where = where;
+      display.mapper = *mapper;
       display.columns = columns;
    }
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -11,23 +11,15 @@
 #include "WaveformCache.h"
 
 #include <cmath>
+#include <cstring>
+
 #include "Sequence.h"
 #include "GetWaveDisplay.h"
 #include "WaveClipUtilities.h"
 
 class WaveCache {
 public:
-   WaveCache()
-      : dirty(-1)
-      , start(-1)
-      , pps(0)
-      , rate(-1)
-      , where(0)
-      , min(0)
-      , max(0)
-      , rms(0)
-   {
-   }
+   WaveCache() = default;
 
    WaveCache(size_t len_, double pixelsPerSecond, double rate_, double t0, int dirty_)
       : dirty(dirty_)
@@ -36,9 +28,7 @@ public:
       , pps(pixelsPerSecond)
       , rate(rate_)
       , where(1 + len)
-      , min(len)
-      , max(len)
-      , rms(len)
+      , columns(len)
    {
    }
 
@@ -46,15 +36,14 @@ public:
    {
    }
 
-   int          dirty;
+   int dirty { -1 };
    const size_t len { 0 }; // counts pixels, not samples
-   const double start;
-   const double pps;
-   const int    rate;
+   const double start { -1.0 };
+   const double pps { -0.0 };
+   const int rate { -1 };
+
    std::vector<sampleCount> where;
-   std::vector<float> min;
-   std::vector<float> max;
-   std::vector<float> rms;
+   std::vector<WaveDisplayColumn> columns;
 };
 
 //
@@ -68,24 +57,20 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 {
    t0 += clip.GetTrimLeft();
 
-   const bool allocated = (display.where != 0);
+   const bool allocated = (display.where != nullptr);
 
    const size_t numPixels = (int)display.width;
 
    size_t p0 = 0;         // least column requiring computation
    size_t p1 = numPixels; // greatest column requiring computation, plus one
 
-   float *min;
-   float *max;
-   float *rms;
-   std::vector<sampleCount> *pWhere;
+   WaveDisplayColumn* columns = nullptr;
+   sampleCount* where = nullptr;
 
    if (allocated) {
       // assume ownWhere is filled.
-      min = &display.min[0];
-      max = &display.max[0];
-      rms = &display.rms[0];
-      pWhere = &display.ownWhere;
+      columns = display.columns;
+      where = display.where;
    }
    else {
       const double tstep = 1.0 / pixelsPerSecond;
@@ -109,10 +94,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          mWaveCache->len >= numPixels) {
 
          // Satisfy the request completely from the cache
-         display.min = &mWaveCache->min[0];
-         display.max = &mWaveCache->max[0];
-         display.rms = &mWaveCache->rms[0];
-         display.where = &mWaveCache->where[0];
+         display.columns = mWaveCache->columns.data();
          return true;
       }
 
@@ -137,12 +119,11 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          oldCache.reset(0);
 
       mWaveCache = std::make_unique<WaveCache>(numPixels, pixelsPerSecond, rate, t0, mDirty);
-      min = &mWaveCache->min[0];
-      max = &mWaveCache->max[0];
-      rms = &mWaveCache->rms[0];
-      pWhere = &mWaveCache->where;
+      columns = mWaveCache->columns.data();
+      where = mWaveCache->where.data();
 
-      fillWhere(*pWhere, numPixels, 0.0, correction,
+      fillWhere(
+         mWaveCache->where, numPixels, 0.0, correction,
          t0, rate, samplesPerPixel);
 
       // The range of pixels we must fetch from the Sequence:
@@ -157,18 +138,15 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 
          // Copy what we can from the old cache.
          const int length = copyEnd - copyBegin;
-         const size_t sizeFloats = length * sizeof(float);
+         const size_t sizeFloats = length * sizeof(WaveDisplayColumn);
          const int srcIdx = (int)copyBegin + oldX0;
-         memcpy(&min[copyBegin], &oldCache->min[srcIdx], sizeFloats);
-         memcpy(&max[copyBegin], &oldCache->max[srcIdx], sizeFloats);
-         memcpy(&rms[copyBegin], &oldCache->rms[srcIdx], sizeFloats);
+
+         std::memcpy(&columns[copyBegin], &oldCache->columns[srcIdx], sizeFloats);
       }
    }
 
    if (p1 > p0) {
       // Cache was not used or did not satisfy the whole request
-      std::vector<sampleCount> &where = *pWhere;
-
       /* handle values in the append buffer */
 
       const auto sequence = clip.GetSequence();
@@ -190,10 +168,9 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          sampleFormat seqFormat = sequence->GetSampleFormat();
          bool didUpdate = false;
          for(auto i = a; i < p1; i++) {
-            auto left = std::max(sampleCount{ 0 },
-                                 where[i] - numSamples);
-            auto right = std::min(sampleCount{ appendBufferLen },
-                                  where[i + 1] - numSamples);
+            auto left = std::max(sampleCount { 0 }, where[i] - numSamples);
+            auto right = std::min(
+               sampleCount { appendBufferLen }, where[i + 1] - numSamples);
 
             //wxCriticalSectionLocker locker(mAppendCriticalSection);
 
@@ -215,12 +192,15 @@ bool WaveClipWaveformCache::GetWaveDisplay(
                      seqFormat, b.get(), len);
                }
 
-               float theMax, theMin, sumsq;
+               float theMax, theMin;
+               double sumsq;
+               
                {
                   const float val = pb[0];
                   theMax = theMin = val;
                   sumsq = val * val;
                }
+
                for(decltype(len) j = 1; j < len; j++) {
                   const float val = pb[j];
                   theMax = std::max(theMax, val);
@@ -228,9 +208,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
                   sumsq += val * val;
                }
 
-               min[i] = theMin;
-               max[i] = theMax;
-               rms[i] = (float)sqrt(sumsq / len);
+               columns[i] = { theMin, theMax, static_cast<float>(sqrt(sumsq / len)) };
 
                didUpdate=true;
             }
@@ -244,11 +222,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       // Done with append buffer, now fetch the rest of the cache miss
       // from the sequence
       if (p1 > p0) {
-         if (!::GetWaveDisplay(*sequence, &min[p0],
-                                        &max[p0],
-                                        &rms[p0],
-                                        p1-p0,
-                                        &where[p0]))
+         if (!::GetWaveDisplay(*sequence, &where[p0], &columns[p0], p1 - p0))
          {
             return false;
          }
@@ -257,10 +231,8 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 
    if (!allocated) {
       // Now report the results
-      display.min = min;
-      display.max = max;
-      display.rms = rms;
-      display.where = &(*pWhere)[0];
+      display.where = where;
+      display.columns = columns;
    }
 
    return true;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -787,7 +787,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
             for (; jj < rectPortion.width; ++jj) {
                const double time =
                   zoomInfo.PositionToTime(jj, -leftOffset) - tOffset;
-               const auto sample = (sampleCount)floor(time * rate + 0.5);
+               const auto sample = sampleCount(time * rate + 0.5);
                if (sample < 0) {
                   ++rectPortion.x;
                   ++skippedLeft;
@@ -795,17 +795,19 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
                }
                if (sample >= numSamples)
                   break;
-               fisheyeDisplay.where[jj - skippedLeft] = sample;
             }
+
+            fisheyeDisplay.mapper.setCustomMapper(
+               [artist, leftOffset, tOffset, rate](uint32_t colum) {
+                  const double time =
+                     artist->pZoomInfo->PositionToTime(colum, -leftOffset) - tOffset;
+                  return sampleCount(time * rate + 0.5);
+               });
 
             skippedRight = rectPortion.width - jj;
             skipped = skippedRight + skippedLeft;
             rectPortion.width -= skipped;
 
-            // where needs a sentinel
-            if (jj > 0)
-               fisheyeDisplay.where[jj - skippedLeft] =
-                  1 + fisheyeDisplay.where[jj - skippedLeft - 1];
             fisheyeDisplay.width -= skipped;
             // Get a wave display for the fisheye, uncached.
             if (rectPortion.width > 0)

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -327,11 +327,9 @@ void FindWavePortions
 }
 
 void DrawMinMaxRMS(
-   TrackPanelDrawingContext &context, const wxRect & rect, const double env[],
-   float zoomMin, float zoomMax,
-   bool dB, float dBRange,
-   const float *min, const float *max, const float *rms,
-   bool muted)
+   TrackPanelDrawingContext& context, const wxRect& rect, const double env[],
+   float zoomMin, float zoomMax, bool dB, float dBRange,
+   const WaveDisplayColumn* columns, bool muted)
 {
    auto &dc = context.dc;
 
@@ -359,7 +357,7 @@ void DrawMinMaxRMS(
    for (int x0 = 0; x0 < rect.width; ++x0) {
       int xx = rect.x + x0;
       double v;
-      v = min[x0] * env[x0];
+      v = columns[x0].min * env[x0];
       if (clipped && bShowClipping && (v <= -MAX_AUDIO))
       {
          if (clipcnt == 0 || clipped[clipcnt - 1] != xx) {
@@ -369,7 +367,7 @@ void DrawMinMaxRMS(
       h1 = GetWaveYPos(v, zoomMin, zoomMax,
                        rect.height, dB, true, dBRange, true);
 
-      v = max[x0] * env[x0];
+      v = columns[x0].max * env[x0];
       if (clipped && bShowClipping && (v >= MAX_AUDIO))
       {
          if (clipcnt == 0 || clipped[clipcnt - 1] != xx) {
@@ -392,9 +390,9 @@ void DrawMinMaxRMS(
       lasth1 = h1;
       lasth2 = h2;
 
-      r1[x0] = GetWaveYPos(-rms[x0] * env[x0], zoomMin, zoomMax,
+      r1[x0] = GetWaveYPos(-columns[x0].rms * env[x0], zoomMin, zoomMax,
                           rect.height, dB, true, dBRange, true);
-      r2[x0] = GetWaveYPos(rms[x0] * env[x0], zoomMin, zoomMax,
+      r2[x0] = GetWaveYPos(columns[x0].rms * env[x0], zoomMin, zoomMax,
                           rect.height, dB, true, dBRange, true);
       // Make sure the rms isn't larger than the waveform min/max
       if (r1[x0] > h1 - 1) {
@@ -776,7 +774,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
       rectPortion.Intersect(mid);
       wxASSERT(rectPortion.width >= 0);
 
-      float *useMin = 0, *useMax = 0, *useRms = 0;
+      WaveDisplayColumn* useColumns = nullptr;
 
       WaveDisplay fisheyeDisplay(rectPortion.width);
       int skipped = 0, skippedLeft = 0, skippedRight = 0;
@@ -807,23 +805,19 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
             // where needs a sentinel
             if (jj > 0)
                fisheyeDisplay.where[jj - skippedLeft] =
-               1 + fisheyeDisplay.where[jj - skippedLeft - 1];
+                  1 + fisheyeDisplay.where[jj - skippedLeft - 1];
             fisheyeDisplay.width -= skipped;
             // Get a wave display for the fisheye, uncached.
             if (rectPortion.width > 0)
                if (!clipCache.GetWaveDisplay( *clip,
                      fisheyeDisplay, t0, -1.0)) // ignored
                   continue; // serious error.  just don't draw??
-            useMin = fisheyeDisplay.min;
-            useMax = fisheyeDisplay.max;
-            useRms = fisheyeDisplay.rms;
+            useColumns = fisheyeDisplay.columns;
          }
       }
       else {
          const int pos = leftOffset - params.hiddenLeftOffset;
-         useMin = display.min + pos;
-         useMax = display.max + pos;
-         useRms = display.rms + pos;
+         useColumns = display.columns + pos;
       }
 
       leftOffset += skippedLeft;
@@ -841,10 +835,9 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
 
                  env2, rectPortion.width, leftOffset, zoomInfo );
 
-            DrawMinMaxRMS( context, rectPortion, env2,
-               zoomMin, zoomMax,
-               dB, dBRange,
-               useMin, useMax, useRms, muted );
+            DrawMinMaxRMS(
+               context, rectPortion, env2, zoomMin, zoomMax, dB, dBRange,
+               useColumns, muted);
          }
          else {
             bool highlight = false;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -330,7 +330,7 @@ void DrawMinMaxRMS(
    TrackPanelDrawingContext &context, const wxRect & rect, const double env[],
    float zoomMin, float zoomMax,
    bool dB, float dBRange,
-   const float *min, const float *max, const float *rms, const int *bl,
+   const float *min, const float *max, const float *rms,
    bool muted)
 {
    auto &dc = context.dc;
@@ -351,15 +351,6 @@ void DrawMinMaxRMS(
    if (bShowClipping) {
       clipped.reinit( size_t(rect.width) );
    }
-
-   long pixAnimOffset = (long)fabs((double)(wxDateTime::Now().GetTicks() * -10)) +
-      wxDateTime::Now().GetMillisecond() / 100; //10 pixels a second
-
-   const auto ms = wxDateTime::Now().GetMillisecond();
-   const auto ticks = (long)fabs((double)(wxDateTime::Now().GetTicks() * -10));
-
-   bool drawStripes = true;
-   bool drawWaveform = true;
 
    const auto &muteSamplePen = artist->muteSamplePen;
    const auto &samplePen = artist->samplePen;
@@ -416,39 +407,8 @@ void DrawMinMaxRMS(
          r2[x0] = r1[x0];
       }
 
-      if (bl[x0] <= -1) {
-         if (drawStripes) {
-            // TODO:unify with buffer drawing.
-            dc.SetPen((bl[x0] % 2) ? muteSamplePen : samplePen);
-            for (int yy = 0; yy < rect.height / 25 + 1; ++yy) {
-               // we are drawing over the buffer, but I think DrawLine takes care of this.
-               AColor::Line(dc,
-                            xx,
-                            rect.y + 25 * yy + (x0 /*+pixAnimOffset*/) % 25,
-                            xx,
-                            rect.y + 25 * yy + (x0 /*+pixAnimOffset*/) % 25 + 6); //take the min so we don't draw past the edge
-            }
-         }
 
-         // draw a dummy waveform - some kind of sinusoid.  We want to animate it so the user knows it's a dummy.  Use the second's unit of a get time function.
-         // Lets use a triangle wave for now since it's easier - I don't want to use sin() or make a wavetable just for this.
-         if (drawWaveform) {
-            int triX;
-            dc.SetPen(samplePen);
-            triX = fabs((double)((x0 + pixAnimOffset) % (2 * rect.height)) - rect.height) + rect.height;
-            for (int yy = 0; yy < rect.height; ++yy) {
-               if ((yy + triX) % rect.height == 0) {
-                  dc.DrawPoint(xx, rect.y + yy);
-               }
-            }
-         }
-
-         // Restore the pen for remaining pixel columns!
-         dc.SetPen(muted ? muteSamplePen : samplePen);
-      }
-      else {
-         AColor::Line(dc, xx, rect.y + h2, xx, rect.y + h1);
-      }
+      AColor::Line(dc, xx, rect.y + h2, xx, rect.y + h1);
    }
 
    // Stroke rms over the min-max
@@ -458,9 +418,7 @@ void DrawMinMaxRMS(
    dc.SetPen(muted ? muteRmsPen : rmsPen);
    for (int x0 = 0; x0 < rect.width; ++x0) {
       int xx = rect.x + x0;
-      if (bl[x0] <= -1) {
-      }
-      else if (r1[x0] != r2[x0]) {
+      if (r1[x0] != r2[x0]) {
          AColor::Line(dc, xx, rect.y + r2[x0], xx, rect.y + r1[x0]);
       }
    }
@@ -819,7 +777,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
       wxASSERT(rectPortion.width >= 0);
 
       float *useMin = 0, *useMax = 0, *useRms = 0;
-      int *useBl = 0;
+
       WaveDisplay fisheyeDisplay(rectPortion.width);
       int skipped = 0, skippedLeft = 0, skippedRight = 0;
       if (portion.inFisheye) {
@@ -859,7 +817,6 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
             useMin = fisheyeDisplay.min;
             useMax = fisheyeDisplay.max;
             useRms = fisheyeDisplay.rms;
-            useBl = fisheyeDisplay.bl;
          }
       }
       else {
@@ -867,7 +824,6 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
          useMin = display.min + pos;
          useMax = display.max + pos;
          useRms = display.rms + pos;
-         useBl = display.bl + pos;
       }
 
       leftOffset += skippedLeft;
@@ -888,7 +844,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
             DrawMinMaxRMS( context, rectPortion, env2,
                zoomMin, zoomMax,
                dB, dBRange,
-               useMin, useMax, useRms, useBl, muted );
+               useMin, useMax, useRms, muted );
          }
          else {
             bool highlight = false;


### PR DESCRIPTION
Audacity uses `WaveDisplay` class to organize data required to draw waveforms on screen.

Originally, it was structured as 5 arrays:

* `where` - array of integers, that represent the first sample of each column
* `bl` - block index, which was only used with on-demand rendering (fun fact - the animation code never worked!)
* `min`, `max`, `rms` - extrema and rms values calculated over all samples composing the column

This PR:

* Removes `bl` as on-demand functionality is not present in Audacity 3
* Removes `where` as it can be calculated in constant time
* Converts structure-of-arrays to array-of-structures to improve the cache locality

While it doesn't provide much performance improvement on its own, it lays the fundamentals for the future PRs.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [?] Each commit compiles and runs on my machine without known undesirable changes of behavior
