### PR TITLE
Fixes the libmpg123.dylib availability on macOS

### DIFF
--- a/cmake-proxies/cmake-modules/CopyLibs.cmake
+++ b/cmake-proxies/cmake-modules/CopyLibs.cmake
@@ -61,14 +61,20 @@ function( gather_libs src )
 
       get_filename_component(dir ${CMAKE_SCRIPT_MODE_FILE} DIRECTORY)
 
-      execute_process( COMMAND  
-         python3 
+      execute_process( COMMAND
+         python3
          "${dir}/../../scripts/build/macOS/fixup_libs.py"
-         -i ${WXWIN} 
-         -o ${DST} 
-         ${src} 
+         -i ${WXWIN}
+         -o ${DST}
+         ${src}
          ECHO_OUTPUT_VARIABLE
+         RESULT_VARIABLE
+              fixup_status
       )
+
+      if(NOT fixup_status EQUAL 0)
+         message(FATAL_ERROR "fixup_status failed with code ${fixup_status}")
+      endif()
    elseif( CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" )
       message(STATUS "Executing LD_LIBRARY_PATH='${WXWIN}' ldd ${src}")
 

--- a/scripts/build/macOS/fixup_libs.py
+++ b/scripts/build/macOS/fixup_libs.py
@@ -21,6 +21,9 @@ class OtoolRunner:
 
         return None
 
+    def _is_system_lib(self, path):
+        return path.startswith('/System/Library/') or path.startswith('/usr/lib/')
+
     def run(self, file):
         if file in self.cache:
             return self.cache[file]
@@ -41,7 +44,7 @@ class OtoolRunner:
                 m = re.match(r'\s+(.*)\s+\(', line)
                 if m:
                     lib_line = m.group(1)
-                    if lib_line.startswith('@') or not pathlib.Path(lib_line).is_absolute():
+                    if lib_line.startswith('@') or not self._is_system_lib(lib_line):
                         name = lib_line.split('/')[-1]
 
                         if name != fileName:


### PR DESCRIPTION
For some reason libmpeg123 was linked into the binary using the absolute path, which tricked `fixup_libs.py` script to consider it to be a system library. This is now fixed.

The first commit fixes random failures of `install_name_tool` on the latest macOS running on AppleSilicon.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
