### PR TITLE
Revert parts of 378ae8d and 652588d...

### DIFF
--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -315,6 +315,11 @@ bool EffectAmplify::TransferDataToWindow(const EffectSettings &)
 
 bool EffectAmplify::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    mRatio = DB_TO_LINEAR(std::clamp<double>(mAmp * Amp.scale, Amp.min * Amp.scale, Amp.max * Amp.scale) / Amp.scale);
 
    mCanClip = mClip->GetValue();

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -416,7 +416,19 @@ bool EffectAutoDuck::DoTransferDataToWindow()
    // Issue 2324: don't remove these two lines
    if (!mUIParent->TransferDataToWindow())
       return false;
+
    mPanel->Refresh(false);
+
+   return true;
+}
+
+bool EffectAutoDuck::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    return true;
 }
 

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -51,6 +51,7 @@ public:
    override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool DoTransferDataToWindow();
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectAutoDuck implementation

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -253,12 +253,29 @@ std::unique_ptr<EffectUIValidator> EffectBassTreble::PopulateOrExchange(
 
 bool EffectBassTreble::TransferDataToWindow(const EffectSettings &)
 {
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    mBassS->SetValue((int) (mBass * Bass.scale));
    mTrebleS->SetValue((int) mTreble *Treble.scale);
    mGainS->SetValue((int) mGain * Gain.scale);
    mLinkCheckBox->SetValue(mLink);
+
    return true;
 }
+
+bool EffectBassTreble::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
+   return true;
+}
+
 
 // EffectBassTreble implementation
 

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -77,6 +77,7 @@ public:
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -365,6 +365,11 @@ bool EffectChangePitch::TransferDataToWindow(const EffectSettings &)
 {
    m_bLoopDetect = true;
 
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    Calc_SemitonesChange_fromPercentChange();
    Calc_ToPitch(); // Call *after* m_dSemitonesChange is updated.
    Calc_ToFrequency();
@@ -387,6 +392,11 @@ bool EffectChangePitch::TransferDataToWindow(const EffectSettings &)
 
 bool EffectChangePitch::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    // from/to pitch controls
    m_nFromPitch = m_pChoice_FromPitch->GetSelection();
    m_nFromOctave = m_pSpin_FromOctave->GetValue();

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -365,6 +365,11 @@ bool EffectChangeSpeed::TransferDataToWindow(const EffectSettings &)
 {
    mbLoopDetect = true;
 
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    if (mFromVinyl == kVinyl_NA)
    {
       mFromVinyl = kVinyl_33AndAThird;
@@ -396,6 +401,10 @@ bool EffectChangeSpeed::TransferDataFromWindow(EffectSettings &)
 {
    // mUIParent->TransferDataFromWindow() loses some precision, so save and restore it.
    double exactPercent = m_PercentChange;
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
    m_PercentChange = exactPercent;
 
    // TODO: just visit these effect settings the default way

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -305,6 +305,11 @@ bool EffectChangeTempo::TransferDataToWindow(const EffectSettings &)
 
    m_bLoopDetect = true;
 
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    // percent change controls
    Update_Slider_PercentChange();
    Update_Text_ToBPM();
@@ -316,6 +321,16 @@ bool EffectChangeTempo::TransferDataToWindow(const EffectSettings &)
    m_pTextCtrl_ToLength->SetName(
       wxString::Format( _("Length in seconds from %s, to"),
          m_pTextCtrl_FromLength->GetValue() ) );
+
+   return true;
+}
+
+bool EffectChangeTempo::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
 
    return true;
 }

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -61,6 +61,7 @@ public:
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectChangeTempo implementation

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -318,6 +318,26 @@ std::unique_ptr<EffectUIValidator> EffectClickRemoval::PopulateOrExchange(
    return nullptr;
 }
 
+bool EffectClickRemoval::TransferDataToWindow(const EffectSettings &)
+{
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
+   return true;
+}
+
+bool EffectClickRemoval::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
+   return true;
+}
+
 void EffectClickRemoval::OnWidthText(wxCommandEvent & WXUNUSED(evt))
 {
    mWidthT->GetValidator()->TransferFromWindow();

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -51,6 +51,8 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    bool ProcessOne(int count, WaveTrack * track,

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -292,6 +292,10 @@ bool EffectCompressor::TransferDataToWindow(const EffectSettings &)
 
 bool EffectCompressor::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate())
+   {
+      return false;
+   }
    return DoTransferDataFromWindow();
 }
 

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -422,6 +422,11 @@ std::unique_ptr<EffectUIValidator> EffectDistortion::PopulateOrExchange(
 
 bool EffectDistortion::TransferDataToWindow(const EffectSettings &)
 {
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    mThresholdS->SetValue((int) (mThreshold * Threshold_dB.scale + 0.5));
    mDCBlockCheckBox->SetValue(mParams.mDCBlock);
    mNoiseFloorS->SetValue((int) mParams.mNoiseFloor + 0.5);
@@ -438,7 +443,13 @@ bool EffectDistortion::TransferDataToWindow(const EffectSettings &)
 
 bool EffectDistortion::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    mThreshold = DB_TO_LINEAR(mParams.mThreshold_dB);
+
    return true;
 }
 

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -251,6 +251,11 @@ bool EffectFindClipping::TransferDataToWindow(const EffectSettings &)
 
 bool EffectFindClipping::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate())
+   {
+      return false;
+   }
+
    ShuttleGui S(mUIParent, eIsGettingFromDialog);
    // To do: eliminate this and just use validators for controls
    DoPopulateOrExchange(S, *mpAccess);

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -312,9 +312,23 @@ std::unique_ptr<EffectUIValidator> EffectLoudness::PopulateOrExchange(
 
 bool EffectLoudness::TransferDataToWindow(const EffectSettings &)
 {
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    // adjust controls which depend on mchoice
    wxCommandEvent dummy;
    OnChoice(dummy);
+   return true;
+}
+
+bool EffectLoudness::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
    return true;
 }
 

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -62,6 +62,7 @@ public:
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectLoudness implementation

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -211,13 +211,22 @@ std::unique_ptr<EffectUIValidator> EffectNoise::PopulateOrExchange(
 
 bool EffectNoise::TransferDataToWindow(const EffectSettings &settings)
 {
-   mNoiseDurationT->SetValue(settings.extra.GetDuration());
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
 
+   mNoiseDurationT->SetValue(settings.extra.GetDuration());
    return true;
 }
 
 bool EffectNoise::TransferDataFromWindow(EffectSettings &settings)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    settings.extra.SetDuration(mNoiseDurationT->GetValue());
    return true;
 }

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -1639,6 +1639,10 @@ void EffectNoiseReduction::Dialog::PopulateOrExchange(ShuttleGui & S)
 
 bool EffectNoiseReduction::Dialog::TransferDataToWindow()
 {
+   // Do the choice controls:
+   if (!EffectDialog::TransferDataToWindow())
+      return false;
+
    for (int id = FIRST_SLIDER; id < END_OF_SLIDERS; id += 2) {
       wxSlider* slider =
          static_cast<wxSlider*>(wxWindow::FindWindowById(id, this));

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -266,7 +266,23 @@ std::unique_ptr<EffectUIValidator> EffectNormalize::PopulateOrExchange(
 
 bool EffectNormalize::TransferDataToWindow(const EffectSettings &)
 {
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    UpdateUI();
+
+   return true;
+}
+
+bool EffectNormalize::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    return true;
 }
 

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -49,6 +49,7 @@ public:
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectNormalize implementation

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -193,6 +193,26 @@ std::unique_ptr<EffectUIValidator> EffectPaulstretch::PopulateOrExchange(
    return nullptr;
 };
 
+bool EffectPaulstretch::TransferDataToWindow(const EffectSettings &)
+{
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
+   return true;
+}
+
+bool EffectPaulstretch::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
+   return true;
+}
+
 // EffectPaulstretch implementation
 
 void EffectPaulstretch::OnText(wxCommandEvent & WXUNUSED(evt))

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -44,6 +44,8 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // EffectPaulstretch implementation

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -286,6 +286,11 @@ std::unique_ptr<EffectUIValidator> EffectPhaser::PopulateOrExchange(
 
 bool EffectPhaser::TransferDataToWindow(const EffectSettings &)
 {
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    mStagesS->SetValue((int) (mStages * Stages.scale));
    mDryWetS->SetValue((int) (mDryWet * DryWet.scale));
    mFreqS->SetValue((int) (mFreq * Freq.scale));
@@ -299,6 +304,11 @@ bool EffectPhaser::TransferDataToWindow(const EffectSettings &)
 
 bool EffectPhaser::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    if (mStages & 1)    // must be even
    {
       mStages &= ~1;

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -188,6 +188,11 @@ bool EffectRepeat::TransferDataToWindow(const EffectSettings &)
 
 bool EffectRepeat::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate())
+   {
+      return false;
+   }
+
    long l;
 
    mRepeatCount->GetValue().ToLong(&l);

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -436,6 +436,11 @@ bool EffectScienFilter::TransferDataToWindow(const EffectSettings &)
 {
    mOrderIndex = mOrder - 1;
 
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    mdBMinSlider->SetValue((int) mdBMin);
    mdBMin = 0.0;                     // force refresh in TransferGraphLimitsFromWindow()
 
@@ -449,6 +454,11 @@ bool EffectScienFilter::TransferDataToWindow(const EffectSettings &)
 
 bool EffectScienFilter::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    mOrder = mOrderIndex + 1;
 
    CalcFilter();

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -256,8 +256,23 @@ std::unique_ptr<EffectUIValidator> EffectTimeScale::PopulateOrExchange(
 
 bool EffectTimeScale::TransferDataToWindow(const EffectSettings &)
 {
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    Update_Slider_RatePercentChangeStart();
    Update_Slider_RatePercentChangeEnd();
+
+   return true;
+}
+
+bool EffectTimeScale::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
 
    return true;
 }

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -50,6 +50,7 @@ public:
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
    double CalcPreviewInputLength(
       const EffectSettings &settings, double previewLength) const override;
 

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -393,12 +393,22 @@ std::unique_ptr<EffectUIValidator> EffectToneGen::PopulateOrExchange(
 
 bool EffectToneGen::TransferDataToWindow(const EffectSettings &settings)
 {
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    mToneDurationT->SetValue(settings.extra.GetDuration());
    return true;
 }
 
 bool EffectToneGen::TransferDataFromWindow(EffectSettings &settings)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    if (!mChirp)
    {
       mFrequency1 = mFrequency0;

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -742,9 +742,25 @@ std::unique_ptr<EffectUIValidator> EffectTruncSilence::PopulateOrExchange(
    return nullptr;
 }
 
+bool EffectTruncSilence::TransferDataToWindow(const EffectSettings &)
+{
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
+   return true;
+}
+
 bool EffectTruncSilence::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    mbIndependent = mIndependent->IsChecked();
+
    return true;
 }
 

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -70,6 +70,7 @@ public:
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1145,6 +1145,8 @@ bool NyquistEffect::EnablesDebug() const
 
 bool NyquistEffect::TransferDataToWindow(const EffectSettings &)
 {
+   mUIParent->TransferDataToWindow();
+
    bool success;
    if (mIsPrompt)
    {
@@ -1165,6 +1167,11 @@ bool NyquistEffect::TransferDataToWindow(const EffectSettings &)
 
 bool NyquistEffect::TransferDataFromWindow(EffectSettings &)
 {
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    if (mIsPrompt)
    {
       return TransferDataFromPromptWindow();

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -690,7 +690,23 @@ std::unique_ptr<EffectUIValidator> VampEffect::PopulateOrExchange(
 
 bool VampEffect::TransferDataToWindow(const EffectSettings &)
 {
+   if (!mUIParent->TransferDataToWindow())
+   {
+      return false;
+   }
+
    UpdateFromPlugin();
+
+   return true;
+}
+
+bool VampEffect::TransferDataFromWindow(EffectSettings &)
+{
+   if (!mUIParent->Validate() || !mUIParent->TransferDataFromWindow())
+   {
+      return false;
+   }
+
    return true;
 }
 

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -73,6 +73,7 @@ public:
       ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
    override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
    // VampEffect implementation


### PR DESCRIPTION
... The data transfers to and from effect dialogs, for built-in effects (or
Vamp, or Nyquist) which are not yet part of the stateless system, were not in
all cases made superfluous, as seen from some known issues including #3353,
#2762, #3234, and others

So just put them back into all of them.  For other effects this may fix bugs we
haven't found or else it is harmlessly redundant.

Resolves: #3533
Resolves: #2762 
Resolves: #2701

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
