### PR TITLE
Fix unsafe autosave

### DIFF
--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -356,6 +356,13 @@ protected:
    // the state used by the third, Audio thread.
    wxMutex mSuspendAudioThread;
 
+public:
+   // Whether an exception (as for exhaustion of resource space) was detected
+   // in recording, and not yet cleared at the end of the procedure to stop
+   // recording.
+   bool HasRecordingException() const
+      { return mRecordingException; }
+
 protected:
    // A flag tested and set in one thread, cleared in another.  Perhaps
    // this guarantee of atomicity is more cautious than necessary.

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1063,8 +1063,10 @@ void ProjectAudioManager::OnAudioIOStopRecording()
          // We want this to have No-fail-guarantee if we get here from exception
          // handling of recording, and that means we rely on the last autosave
          // successfully committed to the database, not risking a failure
-         history.PushState(XO("Recorded Audio"), XO("Record"),
-            UndoPush::NOAUTOSAVE);
+         auto flags = AudioIO::Get()->HasRecordingException()
+            ? UndoPush::NOAUTOSAVE
+            : UndoPush::NONE;
+         history.PushState(XO("Recorded Audio"), XO("Record"), flags);
 
          // Now, we may add a label track to give information about
          // dropouts.  We allow failure of this.


### PR DESCRIPTION
Resolves: #3807

Fix a data loss in crash recovery after completion of recording, which affected 1MB of samples at most in each channel.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
