### PR TITLE
Fix unsafe autosave

### DIFF
--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -514,6 +514,11 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    window.Publish(ProjectWindowDestroyedMessage {});
    ModuleManager::Get().Dispatch(ProjectClosing);
 
+   // Make sure no autosaves happen for the remaining duration of this function,
+   // while the project may be in a partially destroyed state.  Such saves
+   // would destroy user data!
+   ProjectHistory::AutoSave::Scope disallowAutoSave{ {} };
+
    // Stop the timer since there's no need to update anything anymore
    mTimer.reset();
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -194,8 +194,7 @@ void EffectSettingsAccessTee::Set(EffectSettings &&settings,
 {
    // Move copies of the given settings and message into the side
    if (auto pSide = mwSide.lock())
-      pSide->Set(EffectSettings{ settings },
-         pMessage ? pMessage->Clone() : nullptr);
+      pSide->Set(EffectSettings{ settings }, pMessage->Clone());
    // Move the given settings and message through
    mpMain->Set(std::move(settings), std::move(pMessage));
 }


### PR DESCRIPTION

Resolves: #3807

I still have not reproduced #3807.  This is a fix for a possible failure of autosave to keep audio track data -- which I have seen sometimes, but only in my own modified builds, and not in any commit of the master branch.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
