### PR TITLE
Audio unit presets

### DIFF
--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -299,7 +299,7 @@ int AudioUnitEffect::ShowClientInterface(wxWindow &parent, wxDialog &dialog,
 EffectSettings AudioUnitEffect::MakeSettings() const
 {
    AudioUnitEffectSettings settings;
-   FetchSettings(settings);
+   FetchSettings(settings, true);
    return EffectSettings::Make<AudioUnitEffectSettings>(std::move(settings));
 }
 
@@ -379,7 +379,7 @@ AudioUnitEffect::LoadFactoryPreset(int id, EffectSettings &settings) const
 
    // Repopulate the AudioUnitEffectSettings from the change of state in
    // the AudioUnit
-   if (!FetchSettings(GetSettings(settings)))
+   if (!FetchSettings(GetSettings(settings), true))
       return {};
 
    return { nullptr };

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -553,7 +553,7 @@ bool AudioUnitEffect::SavePreset(
    const RegistryPath & group, const AudioUnitEffectSettings &settings) const
 {
    wxCFStringRef cfname(wxFileNameFromPath(group));
-   const auto &[data, _] = MakeBlob(settings, cfname, true);
+   const auto &[data, _] = MakeBlob(*this, settings, cfname, true);
    if (!data)
       return false;
 
@@ -578,7 +578,7 @@ TranslatableString AudioUnitEffect::Export(
    // First set the name of the preset
    wxCFStringRef cfname(wxFileName(path).GetName());
 
-   const auto &[data, message] = MakeBlob(settings, cfname, false);
+   const auto &[data, message] = MakeBlob(*this, settings, cfname, false);
    if (!data || !message.empty())
       return message;
 

--- a/src/effects/audiounits/AudioUnitEffect.h
+++ b/src/effects/audiounits/AudioUnitEffect.h
@@ -110,6 +110,9 @@ public:
    // AudioUnitEffect implementation
 
 private:
+   static RegistryPath ChoosePresetKey(const EffectSettings &settings);
+   static RegistryPath FindPresetKey(const CommandParameters & parms);
+
    TranslatableString Export(
       const AudioUnitEffectSettings &settings, const wxString & path) const;
    TranslatableString Import(

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -129,7 +129,7 @@ size_t AudioUnitInstance::GetTailSize() const
 bool AudioUnitInstance::ProcessInitialize(EffectSettings &settings,
    double sampleRate, ChannelNames chanMap)
 {
-   if (!StoreSettings(GetSettings(settings)))
+   if (!StoreSettings(mProcessor, GetSettings(settings)))
       return false;
 
    mInputList =

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -20,6 +20,8 @@ class AudioUnitInstance : public PerTrackEffect::Instance
    , public AudioUnitWrapper
 {
 public:
+   using Instance::mProcessor;
+
    AudioUnitInstance(const PerTrackEffect &effect,
       AudioComponent component, Parameters &parameters,
       const wxString &identifier,

--- a/src/effects/audiounits/AudioUnitValidator.cpp
+++ b/src/effects/audiounits/AudioUnitValidator.cpp
@@ -129,7 +129,7 @@ bool AudioUnitValidator::IsGraphicalUI()
 bool AudioUnitValidator::FetchSettingsFromInstance(EffectSettings &settings)
 {
    return mInstance
-      .FetchSettings(AudioUnitInstance::GetSettings(settings), true);
+      .FetchSettings(AudioUnitInstance::GetSettings(settings), true, true);
 }
 
 bool AudioUnitValidator::StoreSettingsToInstance(const EffectSettings &settings)

--- a/src/effects/audiounits/AudioUnitValidator.cpp
+++ b/src/effects/audiounits/AudioUnitValidator.cpp
@@ -128,7 +128,8 @@ bool AudioUnitValidator::FetchSettingsFromInstance(EffectSettings &settings)
 
 bool AudioUnitValidator::StoreSettingsToInstance(const EffectSettings &settings)
 {
-   return mInstance.StoreSettings(AudioUnitInstance::GetSettings(settings));
+   return mInstance.StoreSettings(mInstance.mProcessor,
+      AudioUnitInstance::GetSettings(settings));
 }
 
 std::unique_ptr<EffectUIValidator> AudioUnitValidator::Create(

--- a/src/effects/audiounits/AudioUnitValidator.cpp
+++ b/src/effects/audiounits/AudioUnitValidator.cpp
@@ -122,7 +122,8 @@ bool AudioUnitValidator::IsGraphicalUI()
 
 bool AudioUnitValidator::FetchSettingsFromInstance(EffectSettings &settings)
 {
-   return mInstance.FetchSettings(AudioUnitInstance::GetSettings(settings));
+   return mInstance
+      .FetchSettings(AudioUnitInstance::GetSettings(settings), true);
 }
 
 bool AudioUnitValidator::StoreSettingsToInstance(const EffectSettings &settings)

--- a/src/effects/audiounits/AudioUnitWrapper.cpp
+++ b/src/effects/audiounits/AudioUnitWrapper.cpp
@@ -309,8 +309,8 @@ TranslatableString AudioUnitWrapper::InterpretBlob(
       return XO("Failed to set class info for \"%s\" preset").Format(group);
 
    // Repopulate the AudioUnitEffectSettings from the change of state in
-   // the AudioUnit
-   FetchSettings(settings, true);
+   // the AudioUnit, and include the preset
+   FetchSettings(settings, true, true);
    return {};
 }
 
@@ -374,7 +374,7 @@ const
    if (pSettings) {
       // Repopulate the AudioUnitEffectSettings from the change of state in
       // the AudioUnit
-      if (!FetchSettings(GetSettings(*pSettings), true))
+      if (!FetchSettings(GetSettings(*pSettings), true, true))
          return false;
    }
 

--- a/src/effects/audiounits/AudioUnitWrapper.cpp
+++ b/src/effects/audiounits/AudioUnitWrapper.cpp
@@ -177,7 +177,7 @@ bool AudioUnitWrapper::FetchSettings(
    return true;
 }
 
-bool AudioUnitWrapper::StoreSettings(
+bool AudioUnitWrapper::StoreSettings(const EffectDefinitionInterface &,
    const AudioUnitEffectSettings &settings) const
 {
    // This is a const member function inherited by AudioUnitEffect, though it
@@ -365,7 +365,8 @@ const
 }
 
 std::pair<CF_ptr<CFDataRef>, TranslatableString>
-AudioUnitWrapper::MakeBlob(const AudioUnitEffectSettings &settings,
+AudioUnitWrapper::MakeBlob(const EffectDefinitionInterface &effect,
+   const AudioUnitEffectSettings &settings,
    const wxCFStringRef &cfname, bool binary) const
 {
    // This is a const function of AudioUnitEffect, but it mutates
@@ -373,7 +374,7 @@ AudioUnitWrapper::MakeBlob(const AudioUnitEffectSettings &settings,
    // should be the "scratchpad" unit only, not real instance state.
 
    // Update state of the unit from settings
-   StoreSettings(settings);
+   StoreSettings(effect, settings);
 
    CF_ptr<CFDataRef> data;
    TranslatableString message;

--- a/src/effects/audiounits/AudioUnitWrapper.cpp
+++ b/src/effects/audiounits/AudioUnitWrapper.cpp
@@ -292,7 +292,7 @@ TranslatableString AudioUnitWrapper::InterpretBlob(
 
    // Repopulate the AudioUnitEffectSettings from the change of state in
    // the AudioUnit
-   FetchSettings(settings);
+   FetchSettings(settings, true);
    return {};
 }
 

--- a/src/effects/audiounits/AudioUnitWrapper.h
+++ b/src/effects/audiounits/AudioUnitWrapper.h
@@ -150,8 +150,8 @@ struct AudioUnitWrapper
       const wxString &group, const wxMemoryBuffer &buf) const;
 
    //! May allocate memory, so should be called only in the main thread
-   bool FetchSettings(
-      AudioUnitEffectSettings &settings, bool fetchValues = true) const;
+   bool FetchSettings(AudioUnitEffectSettings &settings,
+      bool fetchValues) const;
    bool StoreSettings(const AudioUnitEffectSettings &settings) const;
 
    //! Copy, then clear the optionals in src

--- a/src/effects/audiounits/AudioUnitWrapper.h
+++ b/src/effects/audiounits/AudioUnitWrapper.h
@@ -145,7 +145,8 @@ struct AudioUnitWrapper
     @return smart pointer to data, and an error message
     */
    std::pair<CF_ptr<CFDataRef>, TranslatableString>
-   MakeBlob(const AudioUnitEffectSettings &settings,
+   MakeBlob(const EffectDefinitionInterface &effect,
+      const AudioUnitEffectSettings &settings,
       const wxCFStringRef &cfname, bool binary) const;
 
    //! Interpret the dump made before by MakeBlob
@@ -159,7 +160,8 @@ struct AudioUnitWrapper
    //! May allocate memory, so should be called only in the main thread
    bool FetchSettings(AudioUnitEffectSettings &settings,
       bool fetchValues) const;
-   bool StoreSettings(const AudioUnitEffectSettings &settings) const;
+   bool StoreSettings(const EffectDefinitionInterface &effect,
+      const AudioUnitEffectSettings &settings) const;
 
    //! Copy, then clear the optionals in src
    static bool MoveSettingsContents(

--- a/src/effects/audiounits/AudioUnitWrapper.h
+++ b/src/effects/audiounits/AudioUnitWrapper.h
@@ -22,9 +22,11 @@
 #include <wx/string.h>
 
 #include "AudioUnitUtils.h"
+#include "Identifier.h"
 
 class wxCFStringRef;
 class wxMemoryBuffer;
+class EffectDefinitionInterface;
 class EffectSettings;
 class TranslatableString;
 class AudioUnitWrapper;
@@ -130,6 +132,11 @@ struct AudioUnitWrapper
    using ParameterVisitor =
       std::function< bool(const ParameterInfo &pi, AudioUnitParameterID ID) >;
    void ForEachParameter(ParameterVisitor visitor) const;
+
+   bool LoadPreset(const EffectDefinitionInterface &effect,
+      const RegistryPath & group, EffectSettings &settings) const;
+   bool LoadFactoryPreset(const EffectDefinitionInterface &effect,
+      int id, EffectSettings *pSettings) const;
 
    //! Obtain dump of the setting state of an AudioUnit instance
    /*!

--- a/src/effects/audiounits/AudioUnitWrapper.h
+++ b/src/effects/audiounits/AudioUnitWrapper.h
@@ -45,6 +45,9 @@ struct AudioUnitEffectSettings {
    using StringSet = std::set<wxString>;
    const std::shared_ptr<StringSet> mSharedNames{
       std::make_shared<StringSet>() };
+
+   //! Optionally store a preset
+   std::optional<SInt32> mPresetNumber;
    
    //! Map from numerical parameter IDs (not always a small initial segment
    //! of the integers) to optional pairs of names and floating point values
@@ -159,7 +162,7 @@ struct AudioUnitWrapper
 
    //! May allocate memory, so should be called only in the main thread
    bool FetchSettings(AudioUnitEffectSettings &settings,
-      bool fetchValues) const;
+      bool fetchValues, bool fetchPreset = false) const;
    bool StoreSettings(const EffectDefinitionInterface &effect,
       const AudioUnitEffectSettings &settings) const;
 


### PR DESCRIPTION
Resolves: #3889

This extends #3953

Settings for AudioUnits includes the last chosen factory preset, plus other parameter
changes accumulated after that.

This fixes stickiness and persistency of choices of factory presets for the Waves Studio
Rack plug-in.

However some things in that complicated interface do not yet stick, including maro button
assignments.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
