### PR TITLE
WavPack: default to native WavPack import before FFmpeg (which is slower + missing features)

### DIFF
--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -138,7 +138,7 @@ bool Importer::Initialize()
    using namespace Registry;
    static OrderingPreferenceInitializer init{
       PathStart,
-      { {wxT(""), wxT("AUP,PCM,OGG,FLAC,MP3,LOF,FFmpeg") } }
+      { {wxT(""), wxT("AUP,PCM,OGG,FLAC,MP3,LOF,WavPack,FFmpeg") } }
       // QT and GStreamer are only conditionally compiled and would get
       // placed at the end if present
    };


### PR DESCRIPTION
When I first started testing WavPack import, the default Audacity behavior ("All files") was to use the FFmpeg importer instead of the new native one. It was also not obvious that this was happening unless the file was long enough that the title of the importing window was noticed. FFmpeg has handled WavPack files for a long time, and is generally fine, but there are some reasons to _not_ use it by default:

- It is slower than the native WavPack importer, probably because it's missing the assembly language optimizations
- It does not handle WavPack DSD files (the latest FFmpeg does, but the version here doesn't)
- It does not handle correction files (wvc)
- It does not import all the metadata

I'm not sure if this is the best way to resolve this issue (adding it to the `OrderingPreferenceInitializer`) but that definitely works. I was also able to achieve this by deleting the `"wv"` entry in the list of handled extensions in `ImportFFmpeg.cpp`, but that didn't seem like the right way to do it.

Thanks!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
