### PR TITLE
Fix unintended permutation of Tools menu since commit 99368bc...

### DIFF
--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -1533,7 +1533,7 @@ BaseItemSharedPtr PluginMenuItems()
 {
    using Options = CommandManager::Options;
    static BaseItemSharedPtr items{
-   Items( "",
+   Items( "Macros",
       Section( "RepeatLast",
          // Delayed evaluation:
          [](AudacityProject &project)


### PR DESCRIPTION
... This fixes it, because registry merge treats named and unnamed groupings differently

Resolves: #4172

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
