### PR TITLE
Power buttons dirty the project (even if only restoring prior state)

### DIFF
--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -358,6 +358,8 @@ namespace
          enableButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
 
             mEffectState->SetActive(mEnableButton->IsDown());
+            if (mProject)
+               UndoManager::Get(*mProject).MarkUnsaved();
          });
 
          //Central button with effect name, show settings
@@ -1107,6 +1109,7 @@ RealtimeEffectPanel::RealtimeEffectPanel(
             mEffectList->EnableEffects(mToggleEffects->IsDown());
          
             ProjectHistory::Get(mProject).ModifyState(false);
+            UndoManager::Get(mProject).MarkUnsaved();
          }
       });
 

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -742,8 +742,10 @@ void EffectUIHost::OnEnable(wxCommandEvent & WXUNUSED(evt))
    mEnabled = mEnableBtn->IsDown();
 
    auto mpState = mwState.lock();
-   if (mpState)
+   if (mpState) {
       mpState->SetActive(mEnabled);
+      UndoManager::Get(mProject).MarkUnsaved();
+   }
 
    UpdateControls();
 }


### PR DESCRIPTION
Resolves: #4151

A simple change so that pressing the power button of an effect list or a
single effect causes the nag to save the project when you close the window.

But this also causes the warning without need if you press the button twice,
toggling back to the original state.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
