### PR TITLE
Add tooltips to Record Setup and the Play Setup buttons on the Meter Toolbar

### DIFF
--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -151,6 +151,20 @@ void MeterToolBar::Populate()
    if( mWhichMeters & kWithRecordMeter ){
       //JKC: Record on left, playback on right.  Left to right flow
       //(maybe we should do it differently for Arabic language :-)  )
+      mRecordSetupButton = safenew AButton(this);
+      mRecordSetupButton->SetLabel({});
+      mRecordSetupButton->SetName(_("Record Meter"));
+      mRecordSetupButton->SetToolTip(XO("Record Meter"));
+      mRecordSetupButton->SetImages(
+         theTheme.Image(bmpRecoloredUpSmall),
+         theTheme.Image(bmpRecoloredUpHiliteSmall),
+         theTheme.Image(bmpRecoloredDownSmall),
+         theTheme.Image(bmpRecoloredHiliteSmall),
+         theTheme.Image(bmpRecoloredUpSmall));
+      mRecordSetupButton->SetIcon(theTheme.Image(bmpMic));
+      mRecordSetupButton->SetButtonType(AButton::Type::FrameButton);
+      mRecordSetupButton->SetMinSize({toolbarSingle, toolbarSingle});
+
       mRecordMeter = safenew MeterPanel( &mProject,
                                 this,
                                 wxID_ANY,
@@ -167,6 +181,21 @@ void MeterToolBar::Populate()
    }
 
    if( mWhichMeters & kWithPlayMeter ){
+      mPlaySetupButton = safenew AButton(this);
+      mPlaySetupButton->SetLabel({});
+      mPlaySetupButton->SetName(_("Playback Meter"));
+      mPlaySetupButton->SetToolTip(XO("Playback Meter"));
+      mPlaySetupButton->SetImages(
+         theTheme.Image(bmpRecoloredUpSmall),
+         theTheme.Image(bmpRecoloredUpHiliteSmall),
+         theTheme.Image(bmpRecoloredDownSmall),
+         theTheme.Image(bmpRecoloredHiliteSmall),
+         theTheme.Image(bmpRecoloredUpSmall));
+      mPlaySetupButton->SetIcon(theTheme.Image(bmpSpeaker));
+      mPlaySetupButton->SetButtonType(AButton::Type::FrameButton);
+      mPlaySetupButton->SetMinSize({toolbarSingle, toolbarSingle});
+
+
       mPlayMeter = safenew MeterPanel( &mProject,
                               this,
                               wxID_ANY,

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -219,7 +219,8 @@ void MeterToolBar::UpdatePrefs()
    RegenerateTooltips();
 
    // Set label to pull in language change
-   SetLabel(XO("Meter"));
+   auto label = (mWhichMeters & kWithRecordMeter) ? XO("Recording Meter") : XO("Playback Meter");
+   SetLabel(label);
 
    // Give base class a chance
    ToolBar::UpdatePrefs();


### PR DESCRIPTION
This implements the minor feature requested by #3968.

Signed-off-by: Abhishek Kumar <abhi.kr.2100@gmail.com>

Resolves: https://github.com/audacity/audacity/issues/3968

Added tooltips to the two setup buttons on the Meter Toolbar.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
