### PR TITLE
Play of non-point selection with no loop region should stop at end...

### DIFF
--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -244,7 +244,7 @@ NewDefaultPlaybackPolicy::GetPlaybackSlice(
    double deltat = (frames / mRate) * mLastPlaySpeed;
 
    if (deltat > realTimeRemaining) {
-      toProduce = frames = (realTimeRemaining * mRate) / mLastPlaySpeed;
+      toProduce = frames = 0.5 + (realTimeRemaining * mRate) / mLastPlaySpeed;
       auto realTime = realTimeRemaining;
       double extra = 0;
       if (RevertToOldDefault(schedule)) {
@@ -252,7 +252,7 @@ NewDefaultPlaybackPolicy::GetPlaybackSlice(
          // satisfy its end condition
          const double extraRealTime =
             ((TimeQueueGrainSize + 1) / mRate) * mLastPlaySpeed;
-         auto extra = std::min( extraRealTime, deltat - realTimeRemaining );
+         extra = std::min( extraRealTime, deltat - realTimeRemaining );
          frames = ((realTimeRemaining + extra) * mRate) / mLastPlaySpeed;
       }
       schedule.RealTimeAdvance( realTimeRemaining + extra );


### PR DESCRIPTION
... This fixes a regression from 3.1.3, and is another example of a silly bug
that would have been caught if shadowed variables were flagged as errors.

Resolves: #2721

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
