### PR TITLE
Better fix for issue #3842

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -209,6 +209,8 @@ public:
       auto result = std::forward<Function>(function)(settings);
       this->Set(std::move(settings), std::move(result));
    }
+
+   virtual void SetLastSettingsEqualToMainSettings() {};
 };
 
 //! Implementation of EffectSettings for cases where there is only one thread.

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -826,6 +826,9 @@ void EffectUIHost::OnUserPreset(wxCommandEvent & evt)
       return mEffectUIHost.GetDefinition().LoadUserPreset(
          UserPresetsGroup(mUserPresets[preset]), settings).value_or(nullptr);
    });
+
+   mpAccess->SetLastSettingsEqualToMainSettings();
+
    TransferDataToWindow();
    return;
 }
@@ -837,6 +840,9 @@ void EffectUIHost::OnFactoryPreset(wxCommandEvent & evt)
       return mEffectUIHost.GetDefinition().LoadFactoryPreset(
          evt.GetId() - kFactoryPresetsID, settings).value_or(nullptr);
    });
+
+   mpAccess->SetLastSettingsEqualToMainSettings();
+
    TransferDataToWindow();
    return;
 }

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -230,6 +230,18 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
          }
       }
    }
+
+   void SetLastSettingsEqualToMainSettings() override
+   {
+      if (auto pState = mwState.lock())
+      {
+         if (auto pAccessState = pState->GetAccessState())
+         {
+            pAccessState->mLastSettings = pState->mMainSettings;
+         }
+      }
+   }
+
    void Flush() override {
       if (auto pState = mwState.lock()) {
          if (auto pAccessState = pState->GetAccessState()) {


### PR DESCRIPTION
Resolves: #3842

Maybe this fix is good enough to be merged; if not, take it as a proof of concept showing what was the core problem and how it can be fixed.

In a nutshell: when loading a preset, what happened was that the call to `Flush()` in `EffectUIHost::OnIdle` would make `mMainSettings` (which just took the values from the loaded preset) be overwritten by `mLastSettings` (which was set by the last knob move which happened before the preset loading). I proved this by commenting out the call to Flush() in ::OnIdle - bug disappeared. 

But we probably do not want to remove the call to `Flush` in `OnIdle`, so I resorted to this: force mLastSettings to be set to the just assigned (from preset) mMainSettings, before any call to ::OnIdle comes after the preset load. That's what you will see in this fix.

You might ask yourself: why did DeeGain not suffer from this? (and bluecat in my previous fix where I emulated DeeGain's behavior?) it probably happened that those real/emulated calls to `::Automate` that would happen in response to setting the chunk, would make the preset's settings be copied to `mLastSettings` **before** the first call to `::OnIdle` would come - so `mMainSettings` would then get the correct values.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
