### PR TITLE
Lv2 instance part 1

### DIFF
--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -301,7 +301,7 @@ size_t LV2Effect::GetBlockSize() const
 
 sampleCount LV2Effect::GetLatency()
 {
-   if (mUseLatency && mPorts.mLatencyPort >= 0 && !mLatencyDone) {
+   if (mMaster && mUseLatency && mPorts.mLatencyPort >= 0 && !mLatencyDone) {
       mLatencyDone = true;
       return sampleCount(mMaster->GetLatency());
    }
@@ -330,6 +330,7 @@ size_t LV2Effect::ProcessBlock(EffectSettings &,
    using namespace LV2Symbols;
    wxASSERT(size <= ( size_t) mBlockSize);
 
+   assert(mMaster); // else ProcessInitialize() returned false, I'm not called
    const auto instance = &mMaster->GetInstance();
 
    int i = 0;
@@ -829,6 +830,7 @@ bool LV2Effect::BuildFancy(const EffectSettings &settings)
 #endif
    }
 
+   assert(mMaster); // PopulateUI() guarantees this
    const auto instance = &mMaster->GetInstance();
    mFeatures[mInstanceAccessFeature].data = lilv_instance_get_handle(instance);
    mExtensionDataFeature =

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -76,6 +76,7 @@ LV2Instance::LV2Instance(
    LV2Preferences::GetBufferSize(effect, userBlockSize);
    mUserBlockSize = std::max(1, userBlockSize);
    mBlockSize = mUserBlockSize;
+   lv2_atom_forge_init(&mForge, GetEffect().URIDMapFeature());
 }
 
 LV2Instance::~LV2Instance()
@@ -280,7 +281,6 @@ std::shared_ptr<EffectInstance> LV2Effect::MakeInstance() const
 std::shared_ptr<EffectInstance> LV2Effect::DoMakeInstance()
 {
    LV2Preferences::GetUseGUI(*this, mUseGUI);
-   lv2_atom_forge_init(&mForge, URIDMapFeature());
    return std::make_shared<LV2Instance>(*this, mPorts);
 }
 
@@ -355,7 +355,6 @@ size_t LV2Instance::ProcessBlock(EffectSettings &,
    using namespace LV2Symbols;
    auto pWrapper = GetWrapper();
    auto &mPortStates = GetEffect().mPortStates;
-   auto &mForge = GetEffect().mForge;
 
    assert(size <= mBlockSize);
    assert(pWrapper); // else ProcessInitialize() returned false, I'm not called
@@ -436,7 +435,6 @@ bool LV2Instance::RealtimeResume()
 bool LV2Instance::RealtimeProcessStart(EffectSettings &)
 {
    auto &mPortStates = GetEffect().mPortStates;
-   auto &mForge = GetEffect().mForge;
    mNumSamples = 0;
    for (auto & state : mPortStates.mAtomPortStates)
       state->SendToInstance(mForge, mPositionFrame, mPositionSpeed);

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -65,6 +65,13 @@
 #include <wx/msw/wrapwin.h>
 #endif
 
+LV2Instance::~LV2Instance()
+{
+   // Some temporary ugliness until real statelessness
+   const_cast<LV2Effect&>(static_cast<const LV2Effect&>(mProcessor))
+      .mMaster.reset();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 // LV2Effect
@@ -253,7 +260,7 @@ std::shared_ptr<EffectInstance> LV2Effect::DoMakeInstance()
    LV2Preferences::GetUseLatency(*this, mUseLatency);
    LV2Preferences::GetUseGUI(*this, mUseGUI);
    lv2_atom_forge_init(&mForge, URIDMapFeature());
-   return std::make_shared<Instance>(*this);
+   return std::make_shared<LV2Instance>(*this);
 }
 
 unsigned LV2Effect::GetAudioInCount() const
@@ -612,7 +619,6 @@ bool LV2Effect::CloseUI()
       mSuilInstance.reset();
    }
    mSuilHost.reset();
-   mMaster.reset();
    mParent = nullptr;
    mDialog = nullptr;
 

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -106,7 +106,6 @@ public:
 
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
-   bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
@@ -228,10 +227,8 @@ private:
    bool mLatencyDone{ false };
    bool mRolling{ false };
 
-   //! Holds lv2 library state needed for the user interface
+   //! Holds lv2 library state for UI or for destructive processing
    std::unique_ptr<LV2Wrapper> mMaster;
-   //! Holds lv2 library state for destructive processing
-   std::unique_ptr<LV2Wrapper> mProcess;
    //! Each holds lv2 library state for realtime processing of one track
    std::vector<std::unique_ptr<LV2Wrapper>> mSlaves;
 

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -315,6 +315,19 @@ class LV2Instance final : public StatefulPerTrackEffect::Instance {
 public:
    using Instance::Instance;
    ~LV2Instance() override;
+
+private:
+   LV2Effect &GetEffect() const {
+      // Tolerate const_cast in this class while it sun-sets
+      return static_cast<LV2Effect &>(
+         const_cast<PerTrackEffect &>(mProcessor));
+   }
+   LV2EffectSettings &GetSettings(EffectSettings &settings) const {
+      return GetEffect().GetSettings(settings);
+   }
+   const LV2EffectSettings &GetSettings(const EffectSettings &settings) const {
+      return GetEffect().GetSettings(settings);
+   }
 };
 
 #endif

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -226,8 +226,6 @@ private:
    LV2_External_UI_Widget* mExternalWidget{};
    bool mExternalUIClosed{ false };
 
-   LV2_Atom_Forge mForge{};
-
    //! Index into m_features
    size_t mInstanceAccessFeature{};
    //! Index into m_features
@@ -328,6 +326,7 @@ private:
    //! Each holds lv2 library state for realtime processing of one track
    std::vector<std::unique_ptr<LV2Wrapper>> mSlaves;
 
+   LV2_Atom_Forge mForge{};
 
    // Position info
    float mPositionSpeed{ 1.0f };

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -102,14 +102,6 @@ public:
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
 
-   sampleCount GetLatency() override;
-
-   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
-   size_t ProcessBlock(EffectSettings &settings,
-      const float *const *inBlock, float *const *outBlock, size_t blockLen)
-      override;
-
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
    bool RealtimeAddProcessor(EffectSettings &settings,
@@ -223,8 +215,6 @@ private:
    bool mWantsOptionsInterface{ false };
    bool mWantsStateInterface{ false };
 
-   bool mUseLatency{ false };
-   bool mLatencyDone{ false };
    bool mRolling{ false };
 
    //! Holds lv2 library state for UI or for destructive processing
@@ -311,10 +301,19 @@ private:
    friend class LV2Instance; // Remove this later
 };
 
-class LV2Instance final : public StatefulPerTrackEffect::Instance {
+class LV2Instance final : public StatefulEffectBase::Instance
+   , public PerTrackEffect::Instance
+{
 public:
    LV2Instance(StatefulPerTrackEffect &effect, const LV2Ports &ports);
    ~LV2Instance() override;
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
+      sampleCount totalLen, ChannelNames chanMap) override;
+   size_t ProcessBlock(EffectSettings &settings,
+      const float *const *inBlock, float *const *outBlock, size_t blockLen)
+   override;
+   sampleCount GetLatency(
+      const EffectSettings &settings, double sampleRate) override;
 
    LV2Wrapper *GetWrapper() { return GetEffect().mMaster.get(); }
 
@@ -337,6 +336,9 @@ private:
    }
 
    const LV2Ports &mPorts;
+
+   bool mUseLatency{ false };
+   bool mLatencyDone{ false };
 };
 
 #endif

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -311,7 +311,13 @@ private:
 
    DECLARE_EVENT_TABLE()
 
-   friend class LV2Wrapper;
+   friend class LV2Instance; // Remove this later
+};
+
+class LV2Instance final : public StatefulPerTrackEffect::Instance {
+public:
+   using Instance::Instance;
+   ~LV2Instance() override;
 };
 
 #endif

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -169,7 +169,7 @@ private:
    void SizeRequest(GtkWidget *widget, GtkRequisition *requisition);
 #endif
 
-   bool BuildFancy(const EffectSettings &settings);
+   bool BuildFancy(LilvInstance &instance, const EffectSettings &settings);
    bool BuildPlain(EffectSettingsAccess &access);
 
    bool TransferDataToWindow(const EffectSettings &settings) override;
@@ -313,8 +313,15 @@ private:
 
 class LV2Instance final : public StatefulPerTrackEffect::Instance {
 public:
-   using Instance::Instance;
+   LV2Instance(StatefulPerTrackEffect &effect, const LV2Ports &ports);
    ~LV2Instance() override;
+
+   LV2Wrapper *GetWrapper() { return GetEffect().mMaster.get(); }
+
+   //! Do nothing if there is already an LV2Wrapper.  Else try to make one
+   //! but this may fail.  The wrapper object remains until this is destroyed.
+   void MakeWrapper(const EffectSettings &settings,
+      double projectRate, bool useOutput);
 
 private:
    LV2Effect &GetEffect() const {
@@ -328,6 +335,8 @@ private:
    const LV2EffectSettings &GetSettings(const EffectSettings &settings) const {
       return GetEffect().GetSettings(settings);
    }
+
+   const LV2Ports &mPorts;
 };
 
 #endif


### PR DESCRIPTION
Resolves part of #2980

Begin to define the LV2Instance object.

But there is still some state that it stores in the Effect object, and before moving that out,
we must define the LV2Validator object.

Ultimately the direction of dependencies will be that the Effect depends on the Validator, and both on the Instance.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
