### PR TITLE
fix default time format and TimeAndSampleFormat index

### DIFF
--- a/libraries/lib-numeric-formats/NumericConverter.cpp
+++ b/libraries/lib-numeric-formats/NumericConverter.cpp
@@ -527,9 +527,9 @@ static const BuiltinFormatString BandwidthConverterFormats_[] = {
 // ----------------------------------------------------------------------------
 //
 NumericFormatSymbol NumericConverter::DefaultSelectionFormat()
-{ return TimeConverterFormats_[4].name; }
-NumericFormatSymbol NumericConverter::TimeAndSampleFormat()
 { return TimeConverterFormats_[5].name; }
+NumericFormatSymbol NumericConverter::TimeAndSampleFormat()
+{ return TimeConverterFormats_[6].name; }
 NumericFormatSymbol NumericConverter::SecondsFormat()
 { return TimeConverterFormats_[0].name; }
 NumericFormatSymbol NumericConverter::HoursMinsSecondsFormat()
@@ -574,7 +574,7 @@ NumericConverter::NumericConverter(Type type,
    mType = type;
 
    if (type == NumericConverter::TIME )
-      mDefaultNdx = 4; // Default to "hh:mm:ss + milliseconds".
+      mDefaultNdx = 5; // Default to "hh:mm:ss + milliseconds".
 
    mScalingFactor = 1.0f;
    mSampleRate = 1.0f;


### PR DESCRIPTION
Resolves: #4408

It appears that at some point, an additional time format was added before the default time format (hh:mm:ss - milliseconds), without updating places where the index of the hh:mm:ss - milliseconds format is used. I updated the references to this index and to the index for TimeAndSampleFormat referenced in NumericConverter.cpp.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
