### PR TITLE
Don't stall when Apply button of effect dialog stops play...

### DIFF
--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1234,7 +1234,7 @@ void EffectUIHost::InitializeRealtime()
          if (!(pAccess->IsSameAs(*mpAccess)))
             // Decorate the given access object
             mpAccess = std::make_shared<EffectSettingsAccessTee>(
-               *pAccess, mpAccess);
+               *mpAccess, pAccess);
       }
       /*
       ProjectHistory::Get(mProject).PushState(


### PR DESCRIPTION
... Swap the main and side of EffectSettingsAccessTee, so that Set() uses
the SimpleEffectSettingsAccess -- not the complicated accessor for the temporary
realtime effect state; the one that waits for an "echo"

Resolves: #3058

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
