### PR TITLE
issue #3013: play indicator not displaying correctly.

### DIFF
--- a/src/tracks/ui/PlayIndicatorOverlay.cpp
+++ b/src/tracks/ui/PlayIndicatorOverlay.cpp
@@ -122,7 +122,7 @@ void PlayIndicatorOverlayBase::Draw(OverlayPanel &panel, wxDC &dc)
    if(auto tp = dynamic_cast<TrackPanel*>(&panel)) {
       wxASSERT(mIsMaster);
 
-      AColor::Line(dc, mLastIndicatorX, tp->GetRect().GetTop(), mLastIndicatorX, tp->GetRect().GetBottom());
+      AColor::Line(dc, mLastIndicatorX, 0, mLastIndicatorX, tp->GetSize().GetHeight());
    }
    else if(auto ruler = dynamic_cast<AdornedRulerPanel*>(&panel)) {
       wxASSERT(!mIsMaster);


### PR DESCRIPTION
Partially Resolves: https://github.com/audacity/audacity/issues/3013

This is a partial fix for issue 3013, which also includes the scrub ruler not displaying correctly.

Problem:
Incorrect code which only worked when the parent of the track panel had the same top left hand corner as the track panel. Now that the timeline has been reparented, this is no longer the case.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
