### PR TITLE
Define settings vst3 i2969 4th

### DIFF
--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -965,11 +965,7 @@ void VST3Effect::ExportPresets(const EffectSettings &) const
       return;
    }
 
-   if(!Vst::PresetFile::savePreset(
-      fileStream,
-      FUID::fromTUID (mEffectClassInfo.ID().data()),
-      mEffectComponent.get(),
-      mEditController.get()))
+   if (!VST3Wrapper::SavePreset(fileStream))
    {
       BasicUI::ShowMessageBox(
          XO("Failed to save VST3 preset to file"),
@@ -1173,11 +1169,7 @@ bool VST3Effect::LoadPreset(const wxString& path)
       return false;
    }
 
-   if(!Vst::PresetFile::loadPreset(
-      fileStream,
-      FUID::fromTUID(mEffectClassInfo.ID().data()),
-      mEffectComponent.get(),
-      mEditController.get()))
+   if (!VST3Wrapper::LoadPreset(fileStream))
    {
       BasicUI::ShowMessageBox(
          XO("Unable to apply VST3 preset file %s").Format(path),

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -1150,6 +1150,16 @@ void VST3Effect::ReloadUserOptions()
    SetBlockSize(mUserBlockSize);
 }
 
+EffectSettings VST3Effect::MakeSettings() const
+{
+   auto result = StatefulPerTrackEffect::MakeSettings();
+   // Cause initial population of the map stored in the stateful effect
+   if (!mInitialFetchDone) {
+      FetchSettings(GetSettings(result));
+      mInitialFetchDone = true;
+   }
+   return result;
+}
 
 bool VST3Effect::TransferDataToWindow(const EffectSettings& settings)
 {

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -470,35 +470,6 @@ bool VST3Effect::LoadFactoryPreset(int id, EffectSettings &) const
    return true;
 }
 
-bool VST3Effect::LoadFactoryDefaults(EffectSettings &) const
-{
-   using namespace Steinberg;
-   if(mComponentHandler == nullptr)
-      return false;
-
-   for(int i = 0, count = mEditController->getParameterCount(); i < count; ++i)
-   {
-      Vst::ParameterInfo parameterInfo { };
-      if(mEditController->getParameterInfo(i, parameterInfo) == kResultOk)
-      {
-         if(parameterInfo.flags & Vst::ParameterInfo::kIsReadOnly)
-            continue;
-
-         if(mComponentHandler->beginEdit(parameterInfo.id) == kResultOk)
-         {
-            auto cleanup = finally([&]{
-               mComponentHandler->endEdit(parameterInfo.id);
-            });
-            mComponentHandler->performEdit(parameterInfo.id, parameterInfo.defaultNormalizedValue);
-         }
-         mEditController->setParamNormalized(parameterInfo.id, parameterInfo.defaultNormalizedValue);
-      }
-   }
-   
-
-   return true;
-}
-
 namespace
 {
    unsigned CountChannels(Steinberg::Vst::IComponent* component,

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -405,12 +405,14 @@ bool VST3Effect::LoadUserPreset(
 }
 
 bool VST3Effect::SaveUserPreset(
-   const RegistryPath& name, const EffectSettings &) const
+   const RegistryPath& name, const EffectSettings& settings) const
 {
    using namespace Steinberg;
 
    if(!mEditController)
       return false;
+
+   StoreSettings(GetSettings(settings));
 
    auto processorState = owned(safenew PresetsBufferStream);
    if(mEffectComponent->getState(processorState) != kResultOk)
@@ -882,7 +884,7 @@ bool VST3Effect::CanExportPresets()
    return true;
 }
 
-void VST3Effect::ExportPresets(const EffectSettings &) const
+void VST3Effect::ExportPresets(const EffectSettings& settings) const
 {
    using namespace Steinberg;
 
@@ -914,6 +916,9 @@ void VST3Effect::ExportPresets(const EffectSettings &) const
       );
       return;
    }
+
+   if (!StoreSettings(GetSettings(settings)))
+      return;
 
    if (!VST3Wrapper::SavePreset(fileStream))
    {
@@ -1163,7 +1168,8 @@ EffectSettings VST3Effect::MakeSettings() const
 
 bool VST3Effect::TransferDataToWindow(const EffectSettings& settings)
 {
-   StoreSettings(GetSettings(settings));
+   if (!StoreSettings(GetSettings(settings)))
+      return false;
 
    SyncParameters();
 

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -14,7 +14,6 @@
 
 #include "AudacityException.h"
 
-#include "Base64.h"
 
 #include "BasicUI.h"
 #include "widgets/wxWidgetsWindowPlacement.h"
@@ -27,7 +26,6 @@
 #include <pluginterfaces/vst/ivsteditcontroller.h>
 #include <pluginterfaces/vst/ivstprocesscontext.h>
 #include <public.sdk/source/vst/hosting/hostclasses.h>
-#include <public.sdk/source/vst/vstpresetfile.h>
 
 #include "internal/ComponentHandler.h"
 #include "internal/ParameterChanges.h"
@@ -65,28 +63,6 @@ Steinberg::Vst::IHostApplication& LocalContext()
    return localContext;
 }
 
-class PresetsBufferStream : public Steinberg::Vst::BufferStream
-{
-public:
-
-   static Steinberg::IPtr<PresetsBufferStream> fromString(const wxString& str)
-   {
-      Steinberg::Buffer buffer(str.size() / 4 * 3);
-      auto len = Base64::Decode(str, buffer);
-      wxASSERT(len <= buffer.getSize());
-      buffer.setSize(len);
-
-      auto result = owned(safenew PresetsBufferStream);
-      result->mBuffer.take(buffer);
-      return result;
-   }
-
-   wxString toString() const
-   {
-      return Base64::Encode(mBuffer, mBuffer.getSize());
-   }
-
-};
 
 void ActivateDefaultBuses(Steinberg::Vst::IComponent* component, const Steinberg::Vst::MediaType mediaType, const Steinberg::Vst::BusDirection direction, bool state)
 {

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -23,7 +23,7 @@
 #include <wx/log.h>
 #include <wx/stdpaths.h>
 #include <wx/regex.h>
-#include <pluginterfaces/vst/ivstaudioprocessor.h>
+
 #include <pluginterfaces/vst/ivsteditcontroller.h>
 #include <pluginterfaces/vst/ivstprocesscontext.h>
 #include <public.sdk/source/vst/hosting/hostclasses.h>
@@ -184,7 +184,7 @@ EffectFamilySymbol VST3Effect::GetFamilySymbol()
 }
 
 VST3Effect::VST3Effect(const VST3Effect& other)
-   : mModule(other.mModule), mEffectClassInfo(other.mEffectClassInfo)
+   : VST3Wrapper(other.mModule, other.mEffectClassInfo)
 {
    mUseLatency = other.mUseLatency;
    mUserBlockSize = other.mUserBlockSize;
@@ -215,7 +215,8 @@ VST3Effect::~VST3Effect()
 VST3Effect::VST3Effect(
    std::shared_ptr<VST3::Hosting::Module> module, 
    VST3::Hosting::ClassInfo effectClassInfo)
-   : mModule(std::move(module)), mEffectClassInfo(std::move(effectClassInfo))
+
+   : VST3Wrapper(std::move(module), effectClassInfo)
 {
    using namespace Steinberg;
    Initialize();

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -167,7 +167,7 @@ private:
 
    void SyncParameters() const;
 
-   bool LoadPreset(const wxString& path);
+   bool LoadPreset(const wxString& path, EffectSettings& settings);
 
    void ReloadUserOptions();
 };

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -16,13 +16,13 @@
 #include <wx/wx.h>
 
 #include <pluginterfaces/gui/iplugview.h>
-#include <pluginterfaces/vst/ivstaudioprocessor.h>
-#include <public.sdk/source/vst/hosting/module.h>
 
 #include "../StatefulPerTrackEffect.h"
 #include "internal/ComponentHandler.h"
 
 #include "SampleCount.h"
+
+#include "VST3Utils.h"
 
 class NumericTextCtrl;
 
@@ -42,17 +42,12 @@ class VST3ParametersWindow;
 /**
  * \brief Objects of this class connect Audacity with VST3 effects
  */
-class VST3Effect final : public StatefulPerTrackEffect
+class VST3Effect final : public StatefulPerTrackEffect, private VST3Wrapper
 {
-   //Keep strong reference to a module while effect is alive
-   std::shared_ptr<VST3::Hosting::Module> mModule;
-
    //Following fields are unique to each effect instance
-
-   Steinberg::IPtr<Steinberg::Vst::IComponent> mEffectComponent;
+   
    Steinberg::IPtr<Steinberg::Vst::IAudioProcessor> mAudioProcessor;
    Steinberg::Vst::ProcessSetup mSetup;
-   const VST3::Hosting::ClassInfo mEffectClassInfo;
 
    //Since all of the realtime processors share same presets, following
    //fields are only initialized and assigned in the global effect instance
@@ -61,7 +56,7 @@ class VST3Effect final : public StatefulPerTrackEffect
    Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> mControllerConnectionProxy;
    //Used if provided by the plugin and enabled in the settings
    Steinberg::IPtr<Steinberg::IPlugView> mPlugView;
-   Steinberg::IPtr<Steinberg::Vst::IEditController> mEditController;
+   
    Steinberg::IPtr<internal::ComponentHandler> mComponentHandler;
    wxWindow* mParent { nullptr };
    NumericTextCtrl* mDuration { nullptr };

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -158,12 +158,15 @@ public:
    bool HasOptions() override;
    void ShowOptions() override;
 
+
+   bool TransferDataToWindow(const EffectSettings& settings) override;
+
 private:
    void OnEffectWindowResize(wxSizeEvent & evt);
 
    bool LoadVSTUI(wxWindow* parent);
 
-   void SyncParameters(EffectSettings &) const;
+   void SyncParameters() const;
 
    bool LoadPreset(const wxString& path);
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -79,7 +79,9 @@ class VST3Effect final : public StatefulPerTrackEffect, private VST3Wrapper
 
 
    void Initialize();
-   
+
+   mutable bool mInitialFetchDone{ false };
+
 public:
 
    static EffectFamilySymbol GetFamilySymbol();
@@ -157,6 +159,7 @@ public:
    bool HasOptions() override;
    void ShowOptions() override;
 
+   EffectSettings MakeSettings() const override;
 
    bool TransferDataToWindow(const EffectSettings& settings) override;
 

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -114,7 +114,6 @@ public:
       const RegistryPath & name, const EffectSettings &settings) const override;
    RegistryPaths GetFactoryPresets() const override;
    bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
-   bool LoadFactoryDefaults(EffectSettings &) const override;
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -18,7 +18,6 @@
 #include <wx/stdpaths.h>
 #include <wx/dir.h>
 #include <wx/log.h>
-#include <public.sdk/source/vst/hosting/module.h>
 
 
 #include "ModuleManager.h"

--- a/src/effects/VST3/VST3Utils.cpp
+++ b/src/effects/VST3/VST3Utils.cpp
@@ -10,13 +10,16 @@
 
 **********************************************************************/
 
+
 #include "VST3Utils.h"
+#include "Base64.h"
 
 #include <wx/string.h>
 #include <wx/sizer.h>
 
 #include <pluginterfaces/vst/ivsteditcontroller.h>
 #include <pluginterfaces/vst/ivstparameterchanges.h>
+
 
 wxString VST3Utils::MakePluginPathString(const wxString& modulePath, const std::string& effectUIDString)
 {
@@ -72,4 +75,79 @@ bool VST3Utils::ParseAutomationParameterKey(const wxString& key, Steinberg::Vst:
    }
    return false;
 
+}
+
+
+
+Steinberg::IPtr<PresetsBufferStream> PresetsBufferStream::fromString(const wxString& str)
+{
+   Steinberg::Buffer buffer(str.size() / 4 * 3);
+   auto len = Base64::Decode(str, buffer);
+   assert(len <= buffer.getSize());
+   buffer.setSize(len);
+
+   auto result = owned(safenew PresetsBufferStream);
+   result->mBuffer.take(buffer);
+   return result;
+}
+
+
+wxString PresetsBufferStream::toString() const
+{
+   return Base64::Encode(mBuffer, mBuffer.getSize());
+}
+
+
+
+bool VST3Wrapper::FetchSettings(VST3EffectSettings& vst3Settings) const
+{
+   using namespace Steinberg;
+
+   auto processorState = owned(safenew PresetsBufferStream);
+   if (mEffectComponent->getState(processorState) == kResultOk)
+   {
+      vst3Settings.mProcessorStateStr = processorState->toString();
+   }
+   else
+   {
+      vst3Settings.mProcessorStateStr = std::nullopt;
+   }
+
+   auto controllerState = owned(safenew PresetsBufferStream);
+   if (mEditController->getState(controllerState) == kResultOk)
+   {
+      vst3Settings.mControllerStateStr = controllerState->toString();
+   }
+   else
+   {
+      vst3Settings.mControllerStateStr = std::nullopt;
+   }
+
+   return true;   
+}
+
+
+
+bool VST3Wrapper::StoreSettings(const VST3EffectSettings& vst3settings) const
+{
+   using namespace Steinberg;
+
+   // we need at least the processor state string, otherwise we can not set the EditController
+   if (!vst3settings.mProcessorStateStr)
+      return false;
+
+   auto processorState = PresetsBufferStream::fromString(*vst3settings.mProcessorStateStr);
+   if (mEffectComponent->setState(processorState) != kResultOk)
+      return false;
+
+   if (vst3settings.mControllerStateStr)
+   {
+      auto controllerState = PresetsBufferStream::fromString(*vst3settings.mControllerStateStr);
+
+      if (mEditController->setComponentState(processorState) != kResultOk ||
+         mEditController->setState(controllerState) != kResultOk)
+         return false;
+   }
+
+   return true;
 }

--- a/src/effects/VST3/VST3Utils.cpp
+++ b/src/effects/VST3/VST3Utils.cpp
@@ -151,3 +151,31 @@ bool VST3Wrapper::StoreSettings(const VST3EffectSettings& vst3settings) const
 
    return true;
 }
+
+
+bool VST3Wrapper::LoadPreset(Steinberg::IBStream* fileStream)
+{
+   using namespace Steinberg;
+
+   return Vst::PresetFile::loadPreset
+   (
+      fileStream,
+      FUID::fromTUID(mEffectClassInfo.ID().data()),
+      mEffectComponent.get(),
+      mEditController.get()
+   );
+}
+
+
+bool VST3Wrapper::SavePreset(Steinberg::IBStream* fileStream) const
+{
+   using namespace Steinberg;
+
+   return Vst::PresetFile::savePreset
+   (
+      fileStream,
+      FUID::fromTUID(mEffectClassInfo.ID().data()),
+      mEffectComponent.get(),
+      mEditController.get()
+   );
+}

--- a/src/effects/VST3/VST3Utils.h
+++ b/src/effects/VST3/VST3Utils.h
@@ -101,6 +101,10 @@ struct VST3Wrapper
    bool FetchSettings(      VST3EffectSettings& settings) const;
    bool StoreSettings(const VST3EffectSettings& settings) const;
 
+   bool LoadPreset(Steinberg::IBStream* fileStream);
+   bool SavePreset(Steinberg::IBStream* fileStream) const;
+
+
    VST3EffectSettings mSettings;  // temporary, until the effect is really stateless
 
    //! This function will be rewritten when the effect is really stateless

--- a/src/effects/VST3/VST3Utils.h
+++ b/src/effects/VST3/VST3Utils.h
@@ -12,8 +12,9 @@
 
 #pragma once
 
+#include <pluginterfaces/vst/ivstaudioprocessor.h>
 #include <string>
-#include <pluginterfaces/vst/vsttypes.h>
+#include <public.sdk/source/vst/hosting/module.h>
 
 class wxString;
 class wxWindow;
@@ -56,3 +57,25 @@ public:
    //Returns true on success.
    static bool ParseAutomationParameterKey(const wxString& key, Steinberg::Vst::ParamID& paramId);
 };
+
+
+struct VST3Wrapper
+{
+   VST3Wrapper(std::shared_ptr<VST3::Hosting::Module> module, VST3::Hosting::ClassInfo effectClassInfo)
+      : mModule(std::move(module)),
+        mEffectClassInfo(std::move(effectClassInfo))
+   {}
+
+   // Keep strong reference to a module; this because it has to be destroyed in the destructor of this class,
+   // otherwise the destruction of mEditController and mEffectComponent would trigger a memory fault.
+   std::shared_ptr<VST3::Hosting::Module> mModule;
+
+   const VST3::Hosting::ClassInfo mEffectClassInfo;
+
+   // For the time being, here we have only members that are needed
+   // to iterate parameters and extract preset state
+   //
+   Steinberg::IPtr<Steinberg::Vst::IComponent>      mEffectComponent;
+   Steinberg::IPtr<Steinberg::Vst::IEditController> mEditController;   
+};
+

--- a/src/effects/VST3/VST3Utils.h
+++ b/src/effects/VST3/VST3Utils.h
@@ -15,6 +15,9 @@
 #include <pluginterfaces/vst/ivstaudioprocessor.h>
 #include <string>
 #include <public.sdk/source/vst/hosting/module.h>
+#include <public.sdk/source/vst/vstpresetfile.h>
+
+#include <optional>
 
 class wxString;
 class wxWindow;
@@ -58,6 +61,23 @@ public:
    static bool ParseAutomationParameterKey(const wxString& key, Steinberg::Vst::ParamID& paramId);
 };
 
+class PresetsBufferStream : public Steinberg::Vst::BufferStream
+{
+public:
+
+   static Steinberg::IPtr<PresetsBufferStream> fromString(const wxString& str);
+
+   wxString toString() const;
+};
+
+struct EffectSettings;
+struct VST3EffectSettings
+{
+   // states as saved by IComponent::getState
+   std::optional<std::string> mProcessorStateStr;
+   std::optional<std::string> mControllerStateStr;
+};
+
 
 struct VST3Wrapper
 {
@@ -76,6 +96,33 @@ struct VST3Wrapper
    // to iterate parameters and extract preset state
    //
    Steinberg::IPtr<Steinberg::Vst::IComponent>      mEffectComponent;
-   Steinberg::IPtr<Steinberg::Vst::IEditController> mEditController;   
+   Steinberg::IPtr<Steinberg::Vst::IEditController> mEditController;
+
+   bool FetchSettings(      VST3EffectSettings& settings) const;
+   bool StoreSettings(const VST3EffectSettings& settings) const;
+
+   VST3EffectSettings mSettings;  // temporary, until the effect is really stateless
+
+   //! This function will be rewritten when the effect is really stateless
+   VST3EffectSettings& GetSettings(EffectSettings&) const
+   {
+      return const_cast<VST3Wrapper*>(this)->mSettings;
+   }
+
+   //! This function will be rewritten when the effect is really stateless
+   const VST3EffectSettings& GetSettings(const EffectSettings&) const
+   {
+      return mSettings;
+   }
+
+   //! This is what ::GetSettings will be when the effect becomes really stateless
+   /*
+   static inline VST3EffectSettings& GetSettings(EffectSettings& settings)
+   {
+      auto pSettings = settings.cast<VST3EffectSettings>();
+      assert(pSettings);
+      return *pSettings;
+   }
+   */
 };
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2969

After some reviews and discussions we decided that settings should not hold maps of IDs and normalized values, but rather the whole "state" of the processor and the controller, as created by the VST3 SDK.

This implies such large ripple effects in the code, that this new PR had to be opened.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
