### PR TITLE
Immutable lv2 features lists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -615,6 +615,8 @@ list( APPEND SOURCES
          effects/lv2/LV2Preferences.h
          effects/lv2/LV2Symbols.cpp
          effects/lv2/LV2Symbols.h
+         effects/lv2/LV2UIFeaturesList.cpp
+         effects/lv2/LV2UIFeaturesList.h
          effects/lv2/LV2Utils.h
          effects/lv2/LV2Wrapper.cpp
          effects/lv2/LV2Wrapper.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -609,6 +609,8 @@ list( APPEND SOURCES
          effects/lv2/LV2EffectMeter.h
          effects/lv2/LV2FeaturesList.cpp
          effects/lv2/LV2FeaturesList.h
+         effects/lv2/LV2InstanceFeaturesList.cpp
+         effects/lv2/LV2InstanceFeaturesList.h
          effects/lv2/LV2Ports.cpp
          effects/lv2/LV2Ports.h
          effects/lv2/LV2Preferences.cpp

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -831,7 +831,9 @@ bool LV2Effect::BuildFancy(LV2Validator &validator,
    const auto uinode = lilv_ui_get_uri(ui);
    lilv_world_load_resource(gWorld, uinode);
    UIHandler &handler = *this;
-   auto &features = validator.mUIFeatures.emplace(mFeatures, handler, uinode);
+   auto &features = validator.mUIFeatures.emplace(
+      mFeatures, handler, uinode, &instance,
+      (uiType == node_ExternalUI) ? nullptr : mParent);
    if (!features.mOk)
       return false;
 
@@ -840,18 +842,12 @@ bool LV2Effect::BuildFancy(LV2Validator &validator,
       containerType = LV2_EXTERNAL_UI__Widget;
    else {
       containerType = nativeType;
-      features.mFeatures[features.mParentFeature].data = mParent->GetHandle();
 #if defined(__WXGTK__)
       // Make sure the parent has a window
       if (!gtk_widget_get_window(GTK_WIDGET(mParent->m_wxwindow)))
          gtk_widget_realize(GTK_WIDGET(mParent->m_wxwindow));
 #endif
    }
-
-   features.mFeatures[features.mInstanceAccessFeature].data =
-      lilv_instance_get_handle(&instance);
-   features.mExtensionDataFeature =
-      { lilv_instance_get_descriptor(&instance)->extension_data };
 
    // Set before creating the UI instance so the initial size (if any) can be captured
    mNativeWinInitialSize = wxDefaultSize;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -84,6 +84,14 @@ LV2Instance::~LV2Instance()
       .mMaster.reset();
 }
 
+LV2Validator::LV2Validator(
+   EffectUIClientInterface &effect, EffectSettingsAccess &access
+)  : DefaultEffectUIValidator{ effect, access }
+{
+}
+
+LV2Validator::~LV2Validator() = default;
+
 void LV2Instance::MakeWrapper(const EffectSettings &settings,
    double projectRate, bool useOutput)
 {
@@ -603,7 +611,7 @@ std::unique_ptr<EffectUIValidator> LV2Effect::PopulateUI(ShuttleGui &S,
          return nullptr;
    }
 
-   return std::make_unique<DefaultEffectUIValidator>(*this, access);
+   return std::make_unique<LV2Validator>(*this, access);
 }
 
 bool LV2Effect::IsGraphicalUI()

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -877,8 +877,8 @@ bool LV2Effect::BuildFancy(
    mNativeWinLastSize = wxDefaultSize;
 
    // Create the suil host
-   mSuilHost.reset(suil_host_new(LV2Effect::suil_port_write_func,
-      LV2Effect::suil_port_index_func, nullptr, nullptr));
+   mSuilHost.reset(suil_host_new(LV2UIFeaturesList::suil_port_write,
+      LV2UIFeaturesList::suil_port_index, nullptr, nullptr));
    if (!mSuilHost)
       return false;
 
@@ -1522,13 +1522,7 @@ void LV2Effect::OnSize(wxSizeEvent & evt)
 // Feature handlers
 // ============================================================================
 
-// static callback
-int LV2Effect::ui_resize(LV2UI_Feature_Handle handle, int width, int height)
-{
-   return static_cast<LV2Effect *>(handle)->UIResize(width, height);
-}
-
-int LV2Effect::UIResize(int width, int height)
+int LV2Effect::ui_resize(int width, int height)
 {
    // Queue a wxSizeEvent to resize the plugins UI
    if (mNativeWin) {
@@ -1542,28 +1536,13 @@ int LV2Effect::UIResize(int width, int height)
    return 0;
 }
 
-// static callback
-void LV2Effect::ui_closed(LV2UI_Controller controller)
-{
-   return static_cast<LV2Effect *>(controller)->UIClosed();
-}
-
-void LV2Effect::UIClosed()
+void LV2Effect::ui_closed()
 {
    mExternalUIClosed = true;
 }
 
-// static callback
 // Foreign UI code wants to send a value or event to me, the host
-void LV2Effect::suil_port_write_func(SuilController controller,
-   uint32_t port_index, uint32_t buffer_size, uint32_t protocol,
-   const void *buffer)
-{
-   static_cast<LV2Effect *>(controller)
-      ->SuilPortWrite(port_index, buffer_size, protocol, buffer);
-}
-
-void LV2Effect::SuilPortWrite(uint32_t port_index,
+void LV2Effect::suil_port_write(uint32_t port_index,
    uint32_t buffer_size, uint32_t protocol, const void *buffer)
 {
    // Handle implicit floats
@@ -1581,14 +1560,7 @@ void LV2Effect::SuilPortWrite(uint32_t port_index,
    }
 }
 
-// static callback
-uint32_t LV2Effect::suil_port_index_func(
-   SuilController controller, const char *port_symbol)
-{
-   return static_cast<LV2Effect *>(controller)->SuilPortIndex(port_symbol);
-}
-
-uint32_t LV2Effect::SuilPortIndex(const char *port_symbol)
+uint32_t LV2Effect::suil_port_index(const char *port_symbol)
 {
    for (size_t i = 0, cnt = lilv_plugin_get_num_ports(&mPlug); i < cnt; ++i) {
       const auto port = lilv_plugin_get_port_by_index(&mPlug, i);

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -97,7 +97,7 @@ void LV2Instance::MakeWrapper(const EffectSettings &settings,
 {
    auto &effect = GetEffect();
    auto &pWrapper = effect.mMaster;
-   if (pWrapper)
+   if (pWrapper && projectRate == pWrapper->GetFeatures().mSampleRate)
       // Already made so do nothing
       return;
    pWrapper = LV2Wrapper::Create(effect.mFeatures, mPorts,
@@ -891,7 +891,6 @@ bool LV2Effect::BuildFancy(LV2Validator &validator,
 
    // Reassign the sample rate, which is pointed to by options, which are
    // pointed to by features, before we tell the library the features
-   wrapper.GetFeatures().mSampleRate = mProjectRate;
    mSuilInstance.reset(suil_instance_new(mSuilHost.get(),
       // The void* that the instance passes back to our write and index
       // callback functions, which were given to suil_host_new:

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -243,6 +243,7 @@ bool LV2Effect::InitializePlugin()
    mInstanceAccessFeature = mFeatures.size();
    AddFeature(LV2_INSTANCE_ACCESS_URI, nullptr);
    mParentFeature = mFeatures.size();
+   AddFeature(LV2_UI__parent, nullptr);
    if (!ValidateFeatures(lilv_plugin_get_uri(&mPlug)))
       return false;
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -147,7 +147,7 @@ PluginPath LV2Effect::GetPath() const
 
 ComponentInterfaceSymbol LV2Effect::GetSymbol() const
 {
-   return LilvStringMove(lilv_plugin_get_name(&mPlug));
+   return GetPluginSymbol(mPlug);
 }
 
 VendorSymbol LV2Effect::GetVendor() const

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -316,5 +316,12 @@ private:
    bool mLatencyDone{ false };
 };
 
+class LV2Validator final : public DefaultEffectUIValidator {
+public:
+   LV2Validator(
+      EffectUIClientInterface &effect, EffectSettingsAccess &access);
+   ~LV2Validator() override;
+};
+
 #endif
 #endif

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -23,9 +23,6 @@ class wxArrayString;
 #include <wx/timer.h>
 #include <wx/weakref.h>
 
-#include "lv2/data-access/data-access.h"
-
-#include "LV2FeaturesList.h"
 #include "LV2UIFeaturesList.h"
 #include "LV2Ports.h"
 #include "../../ShuttleGui.h"
@@ -57,8 +54,7 @@ class NumericTextCtrl;
 class LV2EffectMeter;
 class LV2Wrapper;
 
-class LV2Effect final : public LV2FeaturesList
-   , public StatefulPerTrackEffect
+class LV2Effect final : public StatefulPerTrackEffect
    , LV2UIFeaturesList::UIHandler
 {
 public:
@@ -166,6 +162,10 @@ private:
    uint32_t suil_port_index(const char *port_symbol) override;
 
 private:
+   const LilvPlugin &mPlug;
+   const LV2FeaturesList mFeatures{ mPlug };
+   LV2UIFeaturesList mUIFeatures{ mFeatures, *this };
+
    const LV2Ports mPorts{ mPlug };
    LV2PortStates mPortStates{ mPorts };
    LV2PortUIStates mPortUIStates{ mPortStates, mPorts };
@@ -203,24 +203,8 @@ private:
 
    bool mUseGUI{};
 
-   // These objects contain C-style virtual function tables that we fill in
-   const LV2UI_Resize mUIResizeFeature{ this, LV2UIFeaturesList::ui_resize };
-   // Not const, filled in when making a dialog
-   LV2_Extension_Data_Feature mExtensionDataFeature{};
-
-   const LilvNodePtr mHumanId{ lilv_plugin_get_name(&mPlug) };
-   const LV2_External_UI_Host mExternalUIHost{
-      // The void* bound to the argument of ui_closed will be the same
-      // given to suil_instance_new
-      LV2UIFeaturesList::ui_closed, lilv_node_as_string(mHumanId.get()) };
-
    LV2_External_UI_Widget* mExternalWidget{};
    bool mExternalUIClosed{ false };
-
-   //! Index into m_features
-   size_t mInstanceAccessFeature{};
-   //! Index into m_features
-   size_t mParentFeature{};
 
    // UI
    struct PlainUIControl {

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -325,7 +325,7 @@ public:
       const LV2FeaturesList &features, LV2UIFeaturesList::UIHandler &handler);
    ~LV2Validator() override;
 
-   std::optional<LV2UIFeaturesList> mUIFeatures;
+   std::optional<const LV2UIFeaturesList> mUIFeatures;
 };
 
 #endif

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -143,7 +143,7 @@ private:
 #endif
 
    bool BuildFancy(LV2Validator &validator,
-      LilvInstance &instance, const EffectSettings &settings);
+      LV2Wrapper &wrapper, const EffectSettings &settings);
    bool BuildPlain(EffectSettingsAccess &access);
 
    bool TransferDataToWindow(const EffectSettings &settings) override;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -263,6 +263,7 @@ public:
       const EffectSettings &settings, double sampleRate) override;
 
    LV2Wrapper *GetWrapper() { return GetEffect().mMaster.get(); }
+   const LV2Wrapper *GetWrapper() const { return GetEffect().mMaster.get(); }
 
    //! Do nothing if there is already an LV2Wrapper.  Else try to make one
    //! but this may fail.  The wrapper object remains until this is destroyed.
@@ -309,7 +310,6 @@ private:
    float mPositionSpeed{ 1.0f };
    int64_t mPositionFrame{ 0 };
 
-   size_t mBlockSize{};
    size_t mUserBlockSize{};
 
    size_t mNumSamples{};

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -17,6 +17,7 @@
 
 class wxArrayString;
 
+#include <optional>
 #include <vector>
 
 #include <wx/event.h> // to inherit
@@ -52,6 +53,7 @@ class NumericTextCtrl;
 // DECLARE_LOCAL_EVENT_TYPE(EVT_SIZEWINDOW, -1);
 
 class LV2EffectMeter;
+class LV2Validator;
 class LV2Wrapper;
 
 class LV2Effect final : public StatefulPerTrackEffect
@@ -140,7 +142,8 @@ private:
    void SizeRequest(GtkWidget *widget, GtkRequisition *requisition);
 #endif
 
-   bool BuildFancy(LilvInstance &instance, const EffectSettings &settings);
+   bool BuildFancy(LV2Validator &validator,
+      LilvInstance &instance, const EffectSettings &settings);
    bool BuildPlain(EffectSettingsAccess &access);
 
    bool TransferDataToWindow(const EffectSettings &settings) override;
@@ -164,7 +167,6 @@ private:
 private:
    const LilvPlugin &mPlug;
    const LV2FeaturesList mFeatures{ mPlug };
-   LV2UIFeaturesList mUIFeatures{ mFeatures, *this };
 
    const LV2Ports mPorts{ mPlug };
    LV2PortStates mPortStates{ mPorts };
@@ -319,8 +321,11 @@ private:
 class LV2Validator final : public DefaultEffectUIValidator {
 public:
    LV2Validator(
-      EffectUIClientInterface &effect, EffectSettingsAccess &access);
+      EffectUIClientInterface &effect, EffectSettingsAccess &access,
+      const LV2FeaturesList &features, LV2UIFeaturesList::UIHandler &handler);
    ~LV2Validator() override;
+
+   std::optional<LV2UIFeaturesList> mUIFeatures;
 };
 
 #endif

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -31,6 +31,7 @@ class wxArrayString;
 #include "LV2Ports.h"
 #include "../../ShuttleGui.h"
 #include "SampleFormat.h"
+#include "../StatefulPerTrackEffect.h"
 
 #include "NativeWindow.h"
 
@@ -58,6 +59,7 @@ class LV2EffectMeter;
 class LV2Wrapper;
 
 class LV2Effect final : public LV2FeaturesList
+   , public StatefulPerTrackEffect
 {
 public:
    LV2Effect(const LilvPlugin &plug);

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -265,8 +265,9 @@ public:
    LV2Wrapper *GetWrapper() { return GetEffect().mMaster.get(); }
    const LV2Wrapper *GetWrapper() const { return GetEffect().mMaster.get(); }
 
-   //! Do nothing if there is already an LV2Wrapper.  Else try to make one
-   //! but this may fail.  The wrapper object remains until this is destroyed.
+   //! Do nothing if there is already an LV2Wrapper with the desired rate.
+   //! The wrapper object remains until this is destroyed
+   //! or the wrapper is re-made with another rate.
    void MakeWrapper(const EffectSettings &settings,
       double projectRate, bool useOutput);
 

--- a/src/effects/lv2/LV2FeaturesList.cpp
+++ b/src/effects/lv2/LV2FeaturesList.cpp
@@ -30,6 +30,12 @@
 #include "lv2_external_ui.h"
 #include "lv2/worker/worker.h"
 
+ComponentInterfaceSymbol
+LV2FeaturesList::GetPluginSymbol(const LilvPlugin &plug)
+{
+   return LilvStringMove(lilv_plugin_get_name(&plug));
+}
+
 LV2FeaturesList::LV2FeaturesList(const LilvPlugin &plug) : mPlug{ plug }
    , mSuppliesWorkerInterface{ SuppliesWorkerInterface(plug) }
 {
@@ -161,7 +167,8 @@ bool LV2FeaturesList::CheckFeatures(const LilvNode *subject, bool required)
    bool supported = true;
    auto predicate = required ? node_RequiredFeature : node_OptionalFeature;
    if (LilvNodesPtr nodes{
-      lilv_world_find_nodes(gWorld, subject, predicate, nullptr) }) {
+      lilv_world_find_nodes(gWorld, subject, predicate, nullptr) }
+   ){
       LILV_FOREACH(nodes, i, nodes.get()) {
          const auto node = lilv_nodes_get(nodes.get(), i);
          const auto uri = lilv_node_as_string(node);
@@ -198,7 +205,8 @@ bool LV2FeaturesList::CheckOptions(const LilvNode *subject, bool required)
    const auto predicate =
       required ? node_RequiredOption : node_SupportedOption;
    if (LilvNodesPtr nodes{
-      lilv_world_find_nodes(gWorld, subject, predicate, nullptr) }) {
+      lilv_world_find_nodes(gWorld, subject, predicate, nullptr) }
+   ){
       LILV_FOREACH(nodes, i, nodes.get()) {
          const auto node = lilv_nodes_get(nodes.get(), i);
          const auto uri = lilv_node_as_string(node);
@@ -314,7 +322,7 @@ int LV2FeaturesList::LogVPrintf(LV2_URID type, const char *fmt, va_list ap)
    wxCRT_VsnprintfA(msg.get(), len, fmt, ap);
    wxString text(msg.get());
    wxLogGeneric(level,
-      wxT("%s: %s"), GetSymbol().Msgid().Translation(), text);
+      wxT("%s: %s"), GetPluginSymbol(mPlug).Msgid().Translation(), text);
    return len;
 }
 

--- a/src/effects/lv2/LV2FeaturesList.cpp
+++ b/src/effects/lv2/LV2FeaturesList.cpp
@@ -71,6 +71,7 @@ LV2FeaturesListBase::LV2FeaturesListBase(const LilvPlugin &plug) : mPlug{ plug }
 LV2FeaturesList::LV2FeaturesList(const LilvPlugin &plug)
    : LV2FeaturesListBase{ plug }
    , mSuppliesWorkerInterface{ SuppliesWorkerInterface(plug) }
+   , mOk{ InitializeOptions() && InitializeFeatures() }
 {
 }
 
@@ -134,7 +135,6 @@ bool LV2FeaturesList::InitializeFeatures()
    AddFeature(LV2_LOG__log, &mLogFeature);
    // Some plugins specify this as a feature
    AddFeature(LV2_EXTERNAL_UI__Widget, nullptr);
-
    return true;
 }
 

--- a/src/effects/lv2/LV2FeaturesList.cpp
+++ b/src/effects/lv2/LV2FeaturesList.cpp
@@ -95,7 +95,6 @@ bool LV2FeaturesList::InitializeFeatures()
    AddFeature(LV2_LOG__log, &mLogFeature);
    // Some plugins specify this as a feature
    AddFeature(LV2_EXTERNAL_UI__Widget, nullptr);
-   AddFeature(LV2_UI__parent, nullptr);
 
    return true;
 }

--- a/src/effects/lv2/LV2FeaturesList.cpp
+++ b/src/effects/lv2/LV2FeaturesList.cpp
@@ -282,7 +282,7 @@ LV2_URID LV2FeaturesList::urid_map(LV2_URID_Map_Handle handle, const char *uri)
    return static_cast<LV2FeaturesList *>(handle)->URID_Map(uri);
 }
 
-LV2_URID LV2FeaturesList::URID_Map(const char *uri)
+LV2_URID LV2FeaturesList::URID_Map(const char *uri) const
 {
    using namespace LV2Symbols;
    // Map global URIs to lower indices

--- a/src/effects/lv2/LV2FeaturesList.cpp
+++ b/src/effects/lv2/LV2FeaturesList.cpp
@@ -31,6 +31,33 @@
 #include "lv2/worker/worker.h"
 
 LV2FeaturesListBase::~LV2FeaturesListBase() = default;
+
+ExtendedLV2FeaturesList::~ExtendedLV2FeaturesList() = default;
+ExtendedLV2FeaturesList::ExtendedLV2FeaturesList(
+   const LV2FeaturesListBase &baseFeatures
+) : LV2FeaturesListBase{ baseFeatures.mPlug }
+  , mBaseFeatures{ baseFeatures }
+{
+}
+
+auto ExtendedLV2FeaturesList::GetFeaturePointers() const -> FeaturePointers
+{
+   FeaturePointers result{ mBaseFeatures.GetFeaturePointers() };
+   result.pop_back();
+   for (auto &feature : mFeatures)
+      result.push_back(&feature);
+   result.push_back(nullptr);
+   return result;
+}
+
+void ExtendedLV2FeaturesList::AddFeature(const char *uri, const void *data)
+{
+   // This casting to const is innocent
+   // We pass our "virtual function tables" or array of options, which the
+   // library presumably will not change
+   mFeatures.emplace_back(LV2_Feature{ uri, const_cast<void*>(data) });
+}
+
 LV2FeaturesList::~LV2FeaturesList() = default;
 
 ComponentInterfaceSymbol

--- a/src/effects/lv2/LV2FeaturesList.cpp
+++ b/src/effects/lv2/LV2FeaturesList.cpp
@@ -11,8 +11,6 @@
 
 **********************************************************************/
 
-
-
 #if defined(USE_LV2)
 
 #if defined(__GNUC__)
@@ -362,5 +360,4 @@ int LV2FeaturesList::LogVPrintf(LV2_URID type, const char *fmt, va_list ap)
       wxT("%s: %s"), GetPluginSymbol(mPlug).Msgid().Translation(), text);
    return len;
 }
-
 #endif

--- a/src/effects/lv2/LV2FeaturesList.h
+++ b/src/effects/lv2/LV2FeaturesList.h
@@ -17,7 +17,6 @@
 #if USE_LV2
 
 #include "lv2/log/log.h"
-#include "lv2/options/options.h"
 #include "lv2/uri-map/uri-map.h"
 
 #include "LV2Symbols.h"
@@ -76,10 +75,6 @@ public:
    ~LV2FeaturesList() override;
 
    //! @return success
-   bool InitializeOptions();
-
-   //! To be called after InitializeOptions()
-   //! @return success
    bool InitializeFeatures();
 
    FeaturePointers GetFeaturePointers() const override;
@@ -91,40 +86,20 @@ public:
    //! @return whether our host should reciprocally supply the
    //! LV2_Worker_Schedule interface to the plug-in
    bool SuppliesWorkerInterface() const { return mSuppliesWorkerInterface; }
-   //! @return may be null
-   const LV2_Options_Option *NominalBlockLengthOption() const;
-
-   size_t AddOption(LV2_URID, uint32_t size, LV2_URID, const void *value);
-
-   /*!
-    @param subject URI of a plugin
-    @return whether all required options of subject are supported
-    */
-   bool ValidateOptions(const LilvNode *subject);
-
-   /*!
-    @param subject URI of a plugin
-    @param required whether to check required or optional options of subject
-    @return true only if `!required` or else all required options are supported
-    */
-   bool CheckOptions(const LilvNode *subject, bool required);
 
    void AddFeature(const char *uri, const void *data);
-
-   //! May be needed before exposing features and options to the plugin
-   void SetSampleRate(float sampleRate) const { mSampleRate = sampleRate; }
 
    // lv2 functions require a pointer to non-const in places, but presumably
    // have no need to mutate the members of this structure
    LV2_URID_Map *URIDMapFeature() const
    { return const_cast<LV2_URID_Map*>(&mURIDMapFeature); }
 
+   LV2_URID URID_Map(const char *uri) const;
+
 protected:
    static uint32_t uri_to_id(LV2_URI_Map_Callback_Data callback_data,
       const char *map, const char *uri);
    static LV2_URID urid_map(LV2_URID_Map_Handle handle, const char *uri);
-   LV2_URID URID_Map(const char *uri) const;
-
    static const char *urid_unmap(LV2_URID_Unmap_Handle handle, LV2_URID urid);
    const char *URID_Unmap(LV2_URID urid);
 
@@ -150,22 +125,11 @@ protected:
     */
    mutable LV2Symbols::URIDMap mURIDMap;
 
-   std::vector<LV2_Options_Option> mOptions;
-   size_t mBlockSizeOption{};
-
    std::vector<LV2_Feature> mFeatures;
 
-   size_t mBlockSize{ LV2Preferences::DEFAULT_BLOCKSIZE };
-   int mSeqSize{ DEFAULT_SEQSIZE };
-
    const bool mSuppliesWorkerInterface;
-   bool mSupportsNominalBlockLength{ false };
 
 public:
-   size_t mMinBlockSize{ 1 };
-   size_t mMaxBlockSize{ mBlockSize };
-   mutable float mSampleRate{ 44100 };
-
    const bool mOk;
 };
 

--- a/src/effects/lv2/LV2FeaturesList.h
+++ b/src/effects/lv2/LV2FeaturesList.h
@@ -114,12 +114,12 @@ public:
    //! May be needed before exposing features and options to the plugin
    void SetSampleRate(float sampleRate) const { mSampleRate = sampleRate; }
 
-protected:
    // lv2 functions require a pointer to non-const in places, but presumably
    // have no need to mutate the members of this structure
    LV2_URID_Map *URIDMapFeature() const
    { return const_cast<LV2_URID_Map*>(&mURIDMapFeature); }
 
+protected:
    static uint32_t uri_to_id(LV2_URI_Map_Callback_Data callback_data,
       const char *map, const char *uri);
    static LV2_URID urid_map(LV2_URID_Map_Handle handle, const char *uri);
@@ -150,15 +150,18 @@ protected:
 
    std::vector<LV2_Feature> mFeatures;
 
-   mutable float mSampleRate{ 44100 };
    size_t mBlockSize{ LV2Preferences::DEFAULT_BLOCKSIZE };
    int mSeqSize{ DEFAULT_SEQSIZE };
 
-   size_t mMinBlockSize{ 1 };
-   size_t mMaxBlockSize{ mBlockSize };
-
    const bool mSuppliesWorkerInterface;
    bool mSupportsNominalBlockLength{ false };
+
+public:
+   size_t mMinBlockSize{ 1 };
+   size_t mMaxBlockSize{ mBlockSize };
+   mutable float mSampleRate{ 44100 };
+
+   const bool mOk;
 };
 
 #endif

--- a/src/effects/lv2/LV2FeaturesList.h
+++ b/src/effects/lv2/LV2FeaturesList.h
@@ -123,7 +123,7 @@ protected:
    static uint32_t uri_to_id(LV2_URI_Map_Callback_Data callback_data,
       const char *map, const char *uri);
    static LV2_URID urid_map(LV2_URID_Map_Handle handle, const char *uri);
-   LV2_URID URID_Map(const char *uri);
+   LV2_URID URID_Map(const char *uri) const;
 
    static const char *urid_unmap(LV2_URID_Unmap_Handle handle, LV2_URID urid);
    const char *URID_Unmap(LV2_URID urid);
@@ -142,8 +142,13 @@ protected:
    const LV2_Log_Log mLogFeature{
       this, LV2FeaturesList::log_printf, LV2FeaturesList::log_vprintf };
 
-   // Declare local URI map
-   LV2Symbols::URIDMap mURIDMap;
+   //! Per-effect URID map allocates an ID for each URI on first lookup
+   /*!
+    This is some state shared among all instances of an effect, but logically
+    const as a mapping, assuming all reverse lookups of any urid (integer) are
+    done only after at least one lookup of the related uri (string)
+    */
+   mutable LV2Symbols::URIDMap mURIDMap;
 
    std::vector<LV2_Options_Option> mOptions;
    size_t mBlockSizeOption{};

--- a/src/effects/lv2/LV2FeaturesList.h
+++ b/src/effects/lv2/LV2FeaturesList.h
@@ -56,6 +56,18 @@ public:
    bool mNoResize{ false };
 };
 
+//! Extends one (immutable) feature list (whose lifetime contains this one's)
+class ExtendedLV2FeaturesList : public LV2FeaturesListBase {
+public:
+   explicit ExtendedLV2FeaturesList(const LV2FeaturesListBase &baseFeatures);
+   virtual ~ExtendedLV2FeaturesList();
+   FeaturePointers GetFeaturePointers() const override;
+   void AddFeature(const char *uri, const void *data);
+   const LV2FeaturesListBase &mBaseFeatures;
+protected:
+   std::vector<LV2_Feature> mFeatures;
+};
+
 class LV2FeaturesList : public LV2FeaturesListBase {
 public:
    static ComponentInterfaceSymbol GetPluginSymbol(const LilvPlugin &plug);

--- a/src/effects/lv2/LV2FeaturesList.h
+++ b/src/effects/lv2/LV2FeaturesList.h
@@ -20,7 +20,6 @@
 #include "lv2/options/options.h"
 #include "lv2/uri-map/uri-map.h"
 
-#include "../StatefulPerTrackEffect.h"
 #include "LV2Symbols.h"
 #include "LV2Preferences.h" // for DEFAULT_BLOCKSIZE
 
@@ -29,8 +28,10 @@
 
 using LilvNodesPtr = Lilv_ptr<LilvNodes, lilv_nodes_free>;
 
-class LV2FeaturesList : public StatefulPerTrackEffect {
+class LV2FeaturesList {
 public:
+   static ComponentInterfaceSymbol GetPluginSymbol(const LilvPlugin &plug);
+
    explicit LV2FeaturesList(const LilvPlugin &plug);
 
    //! @return success
@@ -58,14 +59,14 @@ public:
 
    /*!
     @param subject URI of a plugin
-    @return whether all required features of subject are supported
+    @return whether all required options of subject are supported
     */
    bool ValidateOptions(const LilvNode *subject);
 
    /*!
     @param subject URI of a plugin
-    @param required whether to check required or optional features of subject
-    @return true only if `!required` or else all checked features are supported
+    @param required whether to check required or optional options of subject
+    @return true only if `!required` or else all required options are supported
     */
    bool CheckOptions(const LilvNode *subject, bool required);
 
@@ -80,7 +81,7 @@ public:
    /*!
     @param subject URI of the host or of the UI identifies a resource in lv2
     @param required whether to check required or optional features of subject
-    @return true only if `!required` or else all checked features are supported
+    @return true only if `!required` or else all required features are supported
     */
    bool CheckFeatures(const LilvNode *subject, bool required);
 

--- a/src/effects/lv2/LV2FeaturesList.h
+++ b/src/effects/lv2/LV2FeaturesList.h
@@ -2,7 +2,7 @@
 
   Audacity: A Digital Audio Editor
 
-  LV2Effect.h
+  @file LV2FeaturesList.h
 
   Paul Licameli split from LV2Effect.h
 
@@ -121,16 +121,17 @@ protected:
    { return const_cast<LV2_URID_Map*>(&mURIDMapFeature); }
 
    static uint32_t uri_to_id(LV2_URI_Map_Callback_Data callback_data,
-                             const char *map,
-                             const char *uri);
+      const char *map, const char *uri);
    static LV2_URID urid_map(LV2_URID_Map_Handle handle, const char *uri);
    LV2_URID URID_Map(const char *uri);
 
    static const char *urid_unmap(LV2_URID_Unmap_Handle handle, LV2_URID urid);
    const char *URID_Unmap(LV2_URID urid);
 
-   static int log_printf(LV2_Log_Handle handle, LV2_URID type, const char *fmt, ...);
-   static int log_vprintf(LV2_Log_Handle handle, LV2_URID type, const char *fmt, va_list ap);
+   static int log_printf(LV2_Log_Handle handle,
+      LV2_URID type, const char *fmt, ...);
+   static int log_vprintf(LV2_Log_Handle handle,
+      LV2_URID type, const char *fmt, va_list ap);
    int LogVPrintf(LV2_URID type, const char *fmt, va_list ap);
 
    // These objects contain C-style virtual function tables that we fill in

--- a/src/effects/lv2/LV2InstanceFeaturesList.cpp
+++ b/src/effects/lv2/LV2InstanceFeaturesList.cpp
@@ -1,0 +1,363 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  LV2FeaturesList.cpp
+
+  Paul Licameli split from LV2Effect.cpp
+
+  Audacity(R) is copyright (c) 1999-2008 Audacity Team.
+  License: GPL v2 or later.  See License.txt.
+
+**********************************************************************/
+
+#if defined(USE_LV2)
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wparentheses"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__clang__)
+#pragma clang diagnostic ignored "-Wparentheses"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#include "LV2FeaturesList.h"
+#include <wx/crt.h>
+#include <wx/log.h>
+#include "lv2/buf-size/buf-size.h"
+#include "lv2_external_ui.h"
+#include "lv2/worker/worker.h"
+
+LV2FeaturesListBase::~LV2FeaturesListBase() = default;
+
+ExtendedLV2FeaturesList::~ExtendedLV2FeaturesList() = default;
+ExtendedLV2FeaturesList::ExtendedLV2FeaturesList(
+   const LV2FeaturesListBase &baseFeatures
+) : LV2FeaturesListBase{ baseFeatures.mPlug }
+  , mBaseFeatures{ baseFeatures }
+{
+}
+
+auto ExtendedLV2FeaturesList::GetFeaturePointers() const -> FeaturePointers
+{
+   FeaturePointers result{ mBaseFeatures.GetFeaturePointers() };
+   result.pop_back();
+   for (auto &feature : mFeatures)
+      result.push_back(&feature);
+   result.push_back(nullptr);
+   return result;
+}
+
+void ExtendedLV2FeaturesList::AddFeature(const char *uri, const void *data)
+{
+   // This casting to const is innocent
+   // We pass our "virtual function tables" or array of options, which the
+   // library presumably will not change
+   mFeatures.emplace_back(LV2_Feature{ uri, const_cast<void*>(data) });
+}
+
+LV2FeaturesList::~LV2FeaturesList() = default;
+
+ComponentInterfaceSymbol
+LV2FeaturesList::GetPluginSymbol(const LilvPlugin &plug)
+{
+   return LilvStringMove(lilv_plugin_get_name(&plug));
+}
+
+LV2FeaturesListBase::LV2FeaturesListBase(const LilvPlugin &plug) : mPlug{ plug }
+{
+}
+
+LV2FeaturesList::LV2FeaturesList(const LilvPlugin &plug)
+   : LV2FeaturesListBase{ plug }
+   , mSuppliesWorkerInterface{ SuppliesWorkerInterface(plug) }
+   , mOk{ InitializeOptions() && InitializeFeatures() }
+{
+}
+
+bool LV2FeaturesList::InitializeOptions()
+{
+   using namespace LV2Symbols;
+
+   // Construct the null-terminated array describing options, and validate it
+   AddOption(urid_SequenceSize, sizeof(mSeqSize), urid_Int, &mSeqSize);
+   AddOption(urid_MinBlockLength,
+      sizeof(mMinBlockSize), urid_Int, &mMinBlockSize);
+   AddOption(urid_MaxBlockLength,
+      sizeof(mMaxBlockSize), urid_Int, &mMaxBlockSize);
+   // Two options are reset later
+   mBlockSizeOption = AddOption(urid_NominalBlockLength,
+      sizeof(mBlockSize), urid_Int, &mBlockSize);
+   AddOption(urid_SampleRate,
+      sizeof(mSampleRate), urid_Float, &mSampleRate);
+   AddOption(0, 0, 0, nullptr);
+   if (!ValidateOptions(lilv_plugin_get_uri(&mPlug)))
+      return false;
+
+   // Adjust the values in the block size features according to the plugin
+   if (LilvNodePtr minLength{ lilv_world_get(gWorld,
+         lilv_plugin_get_uri(&mPlug), node_MinBlockLength, nullptr) }
+      ; lilv_node_is_int(minLength.get())
+   ){
+      if (auto value = lilv_node_as_int(minLength.get())
+         ; value >= 0
+      )
+         mMinBlockSize = std::max<size_t>(mMinBlockSize, value);
+   }
+   if (LilvNodePtr maxLength{ lilv_world_get(gWorld,
+         lilv_plugin_get_uri(&mPlug), node_MaxBlockLength, nullptr) }
+      ; lilv_node_is_int(maxLength.get())
+   ){
+      if (auto value = lilv_node_as_int(maxLength.get())
+         ; value >= 1
+      )
+         mMaxBlockSize = std::min<size_t>(mMaxBlockSize, value);
+   }
+   mMaxBlockSize = std::max(mMaxBlockSize, mMinBlockSize);
+
+   return true;
+}
+
+bool LV2FeaturesList::InitializeFeatures()
+{
+   // Construct null-terminated array of "features" describing our capabilities
+   // to lv2, and validate
+   AddFeature(LV2_UI__noUserResize, nullptr);
+   AddFeature(LV2_UI__fixedSize, nullptr);
+   AddFeature(LV2_UI__idleInterface, nullptr);
+   AddFeature(LV2_UI__makeResident, nullptr);
+   AddFeature(LV2_BUF_SIZE__boundedBlockLength, nullptr);
+   AddFeature(LV2_BUF_SIZE__fixedBlockLength, nullptr);
+   AddFeature(LV2_OPTIONS__options, mOptions.data());
+   AddFeature(LV2_URI_MAP_URI, &mUriMapFeature);
+   AddFeature(LV2_URID__map, &mURIDMapFeature);
+   AddFeature(LV2_URID__unmap, &mURIDUnmapFeature);
+   AddFeature(LV2_LOG__log, &mLogFeature);
+   // Some plugins specify this as a feature
+   AddFeature(LV2_EXTERNAL_UI__Widget, nullptr);
+   return true;
+}
+
+bool LV2FeaturesList::SuppliesWorkerInterface(const LilvPlugin &plug)
+{
+   bool result = false;
+   if (LilvNodesPtr extdata{ lilv_plugin_get_extension_data(&plug) }) {
+      LILV_FOREACH(nodes, i, extdata.get()) {
+         const auto node = lilv_nodes_get(extdata.get(), i);
+         const auto uri = lilv_node_as_string(node);
+         if (strcmp(uri, LV2_WORKER__interface) == 0)
+            result = true;
+      }
+   }
+   return result;
+}
+
+size_t LV2FeaturesList::AddOption(
+   LV2_URID key, uint32_t size, LV2_URID type, const void *value)
+{
+   int ndx = mOptions.size();
+   if (key != 0)
+      mOptions.emplace_back(LV2_Options_Option{
+         LV2_OPTIONS_INSTANCE, 0, key, size, type, value });
+   else
+      mOptions.emplace_back(LV2_Options_Option{});
+   return ndx;
+}
+
+void LV2FeaturesList::AddFeature(const char *uri, const void *data)
+{
+   // This casting to const is innocent
+   // We pass our "virtual function tables" or array of options, which the
+   // library presumably will not change
+   mFeatures.emplace_back(LV2_Feature{ uri, const_cast<void*>(data) });
+}
+
+auto LV2FeaturesList::GetFeaturePointers() const -> FeaturePointers
+{
+   FeaturePointers result;
+   for (auto &feature : mFeatures)
+      result.push_back(&feature);
+   result.push_back(nullptr);
+   return result;
+}
+
+const LV2_Options_Option *LV2FeaturesList::NominalBlockLengthOption() const
+{
+   if (mSupportsNominalBlockLength)
+      return &mOptions[mBlockSizeOption];
+   else
+      return nullptr;
+}
+
+bool LV2FeaturesListBase::ValidateFeatures(const LilvNode *subject)
+{
+   return CheckFeatures(subject, true) && CheckFeatures(subject, false);
+}
+
+bool LV2FeaturesListBase::CheckFeatures(const LilvNode *subject, bool required)
+{
+   using namespace LV2Symbols;
+   bool supported = true;
+   auto predicate = required ? node_RequiredFeature : node_OptionalFeature;
+   if (LilvNodesPtr nodes{
+      lilv_world_find_nodes(gWorld, subject, predicate, nullptr) }
+   ){
+      LILV_FOREACH(nodes, i, nodes.get()) {
+         const auto node = lilv_nodes_get(nodes.get(), i);
+         const auto uri = lilv_node_as_string(node);
+         if ((strcmp(uri, LV2_UI__noUserResize) == 0) ||
+             (strcmp(uri, LV2_UI__fixedSize) == 0))
+            mNoResize = true;
+         else if (strcmp(uri, LV2_WORKER__schedule) == 0) {
+            /* Supported but handled in LV2Wrapper */
+         }
+         else if (required) {
+            auto features = GetFeaturePointers();
+            const auto end = features.end();
+            supported = (end != std::find_if(features.begin(), end,
+               [&](auto &pFeature){ return pFeature &&
+                  strcmp(pFeature->URI, uri) == 0; }));
+            if (!supported) {
+               wxLogError(wxT("%s requires unsupported feature %s"),
+                  lilv_node_as_string(lilv_plugin_get_uri(&mPlug)), uri);
+               break;
+            }
+         }
+      }
+   }
+   return supported;
+}
+
+bool LV2FeaturesList::ValidateOptions(const LilvNode *subject)
+{
+   return CheckOptions(subject, true) && CheckOptions(subject, false);
+}
+
+bool LV2FeaturesList::CheckOptions(const LilvNode *subject, bool required)
+{
+   using namespace LV2Symbols;
+   bool supported = true;
+   const auto predicate =
+      required ? node_RequiredOption : node_SupportedOption;
+   if (LilvNodesPtr nodes{
+      lilv_world_find_nodes(gWorld, subject, predicate, nullptr) }
+   ){
+      LILV_FOREACH(nodes, i, nodes.get()) {
+         const auto node = lilv_nodes_get(nodes.get(), i);
+         const auto uri = lilv_node_as_string(node);
+         const auto urid = URID_Map(uri);
+         if (urid == urid_NominalBlockLength)
+            mSupportsNominalBlockLength = true;
+         // else if (urid == urid_SampleRate)
+            // mSupportsSampleRate = true; // supports changing sample rate
+         else if (required) {
+            const auto end = mOptions.end();
+            supported = (end != std::find_if(mOptions.begin(), end,
+               [&](const auto &option){ return option.key == urid; }));
+            if (!supported) {
+               wxLogError(wxT("%s requires unsupported option %s"),
+                  lilv_node_as_string(lilv_plugin_get_uri(&mPlug)), uri);
+               break;
+            }
+         }
+      }
+   }
+   return supported;
+}
+
+// ============================================================================
+// Feature handlers
+// ============================================================================
+
+// static callback
+uint32_t LV2FeaturesList::uri_to_id(
+   LV2_URI_Map_Callback_Data callback_data, const char *, const char *uri)
+{
+   return static_cast<LV2FeaturesList *>(callback_data)->URID_Map(uri);
+}
+
+// static callback
+LV2_URID LV2FeaturesList::urid_map(LV2_URID_Map_Handle handle, const char *uri)
+{
+   return static_cast<LV2FeaturesList *>(handle)->URID_Map(uri);
+}
+
+LV2_URID LV2FeaturesList::URID_Map(const char *uri) const
+{
+   using namespace LV2Symbols;
+   // Map global URIs to lower indices
+   auto urid = Lookup_URI(gURIDMap, uri, false);
+   if (urid > 0)
+      return urid;
+   // Map local URIs to higher indices
+   urid = Lookup_URI(mURIDMap, uri);
+   if (urid > 0)
+      return urid + gURIDMap.size();
+   return 0;
+}
+
+// static callback
+const char *LV2FeaturesList::urid_unmap(LV2_URID_Unmap_Handle handle, LV2_URID urid)
+{
+   return static_cast<LV2FeaturesList *>(handle)->URID_Unmap(urid);
+}
+
+const char *LV2FeaturesList::URID_Unmap(LV2_URID urid)
+{
+   using namespace LV2Symbols;
+   if (urid > 0) {
+      // Unmap lower indices to global URIs
+      if (urid <= static_cast<LV2_URID>(gURIDMap.size()))
+         return mURIDMap[urid - 1].get();
+      // Unmap higher indices to local URIs
+      urid -= gURIDMap.size();
+      if (urid <= static_cast<LV2_URID>(mURIDMap.size()))
+         return mURIDMap[urid - 1].get();
+   }
+   return nullptr;
+}
+
+// static callback
+int LV2FeaturesList::log_printf(
+   LV2_Log_Handle handle, LV2_URID type, const char *fmt, ...)
+{
+   va_list ap;
+   int len;
+
+   va_start(ap, fmt);
+   len = static_cast<LV2FeaturesList *>(handle)->LogVPrintf(type, fmt, ap);
+   va_end(ap);
+
+   return len;
+}
+
+// static callback
+int LV2FeaturesList::log_vprintf(
+   LV2_Log_Handle handle, LV2_URID type, const char *fmt, va_list ap)
+{
+   return static_cast<LV2FeaturesList *>(handle)->LogVPrintf(type, fmt, ap);
+}
+
+int LV2FeaturesList::LogVPrintf(LV2_URID type, const char *fmt, va_list ap)
+{
+   using namespace LV2Symbols;
+   long level = wxLOG_Error;
+   if (type == urid_Error)
+      level = wxLOG_Error;
+   else if (type == urid_Note)
+      level = wxLOG_Info;
+   else if (type == urid_Trace)
+      level = wxLOG_Trace;
+   else if (type == urid_Warning)
+      level = wxLOG_Warning;
+   else
+      level = wxLOG_Message;
+   int len = wxCRT_VsnprintfA(nullptr, 0, fmt, ap);
+   auto msg = std::make_unique<char[]>(len + 1);
+   wxCRT_VsnprintfA(msg.get(), len, fmt, ap);
+   wxString text(msg.get());
+   wxLogGeneric(level,
+      wxT("%s: %s"), GetPluginSymbol(mPlug).Msgid().Translation(), text);
+   return len;
+}
+#endif

--- a/src/effects/lv2/LV2InstanceFeaturesList.cpp
+++ b/src/effects/lv2/LV2InstanceFeaturesList.cpp
@@ -2,7 +2,7 @@
 
   Audacity: A Digital Audio Editor
 
-  LV2FeaturesList.cpp
+  @file LV2InstanceFeaturesList.cpp
 
   Paul Licameli split from LV2Effect.cpp
 
@@ -11,71 +11,19 @@
 
 **********************************************************************/
 
-#if defined(USE_LV2)
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic ignored "-Wparentheses"
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__clang__)
-#pragma clang diagnostic ignored "-Wparentheses"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-#include "LV2FeaturesList.h"
-#include <wx/crt.h>
+#include "LV2InstanceFeaturesList.h"
 #include <wx/log.h>
-#include "lv2/buf-size/buf-size.h"
-#include "lv2_external_ui.h"
 #include "lv2/worker/worker.h"
 
-LV2FeaturesListBase::~LV2FeaturesListBase() = default;
-
-ExtendedLV2FeaturesList::~ExtendedLV2FeaturesList() = default;
-ExtendedLV2FeaturesList::ExtendedLV2FeaturesList(
-   const LV2FeaturesListBase &baseFeatures
-) : LV2FeaturesListBase{ baseFeatures.mPlug }
-  , mBaseFeatures{ baseFeatures }
+LV2InstanceFeaturesList::LV2InstanceFeaturesList(
+   const LV2FeaturesList &baseFeatures
+)  : ExtendedLV2FeaturesList{ baseFeatures }
+   , mOk{ InitializeOptions() }
 {
+   AddFeature(LV2_OPTIONS__options, mOptions.data());
 }
 
-auto ExtendedLV2FeaturesList::GetFeaturePointers() const -> FeaturePointers
-{
-   FeaturePointers result{ mBaseFeatures.GetFeaturePointers() };
-   result.pop_back();
-   for (auto &feature : mFeatures)
-      result.push_back(&feature);
-   result.push_back(nullptr);
-   return result;
-}
-
-void ExtendedLV2FeaturesList::AddFeature(const char *uri, const void *data)
-{
-   // This casting to const is innocent
-   // We pass our "virtual function tables" or array of options, which the
-   // library presumably will not change
-   mFeatures.emplace_back(LV2_Feature{ uri, const_cast<void*>(data) });
-}
-
-LV2FeaturesList::~LV2FeaturesList() = default;
-
-ComponentInterfaceSymbol
-LV2FeaturesList::GetPluginSymbol(const LilvPlugin &plug)
-{
-   return LilvStringMove(lilv_plugin_get_name(&plug));
-}
-
-LV2FeaturesListBase::LV2FeaturesListBase(const LilvPlugin &plug) : mPlug{ plug }
-{
-}
-
-LV2FeaturesList::LV2FeaturesList(const LilvPlugin &plug)
-   : LV2FeaturesListBase{ plug }
-   , mSuppliesWorkerInterface{ SuppliesWorkerInterface(plug) }
-   , mOk{ InitializeOptions() && InitializeFeatures() }
-{
-}
-
-bool LV2FeaturesList::InitializeOptions()
+bool LV2InstanceFeaturesList::InitializeOptions()
 {
    using namespace LV2Symbols;
 
@@ -118,41 +66,7 @@ bool LV2FeaturesList::InitializeOptions()
    return true;
 }
 
-bool LV2FeaturesList::InitializeFeatures()
-{
-   // Construct null-terminated array of "features" describing our capabilities
-   // to lv2, and validate
-   AddFeature(LV2_UI__noUserResize, nullptr);
-   AddFeature(LV2_UI__fixedSize, nullptr);
-   AddFeature(LV2_UI__idleInterface, nullptr);
-   AddFeature(LV2_UI__makeResident, nullptr);
-   AddFeature(LV2_BUF_SIZE__boundedBlockLength, nullptr);
-   AddFeature(LV2_BUF_SIZE__fixedBlockLength, nullptr);
-   AddFeature(LV2_OPTIONS__options, mOptions.data());
-   AddFeature(LV2_URI_MAP_URI, &mUriMapFeature);
-   AddFeature(LV2_URID__map, &mURIDMapFeature);
-   AddFeature(LV2_URID__unmap, &mURIDUnmapFeature);
-   AddFeature(LV2_LOG__log, &mLogFeature);
-   // Some plugins specify this as a feature
-   AddFeature(LV2_EXTERNAL_UI__Widget, nullptr);
-   return true;
-}
-
-bool LV2FeaturesList::SuppliesWorkerInterface(const LilvPlugin &plug)
-{
-   bool result = false;
-   if (LilvNodesPtr extdata{ lilv_plugin_get_extension_data(&plug) }) {
-      LILV_FOREACH(nodes, i, extdata.get()) {
-         const auto node = lilv_nodes_get(extdata.get(), i);
-         const auto uri = lilv_node_as_string(node);
-         if (strcmp(uri, LV2_WORKER__interface) == 0)
-            result = true;
-      }
-   }
-   return result;
-}
-
-size_t LV2FeaturesList::AddOption(
+size_t LV2InstanceFeaturesList::AddOption(
    LV2_URID key, uint32_t size, LV2_URID type, const void *value)
 {
    int ndx = mOptions.size();
@@ -164,24 +78,8 @@ size_t LV2FeaturesList::AddOption(
    return ndx;
 }
 
-void LV2FeaturesList::AddFeature(const char *uri, const void *data)
-{
-   // This casting to const is innocent
-   // We pass our "virtual function tables" or array of options, which the
-   // library presumably will not change
-   mFeatures.emplace_back(LV2_Feature{ uri, const_cast<void*>(data) });
-}
-
-auto LV2FeaturesList::GetFeaturePointers() const -> FeaturePointers
-{
-   FeaturePointers result;
-   for (auto &feature : mFeatures)
-      result.push_back(&feature);
-   result.push_back(nullptr);
-   return result;
-}
-
-const LV2_Options_Option *LV2FeaturesList::NominalBlockLengthOption() const
+const LV2_Options_Option *
+LV2InstanceFeaturesList::NominalBlockLengthOption() const
 {
    if (mSupportsNominalBlockLength)
       return &mOptions[mBlockSizeOption];
@@ -189,51 +87,13 @@ const LV2_Options_Option *LV2FeaturesList::NominalBlockLengthOption() const
       return nullptr;
 }
 
-bool LV2FeaturesListBase::ValidateFeatures(const LilvNode *subject)
-{
-   return CheckFeatures(subject, true) && CheckFeatures(subject, false);
-}
-
-bool LV2FeaturesListBase::CheckFeatures(const LilvNode *subject, bool required)
-{
-   using namespace LV2Symbols;
-   bool supported = true;
-   auto predicate = required ? node_RequiredFeature : node_OptionalFeature;
-   if (LilvNodesPtr nodes{
-      lilv_world_find_nodes(gWorld, subject, predicate, nullptr) }
-   ){
-      LILV_FOREACH(nodes, i, nodes.get()) {
-         const auto node = lilv_nodes_get(nodes.get(), i);
-         const auto uri = lilv_node_as_string(node);
-         if ((strcmp(uri, LV2_UI__noUserResize) == 0) ||
-             (strcmp(uri, LV2_UI__fixedSize) == 0))
-            mNoResize = true;
-         else if (strcmp(uri, LV2_WORKER__schedule) == 0) {
-            /* Supported but handled in LV2Wrapper */
-         }
-         else if (required) {
-            auto features = GetFeaturePointers();
-            const auto end = features.end();
-            supported = (end != std::find_if(features.begin(), end,
-               [&](auto &pFeature){ return pFeature &&
-                  strcmp(pFeature->URI, uri) == 0; }));
-            if (!supported) {
-               wxLogError(wxT("%s requires unsupported feature %s"),
-                  lilv_node_as_string(lilv_plugin_get_uri(&mPlug)), uri);
-               break;
-            }
-         }
-      }
-   }
-   return supported;
-}
-
-bool LV2FeaturesList::ValidateOptions(const LilvNode *subject)
+bool LV2InstanceFeaturesList::ValidateOptions(const LilvNode *subject)
 {
    return CheckOptions(subject, true) && CheckOptions(subject, false);
 }
 
-bool LV2FeaturesList::CheckOptions(const LilvNode *subject, bool required)
+bool LV2InstanceFeaturesList::CheckOptions(
+   const LilvNode *subject, bool required)
 {
    using namespace LV2Symbols;
    bool supported = true;
@@ -245,7 +105,9 @@ bool LV2FeaturesList::CheckOptions(const LilvNode *subject, bool required)
       LILV_FOREACH(nodes, i, nodes.get()) {
          const auto node = lilv_nodes_get(nodes.get(), i);
          const auto uri = lilv_node_as_string(node);
-         const auto urid = URID_Map(uri);
+         // The signature of our constructor justifies this static_cast
+         const auto urid = static_cast<const LV2FeaturesList&>(mBaseFeatures)
+            .URID_Map(uri);
          if (urid == urid_NominalBlockLength)
             mSupportsNominalBlockLength = true;
          // else if (urid == urid_SampleRate)
@@ -264,100 +126,3 @@ bool LV2FeaturesList::CheckOptions(const LilvNode *subject, bool required)
    }
    return supported;
 }
-
-// ============================================================================
-// Feature handlers
-// ============================================================================
-
-// static callback
-uint32_t LV2FeaturesList::uri_to_id(
-   LV2_URI_Map_Callback_Data callback_data, const char *, const char *uri)
-{
-   return static_cast<LV2FeaturesList *>(callback_data)->URID_Map(uri);
-}
-
-// static callback
-LV2_URID LV2FeaturesList::urid_map(LV2_URID_Map_Handle handle, const char *uri)
-{
-   return static_cast<LV2FeaturesList *>(handle)->URID_Map(uri);
-}
-
-LV2_URID LV2FeaturesList::URID_Map(const char *uri) const
-{
-   using namespace LV2Symbols;
-   // Map global URIs to lower indices
-   auto urid = Lookup_URI(gURIDMap, uri, false);
-   if (urid > 0)
-      return urid;
-   // Map local URIs to higher indices
-   urid = Lookup_URI(mURIDMap, uri);
-   if (urid > 0)
-      return urid + gURIDMap.size();
-   return 0;
-}
-
-// static callback
-const char *LV2FeaturesList::urid_unmap(LV2_URID_Unmap_Handle handle, LV2_URID urid)
-{
-   return static_cast<LV2FeaturesList *>(handle)->URID_Unmap(urid);
-}
-
-const char *LV2FeaturesList::URID_Unmap(LV2_URID urid)
-{
-   using namespace LV2Symbols;
-   if (urid > 0) {
-      // Unmap lower indices to global URIs
-      if (urid <= static_cast<LV2_URID>(gURIDMap.size()))
-         return mURIDMap[urid - 1].get();
-      // Unmap higher indices to local URIs
-      urid -= gURIDMap.size();
-      if (urid <= static_cast<LV2_URID>(mURIDMap.size()))
-         return mURIDMap[urid - 1].get();
-   }
-   return nullptr;
-}
-
-// static callback
-int LV2FeaturesList::log_printf(
-   LV2_Log_Handle handle, LV2_URID type, const char *fmt, ...)
-{
-   va_list ap;
-   int len;
-
-   va_start(ap, fmt);
-   len = static_cast<LV2FeaturesList *>(handle)->LogVPrintf(type, fmt, ap);
-   va_end(ap);
-
-   return len;
-}
-
-// static callback
-int LV2FeaturesList::log_vprintf(
-   LV2_Log_Handle handle, LV2_URID type, const char *fmt, va_list ap)
-{
-   return static_cast<LV2FeaturesList *>(handle)->LogVPrintf(type, fmt, ap);
-}
-
-int LV2FeaturesList::LogVPrintf(LV2_URID type, const char *fmt, va_list ap)
-{
-   using namespace LV2Symbols;
-   long level = wxLOG_Error;
-   if (type == urid_Error)
-      level = wxLOG_Error;
-   else if (type == urid_Note)
-      level = wxLOG_Info;
-   else if (type == urid_Trace)
-      level = wxLOG_Trace;
-   else if (type == urid_Warning)
-      level = wxLOG_Warning;
-   else
-      level = wxLOG_Message;
-   int len = wxCRT_VsnprintfA(nullptr, 0, fmt, ap);
-   auto msg = std::make_unique<char[]>(len + 1);
-   wxCRT_VsnprintfA(msg.get(), len, fmt, ap);
-   wxString text(msg.get());
-   wxLogGeneric(level,
-      wxT("%s: %s"), GetPluginSymbol(mPlug).Msgid().Translation(), text);
-   return len;
-}
-#endif

--- a/src/effects/lv2/LV2InstanceFeaturesList.cpp
+++ b/src/effects/lv2/LV2InstanceFeaturesList.cpp
@@ -13,15 +13,19 @@
 
 #include "LV2InstanceFeaturesList.h"
 #include <wx/log.h>
-#include "lv2/worker/worker.h"
 
 LV2InstanceFeaturesList::LV2InstanceFeaturesList(
-   const LV2FeaturesList &baseFeatures, float sampleRate
+   const LV2FeaturesList &baseFeatures, float sampleRate,
+   const LV2_Worker_Schedule *pWorkerSchedule
 )  : ExtendedLV2FeaturesList{ baseFeatures }
    , mSampleRate{ sampleRate }
    , mOk{ InitializeOptions() }
 {
    AddFeature(LV2_OPTIONS__options, mOptions.data());
+   if (baseFeatures.SuppliesWorkerInterface()) {
+      // Inform the plugin how to send work to another thread
+      AddFeature( LV2_WORKER__schedule, pWorkerSchedule );
+   }
 }
 
 bool LV2InstanceFeaturesList::InitializeOptions()

--- a/src/effects/lv2/LV2InstanceFeaturesList.cpp
+++ b/src/effects/lv2/LV2InstanceFeaturesList.cpp
@@ -16,8 +16,9 @@
 #include "lv2/worker/worker.h"
 
 LV2InstanceFeaturesList::LV2InstanceFeaturesList(
-   const LV2FeaturesList &baseFeatures
+   const LV2FeaturesList &baseFeatures, float sampleRate
 )  : ExtendedLV2FeaturesList{ baseFeatures }
+   , mSampleRate{ sampleRate }
    , mOk{ InitializeOptions() }
 {
    AddFeature(LV2_OPTIONS__options, mOptions.data());

--- a/src/effects/lv2/LV2InstanceFeaturesList.h
+++ b/src/effects/lv2/LV2InstanceFeaturesList.h
@@ -1,0 +1,173 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file LV2FeaturesList.h
+
+  Paul Licameli split from LV2Effect.h
+
+  Audacity(R) is copyright (c) 1999-2013 Audacity Team.
+  License: GPL v2 or later.  See License.txt.
+
+*********************************************************************/
+
+#ifndef __AUDACITY_LV2_FEATURES_LIST__
+#define __AUDACITY_LV2_FEATURES_LIST__
+
+#if USE_LV2
+
+#include "lv2/log/log.h"
+#include "lv2/options/options.h"
+#include "lv2/uri-map/uri-map.h"
+
+#include "LV2Symbols.h"
+#include "LV2Preferences.h" // for DEFAULT_BLOCKSIZE
+
+// Define a reasonable default sequence size in bytes
+#define DEFAULT_SEQSIZE 8192
+
+using LilvNodesPtr = Lilv_ptr<LilvNodes, lilv_nodes_free>;
+
+//! Abstraction of a list of features, with a check for satisfaction of
+//! requirements of a given lv2 "subject"
+class LV2FeaturesListBase {
+public:
+   explicit LV2FeaturesListBase(const LilvPlugin &plug);
+   virtual ~LV2FeaturesListBase();
+
+   //! Get vector of pointers to features, whose `.data()` can be passed to lv2
+   using FeaturePointers = std::vector<const LV2_Feature *>;
+   virtual FeaturePointers GetFeaturePointers() const = 0;
+
+   /*!
+    @param subject URI of the host or of the UI identifies a resource in lv2
+    @return whether all required features of subject are supported
+    */
+   bool ValidateFeatures(const LilvNode *subject);
+
+   /*!
+    @param subject URI of the host or of the UI identifies a resource in lv2
+    @param required whether to check required or optional features of subject
+    @return true only if `!required` or else all required features are supported
+    */
+   bool CheckFeatures(const LilvNode *subject, bool required);
+
+   const LilvPlugin &mPlug;
+   bool mNoResize{ false };
+};
+
+//! Extends one (immutable) feature list (whose lifetime contains this one's)
+class ExtendedLV2FeaturesList : public LV2FeaturesListBase {
+public:
+   explicit ExtendedLV2FeaturesList(const LV2FeaturesListBase &baseFeatures);
+   virtual ~ExtendedLV2FeaturesList();
+   FeaturePointers GetFeaturePointers() const override;
+   void AddFeature(const char *uri, const void *data);
+   const LV2FeaturesListBase &mBaseFeatures;
+protected:
+   std::vector<LV2_Feature> mFeatures;
+};
+
+class LV2FeaturesList : public LV2FeaturesListBase {
+public:
+   static ComponentInterfaceSymbol GetPluginSymbol(const LilvPlugin &plug);
+
+   explicit LV2FeaturesList(const LilvPlugin &plug);
+   ~LV2FeaturesList() override;
+
+   //! @return success
+   bool InitializeOptions();
+
+   //! To be called after InitializeOptions()
+   //! @return success
+   bool InitializeFeatures();
+
+   FeaturePointers GetFeaturePointers() const override;
+
+   //! @return whether our host should reciprocally supply the
+   //! LV2_Worker_Schedule interface to the plug-in
+   static bool SuppliesWorkerInterface(const LilvPlugin &plug);
+
+   //! @return whether our host should reciprocally supply the
+   //! LV2_Worker_Schedule interface to the plug-in
+   bool SuppliesWorkerInterface() const { return mSuppliesWorkerInterface; }
+   //! @return may be null
+   const LV2_Options_Option *NominalBlockLengthOption() const;
+
+   size_t AddOption(LV2_URID, uint32_t size, LV2_URID, const void *value);
+
+   /*!
+    @param subject URI of a plugin
+    @return whether all required options of subject are supported
+    */
+   bool ValidateOptions(const LilvNode *subject);
+
+   /*!
+    @param subject URI of a plugin
+    @param required whether to check required or optional options of subject
+    @return true only if `!required` or else all required options are supported
+    */
+   bool CheckOptions(const LilvNode *subject, bool required);
+
+   void AddFeature(const char *uri, const void *data);
+
+   //! May be needed before exposing features and options to the plugin
+   void SetSampleRate(float sampleRate) const { mSampleRate = sampleRate; }
+
+   // lv2 functions require a pointer to non-const in places, but presumably
+   // have no need to mutate the members of this structure
+   LV2_URID_Map *URIDMapFeature() const
+   { return const_cast<LV2_URID_Map*>(&mURIDMapFeature); }
+
+protected:
+   static uint32_t uri_to_id(LV2_URI_Map_Callback_Data callback_data,
+      const char *map, const char *uri);
+   static LV2_URID urid_map(LV2_URID_Map_Handle handle, const char *uri);
+   LV2_URID URID_Map(const char *uri) const;
+
+   static const char *urid_unmap(LV2_URID_Unmap_Handle handle, LV2_URID urid);
+   const char *URID_Unmap(LV2_URID urid);
+
+   static int log_printf(LV2_Log_Handle handle,
+      LV2_URID type, const char *fmt, ...);
+   static int log_vprintf(LV2_Log_Handle handle,
+      LV2_URID type, const char *fmt, va_list ap);
+   int LogVPrintf(LV2_URID type, const char *fmt, va_list ap);
+
+   // These objects contain C-style virtual function tables that we fill in
+   const LV2_URI_Map_Feature mUriMapFeature{
+      this, LV2FeaturesList::uri_to_id }; // Features we support
+   const LV2_URID_Map mURIDMapFeature{ this, LV2FeaturesList::urid_map };
+   const LV2_URID_Unmap mURIDUnmapFeature{ this, LV2FeaturesList::urid_unmap };
+   const LV2_Log_Log mLogFeature{
+      this, LV2FeaturesList::log_printf, LV2FeaturesList::log_vprintf };
+
+   //! Per-effect URID map allocates an ID for each URI on first lookup
+   /*!
+    This is some state shared among all instances of an effect, but logically
+    const as a mapping, assuming all reverse lookups of any urid (integer) are
+    done only after at least one lookup of the related uri (string)
+    */
+   mutable LV2Symbols::URIDMap mURIDMap;
+
+   std::vector<LV2_Options_Option> mOptions;
+   size_t mBlockSizeOption{};
+
+   std::vector<LV2_Feature> mFeatures;
+
+   size_t mBlockSize{ LV2Preferences::DEFAULT_BLOCKSIZE };
+   int mSeqSize{ DEFAULT_SEQSIZE };
+
+   const bool mSuppliesWorkerInterface;
+   bool mSupportsNominalBlockLength{ false };
+
+public:
+   size_t mMinBlockSize{ 1 };
+   size_t mMaxBlockSize{ mBlockSize };
+   mutable float mSampleRate{ 44100 };
+
+   const bool mOk;
+};
+
+#endif
+#endif

--- a/src/effects/lv2/LV2InstanceFeaturesList.h
+++ b/src/effects/lv2/LV2InstanceFeaturesList.h
@@ -2,7 +2,7 @@
 
   Audacity: A Digital Audio Editor
 
-  @file LV2FeaturesList.h
+  @file LV2InstanceFeaturesList.h
 
   Paul Licameli split from LV2Effect.h
 
@@ -11,86 +11,20 @@
 
 *********************************************************************/
 
-#ifndef __AUDACITY_LV2_FEATURES_LIST__
-#define __AUDACITY_LV2_FEATURES_LIST__
+#ifndef __AUDACITY_LV2_INSTANCE_FEATURES_LIST__
+#define __AUDACITY_LV2_INSTANCE_FEATURES_LIST__
 
 #if USE_LV2
 
-#include "lv2/log/log.h"
+#include "LV2FeaturesList.h"
 #include "lv2/options/options.h"
-#include "lv2/uri-map/uri-map.h"
 
-#include "LV2Symbols.h"
-#include "LV2Preferences.h" // for DEFAULT_BLOCKSIZE
-
-// Define a reasonable default sequence size in bytes
-#define DEFAULT_SEQSIZE 8192
-
-using LilvNodesPtr = Lilv_ptr<LilvNodes, lilv_nodes_free>;
-
-//! Abstraction of a list of features, with a check for satisfaction of
-//! requirements of a given lv2 "subject"
-class LV2FeaturesListBase {
-public:
-   explicit LV2FeaturesListBase(const LilvPlugin &plug);
-   virtual ~LV2FeaturesListBase();
-
-   //! Get vector of pointers to features, whose `.data()` can be passed to lv2
-   using FeaturePointers = std::vector<const LV2_Feature *>;
-   virtual FeaturePointers GetFeaturePointers() const = 0;
-
-   /*!
-    @param subject URI of the host or of the UI identifies a resource in lv2
-    @return whether all required features of subject are supported
-    */
-   bool ValidateFeatures(const LilvNode *subject);
-
-   /*!
-    @param subject URI of the host or of the UI identifies a resource in lv2
-    @param required whether to check required or optional features of subject
-    @return true only if `!required` or else all required features are supported
-    */
-   bool CheckFeatures(const LilvNode *subject, bool required);
-
-   const LilvPlugin &mPlug;
-   bool mNoResize{ false };
-};
-
-//! Extends one (immutable) feature list (whose lifetime contains this one's)
-class ExtendedLV2FeaturesList : public LV2FeaturesListBase {
-public:
-   explicit ExtendedLV2FeaturesList(const LV2FeaturesListBase &baseFeatures);
-   virtual ~ExtendedLV2FeaturesList();
-   FeaturePointers GetFeaturePointers() const override;
-   void AddFeature(const char *uri, const void *data);
-   const LV2FeaturesListBase &mBaseFeatures;
-protected:
-   std::vector<LV2_Feature> mFeatures;
-};
-
-class LV2FeaturesList : public LV2FeaturesListBase {
-public:
-   static ComponentInterfaceSymbol GetPluginSymbol(const LilvPlugin &plug);
-
-   explicit LV2FeaturesList(const LilvPlugin &plug);
-   ~LV2FeaturesList() override;
+struct LV2InstanceFeaturesList final : ExtendedLV2FeaturesList {
+   explicit LV2InstanceFeaturesList(const LV2FeaturesList &baseFeatures);
 
    //! @return success
    bool InitializeOptions();
 
-   //! To be called after InitializeOptions()
-   //! @return success
-   bool InitializeFeatures();
-
-   FeaturePointers GetFeaturePointers() const override;
-
-   //! @return whether our host should reciprocally supply the
-   //! LV2_Worker_Schedule interface to the plug-in
-   static bool SuppliesWorkerInterface(const LilvPlugin &plug);
-
-   //! @return whether our host should reciprocally supply the
-   //! LV2_Worker_Schedule interface to the plug-in
-   bool SuppliesWorkerInterface() const { return mSuppliesWorkerInterface; }
    //! @return may be null
    const LV2_Options_Option *NominalBlockLengthOption() const;
 
@@ -109,62 +43,17 @@ public:
     */
    bool CheckOptions(const LilvNode *subject, bool required);
 
-   void AddFeature(const char *uri, const void *data);
-
-   //! May be needed before exposing features and options to the plugin
-   void SetSampleRate(float sampleRate) const { mSampleRate = sampleRate; }
-
-   // lv2 functions require a pointer to non-const in places, but presumably
-   // have no need to mutate the members of this structure
-   LV2_URID_Map *URIDMapFeature() const
-   { return const_cast<LV2_URID_Map*>(&mURIDMapFeature); }
-
-protected:
-   static uint32_t uri_to_id(LV2_URI_Map_Callback_Data callback_data,
-      const char *map, const char *uri);
-   static LV2_URID urid_map(LV2_URID_Map_Handle handle, const char *uri);
-   LV2_URID URID_Map(const char *uri) const;
-
-   static const char *urid_unmap(LV2_URID_Unmap_Handle handle, LV2_URID urid);
-   const char *URID_Unmap(LV2_URID urid);
-
-   static int log_printf(LV2_Log_Handle handle,
-      LV2_URID type, const char *fmt, ...);
-   static int log_vprintf(LV2_Log_Handle handle,
-      LV2_URID type, const char *fmt, va_list ap);
-   int LogVPrintf(LV2_URID type, const char *fmt, va_list ap);
-
-   // These objects contain C-style virtual function tables that we fill in
-   const LV2_URI_Map_Feature mUriMapFeature{
-      this, LV2FeaturesList::uri_to_id }; // Features we support
-   const LV2_URID_Map mURIDMapFeature{ this, LV2FeaturesList::urid_map };
-   const LV2_URID_Unmap mURIDUnmapFeature{ this, LV2FeaturesList::urid_unmap };
-   const LV2_Log_Log mLogFeature{
-      this, LV2FeaturesList::log_printf, LV2FeaturesList::log_vprintf };
-
-   //! Per-effect URID map allocates an ID for each URI on first lookup
-   /*!
-    This is some state shared among all instances of an effect, but logically
-    const as a mapping, assuming all reverse lookups of any urid (integer) are
-    done only after at least one lookup of the related uri (string)
-    */
-   mutable LV2Symbols::URIDMap mURIDMap;
-
    std::vector<LV2_Options_Option> mOptions;
    size_t mBlockSizeOption{};
-
-   std::vector<LV2_Feature> mFeatures;
 
    size_t mBlockSize{ LV2Preferences::DEFAULT_BLOCKSIZE };
    int mSeqSize{ DEFAULT_SEQSIZE };
 
-   const bool mSuppliesWorkerInterface;
    bool mSupportsNominalBlockLength{ false };
 
-public:
    size_t mMinBlockSize{ 1 };
    size_t mMaxBlockSize{ mBlockSize };
-   mutable float mSampleRate{ 44100 };
+   float mSampleRate{ 44100 };
 
    const bool mOk;
 };

--- a/src/effects/lv2/LV2InstanceFeaturesList.h
+++ b/src/effects/lv2/LV2InstanceFeaturesList.h
@@ -18,10 +18,12 @@
 
 #include "LV2FeaturesList.h"
 #include "lv2/options/options.h"
+#include "lv2/worker/worker.h"
 
 struct LV2InstanceFeaturesList final : ExtendedLV2FeaturesList {
    explicit LV2InstanceFeaturesList(
-      const LV2FeaturesList &baseFeatures, float sampleRate = 44100);
+      const LV2FeaturesList &baseFeatures, float sampleRate = 44100,
+      const LV2_Worker_Schedule *pWorkerSchedule = nullptr);
 
    //! @return success
    bool InitializeOptions();

--- a/src/effects/lv2/LV2InstanceFeaturesList.h
+++ b/src/effects/lv2/LV2InstanceFeaturesList.h
@@ -20,7 +20,8 @@
 #include "lv2/options/options.h"
 
 struct LV2InstanceFeaturesList final : ExtendedLV2FeaturesList {
-   explicit LV2InstanceFeaturesList(const LV2FeaturesList &baseFeatures);
+   explicit LV2InstanceFeaturesList(
+      const LV2FeaturesList &baseFeatures, float sampleRate = 44100);
 
    //! @return success
    bool InitializeOptions();
@@ -53,7 +54,7 @@ struct LV2InstanceFeaturesList final : ExtendedLV2FeaturesList {
 
    size_t mMinBlockSize{ 1 };
    size_t mMaxBlockSize{ mBlockSize };
-   float mSampleRate{ 44100 };
+   const float mSampleRate;
 
    const bool mOk;
 };

--- a/src/effects/lv2/LV2UIFeaturesList.cpp
+++ b/src/effects/lv2/LV2UIFeaturesList.cpp
@@ -12,6 +12,31 @@
 **********************************************************************/
 
 #include "LV2UIFeaturesList.h"
+#include "lv2/instance-access/instance-access.h"
+
+LV2UIFeaturesList::LV2UIFeaturesList(
+   const LV2FeaturesListBase &baseFeatures, UIHandler &handler
+)  : ExtendedLV2FeaturesList{ baseFeatures }
+   , mHandler{ handler }
+{
+}
+
+bool LV2UIFeaturesList::InitializeFeatures()
+{
+   // To be set up later when making a dialog:
+   mExtensionDataFeature = {};
+
+   AddFeature(LV2_UI__resize, &mUIResizeFeature);
+   AddFeature(LV2_DATA_ACCESS_URI, &mExtensionDataFeature);
+   AddFeature(LV2_EXTERNAL_UI__Host, &mExternalUIHost);
+   AddFeature(LV2_EXTERNAL_UI_DEPRECATED_URI, &mExternalUIHost);
+   // Two features must be filled in later
+   mInstanceAccessFeature = mFeatures.size();
+   AddFeature(LV2_INSTANCE_ACCESS_URI, nullptr);
+   mParentFeature = mFeatures.size();
+   AddFeature(LV2_UI__parent, nullptr);
+   return ValidateFeatures(lilv_plugin_get_uri(&mPlug));
+}
 
 int LV2UIFeaturesList::ui_resize(LV2UI_Feature_Handle handle,
    int width, int height)

--- a/src/effects/lv2/LV2UIFeaturesList.cpp
+++ b/src/effects/lv2/LV2UIFeaturesList.cpp
@@ -12,10 +12,11 @@
 **********************************************************************/
 
 #include "LV2UIFeaturesList.h"
+#include "LV2InstanceFeaturesList.h"
 #include "lv2/instance-access/instance-access.h"
 
 LV2UIFeaturesList::LV2UIFeaturesList(
-   const LV2FeaturesListBase &baseFeatures, UIHandler &handler,
+   const LV2InstanceFeaturesList &baseFeatures, UIHandler &handler,
    const LilvNode *node, LilvInstance *pInstance, wxWindow *pParent
 )  : ExtendedLV2FeaturesList{ baseFeatures }
    , mHandler{ handler }

--- a/src/effects/lv2/LV2UIFeaturesList.cpp
+++ b/src/effects/lv2/LV2UIFeaturesList.cpp
@@ -15,13 +15,15 @@
 #include "lv2/instance-access/instance-access.h"
 
 LV2UIFeaturesList::LV2UIFeaturesList(
-   const LV2FeaturesListBase &baseFeatures, UIHandler &handler
+   const LV2FeaturesListBase &baseFeatures, UIHandler &handler,
+   const LilvNode *node
 )  : ExtendedLV2FeaturesList{ baseFeatures }
    , mHandler{ handler }
+   , mOk{ InitializeFeatures(node) }
 {
 }
 
-bool LV2UIFeaturesList::InitializeFeatures()
+bool LV2UIFeaturesList::InitializeFeatures(const LilvNode *node)
 {
    // To be set up later when making a dialog:
    mExtensionDataFeature = {};
@@ -35,7 +37,7 @@ bool LV2UIFeaturesList::InitializeFeatures()
    AddFeature(LV2_INSTANCE_ACCESS_URI, nullptr);
    mParentFeature = mFeatures.size();
    AddFeature(LV2_UI__parent, nullptr);
-   return ValidateFeatures(lilv_plugin_get_uri(&mPlug));
+   return ValidateFeatures(node);
 }
 
 int LV2UIFeaturesList::ui_resize(LV2UI_Feature_Handle handle,

--- a/src/effects/lv2/LV2UIFeaturesList.cpp
+++ b/src/effects/lv2/LV2UIFeaturesList.cpp
@@ -1,0 +1,41 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file LV2UIFeaturesList.cpp
+
+  Paul Licameli split from LV2Effect.cpp
+
+  Audacity(R) is copyright (c) 1999-2008 Audacity Team.
+  License: GPL v2 or later.  See License.txt.
+
+**********************************************************************/
+
+#include "LV2UIFeaturesList.h"
+
+int LV2UIFeaturesList::ui_resize(LV2UI_Feature_Handle handle,
+   int width, int height)
+{
+   return static_cast<UIHandler*>(handle)->ui_resize(width, height);
+}
+
+void LV2UIFeaturesList::ui_closed(LV2UI_Controller controller)
+{
+   return static_cast<UIHandler*>(controller)->ui_closed();
+}
+
+uint32_t LV2UIFeaturesList::suil_port_index(
+   SuilController controller, const char *port_symbol)
+{
+   return static_cast<UIHandler *>(controller)->suil_port_index(port_symbol);
+}
+
+void LV2UIFeaturesList::suil_port_write(SuilController controller,
+   uint32_t port_index, uint32_t buffer_size, uint32_t protocol,
+      const void *buffer)
+{
+   return static_cast<UIHandler *>(controller)
+      ->suil_port_write(port_index, buffer_size, protocol, buffer);
+}
+
+LV2UIFeaturesList::UIHandler::~UIHandler() = default;

--- a/src/effects/lv2/LV2UIFeaturesList.cpp
+++ b/src/effects/lv2/LV2UIFeaturesList.cpp
@@ -16,27 +16,27 @@
 
 LV2UIFeaturesList::LV2UIFeaturesList(
    const LV2FeaturesListBase &baseFeatures, UIHandler &handler,
-   const LilvNode *node
+   const LilvNode *node, LilvInstance *pInstance, wxWindow *pParent
 )  : ExtendedLV2FeaturesList{ baseFeatures }
    , mHandler{ handler }
-   , mOk{ InitializeFeatures(node) }
+   , mOk{ InitializeFeatures(node, pInstance, pParent) }
 {
 }
 
-bool LV2UIFeaturesList::InitializeFeatures(const LilvNode *node)
+bool LV2UIFeaturesList::InitializeFeatures(const LilvNode *node,
+   LilvInstance *pInstance, wxWindow *pParent)
 {
-   // To be set up later when making a dialog:
-   mExtensionDataFeature = {};
-
    AddFeature(LV2_UI__resize, &mUIResizeFeature);
+   mExtensionDataFeature = { pInstance
+      ? lilv_instance_get_descriptor(pInstance)->extension_data
+      : nullptr
+   };
    AddFeature(LV2_DATA_ACCESS_URI, &mExtensionDataFeature);
    AddFeature(LV2_EXTERNAL_UI__Host, &mExternalUIHost);
    AddFeature(LV2_EXTERNAL_UI_DEPRECATED_URI, &mExternalUIHost);
-   // Two features must be filled in later
-   mInstanceAccessFeature = mFeatures.size();
-   AddFeature(LV2_INSTANCE_ACCESS_URI, nullptr);
-   mParentFeature = mFeatures.size();
-   AddFeature(LV2_UI__parent, nullptr);
+   AddFeature(LV2_INSTANCE_ACCESS_URI,
+      pInstance ? lilv_instance_get_handle(pInstance) : nullptr);
+   AddFeature(LV2_UI__parent, pParent ? pParent->GetHandle() : nullptr);
    return ValidateFeatures(node);
 }
 

--- a/src/effects/lv2/LV2UIFeaturesList.h
+++ b/src/effects/lv2/LV2UIFeaturesList.h
@@ -1,0 +1,47 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  @file LV2UIFeaturesList.h
+
+  Paul Licameli split from LV2Effect.h
+
+  Audacity(R) is copyright (c) 1999-2013 Audacity Team.
+  License: GPL v2 or later.  See License.txt.
+
+*********************************************************************/
+
+#ifndef __AUDACITY_LV2_UI_FEATURES_LIST__
+#define __AUDACITY_LV2_UI_FEATURES_LIST__
+
+#if USE_LV2
+
+#include "lv2_external_ui.h"
+#include <suil/suil.h>
+
+struct LV2UIFeaturesList final {
+   //! Abstraction of host services that a plug-ins native UI needs
+   struct UIHandler {
+      virtual ~UIHandler();
+      virtual int ui_resize(int width, int height) = 0;
+      virtual void ui_closed() = 0;
+      virtual void suil_port_write(uint32_t port_index, uint32_t buffer_size,
+         uint32_t protocol, const void *buffer) = 0;
+      virtual uint32_t suil_port_index(const char *port_symbol) = 0;
+   };
+
+   /*! @name static functions that dispatch to a UIHandler
+    @{
+    */
+   static int ui_resize(LV2UI_Feature_Handle handle, int width, int height);
+   static void ui_closed(LV2UI_Controller controller);
+   static uint32_t suil_port_index(
+      SuilController controller, const char *port_symbol);
+   static void suil_port_write(SuilController controller,
+      uint32_t port_index, uint32_t buffer_size, uint32_t protocol,
+      const void *buffer);
+   //! @}
+};
+
+#endif
+#endif

--- a/src/effects/lv2/LV2UIFeaturesList.h
+++ b/src/effects/lv2/LV2UIFeaturesList.h
@@ -21,6 +21,8 @@
 #include <suil/suil.h>
 #include "lv2/data-access/data-access.h"
 
+class LV2InstanceFeaturesList;
+
 struct LV2UIFeaturesList final : ExtendedLV2FeaturesList {
    //! Abstraction of host services that a plug-ins native UI needs
    struct UIHandler {
@@ -33,7 +35,7 @@ struct LV2UIFeaturesList final : ExtendedLV2FeaturesList {
    };
 
    LV2UIFeaturesList(
-      const LV2FeaturesListBase &baseFeatures, UIHandler &handler,
+      const LV2InstanceFeaturesList &baseFeatures, UIHandler &handler,
       const LilvNode *node,
       LilvInstance *pInstance = nullptr, wxWindow *pParent = nullptr);
 

--- a/src/effects/lv2/LV2UIFeaturesList.h
+++ b/src/effects/lv2/LV2UIFeaturesList.h
@@ -33,11 +33,14 @@ struct LV2UIFeaturesList final : ExtendedLV2FeaturesList {
    };
 
    LV2UIFeaturesList(
-      const LV2FeaturesListBase &baseFeatures, UIHandler &handler);
+      const LV2FeaturesListBase &baseFeatures, UIHandler &handler,
+      const LilvNode *node);
 
+private:
    //! @return success
-   bool InitializeFeatures();
+   bool InitializeFeatures(const LilvNode *node);
 
+public:
    // publicize
    using ExtendedLV2FeaturesList::mFeatures;
 
@@ -71,6 +74,8 @@ struct LV2UIFeaturesList final : ExtendedLV2FeaturesList {
    size_t mInstanceAccessFeature{};
    //! Index into m_features
    size_t mParentFeature{};
+
+   const bool mOk;
 };
 
 #endif

--- a/src/effects/lv2/LV2UIFeaturesList.h
+++ b/src/effects/lv2/LV2UIFeaturesList.h
@@ -34,11 +34,13 @@ struct LV2UIFeaturesList final : ExtendedLV2FeaturesList {
 
    LV2UIFeaturesList(
       const LV2FeaturesListBase &baseFeatures, UIHandler &handler,
-      const LilvNode *node);
+      const LilvNode *node,
+      LilvInstance *pInstance = nullptr, wxWindow *pParent = nullptr);
 
 private:
    //! @return success
-   bool InitializeFeatures(const LilvNode *node);
+   bool InitializeFeatures(const LilvNode *node,
+      LilvInstance *pInstance, wxWindow *pParent);
 
 public:
    // publicize
@@ -69,11 +71,6 @@ public:
       // The void* bound to the argument of ui_closed will be the same
       // given to suil_instance_new
       LV2UIFeaturesList::ui_closed, lilv_node_as_string(mHumanId.get()) };
-
-   //! Index into m_features
-   size_t mInstanceAccessFeature{};
-   //! Index into m_features
-   size_t mParentFeature{};
 
    const bool mOk;
 };

--- a/src/effects/lv2/LV2Wrapper.cpp
+++ b/src/effects/lv2/LV2Wrapper.cpp
@@ -114,21 +114,9 @@ LV2Wrapper::~LV2Wrapper()
 
 LV2Wrapper::LV2Wrapper(CreateToken&&, const LV2FeaturesList &featuresList,
    const LilvPlugin &plugin, float sampleRate
-)  : mFeaturesList{ featuresList, sampleRate }
-, mInstance{[
-   &featuresList, &instanceFeaturesList = mFeaturesList,
-   &plugin, sampleRate, pWorkerSchedule = &mWorkerSchedule
-](){
+)  : mFeaturesList{ featuresList, sampleRate, &mWorkerSchedule }
+, mInstance{ [&instanceFeaturesList = mFeaturesList, &plugin, sampleRate](){
    auto features = instanceFeaturesList.GetFeaturePointers();
-   if (featuresList.SuppliesWorkerInterface()) {
-      LV2_Feature tempFeature{ LV2_WORKER__schedule, pWorkerSchedule };
-      // Append a feature to the array, only for the plugin instantiation
-      // Insert another pointer before the null
-      // (features are also used elsewhere to instantiate the UI in the
-      // suil_* functions)
-      // It informs the plugin how to send work to another thread
-      features.insert(features.end() - 1, &tempFeature);
-   }
 
 #if defined(__WXMSW__)
    // Plugins may have dependencies that need to be loaded from the same path

--- a/src/effects/lv2/LV2Wrapper.cpp
+++ b/src/effects/lv2/LV2Wrapper.cpp
@@ -113,15 +113,12 @@ LV2Wrapper::~LV2Wrapper()
 }
 
 LV2Wrapper::LV2Wrapper(CreateToken&&, const LV2FeaturesList &featuresList,
-   const LilvPlugin &plugin, double sampleRate
-)  : mFeaturesList{ featuresList }
+   const LilvPlugin &plugin, float sampleRate
+)  : mFeaturesList{ featuresList, sampleRate }
 , mInstance{[
    &featuresList, &instanceFeaturesList = mFeaturesList,
    &plugin, sampleRate, pWorkerSchedule = &mWorkerSchedule
 ](){
-   // Reassign the sample rate, which is pointed to by options, which are
-   // pointed to by features, before we tell the library the features
-   instanceFeaturesList.mSampleRate = sampleRate;
    auto features = instanceFeaturesList.GetFeaturePointers();
    if (featuresList.SuppliesWorkerInterface()) {
       LV2_Feature tempFeature{ LV2_WORKER__schedule, pWorkerSchedule };

--- a/src/effects/lv2/LV2Wrapper.h
+++ b/src/effects/lv2/LV2Wrapper.h
@@ -19,6 +19,7 @@
 #if USE_LV2
 
 #include "LV2Utils.h"
+#include "LV2InstanceFeaturesList.h"
 
 #include "lilv/lilv.h"
 #include "lv2/core/attributes.h"
@@ -30,7 +31,6 @@
 #include <wx/msgqueue.h>
 
 struct LV2EffectSettings;
-class LV2FeaturesList;
 class LV2Ports;
 class LV2PortStates;
 using LilvInstancePtr = Lilv_ptr<LilvInstance, lilv_instance_free>;
@@ -74,7 +74,7 @@ public:
    LV2_Handle GetHandle() const;
    float GetLatency() const;
    void SetFreeWheeling(bool enable);
-   void SetBlockSize();
+   void SendBlockSize();
    void ConsumeResponses();
    static LV2_Worker_Status schedule_work(LV2_Worker_Schedule_Handle handle,
                                           uint32_t size,
@@ -85,10 +85,13 @@ public:
                                     const void *data);
    LV2_Worker_Status Respond(uint32_t size, const void *data);
 
+   LV2InstanceFeaturesList &GetFeatures() { return mFeaturesList; }
+   const LV2InstanceFeaturesList &GetFeatures() const { return mFeaturesList; }
+
 private:
    void ThreadFunction();
 
-   const LV2FeaturesList &mFeaturesList;
+   LV2InstanceFeaturesList mFeaturesList;
 
    // Another object with an explicit virtual function table
    LV2_Worker_Schedule mWorkerSchedule{ this, LV2Wrapper::schedule_work };

--- a/src/effects/lv2/LV2Wrapper.h
+++ b/src/effects/lv2/LV2Wrapper.h
@@ -91,10 +91,10 @@ public:
 private:
    void ThreadFunction();
 
-   LV2InstanceFeaturesList mFeaturesList;
-
    // Another object with an explicit virtual function table
    LV2_Worker_Schedule mWorkerSchedule{ this, LV2Wrapper::schedule_work };
+
+   LV2InstanceFeaturesList mFeaturesList;
 
    //! @invariant not null
    const LilvInstancePtr mInstance;

--- a/src/effects/lv2/LV2Wrapper.h
+++ b/src/effects/lv2/LV2Wrapper.h
@@ -60,7 +60,7 @@ public:
    //! Constructor may spawn a thread
    LV2Wrapper(CreateToken&&,
       const LV2FeaturesList &featuresList,
-      const LilvPlugin &plugin, double sampleRate);
+      const LilvPlugin &plugin, float sampleRate);
 
    //! If a thread was started, joins it
    ~LV2Wrapper();


### PR DESCRIPTION
Another detour along the journey to lv2 statelessness...

... Don't recycle one array of stateful Features in the effect object, when making the user
interface -- instead, make an immutable, throw-away list of features each time there is 
a new dialog; and don't questionably expose a pointer to a temporary to the foreign code.

All that was actually itself just a digression, to enable the next:

Fix some hidden shared state still hiding in the mutable sample rate in the Effect object,
moving it instead into per-LV2Wrapper Options and Features.

So that eliminates one piece of shared state in LV2Instance, but it remains also to eliminate
mMaster and mPortStates from the Effect object.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
