### PR TITLE
add support for "seconds + milliseconds" time format

### DIFF
--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -378,6 +378,18 @@ static const BuiltinFormatString TimeConverterFormats_[] =  {
    },
 
    {
+   /* i18n-hint: Name of time display format that shows time in seconds
+    * and milliseconds (1/1000 second) */
+   { XO("seconds + milliseconds") },
+   /* i18n-hint: Format string for displaying time in seconds and milliseconds 
+    * as fractional seconds. Change the comma in the middle to the 1000s separator
+    * for your locale, and the 'seconds' on the end to the word for seconds.
+    * Don't change the numbers. The decimal separator is specified using '<' if
+    * your languages uses a ',' or to '>' if your language uses a '.'. */
+   XO("01000,01000>01000 seconds")
+   },
+
+   {
    /* i18n-hint: Name of time display format that shows time in hours, minutes
     * and seconds */
    { XO("hh:mm:ss") },


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4258

Adds support for "seconds + milliseconds" time format to time widget.

![image](https://user-images.githubusercontent.com/5651184/216389232-7aaf14e7-061e-48cc-afbc-8043bb2b07e7.png)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
