### PR TITLE
Fix au mono effects

### DIFF
--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -227,6 +227,10 @@ bool AudioUnitEffect::InitializePlugin()
    if (!CreateAudioUnit())
       return false;
 
+   // Use an arbitrary rate while completing the discovery of channel support
+   if (!SetRateAndChannels(44100.0, GetSymbol().Internal()))
+      return false;
+
    // Determine interactivity
    mInteractive = (Count(mParameters) > 0);
    if (!mInteractive) {
@@ -245,6 +249,7 @@ bool AudioUnitEffect::InitializePlugin()
             kAudioUnitProperty_GetUIComponentList, compDesc);
       }
    }
+
    return true;
 }
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -138,10 +138,6 @@ private:
    const wxString mName;
    const wxString mVendor;
 
-   // Initialized in GetChannelCounts()
-   unsigned mAudioIns{ 2 };
-   unsigned mAudioOuts{ 2 };
-
    bool mInteractive{ false };
    bool mUseLatency{ true };
 

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -275,68 +275,6 @@ bool AudioUnitInstance::RealtimeProcessEnd(EffectSettings &) noexcept
    return true;
 }
 
-bool AudioUnitInstance::SetRateAndChannels(
-   double sampleRate, const wxString &identifier)
-{
-   AudioUnitUtils::StreamBasicDescription streamFormat{
-      // Float64 mSampleRate;
-      sampleRate,
-
-      // UInt32  mFormatID;
-      kAudioFormatLinearPCM,
-
-      // UInt32  mFormatFlags;
-      (kAudioFormatFlagsNativeFloatPacked |
-          kAudioFormatFlagIsNonInterleaved),
-
-      // UInt32  mBytesPerPacket;
-      sizeof(float),
-
-      // UInt32  mFramesPerPacket;
-      1,
-
-      // UInt32  mBytesPerFrame;
-      sizeof(float),
-
-      // UInt32  mChannelsPerFrame;
-      0,
-
-      // UInt32  mBitsPerChannel;
-      sizeof(float) * 8,
-   };
-
-   const struct Info{
-      unsigned nChannels;
-      AudioUnitScope scope;
-      const char *const msg; // used only in log messages
-   } infos[]{
-      { 1, kAudioUnitScope_Global, "global" },
-      { mAudioIns, kAudioUnitScope_Input, "input" },
-      { mAudioOuts, kAudioUnitScope_Output, "output" },
-   };
-   for (const auto &[nChannels, scope, msg] : infos) {
-      if (nChannels) {
-         if (SetProperty(kAudioUnitProperty_SampleRate, sampleRate, scope)) {
-            wxLogError("%ls Didn't accept sample rate on %s\n",
-               // Exposing internal name only in logging
-               identifier.wx_str(), msg);
-            return false;
-         }
-         if (scope != kAudioUnitScope_Global) {
-            streamFormat.mChannelsPerFrame = nChannels;
-            if (SetProperty(kAudioUnitProperty_StreamFormat,
-               streamFormat, scope)) {
-               wxLogError("%ls didn't accept stream format on %s\n",
-                  // Exposing internal name only in logging
-                  identifier.wx_str(), msg);
-               return false;
-            }
-         }
-      }
-   }
-   return true;
-}
-
 OSStatus AudioUnitInstance::Render(
    AudioUnitRenderActionFlags *inActionFlags,
    const AudioTimeStamp *inTimeStamp,

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -26,8 +26,10 @@ AudioUnitInstance::AudioUnitInstance(const PerTrackEffect &effect,
    , AudioUnitWrapper{ component, &parameters }
    , mIdentifier{ identifier }
    , mBlockSize{ InitialBlockSize() }
-   , mAudioIns{ audioIns }, mAudioOuts{ audioOuts }, mUseLatency{ useLatency }
+   , mUseLatency{ useLatency }
 {
+   mAudioIns = audioIns;
+   mAudioOuts = audioOuts;
    CreateAudioUnit();
 }
 

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -106,10 +106,20 @@ bool AudioUnitInstance::ProcessInitialize(EffectSettings &settings,
    mTimeStamp.mFlags = kAudioTimeStampSampleTimeValid;
 
    mInitialization.reset();
+   // Redo this with the correct sample rate, not the arbirary 44100 that the
+   // effect used
+   auto ins = mAudioIns;
+   auto outs = mAudioOuts;
    if (!SetRateAndChannels(sampleRate, mIdentifier))
       return false;
    if (AudioUnitInitialize(mUnit.get())) {
       wxLogError("Couldn't initialize audio unit\n");
+      return false;
+   }
+   if (ins != mAudioIns || outs != mAudioOuts) {
+      // A change of channels with changing rate?  This is unexpected!
+      ins = mAudioIns;
+      outs = mAudioOuts;
       return false;
    }
    mInitialization.reset(mUnit.get());

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -85,8 +85,6 @@ private:
 
    const wxString &mIdentifier; // for debug messages only
    const size_t mBlockSize;
-   const unsigned mAudioIns;
-   const unsigned mAudioOuts;
    const bool mUseLatency;
 };
 #endif

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -59,7 +59,8 @@ private:
       override;
    bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
-   bool SetRateAndChannels(double sampleRate);
+   // @param identifier only for logging messages
+   bool SetRateAndChannels(double sampleRate, const wxString &identifier);
 
    static OSStatus RenderCallback(void *inRefCon,
       AudioUnitRenderActionFlags *inActionFlags,

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -59,9 +59,6 @@ private:
       override;
    bool RealtimeProcessEnd(EffectSettings &settings) noexcept override;
 
-   // @param identifier only for logging messages
-   bool SetRateAndChannels(double sampleRate, const wxString &identifier);
-
    static OSStatus RenderCallback(void *inRefCon,
       AudioUnitRenderActionFlags *inActionFlags,
       const AudioTimeStamp *inTimeStamp,

--- a/src/effects/audiounits/AudioUnitWrapper.cpp
+++ b/src/effects/audiounits/AudioUnitWrapper.cpp
@@ -350,12 +350,13 @@ bool AudioUnitWrapper::SetRateAndChannels(
       sizeof(float) * 8,
    };
 
+   unsigned one = 1u;
    const struct Info{
-      unsigned nChannels;
+      unsigned &nChannels;
       AudioUnitScope scope;
       const char *const msg; // used only in log messages
    } infos[]{
-      { 1, kAudioUnitScope_Global, "global" },
+      { one, kAudioUnitScope_Global, "global" },
       { mAudioIns, kAudioUnitScope_Input, "input" },
       { mAudioOuts, kAudioUnitScope_Output, "output" },
    };
@@ -368,9 +369,15 @@ bool AudioUnitWrapper::SetRateAndChannels(
             return false;
          }
          if (scope != kAudioUnitScope_Global) {
-            streamFormat.mChannelsPerFrame = nChannels;
-            if (SetProperty(kAudioUnitProperty_StreamFormat,
-               streamFormat, scope)) {
+            bool failed = true;
+            ++nChannels;
+            do {
+               --nChannels;
+               streamFormat.mChannelsPerFrame = nChannels;
+               failed = SetProperty(kAudioUnitProperty_StreamFormat,
+                  streamFormat, scope);
+            } while(failed && nChannels > 0);
+            if (failed) {
                wxLogError("%ls didn't accept stream format on %s\n",
                   // Exposing internal name only in logging
                   identifier.wx_str(), msg);

--- a/src/effects/audiounits/AudioUnitWrapper.h
+++ b/src/effects/audiounits/AudioUnitWrapper.h
@@ -163,6 +163,9 @@ struct AudioUnitWrapper
    const Parameters &GetParameters() const
    { return mParameters; }
 
+   // @param identifier only for logging messages
+   bool SetRateAndChannels(double sampleRate, const wxString &identifier);
+
 protected:
    const AudioComponent mComponent;
    AudioUnitCleanup<AudioUnit, AudioComponentInstanceDispose> mUnit;
@@ -170,7 +173,6 @@ protected:
    Parameters mOwnParameters;
    Parameters &mParameters;
 
-   // Initialized in GetChannelCounts()
    unsigned mAudioIns{ 2 };
    unsigned mAudioOuts{ 2 };
 };

--- a/src/effects/audiounits/AudioUnitWrapper.h
+++ b/src/effects/audiounits/AudioUnitWrapper.h
@@ -173,6 +173,7 @@ protected:
    Parameters mOwnParameters;
    Parameters &mParameters;
 
+   // Reassinged in GetRateAndChannels()
    unsigned mAudioIns{ 2 };
    unsigned mAudioOuts{ 2 };
 };

--- a/src/effects/audiounits/AudioUnitWrapper.h
+++ b/src/effects/audiounits/AudioUnitWrapper.h
@@ -169,6 +169,10 @@ protected:
 
    Parameters mOwnParameters;
    Parameters &mParameters;
+
+   // Initialized in GetChannelCounts()
+   unsigned mAudioIns{ 2 };
+   unsigned mAudioOuts{ 2 };
 };
 
 class AudioUnitWrapper::ParameterInfo final


### PR DESCRIPTION
Resolves: #3439

Fix playback, rendering, and destructive application of (for example) Blue Cat Chorus, Mono AudioUnit version, on stereo tracks


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
