### PR TITLE
Issue #3853 - opening Melda vst2 plugins while playing causes hang

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2353,7 +2353,8 @@ intptr_t VSTEffectWrapper::callDispatcher(int opcode,
                                    int index, intptr_t value, void *ptr, float opt)
 {
    // Needed since we might be in the dispatcher when the timer pops
-   wxCRIT_SECT_LOCKER(locker, mDispatcherLock);
+   std::lock_guard<std::mutex> guard(mMutex);
+
    return mAEffect->dispatcher(mAEffect, opcode, index, value, ptr, opt);
 }
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -306,6 +306,8 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler, public VST
    // This is called only on the main thread
    std::unique_ptr<EffectInstance::Message>
       MakeMessageFS(const VSTEffectSettings& settings) const;
+
+   std::mutex mMutex;
 };
 
 class VSTEffectInstance;


### PR DESCRIPTION
Resolves: #3853 



- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
