### PR TITLE
Eliminate one settings copy v2

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -177,12 +177,6 @@ size_t EffectInstance::GetTailSize() const
    return 0;
 }
 
-void EffectInstance::AssignSettings(EffectSettings &dst, EffectSettings &&src)
-   const
-{
-   dst = src;
-}
-
 auto EffectInstance::GetLatency(const EffectSettings &, double) const
    -> SampleCount
 {

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -118,7 +118,7 @@ auto EffectSettingsManager::MakeOutputs() const
 }
 
 bool EffectSettingsManager::CopySettingsContents(
-   const EffectSettings &, EffectSettings &, SettingsCopyDirection ) const
+   const EffectSettings &, EffectSettings &) const
 {
    return true;
 }

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -251,15 +251,6 @@ public:
    virtual bool IsHiddenFromMenus() const;
 };
 
-//! Direction in which settings are copied
-enum class SettingsCopyDirection
-{
-   //! Main thread settings replicated to the worker thread
-   MainToWorker,
-   //! Worker thread settings replicated to main thread
-   WorkerToMain
-};
-
 /*************************************************************************************//**
 
 \class EffectSettingsManager
@@ -302,7 +293,7 @@ public:
     @return success
     */
    virtual bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection copyDirection) const;
+      const EffectSettings &src, EffectSettings &dst) const;
 
    //! Store settings as keys and values
    /*!

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -503,13 +503,6 @@ public:
    //! Correct definitions of it will likely depend on settings and state
    virtual size_t GetTailSize() const;
 
-   //! Main thread receives updates to settings from a processing thread
-   /*!
-    Default implementation simply assigns by copy, not move
-    This might be overridden to copy contents only selectively
-    */
-   virtual void AssignSettings(EffectSettings &dst, EffectSettings &&src) const;
-
    using SampleCount = uint64_t;
 
    /*!

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -323,7 +323,7 @@ public:
       return EffectSettings::Make<Settings>();
    }
    bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection) const override
+      const EffectSettings &src, EffectSettings &dst) const override
    {
       return EffectSettings::Copy<Settings>(src, dst);
    }

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -22,8 +22,6 @@
 //! Mediator of two-way inter-thread communication of changes of settings
 class RealtimeEffectState::AccessState : public NonInterferingBase {
 public:
-   //! @pre `state.mMainSettings.settings.has_value()`
-   //! @invariant `mLastSettings.settings.has_value()`
    AccessState(const EffectSettingsManager &effect, RealtimeEffectState &state)
       : mEffect{ effect }
       , mState{ state }
@@ -31,13 +29,9 @@ public:
       Initialize(state.mMainSettings, state.mMovedOutputs.get());
    }
 
-   //! @pre `settings.settings.has_value()`
-   //! @post `mLastSettings.settings.has_value()`
    void Initialize(SettingsAndCounter &settings,
       const EffectOutputs *pOutputs)
    {
-      assert(settings.settings.has_value());
-
       // Clean initial state of the counter
       settings.counter = 0;
       mLastSettings = settings;
@@ -48,8 +42,6 @@ public:
          pOutputs ? pOutputs->Clone() : nullptr } });
       mChannelFromMain.Write(FromMainSlot{ settings });
       mChannelFromMain.Write(FromMainSlot{ settings });
-
-      assert(mLastSettings.settings.has_value());
    }
 
    void MainRead() {
@@ -184,9 +176,6 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
       return empty;
    }
    void Set(EffectSettings &&settings) override {
-      if (!settings.has_value())
-         // Protect the invariant!
-         return;
       if (auto pState = mwState.lock())
          if (auto pAccessState = pState->GetAccessState()) {
             auto &lastSettings = pAccessState->mLastSettings;
@@ -664,9 +653,8 @@ void RealtimeEffectState::WriteXML(XMLWriter &xmlFile)
 
 std::shared_ptr<EffectSettingsAccess> RealtimeEffectState::GetAccess()
 {
-   if (!GetEffect() // Effect not found!
-       || !mMainSettings.settings.has_value() // can't satisfy pre of ctor
-   )
+   if (!GetEffect())
+      // Effect not found!
       // Return a dummy
       return std::make_shared<Access>();
 

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -150,7 +150,9 @@ private:
    };
 
    struct Response {
-      SettingsAndCounter settings;
+      using Counter = unsigned char;
+
+      Counter counter{ 0 };
       std::unique_ptr<EffectOutputs> pOutputs;
    };
 

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -404,8 +404,8 @@ EffectSettings VST3Effect::MakeSettings() const
    return VST3Wrapper::MakeSettings();
 }
 
-bool VST3Effect::CopySettingsContents(const EffectSettings& src, EffectSettings& dst, SettingsCopyDirection copyDirection) const
+bool VST3Effect::CopySettingsContents(const EffectSettings& src, EffectSettings& dst) const
 {
-   VST3Wrapper::CopySettingsContents(src, dst, copyDirection);
+   VST3Wrapper::CopySettingsContents(src, dst);
    return true;
 }

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -105,7 +105,7 @@ public:
    void ShowOptions() override;
 
    EffectSettings MakeSettings() const override;
-   bool CopySettingsContents(const EffectSettings& src, EffectSettings& dst, SettingsCopyDirection copyDirection) const override;
+   bool CopySettingsContents(const EffectSettings& src, EffectSettings& dst) const override;
 
 private:
    

--- a/src/effects/VST3/VST3Instance.cpp
+++ b/src/effects/VST3/VST3Instance.cpp
@@ -217,9 +217,3 @@ void VST3Instance::ReloadUserOptions()
 
    SetBlockSize(mUserBlockSize);
 }
-
-void VST3Instance::AssignSettings(EffectSettings& dst, EffectSettings&& src) const
-{
-   mWrapper->AssignSettings(dst, std::move(src));
-}
-

--- a/src/effects/VST3/VST3Instance.h
+++ b/src/effects/VST3/VST3Instance.h
@@ -74,6 +74,4 @@ public:
    unsigned GetAudioInCount() const override;
 
    void ReloadUserOptions();
-
-   void AssignSettings(EffectSettings& dst, EffectSettings&& src) const override;
 };

--- a/src/effects/VST3/VST3Wrapper.cpp
+++ b/src/effects/VST3/VST3Wrapper.cpp
@@ -806,15 +806,12 @@ void VST3Wrapper::SaveUserPreset(const EffectDefinitionInterface& effect, const 
       SetConfig(effect, PluginSettings::Private, name, parametersKey, ParametersToString(vst3settings.parameterChanges));
 }
 
-void VST3Wrapper::CopySettingsContents(const EffectSettings& src, EffectSettings& dst, SettingsCopyDirection copyDirection)
+void VST3Wrapper::CopySettingsContents(const EffectSettings& src, EffectSettings& dst)
 {
    auto& from = GetSettings(*const_cast<EffectSettings*>(&src));
    auto& to = GetSettings(dst);
 
    to.changesCounter = from.changesCounter;
-   if(copyDirection == SettingsCopyDirection::MainToWorker)
-   {
-      //Don't allocate in worker
-      std::swap(from.parameterChanges, to.parameterChanges);
-   }
+   //Don't allocate in worker
+   std::swap(from.parameterChanges, to.parameterChanges);
 }

--- a/src/effects/VST3/VST3Wrapper.cpp
+++ b/src/effects/VST3/VST3Wrapper.cpp
@@ -806,28 +806,6 @@ void VST3Wrapper::SaveUserPreset(const EffectDefinitionInterface& effect, const 
       SetConfig(effect, PluginSettings::Private, name, parametersKey, ParametersToString(vst3settings.parameterChanges));
 }
 
-void VST3Wrapper::AssignSettings(EffectSettings& dst, EffectSettings&& src) const
-{
-   if(!dst.has_value())
-      dst = src;
-
-   auto& from = GetSettings(src);
-   auto& to = GetSettings(dst);
-
-   //To avoid allocations we can't copy state part of settings
-   //in CopySettingsContents, so instead we recreate them with
-   //StoreSettings when the main thread performs reading.
-   if(from.changesCounter != to.changesCounter)
-   {
-      StoreSettings(dst);
-      to.changesCounter = from.changesCounter;
-      //We can't discard parameter changes as it's not guaranteed that
-      //::Process was called
-      to.parameterChanges = std::move(from.parameterChanges);
-   }
-   dst.extra = std::move(src.extra);
-}
-
 void VST3Wrapper::CopySettingsContents(const EffectSettings& src, EffectSettings& dst, SettingsCopyDirection copyDirection)
 {
    auto& from = GetSettings(*const_cast<EffectSettings*>(&src));

--- a/src/effects/VST3/VST3Wrapper.h
+++ b/src/effects/VST3/VST3Wrapper.h
@@ -110,8 +110,6 @@ public:
 
    Steinberg::int32 GetLatencySamples() const;
 
-   void AssignSettings(EffectSettings& dst, EffectSettings&& src) const;
-
    static EffectSettings MakeSettings();
 
    static void LoadSettings(const CommandParameters& parms, EffectSettings& settings);

--- a/src/effects/VST3/VST3Wrapper.h
+++ b/src/effects/VST3/VST3Wrapper.h
@@ -117,7 +117,7 @@ public:
    static void LoadUserPreset(const EffectDefinitionInterface& effect, const RegistryPath& name, EffectSettings& settings);
    static void SaveUserPreset(const EffectDefinitionInterface& effect, const RegistryPath& name, const EffectSettings& settings);
 
-   static void CopySettingsContents(const EffectSettings& src, EffectSettings& dst, SettingsCopyDirection copyDirection);
+   static void CopySettingsContents(const EffectSettings& src, EffectSettings& dst);
 
 private:
 

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -304,7 +304,7 @@ EffectSettings AudioUnitEffect::MakeSettings() const
 }
 
 bool AudioUnitEffect::CopySettingsContents(
-   const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection) const
+   const EffectSettings &src, EffectSettings &dst) const
 {
    auto &dstSettings = GetSettings(dst);
    auto &srcSettings = GetSettings(src);

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -69,7 +69,7 @@ public:
 
    EffectSettings MakeSettings() const override;
    bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection) const override;
+      const EffectSettings &src, EffectSettings &dst) const override;
 
    bool SaveSettings(
       const EffectSettings &settings, CommandParameters & parms) const override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -121,7 +121,7 @@ EffectSettings LadspaEffect::MakeSettings() const
 }
 
 bool LadspaEffect::CopySettingsContents(
-   const EffectSettings &src, EffectSettings &dst, SettingsCopyDirection copyDirection) const
+   const EffectSettings &src, EffectSettings &dst) const
 {
    // Do not use the copy constructor of std::vector.  Do an in-place rewrite
    // of the destination vector, which will not allocate memory if dstControls
@@ -140,8 +140,6 @@ bool LadspaEffect::CopySettingsContents(
    if (portValuesCount != portCount)
       return false;
 
-   const auto copyOutputs = copyDirection == SettingsCopyDirection::WorkerToMain;
-
    for (unsigned long p = 0; p < portCount; ++p)
    {
       LADSPA_PortDescriptor d = mData->PortDescriptors[p];
@@ -149,7 +147,7 @@ bool LadspaEffect::CopySettingsContents(
       if (!(LADSPA_IS_PORT_CONTROL(d)))
          continue;
 
-      if (LADSPA_IS_PORT_INPUT(d) || copyOutputs)
+      if (LADSPA_IS_PORT_INPUT(d))
          dstControls[p] = srcControls[p];
    }
 

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -75,8 +75,7 @@ public:
 
    EffectSettings MakeSettings() const override;
    bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst,
-      SettingsCopyDirection copyDirection) const override;
+      const EffectSettings &src, EffectSettings &dst) const override;
 
    std::unique_ptr<EffectOutputs> MakeOutputs() const override;
 

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -192,8 +192,7 @@ EffectSettings LV2Effect::MakeSettings() const
 }
 
 bool LV2Effect::CopySettingsContents(
-   const EffectSettings &src, EffectSettings &dst,
-   SettingsCopyDirection copyDirection) const
+   const EffectSettings &src, EffectSettings &dst) const
 {
    auto &srcControls = GetSettings(src).values;
    auto &dstControls = GetSettings(dst).values;
@@ -215,13 +214,11 @@ bool LV2Effect::CopySettingsContents(
    if (portValuesCount != portsCount)
       return false;
 
-   const auto copyOutputs = copyDirection == SettingsCopyDirection::WorkerToMain;
-   
    size_t portIndex {};
 
    for (auto& port : controlPorts)
    {
-      if (port->mIsInput || copyOutputs)
+      if (port->mIsInput)
          dstControls[portIndex] = srcControls[portIndex];
 
       ++portIndex;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -97,8 +97,7 @@ public:
 private:
    EffectSettings MakeSettings() const override;
    bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst,
-      SettingsCopyDirection copyDirection) const override;
+      const EffectSettings &src, EffectSettings &dst) const override;
 
    std::unique_ptr<EffectOutputs> MakeOutputs() const override;
 


### PR DESCRIPTION
Resolves: #3743

This redraft of #3744 makes even more simplifications of RealtimeEffectState::Access with another stronger assertion.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
