### PR TITLE
Fix #3968: Add and improve tooltips on the Meter Toolbar

### DIFF
--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -234,6 +234,7 @@ void MeterToolBar::Populate()
       mRecordSetupButton = safenew AButton(this);
       mRecordSetupButton->SetLabel({});
       mRecordSetupButton->SetName(_("Record Meter"));
+      mRecordSetupButton->SetToolTip(XO("Record Meter"));
       mRecordSetupButton->SetImages(
          theTheme.Image(bmpRecoloredUpSmall),
          theTheme.Image(bmpRecoloredUpHiliteSmall),
@@ -284,6 +285,7 @@ void MeterToolBar::Populate()
       mPlaySetupButton = safenew AButton(this);
       mPlaySetupButton->SetLabel({});
       mPlaySetupButton->SetName(_("Playback Meter"));
+      mPlaySetupButton->SetToolTip(XO("Playback Meter"));
       mPlaySetupButton->SetImages(
          theTheme.Image(bmpRecoloredUpSmall),
          theTheme.Image(bmpRecoloredUpHiliteSmall),

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -340,8 +340,15 @@ void MeterToolBar::UpdatePrefs()
 {
    RegenerateTooltips();
 
+   // Since the same widget is provides both the Recording Meter as
+   // well as the Playback Meter, we choose an appropriate label
+   // based on which it is
+   auto label = (mWhichMeters & kWithRecordMeter)
+      ? XO("Recording Meter")
+      : XO("Playback Meter");
+
    // Set label to pull in language change
-   SetLabel(XO("Meter"));
+   SetLabel(label);
 
    // Give base class a chance
    ToolBar::UpdatePrefs();


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/3968

The Record Meter and Playback Meter buttons on the Meter Toolbar don't have tooltips. This PR adds said tooltips to them. Moreover, the grabbers on the two sub-toolbars where these two buttons lie have the same generic tooltip. A specific and more descriptive tooltip has been added to each as well.
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
