### PR TITLE
Effect message v2

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -154,7 +154,7 @@ bool EffectInstance::RealtimeResume()
    return true;
 }
 
-bool EffectInstance::RealtimeProcessStart(EffectSettings &)
+bool EffectInstance::RealtimeProcessStart(MessagePackage &)
 {
    return true;
 }

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -154,6 +154,11 @@ bool EffectInstance::RealtimeResume()
    return true;
 }
 
+auto EffectInstance::MakeMessage() const -> std::unique_ptr<Message>
+{
+   return nullptr;
+}
+
 bool EffectInstance::RealtimeProcessStart(MessagePackage &)
 {
    return true;

--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -21,12 +21,15 @@ SimpleEffectSettingsAccess::~SimpleEffectSettingsAccess() = default;
 
 EffectOutputs::~EffectOutputs() = default;
 
+EffectSettingsAccess::Message::~Message() = default;
+
 const EffectSettings &SimpleEffectSettingsAccess::Get()
 {
    return mSettings;
 }
 
-void SimpleEffectSettingsAccess::Set(EffectSettings &&settings)
+void SimpleEffectSettingsAccess::Set(EffectSettings &&settings,
+   std::unique_ptr<Message>)
 {
    mSettings = std::move(settings);
 }

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -474,12 +474,19 @@ public:
     */
    virtual bool RealtimeResume();
 
+   //! Type of messages to send from main thread to processing, which can
+   //! describe the transitions of settings (instead of their states)
+   using Message = EffectSettingsAccess::Message;
+
+   // TODO make it just an alias for Message *
+   struct MessagePackage { EffectSettings &settings; Message *pMessage{}; };
+
    //! settings are possibly changed, since last call, by an asynchronous dialog
    /*!
     @return success
     Default implementation does nothing, returns true
     */
-   virtual bool RealtimeProcessStart(EffectSettings &settings);
+   virtual bool RealtimeProcessStart(MessagePackage &package);
 
    /*!
     @return success

--- a/src/effects/DtmfGen.cpp
+++ b/src/effects/DtmfGen.cpp
@@ -459,6 +459,7 @@ bool EffectDtmf::Validator::ValidateUI()
       // recalculate to make sure all values are up-to-date. This is especially
       // important if the user did not change any values in the dialog
       dtmfSettings.Recalculate(settings);
+      return nullptr;
    });
 
    return true;
@@ -666,6 +667,7 @@ void EffectDtmf::Validator::OnSequence(wxCommandEvent & WXUNUSED(evt))
       auto &dtmfSettings = mSettings;
       dtmfSettings.dtmfSequence = mDtmfSequenceT->GetValue();
       dtmfSettings.Recalculate(settings);
+      return nullptr;
    });
    DoUpdateUI();
 }
@@ -677,6 +679,7 @@ void EffectDtmf::Validator::OnDuration(wxCommandEvent & WXUNUSED(evt))
       auto &effect = GetEffect();
       settings.extra.SetDuration(mDtmfDurationT->GetValue());
       dtmfSettings.Recalculate(settings);
+      return nullptr;
    });
    DoUpdateUI();
 }
@@ -687,6 +690,7 @@ void EffectDtmf::Validator::OnDutyCycle(wxCommandEvent & evt)
       auto &dtmfSettings = mSettings;
       dtmfSettings.dtmfDutyCycle = (double) evt.GetInt() / DutyCycle.scale;
       dtmfSettings.Recalculate(settings);
+      return nullptr;
    });
    DoUpdateUI();
 }

--- a/src/effects/Echo.cpp
+++ b/src/effects/Echo.cpp
@@ -236,6 +236,7 @@ bool EffectEcho::Validator::ValidateUI()
       // pass back the modified settings to the MessageBuffer
 
       EffectEcho::GetSettings(settings) = mSettings;
+      return nullptr;
    }
    );
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -883,6 +883,7 @@ bool DefaultEffectUIValidator::ValidateUI()
    bool result {};
    mAccess.ModifySettings([&](EffectSettings &settings){
       result = mEffect.ValidateUI(settings);
+      return nullptr;
    });
    return result;
 }

--- a/src/effects/EffectBase.cpp
+++ b/src/effects/EffectBase.cpp
@@ -139,6 +139,7 @@ bool EffectBase::DoEffect(EffectSettings &settings, double projectRate,
    auto updater = [&](EffectSettings &settings) {
       settings.extra.SetDuration(duration);
       settings.extra.SetDurationFormat( newFormat );
+      return nullptr;
    };
    // Update our copy of settings; update the EffectSettingsAccess too,
    // if we are going to show a dialog
@@ -469,6 +470,7 @@ void EffectBase::Preview(EffectSettingsAccess &access, bool dryOnly)
          // Preview of non-realtime effect
          auto pInstance = MakeInstance();
          success = pInstance && pInstance->Process(settings);
+         return nullptr;
       });
    }
 

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -28,10 +28,12 @@ public:
    {
       // Clean initial state of the counter
       state.mMainSettings.counter = 0;
-      Initialize(state.mMainSettings.settings, state.mMovedOutputs.get());
+      Initialize(state.mMainSettings.settings,
+         state.mMessage.get(), state.mMovedOutputs.get());
    }
 
    void Initialize(const EffectSettings &settings,
+      const EffectInstance::Message *,
       const EffectOutputs *pOutputs)
    {
       mLastSettings = { settings, 0 };

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -26,14 +26,14 @@ public:
       : mEffect{ effect }
       , mState{ state }
    {
+      // Clean initial state of the counter
+      state.mMainSettings.counter = 0;
       Initialize(state.mMainSettings, state.mMovedOutputs.get());
    }
 
    void Initialize(SettingsAndCounter &settings,
       const EffectOutputs *pOutputs)
    {
-      // Clean initial state of the counter
-      settings.counter = 0;
       mLastSettings = settings;
       // Initialize each message buffer with two copies of settings
       mChannelToMain.Write(ToMainSlot{ { 0,

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -401,7 +401,11 @@ bool RealtimeEffectState::ProcessStart(bool running)
       return false;
 
    // Assuming we are in a processing scope, use the worker settings
-   return pInstance->RealtimeProcessStart(mWorkerSettings.settings);
+   // TODO get a real message from WorkerRead
+   EffectInstance::MessagePackage package{
+      mWorkerSettings.settings, nullptr
+   };
+   return pInstance->RealtimeProcessStart(package);
 }
 
 #define stackAllocate(T, count) static_cast<T*>(alloca(count * sizeof(T)))

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -175,7 +175,7 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
       static EffectSettings empty;
       return empty;
    }
-   void Set(EffectSettings &&settings) override {
+   void Set(EffectSettings &&settings, std::unique_ptr<Message>) override {
       if (auto pState = mwState.lock())
          if (auto pAccessState = pState->GetAccessState()) {
             auto &lastSettings = pAccessState->mLastSettings;
@@ -515,6 +515,7 @@ void RealtimeEffectState::SetActive(bool active)
    auto access = GetAccess();
    access->ModifySettings([&](EffectSettings &settings) {
       settings.extra.SetActive(active);
+      return nullptr;
    });
    access->Flush();
 

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -28,14 +28,14 @@ public:
    {
       // Clean initial state of the counter
       state.mMainSettings.counter = 0;
-      Initialize(state.mMainSettings, state.mMovedOutputs.get());
+      Initialize(state.mMainSettings.settings, state.mMovedOutputs.get());
    }
 
-   void Initialize(SettingsAndCounter &settings,
+   void Initialize(const EffectSettings &settings,
       const EffectOutputs *pOutputs)
    {
-      mLastSettings = settings;
-      // Initialize each message buffer with two copies of settings
+      mLastSettings = { settings, 0 };
+      // Initialize each message buffer with two copies
       mChannelToMain.Write(ToMainSlot{ { 0,
          pOutputs ? pOutputs->Clone() : nullptr } });
       mChannelToMain.Write(ToMainSlot{ { 0,
@@ -103,9 +103,9 @@ public:
    struct FromMainSlot {
       // For initialization of the channel
       FromMainSlot() = default;
-      explicit FromMainSlot(const SettingsAndCounter &settings)
+      explicit FromMainSlot(const EffectSettings &settings)
          // Copy std::any
-         : mSettings{ settings }
+         : mSettings{ settings, 0 }
       {}
       FromMainSlot &operator=(FromMainSlot &&) = default;
 

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -264,6 +264,20 @@ const EffectInstanceFactory *RealtimeEffectState::GetEffect()
    return mPlugin;
 }
 
+std::shared_ptr<EffectInstance> RealtimeEffectState::MakeInstance()
+{
+   mMovedMessage.reset();
+   mMessage.reset();
+   auto result = mPlugin->MakeInstance();
+   if (result) {
+      // Allocate presized containers in messages, so later
+      // copies of contents might avoid free store operations
+      mMessage = result->MakeMessage();
+      mMovedMessage = result->MakeMessage();
+   }
+   return result;
+}
+
 std::shared_ptr<EffectInstance>
 RealtimeEffectState::EnsureInstance(double sampleRate)
 {
@@ -278,7 +292,7 @@ RealtimeEffectState::EnsureInstance(double sampleRate)
 
       //! If there was already an instance, recycle it; else make one here
       if (!pInstance)
-         mwInstance = pInstance = mPlugin->MakeInstance();
+         mwInstance = pInstance = MakeInstance();
       if (!pInstance)
          return {};
 
@@ -299,7 +313,7 @@ std::shared_ptr<EffectInstance> RealtimeEffectState::GetInstance()
    //! If there was already an instance, recycle it; else make one here
    auto pInstance = mwInstance.lock();
    if (!pInstance && mPlugin)
-      mwInstance = pInstance = mPlugin->MakeInstance();
+      mwInstance = pInstance = MakeInstance();
    return pInstance;
 }
 

--- a/src/effects/RealtimeEffectState.h
+++ b/src/effects/RealtimeEffectState.h
@@ -116,6 +116,7 @@ public:
 
 private:
 
+   std::shared_ptr<EffectInstance> MakeInstance();
    std::shared_ptr<EffectInstance> EnsureInstance(double rate);
 
    struct Access;
@@ -158,6 +159,7 @@ private:
 
    //! Updated immediately by Access::Set in the main thread
    NonInterfering<SettingsAndCounter> mMainSettings;
+   std::unique_ptr<EffectInstance::Message> mMessage;
    std::unique_ptr<EffectOutputs> mMovedOutputs;
 
    /*! @name Members that are changed also in the worker thread
@@ -167,6 +169,7 @@ private:
    //! Updated with delay, but atomically, in the worker thread; skipped by the
    //! copy constructor so that there isn't a race when pushing an Undo state
    NonInterfering<SettingsAndCounter> mWorkerSettings;
+   std::unique_ptr<EffectInstance::Message> mMovedMessage;
    std::unique_ptr<EffectOutputs> mOutputs;
 
    //! How many samples must be discarded

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -176,6 +176,7 @@ bool EffectReverb::Validator::ValidateUI()
          // pass back the modified settings to the MessageBuffer
 
          EffectReverb::GetSettings(settings) = mSettings;
+         return nullptr;
       }
    );
 

--- a/src/effects/StatefulEffectBase.cpp
+++ b/src/effects/StatefulEffectBase.cpp
@@ -79,9 +79,10 @@ bool StatefulEffectBase::Instance::RealtimeResume()
    return GetEffect().RealtimeResume();
 }
 
-bool StatefulEffectBase::Instance::RealtimeProcessStart(EffectSettings &settings)
+bool StatefulEffectBase::Instance::RealtimeProcessStart(
+   MessagePackage &package)
 {
-   return GetEffect().RealtimeProcessStart(settings);
+   return GetEffect().RealtimeProcessStart(package);
 }
 
 size_t StatefulEffectBase::Instance::RealtimeProcess(size_t group,
@@ -164,7 +165,7 @@ bool StatefulEffectBase::RealtimeResume()
    return true;
 }
 
-bool StatefulEffectBase::RealtimeProcessStart(EffectSettings &settings)
+bool StatefulEffectBase::RealtimeProcessStart(MessagePackage &)
 {
    return true;
 }

--- a/src/effects/StatefulEffectBase.h
+++ b/src/effects/StatefulEffectBase.h
@@ -40,7 +40,7 @@ public:
          unsigned numChannels, float sampleRate) override;
       bool RealtimeSuspend() override;
       bool RealtimeResume() override;
-      bool RealtimeProcessStart(EffectSettings &settings) override;
+      bool RealtimeProcessStart(MessagePackage &package) override;
       size_t RealtimeProcess(size_t group, EffectSettings &settings,
          const float *const *inBuf, float *const *outBuf, size_t numSamples)
       override;
@@ -91,11 +91,13 @@ public:
    */
    virtual bool RealtimeResume();
 
+   using MessagePackage = EffectInstance::MessagePackage;
+
    /*!
      @copydoc StatefulEffectBase::Instance::RealtimeProcessStart()
      Default implementation does nothing, returns true
    */
-   virtual bool RealtimeProcessStart(EffectSettings &settings);
+   virtual bool RealtimeProcessStart(MessagePackage &package);
 
    /*!
      @copydoc StatefulEffectBase::Instance::RealtimeProcess()

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1087,8 +1087,9 @@ bool VSTEffectInstance::RealtimeResume()
    return true;
 }
 
-bool VSTEffectInstance::RealtimeProcessStart(EffectSettings& settings)
+bool VSTEffectInstance::RealtimeProcessStart(MessagePackage& package)
 {
+   auto &settings = package.settings;
    {
       // If we assume that the user might be moving knobs during realtime processing and wants
       // to hear how the sound changes, we must protect mSettings from data races then

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -551,7 +551,7 @@ public:
    bool RealtimeFinalize(EffectSettings& settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() override;
-   bool RealtimeProcessStart(EffectSettings& settings) override;
+   bool RealtimeProcessStart(MessagePackage& package) override;
    size_t RealtimeProcess(size_t group, EffectSettings& settings,
       const float* const* inbuf, float* const* outbuf, size_t numSamples)
       override;

--- a/src/effects/VST3/VST3Instance.cpp
+++ b/src/effects/VST3/VST3Instance.cpp
@@ -109,8 +109,9 @@ bool VST3Instance::RealtimeProcessEnd(EffectSettings& settings) noexcept
    return true;
 }
 
-bool VST3Instance::RealtimeProcessStart(EffectSettings& settings)
+bool VST3Instance::RealtimeProcessStart(MessagePackage& package)
 {
+   auto &settings = package.settings;
    mWrapper->ProcessBlockStart(settings);
    for (auto &pProcessor : mProcessors)
       pProcessor->mWrapper->ProcessBlockStart(settings);

--- a/src/effects/VST3/VST3Instance.h
+++ b/src/effects/VST3/VST3Instance.h
@@ -52,10 +52,10 @@ public:
       unsigned numChannels, float sampleRate) override;
    bool RealtimeFinalize(EffectSettings& settings) noexcept override;
    bool RealtimeInitialize(EffectSettings& settings, double sampleRate) override;
+   bool RealtimeProcessStart(MessagePackage& package) override;
    size_t RealtimeProcess(size_t group, EffectSettings& settings, const float* const* inBuf, float* const* outBuf,
       size_t numSamples) override;
    bool RealtimeProcessEnd(EffectSettings& settings) noexcept override;
-   bool RealtimeProcessStart(EffectSettings& settings) override;
    bool RealtimeResume() override;
    bool RealtimeSuspend() override;
    SampleCount GetLatency(const EffectSettings& settings, double sampleRate)

--- a/src/effects/VST3/VST3UIValidator.cpp
+++ b/src/effects/VST3/VST3UIValidator.cpp
@@ -71,6 +71,7 @@ void VST3UIValidator::OnIdle(wxIdleEvent& evt)
       mAccess.ModifySettings([this](EffectSettings& settings)
       {
          mWrapper.FlushParameters(settings);
+         return nullptr;
       });
    }
 }
@@ -162,6 +163,7 @@ bool VST3UIValidator::ValidateUI()
          settings.extra.SetDuration(mDuration->GetValue());
       mWrapper.FlushParameters(settings);
       mWrapper.StoreSettings(settings);
+      return nullptr;
    });
 
    return true;
@@ -191,6 +193,7 @@ void VST3UIValidator::OnClose()
       //Flush changes if there is no processing performed at the moment
       mWrapper.FlushParameters(settings);
       mWrapper.StoreSettings(settings);
+      return nullptr;
    });
    //Make sure that new state has been written to the caches...
    mAccess.Flush();
@@ -200,7 +203,10 @@ void VST3UIValidator::OnClose()
 
 bool VST3UIValidator::UpdateUI()
 {
-   mAccess.ModifySettings([&](EffectSettings& settings) { mWrapper.FetchSettings(settings); });
+   mAccess.ModifySettings([&](EffectSettings& settings) {
+      mWrapper.FetchSettings(settings);
+      return nullptr;
+   });
    
    if (mPlainUI != nullptr)
       mPlainUI->ReloadParameters();

--- a/src/effects/VST3/VST3Wrapper.cpp
+++ b/src/effects/VST3/VST3Wrapper.cpp
@@ -283,6 +283,7 @@ public:
             auto& vst3settings = GetSettings(settings);
             vst3settings.parameterChanges[id] = valueNormalized;
             ++vst3settings.changesCounter;
+            return nullptr;
          });
       }
 

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -120,6 +120,7 @@ bool EffectWahwah::Validator::ValidateUI()
       {
          // pass back the modified settings to the MessageBuffer
          GetSettings(settings) = mSettings;
+         return nullptr;
       }
    );
 

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -245,8 +245,9 @@ bool AudioUnitInstance::RealtimeResume()
    return true;
 }
 
-bool AudioUnitInstance::RealtimeProcessStart(EffectSettings &settings)
+bool AudioUnitInstance::RealtimeProcessStart(MessagePackage &package)
 {
+   auto &settings = package.settings;
    auto &mySettings = GetSettings(settings);
    // Store only into the AudioUnit that was not also the source of the fetch
    // in the main thread.  Not only for efficiency, but also because controls

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -53,7 +53,7 @@ private:
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() override;
-   bool RealtimeProcessStart(EffectSettings &settings) override;
+   bool RealtimeProcessStart(MessagePackage &package) override;
    size_t RealtimeProcess(size_t group, EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)
       override;

--- a/src/effects/audiounits/AudioUnitValidator.cpp
+++ b/src/effects/audiounits/AudioUnitValidator.cpp
@@ -107,6 +107,7 @@ bool AudioUnitValidator::ValidateUI()
          settings.extra.SetDuration(mDuration->GetValue());
 #endif
       FetchSettingsFromInstance(settings);
+      return nullptr;
    });
    return true;
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1524,6 +1524,7 @@ bool LadspaEffect::Validator::ValidateUI()
       if (mType == EffectTypeGenerate)
          settings.extra.SetDuration(mDuration->GetValue());
       GetSettings(settings) = mSettings;
+      return nullptr;
    });
    return true;
 }

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -943,7 +943,7 @@ struct LadspaEffect::Instance
    override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() override;
-   bool RealtimeProcessStart(EffectSettings &settings) override;
+   bool RealtimeProcessStart(MessagePackage &package) override;
    size_t RealtimeProcess(size_t group, EffectSettings &settings,
       const float *const *inBuf, float *const *outBuf, size_t numSamples)
    override;
@@ -1082,7 +1082,7 @@ bool LadspaEffect::Instance::RealtimeResume()
    return true;
 }
 
-bool LadspaEffect::Instance::RealtimeProcessStart(EffectSettings &)
+bool LadspaEffect::Instance::RealtimeProcessStart(MessagePackage &)
 {
    return true;
 }

--- a/src/effects/lv2/LV2Instance.cpp
+++ b/src/effects/lv2/LV2Instance.cpp
@@ -201,7 +201,7 @@ bool LV2Instance::RealtimeResume()
    return true;
 }
 
-bool LV2Instance::RealtimeProcessStart(EffectSettings &)
+bool LV2Instance::RealtimeProcessStart(MessagePackage &)
 {
    mNumSamples = 0;
    for (auto & state : mPortStates.mAtomPortStates)

--- a/src/effects/lv2/LV2Instance.h
+++ b/src/effects/lv2/LV2Instance.h
@@ -66,7 +66,7 @@ public:
    bool RealtimeFinalize(EffectSettings &settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() override;
-   bool RealtimeProcessStart(EffectSettings &settings) override;
+   bool RealtimeProcessStart(MessagePackage &package) override;
    size_t RealtimeProcess(size_t group,  EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)
       override;

--- a/src/effects/lv2/LV2Validator.cpp
+++ b/src/effects/lv2/LV2Validator.cpp
@@ -138,6 +138,7 @@ bool LV2Validator::ValidateUI()
    mAccess.ModifySettings([&](EffectSettings &settings){
       if (mType == EffectTypeGenerate)
          settings.extra.SetDuration(mDuration->GetValue());
+      return nullptr;
    });
    return true;
 }
@@ -710,6 +711,7 @@ void LV2Validator::OnTrigger(wxCommandEvent &evt)
    auto & port = mPorts.mControlPorts[idx];
    mAccess.ModifySettings([&](EffectSettings &settings) {
       GetSettings(settings).values[idx] = port->mDef;
+      return nullptr;
    });
 }
 
@@ -718,6 +720,7 @@ void LV2Validator::OnToggle(wxCommandEvent &evt)
    size_t idx = evt.GetId() - ID_Toggles;
    mAccess.ModifySettings([&](EffectSettings &settings) {
       GetSettings(settings).values[idx] = evt.GetInt() ? 1.0 : 0.0;
+      return nullptr;
    });
 }
 
@@ -727,6 +730,7 @@ void LV2Validator::OnChoice(wxCommandEvent &evt)
    auto & port = mPorts.mControlPorts[idx];
    mAccess.ModifySettings([&](EffectSettings &settings) {
       GetSettings(settings).values[idx] = port->mScaleValues[evt.GetInt()];
+      return nullptr;
    });
 }
 
@@ -740,6 +744,7 @@ void LV2Validator::OnText(wxCommandEvent &evt)
       mAccess.ModifySettings([&](EffectSettings &settings) {
          GetSettings(settings).values[idx] =
             port->mSampleRate ? state.mTmp / mSampleRate : state.mTmp;
+         return nullptr;
       });
       SetSlider(state, ctrl);
    }
@@ -762,6 +767,7 @@ void LV2Validator::OnSlider(wxCommandEvent &evt)
    mAccess.ModifySettings([&](EffectSettings &settings) {
       GetSettings(settings).values[idx] =
          port->mSampleRate ? state.mTmp / mSampleRate : state.mTmp;
+      return nullptr;
    });
    mPlainUIControls[idx].mText->GetValidator()->TransferToWindow();
 }
@@ -933,6 +939,7 @@ void LV2Validator::suil_port_write(uint32_t port_index,
          mAccess.ModifySettings([&](EffectSettings &settings){
             GetSettings(settings).values[it->second] =
                *static_cast<const float *>(buffer);
+            return nullptr;
          });
    }
    // Handle event transfers

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1122,6 +1122,7 @@ int NyquistEffect::ShowHostInterface(
          nyquistSettings.proxySettings = std::move(newSettings);
          nyquistSettings.proxyDebug = this->mDebug;
          nyquistSettings.controls = move(effect.mControls);
+         return nullptr;
       });
    }
    if (!pNewInstance)


### PR DESCRIPTION
Resolves: #3745

This redraft of #3746 does not use std::any to implement Message and does not require an EffectInstance to to its copy and merge.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
