### PR TITLE
updated default values for noise reduction effect

### DIFF
--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -525,10 +525,10 @@ bool EffectNoiseReduction::Settings::PrefsIO(bool read)
 
    static const PrefsTableEntry<Settings, double> doubleTable[] = {
          { &Settings::mNewSensitivity, wxT("Sensitivity"), 6.0 },
-         { &Settings::mNoiseGain, wxT("Gain"), 12.0 },
+         { &Settings::mNoiseGain, wxT("Gain"), 6.0 },
          { &Settings::mAttackTime, wxT("AttackTime"), 0.02 },
          { &Settings::mReleaseTime, wxT("ReleaseTime"), 0.10 },
-         { &Settings::mFreqSmoothingBands, wxT("FreqSmoothing"), 3.0 },
+         { &Settings::mFreqSmoothingBands, wxT("FreqSmoothing"), 6.0 },
 
          // Advanced settings
          { &Settings::mOldSensitivity, wxT("OldSensitivity"), DEFAULT_OLD_SENSITIVITY },


### PR DESCRIPTION
Made the required changes as mentioned in issue  #4147 to update the values from 12, 6, 3 to 6, 6, 6

Resolves: *(direct link to the issue)*
#4147 

*(short description of the changes and the motivation to make the changes)*
This is the requested change as mentioned in the Issue to change the default values for the Noise reduction effect

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
