### PR TITLE
Snapping toolbar: drop down list box accessibility issues

### DIFF
--- a/src/toolbars/SnappingToolBar.cpp
+++ b/src/toolbars/SnappingToolBar.cpp
@@ -18,6 +18,7 @@
 #include <wx/checkbox.h>
 #include <wx/combo.h>
 #include <wx/menu.h>
+#include <wx/textctrl.h>
 
 #include "ToolManager.h"
 
@@ -347,12 +348,17 @@ void SnappingToolBar::Populate()
       this, wxID_ANY, {}, wxDefaultPosition, wxDefaultSize /*, wxCB_READONLY*/);
 #if wxUSE_ACCESSIBILITY
    // so that name can be set on a standard control
-   mSnapToCombo->SetAccessible(safenew WindowAccessible(mSnapToCombo));
+   mSnapToCombo->GetTextCtrl()->SetAccessible(
+      safenew WindowAccessible(mSnapToCombo->GetTextCtrl()));
 #endif
 
    //mSnapToCombo->SetEditable(false);
    mSnapToCombo->SetPopupControl(safenew SnapModePopup(mProject));
-   mSnapToCombo->SetName(mSnapToCombo->GetValue());
+   /* i18n-hint: combo box is the type of the control/widget */
+   mSnapToCombo->GetTextCtrl()->SetName(XO("Snap to combo box").Translation());
+   /* Narrator screen reader by default reads the accessibility name of the
+   containing window, which by default is combobox, so set it to an empty string. */
+   mSnapToCombo->SetLabel(wxT(""));
    mSnapToCombo->Enable(snapEnabled);
    mSnapToCombo->SetMinSize(wxSize(150, -1));
    


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4477

Problems for users of screen readers:
1. drop down list box has no accessibility name.
2. it is read as being a text box.

Fix:
1. The focus is a text box within the wxComboCtrl, so set the accessibility name of this text box.

2. If an attempt to change the role of the text box is made by deriving a class from WindowAccessible, and overriding GetRole, then unfortunately, only NVDA reads the override, and Narrator and Jaws still read it as a text box. So include "combo box" in the accessiblity name. The control is then read as "combo box edit", which although its slightly confusing, is probably good enough.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
