### PR TITLE
More in lib audio io

### DIFF
--- a/libraries/lib-audio-devices/AudioIOBase.h
+++ b/libraries/lib-audio-devices/AudioIOBase.h
@@ -44,20 +44,19 @@ struct AudioIOStartStreamOptions
 {
    explicit
    AudioIOStartStreamOptions(
-      const std::shared_ptr<AudacityProject> &pProject, double rate_)
-      : pProject{ pProject }
-      , envelope(nullptr)
+      const std::shared_ptr<AudacityProject> &pProject = {},
+      double rate_ = 44100.0
+   )  : pProject{ pProject }
       , rate(rate_)
-      , preRoll(0.0)
    {}
 
    std::shared_ptr<AudacityProject> pProject;
    std::weak_ptr<Meter> captureMeter, playbackMeter;
-   const BoundedEnvelope *envelope; // for time warping
+   const BoundedEnvelope *envelope{}; // for time warping
    std::shared_ptr< AudioIOListener > listener;
    double rate;
    mutable std::optional<double> pStartTime;
-   double preRoll;
+   double preRoll{ 0.0 };
 
    bool playNonWaveTracks{ true };
 

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -123,6 +123,27 @@ time warp info and AudioIOListener and whether the playback is looped.
 using std::max;
 using std::min;
 
+TransportTracks::TransportTracks(
+   TrackList &trackList, bool selectedOnly, bool nonWaveToo)
+{
+   {
+      const auto range = trackList.Any<SampleTrack>()
+         + (selectedOnly ? &Track::IsSelected : &Track::Any);
+      for (auto pTrack : range)
+         playbackTracks.push_back(pTrack->SharedPointer<SampleTrack>());
+   }
+#ifdef EXPERIMENTAL_MIDI_OUT
+   if (nonWaveToo) {
+      const auto range = trackList.Any<const PlayableTrack>() +
+         (selectedOnly ? &Track::IsSelected : &Track::Any);
+      for (auto pTrack : range)
+         if (!track_cast<const SampleTrack *>(pTrack))
+            otherPlayableTracks.push_back(
+               pTrack->SharedPointer<const PlayableTrack>() );
+   }
+#endif
+}
+
 AudioIO *AudioIO::Get()
 {
    return static_cast< AudioIO* >( AudioIOBase::Get() );

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -77,7 +77,13 @@ struct AudioIOEvent {
    bool on;
 };
 
-struct TransportTracks {
+struct AUDIO_IO_API TransportTracks final {
+   TransportTracks() = default;
+   TransportTracks(
+      TrackList &trackList, bool selectedOnly,
+      bool nonWaveToo = false //!< if true, collect all PlayableTracks
+   );
+
    SampleTrackConstArray playbackTracks;
    WritableSampleTrackArray captureTracks;
    PlayableTrackConstArray otherPlayableTracks;

--- a/libraries/lib-audio-io/ProjectAudioIO.cpp
+++ b/libraries/lib-audio-io/ProjectAudioIO.cpp
@@ -11,7 +11,32 @@ Paul Licameli split from AudacityProject.cpp
 #include "ProjectAudioIO.h"
 
 #include "AudioIOBase.h"
+#include "Mix.h"
 #include "Project.h"
+#include "ProjectRate.h"
+#include "Track.h"
+
+const std::function<ProjectAudioIO::OptionsFactory>
+ProjectAudioIO::DefaultOptionsFactory()
+{ return [] (AudacityProject &project, bool) {
+   auto &projectAudioIO = Get(project);
+   AudioIOStartStreamOptions options{
+      project.shared_from_this(), ProjectRate::Get(project).GetRate()
+   };
+   options.captureMeter = projectAudioIO.GetCaptureMeter();
+   options.playbackMeter = projectAudioIO.GetPlaybackMeter();
+   options.envelope =
+      Mixer::WarpOptions::DefaultWarp::Call(TrackList::Get(project));
+   // options.listener remains null
+   // boolean argument is ignored
+   return options;
+}; }
+
+AudioIOStartStreamOptions ProjectAudioIO::GetDefaultOptions(
+   AudacityProject &project, bool newDefaults)
+{
+   return DefaultOptions::Call(project, newDefaults);
+}
 
 static const AudacityProject::AttachedObjects::RegisteredFactory sAudioIOKey{
   []( AudacityProject &parent ){

--- a/libraries/lib-audio-io/ProjectAudioIO.h
+++ b/libraries/lib-audio-io/ProjectAudioIO.h
@@ -12,12 +12,14 @@ Paul Licameli split from AudacityProject.h
 #define __PROJECT_AUDIO_IO__
 
 #include "ClientData.h" // to inherit
+#include "GlobalVariable.h"
 #include "Observer.h" // to inherit
 #include <wx/weakref.h>
 
 #include <atomic>
 #include <memory>
 class AudacityProject;
+struct AudioIOStartStreamOptions;
 class Meter;
 
 struct SpeedChangeMessage {};
@@ -29,6 +31,30 @@ class AUDIO_IO_API ProjectAudioIO final
    , public Observer::Publisher<SpeedChangeMessage>
 {
 public:
+   //! Type of function constructing AudioIOStartStreamOptions
+   using OptionsFactory =
+      AudioIOStartStreamOptions(
+         AudacityProject &project, bool newDefaults);
+
+   //! Function returning a default factory function, which ignores the
+   //! second argument
+   static const std::function<OptionsFactory> DefaultOptionsFactory();
+
+   //! Global hook making AudioIOStartStreamOptions for a project, which
+   //! has a non-trivial default implementation
+   struct AUDIO_IO_API DefaultOptions : GlobalHook< DefaultOptions,
+      OptionsFactory,
+      DefaultOptionsFactory // default installed implementation
+   >{};
+
+   //! Invoke the global hook, supplying a default argument
+   static AudioIOStartStreamOptions GetDefaultOptions(
+      AudacityProject &project,
+      bool newDefaults = false /*!< if true, policy is meant to respond to
+         looping region; but specifying that is outside this library's scope
+      */
+   );
+
    static ProjectAudioIO &Get( AudacityProject &project );
    static const ProjectAudioIO &Get( const AudacityProject &project );
 

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2093,7 +2093,7 @@ void AdornedRulerPanel::StartQPPlay(
       newDefault = (loopEnabled && newDefault);
       if (newDefault)
          cutPreview = false;
-      auto options = DefaultPlayOptions( *mProject, newDefault );
+      auto options = ProjectAudioIO::GetDefaultOptions(*mProject, newDefault);
 
       if (!cutPreview) {
          if (pStartTime)

--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -28,7 +28,6 @@ processing.  See also MacrosWindow and ApplyMacroDialog.
 #include <wx/time.h>
 
 #include "Project.h"
-#include "ProjectAudioManager.h"
 #include "ProjectHistory.h"
 #include "ProjectSettings.h"
 #include "ProjectWindow.h"

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -421,7 +421,7 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
                return std::make_unique<CutPreviewPlaybackPolicy>(tless, diff);
             };
          token = gAudioIO->StartStream(
-            GetAllPlaybackTracks(TrackList::Get(*p), false, nonWaveToo),
+            TransportTracks{ TrackList::Get(*p), false, nonWaveToo },
             tcp0, tcp1, tcp1, myOptions);
       }
       else {
@@ -432,7 +432,7 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
                t1 = latestEnd;
          }
          token = gAudioIO->StartStream(
-            GetAllPlaybackTracks( tracks, false, nonWaveToo ),
+            TransportTracks{ tracks, false, nonWaveToo },
             t0, t1, mixerLimit, options);
       }
       if (token != 0) {
@@ -727,7 +727,7 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
          // playback.
          /* TODO: set up stereo tracks if that is how the user has set up
           * their preferences, and choose sample format based on prefs */
-         transportTracks = GetAllPlaybackTracks(TrackList::Get( *p ), false, true);
+         transportTracks = TransportTracks{ TrackList::Get( *p ), false, true };
          for (const auto &wt : existingTracks) {
             auto end = transportTracks.playbackTracks.end();
             auto it = std::find(transportTracks.playbackTracks.begin(), end, wt);
@@ -1199,32 +1199,6 @@ DefaultSpeedPlayOptions( AudacityProject &project )
       ProjectRate::Get( project ).GetRate()  //suggested rate
    );
    result.rate = PlayAtSpeedRate;
-   return result;
-}
-
-TransportTracks ProjectAudioManager::GetAllPlaybackTracks(
-   TrackList &trackList, bool selectedOnly, bool nonWaveToo)
-{
-   TransportTracks result;
-   {
-      auto range = trackList.Any< WaveTrack >()
-         + (selectedOnly ? &Track::IsSelected : &Track::Any );
-      for (auto pTrack: range)
-         result.playbackTracks.push_back(
-            pTrack->SharedPointer< WaveTrack >() );
-   }
-#ifdef EXPERIMENTAL_MIDI_OUT
-   if (nonWaveToo) {
-      auto range = trackList.Any< const PlayableTrack >() +
-         (selectedOnly ? &Track::IsSelected : &Track::Any );
-      for (auto pTrack: range)
-         if (!track_cast<const WaveTrack *>(pTrack))
-            result.otherPlayableTracks.push_back(
-               pTrack->SharedPointer< const PlayableTrack >() );
-   }
-#else
-   WXUNUSED(useMidi);
-#endif
    return result;
 }
 

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -118,7 +118,7 @@ public:
    // Play currently selected region, or if nothing selected,
    // play from current cursor.
    void PlayCurrentRegion(
-      bool newDefault = false, //!< See DefaultPlayOptions
+      bool newDefault = false, //!< See ProjectAudioIO::GetDefaultOptions
       bool cutpreview = false);
 
    void OnPause();
@@ -180,12 +180,6 @@ private:
          const AudacityProject &project, StatusBarField field);
 };
 
-AUDACITY_DLL_API
-AudioIOStartStreamOptions DefaultPlayOptions(
-   AudacityProject &project,
-   bool newDefault = false /*!< "new" default playback policy adjusts to
-      changes of the looping region, "old" default plays once straight */
-);
 AudioIOStartStreamOptions DefaultSpeedPlayOptions( AudacityProject &project );
 
 struct PropertiesOfSelected

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -74,11 +74,6 @@ public:
 
    static bool UseDuplex();
 
-   static TransportTracks GetAllPlaybackTracks(
-      TrackList &trackList, bool selectedOnly,
-      bool nonWaveToo = false //!< if true, collect all PlayableTracks
-   );
-
    explicit ProjectAudioManager( AudacityProject &project );
    ProjectAudioManager( const ProjectAudioManager & ) PROHIBITED;
    ProjectAudioManager &operator=( const ProjectAudioManager & ) PROHIBITED;

--- a/src/TransportUtilities.cpp
+++ b/src/TransportUtilities.cpp
@@ -191,7 +191,6 @@ void TransportUtilities::DoStartPlaying(
    const CommandContext &context, bool newDefault)
 {
    auto &project = context.project;
-   auto &projectAudioManager = ProjectAudioManager::Get(project);
    auto gAudioIO = AudioIOBase::Get();
    //play the front project
    if (!gAudioIO->IsBusy()) {

--- a/src/effects/EffectBase.cpp
+++ b/src/effects/EffectBase.cpp
@@ -483,7 +483,7 @@ void EffectBase::Preview(EffectSettingsAccess &access, bool dryOnly)
 
    if (success)
    {
-      auto tracks = ProjectAudioManager::GetAllPlaybackTracks(*mTracks, true);
+      auto tracks = TransportTracks{ *mTracks, true };
 
       // Some effects (Paulstretch) may need to generate more
       // than previewLen, so take the min.

--- a/src/effects/EffectBase.cpp
+++ b/src/effects/EffectBase.cpp
@@ -26,7 +26,7 @@
 #include "widgets/wxWidgetsWindowPlacement.h"
 #include "../MixAndRender.h"
 #include "PluginManager.h"
-#include "../ProjectAudioManager.h"
+#include "ProjectAudioIO.h"
 #include "QualitySettings.h"
 #include "TransactionScope.h"
 #include "ViewInfo.h"
@@ -490,7 +490,7 @@ void EffectBase::Preview(EffectSettingsAccess &access, bool dryOnly)
       t1 = std::min(mT0 + previewLen, mT1);
 
       // Start audio playing
-      auto options = DefaultPlayOptions(*pProject);
+      auto options = ProjectAudioIO::GetDefaultOptions(*pProject);
       int token = gAudioIO->StartStream(tracks, mT0, t1, t1, options);
 
       if (token) {

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -20,6 +20,7 @@
 #include "ConfigInterface.h"
 #include "EffectManager.h"
 #include "PluginManager.h"
+#include "ProjectAudioIO.h"
 #include "ProjectHistory.h"
 #include "../ProjectWindowBase.h"
 #include "../TrackPanelAx.h"
@@ -787,9 +788,9 @@ void EffectUIHost::OnPlay(wxCommandEvent & WXUNUSED(evt))
       
       auto &projectAudioManager = ProjectAudioManager::Get( mProject );
       projectAudioManager.PlayPlayRegion(
-                                         SelectedRegion(mPlayPos, mRegion.t1()),
-                                         DefaultPlayOptions( mProject ),
-                                         PlayMode::normalPlay );
+         SelectedRegion{ mPlayPos, mRegion.t1() },
+         ProjectAudioIO::GetDefaultOptions(mProject),
+         PlayMode::normalPlay);
    }
 }
 

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -339,7 +339,7 @@ void OnPunchAndRoll(const CommandContext &context)
    transportTracks.captureTracks = std::move(tracks);
 
    // Try to start recording
-   auto options = DefaultPlayOptions( project );
+   auto options = ProjectAudioIO::GetDefaultOptions(project);
    options.rate = rateOfSelected;
    options.preRoll = std::max(0L,
       gPrefs->Read(AUDIO_PRE_ROLL_KEY, DEFAULT_PRE_ROLL_SECONDS));
@@ -464,7 +464,7 @@ void OnPlayOneSecond(const CommandContext &context)
       return;
 
    auto &trackPanel = TrackPanel::Get( project );
-   auto options = DefaultPlayOptions( project );
+   auto options = ProjectAudioIO::GetDefaultOptions(project);
 
    double pos = trackPanel.GetMostRecentXPos();
    TransportUtilities::PlayPlayRegionAndWait(
@@ -516,7 +516,7 @@ void OnPlayToSelection(const CommandContext &context)
    // only when playing a short region, less than or equal to a second.
 //   mLastPlayMode = ((t1-t0) > 1.0) ? normalPlay : oneSecondPlay;
 
-   auto playOptions = DefaultPlayOptions( project );
+   auto playOptions = ProjectAudioIO::GetDefaultOptions(project);
 
    TransportUtilities::PlayPlayRegionAndWait(
       context, SelectedRegion(t0, t1),
@@ -540,7 +540,7 @@ void OnPlayBeforeSelectionStart(const CommandContext &context)
    double beforeLen;
    gPrefs->Read(wxT("/AudioIO/CutPreviewBeforeLen"), &beforeLen, 2.0);
 
-   auto playOptions = DefaultPlayOptions( project );
+   auto playOptions = ProjectAudioIO::GetDefaultOptions(project);
 
    TransportUtilities::PlayPlayRegionAndWait(
       context, SelectedRegion(t0 - beforeLen, t0),
@@ -562,7 +562,7 @@ void OnPlayAfterSelectionStart(const CommandContext &context)
    double afterLen;
    gPrefs->Read(wxT("/AudioIO/CutPreviewAfterLen"), &afterLen, 1.0);
 
-   auto playOptions = DefaultPlayOptions( project );
+   auto playOptions = ProjectAudioIO::GetDefaultOptions(project);
 
    if ( t1 - t0 > 0.0 && t1 - t0 < afterLen )
       TransportUtilities::PlayPlayRegionAndWait(
@@ -589,7 +589,7 @@ void OnPlayBeforeSelectionEnd(const CommandContext &context)
    double beforeLen;
    gPrefs->Read(wxT("/AudioIO/CutPreviewBeforeLen"), &beforeLen, 2.0);
 
-   auto playOptions = DefaultPlayOptions( project );
+   auto playOptions = ProjectAudioIO::GetDefaultOptions(project);
 
    if ( t1 - t0 > 0.0 && t1 - t0 < beforeLen )
       TransportUtilities::PlayPlayRegionAndWait(
@@ -615,7 +615,7 @@ void OnPlayAfterSelectionEnd(const CommandContext &context)
    double afterLen;
    gPrefs->Read(wxT("/AudioIO/CutPreviewAfterLen"), &afterLen, 1.0);
 
-   auto playOptions = DefaultPlayOptions( project );
+   auto playOptions = ProjectAudioIO::GetDefaultOptions(project);
 
    TransportUtilities::PlayPlayRegionAndWait(
       context, SelectedRegion(t1, t1 + afterLen),
@@ -640,7 +640,7 @@ void OnPlayBeforeAndAfterSelectionStart
    double afterLen;
    gPrefs->Read(wxT("/AudioIO/CutPreviewAfterLen"), &afterLen, 1.0);
 
-   auto playOptions = DefaultPlayOptions( project );
+   auto playOptions = ProjectAudioIO::GetDefaultOptions(project);
 
    if ( t1 - t0 > 0.0 && t1 - t0 < afterLen )
       TransportUtilities::PlayPlayRegionAndWait(
@@ -670,7 +670,7 @@ void OnPlayBeforeAndAfterSelectionEnd
    double afterLen;
    gPrefs->Read(wxT("/AudioIO/CutPreviewAfterLen"), &afterLen, 1.0);
 
-   auto playOptions = DefaultPlayOptions( project );
+   auto playOptions = ProjectAudioIO::GetDefaultOptions(project);
 
    if ( t1 - t0 > 0.0 && t1 - t0 < beforeLen )
       TransportUtilities::PlayPlayRegionAndWait(

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -327,9 +327,8 @@ void OnPunchAndRoll(const CommandContext &context)
    const auto duplex = ProjectAudioManager::UseDuplex();
    if (duplex)
       // play all
-      transportTracks =
-         ProjectAudioManager::GetAllPlaybackTracks(
-            TrackList::Get( project ), false, true);
+      transportTracks = TransportTracks{
+         TrackList::Get( project ), false, true };
    else
       // play recording tracks only
       std::copy(tracks.begin(), tracks.end(),

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -547,7 +547,7 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
       return;
 
    {
-      auto options = DefaultPlayOptions( *p, newDefault );
+      auto options = ProjectAudioIO::GetDefaultOptions(*p, newDefault);
       // No need to set cutPreview options.
       options.envelope = bFixedSpeedPlay ? mEnvelope.get() : nullptr;
       options.variableSpeed = !bFixedSpeedPlay;

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -406,7 +406,7 @@ bool Scrubber::MaybeStartScrubbing(wxCoord xx)
             mSpeedPlaying = false;
             mKeyboardScrubbing = false;
             auto options =
-               DefaultPlayOptions( *mProject );
+               ProjectAudioIO::GetDefaultOptions(*mProject);
 
 #ifndef USE_SCRUB_THREAD
             // Yuck, we either have to poll "by hand" when scrub polling doesn't

--- a/src/widgets/MeterPanel.cpp
+++ b/src/widgets/MeterPanel.cpp
@@ -61,7 +61,7 @@
 #include "ImageManipulation.h"
 #include "Decibels.h"
 #include "Project.h"
-#include "../ProjectAudioManager.h"
+#include "ProjectAudioIO.h"
 #include "ProjectStatus.h"
 #include "../ProjectWindows.h"
 #include "Prefs.h"
@@ -1866,9 +1866,8 @@ void MeterPanel::StartMonitoring()
 
    if (start && !gAudioIO->IsBusy()){
       AudacityProject *p = mProject;
-      if (p){
-         gAudioIO->StartMonitoring( DefaultPlayOptions( *p ) );
-      }
+      if (p)
+         gAudioIO->StartMonitoring(ProjectAudioIO::GetDefaultOptions(*p));
 
       mLayoutValid = false;
 


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Break dependency of EffectBase on ProjectAudioManager by demoting a piece
of the latter into lib-audio-io.

The untangling of the rest of ProjectAudioManager so it can go into a toolkit
neutral library is a difficult and still unsolved problem.  But this much will
remove one of the blocks in untangling a toolkit neutral library for destructive
effect application, which includes the logic behind the Preview button of the
Effect dialog.

QA:  test starting and stopping of playback, recording (including punch-and-roll), monitoring (click in the output meter), play-at-speed button, scrubbing

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
