### PR TITLE
Open ended toolbars

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1370,7 +1370,7 @@ void AdornedRulerPanel::ReCreateButtons()
 
    wxPoint position( 1, 0 );
 
-   Grabber * pGrabber = safenew Grabber(this, this->GetId());
+   Grabber * pGrabber = safenew Grabber(this, {});
    pGrabber->SetAsSpacer( true );
    //pGrabber->SetSize( 10, 27 ); // default is 10,27
    pGrabber->SetPosition( position );

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -606,11 +606,10 @@ void MenuManager::ModifyToolbarMenus(AudacityProject &project)
    auto &settings = ProjectSettings::Get( project );
 
    // Now, go through each toolbar, and call EnableDisableButtons()
-   for (int i = 0; i < ToolBarCount; i++) {
-      auto bar = toolManager.GetToolBar(i);
+   toolManager.ForEach([](auto bar){
       if (bar)
          bar->EnableDisableButtons();
-   }
+   });
 
    // These don't really belong here, but it's easier and especially so for
    // the Edit toolbar and the sync-lock menu item.

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -552,7 +552,8 @@ void ProjectAudioManager::Stop(bool stopStream /* = true*/)
       }
    }
 
-   const auto toolbar = ToolManager::Get( *project ).GetToolBar(ScrubbingBarID);
+   // To do: eliminate this, use an event instead
+   const auto toolbar = ToolManager::Get( *project ).GetToolBar(wxT("Scrub"));
    if (toolbar)
       toolbar->EnableDisableButtons();
 }

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -770,12 +770,10 @@ void ProjectWindow::OnThemeChange(ThemeChangeMessage message)
       return;
    this->ApplyUpdatedTheme();
    auto &toolManager = ToolManager::Get( project );
-   for( int ii = 0; ii < ToolBarCount; ++ii )
-   {
-      ToolBar *pToolBar = toolManager.GetToolBar(ii);
+   toolManager.ForEach([](auto pToolBar){
       if( pToolBar )
          pToolBar->ReCreateButtons();
-   }
+   });
 }
 
 void ProjectWindow::UpdatePrefs()

--- a/src/Screenshot.cpp
+++ b/src/Screenshot.cpp
@@ -45,6 +45,7 @@ It forwards the actual work of doing the commands to the ScreenshotCommand.
 #include "ProjectWindow.h"
 #include "ProjectWindows.h"
 #include "Prefs.h"
+#include "toolbars/ToolManager.h"
 #include "tracks/ui/TrackView.h"
 #include "widgets/HelpSystem.h"
 
@@ -119,6 +120,8 @@ class ScreenshotBigDialog final : public wxFrame,
 
    std::unique_ptr<ScreenshotCommand> mCommand;
    const CommandContext mContext;
+
+   int mFirstUnusedId = 0;
 
    DECLARE_EVENT_TABLE()
 };
@@ -206,11 +209,16 @@ enum
 
    IdDelayCheckBox,
 
+   IdToggleBackgroundBlue,
+   IdToggleBackgroundWhite,
+
    IdCaptureFirst,
+
    // No point delaying the capture of sets of things.
    IdCaptureEffects= IdCaptureFirst,
    IdCaptureScriptables,
    IdCapturePreferences,
+
    IdCaptureToolbars,
 
    // Put all events that need delay between AllDelayed and LastDelayed.
@@ -220,19 +228,6 @@ enum
    IdCaptureWindowPlus,
    IdCaptureFullScreen,
 
-   IdCaptureSelectionBar,
-   IdCaptureSpectralSelection,
-   IdCaptureTimer,
-   IdCaptureTools,
-   IdCaptureTransport,
-   IdCaptureMeter,
-   IdCapturePlayMeter,
-   IdCaptureRecordMeter,
-   IdCaptureEdit,
-   IdCaptureDevice,
-   IdCaptureTranscription,
-   IdCaptureScrub,
-
    IdCaptureTrackPanel,
    IdCaptureRuler,
    IdCaptureTracks,
@@ -240,11 +235,8 @@ enum
    IdCaptureSecondTrack,
    IdCaptureLast = IdCaptureSecondTrack,
 
-   IdLastDelayedEvent,
-
-   IdToggleBackgroundBlue,
-   IdToggleBackgroundWhite,
-
+   // Reserved values for an unspecified number of toolbars
+   IdFirstToolbar,
 };
 
 BEGIN_EVENT_TABLE(ScreenshotBigDialog, wxFrame)
@@ -419,32 +411,36 @@ void ScreenshotBigDialog::PopulateOrExchange(ShuttleGui & S)
          }
          S.EndHorizontalLay();
 
-         S.StartHorizontalLay();
          {
-            S.Id(IdCaptureSelectionBar).AddButton(XXO("SelectionBar"));
-            S.Id(IdCaptureSpectralSelection).AddButton(XXO("Spectral Selection"));
-            S.Id(IdCaptureTimer).AddButton(XXO("Timer"));
-            S.Id(IdCaptureTools).AddButton(XXO("Tools"));
+            // Discover the available toolbars and make rows of buttons
+            int id = IdFirstToolbar;
+            size_t ii = 0;
+            S.StartHorizontalLay();
+            std::vector<ToolBar *> bars;
+            ToolManager::Get(mProject).ForEach([&](ToolBar *pBar){
+               bars.emplace_back(pBar);
+            });
+            // Sort by translation, for determinacy (per language) of the
+            // sequence
+            static const auto comp = [](ToolBar *a, ToolBar *b){
+               return a->GetLabel().Translation() < b->GetLabel().Translation();
+            };
+            sort(bars.begin(), bars.end(), comp);
+            for_each(bars.begin(), bars.end(), [&](ToolBar *pBar){
+               S.Id(id).AddButton(pBar->GetLabel());
+               Bind(wxEVT_BUTTON,
+                  &ScreenshotBigDialog::OnCaptureSomething, this, id);
+               ++id;
+               // Start a new row at every fourth one
+               if (++ii == 4) {
+                  ii = 0;
+                  S.EndHorizontalLay();
+                  S.StartHorizontalLay();
+               }
+            });
+            mFirstUnusedId = id;
+            S.EndHorizontalLay();
          }
-         S.EndHorizontalLay();
-
-         S.StartHorizontalLay();
-         {
-            S.Id(IdCaptureTransport).AddButton(XXO("Transport"));
-            S.Id(IdCaptureMeter).AddButton(XXO("Meter"));
-            S.Id(IdCapturePlayMeter).AddButton(XXO("Play Meter"));
-            S.Id(IdCaptureRecordMeter).AddButton(XXO("Record Meter"));
-         }
-         S.EndHorizontalLay();
-
-         S.StartHorizontalLay();
-         {
-            S.Id(IdCaptureEdit).AddButton(XXO("Edit"));
-            S.Id(IdCaptureDevice).AddButton(XXO("Device"));
-            S.Id(IdCaptureTranscription).AddButton(XXO("Play-at-Speed"));
-            S.Id(IdCaptureScrub).AddButton(XXO("Scrub"));
-         }
-         S.EndHorizontalLay();
 
          S.StartHorizontalLay();
          {
@@ -521,7 +517,7 @@ bool ScreenshotBigDialog::ProcessEvent(wxEvent & e)
           e.IsCommandEvent() &&
           e.GetEventType() == wxEVT_COMMAND_BUTTON_CLICKED)
       {
-         if( id >= IdAllDelayedEvents && id <= IdLastDelayedEvent &&
+         if( id >= IdAllDelayedEvents &&
           e.GetEventObject() != NULL) {
             mTimer = std::make_unique<ScreenFrameTimer>(this, e);
             mTimer->Start(5000, true);
@@ -579,7 +575,9 @@ void ScreenshotBigDialog::OnUIUpdate(wxUpdateUIEvent &  WXUNUSED(event))
    }
 
    if (needupdate) {
-      for (int i = IdMainWindowSmall; i < IdLastDelayedEvent; i++) {
+      for (int i = IdMainWindowSmall; i < mFirstUnusedId; i++) {
+         if (i == IdToggleBackgroundBlue || i == IdToggleBackgroundWhite)
+            continue;
          wxWindow *w = wxWindow::FindWindowById(i, this);
          if (w) {
             w->Enable(enable);
@@ -673,7 +671,7 @@ void ScreenshotBigDialog::DoCapture(int captureMode)
 
 void ScreenshotBigDialog::OnCaptureSomething(wxCommandEvent &  event)
 {
-   int i = event.GetId() - IdCaptureFirst;
+   int i = event.GetId();
 
    /*
    IdCaptureEffects= IdCaptureFirst,
@@ -719,18 +717,6 @@ void ScreenshotBigDialog::OnCaptureSomething(wxCommandEvent &  event)
       ScreenshotCommand::kfullwindow,
       ScreenshotCommand::kwindowplus,
       ScreenshotCommand::kfullscreen,
-      ScreenshotCommand::kselectionbar,
-      ScreenshotCommand::kspectralselection,
-      ScreenshotCommand::ktimer,
-      ScreenshotCommand::ktools,
-      ScreenshotCommand::ktransport,
-      ScreenshotCommand::kmeter,
-      ScreenshotCommand::kplaymeter,
-      ScreenshotCommand::krecordmeter,
-      ScreenshotCommand::kedit,
-      ScreenshotCommand::kdevice,
-      ScreenshotCommand::ktranscription,
-      ScreenshotCommand::kscrub,
       ScreenshotCommand::ktrackpanel,
       ScreenshotCommand::kruler,
       ScreenshotCommand::ktracks,
@@ -738,7 +724,12 @@ void ScreenshotBigDialog::OnCaptureSomething(wxCommandEvent &  event)
       ScreenshotCommand::ksecondtrack,
    };
 
-   DoCapture(codes[i]);
+   int code;
+   if (i >= IdFirstToolbar)
+      code = ScreenshotCommand::nCaptureWhats + (i - IdFirstToolbar);
+   else
+      code = codes[i - IdCaptureFirst];
+   DoCapture(code);
 }
 
 void ScreenshotBigDialog::TimeZoom(double seconds)

--- a/src/cloud/ShareAudioToolbar.cpp
+++ b/src/cloud/ShareAudioToolbar.cpp
@@ -35,8 +35,13 @@ IMPLEMENT_CLASS(cloud::ShareAudioToolbar, ToolBar);
 
 namespace cloud
 {
+Identifier ShareAudioToolbar::ID()
+{
+   return wxT("Share Audio");
+}
+
 ShareAudioToolbar::ShareAudioToolbar(AudacityProject& project)
-    : ToolBar(project, ShareAudioBarID, XO("Share Audio"), wxT("Share Audio"))
+    : ToolBar(project, ShareAudioBarID, XO("Share Audio"), ID())
 {
 }
 
@@ -76,7 +81,7 @@ void ShareAudioToolbar::RegenerateTooltips()
       switch (iWinID)
       {
       case ID_SHARE_AUDIO_BUTTON:
-         name = wxT("Share Audio");
+         name = ID();
          break;
       }
 

--- a/src/cloud/ShareAudioToolbar.cpp
+++ b/src/cloud/ShareAudioToolbar.cpp
@@ -41,7 +41,7 @@ Identifier ShareAudioToolbar::ID()
 }
 
 ShareAudioToolbar::ShareAudioToolbar(AudacityProject& project)
-    : ToolBar(project, ShareAudioBarID, XO("Share Audio"), ID())
+    : ToolBar(project, XO("Share Audio"), ID())
 {
 }
 
@@ -213,7 +213,7 @@ void ShareAudioToolbar::DestroySizer()
 }
 
 static RegisteredToolbarFactory factory {
-   ShareAudioBarID, [](AudacityProject& project)
+   [](AudacityProject& project)
    { return ToolBar::Holder { safenew ShareAudioToolbar { project } }; }
 };
 

--- a/src/cloud/ShareAudioToolbar.cpp
+++ b/src/cloud/ShareAudioToolbar.cpp
@@ -53,7 +53,7 @@ ShareAudioToolbar& ShareAudioToolbar::Get(AudacityProject& project)
 {
    auto& toolManager = ToolManager::Get(project);
    return *static_cast<ShareAudioToolbar*>(
-      toolManager.GetToolBar(ShareAudioBarID));
+      toolManager.GetToolBar(ID()));
 }
 
 const ShareAudioToolbar& ShareAudioToolbar::Get(const AudacityProject& project)

--- a/src/cloud/ShareAudioToolbar.cpp
+++ b/src/cloud/ShareAudioToolbar.cpp
@@ -222,7 +222,7 @@ namespace
 AttachedToolBarMenuItem sAttachment {
    /* i18n-hint: Clicking this menu item shows the toolbar
       that opens Share Audio dialog */
-   ShareAudioBarID, wxT("ShareAudioTB"), XXO("&Share Audio Toolbar")
+   ShareAudioToolbar::ID(), wxT("ShareAudioTB"), XXO("&Share Audio Toolbar")
 };
 }
 

--- a/src/cloud/ShareAudioToolbar.h
+++ b/src/cloud/ShareAudioToolbar.h
@@ -19,6 +19,8 @@ namespace cloud
 class ShareAudioToolbar final : public ToolBar
 {
 public:
+   static Identifier ID();
+
    explicit ShareAudioToolbar(AudacityProject& project);
    ~ShareAudioToolbar() override;
 

--- a/src/commands/ScreenshotCommand.cpp
+++ b/src/commands/ScreenshotCommand.cpp
@@ -93,15 +93,13 @@ EnumValueSymbols ScreenshotCommand::kCaptureWhatStrings()
        */
       auto pProject = ::GetActiveProject().lock();
       if ( pProject ) {
+         // Toolbars will be sorted by textual ID.
+         // Macro programmers do use these English ids no matter what their
+         // preferred language is.
          ToolManager::Get(*pProject).ForEach([&](ToolBar *pBar){
             mSymbols.emplace_back( pBar->GetSection(), pBar->GetLabel() );
          });
       }
-      // Sort toolbars by textual ID, for determinacy (in case of unpredictable
-      // order of registration) of the controls in the macro editing dialog.
-      // Macro programmeers do use these English ids no matter what their
-      // preferred language is.
-      sort(mSymbols.begin() + nFixed, mSymbols.end());
    }
 
    return mSymbols;

--- a/src/commands/ScreenshotCommand.cpp
+++ b/src/commands/ScreenshotCommand.cpp
@@ -33,6 +33,7 @@ small calculations of rectangles.
 #include <wx/bitmap.h>
 #include <wx/valgen.h>
 
+#include "ActiveProject.h"
 #include "../AdornedRulerPanel.h"
 #include "../TrackPanel.h"
 #include "../toolbars/ToolManager.h"
@@ -52,41 +53,58 @@ const ComponentInterfaceSymbol ScreenshotCommand::Symbol
 namespace{ BuiltinCommandsModule::Registration< ScreenshotCommand > reg; }
 
 
-static const EnumValueSymbol
-kCaptureWhatStrings[ ScreenshotCommand::nCaptureWhats ] =
+EnumValueSymbols ScreenshotCommand::kCaptureWhatStrings()
 {
-   { XO("Window") },
-   { wxT("FullWindow"), XO("Full Window") },
-   { wxT("WindowPlus"), XO("Window Plus") },
-   { XO("Fullscreen") },
-   { XO("Toolbars") },
-   { XO("Effects") },
-   { XO("Scriptables") },
-   { XO("Preferences") },
-   { XO("Selectionbar") },
-   { wxT("SpectralSelection"), XO("Spectral Selection") },
-   { XO("Timer") },
-   { XO("Tools") },
-   { XO("Transport") },
-   { XO("Meter") },
-   { wxT("PlayMeter"), XO("Play Meter") },
-   { wxT("RecordMeter"), XO("Record Meter") },
-   { XO("Edit") },
-   { XO("Device") },
-   { XO("Scrub") },
-   { XO("Play-at-Speed") },
-   { XO("Trackpanel") },
-   { XO("Ruler") },
-   { XO("Tracks") },
-   { wxT("FirstTrack"),       XO("First Track") },
-   { wxT("FirstTwoTracks"),   XO("First Two Tracks") },
-   { wxT("FirstThreeTracks"), XO("First Three Tracks") },
-   { wxT("FirstFourTracks"),  XO("First Four Tracks") },
-   { wxT("SecondTrack"),      XO("Second Track") },
-   { wxT("TracksPlus"),       XO("Tracks Plus") },
-   { wxT("FirstTrackPlus"),   XO("First Track Plus") },
-   { wxT("AllTracks"),        XO("All Tracks") },
-   { wxT("AllTracksPlus"),    XO("All Tracks Plus") },
+   static EnumValueSymbol symbols[]{
+      { XO("Window") },
+      { wxT("FullWindow"), XO("Full Window") },
+      { wxT("WindowPlus"), XO("Window Plus") },
+      { XO("Fullscreen") },
+      { XO("Toolbars") },
+      { XO("Effects") },
+      { XO("Scriptables") },
+      { XO("Preferences") },
+      { XO("Trackpanel") },
+      { XO("Ruler") },
+      { XO("Tracks") },
+      { wxT("FirstTrack"),       XO("First Track") },
+      { wxT("FirstTwoTracks"),   XO("First Two Tracks") },
+      { wxT("FirstThreeTracks"), XO("First Three Tracks") },
+      { wxT("FirstFourTracks"),  XO("First Four Tracks") },
+      { wxT("SecondTrack"),      XO("Second Track") },
+      { wxT("TracksPlus"),       XO("Tracks Plus") },
+      { wxT("FirstTrackPlus"),   XO("First Track Plus") },
+      { wxT("AllTracks"),        XO("All Tracks") },
+      { wxT("AllTracksPlus"),    XO("All Tracks Plus") },
+   };
+
+   if (mSymbols.empty()) {
+      // Compute the table of strings once
+
+      // Some fixed choices
+      copy(std::begin(symbols), std::end(symbols), back_inserter(mSymbols));
+      auto nFixed = mSymbols.size();
+
+      // Discover the set of toolbars -- don't hard-code it here
+      /*
+       There is no context passed in for a project.
+       So this need to use the active project is unfortunate, but the set of
+       toolbars and their identifying strings should not vary among projects
+       */
+      auto pProject = ::GetActiveProject().lock();
+      if ( pProject ) {
+         ToolManager::Get(*pProject).ForEach([&](ToolBar *pBar){
+            mSymbols.emplace_back( pBar->GetSection(), pBar->GetLabel() );
+         });
+      }
+      // Sort toolbars by textual ID, for determinacy (in case of unpredictable
+      // order of registration) of the controls in the macro editing dialog.
+      // Macro programmeers do use these English ids no matter what their
+      // preferred language is.
+      sort(mSymbols.begin() + nFixed, mSymbols.end());
+   }
+
+   return mSymbols;
 };
 
 
@@ -111,8 +129,9 @@ ScreenshotCommand::ScreenshotCommand()
 
 template<bool Const>
 bool ScreenshotCommand::VisitSettings( SettingsVisitorBase<Const> & S ){
+   auto strings = kCaptureWhatStrings();
    S.Define(                               mPath,        wxT("Path"),         wxString{});
-   S.DefineEnum(                           mWhat,        wxT("CaptureWhat"),  kwindow,kCaptureWhatStrings, nCaptureWhats );
+   S.DefineEnum(                           mWhat,        wxT("CaptureWhat"),  kwindow, strings.data(), strings.size() );
    S.DefineEnum(                           mBack,        wxT("Background"),   kNone, kBackgroundStrings, nBackgrounds );
    S.Define(                               mbBringToTop, wxT("ToTop"), true );
    return true;
@@ -126,13 +145,14 @@ bool ScreenshotCommand::VisitSettings( ConstSettingsVisitor & S )
 
 void ScreenshotCommand::PopulateOrExchange(ShuttleGui & S)
 {
+   auto strings = kCaptureWhatStrings();
    S.AddSpace(0, 5);
 
    S.StartMultiColumn(2, wxALIGN_CENTER);
    {
       S.TieTextBox(  XXO("Path:"), mPath);
       S.TieChoice(   XXO("Capture What:"),
-         mWhat, Msgids(kCaptureWhatStrings, nCaptureWhats));
+         mWhat, Msgids(strings.data(), strings.size()));
       S.TieChoice(   XXO("Background:"),
          mBack, Msgids(kBackgroundStrings, nBackgrounds));
       S.TieCheckBox( XXO("Bring To Top"), mbBringToTop);
@@ -303,7 +323,7 @@ bool ScreenshotCommand::Capture(
 
 bool ScreenshotCommand::CaptureToolbar(
    const CommandContext & context,
-   ToolManager *man, int type, const wxString &name)
+   ToolManager *man, Identifier type, const wxString &name)
 {
    bool visible = man->IsVisible(type);
    if (!visible) {
@@ -312,6 +332,9 @@ bool ScreenshotCommand::CaptureToolbar(
    }
 
    wxWindow *w = man->GetToolBar(type);
+   if (!w)
+      return false;
+
    int x = 0, y = 0;
    int width, height;
 
@@ -619,7 +642,7 @@ void ScreenshotCommand::GetDerivedParams()
 
    // Build a suitable filename
    mFileName = MakeFileName(mFilePath,
-      kCaptureWhatStrings[ mCaptureMode ].Translation() );
+      kCaptureWhatStrings()[ mCaptureMode ].Translation() );
 
    if (mBack == kBlue)
    {
@@ -743,7 +766,7 @@ wxRect ScreenshotCommand::GetTrackRect( AudacityProject * pProj, TrackPanel * pa
 wxString ScreenshotCommand::WindowFileName(AudacityProject * proj, wxTopLevelWindow *w){
    if (w != ProjectWindow::Find( proj ) && !w->GetTitle().empty()) {
       mFileName = MakeFileName(mFilePath,
-         kCaptureWhatStrings[ mCaptureMode ].Translation() +
+         kCaptureWhatStrings()[ mCaptureMode ].Translation() +
             (wxT("-") + w->GetTitle() + wxT("-")));
    }
    return mFileName;
@@ -773,101 +796,83 @@ bool ScreenshotCommand::Apply(const CommandContext & context)
 
    auto &toolManager = ToolManager::Get( context.project );
 
-   switch (mCaptureMode) {
-   case kwindow:
-      return Capture(context,  WindowFileName( &context.project, w ) , w, GetWindowRect(w));
-   case kfullwindow:
-   case kwindowplus:
-      return Capture(context,  WindowFileName( &context.project, w ) , w, GetFullWindowRect(w));
-   case kfullscreen:
-      return Capture(context, mFileName, w,GetScreenRect());
-   case ktoolbars:
-      return CaptureDock(context, toolManager.GetTopDock(), mFileName);
-   case kscriptables:
-      CaptureScriptables(context, &context.project, mFileName);
-      break;
-   case keffects:
-      CaptureEffects(context, &context.project, mFileName);
-      break;
-   case kpreferences:
-      CapturePreferences(context, &context.project, mFileName);
-      break;
-   case kselectionbar:
-      return CaptureToolbar(context, &toolManager, SelectionBarID, mFileName);
-   case kspectralselection:
-      return CaptureToolbar(context, &toolManager, SpectralSelectionBarID, mFileName);
-   case ktimer:
-      return CaptureToolbar(context, &toolManager, TimeBarID, mFileName);
-   case ktools:
-      return CaptureToolbar(context, &toolManager, ToolsBarID, mFileName);
-   case ktransport:
-      return CaptureToolbar(context, &toolManager, TransportBarID, mFileName);
-   case kmeter:
-      return CaptureToolbar(context, &toolManager, MeterBarID, mFileName);
-   case krecordmeter:
-      return CaptureToolbar(context, &toolManager, RecordMeterBarID, mFileName);
-   case kplaymeter:
-      return CaptureToolbar(context, &toolManager, PlayMeterBarID, mFileName);
-   case kedit:
-      return CaptureToolbar(context, &toolManager, EditBarID, mFileName);
-   case kdevice:
-      return CaptureToolbar(context, &toolManager, DeviceBarID, mFileName);
-   case ktranscription:
-      return CaptureToolbar(context, &toolManager, TranscriptionBarID, mFileName);
-   case kscrub:
-      return CaptureToolbar(context, &toolManager, ScrubbingBarID, mFileName);
-   case ktrackpanel:
-      return Capture(context, mFileName, panel, GetPanelRect(panel));
-   case kruler:
-      return Capture(context, mFileName, ruler, GetRulerRect(ruler) );
-   case ktracks:
-      return Capture(context, mFileName, panel, GetTracksRect(panel));
-   case kfirsttrack:
-      return Capture(context, mFileName, panel, GetTrackRect( &context.project, panel, 0 ) );
-   case ksecondtrack:
-      return Capture(context, mFileName, panel, GetTrackRect( &context.project, panel, 1 ) );
-   case ktracksplus:
-   {  wxRect r = GetTracksRect(panel);
-      r.SetTop( r.GetTop() - ruler->GetRulerHeight() );
-      r.SetHeight( r.GetHeight() + ruler->GetRulerHeight() );
-      return Capture(context, mFileName, panel, r);
+   if (mCaptureMode < nCaptureWhats) {
+      switch (mCaptureMode) {
+      case kwindow:
+         return Capture(context,  WindowFileName( &context.project, w ) , w, GetWindowRect(w));
+      case kfullwindow:
+      case kwindowplus:
+         return Capture(context,  WindowFileName( &context.project, w ) , w, GetFullWindowRect(w));
+      case kfullscreen:
+         return Capture(context, mFileName, w,GetScreenRect());
+      case ktoolbars:
+         return CaptureDock(context, toolManager.GetTopDock(), mFileName);
+      case kscriptables:
+         CaptureScriptables(context, &context.project, mFileName);
+         return true;
+      case keffects:
+         CaptureEffects(context, &context.project, mFileName);
+         return true;
+      case kpreferences:
+         CapturePreferences(context, &context.project, mFileName);
+         return true;
+      case ktrackpanel:
+         return Capture(context, mFileName, panel, GetPanelRect(panel));
+      case kruler:
+         return Capture(context, mFileName, ruler, GetRulerRect(ruler) );
+      case ktracks:
+         return Capture(context, mFileName, panel, GetTracksRect(panel));
+      case kfirsttrack:
+         return Capture(context, mFileName, panel, GetTrackRect( &context.project, panel, 0 ) );
+      case ksecondtrack:
+         return Capture(context, mFileName, panel, GetTrackRect( &context.project, panel, 1 ) );
+      case ktracksplus:
+      {  wxRect r = GetTracksRect(panel);
+         r.SetTop( r.GetTop() - ruler->GetRulerHeight() );
+         r.SetHeight( r.GetHeight() + ruler->GetRulerHeight() );
+         return Capture(context, mFileName, panel, r);
+      }
+      case kfirsttrackplus:
+      {  wxRect r = GetTrackRect(&context.project, panel, 0 );
+         r.SetTop( r.GetTop() - ruler->GetRulerHeight() );
+         r.SetHeight( r.GetHeight() + ruler->GetRulerHeight() );
+         return Capture(context, mFileName, panel, r );
+      }
+      case kfirsttwotracks:
+      {  wxRect r = GetTrackRect( &context.project, panel, 0 );
+         r = r.Union( GetTrackRect( &context.project, panel, 1 ));
+         return Capture(context, mFileName, panel, r );
+      }
+      case kfirstthreetracks:
+      {  wxRect r = GetTrackRect( &context.project, panel, 0 );
+         r = r.Union( GetTrackRect( &context.project, panel, 2 ));
+         return Capture(context, mFileName, panel, r );
+      }
+      case kfirstfourtracks:
+      {  wxRect r = GetTrackRect( &context.project, panel, 0 );
+         r = r.Union( GetTrackRect( &context.project, panel, 3 ));
+         return Capture(context, mFileName, panel, r );
+      }
+      case kalltracks:
+      {  wxRect r = GetTrackRect( &context.project, panel, 0 );
+         r = r.Union( GetTrackRect( &context.project, panel, nTracks-1 ));
+         return Capture(context, mFileName, panel, r );
+      }
+      case kalltracksplus:
+      {  wxRect r = GetTrackRect( &context.project, panel, 0 );
+         r.SetTop( r.GetTop() - ruler->GetRulerHeight() );
+         r.SetHeight( r.GetHeight() + ruler->GetRulerHeight() );
+         r = r.Union( GetTrackRect( &context.project, panel, nTracks-1 ));
+         return Capture(context, mFileName, panel, r );
+      }
+      default:
+         return false;
+      }
    }
-   case kfirsttrackplus:
-   {  wxRect r = GetTrackRect(&context.project, panel, 0 );
-      r.SetTop( r.GetTop() - ruler->GetRulerHeight() );
-      r.SetHeight( r.GetHeight() + ruler->GetRulerHeight() );
-      return Capture(context, mFileName, panel, r );
+   else if (mCaptureMode < nCaptureWhats + toolManager.CountBars()) {
+      auto id = kCaptureWhatStrings()[mCaptureMode].Internal();
+      return CaptureToolbar(context, &toolManager, id, mFileName);
    }
-   case kfirsttwotracks:
-   {  wxRect r = GetTrackRect( &context.project, panel, 0 );
-      r = r.Union( GetTrackRect( &context.project, panel, 1 ));
-      return Capture(context, mFileName, panel, r );
-   }
-   case kfirstthreetracks:
-   {  wxRect r = GetTrackRect( &context.project, panel, 0 );
-      r = r.Union( GetTrackRect( &context.project, panel, 2 ));
-      return Capture(context, mFileName, panel, r );
-   }
-   case kfirstfourtracks:
-   {  wxRect r = GetTrackRect( &context.project, panel, 0 );
-      r = r.Union( GetTrackRect( &context.project, panel, 3 ));
-      return Capture(context, mFileName, panel, r );
-   }
-   case kalltracks:
-   {  wxRect r = GetTrackRect( &context.project, panel, 0 );
-      r = r.Union( GetTrackRect( &context.project, panel, nTracks-1 ));
-      return Capture(context, mFileName, panel, r );
-   }
-   case kalltracksplus:
-   {  wxRect r = GetTrackRect( &context.project, panel, 0 );
-      r.SetTop( r.GetTop() - ruler->GetRulerHeight() );
-      r.SetHeight( r.GetHeight() + ruler->GetRulerHeight() );
-      r = r.Union( GetTrackRect( &context.project, panel, nTracks-1 ));
-      return Capture(context, mFileName, panel, r );
-   }
-   default:
+   else
       return false;
-   }
-
-   return true;
 }

--- a/src/commands/ScreenshotCommand.h
+++ b/src/commands/ScreenshotCommand.h
@@ -49,18 +49,6 @@ public:
       keffects,
       kscriptables,
       kpreferences,
-      kselectionbar,
-      kspectralselection,
-      ktimer,
-      ktools,
-      ktransport,
-      kmeter,
-      kplaymeter,
-      krecordmeter,
-      kedit,
-      kdevice,
-      kscrub,
-      ktranscription,
       ktrackpanel,
       kruler,
       ktracks,
@@ -75,6 +63,8 @@ public:
       kalltracksplus,
       nCaptureWhats
    };
+
+   EnumValueSymbols kCaptureWhatStrings();
 
    static const ComponentInterfaceSymbol Symbol;
 
@@ -104,6 +94,8 @@ public:
    void GetDerivedParams();
 
 private:
+   EnumValueSymbols mSymbols;
+
    // May need to ignore the screenshot dialog
    // Appears not to be used anymore.
    wxWindow *mIgnore;
@@ -120,7 +112,7 @@ private:
 
    wxRect GetBackgroundRect();
 
-   bool CaptureToolbar(const CommandContext & Context, ToolManager *man, int type, const wxString &name);
+   bool CaptureToolbar(const CommandContext & Context, ToolManager *man, Identifier type, const wxString &name);
    bool CaptureDock(const CommandContext & Context, wxWindow *win, const wxString &fileName);
    void CaptureCommands(const CommandContext & Context, const wxArrayStringEx &Commands  );
    void CaptureEffects(const CommandContext & Context, AudacityProject * pProject, const wxString &fileName );

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -72,9 +72,14 @@ BEGIN_EVENT_TABLE(AudioSetupToolBar, ToolBar)
    EVT_BUTTON(ID_AUDIO_SETUP_BUTTON, AudioSetupToolBar::OnAudioSetup)
 END_EVENT_TABLE()
 
+Identifier AudioSetupToolBar::ID()
+{
+   return wxT("Audio Setup");
+}
+
 //Standard constructor
 AudioSetupToolBar::AudioSetupToolBar( AudacityProject &project )
-: ToolBar( project, AudioSetupBarID, XO("Audio Setup"), wxT("Audio Setup") )
+: ToolBar( project, AudioSetupBarID, XO("Audio Setup"), ID() )
 {
    mSubscription = DeviceManager::Instance()->Subscribe(
       *this, &AudioSetupToolBar::OnRescannedDevices );

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -92,7 +92,7 @@ AudioSetupToolBar::~AudioSetupToolBar()
 AudioSetupToolBar &AudioSetupToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
-   return *static_cast<AudioSetupToolBar*>( toolManager.GetToolBar(AudioSetupBarID) );
+   return *static_cast<AudioSetupToolBar*>(toolManager.GetToolBar(ID()));
 }
 
 const AudioSetupToolBar &AudioSetupToolBar::Get( const AudacityProject &project )

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -79,7 +79,7 @@ Identifier AudioSetupToolBar::ID()
 
 //Standard constructor
 AudioSetupToolBar::AudioSetupToolBar( AudacityProject &project )
-: ToolBar( project, AudioSetupBarID, XO("Audio Setup"), ID() )
+: ToolBar( project, XO("Audio Setup"), ID() )
 {
    mSubscription = DeviceManager::Instance()->Subscribe(
       *this, &AudioSetupToolBar::OnRescannedDevices );
@@ -764,7 +764,7 @@ void AudioSetupToolBar::CommonMenuItemSteps(bool audioSettingsChosen)
    }
 }
 
-static RegisteredToolbarFactory factory{ AudioSetupBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew AudioSetupToolBar{ project } };
    }

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -774,7 +774,7 @@ namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows the toolbar
       that manages the audio devices */
-   AudioSetupBarID, wxT("ShowAudioSetupTB"), XXO("&Audio Setup Toolbar")
+   AudioSetupToolBar::ID(), wxT("ShowAudioSetupTB"), XXO("&Audio Setup Toolbar")
 };
 }
 

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -28,6 +28,7 @@ class AudioSetupToolBar final : public ToolBar {
    static constexpr int kAudioSettings = 15800;
 
  public:
+   static Identifier ID();
 
    explicit AudioSetupToolBar( AudacityProject &project );
    virtual ~AudioSetupToolBar();

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -107,13 +107,18 @@ static const TranslatableString
    , sStateRecord = XO("Recording")
 ;
 
+Identifier ControlToolBar::ID()
+{
+   return wxT("Control");
+}
+
 //Standard constructor
 // This was called "Control" toolbar in the GUI before - now it is "Transport".
 // Note that we use the legacy "Control" string as the section because this
 // gets written to prefs and cannot be changed in prefs to maintain backwards
 // compatibility
 ControlToolBar::ControlToolBar( AudacityProject &project )
-: ToolBar(project, TransportBarID, XO("Transport"), wxT("Control"))
+: ToolBar(project, TransportBarID, XO("Transport"), ID())
 {
    mStrLocale = gPrefs->Read(wxT("/Locale/Language"), wxT(""));
 

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -118,7 +118,7 @@ Identifier ControlToolBar::ID()
 // gets written to prefs and cannot be changed in prefs to maintain backwards
 // compatibility
 ControlToolBar::ControlToolBar( AudacityProject &project )
-: ToolBar(project, TransportBarID, XO("Transport"), ID())
+: ToolBar(project, XO("Transport"), ID())
 {
    mStrLocale = gPrefs->Read(wxT("/Locale/Language"), wxT(""));
 
@@ -795,7 +795,7 @@ void ControlToolBar::StopScrolling()
          (ProjectWindow::PlaybackScroller::Mode::Off);
 }
 
-static RegisteredToolbarFactory factory{ TransportBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew ControlToolBar{ project } }; }
 };

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -804,6 +804,6 @@ namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows the toolbar
       with the big buttons on it (play record etc) */
-   TransportBarID, wxT("ShowTransportTB"), XXO("&Transport Toolbar")
+   ControlToolBar::ID(), wxT("ShowTransportTB"), XXO("&Transport Toolbar")
 };
 }

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -134,14 +134,14 @@ ControlToolBar *ControlToolBar::Find( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
    return static_cast<ControlToolBar*>(
-      toolManager.GetToolBar(TransportBarID) );
+      toolManager.GetToolBar(ID()));
 }
 
 ControlToolBar &ControlToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
    return *static_cast<ControlToolBar*>(
-      toolManager.GetToolBar(TransportBarID) );
+      toolManager.GetToolBar(ID()));
 }
 
 const ControlToolBar &ControlToolBar::Get( const AudacityProject &project )

--- a/src/toolbars/ControlToolBar.h
+++ b/src/toolbars/ControlToolBar.h
@@ -32,6 +32,7 @@ class AudacityProject;
 class AUDACITY_DLL_API ControlToolBar final : public ToolBar {
 
  public:
+   static Identifier ID();
 
    ControlToolBar( AudacityProject &project );
    virtual ~ControlToolBar();

--- a/src/toolbars/CutCopyPasteToolBar.cpp
+++ b/src/toolbars/CutCopyPasteToolBar.cpp
@@ -105,6 +105,16 @@ CutCopyPasteToolBar::~CutCopyPasteToolBar()
 {
 }
 
+bool CutCopyPasteToolBar::ShownByDefault() const
+{
+   return false;
+}
+
+bool CutCopyPasteToolBar::HideAfterReset() const
+{
+   return true;
+}
+
 void CutCopyPasteToolBar::Create(wxWindow * parent)
 {
    ToolBar::Create(parent);

--- a/src/toolbars/CutCopyPasteToolBar.cpp
+++ b/src/toolbars/CutCopyPasteToolBar.cpp
@@ -89,9 +89,14 @@ BEGIN_EVENT_TABLE( CutCopyPasteToolBar, ToolBar )
                       CutCopyPasteToolBar::OnButton )
 END_EVENT_TABLE()
 
+Identifier CutCopyPasteToolBar::ID()
+{
+   return wxT("CutCopyPaste");
+}
+
 //Standard constructor
 CutCopyPasteToolBar::CutCopyPasteToolBar( AudacityProject &project )
-: ToolBar(project, CutCopyPasteBarID, XO("Cut/Copy/Paste"), wxT("CutCopyPaste"))
+: ToolBar(project, CutCopyPasteBarID, XO("Cut/Copy/Paste"), ID())
 , mButtons{ this, project, CutCopyPasteToolbarButtonList, TBNumButtons, first_TB_ID }
 {
 }

--- a/src/toolbars/CutCopyPasteToolBar.cpp
+++ b/src/toolbars/CutCopyPasteToolBar.cpp
@@ -96,7 +96,7 @@ Identifier CutCopyPasteToolBar::ID()
 
 //Standard constructor
 CutCopyPasteToolBar::CutCopyPasteToolBar( AudacityProject &project )
-: ToolBar(project, CutCopyPasteBarID, XO("Cut/Copy/Paste"), ID())
+: ToolBar(project, XO("Cut/Copy/Paste"), ID())
 , mButtons{ this, project, CutCopyPasteToolbarButtonList, TBNumButtons, first_TB_ID }
 {
 }
@@ -179,7 +179,7 @@ void CutCopyPasteToolBar::OnButton(wxCommandEvent & event)
    mButtons.OnButton(event);
 }
 
-static RegisteredToolbarFactory factory{ CutCopyPasteBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew CutCopyPasteToolBar{ project } }; }
 };

--- a/src/toolbars/CutCopyPasteToolBar.cpp
+++ b/src/toolbars/CutCopyPasteToolBar.cpp
@@ -177,7 +177,7 @@ static RegisteredToolbarFactory factory{ CutCopyPasteBarID,
 namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows the toolbar for editing */
-   CutCopyPasteBarID,
+   CutCopyPasteToolBar::ID(),
    wxT("ShowCutCopyPasteTB"),
    XXO("&Cut/Copy/Paste Toolbar"),
    { Registry::OrderingHint::After, "ShowEditTB" }

--- a/src/toolbars/CutCopyPasteToolBar.h
+++ b/src/toolbars/CutCopyPasteToolBar.h
@@ -30,6 +30,8 @@ class CutCopyPasteToolBar final : public ToolBar {
    CutCopyPasteToolBar( AudacityProject &project );
    virtual ~CutCopyPasteToolBar();
 
+   static Identifier ID();
+
    void Create(wxWindow *parent) override;
 
    void OnButton(wxCommandEvent & event);

--- a/src/toolbars/CutCopyPasteToolBar.h
+++ b/src/toolbars/CutCopyPasteToolBar.h
@@ -30,6 +30,9 @@ class CutCopyPasteToolBar final : public ToolBar {
    CutCopyPasteToolBar( AudacityProject &project );
    virtual ~CutCopyPasteToolBar();
 
+   bool ShownByDefault() const override;
+   bool HideAfterReset() const override;
+
    static Identifier ID();
 
    void Create(wxWindow *parent) override;

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -93,7 +93,7 @@ DeviceToolBar::~DeviceToolBar()
 DeviceToolBar &DeviceToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
-   return *static_cast<DeviceToolBar*>( toolManager.GetToolBar(DeviceBarID) );
+   return *static_cast<DeviceToolBar*>(toolManager.GetToolBar(ID()));
 }
 
 const DeviceToolBar &DeviceToolBar::Get( const AudacityProject &project )

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -73,9 +73,14 @@ int DeviceToolbarPrefsID()
    return value;
 }
 
+Identifier DeviceToolBar::ID()
+{
+   return wxT("Device");
+}
+
 //Standard constructor
 DeviceToolBar::DeviceToolBar( AudacityProject &project )
-: ToolBar( project, DeviceBarID, XO("Device"), wxT("Device"), true )
+: ToolBar( project, DeviceBarID, XO("Device"), ID(), true )
 {
    mSubscription = DeviceManager::Instance()->Subscribe(
       *this, &DeviceToolBar::OnRescannedDevices );

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -50,7 +50,6 @@
 #include "../widgets/Grabber.h"
 #include "DeviceManager.h"
 #include "../widgets/AudacityMessageBox.h"
-#include "../widgets/Grabber.h"
 
 #if wxUSE_ACCESSIBILITY
 #include "../widgets/WindowAccessible.h"

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -762,7 +762,7 @@ namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows the toolbar
       that manages devices */
-   DeviceBarID, wxT("ShowDeviceTB"), XXO("&Device Toolbar")
+   DeviceToolBar::ID(), wxT("ShowDeviceTB"), XXO("&Device Toolbar")
 };
 }
 

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -79,7 +79,7 @@ Identifier DeviceToolBar::ID()
 
 //Standard constructor
 DeviceToolBar::DeviceToolBar( AudacityProject &project )
-: ToolBar( project, DeviceBarID, XO("Device"), ID(), true )
+: ToolBar( project, XO("Device"), ID(), true )
 {
    mSubscription = DeviceManager::Instance()->Subscribe(
       *this, &DeviceToolBar::OnRescannedDevices );
@@ -757,7 +757,7 @@ void DeviceToolBar::ShowComboDialog(wxChoice *combo, const TranslatableString &t
 #endif
 }
 
-static RegisteredToolbarFactory factory{ DeviceBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew DeviceToolBar{ project } }; }
 };

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -90,6 +90,11 @@ DeviceToolBar::~DeviceToolBar()
 {
 }
 
+bool DeviceToolBar::ShownByDefault() const
+{
+   return false;
+}
+
 DeviceToolBar &DeviceToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );

--- a/src/toolbars/DeviceToolBar.h
+++ b/src/toolbars/DeviceToolBar.h
@@ -28,6 +28,8 @@ class DeviceToolBar final : public ToolBar {
 
  public:
 
+   static Identifier ID();
+
    DeviceToolBar( AudacityProject &project );
    virtual ~DeviceToolBar();
 

--- a/src/toolbars/DeviceToolBar.h
+++ b/src/toolbars/DeviceToolBar.h
@@ -33,6 +33,8 @@ class DeviceToolBar final : public ToolBar {
    DeviceToolBar( AudacityProject &project );
    virtual ~DeviceToolBar();
 
+   bool ShownByDefault() const override;
+
    static DeviceToolBar &Get( AudacityProject &project );
    static const DeviceToolBar &Get( const AudacityProject &project );
 

--- a/src/toolbars/EditToolBar.cpp
+++ b/src/toolbars/EditToolBar.cpp
@@ -262,7 +262,7 @@ static RegisteredToolbarFactory factory{ EditBarID,
 namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows the toolbar for editing */
-   EditBarID, wxT("ShowEditTB"), XXO("&Edit Toolbar")
+   EditToolBar::ID(), wxT("ShowEditTB"), XXO("&Edit Toolbar")
 };
 }
 

--- a/src/toolbars/EditToolBar.cpp
+++ b/src/toolbars/EditToolBar.cpp
@@ -127,7 +127,7 @@ Identifier EditToolBar::ID()
 
 //Standard constructor
 EditToolBar::EditToolBar( AudacityProject &project )
-: ToolBar(project, EditBarID, XO("Edit"), ID())
+: ToolBar(project, XO("Edit"), ID())
 , mButtons{ this, project, EditToolbarButtonList, ETBNumButtons, first_ETB_ID }
 {
 #ifdef OPTION_SYNC_LOCK_BUTTON
@@ -252,7 +252,7 @@ void EditToolBar::OnButton(wxCommandEvent &event)
    mButtons.OnButton(event);
 }
 
-static RegisteredToolbarFactory factory{ EditBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew EditToolBar{ project } }; }
 };

--- a/src/toolbars/EditToolBar.cpp
+++ b/src/toolbars/EditToolBar.cpp
@@ -120,9 +120,14 @@ BEGIN_EVENT_TABLE( EditToolBar, ToolBar )
                       EditToolBar::OnButton )
 END_EVENT_TABLE()
 
+Identifier EditToolBar::ID()
+{
+   return wxT("Edit");
+}
+
 //Standard constructor
 EditToolBar::EditToolBar( AudacityProject &project )
-: ToolBar(project, EditBarID, XO("Edit"), wxT("Edit"))
+: ToolBar(project, EditBarID, XO("Edit"), ID())
 , mButtons{ this, project, EditToolbarButtonList, ETBNumButtons, first_ETB_ID }
 {
 #ifdef OPTION_SYNC_LOCK_BUTTON

--- a/src/toolbars/EditToolBar.h
+++ b/src/toolbars/EditToolBar.h
@@ -31,6 +31,8 @@ class EditToolBar final : public ToolBar {
 
  public:
 
+   static Identifier ID();
+
    EditToolBar( AudacityProject &project );
    virtual ~EditToolBar();
 

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -178,14 +178,13 @@ ConstMeterToolBars MeterToolBar::GetToolBars(const AudacityProject &project)
 MeterToolBar & MeterToolBar::Get(AudacityProject &project, bool forPlayMeterToolBar)
 {
    auto& toolManager = ToolManager::Get(project);
-   auto  toolBarID = forPlayMeterToolBar ? PlayMeterBarID : RecordMeterBarID;
-
+   const auto &toolBarID = forPlayMeterToolBar ? PlayID() : RecordID();
    return *static_cast<MeterToolBar*>(toolManager.GetToolBar(toolBarID));
 }
 
 const MeterToolBar & MeterToolBar::Get(const AudacityProject &project, bool forPlayMeterToolBar)
 {
-   return Get( const_cast<AudacityProject&>( project ), forPlayMeterToolBar );
+   return Get(const_cast<AudacityProject&>(project), forPlayMeterToolBar);
 }
 
 void MeterToolBar::Create(wxWindow * parent)

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -131,21 +131,28 @@ BEGIN_EVENT_TABLE( MeterToolBar, ToolBar )
    EVT_SIZE( MeterToolBar::OnSize )
 END_EVENT_TABLE()
 
-//Standard constructor
-MeterToolBar::MeterToolBar(AudacityProject &project, int type)
-: ToolBar(project, type, XO("Combined Meter"), wxT("CombinedMeter"), true)
+Identifier MeterToolBar::ID()
 {
-   if( mType == RecordMeterBarID ){
-      mWhichMeters = kWithRecordMeter;
-      mLabel = XO("Recording Meter");
-      mSection = wxT("RecordMeter");
-   } else if( mType == PlayMeterBarID ){
-      mWhichMeters = kWithPlayMeter;
-      mLabel = XO("Playback Meter");
-      mSection = wxT("PlayMeter");
-   } else {
-      mWhichMeters = kWithPlayMeter | kWithRecordMeter;
-   }
+   return wxT("CombinedMeter");
+}
+
+Identifier MeterToolBar::PlayID()
+{
+   return wxT("PlayMeter");
+}
+
+Identifier MeterToolBar::RecordID()
+{
+   return wxT("RecordMeter");
+}
+
+//Standard constructor
+MeterToolBar::MeterToolBar(AudacityProject &project, int type,
+   unsigned whichMeters,
+   const TranslatableString &label, Identifier ID)
+: ToolBar(project, type, label, ID, true)
+, mWhichMeters{ whichMeters }
+{
 }
 
 MeterToolBar::~MeterToolBar()
@@ -500,17 +507,21 @@ void MeterToolBar::AdjustInputGain(int adj)
 static RegisteredToolbarFactory factory1{ RecordMeterBarID,
    []( AudacityProject &project ){
       return ToolBar::Holder{
-         safenew MeterToolBar{ project, RecordMeterBarID } }; }
+         safenew MeterToolBar{ project, RecordMeterBarID, kWithRecordMeter,
+            XO("Recording Meter"), MeterToolBar::RecordID() } }; }
 };
 static RegisteredToolbarFactory factory2{ PlayMeterBarID,
    []( AudacityProject &project ){
       return ToolBar::Holder{
-         safenew MeterToolBar{ project, PlayMeterBarID } }; }
+         safenew MeterToolBar{ project, PlayMeterBarID, kWithPlayMeter,
+            XO("Playback Meter"), MeterToolBar::PlayID() } }; }
 };
 static RegisteredToolbarFactory factory3{ MeterBarID,
    []( AudacityProject &project ){
       return ToolBar::Holder{
-         safenew MeterToolBar{ project, MeterBarID } }; }
+         safenew MeterToolBar{ project, MeterBarID,
+            (kWithPlayMeter|kWithRecordMeter),
+            XO("Combined Meter"), MeterToolBar::ID() } }; }
 };
 
 #include "ToolManager.h"

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -187,6 +187,12 @@ const MeterToolBar & MeterToolBar::Get(const AudacityProject &project, bool forP
    return Get(const_cast<AudacityProject&>(project), forPlayMeterToolBar);
 }
 
+bool MeterToolBar::ShownByDefault() const
+{
+   // The combined meter hides by default
+   return mWhichMeters != (kWithPlayMeter|kWithRecordMeter);
+}
+
 void MeterToolBar::Create(wxWindow * parent)
 {
    ToolBar::Create(parent);

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -147,10 +147,10 @@ Identifier MeterToolBar::RecordID()
 }
 
 //Standard constructor
-MeterToolBar::MeterToolBar(AudacityProject &project, int type,
+MeterToolBar::MeterToolBar(AudacityProject &project,
    unsigned whichMeters,
    const TranslatableString &label, Identifier ID)
-: ToolBar(project, type, label, ID, true)
+: ToolBar(project, label, ID, true)
 , mWhichMeters{ whichMeters }
 {
 }
@@ -509,22 +509,22 @@ void MeterToolBar::AdjustInputGain(int adj)
    mRecordMeter->UpdateSliderControl();
 }
 
-static RegisteredToolbarFactory factory1{ RecordMeterBarID,
+static RegisteredToolbarFactory factory1{
    []( AudacityProject &project ){
       return ToolBar::Holder{
-         safenew MeterToolBar{ project, RecordMeterBarID, kWithRecordMeter,
+         safenew MeterToolBar{ project, kWithRecordMeter,
             XO("Recording Meter"), MeterToolBar::RecordID() } }; }
 };
-static RegisteredToolbarFactory factory2{ PlayMeterBarID,
+static RegisteredToolbarFactory factory2{
    []( AudacityProject &project ){
       return ToolBar::Holder{
-         safenew MeterToolBar{ project, PlayMeterBarID, kWithPlayMeter,
+         safenew MeterToolBar{ project, kWithPlayMeter,
             XO("Playback Meter"), MeterToolBar::PlayID() } }; }
 };
-static RegisteredToolbarFactory factory3{ MeterBarID,
+static RegisteredToolbarFactory factory3{
    []( AudacityProject &project ){
       return ToolBar::Holder{
-         safenew MeterToolBar{ project, MeterBarID,
+         safenew MeterToolBar{ project,
             (kWithPlayMeter|kWithRecordMeter),
             XO("Combined Meter"), MeterToolBar::ID() } }; }
 };

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -529,19 +529,21 @@ namespace {
 AttachedToolBarMenuItem sAttachment1{
    /* i18n-hint: Clicking this menu item shows the toolbar
       with the recording level meters */
-   RecordMeterBarID, wxT("ShowRecordMeterTB"), XXO("&Recording Meter Toolbar"),
-   {}, { MeterBarID }
+   MeterToolBar::RecordID(),
+   wxT("ShowRecordMeterTB"), XXO("&Recording Meter Toolbar"),
+   {}, { MeterToolBar::ID() }
 };
 AttachedToolBarMenuItem sAttachment2{
    /* i18n-hint: Clicking this menu item shows the toolbar
       with the playback level meter */
-   PlayMeterBarID, wxT("ShowPlayMeterTB"), XXO("&Playback Meter Toolbar"),
-   {}, { MeterBarID }
+   MeterToolBar::PlayID(),
+   wxT("ShowPlayMeterTB"), XXO("&Playback Meter Toolbar"),
+   {}, { MeterToolBar::ID() }
 };
 //AttachedToolBarMenuItem sAttachment3{
 //   /* --i18nhint: Clicking this menu item shows the toolbar
 //      which has sound level meters */
-//   MeterBarID, wxT("ShowMeterTB"), XXO("Co&mbined Meter Toolbar"),
+//   MeterToolBar::ID(), wxT("ShowMeterTB"), XXO("Co&mbined Meter Toolbar"),
 //   { Registry::OrderingHint::After, "ShowPlayMeterTB" },
 //   { PlayMeterBarID, RecordMeterBarID }
 //};

--- a/src/toolbars/MeterToolBar.h
+++ b/src/toolbars/MeterToolBar.h
@@ -54,6 +54,8 @@ class MeterToolBar final : public ToolBar {
    static MeterToolBar & Get(AudacityProject &project, bool forPlayMeterToolBar);
    static const MeterToolBar & Get(const AudacityProject &project, bool forPlayMeterToolBar);
 
+   bool ShownByDefault() const override;
+
    void Create(wxWindow *parent) override;
 
    void Populate() override;

--- a/src/toolbars/MeterToolBar.h
+++ b/src/toolbars/MeterToolBar.h
@@ -44,7 +44,7 @@ class MeterToolBar final : public ToolBar {
    static Identifier RecordID();
 
    MeterToolBar(AudacityProject &project,
-      int type, unsigned whichMeters,
+      unsigned whichMeters,
       const TranslatableString &label, Identifier ID);
    virtual ~MeterToolBar();
 

--- a/src/toolbars/MeterToolBar.h
+++ b/src/toolbars/MeterToolBar.h
@@ -39,7 +39,13 @@ class MeterToolBar final : public ToolBar {
 
  public:
 
-   MeterToolBar(AudacityProject &project, int type);
+   static Identifier ID();
+   static Identifier PlayID();
+   static Identifier RecordID();
+
+   MeterToolBar(AudacityProject &project,
+      int type, unsigned whichMeters,
+      const TranslatableString &label, Identifier ID);
    virtual ~MeterToolBar();
 
    static MeterToolBars GetToolBars(AudacityProject &project);
@@ -77,7 +83,7 @@ class MeterToolBar final : public ToolBar {
    void RegenerateTooltips() override {}
    void RebuildLayout(bool force);
 
-   int mWhichMeters;
+   unsigned mWhichMeters;
    wxBoxSizer *mRootSizer{nullptr};
    AButton* mPlaySetupButton{nullptr};
    MeterPanel *mPlayMeter{nullptr};

--- a/src/toolbars/ScrubbingToolBar.cpp
+++ b/src/toolbars/ScrubbingToolBar.cpp
@@ -52,9 +52,14 @@ EVT_COMMAND_RANGE( STBFirstButton,
 EVT_IDLE( ScrubbingToolBar::OnIdle )
 END_EVENT_TABLE()
 
+Identifier ScrubbingToolBar::ID()
+{
+   return wxT("Scrub");
+}
+
 //Standard constructor
 ScrubbingToolBar::ScrubbingToolBar( AudacityProject &project )
-: ToolBar(project, ScrubbingBarID, XO("Scrub"), wxT("Scrub"))
+: ToolBar(project, ScrubbingBarID, XO("Scrub"), ID())
 {
 }
 

--- a/src/toolbars/ScrubbingToolBar.cpp
+++ b/src/toolbars/ScrubbingToolBar.cpp
@@ -59,7 +59,7 @@ Identifier ScrubbingToolBar::ID()
 
 //Standard constructor
 ScrubbingToolBar::ScrubbingToolBar( AudacityProject &project )
-: ToolBar(project, ScrubbingBarID, XO("Scrub"), ID())
+: ToolBar(project, XO("Scrub"), ID())
 {
 }
 
@@ -298,7 +298,7 @@ void ScrubbingToolBar::OnIdle( wxIdleEvent &evt )
    EnableDisableButtons();
 }
 
-static RegisteredToolbarFactory factory{ ScrubbingBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew ScrubbingToolBar{ project } }; }
 };

--- a/src/toolbars/ScrubbingToolBar.cpp
+++ b/src/toolbars/ScrubbingToolBar.cpp
@@ -67,6 +67,11 @@ ScrubbingToolBar::~ScrubbingToolBar()
 {
 }
 
+bool ScrubbingToolBar::ShownByDefault() const
+{
+   return false;
+}
+
 ScrubbingToolBar &ScrubbingToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );

--- a/src/toolbars/ScrubbingToolBar.cpp
+++ b/src/toolbars/ScrubbingToolBar.cpp
@@ -70,7 +70,7 @@ ScrubbingToolBar::~ScrubbingToolBar()
 ScrubbingToolBar &ScrubbingToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
-   return *static_cast<ScrubbingToolBar*>( toolManager.GetToolBar(ScrubbingBarID) );
+   return *static_cast<ScrubbingToolBar*>(toolManager.GetToolBar(ID()));
 }
 
 const ScrubbingToolBar &ScrubbingToolBar::Get( const AudacityProject &project )

--- a/src/toolbars/ScrubbingToolBar.cpp
+++ b/src/toolbars/ScrubbingToolBar.cpp
@@ -302,7 +302,7 @@ namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows the toolbar
       that enables Scrub or Seek playback and Scrub Ruler */
-   ScrubbingBarID, wxT("ShowScrubbingTB"), XXO("Scru&b Toolbar")
+   ScrubbingToolBar::ID(), wxT("ShowScrubbingTB"), XXO("Scru&b Toolbar")
 };
 }
 

--- a/src/toolbars/ScrubbingToolBar.h
+++ b/src/toolbars/ScrubbingToolBar.h
@@ -45,6 +45,8 @@ public:
    ScrubbingToolBar( AudacityProject &project );
    virtual ~ScrubbingToolBar();
 
+   bool ShownByDefault() const override;
+
    static ScrubbingToolBar &Get( AudacityProject &project );
    static const ScrubbingToolBar &Get( const AudacityProject &project );
 

--- a/src/toolbars/ScrubbingToolBar.h
+++ b/src/toolbars/ScrubbingToolBar.h
@@ -40,6 +40,8 @@ class ScrubbingToolBar final : public ToolBar {
 
 public:
 
+   static Identifier ID();
+
    ScrubbingToolBar( AudacityProject &project );
    virtual ~ScrubbingToolBar();
 

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -824,7 +824,7 @@ namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows the toolbar
       for selecting a time range of audio */
-   SelectionBarID, wxT("ShowSelectionTB"), XXO("&Selection Toolbar")
+   SelectionBar::ID(), wxT("ShowSelectionTB"), XXO("&Selection Toolbar")
 };
 }
 

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -114,7 +114,7 @@ Identifier SelectionBar::ID()
 }
 
 SelectionBar::SelectionBar( AudacityProject &project )
-: ToolBar(project, SelectionBarID, XO("Selection"), ID()),
+: ToolBar(project, XO("Selection"), ID()),
   mListener(NULL), mRate(0.0),
   mStart(0.0), mEnd(0.0), mLength(0.0), mCenter(0.0), mAudio(0.0),
   mDrive1( StartTimeID), mDrive2( EndTimeID ),
@@ -831,7 +831,7 @@ void SelectionBar::OnSnapTo(wxCommandEvent & WXUNUSED(event))
    mListener->AS_SetSnapTo(mSnapTo->GetSelection());
 }
 
-static RegisteredToolbarFactory factory{ SelectionBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew SelectionBar{ project } }; }
 };

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -108,8 +108,13 @@ BEGIN_EVENT_TABLE(SelectionBar, ToolBar)
    EVT_COMMAND(wxID_ANY, EVT_CAPTURE_KEY, SelectionBar::OnCaptureKey)
 END_EVENT_TABLE()
 
+Identifier SelectionBar::ID()
+{
+   return wxT("Selection");
+}
+
 SelectionBar::SelectionBar( AudacityProject &project )
-: ToolBar(project, SelectionBarID, XO("Selection"), wxT("Selection")),
+: ToolBar(project, SelectionBarID, XO("Selection"), ID()),
   mListener(NULL), mRate(0.0),
   mStart(0.0), mEnd(0.0), mLength(0.0), mCenter(0.0), mAudio(0.0),
   mDrive1( StartTimeID), mDrive2( EndTimeID ),

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -143,7 +143,7 @@ SelectionBar::~SelectionBar()
 SelectionBar &SelectionBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
-   return *static_cast<SelectionBar*>( toolManager.GetToolBar(SelectionBarID) );
+   return *static_cast<SelectionBar*>(toolManager.GetToolBar(ID()));
 }
 
 const SelectionBar &SelectionBar::Get( const AudacityProject &project )

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -140,6 +140,22 @@ SelectionBar::~SelectionBar()
 {
 }
 
+bool SelectionBar::ShownByDefault() const
+{
+   return
+#ifdef EXPERIMENTAL_DA
+      false
+#else
+      true
+#endif
+   ;
+}
+
+ToolBar::DockID SelectionBar::DefaultDockID() const
+{
+   return BotDockID;
+}
+
 SelectionBar &SelectionBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -51,6 +51,9 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
    SelectionBar( AudacityProject &project );
    virtual ~SelectionBar();
 
+   bool ShownByDefault() const override;
+   DockID DefaultDockID() const override;
+
    static SelectionBar &Get( AudacityProject &project );
    static const SelectionBar &Get( const AudacityProject &project );
 

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -46,6 +46,8 @@ class NumericTextCtrl;
 class AUDACITY_DLL_API SelectionBar final : public ToolBar {
 
  public:
+   static Identifier ID();
+
    SelectionBar( AudacityProject &project );
    virtual ~SelectionBar();
 

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -116,8 +116,7 @@ SpectralSelectionBar::~SpectralSelectionBar()
 SpectralSelectionBar &SpectralSelectionBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
-   return *static_cast<SpectralSelectionBar*>(
-      toolManager.GetToolBar(SpectralSelectionBarID) );
+   return *static_cast<SpectralSelectionBar*>(toolManager.GetToolBar(ID()));
 }
 
 const SpectralSelectionBar &SpectralSelectionBar::Get( const AudacityProject &project )

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -99,8 +99,7 @@ Identifier SpectralSelectionBar::ID()
 }
 
 SpectralSelectionBar::SpectralSelectionBar( AudacityProject &project )
-: ToolBar( project,
-   SpectralSelectionBarID, XO("Spectral Selection"), ID() )
+: ToolBar( project, XO("Spectral Selection"), ID() )
 , mListener(NULL), mbCenterAndWidth(true)
 , mCenter(0.0), mWidth(0.0), mLow(0.0), mHigh(0.0)
 , mCenterCtrl(NULL), mWidthCtrl(NULL), mLowCtrl(NULL), mHighCtrl(NULL)
@@ -498,7 +497,7 @@ void SpectralSelectionBar::SetBandwidthSelectionFormatName(const NumericFormatSy
    }
 }
 
-static RegisteredToolbarFactory factory{ SpectralSelectionBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew SpectralSelectionBar{ project } }; }
 };

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -495,7 +495,7 @@ static RegisteredToolbarFactory factory{ SpectralSelectionBarID,
 
 namespace {
 AttachedToolBarMenuItem sAttachment{
-   SpectralSelectionBarID,
+   SpectralSelectionBar::ID(),
       /* i18n-hint: Clicking this menu item shows the toolbar
       for selecting a frequency range of audio */
    wxT("ShowSpectralSelectionTB"), XXO("Spe&ctral Selection Toolbar")

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -93,9 +93,14 @@ END_EVENT_TABLE()
 static const wxString preferencePath
 (wxT("/GUI/Toolbars/SpectralSelection/CenterAndWidthChoice"));
 
+Identifier SpectralSelectionBar::ID()
+{
+   return wxT("SpectralSelection");
+}
+
 SpectralSelectionBar::SpectralSelectionBar( AudacityProject &project )
 : ToolBar( project,
-   SpectralSelectionBarID, XO("Spectral Selection"), wxT("SpectralSelection") )
+   SpectralSelectionBarID, XO("Spectral Selection"), ID() )
 , mListener(NULL), mbCenterAndWidth(true)
 , mCenter(0.0), mWidth(0.0), mLow(0.0), mHigh(0.0)
 , mCenterCtrl(NULL), mWidthCtrl(NULL), mLowCtrl(NULL), mHighCtrl(NULL)

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -113,6 +113,16 @@ SpectralSelectionBar::~SpectralSelectionBar()
    // Do nothing, sizer deletes the controls
 }
 
+bool SpectralSelectionBar::ShownByDefault() const
+{
+   return false;
+}
+
+ToolBar::DockID SpectralSelectionBar::DefaultDockID() const
+{
+   return BotDockID;
+}
+
 SpectralSelectionBar &SpectralSelectionBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );

--- a/src/toolbars/SpectralSelectionBar.h
+++ b/src/toolbars/SpectralSelectionBar.h
@@ -34,6 +34,9 @@ public:
    SpectralSelectionBar( AudacityProject &project );
    virtual ~SpectralSelectionBar();
 
+   bool ShownByDefault() const override;
+   DockID DefaultDockID() const override;
+
    static SpectralSelectionBar &Get( AudacityProject &project );
    static const SpectralSelectionBar &Get( const AudacityProject &project );
 

--- a/src/toolbars/SpectralSelectionBar.h
+++ b/src/toolbars/SpectralSelectionBar.h
@@ -29,6 +29,8 @@ class SpectralSelectionBar final : public ToolBar {
 
 public:
 
+   static Identifier ID();
+
    SpectralSelectionBar( AudacityProject &project );
    virtual ~SpectralSelectionBar();
 

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -55,7 +55,7 @@ Identifier TimeToolBar::ID()
 }
 
 TimeToolBar::TimeToolBar(AudacityProject &project)
-:  ToolBar(project, TimeBarID, XO("Time"), ID(), true),
+:  ToolBar(project, XO("Time"), ID(), true),
    mListener(NULL),
    mAudioTime(NULL)
 {
@@ -380,9 +380,7 @@ void TimeToolBar::OnIdle(wxIdleEvent &evt)
    mAudioTime->SetValue(wxMax(0.0, audioTime));
 }
 
-static RegisteredToolbarFactory factory
-{
-   TimeBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project )
    {
       return ToolBar::Holder{ safenew TimeToolBar{ project } };

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -67,6 +67,11 @@ TimeToolBar::~TimeToolBar()
 {
 }
 
+ToolBar::DockID TimeToolBar::DefaultDockID() const
+{
+   return BotDockID;
+}
+
 TimeToolBar &TimeToolBar::Get(AudacityProject &project)
 {
    auto &toolManager = ToolManager::Get(project);

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -70,7 +70,7 @@ TimeToolBar::~TimeToolBar()
 TimeToolBar &TimeToolBar::Get(AudacityProject &project)
 {
    auto &toolManager = ToolManager::Get(project);
-   return *static_cast<TimeToolBar*>(toolManager.GetToolBar(TimeBarID));
+   return *static_cast<TimeToolBar*>(toolManager.GetToolBar(ID()));
 }
 
 const TimeToolBar &TimeToolBar::Get(const AudacityProject &project)

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -49,8 +49,13 @@ BEGIN_EVENT_TABLE(TimeToolBar, ToolBar)
    EVT_IDLE(TimeToolBar::OnIdle)
 END_EVENT_TABLE()
 
+Identifier TimeToolBar::ID()
+{
+   return wxT("Time");
+}
+
 TimeToolBar::TimeToolBar(AudacityProject &project)
-:  ToolBar(project, TimeBarID, XO("Time"), wxT("Time"), true),
+:  ToolBar(project, TimeBarID, XO("Time"), ID(), true),
    mListener(NULL),
    mAudioTime(NULL)
 {

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -387,7 +387,7 @@ static RegisteredToolbarFactory factory
 namespace {
 AttachedToolBarMenuItem sAttachment
 {
-   TimeBarID,
+   TimeToolBar::ID(),
    wxT("ShowTimeTB"),
    /* i18n-hint: Clicking this menu item shows the toolbar
       for viewing actual time of the cursor */

--- a/src/toolbars/TimeToolBar.h
+++ b/src/toolbars/TimeToolBar.h
@@ -28,6 +28,8 @@ public:
    TimeToolBar(AudacityProject &project);
    virtual ~TimeToolBar();
    
+   DockID DefaultDockID() const override;
+
    static TimeToolBar &Get(AudacityProject &project);
    static const TimeToolBar &Get(const AudacityProject &project);
    

--- a/src/toolbars/TimeToolBar.h
+++ b/src/toolbars/TimeToolBar.h
@@ -23,6 +23,8 @@ class TimeToolBarListener;
 class TimeToolBar final : public ToolBar
 {
 public:
+   static Identifier ID();
+
    TimeToolBar(AudacityProject &project);
    virtual ~TimeToolBar();
    

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -367,6 +367,20 @@ bool ToolBar::AcceptsFocusFromKeyboard() const
    return false;
 }
 
+bool ToolBar::ShownByDefault() const
+{
+   return true;
+}
+
+bool ToolBar::HideAfterReset() const
+{
+   return false;
+}
+
+ToolBar::DockID ToolBar::DefaultDockID() const
+{
+   return TopDockID;
+}
 
 //
 // Returns the toolbar title

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -461,7 +461,7 @@ void ToolBar::SetVisible( bool bVisible )
    mVisible = bVisible;
 }
 
-std::pair<ToolBarID, ToolBarID> ToolBar::PreferredNeighbors() const noexcept
+std::pair<Identifier, Identifier> ToolBar::PreferredNeighbors() const noexcept
 {
    return { mPreferredLeftNeighbor, mPreferredTopNeighbor };
 }
@@ -660,7 +660,7 @@ ToolDock *ToolBar::GetDock()
    return dynamic_cast<ToolDock*>(GetParent());
 }
 
-void ToolBar::SetPreferredNeighbors(ToolBarID left, ToolBarID top)
+void ToolBar::SetPreferredNeighbors(Identifier left, Identifier top)
 {
    mPreferredLeftNeighbor = left;
    mPreferredTopNeighbor = top;

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -567,7 +567,7 @@ void ToolBar::ReCreateButtons()
       auto ms = std::make_unique<wxBoxSizer>(wxHORIZONTAL);
 
       // Create the grabber and add it to the main sizer
-      mGrabber = safenew Grabber(this, mType);
+      mGrabber = safenew Grabber(this, GetSection());
       ms->Add(mGrabber, 0, wxEXPAND | wxALIGN_LEFT | wxALIGN_TOP | wxRIGHT, 1);
 
       // Use a box sizer for laying out controls

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -489,7 +489,9 @@ bool ToolBar::Expose( bool show )
       if( !IsPositioned() && show ){
          SetPositioned();
          pParent->CentreOnParent();
-         pParent->Move( pParent->GetPosition() + wxSize( mType*10, mType*10 ));
+         // Cascade the undocked bars
+         pParent->Move( pParent->GetPosition() +
+            wxSize{ mIndex * 10, mIndex * 10 });
       }
       pParent->Show( show );
    }

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -330,7 +330,7 @@ END_EVENT_TABLE()
 ToolBar::ToolBar( AudacityProject &project,
                   int type,
                   const TranslatableString &label,
-                  const wxString &section,
+                  const Identifier &section,
                   bool resizable )
 : wxPanelWrapper()
 , mProject{ project }
@@ -388,7 +388,7 @@ TranslatableString ToolBar::GetLabel()
 //
 // Returns the toolbar preferences section
 //
-wxString ToolBar::GetSection()
+Identifier ToolBar::GetSection()
 {
    return mSection;
 }

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -328,7 +328,6 @@ END_EVENT_TABLE()
 // Constructor
 //
 ToolBar::ToolBar( AudacityProject &project,
-                  int type,
                   const TranslatableString &label,
                   const Identifier &section,
                   bool resizable )
@@ -336,7 +335,6 @@ ToolBar::ToolBar( AudacityProject &project,
 , mProject{ project }
 {
    // Save parameters
-   mType = type;
    mLabel = label;
    mSection = section;
    mResizable = resizable;
@@ -349,7 +347,6 @@ ToolBar::ToolBar( AudacityProject &project,
 
    mGrabber = NULL;
    mResizer = NULL;
-   SetId(mType);
 }
 
 //
@@ -405,14 +402,6 @@ TranslatableString ToolBar::GetLabel()
 Identifier ToolBar::GetSection()
 {
    return mSection;
-}
-
-//
-// Returns the toolbar type
-//
-int ToolBar::GetType()
-{
-   return mType;
 }
 
 //
@@ -509,7 +498,7 @@ void ToolBar::Create( wxWindow *parent )
 
    // Create the window and label it
    wxPanelWrapper::Create( mParent,
-                    mType,
+                    wxID_ANY,
                     wxDefaultPosition,
                     wxDefaultSize,
                     wxNO_BORDER | wxTAB_TRAVERSAL,
@@ -1046,17 +1035,15 @@ namespace {
 
 RegisteredToolbarFactory::Functions &GetFunctions()
 {
-   static RegisteredToolbarFactory::Functions factories( ToolBarCount );
+   static RegisteredToolbarFactory::Functions factories;
    return factories;
 }
 
 }
 
-RegisteredToolbarFactory::RegisteredToolbarFactory(
-   int id, const Function &function)
+RegisteredToolbarFactory::RegisteredToolbarFactory(const Function &function)
 {
-   wxASSERT( id >= 0 && id < ToolBarCount );
-   GetFunctions()[ id ] = function;
+   GetFunctions().emplace_back(function);
 }
 
 auto RegisteredToolbarFactory::GetFactories() -> const Functions&

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -110,6 +110,21 @@ class AUDACITY_DLL_API ToolBar /* not final */
       bool resizable = false);
    virtual ~ToolBar();
 
+   //! Whether the toolbar should be shown by default.  Default implementation returns true
+   virtual bool ShownByDefault() const;
+
+   //! Default implementation returns false
+   virtual bool HideAfterReset() const;
+
+   //! Identifies one of the docking areas for toolbars
+   enum DockID {
+      TopDockID = 1,
+      BotDockID = 2
+   };
+
+   //! Which dock the toolbar defaults into.  Default implementation chooses the top dock
+   virtual DockID DefaultDockID() const;
+
    bool AcceptsFocus() const override { return false; };
    bool AcceptsFocusFromKeyboard() const override;
 

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -106,7 +106,7 @@ class AUDACITY_DLL_API ToolBar /* not final */
    using Holder = wxWindowPtr<ToolBar>;
 
    ToolBar( AudacityProject &project,
-      int type, const TranslatableString & label, const Identifier &section,
+      const TranslatableString & label, const Identifier &section,
       bool resizable = false);
    virtual ~ToolBar();
 
@@ -141,7 +141,6 @@ class AUDACITY_DLL_API ToolBar /* not final */
    //! Set a value used for computing cascading positions of undocked bars
    void SetIndex(int index) { mIndex = index; }
 
-   int GetType();
    TranslatableString GetTitle();
    TranslatableString GetLabel();
    Identifier GetSection();
@@ -277,7 +276,6 @@ public:
    AudacityProject &mProject;
    TranslatableString mLabel;
    Identifier mSection;
-   int mType;
    int mIndex{0};
  private:
    void Init(wxWindow *parent, int type, const wxString & title, const wxString & label);
@@ -308,7 +306,7 @@ struct AUDACITY_DLL_API RegisteredToolbarFactory {
    using Function = std::function< ToolBar::Holder( AudacityProject & ) >;
    using Functions = std::vector< Function >;
 
-   RegisteredToolbarFactory( int id, const Function &function );
+   RegisteredToolbarFactory( const Function &function );
 
    static const Functions &GetFactories();
 };

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -63,34 +63,6 @@ DECLARE_EXPORTED_EVENT_TYPE(AUDACITY_DLL_API, EVT_TOOLBAR_UPDATED, -1);
 //
 #define toolbarGap 1
 
-//
-// ToolBar IDs
-//
-enum ToolBarID
-{
-   NoBarID = -1,
-   TransportBarID,
-   ToolsBarID,
-   MeterBarID,
-   RecordMeterBarID,
-   PlayMeterBarID,
-   EditBarID,
-   TranscriptionBarID,
-   ScrubbingBarID,
-   DeviceBarID,
-   SelectionBarID,
-#ifdef EXPERIMENTAL_SPECTRAL_EDITING
-   SpectralSelectionBarID,
-#endif
-   AudioSetupBarID,
-#ifdef HAS_AUDIOCOM_UPLOAD
-   ShareAudioBarID,
-#endif
-   TimeBarID,
-   CutCopyPasteBarID,
-   ToolBarCount
-};
-
 // How may pixels padding each side of a floating toolbar
 enum { ToolBarFloatMargin = 1 };
 

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -136,6 +136,11 @@ class AUDACITY_DLL_API ToolBar /* not final */
    void UpdatePrefs() override;
    virtual void RegenerateTooltips() = 0;
 
+   //! Get a value used for computing cascading positions of undocked bars
+   int GetIndex() const { return mIndex; }
+   //! Set a value used for computing cascading positions of undocked bars
+   void SetIndex(int index) { mIndex = index; }
+
    int GetType();
    TranslatableString GetTitle();
    TranslatableString GetLabel();
@@ -273,6 +278,7 @@ public:
    TranslatableString mLabel;
    Identifier mSection;
    int mType;
+   int mIndex{0};
  private:
    void Init(wxWindow *parent, int type, const wxString & title, const wxString & label);
 

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -106,7 +106,7 @@ class AUDACITY_DLL_API ToolBar /* not final */
    using Holder = wxWindowPtr<ToolBar>;
 
    ToolBar( AudacityProject &project,
-      int type, const TranslatableString & label, const wxString & section,
+      int type, const TranslatableString & label, const Identifier &section,
       bool resizable = false);
    virtual ~ToolBar();
 
@@ -124,7 +124,7 @@ class AUDACITY_DLL_API ToolBar /* not final */
    int GetType();
    TranslatableString GetTitle();
    TranslatableString GetLabel();
-   wxString GetSection();
+   Identifier GetSection();
    ToolDock *GetDock();
 
    void SetPreferredNeighbors(ToolBarID left, ToolBarID top = NoBarID);
@@ -256,7 +256,7 @@ public:
  protected:
    AudacityProject &mProject;
    TranslatableString mLabel;
-   wxString mSection;
+   Identifier mSection;
    int mType;
  private:
    void Init(wxWindow *parent, int type, const wxString & title, const wxString & label);

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -142,7 +142,7 @@ class AUDACITY_DLL_API ToolBar /* not final */
    Identifier GetSection();
    ToolDock *GetDock();
 
-   void SetPreferredNeighbors(ToolBarID left, ToolBarID top = NoBarID);
+   void SetPreferredNeighbors(Identifier left, Identifier top = {});
 
 private:
    void SetLabel(const wxString & label) override;
@@ -151,7 +151,7 @@ public:
    virtual void SetDocked(ToolDock *dock, bool pushed);
 
    //! Defaults to (NoBarID, NoBarId)
-   std::pair<ToolBarID, ToolBarID> PreferredNeighbors() const noexcept;
+   std::pair<Identifier, Identifier> PreferredNeighbors() const noexcept;
 
    // NEW virtual:
    virtual bool Expose(bool show = true);
@@ -283,8 +283,8 @@ public:
 
    wxBoxSizer *mHSizer;
 
-   ToolBarID mPreferredLeftNeighbor { NoBarID };
-   ToolBarID mPreferredTopNeighbor { NoBarID };
+   Identifier mPreferredLeftNeighbor;
+   Identifier mPreferredTopNeighbor;
 
    bool mVisible;
    bool mResizable;

--- a/src/toolbars/ToolDock.cpp
+++ b/src/toolbars/ToolDock.cpp
@@ -95,16 +95,16 @@ auto ToolBarConfiguration::Find(const ToolBar *bar) const -> Position
       return iter->position;
 }
 
-ToolBar* ToolBarConfiguration::FindToolBar(ToolBarID toolBarID) const
+ToolBar* ToolBarConfiguration::FindToolBar(Identifier toolBarID) const
 {
-   if (toolBarID == NoBarID)
+   if (toolBarID.empty())
       return nullptr;
    
    auto This = const_cast<ToolBarConfiguration*>(this);
    auto it = std::find_if(
       This->begin(), This->end(),
       [=](const Place& place)
-      { return place.pTree->pBar->GetType() == toolBarID; });
+      { return place.pTree->pBar->GetSection() == toolBarID; });
 
    return it != end() ? it->pTree->pBar : nullptr;
 }
@@ -241,7 +241,8 @@ void ToolBarConfiguration::Show(ToolBar *bar)
    if (!Contains(bar)) {
       auto position = UnspecifiedPosition;
       const auto preferredNeighbors = bar->PreferredNeighbors();
-      if (preferredNeighbors.first != NoBarID || preferredNeighbors.second != NoBarID)
+      if (!preferredNeighbors.first.empty() ||
+          !preferredNeighbors.second.empty())
       {
          auto leftNeighbor = FindToolBar(preferredNeighbors.first);
          auto topNeighbor = FindToolBar(preferredNeighbors.second);

--- a/src/toolbars/ToolDock.cpp
+++ b/src/toolbars/ToolDock.cpp
@@ -295,9 +295,7 @@ bool ToolBarConfiguration::Read
       gPrefs->Read( wxT("Order"), &ord, -1 );
       // Index was written 1-based
       --ord;
-      if (ord >= ToolBarCount)
-         result = false;
-      else if (ord >= 0)
+      if (ord >= 0)
       {
          // Legacy preferences
          while (pLegacy->bars.size() <= size_t(ord))
@@ -530,7 +528,9 @@ void ToolDock::VisitLayout(LayoutVisitor &visitor,
       ToolBar *lastSib {};
       ToolBar *lastWrappedChild {};
       wxRect rect;
-   } layout[ ToolBarCount ];
+   };
+   std::vector<Item> items(mBars.size());
+   Item *layout = items.data();
    Item *next = layout;
 
    ToolBar *lastRoot {};

--- a/src/toolbars/ToolDock.cpp
+++ b/src/toolbars/ToolDock.cpp
@@ -410,7 +410,6 @@ ToolDock::ToolDock( wxEvtHandler *manager, wxWindow *parent, int dockid ):
 
    // Init
    mManager = manager;
-   memset(mBars, 0, sizeof(mBars)); // otherwise uninitialized
    SetBackgroundColour(theTheme.Colour( clrMedium ));
    SetLayoutDirection(wxLayout_LeftToRight);
    // Use for testing gaps
@@ -433,7 +432,7 @@ void ToolDock::Undock( ToolBar *bar )
    {
       mConfiguration.Remove( bar );
    }
-   mBars[ bar->GetId() ] = nullptr;
+   mBars[ bar->GetSection() ] = nullptr;
 }
 
 //
@@ -448,7 +447,7 @@ void ToolDock::Dock( ToolBar *bar, bool deflate, ToolBarConfiguration::Position 
 
    // Adopt the toolbar into our family
    bar->Reparent( this );
-   mBars[ bar->GetId() ] = bar;
+   mBars[ bar->GetSection() ] = bar;
 
    // Reset size
    bar->SetSize(
@@ -475,7 +474,7 @@ void ToolDock::LoadConfig()
       this->Dock(bar, false);
       // Show it -- hidden bars are not (yet) ever saved as part of a
       // configuration
-      Expose( bar->GetId(), true );
+      Expose( bar->GetSection(), true );
    }
    Updated();
 }
@@ -525,12 +524,13 @@ void ToolDock::VisitLayout(LayoutVisitor &visitor,
 
    // For recording the nested subdivisions of the rectangle
    struct Item {
-      int myBarID { NoBarID };
-      int parentBarID { NoBarID };
+      Identifier section;
+      Item *parent{};
       ToolBar *lastSib {};
       ToolBar *lastWrappedChild {};
       wxRect rect;
    } layout[ ToolBarCount ];
+   Item *next = layout;
 
    ToolBar *lastRoot {};
    ToolBar *lastWrappedRoot {};
@@ -543,21 +543,23 @@ void ToolDock::VisitLayout(LayoutVisitor &visitor,
 
       // set up the chain of ancestors.
       const auto parent = place.position.rightOf;
-      const auto type = ct->GetType();
-      auto &newItem = layout[ type ];
-      newItem.parentBarID = parent ? parent->GetType() : NoBarID;
+      const auto section = ct->GetSection();
+      auto &newItem = *next++;
+      if (parent)
+         newItem.parent = std::find_if(layout, next - 1, [&](Item &item){
+            return parent->GetSection() == item.section;
+         });
       // Mark the slots that really were visited, for final pass through
       // the spaces.
-      newItem.myBarID = type;
+      newItem.section = section;
 
-      const auto parentItem = parent ? &layout[ parent->GetType() ] : nullptr;
       ToolBar *prevSib;
       if (!parent) {
          prevSib = lastRoot;
          lastRoot = ct;
       }
       else {
-         auto &sib = parentItem->lastSib;
+         auto &sib = newItem.parent->lastSib;
          prevSib = sib;
          sib = ct;
       }
@@ -584,7 +586,7 @@ void ToolDock::VisitLayout(LayoutVisitor &visitor,
       // window, the toolbars may "wrap."
       // Can always fall back to the main rectangle even if the bar is too
       // wide.
-      auto pItem = parentItem;
+      auto pItem = newItem.parent;
       auto pRect = pItem ? &pItem->rect : &main;
       while (pRect != &main)
       {
@@ -600,12 +602,13 @@ void ToolDock::VisitLayout(LayoutVisitor &visitor,
          if (!bTooWide && !bTooHigh)
             break;
 
-         if (pItem->parentBarID == NoBarID) {
+         auto parentItem = pItem->parent;
+         if (!parentItem) {
             pItem = nullptr;
             pRect = &main;
          }
          else {
-            pItem = &layout[ pItem->parentBarID ];
+            pItem = parentItem;
             pRect = &pItem->rect;
          }
       }
@@ -613,7 +616,7 @@ void ToolDock::VisitLayout(LayoutVisitor &visitor,
       // Record where the toolbar wrapped
       ToolBar *& sib = pItem ? pItem->lastWrappedChild : lastWrappedRoot;
       ToolBarConfiguration::Position newPosition {
-         pItem ? this->mBars[ pItem->myBarID ] : nullptr,
+         pItem ? this->mBars[ pItem->section ] : nullptr,
          sib
       };
       sib = ct;
@@ -637,19 +640,14 @@ void ToolDock::VisitLayout(LayoutVisitor &visitor,
    if (visitor.ShouldVisitSpaces()) {
       // Visit the fringe where NEW leaves of the tree could go
 
-      // Find the items with leftover spaces
-      const auto end = std::remove_if(layout, layout + ToolBarCount,
-         [](const Item &item){
-            return item.myBarID == NoBarID || item.rect.IsEmpty();
-         }
-      );
       // Sort top to bottom for definiteness, though perhaps not really needed
-      std::sort(layout, end,
+      // Do not use the parent pointers after this sort!
+      std::sort(layout, next,
          [](const Item &lhs, const Item &rhs){
             return lhs.rect.y < rhs.rect.y;
          }
       );
-      for (auto iter = layout; iter != end; ++iter) {
+      for (auto iter = layout; iter != next; ++iter) {
          const auto &item = *iter;
          const auto &rect = item.rect;
 
@@ -659,7 +657,7 @@ void ToolDock::VisitLayout(LayoutVisitor &visitor,
          // Let the visitor determine size
          wxSize sz {};
          ToolBarConfiguration::Position
-            position { this->mBars[ item.myBarID ], item.lastWrappedChild },
+            position { this->mBars[ item.section ], item.lastWrappedChild },
             prevPosition {};
          visitor.ModifySize(nullptr, globalRect, prevPosition, position, sz);
          int tw = sz.GetWidth() + toolbarGap;
@@ -858,7 +856,7 @@ void ToolDock::RestoreConfiguration(ToolBarConfiguration &backup)
 //
 // Set the visible/hidden state of a toolbar
 //
-void ToolDock::Expose( int type, bool show )
+void ToolDock::Expose( Identifier type, bool show )
 {
    ToolBar *t = mBars[ type ];
 

--- a/src/toolbars/ToolDock.h
+++ b/src/toolbars/ToolDock.h
@@ -39,8 +39,8 @@ class GrabberEvent;
 enum
 {
    NoDockID = 0,
-   TopDockID,
-   BotDockID,
+   TopDockID = ToolBar::TopDockID,
+   BotDockID = ToolBar::BotDockID,
    DockCount = 2
 };
 

--- a/src/toolbars/ToolDock.h
+++ b/src/toolbars/ToolDock.h
@@ -230,7 +230,7 @@ public:
    Iterator end() const { return Iterator {}; }
 
    Position Find(const ToolBar *bar) const;
-   ToolBar* FindToolBar(ToolBarID id) const;
+   ToolBar* FindToolBar(Identifier id) const;
 
    bool Contains(const ToolBar *bar) const
    {

--- a/src/toolbars/ToolDock.h
+++ b/src/toolbars/ToolDock.h
@@ -13,6 +13,7 @@
 #ifndef __AUDACITY_TOOLDOCK__
 #define __AUDACITY_TOOLDOCK__
 
+#include <map>
 #include <vector>
 #include <wx/defs.h>
 
@@ -298,7 +299,7 @@ public:
 
    void LoadConfig();
    void LayoutToolBars();
-   void Expose( int type, bool show );
+   void Expose( Identifier type, bool show );
    int GetOrder( ToolBar *bar );
    void Dock( ToolBar *bar, bool deflate,
               ToolBarConfiguration::Position ndx
@@ -341,7 +342,7 @@ public:
    // Configuration as modified by the constraint of the main window width
    ToolBarConfiguration mWrappedConfiguration;
 
-   ToolBar *mBars[ ToolBarCount ];
+   std::map<Identifier, ToolBar*> mBars;
 
  public:
 

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -1046,6 +1046,16 @@ ToolBar *ToolManager::GetToolBar( int type ) const
 }
 
 //
+// Return a pointer to the specified toolbar
+//
+ToolBar *ToolManager::GetToolBar(const Identifier &type) const
+{
+   auto end = std::end(mBars), iter = std::find_if(std::begin(mBars), end,
+      [&](auto &pBar){ return pBar && pBar->GetSection() == type; } );
+   return (iter == end) ? nullptr : iter->get();
+}
+
+//
 // Return a pointer to the top dock
 //
 ToolDock *ToolManager::GetTopDock()

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -927,11 +927,15 @@ void ToolManager::ReadConfig()
    for (const auto& entry : DefaultConfigTable)
    {
       int ndx = entry.barID;
-      ToolBar* bar = mBars[ndx].get();
+      const auto bar = mBars[ndx].get();
+      const auto rightCode = entry.rightOf;
+      const auto rightId =
+         rightCode >= 0 ? mBars[rightCode]->GetSection() : "";
+      const auto belowCode = entry.below;
+      const auto belowId =
+         belowCode >= 0 ? mBars[belowCode]->GetSection() : "";
 
-      bar->SetPreferredNeighbors(
-         static_cast<ToolBarID>(entry.rightOf),
-         static_cast<ToolBarID>(entry.below));
+      bar->SetPreferredNeighbors(rightId, belowId);
    }
 
    if (!someFound)

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -686,10 +686,10 @@ void ToolManager::Reset()
 
 void ToolManager::RegenerateTooltips()
 {
-   for (const auto &bar : mBars) {
+   ForEach([](auto bar){
       if (bar)
          bar->RegenerateTooltips();
-   }
+   });
 }
 
 int ToolManager::FilterEvent(wxEvent &event)
@@ -727,7 +727,7 @@ void ToolManager::ReadConfig()
    int width[ ToolBarCount ];
    int height[ ToolBarCount ];
    int x, y;
-   int dock, ndx;
+   int dock;
    bool someFound { false };
 
 #if defined(__WXMAC__)
@@ -753,9 +753,8 @@ void ToolManager::ReadConfig()
 
 
    // Load and apply settings for each bar
-   for( ndx = 0; ndx < ToolBarCount; ndx++ )
-   {
-      ToolBar *bar = mBars[ ndx ].get();
+   { int ndx = 0;
+   ForEach([&](ToolBar *bar){
       //wxPoint Center = mParent->GetPosition() + (mParent->GetSize() * 0.33);
       //wxPoint Center(
       //   wxSystemSettings::GetMetric( wxSYS_SCREEN_X ) /2 ,
@@ -920,6 +919,8 @@ void ToolManager::ReadConfig()
       // May or may not have gone into a subdirectory,
       // so use an absolute path.
       gPrefs->SetPath( wxT("/GUI/ToolBars") );
+   });
+   ++ndx;
    }
 
    mTopDock->GetConfiguration().PostRead(topLegacy);
@@ -994,10 +995,7 @@ void ToolManager::WriteConfig()
    gPrefs->SetPath( wxT("/GUI/ToolBars") );
 
    // Save state of each bar
-   for( ndx = 0; ndx < ToolBarCount; ndx++ )
-   {
-      ToolBar *bar = mBars[ ndx ].get();
-
+   ForEach([this](ToolBar *bar){
       // Change to the bar subkey
       gPrefs->SetPath( bar->GetSection().GET() );
 
@@ -1032,7 +1030,7 @@ void ToolManager::WriteConfig()
 
       // Change back to the bar root
       gPrefs->SetPath( wxT("..") );
-   }
+   });
 
    // Restore original config path
    gPrefs->SetPath( oldpath );

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -1000,14 +1000,6 @@ void ToolManager::WriteConfig()
 //
 // Return a pointer to the specified toolbar
 //
-ToolBar *ToolManager::GetToolBar( int type ) const
-{
-   return mBars[ type ].get();
-}
-
-//
-// Return a pointer to the specified toolbar
-//
 ToolBar *ToolManager::GetToolBar(const Identifier &type) const
 {
    auto end = std::end(mBars), iter = std::find_if(std::begin(mBars), end,

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -762,7 +762,7 @@ void ToolManager::ReadConfig()
       //   wxSystemSettings::GetMetric( wxSYS_SCREEN_Y ) /2 );
 
       // Change to the bar subkey
-      gPrefs->SetPath( bar->GetSection() );
+      gPrefs->SetPath( bar->GetSection().GET() );
 
       bool bShownByDefault = true;
       int defaultDock = TopDockID;
@@ -999,7 +999,7 @@ void ToolManager::WriteConfig()
       ToolBar *bar = mBars[ ndx ].get();
 
       // Change to the bar subkey
-      gPrefs->SetPath( bar->GetSection() );
+      gPrefs->SetPath( bar->GetSection().GET() );
 
       // Search both docks for toolbar order
       bool to = mTopDock->GetConfiguration().Contains( bar );

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -1118,7 +1118,7 @@ void ToolManager::Expose( int type, bool show )
    // Handle docked and floaters differently
    if( t->IsDocked() )
    {
-      t->GetDock()->Expose( type, show );
+      t->GetDock()->Expose( t->GetSection(), show );
    }
    else
    {

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -1123,12 +1123,29 @@ bool ToolManager::IsVisible( int type )
 }
 
 //
+// Returns the visibility of the specified toolbar
+//
+bool ToolManager::IsVisible( Identifier type )
+{
+   auto pBar = GetToolBar(type);
+   return pBar && IsVisible(pBar->GetId());
+}
+
+//
 // Toggles the visible/hidden state of a toolbar
 //
 void ToolManager::ShowHide( int type )
 {
    Expose( type, !mBars[ type ]->IsVisible() );
    Updated();
+}
+
+//
+// Toggles the visible/hidden state of a toolbar
+//
+void ToolManager::ShowHide( Identifier type )
+{
+   ShowHide(GetToolBar(type)->GetId());
 }
 
 //
@@ -1147,6 +1164,14 @@ void ToolManager::Expose( int type, bool show )
    {
       t->Expose( show );
    }
+}
+
+//
+// Set the visible/hidden state of a toolbar
+//
+void ToolManager::Expose( Identifier type, bool show )
+{
+   Expose(GetToolBar(type)->GetId(), show);
 }
 
 //
@@ -1600,10 +1625,10 @@ bool ToolManager::RestoreFocus()
 #include "../Menus.h"
 
 AttachedToolBarMenuItem::AttachedToolBarMenuItem(
-   ToolBarID id, const CommandID &name, const TranslatableString &label_in,
+   Identifier id, const CommandID &name, const TranslatableString &label_in,
    const Registry::OrderingHint &hint,
-   std::vector< ToolBarID > excludeIDs )
-   : mId{ id }
+   std::vector< Identifier > excludeIDs
+)  : mId{ id }
    , mAttachedItem{
       Registry::Placement{ wxT("View/Other/Toolbars/Toolbars/Other"), hint },
       (  MenuTable::FinderScope(

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -450,7 +450,8 @@ void ToolManager::CreateWindows()
    size_t ii = 0;
    for (const auto &factory : RegisteredToolbarFactory::GetFactories()) {
       if (factory) {
-         mBars[ii] = factory( *parent );
+         // TODO: assignment of indices independently of registration order
+         (mBars[ii] = factory( *parent )) -> SetIndex(ii);
       }
       else
          wxASSERT( false );
@@ -645,7 +646,7 @@ void ToolManager::Reset()
          // If there were multiple hidden toobars the * 10 adjustment means
          // they won't overlap too much.
          floater->CentreOnParent( );
-         const auto index = bar->GetType();
+         const auto index = bar->GetIndex();
          floater->Move(
             floater->GetPosition() + wxSize{ index * 10 - 200, index * 10 });
          bar->SetDocked( NULL, false );

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -447,7 +447,6 @@ void ToolManager::CreateWindows()
    // All have the project as parent window
    wxASSERT(parent);
 
-   size_t ii = 0;
    for (const auto &factory : RegisteredToolbarFactory::GetFactories()) {
       if (factory) {
          auto bar = factory( *parent );
@@ -459,14 +458,15 @@ void ToolManager::CreateWindows()
                bar->Destroy();
                continue;
             }
-            // TODO: assignment of indices independently of registration order
-            bar->SetIndex(ii++);
             slot = std::move(bar);
          }
       }
       else
          wxASSERT( false );
    }
+
+   //! Assign (non-persistent!) sequential ids to the toolbars
+   ForEach([ii = 0](ToolBar *bar) mutable { bar->SetIndex(ii++); });
 
    // We own the timer
    mTimer.SetOwner( this );

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -1468,7 +1468,7 @@ void ToolManager::OnGrabber( GrabberEvent & event )
       return HandleEscapeKey();
 
    // Remember which bar we're dragging
-   mDragBar = mBars[ event.GetId() ].get();
+   mDragBar = GetToolBar(event.BarId());
 
    // Remember state, in case of ESCape key later
    if (mDragBar->IsDocked()) {

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -72,15 +72,12 @@ class AUDACITY_DLL_API ToolManager final
 
    void LayoutToolBars();
 
-   bool IsDocked( int type );
+   bool IsDocked( Identifier type ) const;
 
-   bool IsVisible( int type );
-   bool IsVisible( Identifier type );
+   bool IsVisible( Identifier type ) const;
 
-   void ShowHide( int type );
    void ShowHide( Identifier type );
 
-   void Expose( int type, bool show );
    void Expose( Identifier type, bool show );
 
    ToolBar *GetToolBar(const Identifier &type) const;
@@ -103,14 +100,14 @@ class AUDACITY_DLL_API ToolManager final
    template< typename F >
    void ForEach( const F &fun )
    {
-      std::for_each(std::begin(mBars), std::end(mBars), [&fun](auto pBar){
-         fun(pBar.get());
+      std::for_each(std::begin(mBars), std::end(mBars), [&fun](auto &pair){
+         fun(pair.second.get());
       });
    }
 
    size_t CountBars() const
    {
-      return ToolBarCount;
+      return mBars.size();
    }
 
  private:
@@ -159,7 +156,7 @@ class AUDACITY_DLL_API ToolManager final
    ToolDock *mTopDock{};
    ToolDock *mBotDock{};
 
-   ToolBar::Holder mBars[ ToolBarCount ];
+   std::map<Identifier, ToolBar::Holder> mBars;
 
    wxPoint mPrevPosition {};
    ToolDock *mPrevDock {};

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -97,6 +97,19 @@ class AUDACITY_DLL_API ToolManager final
 
    bool RestoreFocus();
 
+   template< typename F >
+   void ForEach( const F &fun )
+   {
+      std::for_each(std::begin(mBars), std::end(mBars), [&fun](auto pBar){
+         fun(pBar.get());
+      });
+   }
+
+   size_t CountBars() const
+   {
+      return ToolBarCount;
+   }
+
  private:
 
    ToolBar *Float( ToolBar *t, wxPoint & pos );

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -83,7 +83,6 @@ class AUDACITY_DLL_API ToolManager final
    void Expose( int type, bool show );
    void Expose( Identifier type, bool show );
 
-   ToolBar *GetToolBar( int type ) const;
    ToolBar *GetToolBar(const Identifier &type) const;
 
    ToolDock *GetTopDock();

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -75,10 +75,13 @@ class AUDACITY_DLL_API ToolManager final
    bool IsDocked( int type );
 
    bool IsVisible( int type );
+   bool IsVisible( Identifier type );
 
    void ShowHide( int type );
+   void ShowHide( Identifier type );
 
    void Expose( int type, bool show );
+   void Expose( Identifier type, bool show );
 
    ToolBar *GetToolBar( int type ) const;
    ToolBar *GetToolBar(const Identifier &type) const;
@@ -239,16 +242,16 @@ public:
 // hides a toolbar
 struct AUDACITY_DLL_API AttachedToolBarMenuItem : CommandHandlerObject {
    AttachedToolBarMenuItem(
-      ToolBarID id, const CommandID &name, const TranslatableString &label_in,
+      Identifier id, const CommandID &name, const TranslatableString &label_in,
       const Registry::OrderingHint &hint = {},
       // IDs of other toolbars not to be shown simultaneously with this one:
-      std::vector< ToolBarID > excludeIds = {} );
+      std::vector< Identifier > excludeIds = {} );
 
    void OnShowToolBar(const CommandContext &context);
 
-   const ToolBarID mId;
+   const Identifier mId;
    const MenuTable::AttachedItem mAttachedItem;
-   const std::vector< ToolBarID > mExcludeIds;
+   const std::vector< Identifier > mExcludeIds;
 };
 
 #endif

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -97,8 +97,9 @@ class AUDACITY_DLL_API ToolManager final
 
    bool RestoreFocus();
 
+   //! Visit bars, lexicographically by their textual ids
    template< typename F >
-   void ForEach( const F &fun )
+   void ForEach(F &&fun)
    {
       std::for_each(std::begin(mBars), std::end(mBars), [&fun](auto &pair){
          fun(pair.second.get());
@@ -156,6 +157,7 @@ class AUDACITY_DLL_API ToolManager final
    ToolDock *mTopDock{};
    ToolDock *mBotDock{};
 
+   //! map not unordered_map, for the promise made by ForEach
    std::map<Identifier, ToolBar::Holder> mBars;
 
    wxPoint mPrevPosition {};

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -81,6 +81,7 @@ class AUDACITY_DLL_API ToolManager final
    void Expose( int type, bool show );
 
    ToolBar *GetToolBar( int type ) const;
+   ToolBar *GetToolBar(const Identifier &type) const;
 
    ToolDock *GetTopDock();
    const ToolDock *GetTopDock() const;

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -264,7 +264,7 @@ namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows a toolbar
       that has some tools in it */
-   ToolsBarID, wxT("ShowToolsTB"), XXO("T&ools Toolbar"),
+   ToolsToolBar::ID(), wxT("ShowToolsTB"), XXO("T&ools Toolbar"),
 };
 }
 

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -109,7 +109,7 @@ ToolsToolBar::~ToolsToolBar()
 ToolsToolBar &ToolsToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
-   return *static_cast<ToolsToolBar*>( toolManager.GetToolBar(ToolsBarID) );
+   return *static_cast<ToolsToolBar*>(toolManager.GetToolBar(ID()));
 }
 
 const ToolsToolBar &ToolsToolBar::Get( const AudacityProject &project )

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -71,9 +71,14 @@ BEGIN_EVENT_TABLE(ToolsToolBar, ToolBar)
                      ToolsToolBar::OnTool)
 END_EVENT_TABLE()
 
+Identifier ToolsToolBar::ID()
+{
+   return wxT("Tools");
+}
+
 //Standard constructor
 ToolsToolBar::ToolsToolBar( AudacityProject &project )
-: ToolBar(project, ToolsBarID, XO("Tools"), wxT("Tools"))
+: ToolBar(project, ToolsBarID, XO("Tools"), ID())
 {
    using namespace ToolCodes;
 

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -78,7 +78,7 @@ Identifier ToolsToolBar::ID()
 
 //Standard constructor
 ToolsToolBar::ToolsToolBar( AudacityProject &project )
-: ToolBar(project, ToolsBarID, XO("Tools"), ID())
+: ToolBar(project, XO("Tools"), ID())
 {
    using namespace ToolCodes;
 
@@ -255,7 +255,7 @@ void ToolsToolBar::Create(wxWindow * parent)
    UpdatePrefs();
 }
 
-static RegisteredToolbarFactory factory{ ToolsBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew ToolsToolBar{ project } }; }
 };

--- a/src/toolbars/ToolsToolBar.h
+++ b/src/toolbars/ToolsToolBar.h
@@ -35,6 +35,7 @@ const int FirstToolID = 11200;
 class ToolsToolBar final : public ToolBar {
 
  public:
+   static Identifier ID();
 
    ToolsToolBar( AudacityProject &project );
    virtual ~ToolsToolBar();

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -93,10 +93,15 @@ BEGIN_EVENT_TABLE(TranscriptionToolBar, ToolBar)
 END_EVENT_TABLE()
    ;   //semicolon enforces  proper automatic indenting in emacs.
 
+Identifier TranscriptionToolBar::ID()
+{
+   return wxT("Transcription");
+}
+
 ////Standard Constructor
 TranscriptionToolBar::TranscriptionToolBar( AudacityProject &project )
 : ToolBar( project,
-   TranscriptionBarID, XO("Play-at-Speed"), wxT("Transcription"), true )
+   TranscriptionBarID, XO("Play-at-Speed"), ID(), true )
 {
    SetPlaySpeed( 1.0 * 100.0 );
 #ifdef EXPERIMENTAL_VOICE_DETECTION

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -116,7 +116,7 @@ TranscriptionToolBar::~TranscriptionToolBar()
 TranscriptionToolBar &TranscriptionToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );
-   return *static_cast<TranscriptionToolBar*>( toolManager.GetToolBar(TranscriptionBarID) );
+   return *static_cast<TranscriptionToolBar*>(toolManager.GetToolBar(ID()));
 }
 
 const TranscriptionToolBar &TranscriptionToolBar::Get( const AudacityProject &project )

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -1066,7 +1066,8 @@ namespace {
 AttachedToolBarMenuItem sAttachment{
    /* i18n-hint: Clicking this menu item shows the toolbar
       for transcription (currently just vary play speed) */
-   TranscriptionBarID, wxT("ShowTranscriptionTB"), XXO("Pla&y-at-Speed Toolbar")
+   TranscriptionToolBar::ID(),
+   wxT("ShowTranscriptionTB"), XXO("Pla&y-at-Speed Toolbar")
 };
 }
 

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -100,8 +100,7 @@ Identifier TranscriptionToolBar::ID()
 
 ////Standard Constructor
 TranscriptionToolBar::TranscriptionToolBar( AudacityProject &project )
-: ToolBar( project,
-   TranscriptionBarID, XO("Play-at-Speed"), ID(), true )
+: ToolBar( project, XO("Play-at-Speed"), ID(), true )
 {
    SetPlaySpeed( 1.0 * 100.0 );
 #ifdef EXPERIMENTAL_VOICE_DETECTION
@@ -1073,7 +1072,7 @@ void TranscriptionToolBar::AdjustPlaySpeed(float adj)
    OnSpeedSlider(e);
 }
 
-static RegisteredToolbarFactory factory{ TranscriptionBarID,
+static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew TranscriptionToolBar{ project } }; }
 };

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -113,6 +113,22 @@ TranscriptionToolBar::~TranscriptionToolBar()
 {
 }
 
+bool TranscriptionToolBar::ShownByDefault() const
+{
+   return
+#ifdef EXPERIMENTAL_DA
+      false
+#else
+      true
+#endif
+   ;
+}
+
+ToolBar::DockID TranscriptionToolBar::DefaultDockID() const
+{
+   return BotDockID;
+}
+
 TranscriptionToolBar &TranscriptionToolBar::Get( AudacityProject &project )
 {
    auto &toolManager = ToolManager::Get( project );

--- a/src/toolbars/TranscriptionToolBar.h
+++ b/src/toolbars/TranscriptionToolBar.h
@@ -62,6 +62,8 @@ class TranscriptionToolBar final : public ToolBar {
 
  public:
 
+   static Identifier ID();
+
    TranscriptionToolBar( AudacityProject &project );
    virtual ~TranscriptionToolBar();
 

--- a/src/toolbars/TranscriptionToolBar.h
+++ b/src/toolbars/TranscriptionToolBar.h
@@ -67,6 +67,10 @@ class TranscriptionToolBar final : public ToolBar {
    TranscriptionToolBar( AudacityProject &project );
    virtual ~TranscriptionToolBar();
 
+   bool ShownByDefault() const override;
+
+   DockID DefaultDockID() const override;
+
    static TranscriptionToolBar &Get( AudacityProject &project );
    static const TranscriptionToolBar &Get( const AudacityProject &project );
 

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -970,8 +970,8 @@ void Scrubber::OnToggleScrubRuler(const CommandContext&)
    mShowScrubbing = !mShowScrubbing;
    WriteScrubEnabledPref(mShowScrubbing);
    gPrefs->Flush();
-   const auto toolbar =
-      ToolManager::Get( *mProject ).GetToolBar( ScrubbingBarID );
+   // To do: move this, or eliminate it, use an event instead
+   const auto toolbar = ToolManager::Get(*mProject).GetToolBar(wxT("Scrub"));
    toolbar->EnableDisableButtons();
    CheckMenuItems();
 }

--- a/src/widgets/Grabber.cpp
+++ b/src/widgets/Grabber.cpp
@@ -53,12 +53,13 @@ END_EVENT_TABLE()
 //
 // Constructor
 //
-Grabber::Grabber(wxWindow * parent, wxWindowID id)
+Grabber::Grabber(wxWindow * parent, Identifier id)
 : wxWindow(parent,
-           id,
+           wxID_ANY,
            wxDefaultPosition,
            wxSize(grabberWidth, 27),
            wxFULL_REPAINT_ON_RESIZE)
+, mIdentifier{ id }
 {
    mOver = false;
    mPressed = false;
@@ -88,7 +89,7 @@ void Grabber::SendEvent(wxEventType type, const wxPoint & pos, bool escaping)
    wxWindow *parent = GetParent();
 
    // Initialize event and convert mouse coordinates to screen space
-   GrabberEvent e(type, GetId(), parent->ClientToScreen(pos), escaping);
+   GrabberEvent e(type, mIdentifier, parent->ClientToScreen(pos), escaping);
 
    // Set the object of our desire
    e.SetEventObject(parent);

--- a/src/widgets/Grabber.h
+++ b/src/widgets/Grabber.h
@@ -29,7 +29,7 @@ flicker-free use.
 #ifndef __AUDACITY_WIDGETS_GRABBER__
 #define __AUDACITY_WIDGETS_GRABBER__
 
-
+#include "Identifier.h"
 
 #include <wx/defs.h>
 #include <wx/statbmp.h> // to inherit
@@ -49,10 +49,11 @@ class GrabberEvent final : public wxCommandEvent
  public:
 
    GrabberEvent(wxEventType type = wxEVT_NULL,
-                wxWindowID winid = 0,
+                Identifier barId = {},
                 const wxPoint& pt = wxDefaultPosition,
                 bool escaping = false)
-   : wxCommandEvent(type, winid)
+   : wxCommandEvent(type)
+   , mBarId{ barId }
    {
       mPos = pt;
       mEscaping = escaping;
@@ -73,6 +74,8 @@ class GrabberEvent final : public wxCommandEvent
 
    bool IsEscaping() const { return mEscaping; }
 
+   Identifier BarId() const { return mBarId; }
+
    // Clone is required by wxwidgets; implemented via copy constructor
    wxEvent *Clone() const override
    {
@@ -81,6 +84,7 @@ class GrabberEvent final : public wxCommandEvent
 
  protected:
 
+   const Identifier mBarId;
    wxPoint mPos;
    bool mEscaping {};
 };
@@ -104,7 +108,7 @@ class AUDACITY_DLL_API Grabber final : public wxWindow
 
  public:
 
-   Grabber(wxWindow *parent, wxWindowID id);
+   Grabber(wxWindow *parent, Identifier id);
    virtual ~Grabber();
 
    // We don't need or want to accept focus since there's really
@@ -136,6 +140,7 @@ class AUDACITY_DLL_API Grabber final : public wxWindow
    void DrawGrabber(wxDC & dc);
    void SendEvent(wxEventType type, const wxPoint & pos, bool escaping);
 
+   const Identifier mIdentifier;
    bool mOver;
    bool mPressed;
    bool mAsSpacer;


### PR DESCRIPTION
Resolves:

To prepare for extraction of individual toolbars into separate modules, leaving the
general toolbar system itself open-ended: eliminate the enumeration of toolbar types.

There is still mention of toolbar types, but only by string identifiers describing the default
configuration, and it is allowed for the lookup of one of the names to fail.

There was already a registration of toobar types but not yet complete open-endedness.
This isn't really complete yet either -- ideally toolbars should register their own preferred
placements with hints, as do the menu items.

But review is invited for the existing commits which are not likely to change.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
