### PR TITLE
Fixes over optimistic libmpg123 behavior

### DIFF
--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -659,10 +659,8 @@ bool Importer::Import( AudacityProject &project,
             }
          }
 
-         if (res == ProgressResult::Cancelled || res == ProgressResult::Failed)
-         {
+         if (res == ProgressResult::Cancelled)
             return false;
-         }
 
          // We could exit here since we had a match on the file extension,
          // but there may be another plug-in that can import the file and


### PR DESCRIPTION
Resolves: #3206 

This PR attempts to:
1. Improve the detection of the MP3 files on `Open`. This is can be tricky as MP3 has no container header.
2. Prevent Frankenstein MP3 files from importing. Such files are extremely rare. Probably FFMPEG based importer will be able to handle them
3. Fix the case, where `Open` succeeded, but `Import` failed. This can happen surprisingly often, because it is hard to detect MP3 files

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
