### PR TITLE
More in lib basic UI

### DIFF
--- a/libraries/lib-basic-ui/BasicUI.cpp
+++ b/libraries/lib-basic-ui/BasicUI.cpp
@@ -183,6 +183,8 @@ bool RunXDGOpen(const std::string& uri)
 namespace  BasicUI {
 WindowPlacement::~WindowPlacement() = default;
 
+WindowPlacement::operator bool() const { return false; }
+
 Services::~Services() = default;
 
 ProgressDialog::~ProgressDialog() = default;

--- a/libraries/lib-basic-ui/BasicUI.h
+++ b/libraries/lib-basic-ui/BasicUI.h
@@ -217,6 +217,9 @@ public:
       const TranslatableString &boxMsg, bool log) = 0;
 
    virtual bool DoOpenInDefaultBrowser(const wxString &url) = 0;
+
+   virtual std::unique_ptr<WindowPlacement> DoFindFocus() = 0;
+   virtual void DoSetFocus(const WindowPlacement &focus) = 0;
 };
 
 //! Fetch the global instance, or nullptr if none is yet installed
@@ -331,6 +334,25 @@ inline int ShowMultiDialog(const TranslatableString &message,
       return p->DoMultiDialog(message, title, buttons, helpPage, boxMsg, log);
    else
       return -1;
+}
+
+//! Find the window that is accepting keyboard input, if any
+/*!
+ @post `result: result != nullptr` (but may point to an empty WindowPlacement)
+ */
+inline std::unique_ptr<WindowPlacement> FindFocus()
+{
+   if (auto p = Get())
+      if (auto result = p->DoFindFocus())
+         return result;
+   return std::make_unique<WindowPlacement>();
+}
+
+//! Set the window that accepts keyboard input
+inline void SetFocus(const WindowPlacement &focus)
+{
+   if (auto p = Get())
+      p->DoSetFocus(focus);
 }
 
 //! @}

--- a/libraries/lib-basic-ui/BasicUI.h
+++ b/libraries/lib-basic-ui/BasicUI.h
@@ -34,6 +34,8 @@ public:
    WindowPlacement( const WindowPlacement& ) PROHIBITED;
    //! Don't slice
    WindowPlacement &operator=( const WindowPlacement& ) PROHIBITED;
+   //! Whether null; default in the base class returns false
+   virtual explicit operator bool() const;
    virtual ~WindowPlacement();
 };
 

--- a/src/widgets/wxWidgetsBasicUI.cpp
+++ b/src/widgets/wxWidgetsBasicUI.cpp
@@ -218,3 +218,14 @@ bool wxWidgetsBasicUI::DoOpenInDefaultBrowser(const wxString &url)
 {
    return wxLaunchDefaultBrowser(url);
 }
+
+std::unique_ptr<BasicUI::WindowPlacement> wxWidgetsBasicUI::DoFindFocus()
+{
+   return std::make_unique<wxWidgetsWindowPlacement>(wxWindow::FindFocus());
+}
+
+void wxWidgetsBasicUI::DoSetFocus(const BasicUI::WindowPlacement &focus)
+{
+   auto pWindow = wxWidgetsWindowPlacement::GetParent(focus);
+   pWindow->SetFocus();
+}

--- a/src/widgets/wxWidgetsBasicUI.h
+++ b/src/widgets/wxWidgetsBasicUI.h
@@ -48,6 +48,9 @@ protected:
       const TranslatableString &boxMsg, bool log) override;
 
    bool DoOpenInDefaultBrowser(const wxString &url) override;
+
+   std::unique_ptr<BasicUI::WindowPlacement> DoFindFocus() override;
+   void DoSetFocus(const BasicUI::WindowPlacement &focus) override;
 };
 
 #endif

--- a/src/widgets/wxWidgetsWindowPlacement.cpp
+++ b/src/widgets/wxWidgetsWindowPlacement.cpp
@@ -15,6 +15,11 @@ using namespace BasicUI;
 
 wxWidgetsWindowPlacement::~wxWidgetsWindowPlacement() = default;
 
+wxWidgetsWindowPlacement::operator bool() const
+{
+   return pWindow != nullptr;
+}
+
 wxWindow *wxWidgetsWindowPlacement::GetParent(const WindowPlacement &placement)
 {
    if (auto *pPlacement =

--- a/src/widgets/wxWidgetsWindowPlacement.h
+++ b/src/widgets/wxWidgetsWindowPlacement.h
@@ -31,6 +31,9 @@ struct AUDACITY_DLL_API wxWidgetsWindowPlacement final
    {}
 
    ~wxWidgetsWindowPlacement() override;
+
+   explicit operator bool() const override;
+
    wxWindow *pWindow{};
 };
 


### PR DESCRIPTION
Resolves: 

Another small step toward toolkit neutrality of EffectBase.cpp and later
movement of that to a library, by enlarging BasicUI abstractions to support the =
notion of the focused window.

Unchanged behavior for QA to check:

The Preview button of the destructive effect dialog makes a working progress dialog that can be stopped.
The keyboard focus is restored as it was, after either playing the preview completely or stopping the progress dialog (either with a click or a keystroke).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
