### PR TITLE
various string updates

### DIFF
--- a/plug-ins/equalabel.ny
+++ b/plug-ins/equalabel.ny
@@ -24,7 +24,7 @@ $copyright (_ "Released under terms of the GNU General Public License version 2"
 
 
 ;i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
-$control mode (_ "Create labels based on") choice (("Both" (_ "Number & Interval"))
+$control mode (_ "Create labels based on") choice (("Both" (_ "Number and Interval"))
                                                    ("Number" (_ "Number of Labels"))
                                                    ("Interval" (_ "Label Interval"))) 0
 $control totalnum (_ "Number of labels") int-text "" 10 1 1000

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2246,7 +2246,7 @@ void AdornedRulerPanel::ShowMenu(const wxPoint & pos)
    {
       auto item = rulerMenu.Append(OnClearPlayRegionID,
          /* i18n-hint Clear is a verb */
-         _("Clear Looping Region"));
+         _("Clear Loop"));
    }
 
    {

--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -564,7 +564,7 @@ AttachedItem sAttachment{ wxT("View/Windows"),
    ( FinderScope{ findCommandHandler },
    /* i18n-hint: Clicking this menu item shows the various editing steps
       that have been taken.*/
-      Command( wxT("UndoHistory"), XXO("&History..."), &Handler::OnHistory,
+      Command( wxT("UndoHistory"), XXO("&History"), &Handler::OnHistory,
          AudioIONotBusyFlag() ) )
 };
 

--- a/src/IncompatiblePluginsDialog.cpp
+++ b/src/IncompatiblePluginsDialog.cpp
@@ -50,7 +50,7 @@ IncompatiblePluginsDialog::IncompatiblePluginsDialog(
 
    {
       auto buttonsLayout = std::make_unique<wxBoxSizer>(wxHORIZONTAL);
-      auto pluginManagerButton = safenew wxButton(this, wxID_ANY, _("Manage Plug-ins"));
+      auto pluginManagerButton = safenew wxButton(this, wxID_ANY, _("Manage Plugins"));
       pluginManagerButton->Bind(wxEVT_BUTTON, &IncompatiblePluginsDialog::OnPluginManagerClicked, this);
       buttonsLayout->Add(pluginManagerButton);
 
@@ -72,8 +72,10 @@ void IncompatiblePluginsDialog::SetPlugins(const std::vector<wxString>& plugins)
 {
    mText->SetLabelText(XO(
       "Audacity has found %d incompatible plugins which could "\
-      "not be loaded and are disabled. If you wish to enable them, "\
-      "you can do so from \"Manage Plug-Ins\" or click \"Continue\".")
+      "not be loaded. We have disabled these plugins to avoid any "\
+      "stalling or crashes. If you would still like to attempt "\
+      "to use these plugins, you can enable them using "\
+      "\"Manage Plugins\". Otherwise, select \"Continue\".")
       .Format(static_cast<int>(plugins.size())).Translation());
    mText->Wrap(GetClientSize().GetWidth() - 80);
 

--- a/src/LyricsWindow.cpp
+++ b/src/LyricsWindow.cpp
@@ -232,7 +232,7 @@ CommandHandlerObject &findCommandHandler(AudacityProject &) {
 using namespace MenuTable;
 AttachedItem sAttachment{ wxT("View/Windows"),
    ( FinderScope{ findCommandHandler },
-      Command( wxT("Karaoke"), XXO("&Karaoke..."), &Handler::OnKaraoke,
+      Command( wxT("Karaoke"), XXO("&Karaoke"), &Handler::OnKaraoke,
          LabelTracksExistFlag() ) )
 };
 

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -65,7 +65,7 @@
 
 #include "commands/CommandManager.h"
 
-#define AudacityMixerBoardTitle XO("Audacity Mixer Board%s")
+#define AudacityMixerBoardTitle XO("Audacity Mixer%s")
 
 // class MixerTrackSlider
 
@@ -1553,7 +1553,7 @@ CommandHandlerObject &findCommandHandler(AudacityProject &) {
 using namespace MenuTable;
 AttachedItem sAttachment{ wxT("View/Windows"),
    ( FinderScope{ findCommandHandler },
-      Command( wxT("MixerBoard"), XXO("&Mixer Board..."), &Handler::OnMixerBoard,
+      Command( wxT("MixerBoard"), XXO("&Mixer"), &Handler::OnMixerBoard,
          PlayableTracksExistFlag()) )
 };
 

--- a/src/PluginRegistrationDialog.cpp
+++ b/src/PluginRegistrationDialog.cpp
@@ -391,7 +391,7 @@ END_EVENT_TABLE()
 PluginRegistrationDialog::PluginRegistrationDialog(wxWindow *parent)
 :  wxDialogWrapper(parent,
             wxID_ANY,
-            XO("Manage Plug-ins"),
+            XO("Manage Plugins"),
             wxDefaultPosition, wxDefaultSize,
             wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -1178,7 +1178,7 @@ BaseItemSharedPtr EditMenu()
 
          //////////////////////////////////////////////////////////////////////////
 
-         Command( wxT("EditMetaData"), XXO("&Metadata..."), FN(OnEditMetadata),
+         Command( wxT("EditMetaData"), XXO("&Metadata"), FN(OnEditMetadata),
             AudioIONotBusyFlag() )
 
          //////////////////////////////////////////////////////////////////////////
@@ -1190,7 +1190,7 @@ BaseItemSharedPtr EditMenu()
       // not appear in the Edit menu but instead under Audacity, consistent with
       // MacOS conventions.
       Section( "Preferences",
-         Command( wxT("Preferences"), XXO("Pre&ferences..."), FN(OnPreferences),
+         Command( wxT("Preferences"), XXO("Pre&ferences"), FN(OnPreferences),
             AudioIONotBusyFlag(), prefKey )
       )
 

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -530,7 +530,7 @@ BaseItemSharedPtr HelpMenu()
             FN(OnCheckForUpdates),
             AlwaysEnabledFlag ),
    #endif
-         Command( wxT("About"), XXO("&About Audacity..."), FN(OnAbout),
+         Command( wxT("About"), XXO("&About Audacity"), FN(OnAbout),
             AlwaysEnabledFlag )
       )
    ) ) };

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -1173,7 +1173,7 @@ void AddEffectMenuItemGroup(
             }
             // Done collecting
             table.push_back( Menu( wxEmptyString,
-               XXO("Plug-in %d to %d").Format( groupNdx + 1, end ),
+               XXO("Plugin %d to %d").Format( groupNdx + 1, end ),
                std::move( temp1 )
             ) );
             items = max;
@@ -1461,7 +1461,7 @@ BaseItemSharedPtr ToolsMenu()
          }
       ),
 
-      Command( wxT("ManageMacros"), XXO("&Macros..."),
+      Command( wxT("ManageMacros"), XXO("&Macro Manager"),
             FN(OnManageMacros), AudioIONotBusyFlag() ),
 
          Menu( wxT("Macros"), XXO("&Apply Macro"),

--- a/src/widgets/ErrorReportDialog.cpp
+++ b/src/widgets/ErrorReportDialog.cpp
@@ -137,26 +137,12 @@ ErrorReportDialog::ErrorReportDialog(
                S.AddSpace(0, 20);
 
                S.AddVariableText(XO(
-                     "More information about this error may be available on [[https://audacityteam.org/help]]."))
+                     "More information about this error may be available on [[https://audacityteam.org/errors]]."))
                   ->SetFont(textFont);
-               S.AddSpace(0, 12);
-               S.AddVariableText(XO(
-                     "Click \"Send\" to submit the report to Audacity. This information is collected anonymously."))
-                  ->SetFont(textFont);
-
                S.AddSpace(0, 6);
-
-               /* i18n-hint: %s will be replaced with "our Privacy Policy" */
-               AccessibleLinksFormatter privacyPolicy(
-                  XO("See %s for more info."));
-
-               privacyPolicy.FormatLink(
-                  /* i18n-hint: Title of hyperlink to the privacy policy. This is an object of "See". */
-                  wxT("%s"),
-                  XO("our Privacy Policy"),
-                  "https://www.audacityteam.org/about/desktop-privacy-notice/");
-
-               privacyPolicy.Populate(S);
+               S.AddVariableText(XO(
+                     "Would you like to send an anonymous report to help us fix this issue?"))
+                  ->SetFont(textFont);
             }
             S.EndVerticalLay();
          }
@@ -222,7 +208,7 @@ ErrorReportDialog::ErrorReportDialog(
 
             S.AddSpace(13, 0);
 
-            S.Id(wxID_YES).AddButton(XC("&Send", "crash reporter button"));
+            S.Id(wxID_YES).AddButton(XC("&Send Report", "crash reporter button"));
          }
          S.EndHorizontalLay();
 

--- a/src/widgets/ErrorReportDialog.cpp
+++ b/src/widgets/ErrorReportDialog.cpp
@@ -137,6 +137,10 @@ ErrorReportDialog::ErrorReportDialog(
                S.AddSpace(0, 20);
 
                S.AddVariableText(XO(
+                     "More information about this error may be available on [[https://audacityteam.org/help]]."))
+                  ->SetFont(textFont);
+               S.AddSpace(0, 12);
+               S.AddVariableText(XO(
                      "Click \"Send\" to submit the report to Audacity. This information is collected anonymously."))
                   ->SetFont(textFont);
 

--- a/src/widgets/ErrorReportDialog.cpp
+++ b/src/widgets/ErrorReportDialog.cpp
@@ -136,19 +136,27 @@ ErrorReportDialog::ErrorReportDialog(
 
                S.AddSpace(0, 20);
 
-               S.AddVariableText(XO(
-                     "More information about this error may be available on [[https://audacityteam.org/help]]."))
-                  ->SetFont(textFont);
+               /* i18n-hint: %s is replaced with "here" */
+               AccessibleLinksFormatter errorpage(
+                  XO("More information about this error may be available %s."));
+               
+               errorpage.FormatLink(
+                  /* i18n-hint: Title of hyperlink to audacityteam.org/errors. */
+                  wxT("%s"),
+                  XO("here"),
+                  "https://audacityteam.org/errors");
+               errorpage.Populate(S);
+
                S.AddSpace(0, 12);
                S.AddVariableText(XO(
-                     "Click \"Send\" to submit the report to Audacity. This information is collected anonymously."))
+                     "Would you like to send a report to help us fix this issue?"))
                   ->SetFont(textFont);
 
                S.AddSpace(0, 6);
 
                /* i18n-hint: %s will be replaced with "our Privacy Policy" */
                AccessibleLinksFormatter privacyPolicy(
-                  XO("See %s for more info."));
+                  XO("All reports are anonymous. See %s for more info."));
 
                privacyPolicy.FormatLink(
                   /* i18n-hint: Title of hyperlink to the privacy policy. This is an object of "See". */

--- a/src/widgets/ErrorReportDialog.cpp
+++ b/src/widgets/ErrorReportDialog.cpp
@@ -137,12 +137,26 @@ ErrorReportDialog::ErrorReportDialog(
                S.AddSpace(0, 20);
 
                S.AddVariableText(XO(
-                     "More information about this error may be available on [[https://audacityteam.org/errors]]."))
+                     "More information about this error may be available on [[https://audacityteam.org/help]]."))
                   ->SetFont(textFont);
-               S.AddSpace(0, 6);
+               S.AddSpace(0, 12);
                S.AddVariableText(XO(
-                     "Would you like to send an anonymous report to help us fix this issue?"))
+                     "Click \"Send\" to submit the report to Audacity. This information is collected anonymously."))
                   ->SetFont(textFont);
+
+               S.AddSpace(0, 6);
+
+               /* i18n-hint: %s will be replaced with "our Privacy Policy" */
+               AccessibleLinksFormatter privacyPolicy(
+                  XO("See %s for more info."));
+
+               privacyPolicy.FormatLink(
+                  /* i18n-hint: Title of hyperlink to the privacy policy. This is an object of "See". */
+                  wxT("%s"),
+                  XO("our Privacy Policy"),
+                  "https://www.audacityteam.org/about/desktop-privacy-notice/");
+
+               privacyPolicy.Populate(S);
             }
             S.EndVerticalLay();
          }
@@ -208,7 +222,7 @@ ErrorReportDialog::ErrorReportDialog(
 
             S.AddSpace(13, 0);
 
-            S.Id(wxID_YES).AddButton(XC("&Send Report", "crash reporter button"));
+            S.Id(wxID_YES).AddButton(XC("&Send", "crash reporter button"));
          }
          S.EndHorizontalLay();
 


### PR DESCRIPTION
Resolves: #3199

Also 
* updates the message for the incompatible plugins found window
* renames some instances of plug-ins to plugins
* renames Macros... to Macro Manager (to be in line with Plugin Manager)
* Changes wording in the crash report to not make it look like help on crashes can be found in the privacy policy (and thus fixes #2974)
* fixes #2287
* Fixes #3203 