### PR TITLE
Drop UBUNTU_MENUPROXY=0 workaround

### DIFF
--- a/linux/AppImage/AppRun.sh
+++ b/linux/AppImage/AppRun.sh
@@ -23,7 +23,6 @@ export LD_LIBRARY_PATH="${APPDIR}/lib:${LD_LIBRARY_PATH}${fallback_libs}"
 
 export AUDACITY_PATH="${AUDACITY_PATH}:${APPDIR}/share/audacity"
 export AUDACITY_MODULES_PATH="${AUDACITY_MODULES_PATH}:${APPDIR}/lib/modules"
-export UBUNTU_MENUPROXY=0
 
 function help()
 {

--- a/linux/create_appimage.sh
+++ b/linux/create_appimage.sh
@@ -81,7 +81,6 @@ linuxdeploy --list-plugins
 # Create symlinks
 #============================================================================
 
-sed -i 's|env UBUNTU_MENUPROXY=0 ||' "${appdir}/share/applications/audacity.desktop"
 ln -sf --no-dereference . "${appdir}/usr"
 ln -sf share/applications/audacity.desktop "${appdir}/audacity.desktop"
 ln -sf share/icons/hicolor/scalable/apps/audacity.svg "${appdir}/audacity.svg"

--- a/src/audacity.desktop.in
+++ b/src/audacity.desktop.in
@@ -61,7 +61,7 @@ Categories=AudioVideo;Audio;AudioVideoEditing;
 
 Keywords=sound;music editing;voice channel;frequency;modulation;audio trim;clipping;noise reduction;multi track audio editor;edit;mixing;WAV;AIFF;FLAC;MP2;MP3;
 
-Exec=env UBUNTU_MENUPROXY=0 @AUDACITY_NAME@ %F
+Exec=@AUDACITY_NAME@ %F
 StartupNotify=false
 Terminal=false
 MimeType=@MIMETYPES@;


### PR DESCRIPTION
wxWidgets 2.6 did not show menus correct on the global menu applet in Unity in 2010 ([Ubuntu bug #662007](https://launchpad.net/bugs/662077)). The environment variable `UBUNTU_MENUPROXY` was set as workaround.

Audacity 3.2.0 with wxWidgets 3.2 on Ubuntu 22.10 (kinetic) works fine under the Unity desktop. Therefore drop the old workaround.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
