### PR TITLE
issue #3021: vst3 plain gui: accessibility of check boxes

### DIFF
--- a/src/effects/VST3/VST3ParametersWindow.cpp
+++ b/src/effects/VST3/VST3ParametersWindow.cpp
@@ -204,13 +204,14 @@ namespace
 
       VST3ToggleParameter(wxWindow *parent,
                wxWindowID id,
+               const wxString& label,
                Steinberg::Vst::ParamID paramId,
                const wxPoint& pos = wxDefaultPosition,
                const wxSize& size = wxDefaultSize,
-               long style = 0,
+               long style = wxALIGN_RIGHT,
                const wxValidator& validator = wxDefaultValidator,
                const wxString& name = wxCheckBoxNameStr)
-      : wxCheckBox(parent, id, wxEmptyString, pos, size, style, validator, name)
+      : wxCheckBox(parent, id, label, pos, size, style, validator, name)
       , VST3ParameterControl(paramId) { }
 
       void SetNormalizedValue(Steinberg::Vst::IEditController& editController, Steinberg::Vst::ParamValue value) override
@@ -253,14 +254,15 @@ VST3ParametersWindow::VST3ParametersWindow(wxWindow *parent,
       if((parameterInfo.flags & (Vst::ParameterInfo::kCanAutomate | Vst::ParameterInfo::kIsBypass | Vst::ParameterInfo::kIsReadOnly)) == 0)
          continue;
 
-      sizer->Add(safenew wxStaticText(
-         this,
-         wxID_ANY,
-         VST3Utils::ToWxString(parameterInfo.title),
-         wxDefaultPosition,
-         wxDefaultSize,
-         wxALIGN_RIGHT), 0, wxEXPAND
-      );
+      if (parameterInfo.stepCount != 1)      // not a toggle
+         sizer->Add(safenew wxStaticText(
+            this,
+            wxID_ANY,
+            VST3Utils::ToWxString(parameterInfo.title),
+            wxDefaultPosition,
+            wxDefaultSize,
+            wxALIGN_RIGHT), 0, wxEXPAND
+         );
       
       if(parameterInfo.flags & Vst::ParameterInfo::kIsReadOnly)
       {
@@ -277,9 +279,11 @@ VST3ParametersWindow::VST3ParametersWindow(wxWindow *parent,
       //toggle
       else if(parameterInfo.stepCount == 1)
       {
-         const auto toggle = safenew VST3ToggleParameter (this, wxID_ANY, parameterInfo.id);
+         const auto toggle = safenew VST3ToggleParameter (this, wxID_ANY,
+            VST3Utils::ToWxString(parameterInfo.title), parameterInfo.id);
          toggle->Bind(wxEVT_CHECKBOX, &VST3ParametersWindow::OnParameterValueChanged, this);
          sizer->Add(toggle, 0, wxEXPAND);
+         sizer->AddStretchSpacer();
          sizer->AddStretchSpacer();
          RegisterParameterControl(toggle);
       }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/3021

Problem:
The mouse interaction and focus of check boxes in the vst3 plain gui is non-standard, and the names of the check boxes are not read by screen readers.

This is caused by creating a wxCheckBox with an empty label, and adding the text separately.

Fix:
Use a wxCheckBox with a label, and with the wxALIGN_RIGHT style so that the label is to the left of the check box which is the desired layout in this case.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
