### PR TITLE
Make realtime effect settings of duplicated track independent...

### DIFF
--- a/libraries/lib-realtime-effects/RealtimeEffectList.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
 {
    auto result = std::make_unique<RealtimeEffectList>();
    for (auto &pState : mStates)
-      result->mStates.push_back(pState);
+      result->mStates.push_back(pState->Clone());
    result->SetActive(this->IsActive());
    return result;
 }

--- a/libraries/lib-realtime-effects/RealtimeEffectState.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectState.cpp
@@ -318,9 +318,14 @@ RealtimeEffectState::RealtimeEffectState(const PluginID& id)
    BuildAll();
 }
 
-RealtimeEffectState::~RealtimeEffectState()
-{
+RealtimeEffectState::~RealtimeEffectState() = default;
 
+std::shared_ptr<RealtimeEffectState> RealtimeEffectState::Clone() const
+{
+   auto pNewState = RealtimeEffectState::make_shared(GetID());
+   pNewState->mPlugin = mPlugin;
+   pNewState->mMainSettings.Set(mMainSettings);
+   return pNewState;
 }
 
 void RealtimeEffectState::SetID(const PluginID & id)

--- a/libraries/lib-realtime-effects/RealtimeEffectState.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectState.h
@@ -46,6 +46,8 @@ public:
    RealtimeEffectState &operator =(const RealtimeEffectState &other) = delete;
    ~RealtimeEffectState();
 
+   std::shared_ptr<RealtimeEffectState> Clone() const;
+
    //! May be called with nonempty id at most once in the lifetime of a state
    /*!
     Call with empty id is ignored.


### PR DESCRIPTION
... Note that RealtimeEffectList::Clone() was correct as originally written when it held states by unique_ptr, but then the change to shared_ptr introduced this problem.

Resolves: #4169

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
