### PR TITLE
Fix vst3 mono effect play

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -144,7 +144,8 @@ struct AudioIoCallback::TransportState {
           pOwningProject && numPlaybackChannels > 0) {
          // Setup for realtime playback at the rate of the realtime
          // stream, not the rate of the track.
-         mpRealtimeInitialization.emplace(move(wOwningProject), sampleRate);
+         mpRealtimeInitialization.emplace(
+            move(wOwningProject), sampleRate, numPlaybackChannels);
          // The following adds a new effect processor for each logical track.
          for (size_t i = 0, cnt = playbackTracks.size(); i < cnt;) {
             // An array of non-nulls only should be given to us

--- a/src/effects/RealtimeEffectManager.h
+++ b/src/effects/RealtimeEffectManager.h
@@ -194,7 +194,6 @@ private:
    // which are to be called only while there is no playback
    std::vector<Track *> mGroupLeaders; //!< all are non-null
 
-   std::unordered_map<Track *, unsigned> mChans;
    std::unordered_map<Track *, double> mRates;
 };
 
@@ -204,9 +203,11 @@ class InitializationScope {
 public:
    InitializationScope() {}
    explicit InitializationScope(
-      std::weak_ptr<AudacityProject> wProject, double sampleRate)
-      : mSampleRate{ sampleRate }
+      std::weak_ptr<AudacityProject> wProject, double sampleRate,
+      unsigned numPlaybackChannels
+   )  : mSampleRate{ sampleRate }
       , mwProject{ move(wProject) }
+      , mNumPlaybackChannels{ numPlaybackChannels }
    {
       if (auto pProject = mwProject.lock())
          RealtimeEffectManager::Get(*pProject).Initialize(*this, sampleRate);
@@ -228,6 +229,7 @@ public:
 
    std::vector<std::shared_ptr<EffectInstance>> mInstances;
    double mSampleRate;
+   unsigned mNumPlaybackChannels;
 
 private:
    std::weak_ptr<AudacityProject> mwProject;

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -450,8 +450,14 @@ void RealtimeEffectState::Process(Track &track, unsigned chans,
       }
 
       // Point at the correct output buffers
-      copied = std::min(numAudioOut - ondx, numAudioOut);
+      copied = std::min(chans - ondx, numAudioOut);
       std::copy(outbuf + ondx, outbuf + ondx + copied, clientOut);
+      if (copied < numAudioOut) {
+         // This is unexpected.  Is a bad instance demanding 3 channels out?
+         assert(false);
+         // Make determinate pointers
+         std::fill(clientOut + copied, clientOut + numAudioOut, nullptr);
+      }
 
       const auto blockSize = pInstance->GetBlockSize();
       for (size_t block = 0; block < numSamples; block += blockSize) {

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -292,14 +292,13 @@ RealtimeEffectState::EnsureInstance(double sampleRate)
       if (!pInstance)
          return {};
 
-      mInitialized = true;
-
       // PRL: conserving pre-3.2.0 behavior, but I don't know why this arbitrary
       // number was important
       pInstance->SetBlockSize(512);
 
       if (!pInstance->RealtimeInitialize(mMainSettings.settings, sampleRate))
          return {};
+      mInitialized = true;
       return pInstance;
    }
    return pInstance;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -73,7 +73,7 @@ public:
    bool ProcessStart(bool running);
    //! Worker thread processes part of a batch of samples
    void Process(Track &track,
-      unsigned chans,
+      unsigned chans, // How many channels the playback device needs
       const float *const *inbuf, //!< chans input buffers
       float *const *outbuf, //!< chans output buffers
       size_t numSamples);

--- a/src/effects/VST3/VST3Instance.cpp
+++ b/src/effects/VST3/VST3Instance.cpp
@@ -53,13 +53,31 @@ bool VST3Instance::Init()
 
 bool VST3Instance::RealtimeAddProcessor(EffectSettings& settings, unsigned, float sampleRate)
 {
+   if (!mRecruited) {
+      // Assign self to the first processor
+      mRecruited = true;
+      return true;
+   }
+   // Assign another instance with independent state to other processors
+   auto &effect = static_cast<const PerTrackEffect&>(mProcessor);
+   auto uProcessor =
+      std::make_unique<VST3Instance>(effect, mWrapper->GetModule(), mEffectUID);
+   if (!uProcessor->RealtimeInitialize(settings, sampleRate))
+      return false;
+   mProcessors.push_back(move(uProcessor));
    return true;
 }
 
 bool VST3Instance::RealtimeFinalize(EffectSettings& settings) noexcept
 {
+return GuardedCall<bool>([&]{
+   mRecruited = false;
    mWrapper->Finalize();
+   for (auto &pProcessor : mProcessors)
+      pProcessor->mWrapper->Finalize();
+   mProcessors.clear();
    return true;
+});
 }
 
 bool VST3Instance::RealtimeInitialize(EffectSettings& settings, double sampleRate)
@@ -75,8 +93,13 @@ bool VST3Instance::RealtimeInitialize(EffectSettings& settings, double sampleRat
 size_t VST3Instance::RealtimeProcess(size_t group, EffectSettings& settings, const float* const* inBuf,
    float* const* outBuf, size_t numSamples)
 {
-   if(group == 0)
+   if (!mRecruited)
+      // unexpected!
+      return 0;
+   if (group == 0)
       return mWrapper->Process(inBuf, outBuf, numSamples);
+   else if (--group < mProcessors.size())
+     return mProcessors[group]->mWrapper->Process(inBuf, outBuf, numSamples);
    return 0;
 }
 
@@ -88,18 +111,24 @@ bool VST3Instance::RealtimeProcessEnd(EffectSettings& settings) noexcept
 bool VST3Instance::RealtimeProcessStart(EffectSettings& settings)
 {
    mWrapper->ConsumeChanges(settings);
+   for (auto &pProcessor : mProcessors)
+      pProcessor->mWrapper->ConsumeChanges(settings);
    return true;
 }
 
 bool VST3Instance::RealtimeResume()
 {
    mWrapper->ResumeProcessing();
+   for (auto &pProcessor : mProcessors)
+      pProcessor->mWrapper->ResumeProcessing();
    return true;
 }
 
 bool VST3Instance::RealtimeSuspend()
 {
    mWrapper->SuspendProcessing();
+   for (auto &pProcessor : mProcessors)
+      pProcessor->mWrapper->SuspendProcessing();
    return true;
 }
 

--- a/src/effects/VST3/VST3Instance.h
+++ b/src/effects/VST3/VST3Instance.h
@@ -36,6 +36,9 @@ class VST3Instance
    bool mUseLatency { true };
    sampleCount mInitialDelay { 0 };
 
+   bool mRecruited{ false };
+   std::vector<std::unique_ptr<VST3Instance>> mProcessors;
+
 public:
    VST3Instance(const PerTrackEffect& effect, VST3::Hosting::Module& module, VST3::UID effectUID);
    ~VST3Instance() override;

--- a/src/effects/VST3/VST3Wrapper.cpp
+++ b/src/effects/VST3/VST3Wrapper.cpp
@@ -236,6 +236,7 @@ IMPLEMENT_FUNKNOWN_METHODS(SingleInputParameterValue, Steinberg::Vst::IParamValu
 
 VST3Wrapper::VST3Wrapper(VST3::Hosting::Module& module, VST3::UID effectUID)
    : mEffectUID(std::move(effectUID))
+   , mModule{ module }
 {
    using namespace Steinberg;
 
@@ -432,7 +433,7 @@ void VST3Wrapper::Finalize()
    mEffectComponent->setActive(false);
 }
 
-void VST3Wrapper::ConsumeChanges(EffectSettings& settings)
+void VST3Wrapper::ConsumeChanges(const EffectSettings& settings)
 {
    const auto& vst3settings = GetSettings(settings);
    for(auto& p : vst3settings.parameterChanges)

--- a/src/effects/VST3/VST3Wrapper.h
+++ b/src/effects/VST3/VST3Wrapper.h
@@ -53,6 +53,7 @@ public:
 class VST3Wrapper
 {
    EffectSettings mDefaultSettings;
+   VST3::Hosting::Module& mModule;
 public:
    Steinberg::IPtr<Steinberg::Vst::IAudioProcessor> mAudioProcessor;
    Steinberg::Vst::ProcessSetup mSetup;
@@ -70,6 +71,8 @@ public:
    VST3Wrapper& operator=(const VST3Wrapper&) = delete;
    VST3Wrapper& operator=(VST3Wrapper&&) = delete;
 
+   VST3::Hosting::Module& GetModule() const { return mModule; }
+
    bool IsActive() const noexcept;
 
    void FetchSettings(const EffectSettings&);
@@ -82,7 +85,7 @@ public:
    void Finalize();
 
    //Updates internal state with changes from settings
-   void ConsumeChanges(EffectSettings& settings);
+   void ConsumeChanges(const EffectSettings& settings);
    //Used to send EffectSettings to the IAudioProcessor, while effect is inactive(!)
    void FlushSettings(EffectSettings& settings);
 


### PR DESCRIPTION
Resolves: #3434 
Resolves: #3443

Fix playing of a mono VST3 effect like Blue Cat Chorus on a stereo track.  But it does not fix rendering of the track.

The fix is partly in the framework, fixing a bug in the allocation of effect instances to channels, and partly specific to VST3,
which now can have an array of extra processors in its Instance, analogous to AudioUnits instances.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
