### PR TITLE
Effect replacement in sidebar

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -357,6 +357,18 @@ AudioIO::AddState(AudacityProject &project, Track *pTrack, const PluginID & id)
    return RealtimeEffectManager::Get(project).AddState(pInit, pTrack, id);
 }
 
+std::shared_ptr<RealtimeEffectState>
+AudioIO::ReplaceState(AudacityProject &project,
+   Track *pTrack, size_t index, const PluginID & id)
+{
+   RealtimeEffects::InitializationScope *pInit = nullptr;
+   if (mpTransportState)
+      if (auto pProject = GetOwningProject(); pProject.get() == &project)
+         pInit = &*mpTransportState->mpRealtimeInitialization;
+   return RealtimeEffectManager::Get(project)
+      .ReplaceState(pInit, pTrack, index, id);
+}
+
 void AudioIO::RemoveState(AudacityProject &project,
    Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState)
 {

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -367,14 +367,6 @@ void AudioIO::RemoveState(AudacityProject &project,
    RealtimeEffectManager::Get(project).RemoveState(pInit, pTrack, pState);
 }
 
-RealtimeEffects::SuspensionScope AudioIO::SuspensionScope()
-{
-   if (mpTransportState && mpTransportState->mpRealtimeInitialization)
-      return RealtimeEffects::SuspensionScope{
-         *mpTransportState->mpRealtimeInitialization, mOwningProject };
-   return {};
-}
-
 void AudioIO::SetMixer(int inputSource, float recordVolume,
                        float playbackVolume)
 {
@@ -1567,11 +1559,10 @@ void AudioIO::SetPaused(bool state)
    if (state != IsPaused())
    {
       if (auto pOwningProject = mOwningProject.lock()) {
+         // The realtime effects manager may remain "active" but becomes
+         // "suspended" or "resumed".
          auto &em = RealtimeEffectManager::Get(*pOwningProject);
-         if (state)
-            em.Suspend();
-         else
-            em.Resume();
+         em.SetSuspended(state);
       }
    }
 

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -55,7 +55,6 @@ typedef int PaError;
 
 namespace RealtimeEffects {
    class ProcessingScope;
-   class SuspensionScope;
 }
 
 bool ValidateDeviceNames();
@@ -426,8 +425,6 @@ public:
    //! Forwards to RealtimeEffectManager::RemoveState with proper init scope
    void RemoveState(AudacityProject &project,
       Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState);
-
-   RealtimeEffects::SuspensionScope SuspensionScope();
 
    /** \brief Start up Portaudio for capture and recording as needed for
     * input monitoring and software playthrough only

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -422,6 +422,14 @@ public:
    std::shared_ptr<RealtimeEffectState>
    AddState(AudacityProject &project, Track *pTrack, const PluginID & id);
 
+   //! Forwards to RealtimeEffectManager::ReplaceState with proper init scope
+   /*!
+    @post result: `!result || result->GetEffect() != nullptr`
+    */
+   std::shared_ptr<RealtimeEffectState>
+   ReplaceState(AudacityProject &project,
+      Track *pTrack, size_t index, const PluginID & id);
+
    //! Forwards to RealtimeEffectManager::RemoveState with proper init scope
    void RemoveState(AudacityProject &project,
       Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState);

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -407,10 +407,14 @@ namespace
 
          AudioIO::Get()->RemoveState(*project, &*mTrack, mEffectState);
          ProjectHistory::Get(*project).PushState(
-            //i18n-hint: undo history, first parameter - realtime effect name, second - track name
-            XO("'%s' removed from '%s' effect stack").Format(effectName, trackName),
-            //i18n-hint: undo history record
-            XO("Remove realtime effect")
+            /*! i18n-hint: undo history record
+             first parameter - realtime effect name
+             second parameter - track name
+             */
+            XO("Removed %s from %s").Format(effectName, trackName),
+            /*! i18n-hint: undo history record
+             first parameter - realtime effect name */
+            XO("Remove %s").Format(effectName)
          );
       }
       
@@ -444,10 +448,14 @@ namespace
          {
             auto effectName = GetEffectName();
             ProjectHistory::Get(*mProject).PushState(
-               //i18n-hint: undo history, first parameter - realtime effect name, second - track name
-               XO("'%s' effect of '%s' modified").Format(effectName, mTrack->GetName()),
-               //i18n-hint: undo history record
-               XO("Modify realtime effect")
+               /*! i18n-hint: undo history record
+                first parameter - realtime effect name
+                second parameter - track name
+                */
+               XO("Changed %s in %s").Format(effectName, mTrack->GetName()),
+               /*! i18n-hint: undo history record
+                first parameter - realtime effect name */
+               XO("Change %s").Format(effectName)
          );
          }
          else
@@ -703,12 +711,24 @@ public:
          const auto to = event.GetTargetIndex();
          if(from != to)
          {
+            auto effectName =
+               effectList.GetStateAt(from)->GetEffect()->GetName();
+            bool up = (to < from);
             effectList.MoveEffect(from, to);
             ProjectHistory::Get(*mProject).PushState(
-               //i18n-hint: undo history, first parameter - track name, second - old position, third - new position
-               XO("'%s' effects reorder %d->%d").Format(mTrack->GetName(), from + 1, to + 1),
-               //i18n-hint: undo history record
-               XO("Realtime effect reorder"), UndoPush::CONSOLIDATE);
+               (up
+                  /*! i18n-hint: undo history record
+                   first parameter - realtime effect name
+                   second parameter - track name
+                   */
+                  ? XO("Moved %s up in %s")
+                  /*! i18n-hint: undo history record
+                   first parameter - realtime effect name
+                   second parameter - track name
+                   */
+                  : XO("Moved %s down in %s"))
+                  .Format(effectName, mTrack->GetName()),
+               XO("Change effect order"), UndoPush::CONSOLIDATE);
          }
          else
          {
@@ -852,11 +872,15 @@ public:
       {
          auto effect = state->GetEffect();
          assert(effect); // postcondition of AddState
+         const auto effectName = effect->GetName();
          ProjectHistory::Get(*mProject).PushState(
-            //i18n-hint: undo history, first parameter - realtime effect name, second - track name
-            XO("'%s' added to the '%s' effect stack").Format(effect->GetName(), mTrack->GetName()),
+            /*! i18n-hint: undo history record
+             first parameter - realtime effect name
+             second parameter - track name
+             */
+            XO("Added %s to %s").Format(effectName, mTrack->GetName()),
             //i18n-hint: undo history record
-            XO("Add realtime effect"));
+            XO("Add %s").Format(effectName));
       }
    }
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -468,6 +468,9 @@ wxPanel *EffectUIHost::BuildButtonBar(wxWindow *parent)
 
 bool EffectUIHost::Initialize()
 {
+   // Put the checkbox for realtime into the correct initial state
+   mEnabled = !RealtimeEffectManager::Get(mProject).GetSuspended();
+
    // Build a "host" dialog, framing a panel that the client fills in.
    // The frame includes buttons to preview, apply, load and save presets, etc.
    EffectPanel *w {};
@@ -580,14 +583,9 @@ void EffectUIHost::OnPaint(wxPaintEvent & WXUNUSED(evt))
 void EffectUIHost::OnClose(wxCloseEvent & WXUNUSED(evt))
 {
    DoCancel();
-   
    CleanupRealtime();
-   
    Hide();
-
-   mSuspensionScope.reset();
    mpValidator.reset();
-
    Destroy();
 #if wxDEBUG_LEVEL
    mClosed = true;
@@ -805,13 +803,9 @@ void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnEnable(wxCommandEvent & WXUNUSED(evt))
 {
-   mEnabled = mEnableCb->GetValue();
-   
-   if (mEnabled)
-      mSuspensionScope.reset();
-   else
-      mSuspensionScope.emplace(AudioIO::Get()->SuspensionScope());
-
+   // Change the suspension state of realtime processing, though it remains
+   // "active."
+   RealtimeEffectManager::Get(mProject).SetSuspended(!mEnableCb->GetValue());
    UpdateControls();
 }
 

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -142,7 +142,6 @@ private:
    double mPlayPos{ 0.0 };
 
    bool mDismissed{};
-   std::optional<RealtimeEffects::SuspensionScope> mSuspensionScope;
 
 #if wxDEBUG_LEVEL
    // Used only in an assertion

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -148,6 +148,17 @@ void RealtimeEffectList::RemoveState(
    }
 }
 
+std::optional<size_t> RealtimeEffectList::FindState(
+   const std::shared_ptr<RealtimeEffectState> &pState) const
+{
+   const auto begin = mStates.begin()
+      , end = mStates.end()
+      , iter = std::find(begin, end, pState);
+   if (iter == end)
+      return {};
+   return std::distance(begin, iter);
+}
+
 size_t RealtimeEffectList::GetStatesCount() const noexcept
 {
    return mStates.size();

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -100,6 +100,32 @@ RealtimeEffectList::AddState(std::shared_ptr<RealtimeEffectState> pState)
       return false;
 }
 
+bool
+RealtimeEffectList::ReplaceState(size_t index,
+   std::shared_ptr<RealtimeEffectState> pState)
+{
+   if (index >= mStates.size())
+      return false;
+   const auto &id = pState->GetID();
+   if (pState->GetEffect() != nullptr) {
+      auto shallowCopy = mStates;
+      swap(pState, shallowCopy[index]);
+      // Lock for only a short time
+      (LockGuard{ mLock }, swap(shallowCopy, mStates));
+
+      Publisher<RealtimeEffectListMessage>::Publish({
+         RealtimeEffectListMessage::Type::Replace,
+         index,
+         { }
+      });
+
+      return true;
+   }
+   else
+      // Effect initialization failed for the id
+      return false;
+}
+
 void RealtimeEffectList::RemoveState(
    const std::shared_ptr<RealtimeEffectState> &pState)
 {

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -10,6 +10,7 @@
 #define __AUDACITY_REALTIMEEFFECTLIST_H__
 
 #include <atomic>
+#include <optional>
 #include <vector>
 
 #include "PluginProvider.h" // for PluginID
@@ -105,6 +106,10 @@ public:
    //! Use only in the main thread
    //! On success sends Remove message.
    void RemoveState(const std::shared_ptr<RealtimeEffectState> &pState);
+
+   //! Report the position of a state in the list
+   std::optional<size_t> FindState(
+      const std::shared_ptr<RealtimeEffectState> &pState) const;
 
    //! Use only in the main thread, to avoid races
    //! Returns total number of effects in this list

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -29,6 +29,7 @@ struct RealtimeEffectListMessage
    enum class Type
    {
       Insert,///<New effect item was added to the list at srcIndex position
+      Replace,///<Effect item was replaced with a new item at srcIndex position
       Remove,///<Effect item was removed from the list at srcIndex position
       Move ///<Item position has changed, from srcIndex to dstIndex
    };
@@ -92,6 +93,14 @@ public:
     @post result: `!result || pState->GetEffect() != nullptr`
     */
    bool AddState(std::shared_ptr<RealtimeEffectState> pState);
+
+   //! Use only in the main thread
+   //! Returns true for success.
+   //! Sends Insert message on success.
+   /*!
+    @post result: `!result || pState->GetEffect() != nullptr`
+    */
+   bool ReplaceState(size_t index, std::shared_ptr<RealtimeEffectState> pState);
 
    //! Use only in the main thread
    //! On success sends Remove message.

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -69,7 +69,7 @@ void RealtimeEffectManager::Initialize(
    });
 
    // Leave suspended state
-   Resume();
+   SetSuspended(false);
 }
 
 void RealtimeEffectManager::AddTrack(
@@ -93,7 +93,7 @@ void RealtimeEffectManager::AddTrack(
 void RealtimeEffectManager::Finalize() noexcept
 {
    // Reenter suspended state
-   Suspend();
+   SetSuspended(true);
 
    // Assume it is now safe to clean up
    mLatency = std::chrono::microseconds(0);
@@ -107,28 +107,6 @@ void RealtimeEffectManager::Finalize() noexcept
 
    // No longer active
    mActive = false;
-}
-
-void RealtimeEffectManager::Suspend()
-{
-   // Already suspended...bail
-   if (GetSuspended())
-      return;
-
-   // Show that we aren't going to be doing anything
-   // (set atomically, before next ProcessingScope)
-   SetSuspended(true);
-}
-
-void RealtimeEffectManager::Resume() noexcept
-{
-   // Already running...bail
-   if (!GetSuspended())
-      return;
-
-   // Get ready for more action
-   // (set atomically, before next ProcessingScope)
-   SetSuspended(false);
 }
 
 //

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -339,6 +339,13 @@ void RealtimeEffectManager::RemoveState(
    });
 }
 
+std::optional<size_t> RealtimeEffectManager::FindState(
+   Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState) const
+{
+   auto [_, states] = FindStates(mProject, pTrack);
+   return states.FindState(pState);
+}
+
 // Where is this used?
 #if 0
 auto RealtimeEffectManager::GetLatency() const -> Latency

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -271,14 +271,6 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
       ? RealtimeEffectList::Get(*pLeader)
       : RealtimeEffectList::Get(mProject);
 
-   std::optional<RealtimeEffects::SuspensionScope> myScope;
-   if (mActive) {
-      if (pScope)
-         myScope.emplace(*pScope, mProject.weak_from_this());
-      else
-         return nullptr;
-   }
-
    auto pState = RealtimeEffectState::make_shared(id);
    auto &state = *pState;
    
@@ -324,14 +316,6 @@ void RealtimeEffectManager::RemoveState(
    RealtimeEffectList &states = pLeader
       ? RealtimeEffectList::Get(*pLeader)
       : RealtimeEffectList::Get(mProject);
-
-   std::optional<RealtimeEffects::SuspensionScope> myScope;
-   if (mActive) {
-      if (pScope)
-         myScope.emplace(*pScope, mProject.weak_from_this());
-      else
-         return;
-   }
 
    // Remove the state from processing (under the lock guard) before finalizing
    states.RemoveState(pState);

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -98,6 +99,10 @@ public:
    /*! No effect if realtime is active but scope is not supplied */
    void RemoveState(RealtimeEffects::InitializationScope *pScope,
       Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState);
+
+   //! Report the position of a state in the global or a per-track list
+   std::optional<size_t> FindState(
+      Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState) const;
 
    bool GetSuspended() const
       { return mSuspended.load(std::memory_order_relaxed); }

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -57,6 +57,8 @@ public:
    static const RealtimeEffectManager & Get(const AudacityProject &project);
 
    // Realtime effect processing
+
+   //! To be called only from main thread
    bool IsActive() const noexcept;
    void Suspend();
    void Resume() noexcept;
@@ -156,7 +158,7 @@ private:
    void SetSuspended(bool value)
       { mSuspended.store(value, std::memory_order_relaxed); }
 
-   std::atomic<bool> mActive{ false };
+   bool mActive{ false };
 
    // This member is mutated only by Initialize(), AddTrack(), Finalize()
    // which are to be called only while there is no playback

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -36,6 +36,7 @@ struct RealtimeEffectManagerMessage
    enum class Type
    {
       EffectAdded,
+      EffectReplaced,
       EffectRemoved
    };
    Type type;
@@ -73,6 +74,20 @@ public:
    std::shared_ptr<RealtimeEffectState> AddState(
       RealtimeEffects::InitializationScope *pScope, Track *pTrack,
       const PluginID & id);
+
+   //! Main thread replaces a global or per-track effect
+   /*!
+    @param pScope if realtime is active but scope is absent, there is no effect
+    @param pTrack if null, then state is added to the global list
+    @param index position in the list to replace; no effect if out of range
+    @param id identifies the effect
+    @return if null, the given id was not found and the old state remains
+
+    @post result: `!result || result->GetEffect() != nullptr`
+    */
+   std::shared_ptr<RealtimeEffectState> ReplaceState(
+      RealtimeEffects::InitializationScope *pScope, Track *pTrack,
+      size_t index, const PluginID & id);
 
    //! Main thread removes a global or per-track effect
    /*!

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -100,6 +100,10 @@ public:
 private:
    friend RealtimeEffects::InitializationScope;
 
+   std::shared_ptr<RealtimeEffectState>
+   MakeNewState(RealtimeEffects::InitializationScope *pScope,
+      Track *pLeader, const PluginID &id);
+
    //! Main thread begins to define a set of tracks for playback
    void Initialize(RealtimeEffects::InitializationScope &scope,
       double sampleRate);


### PR DESCRIPTION
Resolves: #3050
Resolves: #3092 

Implement the replacement of a chosen effect in the sidebar by the menu button.

Also fix minor omissions in recent UI changes.  Allow the text in the sidebar to wrap,
and update the most recent undo state for changes of power button state.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
