### PR TITLE
Dont set sample rate

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -117,7 +117,7 @@ bool EffectInstance::Init()
    return true;
 }
 
-bool EffectInstance::RealtimeInitialize(EffectSettings &)
+bool EffectInstance::RealtimeInitialize(EffectSettings &, double)
 {
    return false;
 }

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -175,13 +175,6 @@ size_t EffectInstanceWithBlockSize::SetBlockSize(size_t maxBlockSize)
    return (mBlockSize = maxBlockSize);
 }
 
-EffectInstanceWithSampleRate::~EffectInstanceWithSampleRate() = default;
-
-void EffectInstanceWithSampleRate::SetSampleRate(double rate)
-{
-   mSampleRate = rate;
-}
-
 EffectInstanceFactory::~EffectInstanceFactory() = default;
 
 int EffectInstanceFactory::GetMidiInCount() const

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -391,7 +391,7 @@ public:
     Other member functions related to realtime return true or zero, but will not
     be called, unless a derived class overrides RealtimeInitialize.
     */
-   virtual bool RealtimeInitialize(EffectSettings &settings);
+   virtual bool RealtimeInitialize(EffectSettings &settings, double sampleRate);
 
    /*!
     @return success

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -377,8 +377,6 @@ public:
     */
    virtual bool Process(EffectSettings &settings) = 0;
 
-   virtual void SetSampleRate(double rate) = 0;
-
    virtual size_t GetBlockSize() const = 0;
 
    // Suggest a block size, but the return is the size that was really set:
@@ -454,17 +452,6 @@ public:
    size_t SetBlockSize(size_t maxBlockSize) override;
 protected:
    size_t mBlockSize{ 0 };
-};
-
-//! Inherit to add a state variable to an EffectInstance subclass
-class COMPONENTS_API EffectInstanceWithSampleRate
-   : public virtual EffectInstance
-{
-public:
-   ~EffectInstanceWithSampleRate() override;
-   void SetSampleRate(double rate) override;
-protected:
-   double mSampleRate{ 0 };
 };
 
 /***************************************************************************//**

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -138,13 +138,13 @@ AudioIO *AudioIO::Get()
 struct AudioIoCallback::TransportState {
    TransportState(std::weak_ptr<AudacityProject> wOwningProject,
       const WaveTrackArray &playbackTracks,
-      unsigned numPlaybackChannels, double rate)
+      unsigned numPlaybackChannels, double sampleRate)
    {
       if (auto pOwningProject = wOwningProject.lock();
           pOwningProject && numPlaybackChannels > 0) {
          // Setup for realtime playback at the rate of the realtime
          // stream, not the rate of the track.
-         mpRealtimeInitialization.emplace(move(wOwningProject), rate);
+         mpRealtimeInitialization.emplace(move(wOwningProject), sampleRate);
          // The following adds a new effect processor for each logical track.
          for (size_t i = 0, cnt = playbackTracks.size(); i < cnt;) {
             // An array of non-nulls only should be given to us
@@ -155,8 +155,8 @@ struct AudioIoCallback::TransportState {
             }
             unsigned chanCnt = TrackList::Channels(vt).size();
             i += chanCnt; // Visit leaders only
-            mpRealtimeInitialization->AddTrack(
-               *vt, std::min(numPlaybackChannels, chanCnt), rate);
+            mpRealtimeInitialization->AddTrack(*vt,
+               std::min(numPlaybackChannels, chanCnt), sampleRate);
          }
       }
    }

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -124,9 +124,9 @@ unsigned EffectBassTreble::GetAudioOutCount() const
 }
 
 bool EffectBassTreble::ProcessInitialize(
-   EffectSettings &, double, sampleCount, ChannelNames)
+   EffectSettings &, double sampleRate, sampleCount, ChannelNames)
 {
-   InstanceInit(mMaster, mSampleRate);
+   InstanceInit(mMaster, sampleRate);
    return true;
 }
 

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -137,12 +137,10 @@ size_t EffectBassTreble::ProcessBlock(EffectSettings &settings,
    return InstanceProcess(settings, mMaster, inBlock, outBlock, blockLen);
 }
 
-bool EffectBassTreble::RealtimeInitialize(EffectSettings &)
+bool EffectBassTreble::RealtimeInitialize(EffectSettings &, double)
 {
    SetBlockSize(512);
-
    mSlaves.clear();
-
    return true;
 }
 

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -124,10 +124,9 @@ unsigned EffectBassTreble::GetAudioOutCount() const
 }
 
 bool EffectBassTreble::ProcessInitialize(
-   EffectSettings &, sampleCount, ChannelNames)
+   EffectSettings &, double, sampleCount, ChannelNames)
 {
    InstanceInit(mMaster, mSampleRate);
-
    return true;
 }
 

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -57,7 +57,7 @@ public:
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -62,7 +62,8 @@ public:
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
-   bool RealtimeInitialize(EffectSettings &settings) override;
+   bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+      override;
    bool RealtimeAddProcessor(EffectSettings &settings,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -204,9 +204,9 @@ unsigned EffectDistortion::GetAudioOutCount() const
 }
 
 bool EffectDistortion::ProcessInitialize(
-   EffectSettings &, double, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double sampleRate, sampleCount, ChannelNames chanMap)
 {
-   InstanceInit(mMaster, mSampleRate);
+   InstanceInit(mMaster, sampleRate);
    return true;
 }
 

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -204,7 +204,7 @@ unsigned EffectDistortion::GetAudioOutCount() const
 }
 
 bool EffectDistortion::ProcessInitialize(
-   EffectSettings &, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double, sampleCount, ChannelNames chanMap)
 {
    InstanceInit(mMaster, mSampleRate);
    return true;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -216,12 +216,10 @@ size_t EffectDistortion::ProcessBlock(EffectSettings &settings,
    return InstanceProcess(settings, mMaster, inBlock, outBlock, blockLen);
 }
 
-bool EffectDistortion::RealtimeInitialize(EffectSettings &)
+bool EffectDistortion::RealtimeInitialize(EffectSettings &, double)
 {
    SetBlockSize(512);
-
    mSlaves.clear();
-
    return true;
 }
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -87,7 +87,8 @@ public:
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
-   bool RealtimeInitialize(EffectSettings &settings) override;
+   bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+      override;
    bool RealtimeAddProcessor(EffectSettings &settings,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -82,7 +82,7 @@ public:
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -135,7 +135,7 @@ struct EffectDtmf::Instance
       , mT0{ t0 }
    {}
 
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
@@ -154,7 +154,7 @@ struct EffectDtmf::Instance
 };
 
 bool EffectDtmf::Instance::ProcessInitialize(
-   EffectSettings &settings, sampleCount, ChannelNames)
+   EffectSettings &settings, double, sampleCount, ChannelNames)
 {
    auto &dtmfSettings = GetSettings(settings);
    if (dtmfSettings.dtmfNTones == 0) {   // Bail if no DTFM sequence.

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -128,7 +128,6 @@ unsigned EffectDtmf::GetAudioOutCount() const
 struct EffectDtmf::Instance
    : PerTrackEffect::Instance
    , EffectInstanceWithBlockSize
-   , EffectInstanceWithSampleRate
 {
    Instance(const PerTrackEffect &effect, double t0)
       : PerTrackEffect::Instance{ effect }
@@ -142,6 +141,7 @@ struct EffectDtmf::Instance
    override;
 
    const double mT0;
+   double mSampleRate{};
 
    sampleCount numSamplesSequence;  // total number of samples to generate
    sampleCount numSamplesTone;      // number of samples in a tone block
@@ -154,8 +154,10 @@ struct EffectDtmf::Instance
 };
 
 bool EffectDtmf::Instance::ProcessInitialize(
-   EffectSettings &settings, double, sampleCount, ChannelNames)
+   EffectSettings &settings, double sampleRate, sampleCount, ChannelNames)
 {
+   mSampleRate = sampleRate;
+
    auto &dtmfSettings = GetSettings(settings);
    if (dtmfSettings.dtmfNTones == 0) {   // Bail if no DTFM sequence.
       // TODO:  don't use mProcessor for this

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -53,7 +53,7 @@ struct EffectEcho::Instance
       : PerTrackEffect::Instance{ effect }
    {}
 
-   bool ProcessInitialize(EffectSettings& settings,
+   bool ProcessInitialize(EffectSettings& settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
 
    size_t ProcessBlock(EffectSettings& settings,
@@ -120,14 +120,11 @@ unsigned EffectEcho::GetAudioOutCount() const
 }
 
 bool EffectEcho::Instance::ProcessInitialize(
-   EffectSettings& settings, sampleCount, ChannelNames)
+   EffectSettings& settings, double, sampleCount, ChannelNames)
 {
-   auto& echoSettings = GetSettings(settings);
-  
+   auto& echoSettings = GetSettings(settings);  
    if (echoSettings.delay == 0.0)
-   {
       return false;
-   }
 
    histPos = 0;
    auto requestedHistLen = (sampleCount) (mSampleRate * echoSettings.delay);

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -46,8 +46,6 @@ namespace{ BuiltinEffectsModule::Registration< EffectEcho > reg; }
 struct EffectEcho::Instance
    : public PerTrackEffect::Instance
    , public EffectInstanceWithBlockSize
-   , public EffectInstanceWithSampleRate
-
 {
    Instance(const PerTrackEffect& effect)
       : PerTrackEffect::Instance{ effect }
@@ -120,14 +118,14 @@ unsigned EffectEcho::GetAudioOutCount() const
 }
 
 bool EffectEcho::Instance::ProcessInitialize(
-   EffectSettings& settings, double, sampleCount, ChannelNames)
+   EffectSettings& settings, double sampleRate, sampleCount, ChannelNames)
 {
    auto& echoSettings = GetSettings(settings);  
    if (echoSettings.delay == 0.0)
       return false;
 
    histPos = 0;
-   auto requestedHistLen = (sampleCount) (mSampleRate * echoSettings.delay);
+   auto requestedHistLen = (sampleCount) (sampleRate * echoSettings.delay);
 
    // Guard against extreme delay values input by the user
    try {

--- a/src/effects/Fade.cpp
+++ b/src/effects/Fade.cpp
@@ -78,10 +78,9 @@ unsigned EffectFade::GetAudioOutCount() const
 }
 
 bool EffectFade::ProcessInitialize(
-   EffectSettings &, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double, sampleCount, ChannelNames chanMap)
 {
    mSample = 0;
-
    return true;
 }
 

--- a/src/effects/Fade.h
+++ b/src/effects/Fade.h
@@ -31,7 +31,7 @@ public:
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -101,6 +101,13 @@ unsigned EffectNoise::GetAudioOutCount() const
    return 1;
 }
 
+bool EffectNoise::ProcessInitialize(EffectSettings &,
+   double sampleRate, sampleCount, ChannelNames)
+{
+   mSampleRate = sampleRate;
+   return true;
+}
+
 size_t EffectNoise::ProcessBlock(EffectSettings &,
    const float *const *, float *const *outbuf, size_t size)
 {

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -40,6 +40,8 @@ public:
    EffectType GetType() const override;
 
    unsigned GetAudioOutCount() const override;
+   bool ProcessInitialize(EffectSettings &settings,
+      double sampleRate, sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
@@ -55,6 +57,7 @@ public:
 private:
    // EffectNoise implementation
 
+   double mSampleRate{};
    int mType;
    double mAmp;
 

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -32,8 +32,8 @@ bool PerTrackEffect::Instance::Process(EffectSettings &settings)
    return mProcessor.Process(*this, settings);
 }
 
-bool PerTrackEffect::Instance::ProcessInitialize(EffectSettings &settings,
-   sampleCount totalLen, ChannelNames chanMap)
+bool PerTrackEffect::Instance::ProcessInitialize(EffectSettings &,
+   double, sampleCount, ChannelNames)
 {
    return true;
 }
@@ -141,8 +141,10 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
          else
             mSampleCnt = left->TimeToLongSamples(duration);
 
+         const auto sampleRate = left->GetRate();
+
          // Let the client know the sample rate
-         instance.SetSampleRate(left->GetRate());
+         instance.SetSampleRate(sampleRate);
 
          // Get the block size the client wants to use
          auto max = left->GetMaxBlockSize() * 2;
@@ -189,7 +191,7 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
          }
 
          // Go process the track(s)
-         bGoodResult = ProcessTrack(instance, settings,
+         bGoodResult = ProcessTrack(instance, settings, sampleRate,
             count, map, left, right, start, len,
             inBuffer, outBuffer, inBufPos, outBufPos, bufferSize, blockSize,
             numChannels);
@@ -211,22 +213,18 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
 }
 
 bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
-   int count,
-   ChannelNames map,
-   WaveTrack *left,
-   WaveTrack *right,
-   sampleCount start,
-   sampleCount len,
-   FloatBuffers &inBuffer,
-   FloatBuffers &outBuffer,
-   ArrayOf< float * > &inBufPos,
-   ArrayOf< float *> &outBufPos, size_t bufferSize, size_t blockSize,
+   double sampleRate, int count, ChannelNames map,
+   WaveTrack *left, WaveTrack *right,
+   sampleCount start, sampleCount len,
+   FloatBuffers &inBuffer, FloatBuffers &outBuffer,
+   ArrayOf< float * > &inBufPos, ArrayOf< float *> &outBufPos,
+   size_t bufferSize, size_t blockSize,
    unsigned numChannels) const
 {
    bool rc = true;
 
    // Give the plugin a chance to initialize
-   if (!instance.ProcessInitialize(settings, len, map))
+   if (!instance.ProcessInitialize(settings, sampleRate, len, map))
       return false;
 
    { // Start scope for cleanup

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -43,7 +43,8 @@ bool PerTrackEffect::Instance::ProcessFinalize() /* noexcept */
    return true;
 }
 
-sampleCount PerTrackEffect::Instance::GetLatency(const EffectSettings &)
+sampleCount PerTrackEffect::Instance::GetLatency(
+   const EffectSettings &, double)
 {
    return 0;
 }
@@ -251,7 +252,8 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
    auto inPos = start;
    auto outPos = start;
    auto inputRemaining = len;
-   decltype(instance.GetLatency(settings)) curDelay = 0, delayRemaining = 0;
+   decltype(instance.GetLatency(settings, sampleRate))
+      curDelay = 0, delayRemaining = 0;
    decltype(blockSize) curBlockSize = 0;
    decltype(bufferSize) inputBufferCnt = 0;
    decltype(bufferSize) outputBufferCnt = 0;
@@ -383,7 +385,7 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
       // Get the current number of delayed samples and accumulate
       if (isProcessor) {
          {
-            auto delay = instance.GetLatency(settings);
+            auto delay = instance.GetLatency(settings, sampleRate);
             curDelay += delay;
             delayRemaining += delay;
          }

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -144,9 +144,6 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
 
          const auto sampleRate = left->GetRate();
 
-         // Let the client know the sample rate
-         instance.SetSampleRate(sampleRate);
-
          // Get the block size the client wants to use
          auto max = left->GetMaxBlockSize() * 2;
          blockSize = instance.SetBlockSize(max);

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -61,7 +61,8 @@ public:
 
       //! Called for destructive, non-realtime effect computation
       //! Default implementation returns zero
-      virtual sampleCount GetLatency(const EffectSettings &settings);
+      virtual sampleCount GetLatency(
+         const EffectSettings &settings, double sampleRate);
 
    protected:
       const PerTrackEffect &mProcessor;

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -47,7 +47,7 @@ public:
       //! Called at start of destructive processing, for each (mono/stereo) track
       //! Default implementation does nothing, returns true
       virtual bool ProcessInitialize(EffectSettings &settings,
-         sampleCount totalLen, ChannelNames chanMap);
+         double sampleRate, sampleCount totalLen, ChannelNames chanMap);
 
       //! Called at end of destructive processing, for each (mono/stereo) track
       //! Default implementation does nothing, returns true
@@ -80,16 +80,12 @@ protected:
 private:
    bool ProcessPass(Instance &instance, EffectSettings &settings);
    bool ProcessTrack(Instance &instance, EffectSettings &settings,
-      int count,
-      ChannelNames map,
-      WaveTrack *left,
-      WaveTrack *right,
-      sampleCount start,
-      sampleCount len,
-      FloatBuffers &inBuffer,
-      FloatBuffers &outBuffer,
-      ArrayOf< float * > &inBufPos,
-      ArrayOf< float *> &outBufPos, size_t bufferSize, size_t blockSize,
+      double sampleRate, int count, ChannelNames map,
+      WaveTrack *left, WaveTrack *right,
+      sampleCount start, sampleCount len,
+      FloatBuffers &inBuffer, FloatBuffers &outBuffer,
+      ArrayOf< float * > &inBufPos, ArrayOf< float *> &outBufPos,
+      size_t bufferSize, size_t blockSize,
       unsigned mNumChannels) const;
 };
 #endif

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -140,14 +140,11 @@ unsigned EffectPhaser::GetAudioOutCount() const
 }
 
 bool EffectPhaser::ProcessInitialize(
-   EffectSettings &, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double, sampleCount, ChannelNames chanMap)
 {
    InstanceInit(mMaster, mSampleRate);
    if (chanMap[0] == ChannelNameFrontRight)
-   {
       mMaster.phase += M_PI;
-   }
-
    return true;
 }
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -157,12 +157,10 @@ size_t EffectPhaser::ProcessBlock(EffectSettings &settings,
    return InstanceProcess(settings, mMaster, inBlock, outBlock, blockLen);
 }
 
-bool EffectPhaser::RealtimeInitialize(EffectSettings &)
+bool EffectPhaser::RealtimeInitialize(EffectSettings &, double)
 {
    SetBlockSize(512);
-
    mSlaves.clear();
-
    return true;
 }
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -140,9 +140,9 @@ unsigned EffectPhaser::GetAudioOutCount() const
 }
 
 bool EffectPhaser::ProcessInitialize(
-   EffectSettings &, double, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double sampleRate, sampleCount, ChannelNames chanMap)
 {
-   InstanceInit(mMaster, mSampleRate);
+   InstanceInit(mMaster, sampleRate);
    if (chanMap[0] == ChannelNameFrontRight)
       mMaster.phase += M_PI;
    return true;

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -68,7 +68,8 @@ public:
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
-   bool RealtimeInitialize(EffectSettings &settings) override;
+   bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+      override;
    bool RealtimeAddProcessor(EffectSettings &settings,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -63,7 +63,7 @@ public:
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -52,11 +52,8 @@ bool RealtimeEffectManager::IsActive() const noexcept
 }
 
 void RealtimeEffectManager::Initialize(
-   RealtimeEffects::InitializationScope &scope, double rate)
+   RealtimeEffects::InitializationScope &scope, double sampleRate)
 {
-   // Remember the rate
-   mRate = rate;
-
    // (Re)Set processor parameters
    mChans.clear();
    mRates.clear();
@@ -67,8 +64,8 @@ void RealtimeEffectManager::Initialize(
    mActive = true;
 
    // Tell each state to get ready for action
-   VisitAll([&scope, rate](RealtimeEffectState &state, bool){
-      scope.mInstances.push_back(state.Initialize(rate));
+   VisitAll([&scope, sampleRate](RealtimeEffectState &state, bool) {
+      scope.mInstances.push_back(state.Initialize(sampleRate));
    });
 
    // Leave suspended state
@@ -291,7 +288,7 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
    if (pScope && mActive)
    {
       // Adding a state while playback is in-flight
-      auto pInstance = state.Initialize(mRate);
+      auto pInstance = state.Initialize(pScope->mSampleRate);
       pScope->mInstances.push_back(pInstance);
 
       for (auto &leader : mGroupLeaders) {

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -147,10 +147,7 @@ private:
    }
 
    AudacityProject &mProject;
-
    Latency mLatency{ 0 };
-
-   double mRate;
 
    std::atomic<bool> mSuspended{ true };
    bool GetSuspended() const
@@ -174,11 +171,12 @@ class InitializationScope {
 public:
    InitializationScope() {}
    explicit InitializationScope(
-      std::weak_ptr<AudacityProject> wProject, double rate)
-      : mwProject{ move(wProject) }
+      std::weak_ptr<AudacityProject> wProject, double sampleRate)
+      : mSampleRate{ sampleRate }
+      , mwProject{ move(wProject) }
    {
       if (auto pProject = mwProject.lock())
-         RealtimeEffectManager::Get(*pProject).Initialize(*this, rate);
+         RealtimeEffectManager::Get(*pProject).Initialize(*this, sampleRate);
    }
    InitializationScope( InitializationScope &&other ) = default;
    InitializationScope& operator=( InitializationScope &&other ) = default;
@@ -196,6 +194,7 @@ public:
    }
 
    std::vector<std::shared_ptr<EffectInstance>> mInstances;
+   double mSampleRate;
 
 private:
    std::weak_ptr<AudacityProject> mwProject;

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -90,7 +90,8 @@ private:
    friend RealtimeEffects::SuspensionScope;
 
    //! Main thread begins to define a set of tracks for playback
-   void Initialize(RealtimeEffects::InitializationScope &scope, double rate);
+   void Initialize(RealtimeEffects::InitializationScope &scope,
+      double sampleRate);
    //! Main thread adds one track (passing the first of one or more
    //! channels), still before playback
    void AddTrack(RealtimeEffects::InitializationScope &scope,

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -259,7 +259,7 @@ RealtimeEffectState::EnsureInstance(double rate)
       // number was important
       pInstance->SetBlockSize(512);
       
-      if (!pInstance->RealtimeInitialize(mMainSettings))
+      if (!pInstance->RealtimeInitialize(mMainSettings, rate))
          return {};
       return pInstance;
    }

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -235,7 +235,7 @@ const EffectInstanceFactory *RealtimeEffectState::GetEffect()
 }
 
 std::shared_ptr<EffectInstance>
-RealtimeEffectState::EnsureInstance(double rate)
+RealtimeEffectState::EnsureInstance(double sampleRate)
 {
    if (!mPlugin)
       return {};
@@ -253,17 +253,15 @@ RealtimeEffectState::EnsureInstance(double rate)
          return {};
 
       mInitialized = true;
-      pInstance->SetSampleRate(rate);
       
       // PRL: conserving pre-3.2.0 behavior, but I don't know why this arbitrary
       // number was important
       pInstance->SetBlockSize(512);
       
-      if (!pInstance->RealtimeInitialize(mMainSettings, rate))
+      if (!pInstance->RealtimeInitialize(mMainSettings, sampleRate))
          return {};
       return pInstance;
    }
-   pInstance->SetSampleRate(rate);
    return pInstance;
 }
 
@@ -277,22 +275,22 @@ std::shared_ptr<EffectInstance> RealtimeEffectState::GetInstance()
 }
 
 std::shared_ptr<EffectInstance>
-RealtimeEffectState::Initialize(double rate)
+RealtimeEffectState::Initialize(double sampleRate)
 {
    if (!mPlugin)
       return {};
 
    mCurrentProcessor = 0;
    mGroups.clear();
-   return EnsureInstance(rate);
+   return EnsureInstance(sampleRate);
 }
 
 //! Set up processors to be visited repeatedly in Process.
 /*! The iteration over channels in AddTrack and Process must be the same */
 std::shared_ptr<EffectInstance>
-RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
+RealtimeEffectState::AddTrack(Track &track, unsigned chans, float sampleRate)
 {
-   auto pInstance = EnsureInstance(rate);
+   auto pInstance = EnsureInstance(sampleRate);
    if (!pInstance)
       return {};
 
@@ -347,7 +345,7 @@ RealtimeEffectState::AddTrack(Track &track, unsigned chans, float rate)
       // Add a NEW processor
       // Pass reference to worker settings, not main -- such as, for connecting
       // Ladspa ports to the proper addresses.
-      if (pInstance->RealtimeAddProcessor(mWorkerSettings, gchans, rate))
+      if (pInstance->RealtimeAddProcessor(mWorkerSettings, gchans, sampleRate))
          mCurrentProcessor++;
       else
          break;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -57,7 +57,7 @@ public:
    std::shared_ptr<EffectInstance> Initialize(double rate);
    //! Main thread sets up this state before adding it to lists
    std::shared_ptr<EffectInstance>
-   AddTrack(Track &track, unsigned chans, float rate);
+   AddTrack(Track &track, unsigned chans, float sampleRate);
    //! Worker thread begins a batch of samples
    /*! @param running means no pause or deactivation of containing list */
    bool ProcessStart(bool running);

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -186,8 +186,6 @@ bool EffectReverb::Validator::ValidateUI()
 struct EffectReverb::Instance
    : public PerTrackEffect::Instance
    , public EffectInstanceWithBlockSize
-   , public EffectInstanceWithSampleRate
-
 {
    explicit Instance(const PerTrackEffect& effect)
       : PerTrackEffect::Instance{ effect }
@@ -218,7 +216,8 @@ struct EffectReverb::Instance
       // The notion of ChannelNames is unavailable here,
       // so we'll have to force the stereo init, if this is the case
       //
-      InstanceInit(settings, slave, /*ChannelNames=*/nullptr, /*forceStereo=*/(numChannels == 2));
+      InstanceInit(settings, sampleRate,
+         slave, /*ChannelNames=*/nullptr, /*forceStereo=*/(numChannels == 2));
 
       mSlaves.push_back( std::move(slave) );
       return true;
@@ -238,7 +237,8 @@ struct EffectReverb::Instance
       return InstanceProcess(settings, mSlaves[group], inbuf, outbuf, numSamples);
    }
 
-   bool InstanceInit(EffectSettings& settings, EffectReverbState& data, ChannelNames chanMap, bool forceStereo);
+   bool InstanceInit(EffectSettings& settings, double sampleRate,
+      EffectReverbState& data, ChannelNames chanMap, bool forceStereo);
 
    size_t InstanceProcess(EffectSettings& settings, EffectReverbState& data,
       const float* const* inBlock, float* const* outBlock, size_t blockLen);
@@ -301,15 +301,17 @@ unsigned EffectReverb::GetAudioOutCount() const
 
 static size_t BLOCK = 16384;
 
-bool EffectReverb::Instance::ProcessInitialize(
-   EffectSettings& settings, double, sampleCount, ChannelNames chanMap)
+bool EffectReverb::Instance::ProcessInitialize(EffectSettings& settings,
+   double sampleRate, sampleCount, ChannelNames chanMap)
 {
-   return InstanceInit(settings, mMaster, chanMap, /* forceStereo = */ false);
+   return InstanceInit(settings,
+      sampleRate, mMaster, chanMap, /* forceStereo = */ false);
 }
 
 
-bool EffectReverb::Instance::InstanceInit(EffectSettings& settings, EffectReverbState& state,
-                                          ChannelNames chanMap, bool forceStereo)
+bool EffectReverb::Instance::InstanceInit(EffectSettings& settings,
+   double sampleRate, EffectReverbState& state,
+   ChannelNames chanMap, bool forceStereo)
 {   
    auto& rs = GetSettings(settings);   
 
@@ -327,7 +329,7 @@ bool EffectReverb::Instance::InstanceInit(EffectSettings& settings, EffectReverb
    for (unsigned int i = 0; i < state.mNumChans; i++)
    {
       reverb_create(&state.mP[i].reverb,
-                    mSampleRate,
+                    sampleRate,
                     rs.mWetGain,
                     rs.mRoomSize,
                     rs.mReverberance,

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -203,7 +203,7 @@ struct EffectReverb::Instance
 
    // Realtime section
 
-   bool RealtimeInitialize(EffectSettings& settings) override
+   bool RealtimeInitialize(EffectSettings& settings, double) override
    {
       SetBlockSize(512);
       mSlaves.clear();

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -193,7 +193,7 @@ struct EffectReverb::Instance
       : PerTrackEffect::Instance{ effect }
    {}
 
-   bool ProcessInitialize(EffectSettings& settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
 
    size_t ProcessBlock(EffectSettings& settings,
@@ -302,7 +302,7 @@ unsigned EffectReverb::GetAudioOutCount() const
 static size_t BLOCK = 16384;
 
 bool EffectReverb::Instance::ProcessInitialize(
-   EffectSettings& settings, sampleCount, ChannelNames chanMap)
+   EffectSettings& settings, double, sampleCount, ChannelNames chanMap)
 {
    return InstanceInit(settings, mMaster, chanMap, /* forceStereo = */ false);
 }

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -198,11 +198,10 @@ unsigned EffectScienFilter::GetAudioOutCount() const
 }
 
 bool EffectScienFilter::ProcessInitialize(
-   EffectSettings &, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double, sampleCount, ChannelNames chanMap)
 {
    for (int iPair = 0; iPair < (mOrder + 1) / 2; iPair++)
       mpBiquad[iPair].Reset();
-
    return true;
 }
 

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -54,7 +54,7 @@ public:
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/StatefulEffectBase.cpp
+++ b/src/effects/StatefulEffectBase.cpp
@@ -55,11 +55,6 @@ bool StatefulEffectBase::Instance::Init()
    return GetEffect().Init();
 }
 
-void StatefulEffectBase::Instance::SetSampleRate(double rate)
-{
-   GetEffect().SetSampleRate(rate);
-}
-
 bool StatefulEffectBase::Instance::RealtimeInitialize(
    EffectSettings &settings, double sampleRate)
 {
@@ -113,11 +108,6 @@ size_t StatefulEffectBase::Instance::GetBlockSize() const
 size_t StatefulEffectBase::Instance::SetBlockSize(size_t maxBlockSize)
 {
    return GetEffect().SetBlockSize(maxBlockSize);
-}
-
-void StatefulEffectBase::SetSampleRate(double rate)
-{
-   mSampleRate = rate;
 }
 
 size_t StatefulEffectBase::SetBlockSize(size_t maxBlockSize)

--- a/src/effects/StatefulEffectBase.cpp
+++ b/src/effects/StatefulEffectBase.cpp
@@ -60,9 +60,10 @@ void StatefulEffectBase::Instance::SetSampleRate(double rate)
    GetEffect().SetSampleRate(rate);
 }
 
-bool StatefulEffectBase::Instance::RealtimeInitialize(EffectSettings &settings)
+bool StatefulEffectBase::Instance::RealtimeInitialize(
+   EffectSettings &settings, double sampleRate)
 {
-   return GetEffect().RealtimeInitialize(settings);
+   return GetEffect().RealtimeInitialize(settings, sampleRate);
 }
 
 bool StatefulEffectBase::Instance::RealtimeAddProcessor(EffectSettings &settings,
@@ -130,7 +131,7 @@ size_t StatefulEffectBase::GetBlockSize() const
    return mEffectBlockSize;
 }
 
-bool StatefulEffectBase::RealtimeInitialize(EffectSettings &settings)
+bool StatefulEffectBase::RealtimeInitialize(EffectSettings &, double)
 {
    return false;
 }

--- a/src/effects/StatefulEffectBase.h
+++ b/src/effects/StatefulEffectBase.h
@@ -28,8 +28,6 @@ public:
 
       bool Init() override;
 
-      void SetSampleRate(double rate) override;
-   
       size_t GetBlockSize() const override;
       size_t SetBlockSize(size_t maxBlockSize) override;
    
@@ -60,12 +58,6 @@ public:
     @copydoc EffectInstance::Process
     */
    virtual bool Process(EffectInstance &instance, EffectSettings &settings) = 0;
-
-   /*!
-     @copydoc EffectInstance::SetSampleRate()
-     Default implementation assigns mSampleRate
-   */
-   virtual void SetSampleRate(double rate);
 
    /*!
      @copydoc StatefulEffectBase::Instance::RealtimeInitialize()
@@ -129,9 +121,6 @@ public:
    */
    virtual size_t GetBlockSize() const;
 
-protected:
-
-   double         mSampleRate{};
 private:
 
    size_t mEffectBlockSize{ 0 };

--- a/src/effects/StatefulEffectBase.h
+++ b/src/effects/StatefulEffectBase.h
@@ -33,7 +33,8 @@ public:
       size_t GetBlockSize() const override;
       size_t SetBlockSize(size_t maxBlockSize) override;
    
-      bool RealtimeInitialize(EffectSettings &settings) override;
+      bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+         override;
       bool RealtimeAddProcessor(EffectSettings &settings,
          unsigned numChannels, float sampleRate) override;
       bool RealtimeSuspend() override;
@@ -67,63 +68,63 @@ public:
    virtual void SetSampleRate(double rate);
 
    /*!
-     @copydoc RealtimeInitialize::RealtimeInitialize()
+     @copydoc StatefulEffectBase::Instance::RealtimeInitialize()
      Default implementation does nothing, returns false
    */
-   virtual bool RealtimeInitialize(EffectSettings &settings);
+   virtual bool RealtimeInitialize(EffectSettings &settings, double sampleRate);
 
    /*!
-     @copydoc RealtimeInitialize::RealtimeAddProcessor()
+     @copydoc StatefulEffectBase::Instance::RealtimeAddProcessor()
      Default implementation does nothing, returns true
    */
    virtual bool RealtimeAddProcessor(
       EffectSettings &settings, unsigned numChannels, float sampleRate);
 
    /*!
-     @copydoc RealtimeInitialize::RealtimeSuspend()
+     @copydoc StatefulEffectBase::Instance::RealtimeSuspend()
      Default implementation does nothing, returns true
    */
    virtual bool RealtimeSuspend();
 
    /*!
-     @copydoc RealtimeInitialize::RealtimeResume()
+     @copydoc StatefulEffectBase::Instance::RealtimeResume()
      Default implementation does nothing, returns true
    */
    virtual bool RealtimeResume();
 
    /*!
-     @copydoc RealtimeInitialize::RealtimeProcessStart()
+     @copydoc StatefulEffectBase::Instance::RealtimeProcessStart()
      Default implementation does nothing, returns true
    */
    virtual bool RealtimeProcessStart(EffectSettings &settings);
 
    /*!
-     @copydoc RealtimeInitialize::RealtimeProcess()
+     @copydoc StatefulEffectBase::Instance::RealtimeProcess()
      Default implementation does nothing, returns 0
    */
    virtual size_t RealtimeProcess(size_t group, EffectSettings &settings,
       const float *const *inBuf, float *const *outBuf, size_t numSamples);
 
    /*!
-     @copydoc RealtimeInitialize::RealtimeProcessEnd()
+     @copydoc StatefulEffectBase::Instance::RealtimeProcessEnd()
      Default implementation does nothing, returns true
    */
    virtual bool RealtimeProcessEnd(EffectSettings &settings) noexcept;
 
    /*!
-     @copydoc RealtimeInitialize::RealtimeFinalize()
+     @copydoc StatefulEffectBase::Instance::RealtimeFinalize()
      Default implementation does nothing, returns false
    */
    virtual bool RealtimeFinalize(EffectSettings &settings) noexcept;
 
    /*!
-     @copydoc RealtimeInitialize::SetBlockSize()
+     @copydoc StatefulEffectBase::Instance::SetBlockSize()
      Default implementation assigns mEffectBlockSize, returns it
    */
    virtual size_t SetBlockSize(size_t maxBlockSize);
 
    /*!
-     @copydoc RealtimeInitialize::GetBlockSize()
+     @copydoc StatefulEffectBase::Instance::GetBlockSize()
      Default implementation returns mEffectBlockSize
    */
    virtual size_t GetBlockSize() const;

--- a/src/effects/StatefulPerTrackEffect.cpp
+++ b/src/effects/StatefulPerTrackEffect.cpp
@@ -41,7 +41,8 @@ size_t StatefulPerTrackEffect::Instance::ProcessBlock(EffectSettings &settings,
    return GetEffect().ProcessBlock(settings, inBlock, outBlock, blockLen);
 }
 
-sampleCount StatefulPerTrackEffect::Instance::GetLatency(const EffectSettings &)
+sampleCount StatefulPerTrackEffect::Instance::GetLatency(
+   const EffectSettings &, double)
 {
    return GetEffect().GetLatency();
 }

--- a/src/effects/StatefulPerTrackEffect.cpp
+++ b/src/effects/StatefulPerTrackEffect.cpp
@@ -22,10 +22,12 @@
 
 StatefulPerTrackEffect::Instance::~Instance() = default;
 
-bool StatefulPerTrackEffect::Instance::ProcessInitialize(EffectSettings &settings,
+bool StatefulPerTrackEffect::Instance::ProcessInitialize(
+   EffectSettings &settings, double sampleRate,
    sampleCount totalLen, ChannelNames chanMap)
 {
-   return GetEffect().ProcessInitialize(settings, totalLen, chanMap);
+   return GetEffect()
+      .ProcessInitialize(settings, sampleRate, totalLen, chanMap);
 }
 
 bool StatefulPerTrackEffect::Instance::ProcessFinalize() /* noexcept */
@@ -78,7 +80,7 @@ sampleCount StatefulPerTrackEffect::GetLatency()
 }
 
 bool StatefulPerTrackEffect::ProcessInitialize(
-   EffectSettings &settings, sampleCount totalLen, ChannelNames chanMap)
+   EffectSettings &, double, sampleCount, ChannelNames)
 {
    return true;
 }

--- a/src/effects/StatefulPerTrackEffect.h
+++ b/src/effects/StatefulPerTrackEffect.h
@@ -36,7 +36,7 @@ public:
          , PerTrackEffect::Instance{ effect }
       {}
       ~Instance() override;
-      bool ProcessInitialize(EffectSettings &settings,
+      bool ProcessInitialize(EffectSettings &settings, double sampleRate,
          sampleCount totalLen, ChannelNames chanMap) override;
       bool ProcessFinalize() /* noexcept */ override;
       size_t ProcessBlock(EffectSettings &settings,
@@ -66,7 +66,7 @@ public:
    /*!
     @copydoc PerTrackEffect::Instance::ProcessInitialize()
     */
-   virtual bool ProcessInitialize(EffectSettings &settings,
+   virtual bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap = nullptr);
 
    /*!

--- a/src/effects/StatefulPerTrackEffect.h
+++ b/src/effects/StatefulPerTrackEffect.h
@@ -42,7 +42,8 @@ public:
       size_t ProcessBlock(EffectSettings &settings,
          const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
-      sampleCount GetLatency(const EffectSettings &settings) override;
+      sampleCount GetLatency(
+         const EffectSettings &settings, double sampleRate) override;
 
    protected:
       StatefulPerTrackEffect &GetEffect() const

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -144,11 +144,10 @@ unsigned EffectToneGen::GetAudioOutCount() const
 }
 
 bool EffectToneGen::ProcessInitialize(
-   EffectSettings &, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double, sampleCount, ChannelNames chanMap)
 {
    mPositionInCycles = 0.0;
    mSample = 0;
-
    return true;
 }
 

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -144,8 +144,9 @@ unsigned EffectToneGen::GetAudioOutCount() const
 }
 
 bool EffectToneGen::ProcessInitialize(
-   EffectSettings &, double, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double sampleRate, sampleCount, ChannelNames chanMap)
 {
+   mSampleRate = sampleRate;
    mPositionInCycles = 0.0;
    mSample = 0;
    return true;

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -58,6 +58,7 @@ private:
 
    void OnControlUpdate(wxCommandEvent & evt);
 
+   double mSampleRate{};
    const bool mChirp;
 
    // mSample is an external placeholder to remember the last "buffer"

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -39,7 +39,7 @@ public:
    EffectType GetType() const override;
 
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1218,7 +1218,6 @@ int VSTEffect::ShowClientInterface(
    // normal or realtime processing begins
    if (!IsReady())
    {
-      mSampleRate = 44100;
       mBlockSize = 8192;
       // No settings here!  Is this call really needed?  It appears to be
       // redundant with later calls that reach process initialization from the
@@ -2355,7 +2354,7 @@ void VSTEffect::BuildPlain(EffectSettingsAccess &access)
                   NumericConverter::TIME,
                   extra.GetDurationFormat(),
                   extra.GetDuration(),
-                  mSampleRate,
+                  mProjectRate,
                   NumericTextCtrl::Options{}
                      .AutoPos(true));
             mDuration->SetName( XO("Duration") );

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1098,7 +1098,7 @@ void VSTEffect::SetChannelCount(unsigned numChannels)
    mNumChannels = numChannels;
 }
 
-bool VSTEffect::RealtimeInitialize(EffectSettings &settings)
+bool VSTEffect::RealtimeInitialize(EffectSettings &settings, double)
 {
    return ProcessInitialize(settings, 0, nullptr);
 }

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -139,14 +139,13 @@ class VSTEffect final
 
    sampleCount GetLatency() override;
 
-   void SetSampleRate(double rate) override;
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
 
    bool IsReady();
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
-   bool DoProcessInitialize();
+   bool DoProcessInitialize(double sampleRate);
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
@@ -298,7 +297,6 @@ private:
    int mMidiIns;
    int mMidiOuts;
    bool mAutomatable;
-   float mSampleRate;
    size_t mUserBlockSize;
    wxString mName;
    wxString mVendor;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -152,7 +152,8 @@ class VSTEffect final
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
-   bool RealtimeInitialize(EffectSettings &settings) override;
+   bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+      override;
    bool RealtimeAddProcessor(EffectSettings &settings,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -144,9 +144,9 @@ class VSTEffect final
    size_t GetBlockSize() const override;
 
    bool IsReady();
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
-   bool DoProcessInitialize(sampleCount totalLen, ChannelNames chanMap);
+   bool DoProcessInitialize();
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -618,7 +618,7 @@ sampleCount VST3Effect::GetLatency()
 }
 
 bool VST3Effect::ProcessInitialize(
-   EffectSettings &settings, sampleCount, ChannelNames)
+   EffectSettings &settings, double, sampleCount, ChannelNames)
 {
    using namespace Steinberg;
 
@@ -766,7 +766,7 @@ bool VST3Effect::RealtimeAddProcessor(
       auto effect = std::make_unique<VST3Effect>(*this);
       effect->mSetup.processMode = Vst::kRealtime;
       effect->mSetup.sampleRate = sampleRate;
-      if(!effect->ProcessInitialize(settings, {0}, nullptr))
+      if(!effect->ProcessInitialize(settings, sampleRate, {0}, nullptr))
          throw std::runtime_error { "VST3 realtime initialization failed" };
 
       mRealtimeGroupProcessors.push_back(std::move(effect));

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -749,7 +749,7 @@ size_t VST3Effect::ProcessBlock(EffectSettings &,
    return VST3ProcessBlock(mEffectComponent.get(), mSetup, inBlock, outBlock, blockLen, pendingChanges.get());
 }
 
-bool VST3Effect::RealtimeInitialize(EffectSettings &settings)
+bool VST3Effect::RealtimeInitialize(EffectSettings &settings, double)
 {
    //reload current parameters form the editor into parameter queues
    SyncParameters(settings);

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -587,11 +587,6 @@ int VST3Effect::GetMidiOutCount() const
    return 0;
 }
 
-void VST3Effect::SetSampleRate(double rate)
-{
-   mSetup.sampleRate = rate;
-}
-
 size_t VST3Effect::SetBlockSize(size_t maxBlockSize)
 {
    mSetup.maxSamplesPerBlock = 
@@ -618,8 +613,9 @@ sampleCount VST3Effect::GetLatency()
 }
 
 bool VST3Effect::ProcessInitialize(
-   EffectSettings &settings, double, sampleCount, ChannelNames)
+   EffectSettings &settings, double sampleRate, sampleCount, ChannelNames)
 {
+   mSetup.sampleRate = sampleRate;
    using namespace Steinberg;
 
    if(mAudioProcessor->canProcessSampleSize(mSetup.symbolicSampleSize) ==kResultTrue &&
@@ -749,8 +745,9 @@ size_t VST3Effect::ProcessBlock(EffectSettings &,
    return VST3ProcessBlock(mEffectComponent.get(), mSetup, inBlock, outBlock, blockLen, pendingChanges.get());
 }
 
-bool VST3Effect::RealtimeInitialize(EffectSettings &settings, double)
+bool VST3Effect::RealtimeInitialize(EffectSettings &settings, double sampleRate)
 {
+   mSetup.sampleRate = sampleRate;
    //reload current parameters form the editor into parameter queues
    SyncParameters(settings);
    return true;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -129,7 +129,7 @@ public:
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
    sampleCount GetLatency() override;
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -135,7 +135,8 @@ public:
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
-   bool RealtimeInitialize(EffectSettings &settings) override;
+   bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+      override;
    bool RealtimeAddProcessor(EffectSettings &settings,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -125,7 +125,6 @@ public:
    unsigned GetAudioOutCount() const override;
    int GetMidiInCount() const override;
    int GetMidiOutCount() const override;
-   void SetSampleRate(double rate) override;
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
    sampleCount GetLatency() override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -137,7 +137,7 @@ struct EffectWahwah::Instance
       : PerTrackEffect::Instance{ effect }
    {}
 
-   bool ProcessInitialize(EffectSettings& settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
 
    size_t ProcessBlock(EffectSettings& settings,
@@ -221,15 +221,11 @@ unsigned EffectWahwah::GetAudioOutCount() const
 }
 
 bool EffectWahwah::Instance::ProcessInitialize(
-   EffectSettings & settings, sampleCount, ChannelNames chanMap)
+   EffectSettings & settings, double, sampleCount, ChannelNames chanMap)
 {
    InstanceInit(settings, mMaster, mSampleRate);
-
    if (chanMap[0] == ChannelNameFrontRight)
-   {
       mMaster.phase += M_PI;
-   }
-
    return true;
 }
 

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -130,8 +130,6 @@ bool EffectWahwah::Validator::ValidateUI()
 struct EffectWahwah::Instance
    : public PerTrackEffect::Instance
    , public EffectInstanceWithBlockSize
-   , public EffectInstanceWithSampleRate
-
 {
    explicit Instance(const PerTrackEffect& effect)
       : PerTrackEffect::Instance{ effect }
@@ -220,10 +218,10 @@ unsigned EffectWahwah::GetAudioOutCount() const
    return 1;
 }
 
-bool EffectWahwah::Instance::ProcessInitialize(
-   EffectSettings & settings, double, sampleCount, ChannelNames chanMap)
+bool EffectWahwah::Instance::ProcessInitialize(EffectSettings & settings,
+   double sampleRate, sampleCount, ChannelNames chanMap)
 {
-   InstanceInit(settings, mMaster, mSampleRate);
+   InstanceInit(settings, mMaster, sampleRate);
    if (chanMap[0] == ChannelNameFrontRight)
       mMaster.phase += M_PI;
    return true;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -145,7 +145,7 @@ struct EffectWahwah::Instance
 
    //bool ProcessFinalize(void) override;
 
-   bool RealtimeInitialize(EffectSettings& settings) override;
+   bool RealtimeInitialize(EffectSettings& settings, double) override;
 
    bool RealtimeAddProcessor(EffectSettings& settings,
       unsigned numChannels, float sampleRate) override;
@@ -239,12 +239,10 @@ size_t EffectWahwah::Instance::ProcessBlock(EffectSettings &settings,
    return InstanceProcess(settings, mMaster, inBlock, outBlock, blockLen);
 }
 
-bool EffectWahwah::Instance::RealtimeInitialize(EffectSettings &)
+bool EffectWahwah::Instance::RealtimeInitialize(EffectSettings &, double)
 {
    SetBlockSize(512);
-
    mSlaves.clear();
-
    return true;
 }
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -204,7 +204,6 @@ bool AudioUnitEffect::SupportsAutomation() const
 
 class AudioUnitInstance : public PerTrackEffect::Instance
    , public AudioUnitWrapper
-   , EffectInstanceWithSampleRate
 {
 public:
    AudioUnitInstance(const PerTrackEffect &effect,
@@ -285,7 +284,6 @@ AudioUnitInstance::AudioUnitInstance(const PerTrackEffect &effect,
    , mAudioIns{ audioIns }, mAudioOuts{ audioOuts }, mUseLatency{ useLatency }
 {
    CreateAudioUnit();
-   mSampleRate = 44100;
 }
 
 size_t AudioUnitInstance::InitialBlockSize() const
@@ -486,11 +484,6 @@ int AudioUnitEffect::GetMidiOutCount() const
    return 0;
 }
 
-void AudioUnitEffect::SetSampleRate(double rate)
-{
-   mSampleRate = rate;
-}
-
 size_t AudioUnitEffect::SetBlockSize(size_t maxBlockSize)
 {
    return mBlockSize;
@@ -639,7 +632,6 @@ bool AudioUnitInstance::RealtimeAddProcessor(
    }
 
    slave->SetBlockSize(mBlockSize);
-   slave->SetSampleRate(sampleRate);
 
    if (!slave->StoreSettings(effect.GetSettings(settings)))
       return false;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -222,7 +222,7 @@ private:
    size_t GetBlockSize() const override;
    size_t SetBlockSize(size_t maxBlockSize) override;
 
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
@@ -537,7 +537,7 @@ size_t AudioUnitInstance::GetTailSize() const
 #endif
 
 bool AudioUnitInstance::ProcessInitialize(
-   EffectSettings &settings, sampleCount, ChannelNames chanMap)
+   EffectSettings &settings, double, sampleCount, ChannelNames chanMap)
 {
    StoreSettings(// Change this when GetSettings becomes a static function
       static_cast<const AudioUnitEffect&>(mProcessor).GetSettings(settings));
@@ -614,9 +614,10 @@ size_t AudioUnitInstance::ProcessBlock(EffectSettings &,
    return blockLen;
 }
 
-bool AudioUnitInstance::RealtimeInitialize(EffectSettings &settings, double)
+bool AudioUnitInstance::RealtimeInitialize(
+   EffectSettings &settings, double sampleRate)
 {
-   return ProcessInitialize(settings, 0, nullptr);
+   return ProcessInitialize(settings, sampleRate, 0, nullptr);
 }
 
 bool AudioUnitInstance::RealtimeAddProcessor(
@@ -641,7 +642,7 @@ bool AudioUnitInstance::RealtimeAddProcessor(
 
    if (!slave->StoreSettings(effect.GetSettings(settings)))
       return false;
-   if (!slave->ProcessInitialize(settings, 0, nullptr))
+   if (!slave->ProcessInitialize(settings, sampleRate, 0, nullptr))
       return false;
    if (uSlave)
       mSlaves.push_back(move(uSlave));

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -229,7 +229,8 @@ private:
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
-   bool RealtimeInitialize(EffectSettings &settings) override;
+   bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+      override;
    bool RealtimeAddProcessor(EffectSettings &settings,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
@@ -613,7 +614,7 @@ size_t AudioUnitInstance::ProcessBlock(EffectSettings &,
    return blockLen;
 }
 
-bool AudioUnitInstance::RealtimeInitialize(EffectSettings &settings)
+bool AudioUnitInstance::RealtimeInitialize(EffectSettings &settings, double)
 {
    return ProcessInitialize(settings, 0, nullptr);
 }

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -217,7 +217,8 @@ public:
 
 private:
    size_t InitialBlockSize() const;
-   sampleCount GetLatency(const EffectSettings &settings) override;
+   sampleCount GetLatency(const EffectSettings &settings, double sampleRate)
+      override;
 
    size_t GetBlockSize() const override;
    size_t SetBlockSize(size_t maxBlockSize) override;
@@ -512,14 +513,15 @@ size_t AudioUnitInstance::GetBlockSize() const
    return mBlockSize;
 }
 
-sampleCount AudioUnitInstance::GetLatency(const EffectSettings &)
+sampleCount AudioUnitInstance::GetLatency(
+   const EffectSettings &, double sampleRate)
 {
    // Retrieve the latency (can be updated via an event)
    if (mUseLatency && !mLatencyDone) {
       Float64 latency = 0.0;
       if (!GetFixedSizeProperty(kAudioUnitProperty_Latency, latency)) {
          mLatencyDone = true;
-         return sampleCount{ latency * mSampleRate };
+         return sampleCount{ latency * sampleRate };
       }
    }
    return 0;

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -88,7 +88,6 @@ public:
    int GetMidiInCount() const override;
    int GetMidiOutCount() const override;
 
-   void SetSampleRate(double rate) override;
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
 
@@ -163,7 +162,6 @@ private:
 
    bool mInteractive{ false };
    UInt32 mBlockSize{ 0 };
-   Float64 mSampleRate{ 44100.0 };
 
    bool mUseLatency{ true };
 

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -731,7 +731,7 @@ bool LadspaEffect::SupportsAutomation() const
 
 namespace {
 std::pair<float, float>
-InputCountrolPortBounds(const LADSPA_PortRangeHint &hint, double sampleRate)
+InputControlPortBounds(const LADSPA_PortRangeHint &hint, double sampleRate)
 {
    // Find lower and upper bound values for ths hint
    const auto multiplier =
@@ -751,7 +751,7 @@ float InputControlPortDefaultValue(
    const LADSPA_PortRangeHint &hint, double sampleRate)
 {
    // See comments in library header ladspa.h about interpretation of macros
-   const auto bounds = InputCountrolPortBounds(hint, sampleRate);
+   const auto bounds = InputControlPortBounds(hint, sampleRate);
 
    // Function to find low, middle, or high default values
    const auto combine = [bounds,
@@ -855,7 +855,7 @@ bool LadspaEffect::InitializeControls(LadspaEffectSettings &settings) const
       if (LADSPA_IS_PORT_CONTROL(d) && LADSPA_IS_PORT_INPUT(d))
          // Determine the port's default value
          controls[p] = InputControlPortDefaultValue(
-            mData->PortRangeHints[p], mSampleRate);
+            mData->PortRangeHints[p], mProjectRate);
       else
          controls[p] = 0;
    }
@@ -1448,7 +1448,7 @@ LadspaEffect::PopulateOrExchange(ShuttleGui & S,
    EffectInstance &, EffectSettingsAccess &access)
 {
    auto result =
-      std::make_unique<Validator>(*this, access, mSampleRate, GetType());
+      std::make_unique<Validator>(*this, access, mProjectRate, GetType());
    result->PopulateUI(S);
    return result;
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -875,7 +875,8 @@ struct LadspaEffect::Instance
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
-   sampleCount GetLatency(const EffectSettings &settings) override;
+   sampleCount GetLatency(const EffectSettings &settings, double sampleRate)
+      override;
 
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
@@ -927,7 +928,8 @@ int LadspaEffect::GetMidiOutCount() const
    return 0;
 }
 
-sampleCount LadspaEffect::Instance::GetLatency(const EffectSettings &settings)
+sampleCount LadspaEffect::Instance::GetLatency(
+   const EffectSettings &settings, double)
 {
    auto &effect = GetEffect();
    auto &controls = GetSettings(settings).controls;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -865,7 +865,6 @@ bool LadspaEffect::InitializeControls(LadspaEffectSettings &settings) const
 struct LadspaEffect::Instance
    : PerTrackEffect::Instance
    , EffectInstanceWithBlockSize
-   , EffectInstanceWithSampleRate
 {
    using PerTrackEffect::Instance::Instance;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
@@ -941,13 +940,13 @@ sampleCount LadspaEffect::Instance::GetLatency(
 }
 
 bool LadspaEffect::Instance::ProcessInitialize(
-   EffectSettings &settings, double, sampleCount, ChannelNames)
+   EffectSettings &settings, double sampleRate, sampleCount, ChannelNames)
 {
    /* Instantiate the plugin */
    if (!mReady) {
       auto &effect = GetEffect();
       auto &ladspaSettings = GetSettings(settings);
-      mMaster = effect.InitInstance(mSampleRate, ladspaSettings);
+      mMaster = effect.InitInstance(sampleRate, ladspaSettings);
       if (!mMaster)
          return false;
       mReady = true;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -868,7 +868,7 @@ struct LadspaEffect::Instance
    , EffectInstanceWithSampleRate
 {
    using PerTrackEffect::Instance::Instance;
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
@@ -939,7 +939,7 @@ sampleCount LadspaEffect::Instance::GetLatency(const EffectSettings &settings)
 }
 
 bool LadspaEffect::Instance::ProcessInitialize(
-   EffectSettings &settings, sampleCount, ChannelNames)
+   EffectSettings &settings, double, sampleCount, ChannelNames)
 {
    /* Instantiate the plugin */
    if (!mReady) {

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -877,7 +877,8 @@ struct LadspaEffect::Instance
 
    sampleCount GetLatency(const EffectSettings &settings) override;
 
-   bool RealtimeInitialize(EffectSettings &settings) override;
+   bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+      override;
    bool RealtimeAddProcessor(
       EffectSettings &settings, unsigned numChannels, float sampleRate)
    override;
@@ -979,7 +980,7 @@ size_t LadspaEffect::Instance::ProcessBlock(EffectSettings &,
    return blockLen;
 }
 
-bool LadspaEffect::Instance::RealtimeInitialize(EffectSettings &)
+bool LadspaEffect::Instance::RealtimeInitialize(EffectSettings &, double)
 {
    return true;
 }

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -149,7 +149,6 @@ private:
 
    wxString pluginName;
 
-   double mSampleRate{ 44100.0 };
    size_t mBlockSize{ 0 };
 
    bool mInteractive{ false };

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -417,7 +417,7 @@ size_t LV2Effect::ProcessBlock(EffectSettings &,
    return size;
 }
 
-bool LV2Effect::RealtimeInitialize(EffectSettings &)
+bool LV2Effect::RealtimeInitialize(EffectSettings &, double)
 {
    for (auto & state : mPortStates.mCVPortStates)
       state.mBuffer.reinit(mBlockSize, state.mpPort->mIsInput);

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -899,7 +899,6 @@ std::unique_ptr<LV2Wrapper> LV2Effect::InitInstance(
       return nullptr;
 
    wrapper->SetBlockSize();
-   wrapper->SetSampleRate();
 
    static float blackHole;
 
@@ -1866,6 +1865,9 @@ LV2Wrapper::LV2Wrapper(const LV2FeaturesList &featuresList, int latencyPort,
    const LilvPlugin &plugin, double sampleRate)
 :  mFeaturesList{ featuresList }
 {
+   // Reassign the sample rate, which is pointed to by options, which are
+   // pointed to by features, before we tell the library the features
+   mFeaturesList.SetSampleRate(sampleRate);
    auto features = mFeaturesList.GetFeaturePointers();
    LV2_Feature tempFeature{ LV2_WORKER__schedule, &mWorkerSchedule };
    if (mFeaturesList.SuppliesWorkerInterface())
@@ -1946,16 +1948,6 @@ float LV2Wrapper::GetLatency() const
 void LV2Wrapper::SetFreeWheeling(bool enable)
 {
    mFreeWheeling = enable;
-}
-
-void LV2Wrapper::SetSampleRate()
-{
-   if (auto pOption = mFeaturesList.SampleRateOption()
-      ; pOption && mOptionsInterface && mOptionsInterface->set
-   ){
-      LV2_Options_Option options[2]{ *pOption, {} };
-      mOptionsInterface->set(mHandle, options);
-   }
 }
 
 void LV2Wrapper::SetBlockSize()

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -316,7 +316,7 @@ sampleCount LV2Effect::GetLatency()
 }
 
 bool LV2Effect::ProcessInitialize(
-   EffectSettings &settings, sampleCount, ChannelNames chanMap)
+   EffectSettings &settings, double, sampleCount, ChannelNames chanMap)
 {
    mProcess = InitInstance(settings, mSampleRate);
    if (!mProcess)

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -275,21 +275,6 @@ int LV2Effect::GetMidiOutCount() const
    return mPorts.mMidiOut;
 }
 
-void LV2Effect::SetSampleRate(double rate)
-{
-   mSampleRate = (float) rate;
-
-   if (mMaster)
-   {
-      mMaster->SetSampleRate();
-   }
-
-   for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
-   {
-      mSlaves[i]->SetSampleRate();
-   }
-}
-
 size_t LV2Effect::SetBlockSize(size_t maxBlockSize)
 {
    mBlockSize = std::max(mMinBlockSize,
@@ -315,10 +300,10 @@ sampleCount LV2Effect::GetLatency()
    return 0;
 }
 
-bool LV2Effect::ProcessInitialize(
-   EffectSettings &settings, double, sampleCount, ChannelNames chanMap)
+bool LV2Effect::ProcessInitialize(EffectSettings &settings,
+   double sampleRate, sampleCount, ChannelNames chanMap)
 {
-   mProcess = InitInstance(settings, mSampleRate);
+   mProcess = InitInstance(settings, sampleRate);
    if (!mProcess)
       return false;
    for (auto & state : mPortStates.mCVPortStates)

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -124,7 +124,8 @@ public:
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
 
-   bool RealtimeInitialize(EffectSettings &settings) override;
+   bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
+      override;
    bool RealtimeAddProcessor(EffectSettings &settings,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -117,7 +117,7 @@ public:
 
    sampleCount GetLatency() override;
 
-   bool ProcessInitialize(EffectSettings &settings,
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -357,7 +357,6 @@ public:
    LV2_Handle GetHandle() const;
    float GetLatency() const;
    void SetFreeWheeling(bool enable);
-   void SetSampleRate();
    void SetBlockSize();
    void ConsumeResponses();
    static LV2_Worker_Status schedule_work(LV2_Worker_Schedule_Handle handle,

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -111,7 +111,6 @@ public:
    int GetMidiInCount() const override;
    int GetMidiOutCount() const override;
 
-   void SetSampleRate(double rate) override;
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
 

--- a/src/effects/lv2/LV2FeaturesList.cpp
+++ b/src/effects/lv2/LV2FeaturesList.cpp
@@ -48,7 +48,7 @@ bool LV2FeaturesList::InitializeOptions()
    // Two options are reset later
    mBlockSizeOption = AddOption(urid_NominalBlockLength,
       sizeof(mBlockSize), urid_Int, &mBlockSize);
-   mSampleRateOption = AddOption(urid_SampleRate,
+   AddOption(urid_SampleRate,
       sizeof(mSampleRate), urid_Float, &mSampleRate);
    AddOption(0, 0, 0, nullptr);
    if (!ValidateOptions(lilv_plugin_get_uri(&mPlug)))
@@ -151,14 +151,6 @@ const LV2_Options_Option *LV2FeaturesList::NominalBlockLengthOption() const
       return nullptr;
 }
 
-const LV2_Options_Option *LV2FeaturesList::SampleRateOption() const
-{
-   if (mSupportsSampleRate)
-      return &mOptions[mSampleRateOption];
-   else
-      return nullptr;
-}
-
 bool LV2FeaturesList::ValidateFeatures(const LilvNode *subject)
 {
    return CheckFeatures(subject, true) && CheckFeatures(subject, false);
@@ -214,8 +206,8 @@ bool LV2FeaturesList::CheckOptions(const LilvNode *subject, bool required)
          const auto urid = URID_Map(uri);
          if (urid == urid_NominalBlockLength)
             mSupportsNominalBlockLength = true;
-         else if (urid == urid_SampleRate)
-            mSupportsSampleRate = true;
+         // else if (urid == urid_SampleRate)
+            // mSupportsSampleRate = true; // supports changing sample rate
          else if (required) {
             const auto end = mOptions.end();
             supported = (end != std::find_if(mOptions.begin(), end,

--- a/src/effects/lv2/LV2FeaturesList.h
+++ b/src/effects/lv2/LV2FeaturesList.h
@@ -53,8 +53,6 @@ public:
    bool SuppliesWorkerInterface() const { return mSuppliesWorkerInterface; }
    //! @return may be null
    const LV2_Options_Option *NominalBlockLengthOption() const;
-   //! @return may be null
-   const LV2_Options_Option *SampleRateOption() const;
 
    size_t AddOption(LV2_URID, uint32_t size, LV2_URID, const void *value);
 
@@ -85,6 +83,9 @@ public:
     @return true only if `!required` or else all checked features are supported
     */
    bool CheckFeatures(const LilvNode *subject, bool required);
+
+   //! May be needed before exposing features and options to the plugin
+   void SetSampleRate(float sampleRate) const { mSampleRate = sampleRate; }
 
 protected:
    const LilvPlugin &mPlug;
@@ -119,12 +120,11 @@ protected:
    LV2Symbols::URIDMap mURIDMap;
 
    std::vector<LV2_Options_Option> mOptions;
-   size_t mSampleRateOption{};
    size_t mBlockSizeOption{};
 
    std::vector<LV2_Feature> mFeatures;
 
-   float mSampleRate{ 44100 };
+   mutable float mSampleRate{ 44100 };
    size_t mBlockSize{ LV2Preferences::DEFAULT_BLOCKSIZE };
    int mSeqSize{ DEFAULT_SEQSIZE };
 
@@ -133,7 +133,6 @@ protected:
 
    const bool mSuppliesWorkerInterface;
    bool mSupportsNominalBlockLength{ false };
-   bool mSupportsSampleRate{ false };
 
    bool mNoResize{ false };
 };


### PR DESCRIPTION
The next step in LV2 refactoring led to a long digression into other effects.

The EffectInstance abstract class had a virtual function for change of sample
rate, but whether it was really properly done for Ladspa and LV2 effects was
doubtful.

This transformation eliminates the need for that virtual function and ultimately
allows some simplifications of lv2 effect support.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
