### PR TITLE
Source stage and sink

### DIFF
--- a/libraries/lib-math/SampleCount.cpp
+++ b/libraries/lib-math/SampleCount.cpp
@@ -10,7 +10,6 @@
 #include "SampleCount.h"
 
 #include <algorithm>
-#include <limits>
 
 #include <wx/debug.h>
 

--- a/libraries/lib-math/SampleCount.h
+++ b/libraries/lib-math/SampleCount.h
@@ -11,6 +11,7 @@
 #define __AUDACITY_SAMPLE_COUNT__
 
 #include <cstddef>
+#include <limits>
 
 //! Positions or offsets within audio files need a wide type
 /*! This type disallows implicit interconversions with narrower types */
@@ -63,6 +64,9 @@ public:
    sampleCount &operator -- () { --value; return *this; }
    sampleCount operator -- (int)
       { sampleCount result{ *this }; --value; return result; }
+
+   static sampleCount min() { return std::numeric_limits<type>::min(); }
+   static sampleCount max() { return std::numeric_limits<type>::max(); }
 
 private:
    type value;

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -124,7 +124,7 @@ unsigned EffectBassTreble::GetAudioOutCount() const
 }
 
 bool EffectBassTreble::ProcessInitialize(
-   EffectSettings &, double sampleRate, sampleCount, ChannelNames)
+   EffectSettings &, double sampleRate, ChannelNames)
 {
    InstanceInit(mMaster, sampleRate);
    return true;

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -58,7 +58,7 @@ public:
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -204,7 +204,7 @@ unsigned EffectDistortion::GetAudioOutCount() const
 }
 
 bool EffectDistortion::ProcessInitialize(
-   EffectSettings &, double sampleRate, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double sampleRate, ChannelNames chanMap)
 {
    InstanceInit(mMaster, sampleRate);
    return true;

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -83,7 +83,7 @@ public:
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -135,7 +135,7 @@ struct EffectDtmf::Instance
    {}
 
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
    override;
@@ -154,7 +154,7 @@ struct EffectDtmf::Instance
 };
 
 bool EffectDtmf::Instance::ProcessInitialize(
-   EffectSettings &settings, double sampleRate, sampleCount, ChannelNames)
+   EffectSettings &settings, double sampleRate, ChannelNames)
 {
    mSampleRate = sampleRate;
 

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -52,7 +52,7 @@ struct EffectEcho::Instance
    {}
 
    bool ProcessInitialize(EffectSettings& settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
 
    size_t ProcessBlock(EffectSettings& settings,
       const float* const* inBlock, float* const* outBlock, size_t blockLen)  override;
@@ -118,7 +118,7 @@ unsigned EffectEcho::GetAudioOutCount() const
 }
 
 bool EffectEcho::Instance::ProcessInitialize(
-   EffectSettings& settings, double sampleRate, sampleCount, ChannelNames)
+   EffectSettings& settings, double sampleRate, ChannelNames)
 {
    auto& echoSettings = GetSettings(settings);  
    if (echoSettings.delay == 0.0)

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -57,7 +57,7 @@ struct EffectEcho::Instance
    size_t ProcessBlock(EffectSettings& settings,
       const float* const* inBlock, float* const* outBlock, size_t blockLen)  override;
 
-   bool ProcessFinalize(void) override;
+   bool ProcessFinalize() noexcept override;
 
    Floats history;
    size_t histPos;
@@ -144,7 +144,7 @@ bool EffectEcho::Instance::ProcessInitialize(
    return history != NULL;
 }
 
-bool EffectEcho::Instance::ProcessFinalize()
+bool EffectEcho::Instance::ProcessFinalize() noexcept
 {
    return true;
 }

--- a/src/effects/Fade.cpp
+++ b/src/effects/Fade.cpp
@@ -78,7 +78,7 @@ unsigned EffectFade::GetAudioOutCount() const
 }
 
 bool EffectFade::ProcessInitialize(
-   EffectSettings &, double, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double, ChannelNames chanMap)
 {
    mSample = 0;
    return true;

--- a/src/effects/Fade.h
+++ b/src/effects/Fade.h
@@ -32,7 +32,7 @@ public:
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -102,7 +102,7 @@ unsigned EffectNoise::GetAudioOutCount() const
 }
 
 bool EffectNoise::ProcessInitialize(EffectSettings &,
-   double sampleRate, sampleCount, ChannelNames)
+   double sampleRate, ChannelNames)
 {
    mSampleRate = sampleRate;
    return true;

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -40,8 +40,8 @@ public:
    EffectType GetType() const override;
 
    unsigned GetAudioOutCount() const override;
-   bool ProcessInitialize(EffectSettings &settings,
-      double sampleRate, sampleCount totalLen, ChannelNames chanMap) override;
+   bool ProcessInitialize(EffectSettings &settings, double sampleRate,
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -385,14 +385,12 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
 
          if (len > 0) {
             assert(numAudioIn > 0); // checked above
-            assert(!pRight || numAudioIn > 1); // asserted when assigning pRight
             assert(bufferSize > 0); // checked above
          }
          inBuffers.Reinit(numAudioIn, blockSize, bufferSize / blockSize);
          if (len > 0) {
             // post of Reinit satisfies pre of ProcessTrack
             assert(inBuffers.Channels() > 0);
-            assert(!pRight || inBuffers.Channels() > 1);
             assert(inBuffers.BufferSize() > 0);
          }
 
@@ -556,7 +554,7 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
             // Fill the input buffers
             left.GetFloats(&inBuffers.GetWritePosition(0),
                inPos, inputBufferCnt);
-            if (pRight)
+            if (pRight && inBuffers.Channels() > 1)
                pRight->GetFloats(&inBuffers.GetWritePosition(1),
                   inPos, inputBufferCnt);
          }

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -42,7 +42,7 @@ bool PerTrackEffect::Instance::ProcessInitialize(EffectSettings &,
    return true;
 }
 
-bool PerTrackEffect::Instance::ProcessFinalize() /* noexcept */
+bool PerTrackEffect::Instance::ProcessFinalize() noexcept
 {
    return true;
 }
@@ -568,10 +568,7 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
       return false;
 
    auto cleanup = finally( [&] {
-      // Allow the plugin to cleanup
-      if (!instance.ProcessFinalize())
-         // In case of non-exceptional flow of control, set rc
-         rc = false;
+      instance.ProcessFinalize();
    } );
 
    // For each input block of samples, we pass it to the effect along with a

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -33,7 +33,7 @@ bool PerTrackEffect::Instance::Process(EffectSettings &settings)
 }
 
 bool PerTrackEffect::Instance::ProcessInitialize(EffectSettings &,
-   double, sampleCount, ChannelNames)
+   double, ChannelNames)
 {
    return true;
 }
@@ -428,7 +428,7 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
    assert(blockSize > 0);
 
    // Give the plugin a chance to initialize
-   if (!instance.ProcessInitialize(settings, sampleRate, len, map))
+   if (!instance.ProcessInitialize(settings, sampleRate, map))
       return false;
 
    { // Start scope for cleanup

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -624,6 +624,9 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
             // See where curBlockSize was decided:
             assert(curBlockSize <= inBuffers.Remaining());
             inBuffers.Advance(curBlockSize);
+            inPos += curBlockSize;
+            if (!pollUser(inPos))
+               return false;
          }
          else if (delayRemaining > 0) {
             // From this point on, we only want to feed zeros to the plugin
@@ -633,7 +636,6 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
                inBuffers.ClearBuffer(i, blockSize);
          }
       }
-      inPos += curBlockSize;
 
       // Preconditions for Discard() and Consume() hold
       // because curBlockSize <= blockSize <= outBuffers.Remaining()
@@ -652,11 +654,6 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
       if (!sink.Acquire(outBuffers))
          return false;
       // Invariant O preserved
-
-      if (!pollUser(inPos)) {
-         rc = false;
-         break;
-      }
    }
 
    // Put any remaining output

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -396,6 +396,11 @@ WaveTrackSink::WaveTrackSink(WaveTrack &left, WaveTrack *pRight,
 
 WaveTrackSink::~WaveTrackSink() = default;
 
+bool WaveTrackSink::AcceptsBuffers(const Buffers &buffers) const
+{
+   return buffers.Channels() > 0;
+}
+
 bool WaveTrackSink::Acquire(Buffers &data)
 {
    if (data.BlockSize() <= data.Remaining()) {
@@ -624,6 +629,7 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
          assert(source.AcceptsBlockSize(inBuffers.BlockSize()));
 
          WaveTrackSink sink{ left, pRight, start, isGenerator, isProcessor };
+         assert(sink.AcceptsBuffers(outBuffers));
 
          // Go process the track(s)
          try {
@@ -659,6 +665,7 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
    Buffers &inBuffers, Buffers &outBuffers) const
 {
    assert(source.AcceptsBuffers(inBuffers));
+   assert(sink.AcceptsBuffers(outBuffers));
 
    bool rc = true;
    const auto blockSize = inBuffers.BlockSize();

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -683,6 +683,7 @@ bool PerTrackEffect::ProcessTrack(Instance &instance, EffectSettings &settings,
    EffectStage stage{ inBuffers,
       instance, settings, sampleRate, genLength, map };
 
+   outBuffers.Rewind();
    // Invariant O: blockSize positions from outBuffers.Positions() available
    // Initially true because of preconditions that outBuffers has the same
    // block size as inBuffers and is rewound

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -103,7 +103,7 @@ void PerTrackEffect::Buffers::Discard(size_t drop, size_t keep)
    sampleCount oldRemaining = Remaining();
 #endif
    // Assert the pre
-   assert(drop + keep < Remaining());
+   assert(drop + keep <= Remaining());
 
 #if 1
    // Bounds checking version not assuming the pre, new in 3.2
@@ -133,7 +133,6 @@ void PerTrackEffect::Buffers::Discard(size_t drop, size_t keep)
 #else
    // Version that assumes the precondition,
    // which pre-3.2 did without known errors
-   assert(drop + keep <= Remaining());
    for (auto position : mPositions)
       memmove(position, position + drop, keep * sizeof(float));
 #endif
@@ -181,7 +180,6 @@ void PerTrackEffect::Buffers::Advance(size_t count)
 #else
    // Version that assumes the precondition,
    // which pre-3.2 did without known errors
-   assert(count <= Remaining());
    for (auto &position : mPositions)
       position += count;
 #endif

--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -79,12 +79,12 @@ bool PerTrackEffect::Process(
    return bGoodResult;
 }
 
-PerTrackEffect::Buffers::Buffers()
+AudioGraph::Buffers::Buffers()
 {
    assert(IsRewound());
 }
 
-void PerTrackEffect::Buffers::Reinit(
+void AudioGraph::Buffers::Reinit(
    unsigned nChannels, size_t blockSize, size_t nBlocks)
 {
    mBuffers.resize(nChannels);
@@ -97,7 +97,7 @@ void PerTrackEffect::Buffers::Reinit(
    Rewind();
 }
 
-void PerTrackEffect::Buffers::Discard(size_t drop, size_t keep)
+void AudioGraph::Buffers::Discard(size_t drop, size_t keep)
 {
 #ifndef NDEBUG
    sampleCount oldRemaining = Remaining();
@@ -140,7 +140,7 @@ void PerTrackEffect::Buffers::Discard(size_t drop, size_t keep)
    assert(oldRemaining == Remaining());
 }
 
-void PerTrackEffect::Buffers::Advance(size_t count)
+void AudioGraph::Buffers::Advance(size_t count)
 {
 #ifndef NDEBUG
    sampleCount oldRemaining = Remaining();
@@ -187,7 +187,7 @@ void PerTrackEffect::Buffers::Advance(size_t count)
    assert(Remaining() == oldRemaining - count);
 }
 
-void PerTrackEffect::Buffers::Rewind()
+void AudioGraph::Buffers::Rewind()
 {
    auto iterP = mPositions.begin();
    for (auto &buffer : mBuffers)
@@ -195,20 +195,20 @@ void PerTrackEffect::Buffers::Rewind()
    assert(IsRewound());
 }
 
-constSamplePtr PerTrackEffect::Buffers::GetReadPosition(unsigned iChannel) const
+constSamplePtr AudioGraph::Buffers::GetReadPosition(unsigned iChannel) const
 {
    iChannel = std::min(iChannel, Channels() - 1);
    auto buffer = mBuffers[iChannel].data();
    return reinterpret_cast<constSamplePtr>(buffer);
 }
 
-float &PerTrackEffect::Buffers::GetWritePosition(unsigned iChannel)
+float &AudioGraph::Buffers::GetWritePosition(unsigned iChannel)
 {
    assert(iChannel < Channels());
    return mBuffers[iChannel].data()[ Position() ];
 }
 
-void PerTrackEffect::Buffers::ClearBuffer(unsigned iChannel, size_t n)
+void AudioGraph::Buffers::ClearBuffer(unsigned iChannel, size_t n)
 {
    if (iChannel < mPositions.size()) {
       auto p = mPositions[iChannel];

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -303,4 +303,32 @@ private:
    size_t mBufferSize{ 0 };
    size_t mBlockSize{ 0 };
 };
+
+class EffectStage final {
+public:
+   using Buffers = AudioGraph::Buffers;
+   using Instance = PerTrackEffect::Instance;
+
+   //! Completes `instance.ProcessInitialize()` or throws a std::exception
+   EffectStage(Buffers &inBuffers,
+      Instance &instance, EffectSettings &settings,
+      double sampleRate, ChannelNames map);
+   EffectStage(const EffectStage&) = delete;
+   EffectStage &operator =(const EffectStage &) = delete;
+   //! Finalizes the instance
+   ~EffectStage();
+
+   //! Produce exactly `curBlockSize` samples in `data`
+   /*!
+    @pre curBlockSize <= data.BlockSize()
+    @pre data.BlockSize() <= data.Remaining()
+    @return success
+    */
+   bool Process(const Buffers &data, size_t curBlockSize) const;
+
+private:
+   Buffers &mInBuffers;
+   Instance &mInstance;
+   EffectSettings &mSettings;
+};
 #endif

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -218,10 +218,11 @@ private:
    //! Type of function returning false if user cancels progress
    using Poller = std::function<bool(sampleCount blockSize)>;
    /*!
+    Previous contents of inBuffers and outBuffers are ignored
+
     @pre `source.AcceptsBuffers(inBuffers)`
     @pre `source.AcceptsBlockSize(inBuffers.BlockSize())`
     @pre `outBuffers.Channels() > 0`
-    @pre `outBuffers.IsRewound()`
     @pre `inBuffers.BlockSize() == outBuffers.BlockSize()`
     */
    bool ProcessTrack(Instance &instance, EffectSettings &settings,

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -40,12 +40,14 @@ public:
    /*!
     May exceeed a single block of production
     Can assume same buffer is passed each time, while the caller advances it
-    over the previous production.  May rewind or rotate the buffer.
+    over the previous production, or discards it, or rotates the buffer.
+    May rewind or rotate the buffer.
 
     @return number of positions available to read from `data` or nullopt to fail
     @pre `AcceptsBuffers(data)`
     @pre `AcceptsBlockSize(data.BlockSize())`
     @pre `bound <= data.BlockSize()`
+    @pre `data.BlockSize() <= data.Remaining()`
     @post result: `!result || *result <= bound`
     @post result: `!result || *result <= data.Remaining()`
     @post result: `!result || *result <= Remaining()`
@@ -351,6 +353,7 @@ public:
 
    /*!
     @pre `bound <= data.BlockSize()`
+    @pre `data.BlockSize() <= data.Remaining()`
     @post result: `!result || *result <= bound`
     @post result: `!result || *result <= data.Remaining()`
     @post result: `!result || *result <= Remaining()`

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -72,6 +72,9 @@ public:
    using Buffers = AudioGraph::Buffers;
 
    virtual ~Sink();
+
+   virtual bool AcceptsBuffers(const Buffers &buffers) const = 0;
+
    //! Guarantee empty space in Buffers before they are written
    /*!
     @return success
@@ -81,8 +84,8 @@ public:
    //! Acknowledge receipt of data in Buffers, which caller may then Advance()
    /*!
     @return success
+    @pre `AcceptsBuffers(data)`
     @pre `curBlockSize <= data.BlockSize()`
-    @pre `data.Channels() > 0`
     */
    virtual bool Release(const Buffers &data, size_t curBlockSize) = 0;
 };
@@ -128,6 +131,9 @@ public:
    WaveTrackSink(WaveTrack &left, WaveTrack *pRight,
       sampleCount start, bool isGenerator, bool isProcessor);
    ~WaveTrackSink() override;
+
+   //! Accepts buffers only if there is at least one channel
+   bool AcceptsBuffers(const Buffers &buffers) const override;
 
    bool Acquire(Buffers &data) override;
    bool Release(const Buffers &data, size_t curBlockSize) override;
@@ -222,7 +228,7 @@ private:
 
     @pre `source.AcceptsBuffers(inBuffers)`
     @pre `source.AcceptsBlockSize(inBuffers.BlockSize())`
-    @pre `outBuffers.Channels() > 0`
+    @pre `sink.AcceptsBuffers(outBuffers)`
     @pre `inBuffers.BlockSize() == outBuffers.BlockSize()`
     */
    bool ProcessTrack(Instance &instance, EffectSettings &settings,

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -212,18 +212,17 @@ private:
    using Poller = std::function<bool(sampleCount blockSize)>;
    /*!
     @pre `inBuffers.BlockSize() > 0`
-    @pre `len == 0 || inBuffers.Channels() > 0`
-    @pre `len == 0 || inBuffers.BufferSize() > 0`
+    @pre `source.Remaining() == 0 || inBuffers.Channels() > 0`
+    @pre `source.Remaining() == 0 || inBuffers.BufferSize() > 0`
     @pre `outBuffers.Channels() > 0`
     @pre `outBuffers.BufferSize() > 0`
     @pre `outBuffers.IsRewound()`
     @pre `inBuffers.BlockSize() == outBuffers.BlockSize()`
     */
    bool ProcessTrack(Instance &instance, EffectSettings &settings,
-      const Poller &pollUser, std::optional<sampleCount> genLength,
+      AudioGraph::Source &source, AudioGraph::Sink &sink,
+      std::optional<sampleCount> genLength,
       double sampleRate, ChannelNames map,
-      WaveTrack &left, WaveTrack *pRight,
-      sampleCount start, sampleCount len,
       Buffers &inBuffers, Buffers &outBuffers, unsigned mNumChannels) const;
 };
 

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -49,7 +49,7 @@ public:
       //! Called at start of destructive processing, for each (mono/stereo) track
       //! Default implementation does nothing, returns true
       virtual bool ProcessInitialize(EffectSettings &settings,
-         double sampleRate, sampleCount totalLen, ChannelNames chanMap);
+         double sampleRate, ChannelNames chanMap);
 
       //! Called at end of destructive processing, for each (mono/stereo) track
       //! Default implementation does nothing, returns true

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -147,7 +147,6 @@ private:
     @pre `inBuffers.BlockSize() > 0`
     @pre `len == 0 || inBuffers.Channels() > 0`
     @pre `len == 0 || inBuffers.BufferSize() > 0`
-    @pre `!pRight || inBuffers.Channels() > 1`
     @pre `outBuffers.Channels() > 0`
     @pre `outBuffers.BufferSize() > 0`
     @pre `outBuffers.IsRewound()`

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -40,17 +40,18 @@ public:
    /*!
     May exceeed a single block of production
 
-    @return number of positions available to read from `data`
+    @return number of positions available to read from `data` or nullopt to fail
     @pre `AcceptsBuffers(data)`
     @pre `AcceptsBlockSize(data.BlockSize())`
-    @post result: `result <= data.BlockSize()`
-    @post result: `result <= data.Remaining()`
-    @post result: `result <= Remaining()`
+    @post result: `!result || *result <= data.BlockSize()`
+    @post result: `!result || *result <= data.Remaining()`
+    @post result: `!result || *result <= Remaining()`
     @post `data.Remaining() > 0`
-    @post result: `Remaining() == 0 || result > 0` (progress guarantee)
+    @post result: `!result || Remaining() == 0 || *result > 0`
+       (progress guarantee)
     @post `Remaining()` is unchanged
     */
-   virtual size_t Acquire(Buffers &data) = 0;
+   virtual std::optional<size_t> Acquire(Buffers &data) = 0;
 
    //! Result includes any amount Acquired and not yet Released
    /*!
@@ -111,7 +112,7 @@ public:
    //! Always true
    bool AcceptsBlockSize(size_t blockSize) const override;
 
-   size_t Acquire(Buffers &data) override;
+   std::optional<size_t> Acquire(Buffers &data) override;
    sampleCount Remaining() const override;
    //! Can test for user cancellation
    bool Release() override;
@@ -339,14 +340,15 @@ public:
    ~EffectStage();
 
    /*!
-    @post result: `result <= data.BlockSize()`
-    @post result: `result <= data.Remaining()`
-    @post result: `result <= Remaining()`
+    @post result: `!result || *result <= data.BlockSize()`
+    @post result: `!result || *result <= data.Remaining()`
+    @post result: `!result || *result <= Remaining()`
     @post `data.Remaining() > 0`
-    @post result: `Remaining() == 0 || result > 0` (progress guarantee)
+    @post result: `!result || *Remaining() == 0 || *result > 0`
+       (progress guarantee)
     @post `Remaining()` is unchanged
     */
-   size_t Acquire(Buffers &data);
+   std::optional<size_t> Acquire(Buffers &data);
    //! May decrease after one Process() happened!  Then constant
    sampleCount Remaining() const;
    //! @post result: `result <= curBlockSize`

--- a/src/effects/PerTrackEffect.h
+++ b/src/effects/PerTrackEffect.h
@@ -178,7 +178,7 @@ public:
       //! Called at end of destructive processing, for each (mono/stereo) track
       //! Default implementation does nothing, returns true
       //! This may be called during stack unwinding:
-      virtual bool ProcessFinalize() /* noexcept */ ;
+      virtual bool ProcessFinalize() noexcept;
 
       //! Called for destructive effect computation
       virtual size_t ProcessBlock(EffectSettings &settings,

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -140,7 +140,7 @@ unsigned EffectPhaser::GetAudioOutCount() const
 }
 
 bool EffectPhaser::ProcessInitialize(
-   EffectSettings &, double sampleRate, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double sampleRate, ChannelNames chanMap)
 {
    InstanceInit(mMaster, sampleRate);
    if (chanMap[0] == ChannelNameFrontRight)

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -64,7 +64,7 @@ public:
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -192,7 +192,7 @@ struct EffectReverb::Instance
    {}
 
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
 
    size_t ProcessBlock(EffectSettings& settings,
       const float* const* inBlock, float* const* outBlock, size_t blockLen)  override;
@@ -307,7 +307,7 @@ auto EffectReverb::RealtimeSupport() const -> RealtimeSince
 static size_t BLOCK = 16384;
 
 bool EffectReverb::Instance::ProcessInitialize(EffectSettings& settings,
-   double sampleRate, sampleCount, ChannelNames chanMap)
+   double sampleRate, ChannelNames chanMap)
 {
    return InstanceInit(settings,
       sampleRate, mMaster, chanMap, /* forceStereo = */ false);

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -197,7 +197,7 @@ struct EffectReverb::Instance
    size_t ProcessBlock(EffectSettings& settings,
       const float* const* inBlock, float* const* outBlock, size_t blockLen)  override;
 
-   bool ProcessFinalize(void) override; // not every effect needs this
+   bool ProcessFinalize(void) noexcept override;
 
    // Realtime section
 
@@ -350,7 +350,7 @@ bool EffectReverb::Instance::InstanceInit(EffectSettings& settings,
    return true;
 }
 
-bool EffectReverb::Instance::ProcessFinalize()
+bool EffectReverb::Instance::ProcessFinalize() noexcept
 {
    return true;
 }

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -198,7 +198,7 @@ unsigned EffectScienFilter::GetAudioOutCount() const
 }
 
 bool EffectScienFilter::ProcessInitialize(
-   EffectSettings &, double, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double, ChannelNames chanMap)
 {
    for (int iPair = 0; iPair < (mOrder + 1) / 2; iPair++)
       mpBiquad[iPair].Reset();

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -55,7 +55,7 @@ public:
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/StatefulPerTrackEffect.cpp
+++ b/src/effects/StatefulPerTrackEffect.cpp
@@ -23,11 +23,10 @@
 StatefulPerTrackEffect::Instance::~Instance() = default;
 
 bool StatefulPerTrackEffect::Instance::ProcessInitialize(
-   EffectSettings &settings, double sampleRate,
-   sampleCount totalLen, ChannelNames chanMap)
+   EffectSettings &settings, double sampleRate, ChannelNames chanMap)
 {
    return GetEffect()
-      .ProcessInitialize(settings, sampleRate, totalLen, chanMap);
+      .ProcessInitialize(settings, sampleRate, chanMap);
 }
 
 bool StatefulPerTrackEffect::Instance::ProcessFinalize() /* noexcept */
@@ -81,7 +80,7 @@ sampleCount StatefulPerTrackEffect::GetLatency() const
 }
 
 bool StatefulPerTrackEffect::ProcessInitialize(
-   EffectSettings &, double, sampleCount, ChannelNames)
+   EffectSettings &, double, ChannelNames)
 {
    return true;
 }

--- a/src/effects/StatefulPerTrackEffect.cpp
+++ b/src/effects/StatefulPerTrackEffect.cpp
@@ -29,7 +29,7 @@ bool StatefulPerTrackEffect::Instance::ProcessInitialize(
       .ProcessInitialize(settings, sampleRate, chanMap);
 }
 
-bool StatefulPerTrackEffect::Instance::ProcessFinalize() /* noexcept */
+bool StatefulPerTrackEffect::Instance::ProcessFinalize() noexcept
 {
    return GetEffect().ProcessFinalize();
 }
@@ -85,7 +85,7 @@ bool StatefulPerTrackEffect::ProcessInitialize(
    return true;
 }
 
-bool StatefulPerTrackEffect::ProcessFinalize()
+bool StatefulPerTrackEffect::ProcessFinalize() noexcept
 {
    return true;
 }

--- a/src/effects/StatefulPerTrackEffect.h
+++ b/src/effects/StatefulPerTrackEffect.h
@@ -38,7 +38,7 @@ public:
       ~Instance() override;
       bool ProcessInitialize(EffectSettings &settings, double sampleRate,
          ChannelNames chanMap) override;
-      bool ProcessFinalize() override;
+      bool ProcessFinalize() noexcept override;
       size_t ProcessBlock(EffectSettings &settings,
          const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
@@ -73,7 +73,7 @@ public:
    /*!
     @copydoc PerTrackEffect::Instance::ProcessFinalize()
     */
-   virtual bool ProcessFinalize() /* noexcept */;
+   virtual bool ProcessFinalize() noexcept;
 
    /*!
     @copydoc PerTrackEffect::Instance::ProcessBlock()

--- a/src/effects/StatefulPerTrackEffect.h
+++ b/src/effects/StatefulPerTrackEffect.h
@@ -37,8 +37,8 @@ public:
       {}
       ~Instance() override;
       bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-         sampleCount totalLen, ChannelNames chanMap) override;
-      bool ProcessFinalize() /* noexcept */ override;
+         ChannelNames chanMap) override;
+      bool ProcessFinalize() override;
       size_t ProcessBlock(EffectSettings &settings,
          const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
@@ -68,7 +68,7 @@ public:
     @copydoc PerTrackEffect::Instance::ProcessInitialize()
     */
    virtual bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap = nullptr);
+      ChannelNames chanMap = nullptr);
 
    /*!
     @copydoc PerTrackEffect::Instance::ProcessFinalize()

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -144,7 +144,7 @@ unsigned EffectToneGen::GetAudioOutCount() const
 }
 
 bool EffectToneGen::ProcessInitialize(
-   EffectSettings &, double sampleRate, sampleCount, ChannelNames chanMap)
+   EffectSettings &, double sampleRate, ChannelNames chanMap)
 {
    mSampleRate = sampleRate;
    mPositionInCycles = 0.0;

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -40,7 +40,7 @@ public:
 
    unsigned GetAudioOutCount() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1029,13 +1029,15 @@ bool VSTEffect::DoProcessInitialize(double sampleRate)
    return true;
 }
 
-bool VSTEffect::ProcessFinalize()
+bool VSTEffect::ProcessFinalize() noexcept
 {
+return GuardedCall<bool>([&]{
    mReady = false;
 
    PowerOff();
 
    return true;
+});
 }
 
 size_t VSTEffect::ProcessBlock(EffectSettings &,

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -999,7 +999,7 @@ bool VSTEffect::IsReady()
 }
 
 bool VSTEffect::ProcessInitialize(
-   EffectSettings &, double sampleRate, sampleCount, ChannelNames)
+   EffectSettings &, double sampleRate, ChannelNames)
 {
    return DoProcessInitialize(sampleRate);
 }
@@ -1066,7 +1066,7 @@ void VSTEffect::SetChannelCount(unsigned numChannels)
 
 bool VSTEffect::RealtimeInitialize(EffectSettings &settings, double sampleRate)
 {
-   return ProcessInitialize(settings, sampleRate, 0, nullptr);
+   return ProcessInitialize(settings, sampleRate, nullptr);
 }
 
 bool VSTEffect::RealtimeAddProcessor(
@@ -1092,7 +1092,7 @@ bool VSTEffect::RealtimeAddProcessor(
       callDispatcher(effEndSetProgram, 0, 0, NULL, 0.0);
    }
 
-   if (!slave->ProcessInitialize(settings, sampleRate, 0, nullptr))
+   if (!slave->ProcessInitialize(settings, sampleRate, nullptr))
       return false;
 
    mSlaves.emplace_back(move(slave));

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -271,7 +271,7 @@ class VSTEffect final
 
    bool IsReady();
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    bool DoProcessInitialize(double sampleRate);
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -273,7 +273,7 @@ class VSTEffect final
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       ChannelNames chanMap) override;
    bool DoProcessInitialize(double sampleRate);
-   bool ProcessFinalize() override;
+   bool ProcessFinalize() noexcept override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -622,12 +622,14 @@ bool VST3Effect::ProcessInitialize(
    return false;
 }
 
-bool VST3Effect::ProcessFinalize()
+bool VST3Effect::ProcessFinalize() noexcept
 {
+return GuardedCall<bool>([&]{
    using namespace Steinberg;
    mActive = false;
    mAudioProcessor->setProcessing(false);
    return mEffectComponent->setActive(false) == Steinberg::kResultOk;
+});
 }
 
 namespace

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -599,7 +599,7 @@ sampleCount VST3Effect::GetLatency() const
 }
 
 bool VST3Effect::ProcessInitialize(
-   EffectSettings &settings, double sampleRate, sampleCount, ChannelNames)
+   EffectSettings &settings, double sampleRate, ChannelNames)
 {
    if(mSetup.sampleRate != sampleRate)
    {
@@ -764,7 +764,7 @@ bool VST3Effect::RealtimeAddProcessor(
       if(!SetupProcessing(*effect->mEffectComponent.get(), effect->mSetup))
          return false;
       
-      if(!effect->ProcessInitialize(settings, sampleRate, {0}, nullptr))
+      if(!effect->ProcessInitialize(settings, sampleRate, nullptr))
          throw std::runtime_error { "VST3 realtime initialization failed" };
 
       mRealtimeGroupProcessors.push_back(std::move(effect));

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -126,7 +126,7 @@ public:
    size_t GetBlockSize() const override;
    sampleCount GetLatency() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -127,7 +127,7 @@ public:
    sampleCount GetLatency() const override;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       ChannelNames chanMap) override;
-   bool ProcessFinalize() override;
+   bool ProcessFinalize() noexcept override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -136,7 +136,7 @@ struct EffectWahwah::Instance
    {}
 
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
 
    size_t ProcessBlock(EffectSettings& settings,
       const float* const* inBlock, float* const* outBlock, size_t blockLen)  override;
@@ -219,7 +219,7 @@ unsigned EffectWahwah::GetAudioOutCount() const
 }
 
 bool EffectWahwah::Instance::ProcessInitialize(EffectSettings & settings,
-   double sampleRate, sampleCount, ChannelNames chanMap)
+   double sampleRate, ChannelNames chanMap)
 {
    InstanceInit(settings, mMaster, sampleRate);
    if (chanMap[0] == ChannelNameFrontRight)

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -141,7 +141,7 @@ struct EffectWahwah::Instance
    size_t ProcessBlock(EffectSettings& settings,
       const float* const* inBlock, float* const* outBlock, size_t blockLen)  override;
 
-   //bool ProcessFinalize(void) override;
+   //bool ProcessFinalize() noexcept override;
 
    bool RealtimeInitialize(EffectSettings& settings, double) override;
 

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -112,7 +112,7 @@ bool AudioUnitInstance::ProcessInitialize(EffectSettings &settings,
    return true;
 }
 
-bool AudioUnitInstance::ProcessFinalize()
+bool AudioUnitInstance::ProcessFinalize() noexcept
 {
    mOutputList.reset();
    mInputList.reset();

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -79,7 +79,7 @@ size_t AudioUnitInstance::GetTailSize() const
 #endif
 
 bool AudioUnitInstance::ProcessInitialize(EffectSettings &settings,
-   double sampleRate, sampleCount, ChannelNames chanMap)
+   double sampleRate, ChannelNames chanMap)
 {
    StoreSettings(GetSettings(settings));
 
@@ -157,7 +157,7 @@ size_t AudioUnitInstance::ProcessBlock(EffectSettings &,
 bool AudioUnitInstance::RealtimeInitialize(
    EffectSettings &settings, double sampleRate)
 {
-   return ProcessInitialize(settings, sampleRate, 0, nullptr);
+   return ProcessInitialize(settings, sampleRate, nullptr);
 }
 
 bool AudioUnitInstance::RealtimeAddProcessor(
@@ -181,7 +181,7 @@ bool AudioUnitInstance::RealtimeAddProcessor(
 
    if (!slave->StoreSettings(GetSettings(settings)))
       return false;
-   if (!slave->ProcessInitialize(settings, sampleRate, 0, nullptr))
+   if (!slave->ProcessInitialize(settings, sampleRate, nullptr))
       return false;
    if (uSlave)
       mSlaves.push_back(move(uSlave));

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -38,7 +38,7 @@ private:
 
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       ChannelNames chanMap) override;
-   bool ProcessFinalize() override;
+   bool ProcessFinalize() noexcept override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -37,7 +37,7 @@ private:
    size_t SetBlockSize(size_t maxBlockSize) override;
 
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -894,7 +894,7 @@ struct LadspaEffect::Instance
    using PerTrackEffect::Instance::Instance;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
       ChannelNames chanMap) override;
-   bool ProcessFinalize() override;
+   bool ProcessFinalize() noexcept override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
       override;
@@ -977,8 +977,9 @@ bool LadspaEffect::Instance::ProcessInitialize(
    return true;
 }
 
-bool LadspaEffect::Instance::ProcessFinalize()
+bool LadspaEffect::Instance::ProcessFinalize() noexcept
 {
+return GuardedCall<bool>([&]{
    if (mReady) {
       mReady = false;
       GetEffect().FreeInstance(mMaster);
@@ -986,6 +987,7 @@ bool LadspaEffect::Instance::ProcessFinalize()
    }
 
    return true;
+});
 }
 
 size_t LadspaEffect::Instance::ProcessBlock(EffectSettings &,

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -893,7 +893,7 @@ struct LadspaEffect::Instance
 {
    using PerTrackEffect::Instance::Instance;
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    bool ProcessFinalize() override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
@@ -963,7 +963,7 @@ sampleCount LadspaEffect::Instance::GetLatency(
 }
 
 bool LadspaEffect::Instance::ProcessInitialize(
-   EffectSettings &settings, double sampleRate, sampleCount, ChannelNames)
+   EffectSettings &settings, double sampleRate, ChannelNames)
 {
    /* Instantiate the plugin */
    if (!mReady) {

--- a/src/effects/lv2/LV2Instance.cpp
+++ b/src/effects/lv2/LV2Instance.cpp
@@ -86,7 +86,7 @@ sampleCount LV2Instance::GetLatency(const EffectSettings &, double) const
 
 // Start of destructive processing path
 bool LV2Instance::ProcessInitialize(EffectSettings &settings,
-   double sampleRate, sampleCount, ChannelNames chanMap)
+   double sampleRate, ChannelNames chanMap)
 {
    MakeMaster(settings, sampleRate, false);
    if (!mMaster)

--- a/src/effects/lv2/LV2Instance.h
+++ b/src/effects/lv2/LV2Instance.h
@@ -36,7 +36,7 @@ public:
    const LV2PortStates &GetPortStates() const { return mPortStates; }
 
    bool ProcessInitialize(EffectSettings &settings, double sampleRate,
-      sampleCount totalLen, ChannelNames chanMap) override;
+      ChannelNames chanMap) override;
    size_t ProcessBlock(EffectSettings &settings,
       const float *const *inBlock, float *const *outBlock, size_t blockLen)
    override;


### PR DESCRIPTION
More refactoring of PerTrackEffect to serve for generalizing rendering.

Source, stage, and sink objects encapsulate much of the complication of PerTrackEffect::ProcessTrack.

Stage works as a decorator of any other given abstract Sink, presenting its own Sink interface.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
