### PR TITLE
Vst param id bounds check

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -935,9 +935,10 @@ namespace
       // Make a message from a single parameter
       explicit VSTEffectMessage(int id, double value, size_t numParams)
       {
-         mParamsVec.resize(numParams, std::nullopt);
-         if (id < numParams)
-            mParamsVec[id] = value;
+         if (id >= numParams)
+            wxLogDebug(wxT("VST parameter id out of nominal bounds!"));
+         mParamsVec.resize(std::max<size_t>(id + 1, numParams), std::nullopt);
+         mParamsVec[id] = value;
       }
 
       ~VSTEffectMessage() override;
@@ -972,10 +973,13 @@ void VSTEffectMessage::Assign(Message && src)
    mChunk = vstSrc.mChunk;
    vstSrc.mChunk.resize(0);     // capacity will be preserved though
 
-   assert(mParamsVec.size() == vstSrc.mParamsVec.size());
+   // Maybe not, see constructor of VSTEffectMessage
+   // assert(mParamsVec.size() == vstSrc.mParamsVec.size());
+   auto size = vstSrc.mParamsVec.size();
+   if (mParamsVec.size() < size)
+      mParamsVec.resize(size, std::nullopt);
 
-   for (size_t i = 0; i < mParamsVec.size(); i++)
-   {
+   for (size_t i = 0; i < size; ++i) {
       mParamsVec[i] = vstSrc.mParamsVec[i];
 
       // consume the source value
@@ -997,10 +1001,13 @@ void VSTEffectMessage::Merge(Message && src)
 
    vstSrc.mChunk.resize(0);  // capacity will be preserved though
 
-   assert(mParamsVec.size() == vstSrc.mParamsVec.size());
+   // Maybe not, see constructor of VSTEffectMessage
+   // assert(mParamsVec.size() == vstSrc.mParamsVec.size());
+   auto size = vstSrc.mParamsVec.size();
+   if (mParamsVec.size() < size)
+      mParamsVec.resize(size, std::nullopt);
 
-   for (size_t i = 0; i < mParamsVec.size(); i++)
-   {
+   for (size_t i = 0; i < size; ++i) {
       if (chunkWasAssigned)
       {
          mParamsVec[i] = vstSrc.mParamsVec[i];


### PR DESCRIPTION
Resolves: In search of an issue number

Defend against VST plug-ins that Automate an parameter ID that is out of the bounds
reported by the plug-in

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
