### PR TITLE
Fix for issue 3916

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -3851,7 +3851,7 @@ std::unique_ptr<EffectInstance::Message>
 VSTEffectWrapper::MakeMessageFS(VSTEffectSettings &settings) const
 {
    VSTEffectMessage::ParamVector paramVector;
-   paramVector.resize(settings.mParamsMap.size(), std::nullopt);
+   paramVector.resize(mAEffect->numParams, std::nullopt);
    
    ForEachParameter
    (


### PR DESCRIPTION
Resolves: #3916 

The TAL-* effects which trigger the issue above, report more parameters than there actually are; for instance TAL-flanger reports 22 parameters, but only the first 9 are of any use; parameters from 10 to 21 are all named "parameter" and always set to 0.

When building the message, because it is made using ForEachParameter and that scans all 22 parameters, we need therefore to size the parameters vector with 22 items i.e. what the effect reports.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
