### PR TITLE
i3911: Audio setup/share buttons should not be toggle buttons

### DIFF
--- a/src/cloud/ShareAudioToolbar.cpp
+++ b/src/cloud/ShareAudioToolbar.cpp
@@ -155,7 +155,6 @@ void ShareAudioToolbar::MakeShareAudioButton()
    //i18n-hint: Share audio button text, keep as short as possible
    mShareAudioButton->SetLabel(XO("Share Audio"));
    mShareAudioButton->SetButtonType(AButton::FrameButton);
-   mShareAudioButton->SetButtonToggles(true);
    mShareAudioButton->SetImages(
       theTheme.Image(bmpRecoloredUpSmall),
       theTheme.Image(bmpRecoloredUpHiliteSmall),

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -157,7 +157,6 @@ void AudioSetupToolBar::MakeAudioSetupButton()
    //i18n-hint: Audio setup button text, keep as short as possible
    mAudioSetup->SetLabel(XO("Audio Setup"));
    mAudioSetup->SetButtonType(AButton::FrameButton);
-   mAudioSetup->SetButtonToggles(true);
    mAudioSetup->SetImages(
       theTheme.Image(bmpRecoloredUpSmall),
       theTheme.Image(bmpRecoloredUpHiliteSmall),


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/3911

The Audio share and Audio setup buttons are set to be toggle buttons, which they are not. This affects both sighted users and users of screen readers.

Fix:
The buttons are no longer set to be toggle buttons. Note that with this fix the buttons are not shown as down at the point when they are clicked, which they ideally should be. However, the menu opening gives visual feedback that the button has been pressed, and there are a number of other "menu buttons" already in Audacity which have the same behaviour.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
