### PR TITLE
Rewrite audio setup menus

### DIFF
--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -562,7 +562,6 @@ void AudioSetupToolBar::FillHostDevices()
          if (host.empty()) {
             host = device.hostString;
             AudioIOHost.Write(host);
-            gPrefs->Flush();
 
             const auto id = mHost->FindItem(host);
             if (id != wxNOT_FOUND) {
@@ -571,6 +570,8 @@ void AudioSetupToolBar::FillHostDevices()
          }
       }
    }
+
+   gPrefs->Flush();
 
    // The setting of the Device is left up to menu handlers
 }

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -17,7 +17,6 @@
 #include <thread>
 
 #include <wx/log.h>
-#include <wx/menu.h>
 #include <wx/sizer.h>
 #include <wx/tooltip.h>
 
@@ -662,7 +661,14 @@ void AudioSetupToolBar::AppendSubMenu( AudioSetupToolBar &toolbar,
       menuItem->Enable(false);
 }
 
-std::optional<wxString> AudioSetupToolBar::GetSelectedRadioItemLabel(const wxMenu& menu) const
+void AudioSetupToolBar::Choice::AppendSubMenu(
+   AudioSetupToolBar &toolBar, wxMenu &menu, const wxString &title)
+{
+   toolBar.AppendSubMenu(menu, mMenu, title);
+}
+
+std::optional<wxString>
+AudioSetupToolBar::GetSelectedRadioItemLabel(const wxMenu& menu)
 {
    const auto& items = menu.GetMenuItems();
 

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -667,6 +667,13 @@ void AudioSetupToolBar::Choice::AppendSubMenu(
    toolBar.AppendSubMenu(menu, mMenu, title);
 }
 
+void AudioSetupToolBar::Choices::AppendSubMenu(AudioSetupToolBar &toolBar,
+   wxMenu &menu, Callback callback, const wxString &title)
+{
+   AudioSetupToolBar::
+   AppendSubMenu(toolBar, menu, mStrings, mIndex, callback, title);
+}
+
 std::optional<wxString>
 AudioSetupToolBar::GetSelectedRadioItemLabel(const wxMenu& menu)
 {

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -640,6 +640,27 @@ void AudioSetupToolBar::AppendSubMenu(wxMenu& menu, const std::unique_ptr<wxMenu
    }
 }
 
+void AudioSetupToolBar::AppendSubMenu( AudioSetupToolBar &toolbar,
+   wxMenu& menu, const wxArrayString &labels, int checkedItem,
+   Callback callback, const wxString& title)
+{
+   auto subMenu = std::make_unique<wxMenu>();
+   int ii = 0;
+   for (const auto &label : labels) {
+      // Assign fresh ID with wxID_ANY
+      auto subMenuItem = subMenu->AppendRadioItem(wxID_ANY, label);
+      if (ii == checkedItem)
+         subMenuItem->Check();
+      subMenu->Bind(wxEVT_MENU,
+         [&toolbar, callback, ii](wxCommandEvent &){ (toolbar.*callback)(ii); },
+         subMenuItem->GetId());
+      ++ii;
+   }
+   auto menuItem = menu.AppendSubMenu(subMenu.release(), title);
+   if (checkedItem < 0)
+      menuItem->Enable(false);
+}
+
 std::optional<wxString> AudioSetupToolBar::GetSelectedRadioItemLabel(const wxMenu& menu) const
 {
    const auto& items = menu.GetMenuItems();

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -569,26 +569,7 @@ void AudioSetupToolBar::FillInputChannels()
       mInputChannels.Set(newChannels - 1);
 }
 
-void AudioSetupToolBar::AppendSubMenu(wxMenu& menu, const std::unique_ptr<wxMenu>& submenu, const wxString& title)
-{
-   auto clonedMenu = std::make_unique<wxMenu>();
-
-   for (const auto& item : submenu->GetMenuItems()) {
-      auto cloneMenuItem = clonedMenu->AppendRadioItem(item->GetId(), item->GetItemLabelText());
-
-      if (item->IsChecked())
-         cloneMenuItem->Check();
-   }
-
-   auto menuItem = menu.AppendSubMenu(clonedMenu.release(), title);
-
-   const auto selected = GetSelectedRadioItemLabel(*submenu);
-   if (!selected) {
-      menuItem->Enable(false);
-   }
-}
-
-void AudioSetupToolBar::AppendSubMenu( AudioSetupToolBar &toolbar,
+void AudioSetupToolBar::AppendSubMenu(AudioSetupToolBar &toolbar,
    wxMenu& menu, const wxArrayString &labels, int checkedItem,
    Callback callback, const wxString& title)
 {
@@ -609,30 +590,11 @@ void AudioSetupToolBar::AppendSubMenu( AudioSetupToolBar &toolbar,
       menuItem->Enable(false);
 }
 
-void AudioSetupToolBar::Choice::AppendSubMenu(
-   AudioSetupToolBar &toolBar, wxMenu &menu, const wxString &title)
-{
-   toolBar.AppendSubMenu(menu, mMenu, title);
-}
-
 void AudioSetupToolBar::Choices::AppendSubMenu(AudioSetupToolBar &toolBar,
    wxMenu &menu, Callback callback, const wxString &title)
 {
    AudioSetupToolBar::
    AppendSubMenu(toolBar, menu, mStrings, mIndex, callback, title);
-}
-
-std::optional<wxString>
-AudioSetupToolBar::GetSelectedRadioItemLabel(const wxMenu& menu)
-{
-   const auto& items = menu.GetMenuItems();
-
-   for (const auto& item : items) {
-      if (item->IsChecked())
-         return item->GetItemLabelText();
-   }
-
-   return std::nullopt;
 }
 
 void AudioSetupToolBar::OnRescannedDevices(DeviceChangeMessage m)

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -751,6 +751,34 @@ void AudioSetupToolBar::ChangeDevice(int deviceId, bool isInput)
               isInput ? nullptr : &maps[newIndex]);
 }
 
+void AudioSetupToolBar::ChangeDeviceLabel(
+   int deviceId, Choice &choices, bool isInput, int baseId)
+{
+   int newIndex = -1;
+
+   auto host = AudioIOHost.Read();
+   const std::vector<DeviceSourceMap>& maps = isInput ? DeviceManager::Instance()->GetInputDeviceMaps()
+      : DeviceManager::Instance()->GetOutputDeviceMaps();
+
+   if (choices.Set(baseId + deviceId)) {
+      // Update cache with the chosen device
+      wxString newDevice = *choices.Get();
+      for (size_t i = 0; i < maps.size(); ++i) {
+         const auto name = MakeDeviceSourceString(&maps[i]);
+         if (name == newDevice && maps[i].hostString == host)
+            newIndex = i;
+      }
+   }
+
+   if (newIndex < 0) {
+      wxLogDebug(wxT("AudioSetupToolBar::ChangeDeviceLabel(): couldn't find device indices"));
+      return;
+   }
+
+   SetDevices(isInput ? &maps[newIndex] : nullptr,
+              isInput ? nullptr : &maps[newIndex]);
+}
+
 void AudioSetupToolBar::OnHost(int id)
 {
    ChangeHost(id);

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -764,6 +764,11 @@ void AudioSetupToolBar::OnMenu(wxCommandEvent& event)
       audioSettingsChosen = true;
    }
 
+   CommonMenuItemSteps(audioSettingsChosen);
+}
+
+void AudioSetupToolBar::CommonMenuItemSteps(bool audioSettingsChosen)
+{
    auto gAudioIO = AudioIOBase::Get();
    if (gAudioIO) {
       // We cannot have gotten here if gAudioIO->IsAudioTokenActive(),

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -621,24 +621,18 @@ void AudioSetupToolBar::FillInputChannels()
    }
 }
 
-std::unique_ptr<wxMenu> AudioSetupToolBar::CloneMenu(const wxMenu& menu) const
+void AudioSetupToolBar::AppendSubMenu(wxMenu& menu, const std::unique_ptr<wxMenu>& submenu, const wxString& title)
 {
    auto clonedMenu = std::make_unique<wxMenu>();
 
-   for (const auto& item : menu.GetMenuItems()) {
+   for (const auto& item : submenu->GetMenuItems()) {
       auto cloneMenuItem = clonedMenu->AppendRadioItem(item->GetId(), item->GetItemLabelText());
 
       if (item->IsChecked())
          cloneMenuItem->Check();
    }
 
-   return clonedMenu;
-}
-
-void AudioSetupToolBar::AppendSubMenu(wxMenu& menu, const std::unique_ptr<wxMenu>& submenu, const wxString& title)
-{
-   auto clone = CloneMenu(*submenu);
-   auto menuItem = menu.AppendSubMenu(clone.release(), title);
+   auto menuItem = menu.AppendSubMenu(clonedMenu.release(), title);
 
    const auto selected = GetSelectedRadioItemLabel(*submenu);
    if (!selected) {

--- a/src/toolbars/AudioSetupToolBar.cpp
+++ b/src/toolbars/AudioSetupToolBar.cpp
@@ -225,11 +225,13 @@ void AudioSetupToolBar::OnAudioSetup(wxCommandEvent& WXUNUSED(evt))
    menu.AppendSeparator();
 
    //i18n-hint: Audio setup menu
-   mOutput.AppendSubMenu(*this, menu, _("&Playback Device"));
+   mOutput.AppendSubMenu(*this, menu,
+      &AudioSetupToolBar::OnOutput, _("&Playback Device"));
    menu.AppendSeparator();
 
    //i18n-hint: Audio setup menu
-   mInput.AppendSubMenu(*this, menu, _("&Recording Device"));
+   mInput.AppendSubMenu(*this, menu,
+      &AudioSetupToolBar::OnInput, _("&Recording Device"));
    menu.AppendSeparator();
 
    //i18n-hint: Audio setup menu
@@ -239,11 +241,6 @@ void AudioSetupToolBar::OnAudioSetup(wxCommandEvent& WXUNUSED(evt))
    menu.Append(kAudioSettings, _("&Audio Settings..."));
 
    menu.Bind(wxEVT_MENU_CLOSE, [this](auto&) { mAudioSetup->PopUp(); });
-   // Bind two ID ranges and one single ID
-   menu.Bind(wxEVT_MENU, &AudioSetupToolBar::OnInput, this,
-      kInput, kOutput - 1);
-   menu.Bind(wxEVT_MENU, &AudioSetupToolBar::OnOutput, this,
-      kOutput, kAudioSettings - 1);
    menu.Bind(wxEVT_MENU, &AudioSetupToolBar::OnSettings, this, kAudioSettings);
 
    wxWindow* btn = FindWindow(ID_AUDIO_SETUP_BUTTON);
@@ -268,7 +265,7 @@ void AudioSetupToolBar::UpdatePrefs()
    // if the prefs host name doesn't match the one displayed, it changed
    // in another project's AudioSetupToolBar, so we need to repopulate everything.
    if (oldHost != hostName)
-      // updates mHost
+      // updates mHost and mOutput
       FillHostDevices();
 
    auto devName = AudioIORecordingDevice.Read();
@@ -294,14 +291,14 @@ void AudioSetupToolBar::UpdatePrefs()
                }
                else {
                   //use the first item (0th index) if we have no familiar devices
-                  mInput.Set(kInput);
+                  mInput.Set(0);
                   SetDevices(&inMaps[i], nullptr);
                }
                break;
             }
          }
       }
-   } 
+   }
 
    devName = AudioIOPlaybackDevice.Read();
    sourceName = AudioIOPlaybackSource.Read();
@@ -323,7 +320,7 @@ void AudioSetupToolBar::UpdatePrefs()
                }
                else {
                   //use the first item (0th index) if we have no familiar devices
-                  mOutput.Set(kOutput);
+                  mOutput.Set(0);
                   SetDevices(nullptr, &outMaps[i]);
                }
                break;
@@ -697,7 +694,7 @@ void AudioSetupToolBar::SetDevices(const DeviceSourceMap *in, const DeviceSource
 }
 
 void AudioSetupToolBar::ChangeDeviceLabel(
-   int deviceId, Choice &choices, bool isInput, int baseId)
+   int deviceId, Choices &choices, bool isInput)
 {
    int newIndex = -1;
 
@@ -705,7 +702,7 @@ void AudioSetupToolBar::ChangeDeviceLabel(
    const std::vector<DeviceSourceMap>& maps = isInput ? DeviceManager::Instance()->GetInputDeviceMaps()
       : DeviceManager::Instance()->GetOutputDeviceMaps();
 
-   if (choices.Set(baseId + deviceId)) {
+   if (choices.Set(deviceId)) {
       // Update cache with the chosen device
       wxString newDevice = *choices.Get();
       for (size_t i = 0; i < maps.size(); ++i) {
@@ -738,17 +735,15 @@ void AudioSetupToolBar::OnChannels(int id)
    CommonMenuItemSteps(false);
 }
 
-void AudioSetupToolBar::OnInput(wxCommandEvent& event)
+void AudioSetupToolBar::OnInput(int id)
 {
-   int id = event.GetId();
-   ChangeDeviceLabel(id, mInput, true, kInput);
+   ChangeDeviceLabel(id, mInput, true);
    CommonMenuItemSteps(false);
 }
 
-void AudioSetupToolBar::OnOutput(wxCommandEvent& event)
+void AudioSetupToolBar::OnOutput(int id)
 {
-   int id = event.GetId();
-   ChangeDeviceLabel(id, mOutput, false, kOutput);
+   ChangeDeviceLabel(id, mOutput, false);
    CommonMenuItemSteps(false);
 }
 

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -25,7 +25,6 @@ class wxString;
 struct DeviceSourceMap;
 
 class AudioSetupToolBar final : public ToolBar {
-   static constexpr int kHost = 15000;
    static constexpr int kInput = 15200;
    static constexpr int kInputChannels = 15400;
    static constexpr int kOutput = 15600;
@@ -54,7 +53,7 @@ class AudioSetupToolBar final : public ToolBar {
 
  private:
    void OnRescannedDevices(DeviceChangeMessage);
-   void OnHost(wxCommandEvent& event);
+   void OnHost(int id);
    void OnInput(wxCommandEvent& event);
    void OnChannels(wxCommandEvent& event);
    void OnOutput(wxCommandEvent& event);
@@ -198,7 +197,7 @@ class AudioSetupToolBar final : public ToolBar {
    std::unique_ptr<wxMenu> mInput;
    std::unique_ptr<wxMenu> mOutput;
    std::unique_ptr<wxMenu> mInputChannels;
-   Choice mHost{ kHost };
+   Choices mHost;
 
    Observer::Subscription mSubscription;
 

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -25,8 +25,6 @@ class wxString;
 struct DeviceSourceMap;
 
 class AudioSetupToolBar final : public ToolBar {
-   static constexpr int kInput = 15200;
-   static constexpr int kOutput = 15600;
    static constexpr int kAudioSettings = 15800;
 
  public:
@@ -53,16 +51,15 @@ class AudioSetupToolBar final : public ToolBar {
  private:
    void OnRescannedDevices(DeviceChangeMessage);
    void OnHost(int id);
-   void OnInput(wxCommandEvent& event);
+   void OnInput(int id);
    void OnChannels(int id);
-   void OnOutput(wxCommandEvent& event);
+   void OnOutput(int id);
    void OnSettings(wxCommandEvent& event);
    void CommonMenuItemSteps(bool audioSettingsChosen);
 
    bool ChangeHost(int hostId);
-   class Choice;
-   void ChangeDeviceLabel(
-      int deviceId, Choice &choices, bool isInput, int baseId);
+   class Choices;
+   void ChangeDeviceLabel(int deviceId, Choices &choices, bool isInput);
    void RepopulateMenus();
    void FillHosts();
    void FillHostDevices();
@@ -195,8 +192,8 @@ class AudioSetupToolBar final : public ToolBar {
       int mIndex{ -1 };
    };
 
-   Choice mInput{ kInput };
-   Choice mOutput{ kOutput };
+   Choices mInput;
+   Choices mOutput;
    Choices mInputChannels;
    Choices mHost;
 

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -196,7 +196,7 @@ class AudioSetupToolBar final : public ToolBar {
 
    std::unique_ptr<wxMenu> mInput;
    std::unique_ptr<wxMenu> mOutput;
-   std::unique_ptr<wxMenu> mInputChannels;
+   Choice mInputChannels{ kInputChannels };
    Choices mHost;
 
    Observer::Subscription mSubscription;

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -47,7 +47,11 @@ class AudioSetupToolBar final : public ToolBar {
 
  private:
    void OnRescannedDevices(DeviceChangeMessage);
-   void OnMenu(wxCommandEvent& event);
+   void OnHost(wxCommandEvent& event);
+   void OnInput(wxCommandEvent& event);
+   void OnChannels(wxCommandEvent& event);
+   void OnOutput(wxCommandEvent& event);
+   void OnSettings(wxCommandEvent& event);
    void CommonMenuItemSteps(bool audioSettingsChosen);
 
    bool ChangeHost(int hostId);

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -48,6 +48,7 @@ class AudioSetupToolBar final : public ToolBar {
  private:
    void OnRescannedDevices(DeviceChangeMessage);
    void OnMenu(wxCommandEvent& event);
+   void CommonMenuItemSteps(bool audioSettingsChosen);
 
    bool ChangeHost(int hostId);
    void ChangeDevice(int deviceId, bool isInput);

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -70,8 +70,6 @@ class AudioSetupToolBar final : public ToolBar {
    void MakeAudioSetupButton();
    void ArrangeButtons();
 
-   void AppendSubMenu(wxMenu& menu, const std::unique_ptr<wxMenu>& submenu, const wxString& title);
-
    using Callback = void (AudioSetupToolBar::*)(int id);
    // Append submenu with one radio item group
    // Bind menu items to lambdas that invoke callback,
@@ -81,8 +79,6 @@ class AudioSetupToolBar final : public ToolBar {
       const wxArrayString &labels, int checkedItem,
       Callback callback, const wxString& title);
 
-   static std::optional<wxString> GetSelectedRadioItemLabel(const wxMenu& menu);
-
    enum {
       ID_AUDIO_SETUP_BUTTON = 12000,
       BUTTON_COUNT,
@@ -90,59 +86,6 @@ class AudioSetupToolBar final : public ToolBar {
 
    AButton *mAudioSetup{};
    wxBoxSizer *mSizer{};
-
-   class Choice {
-   public:
-      // id0 is the first in the sequence assigned to submenu items
-      explicit Choice(int id0) : mId0{ id0 } {}
-      void Clear() { mMenu = std::make_unique<wxMenu>(); }
-      [[nodiscard]] bool Empty() const {
-         return mMenu->GetMenuItemCount() == 0;
-      }
-      std::optional<wxString> Get() const {
-         return GetSelectedRadioItemLabel(*mMenu);
-      }
-      wxString GetFirst() const {
-         if (!Empty())
-            return mMenu->FindItem(mId0)->GetItemLabelText();
-         return {};
-      }
-      int GetSmallIntegerId() const {
-         for (const auto & item : mMenu->GetMenuItems())
-            if (item->IsChecked())
-               return item->GetId() - mId0;
-         return -1;
-      }
-      int Find(const wxString &name) const {
-         return mMenu->FindItem(name);
-      }
-      bool Set(const wxString &name) {
-         const auto id = mMenu->FindItem(name);
-         if (id != wxNOT_FOUND) {
-            mMenu->FindChildItem(id)->Check();
-            return true;
-         }
-         return false;
-      }
-      void Set(wxArrayString &&names) {
-         Clear();
-         for (int i = 0; i < names.size(); ++i)
-            mMenu->AppendRadioItem(mId0 + i, names[i]);
-      }
-      bool Set(int id) {
-         auto item = mMenu->FindChildItem(id);
-         if (!item)
-            return false;
-         item->Check();
-         return true;
-      }
-      void AppendSubMenu(
-         AudioSetupToolBar &toolBar, wxMenu &menu, const wxString &title);
-
-   private:
-      std::unique_ptr<wxMenu> mMenu{ std::make_unique<wxMenu>() };
-      const int mId0;
-   };
 
    class Choices {
    public:

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -60,7 +60,6 @@ class AudioSetupToolBar final : public ToolBar {
    void CommonMenuItemSteps(bool audioSettingsChosen);
 
    bool ChangeHost(int hostId);
-   void ChangeDevice(int deviceId, bool isInput);
    class Choice;
    void ChangeDeviceLabel(
       int deviceId, Choice &choices, bool isInput, int baseId);
@@ -196,7 +195,7 @@ class AudioSetupToolBar final : public ToolBar {
       int mIndex{ -1 };
    };
 
-   std::unique_ptr<wxMenu> mInput;
+   Choice mInput{ kInput };
    Choice mOutput{ kOutput };
    Choices mInputChannels;
    Choices mHost;

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -61,6 +61,9 @@ class AudioSetupToolBar final : public ToolBar {
 
    bool ChangeHost(int hostId);
    void ChangeDevice(int deviceId, bool isInput);
+   class Choice;
+   void ChangeDeviceLabel(
+      int deviceId, Choice &choices, bool isInput, int baseId);
    void RepopulateMenus();
    void FillHosts();
    void FillHostDevices();

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -26,7 +26,6 @@ struct DeviceSourceMap;
 
 class AudioSetupToolBar final : public ToolBar {
    static constexpr int kInput = 15200;
-   static constexpr int kInputChannels = 15400;
    static constexpr int kOutput = 15600;
    static constexpr int kAudioSettings = 15800;
 
@@ -55,7 +54,7 @@ class AudioSetupToolBar final : public ToolBar {
    void OnRescannedDevices(DeviceChangeMessage);
    void OnHost(int id);
    void OnInput(wxCommandEvent& event);
-   void OnChannels(wxCommandEvent& event);
+   void OnChannels(int id);
    void OnOutput(wxCommandEvent& event);
    void OnSettings(wxCommandEvent& event);
    void CommonMenuItemSteps(bool audioSettingsChosen);
@@ -196,7 +195,7 @@ class AudioSetupToolBar final : public ToolBar {
 
    std::unique_ptr<wxMenu> mInput;
    std::unique_ptr<wxMenu> mOutput;
-   Choice mInputChannels{ kInputChannels };
+   Choices mInputChannels;
    Choices mHost;
 
    Observer::Subscription mSubscription;

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -197,7 +197,7 @@ class AudioSetupToolBar final : public ToolBar {
    };
 
    std::unique_ptr<wxMenu> mInput;
-   std::unique_ptr<wxMenu> mOutput;
+   Choice mOutput{ kOutput };
    Choices mInputChannels;
    Choices mHost;
 

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -25,6 +25,11 @@ class wxString;
 struct DeviceSourceMap;
 
 class AudioSetupToolBar final : public ToolBar {
+   static constexpr int kHost = 15000;
+   static constexpr int kInput = 15200;
+   static constexpr int kInputChannels = 15400;
+   static constexpr int kOutput = 15600;
+   static constexpr int kAudioSettings = 15800;
 
  public:
 
@@ -193,7 +198,7 @@ class AudioSetupToolBar final : public ToolBar {
    std::unique_ptr<wxMenu> mInput;
    std::unique_ptr<wxMenu> mOutput;
    std::unique_ptr<wxMenu> mInputChannels;
-   std::unique_ptr<wxMenu> mHost;
+   Choice mHost{ kHost };
 
    Observer::Subscription mSubscription;
 

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -68,6 +68,15 @@ class AudioSetupToolBar final : public ToolBar {
 
    void AppendSubMenu(wxMenu& menu, const std::unique_ptr<wxMenu>& submenu, const wxString& title);
 
+   using Callback = void (AudioSetupToolBar::*)(int id);
+   // Append submenu with one radio item group
+   // Bind menu items to lambdas that invoke callback,
+   // with successive ids from 0
+   // Check the item with given index, or disable the submenu when that is < 0
+   static void AppendSubMenu(AudioSetupToolBar &toolbar, wxMenu& menu,
+      const wxArrayString &labels, int checkedItem,
+      Callback callback, const wxString& title);
+
    std::optional<wxString> GetSelectedRadioItemLabel(const wxMenu& menu) const;
 
    enum {

--- a/src/toolbars/AudioSetupToolBar.h
+++ b/src/toolbars/AudioSetupToolBar.h
@@ -66,7 +66,6 @@ class AudioSetupToolBar final : public ToolBar {
    void MakeAudioSetupButton();
    void ArrangeButtons();
 
-   std::unique_ptr<wxMenu> CloneMenu(const wxMenu& menu) const;
    void AppendSubMenu(wxMenu& menu, const std::unique_ptr<wxMenu>& submenu, const wxString& title);
 
    std::optional<wxString> GetSelectedRadioItemLabel(const wxMenu& menu) const;


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

QA:  sanity checking that behavior of the Audio Setup toolbar has not changed

Use of wx/menu.h should be limited to just one place in the whole source tree, behind a
facade interface.

This rewrite of AudioSetupToolBar.cpp does not yet remove wx/menu.h but is a step toward
that.

The toolbar was using the checkmark sates of items of hidden wxMenu objects to track
the state of choices the user has made.  But that can be done instead with vectors of
strings and indices into them.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
