### PR TITLE
Zoom toggle

### DIFF
--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1636,7 +1636,7 @@ void ProjectWindow::Zoom(double level)
    float t0 = viewInfo.selectedRegion.t0();
    float t1 = viewInfo.selectedRegion.t1();
    float tAvailable = viewInfo.GetScreenEndTime() - viewInfo.h;
-   float tOnLeft = (tAvailable - t0 + t1)/2.0;
+   float tOnLeft = (tAvailable - (t1 - t0)) / 2.0f;
    // Bug 1292 (Enh) is effectively a request to do this scrolling of  the selection into view.
    // If tOnLeft is positive, then we have room for the selection, so scroll to it.
    if( tOnLeft >=0 )

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -203,11 +203,7 @@ void OnZoomToggle(const CommandContext &context)
 {
    auto &project = context.project;
    auto &viewInfo = ViewInfo::Get( project );
-   auto &trackPanel = TrackPanel::Get( project );
    auto &window = ProjectWindow::Get( project );
-
-//   const double origLeft = viewInfo.h;
-//   const double origWidth = viewInfo.GetScreenEndTime() - origLeft;
 
    // Choose the zoom that is most different to the current zoom.
    double Zoom1 = GetZoomOfPreset( project, TracksPrefs::Zoom1Choice() );
@@ -216,11 +212,15 @@ void OnZoomToggle(const CommandContext &context)
    double ChosenZoom =
       fabs(log(Zoom1 / Z)) > fabs(log( Z / Zoom2)) ? Zoom1:Zoom2;
 
-   window.Zoom(ChosenZoom);
-   trackPanel.Refresh(false);
-//   const double newWidth = GetScreenEndTime() - viewInfo.h;
-//   const double newh = origLeft + (origWidth - newWidth) / 2;
-//   TP_ScrollWindow(newh);
+   double ZoomBy = ChosenZoom / Z;
+   if( ZoomBy > 1 )
+   {
+      window.ZoomInByFactor(ZoomBy);
+   }
+   else
+   {
+      window.ZoomOutByFactor(ZoomBy);
+   }
 }
 
 void OnZoomFit(const CommandContext &context)


### PR DESCRIPTION
The zoom toggle function (shift-Z) did not have good viewport positioning logic when the selection span was much larger than zero.

The first commit fixes a sign error in `ProjectWindow::Zoom` which caused zoom toggling to center on a region one selection width to the left of the actual selection.

However, with that fixed, the behavior still felt bad compared to other forms of zoom, so the second patch changes `OnZoomToggle` to use the much richer `ZoomInByFactor` and `ZoomOutByFactor` logic as appropriate. This make zoom toggling feel "right" to me.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
