### PR TITLE
Menu callback simplification

### DIFF
--- a/modules/mod-null/ModNullCallback.cpp
+++ b/modules/mod-null/ModNullCallback.cpp
@@ -58,7 +58,7 @@ void ModNullCallback::OnFuncSecond(const CommandContext &)
 }
 ModNullCallback * pModNullCallback=NULL;
 
-#define ModNullFN(X) static_cast<CommandFunctorPointer>((&ModNullCallback:: X))
+#define ModNullFN(X) (&ModNullCallback:: X)
 
 extern "C" {
 

--- a/modules/mod-nyq-bench/NyqBench.cpp
+++ b/modules/mod-nyq-bench/NyqBench.cpp
@@ -108,8 +108,7 @@ void RegisterMenuItems()
    static AttachedItem sAttachment{ wxT("Tools"),
       ( FinderScope( findme ), Section( wxT("NyquistWorkBench"),
          Command( wxT("NyqBench"), XXO("&Nyquist Workbench..."),
-            static_cast<CommandFunctorPointer>(&NyqBench::ShowNyqBench),
-            AudioIONotBusyFlag())
+            &NyqBench::ShowNyqBench, AudioIONotBusyFlag())
       ) )
    };
 }

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -1212,37 +1212,27 @@ AttachedWindows::RegisteredFactory sFrequencyWindowKey{
 };
 
 // Define our extra menu item that invokes that factory
-struct Handler : CommandHandlerObject {
-   void OnPlotSpectrum(const CommandContext &context)
-   {
-      auto &project = context.project;
-      CommandManager::Get(project).RegisterLastAnalyzer(context);  //Register Plot Spectrum as Last Analyzer
-      auto freqWindow = &GetAttachedWindows(project)
-         .Get< FrequencyPlotDialog >( sFrequencyWindowKey );
+void OnPlotSpectrum(const CommandContext &context)
+{
+   auto &project = context.project;
+   CommandManager::Get(project).RegisterLastAnalyzer(context);  //Register Plot Spectrum as Last Analyzer
+   auto freqWindow = &GetAttachedWindows(project)
+      .Get< FrequencyPlotDialog >( sFrequencyWindowKey );
 
-      if( VetoDialogHook::Call( freqWindow ) )
-         return;
-      freqWindow->Show(true);
-      freqWindow->Raise();
-      freqWindow->SetFocus();
-   }
-};
-
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
+   if( VetoDialogHook::Call( freqWindow ) )
+      return;
+   freqWindow->Show(true);
+   freqWindow->Raise();
+   freqWindow->SetFocus();
 }
 
 // Register that menu item
 
 using namespace MenuTable;
 AttachedItem sAttachment{ wxT("Analyze/Analyzers/Windows"),
-   ( FinderScope{ findCommandHandler },
-      Command( wxT("PlotSpectrum"), XXO("Plot Spectrum..."),
-         &Handler::OnPlotSpectrum,
-         AudioIONotBusyFlag() | WaveTracksSelectedFlag() | TimeSelectedFlag() ) )
+   Command( wxT("PlotSpectrum"), XXO("Plot Spectrum..."),
+      OnPlotSpectrum,
+      AudioIONotBusyFlag() | WaveTracksSelectedFlag() | TimeSelectedFlag() )
 };
 
 }

--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -503,22 +503,13 @@ AttachedWindows::RegisteredFactory sHistoryWindowKey{
 };
 
 // Define our extra menu item that invokes that factory
-struct Handler : CommandHandlerObject {
-   void OnHistory(const CommandContext &context)
-   {
-      auto &project = context.project;
+void OnHistory(const CommandContext &context)
+{
+   auto &project = context.project;
 
-      auto historyWindow = &GetAttachedWindows(project).Get(sHistoryWindowKey);
-      historyWindow->Show();
-      historyWindow->Raise();
-   }
-};
-
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
+   auto historyWindow = &GetAttachedWindows(project).Get(sHistoryWindowKey);
+   historyWindow->Show();
+   historyWindow->Raise();
 }
 
 // Register that menu item
@@ -561,11 +552,10 @@ AttachedItem sAttachment{ wxT("View/Windows"),
    // FOR REDESIGN,
    // clearly there are some limitations with the flags/mask bitmaps.
 
-   ( FinderScope{ findCommandHandler },
    /* i18n-hint: Clicking this menu item shows the various editing steps
       that have been taken.*/
-      Command( wxT("UndoHistory"), XXO("&History"), &Handler::OnHistory,
-         AudioIONotBusyFlag() ) )
+   Command( wxT("UndoHistory"), XXO("&History"), OnHistory,
+      AudioIONotBusyFlag() )
 };
 
 }

--- a/src/LyricsWindow.cpp
+++ b/src/LyricsWindow.cpp
@@ -209,31 +209,21 @@ AttachedWindows::RegisteredFactory sLyricsWindowKey{
 };
 
 // Define our extra menu item that invokes that factory
-struct Handler : CommandHandlerObject {
-   void OnKaraoke(const CommandContext &context)
-   {
-      auto &project = context.project;
+void OnKaraoke(const CommandContext &context)
+{
+   auto &project = context.project;
 
-      auto lyricsWindow = &GetAttachedWindows(project).Get(sLyricsWindowKey);
-      lyricsWindow->Show();
-      lyricsWindow->Raise();
-   }
-};
-
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
+   auto lyricsWindow = &GetAttachedWindows(project).Get(sLyricsWindowKey);
+   lyricsWindow->Show();
+   lyricsWindow->Raise();
 }
 
 // Register that menu item
 
 using namespace MenuTable;
 AttachedItem sAttachment{ wxT("View/Windows"),
-   ( FinderScope{ findCommandHandler },
-      Command( wxT("Karaoke"), XXO("&Karaoke"), &Handler::OnKaraoke,
-         LabelTracksExistFlag() ) )
+   Command( wxT("Karaoke"), XXO("&Karaoke"), OnKaraoke,
+      LabelTracksExistFlag() )
 };
 
 }

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -233,8 +233,8 @@ WholeMenu::~WholeMenu() {}
 CommandHandlerFinder FinderScope::sFinder =
    [](AudacityProject &project) -> CommandHandlerObject & {
       // If this default finder function is reached, then FinderScope should
-      // have been used somewhere, or an explicit CommandHandlerFinder passed
-      // to menu item constructors
+      // have been used somewhere but was not, or an explicit
+      // CommandHandlerFinder was not passed to menu item constructors
       wxASSERT( false );
       return project;
    };

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1529,32 +1529,22 @@ AttachedWindows::RegisteredFactory sMixerBoardKey{
 };
 
 // Define our extra menu item that invokes that factory
-struct Handler : CommandHandlerObject {
-   void OnMixerBoard(const CommandContext &context)
-   {
-      auto &project = context.project;
+void OnMixerBoard(const CommandContext &context)
+{
+   auto &project = context.project;
 
-      auto mixerBoardFrame = &GetAttachedWindows(project).Get(sMixerBoardKey);
-      mixerBoardFrame->Show();
-      mixerBoardFrame->Raise();
-      mixerBoardFrame->SetFocus();
-   }
-};
-
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
+   auto mixerBoardFrame = &GetAttachedWindows(project).Get(sMixerBoardKey);
+   mixerBoardFrame->Show();
+   mixerBoardFrame->Raise();
+   mixerBoardFrame->SetFocus();
 }
 
 // Register that menu item
 
 using namespace MenuTable;
 AttachedItem sAttachment{ wxT("View/Windows"),
-   ( FinderScope{ findCommandHandler },
-      Command( wxT("MixerBoard"), XXO("&Mixer"), &Handler::OnMixerBoard,
-         PlayableTracksExistFlag()) )
+   Command( wxT("MixerBoard"), XXO("&Mixer"), OnMixerBoard,
+      PlayableTracksExistFlag())
 };
 
 }

--- a/src/SpectralDataDialog.cpp
+++ b/src/SpectralDataDialog.cpp
@@ -476,37 +476,26 @@ void SpectralDataDialog::OnCheckOvertones(wxCommandEvent &event){
 }
 
 namespace {
-struct Handler : CommandHandlerObject {
-   void OnSpectralEditingPanel(const CommandContext &context)
-   {
-      auto &project = context.project;
-      auto &dialog = SpectralDataDialog::Get(project);
-      dialog.Show( !dialog.IsShown() );
-   }
-};
-
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
+void OnSpectralEditingPanel(const CommandContext &context)
+{
+   auto &project = context.project;
+   auto &dialog = SpectralDataDialog::Get(project);
+   dialog.Show( !dialog.IsShown() );
 }
 
 using namespace MenuTable;
 MenuTable::AttachedItem sAttachment{
    wxT("View/Other/Toolbars/Toolbars/Other"),
-   ( FinderScope{ findCommandHandler },
-      Command( wxT("ShowSpectralSelectionPanel"),
-         XXO("Spectra&l Selection Panel"),
-         &Handler::OnSpectralEditingPanel,
-         AlwaysEnabledFlag,
-         CommandManager::Options{}
-            .CheckTest( [](AudacityProject &project) {
-               // Find not Get to avoid creating the dialog if not yet done
-               auto pDialog = SpectralDataDialog::Find(&project);
-               return pDialog && pDialog->IsShown();
-            } ) )
-   )
+   Command( wxT("ShowSpectralSelectionPanel"),
+      XXO("Spectra&l Selection Panel"),
+      OnSpectralEditingPanel,
+      AlwaysEnabledFlag,
+      CommandManager::Options{}
+         .CheckTest( [](AudacityProject &project) {
+            // Find not Get to avoid creating the dialog if not yet done
+            auto pDialog = SpectralDataDialog::Find(&project);
+            return pDialog && pDialog->IsShown();
+         } ) )
 };
 
 }

--- a/src/commands/CommandFunctors.h
+++ b/src/commands/CommandFunctors.h
@@ -32,13 +32,27 @@ class CommandContext;
 using CommandHandlerObject = wxEvtHandler;
 
 // First of two functions registered with each command: an extractor
-// of the handler object from the AudacityProject
+// of the handler object from the AudacityProject, or null
 using CommandHandlerFinder =
    std::function< CommandHandlerObject&(AudacityProject &) >;
 
 // Second of two function pointers registered with each command: a pointer
-// to a member function of the handler object
-using CommandFunctorPointer =
-   void (CommandHandlerObject::*)(const CommandContext &context );
+// to a member function of the handler object, or a pointer to a non-member
+// function when the CommandHandlerFinder is null
+union CommandFunctorPointer {
+   using MemberFn =
+      void (CommandHandlerObject::*)(const CommandContext &context);
+   using NonMemberFn =
+      void (*)(const CommandContext &context);
+
+   CommandFunctorPointer() = default;
+   explicit CommandFunctorPointer(MemberFn memberFn)
+      : memberFn{ memberFn } {}
+   explicit CommandFunctorPointer(NonMemberFn nonMemberFn)
+      : nonMemberFn{ nonMemberFn } {}
+
+   MemberFn memberFn;
+   NonMemberFn nonMemberFn;
+};
 
 #endif

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -1264,8 +1264,13 @@ bool CommandManager::HandleCommandEntry(AudacityProject &project,
    CommandContext context{ project, evt, entry->index, entry->parameter };
    if (pGivenContext)
       context.temporarySelection = pGivenContext->temporarySelection;
-   auto &handler = entry->finder(project);
-   (handler.*(entry->callback))(context);
+   // Discriminate the union entry->callback by entry->finder
+   if (auto &finder = entry->finder) {
+      auto &handler = finder(project);
+      (handler.*(entry->callback.memberFn))(context);
+   }
+   else
+      (entry->callback.nonMemberFn)(context);
    mLastProcessId = 0;
    return true;
 }
@@ -1300,8 +1305,13 @@ void CommandManager::RegisterLastTool(const CommandContext& context) {
 void CommandManager::DoRepeatProcess(const CommandContext& context, int id) {
    mLastProcessId = 0;  //Don't Process this as repeat
    CommandListEntry* entry = mCommandNumericIDHash[id];
-   auto& handler = entry->finder(context.project);
-   (handler.*(entry->callback))(context);
+   // Discriminate the union entry->callback by entry->finder
+   if (auto &finder = entry->finder) {
+      auto &handler = finder(context.project);
+      (handler.*(entry->callback.memberFn))(context);
+   }
+   else
+      (entry->callback.nonMemberFn)(context);
 }
 
 

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -669,7 +669,7 @@ AttachedWindows::RegisteredFactory sContrastDialogKey{
 };
 
 // Define our extra menu item that invokes that factory
-struct Handler : CommandHandlerObject {
+namespace {
    void OnContrast(const CommandContext &context)
    {
       auto &project = context.project;
@@ -682,24 +682,16 @@ struct Handler : CommandHandlerObject {
          return;
       contrastDialog->Show();
    }
-};
-
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
 }
 
 // Register that menu item
 
 using namespace MenuTable;
 AttachedItem sAttachment{ wxT("Analyze/Analyzers/Windows"),
-   ( FinderScope{ findCommandHandler },
-      Command( wxT("ContrastAnalyser"), XXO("Contrast..."),
-         &Handler::OnContrast,
-         AudioIONotBusyFlag() | WaveTracksSelectedFlag() | TimeSelectedFlag(),
-         wxT("Ctrl+Shift+T") ) )
+   Command( wxT("ContrastAnalyser"), XXO("Contrast..."),
+      OnContrast,
+      AudioIONotBusyFlag() | WaveTracksSelectedFlag() | TimeSelectedFlag(),
+      wxT("Ctrl+Shift+T") )
 };
 
 }

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -742,14 +742,12 @@ void DoClipLeftOrRight
 }
 
 /// Namespace for functions for Clip menu
-namespace ClipActions {
+namespace {
 
 // exported helper functions
 // none
 
 // Menu handler functions
-
-struct Handler : CommandHandlerObject {
 
 void OnSelectPrevClipBoundaryToCursor
 (const CommandContext &context)
@@ -817,22 +815,8 @@ void OnClipRight(const CommandContext &context)
    }
 }
 
-}; // struct Handler
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static ClipActions::Handler instance;
-   return instance;
-};
-
 // Menu definitions
 
-#define FN(X) (& ClipActions::Handler :: X)
-
-namespace {
 using namespace MenuTable;
 
 // Register menu items
@@ -842,23 +826,22 @@ BaseItemSharedPtr ClipSelectMenu()
    using Options = CommandManager::Options;
 
    static BaseItemSharedPtr menu {
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Clip"), XXO("Audi&o Clips"),
       Command( wxT("SelPrevClipBoundaryToCursor"),
          XXO("Pre&vious Clip Boundary to Cursor"),
-         FN(OnSelectPrevClipBoundaryToCursor),
+         OnSelectPrevClipBoundaryToCursor,
          WaveTracksExistFlag() ),
       Command( wxT("SelCursorToNextClipBoundary"),
          XXO("Cursor to Ne&xt Clip Boundary"),
-         FN(OnSelectCursorToNextClipBoundary),
+         OnSelectCursorToNextClipBoundary,
          WaveTracksExistFlag() ),
       Command( wxT("SelPrevClip"), XXO("Previo&us Clip"),
-         FN(OnSelectPrevClip), WaveTracksExistFlag(),
+         OnSelectPrevClip, WaveTracksExistFlag(),
          Options{ wxT("Alt+,"), XO("Select Previous Clip") } ),
-      Command( wxT("SelNextClip"), XXO("N&ext Clip"), FN(OnSelectNextClip),
+      Command( wxT("SelNextClip"), XXO("N&ext Clip"), OnSelectNextClip,
          WaveTracksExistFlag(),
          Options{ wxT("Alt+."), XO("Select Next Clip") } )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -872,17 +855,16 @@ BaseItemSharedPtr ClipCursorItems()
    using Options = CommandManager::Options;
 
    static BaseItemSharedPtr items{
-   ( FinderScope{ findCommandHandler },
    Items( wxT("Clip"),
       Command( wxT("CursPrevClipBoundary"), XXO("Pre&vious Clip Boundary"),
-         FN(OnCursorPrevClipBoundary),
+         OnCursorPrevClipBoundary,
          WaveTracksExistFlag(),
          Options{}.LongName( XO("Cursor to Prev Clip Boundary") ) ),
       Command( wxT("CursNextClipBoundary"), XXO("Ne&xt Clip Boundary"),
-         FN(OnCursorNextClipBoundary),
+         OnCursorNextClipBoundary,
          WaveTracksExistFlag(),
          Options{}.LongName( XO("Cursor to Next Clip Boundary") ) )
-   ) ) };
+   ) };
    return items;
 }
 
@@ -896,13 +878,12 @@ BaseItemSharedPtr ExtraTimeShiftItems()
 {
    using Options = CommandManager::Options;
    static BaseItemSharedPtr items{
-   ( FinderScope{ findCommandHandler },
    Items( wxT("TimeShift"),
-      Command( wxT("ClipLeft"), XXO("Time Shift &Left"), FN(OnClipLeft),
+      Command( wxT("ClipLeft"), XXO("Time Shift &Left"), OnClipLeft,
          TracksExistFlag() | TrackPanelHasFocus(), Options{}.WantKeyUp() ),
-      Command( wxT("ClipRight"), XXO("Time Shift &Right"), FN(OnClipRight),
+      Command( wxT("ClipRight"), XXO("Time Shift &Right"), OnClipRight,
          TracksExistFlag() | TrackPanelHasFocus(), Options{}.WantKeyUp() )
-   ) ) };
+   ) };
    return items;
 }
 
@@ -912,5 +893,3 @@ AttachedItem sAttachment3{
 };
 
 }
-
-#undef FN

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -134,11 +134,10 @@ bool DoPasteNothingSelected(AudacityProject &project)
 
 }
 
-namespace EditActions {
+namespace {
 
 // Menu handler functions
 
-struct Handler : CommandHandlerObject {
 void OnUndo(const CommandContext &context)
 {
    auto &project = context.project;
@@ -1021,22 +1020,9 @@ void OnPasteOver(const CommandContext &context)
 }
 #endif
 
-}; // struct Handler
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static EditActions::Handler instance;
-   return instance;
-};
-
 // Menu definitions
 
-#define FN(X) (& EditActions::Handler :: X)
-
-static const ReservedCommandFlag
+const ReservedCommandFlag
 &CutCopyAvailableFlag() { static ReservedCommandFlag flag{
    [](const AudacityProject &project){
       auto range = TrackList::Get( project ).Any<const LabelTrack>()
@@ -1061,7 +1047,6 @@ static const ReservedCommandFlag
    cutCopyOptions()
 }; return flag; }
 
-namespace {
 using namespace MenuTable;
 BaseItemSharedPtr EditMenu()
 {
@@ -1090,13 +1075,12 @@ BaseItemSharedPtr EditMenu()
    ;
 
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Edit"), XXO("&Edit"),
       Section( "UndoRedo",
-         Command( wxT("Undo"), XXO("&Undo"), FN(OnUndo),
+         Command( wxT("Undo"), XXO("&Undo"), OnUndo,
             AudioIONotBusyFlag() | UndoAvailableFlag(), wxT("Ctrl+Z") ),
 
-         Command( wxT("Redo"), XXO("&Redo"), FN(OnRedo),
+         Command( wxT("Redo"), XXO("&Redo"), OnRedo,
             AudioIONotBusyFlag() | RedoAvailableFlag(), redoKey ),
             
          Special( wxT("UndoItemsUpdateStep"),
@@ -1109,42 +1093,42 @@ BaseItemSharedPtr EditMenu()
       Section( "Basic",
          // Basic Edit commands
          /* i18n-hint: (verb)*/
-         Command( wxT("Cut"), XXO("Cu&t"), FN(OnCut),
+         Command( wxT("Cut"), XXO("Cu&t"), OnCut,
             AudioIONotBusyFlag() | CutCopyAvailableFlag() | NoAutoSelect(),
             wxT("Ctrl+X") ),
-         Command( wxT("Delete"), XXO("&Delete"), FN(OnDelete),
+         Command( wxT("Delete"), XXO("&Delete"), OnDelete,
             AudioIONotBusyFlag() | EditableTracksSelectedFlag() | TimeSelectedFlag() | NoAutoSelect(),
             wxT("Ctrl+K") ),
          /* i18n-hint: (verb)*/
-         Command( wxT("Copy"), XXO("&Copy"), FN(OnCopy),
+         Command( wxT("Copy"), XXO("&Copy"), OnCopy,
             AudioIONotBusyFlag() | CutCopyAvailableFlag(), wxT("Ctrl+C") ),
          /* i18n-hint: (verb)*/
-         Command( wxT("Paste"), XXO("&Paste"), FN(OnPaste),
+         Command( wxT("Paste"), XXO("&Paste"), OnPaste,
             AudioIONotBusyFlag(), wxT("Ctrl+V") ),
          /* i18n-hint: (verb)*/
-         Command( wxT("Duplicate"), XXO("Duplic&ate"), FN(OnDuplicate),
+         Command( wxT("Duplicate"), XXO("Duplic&ate"), OnDuplicate,
             NotBusyTimeAndTracksFlags, wxT("Ctrl+D") ),
 
          Section( "",
             Menu( wxT("RemoveSpecial"), XXO("R&emove Special"),
                Section( "",
                   /* i18n-hint: (verb) Do a special kind of cut*/
-                  Command( wxT("SplitCut"), XXO("Spl&it Cut"), FN(OnSplitCut),
+                  Command( wxT("SplitCut"), XXO("Spl&it Cut"), OnSplitCut,
                      NotBusyTimeAndTracksFlags,
                      Options{ wxT("Ctrl+Alt+X") } ),
                   /* i18n-hint: (verb) Do a special kind of DELETE*/
-                  Command( wxT("SplitDelete"), XXO("Split D&elete"), FN(OnSplitDelete),
+                  Command( wxT("SplitDelete"), XXO("Split D&elete"), OnSplitDelete,
                      NotBusyTimeAndTracksFlags,
                      Options{ wxT("Ctrl+Alt+K") } )
                ),
 
                Section( "",
                   /* i18n-hint: (verb)*/
-                  Command( wxT("Silence"), XXO("Silence Audi&o"), FN(OnSilence),
+                  Command( wxT("Silence"), XXO("Silence Audi&o"), OnSilence,
                      AudioIONotBusyFlag() | TimeSelectedFlag() | WaveTracksSelectedFlag(),
                      wxT("Ctrl+L") ),
                   /* i18n-hint: (verb)*/
-                  Command( wxT("Trim"), XXO("Tri&m Audio"), FN(OnTrim),
+                  Command( wxT("Trim"), XXO("Tri&m Audio"), OnTrim,
                      AudioIONotBusyFlag() | TimeSelectedFlag() | WaveTracksSelectedFlag(),
                      Options{ wxT("Ctrl+T") } )
                )
@@ -1159,26 +1143,26 @@ BaseItemSharedPtr EditMenu()
          Menu( wxT("Clip"), XXO("Audi&o Clips"),
             Section( "",
                /* i18n-hint: (verb) It's an item on a menu. */
-               Command( wxT("Split"), XXO("Sp&lit"), FN(OnSplit),
+               Command( wxT("Split"), XXO("Sp&lit"), OnSplit,
                   AudioIONotBusyFlag() | WaveTracksSelectedFlag(),
                   Options{ wxT("Ctrl+I") } ),
-               Command( wxT("SplitNew"), XXO("Split Ne&w"), FN(OnSplitNew),
+               Command( wxT("SplitNew"), XXO("Split Ne&w"), OnSplitNew,
                   AudioIONotBusyFlag() | TimeSelectedFlag() | WaveTracksSelectedFlag(),
                   Options{ wxT("Ctrl+Alt+I") } )
             ),
 
             Section( "",
                /* i18n-hint: (verb)*/
-               Command( wxT("Join"), XXO("&Join"), FN(OnJoin),
+               Command( wxT("Join"), XXO("&Join"), OnJoin,
                   NotBusyTimeAndTracksFlags, wxT("Ctrl+J") ),
-               Command( wxT("Disjoin"), XXO("Detac&h at Silences"), FN(OnDisjoin),
+               Command( wxT("Disjoin"), XXO("Detac&h at Silences"), OnDisjoin,
                   NotBusyTimeAndTracksFlags, wxT("Ctrl+Alt+J") )
             )
          ),
 
          //////////////////////////////////////////////////////////////////////////
 
-         Command( wxT("EditMetaData"), XXO("&Metadata"), FN(OnEditMetadata),
+         Command( wxT("EditMetaData"), XXO("&Metadata"), OnEditMetadata,
             AudioIONotBusyFlag() )
 
          //////////////////////////////////////////////////////////////////////////
@@ -1190,11 +1174,11 @@ BaseItemSharedPtr EditMenu()
       // not appear in the Edit menu but instead under Audacity, consistent with
       // MacOS conventions.
       Section( "Preferences",
-         Command( wxT("Preferences"), XXO("Pre&ferences"), FN(OnPreferences),
+         Command( wxT("Preferences"), XXO("Pre&ferences"), OnPreferences,
             AudioIONotBusyFlag(), prefKey )
       )
 
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -1209,15 +1193,14 @@ BaseItemSharedPtr ExtraEditMenu()
    static const auto flags =
       AudioIONotBusyFlag() | EditableTracksSelectedFlag() | TimeSelectedFlag();
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Edit"), XXO("&Edit"),
-      Command( wxT("DeleteKey"), XXO("&Delete Key"), FN(OnDelete),
+      Command( wxT("DeleteKey"), XXO("&Delete Key"), OnDelete,
          (flags | NoAutoSelect()),
          wxT("Backspace") ),
-      Command( wxT("DeleteKey2"), XXO("Delete Key&2"), FN(OnDelete),
+      Command( wxT("DeleteKey2"), XXO("Delete Key&2"), OnDelete,
          (flags | NoAutoSelect()),
          wxT("Delete") )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -1265,4 +1248,3 @@ AttachedItem sAttachment2{
 };
 
 }
-#undef FN

--- a/src/menus/ExtraMenus.cpp
+++ b/src/menus/ExtraMenus.cpp
@@ -12,17 +12,8 @@
 
 // helper functions and classes
 namespace {
-}
-
-/// Namespace for helper functions for Extra menu
-namespace ExtraActions {
-
-// exported helper functions
-// none
 
 // Menu handler functions
-
-struct Handler : CommandHandlerObject {
 
 void OnOutputGain(const CommandContext &context)
 {
@@ -105,22 +96,8 @@ void OnFullScreen(const CommandContext &context)
    MenuManager::Get(project).ModifyToolbarMenus(project);
 }
 
-}; // struct Handler
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static ExtraActions::Handler instance;
-   return instance;
-};
-
 // Menu definitions
 
-#define FN(X) (& ExtraActions::Handler :: X)
-
-namespace {
 using namespace MenuTable;
 
 BaseItemSharedPtr ExtraMixerMenu();
@@ -157,21 +134,20 @@ AttachedItem sAttachment1{
 BaseItemSharedPtr ExtraMixerMenu()
 {
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Mixer"), XXO("Mi&xer"),
       Command( wxT("OutputGain"), XXO("Ad&just Playback Volume..."),
-         FN(OnOutputGain), AlwaysEnabledFlag ),
+         OnOutputGain, AlwaysEnabledFlag ),
       Command( wxT("OutputGainInc"), XXO("&Increase Playback Volume"),
-         FN(OnOutputGainInc), AlwaysEnabledFlag ),
+         OnOutputGainInc, AlwaysEnabledFlag ),
       Command( wxT("OutputGainDec"), XXO("&Decrease Playback Volume"),
-         FN(OnOutputGainDec), AlwaysEnabledFlag ),
+         OnOutputGainDec, AlwaysEnabledFlag ),
       Command( wxT("InputGain"), XXO("Adj&ust Recording Volume..."),
-         FN(OnInputGain), AlwaysEnabledFlag ),
+         OnInputGain, AlwaysEnabledFlag ),
       Command( wxT("InputGainInc"), XXO("I&ncrease Recording Volume"),
-         FN(OnInputGainInc), AlwaysEnabledFlag ),
+         OnInputGainInc, AlwaysEnabledFlag ),
       Command( wxT("InputGainDec"), XXO("D&ecrease Recording Volume"),
-         FN(OnInputGainDec), AlwaysEnabledFlag )
-   ) ) };
+         OnInputGainDec, AlwaysEnabledFlag )
+   ) };
    return menu;
 }
 
@@ -179,20 +155,19 @@ BaseItemSharedPtr ExtraMixerMenu()
 BaseItemSharedPtr ExtraDeviceMenu()
 {
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Device"), XXO("De&vice"),
       Command( wxT("InputDevice"), XXO("Change &Recording Device..."),
-         FN(OnInputDevice),
+         OnInputDevice,
          AudioIONotBusyFlag(), wxT("Shift+I") ),
       Command( wxT("OutputDevice"), XXO("Change &Playback Device..."),
-         FN(OnOutputDevice),
+         OnOutputDevice,
          AudioIONotBusyFlag(), wxT("Shift+O") ),
-      Command( wxT("AudioHost"), XXO("Change Audio &Host..."), FN(OnAudioHost),
+      Command( wxT("AudioHost"), XXO("Change Audio &Host..."), OnAudioHost,
          AudioIONotBusyFlag(), wxT("Shift+H") ),
       Command( wxT("InputChannels"), XXO("Change Recording Cha&nnels..."),
-         FN(OnInputChannels),
+         OnInputChannels,
          AudioIONotBusyFlag(), wxT("Shift+N") )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -216,10 +191,9 @@ BaseItemSharedPtr ExtraMiscItems()
    ;
 
          return (
-         FinderScope{ findCommandHandler },
          // Accel key is not bindable.
          Command( wxT("FullScreenOnOff"), XXO("&Full Screen (on/off)"),
-            FN(OnFullScreen),
+            OnFullScreen,
             AlwaysEnabledFlag,
             Options{ key }.CheckTest( []( const AudacityProject &project ) {
                return GetProjectFrame( project )
@@ -236,5 +210,3 @@ AttachedItem sAttachment2{
 };
 
 }
-
-#undef FN

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -167,13 +167,7 @@ void DoImport(const CommandContext &context, bool isRaw)
    }
 }
 
-}
-
 // Menu handler functions
-
-namespace FileActions {
-
-struct Handler : CommandHandlerObject {
 
 void OnNew(const CommandContext & )
 {
@@ -536,22 +530,8 @@ void OnExportFLAC(const CommandContext &context)
    DoExport(context.project, "FLAC");
 }
 
-}; // struct Handler
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static FileActions::Handler instance;
-   return instance;
-};
-
 // Menu definitions
 
-#define FN(X) (& FileActions::Handler :: X)
-
-namespace {
 using namespace MenuTable;
 
 #ifdef USE_MIDI
@@ -568,15 +548,14 @@ BaseItemSharedPtr FileMenu()
    using Options = CommandManager::Options;
 
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("File"), XXO("&File"),
       Section( "Basic",
          /*i18n-hint: "New" is an action (verb) to create a NEW project*/
-         Command( wxT("New"), XXO("&New"), FN(OnNew),
+         Command( wxT("New"), XXO("&New"), OnNew,
             AudioIONotBusyFlag(), wxT("Ctrl+N") ),
 
          /*i18n-hint: (verb)*/
-         Command( wxT("Open"), XXO("&Open..."), FN(OnOpen),
+         Command( wxT("Open"), XXO("&Open..."), OnOpen,
             AudioIONotBusyFlag(), wxT("Ctrl+O") ),
 
    #ifdef EXPERIMENTAL_RESET
@@ -584,7 +563,7 @@ BaseItemSharedPtr FileMenu()
          // It's just for developers.
          // Do not translate this menu item (no XXO).
          // It MUST not be shown to regular users.
-         Command( wxT("Reset"), XXO("&Dangerous Reset..."), FN(OnProjectReset),
+         Command( wxT("Reset"), XXO("&Dangerous Reset..."), OnProjectReset,
             AudioIONotBusyFlag() ),
    #endif
 
@@ -623,17 +602,17 @@ BaseItemSharedPtr FileMenu()
 
    /////////////////////////////////////////////////////////////////////////////
 
-         Command( wxT("Close"), XXO("&Close"), FN(OnClose),
+         Command( wxT("Close"), XXO("&Close"), OnClose,
             AudioIONotBusyFlag(), wxT("Ctrl+W") )
       ),
 
       Section( "Save",
          Menu( wxT("Save"), XXO("&Save Project"),
-            Command( wxT("Save"), XXO("&Save Project"), FN(OnSave),
+            Command( wxT("Save"), XXO("&Save Project"), OnSave,
                AudioIONotBusyFlag(), wxT("Ctrl+S") ),
-            Command( wxT("SaveAs"), XXO("Save Project &As..."), FN(OnSaveAs),
+            Command( wxT("SaveAs"), XXO("Save Project &As..."), OnSaveAs,
                AudioIONotBusyFlag() ),
-            Command( wxT("SaveCopy"), XXO("&Backup Project..."), FN(OnSaveCopy),
+            Command( wxT("SaveCopy"), XXO("&Backup Project..."), OnSaveCopy,
                AudioIONotBusyFlag() )
          )//,
 
@@ -642,63 +621,63 @@ BaseItemSharedPtr FileMenu()
          // of space and not confuse users using undo.
          // As additional space used by aup3 is 50% or so, perfectly valid
          // approach to this P1 bug is to not provide the 'Compact' menu item.
-         //Command( wxT("Compact"), XXO("Co&mpact Project"), FN(OnCompact),
+         //Command( wxT("Compact"), XXO("Co&mpact Project"), OnCompact,
          //   AudioIONotBusyFlag(), wxT("Shift+A") )
       ),
 
       Section( "Import-Export",
          Menu( wxT("Export"), XXO("&Export"),
             // Enable Export audio commands only when there are audio tracks.
-            Command( wxT("ExportMp3"), XXO("Export as MP&3"), FN(OnExportMp3),
+            Command( wxT("ExportMp3"), XXO("Export as MP&3"), OnExportMp3,
                AudioIONotBusyFlag() | WaveTracksExistFlag() ),
 
-            Command( wxT("ExportWav"), XXO("Export as &WAV"), FN(OnExportWav),
+            Command( wxT("ExportWav"), XXO("Export as &WAV"), OnExportWav,
                AudioIONotBusyFlag() | WaveTracksExistFlag() ),
 
-            Command( wxT("ExportOgg"), XXO("Export as &OGG"), FN(OnExportOgg),
+            Command( wxT("ExportOgg"), XXO("Export as &OGG"), OnExportOgg,
                AudioIONotBusyFlag() | WaveTracksExistFlag() ),
 
-            Command( wxT("Export"), XXO("&Export Audio..."), FN(OnExportAudio),
+            Command( wxT("Export"), XXO("&Export Audio..."), OnExportAudio,
                AudioIONotBusyFlag() | WaveTracksExistFlag(), wxT("Ctrl+Shift+E") ),
 
             // Enable Export Selection commands only when there's a selection.
             Command( wxT("ExportSel"), XXO("Expo&rt Selected Audio..."),
-               FN(OnExportSelection),
+               OnExportSelection,
                AudioIONotBusyFlag() | TimeSelectedFlag() | WaveTracksSelectedFlag() ),
 
             Command( wxT("ExportLabels"), XXO("Export &Labels..."),
-               FN(OnExportLabels),
+               OnExportLabels,
                AudioIONotBusyFlag() | LabelTracksExistFlag() ),
             // Enable Export audio commands only when there are audio tracks.
             Command( wxT("ExportMultiple"), XXO("Export &Multiple..."),
-               FN(OnExportMultiple),
+               OnExportMultiple,
                AudioIONotBusyFlag() | WaveTracksExistFlag(), wxT("Ctrl+Shift+L") )
    #if defined(USE_MIDI)
             ,
-            Command( wxT("ExportMIDI"), XXO("Export MI&DI..."), FN(OnExportMIDI),
+            Command( wxT("ExportMIDI"), XXO("Export MI&DI..."), OnExportMIDI,
                AudioIONotBusyFlag() | NoteTracksExistFlag() )
    #endif
          ),
 
          Menu( wxT("Import"), XXO("&Import"),
-            Command( wxT("ImportAudio"), XXO("&Audio..."), FN(OnImport),
+            Command( wxT("ImportAudio"), XXO("&Audio..."), OnImport,
                AudioIONotBusyFlag(), wxT("Ctrl+Shift+I") ),
-            Command( wxT("ImportLabels"), XXO("&Labels..."), FN(OnImportLabels),
+            Command( wxT("ImportLabels"), XXO("&Labels..."), OnImportLabels,
                AudioIONotBusyFlag() ),
       #ifdef USE_MIDI
-            Command( wxT("ImportMIDI"), XXO("&MIDI..."), FN(OnImportMIDI),
+            Command( wxT("ImportMIDI"), XXO("&MIDI..."), OnImportMIDI,
                AudioIONotBusyFlag() ),
       #endif // USE_MIDI
-            Command( wxT("ImportRaw"), XXO("&Raw Data..."), FN(OnImportRaw),
+            Command( wxT("ImportRaw"), XXO("&Raw Data..."), OnImportRaw,
                AudioIONotBusyFlag() )
          )
       ),
 
       Section( "Print",
-         Command( wxT("PageSetup"), XXO("Pa&ge Setup..."), FN(OnPageSetup),
+         Command( wxT("PageSetup"), XXO("Pa&ge Setup..."), OnPageSetup,
             AudioIONotBusyFlag() | TracksExistFlag() ),
          /* i18n-hint: (verb) It's item on a menu. */
-         Command( wxT("Print"), XXO("&Print..."), FN(OnPrint),
+         Command( wxT("Print"), XXO("&Print..."), OnPrint,
             AudioIONotBusyFlag() | TracksExistFlag() )
       ),
 
@@ -707,10 +686,10 @@ BaseItemSharedPtr FileMenu()
          // pull it out
          // and put it in the Audacity menu for us based on its ID.
          /* i18n-hint: (verb) It's item on a menu. */
-         Command( wxT("Exit"), XXO("E&xit"), FN(OnExit),
+         Command( wxT("Exit"), XXO("E&xit"), OnExit,
             AlwaysEnabledFlag, wxT("Ctrl+Q") )
       )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -723,20 +702,17 @@ BaseItemSharedPtr HiddenFileMenu()
 {
    static BaseItemSharedPtr menu
    {
-      (
-         FinderScope{ findCommandHandler },
-         ConditionalItems( wxT("HiddenFileItems"),
-            []()
-            {
-               // Ensures that these items never appear in a menu, but
-               // are still available to scripting
-               return false;
-            },
-            Menu( wxT("HiddenFileMenu"), XXO("Hidden File Menu"),
-               Command( wxT("ExportFLAC"), XXO("Export as FLAC"),
-                  FN(OnExportFLAC),
-                  AudioIONotBusyFlag() )
-            )
+      ConditionalItems( wxT("HiddenFileItems"),
+         []()
+         {
+            // Ensures that these items never appear in a menu, but
+            // are still available to scripting
+            return false;
+         },
+         Menu( wxT("HiddenFileMenu"), XXO("Hidden File Menu"),
+            Command( wxT("ExportFLAC"), XXO("Export as FLAC"),
+               OnExportFLAC,
+               AudioIONotBusyFlag() )
          )
       )
    };
@@ -749,5 +725,3 @@ AttachedItem sAttachment2{
 };
 
 }
-
-#undef FN

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -249,13 +249,9 @@ void QuickFixDialog::OnFix(const PrefSetter &setter, wxWindowID id)
 
 }
 
-namespace HelpActions {
-
-// exported helper functions
+namespace {
 
 // Menu handler functions
-
-struct Handler : CommandHandlerObject {
 
 void OnQuickFix(const CommandContext &context)
 {
@@ -444,45 +440,30 @@ void OnHelpWelcome(const CommandContext &context)
 
 #endif
 
-}; // struct Handler
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static HelpActions::Handler instance;
-   return instance;
-};
-
 // Menu definitions
 
-#define FN(X) (& HelpActions::Handler :: X)
-
-namespace {
 using namespace MenuTable;
 BaseItemSharedPtr HelpMenu()
 {
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Help"), XXO("&Help"),
       Section( "Basic",
          // QuickFix menu item not in Audacity 2.3.1 whilst we discuss further.
    #ifdef EXPERIMENTAL_DA
          // DA: Has QuickFix menu item.
-         Command( wxT("QuickFix"), XXO("&Quick Fix..."), FN(OnQuickFix),
+         Command( wxT("QuickFix"), XXO("&Quick Fix..."), OnQuickFix,
             AlwaysEnabledFlag ),
          // DA: 'Getting Started' rather than 'Quick Help'.
-         Command( wxT("QuickHelp"), XXO("&Getting Started"), FN(OnQuickHelp),
+         Command( wxT("QuickHelp"), XXO("&Getting Started"), OnQuickHelp,
             AlwaysEnabledFlag ),
          // DA: Emphasise it is the Audacity Manual (No separate DA manual).
-         Command( wxT("Manual"), XXO("Audacity &Manual"), FN(OnManual),
+         Command( wxT("Manual"), XXO("Audacity &Manual"), OnManual,
             AlwaysEnabledFlag )
 
    #else
-         Command( wxT("QuickHelp"), XXO("&Quick Help..."), FN(OnQuickHelp),
+         Command( wxT("QuickHelp"), XXO("&Quick Help..."), OnQuickHelp,
             AlwaysEnabledFlag ),
-         Command( wxT("Manual"), XXO("&Manual..."), FN(OnManual),
+         Command( wxT("Manual"), XXO("&Manual..."), OnManual,
             AlwaysEnabledFlag )
    #endif
       ),
@@ -495,13 +476,13 @@ BaseItemSharedPtr HelpMenu()
       ( "Other",
          Menu( wxT("Diagnostics"), XXO("&Diagnostics"),
             Command( wxT("DeviceInfo"), XXO("Au&dio Device Info..."),
-               FN(OnAudioDeviceInfo),
+               OnAudioDeviceInfo,
                AudioIONotBusyFlag() ),
-            Command( wxT("Log"), XXO("Show &Log..."), FN(OnShowLog),
+            Command( wxT("Log"), XXO("Show &Log..."), OnShowLog,
                AlwaysEnabledFlag ),
       #if defined(HAS_CRASH_REPORT)
             Command( wxT("CrashReport"), XXO("&Generate Support Data..."),
-               FN(OnCrashReport), AlwaysEnabledFlag )
+               OnCrashReport, AlwaysEnabledFlag )
       #endif
 
       #ifdef IS_ALPHA
@@ -510,22 +491,22 @@ BaseItemSharedPtr HelpMenu()
             // Verbatim for labels
 
             Command( wxT("RaiseSegfault"), Verbatim("Test segfault report"),
-               FN(OnSegfault), AlwaysEnabledFlag ),
+               OnSegfault, AlwaysEnabledFlag ),
 
             Command( wxT("ThrowException"), Verbatim("Test exception report"),
-               FN(OnException), AlwaysEnabledFlag ),
+               OnException, AlwaysEnabledFlag ),
 
             Command( wxT("ViolateAssertion"), Verbatim("Test assertion report"),
-               FN(OnAssertion), AlwaysEnabledFlag ),
+               OnAssertion, AlwaysEnabledFlag ),
 
             // Menu explorer.  Perhaps this should become a macro command
             Command( wxT("MenuTree"), Verbatim("Menu Tree..."),
-               FN(OnMenuTree),
+               OnMenuTree,
                AlwaysEnabledFlag ),
               
             Command(
                  wxT("FrameStatistics"), Verbatim("Frame Statistics..."),
-                 FN(OnFrameStatistics),
+                 OnFrameStatistics,
                  AlwaysEnabledFlag)
       #endif
          )
@@ -539,18 +520,18 @@ BaseItemSharedPtr HelpMenu()
 #ifdef HAS_AUDIOCOM_UPLOAD
          Command(
             wxT("LinkAccount"), XXO("L&ink audio.com account..."),
-            FN(OnLinkAccount), AlwaysEnabledFlag),
+            OnLinkAccount, AlwaysEnabledFlag),
 #endif
          // DA: Does not fully support update checking.
    #if !defined(EXPERIMENTAL_DA) && defined(HAVE_UPDATES_CHECK)
          Command( wxT("Updates"), XXO("&Check for Updates..."),
-            FN(OnCheckForUpdates),
+            OnCheckForUpdates,
             AlwaysEnabledFlag ),
    #endif
-         Command( wxT("About"), XXO("&About Audacity"), FN(OnAbout),
+         Command( wxT("About"), XXO("&About Audacity"), OnAbout,
             AlwaysEnabledFlag )
       )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -560,5 +541,3 @@ AttachedItem sAttachment1{
 };
 
 }
-
-#undef FN

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -280,14 +280,9 @@ void EditClipboardByLabel( AudacityProject &project,
 }
 
 /// Namespace for functions for Edit Label submenu
-namespace LabelEditActions {
-
-// exported helper functions
-// none
+namespace {
 
 // Menu handler functions
-
-struct Handler : CommandHandlerObject {
 
 void OnEditLabels(const CommandContext &context)
 {
@@ -695,22 +690,8 @@ void OnNewLabelTrack(const CommandContext &context)
    track->EnsureVisible();
 }
 
-}; // struct Handler
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static LabelEditActions::Handler instance;
-   return instance;
-};
-
 // Menu definitions
 
-#define FN(X) (& LabelEditActions::Handler :: X)
-
-namespace {
 using namespace MenuTable;
 BaseItemSharedPtr LabelEditMenus()
 {
@@ -724,21 +705,20 @@ BaseItemSharedPtr LabelEditMenus()
    // Returns TWO menus.
    
    static BaseItemSharedPtr menus{
-   ( FinderScope{ findCommandHandler },
    Items( wxT("LabelEditMenus"),
    
    Menu( wxT("Labels"), XXO("&Labels"),
       Section( "",
-         Command( wxT("EditLabels"), XXO("&Edit Labels..."), FN(OnEditLabels),
+         Command( wxT("EditLabels"), XXO("&Edit Labels..."), OnEditLabels,
                     AudioIONotBusyFlag() )
       ),
 
       Section( "",
          Command( wxT("AddLabel"), XXO("Add Label at &Selection"),
-            FN(OnAddLabel), AlwaysEnabledFlag, wxT("Ctrl+B") ),
+            OnAddLabel, AlwaysEnabledFlag, wxT("Ctrl+B") ),
          Command( wxT("AddLabelPlaying"),
             XXO("Add Label at &Playback Position"),
-            FN(OnAddLabelPlaying), AudioIOBusyFlag(),
+            OnAddLabelPlaying, AudioIOBusyFlag(),
    #ifdef __WXMAC__
             wxT("Ctrl+.")
    #else
@@ -746,14 +726,14 @@ BaseItemSharedPtr LabelEditMenus()
    #endif
          ),
          Command( wxT("PasteNewLabel"), XXO("Paste Te&xt to New Label"),
-            FN(OnPasteNewLabel),
+            OnPasteNewLabel,
             AudioIONotBusyFlag(), wxT("Ctrl+Alt+V") )
       ),
 
       Section( "",
          Command( wxT("TypeToCreateLabel"),
             XXO("&Type to Create a Label (on/off)"),
-            FN(OnToggleTypeToCreateLabel), AlwaysEnabledFlag,
+            OnToggleTypeToCreateLabel, AlwaysEnabledFlag,
             Options{}.CheckTest(wxT("/GUI/TypeToCreateLabel"), false) )
       )
    ), // first menu
@@ -763,11 +743,11 @@ BaseItemSharedPtr LabelEditMenus()
    Menu( wxT("Labeled"), XXO("La&beled Audio"),
       Section( "",
          /* i18n-hint: (verb)*/
-         Command( wxT("CutLabels"), XXO("&Cut"), FN(OnCutLabels),
+         Command( wxT("CutLabels"), XXO("&Cut"), OnCutLabels,
             AudioIONotBusyFlag() | LabelsSelectedFlag() | WaveTracksExistFlag() |
                TimeSelectedFlag(),
                Options{ wxT("Alt+X"), XO("Label Cut") } ),
-         Command( wxT("DeleteLabels"), XXO("&Delete"), FN(OnDeleteLabels),
+         Command( wxT("DeleteLabels"), XXO("&Delete"), OnDeleteLabels,
             AudioIONotBusyFlag() | LabelsSelectedFlag() | WaveTracksExistFlag() |
                TimeSelectedFlag(),
             Options{ wxT("Alt+K"), XO("Label Delete") } )
@@ -776,39 +756,39 @@ BaseItemSharedPtr LabelEditMenus()
       Section( "",
          /* i18n-hint: (verb) A special way to cut out a piece of audio*/
          Command( wxT("SplitCutLabels"), XXO("&Split Cut"),
-            FN(OnSplitCutLabels), NotBusyLabelsAndWaveFlags,
+            OnSplitCutLabels, NotBusyLabelsAndWaveFlags,
             Options{ wxT("Alt+Shift+X"), XO("Label Split Cut") } ),
          Command( wxT("SplitDeleteLabels"), XXO("Sp&lit Delete"),
-            FN(OnSplitDeleteLabels), NotBusyLabelsAndWaveFlags,
+            OnSplitDeleteLabels, NotBusyLabelsAndWaveFlags,
             Options{ wxT("Alt+Shift+K"), XO("Label Split Delete") } )
       ),
 
       Section( "",
          Command( wxT("SilenceLabels"), XXO("Silence &Audio"),
-            FN(OnSilenceLabels), NotBusyLabelsAndWaveFlags,
+            OnSilenceLabels, NotBusyLabelsAndWaveFlags,
             Options{ wxT("Alt+L"), XO("Label Silence") } ),
          /* i18n-hint: (verb)*/
-         Command( wxT("CopyLabels"), XXO("Co&py"), FN(OnCopyLabels),
+         Command( wxT("CopyLabels"), XXO("Co&py"), OnCopyLabels,
             NotBusyLabelsAndWaveFlags,
             Options{ wxT("Alt+Shift+C"), XO("Label Copy") } )
       ),
 
       Section( "",
          /* i18n-hint: (verb)*/
-         Command( wxT("SplitLabels"), XXO("Spli&t"), FN(OnSplitLabels),
+         Command( wxT("SplitLabels"), XXO("Spli&t"), OnSplitLabels,
             AudioIONotBusyFlag() | LabelsSelectedFlag() | WaveTracksExistFlag(),
             Options{ wxT("Alt+I"), XO("Label Split") } ),
          /* i18n-hint: (verb)*/
-         Command( wxT("JoinLabels"), XXO("&Join"), FN(OnJoinLabels),
+         Command( wxT("JoinLabels"), XXO("&Join"), OnJoinLabels,
             NotBusyLabelsAndWaveFlags,
             Options{ wxT("Alt+J"), XO("Label Join") } ),
          Command( wxT("DisjoinLabels"), XXO("Detac&h at Silences"),
-            FN(OnDisjoinLabels), NotBusyLabelsAndWaveFlags,
+            OnDisjoinLabels, NotBusyLabelsAndWaveFlags,
             wxT("Alt+Shift+J") )
       )
    ) // second menu
 
-   ) ) }; // two menus
+   ) }; // two menus
    return menus;
 }
 
@@ -819,11 +799,8 @@ AttachedItem sAttachment1{
 };
 
 AttachedItem sAttachment2{ wxT("Tracks/Add/Add"),
-   ( FinderScope{ findCommandHandler },
    Command( wxT("NewLabelTrack"), XXO("&Label Track"),
-      FN(OnNewLabelTrack), AudioIONotBusyFlag() )
-   )
+      OnNewLabelTrack, AudioIONotBusyFlag() )
 };
 
 }
-#undef FN

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -7,37 +7,10 @@
 #include "../toolbars/ToolManager.h"
 
 /// Namespace for functions for View Toolbar menu
-namespace ToolbarActions {
-
-// exported helper functions
-// none
-
-// Menu handler functions
-
-struct Handler : CommandHandlerObject {
-
-void OnResetToolBars(const CommandContext &context)
-{
-   ToolManager::OnResetToolBars(context);
-}
-
-}; // struct Handler
-
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static ToolbarActions::Handler instance;
-   return instance;
-};
+namespace {
 
 // Menu definitions
 
-#define FN(X) (& ToolbarActions::Handler :: X)
-
-namespace{
 using namespace MenuTable;
 
 BaseItemSharedPtr ToolbarsMenu()
@@ -45,18 +18,17 @@ BaseItemSharedPtr ToolbarsMenu()
    using Options = CommandManager::Options;
 
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Section( wxT("Toolbars"),
       Menu( wxT("Toolbars"), XXO("&Toolbars"),
          Section( "Reset",
             /* i18n-hint: (verb)*/
             Command( wxT("ResetToolbars"), XXO("Reset Toolb&ars"),
-               FN(OnResetToolBars), AlwaysEnabledFlag )
+                    ToolManager::OnResetToolBars, AlwaysEnabledFlag )
          ),
 
          Section( "Other" )
       )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -65,5 +37,3 @@ AttachedItem sAttachment1{
    Shared( ToolbarsMenu() )
 };
 }
-
-#undef FN

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -604,11 +604,9 @@ void SetTrackPan(AudacityProject &project, WaveTrack * wt, LWSlider * slider)
 
 }
 
-namespace TrackActions {
+namespace {
 
 // Menu handler functions
-
-struct Handler : CommandHandlerObject {
 
 void OnStereoToMono(const CommandContext &context)
 {
@@ -1185,23 +1183,9 @@ void OnTrackMoveBottom(const CommandContext &context)
    }
 }
 
-}; // struct Handler
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static TrackActions::Handler instance;
-   return instance;
-};
-
 // Menu definitions
 
-#define FN(X) (& TrackActions::Handler :: X)
-
 // Under /MenuBar
-namespace {
 using namespace MenuTable;
 BaseItemSharedPtr TracksMenu()
 {
@@ -1209,7 +1193,6 @@ BaseItemSharedPtr TracksMenu()
    using Options = CommandManager::Options;
    
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Tracks"), XXO("&Tracks"),
       Section( "Add",
          Menu( wxT("Add"), XXO("Add &New") )
@@ -1229,40 +1212,40 @@ BaseItemSharedPtr TracksMenu()
                const PluginDescriptor *plug = PluginManager::Get().GetPlugin(ID);
                if (plug && plug->IsEnabled())
                   return Command( wxT("Stereo to Mono"),
-                     XXO("Mix Stereo Down to &Mono"), FN(OnStereoToMono),
+                     XXO("Mix Stereo Down to &Mono"), OnStereoToMono,
                      AudioIONotBusyFlag() | StereoRequiredFlag() |
-                        WaveTracksSelectedFlag(), Options{}, findCommandHandler );
+                        WaveTracksSelectedFlag(), Options{} );
                else
                   return {};
             },
             Command( wxT("MixAndRender"), XXO("Mi&x and Render"),
-               FN(OnMixAndRender),
+               OnMixAndRender,
                AudioIONotBusyFlag() | WaveTracksSelectedFlag() ),
             Command( wxT("MixAndRenderToNewTrack"),
                XXO("Mix and Render to Ne&w Track"),
-               FN(OnMixAndRenderToNewTrack),
+               OnMixAndRenderToNewTrack,
                AudioIONotBusyFlag() | WaveTracksSelectedFlag(), wxT("Ctrl+Shift+M") )
          ),
 
-         Command( wxT("Resample"), XXO("&Resample..."), FN(OnResample),
+         Command( wxT("Resample"), XXO("&Resample..."), OnResample,
             AudioIONotBusyFlag() | WaveTracksSelectedFlag() )
       ),
 
       Section( "",
-         Command( wxT("RemoveTracks"), XXO("Remo&ve Tracks"), FN(OnRemoveTracks),
+         Command( wxT("RemoveTracks"), XXO("Remo&ve Tracks"), OnRemoveTracks,
             AudioIONotBusyFlag() | AnyTracksSelectedFlag() )
       ),
 
       Section( "",
          Menu( wxT("Mute"), XXO("M&ute/Unmute"),
             Command( wxT("MuteAllTracks"), XXO("&Mute All Tracks"),
-               FN(OnMuteAllTracks), TracksExistFlag(), wxT("Ctrl+U") ),
+               OnMuteAllTracks, TracksExistFlag(), wxT("Ctrl+U") ),
             Command( wxT("UnmuteAllTracks"), XXO("&Unmute All Tracks"),
-               FN(OnUnmuteAllTracks), TracksExistFlag(), wxT("Ctrl+Shift+U") ),
+               OnUnmuteAllTracks, TracksExistFlag(), wxT("Ctrl+Shift+U") ),
             Command( wxT("MuteTracks"), XXO("Mut&e Tracks"),
-               FN(OnMuteSelectedTracks), EditableTracksSelectedFlag(), wxT("Ctrl+Alt+U") ),
+               OnMuteSelectedTracks, EditableTracksSelectedFlag(), wxT("Ctrl+Alt+U") ),
             Command( wxT("UnmuteTracks"), XXO("U&nmute Tracks"),
-               FN(OnUnmuteSelectedTracks), EditableTracksSelectedFlag(), wxT("Ctrl+Alt+Shift+U") )
+               OnUnmuteSelectedTracks, EditableTracksSelectedFlag(), wxT("Ctrl+Alt+Shift+U") )
          ),
 
          Menu( wxT("Pan"), XXO("&Pan"),
@@ -1270,13 +1253,13 @@ BaseItemSharedPtr TracksMenu()
             // pan settings for all tracks
             // in the project could very easily be lost unless we
             // require the tracks to be selected.
-            Command( wxT("PanLeft"), XXO("&Left"), FN(OnPanLeft),
+            Command( wxT("PanLeft"), XXO("&Left"), OnPanLeft,
                EditableTracksSelectedFlag(),
                Options{}.LongName( XO("Pan Left") ) ),
-            Command( wxT("PanRight"), XXO("&Right"), FN(OnPanRight),
+            Command( wxT("PanRight"), XXO("&Right"), OnPanRight,
                EditableTracksSelectedFlag(),
                Options{}.LongName( XO("Pan Right") ) ),
-            Command( wxT("PanCenter"), XXO("&Center"), FN(OnPanCenter),
+            Command( wxT("PanCenter"), XXO("&Center"), OnPanCenter,
                EditableTracksSelectedFlag(),
                Options{}.LongName( XO("Pan Center") ) )
          )
@@ -1291,20 +1274,20 @@ BaseItemSharedPtr TracksMenu()
                      { wxT("EndToEnd"),     XXO("&Align End to End") },
                      { wxT("Together"),     XXO("Align &Together") },
                   },
-                  FN(OnAlignNoSync), AudioIONotBusyFlag() | EditableTracksSelectedFlag())
+                  OnAlignNoSync, AudioIONotBusyFlag() | EditableTracksSelectedFlag())
             ),
 
             Section( "",
                // Alignment commands using selection or zero
                CommandGroup(wxT("Align"),
                   alignLabels(),
-                  FN(OnAlign), AudioIONotBusyFlag() | EditableTracksSelectedFlag())
+                  OnAlign, AudioIONotBusyFlag() | EditableTracksSelectedFlag())
             ),
 
             Section( "",
                Command( wxT("MoveSelectionWithTracks"),
                   XXO("&Move Selection with Tracks (on/off)"),
-                  FN(OnMoveSelectionWithTracks),
+                  OnMoveSelectionWithTracks,
                   AlwaysEnabledFlag,
                   Options{}.CheckTest( wxT("/GUI/MoveSelectionWithTracks"), false ) )
             )
@@ -1315,7 +1298,7 @@ BaseItemSharedPtr TracksMenu()
          // Do we need this sub-menu at all?
          Menu( wxT("MoveSelectionAndTracks"), XO("Move Sele&ction and Tracks"), {
             CommandGroup(wxT("AlignMove"), alignLabels(),
-               FN(OnAlignMoveSel), AudioIONotBusyFlag() | EditableTracksSelectedFlag()),
+               OnAlignMoveSel, AudioIONotBusyFlag() | EditableTracksSelectedFlag()),
          } ),
    #endif
 
@@ -1323,17 +1306,17 @@ BaseItemSharedPtr TracksMenu()
 
    #ifdef EXPERIMENTAL_SCOREALIGN
          Command( wxT("ScoreAlign"), XXO("Synchronize MIDI with Audio"),
-            FN(OnScoreAlign),
+            OnScoreAlign,
             AudioIONotBusyFlag() | NoteTracksSelectedFlag() | WaveTracksSelectedFlag() ),
    #endif // EXPERIMENTAL_SCOREALIGN
 
          //////////////////////////////////////////////////////////////////////////
 
          Menu( wxT("Sort"), XXO("S&ort Tracks"),
-            Command( wxT("SortByTime"), XXO("By &Start Time"), FN(OnSortTime),
+            Command( wxT("SortByTime"), XXO("By &Start Time"), OnSortTime,
                TracksExistFlag(),
                Options{}.LongName( XO("Sort by Time") ) ),
-            Command( wxT("SortByName"), XXO("By &Name"), FN(OnSortName),
+            Command( wxT("SortByName"), XXO("By &Name"), OnSortName,
                TracksExistFlag(),
                Options{}.LongName( XO("Sort by Name") ) )
          )
@@ -1346,13 +1329,13 @@ BaseItemSharedPtr TracksMenu()
 
       Section( "",
          Command( wxT("SyncLock"), XXO("Sync-&Lock Tracks (on/off)"),
-            FN(OnSyncLock), AlwaysEnabledFlag,
+            OnSyncLock, AlwaysEnabledFlag,
             Options{}.CheckTest( wxT("/GUI/SyncLockTracks"), false ) )
       )
 
 #endif
 
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -1365,53 +1348,52 @@ BaseItemSharedPtr ExtraTrackMenu()
 {
    using Options = CommandManager::Options;
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Track"), XXO("&Track"),
       Command( wxT("TrackPan"), XXO("Change P&an on Focused Track..."),
-         FN(OnTrackPan),
+         OnTrackPan,
          TrackPanelHasFocus() | TracksExistFlag(), wxT("Shift+P") ),
       Command( wxT("TrackPanLeft"), XXO("Pan &Left on Focused Track"),
-         FN(OnTrackPanLeft),
+         OnTrackPanLeft,
          TrackPanelHasFocus() | TracksExistFlag(), wxT("Alt+Shift+Left") ),
       Command( wxT("TrackPanRight"), XXO("Pan &Right on Focused Track"),
-         FN(OnTrackPanRight),
+         OnTrackPanRight,
          TrackPanelHasFocus() | TracksExistFlag(), wxT("Alt+Shift+Right") ),
       Command( wxT("TrackGain"), XXO("Change Gai&n on Focused Track..."),
-         FN(OnTrackGain),
+         OnTrackGain,
          TrackPanelHasFocus() | TracksExistFlag(), wxT("Shift+G") ),
       Command( wxT("TrackGainInc"), XXO("&Increase Gain on Focused Track"),
-         FN(OnTrackGainInc),
+         OnTrackGainInc,
          TrackPanelHasFocus() | TracksExistFlag(), wxT("Alt+Shift+Up") ),
       Command( wxT("TrackGainDec"), XXO("&Decrease Gain on Focused Track"),
-         FN(OnTrackGainDec),
+         OnTrackGainDec,
          TrackPanelHasFocus() | TracksExistFlag(), wxT("Alt+Shift+Down") ),
       Command( wxT("TrackMenu"), XXO("Op&en Menu on Focused Track..."),
-         FN(OnTrackMenu),
+         OnTrackMenu,
          TracksExistFlag() | TrackPanelHasFocus(),
          Options{ wxT("Shift+M") }.SkipKeyDown() ),
       Command( wxT("TrackMute"), XXO("M&ute/Unmute Focused Track"),
-         FN(OnTrackMute),
+         OnTrackMute,
          TracksExistFlag() | TrackPanelHasFocus(), wxT("Shift+U") ),
       Command( wxT("TrackSolo"), XXO("&Solo/Unsolo Focused Track"),
-         FN(OnTrackSolo),
+         OnTrackSolo,
          TracksExistFlag() | TrackPanelHasFocus(), wxT("Shift+S") ),
       Command( wxT("TrackClose"), XXO("&Close Focused Track"),
-         FN(OnTrackClose),
+         OnTrackClose,
          AudioIONotBusyFlag() | TrackPanelHasFocus() | TracksExistFlag(),
          wxT("Shift+C") ),
       Command( wxT("TrackMoveUp"), XXO("Move Focused Track U&p"),
-         FN(OnTrackMoveUp),
+         OnTrackMoveUp,
          AudioIONotBusyFlag() | TrackPanelHasFocus() | TracksExistFlag() ),
       Command( wxT("TrackMoveDown"), XXO("Move Focused Track Do&wn"),
-         FN(OnTrackMoveDown),
+         OnTrackMoveDown,
          AudioIONotBusyFlag() | TrackPanelHasFocus() | TracksExistFlag() ),
       Command( wxT("TrackMoveTop"), XXO("Move Focused Track to T&op"),
-         FN(OnTrackMoveTop),
+         OnTrackMoveTop,
          AudioIONotBusyFlag() | TrackPanelHasFocus() | TracksExistFlag() ),
       Command( wxT("TrackMoveBottom"), XXO("Move Focused Track to &Bottom"),
-         FN(OnTrackMoveBottom),
+         OnTrackMoveBottom,
          AudioIONotBusyFlag() | TrackPanelHasFocus() | TracksExistFlag() )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -1421,5 +1403,3 @@ AttachedItem sAttachment2{
 };
 
 }
-
-#undef FN

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -158,9 +158,7 @@ static const auto SetLoopOutTitle = XXO("Set Loop &Out");
 
 // Menu handler functions
 
-namespace TransportActions {
-
-struct Handler : CommandHandlerObject {
+namespace {
 
 // This plays (once, with fixed bounds) OR Stops audio.  It's a toggle.
 // The default binding for Shift+SPACE.
@@ -926,23 +924,9 @@ void OnStopSelect(const CommandContext &context)
 }
 #endif
 
-}; // struct Handler
-
-} // namespace
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static TransportActions::Handler instance;
-   return instance;
-};
-
 // Menu definitions
 
-#define FN(X) (& TransportActions::Handler :: X)
-
 // Under /MenuBar
-namespace {
 using namespace MenuTable;
 BaseItemSharedPtr TransportMenu()
 {
@@ -951,26 +935,25 @@ BaseItemSharedPtr TransportMenu()
    static const auto CanStopFlags = AudioIONotBusyFlag() | CanStopAudioStreamFlag();
 
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    /* i18n-hint: 'Transport' is the name given to the set of controls that
       play, record, pause etc. */
    Menu( wxT("Transport"), XXO("Tra&nsport"),
       Section( "Basic",
          Menu( wxT("Play"), XXO("Pl&aying"),
             /* i18n-hint: (verb) Start or Stop audio playback*/
-            Command( wxT("DefaultPlayStop"), XXO("Pl&ay/Stop"), FN(OnPlayDefaultOrStop),
+            Command( wxT("DefaultPlayStop"), XXO("Pl&ay/Stop"), OnPlayDefaultOrStop,
                CanStopAudioStreamFlag(), wxT("Space") ),
             Command( wxT("PlayStopSelect"), XXO("Play/Stop and &Set Cursor"),
-               FN(OnPlayStopSelect), CanStopAudioStreamFlag(), wxT("X") ),
-            Command( wxT("OncePlayStop"), XXO("Play &Once/Stop"), FN(OnPlayOnceOrStop),
+               OnPlayStopSelect, CanStopAudioStreamFlag(), wxT("X") ),
+            Command( wxT("OncePlayStop"), XXO("Play &Once/Stop"), OnPlayOnceOrStop,
                CanStopAudioStreamFlag(), wxT("Shift+Space") ),
-            Command( wxT("Pause"), XXO("&Pause"), FN(OnPause),
+            Command( wxT("Pause"), XXO("&Pause"), OnPause,
                CanStopAudioStreamFlag(), wxT("P") )
          ),
 
          Menu( wxT("Record"), XXO("&Recording"),
             /* i18n-hint: (verb)*/
-            Command( wxT("Record1stChoice"), XXO("&Record"), FN(OnRecord),
+            Command( wxT("Record1stChoice"), XXO("&Record"), OnRecord,
                CanStopFlags, wxT("R") ),
 
             // The OnRecord2ndChoice function is: if normal record records beside,
@@ -985,17 +968,16 @@ BaseItemSharedPtr TransportMenu()
                // It should be bound to Shift+R
                (gPrefs->ReadBool("/GUI/PreferNewTrackRecord", false)
                 ? XXO("&Append Record") : XXO("Record &New Track")),
-               FN(OnRecord2ndChoice), CanStopFlags,
-               wxT("Shift+R"),
-               findCommandHandler
+               OnRecord2ndChoice, CanStopFlags,
+               wxT("Shift+R")
             ); },
 
             Command( wxT("TimerRecord"), XXO("&Timer Record..."),
-               FN(OnTimerRecord), CanStopFlags, wxT("Shift+T") ),
+               OnTimerRecord, CanStopFlags, wxT("Shift+T") ),
 
    #ifdef EXPERIMENTAL_PUNCH_AND_ROLL
             Command( wxT("PunchAndRoll"), XXO("Punch and Rol&l Record"),
-               FN(OnPunchAndRoll),
+               OnPunchAndRoll,
                WaveTracksExistFlag() | AudioIONotBusyFlag(), wxT("Shift+D") ),
    #endif
 
@@ -1003,7 +985,7 @@ BaseItemSharedPtr TransportMenu()
             // rather than put it at the top level.
             // CommandManger::AddItem can now cope with simple duplicated items.
             // PRL:  caution, this is a duplicated command name!
-            Command( wxT("Pause"), XXO("&Pause"), FN(OnPause),
+            Command( wxT("Pause"), XXO("&Pause"), OnPause,
                CanStopAudioStreamFlag(), wxT("P") )
          )
       ),
@@ -1012,44 +994,44 @@ BaseItemSharedPtr TransportMenu()
          Section( "",
             Menu( wxT("PlayRegion"), XXO("&Looping"),
                Command( wxT("TogglePlayRegion"), LoopToggleText,
-                  FN(OnTogglePlayRegion), AlwaysEnabledFlag,
+                  OnTogglePlayRegion, AlwaysEnabledFlag,
                      Options(L"L").CheckTest([](const AudacityProject& project){
                          return IsLoopingEnabled(project);
                      } )),
                Command( wxT("ClearPlayRegion"), XXO("&Clear Loop"),
-                  FN(OnClearPlayRegion), AlwaysEnabledFlag, L"Shift+Alt+L" ),
+                  OnClearPlayRegion, AlwaysEnabledFlag, L"Shift+Alt+L" ),
                Command( wxT("SetPlayRegionToSelection"),
                   XXO("&Set Loop to Selection"),
-                  FN(OnSetPlayRegionToSelection), AlwaysEnabledFlag,
+                  OnSetPlayRegionToSelection, AlwaysEnabledFlag,
                      L"Shift+L" ),
                Command( wxT("SetPlayRegionIn"),
                   SetLoopInTitle,
-                  FN(OnSetPlayRegionIn), AlwaysEnabledFlag ),
+                  OnSetPlayRegionIn, AlwaysEnabledFlag ),
                Command( wxT("SetPlayRegionOut"),
                   SetLoopOutTitle,
-                  FN(OnSetPlayRegionOut), AlwaysEnabledFlag )
+                  OnSetPlayRegionOut, AlwaysEnabledFlag )
             )
          ),
 
          Command( wxT("RescanDevices"), XXO("R&escan Audio Devices"),
-            FN(OnRescanDevices), AudioIONotBusyFlag() | CanStopAudioStreamFlag() ),
+            OnRescanDevices, AudioIONotBusyFlag() | CanStopAudioStreamFlag() ),
 
          Menu( wxT("Options"), XXO("Transport &Options"),
             Section( "",
                // Sound Activated recording options
                Command( wxT("SoundActivationLevel"),
-                  XXO("Sound Activation Le&vel..."), FN(OnSoundActivated),
+                  XXO("Sound Activation Le&vel..."), OnSoundActivated,
                   AudioIONotBusyFlag() | CanStopAudioStreamFlag() ),
                Command( wxT("SoundActivation"),
                   XXO("Sound A&ctivated Recording (on/off)"),
-                  FN(OnToggleSoundActivated),
+                  OnToggleSoundActivated,
                   AudioIONotBusyFlag() | CanStopAudioStreamFlag(),
                   Options{}.CheckTest(wxT("/AudioIO/SoundActivatedRecord"), false) )
             ),
 
             Section( "",
                Command( wxT("PinnedHead"), XXO("Pinned Play/Record &Head (on/off)"),
-                  FN(OnTogglePinnedHead),
+                  OnTogglePinnedHead,
                   // Switching of scrolling on and off is permitted
                   // even during transport
                   AlwaysEnabledFlag,
@@ -1057,7 +1039,7 @@ BaseItemSharedPtr TransportMenu()
                      return TracksPrefs::GetPinnedHeadPreference(); } ) ),
 
                Command( wxT("Overdub"), XXO("&Overdub (on/off)"),
-                  FN(OnTogglePlayRecording),
+                  OnTogglePlayRecording,
                   AudioIONotBusyFlag() | CanStopAudioStreamFlag(),
                   Options{}.CheckTest( wxT("/AudioIO/Duplex"),
 #ifdef EXPERIMENTAL_DA
@@ -1067,7 +1049,7 @@ BaseItemSharedPtr TransportMenu()
 #endif
                   ) ),
                Command( wxT("SWPlaythrough"), XXO("So&ftware Playthrough (on/off)"),
-                  FN(OnToggleSWPlaythrough),
+                  OnToggleSWPlaythrough,
                   AudioIONotBusyFlag() | CanStopAudioStreamFlag(),
                   Options{}.CheckTest( wxT("/AudioIO/SWPlaythrough"), false ) )
 
@@ -1076,7 +1058,7 @@ BaseItemSharedPtr TransportMenu()
                ,
                Command( wxT("AutomatedInputLevelAdjustmentOnOff"),
                   XXO("A&utomated Recording Level Adjustment (on/off)"),
-                  FN(OnToggleAutomatedInputLevelAdjustment),
+                  OnToggleAutomatedInputLevelAdjustment,
                   AudioIONotBusyFlag() | CanStopAudioStreamFlag(),
                   Options{}.CheckTest(
                      wxT("/AudioIO/AutomatedInputLevelAdjustment"), false ) )
@@ -1084,7 +1066,7 @@ BaseItemSharedPtr TransportMenu()
             )
          )
       )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -1096,44 +1078,43 @@ AttachedItem sAttachment1{
 BaseItemSharedPtr ExtraTransportMenu()
 {
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Transport"), XXO("T&ransport"),
       // PlayStop is already in the menus.
       /* i18n-hint: (verb) Start playing audio*/
-      Command( wxT("Play"), XXO("Pl&ay Once"), FN(OnPlayOnceOrStop),
+      Command( wxT("Play"), XXO("Pl&ay Once"), OnPlayOnceOrStop,
          WaveTracksExistFlag() | AudioIONotBusyFlag() ),
       /* i18n-hint: (verb) Stop playing audio*/
-      Command( wxT("Stop"), XXO("Sto&p"), FN(OnStop),
+      Command( wxT("Stop"), XXO("Sto&p"), OnStop,
          AudioIOBusyFlag() | CanStopAudioStreamFlag() ),
-      Command( wxT("PlayOneSec"), XXO("Play &One Second"), FN(OnPlayOneSecond),
+      Command( wxT("PlayOneSec"), XXO("Play &One Second"), OnPlayOneSecond,
          CaptureNotBusyFlag(), wxT("1") ),
       Command( wxT("PlayToSelection"), XXO("Play to &Selection"),
-         FN(OnPlayToSelection),
+         OnPlayToSelection,
          CaptureNotBusyFlag(), wxT("B") ),
       Command( wxT("PlayBeforeSelectionStart"),
-         XXO("Play &Before Selection Start"), FN(OnPlayBeforeSelectionStart),
+         XXO("Play &Before Selection Start"), OnPlayBeforeSelectionStart,
          CaptureNotBusyFlag(), wxT("Shift+F5") ),
       Command( wxT("PlayAfterSelectionStart"),
-         XXO("Play Af&ter Selection Start"), FN(OnPlayAfterSelectionStart),
+         XXO("Play Af&ter Selection Start"), OnPlayAfterSelectionStart,
          CaptureNotBusyFlag(), wxT("Shift+F6") ),
       Command( wxT("PlayBeforeSelectionEnd"),
-         XXO("Play Be&fore Selection End"), FN(OnPlayBeforeSelectionEnd),
+         XXO("Play Be&fore Selection End"), OnPlayBeforeSelectionEnd,
          CaptureNotBusyFlag(), wxT("Shift+F7") ),
       Command( wxT("PlayAfterSelectionEnd"),
-         XXO("Play Aft&er Selection End"), FN(OnPlayAfterSelectionEnd),
+         XXO("Play Aft&er Selection End"), OnPlayAfterSelectionEnd,
          CaptureNotBusyFlag(), wxT("Shift+F8") ),
       Command( wxT("PlayBeforeAndAfterSelectionStart"),
          XXO("Play Before a&nd After Selection Start"),
-         FN(OnPlayBeforeAndAfterSelectionStart), CaptureNotBusyFlag(),
+         OnPlayBeforeAndAfterSelectionStart, CaptureNotBusyFlag(),
          wxT("Ctrl+Shift+F5") ),
       Command( wxT("PlayBeforeAndAfterSelectionEnd"),
          XXO("Play Before an&d After Selection End"),
-         FN(OnPlayBeforeAndAfterSelectionEnd), CaptureNotBusyFlag(),
+         OnPlayBeforeAndAfterSelectionEnd, CaptureNotBusyFlag(),
          wxT("Ctrl+Shift+F7") ),
       Command( wxT("PlayCutPreview"), XXO("Play C&ut Preview"),
-         FN(OnPlayCutPreview),
+         OnPlayCutPreview,
          CaptureNotBusyFlag(), wxT("C") )
-   ) ) };
+   ) };
    return menu;
 }
 
@@ -1145,22 +1126,21 @@ AttachedItem sAttachment2{
 BaseItemSharedPtr ExtraPlayAtSpeedMenu()
 {
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("PlayAtSpeed"), XXO("&Play-at-Speed"),
       /* i18n-hint: 'Normal Play-at-Speed' doesn't loop or cut preview. */
       Command( wxT("PlayAtSpeedLooped"), XXO("&Play-at-Speed"),
-         FN(OnPlayAtSpeedLooped), CaptureNotBusyFlag() ),
+         OnPlayAtSpeedLooped, CaptureNotBusyFlag() ),
       Command( wxT("PlayAtSpeed"), XXO("Play-at-Speed &Once"),
-         FN(OnPlayAtSpeed), CaptureNotBusyFlag() ),
+         OnPlayAtSpeed, CaptureNotBusyFlag() ),
       Command( wxT("PlayAtSpeedCutPreview"), XXO("Play C&ut Preview-at-Speed"),
-         FN(OnPlayAtSpeedCutPreview), CaptureNotBusyFlag() ),
+         OnPlayAtSpeedCutPreview, CaptureNotBusyFlag() ),
       Command( wxT("SetPlaySpeed"), XXO("Ad&just Playback Speed..."),
-         FN(OnSetPlaySpeed), CaptureNotBusyFlag() ),
+         OnSetPlaySpeed, CaptureNotBusyFlag() ),
       Command( wxT("PlaySpeedInc"), XXO("&Increase Playback Speed"),
-         FN(OnPlaySpeedInc), CaptureNotBusyFlag() ),
+         OnPlaySpeedInc, CaptureNotBusyFlag() ),
       Command( wxT("PlaySpeedDec"), XXO("&Decrease Playback Speed"),
-         FN(OnPlaySpeedDec), CaptureNotBusyFlag() )
-   ) ) };
+         OnPlaySpeedDec, CaptureNotBusyFlag() )
+   ) };
    return menu;
 }
 
@@ -1173,15 +1153,14 @@ BaseItemSharedPtr ExtraSelectionItems()
 {
    using Options = CommandManager::Options;
    static BaseItemSharedPtr items{
-   (FinderScope{ findCommandHandler },
    Items(wxT("MoveToLabel"),
       Command(wxT("MoveToPrevLabel"), XXO("Move to Pre&vious Label"),
-         FN(OnMoveToPrevLabel),
+         OnMoveToPrevLabel,
          CaptureNotBusyFlag() | TrackPanelHasFocus(), wxT("Alt+Left")),
       Command(wxT("MoveToNextLabel"), XXO("Move to Ne&xt Label"),
-         FN(OnMoveToNextLabel),
+         OnMoveToNextLabel,
          CaptureNotBusyFlag() | TrackPanelHasFocus(), wxT("Alt+Right"))
-   )) };
+   ) };
    return items;
 }
 
@@ -1191,5 +1170,3 @@ AttachedItem sAttachment4{
 };
 
 }
-
-#undef FN

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -283,14 +283,10 @@ void SetTool(AudacityProject &project, int tool)
 }
 
 /// Namespace for functions for View Toolbar menu
-namespace ToolActions {
-
-// exported helper functions
-// none
+namespace {
 
 // Menu handler functions
 
-struct Handler : CommandHandlerObject {
 /// Handler to set the select tool active
 void OnSelectTool(const CommandContext &context)
 {
@@ -334,40 +330,26 @@ void OnNextTool(const CommandContext &context)
    trackPanel.Refresh(false);
 }
 
-}; // struct Handler
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static ToolActions::Handler instance;
-   return instance;
-};
-
-#define FN(X) (& ToolActions::Handler :: X)
-
 using namespace MenuTable;
 BaseItemSharedPtr ExtraToolsMenu()
 {
    static BaseItemSharedPtr menu{
-   ( FinderScope{ findCommandHandler },
    Menu( wxT("Tools"), XXO("T&ools"),
-      Command( wxT("SelectTool"), XXO("&Selection Tool"), FN(OnSelectTool),
+      Command( wxT("SelectTool"), XXO("&Selection Tool"), OnSelectTool,
          AlwaysEnabledFlag, wxT("F1") ),
       Command( wxT("EnvelopeTool"), XXO("&Envelope Tool"),
-         FN(OnEnvelopeTool), AlwaysEnabledFlag, wxT("F2") ),
-      Command( wxT("DrawTool"), XXO("&Draw Tool"), FN(OnDrawTool),
+         OnEnvelopeTool, AlwaysEnabledFlag, wxT("F2") ),
+      Command( wxT("DrawTool"), XXO("&Draw Tool"), OnDrawTool,
          AlwaysEnabledFlag, wxT("F3") ),
-      Command( wxT("MultiTool"), XXO("&Multi Tool"), FN(OnMultiTool),
+      Command( wxT("MultiTool"), XXO("&Multi Tool"), OnMultiTool,
          AlwaysEnabledFlag, wxT("F6") ),
-      Command( wxT("PrevTool"), XXO("&Previous Tool"), FN(OnPrevTool),
+      Command( wxT("PrevTool"), XXO("&Previous Tool"), OnPrevTool,
          AlwaysEnabledFlag, wxT("A") ),
-      Command( wxT("NextTool"), XXO("&Next Tool"), FN(OnNextTool),
+      Command( wxT("NextTool"), XXO("&Next Tool"), OnNextTool,
          AlwaysEnabledFlag, wxT("D") )
-   ) ) };
+   ) };
    return menu;
 }
-
-#undef FN
 
 AttachedItem sAttachment2{
    wxT("Optional/Extra/Part1"),

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackMenuItems.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackMenuItems.cpp
@@ -25,7 +25,6 @@ Paul Licameli split from TrackMenus.cpp
 
 #ifdef EXPERIMENTAL_MIDI_OUT
 namespace {
-struct Handler : CommandHandlerObject {
 void OnMidiDeviceInfo(const CommandContext &context)
 {
    auto &project = context.project;
@@ -34,26 +33,13 @@ void OnMidiDeviceInfo(const CommandContext &context)
    ShowDiagnostics( project, info,
       XO("MIDI Device Info"), wxT("midideviceinfo.txt") );
 }
-};
-
-static CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
-};
 
 using namespace MenuTable;
-#define FN(X) (& Handler :: X)
 AttachedItem sAttachment{
    { wxT("Help/Other/Diagnostics"),
       { OrderingHint::After, wxT("DeviceInfo") } },
-   ( FinderScope{ findCommandHandler },
-      Command( wxT("MidiDeviceInfo"), XXO("&MIDI Device Info..."),
-         FN(OnMidiDeviceInfo),
-         AudioIONotBusyFlag() )
-   )
+   Command( wxT("MidiDeviceInfo"), XXO("&MIDI Device Info..."),
+      OnMidiDeviceInfo, AudioIONotBusyFlag() )
 };
-#undef FN
 }
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -567,8 +567,6 @@ namespace {
 
 // Menu handler functions
 
-struct Handler : CommandHandlerObject {
-
 void OnEditClipName(const CommandContext &context)
 {
    auto &project = context.project;
@@ -583,28 +581,13 @@ void OnEditClipName(const CommandContext &context)
    }
 }
 
-};
-
-#define FN(X) (& Handler :: X)
-
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
-};
-
 using namespace MenuTable;
 
 // Register menu items
 
 AttachedItem sAttachment{ wxT("Edit/Other"),
-   ( FinderScope{ findCommandHandler },
-      Command( L"RenameClip", XXO("Rename Clip..."),
-         &Handler::OnEditClipName, SomeClipIsSelectedFlag(),
-         wxT("Ctrl+F2") ) )
+   Command( L"RenameClip", XXO("Rename Clip..."),
+      OnEditClipName, SomeClipIsSelectedFlag(), wxT("Ctrl+F2") )
 };
 
 }
-
-#undef FN

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackMenuItems.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackMenuItems.cpp
@@ -23,7 +23,6 @@ Paul Licameli split from TrackMenus.cpp
 namespace {
 using namespace MenuTable;
 
-struct Handler : CommandHandlerObject {
 void OnNewWaveTrack(const CommandContext &context)
 {
    auto &project = context.project;
@@ -80,25 +79,13 @@ void OnNewStereoTrack(const CommandContext &context)
    left->EnsureVisible();
 }
 
-};
-
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
-}
-
-#define FN(X) (&Handler :: X)
 AttachedItem sAttachment{ wxT("Tracks/Add/Add"),
-   ( FinderScope{ findCommandHandler },
    Items( "",
-      Command( wxT("NewMonoTrack"), XXO("&Mono Track"), FN(OnNewWaveTrack),
+      Command( wxT("NewMonoTrack"), XXO("&Mono Track"), OnNewWaveTrack,
          AudioIONotBusyFlag(), wxT("Ctrl+Shift+N") ),
       Command( wxT("NewStereoTrack"), XXO("&Stereo Track"),
-         FN(OnNewStereoTrack), AudioIONotBusyFlag() )
-   ) )
+         OnNewStereoTrack, AudioIONotBusyFlag() )
+   )
 };
-#undef FN
 
 }

--- a/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
@@ -23,7 +23,6 @@ Paul Licameli split from TrackMenus.cpp
 namespace {
 using namespace MenuTable;
 
-struct Handler : CommandHandlerObject {
 void OnNewTimeTrack(const CommandContext &context)
 {
    auto &project = context.project;
@@ -50,22 +49,11 @@ void OnNewTimeTrack(const CommandContext &context)
    TrackFocus::Get(project).Set(t);
    t->EnsureVisible();
 }
-};
 
-CommandHandlerObject &findCommandHandler(AudacityProject &) {
-   // Handler is not stateful.  Doesn't need a factory registered with
-   // AudacityProject.
-   static Handler instance;
-   return instance;
-}
-
-#define FN(X) (&Handler :: X)
 AttachedItem sAttachment{ wxT("Tracks/Add/Add"),
-   ( FinderScope{ findCommandHandler },
      Command( wxT("NewTimeTrack"), XXO("&Time Track"),
-        FN(OnNewTimeTrack), AudioIONotBusyFlag() )
+        OnNewTimeTrack, AudioIONotBusyFlag()
  )
 };
-#undef FN
 
 }


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Eliminate verbosity in the definition of most menu items, which can call a stateless
nonmember function.  The prior system was general enough to use member functions
of a stateful static object, but that requires more boilerplate that only a few callbacks need.

Let's do this simplification before other restructurings that will cut and paste many menu
items, so that more of them are scattered and use registries to put them in their places.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
