### PR TITLE
Fixes wxString::Format assertions in VST3 plain UI

### DIFF
--- a/src/effects/VST3/VST3ParametersWindow.cpp
+++ b/src/effects/VST3/VST3ParametersWindow.cpp
@@ -71,7 +71,7 @@ namespace
          if(mUnits.empty())
             SetLabel(VST3Utils::ToWxString(str));
          else
-            SetLabel(wxString::Format("%s %s", str, mUnits));
+            SetLabel(wxString::Format("%s %s", VST3Utils::ToWxString(str), mUnits));
       }
       
       Steinberg::Vst::ParamValue GetNormalizedValue(Steinberg::Vst::IEditController& editController) const override
@@ -190,7 +190,7 @@ namespace
       {
          Steinberg::Vst::String128 str{ };
          editController.getParamStringByValue(GetParameterId(), value, str);
-         SetName(wxString::Format("%s %s %s", mTitle, str, mUnits));
+         SetName(wxString::Format("%s %s %s", mTitle, VST3Utils::ToWxString(str), mUnits));
       }
 
       Steinberg::Vst::ParamValue GetNormalizedValue(Steinberg::Vst::IEditController& editController) const override


### PR DESCRIPTION
Fixes assertion issue similar to on described in #3413, but for other parameter types

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
