### PR TITLE
several WavPack import/export fixes

### DIFF
--- a/src/export/ExportWavPack.cpp
+++ b/src/export/ExportWavPack.cpp
@@ -80,6 +80,7 @@ ExportWavPackOptions::~ExportWavPackOptions()
 
 const TranslatableStrings ExportQualityNames{
    XO("Low Quality (Fast)") ,
+   XO("Normal Quality") ,
    XO("High Quality (Slow)") ,
    XO("Very High Quality (Slowest)") ,
 };
@@ -88,6 +89,7 @@ const std::vector< int > ExportQualityValues{
    0,
    1,
    2,
+   3,
 };
 
 namespace {
@@ -315,10 +317,10 @@ ProgressResult ExportWavPack::Export(AudacityProject *project,
 
    if (quality == 0) {
       config.flags |= CONFIG_FAST_FLAG;
-   } else if (quality == 1) {
+   } else if (quality == 2) {
       config.flags |= CONFIG_HIGH_FLAG;
-   } else {
-      config.flags |= CONFIG_VERY_HIGH_FLAG;
+   } else if (quality == 3) {
+      config.flags |= CONFIG_HIGH_FLAG | CONFIG_VERY_HIGH_FLAG;
    }
 
    if (hybridMode) {

--- a/src/export/ExportWavPack.cpp
+++ b/src/export/ExportWavPack.cpp
@@ -421,7 +421,7 @@ ProgressResult ExportWavPack::Export(AudacityProject *project,
          WavpackAppendTagItem(wpc,
                               n.mb_str(wxConvUTF8),
                               v.mb_str(wxConvUTF8),
-                              static_cast<int>( v.length() ));
+                              static_cast<int>( strlen(v.mb_str(wxConvUTF8)) ));
       }
 
       if (!WavpackWriteTag(wpc)) {

--- a/src/export/ExportWavPack.cpp
+++ b/src/export/ExportWavPack.cpp
@@ -310,10 +310,16 @@ ProgressResult ExportWavPack::Export(AudacityProject *project,
 
    config.num_channels = numChannels;
    config.sample_rate = rate;
-   config.channel_mask = config.num_channels == 1 ? 4 : 3; // Microsoft standard, mono = 4, stereo = 3
    config.bits_per_sample = bitDepth;
    config.bytes_per_sample = bitDepth/8;
    config.float_norm_exp = format == floatSample ? 127 : 0;
+
+   if (config.num_channels <= 2)
+      config.channel_mask = 0x5 - config.num_channels;
+   else if (config.num_channels <= 18)
+      config.channel_mask = (1U << config.num_channels) - 1;
+   else
+      config.channel_mask = 0x3FFFF;
 
    if (quality == 0) {
       config.flags |= CONFIG_FAST_FLAG;

--- a/src/export/ExportWavPack.cpp
+++ b/src/export/ExportWavPack.cpp
@@ -378,33 +378,17 @@ ProgressResult ExportWavPack::Export(AudacityProject *project,
             break;
          
          if (format == int16Sample) {
-            const char *mixed = mixer->GetBuffer();
+            const int16_t *mixed = reinterpret_cast<const int16_t*>(mixer->GetBuffer());
             for (decltype(samplesThisRun) j = 0; j < samplesThisRun; j++) {
                for (size_t i = 0; i < numChannels; i++) {
-                  int32_t value = *mixed++ & 0xff;
-                  value += *mixed++ << 8;
-                  wavpackBuffer[j*numChannels + i] = value;
+                  wavpackBuffer[j*numChannels + i] = (static_cast<int32_t>(*mixed++) * 65536) >> 16;
                }
             }
-         } else if (format == int24Sample || (WavpackGetMode(wpc) & MODE_FLOAT) == MODE_FLOAT) {
+         } else {
             const int *mixed = reinterpret_cast<const int*>(mixer->GetBuffer());
             for (decltype(samplesThisRun) j = 0; j < samplesThisRun; j++) {
                for (size_t i = 0; i < numChannels; i++) {
                   wavpackBuffer[j*numChannels + i] = *mixed++;
-               }
-            }
-         } else {
-            const float *mixed = reinterpret_cast<const float*>(mixer->GetBuffer());
-            for (decltype(samplesThisRun) j = 0; j < samplesThisRun; j++) {
-               for (size_t i = 0; i < numChannels; i++) {
-                  int64_t intValue = static_cast<int64_t>((*mixed++) * (std::numeric_limits<int32_t>::max()));
-
-                  intValue = std::clamp<int64_t>(
-                     intValue,
-                     std::numeric_limits<int32_t>::min(),
-                     std::numeric_limits<int32_t>::max());
-
-                  wavpackBuffer[j*numChannels + i] = static_cast<int32_t>(intValue);
                }
             }
          }

--- a/src/export/ExportWavPack.cpp
+++ b/src/export/ExportWavPack.cpp
@@ -107,7 +107,7 @@ const std::vector< int > ExportBitDepthValues{
 };
 
 IntSetting QualitySetting{ L"/FileFormats/WavPackEncodeQuality", 1 };
-IntSetting BitrateSetting{ L"/FileFormats/WavPackBitrate", 160 };
+IntSetting BitrateSetting{ L"/FileFormats/WavPackBitrate", 40 };
 IntSetting BitDepthSetting{ L"/FileFormats/WavPackBitDepth", 16 };
 
 BoolSetting HybridModeSetting{ L"/FileFormats/WavPackHybridMode", false };
@@ -119,47 +119,33 @@ Copied from ExportMP2.cpp by
    Markus Meyer
 */
 
-// i18n-hint kbps abbreviates "thousands of bits per second"
-inline TranslatableString n_kbps( int n ) { return XO("%d kbps").Format( n ); }
+// i18n-hint bps abbreviates "bits per sample"
+inline TranslatableString n_bps( int n ) { return XO("%.1f bps").Format( n / 10.0 ); }
 
 const TranslatableStrings BitRateNames {
-   n_kbps(16),
-   n_kbps(24),
-   n_kbps(32),
-   n_kbps(40),
-   n_kbps(48),
-   n_kbps(56),
-   n_kbps(64),
-   n_kbps(80),
-   n_kbps(96),
-   n_kbps(112),
-   n_kbps(128),
-   n_kbps(160),
-   n_kbps(192),
-   n_kbps(224),
-   n_kbps(256),
-   n_kbps(320),
-   n_kbps(384),
+   n_bps(22),
+   n_bps(25),
+   n_bps(30),
+   n_bps(35),
+   n_bps(40),
+   n_bps(45),
+   n_bps(50),
+   n_bps(60),
+   n_bps(70),
+   n_bps(80),
 };
 
 const std::vector< int > BitRateValues {
-   16,
-   24,
-   32,
+   22,
+   25,
+   30,
+   35,
    40,
-   48,
-   56,
-   64,
+   45,
+   50,
+   60,
+   70,
    80,
-   96,
-   112,
-   128,
-   160,
-   192,
-   224,
-   256,
-   320,
-   384,
 };
 
 }
@@ -331,8 +317,7 @@ ProgressResult ExportWavPack::Export(AudacityProject *project,
 
    if (hybridMode) {
       config.flags |= CONFIG_HYBRID_FLAG;
-      config.flags |= CONFIG_BITRATE_KBPS;
-      config.bitrate = bitRate;
+      config.bitrate = bitRate / 10.0;
 
       if (createCorrectionFile) {
          config.flags |= CONFIG_CREATE_WVC;

--- a/src/import/ImportWavPack.cpp
+++ b/src/import/ImportWavPack.cpp
@@ -194,8 +194,12 @@ ProgressResult WavPackImportFileHandle::Import(WaveTrackFactory *trackFactory, T
          samplesRead = WavpackUnpackSamples(mWavPackContext, wavpackBuffer.get(), SAMPLES_TO_READ);
 
          if (mFormat == int16Sample) {
-            for (int64_t c = 0; c < samplesRead * mNumChannels; c++)
-               int16Buffer[c] = static_cast<int16_t>(wavpackBuffer[c]);
+            if (mBytesPerSample == 1)
+               for (int64_t c = 0; c < samplesRead * mNumChannels; c++)
+                  int16Buffer[c] = static_cast<int16_t>(wavpackBuffer[c] * 256);
+            else
+               for (int64_t c = 0; c < samplesRead * mNumChannels; c++)
+                  int16Buffer[c] = static_cast<int16_t>(wavpackBuffer[c]);
 
             for (unsigned channel = 0; channel < mNumChannels; channel++) {
                mChannels[channel]->Append(

--- a/src/import/ImportWavPack.cpp
+++ b/src/import/ImportWavPack.cpp
@@ -24,6 +24,7 @@
 #include "ImportPlugin.h"
 
 #include<wx/string.h>
+#include<wx/log.h>
 #include<stdlib.h>
 #include<wavpack/wavpack.h>
 
@@ -104,11 +105,12 @@ TranslatableString WavPackImportPlugin::GetPluginFormatDescription()
 std::unique_ptr<ImportFileHandle> WavPackImportPlugin::Open(const FilePath &filename, AudacityProject*)
 {
    char errMessage[100]; // To hold possible error message
-   int flags = OPEN_WVC | OPEN_FILE_UTF8 | OPEN_TAGS;
+   int flags = OPEN_WVC | OPEN_FILE_UTF8 | OPEN_TAGS | OPEN_DSD_AS_PCM | OPEN_NORMALIZE;
    WavpackContext *wavpackContext = WavpackOpenFileInput(filename, errMessage, flags, 0);
    
    if (!wavpackContext) {
       // Some error occured(e.g. File not found or is invalid)
+      wxLogDebug("WavpackOpenFileInput() failed on file %s, error = %s", filename, errMessage);
       return nullptr;
    }
 

--- a/src/import/ImportWavPack.cpp
+++ b/src/import/ImportWavPack.cpp
@@ -257,12 +257,14 @@ ProgressResult WavPackImportFileHandle::Import(WaveTrackFactory *trackFactory, T
             itemLen = WavpackGetTagItemIndexed(mWavPackContext, i, NULL, 0);
             std::string item (itemLen + 1, '\0');
             WavpackGetTagItemIndexed(mWavPackContext, i, item.data(), itemLen + 1);
+            item.resize(itemLen);           // remove terminating NULL from std::string
             name = audacity::ToWXString(item);
 
             // Get the actual length of the value for this item key
             valueLen = WavpackGetTagItem(mWavPackContext, item.data(), NULL, 0);
             std::string itemValue (valueLen + 1, '\0');
             WavpackGetTagItem(mWavPackContext, item.data(), itemValue.data(), valueLen + 1);
+            itemValue.resize(valueLen);     // remove terminating NULL from std::string
 
             if (apeTag) {
                for (int j = 0; j < valueLen; j++) {


### PR DESCRIPTION
Hi Audacity team!

First I would like to thank the Audacity team, and particularly @Subhra264, for integrating WavPack into Audacity. Great work!

Unfortunately at the time I was not aware that this was ongoing because I found out about it the day it was committed to master. I'm sure that if I'd been aware I could have helped it along and perhaps saved some headaches. But in any event, I have been testing it now for the past week or so and have discovered and and fixed some minor issues and put together these eight commits.

Probably the easiest way to review them is to look at the individual commits. Most of them were pretty trivial to find (like files from the [official WavPack test suite](http://www.rarewares.org/wavpack/test_suite.zip) that simply would not load), and while I'm happy to go into more detail, these should all be pretty self-explanatory. One issue, however, requires a little more explanation.

The hybrid mode of WavPack was configured with a bitrate from 16 - 384 `kbps` (kbits per second). The problem with this is that this fixed range does not take into account the sample rate and number of channels (which directly affect the bitrates available), and therefore presents sometimes inappropriate values. For example, with 24/96 stereo audio the minimum bitrate that the hybrid mode will work at is around 430 kbps, and 6-channel, 48-kHz audio will only go down to 650 kbps. So for these common audio formats the entire range of presented bitrates is too low, which essentially makes the feature useless.

The solution I came up with is to present the bitrate in `bits per sample` instead, ranging from 2.2 (the minimum the hybrid mode will operate) to 8.0 (the practical upper limit which is always audibly transparent). I believe that this makes the feature usable while still presenting something easily understood by the user.

Please let me know if I can explain any of these changes more fully, and thanks again for this contribution!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
