### PR TITLE
Break dependencies on ffmpeg and mp3

### DIFF
--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -233,7 +233,24 @@ namespace Registry {
    // a GroupItem.
    REGISTRIES_API
    void RegisterItem( GroupItem &registry, const Placement &placement,
-      BaseItemPtr pItem );
+      BaseItemPtr pItem //!< Registry takes ownership
+   );
+   
+   //! Generates classes whose instances register items at construction
+   /*!
+       Usually constructed statically
+       @tparam Item inherits `BaseItem`
+       @tparam RegistryClass defines static member `Registry()` returning `GroupItem&`
+    */
+   template<typename Item, typename RegistryClass = Item> class RegisteredItem {
+   public:
+      RegisteredItem(std::unique_ptr<Item> pItem, const Placement &placement)
+      {
+         if (pItem)
+            RegisterItem(
+               RegistryClass::Registry(), placement, std::move( pItem ) );
+      }
+   };
    
    // Define actions to be done in Visit.
    // Default implementations do nothing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -654,12 +654,14 @@ list( APPEND SOURCES
       export/ExportMultiple.cpp
       export/ExportMultiple.h
       export/ExportPCM.cpp
+      export/MP3Prefs.cpp
 
       # Optional exporters
       $<$<BOOL:${USE_FFMPEG}>:
          export/ExportFFmpeg.cpp
          export/ExportFFmpegDialogs.cpp
          export/ExportFFmpegDialogs.h
+         export/FFmpegPrefs.cpp
       >
 
       $<$<BOOL:${USE_LIBFLAC}>:

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -249,22 +249,23 @@ using namespace Registry;
 
 const auto MenuPathStart = wxT("MenuBar");
 
-static Registry::GroupItem &sRegistry()
-{
-   static Registry::TransparentGroupItem<> registry{ MenuPathStart };
-   return registry;
 }
+
+Registry::GroupItem &MenuTable::ItemRegistry::Registry()
+{
+   static TransparentGroupItem<> registry{ MenuPathStart };
+   return registry;
 }
 
 MenuTable::AttachedItem::AttachedItem(
    const Placement &placement, BaseItemPtr pItem )
+   : RegisteredItem{ std::move(pItem), placement }
 {
-   Registry::RegisterItem( sRegistry(), placement, std::move( pItem ) );
 }
 
 void MenuTable::DestroyRegistry()
 {
-   sRegistry().items.clear();
+   MenuTable::ItemRegistry::Registry().items.clear();
 }
 
 namespace {
@@ -442,7 +443,8 @@ void MenuManager::Visit( ToolbarMenuVisitor &visitor )
    static const auto menuTree = MenuTable::Items( MenuPathStart );
 
    wxLogNull nolog;
-   Registry::Visit( visitor, menuTree.get(), &sRegistry() );
+   Registry::Visit( visitor, menuTree.get(),
+      &MenuTable::ItemRegistry::Registry() );
 }
 
 // TODO: This surely belongs in CommandManager?

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -767,10 +767,15 @@ namespace MenuTable {
       const Identifier &name, const SpecialItem::Appender &fn )
          { return std::make_unique<SpecialItem>( name, fn ); }
 
+   struct ItemRegistry {
+      static GroupItem &Registry();
+   };
+
    // Typically you make a static object of this type in the .cpp file that
    // also defines the added menu actions.
    // pItem can be specified by an expression using the inline functions above.
    struct AUDACITY_DLL_API AttachedItem final
+      : public RegisteredItem<BaseItem, ItemRegistry>
    {
       AttachedItem( const Placement &placement, BaseItemPtr pItem );
 

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -285,23 +285,7 @@ BEGIN_EVENT_TABLE(Exporter, wxEvtHandler)
 END_EVENT_TABLE()
 
 namespace {
-const auto PathStart = wxT("Exporters");
-
-static Registry::GroupItem &sRegistry()
-{
-   static Registry::TransparentGroupItem<> registry{ PathStart };
-   return registry;
-}
-
-struct ExporterItem final : Registry::SingleItem {
-   ExporterItem(
-      const Identifier &id, const Exporter::ExportPluginFactory &factory )
-      : SingleItem{ id }
-      , mFactory{ factory }
-   {}
-
-   Exporter::ExportPluginFactory mFactory;
-};
+   const auto PathStart = L"Exporters";
 
    using ExportPluginFactories = std::vector< Exporter::ExportPluginFactory >;
    ExportPluginFactories &sFactories()
@@ -311,14 +295,27 @@ struct ExporterItem final : Registry::SingleItem {
    }
 }
 
+Registry::GroupItem &Exporter::ExporterItem::Registry()
+{
+   static Registry::TransparentGroupItem<> registry{ PathStart };
+   return registry;
+}
+
+Exporter::ExporterItem::ExporterItem(
+   const Identifier &id, const Exporter::ExportPluginFactory &factory )
+   : SingleItem{ id }
+   , mFactory{ factory }
+{}
+
 Exporter::RegisteredExportPlugin::RegisteredExportPlugin(
    const Identifier &id,
    const ExportPluginFactory &factory,
    const Registry::Placement &placement )
+   : RegisteredItem{
+      factory ? std::make_unique< ExporterItem >( id, factory ) : nullptr,
+      placement
+   }
 {
-   if ( factory )
-      Registry::RegisterItem( sRegistry(), placement,
-         std::make_unique< ExporterItem >( id, factory ) );
 }
 
 Exporter::Exporter( AudacityProject &project )
@@ -343,7 +340,7 @@ Exporter::Exporter( AudacityProject &project )
          // visit the registry to collect the plug-ins properly
          // sorted
          TransparentGroupItem<> top{ PathStart };
-         Registry::Visit( *this, &top, &sRegistry() );
+         Registry::Visit( *this, &top, &ExporterItem::Registry() );
       }
 
       void Visit( SingleItem &item, const Path &path ) override

--- a/src/export/Export.h
+++ b/src/export/Export.h
@@ -170,6 +170,7 @@ wxDECLARE_EXPORTED_EVENT(AUDACITY_DLL_API,
 
 class  AUDACITY_DLL_API Exporter final : public wxEvtHandler
 {
+   struct ExporterItem;
 public:
 
    using ExportPluginFactory =
@@ -180,7 +181,9 @@ public:
    // Register factories, not plugin objects themselves, which allows them
    // to have some fresh state variables each time export begins again
    // and to compute translated strings for the current locale
-   struct AUDACITY_DLL_API RegisteredExportPlugin{
+   struct AUDACITY_DLL_API RegisteredExportPlugin
+      : public Registry::RegisteredItem<ExporterItem>
+   {
       RegisteredExportPlugin(
          const Identifier &id, // an internal string naming the plug-in
          const ExportPluginFactory&,
@@ -226,6 +229,13 @@ public:
    void OnHelp(wxCommandEvent &evt);
 
 private:
+   struct AUDACITY_DLL_API ExporterItem final : Registry::SingleItem {
+      static Registry::GroupItem &Registry();
+      ExporterItem(
+         const Identifier &id, const Exporter::ExportPluginFactory &factory );
+      Exporter::ExportPluginFactory mFactory;
+   };
+
    bool ExamineTracks();
    bool GetFilename();
    bool CheckFilename();

--- a/src/export/FFmpegPrefs.cpp
+++ b/src/export/FFmpegPrefs.cpp
@@ -1,0 +1,221 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  LibraryPrefs.cpp
+
+  Joshua Haberman
+  Dominic Mazzoni
+  James Crook
+
+*******************************************************************//**
+
+\class LibraryPrefs
+\brief A PrefsPanel used to select manage external libraries like the
+MP3 and FFmpeg encoding libraries.
+
+*//*******************************************************************/
+
+
+#include "LibraryPrefs.h"
+
+#include <wx/defs.h>
+#include <wx/stattext.h>
+
+#include "../FFmpeg.h"
+#include "../export/ExportMP3.h"
+#include "../widgets/HelpSystem.h"
+#include "../widgets/AudacityMessageBox.h"
+#include "../widgets/ReadOnlyText.h"
+#include "../widgets/wxTextCtrlWrapper.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define ID_FFMPEG_FIND_BUTTON       7003
+#define ID_FFMPEG_DOWN_BUTTON       7004
+
+BEGIN_EVENT_TABLE(LibraryPrefs, PrefsPanel)
+   EVT_BUTTON(ID_FFMPEG_FIND_BUTTON, LibraryPrefs::OnFFmpegFindButton)
+   EVT_BUTTON(ID_FFMPEG_DOWN_BUTTON, LibraryPrefs::OnFFmpegDownButton)
+END_EVENT_TABLE()
+
+LibraryPrefs::LibraryPrefs(wxWindow * parent, wxWindowID winid)
+/* i18-hint: refers to optional plug-in software libraries */
+:   PrefsPanel(parent, winid, XO("Libraries"))
+{
+   Populate();
+}
+
+LibraryPrefs::~LibraryPrefs()
+{
+}
+
+ComponentInterfaceSymbol LibraryPrefs::GetSymbol() const
+{
+   return LIBRARY_PREFS_PLUGIN_SYMBOL;
+}
+
+TranslatableString LibraryPrefs::GetDescription() const
+{
+   return XO("Preferences for Library");
+}
+
+ManualPageID LibraryPrefs::HelpPageName()
+{
+   return "Libraries_Preferences";
+}
+
+/// Creates the dialog and its contents.
+void LibraryPrefs::Populate()
+{
+   //------------------------- Main section --------------------
+   // Now construct the GUI itself.
+   // Use 'eIsCreatingFromPrefs' so that the GUI is
+   // initialised with values from gPrefs.
+   ShuttleGui S(this, eIsCreatingFromPrefs);
+   PopulateOrExchange(S);
+   // ----------------------- End of main section --------------
+
+   // Set the MP3 Version string.
+   SetMP3VersionText();
+   SetFFmpegVersionText();
+}
+
+/// This PopulateOrExchange function is a good example of mixing the fully
+/// automatic style of reading/writing from GUI to prefs with the partial form.
+///
+/// You'll notice that some of the Tie functions have Prefs identifiers in them
+/// and others don't.
+void LibraryPrefs::PopulateOrExchange(ShuttleGui & S)
+{
+   S.SetBorder(2);
+   S.StartScroller();
+
+   S.StartStatic(XO("LAME MP3 Export Library"));
+   {
+      S.StartTwoColumn();
+      {
+         mMP3Version = S
+            .Position(wxALIGN_CENTRE_VERTICAL)
+            .AddReadOnlyText(XO("MP3 Library Version:"), "");
+      }
+      S.EndTwoColumn();
+   }
+   S.EndStatic();
+
+   S.StartStatic(XO("FFmpeg Import/Export Library"));
+   {
+      S.StartTwoColumn();
+      {
+         auto version =
+#if defined(USE_FFMPEG)
+            XO("No compatible FFmpeg library was found");
+#else
+            XO("FFmpeg support is not compiled in");
+#endif
+
+         mFFmpegVersion = S
+            .Position(wxALIGN_CENTRE_VERTICAL)
+            .AddReadOnlyText(XO("FFmpeg Library Version:"), version.Translation());
+
+         S.AddVariableText(XO("FFmpeg Library:"),
+            true, wxALL | wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL);
+         S.Id(ID_FFMPEG_FIND_BUTTON);
+         S
+#if !defined(USE_FFMPEG) || defined(DISABLE_DYNAMIC_LOADING_FFMPEG)
+            .Disable()
+#endif
+            .AddButton(XXO("Loca&te..."),
+                       wxALL | wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL);
+         S.AddVariableText(XO("FFmpeg Library:"),
+            true, wxALL | wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL);
+         S.Id(ID_FFMPEG_DOWN_BUTTON);
+         S
+#if !defined(USE_FFMPEG) || defined(DISABLE_DYNAMIC_LOADING_FFMPEG)
+            .Disable()
+#endif
+            .AddButton(XXO("Dow&nload"),
+                       wxALL | wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL);
+      }
+      S.EndTwoColumn();
+   }
+   S.EndStatic();
+   S.EndScroller();
+
+}
+
+/// Sets the a text area on the dialog to have the name
+/// of the MP3 Library version.
+void LibraryPrefs::SetMP3VersionText(bool prompt)
+{
+   mMP3Version->SetValue(GetMP3Version(this, prompt));
+}
+
+void LibraryPrefs::SetFFmpegVersionText()
+{
+   mFFmpegVersion->SetValue(GetFFmpegVersion());
+}
+
+void LibraryPrefs::OnFFmpegFindButton(wxCommandEvent & WXUNUSED(event))
+{
+#ifdef USE_FFMPEG
+   bool showerrs =
+#if defined(_DEBUG)
+      true;
+#else
+      false;
+#endif
+   // Load the libs ('true' means that all errors will be shown)
+   bool locate = !LoadFFmpeg(showerrs);
+
+   // Libs are fine, don't show "locate" dialog unless user really wants it
+   if (!locate) {
+      int response = AudacityMessageBox(
+         XO(
+"Audacity has automatically detected valid FFmpeg libraries.\nDo you still want to locate them manually?"),
+         XO("Success"),
+         wxCENTRE | wxYES_NO | wxNO_DEFAULT |wxICON_QUESTION);
+      if (response == wxYES) {
+        locate = true;
+      }
+   }
+
+   if (locate) {
+      // Show "Locate FFmpeg" dialog
+      FindFFmpegLibs(this);
+      LoadFFmpeg(showerrs);
+   }
+
+   SetFFmpegVersionText();
+#endif
+}
+
+void LibraryPrefs::OnFFmpegDownButton(wxCommandEvent & WXUNUSED(event))
+{
+   HelpSystem::ShowHelp(this, L"FAQ:Installing_the_FFmpeg_Import_Export_Library", true);
+}
+
+bool LibraryPrefs::Commit()
+{
+   ShuttleGui S(this, eIsSavingToPrefs);
+   PopulateOrExchange(S);
+
+   return true;
+}
+
+#if !defined(DISABLE_DYNAMIC_LOADING_FFMPEG) || !defined(DISABLE_DYNAMIC_LOADING_LAME)
+namespace{
+PrefsPanel::Registration sAttachment{ "Library",
+   [](wxWindow *parent, wxWindowID winid, AudacityProject *)
+   {
+      wxASSERT(parent); // to justify safenew
+      return safenew LibraryPrefs(parent, winid);
+   },
+   false,
+   // Register with an explicit ordering hint because this one is
+   // only conditionally compiled
+   { "", { Registry::OrderingHint::Before, "Directories" } }
+};
+}
+#endif

--- a/src/export/FFmpegPrefs.cpp
+++ b/src/export/FFmpegPrefs.cpp
@@ -33,61 +33,6 @@ void SetFFmpegVersionText(State &state)
    FFmpegVersion->SetValue(GetFFmpegVersion());
 }
 
-#if 0
-////////////////////////////////////////////////////////////////////////////////
-
-#define ID_FFMPEG_FIND_BUTTON       7003
-#define ID_FFMPEG_DOWN_BUTTON       7004
-
-BEGIN_EVENT_TABLE(LibraryPrefs, PrefsPanel)
-   EVT_BUTTON(ID_FFMPEG_FIND_BUTTON, LibraryPrefs::OnFFmpegFindButton)
-   EVT_BUTTON(ID_FFMPEG_DOWN_BUTTON, LibraryPrefs::OnFFmpegDownButton)
-END_EVENT_TABLE()
-
-LibraryPrefs::LibraryPrefs(wxWindow * parent, wxWindowID winid)
-/* i18-hint: refers to optional plug-in software libraries */
-:   PrefsPanel(parent, winid, XO("Libraries"))
-{
-   Populate();
-}
-
-LibraryPrefs::~LibraryPrefs()
-{
-}
-
-ComponentInterfaceSymbol LibraryPrefs::GetSymbol() const
-{
-   return LIBRARY_PREFS_PLUGIN_SYMBOL;
-}
-
-TranslatableString LibraryPrefs::GetDescription() const
-{
-   return XO("Preferences for Library");
-}
-
-ManualPageID LibraryPrefs::HelpPageName()
-{
-   return "Libraries_Preferences";
-}
-
-/// Creates the dialog and its contents.
-void LibraryPrefs::Populate()
-{
-   //------------------------- Main section --------------------
-   // Now construct the GUI itself.
-   // Use 'eIsCreatingFromPrefs' so that the GUI is
-   // initialised with values from gPrefs.
-   ShuttleGui S(this, eIsCreatingFromPrefs);
-   PopulateOrExchange(S);
-   // ----------------------- End of main section --------------
-
-   // Set the MP3 Version string.
-   SetMP3VersionText();
-   SetFFmpegVersionText();
-}
-
-#endif
-
 void AddControls( ShuttleGui &S )
 {
    auto pState = std::make_shared<State>();

--- a/src/export/FFmpegPrefs.cpp
+++ b/src/export/FFmpegPrefs.cpp
@@ -2,34 +2,38 @@
 
   Audacity: A Digital Audio Editor
 
-  LibraryPrefs.cpp
+  @file FFmpegPrefs.cpp
+  @brief adds controls for FFmpeg import/export to Library preferences
 
-  Joshua Haberman
-  Dominic Mazzoni
-  James Crook
+  Paul Licameli split from LibraryPrefs.cpp
 
-*******************************************************************//**
-
-\class LibraryPrefs
-\brief A PrefsPanel used to select manage external libraries like the
-MP3 and FFmpeg encoding libraries.
-
-*//*******************************************************************/
-
-
-#include "LibraryPrefs.h"
-
-#include <wx/defs.h>
-#include <wx/stattext.h>
+**********************************************************************/
 
 #include "../FFmpeg.h"
-#include "../export/ExportMP3.h"
-#include "../widgets/HelpSystem.h"
+#include "Internat.h"
+#include "ShuttleGui.h"
+#include "../prefs/LibraryPrefs.h"
 #include "../widgets/AudacityMessageBox.h"
-#include "../widgets/ReadOnlyText.h"
-#include "../widgets/wxTextCtrlWrapper.h"
+#include "widgets/HelpSystem.h"
+#include "widgets/ReadOnlyText.h"
+#include <wx/stattext.h>
 
+namespace {
 
+struct State {
+   wxWindow *parent = nullptr;
+   ReadOnlyText *FFmpegVersion = nullptr;
+};
+
+void OnFFmpegFindButton(State &state);
+
+void SetFFmpegVersionText(State &state)
+{
+   auto FFmpegVersion = state.FFmpegVersion;
+   FFmpegVersion->SetValue(GetFFmpegVersion());
+}
+
+#if 0
 ////////////////////////////////////////////////////////////////////////////////
 
 #define ID_FFMPEG_FIND_BUTTON       7003
@@ -82,82 +86,65 @@ void LibraryPrefs::Populate()
    SetFFmpegVersionText();
 }
 
-/// This PopulateOrExchange function is a good example of mixing the fully
-/// automatic style of reading/writing from GUI to prefs with the partial form.
-///
-/// You'll notice that some of the Tie functions have Prefs identifiers in them
-/// and others don't.
-void LibraryPrefs::PopulateOrExchange(ShuttleGui & S)
-{
-   S.SetBorder(2);
-   S.StartScroller();
+#endif
 
-   S.StartStatic(XO("LAME MP3 Export Library"));
-   {
-      S.StartTwoColumn();
-      {
-         mMP3Version = S
-            .Position(wxALIGN_CENTRE_VERTICAL)
-            .AddReadOnlyText(XO("MP3 Library Version:"), "");
-      }
-      S.EndTwoColumn();
-   }
-   S.EndStatic();
+void AddControls( ShuttleGui &S )
+{
+   auto pState = std::make_shared<State>();
+   pState->parent = S.GetParent();
 
    S.StartStatic(XO("FFmpeg Import/Export Library"));
    {
       S.StartTwoColumn();
       {
          auto version =
-#if defined(USE_FFMPEG)
+ #if defined(USE_FFMPEG)
             XO("No compatible FFmpeg library was found");
-#else
+ #else
             XO("FFmpeg support is not compiled in");
-#endif
+ #endif
 
-         mFFmpegVersion = S
-            .Position(wxALIGN_CENTRE_VERTICAL)
+         pState->FFmpegVersion = S
+           .Position(wxALIGN_CENTRE_VERTICAL)
             .AddReadOnlyText(XO("FFmpeg Library Version:"), version.Translation());
 
          S.AddVariableText(XO("FFmpeg Library:"),
             true, wxALL | wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL);
-         S.Id(ID_FFMPEG_FIND_BUTTON);
+
+         auto pFindButton =
          S
 #if !defined(USE_FFMPEG) || defined(DISABLE_DYNAMIC_LOADING_FFMPEG)
             .Disable()
 #endif
             .AddButton(XXO("Loca&te..."),
                        wxALL | wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL);
+         pFindButton->Bind(wxEVT_BUTTON, [pState](wxCommandEvent&){
+            OnFFmpegFindButton(*pState);
+         });
+
          S.AddVariableText(XO("FFmpeg Library:"),
             true, wxALL | wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL);
-         S.Id(ID_FFMPEG_DOWN_BUTTON);
+
+         auto pDownButton =
          S
 #if !defined(USE_FFMPEG) || defined(DISABLE_DYNAMIC_LOADING_FFMPEG)
             .Disable()
 #endif
             .AddButton(XXO("Dow&nload"),
                        wxALL | wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL);
+         pDownButton->Bind(wxEVT_BUTTON, [pState](wxCommandEvent&){
+            HelpSystem::ShowHelp(pState->parent,
+               wxT("FAQ:Installing_the_FFmpeg_Import_Export_Library"), true);
+         });
       }
       S.EndTwoColumn();
    }
    S.EndStatic();
-   S.EndScroller();
 
+   SetFFmpegVersionText(*pState);
 }
 
-/// Sets the a text area on the dialog to have the name
-/// of the MP3 Library version.
-void LibraryPrefs::SetMP3VersionText(bool prompt)
-{
-   mMP3Version->SetValue(GetMP3Version(this, prompt));
-}
-
-void LibraryPrefs::SetFFmpegVersionText()
-{
-   mFFmpegVersion->SetValue(GetFFmpegVersion());
-}
-
-void LibraryPrefs::OnFFmpegFindButton(wxCommandEvent & WXUNUSED(event))
+void OnFFmpegFindButton(State &state)
 {
 #ifdef USE_FFMPEG
    bool showerrs =
@@ -183,39 +170,13 @@ void LibraryPrefs::OnFFmpegFindButton(wxCommandEvent & WXUNUSED(event))
 
    if (locate) {
       // Show "Locate FFmpeg" dialog
-      FindFFmpegLibs(this);
+      FindFFmpegLibs(state.parent);
       LoadFFmpeg(showerrs);
    }
-
-   SetFFmpegVersionText();
+   SetFFmpegVersionText(state);
 #endif
 }
 
-void LibraryPrefs::OnFFmpegDownButton(wxCommandEvent & WXUNUSED(event))
-{
-   HelpSystem::ShowHelp(this, L"FAQ:Installing_the_FFmpeg_Import_Export_Library", true);
-}
+LibraryPrefs::RegisteredControls reg{ wxT("FFmpeg"), AddControls };
 
-bool LibraryPrefs::Commit()
-{
-   ShuttleGui S(this, eIsSavingToPrefs);
-   PopulateOrExchange(S);
-
-   return true;
 }
-
-#if !defined(DISABLE_DYNAMIC_LOADING_FFMPEG) || !defined(DISABLE_DYNAMIC_LOADING_LAME)
-namespace{
-PrefsPanel::Registration sAttachment{ "Library",
-   [](wxWindow *parent, wxWindowID winid, AudacityProject *)
-   {
-      wxASSERT(parent); // to justify safenew
-      return safenew LibraryPrefs(parent, winid);
-   },
-   false,
-   // Register with an explicit ordering hint because this one is
-   // only conditionally compiled
-   { "", { Registry::OrderingHint::Before, "Directories" } }
-};
-}
-#endif

--- a/src/export/MP3Prefs.cpp
+++ b/src/export/MP3Prefs.cpp
@@ -1,0 +1,221 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  LibraryPrefs.cpp
+
+  Joshua Haberman
+  Dominic Mazzoni
+  James Crook
+
+*******************************************************************//**
+
+\class LibraryPrefs
+\brief A PrefsPanel used to select manage external libraries like the
+MP3 and FFmpeg encoding libraries.
+
+*//*******************************************************************/
+
+
+#include "LibraryPrefs.h"
+
+#include <wx/defs.h>
+#include <wx/stattext.h>
+
+#include "../FFmpeg.h"
+#include "../export/ExportMP3.h"
+#include "../widgets/HelpSystem.h"
+#include "../widgets/AudacityMessageBox.h"
+#include "../widgets/ReadOnlyText.h"
+#include "../widgets/wxTextCtrlWrapper.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define ID_FFMPEG_FIND_BUTTON       7003
+#define ID_FFMPEG_DOWN_BUTTON       7004
+
+BEGIN_EVENT_TABLE(LibraryPrefs, PrefsPanel)
+   EVT_BUTTON(ID_FFMPEG_FIND_BUTTON, LibraryPrefs::OnFFmpegFindButton)
+   EVT_BUTTON(ID_FFMPEG_DOWN_BUTTON, LibraryPrefs::OnFFmpegDownButton)
+END_EVENT_TABLE()
+
+LibraryPrefs::LibraryPrefs(wxWindow * parent, wxWindowID winid)
+/* i18-hint: refers to optional plug-in software libraries */
+:   PrefsPanel(parent, winid, XO("Libraries"))
+{
+   Populate();
+}
+
+LibraryPrefs::~LibraryPrefs()
+{
+}
+
+ComponentInterfaceSymbol LibraryPrefs::GetSymbol() const
+{
+   return LIBRARY_PREFS_PLUGIN_SYMBOL;
+}
+
+TranslatableString LibraryPrefs::GetDescription() const
+{
+   return XO("Preferences for Library");
+}
+
+ManualPageID LibraryPrefs::HelpPageName()
+{
+   return "Libraries_Preferences";
+}
+
+/// Creates the dialog and its contents.
+void LibraryPrefs::Populate()
+{
+   //------------------------- Main section --------------------
+   // Now construct the GUI itself.
+   // Use 'eIsCreatingFromPrefs' so that the GUI is
+   // initialised with values from gPrefs.
+   ShuttleGui S(this, eIsCreatingFromPrefs);
+   PopulateOrExchange(S);
+   // ----------------------- End of main section --------------
+
+   // Set the MP3 Version string.
+   SetMP3VersionText();
+   SetFFmpegVersionText();
+}
+
+/// This PopulateOrExchange function is a good example of mixing the fully
+/// automatic style of reading/writing from GUI to prefs with the partial form.
+///
+/// You'll notice that some of the Tie functions have Prefs identifiers in them
+/// and others don't.
+void LibraryPrefs::PopulateOrExchange(ShuttleGui & S)
+{
+   S.SetBorder(2);
+   S.StartScroller();
+
+   S.StartStatic(XO("LAME MP3 Export Library"));
+   {
+      S.StartTwoColumn();
+      {
+         mMP3Version = S
+            .Position(wxALIGN_CENTRE_VERTICAL)
+            .AddReadOnlyText(XO("MP3 Library Version:"), "");
+      }
+      S.EndTwoColumn();
+   }
+   S.EndStatic();
+
+   S.StartStatic(XO("FFmpeg Import/Export Library"));
+   {
+      S.StartTwoColumn();
+      {
+         auto version =
+#if defined(USE_FFMPEG)
+            XO("No compatible FFmpeg library was found");
+#else
+            XO("FFmpeg support is not compiled in");
+#endif
+
+         mFFmpegVersion = S
+            .Position(wxALIGN_CENTRE_VERTICAL)
+            .AddReadOnlyText(XO("FFmpeg Library Version:"), version.Translation());
+
+         S.AddVariableText(XO("FFmpeg Library:"),
+            true, wxALL | wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL);
+         S.Id(ID_FFMPEG_FIND_BUTTON);
+         S
+#if !defined(USE_FFMPEG) || defined(DISABLE_DYNAMIC_LOADING_FFMPEG)
+            .Disable()
+#endif
+            .AddButton(XXO("Loca&te..."),
+                       wxALL | wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL);
+         S.AddVariableText(XO("FFmpeg Library:"),
+            true, wxALL | wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL);
+         S.Id(ID_FFMPEG_DOWN_BUTTON);
+         S
+#if !defined(USE_FFMPEG) || defined(DISABLE_DYNAMIC_LOADING_FFMPEG)
+            .Disable()
+#endif
+            .AddButton(XXO("Dow&nload"),
+                       wxALL | wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL);
+      }
+      S.EndTwoColumn();
+   }
+   S.EndStatic();
+   S.EndScroller();
+
+}
+
+/// Sets the a text area on the dialog to have the name
+/// of the MP3 Library version.
+void LibraryPrefs::SetMP3VersionText(bool prompt)
+{
+   mMP3Version->SetValue(GetMP3Version(this, prompt));
+}
+
+void LibraryPrefs::SetFFmpegVersionText()
+{
+   mFFmpegVersion->SetValue(GetFFmpegVersion());
+}
+
+void LibraryPrefs::OnFFmpegFindButton(wxCommandEvent & WXUNUSED(event))
+{
+#ifdef USE_FFMPEG
+   bool showerrs =
+#if defined(_DEBUG)
+      true;
+#else
+      false;
+#endif
+   // Load the libs ('true' means that all errors will be shown)
+   bool locate = !LoadFFmpeg(showerrs);
+
+   // Libs are fine, don't show "locate" dialog unless user really wants it
+   if (!locate) {
+      int response = AudacityMessageBox(
+         XO(
+"Audacity has automatically detected valid FFmpeg libraries.\nDo you still want to locate them manually?"),
+         XO("Success"),
+         wxCENTRE | wxYES_NO | wxNO_DEFAULT |wxICON_QUESTION);
+      if (response == wxYES) {
+        locate = true;
+      }
+   }
+
+   if (locate) {
+      // Show "Locate FFmpeg" dialog
+      FindFFmpegLibs(this);
+      LoadFFmpeg(showerrs);
+   }
+
+   SetFFmpegVersionText();
+#endif
+}
+
+void LibraryPrefs::OnFFmpegDownButton(wxCommandEvent & WXUNUSED(event))
+{
+   HelpSystem::ShowHelp(this, L"FAQ:Installing_the_FFmpeg_Import_Export_Library", true);
+}
+
+bool LibraryPrefs::Commit()
+{
+   ShuttleGui S(this, eIsSavingToPrefs);
+   PopulateOrExchange(S);
+
+   return true;
+}
+
+#if !defined(DISABLE_DYNAMIC_LOADING_FFMPEG) || !defined(DISABLE_DYNAMIC_LOADING_LAME)
+namespace{
+PrefsPanel::Registration sAttachment{ "Library",
+   [](wxWindow *parent, wxWindowID winid, AudacityProject *)
+   {
+      wxASSERT(parent); // to justify safenew
+      return safenew LibraryPrefs(parent, winid);
+   },
+   false,
+   // Register with an explicit ordering hint because this one is
+   // only conditionally compiled
+   { "", { Registry::OrderingHint::Before, "Directories" } }
+};
+}
+#endif

--- a/src/export/MP3Prefs.cpp
+++ b/src/export/MP3Prefs.cpp
@@ -19,61 +19,6 @@
 
 namespace {
 
-#if 0
-////////////////////////////////////////////////////////////////////////////////
-
-#define ID_FFMPEG_FIND_BUTTON       7003
-#define ID_FFMPEG_DOWN_BUTTON       7004
-
-BEGIN_EVENT_TABLE(LibraryPrefs, PrefsPanel)
-   EVT_BUTTON(ID_FFMPEG_FIND_BUTTON, LibraryPrefs::OnFFmpegFindButton)
-   EVT_BUTTON(ID_FFMPEG_DOWN_BUTTON, LibraryPrefs::OnFFmpegDownButton)
-END_EVENT_TABLE()
-
-LibraryPrefs::LibraryPrefs(wxWindow * parent, wxWindowID winid)
-/* i18-hint: refers to optional plug-in software libraries */
-:   PrefsPanel(parent, winid, XO("Libraries"))
-{
-   Populate();
-}
-
-LibraryPrefs::~LibraryPrefs()
-{
-}
-
-ComponentInterfaceSymbol LibraryPrefs::GetSymbol() const
-{
-   return LIBRARY_PREFS_PLUGIN_SYMBOL;
-}
-
-TranslatableString LibraryPrefs::GetDescription() const
-{
-   return XO("Preferences for Library");
-}
-
-ManualPageID LibraryPrefs::HelpPageName()
-{
-   return "Libraries_Preferences";
-}
-
-/// Creates the dialog and its contents.
-void LibraryPrefs::Populate()
-{
-   //------------------------- Main section --------------------
-   // Now construct the GUI itself.
-   // Use 'eIsCreatingFromPrefs' so that the GUI is
-   // initialised with values from gPrefs.
-   ShuttleGui S(this, eIsCreatingFromPrefs);
-   PopulateOrExchange(S);
-   // ----------------------- End of main section --------------
-
-   // Set the MP3 Version string.
-   SetMP3VersionText();
-   SetFFmpegVersionText();
-}
-
-#endif
-
 void AddControls( ShuttleGui &S )
 {
    S.StartStatic(XO("LAME MP3 Export Library"));

--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -47,7 +47,6 @@ ImportLOF.cpp, and ImportAUP.cpp.
 #include <wx/listbox.h>
 #include <wx/log.h>
 #include <wx/sizer.h>         //for wxBoxSizer
-#include "../FFmpeg.h"
 #include "FileNames.h"
 #include "../ShuttleGui.h"
 #include "Project.h"
@@ -798,15 +797,19 @@ bool Importer::Import( AudacityProject &project,
       }
 
       // we were not able to recognize the file type
+      TranslatableString extraMessages;
+      for(const auto &importPlugin : sImportPluginList()) {
+         auto message = importPlugin->FailureHint();
+         if (!message.empty()) {
+            extraMessages += message;
+            extraMessages += Verbatim("\n");
+         }
+      }
+
       errorMessage = XO(
 /* i18n-hint: %s will be the filename */
 "Audacity did not recognize the type of the file '%s'.\n\n%sFor uncompressed files, also try File > Import > Raw Data.")
-         .Format( fName,
-#if defined(USE_FFMPEG)
-               !FFmpegFunctions::Load()
-                  ? XO("Try installing FFmpeg.\n\n") :
-#endif
-                  Verbatim("") );
+         .Format( fName, extraMessages );
    }
    else
    {

--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -86,32 +86,35 @@ ImportPluginList &Importer::sImportPluginList()
 }
 
 namespace {
-static const auto PathStart = wxT("Importers");
+static const auto PathStart = L"Importers";
 
-static Registry::GroupItem &sRegistry()
+
+}
+
+Registry::GroupItem &Importer::ImporterItem::Registry()
 {
    static Registry::TransparentGroupItem<> registry{ PathStart };
    return registry;
 }
 
-struct ImporterItem final : Registry::SingleItem {
-   ImporterItem( const Identifier &id, std::unique_ptr<ImportPlugin> pPlugin )
-      : SingleItem{ id }
-      , mpPlugin{ std::move( pPlugin ) }
-   {}
+Importer::ImporterItem::ImporterItem( const Identifier &id, std::unique_ptr<ImportPlugin> pPlugin )
+   : SingleItem{ id }
+   , mpPlugin{ std::move( pPlugin ) }
+{}
 
-   std::unique_ptr<ImportPlugin> mpPlugin;
-};
-}
+Importer::ImporterItem::~ImporterItem() = default;
 
 Importer::RegisteredImportPlugin::RegisteredImportPlugin(
    const Identifier &id,
    std::unique_ptr<ImportPlugin> pPlugin,
    const Registry::Placement &placement )
+   : RegisteredItem{
+      pPlugin
+         ? std::make_unique< ImporterItem >( id, std::move( pPlugin ) )
+         : nullptr,
+      placement
+   }
 {
-   if ( pPlugin )
-      Registry::RegisterItem( sRegistry(), placement,
-         std::make_unique< ImporterItem >( id, std::move( pPlugin ) ) );
 }
 
 UnusableImportPluginList &Importer::sUnusableImportPluginList()
@@ -147,7 +150,7 @@ bool Importer::Initialize()
          // Once only, visit the registry to collect the plug-ins properly
          // sorted
          TransparentGroupItem<> top{ PathStart };
-         Registry::Visit( *this, &top, &sRegistry() );
+         Registry::Visit( *this, &top, &ImporterItem::Registry() );
       }
 
       void Visit( SingleItem &item, const Path &path ) override

--- a/src/import/Import.h
+++ b/src/import/Import.h
@@ -77,12 +77,15 @@ class ExtImportItem
   wxArrayString mime_types;
 };
 
-class AUDACITY_DLL_API Importer {
+class AUDACITY_DLL_API  Importer {
+   struct ImporterItem;
 public:
 
    // Objects of this type are statically constructed in files implementing
    // subclasses of ImportPlugin
-   struct AUDACITY_DLL_API RegisteredImportPlugin{
+   struct AUDACITY_DLL_API RegisteredImportPlugin final
+      : public Registry::RegisteredItem<ImporterItem>
+   {
       RegisteredImportPlugin(
          const Identifier &id, // an internal string naming the plug-in
          std::unique_ptr<ImportPlugin>,
@@ -176,6 +179,14 @@ public:
               TranslatableString &errorMessage);
 
 private:
+   struct AUDACITY_DLL_API ImporterItem final : Registry::SingleItem {
+      static Registry::GroupItem &Registry();
+
+      ImporterItem( const Identifier &id, std::unique_ptr<ImportPlugin> pPlugin );
+      ~ImporterItem();
+      std::unique_ptr<ImportPlugin> mpPlugin;
+   };
+
    static Importer mInstance;
 
    ExtImportItems mExtImportItems;

--- a/src/import/ImportFFmpeg.cpp
+++ b/src/import/ImportFFmpeg.cpp
@@ -174,6 +174,12 @@ public:
    wxString GetPluginStringID() override { return wxT("libav"); }
    TranslatableString GetPluginFormatDescription() override;
 
+   TranslatableString FailureHint() const override
+   {
+      return !FFmpegFunctions::Load()
+         ? XO("Try installing FFmpeg.\n") : TranslatableString{};
+   }
+
    ///! Probes the file and opens it if appropriate
    std::unique_ptr<ImportFileHandle> Open(
       const FilePath &Filename, AudacityProject*) override;

--- a/src/import/ImportPlugin.cpp
+++ b/src/import/ImportPlugin.cpp
@@ -33,6 +33,11 @@ bool ImportPlugin::SupportsExtension(const FileExtension &extension)
    return mExtensions.Index(extension, false) != wxNOT_FOUND;
 }
 
+TranslatableString ImportPlugin::FailureHint() const
+{
+   return {};
+}
+
 ImportFileHandle::ImportFileHandle(const FilePath & filename)
 :  mFilename(filename)
 {

--- a/src/import/ImportPlugin.h
+++ b/src/import/ImportPlugin.h
@@ -59,6 +59,7 @@ class ProgressDialog;
 namespace BasicUI{ enum class ProgressResult : unsigned; }
 class WaveTrackFactory;
 class Track;
+class TranslatableString;
 class Tags;
 
 class ImportFileHandle;
@@ -81,6 +82,10 @@ public:
    // import.  If a filename matches any of these extensions,
    // this importer will get first dibs on importing it.
    virtual FileExtensions GetSupportedExtensions();
+
+   //! User visible message suggesting what to do when a file type isn't recognized; default empty string
+   /*! Should end with one newline if not empty */
+   virtual TranslatableString FailureHint() const;
 
    bool SupportsExtension(const FileExtension &extension);
 

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -18,7 +18,6 @@
 #include "../commands/CommandManager.h"
 #include "RealtimeEffectList.h"
 #include "RealtimeEffectState.h"
-#include "../export/ExportMP3.h"
 #include "../export/ExportMultiple.h"
 #include "../import/Import.h"
 #include "../import/ImportRaw.h"

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -31,6 +31,35 @@ MP3 and FFmpeg encoding libraries.
 
 
 ////////////////////////////////////////////////////////////////////////////////
+static const auto PathStart = wxT("LibraryPreferences");
+
+Registry::GroupItem &LibraryPrefs::PopulatorItem::Registry()
+{
+   static Registry::TransparentGroupItem<> registry{ PathStart };
+   return registry;
+}
+
+LibraryPrefs::PopulatorItem::PopulatorItem(
+   const Identifier &id, Populator populator)
+   : SingleItem{ id }
+   , mPopulator{ move(populator) }
+{}
+
+LibraryPrefs::RegisteredControls::RegisteredControls(
+   const Identifier &id, Populator populator,
+   const Registry::Placement &placement )
+   : RegisteredItem{
+      std::make_unique< PopulatorItem >( id, move(populator) ),
+      placement
+   }
+{}
+
+bool LibraryPrefs::RegisteredControls::Any()
+{
+   return !PopulatorItem::Registry().items.empty();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 #define ID_FFMPEG_FIND_BUTTON       7003
 #define ID_FFMPEG_DOWN_BUTTON       7004
@@ -89,8 +118,27 @@ void LibraryPrefs::Populate()
 /// and others don't.
 void LibraryPrefs::PopulateOrExchange(ShuttleGui & S)
 {
+   using namespace Registry;
+
    S.SetBorder(2);
    S.StartScroller();
+
+   struct MyVisitor final : Visitor {
+      MyVisitor( ShuttleGui &S ) : S{ S }
+      {
+         // visit the registry to collect the plug-ins properly
+         // sorted
+         TransparentGroupItem<> top{ PathStart };
+         Registry::Visit( *this, &top, &PopulatorItem::Registry() );
+      }
+
+      void Visit( Registry::SingleItem &item, const Path &path ) override
+      {
+         static_cast<PopulatorItem&>(item).mPopulator(S);
+      }
+
+      ShuttleGui &S;
+   } visitor{ S };
 
    S.StartStatic(XO("LAME MP3 Export Library"));
    {
@@ -219,3 +267,8 @@ PrefsPanel::Registration sAttachment{ "Library",
 };
 }
 #endif
+
+LibraryPrefs::RegisteredControls::Init::Init()
+{
+   (void) PopulatorItem::Registry();
+}

--- a/src/prefs/LibraryPrefs.h
+++ b/src/prefs/LibraryPrefs.h
@@ -13,6 +13,7 @@
 #ifndef __AUDACITY_FILE_FORMAT_PREFS__
 #define __AUDACITY_FILE_FORMAT_PREFS__
 
+#include <functional>
 #include <wx/defs.h>
 
 #include "PrefsPanel.h"
@@ -26,7 +27,25 @@ class ShuttleGui;
 
 class LibraryPrefs final : public PrefsPanel
 {
+   struct PopulatorItem;
  public:
+
+   //! Type of function that adds to the Library preference page
+   using Populator = std::function< void(ShuttleGui&) >;
+
+   //! To be statically constructed, it registers additions to the Library preference page
+   struct AUDACITY_DLL_API RegisteredControls
+      : public Registry::RegisteredItem<PopulatorItem>
+   {
+      // Whether any controls have been registered
+      static bool Any();
+
+      RegisteredControls( const Identifier &id, Populator populator,
+         const Registry::Placement &placement = { wxEmptyString, {} } );
+
+      struct AUDACITY_DLL_API Init{ Init(); };
+   };
+
    LibraryPrefs(wxWindow * parent, wxWindowID winid);
    ~LibraryPrefs();
    ComponentInterfaceSymbol GetSymbol() const override;
@@ -36,18 +55,33 @@ class LibraryPrefs final : public PrefsPanel
    ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
+
  private:
-   void Populate();
    void SetMP3VersionText(bool prompt = false);
    void SetFFmpegVersionText();
-
+ 
    void OnFFmpegFindButton(wxCommandEvent & e);
    void OnFFmpegDownButton(wxCommandEvent & e);
+
 
    ReadOnlyText *mMP3Version;
    ReadOnlyText *mFFmpegVersion;
 
    DECLARE_EVENT_TABLE()
+
+ private:
+   struct AUDACITY_DLL_API PopulatorItem final : Registry::SingleItem {
+      static Registry::GroupItem &Registry();
+   
+      PopulatorItem(const Identifier &id, Populator populator);
+
+      Populator mPopulator;
+   };
+
+   void Populate();
 };
+
+// Guarantees registry exists before attempts to use it
+static LibraryPrefs::RegisteredControls::Init sInitRegisteredControls;
 
 #endif

--- a/src/prefs/LibraryPrefs.h
+++ b/src/prefs/LibraryPrefs.h
@@ -20,7 +20,6 @@
 
 class wxStaticText;
 class wxTextCtrl;
-class ReadOnlyText;
 class ShuttleGui;
 
 #define LIBRARY_PREFS_PLUGIN_SYMBOL ComponentInterfaceSymbol{ XO("Library") }
@@ -55,19 +54,6 @@ class LibraryPrefs final : public PrefsPanel
    ManualPageID HelpPageName() override;
    void PopulateOrExchange(ShuttleGui & S) override;
 
-
- private:
-   void SetMP3VersionText(bool prompt = false);
-   void SetFFmpegVersionText();
- 
-   void OnFFmpegFindButton(wxCommandEvent & e);
-   void OnFFmpegDownButton(wxCommandEvent & e);
-
-
-   ReadOnlyText *mMP3Version;
-   ReadOnlyText *mFFmpegVersion;
-
-   DECLARE_EVENT_TABLE()
 
  private:
    struct AUDACITY_DLL_API PopulatorItem final : Registry::SingleItem {

--- a/src/prefs/PrefsDialog.cpp
+++ b/src/prefs/PrefsDialog.cpp
@@ -485,12 +485,17 @@ PrefsDialog::PrefsDialog(
                   const auto &node = *it;
                   const auto &factory = node.factory;
                   wxWindow *const w = factory(mCategories, wxID_ANY, pProject);
-                  if (stack.empty())
+                  node.enabled = (w != nullptr);
+                  if (stack.empty()) {
                      // Parameters are: AddPage(page, name, IsSelected, imageId).
-                     mCategories->AddPage(w, w->GetName(), false, 0);
+                     if (w)
+                        mCategories->AddPage(w, w->GetName(), false, 0);
+                  }
                   else {
                      IntPair &top = *stack.rbegin();
-                     mCategories->InsertSubPage(top.first, w, w->GetName(), false, 0);
+                     if (w)
+                        mCategories->InsertSubPage(top.first,
+                           w, w->GetName(), false, 0);
                      if (--top.second == 0) {
                         // Expand all nodes before the layout calculation
                         mCategories->ExpandNode(top.first, true);
@@ -513,18 +518,21 @@ PrefsDialog::PrefsDialog(
          const auto &node = factories[0];
          const auto &factory = node.factory;
          mUniquePage = factory(S.GetParent(), wxID_ANY, pProject);
-         wxWindow * uniquePageWindow = S.Prop(1)
-            .Position(wxEXPAND)
-            .AddWindow(mUniquePage);
-         // We're not in the wxTreebook, so add the accelerator here
-         wxAcceleratorEntry entries[1];
+         node.enabled = (mUniquePage != nullptr);
+         if (mUniquePage) {
+            wxWindow * uniquePageWindow = S.Prop(1)
+               .Position(wxEXPAND)
+               .AddWindow(mUniquePage);
+            // We're not in the wxTreebook, so add the accelerator here
+            wxAcceleratorEntry entries[1];
 #if defined(__WXMAC__)
-         // Is there a standard shortcut on Mac?
+            // Is there a standard shortcut on Mac?
 #else
-         entries[0].Set(wxACCEL_NORMAL, (int) WXK_F1, wxID_HELP);
+            entries[0].Set(wxACCEL_NORMAL, (int) WXK_F1, wxID_HELP);
 #endif
-         wxAcceleratorTable accel(1, entries);
-         uniquePageWindow->SetAcceleratorTable(accel);
+            wxAcceleratorTable accel(1, entries);
+            uniquePageWindow->SetAcceleratorTable(accel);
+         }
       }
    }
    S.EndVerticalLay();
@@ -552,8 +560,10 @@ PrefsDialog::PrefsDialog(
    {
       int iPage = 0;
       for (auto it = factories.begin(), end = factories.end();
-         it != end; ++it, ++iPage)
-         mCategories->ExpandNode(iPage, it->expanded);
+         it != end; ++it) {
+         if (it->enabled)
+            mCategories->ExpandNode(iPage++, it->expanded);
+      }
    }
 
    // This ASSERT was originally used to limit us to 800 x 600.
@@ -605,7 +615,7 @@ int PrefsDialog::ShowModal()
          selected = 0;  // clamp to available range of tabs
       mCategories->SetSelection(selected);
    }
-   else {
+   else if (mUniquePage) {
       auto Temp = mTitlePrefix;
       Temp.Join( Verbatim( mUniquePage->GetLabel() ), wxT(" ") );
       SetTitle(Temp);
@@ -624,7 +634,7 @@ void PrefsDialog::OnCancel(wxCommandEvent & WXUNUSED(event))
          ((PrefsPanel *)mCategories->GetPage(i))->Cancel();
       }
    }
-   else
+   else if (mUniquePage)
       mUniquePage->Cancel();
 
    // Remember modified dialog size, even if cancelling.
@@ -643,21 +653,21 @@ PrefsPanel * PrefsDialog::GetCurrentPanel()
    if( mCategories) 
       return static_cast<PrefsPanel*>(mCategories->GetCurrentPage());
    else
-   {
-      wxASSERT( mUniquePage );
       return mUniquePage;
-   }
 }
 
 void PrefsDialog::OnPreview(wxCommandEvent & WXUNUSED(event))
 {
-   GetCurrentPanel()->Preview();
+   if (const auto pPanel = GetCurrentPanel())
+      pPanel->Preview();
 }
 
 void PrefsDialog::OnHelp(wxCommandEvent & WXUNUSED(event))
 {
-   const auto &page = GetCurrentPanel()->HelpPageName();
-   HelpSystem::ShowHelp(this, page, true);
+   if (const auto pPanel = GetCurrentPanel()) {
+      const auto &page = pPanel->HelpPageName();
+      HelpSystem::ShowHelp(this, page, true);
+   }
 }
 
 void PrefsDialog::ShuttleAll( ShuttleGui & S)
@@ -673,7 +683,8 @@ void PrefsDialog::ShuttleAll( ShuttleGui & S)
    else
    {
       S.ResetId();
-      mUniquePage->PopulateOrExchange( S );
+      if (mUniquePage)
+         mUniquePage->PopulateOrExchange( S );
    }
 }
 
@@ -701,7 +712,7 @@ void PrefsDialog::OnOK(wxCommandEvent & WXUNUSED(event))
          }
       }
    }
-   else {
+   else if (mUniquePage) {
       if (!mUniquePage->Validate())
          return;
    }
@@ -719,7 +730,7 @@ void PrefsDialog::OnOK(wxCommandEvent & WXUNUSED(event))
          panel->Commit();
       }
    }
-   else {
+   else if (mUniquePage) {
       mUniquePage->Preview();
       mUniquePage->Commit();
    }
@@ -835,8 +846,10 @@ void PrefsDialog::RecordExpansionState()
    {
       int iPage = 0;
       for (auto it = mFactories.begin(), end = mFactories.end();
-         it != end; ++it, ++iPage)
-         it->expanded = mCategories->IsNodeExpanded(iPage);
+         it != end; ++it) {
+         if (it->enabled)
+            it->expanded = mCategories->IsNodeExpanded(iPage++);
+      }
    }
    else
       mFactories[0].expanded = true;

--- a/src/prefs/PrefsPanel.cpp
+++ b/src/prefs/PrefsPanel.cpp
@@ -41,7 +41,7 @@ struct PrefsItemVisitor final : Registry::Visitor {
    void BeginGroup( Registry::GroupItem &item, const Path & ) override
    {
       auto pItem = dynamic_cast<PrefsItem*>( &item );
-      if (!pItem)
+      if (!pItem || !pItem->factory)
          return;
       indices.push_back( factories.size() );
       factories.emplace_back( pItem->factory, 0, pItem->expanded );
@@ -51,7 +51,7 @@ struct PrefsItemVisitor final : Registry::Visitor {
    void EndGroup( Registry::GroupItem &item, const Path & ) override
    {
       auto pItem = dynamic_cast<PrefsItem*>( &item );
-      if (!pItem)
+      if (!pItem || !pItem->factory)
          return;
       auto &factory = factories[ indices.back() ];
       factory.nChildren = childCounts.back();

--- a/src/prefs/PrefsPanel.h
+++ b/src/prefs/PrefsPanel.h
@@ -49,6 +49,8 @@ class ShuttleGui;
 class AUDACITY_DLL_API PrefsPanel /* not final */
    : public wxPanelWrapper, ComponentInterface
 {
+   struct PrefsItem;
+
  public:
     // An array of PrefsNode specifies the tree of pages in pre-order traversal.
     struct PrefsNode {
@@ -82,6 +84,7 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
    // Typically you make a static object of this type in the .cpp file that
    // also implements the PrefsPanel subclass.
    struct AUDACITY_DLL_API Registration final
+      : public Registry::RegisteredItem<PrefsItem>
    {
       Registration( const wxString &name, const Factory &factory,
          bool expanded = true,
@@ -121,6 +124,20 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
    virtual ManualPageID HelpPageName();
 
    virtual void Cancel();
+
+ private:
+   struct AUDACITY_DLL_API PrefsItem final
+      : Registry::ConcreteGroupItem<false> {
+      PrefsPanel::Factory factory;
+      bool expanded{ false };
+
+      static Registry::GroupItem &Registry();
+
+      PrefsItem( const wxString &name,
+         const PrefsPanel::Factory &factory_, bool expanded_ );
+
+      struct Visitor;
+   };
 };
 
 #endif

--- a/src/prefs/PrefsPanel.h
+++ b/src/prefs/PrefsPanel.h
@@ -58,6 +58,7 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
        Factory factory;
        size_t nChildren{ 0 };
        bool expanded{ false };
+       mutable bool enabled{ true };
 
        PrefsNode(const Factory &factory_,
           unsigned nChildren_ = 0,


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Some dependency breaking before other import and export refactoring into modules

QA:  Test that all works as before in the Libraries page of the Preferences dialog.

Verify that the error message shows as before, when you try to import a file type that requires FFmpeg, but that is not installed on the system.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
