### PR TITLE
Resample, undo, redo shouldnt truncate the track; a58328c broke it...

### DIFF
--- a/libraries/lib-wave-track/Sequence.cpp
+++ b/libraries/lib-wave-track/Sequence.cpp
@@ -431,6 +431,7 @@ std::unique_ptr<Sequence> Sequence::Copy( const SampleBlockFactoryPtr &pFactory,
 
       dest->Append(
          buffer.ptr(), format, blocklen, 1, mSampleFormats.Effective());
+      dest->Flush();
    }
    else
       --b0;
@@ -454,6 +455,7 @@ std::unique_ptr<Sequence> Sequence::Copy( const SampleBlockFactoryPtr &pFactory,
          Get(b1, buffer.ptr(), format, block.start, blocklen, true);
          dest->Append(
             buffer.ptr(), format, blocklen, 1, mSampleFormats.Effective());
+         dest->Flush();
       }
       else
          // Special case of a whole block

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -826,6 +826,7 @@ void WaveClip::Resample(int rate, BasicUI::ProgressDialog *progress)
       // Use No-fail-guarantee in these steps
       mSequence = std::move(newSequence);
       mRate = rate;
+      Flush();
       Caches::ForEach( std::mem_fn( &WaveClipListener::Invalidate ) );
    }
 }


### PR DESCRIPTION
... And in principle, Sequence::Copy() also needs a fix for completeness; though in practice, that function is not used

Resolves: #4417

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
