### PR TITLE
Add support for linked track normalization

### DIFF
--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -36,7 +36,7 @@
 const EffectParameterMethods& EffectNormalize::Parameters() const
 {
    static CapturedParameters<EffectNormalize,
-      PeakLevel, ApplyGain, RemoveDC, StereoInd
+      PeakLevel, ApplyGain, RemoveDC, StereoInd, TrackInd
    > parameters;
    return parameters;
 }
@@ -282,6 +282,13 @@ std::unique_ptr<EffectUIValidator> EffectNormalize::PopulateOrExchange(
                .Validator<wxGenericValidator>(&mStereoInd)
                .AddCheckBox(XXO("N&ormalize stereo channels independently"),
                                                mStereoInd);
+
+            // TODO: better alignment on dialog; this is sort of crammed in at the bottom.
+            mTrackIndCheckBox = S
+               .Validator<wxGenericValidator>(&mTrackInd)
+               .AddCheckBox(XXO("Normalize &tracks independently"),
+                                               mTrackInd);
+
          }
          S.EndVerticalLay();
       }
@@ -508,7 +515,8 @@ void EffectNormalize::UpdateUI()
    // Disallow level stuff if not normalizing
    mLevelTextCtrl->Enable(mGain);
    mLeveldB->Enable(mGain);
-   mStereoIndCheckBox->Enable(mGain);
+   mStereoIndCheckBox->Enable(mGain /*&& mTrackIndCheckBox->IsChecked()*/ /* TODO */);
+   mTrackIndCheckBox->Enable(mGain);
 
    // Disallow OK/Preview if doing nothing
    EnableApply(mGain || mDC);

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -524,7 +524,7 @@ void EffectNormalize::UpdateUI()
    // Disallow level stuff if not normalizing
    mLevelTextCtrl->Enable(mGain);
    mLeveldB->Enable(mGain);
-   mStereoIndCheckBox->Enable(mGain /*&& mTrackIndCheckBox->IsChecked()*/ /* TODO */);
+   mStereoIndCheckBox->Enable(mGain && mTrackIndCheckBox->IsChecked());
    mTrackIndCheckBox->Enable(mGain);
 
    // Disallow OK/Preview if doing nothing

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -189,6 +189,15 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
 
    }
 
+   // if linking all tracks, use the minimum of all the multipliers
+   if (!mTrackInd && !tasks.empty()) {
+      auto minMult = tasks[0].mMult;
+      for (auto k = 1; k < tasks.size(); ++k)
+         minMult = std::min(minMult, tasks[k].mMult);
+      for (auto& params : tasks)
+         params.mMult = minMult;
+   }
+
    // now apply normalization to each track
    for (const auto &params : tasks) {
 

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -88,6 +88,7 @@ private:
    bool   mGain;
    bool   mDC;
    bool   mStereoInd;
+   bool   mTrackInd;
 
    wxCheckBox *mGainCheckBox;
    wxCheckBox *mDCCheckBox;
@@ -95,6 +96,7 @@ private:
    wxStaticText *mLeveldB;
    wxStaticText *mWarning;
    wxCheckBox *mStereoIndCheckBox;
+   wxCheckBox* mTrackIndCheckBox;
    bool mCreating;
 
    const EffectParameterMethods& Parameters() const override;
@@ -108,6 +110,8 @@ static constexpr EffectParameter ApplyGain{ &EffectNormalize::mGain,
    L"ApplyGain",           true,    false,   true, 1  };
 static constexpr EffectParameter StereoInd{ &EffectNormalize::mStereoInd,
    L"StereoIndependent",   false,   false,   true, 1  };
+static constexpr EffectParameter TrackInd{ &EffectNormalize::mTrackInd,
+   L"TrackIndependent",    true,    false,   true, 1 };
 };
 
 #endif

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -54,14 +54,30 @@ public:
 private:
    // EffectNormalize implementation
 
-   bool ProcessOne(
-      WaveTrack * t, const TranslatableString &msg, double& progress, float offset);
+   struct NormParams { // per track
+      double mCurT0;
+      double mCurT1;
+      float  mMult;
+      double mSum;
+      std::vector<float> mOffsets; // per channel
+      NormParams () : mCurT0(0), mCurT1(0), mMult(0), mSum(0) { }
+   };
+
+   // Note: 'offset' is always passed separately from 'params' because offsets are per channel,
+   // not per track, and NormParams was added after the fact (used to be member vars). The
+   // alternative would be to pass a channel index to each of these functions (to specify which
+   // of params.mOffsets[] to use). Using a channel index would be a debatably better approach,
+   // but would require some additional code changes, and I am trying to make the least amount
+   // of changes possible. Possible TODO.           [JC3, 2023-Feb-04, while adding NormParams]
+
+   bool ProcessOne(WaveTrack * t, const TranslatableString &msg, double& progress,
+                   float offset, const NormParams &params);
    bool AnalyseTrack(const WaveTrack * track, const TranslatableString &msg,
-                     double &progress, float &offset, float &extent);
+                     double &progress, float &offset, float &extent, NormParams &params);
    bool AnalyseTrackData(const WaveTrack * track, const TranslatableString &msg, double &progress,
-                     float &offset);
-   void AnalyseDataDC(float *buffer, size_t len);
-   void ProcessData(float *buffer, size_t len, float offset);
+                     float &offset, NormParams &params);
+   void AnalyseDataDC(float *buffer, size_t len, NormParams &params);
+   void ProcessData(float *buffer, size_t len, float offset, const NormParams &params);
 
    void OnUpdateUI(wxCommandEvent & evt);
    void UpdateUI();
@@ -71,11 +87,6 @@ private:
    bool   mGain;
    bool   mDC;
    bool   mStereoInd;
-
-   double mCurT0;
-   double mCurT1;
-   float  mMult;
-   double mSum;
 
    wxCheckBox *mGainCheckBox;
    wxCheckBox *mDCCheckBox;

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -55,12 +55,13 @@ private:
    // EffectNormalize implementation
 
    struct NormParams { // per track
+      WaveTrack* mTrack;
       double mCurT0;
       double mCurT1;
       float  mMult;
       double mSum;
       std::vector<float> mOffsets; // per channel
-      NormParams () : mCurT0(0), mCurT1(0), mMult(0), mSum(0) { }
+      NormParams () : mTrack(nullptr), mCurT0(0), mCurT1(0), mMult(0), mSum(0) { }
    };
 
    // Note: 'offset' is always passed separately from 'params' because offsets are per channel,


### PR DESCRIPTION
Resolves: #4272 

Adds "Normalize Tracks Independently" check box to Normalize effect, checked by default.

When unchecked, the maximum values of all selected tracks will be considered together, and every selected track will be multiplied by the same multiplier. I.e. all tracks will be linked when normalizing.

Includes a number of supporting code changes, notably separating analysis step and processing step into two different loops.

i18n: This adds one new string that will need translated ("Normalize tracks independently").

See #4272 for discussion.
See commit log for details.

Test file: [normalize_test.aup3.gz](https://github.com/audacity/audacity/files/10609962/normalize_test.aup3.gz)

Test instructions:
- With "Normalize Tracks Independently" checked, select various combinations of tracks and observe results.
- With "Normalize Tracks Independently" unchecked, select the tracks that aren't already normalized (i.e. "80+0" and "90+0") and observe results.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
