### PR TITLE
Fixes uninitalized mBuffer in LV2AtomPortState

### DIFF
--- a/src/effects/lv2/LV2Ports.h
+++ b/src/effects/lv2/LV2Ports.h
@@ -93,6 +93,8 @@ struct LV2AtomPortState final {
        which we can also munlock in its destructor?
        */
       zix_ring_mlock(mRing.get());
+
+      ResetForInstanceOutput();
    }
 
    //! Transfer incoming events from the ring buffer to the event buffer.
@@ -176,7 +178,7 @@ public:
       , mSampleRate{ sampleRate }
       , mTrigger{ trigger }, mLogarithmic{ logarithmic }
    {}
- 
+
    // ScalePoints
    const std::vector<double> mScaleValues;
    const wxArrayString mScaleLabels;


### PR DESCRIPTION
Fixes uninitalized mBuffer in LV2AtomPortState
`LV2Wrapper::Create` performs `ReceiveFromInstance` for every atom port. However, mBuffer contents was never initialized before that. 

`zix_ring_write` expects that the first two DWORDS are well defined, not
doing so resulted in UB.

Resolves: #3323 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
