### PR TITLE
MP3 import based on libmpg123

### DIFF
--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -110,19 +110,37 @@ add_conan_lib(
 )
 
 add_conan_lib(
+   mpg123
+   mpg123/1.29.3
+   PKG_CONFIG "libmpg123"
+   OPTION_NAME libmpg123
+   INTERFACE_NAME MPG123::libmpg123
+   CONAN_OPTIONS
+      mpg123:shared=True
+      mpg123:network=False
+)
+
+if( USE_LIBMPG123 )
+   # If we are building against libmpg123, we need to drop
+   # the previos configuration, which may used libmad
+   set( USE_LIBMAD OFF CACHE INTERNAL "" FORCE )
+   set( ${_OPT}use_libmad "off" )
+else()
+   add_conan_lib(
+      libmad
+      libmad/0.15.2b-1@
+      OPTION_NAME libmad
+      PKG_CONFIG "mad >= 0.15.0b" # Ubuntu has broken PC file
+   )
+endif()
+
+add_conan_lib(
    libid3tag
    libid3tag/0.15.2b@audacity/stable
    OPTION_NAME libid3tag
    PKG_CONFIG "id3tag >= 0.15.0b" # Ubuntu has broken PC file
    CONAN_OPTIONS
       libid3tag:zlib=${id3tag_zlib}
-)
-
-add_conan_lib(
-   libmad
-   libmad/0.15.2b-1@
-   OPTION_NAME libmad
-   PKG_CONFIG "mad >= 0.15.0b" # Ubuntu has broken PC file
 )
 
 add_conan_lib(

--- a/linux/packages/arch/PKGBUILD
+++ b/linux/packages/arch/PKGBUILD
@@ -37,6 +37,7 @@ depends=(zlib
    freetype2
    fontconfig
    mesa
+   mpg123
 )
 
 makedepends=(

--- a/linux/packages/arch/dependencies.sh
+++ b/linux/packages/arch/dependencies.sh
@@ -40,6 +40,7 @@ deps=(
    freetype2
    fontconfig
    mesa
+   mpg123
 )
 
 pacman -Syu --noconfirm \

--- a/linux/packages/fedora34/audacity.spec
+++ b/linux/packages/fedora34/audacity.spec
@@ -61,6 +61,7 @@ BuildRequires: harfbuzz-devel
 BuildRequires: freetype-devel
 BuildRequires: fontconfig-devel
 BuildRequires: mesa-libEGL-devel
+BuildRequires: mpg123-devel
 
 Requires:      portaudio%{?_isa} >= 19-16
 

--- a/linux/packages/fedora34/dependencies.sh
+++ b/linux/packages/fedora34/dependencies.sh
@@ -52,6 +52,7 @@ deps=(
    freetype-devel
    fontconfig-devel
    mesa-libEGL-devel
+   mpg123-devel
 )
 
 dnf install -y \

--- a/linux/packages/ubuntu-20.04/debian/control
+++ b/linux/packages/ubuntu-20.04/debian/control
@@ -46,7 +46,8 @@ Build-Depends: cmake,
                libharfbuzz-dev,
                libfreetype6-dev,
                libfontconfig-dev,
-               libegl1-mesa-dev
+               libegl1-mesa-dev,
+               libmpg123-dev
 Homepage: https://www.audacityteam.org/
 Rules-Requires-Root: no
 

--- a/linux/packages/ubuntu-20.04/dependencies.sh
+++ b/linux/packages/ubuntu-20.04/dependencies.sh
@@ -60,6 +60,7 @@ deps=(
    libfreetype6-dev
    libfontconfig-dev
    libegl1-mesa-dev
+   libmpg123-dev
 )
 
 apt-get update

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -644,9 +644,11 @@ void AboutDialog::PopulateInformationPage( ShuttleGui & S )
       << wxT("<table>");   // start table of file formats supported
 
 
-   #ifdef USE_LIBMAD
+   #if defined(USE_LIBMAD)
    /* i18n-hint: This is what the library (libmad) does - imports MP3 files */
    AddBuildinfoRow(&informationStr, wxT("libmad"), XO("MP3 Importing"), enabled);
+   #elif defined(USE_LIBID3TAG)
+   AddBuildinfoRow(&informationStr, wxT("libmpg123"), XO("MP3 Importing"), enabled);
    #else
    AddBuildinfoRow(&informationStr, wxT("libmad"), XO("MP3 Importing"), disabled);
    #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -706,7 +706,7 @@ list( APPEND SOURCES
       >
 
       $<$<BOOL:${USE_LIBMAD}>:
-         import/ImportMP3.cpp
+         import/ImportMP3_MAD.cpp
       >
 
       $<$<AND:$<BOOL:${USE_LIBOGG}>,$<BOOL:${USE_LIBVORBIS}>>:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -709,6 +709,10 @@ list( APPEND SOURCES
          import/ImportMP3_MAD.cpp
       >
 
+      $<$<BOOL:${USE_LIBMPG123}>:
+         import/ImportMP3_MPG123.cpp
+      >
+
       $<$<AND:$<BOOL:${USE_LIBOGG}>,$<BOOL:${USE_LIBVORBIS}>>:
          import/ImportOGG.cpp
       >
@@ -1172,6 +1176,7 @@ list( APPEND LIBRARIES
       $<$<BOOL:${USE_LIBFLAC}>:FLAC::FLAC>
       $<$<BOOL:${USE_LIBFLAC}>:FLAC::FLAC++>
       $<$<BOOL:${USE_LIBMAD}>:libmad::libmad>
+      $<$<BOOL:${USE_LIBMPG123}>:MPG123::libmpg123>
       $<$<BOOL:${USE_LIBOGG}>:Ogg::ogg>
       $<$<BOOL:${USE_LIBVORBIS}>:Vorbis::vorbis>
       $<$<BOOL:${USE_LIBVORBIS}>:Vorbis::vorbisfile>
@@ -1374,7 +1379,7 @@ else()
          audio/x-flac
       )
    endif()
-   if( USE_LIBMAD )
+   if( USE_LIBMAD OR USE_LIBMPG123)
       list( APPEND MIMETYPES
          audio/mpeg
       )

--- a/src/audacity_config.h.in
+++ b/src/audacity_config.h.in
@@ -63,6 +63,9 @@
 /* Define if mp3 support is implemented with the libmad library */
 #cmakedefine USE_LIBMAD 1
 
+/* Define if mp3 support is implemented with the libmpg123 library */
+#cmakedefine USE_LIBMPG123 1
+
 /* Define if libtwolame (MP2 export) support should be enabled */
 #cmakedefine USE_LIBTWOLAME 1
 

--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -28,7 +28,7 @@ It's defined in Import.h
 
 \class Importer
 \brief Class which actually imports the auido, using functions defined
-in ImportPCM.cpp, ImportMP3.cpp, ImportOGG.cpp, ImportRawData.cpp,
+in ImportPCM.cpp, ImportMP3_*.cpp, ImportOGG.cpp, ImportRawData.cpp,
 ImportLOF.cpp, and ImportAUP.cpp.
 
 *//******************************************************************/

--- a/src/import/ImportMP3_MAD.cpp
+++ b/src/import/ImportMP3_MAD.cpp
@@ -2,7 +2,7 @@
 
   Audacity: A Digital Audio Editor
 
-  ImportMP3.cpp
+  ImportMP3_MAD.cpp
 
   Joshua Haberman
   Leland Lucius
@@ -474,7 +474,7 @@ void MP3ImportFileHandle::CheckLyrics()
       size_t len = offset - pos;
 
       // Ensure file is positioned to start of (possible) lyrics
-      if (mFile.Seek(pos, wxFromStart) == wxInvalidOffset || mFile.Error())  
+      if (mFile.Seek(pos, wxFromStart) == wxInvalidOffset || mFile.Error())
       {
          return;
       }
@@ -500,7 +500,7 @@ void MP3ImportFileHandle::CheckLyrics()
    else if (memcmp(mInputBuffer, "LYRICS200", 9) == 0)
    {
       // Ensure file is positioned to start of (possible) lyrics
-      if (mFile.Seek(-15, wxFromCurrent) == wxInvalidOffset || mFile.Error())  
+      if (mFile.Seek(-15, wxFromCurrent) == wxInvalidOffset || mFile.Error())
       {
          return;
       }
@@ -562,7 +562,7 @@ void MP3ImportFileHandle::CheckID3V2Tags(bool atEnd)
 bool MP3ImportFileHandle::CheckMP3()
 {
    wxFileOffset savedPos = mFilePos;
-   
+
    // Ensure file is positioned to start of 1st mp3 frame
    if (mFile.Seek(mFilePos, wxFromStart) == wxInvalidOffset || mFile.Error())
    {
@@ -817,7 +817,7 @@ void MP3ImportFileHandle::LoadID3(Tags *tags)
          ustr = id3_field_getstrings(&frame->fields[1], 0);
       }
 
-      // Convert the value 
+      // Convert the value
       if (ustr)
       {
          v = toString(ustr);

--- a/src/import/ImportMP3_MPG123.cpp
+++ b/src/import/ImportMP3_MPG123.cpp
@@ -1,0 +1,475 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  ImportMP3_MPG123.cpp
+
+  Dmitry Vedenko
+
+*/
+
+#include <wx/defs.h>
+#include <cstddef>
+
+#include "Import.h"
+#include "BasicUI.h"
+#include "ImportPlugin.h"
+#include "Project.h"
+
+#define DESC XO("MP3 files")
+
+#include <wx/file.h>
+#include <wx/string.h>
+#include <wx/log.h>
+
+#include <mpg123.h>
+
+#include "Prefs.h"
+#include "../Tags.h"
+#include "../WaveTrack.h"
+#include "../widgets/AudacityMessageBox.h"
+#include "../widgets/ProgressDialog.h"
+
+#include "CodeConversions.h"
+
+namespace
+{
+
+static const auto exts = { wxT("mp3"), wxT("mp2"), wxT("mpa") };
+
+class MP3ImportPlugin final : public ImportPlugin
+{
+public:
+   MP3ImportPlugin()
+       : ImportPlugin(
+            FileExtensions(exts.begin(), exts.end()))
+   {
+#if MPG123_API_VERSION < 46
+      // Newer versions of the library don't need that anymore, but it is safe
+      // to have the no-op call present for compatibility with old versions.
+      mpg123_init();
+#endif
+   }
+
+   wxString GetPluginStringID() override
+   {
+      return wxT("libmpg123");
+   }
+
+   TranslatableString GetPluginFormatDescription() override
+   {
+      return DESC;
+   }
+
+   std::unique_ptr<ImportFileHandle> Open(const FilePath &Filename, AudacityProject*) override;
+}; // class MP3ImportPlugin
+
+using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
+
+class MP3ImportFileHandle final : public ImportFileHandle
+{
+public:
+   MP3ImportFileHandle(const FilePath &filename);
+   ~MP3ImportFileHandle();
+
+   TranslatableString GetFileDescription() override;
+   ByteCount GetFileUncompressedBytes() override;
+   ProgressResult Import(WaveTrackFactory *trackFactory, TrackHolders &outTracks, Tags *tags) override;
+
+   void ReadTags(Tags* tags);
+
+   wxInt32 GetStreamCount() override;
+   const TranslatableStrings &GetStreamInfo() override;
+   void SetStreamUsage(wxInt32 StreamID, bool Use) override;
+
+private:
+   bool Open();
+
+private:
+   static ptrdiff_t ReadCallback(void* handle, void* buffer, size_t size);
+   static off_t SeekCallback(void* handle, off_t offset, int whence);
+
+   wxFile mFile;
+   wxFileOffset mFileLen { 0 };
+
+   WaveTrackFactory* mTrackFactory { nullptr };
+   NewChannelGroup mChannels;
+   unsigned mNumChannels { 0 };
+
+   ProgressResult mUpdateResult { ProgressResult::Success };
+
+   mpg123_handle* mHandle { nullptr };
+
+   friend MP3ImportPlugin;
+}; // class MP3ImportFileHandle
+
+std::unique_ptr<ImportFileHandle> MP3ImportPlugin::Open(
+   const FilePath &Filename, AudacityProject *)
+{
+   auto handle = std::make_unique<MP3ImportFileHandle>(Filename);
+
+   if (!handle->Open())
+      return nullptr;
+
+   return handle;
+}
+
+static Importer::RegisteredImportPlugin registered
+{
+   "MP3",
+   std::make_unique<MP3ImportPlugin>()
+};
+
+// ============================================================================
+// MP3ImportFileHandle
+// ============================================================================
+
+MP3ImportFileHandle::MP3ImportFileHandle(const FilePath& filename)
+    : ImportFileHandle(filename)
+{
+   int errorCode = MPG123_OK;
+   mHandle = mpg123_new(nullptr, &errorCode);
+
+   if (errorCode != MPG123_OK)
+   {
+      wxLogError(
+         "Failed to create MPG123 handle: %s",
+         mpg123_plain_strerror(errorCode));
+
+      mHandle = nullptr;
+
+      return;
+   }
+
+   errorCode = mpg123_replace_reader_handle(
+      mHandle, ReadCallback, SeekCallback, nullptr);
+
+   if (errorCode != MPG123_OK)
+   {
+      wxLogError(
+         "Failed to set reader on the MPG123 handle: %s",
+         mpg123_plain_strerror(errorCode));
+
+      mpg123_delete(mHandle);
+      mHandle = nullptr;
+   }
+
+   // We force mpg123 to decode into floats
+   mpg123_param(mHandle, MPG123_FLAGS, MPG123_FORCE_FLOAT, 0.0);
+
+   if (errorCode != MPG123_OK)
+   {
+      wxLogError(
+         "Failed to set options on the MPG123 handle",
+         mpg123_plain_strerror(errorCode));
+
+      mpg123_delete(mHandle);
+      mHandle = nullptr;
+   }
+}
+
+MP3ImportFileHandle::~MP3ImportFileHandle()
+{
+   // nullptr is a valid input for the mpg123_delete
+   mpg123_delete(mHandle);
+}
+
+TranslatableString MP3ImportFileHandle::GetFileDescription()
+{
+   return DESC;
+}
+
+auto MP3ImportFileHandle::GetFileUncompressedBytes() -> ByteCount
+{
+   // We have to parse the file first using mpg123_scan,
+   // we do not want to do that before the import starts.
+   return 0;
+}
+
+wxInt32 MP3ImportFileHandle::GetStreamCount()
+{
+   return 1;
+}
+
+const TranslatableStrings &MP3ImportFileHandle::GetStreamInfo()
+{
+   static TranslatableStrings empty;
+   return empty;
+}
+
+void MP3ImportFileHandle::SetStreamUsage(wxInt32 WXUNUSED(StreamID), bool WXUNUSED(Use))
+{
+}
+
+ProgressResult MP3ImportFileHandle::Import(WaveTrackFactory *trackFactory,
+                                           TrackHolders &outTracks,
+                                           Tags *tags)
+{
+   auto finalAction = finally([handle = mHandle]() { mpg123_close(handle); });
+
+   outTracks.clear();
+   mTrackFactory = trackFactory;
+
+   CreateProgress();
+
+   int ret = mpg123_scan(mHandle);
+
+   if (ret != MPG123_OK)
+   {
+      wxLogError(
+         "Failed to scan MP3 file: %s", mpg123_plain_strerror(ret));
+
+      return ProgressResult::Failed;
+   }
+
+   long long framesCount = mpg123_framelength(mHandle);
+
+   mUpdateResult = mProgress->Update(0ll, framesCount);
+
+   if (mUpdateResult == ProgressResult::Cancelled)
+      return ProgressResult::Cancelled;
+
+   off_t frameIndex { 0 };
+   unsigned char* data { nullptr };
+   size_t dataSize { 0 };
+
+   int encoding = MPG123_ENC_FLOAT_32;
+
+   std::vector<float> conversionBuffer;
+
+   while ((ret = mpg123_decode_frame(mHandle, &frameIndex, &data, &dataSize)) ==
+                 MPG123_OK ||
+          ret == MPG123_NEW_FORMAT)
+   {
+      mUpdateResult = mProgress->Update(
+         static_cast<long long>(frameIndex), framesCount);
+
+      if (mUpdateResult == ProgressResult::Cancelled)
+         return ProgressResult::Cancelled;
+
+      if (ret == MPG123_NEW_FORMAT)
+      {
+         long rate;
+         int channels;
+         mpg123_getformat(mHandle, &rate, &channels, &encoding);
+
+         mNumChannels = channels == MPG123_MONO ? 1 : 2;
+         mChannels.resize(mNumChannels);
+
+         if (encoding != MPG123_ENC_FLOAT_32 && encoding != MPG123_ENC_FLOAT_64)
+         {
+            wxLogError("MPG123 returned unexpected encoding");
+
+            return ProgressResult::Failed;
+         }
+
+         for (unsigned i = 0; i < mNumChannels; ++i)
+            mChannels[i] = NewWaveTrack(*mTrackFactory, floatSample, rate);
+
+         continue;
+      }
+
+      constSamplePtr samples = reinterpret_cast<constSamplePtr>(data);
+      const size_t samplesCount = dataSize / sizeof(float) / mNumChannels;
+
+      // libmpg123 picks up the format based on some "internal" precision.
+      // This case is not expected to happen
+      if (encoding == MPG123_ENC_FLOAT_64)
+      {
+         conversionBuffer.resize(samplesCount * mNumChannels);
+
+         for (size_t sampleIndex = 0; sampleIndex < conversionBuffer.size();
+              ++sampleIndex)
+         {
+            conversionBuffer[sampleIndex] = static_cast<float>(
+               reinterpret_cast<const double*>(data)[sampleIndex]);
+         }
+
+         samples = reinterpret_cast<constSamplePtr>(conversionBuffer.data());
+      }
+      // Just copy the interleaved data to the channels
+      for (unsigned channel = 0; channel < mNumChannels; ++channel)
+      {
+         mChannels[channel]->Append(
+            samples + sizeof(float) * channel, floatSample, samplesCount,
+            mNumChannels);
+      }
+   }
+
+   if (ret != MPG123_DONE)
+   {
+      wxLogError(
+         "Failed to decode MP3 file: %s", mpg123_plain_strerror(ret));
+
+      return ProgressResult::Failed;
+   }
+
+   // Flush and trim the channels
+   for (const auto &channel : mChannels)
+      channel->Flush();
+
+   // Copy the WaveTrack pointers into the Track pointer list that
+   // we are expected to fill
+   outTracks.push_back(std::move(mChannels));
+
+   ReadTags(tags);
+
+   return mUpdateResult;
+}
+
+void MP3ImportFileHandle::ReadTags(Tags* tags)
+{
+   mpg123_id3v1* v1;
+   mpg123_id3v2* v2;
+   int meta;
+
+   meta = mpg123_meta_check(mHandle);
+
+   if (meta & MPG123_ID3 && mpg123_id3(mHandle, &v1, &v2) == MPG123_OK)
+   {
+      if (v2 != nullptr && v2->title != nullptr && v2->title->fill > 0)
+         tags->SetTag(TAG_TITLE, audacity::ToWXString(v2->title->p));
+      else if (v1 != nullptr && v1->title[0] != '\0')
+         tags->SetTag(TAG_TITLE, audacity::ToWXString(v1->title));
+
+      if (v2 != nullptr && v2->artist != nullptr && v2->artist->fill > 0)
+         tags->SetTag(TAG_ARTIST, audacity::ToWXString(v2->artist->p));
+      else if (v1 != nullptr && v1->artist[0] != '\0')
+         tags->SetTag(TAG_ARTIST, audacity::ToWXString(v1->artist));
+
+      if (v2 != nullptr && v2->album != nullptr && v2->album->fill > 0)
+         tags->SetTag(TAG_ALBUM, audacity::ToWXString(v2->album->p));
+      else if (v1 != nullptr && v1->album[0] != '\0')
+         tags->SetTag(TAG_ALBUM, audacity::ToWXString(v1->album));
+
+      if (v2 != nullptr && v2->year != nullptr && v2->year->fill > 0)
+         tags->SetTag(TAG_YEAR, audacity::ToWXString(v2->year->p));
+      else if (v1 != nullptr && v1->year[0] != '\0')
+         tags->SetTag(TAG_YEAR, audacity::ToWXString(std::string(v1->year, 4)));
+
+      // ID2V2 genre can be quite complex:
+      // (from https://id3.org/id3v2.3.0)
+      // References to the ID3v1 genres can be made by, as first byte, enter
+      // "(" followed by a number from the genres list (appendix A) and ended
+      // with a ")" character. This is optionally followed by a refinement,
+      // e.g. "(21)" or "(4)Eurodisco". Several references can be made in the
+      // same frame, e.g. "(51)(39)". However, Audacity only supports one
+      // genre, so we just skip ( a parse the number afterwards.
+      if (v2 != nullptr && v2->genre != nullptr && v2->genre->fill > 0)
+         tags->SetTag(TAG_GENRE, tags->GetGenre(std::stoi(v2->genre->p + 1)));
+      else if (v1 != nullptr)
+         tags->SetTag(TAG_GENRE, tags->GetGenre(v1->genre));
+
+      if (v2 != nullptr && v2->comment != nullptr && v2->comment->fill > 0)
+         tags->SetTag(TAG_COMMENTS, audacity::ToWXString(v2->comment->p));
+      else if (v1 != nullptr && v1->comment[0] != '\0')
+         tags->SetTag(TAG_COMMENTS, audacity::ToWXString(v1->comment));
+
+      if (v2 != nullptr)
+      {
+         for (size_t i = 0; i < v2->comments; ++i)
+         {
+            if (v2->comment_list[i].text.fill == 0)
+               continue;
+
+            tags->SetTag(
+               audacity::ToWXString(std::string(v2->comment_list[i].id, 4)),
+               audacity::ToWXString(v2->comment_list[i].text.p));
+         }
+
+         for (size_t i = 0; i < v2->extras; ++i)
+         {
+            if (v2->extra[i].text.fill == 0)
+               continue;
+
+            tags->SetTag(
+               audacity::ToWXString(std::string(v2->extra[i].id, 4)),
+               audacity::ToWXString(v2->extra[i].text.p));
+         }
+
+         // libmpg123 does not parse TRCK tag, we have to do it ourselves
+         for (size_t i = 0; i < v2->texts; ++i)
+         {
+            if (memcmp(v2->text[i].id, "TRCK", 4) == 0)
+            {
+               tags->SetTag(
+                  TAG_TRACK, audacity::ToWXString(v2->text[i].text.p));
+            }
+         }
+      }
+   }
+}
+
+bool MP3ImportFileHandle::Open()
+{
+   if (mHandle == nullptr)
+      return false;
+
+   // Open the file
+   if (!mFile.Open(mFilename))
+   {
+      return false;
+   }
+
+   // Get the length of the file
+   mFileLen = mFile.Seek(0, wxFromEnd);
+
+   if (mFileLen == wxInvalidOffset || mFile.Error())
+   {
+      mFile.Close();
+      return false;
+   }
+
+   if (mFile.Seek(0, wxFromStart) == wxInvalidOffset || mFile.Error())
+   {
+      mFile.Close();
+      return false;
+   }
+
+   // Check if file is an MP3
+   auto errorCode = mpg123_open_handle(mHandle, this);
+
+   if (errorCode != MPG123_OK)
+   {
+      wxLogError(
+         "Failed to open MP3 file: %s", mpg123_plain_strerror(errorCode));
+
+      return false;
+   }
+
+   return true;
+}
+
+ptrdiff_t MP3ImportFileHandle::ReadCallback(
+   void* handle, void* buffer, size_t size)
+{
+   return static_cast<MP3ImportFileHandle*>(handle)->mFile.Read(buffer, size);
+}
+
+wxSeekMode GetWXSeekMode(int whence)
+{
+   switch (whence)
+   {
+   case SEEK_SET:
+      return wxFromStart;
+   case SEEK_CUR:
+      return wxFromCurrent;
+   case SEEK_END:
+      return wxFromEnd;
+   default:
+      // We have covered all the lseek whence modes defined by POSIX
+      // so this branch should not be reachable
+      assert(false);
+      return wxFromStart;
+   }
+}
+
+off_t MP3ImportFileHandle::SeekCallback(
+   void* handle, off_t offset, int whence)
+{
+   return static_cast<MP3ImportFileHandle*>(handle)->mFile.Seek(
+      offset, GetWXSeekMode(whence));
+}
+
+} // namespace


### PR DESCRIPTION
Resolves: #2236 
Resolves: #2634 
Resolves: #3029

Audacity uses `libmad` to import MP3 files. It seems that this library struggles to play some allegedly valid mp3 files.
Similar behavior is observed when using `madplay`.

This PR introduces an alternative MP3 importer, based on `libmpg123`, which is known to be used by major software, such as VLC.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
