### PR TITLE
Fix data race v2

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -126,6 +126,7 @@ struct EffectSettings : audacity::TypedAny<EffectSettings> {
 class COMPONENTS_API EffectOutputs {
 public:
    virtual ~EffectOutputs();
+   virtual std::unique_ptr<EffectOutputs> Clone() const = 0;
 };
 
 //! Interface for accessing an EffectSettings that may change asynchronously in

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -127,6 +127,18 @@ class COMPONENTS_API EffectOutputs {
 public:
    virtual ~EffectOutputs();
    virtual std::unique_ptr<EffectOutputs> Clone() const = 0;
+
+   //! Update one Outputs object from another
+   /*!
+    This may run in a worker thread, and should avoid allocating and freeing.
+    Even on the main thread, it must avoid relocation of members of containers.
+    Therefore do not grow or clear any containers, but assign the preallocated
+    contents of one container from another.
+
+    @param src settings to copy from; assume it comes from the same
+    EffectSettingsManager as *this
+    */
+   virtual void Assign(EffectOutputs &&src) = 0;
 };
 
 //! Interface for accessing an EffectSettings that may change asynchronously in

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -64,7 +64,7 @@ public:
    std::shared_ptr<EffectInstance> GetInstance();
 
    //! Get locations that a GUI can connect meters to
-   const EffectOutputs *GetOutputs() const { return mMainOutputs.get(); }
+   const EffectOutputs *GetOutputs() const { return mMovedOutputs.get(); }
 
    //! Main thread sets up for playback
    std::shared_ptr<EffectInstance> Initialize(double rate);
@@ -156,7 +156,7 @@ private:
 
    //! Updated immediately by Access::Set in the main thread
    NonInterfering<SettingsAndCounter> mMainSettings;
-   std::unique_ptr<EffectOutputs> mMainOutputs;
+   std::unique_ptr<EffectOutputs> mMovedOutputs;
 
    /*! @name Members that are changed also in the worker thread
     @{
@@ -165,6 +165,7 @@ private:
    //! Updated with delay, but atomically, in the worker thread; skipped by the
    //! copy constructor so that there isn't a race when pushing an Undo state
    NonInterfering<SettingsAndCounter> mWorkerSettings;
+   std::unique_ptr<EffectOutputs> mOutputs;
 
    //! How many samples must be discarded
    std::optional<EffectInstance::SampleCount> mLatency;

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -148,7 +148,12 @@ private:
          std::swap(counter, other.counter);
       }
    };
-   
+
+   struct Response {
+      SettingsAndCounter settings;
+      std::unique_ptr<EffectOutputs> pOutputs;
+   };
+
    //! Updated immediately by Access::Set in the main thread
    NonInterfering<SettingsAndCounter> mMainSettings;
    std::unique_ptr<EffectOutputs> mMainOutputs;
@@ -160,6 +165,7 @@ private:
    //! Updated with delay, but atomically, in the worker thread; skipped by the
    //! copy constructor so that there isn't a race when pushing an Undo state
    NonInterfering<SettingsAndCounter> mWorkerSettings;
+
    //! How many samples must be discarded
    std::optional<EffectInstance::SampleCount> mLatency;
    //! Assigned in the worker thread at the start of each processing scope

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -680,6 +680,11 @@ void LadspaEffectMeter::OnSize(wxSizeEvent & WXUNUSED(evt))
 
 LadspaEffectOutputs::~LadspaEffectOutputs() = default;
 
+auto LadspaEffectOutputs::Clone() const -> std::unique_ptr<EffectOutputs>
+{
+   return std::make_unique<LadspaEffectOutputs>(*this);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 // LadspaEffect

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -685,6 +685,15 @@ auto LadspaEffectOutputs::Clone() const -> std::unique_ptr<EffectOutputs>
    return std::make_unique<LadspaEffectOutputs>(*this);
 }
 
+void LadspaEffectOutputs::Assign(EffectOutputs &&src)
+{
+   // Don't really need to modify src
+   const auto &srcValues = static_cast<LadspaEffectOutputs&>(src).controls;
+   auto &dstValues = controls;
+   assert(srcValues.size() == dstValues.size());
+   copy(srcValues.begin(), srcValues.end(), dstValues.data());
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 // LadspaEffect

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -53,6 +53,8 @@ struct LadspaEffectSettings {
 //! Carry output control port information back to main thread
 struct LadspaEffectOutputs : EffectOutputs {
    ~LadspaEffectOutputs() override;
+   std::unique_ptr<EffectOutputs> Clone() const override;
+
    // Allocate as many slots as there are ports, although some may correspond
    // to input and audio ports and remain unused
    std::vector<float> controls;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -55,6 +55,8 @@ struct LadspaEffectOutputs : EffectOutputs {
    ~LadspaEffectOutputs() override;
    std::unique_ptr<EffectOutputs> Clone() const override;
 
+   void Assign(EffectOutputs &&src) override;
+
    // Allocate as many slots as there are ports, although some may correspond
    // to input and audio ports and remain unused
    std::vector<float> controls;

--- a/src/effects/lv2/LV2Ports.cpp
+++ b/src/effects/lv2/LV2Ports.cpp
@@ -141,6 +141,15 @@ auto LV2EffectOutputs::Clone() const -> std::unique_ptr<EffectOutputs>
    return std::make_unique<LV2EffectOutputs>(*this);
 }
 
+void LV2EffectOutputs::Assign(EffectOutputs &&src)
+{
+   // Don't really need to modify src
+   const auto &srcValues = static_cast<LV2EffectOutputs&>(src).values;
+   auto &dstValues = values;
+   assert(srcValues.size() == dstValues.size());
+   copy(srcValues.begin(), srcValues.end(), dstValues.data());
+}
+
 LV2Ports::LV2Ports(const LilvPlugin &plug)
 {
    using namespace LV2Symbols;

--- a/src/effects/lv2/LV2Ports.cpp
+++ b/src/effects/lv2/LV2Ports.cpp
@@ -136,6 +136,11 @@ size_t LV2ControlPort::Discretize(float value) const
 
 LV2EffectOutputs::~LV2EffectOutputs() = default;
 
+auto LV2EffectOutputs::Clone() const -> std::unique_ptr<EffectOutputs>
+{
+   return std::make_unique<LV2EffectOutputs>(*this);
+}
+
 LV2Ports::LV2Ports(const LilvPlugin &plug)
 {
    using namespace LV2Symbols;

--- a/src/effects/lv2/LV2Ports.h
+++ b/src/effects/lv2/LV2Ports.h
@@ -228,6 +228,7 @@ inline const LV2EffectSettings &GetSettings(const EffectSettings &settings)
 struct LV2EffectOutputs : EffectOutputs {
    ~LV2EffectOutputs() override;
    std::unique_ptr<EffectOutputs> Clone() const override;
+   void Assign(EffectOutputs &&src) override;
    //! vector of values in correspondence with the control ports
    std::vector<float> values;
 };

--- a/src/effects/lv2/LV2Ports.h
+++ b/src/effects/lv2/LV2Ports.h
@@ -227,6 +227,7 @@ inline const LV2EffectSettings &GetSettings(const EffectSettings &settings)
 //! Carry output control port information back to main thread
 struct LV2EffectOutputs : EffectOutputs {
    ~LV2EffectOutputs() override;
+   std::unique_ptr<EffectOutputs> Clone() const override;
    //! vector of values in correspondence with the control ports
    std::vector<float> values;
 };


### PR DESCRIPTION
Resolves: #3737

This redraft of #3736 without std::any lets one EffectOutputs reassign itself from another without the help of an Effect object.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
