### PR TITLE
metadata editor: set max height to prevent taskbar overlap

### DIFF
--- a/src/TagsEditor.cpp
+++ b/src/TagsEditor.cpp
@@ -243,7 +243,8 @@ TagsEditorDialog::TagsEditorDialog(wxWindow * parent,
    Fit();
    Center();
    wxSize sz = GetSize();
-   SetSizeHints(sz.x, std::min(sz.y, 600));
+   SetSizeHints(sz.x, std::min(sz.y, 600), 
+      wxDefaultCoord, wxDisplay().GetGeometry().GetHeight() - 100);
 
    // Restore the original tags because TransferDataToWindow() will be called again
    for(unsigned i = 0; i < mEditTags.size(); ++i)


### PR DESCRIPTION
Resolves: #2482 

While #2484 set a reasonable min-height and makes the window resizable once it overlaps with the taskbar, it still would allow for the default window size to go all the way from the top to the taskbar. Here I shave off another 100px so that a user always has access to the entire thing without resizing (even though they still may need to drag it upwards to have it not overlap). 

NB: This intentionally targets master; I'm not sure how this handles HiDPI and dual screens with different sizes, and I don't want to hold up this release with a P4 fix