### PR TITLE
Sidebar bugs

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -484,6 +484,8 @@ public:
     and reloaded from files.
 
     @param settings may be assumed to have a lifetime enclosing the instance's
+
+    @post `true` (no promises that the result isn't null)
     */
    virtual std::shared_ptr<EffectInstance> MakeInstance() const = 0;
 

--- a/libraries/lib-utility/TypedAny.h
+++ b/libraries/lib-utility/TypedAny.h
@@ -27,13 +27,14 @@ template<typename Tag> class TypedAny
    // Primary template:
    template<typename... Args> struct Good_args : std::true_type{};
    // Partial specialization:
-   template<typename Arg> struct Good_args<Arg> : std::bool_constant<
-      !std::is_same_v<Tag, std::remove_const_t< std::remove_reference_t<Arg> > >
-   >{};
+   template<typename Arg> struct Good_args<Arg>
+   : std::bool_constant< !std::is_base_of_v<TypedAny,
+      std::remove_const_t< std::remove_reference_t<Arg> >
+   > >{};
 public:
    //! Constructor with arguments just as for std::any, but it is explicit
    template<typename... Args,
-      typename restriction = std::enable_if_t< Good_args<Args...>::value, void >
+      typename restriction = std::enable_if_t< Good_args<Args...>::value >
    >
    explicit TypedAny(Args &&... args)
       : mAny(std::forward<Args>(args)...)

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -53,7 +53,10 @@ struct PaStreamCallbackTimeInfo;
 typedef unsigned long PaStreamCallbackFlags;
 typedef int PaError;
 
-namespace RealtimeEffects { class SuspensionScope; }
+namespace RealtimeEffects {
+   class ProcessingScope;
+   class SuspensionScope;
+}
 
 bool ValidateDeviceNames();
 
@@ -588,7 +591,8 @@ private:
 
    //! First part of TrackBufferExchange
    void FillPlayBuffers();
-   void TransformPlayBuffers();
+   void TransformPlayBuffers(
+      std::optional<RealtimeEffects::ProcessingScope> &scope);
 
    //! Second part of TrackBufferExchange
    void DrainRecordBuffers();

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -31,7 +31,8 @@ class EffectPlugin;
 /*! The dialog may be modal or non-modal */
 using EffectDialogFactory = std::function< wxDialog* (
    wxWindow &parent, EffectPlugin &, EffectUIClientInterface &,
-   EffectInstance &, EffectSettingsAccess & ) >;
+   std::shared_ptr<EffectInstance> &,
+   EffectSettingsAccess & ) >;
 
 class TrackList;
 class WaveTrackFactory;
@@ -62,8 +63,9 @@ public:
    /*!
     But there are a few unusual overrides for historical reasons
 
-    @param instance is only guaranteed to have lifetime suitable for a modal
-    dialog, unless the dialog stores instance.shared_from_this()
+    @param pInstance may be passed to factory, and is only guaranteed to have
+    lifetime suitable for a modal dialog, unless the dialog stores a copy of
+    pInstance
 
     @param access is only guaranteed to have lifetime suitable for a modal
     dialog, unless the dialog stores access.shared_from_this()
@@ -73,7 +75,7 @@ public:
     */
    virtual int ShowHostInterface(
       wxWindow &parent, const EffectDialogFactory &factory,
-      EffectInstance &instance, EffectSettingsAccess &access,
+      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
       bool forceModal = false) = 0;
 
    virtual void Preview(EffectSettingsAccess &access, bool dryOnly) = 0;

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -29,6 +29,10 @@ class EffectPlugin;
 
 //! Type of function that creates a dialog for an effect
 /*! The dialog may be modal or non-modal */
+   /*
+    @param[out] pInstance may construct
+    (and then must call Init() with success), or leave null for failure
+    */
 using EffectDialogFactory = std::function< wxDialog* (
    wxWindow &parent, EffectPlugin &, EffectUIClientInterface &,
    std::shared_ptr<EffectInstance> &,

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -38,7 +38,23 @@ PlaybackPolicy::BufferTimes
 PlaybackPolicy::SuggestedBufferTimes(PlaybackSchedule &)
 {
    using namespace std::chrono;
+#if 1
+   // Shorter times than in the default policy so that responses, to changes of
+   // loop region or speed slider or other such controls, don't lag too much
+   return { 0.05s, 0.05s, 0.25s };
+#else
+/*
+The old values, going very far back.
+
+There are old comments in the code about larger batches of work filling the
+queue with samples, to reduce CPU usage.  Maybe this doesn't matter with most
+modern machines, or maybe there will prove to be a need to choose the numbers
+more smartly than these hardcoded values.  Maybe we will need to figure out
+adaptiveness of the buffer size by detecting how long the work takes.  Maybe
+we can afford even smaller times.
+*/
    return { 4.0s, 4.0s, 10.0s };
+#endif
 }
 
 bool PlaybackPolicy::AllowSeek(PlaybackSchedule &)

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -625,6 +625,7 @@ public:
       rootSizer->Add(addEffectTutorialLink, 0, wxLEFT | wxRIGHT | wxEXPAND, 20);
 
       SetSizer(rootSizer.release());
+      SetMinSize({});
 
       Bind(EVT_MOVABLE_CONTROL_DRAG_STARTED, [dropHintLine](const MovableControlEvent& event)
       {

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -424,8 +424,7 @@ namespace
          auto initialSettings = access->Get();
          auto cleanup = EffectManager::Get().SetBatchProcessing(ID);
 
-         std::shared_ptr<EffectInstance> pInstance =
-            effectPlugin->MakeInstance(); // short-lived object
+         std::shared_ptr<EffectInstance> pInstance;
 
          // Like the call in EffectManager::PromptUser, but access causes
          // the necessary inter-thread communication of settings changes

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -311,7 +311,6 @@ namespace
          auto enableButton = safenew ThemedButtonWrapper<wxBitmapButton>(this, wxID_ANY, wxBitmap{}, wxDefaultPosition, wxDefaultSize, wxNO_BORDER);
          enableButton->SetBitmapIndex(bmpEffectOn);
          enableButton->SetBackgroundColorIndex(clrEffectListItemBackground);
-         enableButton->Bind(wxEVT_BUTTON, &RealtimeEffectControl::OnEnableButtonClicked, this);
          mEnableButton = enableButton;
 
          enableButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
@@ -456,14 +455,6 @@ namespace
 
          ShowSelectEffectMenu(mChangeButton, this);
          //TODO: replace effect
-      }
-
-      void OnEnableButtonClicked(wxCommandEvent&)
-      {
-         if(mEffectState == nullptr)
-            return;//not initialized
-
-         //TODO: implement
       }
 
       void OnPaint(wxPaintEvent&)

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -174,7 +174,7 @@ int Effect::ShowClientInterface(
 
 int Effect::ShowHostInterface(wxWindow &parent,
    const EffectDialogFactory &factory,
-   EffectInstance &instance, EffectSettingsAccess &access,
+   std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
    bool forceModal)
 {
    if (!IsInteractive())
@@ -197,7 +197,7 @@ int Effect::ShowHostInterface(wxWindow &parent,
    // populate it.  That factory function is called indirectly through a
    // std::function to avoid source code dependency cycles.
    EffectUIClientInterface *const client = this;
-   mHostUIDialog = factory(parent, *this, *client, instance, access);
+   mHostUIDialog = factory(parent, *this, *client, pInstance, access);
    if (!mHostUIDialog)
       return 0;
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -116,7 +116,7 @@ class AUDACITY_DLL_API Effect /* not final */
 
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectInstance &instance, EffectSettingsAccess &access,
+      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
       bool forceModal = false) override;
    bool SaveSettingsAsString(
       const EffectSettings &settings, wxString & parms) const override;

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -333,12 +333,13 @@ bool EffectManager::PromptUser(
 {
    bool result = false;
    if (auto effect = GetEffect(ID)) {
+      auto pInstance = effect->MakeInstance(); // short-lived object
       //! Show the effect dialog, only so that the user can choose settings,
       //! for instance to define a macro.
       if (const auto pSettings = GetDefaultSettings(ID))
          result = effect->ShowHostInterface(
             parent, factory,
-            *effect->MakeInstance(), // short-lived object
+            pInstance,
             *std::make_shared<SimpleEffectSettingsAccess>(*pSettings),
             effect->IsBatchProcessing() ) != 0;
       return result;

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -333,7 +333,7 @@ bool EffectManager::PromptUser(
 {
    bool result = false;
    if (auto effect = GetEffect(ID)) {
-      auto pInstance = effect->MakeInstance(); // short-lived object
+      std::shared_ptr<EffectInstance> pInstance;
       //! Show the effect dialog, only so that the user can choose settings,
       //! for instance to define a macro.
       if (const auto pSettings = GetDefaultSettings(ID))

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -203,7 +203,7 @@ bool EffectSettingsAccessTee::IsSameAs(
 
 EffectUIHost::EffectUIHost(wxWindow *parent,
    AudacityProject &project, EffectPlugin &effect,
-   EffectUIClientInterface &client, EffectInstance &instance,
+   EffectUIClientInterface &client, std::shared_ptr<EffectInstance> &pInstance,
    EffectSettingsAccess &access,
    const std::shared_ptr<RealtimeEffectState> &pPriorState)
 :  wxDialogWrapper(parent, wxID_ANY, effect.GetDefinition().GetName(),
@@ -213,7 +213,7 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
 , mClient{ client }
 // Grab a pointer to the instance object,
 // extending its lifetime while this remains:
-, mpInstance{ instance.shared_from_this() }
+, mpInstance{ pInstance }
 // Grab a pointer to the access object,
 // extending its lifetime while this remains:
 , mpGivenAccess{ access.shared_from_this() }
@@ -1280,7 +1280,7 @@ void EffectUIHost::CleanupRealtime()
 wxDialog *EffectUI::DialogFactory( wxWindow &parent,
    EffectPlugin &host,
    EffectUIClientInterface &client,
-   EffectInstance &instance,
+   std::shared_ptr<EffectInstance> &pInstance,
    EffectSettingsAccess &access)
 {
    // Make sure there is an associated project, whose lifetime will
@@ -1290,7 +1290,7 @@ wxDialog *EffectUI::DialogFactory( wxWindow &parent,
    if ( !project )
       return nullptr;
    Destroy_ptr<EffectUIHost> dlg{ safenew EffectUIHost{ &parent,
-      *project, host, client, instance, access } };
+      *project, host, client, pInstance, access } };
    dlg->InitializeRealtime();
    if (dlg->Initialize())
       // release() is safe because parent will own it

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -44,7 +44,7 @@ public:
    // constructors and destructors
    EffectUIHost(wxWindow *parent, AudacityProject &project,
       EffectPlugin &effect, EffectUIClientInterface &client,
-      EffectInstance &instance, EffectSettingsAccess &access,
+      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
       const std::shared_ptr<RealtimeEffectState> &pPriorState = {});
    virtual ~EffectUIHost();
 
@@ -154,7 +154,8 @@ namespace  EffectUI {
 
    AUDACITY_DLL_API
    wxDialog *DialogFactory( wxWindow &parent, EffectPlugin &host,
-      EffectUIClientInterface &client, EffectInstance &instance,
+      EffectUIClientInterface &client,
+      std::shared_ptr<EffectInstance> &pInstance,
       EffectSettingsAccess &access);
 
    /** Run an effect given the plugin ID */

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -42,9 +42,14 @@ class EffectUIHost final : public wxDialogWrapper
 {
 public:
    // constructors and destructors
+   /*
+    @param[out] pInstance may construct
+    (and then must call Init() with success), or leave null for failure
+    */
    EffectUIHost(wxWindow *parent, AudacityProject &project,
       EffectPlugin &effect, EffectUIClientInterface &client,
-      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
+      std::shared_ptr<EffectInstance> &pInstance,
+      EffectSettingsAccess &access,
       const std::shared_ptr<RealtimeEffectState> &pPriorState = {});
    virtual ~EffectUIHost();
 
@@ -53,10 +58,11 @@ public:
 
    int ShowModal() override;
 
-   void InitializeRealtime();
    bool Initialize();
 
 private:
+   std::shared_ptr<EffectInstance> InitializeInstance();
+
    wxPanel *BuildButtonBar( wxWindow *parent );
 
    void OnInitDialog(wxInitDialogEvent & evt);
@@ -97,8 +103,6 @@ private:
    wxWindow *const mParent;
    EffectPlugin &mEffectUIHost;
    EffectUIClientInterface &mClient;
-   //! @invariant not null
-   const std::shared_ptr<EffectInstance> mpInstance;
    //! @invariant not null
    const EffectPlugin::EffectSettingsAccessPtr mpGivenAccess;
    EffectPlugin::EffectSettingsAccessPtr mpAccess;
@@ -144,6 +148,8 @@ private:
    // Used only in an assertion
    bool mClosed{ false };
 #endif
+
+   const std::shared_ptr<EffectInstance> mpInstance;
 
    DECLARE_EVENT_TABLE()
 };

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -445,7 +445,7 @@ EffectType EffectNoiseReduction::GetType() const
  the framework for managing settings of other effects. */
 int EffectNoiseReduction::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &,
-   EffectInstance &, EffectSettingsAccess &access,
+   std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
    bool forceModal)
 {
    // to do: use forceModal correctly

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -448,6 +448,11 @@ int EffectNoiseReduction::ShowHostInterface(
    std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
    bool forceModal)
 {
+   // Assign the out parameter
+   pInstance = MakeInstance();
+   if (pInstance && !pInstance->Init())
+      pInstance.reset();
+
    // to do: use forceModal correctly
 
    // Doesn't use the factory but substitutes its own dialog

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -39,7 +39,7 @@ public:
 
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectInstance &instance, EffectSettingsAccess &access,
+      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
       bool forceModal = false) override;
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -164,6 +164,11 @@ int EffectNoiseRemoval::ShowHostInterface(
    std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
    bool forceModal )
 {
+   // Assign the out parameter
+   pInstance = MakeInstance();
+   if (pInstance && !pInstance->Init())
+      pInstance.reset();
+
    // to do: use forceModal correctly
    NoiseRemovalDialog dlog(this, access, &parent);
    dlog.mSensitivity = mSensitivity;

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -161,7 +161,7 @@ bool EffectNoiseRemoval::CheckWhetherSkipEffect(const EffectSettings &) const
  the framework for managing settings of other effects. */
 int EffectNoiseRemoval::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &,
-   EffectInstance &, EffectSettingsAccess &access,
+   std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
    bool forceModal )
 {
    // to do: use forceModal correctly

--- a/src/effects/NoiseRemoval.h
+++ b/src/effects/NoiseRemoval.h
@@ -55,7 +55,7 @@ public:
 
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectInstance &instance, EffectSettingsAccess &access,
+      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
       bool forceModal = false) override;
    bool Init() override;
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -76,12 +76,6 @@ const RealtimeEffectList &RealtimeEffectList::Get(const Track &track)
    return Get(const_cast<Track &>(track));
 }
 
-void RealtimeEffectList::Visit(StateVisitor func)
-{
-   for (auto &state : mStates)
-      func(*state, IsActive());
-}
-
 bool
 RealtimeEffectList::AddState(std::shared_ptr<RealtimeEffectState> pState)
 {

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -72,11 +72,18 @@ public:
    static RealtimeEffectList &Get(Track &track);
    static const RealtimeEffectList &Get(const Track &track);
 
-   using StateVisitor =
-      std::function<void(RealtimeEffectState &state, bool listIsActive)>;
+   // Type that state visitor functions would have for out-of-line definition
+   // of Visit
+   // using StateVisitor =
+      // std::function<void(RealtimeEffectState &state, bool listIsActive)> ;
 
    //! Apply the function to all states sequentially.
-   void Visit(StateVisitor func);
+   template<typename StateVisitor>
+   void Visit(const StateVisitor &func)
+   {
+      for (auto &state : mStates)
+         func(*state, IsActive());
+   }
 
    //! Use only in the main thread
    //! Returns true for success.

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -10,7 +10,6 @@
 
 
 #include "RealtimeEffectManager.h"
-#include "RealtimeEffectList.h"
 #include "RealtimeEffectState.h"
 
 #include <memory>
@@ -224,15 +223,6 @@ void RealtimeEffectManager::ProcessEnd(bool suspended) noexcept
    });
 }
 
-void RealtimeEffectManager::VisitGroup(Track &leader, StateVisitor func)
-{
-   // Call the function for each effect on the master list
-   RealtimeEffectList::Get(mProject).Visit(func);
-
-   // Call the function for each effect on the track list
-   RealtimeEffectList::Get(leader).Visit(func);
-}
-
 RealtimeEffectManager::
 AllListsLock::AllListsLock(RealtimeEffectManager *pManager)
    : mpManager{ pManager }
@@ -273,16 +263,6 @@ void RealtimeEffectManager::AllListsLock::Reset()
          RealtimeEffectList::Get(*leader).GetLock().unlock();
       mpManager = nullptr;
    }
-}
-
-void RealtimeEffectManager::VisitAll(StateVisitor func)
-{
-   // Call the function for each effect on the master list
-   RealtimeEffectList::Get(mProject).Visit(func);
-
-   // And all track lists
-   for (auto leader : mGroupLeaders)
-      RealtimeEffectList::Get(*leader).Visit(func);
 }
 
 std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -234,33 +234,41 @@ const EffectInstanceFactory *RealtimeEffectState::GetEffect()
    return mPlugin;
 }
 
-bool RealtimeEffectState::EnsureInstance(double rate)
+std::shared_ptr<EffectInstance>
+RealtimeEffectState::EnsureInstance(double rate)
 {
-   if (!mInstance) {
+   if (!mPlugin)
+      return {};
+
+   auto pInstance = mwInstance.lock();
+   if (!pInstance) {
       //! copying settings in the main thread while worker isn't yet running
       mWorkerSettings = mMainSettings;
       mLastActive = IsActive();
       
-      mInstance = mPlugin->MakeInstance();
-      if (!mInstance)
-         return false;
+      mwInstance = pInstance = mPlugin->MakeInstance();
+      if (!pInstance)
+         return {};
       
-      mInstance->SetSampleRate(rate);
+      pInstance->SetSampleRate(rate);
       
       // PRL: conserving pre-3.2.0 behavior, but I don't know why this arbitrary
       // number was important
-      mInstance->SetBlockSize(512);
+      pInstance->SetBlockSize(512);
       
-      return mInstance->RealtimeInitialize(mMainSettings);
+      if (!pInstance->RealtimeInitialize(mMainSettings))
+         return {};
+      return pInstance;
    }
-   mInstance->SetSampleRate(rate);
-   return true;
+   pInstance->SetSampleRate(rate);
+   return pInstance;
 }
 
-bool RealtimeEffectState::Initialize(double rate)
+std::shared_ptr<EffectInstance>
+RealtimeEffectState::Initialize(double rate)
 {
    if (!mPlugin)
-      return false;
+      return {};
 
    mCurrentProcessor = 0;
    mGroups.clear();
@@ -269,13 +277,15 @@ bool RealtimeEffectState::Initialize(double rate)
 
 //! Set up processors to be visited repeatedly in Process.
 /*! The iteration over channels in AddTrack and Process must be the same */
-bool RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
+std::shared_ptr<EffectInstance>
+RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
 {
-   if (!EnsureInstance(rate))
-      return false;
+   auto pInstance = EnsureInstance(rate);
+   if (!pInstance)
+      return {};
 
-   if (!mPlugin || !mInstance)
-      return false;
+   if (!mPlugin)
+      return {};
 
    auto ichans = chans;
    auto ochans = chans;
@@ -325,7 +335,7 @@ bool RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
       // Add a NEW processor
       // Pass reference to worker settings, not main -- such as, for connecting
       // Ladspa ports to the proper addresses.
-      if (mInstance->RealtimeAddProcessor(mWorkerSettings, gchans, rate))
+      if (pInstance->RealtimeAddProcessor(mWorkerSettings, gchans, rate))
          mCurrentProcessor++;
       else
          break;
@@ -333,9 +343,9 @@ bool RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
 
    if (mCurrentProcessor > first) {
       mGroups[&track] = first;
-      return true;
+      return pInstance;
    }
-   return false;
+   return {};
 }
 
 bool RealtimeEffectState::ProcessStart(bool running)
@@ -348,23 +358,24 @@ bool RealtimeEffectState::ProcessStart(bool running)
       pAccessState->WorkerRead();
    
    // Detect transitions of activity state
+   auto pInstance = mwInstance.lock();
    bool active = IsActive() && running;
    if (active != mLastActive) {
-      if (mInstance) {
+      if (pInstance) {
          bool success = active
-            ? mInstance->RealtimeResume()
-            : mInstance->RealtimeSuspend();
+            ? pInstance->RealtimeResume()
+            : pInstance->RealtimeSuspend();
          if (!success)
             return false;
       }
       mLastActive = active;
    }
 
-   if (!mInstance || !active)
+   if (!pInstance || !active)
       return false;
 
    // Assuming we are in a processing scope, use the worker settings
-   return mInstance->RealtimeProcessStart(mWorkerSettings);
+   return pInstance->RealtimeProcessStart(mWorkerSettings);
 }
 
 //! Visit the effect processors that were added in AddTrack
@@ -374,7 +385,8 @@ size_t RealtimeEffectState::Process(Track &track,
    const float *const *inbuf, float *const *outbuf, float *dummybuf,
    size_t numSamples)
 {
-   if (!mPlugin || !mInstance) {
+   auto pInstance = mwInstance.lock();
+   if (!mPlugin || !pInstance) {
       for (size_t ii = 0; ii < chans; ++ii)
          memcpy(outbuf[ii], inbuf[ii], numSamples * sizeof(float));
       return numSamples; // consider all samples to be trivially processed
@@ -469,12 +481,12 @@ size_t RealtimeEffectState::Process(Track &track,
 
       // Finally call the plugin to process the block
       len = 0;
-      const auto blockSize = mInstance->GetBlockSize();
+      const auto blockSize = pInstance->GetBlockSize();
       for (decltype(numSamples) block = 0; block < numSamples; block += blockSize)
       {
          auto cnt = std::min(numSamples - block, blockSize);
          // Assuming we are in a processing scope, use the worker settings
-         len += mInstance->RealtimeProcess(processor,
+         len += pInstance->RealtimeProcess(processor,
             mWorkerSettings, clientIn, clientOut, cnt);
 
          for (size_t i = 0 ; i < numAudioIn; i++)
@@ -495,9 +507,10 @@ size_t RealtimeEffectState::Process(Track &track,
 
 bool RealtimeEffectState::ProcessEnd(bool running)
 {
-   bool result = mInstance && IsActive() && running &&
+   auto pInstance = mwInstance.lock();
+   bool result = pInstance && IsActive() && running &&
       // Assuming we are in a processing scope, use the worker settings
-      mInstance->RealtimeProcessEnd(mWorkerSettings);
+      pInstance->RealtimeProcessEnd(mWorkerSettings);
 
    if (auto pAccessState = TestAccessState())
       // Always done, regardless of activity
@@ -523,11 +536,11 @@ bool RealtimeEffectState::Finalize() noexcept
    mGroups.clear();
    mCurrentProcessor = 0;
 
-   if (!mInstance)
+   auto pInstance = mwInstance.lock();
+   if (!pInstance)
       return false;
 
-   auto result = mInstance->RealtimeFinalize(mMainSettings);
-   mInstance.reset();
+   auto result = pInstance->RealtimeFinalize(mMainSettings);
    return result;
 }
 

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -137,9 +137,10 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
             const EffectSettings *pResult{};
             do {
                pResult = &pAccessState->MainRead();
-               if (pResult->extra.GetCounter() ==
+               if (!lastSettings.has_value() ||
+                   pResult->extra.GetCounter() ==
                    lastSettings.extra.GetCounter()) {
-                  // Echo is completed
+                  // First-time Get(), or else, echo is completed
                   break;
                }
                else if (auto pAudioIO = AudioIOBase::Get()

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -46,6 +46,12 @@ public:
    void SetID(const PluginID & id);
    const PluginID& GetID() const noexcept;
    const EffectInstanceFactory *GetEffect();
+
+   //! Expose a pointer to the state's instance (making one as needed).
+   /*!
+    @post `true` (no promise result is not null)
+    */
+   std::shared_ptr<EffectInstance> GetInstance();
    
    //! Main thread sets up for playback
    std::shared_ptr<EffectInstance> Initialize(double rate);
@@ -125,6 +131,7 @@ private:
 
    //! Stateful instance made by the plug-in
    std::weak_ptr<EffectInstance> mwInstance;
+   bool mInitialized{ false };
 
    // This must not be reset to nullptr while a worker thread is running.
    // In fact it is never yet reset to nullptr, before destruction.

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -46,13 +46,12 @@ public:
    void SetID(const PluginID & id);
    const PluginID& GetID() const noexcept;
    const EffectInstanceFactory *GetEffect();
-
-   bool EnsureInstance(double rate);
    
    //! Main thread sets up for playback
-   bool Initialize(double rate);
+   std::shared_ptr<EffectInstance> Initialize(double rate);
    //! Main thread sets up this state before adding it to lists
-   bool AddTrack(Track &track, unsigned chans, float rate);
+   std::shared_ptr<EffectInstance>
+   AddTrack(Track &track, unsigned chans, float rate);
    //! Worker thread begins a batch of samples
    /*! @param running means no pause or deactivation of containing list */
    bool ProcessStart(bool running);
@@ -88,6 +87,8 @@ public:
    std::shared_ptr<EffectSettingsAccess> GetAccess();
 
 private:
+   std::shared_ptr<EffectInstance> EnsureInstance(double rate);
+
    struct Access;
    struct AccessState;
 
@@ -123,7 +124,7 @@ private:
    wxString mParameters;  // Used only during deserialization
 
    //! Stateful instance made by the plug-in
-   std::shared_ptr<EffectInstance> mInstance;
+   std::weak_ptr<EffectInstance> mwInstance;
 
    // This must not be reset to nullptr while a worker thread is running.
    // In fact it is never yet reset to nullptr, before destruction.

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1053,13 +1053,14 @@ finish:
 
 int NyquistEffect::ShowHostInterface(
    wxWindow &parent, const EffectDialogFactory &factory,
-   EffectInstance &instance, EffectSettingsAccess &access, bool forceModal)
+   std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
+   bool forceModal)
 {
    int res = wxID_APPLY;
    if (!(Effect::TestUIFlags(EffectManager::kRepeatNyquistPrompt) && mIsPrompt)) {
       // Show the normal (prompt or effect) interface
       res = Effect::ShowHostInterface(
-         parent, factory, instance, access, forceModal);
+         parent, factory, pInstance, access, forceModal);
    }
 
 
@@ -1080,7 +1081,7 @@ int NyquistEffect::ShowHostInterface(
    // Must give effect its own settings to interpret, not those in access
    // Let's also give it its own instance
    auto newSettings = effect.MakeSettings();
-   auto newInstance = effect.MakeInstance();
+   auto pNewInstance = effect.MakeInstance();
    auto newAccess = std::make_shared<SimpleEffectSettingsAccess>(newSettings);
 
    if (IsBatchProcessing()) {
@@ -1092,7 +1093,7 @@ int NyquistEffect::ShowHostInterface(
 
       // Show the normal (prompt or effect) interface
       res = effect.ShowHostInterface(
-         parent, factory, *newInstance, *newAccess, forceModal);
+         parent, factory, pNewInstance, *newAccess, forceModal);
       if (res) {
          CommandParameters cp;
          effect.SaveSettings(newSettings, cp);
@@ -1103,7 +1104,7 @@ int NyquistEffect::ShowHostInterface(
       if (!factory)
          return 0;
       res = effect.ShowHostInterface(
-         parent, factory, *newInstance, *newAccess, false );
+         parent, factory, pNewInstance, *newAccess, false );
       if (!res)
          return 0;
 

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1069,7 +1069,7 @@ int NyquistEffect::ShowHostInterface(
 
    // We're done if the user clicked "Close", we are not the Nyquist Prompt,
    // or the program currently loaded into the prompt doesn't have a UI.
-   if (!res || !mIsPrompt || mControls.size() == 0)
+   if (!res || !mIsPrompt || mControls.size() == 0 || !pInstance)
       return res;
 
    // Nyquist prompt was OK, but gave us some magic ;control comments to
@@ -1115,6 +1115,9 @@ int NyquistEffect::ShowHostInterface(
          nyquistSettings.proxyDebug = this->mDebug;
       });
    }
+   if (!pNewInstance)
+      // Propagate the failure from nested ShowHostInterface
+      pInstance.reset();
    return res;
 }
 

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -120,7 +120,7 @@ public:
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    int ShowHostInterface( wxWindow &parent,
       const EffectDialogFactory &factory,
-      EffectInstance &instance, EffectSettingsAccess &access,
+      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
       bool forceModal = false) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)


### PR DESCRIPTION
Resolves: #3072
Resolves: #3073
Resolves: #3074
Resolves: #3123
Resolves: #2954

Fix a crash and a deadlock, both involving recent changes in RealtimeEffectState::Access, introduced at
ecc8de80

Fix inability make the sidebar narrower than the un-wrapped text message

Fix long lag in response to adjustment of sliders during preview of realtime effect

Fix initial enabled status of effects in the stack

Prepare to fix output metering by associating the effect dialog with the correct instance

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
