### PR TITLE
LabelTrackView: Fix layout bugs

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTrackView.h
+++ b/src/tracks/labeltrack/ui/LabelTrackView.h
@@ -47,7 +47,9 @@ public:
    enum : int { DefaultFontSize = 0 }; //system preferred
    static constexpr int TextFramePadding { 2 };
    static constexpr int TextFrameYOffset { -1 };
-   static constexpr int LabelBarHeight { 6 }; 
+   static constexpr int LabelBarHeight { 5 }; // odd/even should match mIconHeight
+   static constexpr int LabelRowMargin { 3 };
+   static constexpr int LabelRowHeightRoundUp{ 1 }; // round up when adding to y centerline
 
    explicit
    LabelTrackView( const std::shared_ptr<Track> &pTrack );
@@ -212,11 +214,12 @@ private:
    static void DrawGlyphs( wxDC & dc, const LabelStruct &ls, const wxRect & r,
       int GlyphLeft, int GlyphRight);
    static int GetTextFrameHeight();
+   static int GetLabelRowHeight();
    static void DrawText( wxDC & dc, const LabelStruct &ls, const wxRect & r);
    static void DrawTextBox( wxDC & dc, const LabelStruct &ls, const wxRect & r);
    static void DrawBar(wxDC& dc, const LabelStruct& ls, const wxRect& r);
    static void DrawHighlight(
-      wxDC & dc, const LabelStruct &ls, int xPos1, int xPos2, int charHeight);
+      wxDC & dc, const LabelStruct &ls, int xPos1, int xPos2);
 
 public:
    /// convert pixel coordinate to character position in text box


### PR DESCRIPTION
Fixes several issues with label track layout that are especially visible
at larger font sizes:

* Text aligned too low inside containing box, with descenders escaping
  the box or even overlapping the label bar.
* Text boxes overlapping the label bar above.
* Empty text boxes drawing at the top edge of the track when the vertical
  size of the track is too small to display any part of the label.
* Icons/glyphs (the handles on the ends of the label bar) not being
  properly centered on the label bar.
* Rounding errors causing visual instability when moving between even/odd
  font sizes.
* Layout not responding properly to adjustments of the constants that drive
  the layout (sizes, padding, etc).

One deliberate visual change:

* LabelBarHeight was even while the icons/glyphs were odd height, making
  it impossible to perfectly center them. Reduced LabelBarHeight by 1.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
