### PR TITLE
Log some statistics about the times when ProgressDialog was shown

### DIFF
--- a/src/widgets/ProgressDialog.cpp
+++ b/src/widgets/ProgressDialog.cpp
@@ -38,6 +38,8 @@
 #include <wx/evtloop.h>
 #include <wx/gauge.h>
 #include <wx/frame.h>
+#include <wx/intl.h>
+#include <wx/log.h>
 #include <wx/msgdlg.h>
 #include <wx/settings.h>
 #include <wx/sizer.h>

--- a/src/widgets/ProgressDialog.cpp
+++ b/src/widgets/ProgressDialog.cpp
@@ -48,6 +48,8 @@
 
 #include "Prefs.h"
 
+#include "MemoryX.h"
+
 // This really should be a Preferences setting
 static const unsigned char beep[] =
 {

--- a/src/widgets/ProgressDialog.h
+++ b/src/widgets/ProgressDialog.h
@@ -18,7 +18,7 @@
 #ifndef __AUDACITY_WIDGETS_PROGRESSDIALOG__
 #define __AUDACITY_WIDGETS_PROGRESSDIALOG__
 
-
+#include <chrono>
 
 #include <vector>
 #include <wx/defs.h>
@@ -117,6 +117,7 @@ protected:
    wxLongLong_t mStartTime;
    wxLongLong_t mLastUpdate;
    wxLongLong_t mYieldTimer;
+   wxLongLong_t mElapsedTime {};
    int mLastValue; // gauge value, range = [0,1000]
 
    bool mCancel;
@@ -152,6 +153,10 @@ private:
    wxStaticText *mMessage{} ;
    int mLastW{ 0 };
    int mLastH{ 0 };
+
+   std::chrono::nanoseconds mPollTime {};
+   unsigned mPollsCount { 0 };
+   unsigned mYieldsCount { 0 };
 
    DECLARE_EVENT_TABLE()
 };

--- a/src/widgets/ProgressDialog.h
+++ b/src/widgets/ProgressDialog.h
@@ -154,8 +154,9 @@ private:
    int mLastW{ 0 };
    int mLastH{ 0 };
 
-   std::chrono::nanoseconds mPollTime {};
+   std::chrono::nanoseconds mTotalPollTime {};
    unsigned mPollsCount { 0 };
+   std::chrono::nanoseconds mTotalYieldTime {};
    unsigned mYieldsCount { 0 };
 
    DECLARE_EVENT_TABLE()


### PR DESCRIPTION
This is a minor change, that logs the time an operation with a ProgressDialog took.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
