### PR TITLE
Non modal setting dialogs for stacked effects

### DIFF
--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1307,7 +1307,9 @@ struct TrackListEvent
       ADDITION,
 
       //! Posted when a track has been deleted from a tracklist. Also posted when one track replaces another
-      /*! mpTrack points to the first track after the deletion, if there is one. */
+      /*! mpTrack points to the removed track. It is expected, that track is valid during the event.
+       *! mExtra is 1 if the track is being replaced by another track, 0 otherwise.
+       */
       DELETION,
    };
 
@@ -1709,7 +1711,7 @@ private:
    void DataEvent( const std::shared_ptr<Track> &pTrack, int code );
    void EnsureVisibleEvent(
       const std::shared_ptr<Track> &pTrack, bool modifyState );
-   void DeletionEvent(TrackNodePointer node = {});
+   void DeletionEvent(std::weak_ptr<Track> node, bool duringReplace);
    void AdditionEvent(TrackNodePointer node);
    void ResizingEvent(TrackNodePointer node);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -470,6 +470,8 @@ list( APPEND SOURCES
       effects/RealtimeEffectManager.h
       effects/RealtimeEffectState.cpp
       effects/RealtimeEffectState.h
+      effects/RealtimeEffectStateUI.h
+      effects/RealtimeEffectStateUI.cpp
       effects/Repair.cpp
       effects/Repair.h
       effects/Repeat.cpp

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -6,7 +6,7 @@
 
    Paul Licameli
    split from EffectInterface.h
-   
+
 **********************************************************************/
 
 #ifndef __AUDACITY_EFFECTPLUGIN_H__
@@ -83,6 +83,14 @@ public:
       wxWindow &parent, const EffectDialogFactory &factory,
       std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
       bool forceModal = false) = 0;
+
+   //! Returns the EffectUIClientInterface instance for this effect
+   /*!
+    * Usually returns self. May return nullptr. EffectPlugin is responsible for the lifetime of the
+    * returned instance.
+    * @return EffectUIClientInterface object or nullptr, if the effect does not implement the interface.
+    */
+   virtual EffectUIClientInterface* GetEffectUIClientInterface() = 0;
 
    virtual void Preview(EffectSettingsAccess &access, bool dryOnly) = 0;
    virtual bool SaveSettingsAsString(

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -587,6 +587,7 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    // to save the state of the toolbars.
    ToolManager::Get( project ).Destroy();
 
+   window.Publish(ProjectWindowDestroyedMessage {});
    window.DestroyChildren();
 
    // Close project only now, because TrackPanel might have been holding

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -640,7 +640,7 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
 
    mContainerWindow->Initialize(mTrackListWindow);
 
-   auto effectsPanel = safenew ThemedWindowWrapper<RealtimeEffectPanel>(mContainerWindow, wxID_ANY);
+   auto effectsPanel = safenew ThemedWindowWrapper<RealtimeEffectPanel>(mProject, mContainerWindow, wxID_ANY);
    effectsPanel->SetBackgroundColorIndex(clrMedium);
    effectsPanel->Hide();//initially hidden
    effectsPanel->Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent&)

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -699,7 +699,7 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
          {
             auto& project = GetProject();
             auto& trackFocus = TrackFocus::Get(project);
-            ShowEffectsPanel(project, trackFocus.Get());
+            ShowEffectsPanel(trackFocus.Get());
          }
       });
 
@@ -1906,7 +1906,7 @@ void ProjectWindow::DoZoomFit()
    window.TP_ScrollWindow(start);
 }
 
-void ProjectWindow::ShowEffectsPanel(AudacityProject& project, Track* track)
+void ProjectWindow::ShowEffectsPanel(Track* track)
 {
    if(track == nullptr)
    {
@@ -1916,7 +1916,7 @@ void ProjectWindow::ShowEffectsPanel(AudacityProject& project, Track* track)
 
    wxWindowUpdateLocker freeze(this);
 
-   mEffectsWindow->SetTrack(project, track->shared_from_this());
+   mEffectsWindow->SetTrack(track->shared_from_this());
 
    if(mContainerWindow->GetWindow1() != mEffectsWindow)
    {

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -137,7 +137,7 @@ public:
    double GetZoomOfToFit() const;
    void DoZoomFit();
    
-   void ShowEffectsPanel(AudacityProject& project, Track* track = nullptr);
+   void ShowEffectsPanel(Track* track = nullptr);
    void HideEffectsPanel();
    bool IsEffectsPanelShown();
 

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -28,13 +28,18 @@ class RealtimeEffectPanel;
 class ProjectWindow;
 void InitProjectWindow( ProjectWindow &window );
 
+//! Message sent when the project window is closed.
+struct ProjectWindowDestroyedMessage final : Observer::Message {};
+
 ///\brief A top-level window associated with a project, and handling scrollbars
 /// and zooming
 class AUDACITY_DLL_API ProjectWindow final : public ProjectWindowBase
    , public TrackPanelListener
    , public PrefsListener
+   , public Observer::Publisher<ProjectWindowDestroyedMessage>
 {
 public:
+   using Observer::Publisher<ProjectWindowDestroyedMessage>::Publish;
    static ProjectWindow &Get( AudacityProject &project );
    static const ProjectWindow &Get( const AudacityProject &project );
    static ProjectWindow *Find( AudacityProject *pProject );

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -1075,7 +1075,7 @@ RealtimeEffectPanel::RealtimeEffectPanel(
       });
 }
 
-void RealtimeEffectPanel::SetTrack(AudacityProject& project, const std::shared_ptr<Track>& track)
+void RealtimeEffectPanel::SetTrack(const std::shared_ptr<Track>& track)
 {
    //Avoid creation-on-demand of a useless, empty list in case the track is of non-wave type.
    if(track && dynamic_cast<WaveTrack*>(&*track) != nullptr)
@@ -1087,7 +1087,7 @@ void RealtimeEffectPanel::SetTrack(AudacityProject& project, const std::shared_p
             ? bmpEffectOn
             : bmpEffectOff
       );
-      mEffectList->SetTrack(project, track);
+      mEffectList->SetTrack(mProject, track);
 
       mCurrentTrack = track;
    }

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -41,7 +41,10 @@ class RealtimeEffectPanel : public wxWindow
    std::weak_ptr<Track> mCurrentTrack;
 
    Observer::Subscription mTrackListChanged;
-   
+   Observer::Subscription mUndoSubscription;
+
+   std::vector<std::shared_ptr<Track>> mPotentiallyRemovedTracks;
+
 public:
    RealtimeEffectPanel(
       AudacityProject& project, wxWindow* parent,

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -58,6 +58,6 @@ public:
     * \brief Shows effects from the effect stack of the track
     * \param track Pointer to the existing track, or null
     */
-   void SetTrack(AudacityProject& project, const std::shared_ptr<Track>& track);
+   void SetTrack(const std::shared_ptr<Track>& track);
    void ResetTrack();
 };

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -15,6 +15,7 @@
 #include <wx/weakref.h>
 
 #include "ThemedWrappers.h"
+#include "Observer.h"
 
 class Track;
 
@@ -35,9 +36,15 @@ class RealtimeEffectPanel : public wxWindow
    ThemedButtonWrapper<wxBitmapButton>* mToggleEffects{nullptr};
    wxStaticText* mTrackTitle {nullptr};
    RealtimeEffectListWindow* mEffectList{nullptr};
-   wxWeakRef<AudacityProject> mProject;
+   AudacityProject& mProject;
+
+   std::weak_ptr<Track> mCurrentTrack;
+
+   Observer::Subscription mTrackListChanged;
+   
 public:
-   RealtimeEffectPanel(wxWindow *parent,
+   RealtimeEffectPanel(
+      AudacityProject& project, wxWindow* parent,
                 wxWindowID id,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -45,6 +45,11 @@ class RealtimeEffectPanel : public wxWindow
 
    std::vector<std::shared_ptr<Track>> mPotentiallyRemovedTracks;
 
+   // RealtimeEffectPanel is wrapped using ThemedWindowWrapper,
+   // so we cannot subscribe to Prefs directly
+   struct PrefsListenerHelper;
+   std::unique_ptr<PrefsListenerHelper> mPrefsListenerHelper;
+
 public:
    RealtimeEffectPanel(
       AudacityProject& project, wxWindow* parent,
@@ -53,6 +58,8 @@ public:
                 const wxSize& size = wxDefaultSize,
                 long style = 0,
                 const wxString& name = wxPanelNameStr);
+
+   ~RealtimeEffectPanel() override;
 
    /**
     * \brief Shows effects from the effect stack of the track

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -872,6 +872,10 @@ int Effect::MessageBox( const TranslatableString& message,
       : XO("%s: %s").Format( GetName(), titleStr );
    return AudacityMessageBox( message, title, style, mUIParent );
 }
+EffectUIClientInterface* Effect::GetEffectUIClientInterface()
+{
+   return this;
+}
 
 DefaultEffectUIValidator::DefaultEffectUIValidator(
    EffectUIClientInterface &effect, EffectSettingsAccess &access,

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -122,6 +122,8 @@ class AUDACITY_DLL_API Effect /* not final */
    int ShowClientInterface(wxWindow &parent, wxDialog &dialog,
       EffectUIValidator *pValidator, bool forceModal) override;
 
+   EffectUIClientInterface* GetEffectUIClientInterface() override;
+
    // EffectUIClientInterface implementation
 
    std::unique_ptr<EffectUIValidator> PopulateUI(
@@ -179,7 +181,7 @@ class AUDACITY_DLL_API Effect /* not final */
    bool EnableApply(bool enable = true);
 
  protected:
-   
+
    bool EnablePreview(bool enable = true);
 
    //! Default implementation returns false

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -223,7 +223,7 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
 // extending its lifetime while this remains:
 , mpGivenAccess{ access.shared_from_this() }
 , mpAccess{ mpGivenAccess }
-, mpState{ pPriorState }
+, mwState{ pPriorState }
 , mProject{ project }
 , mParent{ parent }
 , mSupportsRealtime{ mEffectUIHost.GetDefinition().SupportsRealtime() }
@@ -1230,6 +1230,8 @@ std::shared_ptr<EffectInstance> EffectUIHost::InitializeInstance()
    // We are still constructing and the return initializes a const member
    std::shared_ptr<EffectInstance> result;
 
+   auto mpState = mwState.lock();
+ 
    bool priorState = (mpState != nullptr);
    if (!priorState) {
       auto gAudioIO = AudioIO::Get();
@@ -1285,6 +1287,8 @@ void EffectUIHost::CleanupRealtime()
    bool noPriorState(mSubscription);
    mSubscription.Reset();
    if (mSupportsRealtime && mInitialized) {
+      auto mpState = mwState.lock();
+
       if (noPriorState && mpState) {
          AudioIO::Get()->RemoveState(mProject, nullptr, mpState);
          mpState.reset();

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -108,7 +108,7 @@ private:
    const EffectPlugin::EffectSettingsAccessPtr mpGivenAccess;
    EffectPlugin::EffectSettingsAccessPtr mpAccess;
    EffectPlugin::EffectSettingsAccessPtr mpAccess2;
-   std::shared_ptr<RealtimeEffectState> mpState{};
+   std::weak_ptr<RealtimeEffectState> mwState{};
    std::unique_ptr<EffectUIValidator> mpValidator;
 
    RegistryPaths mUserPresets;

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -983,7 +983,7 @@ bool EffectNoiseReduction::Worker::Classify(unsigned nWindows, int band)
       // avoid being fooled by up and down excursions into
       // either the mistake of classifying noise as not noise
       // (leaving a musical noise chime), or the opposite
-      // (distorting the signal with a drop out). 
+      // (distorting the signal with a drop out).
       if (nWindows <= 3)
          // No different from second greatest.
          goto secondGreatest;
@@ -1064,7 +1064,7 @@ void EffectNoiseReduction::Worker::ReduceNoise()
          pGain += mBinLow;
          for (size_t jj = mBinLow; jj < mBinHigh; ++jj) {
             const bool isNoise = Classify(nWindows, jj);
-            if (!isNoise) 
+            if (!isNoise)
                *pGain = 1.0;
             ++pGain;
          }
@@ -1415,8 +1415,8 @@ void EffectNoiseReduction::Dialog::DisableControlsIfIsolating()
 #endif
    };
    static const auto nToDisable = sizeof(toDisable) / sizeof(toDisable[0]);
-   
-   bool bIsolating = 
+
+   bool bIsolating =
 #ifdef ISOLATE_CHOICE
       mKeepNoise->GetValue();
 #else

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -83,14 +83,15 @@ RealtimeEffectList::AddState(std::shared_ptr<RealtimeEffectState> pState)
    const auto &id = pState->GetID();
    if (pState->GetEffect() != nullptr) {
       auto shallowCopy = mStates;
-      shallowCopy.emplace_back(move(pState));
+      shallowCopy.emplace_back(pState);
       // Lock for only a short time
       (LockGuard{ mLock }, swap(shallowCopy, mStates));
 
       Publisher<RealtimeEffectListMessage>::Publish({
          RealtimeEffectListMessage::Type::Insert,
          mStates.size() - 1,
-         { }
+         { },
+         pState
       });
 
       return true;
@@ -107,7 +108,7 @@ RealtimeEffectList::ReplaceState(size_t index,
    if (index >= mStates.size())
       return false;
    const auto &id = pState->GetID();
-   if (pState->GetEffect() != nullptr) {
+   if (pState->GetEffect() != nullptr) {     
       auto shallowCopy = mStates;
       swap(pState, shallowCopy[index]);
       // Lock for only a short time
@@ -116,7 +117,8 @@ RealtimeEffectList::ReplaceState(size_t index,
       Publisher<RealtimeEffectListMessage>::Publish({
          RealtimeEffectListMessage::Type::Replace,
          index,
-         { }
+         { },
+         pState
       });
 
       return true;
@@ -133,7 +135,7 @@ void RealtimeEffectList::RemoveState(
    auto end = shallowCopy.end(),
       found = std::find(shallowCopy.begin(), end, pState);
    if (found != end)
-   {
+   {      
       const auto index = std::distance(shallowCopy.begin(), found);
       shallowCopy.erase(found);
 
@@ -143,7 +145,8 @@ void RealtimeEffectList::RemoveState(
       Publisher<RealtimeEffectListMessage>::Publish({
          RealtimeEffectListMessage::Type::Remove,
          static_cast<size_t>(index),
-         { }
+         { },
+         pState
       });
    }
 }
@@ -157,8 +160,8 @@ void RealtimeEffectList::Clear()
    (LockGuard{ mLock }, swap(temp, mStates));
 
    for (auto index = temp.size(); index--;)
-      Publisher<RealtimeEffectListMessage>::Publish({
-         RealtimeEffectListMessage::Type::Remove, index, { } });
+      Publisher<RealtimeEffectListMessage>::Publish(
+         { RealtimeEffectListMessage::Type::Remove, index, {}, temp[index] });
 }
 
 std::optional<size_t> RealtimeEffectList::FindState(
@@ -217,7 +220,8 @@ void RealtimeEffectList::MoveEffect(size_t fromIndex, size_t toIndex)
    Publisher<RealtimeEffectListMessage>::Publish({
       RealtimeEffectListMessage::Type::Move,
       fromIndex,
-      toIndex
+      toIndex,
+      mStates[toIndex]
    });
 }
 

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
 {
    auto result = std::make_unique<RealtimeEffectList>();
    for (auto &pState : mStates)
-      result->mStates.push_back(RealtimeEffectState::make_shared(*pState));
+      result->mStates.push_back(pState);
    result->SetActive(this->IsActive());
    return result;
 }

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -25,18 +25,19 @@ class RealtimeEffectState;
 
 class Track;
 
-struct RealtimeEffectListMessage
+struct RealtimeEffectListMessage final
 {
    enum class Type
    {
-      Insert,///<New effect item was added to the list at srcIndex position
-      Replace,///<Effect item was replaced with a new item at srcIndex position
-      Remove,///<Effect item was removed from the list at srcIndex position
-      Move ///<Item position has changed, from srcIndex to dstIndex
+      Insert,///<New effect item was added to the list at srcIndex position. affectedState is a new state
+      Replace,///<Effect item was replaced with a new item at srcIndex position. affectedState is an old state.
+      Remove,///<Effect item was removed from the list at srcIndex position. affectedState is removed state.
+      Move ///<Item position has changed, from srcIndex to dstIndex.  affectedState is the moved state
    };
    Type type;
    size_t srcIndex;
    size_t dstIndex;
+   std::shared_ptr<RealtimeEffectState> affectedState;
 };
 
 class RealtimeEffectList final

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -213,20 +213,16 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
    std::weak_ptr<RealtimeEffectState> mwState;
 };
 
-RealtimeEffectState::RealtimeEffectState(const PluginID & id)
+RealtimeEffectState::RealtimeEffectState(const PluginID& id)
 {
    SetID(id);
+   BuildAll();
 }
 
-RealtimeEffectState::RealtimeEffectState(const RealtimeEffectState &other)
-  : mID{ other.mID }
-  , mPlugin{ other.mPlugin }
-  , mMainSettings{ other.mMainSettings }
+RealtimeEffectState::~RealtimeEffectState()
 {
-   // Do not copy mWorkerSettings
-}
 
-RealtimeEffectState::~RealtimeEffectState() = default;
+}
 
 void RealtimeEffectState::SetID(const PluginID & id)
 {
@@ -244,7 +240,6 @@ const PluginID& RealtimeEffectState::GetID() const noexcept
 {
    return mID;
 }
-
 
 const EffectInstanceFactory *RealtimeEffectState::GetEffect()
 {
@@ -271,7 +266,7 @@ RealtimeEffectState::EnsureInstance(double sampleRate)
       //! copying settings in the main thread while worker isn't yet running
       mWorkerSettings = mMainSettings;
       mLastActive = IsActive();
-      
+
       //! If there was already an instance, recycle it; else make one here
       if (!pInstance)
          mwInstance = pInstance = mPlugin->MakeInstance();
@@ -279,11 +274,11 @@ RealtimeEffectState::EnsureInstance(double sampleRate)
          return {};
 
       mInitialized = true;
-      
+
       // PRL: conserving pre-3.2.0 behavior, but I don't know why this arbitrary
       // number was important
       pInstance->SetBlockSize(512);
-      
+
       if (!pInstance->RealtimeInitialize(mMainSettings, sampleRate))
          return {};
       return pInstance;
@@ -392,7 +387,7 @@ bool RealtimeEffectState::ProcessStart(bool running)
    // processing scope.
    if (auto pAccessState = TestAccessState())
       pAccessState->WorkerRead();
-   
+
    // Detect transitions of activity state
    auto pInstance = mwInstance.lock();
    bool active = IsActive() && running;

--- a/src/effects/RealtimeEffectStateUI.cpp
+++ b/src/effects/RealtimeEffectStateUI.cpp
@@ -1,0 +1,158 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  RealtimeEffectStateUI.cpp
+
+  Dmitry Vedenko
+
+**********************************************************************/
+#include "RealtimeEffectStateUI.h"
+
+#include <cassert>
+
+#include "EffectUI.h"
+#include "RealtimeEffectState.h"
+
+#include "EffectManager.h"
+#include "ProjectWindow.h"
+#include "Track.h"
+
+namespace
+{
+const RealtimeEffectState::RegisteredFactory realtimeEffectStateUIFactory { [](auto& state)
+   { return std::make_unique<RealtimeEffectStateUI>(state); }
+};
+} // namespace
+
+
+RealtimeEffectStateUI::RealtimeEffectStateUI(RealtimeEffectState& state)
+    : mRealtimeEffectState(state)
+{
+}
+
+RealtimeEffectStateUI::~RealtimeEffectStateUI()
+{
+   Hide();
+}
+
+bool RealtimeEffectStateUI::IsShown() const noexcept
+{
+   return mEffectUIHost != nullptr;
+}
+
+void RealtimeEffectStateUI::Show(AudacityProject& project)
+{
+   if (mEffectUIHost != nullptr && mEffectUIHost->IsShown())
+   {
+      // Bring the host to front
+      mEffectUIHost->Raise();
+      return;
+   }
+
+   const auto ID = mRealtimeEffectState.GetID();
+   const auto effectPlugin = EffectManager::Get().GetEffect(ID);
+
+   if (effectPlugin == nullptr)
+      return;
+
+   EffectUIClientInterface* client = effectPlugin->GetEffectUIClientInterface();
+
+   // Effect has no client interface
+   if (client == nullptr)
+      return;
+
+   auto& projectWindow = ProjectWindow::Get(project);
+
+   std::shared_ptr<EffectInstance> pInstance;
+
+   auto access = mRealtimeEffectState.GetAccess();
+
+   // EffectUIHost invokes shared_from_this on access
+   Destroy_ptr<EffectUIHost> dlg(safenew EffectUIHost(
+      &projectWindow, project, *effectPlugin, *client, pInstance, *access,
+      mRealtimeEffectState.shared_from_this()));
+
+   if (!dlg->Initialize())
+      return;
+
+   // Dialog is owned by its parent now!
+   mEffectUIHost = dlg.release();
+
+   UpdateTitle();
+
+   client->ShowClientInterface(
+      projectWindow, *mEffectUIHost, mEffectUIHost->GetValidator(), false);
+
+   // The dialog was modal? That shouldn't have happened
+   if (mEffectUIHost == nullptr || !mEffectUIHost->IsShown())
+   {
+      assert(false);
+      mEffectUIHost = {};
+   }
+
+   mProjectWindowDestroyedSubscription = projectWindow.Subscribe(
+      [this](ProjectWindowDestroyedMessage) { Hide(); });
+}
+
+void RealtimeEffectStateUI::Hide()
+{
+   if (mEffectUIHost != nullptr)
+   {
+      // EffectUIHost calls Destroy in OnClose handler
+      mEffectUIHost->Close();
+      mEffectUIHost = {};
+   }
+}
+
+void RealtimeEffectStateUI::Toggle(AudacityProject& project)
+{
+   if(IsShown())
+      Hide();
+   else
+      Show(project);
+}
+
+void RealtimeEffectStateUI::UpdateTrackData(const Track& track)
+{
+   mTrackName = track.GetName();
+
+   UpdateTitle();
+}
+
+RealtimeEffectStateUI& RealtimeEffectStateUI::Get(RealtimeEffectState& state)
+{      
+   return state.Get<RealtimeEffectStateUI&>(realtimeEffectStateUIFactory);
+}
+
+const RealtimeEffectStateUI&
+RealtimeEffectStateUI::Get(const RealtimeEffectState& state)
+{
+   return Get(const_cast<RealtimeEffectState&>(state));
+}
+
+void RealtimeEffectStateUI::UpdateTitle()
+{
+   if (mEffectUIHost == nullptr)
+      return;
+
+   if (mEffectName.empty())
+   {
+      const auto ID = mRealtimeEffectState.GetID();
+      const auto effectPlugin = EffectManager::Get().GetEffect(ID);
+
+      if (effectPlugin != nullptr)
+         mEffectName = effectPlugin->GetDefinition().GetName();
+   }
+
+   const auto title =
+      mTrackName.empty() ?
+         mEffectName :
+         /* i18n-hint: First %s is an effect name, second is a track name */
+         XO("%s - %s").Format(mEffectName, mTrackName);
+
+   mEffectUIHost->SetTitle(title);
+   mEffectUIHost->SetName(title);
+}
+

--- a/src/effects/RealtimeEffectStateUI.h
+++ b/src/effects/RealtimeEffectStateUI.h
@@ -1,0 +1,57 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  RealtimeEffectStateUI.h
+
+  Dmitry Vedenko
+
+**********************************************************************/
+#pragma once
+
+// wx/weakref.h misses this include
+#include <type_traits>
+#include <wx/weakref.h>
+
+#include "ClientData.h"
+#include "Observer.h"
+
+class RealtimeEffectState;
+class Track;
+class EffectUIHost;
+class EffectInstance;
+
+class AudacityProject;
+
+//! UI state for realtime effect
+class RealtimeEffectStateUI final :
+    public ClientData::Base
+{
+public:
+   explicit RealtimeEffectStateUI(RealtimeEffectState& state);
+   ~RealtimeEffectStateUI() override;
+
+   [[nodiscard]] bool IsShown() const noexcept;
+
+   void Show(AudacityProject& project);
+   void Hide();
+   void Toggle(AudacityProject& project);
+
+   void UpdateTrackData(const Track& track);
+
+   static RealtimeEffectStateUI &Get(RealtimeEffectState &state);
+   static const RealtimeEffectStateUI &Get(const RealtimeEffectState &state);
+
+private:
+   void UpdateTitle();
+   
+   RealtimeEffectState& mRealtimeEffectState;
+
+   wxWeakRef<EffectUIHost> mEffectUIHost;
+
+   TranslatableString mEffectName;
+   wxString mTrackName;
+
+   Observer::Subscription mProjectWindowDestroyedSubscription;
+}; // class RealtimeEffectStateUI

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -444,7 +444,7 @@ void DoManageRealtimeEffectsSidePanel(AudacityProject &project)
    if (projectWindow.IsEffectsPanelShown())
       projectWindow.HideEffectsPanel();
    else
-      projectWindow.ShowEffectsPanel(project, trackFocus.Get());
+      projectWindow.ShowEffectsPanel(trackFocus.Get());
 }
 
 bool CompareEffectsByName(const PluginDescriptor *a, const PluginDescriptor *b)

--- a/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
@@ -150,7 +150,7 @@ EffectsButtonHandle::~EffectsButtonHandle()
 UIHandle::Result EffectsButtonHandle::CommitChanges
 (const wxMouseEvent &event, AudacityProject *pProject, wxWindow *pParent)
 {
-   ProjectWindow::Get(*pProject).ShowEffectsPanel(*pProject, mpTrack.lock().get());
+   ProjectWindow::Get(*pProject).ShowEffectsPanel(mpTrack.lock().get());
    return RefreshCode::RefreshNone;
 }
 


### PR DESCRIPTION
Resolves: #3102
Resolves: #3366 
Resolves: #3367

This PR makes setting dialogs to be non modal, so Audacity interface can be interactive while the dialog is open.

Key points:

1. One dialog can be opened per one effect instance:
    1. Dialog is closed when the effect instance is removed
    2. Dialog is closed when the track is removed
    3. Dialog survives "destructive" operations on the track, such as recording, using generators and applying destructive effects
    4. Dialog title reflects the name of a track
    5. Dialog title does not (yet) reflect the effect placement inside the stack or any additional parameters (for example - Ardour shows like `Track 1: Distortion [VST3]`). Current design currently lacks this features (@Tantacrul @LWinterberg FYI)
2. This PR does not address #3090. `Apply` behavior is left as is, as it will be removed as a part of #3090
3. Changing effect parameters is not reflected in the Undo Stack. This should be a separate task, and it should be a responsibility of each individual effect subclass to implement such functionality: we need to reflect the changed parameter in the undo text, like "Undo Change Gain". It has been agreed that this can be solved outside the Audacity 3.2 scope. For reference - Garage Band and Motu Performer offer no such functionality and it is unreliable in Ableton.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
