### PR TITLE
Separate effect outputs

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -109,6 +109,11 @@ auto EffectSettingsManager::MakeSettings() const -> EffectSettings
    return {};
 }
 
+auto EffectSettingsManager::MakeOutputs() const -> EffectOutputs
+{
+   return {};
+}
+
 bool EffectSettingsManager::CopySettingsContents(
    const EffectSettings &, EffectSettings &, SettingsCopyDirection ) const
 {

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -132,7 +132,8 @@ bool EffectInstance::RealtimeInitialize(EffectSettings &, double)
    return false;
 }
 
-bool EffectInstance::RealtimeAddProcessor(EffectSettings &, unsigned, float)
+bool EffectInstance::RealtimeAddProcessor(
+   EffectSettings &, EffectOutputs&, unsigned, float)
 {
    return true;
 }

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -641,13 +641,16 @@ public:
     object
     @param access guaranteed to have a lifetime containing that of the returned
     object
+    @param pOutputs null, or else points to outputs with lifetime containing
+    that of the returned object
 
     @return null for failure; else an object invoked to retrieve values of UI
     controls; it might also hold some state needed to implement event handlers
     of the controls; it will exist only while the dialog continues to exist
     */
    virtual std::unique_ptr<EffectUIValidator> PopulateUI(ShuttleGui &S,
-      EffectInstance &instance, EffectSettingsAccess &access) = 0;
+      EffectInstance &instance, EffectSettingsAccess &access,
+      EffectOutputs *pOutputs) = 0;
 
    virtual bool CanExportPresets() = 0;
    virtual void ExportPresets(const EffectSettings &settings) const = 0;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -99,27 +99,6 @@ struct EffectSettings : audacity::TypedAny<EffectSettings> {
       TypedAny::swap(other);
       std::swap(extra, other.extra);
    }
-
-   //! Like make_any but a static member function
-   template<typename T, typename... Args>
-   static EffectSettings Make(Args &&... args)
-   {
-      return EffectSettings(std::in_place_type<T>, std::forward<Args>(args)...);
-   }
-
-   //! Convenience for defining overrides of
-   //! EffectDefinitionInterface::CopySettingsContents
-   template<typename T>
-   static bool Copy(const EffectSettings &src, EffectSettings &dst)
-   {
-      const T *pSrc = src.cast<T>();
-      T *pDst = dst.cast<T>();
-      if (pSrc && pDst) {
-         *pDst = *pSrc;
-         return true;
-      }
-      return false;
-   }
 };
 
 //! Interface for accessing an EffectSettings that may change asynchronously in

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -422,7 +422,8 @@ public:
     Default implementation does nothing, returns true
     */
    virtual bool RealtimeAddProcessor(
-      EffectSettings &settings, unsigned numChannels, float sampleRate);
+      EffectSettings &settings, EffectOutputs &outputs,
+      unsigned numChannels, float sampleRate);
 
    /*!
     @return success

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -101,6 +101,11 @@ struct EffectSettings : audacity::TypedAny<EffectSettings> {
    }
 };
 
+//! Hold values to send to effect output meters
+struct EffectOutputs : audacity::TypedAny<EffectOutputs> {
+   using TypedAny::TypedAny;
+};
+
 //! Interface for accessing an EffectSettings that may change asynchronously in
 //! another thread; to be used in the main thread, only.
 /*! Updates are communicated atomically both ways.  The address of Get() should
@@ -306,6 +311,16 @@ public:
    //! Default implementation returns false
    virtual bool VisitSettings(
       ConstSettingsVisitor &visitor, const EffectSettings &settings) const;
+
+   /*! @name outputs
+    @{
+    */
+   //! Produce an object to hold values to send to effect output meters
+   /*!
+    Default implementation returns an empty any
+    */
+   virtual EffectOutputs MakeOutputs() const;
+   //! @}
 };
 
 class wxDialog;

--- a/libraries/lib-utility/TypedAny.h
+++ b/libraries/lib-utility/TypedAny.h
@@ -73,9 +73,21 @@ public:
 
    //! Like make_any but a static member function
    template<typename T, typename... Args>
-   static TypedAny make(Args &&... args)
+   static Tag make(Args &&... args)
    {
-      return TypedAny(std::in_place_type<T>, std::forward<Args>(args)...);
+      return Tag(std::in_place_type<T>, std::forward<Args>(args)...);
+   }
+
+   template<typename T>
+   static bool copy(const TypedAny &src, TypedAny &dst)
+   {
+      const T *pSrc = src.cast<T>();
+      T *pDst = dst.cast<T>();
+      if (pSrc && pDst) {
+         *pDst = *pSrc;
+         return true;
+      }
+      return false;
    }
 
    //! @}

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -206,7 +206,8 @@ void EffectAmplify::Preview(EffectSettingsAccess &access, bool dryOnly)
 }
 
 std::unique_ptr<EffectUIValidator> EffectAmplify::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    enum{ precision = 3 }; // allow (a generous) 3 decimal  places for Amplification (dB)
 

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -57,8 +57,8 @@ public:
    bool Init() override;
    void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -331,7 +331,8 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
 }
 
 std::unique_ptr<EffectUIValidator> EffectAutoDuck::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.SetBorder(5);
    S.StartVerticalLay(true);

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -47,8 +47,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool DoTransferDataToWindow();
    bool TransferDataFromWindow(EffectSettings &settings) override;

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -179,7 +179,8 @@ bool EffectBassTreble::CheckWhetherSkipEffect(const EffectSettings &) const
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator> EffectBassTreble::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -144,7 +144,7 @@ bool EffectBassTreble::RealtimeInitialize(EffectSettings &, double)
 }
 
 bool EffectBassTreble::RealtimeAddProcessor(
-   EffectSettings &, unsigned, float sampleRate)
+   EffectSettings &, EffectOutputs &, unsigned, float sampleRate)
 {
    EffectBassTrebleState slave;
 

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -64,7 +64,7 @@ public:
       override;
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
-   bool RealtimeAddProcessor(EffectSettings &settings,
+   bool RealtimeAddProcessor(EffectSettings& settings, EffectOutputs &outputs,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    size_t RealtimeProcess(size_t group,  EffectSettings &settings,

--- a/src/effects/BassTreble.h
+++ b/src/effects/BassTreble.h
@@ -74,8 +74,8 @@ public:
    // Effect Implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -232,7 +232,8 @@ bool EffectChangePitch::CheckWhetherSkipEffect(const EffectSettings &) const
 }
 
 std::unique_ptr<EffectUIValidator> EffectChangePitch::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    DeduceFrequencies(); // Set frequency-related control values based on sample.
 

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -60,8 +60,8 @@ public:
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -238,7 +238,8 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
 }
 
 std::unique_ptr<EffectUIValidator> EffectChangeSpeed::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    {
       wxString formatId;

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -50,8 +50,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ChangeTempo.cpp
+++ b/src/effects/ChangeTempo.cpp
@@ -195,7 +195,8 @@ bool EffectChangeTempo::Process(EffectInstance &, EffectSettings &settings)
 }
 
 std::unique_ptr<EffectUIValidator> EffectChangeTempo::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    enum { precision = 2 };
 

--- a/src/effects/ChangeTempo.h
+++ b/src/effects/ChangeTempo.h
@@ -58,8 +58,8 @@ public:
    double CalcPreviewInputLength(
       const EffectSettings &settings, double previewLength) const override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -274,7 +274,8 @@ bool EffectClickRemoval::RemoveClicks(size_t len, float *buffer)
 }
 
 std::unique_ptr<EffectUIValidator> EffectClickRemoval::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.AddSpace(0, 5);
    S.SetBorder(10);

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -49,8 +49,8 @@ public:
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -157,7 +157,8 @@ TranslatableString RatioLabelFormat( int sliderValue, double value )
 }
 
 std::unique_ptr<EffectUIValidator> EffectCompressor::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.SetBorder(5);
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -49,8 +49,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool DoTransferDataFromWindow();
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -224,7 +224,7 @@ bool EffectDistortion::RealtimeInitialize(EffectSettings &, double)
 }
 
 bool EffectDistortion::RealtimeAddProcessor(
-   EffectSettings &, unsigned, float sampleRate)
+   EffectSettings &, EffectOutputs &, unsigned, float sampleRate)
 {
    EffectDistortionState slave;
 

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -285,7 +285,8 @@ bool EffectDistortion::DoLoadFactoryPreset(int id)
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator> EffectDistortion::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.AddSpace(0, 5);
    S.StartVerticalLay();

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -99,8 +99,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -89,7 +89,7 @@ public:
       override;
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
-   bool RealtimeAddProcessor(EffectSettings &settings,
+   bool RealtimeAddProcessor(EffectSettings& settings, EffectOutputs &outputs,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    size_t RealtimeProcess(size_t group,  EffectSettings &settings,

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -414,7 +414,8 @@ void EffectDtmf::Validator::PopulateOrExchange(ShuttleGui & S,
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator> EffectDtmf::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    auto &settings = access.Get();
    auto &dtmfSettings = GetSettings(settings);

--- a/src/effects/DtmfGen.h
+++ b/src/effects/DtmfGen.h
@@ -60,8 +60,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
 
    struct Instance;
    std::shared_ptr<EffectInstance> MakeInstance() const override;

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -194,7 +194,8 @@ struct EffectEcho::Validator
 
 
 std::unique_ptr<EffectUIValidator> EffectEcho::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    auto& settings = access.Get();
    auto& myEffSettings = GetSettings(settings);

--- a/src/effects/Echo.h
+++ b/src/effects/Echo.h
@@ -51,8 +51,8 @@ public:
 
    // Effect implementation
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
 
    struct Validator;
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -278,7 +278,7 @@ bool Effect::LoadFactoryDefaults(EffectSettings &settings) const
 // EffectUIClientInterface implementation
 
 std::unique_ptr<EffectUIValidator> Effect::PopulateUI(ShuttleGui &S,
-   EffectInstance &instance, EffectSettingsAccess &access)
+   EffectInstance &instance, EffectSettingsAccess &access, EffectOutputs *)
 {
    auto parent = S.GetParent();
    mUIParent = parent;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -278,7 +278,8 @@ bool Effect::LoadFactoryDefaults(EffectSettings &settings) const
 // EffectUIClientInterface implementation
 
 std::unique_ptr<EffectUIValidator> Effect::PopulateUI(ShuttleGui &S,
-   EffectInstance &instance, EffectSettingsAccess &access, EffectOutputs *)
+   EffectInstance &instance, EffectSettingsAccess &access,
+   EffectOutputs *pOutputs)
 {
    auto parent = S.GetParent();
    mUIParent = parent;
@@ -286,7 +287,7 @@ std::unique_ptr<EffectUIValidator> Effect::PopulateUI(ShuttleGui &S,
 //   LoadUserPreset(CurrentSettingsGroup());
 
    // Let the effect subclass provide its own validator if it wants
-   auto result = PopulateOrExchange(S, instance, access);
+   auto result = PopulateOrExchange(S, instance, access, pOutputs);
 
    mUIParent->SetMinSize(mUIParent->GetSizer()->GetMinSize());
 
@@ -585,7 +586,8 @@ bool Effect::Delegate(Effect &delegate, EffectSettings &settings)
 }
 
 std::unique_ptr<EffectUIValidator> Effect::PopulateOrExchange(
-   ShuttleGui &, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui &, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    return nullptr;
 }

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -197,7 +197,8 @@ class AUDACITY_DLL_API Effect /* not final */
     DefaultEffectUIValidator; default implementation returns null
     */
    virtual std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access);
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access,
+      EffectOutputs *pOutputs);
 
    // No more virtuals!
 

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -127,8 +127,8 @@ class AUDACITY_DLL_API Effect /* not final */
    // EffectUIClientInterface implementation
 
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access,
+      EffectOutputs *pOutputs) override;
    //! @return false
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -319,12 +319,12 @@ class EffectWithSettings : public Base {
 public:
    EffectSettings MakeSettings() const override
    {
-      return EffectSettings::Make<Settings>();
+      return EffectSettings::make<Settings>();
    }
    bool CopySettingsContents(
       const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection) const override
    {
-      return EffectSettings::Copy<Settings>(src, dst);
+      return EffectSettings::copy<Settings>(src, dst);
    }
    //! Assume settings originated from MakeSettings() and copies thereof
    static inline Settings &GetSettings(EffectSettings &settings)

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -228,6 +228,7 @@ EffectUIHost::EffectUIHost(wxWindow *parent,
 , mSupportsRealtime{ mEffectUIHost.GetDefinition().SupportsRealtime() }
 , mHadPriorState{ (pPriorState != nullptr) }
 , mpInstance{ InitializeInstance() }
+, mpOutputs{ pPriorState ? &pPriorState->GetOutputs() : nullptr }
 {
    // Assign the out parameter
    pInstance = mpInstance;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -422,7 +422,7 @@ bool EffectUIHost::Initialize()
 
       // Let the client add things to the panel
       ShuttleGui S1{ uw.get(), eIsCreating };
-      mpValidator = mClient.PopulateUI(S1, *mpInstance, *mpAccess);
+      mpValidator = mClient.PopulateUI(S1, *mpInstance, *mpAccess, mpOutputs);
       if (!mpValidator)
          return false;
 

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -161,6 +161,7 @@ private:
 #endif
 
    const std::shared_ptr<EffectInstance> mpInstance;
+   EffectOutputs *const mpOutputs;
 
    DECLARE_EVENT_TABLE()
 };

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -679,7 +679,8 @@ bool EffectEqualization::CloseUI()
 }
 
 std::unique_ptr<EffectUIValidator> EffectEqualization::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    S.SetBorder(0);
 

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -137,8 +137,8 @@ public:
 
    bool CloseUI() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
 
 private:

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -215,7 +215,8 @@ bool EffectFindClipping::ProcessOne(LabelTrack * lt,
 }
 
 std::unique_ptr<EffectUIValidator> EffectFindClipping::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    DoPopulateOrExchange(S, access);
    return nullptr;

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -43,8 +43,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    void DoPopulateOrExchange(
       ShuttleGui & S, EffectSettingsAccess &access);
    bool TransferDataToWindow(const EffectSettings &settings) override;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -213,7 +213,8 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
 }
 
 std::unique_ptr<EffectUIValidator> EffectLoudness::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.StartVerticalLay(0);
    {

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -59,8 +59,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Noise.cpp
+++ b/src/effects/Noise.cpp
@@ -177,7 +177,8 @@ size_t EffectNoise::ProcessBlock(EffectSettings &,
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator> EffectNoise::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    wxASSERT(nTypes == WXSIZEOF(kTypeStrings));
 

--- a/src/effects/Noise.h
+++ b/src/effects/Noise.h
@@ -49,8 +49,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -212,7 +212,8 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
 }
 
 std::unique_ptr<EffectUIValidator> EffectNormalize::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    mCreating = true;
 

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -46,8 +46,8 @@ public:
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -171,7 +171,8 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
 
 
 std::unique_ptr<EffectUIValidator> EffectPaulstretch::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.StartMultiColumn(2, wxALIGN_CENTER);
    {

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -42,8 +42,8 @@ public:
       const EffectSettings &settings, double previewLength) const override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -191,7 +191,8 @@ size_t EffectPhaser::RealtimeProcess(size_t group, EffectSettings &settings,
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator> EffectPhaser::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -162,7 +162,7 @@ bool EffectPhaser::RealtimeInitialize(EffectSettings &, double)
 }
 
 bool EffectPhaser::RealtimeAddProcessor(
-   EffectSettings &, unsigned, float sampleRate)
+   EffectSettings &, EffectOutputs &, unsigned, float sampleRate)
 {
    EffectPhaserState slave;
 

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -80,8 +80,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Phaser.h
+++ b/src/effects/Phaser.h
@@ -70,7 +70,7 @@ public:
       override;
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
-   bool RealtimeAddProcessor(EffectSettings &settings,
+   bool RealtimeAddProcessor(EffectSettings& settings, EffectOutputs &outputs,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    size_t RealtimeProcess(size_t group,  EffectSettings &settings,

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -369,10 +369,11 @@ RealtimeEffectState::AddTrack(Track &track, unsigned chans, float sampleRate)
    AllocateChannelsToProcessors(chans, numAudioIn, numAudioOut,
    [&](unsigned, unsigned){
       // Add a NEW processor
-      // Pass reference to worker settings, not main -- such as, for connecting
-      // Ladspa ports to the proper addresses.
+      // Pass mMainOutputs for now -- though strictly speaking,
+      // that may cause data races with the main thread doing unsynchronized
+      // reads to update the UI.
       if (pInstance->RealtimeAddProcessor(
-         mWorkerSettings.settings, numAudioIn, sampleRate)
+         mWorkerSettings.settings, mMainOutputs, numAudioIn, sampleRate)
       ) {
          mCurrentProcessor++;
          return true;

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -270,6 +270,7 @@ const EffectInstanceFactory *RealtimeEffectState::GetEffect()
          mMainSettings.counter = 0;
          mMainSettings.settings = mPlugin->MakeSettings();
          mMainSettings.settings.extra.SetActive(wasActive);
+         mMainOutputs = mPlugin->MakeOutputs();
       }
    }
    return mPlugin;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -63,6 +63,9 @@ public:
     */
    std::shared_ptr<EffectInstance> GetInstance();
 
+   //! Get locations that a GUI can connect meters to
+   EffectOutputs &GetOutputs() { return mMainOutputs; }
+
    //! Main thread sets up for playback
    std::shared_ptr<EffectInstance> Initialize(double rate);
    //! Main thread sets up this state before adding it to lists
@@ -148,6 +151,7 @@ private:
    
    //! Updated immediately by Access::Set in the main thread
    NonInterfering<SettingsAndCounter> mMainSettings;
+   EffectOutputs mMainOutputs;
 
    /*! @name Members that are changed also in the worker thread
     @{

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -156,7 +156,8 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
 }
 
 std::unique_ptr<EffectUIValidator> EffectRepeat::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.StartHorizontalLay(wxCENTER, false);
    {

--- a/src/effects/Repeat.h
+++ b/src/effects/Repeat.h
@@ -43,8 +43,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -208,7 +208,7 @@ struct EffectReverb::Instance
       return true;
    }
 
-   bool RealtimeAddProcessor(EffectSettings& settings,
+   bool RealtimeAddProcessor(EffectSettings& settings, EffectOutputs &,
       unsigned numChannels, float sampleRate) override
    {
       EffectReverbState slave;

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -457,7 +457,8 @@ bool EffectReverb::LoadFactoryPreset(int id, EffectSettings& settings) const
 
 // Effect implementation
 std::unique_ptr<EffectUIValidator> EffectReverb::PopulateOrExchange(
-   ShuttleGui& S, EffectInstance&, EffectSettingsAccess& access)
+   ShuttleGui& S, EffectInstance&, EffectSettingsAccess& access,
+   EffectOutputs *)
 {
    auto& settings = access.Get();
    auto& myEffSettings = GetSettings(settings);

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -71,8 +71,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
 
    struct Validator;
 

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -259,7 +259,8 @@ bool EffectScienFilter::Init()
 }
 
 std::unique_ptr<EffectUIValidator> EffectScienFilter::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.AddSpace(5);
    S.SetSizerProportion(1);

--- a/src/effects/ScienFilter.h
+++ b/src/effects/ScienFilter.h
@@ -64,8 +64,8 @@ public:
 
    bool Init() override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -66,7 +66,8 @@ EffectType EffectSilence::GetType() const
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator> EffectSilence::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    S.StartVerticalLay();
    {

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -38,8 +38,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/StatefulEffectBase.cpp
+++ b/src/effects/StatefulEffectBase.cpp
@@ -61,10 +61,12 @@ bool StatefulEffectBase::Instance::RealtimeInitialize(
    return GetEffect().RealtimeInitialize(settings, sampleRate);
 }
 
-bool StatefulEffectBase::Instance::RealtimeAddProcessor(EffectSettings &settings,
-   unsigned numChannels, float sampleRate)
+bool StatefulEffectBase::Instance::
+RealtimeAddProcessor(EffectSettings &settings,
+   EffectOutputs &outputs, unsigned numChannels, float sampleRate)
 {
-   return GetEffect().RealtimeAddProcessor(settings, numChannels, sampleRate);
+   return GetEffect()
+      .RealtimeAddProcessor(settings, outputs, numChannels, sampleRate);
 }
 
 bool StatefulEffectBase::Instance::RealtimeSuspend()
@@ -146,8 +148,8 @@ bool StatefulEffectBase::RealtimeInitialize(EffectSettings &, double)
    return false;
 }
 
-bool StatefulEffectBase::RealtimeAddProcessor(
-   EffectSettings &settings, unsigned numChannels, float sampleRate)
+bool StatefulEffectBase::RealtimeAddProcessor(EffectSettings &settings,
+   EffectOutputs &, unsigned numChannels, float sampleRate)
 {
    return true;
 }

--- a/src/effects/StatefulEffectBase.h
+++ b/src/effects/StatefulEffectBase.h
@@ -36,6 +36,7 @@ public:
       bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
          override;
       bool RealtimeAddProcessor(EffectSettings &settings,
+         EffectOutputs &outputs,
          unsigned numChannels, float sampleRate) override;
       bool RealtimeSuspend() override;
       bool RealtimeResume() override;
@@ -75,8 +76,8 @@ public:
      @copydoc StatefulEffectBase::Instance::RealtimeAddProcessor()
      Default implementation does nothing, returns true
    */
-   virtual bool RealtimeAddProcessor(
-      EffectSettings &settings, unsigned numChannels, float sampleRate);
+   virtual bool RealtimeAddProcessor(EffectSettings &settings,
+      EffectOutputs &outputs, unsigned numChannels, float sampleRate);
 
    /*!
      @copydoc StatefulEffectBase::Instance::RealtimeSuspend()

--- a/src/effects/TimeScale.cpp
+++ b/src/effects/TimeScale.cpp
@@ -150,7 +150,8 @@ bool EffectTimeScale::Process(
 }
 
 std::unique_ptr<EffectUIValidator> EffectTimeScale::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    S.SetBorder(5);
    S.AddSpace(0, 5);

--- a/src/effects/TimeScale.h
+++ b/src/effects/TimeScale.h
@@ -47,8 +47,8 @@ public:
    void Preview(EffectSettingsAccess &access, bool dryOnly) override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
    double CalcPreviewInputLength(

--- a/src/effects/ToneGen.cpp
+++ b/src/effects/ToneGen.cpp
@@ -271,7 +271,8 @@ void EffectToneGen::PostSet()
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator> EffectToneGen::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    wxTextCtrl *t;
 

--- a/src/effects/ToneGen.h
+++ b/src/effects/ToneGen.h
@@ -48,8 +48,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -663,7 +663,8 @@ bool EffectTruncSilence::Analyze(RegionList& silenceList,
 
 
 std::unique_ptr<EffectUIValidator> EffectTruncSilence::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    wxASSERT(nActions == WXSIZEOF(kActionStrings));
 

--- a/src/effects/TruncSilence.h
+++ b/src/effects/TruncSilence.h
@@ -68,8 +68,8 @@ public:
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1042,8 +1042,8 @@ bool VSTEffectInstance::RealtimeInitialize(EffectSettings &settings, double samp
    return DoProcessInitialize(sampleRate);
 }
 
-bool VSTEffectInstance::RealtimeAddProcessor(
-   EffectSettings &settings, unsigned numChannels, float sampleRate)
+bool VSTEffectInstance::RealtimeAddProcessor(EffectSettings &settings,
+   EffectOutputs &, unsigned numChannels, float sampleRate)
 {
    auto slave = std::make_unique<VSTEffectInstance>(GetEffect(), mPath, mBlockSize, mUserBlockSize, mUseLatency);
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1281,7 +1281,7 @@ bool VSTEffect::DoLoadFactoryPreset(int id)
 // ============================================================================
 
 std::unique_ptr<EffectUIValidator> VSTEffect::PopulateUI(ShuttleGui &S,
-   EffectInstance& instance, EffectSettingsAccess &access)
+   EffectInstance& instance, EffectSettingsAccess &access, EffectOutputs *)
 {
    auto parent = S.GetParent();
    mDialog = static_cast<wxDialog *>(wxGetTopLevelParent(parent));

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -359,8 +359,8 @@ class VSTEffect final
    std::shared_ptr<EffectInstance> MakeInstance() const override;
    std::shared_ptr<EffectInstance> DoMakeInstance();
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access,
+      EffectOutputs *pOutputs) override;
    bool IsGraphicalUI() override;
    bool ValidateUI(EffectSettings &) override;
    bool CloseUI() override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -546,7 +546,7 @@ public:
 
    bool RealtimeInitialize(EffectSettings& settings, double sampleRate)
       override;
-   bool RealtimeAddProcessor(EffectSettings& settings,
+   bool RealtimeAddProcessor(EffectSettings& settings, EffectOutputs &outputs,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings& settings) noexcept override;
    bool RealtimeSuspend() override;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -257,7 +257,7 @@ std::shared_ptr<EffectInstance> VST3Effect::MakeInstance() const
 }
 
 std::unique_ptr<EffectUIValidator> VST3Effect::PopulateUI(ShuttleGui& S,
-   EffectInstance& instance, EffectSettingsAccess &access)
+   EffectInstance& instance, EffectSettingsAccess &access, EffectOutputs *)
 {
    bool useGUI { true };
    GetConfig(*this, PluginSettings::Shared, wxT("Options"),

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -94,8 +94,8 @@ public:
    std::shared_ptr<EffectInstance> MakeInstance() const override;
 
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access,
+      EffectOutputs *pOutputs) override;
 
    bool CloseUI() override;
    bool CanExportPresets() override;

--- a/src/effects/VST3/VST3Instance.cpp
+++ b/src/effects/VST3/VST3Instance.cpp
@@ -51,7 +51,8 @@ bool VST3Instance::Init()
    return Instance::Init();
 }
 
-bool VST3Instance::RealtimeAddProcessor(EffectSettings& settings, unsigned, float sampleRate)
+bool VST3Instance::RealtimeAddProcessor(EffectSettings& settings,
+   EffectOutputs &, unsigned, float sampleRate)
 {
    if (!mRecruited) {
       // Assign self to the first processor

--- a/src/effects/VST3/VST3Instance.h
+++ b/src/effects/VST3/VST3Instance.h
@@ -48,7 +48,8 @@ public:
 
    size_t GetTailSize() const override;
    bool Init() override;
-   bool RealtimeAddProcessor(EffectSettings& settings, unsigned numChannels, float sampleRate) override;
+   bool RealtimeAddProcessor(EffectSettings& settings, EffectOutputs &outputs,
+      unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings& settings) noexcept override;
    bool RealtimeInitialize(EffectSettings& settings, double sampleRate) override;
    size_t RealtimeProcess(size_t group, EffectSettings& settings, const float* const* inBuf, float* const* outBuf,

--- a/src/effects/VST3/VST3Wrapper.cpp
+++ b/src/effects/VST3/VST3Wrapper.cpp
@@ -733,7 +733,7 @@ Steinberg::int32 VST3Wrapper::GetLatencySamples() const
 
 EffectSettings VST3Wrapper::MakeSettings()
 {
-   return EffectSettings::Make<VST3EffectSettings>();
+   return EffectSettings::make<VST3EffectSettings>();
 }
 
 void VST3Wrapper::LoadSettings(const CommandParameters& parms, EffectSettings& settings)

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -263,7 +263,8 @@ size_t EffectWahwah::Instance::RealtimeProcess(size_t group, EffectSettings &set
 // Effect implementation
 
 std::unique_ptr<EffectUIValidator> EffectWahwah::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    auto& settings = access.Get();
    auto& myEffSettings = GetSettings(settings);

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -146,7 +146,7 @@ struct EffectWahwah::Instance
    bool RealtimeInitialize(EffectSettings& settings, double) override;
 
    bool RealtimeAddProcessor(EffectSettings& settings,
-      unsigned numChannels, float sampleRate) override;
+      EffectOutputs &outputs, unsigned numChannels, float sampleRate) override;
 
    bool RealtimeFinalize(EffectSettings& settings) noexcept override;
 
@@ -234,7 +234,7 @@ bool EffectWahwah::Instance::RealtimeInitialize(EffectSettings &, double)
 }
 
 bool EffectWahwah::Instance::RealtimeAddProcessor(
-   EffectSettings &settings, unsigned, float sampleRate)
+   EffectSettings &settings, EffectOutputs &, unsigned, float sampleRate)
 {
    EffectWahwahState slave;
 

--- a/src/effects/Wahwah.h
+++ b/src/effects/Wahwah.h
@@ -90,8 +90,8 @@ public:
    // Effect implementation
 
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
 
    struct Validator;
    struct Instance;

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -422,7 +422,7 @@ RegistryPaths AudioUnitEffect::GetFactoryPresets() const
 // ============================================================================
 
 std::unique_ptr<EffectUIValidator> AudioUnitEffect::PopulateUI(ShuttleGui &S,
-   EffectInstance &instance, EffectSettingsAccess &access)
+   EffectInstance &instance, EffectSettingsAccess &access, EffectOutputs *)
 {
    mParent = S.GetParent();
    return AudioUnitValidator::Create(*this, S, mUIType, instance, access);

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -300,7 +300,7 @@ EffectSettings AudioUnitEffect::MakeSettings() const
 {
    AudioUnitEffectSettings settings;
    FetchSettings(settings);
-   return EffectSettings::Make<AudioUnitEffectSettings>(std::move(settings));
+   return EffectSettings::make<AudioUnitEffectSettings>(std::move(settings));
 }
 
 bool AudioUnitEffect::CopySettingsContents(

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -95,8 +95,8 @@ public:
 
    std::shared_ptr<EffectInstance> MakeInstance() const override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access,
+      EffectOutputs *pOutputs) override;
    bool CloseUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -190,7 +190,7 @@ bool AudioUnitInstance::RealtimeInitialize(
 }
 
 bool AudioUnitInstance::RealtimeAddProcessor(
-   EffectSettings &settings, unsigned, float sampleRate)
+   EffectSettings &settings, EffectOutputs &, unsigned, float sampleRate)
 {
    if (!mRecruited) {
       // Assign self to the first processor

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -48,7 +48,7 @@ private:
 
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
-   bool RealtimeAddProcessor(EffectSettings &settings,
+   bool RealtimeAddProcessor(EffectSettings& settings, EffectOutputs &outputs,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -156,6 +156,12 @@ bool LadspaEffect::CopySettingsContents(
    return true;
 }
 
+auto LadspaEffect::MakeOutputs() const -> EffectOutputs
+{
+   auto result = EffectOutputs::make<LadspaPortValues>( mData->PortCount );
+   return result;
+}
+
 // ============================================================================
 // ComponentInterface implementation
 // ============================================================================

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -604,13 +604,15 @@ BEGIN_EVENT_TABLE(LadspaEffectMeter, wxWindow)
 END_EVENT_TABLE()
 
 LadspaEffectMeter::LadspaEffectMeter(wxWindow *parent, const float & val, float min, float max)
-:  wxWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxDEFAULT_CONTROL_BORDER),
+:  wxWindow{ parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+      wxSIMPLE_BORDER },
    mVal(val)
 {
    mMin = min;
    mMax = max;
    mLastValue = -mVal;
    SetBackgroundColour(*wxWHITE);
+   SetMinSize({ 20, 20 });
 }
 
 LadspaEffectMeter::~LadspaEffectMeter()

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -955,7 +955,8 @@ bool LadspaEffect::Instance::ProcessInitialize(
    if (!mReady) {
       auto &effect = GetEffect();
       auto &ladspaSettings = GetSettings(settings);
-      mMaster = effect.InitInstance(sampleRate, ladspaSettings);
+      // Destructive effect processing doesn't need output ports
+      mMaster = effect.InitInstance(sampleRate, ladspaSettings, nullptr);
       if (!mMaster)
          return false;
       mReady = true;
@@ -997,18 +998,18 @@ bool LadspaEffect::Instance::RealtimeInitialize(EffectSettings &, double)
 }
 
 bool LadspaEffect::Instance::RealtimeAddProcessor(
-   EffectSettings &settings, EffectOutputs &, unsigned, float sampleRate)
+   EffectSettings &settings, EffectOutputs &outputs, unsigned, float sampleRate)
 {
    auto &effect = GetEffect();
    auto &ladspaSettings = GetSettings(settings);
-   LADSPA_Handle slave = effect.InitInstance(sampleRate, ladspaSettings);
+  // Connect to outputs only if this is the first processor for the track.
+  // (What's right when a mono effect is on a stereo channel?  Unclear, but
+  // this definitely causes connection with the first channel.)
+   auto pLadspaOutputs = mSlaves.empty() ? &GetValues(outputs) : nullptr;
+   auto slave = effect.InitInstance(sampleRate, ladspaSettings, pLadspaOutputs);
    if (!slave)
-   {
       return false;
-   }
-
    mSlaves.push_back(slave);
-
    return true;
 }
 
@@ -1156,12 +1157,14 @@ bool LadspaEffect::LoadFactoryPreset(int, EffectSettings &) const
 
 struct LadspaEffect::Validator : EffectUIValidator {
    Validator(EffectUIClientInterface &effect,
-      EffectSettingsAccess &access, double sampleRate, EffectType type)
+      EffectSettingsAccess &access, double sampleRate, EffectType type,
+      LadspaPortValues *pOutputs)
       : EffectUIValidator{ effect, access }
       , mSampleRate{ sampleRate }
       , mType{ type }
       // Copy settings
       , mSettings{ GetSettings(access.Get()) }
+      , mpOutputs{ pOutputs }
    {}
 
    bool UpdateUI() override;
@@ -1180,6 +1183,7 @@ struct LadspaEffect::Validator : EffectUIValidator {
    const double mSampleRate;
    const EffectType mType;
    LadspaEffectSettings mSettings;
+   LadspaPortValues *const mpOutputs;
 
    NumericTextCtrl *mDuration{};
    wxWeakRef<wxDialog> mDialog;
@@ -1444,8 +1448,10 @@ void LadspaEffect::Validator::PopulateUI(ShuttleGui &S)
 
             // Capture const reference to output control value for later
             // display update
+            static float sink;
+            auto pOutput = mpOutputs ? &mpOutputs->controls[p] : &sink;
             mMeters[p] = safenew LadspaEffectMeter(
-               w, controls[p], lower, upper);
+               w, *pOutput, lower, upper);
             mMeters[p]->SetLabel(labelText);    // for screen readers
             gridSizer->Add(mMeters[p], 1, wxEXPAND | wxALIGN_CENTER_VERTICAL | wxALL, 5);
          }
@@ -1471,10 +1477,11 @@ void LadspaEffect::Validator::PopulateUI(ShuttleGui &S)
 std::unique_ptr<EffectUIValidator>
 LadspaEffect::PopulateOrExchange(ShuttleGui & S,
    EffectInstance &, EffectSettingsAccess &access,
-   EffectOutputs *)
+   EffectOutputs *pOutputs)
 {
-   auto result =
-      std::make_unique<Validator>(*this, access, mProjectRate, GetType());
+   auto pValues = pOutputs ? &GetValues(*pOutputs) : nullptr;
+   auto result = std::make_unique<Validator>(*this, access, mProjectRate,
+      GetType(), pValues);
    result->PopulateUI(S);
    return result;
 }
@@ -1603,7 +1610,8 @@ bool LadspaEffect::SaveParameters(
 }
 
 LADSPA_Handle LadspaEffect::InitInstance(
-   float sampleRate, LadspaEffectSettings &settings) const
+   float sampleRate, LadspaEffectSettings &settings,
+   LadspaPortValues *pOutputs) const
 {
    /* Instantiate the plugin */
    LADSPA_Handle handle = mData->instantiate(mData, sampleRate);
@@ -1613,8 +1621,15 @@ LADSPA_Handle LadspaEffect::InitInstance(
    auto &controls = settings.controls;
    for (unsigned long p = 0; p < mData->PortCount; ++p) {
       LADSPA_PortDescriptor d = mData->PortDescriptors[p];
-      if (LADSPA_IS_PORT_CONTROL(d))
-         mData->connect_port(handle, p, &controls[p]);
+      if (LADSPA_IS_PORT_CONTROL(d)) {
+         if (LADSPA_IS_PORT_INPUT(d))
+            mData->connect_port(handle, p, &controls[p]);
+         else {
+            static LADSPA_Data sink;
+            mData->connect_port(handle, p,
+               pOutputs ? &pOutputs->controls[p] : &sink);
+         }
+      }
    }
    if (mData->activate)
       mData->activate(handle);

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1470,7 +1470,8 @@ void LadspaEffect::Validator::PopulateUI(ShuttleGui &S)
 
 std::unique_ptr<EffectUIValidator>
 LadspaEffect::PopulateOrExchange(ShuttleGui & S,
-   EffectInstance &, EffectSettingsAccess &access)
+   EffectInstance &, EffectSettingsAccess &access,
+   EffectOutputs *)
 {
    auto result =
       std::make_unique<Validator>(*this, access, mProjectRate, GetType());

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -115,7 +115,7 @@ LadspaEffectsModule::~LadspaEffectsModule()
 // the structure.  Instead allocate a number of values chosen by the plug-in
 EffectSettings LadspaEffect::MakeSettings() const
 {
-   auto result = EffectSettings::Make<LadspaEffectSettings>( mData->PortCount );
+   auto result = EffectSettings::make<LadspaEffectSettings>( mData->PortCount );
    InitializeControls(GetSettings(result));
    return result;
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -908,8 +908,8 @@ struct LadspaEffect::Instance
 
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
-   bool RealtimeAddProcessor(
-      EffectSettings &settings, unsigned numChannels, float sampleRate)
+   bool RealtimeAddProcessor(EffectSettings &settings,
+      EffectOutputs &outputs, unsigned numChannels, float sampleRate)
    override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() override;
@@ -997,7 +997,7 @@ bool LadspaEffect::Instance::RealtimeInitialize(EffectSettings &, double)
 }
 
 bool LadspaEffect::Instance::RealtimeAddProcessor(
-   EffectSettings &settings, unsigned, float sampleRate)
+   EffectSettings &settings, EffectOutputs &, unsigned, float sampleRate)
 {
    auto &effect = GetEffect();
    auto &ladspaSettings = GetSettings(settings);

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -40,15 +40,32 @@ class NumericTextCtrl;
 
 class LadspaEffectMeter;
 
-struct LadspaEffectSettings {
-   explicit LadspaEffectSettings(size_t nPorts = 0)
+struct LadspaPortValues {
+   explicit LadspaPortValues(size_t nPorts = 0)
       : controls( nPorts )
    {}
 
    // Allocate as many slots as there are ports, although some may correspond
-   // to audio, not control, ports and so rest unused
+   // to audio ports, or control ports with irrelevant in/out direction, and so
+   // waste a little space, which is not likely to be large
    std::vector<float> controls;
 };
+
+//! Assume outputs originated from LadspaEffect::MakeOutputs()
+//! and copies thereof
+static inline LadspaPortValues &GetValues(EffectOutputs &outputs)
+{
+   auto pValues = outputs.cast<LadspaPortValues>();
+   assert(pValues);
+   return *pValues;
+}
+
+static inline const LadspaPortValues &GetValues(const EffectOutputs &outputs)
+{
+   return GetValues(const_cast<EffectOutputs &>(outputs));
+}
+
+using LadspaEffectSettings = LadspaPortValues;
 
 class LadspaEffect final
    : public EffectWithSettings<LadspaEffectSettings, PerTrackEffect>
@@ -65,6 +82,8 @@ public:
    bool CopySettingsContents(
       const EffectSettings &src, EffectSettings &dst,
       SettingsCopyDirection copyDirection) const override;
+
+   EffectOutputs MakeOutputs() const override;
 
    // ComponentInterface implementation
 

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -149,7 +149,8 @@ private:
       const RegistryPath & group, const EffectSettings &settings) const;
 
    LADSPA_Handle InitInstance(
-      float sampleRate, LadspaEffectSettings &settings) const;
+      float sampleRate, LadspaEffectSettings &settings,
+      LadspaPortValues *pOutputs) const;
    void FreeInstance(LADSPA_Handle handle) const;
 
 private:

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -127,8 +127,8 @@ public:
    std::shared_ptr<EffectInstance> MakeInstance() const override;
    struct Validator;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
 
    bool CanExportPresets() override;
    void ExportPresets(const EffectSettings &settings) const override;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -324,7 +324,8 @@ bool LV2Effect::LoadSettings(
 // May come here before destructive processing
 // Or maybe not (if you "Repeat Last Effect")
 std::unique_ptr<EffectUIValidator> LV2Effect::PopulateUI(ShuttleGui &S,
-   EffectInstance &instance, EffectSettingsAccess &access, EffectOutputs *)
+   EffectInstance &instance, EffectSettingsAccess &access,
+   EffectOutputs *pOutputs)
 {
    auto &settings = access.Get();
    auto parent = S.GetParent();
@@ -332,7 +333,7 @@ std::unique_ptr<EffectUIValidator> LV2Effect::PopulateUI(ShuttleGui &S,
 
    auto &myInstance = dynamic_cast<LV2Instance &>(instance);
    auto pWrapper =
-      myInstance.MakeWrapper(settings, mProjectRate, true);
+      myInstance.MakeWrapper(settings, mProjectRate, pOutputs);
    if (!pWrapper) {
       AudacityMessageBox( XO("Couldn't instantiate effect") );
       return nullptr;
@@ -349,7 +350,7 @@ std::unique_ptr<EffectUIValidator> LV2Effect::PopulateUI(ShuttleGui &S,
 
    auto result = std::make_unique<LV2Validator>(*this, mPlug,
       dynamic_cast<LV2Instance&>(instance),
-      access, mProjectRate, mFeatures, mPorts, parent, useGUI);
+      access, pOutputs, mProjectRate, mFeatures, mPorts, parent, useGUI);
 
    if (result->mUseGUI)
       result->mUseGUI = result->BuildFancy(move(pWrapper), settings);

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -180,7 +180,7 @@ bool LV2Effect::InitializePlugin()
 
 EffectSettings LV2Effect::MakeSettings() const
 {
-   auto result = EffectSettings::Make<LV2EffectSettings>();
+   auto result = EffectSettings::make<LV2EffectSettings>();
    auto &settings = GetSettings(result);
    settings.values.reserve(mPorts.mControlPorts.size());
    for (auto &controlPort : mPorts.mControlPorts) {

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -182,6 +182,7 @@ EffectSettings LV2Effect::MakeSettings() const
 {
    auto result = EffectSettings::make<LV2EffectSettings>();
    auto &settings = GetSettings(result);
+   // This may waste a bit of space on output ports, but not likely much
    settings.values.reserve(mPorts.mControlPorts.size());
    for (auto &controlPort : mPorts.mControlPorts) {
       auto &value = settings.values.emplace_back();
@@ -229,6 +230,19 @@ bool LV2Effect::CopySettingsContents(
    // Ignore mpState
 
    return true;
+}
+
+auto LV2Effect::MakeOutputs() const -> EffectOutputs
+{
+   auto result = EffectOutputs::make<LV2PortValues>();
+   auto &values = GetValues(result);
+   // This may waste a bit of space on input ports, but not likely much
+   values.values.reserve(mPorts.mControlPorts.size());
+   for (auto &controlPort : mPorts.mControlPorts) {
+      auto &value = values.values.emplace_back();
+      value = controlPort->mDef;
+   }
+   return result;
 }
 
 std::shared_ptr<EffectInstance> LV2Effect::MakeInstance() const

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -324,7 +324,7 @@ bool LV2Effect::LoadSettings(
 // May come here before destructive processing
 // Or maybe not (if you "Repeat Last Effect")
 std::unique_ptr<EffectUIValidator> LV2Effect::PopulateUI(ShuttleGui &S,
-   EffectInstance &instance, EffectSettingsAccess &access)
+   EffectInstance &instance, EffectSettingsAccess &access, EffectOutputs *)
 {
    auto &settings = access.Get();
    auto parent = S.GetParent();

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -100,6 +100,8 @@ private:
       const EffectSettings &src, EffectSettings &dst,
       SettingsCopyDirection copyDirection) const override;
 
+   EffectOutputs MakeOutputs() const override;
+
    bool LoadParameters(
       const RegistryPath & group, EffectSettings &settings) const;
    bool SaveParameters(

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -81,8 +81,8 @@ public:
 
    std::shared_ptr<EffectInstance> MakeInstance() const override;
    std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access,
+      EffectOutputs *pOutputs) override;
    bool CloseUI() override;
 
    bool CanExportPresets() override;

--- a/src/effects/lv2/LV2EffectMeter.cpp
+++ b/src/effects/lv2/LV2EffectMeter.cpp
@@ -33,13 +33,14 @@ END_EVENT_TABLE()
 
 LV2EffectMeter::LV2EffectMeter(
    wxWindow *parent, const LV2ControlPortPtr port, const float &value
-)  : wxWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-      wxDEFAULT_CONTROL_BORDER)
+)  : wxWindow{ parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+      wxSIMPLE_BORDER }
    , mControlPort(port)
    , mValue{ value }
 {
    mLastValue = -value;
    SetBackgroundColour(*wxWHITE);
+   SetMinSize({ 20, 20 });
 }
 
 LV2EffectMeter::~LV2EffectMeter()

--- a/src/effects/lv2/LV2Instance.cpp
+++ b/src/effects/lv2/LV2Instance.cpp
@@ -42,23 +42,25 @@ LV2Instance::LV2Instance(
 LV2Instance::~LV2Instance() = default;
 
 void LV2Instance::MakeMaster(const EffectSettings &settings,
-   double sampleRate, bool useOutput)
+   double sampleRate)
 {
+   // Come here only when doing non-realtime application of the effect, in which
+   // case, we don't care about capturing the output ports
    if (mMaster && sampleRate == mFeatures.mSampleRate) {
       // Already made but be sure to connect control ports to the right place
-      mMaster->ConnectControlPorts(mPorts, GetSettings(settings), useOutput);
+      mMaster->ConnectControlPorts(mPorts, GetSettings(settings), nullptr);
       return;
    }
-   mMaster = MakeWrapper(settings, sampleRate, useOutput);
+   mMaster = MakeWrapper(settings, sampleRate, nullptr);
    SetBlockSize(mUserBlockSize);
 }
 
 std::unique_ptr<LV2Wrapper>
 LV2Instance::MakeWrapper(const EffectSettings &settings,
-   double sampleRate, bool useOutput)
+   double sampleRate, EffectOutputs *pOutputs)
 {
    return LV2Wrapper::Create(mFeatures, mPorts, mPortStates,
-      GetSettings(settings), sampleRate, useOutput);
+      GetSettings(settings), sampleRate, pOutputs);
 }
 
 size_t LV2Instance::SetBlockSize(size_t maxBlockSize)
@@ -99,7 +101,7 @@ auto LV2Instance::GetLatency(const EffectSettings &, double) const
 bool LV2Instance::ProcessInitialize(EffectSettings &settings,
    double sampleRate, ChannelNames chanMap)
 {
-   MakeMaster(settings, sampleRate, false);
+   MakeMaster(settings, sampleRate);
    if (!mMaster)
       return false;
    for (auto & state : mPortStates.mCVPortStates)
@@ -156,10 +158,14 @@ return GuardedCall<bool>([&]{
 }
 
 bool LV2Instance::RealtimeAddProcessor(
-   EffectSettings &settings, EffectOutputs &, unsigned, float sampleRate)
+   EffectSettings &settings, EffectOutputs &outputs, unsigned, float sampleRate)
 {
+   // Connect to outputs only if this is the first processor for the track.
+   // (What's right when a mono effect is on a stereo channel?  Unclear, but
+   // this definitely causes connection with the first channel.)
    auto pInstance = LV2Wrapper::Create(mFeatures,
-      mPorts, mPortStates, GetSettings(settings), sampleRate, false);
+      mPorts, mPortStates, GetSettings(settings), sampleRate,
+      mSlaves.empty() ? &outputs : nullptr);
    if (!pInstance)
       return false;
    pInstance->Activate();

--- a/src/effects/lv2/LV2Instance.cpp
+++ b/src/effects/lv2/LV2Instance.cpp
@@ -156,7 +156,7 @@ return GuardedCall<bool>([&]{
 }
 
 bool LV2Instance::RealtimeAddProcessor(
-   EffectSettings &settings, unsigned, float sampleRate)
+   EffectSettings &settings, EffectOutputs &, unsigned, float sampleRate)
 {
    auto pInstance = LV2Wrapper::Create(mFeatures,
       mPorts, mPortStates, GetSettings(settings), sampleRate, false);

--- a/src/effects/lv2/LV2Instance.h
+++ b/src/effects/lv2/LV2Instance.h
@@ -48,11 +48,10 @@ public:
    //! Do nothing if there is already an LV2Wrapper with the desired rate.
    //! The wrapper object remains until this is destroyed
    //! or the wrapper is re-made with another rate.
-   void MakeMaster(const EffectSettings &settings,
-      double sampleRate, bool useOutput);
+   void MakeMaster(const EffectSettings &settings, double sampleRate);
 
    std::unique_ptr<LV2Wrapper> MakeWrapper(const EffectSettings &settings,
-      double sampleRate, bool useOutput);
+      double sampleRate, EffectOutputs *pOutputs);
 
    size_t GetBlockSize() const override;
    size_t SetBlockSize(size_t maxBlockSize) override;

--- a/src/effects/lv2/LV2Instance.h
+++ b/src/effects/lv2/LV2Instance.h
@@ -62,7 +62,7 @@ public:
 
    bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
       override;
-   bool RealtimeAddProcessor(EffectSettings &settings,
+   bool RealtimeAddProcessor(EffectSettings& settings, EffectOutputs &outputs,
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;

--- a/src/effects/lv2/LV2Ports.h
+++ b/src/effects/lv2/LV2Ports.h
@@ -203,14 +203,31 @@ using LV2ControlPortPtr = std::shared_ptr<LV2ControlPort>;
 using LV2ControlPortArray = std::vector<LV2ControlPortPtr>;
 
 //! Storage locations to be connected to LV2 control ports
-struct LV2EffectSettings final {
+struct LV2PortValues {
    //! vector of values in correspondence with the control ports
    std::vector<float> values;
+};
+
+//! Assume outputs originated from LV2Effect::MakeOutputs()
+//! and copies thereof
+static inline LV2PortValues &GetValues(EffectOutputs &outputs)
+{
+   auto pValues = outputs.cast<LV2PortValues>();
+   assert(pValues);
+   return *pValues;
+}
+
+static inline const LV2PortValues &GetValues(const EffectOutputs &outputs)
+{
+   return GetValues(const_cast<EffectOutputs &>(outputs));
+}
+
+struct LV2EffectSettings final : LV2PortValues {
    //! Result of last load of a preset; may be null
    mutable std::shared_ptr<const LilvState> mpState;
 };
 
-//! Assume settings originated from LV2Effecct::MakeSettings()
+//! Assume settings originated from LV2Effect::MakeSettings()
 //! and copies thereof
 inline LV2EffectSettings &GetSettings(EffectSettings &settings)
 {

--- a/src/effects/lv2/LV2Validator.h
+++ b/src/effects/lv2/LV2Validator.h
@@ -54,7 +54,8 @@ class LV2Validator final : public EffectUIValidator
 public:
    LV2Validator(EffectBase &effect,
       const LilvPlugin &plug, LV2Instance &instance,
-      EffectSettingsAccess &access, double sampleRate,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs,
+      double sampleRate,
       const LV2FeaturesList &features,
       const LV2Ports &ports, wxWindow *parent, bool useGUI);
    ~LV2Validator() override;
@@ -98,6 +99,7 @@ public:
    const LilvPlugin &mPlug;
    const EffectType mType;
    LV2Instance &mInstance;
+   EffectOutputs *const mpOutputs;
    const double mSampleRate;
    const LV2Ports &mPorts;
    std::unique_ptr<LV2Wrapper> mpWrapper;

--- a/src/effects/lv2/LV2Wrapper.cpp
+++ b/src/effects/lv2/LV2Wrapper.cpp
@@ -32,7 +32,7 @@
 std::unique_ptr<LV2Wrapper> LV2Wrapper::Create(
    LV2InstanceFeaturesList &baseFeatures,
    const LV2Ports &ports, LV2PortStates &portStates,
-   const LV2EffectSettings &settings, float sampleRate, bool useOutput)
+   const LV2EffectSettings &settings, float sampleRate, EffectOutputs *pOutputs)
 {
    auto &plug = baseFeatures.mPlug;
 
@@ -46,7 +46,7 @@ std::unique_ptr<LV2Wrapper> LV2Wrapper::Create(
 
    const auto instance = &wrapper->GetInstance();
    wrapper->SendBlockSize();
-   wrapper->ConnectPorts(ports, portStates, settings, useOutput);
+   wrapper->ConnectPorts(ports, portStates, settings, pOutputs);
 
    // Give plugin a chance to initialize.  The SWH plugins (like AllPass) need
    // this before it can be safely deleted.
@@ -61,10 +61,12 @@ std::unique_ptr<LV2Wrapper> LV2Wrapper::Create(
 }
 
 void LV2Wrapper::ConnectControlPorts(
-   const LV2Ports &ports, const LV2EffectSettings &settings, bool useOutput)
+   const LV2Ports &ports, const LV2EffectSettings &settings,
+   EffectOutputs *pOutputs)
 {
    const auto instance = &GetInstance();
    static float blackHole;
+   auto pValues = pOutputs ? &GetValues(*pOutputs) : nullptr;
 
    // Connect all control ports
    const auto latencyPort = ports.mLatencyPort;
@@ -74,24 +76,21 @@ void LV2Wrapper::ConnectControlPorts(
    auto &values = settings.values;
    size_t index = 0;
    for (auto & port : ports.mControlPorts) {
-      // If it's not an input port and output values are unwanted,
-      // then connect the port to a dummy.
-      // Otherwise, connect it to the real value field.
-      lilv_instance_connect_port(instance, port->mIndex,
-         !port->mIsInput && useOutput
-            ? &blackHole
-            // Treat settings slot corresponding to an output port as mutable
-            // Otherwise those for input ports must still pass to the library
-            // as nominal pointers to non-const
-            : &const_cast<float&>(values[index]));
+      void *const location = port->mIsInput
+         // Settings slots for input ports must pass to the library
+         // as nominal pointers to non-const
+         ? &const_cast<float&>(values[index])
+         : pValues ? &pValues->values[index]
+         : &blackHole;
+      lilv_instance_connect_port(instance, port->mIndex, location);
       ++index;
    }
 }
 
 void LV2Wrapper::ConnectPorts(const LV2Ports &ports, LV2PortStates &portStates,
-   const LV2EffectSettings &settings, bool useOutput)
+   const LV2EffectSettings &settings, EffectOutputs *pOutputs)
 {
-   ConnectControlPorts(ports, settings, useOutput);
+   ConnectControlPorts(ports, settings, pOutputs);
 
    const auto instance = &GetInstance();
 

--- a/src/effects/lv2/LV2Wrapper.h
+++ b/src/effects/lv2/LV2Wrapper.h
@@ -30,6 +30,7 @@
 #include <thread>
 #include <wx/msgqueue.h>
 
+struct EffectOutputs;
 struct LV2EffectSettings;
 class LV2Ports;
 class LV2PortStates;
@@ -55,7 +56,8 @@ public:
    static std::unique_ptr<LV2Wrapper> Create(
       LV2InstanceFeaturesList &baseFeatures,
       const LV2Ports &ports, LV2PortStates &portStates,
-      const LV2EffectSettings &settings, float sampleRate, bool useOutput);
+      const LV2EffectSettings &settings, float sampleRate,
+      EffectOutputs *pOutputs);
 
    //! Constructor may spawn a thread
    LV2Wrapper(CreateToken&&,
@@ -66,10 +68,10 @@ public:
    ~LV2Wrapper();
 
    void ConnectControlPorts(const LV2Ports &ports,
-      const LV2EffectSettings &settings, bool useOutput);
+      const LV2EffectSettings &settings, EffectOutputs *pOutputs);
    void ConnectPorts(const LV2Ports &ports,
       LV2PortStates &portStates, const LV2EffectSettings &settings,
-      bool useOutput);
+      EffectOutputs *pOutputs);
    void Activate();
    void Deactivate();
    LilvInstance &GetInstance() const;

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -297,7 +297,7 @@ public:
             portStates,
             GetSettings(settings),
             44100.0,
-            false);
+            nullptr);
 
          if(!wrapper)
             throw std::runtime_error("Cannot create LV2 instance");

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1131,7 +1131,8 @@ int NyquistEffect::ShowHostInterface(
 }
 
 std::unique_ptr<EffectUIValidator> NyquistEffect::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    if (mIsPrompt)
       BuildPromptWindow(S);

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -125,8 +125,8 @@ public:
       std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
       bool forceModal = false) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -527,7 +527,8 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
 }
 
 std::unique_ptr<EffectUIValidator> VampEffect::PopulateOrExchange(
-   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &)
+   ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
+   EffectOutputs *)
 {
    Vamp::Plugin::ProgramList programs = mPlugin->getPrograms();
 

--- a/src/effects/vamp/VampEffect.h
+++ b/src/effects/vamp/VampEffect.h
@@ -70,8 +70,8 @@ public:
    bool Init() override;
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access)
-   override;
+      ShuttleGui & S, EffectInstance &instance,
+      EffectSettingsAccess &access, EffectOutputs *pOutputs) override;
    bool TransferDataToWindow(const EffectSettings &settings) override;
    bool TransferDataFromWindow(EffectSettings &settings) override;
 


### PR DESCRIPTION
Resolves: #3729

Output port locations for Ladspa and LV2 effects are not inside their EffectSettings.

This is preliminary to other simplifications of inter-thread communications.

Incidentally, the UI for output metering of Ladspa and LV2 effects becomes really functional.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
