### PR TITLE
Additional folders added to .gitignore to enable easier building with VS 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,8 @@ win/.vs/
 win/packages
 win/.nuget
 win-alt-build
+/audacity-binaries
+/.vs
 
 # All those help files
 help/manual*


### PR DESCRIPTION
Resolves: The inability to build Audacity using Visual Studio 2022 when the build binaries are located in a folder outside of the audacity repository.

To build Audacity under Windows using Visual Studio 2022, the binaries need to be built inside a folder within the local audacity repository. Adding "/audacity-binaries" and "/.vs" to the .gitignore file is required to stop changes therein being monitored by Git. Here, "/audacity-binaries" is the target name of the folder for the binaries when setting up using CMake GUI.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
