### PR TITLE
Clear effect stacks after Mix Down to Mono or (either) Mix-and-Render

### DIFF
--- a/src/MixAndRender.cpp
+++ b/src/MixAndRender.cpp
@@ -12,6 +12,7 @@ Paul Licameli split from Mix.cpp
 
 #include "BasicUI.h"
 #include "Mix.h"
+#include "effects/RealtimeEffectList.h"
 #include "WaveTrack.h"
 
 using WaveTrackConstArray = std::vector < std::shared_ptr < const WaveTrack > >;
@@ -188,6 +189,10 @@ void MixAndRender(const TrackIterRange<const WaveTrack> &trackRange,
    wxPrintf("Elapsed time: %f sec\n", elapsedTime);
    wxPrintf("Max number of tracks to mix in real time: %f\n", maxTracks);
 #endif
+
+      for (auto pTrack : { uLeft.get(), uRight.get() })
+         if (pTrack)
+            RealtimeEffectList::Get(*pTrack).Clear();
    }
 }
 

--- a/src/effects/RealtimeEffectList.cpp
+++ b/src/effects/RealtimeEffectList.cpp
@@ -148,6 +148,19 @@ void RealtimeEffectList::RemoveState(
    }
 }
 
+void RealtimeEffectList::Clear()
+{
+   decltype(mStates) temp;
+   
+   // Swap an empty list in as a whole, not removing one at a time
+   // Lock for only a short time
+   (LockGuard{ mLock }, swap(temp, mStates));
+
+   for (auto index = temp.size(); index--;)
+      Publisher<RealtimeEffectListMessage>::Publish({
+         RealtimeEffectListMessage::Type::Remove, index, { } });
+}
+
 std::optional<size_t> RealtimeEffectList::FindState(
    const std::shared_ptr<RealtimeEffectState> &pState) const
 {

--- a/src/effects/RealtimeEffectList.h
+++ b/src/effects/RealtimeEffectList.h
@@ -107,6 +107,9 @@ public:
    //! On success sends Remove message.
    void RemoveState(const std::shared_ptr<RealtimeEffectState> &pState);
 
+   //! Use only in the main thread.  Sends Remove messages
+   void Clear();
+
    //! Report the position of a state in the list
    std::optional<size_t> FindState(
       const std::shared_ptr<RealtimeEffectState> &pState) const;

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -22,6 +22,7 @@
 #include "Mix.h"
 #include "MixAndRender.h"
 #include "Project.h"
+#include "RealtimeEffectList.h"
 #include "../WaveTrack.h"
 #include "../widgets/ProgressDialog.h"
 
@@ -214,6 +215,7 @@ bool EffectStereoToMono::ProcessOne(sampleCount & curTime, sampleCount totalTime
    left->Paste(minStart, outTrack.get());
    mOutputTracks->UnlinkChannels(*left);
    mOutputTracks->Remove(right);
+   RealtimeEffectList::Get(*left).Clear();
 
    return bResult;
 }


### PR DESCRIPTION
Resolves: #3356

Mix Stereo Down To Mono, Mix And Render (to same or to new track)
now leave the resulting effect stacks empty

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
