### PR TITLE
Toolkit neutral menus part 1

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -958,8 +958,8 @@ BEGIN_EVENT_TABLE(AudacityApp, wxApp)
 #endif
 
    // Recent file event handlers.
-   EVT_MENU(FileHistory::ID_RECENT_CLEAR, AudacityApp::OnMRUClear)
-   EVT_MENU_RANGE(FileHistory::ID_RECENT_FIRST, FileHistory::ID_RECENT_LAST,
+   EVT_MENU(FileHistoryMenus::ID_RECENT_CLEAR, AudacityApp::OnMRUClear)
+   EVT_MENU_RANGE(FileHistoryMenus::ID_RECENT_FIRST, FileHistoryMenus::ID_RECENT_LAST,
       AudacityApp::OnMRUFile)
 
    // Handle AppCommandEvents (usually from a script)
@@ -1024,7 +1024,7 @@ void AudacityApp::OnMRUClear(wxCommandEvent& WXUNUSED(event))
 // then it tries to Import(). Very questionable handling, imo.
 // Better, for example, to check the file type early on.
 void AudacityApp::OnMRUFile(wxCommandEvent& event) {
-   int n = event.GetId() - FileHistory::ID_RECENT_FIRST;
+   int n = event.GetId() - FileHistoryMenus::ID_RECENT_FIRST;
    auto &history = FileHistory::Global();
    const auto &fullPathStr = history[ n ];
 
@@ -1517,8 +1517,7 @@ bool AudacityApp::InitPart2()
          wxMenuBar::MacSetCommonMenuBar(menuBar.release());
       }
 
-      auto &recentFiles = FileHistory::Global();
-      recentFiles.UseMenu(recentMenu);
+      FileHistoryMenus::Instance().UseMenu(recentMenu);
 
 #endif //__WXMAC__
       temporarywindow.Show(false);

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -958,9 +958,9 @@ BEGIN_EVENT_TABLE(AudacityApp, wxApp)
 #endif
 
    // Recent file event handlers.
-   EVT_MENU(FileHistoryMenus::ID_RECENT_CLEAR, AudacityApp::OnMRUClear)
-   EVT_MENU_RANGE(FileHistoryMenus::ID_RECENT_FIRST, FileHistoryMenus::ID_RECENT_LAST,
-      AudacityApp::OnMRUFile)
+   EVT_MENU(ProjectManager::FileHistoryMenus::ID_RECENT_CLEAR, AudacityApp::OnMRUClear)
+   EVT_MENU_RANGE(ProjectManager::FileHistoryMenus::ID_RECENT_FIRST,
+      ProjectManager::FileHistoryMenus::ID_RECENT_LAST, AudacityApp::OnMRUFile)
 
    // Handle AppCommandEvents (usually from a script)
    EVT_APP_COMMAND(wxID_ANY, AudacityApp::OnReceiveCommand)
@@ -1024,7 +1024,7 @@ void AudacityApp::OnMRUClear(wxCommandEvent& WXUNUSED(event))
 // then it tries to Import(). Very questionable handling, imo.
 // Better, for example, to check the file type early on.
 void AudacityApp::OnMRUFile(wxCommandEvent& event) {
-   int n = event.GetId() - FileHistoryMenus::ID_RECENT_FIRST;
+   int n = event.GetId() - ProjectManager::FileHistoryMenus::ID_RECENT_FIRST;
    auto &history = FileHistory::Global();
    const auto &fullPathStr = history[ n ];
 
@@ -1517,7 +1517,7 @@ bool AudacityApp::InitPart2()
          wxMenuBar::MacSetCommonMenuBar(menuBar.release());
       }
 
-      FileHistoryMenus::Instance().UseMenu(recentMenu);
+      ProjectManager::UseMenu(recentMenu);
 
 #endif //__WXMAC__
       temporarywindow.Show(false);

--- a/src/AudacityApp.h
+++ b/src/AudacityApp.h
@@ -65,14 +65,6 @@ class AudacityApp final : public wxApp {
    void OnQueryEndSession(wxCloseEvent & event);
    void OnEndSession(wxCloseEvent & event);
 
-   // Most Recently Used File support (for all platforms).
-   void OnMRUClear(wxCommandEvent &event);
-   void OnMRUFile(wxCommandEvent &event);
-   // Backend for above - returns true for success, false for failure
-   bool MRUOpen(const FilePath &fileName);
-   // A wrapper of the above that does not throw
-   bool SafeMRUOpen(const wxString &fileName);
-
    void OnReceiveCommand(AppCommandEvent &event);
 
    void OnKeyDown(wxKeyEvent &event);

--- a/src/LogWindow.cpp
+++ b/src/LogWindow.cpp
@@ -140,9 +140,6 @@ void LogWindow::Show(bool show)
    // Hook into the frame events
    frame->Bind(wxEVT_CLOSE_WINDOW, OnCloseWindow );
 
-   frame->Bind(   wxEVT_COMMAND_MENU_SELECTED, OnSave, LoggerID_Save);
-   frame->Bind(   wxEVT_COMMAND_MENU_SELECTED, OnClear, LoggerID_Clear);
-   frame->Bind(   wxEVT_COMMAND_MENU_SELECTED, OnClose, LoggerID_Close);
    frame->Bind(   wxEVT_COMMAND_BUTTON_CLICKED, OnSave, LoggerID_Save);
    frame->Bind(   wxEVT_COMMAND_BUTTON_CLICKED, OnClear, LoggerID_Clear);
    frame->Bind(   wxEVT_COMMAND_BUTTON_CLICKED, OnClose, LoggerID_Close);

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -185,11 +185,11 @@ void MenuVisitor::DoSeparator()
 namespace MenuTable {
 
 MenuItem::MenuItem( const Identifier &internalName,
-   const TranslatableString &title_, BaseItemPtrs &&items_ )
+   const BasicMenu::Item::Text &text, BaseItemPtrs &&items_ )
 : ConcreteGroupItem< false, ToolbarMenuVisitor >{
-   internalName, std::move( items_ ) }, title{ title_ }
+   internalName, std::move( items_ ) }, text{ text }
 {
-   wxASSERT( !title.empty() );
+   wxASSERT( !text.label.main.empty() );
 }
 MenuItem::~MenuItem() {}
 
@@ -202,12 +202,12 @@ ConditionalGroupItem::ConditionalGroupItem(
 ConditionalGroupItem::~ConditionalGroupItem() {}
 
 CommandItem::CommandItem(const CommandID &name_,
-         const TranslatableString &label_in_,
+         const BasicMenu::Item::Text &text,
          CommandFunctorPointer callback_,
          CommandFlag flags_,
          const CommandManager::Options &options_,
          CommandHandlerFinder finder_)
-: SingleItem{ name_ }, label_in{ label_in_ }
+: SingleItem{ name_ }, text{ text }
 , finder{ finder_ }, callback{ callback_ }
 , flags{ flags_ }, options{ options_ }
 {}
@@ -283,7 +283,7 @@ struct MenuItemVisitor : ToolbarMenuVisitor
       auto pItem = &item;
       if (const auto pMenu =
           dynamic_cast<MenuItem*>( pItem )) {
-         manager.BeginMenu( pMenu->title );
+         manager.BeginMenu( pMenu->text );
       }
       else
       if (const auto pConditionalGroup =
@@ -342,7 +342,7 @@ struct MenuItemVisitor : ToolbarMenuVisitor
       if (const auto pCommand =
           dynamic_cast<CommandItem*>( pItem )) {
          manager.AddItem( project,
-            pCommand->name, pCommand->label_in,
+            pCommand->name, pCommand->text,
             pCommand->finder, pCommand->callback,
             pCommand->flags, pCommand->options
          );

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -878,7 +878,7 @@ AudacityProject *ProjectFileManager::OpenFile( const ProjectChooserFn &chooser,
 
    // Make sure it isn't already open.
    // Vaughan, 2011-03-25: This was done previously in AudacityProject::OpenFiles()
-   //    and AudacityApp::MRUOpen(), but if you open an aup file by double-clicking it
+   //    and ProjectManager::MRUOpen(), but if you open an aup file by double-clicking it
    //    from, e.g., Win Explorer, it would bypass those, get to here with no check,
    //    then open a NEW project from the same data with no warning.
    //    This was reported in http://bugzilla.audacityteam.org/show_bug.cgi?id=137#c17,

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -50,6 +50,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "widgets/WindowAccessible.h"
 
 #include <wx/app.h>
+#include <wx/menu.h>
 #include <wx/scrolbar.h>
 #include <wx/sizer.h>
 #include <wx/splitter.h>
@@ -887,4 +888,78 @@ int ProjectManager::GetEstimatedRecordingMinsLeftOnDisk(long lCaptureChannels) {
    // Convert to minutes before returning
    int iRecMins = (int)round(dRecTime / 60.0);
    return iRecMins;
+}
+
+void ProjectManager::UseMenu(wxMenu *menu)
+{
+   FileHistoryMenus::Instance().UseMenu(menu);
+}
+
+void ProjectManager::FileHistoryMenus::UseMenu(wxMenu *menu)
+{
+   Compress();
+
+   auto end = mMenus.end();
+   auto iter = std::find(mMenus.begin(), end, menu);
+   auto found = (iter != end);
+
+   if (!found)
+      mMenus.push_back(menu);
+   else {
+      wxASSERT(false);
+   }
+
+   NotifyMenu( menu );
+}
+
+ProjectManager::FileHistoryMenus::FileHistoryMenus()
+{
+   mSubscription = FileHistory::Global()
+      .Subscribe(*this, &FileHistoryMenus::OnChangedHistory);
+}
+
+ProjectManager::FileHistoryMenus &ProjectManager::FileHistoryMenus::Instance()
+{
+   static FileHistoryMenus instance;
+   return instance;
+}
+
+void ProjectManager::FileHistoryMenus::OnChangedHistory(Observer::Message)
+{
+   Compress();
+   for (auto pMenu : mMenus)
+      if (pMenu)
+         NotifyMenu(pMenu);
+}
+
+void ProjectManager::FileHistoryMenus::NotifyMenu(wxMenu *menu)
+{
+   wxMenuItemList items = menu->GetMenuItems();
+   for (auto end = items.end(), iter = items.begin(); iter != end;)
+      menu->Destroy(*iter++);
+
+   const auto &history = FileHistory::Global();
+   int mIDBase = ID_RECENT_CLEAR;
+   int i = 0;
+   for (auto item : history) {
+      item.Replace( "&", "&&" );
+      menu->Append(mIDBase + 1 + i++, item);
+   }
+
+   if (history.size() > 0) {
+      menu->AppendSeparator();
+   }
+   menu->Append(mIDBase, _("&Clear"));
+   menu->Enable(mIDBase, history.size() > 0);
+}
+
+void ProjectManager::FileHistoryMenus::Compress()
+{
+   // Clear up expired weak pointers
+   auto end = mMenus.end();
+   mMenus.erase(
+     std::remove_if( mMenus.begin(), end,
+        [](wxWeakRef<wxMenu> &pMenu){ return !pMenu; } ),
+     end
+   );
 }

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -895,6 +895,77 @@ void ProjectManager::UseMenu(wxMenu *menu)
    FileHistoryMenus::Instance().UseMenu(menu);
 }
 
+//vvv Basically, anything from Recent Files is treated as a .aup3, until proven otherwise,
+// then it tries to Import(). Very questionable handling, imo.
+// Better, for example, to check the file type early on.
+void ProjectManager::OnMRUFile(wxCommandEvent& event) {
+   int n = event.GetId() - FileHistoryMenus::ID_RECENT_FIRST;
+   auto &history = FileHistory::Global();
+   const auto &fullPathStr = history[ n ];
+
+   // Try to open only if not already open.
+   // Test IsAlreadyOpen() here even though AudacityProject::MRUOpen() also now checks,
+   // because we don't want to Remove() just because it already exists,
+   // and AudacityApp::OnMacOpenFile() calls MRUOpen() directly.
+   // that method does not return the bad result.
+   // PRL: Don't call SafeMRUOpen
+   // -- if open fails for some exceptional reason of resource exhaustion that
+   // the user can correct, leave the file in history.
+   if (!ProjectFileManager::IsAlreadyOpen(fullPathStr) && !MRUOpen(fullPathStr))
+      history.Remove(n);
+}
+
+// backend for OnMRUFile
+// TODO: Would be nice to make this handle not opening a file with more panache.
+//  - Inform the user if DefaultOpenPath not set.
+//  - Switch focus to correct instance of project window, if already open.
+bool ProjectManager::MRUOpen(const FilePath &fullPathStr) {
+   // Most of the checks below are copied from ProjectManager::OpenFiles.
+   // - some rationalisation might be possible.
+
+   auto pProj = GetActiveProject().lock();
+   auto proj = pProj.get();
+
+   if (!fullPathStr.empty())
+   {
+      // verify that the file exists
+      if (wxFile::Exists(fullPathStr))
+      {
+         FileNames::UpdateDefaultPath(FileNames::Operation::Open, ::wxPathOnly(fullPathStr));
+
+         // Make sure it isn't already open.
+         // Test here even though AudacityProject::OpenFile() also now checks, because
+         // that method does not return the bad result.
+         // That itself may be a FIXME.
+         if (ProjectFileManager::IsAlreadyOpen(fullPathStr))
+            return false;
+
+         //! proj may be null
+         ( void ) ProjectManager::OpenProject( proj, fullPathStr,
+               true /* addtohistory */, false /* reuseNonemptyProject */ );
+      }
+      else {
+         // File doesn't exist - remove file from history
+         AudacityMessageBox(
+            XO(
+"%s could not be found.\n\nIt has been removed from the list of recent files.")
+               .Format(fullPathStr) );
+         return(false);
+      }
+   }
+   return(true);
+}
+
+bool ProjectManager::SafeMRUOpen(const wxString &fullPathStr)
+{
+   return GuardedCall< bool >( [&]{ return MRUOpen( fullPathStr ); } );
+}
+
+void ProjectManager::OnMRUClear(wxCommandEvent& WXUNUSED(event))
+{
+   FileHistory::Global().Clear();
+}
+
 void ProjectManager::FileHistoryMenus::UseMenu(wxMenu *menu)
 {
    Compress();
@@ -943,7 +1014,9 @@ void ProjectManager::FileHistoryMenus::NotifyMenu(wxMenu *menu)
    int i = 0;
    for (auto item : history) {
       item.Replace( "&", "&&" );
-      menu->Append(mIDBase + 1 + i++, item);
+      auto id = mIDBase + 1 + i++;
+      menu->Append(id, item);
+      menu->Bind(wxEVT_MENU, ProjectManager::OnMRUFile, id);
    }
 
    if (history.size() > 0) {
@@ -951,6 +1024,7 @@ void ProjectManager::FileHistoryMenus::NotifyMenu(wxMenu *menu)
    }
    menu->Append(mIDBase, _("&Clear"));
    menu->Enable(mIDBase, history.size() > 0);
+   menu->Bind(wxEVT_MENU, ProjectManager::OnMRUClear, mIDBase);
 }
 
 void ProjectManager::FileHistoryMenus::Compress()

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -15,6 +15,7 @@ Paul Licameli split from AudacityProject.h
 
 #include <wx/event.h> // to inherit
 #include "ClientData.h" // to inherit
+#include "widgets/FileHistory.h"
 #include "Identifier.h"
 #include "Observer.h"
 
@@ -116,6 +117,37 @@ public:
    void SetSkipSavePrompt(bool bSkip) { sbSkipPromptingForSave = bSkip; };
 
    static void SetClosingAll(bool closing);
+
+   // Causes this menu to reflect the contents of the global FileHistory,
+   // now and also whenever the history changes.
+   static void UseMenu(wxMenu *menu);
+
+   class FileHistoryMenus {
+   private:
+      FileHistoryMenus();
+
+   public:
+      static FileHistoryMenus &Instance();
+
+      // These constants define the range of IDs reserved by the global file history
+      enum {
+         ID_RECENT_CLEAR = 6100,
+         ID_RECENT_FIRST = 6101,
+         ID_RECENT_LAST  = ID_RECENT_FIRST + FileHistory::MAX_FILES - 1,
+      };
+
+      // Make the menu reflect the contents of the global FileHistory,
+      // now and also whenever the history changes.
+      void UseMenu(wxMenu *menu);
+      
+   private:
+      void OnChangedHistory(Observer::Message);
+      void NotifyMenu(wxMenu *menu);
+      std::vector< wxWeakRef< wxMenu > > mMenus;
+      Observer::Subscription mSubscription;
+
+      void Compress();
+   };
 
 private:
    void OnReconnectionFailure(ProjectFileIOMessage);

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -122,6 +122,15 @@ public:
    // now and also whenever the history changes.
    static void UseMenu(wxMenu *menu);
 
+   // Most Recently Used File support (for all platforms).
+   static void OnMRUClear(wxCommandEvent &event);
+   static void OnMRUFile(wxCommandEvent &event);
+   // Backend for above - returns true for success, false for failure
+   static bool MRUOpen(const FilePath &fileName);
+   // A wrapper of the above that does not throw
+   static bool SafeMRUOpen(const wxString &fileName);
+
+private:
    class FileHistoryMenus {
    private:
       FileHistoryMenus();
@@ -133,7 +142,6 @@ public:
       enum {
          ID_RECENT_CLEAR = 6100,
          ID_RECENT_FIRST = 6101,
-         ID_RECENT_LAST  = ID_RECENT_FIRST + FileHistory::MAX_FILES - 1,
       };
 
       // Make the menu reflect the contents of the global FileHistory,

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -482,9 +482,12 @@ void CommandManager::EndSubMenu()
    mSubMenuList.pop_back();
 
    //Add the submenu to the current menu
-   auto name = tmpSubMenu.text.label.main.Translation();
-   CurrentMenu()->Append(0, name, tmpSubMenu.menu.release(),
-      name /* help string */ );
+   auto &text = tmpSubMenu.text;
+   // PRL:  Use help for commands as well as submenus?
+   CurrentMenu()->Append(0,
+      text.label.main.Translation(),
+      tmpSubMenu.menu.release(),
+      text.GetHelp().Translation() );
    mbSeparatorAllowed = true;
 }
 
@@ -561,6 +564,7 @@ void CommandManager::AddItem(AudacityProject &project,
 
 
    auto &checker = options.checker;
+   // PRL:  store a help string?
    if (checker) {
       CurrentMenu()->AppendCheckItem(ID, label);
       CurrentMenu()->Check(ID, checker( project ));

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -452,33 +452,31 @@ BaseItemSharedPtr FileMenu()
    /////////////////////////////////////////////////////////////////////////////
 
          Menu( wxT("Recent"),
+            {
    #ifdef __WXMAC__
-            /* i18n-hint: This is the name of the menu item on Mac OS X only */
-            XXO("Open Recent")
+               /* i18n-hint: This is the name of the menu item on Mac OS X only */
+               XXO("Open Recent")
    #else
-            /* i18n-hint: This is the name of the menu item on Windows and Linux */
-            XXO("Recent &Files")
+               /* i18n-hint: This is the name of the menu item on Windows and Linux */
+               XXO("Recent &Files")
    #endif
+               , {}, // empty accelerator
+
+               // Bug 143 workaround.
+               // For a menu that has scrollers,
+               // the scrollers have an ID of 0 (not wxID_NONE which is -3).
+               // Therefore wxWidgets attempts to find a help string. See
+               // wxFrameBase::ShowMenuHelp(int menuId)
+               // Don't find a bogus automatic help string of "Recent &Files"
+               // from the submenu.
+               Verbatim("")
+            }
             ,
             Special( wxT("PopulateRecentFilesStep"),
             [](AudacityProject &, wxMenu &theMenu){
                // Recent Files and Recent Projects menus
                auto &history = FileHistory::Global();
                history.UseMenu( &theMenu );
-
-               wxWeakRef<wxMenu> recentFilesMenu{ &theMenu };
-               wxTheApp->CallAfter( [=] {
-                  // Bug 143 workaround.
-                  // The bug is in wxWidgets.  For a menu that has scrollers,
-                  // the scrollers have an ID of 0 (not wxID_NONE which is -3).
-                  // Therefore wxWidgets attempts to find a help string. See
-                  // wxFrameBase::ShowMenuHelp(int menuId)
-                  // It finds a bogus automatic help string of "Recent &Files"
-                  // from that submenu.
-                  // So we set the help string for command with Id 0 to empty.
-                  if ( recentFilesMenu )
-                     recentFilesMenu->GetParent()->SetHelpString( 0, "" );
-               } );
             } )
          ),
 

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -475,7 +475,7 @@ BaseItemSharedPtr FileMenu()
             Special( wxT("PopulateRecentFilesStep"),
             [](AudacityProject &, wxMenu &theMenu){
                // Recent Files and Recent Projects menus
-               auto &history = FileHistory::Global();
+               auto &history = FileHistoryMenus::Instance();
                history.UseMenu( &theMenu );
             } )
          ),

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -475,8 +475,7 @@ BaseItemSharedPtr FileMenu()
             Special( wxT("PopulateRecentFilesStep"),
             [](AudacityProject &, wxMenu &theMenu){
                // Recent Files and Recent Projects menus
-               auto &history = FileHistoryMenus::Instance();
-               history.UseMenu( &theMenu );
+               ProjectManager::UseMenu( &theMenu );
             } )
          ),
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
@@ -277,14 +277,12 @@ BeginSection( "Scales" );
          AppendRadioItem( names[ii].Internal(),
             OnFirstSpectrumScaleID + ii, names[ii].Msgid(),
             POPUP_MENU_FN( OnSpectrumScaleType ),
-            []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-               WaveTrack *const wt =
-                  static_cast<SpectrumVRulerMenuTable&>( handler )
-                     .mpData->pTrack;
-               if ( id ==
-                  OnFirstSpectrumScaleID +
-                      (int)(wt->GetSpectrogramSettings().scaleType ) )
-                  menu.Check(id, true);
+            [this, ii]() -> BasicMenu::Item::State {
+               WaveTrack *const wt = mpData->pTrack;
+               return { true, // Always enabled, not always checked
+                  ii == static_cast<int>(
+                     wt->GetSpectrogramSettings().scaleType )
+               };
             }
          );
       }

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -1035,11 +1035,11 @@ PopupMenuTable::AttachedItem sAttachment{
                   (wxCommandEventFunction)
                      (&SpectrogramSettingsHandler::OnSpectrogramSettings),
                   SpectrogramSettingsHandler::Instance(),
-                  []( PopupMenuHandler &handler, wxMenu &menu, int id ){
+                  []{
                      // Bug 1253.  Shouldn't open preferences if audio is busy.
                      // We can't change them on the fly yet anyway.
                      auto gAudioIO = AudioIOBase::Get();
-                     menu.Enable(id, !gAudioIO->IsBusy());
+                     return !gAudioIO->IsBusy();
                   } );
             else
                return nullptr;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
@@ -279,14 +279,11 @@ BEGIN_POPUP_MENU(WaveformVRulerMenuTable)
          AppendRadioItem( names[ii].Internal(),
             OnFirstWaveformScaleID + ii, names[ii].Msgid(),
             POPUP_MENU_FN( OnWaveformScaleType ),
-            []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-               const auto pData =
-                  static_cast< WaveformVRulerMenuTable& >( handler ).mpData;
-               WaveTrack *const wt = pData->pTrack;
-               if ( id ==
-                  OnFirstWaveformScaleID +
-                  (int)(wt->GetWaveformSettings().scaleType) )
-                  menu.Check(id, true);
+            [this, ii]() -> BasicMenu::Item::State {
+               WaveTrack *const wt = mpData->pTrack;
+               return { true,
+                  ii == static_cast<int>(wt->GetWaveformSettings().scaleType)
+               };
             }
           );
       }

--- a/src/tracks/timetrack/ui/TimeTrackControls.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackControls.cpp
@@ -129,21 +129,20 @@ void TimeTrackMenuTable::OnTimeTrackLogInt(wxCommandEvent & /*event*/)
 }
 
 BEGIN_POPUP_MENU(TimeTrackMenuTable)
-   static const auto findTrack = []( PopupMenuHandler &handler ){
-      return static_cast<TimeTrack*>(
-         static_cast<TimeTrackMenuTable&>( handler ).mpData->pTrack );
+   static const auto findTrack = []( TimeTrackMenuTable &handler ){
+      return static_cast<TimeTrack*>( handler.mpData->pTrack );
    };
 
    BeginSection( "Scales" );
       AppendRadioItem( "Linear", OnTimeTrackLinID, XXO("&Linear scale"),
          POPUP_MENU_FN( OnTimeTrackLin ),
-         []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-            menu.Check( id, !findTrack(handler)->GetDisplayLog() );
+         [this]() -> BasicMenu::Item::State {
+            return { true, !findTrack(*this)->GetDisplayLog() };
          } );
       AppendRadioItem( "Log", OnTimeTrackLogID, XXO("L&ogarithmic scale"),
          POPUP_MENU_FN( OnTimeTrackLog ),
-         []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-            menu.Check( id, findTrack(handler)->GetDisplayLog() );
+         [this]() -> BasicMenu::Item::State {
+            return { true, findTrack(*this)->GetDisplayLog() };
          } );
    EndSection();
 
@@ -152,8 +151,8 @@ BEGIN_POPUP_MENU(TimeTrackMenuTable)
          POPUP_MENU_FN( OnSetTimeTrackRange ) );
       AppendCheckItem( "LogInterp", OnTimeTrackLogIntID,
          XXO("Logarithmic &Interpolation"), POPUP_MENU_FN( OnTimeTrackLogInt),
-         []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-            menu.Check( id, findTrack(handler)->GetInterpolateLog() );
+         [this]() -> BasicMenu::Item::State {
+            return { true, findTrack(*this)->GetInterpolateLog() };
          } );
    EndSection();
 

--- a/src/tracks/ui/CommonTrackControls.cpp
+++ b/src/tracks/ui/CommonTrackControls.cpp
@@ -118,13 +118,13 @@ void TrackMenuTable::InitUserData(void *pUserData)
 }
 
 BEGIN_POPUP_MENU(TrackMenuTable)
-   static const auto enableIfCanMove = [](bool up){ return
-      [up]( PopupMenuHandler &handler, wxMenu &menu, int id ){
-         auto pData = static_cast<TrackMenuTable&>( handler ).mpData;
-         const auto &tracks = TrackList::Get( pData->project );
-         Track *const pTrack = pData->pTrack;
-         menu.Enable( id,
-            up ? tracks.CanMoveUp(pTrack) : tracks.CanMoveDown(pTrack) );
+   // A function that returns a function
+   static const auto canMove = [this](bool up) {
+      return [this, up]{
+         const auto &tracks = TrackList::Get( mpData->project );
+         Track *const pTrack = mpData->pTrack;
+         return
+            up ? tracks.CanMoveUp(pTrack) : tracks.CanMoveDown(pTrack);
       };
    };
 
@@ -144,7 +144,7 @@ BEGIN_POPUP_MENU(TrackMenuTable)
                    GetKeyFromName(wxT("TrackMoveUp")).GET() ),
              wxT("\t")
          ),
-         POPUP_MENU_FN( OnMoveTrack ), enableIfCanMove(true) );
+         POPUP_MENU_FN( OnMoveTrack ), canMove(true) );
       AppendItem( "Down",
          OnMoveDownID,
          XXO("Move Track &Down").Join(
@@ -154,7 +154,7 @@ BEGIN_POPUP_MENU(TrackMenuTable)
                   GetKeyFromName(wxT("TrackMoveDown")).GET() ),
              wxT("\t")
          ),
-         POPUP_MENU_FN( OnMoveTrack ), enableIfCanMove(false) );
+         POPUP_MENU_FN( OnMoveTrack ), canMove(false) );
       AppendItem( "Top",
          OnMoveTopID,
          XXO("Move Track to &Top").Join(
@@ -164,7 +164,7 @@ BEGIN_POPUP_MENU(TrackMenuTable)
                    GetKeyFromName(wxT("TrackMoveTop")).GET() ),
              wxT("\t")
          ),
-         POPUP_MENU_FN( OnMoveTrack ), enableIfCanMove(true) );
+         POPUP_MENU_FN( OnMoveTrack ), canMove(true) );
       AppendItem( "Bottom",
          OnMoveBottomID,
          XXO("Move Track to &Bottom").Join(
@@ -174,7 +174,7 @@ BEGIN_POPUP_MENU(TrackMenuTable)
                   GetKeyFromName(wxT("TrackMoveBottom")).GET() ),
              wxT("\t")
          ),
-         POPUP_MENU_FN( OnMoveTrack ), enableIfCanMove(false) );
+         POPUP_MENU_FN( OnMoveTrack ), canMove(false) );
    EndSection();
 END_POPUP_MENU()
 

--- a/src/widgets/BasicMenu.cpp
+++ b/src/widgets/BasicMenu.cpp
@@ -24,6 +24,19 @@ Paul Licameli
 
 namespace BasicMenu {
 
+namespace Item {
+
+TranslatableString Label::Full() const
+{
+   return accel.empty()
+      ? main
+      : TranslatableString{ main }
+         .Join( Verbatim( accel.GET() ), L"\t" );
+}
+
+}
+
+
 namespace {
 
 const auto JournalCode = L"PopupMenu";

--- a/src/widgets/BasicMenu.h
+++ b/src/widgets/BasicMenu.h
@@ -73,16 +73,34 @@ struct AUDACITY_DLL_API Label {
    TranslatableString Full() const;
 };
 
-//! Full menu texts
+//! Full menu texts including an optional help string
 struct Text {
    Label label;
-   // More fields in future
+   std::optional<TranslatableString> pHelp;
 
    Text() = default;
    Text( const TranslatableString &main,
       const NormalizedKeyString &accel = {} )
       : label{ main, accel }
    {}
+   Text( const TranslatableString &main,
+      const NormalizedKeyString &accel,
+      const TranslatableString &help )
+      : label{ main, accel }
+      , pHelp{ help }
+   {}
+   Text( const Label &label)
+      : label{ label }
+   {}
+   Text( const Label &label, const TranslatableString &help )
+      : label{ label }
+      , pHelp{ help }
+   {}
+
+   TranslatableString GetHelp() const
+   {
+      return pHelp ? *pHelp : label.main.Stripped();
+   }
 };
 
 //! Callback to associate with a menu item

--- a/src/widgets/BasicMenu.h
+++ b/src/widgets/BasicMenu.h
@@ -13,6 +13,10 @@ Paul Licameli
 #define __AUDACITY_BASIC_MENU__
 
 #include "BasicUIPoint.h"
+#include <functional>
+#include <optional>
+#include "Internat.h"
+#include "../commands/Keyboard.h"
 
 namespace BasicUI{ class WindowPlacement; }
 
@@ -21,6 +25,70 @@ class wxMenu; // To be removed
 namespace BasicMenu {
 
 using Point = BasicUI::Point;
+
+namespace Item {
+
+//! Identifies menu items
+using ID = int;
+static constexpr ID InvalidID = -1;
+
+   //! Types of menu items
+enum class Type {
+    Separator = -1,
+    Normal,
+    Check,
+    Radio,
+    SubMenu,
+};
+
+//! Describes actual or requested state of a menu item
+struct State {
+   //! Mask bits to specify a subset of state
+   enum : unsigned {
+      Enable = 0x01,
+      Check = 0x02,
+   };
+
+   //! Implicitly constructible from one bool, just for enabled state
+   State( bool enable = true, bool check = false )
+      : enabled{ enable }, checked{ check }
+   {}
+
+   bool enabled;
+   bool checked;
+};
+   
+//! Determines user-visible text on the menu button
+struct AUDACITY_DLL_API Label {
+   TranslatableString main;
+   NormalizedKeyString accel;
+
+   Label() = default;
+   Label( const TranslatableString &main,
+      const NormalizedKeyString &accel = {} )
+      : main{ main }, accel{ accel }
+   {}
+
+   //! Computes the full label text
+   TranslatableString Full() const;
+};
+
+//! Full menu texts
+struct Text {
+   Label label;
+   // More fields in future
+
+   Text() = default;
+   Text( const TranslatableString &main,
+      const NormalizedKeyString &accel = {} )
+      : label{ main, accel }
+   {}
+};
+
+//! Callback to associate with a menu item
+using Action = std::function< void() >;
+
+}
 
 class AUDACITY_DLL_API Handle
 {

--- a/src/widgets/FileHistory.cpp
+++ b/src/widgets/FileHistory.cpp
@@ -17,7 +17,6 @@
 #include "FileHistory.h"
 
 #include <wx/defs.h>
-#include <wx/menu.h>
 
 #include "Internat.h"
 #include "Prefs.h"
@@ -92,23 +91,6 @@ void FileHistory::Clear()
    NotifyMenus();
 }
 
-void FileHistoryMenus::UseMenu(wxMenu *menu)
-{
-   Compress();
-
-   auto end = mMenus.end();
-   auto iter = std::find(mMenus.begin(), end, menu);
-   auto found = (iter != end);
-
-   if (!found)
-      mMenus.push_back(menu);
-   else {
-      wxASSERT(false);
-   }
-
-   NotifyMenu( menu );
-}
-
 void FileHistory::Load(wxConfigBase & config, const wxString & group)
 {
    mHistory.clear();
@@ -153,56 +135,3 @@ void FileHistory::NotifyMenus()
    Publish({});
    Save(*gPrefs);
 }
-
-FileHistoryMenus::FileHistoryMenus()
-{
-   mSubscription = FileHistory::Global()
-      .Subscribe(*this, &FileHistoryMenus::OnChangedHistory);
-}
-
-FileHistoryMenus &FileHistoryMenus::Instance()
-{
-   static FileHistoryMenus instance;
-   return instance;
-}
-
-void FileHistoryMenus::OnChangedHistory(Observer::Message)
-{
-   Compress();
-   for (auto pMenu : mMenus)
-      if (pMenu)
-         NotifyMenu(pMenu);
-}
-
-void FileHistoryMenus::NotifyMenu(wxMenu *menu)
-{
-   wxMenuItemList items = menu->GetMenuItems();
-   for (auto end = items.end(), iter = items.begin(); iter != end;)
-      menu->Destroy(*iter++);
-
-   const auto &history = FileHistory::Global();
-   int mIDBase = ID_RECENT_CLEAR;
-   int i = 0;
-   for (auto item : history) {
-      item.Replace( "&", "&&" );
-      menu->Append(mIDBase + 1 + i++, item);
-   }
-
-   if (history.size() > 0) {
-      menu->AppendSeparator();
-   }
-   menu->Append(mIDBase, _("&Clear"));
-   menu->Enable(mIDBase, history.size() > 0);
-}
-
-void FileHistoryMenus::Compress()
-{
-   // Clear up expired weak pointers
-   auto end = mMenus.end();
-   mMenus.erase(
-     std::remove_if( mMenus.begin(), end,
-        [](wxWeakRef<wxMenu> &pMenu){ return !pMenu; } ),
-     end
-   );
-}
-

--- a/src/widgets/FileHistory.h
+++ b/src/widgets/FileHistory.h
@@ -62,31 +62,4 @@ class AUDACITY_DLL_API FileHistory
    wxString mGroup;
 };
 
-class FileHistoryMenus {
-private:
-   FileHistoryMenus();
-
-public:
-   static FileHistoryMenus &Instance();
-
-   // These constants define the range of IDs reserved by the global file history
-   enum {
-      ID_RECENT_CLEAR = 6100,
-      ID_RECENT_FIRST = 6101,
-      ID_RECENT_LAST  = ID_RECENT_FIRST + FileHistory::MAX_FILES - 1,
-   };
-
-   // Make the menu reflect the contents of the global FileHistory,
-   // now and also whenever the history changes.
-   void UseMenu(wxMenu *menu);
-   
-private:
-   void OnChangedHistory(Observer::Message);
-   void NotifyMenu(wxMenu *menu);
-   std::vector< wxWeakRef< wxMenu > > mMenus;
-   Observer::Subscription mSubscription;
-
-   void Compress();
-};
-
 #endif

--- a/src/widgets/FileHistory.h
+++ b/src/widgets/FileHistory.h
@@ -17,25 +17,21 @@
 #include <wx/weakref.h> // member variable
 
 #include "Identifier.h"
+#include "Observer.h"
 #include "wxArrayStringEx.h"
 
 class wxConfigBase;
 class wxMenu;
 
 class AUDACITY_DLL_API FileHistory
+   : public Observer::Publisher<>
 {
  public:
-   FileHistory(size_t maxfiles = 12, wxWindowID idbase = wxID_FILE);
+   enum { MAX_FILES = 12 };
+   FileHistory(size_t maxfiles = MAX_FILES);
    virtual ~FileHistory();
    FileHistory( const FileHistory& ) = delete;
    FileHistory &operator =( const FileHistory & ) = delete;
-
-   // These constants define the range of IDs reserved by the global file history
-   enum {
-      ID_RECENT_CLEAR = 6100,
-      ID_RECENT_FIRST = 6101,
-      ID_RECENT_LAST  = 6112
-   };
 
    static FileHistory &Global();
 
@@ -43,10 +39,6 @@ class AUDACITY_DLL_API FileHistory
    { AddFileToHistory( file, true ); }
    void Remove( size_t i );
    void Clear();
-
-   // Causes this menu to reflect the contents of this FileHistory, now and
-   // also whenever the history changes.
-   void UseMenu(wxMenu *menu);
 
    void Load(wxConfigBase& config, const wxString & group = wxEmptyString);
    void Save(wxConfigBase& config);
@@ -57,21 +49,44 @@ class AUDACITY_DLL_API FileHistory
    const_iterator end() const { return mHistory.end(); }
    const FilePath &operator[] ( size_t ii ) const { return mHistory[ ii ]; }
    bool empty() const { return mHistory.empty(); }
+   size_t size() const { return mHistory.size(); }
 
  private:
    void AddFileToHistory(const FilePath & file, bool update);
    void NotifyMenus();
-   void NotifyMenu(wxMenu *menu);
-
-   void Compress();
 
    size_t mMaxFiles;
-   wxWindowID mIDBase;
 
-   std::vector< wxWeakRef< wxMenu > > mMenus;
    FilePaths mHistory;
 
    wxString mGroup;
+};
+
+class FileHistoryMenus {
+private:
+   FileHistoryMenus();
+
+public:
+   static FileHistoryMenus &Instance();
+
+   // These constants define the range of IDs reserved by the global file history
+   enum {
+      ID_RECENT_CLEAR = 6100,
+      ID_RECENT_FIRST = 6101,
+      ID_RECENT_LAST  = ID_RECENT_FIRST + FileHistory::MAX_FILES - 1,
+   };
+
+   // Make the menu reflect the contents of the global FileHistory,
+   // now and also whenever the history changes.
+   void UseMenu(wxMenu *menu);
+   
+private:
+   void OnChangedHistory(Observer::Message);
+   void NotifyMenu(wxMenu *menu);
+   std::vector< wxWeakRef< wxMenu > > mMenus;
+   Observer::Subscription mSubscription;
+
+   void Compress();
 };
 
 #endif

--- a/src/widgets/PopupMenuTable.cpp
+++ b/src/widgets/PopupMenuTable.cpp
@@ -117,8 +117,14 @@ void PopupMenuBuilder::DoVisit( Registry::SingleItem &item, const Path &path )
    // redundant
    pEntry->handler.InitUserData( mpUserData );
 
-   if ( pEntry->init )
-      pEntry->init( pEntry->handler, *mMenu, pEntry->id );
+   if ( pEntry->stateFn ) {
+      const auto state = pEntry->stateFn();
+      if ( auto pItem = mMenu->FindItem( pEntry->id ) ) {
+         pItem->Enable( state.enabled );
+         if ( pItem->IsCheckable() )
+            pItem->Check( state.checked );
+      }
+   }
 
    mMenu->Bind(
       wxEVT_COMMAND_MENU_SELECTED, pEntry->func, &pEntry->handler, pEntry->id);
@@ -167,10 +173,10 @@ void PopupMenuTable::Append( Registry::BaseItemPtr pItem )
 void PopupMenuTable::Append(
    const Identifier &stringId, PopupMenuTableEntry::Type type, int id,
    const TranslatableString &string, wxCommandEventFunction memFn,
-   const PopupMenuTableEntry::InitFunction &init )
+   const PopupMenuTableEntry::StateFunction &stateFn )
 {
    Append( std::make_unique<Entry>(
-      stringId, type, id, string, memFn, *this, init ) );
+      stringId, type, id, string, memFn, *this, stateFn ) );
 }
 
 void PopupMenuTable::BeginSection( const Identifier &name )

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -27,6 +27,7 @@ class wxCommandEvent;
 
 #include "Internat.h"
 #include "../commands/CommandManager.h"
+#include "BasicMenu.h"
 
 class PopupMenuHandler;
 class PopupMenuTable;
@@ -34,28 +35,28 @@ class PopupMenuTable;
 struct AUDACITY_DLL_API PopupMenuTableEntry : Registry::SingleItem
 {
    enum Type { Item, RadioItem, CheckItem };
-   using InitFunction =
-      std::function< void( PopupMenuHandler &handler, wxMenu &menu, int id ) >;
+   //! Function to determine whether a menu item should be enabled and checked
+   using StateFunction = std::function< BasicMenu::Item::State() >;
 
    Type type;
    int id;
    TranslatableString caption;
    wxCommandEventFunction func;
    PopupMenuHandler &handler;
-   InitFunction init;
+   StateFunction stateFn;
 
    //! @pre func is not null
    PopupMenuTableEntry( const Identifier &stringId,
       Type type_, int id_, const TranslatableString &caption_,
       wxCommandEventFunction func_, PopupMenuHandler &handler_,
-      InitFunction init_ = {} )
+      StateFunction stateFn = {} )
       : SingleItem{ stringId }
       , type(type_)
       , id(id_)
       , caption(caption_)
       , func(func_)
       , handler( handler_ )
-      , init( init_ )
+      , stateFn( move(stateFn) )
    {
       wxASSERT(func);
    }
@@ -196,25 +197,22 @@ protected:
    void Append(
       const Identifier &stringId, PopupMenuTableEntry::Type type, int id,
       const TranslatableString &string, wxCommandEventFunction memFn,
-      // This callback might check or disable a menu item:
-      const PopupMenuTableEntry::InitFunction &init );
+      const PopupMenuTableEntry::StateFunction &stateFn );
 
    void AppendItem( const Identifier &stringId, int id,
       const TranslatableString &string, wxCommandEventFunction memFn,
-      // This callback might check or disable a menu item:
-      const PopupMenuTableEntry::InitFunction &init = {} )
-   { Append( stringId, PopupMenuTableEntry::Item, id, string, memFn, init ); }
+      const PopupMenuTableEntry::StateFunction &stateFn = {} )
+   { Append( stringId, PopupMenuTableEntry::Item, id, string, memFn, stateFn ); }
 
    void AppendRadioItem( const Identifier &stringId, int id,
       const TranslatableString &string, wxCommandEventFunction memFn,
-      // This callback might check or disable a menu item:
-      const PopupMenuTableEntry::InitFunction &init = {} )
-   { Append( stringId, PopupMenuTableEntry::RadioItem, id, string, memFn, init ); }
+      const PopupMenuTableEntry::StateFunction &stateFn = {} )
+   { Append( stringId, PopupMenuTableEntry::RadioItem, id, string, memFn, stateFn ); }
 
-   void AppendCheckItem( const Identifier &stringId, int id,
+    void AppendCheckItem( const Identifier &stringId, int id,
       const TranslatableString &string, wxCommandEventFunction memFn,
-      const PopupMenuTableEntry::InitFunction &init = {} )
-   { Append( stringId, PopupMenuTableEntry::CheckItem, id, string, memFn, init ); }
+      const PopupMenuTableEntry::StateFunction &stateFn = {} )
+   { Append( stringId, PopupMenuTableEntry::CheckItem, id, string, memFn, stateFn ); }
 
    void BeginSection( const Identifier &name );
    void EndSection();


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

A part of the work needed to extract a toolkit-neutral facade library for menus and menu bars.

More commits to come, but these preliminary commits are stable enough to invite review now.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
