### PR TITLE
Invalidate named Settings, Tie-d to controls in Preference panes...

### DIFF
--- a/src/prefs/DevicePrefs.cpp
+++ b/src/prefs/DevicePrefs.cpp
@@ -411,6 +411,8 @@ bool DevicePrefs::Commit()
       AudioIORecordChannels.Write(mChannels->GetSelection() + 1);
    }
 
+   AudioIOLatencyDuration.Invalidate();
+   AudioIOLatencyCorrection.Invalidate();
    return true;
 }
 

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -239,6 +239,7 @@ bool GUIPrefs::Commit()
    }
    AColor::ApplyUpdatedImages();
 
+   GUIBlendThemes.Invalidate();
    return true;
 }
 

--- a/src/prefs/MidiIOPrefs.cpp
+++ b/src/prefs/MidiIOPrefs.cpp
@@ -282,6 +282,7 @@ bool MidiIOPrefs::Commit()
             wxString(wxSafeConvertMB2WX(info->name))));
    }
 #endif
+   MIDISynthLatency_ms.Invalidate();
    return gPrefs->Flush();
 }
 

--- a/src/prefs/TracksPrefs.cpp
+++ b/src/prefs/TracksPrefs.cpp
@@ -436,6 +436,7 @@ bool TracksPrefs::Commit()
       gPrefs->Flush();
    }
 
+   AudioTrackNameSetting.Invalidate();
    return true;
 }
 


### PR DESCRIPTION
... This fixes reported issue 3399 which is a regression on 3.1.3; similar
bugs, not yet reported, existed in other settings.  The bug was introduced at
712e72a

Affected settings:

- Latency correction and duration in Device
- "Blend system and Audacity theme" in Interface
- MIDI synth latency in MIDI
- Default audio track name in Tracks

Resolves: #3399 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
