### PR TITLE
Fixes number of problems with VST3 settings

### DIFF
--- a/src/effects/VST3/VST3Instance.cpp
+++ b/src/effects/VST3/VST3Instance.cpp
@@ -72,9 +72,9 @@ bool VST3Instance::RealtimeFinalize(EffectSettings& settings) noexcept
 {
 return GuardedCall<bool>([&]{
    mRecruited = false;
-   mWrapper->Finalize();
+   mWrapper->Finalize(&settings);
    for (auto &pProcessor : mProcessors)
-      pProcessor->mWrapper->Finalize();
+      pProcessor->mWrapper->Finalize(nullptr);
    mProcessors.clear();
    return true;
 });
@@ -144,7 +144,7 @@ bool VST3Instance::ProcessFinalize() noexcept
 {
    return GuardedCall<bool>([&]
    {
-      mWrapper->Finalize();
+      mWrapper->Finalize(nullptr);
       return true;
    });
 }

--- a/src/effects/VST3/VST3Wrapper.h
+++ b/src/effects/VST3/VST3Wrapper.h
@@ -82,12 +82,12 @@ public:
    bool SavePreset(Steinberg::IBStream* fileStream) const;
 
    bool Initialize(const EffectSettings& settings, Steinberg::Vst::SampleRate sampleRate, Steinberg::int32 processMode, Steinberg::int32 maxSamplesPerBlock);
-   void Finalize();
+   void Finalize(EffectSettings* settings);
 
    //Updates internal state with changes from settings
    void ConsumeChanges(const EffectSettings& settings);
-   //Used to send EffectSettings to the IAudioProcessor, while effect is inactive(!)
-   void FlushSettings(EffectSettings& settings);
+   //Used to send EffectSettings changes to the IAudioProcessor, while effect is inactive(!)
+   void FlushParameters(EffectSettings& settings);
 
    //Intialize first, before calling to Process. It's safe to it use from another thread
    size_t Process(const float* const* inBlock, float* const* outBlock, size_t blockLen);


### PR DESCRIPTION
Resolves: #3427
Resolves: #3437 

VST3Wrapper now stores latest parameter values as a part of it's state that, presumably, would help avoid issues with consistency since `IComponent::setState` are applied immediately while parameter changes aren't applied until consumed on the worker side. Though for this reason it is possible that there could be audiable transition when preset is applied (see `VST3UIValidator::UpdateUI`) not caused by absense of interpolation.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
