### PR TITLE
Fixes wrong speaker arrangement used for aux input buses

### DIFF
--- a/src/effects/VST3/VST3Wrapper.cpp
+++ b/src/effects/VST3/VST3Wrapper.cpp
@@ -115,10 +115,11 @@ bool ActivateMainAudioBuses(Steinberg::Vst::IComponent& component)
       processor->getBusArrangement(Vst::kInput, i, defaultArragement);
 
       arrangement =
-         GetBusArragementForChannels(busInfo.channelCount, defaultArragement);
+         busInfo.busType == Vst::kMain
+            ? GetBusArragementForChannels(busInfo.channelCount, defaultArragement)
+            : Vst::SpeakerArr::kEmpty;
       
       component.activateBus(Vst::kAudio, Vst::kInput, i, busInfo.busType == Vst::kMain);
-
       defaultInputSpeakerArrangements.push_back(arrangement);
    }
    for(int i = 0, count = component.getBusCount(Vst::kAudio, Vst::kOutput); i < count; ++i)
@@ -132,9 +133,9 @@ bool ActivateMainAudioBuses(Steinberg::Vst::IComponent& component)
       processor->getBusArrangement(Vst::kOutput, i, defaultArragement);
 
       arrangement =
-         busInfo.busType == Vst::kMain ?
-            GetBusArragementForChannels(busInfo.channelCount, defaultArragement) :
-            Vst::SpeakerArr::kEmpty;
+         busInfo.busType == Vst::kMain
+            ? GetBusArragementForChannels(busInfo.channelCount, defaultArragement)
+            : Vst::SpeakerArr::kEmpty;
 
       component.activateBus(Vst::kAudio, Vst::kOutput, i, busInfo.busType == Vst::kMain);
       defaultOutputSpeakerArrangements.push_back(arrangement);


### PR DESCRIPTION
Aux buses aren't supported yet, set speaker arrangement to kEmpty for both input and output aux bus types

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
