### PR TITLE
Rewrite mixer

### DIFF
--- a/libraries/lib-sample-track/Mix.cpp
+++ b/libraries/lib-sample-track/Mix.cpp
@@ -148,20 +148,18 @@ Mixer::Mixer(const SampleTrackConstArray &inputTracks,
    , mQueueStart( mNumInputTracks, 0 )
    , mQueueLen( mNumInputTracks, 0 )
 
-   , mInterleavedBufferSize{
-      mBufferSize * (mInterleaved ? mNumChannels : 1) }
    // PRL:  Bug2536: see other comments below for the `+ 1`
-   , mFloatBuffer( mInterleavedBufferSize + 1 )
+   , mFloatBuffer( mBufferSize + 1 )
 
    // non-interleaved
    , mTemp{ initVector<float>(mNumChannels, mBufferSize) }
    , mBuffer{ initVector<SampleBuffer>(mInterleaved ? 1 : mNumChannels,
-      [size = mInterleavedBufferSize, format = mFormat](auto &buffer){
-         buffer.Allocate(size, format);
-      }
+      [format = mFormat,
+         size = mBufferSize * (mInterleaved ? mNumChannels : 1)
+      ](auto &buffer){ buffer.Allocate(size, format); }
    )}
 
-   , mEnvValues( std::max(sQueueMaxLen, mInterleavedBufferSize) )
+   , mEnvValues( std::max(sQueueMaxLen, mBufferSize) )
    , mResample( mNumInputTracks )
    , mSpeed{ warpOptions.initialSpeed }
 

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -230,7 +230,6 @@ class SAMPLE_TRACK_API Mixer {
    // Each channel's data is transformed, including application of
    // gains and pans, and then (maybe many-to-one) mixer specifications
    // determine where in mTemp it is accumulated
-   const unsigned   mNumBuffers;
    std::vector<std::vector<float>> mTemp;
 
    // Final result applies dithering and interleaving

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -95,6 +95,9 @@ class SAMPLE_TRACK_API Mixer {
          bool highQuality = true, MixerSpec *mixerSpec = nullptr,
          bool applytTrackGains = true);
 
+   Mixer(const Mixer&) = delete;
+   Mixer &operator=(const Mixer&) = delete;
+
    virtual ~ Mixer();
 
    //

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -152,16 +152,12 @@ class SAMPLE_TRACK_API Mixer {
    /*!
     @post result: `result <= maxOut`
     */
-   size_t MixSameRate(size_t maxOut, SampleTrackCache &cache, sampleCount *pos,
-      float &floatBuffer);
+   size_t MixSameRate(size_t ii, size_t maxOut, float &floatBuffer);
 
    /*!
     @post result: `result <= maxOut`
     */
-   size_t MixVariableRates(size_t maxOut, SampleTrackCache &cache,
-      sampleCount *pos, float *queue,
-      int *queueStart, int *queueLen,
-      Resample * pResample, float &floatBuffer);
+   size_t MixVariableRates(size_t ii, size_t maxOut, float &floatBuffer);
 
    void MakeResamplers();
 

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -7,15 +7,7 @@
   Dominic Mazzoni
   Markus Meyer
 
-********************************************************************//**
-
-\class ArrayOf
-\brief Memory.h template class for making an array of float, bool, etc.
-
-\class ArraysOf
-\brief memory.h template class for making an array of arrays.
-
-*//********************************************************************/
+***********************************************************************/
 
 #ifndef __AUDACITY_MIX__
 #define __AUDACITY_MIX__
@@ -211,11 +203,12 @@ class SAMPLE_TRACK_API Mixer {
    // INPUT
 
    // SampleTrackCaches are the source of data
-   ArrayOf<SampleTrackCache> mInputTrack;
+   std::vector<SampleTrackCache> mInputTrack;
+
    // Fetch position for source
    // mSamplePos holds for each track the next sample position not
    // yet processed.
-   ArrayOf<sampleCount> mSamplePos;
+   std::vector<sampleCount> mSamplePos;
    // There is also a double-valued fetch position with (reassignable) bounds
    double           mT0; // Start time
    double           mT1; // Stop time (none if mT0==mT1)
@@ -224,38 +217,38 @@ class SAMPLE_TRACK_API Mixer {
    // BUFFERS
 
    // First intermediate buffer when resampling is needed
-   FloatBuffers     mSampleQueue;
+   std::vector<std::vector<float>> mSampleQueue;
    // Position in each queue of the start of the next block to resample
-   ArrayOf<int>     mQueueStart;
+   std::vector<int>     mQueueStart;
    // For each queue, the number of available samples after the queue start
-   ArrayOf<int>     mQueueLen;
+   std::vector<int>     mQueueLen;
 
    // Resample into this buffer, or produce directly when not resampling
    const size_t     mInterleavedBufferSize;
-   Floats           mFloatBuffer;
+   std::vector<float>   mFloatBuffer;
 
    // Each channel's data is transformed, including application of
    // gains and pans, and then (maybe many-to-one) mixer specifications
    // determine where in mTemp it is accumulated
    const unsigned   mNumBuffers;
-   ArrayOf<Floats>  mTemp;
+   std::vector<std::vector<float>> mTemp;
 
    // Final result applies dithering and interleaving
-   ArrayOf<SampleBuffer> mBuffer;
+   const std::vector<SampleBuffer> mBuffer;
 
    // TRANSFORMATION STATE
 
    // Gain envelopes are applied to input before other transformations
-   Doubles          mEnvValues;
+   std::vector<double> mEnvValues;
 
-   ArrayOf<std::unique_ptr<Resample>> mResample;
+   std::vector<std::unique_ptr<Resample>> mResample;
    // Varying scrub speed is one cause for resampling
    double           mSpeed;
 
    // TODO -- insert effect stages here
 
    // Gain slider settings are applied late
-   Floats           mGains;
+   std::vector<float> mGains;
 
    // Last step is accumulating results into the output buffers, with dithering
 };

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -90,6 +90,8 @@ class SAMPLE_TRACK_API Mixer {
 
    /*!
     @pre all `inputTracks` are non-null
+    @pre any left channels in inputTracks are immediately followed by their
+       partners
     @post `BufferSize() == outBufferSize`
     */
    Mixer(const SampleTrackConstArray &inputTracks, bool mayThrow,
@@ -150,7 +152,8 @@ class SAMPLE_TRACK_API Mixer {
    /*!
     @post result: `result <= maxOut`
     */
-   size_t MixSameRate(size_t maxOut, SampleTrackCache &cache, sampleCount *pos);
+   size_t MixSameRate(size_t maxOut, SampleTrackCache &cache, sampleCount *pos,
+      float &floatBuffer);
 
    /*!
     @post result: `result <= maxOut`
@@ -158,7 +161,7 @@ class SAMPLE_TRACK_API Mixer {
    size_t MixVariableRates(size_t maxOut, SampleTrackCache &cache,
       sampleCount *pos, float *queue,
       int *queueStart, int *queueLen,
-      Resample * pResample);
+      Resample * pResample, float &floatBuffer);
 
    void MakeResamplers();
 
@@ -221,8 +224,9 @@ class SAMPLE_TRACK_API Mixer {
    // For each queue, the number of available samples after the queue start
    std::vector<int>     mQueueLen;
 
-   // Resample into this buffer, or produce directly when not resampling
-   std::vector<float>   mFloatBuffer;
+   // Resample into these buffers, or produce directly when not resampling
+   // TODO: more-than-two-channels
+   std::vector<float>   mFloatBuffers[2];
 
    // Each channel's data is transformed, including application of
    // gains and pans, and then (maybe many-to-one) mixer specifications

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -224,7 +224,6 @@ class SAMPLE_TRACK_API Mixer {
    std::vector<int>     mQueueLen;
 
    // Resample into this buffer, or produce directly when not resampling
-   const size_t     mInterleavedBufferSize;
    std::vector<float>   mFloatBuffer;
 
    // Each channel's data is transformed, including application of

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -151,13 +151,13 @@ class SAMPLE_TRACK_API Mixer {
     @post result: `result <= maxOut`
     */
    size_t MixSameRate(size_t maxOut,
-      int *channelFlags, SampleTrackCache &cache, sampleCount *pos);
+      const unsigned char *channelFlags, SampleTrackCache &cache, sampleCount *pos);
 
    /*!
     @post result: `result <= maxOut`
     */
    size_t MixVariableRates(size_t maxOut,
-      int *channelFlags, SampleTrackCache &cache,
+      const unsigned char *channelFlags, SampleTrackCache &cache,
       sampleCount *pos, float *queue,
       int *queueStart, int *queueLen,
       Resample * pResample);

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -150,14 +150,12 @@ class SAMPLE_TRACK_API Mixer {
    /*!
     @post result: `result <= maxOut`
     */
-   size_t MixSameRate(size_t maxOut,
-      const unsigned char *channelFlags, SampleTrackCache &cache, sampleCount *pos);
+   size_t MixSameRate(size_t maxOut, SampleTrackCache &cache, sampleCount *pos);
 
    /*!
     @post result: `result <= maxOut`
     */
-   size_t MixVariableRates(size_t maxOut,
-      const unsigned char *channelFlags, SampleTrackCache &cache,
+   size_t MixVariableRates(size_t maxOut, SampleTrackCache &cache,
       sampleCount *pos, float *queue,
       int *queueStart, int *queueLen,
       Resample * pResample);
@@ -246,7 +244,6 @@ class SAMPLE_TRACK_API Mixer {
    // TODO -- insert effect stages here
 
    // Gain slider settings are applied late
-   std::vector<float> mGains;
 
    // Last step is accumulating results into the output buffers, with dithering
 };

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -83,11 +83,21 @@ class SAMPLE_TRACK_API Mixer {
        double initialSpeed{ 1.0 };
     };
 
+   // Information derived from WarpOptions and other data
+   struct ResampleParameters {
+      ResampleParameters(
+         const SampleTrackConstArray &inputTracks, double rate,
+         const WarpOptions &options);
+      bool             mbVariableRates{ false };
+      std::vector<double> mMinFactor, mMaxFactor;
+   };
+
     //
    // Constructor / Destructor
    //
 
    /*!
+    @pre all `inputTracks` are non-null
     @post `BufferSize() == outBufferSize`
     */
    Mixer(const SampleTrackConstArray &inputTracks, bool mayThrow,
@@ -181,8 +191,11 @@ class SAMPLE_TRACK_API Mixer {
 
    // Transformations
    const size_t     mBufferSize;
+   // Resampling, as needed, after gain envelope
    const double     mRate; // may require resampling
    const BoundedEnvelope *const mEnvelope; // for time warp which also resamples
+   // derived parameters
+   const ResampleParameters mResampleParameters;
 
    // Output
    const bool       mApplyTrackGains;
@@ -194,10 +207,6 @@ class SAMPLE_TRACK_API Mixer {
    // General
    const bool       mMayThrow;
 
-   // DERIVED PARAMETERS
-   // Resampling, sometimes, after gain envelope
-   bool             mbVariableRates{ false };
-   std::vector<double> mMinFactor, mMaxFactor;
 
    // INPUT
 

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -146,18 +146,19 @@ class SAMPLE_TRACK_API Mixer {
 
    void Clear();
    /*!
-    @post result: `result <= mMaxOut`
+    @post result: `result <= maxOut`
     */
-   size_t MixSameRate(int *channelFlags, SampleTrackCache &cache,
-                           sampleCount *pos);
+   size_t MixSameRate(size_t maxOut,
+      int *channelFlags, SampleTrackCache &cache, sampleCount *pos);
 
    /*!
-    @post result: `result <= mMaxOut`
+    @post result: `result <= maxOut`
     */
-   size_t MixVariableRates(int *channelFlags, SampleTrackCache &cache,
-                                sampleCount *pos, float *queue,
-                                int *queueStart, int *queueLen,
-                                Resample * pResample);
+   size_t MixVariableRates(size_t maxOut,
+      int *channelFlags, SampleTrackCache &cache,
+      sampleCount *pos, float *queue,
+      int *queueStart, int *queueLen,
+      Resample * pResample);
 
    void MakeResamplers();
 
@@ -190,7 +191,6 @@ class SAMPLE_TRACK_API Mixer {
    MixerSpec *const mMixerSpec;
 
    // Output
-   size_t              mMaxOut{};
    const unsigned   mNumChannels;
    Floats           mGains;
    const size_t     mBufferSize;


### PR DESCRIPTION
Preliminary cleanups of the Mixer class in lib-sample-track,
before we fix the rendering of effects by reuse of the new AudioGraph
classes, which wil be separated from PerTrackEffect.cpp.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
