### PR TITLE
More effect messages

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -354,16 +354,21 @@ public:
    virtual RegistryPaths GetFactoryPresets() const = 0;
 
    //! Change settings to a user-named preset
-   virtual bool LoadUserPreset(
+   //! @return nullopt for failure
+   [[nodiscard]] virtual OptionalMessage LoadUserPreset(
       const RegistryPath & name, EffectSettings &settings) const = 0;
    //! Save settings in the configuration file as a user-named preset
    virtual bool SaveUserPreset(
       const RegistryPath & name, const EffectSettings &settings) const = 0;
 
    //! Change settings to the preset whose name is `GetFactoryPresets()[id]`
-   virtual bool LoadFactoryPreset(int id, EffectSettings &settings) const = 0;
+   //! @return nullopt for failure
+   [[nodiscard]] virtual OptionalMessage LoadFactoryPreset(
+      int id, EffectSettings &settings) const = 0;
    //! Change settings back to "factory default"
-   virtual bool LoadFactoryDefaults(EffectSettings &settings) const = 0;
+   //! @return nullopt for failure
+   [[nodiscard]] virtual OptionalMessage LoadFactoryDefaults(
+      EffectSettings &settings) const = 0;
    //! @}
 
    //! Visit settings (and maybe change them), if defined.

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -48,6 +48,7 @@
 
 #include "TypedAny.h"
 #include <memory>
+#include <optional>
 #include <type_traits>
 #include <wx/event.h>
 
@@ -286,6 +287,9 @@ public:
    //! Default is false
    virtual bool IsHiddenFromMenus() const;
 };
+
+using OptionalMessage =
+   std::optional<std::unique_ptr<EffectSettingsAccess::Message>>;
 
 /*************************************************************************************//**
 
@@ -721,7 +725,9 @@ public:
 
    virtual bool CanExportPresets() = 0;
    virtual void ExportPresets(const EffectSettings &settings) const = 0;
-   virtual void ImportPresets(EffectSettings &settings) = 0;
+   //! @return nullopt for failure
+   [[nodiscard]] virtual OptionalMessage
+      ImportPresets(EffectSettings &settings) = 0;
 
    virtual bool HasOptions() = 0;
    virtual void ShowOptions() = 0;

--- a/src/EffectPlugin.h
+++ b/src/EffectPlugin.h
@@ -95,7 +95,8 @@ public:
    virtual void Preview(EffectSettingsAccess &access, bool dryOnly) = 0;
    virtual bool SaveSettingsAsString(
       const EffectSettings &settings, wxString & parms) const = 0;
-   virtual bool LoadSettingsFromString(
+   // @return nullptr for failure
+   [[nodiscard]] virtual OptionalMessage LoadSettingsFromString(
       const wxString & parms, EffectSettings &settings) const = 0;
    virtual bool IsBatchProcessing() const = 0;
    virtual void SetBatchProcessing() = 0;

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -150,13 +150,14 @@ size_t EffectAmplify::ProcessBlock(EffectSettings &,
    return blockLen;
 }
 
-bool EffectAmplify::LoadFactoryDefaults(EffectSettings &) const
+OptionalMessage
+EffectAmplify::LoadFactoryDefaults(EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
-   return const_cast<EffectAmplify&>(*this).DoLoadFactoryDefaults();
+   return const_cast<EffectAmplify&>(*this).DoLoadFactoryDefaults(settings);
 }
 
-bool EffectAmplify::DoLoadFactoryDefaults()
+OptionalMessage EffectAmplify::DoLoadFactoryDefaults(EffectSettings &settings)
 {
    Init();
 
@@ -173,7 +174,7 @@ bool EffectAmplify::DoLoadFactoryDefaults()
    mCanClip = false;
 
    ClampRatio();
-   return true;
+   return Effect::LoadFactoryDefaults(settings);
 }
 
 // Effect implementation

--- a/src/effects/Amplify.h
+++ b/src/effects/Amplify.h
@@ -43,8 +43,9 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool LoadFactoryDefaults(EffectSettings &settings) const override;
-   bool DoLoadFactoryDefaults();
+   OptionalMessage LoadFactoryDefaults(EffectSettings &settings)
+      const override;
+   OptionalMessage DoLoadFactoryDefaults(EffectSettings &settings);
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -170,13 +170,14 @@ EffectType EffectChangePitch::GetType() const
    return EffectTypeProcess;
 }
 
-bool EffectChangePitch::LoadFactoryDefaults(EffectSettings &settings) const
+OptionalMessage EffectChangePitch::LoadFactoryDefaults(EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
    return const_cast<EffectChangePitch&>(*this).DoLoadFactoryDefaults(settings);
 }
 
-bool EffectChangePitch::DoLoadFactoryDefaults(EffectSettings &settings)
+OptionalMessage
+EffectChangePitch::DoLoadFactoryDefaults(EffectSettings &settings)
 {
    DeduceFrequencies();
 

--- a/src/effects/ChangePitch.h
+++ b/src/effects/ChangePitch.h
@@ -54,8 +54,9 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool LoadFactoryDefaults(EffectSettings &settings) const override;
-   bool DoLoadFactoryDefaults(EffectSettings &settings);
+   OptionalMessage LoadFactoryDefaults(EffectSettings &settings)
+      const override;
+   OptionalMessage DoLoadFactoryDefaults(EffectSettings &settings);
 
    bool Process(EffectInstance &instance, EffectSettings &settings) override;
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -139,13 +139,14 @@ EffectType EffectChangeSpeed::GetType() const
    return EffectTypeProcess;
 }
 
-bool EffectChangeSpeed::LoadFactoryDefaults(EffectSettings &settings) const
+OptionalMessage EffectChangeSpeed::LoadFactoryDefaults(EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
    return const_cast<EffectChangeSpeed&>(*this).DoLoadFactoryDefaults(settings);
 }
 
-bool EffectChangeSpeed::DoLoadFactoryDefaults(EffectSettings &settings)
+OptionalMessage
+EffectChangeSpeed::DoLoadFactoryDefaults(EffectSettings &settings)
 {
    mFromVinyl = kVinyl_33AndAThird;
    mFormat = NumericConverter::DefaultSelectionFormat();

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -41,8 +41,9 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool LoadFactoryDefaults(EffectSettings &settings) const override;
-   bool DoLoadFactoryDefaults(EffectSettings &settings);
+   OptionalMessage LoadFactoryDefaults(EffectSettings &settings)
+      const override;
+   OptionalMessage DoLoadFactoryDefaults(EffectSettings &settings);
 
    bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
    double CalcPreviewInputLength(

--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -262,23 +262,24 @@ RegistryPaths EffectDistortion::GetFactoryPresets() const
    return names;
 }
 
-bool EffectDistortion::LoadFactoryPreset(int id, EffectSettings &) const
+OptionalMessage
+EffectDistortion::LoadFactoryPreset(int id, EffectSettings &) const
 {
    // To do: externalize state so const_cast isn't needed
    return const_cast<EffectDistortion*>(this)->DoLoadFactoryPreset(id);
 }
 
-bool EffectDistortion::DoLoadFactoryPreset(int id)
+OptionalMessage EffectDistortion::DoLoadFactoryPreset(int id)
 {
    if (id < 0 || id >= (int) WXSIZEOF(FactoryPresets))
    {
-      return false;
+      return {};
    }
 
    mParams = FactoryPresets[id].params;
    mThreshold = DB_TO_LINEAR(mParams.mThreshold_dB);
 
-   return true;
+   return { nullptr };
 }
 
 

--- a/src/effects/Distortion.h
+++ b/src/effects/Distortion.h
@@ -77,8 +77,9 @@ public:
    EffectType GetType() const override;
    RealtimeSince RealtimeSupport() const override;
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
-   bool DoLoadFactoryPreset(int id);
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
+   OptionalMessage DoLoadFactoryPreset(int id);
 
    unsigned GetAudioInCount() const override;
    unsigned GetAudioOutCount() const override;

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -235,7 +235,7 @@ bool Effect::LoadSettings(
    return Parameters().Set( *const_cast<Effect*>(this), parms, settings );
 }
 
-bool Effect::LoadUserPreset(
+OptionalMessage Effect::LoadUserPreset(
    const RegistryPath & name, EffectSettings &settings) const
 {
    // Find one string in the registry and then reinterpret it
@@ -243,7 +243,7 @@ bool Effect::LoadUserPreset(
    wxString parms;
    if (!GetConfig(GetDefinition(), PluginSettings::Private,
       name, wxT("Parameters"), parms))
-      return false;
+      return {};
 
    return LoadSettingsFromString(parms, settings);
 }
@@ -265,12 +265,12 @@ RegistryPaths Effect::GetFactoryPresets() const
    return {};
 }
 
-bool Effect::LoadFactoryPreset(int id, EffectSettings &settings) const
+OptionalMessage Effect::LoadFactoryPreset(int id, EffectSettings &settings) const
 {
-   return true;
+   return { nullptr };
 }
 
-bool Effect::LoadFactoryDefaults(EffectSettings &settings) const
+OptionalMessage Effect::LoadFactoryDefaults(EffectSettings &settings) const
 {
    return LoadUserPreset(FactoryDefaultsGroup(), settings);
 }
@@ -399,6 +399,8 @@ OptionalMessage Effect::ImportPresets(EffectSettings &settings)
    if (!f.IsOpened())
       return {};
 
+   OptionalMessage result{};
+
    if (f.ReadAll(&params)) {
       wxString ident = params.BeforeFirst(':');
       params = params.AfterFirst(':');
@@ -424,13 +426,12 @@ OptionalMessage Effect::ImportPresets(EffectSettings &settings)
          }
          return {};
       }
-      if (!LoadSettingsFromString(params, settings))
-         return {};
+      result = LoadSettingsFromString(params, settings);
    }
 
    //SetWindowTitle();
 
-   return { nullptr };
+   return result;
 }
 
 bool Effect::HasOptions()
@@ -481,7 +482,7 @@ bool Effect::SaveSettingsAsString(
    return eap.GetParameters(parms);
 }
 
-bool Effect::LoadSettingsFromString(
+OptionalMessage Effect::LoadSettingsFromString(
    const wxString & parms, EffectSettings &settings) const
 {
    // If the string starts with one of certain significant substrings,
@@ -491,28 +492,28 @@ bool Effect::LoadSettingsFromString(
    // ultimately the uses of it by EffectManager::GetPreset, which is used by
    // the macro management dialog)
    wxString preset = parms;
-   bool success = false;
+   OptionalMessage result;
    if (preset.StartsWith(kUserPresetIdent))
    {
       preset.Replace(kUserPresetIdent, wxEmptyString, false);
-      success = LoadUserPreset(UserPresetsGroup(preset), settings);
+      result = LoadUserPreset(UserPresetsGroup(preset), settings);
    }
    else if (preset.StartsWith(kFactoryPresetIdent))
    {
       preset.Replace(kFactoryPresetIdent, wxEmptyString, false);
       auto presets = GetFactoryPresets();
-      success = LoadFactoryPreset(
+      result = LoadFactoryPreset(
          make_iterator_range( presets ).index( preset ), settings );
    }
    else if (preset.StartsWith(kCurrentSettingsIdent))
    {
       preset.Replace(kCurrentSettingsIdent, wxEmptyString, false);
-      success = LoadUserPreset(CurrentSettingsGroup(), settings);
+      result = LoadUserPreset(CurrentSettingsGroup(), settings);
    }
    else if (preset.StartsWith(kFactoryDefaultsIdent))
    {
       preset.Replace(kFactoryDefaultsIdent, wxEmptyString, false);
-      success = LoadUserPreset(FactoryDefaultsGroup(), settings);
+      result = LoadUserPreset(FactoryDefaultsGroup(), settings);
    }
    else
    {
@@ -525,28 +526,30 @@ bool Effect::LoadSettingsFromString(
       S.SetForValidating( &eap );
       // VisitSettings returns false if not defined for this effect.
       // To do: fix const_cast in use of VisitSettings
-      if ( !const_cast<Effect*>(this)->VisitSettings(S, settings) )
+      if ( !const_cast<Effect*>(this)->VisitSettings(S, settings) ) {
          // the old method...
-         success = LoadSettings(eap, settings);
+         if (LoadSettings(eap, settings))
+            return { nullptr };
+      }
       else if( !S.bOK )
-         success = false;
+         result = {};
       else{
-         success = true;
+         result = { nullptr };
          S.SetForWriting( &eap );
          const_cast<Effect*>(this)->VisitSettings(S, settings);
       }
    }
 
-   if (!success)
+   if (!result)
    {
       Effect::MessageBox(
          XO("%s: Could not load settings below. Default settings will be used.\n\n%s")
             .Format( GetName(), preset ) );
       // We are using default settings and we still wish to continue.
-      return true;
+      result = { nullptr };
       //return false;
    }
-   return true;
+   return result;
 }
 
 unsigned Effect::TestUIFlags(unsigned mask) {
@@ -576,7 +579,8 @@ void Effect::UnsetBatchProcessing()
    // If effect is not stateful, this call doesn't really matter, and the
    // settings object is a dummy
    auto dummySettings = MakeSettings();
-   LoadUserPreset(GetSavedStateGroup(), dummySettings);
+   // Ignore failure
+   (void ) LoadUserPreset(GetSavedStateGroup(), dummySettings);
 }
 
 bool Effect::Delegate(Effect &delegate, EffectSettings &settings)

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -105,14 +105,16 @@ class AUDACITY_DLL_API Effect /* not final */
    bool LoadSettings(
       const CommandParameters & parms, EffectSettings &settings) const override;
 
-   bool LoadUserPreset(
+   OptionalMessage LoadUserPreset(
       const RegistryPath & name, EffectSettings &settings) const override;
    bool SaveUserPreset(
       const RegistryPath & name, const EffectSettings &settings) const override;
 
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
-   bool LoadFactoryDefaults(EffectSettings &settings) const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
+   OptionalMessage LoadFactoryDefaults(EffectSettings &settings)
+      const override;
 
    // VisitSettings(), SaveSettings(), and LoadSettings()
    // use the functions of EffectParameterMethods.  By default, this function
@@ -154,7 +156,7 @@ class AUDACITY_DLL_API Effect /* not final */
       bool forceModal = false) override;
    bool SaveSettingsAsString(
       const EffectSettings &settings, wxString & parms) const override;
-   bool LoadSettingsFromString(
+   [[nodiscard]] OptionalMessage LoadSettingsFromString(
       const wxString & parms, EffectSettings &settings) const override;
    bool IsBatchProcessing() const override;
    void SetBatchProcessing() override;

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -136,7 +136,7 @@ class AUDACITY_DLL_API Effect /* not final */
 
    bool CanExportPresets() override;
    void ExportPresets(const EffectSettings &settings) const override;
-   void ImportPresets(EffectSettings &settings) override;
+   OptionalMessage ImportPresets(EffectSettings &settings) override;
 
    bool HasOptions() override;
    void ShowOptions() override;

--- a/src/effects/EffectManager.cpp
+++ b/src/effects/EffectManager.cpp
@@ -300,10 +300,10 @@ bool EffectManager::SetEffectParameters(
       if (eap.HasEntry(wxT("Use Preset")))
       {
          return effect->LoadSettingsFromString(
-            eap.Read(wxT("Use Preset")), settings);
+            eap.Read(wxT("Use Preset")), settings).has_value();
       }
 
-      return effect->LoadSettingsFromString(params, settings);
+      return effect->LoadSettingsFromString(params, settings).has_value();
    }
    AudacityCommand *command = GetAudacityCommand(ID);
    
@@ -816,7 +816,8 @@ void InitializePreset(
       SetConfig(manager, PluginSettings::Private, FactoryDefaultsGroup(),
          InitializedKey, true);
    }
-   manager.LoadUserPreset(CurrentSettingsGroup(), settings);
+   // ignore failure
+   (void) manager.LoadUserPreset(CurrentSettingsGroup(), settings);
 }
 
 std::pair<ComponentInterface *, EffectSettings>

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -597,9 +597,9 @@ void EffectUIHost::DoCancel()
          // For the destructive effect dialog only
          // Restore effect state from last updated preferences
          mpAccess->ModifySettings([&](EffectSettings &settings) {
-            mEffectUIHost.GetDefinition()
-              .LoadUserPreset(CurrentSettingsGroup(), settings);
-            return nullptr;
+            // ignore failure
+            return mEffectUIHost.GetDefinition().LoadUserPreset(
+               CurrentSettingsGroup(), settings).value_or(nullptr);
          });
       }
       if (IsModal())
@@ -822,9 +822,9 @@ void EffectUIHost::OnUserPreset(wxCommandEvent & evt)
    int preset = evt.GetId() - kUserPresetsID;
    
    mpAccess->ModifySettings([&](EffectSettings &settings){
-      mEffectUIHost.GetDefinition()
-         .LoadUserPreset(UserPresetsGroup(mUserPresets[preset]), settings);
-      return nullptr;
+      // ignore failure
+      return mEffectUIHost.GetDefinition().LoadUserPreset(
+         UserPresetsGroup(mUserPresets[preset]), settings).value_or(nullptr);
    });
    TransferDataToWindow();
    return;
@@ -833,9 +833,9 @@ void EffectUIHost::OnUserPreset(wxCommandEvent & evt)
 void EffectUIHost::OnFactoryPreset(wxCommandEvent & evt)
 {
    mpAccess->ModifySettings([&](EffectSettings &settings){
-      mEffectUIHost.GetDefinition()
-         .LoadFactoryPreset(evt.GetId() - kFactoryPresetsID, settings);
-      return nullptr;
+      //! ignore failure
+      return mEffectUIHost.GetDefinition().LoadFactoryPreset(
+         evt.GetId() - kFactoryPresetsID, settings).value_or(nullptr);
    });
    TransferDataToWindow();
    return;
@@ -972,8 +972,9 @@ void EffectUIHost::OnOptions(wxCommandEvent & WXUNUSED(evt))
 void EffectUIHost::OnDefaults(wxCommandEvent & WXUNUSED(evt))
 {
    mpAccess->ModifySettings([&](EffectSettings &settings){
-      mEffectUIHost.GetDefinition().LoadFactoryDefaults(settings);
-      return nullptr;
+      // ignore failure
+      return mEffectUIHost.GetDefinition().LoadFactoryDefaults(settings)
+         .value_or(nullptr);
    });
    TransferDataToWindow();
    return;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -943,8 +943,8 @@ void EffectUIHost::OnSaveAs(wxCommandEvent & WXUNUSED(evt))
 void EffectUIHost::OnImport(wxCommandEvent & WXUNUSED(evt))
 {
    mpAccess->ModifySettings([&](EffectSettings &settings){
-      mClient.ImportPresets(settings);
-      return nullptr;
+      // ignore failure
+      return mClient.ImportPresets(settings).value_or(nullptr);
    });
    TransferDataToWindow();
    LoadUserPresets();

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -422,13 +422,17 @@ bool EffectEqualization::VisitSettings(
    return true;
 }
 
-bool EffectEqualization::LoadFactoryDefaults(EffectSettings &settings) const
+OptionalMessage
+EffectEqualization::LoadFactoryDefaults(EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
-   return const_cast<EffectEqualization&>(*this).DoLoadFactoryDefaults(settings);
+   if (!const_cast<EffectEqualization&>(*this).DoLoadFactoryDefaults(settings))
+      return {};
+   return { nullptr };
 }
 
-bool EffectEqualization::DoLoadFactoryDefaults(EffectSettings &settings)
+OptionalMessage
+EffectEqualization::DoLoadFactoryDefaults(EffectSettings &settings)
 {
    mdBMin = dBMin.def;
    mdBMax = dBMax.def;
@@ -485,7 +489,8 @@ RegistryPaths EffectEqualization::GetFactoryPresets() const
    return names;
 }
 
-bool EffectEqualization::LoadFactoryPreset(int id, EffectSettings &settings) const
+OptionalMessage
+EffectEqualization::LoadFactoryPreset(int id, EffectSettings &settings) const
 {
    int index = -1;
    for (size_t i = 0; i < WXSIZEOF(FactoryPresets); i++)
@@ -498,7 +503,7 @@ bool EffectEqualization::LoadFactoryPreset(int id, EffectSettings &settings) con
       }
    }
    if (index < 0)
-      return false;
+      return {};
 
    // mParams = 
    wxString params = FactoryPresets[index].values;
@@ -507,8 +512,9 @@ bool EffectEqualization::LoadFactoryPreset(int id, EffectSettings &settings) con
    ShuttleSetAutomation S;
    S.SetForWriting( &eap );
    // To do: externalize state so const_cast isn't needed
-   const_cast<EffectEqualization*>(this)->VisitSettings(S, settings);
-   return true;
+   if (!const_cast<EffectEqualization*>(this)->VisitSettings(S, settings))
+      return {};
+   return { nullptr };
 }
 
 

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -120,11 +120,13 @@ public:
    // EffectDefinitionInterface implementation
 
    EffectType GetType() const override;
-   bool LoadFactoryDefaults(EffectSettings &settings) const override;
-   bool DoLoadFactoryDefaults(EffectSettings &settings);
+   OptionalMessage LoadFactoryDefaults(EffectSettings &settings)
+      const override;
+   OptionalMessage DoLoadFactoryDefaults(EffectSettings &settings);
 
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
 
    // EffectUIClientInterface implementation
 

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -52,6 +52,7 @@ public:
    }
    void MainWrite(SettingsAndCounter &&settings,
       std::unique_ptr<EffectInstance::Message> pMessage) {
+
       // Main thread may simply swap new content into place
       mChannelFromMain.Write(FromMainSlot::Message{
          std::move(settings.settings), settings.counter, std::move(pMessage) });
@@ -192,8 +193,19 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
    }
    void Set(EffectSettings &&settings, std::unique_ptr<Message> pMessage)
    override {
-      if (auto pState = mwState.lock())
+      if (auto pState = mwState.lock()) {
          if (auto pAccessState = pState->GetAccessState()) {
+            if (pMessage && !pAccessState->mState.mInitialized) {
+               // Other thread isn't processing.
+               // Let the instance consume the message directly.
+               if (auto pInstance = pState->mwInstance.lock()) {
+                  EffectInstance::MessagePackage package{
+                     pState->mWorkerSettings.settings, pMessage.get()
+                  };
+                  pInstance->RealtimeProcessStart(package);
+                  return;
+               }
+            }
             auto &lastSettings = pAccessState->mLastSettings;
             // move to remember values here
             lastSettings.settings = std::move(settings);
@@ -202,6 +214,7 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
             pAccessState->MainWrite(
                SettingsAndCounter{ lastSettings }, std::move(pMessage));
          }
+      }
    }
    void Flush() override {
       if (auto pState = mwState.lock()) {

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -444,16 +444,17 @@ RegistryPaths EffectReverb::GetFactoryPresets() const
 }
 
 
-bool EffectReverb::LoadFactoryPreset(int id, EffectSettings& settings) const
+OptionalMessage
+EffectReverb::LoadFactoryPreset(int id, EffectSettings& settings) const
 {
    if (id < 0 || id >= (int) WXSIZEOF(FactoryPresets))
    {
-      return false;
+      return {};
    }
 
    EffectReverb::GetSettings(settings) = FactoryPresets[id].preset;
 
-   return true;
+   return { nullptr };
 }
 
 // Effect implementation

--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -64,7 +64,8 @@ public:
 
    EffectType GetType() const override;
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
 
    RealtimeSince RealtimeSupport() const override;
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1429,7 +1429,7 @@ void VSTEffect::ExportPresets(const EffectSettings& settings) const
 //
 // Based on work by Sven Giermann
 //
-void VSTEffect::ImportPresets(EffectSettings& settings)
+OptionalMessage VSTEffect::ImportPresets(EffectSettings& settings)
 {
    wxString path;
 
@@ -1450,7 +1450,7 @@ void VSTEffect::ImportPresets(EffectSettings& settings)
    // User canceled...
    if (path.empty())
    {
-      return;
+      return {};
    }
 
    wxFileName fn(path);
@@ -1477,7 +1477,7 @@ void VSTEffect::ImportPresets(EffectSettings& settings)
          wxOK | wxCENTRE,
          mParent);
 
-         return;
+      return {};
    }
 
    if (!success)
@@ -1488,12 +1488,13 @@ void VSTEffect::ImportPresets(EffectSettings& settings)
          wxOK | wxCENTRE,
          mParent);
 
-      return;
+      return {};
    }
 
-   FetchSettings(GetSettings(settings));
+   if (!FetchSettings(GetSettings(settings)))
+      return {};
 
-   return;
+   return { nullptr };
 }
 
 bool VSTEffect::HasOptions()

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -367,7 +367,7 @@ class VSTEffect final
 
    bool CanExportPresets() override;
    void ExportPresets(const EffectSettings &settings) const override;
-   void ImportPresets(EffectSettings &settings) override;
+   OptionalMessage ImportPresets(EffectSettings &settings) override;
 
    bool HasOptions() override;
    void ShowOptions() override;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -337,14 +337,15 @@ class VSTEffect final
    bool LoadSettings(
       const CommandParameters & parms, EffectSettings &settings) const override;
 
-   bool LoadUserPreset(
+   OptionalMessage LoadUserPreset(
       const RegistryPath & name, EffectSettings &settings) const override;
    
    bool SaveUserPreset(
       const RegistryPath & name, const EffectSettings &settings) const override;
 
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
    bool DoLoadFactoryPreset(int id);
 
    int ShowClientInterface(wxWindow &parent, wxDialog &dialog,
@@ -422,7 +423,8 @@ private:
    std::vector<int> GetEffectIDs();
 
    // Parameter loading and saving
-   bool LoadParameters(const RegistryPath & group, EffectSettings &settings) const;
+   OptionalMessage
+      LoadParameters(const RegistryPath & group, EffectSettings &settings) const;
    bool SaveParameters(
        const RegistryPath & group, const EffectSettings &settings) const;
 

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -191,11 +191,10 @@ bool VST3Effect::LoadSettings(
    return true;
 }
 
-bool VST3Effect::LoadUserPreset(
+OptionalMessage VST3Effect::LoadUserPreset(
    const RegistryPath& name, EffectSettings& settings) const
 {
-   VST3Wrapper::LoadUserPreset(*this, name, settings);
-   return true;
+   return VST3Wrapper::LoadUserPreset(*this, name, settings);
 }
 
 bool VST3Effect::SaveUserPreset(
@@ -225,14 +224,15 @@ RegistryPaths VST3Effect::GetFactoryPresets() const
    return mFactoryPresets;
 }
 
-bool VST3Effect::LoadFactoryPreset(int id, EffectSettings& settings) const
+OptionalMessage VST3Effect::LoadFactoryPreset(int id, EffectSettings& settings) const
 {
    if(id >= 0 && id < mFactoryPresets.size())
    {
       auto filename = wxFileName(GetFactoryPresetsPath(mEffectClassInfo), mFactoryPresets[id] + ".vstpreset");
-      return LoadPreset(filename.GetFullPath(), settings);
+      if (!LoadPreset(filename.GetFullPath(), settings))
+         return {};
    }
-   return true;
+   return { nullptr };
 }
 
 int VST3Effect::ShowClientInterface(wxWindow& parent, wxDialog& dialog,

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -334,7 +334,7 @@ void VST3Effect::ExportPresets(const EffectSettings& settings) const
    }
 }
 
-void VST3Effect::ImportPresets(EffectSettings& settings)
+OptionalMessage VST3Effect::ImportPresets(EffectSettings& settings)
 {
    using namespace Steinberg;
 
@@ -350,9 +350,12 @@ void VST3Effect::ImportPresets(EffectSettings& settings)
       nullptr
    );
    if(path.empty())
-      return;
+      return {};
 
-   LoadPreset(path, settings);
+   if (!LoadPreset(path, settings))
+      return {};
+
+   return { nullptr };
 }
 
 bool VST3Effect::HasOptions()

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -81,12 +81,13 @@ public:
       const EffectSettings &settings, CommandParameters & parms) const override;
    bool LoadSettings(
       const CommandParameters & parms, EffectSettings &settings) const override;
-   bool LoadUserPreset(
+   OptionalMessage LoadUserPreset(
       const RegistryPath & name, EffectSettings &settings) const override;
    bool SaveUserPreset(
       const RegistryPath & name, const EffectSettings &settings) const override;
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
 
    int ShowClientInterface(wxWindow &parent, wxDialog &dialog,
       EffectUIValidator *pValidator, bool forceModal) override;

--- a/src/effects/VST3/VST3Effect.h
+++ b/src/effects/VST3/VST3Effect.h
@@ -100,7 +100,7 @@ public:
    bool CloseUI() override;
    bool CanExportPresets() override;
    void ExportPresets(const EffectSettings &settings) const override;
-   void ImportPresets(EffectSettings &settings) override;
+   OptionalMessage ImportPresets(EffectSettings &settings) override;
    bool HasOptions() override;
    void ShowOptions() override;
 

--- a/src/effects/VST3/VST3Wrapper.cpp
+++ b/src/effects/VST3/VST3Wrapper.cpp
@@ -773,7 +773,8 @@ void VST3Wrapper::SaveSettings(const EffectSettings& settings, CommandParameters
       parms.Write(parametersKey, ParametersToString(vst3settings.parameterChanges)); 
 }
 
-void VST3Wrapper::LoadUserPreset(const EffectDefinitionInterface& effect, const RegistryPath& name, EffectSettings& settings)
+OptionalMessage VST3Wrapper::LoadUserPreset(
+   const EffectDefinitionInterface& effect, const RegistryPath& name, EffectSettings& settings)
 {
    VST3EffectSettings vst3settings;
    
@@ -790,6 +791,7 @@ void VST3Wrapper::LoadUserPreset(const EffectDefinitionInterface& effect, const 
       vst3settings.parameterChanges = ParametersFromString(parametersStr);
 
    std::swap(vst3settings, GetSettings(settings));
+   return { nullptr };
 }
 
 void VST3Wrapper::SaveUserPreset(const EffectDefinitionInterface& effect, const RegistryPath& name, const EffectSettings& settings)

--- a/src/effects/VST3/VST3Wrapper.h
+++ b/src/effects/VST3/VST3Wrapper.h
@@ -114,7 +114,8 @@ public:
 
    static void LoadSettings(const CommandParameters& parms, EffectSettings& settings);
    static void SaveSettings(const EffectSettings& settings, CommandParameters& parms);
-   static void LoadUserPreset(const EffectDefinitionInterface& effect, const RegistryPath& name, EffectSettings& settings);
+   static OptionalMessage LoadUserPreset(
+      const EffectDefinitionInterface& effect, const RegistryPath& name, EffectSettings& settings);
    static void SaveUserPreset(const EffectDefinitionInterface& effect, const RegistryPath& name, const EffectSettings& settings);
 
    static void CopySettingsContents(const EffectSettings& src, EffectSettings& dst);

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -366,7 +366,7 @@ bool AudioUnitEffect::LoadSettings(
    return true;
 }
 
-bool AudioUnitEffect::LoadUserPreset(
+OptionalMessage AudioUnitEffect::LoadUserPreset(
    const RegistryPath & name, EffectSettings &settings) const
 {
    // To do: externalize state so const_cast isn't needed
@@ -379,28 +379,32 @@ bool AudioUnitEffect::SaveUserPreset(
    return SavePreset(name, GetSettings(settings));
 }
 
-bool AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &settings) const
+OptionalMessage
+AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &settings) const
 {
    // Issue 3441: Some factory presets of some effects do not reassign all
    // controls.  So first put controls into a default state, not contaminated
    // by previous importing or other loading of settings into this wrapper.
-   LoadPreset(FactoryDefaultsGroup(), settings);
+   if (!LoadPreset(FactoryDefaultsGroup(), settings))
+      return {};
 
    // Retrieve the list of factory presets
    CF_ptr<CFArrayRef> array;
    if (GetFixedSizeProperty(kAudioUnitProperty_FactoryPresets, array) ||
        id < 0 || id >= CFArrayGetCount(array.get()))
-      return false;
+      return {};
 
    // Mutate the scratch pad AudioUnit in the effect
-   if (!SetProperty(kAudioUnitProperty_PresentPreset,
-      *static_cast<const AUPreset*>(CFArrayGetValueAtIndex(array.get(), id)))) {
-      // Repopulate the AudioUnitEffectSettings from the change of state in
-      // the AudioUnit
-      FetchSettings(GetSettings(settings));
-      return true;
-   }
-   return false;
+   if (SetProperty(kAudioUnitProperty_PresentPreset,
+      *static_cast<const AUPreset*>(CFArrayGetValueAtIndex(array.get(), id))))
+      return {};
+
+   // Repopulate the AudioUnitEffectSettings from the change of state in
+   // the AudioUnit
+   if (!FetchSettings(GetSettings(settings)))
+      return {};
+
+   return { nullptr };
 }
 
 RegistryPaths AudioUnitEffect::GetFactoryPresets() const
@@ -576,11 +580,11 @@ bool AudioUnitEffect::MigrateOldConfigFile(
    return false;
 }
 
-bool AudioUnitEffect::LoadPreset(
+OptionalMessage AudioUnitEffect::LoadPreset(
    const RegistryPath & group, EffectSettings &settings) const
 {
    if (MigrateOldConfigFile(group, settings))
-      return true;
+      return { nullptr };
 
    // Retrieve the preset
    wxString parms;
@@ -589,7 +593,7 @@ bool AudioUnitEffect::LoadPreset(
       // Commented "CurrentSettings" gets tried a lot and useless messages appear
       // in the log
       //wxLogError(wxT("Preset key \"%s\" not found in group \"%s\""), PRESET_KEY, group);
-      return false;
+      return {};
    }
 
    // Decode it, complementary to what SaveBlobToConfig did
@@ -597,10 +601,10 @@ bool AudioUnitEffect::LoadPreset(
       InterpretBlob(GetSettings(settings), group, wxBase64Decode(parms));
    if (!error.empty()) {
       wxLogError(error.Debug());
-      return false;
+      return {};
    }
 
-   return true;
+   return { nullptr };
 }
 
 bool AudioUnitEffect::SavePreset(

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -496,7 +496,7 @@ void AudioUnitEffect::ExportPresets(const EffectSettings &settings) const
          mParent);
 }
 
-void AudioUnitEffect::ImportPresets(EffectSettings &settings)
+OptionalMessage AudioUnitEffect::ImportPresets(EffectSettings &settings)
 {
    // Generate the user domain path
    wxFileName fn;
@@ -521,15 +521,19 @@ void AudioUnitEffect::ImportPresets(EffectSettings &settings)
 
    // User canceled...
    if (path.empty())
-      return;
+      return {};
 
    auto msg = Import(GetSettings(settings), path);
-   if (!msg.empty())
+   if (!msg.empty()) {
       AudacityMessageBox(
          XO("Could not import \"%s\" preset\n\n%s").Format(path, msg),
          XO("Import Audio Unit Presets"),
          wxOK | wxCENTRE,
          mParent);
+      return {};
+   }
+
+   return { nullptr };
 }
 
 bool AudioUnitEffect::HasOptions()

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -77,13 +77,14 @@ public:
    bool LoadSettings(
       const CommandParameters & parms, EffectSettings &settings) const override;
 
-   bool LoadUserPreset(
+   OptionalMessage LoadUserPreset(
       const RegistryPath & name, EffectSettings &settings) const override;
    bool SaveUserPreset(
       const RegistryPath & name, const EffectSettings &settings) const override;
 
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
 
    int ShowClientInterface(wxWindow &parent, wxDialog &dialog,
       EffectUIValidator *pValidator, bool forceModal) override;
@@ -125,7 +126,8 @@ private:
 
    bool MigrateOldConfigFile(
       const RegistryPath & group, EffectSettings &settings) const;
-   bool LoadPreset(const RegistryPath & group, EffectSettings &settings) const;
+   OptionalMessage
+      LoadPreset(const RegistryPath & group, EffectSettings &settings) const;
    bool SavePreset(const RegistryPath & group,
       const AudioUnitEffectSettings &settings) const;
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -101,7 +101,7 @@ public:
 
    bool CanExportPresets() override;
    void ExportPresets(const EffectSettings &settings) const override;
-   void ImportPresets(EffectSettings &settings) override;
+   OptionalMessage ImportPresets(EffectSettings &settings) override;
 
    bool HasOptions() override;
    void ShowOptions() override;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1547,8 +1547,9 @@ void LadspaEffect::ExportPresets(const EffectSettings &) const
 {
 }
 
-void LadspaEffect::ImportPresets(EffectSettings &)
+OptionalMessage LadspaEffect::ImportPresets(EffectSettings &)
 {
+   return { nullptr };
 }
 
 bool LadspaEffect::HasOptions()

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -1160,7 +1160,7 @@ bool LadspaEffect::LoadSettings(
    return true;
 }
 
-bool LadspaEffect::LoadUserPreset(
+OptionalMessage LadspaEffect::LoadUserPreset(
    const RegistryPath & name, EffectSettings &settings) const
 {
    return LoadParameters(name, settings);
@@ -1177,9 +1177,9 @@ RegistryPaths LadspaEffect::GetFactoryPresets() const
    return {};
 }
 
-bool LadspaEffect::LoadFactoryPreset(int, EffectSettings &) const
+OptionalMessage LadspaEffect::LoadFactoryPreset(int, EffectSettings &) const
 {
-   return true;
+   return { nullptr };
 }
 
 // ============================================================================
@@ -1614,23 +1614,25 @@ void LadspaEffect::Unload()
    }
 }
 
-bool LadspaEffect::LoadParameters(
+OptionalMessage LadspaEffect::LoadParameters(
    const RegistryPath & group, EffectSettings &settings) const
 {
    wxString parms;
    if (!GetConfig(*this, PluginSettings::Private, group, wxT("Parameters"),
       parms, wxEmptyString))
    {
-      return false;
+      return {};
    }
 
    CommandParameters eap;
    if (!eap.SetParameters(parms))
    {
-      return false;
+      return {};
    }
 
-   return LoadSettings(eap, settings);
+   if (!LoadSettings(eap, settings))
+      return {};
+   return { nullptr };
 }
 
 bool LadspaEffect::SaveParameters(

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -126,7 +126,7 @@ public:
 
    bool CanExportPresets() override;
    void ExportPresets(const EffectSettings &settings) const override;
-   void ImportPresets(EffectSettings &settings) override;
+   OptionalMessage ImportPresets(EffectSettings &settings) override;
 
    bool HasOptions() override;
    void ShowOptions() override;

--- a/src/effects/ladspa/LadspaEffect.h
+++ b/src/effects/ladspa/LadspaEffect.h
@@ -101,13 +101,14 @@ public:
    bool LoadSettings(
       const CommandParameters & parms, EffectSettings &settings) const override;
 
-   bool LoadUserPreset(
+   OptionalMessage LoadUserPreset(
       const RegistryPath & name, EffectSettings &settings) const override;
    bool SaveUserPreset(
       const RegistryPath & name, const EffectSettings &settings) const override;
 
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
 
    int ShowClientInterface(wxWindow &parent, wxDialog &dialog,
       EffectUIValidator *pValidator, bool forceModal) override;
@@ -137,7 +138,7 @@ private:
    bool Load();
    void Unload();
 
-   bool LoadParameters(
+   OptionalMessage LoadParameters(
       const RegistryPath & group, EffectSettings &settings) const;
    bool SaveParameters(
       const RegistryPath & group, const EffectSettings &settings) const;

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -444,8 +444,9 @@ void LV2Effect::ExportPresets(const EffectSettings &) const
 {
 }
 
-void LV2Effect::ImportPresets(EffectSettings &)
+OptionalMessage LV2Effect::ImportPresets(EffectSettings &)
 {
+   return { nullptr };
 }
 
 bool LV2Effect::HasOptions()

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -368,7 +368,7 @@ bool LV2Effect::CloseUI()
    return true;
 }
 
-bool LV2Effect::LoadUserPreset(
+OptionalMessage LV2Effect::LoadUserPreset(
    const RegistryPath &name, EffectSettings &settings) const
 {
    return LoadParameters(name, settings);
@@ -410,29 +410,30 @@ RegistryPaths LV2Effect::GetFactoryPresets() const
    return mFactoryPresetNames;
 }
 
-bool LV2Effect::LoadFactoryPreset(int id, EffectSettings &settings) const
+OptionalMessage
+LV2Effect::LoadFactoryPreset(int id, EffectSettings &settings) const
 {
    using namespace LV2Symbols;
    if (id < 0 || id >= (int) mFactoryPresetUris.size())
-      return false;
+      return {};
 
    LilvNodePtr preset{ lilv_new_uri(gWorld, mFactoryPresetUris[id].ToUTF8()) };
    if (!preset)
-      return false;
+      return {};
 
    using LilvStatePtr = Lilv_ptr<LilvState, lilv_state_free>;
-   if (LilvStatePtr state{
+   LilvStatePtr state{
       lilv_state_new_from_world(gWorld,
          mFeatures.URIDMapFeature(), preset.get())
-   }){
-      auto &mySettings = GetSettings(settings);
-      mPorts.EmitPortValues(*state, mySettings);
-      // Save the state, for whatever might not be contained in port values
-      mySettings.mpState = move(state);
-      return true;
-   }
-   else
-      return false;
+   };
+   if (!state)
+      return {};
+
+   auto &mySettings = GetSettings(settings);
+   mPorts.EmitPortValues(*state, mySettings);
+   // Save the state, for whatever might not be contained in port values
+   mySettings.mpState = move(state);
+   return { nullptr };
 }
 
 bool LV2Effect::CanExportPresets()
@@ -463,17 +464,19 @@ void LV2Effect::ShowOptions()
 // LV2Effect Implementation
 // ============================================================================
 
-bool LV2Effect::LoadParameters(
+OptionalMessage LV2Effect::LoadParameters(
    const RegistryPath &group, EffectSettings &settings) const
 {
    wxString parms;
    if (!GetConfig(*this,
       PluginSettings::Private, group, wxT("Parameters"), parms, wxEmptyString))
-      return false;
+      return {};
    CommandParameters eap;
    if (!eap.SetParameters(parms))
-      return false;
-   return LoadSettings(eap, settings);
+      return {};
+   if (!LoadSettings(eap, settings))
+      return {};
+   return { nullptr };
 }
 
 bool LV2Effect::SaveParameters(

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -64,13 +64,14 @@ public:
    bool LoadSettings(
       const CommandParameters & parms, EffectSettings &settings) const override;
 
-   bool LoadUserPreset(
+   OptionalMessage LoadUserPreset(
       const RegistryPath & name, EffectSettings &settings) const override;
    bool SaveUserPreset(
       const RegistryPath & name, const EffectSettings &settings) const override;
 
    RegistryPaths GetFactoryPresets() const override;
-   bool LoadFactoryPreset(int id, EffectSettings &settings) const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
 
    int ShowClientInterface(wxWindow &parent, wxDialog &dialog,
       EffectUIValidator *pValidator, bool forceModal) override;
@@ -101,7 +102,7 @@ private:
 
    std::unique_ptr<EffectOutputs> MakeOutputs() const override;
 
-   bool LoadParameters(
+   OptionalMessage LoadParameters(
       const RegistryPath & group, EffectSettings &settings) const;
    bool SaveParameters(
       const RegistryPath & group, const EffectSettings &settings) const;

--- a/src/effects/lv2/LV2Effect.h
+++ b/src/effects/lv2/LV2Effect.h
@@ -87,7 +87,7 @@ public:
 
    bool CanExportPresets() override;
    void ExportPresets(const EffectSettings &settings) const override;
-   void ImportPresets(EffectSettings &settings) override;
+   OptionalMessage ImportPresets(EffectSettings &settings) override;
 
    bool HasOptions() override;
    void ShowOptions() override;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -653,7 +653,8 @@ bool NyquistEffect::Init()
          ParseFile();
          mFileModified = mFileName.GetModificationTime();
 
-         LoadUserPreset(key, dummySettings);
+         // Ignore failure
+         (void) LoadUserPreset(key, dummySettings);
       }
    }
 


### PR DESCRIPTION
Resolves: #3830

optional<unique_ptr<EffectSettingsAccess::Message>>, not boolean, returned now from
more virtual functions.

The overrides return {} for failure and { nullptr } for success.

Later some overrides may return a non-empty optional with a non-null unique_ptr in it which
will then be sent across threads.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
