### PR TITLE
improve zooming behavior

### DIFF
--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -481,7 +481,7 @@ mutable -> unsigned {
 #endif
 
       wxCoord xTrackEnd = viewInfo.TimeToPosition( audioEndTime );
-      viewInfo.ZoomBy(pow(2.0, steps));
+      viewInfo.ZoomBy(pow(1.25, steps));
 
       double new_center_h = viewInfo.PositionToTime(xx, trackLeftEdge);
       viewInfo.h += (center_h - new_center_h);

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -466,8 +466,6 @@ mutable -> unsigned {
       // Time corresponding to last (most far right) audio.
       double audioEndTime = TrackList::Get( *pProject ).GetEndTime();
 
-// Disabled this code to fix Bug 1923 (tricky to wheel-zoom right of waveform).
-#if 0
       // When zooming in empty space, it's easy to 'lose' the waveform.
       // This prevents it.
       // IF zooming in
@@ -478,7 +476,6 @@ mutable -> unsigned {
             // Zooming brings far right of audio to mouse.
             center_h = audioEndTime;
       }
-#endif
 
       wxCoord xTrackEnd = viewInfo.TimeToPosition( audioEndTime );
       viewInfo.ZoomBy(pow(1.25, steps));


### PR DESCRIPTION
Zooming with the scrollwheel in Audacity got identified as being much too quick, resulting in easy overscrolling into either the sample level or the days-and-weeks level. This PR reduces the factor from 2x to 1.25x for mouse wheel scrolling. 

Partially reverts fc25ce093fcee957f920827fa7e052b35f3c6c72