### PR TITLE
Fix for freeze when loading a preset with Melda Plugins

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -34,6 +34,10 @@ void SimpleEffectSettingsAccess::Set(EffectSettings &&settings,
    mSettings = std::move(settings);
 }
 
+void SimpleEffectSettingsAccess::Set(std::unique_ptr<Message>)
+{
+}
+
 void SimpleEffectSettingsAccess::Flush()
 {
 }

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -188,6 +188,8 @@ public:
    virtual const EffectSettings &Get() = 0;
    virtual void Set(EffectSettings &&settings,
       std::unique_ptr<Message> pMessage = nullptr) = 0;
+   //! Message-only overload of Set().  In future, this should be the only one.
+   virtual void Set(std::unique_ptr<Message> pMessage = nullptr) = 0;
 
    //! Make the last `Set` changes "persistent" in underlying storage
    /*!
@@ -223,6 +225,7 @@ public:
    const EffectSettings &Get() override;
    void Set(EffectSettings &&settings,
       std::unique_ptr<Message> pMessage) override;
+   void Set(std::unique_ptr<Message> pMessage) override;
    void Flush() override;
    bool IsSameAs(const EffectSettingsAccess &other) const override;
 private:

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -167,6 +167,7 @@ public:
    const EffectSettings &Get() override;
    void Set(EffectSettings &&settings,
       std::unique_ptr<Message> pMessage) override;
+   void Set(std::unique_ptr<Message> pMessage) override;
    void Flush() override;
    bool IsSameAs(const EffectSettingsAccess &other) const override;
 private:
@@ -197,6 +198,15 @@ void EffectSettingsAccessTee::Set(EffectSettings &&settings,
          pMessage ? pMessage->Clone() : nullptr);
    // Move the given settings and message through
    mpMain->Set(std::move(settings), std::move(pMessage));
+}
+
+void EffectSettingsAccessTee::Set(std::unique_ptr<Message> pMessage)
+{
+   // Move copies of the given message into the side
+   if (auto pSide = mwSide.lock())
+      pSide->Set(pMessage ? pMessage->Clone() : nullptr);
+   // Move the given message through
+   mpMain->Set(std::move(pMessage));
 }
 
 void EffectSettingsAccessTee::Flush()

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1,4 +1,4 @@
-/**********************************************************************
+ /**********************************************************************
 
   Audacity: A Digital Audio Editor
 
@@ -1236,7 +1236,14 @@ bool VSTEffectInstance::RealtimeProcessStart(MessagePackage& package)
    auto& message = static_cast<VSTEffectMessage&>(*package.pMessage);
 
    auto &chunk = message.mChunk;
-   if (!chunk.empty()) {
+
+   // Do not set the chunk if the plugin is by Melda and we are called
+   // in the audio thread - otherwise the whole app will freeze.
+   const bool IsMeldaPlugin = (mVendor == "MeldaProduction");
+   const bool IsAudioThread = (mMainThreadId != std::this_thread::get_id());
+   
+   if (!chunk.empty() && !(IsMeldaPlugin && IsAudioThread) )
+   {
       // Apply the chunk first
 
       VstPatchChunkInfo info = {

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -3731,11 +3731,12 @@ bool VSTEffectWrapper::StoreSettings(const VSTEffectSettings& vstSettings) const
    {
       VstPatchChunkInfo info = { 1, mAEffect->uniqueID, mAEffect->version, mAEffect->numParams, "" };
       callSetChunk(true, chunk.size(), const_cast<char *>(chunk.data()), &info);
-      return true;
    }
 
 
-   // Chunk unavailable / decoding it did not work? fall back to param ID-value pairs
+   // Settings (like the message) may store both a chunk, and also accumulated
+   // slider movements to reapply after the chunk change.  Or it might be
+   // no chunk and id-value pairs only
 
    constCallDispatcher(effBeginSetProgram, 0, 0, NULL, 0.0);
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2701,10 +2701,7 @@ void VSTEffectValidator::OnSlider(wxCommandEvent & evt)
 
    NotifyParameterChanged(i, value);
    // Send changed settings (only) to the worker thread
-   mAccess.ModifySettings([&](EffectSettings&) {
-      auto result = GetInstance().MakeMessage(i, value);
-      return result;
-   });
+   mAccess.Set(GetInstance().MakeMessage(i, value));
    mNeedFlush = i;
 }
 
@@ -3875,10 +3872,7 @@ void VSTEffectValidator::Automate(int index, float value)
 {
    NotifyParameterChanged(index, value);
    // Send changed settings (only) to the worker thread
-   mAccess.ModifySettings([&](EffectSettings&) {
-      auto result = GetInstance().MakeMessage(index, value);
-      return result;
-   });
+   mAccess.Set(GetInstance().MakeMessage(index, value));
    mNeedFlush = index;
 }
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -3831,8 +3831,15 @@ VSTEffectValidator::VSTEffectValidator
    mAccess.ModifySettings([&](EffectSettings &settings){
       return GetInstance().MakeMessageFS(VSTEffectInstance::GetSettings(settings));
    });
+
    auto settings = mAccess.Get();
    StoreSettingsToInstance(settings);
+
+   //! Note the parameter names for later use
+   mInstance.ForEachParameter([&](const VSTEffectWrapper::ParameterInfo &pi) {
+      mParamNames.push_back(pi.mName);
+      return true;
+   } );
 
    mTimer = std::make_unique<VSTEffectTimer>(this);
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -644,6 +644,9 @@ private:
    
    VSTControl* mControl;
 
+   // Mapping from parameter ID to string
+   std::vector<wxString> mParamNames;
+
    int mNumParams{ 0 };
 };
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -631,7 +631,9 @@ private:
 
    bool mWantsEditIdle{ false };
    bool mWantsIdle{ false };
-   int mNeedFlush{ -1 };
+
+   // Remembers last slider movements until idle time
+   std::vector<std::pair<int, double>> mLastMovements{};
 
    ArrayOf<wxStaticText*> mNames;
    ArrayOf<wxSlider*> mSliders;


### PR DESCRIPTION
Resolves: #3915

I know this is not a proper fix - it works though, and it unlocks many plugins.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
