### PR TITLE
Position independent code for GNU compiles of some 3party libs...

### DIFF
--- a/cmake-proxies/libsbsms/CMakeLists.txt
+++ b/cmake-proxies/libsbsms/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       ${TARGET_ROOT}/src/buffer.cpp
       ${TARGET_ROOT}/src/dBTable.cpp
@@ -18,14 +18,14 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/src/trackpoint.cpp
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PRIVATE
       ${_PRVDIR}
    PUBLIC
       ${TARGET_ROOT}/include
 )
 
-list( APPEND OPTIONS
+set( OPTIONS
    PRIVATE
       $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-enum-compare>
       ${MMX_FLAG}
@@ -48,3 +48,4 @@ target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_options( ${TARGET} PRIVATE ${OPTIONS} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
 
+set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE On)

--- a/cmake-proxies/libvamp/CMakeLists.txt
+++ b/cmake-proxies/libvamp/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       ${TARGET_ROOT}/src/vamp-hostsdk/PluginBufferingAdapter.cpp
       ${TARGET_ROOT}/src/vamp-hostsdk/PluginChannelAdapter.cpp
@@ -15,12 +15,12 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/src/vamp-hostsdk/RealTime.cpp
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PUBLIC
       ${TARGET_ROOT}
 )
 
-list( APPEND DEFINES
+set( DEFINES
    PRIVATE
       _USE_MATH_DEFINES
 )
@@ -30,3 +30,4 @@ target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
 
+set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE On)

--- a/cmake-proxies/lv2/CMakeLists.txt
+++ b/cmake-proxies/lv2/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
 
       # lilv
@@ -70,7 +70,7 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/suil/suil/suil.h
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PRIVATE
       ${_PRVDIR}
       ${TARGET_ROOT}/lilv/src
@@ -90,12 +90,12 @@ list( APPEND INCLUDES
       ${TARGET_ROOT}/suil
 )
 
-list( APPEND DEFINES
+set( DEFINES
    PRIVATE
       SUIL_INTERNAL
 )
 
-list( APPEND HEADERS
+set( HEADERS
 
    # lv2
 
@@ -271,3 +271,4 @@ target_sources( ${TARGET} PRIVATE ${SOURCES} ${HEADERS} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
 
+set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE On)

--- a/cmake-proxies/portsmf/CMakeLists.txt
+++ b/cmake-proxies/portsmf/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       ${TARGET_ROOT}/allegro.cpp
       ${TARGET_ROOT}/allegrord.cpp
@@ -15,7 +15,7 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/strparse.cpp
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PUBLIC
       ${TARGET_ROOT}/include
 )
@@ -24,3 +24,4 @@ organize_source( "${TARGET_ROOT}" "" "${SOURCES}" )
 target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
 
+set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE On)

--- a/cmake-proxies/soundtouch/CMakeLists.txt
+++ b/cmake-proxies/soundtouch/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES 
+set( SOURCES 
    PRIVATE
       ${TARGET_ROOT}/source/SoundTouch/AAFilter.cpp
       ${TARGET_ROOT}/source/SoundTouch/FIFOSampleBuffer.cpp
@@ -16,13 +16,13 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/source/SoundTouch/sse_optimized.cpp
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PUBLIC
       ${_PUBDIR}
       ${TARGET_ROOT}/include
 )
 
-list( APPEND OPTIONS
+set( OPTIONS
    PRIVATE
       ${MMX_FLAG}
       ${SSE_FLAG}
@@ -35,3 +35,4 @@ target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_options( ${TARGET} PRIVATE ${OPTIONS} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
 
+set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE On)

--- a/cmake-proxies/sqlite/CMakeLists.txt
+++ b/cmake-proxies/sqlite/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
 
       # sqlite
@@ -12,12 +12,12 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/sqlite3.h
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PUBLIC
       ${TARGET_ROOT}
 )
 
-list( APPEND DEFINES
+set( DEFINES
    PRIVATE
       #
       # Recommended in SQLite docs
@@ -43,4 +43,6 @@ organize_source( "${TARGET_ROOT}" "" "${SOURCES}" )
 target_sources( ${TARGET} PRIVATE ${SOURCES} )
 target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
+
+set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE On)
 

--- a/cmake-proxies/twolame/CMakeLists.txt
+++ b/cmake-proxies/twolame/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       ${TARGET_ROOT}/libtwolame/ath.c
       ${TARGET_ROOT}/libtwolame/availbits.c
@@ -26,19 +26,19 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/libtwolame/util.c
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PRIVATE
       ${_PRVDIR}
    PUBLIC
       ${TARGET_ROOT}/libtwolame
 )
 
-list( APPEND DEFINES
+set( DEFINES
    PRIVATE
       LIBTWOLAME_STATIC
 )
 
-list( APPEND OPTIONS
+set( OPTIONS
    PRIVATE
       $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-implicit-function-declaration>
 )
@@ -54,3 +54,4 @@ target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
 target_compile_options( ${TARGET} PRIVATE ${OPTIONS} )
 target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
 
+set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE On)


### PR DESCRIPTION
... so that they can be linked into MODULE type libraries, when later we make extractions.

But following the example of 824ffe95, just do it for all platforms, though not needed to make modules on macOS or Windows.

(Also improve some CMake code to assign, not append list variables so that they aren't contaminated by the calling environment.)

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
