### PR TITLE
fix bug Audacity#3723: Add clip name to GetInfo: Type=Clips

### DIFF
--- a/src/commands/GetInfoCommand.cpp
+++ b/src/commands/GetInfoCommand.cpp
@@ -528,6 +528,7 @@ bool GetInfoCommand::SendClips(const CommandContext &context)
             context.AddItem(pClip->GetPlayStartTime(), "start");
             context.AddItem(pClip->GetPlayEndTime(), "end");
             context.AddItem(pClip->GetColourIndex(), "color");
+            context.AddItem(pClip->GetName(), "name");
             context.EndStruct();
          }
       });


### PR DESCRIPTION
Resolves: [#3723](https://github.com/audacity/audacity/issues/3723)

Adds "name" to the struct for the GetInfo command with type "Clips", uses the existing GetName() function in WaveClip.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
