### PR TITLE
Removed no longer needed hasCockosViewAsConfig check, as MacOS builds are now 64 bits.

### DIFF
--- a/src/effects/VST/VSTControlOSX.mm
+++ b/src/effects/VST/VSTControlOSX.mm
@@ -129,17 +129,6 @@ bool VSTControl::Create(wxWindow *parent, VSTEffectLink *link)
 
 void VSTControl::CreateCocoa()
 {
-   auto code = 0xffff0000 & mLink->callDispatcher(
-      effCanDo, 0, 0, (void *) "hasCockosViewAsConfig", 0.0);
-   if (!(code == 0 || code == 0xbeef0000))
-   {
-      // PRL: allowing 0 makes Melda plug-ins work.  Allowing the other
-      // value makes many other plug-ins work.
-      // Can this entire test and early return path be eliminated without
-      // bad consequences now that the build is 64 bit?
-      return;
-   }
-
    VstRect *rect;
 
    // Some effects like to have us get their rect before opening them.


### PR DESCRIPTION
Resolves: #3570 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
