### PR TITLE
issue #2162 Punch and roll: tracks are not played in sync

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1163,19 +1163,20 @@ bool AudioIO::AllocateBuffers(
                mixTracks.push_back(mPlaybackTracks[i]);
 
                double startTime, endTime;
-               if (make_iterator_range(tracks.prerollTracks)
-                      .contains(mPlaybackTracks[i])) {
-                  // Stop playing this track after pre-roll
+               if (!tracks.prerollTracks.empty())
                   startTime = mPlaybackSchedule.mT0;
+               else
+                  startTime = t0;
+
+               if (make_iterator_range(tracks.prerollTracks)
+                  .contains(mPlaybackTracks[i]))
+                  // Stop playing this track after pre-roll
                   endTime = t0;
-               }
-               else {
+               else
                   // Pass t1 -- not mT1 as may have been adjusted for latency
                   // -- so that overdub recording stops playing back samples
                   // at the right time, though transport may continue to record
-                  startTime = t0;
                   endTime = t1;
-               }
 
                mPlaybackMixers[i] = std::make_unique<Mixer>
                   (mixTracks,


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2162

I think the problem started in master with commit:30b7882e107c32

Fix:
If there are any preroll tracks, set the start of all the playback tracks to the same value.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
