### PR TITLE
fix miscellaneous compilation issues for musl libc

### DIFF
--- a/libraries/lib-ipc/IPCClient.cpp
+++ b/libraries/lib-ipc/IPCClient.cpp
@@ -13,6 +13,7 @@
 #include "IPCClient.h"
 #include "IPCChannel.h"
 
+#include <cstdint>
 #include <thread>
 #include <stdexcept>
 
@@ -40,7 +41,7 @@ public:
       sockaddr_in addrin {};
       addrin.sin_family = AF_INET;
       addrin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-      addrin.sin_port = htons(static_cast<u_short>(port));
+      addrin.sin_port = htons(static_cast<uint16_t>(port));
 
       if(connect(*fd, reinterpret_cast<const sockaddr*>(&addrin), sizeof(addrin)) == SOCKET_ERROR)
       {

--- a/libraries/lib-ipc/internal/ipc-types.h
+++ b/libraries/lib-ipc/internal/ipc-types.h
@@ -18,6 +18,7 @@
 #define CLOSE_SOCKET closesocket
 #define NFDS(x) (0)//not used on winsock2
 #else
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <unistd.h>

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -842,8 +842,8 @@ int main(int argc, char *argv[])
    // never be able to get rid of the messages entirely, but we should
    // look into what's causing them, so allow them to show in Debug
    // builds.
-   stdout = freopen("/dev/null", "w", stdout);
-   stderr = freopen("/dev/null", "w", stderr);
+   freopen("/dev/null", "w", stdout);
+   freopen("/dev/null", "w", stderr);
 
    return wxEntry(argc, argv);
 }


### PR DESCRIPTION
fixes various issues compiling under musl libc:

- u_short isn't a standard typename and doesn't exist
- <sys/select.h> is needed for fd_ functions
- assigning to stdout/err is invalid, but freopen already does this so there is no need to

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
