### PR TITLE
Simplify module graph

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -344,6 +344,8 @@ function( append_node_attributes var target )
    if( NOT "wxwidgets::wxwidgets" IN_LIST dependencies )
       # Toolkit neutral targets
       set( color "lightgreen" )
+      # Enforce usage of only a subset of wxBase that excludes the event loop
+      apply_wxbase_restrictions( ${target} )
    endif()
    string( APPEND "${var}" " style=filled fillcolor=${color}" )
    set( "${var}" "${${var}}" PARENT_SCOPE)

--- a/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
+++ b/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
@@ -1,3 +1,34 @@
+# Expose only the GUI-less subset of full wxWidgets
+# Also prohibit use of some other headers by pre-defining their include guards
+# wxUSE_GUI=0 doesn't exclude all of wxCore dependency, and the application
+# object and event loops are in wxBase, but we want to exclude their use too
+set ( WXBASE_RESTRICTIONS
+   "wxUSE_GUI=0"
+
+   # Don't use app.h
+   _WX_APP_H_BASE_
+
+   # Don't use evtloop.h
+   _WX_EVTLOOP_H_
+
+   # Don't use image.h
+   _WX_IMAGE_H
+
+   # Don't use colour.h
+   _WX_COLOUR_H_BASE_
+
+   # Don't use brush.h
+   _WX_BRUSH_H_BASE_
+
+   # Don't use pen.h
+   _WX_PEN_H_BASE_
+)
+
+function( apply_wxbase_restrictions target )
+   target_compile_definitions( ${target} PRIVATE ${WXBASE_RESTRICTIONS} )
+endfunction()
+
+
 # Make the wxBase interface target which exposes a limited view of wxWidgets --
 # only the subset of wxBase consistent with "toolkit neutrality"
 function(make_wxBase old)
@@ -10,32 +41,6 @@ function(make_wxBase old)
    string(REPLACE "wxUSE_GUI=1" "" defs "${defs}")
 
    set_property(TARGET wxBase PROPERTY INTERFACE_COMPILE_DEFINITIONS ${defs})
-
-   # wxBase exposes only the GUI-less subset of full wxWidgets
-   # Also prohibit use of some other headers by pre-defining their include guards
-   # wxUSE_GUI=0 doesn't exclude all of wxCore dependency, and the application
-   # object and event loops are in wxBase, but we want to exclude their use too
-   target_compile_definitions( wxBase INTERFACE
-      "wxUSE_GUI=0"
-
-      # Don't use app.h
-      _WX_APP_H_BASE_
-
-      # Don't use evtloop.h
-      _WX_EVTLOOP_H_
-
-      # Don't use image.h
-      _WX_IMAGE_H
-
-      # Don't use colour.h
-      _WX_COLOUR_H_BASE_
-
-      # Don't use brush.h
-      _WX_BRUSH_H_BASE_
-
-      # Don't use pen.h
-      _WX_PEN_H_BASE_
-   )
 
    find_package( Threads QUIET )
    if( Threads_FOUND )

--- a/libraries/lib-audio-devices/CMakeLists.txt
+++ b/libraries/lib-audio-devices/CMakeLists.txt
@@ -24,8 +24,6 @@ set( LIBRARIES
    portaudio::portaudio
    $<$<BOOL:${USE_PORTMIXER}>:portmixer>
    lib-preferences-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-audio-devices "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-audio-graph/CMakeLists.txt
+++ b/libraries/lib-audio-graph/CMakeLists.txt
@@ -15,7 +15,6 @@ set( SOURCES
    EffectStage.h
 )
 set( LIBRARIES
-   lib-exceptions
    lib-math-interface
    lib-track
 )

--- a/libraries/lib-audio-graph/CMakeLists.txt
+++ b/libraries/lib-audio-graph/CMakeLists.txt
@@ -18,8 +18,6 @@ set( LIBRARIES
    lib-exceptions
    lib-math-interface
    lib-track
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-audio-graph "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-audio-io/CMakeLists.txt
+++ b/libraries/lib-audio-io/CMakeLists.txt
@@ -24,8 +24,6 @@ set( LIBRARIES
    lib-project-rate-interface
    lib-realtime-effects
    lib-sample-track-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-audio-io "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-basic-ui/CMakeLists.txt
+++ b/libraries/lib-basic-ui/CMakeLists.txt
@@ -20,8 +20,6 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-strings-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-basic-ui "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-cloud-audiocom/CMakeLists.txt
+++ b/libraries/lib-cloud-audiocom/CMakeLists.txt
@@ -22,9 +22,6 @@ set( SOURCES
 set ( LIBRARIES
    lib-cloud-upload-interface
    lib-network-manager-interface # Required for the networking
-   lib-string-utils-interface # ToUtf8
-   lib-preferences-interface
-   lib-basic-ui-interface # CallAfter
    lib-files-interface # FileNames
 
    PRIVATE

--- a/libraries/lib-cloud-upload/CMakeLists.txt
+++ b/libraries/lib-cloud-upload/CMakeLists.txt
@@ -18,8 +18,6 @@ set( SOURCES
 
 set ( LIBRARIES
    lib-strings-interface
-   PRIVATE
-      wxBase
 )
 
 set ( DEFINES

--- a/libraries/lib-components/CMakeLists.txt
+++ b/libraries/lib-components/CMakeLists.txt
@@ -22,8 +22,6 @@ set( SOURCES
 set( LIBRARIES
    lib-strings-interface
    lib-utility
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-components "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-exceptions/CMakeLists.txt
+++ b/libraries/lib-exceptions/CMakeLists.txt
@@ -26,8 +26,6 @@ list( APPEND SOURCES
 set( LIBRARIES
    lib-utility-interface
    lib-basic-ui-interface
-   PRIVATE
-   wxBase
 )
 
 if( APPLE AND MIN_MACOS_VERSION VERSION_LESS "10.12")

--- a/libraries/lib-ffmpeg-support/CMakeLists.txt
+++ b/libraries/lib-ffmpeg-support/CMakeLists.txt
@@ -94,7 +94,6 @@ if (${_OPT}use_ffmpeg)
 
    set( LIBRARIES
       PRIVATE
-      wxBase
       lib-preferences
       lib-files
       lib-math

--- a/libraries/lib-ffmpeg-support/CMakeLists.txt
+++ b/libraries/lib-ffmpeg-support/CMakeLists.txt
@@ -94,7 +94,6 @@ if (${_OPT}use_ffmpeg)
 
    set( LIBRARIES
       PRIVATE
-      lib-preferences
       lib-files
       lib-math
    )

--- a/libraries/lib-files/CMakeLists.txt
+++ b/libraries/lib-files/CMakeLists.txt
@@ -28,8 +28,6 @@ set( SOURCES
 set( LIBRARIES
    lib-exceptions-interface
    lib-preferences-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-files "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-math/CMakeLists.txt
+++ b/libraries/lib-math/CMakeLists.txt
@@ -29,8 +29,6 @@ set( SOURCES
 set( LIBRARIES
    libsoxr
    lib-preferences-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-math "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-module-manager/CMakeLists.txt
+++ b/libraries/lib-module-manager/CMakeLists.txt
@@ -26,8 +26,6 @@ set( SOURCES
    PluginManager.h
 )
 set( LIBRARIES
-   lib-components-interface
-   lib-files-interface
    lib-xml-interface
    lib-ipc-interface
 )

--- a/libraries/lib-module-manager/CMakeLists.txt
+++ b/libraries/lib-module-manager/CMakeLists.txt
@@ -30,8 +30,6 @@ set( LIBRARIES
    lib-files-interface
    lib-xml-interface
    lib-ipc-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-module-manager "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-network-manager/CMakeLists.txt
+++ b/libraries/lib-network-manager/CMakeLists.txt
@@ -39,7 +39,6 @@ set ( LIBRARIES PRIVATE
     lib-string-utils-interface
     lib-exceptions-interface
     lib-utility-interface
-    wxwidgets::base
 )
 
 set ( DEFINES INTERFACE "HAS_NETWORKING" )

--- a/libraries/lib-network-manager/CMakeLists.txt
+++ b/libraries/lib-network-manager/CMakeLists.txt
@@ -33,12 +33,12 @@ set( SOURCES
 )
 
 
-set ( LIBRARIES PRIVATE
+set ( LIBRARIES
+    lib-string-utils-interface
+PRIVATE
     CURL::libcurl
     threadpool::threadpool
-    lib-string-utils-interface
     lib-exceptions-interface
-    lib-utility-interface
 )
 
 set ( DEFINES INTERFACE "HAS_NETWORKING" )

--- a/libraries/lib-preferences/CMakeLists.txt
+++ b/libraries/lib-preferences/CMakeLists.txt
@@ -21,11 +21,8 @@ set( SOURCES
    Prefs.h
 )
 set( LIBRARIES 
-   lib-utility-interface
    lib-basic-ui-interface
    lib-components-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-preferences "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-project-history/CMakeLists.txt
+++ b/libraries/lib-project-history/CMakeLists.txt
@@ -12,8 +12,6 @@ set( LIBRARIES
    lib-screen-geometry-interface
    lib-track-interface
    lib-transactions-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-project-history "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-project-rate/CMakeLists.txt
+++ b/libraries/lib-project-rate/CMakeLists.txt
@@ -18,7 +18,6 @@ set( SOURCES
 set( LIBRARIES
    lib-project-interface
    lib-audio-devices-interface
-   lib-xml-interface
    lib-math-interface
 )
 audacity_library( lib-project-rate "${SOURCES}" "${LIBRARIES}"

--- a/libraries/lib-project-rate/CMakeLists.txt
+++ b/libraries/lib-project-rate/CMakeLists.txt
@@ -20,8 +20,6 @@ set( LIBRARIES
    lib-audio-devices-interface
    lib-xml-interface
    lib-math-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-project-rate "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-project/CMakeLists.txt
+++ b/libraries/lib-project/CMakeLists.txt
@@ -22,8 +22,6 @@ set( SOURCES
 set( LIBRARIES
    lib-registries-interface
    lib-xml-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-project "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-realtime-effects/CMakeLists.txt
+++ b/libraries/lib-realtime-effects/CMakeLists.txt
@@ -15,8 +15,6 @@ set( LIBRARIES
    lib-math-interface
    lib-module-manager-interface
    lib-project-history-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-realtime-effects "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-registries/CMakeLists.txt
+++ b/libraries/lib-registries/CMakeLists.txt
@@ -39,8 +39,6 @@ set( SOURCES
 set( LIBRARIES
    lib-preferences-interface
    lib-exceptions
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-registries "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-sample-track/CMakeLists.txt
+++ b/libraries/lib-sample-track/CMakeLists.txt
@@ -34,8 +34,6 @@ set( LIBRARIES
    lib-audio-graph-interface
    lib-components-interface
    lib-track-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-sample-track "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-sample-track/CMakeLists.txt
+++ b/libraries/lib-sample-track/CMakeLists.txt
@@ -32,8 +32,6 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-audio-graph-interface
-   lib-components-interface
-   lib-track-interface
 )
 audacity_library( lib-sample-track "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-screen-geometry/CMakeLists.txt
+++ b/libraries/lib-screen-geometry/CMakeLists.txt
@@ -13,9 +13,7 @@ set( SOURCES
    ZoomInfo.h
 )
 set( LIBRARIES
-   lib-preferences-interface
    lib-project-interface
-   lib-xml-interface
 )
 audacity_library( lib-screen-geometry "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-screen-geometry/CMakeLists.txt
+++ b/libraries/lib-screen-geometry/CMakeLists.txt
@@ -16,8 +16,6 @@ set( LIBRARIES
    lib-preferences-interface
    lib-project-interface
    lib-xml-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-screen-geometry "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-string-utils/CMakeLists.txt
+++ b/libraries/lib-string-utils/CMakeLists.txt
@@ -26,8 +26,7 @@ set(SOURCES
 )
 
 set( LIBRARIES
-   PRIVATE
-   wxwidgets::base
+   wxBase
 )
 
 audacity_library( ${TARGET} "${SOURCES}" "${LIBRARIES}" "" "" )

--- a/libraries/lib-strings/CMakeLists.txt
+++ b/libraries/lib-strings/CMakeLists.txt
@@ -29,7 +29,6 @@ set( SOURCES
    wxArrayStringEx.cpp
 )
 set( LIBRARIES
-   PRIVATE
    wxBase
 )
 audacity_library( lib-strings "${SOURCES}" "${LIBRARIES}"

--- a/libraries/lib-tags/CMakeLists.txt
+++ b/libraries/lib-tags/CMakeLists.txt
@@ -10,8 +10,6 @@ set( LIBRARIES
    lib-project-history-interface
    lib-registries-interface
    lib-xml-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-tags "${SOURCES}" "${LIBRARIES}"
    "" "" )

--- a/libraries/lib-tags/CMakeLists.txt
+++ b/libraries/lib-tags/CMakeLists.txt
@@ -8,8 +8,6 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-project-history-interface
-   lib-registries-interface
-   lib-xml-interface
 )
 audacity_library( lib-tags "${SOURCES}" "${LIBRARIES}"
    "" "" )

--- a/libraries/lib-theme-resources/CMakeLists.txt
+++ b/libraries/lib-theme-resources/CMakeLists.txt
@@ -192,8 +192,6 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-theme-interface
-   PRIVATE
-   wxwidgets::wxwidgets
  )
 audacity_library( lib-theme-resources "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-theme/CMakeLists.txt
+++ b/libraries/lib-theme/CMakeLists.txt
@@ -17,7 +17,6 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-files-interface
-   PRIVATE
    wxwidgets::wxwidgets
  )
 audacity_library( lib-theme "${SOURCES}" "${LIBRARIES}"

--- a/libraries/lib-track/CMakeLists.txt
+++ b/libraries/lib-track/CMakeLists.txt
@@ -33,7 +33,6 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-project-interface
-   lib-xml-interface
 )
 audacity_library( lib-track "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-track/CMakeLists.txt
+++ b/libraries/lib-track/CMakeLists.txt
@@ -34,8 +34,6 @@ set( SOURCES
 set( LIBRARIES
    lib-project-interface
    lib-xml-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-track "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-transactions/CMakeLists.txt
+++ b/libraries/lib-transactions/CMakeLists.txt
@@ -14,8 +14,6 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-exceptions-interface
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-transactions "${SOURCES}" "${LIBRARIES}"
    ""

--- a/libraries/lib-xml/CMakeLists.txt
+++ b/libraries/lib-xml/CMakeLists.txt
@@ -22,8 +22,6 @@ set( LIBRARIES
    lib-files-interface
    lib-string-utils-interface
    expat::expat
-   PRIVATE
-   wxBase
 )
 audacity_library( lib-xml "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1528,11 +1528,9 @@ endif()
 
 set( AUDACITY_LIBRARIES
 # A sub-sequence of what is in libraries/CMakeLists.txt :
-   lib-string-utils-interface
    lib-uuid-interface
    lib-theme-resources-interface
    lib-graphics-interface
-   lib-audio-graph
    lib-tags-interface
    lib-audio-io-interface
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1569,6 +1569,8 @@ list( APPEND AUDACITY_LIBRARIES
    lib-sentry-reporting
 )
 
+propagate_interesting_dependencies( ${TARGET} "${AUDACITY_LIBRARIES}" )
+
 target_sources( ${TARGET} PRIVATE ${HEADERS} ${SOURCES} ${RESOURCES} ${MAC_RESOURCES} ${WIN_RESOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_compile_options( ${TARGET} PRIVATE ${OPTIONS} )
@@ -1628,7 +1630,9 @@ else()
 endif()
 
 # collect dependency information for third party libraries
-list( APPEND GRAPH_EDGES "Audacity [shape=house]" )
+set( AUDACITY_NODE_ATTRIBUTES "shape=house" )
+append_node_attributes( AUDACITY_NODE_ATTRIBUTES ${TARGET} )
+list( APPEND GRAPH_EDGES "Audacity [${AUDACITY_NODE_ATTRIBUTES}]" )
 foreach( LIBRARY ${LIBRARIES} ${AUDACITY_LIBRARIES} )
    if (NOT LIBRARY MATCHES "PUBLIC|PRIVATE|INTERFACE")
       canonicalize_node_name(LIBRARY "${LIBRARY}")


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Make fewer edges in the graphviz output in modules.dot.svg by allowing inherited
dependencies on wxBase from any library, or module, or Audacity and removing some
other unnecessary edges.

This will aid understanding as libraries and modules become more numerous.

Color what is not toolkit-neutral red, and what is, green.

Before:
![modules dot](https://user-images.githubusercontent.com/11670369/212779547-ac56c452-dff4-47c7-bd09-17e4cfd6547b.svg)

After:

![modules dot](https://user-images.githubusercontent.com/11670369/212915594-a2193cdc-e08c-42c0-b1bd-ea9fc622099b.svg)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
