### PR TITLE
Fix translation of "host" in Audio Setup tool bar

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -17170,7 +17170,7 @@ msgstr "Audio-Einrichtung"
 #. i18n-hint: Audio setup menu
 #: src/toolbars/AudioSetupToolBar.cpp
 msgid "&Host"
-msgstr "&Rechner"
+msgstr "Audio&host"
 
 #. i18n-hint: Audio setup menu
 #: src/toolbars/AudioSetupToolBar.cpp
@@ -17189,7 +17189,7 @@ msgstr "Aufnahme&kanäle"
 
 #: src/toolbars/AudioSetupToolBar.cpp
 msgid "&Audio Settings..."
-msgstr "&Audio-Einstellungen ..."
+msgstr "Audio-&Einstellungen ..."
 
 #: src/toolbars/AudioSetupToolBar.cpp src/toolbars/DeviceToolBar.cpp
 msgid "1 (Mono) Recording Channel"


### PR DESCRIPTION
The german "Rechners" refers to a computer. All other instances of "host" or "audio host" are kept as "Host", so use it in Audio Setup tool bar as well. Further the keyboard shortcut "A" was used twice, although I was not able to us keyboard navigation in Windows in that toolbar.


- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
