### PR TITLE
LV2 output monitoring

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -109,7 +109,7 @@ auto EffectSettingsManager::MakeSettings() const -> EffectSettings
 }
 
 bool EffectSettingsManager::CopySettingsContents(
-   const EffectSettings &, EffectSettings &) const
+   const EffectSettings &, EffectSettings &, SettingsCopyDirection ) const
 {
    return true;
 }

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -239,6 +239,15 @@ public:
    virtual bool IsHiddenFromMenus() const;
 };
 
+//! Direction in which settings are copied
+enum class SettingsCopyDirection
+{
+   //! Main thread settings replicated to the worker thread
+   MainToWorker,
+   //! Worker thread settings replicated to main thread
+   WorkerToMain
+};
+
 /*************************************************************************************//**
 
 \class EffectSettingsManager
@@ -277,10 +286,11 @@ public:
 
     @param src settings to copy from
     @param dst settings to copy into
+    @param copyDirection direction in which copy is performed
     @return success
     */
    virtual bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst) const;
+      const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection copyDirection) const;
 
    //! Store settings as keys and values
    /*!

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -289,7 +289,7 @@ public:
       return EffectSettings::Make<Settings>();
    }
    bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst) const override
+      const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection) const override
    {
       return EffectSettings::Copy<Settings>(src, dst);
    }

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -189,7 +189,6 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
    void Flush() override {
       if (auto pState = mwState.lock()) {
          if (auto pAccessState = pState->GetAccessState()) {
-            auto &lastSettings = pAccessState->mLastSettings;
             const EffectSettings *pResult{};
             while (!(pResult = FlushAttempt(*pAccessState))) {
                // Wait for progress of audio thread
@@ -197,6 +196,7 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
                std::this_thread::sleep_for(50ms);
             }
             pState->mMainSettings.Set(*pResult); // Update the state
+            pAccessState->mLastSettings = *pResult;
          }
       }
    }

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -78,7 +78,9 @@ public:
       // Worker thread writes the slot
       ToMainSlot& operator=(EffectAndSettings &&arg) {
          // This happens during MessageBuffer's busying of the slot
-         arg.effect.CopySettingsContents(arg.settings, mSettings);
+         arg.effect.CopySettingsContents(
+            arg.settings, mSettings,
+            SettingsCopyDirection::WorkerToMain);
          mSettings.extra = arg.settings.extra;
          return *this;
       }
@@ -111,7 +113,9 @@ public:
       struct Reader { Reader(FromMainSlot &&slot,
          const EffectSettingsManager &effect, EffectSettings &settings) {
             // This happens during MessageBuffer's busying of the slot
-            effect.CopySettingsContents(slot.mSettings, settings);
+            effect.CopySettingsContents(
+               slot.mSettings, settings,
+               SettingsCopyDirection::MainToWorker);
             settings.extra = slot.mSettings.extra;
       } };
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -320,7 +320,7 @@ EffectSettings AudioUnitEffect::MakeSettings() const
 }
 
 bool AudioUnitEffect::CopySettingsContents(
-   const EffectSettings &src, EffectSettings &dst) const
+   const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection) const
 {
    auto &dstSettings = GetSettings(dst);
    auto &srcSettings = GetSettings(src);
@@ -597,7 +597,7 @@ bool AudioUnitEffect::LoadPreset(
       //wxLogError(wxT("Preset key \"%s\" not found in group \"%s\""), PRESET_KEY, group);
       return false;
    }
-   
+
    // Decode it, complementary to what SaveBlobToConfig did
    auto error =
       InterpretBlob(GetSettings(settings), group, wxBase64Decode(parms));

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -69,7 +69,7 @@ public:
 
    EffectSettings MakeSettings() const override;
    bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst) const override;
+      const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection) const override;
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;
@@ -113,7 +113,7 @@ public:
    void ShowOptions() override;
 
    // AudioUnitEffect implementation
-   
+
 private:
    TranslatableString Export(
       const AudioUnitEffectSettings &settings, const wxString & path) const;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -121,7 +121,7 @@ EffectSettings LadspaEffect::MakeSettings() const
 }
 
 bool LadspaEffect::CopySettingsContents(
-   const EffectSettings &src, EffectSettings &dst) const
+   const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection copyDirection) const
 {
    // Do not use the copy constructor of std::vector.  Do an in-place rewrite
    // of the destination vector, which will not allocate memory if dstControls

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -126,10 +126,33 @@ bool LadspaEffect::CopySettingsContents(
    // Do not use the copy constructor of std::vector.  Do an in-place rewrite
    // of the destination vector, which will not allocate memory if dstControls
    // began with sufficient capacity.
+   const auto portCount = mData->PortCount;
+   
    auto &srcControls = GetSettings(src).controls;
    auto &dstControls = GetSettings(dst).controls;
-   dstControls.resize(0);
-   copy(srcControls.begin(), srcControls.end(), back_inserter(dstControls));
+
+   assert(srcControls.size() == portCount);
+   assert(dstControls.size() == portCount);
+
+   const auto portValuesCount =
+      std::min(srcControls.size(), dstControls.size());
+
+   if (portValuesCount != portCount)
+      return false;
+
+   const auto copyOutputs = copyDirection == SettingsCopyDirection::WorkerToMain;
+
+   for (unsigned long p = 0; p < portCount; ++p)
+   {
+      LADSPA_PortDescriptor d = mData->PortDescriptors[p];
+      
+      if (!(LADSPA_IS_PORT_CONTROL(d)))
+         continue;
+
+      if (LADSPA_IS_PORT_INPUT(d) || copyOutputs)
+         dstControls[p] = srcControls[p];
+   }
+   
    return true;
 }
 

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -63,7 +63,8 @@ public:
 
    EffectSettings MakeSettings() const override;
    bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst) const override;
+      const EffectSettings &src, EffectSettings &dst,
+      SettingsCopyDirection copyDirection) const override;
 
    // ComponentInterface implementation
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -191,7 +191,8 @@ EffectSettings LV2Effect::MakeSettings() const
 }
 
 bool LV2Effect::CopySettingsContents(
-   const EffectSettings &src, EffectSettings &dst) const
+   const EffectSettings &src, EffectSettings &dst,
+   SettingsCopyDirection copyDirection) const
 {
    auto &srcControls = GetSettings(src).values;
    auto &dstControls = GetSettings(dst).values;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -197,15 +197,34 @@ bool LV2Effect::CopySettingsContents(
    auto &srcControls = GetSettings(src).values;
    auto &dstControls = GetSettings(dst).values;
 
+   const auto &controlPorts = mPorts.mControlPorts;
+   const auto portsCount = controlPorts.size();
    // Do not use the copy constructor of std::vector.  Do an in-place rewrite
    // of the destination vector, which will not allocate memory if dstControls
    // began with sufficient capacity.
-   // And that will be try if dstControls originated with MakeSettings() or a
+   // And that will be true if dstControls originated with MakeSettings() or a
    // copy of it, because the set of control ports does not vary after
    // initialization of the plug-in.
-   assert(srcControls.size() == dstControls.size());
-   dstControls.resize(0);
-   copy(srcControls.begin(), srcControls.end(), back_inserter(dstControls));
+   assert(srcControls.size() == portsCount);
+   assert(dstControls.size() == portsCount);
+   // But let's be sure
+   const auto portValuesCount =
+      std::min(srcControls.size(), dstControls.size());
+
+   if (portValuesCount != portsCount)
+      return false;
+
+   const auto copyOutputs = copyDirection == SettingsCopyDirection::WorkerToMain;
+   
+   size_t portIndex {};
+
+   for (auto& port : controlPorts)
+   {
+      if (port->mIsInput || copyOutputs)
+         dstControls[portIndex] = srcControls[portIndex];
+
+      ++portIndex;
+   }
 
    // Ignore mpState
 

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -100,7 +100,8 @@ public:
 private:
    EffectSettings MakeSettings() const override;
    bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst) const override;
+      const EffectSettings &src, EffectSettings &dst,
+      SettingsCopyDirection copyDirection) const override;
 
    bool LoadParameters(
       const RegistryPath & group, EffectSettings &settings) const;

--- a/src/effects/lv2/LV2Validator.cpp
+++ b/src/effects/lv2/LV2Validator.cpp
@@ -739,9 +739,12 @@ void LV2Validator::OnIdle(wxIdleEvent &evt)
    // Is this idle time polling for changes of input redundant with
    // TransferDataToWindow or is it really needed?  Probably harmless.
    // In case of output control port values though, it is needed for metering.
+   mAccess.Flush();
+   auto& values = GetSettings(mAccess.Get()).values;
+
    size_t index = 0; for (auto &state : portUIStates.mControlPortStates) {
       auto &port = state.mpPort;
-      const auto &value = GetSettings(mAccess.Get()).values[index];
+      const auto& value = values[index];
       // Let UI know that a port's value has changed
       if (value != state.mLst) {
          suil_instance_port_event(mSuilInstance.get(),


### PR DESCRIPTION
Resolves: #3214 

This PR fixes the output monitoring for LV2 and LADSPA effect families, which are similarly implemented. Unlike AudioUnits - LV2/LADSPA have output ports, that are used to update the UI. 

Audacity implementation maps both input and output ports into the `EffectSettings` instance. During the realtime processing,
Audacity uses double buffered channels to transfer settings data between main and worker threads. In order not to overwrite
output values during this process `SettingsCopyDirection` argument is added to `CopySettingsContents`. This argument is
ignored now by all effects except LV2/LADSPA.

The next issue that was observed - it was not possible to sync `RealtimeEffectState::Access` and `RealtimeEffectState`. The sync now can be performed explicitly by calling `Flush`. It is not possible to sync implicitly, as it breaks effects UI. (That was observed first with AU and fixed by @Paul-Licameli)

`Flush` is called by the LV2Validator inside idle handler. LADSPA implementation is different and it seems that it doesn't require Flush call (but if LADSPA would work properly with non modal dialogs is a question).

This PR does not provide output monitoring for plain UI, see #3240

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
