### PR TITLE
Per track effect refactor 1

### DIFF
--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -480,13 +480,10 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
       auto &selectedRegion = ViewInfo::Get( *pProject ).selectedRegion;
       auto t1 = selectedRegion.t1();
       PasteTimeWarper warper{ t1, mT0 + genLeft->GetEndTime() };
-      left->ClearAndPaste(mT0, t1, genLeft.get(), true, true,
-         &warper);
-
+      left->ClearAndPaste(mT0, t1, genLeft.get(), true, true, &warper);
       if (genRight) {
          genRight->Flush();
-         right->ClearAndPaste(mT0, selectedRegion.t1(),
-            genRight.get(), true, true, nullptr /* &warper */);
+         right->ClearAndPaste(mT0, t1, genRight.get(), true, true, &warper);
       }
    }
 

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -373,10 +373,6 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
          inputBufferCnt -= curBlockSize;
       }
 
-      // "ls" and "rs" serve as the input sample index for the left and
-      // right channels when processing the input samples.  If we flip
-      // over to processing delayed samples, they simply become counters
-      // for the progress display.
       inPos += curBlockSize;
 
       // Get the current number of delayed samples and accumulate

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -215,13 +215,13 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
 }
 
 bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
-   double sampleRate, int count, ChannelNames map,
-   WaveTrack &left, WaveTrack *pRight,
-   sampleCount start, sampleCount len,
+   const double sampleRate, const int count, const ChannelNames map,
+   WaveTrack &left, WaveTrack *const pRight,
+   const sampleCount start, const sampleCount len,
    FloatBuffers &inBuffer, FloatBuffers &outBuffer,
    ArrayOf< float * > &inBufPos, ArrayOf< float *> &outBufPos,
-   size_t bufferSize, size_t blockSize,
-   unsigned numChannels) const
+   const size_t bufferSize, const size_t blockSize,
+   const unsigned numChannels) const
 {
    bool rc = true;
 
@@ -253,15 +253,14 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
    auto inPos = start;
    auto outPos = start;
    auto inputRemaining = len;
-   decltype(instance.GetLatency(settings, sampleRate))
-      curDelay = 0, delayRemaining = 0;
-   decltype(blockSize) curBlockSize = 0;
-   decltype(bufferSize) inputBufferCnt = 0;
-   decltype(bufferSize) outputBufferCnt = 0;
+   sampleCount curDelay = 0, delayRemaining = 0;
+   size_t curBlockSize = 0;
+   size_t inputBufferCnt = 0;
+   size_t outputBufferCnt = 0;
    bool cleared = false;
    auto chans = std::min<unsigned>(GetAudioOutCount(), numChannels);
    std::shared_ptr<WaveTrack> genLeft, genRight;
-   decltype(len) genLength = 0;
+   sampleCount genLength = 0;
    bool isGenerator = GetType() == EffectTypeGenerate;
    bool isProcessor = GetType() == EffectTypeProcess;
    double genDur = 0;

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -16,6 +16,8 @@
 
 #include "Effect.h" // to inherit
 #include "MemoryX.h"
+#include <functional>
+#include <optional>
 
 using FloatBuffers = ArraysOf<float>;
 
@@ -80,8 +82,11 @@ protected:
 
 private:
    bool ProcessPass(Instance &instance, EffectSettings &settings);
+   //! Type of function returning false if user cancels progress
+   using Poller = std::function<bool(sampleCount blockSize)>;
    bool ProcessTrack(Instance &instance, EffectSettings &settings,
-      double sampleRate, int count, ChannelNames map,
+      const Poller &pollUser, std::optional<sampleCount> genLength,
+      double sampleRate, ChannelNames map,
       WaveTrack &left, WaveTrack *pRight,
       sampleCount start, sampleCount len,
       FloatBuffers &inBuffer, FloatBuffers &outBuffer,

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -64,7 +64,7 @@ public:
       //! Called for destructive, non-realtime effect computation
       //! Default implementation returns zero
       virtual sampleCount GetLatency(
-         const EffectSettings &settings, double sampleRate);
+         const EffectSettings &settings, double sampleRate) const;
 
    protected:
       const PerTrackEffect &mProcessor;

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -82,7 +82,7 @@ private:
    bool ProcessPass(Instance &instance, EffectSettings &settings);
    bool ProcessTrack(Instance &instance, EffectSettings &settings,
       double sampleRate, int count, ChannelNames map,
-      WaveTrack *left, WaveTrack *right,
+      WaveTrack &left, WaveTrack *pRight,
       sampleCount start, sampleCount len,
       FloatBuffers &inBuffer, FloatBuffers &outBuffer,
       ArrayOf< float * > &inBufPos, ArrayOf< float *> &outBufPos,

--- a/src/effects/StatefulPerTrackEffect.cpp
+++ b/src/effects/StatefulPerTrackEffect.cpp
@@ -42,7 +42,7 @@ size_t StatefulPerTrackEffect::Instance::ProcessBlock(EffectSettings &settings,
 }
 
 sampleCount StatefulPerTrackEffect::Instance::GetLatency(
-   const EffectSettings &, double)
+   const EffectSettings &, double) const
 {
    return GetEffect().GetLatency();
 }
@@ -75,7 +75,7 @@ size_t StatefulPerTrackEffect::GetBlockSize() const
    return mBlockSize;
 }
 
-sampleCount StatefulPerTrackEffect::GetLatency()
+sampleCount StatefulPerTrackEffect::GetLatency() const
 {
    return 0;
 }

--- a/src/effects/StatefulPerTrackEffect.cpp
+++ b/src/effects/StatefulPerTrackEffect.cpp
@@ -49,7 +49,7 @@ sampleCount StatefulPerTrackEffect::Instance::GetLatency(
 
 std::shared_ptr<EffectInstance> StatefulPerTrackEffect::MakeInstance() const
 {
-   // Cheat with const-cast to return an object that calls through to
+   // Cheat with const_cast to return an object that calls through to
    // non-const methods of a stateful effect.
    // Stateless effects should override this function and be really const
    // correct.
@@ -89,10 +89,4 @@ bool StatefulPerTrackEffect::ProcessInitialize(
 bool StatefulPerTrackEffect::ProcessFinalize()
 {
    return true;
-}
-
-size_t StatefulPerTrackEffect::ProcessBlock(EffectSettings &settings,
-   const float *const *inBlock, float *const *outBlock, size_t blockLen)
-{
-   return 0;
 }

--- a/src/effects/StatefulPerTrackEffect.h
+++ b/src/effects/StatefulPerTrackEffect.h
@@ -43,7 +43,7 @@ public:
          const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
       sampleCount GetLatency(
-         const EffectSettings &settings, double sampleRate) override;
+         const EffectSettings &settings, double sampleRate) const override;
 
    protected:
       StatefulPerTrackEffect &GetEffect() const
@@ -62,7 +62,7 @@ public:
    /*!
     @copydoc PerTrackEffect::Instance::GetLatency()
     */
-   virtual sampleCount GetLatency();
+   virtual sampleCount GetLatency() const;
 
    /*!
     @copydoc PerTrackEffect::Instance::ProcessInitialize()

--- a/src/effects/StatefulPerTrackEffect.h
+++ b/src/effects/StatefulPerTrackEffect.h
@@ -79,7 +79,7 @@ public:
     @copydoc PerTrackEffect::Instance::ProcessBlock()
     */
    virtual size_t ProcessBlock(EffectSettings &settings,
-      const float *const *inBlock, float *const *outBlock, size_t blockLen);
+      const float *const *inBlock, float *const *outBlock, size_t blockLen) = 0;
 
 private:
    bool Process(EffectInstance &instance, EffectSettings &settings) final;

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1009,16 +1009,10 @@ size_t VSTEffect::GetBlockSize() const
    return mBlockSize;
 }
 
-sampleCount VSTEffect::GetLatency()
+sampleCount VSTEffect::GetLatency() const
 {
    if (mUseLatency)
-   {
-      // ??? Threading issue ???
-      auto delay = mBufferDelay;
-      mBufferDelay = 0;
-      return delay;
-   }
-
+      return mBufferDelay;
    return 0;
 }
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -137,7 +137,7 @@ class VSTEffect final
    int GetMidiInCount() const override;
    int GetMidiOutCount() const override;
 
-   sampleCount GetLatency() override;
+   sampleCount GetLatency() const override;
 
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -525,15 +525,13 @@ size_t VST3Effect::GetBlockSize() const
    return mSetup.maxSamplesPerBlock;
 }
 
-sampleCount VST3Effect::GetLatency()
+sampleCount VST3Effect::GetLatency() const
 {
    if(mUseLatency)
    {
       if(!mRealtimeGroupProcessors.empty())
          return mRealtimeGroupProcessors[0]->GetLatency();
-      auto delay = mInitialDelay;
-      mInitialDelay = 0u;
-      return delay;
+      return mInitialDelay;
    }
    return { 0u };
 }

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -123,7 +123,7 @@ public:
    int GetMidiOutCount() const override;
    size_t SetBlockSize(size_t maxBlockSize) override;
    size_t GetBlockSize() const override;
-   sampleCount GetLatency() override;
+   sampleCount GetLatency() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       sampleCount totalLen, ChannelNames chanMap) override;
    bool ProcessFinalize() override;

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -55,13 +55,12 @@ size_t AudioUnitInstance::GetBlockSize() const
 }
 
 sampleCount AudioUnitInstance::GetLatency(
-   const EffectSettings &, double sampleRate)
+   const EffectSettings &, double sampleRate) const
 {
    // Retrieve the latency (can be updated via an event)
-   if (mUseLatency && !mLatencyDone) {
+   if (mUseLatency) {
       Float64 latency = 0.0;
       if (!GetFixedSizeProperty(kAudioUnitProperty_Latency, latency)) {
-         mLatencyDone = true;
          return sampleCount{ latency * sampleRate };
       }
    }
@@ -110,7 +109,6 @@ bool AudioUnitInstance::ProcessInitialize(EffectSettings &settings,
    if (!BypassEffect(false))
       return false;
 
-   mLatencyDone = false;
    return true;
 }
 
@@ -364,8 +362,7 @@ void AudioUnitInstance::EventListener(const AudioUnitEvent *inEvent,
       // Handle latency changes
       if (inEvent->mArgument.mProperty.mPropertyID ==
           kAudioUnitProperty_Latency) {
-         // Allow change to be used
-         //mLatencyDone = false;
+         // Do what?
       }
       return;
    }

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -31,7 +31,7 @@ public:
 private:
    size_t InitialBlockSize() const;
    sampleCount GetLatency(const EffectSettings &settings, double sampleRate)
-      override;
+      const override;
 
    size_t GetBlockSize() const override;
    size_t SetBlockSize(size_t maxBlockSize) override;
@@ -84,6 +84,5 @@ private:
    const unsigned mAudioIns;
    const unsigned mAudioOuts;
    const bool mUseLatency;
-   bool mLatencyDone{ false };
 };
 #endif

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -877,7 +877,7 @@ struct LadspaEffect::Instance
       override;
 
    sampleCount GetLatency(const EffectSettings &settings, double sampleRate)
-      override;
+      const override;
 
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
@@ -897,7 +897,6 @@ struct LadspaEffect::Instance
       { return static_cast<const LadspaEffect &>(mProcessor); }
 
    bool mReady{ false };
-   bool mLatencyDone{ false };
    LADSPA_Handle mMaster{};
 
    // Realtime processing
@@ -930,12 +929,11 @@ int LadspaEffect::GetMidiOutCount() const
 }
 
 sampleCount LadspaEffect::Instance::GetLatency(
-   const EffectSettings &settings, double)
+   const EffectSettings &settings, double) const
 {
    auto &effect = GetEffect();
    auto &controls = GetSettings(settings).controls;
-   if (effect.mUseLatency && effect.mLatencyPort >= 0 && !mLatencyDone) {
-      mLatencyDone = true;
+   if (effect.mUseLatency && effect.mLatencyPort >= 0) {
       return sampleCount{ controls[effect.mLatencyPort] };
    }
    return 0;
@@ -953,7 +951,6 @@ bool LadspaEffect::Instance::ProcessInitialize(
          return false;
       mReady = true;
    }
-   mLatencyDone = false;
    return true;
 }
 

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -20,7 +20,7 @@ class wxArrayString;
 #include "LV2Ports.h"
 #include "../../ShuttleGui.h"
 #include "SampleFormat.h"
-#include "../StatefulPerTrackEffect.h"
+#include "../PerTrackEffect.h"
 
 // We use deprecated LV2 interfaces to remain compatible with older
 // plug-ins, so disable warnings
@@ -33,7 +33,7 @@ LV2_DISABLE_DEPRECATION_WARNINGS
 
 class LV2Validator;
 
-class LV2Effect final : public StatefulPerTrackEffect
+class LV2Effect final : public PerTrackEffect
 {
 public:
    LV2Effect(const LilvPlugin &plug);

--- a/src/effects/lv2/LV2Instance.cpp
+++ b/src/effects/lv2/LV2Instance.cpp
@@ -78,12 +78,10 @@ size_t LV2Instance::GetBlockSize() const
       return LV2Preferences::DEFAULT_BLOCKSIZE;
 }
 
-sampleCount LV2Instance::GetLatency(const EffectSettings &, double)
+sampleCount LV2Instance::GetLatency(const EffectSettings &, double) const
 {
-   if (mMaster && mUseLatency && mPorts.mLatencyPort >= 0 && !mLatencyDone) {
-      mLatencyDone = true;
+   if (mMaster && mUseLatency && mPorts.mLatencyPort >= 0)
       return sampleCount(mMaster->GetLatency());
-   }
    return 0;
 }
 
@@ -98,7 +96,6 @@ bool LV2Instance::ProcessInitialize(EffectSettings &settings,
    for (auto & state : mPortStates.mCVPortStates)
       state.mBuffer.reinit(GetBlockSize(), state.mpPort->mIsInput);
    mMaster->Activate();
-   mLatencyDone = false;
    return true;
 }
 

--- a/src/effects/lv2/LV2Instance.h
+++ b/src/effects/lv2/LV2Instance.h
@@ -39,7 +39,7 @@ public:
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
    override;
    sampleCount GetLatency(
-      const EffectSettings &settings, double sampleRate) override;
+      const EffectSettings &settings, double sampleRate) const override;
 
    const LV2Wrapper *GetMaster() const { return mMaster.get(); }
 
@@ -87,7 +87,6 @@ private:
    size_t mNumSamples{};
    bool mRolling{ true };
    bool mUseLatency{ false };
-   bool mLatencyDone{ false };
 };
 
 #endif


### PR DESCRIPTION
Some preliminaries for addressing issues #3221 (latency) and #3150 (rendering)

Commits ec8ff49fe, 733cb1e4, f6e4fe993 added many arguments to
PerTrackEffect::ProcessTrack() as many unnecessary member variables became
stack variables instead for only the duration of the calling function; this exposed
much of the state ProcessTrack() was using.

This branch begins an encapsulation of this state into some objects of new classes
which will leave ProcessTrack() as a much shorter function with fewer arguments.

It also makes GetLatency() a const member function of effect instances, as it should
be.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
