### PR TITLE
Fix errors in EffectStage::Acquire when there is short latency...

### DIFF
--- a/libraries/lib-audio-graph/EffectStage.h
+++ b/libraries/lib-audio-graph/EffectStage.h
@@ -64,10 +64,8 @@ private:
    bool Process(
       const Buffers &data, size_t curBlockSize, size_t outBufferOffset) const;
 
-   std::optional<size_t> FetchProcessAndAdvance(
+   [[nodiscard]] std::optional<size_t> FetchProcessAndAdvance(
       Buffers &data, size_t bound, bool doZeros, size_t outBufferOffset = 0);
-
-   void FinishUpstream();
 
    Source &mUpstream;
    //! @invariant mInBuffers.BlockSize() <= mInBuffers.Remaining()
@@ -77,7 +75,6 @@ private:
    const double mSampleRate;
    const bool mIsProcessor;
 
-   sampleCount mDelay{};
    sampleCount mDelayRemaining;
    size_t mLastProduced{};
    size_t mLastZeroes{};


### PR DESCRIPTION
... In the example of AUDynamicsProcessor, latency is 256 samples, while block
size defaults to 512.

Resolves: #3340

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
