### PR TITLE
Avoid a full reinit of fifo, combs and allpass filters when possible...

### DIFF
--- a/src/effects/Reverb.h
+++ b/src/effects/Reverb.h
@@ -42,7 +42,9 @@ struct EffectReverbSettings
    double mStereoWidth { stereoWidthDefault };
    bool   mWetOnly     { wetOnlyDefault };
 
-   friend bool operator==(const EffectReverbSettings& a, const EffectReverbSettings& b);   
+   friend bool operator==(const EffectReverbSettings& a, const EffectReverbSettings& b);
+
+   friend bool OnlySimpleParametersChanged(const EffectReverbSettings& a, const EffectReverbSettings& b);
 };
 
 


### PR DESCRIPTION
Resolves: #4107 

Some of the parameters do not require a full re-initialization of the reverb when changed.
When taking advantage of this, users will be able to hear the reverb when tweaking one of them.


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
