### PR TITLE
A bit of fun with templates

### DIFF
--- a/libraries/lib-audio-io/ProjectAudioIO.cpp
+++ b/libraries/lib-audio-io/ProjectAudioIO.cpp
@@ -16,9 +16,9 @@ Paul Licameli split from AudacityProject.cpp
 #include "ProjectRate.h"
 #include "Track.h"
 
-const std::function<ProjectAudioIO::OptionsFactory>
-ProjectAudioIO::DefaultOptionsFactory()
-{ return [] (AudacityProject &project, bool) {
+AudioIOStartStreamOptions
+ProjectAudioIO::DefaultOptionsFactory(AudacityProject &project, bool)
+{
    auto &projectAudioIO = Get(project);
    AudioIOStartStreamOptions options{
       project.shared_from_this(), ProjectRate::Get(project).GetRate()
@@ -30,7 +30,7 @@ ProjectAudioIO::DefaultOptionsFactory()
    // options.listener remains null
    // boolean argument is ignored
    return options;
-}; }
+}
 
 AudioIOStartStreamOptions ProjectAudioIO::GetDefaultOptions(
    AudacityProject &project, bool newDefaults)

--- a/libraries/lib-audio-io/ProjectAudioIO.h
+++ b/libraries/lib-audio-io/ProjectAudioIO.h
@@ -31,19 +31,14 @@ class AUDIO_IO_API ProjectAudioIO final
    , public Observer::Publisher<SpeedChangeMessage>
 {
 public:
-   //! Type of function constructing AudioIOStartStreamOptions
-   using OptionsFactory =
-      AudioIOStartStreamOptions(
-         AudacityProject &project, bool newDefaults);
-
    //! Default factory function ignores the second argument
    static AudioIOStartStreamOptions
    DefaultOptionsFactory(AudacityProject &project, bool newDefaults);
 
    //! Global hook making AudioIOStartStreamOptions for a project, which
    //! has a non-trivial default implementation
-   struct AUDIO_IO_API DefaultOptions : GlobalHook< DefaultOptions,
-      OptionsFactory, DefaultOptionsFactory
+   struct AUDIO_IO_API DefaultOptions : DefaultedGlobalHook<DefaultOptions,
+      DefaultOptionsFactory
    >{};
 
    //! Invoke the global hook, supplying a default argument

--- a/libraries/lib-audio-io/ProjectAudioIO.h
+++ b/libraries/lib-audio-io/ProjectAudioIO.h
@@ -36,15 +36,14 @@ public:
       AudioIOStartStreamOptions(
          AudacityProject &project, bool newDefaults);
 
-   //! Function returning a default factory function, which ignores the
-   //! second argument
-   static const std::function<OptionsFactory> DefaultOptionsFactory();
+   //! Default factory function ignores the second argument
+   static AudioIOStartStreamOptions
+   DefaultOptionsFactory(AudacityProject &project, bool newDefaults);
 
    //! Global hook making AudioIOStartStreamOptions for a project, which
    //! has a non-trivial default implementation
    struct AUDIO_IO_API DefaultOptions : GlobalHook< DefaultOptions,
-      OptionsFactory,
-      DefaultOptionsFactory // default installed implementation
+      OptionsFactory, DefaultOptionsFactory
    >{};
 
    //! Invoke the global hook, supplying a default argument

--- a/libraries/lib-utility/GlobalVariable.h
+++ b/libraries/lib-utility/GlobalVariable.h
@@ -158,6 +158,9 @@ class GlobalHook : public GlobalVariable<Tag,
 {
 public:
    using result_type = typename std::function<Signature>::result_type;
+   using Scope = typename GlobalVariable<Tag,
+      const std::function<Signature>, Default, Options...
+   >::Scope;
 
    //! Null check of the installed function is done for you
    /*! Requires that the return type of the function is void or
@@ -173,6 +176,24 @@ public:
       else
          return result_type{};
    }
+
+   //! Can generate overriding hooks of unique_ptr factories
+   template<typename Derived>
+   struct SubstituteInUnique : Scope { SubstituteInUnique() : Scope{
+      // Generic lambda is coerced to the needed pointer-to-function type
+      [](auto &&...args) -> result_type { return
+         std::make_unique<Derived>(std::forward<decltype(args)>(args)...);
+      }
+   }{}};
+
+   //! Can generate overriding hooks of shared_ptr factories
+   template<typename Derived>
+   struct SubstituteInShared : Scope { SubstituteInShared() : Scope{
+      // Generic lambda is coerced to the needed pointer-to-function type
+      [](auto &&...args) -> result_type { return
+         std::make_shared<Derived>(std::forward<decltype(args)>(args)...);
+      }
+   }{}};
 };
 
 //! Global function-valued variable, with a default implementation given,
@@ -186,6 +207,28 @@ class DefaultedGlobalHook : public GlobalHook< Tag,
    Options...
 >
 {
+};
+
+//! Generates functions useful as defaults of hooks
+template<typename Type, typename... Arguments> struct UniquePtrFactory {
+   static auto Function(Arguments... arguments) -> std::unique_ptr<Type>
+   {
+      return std::make_unique<Type>(std::forward<Arguments&&>(arguments)...);
+   }
+};
+
+//! Generates functions useful as defaults of hooks
+template<typename Type, typename... Arguments> struct SharedPtrFactory {
+   static auto Function(Arguments... arguments) -> std::shared_ptr<Type>
+   {
+      return std::make_shared<Type>(std::forward<Arguments&&>(arguments)...);
+   }
+};
+
+//! Generates functions returning a constant
+//! (not needed for the default-constructed value of a hook's return type)
+template<auto Value, typename... Arguments> struct Constantly {
+   static decltype(Value) Function (Arguments...) { return Value; }
 };
 
 #endif

--- a/libraries/lib-utility/GlobalVariable.h
+++ b/libraries/lib-utility/GlobalVariable.h
@@ -175,4 +175,17 @@ public:
    }
 };
 
+//! Global function-valued variable, with a default implementation given,
+//! and adding a convenient Call()
+/*!
+ @tparam DefaultFunction names a function or static member function
+ */
+template<typename Tag, auto DefaultFunction, auto... Options>
+class DefaultedGlobalHook : public GlobalHook< Tag,
+   std::remove_pointer_t<decltype(DefaultFunction)>, DefaultFunction,
+   Options...
+>
+{
+};
+
 #endif

--- a/libraries/lib-utility/GlobalVariable.h
+++ b/libraries/lib-utility/GlobalVariable.h
@@ -26,11 +26,11 @@
  no initializer function; if const-qualified, that means Get() gives
  non-mutating access, but Set() and Scope{...} are still possible if Type is
  movable
- @tparam initializer optional function that computes initial value
+ @tparam initializer initial value, or a function that computes initial value
  @tparam ScopedOnly if true, then enforce RAII for changes of the variable
  (do not generate Set() or Scope::Commit())
  */
-template <typename Tag, typename Type, Type (*initializer)() = nullptr,
+template <typename Tag, typename Type, auto initializer = nullptr,
    bool ScopedOnly = true>
 class GlobalVariable {
    struct dummy{ explicit dummy(){} };
@@ -124,7 +124,13 @@ private:
    static mutable_type &Instance()
    {
       static_assert(!std::is_reference_v<stored_type>);
-      if constexpr (initializer != nullptr) {
+      if constexpr (std::is_convertible_v<
+        decltype(initializer), mutable_type
+      >) {
+         static mutable_type instance{ initializer };
+         return instance;
+      }
+      else if constexpr (initializer != nullptr) {
          static mutable_type instance{ initializer() };
          return instance;
       }
@@ -144,9 +150,11 @@ private:
 };
 
 //! Global function-valued variable, adding a convenient Call()
-template<typename Tag, typename Signature, auto... Options>
-class GlobalHook
-   : public GlobalVariable<Tag, const std::function<Signature>, Options...>
+template<typename Tag, typename Signature, auto Default = nullptr,
+   auto... Options>
+class GlobalHook : public GlobalVariable<Tag,
+   const std::function<Signature>, Default, Options...
+>
 {
 public:
    using result_type = typename std::function<Signature>::result_type;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1159,7 +1159,7 @@ const ReservedCommandFlag&
 static ProjectAudioIO::DefaultOptions::Scope sScope {
 [](AudacityProject &project, bool newDefault) -> AudioIOStartStreamOptions {
    //! Invoke the library default implemantation directly bypassing the hook
-   auto options = ProjectAudioIO::DefaultOptionsFactory()(project, newDefault);
+   auto options = ProjectAudioIO::DefaultOptionsFactory(project, newDefault);
 
    //! Decorate with more info
    options.listener = ProjectAudioManager::Get(project).shared_from_this();


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Redo the fix at 6a6b6d41961e24dd493aed8a621367088d4f0f72 with new template conveniences that simplify it, and will simplify many repetitions of the pattern to come in more refactoring.

QA: test starting and stopping of playback, recording (including punch-and-roll), monitoring (click in the output meter), play-at-speed button, scrubbing

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
