### PR TITLE
Fix handle leak on Linux and macOS

### DIFF
--- a/lib-src/libnyquist/nyquist/sys/mac/macstuff.c
+++ b/lib-src/libnyquist/nyquist/sys/mac/macstuff.c
@@ -210,7 +210,10 @@ void setup_preferences(char *filename)
         pf = fopen((char *) prefname, "w");
         if (pf == NULL) return;
         cp = strrchr((char *) filename, ':');
-        if (cp == NULL) return;
+        if (cp == NULL) {
+            fclose(pf);
+            return;
+        }
         cp[1] = 0;
         /* now, filename is the path. If filename ends in runtime, this
          * is probably the standard nyquist runtime folder. We should put

--- a/modules/scripting/mod-script-pipe/PipeServer.cpp
+++ b/modules/scripting/mod-script-pipe/PipeServer.cpp
@@ -161,6 +161,7 @@ void PipeServer()
    if (fromFifo == NULL)
    {
       perror("Unable to open fifo from server to script");
+      fclose(toFifo);
       return;
    }
 


### PR DESCRIPTION
If opening toFifo succeeds but fromFifo fails, the original code would leak the toFifo filehandle.

Resolves: *(direct link to the issue)*

I found, via Cppcheck, that there are a few file handle leaks in Audacity. This PR fixes those leaks. In setup_preferences on macOS, if opening the file whose name is specified in `prefname` succeeds but a colon was not found in the filename, the file handle `pf` leaks when the function returns without closing it.

Cppcheck errors:
```
[D:/Linux_home/nathan/src/audacity/lib-src/libnyquist/nyquist/sys/mac/macstuff.c:213] (error) Resource leak: pf [resourceLeak]
[D:/Linux_home/nathan/src/audacity/modules/mod-script-pipe/PipeServer.cpp:164] (error) Resource leak: toFifo [resourceLeak]
```

Cppcheck version 2.10
Audacity version: 3.2.5-6ec6548af "A bit of fun with templates"

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
