### PR TITLE
Issue 3792: Various play commands do not exit play mode

### DIFF
--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -104,8 +104,8 @@ PlaybackPolicy::GetPlaybackSlice(PlaybackSchedule &schedule, size_t available)
       const double extraRealTime = (TimeQueueGrainSize + 1) / mRate;
       auto extra = std::min( extraRealTime, deltat - realTimeRemaining );
       auto realTime = realTimeRemaining + extra;
-      frames = realTime * mRate;
-      toProduce = realTimeRemaining * mRate;
+      frames = realTime * mRate + 0.5;
+      toProduce = realTimeRemaining * mRate + 0.5;
       schedule.RealTimeAdvance( realTime );
    }
    else

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -233,12 +233,12 @@ PlaybackSlice CutPreviewPlaybackPolicy::GetPlaybackSlice(
 {
    size_t frames = available;
    size_t toProduce = frames;
-   sampleCount samples1(mDuration1 * mRate);
+   sampleCount samples1(mDuration1 * mRate + 0.5);
    if (samples1 > 0 && samples1 < frames)
       // Shorter slice than requested, up to the discontinuity
       toProduce = frames = samples1.as_size_t();
    else if (samples1 == 0) {
-      sampleCount samples2(mDuration2 * mRate);
+      sampleCount samples2(mDuration2 * mRate + 0.5);
       if (samples2 < frames) {
          toProduce = samples2.as_size_t();
          // Produce some extra silence so that the time queue consumer can


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/3792

This affects "play cut preview", and most of the play before/after commands on the transport sub menu of the extra menu.

Whether or not the commands exit play mode depends in some apparently random way on one or more values of selection start, selection end, and in the playback page of preferences: the values of cut preview before and after cut region.

Play cut preview:
In CutPreviewPlaybackPolicy::GetPlaybackSlice(), in the initialization of Samples2, the fractional part of mDuration2 * mRate is disregarded. This can result in CutPreviewPlaybackPolicy::Done() never returning true. The fix is to round the value of the float, rather than disregarding the fractional part. The initialization of Samples1 was also changed, just for consistency.

Play after/before commands.
A similar issue.
In PlaybackPolicy::GetPlaybackSlice(), assignment of toProduce was changed to include rounding, and the assignment of frames was changed for consistency.

Note that in NewDefaultPlaybackPolicy::GetPlaybackSlice(), rounding is already used: toProduce = frames = 0.5 + (realTimeRemaining * mRate) / mLastPlaySpeed;




<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
