### PR TITLE
Remove screenshot button for now absent Mixer toolbar

### DIFF
--- a/src/Screenshot.cpp
+++ b/src/Screenshot.cpp
@@ -225,7 +225,6 @@ enum
    IdCaptureTimer,
    IdCaptureTools,
    IdCaptureTransport,
-   IdCaptureMixer,
    IdCaptureMeter,
    IdCapturePlayMeter,
    IdCaptureRecordMeter,
@@ -426,13 +425,12 @@ void ScreenshotBigDialog::PopulateOrExchange(ShuttleGui & S)
             S.Id(IdCaptureSpectralSelection).AddButton(XXO("Spectral Selection"));
             S.Id(IdCaptureTimer).AddButton(XXO("Timer"));
             S.Id(IdCaptureTools).AddButton(XXO("Tools"));
-            S.Id(IdCaptureTransport).AddButton(XXO("Transport"));
          }
          S.EndHorizontalLay();
 
          S.StartHorizontalLay();
          {
-            S.Id(IdCaptureMixer).AddButton(XXO("Mixer"));
+            S.Id(IdCaptureTransport).AddButton(XXO("Transport"));
             S.Id(IdCaptureMeter).AddButton(XXO("Meter"));
             S.Id(IdCapturePlayMeter).AddButton(XXO("Play Meter"));
             S.Id(IdCaptureRecordMeter).AddButton(XXO("Record Meter"));


### PR DESCRIPTION
Resolves: #4040

Remove button for Mixer toolbar from Screenshot dialog

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
