### PR TITLE
Flush delay buffers

### DIFF
--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -391,6 +391,8 @@ void AudioUnitInstance::EventListener(const AudioUnitEvent *inEvent,
 bool AudioUnitInstance::BypassEffect(bool bypass)
 {
    UInt32 value = (bypass ? 1 : 0);
+   if (bypass && AudioUnitReset(mUnit.get(), kAudioUnitScope_Global, 0))
+      return false;
    return !SetProperty(kAudioUnitProperty_BypassEffect, value);
 }
 

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -81,7 +81,8 @@ size_t AudioUnitInstance::GetTailSize() const
 bool AudioUnitInstance::ProcessInitialize(EffectSettings &settings,
    double sampleRate, ChannelNames chanMap)
 {
-   StoreSettings(GetSettings(settings));
+   if (!StoreSettings(GetSettings(settings)))
+      return false;
 
    mInputList =
       PackedArray::AllocateCount<AudioBufferList>(mAudioIns)(mAudioIns);
@@ -179,8 +180,6 @@ bool AudioUnitInstance::RealtimeAddProcessor(
 
    slave->SetBlockSize(mBlockSize);
 
-   if (!slave->StoreSettings(GetSettings(settings)))
-      return false;
    if (!slave->ProcessInitialize(settings, sampleRate, nullptr))
       return false;
    if (uSlave)

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1038,11 +1038,17 @@ return GuardedCall<bool>([&]{
 
 bool LadspaEffect::Instance::RealtimeSuspend()
 {
+   if (auto fn = GetEffect().mData->deactivate)
+      for (auto &slave : mSlaves)
+         fn(slave);
    return true;
 }
 
 bool LadspaEffect::Instance::RealtimeResume()
 {
+   if (auto fn = GetEffect().mData->activate)
+      for (auto &slave : mSlaves)
+         fn(slave);
    return true;
 }
 

--- a/src/effects/lv2/LV2Instance.cpp
+++ b/src/effects/lv2/LV2Instance.cpp
@@ -158,6 +158,11 @@ bool LV2Instance::RealtimeAddProcessor(
 
 bool LV2Instance::RealtimeSuspend()
 {
+   if (mMaster)
+      mMaster->Deactivate();
+   for (auto &pSlave : mSlaves)
+      pSlave->Deactivate();
+
    mPositionSpeed = 0.0;
    mPositionFrame = 0;
    mRolling = false;
@@ -167,6 +172,11 @@ bool LV2Instance::RealtimeSuspend()
 
 bool LV2Instance::RealtimeResume()
 {
+   if (mMaster)
+      mMaster->Activate();
+   for (auto &pSlave : mSlaves)
+      pSlave->Activate();
+
    mPositionSpeed = 1.0;
    mPositionFrame = 0;
    mRolling = true;


### PR DESCRIPTION
Resolves: #3112 (except for VST2)

Fix realtime play of Ladspa, Lv2, and AudioUnit effects, so they properly clear delay buffers when you power an effect or
effect list off.

I believe VST3 required no fix here, but the right fix for VST2 isn't known to me yet.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
