### PR TITLE
Issue 3981

### DIFF
--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -25,6 +25,7 @@
 #include <optional>
 #include <mutex>
 #include <thread>
+#include <atomic>
 
 class wxSizerItem;
 class wxSlider;
@@ -552,6 +553,8 @@ public:
    // overrides in the Validator which owns the instance - this sets it.
    void SetOwningValidator(VSTEffectUIWrapper* vi);
 
+   bool OnePresetWasLoadedWhilePlaying();
+
 private:
 
    void callProcessReplacing(
@@ -568,6 +571,8 @@ private:
    bool mRecruited{ false };
 
    VSTEffectUIWrapper* mpOwningValidator{};
+
+   std::atomic_bool mPresetLoadedWhilePlaying{ false };
 };
 
 


### PR DESCRIPTION
Resolves: #3981

When a preset is loaded ::realtimeprocessStart will be called; however: 

- when the preset load is done **when playing is stopped**, it will be called in the main thread and then a call to UpdateUI() will follow; but

- when the preset load is done **when playing is on**, first we get the call to UpdateUI() and then the call to ::realtimeprocessStart, but the latter will be **in the audio thread** this time

So here we do this: take a "note" when the second case happens by means of an atomic bool, and act on it during idle time.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
