### PR TITLE
Plugin host startup fixes

### DIFF
--- a/libraries/lib-ipc/IPCClient.cpp
+++ b/libraries/lib-ipc/IPCClient.cpp
@@ -31,6 +31,12 @@ public:
       if(!fd)
          throw std::runtime_error("cannot create socket");
 
+#if defined(__unix__) || defined(__APPLE__)
+      auto fdFlags = fcntl(*fd, F_GETFD, 0);
+      if(fdFlags != -1)
+         fcntl(*fd, F_SETFD, fdFlags | FD_CLOEXEC);
+#endif
+      
       sockaddr_in addrin {};
       addrin.sin_family = AF_INET;
       addrin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);

--- a/libraries/lib-ipc/internal/ipc-types.h
+++ b/libraries/lib-ipc/internal/ipc-types.h
@@ -22,6 +22,7 @@
 #include <netinet/in.h>
 #include <unistd.h>
 #include <poll.h>
+#include <fcntl.h>
 
 #define INVALID_SOCKET -1
 #define SOCKET_ERROR -1

--- a/libraries/lib-module-manager/PluginHost.cpp
+++ b/libraries/lib-module-manager/PluginHost.cpp
@@ -205,9 +205,9 @@ bool PluginHost::Start(int connectPort)
    return false;
 }
 
-bool PluginHost::IsHostProcess()
+bool PluginHost::IsHostProcess(int argc, wxChar** argv)
 {
-   return wxTheApp && wxTheApp->argc >= 3 && wxStrcmp(wxTheApp->argv[1], HostArgument) == 0;
+   return argc >= 3 && wxStrcmp(argv[1], HostArgument) == 0;
 }
 
 class PluginHostModule final :
@@ -218,7 +218,7 @@ public:
 
    bool OnInit() override
    {
-      if(PluginHost::IsHostProcess())
+      if(PluginHost::IsHostProcess(wxTheApp->argc, wxTheApp->argv))
       {
          long connectPort;
          if(!wxTheApp->argv[2].ToLong(&connectPort))

--- a/libraries/lib-module-manager/PluginHost.h
+++ b/libraries/lib-module-manager/PluginHost.h
@@ -19,9 +19,8 @@
 #include <condition_variable>
 #include <wx/string.h>
 
+#include "IPCClient.h"
 #include "PluginIPCUtils.h"
-
-class IPCClient;
 
 /**
  * \brief Internal class, processes plugin validation requests
@@ -33,7 +32,7 @@ class IPCClient;
  * send another request until host hasn't finish processing
  * previous request.
  */
-class PluginHost final : public IPCChannelStatusCallback
+class MODULE_MANAGER_API PluginHost final : public IPCChannelStatusCallback
 {
    static constexpr auto HostArgument =  "--host";
 
@@ -57,7 +56,7 @@ public:
    static bool Start(int connectPort);
 
    ///Returns true if current process is considered to be a plugin host process
-   static bool IsHostProcess();
+   static bool IsHostProcess(int argc, wxChar** argv);
 
    explicit PluginHost(int connectPort);
 

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -797,10 +797,26 @@ public:
 IMPLEMENT_APP_NO_MAIN(AudacityApp)
 IMPLEMENT_WX_THEME_SUPPORT
 
+#include <ApplicationServices/ApplicationServices.h>
+
+namespace
+{
+bool sOSXIsGUIApplication { true };
+}
+
 int main(int argc, char *argv[])
 {
    wxDISABLE_DEBUG_SUPPORT();
 
+   wxCmdLineArgsArray argsArray;
+   argsArray.Init(argc, argv);
+   if(PluginHost::IsHostProcess(argc, argsArray))
+   {
+      sOSXIsGUIApplication = false;
+      ProcessSerialNumber psn = { 0, kCurrentProcess };
+      TransformProcessType(&psn, kProcessTransformToUIElementApplication);
+   }
+   
    return wxEntry(argc, argv);
 }
 
@@ -1139,6 +1155,13 @@ bool AudacityApp::Initialize(int& argc, wxChar** argv)
    }
    return wxApp::Initialize(argc, argv);
 }
+
+#ifdef __WXMAC__
+bool AudacityApp::OSXIsGUIApplication()
+{
+   return sOSXIsGUIApplication;
+}
+#endif
 
 AudacityApp::~AudacityApp()
 {

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -139,6 +139,7 @@ It handles initialization and termination by subclassing wxApp.
 //#include "Profiler.h"
 
 #include "ModuleManager.h"
+#include "PluginHost.h"
 
 #include "import/Import.h"
 
@@ -1119,16 +1120,24 @@ bool AudacityApp::OnExceptionInMainLoop()
 
 AudacityApp::AudacityApp()
 {
+}
+
+bool AudacityApp::Initialize(int& argc, wxChar** argv)
+{
+   if(!PluginHost::IsHostProcess(argc, argv))
+   {
 #if defined(USE_BREAKPAD)
-    InitBreakpad();
-// Do not capture crashes in debug builds
+      InitBreakpad();
+      // Do not capture crashes in debug builds
 #elif !defined(_DEBUG)
 #if defined(HAS_CRASH_REPORT)
 #if defined(wxUSE_ON_FATAL_EXCEPTION) && wxUSE_ON_FATAL_EXCEPTION
-   wxHandleFatalExceptions();
+      wxHandleFatalExceptions();
 #endif
 #endif
 #endif
+   }
+   return wxApp::Initialize(argc, argv);
 }
 
 AudacityApp::~AudacityApp()

--- a/src/AudacityApp.h
+++ b/src/AudacityApp.h
@@ -40,6 +40,9 @@ class AudacityApp final : public wxApp {
    ~AudacityApp();
    
    bool Initialize(int& argc, wxChar** argv) override;
+#ifdef __WXMAC__
+   bool OSXIsGUIApplication() override;
+#endif
    
    bool OnInit() override;
    bool InitPart2();

--- a/src/AudacityApp.h
+++ b/src/AudacityApp.h
@@ -38,6 +38,9 @@ class AudacityApp final : public wxApp {
  public:
    AudacityApp();
    ~AudacityApp();
+   
+   bool Initialize(int& argc, wxChar** argv) override;
+   
    bool OnInit() override;
    bool InitPart2();
    int OnRun() override;


### PR DESCRIPTION
Resolves: #3256
Resolves: #3802

Disables breakpad handler in plugin host process. Presumably that can fix #3802 on MacOS/Linux.
Hides plugin host process icon from dock on MacOS and prevents native crash report dialog to appear #3256.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
