### PR TITLE
When EffectInstance::Init() fails, don't proceed with effect dialog

### DIFF
--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1172,6 +1172,10 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
    std::shared_ptr<EffectInstance> pInstance;
    Destroy_ptr<EffectUIHost> dlg{ safenew EffectUIHost{ &parent,
       *project, host, client, pInstance, access } };
+   if (!pInstance) {
+      dlg->SetClosed();
+      return {};
+   }
    if (dlg->Initialize()) {
       auto pValidator = dlg->GetValidator();
       // release() is safe because parent will own it

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -66,6 +66,12 @@ public:
 
    bool HandleCommandKeystrokes() override;
 
+   void SetClosed() {
+#if wxDEBUG_LEVEL
+      mClosed = true;
+#endif
+   }
+
 private:
    std::shared_ptr<EffectInstance> InitializeInstance();
 


### PR DESCRIPTION
Resolves: #3580

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
