### PR TITLE
Fix dependency cycle

### DIFF
--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -52,6 +52,7 @@ Paul Licameli split from AudacityProject.cpp
 #include <wx/app.h>
 #include <wx/scrolbar.h>
 #include <wx/sizer.h>
+#include <wx/splitter.h>
 
 #ifdef __WXGTK__
 #include "../images/AudacityLogoAlpha.xpm"

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -37,7 +37,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "widgets/WindowAccessible.h"
 
 #include "ThemedWrappers.h"
-#include "RealtimeEffectPanel.h"
 
 #include <wx/app.h>
 #include <wx/display.h>
@@ -1245,11 +1244,6 @@ bool ProjectWindow::IsIconized() const
    return mIconized;
 }
 
-RealtimeEffectPanel &ProjectWindow::GetEffectsWindow() noexcept
-{
-   return RealtimeEffectPanel::Get(mProject);
-}
-
 wxWindow* ProjectWindow::GetTrackListWindow() noexcept
 {
    return mTrackListWindow;
@@ -1889,21 +1883,6 @@ void ProjectWindow::DoZoomFit()
 
    window.Zoom( window.GetZoomOfToFit() );
    window.TP_ScrollWindow(start);
-}
-
-void ProjectWindow::HideEffectsPanel()
-{
-   wxWindowUpdateLocker freeze(this);
-
-   auto &effectsWindow = GetEffectsWindow();
-   if(mContainerWindow->GetWindow2() == nullptr)
-      //only effects panel is present, restore split positions before removing effects panel
-      //Workaround: ::Replace and ::Initialize do not work here...
-      mContainerWindow->SplitVertically(&effectsWindow, mTrackListWindow);
-
-   mContainerWindow->Unsplit(&effectsWindow);
-   mTrackListWindow->SetFocus();
-   Layout();
 }
 
 static ToolManager::TopPanelHook::Scope scope {

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -688,17 +688,6 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
 
    mThemeChangeSubscription =
       theTheme.Subscribe(*this, &ProjectWindow::OnThemeChange);
-
-   mFocusChangeSubscription = TrackFocus::Get(project)
-      .Subscribe([this](const TrackFocusChangeMessage& msg) {
-         if(GetEffectsWindow().IsShown())
-         {
-            auto& project = GetProject();
-            auto& trackFocus = TrackFocus::Get(project);
-            ShowEffectsPanel(trackFocus.Get(), false);
-         }
-      });
-
 }
 
 ProjectWindow::~ProjectWindow()
@@ -1266,7 +1255,7 @@ wxWindow* ProjectWindow::GetTrackListWindow() noexcept
    return mTrackListWindow;
 }
 
-wxWindow* ProjectWindow::GetContainerWindow() noexcept
+wxSplitterWindow* ProjectWindow::GetContainerWindow() noexcept
 {
    return mContainerWindow;
 }
@@ -1900,32 +1889,6 @@ void ProjectWindow::DoZoomFit()
 
    window.Zoom( window.GetZoomOfToFit() );
    window.TP_ScrollWindow(start);
-}
-
-void ProjectWindow::ShowEffectsPanel(Track* track, bool focus)
-{
-   auto &effectsWindow = GetEffectsWindow();
-   if(track == nullptr)
-   {
-      effectsWindow.ResetTrack();
-      return;
-   }
-
-   wxWindowUpdateLocker freeze(this);
-
-   effectsWindow.SetTrack(track->shared_from_this());
-
-   if(mContainerWindow->GetWindow1() != &effectsWindow)
-   {
-      //Restore previous effects window size
-      mContainerWindow->SplitVertically(
-         &effectsWindow,
-         mTrackListWindow,
-         effectsWindow.GetSize().GetWidth());
-   }
-   if(focus)
-      effectsWindow.SetFocus();
-   Layout();
 }
 
 void ProjectWindow::HideEffectsPanel()

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -78,7 +78,7 @@ public:
     * track list windows
     * \return Pointer to a container window (not null)
     */
-   wxWindow* GetContainerWindow() noexcept;
+   wxSplitterWindow* GetContainerWindow() noexcept;
    /**
     * \brief Top panel contains project-related controls and tools.
     * \return Pointer to a top panel window (not null)
@@ -135,7 +135,6 @@ public:
    double GetZoomOfToFit() const;
    void DoZoomFit();
    
-   void ShowEffectsPanel(Track* track = nullptr, bool focus = false);
    void HideEffectsPanel();
 
    void ApplyUpdatedTheme();
@@ -237,8 +236,6 @@ private:
    Observer::Subscription mUndoSubscription
       , mThemeChangeSubscription;
    std::unique_ptr<PlaybackScroller> mPlaybackScroller;
-
-   Observer::Subscription mFocusChangeSubscription;
 
    DECLARE_EVENT_TABLE()
 };

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -64,10 +64,6 @@ public:
 
    void Reset();
 
-private:
-   RealtimeEffectPanel &GetEffectsWindow() noexcept;
-
-public:
    /**
     * \brief Track list window is the parent container for TrackPanel
     * \return Pointer to a track list window (not null)
@@ -135,8 +131,6 @@ public:
    double GetZoomOfToFit() const;
    void DoZoomFit();
    
-   void HideEffectsPanel();
-
    void ApplyUpdatedTheme();
 
    // Scrollbars

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -64,12 +64,10 @@ public:
 
    void Reset();
 
-   /**
-    * \brief Effect window contains list off effects assigned to
-    * a selected track.
-    * \return Pointer to an effects side-panel window (not null)
-    */
-   wxWindow* GetEffectsWindow() noexcept;
+private:
+   RealtimeEffectPanel &GetEffectsWindow() noexcept;
+
+public:
    /**
     * \brief Track list window is the parent container for TrackPanel
     * \return Pointer to a track list window (not null)
@@ -139,7 +137,6 @@ public:
    
    void ShowEffectsPanel(Track* track = nullptr, bool focus = false);
    void HideEffectsPanel();
-   bool IsEffectsPanelShown();
 
    void ApplyUpdatedTheme();
 
@@ -219,7 +216,6 @@ private:
 
    wxPanel *mTopPanel{};
    wxSplitterWindow* mContainerWindow;
-   RealtimeEffectPanel* mEffectsWindow{};
    wxWindow* mTrackListWindow{};
    
    wxScrollBar *mHsbar{};

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -52,6 +52,9 @@ class RealtimeEffectPanel : public wxPanel
    std::unique_ptr<PrefsListenerHelper> mPrefsListenerHelper;
 
 public:
+   static RealtimeEffectPanel &Get(AudacityProject &project);
+   static const RealtimeEffectPanel &Get(const AudacityProject &project);
+
    RealtimeEffectPanel(
       AudacityProject& project, wxWindow* parent,
                 wxWindowID id,

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -43,6 +43,7 @@ class RealtimeEffectPanel : public wxPanel
 
    Observer::Subscription mTrackListChanged;
    Observer::Subscription mUndoSubscription;
+   Observer::Subscription mFocusChangeSubscription;
 
    std::vector<std::shared_ptr<Track>> mPotentiallyRemovedTracks;
 
@@ -64,6 +65,8 @@ public:
                 const wxString& name = wxPanelNameStr);
 
    ~RealtimeEffectPanel() override;
+
+   void ShowPanel(Track* track, bool focus);
 
    /**
     * \brief Shows effects from the effect stack of the track

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -67,6 +67,7 @@ public:
    ~RealtimeEffectPanel() override;
 
    void ShowPanel(Track* track, bool focus);
+   void HidePanel();
 
    /**
     * \brief Shows effects from the effect stack of the track

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -6,6 +6,7 @@
 #include "ProjectHistory.h"
 #include "../ProjectWindow.h"
 #include "../ProjectWindows.h"
+#include "../RealtimeEffectPanel.h"
 #include "Track.h"
 #include "../SelectionState.h"
 #include "../TrackPanel.h"
@@ -35,7 +36,7 @@ void NextOrPrevFrame(AudacityProject &project, bool forward)
    if(!ToolManager::Get(project).GetTopDock()->GetChildren().IsEmpty())
       seq.push_back(ProjectWindow::Get( project ).GetTopPanel());
    seq.push_back(&TrackPanel::Get( project ));
-   seq.push_back(ProjectWindow::Get(project).GetEffectsWindow());
+   seq.push_back(&RealtimeEffectPanel::Get(project));
    if(!ToolManager::Get( project ).GetBotDock()->GetChildren().IsEmpty())
       seq.push_back(ToolManager::Get( project ).GetBotDock());
 

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -14,6 +14,7 @@
 #include "../ProjectWindow.h"
 #include "../ProjectWindows.h"
 #include "../ProjectSelectionManager.h"
+#include "RealtimeEffectPanel.h"
 #include "../toolbars/ToolManager.h"
 #include "../Screenshot.h"
 #include "../TrackPanelAx.h"
@@ -434,7 +435,7 @@ void DoManageRealtimeEffectsSidePanel(AudacityProject &project)
    auto &trackFocus = TrackFocus::Get(project);
    auto &projectWindow = ProjectWindow::Get(project);
 
-   if (projectWindow.IsEffectsPanelShown())
+   if (RealtimeEffectPanel::Get(project).IsShown())
       projectWindow.HideEffectsPanel();
    else
       projectWindow.ShowEffectsPanel(trackFocus.Get(), true);

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -435,10 +435,11 @@ void DoManageRealtimeEffectsSidePanel(AudacityProject &project)
    auto &trackFocus = TrackFocus::Get(project);
    auto &projectWindow = ProjectWindow::Get(project);
 
-   if (RealtimeEffectPanel::Get(project).IsShown())
+   auto &panel = RealtimeEffectPanel::Get(project);
+   if (panel.IsShown())
       projectWindow.HideEffectsPanel();
    else
-      projectWindow.ShowEffectsPanel(trackFocus.Get(), true);
+      panel.ShowPanel(trackFocus.Get(), true);
 }
 
 bool CompareEffectsByName(const PluginDescriptor *a, const PluginDescriptor *b)

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -433,11 +433,9 @@ void DoManagePluginsMenu(AudacityProject &project)
 void DoManageRealtimeEffectsSidePanel(AudacityProject &project)
 {
    auto &trackFocus = TrackFocus::Get(project);
-   auto &projectWindow = ProjectWindow::Get(project);
-
    auto &panel = RealtimeEffectPanel::Get(project);
    if (panel.IsShown())
-      projectWindow.HideEffectsPanel();
+      panel.HidePanel();
    else
       panel.ShowPanel(trackFocus.Get(), true);
 }

--- a/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
@@ -16,6 +16,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "Project.h"
 #include "../../../ProjectSettings.h"
 #include "../../../RefreshCode.h"
+#include "../../../RealtimeEffectPanel.h"
 #include "Track.h"
 #include "../../../TrackPanelAx.h"
 #include "../../../TrackInfo.h"
@@ -24,7 +25,6 @@ Paul Licameli split from TrackPanel.cpp
 
 #include <wx/window.h>
 
-#include "ProjectWindow.h"
 MuteButtonHandle::MuteButtonHandle
 ( const std::shared_ptr<Track> &pTrack, const wxRect &rect )
    : ButtonHandle{ pTrack, rect }
@@ -150,7 +150,7 @@ EffectsButtonHandle::~EffectsButtonHandle()
 UIHandle::Result EffectsButtonHandle::CommitChanges
 (const wxMouseEvent &event, AudacityProject *pProject, wxWindow *pParent)
 {
-   ProjectWindow::Get(*pProject).ShowEffectsPanel(mpTrack.lock().get(), true);
+   RealtimeEffectPanel::Get(*pProject).ShowPanel(mpTrack.lock().get(), true);
    return RefreshCode::RefreshNone;
 }
 


### PR DESCRIPTION
Resolves: #3803

Invert dependency of ProjectWindow on RealtimeEffectPanel, breaking a cycle.

Dependencies on RealtimeEffectPanel are added in some src/menus files but that is acceptably acyclic.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
