### PR TITLE
A new way to read user locale on macOS

### DIFF
--- a/libraries/lib-strings/Languages.cpp
+++ b/libraries/lib-strings/Languages.cpp
@@ -74,7 +74,7 @@ static bool TranslationExists(const FilePaths &pathList, wxString code)
 }
 
 #ifdef __WXMAC__
-#include <CoreFoundation/CFLocale.h>
+#include <CoreFoundation/CFPreferences.h>
 #include <wx/osx/core/cfstring.h>
 #endif
 
@@ -87,32 +87,35 @@ wxString GetSystemLanguageCode(const FilePaths &pathList)
 
    GetLanguages(pathList, langCodes, langNames);
 
-   int sysLang = wxLocale::GetSystemLanguage();
-
    const wxLanguageInfo *info;
 
 #ifdef __WXMAC__
-   // PRL: Bug 1227, system language on Mac may not be right because wxW3 is
-   // dependent on country code too in wxLocale::GetSystemLanguage().
+   // https://github.com/audacity/audacity/issues/2493
+   // It was observed, that macOS can have multiple `system default` languages,
+   // depending on the application rather than the user preferences.
+   // As a workaround, let's query the locale preferences for the application.
+   const wxCFStringRef appleLocale((CFStringRef)CFPreferencesCopyAppValue(CFSTR("AppleLocale"),
+                             kCFPreferencesCurrentApplication));
 
-   if (sysLang == wxLANGUAGE_UNKNOWN)
+   const auto localeString = appleLocale.AsString();
+   // AppleLocale has `Apple` locale format, but let us try our luck
+   // and pass it FindLanguageInfo, so we can get the best possible match.
+   info = wxLocale::FindLanguageInfo(localeString);
+
+   if (info == nullptr)
    {
-      // wxW3 did a too-specific lookup of language and country, when
-      // there is nothing for that combination; try it by language alone.
-
-      // The following lines are cribbed from that function.
-      wxCFRef<CFLocaleRef> userLocaleRef(CFLocaleCopyCurrent());
-      wxCFStringRef str(wxCFRetain((CFStringRef)CFLocaleGetValue(userLocaleRef, kCFLocaleLanguageCode)));
-      auto lang = str.AsString();
-
-      // Now avoid wxLocale::GetLanguageInfo(), instead calling:
-      info = wxLocale::FindLanguageInfo(lang);
+      // Full match has failed, lets match the language code only.
+      // wxLocale expects a two symbol code
+      wxString langCode = localeString.Left(2);
+      info = wxLocale::FindLanguageInfo(langCode);
    }
-   else
-#endif
+#else
    {
+
+      const auto sysLang = wxLocale::GetSystemLanguage();
       info = wxLocale::GetLanguageInfo(sysLang);
    }
+#endif
 
    if (info) {
       wxString fullCode = info->CanonicalName;
@@ -227,7 +230,7 @@ void GetLanguages( FilePaths pathList,
 #endif
 
    // For each language in our list we look for a corresponding entry in
-   // wxLocale.  
+   // wxLocale.
    for ( auto end = localLanguageName.end(), i = localLanguageName.begin();
       i != end; ++i )
    {

--- a/scripts/build/macOS/build_universal.sh
+++ b/scripts/build/macOS/build_universal.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+buildDirectory=$1
+buildType=$2
+
+scriptLocation=$(dirname "$(readlink -f "$0")")
+sourceLocation=$(readlink -f "$scriptLocation/../../..")
+
+cmake -B "${buildDirectory}/x64" -S "${sourceLocation}" -DCMAKE_BUILD_TYPE="${buildType}" -DCMAKE_CONFIGURATION_TYPES="${buildType}" -DMACOS_ARCHITECTURE=x86_64 -G Xcode
+cmake --build "${buildDirectory}/x64" --config "${buildType}"
+
+cmake -B "${buildDirectory}/arm64" -S "${sourceLocation}" -DCMAKE_BUILD_TYPE="${buildType}" -DCMAKE_CONFIGURATION_TYPES="${buildType}" -DMACOS_ARCHITECTURE=arm64 -G Xcode -DIMAGE_COMPILER_EXECUTABLE="${buildDirectory}/x64/utils/${buildType}/image-compiler"
+cmake --build "${buildDirectory}/arm64" --config "${buildType}"
+
+rm -Rf "${buildDirectory}/Audacity.app"
+cp -R "${buildDirectory}/x64/bin/${buildType}" "${buildDirectory}"
+
+lipo_dir() {
+    local dir="$1"
+    local filter="$2"
+
+    local x64dir="${buildDirectory}/x64/bin/${buildType}/Audacity.app/Contents/${dir}"
+    local armdir="${buildDirectory}/arm64/bin/${buildType}/Audacity.app/Contents/${dir}"
+    local outdir="${buildDirectory}/${buildType}/Audacity.app/Contents/${dir}"
+
+    for filename in ${outdir}/${filter}; do
+        [ -e "${filename}" ] || continue
+        local baseName=$(basename "${filename}")
+        echo "Processing ${baseName}"
+        lipo -create "${x64dir}/${baseName}" "${armdir}/${baseName}" -output "${outdir}/${baseName}"
+    done
+}
+
+lipo_dir "MacOS" "*"
+lipo_dir "Frameworks" "*.dylib"
+lipo_dir "modules" "*.so"


### PR DESCRIPTION
Resolves: #2493 

It was observed, that for some undiscovered reason macOS can different `System Default` languages based  on application alone.

This issue affects only the builds made by `audacity/audacity` CI. Comparing the builds shows, that there is no metadata difference. Three binaries are different, but it seems that the reasons is that Audacity build is not reproducible.

As a workaround the system preferences are read, which seem to provide a consistent value. Apple used a similar approach internally, but they claim that the performance is not good enough for tight loops. This is clearly not the case for Audacity

<img width="780" alt="Screenshot 2022-06-22 at 17 54 07" src="https://user-images.githubusercontent.com/2660628/175278835-9b938432-e9dd-4200-8bcb-ce0026f80946.png">
<img width="780" alt="Screenshot 2022-06-22 at 17 53 53" src="https://user-images.githubusercontent.com/2660628/175278842-6c18134a-9e1e-47c4-9c97-faec2fd7d692.png">

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:

- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
