### PR TITLE
Unnecessary spaces in src/HelpText.cpp

### DIFF
--- a/src/HelpText.cpp
+++ b/src/HelpText.cpp
@@ -262,12 +262,12 @@ static wxString HelpTextBuiltIn( const wxString & Key )
          << wxT("</li><li>")
          << XO(
 /* i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.*/
-" [[help:Main_Page|Manual]]")
+"[[help:Main_Page|Manual]]")
          << wxT("</li><li>")
          << XO("[[https://support.audacityteam.org/|Tutorials & How-tos]]")
          << wxT("</li><li>")
          << XO(
-" [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online.")
+"[[https://forum.audacityteam.org/|Forum]] - ask your question directly, online.")
          << wxT("</li></ul></p>")
    ;
 


### PR DESCRIPTION
Unnecessary spaces in strings to translate.

Greetings,
Gootector

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
