### PR TITLE
Do not strip debug info for CMAKE_BUILD_TYPE=RelWithDebInfo

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -469,11 +469,11 @@ function( audacity_module_fn NAME SOURCES IMPORT_TARGETS
    target_link_options( ${TARGET} PRIVATE ${LOPTS} )
    target_link_libraries( ${TARGET} PUBLIC ${LIBRARIES} )
 
-   if( NOT CMAKE_SYSTEM_NAME MATCHES "Windows" )
+   if( NOT CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT CMAKE_BUILD_TYPE MATCHES "Debug|RelWithDebInfo" )
       add_custom_command(
          TARGET "${TARGET}"
          POST_BUILD
-         COMMAND $<IF:$<CONFIG:Debug>,echo,strip> -x $<TARGET_FILE:${TARGET}>
+         COMMAND strip -x $<TARGET_FILE:${TARGET}>
       )
    endif()
 


### PR DESCRIPTION
If `CMAKE_BUILD_TYPE` is set to `RelWithDebInfo` the debug information should not be stripped. Currently `strip -x` is called when `RelWithDebInfo` is set. A useless `echo` is called when `Debug` is set.

Skip `strip -x` when `CMAKE_BUILD_TYPE` is set to `Debug` or `RelWithDebInfo`.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
