### PR TITLE
Add note about audacity_use_pch to BUILDING

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -89,6 +89,9 @@ If you install Graphviz, then an image file modules.dot.svg is generated in the 
 
 You will also be able to change to the scripts directory and run ./graph.pl to generate a diagram of dependencies among source code files within the executable.
 
+## Precompiled Headers
+
+While precompiled headers are useful, we want Audacity to run with or without this feature enabled. For that reason, we recommend setting `audacity_use_pch=NO` in CMake when configuring to disable precompiled headers for your build.
 
 ## Building on Windows
 


### PR DESCRIPTION
Add a small note to the BUILDING.txt file to explain precompiled headers. This reduces the change of a commit that works with precompiled headers but doesn't work without them.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] There are no behavior changes unnecessary for the stated purpose of the PR
