### PR TITLE
Adds an explicit way to mark the project dirty

### DIFF
--- a/libraries/lib-project-history/UndoManager.cpp
+++ b/libraries/lib-project-history/UndoManager.cpp
@@ -203,9 +203,6 @@ void UndoManager::ModifyState(const TrackList &l,
 //   SonifyEndModifyState();
 
    EnqueueMessage({ UndoRedoMessage::Modified });
-
-   if (saved == current)
-      saved = -1;
 }
 
 void UndoManager::RenameState( int state,
@@ -353,6 +350,11 @@ void UndoManager::VisitStates(
       for (auto ii = begin; ii > end; --ii)
          consumer(*stack[ii]);
    }
+}
+
+void UndoManager::MarkUnsaved()
+{
+   saved = -1;
 }
 
 bool UndoManager::UnsavedChanges() const

--- a/libraries/lib-project-history/UndoManager.h
+++ b/libraries/lib-project-history/UndoManager.h
@@ -218,6 +218,7 @@ class PROJECT_HISTORY_API UndoManager final
    bool UndoAvailable();
    bool RedoAvailable();
 
+   void MarkUnsaved();
    bool UnsavedChanges() const;
    int GetSavedState() const;
    void StateSaved();

--- a/src/effects/RealtimeEffectStateUI.cpp
+++ b/src/effects/RealtimeEffectStateUI.cpp
@@ -16,6 +16,7 @@
 #include "RealtimeEffectState.h"
 
 #include "EffectManager.h"
+#include "UndoManager.h"
 #include "ProjectHistory.h"
 #include "ProjectWindow.h"
 #include "Track.h"
@@ -110,7 +111,7 @@ void RealtimeEffectStateUI::Show(AudacityProject& project)
       });
 
    mParameterChangedSubscription = mEffectUIHost->GetValidator()->Subscribe(
-      [this](auto) { ProjectHistory::Get(*mpProject).ModifyState(false); });
+      [this](auto) { UndoManager::Get(*mpProject).MarkUnsaved(); });
 }
 
 void RealtimeEffectStateUI::Hide(AudacityProject* project)


### PR DESCRIPTION
Resolves: #4019 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
