### PR TITLE
Issue #3482: accessibility of power toggle buttons in dialogs

### DIFF
--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -120,6 +120,7 @@ for registering for changes.
 #include "widgets/ReadOnlyText.h"
 #include "widgets/wxPanelWrapper.h"
 #include "widgets/wxTextCtrlWrapper.h"
+#include "widgets/AButton.h"
 #include "AllThemeResources.h"
 
 #if wxUSE_ACCESSIBILITY
@@ -393,6 +394,21 @@ wxBitmapButton * ShuttleGuiBase::AddBitmapButton(
    UpdateSizersCore(false, PositionFlags | wxALL);
    if (setDefault)
       pBtn->SetDefault();
+   return pBtn;
+}
+
+AButton* ShuttleGuiBase::AddBitmapToggleButton(
+   const wxImage& ImageOn, const wxImage& ImageOff, int PositionFlags)
+{
+   UseUpId();
+   if (mShuttleMode != eIsCreating)
+      return wxDynamicCast(wxWindow::FindWindowById(miId, mpDlg), AButton);
+   AButton* pBtn;
+   mpWind = pBtn = safenew AButton(GetParent(), miId,
+      wxDefaultPosition, wxDefaultSize, true);
+   pBtn->SetImages(ImageOff, ImageOff, ImageOn, ImageOn, ImageOff);
+   miProp = 0;
+   UpdateSizersCore(false, PositionFlags | wxALL);
    return pBtn;
 }
 

--- a/src/ShuttleGui.h
+++ b/src/ShuttleGui.h
@@ -74,6 +74,7 @@ class wxListBox;
 class wxGrid;
 class Shuttle;
 class ReadOnlyText;
+class AButton;
 
 class WrappedType;
 
@@ -284,6 +285,9 @@ public:
    wxBitmapButton * AddBitmapButton(
       const wxBitmap &Bitmap, int PositionFlags = wxALIGN_CENTRE,
       bool setDefault = false );
+   // Always ORs the flags with wxALL (which affects borders):
+   AButton* AddBitmapToggleButton(
+      const wxImage& ImageOn, const wxImage& ImageOff, int PositionFlags = wxALIGN_CENTRE);
    // When PositionFlags is 0, applies wxALL (which affects borders),
    // and either wxALIGN_CENTER (if bCenter) or else wxEXPAND
    wxStaticText * AddVariableText(

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -103,8 +103,9 @@ private:
 #include "../commands/CommandContext.h"
 #include "../widgets/AudacityMessageBox.h"
 #include "../widgets/HelpSystem.h"
+#include "../widgets/AButton.h"
 
-#include <wx/bmpbuttn.h>
+#include <wx/button.h>
 #include <wx/checkbox.h>
 #include <wx/dcclient.h>
 #include <wx/dcmemory.h>
@@ -353,8 +354,8 @@ void EffectUIHost::BuildButtonBar(ShuttleGui &S, bool graphicalUI)
          {
             mEnableBtn = S.Id(kEnableID)
                .Position(wxALIGN_CENTER | wxTOP | wxBOTTOM)
-               .Name(XO("Enable"))
-               .AddBitmapButton(mEnabled ? mRealtimeEnabledBM : mRealtimeDisabledBM);
+               .Name(XO("Power"))
+               .AddBitmapToggleButton(theTheme.Image(bmpEffectOn), theTheme.Image(bmpEffectOff));
          }
 
          mMenuBtn = S.Id( kMenuID )
@@ -419,9 +420,6 @@ void EffectUIHost::BuildButtonBar(ShuttleGui &S, bool graphicalUI)
 bool EffectUIHost::Initialize()
 {
    mEnabled = mpAccess->Get().extra.GetActive();
-
-   mRealtimeEnabledBM = theTheme.Bitmap(bmpEffectOn);
-   mRealtimeDisabledBM = theTheme.Bitmap(bmpEffectOff);
 
    // Build a "host" dialog, framing a panel that the client fills in.
    // The frame includes buttons to preview, apply, load and save presets, etc.
@@ -738,7 +736,7 @@ void EffectUIHost::OnMenu(wxCommandEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnEnable(wxCommandEvent & WXUNUSED(evt))
 {
-   mEnabled = !mEnabled;
+   mEnabled = mEnableBtn->IsDown();
 
    auto mpState = mwState.lock();
    if (mpState)
@@ -1063,7 +1061,7 @@ void EffectUIHost::UpdateControls()
 
    if (IsOpenedFromEffectPanel())
    {
-      mEnableBtn->SetBitmapLabel(mEnabled ? mRealtimeEnabledBM : mRealtimeDisabledBM);
+      mEnabled ? mEnableBtn->PushDown() : mEnableBtn->PopUp();
       return;
    }
 
@@ -1137,8 +1135,6 @@ std::shared_ptr<EffectInstance> EffectUIHost::InitializeInstance()
 
          mEffectStateSubscription = mpState->Subscribe([this](RealtimeEffectStateChange state) {
             mEnabled = (state == RealtimeEffectStateChange::EffectOn);
-            mEnableBtn->SetBitmapLabel(mEnabled ? mRealtimeEnabledBM : mRealtimeDisabledBM);
-
             UpdateControls();
          });
       }

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -14,8 +14,6 @@
 #ifndef __AUDACITY_EFFECTUI_H__
 #define __AUDACITY_EFFECTUI_H__
 
-#include <wx/bitmap.h> // member variables
-
 #include <optional>
 
 #include "Identifier.h"
@@ -37,6 +35,7 @@ class AudacityProject;
 class RealtimeEffectState;
 
 class wxCheckBox;
+class AButton;
 
 //
 class EffectUIHost final
@@ -135,12 +134,9 @@ private:
 
    wxButton *mApplyBtn{};
    wxButton *mMenuBtn{};
-   wxButton *mEnableBtn{};
+   AButton *mEnableBtn{};
    wxButton *mDebugBtn{};
    wxButton *mPlayToggleBtn{};
-
-   wxBitmap mRealtimeEnabledBM;
-   wxBitmap mRealtimeDisabledBM;
 
    bool mEnabled{ true };
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/3482
Resolves: https://github.com/audacity/audacity/issues/3492

Problem: The state of the power toggle buttons in realtime effects dialogs are not accessible for users of screen readers.

Fix: A wxBitmapButton was previously used for the power toggle button. However it's not possible to imitate a toggle button for all the Windows screen readers using this control. So use an AButton instead. This is already used for the power buttons in the realtime effects panel, and has already been made to imitate a toggle button for all Windows screen readers.

Notes:
- Using an AButton means that it probably won't be easily possible to assign an access key to this button. But this is a minor issue compared to the state of the button not being accessible.
- The accessibility name of the toggle button was changed from Enable to Power to make it consistent with the power toggle buttons in the realtime effects panel.
- In EffectUIHost::InitializeInstance(), a line updating the state of the toggle button was removed, as it was immediately prior to a call to UpdateControls() which updates the state of the toggle button.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
