### PR TITLE
Pass Vst::ProcessContext

### DIFF
--- a/src/effects/VST3/VST3Wrapper.h
+++ b/src/effects/VST3/VST3Wrapper.h
@@ -3,6 +3,7 @@
 #include <pluginterfaces/base/smartpointer.h>
 #include <pluginterfaces/vst/ivstaudioprocessor.h>
 #include <pluginterfaces/vst/ivstparameterchanges.h>
+#include <pluginterfaces/vst/ivstprocesscontext.h>
 #include <public.sdk/source/vst/hosting/module.h>
 
 #include "EffectInterface.h"
@@ -139,4 +140,6 @@ private:
    //in VST3EffectSettings structure, dynamically assigned during
    //processing
    std::unique_ptr<SingleInputParameterValue[]> mParameterQueues;
+
+   Steinberg::Vst::ProcessContext mProcessContext { };
 };


### PR DESCRIPTION
Resolves: #3783
Resolves: #3669 

Some plugins (like meters/analyzers) expect playback state to be reported to work properly.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
