### PR TITLE
Fix free store allocation that was hiding in EffectSettingsAccess...

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -73,9 +73,9 @@ class COMPONENTS_API EffectSettingsExtra final {
 public:
    static const RegistryPath &DurationKey();
    const NumericFormatSymbol& GetDurationFormat() const
-      { return mDurationFormat; }
+      { return *mpDurationFormat; }
    void SetDurationFormat(const NumericFormatSymbol &durationFormat)
-      { mDurationFormat = durationFormat; }
+      { *mpDurationFormat = durationFormat; }
 
    //! @return value is not negative
    double GetDuration() const { return mDuration; }
@@ -90,7 +90,9 @@ public:
    bool GetActive() const { return mActive; }
    void SetActive(bool value) { mActive = value; }
 private:
-   NumericFormatSymbol mDurationFormat{};
+   std::shared_ptr<NumericFormatSymbol> mpDurationFormat{
+      std::make_shared<NumericFormatSymbol>()
+   };
    double mDuration{}; //!< @invariant non-negative
    Counter mCounter{ 0 };
    bool mActive{ true };


### PR DESCRIPTION
... This is the simplest fix to write for now.

Note that the get and set of duration format happen only in the main thread, so
no harm in simply sharing the state.

In the next version we should rewrite the inter-thread communication more
thoroughly and separate concerns better, so that the structure holding
persistent settings may be different from those carrying messages between
threads.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
