### PR TITLE
Fix mono reverbs

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1935,12 +1935,13 @@ void AudioIO::TransformPlayBuffers(
             // Then supply some non-null fake input buffers, because the
             // various ProcessBlock overrides of effects may crash without it.
             // But it would be good to find the fixes to make this unnecessary.
-            float **scratch = &mScratchPointers[mNumPlaybackChannels + 1];
+            float **scratch = &mScratchPointers[mNumPlaybackChannels];
             while (iChannel < mNumPlaybackChannels)
-               pointers[iChannel++] = *scratch++;
+               memset((pointers[iChannel++] = *scratch++), 0, len * sizeof(float));
 
             if (len && pScope)
-               pScope->Process(*vt, &pointers[0], mScratchPointers.data(), len);
+               pScope->Process(*vt, &pointers[0], mScratchPointers.data(),
+                  mNumPlaybackChannels, len);
          }
       }
    }

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -30,6 +30,7 @@ class RingBuffer final : public NonInterferingBase {
               size_t padding = 0);
    size_t Clear(sampleFormat format, size_t samples);
    //! Get access to written but unflushed data, which is in at most two blocks
+   //! Excludes the padding of the most recent Put()
    std::pair<samplePtr, size_t> GetUnflushed(unsigned iBlock);
    //! Flush after a sequence of Put (and/or Clear) calls to let consumer see
    void Flush();
@@ -48,6 +49,7 @@ class RingBuffer final : public NonInterferingBase {
    size_t Free( size_t start, size_t end );
 
    size_t mWritten{0};
+   size_t mLastPadding{0};
 
    // Align the two atomics to avoid false sharing
    NonInterfering< std::atomic<size_t> > mStart{ 0 }, mEnd{ 0 };

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -126,7 +126,7 @@ void RealtimeEffectManager::ProcessStart(bool suspended)
 // This will be called in a thread other than the main GUI thread.
 //
 size_t RealtimeEffectManager::Process(bool suspended, Track &track,
-   float *const *buffers, float *const *scratch,
+   float *const *buffers, float *const *scratch, unsigned nBuffers,
    size_t numSamples)
 {
    // Can be suspended because of the audio stream being paused or because effects
@@ -142,14 +142,13 @@ size_t RealtimeEffectManager::Process(bool suspended, Track &track,
 
    // Allocate the in and out buffer arrays
    const auto ibuf =
-      static_cast<float **>(alloca(chans * sizeof(float *)));
+      static_cast<float **>(alloca(nBuffers * sizeof(float *)));
    const auto obuf =
-      static_cast<float **>(alloca(chans * sizeof(float *)));
+      static_cast<float **>(alloca(nBuffers * sizeof(float *)));
 
    // And populate the input with the buffers we've been given while allocating
    // NEW output buffers
-   for (unsigned int i = 0; i < chans; i++)
-   {
+   for (unsigned int i = 0; i < nBuffers; i++) {
       ibuf[i] = buffers[i];
       obuf[i] = scratch[i];
    }
@@ -161,7 +160,7 @@ size_t RealtimeEffectManager::Process(bool suspended, Track &track,
    VisitGroup(track,
       [&](RealtimeEffectState &state, bool)
       {
-         state.Process(track, chans, ibuf, obuf, scratch[chans], numSamples);
+         state.Process(track, chans, ibuf, obuf, numSamples);
          for (auto i = 0; i < chans; ++i)
             std::swap(ibuf[i], obuf[i]);
          called++;

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -147,7 +147,8 @@ private:
    void ProcessStart(bool suspended);
    /*! @copydoc ProcessScope::Process */
    size_t Process(bool suspended, Track &track,
-      float *const *buffers, float *const *scratch, size_t numSamples);
+      float *const *buffers, float *const *scratch,
+      unsigned nBuffers, size_t numSamples);
    void ProcessEnd(bool suspended) noexcept;
 
    RealtimeEffectManager(const RealtimeEffectManager&) = delete;
@@ -260,16 +261,16 @@ public:
    }
 
    size_t Process(Track &track,
-      float *const *buffers, /*!< Assume as many buffers, as channels were
-         specified in the AddTrack call */
-      float *const *scratch, /*!< As many temporary buffers as in buffers,
-         plus one more */
+      float *const *buffers,
+      float *const *scratch,
+      unsigned nBuffers, //!< how many buffers; equal number of scratches
       size_t numSamples //!< length of each buffer
    )
    {
       if (auto pProject = mwProject.lock())
          return RealtimeEffectManager::Get(*pProject)
-            .Process(mSuspended, track, buffers, scratch, numSamples);
+            .Process(mSuspended, track, buffers, scratch,
+               nBuffers, numSamples);
       else
          return numSamples; // consider them trivially processed
    }

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -416,16 +416,17 @@ bool RealtimeEffectState::ProcessStart(bool running)
 
 //! Visit the effect processors that were added in AddTrack
 /*! The iteration over channels in AddTrack and Process must be the same */
-size_t RealtimeEffectState::Process(Track &track,
+void RealtimeEffectState::Process(Track &track,
    unsigned chans,
    const float *const *inbuf, float *const *outbuf, float *dummybuf,
    size_t numSamples)
 {
    auto pInstance = mwInstance.lock();
    if (!mPlugin || !pInstance || !mLastActive) {
+      // Process trivially
       for (size_t ii = 0; ii < chans; ++ii)
          memcpy(outbuf[ii], inbuf[ii], numSamples * sizeof(float));
-      return numSamples; // consider all samples to be trivially processed
+      return;
    }
 
    // The caller passes the number of channels to process and specifies
@@ -537,8 +538,6 @@ size_t RealtimeEffectState::Process(Track &track,
       }
       processor++;
    }
-
-   return len;
 }
 
 bool RealtimeEffectState::ProcessEnd()

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -416,10 +416,8 @@ bool RealtimeEffectState::ProcessStart(bool running)
 
 //! Visit the effect processors that were added in AddTrack
 /*! The iteration over channels in AddTrack and Process must be the same */
-void RealtimeEffectState::Process(Track &track,
-   unsigned chans,
-   const float *const *inbuf, float *const *outbuf, float *dummybuf,
-   size_t numSamples)
+void RealtimeEffectState::Process(Track &track, unsigned chans,
+   const float *const *inbuf, float *const *outbuf, size_t numSamples)
 {
    auto pInstance = mwInstance.lock();
    if (!mPlugin || !pInstance || !mLastActive) {
@@ -456,19 +454,12 @@ void RealtimeEffectState::Process(Track &track,
    // Call the client until we run out of input or output channels
    while (ichans > 0 && ochans > 0)
    {
-      // If we don't have enough input channels to accommodate the client's
-      // requirements, then we replicate the input channels until the
-      // client's needs are met.
+      // Assume sufficient buffers of zeroes given when the stored track
+      // did not have enough channels
       if (ichans < numAudioIn)
       {
          for (size_t i = 0; i < numAudioIn; i++)
-         {
-            if (indx == ichans)
-            {
-               indx = 0;
-            }
             clientIn[i] = inbuf[indx++];
-         }
 
          // All input channels have been consumed
          ichans = 0;
@@ -491,16 +482,7 @@ void RealtimeEffectState::Process(Track &track,
       if (ochans < numAudioOut)
       {
          for (size_t i = 0; i < numAudioOut; i++)
-         {
-            if (i < ochans)
-            {
-               clientOut[i] = outbuf[i];
-            }
-            else
-            {
-               clientOut[i] = dummybuf;
-            }
-         }
+            clientOut[i] = outbuf[i];
 
          // All output channels have been consumed
          ochans = 0;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -65,7 +65,7 @@ public:
    /*! @param running means no pause or deactivation of containing list */
    bool ProcessStart(bool running);
    //! Worker thread processes part of a batch of samples
-   size_t Process(Track &track,
+   void Process(Track &track,
       unsigned chans,
       const float *const *inbuf, //!< chans input buffers
       float *const *outbuf, //!< chans output buffers

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -69,7 +69,6 @@ public:
       unsigned chans,
       const float *const *inbuf, //!< chans input buffers
       float *const *outbuf, //!< chans output buffers
-      float *dummybuf, //!< one scratch buffer
       size_t numSamples);
    //! Worker thread finishes a batch of samples
    bool ProcessEnd();


### PR DESCRIPTION
Resolves: #3315 

Make sure the inputs given to realtime play of a mono track are the same as given to destructive effect application and
rendering.

This makes a difference with reverb effects, which do not process channels independently, but rather have each output
channel affected by each input channel.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
