### PR TITLE
Ignore return value of AudioUnitInstance::BypassEffect...

### DIFF
--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -135,7 +135,8 @@ bool AudioUnitInstance::ProcessInitialize(EffectSettings &settings,
       return false;
 
    if (!BypassEffect(false))
-      return false;
+      // Ignore bad return value.  Some (like Xfer OTT) give a bad status.
+      ;
 
    return true;
 }
@@ -223,20 +224,24 @@ return GuardedCall<bool>([&]{
 bool AudioUnitInstance::RealtimeSuspend()
 {
    if (!BypassEffect(true))
-      return false;
+      //return false
+      ;
    for (auto &pSlave : mSlaves)
       if (!pSlave->BypassEffect(true))
-         return false;
+         //return false
+         ;
    return true;
 }
 
 bool AudioUnitInstance::RealtimeResume()
 {
    if (!BypassEffect(false))
-      return false;
+      //return false
+      ;
    for (auto &pSlave: mSlaves)
       if (!pSlave->BypassEffect(false))
-         return false;
+         //return false
+         ;
    return true;
 }
 


### PR DESCRIPTION
... This allows Xfer OTT to work, and also to power on and off

Resolves: #3581 
(At least for Xfer OTT on macOS)

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
