### PR TITLE
Effect power buttons

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -132,7 +132,7 @@ bool EffectInstance::RealtimeSuspend()
    return true;
 }
 
-bool EffectInstance::RealtimeResume() noexcept
+bool EffectInstance::RealtimeResume()
 {
    return true;
 }

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -410,7 +410,7 @@ public:
     @return success
     Default implementation does nothing, returns true
     */
-   virtual bool RealtimeResume() noexcept;
+   virtual bool RealtimeResume();
 
    //! settings are possibly changed, since last call, by an asynchronous dialog
    /*!

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -86,10 +86,14 @@ public:
    using Counter = unsigned char;
    Counter GetCounter() const { return mCounter; }
    void SetCounter(Counter value) { mCounter = value; }
+
+   bool GetActive() const { return mActive; }
+   void SetActive(bool value) { mActive = value; }
 private:
    NumericFormatSymbol mDurationFormat{};
    double mDuration{}; //!< @invariant non-negative
    Counter mCounter{ 0 };
+   bool mActive{ true };
 };
 
 //! Externalized state of a plug-in

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -728,6 +728,12 @@ public:
       }
    }
 
+   void EnableEffects(bool enable)
+   {
+      if (mTrack)
+         RealtimeEffectList::Get(*mTrack).SetActive(enable);
+   }
+
    void ReloadEffectsList()
    {
       wxWindowUpdateLocker freeze(this);
@@ -804,10 +810,21 @@ RealtimeEffectPanel::RealtimeEffectPanel(wxWindow* parent, wxWindowID id, const 
    {
       auto hSizer = std::make_unique<wxBoxSizer>(wxHORIZONTAL);
       auto toggleEffects = safenew ThemedButtonWrapper<wxBitmapButton>(header, wxID_ANY, wxBitmap{}, wxDefaultPosition, wxDefaultSize, wxNO_BORDER);
-      toggleEffects->SetBitmapIndex(bmpEffectOff);
+      toggleEffects->SetBitmapIndex(bmpEffectOn);
       toggleEffects->SetBackgroundColorIndex(clrMedium);
       mToggleEffects = toggleEffects;
 
+      toggleEffects->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+         auto pButton =
+            static_cast<ThemedButtonWrapper<wxBitmapButton>*>(mToggleEffects);
+         auto index = pButton->GetBitmapIndex();
+         bool wasEnabled = (index == bmpEffectOn);
+         if (mEffectList) {
+            mEffectList->EnableEffects(!wasEnabled);
+         }
+         pButton->SetBitmapIndex(wasEnabled ? bmpEffectOff : bmpEffectOn);
+      });
+   
       hSizer->Add(toggleEffects, 0, wxSTRETCH_NOT | wxALIGN_CENTER | wxLEFT, 5);
       {
          auto vSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);

--- a/src/ThemedWrappers.h
+++ b/src/ThemedWrappers.h
@@ -100,6 +100,11 @@ public:
          theTheme.Subscribe(*this, &ThemedButtonWrapper::OnThemeChange);
    }
 
+   int GetBitmapIndex() const
+   {
+      return mBitmapIndex;
+   }
+
    void SetBitmapIndex(int index)
    {
       mBitmapIndex = index;

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -176,10 +176,19 @@ const std::string &RealtimeEffectList::XMLTag()
    return result;
 }
 
+static constexpr auto activeAttribute = "active";
+
 bool RealtimeEffectList::HandleXMLTag(
-   const std::string_view &tag, const AttributesList &)
+   const std::string_view &tag, const AttributesList &attrs)
 {
-   return (tag == XMLTag());
+   if (tag == XMLTag()) {
+      for (auto &[attr, value] : attrs) {
+         if (attr == activeAttribute)
+            SetActive(value.Get<bool>());
+      }
+      return true;
+   }
+   return false;
 }
 
 XMLTagHandler *RealtimeEffectList::HandleXMLChild(const std::string_view &tag)
@@ -197,6 +206,7 @@ void RealtimeEffectList::WriteXML(XMLWriter &xmlFile) const
       return;
 
    xmlFile.StartTag(XMLTag());
+   xmlFile.WriteAttr(activeAttribute, IsActive());
 
    for (const auto & state : mStates)
       state->WriteXML(xmlFile);

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -79,7 +79,7 @@ const RealtimeEffectList &RealtimeEffectList::Get(const Track &track)
 void RealtimeEffectList::Visit(StateVisitor func)
 {
    for (auto &state : mStates)
-      func(*state, !state->IsActive());
+      func(*state, IsActive());
 }
 
 bool
@@ -208,6 +208,16 @@ void RealtimeEffectList::RestoreUndoRedoState(AudacityProject &project) noexcept
 {
    // Restore per-project states
    Set(project, shared_from_this());
+}
+
+bool RealtimeEffectList::IsActive() const
+{
+   return mActive.load(std::memory_order_relaxed);
+}
+
+void RealtimeEffectList::SetActive(bool value)
+{
+   (LockGuard{ mLock }, mActive.store(value, std::memory_order_relaxed));
 }
 
 static UndoRedoExtensionRegistry::Entry sEntry {

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -156,8 +156,8 @@ void RealtimeEffectManager::ProcessStart(bool suspended)
 
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended.
-   VisitAll([suspended](RealtimeEffectState &state, bool bypassed){
-      state.ProcessStart(!suspended && !bypassed);
+   VisitAll([suspended](RealtimeEffectState &state, bool listIsActive){
+      state.ProcessStart(!suspended && listIsActive);
    });
 }
 
@@ -202,9 +202,9 @@ size_t RealtimeEffectManager::Process(bool suspended, Track &track,
    // Tracks how many processors were called
    size_t called = 0;
    VisitGroup(track,
-      [&](RealtimeEffectState &state, bool bypassed)
+      [&](RealtimeEffectState &state, bool listIsActive)
       {
-         if (bypassed)
+         if (!(listIsActive && state.IsActive()))
             return;
 
          state.Process(track, chans, ibuf, obuf, scratch[chans], numSamples);
@@ -242,8 +242,8 @@ void RealtimeEffectManager::ProcessEnd(bool suspended) noexcept
 
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended.
-   VisitAll([suspended](RealtimeEffectState &state, bool bypassed){
-      state.ProcessEnd(!suspended && !bypassed);
+   VisitAll([suspended](RealtimeEffectState &state, bool listIsActive){
+      state.ProcessEnd(!suspended && listIsActive);
    });
 }
 

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -116,11 +116,11 @@ void RealtimeEffectManager::Suspend()
    std::lock_guard<std::mutex> guard(mLock);
 
    // Already suspended...bail
-   if (mSuspended)
+   if (GetSuspended())
       return;
 
    // Show that we aren't going to be doing anything
-   mSuspended = true;
+   SetSuspended(true);
 
    // And make sure the effects don't either
    VisitAll([](RealtimeEffectState &state, bool){
@@ -134,7 +134,7 @@ void RealtimeEffectManager::Resume() noexcept
    std::lock_guard<std::mutex> guard(mLock);
 
    // Already running...bail
-   if (!mSuspended)
+   if (!GetSuspended())
       return;
 
    // Tell the effects to get ready for more action
@@ -143,28 +143,29 @@ void RealtimeEffectManager::Resume() noexcept
    });
 
    // And we should too
-   mSuspended = false;
+   SetSuspended(false);
 }
 
 //
 // This will be called in a different thread than the main GUI thread.
 //
-void RealtimeEffectManager::ProcessStart()
+void RealtimeEffectManager::ProcessStart(bool suspended)
 {
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended.
-   VisitAll([this](RealtimeEffectState &state, bool bypassed){
-      state.ProcessStart(!mSuspended && !bypassed);
+   VisitAll([suspended](RealtimeEffectState &state, bool bypassed){
+      state.ProcessStart(!suspended && !bypassed);
    });
 }
 
 //
-// This will be called in a different thread than the main GUI thread.
+
+// This will be called in a thread other than the main GUI thread.
 //
-size_t RealtimeEffectManager::Process(Track &track,
+size_t RealtimeEffectManager::Process(bool suspended, Track &track,
    float *const *buffers, float *const *scratch,
    size_t numSamples)
 {
@@ -173,7 +174,7 @@ size_t RealtimeEffectManager::Process(Track &track,
 
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended, so allow the samples to pass as-is.
-   if (mSuspended)
+   if (suspended)
       return numSamples;
 
    auto chans = mChans[&track];
@@ -234,15 +235,15 @@ size_t RealtimeEffectManager::Process(Track &track,
 //
 // This will be called in a different thread than the main GUI thread.
 //
-void RealtimeEffectManager::ProcessEnd() noexcept
+void RealtimeEffectManager::ProcessEnd(bool suspended) noexcept
 {
    // Protect...
    std::lock_guard<std::mutex> guard(mLock);
 
    // Can be suspended because of the audio stream being paused or because effects
    // have been suspended.
-   VisitAll([this](RealtimeEffectState &state, bool bypassed){
-      state.ProcessEnd(!mSuspended && !bypassed);
+   VisitAll([suspended](RealtimeEffectState &state, bool bypassed){
+      state.ProcessEnd(!suspended && !bypassed);
    });
 }
 

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -121,11 +121,6 @@ void RealtimeEffectManager::Suspend()
 
    // Show that we aren't going to be doing anything
    SetSuspended(true);
-
-   // And make sure the effects don't either
-   VisitAll([](RealtimeEffectState &state, bool){
-      state.Suspend();
-   });
 }
 
 void RealtimeEffectManager::Resume() noexcept
@@ -137,12 +132,7 @@ void RealtimeEffectManager::Resume() noexcept
    if (!GetSuspended())
       return;
 
-   // Tell the effects to get ready for more action
-   VisitAll([](RealtimeEffectState &state, bool){
-      state.Resume();
-   });
-
-   // And we should too
+   // Get ready for more action
    SetSuspended(false);
 }
 

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -109,11 +109,11 @@ private:
       ~AllListsLock() { Reset(); }
    };
 
-   void ProcessStart();
+   void ProcessStart(bool suspended);
    /*! @copydoc ProcessScope::Process */
-   size_t Process(Track &track,
+   size_t Process(bool suspended, Track &track,
       float *const *buffers, float *const *scratch, size_t numSamples);
-   void ProcessEnd() noexcept;
+   void ProcessEnd(bool suspended) noexcept;
 
    RealtimeEffectManager(const RealtimeEffectManager&) = delete;
    RealtimeEffectManager &operator=(const RealtimeEffectManager&) = delete;
@@ -136,6 +136,11 @@ private:
    double mRate;
 
    std::atomic<bool> mSuspended{ true };
+   bool GetSuspended() const
+      { return mSuspended.load(std::memory_order_relaxed); }
+   void SetSuspended(bool value)
+      { mSuspended.store(value, std::memory_order_relaxed); }
+
    std::atomic<bool> mActive{ false };
 
    // This member is mutated only by Initialize(), AddTrack(), Finalize()
@@ -187,7 +192,7 @@ public:
    {
       if (auto pProject = mwProject.lock()) {
          auto &manager = RealtimeEffectManager::Get(*pProject);
-         if (!manager.mSuspended)
+         if (!manager.GetSuspended())
             manager.Suspend();
          else
             mwProject.reset();
@@ -213,6 +218,7 @@ public:
       if (auto pProject = mwProject.lock()) {
          auto &manager = RealtimeEffectManager::Get(*pProject);
          mLocks = { &manager };
+         mSuspended = manager.GetSuspended();
       }
    }
    //! Require a prior InializationScope to ensure correct nesting
@@ -221,14 +227,14 @@ public:
       : mwProject{ move(wProject) }
    {
       if (auto pProject = mwProject.lock())
-         RealtimeEffectManager::Get(*pProject).ProcessStart();
+         RealtimeEffectManager::Get(*pProject).ProcessStart(mSuspended);
    }
    ProcessingScope( ProcessingScope &&other ) = default;
    ProcessingScope& operator=( ProcessingScope &&other ) = default;
    ~ProcessingScope()
    {
       if (auto pProject = mwProject.lock())
-         RealtimeEffectManager::Get(*pProject).ProcessEnd();
+         RealtimeEffectManager::Get(*pProject).ProcessEnd(mSuspended);
    }
 
    size_t Process(Track &track,
@@ -241,7 +247,7 @@ public:
    {
       if (auto pProject = mwProject.lock())
          return RealtimeEffectManager::Get(*pProject)
-            .Process(track, buffers, scratch, numSamples);
+            .Process(mSuspended, track, buffers, scratch, numSamples);
       else
          return numSamples; // consider them trivially processed
    }
@@ -249,6 +255,7 @@ public:
 private:
    RealtimeEffectManager::AllListsLock mLocks;
    std::weak_ptr<AudacityProject> mwProject;
+   bool mSuspended{};
 };
 }
 

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -62,7 +62,7 @@ public:
    bool IsActive() const noexcept;
    void Suspend();
    void Resume() noexcept;
-   Latency GetLatency() const;
+//   Latency GetLatency() const;
 
    //! Main thread appends a global or per-track effect
    /*!
@@ -130,7 +130,6 @@ private:
 
    AudacityProject &mProject;
 
-   std::mutex mLock;
    Latency mLatency{ 0 };
 
    double mRate;

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -119,7 +119,7 @@ private:
    RealtimeEffectManager &operator=(const RealtimeEffectManager&) = delete;
 
    using StateVisitor =
-      std::function<void(RealtimeEffectState &state, bool bypassed)> ;
+      std::function<void(RealtimeEffectState &state, bool listIsActive)> ;
 
    //! Visit the per-project states first, then states for leader if not null
    void VisitGroup(Track &leader, StateVisitor func);

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -339,13 +339,13 @@ bool RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
    return false;
 }
 
-bool RealtimeEffectState::ProcessStart(bool active)
+bool RealtimeEffectState::ProcessStart(bool running)
 {
    // Get state changes from the main thread
    if (auto pAccessState = TestAccessState())
       pAccessState->WorkerRead();
 
-   if (!mInstance || !active)
+   if (!mInstance || !IsActive() || !running)
       return false;
 
    // Assuming we are in a processing scope, use the worker settings
@@ -478,9 +478,9 @@ size_t RealtimeEffectState::Process(Track &track,
    return len;
 }
 
-bool RealtimeEffectState::ProcessEnd(bool active)
+bool RealtimeEffectState::ProcessEnd(bool running)
 {
-   bool result = mInstance && active &&
+   bool result = mInstance && IsActive() && running &&
       // Assuming we are in a processing scope, use the worker settings
       mInstance->RealtimeProcessEnd(mWorkerSettings);
 

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -531,6 +531,7 @@ static const auto parametersAttribute = "parameters";
 static const auto parameterAttribute = "parameter";
 static const auto nameAttribute = "name";
 static const auto valueAttribute = "value";
+static constexpr auto activeAttribute = "active";
 
 bool RealtimeEffectState::HandleXMLTag(
    const std::string_view &tag, const AttributesList &attrs)
@@ -539,11 +540,7 @@ bool RealtimeEffectState::HandleXMLTag(
       mParameters.clear();
       mPlugin = nullptr;
       mID.clear();
-
-      for (auto pair : attrs) {
-         auto attr = pair.first;
-         auto value = pair.second;
-
+      for (auto &[attr, value] : attrs) {
          if (attr == idAttribute) {
             SetID(value.ToWString());
             if (!mPlugin) {
@@ -552,8 +549,9 @@ bool RealtimeEffectState::HandleXMLTag(
          }
          else if (attr == versionAttribute) {
          }
+         else if (attr == activeAttribute)
+            mMainSettings.extra.SetActive(value.Get<bool>());
       }
-
       return true;
    }
    else if (tag == parametersAttribute)
@@ -561,19 +559,13 @@ bool RealtimeEffectState::HandleXMLTag(
    else if (tag == parameterAttribute) {
       wxString n;
       wxString v;
-
-      for (auto pair : attrs) {
-         auto attr = pair.first;
-         auto value = pair.second;
-
+      for (auto &[attr, value] : attrs) {
          if (attr == nameAttribute)
             n = value.ToWString();
          else if (attr == valueAttribute)
             v = value.ToWString();
       }
-
       mParameters += wxString::Format(wxT("\"%s=%s\" "), n, v);
-
       return true;
    }
    else
@@ -604,6 +596,8 @@ void RealtimeEffectState::WriteXML(XMLWriter &xmlFile)
       return;
 
    xmlFile.StartTag(XMLTag());
+   const auto active = mMainSettings.extra.GetActive();
+   xmlFile.WriteAttr(activeAttribute, active);
    xmlFile.WriteAttr(
       idAttribute, XMLWriter::XMLEsc(PluginManager::GetID(mPlugin)));
    xmlFile.WriteAttr(versionAttribute, XMLWriter::XMLEsc(mPlugin->GetVersion()));

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -67,8 +67,10 @@ public:
    //! Worker thread finishes a batch of samples
    /*! @param running means no pause or deactivation of containing list */
    bool ProcessEnd(bool running);
+
    //! To be tested only in the worker thread
    bool IsActive() const noexcept;
+
    //! Main thread cleans up playback
    bool Finalize() noexcept;
 
@@ -131,8 +133,6 @@ private:
    
    size_t mCurrentProcessor{ 0 };
    std::unordered_map<Track *, size_t> mGroups;
-
-   std::atomic<int> mSuspendCount{ 1 };    // Effects are initially suspended
 };
 
 #endif // __AUDACITY_REALTIMEEFFECTSTATE_H__

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -47,6 +47,8 @@ public:
    const PluginID& GetID() const noexcept;
    const EffectInstanceFactory *GetEffect();
 
+   bool EnsureInstance(double rate);
+   
    //! Main thread sets up for playback
    bool Initialize(double rate);
    //! Main thread sets up this state before adding it to lists

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -55,7 +55,8 @@ public:
    //! Main thread sets up this state before adding it to lists
    bool AddTrack(Track &track, unsigned chans, float rate);
    //! Worker thread begins a batch of samples
-   bool ProcessStart(bool active);
+   /*! @param running means no pause or deactivation of containing list */
+   bool ProcessStart(bool running);
    //! Worker thread processes part of a batch of samples
    size_t Process(Track &track,
       unsigned chans,
@@ -64,7 +65,9 @@ public:
       float *dummybuf, //!< one scratch buffer
       size_t numSamples);
    //! Worker thread finishes a batch of samples
-   bool ProcessEnd(bool active);
+   /*! @param running means no pause or deactivation of containing list */
+   bool ProcessEnd(bool running);
+   //! To be tested only in the worker thread
    bool IsActive() const noexcept;
    //! Main thread cleans up playback
    bool Finalize() noexcept;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -47,9 +47,6 @@ public:
    const PluginID& GetID() const noexcept;
    const EffectInstanceFactory *GetEffect();
 
-   bool Suspend();
-   bool Resume() noexcept;
-
    //! Main thread sets up for playback
    bool Initialize(double rate);
    //! Main thread sets up this state before adding it to lists
@@ -68,7 +65,7 @@ public:
    /*! @param running means no pause or deactivation of containing list */
    bool ProcessEnd(bool running);
 
-   //! To be tested only in the worker thread
+   //! Test only in the worker thread, or else when there is no processing
    bool IsActive() const noexcept;
 
    //! Main thread cleans up playback
@@ -133,6 +130,8 @@ private:
    
    size_t mCurrentProcessor{ 0 };
    std::unordered_map<Track *, size_t> mGroups;
+
+   bool mLastActive{};
 };
 
 #endif // __AUDACITY_REALTIMEEFFECTSTATE_H__

--- a/src/effects/StatefulEffectBase.cpp
+++ b/src/effects/StatefulEffectBase.cpp
@@ -76,7 +76,7 @@ bool StatefulEffectBase::Instance::RealtimeSuspend()
    return GetEffect().RealtimeSuspend();
 }
 
-bool StatefulEffectBase::Instance::RealtimeResume() noexcept
+bool StatefulEffectBase::Instance::RealtimeResume()
 {
    return GetEffect().RealtimeResume();
 }
@@ -146,7 +146,7 @@ bool StatefulEffectBase::RealtimeSuspend()
    return true;
 }
 
-bool StatefulEffectBase::RealtimeResume() noexcept
+bool StatefulEffectBase::RealtimeResume()
 {
    return true;
 }

--- a/src/effects/StatefulEffectBase.h
+++ b/src/effects/StatefulEffectBase.h
@@ -37,7 +37,7 @@ public:
       bool RealtimeAddProcessor(EffectSettings &settings,
          unsigned numChannels, float sampleRate) override;
       bool RealtimeSuspend() override;
-      bool RealtimeResume() noexcept override;
+      bool RealtimeResume() override;
       bool RealtimeProcessStart(EffectSettings &settings) override;
       size_t RealtimeProcess(size_t group, EffectSettings &settings,
          const float *const *inBuf, float *const *outBuf, size_t numSamples)
@@ -89,7 +89,7 @@ public:
      @copydoc RealtimeInitialize::RealtimeResume()
      Default implementation does nothing, returns true
    */
-   virtual bool RealtimeResume() noexcept;
+   virtual bool RealtimeResume();
 
    /*!
      @copydoc RealtimeInitialize::RealtimeProcessStart()

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1164,16 +1164,14 @@ bool VSTEffect::RealtimeSuspend()
    return true;
 }
 
-bool VSTEffect::RealtimeResume() noexcept
+bool VSTEffect::RealtimeResume()
 {
-return GuardedCall<bool>([&]{
    PowerOn();
 
    for (const auto &slave : mSlaves)
       slave->PowerOn();
 
    return true;
-});
 }
 
 bool VSTEffect::RealtimeProcessStart(EffectSettings &)

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -157,7 +157,7 @@ class VSTEffect final
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
-   bool RealtimeResume() noexcept override;
+   bool RealtimeResume() override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(size_t group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -802,14 +802,11 @@ bool VST3Effect::RealtimeSuspend()
    return true;
 }
 
-bool VST3Effect::RealtimeResume() noexcept
+bool VST3Effect::RealtimeResume()
 {
-   return GuardedCall<bool>([this]()
-   {
-      for(auto& effect : mRealtimeGroupProcessors)
-         effect->mAudioProcessor->setProcessing(true);
-      return true;
-   });
+   for(auto& effect : mRealtimeGroupProcessors)
+      effect->mAudioProcessor->setProcessing(true);
+   return true;
 }
 
 bool VST3Effect::RealtimeProcessStart(EffectSettings &)

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -140,7 +140,7 @@ public:
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
-   bool RealtimeResume() noexcept override;
+   bool RealtimeResume() override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(size_t group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -610,24 +610,17 @@ bool AudioUnitEffect::RealtimeSuspend()
    return true;
 }
 
-bool AudioUnitEffect::RealtimeResume() noexcept
+bool AudioUnitEffect::RealtimeResume()
 {
-return GuardedCall<bool>([&]{
    if (!BypassEffect(false))
-   {
       return false;
-   }
 
-   for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
-   {
-      if (!mSlaves[i]->BypassEffect(false))
-      {
+   for (auto &slave: mSlaves) {
+      if (!slave->BypassEffect(false))
          return false;
-      }
    }
 
    return true;
-});
 }
 
 bool AudioUnitEffect::RealtimeProcessStart(EffectSettings &)

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -109,7 +109,7 @@ public:
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
-   bool RealtimeResume() noexcept override;
+   bool RealtimeResume() override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(size_t group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -882,7 +882,7 @@ struct LadspaEffect::Instance
       EffectSettings &settings, unsigned numChannels, float sampleRate)
    override;
    bool RealtimeSuspend() override;
-   bool RealtimeResume() noexcept override;
+   bool RealtimeResume() override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(size_t group, EffectSettings &settings,
       const float *const *inBuf, float *const *outBuf, size_t numSamples)
@@ -1017,7 +1017,7 @@ bool LadspaEffect::Instance::RealtimeSuspend()
    return true;
 }
 
-bool LadspaEffect::Instance::RealtimeResume() noexcept
+bool LadspaEffect::Instance::RealtimeResume()
 {
    return true;
 }

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -1200,7 +1200,7 @@ bool LV2Effect::RealtimeSuspend()
    return true;
 }
 
-bool LV2Effect::RealtimeResume() noexcept
+bool LV2Effect::RealtimeResume()
 {
    mPositionSpeed = 1.0;
    mPositionFrame = 0.0;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -310,7 +310,7 @@ public:
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
-   bool RealtimeResume() noexcept override;
+   bool RealtimeResume() override;
    bool RealtimeProcessStart(EffectSettings &settings) override;
    size_t RealtimeProcess(size_t group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)


### PR DESCRIPTION
Resolves: #2986

Put an implementation behind the on/off buttons for each effect in the stack and for the whole stack.

These settings persist in the project file.

This PR also fixes all remaining race conditions I know of in managing realtime effect lists and states,
and removes the last uses of heavyweight mutex locks by the audio thread.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
