### PR TITLE
Blacklist ignite

### DIFF
--- a/src/effects/audiounits/AudioUnitEffectsModule.cpp
+++ b/src/effects/audiounits/AudioUnitEffectsModule.cpp
@@ -39,6 +39,7 @@ BlackList[] =
    { 'appl', 'aumx', 'mcmx' },   // Apple: AUMultiChannelMixer
    { 'appl', 'aumx', 'mxmx' },   // Apple: AUMatrixMixer
    { 'appl', 'aumx', 'smxr' },   // Apple: AUMixer
+   { 'Ignt', 'aufx', 'PTQX' },   // Ignite Amps PTEq-X
 };
 
 // ============================================================================


### PR DESCRIPTION
Resolves: #4003

Simply blacklist PTEq-X if we can't discover a better fix for why this black box crashes while other AU effects are just fine.

Plugin registry must be clean first.  It won't be excluded if it was already registered.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
