### PR TITLE
issue #3084: Audio setup toolbar menu: no access keys

### DIFF
--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -267,18 +267,18 @@ void AudioSetupToolBar::OnAudioSetup(wxCommandEvent& WXUNUSED(evt))
 
    wxMenu menu;
 
-   AppendSubMenu(menu, mHost, "Host");
+   AppendSubMenu(menu, mHost, "&Host");
    menu.AppendSeparator();
 
-   AppendSubMenu(menu, mOutput, "Playback Device");
+   AppendSubMenu(menu, mOutput, "&Playback Device");
    menu.AppendSeparator();
 
-   AppendSubMenu(menu, mInput, "Recording Device");
+   AppendSubMenu(menu, mInput, "&Recording Device");
    menu.AppendSeparator();
 
-   AppendSubMenu(menu, mInputChannels, "Recording Channels");
+   AppendSubMenu(menu, mInputChannels, "Recording &Channels");
    menu.AppendSeparator();
-   menu.Append(kAudioSettings, _("Audio Settings..."));
+   menu.Append(kAudioSettings, _("&Audio Settings..."));
 
    menu.Bind(wxEVT_MENU_CLOSE, [this](auto&) { mAudioSetup->PopUp(); });
    menu.Bind(wxEVT_MENU, &AudioSetupToolBar::OnMenu, this);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/3084

Audio setup toolbar: menu items do not have access keys

Fix: add access keys


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
