### PR TITLE
Fix issue #3999: Change cursor to four-way-arrows when on a grabber

### DIFF
--- a/src/widgets/Grabber.cpp
+++ b/src/widgets/Grabber.cpp
@@ -71,6 +71,8 @@ Grabber::Grabber(wxWindow * parent, wxWindowID id)
    of horizontal bumps */
    SetLabel(_("Grabber"));
    SetName(_("Grabber"));
+
+   SetCursor(wxCURSOR_SIZING);
 }
 
 //


### PR DESCRIPTION
Signed-off-by: Abhishek Kumar <abhi.kr.2100@gmail.com>

Resolves: https://github.com/audacity/audacity/issues/3999

*(short description of the changes and the motivation to make the changes)*
Changes cursor to four-way-arrows when on a grabber.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
