### PR TITLE
Fix window closing crash

### DIFF
--- a/libraries/lib-project/Project.cpp
+++ b/libraries/lib-project/Project.cpp
@@ -75,12 +75,22 @@ int AudacityProject::mProjectCounter=0;// global counter.
 //This array holds onto all of the projects currently open
 AllProjects::Container AllProjects::gAudacityProjects;
 
-AudacityProject::AudacityProject()
+std::shared_ptr<AudacityProject> AudacityProject::Create()
+{
+   // Must complete make_shared before using shared_from_this() or
+   // weak_from_this()
+   auto result = std::make_shared<AudacityProject>(CreateToken{});
+   // Only now build the attached objects, which also causes the project window
+   // to be built on demand
+   result->AttachedObjects::BuildAll();
+   // But not for all the attached windows.  They get built on demand only
+   // later.
+   return result;
+}
+
+AudacityProject::AudacityProject(CreateToken)
 {
    mProjectNo = mProjectCounter++; // Bug 322
-   AttachedObjects::BuildAll();
-   // But not for the attached windows.  They get built only on demand, such as
-   // from menu items.
 }
 
 AudacityProject::~AudacityProject()

--- a/libraries/lib-project/Project.h
+++ b/libraries/lib-project/Project.h
@@ -87,10 +87,14 @@ class PROJECT_API AudacityProject final
    , public AttachedProjectObjects
    , public std::enable_shared_from_this<AudacityProject>
 {
+   struct CreateToken{};
  public:
    using AttachedObjects = ::AttachedProjectObjects;
 
-   AudacityProject();
+   //! Use this factory function
+   static std::shared_ptr<AudacityProject> Create();
+   //! Don't use this constructor directly
+   AudacityProject(CreateToken);
    virtual ~AudacityProject();
 
    int GetProjectNumber(){ return mProjectNo;}

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -2692,7 +2692,7 @@ FROM sampleblocks WHERE blockid = ?1;)";
 }
 
 InvisibleTemporaryProject::InvisibleTemporaryProject()
-   : mpProject{ std::make_shared< AudacityProject >() }
+   : mpProject{ AudacityProject::Create() }
 {
 }
 

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -175,7 +175,10 @@ void ProjectManager::SaveWindowSize()
 
 void InitProjectWindow( ProjectWindow &window )
 {
-   auto &project = window.GetProject();
+   auto pProject = window.FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
 
 #ifdef EXPERIMENTAL_DA2
    SetBackgroundColour(theTheme.Colour( clrMedium ));

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -338,7 +338,7 @@ AudacityProject *ProjectManager::New()
    
    // Create and show a NEW project
    // Use a non-default deleter in the smart pointer!
-   auto sp = std::make_shared< AudacityProject >();
+   auto sp = AudacityProject::Create();
    AllProjects{}.Add( sp );
    auto p = sp.get();
    auto &project = *p;

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -645,7 +645,8 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
 
    mContainerWindow->Initialize(mTrackListWindow);
 
-   auto effectsPanel = safenew ThemedWindowWrapper<RealtimeEffectPanel>(mProject, mContainerWindow, wxID_ANY);
+   auto effectsPanel = safenew ThemedWindowWrapper<RealtimeEffectPanel>(
+      project, mContainerWindow, wxID_ANY);
    effectsPanel->SetName(_("Realtime effects"));
    effectsPanel->SetBackgroundColorIndex(clrMedium);
    effectsPanel->Hide();//initially hidden
@@ -703,9 +704,10 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
       .Subscribe([this](const TrackFocusChangeMessage& msg) {
          if(mEffectsWindow->IsShown())
          {
-            auto& project = GetProject();
-            auto& trackFocus = TrackFocus::Get(project);
-            ShowEffectsPanel(trackFocus.Get(), false);
+            if (auto project = FindProject()) {
+               auto& trackFocus = TrackFocus::Get(*project);
+               ShowEffectsPanel(trackFocus.Get(), false);
+            }
          }
       });
 
@@ -739,7 +741,6 @@ END_EVENT_TABLE()
 
 void ProjectWindow::ApplyUpdatedTheme()
 {
-   auto &project = mProject;
    SetBackgroundColour(theTheme.Colour( clrMedium ));
    ClearBackground();// For wxGTK.
 }
@@ -754,7 +755,11 @@ void ProjectWindow::RedrawProject(const bool bForceWaveTracks /*= false*/)
    if (pThis->IsBeingDeleted())
       return;
 
-   auto &project = pThis->mProject ;
+   auto pProject = pThis->FindProject();
+   if (!pProject)
+      return;
+
+   auto &project = *pProject;
    auto &tracks = TrackList::Get( project );
    auto &trackPanel = GetProjectPanel( project );
    pThis->FixScrollbars();
@@ -771,9 +776,13 @@ void ProjectWindow::RedrawProject(const bool bForceWaveTracks /*= false*/)
 
 void ProjectWindow::OnThemeChange(ThemeChangeMessage message)
 {
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
+
    if (message.appearance)
       return;
-   auto &project = mProject;
    this->ApplyUpdatedTheme();
    auto &toolManager = ToolManager::Get( project );
    for( int ii = 0; ii < ToolBarCount; ++ii )
@@ -823,8 +832,12 @@ const int sbarHjump = 30;       //STM: This is how far the thumb jumps when the 
 // Make sure selection edge is in view
 void ProjectWindow::ScrollIntoView(double pos)
 {
-   auto &trackPanel = GetProjectPanel( mProject );
-   auto &viewInfo = ViewInfo::Get( mProject );
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
+   auto &trackPanel = GetProjectPanel( project );
+   auto &viewInfo = ViewInfo::Get( project );
    auto w = viewInfo.GetTracksUsableWidth();
 
    int pixel = viewInfo.TimeToPosition(pos);
@@ -838,7 +851,11 @@ void ProjectWindow::ScrollIntoView(double pos)
 
 void ProjectWindow::ScrollIntoView(int x)
 {
-   auto &viewInfo = ViewInfo::Get( mProject );
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
+   auto &viewInfo = ViewInfo::Get( project );
    ScrollIntoView(viewInfo.PositionToTime(x, viewInfo.GetLeftOffset()));
 }
 
@@ -848,7 +865,10 @@ void ProjectWindow::ScrollIntoView(int x)
 ///
 void ProjectWindow::OnScrollLeft()
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    wxInt64 pos = mHsbar->GetThumbPosition();
    // move at least one scroll increment
@@ -871,7 +891,10 @@ void ProjectWindow::OnScrollLeft()
 
 void ProjectWindow::OnScrollRight()
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    wxInt64 pos = mHsbar->GetThumbPosition();
    // move at least one scroll increment
@@ -896,7 +919,10 @@ void ProjectWindow::OnScrollRight()
 ///
 void ProjectWindow::OnScrollLeftButton(wxScrollEvent & /*event*/)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    wxInt64 pos = mHsbar->GetThumbPosition();
    // move at least one scroll increment
@@ -917,7 +943,10 @@ void ProjectWindow::OnScrollLeftButton(wxScrollEvent & /*event*/)
 ///
 void ProjectWindow::OnScrollRightButton(wxScrollEvent & /*event*/)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    wxInt64 pos = mHsbar->GetThumbPosition();
    // move at least one scroll increment
@@ -939,7 +968,10 @@ void ProjectWindow::OnScrollRightButton(wxScrollEvent & /*event*/)
 
 bool ProjectWindow::MayScrollBeyondZero() const
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return false;
+   auto &project = *pProject;
    auto &scrubber = Scrubber::Get( project );
    auto &viewInfo = ViewInfo::Get( project );
    if (viewInfo.bScrollBeyondZero)
@@ -960,7 +992,10 @@ bool ProjectWindow::MayScrollBeyondZero() const
 
 double ProjectWindow::ScrollingLowerBoundTime() const
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return 0;
+   auto &project = *pProject;
    auto &tracks = TrackList::Get( project );
    auto &viewInfo = ViewInfo::Get( project );
    if (!MayScrollBeyondZero())
@@ -973,7 +1008,10 @@ double ProjectWindow::ScrollingLowerBoundTime() const
 // That's why ViewInfo::TimeRangeToPixelWidth was defined, with some regret.
 double ProjectWindow::PixelWidthBeforeTime(double scrollto) const
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return 0;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    const double lowerBound = ScrollingLowerBoundTime();
    return
@@ -983,7 +1021,10 @@ double ProjectWindow::PixelWidthBeforeTime(double scrollto) const
 
 void ProjectWindow::SetHorizontalThumb(double scrollto)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    const auto unscaled = PixelWidthBeforeTime(scrollto);
    const int max = mHsbar->GetRange() - mHsbar->GetThumbSize();
@@ -1046,7 +1087,10 @@ bool ProjectWindow::TP_ScrollUpDown(int delta)
 
 void ProjectWindow::FixScrollbars()
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &tracks = TrackList::Get( project );
    auto &trackPanel = GetProjectPanel( project );
    auto &viewInfo = ViewInfo::Get( project );
@@ -1202,7 +1246,10 @@ void ProjectWindow::FixScrollbars()
 
 void ProjectWindow::UpdateLayout()
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &trackPanel = GetProjectPanel( project );
    auto &toolManager = ToolManager::Get( project );
 
@@ -1296,6 +1343,10 @@ void ProjectWindow::Reset()
 
 void ProjectWindow::UpdateStatusWidths()
 {
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    enum { nWidths = nStatusBarFields + 1 };
    int widths[ nWidths ]{ 0 };
    widths[ rateStatusBarField ] = 150;
@@ -1308,7 +1359,7 @@ void ProjectWindow::UpdateStatusWidths()
       int &width = widths[ ii ];
       for ( const auto &function : functions ) {
          auto results =
-            function( mProject, static_cast< StatusBarField >( ii ) );
+            function( project, static_cast< StatusBarField >( ii ) );
          for ( const auto &string : results.first ) {
             int w;
             statusBar->GetTextExtent(string.Translation(), &w, nullptr);
@@ -1483,7 +1534,10 @@ void ProjectWindow::OnUndoReset()
 
 void ProjectWindow::OnScroll(wxScrollEvent & WXUNUSED(event))
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    const wxInt64 offset = PixelWidthBeforeTime(0.0);
    viewInfo.sbarH =
@@ -1501,7 +1555,10 @@ void ProjectWindow::OnScroll(wxScrollEvent & WXUNUSED(event))
 
 void ProjectWindow::DoScroll()
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &trackPanel = GetProjectPanel( project );
    auto &viewInfo = ViewInfo::Get( project );
    const double lowerBound = ScrollingLowerBoundTime();
@@ -1547,9 +1604,12 @@ void ProjectWindow::OnMenu(wxCommandEvent & event)
       return;
    }
 #endif
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &commandManager = CommandManager::Get( project );
-   bool handled = commandManager.HandleMenuID( GetProject(),
+   bool handled = commandManager.HandleMenuID( project,
       event.GetId(), MenuManager::Get( project ).GetUpdateFlags(),
       false);
 
@@ -1563,7 +1623,10 @@ void ProjectWindow::OnMenu(wxCommandEvent & event)
 
 void ProjectWindow::OnUpdateUI(wxUpdateUIEvent & WXUNUSED(event))
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    MenuManager::Get( project ).UpdateMenus();
 }
 
@@ -1575,7 +1638,10 @@ void ProjectWindow::OnActivate(wxActivateEvent & event)
       return;
    }
 
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
 
    mActive = event.GetActive();
 
@@ -1606,14 +1672,20 @@ bool ProjectWindow::IsActive()
 
 void ProjectWindow::OnMouseEvent(wxMouseEvent & event)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    if (event.ButtonDown())
       SetActiveProject( &project );
 }
 
 void ProjectWindow::ZoomAfterImport(Track *pTrack)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &tracks = TrackList::Get( project );
    auto &trackPanel = GetProjectPanel( project );
 
@@ -1633,7 +1705,10 @@ void ProjectWindow::ZoomAfterImport(Track *pTrack)
 // Utility function called by other zoom methods
 void ProjectWindow::Zoom(double level)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    viewInfo.SetZoom(level);
    FixScrollbars();
@@ -1652,7 +1727,10 @@ void ProjectWindow::Zoom(double level)
 // Utility function called by other zoom methods
 void ProjectWindow::ZoomBy(double multiplier)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    viewInfo.ZoomBy(multiplier);
    FixScrollbars();
@@ -1668,7 +1746,10 @@ void ProjectWindow::ZoomBy(double multiplier)
 ///////////////////////////////////////////////////////////////////
 void ProjectWindow::Rewind(bool shift)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    viewInfo.selectedRegion.setT0(0, false);
    if (!shift)
@@ -1688,7 +1769,10 @@ void ProjectWindow::Rewind(bool shift)
 ///////////////////////////////////////////////////////////////////
 void ProjectWindow::SkipEnd(bool shift)
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &tracks = TrackList::Get( project );
    auto &viewInfo = ViewInfo::Get( project );
    double len = tracks.GetEndTime();
@@ -1782,7 +1866,10 @@ void ProjectWindow::PlaybackScroller::OnTimer()
 
 void ProjectWindow::ZoomInByFactor( double ZoomFactor )
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
 
    auto gAudioIO = AudioIO::Get();
@@ -1862,7 +1949,10 @@ void ProjectWindow::ZoomInByFactor( double ZoomFactor )
 
 void ProjectWindow::ZoomOutByFactor( double ZoomFactor )
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
 
    //Zoom() may change these, so record original values:
@@ -1879,7 +1969,10 @@ void ProjectWindow::ZoomOutByFactor( double ZoomFactor )
 
 double ProjectWindow::GetZoomOfToFit() const
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return 1.0;
+   auto &project = *pProject;
    auto &tracks = TrackList::Get( project );
    auto &viewInfo = ViewInfo::Get( project );
 
@@ -1899,7 +1992,10 @@ double ProjectWindow::GetZoomOfToFit() const
 
 void ProjectWindow::DoZoomFit()
 {
-   auto &project = mProject;
+   auto pProject = FindProject();
+   if (!pProject)
+      return;
+   auto &project = *pProject;
    auto &viewInfo = ViewInfo::Get( project );
    auto &tracks = TrackList::Get( project );
    auto &window = *this;

--- a/src/ProjectWindowBase.cpp
+++ b/src/ProjectWindowBase.cpp
@@ -17,7 +17,7 @@ ProjectWindowBase::ProjectWindowBase(wxWindow * parent, wxWindowID id,
                                  const wxPoint & pos,
                                  const wxSize & size, AudacityProject &project)
    : wxFrame(parent, id, _TS("Audacity"), pos, size)
-   , mProject{ project }
+   , mwProject{ project.weak_from_this() }
 {
    SetProjectFrame( project, *this );
 
@@ -44,7 +44,7 @@ ProjectWindowBase *FindProjectWindow( wxWindow *pWindow )
 AudacityProject *FindProjectFromWindow( wxWindow *pWindow )
 {
    auto pProjectWindow = FindProjectWindow( pWindow );
-   return pProjectWindow ? &pProjectWindow->GetProject() : nullptr;
+   return pProjectWindow ? pProjectWindow->FindProject().get() : nullptr;
 }
 
 const AudacityProject *FindProjectFromWindow( const wxWindow *pWindow )

--- a/src/ProjectWindowBase.h
+++ b/src/ProjectWindowBase.h
@@ -12,6 +12,7 @@ Paul Licameli split from ProjectWindow.h
 #define __AUDACITY_PROJECT_WINDOW_BASE__
 
 #include <wx/frame.h> // to inherit
+#include <memory>
 
 class AudacityProject;
 
@@ -26,11 +27,13 @@ public:
 
    ~ProjectWindowBase() override;
 
-   AudacityProject &GetProject() { return mProject; }
-   const AudacityProject &GetProject() const { return mProject; }
+   std::shared_ptr<AudacityProject> FindProject()
+      { return mwProject.lock(); }
+   std::shared_ptr<const AudacityProject> FindProject() const
+      { return mwProject.lock(); }
 
 protected:
-   AudacityProject &mProject;
+   std::weak_ptr<AudacityProject> mwProject;
 };
 
 AUDACITY_DLL_API AudacityProject *FindProjectFromWindow( wxWindow *pWindow );

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -364,7 +364,7 @@ AudacityProject * TrackPanel::GetProject() const
    while(window != nullptr)
    {
       if(const auto projectWindow = dynamic_cast<ProjectWindow*>(window))
-         return &projectWindow->GetProject();
+         return projectWindow->FindProject().get();
 
       window = window->GetParent();
    }


### PR DESCRIPTION
Resolves: #3892 

Possible fix for some crashes on Windows after closing project window.

Long but repetitious -- a lot of null checks in event handlers of ProjectWindow,
which now holds a weak pointer, not a reference, to its project.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
