### PR TITLE
Fix crash in rendering IEM effects, which expect many channel buffers

### DIFF
--- a/libraries/lib-audio-graph/AudioGraphBuffers.cpp
+++ b/libraries/lib-audio-graph/AudioGraphBuffers.cpp
@@ -36,7 +36,8 @@ void AudioGraph::Buffers::Reinit(
    mPositions.resize(nChannels);
    const auto bufferSize = blockSize * nBlocks;
    for (auto &buffer : mBuffers)
-      buffer.resize(bufferSize + padding);
+      // Guarantee initial zeroes (needed at least in last buffer sometimes)
+      buffer.resize(bufferSize + padding, 0.0f);
    mBufferSize = bufferSize;
    mBlockSize = blockSize;
    Rewind();

--- a/libraries/lib-sample-track/Mix.cpp
+++ b/libraries/lib-sample-track/Mix.cpp
@@ -96,6 +96,8 @@ Mixer::Mixer(Inputs inputs,
    // TODO: more-than-two-channels
    // Issue 3565 workaround:  allocate one extra buffer when applying a
    // GVerb effect stage.  It is simply discarded
+   // See also issue 3854, when the number of out channels expected by the
+   // plug-in is yet larger
    , mFloatBuffers{ 3, mBufferSize, 1, 1 }
 
    // non-interleaved
@@ -140,7 +142,9 @@ Mixer::Mixer(Inputs inputs,
          auto &settings = mSettings.emplace_back(stage.settings);
          // TODO: more-than-two-channels
          // Like mFloatBuffers but padding not needed for soxr
-         auto &stageInput = mStageBuffers.emplace_back(2, mBufferSize, 1);
+         // Allocate one extra buffer to hold dummy zero inputs
+         // (Issue 3854)
+         auto &stageInput = mStageBuffers.emplace_back(3, mBufferSize, 1);
          const auto &factory = [&stage]{
             // Avoid unnecessary repeated calls to the factory
             return stage.mpFirstInstance


### PR DESCRIPTION
Resolves: #3857

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
