### PR TITLE
Wavpack enhancements

### DIFF
--- a/src/export/ExportWavPack.cpp
+++ b/src/export/ExportWavPack.cpp
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 #define ID_HYBRID_MODE 9000
+#define ID_CREATE_WVC  9001
 
 class ExportWavPackOptions final : public wxPanelWrapper
 {
@@ -52,6 +53,7 @@ public:
    bool TransferDataFromWindow() override;
 
    void OnHybridMode(wxCommandEvent& evt);
+   void OnCreateCorrection(wxCommandEvent& evt);
 
 private:
    wxCheckBox *mCreateCorrectionFile { nullptr };
@@ -62,6 +64,7 @@ private:
 
 BEGIN_EVENT_TABLE(ExportWavPackOptions, wxPanelWrapper)
    EVT_CHECKBOX(ID_HYBRID_MODE, ExportWavPackOptions::OnHybridMode)
+   EVT_CHECKBOX(ID_CREATE_WVC,  ExportWavPackOptions::OnCreateCorrection)
 END_EVENT_TABLE()
 
 ExportWavPackOptions::ExportWavPackOptions(wxWindow *parent, int WXUNUSED(format))
@@ -176,7 +179,11 @@ void ExportWavPackOptions::PopulateOrExchange(ShuttleGui & S)
             );
 
             S.Id(ID_HYBRID_MODE).TieCheckBox( XXO("Hybrid Mode"), HybridModeSetting);
-            mCreateCorrectionFile = S.Disable(!hybridMode).TieCheckBox( XXO("Create Correction(.wvc) File"), CreateCorrectionFileSetting);
+
+            mCreateCorrectionFile = S.Id(ID_CREATE_WVC).Disable(!hybridMode).TieCheckBox(
+               XXO("Create Correction(.wvc) File"),
+               CreateCorrectionFileSetting
+            );
 
             mBitRate = S.Disable(!hybridMode).TieNumberAsChoice(
                XXO("Bit Rate:"),
@@ -212,6 +219,11 @@ void ExportWavPackOptions::OnHybridMode(wxCommandEvent&)
    const auto hybridMode = HybridModeSetting.Toggle();
    mCreateCorrectionFile->Enable(hybridMode);
    mBitRate->Enable(hybridMode);
+};
+
+void ExportWavPackOptions::OnCreateCorrection(wxCommandEvent&)
+{
+   CreateCorrectionFileSetting.Toggle();
 };
 
 //---------------------------------------------------------------------------

--- a/src/export/ExportWavPack.cpp
+++ b/src/export/ExportWavPack.cpp
@@ -342,6 +342,12 @@ ProgressResult ExportWavPack::Export(AudacityProject *project,
       }
    }
 
+   // If we're not creating a correction file now, any one that currently exists with this name
+   // will become obsolete now, so delete it if it happens to exist (although it usually won't)
+
+   if (!hybridMode || !createCorrectionFile)
+      wxRemoveFile(fName.GetFullPath().Append("c"));
+
    WavpackContext *wpc = WavpackOpenFileOutput(WriteBlock, &outWvFile, createCorrectionFile ? &outWvcFile : nullptr);
    auto closeWavPackContext = finally([wpc]() { WavpackCloseFile(wpc); });
 

--- a/src/export/ExportWavPack.cpp
+++ b/src/export/ExportWavPack.cpp
@@ -418,9 +418,7 @@ ProgressResult ExportWavPack::Export(AudacityProject *project,
       for (const auto &pair : metadata->GetRange()) {
          n = pair.first;
          const auto &v = pair.second;
-         if (n == TAG_YEAR) {
-            n = wxT("DATE");
-         }
+
          WavpackAppendTagItem(wpc,
                               n.mb_str(wxConvUTF8),
                               v.mb_str(wxConvUTF8),

--- a/src/import/ImportWavPack.cpp
+++ b/src/import/ImportWavPack.cpp
@@ -32,6 +32,7 @@
 #include "../Tags.h"
 #include "../WaveTrack.h"
 #include "../widgets/ProgressDialog.h"
+#include "../widgets/AudacityMessageBox.h"
 #include "CodeConversions.h"
 
 #define DESC XO("WavPack files")
@@ -229,6 +230,10 @@ ProgressResult WavPackImportFileHandle::Import(WaveTrackFactory *trackFactory, T
          updateResult = mProgress->Update(WavpackGetProgress(mWavPackContext), 1.0);
       } while (updateResult == ProgressResult::Success && samplesRead != 0);
    }
+
+   if (WavpackGetNumErrors(mWavPackContext))
+      AudacityMessageBox( XO( "Encountered %d errors decoding WavPack file!" ).Format( WavpackGetNumErrors(mWavPackContext) ),
+                          XO( "WavPack Importer" ), wxOK | wxICON_EXCLAMATION | wxCENTRE);
 
    if (updateResult != ProgressResult::Stopped && updateResult != ProgressResult::Cancelled
          && totalSamplesRead < mNumSamples)


### PR DESCRIPTION
I found a few straggling issues with the WavPack import/export, and I also added a couple enhancements.

These changes should all be simple and straightforward except one. I noticed during my testing that once I had enabled the "correction" files, I was unable to turn them back off in the dialog. This was not obvious at first because the setting _appeared_ to be off (the checkbox was unchecked), but the correction file was still generated. This was persistent and the only way to clear the setting for real was to shutdown and restart Audacity.

I never could figure out why this was happening. Either the `TieCheckBox` functionality is broken (unlikely) or it was simply not being used correctly in this case. I looked at other instances and couldn't find another example of `TieCheckBox` being used the exact same way, so I decided to just convert it to a toggle event like the "hybrid" checkbox (which was working correctly). This fixed the issue and I have not seen any regression after extensive testing.

Thanks again for your consideration and including WavPack in Audacity! 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
