### PR TITLE
Additional ruler changes

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVRulerControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVRulerControls.cpp
@@ -353,7 +353,7 @@ void WaveformVRulerControls::DoUpdateVRuler(
       }
    }
    else {
-      vruler->SetUnits({});
+      vruler->SetUnits(XO("dB"));
       
       auto &cache = WaveformScale::Get(*wt);
       

--- a/src/widgets/LinearUpdater.cpp
+++ b/src/widgets/LinearUpdater.cpp
@@ -54,9 +54,9 @@ void LinearUpdater::Update(
          mMin, mMax, mLength, mRight, mBottom, &context]
    (double value) -> int {
       // Make a tick only if the value is strictly between the bounds
-      if (value <= std::min(mMin, mMax))
+      if (value < std::min(mMin, mMax))
          return -1;
-      if (value >= std::max(mMin, mMax))
+      if (value > std::max(mMin, mMax))
          return -1;
 
       int mid;

--- a/src/widgets/TimeFormat.cpp
+++ b/src/widgets/TimeFormat.cpp
@@ -112,8 +112,7 @@ void TimeFormat::SetLabelString(
 
    if (tickType == RulerFormat::t_major) {
       if (d < 0) {
-         s = wxT("-");
-         d = -d;
+         return;
       }
 
 #if ALWAYS_HH_MM_SS


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Extends
- [x] #4394 

Three commits from @micpap25 that this reviewer was unsure of.  They would have some visible side effects on other rulers than the beats and measures.  Are they really part of the intended scope?

- Fix an off-by-one error (was it an error?) drawing ticks at extremes
- Add "dB" after each number on the old logarithmic vertical ruler
- Don't draw negative time.  (But in #4394 already, there are no negative beats.)

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
