### PR TITLE
cmake: Use mp3lame pkg-config for lame

### DIFF
--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -105,7 +105,7 @@ add_conan_lib(
    libmp3lame/3.100
    REQUIRED
    INTERFACE_NAME libmp3lame::libmp3lame
-   PKG_CONFIG "lame >= 3.100"
+   PKG_CONFIG "mp3lame >= 3.100"
    ALLOW_FIND_PACKAGE
 )
 


### PR DESCRIPTION
The lame project does not provide a pkg-config file for libmp3lame. lame 3.100-4 in Debian/Ubuntu ships a `mp3lame.pc` file in `libmp3lame-dev`.

Correct the pkg-config name to `mp3lame` to find the pkg-config file.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
