### PR TITLE
Fix x42 crash on close

### DIFF
--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -116,6 +116,7 @@ public:
    void SetSkipSavePrompt(bool bSkip) { sbSkipPromptingForSave = bSkip; };
 
    static void SetClosingAll(bool closing);
+   static bool GetClosingAll();
 
 private:
    void OnReconnectionFailure(ProjectFileIOMessage);

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -265,6 +265,11 @@ EffectUIHost::~EffectUIHost()
       mpValidator->Disconnect();
    DestroyChildren();
    wxASSERT(mClosed);
+
+   // mpValidator is the last member, and would otherwise still be destroyed
+   // before any other member or base class
+   mpValidator.reset();
+   Publish({});
 }
 
 // ============================================================================

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -38,10 +38,14 @@ class RealtimeEffectState;
 
 class wxCheckBox;
 
+//! A message sent by EffectUIHost, while still in its destructor
+struct ValidatorWasDestroyed{};
+
 //
 class EffectUIHost final
    : public wxDialogWrapper
    , public TopLevelKeystrokeHandlingWindow
+   , public Observer::Publisher<ValidatorWasDestroyed>
 {
 public:
    // constructors and destructors
@@ -162,6 +166,7 @@ private:
    const std::shared_ptr<EffectInstance> mpInstance;
    const EffectOutputs *const mpOutputs;
 
+   // This must remain the last non-static member
    std::unique_ptr<EffectUIValidator> mpValidator;
 
    DECLARE_EVENT_TABLE()

--- a/src/effects/RealtimeEffectStateUI.h
+++ b/src/effects/RealtimeEffectStateUI.h
@@ -50,11 +50,24 @@ public:
    void AutoSave(AudacityProject &project);
 
 private:
+   // To push event handlers onto two windows requires distinct handler objects
+   struct ProjectWindowSubscriber : wxEvtHandler {
+      explicit ProjectWindowSubscriber(RealtimeEffectStateUI &state)
+         : mState{ state } {}
+      void InterceptCloseFrame(wxCloseEvent & evt);
+      void PushHandler(AudacityProject &project);
+
+      RealtimeEffectStateUI &mState;
+
+      DECLARE_EVENT_TABLE()
+   } mSubscriber{ *this };
+
    void UpdateTitle();
    
    RealtimeEffectState& mRealtimeEffectState;
 
    wxWeakRef<EffectUIHost> mEffectUIHost;
+   wxWeakRef<wxWindow> mpProjectWindow{};
 
    TranslatableString mEffectName;
    wxString mTrackName;
@@ -63,6 +76,6 @@ private:
    Observer::Subscription mProjectWindowDestroyedSubscription;
    Observer::Subscription mParameterChangedSubscription;
 
-   void OnClose(wxCloseEvent & evt);
+   void OnCloseDialog(wxCloseEvent & evt);
    DECLARE_EVENT_TABLE()
 }; // class RealtimeEffectStateUI

--- a/src/effects/RealtimeEffectStateUI.h
+++ b/src/effects/RealtimeEffectStateUI.h
@@ -69,12 +69,18 @@ private:
    wxWeakRef<EffectUIHost> mEffectUIHost;
    wxWeakRef<wxWindow> mpProjectWindow{};
 
+   // Whether to pass a close event to the main window after dialog closes
+   bool mDoClose{ false };
+   // Context for doing the closing of the main window correctly
+   bool mCanVeto{ false };
+
    TranslatableString mEffectName;
    wxString mTrackName;
    AudacityProject *mpProject{};
 
    Observer::Subscription mProjectWindowDestroyedSubscription;
    Observer::Subscription mParameterChangedSubscription;
+   Observer::Subscription mValidatorDestroyedSubscription;
 
    void OnCloseDialog(wxCloseEvent & evt);
    DECLARE_EVENT_TABLE()

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -347,12 +347,6 @@ std::unique_ptr<EffectUIValidator> LV2Effect::PopulateUI(ShuttleGui &S,
       dynamic_cast<LV2Instance&>(instance),
       access, pOutputs, mProjectRate, mFeatures, mPorts, parent, useGUI);
 
-#ifdef __WXMAC__
-   const auto vendor = GetVendor().Msgid().Translation();
-   const bool doX42Hack = vendor == "Robin Gareus";
-   result->mUI.mJustLeakMemory = doX42Hack;
-#endif
-
    if (result->mUseGUI)
       result->mUseGUI = result->BuildFancy(move(pWrapper), settings);
    if (!result->mUseGUI && !result->BuildPlain(access))

--- a/src/effects/lv2/LV2Validator.h
+++ b/src/effects/lv2/LV2Validator.h
@@ -134,9 +134,6 @@ public:
       ~UI() { Destroy(); }
       SuilInstancePtr mSuilInstance;
       wxWindowPtr<NativeWindow> mNativeWin{};
-#ifdef __WXMAC__
-      bool mJustLeakMemory{ false };
-#endif
    } mUI;
 
    wxSize mNativeWinInitialSize{ wxDefaultSize };


### PR DESCRIPTION
Resolves: #4096

Fix crash that happens on macOS when closing project window or program,
as with Command+W or Command+Q, while the non-modal effect dialog is
open, of an x42 plug-in.

See commit 32a6779, which compensated for memory management bugs in these
plug-ins before, but not this case.

This strange fix pushes some event handlers on the effect dialog and the main
project window, to control their sequence of destruction in a way that works
around the bug, but still also depending on the fix at 32a6779 to correct an
unbalanced extra CFRelease somewhere in the foreign code.

Code comments explain more about the simpler attempted fixes that were not
enough.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
