### PR TITLE
Fix peak detection in Amplify and Normalize effects...

### DIFF
--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -154,6 +154,8 @@ void WaveClip::MarkChanged() // NOFAIL-GUARANTEE
 std::pair<float, float> WaveClip::GetMinMax(
    double t0, double t1, bool mayThrow) const
 {
+   t0 = std::max(t0, GetPlayStartTime());
+   t1 = std::min(t1, GetPlayEndTime());
    if (t0 > t1) {
       if (mayThrow)
          THROW_INCONSISTENCY_EXCEPTION;


### PR DESCRIPTION
... Also fixes PEAK-LEVEL and PEAK properties of *SELECTION* in Nyquist

Resolves: #3372

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
