### PR TITLE
Break an effect dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -378,6 +378,8 @@ list( APPEND SOURCES
 
       effects/Amplify.cpp
       effects/Amplify.h
+      effects/AnalysisTracks.cpp
+      effects/AnalysisTracks.h
       effects/AutoDuck.cpp
       effects/AutoDuck.h
       effects/BassTreble.cpp

--- a/src/effects/AnalysisTracks.cpp
+++ b/src/effects/AnalysisTracks.cpp
@@ -1,0 +1,853 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Effect.cpp
+
+  Dominic Mazzoni
+  Vaughan Johnson
+  Martyn Shaw
+
+*******************************************************************//**
+
+\class Effect
+\brief Base class for many of the effects in Audacity.
+
+*//*******************************************************************/
+
+
+#include "Effect.h"
+
+#include <algorithm>
+
+#include <wx/defs.h>
+#include <wx/sizer.h>
+
+#include "ConfigInterface.h"
+#include "../LabelTrack.h"
+#include "../ProjectSettings.h"
+#include "../SelectFile.h"
+#include "../ShuttleAutomation.h"
+#include "../ShuttleGui.h"
+#include "../SyncLock.h"
+#include "ViewInfo.h"
+#include "WaveTrack.h"
+#include "wxFileNameWrapper.h"
+#include "../widgets/ProgressDialog.h"
+#include "../widgets/NumericTextCtrl.h"
+#include "../widgets/AudacityMessageBox.h"
+#include "../widgets/VetoDialogHook.h"
+
+#include <unordered_map>
+
+static const int kPlayID = 20102;
+static_assert(kPlayID == EffectUIValidator::kPlayID);
+
+using t2bHash = std::unordered_map< void*, bool >;
+
+bool StatefulEffect::Instance::Process(EffectSettings &settings)
+{
+   return GetEffect().Process(*this, settings);
+}
+
+auto StatefulEffect::Instance::GetLatency(const EffectSettings &, double) const
+   -> SampleCount
+{
+   return GetEffect().GetLatency().as_long_long();
+}
+
+size_t StatefulEffect::Instance::ProcessBlock(EffectSettings &,
+   const float *const *, float *const *, size_t)
+{
+   return 0;
+}
+
+Effect::Effect()
+{
+}
+
+Effect::~Effect()
+{
+   // Destroying what is usually the unique Effect object of its subclass,
+   // which lasts until the end of the session.
+   // Maybe there is a non-modal realtime dialog still open.
+   if (mHostUIDialog)
+      mHostUIDialog->Close();
+}
+
+// ComponentInterface implementation
+
+PluginPath Effect::GetPath() const
+{
+   return BUILTIN_EFFECT_PREFIX + GetSymbol().Internal();
+}
+
+ComponentInterfaceSymbol Effect::GetSymbol() const
+{
+   return {};
+}
+
+VendorSymbol Effect::GetVendor() const
+{
+   return XO("Audacity");
+}
+
+wxString Effect::GetVersion() const
+{
+   return AUDACITY_VERSION_STRING;
+}
+
+TranslatableString Effect::GetDescription() const
+{
+   return {};
+}
+
+// EffectDefinitionInterface implementation
+
+EffectType Effect::GetType() const
+{
+   return EffectTypeNone;
+}
+
+EffectFamilySymbol Effect::GetFamily() const
+{
+   // Unusually, the internal and visible strings differ for the built-in
+   // effect family.
+   return { wxT("Audacity"), XO("Built-in") };
+}
+
+bool Effect::IsInteractive() const
+{
+   return true;
+}
+
+bool Effect::IsDefault() const
+{
+   return true;
+}
+
+auto Effect::RealtimeSupport() const -> RealtimeSince
+{
+   return RealtimeSince::Never;
+}
+
+bool Effect::SupportsAutomation() const
+{
+   return true;
+}
+
+std::shared_ptr<EffectInstance> StatefulEffect::MakeInstance() const
+{
+   // Cheat with const-cast to return an object that calls through to
+   // non-const methods of a stateful effect.
+   // Stateless effects should override this function and be really const
+   // correct.
+   return std::make_shared<Instance>(const_cast<StatefulEffect&>(*this));
+}
+
+const EffectParameterMethods &Effect::Parameters() const
+{
+   static const CapturedParameters<Effect> empty;
+   return empty;
+}
+
+int Effect::ShowClientInterface(wxWindow &parent, wxDialog &dialog,
+   EffectUIValidator *, bool forceModal)
+{
+   // Remember the dialog with a weak pointer, but don't control its lifetime
+   mUIDialog = &dialog;
+   mUIDialog->Layout();
+   mUIDialog->Fit();
+   mUIDialog->SetMinSize(mUIDialog->GetSize());
+   if (VetoDialogHook::Call(mUIDialog))
+      return 0;
+   if (SupportsRealtime() && !forceModal) {
+      mUIDialog->Show();
+      // Return false to bypass effect processing
+      return 0;
+   }
+   return mUIDialog->ShowModal();
+}
+
+int Effect::ShowHostInterface(wxWindow &parent,
+   const EffectDialogFactory &factory,
+   std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
+   bool forceModal)
+{
+   if (!IsInteractive())
+      // Effect without UI just proceeds quietly to apply it destructively.
+      return wxID_APPLY;
+
+   if (mHostUIDialog)
+   {
+      // Realtime effect has shown its nonmodal dialog, now hides it, and does
+      // nothing else.
+      if ( mHostUIDialog->Close(true) )
+         mHostUIDialog = nullptr;
+      return 0;
+   }
+
+   // Create the dialog
+   // Host, not client, is responsible for invoking the factory and managing
+   // the lifetime of the dialog.
+   // The usual factory lets the client (which is this, when self-hosting)
+   // populate it.  That factory function is called indirectly through a
+   // std::function to avoid source code dependency cycles.
+   EffectUIClientInterface *const client = this;
+   auto results = factory(parent, *this, *client, access);
+   mHostUIDialog = results.pDialog;
+   pInstance = results.pInstance;
+   if (!mHostUIDialog)
+      return 0;
+
+   // Let the client show the dialog and decide whether to keep it open
+   auto result = client->ShowClientInterface(parent, *mHostUIDialog,
+      results.pValidator, forceModal);
+   if (mHostUIDialog && !mHostUIDialog->IsShown())
+      // Client didn't show it, or showed it modally and closed it
+      // So destroy it.
+      // (I think mHostUIDialog only needs to be a local variable in this
+      // function -- that it is always null when the function begins -- but
+      // that may change. PRL)
+      mHostUIDialog->Destroy();
+
+   return result;
+}
+
+bool Effect::VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
+{
+   Parameters().Visit(*this, visitor, settings);
+   return true;
+}
+
+bool Effect::VisitSettings(
+   ConstSettingsVisitor &visitor, const EffectSettings &settings) const
+{
+   Parameters().Visit(*this, visitor, settings);
+   return true;
+}
+
+bool Effect::SaveSettings(
+   const EffectSettings &settings, CommandParameters & parms) const
+{
+   Parameters().Get( *this, settings, parms );
+   return true;
+}
+
+bool Effect::LoadSettings(
+   const CommandParameters & parms, EffectSettings &settings) const
+{
+   // The first argument, and with it the const_cast, will disappear when
+   // all built-in effects are stateless.
+   return Parameters().Set( *const_cast<Effect*>(this), parms, settings );
+}
+
+OptionalMessage Effect::LoadUserPreset(
+   const RegistryPath & name, EffectSettings &settings) const
+{
+   // Find one string in the registry and then reinterpret it
+   // as complete settings
+   wxString parms;
+   if (!GetConfig(GetDefinition(), PluginSettings::Private,
+      name, wxT("Parameters"), parms))
+      return {};
+
+   return LoadSettingsFromString(parms, settings);
+}
+
+bool Effect::SaveUserPreset(
+   const RegistryPath & name, const EffectSettings &settings) const
+{
+   // Save all settings as a single string value in the registry
+   wxString parms;
+   if (!SaveSettingsAsString(settings, parms))
+      return false;
+
+   return SetConfig(GetDefinition(), PluginSettings::Private,
+      name, wxT("Parameters"), parms);
+}
+
+RegistryPaths Effect::GetFactoryPresets() const
+{
+   return {};
+}
+
+OptionalMessage Effect::LoadFactoryPreset(int id, EffectSettings &settings) const
+{
+   return { nullptr };
+}
+
+OptionalMessage Effect::LoadFactoryDefaults(EffectSettings &settings) const
+{
+   return LoadUserPreset(FactoryDefaultsGroup(), settings);
+}
+
+// EffectUIClientInterface implementation
+
+std::unique_ptr<EffectUIValidator> Effect::PopulateUI(ShuttleGui &S,
+   EffectInstance &instance, EffectSettingsAccess &access,
+   const EffectOutputs *pOutputs)
+{
+   auto parent = S.GetParent();
+   mUIParent = parent;
+
+//   LoadUserPreset(CurrentSettingsGroup());
+
+   // Let the effect subclass provide its own validator if it wants
+   auto result = PopulateOrExchange(S, instance, access, pOutputs);
+
+   mUIParent->SetMinSize(mUIParent->GetSizer()->GetMinSize());
+
+   if (!result) {
+      // No custom validator object?  Then use the default
+      result = std::make_unique<DefaultEffectUIValidator>(
+         *this, access, S.GetParent());
+      mUIParent->PushEventHandler(this);
+   }
+   return result;
+}
+
+bool Effect::IsGraphicalUI()
+{
+   return false;
+}
+
+bool Effect::ValidateUI(EffectSettings &)
+{
+   return true;
+}
+
+bool Effect::CloseUI()
+{
+   mUIParent = nullptr;
+   mUIDialog = nullptr;
+   return true;
+}
+
+bool Effect::CanExportPresets()
+{
+   return true;
+}
+
+static const FileNames::FileTypes &PresetTypes()
+{
+   static const FileNames::FileTypes result {
+      { XO("Presets"), { wxT("txt") }, true },
+      FileNames::AllFiles
+   };
+   return result;
+};
+
+void Effect::ExportPresets(const EffectSettings &settings) const
+{
+   wxString params;
+   SaveSettingsAsString(settings, params);
+   auto commandId = GetSquashedName(GetSymbol().Internal());
+   params =  commandId.GET() + ":" + params;
+
+   auto path = SelectFile(FileNames::Operation::Presets,
+                                     XO("Export Effect Parameters"),
+                                     wxEmptyString,
+                                     wxEmptyString,
+                                     wxEmptyString,
+                                     PresetTypes(),
+                                     wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
+                                     nullptr);
+   if (path.empty()) {
+      return;
+   }
+
+   // Create/Open the file
+   wxFFile f(path, wxT("wb"));
+   if (!f.IsOpened())
+   {
+      AudacityMessageBox(
+         XO("Could not open file: \"%s\"").Format( path ),
+         XO("Error Saving Effect Presets"),
+         wxICON_EXCLAMATION,
+         NULL);
+      return;
+   }
+
+   f.Write(params);
+   if (f.Error())
+   {
+      AudacityMessageBox(
+         XO("Error writing to file: \"%s\"").Format( path ),
+         XO("Error Saving Effect Presets"),
+         wxICON_EXCLAMATION,
+         NULL);
+   }
+
+   f.Close();
+
+
+   //SetWindowTitle();
+
+}
+
+OptionalMessage Effect::ImportPresets(EffectSettings &settings)
+{
+   wxString params;
+
+   auto path = SelectFile(FileNames::Operation::Presets,
+                                     XO("Import Effect Parameters"),
+                                     wxEmptyString,
+                                     wxEmptyString,
+                                     wxEmptyString,
+                                     PresetTypes(),
+                                     wxFD_OPEN | wxRESIZE_BORDER,
+                                     nullptr);
+   if (path.empty()) {
+      return {};
+   }
+
+   wxFFile f(path);
+   if (!f.IsOpened())
+      return {};
+
+   OptionalMessage result{};
+
+   if (f.ReadAll(&params)) {
+      wxString ident = params.BeforeFirst(':');
+      params = params.AfterFirst(':');
+
+      auto commandId = GetSquashedName(GetSymbol().Internal());
+
+      if (ident != commandId) {
+         // effect identifiers are a sensible length!
+         // must also have some params.
+         if ((params.Length() < 2 ) || (ident.Length() < 2) || (ident.Length() > 30))
+         {
+            Effect::MessageBox(
+               /* i18n-hint %s will be replaced by a file name */
+               XO("%s: is not a valid presets file.\n")
+               .Format(wxFileNameFromPath(path)));
+         }
+         else
+         {
+            Effect::MessageBox(
+               /* i18n-hint %s will be replaced by a file name */
+               XO("%s: is for a different Effect, Generator or Analyzer.\n")
+               .Format(wxFileNameFromPath(path)));
+         }
+         return {};
+      }
+      result = LoadSettingsFromString(params, settings);
+   }
+
+   //SetWindowTitle();
+
+   return result;
+}
+
+bool Effect::HasOptions()
+{
+   return false;
+}
+
+void Effect::ShowOptions()
+{
+}
+
+// EffectPlugin implementation
+
+const EffectSettingsManager& Effect::GetDefinition() const
+{
+   return *this;
+}
+
+NumericFormatSymbol Effect::GetSelectionFormat()
+{
+   if( !IsBatchProcessing() && FindProject() )
+      return ProjectSettings::Get( *FindProject() ).GetSelectionFormat();
+   return NumericConverter::HoursMinsSecondsFormat();
+}
+
+wxString Effect::GetSavedStateGroup()
+{
+   return wxT("SavedState");
+}
+
+// Effect implementation
+
+bool Effect::SaveSettingsAsString(
+   const EffectSettings &settings, wxString & parms) const
+{
+   CommandParameters eap;
+   ShuttleGetAutomation S;
+   S.mpEap = &eap;
+   if( VisitSettings( S, settings ) ){
+      ;// got eap value using VisitSettings.
+   }
+   // Won't be needed in future
+   else if (!SaveSettings(settings, eap))
+   {
+      return false;
+   }
+
+   return eap.GetParameters(parms);
+}
+
+OptionalMessage Effect::LoadSettingsFromString(
+   const wxString & parms, EffectSettings &settings) const
+{
+   // If the string starts with one of certain significant substrings,
+   // then the rest of the string is reinterpreted as part of a registry key,
+   // and a user or factory preset is then loaded.
+   // (Where did these prefixes come from?  See EffectPresetsDialog; and
+   // ultimately the uses of it by EffectManager::GetPreset, which is used by
+   // the macro management dialog)
+   wxString preset = parms;
+   OptionalMessage result;
+   if (preset.StartsWith(kUserPresetIdent))
+   {
+      preset.Replace(kUserPresetIdent, wxEmptyString, false);
+      result = LoadUserPreset(UserPresetsGroup(preset), settings);
+   }
+   else if (preset.StartsWith(kFactoryPresetIdent))
+   {
+      preset.Replace(kFactoryPresetIdent, wxEmptyString, false);
+      auto presets = GetFactoryPresets();
+      result = LoadFactoryPreset(
+         make_iterator_range( presets ).index( preset ), settings );
+   }
+   else if (preset.StartsWith(kCurrentSettingsIdent))
+   {
+      preset.Replace(kCurrentSettingsIdent, wxEmptyString, false);
+      result = LoadUserPreset(CurrentSettingsGroup(), settings);
+   }
+   else if (preset.StartsWith(kFactoryDefaultsIdent))
+   {
+      preset.Replace(kFactoryDefaultsIdent, wxEmptyString, false);
+      result = LoadUserPreset(FactoryDefaultsGroup(), settings);
+   }
+   else
+   {
+      // If the string did not start with any of the significant substrings,
+      // then use VisitSettings or LoadSettings to reinterpret it,
+      // or use LoadSettings.
+      // This interprets what was written by SaveSettings, above.
+      CommandParameters eap(parms);
+      ShuttleSetAutomation S;
+      S.SetForValidating( &eap );
+      // VisitSettings returns false if not defined for this effect.
+      // To do: fix const_cast in use of VisitSettings
+      if ( !const_cast<Effect*>(this)->VisitSettings(S, settings) ) {
+         // the old method...
+         if (LoadSettings(eap, settings))
+            return { nullptr };
+      }
+      else if( !S.bOK )
+         result = {};
+      else{
+         result = { nullptr };
+         S.SetForWriting( &eap );
+         const_cast<Effect*>(this)->VisitSettings(S, settings);
+      }
+   }
+
+   if (!result)
+   {
+      Effect::MessageBox(
+         XO("%s: Could not load settings below. Default settings will be used.\n\n%s")
+            .Format( GetName(), preset ) );
+      // We are using default settings and we still wish to continue.
+      result = { nullptr };
+      //return false;
+   }
+   return result;
+}
+
+unsigned Effect::TestUIFlags(unsigned mask) {
+   return mask & mUIFlags;
+}
+
+bool Effect::IsBatchProcessing() const
+{
+   return mIsBatch;
+}
+
+void Effect::SetBatchProcessing()
+{
+   mIsBatch = true;
+   // Save effect's internal state in a special registry path
+   // just for this purpose
+   // If effect is not stateful, this step doesn't really matter, and the
+   // settings object is a dummy
+   auto dummySettings = MakeSettings();
+   SaveUserPreset(GetSavedStateGroup(), dummySettings);
+}
+
+void Effect::UnsetBatchProcessing()
+{
+   mIsBatch = false;
+   // Restore effect's internal state from registry
+   // If effect is not stateful, this call doesn't really matter, and the
+   // settings object is a dummy
+   auto dummySettings = MakeSettings();
+   // Ignore failure
+   (void ) LoadUserPreset(GetSavedStateGroup(), dummySettings);
+}
+
+bool Effect::Delegate(Effect &delegate, EffectSettings &settings)
+{
+   NotifyingSelectedRegion region;
+   region.setTimes( mT0, mT1 );
+
+   return delegate.DoEffect(settings, mProjectRate, mTracks, mFactory,
+      region, mUIFlags, nullptr, nullptr, nullptr);
+}
+
+std::unique_ptr<EffectUIValidator> Effect::PopulateOrExchange(
+   ShuttleGui &, EffectInstance &, EffectSettingsAccess &,
+   const EffectOutputs *)
+{
+   return nullptr;
+}
+
+bool Effect::TransferDataToWindow(const EffectSettings &)
+{
+   return true;
+}
+
+bool Effect::TransferDataFromWindow(EffectSettings &)
+{
+   return true;
+}
+
+bool Effect::TotalProgress(double frac, const TranslatableString &msg) const
+{
+   auto updateResult = (mProgress ?
+      mProgress->Poll(frac * 1000, 1000, msg) :
+      ProgressResult::Success);
+   return (updateResult != ProgressResult::Success);
+}
+
+bool Effect::TrackProgress(
+   int whichTrack, double frac, const TranslatableString &msg) const
+{
+   auto updateResult = (mProgress ?
+      mProgress->Poll((whichTrack + frac) * 1000,
+         (double) mNumTracks * 1000, msg) :
+      ProgressResult::Success);
+   return (updateResult != ProgressResult::Success);
+}
+
+bool Effect::TrackGroupProgress(
+   int whichGroup, double frac, const TranslatableString &msg) const
+{
+   auto updateResult = (mProgress ?
+      mProgress->Poll((whichGroup + frac) * 1000,
+         (double) mNumGroups * 1000, msg) :
+      ProgressResult::Success);
+   return (updateResult != ProgressResult::Success);
+}
+
+void Effect::GetBounds(
+   const WaveTrack &track, const WaveTrack *pRight,
+   sampleCount *start, sampleCount *len)
+{
+   auto t0 = std::max( mT0, track.GetStartTime() );
+   auto t1 = std::min( mT1, track.GetEndTime() );
+
+   if ( pRight ) {
+      t0 = std::min( t0, std::max( mT0, pRight->GetStartTime() ) );
+      t1 = std::max( t1, std::min( mT1, pRight->GetEndTime() ) );
+   }
+
+   if (t1 > t0) {
+      *start = track.TimeToLongSamples(t0);
+      auto end = track.TimeToLongSamples(t1);
+      *len = end - *start;
+   }
+   else {
+      *start = 0;
+      *len = 0;
+   }
+}
+
+//
+// private methods
+//
+// Use this method to copy the input tracks to mOutputTracks, if
+// doing the processing on them, and replacing the originals only on success (and not cancel).
+// Copy the group tracks that have tracks selected
+// If not all sync-locked selected, then only selected wave tracks.
+void Effect::CopyInputTracks(bool allSyncLockSelected)
+{
+   // Reset map
+   mIMap.clear();
+   mOMap.clear();
+
+   mOutputTracks = TrackList::Create(
+      const_cast<AudacityProject*>( FindProject() ) // how to remove this const_cast?
+  );
+
+   auto trackRange = mTracks->Any() +
+      [&] (const Track *pTrack) {
+         return allSyncLockSelected
+         ? SyncLock::IsSelectedOrSyncLockSelected(pTrack)
+         : track_cast<const WaveTrack*>( pTrack ) && pTrack->GetSelected();
+      };
+
+   t2bHash added;
+
+   for (auto aTrack : trackRange)
+   {
+      Track *o = mOutputTracks->Add(aTrack->Duplicate());
+      mIMap.push_back(aTrack);
+      mOMap.push_back(o);
+   }
+}
+
+Track *Effect::AddToOutputTracks(const std::shared_ptr<Track> &t)
+{
+   mIMap.push_back(NULL);
+   mOMap.push_back(t.get());
+   return mOutputTracks->Add(t);
+}
+
+Effect::AddedAnalysisTrack::AddedAnalysisTrack(Effect *pEffect, const wxString &name)
+   : mpEffect(pEffect)
+{
+   if(!name.empty())
+      mpTrack = LabelTrack::Create(*pEffect->mTracks, name);
+   else
+      mpTrack = LabelTrack::Create(*pEffect->mTracks);
+}
+
+Effect::AddedAnalysisTrack::AddedAnalysisTrack(AddedAnalysisTrack &&that)
+{
+   mpEffect = that.mpEffect;
+   mpTrack = that.mpTrack;
+   that.Commit();
+}
+
+void Effect::AddedAnalysisTrack::Commit()
+{
+   mpEffect = nullptr;
+}
+
+Effect::AddedAnalysisTrack::~AddedAnalysisTrack()
+{
+   if (mpEffect) {
+      // not committed -- DELETE the label track
+      mpEffect->mTracks->Remove(mpTrack);
+   }
+}
+
+auto Effect::AddAnalysisTrack(const wxString &name) -> std::shared_ptr<AddedAnalysisTrack>
+{
+   return std::shared_ptr<AddedAnalysisTrack>
+      { safenew AddedAnalysisTrack{ this, name } };
+}
+
+Effect::ModifiedAnalysisTrack::ModifiedAnalysisTrack
+   (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name)
+   : mpEffect(pEffect)
+{
+   // copy LabelTrack here, so it can be undone on cancel
+   auto newTrack = pOrigTrack->Copy(pOrigTrack->GetStartTime(), pOrigTrack->GetEndTime());
+
+   mpTrack = static_cast<LabelTrack*>(newTrack.get());
+
+   // Why doesn't LabelTrack::Copy complete the job? :
+   mpTrack->SetOffset(pOrigTrack->GetStartTime());
+   if (!name.empty())
+      mpTrack->SetName(name);
+
+   // mpOrigTrack came from mTracks which we own but expose as const to subclasses
+   // So it's okay that we cast it back to const
+   mpOrigTrack =
+      pEffect->mTracks->Replace(const_cast<LabelTrack*>(pOrigTrack),
+         newTrack );
+}
+
+Effect::ModifiedAnalysisTrack::ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that)
+{
+   mpEffect = that.mpEffect;
+   mpTrack = that.mpTrack;
+   mpOrigTrack = std::move(that.mpOrigTrack);
+   that.Commit();
+}
+
+void Effect::ModifiedAnalysisTrack::Commit()
+{
+   mpEffect = nullptr;
+}
+
+Effect::ModifiedAnalysisTrack::~ModifiedAnalysisTrack()
+{
+   if (mpEffect) {
+      // not committed -- DELETE the label track
+      // mpOrigTrack came from mTracks which we own but expose as const to subclasses
+      // So it's okay that we cast it back to const
+      mpEffect->mTracks->Replace(mpTrack, mpOrigTrack);
+   }
+}
+
+auto Effect::ModifyAnalysisTrack
+   (const LabelTrack *pOrigTrack, const wxString &name) -> ModifiedAnalysisTrack
+{
+   return{ this, pOrigTrack, name };
+}
+
+bool Effect::CheckWhetherSkipEffect(const EffectSettings &) const
+{
+   return false;
+}
+
+double Effect::CalcPreviewInputLength(
+   const EffectSettings &, double previewLength) const
+{
+   return previewLength;
+}
+
+int Effect::MessageBox( const TranslatableString& message,
+   long style, const TranslatableString &titleStr) const
+{
+   auto title = titleStr.empty()
+      ? GetName()
+      : XO("%s: %s").Format( GetName(), titleStr );
+   return AudacityMessageBox( message, title, style, mUIParent );
+}
+EffectUIClientInterface* Effect::GetEffectUIClientInterface()
+{
+   return this;
+}
+
+DefaultEffectUIValidator::DefaultEffectUIValidator(
+   EffectUIClientInterface &effect, EffectSettingsAccess &access,
+   wxWindow *pParent)
+   : EffectUIValidator{ effect, access }, mpParent{ pParent }
+{
+}
+
+DefaultEffectUIValidator::~DefaultEffectUIValidator()
+{
+   Disconnect();
+}
+
+bool DefaultEffectUIValidator::ValidateUI()
+{
+   bool result {};
+   mAccess.ModifySettings([&](EffectSettings &settings){
+      result = mEffect.ValidateUI(settings);
+      return nullptr;
+   });
+   return result;
+}
+
+bool DefaultEffectUIValidator::IsGraphicalUI()
+{
+   return mEffect.IsGraphicalUI();
+}
+
+void DefaultEffectUIValidator::Disconnect()
+{
+   if (mpParent) {
+      mpParent->PopEventHandler();
+      mpParent = nullptr;
+   }
+}

--- a/src/effects/AnalysisTracks.cpp
+++ b/src/effects/AnalysisTracks.cpp
@@ -2,11 +2,13 @@
 
   Audacity: A Digital Audio Editor
 
-  Effect.cpp
+  AnalysisTracks.cpp
 
   Dominic Mazzoni
   Vaughan Johnson
   Martyn Shaw
+
+  Paul Licameli split from Effect.cpp
 
 *******************************************************************//**
 
@@ -14,701 +16,11 @@
 \brief Base class for many of the effects in Audacity.
 
 *//*******************************************************************/
-
-
+#include "AnalysisTracks.h"
 #include "Effect.h"
-
-#include <algorithm>
-
-#include <wx/defs.h>
-#include <wx/sizer.h>
-
-#include "ConfigInterface.h"
 #include "../LabelTrack.h"
-#include "../ProjectSettings.h"
-#include "../SelectFile.h"
-#include "../ShuttleAutomation.h"
-#include "../ShuttleGui.h"
-#include "../SyncLock.h"
-#include "ViewInfo.h"
-#include "WaveTrack.h"
-#include "wxFileNameWrapper.h"
-#include "../widgets/ProgressDialog.h"
-#include "../widgets/NumericTextCtrl.h"
-#include "../widgets/AudacityMessageBox.h"
-#include "../widgets/VetoDialogHook.h"
 
-#include <unordered_map>
-
-static const int kPlayID = 20102;
-static_assert(kPlayID == EffectUIValidator::kPlayID);
-
-using t2bHash = std::unordered_map< void*, bool >;
-
-bool StatefulEffect::Instance::Process(EffectSettings &settings)
-{
-   return GetEffect().Process(*this, settings);
-}
-
-auto StatefulEffect::Instance::GetLatency(const EffectSettings &, double) const
-   -> SampleCount
-{
-   return GetEffect().GetLatency().as_long_long();
-}
-
-size_t StatefulEffect::Instance::ProcessBlock(EffectSettings &,
-   const float *const *, float *const *, size_t)
-{
-   return 0;
-}
-
-Effect::Effect()
-{
-}
-
-Effect::~Effect()
-{
-   // Destroying what is usually the unique Effect object of its subclass,
-   // which lasts until the end of the session.
-   // Maybe there is a non-modal realtime dialog still open.
-   if (mHostUIDialog)
-      mHostUIDialog->Close();
-}
-
-// ComponentInterface implementation
-
-PluginPath Effect::GetPath() const
-{
-   return BUILTIN_EFFECT_PREFIX + GetSymbol().Internal();
-}
-
-ComponentInterfaceSymbol Effect::GetSymbol() const
-{
-   return {};
-}
-
-VendorSymbol Effect::GetVendor() const
-{
-   return XO("Audacity");
-}
-
-wxString Effect::GetVersion() const
-{
-   return AUDACITY_VERSION_STRING;
-}
-
-TranslatableString Effect::GetDescription() const
-{
-   return {};
-}
-
-// EffectDefinitionInterface implementation
-
-EffectType Effect::GetType() const
-{
-   return EffectTypeNone;
-}
-
-EffectFamilySymbol Effect::GetFamily() const
-{
-   // Unusually, the internal and visible strings differ for the built-in
-   // effect family.
-   return { wxT("Audacity"), XO("Built-in") };
-}
-
-bool Effect::IsInteractive() const
-{
-   return true;
-}
-
-bool Effect::IsDefault() const
-{
-   return true;
-}
-
-auto Effect::RealtimeSupport() const -> RealtimeSince
-{
-   return RealtimeSince::Never;
-}
-
-bool Effect::SupportsAutomation() const
-{
-   return true;
-}
-
-std::shared_ptr<EffectInstance> StatefulEffect::MakeInstance() const
-{
-   // Cheat with const-cast to return an object that calls through to
-   // non-const methods of a stateful effect.
-   // Stateless effects should override this function and be really const
-   // correct.
-   return std::make_shared<Instance>(const_cast<StatefulEffect&>(*this));
-}
-
-const EffectParameterMethods &Effect::Parameters() const
-{
-   static const CapturedParameters<Effect> empty;
-   return empty;
-}
-
-int Effect::ShowClientInterface(wxWindow &parent, wxDialog &dialog,
-   EffectUIValidator *, bool forceModal)
-{
-   // Remember the dialog with a weak pointer, but don't control its lifetime
-   mUIDialog = &dialog;
-   mUIDialog->Layout();
-   mUIDialog->Fit();
-   mUIDialog->SetMinSize(mUIDialog->GetSize());
-   if (VetoDialogHook::Call(mUIDialog))
-      return 0;
-   if (SupportsRealtime() && !forceModal) {
-      mUIDialog->Show();
-      // Return false to bypass effect processing
-      return 0;
-   }
-   return mUIDialog->ShowModal();
-}
-
-int Effect::ShowHostInterface(wxWindow &parent,
-   const EffectDialogFactory &factory,
-   std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
-   bool forceModal)
-{
-   if (!IsInteractive())
-      // Effect without UI just proceeds quietly to apply it destructively.
-      return wxID_APPLY;
-
-   if (mHostUIDialog)
-   {
-      // Realtime effect has shown its nonmodal dialog, now hides it, and does
-      // nothing else.
-      if ( mHostUIDialog->Close(true) )
-         mHostUIDialog = nullptr;
-      return 0;
-   }
-
-   // Create the dialog
-   // Host, not client, is responsible for invoking the factory and managing
-   // the lifetime of the dialog.
-   // The usual factory lets the client (which is this, when self-hosting)
-   // populate it.  That factory function is called indirectly through a
-   // std::function to avoid source code dependency cycles.
-   EffectUIClientInterface *const client = this;
-   auto results = factory(parent, *this, *client, access);
-   mHostUIDialog = results.pDialog;
-   pInstance = results.pInstance;
-   if (!mHostUIDialog)
-      return 0;
-
-   // Let the client show the dialog and decide whether to keep it open
-   auto result = client->ShowClientInterface(parent, *mHostUIDialog,
-      results.pValidator, forceModal);
-   if (mHostUIDialog && !mHostUIDialog->IsShown())
-      // Client didn't show it, or showed it modally and closed it
-      // So destroy it.
-      // (I think mHostUIDialog only needs to be a local variable in this
-      // function -- that it is always null when the function begins -- but
-      // that may change. PRL)
-      mHostUIDialog->Destroy();
-
-   return result;
-}
-
-bool Effect::VisitSettings(SettingsVisitor &visitor, EffectSettings &settings)
-{
-   Parameters().Visit(*this, visitor, settings);
-   return true;
-}
-
-bool Effect::VisitSettings(
-   ConstSettingsVisitor &visitor, const EffectSettings &settings) const
-{
-   Parameters().Visit(*this, visitor, settings);
-   return true;
-}
-
-bool Effect::SaveSettings(
-   const EffectSettings &settings, CommandParameters & parms) const
-{
-   Parameters().Get( *this, settings, parms );
-   return true;
-}
-
-bool Effect::LoadSettings(
-   const CommandParameters & parms, EffectSettings &settings) const
-{
-   // The first argument, and with it the const_cast, will disappear when
-   // all built-in effects are stateless.
-   return Parameters().Set( *const_cast<Effect*>(this), parms, settings );
-}
-
-OptionalMessage Effect::LoadUserPreset(
-   const RegistryPath & name, EffectSettings &settings) const
-{
-   // Find one string in the registry and then reinterpret it
-   // as complete settings
-   wxString parms;
-   if (!GetConfig(GetDefinition(), PluginSettings::Private,
-      name, wxT("Parameters"), parms))
-      return {};
-
-   return LoadSettingsFromString(parms, settings);
-}
-
-bool Effect::SaveUserPreset(
-   const RegistryPath & name, const EffectSettings &settings) const
-{
-   // Save all settings as a single string value in the registry
-   wxString parms;
-   if (!SaveSettingsAsString(settings, parms))
-      return false;
-
-   return SetConfig(GetDefinition(), PluginSettings::Private,
-      name, wxT("Parameters"), parms);
-}
-
-RegistryPaths Effect::GetFactoryPresets() const
-{
-   return {};
-}
-
-OptionalMessage Effect::LoadFactoryPreset(int id, EffectSettings &settings) const
-{
-   return { nullptr };
-}
-
-OptionalMessage Effect::LoadFactoryDefaults(EffectSettings &settings) const
-{
-   return LoadUserPreset(FactoryDefaultsGroup(), settings);
-}
-
-// EffectUIClientInterface implementation
-
-std::unique_ptr<EffectUIValidator> Effect::PopulateUI(ShuttleGui &S,
-   EffectInstance &instance, EffectSettingsAccess &access,
-   const EffectOutputs *pOutputs)
-{
-   auto parent = S.GetParent();
-   mUIParent = parent;
-
-//   LoadUserPreset(CurrentSettingsGroup());
-
-   // Let the effect subclass provide its own validator if it wants
-   auto result = PopulateOrExchange(S, instance, access, pOutputs);
-
-   mUIParent->SetMinSize(mUIParent->GetSizer()->GetMinSize());
-
-   if (!result) {
-      // No custom validator object?  Then use the default
-      result = std::make_unique<DefaultEffectUIValidator>(
-         *this, access, S.GetParent());
-      mUIParent->PushEventHandler(this);
-   }
-   return result;
-}
-
-bool Effect::IsGraphicalUI()
-{
-   return false;
-}
-
-bool Effect::ValidateUI(EffectSettings &)
-{
-   return true;
-}
-
-bool Effect::CloseUI()
-{
-   mUIParent = nullptr;
-   mUIDialog = nullptr;
-   return true;
-}
-
-bool Effect::CanExportPresets()
-{
-   return true;
-}
-
-static const FileNames::FileTypes &PresetTypes()
-{
-   static const FileNames::FileTypes result {
-      { XO("Presets"), { wxT("txt") }, true },
-      FileNames::AllFiles
-   };
-   return result;
-};
-
-void Effect::ExportPresets(const EffectSettings &settings) const
-{
-   wxString params;
-   SaveSettingsAsString(settings, params);
-   auto commandId = GetSquashedName(GetSymbol().Internal());
-   params =  commandId.GET() + ":" + params;
-
-   auto path = SelectFile(FileNames::Operation::Presets,
-                                     XO("Export Effect Parameters"),
-                                     wxEmptyString,
-                                     wxEmptyString,
-                                     wxEmptyString,
-                                     PresetTypes(),
-                                     wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
-                                     nullptr);
-   if (path.empty()) {
-      return;
-   }
-
-   // Create/Open the file
-   wxFFile f(path, wxT("wb"));
-   if (!f.IsOpened())
-   {
-      AudacityMessageBox(
-         XO("Could not open file: \"%s\"").Format( path ),
-         XO("Error Saving Effect Presets"),
-         wxICON_EXCLAMATION,
-         NULL);
-      return;
-   }
-
-   f.Write(params);
-   if (f.Error())
-   {
-      AudacityMessageBox(
-         XO("Error writing to file: \"%s\"").Format( path ),
-         XO("Error Saving Effect Presets"),
-         wxICON_EXCLAMATION,
-         NULL);
-   }
-
-   f.Close();
-
-
-   //SetWindowTitle();
-
-}
-
-OptionalMessage Effect::ImportPresets(EffectSettings &settings)
-{
-   wxString params;
-
-   auto path = SelectFile(FileNames::Operation::Presets,
-                                     XO("Import Effect Parameters"),
-                                     wxEmptyString,
-                                     wxEmptyString,
-                                     wxEmptyString,
-                                     PresetTypes(),
-                                     wxFD_OPEN | wxRESIZE_BORDER,
-                                     nullptr);
-   if (path.empty()) {
-      return {};
-   }
-
-   wxFFile f(path);
-   if (!f.IsOpened())
-      return {};
-
-   OptionalMessage result{};
-
-   if (f.ReadAll(&params)) {
-      wxString ident = params.BeforeFirst(':');
-      params = params.AfterFirst(':');
-
-      auto commandId = GetSquashedName(GetSymbol().Internal());
-
-      if (ident != commandId) {
-         // effect identifiers are a sensible length!
-         // must also have some params.
-         if ((params.Length() < 2 ) || (ident.Length() < 2) || (ident.Length() > 30))
-         {
-            Effect::MessageBox(
-               /* i18n-hint %s will be replaced by a file name */
-               XO("%s: is not a valid presets file.\n")
-               .Format(wxFileNameFromPath(path)));
-         }
-         else
-         {
-            Effect::MessageBox(
-               /* i18n-hint %s will be replaced by a file name */
-               XO("%s: is for a different Effect, Generator or Analyzer.\n")
-               .Format(wxFileNameFromPath(path)));
-         }
-         return {};
-      }
-      result = LoadSettingsFromString(params, settings);
-   }
-
-   //SetWindowTitle();
-
-   return result;
-}
-
-bool Effect::HasOptions()
-{
-   return false;
-}
-
-void Effect::ShowOptions()
-{
-}
-
-// EffectPlugin implementation
-
-const EffectSettingsManager& Effect::GetDefinition() const
-{
-   return *this;
-}
-
-NumericFormatSymbol Effect::GetSelectionFormat()
-{
-   if( !IsBatchProcessing() && FindProject() )
-      return ProjectSettings::Get( *FindProject() ).GetSelectionFormat();
-   return NumericConverter::HoursMinsSecondsFormat();
-}
-
-wxString Effect::GetSavedStateGroup()
-{
-   return wxT("SavedState");
-}
-
-// Effect implementation
-
-bool Effect::SaveSettingsAsString(
-   const EffectSettings &settings, wxString & parms) const
-{
-   CommandParameters eap;
-   ShuttleGetAutomation S;
-   S.mpEap = &eap;
-   if( VisitSettings( S, settings ) ){
-      ;// got eap value using VisitSettings.
-   }
-   // Won't be needed in future
-   else if (!SaveSettings(settings, eap))
-   {
-      return false;
-   }
-
-   return eap.GetParameters(parms);
-}
-
-OptionalMessage Effect::LoadSettingsFromString(
-   const wxString & parms, EffectSettings &settings) const
-{
-   // If the string starts with one of certain significant substrings,
-   // then the rest of the string is reinterpreted as part of a registry key,
-   // and a user or factory preset is then loaded.
-   // (Where did these prefixes come from?  See EffectPresetsDialog; and
-   // ultimately the uses of it by EffectManager::GetPreset, which is used by
-   // the macro management dialog)
-   wxString preset = parms;
-   OptionalMessage result;
-   if (preset.StartsWith(kUserPresetIdent))
-   {
-      preset.Replace(kUserPresetIdent, wxEmptyString, false);
-      result = LoadUserPreset(UserPresetsGroup(preset), settings);
-   }
-   else if (preset.StartsWith(kFactoryPresetIdent))
-   {
-      preset.Replace(kFactoryPresetIdent, wxEmptyString, false);
-      auto presets = GetFactoryPresets();
-      result = LoadFactoryPreset(
-         make_iterator_range( presets ).index( preset ), settings );
-   }
-   else if (preset.StartsWith(kCurrentSettingsIdent))
-   {
-      preset.Replace(kCurrentSettingsIdent, wxEmptyString, false);
-      result = LoadUserPreset(CurrentSettingsGroup(), settings);
-   }
-   else if (preset.StartsWith(kFactoryDefaultsIdent))
-   {
-      preset.Replace(kFactoryDefaultsIdent, wxEmptyString, false);
-      result = LoadUserPreset(FactoryDefaultsGroup(), settings);
-   }
-   else
-   {
-      // If the string did not start with any of the significant substrings,
-      // then use VisitSettings or LoadSettings to reinterpret it,
-      // or use LoadSettings.
-      // This interprets what was written by SaveSettings, above.
-      CommandParameters eap(parms);
-      ShuttleSetAutomation S;
-      S.SetForValidating( &eap );
-      // VisitSettings returns false if not defined for this effect.
-      // To do: fix const_cast in use of VisitSettings
-      if ( !const_cast<Effect*>(this)->VisitSettings(S, settings) ) {
-         // the old method...
-         if (LoadSettings(eap, settings))
-            return { nullptr };
-      }
-      else if( !S.bOK )
-         result = {};
-      else{
-         result = { nullptr };
-         S.SetForWriting( &eap );
-         const_cast<Effect*>(this)->VisitSettings(S, settings);
-      }
-   }
-
-   if (!result)
-   {
-      Effect::MessageBox(
-         XO("%s: Could not load settings below. Default settings will be used.\n\n%s")
-            .Format( GetName(), preset ) );
-      // We are using default settings and we still wish to continue.
-      result = { nullptr };
-      //return false;
-   }
-   return result;
-}
-
-unsigned Effect::TestUIFlags(unsigned mask) {
-   return mask & mUIFlags;
-}
-
-bool Effect::IsBatchProcessing() const
-{
-   return mIsBatch;
-}
-
-void Effect::SetBatchProcessing()
-{
-   mIsBatch = true;
-   // Save effect's internal state in a special registry path
-   // just for this purpose
-   // If effect is not stateful, this step doesn't really matter, and the
-   // settings object is a dummy
-   auto dummySettings = MakeSettings();
-   SaveUserPreset(GetSavedStateGroup(), dummySettings);
-}
-
-void Effect::UnsetBatchProcessing()
-{
-   mIsBatch = false;
-   // Restore effect's internal state from registry
-   // If effect is not stateful, this call doesn't really matter, and the
-   // settings object is a dummy
-   auto dummySettings = MakeSettings();
-   // Ignore failure
-   (void ) LoadUserPreset(GetSavedStateGroup(), dummySettings);
-}
-
-bool Effect::Delegate(Effect &delegate, EffectSettings &settings)
-{
-   NotifyingSelectedRegion region;
-   region.setTimes( mT0, mT1 );
-
-   return delegate.DoEffect(settings, mProjectRate, mTracks, mFactory,
-      region, mUIFlags, nullptr, nullptr, nullptr);
-}
-
-std::unique_ptr<EffectUIValidator> Effect::PopulateOrExchange(
-   ShuttleGui &, EffectInstance &, EffectSettingsAccess &,
-   const EffectOutputs *)
-{
-   return nullptr;
-}
-
-bool Effect::TransferDataToWindow(const EffectSettings &)
-{
-   return true;
-}
-
-bool Effect::TransferDataFromWindow(EffectSettings &)
-{
-   return true;
-}
-
-bool Effect::TotalProgress(double frac, const TranslatableString &msg) const
-{
-   auto updateResult = (mProgress ?
-      mProgress->Poll(frac * 1000, 1000, msg) :
-      ProgressResult::Success);
-   return (updateResult != ProgressResult::Success);
-}
-
-bool Effect::TrackProgress(
-   int whichTrack, double frac, const TranslatableString &msg) const
-{
-   auto updateResult = (mProgress ?
-      mProgress->Poll((whichTrack + frac) * 1000,
-         (double) mNumTracks * 1000, msg) :
-      ProgressResult::Success);
-   return (updateResult != ProgressResult::Success);
-}
-
-bool Effect::TrackGroupProgress(
-   int whichGroup, double frac, const TranslatableString &msg) const
-{
-   auto updateResult = (mProgress ?
-      mProgress->Poll((whichGroup + frac) * 1000,
-         (double) mNumGroups * 1000, msg) :
-      ProgressResult::Success);
-   return (updateResult != ProgressResult::Success);
-}
-
-void Effect::GetBounds(
-   const WaveTrack &track, const WaveTrack *pRight,
-   sampleCount *start, sampleCount *len)
-{
-   auto t0 = std::max( mT0, track.GetStartTime() );
-   auto t1 = std::min( mT1, track.GetEndTime() );
-
-   if ( pRight ) {
-      t0 = std::min( t0, std::max( mT0, pRight->GetStartTime() ) );
-      t1 = std::max( t1, std::min( mT1, pRight->GetEndTime() ) );
-   }
-
-   if (t1 > t0) {
-      *start = track.TimeToLongSamples(t0);
-      auto end = track.TimeToLongSamples(t1);
-      *len = end - *start;
-   }
-   else {
-      *start = 0;
-      *len = 0;
-   }
-}
-
-//
-// private methods
-//
-// Use this method to copy the input tracks to mOutputTracks, if
-// doing the processing on them, and replacing the originals only on success (and not cancel).
-// Copy the group tracks that have tracks selected
-// If not all sync-locked selected, then only selected wave tracks.
-void Effect::CopyInputTracks(bool allSyncLockSelected)
-{
-   // Reset map
-   mIMap.clear();
-   mOMap.clear();
-
-   mOutputTracks = TrackList::Create(
-      const_cast<AudacityProject*>( FindProject() ) // how to remove this const_cast?
-  );
-
-   auto trackRange = mTracks->Any() +
-      [&] (const Track *pTrack) {
-         return allSyncLockSelected
-         ? SyncLock::IsSelectedOrSyncLockSelected(pTrack)
-         : track_cast<const WaveTrack*>( pTrack ) && pTrack->GetSelected();
-      };
-
-   t2bHash added;
-
-   for (auto aTrack : trackRange)
-   {
-      Track *o = mOutputTracks->Add(aTrack->Duplicate());
-      mIMap.push_back(aTrack);
-      mOMap.push_back(o);
-   }
-}
-
-Track *Effect::AddToOutputTracks(const std::shared_ptr<Track> &t)
-{
-   mIMap.push_back(NULL);
-   mOMap.push_back(t.get());
-   return mOutputTracks->Add(t);
-}
-
-Effect::AddedAnalysisTrack::AddedAnalysisTrack(Effect *pEffect, const wxString &name)
+AddedAnalysisTrack::AddedAnalysisTrack(Effect *pEffect, const wxString &name)
    : mpEffect(pEffect)
 {
    if(!name.empty())
@@ -717,19 +29,19 @@ Effect::AddedAnalysisTrack::AddedAnalysisTrack(Effect *pEffect, const wxString &
       mpTrack = LabelTrack::Create(*pEffect->mTracks);
 }
 
-Effect::AddedAnalysisTrack::AddedAnalysisTrack(AddedAnalysisTrack &&that)
+AddedAnalysisTrack::AddedAnalysisTrack(AddedAnalysisTrack &&that)
 {
    mpEffect = that.mpEffect;
    mpTrack = that.mpTrack;
    that.Commit();
 }
 
-void Effect::AddedAnalysisTrack::Commit()
+void AddedAnalysisTrack::Commit()
 {
    mpEffect = nullptr;
 }
 
-Effect::AddedAnalysisTrack::~AddedAnalysisTrack()
+AddedAnalysisTrack::~AddedAnalysisTrack()
 {
    if (mpEffect) {
       // not committed -- DELETE the label track
@@ -737,13 +49,14 @@ Effect::AddedAnalysisTrack::~AddedAnalysisTrack()
    }
 }
 
-auto Effect::AddAnalysisTrack(const wxString &name) -> std::shared_ptr<AddedAnalysisTrack>
+std::shared_ptr<AddedAnalysisTrack> AddAnalysisTrack(
+   Effect &effect, const wxString &name)
 {
    return std::shared_ptr<AddedAnalysisTrack>
-      { safenew AddedAnalysisTrack{ this, name } };
+      { safenew AddedAnalysisTrack{ &effect, name } };
 }
 
-Effect::ModifiedAnalysisTrack::ModifiedAnalysisTrack
+ModifiedAnalysisTrack::ModifiedAnalysisTrack
    (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name)
    : mpEffect(pEffect)
 {
@@ -764,7 +77,7 @@ Effect::ModifiedAnalysisTrack::ModifiedAnalysisTrack
          newTrack );
 }
 
-Effect::ModifiedAnalysisTrack::ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that)
+ModifiedAnalysisTrack::ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that)
 {
    mpEffect = that.mpEffect;
    mpTrack = that.mpTrack;
@@ -772,12 +85,12 @@ Effect::ModifiedAnalysisTrack::ModifiedAnalysisTrack(ModifiedAnalysisTrack &&tha
    that.Commit();
 }
 
-void Effect::ModifiedAnalysisTrack::Commit()
+void ModifiedAnalysisTrack::Commit()
 {
    mpEffect = nullptr;
 }
 
-Effect::ModifiedAnalysisTrack::~ModifiedAnalysisTrack()
+ModifiedAnalysisTrack::~ModifiedAnalysisTrack()
 {
    if (mpEffect) {
       // not committed -- DELETE the label track
@@ -787,67 +100,8 @@ Effect::ModifiedAnalysisTrack::~ModifiedAnalysisTrack()
    }
 }
 
-auto Effect::ModifyAnalysisTrack
-   (const LabelTrack *pOrigTrack, const wxString &name) -> ModifiedAnalysisTrack
+ModifiedAnalysisTrack ModifyAnalysisTrack(
+   Effect &effect, const LabelTrack *pOrigTrack, const wxString &name)
 {
-   return{ this, pOrigTrack, name };
-}
-
-bool Effect::CheckWhetherSkipEffect(const EffectSettings &) const
-{
-   return false;
-}
-
-double Effect::CalcPreviewInputLength(
-   const EffectSettings &, double previewLength) const
-{
-   return previewLength;
-}
-
-int Effect::MessageBox( const TranslatableString& message,
-   long style, const TranslatableString &titleStr) const
-{
-   auto title = titleStr.empty()
-      ? GetName()
-      : XO("%s: %s").Format( GetName(), titleStr );
-   return AudacityMessageBox( message, title, style, mUIParent );
-}
-EffectUIClientInterface* Effect::GetEffectUIClientInterface()
-{
-   return this;
-}
-
-DefaultEffectUIValidator::DefaultEffectUIValidator(
-   EffectUIClientInterface &effect, EffectSettingsAccess &access,
-   wxWindow *pParent)
-   : EffectUIValidator{ effect, access }, mpParent{ pParent }
-{
-}
-
-DefaultEffectUIValidator::~DefaultEffectUIValidator()
-{
-   Disconnect();
-}
-
-bool DefaultEffectUIValidator::ValidateUI()
-{
-   bool result {};
-   mAccess.ModifySettings([&](EffectSettings &settings){
-      result = mEffect.ValidateUI(settings);
-      return nullptr;
-   });
-   return result;
-}
-
-bool DefaultEffectUIValidator::IsGraphicalUI()
-{
-   return mEffect.IsGraphicalUI();
-}
-
-void DefaultEffectUIValidator::Disconnect()
-{
-   if (mpParent) {
-      mpParent->PopEventHandler();
-      mpParent = nullptr;
-   }
+   return{ &effect, pOrigTrack, name };
 }

--- a/src/effects/AnalysisTracks.h
+++ b/src/effects/AnalysisTracks.h
@@ -1,0 +1,370 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Effect.h
+
+  Dominic Mazzoni
+  Vaughan Johnson
+
+**********************************************************************/
+
+#ifndef __AUDACITY_EFFECT__
+#define __AUDACITY_EFFECT__
+
+#include "EffectBase.h"
+
+#include "StatefulEffectBase.h"
+
+#define BUILTIN_EFFECT_PREFIX wxT("Built-in Effect: ")
+
+class EffectParameterMethods;
+class LabelTrack;
+class WaveTrack;
+
+class sampleCount;
+
+//! Default implementation of EffectUIValidator invokes ValidateUI
+//! and IsGraphicalUI methods of an EffectUIClientInterface
+/*
+ Also pops the even handler stack of a window, if given to the contructor
+
+ This is a transitional class; it should be eliminated when all effect classes
+ define their own associated subclasses of EffectUIValidator, which can hold
+ state only for the lifetime of a dialog, so the effect object need not hold it
+*/
+class DefaultEffectUIValidator
+   : public EffectUIValidator
+   // Inherit wxEvtHandler so that Un-Bind()-ing is automatic in the destructor
+   , protected wxEvtHandler
+{
+public:
+   /*!
+    @param pParent if not null, caller will push an event handler onto this
+    window; then this object is responsible to pop it
+    */
+   DefaultEffectUIValidator(
+      EffectUIClientInterface &effect, EffectSettingsAccess &access,
+      wxWindow *pParent = nullptr);
+   //! Calls Disconnect
+   ~DefaultEffectUIValidator() override;
+   //! Calls mEffect.ValidateUI()
+   bool ValidateUI() override;
+   //! @return mEffect.IsGraphicalUI()
+   bool IsGraphicalUI() override;
+   void Disconnect() override;
+protected:
+   wxWindow *mpParent{};
+};
+
+class AUDACITY_DLL_API Effect /* not final */
+   : public wxEvtHandler
+   , public EffectBase
+{
+ //
+ // public methods
+ //
+ // Used by the outside program to determine properties of an effect and
+ // apply the effect to one or more tracks.
+ //
+ public:
+   static inline Effect *FetchParameters(Effect &e, EffectSettings &)
+   { return &e; }
+
+   // The constructor is called once by each subclass at the beginning of the program.
+   // Avoid allocating memory or doing time-consuming processing here.
+   Effect();
+   virtual ~Effect();
+
+   // ComponentInterface implementation
+
+   PluginPath GetPath() const override;
+   bool VisitSettings(
+      SettingsVisitor &visitor, EffectSettings &settings) override;
+   bool VisitSettings(
+      ConstSettingsVisitor &visitor, const EffectSettings &settings)
+      const override;
+
+   ComponentInterfaceSymbol GetSymbol() const override;
+
+   VendorSymbol GetVendor() const override;
+   wxString GetVersion() const override;
+   TranslatableString GetDescription() const override;
+
+   // EffectDefinitionInterface implementation
+
+   EffectType GetType() const override;
+   EffectFamilySymbol GetFamily() const override;
+   bool IsInteractive() const override;
+   bool IsDefault() const override;
+   RealtimeSince RealtimeSupport() const override;
+   bool SupportsAutomation() const override;
+
+   bool SaveSettings(
+      const EffectSettings &settings, CommandParameters & parms) const override;
+   bool LoadSettings(
+      const CommandParameters & parms, EffectSettings &settings) const override;
+
+   OptionalMessage LoadUserPreset(
+      const RegistryPath & name, EffectSettings &settings) const override;
+   bool SaveUserPreset(
+      const RegistryPath & name, const EffectSettings &settings) const override;
+
+   RegistryPaths GetFactoryPresets() const override;
+   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
+      const override;
+   OptionalMessage LoadFactoryDefaults(EffectSettings &settings)
+      const override;
+
+   // VisitSettings(), SaveSettings(), and LoadSettings()
+   // use the functions of EffectParameterMethods.  By default, this function
+   // defines an empty list of parameters.
+   virtual const EffectParameterMethods &Parameters() const;
+
+   int ShowClientInterface(wxWindow &parent, wxDialog &dialog,
+      EffectUIValidator *pValidator, bool forceModal) override;
+
+   EffectUIClientInterface* GetEffectUIClientInterface() override;
+
+   // EffectUIClientInterface implementation
+
+   std::unique_ptr<EffectUIValidator> PopulateUI(
+      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access,
+      const EffectOutputs *pOutputs) override;
+   //! @return false
+   bool IsGraphicalUI() override;
+   bool ValidateUI(EffectSettings &) override;
+   bool CloseUI() override;
+
+   bool CanExportPresets() override;
+   void ExportPresets(const EffectSettings &settings) const override;
+   OptionalMessage ImportPresets(EffectSettings &settings) override;
+
+   bool HasOptions() override;
+   void ShowOptions() override;
+
+   // EffectPlugin implementation
+
+   const EffectSettingsManager& GetDefinition() const override;
+   virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar
+
+   // EffectPlugin implementation
+
+   int ShowHostInterface( wxWindow &parent,
+      const EffectDialogFactory &factory,
+      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
+      bool forceModal = false) override;
+   bool SaveSettingsAsString(
+      const EffectSettings &settings, wxString & parms) const override;
+   [[nodiscard]] OptionalMessage LoadSettingsFromString(
+      const wxString & parms, EffectSettings &settings) const override;
+   bool IsBatchProcessing() const override;
+   void SetBatchProcessing() override;
+   void UnsetBatchProcessing() override;
+   bool TransferDataToWindow(const EffectSettings &settings) override;
+   bool TransferDataFromWindow(EffectSettings &settings) override;
+
+   // Effect implementation
+
+   unsigned TestUIFlags(unsigned mask);
+
+   //! Re-invoke DoEffect on another Effect object that implements the work
+   bool Delegate(Effect &delegate, EffectSettings &settings);
+
+   // Display a message box, using effect's (translated) name as the prefix
+   // for the title.
+   enum : long { DefaultMessageBoxStyle = wxOK | wxCENTRE };
+   int MessageBox(const TranslatableString& message,
+                  long style = DefaultMessageBoxStyle,
+                  const TranslatableString& titleStr = {}) const;
+
+   static void IncEffectCounter(){ nEffectsDone++;}
+
+protected:
+
+   //! Default implementation returns false
+   bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
+
+   //! Default implementation returns `previewLength`
+   double CalcPreviewInputLength(
+      const EffectSettings &settings, double previewLength) const override;
+
+   //! Add controls to effect panel; always succeeds
+   /*!
+    @return if not null, then return it from Effect::PopulateUI instead of a
+    DefaultEffectUIValidator; default implementation returns null
+    */
+   virtual std::unique_ptr<EffectUIValidator> PopulateOrExchange(
+      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access,
+      const EffectOutputs *pOutputs);
+
+   // No more virtuals!
+
+   // The Progress methods all return true if the user has cancelled;
+   // you should exit immediately if this happens (cleaning up memory
+   // is okay, but don't try to undo).
+
+   // Pass a fraction between 0.0 and 1.0
+   bool TotalProgress(double frac, const TranslatableString & = {}) const;
+
+   // Pass a fraction between 0.0 and 1.0, for the current track
+   // (when doing one track at a time)
+   bool TrackProgress(
+      int whichTrack, double frac, const TranslatableString & = {}) const;
+
+   // Pass a fraction between 0.0 and 1.0, for the current track group
+   // (when doing stereo groups at a time)
+   bool TrackGroupProgress(
+      int whichGroup, double frac, const TranslatableString & = {}) const;
+
+   int GetNumWaveTracks() const { return mNumTracks; }
+   int GetNumWaveGroups() const { return mNumGroups; }
+
+   // Calculates the start time and length in samples for one or two channels
+   void GetBounds(
+      const WaveTrack &track, const WaveTrack *pRight,
+      sampleCount *start, sampleCount *len);
+
+   // Use this method to copy the input tracks to mOutputTracks, if
+   // doing the processing on them, and replacing the originals only on success (and not cancel).
+   // If not all sync-locked selected, then only selected wave tracks.
+   void CopyInputTracks(bool allSyncLockSelected = false);
+
+   // For the use of analyzers, which don't need to make output wave tracks,
+   // but may need to add label tracks.
+   class AUDACITY_DLL_API AddedAnalysisTrack {
+      friend Effect;
+      AddedAnalysisTrack(Effect *pEffect, const wxString &name);
+      AddedAnalysisTrack(const AddedAnalysisTrack&) PROHIBITED;
+
+   public:
+
+      AddedAnalysisTrack() {}
+
+      // So you can have a vector of them
+      AddedAnalysisTrack(AddedAnalysisTrack &&that);
+
+      LabelTrack *get() const { return mpTrack; }
+
+      // Call this to indicate successful completion of the analyzer.
+      void Commit();
+
+      // Destructor undoes the addition of the analysis track if not committed.
+      ~AddedAnalysisTrack();
+
+   private:
+      Effect *mpEffect{};
+      LabelTrack *mpTrack{};
+   };
+
+   // Set name to given value if that is not empty, else use default name
+   std::shared_ptr<AddedAnalysisTrack> AddAnalysisTrack(const wxString &name = wxString());
+
+   // For the use of analyzers, which don't need to make output wave tracks,
+   // but may need to modify label tracks.
+   class AUDACITY_DLL_API ModifiedAnalysisTrack {
+      friend Effect;
+      ModifiedAnalysisTrack
+         (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name);
+      ModifiedAnalysisTrack(const ModifiedAnalysisTrack&) PROHIBITED;
+
+   public:
+
+      ModifiedAnalysisTrack();
+
+      // So you can have a vector of them
+      ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that);
+
+      LabelTrack *get() const { return mpTrack; }
+
+      // Call this to indicate successful completion of the analyzer.
+      void Commit();
+
+      // Destructor undoes the modification of the analysis track if not committed.
+      ~ModifiedAnalysisTrack();
+
+   private:
+      Effect *mpEffect{};
+      LabelTrack *mpTrack{};
+      std::shared_ptr<Track> mpOrigTrack{};
+   };
+
+   // Set name to given value if that is not empty, else use default name
+   ModifiedAnalysisTrack ModifyAnalysisTrack
+      (const LabelTrack *pOrigTrack, const wxString &name = wxString());
+
+   // Use this to append a NEW output track.
+   Track *AddToOutputTracks(const std::shared_ptr<Track> &t);
+
+protected:
+   // UI
+   //! This smart pointer tracks the lifetime of the dialog
+   wxWeakRef<wxDialog> mHostUIDialog;
+
+private:
+   wxWindow       *mUIParent{};
+   wxString GetSavedStateGroup();
+
+   bool mIsBatch{ false };
+};
+
+//! Convenience for generating EffectDefinitionInterface overrides
+//! and static down-casting functions
+template<typename Settings, typename Base>
+class EffectWithSettings : public Base {
+public:
+   EffectSettings MakeSettings() const override
+   {
+      return EffectSettings::Make<Settings>();
+   }
+   bool CopySettingsContents(
+      const EffectSettings &src, EffectSettings &dst) const override
+   {
+      return EffectSettings::Copy<Settings>(src, dst);
+   }
+   //! Assume settings originated from MakeSettings() and copies thereof
+   static inline Settings &GetSettings(EffectSettings &settings)
+   {
+      auto pSettings = settings.cast<Settings>();
+      assert(pSettings);
+      return *pSettings;
+   }
+   //! Assume settings originated from MakeSettings() and copies thereof
+   static inline const Settings &GetSettings(const EffectSettings &settings)
+   {
+      return GetSettings(const_cast<EffectSettings &>(settings));
+   }
+   static inline Settings *
+   FetchParameters(Base &, EffectSettings &s) {
+      return &GetSettings(s);
+   }
+};
+
+//! Subclass of Effect, to be eliminated after all of its subclasses
+//! are rewritten to be stateless
+class StatefulEffect
+   : public StatefulEffectBase
+   , public Effect
+{
+public:
+   class AUDACITY_DLL_API Instance : public StatefulEffectBase::Instance {
+   public:
+      using StatefulEffectBase::Instance::Instance;
+      bool Process(EffectSettings &settings) override;
+      SampleCount GetLatency(
+         const EffectSettings &settings, double sampleRate) const override;
+      //! Default implementation fails (returns 0 always)
+      size_t ProcessBlock(EffectSettings &settings,
+         const float *const *inBlock, float *const *outBlock, size_t blockLen)
+      override;
+   };
+   std::shared_ptr<EffectInstance> MakeInstance() const override;
+};
+
+// FIXME:
+// FIXME:  Remove this once all effects are using the NEW dialog
+// FIXME:
+
+#define ID_EFFECT_PREVIEW ePreviewID
+
+#endif

--- a/src/effects/AnalysisTracks.h
+++ b/src/effects/AnalysisTracks.h
@@ -2,369 +2,82 @@
 
   Audacity: A Digital Audio Editor
 
-  Effect.h
+  AnalysisTracks.h
 
   Dominic Mazzoni
   Vaughan Johnson
 
+  Paul Licameli split from Effect.h
+
 **********************************************************************/
+#ifndef __AUDACITY_ANALYSIS_TRACKS__
+#define __AUDACITY_ANALYSIS_TRACKS__
 
-#ifndef __AUDACITY_EFFECT__
-#define __AUDACITY_EFFECT__
+#include <wx/string.h>
+#include <memory>
 
-#include "EffectBase.h"
-
-#include "StatefulEffectBase.h"
-
-#define BUILTIN_EFFECT_PREFIX wxT("Built-in Effect: ")
-
-class EffectParameterMethods;
+class Effect;
 class LabelTrack;
-class WaveTrack;
+class Track;
 
-class sampleCount;
+// For the use of analyzers, which don't need to make output wave tracks,
+// but may need to add label tracks.
+class AUDACITY_DLL_API AddedAnalysisTrack {
+   AddedAnalysisTrack(const AddedAnalysisTrack&) = delete;
 
-//! Default implementation of EffectUIValidator invokes ValidateUI
-//! and IsGraphicalUI methods of an EffectUIClientInterface
-/*
- Also pops the even handler stack of a window, if given to the contructor
-
- This is a transitional class; it should be eliminated when all effect classes
- define their own associated subclasses of EffectUIValidator, which can hold
- state only for the lifetime of a dialog, so the effect object need not hold it
-*/
-class DefaultEffectUIValidator
-   : public EffectUIValidator
-   // Inherit wxEvtHandler so that Un-Bind()-ing is automatic in the destructor
-   , protected wxEvtHandler
-{
 public:
-   /*!
-    @param pParent if not null, caller will push an event handler onto this
-    window; then this object is responsible to pop it
-    */
-   DefaultEffectUIValidator(
-      EffectUIClientInterface &effect, EffectSettingsAccess &access,
-      wxWindow *pParent = nullptr);
-   //! Calls Disconnect
-   ~DefaultEffectUIValidator() override;
-   //! Calls mEffect.ValidateUI()
-   bool ValidateUI() override;
-   //! @return mEffect.IsGraphicalUI()
-   bool IsGraphicalUI() override;
-   void Disconnect() override;
-protected:
-   wxWindow *mpParent{};
-};
+   AddedAnalysisTrack(Effect *pEffect, const wxString &name);
+   AddedAnalysisTrack() {}
 
-class AUDACITY_DLL_API Effect /* not final */
-   : public wxEvtHandler
-   , public EffectBase
-{
- //
- // public methods
- //
- // Used by the outside program to determine properties of an effect and
- // apply the effect to one or more tracks.
- //
- public:
-   static inline Effect *FetchParameters(Effect &e, EffectSettings &)
-   { return &e; }
+   // So you can have a vector of them
+   AddedAnalysisTrack(AddedAnalysisTrack &&that);
 
-   // The constructor is called once by each subclass at the beginning of the program.
-   // Avoid allocating memory or doing time-consuming processing here.
-   Effect();
-   virtual ~Effect();
+   LabelTrack *get() const { return mpTrack; }
 
-   // ComponentInterface implementation
+   // Call this to indicate successful completion of the analyzer.
+   void Commit();
 
-   PluginPath GetPath() const override;
-   bool VisitSettings(
-      SettingsVisitor &visitor, EffectSettings &settings) override;
-   bool VisitSettings(
-      ConstSettingsVisitor &visitor, const EffectSettings &settings)
-      const override;
-
-   ComponentInterfaceSymbol GetSymbol() const override;
-
-   VendorSymbol GetVendor() const override;
-   wxString GetVersion() const override;
-   TranslatableString GetDescription() const override;
-
-   // EffectDefinitionInterface implementation
-
-   EffectType GetType() const override;
-   EffectFamilySymbol GetFamily() const override;
-   bool IsInteractive() const override;
-   bool IsDefault() const override;
-   RealtimeSince RealtimeSupport() const override;
-   bool SupportsAutomation() const override;
-
-   bool SaveSettings(
-      const EffectSettings &settings, CommandParameters & parms) const override;
-   bool LoadSettings(
-      const CommandParameters & parms, EffectSettings &settings) const override;
-
-   OptionalMessage LoadUserPreset(
-      const RegistryPath & name, EffectSettings &settings) const override;
-   bool SaveUserPreset(
-      const RegistryPath & name, const EffectSettings &settings) const override;
-
-   RegistryPaths GetFactoryPresets() const override;
-   OptionalMessage LoadFactoryPreset(int id, EffectSettings &settings)
-      const override;
-   OptionalMessage LoadFactoryDefaults(EffectSettings &settings)
-      const override;
-
-   // VisitSettings(), SaveSettings(), and LoadSettings()
-   // use the functions of EffectParameterMethods.  By default, this function
-   // defines an empty list of parameters.
-   virtual const EffectParameterMethods &Parameters() const;
-
-   int ShowClientInterface(wxWindow &parent, wxDialog &dialog,
-      EffectUIValidator *pValidator, bool forceModal) override;
-
-   EffectUIClientInterface* GetEffectUIClientInterface() override;
-
-   // EffectUIClientInterface implementation
-
-   std::unique_ptr<EffectUIValidator> PopulateUI(
-      ShuttleGui &S, EffectInstance &instance, EffectSettingsAccess &access,
-      const EffectOutputs *pOutputs) override;
-   //! @return false
-   bool IsGraphicalUI() override;
-   bool ValidateUI(EffectSettings &) override;
-   bool CloseUI() override;
-
-   bool CanExportPresets() override;
-   void ExportPresets(const EffectSettings &settings) const override;
-   OptionalMessage ImportPresets(EffectSettings &settings) override;
-
-   bool HasOptions() override;
-   void ShowOptions() override;
-
-   // EffectPlugin implementation
-
-   const EffectSettingsManager& GetDefinition() const override;
-   virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar
-
-   // EffectPlugin implementation
-
-   int ShowHostInterface( wxWindow &parent,
-      const EffectDialogFactory &factory,
-      std::shared_ptr<EffectInstance> &pInstance, EffectSettingsAccess &access,
-      bool forceModal = false) override;
-   bool SaveSettingsAsString(
-      const EffectSettings &settings, wxString & parms) const override;
-   [[nodiscard]] OptionalMessage LoadSettingsFromString(
-      const wxString & parms, EffectSettings &settings) const override;
-   bool IsBatchProcessing() const override;
-   void SetBatchProcessing() override;
-   void UnsetBatchProcessing() override;
-   bool TransferDataToWindow(const EffectSettings &settings) override;
-   bool TransferDataFromWindow(EffectSettings &settings) override;
-
-   // Effect implementation
-
-   unsigned TestUIFlags(unsigned mask);
-
-   //! Re-invoke DoEffect on another Effect object that implements the work
-   bool Delegate(Effect &delegate, EffectSettings &settings);
-
-   // Display a message box, using effect's (translated) name as the prefix
-   // for the title.
-   enum : long { DefaultMessageBoxStyle = wxOK | wxCENTRE };
-   int MessageBox(const TranslatableString& message,
-                  long style = DefaultMessageBoxStyle,
-                  const TranslatableString& titleStr = {}) const;
-
-   static void IncEffectCounter(){ nEffectsDone++;}
-
-protected:
-
-   //! Default implementation returns false
-   bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
-
-   //! Default implementation returns `previewLength`
-   double CalcPreviewInputLength(
-      const EffectSettings &settings, double previewLength) const override;
-
-   //! Add controls to effect panel; always succeeds
-   /*!
-    @return if not null, then return it from Effect::PopulateUI instead of a
-    DefaultEffectUIValidator; default implementation returns null
-    */
-   virtual std::unique_ptr<EffectUIValidator> PopulateOrExchange(
-      ShuttleGui & S, EffectInstance &instance, EffectSettingsAccess &access,
-      const EffectOutputs *pOutputs);
-
-   // No more virtuals!
-
-   // The Progress methods all return true if the user has cancelled;
-   // you should exit immediately if this happens (cleaning up memory
-   // is okay, but don't try to undo).
-
-   // Pass a fraction between 0.0 and 1.0
-   bool TotalProgress(double frac, const TranslatableString & = {}) const;
-
-   // Pass a fraction between 0.0 and 1.0, for the current track
-   // (when doing one track at a time)
-   bool TrackProgress(
-      int whichTrack, double frac, const TranslatableString & = {}) const;
-
-   // Pass a fraction between 0.0 and 1.0, for the current track group
-   // (when doing stereo groups at a time)
-   bool TrackGroupProgress(
-      int whichGroup, double frac, const TranslatableString & = {}) const;
-
-   int GetNumWaveTracks() const { return mNumTracks; }
-   int GetNumWaveGroups() const { return mNumGroups; }
-
-   // Calculates the start time and length in samples for one or two channels
-   void GetBounds(
-      const WaveTrack &track, const WaveTrack *pRight,
-      sampleCount *start, sampleCount *len);
-
-   // Use this method to copy the input tracks to mOutputTracks, if
-   // doing the processing on them, and replacing the originals only on success (and not cancel).
-   // If not all sync-locked selected, then only selected wave tracks.
-   void CopyInputTracks(bool allSyncLockSelected = false);
-
-   // For the use of analyzers, which don't need to make output wave tracks,
-   // but may need to add label tracks.
-   class AUDACITY_DLL_API AddedAnalysisTrack {
-      friend Effect;
-      AddedAnalysisTrack(Effect *pEffect, const wxString &name);
-      AddedAnalysisTrack(const AddedAnalysisTrack&) PROHIBITED;
-
-   public:
-
-      AddedAnalysisTrack() {}
-
-      // So you can have a vector of them
-      AddedAnalysisTrack(AddedAnalysisTrack &&that);
-
-      LabelTrack *get() const { return mpTrack; }
-
-      // Call this to indicate successful completion of the analyzer.
-      void Commit();
-
-      // Destructor undoes the addition of the analysis track if not committed.
-      ~AddedAnalysisTrack();
-
-   private:
-      Effect *mpEffect{};
-      LabelTrack *mpTrack{};
-   };
-
-   // Set name to given value if that is not empty, else use default name
-   std::shared_ptr<AddedAnalysisTrack> AddAnalysisTrack(const wxString &name = wxString());
-
-   // For the use of analyzers, which don't need to make output wave tracks,
-   // but may need to modify label tracks.
-   class AUDACITY_DLL_API ModifiedAnalysisTrack {
-      friend Effect;
-      ModifiedAnalysisTrack
-         (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name);
-      ModifiedAnalysisTrack(const ModifiedAnalysisTrack&) PROHIBITED;
-
-   public:
-
-      ModifiedAnalysisTrack();
-
-      // So you can have a vector of them
-      ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that);
-
-      LabelTrack *get() const { return mpTrack; }
-
-      // Call this to indicate successful completion of the analyzer.
-      void Commit();
-
-      // Destructor undoes the modification of the analysis track if not committed.
-      ~ModifiedAnalysisTrack();
-
-   private:
-      Effect *mpEffect{};
-      LabelTrack *mpTrack{};
-      std::shared_ptr<Track> mpOrigTrack{};
-   };
-
-   // Set name to given value if that is not empty, else use default name
-   ModifiedAnalysisTrack ModifyAnalysisTrack
-      (const LabelTrack *pOrigTrack, const wxString &name = wxString());
-
-   // Use this to append a NEW output track.
-   Track *AddToOutputTracks(const std::shared_ptr<Track> &t);
-
-protected:
-   // UI
-   //! This smart pointer tracks the lifetime of the dialog
-   wxWeakRef<wxDialog> mHostUIDialog;
+   // Destructor undoes the addition of the analysis track if not committed.
+   ~AddedAnalysisTrack();
 
 private:
-   wxWindow       *mUIParent{};
-   wxString GetSavedStateGroup();
-
-   bool mIsBatch{ false };
+   Effect *mpEffect{};
+   LabelTrack *mpTrack{};
 };
 
-//! Convenience for generating EffectDefinitionInterface overrides
-//! and static down-casting functions
-template<typename Settings, typename Base>
-class EffectWithSettings : public Base {
+// Set name to given value if that is not empty, else use default name
+std::shared_ptr<AddedAnalysisTrack> AddAnalysisTrack(Effect &effect,
+   const wxString &name = wxString());
+
+// For the use of analyzers, which don't need to make output wave tracks,
+// but may need to modify label tracks.
+class AUDACITY_DLL_API ModifiedAnalysisTrack {
+   ModifiedAnalysisTrack(const ModifiedAnalysisTrack&) = delete;
+
 public:
-   EffectSettings MakeSettings() const override
-   {
-      return EffectSettings::Make<Settings>();
-   }
-   bool CopySettingsContents(
-      const EffectSettings &src, EffectSettings &dst) const override
-   {
-      return EffectSettings::Copy<Settings>(src, dst);
-   }
-   //! Assume settings originated from MakeSettings() and copies thereof
-   static inline Settings &GetSettings(EffectSettings &settings)
-   {
-      auto pSettings = settings.cast<Settings>();
-      assert(pSettings);
-      return *pSettings;
-   }
-   //! Assume settings originated from MakeSettings() and copies thereof
-   static inline const Settings &GetSettings(const EffectSettings &settings)
-   {
-      return GetSettings(const_cast<EffectSettings &>(settings));
-   }
-   static inline Settings *
-   FetchParameters(Base &, EffectSettings &s) {
-      return &GetSettings(s);
-   }
+   ModifiedAnalysisTrack
+      (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name);
+   ModifiedAnalysisTrack();
+
+   // So you can have a vector of them
+   ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that);
+
+   LabelTrack *get() const { return mpTrack; }
+
+   // Call this to indicate successful completion of the analyzer.
+   void Commit();
+
+   // Destructor undoes the modification of the analysis track if not committed.
+   ~ModifiedAnalysisTrack();
+
+private:
+   Effect *mpEffect{};
+   LabelTrack *mpTrack{};
+   std::shared_ptr<Track> mpOrigTrack{};
 };
 
-//! Subclass of Effect, to be eliminated after all of its subclasses
-//! are rewritten to be stateless
-class StatefulEffect
-   : public StatefulEffectBase
-   , public Effect
-{
-public:
-   class AUDACITY_DLL_API Instance : public StatefulEffectBase::Instance {
-   public:
-      using StatefulEffectBase::Instance::Instance;
-      bool Process(EffectSettings &settings) override;
-      SampleCount GetLatency(
-         const EffectSettings &settings, double sampleRate) const override;
-      //! Default implementation fails (returns 0 always)
-      size_t ProcessBlock(EffectSettings &settings,
-         const float *const *inBlock, float *const *outBlock, size_t blockLen)
-      override;
-   };
-   std::shared_ptr<EffectInstance> MakeInstance() const override;
-};
-
-// FIXME:
-// FIXME:  Remove this once all effects are using the NEW dialog
-// FIXME:
-
-#define ID_EFFECT_PREVIEW ePreviewID
+// Set name to given value if that is not empty, else use default name
+ModifiedAnalysisTrack ModifyAnalysisTrack(Effect &effect,
+   const LabelTrack *pOrigTrack, const wxString &name = wxString());
 
 #endif

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -19,6 +19,7 @@
 class wxSlider;
 class wxChoice;
 class wxTextCtrl;
+class LabelTrack;
 class NumericTextCtrl;
 class ShuttleGui;
 

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -24,7 +24,6 @@
 #include <wx/sizer.h>
 
 #include "ConfigInterface.h"
-#include "../LabelTrack.h"
 #include "../ProjectSettings.h"
 #include "../SelectFile.h"
 #include "../ShuttleAutomation.h"
@@ -706,91 +705,6 @@ Track *Effect::AddToOutputTracks(const std::shared_ptr<Track> &t)
    mIMap.push_back(NULL);
    mOMap.push_back(t.get());
    return mOutputTracks->Add(t);
-}
-
-Effect::AddedAnalysisTrack::AddedAnalysisTrack(Effect *pEffect, const wxString &name)
-   : mpEffect(pEffect)
-{
-   if(!name.empty())
-      mpTrack = LabelTrack::Create(*pEffect->mTracks, name);
-   else
-      mpTrack = LabelTrack::Create(*pEffect->mTracks);
-}
-
-Effect::AddedAnalysisTrack::AddedAnalysisTrack(AddedAnalysisTrack &&that)
-{
-   mpEffect = that.mpEffect;
-   mpTrack = that.mpTrack;
-   that.Commit();
-}
-
-void Effect::AddedAnalysisTrack::Commit()
-{
-   mpEffect = nullptr;
-}
-
-Effect::AddedAnalysisTrack::~AddedAnalysisTrack()
-{
-   if (mpEffect) {
-      // not committed -- DELETE the label track
-      mpEffect->mTracks->Remove(mpTrack);
-   }
-}
-
-auto Effect::AddAnalysisTrack(const wxString &name) -> std::shared_ptr<AddedAnalysisTrack>
-{
-   return std::shared_ptr<AddedAnalysisTrack>
-      { safenew AddedAnalysisTrack{ this, name } };
-}
-
-Effect::ModifiedAnalysisTrack::ModifiedAnalysisTrack
-   (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name)
-   : mpEffect(pEffect)
-{
-   // copy LabelTrack here, so it can be undone on cancel
-   auto newTrack = pOrigTrack->Copy(pOrigTrack->GetStartTime(), pOrigTrack->GetEndTime());
-
-   mpTrack = static_cast<LabelTrack*>(newTrack.get());
-
-   // Why doesn't LabelTrack::Copy complete the job? :
-   mpTrack->SetOffset(pOrigTrack->GetStartTime());
-   if (!name.empty())
-      mpTrack->SetName(name);
-
-   // mpOrigTrack came from mTracks which we own but expose as const to subclasses
-   // So it's okay that we cast it back to const
-   mpOrigTrack =
-      pEffect->mTracks->Replace(const_cast<LabelTrack*>(pOrigTrack),
-         newTrack );
-}
-
-Effect::ModifiedAnalysisTrack::ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that)
-{
-   mpEffect = that.mpEffect;
-   mpTrack = that.mpTrack;
-   mpOrigTrack = std::move(that.mpOrigTrack);
-   that.Commit();
-}
-
-void Effect::ModifiedAnalysisTrack::Commit()
-{
-   mpEffect = nullptr;
-}
-
-Effect::ModifiedAnalysisTrack::~ModifiedAnalysisTrack()
-{
-   if (mpEffect) {
-      // not committed -- DELETE the label track
-      // mpOrigTrack came from mTracks which we own but expose as const to subclasses
-      // So it's okay that we cast it back to const
-      mpEffect->mTracks->Replace(mpTrack, mpOrigTrack);
-   }
-}
-
-auto Effect::ModifyAnalysisTrack
-   (const LabelTrack *pOrigTrack, const wxString &name) -> ModifiedAnalysisTrack
-{
-   return{ this, pOrigTrack, name };
 }
 
 bool Effect::CheckWhetherSkipEffect(const EffectSettings &) const

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -19,7 +19,6 @@
 #define BUILTIN_EFFECT_PREFIX wxT("Built-in Effect: ")
 
 class EffectParameterMethods;
-class LabelTrack;
 class WaveTrack;
 
 class sampleCount;
@@ -229,69 +228,6 @@ protected:
    // doing the processing on them, and replacing the originals only on success (and not cancel).
    // If not all sync-locked selected, then only selected wave tracks.
    void CopyInputTracks(bool allSyncLockSelected = false);
-
-   // For the use of analyzers, which don't need to make output wave tracks,
-   // but may need to add label tracks.
-   class AUDACITY_DLL_API AddedAnalysisTrack {
-      friend Effect;
-      AddedAnalysisTrack(Effect *pEffect, const wxString &name);
-      AddedAnalysisTrack(const AddedAnalysisTrack&) PROHIBITED;
-
-   public:
-
-      AddedAnalysisTrack() {}
-
-      // So you can have a vector of them
-      AddedAnalysisTrack(AddedAnalysisTrack &&that);
-
-      LabelTrack *get() const { return mpTrack; }
-
-      // Call this to indicate successful completion of the analyzer.
-      void Commit();
-
-      // Destructor undoes the addition of the analysis track if not committed.
-      ~AddedAnalysisTrack();
-
-   private:
-      Effect *mpEffect{};
-      LabelTrack *mpTrack{};
-   };
-
-   // Set name to given value if that is not empty, else use default name
-   std::shared_ptr<AddedAnalysisTrack> AddAnalysisTrack(const wxString &name = wxString());
-
-   // For the use of analyzers, which don't need to make output wave tracks,
-   // but may need to modify label tracks.
-   class AUDACITY_DLL_API ModifiedAnalysisTrack {
-      friend Effect;
-      ModifiedAnalysisTrack
-         (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name);
-      ModifiedAnalysisTrack(const ModifiedAnalysisTrack&) PROHIBITED;
-
-   public:
-
-      ModifiedAnalysisTrack();
-
-      // So you can have a vector of them
-      ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that);
-
-      LabelTrack *get() const { return mpTrack; }
-
-      // Call this to indicate successful completion of the analyzer.
-      void Commit();
-
-      // Destructor undoes the modification of the analysis track if not committed.
-      ~ModifiedAnalysisTrack();
-
-   private:
-      Effect *mpEffect{};
-      LabelTrack *mpTrack{};
-      std::shared_ptr<Track> mpOrigTrack{};
-   };
-
-   // Set name to given value if that is not empty, else use default name
-   ModifiedAnalysisTrack ModifyAnalysisTrack
-      (const LabelTrack *pOrigTrack, const wxString &name = wxString());
 
    // Use this to append a NEW output track.
    Track *AddToOutputTracks(const std::shared_ptr<Track> &t);

--- a/src/effects/EffectBase.h
+++ b/src/effects/EffectBase.h
@@ -124,8 +124,11 @@ private:
 
    void CountWaveTracks();
 
+public:
+   // Public until we can move this field out of here into EffectContext
    TrackList *mTracks{}; // the complete list of all tracks
-   //! This weak pointer may be the same as mHostUIDialog, or null
+
+private:
    bool mIsLinearEffect{ false };
    bool mPreviewWithNotSelected{ false };
    bool mPreviewFullSelection{ false };

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -21,6 +21,7 @@
 
 
 #include "FindClipping.h"
+#include "AnalysisTracks.h"
 #include "LoadEffects.h"
 
 #include <math.h>
@@ -92,9 +93,9 @@ bool EffectFindClipping::Process(EffectInstance &, EffectSettings &)
 
    LabelTrack *lt{};
    if (!clt)
-      addedTrack = (AddAnalysisTrack(name)), lt = addedTrack->get();
+      addedTrack = (AddAnalysisTrack(*this, name)), lt = addedTrack->get();
    else
-      modifiedTrack.emplace(ModifyAnalysisTrack(clt, name)),
+      modifiedTrack.emplace(ModifyAnalysisTrack(*this, clt, name)),
       lt = modifiedTrack->get();
 
    int count = 0;

--- a/src/effects/SoundTouchEffect.h
+++ b/src/effects/SoundTouchEffect.h
@@ -27,6 +27,7 @@ namespace soundtouch { class SoundTouch; }
 
 
 class TimeWarper;
+class LabelTrack;
 class NoteTrack;
 class WaveTrack;
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -15,6 +15,7 @@
 
 #if defined(USE_VAMP)
 #include "VampEffect.h"
+#include "../AnalysisTracks.h"
 
 #include <vamp-hostsdk/Plugin.h>
 #include <vamp-hostsdk/PluginChannelAdapter.h>
@@ -357,7 +358,7 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
       multiple = true;
    }
 
-   std::vector<std::shared_ptr<Effect::AddedAnalysisTrack>> addedTracks;
+   std::vector<std::shared_ptr<AddedAnalysisTrack>> addedTracks;
 
    for (auto leader : inputTracks()->Leaders<const WaveTrack>())
    {
@@ -429,7 +430,7 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
       }
 
       const auto effectName = GetSymbol().Translation();
-      addedTracks.push_back(AddAnalysisTrack(
+      addedTracks.push_back(AddAnalysisTrack(*this,
          multiple
          ? wxString::Format( _("%s: %s"), left->GetName(), effectName )
          : effectName


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Break dependency of Effect on LabelTrack, for which there is not (yet) a library.

Even if there is such a library later, better not to have this extra dependency.

Extract utilities from Effect that are only used by some Analyzers.

QA:  things to test include Vamp analyers and the Find Clipping analyzer.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
