### PR TITLE
Issue 4014

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,21 @@
 List of significant changes and bug fixes going back to version 1.1.0
 
+Changes in version 3.2.2
+
+ This is a patch release for Audacity 3.2. It enables use of VST2 as realtime effects and fixes some bugs.
+
+   * #2850 VST2 effects are now realtime capable. 
+     Additional plugins have been added to plugins.audacityteam.org
+   * #3696 Improved accessibility of the meters
+   * #3769 Fixed a crash when editing some macro parameters
+   * #3792 Fixed some play commands getting stuck in play mode
+   * #3670 Audacity no longer quietly discards changes in realtime effects but instead asks if you want to save before quitting
+   * #3838 Plugin scanning now lets you skip individual plugins if scanning gets stuck on them
+   * #3980 Plugin scanning no longer produces "Audacity crashed" windows when a plugin fails validation, 
+     and no longer shows the plugins in the macOS dock during validation
+   * #3883 Fixed an issue with labels losing focus on macOS Ventura
+   * Fixed various plugin-specific issues
+
 Changes in version 3.2.1
 
  This is a patch release. It fixes some bugs and has minor improvements. 

--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -234,6 +234,7 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
                      stateSettings, pMessage.get()
                   };
                   pInstance->RealtimeProcessStart(package);
+                  pInstance->RealtimeProcessEnd(stateSettings);
                   pAccessState->mLastSettings.settings = stateSettings;
                   return;
                }
@@ -261,6 +262,7 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
                      stateSettings, pMessage.get()
                   };
                   pInstance->RealtimeProcessStart(package);
+                  pInstance->RealtimeProcessEnd(stateSettings);
                   // Don't need to update pAccessState->mLastSettings
                   return;
                }
@@ -606,9 +608,10 @@ size_t RealtimeEffectState::Process(Track &track, unsigned chans,
 bool RealtimeEffectState::ProcessEnd()
 {
    auto pInstance = mwInstance.lock();
-   bool result = pInstance && IsActive() && mLastActive &&
+   bool result = pInstance &&
       // Assuming we are in a processing scope, use the worker settings
-      pInstance->RealtimeProcessEnd(mWorkerSettings.settings);
+      pInstance->RealtimeProcessEnd(mWorkerSettings.settings) &&
+      IsActive() && mLastActive;
 
    if (auto pAccessState = TestAccessState())
       // Always done, regardless of activity

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1210,6 +1210,10 @@ bool VSTEffectInstance::RealtimeAddProcessor(EffectSettings &settings,
 bool VSTEffectInstance::RealtimeFinalize(EffectSettings&) noexcept
 {
 return GuardedCall<bool>([&]{
+
+   if (mpOwningValidator)
+      mpOwningValidator->Flush();
+
    mRecruited = false;
 
    for (const auto &slave : mSlaves)
@@ -2185,6 +2189,14 @@ bool VSTEffect::SaveUserPreset(
 
    return SetConfig(*this, PluginSettings::Private,
       group, wxT("Parameters"), parms);
+}
+
+void VSTEffectUIWrapper::Flush()
+{}
+
+void VSTEffectValidator::Flush()
+{
+   mAccess.Flush();
 }
 
 void VSTEffectValidator::OnTimer()

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1175,6 +1175,11 @@ size_t VSTEffectInstance::ProcessBlock(EffectSettings &,
 
 bool VSTEffectInstance::RealtimeInitialize(EffectSettings &settings, double sampleRate)
 {
+   // Temporarily disconnect from any validator, so that setting the chunk
+   // does not cause Automate() callbacks (as some effects will do) that then
+   // would send slider movement messages that might destroy information in
+   // the settings.
+   auto vr = valueRestorer(mpOwningValidator, (VSTEffectUIWrapper*)nullptr);
    return ProcessInitialize(settings, sampleRate, {});
 }
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1241,24 +1241,71 @@ bool VSTEffectInstance::OnePresetWasLoadedWhilePlaying()
    return mPresetLoadedWhilePlaying.exchange(false);
 }
 
+void VSTEffectInstance::DeferChunkApplication()
+{
+   std::lock_guard<std::mutex> guard(mDeferredChunkMutex);
+
+   if (! mChunkToSetAtIdleTime.empty() )
+   {    
+      ApplyChunk(mChunkToSetAtIdleTime);
+      mChunkToSetAtIdleTime.resize(0);
+   }
+}
+
+
+void VSTEffectInstance::ApplyChunk(std::vector<char>& chunk)
+{
+   VstPatchChunkInfo info = {
+      1, mAEffect->uniqueID, mAEffect->version, mAEffect->numParams, "" };
+
+   const auto len = chunk.size();
+   const auto data = chunk.data();
+
+   callSetChunk(true, len, data, &info);
+   for (auto& slave : mSlaves)
+      slave->callSetChunk(true, len, data, &info);
+}
+
+
+bool VSTEffectInstance::ChunkMustBeAppliedInMainThread() const
+{
+   // Some plugins (e.g. Melda) can not have their chunk set in the
+   // audio thread, resulting in making the whole app hang.
+   // This is why we defer the setting of the chunk in the main thread.
+
+   const bool IsAudioThread = (mMainThreadId != std::this_thread::get_id());
+   
+   return IsAudioThread && mIsMeldaPlugin;
+}
+
+
 bool VSTEffectInstance::RealtimeProcessStart(MessagePackage& package)
 {
+   const bool applyChunkInMainThread = ChunkMustBeAppliedInMainThread();
+
+   if (applyChunkInMainThread)
+      mDeferredChunkMutex.lock();
+
    if (!package.pMessage)
       return true;
 
    auto& message = static_cast<VSTEffectMessage&>(*package.pMessage);
 
    auto &chunk = message.mChunk;
-   if (!chunk.empty()) {
-      // Apply the chunk first
 
-      VstPatchChunkInfo info = {
-         1, mAEffect->uniqueID, mAEffect->version, mAEffect->numParams, "" };
-      const auto len = chunk.size();
-      const auto data = chunk.data();
-      callSetChunk(true, len, data, &info);
-      for (auto& slave : mSlaves)
-         slave->callSetChunk(true, len, data, &info);
+   if (!chunk.empty())
+   {
+      if (applyChunkInMainThread)
+      {
+         // Apply the chunk later
+         //
+         mChunkToSetAtIdleTime = chunk;
+      }
+      else
+      {
+         // Apply the chunk now
+         ApplyChunk(chunk);
+      }
 
       // Don't apply the chunk again until another message supplies a chunk
       chunk.resize(0);
@@ -1330,6 +1377,9 @@ size_t VSTEffectInstance::RealtimeProcess(size_t group, EffectSettings &settings
 
 bool VSTEffectInstance::RealtimeProcessEnd(EffectSettings &) noexcept
 {
+   if ( ChunkMustBeAppliedInMainThread() )
+      mDeferredChunkMutex.unlock();
+
    return true;
 }
 
@@ -2295,6 +2345,8 @@ void VSTEffectValidator::OnIdle(wxIdleEvent& evt)
       mLastMovements.clear();
    }
 
+   GetInstance().DeferChunkApplication();
+
    if ( GetInstance().OnePresetWasLoadedWhilePlaying() )
    {
       RefreshParameters();
@@ -2376,7 +2428,8 @@ intptr_t VSTEffectWrapper::callDispatcher(int opcode,
                                    int index, intptr_t value, void *ptr, float opt)
 {
    // Needed since we might be in the dispatcher when the timer pops
-   wxCRIT_SECT_LOCKER(locker, mDispatcherLock);
+   std::lock_guard guard(mDispatcherLock);
+
    return mAEffect->dispatcher(mAEffect, opcode, index, value, ptr, opt);
 }
 
@@ -3956,6 +4009,8 @@ VSTEffectInstance::VSTEffectInstance
       mBlockSize = 8192;
       DoProcessInitialize(44100.0);
    }
+
+   mIsMeldaPlugin = (mVendor == "MeldaProduction");
 }
 
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -4086,6 +4086,8 @@ void VSTEffectValidator::OnClose()
    mDialog = NULL;
 
    mAccess.Flush();
+
+   ValidateUI();
 }
 
 #endif // USE_VST

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -142,7 +142,7 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler, public VST
    intptr_t constCallDispatcher(int opcode, int index,
       intptr_t value, void* ptr, float opt) const;
 
-   wxCRIT_SECT_DECLARE_MEMBER(mDispatcherLock);
+   std::recursive_mutex mDispatcherLock;
 
    float callGetParameter(int index) const;
 
@@ -555,6 +555,8 @@ public:
 
    bool OnePresetWasLoadedWhilePlaying();
 
+   void DeferChunkApplication();
+
 private:
 
    void callProcessReplacing(
@@ -573,6 +575,15 @@ private:
    VSTEffectUIWrapper* mpOwningValidator{};
 
    std::atomic_bool mPresetLoadedWhilePlaying{ false };
+
+   std::mutex mDeferredChunkMutex;
+   std::vector<char> mChunkToSetAtIdleTime{};
+
+   void ApplyChunk(std::vector<char>& chunk);
+
+   bool ChunkMustBeAppliedInMainThread() const;
+
+   bool mIsMeldaPlugin{ false };
 };
 
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -107,6 +107,7 @@ struct VSTEffectUIWrapper
    virtual void NeedIdle();
    virtual void SizeWindow(int w, int h);
    virtual void Automate(int index, float value);
+   virtual void Flush();
 };
 
 
@@ -626,6 +627,8 @@ public:
    int ShowDialog(bool nonModal);
 
    bool IsGraphicalUI() override;
+
+   void Flush() override;
 
 protected:
    void SizeWindow(int w, int h) override;

--- a/src/effects/audiounits/AudioUnitEffectsModule.cpp
+++ b/src/effects/audiounits/AudioUnitEffectsModule.cpp
@@ -39,6 +39,7 @@ BlackList[] =
    { 'appl', 'aumx', 'mcmx' },   // Apple: AUMultiChannelMixer
    { 'appl', 'aumx', 'mxmx' },   // Apple: AUMatrixMixer
    { 'appl', 'aumx', 'smxr' },   // Apple: AUMixer
+   { 'Ignt', 'aufx', 'PTQX' },   // Ignite Amps PTEq-X
 };
 
 // ============================================================================

--- a/src/prefs/ApplicationPrefs.cpp
+++ b/src/prefs/ApplicationPrefs.cpp
@@ -107,6 +107,7 @@ bool ApplicationPrefs::Commit()
 {
    ShuttleGui S(this, eIsSavingToPrefs);
    PopulateOrExchange(S);
+   DefaultUpdatesCheckingFlag.Invalidate();
 
    return true;
 }

--- a/src/prefs/QualityPrefs.cpp
+++ b/src/prefs/QualityPrefs.cpp
@@ -200,6 +200,8 @@ bool QualityPrefs::Commit()
    ShuttleGui S(this, eIsSavingToPrefs);
    PopulateOrExchange(S);
 
+   QualitySettings::DefaultSampleRate.Invalidate();
+
    // The complex compound control may have value 'other' in which case the
    // value in prefs comes from the second field.
    if (mOtherSampleRate->IsEnabled()) {

--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -120,6 +120,8 @@ bool TracksBehaviorsPrefs::Commit()
 {
    ShuttleGui S(this, eIsSavingToPrefs);
    PopulateOrExchange(S);
+   EditClipsCanMove.Invalidate();
+   ScrollingPreference.Invalidate();
 
    return true;
 }

--- a/src/widgets/ASlider.cpp
+++ b/src/widgets/ASlider.cpp
@@ -611,7 +611,6 @@ void LWSlider::Init(wxWindow * parent,
    mThumbBitmapHilited = nullptr;
    mScrollLine = 1.0f;
    mScrollPage = 5.0f;
-   mTipPanel = NULL;
 
    AdjustSize(size);
 
@@ -1408,8 +1407,22 @@ void LWSlider::OnKeyDown(wxKeyEvent & event)
 
 void LWSlider::SetParent(wxWindow* parent)
 {
+   if(mParent == parent)
+      return;
+   
    mParent = parent;
-   CreatePopWin();
+   if(mTipPanel)
+   {
+      if(parent != nullptr)
+         mTipPanel->SetParent(parent);
+      else
+      {
+         mTipPanel->Destroy();
+         mTipPanel = nullptr;
+      }
+   }
+   else if(parent != nullptr)
+      CreatePopWin();
 }
 
 

--- a/src/widgets/ASlider.h
+++ b/src/widgets/ASlider.h
@@ -244,7 +244,7 @@ class AUDACITY_DLL_API LWSlider
 
    wxWindowID mID;
 
-   TipWindow* mTipPanel{nullptr};
+   wxWeakRef<TipWindow> mTipPanel;
    TranslatableString mTipTemplate;
 
    bool mIsDragging;


### PR DESCRIPTION
Resolves: #4014 

It turned out that when ordering a stop, the last movements would actually always be sent to the framework, but then if play was ordered too quickly after the stop, the framework would not have enough time to send the updated settings to `ProcessInitialize`.

Making the Validator call Flush() on its `mAccess` when stopping, fixed the problem: the `mLastMovements` sent to the framework would then always come back to `ProcessInitialize`.


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
