### PR TITLE
Vst refresh rate

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -34,6 +34,10 @@ void SimpleEffectSettingsAccess::Set(EffectSettings &&settings,
    mSettings = std::move(settings);
 }
 
+void SimpleEffectSettingsAccess::Set(std::unique_ptr<Message>)
+{
+}
+
 void SimpleEffectSettingsAccess::Flush()
 {
 }

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -188,6 +188,8 @@ public:
    virtual const EffectSettings &Get() = 0;
    virtual void Set(EffectSettings &&settings,
       std::unique_ptr<Message> pMessage = nullptr) = 0;
+   //! Message-only overload of Set().  In future, this should be the only one.
+   virtual void Set(std::unique_ptr<Message> pMessage = nullptr) = 0;
 
    //! Make the last `Set` changes "persistent" in underlying storage
    /*!
@@ -223,6 +225,7 @@ public:
    const EffectSettings &Get() override;
    void Set(EffectSettings &&settings,
       std::unique_ptr<Message> pMessage) override;
+   void Set(std::unique_ptr<Message> pMessage) override;
    void Flush() override;
    bool IsSameAs(const EffectSettingsAccess &other) const override;
 private:

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -167,6 +167,7 @@ public:
    const EffectSettings &Get() override;
    void Set(EffectSettings &&settings,
       std::unique_ptr<Message> pMessage) override;
+   void Set(std::unique_ptr<Message> pMessage) override;
    void Flush() override;
    bool IsSameAs(const EffectSettingsAccess &other) const override;
 private:
@@ -197,6 +198,15 @@ void EffectSettingsAccessTee::Set(EffectSettings &&settings,
          pMessage ? pMessage->Clone() : nullptr);
    // Move the given settings and message through
    mpMain->Set(std::move(settings), std::move(pMessage));
+}
+
+void EffectSettingsAccessTee::Set(std::unique_ptr<Message> pMessage)
+{
+   // Move copies of the given message into the side
+   if (auto pSide = mwSide.lock())
+      pSide->Set(pMessage ? pMessage->Clone() : nullptr);
+   // Move the given message through
+   mpMain->Set(std::move(pMessage));
 }
 
 void EffectSettingsAccessTee::Flush()

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2707,10 +2707,7 @@ void VSTEffectValidator::OnSlider(wxCommandEvent & evt)
 
    NotifyParameterChanged(i, value);
    // Send changed settings (only) to the worker thread
-   mAccess.ModifySettings([&](EffectSettings&) {
-      auto result = GetInstance().MakeMessage(i, value);
-      return result;
-   });
+   mAccess.Set(GetInstance().MakeMessage(i, value));
    mNeedFlush = i;
 }
 
@@ -3881,10 +3878,7 @@ void VSTEffectValidator::Automate(int index, float value)
 {
    NotifyParameterChanged(index, value);
    // Send changed settings (only) to the worker thread
-   mAccess.ModifySettings([&](EffectSettings&) {
-      auto result = GetInstance().MakeMessage(index, value);
-      return result;
-   });
+   mAccess.Set(GetInstance().MakeMessage(index, value));
    mNeedFlush = index;
 }
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -3737,11 +3737,12 @@ bool VSTEffectWrapper::StoreSettings(const VSTEffectSettings& vstSettings) const
    {
       VstPatchChunkInfo info = { 1, mAEffect->uniqueID, mAEffect->version, mAEffect->numParams, "" };
       callSetChunk(true, chunk.size(), const_cast<char *>(chunk.data()), &info);
-      return true;
    }
 
 
-   // Chunk unavailable / decoding it did not work? fall back to param ID-value pairs
+   // Settings (like the message) may store both a chunk, and also accumulated
+   // slider movements to reapply after the chunk change.  Or it might be
+   // no chunk and id-value pairs only
 
    constCallDispatcher(effBeginSetProgram, 0, 0, NULL, 0.0);
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -3837,8 +3837,15 @@ VSTEffectValidator::VSTEffectValidator
    mAccess.ModifySettings([&](EffectSettings &settings){
       return GetInstance().MakeMessageFS(VSTEffectInstance::GetSettings(settings));
    });
+
    auto settings = mAccess.Get();
    StoreSettingsToInstance(settings);
+
+   //! Note the parameter names for later use
+   mInstance.ForEachParameter([&](const VSTEffectWrapper::ParameterInfo &pi) {
+      mParamNames.push_back(pi.mName);
+      return true;
+   } );
 
    mTimer = std::make_unique<VSTEffectTimer>(this);
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2257,20 +2257,25 @@ void VSTEffectValidator::NotifyParameterChanged(int index, float value)
 void VSTEffectValidator::OnIdle(wxIdleEvent& evt)
 {
    evt.Skip();
-
-   // Be sure the instance has got any messages
-   if (mNeedFlush != -1) {
+   if (!mLastMovements.empty()) {
+      // Be sure the instance has got any messages
       mAccess.Flush();
-
-      // Update settings, for stickiness
-      mAccess.ModifySettings([this](EffectSettings& settings)
-      {
-         FetchSettingsFromInstance(settings);
+      mAccess.ModifySettings([&](EffectSettings& settings) {
+         // Update settings, for stickiness
+         // But don't do a complete FetchSettingsFromInstance
+         for (auto [index, value] : mLastMovements) {
+            if (index >= 0 && index < mParamNames.size()) {
+               const auto &string = mParamNames[index];
+               auto &mySettings = VSTEffectWrapper::GetSettings(settings);
+               mySettings.mParamsMap[string] = value;
+            }
+         }
+         // Succeed but with a null message
          return nullptr;
       });
-
-      RefreshParameters(mNeedFlush);
-      mNeedFlush = -1;
+      for (auto [index, _] : mLastMovements)
+         RefreshParameters(index);
+      mLastMovements.clear();
    }
 }
 
@@ -2708,7 +2713,7 @@ void VSTEffectValidator::OnSlider(wxCommandEvent & evt)
    NotifyParameterChanged(i, value);
    // Send changed settings (only) to the worker thread
    mAccess.Set(GetInstance().MakeMessage(i, value));
-   mNeedFlush = i;
+   mLastMovements.emplace_back(i, value);
 }
 
 bool VSTEffectWrapper::LoadFXB(const wxFileName & fn)
@@ -3801,7 +3806,7 @@ VSTEffectWrapper::MakeMessageFS(const VSTEffectSettings &settings) const
 {
    VSTEffectMessage::ParamVector paramVector;
    paramVector.resize(mAEffect->numParams, std::nullopt);
-   
+
    ForEachParameter
    (
       [&](const VSTEffectWrapper::ParameterInfo& pi)
@@ -3887,7 +3892,7 @@ void VSTEffectValidator::Automate(int index, float value)
    NotifyParameterChanged(index, value);
    // Send changed settings (only) to the worker thread
    mAccess.Set(GetInstance().MakeMessage(index, value));
-   mNeedFlush = index;
+   mLastMovements.emplace_back(index, value);
 }
 
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -644,6 +644,9 @@ private:
    
    VSTControl* mControl;
 
+   // Mapping from parameter ID to string
+   std::vector<wxString> mParamNames;
+
    int mNumParams{ 0 };
 };
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -631,7 +631,9 @@ private:
 
    bool mWantsEditIdle{ false };
    bool mWantsIdle{ false };
-   int mNeedFlush{ -1 };
+
+   // Remembers last slider movements until idle time
+   std::vector<std::pair<int, double>> mLastMovements{};
 
    ArrayOf<wxStaticText*> mNames;
    ArrayOf<wxSlider*> mSliders;


### PR DESCRIPTION
Resolves: #3902

Fix slow refresh rate while dragging sliders during playback of VST2 effects.

Mainly it works by not fetching settings from the instance in idle time, while still
presrving stickiness and persistency of sliders by other means.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
