### PR TITLE
Remove obsolete ;manpage header from Nyquist plug-ins

### DIFF
--- a/plug-ins/SpectralEditParametricEQ.ny
+++ b/plug-ins/SpectralEditParametricEQ.ny
@@ -3,7 +3,6 @@ $version 4
 $type process spectral
 $preview linear
 $name (_ "Spectral Edit Parametric EQ")
-$manpage "Spectral_edit_parametric_EQ"
 $debugbutton false
 $author (_ "Paul Licameli")
 $release 2.3.0-1

--- a/plug-ins/SpectralEditShelves.ny
+++ b/plug-ins/SpectralEditShelves.ny
@@ -3,7 +3,6 @@ $version 4
 $type process spectral
 $preview linear
 $name (_ "Spectral Edit Shelves")
-$manpage "Spectral_edit_shelves"
 $debugbutton false
 $author (_ "Paul Licameli")
 $release 2.3.0-1

--- a/plug-ins/adjustable-fade.ny
+++ b/plug-ins/adjustable-fade.ny
@@ -4,7 +4,6 @@ $type process
 $preview linear
 $preview selection
 $name (_ "Adjustable Fade")
-$manpage "Adjustable_Fade"
 $debugbutton false
 $author (_ "Steve Daulton")
 $release 3.0.4-1

--- a/plug-ins/beat.ny
+++ b/plug-ins/beat.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type analyze
 $name (_ "Beat Finder")
-$manpage "Beat_Finder"
 $debugbutton false
 $author (_ "Audacity")
 $release 2.3.2-1

--- a/plug-ins/clipfix.ny
+++ b/plug-ins/clipfix.ny
@@ -3,7 +3,6 @@ $version 4
 $type process
 $preview enabled
 $name (_ "Clip Fix")
-$manpage "Clip_Fix"
 $debugbutton false
 $author (_ "Benjamin Schwartz and Steve Daulton")
 $release 2.3.0-1

--- a/plug-ins/crossfadetracks.ny
+++ b/plug-ins/crossfadetracks.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type process
 $name (_ "Crossfade Tracks")
-$manpage "Crossfade_Tracks"
 $debugbutton disabled
 $preview selection
 $author (_ "Steve Daulton")

--- a/plug-ins/delay.ny
+++ b/plug-ins/delay.ny
@@ -3,7 +3,6 @@ $version 4
 $type process
 $preview linear
 $name (_ "Delay")
-$manpage "Delay"
 $debugbutton false
 $author (_ "Steve Daulton")
 $release 2.3.1-1

--- a/plug-ins/eq-xml-to-txt-converter.ny
+++ b/plug-ins/eq-xml-to-txt-converter.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type tool
 $name (_ "EQ XML to TXT Converter")
-$manpage "EQ_XML_to_TXT_Converter"
 $debugbutton false
 $preview disabled
 $author (_ "Steve Daulton")

--- a/plug-ins/equalabel.ny
+++ b/plug-ins/equalabel.ny
@@ -4,7 +4,6 @@ $type tool analyze
 $debugbutton false
 $debugflags trace
 $name (_ "Regular Interval Labels")
-$manpage "Regular_Interval_Labels"
 $author (_ "Steve Daulton")
 $release 2.3.1-1
 $copyright (_ "GNU General Public License v2.0 or later")

--- a/plug-ins/highpass.ny
+++ b/plug-ins/highpass.ny
@@ -3,7 +3,6 @@ $version 4
 $type process
 $preview linear
 $name (_ "High-Pass Filter")
-$manpage "High-Pass_Filter"
 $debugbutton disabled
 $author (_ "Dominic Mazzoni")
 $release 2.3.0-1

--- a/plug-ins/label-sounds.ny
+++ b/plug-ins/label-sounds.ny
@@ -3,7 +3,6 @@ $version 4
 $type analyze
 ;i18n-hint: Name of effect that labels sounds
 $name (_ "Label Sounds")
-$manpage "Label_Sounds"
 $debugbutton false
 $author (_ "Steve Daulton")
 $release 3.0.4-1

--- a/plug-ins/limiter.ny
+++ b/plug-ins/limiter.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type process
 $name (_ "Limiter")
-$manpage "Limiter"
 $debugbutton false
 $preview enabled
 $author (_ "Steve Daulton")

--- a/plug-ins/lowpass.ny
+++ b/plug-ins/lowpass.ny
@@ -3,7 +3,6 @@ $version 4
 $type process
 $preview linear
 $name (_ "Low-Pass Filter")
-$manpage "Low-Pass_Filter"
 $debugbutton disabled
 $author (_ "Dominic Mazzoni")
 $release 2.3.0-1

--- a/plug-ins/noisegate.ny
+++ b/plug-ins/noisegate.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type process
 $name (_ "Noise Gate")
-$manpage "Noise_Gate"
 $debugbutton false
 $preview enabled
 $author (_ "Steve Daulton")

--- a/plug-ins/notch.ny
+++ b/plug-ins/notch.ny
@@ -3,7 +3,6 @@ $version 4
 $type process
 $preview linear
 $name (_ "Notch Filter")
-$manpage "Notch_Filter"
 $debugbutton false
 $author (_ "Steve Daulton and Bill Wharrie")
 $release 2.3.0-1

--- a/plug-ins/nyquist-plug-in-installer.ny
+++ b/plug-ins/nyquist-plug-in-installer.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type tool
 $name (_ "Nyquist Plugin Installer")
-$manpage "Nyquist_Plug-in_Installer"
 $debugbutton false
 $preview disabled
 $author "Steve Daulton"

--- a/plug-ins/pluck.ny
+++ b/plug-ins/pluck.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type generate
 $name (_ "Pluck")
-$manpage "Pluck"
 $debugbutton false
 $preview linear
 $author (_ "David R.Sky")

--- a/plug-ins/rhythmtrack.ny
+++ b/plug-ins/rhythmtrack.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type generate
 $name (_ "Rhythm Track")
-$manpage "Rhythm_Track"
 $debugbutton false
 $preview linear
 $author (_ "Dominic Mazzoni, David R. Sky and Steve Daulton")

--- a/plug-ins/rissetdrum.ny
+++ b/plug-ins/rissetdrum.ny
@@ -4,7 +4,6 @@ $type generate
 $preview linear
 $i18n-hint named for Jean-Claude Risset (silent t)
 $name (_ "Risset Drum")
-$manpage "Risset_Drum"
 $debugbutton false
 $author (_ "Steven Jones")
 $release 2.3.0-1

--- a/plug-ins/sample-data-export.ny
+++ b/plug-ins/sample-data-export.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type tool analyze
 $name (_ "Sample Data Export")
-$manpage "Sample_Data_Export"
 $debugbutton false
 $author (_ "Steve Daulton")
 $release 3.0.4-1

--- a/plug-ins/sample-data-import.ny
+++ b/plug-ins/sample-data-import.ny
@@ -2,7 +2,6 @@ $nyquist plug-in
 $version 4
 $type tool generate
 $name (_ "Sample Data Import")
-$manpage "Sample_Data_Import"
 $debugbutton false
 $author (_ "Steve Daulton")
 $release 3.0.4-1

--- a/plug-ins/tremolo.ny
+++ b/plug-ins/tremolo.ny
@@ -3,7 +3,6 @@ $version 3
 $type process
 $preview linear
 $name (_ "Tremolo")
-$manpage "Tremolo"
 $debugbutton disabled
 $author (_ "Steve Daulton")
 $release 2.3.0-1

--- a/plug-ins/vocalrediso.ny
+++ b/plug-ins/vocalrediso.ny
@@ -3,7 +3,6 @@ $version 4
 $type process
 $preview linear
 $name (_ "Vocal Reduction and Isolation")
-$manpage "Vocal_Reduction_and_Isolation"
 $debugbutton false
 $author (_ "Robert Haenggi")
 $release 3.0.1-1

--- a/plug-ins/vocoder.ny
+++ b/plug-ins/vocoder.ny
@@ -3,7 +3,6 @@ $version 4
 $type process
 $preview enabled
 $name (_ "Vocoder")
-$manpage "Vocoder"
 $debugbutton false
 $author (_ "Edgar-RFT and Steve Daulton")
 $release 3.1.2-1


### PR DESCRIPTION
Resolves: Obsolete headers in shipped plugins

*When the "?" help button was removed from effects, the ";manpage" header became obsolete clutter.*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
