### PR TITLE
Destroy panel before validator

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -208,6 +208,10 @@ bool EffectUIValidator::IsGraphicalUI()
    return false;
 }
 
+void EffectUIValidator::Disconnect()
+{
+}
+
 void EffectUIValidator::OnClose()
 {
    if (!mUIClosed)

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -587,6 +587,12 @@ public:
     */
    virtual bool IsGraphicalUI();
 
+   //! On the first call only, may disconnect from further event handling
+   /*!
+    Default implemantation does nothing
+    */
+   virtual void Disconnect();
+
    /*!
     Handle the UI OnClose event. Default implementation calls mEffect.CloseUI()
    */

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -878,8 +878,7 @@ DefaultEffectUIValidator::DefaultEffectUIValidator(
 
 DefaultEffectUIValidator::~DefaultEffectUIValidator()
 {
-   if (mpParent)
-      mpParent->PopEventHandler();
+   Disconnect();
 }
 
 bool DefaultEffectUIValidator::ValidateUI()
@@ -894,4 +893,12 @@ bool DefaultEffectUIValidator::ValidateUI()
 bool DefaultEffectUIValidator::IsGraphicalUI()
 {
    return mEffect.IsGraphicalUI();
+}
+
+void DefaultEffectUIValidator::Disconnect()
+{
+   if (mpParent) {
+      mpParent->PopEventHandler();
+      mpParent = nullptr;
+   }
 }

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -40,18 +40,20 @@ class DefaultEffectUIValidator
 public:
    /*!
     @param pParent if not null, caller will push an event handler onto this
-    window; then this object is responsible to pop it in the destructor
+    window; then this object is responsible to pop it
     */
    DefaultEffectUIValidator(
       EffectUIClientInterface &effect, EffectSettingsAccess &access,
       wxWindow *pParent = nullptr);
+   //! Calls Disconnect
    ~DefaultEffectUIValidator() override;
    //! Calls mEffect.ValidateUI()
    bool ValidateUI() override;
    //! @return mEffect.IsGraphicalUI()
    bool IsGraphicalUI() override;
+   void Disconnect() override;
 protected:
-   wxWindow *const mpParent;
+   wxWindow *mpParent{};
 };
 
 class AUDACITY_DLL_API Effect /* not final */

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -245,6 +245,9 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
 
 EffectUIHost::~EffectUIHost()
 {
+   if (mpValidator)
+      mpValidator->Disconnect();
+   DestroyChildren();
    wxASSERT(mClosed);
 }
 

--- a/src/effects/lv2/LV2Validator.cpp
+++ b/src/effects/lv2/LV2Validator.cpp
@@ -101,10 +101,17 @@ bool LV2Validator::ValidateUI()
    return true;
 }
 
+void LV2Validator::Disconnect()
+{
+   if (mParent) {
+      mParent->PopEventHandler(this);
+      mParent = nullptr;
+   }
+}
+
 LV2Validator::~LV2Validator()
 {
-   if (mParent)
-      mParent->RemoveEventHandler(this);
+   Disconnect();
 }
 
 std::shared_ptr<SuilHost> LV2Validator::GetSuilHost()

--- a/src/effects/lv2/LV2Validator.h
+++ b/src/effects/lv2/LV2Validator.h
@@ -62,6 +62,7 @@ public:
    bool ValidateUI() override;
    bool UpdateUI() override;
    bool IsGraphicalUI() override;
+   void Disconnect() override;
 
    int ui_resize(int width, int height) override;
    void ui_closed() override;
@@ -104,7 +105,7 @@ public:
    LV2PortUIStates mPortUIStates;
 
    std::shared_ptr<SuilHost> mSuilHost;
-   wxWindow *const mParent;
+   wxWindow *mParent;
    bool mUseGUI{};
 
    // UI


### PR DESCRIPTION
Contributes to LV2 statelessness

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
