### PR TITLE
Wait for AudioThread to ACK in StartStream

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1028,6 +1028,9 @@ int AudioIO::StartStream(const TransportTracks &tracks,
       Publish({ pOwningProject.get(), AudioIOEvent::CAPTURE, true });
 
    commit = true;
+
+   WaitForAudioThreadStarted();
+
    return mStreamToken;
 }
 
@@ -3224,14 +3227,6 @@ void AudioIoCallback::WaitForAudioThreadStarted()
    mAudioThreadAcknowledge.store(Acknowledge::eNone, std::memory_order_release);
 }
 
-
-void AudioIoCallback::StartAudioThreadAndWait()
-{
-   StartAudioThread();
-   WaitForAudioThreadStarted();
-}
-
-
 void AudioIoCallback::StopAudioThread()
 {
    mAudioThreadTrackBufferExchangeLoopRunning.store(false, std::memory_order_release);
@@ -3246,13 +3241,6 @@ void AudioIoCallback::WaitForAudioThreadStopped()
    }
    mAudioThreadAcknowledge.store(Acknowledge::eNone, std::memory_order_release);
 }
-
-void AudioIoCallback::StopAudioThreadAndWait()
-{
-   StopAudioThread();
-   WaitForAudioThreadStopped();
-}
-
 
 void AudioIoCallback::ProcessOnceAndWait(std::chrono::milliseconds sleepTime)
 {

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -313,10 +313,6 @@ public:
       
    std::atomic<Acknowledge>  mAudioThreadAcknowledge;
 
-   // Sync start/stop of AudioThread processing
-   void StartAudioThreadAndWait();
-   void StopAudioThreadAndWait();
-
    // Async start/stop + wait of AudioThread processing.
    // Provided to allow more flexibility, however use with caution:
    // never call Stop between Start and the wait for Started (and the converse)


### PR DESCRIPTION
Resolves: #3699 
Resolves: https://github.com/audacity/audacity/issues/3716

When rapidly mashing the spacebar, there is a chance that AudioThread will 
never change the internal state to `State::eLoopRunning`.

In this scenario, `StopStream` will wait indefinitely for the AudioThread to ACK.

Waiting in `StartStream` ensures, that AudioThread has entered an expected 
state before the `StopStream` is called.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
