### PR TITLE
Fix closing of LV2 dialogs...

### DIFF
--- a/src/effects/lv2/LV2Validator.cpp
+++ b/src/effects/lv2/LV2Validator.cpp
@@ -104,9 +104,10 @@ bool LV2Validator::ValidateUI()
 void LV2Validator::Disconnect()
 {
    if (mParent) {
-      mParent->PopEventHandler(this);
+      mParent->PopEventHandler();
       mParent = nullptr;
    }
+   mNativeWin = nullptr;
 }
 
 LV2Validator::~LV2Validator()


### PR DESCRIPTION
... Default the argument of PopEventHandler so we don't double-delete the
validator.

That's not enough: also null the pointer to the NativeWindow, so we don't
double-delete it either, when next we call DestroyChildren from
EffectUIHost::~EffectUIHost().

Resolves: #3433

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
