### PR TITLE
Fix freezing melda plugins

### DIFF
--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -141,7 +141,7 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler, public VST
    intptr_t constCallDispatcher(int opcode, int index,
       intptr_t value, void* ptr, float opt) const;
 
-   wxCRIT_SECT_DECLARE_MEMBER(mDispatcherLock);
+   std::recursive_mutex mMutex;
 
    float callGetParameter(int index) const;
 


### PR DESCRIPTION
Resolves: #3915

Melda plug-ins appear to need event dispatch to continue on the main thread, for
any other thread to make progress while setting the chunk.  (No, returning a more
proper Process Level value did not help).

Not sure whether to blame the plug-in, but this workaround may do it.

But I have some doubts about other consequences of yields to the event loop.  It
can cause some surprising unexpected recursions to our own event handlers.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
