### PR TITLE
"Delay" effect: Add better quality pitch shifting

### DIFF
--- a/plug-ins/delay.ny
+++ b/plug-ins/delay.ny
@@ -6,11 +6,11 @@ $name (_ "Delay")
 $manpage "Delay"
 $debugbutton false
 $author (_ "Steve Daulton")
-$release 2.3.1-1
+$release 2.4.2-1
 $copyright (_ "GNU General Public License v2.0")
 
 
-;; License: GPL v2
+;; License: GPL v2 or later.
 ;; http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 ;; based on 'Delay' by David R. Sky
 ;;
@@ -24,20 +24,62 @@ $control delay-type (_ "Delay type") choice ((_ "Regular")
 $control dgain (_ "Delay level per echo (dB)") real "" -6 -30 1
 $control delay (_ "Delay time (seconds)") real "" 0.3 0 5
 $control pitch-type (_ "Pitch change effect") choice (("PitchTempo" (_ "Pitch/Tempo"))
-                                                      ("LQPitchShift" (_ "Low-quality Pitch Shift"))) 0 
+                                                      ("LQPitchShift" (_ "Low-quality Pitch Shift"))
+                                                      ("HQPitchShift" (_ "High-quality Pitch Shift"))) 0
 $control shift (_ "Pitch change per echo (semitones)") real "" 0 -2 2
 $control number (_ "Number of echoes") int "" 5 1 30
 $control constrain (_ "Allow duration to change") choice ((_ "Yes")(_ "No")) 0 
 
 
-;; The default pitch shift effect is a simple resampling, 
-;; so both pitch and tempo of the delayed audio will change 
-;; [as in Audacity's Change Speed effect].
-;; LQ Pitch Shift (Low Quality) changes the pitch without 
-;; changing the tempo, but the sound quality is not very good 
-;; and tends to cause a short echo effect which can be quite 
-;; noticeable on percussive sounds though may be acceptable 
-;; on other sounds.
+;; High-quality Pitch Shift option added, March 2023.
+;;
+;; "High-quality Pitch Shift" is accomplished with a phase vocoder.
+;; "Pitch/Tempo" and "Low-quality Pitch Shift" remain identical
+;; to previous version of Audacity.
+;;
+;; "Pitch/Tempo" is simple resampling, so both pitch and tempo
+;; of the delayed audio will change (as in Audacity's
+;; "Change Speed" effect).
+;;
+;; "Low-quality Pitch Shift" changes the pitch without changing
+;; the tempo, but has relatively poor sound quality.
+
+
+;;; Pitch shift audio.
+(defun p-shift (sig snd-len ratio)
+  (when (= shift 0)
+    ; no-op.
+    (return-from p-shift sig))
+  (case pitch-type (0 (change-speed sig ratio))
+                   (1 (lq-pitch sig ratio))
+                   (t (hq-pitch sig snd-len ratio))))
+
+
+;;; Change speed.
+(defun change-speed (sig ratio)
+  (force-srate *sound-srate* 
+    (stretch-abs (/ ratio) (sound sig))))
+
+
+;;; Low quality pitch shift.
+;; This uses the ancient "Synthesis Toolkit" pitch shifter.
+;; STK_PITSHIFT: a simple pitch shifter using delay lines.
+;; Filtering and fixed sample rate are used to squeeze slightly
+;; better sound quality out of this old library.
+(defun lq-pitch(sig ratio)
+  ; pitshift quality best at 44100
+  (let ((sig (force-srate 44100 sig))
+          ; anti-alias filter frequency
+          (minrate (* 0.5 (min *sound-srate* 44100))))
+      (force-srate *sound-srate*
+        ; pitshift requires rates to match
+        (progv '(*sound-srate*) (list 44100)
+          (cond 
+            ((> shift 5)  ; reduce aliasing
+              (pitshift (lp-wall sig (/ minrate ratio)) ratio 1))
+            ((< shift -2)  ; reduce sub-sonic frequencies
+              (pitshift (hp sig 20) ratio 1))
+            (T (pitshift sig ratio 1)))))))
 
 
 ;;; Anti-alias low pass filter
@@ -47,69 +89,52 @@ $control constrain (_ "Allow duration to change") choice ((_ "Yes")(_ "No")) 0
       ((= count 10) sig)
     (setf sig (lowpass8 sig freq))))
 
-;;; Change speed
-(defun change-speed (sig shift)
-  (if (= shift 0)                               ; no pitch shift
-    sig
-    (let ((ratio (expt 0.5 (/ shift 12.0))))    ; shift value as frequency ratio
-      (force-srate *sound-srate* 
-        (stretch-abs ratio (sound sig))))))
 
-;;; Pitch shift audio 
-(defun p-shift (sig shift)
-  (if (= shift 0)                               ; no pitch shift
-    sig
-    (let ((sig (force-srate 44100 sig))         ; pitshift quality best at 44100
-          ; anti-alias filter frequency
-          (minrate (* 0.5 (min *sound-srate* 44100)))
-          (ratio (expt 0.5 (/ shift -12.0))))   ; shift value as frequency ratio
-      (force-srate *sound-srate*                ; convert back to correct rate
-        (progv '(*sound-srate*) (list 44100)    ; pitshift requires rates to match
-          (cond 
-            ((> shift 5)                        ; reduce aliasing
-              (pitshift (lp-wall sig (/ minrate ratio)) ratio 1))
-            ((< shift -2)
-              (pitshift (hp sig 20) ratio 1))   ; reduce sub-sonic frequencies
-            (T (pitshift sig ratio 1))))))))
+;;; High quality pitch shift.
+(defun hq-pitch(sig snd-len shift-ratio)
+  (let ((stretchfn (const 1))
+        (pitchfn (const shift-ratio)))
+    (pv-time-pitch sig stretchfn pitchfn snd-len)))
+
 
 ;;; Apply effects to echo
-(defun modify (sig num gain shift p-type)
-  (let ((gain (db-to-linear (* num gain)))
-        (shift (* num shift)))
-    (if (= p-type 0)
-        (mult gain (change-speed sig shift))
-        (mult gain (p-shift sig shift)))))
+(defun modify (sig echo-num snd-len)
+  (let ((gain (db-to-linear (* echo-num dgain)))
+        (shift (* echo-num shift))
+        ; convert semitone shift to ratio.
+        (ratio (power 2.0 (/ (* echo-num shift) 12.0))))
+    (if (= pitch-type 0)
+        (mult gain (change-speed sig ratio))
+        (mult gain (p-shift sig snd-len ratio)))))
 
-;;; Compute echoes
-(defun delays (sound gain delay shift num type mod)
+
+;;; Compute echoes.
+(defun delays (sig snd-len)
+  (when  (>= delay-type 1)  ; Bouncing delay.
+    (setf delay (/ delay number)))
+  ;; The echo loop.
   (let ((echo (s-rest 0)))
     (do ((count 1 (1+ count))
          (dly 0))
-         ((> count num)(sim echo sound))
-      (setq dly 
-        (case type
-          (0 (+ dly delay))
-          (1 (+ dly (* delay (- (1+ num) count))))
-          (2 (+ dly (* delay count)))))
-      (setf echo (sim
-        (at 0 (cue echo))
-        (at-abs dly
-          (cue (modify sound count gain shift mod))))))))
+         ((> count number)(sim echo sig))
+      (let ((modified-sig (modify sig count snd-len)))
+        (setq dly 
+          (case delay-type
+            (0 (+ dly delay))
+            (1 (+ dly (* delay (- (1+ number) count))))
+            (2 (+ dly (* delay count)))))
+        (setf echo (sim
+            (at 0 (cue echo))
+            (at-abs dly
+                (cue modified-sig))))))))
+
 
 (defun constrain-abs (sig dur)
   (extract-abs 0 dur (cue sig)))
 
 
-(let* ((delay (if (= delay-type 0)
-                  delay
-                  (/ delay number)))
-       (output (multichan-expand #'delays *track*
-                                          dgain
-                                          delay
-                                          shift
-                                          number
-                                          delay-type
-                                          pitch-type)))
+(let* ((dur (get-duration 1))
+       (output (multichan-expand #'delays *track* dur)))
   (if (= constrain 1)
-      (multichan-expand #'constrain-abs output (get-duration 1))
+      (multichan-expand #'constrain-abs output dur)
       output))


### PR DESCRIPTION
Resolves: Poor quality pitch shift in Delay effect.

*(Nyquist now has a phase-vocoder which can provide much better quality pitch shifting than the old STK pitch shifter. 
This commit adds a "High-quality pitch shift" option, while retaining backward compatibility with the previous version.)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
