### PR TITLE
Fix issue 4201

### DIFF
--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -1275,7 +1275,7 @@ const ControlInfo *controlInfo() {
          0.0, 48.0, 48, wxT("%d"), true,
          XXO("&Noise reduction (dB):"), XO("Noise reduction")),
          ControlInfo(&EffectNoiseReduction::Settings::mNewSensitivity,
-         0.0, 24.0, 48, wxT("%.2f"), false,
+         0.01, 24.0, 48, wxT("%.2f"), false,
          XXO("&Sensitivity:"), XO("Sensitivity")),
 #ifdef ATTACK_AND_RELEASE
          ControlInfo(&EffectNoiseReduction::Settings::mAttackTime,


### PR DESCRIPTION
When 'Sensitivity' is zero, the effect is unexpectedly a no-op. The solution is to limit the Sensitivity slider to a range that works. As the widget has (very reasonably) 2 decimal places, and a Sensitivity value of 0.01 has a very subtle effect, 0.01 is a good choice as the minimum Sensitivity.

Resolves: #4201 (https://github.com/audacity/audacity/issues/4201)*

*Set minimum Sensitivity to 0.01*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
