### PR TITLE
Adds string_view overloads to CodeConversions

### DIFF
--- a/libraries/lib-string-utils/CodeConversions.cpp
+++ b/libraries/lib-string-utils/CodeConversions.cpp
@@ -36,6 +36,12 @@ std::wstring ToWString (const std::string& str)
     return std::wstring_convert<std::codecvt_utf8<wchar_t>> ().from_bytes (str);
 }
 
+STRING_UTILS_API std::wstring ToWString(std::string_view str)
+{
+   return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(
+      str.data(), str.data() + str.length());
+}
+
 std::wstring ToWString (const char* str)
 {
     return std::wstring_convert<std::codecvt_utf8<wchar_t>> ().from_bytes (str);
@@ -49,6 +55,16 @@ std::wstring ToWString (const wxString& str)
 wxString ToWXString (const std::string& str)
 {
     return wxString::FromUTF8 (str);
+}
+
+STRING_UTILS_API wxString ToWXString(std::string_view str)
+{
+   return wxString::FromUTF8(str.data(), str.length());
+}
+
+STRING_UTILS_API wxString ToWXString(const char* str)
+{
+   return wxString::FromUTF8(str);
 }
 
 wxString ToWXString (const std::wstring& str)

--- a/libraries/lib-string-utils/CodeConversions.h
+++ b/libraries/lib-string-utils/CodeConversions.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <wx/string.h>
 
 namespace audacity
@@ -22,10 +23,13 @@ STRING_UTILS_API std::string ToUTF8 (const wxString& wstr);
 
 // std::wstring is UTF16 on windows and UTF32 elsewhere.
 STRING_UTILS_API std::wstring ToWString (const std::string& str);
+STRING_UTILS_API std::wstring ToWString (std::string_view str);
 STRING_UTILS_API std::wstring ToWString (const char* str);
 STRING_UTILS_API std::wstring ToWString (const wxString& str);
 
 STRING_UTILS_API wxString ToWXString (const std::string& str);
+STRING_UTILS_API wxString ToWXString (std::string_view str);
+STRING_UTILS_API wxString ToWXString (const char* str);
 STRING_UTILS_API wxString ToWXString (const std::wstring& str);
 
 }


### PR DESCRIPTION
- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
