### PR TITLE
Quick fix for crash playing mono tracks with stacked effects

### DIFF
--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -451,7 +451,7 @@ void RealtimeEffectState::Process(Track &track, unsigned chans,
       }
 
       // Point at the correct output buffers
-      copied = std::min(chans - ondx, numAudioOut);
+      copied = std::min(numAudioOut - ondx, numAudioOut);
       std::copy(outbuf + ondx, outbuf + ondx + copied, clientOut);
 
       const auto blockSize = pInstance->GetBlockSize();


### PR DESCRIPTION
Resolves: #3443

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
