### PR TITLE
"Wet only" checkbox of Reverb works in real-time

### DIFF
--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -149,6 +149,8 @@ struct EffectReverb::Validator
 
 #undef SpinSliderHandlers
 
+   void OnCheckbox(wxCommandEvent &evt);
+
 };
 
 
@@ -487,7 +489,8 @@ void EffectReverb::Validator::PopulateOrExchange(ShuttleGui & S)
    S.StartHorizontalLay(wxCENTER, false);
    {
       mWetOnlyC =
-      S.AddCheckBox(XXO("Wet O&nly"), WetOnly.def);      
+      S.AddCheckBox(XXO("Wet O&nly"), WetOnly.def);
+      BindTo(*mWetOnlyC, wxEVT_CHECKBOX, &Validator::OnCheckbox);
    }
    S.EndHorizontalLay();
 
@@ -550,5 +553,9 @@ SpinSliderHandlers(WetGain)
 SpinSliderHandlers(DryGain)
 SpinSliderHandlers(StereoWidth)
 
-#undef SpinSliderHandlers
+void EffectReverb::Validator::OnCheckbox(wxCommandEvent &evt)
+{
+   ValidateUI();
+}
 
+#undef SpinSliderHandlers


### PR DESCRIPTION
Resolves: #3061

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
