### PR TITLE
fix for vst2 plugins which do not support chunk

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -3569,7 +3569,7 @@ bool VSTEffectWrapper::StoreSettings(const VSTEffectSettings& vst3settings) cons
    
    constCallDispatcher(effEndSetProgram, 0, 0, NULL, 0.0);
 
-   return false;
+   return true;
 }
 
 bool VSTEffect::TransferDataToWindow(const EffectSettings& settings)


### PR DESCRIPTION
Resolves: 

This fix is so small and correcting an obvious oversight, that I do not think it is worth opening an issue for it (but if I am wrong please tell me and I will open one).

The bug shows up when using vst2 plugins which do not support the "chunk" so in that case they fall back to saving settings as key-value pairs. The only problem was that once they take that path, `StoreSettings` wrongly returned `false` instead of `true`, and that in turn creates a chain of events that prevents the application of destructive processing.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
