### PR TITLE
Vst refresh rate

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -31,7 +31,8 @@ const EffectSettings &SimpleEffectSettingsAccess::Get()
 void SimpleEffectSettingsAccess::Set(EffectSettings &&settings,
    std::unique_ptr<Message>)
 {
-   mSettings = std::move(settings);
+   if (settings.has_value())
+      mSettings = std::move(settings);
 }
 
 void SimpleEffectSettingsAccess::Flush()
@@ -111,7 +112,8 @@ bool EffectSettingsManager::VisitSettings(
 
 auto EffectSettingsManager::MakeSettings() const -> EffectSettings
 {
-   return {};
+   // Return a non-empty any
+   return EffectSettings::Make<nullptr_t>();
 }
 
 auto EffectSettingsManager::MakeOutputs() const

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -219,6 +219,7 @@ public:
       : mSettings{settings} {}
    ~SimpleEffectSettingsAccess() override;
    const EffectSettings &Get() override;
+   //! Reassigns mSettings only if settings.has_value()
    void Set(EffectSettings &&settings,
       std::unique_ptr<Message> pMessage) override;
    void Flush() override;

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -212,7 +212,7 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
                // Let the instance consume the message directly.
                if (auto pInstance = pState->mwInstance.lock()) {
                   auto &stateSettings = pState->mMainSettings.settings;
-                  stateSettings = settings;
+                  stateSettings = std::move(settings);
                   EffectInstance::MessagePackage package{
                      stateSettings, pMessage.get()
                   };

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -211,8 +211,10 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
                // Other thread isn't processing.
                // Let the instance consume the message directly.
                if (auto pInstance = pState->mwInstance.lock()) {
+                  auto &stateSettings = pState->mMainSettings.settings;
+                  stateSettings = settings;
                   EffectInstance::MessagePackage package{
-                     pState->mWorkerSettings.settings, pMessage.get()
+                     stateSettings, pMessage.get()
                   };
                   pInstance->RealtimeProcessStart(package);
                   return;
@@ -461,14 +463,22 @@ bool RealtimeEffectState::ProcessStart(bool running)
       mLastActive = active;
    }
 
+   bool result = false;
+   if (pInstance) {
+      // Consume messages even if not processing
+      // (issue #3855: plain UI for VST 2 effects)
+
+      // Assuming we are in a processing scope, use the worker settings
+      EffectInstance::MessagePackage package{
+         mWorkerSettings.settings, mMovedMessage.get()
+      };
+      result = pInstance->RealtimeProcessStart(package);
+   }
+
    if (!pInstance || !active)
       return false;
-
-   // Assuming we are in a processing scope, use the worker settings
-   EffectInstance::MessagePackage package{
-      mWorkerSettings.settings, mMovedMessage.get()
-   };
-   return pInstance->RealtimeProcessStart(package);
+   else
+      return result;
 }
 
 #define stackAllocate(T, count) static_cast<T*>(alloca(count * sizeof(T)))

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2756,10 +2756,7 @@ void VSTEffectValidator::OnSlider(wxCommandEvent & evt)
    float value = s->GetValue() / 1000.0;
 
    // Send changed settings (only) to the worker thread
-   mAccess.ModifySettings([&](EffectSettings&) {
-      auto result = GetInstance().MakeMessage(i, value);
-      return result;
-   });
+   mAccess.Set({}, GetInstance().MakeMessage(i, value));
    mNeedFlush = i;
 }
 
@@ -3915,10 +3912,7 @@ void VSTEffectInstance::Automate(int index, float value)
 void VSTEffectValidator::Automate(int index, float value)
 {
    // Send changed settings (only) to the worker thread
-   mAccess.ModifySettings([&](EffectSettings&) {
-      auto result = GetInstance().MakeMessage(index, value);
-      return result;
-   });
+   mAccess.Set({}, GetInstance().MakeMessage(index, value));
    mNeedFlush = index;
 }
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -912,92 +912,11 @@ bool VSTEffect::InitializePlugin()
 }
 
 
-bool VSTEffectWrapper::TransferSettingsContents
-(
-   VSTEffectSettings& src,
-   VSTEffectSettings& dst,
-   bool doMove,
-   bool doMerge
-)
+bool VSTEffectWrapper::CopySettingsContents(const VSTEffectSettings&,
+                                                  VSTEffectSettings&) const
 {
-   dst.mNumParams = src.mNumParams;
-   dst.mUniqueID  = src.mUniqueID;
-   dst.mVersion   = src.mVersion;
-
-   assert(dst.mParamsMap.size() == src.mParamsMap.size());
-
-   bool discard = false;
-
-   // Do the chunk first
-   if (!src.mChunk.empty())
-   {
-      dst.mChunk = src.mChunk;
-      if (doMove)
-      {
-         src.mChunk.resize(0);
-      }
-
-      // If a new chunk is merged, any unconsumed slider movements in the
-      // parameters map are discarded before the other thread sees them
-      discard = doMerge;
-   }
-   else if (!doMerge)
-   {
-      // Assignment means copy the emptiness of the chunk
-      dst.mChunk.resize(0);
-   }
-   
-
-   // Then do an in-place rewrite of dst, avoiding allocations
-   auto& dstMap = dst.mParamsMap;
-   auto dstIter = dstMap.begin(), dstEnd = dstMap.end();
-   auto& srcMap = src.mParamsMap;
-
-   for (auto& [key, srcValue] : srcMap)
-   {
-      assert(dstIter != dstEnd);
-      auto& [dstKey, dstValue] = *dstIter;
-      assert(dstKey == key);
-
-      if (discard || (!srcValue && !doMerge))
-      {
-         // Merging a chunk message, or else,
-         // source has no value, and we do not want to merge (i.e. keep any
-         // dest value that might be there) - delete the destination value
-         dstValue = std::nullopt;
-      }
-      else if (srcValue)
-      {
-         dstValue = srcValue;
-      }
-
-      if (doMove)
-      {
-         srcValue = std::nullopt;
-      }
-
-      dstIter++;
-   }
-
-   assert(dstIter == dstEnd);
-
+   // No longer needs to do anything
    return true;
-}
-
-
-bool VSTEffectWrapper::CopySettingsContents(const VSTEffectSettings& src,
-                                                  VSTEffectSettings& dst) const
-{
-   return TransferSettingsContents(
-      const_cast<VSTEffectSettings&>(src), dst, /*move =*/ false, /*merge =*/ false);
-}
-
-
-bool VSTEffectWrapper::MoveSettingsContents(VSTEffectSettings&& src,
-                                            VSTEffectSettings&  dst,
-                                            bool                merge)
-{
-   return TransferSettingsContents(src, dst, /*move =*/ true, merge);
 }
 
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2235,6 +2235,7 @@ void VSTEffectValidator::OnIdle(wxIdleEvent& evt)
       mAccess.ModifySettings([this](EffectSettings& settings)
       {
          FetchSettingsFromInstance(settings);
+         // Succeed but with a null message
          return nullptr;
       });
 
@@ -3906,7 +3907,8 @@ bool VSTEffectValidator::ValidateUI()
 
       FetchSettingsFromInstance(settings);
 
-      return GetInstance().MakeMessage();
+      // Succeed but with a null message
+      return nullptr;
    });
 
    return true;

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -3792,8 +3792,15 @@ VSTEffectValidator::VSTEffectValidator
    mAccess.ModifySettings([&](EffectSettings &settings){
       return GetInstance().MakeMessageFS(VSTEffectInstance::GetSettings(settings));
    });
+
    auto settings = mAccess.Get();
    StoreSettingsToInstance(settings);
+
+   //! Note the parameter names for later use
+   mInstance.ForEachParameter([&](const VSTEffectWrapper::ParameterInfo &pi) {
+      mParamNames.push_back(pi.mName);
+      return true;
+   } );
 
    mTimer = std::make_unique<VSTEffectTimer>(this);
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -633,7 +633,9 @@ private:
 
    bool mWantsEditIdle{ false };
    bool mWantsIdle{ false };
-   int mNeedFlush{ -1 };
+
+   // Remembers last slider movement until idle time
+   std::optional<std::pair<int, double>> mLastMovement{};
 
    ArrayOf<wxStaticText*> mNames;
    ArrayOf<wxSlider*> mSliders;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -646,6 +646,9 @@ private:
    
    VSTControl* mControl;
 
+   // Mapping from parameter ID to string
+   std::vector<wxString> mParamNames;
+
    int mNumParams{ 0 };
 };
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -428,13 +428,6 @@ private:
    
    std::vector<int> GetEffectIDs();
 
-   // Parameter loading and saving
-   OptionalMessage
-      LoadParameters(const RegistryPath & group, EffectSettings &settings) const;
-   bool SaveParameters(
-       const RegistryPath & group, const EffectSettings &settings) const;
-
-
    // UI
    
    
@@ -650,7 +643,7 @@ private:
 
    bool mWantsEditIdle{ false };
    bool mWantsIdle{ false };
-   bool mNeedFlush{ false };
+   int mNeedFlush{ -1 };
 
    ArrayOf<wxStaticText*> mNames;
    ArrayOf<wxSlider*> mSliders;

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -21,7 +21,7 @@
 #include "XMLTagHandler.h"
 #include <wx/weakref.h>
 
-#include <map>
+#include <unordered_map>
 #include <optional>
 #include <mutex>
 #include <thread>
@@ -97,7 +97,7 @@ struct VSTEffectSettings
    std::vector<char> mChunk;
 
    // Fallback data used when the chunk is not available.
-   std::map<wxString, std::optional<std::pair<int,double> > > mParamsMap;
+   std::unordered_map<wxString, std::optional<double> > mParamsMap;
 };
 
 
@@ -315,7 +315,10 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler, public VST
    static bool MoveSettingsContents(VSTEffectSettings&& src,
                                     VSTEffectSettings&  dst,
                                     bool merge);
-   
+
+   // Make message carrying all the information in settings, including chunks
+   std::unique_ptr<EffectInstance::Message>
+      MakeMessageFS(VSTEffectSettings& settings) const;
 };
 
 class VSTEffectInstance;
@@ -594,9 +597,6 @@ class VSTEffectValidator final
    , public VSTEffectUIWrapper
 {
 public:
-   // Make message carrying all the information in settings, including chunks
-   static std::unique_ptr<EffectInstance::Message>
-      MakeMessage(VSTEffectSettings &settings);
 
     VSTEffectValidator(VSTEffectInstance&       instance,
                        EffectUIClientInterface& effect,

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -302,19 +302,9 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler, public VST
    void         SetBufferDelay(int samples);
 
 
-   static bool TransferSettingsContents(VSTEffectSettings& src,
-                                        VSTEffectSettings& dst,
-                                        bool doMove,
-                                        bool doMerge);
-
-   //! Copy from one map to another
+   //! Dummy method isn't needed for inter-thread communication any longer
    bool CopySettingsContents(const VSTEffectSettings& src,
                                    VSTEffectSettings& dst) const;
-
-   //! Copy, then clear the optionals in src
-   static bool MoveSettingsContents(VSTEffectSettings&& src,
-                                    VSTEffectSettings&  dst,
-                                    bool merge);
 
    // Make message carrying all the information in settings, including chunks
    std::unique_ptr<EffectInstance::Message>


### PR DESCRIPTION
Resolves: #3902

Dragging plain UI sliders or fancy UI controls of VST2 effects, during playback, will not cause the
green play head's movement to slow noticeably.

Note this PR is based on #3900 which may be reviewed separately and merged first

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
