### PR TITLE
Break dependency cycle

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -32,7 +32,6 @@
 #include "CellularPanel.h"
 #include "../images/Cursors.h"
 #include "HitTestResult.h"
-#include "Menus.h"
 #include "Prefs.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
@@ -50,6 +49,7 @@
 #include "prefs/TracksPrefs.h"
 #include "prefs/ThemePrefs.h"
 #include "toolbars/ToolBar.h"
+#include "toolbars/ToolManager.h"
 #include "tracks/ui/Scrubbing.h"
 #include "tracks/ui/TrackView.h"
 #include "widgets/AButton.h"
@@ -2796,7 +2796,7 @@ void AdornedRulerPanel::TogglePinnedHead()
 {
    bool value = !TracksPrefs::GetPinnedHeadPreference();
    TracksPrefs::SetPinnedHeadPreference(value, true);
-   MenuManager::ModifyAllProjectToolbarMenus();
+   ToolManager::ModifyAllProjectToolbarMenus();
 
    auto &project = *mProject;
    // Update button image

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -326,6 +326,7 @@ list( APPEND SOURCES
       commands/CommandContext.h
       commands/CommandDirectory.cpp
       commands/CommandDirectory.h
+      commands/CommandFlag.cpp
       commands/CommandFlag.h
       commands/CommandFunctors.h
       commands/CommandDispatch.cpp

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -34,11 +34,9 @@
 
 #include "Project.h"
 #include "ProjectHistory.h"
-#include "ProjectSettings.h"
 #include "ProjectWindows.h"
 #include "UndoManager.h"
 #include "commands/CommandManager.h"
-#include "toolbars/ToolManager.h"
 #include "widgets/AudacityMessageBox.h"
 #include "BasicUI.h"
 
@@ -596,38 +594,6 @@ CommandFlag MenuManager::GetUpdateFlags( bool checkActive ) const
    return flags;
 }
 
-void MenuManager::ModifyAllProjectToolbarMenus()
-{
-   for (auto pProject : AllProjects{}) {
-      auto &project = *pProject;
-      MenuManager::Get(project).ModifyToolbarMenus(project);
-   }
-}
-
-void MenuManager::ModifyToolbarMenus(AudacityProject &project)
-{
-   // Refreshes can occur during shutdown and the toolmanager may already
-   // be deleted, so protect against it.
-   auto &toolManager = ToolManager::Get( project );
-
-   auto &settings = ProjectSettings::Get( project );
-
-   // Now, go through each toolbar, and call EnableDisableButtons()
-   toolManager.ForEach([](auto bar){
-      if (bar)
-         bar->EnableDisableButtons();
-   });
-
-   // These don't really belong here, but it's easier and especially so for
-   // the Edit toolbar and the sync-lock menu item.
-   bool active;
-
-   gPrefs->Read(wxT("/GUI/SyncLockTracks"), &active, false);
-   settings.SetSyncLock(active);
-
-   CommandManager::Get( project ).UpdateCheckmarks( project );
-}
-
 namespace
 {
    using MenuItemEnablers = std::vector<MenuItemEnabler>;
@@ -683,7 +649,7 @@ void MenuManager::UpdateMenus( bool checkActive )
       (mWhatIfNoSelection == 0 ? flags2 : flags) // the "strict" flags
    );
 
-   MenuManager::ModifyToolbarMenus(project);
+   Publish({});
 }
 
 /// The following method moves to the previous track

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -70,9 +70,13 @@ public:
 
 struct ToolbarMenuVisitor;
 
+//! Sent when menus update (such as for changing enablement of items)
+struct MenuUpdateMessage {};
+
 class AUDACITY_DLL_API MenuManager final
    : public MenuCreator
    , public ClientData::Base
+   , public Observer::Publisher<MenuUpdateMessage>
    , private PrefsListener
 {
 public:
@@ -89,9 +93,6 @@ public:
    static void Visit( ToolbarMenuVisitor &visitor );
 
    static void ModifyUndoMenuItems(AudacityProject &project);
-   static void ModifyToolbarMenus(AudacityProject &project);
-   // Calls ModifyToolbarMenus() on all projects
-   static void ModifyAllProjectToolbarMenus();
 
    // checkActive is a temporary hack that should be removed as soon as we
    // get multiple effect preview working

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1304,8 +1304,6 @@ void ProjectAudioManager::DoPlayStopSelect()
    }
 }
 
-#include "CommonCommandFlags.h"
-
 static RegisteredMenuItemEnabler stopIfPaused{{
    []{ return PausedFlag(); },
    []{ return AudioIONotBusyFlag(); },

--- a/src/commands/CommandFlag.cpp
+++ b/src/commands/CommandFlag.cpp
@@ -1,0 +1,65 @@
+/**********************************************************************
+
+Audacity: A Digital Audio Editor
+
+CommandFlag.cpp
+
+Paul Licameli split from Menus.cpp
+
+**********************************************************************/
+
+#include "CommandFlag.h"
+
+namespace {
+ReservedCommandFlag::Predicates &sPredicates()
+{
+   static ReservedCommandFlag::Predicates thePredicates;
+   return thePredicates;
+}
+
+std::vector< CommandFlagOptions > &sOptions()
+{
+   static std::vector< CommandFlagOptions > theOptions;
+   return theOptions;
+}
+}
+
+const ReservedCommandFlag::Predicates &ReservedCommandFlag::RegisteredPredicates()
+{
+   return sPredicates();
+}
+
+const std::vector< CommandFlagOptions > &ReservedCommandFlag::Options()
+{
+   return sOptions();
+}
+
+ReservedCommandFlag::ReservedCommandFlag(
+   const Predicate &predicate, const CommandFlagOptions &options )
+{
+   static size_t sNextReservedFlag = 0;
+   // This will throw std::out_of_range if the constant NCommandFlags is too
+   // small
+   set( sNextReservedFlag++ );
+   sPredicates().emplace_back( predicate );
+   sOptions().emplace_back( options );
+}
+
+namespace {
+MenuItemEnablers &sEnablers()
+{
+   static MenuItemEnablers enablers;
+   return enablers;
+}
+}
+
+const MenuItemEnablers &RegisteredMenuItemEnabler::Enablers()
+{
+   return sEnablers();
+}
+
+RegisteredMenuItemEnabler::RegisteredMenuItemEnabler(
+   const MenuItemEnabler &enabler )
+{
+   sEnablers().emplace_back( enabler );
+}

--- a/src/commands/CommandFlag.h
+++ b/src/commands/CommandFlag.h
@@ -88,6 +88,11 @@ class AUDACITY_DLL_API ReservedCommandFlag : public CommandFlag
 {
 public:
    using Predicate = std::function< bool( const AudacityProject& ) >;
+   using Predicates = std::vector< Predicate >;
+
+   static const std::vector< CommandFlagOptions > &Options();
+   static const Predicates &RegisteredPredicates();
+
    ReservedCommandFlag( const Predicate &predicate,
       const CommandFlagOptions &options = {} );
 };
@@ -114,12 +119,13 @@ struct MenuItemEnabler {
    Action tryEnable;
 };
 
+using MenuItemEnablers = std::vector<MenuItemEnabler>;
+
 // Typically this is statically constructed:
 struct AUDACITY_DLL_API RegisteredMenuItemEnabler{
+   static const MenuItemEnablers &Enablers();
    RegisteredMenuItemEnabler( const MenuItemEnabler &enabler );
 };
 
-// Unnecessary #include to indicate otherwise hidden link dependencies
-#include "Menus.h"
 
 #endif

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -5,7 +5,6 @@
 #include "../LabelTrack.h"
 #include "../Menus.h"
 #include "../NoteTrack.h"
-#include "Prefs.h"
 #include "Project.h"
 #include "ProjectHistory.h"
 #include "ProjectRate.h"

--- a/src/menus/ExtraMenus.cpp
+++ b/src/menus/ExtraMenus.cpp
@@ -5,6 +5,7 @@
 #include "ProjectWindows.h"
 #include "../commands/CommandContext.h"
 #include "../commands/CommandManager.h"
+#include "../toolbars/ToolManager.h"
 
 #include <wx/frame.h>
 
@@ -21,7 +22,7 @@ void OnFullScreen(const CommandContext &context)
    bool bChecked = !window.wxTopLevelWindow::IsFullScreen();
    window.wxTopLevelWindow::ShowFullScreen(bChecked);
 
-   MenuManager::Get(project).ModifyToolbarMenus(project);
+   ToolManager::Get(project).ModifyToolbarMenus(project);
 }
 
 // Menu definitions

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -2,7 +2,6 @@
 #include "../Clipboard.h"
 #include "../CommonCommandFlags.h"
 #include "../LabelTrack.h"
-#include "../Menus.h"
 #include "Prefs.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
@@ -18,6 +17,7 @@
 #include "../commands/CommandContext.h"
 #include "../commands/CommandManager.h"
 #include "../tracks/labeltrack/ui/LabelTrackView.h"
+#include "toolbars/ToolManager.h"
 
 using Region = WaveTrack::Region;
 using Regions = WaveTrack::Regions;
@@ -381,7 +381,7 @@ void OnToggleTypeToCreateLabel(const CommandContext &WXUNUSED(context) )
    gPrefs->Read(wxT("/GUI/TypeToCreateLabel"), &typeToCreateLabel, false);
    gPrefs->Write(wxT("/GUI/TypeToCreateLabel"), !typeToCreateLabel);
    gPrefs->Flush();
-   MenuManager::ModifyAllProjectToolbarMenus();
+   ToolManager::ModifyAllProjectToolbarMenus();
 }
 
 void OnCutLabels(const CommandContext &context)

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -1,6 +1,3 @@
-
-
-#include "../Menus.h"
 #include "../ProjectSettings.h"
 #include "../commands/CommandContext.h"
 #include "../commands/CommandManager.h"

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -28,6 +28,7 @@
 #include "../effects/EffectUI.h"
 #include "QualitySettings.h"
 #include "../tracks/playabletrack/wavetrack/ui/WaveTrackControls.h"
+#include "../toolbars/ToolManager.h"
 #include "../widgets/ASlider.h"
 #include "../widgets/AudacityMessageBox.h"
 #include "../widgets/ProgressDialog.h"
@@ -988,7 +989,7 @@ void OnSyncLock(const CommandContext &context)
    gPrefs->Flush();
 
    // Toolbar, project sync-lock handled within
-   MenuManager::ModifyAllProjectToolbarMenus();
+   ToolManager::ModifyAllProjectToolbarMenus();
 
    trackPanel.Refresh(false);
 }

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -25,6 +25,7 @@
 #include "../commands/CommandContext.h"
 #include "../commands/CommandManager.h"
 #include "../toolbars/ControlToolBar.h"
+#include "../toolbars/ToolManager.h"
 #include "../widgets/AudacityMessageBox.h"
 #include "BasicUI.h"
 #include "../widgets/ProgressDialog.h"
@@ -414,7 +415,7 @@ void OnToggleSoundActivated(const CommandContext &WXUNUSED(context) )
    gPrefs->Read(wxT("/AudioIO/SoundActivatedRecord"), &pause, false);
    gPrefs->Write(wxT("/AudioIO/SoundActivatedRecord"), !pause);
    gPrefs->Flush();
-   MenuManager::ModifyAllProjectToolbarMenus();
+   ToolManager::ModifyAllProjectToolbarMenus();
 }
 
 void OnTogglePlayRecording(const CommandContext &WXUNUSED(context) )
@@ -427,7 +428,7 @@ void OnTogglePlayRecording(const CommandContext &WXUNUSED(context) )
 #endif
    gPrefs->Write(wxT("/AudioIO/Duplex"), !Duplex);
    gPrefs->Flush();
-   MenuManager::ModifyAllProjectToolbarMenus();
+   ToolManager::ModifyAllProjectToolbarMenus();
 }
 
 void OnToggleSWPlaythrough(const CommandContext &WXUNUSED(context) )
@@ -436,7 +437,7 @@ void OnToggleSWPlaythrough(const CommandContext &WXUNUSED(context) )
    gPrefs->Read(wxT("/AudioIO/SWPlaythrough"), &SWPlaythrough, false);
    gPrefs->Write(wxT("/AudioIO/SWPlaythrough"), !SWPlaythrough);
    gPrefs->Flush();
-   MenuManager::ModifyAllProjectToolbarMenus();
+   ToolManager::ModifyAllProjectToolbarMenus();
 }
 
 #ifdef EXPERIMENTAL_AUTOMATED_INPUT_LEVEL_ADJUSTMENT
@@ -448,7 +449,7 @@ void OnToggleAutomatedInputLevelAdjustment(
       wxT("/AudioIO/AutomatedInputLevelAdjustment"), &AVEnabled, false);
    gPrefs->Write(wxT("/AudioIO/AutomatedInputLevelAdjustment"), !AVEnabled);
    gPrefs->Flush();
-   MenuManager::ModifyAllProjectToolbarMenus();
+   ToolManager::ModifyAllProjectToolbarMenus();
 }
 #endif
 

--- a/src/toolbars/ToolBarButtons.cpp
+++ b/src/toolbars/ToolBarButtons.cpp
@@ -16,6 +16,7 @@
 
 #include "AllThemeResources.h"
 #include "../widgets/AButton.h"
+#include "../Menus.h"
 #include "Project.h"
 
 #include "../commands/CommandContext.h"

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -471,6 +471,9 @@ void ToolManager::CreateWindows()
    ReadConfig();
 
    wxEvtHandler::AddFilter(this);
+
+   mMenuManagerSubscription = MenuManager::Get(*mParent)
+      .Subscribe(*this, &ToolManager::OnMenuUpdate);
 }
 
 //
@@ -564,7 +567,7 @@ void ToolManager::OnResetToolBars(const CommandContext &context)
    auto &toolManager = ToolManager::Get( project );
 
    toolManager.Reset();
-   MenuManager::Get(project).ModifyToolbarMenus(project);
+   Get(project).ModifyToolbarMenus(project);
 }
 
 
@@ -1331,6 +1334,11 @@ void ToolManager::OnCaptureLost( wxMouseCaptureLostEvent & event )
    OnMouse(e);
 }
 
+void ToolManager::OnMenuUpdate(MenuUpdateMessage)
+{
+   ModifyToolbarMenus( *mParent );
+}
+
 //
 // Watch for shift key changes
 //
@@ -1554,8 +1562,39 @@ bool ToolManager::RestoreFocus()
    return false;
 }
 
-#include "../commands/CommandContext.h"
-#include "../Menus.h"
+void ToolManager::ModifyAllProjectToolbarMenus()
+{
+   for (auto pProject : AllProjects{}) {
+      auto &project = *pProject;
+      ModifyToolbarMenus(project);
+   }
+}
+
+#include "../commands/CommandManager.h"
+#include "../ProjectSettings.h"
+void ToolManager::ModifyToolbarMenus(AudacityProject &project)
+{
+   // Refreshes can occur during shutdown and the toolmanager may already
+   // be deleted, so protect against it.
+   auto &toolManager = ToolManager::Get( project );
+
+   auto &settings = ProjectSettings::Get( project );
+
+   // Now, go through each toolbar, and call EnableDisableButtons()
+   toolManager.ForEach([](auto bar){
+      if (bar)
+         bar->EnableDisableButtons();
+   });
+
+   // These don't really belong here, but it's easier and especially so for
+   // the Edit toolbar and the sync-lock menu item.
+   bool active;
+
+   gPrefs->Read(wxT("/GUI/SyncLockTracks"), &active, false);
+   settings.SetSyncLock(active);
+
+   CommandManager::Get( project ).UpdateCheckmarks( project );
+}
 
 AttachedToolBarMenuItem::AttachedToolBarMenuItem(
    Identifier id, const CommandID &name, const TranslatableString &label_in,
@@ -1588,5 +1627,5 @@ void AttachedToolBarMenuItem::OnShowToolBar( const CommandContext &context )
    }
 
    toolManager.ShowHide(mId);
-   MenuManager::Get(project).ModifyToolbarMenus(project);
+   ToolManager::Get(project).ModifyToolbarMenus(project);
 }

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -51,6 +51,7 @@
 #include "AColor.h"
 #include "AllThemeResources.h"
 #include "ImageManipulation.h"
+#include "Menus.h"
 #include "Prefs.h"
 #include "Project.h"
 #include "ProjectWindows.h"

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -22,6 +22,7 @@
 
 #include "ClientData.h"
 #include "GlobalVariable.h"
+#include "Observer.h"
 #include "ToolDock.h"
 
 #include "../commands/CommandFunctors.h"
@@ -111,10 +112,15 @@ class AUDACITY_DLL_API ToolManager final
       return mBars.size();
    }
 
+   static void ModifyToolbarMenus(AudacityProject &project);
+   // Calls ModifyToolbarMenus() on all projects
+   static void ModifyAllProjectToolbarMenus();
+
  private:
 
    ToolBar *Float( ToolBar *t, wxPoint & pos );
 
+   void OnMenuUpdate(struct MenuUpdateMessage);
    void OnTimer( wxTimerEvent & event );
    void OnMouse( wxMouseEvent & event );
    void OnCaptureLost( wxMouseCaptureLostEvent & event );
@@ -130,6 +136,7 @@ class AUDACITY_DLL_API ToolManager final
    void WriteConfig();
    void Updated();
 
+   Observer::Subscription mMenuManagerSubscription;
    AudacityProject *mParent;
    wxWindowRef mLastFocus{};
 

--- a/src/tracks/ui/CommonTrackPanelCell.cpp
+++ b/src/tracks/ui/CommonTrackPanelCell.cpp
@@ -19,6 +19,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../commands/CommandContext.h"
 #include "../../commands/CommandManager.h"
 #include "../../HitTestResult.h"
+#include "../../Menus.h"
 #include "../../RefreshCode.h"
 #include "../../TrackPanelMouseEvent.h"
 #include "ViewInfo.h"


### PR DESCRIPTION
Resolves: 

The strongly connected component of six files:
   CommandFlag
   CommandManager
   Menus
   ToolBar
   ToolDock
   ToolManager

-- is broken up.  Two cycles of two still remain:
   ToolBar
   ToolDock

and
   CommandManager
   Menus

<img width="127" alt="image" src="https://user-images.githubusercontent.com/11670369/211207416-4cd46af4-0613-4639-a96d-e52db57aba3d.png">



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
