### PR TITLE
Effect settings dialog is always modal for destructive workflows

### DIFF
--- a/src/effects/EffectBase.cpp
+++ b/src/effects/EffectBase.cpp
@@ -166,7 +166,7 @@ bool EffectBase::DoEffect(EffectSettings &settings, double projectRate,
    if ( pParent && dialogFactory && pAccess &&
       IsInteractive()) {
       if (!ShowHostInterface(
-         *pParent, dialogFactory, pInstance, *pAccess, IsBatchProcessing() ) )
+         *pParent, dialogFactory, pInstance, *pAccess, true ) )
          return false;
       else if (!pInstance)
          return false;

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -279,8 +279,7 @@ void AddGroupedEffectMenuItems(
 
       groupNames.push_back( name );
       groupPlugs.push_back(plug->GetID());
-      groupFlags.push_back(
-         plug->IsEffectRealtime() ? realflags : FixBatchFlags( batchflags, plug ) );
+      groupFlags.push_back(FixBatchFlags( batchflags, plug ) );
    }
 
    if (groupNames.size() > 0)
@@ -343,8 +342,7 @@ void AddSortedEffectMenuItems(
       );
 
       groupPlugs.push_back(plug->GetID());
-      groupFlags.push_back(
-         plug->IsEffectRealtime() ? realflags : FixBatchFlags( batchflags, plug ) );
+      groupFlags.push_back(FixBatchFlags( batchflags, plug ) );
    }
 
    if (groupNames.size() > 0)
@@ -383,8 +381,7 @@ auto MakeAddGroupItems(const EffectsMenuGroups& list, CommandFlag batchflags, Co
                groupNames.push_back( name );
 
             groupPlugs.push_back(plug->GetID());
-            groupFlags.push_back(
-               plug->IsEffectRealtime() ? realflags : FixBatchFlags( batchflags, plug ) );
+            groupFlags.push_back(FixBatchFlags( batchflags, plug ) );
          }
 
          if (!groupNames.empty())


### PR DESCRIPTION
Resolves: #2987

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
