### PR TITLE
Issue 3565: GVerb crashes in effect stack of stereo track...

### DIFF
--- a/libraries/lib-sample-track/Mix.cpp
+++ b/libraries/lib-sample-track/Mix.cpp
@@ -94,7 +94,9 @@ Mixer::Mixer(Inputs inputs,
 
    // PRL:  Bug2536: see other comments below for the last, padding argument
    // TODO: more-than-two-channels
-   , mFloatBuffers{ 2, mBufferSize, 1, 1 }
+   // Issue 3565 workaround:  allocate one extra buffer when applying a
+   // GVerb effect stage.  It is simply discarded
+   , mFloatBuffers{ 3, mBufferSize, 1, 1 }
 
    // non-interleaved
    , mTemp{ initVector<float>(mNumChannels, mBufferSize) }
@@ -238,7 +240,7 @@ size_t Mixer::Process(const size_t maxToProcess)
 
    Clear();
    // TODO: more-than-two-channels
-   auto maxChannels = mFloatBuffers.Channels();
+   auto maxChannels = std::max(2u, mFloatBuffers.Channels());
 
    for (auto &[ upstream, downstream ] : mDecoratedSources) {
       auto oResult = downstream.Acquire(mFloatBuffers, maxToProcess);


### PR DESCRIPTION
... This simple fix corrects the crash.  Whether the resulting output is correct is a matter of definition.

GVerb takes one channel in and always writes two channels out.  When rendering the right channel then, supply an extra throw-away buffer.

What happens in the result is that the left output, only, of each channel is retained.

What really should be done?  It might make sense to mix the two pairs of output channels down to one pair, losing none of the output.

That is outside the scope of this simple fix.

Resolves: #3565

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
