### PR TITLE
Added missing call to ValidateUI

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -4086,6 +4086,8 @@ void VSTEffectValidator::OnClose()
    mDialog = NULL;
 
    mAccess.Flush();
+
+   ValidateUI();
 }
 
 #endif // USE_VST


### PR DESCRIPTION
Resolves: #3993 

The deferring of setting the chunk to idle time/main thread, uncovered something wrong in the vst2 implementation.
What happened was: in the situation described by the repro steps, the chunk coming in through `::RealtimeProcessStart` (i.e. contained in the incoming message) was always wrong - it would be always be equal to a default value, no matter how the knobs would have been turned.

What happens in non-melda plugins, is that in the remainder of `::RealtimeProcessStart`, the effects of this wrong chunk being set would be soon after overwritten by setting the values found in the message's `mParamsVec` - and those values would be right.

But for Melda plugins, setting the wrong chunk is deferred to later: so, values from `mParamsVec` would be set first, and _then_ the wrong chunk would be applied. This also explains why the wrong knob positions would happen sometimes even a second later.

But ultimately, why was the incoming chunk wrong? because the right value for it was never communicated back to the framework. A call to `ValidateUI()` at the end of `VSTEffectValidator::OnClose()` fixed that.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
