### PR TITLE
TrackId really can identify tracks across undo states...

### DIFF
--- a/libraries/lib-project-history/ProjectHistory.cpp
+++ b/libraries/lib-project-history/ProjectHistory.cpp
@@ -140,7 +140,7 @@ void ProjectHistory::PopState(const UndoState &state, bool doAutosave)
 
    dstTracks.Clear();
    for (auto t : tracks->Any())
-      dstTracks.Add(t->Duplicate());
+      dstTracks.Add(t->Duplicate(), t->GetId());
 }
 
 void ProjectHistory::SetStateTo(unsigned int n, bool doAutosave)

--- a/libraries/lib-project-history/ProjectHistory.h
+++ b/libraries/lib-project-history/ProjectHistory.h
@@ -46,13 +46,19 @@ public:
    void SetStateTo(unsigned int n, bool doAutosave = true);
    bool UndoAvailable() const;
    bool RedoAvailable() const;
+   //! New saved state will make TrackIds correspond with current project
+   //! contents
    void PushState(
       const TranslatableString &desc,
       const TranslatableString &shortDesc); // use UndoPush::AUTOSAVE
+   //! New saved state will make TrackIds correspond with current project
+   //! contents
    void PushState(
       const TranslatableString &desc,
       const TranslatableString &shortDesc, UndoPush flags);
    void RollbackState();
+   //! Modified state will make TrackIds correspond with current project
+   //! contents
    void ModifyState(bool bWantsAutoSave);    // if true, writes auto-save file.
       // Should set only if you really want the state change restored after
       // a crash, as it can take many seconds for large (eg. 10 track-hours)

--- a/libraries/lib-project-history/UndoManager.cpp
+++ b/libraries/lib-project-history/UndoManager.cpp
@@ -189,10 +189,12 @@ void UndoManager::ModifyState(const TrackList &l,
    // Duplicate
    auto tracksCopy = TrackList::Create( nullptr );
    for (auto t : l) {
-      if ( t->GetId() == TrackId{} )
+      const auto id = t->GetId();
+      if (id == TrackId{})
          // Don't copy a pending added track
          continue;
-      tracksCopy->Add(t->Duplicate());
+      // Make TrackIds correspond between current state and saved
+      tracksCopy->Add(t->Duplicate(), id);
    }
 
    // Replace
@@ -239,10 +241,12 @@ void UndoManager::PushState(const TrackList &l,
 
    auto tracksCopy = TrackList::Create( nullptr );
    for (auto t : l) {
-      if ( t->GetId() == TrackId{} )
+      const auto id = t->GetId();
+      if (id == TrackId{})
          // Don't copy a pending added track
          continue;
-      tracksCopy->Add(t->Duplicate());
+      // Make TrackIds correspond between current state and saved
+      tracksCopy->Add(t->Duplicate(), id);
    }
 
    mayConsolidate = true;

--- a/libraries/lib-project-history/UndoManager.h
+++ b/libraries/lib-project-history/UndoManager.h
@@ -176,11 +176,15 @@ class PROJECT_HISTORY_API UndoManager final
    UndoManager( const UndoManager& ) = delete;
    UndoManager& operator = ( const UndoManager& ) = delete;
 
+   //! New saved state will make TrackIds correspond with current project
+   //! contents
    void PushState(const TrackList &l,
                   const SelectedRegion &selectedRegion,
                   const TranslatableString &longDescription,
                   const TranslatableString &shortDescription,
                   UndoPush flags = UndoPush::NONE);
+   //! Modified state will make TrackIds correspond with current project
+   //! contents
    void ModifyState(const TrackList &l,
                     const SelectedRegion &selectedRegion);
    void RenameState( int state,

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -712,14 +712,14 @@ Track *TrackList::DoAddToHead(const std::shared_ptr<Track> &t)
    return front().get();
 }
 
-Track *TrackList::DoAdd(const std::shared_ptr<Track> &t)
+Track *TrackList::DoAdd(const std::shared_ptr<Track> &t, TrackId id)
 {
    push_back(t);
 
    auto n = getPrev( getEnd() );
 
    t->SetOwner(shared_from_this(), n);
-   t->SetId( TrackId{ ++sCounter } );
+   t->SetId( (id == TrackId{}) ? TrackId{ ++sCounter } : id );
    RecalcPositions(n);
    AdditionEvent(n);
    return back().get();

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -146,7 +146,14 @@ template<typename T>
     (A track added by TrackList::RegisterPendingNewTrack() that is not yet applied is not
     considered added.)
  
-    TrackIds are assigned uniquely across projects. */
+    Undo management should set TrackIds in Track objects representing states of
+    "the same" track in history so they are equal.
+
+    Otherwise TrackIds are assigned uniquely in-session, if no second
+    argument is given to TrackList::Add().
+
+    TrackIds are then unique even across projects in-session.
+ */
 class TrackId
 {
 public:
@@ -1510,7 +1517,7 @@ class TRACK_API TrackList final
 
 private:
    Track *DoAddToHead(const std::shared_ptr<Track> &t);
-   Track *DoAdd(const std::shared_ptr<Track> &t);
+   Track *DoAdd(const std::shared_ptr<Track> &t, TrackId id);
 
    template< typename TrackType, typename InTrackType >
       static TrackIterRange< TrackType >
@@ -1559,8 +1566,8 @@ public:
          { return static_cast< TrackKind* >( DoAddToHead( t ) ); }
 
    template<typename TrackKind>
-      TrackKind *Add( const std::shared_ptr< TrackKind > &t )
-         { return static_cast< TrackKind* >( DoAdd( t ) ); }
+      TrackKind *Add( const std::shared_ptr< TrackKind > &t, TrackId id = {} )
+         { return static_cast< TrackKind* >( DoAdd( t, id ) ); }
    
    //! Removes linkage if track belongs to a group
    void UnlinkChannels(Track& track);


### PR DESCRIPTION
... It wasn't broken for its other intended purposes, but had not been used for
this purpose before.

Resolves: assists development of non-modality of effect dialogs

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
