### PR TITLE
Per track effect buffers again

### DIFF
--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -170,14 +170,13 @@ float &PerTrackEffect::Buffers::GetWritePosition(unsigned iChannel)
    return *mBuffers[iChannel].data();
 }
 
-void PerTrackEffect::Buffers::ClearBuffer(
-   unsigned iChannel, size_t n, size_t offset)
+void PerTrackEffect::Buffers::ClearBuffer(unsigned iChannel, size_t n)
 {
    if (iChannel < mPositions.size()) {
       auto p = mPositions[iChannel];
       auto &buffer = mBuffers[iChannel];
       auto end = buffer.data() + buffer.size();
-      p = std::min(end, p + offset);
+      p = std::min(end, p);
       n = std::min<size_t>(end - p, n);
       std::fill(p, p + n, 0);
    }
@@ -464,20 +463,6 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
             // inputRemaining is positive and bounded by a size_t
             curBlockSize = inputRemaining.as_size_t();
             inputRemaining = 0;
-
-            // Clear the remainder of the buffers so that a full block can be passed
-            // to the effect
-            auto cnt = blockSize - curBlockSize;
-            for (size_t i = 0; i < numChannels; i++)
-               inBuffers.ClearBuffer(i, cnt, curBlockSize);
-
-            // Might be able to use up some of the delayed samples
-            if (delayRemaining != 0) {
-               // Don't use more than needed
-               cnt = limitSampleBufferSize(cnt, delayRemaining);
-               delayRemaining -= cnt;
-               curBlockSize += cnt;
-            }
          }
       }
       // We've exhausted the input samples and are now working on the delay

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -129,8 +129,8 @@ private:
       float &GetWritePosition(unsigned iChannel);
 
       //! Zero-fill n places in one of the buffers,
-      //! starting from its position plus offset
-      void ClearBuffer(unsigned iChannel, size_t n, size_t offset = 0);
+      //! starting from its position
+      void ClearBuffer(unsigned iChannel, size_t n);
    private:
       std::vector<std::vector<float>> mBuffers;
       std::vector<float *> mPositions;

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -117,9 +117,15 @@ private:
       /*!
        @param drop how many values to discard
        @param keep how many following values are defined
+       @pre drop + keep <= Remaining()
+       @post `Remaining()` is unchanged
        */
       void Discard(size_t drop, size_t keep);
       //! Move the positions
+      /*!
+       @pre count <= Remaining()
+       @post `Remaining()` reduced by `count`
+       */
       void Advance(size_t count);
       //! Reset positions to starts of buffers
       /*!


### PR DESCRIPTION
Next steps in refactoring for rendering.

Clarify how the main loop of ProcessTrack manages input and output buffers, and prove there are no overflows, and that
there is loop termination.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
