### PR TITLE
Fix setting audacity_use_midi=off

### DIFF
--- a/src/Experimental.cmake
+++ b/src/Experimental.cmake
@@ -107,23 +107,6 @@ set( EXPERIMENTAL_OPTIONS_LIST
    # Paul Licameli (PRL) 29 Nov 2014
    #IMPROVED_SEEKING
 
-   #MIDI_IN
-
-   # RBD, 1 Sep 2008
-   # Enables MIDI Output of NoteTrack (MIDI) data during playback
-   # USE_MIDI must be defined in order for MIDI_OUT to work
-   MIDI_OUT
-
-   # JKC, 17 Aug 2017
-   # Enables the MIDI note stretching feature, which currently
-   # a) Is broken on Linux (Bug 1646)
-   # b) Crashes with Sync-Lock (Bug 1719)
-   # c) Needs UI design review.
-   #MIDI_STRETCHING
-
-   # USE_MIDI must be defined in order for SCOREALIGN to work
-   #SCOREALIGN
-
    #Automatically tries to find an acceptable input volume
    #AUTOMATED_INPUT_LEVEL_ADJUSTMENT
 
@@ -187,6 +170,27 @@ set( EXPERIMENTAL_OPTIONS_LIST
 )
 
 # Some more flags that depend on other configuration options
+
+if( NOT audacity_use_midi STREQUAL "off" )
+   list( APPEND EXPERIMENTAL_OPTIONS_LIST
+      #MIDI_IN
+
+      # RBD, 1 Sep 2008
+      # Enables MIDI Output of NoteTrack (MIDI) data during playback
+      # USE_MIDI must be defined in order for MIDI_OUT to work
+      MIDI_OUT
+
+      # JKC, 17 Aug 2017
+      # Enables the MIDI note stretching feature, which currently
+      # a) Is broken on Linux (Bug 1646)
+      # b) Crashes with Sync-Lock (Bug 1719)
+      # c) Needs UI design review.
+      #MIDI_STRETCHING
+
+      # USE_MIDI must be defined in order for SCOREALIGN to work
+      #SCOREALIGN
+   )
+endif()
 
 if( "SCRUBBING_SUPPORT" IN_LIST EXPERIMENTAL_OPTIONS_LIST )
    list( APPEND EXPERIMENTAL_OPTIONS_LIST SCRUBBING_SCROLL_WHEEL )


### PR DESCRIPTION
Resolves: #2305
When disabling MIDI support, cmake will fail:

```
$ cmake -B build -Daudacity_use_midi=off
[...]
CMake Error at cmake-proxies/CMakeLists.txt:314 (message):
  EXPERIMENTAL_MIDI_OUT requires USE_MIDI
```

Disable `EXPERIMENTAL_MIDI_OUT` in case MIDI support was explicitly disabled.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
