### PR TITLE
Fixes Xcode >= 14 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,20 @@ set( _OPT "audacity_" )
 # Our very own project
 project( Audacity )
 
+# XCode 14 no longer allows building unsigned binaries.
+# So for the XCode 14 `-` is passed as the code sign identity, which stands for
+# local signing. `--deep` is passed, because 3d party libraries are copied unsigned.
+# XCODE_VERSION is defined only after the project() command
+
+if( APPLE )
+   if (XCODE_VERSION VERSION_LESS 14)
+      set( CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "" CACHE INTERNAL "" )
+   else()
+      set( CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "-" CACHE INTERNAL "" )
+      set( CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS "--deep" CACHE INTERNAL "")
+   endif()
+endif()
+
 # Load our functions/macros
 include( AudacityFunctions )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1429,6 +1429,22 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
          ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Wrapper> "${_EXEDIR}/Wrapper"
       POST_BUILD
    )
+
+   # Because the wrapper is copied into the bundle, we need to
+   # re-sing the bundle as the last post build step.
+   # This is only required when using the Xcode generator with
+   # the  Xcode >= 14.
+   if (XCODE_VERSION VERSION_GREATER_EQUAL 14)
+      add_custom_command(
+         TARGET
+            ${TARGET}
+         COMMAND
+            ${CMAKE_COMMAND} -E echo "Fixing Xcode 14 code signing issues"
+         COMMAND
+            codesign --force --deep --sign - "${_DESTDIR}/Audacity.app"
+         POST_BUILD
+      )
+   endif()
 else()
    set_target_properties(
       ${TARGET}


### PR DESCRIPTION
Xcode >= 14 no longer allows to disable code signing. This limitation is overcame by enabling "Sign to Run Locally by Xcode"

> This PR does not immediately change the behavior of CI builds, as CI uses Xcode 13

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
