### PR TITLE
Generators can show progress dialogs again...

### DIFF
--- a/src/effects/PerTrackEffect.cpp
+++ b/src/effects/PerTrackEffect.cpp
@@ -170,7 +170,12 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
 
          if (len > 0)
             assert(numAudioIn > 0); // checked above
-         inBuffers.Reinit(numAudioIn, blockSize,
+         inBuffers.Reinit(
+            // TODO fix this hack for making Generator progress work without
+            // assertion violations.  Make a dummy Source class that doesn't
+            // care about the buffers.
+            std::max(1u, numAudioIn),
+            blockSize,
             std::max<size_t>(1, bufferSize / blockSize));
          if (len > 0)
             // post of Reinit later satisfies pre of Source::Acquire()
@@ -241,6 +246,10 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
 
          // Assured above
          assert(len == 0 || inBuffers.Channels() > 0);
+         // TODO fix this hack to make the time remaining of the generator
+         // progress dialog correct
+         if (len == 0 && genLength)
+            len = *genLength;
          SampleTrackSource source{ left, pRight, start, len, pollUser };
          // Assert source is safe to Acquire inBuffers
          assert(source.AcceptsBuffers(inBuffers));


### PR DESCRIPTION
... There was also a bug, that a click on Cancel during destructive effect
application didn't really cancel.  (Try generating 10h of noise, then
amplifying).

Also make sure remaining time shows a reasonable value.

This fix is quick and a bit inelegant -- it still does unnecessary fetches of
the source trak samples but ignores them.

Resolves: #3418 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
