### PR TITLE
Fixes RT effects processing on destructive path

### DIFF
--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1242,7 +1242,7 @@ std::shared_ptr<EffectInstance> EffectUIHost::InitializeInstance()
 
    if (mSupportsRealtime && !mInitialized) {
       if (!priorState)
-         mpState =
+         mwState = mpState = mpTempProjectState =
             AudioIO::Get()->AddState(mProject, nullptr, GetID(mEffectUIHost));
       if (mpState) {
          // Find the right instance to connect to the dialog
@@ -1284,14 +1284,12 @@ std::shared_ptr<EffectInstance> EffectUIHost::InitializeInstance()
 
 void EffectUIHost::CleanupRealtime()
 {
-   bool noPriorState(mSubscription);
    mSubscription.Reset();
-   if (mSupportsRealtime && mInitialized) {
-      auto mpState = mwState.lock();
 
-      if (noPriorState && mpState) {
-         AudioIO::Get()->RemoveState(mProject, nullptr, mpState);
-         mpState.reset();
+   if (mSupportsRealtime && mInitialized) {
+      if (mpTempProjectState) {
+         AudioIO::Get()->RemoveState(mProject, nullptr, mpTempProjectState);
+         mpTempProjectState.reset();
       /*
          ProjectHistory::Get(mProject).PushState(
             XO("Removed %s effect").Format(mpState->GetEffect()->GetName()),

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -109,6 +109,8 @@ private:
    EffectPlugin::EffectSettingsAccessPtr mpAccess;
    EffectPlugin::EffectSettingsAccessPtr mpAccess2;
    std::weak_ptr<RealtimeEffectState> mwState{};
+   // Temporary state used for destructive processing
+   std::shared_ptr<RealtimeEffectState> mpTempProjectState {};
    std::unique_ptr<EffectUIValidator> mpValidator;
 
    RegistryPaths mUserPresets;


### PR DESCRIPTION
Strong reference to the created temporary instance is stored in order to fulfil preconditions required by EffectUIHost::CleanupRealtime()

Resolves: #3389

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
