### PR TITLE
Define instance vst2

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1784,7 +1784,7 @@ bool VSTEffect::LoadCommon()
 }
 
 
-bool VSTEffect::Load()
+bool VSTEffectWrapper::Load()
 {
    bool success = false;
 
@@ -1807,7 +1807,7 @@ bool VSTEffect::Load()
       // Note:  Some hosts use "user" and some use "ptr2/resvd2".  It might
       //        be worthwhile to check if user is NULL before using it and
       //        then falling back to "ptr2/resvd2".
-      mAEffect->ptr2 = static_cast<VSTEffectWrapper*>(this);
+      mAEffect->ptr2 = this;
 
       // Give the plugin an initial sample rate and blocksize
       callDispatcher(effSetSampleRate, 0, 0, NULL, 48000.0);
@@ -1817,7 +1817,13 @@ bool VSTEffect::Load()
       // I've found one plugin (SoundHack +morphfilter) that will
       // crash Audacity when saving the initial default parameters
       // with this.
-      callSetProgram(0);
+      //
+      // The following 3 calls to callDispatcher are equivalent to callSetProgram(0),
+      // only done on the mAEFfect handle and not on the slaves too, if present
+      //
+      callDispatcher(effBeginSetProgram, 0, 0, NULL, 0.0);
+      callDispatcher(effSetProgram,      0, 0, NULL, 0.0);
+      callDispatcher(effEndSetProgram,   0, 0, NULL, 0.0);
 
       // Pretty confident that we're good to go
       success = true;

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -802,10 +802,11 @@ VSTEffect::VSTEffect(const PluginPath & path, VSTEffect *master)
    mTimeInfo.timeSigDenominator = 4;
    mTimeInfo.flags = kVstTempoValid | kVstNanosValid;
 
-   // If we're a slave then go ahead a load immediately
+   // If we're a slave then go ahead and load immediately
    if (mMaster)
    {
-      Load();
+      if ( ! Load() )
+         Unload();
    }
 }
 
@@ -918,7 +919,8 @@ bool VSTEffect::InitializePlugin()
 {
    if (!mAEffect)
    {
-      Load();
+      if ( ! Load() )
+         Unload();
    }
 
    if (!mAEffect)
@@ -1819,11 +1821,6 @@ bool VSTEffect::Load()
 
       // Pretty confident that we're good to go
       success = true;
-   }
-
-   if (!success)
-   {
-      Unload();
    }
 
    return success;

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -802,6 +802,10 @@ VSTEffect::VSTEffect(const PluginPath & path, VSTEffect *master)
    mTimeInfo.timeSigDenominator = 4;
    mTimeInfo.flags = kVstTempoValid | kVstNanosValid;
 
+   // Get the constant data that are shared by all instances
+   // (e.g. entry point in the dll, vst version, no. of channels etc.)
+   LoadCommon();
+
    // If we're a slave then go ahead and load immediately
    if (mMaster)
    {
@@ -1782,13 +1786,9 @@ bool VSTEffect::LoadCommon()
 
 bool VSTEffect::Load()
 {
-   // TODO: move this call out of here, so that it is executed only once
-   if ( ! LoadCommon() )
-      return false;
-
    bool success = false;
 
-   // Initialize the plugin
+   // Create the handle to the plugin, also setting the vst callback function
    try
    {
       mAEffect = mPluginMain(VSTEffectWrapper::AudioMaster);

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -218,6 +218,12 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler
    virtual int GetProcessLevel() = 0;
    virtual void SizeWindow(int w, int h) = 0;
    virtual void Automate(int index, float value) = 0;
+
+   // Loaded once when getting common VST things;
+   // placed here because they will be reused when an instance is created
+   //
+   vstPluginMain mPluginMain = nullptr;   // entry point in the plugin dll
+   wxString      mRealPath;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -355,6 +361,9 @@ protected:
 
 private:
    // Plugin loading and unloading
+
+   bool LoadCommon();
+
    bool Load();
    void Unload();
    std::vector<int> GetEffectIDs();

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -106,6 +106,9 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler
    intptr_t callDispatcher(int opcode, int index,
       intptr_t value, void* ptr, float opt) override;
 
+   intptr_t callDispatcher(AEffect* handle, int opcode, int index,
+      intptr_t value, void* ptr, float opt);
+
    intptr_t constCallDispatcher(int opcode, int index,
       intptr_t value, void* ptr, float opt) const;
 
@@ -119,6 +122,8 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler
 
    int      GetString(wxString& outstr, int opcode, int index = 0) const;
    wxString GetString(int opcode, int index = 0) const;
+
+   wxString GetStringFromHandle(int opcode, AEffect* handle) const;
 
    struct ParameterInfo
    {

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -229,6 +229,8 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler
    //
    vstPluginMain mPluginMain = nullptr;   // entry point in the plugin dll
    wxString      mRealPath;
+
+   bool Load();
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -369,7 +371,6 @@ private:
 
    bool LoadCommon();
 
-   bool Load();
    void Unload();
    std::vector<int> GetEffectIDs();
 


### PR DESCRIPTION
Resolves: part of https://github.com/audacity/audacity/issues/3192

Before even going through the steps suggested at the issue above, it seemed necessary to bring some important functionality in the wrapper class: the vst callback function, and the part of the original ::Load method which makes sense to be executed when a new instance will be created. Take into consideration that VstEffectInstance will inherit from VstEffectWrapper.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
