### PR TITLE
Shelf Filter added

### DIFF
--- a/plug-ins/CMakeLists.txt
+++ b/plug-ins/CMakeLists.txt
@@ -7,6 +7,7 @@ message( STATUS "========== Configuring ${TARGET} ==========" )
 def_vars()
 
 list( APPEND SOURCES
+   ShelfFilter.ny
    SpectralEditMulti.ny
    SpectralEditParametricEQ.ny
    SpectralEditShelves.ny

--- a/plug-ins/ShelfFilter.ny
+++ b/plug-ins/ShelfFilter.ny
@@ -1,0 +1,34 @@
+$nyquist plug-in
+$version 4
+$type process
+$preview linear
+$name (_ "Shelf Filter")
+$debugbutton disabled
+$author (_ "Steve Daulton")
+$release 2.4.0
+$copyright (_ "GNU General Public License v2.0")
+
+;; License: GPL v2
+;; http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+;;
+;; For information about writing and modifying Nyquist plug-ins:
+;; https://wiki.audacityteam.org/wiki/Nyquist_Plug-ins_Reference
+
+
+$control type (_ "Filter type") choice (("Low" (_ "Low-shelf"))
+                                        ("High" (_ "High-shelf"))) 0
+$control hz (_ "Frequency (Hz)") int "" 1000 10 10000
+$control gain (_ "Amount (dB)") int "" -6 -72 72
+
+
+(cond ((> hz (/ *sound-srate* 2))
+          (format nil (_ "Error.~%Frequency set too high for selected track.")))
+      ((> hz (/ *sound-srate* 2.1))  ;Handle edge case close to Nyquist frequency.
+          (setf *track* (force-srate (* 2 *sound-srate*) *track*))
+          (if (= type 0)
+              (force-srate *sound-srate* (eq-lowshelf *track* hz gain))
+              (force-srate *sound-srate* (eq-highshelf *track* hz gain))))
+      ((= gain 0) "")  ; no-op
+      (t  (if (= type 0)
+              (eq-lowshelf *track* hz gain)
+              (eq-highshelf *track* hz gain))))

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -44,6 +44,7 @@ const static wxChar *kShippedEffects[] =
    wxT("rissetdrum.ny"),
    wxT("sample-data-export.ny"),
    wxT("sample-data-import.ny"),
+   wxT("ShelfFilter.ny"),
    wxT("spectral-delete.ny"),
    wxT("SpectralEditMulti.ny"),
    wxT("SpectralEditParametricEQ.ny"),


### PR DESCRIPTION
Resolves: *Absence of a shelf filter in Audacity*

*Audacity has High-pass, Low-pass, and a Notch filter, but notable by its absence there is no shelf filter. This pull requests adds the missing filter. The filter can be set for High-shelf or Low-shelf.*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
