### PR TITLE
Selection toolbar: numeric ctrls are not adjacent in tab order

### DIFF
--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -263,6 +263,8 @@ void SelectionBar::AddSelectionSetupButton(wxSizer* pSizer)
 
    setupBtn->Bind(wxEVT_BUTTON, [this, showMenu](auto&) { showMenu(); });
    pSizer->Add(setupBtn, 0, wxALIGN_RIGHT | wxBOTTOM | wxRIGHT, 5);
+
+   mSetupButton = setupBtn;
 }
 
 void SelectionBar::Populate()
@@ -282,6 +284,8 @@ void SelectionBar::Populate()
    AddTime(0, mainSizer);
    AddSelectionSetupButton(mainSizer);
    AddTime(1, mainSizer);
+
+   mSetupButton->MoveBeforeInTabOrder(mTimeControls[0]);
 
    // Update the selection mode before the layout
    SetSelectionMode(mSelectionMode);

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -98,6 +98,7 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
    SelectionMode mLastSelectionMode {};
 
    std::array<NumericTextCtrl*, 2> mTimeControls {};
+   AButton* mSetupButton{};
 
    wxString mLastValidText;
    


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4478

Problem: controls in selection toolbar have an inconvenient and peculiar tab order - the setup button comes between the two numeric controls.

Fix: Change the tab order to: setup button, first numeric ctrl, second numeric ctrl.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
