### PR TITLE
More in lib time frequency selection

### DIFF
--- a/libraries/lib-components/EffectInterface.h
+++ b/libraries/lib-components/EffectInterface.h
@@ -76,9 +76,9 @@ using EffectFamilySymbol = ComponentInterfaceSymbol;
 class COMPONENTS_API EffectSettingsExtra final {
 public:
    static const RegistryPath &DurationKey();
-   const NumericFormatSymbol& GetDurationFormat() const
+   const NumericFormatID& GetDurationFormat() const
       { return mDurationFormat; }
-   void SetDurationFormat(const NumericFormatSymbol &durationFormat)
+   void SetDurationFormat(const NumericFormatID &durationFormat)
       { mDurationFormat = durationFormat; }
 
    //! @return value is not negative
@@ -88,7 +88,7 @@ public:
    bool GetActive() const { return mActive; }
    void SetActive(bool value) { mActive = value; }
 private:
-   NumericFormatSymbol mDurationFormat{};
+   NumericFormatID mDurationFormat{};
    double mDuration{}; //!< @invariant non-negative
    bool mActive{ true };
 };

--- a/libraries/lib-effects/Effect.cpp
+++ b/libraries/lib-effects/Effect.cpp
@@ -184,11 +184,12 @@ const EffectSettingsManager& Effect::GetDefinition() const
    return *this;
 }
 
-NumericFormatSymbol Effect::GetSelectionFormat()
+NumericFormatID Effect::GetSelectionFormat()
 {
    if( !IsBatchProcessing() && FindProject() )
-      return ProjectNumericFormats::Get( *FindProject() ).GetSelectionFormat();
-   return NumericConverterFormats::HoursMinsSecondsFormat();
+      return ProjectNumericFormats::Get( *FindProject() )
+         .GetSelectionFormat();
+   return NumericConverterFormats::HoursMinsSecondsFormat().Internal();
 }
 
 wxString Effect::GetSavedStateGroup()

--- a/libraries/lib-effects/Effect.h
+++ b/libraries/lib-effects/Effect.h
@@ -89,7 +89,8 @@ class EFFECTS_API Effect /* not final */
    // EffectPlugin implementation
 
    const EffectSettingsManager& GetDefinition() const override;
-   virtual NumericFormatSymbol GetSelectionFormat() /* not override? */; // time format in Selection toolbar
+   // time format in Selection toolbar
+   virtual NumericFormatID GetSelectionFormat() /* not override? */;
 
    bool SaveSettingsAsString(
       const EffectSettings &settings, wxString & parms) const override;

--- a/libraries/lib-effects/EffectBase.cpp
+++ b/libraries/lib-effects/EffectBase.cpp
@@ -133,12 +133,13 @@ bool EffectBase::DoEffect(EffectSettings &settings,
    }
 
    // This is happening inside EffectSettingsAccess::ModifySettings
-   auto newFormat = isSelection
-      ? NumericConverterFormats::TimeAndSampleFormat()
-      : NumericConverterFormats::DefaultSelectionFormat();
+   auto newFormat = (isSelection
+         ? NumericConverterFormats::TimeAndSampleFormat()
+         : NumericConverterFormats::DefaultSelectionFormat()
+      ).Internal();
    auto updater = [&](EffectSettings &settings) {
       settings.extra.SetDuration(duration);
-      settings.extra.SetDurationFormat( newFormat );
+      settings.extra.SetDurationFormat(newFormat);
       return nullptr;
    };
    // Update our copy of settings; update the EffectSettingsAccess too,

--- a/libraries/lib-numeric-formats/NumericConverter.h
+++ b/libraries/lib-numeric-formats/NumericConverter.h
@@ -33,7 +33,7 @@ class NUMERIC_FORMATS_API NumericConverter /* not final */ :
 {
 public:
    NumericConverter(const FormatterContext& context, NumericConverterType type,
-                    const NumericFormatSymbol & formatName = {},
+                    const NumericFormatID & formatName = {},
                     double value = 0.0f);
 
    virtual ~NumericConverter();  
@@ -53,11 +53,11 @@ private:
 
 public:
    // returns true if the format type really changed:
-   bool SetTypeAndFormatName(const NumericConverterType& type, const NumericFormatSymbol& formatName);
+   bool SetTypeAndFormatName(const NumericConverterType& type, const NumericFormatID& formatName);
    // returns true if the format name really changed:
-   bool SetFormatName(const NumericFormatSymbol & formatName);
+   bool SetFormatName(const NumericFormatID &formatName);
    // Could be empty if custom format is used
-   NumericFormatSymbol GetFormatName() const;
+   NumericFormatID GetFormatName() const;
 
    bool SetCustomFormat(const TranslatableString& customFormat);
 
@@ -96,7 +96,7 @@ protected:
    std::unique_ptr<NumericConverterFormatter>
                  mFormatter;
    
-   NumericFormatSymbol mFormatSymbol;
+   NumericFormatID mFormatID;
    TranslatableString mCustomFormat;
 
    // Formatted mValue, by ValueToControls().

--- a/libraries/lib-numeric-formats/NumericConverterFormats.cpp
+++ b/libraries/lib-numeric-formats/NumericConverterFormats.cpp
@@ -62,7 +62,7 @@ NumericFormatSymbol Default(const NumericConverterType& type)
 NUMERIC_FORMATS_API NumericFormatSymbol Lookup(
    const FormatterContext& context, 
    const NumericConverterType& type,
-   const NumericFormatSymbol& formatIdentifier)
+   const NumericFormatID& formatIdentifier)
 {
    if (formatIdentifier.empty())
       return Default(type);
@@ -74,14 +74,6 @@ NUMERIC_FORMATS_API NumericFormatSymbol Lookup(
 
    return result->symbol;
 }
-
-NUMERIC_FORMATS_API NumericFormatSymbol Lookup(
-   const FormatterContext& context, const NumericConverterType& type,
-   const wxString& formatIdentifier)
-{
-   return Lookup(context, type, NumericFormatSymbol { formatIdentifier });
-}
-
 
 NUMERIC_FORMATS_API NumericFormatSymbol DefaultSelectionFormat()
 {
@@ -134,8 +126,8 @@ NUMERIC_FORMATS_API NumericFormatSymbol OctavesFormat()
     * in octaves */
    return { XO("octaves") };
 }
-NUMERIC_FORMATS_API NumericFormatSymbol
-GetBestDurationFormat(const NumericFormatSymbol& timeFormat)
+NUMERIC_FORMATS_API NumericFormatID
+GetBestDurationFormat(const NumericFormatID& timeFormat)
 {
    return timeFormat;
 }

--- a/libraries/lib-numeric-formats/NumericConverterFormats.h
+++ b/libraries/lib-numeric-formats/NumericConverterFormats.h
@@ -29,12 +29,7 @@ NUMERIC_FORMATS_API NumericFormatSymbol Default(const NumericConverterType& type
 //! Looks up the format, returns Default for the type if the format is not registered
 NUMERIC_FORMATS_API NumericFormatSymbol Lookup(
    const FormatterContext& context, const NumericConverterType& type,
-   const wxString& formatIdentifier);
-
-//! Looks up the format, returns Default for the type if the format is not registered
-NUMERIC_FORMATS_API NumericFormatSymbol Lookup(
-   const FormatterContext& context, const NumericConverterType& type,
-   const NumericFormatSymbol& formatIdentifier);
+   const NumericFormatID& formatIdentifier);
 
 NUMERIC_FORMATS_API NumericFormatSymbol DefaultSelectionFormat();
 NUMERIC_FORMATS_API NumericFormatSymbol TimeAndSampleFormat();
@@ -46,6 +41,6 @@ NUMERIC_FORMATS_API NumericFormatSymbol HertzFormat();
 NUMERIC_FORMATS_API NumericFormatSymbol OctavesFormat();
 
 //! Return the best duration format for the given time format. Currently is an identity function
-NUMERIC_FORMATS_API NumericFormatSymbol
-GetBestDurationFormat(const NumericFormatSymbol& timeFormat);
+NUMERIC_FORMATS_API NumericFormatID
+GetBestDurationFormat(const NumericFormatID& timeFormat);
 }

--- a/libraries/lib-numeric-formats/NumericConverterRegistry.cpp
+++ b/libraries/lib-numeric-formats/NumericConverterRegistry.cpp
@@ -119,7 +119,7 @@ void NumericConverterRegistry::Visit(
 
 const NumericConverterRegistryItem* NumericConverterRegistry::Find(
    const FormatterContext& context, 
-   const NumericConverterType& type, const NumericFormatSymbol& symbol)
+   const NumericConverterType& type, const NumericFormatID& symbol)
 {
    const NumericConverterRegistryItem* result = nullptr;
 
@@ -128,7 +128,7 @@ const NumericConverterRegistryItem* NumericConverterRegistry::Find(
       type,
       [&result, symbol](const NumericConverterRegistryItem& item)
       {
-         if (item.symbol == symbol)
+         if (item.symbol.Internal() == symbol)
             result = &item;
       });
 

--- a/libraries/lib-numeric-formats/NumericConverterRegistry.h
+++ b/libraries/lib-numeric-formats/NumericConverterRegistry.h
@@ -96,7 +96,7 @@ struct NUMERIC_FORMATS_API NumericConverterRegistry final
 
    static const NumericConverterRegistryItem* Find(
       const FormatterContext& context, const NumericConverterType& type,
-      const NumericFormatSymbol& symbol);
+      const NumericFormatID& symbol);
 };
 
 constexpr auto NumericConverterFormatterItem =

--- a/libraries/lib-numeric-formats/ProjectNumericFormats.cpp
+++ b/libraries/lib-numeric-formats/ProjectNumericFormats.cpp
@@ -38,43 +38,35 @@ const ProjectNumericFormats &ProjectNumericFormats::Get(
 
 ProjectNumericFormats::ProjectNumericFormats(const AudacityProject& project)
    : mProject { project }
-   , mSelectionFormat{ NumericConverterFormats::Lookup(
-      FormatterContext::ProjectContext(project),
-      NumericConverterType_TIME(),
-      gPrefs->Read(wxT("/SelectionFormat"), wxT("")))
+   , mSelectionFormat{
+      gPrefs->Read(wxT("/SelectionFormat"), wxT(""))
    }
-   , mFrequencySelectionFormatName{ NumericConverterFormats::Lookup(
-      FormatterContext::ProjectContext(project),
-      NumericConverterType_FREQUENCY(),
-      gPrefs->Read(wxT("/FrequencySelectionFormatName"), wxT("")) )
+   , mFrequencySelectionFormatName{
+      gPrefs->Read(wxT("/FrequencySelectionFormatName"), wxT(""))
    }
-   , mBandwidthSelectionFormatName{ NumericConverterFormats::Lookup(
-      FormatterContext::ProjectContext(project),
-      NumericConverterType_BANDWIDTH(),
-      gPrefs->Read(wxT("/BandwidthSelectionFormatName"), wxT("")) )
+   , mBandwidthSelectionFormatName{
+      gPrefs->Read(wxT("/BandwidthSelectionFormatName"), wxT(""))
    }
-   , mAudioTimeFormat{ NumericConverterFormats::Lookup(
-      FormatterContext::ProjectContext(project),
-      NumericConverterType_TIME(),
-      gPrefs->Read(wxT("/AudioTimeFormat"), wxT("hh:mm:ss")))
+   , mAudioTimeFormat{
+      gPrefs->Read(wxT("/AudioTimeFormat"), wxT("hh:mm:ss"))
    }
 {}
 
 ProjectNumericFormats::~ProjectNumericFormats() = default;
 
-const NumericFormatSymbol &
+NumericFormatID
 ProjectNumericFormats::GetFrequencySelectionFormatName() const
 {
    return mFrequencySelectionFormatName;
 }
 
 void ProjectNumericFormats::SetFrequencySelectionFormatName(
-   const NumericFormatSymbol & formatName)
+   const NumericFormatID & formatName)
 {
    mFrequencySelectionFormatName = formatName;
 }
 
-const NumericFormatSymbol &
+NumericFormatID
 ProjectNumericFormats::GetBandwidthSelectionFormatName() const
 {
    return mBandwidthSelectionFormatName;
@@ -88,28 +80,27 @@ NumericFormatSymbol ProjectNumericFormats::LookupFormat(
 }
 
 void ProjectNumericFormats::SetBandwidthSelectionFormatName(
-   const NumericFormatSymbol & formatName)
+   const NumericFormatID &formatName)
 {
    mBandwidthSelectionFormatName = formatName;
 }
 
-void ProjectNumericFormats::SetSelectionFormat(
-   const NumericFormatSymbol & format)
+void ProjectNumericFormats::SetSelectionFormat(const NumericFormatID &format)
 {
    mSelectionFormat = format;
 }
 
-const NumericFormatSymbol & ProjectNumericFormats::GetSelectionFormat() const
+NumericFormatID ProjectNumericFormats::GetSelectionFormat() const
 {
    return mSelectionFormat;
 }
 
-void ProjectNumericFormats::SetAudioTimeFormat(const NumericFormatSymbol & format)
+void ProjectNumericFormats::SetAudioTimeFormat(const NumericFormatID &format)
 {
    mAudioTimeFormat = format;
 }
 
-const NumericFormatSymbol & ProjectNumericFormats::GetAudioTimeFormat() const
+NumericFormatID ProjectNumericFormats::GetAudioTimeFormat() const
 {
    return mAudioTimeFormat;
 }
@@ -118,11 +109,11 @@ static ProjectFileIORegistry::AttributeWriterEntry entry {
 [](const AudacityProject &project, XMLWriter &xmlFile){
    auto &formats = ProjectNumericFormats::Get(project);
    xmlFile.WriteAttr(wxT("selectionformat"),
-                     formats.GetSelectionFormat().Internal());
+                     formats.GetSelectionFormat().GET());
    xmlFile.WriteAttr(wxT("frequencyformat"),
-                     formats.GetFrequencySelectionFormatName().Internal());
+                     formats.GetFrequencySelectionFormatName().GET());
    xmlFile.WriteAttr(wxT("bandwidthformat"),
-                     formats.GetBandwidthSelectionFormatName().Internal());
+                     formats.GetBandwidthSelectionFormatName().GET());
 }
 };
 
@@ -133,15 +124,12 @@ static ProjectFileIORegistry::AttributeReaderEntries entries {
    // Maybe that should be abandoned.  Enough to save changes in the user
    // preference file.
    { "selectionformat", [](auto &formats, auto value){
-      formats.SetSelectionFormat(formats.LookupFormat(
-              NumericConverterType_TIME(), value.ToWString()));
+      formats.SetSelectionFormat(value.ToWString());
    } },
    { "frequencyformat", [](auto &formats, auto value){
-           formats.SetFrequencySelectionFormatName(formats.LookupFormat(
-              NumericConverterType_FREQUENCY(), value.ToWString()));
+      formats.SetFrequencySelectionFormatName(value.ToWString());
    } },
    { "bandwidthformat", [](auto &formats, auto value){
-           formats.SetBandwidthSelectionFormatName(formats.LookupFormat(
-              NumericConverterType_BANDWIDTH(), value.ToWString()));
+      formats.SetBandwidthSelectionFormatName(value.ToWString());
    } },
 } };

--- a/libraries/lib-numeric-formats/ProjectNumericFormats.cpp
+++ b/libraries/lib-numeric-formats/ProjectNumericFormats.cpp
@@ -63,7 +63,14 @@ ProjectNumericFormats::GetFrequencySelectionFormatName() const
 void ProjectNumericFormats::SetFrequencySelectionFormatName(
    const NumericFormatID & formatName)
 {
-   mFrequencySelectionFormatName = formatName;
+   if (mFrequencySelectionFormatName != formatName) {
+      ProjectNumericFormatsEvent e{
+         ProjectNumericFormatsEvent::ChangedFrequencyFormat,
+         mFrequencySelectionFormatName, formatName
+      };
+      mFrequencySelectionFormatName = formatName;
+      Publish(e);
+   }
 }
 
 NumericFormatID
@@ -82,12 +89,26 @@ NumericFormatSymbol ProjectNumericFormats::LookupFormat(
 void ProjectNumericFormats::SetBandwidthSelectionFormatName(
    const NumericFormatID &formatName)
 {
-   mBandwidthSelectionFormatName = formatName;
+   if (mBandwidthSelectionFormatName != formatName) {
+      ProjectNumericFormatsEvent e{
+         ProjectNumericFormatsEvent::ChangedBandwidthFormat,
+         mBandwidthSelectionFormatName, formatName
+      };
+      mBandwidthSelectionFormatName = formatName;
+      Publish(e);
+   }
 }
 
 void ProjectNumericFormats::SetSelectionFormat(const NumericFormatID &format)
 {
-   mSelectionFormat = format;
+   if (mSelectionFormat != format) {
+      ProjectNumericFormatsEvent e{
+         ProjectNumericFormatsEvent::ChangedSelectionFormat,
+         mSelectionFormat, format
+      };
+      mSelectionFormat = format;
+      Publish(e);
+   }
 }
 
 NumericFormatID ProjectNumericFormats::GetSelectionFormat() const
@@ -97,7 +118,14 @@ NumericFormatID ProjectNumericFormats::GetSelectionFormat() const
 
 void ProjectNumericFormats::SetAudioTimeFormat(const NumericFormatID &format)
 {
-   mAudioTimeFormat = format;
+   if (mAudioTimeFormat != format) {
+      ProjectNumericFormatsEvent e{
+         ProjectNumericFormatsEvent::ChangedAudioTimeFormat,
+         mAudioTimeFormat, format
+      };
+      mAudioTimeFormat = format;
+      Publish(e);
+   }
 }
 
 NumericFormatID ProjectNumericFormats::GetAudioTimeFormat() const

--- a/libraries/lib-numeric-formats/ProjectNumericFormats.h
+++ b/libraries/lib-numeric-formats/ProjectNumericFormats.h
@@ -13,10 +13,24 @@
 #include "ClientData.h"
 #include "ComponentInterfaceSymbol.h"
 #include "NumericConverterType.h"
+#include "Observer.h"
 
 class AudacityProject;
 
-class NUMERIC_FORMATS_API ProjectNumericFormats final : public ClientData::Base
+struct ProjectNumericFormatsEvent {
+   const enum Type : int {
+      ChangedSelectionFormat,
+      ChangedAudioTimeFormat,
+      ChangedFrequencyFormat,
+      ChangedBandwidthFormat,
+   } type;
+   const NumericFormatID oldValue;
+   const NumericFormatID newValue;
+};
+
+class NUMERIC_FORMATS_API ProjectNumericFormats final
+   : public ClientData::Base
+   , public Observer::Publisher<ProjectNumericFormatsEvent>
 {
 public:
    static ProjectNumericFormats &Get(AudacityProject &project);

--- a/libraries/lib-numeric-formats/ProjectNumericFormats.h
+++ b/libraries/lib-numeric-formats/ProjectNumericFormats.h
@@ -26,29 +26,29 @@ public:
    ~ProjectNumericFormats() override;
 
    // Selection Format
-   void SetSelectionFormat(const NumericFormatSymbol & format);
-   const NumericFormatSymbol & GetSelectionFormat() const;
+   void SetSelectionFormat(const NumericFormatID & format);
+   NumericFormatID GetSelectionFormat() const;
 
    // AudioTime format
-   void SetAudioTimeFormat(const NumericFormatSymbol & format);
-   const NumericFormatSymbol & GetAudioTimeFormat() const;
+   void SetAudioTimeFormat(const NumericFormatID & format);
+   NumericFormatID GetAudioTimeFormat() const;
 
    // Spectral Selection Formats
-   void SetFrequencySelectionFormatName(const NumericFormatSymbol & format);
-   const NumericFormatSymbol & GetFrequencySelectionFormatName() const;
+   void SetFrequencySelectionFormatName(const NumericFormatID & format);
+   NumericFormatID GetFrequencySelectionFormatName() const;
 
-   void SetBandwidthSelectionFormatName(const NumericFormatSymbol & format);
-   const NumericFormatSymbol & GetBandwidthSelectionFormatName() const;
+   void SetBandwidthSelectionFormatName(const NumericFormatID & format);
+   NumericFormatID GetBandwidthSelectionFormatName() const;
 
    NumericFormatSymbol LookupFormat(const NumericConverterType& type, const wxString& identifier);
 
 private:
    const AudacityProject& mProject;
    
-   NumericFormatSymbol mSelectionFormat;
-   NumericFormatSymbol mFrequencySelectionFormatName;
-   NumericFormatSymbol mBandwidthSelectionFormatName;
-   NumericFormatSymbol mAudioTimeFormat;
+   NumericFormatID mSelectionFormat;
+   NumericFormatID mFrequencySelectionFormatName;
+   NumericFormatID mBandwidthSelectionFormatName;
+   NumericFormatID mAudioTimeFormat;
 };
 
 #endif

--- a/libraries/lib-snapping/CMakeLists.txt
+++ b/libraries/lib-snapping/CMakeLists.txt
@@ -18,13 +18,17 @@ set(SOURCES
 
    ProjectSnap.cpp
    ProjectSnap.h
+   Snap.cpp
+   Snap.h
    SnapUtils.cpp
    SnapUtils.h
 )
 
 set( LIBRARIES
-   lib-project-rate
-   lib-numeric-formats
+   lib-project-rate-interface
+   lib-numeric-formats-interface
+   lib-screen-geometry-interface
+   lib-track-interface
 )
 
 audacity_library( ${TARGET} "${SOURCES}" "${LIBRARIES}" "" "" )

--- a/libraries/lib-snapping/Snap.cpp
+++ b/libraries/lib-snapping/Snap.cpp
@@ -19,7 +19,7 @@
 #include "ProjectRate.h"
 #include "ProjectSnap.h"
 #include "Track.h"
-#include "ViewInfo.h"
+#include "ZoomInfo.h"
 
 inline bool operator < (SnapPoint s1, SnapPoint s2)
 {

--- a/libraries/lib-snapping/Snap.h
+++ b/libraries/lib-snapping/Snap.h
@@ -52,7 +52,7 @@ struct SnapResults {
    bool Snapped() const { return snappedPoint || snappedTime; }
 };
 
-class AUDACITY_DLL_API SnapManager
+class SNAPPING_API SnapManager
 {
 public:
    //! Construct only for specified candidate points

--- a/libraries/lib-strings/Identifier.h
+++ b/libraries/lib-strings/Identifier.h
@@ -235,5 +235,7 @@ using CommandIDs = std::vector<CommandID>;
 struct ManualPageIDTag;
 using ManualPageID = TaggedIdentifier< ManualPageIDTag >;
 
+using NumericFormatID = TaggedIdentifier<struct NumericFormatIDTag>;
+
 #endif
 

--- a/libraries/lib-time-frequency-selection/CMakeLists.txt
+++ b/libraries/lib-time-frequency-selection/CMakeLists.txt
@@ -4,14 +4,15 @@ spectral selection, and play region
 ]]
 
 set( SOURCES
+   ProjectSelectionManager.cpp
+   ProjectSelectionManager.h
    SelectedRegion.cpp
    SelectedRegion.h
    ViewInfo.cpp
    ViewInfo.h
 )
 set( LIBRARIES
-   lib-project-history-interface
-   lib-screen-geometry-interface
+   lib-snapping-interface
 )
 audacity_library( lib-time-frequency-selection "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-time-frequency-selection/ProjectSelectionManager.cpp
+++ b/libraries/lib-time-frequency-selection/ProjectSelectionManager.cpp
@@ -12,7 +12,6 @@ Paul Licameli split from ProjectManager.cpp
 #include "Project.h"
 #include "ProjectHistory.h"
 #include "ProjectNumericFormats.h"
-#include "ProjectRate.h"
 #include "ProjectSnap.h"
 #include "ProjectTimeSignature.h"
 #include "Snap.h"

--- a/libraries/lib-time-frequency-selection/ProjectSelectionManager.h
+++ b/libraries/lib-time-frequency-selection/ProjectSelectionManager.h
@@ -25,7 +25,7 @@ struct ProjectNumericFormatsEvent;
  by updating persistent preferences, and updating the time selection to be
  consistent with those choices.
  */
-class AUDACITY_DLL_API ProjectSelectionManager final
+class TIME_FREQUENCY_SELECTION_API ProjectSelectionManager final
    : public ClientData::Base
 {
 public:

--- a/libraries/lib-track-selection/CMakeLists.txt
+++ b/libraries/lib-track-selection/CMakeLists.txt
@@ -15,7 +15,6 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-time-frequency-selection-interface
-   lib-track-interface
 )
 audacity_library( lib-track-selection "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -34,7 +34,6 @@
 
 class wxTextFile;
 class Track;
-class ProjectSettings;
 class AudacityProject;
 
 using TrackArray = std::vector< Track* >;

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -529,6 +529,14 @@ Track::LinkType ToLinkType(int value)
 
 }
 
+double WaveTrack::ProjectNyquistFrequency(const AudacityProject &project)
+{
+   auto &tracks = TrackList::Get(project);
+   return std::max(ProjectRate::Get(project).GetRate(),
+      tracks.Any<const WaveTrack>().max(&WaveTrack::GetRate))
+      / 2.0;
+}
+
 static auto DefaultName = XO("Audio");
 
 WaveChannel::~WaveChannel() = default;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -24,6 +24,8 @@
 #include <wx/thread.h>
 #include <wx/longlong.h>
 
+class AudacityProject;
+
 namespace BasicUI{ class ProgressDialog; }
 
 class SampleBlockFactory;
@@ -241,6 +243,8 @@ public:
    using Regions = std::vector < Region >;
 
    static wxString GetDefaultAudioTrackNamePreference();
+
+   static double ProjectNyquistFrequency(const AudacityProject &project);
 
    //
    // Constructor / Destructor / Duplicator

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -442,34 +442,22 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
 
    if (mProjectAttrs.haveselectionformat)
    {
-      selman.AS_SetSelectionFormat(NumericConverterFormats::Lookup(
-         FormatterContext::ProjectContext(mProject), NumericConverterType_TIME(),
-         mProjectAttrs.selectionformat));
+      selman.AS_SetSelectionFormat(mProjectAttrs.selectionformat);
    }
 
    if (mProjectAttrs.haveaudiotimeformat)
    {
-      selman.TT_SetAudioTimeFormat(NumericConverterFormats::Lookup(
-         FormatterContext::ProjectContext(mProject), NumericConverterType_TIME(),
-         mProjectAttrs.audiotimeformat));
+      selman.TT_SetAudioTimeFormat(mProjectAttrs.audiotimeformat);
    }
 
    if (mProjectAttrs.havefrequencyformat)
    {
-      selman.SSBL_SetFrequencySelectionFormatName(
-         NumericConverterFormats::Lookup(
-            FormatterContext::ProjectContext(mProject),
-            NumericConverterType_FREQUENCY(),
-         mProjectAttrs.frequencyformat));
+      selman.SSBL_SetFrequencySelectionFormatName(mProjectAttrs.frequencyformat);
    }
 
    if (mProjectAttrs.havebandwidthformat)
    {
-      selman.SSBL_SetBandwidthSelectionFormatName(
-         NumericConverterFormats::Lookup(
-            FormatterContext::ProjectContext(mProject),
-            NumericConverterType_BANDWIDTH(),
-         mProjectAttrs.bandwidthformat));
+      selman.SSBL_SetBandwidthSelectionFormatName(mProjectAttrs.bandwidthformat);
    }
 
    // PRL: It seems this must happen after SetSnapTo

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -42,7 +42,6 @@
 #include "ViewInfo.h"
 #include "WaveClip.h"
 #include "WaveTrack.h"
-#include "toolbars/SelectionBar.h"
 #include "widgets/NumericTextCtrl.h"
 #include "XMLFileReader.h"
 #include "wxFileNameWrapper.h"

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -34,7 +34,6 @@
 #include "ProjectHistory.h"
 #include "ProjectNumericFormats.h"
 #include "ProjectRate.h"
-#include "ProjectSelectionManager.h"
 #include "ProjectSnap.h"
 #include "ProjectWindows.h"
 #include "Sequence.h"
@@ -319,7 +318,6 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
    auto &tracks = TrackList::Get(mProject);
    auto &viewInfo = ViewInfo::Get(mProject);
    auto &formats = ProjectNumericFormats::Get(mProject);
-   auto &selman = ProjectSelectionManager::Get(mProject);
 
    auto oldNumTracks = tracks.Size();
    auto cleanup = finally([this, &tracks, oldNumTracks]{
@@ -458,7 +456,7 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
 
    if (mProjectAttrs.havebandwidthformat)
    {
-      selman.SSBL_SetBandwidthSelectionFormatName(mProjectAttrs.bandwidthformat);
+      formats.SetBandwidthSelectionFormatName(mProjectAttrs.bandwidthformat);
    }
 
    // PRL: It seems this must happen after SetSnapTo

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -453,7 +453,7 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
 
    if (mProjectAttrs.havefrequencyformat)
    {
-      selman.SSBL_SetFrequencySelectionFormatName(mProjectAttrs.frequencyformat);
+      formats.SetFrequencySelectionFormatName(mProjectAttrs.frequencyformat);
    }
 
    if (mProjectAttrs.havebandwidthformat)

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -448,7 +448,7 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
 
    if (mProjectAttrs.haveaudiotimeformat)
    {
-      selman.TT_SetAudioTimeFormat(mProjectAttrs.audiotimeformat);
+      formats.SetAudioTimeFormat(mProjectAttrs.audiotimeformat);
    }
 
    if (mProjectAttrs.havefrequencyformat)

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -32,9 +32,9 @@
 #include "Project.h"
 #include "ProjectFileManager.h"
 #include "ProjectHistory.h"
+#include "ProjectNumericFormats.h"
 #include "ProjectRate.h"
 #include "ProjectSelectionManager.h"
-#include "ProjectSettings.h"
 #include "ProjectSnap.h"
 #include "ProjectWindows.h"
 #include "Sequence.h"
@@ -318,6 +318,7 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
    auto &history = ProjectHistory::Get(mProject);
    auto &tracks = TrackList::Get(mProject);
    auto &viewInfo = ViewInfo::Get(mProject);
+   auto &formats = ProjectNumericFormats::Get(mProject);
    auto &selman = ProjectSelectionManager::Get(mProject);
 
    auto oldNumTracks = tracks.Size();
@@ -442,7 +443,7 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
 
    if (mProjectAttrs.haveselectionformat)
    {
-      selman.AS_SetSelectionFormat(mProjectAttrs.selectionformat);
+      formats.SetSelectionFormat(mProjectAttrs.selectionformat);
    }
 
    if (mProjectAttrs.haveaudiotimeformat)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -181,8 +181,6 @@ list( APPEND SOURCES
       SelectUtilities.h
       ShuttleGetDefinition.cpp
       ShuttleGetDefinition.h
-      Snap.cpp
-      Snap.h
       SoundActivatedRecord.cpp
       SoundActivatedRecord.h
       SpectralDataDialog.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -683,12 +683,10 @@ list( APPEND SOURCES
       toolbars/ScrubbingToolBar.h
       toolbars/SelectionBar.cpp
       toolbars/SelectionBar.h
-      toolbars/SelectionBarListener.h
       toolbars/SnappingToolBar.cpp
       toolbars/SnappingToolBar.h
       toolbars/SpectralSelectionBar.cpp
       toolbars/SpectralSelectionBar.h
-      toolbars/SpectralSelectionBarListener.h
       toolbars/TimeSignatureToolBar.cpp
       toolbars/TimeSignatureToolBar.h
       toolbars/TimeToolBar.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,8 +157,6 @@ list( APPEND SOURCES
       ProjectFileManager.h
       ProjectManager.cpp
       ProjectManager.h
-      ProjectSelectionManager.cpp
-      ProjectSelectionManager.h
       ProjectSettings.cpp
       ProjectSettings.h
       ProjectTempoListener.cpp

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -97,8 +97,8 @@ LabelDialog::LabelDialog(wxWindow *parent,
                          LabelTrack *selectedTrack,
                          int index,
                          ViewInfo &viewinfo,
-                         const NumericFormatSymbol & format,
-                         const NumericFormatSymbol &freqFormat)
+                         const NumericFormatID & format,
+                         const NumericFormatID &freqFormat)
 : wxDialogWrapper(parent,
            wxID_ANY,
            XO("Edit Labels"),
@@ -529,7 +529,7 @@ void LabelDialog::OnUpdate(wxCommandEvent &event)
    // Remember the NEW format and repopulate grid
    mFormat = NumericConverterFormats::Lookup(
       FormatterContext::ProjectContext(mProject),
-      NumericConverterType_TIME(), event.GetString() );
+      NumericConverterType_TIME(), event.GetString()).Internal();
    TransferDataToWindow();
 
    event.Skip(false);
@@ -540,7 +540,7 @@ void LabelDialog::OnFreqUpdate(wxCommandEvent &event)
    // Remember the NEW format and repopulate grid
    mFreqFormat = NumericConverterFormats::Lookup(
       FormatterContext::ProjectContext(mProject),
-      NumericConverterType_FREQUENCY(), event.GetString() );
+      NumericConverterType_FREQUENCY(), event.GetString()).Internal();
    TransferDataToWindow();
 
    event.Skip(false);

--- a/src/LabelDialog.h
+++ b/src/LabelDialog.h
@@ -48,8 +48,8 @@ class LabelDialog final : public wxDialogWrapper
                int index,
 
                ViewInfo &viewinfo,
-               const NumericFormatSymbol & format,
-               const NumericFormatSymbol &freqFormat);
+               const NumericFormatID & format,
+               const NumericFormatID &freqFormat);
    ~LabelDialog();
 
     bool Show(bool show = true) override;
@@ -106,7 +106,7 @@ class LabelDialog final : public wxDialogWrapper
    int mIndex { -1 };
    ViewInfo *mViewInfo;
    wxArrayString mTrackNames;
-   NumericFormatSymbol mFormat, mFreqFormat;
+   NumericFormatID mFormat, mFreqFormat;
 
    int mInitialRow;
 

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -70,7 +70,7 @@ ProjectAudioManager::ProjectAudioManager( AudacityProject &project )
 {
    static ProjectStatus::RegisteredStatusWidthFunction
       registerStatusWidthFunction{ StatusWidthFunction };
-   mCheckpointFailureSubcription = ProjectFileIO::Get(project)
+   mCheckpointFailureSubscription = ProjectFileIO::Get(project)
       .Subscribe(*this, &ProjectAudioManager::OnCheckpointFailure);
 }
 

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -159,7 +159,7 @@ private:
 
    void OnCheckpointFailure(ProjectFileIOMessage);
 
-   Observer::Subscription mCheckpointFailureSubcription;
+   Observer::Subscription mCheckpointFailureSubscription;
    AudacityProject &mProject;
 
    PlayMode mLastPlayMode{ PlayMode::normalPlay };

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -46,7 +46,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "ImportPlugin.h"
 #include "import/ImportMIDI.h"
 #include "import/ImportStreamDialog.h"
-#include "toolbars/SelectionBar.h"
 #include "AudacityMessageBox.h"
 #include "widgets/FileHistory.h"
 #include "widgets/UnwritableLocationErrorDialog.h"

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1084,9 +1084,6 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
       window.mbInitializingScrollbar = true;
 
       auto &selectionManager = ProjectSelectionManager::Get( project );
-
-      selectionManager.AS_SetSelectionFormat(
-         formats.GetSelectionFormat());
       selectionManager.TT_SetAudioTimeFormat(
          formats.GetAudioTimeFormat());
       selectionManager.SSBL_SetFrequencySelectionFormatName(

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -25,8 +25,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "Project.h"
 #include "ProjectFileIO.h"
 #include "ProjectHistory.h"
-#include "ProjectNumericFormats.h"
-#include "ProjectSelectionManager.h"
 #include "ProjectWindows.h"
 #include "ProjectRate.h"
 #include "ProjectSettings.h"
@@ -1079,14 +1077,8 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
    const bool err = results.trackError;
 
    if (bParseSuccess && !err) {
-      auto &formats = ProjectNumericFormats::Get( project );
-      auto &settings = ProjectSettings::Get( project );
       window.mbInitializingScrollbar = true;
 
-      auto &selectionManager = ProjectSelectionManager::Get( project );
-      selectionManager.SSBL_SetBandwidthSelectionFormatName(
-         formats.GetBandwidthSelectionFormatName());
-      
       ProjectHistory::Get( project ).InitialState();
       TrackFocus::Get(project).Set(*tracks.begin());
       window.HandleResize();

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1085,10 +1085,12 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
 
       auto &selectionManager = ProjectSelectionManager::Get( project );
 
-      selectionManager.AS_SetSelectionFormat(formats.GetSelectionFormat());
-      selectionManager.TT_SetAudioTimeFormat(formats.GetAudioTimeFormat());
+      selectionManager.AS_SetSelectionFormat(
+         formats.GetSelectionFormat());
+      selectionManager.TT_SetAudioTimeFormat(
+         formats.GetAudioTimeFormat());
       selectionManager.SSBL_SetFrequencySelectionFormatName(
-      formats.GetFrequencySelectionFormatName());
+         formats.GetFrequencySelectionFormatName());
       selectionManager.SSBL_SetBandwidthSelectionFormatName(
          formats.GetBandwidthSelectionFormatName());
       

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1084,8 +1084,6 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
       window.mbInitializingScrollbar = true;
 
       auto &selectionManager = ProjectSelectionManager::Get( project );
-      selectionManager.SSBL_SetFrequencySelectionFormatName(
-         formats.GetFrequencySelectionFormatName());
       selectionManager.SSBL_SetBandwidthSelectionFormatName(
          formats.GetBandwidthSelectionFormatName());
       

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1084,8 +1084,6 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
       window.mbInitializingScrollbar = true;
 
       auto &selectionManager = ProjectSelectionManager::Get( project );
-      selectionManager.TT_SetAudioTimeFormat(
-         formats.GetAudioTimeFormat());
       selectionManager.SSBL_SetFrequencySelectionFormatName(
          formats.GetFrequencySelectionFormatName());
       selectionManager.SSBL_SetBandwidthSelectionFormatName(

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -25,7 +25,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "ProjectFileIO.h"
 #include "ProjectFileManager.h"
 #include "ProjectHistory.h"
-#include "ProjectSelectionManager.h"
 #include "ProjectWindows.h"
 #include "ProjectRate.h"
 #include "ProjectSettings.h"
@@ -41,9 +40,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "import/ImportMIDI.h"
 #include "QualitySettings.h"
 #include "toolbars/MeterToolBar.h"
-#include "toolbars/SelectionBar.h"
-#include "toolbars/SpectralSelectionBar.h"
-#include "toolbars/TimeToolBar.h"
 #include "toolbars/ToolManager.h"
 #include "AudacityMessageBox.h"
 #include "widgets/FileHistory.h"
@@ -373,13 +369,7 @@ AudacityProject *ProjectManager::New()
    auto gAudioIO = AudioIO::Get();
    gAudioIO->SetListener(
       ProjectAudioManager::Get( project ).shared_from_this() );
-   auto &projectSelectionManager = ProjectSelectionManager::Get( project );
-   SelectionBar::Get( project ).SetListener( &projectSelectionManager );
-#ifdef EXPERIMENTAL_SPECTRAL_EDITING
-   SpectralSelectionBar::Get( project ).SetListener( &projectSelectionManager );
-#endif
-   TimeToolBar::Get( project ).SetListener( &projectSelectionManager );
-      
+
    //Set the NEW project as active:
    SetActiveProject(p);
    

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -11,7 +11,6 @@ Paul Licameli split from ProjectManager.cpp
 
 #include "Project.h"
 #include "ProjectHistory.h"
-#include "ProjectWindows.h"
 #include "ProjectNumericFormats.h"
 #include "ProjectRate.h"
 #include "ProjectSnap.h"
@@ -19,7 +18,6 @@ Paul Licameli split from ProjectManager.cpp
 #include "Snap.h"
 #include "ViewInfo.h"
 #include "WaveTrack.h"
-#include "toolbars/SpectralSelectionBar.h"
 
 static AudacityProject::AttachedObjects::RegisteredFactory
 sProjectSelectionManagerKey {
@@ -60,6 +58,7 @@ ProjectSelectionManager::ProjectSelectionManager(AudacityProject& project)
    SetSelectionFormat(formats.GetSelectionFormat());
    SetAudioTimeFormat(formats.GetAudioTimeFormat());
    SetFrequencySelectionFormatName(formats.GetFrequencySelectionFormatName());
+   SetBandwidthSelectionFormatName(formats.GetBandwidthSelectionFormatName());
 
    // And stay consistent
    mFormatsSubscription = ProjectNumericFormats::Get(project)
@@ -100,6 +99,9 @@ void ProjectSelectionManager::OnFormatsChanged(ProjectNumericFormatsEvent evt)
    case ProjectNumericFormatsEvent::ChangedFrequencyFormat:
       return SetFrequencySelectionFormatName(
          formats.GetFrequencySelectionFormatName());
+   case ProjectNumericFormatsEvent::ChangedBandwidthFormat:
+      return SetBandwidthSelectionFormatName(
+         formats.GetBandwidthSelectionFormatName());
    default:
       break;
    }
@@ -136,21 +138,11 @@ void ProjectSelectionManager::SetFrequencySelectionFormatName(
    gPrefs->Flush();
 }
 
-void ProjectSelectionManager::SSBL_SetBandwidthSelectionFormatName(
+void ProjectSelectionManager::SetBandwidthSelectionFormatName(
    const NumericFormatID & formatName)
 {
-   auto &project = mProject;
-   auto &formats = ProjectNumericFormats::Get( project );
-
-   formats.SetBandwidthSelectionFormatName( formatName );
-
    gPrefs->Write(wxT("/BandwidthSelectionFormatName"), formatName.GET());
    gPrefs->Flush();
-
-#ifdef EXPERIMENTAL_SPECTRAL_EDITING
-   SpectralSelectionBar::Get(project)
-      .SetBandwidthSelectionFormatName(formatName.GET());
-#endif
 }
 
 void ProjectSelectionManager::ModifySpectralSelection(

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -7,7 +7,6 @@ ProjectSelectionManager.cpp
 Paul Licameli split from ProjectManager.cpp
 
 **********************************************************************/
-
 #include "ProjectSelectionManager.h"
 
 #include "Project.h"
@@ -20,7 +19,6 @@ Paul Licameli split from ProjectManager.cpp
 #include "Snap.h"
 #include "ViewInfo.h"
 #include "WaveTrack.h"
-#include "toolbars/SelectionBar.h"
 #include "toolbars/SpectralSelectionBar.h"
 #include "toolbars/TimeToolBar.h"
 
@@ -58,6 +56,11 @@ ProjectSelectionManager::ProjectSelectionManager(AudacityProject& project)
          [this](auto&) { SnapSelection(); }) } 
 
 {
+   // Be consistent with ProjectNumericFormats
+   auto &formats = ProjectNumericFormats::Get(mProject);
+   SetSelectionFormat(formats.GetSelectionFormat());
+
+   // And stay consistent
    mFormatsSubscription = ProjectNumericFormats::Get(project)
       .Subscribe(*this, &ProjectSelectionManager::OnFormatsChanged);
 }
@@ -89,22 +92,17 @@ void ProjectSelectionManager::OnFormatsChanged(ProjectNumericFormatsEvent evt)
 {
    auto &formats = ProjectNumericFormats::Get(mProject);
    switch (evt.type) {
+   case ProjectNumericFormatsEvent::ChangedSelectionFormat:
+      return SetSelectionFormat(formats.GetSelectionFormat());
    default:
       break;
    }
 }
 
-void ProjectSelectionManager::AS_SetSelectionFormat(
-   const NumericFormatID & format)
+void ProjectSelectionManager::SetSelectionFormat(const NumericFormatID & format)
 {
-   auto &project = mProject;
-   auto &formats = ProjectNumericFormats::Get( project );
-   formats.SetSelectionFormat( format );
-
    gPrefs->Write(wxT("/SelectionFormat"), format);
    gPrefs->Flush();
-
-   SelectionBar::Get( project ).SetSelectionFormat(format);
 }
 
 void

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -17,7 +17,6 @@ Paul Licameli split from ProjectManager.cpp
 #include "ProjectTimeSignature.h"
 #include "Snap.h"
 #include "ViewInfo.h"
-#include "WaveTrack.h"
 
 static AudacityProject::AttachedObjects::RegisteredFactory
 sProjectSelectionManagerKey {
@@ -145,21 +144,17 @@ void ProjectSelectionManager::SetBandwidthSelectionFormatName(
    gPrefs->Flush();
 }
 
-void ProjectSelectionManager::ModifySpectralSelection(
+void ProjectSelectionManager::ModifySpectralSelection(double nyquist,
    double &bottom, double &top, bool done)
 {
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
    auto &project = mProject;
    auto &history = ProjectHistory::Get(project);
    auto &viewInfo = ViewInfo::Get(project);
-   auto &tracks = TrackList::Get(mProject);
-   auto nyq = std::max(ProjectRate::Get(project).GetRate(),
-      tracks.Any<const WaveTrack>().max(&WaveTrack::GetRate))
-      / 2.0;
    if (bottom >= 0.0)
-      bottom = std::min(nyq, bottom);
+      bottom = std::min(nyquist, bottom);
    if (top >= 0.0)
-      top = std::min(nyq, top);
+      top = std::min(nyquist, top);
    viewInfo.selectedRegion.setFrequencies(bottom, top);
    if (done)
       history.ModifyState(false);

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -89,12 +89,6 @@ void ProjectSelectionManager::SnapSelection()
    }
 }
 
-NumericFormatID ProjectSelectionManager::AS_GetSelectionFormat()
-{
-   auto &project = mProject;
-   return ProjectNumericFormats::Get(project).GetSelectionFormat();
-}
-
 void ProjectSelectionManager::AS_SetSelectionFormat(
    const NumericFormatID & format)
 {
@@ -106,13 +100,6 @@ void ProjectSelectionManager::AS_SetSelectionFormat(
    gPrefs->Flush();
 
    SelectionBar::Get( project ).SetSelectionFormat(format);
-}
-
-NumericFormatID ProjectSelectionManager::TT_GetAudioTimeFormat()
-{
-   auto &project = mProject;
-   auto &formats = ProjectNumericFormats::Get( project );
-   return formats.GetAudioTimeFormat();
 }
 
 void
@@ -142,23 +129,6 @@ void ProjectSelectionManager::AS_ModifySelection(
    }
 }
 
-double ProjectSelectionManager::SSBL_GetRate() const
-{
-   auto &project = mProject;
-   auto &tracks = TrackList::Get( project );
-   // Return maximum of project rate and all track rates.
-   return std::max( ProjectRate::Get( project ).GetRate(),
-      tracks.Any<const WaveTrack>().max(&WaveTrack::GetRate));
-}
-
-NumericFormatID
-ProjectSelectionManager::SSBL_GetFrequencySelectionFormatName()
-{
-   auto &project = mProject;
-   auto &formats = ProjectNumericFormats::Get( project );
-   return formats.GetFrequencySelectionFormatName();
-}
-
 void ProjectSelectionManager::SSBL_SetFrequencySelectionFormatName(
    const NumericFormatID &formatName)
 {
@@ -174,14 +144,6 @@ void ProjectSelectionManager::SSBL_SetFrequencySelectionFormatName(
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
    SpectralSelectionBar::Get( project ).SetFrequencySelectionFormatName(formatName);
 #endif
-}
-
-NumericFormatID
-ProjectSelectionManager::SSBL_GetBandwidthSelectionFormatName()
-{
-   auto &project = mProject;
-   auto &formats = ProjectNumericFormats::Get( project );
-   return formats.GetBandwidthSelectionFormatName();
 }
 
 void ProjectSelectionManager::SSBL_SetBandwidthSelectionFormatName(
@@ -210,7 +172,10 @@ void ProjectSelectionManager::SSBL_ModifySpectralSelection(
    auto &trackPanel = TrackPanel::Get( project );
    auto &viewInfo = ViewInfo::Get( project );
 
-   double nyq = SSBL_GetRate() / 2.0;
+   auto &tracks = TrackList::Get(mProject);
+   auto nyq = std::max(ProjectRate::Get(project).GetRate(),
+      tracks.Any<const WaveTrack>().max(&WaveTrack::GetRate))
+      / 2.0;
    if (bottom >= 0.0)
       bottom = std::min(nyq, bottom);
    if (top >= 0.0)

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -17,8 +17,6 @@ Paul Licameli split from ProjectManager.cpp
 #include "ProjectRate.h"
 #include "ProjectSnap.h"
 #include "ProjectTimeSignature.h"
-#include "ProjectSettings.h"
-#include "ProjectWindow.h"
 #include "Snap.h"
 #include "TrackPanel.h"
 #include "ViewInfo.h"
@@ -61,6 +59,8 @@ ProjectSelectionManager::ProjectSelectionManager(AudacityProject& project)
          [this](auto&) { SnapSelection(); }) } 
 
 {
+   mFormatsSubscription = ProjectNumericFormats::Get(project)
+      .Subscribe(*this, &ProjectSelectionManager::OnFormatsChanged);
 }
 
 ProjectSelectionManager::~ProjectSelectionManager() = default;
@@ -86,6 +86,15 @@ void ProjectSelectionManager::SnapSelection()
    {
       selectedRegion.setTimes(t0, t1);
       TrackPanel::Get(mProject).Refresh(false);
+   }
+}
+
+void ProjectSelectionManager::OnFormatsChanged(ProjectNumericFormatsEvent evt)
+{
+   auto &formats = ProjectNumericFormats::Get(mProject);
+   switch (evt.type) {
+   default:
+      break;
    }
 }
 

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -59,6 +59,7 @@ ProjectSelectionManager::ProjectSelectionManager(AudacityProject& project)
    auto &formats = ProjectNumericFormats::Get(mProject);
    SetSelectionFormat(formats.GetSelectionFormat());
    SetAudioTimeFormat(formats.GetAudioTimeFormat());
+   SetFrequencySelectionFormatName(formats.GetFrequencySelectionFormatName());
 
    // And stay consistent
    mFormatsSubscription = ProjectNumericFormats::Get(project)
@@ -96,6 +97,9 @@ void ProjectSelectionManager::OnFormatsChanged(ProjectNumericFormatsEvent evt)
       return SetSelectionFormat(formats.GetSelectionFormat());
    case ProjectNumericFormatsEvent::ChangedAudioTimeFormat:
       return SetAudioTimeFormat(formats.GetAudioTimeFormat());
+   case ProjectNumericFormatsEvent::ChangedFrequencyFormat:
+      return SetFrequencySelectionFormatName(
+         formats.GetFrequencySelectionFormatName());
    default:
       break;
    }
@@ -124,21 +128,12 @@ void ProjectSelectionManager::ModifySelection(
       history.ModifyState(false);
 }
 
-void ProjectSelectionManager::SSBL_SetFrequencySelectionFormatName(
+void ProjectSelectionManager::SetFrequencySelectionFormatName(
    const NumericFormatID &formatName)
 {
-   auto &project = mProject;
-   auto &formats = ProjectNumericFormats::Get( project );
-
-   formats.SetFrequencySelectionFormatName( formatName );
-
    gPrefs->Write(wxT("/FrequencySelectionFormatName"),
                  formatName.GET());
    gPrefs->Flush();
-
-#ifdef EXPERIMENTAL_SPECTRAL_EDITING
-   SpectralSelectionBar::Get( project ).SetFrequencySelectionFormatName(formatName);
-#endif
 }
 
 void ProjectSelectionManager::SSBL_SetBandwidthSelectionFormatName(

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -89,40 +89,40 @@ void ProjectSelectionManager::SnapSelection()
    }
 }
 
-const NumericFormatSymbol & ProjectSelectionManager::AS_GetSelectionFormat()
+NumericFormatID ProjectSelectionManager::AS_GetSelectionFormat()
 {
    auto &project = mProject;
    return ProjectNumericFormats::Get(project).GetSelectionFormat();
 }
 
 void ProjectSelectionManager::AS_SetSelectionFormat(
-   const NumericFormatSymbol & format)
+   const NumericFormatID & format)
 {
    auto &project = mProject;
    auto &formats = ProjectNumericFormats::Get( project );
    formats.SetSelectionFormat( format );
 
-   gPrefs->Write(wxT("/SelectionFormat"), format.Internal());
+   gPrefs->Write(wxT("/SelectionFormat"), format);
    gPrefs->Flush();
 
    SelectionBar::Get( project ).SetSelectionFormat(format);
 }
 
-const NumericFormatSymbol & ProjectSelectionManager::TT_GetAudioTimeFormat()
+NumericFormatID ProjectSelectionManager::TT_GetAudioTimeFormat()
 {
    auto &project = mProject;
    auto &formats = ProjectNumericFormats::Get( project );
    return formats.GetAudioTimeFormat();
 }
 
-void ProjectSelectionManager::TT_SetAudioTimeFormat(
-   const NumericFormatSymbol & format)
+void
+ProjectSelectionManager::TT_SetAudioTimeFormat(const NumericFormatID & format)
 {
    auto &project = mProject;
    auto &formats = ProjectNumericFormats::Get( project );
    formats.SetAudioTimeFormat( format );
 
-   gPrefs->Write(wxT("/AudioTimeFormat"), format.Internal());
+   gPrefs->Write(wxT("/AudioTimeFormat"), format.GET());
    gPrefs->Flush();
 
    TimeToolBar::Get( project ).SetAudioTimeFormat(format);
@@ -151,7 +151,7 @@ double ProjectSelectionManager::SSBL_GetRate() const
       tracks.Any<const WaveTrack>().max(&WaveTrack::GetRate));
 }
 
-const NumericFormatSymbol &
+NumericFormatID
 ProjectSelectionManager::SSBL_GetFrequencySelectionFormatName()
 {
    auto &project = mProject;
@@ -160,7 +160,7 @@ ProjectSelectionManager::SSBL_GetFrequencySelectionFormatName()
 }
 
 void ProjectSelectionManager::SSBL_SetFrequencySelectionFormatName(
-   const NumericFormatSymbol & formatName)
+   const NumericFormatID &formatName)
 {
    auto &project = mProject;
    auto &formats = ProjectNumericFormats::Get( project );
@@ -168,7 +168,7 @@ void ProjectSelectionManager::SSBL_SetFrequencySelectionFormatName(
    formats.SetFrequencySelectionFormatName( formatName );
 
    gPrefs->Write(wxT("/FrequencySelectionFormatName"),
-                 formatName.Internal());
+                 formatName.GET());
    gPrefs->Flush();
 
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
@@ -176,7 +176,7 @@ void ProjectSelectionManager::SSBL_SetFrequencySelectionFormatName(
 #endif
 }
 
-const NumericFormatSymbol &
+NumericFormatID
 ProjectSelectionManager::SSBL_GetBandwidthSelectionFormatName()
 {
    auto &project = mProject;
@@ -185,19 +185,19 @@ ProjectSelectionManager::SSBL_GetBandwidthSelectionFormatName()
 }
 
 void ProjectSelectionManager::SSBL_SetBandwidthSelectionFormatName(
-   const NumericFormatSymbol & formatName)
+   const NumericFormatID & formatName)
 {
    auto &project = mProject;
    auto &formats = ProjectNumericFormats::Get( project );
 
    formats.SetBandwidthSelectionFormatName( formatName );
 
-   gPrefs->Write(wxT("/BandwidthSelectionFormatName"),
-      formatName.Internal());
+   gPrefs->Write(wxT("/BandwidthSelectionFormatName"), formatName.GET());
    gPrefs->Flush();
 
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
-   SpectralSelectionBar::Get( project ).SetBandwidthSelectionFormatName(formatName);
+   SpectralSelectionBar::Get(project)
+      .SetBandwidthSelectionFormatName(formatName.GET());
 #endif
 }
 

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -20,7 +20,6 @@ Paul Licameli split from ProjectManager.cpp
 #include "ViewInfo.h"
 #include "WaveTrack.h"
 #include "toolbars/SpectralSelectionBar.h"
-#include "toolbars/TimeToolBar.h"
 
 static AudacityProject::AttachedObjects::RegisteredFactory
 sProjectSelectionManagerKey {
@@ -59,6 +58,7 @@ ProjectSelectionManager::ProjectSelectionManager(AudacityProject& project)
    // Be consistent with ProjectNumericFormats
    auto &formats = ProjectNumericFormats::Get(mProject);
    SetSelectionFormat(formats.GetSelectionFormat());
+   SetAudioTimeFormat(formats.GetAudioTimeFormat());
 
    // And stay consistent
    mFormatsSubscription = ProjectNumericFormats::Get(project)
@@ -94,6 +94,8 @@ void ProjectSelectionManager::OnFormatsChanged(ProjectNumericFormatsEvent evt)
    switch (evt.type) {
    case ProjectNumericFormatsEvent::ChangedSelectionFormat:
       return SetSelectionFormat(formats.GetSelectionFormat());
+   case ProjectNumericFormatsEvent::ChangedAudioTimeFormat:
+      return SetAudioTimeFormat(formats.GetAudioTimeFormat());
    default:
       break;
    }
@@ -105,17 +107,10 @@ void ProjectSelectionManager::SetSelectionFormat(const NumericFormatID & format)
    gPrefs->Flush();
 }
 
-void
-ProjectSelectionManager::TT_SetAudioTimeFormat(const NumericFormatID & format)
+void ProjectSelectionManager::SetAudioTimeFormat(const NumericFormatID & format)
 {
-   auto &project = mProject;
-   auto &formats = ProjectNumericFormats::Get( project );
-   formats.SetAudioTimeFormat( format );
-
    gPrefs->Write(wxT("/AudioTimeFormat"), format.GET());
    gPrefs->Flush();
-
-   TimeToolBar::Get( project ).SetAudioTimeFormat(format);
 }
 
 void ProjectSelectionManager::ModifySelection(

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -18,7 +18,6 @@ Paul Licameli split from ProjectManager.cpp
 #include "ProjectSnap.h"
 #include "ProjectTimeSignature.h"
 #include "Snap.h"
-#include "TrackPanel.h"
 #include "ViewInfo.h"
 #include "WaveTrack.h"
 #include "toolbars/SelectionBar.h"
@@ -83,10 +82,7 @@ void ProjectSelectionManager::SnapSelection()
    const double t1 = projectSnap.SnapTime(oldt1).time;
 
    if (t0 != oldt0 || t1 != oldt1)
-   {
       selectedRegion.setTimes(t0, t1);
-      TrackPanel::Get(mProject).Refresh(false);
-   }
 }
 
 void ProjectSelectionManager::OnFormatsChanged(ProjectNumericFormatsEvent evt)
@@ -124,18 +120,15 @@ ProjectSelectionManager::TT_SetAudioTimeFormat(const NumericFormatID & format)
    TimeToolBar::Get( project ).SetAudioTimeFormat(format);
 }
 
-void ProjectSelectionManager::AS_ModifySelection(
+void ProjectSelectionManager::ModifySelection(
    double &start, double &end, bool done)
 {
    auto &project = mProject;
    auto &history = ProjectHistory::Get( project );
-   auto &trackPanel = TrackPanel::Get( project );
    auto &viewInfo = ViewInfo::Get( project );
    viewInfo.selectedRegion.setTimes(start, end);
-   trackPanel.Refresh(false);
-   if (done) {
+   if (done)
       history.ModifyState(false);
-   }
 }
 
 void ProjectSelectionManager::SSBL_SetFrequencySelectionFormatName(
@@ -172,15 +165,13 @@ void ProjectSelectionManager::SSBL_SetBandwidthSelectionFormatName(
 #endif
 }
 
-void ProjectSelectionManager::SSBL_ModifySpectralSelection(
+void ProjectSelectionManager::ModifySpectralSelection(
    double &bottom, double &top, bool done)
 {
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
    auto &project = mProject;
-   auto &history = ProjectHistory::Get( project );
-   auto &trackPanel = TrackPanel::Get( project );
-   auto &viewInfo = ViewInfo::Get( project );
-
+   auto &history = ProjectHistory::Get(project);
+   auto &viewInfo = ViewInfo::Get(project);
    auto &tracks = TrackList::Get(mProject);
    auto nyq = std::max(ProjectRate::Get(project).GetRate(),
       tracks.Any<const WaveTrack>().max(&WaveTrack::GetRate))
@@ -190,10 +181,8 @@ void ProjectSelectionManager::SSBL_ModifySpectralSelection(
    if (top >= 0.0)
       top = std::min(nyq, top);
    viewInfo.selectedRegion.setFrequencies(bottom, top);
-   trackPanel.Refresh(false);
-   if (done) {
+   if (done)
       history.ModifyState(false);
-   }
 #else
    bottom; top; done;
 #endif

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -36,7 +36,7 @@ private:
    void OnFormatsChanged(ProjectNumericFormatsEvent);
 
 public:
-   void AS_SetSelectionFormat(const NumericFormatID & format);
+   void SetSelectionFormat(const NumericFormatID & format);
 
    void TT_SetAudioTimeFormat(const NumericFormatID & format);
    void ModifySelection(double &start, double &end, bool done);

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -30,19 +30,14 @@ public:
       const ProjectSelectionManager & ) = delete;
    ~ProjectSelectionManager() override;
 
-   NumericFormatID AS_GetSelectionFormat();
    void AS_SetSelectionFormat(const NumericFormatID & format);
 
-   NumericFormatID TT_GetAudioTimeFormat();
    void TT_SetAudioTimeFormat(const NumericFormatID & format);
    void AS_ModifySelection(double &start, double &end, bool done);
 
 
-   double SSBL_GetRate() const;
-   NumericFormatID SSBL_GetFrequencySelectionFormatName();
    void SSBL_SetFrequencySelectionFormatName(
       const NumericFormatID & formatName);
-   NumericFormatID SSBL_GetBandwidthSelectionFormatName();
    void SSBL_SetBandwidthSelectionFormatName(
       const NumericFormatID & formatName);
    void SSBL_ModifySpectralSelection(

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -39,14 +39,14 @@ public:
    void AS_SetSelectionFormat(const NumericFormatID & format);
 
    void TT_SetAudioTimeFormat(const NumericFormatID & format);
-   void AS_ModifySelection(double &start, double &end, bool done);
+   void ModifySelection(double &start, double &end, bool done);
 
 
    void SSBL_SetFrequencySelectionFormatName(
       const NumericFormatID & formatName);
    void SSBL_SetBandwidthSelectionFormatName(
       const NumericFormatID & formatName);
-   void SSBL_ModifySpectralSelection(
+   void ModifySpectralSelection(
       double &bottom, double &top, bool done);
 
 private:

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -41,7 +41,7 @@ public:
    void ModifySelection(double &start, double &end, bool done);
    void SetFrequencySelectionFormatName(
       const NumericFormatID & formatName);
-   void SSBL_SetBandwidthSelectionFormatName(
+   void SetBandwidthSelectionFormatName(
       const NumericFormatID & formatName);
    void ModifySpectralSelection(
       double &bottom, double &top, bool done);

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -39,8 +39,7 @@ public:
    void SetSelectionFormat(const NumericFormatID & format);
    void SetAudioTimeFormat(const NumericFormatID & format);
    void ModifySelection(double &start, double &end, bool done);
-
-   void SSBL_SetFrequencySelectionFormatName(
+   void SetFrequencySelectionFormatName(
       const NumericFormatID & formatName);
    void SSBL_SetBandwidthSelectionFormatName(
       const NumericFormatID & formatName);

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -19,6 +19,12 @@ Paul Licameli split from ProjectManager.cpp
 class AudacityProject;
 struct ProjectNumericFormatsEvent;
 
+//! This object is useful mostly as an observer of others in the project
+/*!
+ It listens for changes of selection formats and snap-to choices, and reacts
+ by updating persistent preferences, and updating the time selection to be
+ consistent with those choices.
+ */
 class AUDACITY_DLL_API ProjectSelectionManager final
    : public ClientData::Base
 {
@@ -26,27 +32,26 @@ public:
    static ProjectSelectionManager &Get( AudacityProject &project );
    static const ProjectSelectionManager &Get( const AudacityProject &project );
 
-   explicit ProjectSelectionManager( AudacityProject &project );
-   ProjectSelectionManager( const ProjectSelectionManager & ) = delete;
+   explicit ProjectSelectionManager(AudacityProject &project);
+   ProjectSelectionManager(const ProjectSelectionManager &) = delete;
    ProjectSelectionManager &operator=(
-      const ProjectSelectionManager & ) = delete;
+      const ProjectSelectionManager &) = delete;
    ~ProjectSelectionManager() override;
 
-private:
-   void OnFormatsChanged(ProjectNumericFormatsEvent);
-
-public:
-   void SetSelectionFormat(const NumericFormatID & format);
-   void SetAudioTimeFormat(const NumericFormatID & format);
    void ModifySelection(double &start, double &end, bool done);
-   void SetFrequencySelectionFormatName(
-      const NumericFormatID & formatName);
-   void SetBandwidthSelectionFormatName(
-      const NumericFormatID & formatName);
    void ModifySpectralSelection(
       double &bottom, double &top, bool done);
 
 private:
+   void OnFormatsChanged(ProjectNumericFormatsEvent);
+
+   void SetSelectionFormat(const NumericFormatID & format);
+   void SetAudioTimeFormat(const NumericFormatID & format);
+   void SetFrequencySelectionFormatName(
+      const NumericFormatID & formatName);
+   void SetBandwidthSelectionFormatName(
+      const NumericFormatID & formatName);
+
    void SnapSelection();
 
    Observer::Subscription mFormatsSubscription;

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -12,10 +12,12 @@ Paul Licameli split from ProjectManager.cpp
 #define __AUDACITY_PROJECT_SELECTION_MANAGER__
 
 #include "ClientData.h" // to inherit
+#include "Observer.h"
 #include "ComponentInterfaceSymbol.h"
 #include "Observer.h"
 
 class AudacityProject;
+struct ProjectNumericFormatsEvent;
 
 class AUDACITY_DLL_API ProjectSelectionManager final
    : public ClientData::Base
@@ -30,6 +32,10 @@ public:
       const ProjectSelectionManager & ) = delete;
    ~ProjectSelectionManager() override;
 
+private:
+   void OnFormatsChanged(ProjectNumericFormatsEvent);
+
+public:
    void AS_SetSelectionFormat(const NumericFormatID & format);
 
    void TT_SetAudioTimeFormat(const NumericFormatID & format);
@@ -46,6 +52,7 @@ public:
 private:
    void SnapSelection();
 
+   Observer::Subscription mFormatsSubscription;
    AudacityProject &mProject;
 
    Observer::Subscription mSnappingChangedSubscription;

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -39,7 +39,7 @@ public:
    ~ProjectSelectionManager() override;
 
    void ModifySelection(double &start, double &end, bool done);
-   void ModifySpectralSelection(
+   void ModifySpectralSelection(double nyquist,
       double &bottom, double &top, bool done);
 
 private:

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -12,8 +12,6 @@ Paul Licameli split from ProjectManager.cpp
 #define __AUDACITY_PROJECT_SELECTION_MANAGER__
 
 #include "ClientData.h" // to inherit
-#include "toolbars/SelectionBarListener.h" // to inherit
-#include "toolbars/SpectralSelectionBarListener.h" // to inherit
 #include "ComponentInterfaceSymbol.h"
 #include "Observer.h"
 
@@ -21,9 +19,6 @@ class AudacityProject;
 
 class AUDACITY_DLL_API ProjectSelectionManager final
    : public ClientData::Base
-   , public SelectionBarListener
-   , public SpectralSelectionBarListener
-   , public TimeToolBarListener
 {
 public:
    static ProjectSelectionManager &Get( AudacityProject &project );
@@ -35,23 +30,23 @@ public:
       const ProjectSelectionManager & ) = delete;
    ~ProjectSelectionManager() override;
 
-   // SelectionBarListener callback methods
-   NumericFormatID AS_GetSelectionFormat() override;
-   void AS_SetSelectionFormat(const NumericFormatID & format) override;
-   NumericFormatID TT_GetAudioTimeFormat() override;
-   void TT_SetAudioTimeFormat(const NumericFormatID & format) override;
-   void AS_ModifySelection(double &start, double &end, bool done) override;
+   NumericFormatID AS_GetSelectionFormat();
+   void AS_SetSelectionFormat(const NumericFormatID & format);
 
-   // SpectralSelectionBarListener callback methods
-   double SSBL_GetRate() const override;
-   NumericFormatID SSBL_GetFrequencySelectionFormatName() override;
+   NumericFormatID TT_GetAudioTimeFormat();
+   void TT_SetAudioTimeFormat(const NumericFormatID & format);
+   void AS_ModifySelection(double &start, double &end, bool done);
+
+
+   double SSBL_GetRate() const;
+   NumericFormatID SSBL_GetFrequencySelectionFormatName();
    void SSBL_SetFrequencySelectionFormatName(
-      const NumericFormatID & formatName) override;
-   NumericFormatID SSBL_GetBandwidthSelectionFormatName() override;
+      const NumericFormatID & formatName);
+   NumericFormatID SSBL_GetBandwidthSelectionFormatName();
    void SSBL_SetBandwidthSelectionFormatName(
-      const NumericFormatID & formatName) override;
+      const NumericFormatID & formatName);
    void SSBL_ModifySpectralSelection(
-      double &bottom, double &top, bool done) override;
+      double &bottom, double &top, bool done);
 
 private:
    void SnapSelection();

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -36,20 +36,20 @@ public:
    ~ProjectSelectionManager() override;
 
    // SelectionBarListener callback methods
-   const NumericFormatSymbol & AS_GetSelectionFormat() override;
-   void AS_SetSelectionFormat(const NumericFormatSymbol & format) override;
-   const NumericFormatSymbol & TT_GetAudioTimeFormat() override;
-   void TT_SetAudioTimeFormat(const NumericFormatSymbol & format) override;
+   NumericFormatID AS_GetSelectionFormat() override;
+   void AS_SetSelectionFormat(const NumericFormatID & format) override;
+   NumericFormatID TT_GetAudioTimeFormat() override;
+   void TT_SetAudioTimeFormat(const NumericFormatID & format) override;
    void AS_ModifySelection(double &start, double &end, bool done) override;
 
    // SpectralSelectionBarListener callback methods
    double SSBL_GetRate() const override;
-   const NumericFormatSymbol & SSBL_GetFrequencySelectionFormatName() override;
+   NumericFormatID SSBL_GetFrequencySelectionFormatName() override;
    void SSBL_SetFrequencySelectionFormatName(
-      const NumericFormatSymbol & formatName) override;
-   const NumericFormatSymbol & SSBL_GetBandwidthSelectionFormatName() override;
+      const NumericFormatID & formatName) override;
+   NumericFormatID SSBL_GetBandwidthSelectionFormatName() override;
    void SSBL_SetBandwidthSelectionFormatName(
-      const NumericFormatSymbol & formatName) override;
+      const NumericFormatID & formatName) override;
    void SSBL_ModifySpectralSelection(
       double &bottom, double &top, bool done) override;
 

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -37,10 +37,8 @@ private:
 
 public:
    void SetSelectionFormat(const NumericFormatID & format);
-
-   void TT_SetAudioTimeFormat(const NumericFormatID & format);
+   void SetAudioTimeFormat(const NumericFormatID & format);
    void ModifySelection(double &start, double &end, bool done);
-
 
    void SSBL_SetFrequencySelectionFormatName(
       const NumericFormatID & formatName);

--- a/src/ProjectSettings.cpp
+++ b/src/ProjectSettings.cpp
@@ -17,20 +17,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "QualitySettings.h"
 #include "widgets/NumericTextCtrl.h"
 
-wxDEFINE_EVENT(EVT_PROJECT_SETTINGS_CHANGE, wxCommandEvent);
-
-namespace {
-   void Notify(
-      AudacityProject &project, ProjectSettings::EventCode code,
-      long previousValue )
-   {
-      wxCommandEvent e{ EVT_PROJECT_SETTINGS_CHANGE };
-      e.SetInt( static_cast<int>( code ) );
-      e.SetExtraLong( previousValue );
-      project.ProcessEvent( e );
-   }
-}
-
 static const AudacityProject::AttachedObjects::RegisteredFactory
 sProjectSettingsKey{
   []( AudacityProject &project ){
@@ -90,9 +76,9 @@ void ProjectSettings::UpdatePrefs()
 }
 
 void ProjectSettings::SetTool(int tool) {
-   if (auto oldValue = mCurrentTool; oldValue != tool) {
+   if (auto oldValue = mCurrentTool; tool != oldValue) {
       mCurrentTool = tool;
-      Notify( mProject, ChangedTool, oldValue );
+      Publish({ ProjectSettingsEvent::ChangedTool, oldValue, tool });
    }
 }
 

--- a/src/ProjectSettings.h
+++ b/src/ProjectSettings.h
@@ -15,19 +15,14 @@ Paul Licameli split from AudacityProject.h
 #include <wx/event.h> // to declare custom event type
 
 #include "ClientData.h" // to inherit
+#include "Observer.h"
 #include "Prefs.h" // to inherit
 #include "audacity/Types.h"
 
 class AudacityProject;
 
-// Sent to the project when certain settings change
-// See enum EventCode below for values of GetInt() identifying changed setting
-// The previous value of that setting can also be found using GetExtraLong()
-wxDECLARE_EXPORTED_EVENT(AUDACITY_DLL_API,
-   EVT_PROJECT_SETTINGS_CHANGE, wxCommandEvent);
-
 namespace ToolCodes {
-enum {
+enum : int {
    // The buttons that are in the Tools toolbar must be in correspondence
    // with the first few
    selectTool,
@@ -44,21 +39,25 @@ enum {
 };
 }
 
+struct ProjectSettingsEvent {
+   const enum Type : int {
+      ChangedTool,
+   } type;
+   const int oldValue;
+   const int newValue;
+};
+
 ///\brief Holds various per-project settings values,
 /// and sends events to the project when certain values change
 class AUDACITY_DLL_API ProjectSettings final
    : public ClientData::Base
+   , public Observer::Publisher<ProjectSettingsEvent>
    , private PrefsListener
 {
 public:
    static ProjectSettings &Get( AudacityProject &project );
    static const ProjectSettings &Get( const AudacityProject &project );
    
-   // Values retrievable from GetInt() of the event for settings change
-   enum EventCode : int {
-      ChangedTool,
-   };
-
    explicit ProjectSettings( AudacityProject &project );
    ProjectSettings( const ProjectSettings & ) = delete;
    ProjectSettings &operator=( const ProjectSettings & ) = delete;

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -700,7 +700,7 @@ ProjectWindow::ProjectWindow(wxWindow * parent, wxWindowID id,
       theTheme.Subscribe(*this, &ProjectWindow::OnThemeChange);
 
    // Subscribe to title changes published by ProjectFileIO
-   mTitleChangeSubcription = ProjectFileIO::Get(project)
+   mTitleChangeSubscription = ProjectFileIO::Get(project)
       .Subscribe(*this, &ProjectWindow::OnProjectTitleChange);
 
    // Subscribe to snapping changes

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -231,7 +231,7 @@ private:
 
    Observer::Subscription mUndoSubscription
       , mThemeChangeSubscription
-      , mTitleChangeSubcription
+      , mTitleChangeSubscription
       , mSnappingChangedSubscription
    ;
    std::unique_ptr<PlaybackScroller> mPlaybackScroller;

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -22,7 +22,6 @@
 #include "ProjectNumericFormats.h"
 #include "ProjectWindows.h"
 #include "ProjectRate.h"
-#include "ProjectSettings.h"
 #include "SelectionState.h"
 #include "SyncLock.h"
 #include "TimeDialog.h"

--- a/src/Snap.cpp
+++ b/src/Snap.cpp
@@ -298,16 +298,3 @@ SnapResults SnapManager::Snap
 
    return results;
 }
-
-#include "AColor.h"
-
-void SnapManager::Draw( wxDC *dc, wxInt64 snap0, wxInt64 snap1 )
-{
-   AColor::SnapGuidePen(dc);
-   if ( snap0 >= 0 ) {
-      AColor::Line(*dc, (int)snap0, 0, (int)snap0, 30000);
-   }
-   if ( snap1 >= 0 ) {
-      AColor::Line(*dc, (int)snap1, 0, (int)snap1, 30000);
-   }
-}

--- a/src/Snap.h
+++ b/src/Snap.h
@@ -80,9 +80,6 @@ public:
    SnapResults Snap(Track *currentTrack,
              double t,
              bool rightEdge);
-   
-   // The two coordinates need not be ordered:
-   static void Draw( wxDC *dc, wxInt64 snap0, wxInt64 snap1 );
 
 private:
 

--- a/src/Snap.h
+++ b/src/Snap.h
@@ -111,7 +111,7 @@ private:
 
    Identifier mSnapTo {};
    double mRate{ 0.0 };
-   NumericFormatSymbol mFormat{};
+   NumericFormatID mFormat{};
 };
 
 #endif

--- a/src/TimeDialog.cpp
+++ b/src/TimeDialog.cpp
@@ -28,7 +28,7 @@ END_EVENT_TABLE()
 
 TimeDialog::TimeDialog(wxWindow *parent,
                        const TranslatableString &title,
-                       const NumericFormatSymbol &format,
+                       const NumericFormatID &format,
                        const AudacityProject &project,
                        double time,
                        const TranslatableString &prompt)
@@ -96,7 +96,7 @@ const double TimeDialog::GetTimeValue()
    return mTime;
 }
 
-void TimeDialog::SetFormatString(const NumericFormatSymbol &formatString)
+void TimeDialog::SetFormatString(const NumericFormatID &formatString)
 {
    mFormat = formatString;
    TransferDataToWindow();

--- a/src/TimeDialog.h
+++ b/src/TimeDialog.h
@@ -27,12 +27,12 @@ class AUDACITY_DLL_API TimeDialog final : public wxDialogWrapper
 
    TimeDialog(wxWindow *parent,
               const TranslatableString &title,
-              const NumericFormatSymbol &format,
+              const NumericFormatID &format,
               const AudacityProject &project,
               double time,
               const TranslatableString &prompt = XO("Duration"));
 
-   void SetFormatString(const NumericFormatSymbol &formatString);
+   void SetFormatString(const NumericFormatID &formatString);
    void SetTimeValue(double newTime);
    const double GetTimeValue();
 
@@ -47,7 +47,7 @@ class AUDACITY_DLL_API TimeDialog final : public wxDialogWrapper
  private:
 
    TranslatableString mPrompt;
-   NumericFormatSymbol mFormat;
+   NumericFormatID mFormat;
    const AudacityProject &mProject;
    double mTime;
 

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -47,7 +47,6 @@
 #include "ProjectManager.h"
 #include "ProjectRate.h"
 #include "ProjectWindow.h"
-#include "ProjectSettings.h"
 #include "Project.h"
 #include "Prefs.h"
 #include "Track.h"

--- a/src/TrackArt.cpp
+++ b/src/TrackArt.cpp
@@ -817,3 +817,12 @@ void TrackArt::DrawCursor(TrackPanelDrawingContext& context,
        }
    }
 }
+
+void TrackArt::DrawSnapLines(wxDC *dc, wxInt64 snap0, wxInt64 snap1)
+{
+   AColor::SnapGuidePen(dc);
+   if (snap0 >= 0)
+      AColor::Line(*dc, (int)snap0, 0, (int)snap0, 30000);
+   if (snap1 >= 0)
+      AColor::Line(*dc, (int)snap1, 0, (int)snap1, 30000);
+}

--- a/src/TrackArt.h
+++ b/src/TrackArt.h
@@ -16,6 +16,7 @@ class wxBrush;
 class wxDC;
 class wxRect;
 class wxString;
+#include <wx/types.h>
 
 namespace TrackArt {
 
@@ -64,6 +65,9 @@ namespace TrackArt {
 
    AUDACITY_DLL_API
    wxString TruncateText(wxDC& dc, const wxString& text, const int maxWidth);
+
+   AUDACITY_DLL_API
+   void DrawSnapLines(wxDC *dc, wxInt64 snap0, wxInt64 snap1);
 }
 
 extern AUDACITY_DLL_API int GetWaveYPos(float value, float min, float max,

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -337,6 +337,8 @@ TrackPanel::TrackPanel(wxWindow * parent, wxWindowID id,
 
    mProjectRulerInvalidatedSubscription =
       ProjectTimeRuler::Get(*theProject).GetRuler().Subscribe([this](auto mode) { Refresh(); });
+   mSelectionSubscription = viewInfo->selectedRegion
+      .Subscribe([this](auto&){ Refresh(false); });
 
    UpdatePrefs();
 }

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -195,6 +195,7 @@ protected:
       , mRealtimeEffectManagerSubscription
       , mSyncLockSubscription
       , mProjectRulerInvalidatedSubscription
+      , mSelectionSubscription
    ;
 
    TrackPanelListener *mListener;

--- a/src/commands/SelectCommand.cpp
+++ b/src/commands/SelectCommand.cpp
@@ -194,7 +194,7 @@ bool SelectFrequenciesCommand::Apply(const CommandContext & context){
    if( !bHasBottom )
       mBottom = 0.0;
 
-   ProjectSelectionManager::Get( context.project ).SSBL_ModifySpectralSelection(
+   ProjectSelectionManager::Get( context.project ).ModifySpectralSelection(
       mBottom, mTop, false);// false for not done.
    return true;
 }

--- a/src/commands/SelectCommand.cpp
+++ b/src/commands/SelectCommand.cpp
@@ -47,6 +47,7 @@ explicitly code all three.
 #include "Effect.h"
 #include "ViewInfo.h"
 #include "CommandContext.h"
+#include "WaveTrack.h"
 
 
 const ComponentInterfaceSymbol SelectTimeCommand::Symbol
@@ -194,7 +195,8 @@ bool SelectFrequenciesCommand::Apply(const CommandContext & context){
    if( !bHasBottom )
       mBottom = 0.0;
 
-   ProjectSelectionManager::Get( context.project ).ModifySpectralSelection(
+   ProjectSelectionManager::Get(context.project).ModifySpectralSelection(
+      WaveTrack::ProjectNyquistFrequency(context.project),
       mBottom, mTop, false);// false for not done.
    return true;
 }

--- a/src/commands/SelectCommand.cpp
+++ b/src/commands/SelectCommand.cpp
@@ -39,7 +39,7 @@ explicitly code all three.
 #include "../CommonCommandFlags.h"
 #include "EffectOutputTracks.h"
 #include "LoadCommands.h"
-#include "../ProjectSelectionManager.h"
+#include "ProjectSelectionManager.h"
 #include "../TrackPanel.h"
 #include "SettingsVisitor.h"
 #include "ShuttleGui.h"

--- a/src/commands/SetProjectCommand.cpp
+++ b/src/commands/SetProjectCommand.cpp
@@ -31,7 +31,6 @@
 #include "SettingsVisitor.h"
 #include "ShuttleGui.h"
 #include "CommandContext.h"
-#include "../toolbars/SelectionBar.h"
 
 #include <wx/frame.h>
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -107,7 +107,7 @@ EffectChangeSpeed::EffectChangeSpeed()
    mToVinyl = kVinyl_33AndAThird;
    mFromLength = 0.0;
    mToLength = 0.0;
-   mFormat = NumericConverterFormats::DefaultSelectionFormat();
+   mFormat = NumericConverterFormats::DefaultSelectionFormat().Internal();
    mbLoopDetect = false;
 
    SetLinearEffectFlag(true);
@@ -152,7 +152,7 @@ OptionalMessage
 EffectChangeSpeed::DoLoadFactoryDefaults(EffectSettings &settings)
 {
    mFromVinyl = kVinyl_33AndAThird;
-   mFormat = NumericConverterFormats::DefaultSelectionFormat();
+   mFormat = NumericConverterFormats::DefaultSelectionFormat().Internal();
 
    return Effect::LoadFactoryDefaults(settings);
 }
@@ -308,10 +308,10 @@ std::unique_ptr<EffectEditor> EffectChangeSpeed::PopulateOrExchange(
       wxString formatId;
       GetConfig(GetDefinition(), PluginSettings::Private,
          CurrentSettingsGroup(),
-         wxT("TimeFormat"), formatId, mFormat.Internal());
+         wxT("TimeFormat"), formatId, mFormat.GET());
       mFormat = NumericConverterFormats::Lookup(
          FormatterContext::SampleRateContext(mProjectRate),
-         NumericConverterType_TIME(), formatId);
+         NumericConverterType_TIME(), formatId).Internal();
    }
    GetConfig(GetDefinition(), PluginSettings::Private,
       CurrentSettingsGroup(),
@@ -470,7 +470,7 @@ bool EffectChangeSpeed::TransferDataFromWindow(EffectSettings &)
 
    // TODO: just visit these effect settings the default way
    SetConfig(GetDefinition(), PluginSettings::Private,
-      CurrentSettingsGroup(), wxT("TimeFormat"), mFormat.Internal());
+      CurrentSettingsGroup(), wxT("TimeFormat"), mFormat.GET());
    SetConfig(GetDefinition(), PluginSettings::Private,
       CurrentSettingsGroup(), wxT("VinylChoice"), mFromVinyl);
 
@@ -673,7 +673,7 @@ void EffectChangeSpeed::OnTimeCtrlUpdate(wxCommandEvent & evt)
 {
    mFormat = NumericConverterFormats::Lookup(
       FormatterContext::SampleRateContext(mProjectRate),
-      NumericConverterType_TIME(), evt.GetString());
+      NumericConverterType_TIME(), evt.GetString()).Internal();
 
    mpFromLengthCtrl->SetFormatName(mFormat);
    // Update From/To Length controls (precision has changed).

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -120,7 +120,7 @@ private:
    // private effect parameters
    int      mToVinyl;         // to standard vinyl speed (rpm)
    double   mToLength;        // target length of selection
-   NumericFormatSymbol mFormat;          // time control format
+   NumericFormatID mFormat;          // time control format
 
    const EffectParameterMethods& Parameters() const override;
    DECLARE_EVENT_TABLE()

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -251,7 +251,7 @@ ContrastDialog::ContrastDialog(wxWindow * parent, wxWindowID id,
                NumericTextCtrl(FormatterContext::SampleRateContext(mProjectRate),
                          S.GetParent(), ID_FOREGROUNDSTART_T,
                          NumericConverterType_TIME(),
-                         NumericConverterFormats::HundredthsFormat(),
+                         NumericConverterFormats::HundredthsFormat().Internal(),
                          0.0,
                          options);
          }
@@ -264,7 +264,7 @@ ContrastDialog::ContrastDialog(wxWindow * parent, wxWindowID id,
                NumericTextCtrl(FormatterContext::SampleRateContext(mProjectRate),
                          S.GetParent(), ID_FOREGROUNDEND_T,
                          NumericConverterType_TIME(),
-                         NumericConverterFormats::HundredthsFormat(),
+                         NumericConverterFormats::HundredthsFormat().Internal(),
                          0.0,
                          options);
          }
@@ -285,7 +285,7 @@ ContrastDialog::ContrastDialog(wxWindow * parent, wxWindowID id,
                NumericTextCtrl(FormatterContext::SampleRateContext(mProjectRate),
                          S.GetParent(), ID_BACKGROUNDSTART_T,
                          NumericConverterType_TIME(),
-                         NumericConverterFormats::HundredthsFormat(),
+                         NumericConverterFormats::HundredthsFormat().Internal(),
                          0.0,
                          options);
          }
@@ -298,7 +298,7 @@ ContrastDialog::ContrastDialog(wxWindow * parent, wxWindowID id,
                NumericTextCtrl(FormatterContext::SampleRateContext(mProjectRate),
                          S.GetParent(), ID_BACKGROUNDEND_T,
                          NumericConverterType_TIME(),
-                         NumericConverterFormats::HundredthsFormat(),
+                         NumericConverterFormats::HundredthsFormat().Internal(),
                          0.0,
                          options);
          }

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -16,7 +16,6 @@
 
 #include "Export.h"
 #include "ExportUtils.h"
-#include "ProjectSettings.h"
 #include "WaveTrack.h"
 #include "LabelTrack.h"
 #include "Mix.h"

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -4,7 +4,6 @@
 #include "PluginManager.h"
 #include "Prefs.h"
 #include "Project.h"
-#include "ProjectSettings.h"
 #include "../ProjectFileManager.h"
 #include "ProjectHistory.h"
 #include "../ProjectManager.h"

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -17,7 +17,6 @@
 #include "Prefs.h"
 #include "Project.h"
 #include "ProjectSnap.h"
-#include "../ProjectSelectionManager.h"
 #include "../ProjectWindows.h"
 #include "SelectFile.h"
 #include "ShuttleGui.h"

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -10,7 +10,6 @@
 #include "Project.h"
 #include "ProjectRate.h"
 #include "ProjectSnap.h"
-#include "../ProjectSettings.h"
 #include "../ProjectWindow.h"
 #include "../ProjectWindows.h"
 #include "RealtimeEffectPanel.h"

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -13,7 +13,6 @@
 #include "../ProjectSettings.h"
 #include "../ProjectWindow.h"
 #include "../ProjectWindows.h"
-#include "../ProjectSelectionManager.h"
 #include "RealtimeEffectPanel.h"
 #include "SampleTrack.h"
 #include "SyncLock.h"

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -9,7 +9,6 @@
 #include "ProjectHistory.h"
 #include "ProjectRate.h"
 #include "ProjectSnap.h"
-#include "../ProjectSettings.h"
 #include "../ProjectWindow.h"
 #include "../ProjectWindows.h"
 #include "../SelectUtilities.h"

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -9,7 +9,6 @@
 #include "ProjectHistory.h"
 #include "ProjectRate.h"
 #include "ProjectSnap.h"
-#include "../ProjectSelectionManager.h"
 #include "../ProjectSettings.h"
 #include "../ProjectWindow.h"
 #include "../ProjectWindows.h"

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -1,4 +1,3 @@
-#include "../ProjectSettings.h"
 #include "../commands/CommandContext.h"
 #include "../commands/CommandManager.h"
 #include "../toolbars/ToolManager.h"

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -8,7 +8,6 @@
 #include "ProjectAudioIO.h"
 #include "../ProjectAudioManager.h"
 #include "ProjectHistory.h"
-#include "../ProjectSettings.h"
 #include "../ProjectWindows.h"
 #include "../ProjectWindow.h"
 #include "../SelectUtilities.h"

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -57,7 +57,6 @@
 #include "Project.h"
 #include "ProjectAudioIO.h"
 #include "../ProjectAudioManager.h"
-#include "../ProjectSettings.h"
 #include "ProjectStatus.h"
 #include "../ProjectWindow.h"
 #include "../SelectUtilities.h"

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -49,6 +49,7 @@ selection range.
 #include "Prefs.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
+#include "ProjectNumericFormats.h"
 #include "ProjectRate.h"
 #include "ProjectSelectionManager.h"
 #include "ProjectTimeSignature.h"
@@ -216,8 +217,8 @@ void SelectionBar::AddTitle(
 
 void SelectionBar::AddTime(int id, wxSizer * pSizer)
 {
-   auto formatName =
-      ProjectSelectionManager::Get(mProject).AS_GetSelectionFormat();
+   auto &formats = ProjectNumericFormats::Get(mProject);
+   auto formatName = formats.GetSelectionFormat();
    auto pCtrl = safenew NumericTextCtrl(FormatterContext::ProjectContext(mProject),
       this, id, NumericConverterType_TIME(), formatName, 0.0);
 
@@ -312,8 +313,8 @@ void SelectionBar::Populate()
    Layout();
 
    CallAfter([this]{
-      auto &manager = ProjectSelectionManager::Get(mProject);
-      SetSelectionFormat(manager.AS_GetSelectionFormat());
+      auto &formats = ProjectNumericFormats::Get(mProject);
+      SetSelectionFormat(formats.GetSelectionFormat());
    });
 
 }

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -223,7 +223,7 @@ void SelectionBar::AddTitle(
 void SelectionBar::AddTime(
    int id, wxSizer * pSizer ){
    auto formatName = mListener ? mListener->AS_GetSelectionFormat()
-      : NumericFormatSymbol{};
+      : NumericFormatID{};
    auto pCtrl = safenew NumericTextCtrl(FormatterContext::ProjectContext(mProject),
       this, id, NumericConverterType_TIME(), formatName, 0.0);
 
@@ -474,9 +474,7 @@ void SelectionBar::OnUpdate(wxCommandEvent &evt)
          std::distance(mTimeControls.begin(), focusedCtrlIt) :
          -1;
 
-   auto format = NumericConverterFormats::Lookup(
-      FormatterContext::ProjectContext(mProject), NumericConverterType_TIME(),
-      evt.GetString());
+   auto format = evt.GetString();
 
    // Save format name before recreating the controls so they resize properly
    if (mTimeControls.front())
@@ -580,7 +578,7 @@ void SelectionBar::SetTimes(double start, double end)
    }
 }
 
-void SelectionBar::SetSelectionFormat(const NumericFormatSymbol & format)
+void SelectionBar::SetSelectionFormat(const NumericFormatID & format)
 {
    if (mTimeControls.front() == nullptr)
       return;
@@ -590,7 +588,7 @@ void SelectionBar::SetSelectionFormat(const NumericFormatSymbol & format)
    // Test first whether changed, to avoid infinite recursion from OnUpdate
    if ( changed ) {
       wxCommandEvent e;
-      e.SetString(format.Internal());
+      e.SetString(format.GET());
       OnUpdate(e);
    }
 }
@@ -618,7 +616,7 @@ void SelectionBar::OnCaptureKey(wxCommandEvent &event)
    event.Skip();
 }
 
-void SelectionBar::UpdateTimeControlsFormat(const NumericFormatSymbol& format)
+void SelectionBar::UpdateTimeControlsFormat(const NumericFormatID& format)
 {
    for (size_t controlIndex = 0; controlIndex < mTimeControls.size();
         ++controlIndex)
@@ -633,8 +631,8 @@ void SelectionBar::UpdateTimeControlsFormat(const NumericFormatSymbol& format)
 
       ctrl->SetTypeAndFormatName(
          type, type != NumericConverterType_DURATION() ?
-                  format :
-                  NumericConverterFormats::GetBestDurationFormat(format));
+            format :
+            NumericConverterFormats::GetBestDurationFormat(format));
    }
 }
 

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -130,7 +130,9 @@ Identifier SelectionBar::ID()
 SelectionBar::SelectionBar( AudacityProject &project )
 : ToolBar(project, XO("Selection"), ID()),
   mRate(0.0),
-  mStart(0.0), mEnd(0.0), mLength(0.0), mCenter(0.0)
+  mStart(0.0), mEnd(0.0), mLength(0.0), mCenter(0.0),
+  mFormatsSubscription{ ProjectNumericFormats::Get(project).Subscribe(
+     *this, &SelectionBar::OnFormatsChanged) }
 {
    // Make sure we have a valid rate as the NumericTextCtrl()s
    // created in Populate()
@@ -586,6 +588,15 @@ void SelectionBar::SetSelectionFormat(const NumericFormatID & format)
       wxCommandEvent e;
       e.SetString(format.GET());
       OnUpdate(e);
+   }
+}
+
+void SelectionBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
+{
+   auto &formats = ProjectNumericFormats::Get(mProject);
+   switch (evt.type) {
+   default:
+      break;
    }
 }
 

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -454,7 +454,7 @@ void SelectionBar::ModifySelection(int driver, bool done)
 
    // Places the start-end markers on the track panel.
    auto &manager = ProjectSelectionManager::Get(mProject);
-   manager.AS_ModifySelection(start, end, done);
+   manager.ModifySelection(start, end, done);
 }
 
 // Called when one of the format drop downs is changed.

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -477,8 +477,9 @@ void SelectionBar::OnUpdate(wxCommandEvent &evt)
    // Save format name before recreating the controls so they resize properly
    if (mTimeControls.front())
    {
-      auto &manager = ProjectSelectionManager::Get(mProject);
-      manager.AS_SetSelectionFormat(format);
+      auto &formats = ProjectNumericFormats::Get(mProject);
+      formats.SetSelectionFormat(format);
+      // Then my Subscription is called
    }
 
    // ReCreateButtons() will get rid of our sizers and controls
@@ -595,6 +596,8 @@ void SelectionBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
 {
    auto &formats = ProjectNumericFormats::Get(mProject);
    switch (evt.type) {
+   case ProjectNumericFormatsEvent::ChangedSelectionFormat:
+      return SetSelectionFormat(formats.GetSelectionFormat());
    default:
       break;
    }

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -53,7 +53,6 @@ selection range.
 #include "ProjectRate.h"
 #include "ProjectSelectionManager.h"
 #include "ProjectTimeSignature.h"
-#include "../ProjectSettings.h"
 #include "ViewInfo.h"
 #include "AllThemeResources.h"
 #include "ImageManipulation.h"

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -66,7 +66,7 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
 
    void SetTimes(double start, double end);
 
-   void SetSelectionFormat(const NumericFormatSymbol & format);
+   void SetSelectionFormat(const NumericFormatID & format);
    void SetListener(SelectionBarListener *l);
    void RegenerateTooltips() override;
 
@@ -90,7 +90,7 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
    void ModifySelection(int driver, bool done = false);
    void SelectionModeUpdated();
 
-   void UpdateTimeControlsFormat(const NumericFormatSymbol& format);
+   void UpdateTimeControlsFormat(const NumericFormatID& format);
 
    void FitToTimeControls();
 

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -92,6 +92,8 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
 
    void FitToTimeControls();
 
+   void OnFormatsChanged(struct ProjectNumericFormatsEvent);
+
    double mRate;
    double mStart, mEnd, mLength, mCenter;
 
@@ -104,7 +106,8 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
    Observer::Subscription mFormatChangedToFitValueSubscription[2];
 
    wxString mLastValidText;
-   
+   const Observer::Subscription mFormatsSubscription;
+
  public:
 
    DECLARE_CLASS(SelectionBar)

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -30,7 +30,6 @@ class wxSizeEvent;
 class wxStaticText;
 
 class AudacityProject;
-class SelectionBarListener;
 class NumericTextCtrl;
 
 extern IntSetting SelectionToolbarMode;
@@ -67,7 +66,6 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
    void SetTimes(double start, double end);
 
    void SetSelectionFormat(const NumericFormatID & format);
-   void SetListener(SelectionBarListener *l);
    void RegenerateTooltips() override;
 
  private:
@@ -94,7 +92,6 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
 
    void FitToTimeControls();
 
-   SelectionBarListener * mListener;
    double mRate;
    double mStart, mEnd, mLength, mCenter;
 

--- a/src/toolbars/SelectionBarListener.h
+++ b/src/toolbars/SelectionBarListener.h
@@ -23,8 +23,8 @@ class AUDACITY_DLL_API SelectionBarListener /* not final */ {
    SelectionBarListener(){};
    virtual ~SelectionBarListener(){};
 
-   virtual const NumericFormatSymbol & AS_GetSelectionFormat() = 0;
-   virtual void AS_SetSelectionFormat(const NumericFormatSymbol & format) = 0;
+   virtual NumericFormatID AS_GetSelectionFormat() = 0;
+   virtual void AS_SetSelectionFormat(const NumericFormatID & format) = 0;
    virtual void AS_ModifySelection(double &start, double &end, bool done) = 0;
 };
 
@@ -35,8 +35,8 @@ class AUDACITY_DLL_API TimeToolBarListener /* not final */ {
    TimeToolBarListener(){};
    virtual ~TimeToolBarListener(){};
 
-   virtual const NumericFormatSymbol & TT_GetAudioTimeFormat() = 0;
-   virtual void TT_SetAudioTimeFormat(const NumericFormatSymbol & format) = 0;
+   virtual NumericFormatID TT_GetAudioTimeFormat() = 0;
+   virtual void TT_SetAudioTimeFormat(const NumericFormatID & format) = 0;
 };
 
 #endif

--- a/src/toolbars/SnappingToolBar.cpp
+++ b/src/toolbars/SnappingToolBar.cpp
@@ -30,7 +30,6 @@
 
 #include "Prefs.h"
 #include "Project.h"
-#include "../ProjectSettings.h"
 #include "ViewInfo.h"
 
 #include "AllThemeResources.h"

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -381,6 +381,9 @@ void SpectralSelectionBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
    case ProjectNumericFormatsEvent::ChangedFrequencyFormat:
       return SetFrequencySelectionFormatName(
          formats.GetFrequencySelectionFormatName());
+   case ProjectNumericFormatsEvent::ChangedBandwidthFormat:
+      return SetBandwidthSelectionFormatName(
+         formats.GetBandwidthSelectionFormatName());
    default:
       break;
    }
@@ -388,7 +391,6 @@ void SpectralSelectionBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
 
 void SpectralSelectionBar::OnUpdate(wxCommandEvent &evt)
 {
-   auto &manager = ProjectSelectionManager::Get(mProject);
    auto &formats = ProjectNumericFormats::Get(mProject);
    wxWindow *w = FindFocus();
    bool centerFocus = (w && w == mCenterCtrl);
@@ -406,8 +408,8 @@ void SpectralSelectionBar::OnUpdate(wxCommandEvent &evt)
    }
    else if (mbCenterAndWidth &&
             type == EVT_BANDWIDTHTEXTCTRL_UPDATED) {
-      auto bandwidthFormatName = evt.GetString();
-      manager.SSBL_SetBandwidthSelectionFormatName(bandwidthFormatName);
+      formats.SetBandwidthSelectionFormatName(evt.GetString());
+      // Then my subscription is called
    }
 
    // ReCreateButtons() will get rid of our sizers and controls

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -271,9 +271,7 @@ void SpectralSelectionBar::ModifySpectralSelection(bool done)
 {
    auto &manager = ProjectSelectionManager::Get(mProject);
    auto &tracks = TrackList::Get(mProject);
-   const auto rate = std::max(ProjectRate::Get(mProject).GetRate(),
-      tracks.Any<const WaveTrack>().max(&WaveTrack::GetRate));
-   const double nyq = rate / 2.0;
+   const auto nyq = WaveTrack::ProjectNyquistFrequency(mProject);
 
    double bottom, top;
    if (mbCenterAndWidth) {
@@ -337,7 +335,7 @@ void SpectralSelectionBar::ModifySpectralSelection(bool done)
 
    // Notify project and track panel, which may change
    // the values again, and call back to us in SetFrequencies()
-   manager.ModifySpectralSelection(bottom, top, done);
+   manager.ModifySpectralSelection(nyq, bottom, top, done);
 }
 
 void SpectralSelectionBar::OnCtrl(wxCommandEvent & event)

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -378,6 +378,9 @@ void SpectralSelectionBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
 {
    auto &formats = ProjectNumericFormats::Get(mProject);
    switch (evt.type) {
+   case ProjectNumericFormatsEvent::ChangedFrequencyFormat:
+      return SetFrequencySelectionFormatName(
+         formats.GetFrequencySelectionFormatName());
    default:
       break;
    }
@@ -386,6 +389,7 @@ void SpectralSelectionBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
 void SpectralSelectionBar::OnUpdate(wxCommandEvent &evt)
 {
    auto &manager = ProjectSelectionManager::Get(mProject);
+   auto &formats = ProjectNumericFormats::Get(mProject);
    wxWindow *w = FindFocus();
    bool centerFocus = (w && w == mCenterCtrl);
    bool widthFocus = (w && w == mWidthCtrl);
@@ -397,8 +401,8 @@ void SpectralSelectionBar::OnUpdate(wxCommandEvent &evt)
    // Save formats before recreating the controls so they resize properly
    wxEventType type = evt.GetEventType();
    if (type == EVT_FREQUENCYTEXTCTRL_UPDATED) {
-      auto frequencyFormatName = evt.GetString();
-      manager.SSBL_SetFrequencySelectionFormatName(frequencyFormatName);
+      formats.SetFrequencySelectionFormatName(evt.GetString());
+      // Then my subscription is called
    }
    else if (mbCenterAndWidth &&
             type == EVT_BANDWIDTHTEXTCTRL_UPDATED) {

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -17,18 +17,11 @@ the Free Software Foundation; either version 2 of the License, or
 \brief (not quite a Toolbar) at foot of screen for setting and viewing the
 frequency selection range.
 
-*//****************************************************************//**
-
-\class SpectralSelectionBarListener
-\brief A class used to forward events to do
-with changes in the SpectralSelectionBar.
-
 *//*******************************************************************/
 
 
 
 #include "SpectralSelectionBar.h"
-#include "SpectralSelectionBarListener.h"
 
 #include "ToolManager.h"
 
@@ -52,6 +45,7 @@ with changes in the SpectralSelectionBar.
 
 #include "Prefs.h"
 #include "Project.h"
+#include "../ProjectSelectionManager.h"
 #include "AllThemeResources.h"
 #include "SelectedRegion.h"
 #include "ViewInfo.h"
@@ -97,7 +91,7 @@ Identifier SpectralSelectionBar::ID()
 
 SpectralSelectionBar::SpectralSelectionBar( AudacityProject &project )
 : ToolBar( project, XO("Spectral Selection"), ID() )
-, mListener(NULL), mbCenterAndWidth(true)
+, mbCenterAndWidth(true)
 , mCenter(0.0), mWidth(0.0), mLow(0.0), mHigh(0.0)
 , mCenterCtrl(NULL), mWidthCtrl(NULL), mLowCtrl(NULL), mHighCtrl(NULL)
 , mChoice(NULL)
@@ -142,13 +136,9 @@ void SpectralSelectionBar::Populate()
    SetBackgroundColour( theTheme.Colour( clrMedium  ) );
    gPrefs->Read(preferencePath, &mbCenterAndWidth, true);
 
-   auto frequencyFormatName = mListener
-      ? mListener->SSBL_GetFrequencySelectionFormatName()
-      : NumericFormatID{};
-   auto bandwidthFormatName = mListener
-      ? mListener->SSBL_GetBandwidthSelectionFormatName()
-      : NumericFormatID{};
-
+   auto &manager = ProjectSelectionManager::Get(mProject);
+   auto frequencyFormatName = manager.SSBL_GetFrequencySelectionFormatName();
+   auto bandwidthFormatName = manager.SSBL_GetBandwidthSelectionFormatName();
    wxFlexGridSizer *mainSizer = safenew wxFlexGridSizer(1, 1, 1);
    Add(mainSizer, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 5);
 
@@ -229,6 +219,14 @@ void SpectralSelectionBar::Populate()
    mainSizer->Layout();
 
    Layout();
+
+   CallAfter([this]{
+      auto &manager = ProjectSelectionManager::Get(mProject);
+      SetFrequencySelectionFormatName(
+         manager.SSBL_GetFrequencySelectionFormatName());
+      SetBandwidthSelectionFormatName(
+         manager.SSBL_GetBandwidthSelectionFormatName());
+   });
 }
 
 void SpectralSelectionBar::UpdatePrefs()
@@ -257,13 +255,6 @@ void SpectralSelectionBar::UpdatePrefs()
    ToolBar::UpdatePrefs();
 }
 
-void SpectralSelectionBar::SetListener(SpectralSelectionBarListener *l)
-{
-   mListener = l;
-   SetFrequencySelectionFormatName(mListener->SSBL_GetFrequencySelectionFormatName());
-   SetBandwidthSelectionFormatName(mListener->SSBL_GetBandwidthSelectionFormatName());
-};
-
 void SpectralSelectionBar::OnSize(wxSizeEvent &evt)
 {
    Refresh(true);
@@ -273,7 +264,8 @@ void SpectralSelectionBar::OnSize(wxSizeEvent &evt)
 
 void SpectralSelectionBar::ModifySpectralSelection(bool done)
 {
-   const double nyq = mListener->SSBL_GetRate() / 2.0;
+   auto &manager = ProjectSelectionManager::Get(mProject);
+   const double nyq = manager.SSBL_GetRate() / 2.0;
 
    double bottom, top;
    if (mbCenterAndWidth) {
@@ -337,7 +329,7 @@ void SpectralSelectionBar::ModifySpectralSelection(bool done)
 
    // Notify project and track panel, which may change
    // the values again, and call back to us in SetFrequencies()
-   mListener->SSBL_ModifySpectralSelection(bottom, top, done);
+   manager.SSBL_ModifySpectralSelection(bottom, top, done);
 }
 
 void SpectralSelectionBar::OnCtrl(wxCommandEvent & event)
@@ -376,6 +368,7 @@ void SpectralSelectionBar::OnIdle( wxIdleEvent &evt )
 
 void SpectralSelectionBar::OnUpdate(wxCommandEvent &evt)
 {
+   auto &manager = ProjectSelectionManager::Get(mProject);
    wxWindow *w = FindFocus();
    bool centerFocus = (w && w == mCenterCtrl);
    bool widthFocus = (w && w == mWidthCtrl);
@@ -388,14 +381,12 @@ void SpectralSelectionBar::OnUpdate(wxCommandEvent &evt)
    wxEventType type = evt.GetEventType();
    if (type == EVT_FREQUENCYTEXTCTRL_UPDATED) {
       auto frequencyFormatName = evt.GetString();
-      if (mListener)
-         mListener->SSBL_SetFrequencySelectionFormatName(frequencyFormatName);
+      manager.SSBL_SetFrequencySelectionFormatName(frequencyFormatName);
    }
    else if (mbCenterAndWidth &&
             type == EVT_BANDWIDTHTEXTCTRL_UPDATED) {
       auto bandwidthFormatName = evt.GetString();
-      if (mListener)
-         mListener->SSBL_SetBandwidthSelectionFormatName(bandwidthFormatName);
+      manager.SSBL_SetBandwidthSelectionFormatName(bandwidthFormatName);
    }
 
    // ReCreateButtons() will get rid of our sizers and controls

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -337,7 +337,7 @@ void SpectralSelectionBar::ModifySpectralSelection(bool done)
 
    // Notify project and track panel, which may change
    // the values again, and call back to us in SetFrequencies()
-   manager.SSBL_ModifySpectralSelection(bottom, top, done);
+   manager.ModifySpectralSelection(bottom, top, done);
 }
 
 void SpectralSelectionBar::OnCtrl(wxCommandEvent & event)

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -99,6 +99,8 @@ SpectralSelectionBar::SpectralSelectionBar( AudacityProject &project )
 , mCenterCtrl(NULL), mWidthCtrl(NULL), mLowCtrl(NULL), mHighCtrl(NULL)
 , mChoice(NULL)
 {
+   mFormatsSubscription = ProjectNumericFormats::Get(project)
+      .Subscribe(*this, &SpectralSelectionBar::OnFormatsChanged);
 }
 
 SpectralSelectionBar::~SpectralSelectionBar()
@@ -370,6 +372,15 @@ void SpectralSelectionBar::OnIdle( wxIdleEvent &evt )
    auto &project = mProject;
    const auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
    SetFrequencies( selectedRegion.f0(), selectedRegion.f1() );
+}
+
+void SpectralSelectionBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
+{
+   auto &formats = ProjectNumericFormats::Get(mProject);
+   switch (evt.type) {
+   default:
+      break;
+   }
 }
 
 void SpectralSelectionBar::OnUpdate(wxCommandEvent &evt)

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -144,10 +144,10 @@ void SpectralSelectionBar::Populate()
 
    auto frequencyFormatName = mListener
       ? mListener->SSBL_GetFrequencySelectionFormatName()
-      : NumericFormatSymbol{};
+      : NumericFormatID{};
    auto bandwidthFormatName = mListener
       ? mListener->SSBL_GetBandwidthSelectionFormatName()
-      : NumericFormatSymbol{};
+      : NumericFormatID{};
 
    wxFlexGridSizer *mainSizer = safenew wxFlexGridSizer(1, 1, 1);
    Add(mainSizer, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 5);
@@ -235,14 +235,16 @@ void SpectralSelectionBar::UpdatePrefs()
 {
    {
       wxCommandEvent e(EVT_FREQUENCYTEXTCTRL_UPDATED);
-      e.SetString((mbCenterAndWidth ? mCenterCtrl : mLowCtrl)->GetFormatName().Internal());
+      e.SetString(
+         (mbCenterAndWidth ? mCenterCtrl : mLowCtrl)
+            ->GetFormatName().GET());
       OnUpdate(e);
    }
 
    if (mbCenterAndWidth)
    {
       wxCommandEvent e(EVT_BANDWIDTHTEXTCTRL_UPDATED);
-      e.SetString(mWidthCtrl->GetFormatName().Internal());
+      e.SetString(mWidthCtrl->GetFormatName().GET());
       OnUpdate(e);
    }
 
@@ -468,7 +470,8 @@ void SpectralSelectionBar::SetFrequencies(double bottom, double top)
    }
 }
 
-void SpectralSelectionBar::SetFrequencySelectionFormatName(const NumericFormatSymbol & formatName)
+void SpectralSelectionBar::SetFrequencySelectionFormatName(
+   const NumericFormatID &formatName)
 {
    NumericTextCtrl *frequencyCtrl = (mbCenterAndWidth ? mCenterCtrl : mLowCtrl);
    bool changed =
@@ -476,12 +479,13 @@ void SpectralSelectionBar::SetFrequencySelectionFormatName(const NumericFormatSy
    // Test first whether changed, to avoid infinite recursion from OnUpdate
    if (changed) {
       wxCommandEvent e(EVT_FREQUENCYTEXTCTRL_UPDATED);
-      e.SetString(frequencyCtrl->GetFormatName().Internal());
+      e.SetString(frequencyCtrl->GetFormatName().GET());
       OnUpdate(e);
    }
 }
 
-void SpectralSelectionBar::SetBandwidthSelectionFormatName(const NumericFormatSymbol & formatName)
+void SpectralSelectionBar::SetBandwidthSelectionFormatName(
+   const NumericFormatID &formatName)
 {
    if (mbCenterAndWidth) {
       bool changed =
@@ -489,7 +493,7 @@ void SpectralSelectionBar::SetBandwidthSelectionFormatName(const NumericFormatSy
       // Test first whether changed, to avoid infinite recursion from OnUpdate
       if (changed) {
          wxCommandEvent e(EVT_BANDWIDTHTEXTCTRL_UPDATED);
-         e.SetString(mWidthCtrl->GetFormatName().Internal());
+         e.SetString(mWidthCtrl->GetFormatName().GET());
          OnUpdate(e);
       }
    }

--- a/src/toolbars/SpectralSelectionBar.cpp
+++ b/src/toolbars/SpectralSelectionBar.cpp
@@ -47,7 +47,7 @@ frequency selection range.
 #include "Project.h"
 #include "ProjectNumericFormats.h"
 #include "ProjectRate.h"
-#include "../ProjectSelectionManager.h"
+#include "ProjectSelectionManager.h"
 #include "AllThemeResources.h"
 #include "SelectedRegion.h"
 #include "ViewInfo.h"

--- a/src/toolbars/SpectralSelectionBar.h
+++ b/src/toolbars/SpectralSelectionBar.h
@@ -48,8 +48,8 @@ public:
    void UpdatePrefs() override;
 
    void SetFrequencies(double bottom, double top);
-   void SetFrequencySelectionFormatName(const NumericFormatSymbol & formatName);
-   void SetBandwidthSelectionFormatName(const NumericFormatSymbol & formatName);
+   void SetFrequencySelectionFormatName(const NumericFormatID & formatName);
+   void SetBandwidthSelectionFormatName(const NumericFormatID & formatName);
    void SetListener(SpectralSelectionBarListener *l);
 
    void RegenerateTooltips() override {};

--- a/src/toolbars/SpectralSelectionBar.h
+++ b/src/toolbars/SpectralSelectionBar.h
@@ -13,6 +13,7 @@ Paul Licameli
 
 #include <wx/defs.h>
 
+#include "Observer.h"
 #include "ToolBar.h"
 
 class wxChoice;
@@ -23,6 +24,7 @@ class wxSizeEvent;
 
 class AudacityProject;
 class NumericTextCtrl;
+struct ProjectNumericFormatsEvent;
 
 class SpectralSelectionBar final : public ToolBar {
 
@@ -56,6 +58,7 @@ private:
 
    void ValuesToControls();
    void SetBounds();
+   void OnFormatsChanged(ProjectNumericFormatsEvent);
    void OnUpdate(wxCommandEvent &evt);
    void OnCtrl(wxCommandEvent &evt);
    void OnChoice(wxCommandEvent &evt);
@@ -64,6 +67,8 @@ private:
    void OnSize(wxSizeEvent &evt);
 
    void ModifySpectralSelection(bool done = false);
+
+   Observer::Subscription mFormatsSubscription;
 
    bool mbCenterAndWidth;
 

--- a/src/toolbars/SpectralSelectionBar.h
+++ b/src/toolbars/SpectralSelectionBar.h
@@ -22,7 +22,6 @@ class wxDC;
 class wxSizeEvent;
 
 class AudacityProject;
-class SpectralSelectionBarListener;
 class NumericTextCtrl;
 
 class SpectralSelectionBar final : public ToolBar {
@@ -50,7 +49,6 @@ public:
    void SetFrequencies(double bottom, double top);
    void SetFrequencySelectionFormatName(const NumericFormatID & formatName);
    void SetBandwidthSelectionFormatName(const NumericFormatID & formatName);
-   void SetListener(SpectralSelectionBarListener *l);
 
    void RegenerateTooltips() override {};
 
@@ -66,8 +64,6 @@ private:
    void OnSize(wxSizeEvent &evt);
 
    void ModifySpectralSelection(bool done = false);
-
-   SpectralSelectionBarListener * mListener;
 
    bool mbCenterAndWidth;
 

--- a/src/toolbars/SpectralSelectionBarListener.h
+++ b/src/toolbars/SpectralSelectionBarListener.h
@@ -23,11 +23,11 @@ class AUDACITY_DLL_API SpectralSelectionBarListener /* not final */ {
 
    virtual double SSBL_GetRate() const = 0;
 
-   virtual const NumericFormatSymbol & SSBL_GetFrequencySelectionFormatName() = 0;
-   virtual void SSBL_SetFrequencySelectionFormatName(const NumericFormatSymbol & formatName) = 0;
+   virtual NumericFormatID SSBL_GetFrequencySelectionFormatName() = 0;
+   virtual void SSBL_SetFrequencySelectionFormatName(const NumericFormatID & formatName) = 0;
 
-   virtual const NumericFormatSymbol & SSBL_GetBandwidthSelectionFormatName() = 0;
-   virtual void SSBL_SetBandwidthSelectionFormatName(const NumericFormatSymbol & formatName) = 0;
+   virtual NumericFormatID SSBL_GetBandwidthSelectionFormatName() = 0;
+   virtual void SSBL_SetBandwidthSelectionFormatName(const NumericFormatID & formatName) = 0;
 
    virtual void SSBL_ModifySpectralSelection(double &bottom, double &top, bool done) = 0;
 };

--- a/src/toolbars/TimeSignatureToolBar.cpp
+++ b/src/toolbars/TimeSignatureToolBar.cpp
@@ -26,7 +26,6 @@
 
 #include "Prefs.h"
 #include "Project.h"
-#include "../ProjectSettings.h"
 #include "ViewInfo.h"
 
 #include "AllThemeResources.h"

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -106,9 +106,9 @@ void TimeToolBar::Populate()
    // and OnUpdate() for more info.
    mSettingInitialSize = true;
    CallAfter([this]{
+      auto &formats = ProjectNumericFormats::Get(mProject);
       // Get (and set) the saved time format
-      SetAudioTimeFormat(
-         ProjectSelectionManager::Get(mProject).TT_GetAudioTimeFormat());
+      SetAudioTimeFormat(formats.GetAudioTimeFormat());
 
       // During initialization, if the saved format is the same as the default,
       // OnUpdate() will not otherwise be called but we need it to set the

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -121,7 +121,7 @@ void TimeToolBar::UpdatePrefs()
    // Since the language may have changed, we need to force an update to accommodate
    // different length text
    wxCommandEvent e;
-   e.SetString(mAudioTime->GetFormatName().Internal());
+   e.SetString(mAudioTime->GetFormatName().GET());
    OnUpdate(e);
 
    // Language may have changed so reset label
@@ -138,7 +138,8 @@ void TimeToolBar::SetToDefaultSize()
    SetMinSize(wxDefaultSize);
 
    // Set the default time format
-   SetAudioTimeFormat(NumericConverterFormats::HoursMinsSecondsFormat());
+   SetAudioTimeFormat(
+      NumericConverterFormats::HoursMinsSecondsFormat().Internal());
 
    // Set the default size
    SetSize(GetInitialWidth(), 48);
@@ -200,18 +201,18 @@ void TimeToolBar::SetListener(TimeToolBarListener *l)
    // OnUpdate() will not be called and need it to set the initial size.
    if (mSettingInitialSize) {
       wxCommandEvent e;
-      e.SetString(mAudioTime->GetFormatName().Internal());
+      e.SetString(mAudioTime->GetFormatName().GET());
       OnUpdate(e);
    }
 }
 
-void TimeToolBar::SetAudioTimeFormat(const NumericFormatSymbol & format)
+void TimeToolBar::SetAudioTimeFormat(const NumericFormatID & format)
 {
    // Set the format if it's different from previous
    if (mAudioTime->SetFormatName(format)) {
       // Simulate an update since the format has changed.
       wxCommandEvent e;
-      e.SetString(format.Internal());
+      e.SetString(format.GET());
       OnUpdate(e);
    }
 }

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -30,7 +30,6 @@
 #include "ProjectAudioIO.h"
 #include "ProjectNumericFormats.h"
 #include "ProjectRate.h"
-#include "../ProjectSelectionManager.h"
 #include "ProjectTimeSignature.h"
 #include "ViewInfo.h"
 
@@ -278,6 +277,9 @@ void TimeToolBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
 {
    auto &settings = ProjectNumericFormats::Get(mProject);
    switch (evt.type) {
+   case ProjectNumericFormatsEvent::ChangedAudioTimeFormat:
+      SetAudioTimeFormat(settings.GetAudioTimeFormat());
+      break;
    default:
       break;
    }
@@ -296,8 +298,9 @@ void TimeToolBar::OnUpdate(wxCommandEvent &evt)
    SetMaxSize(wxDefaultSize);
 
    // Save format name before recreating the controls so they resize properly
-   ProjectSelectionManager::Get(mProject)
-      .TT_SetAudioTimeFormat(evt.GetString());
+   auto &formats = ProjectNumericFormats::Get(mProject);
+   formats.SetAudioTimeFormat(evt.GetString());
+   // Then my subscription is called
 
    // During initialization, the desired size will have already been set at this point
    // and the "best" size" would override it, so we simply send a size event to force

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -23,7 +23,6 @@
 #endif
 
 #include "TimeToolBar.h"
-#include "SelectionBarListener.h"
 #include "ToolManager.h"
 
 #include "AudioIO.h"
@@ -31,6 +30,7 @@
 #include "ProjectAudioIO.h"
 #include "ProjectNumericFormats.h"
 #include "ProjectRate.h"
+#include "../ProjectSelectionManager.h"
 #include "ProjectTimeSignature.h"
 #include "ViewInfo.h"
 
@@ -57,8 +57,8 @@ Identifier TimeToolBar::ID()
 }
 
 TimeToolBar::TimeToolBar(AudacityProject &project)
-:  ToolBar(project, XO("Time"), ID(), true),
-   mListener(NULL), mAudioTime(NULL)
+   :  ToolBar(project, XO("Time"), ID(), true)
+   , mAudioTime{ nullptr }
 {
 }
 
@@ -105,6 +105,19 @@ void TimeToolBar::Populate()
    // from being used as we want to ensure the saved size is used instead. See SetDocked()
    // and OnUpdate() for more info.
    mSettingInitialSize = true;
+   CallAfter([this]{
+      // Get (and set) the saved time format
+      SetAudioTimeFormat(
+         ProjectSelectionManager::Get(mProject).TT_GetAudioTimeFormat());
+
+      // During initialization, if the saved format is the same as the default,
+      // OnUpdate() will not otherwise be called but we need it to set the
+      // initial size.
+      assert(mSettingInitialSize);
+      wxCommandEvent e;
+      e.SetString(mAudioTime->GetFormatName().GET());
+      OnUpdate(e);
+   });
 
    // Establish initial resizing limits
    //   SetResizingLimits();
@@ -186,23 +199,6 @@ void TimeToolBar::SetDocked(ToolDock *dock, bool pushed)
          // Inform others the toolbar has changed
          Updated();
       }
-   }
-}
-
-void TimeToolBar::SetListener(TimeToolBarListener *l)
-{
-   // Remember the listener
-   mListener = l;
-
-   // Get (and set) the saved time format
-   SetAudioTimeFormat(mListener->TT_GetAudioTimeFormat());
-
-   // During initialization, if the saved format is the same as the default,
-   // OnUpdate() will not be called and need it to set the initial size.
-   if (mSettingInitialSize) {
-      wxCommandEvent e;
-      e.SetString(mAudioTime->GetFormatName().GET());
-      OnUpdate(e);
    }
 }
 
@@ -289,10 +285,9 @@ void TimeToolBar::OnUpdate(wxCommandEvent &evt)
    SetMaxSize(wxDefaultSize);
 
    // Save format name before recreating the controls so they resize properly
-   if (mListener) {
-      mListener->TT_SetAudioTimeFormat(evt.GetString());
-   }
-   
+   ProjectSelectionManager::Get(mProject)
+      .TT_SetAudioTimeFormat(evt.GetString());
+
    // During initialization, the desired size will have already been set at this point
    // and the "best" size" would override it, so we simply send a size event to force
    // the content to fit inside the toolbar.

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -60,6 +60,8 @@ TimeToolBar::TimeToolBar(AudacityProject &project)
    :  ToolBar(project, XO("Time"), ID(), true)
    , mAudioTime{ nullptr }
 {
+   mFormatsSubscription = ProjectNumericFormats::Get(project)
+      .Subscribe(*this, &TimeToolBar::OnFormatsChanged);
 }
 
 TimeToolBar::~TimeToolBar()
@@ -270,6 +272,15 @@ void TimeToolBar::SetResizingLimits()
    // And finally set them both
    SetMinSize(minSize);
    SetMaxSize(maxSize);
+}
+
+void TimeToolBar::OnFormatsChanged(ProjectNumericFormatsEvent evt)
+{
+   auto &settings = ProjectNumericFormats::Get(mProject);
+   switch (evt.type) {
+   default:
+      break;
+   }
 }
 
 // Called when the format drop downs is changed.

--- a/src/toolbars/TimeToolBar.h
+++ b/src/toolbars/TimeToolBar.h
@@ -44,7 +44,7 @@ public:
    wxSize GetDockedSize() override;
    void SetDocked(ToolDock *dock, bool pushed) override;
    void SetListener(TimeToolBarListener *l);
-   void SetAudioTimeFormat(const NumericFormatSymbol & format);
+   void SetAudioTimeFormat(const NumericFormatID & format);
    void ResizingDone() override;
 
 private:

--- a/src/toolbars/TimeToolBar.h
+++ b/src/toolbars/TimeToolBar.h
@@ -18,7 +18,6 @@
 #include "Observer.h"
 
 class NumericTextCtrl;
-class TimeToolBarListener;
 
 class TimeToolBar final : public ToolBar
 {
@@ -43,7 +42,6 @@ public:
    void SetToDefaultSize() override;
    wxSize GetDockedSize() override;
    void SetDocked(ToolDock *dock, bool pushed) override;
-   void SetListener(TimeToolBarListener *l);
    void SetAudioTimeFormat(const NumericFormatID & format);
    void ResizingDone() override;
 
@@ -55,10 +53,9 @@ private:
    void OnSize(wxSizeEvent &evt);
    void OnIdle(wxIdleEvent &evt);
 
-   TimeToolBarListener *mListener;
    NumericTextCtrl *mAudioTime;
    float mDigitRatio;
-   bool mSettingInitialSize;
+   bool mSettingInitialSize = true;
 
    static const int minDigitH = 17;
    static const int maxDigitH = 100;

--- a/src/toolbars/TimeToolBar.h
+++ b/src/toolbars/TimeToolBar.h
@@ -18,6 +18,7 @@
 #include "Observer.h"
 
 class NumericTextCtrl;
+struct ProjectNumericFormatsEvent;
 
 class TimeToolBar final : public ToolBar
 {
@@ -48,7 +49,7 @@ public:
 private:
    void SetResizingLimits();
    wxSize ComputeSizing(int digitH);
-   
+   void OnFormatsChanged(ProjectNumericFormatsEvent);
    void OnUpdate(wxCommandEvent &evt);
    void OnSize(wxSizeEvent &evt);
    void OnIdle(wxIdleEvent &evt);
@@ -61,6 +62,7 @@ private:
    static const int maxDigitH = 100;
 
    Observer::Subscription mFormatChangedToFitValueSubscription;
+   Observer::Subscription mFormatsSubscription;
 
 public:
    

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -93,8 +93,8 @@ ToolsToolBar::ToolsToolBar( AudacityProject &project )
    else
       mCurrentTool = selectTool;
 
-   project.Bind(EVT_PROJECT_SETTINGS_CHANGE,
-      &ToolsToolBar::OnToolChanged, this);
+   mSubscription = ProjectSettings::Get(project)
+      .Subscribe(*this, &ToolsToolBar::OnToolChanged);
 }
 
 ToolsToolBar::~ToolsToolBar()
@@ -222,10 +222,9 @@ void ToolsToolBar::OnTool(wxCommandEvent & evt)
       pButton->PushDown();
 }
 
-void ToolsToolBar::OnToolChanged(wxCommandEvent &evt)
+void ToolsToolBar::OnToolChanged(ProjectSettingsEvent evt)
 {
-   evt.Skip(); // Let other listeners hear the event too
-   if (evt.GetInt() != ProjectSettings::ChangedTool)
+   if (evt.type != ProjectSettingsEvent::ChangedTool)
       return;
    DoToolChanged();
    ProjectWindow::Get( mProject ).RedrawProject();

--- a/src/toolbars/ToolsToolBar.h
+++ b/src/toolbars/ToolsToolBar.h
@@ -16,6 +16,7 @@
 
 #include <wx/defs.h>
 
+#include "Observer.h"
 #include "ToolBar.h"
 
 class wxCommandEvent;
@@ -26,6 +27,7 @@ class wxWindow;
 
 class AButton;
 class AudacityProject;
+struct ProjectSettingsEvent;
 
 // Code duplication warning: these apparently need to be in the
 // same order as the enum in ToolsToolBar.cpp
@@ -46,7 +48,7 @@ class ToolsToolBar final : public ToolBar {
    void UpdatePrefs() override;
 
    void OnTool(wxCommandEvent & evt);
-   void OnToolChanged(wxCommandEvent &evt);
+   void OnToolChanged(ProjectSettingsEvent);
    void DoToolChanged();
 
    void Populate() override;
@@ -61,6 +63,8 @@ class ToolsToolBar final : public ToolBar {
    static AButton *MakeTool(
       ToolsToolBar *pBar, teBmps eTool, int id, const TranslatableString &label);
    enum { numTools = 4 };
+
+   Observer::Subscription mSubscription;
    AButton *mTool[numTools];
    wxGridSizer *mToolSizer;
    int mCurrentTool;

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
@@ -18,7 +18,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "ProjectAudioIO.h"
 #include "ProjectHistory.h"
 #include "../../../../RefreshCode.h"
-#include "../../../../Snap.h" // for kPixelTolerance
+#include "Snap.h" // for kPixelTolerance
 #include "../../../../TrackPanelMouseEvent.h"
 #include "UndoManager.h"
 #include "ViewInfo.h"

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -33,7 +33,6 @@ Paul Licameli split from WaveChannelView.cpp
 #include "WaveClip.h"
 #include "WaveTrack.h"
 #include "../../../../prefs/SpectrogramSettings.h"
-#include "../../../../ProjectSettings.h"
 #include "WaveTrackLocation.h"
 
 #include <wx/dcmemory.h>

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -16,7 +16,7 @@
 
 #include "../../../../TrackArt.h"
 #include "../../../../TrackArtist.h"
-#include "../../../../Snap.h"
+#include "Snap.h"
 #include "../../../../TrackPanelDrawingContext.h"
 #include "../../../../../images/Cursors.h"
 #include "WaveClip.h"

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -14,6 +14,7 @@
 
 #include <wx/event.h>
 
+#include "../../../../TrackArt.h"
 #include "../../../../TrackArtist.h"
 #include "../../../../Snap.h"
 #include "../../../../TrackPanelDrawingContext.h"
@@ -288,7 +289,7 @@ public:
       if(iPass == TrackArtist::PassSnapping && mSnap.Snapped())
       {
          auto &dc = context.dc;
-         SnapManager::Draw(&dc, rect.x + mSnap.outCoord, -1);
+         TrackArt::DrawSnapLines(&dc, rect.x + mSnap.outCoord, -1);
       }
    }
 

--- a/src/tracks/ui/SelectHandle.cpp
+++ b/src/tracks/ui/SelectHandle.cpp
@@ -27,6 +27,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../SelectUtilities.h"
 #include "SelectionState.h"
 #include "SyncLock.h"
+#include "../../TrackArt.h"
 #include "../../TrackArtist.h"
 #include "../../TrackPanelAx.h"
 #include "../../TrackPanel.h"
@@ -1028,7 +1029,7 @@ void SelectHandle::Draw(
       if ( mSnapManager ) {
          auto coord1 = (mUseSnap || IsClicked()) ? mSnapStart.outCoord : -1;
          auto coord2 = (!mUseSnap || !IsClicked()) ? -1 : mSnapEnd.outCoord;
-         mSnapManager->Draw( &dc, coord1, coord2 );
+         TrackArt::DrawSnapLines(&dc, coord1, coord2);
       }
    }
 }

--- a/src/tracks/ui/SelectHandle.h
+++ b/src/tracks/ui/SelectHandle.h
@@ -13,7 +13,7 @@ Paul Licameli split from TrackPanel.cpp
 
 #include "../../UIHandle.h"
 #include "SelectedRegion.h"
-#include "../../Snap.h"
+#include "Snap.h"
 
 #include <vector>
 

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -16,7 +16,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "ProjectHistory.h"
 #include "../../ProjectSettings.h"
 #include "../../RefreshCode.h"
-#include "../../Snap.h"
+#include "Snap.h"
 #include "SyncLock.h"
 #include "Track.h"
 #include "../../TrackArt.h"

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -19,6 +19,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../Snap.h"
 #include "SyncLock.h"
 #include "Track.h"
+#include "../../TrackArt.h"
 #include "../../TrackArtist.h"
 #include "../../TrackPanelDrawingContext.h"
 #include "../../TrackPanelMouseEvent.h"
@@ -988,8 +989,8 @@ void TimeShiftHandle::Draw(
       auto &dc = context.dc;
       // Draw snap guidelines if we have any
       if ( mSnapManager ) {
-         mSnapManager->Draw(
-            &dc, mClipMoveState.snapLeft, mClipMoveState.snapRight );
+         TrackArt::DrawSnapLines(
+            &dc, mClipMoveState.snapLeft, mClipMoveState.snapRight);
       }
    }
 }

--- a/src/widgets/Grid.cpp
+++ b/src/widgets/Grid.cpp
@@ -123,7 +123,7 @@ class GridAx final : public WindowAccessible
 
 NumericEditor::NumericEditor(
    const FormatterContext& context, NumericConverterType type,
-   const NumericFormatSymbol& format)
+   const NumericFormatID& format)
     : mContext { context }
 {
    mType = std::move(type);
@@ -224,12 +224,12 @@ wxString NumericEditor::GetValue() const
    return wxString::Format(wxT("%g"), GetNumericTextControl()->GetValue());
 }
 
-NumericFormatSymbol NumericEditor::GetFormat() const
+NumericFormatID NumericEditor::GetFormat() const
 {
    return mFormat;
 }
 
-void NumericEditor::SetFormat(const NumericFormatSymbol &format)
+void NumericEditor::SetFormat(const NumericFormatID &format)
 {
    mFormat = format;
 }
@@ -479,13 +479,15 @@ Grid::Grid(
 
    RegisterDataType(GRID_VALUE_TIME,
                     safenew NumericRenderer{ mContext, NumericConverterType_TIME() },
-                    safenew NumericEditor { mContext, NumericConverterType_TIME(),
-                        NumericConverterFormats::SecondsFormat() });
+                    safenew NumericEditor
+                      { mContext, NumericConverterType_TIME(),
+                        NumericConverterFormats::SecondsFormat().Internal() });
 
    RegisterDataType(GRID_VALUE_FREQUENCY,
                     safenew NumericRenderer{ mContext, NumericConverterType_FREQUENCY() },
-                    safenew NumericEditor { mContext, NumericConverterType_FREQUENCY(),
-                      NumericConverterFormats::HertzFormat() });
+                    safenew NumericEditor
+                    { mContext, NumericConverterType_FREQUENCY(),
+                      NumericConverterFormats::HertzFormat().Internal() });
 
    RegisterDataType(GRID_VALUE_CHOICE,
                     safenew wxGridCellStringRenderer,

--- a/src/widgets/Grid.h
+++ b/src/widgets/Grid.h
@@ -41,7 +41,7 @@ class AUDACITY_DLL_API NumericEditor /* not final */ : public wxGridCellEditor
 public:
 
    NumericEditor
-      (const FormatterContext& context, NumericConverterType type, const NumericFormatSymbol &format);
+      (const FormatterContext& context, NumericConverterType type, const NumericFormatID &format);
 
    ~NumericEditor();
 
@@ -60,8 +60,8 @@ public:
 
    void Reset() override;
 
-   NumericFormatSymbol GetFormat() const;
-   void SetFormat(const NumericFormatSymbol &format);
+   NumericFormatID GetFormat() const;
+   void SetFormat(const NumericFormatID &format);
 
    wxGridCellEditor *Clone() const override;
    wxString GetValue() const override;
@@ -71,7 +71,7 @@ public:
 
  private:
 
-   NumericFormatSymbol mFormat;
+   NumericFormatID mFormat;
    NumericConverterType mType;
    double mOld;
    wxString mOldString;

--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -146,7 +146,7 @@ NumericTextCtrl::NumericTextCtrl(
                            const FormatterContext& context,
                            wxWindow *parent, wxWindowID id,
                            NumericConverterType type,
-                           const NumericFormatSymbol &formatName,
+                           const NumericFormatID &formatName,
                            double timeValue,
                            const Options &options,
                            const wxPoint &pos,
@@ -234,7 +234,7 @@ void NumericTextCtrl::UpdateAutoFocus()
    }
 }
 
-bool NumericTextCtrl::SetTypeAndFormatName(const NumericConverterType& type, const NumericFormatSymbol& formatName)
+bool NumericTextCtrl::SetTypeAndFormatName(const NumericConverterType& type, const NumericFormatID& formatName)
 {
    if (!NumericConverter::SetTypeAndFormatName(type, formatName))
       return false;
@@ -244,7 +244,7 @@ bool NumericTextCtrl::SetTypeAndFormatName(const NumericConverterType& type, con
    return true;
 }
 
-bool NumericTextCtrl::SetFormatName(const NumericFormatSymbol& formatName)
+bool NumericTextCtrl::SetFormatName(const NumericFormatID& formatName)
 {
    if (!NumericConverter::SetFormatName(formatName))
       return false;
@@ -575,17 +575,18 @@ void NumericTextCtrl::OnContext(wxContextMenuEvent &event)
 
    SetFocus();
 
-   std::vector<NumericFormatSymbol> symbols;
+   std::vector<NumericFormatID> symbols;
 
    NumericConverterRegistry::Visit(
       mContext,
       mType,
       [&menu, &symbols, this, i = ID_MENU](auto& item) mutable
       {
-         symbols.push_back(item.symbol);
+         const auto ID = item.symbol.Internal();
+         symbols.push_back(ID);
          menu.AppendRadioItem(i, item.symbol.Translation());
 
-         if (mFormatSymbol == item.symbol)
+         if (mFormatID == ID)
             menu.Check(i, true);
 
          ++i;
@@ -620,13 +621,13 @@ void NumericTextCtrl::OnContext(wxContextMenuEvent &event)
 
    for (const auto& symbol : symbols)
    {
-      if (!menu.IsChecked(menuIndex++) || mFormatSymbol == symbol)
+      if (!menu.IsChecked(menuIndex++) || mFormatID == symbol)
          continue;
          
       SetFormatName(symbol);
 
       wxCommandEvent e(eventType, GetId());
-      e.SetString(symbol.Internal());
+      e.SetString(symbol.GET());
       GetParent()->GetEventHandler()->AddPendingEvent(e);
 
       break;
@@ -1111,7 +1112,7 @@ wxAccStatus NumericTextCtrlAx::GetLocation(wxRect & rect, int elementId)
 }
 
 static void GetFraction( const FormatterContext& context, wxString &label, NumericConverterType type,
-   const NumericFormatSymbol &formatSymbol )
+   const NumericFormatID &formatSymbol )
 {
    auto result = NumericConverterRegistry::Find(context, type, formatSymbol);
 
@@ -1184,7 +1185,7 @@ wxAccStatus NumericTextCtrlAx::GetName(int childId, wxString *name)
 
          if (field > 1 && field == cnt) {
             if (mFields[field - 2].label == decimal) {
-               GetFraction( mCtrl->mContext, label, mCtrl->mType, mCtrl->mFormatSymbol );
+               GetFraction( mCtrl->mContext, label, mCtrl->mType, mCtrl->mFormatID);
             }
          }
          // If the field following this one represents fractions of a

--- a/src/widgets/NumericTextCtrl.h
+++ b/src/widgets/NumericTextCtrl.h
@@ -45,7 +45,7 @@ class AUDACITY_DLL_API NumericTextCtrl final
       bool menuEnabled { true };
       bool hasInvalidValue { false };
       double invalidValue { -1.0 };
-      NumericFormatSymbol formatSymbol {};
+      NumericFormatID formatSymbol {};
       TranslatableString customFormat {};
       bool hasValue { false };
       double value{ -1.0 };
@@ -58,7 +58,7 @@ class AUDACITY_DLL_API NumericTextCtrl final
       Options &InvalidValue (bool has, double v = -1.0)
          { hasInvalidValue = has, invalidValue = v; return *this; }
       // use a custom format not in the tables:
-      Options& FormatSymbol(const NumericFormatSymbol& f)
+      Options& FormatSymbol(const NumericFormatID& f)
          { formatSymbol = f; return *this; }
       Options& CustomFormat(const TranslatableString& f)
          { customFormat = f; return *this; }
@@ -69,7 +69,7 @@ class AUDACITY_DLL_API NumericTextCtrl final
    NumericTextCtrl(
       const FormatterContext& context, wxWindow* parent, wxWindowID winid,
                    NumericConverterType type,
-                   const NumericFormatSymbol &formatName = {},
+                   const NumericFormatID &formatName = {},
                    double value = 0.0,
                    const Options &options = {},
                    const wxPoint &pos = wxDefaultPosition,
@@ -89,9 +89,9 @@ class AUDACITY_DLL_API NumericTextCtrl final
 
    // returns true if the format type really changed:
    bool SetTypeAndFormatName(
-      const NumericConverterType& type, const NumericFormatSymbol& formatName);
+      const NumericConverterType& type, const NumericFormatID& formatName);
    // returns true iff the format name really changed:
-   bool SetFormatName(const NumericFormatSymbol & formatName);
+   bool SetFormatName(const NumericFormatID &formatName);
    bool SetCustomFormat(const TranslatableString& customFormat);
 
    void SetFieldFocus(int /* digit */);


### PR DESCRIPTION
Resolves:

Depends on
- [ ] #4379

ProjectSelectionManager moves into lib-time-frequency-selection, which requires Snap to move into lib-snapping.

No new libraries but some changes in dependencies among libraries.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
