### PR TITLE
Fixes `read_packet` implementation for FFmpeg 4.4+

### DIFF
--- a/libraries/lib-ffmpeg-support/impl/avformat/AVIOContextWrapperImpl.inl
+++ b/libraries/lib-ffmpeg-support/impl/avformat/AVIOContextWrapperImpl.inl
@@ -138,6 +138,20 @@ public:
       if (mAVIOContext != nullptr)
          mAVIOContext->direct = direct;
    }
+
+   int Read(uint8_t* buf, int size) override
+   {
+      if (mpFile == nullptr)
+         return AUDACITY_AVERROR(EINVAL);
+
+#if LIBAVFORMAT_VERSION_MAJOR >= 58
+      // At least starting from avformat 58 FFmpeg expects EOF to be returned here
+      // instead of 0. This is critical for some codecs
+      if (mpFile->Eof())
+         return AUDACITY_AVERROR_EOF;
+#endif
+      return static_cast<int>(mpFile->Read(buf, size));
+   }
 };
 
 std::unique_ptr<AVIOContextWrapper> CreateAVIOContextWrapper(const FFmpegFunctions& ffmpeg)

--- a/libraries/lib-ffmpeg-support/wrappers/AVIOContextWrapper.cpp
+++ b/libraries/lib-ffmpeg-support/wrappers/AVIOContextWrapper.cpp
@@ -84,9 +84,11 @@ AVIOContextWrapper::Open(const wxString& fileName, bool forWriting)
 int AVIOContextWrapper::FileRead(void* opaque, uint8_t* buf, int size)
 {
    AVIOContextWrapper* wrapper = static_cast<AVIOContextWrapper*>(opaque);
-   if (!(wrapper && wrapper->mpFile))
-      return {};
-   return wrapper->mpFile->Read(buf, size);
+   
+   if (wrapper == nullptr)
+      return AUDACITY_AVERROR(EINVAL);
+   
+   return wrapper->Read(buf, size);
 }
 
 int AVIOContextWrapper::FileWrite(void* opaque, const uint8_t* buf, int size)

--- a/libraries/lib-ffmpeg-support/wrappers/AVIOContextWrapper.h
+++ b/libraries/lib-ffmpeg-support/wrappers/AVIOContextWrapper.h
@@ -67,15 +67,17 @@ public:
 
    virtual int GetDirect() const noexcept = 0;
    virtual void SetDirect(int direct) noexcept = 0;
+
 protected:
+   virtual int Read(uint8_t* buf, int size) = 0;
    const FFmpegFunctions& mFFmpeg;
    AVIOContext* mAVIOContext { nullptr };
+
+   //! This is held indirectly by unique_ptr just so it can be swapped
+   std::unique_ptr<wxFile> mpFile;
 
 private:
    static int FileRead(void* opaque, uint8_t* buf, int size);
    static int FileWrite(void* opaque, const uint8_t* buf, int size);
    static int64_t FileSeek(void* opaque, int64_t pos, int whence);
-
-   //! This is held indirectly by unique_ptr just so it can be swapped
-   std::unique_ptr<wxFile> mpFile;
 };


### PR DESCRIPTION
Starting from some unknown moment FFmpeg (version 58 at least) requires returning `AVERROR_EOF` to mark the end of stream. 

In all versions FFmpeg accepted negative return values to indicate that error has occurred.

Resolves: #3185 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
