### PR TITLE
tweak to default width of meter bar and project window

### DIFF
--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -51,9 +51,9 @@ Paul Licameli split from AudacityProject.cpp
 namespace
 {
 #ifdef HAS_AUDIOCOM_UPLOAD
-   constexpr int DEFAULT_WINDOW_WIDTH = 1260;
+   constexpr int DEFAULT_WINDOW_WIDTH = 1120;
 #else
-   constexpr int DEFAULT_WINDOW_WIDTH = 1200;
+   constexpr int DEFAULT_WINDOW_WIDTH = 1060;
 #endif
    constexpr int DEFAULT_WINDOW_HEIGHT = 674;
 }

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -294,7 +294,7 @@ bool MeterToolBar::Expose( bool show )
 int MeterToolBar::GetInitialWidth()
 {
    return (mWhichMeters ==
-      (kWithRecordMeter + kWithPlayMeter)) ? 338 : 260;
+      (kWithRecordMeter + kWithPlayMeter)) ? 338 : 290;
 }
 
 // The meter's sizing code does not take account of the resizer


### PR DESCRIPTION
Resolves: #3627
part 1 of it anyway.

looks like this to me: 
![image](https://user-images.githubusercontent.com/87814144/190619916-cfd794c5-580e-4b4a-811e-00d09adf5a0a.png)
