### PR TITLE
Forward OnClose event of the EffectHostUI to the Effect

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -197,10 +197,7 @@ EffectUIValidator::EffectUIValidator(
    , mAccess{access}
 {}
 
-EffectUIValidator::~EffectUIValidator()
-{
-   mEffect.CloseUI();
-}
+EffectUIValidator::~EffectUIValidator() = default;
 
 bool EffectUIValidator::UpdateUI()
 {
@@ -210,6 +207,15 @@ bool EffectUIValidator::UpdateUI()
 bool EffectUIValidator::IsGraphicalUI()
 {
    return false;
+}
+
+void EffectUIValidator::OnClose()
+{
+   if (!mUIClosed)
+   {
+      mEffect.CloseUI();
+      mUIClosed = true;
+   }
 }
 
 DefaultEffectUIValidator::~DefaultEffectUIValidator() = default;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -543,6 +543,11 @@ public:
     */
    virtual bool IsGraphicalUI();
 
+   /*!
+    Handle the UI OnClose event. Default implementation calls mEffect.CloseUI()
+   */
+   virtual void OnClose();
+
 protected:
    // Convenience function template for binding event handler functions
    template<typename EventTag, typename Class, typename Event>
@@ -554,6 +559,8 @@ protected:
 
    EffectUIClientInterface &mEffect;
    EffectSettingsAccess &mAccess;
+
+   bool mUIClosed { false };
 };
 
 /*************************************************************************************//**

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -585,8 +585,13 @@ void EffectUIHost::OnClose(wxCloseEvent & WXUNUSED(evt))
 {
    DoCancel();
    CleanupRealtime();
+
+   if (mpValidator)
+      mpValidator->OnClose();
+   
    Hide();
    Destroy();
+   
 #if wxDEBUG_LEVEL
    mClosed = true;
 #endif


### PR DESCRIPTION
Resolves: #3232 

As a part of transition to the new Effect architecture `EffectUIValidator` subclasses now handle the events from wxWidgets. This makes deleting `EffectUIValidator` instance from the `EffectUIHost::OnClose` to be unsafe and in fact it has introduced #3220: LV2Validator called `Close` from the `OnIdle` handler, which deleted the handler mid-processing.  

However, the destructor of `EffectUIValidator` had a side effect of calling `CloseUI` on the plugin itself. This broke Nyquist debug mode: after pressing Debug button `EffectUIHost::Destroy` was called, which has delayed the `EffectUIHost` and `EffectUIValidator` destructors until the next idle event in the run loop. However, `NyquistEffect` relied on `CloseUI` to correctly setup parent of the `NyquistOutputDialog`. Omission of `CloseUI` from the `EffectUIHost::OnClose` results in attempt to `delete` a stack object, because `NyquistOutputDialog` is attached to the `EffectUIHost` in the destroying state.

Resolves: #3247

Oddly enough, `Regular Interval Labels` always opened `NyquistOutputDialog` on default settings, so this plugin was crashing regardless of pressing the Debug button

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
