### PR TITLE
Issue 4021

### DIFF
--- a/libraries/lib-components/EffectInterface.cpp
+++ b/libraries/lib-components/EffectInterface.cpp
@@ -163,6 +163,11 @@ auto EffectInstance::MakeMessage() const -> std::unique_ptr<Message>
    return nullptr;
 }
 
+bool EffectInstance::UsesMessages() const noexcept
+{
+   return false;
+}
+
 bool EffectInstance::RealtimeProcessStart(MessagePackage &)
 {
    return true;

--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -527,6 +527,14 @@ public:
    // TODO make it just an alias for Message *
    struct MessagePackage { EffectSettings &settings; Message *pMessage{}; };
 
+   //! If true, the effect makes no use EffectSettings for inter-thread
+   //! comminication
+   /*!
+    Default implementation returns false.  In future, all effects should be
+    rewritten to use messages and this function will be removed.
+    */
+   virtual bool UsesMessages() const noexcept;
+
    //! settings are possibly changed, since last call, by an asynchronous dialog
    /*!
     @return success

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -650,15 +650,17 @@ void RealtimeEffectState::SetActive(bool active)
 
 bool RealtimeEffectState::Finalize() noexcept
 {
-   // This is the main thread cleaning up a state not now used in processing
-   mMainSettings = mWorkerSettings;
-
    mGroups.clear();
    mCurrentProcessor = 0;
 
    auto pInstance = mwInstance.lock();
    if (!pInstance)
       return false;
+
+   if (!pInstance->UsesMessages()) {
+      // This is the main thread cleaning up a state not now used in processing
+      mMainSettings = mWorkerSettings;
+   }
 
    auto result = pInstance->RealtimeFinalize(mMainSettings.settings);
    mLatency = {};

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1284,6 +1284,11 @@ bool VSTEffectInstance::ChunkMustBeAppliedInMainThread() const
 }
 
 
+bool VSTEffectInstance::UsesMessages() const noexcept
+{
+   return true;
+}
+
 bool VSTEffectInstance::RealtimeProcessStart(MessagePackage& package)
 {
    const bool applyChunkInMainThread = ChunkMustBeAppliedInMainThread();

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -511,6 +511,7 @@ public:
    bool RealtimeFinalize(EffectSettings& settings) noexcept override;
    bool RealtimeSuspend() override;
    bool RealtimeResume() override;
+   bool UsesMessages() const noexcept override;
    bool RealtimeProcessStart(MessagePackage& package) override;
    size_t RealtimeProcess(size_t group, EffectSettings& settings,
       const float* const* inbuf, float* const* outbuf, size_t numSamples)

--- a/src/effects/audiounits/AudioUnitInstance.cpp
+++ b/src/effects/audiounits/AudioUnitInstance.cpp
@@ -300,6 +300,11 @@ MakeMessage(AudioUnitParameterID id, AudioUnitParameterValue value) const
    return std::make_unique<AudioUnitMessage>(std::move(settings));
 }
 
+bool AudioUnitInstance::UsesMessages() const noexcept
+{
+   return true;
+}
+
 bool AudioUnitInstance::RealtimeProcessStart(MessagePackage &package)
 {
    if (!package.pMessage)

--- a/src/effects/audiounits/AudioUnitInstance.h
+++ b/src/effects/audiounits/AudioUnitInstance.h
@@ -63,6 +63,7 @@ private:
    bool RealtimeSuspend() override;
    bool RealtimeResume() override;
 
+   bool UsesMessages() const noexcept override;
    bool RealtimeProcessStart(MessagePackage &package) override;
    size_t RealtimeProcess(size_t group, EffectSettings &settings,
       const float *const *inbuf, float *const *outbuf, size_t numSamples)


### PR DESCRIPTION
Resolves: #4021

Fix stickiness of AU and VST 2 parameter changes when dialog is closed during play.

Incidentally add some defensive code to VSTEffectMessage constructor

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
