### PR TITLE
issue #3013: Scrub ruler not displaying correctly

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2142,7 +2142,7 @@ bool AdornedRulerPanel::SetPanelSize()
    if ( size != oldSize ) {
       SetSize(size);
       SetMinSize(size);
-      GetParent()->PostSizeEventToParent();
+      PostSizeEventToParent();
       return true;
    }
    else


### PR DESCRIPTION
Partially Resolves: https://github.com/audacity/audacity/issues/3013

This is a partial fix for issue 3013, which also includes the play indicator not displaying correctly.

Fix:
Now that the timeline has been reparented by the main window, the size event only needs to be sent to the timeline's parent, not grandparent - no other windows are affected by the resize.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
