### PR TITLE
Issue 2965: plugin management improvements

### DIFF
--- a/libraries/lib-components/PluginProvider.h
+++ b/libraries/lib-components/PluginProvider.h
@@ -155,8 +155,6 @@ public:
       const RegistrationCallback &callback )
          = 0;
 
-   /*! @return true if the plug-in is still valid, otherwise false. */
-   virtual bool IsPluginValid(const PluginPath & path, bool bFast) = 0;
    /**
     * \brief Performs plugin/module existence check, still plugin may fail to load.
     * Implementation should avoid loading plugins during this check.

--- a/libraries/lib-components/PluginProvider.h
+++ b/libraries/lib-components/PluginProvider.h
@@ -171,7 +171,7 @@ public:
 // be declared static so as not to interfere with other providers during link.
 // ----------------------------------------------------------------------------
 #define DECLARE_PROVIDER_ENTRY(name)                  \
-static PluginProvider * name()
+static std::unique_ptr<PluginProvider> name()
 
 // ----------------------------------------------------------------------------
 // This will create a class and instance that will register the provider entry
@@ -203,11 +203,11 @@ static name name ## _instance;
 DECLARE_BUILTIN_PROVIDER_BASE(name)                   \
 void name::Register()                                 \
 {                                                     \
-   RegisterProvider(AudacityModule);                  \
+   RegisterProviderFactory(AudacityModule);                  \
 }                                                     \
 void name::Unregister()                               \
 {                                                     \
-   UnregisterProvider(AudacityModule);                \
+   UnregisterProviderFactory(AudacityModule);                \
 }
 
 #endif // __AUDACITY_MODULEINTERFACE_H__

--- a/libraries/lib-components/PluginProvider.h
+++ b/libraries/lib-components/PluginProvider.h
@@ -157,6 +157,13 @@ public:
 
    /*! @return true if the plug-in is still valid, otherwise false. */
    virtual bool IsPluginValid(const PluginPath & path, bool bFast) = 0;
+   /**
+    * \brief Performs plugin/module existence check, still plugin may fail to load.
+    * Implementation should avoid loading plugins during this check.
+    * \param path Internal plugin path/ID discovered via DiscoverPluginsAtPath
+    * or module path returned by FindModulePaths
+    */
+   virtual bool CheckPluginExist(const PluginPath& path) const = 0;
 
    //! Load the plug-in at a path reported by DiscoverPluginsAtPath
    /*!

--- a/libraries/lib-module-manager/ModuleManager.cpp
+++ b/libraries/lib-module-manager/ModuleManager.cpp
@@ -174,7 +174,7 @@ void * Module::GetSymbol(const wxString &name)
 std::unique_ptr<ModuleManager> ModuleManager::mInstance{};
 
 // Give builtin providers a means to identify themselves
-using BuiltinProviderList = std::vector<PluginProviderMain>;
+using BuiltinProviderList = std::vector<PluginProviderFactory>;
 namespace {
    BuiltinProviderList &builtinProviderList()
    {
@@ -183,19 +183,17 @@ namespace {
    }
 }
 
-void RegisterProvider(PluginProviderMain pluginProviderMain)
+void RegisterProviderFactory(PluginProviderFactory pluginProviderFactory)
 {
    auto &list = builtinProviderList();
-   if ( pluginProviderMain )
-      list.push_back(pluginProviderMain);
-
-   return;
+   if(pluginProviderFactory)
+      list.push_back(std::move(pluginProviderFactory));
 }
 
-void UnregisterProvider(PluginProviderMain pluginProviderMain)
+void UnregisterProviderFactory(PluginProviderFactory pluginProviderFactory)
 {
    auto &list = builtinProviderList();
-   auto end = list.end(), iter = std::find(list.begin(), end, pluginProviderMain);
+   auto end = list.end(), iter = std::find(list.begin(), end, pluginProviderFactory);
    if (iter != end)
       list.erase(iter);
 }
@@ -387,6 +385,29 @@ int ModuleManager::Dispatch(ModuleDispatchTypes type)
    return 0;
 }
 
+PluginProviderUniqueHandle::~PluginProviderUniqueHandle()
+{
+   if(mPtr)
+   {
+      mPtr->Terminate();
+      //No profit in comparison to calling/performing PluginProvider::Terminate
+      //from a destructor of the PluginProvider, since we don't offer any
+      //options to deal with errors...
+      //
+      //Example:
+      //try {
+      //   provider->Terminate();
+      //}
+      //catch(e) {
+      //   if(Dialog::ShowError("... Are you sure?") != Dialog::ResultOk)
+      //      //other providers might have been terminated by that time,
+      //      //so it might be a better option to repeatedly ask "Try again"/"Continue"
+      //      return;
+      //}
+      //provider.reset();//no errors, or user confirmed deletion
+   }
+}
+
 // ============================================================================
 //
 // Return reference to singleton
@@ -396,9 +417,7 @@ int ModuleManager::Dispatch(ModuleDispatchTypes type)
 ModuleManager & ModuleManager::Get()
 {
    if (!mInstance)
-   {
-      mInstance.reset(safenew ModuleManager);
-   }
+      mInstance = std::make_unique<ModuleManager>();
 
    return *mInstance;
 }
@@ -457,30 +476,18 @@ bool ModuleManager::DiscoverProviders()
 
 void ModuleManager::InitializeBuiltins()
 {
-   for (auto pluginProviderMain : builtinProviderList())
+   for (const auto& pluginProviderFactory : builtinProviderList())
    {
-      PluginProviderHandle provider{ pluginProviderMain(), PluginProviderDeleter{} };
-      if (provider && provider->Initialize()) {
-         // Register the provider
-         auto pInterface = provider.get();
-         auto id = GetID(pInterface);
+      auto pluginProvider = pluginProviderFactory();
+      
+      if (pluginProvider && pluginProvider->Initialize()) {
+         PluginProviderUniqueHandle handle { std::move(pluginProvider) };
+         
+         auto id = GetID(handle.get());
 
          // Need to remember it 
-         mProviders[id] = std::move(provider);
+         mProviders[id] = std::move(handle);
       }
-      else
-      {
-         // Don't leak!  Destructor of module does that.
-      }
-   }
-}
-
-void PluginProviderDeleter::operator() (PluginProvider *pInterface) const
-{
-   if (pInterface)
-   {
-      pInterface->Terminate();
-      std::unique_ptr < PluginProvider > { pInterface }; // DELETE it
    }
 }
 

--- a/libraries/lib-module-manager/ModuleManager.cpp
+++ b/libraries/lib-module-manager/ModuleManager.cpp
@@ -525,6 +525,14 @@ std::unique_ptr<ComponentInterface> ModuleManager::LoadPlugin(
       return iter->second->LoadPlugin(path);
 }
 
+bool ModuleManager::CheckPluginExist(const PluginID& providerId, const PluginPath& path)
+{
+   if(mProviders.find(providerId) == mProviders.end())
+      return false;
+
+   return mProviders[providerId]->CheckPluginExist(path);
+}
+
 bool ModuleManager::IsProviderValid(const PluginID & WXUNUSED(providerID),
                                     const PluginPath & path)
 {

--- a/libraries/lib-module-manager/ModuleManager.cpp
+++ b/libraries/lib-module-manager/ModuleManager.cpp
@@ -550,15 +550,3 @@ bool ModuleManager::IsProviderValid(const PluginID & WXUNUSED(providerID),
 
    return false;
 }
-
-bool ModuleManager::IsPluginValid(const PluginID & providerID,
-                                  const PluginPath & path,
-                                  bool bFast)
-{
-   if (mProviders.find(providerID) == mProviders.end())
-   {
-      return false;
-   }
-
-   return mProviders[providerID]->IsPluginValid(path, bFast);
-}

--- a/libraries/lib-module-manager/ModuleManager.h
+++ b/libraries/lib-module-manager/ModuleManager.h
@@ -129,6 +129,7 @@ public:
 
    bool IsProviderValid(const PluginID & provider, const PluginPath & path);
    bool IsPluginValid(const PluginID & provider, const PluginPath & path, bool bFast);
+   bool CheckPluginExist(const PluginID& providerId, const PluginPath& path);
 
 private:
    // I'm a singleton class

--- a/libraries/lib-module-manager/ModuleManager.h
+++ b/libraries/lib-module-manager/ModuleManager.h
@@ -128,7 +128,6 @@ public:
       LoadPlugin(const PluginID & provider, const PluginPath & path);
 
    bool IsProviderValid(const PluginID & provider, const PluginPath & path);
-   bool IsPluginValid(const PluginID & provider, const PluginPath & path, bool bFast);
    bool CheckPluginExist(const PluginID& providerId, const PluginPath& path);
 
 private:

--- a/libraries/lib-module-manager/ModuleManager.h
+++ b/libraries/lib-module-manager/ModuleManager.h
@@ -58,15 +58,28 @@ private:
    fnModuleDispatch mDispatch;
 };
 
-struct PluginProviderDeleter {
-   void operator ()(PluginProvider *pInterface) const;
+class MODULE_MANAGER_API PluginProviderUniqueHandle final
+{
+   std::unique_ptr<PluginProvider> mPtr;
+public:
+   PluginProviderUniqueHandle() = default;
+   explicit PluginProviderUniqueHandle(std::unique_ptr<PluginProvider> ptr) : mPtr(std::move(ptr)) { }
+   ~PluginProviderUniqueHandle();
+
+   PluginProviderUniqueHandle(PluginProviderUniqueHandle&&) = default;
+   PluginProviderUniqueHandle& operator=(PluginProviderUniqueHandle&&) = default;
+
+   PluginProviderUniqueHandle(const PluginProviderUniqueHandle&) = delete;
+   PluginProviderUniqueHandle& operator=(const PluginProviderUniqueHandle&) = delete;
+
+   PluginProvider* get() noexcept { return mPtr.get(); }
+   const PluginProvider* get() const noexcept { return mPtr.get(); }
+
+   PluginProvider* operator->() noexcept { return mPtr.get(); }
+   const PluginProvider* operator->() const noexcept { return mPtr.get(); }
 };
 
-using PluginProviderHandle = std::unique_ptr<
-   PluginProvider, PluginProviderDeleter
->;
-
-typedef std::map<wxString, PluginProviderHandle> PluginProviderMap;
+using PluginProviderHandlesMap = std::map<wxString, PluginProviderUniqueHandle>;
 
 class MODULE_MANAGER_API ModuleManager final
 {
@@ -103,6 +116,9 @@ public:
    auto Providers() const
    { return make_iterator_range(mProviders.cbegin(), mProviders.cend()); }
 
+   auto Providers()
+   { return make_iterator_range(mProviders.begin(), mProviders.end()); }
+
    bool RegisterEffectPlugin(const PluginID & provider, const PluginPath & path,
                        TranslatableString &errMsg);
 
@@ -118,20 +134,20 @@ private:
    // I'm a singleton class
    ModuleManager();
    ~ModuleManager();
-   ModuleManager(const ModuleManager&) PROHIBITED;
-   ModuleManager &operator=(const ModuleManager&) PROHIBITED;
+   ModuleManager(const ModuleManager&) = delete;
+   ModuleManager &operator=(const ModuleManager&) = delete;
 
    void InitializeBuiltins();
 
-private:
-   friend PluginProviderDeleter;
+   friend std::unique_ptr<ModuleManager> std::make_unique<ModuleManager>();
+
    friend std::default_delete<ModuleManager>;
    static std::unique_ptr<ModuleManager> mInstance;
 
    // Providers can each report availability of any number of Plug-Ins
    // identified by "paths", and are also factories of ComponentInterface
    // objects for each path
-   PluginProviderMap mProviders;
+   PluginProviderHandlesMap mProviders;
 
    // Other libraries that receive notifications of events described by
    // ModuleDispatchTypes:
@@ -139,18 +155,18 @@ private:
 };
 
 // ----------------------------------------------------------------------------
-// The module entry point prototype (a factory of PluginProvider objects)
+// A factory of PluginProvider objects
 // ----------------------------------------------------------------------------
-using PluginProviderMain = PluginProvider *(*)();
+using PluginProviderFactory = std::unique_ptr<PluginProvider> (*)();
 
 MODULE_MANAGER_API
-void RegisterProvider(PluginProviderMain rtn);
+void RegisterProviderFactory(PluginProviderFactory factory);
 MODULE_MANAGER_API
-void UnregisterProvider(PluginProviderMain rtn);
+void UnregisterProviderFactory(PluginProviderFactory factory);
 
 // Guarantee the registry exists before any registrations, so it will
 // be destroyed only after the un-registrations
 static struct Init{
-   Init() { RegisterProvider(nullptr); } } sInitBuiltinModules;
+   Init() { RegisterProviderFactory(nullptr); } } sInitBuiltinModules;
 
 #endif /* __AUDACITY_MODULEMANAGER_H__ */

--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -395,7 +395,7 @@ void PluginManager::Initialize(FileConfigFactory factory)
 
    auto &mm = ModuleManager::Get();
    mm.DiscoverProviders();
-   for (const auto &[id, module] : mm.Providers()) {
+   for (auto& [id, module] : mm.Providers()) {
       RegisterPlugin(module.get());
       // Allow the module to auto-register children
       module->AutoRegisterPlugins(*this);

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -201,6 +201,11 @@ BuiltinCommandsModule::LoadPlugin(const PluginPath & path)
    return Instantiate(path);
 }
 
+bool BuiltinCommandsModule::CheckPluginExist(const PluginPath& path) const
+{
+   return mCommands.find( path ) != mCommands.end();
+}
+
 // ============================================================================
 // BuiltinCommandsModule implementation
 // ============================================================================

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -57,7 +57,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew BuiltinCommandsModule();
+   return std::make_unique<BuiltinCommandsModule>();
 }
 
 // ============================================================================

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -187,13 +187,6 @@ unsigned BuiltinCommandsModule::DiscoverPluginsAtPath(
    return 0;
 }
 
-bool BuiltinCommandsModule::IsPluginValid(const PluginPath & path, bool bFast)
-{
-   // bFast is unused as checking in the list is fast.
-   static_cast<void>(bFast); // avoid unused variable warning
-   return mCommands.find( path ) != mCommands.end();
-}
-
 std::unique_ptr<ComponentInterface>
 BuiltinCommandsModule::LoadPlugin(const PluginPath & path)
 {

--- a/src/commands/LoadCommands.h
+++ b/src/commands/LoadCommands.h
@@ -68,6 +68,7 @@ public:
          override;
 
    bool IsPluginValid(const PluginPath & path, bool bFast) override;
+   bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath & path) override;

--- a/src/commands/LoadCommands.h
+++ b/src/commands/LoadCommands.h
@@ -67,7 +67,6 @@ public:
       const RegistrationCallback &callback)
          override;
 
-   bool IsPluginValid(const PluginPath & path, bool bFast) override;
    bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -190,13 +190,6 @@ unsigned BuiltinEffectsModule::DiscoverPluginsAtPath(
    return 0;
 }
 
-bool BuiltinEffectsModule::IsPluginValid(const PluginPath & path, bool bFast)
-{
-   // bFast is unused as checking in the list is fast.
-   static_cast<void>(bFast);
-   return mEffects.find( path ) != mEffects.end();
-}
-
 std::unique_ptr<ComponentInterface>
 BuiltinEffectsModule::LoadPlugin(const PluginPath & path)
 {

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -204,6 +204,11 @@ BuiltinEffectsModule::LoadPlugin(const PluginPath & path)
    return Instantiate(path);
 }
 
+bool BuiltinEffectsModule::CheckPluginExist(const PluginPath& path) const
+{
+   return mEffects.find( path ) != mEffects.end();
+}
+
 // ============================================================================
 // BuiltinEffectsModule implementation
 // ============================================================================

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -55,7 +55,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew BuiltinEffectsModule();
+   return std::make_unique<BuiltinEffectsModule>();
 }
 
 // ============================================================================

--- a/src/effects/LoadEffects.h
+++ b/src/effects/LoadEffects.h
@@ -68,6 +68,8 @@ public:
          override;
 
    bool IsPluginValid(const PluginPath & path, bool bFast) override;
+   
+   bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath & path) override;

--- a/src/effects/LoadEffects.h
+++ b/src/effects/LoadEffects.h
@@ -66,8 +66,6 @@ public:
       const PluginPath & path, TranslatableString &errMsg,
       const RegistrationCallback &callback)
          override;
-
-   bool IsPluginValid(const PluginPath & path, bool bFast) override;
    
    bool CheckPluginExist(const PluginPath& path) const override;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -402,6 +402,12 @@ VSTEffectsModule::LoadPlugin(const PluginPath & path)
    return result;
 }
 
+bool VSTEffectsModule::CheckPluginExist(const PluginPath& path) const
+{
+   const auto modulePath = path.BeforeFirst(wxT(';'));
+   return wxFileName::FileExists(modulePath) || wxFileName::DirExists(modulePath);
+}
+
 // ============================================================================
 // ModuleEffectInterface implementation
 // ============================================================================

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -145,7 +145,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create our effects module and register
    // Trust the module manager not to leak this
-   return safenew VSTEffectsModule();
+   return std::make_unique<VSTEffectsModule>();
 }
 
 // ============================================================================

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -384,14 +384,6 @@ unsigned VSTEffectsModule::DiscoverPluginsAtPath(
    return 0;
 }
 
-bool VSTEffectsModule::IsPluginValid(const PluginPath & path, bool bFast)
-{
-   if( bFast )
-      return true;
-   wxString realPath = path.BeforeFirst(wxT(';'));
-   return wxFileName::FileExists(realPath) || wxFileName::DirExists(realPath);
-}
-
 std::unique_ptr<ComponentInterface>
 VSTEffectsModule::LoadPlugin(const PluginPath & path)
 {

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -529,6 +529,8 @@ public:
          override;
 
    bool IsPluginValid(const PluginPath & path, bool bFast) override;
+   
+   bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath & path) override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -527,8 +527,6 @@ public:
       const PluginPath & path, TranslatableString &errMsg,
       const RegistrationCallback &callback)
          override;
-
-   bool IsPluginValid(const PluginPath & path, bool bFast) override;
    
    bool CheckPluginExist(const PluginPath& path) const override;
 

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -293,4 +293,11 @@ VST3EffectsModule::LoadPlugin(const PluginPath& pluginPath)
    return nullptr;
 }
 
+bool VST3EffectsModule::CheckPluginExist(const PluginPath& path) const
+{
+   wxString modulePath;
+   if(VST3Utils::ParsePluginPath(path, &modulePath, nullptr))
+      return wxFileName::FileExists(modulePath) || wxFileName::DirExists(modulePath);
 
+   return wxFileName::FileExists(path) || wxFileName::DirExists(path);
+}

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -251,18 +251,6 @@ unsigned VST3EffectsModule::DiscoverPluginsAtPath(const PluginPath& path, Transl
    return 0u;
 }
 
-bool VST3EffectsModule::IsPluginValid(const PluginPath& path, bool bFast)
-{
-   if(bFast)
-      return VST3Utils::ParsePluginPath(path, nullptr, nullptr);
-
-   wxString modulePath;
-   if(VST3Utils::ParsePluginPath(path, &modulePath, nullptr))
-      return wxFileName::FileExists(modulePath) || wxFileName::DirExists(modulePath);
-
-   return false;
-}
-
 std::unique_ptr<ComponentInterface>
 VST3EffectsModule::LoadPlugin(const PluginPath& pluginPath)
 {

--- a/src/effects/VST3/VST3EffectsModule.cpp
+++ b/src/effects/VST3/VST3EffectsModule.cpp
@@ -35,7 +35,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create our effects module and register
    // Trust the module manager not to leak this
-   return safenew VST3EffectsModule();
+   return std::make_unique<VST3EffectsModule>();
 }
 
 DECLARE_BUILTIN_PROVIDER(VST3Builtin);

--- a/src/effects/VST3/VST3EffectsModule.h
+++ b/src/effects/VST3/VST3EffectsModule.h
@@ -56,6 +56,7 @@ public:
    unsigned DiscoverPluginsAtPath(const PluginPath& path, TranslatableString& errMsg,
       const RegistrationCallback& callback) override;
    bool IsPluginValid(const PluginPath& path, bool bFast) override;
+   bool CheckPluginExist(const PluginPath& path) const override;
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath& path) override;
 

--- a/src/effects/VST3/VST3EffectsModule.h
+++ b/src/effects/VST3/VST3EffectsModule.h
@@ -55,7 +55,6 @@ public:
    PluginPaths FindModulePaths(PluginManagerInterface& pluginManager) override;
    unsigned DiscoverPluginsAtPath(const PluginPath& path, TranslatableString& errMsg,
       const RegistrationCallback& callback) override;
-   bool IsPluginValid(const PluginPath& path, bool bFast) override;
    bool CheckPluginExist(const PluginPath& path) const override;
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath& path) override;

--- a/src/effects/audiounits/AudioUnitEffectsModule.cpp
+++ b/src/effects/audiounits/AudioUnitEffectsModule.cpp
@@ -54,7 +54,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew AudioUnitEffectsModule();
+   return std::make_unique<AudioUnitEffectsModule>();
 }
 
 // ============================================================================
@@ -67,6 +67,51 @@ DECLARE_BUILTIN_PROVIDER(AudioUnitEffectsBuiltin);
 // AudioUnitEffectsModule
 //
 ///////////////////////////////////////////////////////////////////////////////
+
+
+namespace
+{
+
+wxString FromOSType(OSType type)
+{
+   OSType rev = (type & 0xff000000) >> 24 |
+                (type & 0x00ff0000) >> 8  |
+                (type & 0x0000ff00) << 8  |
+                (type & 0x000000ff) << 24;
+   
+   return wxString::FromUTF8(reinterpret_cast<char *>(&rev), 4);
+}
+
+OSType ToOSType(const wxString & type)
+{
+   wxCharBuffer buf = type.ToUTF8();
+
+   OSType rev = ((unsigned char)buf.data()[0]) << 24 |
+                ((unsigned char)buf.data()[1]) << 16 |
+                ((unsigned char)buf.data()[2]) << 8 |
+                ((unsigned char)buf.data()[3]);
+
+   return rev;
+}
+
+AudioComponent FindAudioUnit(const PluginPath & path,
+                                                     wxString & name)
+{
+   wxStringTokenizer tokens(path, wxT("/"));
+
+   AudioComponentDescription desc;
+
+   desc.componentManufacturer = ToOSType(tokens.GetNextToken());
+   desc.componentType = ToOSType(tokens.GetNextToken());
+   desc.componentSubType = ToOSType(tokens.GetNextToken());
+   desc.componentFlags = 0;
+   desc.componentFlagsMask = 0;
+
+   name = tokens.GetNextToken();
+   return AudioComponentFindNext(NULL, &desc);
+}
+
+}
 
 AudioUnitEffectsModule::AudioUnitEffectsModule()
 {
@@ -263,42 +308,4 @@ void AudioUnitEffectsModule::LoadAudioUnitsOfType(OSType inAUType,
    }
 }
 
-AudioComponent AudioUnitEffectsModule::FindAudioUnit(const PluginPath & path,
-                                                     wxString & name)
-{
-   wxStringTokenizer tokens(path, wxT("/"));
-
-   AudioComponentDescription desc;
-
-   desc.componentManufacturer = ToOSType(tokens.GetNextToken());
-   desc.componentType = ToOSType(tokens.GetNextToken());
-   desc.componentSubType = ToOSType(tokens.GetNextToken());
-   desc.componentFlags = 0;
-   desc.componentFlagsMask = 0;
-
-   name = tokens.GetNextToken();
-   return AudioComponentFindNext(NULL, &desc);
-}
-
-wxString AudioUnitEffectsModule::FromOSType(OSType type)
-{
-   OSType rev = (type & 0xff000000) >> 24 |
-                (type & 0x00ff0000) >> 8  |
-                (type & 0x0000ff00) << 8  |
-                (type & 0x000000ff) << 24;
-   
-   return wxString::FromUTF8(reinterpret_cast<char *>(&rev), 4);
-}
-
-OSType AudioUnitEffectsModule::ToOSType(const wxString & type)
-{
-   wxCharBuffer buf = type.ToUTF8();
-
-   OSType rev = ((unsigned char)buf.data()[0]) << 24 |
-                ((unsigned char)buf.data()[1]) << 16 |
-                ((unsigned char)buf.data()[2]) << 8 |
-                ((unsigned char)buf.data()[3]);
-
-   return rev;
-}
 #endif

--- a/src/effects/audiounits/AudioUnitEffectsModule.cpp
+++ b/src/effects/audiounits/AudioUnitEffectsModule.cpp
@@ -253,6 +253,12 @@ AudioUnitEffectsModule::LoadPlugin(const PluginPath & path)
    return nullptr;
 }
 
+bool AudioUnitEffectsModule::CheckPluginExist(const PluginPath& path) const
+{
+   wxString unused;
+   return FindAudioUnit(path, unused) != nullptr;
+}
+
 // ============================================================================
 // AudioUnitEffectsModule implementation
 // ============================================================================

--- a/src/effects/audiounits/AudioUnitEffectsModule.cpp
+++ b/src/effects/audiounits/AudioUnitEffectsModule.cpp
@@ -230,17 +230,6 @@ unsigned AudioUnitEffectsModule::DiscoverPluginsAtPath(
    return 1;
 }
 
-bool AudioUnitEffectsModule::IsPluginValid(const PluginPath & path, bool bFast)
-{
-   if (bFast)
-   {
-      return true;
-   }
-
-   wxString name;
-   return FindAudioUnit(path, name) != NULL;
-}
-
 std::unique_ptr<ComponentInterface>
 AudioUnitEffectsModule::LoadPlugin(const PluginPath & path)
 {

--- a/src/effects/audiounits/AudioUnitEffectsModule.h
+++ b/src/effects/audiounits/AudioUnitEffectsModule.h
@@ -56,6 +56,9 @@ public:
 
    bool IsPluginValid(const PluginPath & path, bool bFast) override;
 
+   
+   bool CheckPluginExist(const PluginPath& path) const override;
+   
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath & path) override;
 

--- a/src/effects/audiounits/AudioUnitEffectsModule.h
+++ b/src/effects/audiounits/AudioUnitEffectsModule.h
@@ -54,8 +54,6 @@ public:
       const RegistrationCallback &callback)
          override;
 
-   bool IsPluginValid(const PluginPath & path, bool bFast) override;
-
    
    bool CheckPluginExist(const PluginPath& path) const override;
    

--- a/src/effects/audiounits/AudioUnitEffectsModule.h
+++ b/src/effects/audiounits/AudioUnitEffectsModule.h
@@ -62,10 +62,6 @@ public:
    // AudioUnitEffectModule implementation
 
    void LoadAudioUnitsOfType(OSType inAUType, PluginPaths & effects);
-   AudioComponent FindAudioUnit(const PluginPath & path, wxString & name);
-
-   wxString FromOSType(OSType type);
-   OSType ToOSType(const wxString & type);
 };
 
 #endif

--- a/src/effects/audiounits/AudioUnitWrapper.cpp
+++ b/src/effects/audiounits/AudioUnitWrapper.cpp
@@ -17,6 +17,7 @@
 #include "EffectInterface.h"
 #include "Internat.h"
 #include "ModuleManager.h"
+#include "PluginProvider.h"
 
 #include <wx/osx/core/private.h>
 

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -398,6 +398,12 @@ LadspaEffectsModule::LoadPlugin(const PluginPath & path)
    return result;
 }
 
+bool LadspaEffectsModule::CheckPluginExist(const PluginPath& path) const
+{
+   const auto realPath = path.BeforeFirst(wxT(';'));
+   return wxFileName::FileExists(realPath);
+}
+
 FilePaths LadspaEffectsModule::GetSearchPaths()
 {
    FilePaths pathList;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -89,7 +89,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew LadspaEffectsModule();
+   return std::make_unique<LadspaEffectsModule>();
 }
 
 // ============================================================================

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -375,14 +375,6 @@ unsigned LadspaEffectsModule::DiscoverPluginsAtPath(
    return nLoaded;
 }
 
-bool LadspaEffectsModule::IsPluginValid(const PluginPath & path, bool bFast)
-{
-   if( bFast )
-      return true;
-   wxString realPath = path.BeforeFirst(wxT(';'));
-   return wxFileName::FileExists(realPath);
-}
-
 std::unique_ptr<ComponentInterface>
 LadspaEffectsModule::LoadPlugin(const PluginPath & path)
 {

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -207,6 +207,8 @@ public:
          override;
 
    bool IsPluginValid(const PluginPath & path, bool bFast) override;
+   
+   bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath & path) override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -205,8 +205,6 @@ public:
       const PluginPath & path, TranslatableString &errMsg,
       const RegistrationCallback &callback)
          override;
-
-   bool IsPluginValid(const PluginPath & path, bool bFast) override;
    
    bool CheckPluginExist(const PluginPath& path) const override;
 

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -259,13 +259,6 @@ unsigned LV2EffectsModule::DiscoverPluginsAtPath(
    return 0;
 }
 
-bool LV2EffectsModule::IsPluginValid(const PluginPath & path, bool bFast)
-{
-   if( bFast )
-      return true;
-   return GetPlugin(path) != NULL;
-}
-
 std::unique_ptr<ComponentInterface>
 LV2EffectsModule::LoadPlugin(const PluginPath & path)
 {

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -55,7 +55,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew LV2EffectsModule();
+   return std::make_unique<LV2EffectsModule>();
 }
 
 // ============================================================================

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -278,6 +278,11 @@ LV2EffectsModule::LoadPlugin(const PluginPath & path)
    return nullptr;
 }
 
+bool LV2EffectsModule::CheckPluginExist(const PluginPath & path) const
+{
+   return GetPlugin(path) != nullptr;
+}
+
 // ============================================================================
 // LV2EffectsModule implementation
 // ============================================================================

--- a/src/effects/lv2/LoadLV2.h
+++ b/src/effects/lv2/LoadLV2.h
@@ -55,7 +55,6 @@ public:
       const RegistrationCallback &callback)
          override;
 
-   bool IsPluginValid(const PluginPath & path, bool bFast) override;
    bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>

--- a/src/effects/lv2/LoadLV2.h
+++ b/src/effects/lv2/LoadLV2.h
@@ -56,6 +56,7 @@ public:
          override;
 
    bool IsPluginValid(const PluginPath & path, bool bFast) override;
+   bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath & path) override;
@@ -63,7 +64,7 @@ public:
    // LV2EffectModule implementation
 
 private:
-   const LilvPlugin *GetPlugin(const PluginPath & path);
+   static const LilvPlugin *GetPlugin(const PluginPath & path);
 };
 
 #endif

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -250,17 +250,6 @@ unsigned NyquistEffectsModule::DiscoverPluginsAtPath(
    return 0;
 }
 
-bool NyquistEffectsModule::IsPluginValid(const PluginPath & path, bool bFast)
-{
-   // Ignores bFast parameter, since checking file exists is fast enough for
-   // the small number of Nyquist plug-ins that we have.
-   static_cast<void>(bFast);
-   if(path == NYQUIST_PROMPT_ID)
-      return true;
-
-   return wxFileName::FileExists(path);
-}
-
 std::unique_ptr<ComponentInterface>
 NyquistEffectsModule::LoadPlugin(const PluginPath & path)
 {

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -271,6 +271,14 @@ NyquistEffectsModule::LoadPlugin(const PluginPath & path)
    return nullptr;
 }
 
+bool NyquistEffectsModule::CheckPluginExist(const PluginPath& path) const
+{
+   if(path == NYQUIST_PROMPT_ID)
+      return true;
+
+   return wxFileName::FileExists(path);
+}
+
 // ============================================================================
 // NyquistEffectsModule implementation
 // ============================================================================

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -67,7 +67,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew NyquistEffectsModule();
+   return std::make_unique<NyquistEffectsModule>();
 }
 
 // ============================================================================

--- a/src/effects/nyquist/LoadNyquist.h
+++ b/src/effects/nyquist/LoadNyquist.h
@@ -48,8 +48,6 @@ public:
       const PluginPath & path, TranslatableString &errMsg,
       const RegistrationCallback &callback)
          override;
-
-   bool IsPluginValid(const PluginPath & path, bool bFast) override;
    
    bool CheckPluginExist(const PluginPath& path) const override;
 

--- a/src/effects/nyquist/LoadNyquist.h
+++ b/src/effects/nyquist/LoadNyquist.h
@@ -50,6 +50,8 @@ public:
          override;
 
    bool IsPluginValid(const PluginPath & path, bool bFast) override;
+   
+   bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath & path) override;

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -248,6 +248,15 @@ VampEffectsModule::LoadPlugin(const PluginPath & path)
    return nullptr;
 }
 
+bool VampEffectsModule::CheckPluginExist(const PluginPath& path) const
+{
+   PluginLoader::PluginKey key = path.BeforeLast(wxT('/')).ToUTF8().data();
+   const auto libraryPathUTF8 = PluginLoader::getInstance()->getLibraryPathForPlugin(key);
+   if(!libraryPathUTF8.empty())
+      return wxFileName::FileExists(wxString::FromUTF8(libraryPathUTF8));
+   return wxFileName::FileExists(path);
+}
+
 // VampEffectsModule implementation
 
 std::unique_ptr<Vamp::Plugin> VampEffectsModule::FindPlugin(const PluginPath & path,

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -39,7 +39,7 @@ DECLARE_PROVIDER_ENTRY(AudacityModule)
 {
    // Create and register the importer
    // Trust the module manager not to leak this
-   return safenew VampEffectsModule();
+   return std::make_unique<VampEffectsModule>();
 }
 
 // ============================================================================

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -239,7 +239,7 @@ VampEffectsModule::LoadPlugin(const PluginPath & path)
 
 bool VampEffectsModule::CheckPluginExist(const PluginPath& path) const
 {
-   PluginLoader::PluginKey key = path.BeforeLast(wxT('/')).ToUTF8().data();
+   PluginLoader::PluginKey key = path.BeforeFirst(wxT('/')).ToUTF8().data();
    const auto libraryPathUTF8 = PluginLoader::getInstance()->getLibraryPathForPlugin(key);
    if(!libraryPathUTF8.empty())
       return wxFileName::FileExists(wxString::FromUTF8(libraryPathUTF8));
@@ -252,7 +252,7 @@ std::unique_ptr<Vamp::Plugin> VampEffectsModule::FindPlugin(const PluginPath & p
                                       int & output,
                                       bool & hasParameters)
 {
-   PluginLoader::PluginKey key = path.BeforeLast(wxT('/')).ToUTF8().data();
+   PluginLoader::PluginKey key = path.BeforeFirst(wxT('/')).ToUTF8().data();
 
    std::unique_ptr<Plugin> vp{ PluginLoader::getInstance()->loadPlugin(key, 48000) }; // rate doesn't matter here
    if (!vp)

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -225,17 +225,6 @@ unsigned VampEffectsModule::DiscoverPluginsAtPath(
    return 0;
 }
 
-bool VampEffectsModule::IsPluginValid(const PluginPath & path, bool bFast)
-{
-   int output;
-   bool hasParameters;
-   if( bFast )
-      return true;
-
-   auto vp = FindPlugin(path, output, hasParameters);
-   return bool(vp);
-}
-
 std::unique_ptr<ComponentInterface>
 VampEffectsModule::LoadPlugin(const PluginPath & path)
 {

--- a/src/effects/vamp/LoadVamp.h
+++ b/src/effects/vamp/LoadVamp.h
@@ -57,6 +57,8 @@ public:
          override;
 
    bool IsPluginValid(const PluginPath & path, bool bFast) override;
+   
+   bool CheckPluginExist(const PluginPath& path) const override;
 
    std::unique_ptr<ComponentInterface>
       LoadPlugin(const PluginPath & path) override;

--- a/src/effects/vamp/LoadVamp.h
+++ b/src/effects/vamp/LoadVamp.h
@@ -55,8 +55,6 @@ public:
       const PluginPath & path, TranslatableString &errMsg,
       const RegistrationCallback &callback)
          override;
-
-   bool IsPluginValid(const PluginPath & path, bool bFast) override;
    
    bool CheckPluginExist(const PluginPath& path) const override;
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -75,8 +75,8 @@ VampEffect::VampEffect(std::unique_ptr<Vamp::Plugin> &&plugin,
    mHasParameters(hasParameters),
    mRate(0)
 {
-   mKey = mPath.BeforeLast(wxT('/')).ToUTF8();
-   mName = mPath.AfterLast(wxT('/'));
+   mKey = mPath.BeforeFirst(wxT('/')).ToUTF8();
+   mName = mPath.AfterFirst(wxT('/'));
 }
 
 VampEffect::~VampEffect()


### PR DESCRIPTION
Resolves: #2965
Resolves: #3286

Not only Nyquist plug-ins are removed from the registry, but all other types of plug-ins are checked for existence as well.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
