### PR TITLE
Use define_property so required CMake minimum won't increase yet

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -338,6 +338,13 @@ function( canonicalize_node_name var node )
    set( "${var}" "${node}" PARENT_SCOPE )
 endfunction()
 
+define_property(TARGET PROPERTY AUDACITY_GRAPH_DEPENDENCIES
+   BRIEF_DOCS
+      "Propagates information used in generating a target dependency diagram"
+   FULL_DOCS
+      "Audacity uses this at configuration time only, not generation time."
+)
+
 function( append_node_attributes var target )
    get_target_property( dependencies ${target} AUDACITY_GRAPH_DEPENDENCIES )
    set( color "lightpink" )


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Commit dc5718cefe8f8099c1878b5f757bbd19a128563a unintentionally increased the require CMake minimum version, but this corrects that while still preserving the advantages of that commit.

This small change should bypass QA confirmation, as having no effect at all on the built program.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
