### PR TITLE
Use std::uncaught_exceptions where possible

### DIFF
--- a/libraries/lib-exceptions/AudacityException.cpp
+++ b/libraries/lib-exceptions/AudacityException.cpp
@@ -87,7 +87,7 @@ void MessageBoxException::DelayedHandlerAction()
       // displays its message.  We assume that multiple messages have a
       // common cause such as exhaustion of disk space so that the others
       // give the user no useful added information.
-      
+
       using namespace BasicUI;
       if ( wxAtomicDec( sOutstandingMessages ) == 0 ) {
          if (exceptionType != ExceptionType::Internal

--- a/libraries/lib-exceptions/CMakeLists.txt
+++ b/libraries/lib-exceptions/CMakeLists.txt
@@ -29,6 +29,14 @@ set( LIBRARIES
    PRIVATE
    wxBase
 )
+
+if( APPLE AND MIN_MACOS_VERSION VERSION_LESS "10.12")
+   set( DEFINITIONS
+      PRIVATE
+         -DUNCAUGHT_EXCEPTIONS_UNAVAILABLE
+   )
+endif()
+
 audacity_library( lib-exceptions "${SOURCES}" "${LIBRARIES}"
-   "" ""
+   "${DEFINITIONS}" ""
 )


### PR DESCRIPTION
`std::uncaught_exception` was deprecated in C++17, however it is only available on macOS 10.12 or later.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
