### PR TITLE
Hide MIDI CC parameters from VST3's plain UI

### DIFF
--- a/src/effects/VST3/VST3ParametersWindow.cpp
+++ b/src/effects/VST3/VST3ParametersWindow.cpp
@@ -255,6 +255,15 @@ VST3ParametersWindow::VST3ParametersWindow(wxWindow *parent,
       if((parameterInfo.flags & (Vst::ParameterInfo::kCanAutomate | Vst::ParameterInfo::kIsBypass | Vst::ParameterInfo::kIsReadOnly)) == 0)
          continue;
 
+      {
+         // Hide proxy parameters with name that starts with "MIDI CC "
+         // That prevents Plain UI from creating many useless controls
+         static_assert(sizeof(Steinberg::tchar) == sizeof(char16_t));
+         static const std::basic_string_view<tchar> MIDI_CC { reinterpret_cast<const tchar*>(u"MIDI CC ") };
+         if(std::basic_string_view<tchar>(parameterInfo.title).rfind(MIDI_CC, 0) == 0)
+            continue;
+      }
+      
       if (parameterInfo.stepCount != 1)      // not a toggle
          sizer->Add(safenew wxStaticText(
             this,


### PR DESCRIPTION
Resolves: #3216 

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
