### PR TITLE
Precondition of ProcessTrack() was too strong for generators

### DIFF
--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -141,8 +141,8 @@ private:
    //! Type of function returning false if user cancels progress
    using Poller = std::function<bool(sampleCount blockSize)>;
    /*!
-    @pre `inBuffers.Channels() > 0`
-    @pre `inBuffers.BufferSize() > 0`
+    @pre `len == 0 || inBuffers.Channels() > 0`
+    @pre `len == 0 || inBuffers.BufferSize() > 0`
     @pre `!pRight || inBuffers.Channels() > 1`
     @pre `outBuffers.Channels() > 0`
     @pre `outBuffers.BufferSize() > 0`


### PR DESCRIPTION
Resolves: #3231

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
