### PR TITLE
Fixes Nyquist Prompt for effects, producing UI

### DIFF
--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -312,6 +312,11 @@ private:
    DECLARE_EVENT_TABLE()
 
    friend class NyquistEffectsModule;
+
+   struct SharedValidatorState;
+   struct NyquistEffectUIValidator;
+
+   std::weak_ptr<SharedValidatorState> mSharedValidatorState;
 };
 
 class NyquistOutputDialog final : public wxDialogWrapper


### PR DESCRIPTION
`NyquistEffect` violates the assumption, that Effect outlives Validator in case the code from Nyquist Prompt generates another dialog. In this case, UI is shown for a stack allocated `NyquistEffect`, which is destroyed before the `EffectUI` destructor is called.

Resolves: #3345 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
