### PR TITLE
bug 1607 - ensure that NYQ_MAX_LEN is big enough on all supported pla…

### DIFF
--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -109,8 +109,9 @@ enum
    ID_FILE = 15000
 };
 
-// Protect Nyquist from selections greater than 2^31 samples (bug 439)
-#define NYQ_MAX_LEN (std::numeric_limits<long>::max())
+// mMaxLen is still required for some plug-ins even though bug 439 appears
+// to be fixed. This defines its initialised value.
+#define NYQ_MAX_LEN (std::numeric_limits<long long>::max())
 
 #define UNINITIALIZED_CONTROL ((double)99999999.99)
 
@@ -913,20 +914,7 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
             auto end = mCurTrack[0]->TimeToLongSamples(mT1);
             mCurLen = end - mCurStart[0];
 
-            if (mCurLen > NYQ_MAX_LEN) {
-               float hours = (float)NYQ_MAX_LEN / (44100 * 60 * 60);
-               const auto message =
-                  XO(
-"Selection too long for Nyquist code.\nMaximum allowed selection is %ld samples\n(about %.1f hours at 44100 Hz sample rate).")
-                     .Format((long)NYQ_MAX_LEN, hours);
-               Effect::MessageBox(
-                  message,
-                  wxOK | wxCENTRE,
-                  XO("Nyquist Error") );
-               if (!mProjectChanged)
-                  em.SetSkipStateFlag(true);
-               return false;
-            }
+            wxASSERT(mCurLen <= NYQ_MAX_LEN);
 
             mCurLen = std::min(mCurLen, mMaxLen);
          }


### PR DESCRIPTION
bug 1607 - ensure that NYQ_MAX_LEN is big enough on all supported platforms

Resolves: #1607 

*(short description of the changes and the motivation to make the changes)*
Define NYQ_MAX_LEN as LLONG_MAX as this is the same on all supported platforms, whereas LONG_MAX isn't.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
