### PR TITLE
Issue-#4310 resolved by adding error message earlier so it fits in the dialog box

### DIFF
--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -244,7 +244,7 @@ std::unique_ptr<EffectUIValidator> EffectNormalize::PopulateOrExchange(
                      PeakLevel.min,
                      PeakLevel.max )
                   .AddTextBox( {}, L"", 10);
-               mLeveldB = S.AddVariableText(XO("dB (Maximum 0dB)"), false,
+               mLeveldB = S.AddVariableText(XO("dB (Maximum 0dB)  "), false,
                   wxALIGN_CENTER_VERTICAL | wxALIGN_LEFT);
                mWarning = S.AddVariableText( {}, false,
                   wxALIGN_CENTER_VERTICAL | wxALIGN_LEFT);

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -244,7 +244,7 @@ std::unique_ptr<EffectUIValidator> EffectNormalize::PopulateOrExchange(
                      PeakLevel.min,
                      PeakLevel.max )
                   .AddTextBox( {}, L"", 10);
-               mLeveldB = S.AddVariableText(XO("dB"), false,
+               mLeveldB = S.AddVariableText(XO("dB (Maximum 0dB)"), false,
                   wxALIGN_CENTER_VERTICAL | wxALIGN_LEFT);
                mWarning = S.AddVariableText( {}, false,
                   wxALIGN_CENTER_VERTICAL | wxALIGN_LEFT);
@@ -472,7 +472,7 @@ void EffectNormalize::UpdateUI()
 
    if (!mUIParent->TransferDataFromWindow())
    {
-      mWarning->SetLabel(_("(Maximum 0dB)"));
+      mWarning->SetLabel(_(" "));
       EffectUIValidator::EnableApply(mUIParent, false);
       return;
    }


### PR DESCRIPTION
… dialog box

Resolves: https://github.com/audacity/audacity/issues/4310)

*The Issue was that after entering some positive value in the text box to Normalize error (Maximum 0dB) was displayed after
the text Field but was not fit to the dialog box
Changes-
1. the Message (Maximum 0db) now appears as default message and fits to the dialog box
2. after entering a positive number in the text Box only the apply button doesn't allow and no new text appears on the dialog box*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
