### PR TITLE
Phaser, Wahwah, BassTreble, and Reverb available in the sidebar...

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -268,7 +268,10 @@ public:
    //! In which versions of Audacity was an effect realtime capable?
    enum class RealtimeSince : unsigned {
       Never,
-      Since_3_2,
+      // For built-in effects that became realtime in 3.2.x or a later version
+      // but were non-realtime in an earlier version; must also increase
+      // REGVERCUR in any release with such a change
+      After_3_1,
       Always,
    };
 

--- a/libraries/lib-module-manager/PluginDescriptor.cpp
+++ b/libraries/lib-module-manager/PluginDescriptor.cpp
@@ -200,7 +200,7 @@ void PluginDescriptor::SetRealtimeSupport(
    mEffectRealtime = realtime;
 }
 
-static constexpr auto Since_3_2_string = "00";
+static constexpr auto After_3_1_string = "00";
 
 wxString PluginDescriptor::SerializeRealtimeSupport() const
 {
@@ -211,9 +211,9 @@ wxString PluginDescriptor::SerializeRealtimeSupport() const
    default:
       // A value that earlier Audacity interprets as false
       return "0";
-   case EffectDefinitionInterface::RealtimeSince::Since_3_2:
+   case EffectDefinitionInterface::RealtimeSince::After_3_1:
       // A different value that earlier Audacity interprets as false
-      return Since_3_2_string;
+      return After_3_1_string;
    case EffectDefinitionInterface::RealtimeSince::Always:
       // A value that earlier Audacity interprets as true
       return "1";
@@ -224,8 +224,8 @@ void PluginDescriptor::DeserializeRealtimeSupport(const wxString &value)
 {
    // Interpret the values stored by SerializeRealtimeSupport, or by previous
    // versions of Audacity
-   if (value == Since_3_2_string)
-      mEffectRealtime = EffectDefinitionInterface::RealtimeSince::Since_3_2;
+   if (value == After_3_1_string)
+      mEffectRealtime = EffectDefinitionInterface::RealtimeSince::After_3_1;
    else {
       // This leaves some open-endedness for future versions of Audacity to
       // define other string values they interpret one way, but we interpret

--- a/libraries/lib-module-manager/PluginManager.h
+++ b/libraries/lib-module-manager/PluginManager.h
@@ -236,6 +236,6 @@ private:
 #define NYQUIST_PROMPT_NAME XO("Nyquist Prompt")
 
 // Latest version of the plugin registry config
-constexpr auto REGVERCUR = "1.2";
+constexpr auto REGVERCUR = "1.3";
 
 #endif /* __AUDACITY_PLUGINMANAGER_H__ */

--- a/src/effects/BassTreble.cpp
+++ b/src/effects/BassTreble.cpp
@@ -198,9 +198,7 @@ EffectType EffectBassTreble::GetType() const
 
 auto EffectBassTreble::RealtimeSupport() const -> RealtimeSince
 {
-   // TODO reenable after achieving statelessness
-   return RealtimeSince::Never;
-   //return RealtimeSince::Always;
+   return RealtimeSince::After_3_1;
 }
 
 unsigned EffectBassTreble::Instance::GetAudioInCount() const

--- a/src/effects/Phaser.cpp
+++ b/src/effects/Phaser.cpp
@@ -220,9 +220,7 @@ EffectType EffectPhaser::GetType() const
 
 auto EffectPhaser::RealtimeSupport() const -> RealtimeSince
 {
-   // TODO reenable after achieving statelessness
-   return RealtimeSince::Never;
-//   return RealtimeSince::Always;
+   return RealtimeSince::After_3_1;
 }
 
 unsigned EffectPhaser::Instance::GetAudioInCount() const

--- a/src/effects/Reverb.cpp
+++ b/src/effects/Reverb.cpp
@@ -304,7 +304,7 @@ EffectType EffectReverb::GetType() const
 
 auto EffectReverb::RealtimeSupport() const -> RealtimeSince
 {
-   return RealtimeSince::Never;
+   return RealtimeSince::After_3_1;
 }
 
 static size_t BLOCK = 16384;

--- a/src/effects/VST3/VST3Effect.cpp
+++ b/src/effects/VST3/VST3Effect.cpp
@@ -168,7 +168,7 @@ bool VST3Effect::IsDefault() const
 auto VST3Effect::RealtimeSupport() const -> RealtimeSince
 {
    return GetType() == EffectTypeProcess
-      ? RealtimeSince::Since_3_2
+      ? RealtimeSince::After_3_1
       : RealtimeSince::Never;
 }
 

--- a/src/effects/Wahwah.cpp
+++ b/src/effects/Wahwah.cpp
@@ -209,7 +209,7 @@ EffectType EffectWahwah::GetType() const
 
 auto EffectWahwah::RealtimeSupport() const -> RealtimeSince
 {
-   return RealtimeSince::Never;
+   return RealtimeSince::After_3_1;
 }
 
 bool EffectWahwah::Instance::ProcessInitialize(EffectSettings & settings,

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -185,7 +185,7 @@ bool AudioUnitEffect::IsDefault() const
 auto AudioUnitEffect::RealtimeSupport() const -> RealtimeSince
 {
    return GetType() == EffectTypeProcess
-      ? RealtimeSince::Since_3_2
+      ? RealtimeSince::After_3_1
       : RealtimeSince::Never;
 }
 

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -784,7 +784,7 @@ bool LadspaEffect::IsDefault() const
 auto LadspaEffect::RealtimeSupport() const -> RealtimeSince
 {
    return GetType() == EffectTypeProcess
-      ? RealtimeSince::Since_3_2
+      ? RealtimeSince::After_3_1
       : RealtimeSince::Never;
 }
 


### PR DESCRIPTION
... Though Reverb has known problems with adjustment of controls, to be fixed.

Also bump REGVERCUR so that you don't need to delete an old pluginregistry.cfg first, and also, the effects will not be in the sidebar if you then downgrade to Audacity 3.2.2 or earlier.

Also renamed one enumeration constant to be clearer about its meaning.

Resolves: #4063

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
