### PR TITLE
v3.3.0: Update Italian Translations

### DIFF
--- a/locale/it.po
+++ b/locale/it.po
@@ -2,25 +2,24 @@
 # Copyright (C) YEAR Audacity Team
 # This file is distributed under the same license as the audacity package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 # Translators:
-# Matteo O., 2022
-# Paval Shalamitski <yehekim@gmail.com>, 2022
-# Michele Locati <michele@locati.it>, 2022
-#
+# Matteo O., 2023
+# Paval Shalamitski <yehekim@gmail.com>, 2023
+# Michele Locati <michele@locati.it>, 2023
+# 
 #, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: audacity 3.0.3\n"
+msgstr "Project-Id-Version: audacity 3.0.3\n"
 "Report-Msgid-Bugs-To: audacity-translation@lists.sourceforge.net\n"
 "POT-Creation-Date: 2023-04-05 16:57+0300\n"
-"PO-Revision-Date: 2022-12-22 07:39+0000\n"
-"Last-Translator: Michele Locati <michele@locati.it>, 2022\n"
-"Language-Team: Italian (https://www.transifex.com/klyok/teams/690/it/)\n"
-"Language: it\n"
+"PO-Revision-Date: 2023-04-06 15:56+0000\n"
+"Last-Translator: Michele Locati <michele@locati.it>, 2023\n"
+"Language-Team: Italian (https://app.transifex.com/klyok/teams/690/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: it\n"
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #: libraries/lib-audio-devices/AudioIOBase.cpp src/NoteTrack.cpp
@@ -159,11 +158,9 @@ msgid "Could not find any audio devices.\n"
 msgstr "Nessun dispositivo audio trovato.\n"
 
 #: libraries/lib-audio-io/AudioIO.cpp
-msgid ""
-"You will not be able to play or record audio.\n"
+msgid "You will not be able to play or record audio.\n"
 "\n"
-msgstr ""
-"Potrebbe essere impossibile riprodurre o registrare audio.\n"
+msgstr "Potrebbe essere impossibile riprodurre o registrare audio.\n"
 "\n"
 
 #: libraries/lib-audio-io/AudioIO.cpp src/MIDIPlay.cpp
@@ -181,11 +178,9 @@ msgstr "Audio di Audacity"
 
 #: libraries/lib-audio-io/AudioIO.cpp src/ProjectAudioManager.cpp
 #, c-format
-msgid ""
-"Error opening recording device.\n"
+msgid "Error opening recording device.\n"
 "Error code: %s"
-msgstr ""
-"Errore durante l'apertura del dispositivo di registrazione.\n"
+msgstr "Errore durante l'apertura del dispositivo di registrazione.\n"
 "Codice errore: %s"
 
 #: libraries/lib-audio-io/AudioIO.cpp libraries/lib-effects/EffectBase.cpp
@@ -259,12 +254,10 @@ msgstr "Incorporato"
 
 #: libraries/lib-effects/Effect.cpp src/commands/AudacityCommand.cpp
 #, c-format
-msgid ""
-"%s: Could not load settings below. Default settings will be used.\n"
+msgid "%s: Could not load settings below. Default settings will be used.\n"
 "\n"
 "%s"
-msgstr ""
-"%s: impossibile caricare le impostazioni seguenti. Verranno utilizzate le impostazioni predefinite.\n"
+msgstr "%s: impossibile caricare le impostazioni seguenti. Verranno utilizzate le impostazioni predefinite.\n"
 "\n"
 "%s"
 
@@ -282,15 +275,14 @@ msgid "Previewing"
 msgstr "Anteprima"
 
 #: libraries/lib-effects/EffectBase.cpp src/ProjectAudioManager.cpp
-msgid ""
-"Error opening sound device.\n"
+msgid "Error opening sound device.\n"
 "Try changing the audio host, playback device and the project sample rate."
-msgstr ""
-"Errore nell'apertura del dispositivo audio. \n"
+msgstr "Errore nell'apertura del dispositivo audio. \n"
 "Provare a cambiare il sistema audio, il dispositivo di riproduzione e la frequenza di campionamento del progetto."
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or
+#. Nyqvist).
 #. In the translations of this and other strings, you may transliterate the
 #. name into another alphabet.
 #: libraries/lib-effects/EffectBase.h
@@ -328,20 +320,16 @@ msgstr "Mixaggio e renderizzazione delle tracce"
 
 #: libraries/lib-exceptions/InconsistencyException.cpp
 #, c-format
-msgid ""
-"Internal error in %s at %s line %d.\n"
+msgid "Internal error in %s at %s line %d.\n"
 "Please inform the Audacity team at https://forum.audacityteam.org/."
-msgstr ""
-"Errore interno in %s nel file %s alla linea %d.\n"
+msgstr "Errore interno in %s nel file %s alla linea %d.\n"
 "Si invita a informare il team di Audacity all'indirizzo https://forum.audacityteam.org/."
 
 #: libraries/lib-exceptions/InconsistencyException.cpp
 #, c-format
-msgid ""
-"Internal error at %s line %d.\n"
+msgid "Internal error at %s line %d.\n"
 "Please inform the Audacity team at https://forum.audacityteam.org/."
-msgstr ""
-"Errore interno nel file %s alla linea %d.\n"
+msgstr "Errore interno nel file %s alla linea %d.\n"
 "Si invita a informare il team di Audacity all'indirizzo https://forum.audacityteam.org/."
 
 #: libraries/lib-exceptions/InconsistencyException.h
@@ -365,12 +353,10 @@ msgstr "Audacity ha scritto con successo un file in %s ma non è riuscito a rino
 
 #: libraries/lib-files/FileException.cpp
 #, c-format
-msgid ""
-"Audacity failed to write to a file.\n"
+msgid "Audacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
-msgstr ""
-"Audacity non è riuscito a scrivere un file.\n"
+msgstr "Audacity non è riuscito a scrivere un file.\n"
 "Forse %s non è scrivibile o il disco è pieno.\n"
 "Per consigli su come liberare spazio fare clic sul pulsante di aiuto."
 
@@ -425,11 +411,9 @@ msgstr "(%s)"
 
 #: libraries/lib-files/FileNames.cpp
 #, c-format
-msgid ""
-"\n"
+msgid "\n"
 "%s does not have write permissions."
-msgstr ""
-"\n"
+msgstr "\n"
 "%s non ha i permessi di scrittura."
 
 #: libraries/lib-files/TempDirectory.cpp
@@ -437,21 +421,17 @@ msgid "Unsuitable"
 msgstr "Non adatto"
 
 #: libraries/lib-files/TempDirectory.cpp
-msgid ""
-"The temporary files directory is on a FAT formatted drive.\n"
+msgid "The temporary files directory is on a FAT formatted drive.\n"
 "Resetting to default location."
-msgstr ""
-"La cartella dei file temporanei è in un disco formattato in formato FAT.\n"
+msgstr "La cartella dei file temporanei è in un disco formattato in formato FAT.\n"
 "Verrà ripristinata la posizione predefinita."
 
 #: libraries/lib-files/TempDirectory.cpp
 #, c-format
-msgid ""
-"%s\n"
+msgid "%s\n"
 "\n"
 "For tips on suitable drives, click the help button."
-msgstr ""
-"%s\n"
+msgstr "%s\n"
 "\n"
 "Per consigli sui dischi idonei fare clic sul pulsante di aiuto."
 
@@ -566,45 +546,37 @@ msgstr "Modulo non adatto"
 
 #: libraries/lib-module-manager/ModuleManager.cpp
 #, c-format
-msgid ""
-"Unable to load the \"%s\" module.\n"
+msgid "Unable to load the \"%s\" module.\n"
 "\n"
 "Error: %s"
-msgstr ""
-"Impossibile caricare il modulo \"%s\".\n"
+msgstr "Impossibile caricare il modulo \"%s\".\n"
 "\n"
 "Errore: %s"
 
 #: libraries/lib-module-manager/ModuleManager.cpp
 #, c-format
-msgid ""
-"The module \"%s\" does not provide a version string.\n"
+msgid "The module \"%s\" does not provide a version string.\n"
 "\n"
 "It will not be loaded."
-msgstr ""
-"Il modulo \"%s\" non fornisce una stringa di versione.\n"
+msgstr "Il modulo \"%s\" non fornisce una stringa di versione.\n"
 "\n"
 "Non verrà caricato."
 
 #: libraries/lib-module-manager/ModuleManager.cpp
 #, c-format
-msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+msgid "The module \"%s\" is matched with Audacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
-msgstr ""
-"Il modulo \"%s\" è abbinato con la versione \"%s\" di Audacity.\n"
+msgstr "Il modulo \"%s\" è abbinato con la versione \"%s\" di Audacity.\n"
 "\n"
 "Non verrà caricato."
 
 #: libraries/lib-module-manager/ModuleManager.cpp
 #, c-format
-msgid ""
-"The module \"%s\" failed to initialize.\n"
+msgid "The module \"%s\" failed to initialize.\n"
 "\n"
 "It will not be loaded."
-msgstr ""
-"Si è verificato un problema durante l'inizializzazione del modulo \"%s\".\n"
+msgstr "Si è verificato un problema durante l'inizializzazione del modulo \"%s\".\n"
 "\n"
 "Non verrà caricato."
 
@@ -614,12 +586,10 @@ msgid "Module \"%s\" found."
 msgstr "Modulo \"%s\" trovato."
 
 #: libraries/lib-module-manager/ModuleManager.cpp
-msgid ""
-"\n"
+msgid "\n"
 "\n"
 "Only use modules from trusted sources"
-msgstr ""
-"\n"
+msgstr "\n"
 "\n"
 "Usare solo moduli da fonti attendibili"
 
@@ -644,12 +614,10 @@ msgstr "Provare a caricare questo modulo?"
 
 #: libraries/lib-module-manager/ModuleManager.cpp
 #, c-format
-msgid ""
-"The module \"%s\" does not provide any of the required functions.\n"
+msgid "The module \"%s\" does not provide any of the required functions.\n"
 "\n"
 "It will not be loaded."
-msgstr ""
-"Il modulo \"%s\" non fornisce alcuna delle funzionalità richieste.\n"
+msgstr "Il modulo \"%s\" non fornisce alcuna delle funzionalità richieste.\n"
 "\n"
 "Non verrà caricato."
 
@@ -668,11 +636,9 @@ msgstr "Il file dell'estensione è in uso. Impossibile sovrascrivere"
 
 #: libraries/lib-module-manager/PluginManager.cpp
 #, c-format
-msgid ""
-"Failed to register:\n"
+msgid "Failed to register:\n"
 "%s"
-msgstr ""
-"Registrazione fallita:\n"
+msgstr "Registrazione fallita:\n"
 "%s"
 
 #. i18n-hint A plug-in is an optional added program for a sound
@@ -732,9 +698,10 @@ msgstr "hh:mm:ss + centesimi"
 #. i18n-hint: Name of display format that shows frequency in hertz
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
-#: libraries/lib-numeric-formats/NumericConverterFormats.cpp src/FreqWindow.cpp
-#: src/effects/ChangePitch.cpp src/effects/EqualizationUI.cpp
-#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: libraries/lib-numeric-formats/NumericConverterFormats.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp
+#: src/effects/EqualizationUI.cpp src/effects/ScienFilter.cpp
+#: src/import/ImportRaw.cpp
 msgid "Hz"
 msgstr "Hz"
 
@@ -746,24 +713,24 @@ msgstr "ottave"
 
 #. i18n-hint: The music theory "bar"
 #: libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
-#, fuzzy
 msgid "bar"
-msgstr "Barra degli strumenti"
+msgstr "battuta"
 
 #. i18n-hint: The music theory "beat"
 #: libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
 msgid "beat"
-msgstr ""
+msgstr "ritmo"
 
 #. i18n-hint: "bar" and "beat" are musical notation elements.
 #: libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
 msgid "bar:beat"
-msgstr ""
+msgstr "battuta:ritmo"
 
-#. i18n-hint: "bar" and "beat" are musical notation elements. "tick" corresponds to a 16th note.
+#. i18n-hint: "bar" and "beat" are musical notation elements. "tick"
+#. corresponds to a 16th note.
 #: libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
 msgid "bar:beat:tick"
-msgstr ""
+msgstr "battuta:ritmo:semicroma"
 
 #. i18n-hint: Format string for displaying time in seconds. Change the comma
 #. * in the middle to the 1000s separator for your locale, and the 'seconds'
@@ -775,19 +742,18 @@ msgstr "01000,01000 secondi"
 #. i18n-hint: Name of time display format that shows time in seconds
 #. * and milliseconds (1/1000 second)
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
-#, fuzzy
 msgid "seconds + milliseconds"
-msgstr "hh:mm:ss + millisecondi"
+msgstr "secondi + millisecondi"
 
 #. i18n-hint: Format string for displaying time in seconds and milliseconds
-#. * as fractional seconds. Change the comma in the middle to the 1000s separator
+#. * as fractional seconds. Change the comma in the middle to the 1000s
+#. separator
 #. * for your locale, and the 'seconds' on the end to the word for seconds.
 #. * Don't change the numbers. The decimal separator is specified using '<' if
 #. * your languages uses a ',' or to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
-#, fuzzy
 msgid "01000,01000>01000 seconds"
-msgstr "01000,01000 secondi"
+msgstr "01000,01000<01000 secondi"
 
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 #: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
@@ -820,10 +786,12 @@ msgstr "0100 giorni 024 h 060 m 060 s"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
-#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for
+#. seconds
 #. * (the hundredths are shown as decimal seconds). Don't change the numbers
 #. * unless there aren't 60 minutes in an hour in your locale.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "0100 h 060 m 060>0100 s"
@@ -834,11 +802,13 @@ msgid "centiseconds"
 msgstr "centesimi di secondo"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
-#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to
+#. the
 #. * abbreviation for minutes and 's' to the abbreviation for seconds (the
 #. * milliseconds are shown as decimal seconds) . Don't change the numbers
 #. * unless there aren't 60 minutes in an hour in your locale.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "0100 h 060 m 060>01000 s"
@@ -849,7 +819,8 @@ msgstr "0100 h 060 m 060>01000 s"
 #. * abbreviation for minutes, 's' to the abbreviation for seconds and
 #. * translate samples . Don't change the numbers
 #. * unless there aren't 60 seconds in a minute in your locale.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "0100 h 060 m 060 s+># samples"
@@ -858,7 +829,6 @@ msgstr "0100 h 060 m 060 s+># campioni"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
-#.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 #: plug-ins/sample-data-export.ny
 msgid "samples"
@@ -883,7 +853,8 @@ msgstr "hh:mm:ss + fotogrammi film (24 fps)"
 #. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
 #. * for seconds and translate 'frames' . Don't change the numbers
 #. * unless there aren't 60 seconds in a minute in your locale.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "0100 h 060 m 060 s+>24 frames"
@@ -914,7 +885,8 @@ msgstr "hh:mm:ss + fotogrammi NTSC saltati"
 #. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
 #. * for seconds and translate 'frames'. Leave the |N alone, it's important!
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "0100 h 060 m 060 s+>30 frames|N"
@@ -932,7 +904,8 @@ msgstr "hh:mm:ss + fotogrammi NTSC non saltati"
 #. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
 #. * for seconds and translate 'frames'. Leave the | .999000999 alone,
 #. * the whole things really is slightly off-speed!
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "0100 h 060 m 060 s+>030 frames| .999000999"
@@ -963,7 +936,8 @@ msgstr "hh:mm:ss + fotogrammi PAL (25 fps)"
 #. * and frames with PAL TV frames. Change the 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
 #. * for seconds and translate 'frames'. Nice simple time code!
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "0100 h 060 m 060 s+>25 frames"
@@ -988,13 +962,14 @@ msgstr "01000,01000 fotogrammi|25"
 #. * seconds and frames at CD Audio frame rate (75 frames per second)
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "hh:mm:ss + CDDA frames (75 fps)"
-msgstr "hh:mm:ss + fotogrammi CDDA (75 frame/sec)"
+msgstr "hh:mm:ss + fotogrammi CDDA (75 fps)"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and frames with CD Audio frames. Change the 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
 #. * for seconds and translate 'frames'.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "0100 h 060 m 060 s+>75 frames"
@@ -1005,7 +980,7 @@ msgstr "0100 h 060 m 060 s+>75 fotogrammi"
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "CDDA frames (75 fps)"
-msgstr "Fotogrammi CDDA (75 frame/sec)"
+msgstr "Fotogrammi CDDA (75 fps)"
 
 #. i18n-hint: Format string for displaying time in frames with CD Audio
 #. * frames. Change the comma
@@ -1017,7 +992,8 @@ msgstr "01000,01000 frame|75"
 
 #. i18n-hint: Format string for displaying frequency in hertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "010,01000>0100 Hz"
@@ -1034,7 +1010,8 @@ msgstr "kHz"
 
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "01000>01000 kHz|0.001"
@@ -1046,7 +1023,8 @@ msgstr "hertz"
 
 #. i18n-hint: Format string for displaying log of frequency in octaves.
 #. * Change the decimal points for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "100>01000 octaves|1.442695041"
@@ -1066,7 +1044,8 @@ msgstr "semitoni + centesimi"
 #. i18n-hint: Format string for displaying log of frequency in semitones
 #. * and cents.
 #. * Change the decimal points for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * The decimal separator is specified using '<' if your language uses a ','
+#. or
 #. * to '>' if your language uses a '.'.
 #: libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
 msgid "1000 semitones >0100 cents|17.312340491"
@@ -1135,12 +1114,10 @@ msgstr "Non è stato possibile scrivere su %s.\n"
 
 #: libraries/lib-project-file-io/DBConnection.cpp
 #, c-format
-msgid ""
-"Disk is full.\n"
+msgid "Disk is full.\n"
 "%s\n"
 "For tips on freeing up space, click the help button."
-msgstr ""
-"Il disco è pieno.\n"
+msgstr "Il disco è pieno.\n"
 "%s\n"
 "Per consigli su come liberare spazio fare clic sul pulsante di aiuto."
 
@@ -1148,9 +1125,10 @@ msgstr ""
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #: libraries/lib-project-file-io/SqliteSampleBlock.cpp
 #: libraries/lib-transactions/TransactionScope.cpp
-#: libraries/lib-wave-track/WaveClip.cpp libraries/lib-wave-track/WaveTrack.cpp
-#: libraries/lib-wx-init/LogWindow.cpp modules/mod-nyq-bench/NyqBench.cpp
-#: src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp
+#: libraries/lib-wave-track/WaveClip.cpp
+#: libraries/lib-wave-track/WaveTrack.cpp libraries/lib-wx-init/LogWindow.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/export/Export.cpp
+#: src/export/ExportCL.cpp src/export/ExportMultiple.cpp
 #: src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp
 #: src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp
 #: src/widgets/Warning.cpp
@@ -1159,34 +1137,28 @@ msgstr "Attenzione"
 
 #: libraries/lib-project-file-io/DBConnection.cpp
 #, c-format
-msgid ""
-"Failed to create savepoint:\n"
+msgid "Failed to create savepoint:\n"
 "\n"
 "%s"
-msgstr ""
-"Impossibile creare punto di salvataggio:\n"
+msgstr "Impossibile creare punto di salvataggio:\n"
 "\n"
 "%s"
 
 #: libraries/lib-project-file-io/DBConnection.cpp
 #, c-format
-msgid ""
-"Failed to release savepoint:\n"
+msgid "Failed to release savepoint:\n"
 "\n"
 "%s"
-msgstr ""
-"Impossibile rilasciare punto di salvataggio:\n"
+msgstr "Impossibile rilasciare punto di salvataggio:\n"
 "\n"
 "%s"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"There is very little free disk space left on %s\n"
+msgid "There is very little free disk space left on %s\n"
 "Please select a bigger temporary directory location in\n"
 "Directories Preferences."
-msgstr ""
-"È rimasto davvero poco spazio libero su %s\n"
+msgstr "È rimasto davvero poco spazio libero su %s\n"
 "Selezionare una cartella temporanea più grande nelle\n"
 "Preferenze delle cartelle."
 
@@ -1196,12 +1168,10 @@ msgstr "Non è stato possibile aprire il database del progetto"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"Failed to open database file:\n"
+msgid "Failed to open database file:\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato possibile aprire il file del database:\n"
+msgstr "Non è stato possibile aprire il file del database:\n"
 "\n"
 "%s"
 
@@ -1215,22 +1185,18 @@ msgstr "Impossibile ripristinare la connessione"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"Failed to execute a project file command:\n"
+msgid "Failed to execute a project file command:\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato possibile eseguire un comando di file del progetto:\n"
+msgstr "Non è stato possibile eseguire un comando di file del progetto:\n"
 "\n"
 "%s"
 
 #. i18n-hint: An error message.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"Project is in a read only directory\n"
+msgid "Project is in a read only directory\n"
 "(Unable to create the required temporary files)"
-msgstr ""
-"Il progetto è in una cartella in sola lettura\n"
+msgstr "Il progetto è in una cartella in sola lettura\n"
 "(impossibile creare i file temporanei richiesti)"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -1238,12 +1204,10 @@ msgid "This is not an Audacity project file"
 msgstr "Questo non è un file di progetto di Audacity"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"This project was created with a newer version of Audacity.\n"
+msgid "This project was created with a newer version of Audacity.\n"
 "\n"
 "You will need to upgrade to open it."
-msgstr ""
-"Questo progetto è stato creato con una versione più recente di Audacity.\n"
+msgstr "Questo progetto è stato creato con una versione più recente di Audacity.\n"
 "\n"
 "È necessario aggiornare per aprirlo."
 
@@ -1258,65 +1222,51 @@ msgstr "Impossibile aggiungere la funzione 'inset' (impossibile verificare i blo
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"Project is read only\n"
+msgid "Project is read only\n"
 "(Unable to work with the blockfiles)"
-msgstr ""
-"Il progetto è in sola lettura\n"
+msgstr "Il progetto è in sola lettura\n"
 "(impossibile lavorare con i blockfile)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"Project is locked\n"
+msgid "Project is locked\n"
 "(Unable to work with the blockfiles)"
-msgstr ""
-"Il progetto è bloccato\n"
+msgstr "Il progetto è bloccato\n"
 "(impossibile lavorare con i blockfile)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"Project is busy\n"
+msgid "Project is busy\n"
 "(Unable to work with the blockfiles)"
-msgstr ""
-"Il progetto è occupato\n"
+msgstr "Il progetto è occupato\n"
 "(impossibile lavorare con i blockfile)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"Project is corrupt\n"
+msgid "Project is corrupt\n"
 "(Unable to work with the blockfiles)"
-msgstr ""
-"Il progetto è corrotto\n"
+msgstr "Il progetto è corrotto\n"
 "(impossibile lavorare con i blockfile)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"Some permissions issue\n"
+msgid "Some permissions issue\n"
 "(Unable to work with the blockfiles)"
-msgstr ""
-"Alcuni problemi con i permessi\n"
+msgstr "Alcuni problemi con i permessi\n"
 "(impossibile lavorare con i blockfile)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"A disk I/O error\n"
+msgid "A disk I/O error\n"
 "(Unable to work with the blockfiles)"
-msgstr ""
-"Un errore di I/O del disco\n"
+msgstr "Un errore di I/O del disco\n"
 "(impossibile lavorare con i blockfile)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
-msgid ""
-"Not authorized\n"
+msgid "Not authorized\n"
 "(Unable to work with the blockfiles)"
-msgstr ""
-"Non autorizzato\n"
+msgstr "Non autorizzato\n"
 "(impossibile lavorare con i blockfile)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1343,12 +1293,10 @@ msgstr "Non è stato possibile passare alla modalità journaling veloce"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"Unable to prepare project file command:\n"
+msgid "Unable to prepare project file command:\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato possibile preparare il comando di file del progetto:\n"
+msgstr "Non è stato possibile preparare il comando di file del progetto:\n"
 "\n"
 "%s"
 
@@ -1366,13 +1314,11 @@ msgstr "Non è stato possibile associare un parametro SQL"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"Failed to update the project file.\n"
+msgid "Failed to update the project file.\n"
 "The following command failed:\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato possibile aggiornare il file di progetto\n"
+msgstr "Non è stato possibile aggiornare il file di progetto\n"
 "Il comando seguente è fallito:\n"
 "\n"
 "%s"
@@ -1391,12 +1337,10 @@ msgstr "Errore scrittura file"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"Audacity failed to write file %s.\n"
+msgid "Audacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
-msgstr ""
-"Audacity non è riuscito a scrivere il file %s.\n"
+msgstr "Audacity non è riuscito a scrivere il file %s.\n"
 "Forse il disco è pieno o non scrivibile.\n"
 "Per consigli su come liberare spazio fare clic\n"
 "sul pulsante di aiuto."
@@ -1423,11 +1367,9 @@ msgstr "(Recuperato)"
 #. i18n-hint: %s will be replaced by the version number.
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"This file was saved using Audacity %s.\n"
+msgid "This file was saved using Audacity %s.\n"
 "You are using Audacity %s. You may need to upgrade to a newer version to open this file."
-msgstr ""
-"Questo file è stato salvato usando Audacity %s.\n"
+msgstr "Questo file è stato salvato usando Audacity %s.\n"
 "Ora si sta usando Audacity %s. È necessario aggiornare a una nuova versione per aprire questo file."
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -1464,26 +1406,22 @@ msgstr "Sincronizzazione in corso"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"The project failed to open, possibly due to limited space\n"
+msgid "The project failed to open, possibly due to limited space\n"
 "on the storage device.\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato possibile aprire il progetto, forse a causa di spazio\n"
+msgstr "Non è stato possibile aprire il progetto, forse a causa di spazio\n"
 "limitato sul dispositivo di salvataggio.\n"
 "\n"
 "%s"
 
 #: libraries/lib-project-file-io/ProjectFileIO.cpp
 #, c-format
-msgid ""
-"Unable to remove autosave information, possibly due to limited space\n"
+msgid "Unable to remove autosave information, possibly due to limited space\n"
 "on the storage device.\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato possibile rimuovere l'informazione di salvataggio,\n"
+msgstr "Non è stato possibile rimuovere l'informazione di salvataggio,\n"
 "forse a causa di spazio limitato sul dispositivo di salvataggio.\n"
 "\n"
 "%s"
@@ -1497,11 +1435,9 @@ msgid "Automatic database backup failed."
 msgstr "Backup automatico del database fallito."
 
 #: libraries/lib-project-file-io/ProjectSerializer.cpp
-msgid ""
-"This recovery file was saved by Audacity 2.3.0 or before.\n"
+msgid "This recovery file was saved by Audacity 2.3.0 or before.\n"
 "You need to run that version of Audacity to recover the project."
-msgstr ""
-"Questo file di ripristino è stato salvato con Audacity 2.3.0 or precedente.\n"
+msgstr "Questo file di ripristino è stato salvato con Audacity 2.3.0 or precedente.\n"
 "È necessario eseguire quella versione di Audacity per recuperare il progetto."
 
 #: libraries/lib-project-file-io/SqliteSampleBlock.cpp
@@ -1581,83 +1517,78 @@ msgstr "Correg&gi"
 
 #. i18n-hint: The music theory "beat"
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "Beats"
-msgstr "&Battute"
+msgstr "Ritmi"
 
 #. i18n-hint: The music theory "bar"
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "Bar"
-msgstr "Bark"
+msgstr "Battuta"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "1/2"
-msgstr "128"
+msgstr "1/2"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/4"
-msgstr ""
+msgstr "1/4"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "1/8"
-msgstr "128"
+msgstr "1/8"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/16"
-msgstr ""
+msgstr "1/16"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/32"
-msgstr ""
+msgstr "1/32"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/64"
-msgstr ""
+msgstr "1/64"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/128"
-msgstr ""
+msgstr "1/128"
 
 #. i18n-hint: The music theory "triplet"
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "Triplets"
-msgstr ""
+msgstr "Terzine"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/2 (triplets)"
-msgstr ""
+msgstr "1/2 (terzine)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/4 (triplets)"
-msgstr ""
+msgstr "1/4 (terzine)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/8 (triplets)"
-msgstr ""
+msgstr "1/8 (terzine)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/16 (triplets)"
-msgstr ""
+msgstr "1/16 (terzine)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/32 (triplets)"
-msgstr ""
+msgstr "1/32 (terzine)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/64 (triplets)"
-msgstr ""
+msgstr "1/64 (terzine)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
 msgid "1/128 (triplets)"
-msgstr ""
+msgstr "1/128 (terzine)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "Seconds && samples"
-msgstr "Secondo più grande"
+msgstr "Secondi && campioni"
 
 #: libraries/lib-snapping/SnapUtils.cpp src/prefs/TracksPrefs.cpp
 #: plug-ins/sample-data-export.ny
@@ -1665,48 +1596,40 @@ msgid "Seconds"
 msgstr "Secondi"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "Deciseconds"
-msgstr "centesimi di secondo"
+msgstr "Decimi di secondo"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "Centiseconds"
-msgstr "centesimi di secondo"
+msgstr "Centesimi di secondo"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "Milliseconds"
-msgstr "millisecondi"
+msgstr "Millisecondi"
 
 #: libraries/lib-snapping/SnapUtils.cpp src/prefs/TracksPrefs.cpp
 msgid "Samples"
 msgstr "Campioni"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "Video frames"
-msgstr "Fotogrammi NTSC"
+msgstr "Fotogrammi video"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "Film frames (24 fps)"
-msgstr "fotogrammi film (24 fps)"
+msgstr "Fotogrammi film (24 fps)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "NTSC frames (29.97 fps)"
-msgstr "Fotogrammi CDDA (75 frame/sec)"
+msgstr "Fotogrammi NTSC (29,97 fps)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "NTSC frames (30 fps)"
-msgstr "Fotogrammi CDDA (75 frame/sec)"
+msgstr "Fotogrammi NTSC (30 fps)"
 
 #: libraries/lib-snapping/SnapUtils.cpp
-#, fuzzy
 msgid "CD frames"
-msgstr "Fotogrammi NTSC"
+msgstr "Fotogrammi CD"
 
 #: libraries/lib-strings/FutureStrings.h src/toolbars/CutCopyPasteToolBar.cpp
 msgid "Cut/Copy/Paste"
@@ -1773,76 +1696,63 @@ msgid "Light"
 msgstr "Chiaro"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
-#. graphical user interface, including choices of colors, and similarity of images
+#. graphical user interface, including choices of colors, and similarity of
+#. images
 #. such as those on button controls.  Audacity can load and save alternative
 #. themes.
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Themes written to:\n"
+msgid "Themes written to:\n"
 "  %s/*/%s."
-msgstr ""
-"Temi scritti in :\n"
+msgstr "Temi scritti in :\n"
 "  %s/*/%s."
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Audacity could not write file:\n"
+msgid "Audacity could not write file:\n"
 "  %s."
-msgstr ""
-"Audacity non può scrivere il file:\n"
+msgstr "Audacity non può scrivere il file:\n"
 "  %s."
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Audacity could not open file:\n"
+msgid "Audacity could not open file:\n"
 "  %s\n"
 "for writing."
-msgstr ""
-"Audacity non può aprire il file:\n"
+msgstr "Audacity non può aprire il file:\n"
 "  %s\n"
 "per la scrittura."
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Audacity could not write images to file:\n"
+msgid "Audacity could not write images to file:\n"
 "  %s."
-msgstr ""
-"Audacity non può scrivere immagini nel file:\n"
+msgstr "Audacity non può scrivere immagini nel file:\n"
 "  %s."
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Audacity could not find file:\n"
+msgid "Audacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
-msgstr ""
-"Audacity non può trovare il file:\n"
+msgstr "Audacity non può trovare il file:\n"
 "  %s.\n"
 "Tema non caricato."
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Audacity could not load file:\n"
+msgid "Audacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
-msgstr ""
-"Audacity non può caricare il file:\n"
+msgstr "Audacity non può caricare il file:\n"
 "  %s.\n"
 "Probabile formato png non valido?"
 
 #: libraries/lib-theme/Theme.cpp
-msgid ""
-"Audacity could not read its default theme.\n"
+msgid "Audacity could not read its default theme.\n"
 "Please report the problem."
-msgstr ""
-"Audacity non può leggere il tema predefinito.\n"
+msgstr "Audacity non può leggere il tema predefinito.\n"
 "Inviare un report sul problema."
 
 #: libraries/lib-theme/Theme.cpp
@@ -1852,51 +1762,41 @@ msgstr "Impossibile leggere dal file: %s"
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"None of the expected theme component files\n"
+msgid "None of the expected theme component files\n"
 " were found in:\n"
 "  %s."
-msgstr ""
-"Nessuno dei file previsti componenti il tema\n"
+msgstr "Nessuno dei file previsti componenti il tema\n"
 " è stato trovato in:\n"
 "  %s."
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Themes written to:\n"
+msgid "Themes written to:\n"
 "  %s/*/Components/."
-msgstr ""
-"Temi scritti in:\n"
+msgstr "Temi scritti in:\n"
 "  %s/*/Components/."
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Could not create directory:\n"
+msgid "Could not create directory:\n"
 "  %s"
-msgstr ""
-"Impossibile creare la cartella:\n"
+msgstr "Impossibile creare la cartella:\n"
 "  %s"
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Some required files in:\n"
+msgid "Some required files in:\n"
 "  %s\n"
 "were already present. Overwrite?"
-msgstr ""
-"Alcuni file richiesti in:\n"
+msgstr "Alcuni file richiesti in:\n"
 "  %s\n"
 "sono già presenti. Sovrascriverli?"
 
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Audacity could not save file:\n"
+msgid "Audacity could not save file:\n"
 "  %s"
-msgstr ""
-"Audacity non può salvare il file:\n"
+msgstr "Audacity non può salvare il file:\n"
 "  %s"
 
 #: libraries/lib-theme/Theme.cpp src/FreqWindow.cpp src/LabelDialog.cpp
@@ -1908,11 +1808,9 @@ msgstr "Impossibile scrivere nel file: %s"
 #. i18n-hint "Cee" means the C computer programming language
 #: libraries/lib-theme/Theme.cpp
 #, c-format
-msgid ""
-"Themes as Cee code written to:\n"
+msgid "Themes as Cee code written to:\n"
 "  %s/*%s."
-msgstr ""
-"Temi come codice Cee scritti in:\n"
+msgstr "Temi come codice Cee scritti in:\n"
 "  %s/*%s."
 
 #. i18n-hint: user defined
@@ -1980,11 +1878,9 @@ msgstr "Non è stato possibile scrivere su file la combinazione VST3"
 
 #: libraries/lib-wave-track/Sequence.cpp
 #, c-format
-msgid ""
-"Sequence has block file exceeding maximum %s samples per block.\n"
+msgid "Sequence has block file exceeding maximum %s samples per block.\n"
 "Truncating to this maximum length."
-msgstr ""
-"La sequenza ha un file di blocco che eccede il limite massimo di %s campioni per blocco.\n"
+msgstr "La sequenza ha un file di blocco che eccede il limite massimo di %s campioni per blocco.\n"
 "Troncamento a questa lunghezza massima."
 
 #: libraries/lib-wave-track/Sequence.cpp
@@ -2160,16 +2056,16 @@ msgstr "Questi sono i nostri canali di supporto:"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: libraries/lib-wx-init/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]]"
-msgstr ""
+msgstr "[[help:Quick_Help|Guida rapida]]"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: libraries/lib-wx-init/HelpText.cpp
 msgid " [[help:Main_Page|Manual]]"
-msgstr ""
+msgstr " [[help:Main_Page|Manuale]]"
 
 #: libraries/lib-wx-init/HelpText.cpp
 msgid "[[https://support.audacityteam.org/|Tutorials & How-tos]]"
-msgstr ""
+msgstr "[[https://support.audacityteam.org/|Tutorial e guide]]"
 
 #: libraries/lib-wx-init/HelpText.cpp
 msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
@@ -2226,7 +2122,8 @@ msgstr "Impossibile salvare il registro nel file: %s"
 msgid "Show Log for Details"
 msgstr "Mostra registro per dettagli"
 
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a
+#. button.
 #: libraries/lib-wx-init/MultiDialog.cpp src/AboutDialog.cpp
 #: src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp
 msgid "OK"
@@ -2688,97 +2585,113 @@ msgstr "Ferma script"
 msgid "No revision identifier was provided"
 msgstr "Non è stato fornito alcun identificativo di revisione"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, system administration"
 msgstr "%s, amministrazione sistema"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, co-founder and developer"
 msgstr "%s, cofondatore e sviluppatore"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, designer"
 msgstr "%s, designer"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer"
 msgstr "%s, sviluppatore"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer and support"
 msgstr "%s, sviluppatore e supporto"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, documentation and support"
 msgstr "%s, documentazione e assistenza"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, QA tester, documentation and support"
 msgstr "%s, tester QA, documentazione e supporto"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, documentation and support, French"
 msgstr "%s, documentazione e assistenza, Francese"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
 msgstr "%s, controllo di qualità"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, accessibility advisor"
 msgstr "%s, consulente accessibilità"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "%s, artista grafico"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, composer"
 msgstr "%s, compositore"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, tester"
 msgstr "%s, tester"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "%s, estensioni Nyquist"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, web developer"
 msgstr "%s, sviluppatore web"
 
-#. i18n-hint: For "About Audacity..." credits, substituting a person's proper name
+#. i18n-hint: For "About Audacity..." credits, substituting a person's proper
+#. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphics"
@@ -2870,9 +2783,9 @@ msgstr "Sito web di %s: "
 #. i18n-hint Audacity's name substitutes for first and third %s,
 #. and a "copyright" symbol for the second
 #: src/AboutDialog.cpp
-#, fuzzy, c-format
+#, c-format
 msgid "%s software is copyright %s 1999-2023 %s Team."
-msgstr "Il software %s è protetto da copyright %s 1999-2021 Team di %s."
+msgstr "Il software %s è protetto da copyright %s 1099-2023 Team di %s."
 
 #. i18n-hint Audacity's name substitutes for %s
 #: src/AboutDialog.cpp
@@ -2938,7 +2851,7 @@ msgstr "Compilatore:"
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
-msgstr "Prefisso installazione: "
+msgstr "Prefisso installazione:"
 
 #: src/AboutDialog.cpp
 msgid "Cache folder:"
@@ -3060,21 +2973,20 @@ msgstr "La verifica di aggiornamenti e la segnalazione degli errori richiedono l
 msgid "See %s for more info."
 msgstr "Vedere %s per ulteriori informazioni."
 
-#. i18n-hint: Title of hyperlink to the privacy policy. This is an object of "See".
+#. i18n-hint: Title of hyperlink to the privacy policy. This is an object of
+#. "See".
 #: src/AboutDialog.cpp src/prefs/ApplicationPrefs.cpp
 #: src/update/UpdateNoticeDialog.cpp src/widgets/ErrorReportDialog.cpp
 msgid "our Privacy Policy"
 msgstr "la nostra politica relativa alla privacy"
 
 #: src/AdornedRulerPanel.cpp
-#, fuzzy
 msgid "Minutes and Seconds"
-msgstr "5esimi di secondo"
+msgstr "Minuti e secondi"
 
 #: src/AdornedRulerPanel.cpp
-#, fuzzy
 msgid "Beats and Measures"
-msgstr "Ricerca battuta"
+msgstr "Ritmo e misure"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to define a looping region."
@@ -3101,7 +3013,6 @@ msgstr "Timeline"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Fare clic o trascinare per iniziare la ricerca"
@@ -3109,7 +3020,6 @@ msgstr "Fare clic o trascinare per iniziare la ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Fare clic o trascinare per iniziare lo scorrimento"
@@ -3117,7 +3027,6 @@ msgstr "Fare clic o trascinare per iniziare lo scorrimento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Fare clic e spostarsi per scorrere. Fare clic e trascinare per ricercare."
@@ -3125,7 +3034,6 @@ msgstr "Fare clic e spostarsi per scorrere. Fare clic e trascinare per ricercare
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Spostarsi per ricercare"
@@ -3133,7 +3041,6 @@ msgstr "Spostarsi per ricercare"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Spostarsi per scorrere"
@@ -3197,12 +3104,10 @@ msgid "Failed!"
 msgstr "Fallito!"
 
 #: src/AudacityApp.cpp
-msgid ""
-"Reset Preferences?\n"
+msgid "Reset Preferences?\n"
 "\n"
 "This is a one-time question, after an 'install' where you asked to have the Preferences reset."
-msgstr ""
-"Azzerare le preferenze?\n"
+msgstr "Azzerare le preferenze?\n"
 "\n"
 "Questa domanda viene posta una sola volta, dopo una 'installazione' in cui è stato chiesto di azzerare le preferenze."
 
@@ -3212,12 +3117,10 @@ msgstr "Azzera le preferenze di Audacity"
 
 #: src/AudacityApp.cpp
 #, c-format
-msgid ""
-"%s could not be found.\n"
+msgid "%s could not be found.\n"
 "\n"
 "It has been removed from the list of recent files."
-msgstr ""
-"Impossibile trovare %s.\n"
+msgstr "Impossibile trovare %s.\n"
 "\n"
 "È stato rimosso dall'elenco dei file recenti."
 
@@ -3260,21 +3163,17 @@ msgid "&File"
 msgstr "&File"
 
 #: src/AudacityApp.cpp
-msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
+msgid "Audacity could not find a safe place to store temporary files.\n"
 "Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
-msgstr ""
-"Non è stato possibile trovare una posizione sicura dove salvare i file temporanei.\n"
+msgstr "Non è stato possibile trovare una posizione sicura dove salvare i file temporanei.\n"
 "Audacity ha bisogno di una posizione in cui i programmi automatici di pulizia non eliminano i file temporanei.\n"
 "Specificare un'appropriata cartella nella finestra di dialogo delle preferenze."
 
 #: src/AudacityApp.cpp
-msgid ""
-"Audacity could not find a place to store temporary files.\n"
+msgid "Audacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
-msgstr ""
-"Impossibile trovare una posizione dove salvare i file temporanei.\n"
+msgstr "Impossibile trovare una posizione dove salvare i file temporanei.\n"
 "Specificare una cartella adatta nella finestra di dialogo delle preferenze."
 
 #: src/AudacityApp.cpp
@@ -3282,21 +3181,17 @@ msgid "Audacity is now going to exit. Please launch Audacity again to use the ne
 msgstr "Si sta uscendo da Audacity. Riavviare Audacity per usare la nuova cartella temporanea."
 
 #: src/AudacityApp.cpp
-msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+msgid "Running two copies of Audacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
-msgstr ""
-"L'esecuzione contemporanea di due copie di Audacity può causare\n"
+msgstr "L'esecuzione contemporanea di due copie di Audacity può causare\n"
 "perdita di dati o un blocco del sistema.\n"
 "\n"
 
 #: src/AudacityApp.cpp
-msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
+msgid "Audacity was not able to lock the temporary files directory.\n"
 "This folder may be in use by another copy of Audacity.\n"
-msgstr ""
-"Non è stato possibile bloccare la cartella dei file temporanei.\n"
+msgstr "Non è stato possibile bloccare la cartella dei file temporanei.\n"
 "Questa cartella potrebbe essere in uso in un'altra copia di Audacity.\n"
 
 #: src/AudacityApp.cpp
@@ -3312,11 +3207,9 @@ msgid "The system has detected that another copy of Audacity is running.\n"
 msgstr "Il sistema ha rilevato che un'altra copia di Audacity è in esecuzione.\n"
 
 #: src/AudacityApp.cpp
-msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+msgid "Use the New or Open commands in the currently running Audacity\n"
 "process to open multiple projects simultaneously.\n"
-msgstr ""
-"Usa i comandi Nuovo o Apri nel processo di Audacity attualmente\n"
+msgstr "Usa i comandi Nuovo o Apri nel processo di Audacity attualmente\n"
 "in esecuzione per aprire più progetti contemporaneamente.\n"
 
 #: src/AudacityApp.cpp
@@ -3325,12 +3218,10 @@ msgstr "Audacity è già in esecuzione"
 
 #: src/AudacityApp.cpp
 #, c-format
-msgid ""
-"Unable to create shared memory segment.\n"
+msgid "Unable to create shared memory segment.\n"
 "\n"
 "error code=%d : \"%s\"."
-msgstr ""
-"Impossibile creare un segmento di memoria condivisa.\n"
+msgstr "Impossibile creare un segmento di memoria condivisa.\n"
 "\n"
 "codice errore=%d : \"%s\"."
 
@@ -3339,61 +3230,51 @@ msgid "Audacity Startup Failure"
 msgstr "Avvio di Audacity fallito"
 
 #: src/AudacityApp.cpp
-msgid ""
-"Unable to acquire semaphores.\n"
+msgid "Unable to acquire semaphores.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
-msgstr ""
-"Impossibile acquisire i semafori.\n"
+msgstr "Impossibile acquisire i semafori.\n"
 "\n"
 "Ciò è probabilmente dovuto a scarsità di risorse\n"
 "e potrebbe essere necessario un riavvio."
 
 #: src/AudacityApp.cpp
-msgid ""
-"Unable to create semaphores.\n"
+msgid "Unable to create semaphores.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
-msgstr ""
-"Impossibile creare semafori.\n"
+msgstr "Impossibile creare semafori.\n"
 "\n"
 "Ciò è probabilmente dovuto a scarsità di risorse\n"
 "e potrebbe essere necessario un riavvio."
 
 #: src/AudacityApp.cpp
-msgid ""
-"Unable to acquire lock semaphore.\n"
+msgid "Unable to acquire lock semaphore.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
-msgstr ""
-"Impossibile acquisire il lock del semaforo.\n"
+msgstr "Impossibile acquisire il lock del semaforo.\n"
 "\n"
 "Ciò è probabilmente dovuto a scarsità di risorse\n"
 "e potrebbe essere necessario un riavvio."
 
 #: src/AudacityApp.cpp
-msgid ""
-"Unable to acquire server semaphore.\n"
+msgid "Unable to acquire server semaphore.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
-msgstr ""
-"Impossibile acquisire il semaforo del server.\n"
+msgstr "Impossibile acquisire il semaforo del server.\n"
 "\n"
 "Ciò è probabilmente dovuto a scarsità di risorse\n"
 "e potrebbe essere necessario un riavvio."
 
 #: src/AudacityApp.cpp
-msgid ""
-"The Audacity IPC server failed to initialize.\n"
+msgid "The Audacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
-msgstr ""
-"Impossibile inizializzare il server ICP di Audacity .\n"
+msgstr "Impossibile inizializzare il server ICP di Audacity .\n"
 "\n"
 "Ciò è probabilmente dovuto a scarsità di risorse\n"
 "e potrebbe essere necessario un riavvio."
@@ -3413,7 +3294,7 @@ msgstr "imposta massima dimensione blocchi disco in byte"
 #. "log," "trail," "trace" have somewhat similar meanings
 #: src/AudacityApp.cpp
 msgid "replay a journal file"
-msgstr "riesegui un giornale di registrazione"
+msgstr "riesegui un file journal"
 
 #. i18n-hint: This displays a list of available options
 #: src/AudacityApp.cpp
@@ -3442,13 +3323,11 @@ msgid "Handle 'audacity://' url"
 msgstr "Gestisci gli url 'audacity://'"
 
 #: src/AudacityApp.cpp
-msgid ""
-"Audacity project (.aup3) files are not currently \n"
+msgid "Audacity project (.aup3) files are not currently \n"
 "associated with Audacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
-msgstr ""
-"I file del progetto Audacity (.aup3) non solo al\n"
+msgstr "I file del progetto Audacity (.aup3) non solo al\n"
 "momento associati ad Audacity.\n"
 "\n"
 "Associarli, in modo da poterli aprire con un doppio clic?"
@@ -3463,8 +3342,7 @@ msgstr "Errore di configurazione di Audacity"
 
 #: src/AudacityFileConfig.cpp
 #, c-format
-msgid ""
-"The following configuration file could not be accessed:\n"
+msgid "The following configuration file could not be accessed:\n"
 "\n"
 "\t%s\n"
 "\n"
@@ -3473,8 +3351,7 @@ msgid ""
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
 "If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
-msgstr ""
-"Non è stato possibile accedere al seguente file di configurazione:\n"
+msgstr "Non è stato possibile accedere al seguente file di configurazione:\n"
 "\n"
 "\t%s\n"
 "\n"
@@ -3493,35 +3370,35 @@ msgid "&Retry"
 msgstr "&Riprova"
 
 #: src/AudioPasteDialog.cpp src/prefs/TracksBehaviorsPrefs.cpp
-msgid ""
-"Smart clip.\n"
+msgid "Smart clip.\n"
 "The entire source clip will be pasted into your project, allowing you to access\n"
 "trimmed audio data anytime."
-msgstr ""
+msgstr "Clip intelligente.\n"
+"L'intera clip sorgente verrà incollata nel progetto, consentendo\n"
+"di accedere ai dati audio tagliati in qualsiasi momento."
 
 #: src/AudioPasteDialog.cpp src/prefs/TracksBehaviorsPrefs.cpp
-msgid ""
-"Selected audio only.\n"
+msgid "Selected audio only.\n"
 "Only the selected portion of the source clip will be pasted."
-msgstr ""
+msgstr "Solo audio selezionato.\n"
+"Verrà incollata solo la parte selezionata della clip sorgente."
 
 #: src/AudioPasteDialog.cpp
-#, fuzzy
 msgid "Paste audio"
-msgstr "Condividi audio"
+msgstr "Incolla audio"
 
 #: src/AudioPasteDialog.cpp
 msgid "How would you like to paste your audio?"
-msgstr ""
+msgstr "Come incollare l'audio?"
 
 #: src/AudioPasteDialog.cpp
 #, c-format
 msgid "Audio data is %s. Larger sizes will take longer to paste."
-msgstr ""
+msgstr "I dati audio sono di %s. Le dimensioni maggiori impiegheranno più tempo per essere incollate."
 
 #: src/AudioPasteDialog.cpp
 msgid "Remember my choice and don't ask again"
-msgstr ""
+msgstr "Ricorda la mia scelta e non chiedermelo più"
 
 #: src/AudioPasteDialog.cpp
 msgid "Continue"
@@ -3532,12 +3409,10 @@ msgid "Automatic Crash Recovery"
 msgstr "Ripristino automatico da crash"
 
 #: src/AutoRecoveryDialog.cpp
-msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+msgid "The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
-msgstr ""
-"I seguenti progetti non sono stati salvati correttamente l'ultima volta che Audacity è stato eseguito e possono essere ripristinati.\n"
+msgstr "I seguenti progetti non sono stati salvati correttamente l'ultima volta che Audacity è stato eseguito e possono essere ripristinati.\n"
 "\n"
 "Dopo il ripristino, salvare i progetti per assicurarsi che le modifiche vengano scritte su disco."
 
@@ -3574,12 +3449,10 @@ msgid "No projects selected"
 msgstr "Nessun progetto selezionato"
 
 #: src/AutoRecoveryDialog.cpp
-msgid ""
-"Are you sure you want to discard the selected projects?\n"
+msgid "Are you sure you want to discard the selected projects?\n"
 "\n"
 "Choosing \"Yes\" permanently deletes the selected projects immediately."
-msgstr ""
-"Scartare i progetti selezionati?\n"
+msgstr "Scartare i progetti selezionati?\n"
 "\n"
 "Selezionando \"Sì\" i progetti selezionati verranno immediatamente eliminati in modo permanente."
 
@@ -3644,7 +3517,8 @@ msgstr "Comando di menu (con parametri)"
 msgid "Menu Command (No Parameters)"
 msgstr "Comando di menu (senza parametri)"
 
-#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove
+#. Tracks".
 #: src/BatchCommands.cpp src/CommonCommandFlags.cpp
 #, c-format
 msgid "\"%s\" requires one or more tracks to be selected."
@@ -3677,12 +3551,10 @@ msgstr "Applica '%s'"
 
 #: src/BatchCommands.cpp
 #, c-format
-msgid ""
-"Apply %s with parameter(s)\n"
+msgid "Apply %s with parameter(s)\n"
 "\n"
 "%s"
-msgstr ""
-"Applica %s con parametro/i\n"
+msgstr "Applica %s con parametro/i\n"
 "\n"
 "%s"
 
@@ -3865,7 +3737,8 @@ msgstr "Nome della nuova macro"
 msgid "Name must not be blank"
 msgstr "Il nome non deve essere vuoto"
 
-#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/' and '\'.
+#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/'
+#. and '\'.
 #: src/BatchProcessDialog.cpp
 #, c-format
 msgid "Names may not contain '%c' and '%c'"
@@ -4014,11 +3887,9 @@ msgstr "Incolla: %lld\n"
 
 #: src/Benchmark.cpp
 #, c-format
-msgid ""
-"Trial %d\n"
+msgid "Trial %d\n"
 "Failed on Paste.\n"
-msgstr ""
-"Prova %d\n"
+msgstr "Prova %d\n"
 "Fallita durante l'incollamento.\n"
 
 #: src/Benchmark.cpp
@@ -4073,11 +3944,9 @@ msgstr "Tempo per controllare tutti i dati (2): %ld ms\n"
 
 #: src/Benchmark.cpp
 #, c-format
-msgid ""
-"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+msgid "At 44100 Hz, %d bytes per sample, the estimated number of\n"
 " simultaneous tracks that could be played at once: %.1f\n"
-msgstr ""
-"A 44100 Hz, %d byte per campione, numero stimato di\n"
+msgstr "A 44100 Hz, %d byte per campione, numero stimato di\n"
 "tracce eseguibili simultaneamente: : %.1f\n"
 
 #: src/Benchmark.cpp
@@ -4088,25 +3957,26 @@ msgstr "TEST FALLITO!!!\n"
 msgid "Benchmark completed successfully.\n"
 msgstr "Benchmark completato con successo.\n"
 
-#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize,
+#. Cut, Fade.
 #: src/CommonCommandFlags.cpp
 #, c-format
-msgid ""
-"You must first select some audio for '%s' to act on.\n"
+msgid "You must first select some audio for '%s' to act on.\n"
 "\n"
 "Ctrl + A selects all audio."
-msgstr ""
-"Prima è necessario selezionare l'audio per cui '%s' deve operare.\n"
+msgstr "Prima è necessario selezionare l'audio per cui '%s' deve operare.\n"
 "\n"
 "Ctrl + A seleziona tutto l'audio."
 
-#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize,
+#. Cut, Fade.
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
 msgstr "Selezionare l'audio da utilizzare per l'azione %s (ad esempio, Cmd + A per selezionare tutto) quindi riprovare."
 
-#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize,
+#. Cut, Fade.
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
@@ -4116,18 +3986,17 @@ msgstr "Selezionare l'audio da utilizzare per l'azione %s (ad esempio, Ctrl + A 
 msgid "No Audio Selected"
 msgstr "Nessun audio selezionato"
 
-#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise
+#. Reduction'.
 #: src/CommonCommandFlags.cpp
 #, c-format
-msgid ""
-"Select the audio for %s to use.\n"
+msgid "Select the audio for %s to use.\n"
 "\n"
 "1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
 "\n"
 "2. When you have got your noise profile, select the audio you want to change\n"
 "and use %s to change that audio."
-msgstr ""
-"Selezionare l'audio da usare per %s.\n"
+msgstr "Selezionare l'audio da usare per %s.\n"
 "\n"
 "1. Selezionare audio che rappresenta rumore e usare %s per ottenere il proprio\n"
 "'profilo di rumore'.\n"
@@ -4136,27 +4005,21 @@ msgstr ""
 "modificare e usare %s per modificarlo."
 
 #: src/CommonCommandFlags.cpp
-msgid ""
-"You can only do this when playing and recording are\n"
+msgid "You can only do this when playing and recording are\n"
 "stopped. (Pausing is not sufficient.)"
-msgstr ""
-"È possibile compiere questa azione solo quando la riproduzione e\n"
+msgstr "È possibile compiere questa azione solo quando la riproduzione e\n"
 "la registrazione sono fermate. (Mettere in pausa non basta)."
 
 #: src/CommonCommandFlags.cpp
-msgid ""
-"You must first select some stereo audio to perform this\n"
+msgid "You must first select some stereo audio to perform this\n"
 "action. (You cannot use this with mono.)"
-msgstr ""
-"Prima di eseguire questa azione è necessario selezionare un\n"
+msgstr "Prima di eseguire questa azione è necessario selezionare un\n"
 "audio stereo. (Non è possibile utilizzarla con audio mono)."
 
 #: src/CommonCommandFlags.cpp
-msgid ""
-"You must first select some audio to perform this action.\n"
+msgid "You must first select some audio to perform this action.\n"
 "(Selecting other kinds of track won't work.)"
-msgstr ""
-"Prima di eseguire questa azione è necessario selezionare un audio.\n"
+msgstr "Prima di eseguire questa azione è necessario selezionare un audio.\n"
 "(La selezione di altri tipi di tracce non va bene)."
 
 #: src/CrashReport.cpp
@@ -4180,21 +4043,17 @@ msgid "Project Depends on Other Audio Files"
 msgstr "Il progetto dipende da altri file audio"
 
 #: src/Dependencies.cpp
-msgid ""
-"Copying these files into your project will remove this dependency.\n"
+msgid "Copying these files into your project will remove this dependency.\n"
 "This is safer, but needs more disk space."
-msgstr ""
-"Copiare questi file nel proprio progetto per rimuovere la dipendenza.\n"
+msgstr "Copiare questi file nel proprio progetto per rimuovere la dipendenza.\n"
 "È più sicuro, ma necessita di più spazio di archiviazione."
 
 #: src/Dependencies.cpp
-msgid ""
-"\n"
+msgid "\n"
 "\n"
 "Files shown as MISSING have been moved or deleted and cannot be copied.\n"
 "Restore them to their original location to be able to copy into project."
-msgstr ""
-"\n"
+msgstr "\n"
 "\n"
 "I file mostrati come MANCANTI sono stati spostati o eliminati e non possono essere copiati.\n"
 "È necessario ripristinarli nella loro posizione originale per poterli copiare nel progetto."
@@ -4276,14 +4135,12 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Se si procede il progetto non verrà salvato su disco. Si è sicuri di voler procedere?"
 
 #: src/Dependencies.cpp
-msgid ""
-"Your project is self-contained; it does not depend on any external audio files. \n"
+msgid "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
 "Some older Audacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
-msgstr ""
-"Il progetto è attualmente auto-contenuto: non dipende da file audio esterni. \n"
+msgstr "Il progetto è attualmente auto-contenuto: non dipende da file audio esterni. \n"
 "\n"
 "Alcuni progetti di Audacity più vecchi potrebbero non essere auto-contenuti,\n"
 "ed è necessario mantenerene le dipendenze esterne nella corretta posizione.\n"
@@ -4303,14 +4160,12 @@ msgid "Dropouts"
 msgstr "Perdite"
 
 #: src/DropoutDetector.cpp
-msgid ""
-"Recorded audio was lost at the labeled locations. Possible causes:\n"
+msgid "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
 "Other applications are competing with Audacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
-msgstr ""
-"L'audio registrato è andato perso nelle posizioni etichettate. Cause possibili:\n"
+msgstr "L'audio registrato è andato perso nelle posizioni etichettate. Cause possibili:\n"
 "\n"
 "Altre applicazioni condividono con Audacity la potenza di calcolo del processore\n"
 "\n"
@@ -4325,13 +4180,11 @@ msgid "FFmpeg support not compiled in"
 msgstr "Supporto FFmpeg non compilato"
 
 #: src/FFmpeg.cpp
-msgid ""
-"FFmpeg was configured in Preferences and successfully loaded before, \n"
+msgid "FFmpeg was configured in Preferences and successfully loaded before, \n"
 "but this time Audacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
-msgstr ""
-"FFmpeg era già stato configurato nelle preferenze e precedentemente è stato caricato \n"
+msgstr "FFmpeg era già stato configurato nelle preferenze e precedentemente è stato caricato \n"
 "con successo, tuttavia questa volta Audacity non è riuscito a caricarlo all'avvio. \n"
 "\n"
 "Tornare in Preferenze > Librerie per riconfigurarlo."
@@ -4402,14 +4255,12 @@ msgid "FFmpeg not found"
 msgstr "Impossibile trovare FFmpeg"
 
 #: src/FFmpeg.cpp
-msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+msgid "Audacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
 "to download or locate the FFmpeg libraries."
-msgstr ""
-"Audacity ha cercato di usare FFmpeg per importare un file audio,\n"
+msgstr "Audacity ha cercato di usare FFmpeg per importare un file audio,\n"
 "ma le librerie non sono state trovate.\n"
 "\n"
 "Per usare FFmpeg per l'importazione, andare in\n"
@@ -4420,7 +4271,8 @@ msgstr ""
 msgid "Do not show this warning again"
 msgstr "Non mostrare di nuovo questo avviso"
 
-#. i18n-hint: %s will be the error message from the libsndfile software library
+#. i18n-hint: %s will be the error message from the libsndfile software
+#. library
 #: src/FileFormats.cpp
 #, c-format
 msgid "Error (file may not have been written): %s"
@@ -4561,26 +4413,30 @@ msgstr "I dati selezionati non sono sufficienti."
 msgid "s"
 msgstr "s"
 
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g.
+#. A#
 #: src/FreqWindow.cpp
 #, c-format
 msgid "%d Hz (%s) = %d dB"
 msgstr "%d Hz (%s) = %d dB"
 
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g.
+#. A#
 #: src/FreqWindow.cpp
 #, c-format
 msgid "%d Hz (%s) = %.1f dB"
 msgstr "%d Hz (%s) = %.1f dB"
 
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g.
+#. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
 #, c-format
 msgid "%.4f sec (%d Hz) (%s) = %f"
 msgstr "%.4f sec (%d Hz) (%s) = %f"
 
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g.
+#. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
 #, c-format
@@ -4671,7 +4527,7 @@ msgstr "La compressione ha liberato %s di spazio disco."
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History"
-msgstr "&Cronologia"
+msgstr "Cronolo&gia"
 
 #: src/IncompatiblePluginsDialog.cpp
 msgid "New Plugins"
@@ -4682,9 +4538,8 @@ msgid "Incompatible plugin(s) found"
 msgstr "Trovate estensioni incompatibili"
 
 #: src/IncompatiblePluginsDialog.cpp
-#, fuzzy
 msgid "&Manage Plugins"
-msgstr "Gestisci estensioni"
+msgstr "&Gestisci estensioni"
 
 #: src/IncompatiblePluginsDialog.cpp src/cloud/audiocom/LinkAccountDialog.cpp
 #: src/cloud/audiocom/ShareAudioDialog.cpp
@@ -4702,9 +4557,9 @@ msgid "Audacity has found %d incompatible plugins which could not be loaded. We 
 msgstr "Audacity ha trovato %d estensioni incompatibili che non possono essere caricate. Queste estensioni sono state disabilitate per evitare blocchi o arresti anomali. Per provare a utilizzare comunque queste estensioni, è possibile abilitarle utilizzando \"Gestisci estensioni\". In caso contrario, selezionare \"Continua\"."
 
 #: src/IncompatiblePluginsDialog.cpp
-#, fuzzy, c-format
+#, c-format
 msgid "Audacity has found %d incompatible plugins which could not be loaded. We have disabled these plugins to avoid any stalling or crashes."
-msgstr "Audacity ha trovato %d estensioni incompatibili che non possono essere caricate. Queste estensioni sono state disabilitate per evitare blocchi o arresti anomali. Per provare a utilizzare comunque queste estensioni, è possibile abilitarle utilizzando \"Gestisci estensioni\". In caso contrario, selezionare \"Continua\"."
+msgstr "Audacity ha trovato %d estensioni incompatibili che non possono essere caricate. Queste estensioni sono state disabilitate per evitare blocchi o arresti anomali."
 
 #: src/JournalEvents.cpp
 msgid "Journal recording failed"
@@ -4819,11 +4674,9 @@ msgstr "Errore nella conversione del file di progetto precedente"
 
 #: src/Legacy.cpp
 #, c-format
-msgid ""
-"Converted a 1.0 project file to the new format.\n"
+msgid "Converted a 1.0 project file to the new format.\n"
 "The old file has been saved as '%s'"
-msgstr ""
-"Un file di progetto 1.0 è stato convertito nel nuovo formato.\n"
+msgstr "Un file di progetto 1.0 è stato convertito nel nuovo formato.\n"
 "Il vecchio file è stato salvato come '%s'"
 
 #: src/Legacy.cpp
@@ -4844,11 +4697,9 @@ msgid "There was an error initializing the midi i/o layer.\n"
 msgstr "Si è verificato un errore durante l'inizializzazione del layer I/O MIDI.\n"
 
 #: src/MIDIPlay.cpp
-msgid ""
-"You will not be able to play midi.\n"
+msgid "You will not be able to play midi.\n"
 "\n"
-msgstr ""
-"Non sarà possibile riprodurre MIDI.\n"
+msgstr "Non sarà possibile riprodurre MIDI.\n"
 "\n"
 
 #: src/MIDIPlay.cpp
@@ -4862,7 +4713,7 @@ msgstr "Ann&ulla %s"
 
 #: src/Menus.cpp src/menus/EditMenus.cpp
 msgid "&Undo"
-msgstr "Ann&ulla"
+msgstr "&Annulla"
 
 #: src/Menus.cpp
 #, c-format
@@ -4874,11 +4725,9 @@ msgid "&Redo"
 msgstr "&Ripristina"
 
 #: src/Menus.cpp
-msgid ""
-"There was a problem with your last action. If you think\n"
+msgid "There was a problem with your last action. If you think\n"
 "this is a bug, please tell us exactly where it occurred."
-msgstr ""
-"Si è verificato un problema con l'ultima azione. Se si ritiene che\n"
+msgstr "Si è verificato un problema con l'ultima azione. Se si ritiene che\n"
 "sia un errore, sarebbe utile comunicarci dove si è verificato."
 
 #: src/Menus.cpp
@@ -4899,7 +4748,8 @@ msgid "Gain"
 msgstr "Guadagno"
 
 #. i18n-hint: title of the MIDI Velocity slider
-#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note
+#. tracks
 #: src/MixerBoard.cpp
 #: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
 #: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
@@ -5082,27 +4932,32 @@ msgstr "La♭"
 msgid "B♭"
 msgstr "Si♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
+#. scale
 #: src/PitchName.cpp
 msgid "C♯/D♭"
 msgstr "Do♯/Do♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
+#. scale
 #: src/PitchName.cpp
 msgid "D♯/E♭"
 msgstr "Re♯/Mi♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
+#. scale
 #: src/PitchName.cpp
 msgid "F♯/G♭"
 msgstr "Fa♯/Sol♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
+#. scale
 #: src/PitchName.cpp
 msgid "G♯/A♭"
 msgstr "Sol♯/La♭"
 
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic
+#. scale
 #: src/PitchName.cpp
 msgid "A♯/B♭"
 msgstr "La♯/Si♭"
@@ -5128,7 +4983,7 @@ msgstr "Mostra tutto"
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
 msgid "&All"
-msgstr "&Tutto"
+msgstr "T&utto"
 
 #. i18n-hint: Radio button to show just the currently disabled effects
 #: src/PluginRegistrationDialog.cpp
@@ -5190,33 +5045,27 @@ msgstr "&Disabilita"
 
 #: src/PluginRegistrationDialog.cpp
 #, c-format
-msgid ""
-"Enabling effects or commands:\n"
+msgid "Enabling effects or commands:\n"
 "\n"
 "%s"
-msgstr ""
-"Abilitazione di effetti o comandi:\n"
-"\n"
-"%s"
-
-#: src/PluginRegistrationDialog.cpp
-#, c-format
-msgid ""
-"Enabling effect or command:\n"
-"\n"
-"%s"
-msgstr ""
-"Abilitazione effetto o comando:\n"
+msgstr "Abilitazione di effetti o comandi:\n"
 "\n"
 "%s"
 
 #: src/PluginRegistrationDialog.cpp
 #, c-format
-msgid ""
-"Effect or Command at %s failed to register:\n"
+msgid "Enabling effect or command:\n"
+"\n"
 "%s"
-msgstr ""
-"Non è stato possibile registrare l'effetto/comando in %s:\n"
+msgstr "Abilitazione effetto o comando:\n"
+"\n"
+"%s"
+
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid "Effect or Command at %s failed to register:\n"
+"%s"
+msgstr "Non è stato possibile registrare l'effetto/comando in %s:\n"
 "%s"
 
 #: src/PluginStartupRegistration.cpp
@@ -5238,7 +5087,7 @@ msgstr "Imposta pa&gina..."
 #. i18n-hint: (verb) It's item on a menu.
 #: src/Printing.cpp
 msgid "&Print..."
-msgstr "&Stampa..."
+msgstr "Stam&pa..."
 
 #: src/ProjectAudioManager.cpp
 #, c-format
@@ -5256,12 +5105,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Frequenze di campionamento non corrispondenti"
 
 #: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
-msgid ""
-"Too few tracks are selected for recording at this sample rate.\n"
+msgid "Too few tracks are selected for recording at this sample rate.\n"
 "(Audacity requires two channels at the same sample rate for\n"
 "each stereo track)"
-msgstr ""
-"Sono state selezionate troppo poche tracce a questa frequenza di campionamento.\n"
+msgstr "Sono state selezionate troppo poche tracce a questa frequenza di campionamento.\n"
 "(Audacity richiede due canali alla stessa frequenza di campionamento per\n"
 "ciascuna traccia stereo)"
 
@@ -5269,7 +5116,8 @@ msgstr ""
 msgid "Too Few Compatible Tracks Selected"
 msgstr "Troppo poche tracce compatibili selezionate"
 
-#. i18n-hint a numerical suffix added to distinguish otherwise like-named clips when new record started
+#. i18n-hint a numerical suffix added to distinguish otherwise like-named
+#. clips when new record started
 #: src/ProjectAudioManager.cpp
 #, c-format
 msgctxt "clip name template"
@@ -5311,8 +5159,7 @@ msgstr "Analisi dei dati del file del progetto"
 
 #: src/ProjectFSCK.cpp
 #, c-format
-msgid ""
-"Project check of \"%s\" folder \n"
+msgid "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
 "('aliased files'). There is no way for Audacity \n"
 "to recover these files automatically. \n"
@@ -5327,8 +5174,7 @@ msgid ""
 "If you choose the third option, this will save the \n"
 "project in its current state, unless you \"Close \n"
 "project immediately\" on further error alerts."
-msgstr ""
-"Il controllo del progetto della cartella \"%s\" \n"
+msgstr "Il controllo del progetto della cartella \"%s\" \n"
 "ha rilevato %lld file audio esterni mancanti \n"
 "('File alias'). Audacity non è in grado \n"
 "di recuperare questi file in modo automatico. \n"
@@ -5358,13 +5204,11 @@ msgstr "Attenzione - File alias mancanti"
 
 #: src/ProjectFSCK.cpp
 #, c-format
-msgid ""
-"Project check of \"%s\" folder \n"
+msgid "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
 "Audacity can fully regenerate these files \n"
 "from the current audio in the project."
-msgstr ""
-"Il controllo del progetto nella cartella \"%s\" \n"
+msgstr "Il controllo del progetto nella cartella \"%s\" \n"
 "ha rilevato %lld blocchi di file alias (.auf) mancanti. \n"
 "Audacity può rigenerare completamente questi file \n"
 "partendo dall'audio attualmente nel progetto."
@@ -5387,8 +5231,7 @@ msgstr "Attenzione - File alias di riepilogo mancanti"
 
 #: src/ProjectFSCK.cpp
 #, c-format
-msgid ""
-"Project check of \"%s\" folder \n"
+msgid "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
 "deletion. There is no way for Audacity to recover \n"
@@ -5400,8 +5243,7 @@ msgid ""
 "\n"
 "Note that for the second option, the waveform \n"
 "may not show silence."
-msgstr ""
-"Il controllo del progetto della cartella \"%s\" \n"
+msgstr "Il controllo del progetto della cartella \"%s\" \n"
 "ha rilevato %lld blocchi di file dati audio (.au) mancanti, \n"
 "probabilmente a causa di un errore, di un crash di sistema, o di\n"
 "una cancellazione accidentale. Audacity non è in grado di\n"
@@ -5424,13 +5266,11 @@ msgstr "Attenzione - File di blocco dati audio mancanti"
 
 #: src/ProjectFSCK.cpp
 #, c-format
-msgid ""
-"Project check of \"%s\" folder \n"
+msgid "Project check of \"%s\" folder \n"
 "found %d orphan block file(s). These files are \n"
 "unused by this project, but might belong to other projects. \n"
 "They are doing no harm and are small."
-msgstr ""
-"Il controllo del progetto nella cartella \"%s\" \n"
+msgstr "Il controllo del progetto nella cartella \"%s\" \n"
 "ha trovato %d file di blocchi orfani. Questi file non sono \n"
 "utilizzati da questo progetto, ma potrebbero appartenere ad altri progetti. \n"
 "Non creano problemi e sono di piccole dimensioni."
@@ -5452,12 +5292,10 @@ msgid "Cleaning up unused directories in project data"
 msgstr "Pulizia delle cartelle inutilizzate nei dati del progetto"
 
 #: src/ProjectFSCK.cpp
-msgid ""
-"Project check found file inconsistencies during automatic recovery.\n"
+msgid "Project check found file inconsistencies during automatic recovery.\n"
 "\n"
 "Select 'Help > Diagnostics > Show Log...' to see details."
-msgstr ""
-"Il controllo del progetto ha trovato incoerenze durante il recupero automatico. \n"
+msgstr "Il controllo del progetto ha trovato incoerenze durante il recupero automatico. \n"
 "\n"
 "Selezionare 'Aiuto > Diagnostica > Mostra registro...' per vedere i dettagli."
 
@@ -5466,24 +5304,20 @@ msgid "Warning: Problems in Automatic Recovery"
 msgstr "Attenzione: problemi nel recupero automatico"
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+msgid "This project was not saved properly the last time Audacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
-msgstr ""
-"Questo progetto non è stato salvato correttamente\n"
+msgstr "Questo progetto non è stato salvato correttamente\n"
 "l'ultima volta che Audacity è stato eseguito.\n"
 "\n"
 "È stato ripristinato l'ultimo snapshot."
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+msgid "This project was not saved properly the last time Audacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
-msgstr ""
-"Questo progetto non è stato salvato correttamente\n"
+msgstr "Questo progetto non è stato salvato correttamente\n"
 "l'ultima volta che Audacity è stato eseguito.\n"
 "\n"
 "È stato ripristinato l'ultimo snapshot, ma è necessario salvarlo per mantenerne il contenuto."
@@ -5497,8 +5331,7 @@ msgid "Projects cannot be saved to FAT drives."
 msgstr "I progetti non possono essere salvati su dischi FAT."
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"Your project is now empty.\n"
+msgid "Your project is now empty.\n"
 "If saved, the project will have no tracks.\n"
 "\n"
 "To save any previously open tracks:\n"
@@ -5506,8 +5339,7 @@ msgid ""
 "are open, then File > Save Project.\n"
 "\n"
 "Save anyway?"
-msgstr ""
-"Il progetto ora è vuoto.\n"
+msgstr "Il progetto ora è vuoto.\n"
 "Se salvato, il progetto non conterrà tracce.\n"
 "\n"
 "Per salvare ogni traccia precedentemente aperta:\n"
@@ -5525,12 +5357,10 @@ msgid "Insufficient Disk Space"
 msgstr "Spazio disco insufficiente"
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"The project size exceeds the available free space on the target disk.\n"
+msgid "The project size exceeds the available free space on the target disk.\n"
 "\n"
 "Please select a different disk with more free space."
-msgstr ""
-"La dimensione del progetto supera lo spazio disponibile sul disco di destinazione.\n"
+msgstr "La dimensione del progetto supera lo spazio disponibile sul disco di destinazione.\n"
 "\n"
 "Selezionare un disco differente con più spazio libero."
 
@@ -5544,11 +5374,9 @@ msgid "Saved %s"
 msgstr "%s salvato"
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"The project was not saved because the file name provided would overwrite another project.\n"
+msgid "The project was not saved because the file name provided would overwrite another project.\n"
 "Please try again and select an original name."
-msgstr ""
-"Il progetto non è stato salvato poiché il nome di file fornito sovrascriverebbe un altro progetto.\n"
+msgstr "Il progetto non è stato salvato poiché il nome di file fornito sovrascriverebbe un altro progetto.\n"
 "Riprovare selezionando un nome originale."
 
 #: src/ProjectFileManager.cpp
@@ -5557,26 +5385,22 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sSalva progetto \"%s\" con nome..."
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+msgid "'Save Project' is for an Audacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
-msgstr ""
-"'Salva progetto' è per un progetto di Audacity, non per un file audio.\n"
+msgstr "'Salva progetto' è per un progetto di Audacity, non per un file audio.\n"
 "Per avere un file audio da aprire con altre applicazioni, usare 'Esporta'.\n"
 
 #. i18n-hint: In each case, %s is the name
 #. of the file being overwritten.
 #: src/ProjectFileManager.cpp
 #, c-format
-msgid ""
-"   Do you want to overwrite the project:\n"
+msgid "   Do you want to overwrite the project:\n"
 "\"%s\"?\n"
 "\n"
 "   If you select \"Yes\" the project\n"
 "\"%s\"\n"
 "   will be irreversibly overwritten."
-msgstr ""
-"   Sovrascrivere il progetto:\n"
+msgstr "   Sovrascrivere il progetto:\n"
 "\"%s\"?\n"
 "\n"
 "   Se si seleziona \"Sì\" il progetto\n"
@@ -5589,11 +5413,9 @@ msgid "Overwrite Project Warning"
 msgstr "Avviso sovrascrittura progetto"
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"The project was not saved because the selected project is open in another window.\n"
+msgid "The project was not saved because the selected project is open in another window.\n"
 "Please try again and select an original name."
-msgstr ""
-"Il progetto non è stato salvato poiché il progetto selezionato è aperto in un'altra finestra.\n"
+msgstr "Il progetto non è stato salvato poiché il progetto selezionato è aperto in un'altra finestra.\n"
 "Riprovare selezionando un nome di file non in uso."
 
 #: src/ProjectFileManager.cpp
@@ -5602,11 +5424,9 @@ msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "%sSalva copia del progetto\"%s\" come..."
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"Saving a copy must not overwrite an existing saved project.\n"
+msgid "Saving a copy must not overwrite an existing saved project.\n"
 "Please try again and select an original name."
-msgstr ""
-"Salvare una copia non deve sovrascrivere un progetto salvato esistente.\n"
+msgstr "Salvare una copia non deve sovrascrivere un progetto salvato esistente.\n"
 "Riprovare selezionando un nome originale."
 
 #: src/ProjectFileManager.cpp
@@ -5627,13 +5447,11 @@ msgid "Error Opening Project"
 msgstr "Errore durante l'apertura del progetto"
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"You are trying to open an automatically created backup file.\n"
+msgid "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
 "Please open the actual Audacity project file instead."
-msgstr ""
-"Si sta cercando di aprire un file di backup creato automaticamente.\n"
+msgstr "Si sta cercando di aprire un file di backup creato automaticamente.\n"
 "In questo modo si può avere una grave perdita di dati.\n"
 "\n"
 "Aprire invece il vero file di progetto di Audacity."
@@ -5652,11 +5470,9 @@ msgstr "Errore durante l'apertura del file"
 
 #: src/ProjectFileManager.cpp
 #, c-format
-msgid ""
-"File may be invalid or corrupted: \n"
+msgid "File may be invalid or corrupted: \n"
 "%s"
-msgstr ""
-"Il file può essere non valido o danneggiato: \n"
+msgstr "Il file può essere non valido o danneggiato: \n"
 "%s"
 
 #: src/ProjectFileManager.cpp
@@ -5664,11 +5480,9 @@ msgid "Error Opening File or Project"
 msgstr "Errore durante l'apertura del file o del progetto"
 
 #: src/ProjectFileManager.cpp
-msgid ""
-"Project resides on FAT formatted drive.\n"
+msgid "Project resides on FAT formatted drive.\n"
 "Copy it to another drive to open it."
-msgstr ""
-"Il progetto risiede su un disco formattato in formato FAT.\n"
+msgstr "Il progetto risiede su un disco formattato in formato FAT.\n"
 "Per aprirlo è necessario copiarlo su un altro disco."
 
 #: src/ProjectFileManager.cpp
@@ -5713,16 +5527,14 @@ msgstr "Comprimi progetto"
 
 #: src/ProjectFileManager.cpp
 #, c-format
-msgid ""
-"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+msgid "Compacting this project will free up disk space by removing unused bytes within the file.\n"
 "\n"
 "There is %s of free disk space and this project is currently using %s.\n"
 "\n"
 "If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
 "\n"
 "Do you want to continue?"
-msgstr ""
-"La compressione di questo progetto libererà spazio disco rimuovendo i byte del file non utilizzati.\n"
+msgstr "La compressione di questo progetto libererà spazio disco rimuovendo i byte del file non utilizzati.\n"
 "\n"
 "Il disco ha %s di spazio libero e questo progetto sta attualmente usando %s.\n"
 "\n"
@@ -5748,7 +5560,8 @@ msgstr "[Progetto %02i] "
 msgid "Welcome to Audacity version %s"
 msgstr "Benvenuto nella versione %s di Audacity"
 
-#. i18n-hint: The first %s numbers the project, the second %s is the project name.
+#. i18n-hint: The first %s numbers the project, the second %s is the project
+#. name.
 #: src/ProjectManager.cpp
 #, c-format
 msgid "%sSave changes to %s?"
@@ -5759,15 +5572,13 @@ msgid "Save project before closing?"
 msgstr "Salvare il progetto prima di chiudere?"
 
 #: src/ProjectManager.cpp
-msgid ""
-"\n"
+msgid "\n"
 "If saved, the project will have no tracks.\n"
 "\n"
 "To save any previously open tracks:\n"
 "Cancel, Edit > Undo until all tracks\n"
 "are open, then File > Save Project."
-msgstr ""
-"\n"
+msgstr "\n"
 "Se salvato, il progetto non conterrà alcuna traccia.\n"
 "\n"
 "Per salvare ogni traccia precedentemente aperta:\n"
@@ -5835,7 +5646,6 @@ msgstr "%s (mancante)"
 #. i18n-hint: undo history record
 #. first parameter - realtime effect name
 #. second parameter - track name
-#.
 #: src/RealtimeEffectPanel.cpp
 #, c-format
 msgid "Removed %s from %s"
@@ -5850,7 +5660,6 @@ msgstr "Rimuovi %s"
 
 #. i18n-hint: undo history,
 #. first and second parameters - realtime effect names
-#.
 #: src/RealtimeEffectPanel.cpp
 #, c-format
 msgid "Replaced %s with %s"
@@ -5880,7 +5689,6 @@ msgstr "Guarda video"
 #. i18n-hint: undo history record
 #. first parameter - realtime effect name
 #. second parameter - track name
-#.
 #: src/RealtimeEffectPanel.cpp
 #, c-format
 msgid "Moved %s up in %s"
@@ -5889,7 +5697,6 @@ msgstr "%s spostato su in %s"
 #. i18n-hint: undo history record
 #. first parameter - realtime effect name
 #. second parameter - track name
-#.
 #: src/RealtimeEffectPanel.cpp
 #, c-format
 msgid "Moved %s down in %s"
@@ -5916,20 +5723,18 @@ msgid "Realtime effects are non-destructive and can be changed at any time."
 msgstr "Gli effetti in tempo reale non sono distruttivi e possono essere modificati in qualsiasi momento."
 
 #: src/RealtimeEffectPanel.cpp src/effects/EffectUI.cpp
-msgid ""
-"This plugin could not be loaded.\n"
+msgid "This plugin could not be loaded.\n"
 "It may have been deleted."
-msgstr ""
+msgstr "Non è stato possibile caricare questa estensione.\n"
+"Potrebbe essere stata eliminata."
 
 #: src/RealtimeEffectPanel.cpp src/effects/EffectUI.cpp
-#, fuzzy
 msgid "Plugin Error"
-msgstr "Errore valore"
+msgstr "Errore estensione"
 
 #. i18n-hint: undo history record
 #. first parameter - realtime effect name
 #. second parameter - track name
-#.
 #: src/RealtimeEffectPanel.cpp
 #, c-format
 msgid "Added %s to %s"
@@ -6044,7 +5849,8 @@ msgid "Ruler"
 msgstr "Righello"
 
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
-#. * data associated with a time line, such as sequences of labels, and musical
+#. * data associated with a time line, such as sequences of labels, and
+#. musical
 #. * notes
 #: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
 #: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
@@ -6154,11 +5960,9 @@ msgid "Enable smart selection"
 msgstr "Abilita selezione intelligente"
 
 #: src/SpectralDataDialog.cpp
-msgid ""
-"Select the fundamental frequency\n"
+msgid "Select the fundamental frequency\n"
 "and release the mouse"
-msgstr ""
-"Selezionare la frequenza fondamentale\n"
+msgstr "Selezionare la frequenza fondamentale\n"
 "e rilasciare il mouse"
 
 #: src/SpectralDataDialog.cpp
@@ -6302,14 +6106,18 @@ msgstr "Tag dei metadati"
 msgid "&Metadata"
 msgstr "&Metadati"
 
-#. i18n-hint: This string is used to configure the controls which shows the recording
-#. * duration. As such it is important that only the alphabetic parts of the string
+#. i18n-hint: This string is used to configure the controls which shows the
+#. recording
+#. * duration. As such it is important that only the alphabetic parts of the
+#. string
 #. * are translated, with the numbers left exactly as they are.
-#. * The string 'days' indicates that the first number in the control will be the number of days,
-#. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
-#. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
+#. * The string 'days' indicates that the first number in the control will be
+#. the number of days,
+#. * then the 'h' indicates the second number displayed is hours, the 'm'
+#. indicates the third
+#. * number displayed is minutes, and the 's' indicates that the fourth number
+#. displayed is
 #. * seconds.
-#.
 #: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
 #: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
 #: src/effects/VST/VSTEffect.cpp src/effects/VST3/VST3Editor.cpp
@@ -6326,12 +6134,10 @@ msgid "Save Timer Recording As"
 msgstr "Salva registrazione programmata come"
 
 #: src/TimerRecordDialog.cpp
-msgid ""
-"The selected file name could not be used\n"
+msgid "The selected file name could not be used\n"
 "for Timer Recording because it would overwrite another project.\n"
 "Please try again and select an original name."
-msgstr ""
-"Il nome di file selezionato non può essere usato\n"
+msgstr "Il nome di file selezionato non può essere usato\n"
 "per la registrazione programmata poiché sovrascriverebbe un altro progetto.\n"
 "Riprovare selezionando un nome originale."
 
@@ -6365,15 +6171,13 @@ msgstr "Errore nell'esportazione automatica"
 
 #: src/TimerRecordDialog.cpp
 #, c-format
-msgid ""
-"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+msgid "You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
 "\n"
 "Do you wish to continue?\n"
 "\n"
 "Planned recording duration:   %s\n"
 "Recording time remaining on disk:   %s"
-msgstr ""
-"In base alle impostazioni attuali è possibile che non ci sia abbastanza spazio disco libero per completare questa registrazione programmata.\n"
+msgstr "In base alle impostazioni attuali è possibile che non ci sia abbastanza spazio disco libero per completare questa registrazione programmata.\n"
 "\n"
 "Procedere?\n"
 "\n"
@@ -6427,67 +6231,55 @@ msgstr "Registrazione programmata completata."
 
 #: src/TimerRecordDialog.cpp
 #, c-format
-msgid ""
-"%s\n"
+msgid "%s\n"
 "\n"
 "Recording saved: %s"
-msgstr ""
-"%s\n"
+msgstr "%s\n"
 "\n"
 "Registrazione salvata: %s"
 
 #: src/TimerRecordDialog.cpp
 #, c-format
-msgid ""
-"%s\n"
+msgid "%s\n"
 "\n"
 "Error saving recording."
-msgstr ""
-"%s\n"
+msgstr "%s\n"
 "\n"
 "Errore durante il salvataggio della registrazione."
 
 #: src/TimerRecordDialog.cpp
 #, c-format
-msgid ""
-"%s\n"
+msgid "%s\n"
 "\n"
 "Recording exported: %s"
-msgstr ""
-"%s\n"
+msgstr "%s\n"
 "\n"
 "Registrazione esportata: %s"
 
 #: src/TimerRecordDialog.cpp
 #, c-format
-msgid ""
-"%s\n"
+msgid "%s\n"
 "\n"
 "Error exporting recording."
-msgstr ""
-"%s\n"
+msgstr "%s\n"
 "\n"
 "Errore durante l'esportazione della registrazione."
 
 #: src/TimerRecordDialog.cpp
 #, c-format
-msgid ""
-"%s\n"
+msgid "%s\n"
 "\n"
 "'%s' has been canceled due to the error(s) noted above."
-msgstr ""
-"%s\n"
+msgstr "%s\n"
 "\n"
 "'%s' è stato annullato a causa degli errori riportati sopra."
 
 #: src/TimerRecordDialog.cpp
 #, c-format
-msgid ""
-"%s\n"
+msgid "%s\n"
 "\n"
 "'%s' has been canceled as the recording was stopped."
-msgstr ""
-"%s\n"
+msgstr "%s\n"
 "\n"
 "'%s' è stato annullato poiché la registrazione è stata interrotta."
 
@@ -6505,12 +6297,15 @@ msgstr "099 h 060 m 060 s"
 msgid "099 days 024 h 060 m 060 s"
 msgstr "099 giorni 024 h 060 m 060 s"
 
-#. i18n-hint: This string is used to configure the controls for times when the recording is
-#. * started and stopped. As such it is important that only the alphabetic parts of the string
+#. i18n-hint: This string is used to configure the controls for times when the
+#. recording is
+#. * started and stopped. As such it is important that only the alphabetic
+#. parts of the string
 #. * are translated, with the numbers left exactly as they are.
-#. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
-#. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
-#.
+#. * The 'h' indicates the first number displayed is hours, the 'm' indicates
+#. the second number
+#. * displayed is minutes, and the 's' indicates that the third number
+#. displayed is seconds.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data e ora di inizio"
@@ -6555,8 +6350,8 @@ msgstr "Abilitare l'&esportazione automatica?"
 msgid "Export Project As:"
 msgstr "Esporta progetto con nome:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
-#: src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opzioni"
 
@@ -6623,22 +6418,18 @@ msgid "Audacity Timer Record - Waiting"
 msgstr "Registrazione programmata di Audacity - In attesa"
 
 #: src/TimerRecordDialog.cpp
-msgid ""
-"Timer Recording cannot be used with more than one open project.\n"
+msgid "Timer Recording cannot be used with more than one open project.\n"
 "\n"
 "Please close any additional projects and try again."
-msgstr ""
-"La registrazione programmata non può essere usata con più di un progetto aperto.\n"
+msgstr "La registrazione programmata non può essere usata con più di un progetto aperto.\n"
 "\n"
 "Chiudere eventuali altri progetti e riprovare."
 
 #: src/TimerRecordDialog.cpp
-msgid ""
-"Timer Recording cannot be used while you have unsaved changes.\n"
+msgid "Timer Recording cannot be used while you have unsaved changes.\n"
 "\n"
 "Please save or close this project and try again."
-msgstr ""
-"La registrazione programmata non può essere usata quando vi sono modifiche non salvate.\n"
+msgstr "La registrazione programmata non può essere usata quando vi sono modifiche non salvate.\n"
 "\n"
 "Salvare o chiudere questo progetto e riprovare."
 
@@ -6768,14 +6559,16 @@ msgstr "Sposta traccia in alto"
 msgid "Move Track Down"
 msgstr "Sposta traccia in basso"
 
-#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
+#. i18n-hint: These are strings for the status bar, and indicate whether
+#. Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
 #: src/TransportUtilities.cpp src/toolbars/ControlToolBar.cpp
 msgid "Playing"
 msgstr "Riproduzione"
 
-#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
+#. i18n-hint: These are strings for the status bar, and indicate whether
+#. Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
 #: src/TransportUtilities.cpp src/prefs/MidiIOPrefs.cpp
@@ -6796,7 +6589,8 @@ msgstr "La selezione è troppo piccola per usare la voce chiave."
 msgid "Calibration Results\n"
 msgstr "Risultati calibrazione\n"
 
-#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard
+#. Deviations'
 #: src/VoiceKey.cpp
 #, c-format
 msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
@@ -6931,12 +6725,10 @@ msgstr "Premere \"Continua\" per fare l'upload su audio.com"
 
 #: src/cloud/audiocom/ShareAudioDialog.cpp
 #, c-format
-msgid ""
-"Your audio will be uploaded to our sharing service: %s,%%which requires a free account to use.\n"
+msgid "Your audio will be uploaded to our sharing service: %s,%%which requires a free account to use.\n"
 "\n"
 "If you have problems uploading, try the Link Account button."
-msgstr ""
-"L'audio verrà caricato sul nostro servizio di condivisione: %s,%%che richiede un account gratuito per essere utilizzato.\n"
+msgstr "L'audio verrà caricato sul nostro servizio di condivisione: %s,%%che richiede un account gratuito per essere utilizzato.\n"
 "\n"
 "In caso di problemi con l'upload, provare a premere il pulsante Collega account."
 
@@ -6956,7 +6748,8 @@ msgstr "Preparazione dell'audio in corso..."
 msgid "Shareable link"
 msgstr "Collegamento da condividere"
 
-#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#. i18n-hint: An item name followed by a value, with appropriate separating
+#. punctuation
 #: src/commands/AudacityCommand.cpp src/effects/EffectUIServices.cpp
 #: src/effects/EqualizationCurves.cpp src/effects/vamp/VampEffect.cpp
 #: src/import/ImportRaw.cpp src/menus/MenuHelper.cpp
@@ -6992,11 +6785,9 @@ msgstr "Comando"
 
 #: src/commands/CommandManager.cpp
 #, c-format
-msgid ""
-"\n"
+msgid "\n"
 "* %s, because you have assigned the shortcut %s to %s"
-msgstr ""
-"\n"
+msgstr "\n"
 "* %s, in quanto hai assegnato la combinazione di tasti %s a %s"
 
 #: src/commands/CommandManager.cpp
@@ -7723,9 +7514,8 @@ msgstr "Imposta aspetto traccia"
 #. i18n-hint: abbreviates amplitude
 #: src/commands/SetTrackInfoCommand.cpp src/prefs/TracksPrefs.cpp
 #: src/prefs/WaveformSettings.cpp
-#, fuzzy
 msgid "Linear (amp)"
-msgstr "Lineare in ingresso"
+msgstr "Lineare (amp)"
 
 #. i18n-hint: abbreviates decibels
 #: src/commands/SetTrackInfoCommand.cpp src/prefs/TracksPrefs.cpp
@@ -7736,9 +7526,8 @@ msgstr "Logaritmica (dB)"
 #. i18n-hint: abbreviates decibels
 #: src/commands/SetTrackInfoCommand.cpp src/prefs/TracksPrefs.cpp
 #: src/prefs/WaveformSettings.cpp
-#, fuzzy
 msgid "Linear (dB)"
-msgstr "Lineare"
+msgstr "Lineare (dB)"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
@@ -7842,14 +7631,16 @@ msgstr "Riduzione automatica volume"
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "Riduci il volume di una o più tracce se il volume di uno specificato traccia \"di controllo\" raggiunge un particolare livello"
 
-#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the
+#. volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
 #: src/effects/AutoDuck.cpp
 msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
 msgstr "La traccia selezionata non contiene audio. L'effetto Riduci volume automaticamente può elaborare solo tracce audio."
 
-#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the
+#. volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
 #: src/effects/AutoDuck.cpp
@@ -8106,7 +7897,8 @@ msgstr "Regola la velocità, cambiando tempo e intonazione"
 msgid "&Speed Multiplier:"
 msgstr "Moltiplicatore di &velocità:"
 
-#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per
+#. minute".
 #. "vinyl" refers to old-fashioned phonograph records
 #: src/effects/ChangeSpeed.cpp
 msgid "Standard Vinyl rpm:"
@@ -8114,7 +7906,6 @@ msgstr "Giri/minuto vinile:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
-#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Da g/m"
@@ -8127,7 +7918,6 @@ msgstr "&da"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
-#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "A g/m"
@@ -8341,20 +8131,23 @@ msgid "Attack Time"
 msgstr "Tempo di attacco"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
-#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release'
+#. where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "Tempo di &rilascio:"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
-#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release'
+#. where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "Release Time"
 msgstr "Tempo di rilascio"
 
-#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate
+#. it.
 #: src/effects/Compressor.cpp
 msgid "Ma&ke-up gain for 0 dB after compressing"
 msgstr "Componi guadagno per 0 dB dopo la compressione"
@@ -8394,19 +8187,15 @@ msgid "Please select an audio track."
 msgstr "Selezionare una traccia audio."
 
 #: src/effects/Contrast.cpp
-msgid ""
-"Invalid audio selection.\n"
+msgid "Invalid audio selection.\n"
 "Please ensure that audio is selected."
-msgstr ""
-"Selezione audio non valida.\n"
+msgstr "Selezione audio non valida.\n"
 "Accertarsi che l'audio sia selezionato."
 
 #: src/effects/Contrast.cpp
-msgid ""
-"Nothing to measure.\n"
+msgid "Nothing to measure.\n"
 "Please select a section of a track."
-msgstr ""
-"Nulla da misurare.\n"
+msgstr "Nulla da misurare.\n"
 "Selezionare una sezione di una traccia."
 
 #. i18n-hint: RMS abbreviates root mean square, a certain averaging method
@@ -8537,7 +8326,8 @@ msgstr "Livello di sfondo troppo alto"
 msgid "Background higher than foreground"
 msgstr "Fondo più alto del primo piano"
 
-#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0',
+#. see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
 msgid "WCAG2 Pass"
 msgstr "WCAG2 superato"
@@ -8899,11 +8689,9 @@ msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by t
 msgstr "Genera toni multifrequenza (DTMF - dual-tone multi-frequency) come quelli prodotti dalla tastiera dei telefoni"
 
 #: src/effects/DtmfGen.cpp
-msgid ""
-"DTMF sequence empty.\n"
+msgid "DTMF sequence empty.\n"
 "Check ALL settings for this effect."
-msgstr ""
-"Sequenza DTMF vuota.\n"
+msgstr "Sequenza DTMF vuota.\n"
 "Verificate TUTTE le impostazioni di questo effetto."
 
 #: src/effects/DtmfGen.cpp
@@ -9010,14 +8798,12 @@ msgstr "Predefiniti di fabbrica"
 
 #: src/effects/EffectManager.cpp
 #, c-format
-msgid ""
-"Attempting to initialize the following effect failed:\n"
+msgid "Attempting to initialize the following effect failed:\n"
 "\n"
 "%s\n"
 "\n"
 "More information may be available in 'Help > Diagnostics > Show Log'"
-msgstr ""
-"Il tentativo di inizializzare il seguente effetto è fallito:\n"
+msgstr "Il tentativo di inizializzare il seguente effetto è fallito:\n"
 "\n"
 "%s\n"
 "\n"
@@ -9030,14 +8816,12 @@ msgstr "Impossibile inizializzare l'effetto"
 
 #: src/effects/EffectManager.cpp
 #, c-format
-msgid ""
-"Attempting to initialize the following command failed:\n"
+msgid "Attempting to initialize the following command failed:\n"
 "\n"
 "%s\n"
 "\n"
 "More information may be available in 'Help > Diagnostics > Show Log'"
-msgstr ""
-"Il tentativo di inizializzare il seguente comando è fallito:\n"
+msgstr "Il tentativo di inizializzare il seguente comando è fallito:\n"
 "\n"
 "%s\n"
 "\n"
@@ -9141,12 +8925,10 @@ msgid "You must specify a name"
 msgstr "È necessario specificare un nome"
 
 #: src/effects/EffectUI.cpp
-msgid ""
-"Preset already exists.\n"
+msgid "Preset already exists.\n"
 "\n"
 "Replace?"
-msgstr ""
-"Combinazione già esistente.\n"
+msgstr "Combinazione già esistente.\n"
 "\n"
 "Sostituirla?"
 
@@ -9218,15 +9000,13 @@ msgstr "Effetto non disponibile"
 
 #: src/effects/Equalization48x.cpp
 #, c-format
-msgid ""
-"Benchmark times:\n"
+msgid "Benchmark times:\n"
 "Original: %s\n"
 "Default Segmented: %s\n"
 "Default Threaded: %s\n"
 "SSE: %s\n"
 "SSE Threaded: %s\n"
-msgstr ""
-"Tempi di benchmark:\n"
+msgstr "Tempi di benchmark:\n"
 "Originale: %s\n"
 "Predefinito segmentato: %s\n"
 "Predefinito con thread: %s\n"
@@ -9243,7 +9023,8 @@ msgstr "%d Hz"
 msgid "%g kHz"
 msgstr "%g kHz"
 
-#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in
+#. translation.
 #: src/effects/EqualizationBandSliders.cpp
 #, c-format
 msgid "%gk"
@@ -9263,13 +9044,11 @@ msgstr "senza nome"
 #. i18n-hint: EQ stands for 'Equalization'.
 #: src/effects/EqualizationCurves.cpp
 #, c-format
-msgid ""
-"Error Loading EQ Curves from file:\n"
+msgid "Error Loading EQ Curves from file:\n"
 "%s\n"
 "Error message says:\n"
 "%s"
-msgstr ""
-"Errore nel caricamento delle curve EQ da file:\n"
+msgstr "Errore nel caricamento delle curve EQ da file:\n"
 "%s\n"
 "Il messaggio di errore dice:\n"
 "%s"
@@ -9311,11 +9090,9 @@ msgid "De&faults"
 msgstr "Prede&finiti"
 
 #: src/effects/EqualizationCurvesDialog.cpp
-msgid ""
-"Rename 'unnamed' to save a new entry.\n"
+msgid "Rename 'unnamed' to save a new entry.\n"
 "'OK' saves all changes, 'Cancel' doesn't."
-msgstr ""
-"Rinomina 'senza nome' per salvare una nuova voce.\n"
+msgstr "Rinomina 'senza nome' per salvare una nuova voce.\n"
 "'OK' per salvare tutte le modifiche, 'Annulla' per annullarle."
 
 #: src/effects/EqualizationCurvesDialog.cpp
@@ -9426,11 +9203,9 @@ msgid "Cubic"
 msgstr "Cubico"
 
 #: src/effects/EqualizationUI.cpp
-msgid ""
-"To use this filter curve in a macro, please choose a new name for it.\n"
+msgid "To use this filter curve in a macro, please choose a new name for it.\n"
 "Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
-msgstr ""
-"Per usare questa curva filtrante in una macro, selezionare un nuovo nome per essa.\n"
+msgstr "Per usare questa curva filtrante in una macro, selezionare un nuovo nome per essa.\n"
 "Selezionare il pulsante 'Salva/gestisci curve...' e rinominare la curva 'senza nome', quindi usarla."
 
 #: src/effects/EqualizationUI.cpp
@@ -9769,11 +9544,9 @@ msgid "Step 1"
 msgstr "Passo 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
-msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+msgid "Select a few seconds of just noise so Audacity knows what to filter out,\n"
 "then click Get Noise Profile:"
-msgstr ""
-"Selezionare pochi secondi del rumore in modo che Audacity riconosca quello va filtrato,\n"
+msgstr "Selezionare pochi secondi del rumore in modo che Audacity riconosca quello va filtrato,\n"
 "quindi fare clic su Elabora profilo rumore:"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
@@ -9785,11 +9558,9 @@ msgid "Step 2"
 msgstr "Passo 2"
 
 #: src/effects/NoiseReduction.cpp
-msgid ""
-"Select all of the audio you want filtered, choose how much noise you want\n"
+msgid "Select all of the audio you want filtered, choose how much noise you want\n"
 "filtered out, and then click 'OK' to reduce noise.\n"
-msgstr ""
-"Selezionare tutto l'audio da filtrare, indicare quanto rumore deve essere\n"
+msgstr "Selezionare tutto l'audio da filtrare, indicare quanto rumore deve essere\n"
 "filtrato, quindi fare clic su 'OK' per ridurre il rumore.\n"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
@@ -9805,7 +9576,8 @@ msgstr "Ri&duci"
 msgid "&Isolate"
 msgstr "&Isola"
 
-#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#. i18n-hint: Means the difference between effect and original sound.
+#. Translate differently from "Reduce" !
 #: src/effects/NoiseReduction.cpp
 msgid "Resid&ue"
 msgstr "Resid&uo"
@@ -9896,11 +9668,9 @@ msgid "Removes constant background noise such as fans, tape noise, or hums"
 msgstr "Rimuove rumori costanti di fondo come fruscii, rumore di nastro, o ronzii"
 
 #: src/effects/NoiseRemoval.cpp
-msgid ""
-"Select all of the audio you want filtered, choose how much noise you want\n"
+msgid "Select all of the audio you want filtered, choose how much noise you want\n"
 "filtered out, and then click 'OK' to remove noise.\n"
-msgstr ""
-"Selezionare tutto l'audio da filtrare, scegliere la quantità di rumore da\n"
+msgstr "Selezionare tutto l'audio da filtrare, scegliere la quantità di rumore da\n"
 "filtrare, quindi fare clic su 'OK' per eliminare il rumore.\n"
 
 #: src/effects/NoiseRemoval.cpp
@@ -9982,7 +9752,7 @@ msgstr "&Rimuovi offset DC (centra su 0,0 verticalmente)"
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
-msgstr "&Normalizza ampiezza picco a"
+msgstr "&Normalizza ampiezza picco a   "
 
 #: src/effects/Normalize.cpp
 msgid "Peak amplitude dB"
@@ -10003,7 +9773,6 @@ msgstr "Usa Paulstretch solo per un estremo allungamento temporale o un effetto 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
-#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Fa&ttore di allungamento:"
@@ -10012,44 +9781,41 @@ msgstr "Fa&ttore di allungamento:"
 msgid "&Time Resolution (seconds):"
 msgstr "Risoluzione &temporale (secondi):"
 
-#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch
+#. effect.
 #: src/effects/Paulstretch.cpp
 #, c-format
-msgid ""
-"Audio selection too short to preview.\n"
+msgid "Audio selection too short to preview.\n"
 "\n"
 "Try increasing the audio selection to at least %.1f seconds,\n"
 "or reducing the 'Time Resolution' to less than %.1f seconds."
-msgstr ""
-"L'audio selezionato è troppo breve per l'anteprima.\n"
+msgstr "L'audio selezionato è troppo breve per l'anteprima.\n"
 "\n"
 "Provare ad aumentare l'audio selezionato ad almeno %.1f secondi,\n"
 "o a ridurre la risoluzione temporale a meno di %.1f secondi."
 
-#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch
+#. effect.
 #: src/effects/Paulstretch.cpp
 #, c-format
-msgid ""
-"Unable to Preview.\n"
+msgid "Unable to Preview.\n"
 "\n"
 "For the current audio selection, the maximum\n"
 "'Time Resolution' is %.1f seconds."
-msgstr ""
-"Anteprima impossibile\n"
+msgstr "Anteprima impossibile\n"
 "\n"
 "Per l'audio attualmente selezionato la massima\n"
 "risoluzione temporale è di %.1f secondi."
 
-#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch
+#. effect.
 #: src/effects/Paulstretch.cpp
 #, c-format
-msgid ""
-"The 'Time Resolution' is too long for the selection.\n"
+msgid "The 'Time Resolution' is too long for the selection.\n"
 "\n"
 "Try increasing the audio selection to at least %.1f seconds,\n"
 "or reducing the 'Time Resolution' to less than %.1f seconds."
-msgstr ""
-"La risoluzione temporale è troppo lunga per la selezione.\n"
+msgstr "La risoluzione temporale è troppo lunga per la selezione.\n"
 "\n"
 "Provare ad aumentare l'audio selezionato ad almeno %.1f secondi,\n"
 "o a ridurre la risoluzione temporale a meno di %.1f secondi."
@@ -10133,24 +9899,20 @@ msgid "Sets the peak amplitude of a one or more tracks"
 msgstr "Imposta l'ampiezza di picco di una o più tracce"
 
 #: src/effects/Repair.cpp
-msgid ""
-"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+msgid "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
 "Zoom in and select a tiny fraction of a second to repair."
-msgstr ""
-"L'effetto ripara è studiato per essere utilizzato su sezioni molto brevi di audio danneggiato (fino a 128 campioni).\n"
+msgstr "L'effetto ripara è studiato per essere utilizzato su sezioni molto brevi di audio danneggiato (fino a 128 campioni).\n"
 " \n"
 "Fare lo zoom in avanti e selezionare una piccola frazione di secondo da riparare."
 
 #: src/effects/Repair.cpp
-msgid ""
-"Repair works by using audio data outside the selection region.\n"
+msgid "Repair works by using audio data outside the selection region.\n"
 "\n"
 "Please select a region that has audio touching at least one side of it.\n"
 "\n"
 "The more surrounding audio, the better it performs."
-msgstr ""
-"La funzione ripara lavora utilizzando dati audio al di fuori della regione selezionata.\n"
+msgstr "La funzione ripara lavora utilizzando dati audio al di fuori della regione selezionata.\n"
 "\n"
 "Selezionare una zona che abbia un segnale audio a contatto con almeno uno dei suoi lati.\n"
 "\n"
@@ -10286,17 +10048,20 @@ msgstr "Inverti l'audio selezionato"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Tempo SBSMS / stiramento intonazione"
 
-#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#. i18n-hint: Butterworth is the name of the person after whom the filter type
+#. is named.
 #: src/effects/ScienFilter.cpp
 msgid "Butterworth"
 msgstr "Butterworth"
 
-#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type
+#. is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
 msgstr "Chebyshev tipo I"
 
-#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type
+#. is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type II"
 msgstr "Chebyshev tipo II"
@@ -10326,7 +10091,8 @@ msgstr "Per applicare un filtro, tutte le tracce selezionate devono avere la ste
 msgid "&Filter Type:"
 msgstr "Tipo &filtro:"
 
-#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number
+#. between 1 and 10.
 #: src/effects/ScienFilter.cpp
 msgid "O&rder:"
 msgstr "O&rdine:"
@@ -10395,32 +10161,40 @@ msgstr "Soglia silenzio:"
 msgid "Silence Threshold"
 msgstr "Soglia silenzio"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than
+#. 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the
+#. user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
 msgstr "Tempo di pre-smorzamento:"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than
+#. 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the
+#. user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time"
 msgstr "Tempo di pre-smorzamento"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than
+#. 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the
+#. user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Line Time:"
 msgstr "Linea tempo:"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than
+#. 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the
+#. user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
@@ -10431,8 +10205,10 @@ msgstr "Linea tempo"
 msgid "Smooth Time:"
 msgstr "Tempo smorzamento:"
 
-#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
-#. This is a NEW experimental effect, and until we have it documented in the user
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than
+#. 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the
+#. user
 #. manual we don't have a clear description of what this parameter does.
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
@@ -10756,7 +10532,8 @@ msgstr "Non è stato possibile leggere il file delle combinazioni."
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Questo file di parametri è stato salvato da %s. Procedere?"
 
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software
+#. protocol
 #. developed by Steinberg GmbH
 #: src/effects/VST/VSTEffect.h
 msgid "VST"
@@ -10830,12 +10607,10 @@ msgstr "File di combinazioni Audio Unit standard"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
-msgid ""
-"Could not export \"%s\" preset\n"
+msgid "Could not export \"%s\" preset\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato possibile esportare la combinazione \"%s\"\n"
+msgstr "Non è stato possibile esportare la combinazione \"%s\"\n"
 "\n"
 "%s"
 
@@ -10850,12 +10625,10 @@ msgstr "Importa combinazione Audio Unit come %s:"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
-msgid ""
-"Could not import \"%s\" preset\n"
+msgid "Could not import \"%s\" preset\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato pissibile importare la combinazione \"%s\"\n"
+msgstr "Non è stato pissibile importare la combinazione \"%s\"\n"
 "\n"
 "%s"
 
@@ -10971,7 +10744,6 @@ msgstr "I dati XML sono vuoti dopo la conversione"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
-#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Effetti LADSPA"
@@ -10992,8 +10764,10 @@ msgstr "Opzioni effetti LADSPA"
 msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Come parte del loro processo, alcuni effetti LADSPA ritardano l'audio restituito ad Audacity. Quando questo ritardo non è compensato verranno inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione per fornire questa compensazione; notare che tuttavia potrebbe non funzionare con tutti gli effetti LADSPA."
 
-#. i18n-hint: An item name introducing a value, which is not part of the string but
-#. appears in a following text box window; translate with appropriate punctuation
+#. i18n-hint: An item name introducing a value, which is not part of the
+#. string but
+#. appears in a following text box window; translate with appropriate
+#. punctuation
 #: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
 #: src/effects/vamp/VampEffect.cpp
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -11007,7 +10781,6 @@ msgstr "Uscita effetto"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
-#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "LADSPA"
@@ -11063,7 +10836,8 @@ msgstr "Fornisce ad Audacity il supporto agli effetti Nyquist"
 msgid "Applying Nyquist Effect..."
 msgstr "Applicazione dell'effetto Nyquist..."
 
-#. i18n-hint: It is acceptable to translate this the same as for "Nyquist Prompt"
+#. i18n-hint: It is acceptable to translate this the same as for "Nyquist
+#. Prompt"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist Worker"
 msgstr "Operatore Nyquist"
@@ -11073,20 +10847,16 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Intestazione dell'estensione Nyquist con formato non valido"
 
 #: src/effects/nyquist/Nyquist.cpp
-msgid ""
-"Enable track spectrogram view before\n"
+msgid "Enable track spectrogram view before\n"
 "applying 'Spectral' effects."
-msgstr ""
-"Abilitare la vista traccia spettrogramma\n"
+msgstr "Abilitare la vista traccia spettrogramma\n"
 "prima di applicare gli effetti \"Spettrale\"."
 
 #: src/effects/nyquist/Nyquist.cpp
-msgid ""
-"To use 'Spectral effects', enable 'Spectral Selection'\n"
+msgid "To use 'Spectral effects', enable 'Spectral Selection'\n"
 "in the track Spectrogram settings and select the\n"
 "frequency range for the effect to act on."
-msgstr ""
-"Per usare 'Effetti spettrali', abilitare 'Selezione spettrale'\n"
+msgstr "Per usare 'Effetti spettrali', abilitare 'Selezione spettrale'\n"
 "nelle impostazioni traccia spettrogramma e seleziona\n"
 "l'intervallo frequenza per l'effetto ad agire."
 
@@ -11109,12 +10879,10 @@ msgstr "Non è possibile applicare effetti sulle tracce stereo quando i canali i
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
-msgid ""
-"Selection too long for Nyquist code.\n"
+msgid "Selection too long for Nyquist code.\n"
 "Maximum allowed selection is %ld samples\n"
 "(about %.1f hours at 44100 Hz sample rate)."
-msgstr ""
-"Selezione troppo lunga per il codice Nyquist.\n"
+msgstr "Selezione troppo lunga per il codice Nyquist.\n"
 "La selezione massima permessa è %ld campioni\n"
 "(circa %.1f ore a una frequenza di campionamento di 44100 Hz)."
 
@@ -11190,15 +10958,13 @@ msgid "Could not open file"
 msgstr "Impossibile aprire il file"
 
 #: src/effects/nyquist/Nyquist.cpp
-msgid ""
-"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+msgid "Your code looks like SAL syntax, but there is no 'return' statement.\n"
 "For SAL, use a return statement such as:\n"
 "\treturn *track* * 0.1\n"
 "or for LISP, begin with an open parenthesis such as:\n"
 "\t(mult *track* 0.1)\n"
 " ."
-msgstr ""
-"Sembra che il codice usi una sintassi SAL, ma non c'è alcuna istruzione 'return'.\n"
+msgstr "Sembra che il codice usi una sintassi SAL, ma non c'è alcuna istruzione 'return'.\n"
 "Per SAL, usa un'istruzione return come ad esempio:\n"
 "\treturn *track* * 0.1\n"
 "o per LISP, iniziare con una parentesi aperta come ad esempio:\n"
@@ -11222,11 +10988,9 @@ msgstr "\"%s\" non è un percorso di file valido."
 #. i18n-hint: Warning that there is one quotation mark rather than a pair.
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
-msgid ""
-"Mismatched quotes in\n"
+msgid "Mismatched quotes in\n"
 "%s"
-msgstr ""
-"Apici non corrispondenti in\n"
+msgstr "Apici non corrispondenti in\n"
 "%s"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -11248,11 +11012,9 @@ msgid "Lisp scripts"
 msgstr "Script List"
 
 #: src/effects/nyquist/Nyquist.cpp
-msgid ""
-"Current program has been modified.\n"
+msgid "Current program has been modified.\n"
 "Discard changes?"
-msgstr ""
-"Il programma corrente è stato modificato.\n"
+msgstr "Il programma corrente è stato modificato.\n"
 "Scartare le modifiche?"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -11265,11 +11027,9 @@ msgstr "Impossibile salvare il file"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
-msgid ""
-"Value range:\n"
+msgid "Value range:\n"
 "%s to %s"
-msgstr ""
-"Intervallo valore:\n"
+msgstr "Intervallo valore:\n"
 "da %s a %s"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -11317,7 +11077,8 @@ msgstr "Impostazioni estensione"
 msgid "Program"
 msgstr "Programma"
 
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. i18n-hint: Vamp is the proper name of a software protocol for sound
+#. analysis.
 #. It is not an abbreviation for anything.  See http://vamp-plugins.org
 #: src/effects/vamp/VampEffect.h
 msgid "Vamp"
@@ -11350,14 +11111,12 @@ msgstr "Esportare il file come \"%s\"?\n"
 
 #: src/export/Export.cpp
 #, c-format
-msgid ""
-"You are about to export a %s file with the name \"%s\".\n"
+msgid "You are about to export a %s file with the name \"%s\".\n"
 "\n"
 "Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
 "\n"
 "Are you sure you want to export the file under this name?"
-msgstr ""
-"Si sta per esportare file %s con il nome \"%s\".\n"
+msgstr "Si sta per esportare file %s con il nome \"%s\".\n"
 "\n"
 "Normalmente questi file terminano con \".%s\", e alcuni programmi non apriranno i file con estensioni non standard.\n"
 "\n"
@@ -11420,11 +11179,9 @@ msgstr "Pannello mixer"
 
 #: src/export/Export.cpp
 #, c-format
-msgid ""
-"Unable to export.\n"
+msgid "Unable to export.\n"
 "Error %s"
-msgstr ""
-"Impossibile esportare.\n"
+msgstr "Impossibile esportare.\n"
 "Errore %s"
 
 #: src/export/ExportCL.cpp
@@ -11434,7 +11191,8 @@ msgstr "Mostra output"
 #. i18n-hint: Some programmer-oriented terminology here:
 #. "Data" refers to the sound to be exported, "piped" means sent,
 #. and "standard in" means the default input stream that the external program,
-#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually
+#. used
 #. in the program as a format string.  Keep %f unchanged.
 #: src/export/ExportCL.cpp
 #, c-format
@@ -11494,11 +11252,9 @@ msgid "Unable to locate \"%s\" in your path."
 msgstr "Non è stato possibile trovare \"%s\" tra i tuoi percorsi."
 
 #: src/export/ExportFFmpeg.cpp
-msgid ""
-"Properly configured FFmpeg is required to proceed.\n"
+msgid "Properly configured FFmpeg is required to proceed.\n"
 "You can configure it at Preferences > Libraries."
-msgstr ""
-"Per procedere è necessaria una corretta configurazione di FFmpeg.\n"
+msgstr "Per procedere è necessaria una corretta configurazione di FFmpeg.\n"
 "È possibile configurarlo in Preferenze > Librerie."
 
 #: src/export/ExportFFmpeg.cpp
@@ -11532,11 +11288,9 @@ msgstr "FFmpeg : ERRORE - Impossibile scrivere le intestazioni nel file di outpu
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
 #, c-format
-msgid ""
-"FFmpeg cannot find audio codec 0x%x.\n"
+msgid "FFmpeg cannot find audio codec 0x%x.\n"
 "Support for this codec is probably not compiled in."
-msgstr ""
-"FFmpeg non può trovare il codec audio 0x%x.\n"
+msgstr "FFmpeg non può trovare il codec audio 0x%x.\n"
 "Il supporto per questo codec probabilmente non è stato compilato."
 
 #: src/export/ExportFFmpeg.cpp
@@ -11550,12 +11304,10 @@ msgstr "Il codec ha segnalato un parametro non valido (EINVAL)"
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
 #, c-format
-msgid ""
-"Can't open audio codec \"%s\" (0x%x)\n"
+msgid "Can't open audio codec \"%s\" (0x%x)\n"
 "\n"
 "%s"
-msgstr ""
-"Non è possibile aprire il codec audio \"%s\" (0x%x)\n"
+msgstr "Non è possibile aprire il codec audio \"%s\" (0x%x)\n"
 "\n"
 "%s"
 
@@ -11621,20 +11373,16 @@ msgstr "Ricampiona"
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
-msgid ""
-"The project sample rate (%d) is not supported by the current output\n"
+msgid "The project sample rate (%d) is not supported by the current output\n"
 "file format. "
-msgstr ""
-"La frequenza di campionamento (%d) del progetto non è supportata dall'attuale\n"
+msgstr "La frequenza di campionamento (%d) del progetto non è supportata dall'attuale\n"
 "formato del file di destinazione. "
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
-msgid ""
-"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+msgid "The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
 "supported by the current output file format. "
-msgstr ""
-"La combinazione della frequenza di campionamento (%d) e del bit rate (%d kbps) del progetto non è\n"
+msgstr "La combinazione della frequenza di campionamento (%d) e del bit rate (%d kbps) del progetto non è\n"
 "supportata dall'attuale formato del file di destinazione. "
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
@@ -11934,12 +11682,10 @@ msgid "General Options"
 msgstr "Opzioni generali"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"ISO 639 3-letter language code\n"
+msgid "ISO 639 3-letter language code\n"
 "Optional\n"
 "empty - automatic"
-msgstr ""
-"Codice lingua a 3 lettere ISO 639\n"
+msgstr "Codice lingua a 3 lettere ISO 639\n"
 "Opzionale\n"
 "vuoto - automatica"
 
@@ -11957,12 +11703,10 @@ msgstr "VBL"
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Codec tag (FOURCC)\n"
+msgid "Codec tag (FOURCC)\n"
 "Optional\n"
 "empty - automatic"
-msgstr ""
-"Tag del codec (FOURCC)\n"
+msgstr "Tag del codec (FOURCC)\n"
 "Opzionale\n"
 "vuoto - automatico"
 
@@ -11971,25 +11715,21 @@ msgid "Tag:"
 msgstr "Tag:"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+msgid "Bit Rate (bits/second) - influences the resulting file size and quality\n"
 "Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
 "0 - automatic\n"
 "Recommended - 192000"
-msgstr ""
-"Bit rate (bit/secondo) - influenza la dimensione file e la qualità risultanti\n"
+msgstr "Bit rate (bit/secondo) - influenza la dimensione file e la qualità risultanti\n"
 "Alcuni codec possono accettare solo specifici valori (128k, 192k, 256k ecc.)\n"
 "0 - automatico\n"
 "Raccomandato - 192000"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Overall quality, used differently by different codecs\n"
+msgid "Overall quality, used differently by different codecs\n"
 "Required for vorbis\n"
 "0 - automatic\n"
 "-1 - off (use bitrate instead)"
-msgstr ""
-"Qualità complessiva, usata diversamente da differenti codec\n"
+msgstr "Qualità complessiva, usata diversamente da differenti codec\n"
 "Richiesta per vorbis\n"
 "0 - automatico\n"
 "-1 - off (usa invece bitrate)"
@@ -11999,11 +11739,9 @@ msgid "Quality:"
 msgstr "Qualità:"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Sample rate (Hz)\n"
+msgid "Sample rate (Hz)\n"
 "0 - don't change sample rate"
-msgstr ""
-"Frequenza di campionamento (Hz)\n"
+msgstr "Frequenza di campionamento (Hz)\n"
 "0 - non cambia la frequenza di campionamento"
 
 #: src/export/ExportFFmpegDialogs.cpp
@@ -12011,22 +11749,18 @@ msgid "Sample Rate:"
 msgstr "Frequenza di campionamento:"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Audio cutoff bandwidth (Hz)\n"
+msgid "Audio cutoff bandwidth (Hz)\n"
 "Optional\n"
 "0 - automatic"
-msgstr ""
-"Ampiezza banda frequenza di taglio audio (Hz)\n"
+msgstr "Ampiezza banda frequenza di taglio audio (Hz)\n"
 "Opzionale\n"
 "0 - automatico"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"AAC Profile\n"
+msgid "AAC Profile\n"
 "Low Complexity - default\n"
 "Most players won't play anything other than LC"
-msgstr ""
-"Profilo AAC\n"
+msgstr "Profilo AAC\n"
 "Bassa complessità (Low Complexity) - predefinito\n"
 "La maggior parte dei lettori non riproduce nient'altro che LC"
 
@@ -12039,14 +11773,12 @@ msgid "FLAC options"
 msgstr "Opzioni FLAC"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Compression level\n"
+msgid "Compression level\n"
 "Required for FLAC\n"
 "-1 - automatic\n"
 "min - 0 (fast encoding, large output file)\n"
 "max - 10 (slow encoding, small output file)"
-msgstr ""
-"Livello di compressione\n"
+msgstr "Livello di compressione\n"
 "Richiesto per FLAC\n"
 "-1 - automatico\n"
 "min - 0 (codifica veloce, file risultante grande)\n"
@@ -12057,14 +11789,12 @@ msgid "Compression:"
 msgstr "Compressione:"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Frame size\n"
+msgid "Frame size\n"
 "Optional\n"
 "0 - default\n"
 "min - 16\n"
 "max - 65535"
-msgstr ""
-"Dimensione frame\n"
+msgstr "Dimensione frame\n"
 "Opzionale\n"
 "0 - predefinita\n"
 "min - 16\n"
@@ -12075,14 +11805,12 @@ msgid "Frame:"
 msgstr "Frame:"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"LPC coefficients precision\n"
+msgid "LPC coefficients precision\n"
 "Optional\n"
 "0 - default\n"
 "min - 1\n"
 "max - 15"
-msgstr ""
-"Coefficienti di precisione LPC\n"
+msgstr "Coefficienti di precisione LPC\n"
 "Opzionale\n"
 "0 - predefinito\n"
 "min - 1\n"
@@ -12093,13 +11821,11 @@ msgid "LPC"
 msgstr "LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Prediction Order Method\n"
+msgid "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
 "Log search - slowest, best compression\n"
 "Full search - default"
-msgstr ""
-"Metodo ordine di predizione (Prediction Order)\n"
+msgstr "Metodo ordine di predizione (Prediction Order)\n"
 "Stimato - veloce, compressione minore\n"
 "Ricerca registro - lento, compressione migliore\n"
 "Ricerca completa - predefinito"
@@ -12109,14 +11835,12 @@ msgid "PdO Method:"
 msgstr "Metodo PdO:"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Minimal prediction order\n"
+msgid "Minimal prediction order\n"
 "Optional\n"
 "-1 - default\n"
 "min - 0\n"
 "max - 32 (with LPC) or 4 (without LPC)"
-msgstr ""
-"Ordine di predizione (Prediction Order) minimo\n"
+msgstr "Ordine di predizione (Prediction Order) minimo\n"
 "Opzionale\n"
 "-1 - predefinito\n"
 "min - 0\n"
@@ -12127,14 +11851,12 @@ msgid "Min. PdO"
 msgstr "PdO min."
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Maximal prediction order\n"
+msgid "Maximal prediction order\n"
 "Optional\n"
 "-1 - default\n"
 "min - 0\n"
 "max - 32 (with LPC) or 4 (without LPC)"
-msgstr ""
-"Ordine di predizione (Prediction Order) massimo\n"
+msgstr "Ordine di predizione (Prediction Order) massimo\n"
 "Opzionale\n"
 "-1 - predefinito\n"
 "min - 0\n"
@@ -12145,14 +11867,12 @@ msgid "Max. PdO"
 msgstr "PdO max"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Minimal partition order\n"
+msgid "Minimal partition order\n"
 "Optional\n"
 "-1 - default\n"
 "min - 0\n"
 "max - 8"
-msgstr ""
-"Ordine di partizione (Partition Order) minimo\n"
+msgstr "Ordine di partizione (Partition Order) minimo\n"
 "Opzionale\n"
 "-1 - predefinito\n"
 "min - 0\n"
@@ -12163,14 +11883,12 @@ msgid "Min. PtO"
 msgstr "PtO min."
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Maximal partition order\n"
+msgid "Maximal partition order\n"
 "Optional\n"
 "-1 - default\n"
 "min - 0\n"
 "max - 8"
-msgstr ""
-"Ordine di partizione (Partition Order) massimo\n"
+msgstr "Ordine di partizione (Partition Order) massimo\n"
 "Opzionale\n"
 "-1 - predefinito\n"
 "min - 0\n"
@@ -12191,36 +11909,38 @@ msgid "MPEG container options"
 msgstr "Opzioni contenitore MPEG"
 
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Maximum bit rate of the multiplexed stream\n"
+msgid "Maximum bit rate of the multiplexed stream\n"
 "Optional\n"
 "0 - default"
-msgstr ""
-"Massimo bit rate del flusso multiplexato\n"
+msgstr "Massimo bit rate del flusso multiplexato\n"
 "Opzionale\n"
 "0 - predefinito"
 
-#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
-#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between
+#. several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for
+#. MPEG
 #. it has a hard to predict effect on the degree of compression
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Mux Rate:"
 msgstr "Mux rate:"
 
-#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
-#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on
+#. compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one
+#. piece.
 #: src/export/ExportFFmpegDialogs.cpp
-msgid ""
-"Packet size\n"
+msgid "Packet size\n"
 "Optional\n"
 "0 - default"
-msgstr ""
-"Dimensione pacchetti\n"
+msgstr "Dimensione pacchetti\n"
 "Opzionale\n"
 "0 - predefinito"
 
-#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
-#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on
+#. compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one
+#. piece.
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Packet Size:"
 msgstr "Dimensione pacchetti:"
@@ -12244,7 +11964,7 @@ msgstr "Selezionare il file XML con le combinazioni da importare"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
-msgstr "Nessuna preimpostazione da esportare."
+msgstr "Nessuna preimpostazione da esportare"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Select xml file to export presets into"
@@ -12305,11 +12025,9 @@ msgstr "L'esportatore FLAC non è riuscito ad aprire %s"
 
 #: src/export/ExportFLAC.cpp
 #, c-format
-msgid ""
-"FLAC encoder failed to initialize\n"
+msgid "FLAC encoder failed to initialize\n"
 "Status: %d"
-msgstr ""
-"Non è stato possibile inizializzare il codificatore FLAC\n"
+msgstr "Non è stato possibile inizializzare il codificatore FLAC\n"
 "Stato: %d"
 
 #: src/export/ExportFLAC.cpp
@@ -12341,11 +12059,9 @@ msgid "Allegro file"
 msgstr "File Allegro"
 
 #: src/export/ExportMIDI.cpp
-msgid ""
-"You have selected a filename with an unrecognized file extension.\n"
+msgid "You have selected a filename with an unrecognized file extension.\n"
 "Do you want to continue?"
-msgstr ""
-"È stato selezionato un nome di file con una estensione di file non riconosciuta.\n"
+msgstr "È stato selezionato un nome di file con una estensione di file non riconosciuta.\n"
 "Procedere?"
 
 #: src/export/ExportMIDI.cpp
@@ -12497,7 +12213,8 @@ msgstr "Modalità canale:"
 msgid "Force export to mono"
 msgstr "Forza esportazione in mono"
 
-#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#. i18n-hint: LAME is the name of an MP3 converter and should not be
+#. translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Individua LAME"
@@ -12533,11 +12250,9 @@ msgstr "Dove si trova il file %s?"
 
 #: src/export/ExportMP3.cpp
 #, c-format
-msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
+msgid "You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
 "Please download the latest version of 'LAME for Audacity'."
-msgstr ""
-"Ci si sta collegando a lame_enc.dll v%d.%d. Questa versione non è compatibile con Audacity %d.%d.%d.\n"
+msgstr "Ci si sta collegando a lame_enc.dll v%d.%d. Questa versione non è compatibile con Audacity %d.%d.%d.\n"
 "Scaricare l'ultima versione di 'LAME per Audacity'."
 
 #: src/export/ExportMP3.cpp
@@ -12621,20 +12336,16 @@ msgstr "Errore %ld restituito dal codificatore MP3"
 
 #: src/export/ExportMP3.cpp
 #, c-format
-msgid ""
-"The project sample rate (%d) is not supported by the MP3\n"
+msgid "The project sample rate (%d) is not supported by the MP3\n"
 "file format. "
-msgstr ""
-"Le frequenza di campionamento (%d) del progetto non è\n"
+msgstr "Le frequenza di campionamento (%d) del progetto non è\n"
 "supportata dal formato di file MP3.  "
 
 #: src/export/ExportMP3.cpp
 #, c-format
-msgid ""
-"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+msgid "The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
 "supported by the MP3 file format. "
-msgstr ""
-"La combinazione della frequenza di campionamento (%d) e del bit rate\n"
+msgstr "La combinazione della frequenza di campionamento (%d) e del bit rate\n"
 "(%d kbps) del progetto non è supportata dal formato file MP3. "
 
 #: src/export/ExportMP3.cpp
@@ -12654,11 +12365,9 @@ msgid "Cannot Export Multiple"
 msgstr "Esportazione multipla non possibile"
 
 #: src/export/ExportMultiple.cpp
-msgid ""
-"You have no unmuted Audio Tracks and no applicable \n"
+msgid "You have no unmuted Audio Tracks and no applicable \n"
 "labels, so you cannot export to separate audio files."
-msgstr ""
-"Non ci sono audio non silenziate e nessuna etichetta\n"
+msgstr "Non ci sono audio non silenziate e nessuna etichetta\n"
 "applicabile, quindi non si può esportare in file audio separati."
 
 #: src/export/ExportMultiple.cpp
@@ -12757,12 +12466,10 @@ msgstr "Qualcosa è andato davvero storto dopo l'esportazione dei seguenti %lld 
 
 #: src/export/ExportMultiple.cpp
 #, c-format
-msgid ""
-"\"%s\" doesn't exist.\n"
+msgid "\"%s\" doesn't exist.\n"
 "\n"
 "Would you like to create it?"
-msgstr ""
-"\"%s\" non esiste.\n"
+msgstr "\"%s\" non esiste.\n"
 "\n"
 "Crearla?"
 
@@ -12773,15 +12480,13 @@ msgstr "Proseguire con l'esportazione dei file rimanenti?"
 #. i18n-hint: The second %s gives some letters that can't be used.
 #: src/export/ExportMultiple.cpp
 #, c-format
-msgid ""
-"Label or track \"%s\" is not a legal file name.\n"
+msgid "Label or track \"%s\" is not a legal file name.\n"
 "You cannot use any of these characters:\n"
 "\n"
 "%s\n"
 "\n"
 "Suggested replacement:"
-msgstr ""
-"L'etichetta o traccia \"%s\" non è un nome di file valido.\n"
+msgstr "L'etichetta o traccia \"%s\" non è un nome di file valido.\n"
 "Non è possibile usare i seguenti caratteri:\n"
 "\n"
 "%s\n"
@@ -12791,12 +12496,10 @@ msgstr ""
 #. i18n-hint: The second %s gives a letter that can't be used.
 #: src/export/ExportMultiple.cpp
 #, c-format
-msgid ""
-"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+msgid "Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
 "\n"
 "Suggested replacement:"
-msgstr ""
-"L'etichetta o traccia \"%s\" non è un nome di file valido. Non è possibile usare \"%s\".\n"
+msgstr "L'etichetta o traccia \"%s\" non è un nome di file valido. Non è possibile usare \"%s\".\n"
 "\n"
 "Sostituzione suggerita:"
 
@@ -12861,11 +12564,9 @@ msgid "Other uncompressed files"
 msgstr "Altri file non compressi"
 
 #: src/export/ExportPCM.cpp
-msgid ""
-"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+msgid "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
 "Audacity cannot do this, the Export was abandoned."
-msgstr ""
-"Si è cercato di esportare un file WAV o AIFF che sarebbe più grande di 4GB.\n"
+msgstr "Si è cercato di esportare un file WAV o AIFF che sarebbe più grande di 4GB.\n"
 "Questa operazione non è supportata da Aucacity: l'esportazione è stata interrotta."
 
 #: src/export/ExportPCM.cpp
@@ -12873,11 +12574,9 @@ msgid "Error Exporting"
 msgstr "Errore di esportazione"
 
 #: src/export/ExportPCM.cpp
-msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+msgid "Your exported WAV file has been truncated as Audacity cannot export WAV\n"
 "files bigger than 4GB."
-msgstr ""
-"Il file WAV esportato è stato troncato in quanto Aucacity non può esportare\n"
+msgstr "Il file WAV esportato è stato troncato in quanto Aucacity non può esportare\n"
 "file WAV più grandi di 4GB."
 
 #: src/export/ExportPCM.cpp
@@ -12902,11 +12601,9 @@ msgstr "Esportazione dell'audio selezionato come %s"
 #. * error"
 #: src/export/ExportPCM.cpp
 #, c-format
-msgid ""
-"Error while writing %s file (disk full?).\n"
+msgid "Error while writing %s file (disk full?).\n"
 "Libsndfile says \"%s\""
-msgstr ""
-"Errore durante la scrittura del file %s (disco pieno?).\n"
+msgstr "Errore durante la scrittura del file %s (disco pieno?).\n"
 "Libsndfile indica \"%s\""
 
 #: src/export/ExportWavPack.cpp
@@ -12992,11 +12689,9 @@ msgid "Dow&nload"
 msgstr "Sca&rica"
 
 #: src/export/FFmpegPrefs.cpp
-msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+msgid "Audacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
-msgstr ""
-"Audacity ha automaticamente individuato delle librerie FFmpeg valide.\n"
+msgstr "Audacity ha automaticamente individuato delle librerie FFmpeg valide.\n"
 "Proseguire comunque con la ricerca manuale?"
 
 #: src/export/FFmpegPrefs.cpp
@@ -13017,25 +12712,21 @@ msgstr "Tutti i file supportati"
 
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" \n"
+msgid "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
 "Audacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
-msgstr ""
-"\"%s\" \n"
+msgstr "\"%s\" \n"
 "è un file MIDI, non un file audio. \n"
 "Audacity non può aprire questo tipo di file per la riproduzione,\n"
 "ma è possibile modificarlo facendo clic su File > Importa > MIDI."
 
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" \n"
+msgid "\"%s\" \n"
 "is a not an audio file. \n"
 "Audacity cannot open this type of file."
-msgstr ""
-"\"%s\" \n"
+msgstr "\"%s\" \n"
 "non è un file audio. \n"
 "Audacity non può aprire questo tipo di file."
 
@@ -13051,13 +12742,11 @@ msgstr "Questa versione di Audacity non è stata compilata con il supporto per %
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is an audio CD track. \n"
+msgid "\"%s\" is an audio CD track. \n"
 "Audacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
 "Audacity can import, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è una traccia di un CD audio. \n"
+msgstr "\"%s\" è una traccia di un CD audio. \n"
 "Audacity non può aprire direttamente i CD audio. \n"
 "Estrarre (fare il rip) le tracce del CD in un formato\n"
 "audio che Audacity può importare, come WAV o AIFF."
@@ -13065,50 +12754,42 @@ msgstr ""
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is a playlist file. \n"
+msgid "\"%s\" is a playlist file. \n"
 "Audacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
-msgstr ""
-"\"%s\" è una playlist. \n"
+msgstr "\"%s\" è una playlist. \n"
 "Audacity non può aprire questo file poiché contiene solo collegamenti ad altri file. \n"
 "È possibile aprirlo in un editor di testo e scaricare gli effettivi file audio."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is a Windows Media Audio file. \n"
+msgid "\"%s\" is a Windows Media Audio file. \n"
 "Audacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file Windows Media Audio. \n"
+msgstr "\"%s\" è un file Windows Media Audio. \n"
 "Audacity non può aprire questo tipo di file a causa di restrizioni di brevetto. \n"
 "È necessario convertirlo in un formato audio supportato, come WAV o AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is an Advanced Audio Coding file.\n"
+msgid "\"%s\" is an Advanced Audio Coding file.\n"
 "Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file Advanced Audio Coding. \n"
+msgstr "\"%s\" è un file Advanced Audio Coding. \n"
 "Audacity non può aprire questo tipo di file senza la libreria facoltativa FFmpeg.\n"
 "Senza di essa è necessario convertirlo in un formato audio supportato, come WAV o AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is an encrypted audio file. \n"
+msgid "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
 "Audacity cannot open this type of file due to the encryption. \n"
 "Try recording the file into Audacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file audio criptato. \n"
+msgstr "\"%s\" è un file audio criptato. \n"
 "Questi file tipicamente provengono da un negozio di musica online. \n"
 "Audacity non può aprire questo tipo di file a causa della crittografia. \n"
 "Cercare di registrare il file in Audacity, o di masterizzarlo in un CD audio, \n"
@@ -13117,25 +12798,21 @@ msgstr ""
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is a RealPlayer media file. \n"
+msgid "\"%s\" is a RealPlayer media file. \n"
 "Audacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file multimediale RealPlayer. \n"
+msgstr "\"%s\" è un file multimediale RealPlayer. \n"
 "Audacity non può aprire questo formato proprietario. \n"
 "È necessario convertirlo in un formato audio supportato, come WAV o AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is a notes-based file, not an audio file. \n"
+msgid "\"%s\" is a notes-based file, not an audio file. \n"
 "Audacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
 "then import it, or record it into Audacity."
-msgstr ""
-"\"%s\" è un file basato sulle note, non un file audio. \n"
+msgstr "\"%s\" è un file basato sulle note, non un file audio. \n"
 "Audacity non può aprire questo tipo di file. \n"
 "Cercare di convertirlo in un formato audio come WAV o AIFF e \n"
 "quindi importarlo, oppure registrarlo in Audacity."
@@ -13143,14 +12820,12 @@ msgstr ""
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is a Musepack audio file. \n"
+msgid "\"%s\" is a Musepack audio file. \n"
 "Audacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file audio Musepack. \n"
+msgstr "\"%s\" è un file audio Musepack. \n"
 "Audacity non può aprire questo tipo di file. \n"
 "Se si ritieni che possa essere un file mp3, rinominarlo affinché termini\n"
 "con l'estensione \".mp3\"  e riprovare a importarlo. Altrimenti è necessario\n"
@@ -13159,48 +12834,40 @@ msgstr ""
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is a Wavpack audio file. \n"
+msgid "\"%s\" is a Wavpack audio file. \n"
 "Audacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file audio Wavpack. \n"
+msgstr "\"%s\" è un file audio Wavpack. \n"
 "Audacity non può aprire questo tipo di file. \n"
 "È necessario convertirlo in un formato audio supportato, come WAV o AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is a Dolby Digital audio file. \n"
+msgid "\"%s\" is a Dolby Digital audio file. \n"
 "Audacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file audio Dolby Digital. \n"
+msgstr "\"%s\" è un file audio Dolby Digital. \n"
 "Audacity non può attualmente aprire questo tipo di file. \n"
 "È necessario convertirlo in un formato audio supportato, come WAV o AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is an Ogg Speex audio file. \n"
+msgid "\"%s\" is an Ogg Speex audio file. \n"
 "Audacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file audio Ogg Speex. \n"
+msgstr "\"%s\" è un file audio Ogg Speex. \n"
 "Audacity non può attualmente aprire questo tipo di file. \n"
 "È necessario convertirlo in un formato audio supportato, come WAV o AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"\"%s\" is a video file. \n"
+msgid "\"%s\" is a video file. \n"
 "Audacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
-msgstr ""
-"\"%s\" è un file video. \n"
+msgstr "\"%s\" è un file video. \n"
 "Audacity non può attualmente aprire questo tipo di file. \n"
 "È necessario estrarne l'audio in un formato audio supportato, come WAV o AIFF."
 
@@ -13212,12 +12879,10 @@ msgstr "Impossibile trovare il file \"%s\"."
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+msgid "Audacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
-msgstr ""
-"Audacity non ha riconosciuto il tipo del file '%s'.\n"
+msgstr "Audacity non ha riconosciuto il tipo del file '%s'.\n"
 "\n"
 "%sPer i file non compressi è anche possibile provare File > Importa > Dati raw."
 
@@ -13229,13 +12894,11 @@ msgstr "%s, %s"
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
-msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+msgid "Audacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
-msgstr ""
-"Audacity ha riconosciuto il tipo di file '%s'.\n"
+msgstr "Audacity ha riconosciuto il tipo di file '%s'.\n"
 "Gli importatori che presumibilmente supportano tali file sono:\n"
 "%s,\n"
 "ma nessuno di essi ha riconosciuto questo formato file."
@@ -13246,12 +12909,10 @@ msgstr "File di progetto AUP (*.aup)"
 
 #: src/import/ImportAUP.cpp
 #, c-format
-msgid ""
-"Couldn't import the project:\n"
+msgid "Couldn't import the project:\n"
 "\n"
 "%s"
-msgstr ""
-"Non è stato possibile importare il progetto:\n"
+msgstr "Non è stato possibile importare il progetto:\n"
 "\n"
 "%s"
 
@@ -13260,14 +12921,12 @@ msgid "Import Project"
 msgstr "Importa progetto"
 
 #: src/import/ImportAUP.cpp
-msgid ""
-"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+msgid "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
 "you may import it with this version of Audacity."
-msgstr ""
-"Il progetto è stato salvato con Audacity versione 1.0 o precente.\n"
+msgstr "Il progetto è stato salvato con Audacity versione 1.0 o precente.\n"
 "Il formato è cambiato e questa versione di Audacity non è in\n"
 "grado di importare il progetto.\n"
 "\n"
@@ -13338,16 +12997,14 @@ msgstr "Attributo sequenza 'numsamples' non valido."
 
 #: src/import/ImportAUP.cpp
 msgid "Unable to parse the waveblock 'start' attribute"
-msgstr "Non è stato possibile analizzare l'attributo 'start' di waveblock."
+msgstr "Non è stato possibile analizzare l'attributo 'start' di waveblock"
 
 #: src/import/ImportAUP.cpp
 #, c-format
-msgid ""
-"Missing project file %s\n"
+msgid "Missing project file %s\n"
 "\n"
 "Inserting silence instead."
-msgstr ""
-"Manca il file di progetto %s\n"
+msgstr "Manca il file di progetto %s\n"
 "\n"
 "Verrà inserito del silenzio al suo posto."
 
@@ -13361,12 +13018,10 @@ msgstr "L'attributo 'len' di silentblockfile manca o non è valido."
 
 #: src/import/ImportAUP.cpp
 #, c-format
-msgid ""
-"Missing alias file %s\n"
+msgid "Missing alias file %s\n"
 "\n"
 "Inserting silence instead."
-msgstr ""
-"Manca il file alias %s\n"
+msgstr "Manca il file alias %s\n"
 "\n"
 "Verrà inserito del silenzio al suo posto."
 
@@ -13380,12 +13035,10 @@ msgstr "L'attributo 'aliaslen' di pcmaliasblockfile manca o non è valido."
 
 #: src/import/ImportAUP.cpp
 #, c-format
-msgid ""
-"Error while processing %s\n"
+msgid "Error while processing %s\n"
 "\n"
 "Inserting silence."
-msgstr ""
-"Errore durante l'elaborazione di %s\n"
+msgstr "Errore durante l'elaborazione di %s\n"
 "\n"
 "Inserimento di silenzio."
 
@@ -13409,11 +13062,8 @@ msgid "FFmpeg-compatible files"
 msgstr "File compatibili con FFmpeg"
 
 #: src/import/ImportFFmpeg.cpp
-#, fuzzy
 msgid "Try installing FFmpeg.\n"
-msgstr ""
-"Provare ad installare FFmpeg.\n"
-"\n"
+msgstr "Prova a installare FFmpeg.\n"
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/import/ImportFFmpeg.cpp
@@ -13536,13 +13186,11 @@ msgid "MP3 files"
 msgstr "File MP3"
 
 #: src/import/ImportMP3_MAD.cpp
-msgid ""
-"Import failed\n"
+msgid "Import failed\n"
 "\n"
 "This is likely caused by a malformed MP3.\n"
 "\n"
-msgstr ""
-"Importazione fallita\n"
+msgstr "Importazione fallita\n"
 "\n"
 "La probabile cause è un MP3 non corretto.\n"
 "\n"
@@ -13747,7 +13395,7 @@ msgstr "VOX ADPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
-msgstr "PCM a 16 bit "
+msgstr "PCM a 16 bit"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
@@ -13909,7 +13557,6 @@ msgstr "%s destra"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
-#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %s, %d of %d clip %s"
@@ -13935,7 +13582,6 @@ msgstr "fine"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
-#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %s and %s %s, %d and %d of %d clip %s"
@@ -13977,7 +13623,7 @@ msgstr "clip non spostata"
 
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Audi&o Clips"
-msgstr "Clip audi&o"
+msgstr "C&lip audio"
 
 #: src/menus/ClipMenus.cpp
 msgid "Pre&vious Clip Boundary to Cursor"
@@ -14053,13 +13699,12 @@ msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "Eliminati %.2f secondi a t=%.2f"
 
 #: src/menus/EditMenus.cpp
-#, fuzzy
 msgid "Paste clip"
-msgstr "Incolla dagli appunti"
+msgstr "Incolla clip"
 
 #: src/menus/EditMenus.cpp
 msgid "Pasting clip contents, please wait"
-msgstr ""
+msgstr "Attendere mentre il contenuto della clip viene incollato"
 
 #: src/menus/EditMenus.cpp
 msgid "Pasting one type of track into another is not allowed."
@@ -14171,11 +13816,11 @@ msgstr "&Incolla"
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp
 msgid "Duplic&ate"
-msgstr "Duplic&a"
+msgstr "&Duplica"
 
 #: src/menus/EditMenus.cpp
 msgid "R&emove Special"
-msgstr "R&imuovi speciale"
+msgstr "Rimuovi &speciale"
 
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
@@ -14217,7 +13862,7 @@ msgstr "Separ&a ai silenzi"
 
 #: src/menus/EditMenus.cpp
 msgid "Pre&ferences"
-msgstr "Pre&ferenze"
+msgstr "&Preferenze"
 
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
@@ -14241,11 +13886,9 @@ msgstr "Impossibile procedere con l'esportazione."
 
 #: src/menus/FileMenus.cpp
 #, c-format
-msgid ""
-"Cannot create directory '%s'. \n"
+msgid "Cannot create directory '%s'. \n"
 "File already exists that is not a directory"
-msgstr ""
-"Impossibile creare la cartella '%s'. \n"
+msgstr "Impossibile creare la cartella '%s'. \n"
 "Il file esiste già e non è una cartella"
 
 #: src/menus/FileMenus.cpp
@@ -14286,7 +13929,7 @@ msgstr "&File recenti"
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
-msgstr "&Salva progetto"
+msgstr "Sal&va progetto"
 
 #: src/menus/FileMenus.cpp
 msgid "Save Project &As..."
@@ -14551,7 +14194,7 @@ msgstr "Nuova traccia"
 
 #: src/menus/LabelMenus.cpp
 msgid "&Labels"
-msgstr "&Etichette"
+msgstr "Etic&hette"
 
 #: src/menus/LabelMenus.cpp
 msgid "&Edit Labels..."
@@ -14575,7 +14218,7 @@ msgstr "&Digita per creare un'etichetta (attiva/disattiva)"
 
 #: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
-msgstr "Audio con etich&ette"
+msgstr "A&udio con etichette"
 
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
@@ -14705,7 +14348,7 @@ msgstr "Commuta traccia evi&denziata"
 #. the user's interactions with the application
 #: src/menus/PluginMenus.cpp
 msgid "A journal will be recorded after Audacity restarts."
-msgstr "Verrà salvato un giornale di registrazione dopo il riavvio di Audacity."
+msgstr "Un journal verrà registrato dopo il riavvio di Audacity."
 
 #. i18n-hint a "journal" is a text file that records
 #. the user's interactions with the application
@@ -14735,7 +14378,7 @@ msgstr "Ripeti ultimo effetto"
 
 #: src/menus/PluginMenus.cpp
 msgid "&Analyze"
-msgstr "&Analizza"
+msgstr "Anali&zza"
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Analyzer"
@@ -14743,7 +14386,7 @@ msgstr "Ripeti ultimo analizzatore"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
-msgstr "&Strumenti"
+msgstr "Str&umenti"
 
 #: src/menus/PluginMenus.cpp
 msgid "Reset &Configuration"
@@ -14806,7 +14449,7 @@ msgstr "Seleziona sincronizzazione bloccata"
 
 #: src/menus/SelectMenus.cpp
 msgid "R&egion"
-msgstr "R&egione"
+msgstr "&Regione"
 
 #: src/menus/SelectMenus.cpp
 msgid "&Left at Playback Position"
@@ -14858,7 +14501,7 @@ msgstr "Recupera selezio&ne"
 
 #: src/menus/SelectMenus.cpp
 msgid "Cursor to Stored &Cursor Position"
-msgstr "Da cursore a posizione memorizzata del &cursore"
+msgstr "&Da cursore a posizione memorizzata del cursore"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
@@ -14866,7 +14509,7 @@ msgstr "Seleziona da cursore a memorizzato"
 
 #: src/menus/SelectMenus.cpp
 msgid "Store Cursor Pos&ition"
-msgstr "Memorizza pos&izione cursore"
+msgstr "&Memorizza posizione cursore"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -15007,7 +14650,6 @@ msgstr "Sposta&mento lungo del cursore a destra"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
-#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Cer&ca"
@@ -15452,7 +15094,6 @@ msgstr "nessuna traccia etichette nella o sotto la traccia evidenziata"
 #. first number gives the position of that label in a sequence
 #. of labels,
 #. and the last number is the total number of labels in the sequence.
-#.
 #: src/menus/TransportMenus.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
 #, c-format
 msgid "%s %d of %d"
@@ -15493,11 +15134,11 @@ msgstr "Selezionare un tempo all'interno di una clip."
 #. play, record, pause etc.
 #: src/menus/TransportMenus.cpp
 msgid "Tra&nsport"
-msgstr "Attiv&ità"
+msgstr "Att&ività"
 
 #: src/menus/TransportMenus.cpp
 msgid "Pl&aying"
-msgstr "Riproduzi&one"
+msgstr "Ri&produzione"
 
 #. i18n-hint: (verb) Start or Stop audio playback
 #: src/menus/TransportMenus.cpp
@@ -15689,7 +15330,7 @@ msgstr "E&spandi tracce compresse"
 
 #: src/menus/ViewMenus.cpp
 msgid "Sk&ip to"
-msgstr "V&ai a"
+msgstr "&Vai a"
 
 #: src/menus/ViewMenus.cpp
 msgid "Selection Sta&rt"
@@ -15713,13 +15354,14 @@ msgstr "&Nome traccia (on/off)"
 
 #: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
-msgstr "&Mostra clipping (attiva/disattiva)"
+msgstr "Mostra &clipping (attiva/disattiva)"
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
 msgstr "Preferenze dell'applicazione"
 
-#. i18n-hint: Title for the update notifications panel in the preferences dialog.
+#. i18n-hint: Title for the update notifications panel in the preferences
+#. dialog.
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Update notifications"
 msgstr "Notifiche aggiornamenti"
@@ -15751,9 +15393,8 @@ msgid "&Don't apply effects in batch mode"
 msgstr "&Non applicare effetti in modalità batch"
 
 #: src/prefs/DevicePrefs.cpp
-#, fuzzy
 msgid "Audio Settings"
-msgstr "Impostazioni audio:"
+msgstr "Impostazioni audio"
 
 #: src/prefs/DevicePrefs.cpp
 #, c-format
@@ -15804,18 +15445,16 @@ msgid "Cha&nnels:"
 msgstr "Ca&nali:"
 
 #: src/prefs/DevicePrefs.cpp
-#, fuzzy
 msgid "&Project Sample Rate:"
-msgstr "Frequenza di campionamento:"
+msgstr "Frequenza di campionamento del &progetto:"
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Project Sample Rate used when recording new tracks and for playback, mixdowns and exports in this project"
-msgstr ""
+msgstr "Frequenza di campionamento del progetto usata per la registrazione di nuove tracce e per la riproduzione, i mixdown e le esportazioni in questo progetto"
 
 #: src/prefs/DevicePrefs.cpp
-#, fuzzy
 msgid "D&efault Sample Rate:"
-msgstr "&Frequenza di campionamento predefinita:"
+msgstr "Fre&quenza di campionamento predefinita:"
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Default Sample &Format:"
@@ -15868,11 +15507,9 @@ msgid "Default directories"
 msgstr "Cartelle predefinite"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid ""
-"Leave a field empty to go to the last directory used for that operation.\n"
+msgid "Leave a field empty to go to the last directory used for that operation.\n"
 "Fill in a field to always go to that directory for that operation."
-msgstr ""
-"Lasciare un campo vuoto per andare alla cartella usata l'ultima volta per quell'operazione.\n"
+msgstr "Lasciare un campo vuoto per andare alla cartella usata l'ultima volta per quell'operazione.\n"
 "Se si specifica un valore, tale cartella verrà sempre usata per quell'operazione."
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -15949,11 +15586,9 @@ msgstr "Seleziona una posizione"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
-msgid ""
-"\n"
+msgid "\n"
 "Directory %s does not exist. Create it?"
-msgstr ""
-"\n"
+msgstr "\n"
 "La cartella %s non esiste. Crearla?"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -15962,11 +15597,9 @@ msgstr "Impossibile creare la cartella."
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
-msgid ""
-"\n"
+msgid "\n"
 "%s"
-msgstr ""
-"\n"
+msgstr "\n"
 "%s"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -16020,39 +15653,32 @@ msgid "Preferences for Effects"
 msgstr "Preferenze per effetti"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Sort by effect name"
-msgstr "Ordinati per nome effetto"
+msgstr "Ordina per nome effetto"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Sort by publisher and effect name"
-msgstr "Ordinati per editore e nome effetto"
+msgstr "Ordina per editore e nome dell'effetto"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Sort by type and effect name"
-msgstr "Ordinati per tipo e nome effetto"
+msgstr "Ordina per tipo e nome effetto"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Group by publisher"
-msgstr "Raggruppati per editore"
+msgstr "Raggruppa per editore"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Group by type"
-msgstr "Raggruppati per tipo"
+msgstr "Raggruppa per tipo"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Group by category"
-msgstr "Raggruppati per tipo"
+msgstr "Raggruppa per categoria"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Group by type and publisher"
-msgstr "Raggruppati per editore"
+msgstr "Raggruppa per tipo ed editore"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
@@ -16060,12 +15686,11 @@ msgstr "Opzioni effetti"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect menu &organization:"
-msgstr ""
+msgstr "&Organizzazione menu effetti:"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Realtime effect o&rganization:"
-msgstr "Effetti in tempo reale per %s"
+msgstr "O&rganizzazione effetti in tempo reale:"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Instruction Set"
@@ -16076,9 +15701,8 @@ msgid "&Use SSE/SSE2/.../AVX"
 msgstr "&Usa SSE/SSE2/.../AVX"
 
 #: src/prefs/EffectsPrefs.cpp
-#, fuzzy
 msgid "Open Plugin Manager"
-msgstr "Gestore delle estensioni"
+msgstr "Apri il gestore delle estensioni"
 
 #. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
 #. * audio file import options
@@ -16200,7 +15824,8 @@ msgstr "-120 dB (limite approssimativo dell'udito umano)"
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (intervallo PCM di campioni a 24 bit)"
 
-#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
+#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformPrefs.cpp
 msgid "Display"
 msgstr "Visualizzazione"
 
@@ -16408,11 +16033,9 @@ msgstr "Pre&definiti"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
-msgid ""
-"\n"
+msgid "\n"
 "   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
-msgstr ""
-"\n"
+msgstr "\n"
 "   *   \"%s\"  (poiché la combinazione '%s' è usata da \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -16425,11 +16048,9 @@ msgstr "Errore nell'importazione delle combinazioni di tasti"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
-msgid ""
-"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+msgid "The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
 "Nothing is imported."
-msgstr ""
-"Il file con le combinazioni contiene conbinazioni duplicate non valide per \"%s\" e \"%s\".\n"
+msgstr "Il file con le combinazioni contiene conbinazioni duplicate non valide per \"%s\" e \"%s\".\n"
 "Non è stato importato alcunché."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -16438,11 +16059,9 @@ msgid "Loaded %d keyboard shortcuts\n"
 msgstr "%d combinazioni di tasti caricate\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid ""
-"\n"
+msgid "\n"
 "The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
-msgstr ""
-"\n"
+msgstr "\n"
 "I comandi seguenti non sono menzionati nel file importato, ma le loro combinazioni di tasti sono state rimosse in quanto in conflitto con altre nuove combinazioni di tasti:\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -16466,14 +16085,12 @@ msgid "You must select a binding before assigning a shortcut"
 msgstr "È necessario specificare la combinazione di tasti"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid ""
-"\n"
+msgid "\n"
 "\n"
 "\t and\n"
 "\n"
 "\t"
-msgstr ""
-"\n"
+msgstr "\n"
 "\n"
 "\t e\n"
 "\n"
@@ -16481,8 +16098,7 @@ msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
-msgid ""
-"The keyboard shortcut '%s' is already assigned to:\n"
+msgid "The keyboard shortcut '%s' is already assigned to:\n"
 "\n"
 "\t%s\n"
 "\n"
@@ -16492,8 +16108,7 @@ msgid ""
 "\t%s\n"
 "\n"
 "instead. Otherwise, click Cancel."
-msgstr ""
-"La combinazioni di tasti '%s' è già assegnata a:\n"
+msgstr "La combinazioni di tasti '%s' è già assegnata a:\n"
 "\n"
 "\t%s\n"
 "\n"
@@ -16551,7 +16166,8 @@ msgstr "La latenza del sintetizzatore MIDI deve essere un numero intero"
 msgid "Midi IO"
 msgstr "IO MIDI"
 
-#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW
+#. features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
 msgstr "Moduli"
@@ -16561,11 +16177,9 @@ msgid "Preferences for Module"
 msgstr "Preferenze per modulo"
 
 #: src/prefs/ModulePrefs.cpp
-msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+msgid "These are experimental modules. Enable them only if you've read the Audacity Manual\n"
 "and know what you are doing."
-msgstr ""
-"Questi sono moduli sperimentali. Abilitarli solo dopo aver letto il manuale di Audacity\n"
+msgstr "Questi sono moduli sperimentali. Abilitarli solo dopo aver letto il manuale di Audacity\n"
 "e se si sa quello che si sta facendo."
 
 #. i18n-hint preserve the leading spaces
@@ -16880,7 +16494,8 @@ msgstr "Conversione in tempo reale"
 msgid "Sample Rate Con&verter:"
 msgstr "Con&vertitore della frequenza di campionamento:"
 
-#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#. i18n-hint: technical term for randomization to reduce undesirable
+#. resampling artifacts
 #: src/prefs/QualityPrefs.cpp
 msgid "&Dither:"
 msgstr "&Retinatura:"
@@ -16893,7 +16508,8 @@ msgstr "Conversione ad alta qualità"
 msgid "Sample Rate Conver&ter:"
 msgstr "Conver&titore della frequenza di campionamento:"
 
-#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#. i18n-hint: technical term for randomization to reduce undesirable
+#. resampling artifacts
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Reti&natura:"
@@ -16918,7 +16534,8 @@ msgstr "&Software Playthrough dell'ingresso"
 msgid "Record on a new track"
 msgstr "Registra in una nuova traccia"
 
-#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the
+#. recording
 #: src/prefs/RecordingPrefs.cpp
 msgid "Detect dropouts"
 msgstr "Rileva cadute del segnale audio"
@@ -17015,12 +16632,14 @@ msgstr "Cross&fade:"
 msgid "Mel"
 msgstr "Mel"
 
-#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for
+#. Heinrich Barkhausen
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Bark"
 msgstr "Bark"
 
-#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates
+#. Equivalent Rectangular Bandwidth
 #: src/prefs/SpectrogramSettings.cpp
 msgid "ERB"
 msgstr "ERB"
@@ -17181,7 +16800,8 @@ msgstr "A&bilita selezione spettrale"
 msgid "Show a grid along the &Y-axis"
 msgstr "Mostra una griglia sull'asse &Y"
 
-#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be
+#. translated
 #: src/prefs/SpectrumPrefs.cpp
 msgid "FFT Find Notes"
 msgstr "Trova note FFT"
@@ -17243,7 +16863,8 @@ msgid "The maximum number of notes must be in the range 1..128"
 msgstr "Il numero massimo di note deve essere compreso tra 1 e 128"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
-#. graphical user interface, including choices of colors, and similarity of images
+#. graphical user interface, including choices of colors, and similarity of
+#. images
 #. such as those on button controls.  Audacity can load and save alternative
 #. themes.
 #: src/prefs/ThemePrefs.cpp src/prefs/ThemePrefs.h
@@ -17259,15 +16880,13 @@ msgid "Info"
 msgstr "Informazioni"
 
 #: src/prefs/ThemePrefs.cpp
-msgid ""
-"Themability is an experimental feature.\n"
+msgid "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
 "Click \"Load Theme Cache\" to load the changed images and colors back into Audacity."
-msgstr ""
-"Il tema è una funzione sperimentale.\n"
+msgstr "Il tema è una funzione sperimentale.\n"
 "\n"
 "Per provarlo, fare clic su \"Salva cache tema\" quindi trovare e modificare immagini e colori\n"
 "in ImageCacheVxx.png usando un editor di immagini come Gimp.\n"
@@ -17275,8 +16894,7 @@ msgstr ""
 "Fare clic su \"Carica cache tema\" per caricare in Audacity le immagini e i colori modificati."
 
 #: src/prefs/ThemePrefs.cpp
-msgid ""
-"Saving and loading individual theme files uses a separate file for each image, but is\n"
+msgid "Saving and loading individual theme files uses a separate file for each image, but is\n"
 "otherwise the same idea."
 msgstr "Il salvataggio e il caricamento di singoli file del tema usano un file separato per ciascuna immagine, altrimenti l'approccio è il medesimo."
 
@@ -17324,10 +16942,10 @@ msgid "Multi-track"
 msgstr "Multi-traccia"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
-msgid ""
-"Ask me each time.\n"
+msgid "Ask me each time.\n"
 "Show dialog each time audio is pasted."
-msgstr ""
+msgstr "Chiedimelo ogni volta.\n"
+"Mostra la finestra di dialogo ogni volta che l'audio viene incollato."
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "&Select all audio, if selection required"
@@ -17371,14 +16989,12 @@ msgid "Solo &Button:"
 msgstr "&Pulsante Solo:"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
-#, fuzzy
 msgid "Pasted audio"
-msgstr "Audio con etich&ette"
+msgstr "Audio incollato"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
-#, fuzzy
 msgid "Paste audio from other Audacity project as"
-msgstr "Incollato dagli appunti"
+msgstr "Incolla l'audio da un altro progetto Audacity come"
 
 #: src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.h
 msgid "Waveform"
@@ -17594,7 +17210,8 @@ msgstr "2 (stereo) canali di registrazione"
 msgid "&Audio Setup Toolbar"
 msgstr "Barra degli strumenti di configurazione dell'&audio"
 
-#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
+#. i18n-hint: These are strings for the status bar, and indicate whether
+#. Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
 #: src/toolbars/ControlToolBar.cpp
@@ -17641,7 +17258,8 @@ msgstr "Seleziona fino alla fine"
 msgid "Select to Start"
 msgstr "Seleziona fino all'inizio"
 
-#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
+#. i18n-hint: These are strings for the status bar, and indicate whether
+#. Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
@@ -17792,12 +17410,14 @@ msgstr " Troncato "
 msgid "Record Meter"
 msgstr "Monitor registrazione"
 
-#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being
+#. recorded.
 #: src/toolbars/MeterToolBar.cpp
 msgid "Recording Level"
 msgstr "Livello registrazione"
 
-#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being
+#. recorded.
 #. This is the name used in screen reader software, where having 'Meter' first
 #. apparently is helpful to partially sighted people.
 #: src/toolbars/MeterToolBar.cpp
@@ -17883,7 +17503,6 @@ msgstr "Scorrimento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Ferma scorrimento"
@@ -17891,7 +17510,6 @@ msgstr "Ferma scorrimento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Inizia scorrimento"
@@ -17899,7 +17517,6 @@ msgstr "Inizia scorrimento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Ferma ricerca"
@@ -17907,7 +17524,6 @@ msgstr "Ferma ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
-#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Inizia ricerca"
@@ -17935,9 +17551,8 @@ msgid "Center"
 msgstr "Centra"
 
 #: src/toolbars/SelectionBar.cpp
-#, fuzzy
 msgid "Selection Toolbar Setup"
-msgstr "Barra &selezione"
+msgstr "Configurazione della barra degli strumenti di selezione"
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Start and End of Selection"
@@ -17962,26 +17577,23 @@ msgid "&Selection Toolbar"
 msgstr "Barra &selezione"
 
 #: src/toolbars/SnappingToolBar.cpp
-#, fuzzy
 msgid "Snapping"
-msgstr "(ancoraggio)"
+msgstr "Agganciamento"
 
 #: src/toolbars/SnappingToolBar.cpp
-#, fuzzy
 msgid "Snap"
-msgstr "Ancora"
+msgstr "Aggancia"
 
 #. i18n-hint: combo box is the type of the control/widget
 #: src/toolbars/SnappingToolBar.cpp
 msgid "Snap to combo box"
-msgstr ""
+msgstr "Casella combinata dell'aggancio"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a time range of audio
 #: src/toolbars/SnappingToolBar.cpp
-#, fuzzy
 msgid "&Snapping Toolbar"
-msgstr "Barra &selezione"
+msgstr "Narra degli strumenti di aggancio"
 
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
@@ -18014,41 +17626,38 @@ msgid "Spe&ctral Selection Toolbar"
 msgstr "Barra selezione spe&ttrale"
 
 #: src/toolbars/TimeSignatureToolBar.cpp
-#, fuzzy
 msgid "Time Signature"
-msgstr "Timeline"
+msgstr "Indicazione del tempo"
 
 #: src/toolbars/TimeSignatureToolBar.cpp
-#, fuzzy
 msgid "Tempo"
-msgstr "Intonazione/tempo"
+msgstr "Tempo"
 
 #: src/toolbars/TimeSignatureToolBar.cpp
 msgid "Upper Time Signature"
-msgstr ""
+msgstr "Indicazione del tempo superiore"
 
 #: src/toolbars/TimeSignatureToolBar.cpp
 msgid "Lower Time Signature"
-msgstr ""
+msgstr "Indicazione del tempo inferiore"
 
 #: src/toolbars/TimeSignatureToolBar.cpp
-#, fuzzy
 msgid "Tempo Changed"
-msgstr "Modifica tempo finale (%)"
+msgstr "Tempo modificato"
 
 #: src/toolbars/TimeSignatureToolBar.cpp
 msgid "Upper Time Signature Changed"
-msgstr ""
+msgstr "Indicazione del tempo superiore modificata"
 
 #: src/toolbars/TimeSignatureToolBar.cpp
 msgid "Lower Time Signature Changed"
-msgstr ""
+msgstr "Indicazione del tempo inferiore modificata"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a time range of audio
 #: src/toolbars/TimeSignatureToolBar.cpp
 msgid "Time Signature Toolbar (Beta)"
-msgstr ""
+msgstr "Barra degli strumenti dell'indicazione del tempo (beta)"
 
 #: src/toolbars/TimeToolBar.cpp
 msgid "Time"
@@ -18371,12 +17980,10 @@ msgid "&Spectrogram"
 msgstr "&Spettro"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
-msgid ""
-"To change Spectrogram Settings, stop any\n"
+msgid "To change Spectrogram Settings, stop any\n"
 " playing or recording first."
-msgstr ""
-"Arrestare la riproduzione e la registrazione prima\n"
-"di cambiare le impostazioni dello spettrogramma,"
+msgstr "Arrestare la riproduzione e la registrazione prima\n"
+"di cambiare le impostazioni dello spettrogramma."
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "Stop the Audio First"
@@ -18388,7 +17995,7 @@ msgstr "Impostazioni s&pettrogramma..."
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectral"
-msgstr "S&pettro"
+msgstr "&Spettro"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "To&ggle Spectral Selection"
@@ -18442,7 +18049,7 @@ msgstr "Modifica nome clip"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Rename Clip..."
-msgstr "Rinomina clip..."
+msgstr "Ri&nomina clip..."
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Format"
@@ -18463,7 +18070,8 @@ msgid "Processing...   %i%%"
 msgstr "Elaborazione...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
-#. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
+#. i18n-hint: The strings name a track and a channel choice (mono, left, or
+#. right)
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
@@ -18899,7 +18507,6 @@ msgstr "Inviluppo regolato."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
-#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Scorri"
@@ -18911,7 +18518,6 @@ msgstr "Ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
-#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Righello scorrimento"
@@ -18930,7 +18536,7 @@ msgstr "Spostare il puntatore del mouse per scorrere"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scru&bbing"
-msgstr "Sco&rrimento"
+msgstr "&Scorrimento"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -18973,7 +18579,8 @@ msgstr "Fare clic e trascinare per regolare la larghezza della banda di frequenz
 msgid "Edit, Preferences..."
 msgstr "Modifica, preferenze..."
 
-#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac
+#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux,
+#. "Command+," for Mac
 #: src/tracks/ui/SelectHandle.cpp
 #, c-format
 msgid "Multi-Tool Mode: %s for Mouse and Keyboard Preferences."
@@ -18987,7 +18594,8 @@ msgstr "Fare clic e trascinare per impostare la larghezza della banda di frequen
 msgid "Click and drag to select audio"
 msgstr "Fare clic e trascinare per selezionare l'audio"
 
-#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any
+#. nearby label or clip boundaries
 #: src/tracks/ui/SelectHandle.cpp
 msgid "(snapping)"
 msgstr "(ancoraggio)"
@@ -19044,13 +18652,15 @@ msgstr "Comando+Clic"
 msgid "Ctrl+Click"
 msgstr "Ctrl+Clic"
 
-#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows,
+#. 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track. Drag up or down to change track order."
 msgstr "%s per selezionare o deselezionare traccia. Trascinare in alto o in basso per cambiare l'ordine della traccia."
 
-#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows,
+#. 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track."
@@ -19098,7 +18708,8 @@ msgstr "Verifica aggiornamenti"
 msgid "If you want to change your preference for automatic updates checking, you can find it in %s."
 msgstr "È possibile modificare le opzioni sulla verifica automatica di aggiornamenti in %s."
 
-#. i18n-hint: Hyperlink title that opens Preferences dialog on Application page and is substituted into "... you can find it in %s." string.
+#. i18n-hint: Hyperlink title that opens Preferences dialog on Application
+#. page and is substituted into "... you can find it in %s." string.
 #. i18n-hint: a page in the Preferences dialog; use same name
 #: src/update/NoUpdatesAvailableDialog.cpp src/update/UpdateNoticeDialog.cpp
 msgid "Preferences > Application"
@@ -19153,7 +18764,8 @@ msgstr "Per rimanete aggiornati si riceverà una notifica in-app qualora ci sia 
 msgid "In order to protect your privacy, Audacity does not collect any personal information. However, app update checking does require network access."
 msgstr "Al fine di tutelare la privacy, Audacity non colleziona nessuna informazione personale. Tuttavia la verifica della presenza di aggiornamenti richiede l'accesso alla rete."
 
-#. i18n-hint: Hint to the user about how to turn the app update off. %s is replaced with "Preferences > Application" link
+#. i18n-hint: Hint to the user about how to turn the app update off. %s is
+#. replaced with "Preferences > Application" link
 #: src/update/UpdateNoticeDialog.cpp
 #, c-format
 msgid "You can turn off app update checking at any time in %s."
@@ -19313,12 +18925,10 @@ msgid "Refresh Rate"
 msgstr "Frequenza di aggiornamento"
 
 #: src/widgets/MeterPanel.cpp
-msgid ""
-"Higher refresh rates make the meter show more frequent\n"
+msgid "Higher refresh rates make the meter show more frequent\n"
 "changes. A rate of 30 per second or less should prevent\n"
 "the meter affecting audio quality on slower machines."
-msgstr ""
-"Frequenze di aggiornamento permettono al monitor di visualizzare modifiche\n"
+msgstr "Frequenze di aggiornamento permettono al monitor di visualizzare modifiche\n"
 "più frequenti. Una frequenza di 30 per secondo o meno dovrebbe impedire\n"
 "che il monitor influisca sulla qualità dell'audio nelle macchine più lente."
 
@@ -19359,23 +18969,22 @@ msgid "Vertical"
 msgstr "Verticale"
 
 #: src/widgets/MissingPluginsErrorDialog.cpp
-#, fuzzy
 msgid "Missing Plugins"
-msgstr "Gestisci estensioni"
+msgstr "Estensioni mancanti"
 
 #: src/widgets/MissingPluginsErrorDialog.cpp
 msgid "This project contains some realtime effect plugins that cannot be found on this system."
-msgstr ""
+msgstr "Questo progetto contiene alcune estensioni con effetti in tempo reale che non sono state trovate su questo sistema."
 
 #. i18n-hint: %s will be replaced with "Learn more"
 #: src/widgets/MissingPluginsErrorDialog.cpp
 #, c-format
 msgid "The project may sound different than intended. %s"
-msgstr ""
+msgstr "Il progetto potrebbe essere riprodotto diversamente da quanto previsto. %s"
 
 #: src/widgets/MissingPluginsErrorDialog.cpp
 msgid "Learn more"
-msgstr ""
+msgstr "Ulteriori informazioni"
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
@@ -19403,7 +19012,8 @@ msgstr "Verificare che la cartella esista, che si abbiano i permessi necessari e
 msgid "You can change the directory in %s."
 msgstr "Non è possibile cambiare la cartella in %s."
 
-#. i18n-hint: Hyperlink title that opens Preferences dialog on Directories page.
+#. i18n-hint: Hyperlink title that opens Preferences dialog on Directories
+#. page.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Preferences > Directories"
 msgstr "Preferenze > Cartelle"
@@ -19465,9 +19075,8 @@ msgid "Value must not be greater than %s"
 msgstr "Il valore non deve essere maggiore di %s"
 
 #: plug-ins/ShelfFilter.ny resources/EffectsMenuDefaults.xml
-#, fuzzy
 msgid "Shelf Filter"
-msgstr "Filtro notch"
+msgstr "Filtro shelf"
 
 #: plug-ins/ShelfFilter.ny plug-ins/StudioFadeOut.ny
 #: plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny
@@ -19481,23 +19090,23 @@ msgstr "Steve Daulton"
 
 #: plug-ins/ShelfFilter.ny plug-ins/SpectralEditMulti.ny
 #: plug-ins/SpectralEditParametricEQ.ny plug-ins/beat.ny plug-ins/clipfix.ny
-#: plug-ins/delay.ny plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/pluck.ny
-#: plug-ins/rhythmtrack.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/delay.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/vocalrediso.ny
+#: plug-ins/vocoder.ny
 msgid "GNU General Public License v2.0"
 msgstr "GNU General Public License v2.0"
 
 #: plug-ins/ShelfFilter.ny
-#, fuzzy
 msgid "Filter type"
-msgstr "Tipo file:"
+msgstr "Tipo di filtro"
 
 #: plug-ins/ShelfFilter.ny
 msgid "Low-shelf"
-msgstr ""
+msgstr "Low-shelf"
 
 #: plug-ins/ShelfFilter.ny
 msgid "High-shelf"
-msgstr ""
+msgstr "High-shelf"
 
 #: plug-ins/ShelfFilter.ny plug-ins/highpass.ny plug-ins/lowpass.ny
 #: plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
@@ -19505,14 +19114,13 @@ msgid "Frequency (Hz)"
 msgstr "Frequenza (Hz)"
 
 #: plug-ins/ShelfFilter.ny
-#, fuzzy
 msgid "Amount (dB)"
-msgstr "Sinistra (dB)"
+msgstr "Quantità (dB)"
 
 #: plug-ins/ShelfFilter.ny
 #, lisp-format
 msgid "Error.~%Frequency set too high for selected track."
-msgstr ""
+msgstr "Errore.~%Frequenza troppo alta per la traccia selezionata."
 
 #: plug-ins/SpectralEditMulti.ny resources/EffectsMenuDefaults.xml
 msgid "Spectral Edit Multi Tool"
@@ -19531,23 +19139,19 @@ msgstr "~aSelezionare le frequenze."
 
 #: plug-ins/SpectralEditMulti.ny
 #, lisp-format
-msgid ""
-"~aBandwidth is zero (the upper and lower~%~\n"
+msgid "~aBandwidth is zero (the upper and lower~%~\n"
 "                       frequencies are both ~a Hz).~%~\n"
 "                       Please select a frequency range."
-msgstr ""
-"~aLa larghezza di banda è zero (le frequenze superiori e inferiori~%~\n"
+msgstr "~aLa larghezza di banda è zero (le frequenze superiori e inferiori~%~\n"
 "                       sono entrambe ~a Hz).~%~\n"
 "                       Selezionare un intervallo di frequenza."
 
 #: plug-ins/SpectralEditMulti.ny
 #, lisp-format
-msgid ""
-"~aNotch filter parameters cannot be applied.~%~\n"
+msgid "~aNotch filter parameters cannot be applied.~%~\n"
 "                      Try increasing the low frequency bound~%~\n"
 "                      or reduce the filter 'Width'."
-msgstr ""
-"~aI parametri del filtro Notch non possono essere applicati.~%~\n"
+msgstr "~aI parametri del filtro Notch non possono essere applicati.~%~\n"
 "                      Provare ad aumentare il limite delle basse frequenze~%~\n"
 "                      o a ridurre la 'larghezza' del filtro."
 
@@ -19582,23 +19186,19 @@ msgstr "~ala frequenza centrale deve essere maggiore di 0 Hz."
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
-msgid ""
-"~aFrequency selection is too high for track sample rate.~%~\n"
+msgid "~aFrequency selection is too high for track sample rate.~%~\n"
 "                        For the current track, the high frequency setting cannot~%~\n"
 "                        be greater than ~a Hz"
-msgstr ""
-"~aLa selezione della frequenza è troppo alta per la frequenza di campionamento della traccia.~%~\n"
+msgstr "~aLa selezione della frequenza è troppo alta per la frequenza di campionamento della traccia.~%~\n"
 "                        Per la traccia corrente, l'impostazione dell'alta frequenza non può~%~\n"
 "                        superare i ~a Hz"
 
 #: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
 #, lisp-format
-msgid ""
-"~aBandwidth is zero (the upper and lower~%~\n"
+msgid "~aBandwidth is zero (the upper and lower~%~\n"
 "                         frequencies are both ~a Hz).~%~\n"
 "                         Please select a frequency range."
-msgstr ""
-"~aLa larghezza di banda è zero (le frequenze superiori e inferiori~%~\n"
+msgstr "~aLa larghezza di banda è zero (le frequenze superiori e inferiori~%~\n"
 "                         sono entrambe ~a Hz).~%~\n"
 "                         Selezionare un intervallo di frequenza."
 
@@ -19747,12 +19347,10 @@ msgstr "~aI valori percentuali non possono essere maggiori di 1000 %."
 
 #: plug-ins/adjustable-fade.ny
 #, lisp-format
-msgid ""
-"~adB values cannot be more than +100 dB.~%~%~\n"
+msgid "~adB values cannot be more than +100 dB.~%~%~\n"
 "                                 Hint: 6 dB doubles the amplitude~%~\n"
 "                                 -6 dB halves the amplitude."
-msgstr ""
-"~aValori in dB non possono superare +100 dB.~%~%~\n"
+msgstr "~aValori in dB non possono superare +100 dB.~%~%~\n"
 "                                 Consiglio: 6 dB raddoppiano l'ampiezza~%~\n"
 "                                 -6 dB dimezzano l'ampiezza."
 
@@ -19885,9 +19483,8 @@ msgid "Low-quality Pitch Shift"
 msgstr "Spostamento intonazione a bassa qualità"
 
 #: plug-ins/delay.ny
-#, fuzzy
 msgid "High-quality Pitch Shift"
-msgstr "Spostamento intonazione a bassa qualità"
+msgstr "Spostamento tono ad alta qualità"
 
 #: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
@@ -20103,12 +19700,10 @@ msgstr "La frequenza deve essere almeno di 0.1 Hz."
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 #, lisp-format
-msgid ""
-"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+msgid "Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
 "                   Track sample rate is ~a Hz~%~\n"
 "                   Frequency must be less than ~a Hz."
-msgstr ""
-"Errore:~%~%La frequenza (~a Hz) è troppo alta per la frequenza di campionamento della traccia.~%~%~\n"
+msgstr "Errore:~%~%La frequenza (~a Hz) è troppo alta per la frequenza di campionamento della traccia.~%~%~\n"
 "                   La frequenza di campionamento della traccia è di ~a Hz~%~\n"
 "                   La frequenza deve essere inferiore a ~a Hz."
 
@@ -20195,9 +19790,9 @@ msgid "Error.~%Selection must be less than ~a."
 msgstr "Errore.~% La selezione deve essere minore di ~a."
 
 #: plug-ins/label-sounds.ny
-#, fuzzy, lisp-format
+#, lisp-format
 msgid "No sounds found.~%Try lowering 'Threshold level (dB)'."
-msgstr "Nessun suono trovato.~%Provare ad abbassare la 'soglia' o a ridurre la 'Durata minima suono'."
+msgstr "Nessun suono trovato.~%Provare ad abbassare 'Livello di soglia (dB)'."
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -20220,7 +19815,8 @@ msgstr "Limite morbido"
 msgid "Hard Limit"
 msgstr "Limite rigido"
 
-#. i18n-hint: clipping of wave peaks and troughs, not division of a track into clips
+#. i18n-hint: clipping of wave peaks and troughs, not division of a track into
+#. clips
 #: plug-ins/limiter.ny
 msgid "Soft Clip"
 msgstr "Clip morbido"
@@ -20230,19 +19826,15 @@ msgid "Hard Clip"
 msgstr "Clipping rigido"
 
 #: plug-ins/limiter.ny
-msgid ""
-"Input Gain (dB)\n"
+msgid "Input Gain (dB)\n"
 "mono/Left"
-msgstr ""
-"Guadagno ingresso (dB)\n"
+msgstr "Guadagno ingresso (dB)\n"
 "mono/sinistro"
 
 #: plug-ins/limiter.ny
-msgid ""
-"Input Gain (dB)\n"
+msgid "Input Gain (dB)\n"
 "Right channel"
-msgstr ""
-"Guadagno ingresso (dB)\n"
+msgstr "Guadagno ingresso (dB)\n"
 "Canale destro"
 
 #: plug-ins/limiter.ny
@@ -20311,46 +19903,38 @@ msgstr "Decadimento (ms)"
 
 #: plug-ins/noisegate.ny
 #, lisp-format
-msgid ""
-"Error.\n"
+msgid "Error.\n"
 "\"Gate frequencies above: ~s kHz\"\n"
 "is too high for selected track.\n"
 "Set the control below ~a kHz."
-msgstr ""
-"Error.\n"
+msgstr "Error.\n"
 "\"Frequenze del gate superiori: ~s kHz\"\n"
 "troppo elevate per la traccia selezionata.\n"
 "Impostare il controllo sotto ~a kHz."
 
 #: plug-ins/noisegate.ny
 #, lisp-format
-msgid ""
-"Error.\n"
+msgid "Error.\n"
 "Selection too long.\n"
 "Maximum length is ~a."
-msgstr ""
-"Errore.\n"
+msgstr "Errore.\n"
 "Selezione troppo lunga.\n"
 "La lunghezza massima è ~a."
 
 #: plug-ins/noisegate.ny
 #, lisp-format
-msgid ""
-"Error.\n"
+msgid "Error.\n"
 "Insufficient audio selected.\n"
 "Make the selection longer than ~a ms."
-msgstr ""
-"Errore.\n"
+msgstr "Errore.\n"
 "Audio selezionato non sufficiente.\n"
 "La selezione deve essere più lunga di ~a ms."
 
 #: plug-ins/noisegate.ny
 #, lisp-format
-msgid ""
-"Peak based on first ~a seconds ~a dB~%\n"
+msgid "Peak based on first ~a seconds ~a dB~%\n"
 "Suggested Threshold Setting ~a dB."
-msgstr ""
-"Picco basato sui primi ~a secondi ~a dB~%\n"
+msgstr "Picco basato sui primi ~a secondi ~a dB~%\n"
 "Impostazione soglia suggerita ~a dB."
 
 #. i18n-hint: hours and minutes. Do not translate "~a".
@@ -20373,12 +19957,10 @@ msgstr "Q (un valore più alto riduce la larghezza)"
 
 #: plug-ins/notch.ny
 #, lisp-format
-msgid ""
-"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+msgid "Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
 "                 Track sample rate is ~a Hz.~%~\n"
 "                 Frequency must be less than ~a Hz."
-msgstr ""
-"Errore:~%~%La frequenza (~a Hz) è troppo alta per la frequenza di campionamento della traccia.~%~%~\n"
+msgstr "Errore:~%~%La frequenza (~a Hz) è troppo alta per la frequenza di campionamento della traccia.~%~%~\n"
 "                 La frequenza di campionamento della traccia è di ~a Hz.~%~\n"
 "                 La frequenza deve essere inferiore a ~a Hz."
 
@@ -20605,11 +20187,9 @@ msgid "MIDI pitch of weak beat"
 msgstr "Intonazione MIDI di battuta debole"
 
 #: plug-ins/rhythmtrack.ny
-msgid ""
-"Set either 'Number of bars' or\n"
+msgid "Set either 'Number of bars' or\n"
 "'Rhythm track duration' to greater than zero."
-msgstr ""
-"Impostare il 'numero di barre' o la\n"
+msgstr "Impostare il 'numero di barre' o la\n"
 "'durata traccia ritmo' a maggiore di zero."
 
 #: plug-ins/rissetdrum.ny
@@ -20750,21 +20330,17 @@ msgstr "~a   ~a~%~aFrequenza di campionamento: ~a Hz.~%Lunghezza elaborata: ~a c
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
-msgid ""
-"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+msgid "~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
 "                     Length processed: ~a samples ~a seconds.~a"
-msgstr ""
-"~a   ~a~%~aFrequenza di campionamento: ~a Hz. Valori campioni in scala ~a.~%~\n"
+msgstr "~a   ~a~%~aFrequenza di campionamento: ~a Hz. Valori campioni in scala ~a.~%~\n"
 "                     Lunghezza elaborata: ~a campioni ~a secondi.~a"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
-msgid ""
-"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+msgid "~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
 "                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
 "                  DC offset: ~a~a"
-msgstr ""
-"~a~%Frequenza di campionamento: ~a Hz. Valori campioni in scala ~a. ~a.~%~aLunghezza elaborata: ~a ~\n"
+msgstr "~a~%Frequenza di campionamento: ~a Hz. Valori campioni in scala ~a. ~a.~%~aLunghezza elaborata: ~a ~\n"
 "                  campioni, ~a secondi.~%Ampiezza picco: ~a (lineare) ~a dB. RMS non ponderato: ~a dB.~%~\n"
 "                  Offset DC: ~a~a"
 
@@ -20803,13 +20379,15 @@ msgstr "<b>Frequenza di campionamento:</b> &nbsp;&nbsp;~a Hz."
 msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
 msgstr "<b>Ampiezza picco:</b> &nbsp;&nbsp;~a (lineare) &nbsp;&nbsp;~a dB."
 
-#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a
+#. signal; there also "weighted" versions of it but this isn't that
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
 msgstr "<b>RMS</b> (non ponderato): &nbsp;&nbsp;~a dB."
 
-#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#. i18n-hint: DC derives from "direct current" in electronics, really means
+#. the zero frequency component of a signal
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
@@ -20863,12 +20441,10 @@ msgstr "Destra (dB)"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
-msgid ""
-"Produced with <span>Sample Data Export</span> for\n"
+msgid "Produced with <span>Sample Data Export</span> for\n"
 "<a href=\"~a\">Audacity</a> by Steve\n"
 "Daulton"
-msgstr ""
-"Prodotto con <span>Esporta dati campione</span> per\n"
+msgstr "Prodotto con <span>Esporta dati campione</span> per\n"
 "<a href=\"~a\">Audacity</a> da Steve\n"
 "Daulton"
 
@@ -20940,34 +20516,28 @@ msgstr "Leggi come zero"
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
-msgid ""
-"Error~%~\n"
+msgid "Error~%~\n"
 "                        '~a' could not be opened.~%~\n"
 "                        Check that file exists."
-msgstr ""
-"Errore~%~\n"
+msgstr "Errore~%~\n"
 "                        '~a' non può essere aperto.~%~\n"
 "                        Controllare che il file esista."
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
-msgid ""
-"Error:~%~\n"
+msgid "Error:~%~\n"
 "              The file must contain only plain ASCII text.~%~\n"
 "              (Invalid byte '~a' at byte number: ~a)"
-msgstr ""
-"Errore:~%~\n"
+msgstr "Errore:~%~\n"
 "              Il file deve contenere solo testo ASCII normale.~%~\n"
 "              (Byte '~a' non valido al numero byte: ~a)"
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
-msgid ""
-"Error~%~\n"
+msgid "Error~%~\n"
 "              Data must be numbers in plain ASCII text.~%~\n"
 "              '~a' is not a numeric value."
-msgstr ""
-"Errore~%~\n"
+msgstr "Errore~%~\n"
 "              I dati devono essere numeri in testo ASCII normale.~%~\n"
 "              '~a' non è un valore numerico valido."
 
@@ -21059,8 +20629,7 @@ msgstr "Taglio alto per voci (Hz)"
 
 #: plug-ins/vocalrediso.ny
 #, lisp-format
-msgid ""
-"Average x: ~a, y: ~a\n"
+msgid "Average x: ~a, y: ~a\n"
 "                    Covariance x y: ~a\n"
 "                    Average variance x: ~a, y: ~a\n"
 "                    Standard deviation x: ~a, y: ~a\n"
@@ -21068,8 +20637,7 @@ msgid ""
 "                    Coefficient of determination: ~a\n"
 "                    Variation of residuals: ~a\n"
 "                    y equals ~a plus ~a times x~%"
-msgstr ""
-"Media x: ~a, y: ~a\n"
+msgstr "Media x: ~a, y: ~a\n"
 "                    Covarianza x y: ~a\n"
 "                    Varianza media x: ~a, y: ~a\n"
 "                    Deviazione standard x: ~a, y: ~a\n"
@@ -21084,21 +20652,17 @@ msgid "Pan position: ~a~%The left and right channels are correlated by about ~a 
 msgstr "Posizione bilanciamento: ~a~%I canali sinistro e destro sono correlati di circa ~a %. Questo significa:~%~a~%"
 
 #: plug-ins/vocalrediso.ny
-msgid ""
-" - The two channels are identical, i.e. dual mono.\n"
+msgid " - The two channels are identical, i.e. dual mono.\n"
 "                The center can't be removed.\n"
 "                Any remaining difference may be caused by lossy encoding."
-msgstr ""
-" - I due canali sono identici, cioè doppio mono.\n"
+msgstr " - I due canali sono identici, cioè doppio mono.\n"
 "                Il centro non può essere rimosso.\n"
 "                Qualsiasi differenza residua può essere causata da una codifica con perdita."
 
 #: plug-ins/vocalrediso.ny
-msgid ""
-" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+msgid " - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
 "                Most likely, the center extraction will be poor."
-msgstr ""
-" - I due canali sono fortemente correlati, ovvero quasi mono o estremamente bilanciati.\n"
+msgstr " - I due canali sono fortemente correlati, ovvero quasi mono o estremamente bilanciati.\n"
 "                Molto probabilmente, l'estrazione centrale sarà scarsa."
 
 #: plug-ins/vocalrediso.ny
@@ -21106,41 +20670,33 @@ msgid " - A fairly good value, at least stereo in average and not too wide sprea
 msgstr " - Un valore abbastanza buono, stereo almeno in media e non troppo diffuso."
 
 #: plug-ins/vocalrediso.ny
-msgid ""
-" - An ideal value for Stereo.\n"
+msgid " - An ideal value for Stereo.\n"
 "                However, the center extraction depends also on the used reverb."
-msgstr ""
-" - Un valore ideale per lo stereo.\n"
+msgstr " - Un valore ideale per lo stereo.\n"
 "                Tuttavia, l'estrazione centrale dipende anche dal riverbero usato."
 
 #: plug-ins/vocalrediso.ny
-msgid ""
-" - The two channels are almost not related.\n"
+msgid " - The two channels are almost not related.\n"
 "                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
 "                The center extraction can still be good though."
-msgstr ""
-" - I due canali sono quasi non correlati.\n"
+msgstr " - I due canali sono quasi non correlati.\n"
 "                Si ha solo rumore o il pezzo è stato masterizzato in modo sbilanciato.\n"
 "                L'estrazione centrale può comunque essere abbastanza buona."
 
 #: plug-ins/vocalrediso.ny
-msgid ""
-" - Although the Track is stereo, the field is obviously extra wide.\n"
+msgid " - Although the Track is stereo, the field is obviously extra wide.\n"
 "                This can cause strange effects.\n"
 "                Especially when played by only one speaker."
-msgstr ""
-" - Sebbene la traccia sia stereo, il campo è evidentemente molto ampio.\n"
+msgstr " - Sebbene la traccia sia stereo, il campo è evidentemente molto ampio.\n"
 "                Questo può causare strani effetti.\n"
 "                Soprattutto se riprodotto da un solo altoparlante."
 
 #: plug-ins/vocalrediso.ny
-msgid ""
-" - The two channels are nearly identical.\n"
+msgid " - The two channels are nearly identical.\n"
 "                  Obviously, a pseudo stereo effect has been used\n"
 "                  to spread the signal over the physical distance between the speakers.\n"
 "                  Don't expect good results from a center removal."
-msgstr ""
-" - I due canali sono quasi identici.\n"
+msgstr " - I due canali sono quasi identici.\n"
 "                  Ovviamente, è stato usato un effetto pseudo-stereo\n"
 "                  per diffondere il segnale sulla distanza fisica tra gli altoparlanti.\n"
 "                  Non sono attesi buoni risultati da una rimozione del centro."
@@ -21240,161 +20796,3 @@ msgstr "Rimozione voce"
 #: resources/EffectsMenuDefaults.xml
 msgid "Spectral Tools"
 msgstr "Strumenti spettrali"
-
-#, c-format
-#~ msgid "Exception code 0x%x"
-#~ msgstr "Codice eccezione 0x%x"
-
-#~ msgid "Unknown exception"
-#~ msgstr "Eccezione sconosciuta"
-
-#~ msgid "Unknown error"
-#~ msgstr "Errore sconosciuto"
-
-#~ msgid "Problem Report for Audacity"
-#~ msgstr "Rapporto problemi per Audacity"
-
-#~ msgid "Click \"Send\" to submit the report to Audacity. This information is collected anonymously."
-#~ msgstr "Fare clic su \"Invia\" per inviare il rapporto ad Audacity. Queste informazioni sono collezionate in forma anonima."
-
-#~ msgid "Failed to send crash report"
-#~ msgstr "Non è stato possibile inviare il rapporto sull'arresto anomalo"
-
-#~ msgid "Former Musers"
-#~ msgstr "Ex dipendenti di Muse"
-
-#~ msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-#~ msgstr ""
-#~ "[[help:Quick_Help|Guida rapida]] - se non installata localmente,\n"
-#~ "[[https://manual.audacityteam.org/quick_help.html|visualizza online]]"
-
-#~ msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
-#~ msgstr " [[help:Main_Page|Manuale]] - se non installato localmente, [[https://manual.audacityteam.org/|visualizza online]]"
-
-#~ msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-#~ msgstr "Inoltre:</b> Visita il nostro [[https://wiki.audacityteam.org/index.php|wiki]] per suggerimenti, trucchi, ulteriori tutorial ed estensioni per gli effetti."
-
-#~ msgid "SelectionBar"
-#~ msgstr "Barra di selezione"
-
-#~ msgid "Timer"
-#~ msgstr "Timer"
-
-#~ msgid "Play Meter"
-#~ msgstr "Monitor riproduzione"
-
-#~ msgid "Nearest"
-#~ msgstr "Il più vicino"
-
-#~ msgid "Prior"
-#~ msgstr "Precedente"
-
-#~ msgid "Selectionbar"
-#~ msgstr "Barra di selezione"
-
-#~ msgid "Enable"
-#~ msgstr "Abilita"
-
-#~ msgid "&Processing: "
-#~ msgstr "&Elaborazione: "
-
-#~ msgid "D&efault"
-#~ msgstr "Pr&edefinito"
-
-#~ msgid "&SSE"
-#~ msgstr "&SSE"
-
-#~ msgid "SSE &Threaded"
-#~ msgstr "SSE con &thread"
-
-#~ msgid "A&VX"
-#~ msgstr "A&VX"
-
-#~ msgid "AV&X Threaded"
-#~ msgstr "AV&X con thread"
-
-#~ msgid "&Bench"
-#~ msgstr "&Bench"
-
-#~ msgid "Cannot open file"
-#~ msgstr "Impossibile aprire il file"
-
-#, c-format
-#~ msgid "Cannot open VST3 preset file %s"
-#~ msgstr "Impossibile aprire il file della combinazione VST3 %s"
-
-#, c-format
-#~ msgid "Plugin %d to %d"
-#~ msgstr "Estensione %d a %d"
-
-#~ msgid "&Window"
-#~ msgstr "&Finestra"
-
-#~ msgid "&Minimize"
-#~ msgstr "&Minimizza"
-
-#~ msgid "&Bring All to Front"
-#~ msgstr "&Porta tutto in primo piano"
-
-#~ msgid "Minimize All Projects"
-#~ msgstr "Minimizza tutti i progetti"
-
-#~ msgid "Devices"
-#~ msgstr "Dispositivi"
-
-#~ msgid "Preferences for Device"
-#~ msgstr "Preferenze per dispositivo"
-
-#~ msgid "Default"
-#~ msgstr "Predefinito"
-
-#~ msgid "&LADSPA"
-#~ msgstr "&LADSPA"
-
-#~ msgid "LV&2"
-#~ msgstr "LV&2"
-
-#~ msgid "N&yquist"
-#~ msgstr "N&yquist"
-
-#~ msgid "&Vamp"
-#~ msgstr "&Vamp"
-
-#~ msgid "V&ST"
-#~ msgstr "V&ST"
-
-#~ msgid "Enable Effects"
-#~ msgstr "Abilita effetti"
-
-#~ msgid "S&ort or Group:"
-#~ msgstr "&Ordina o raggruppa:"
-
-#~ msgid "&Maximum effects per group (0 to disable):"
-#~ msgstr "Numero &massimo di effetti per gruppo (0 per disabilitare):"
-
-#~ msgid "&Vari-Speed Play"
-#~ msgstr "Riproduzione a &varie velocità"
-
-#~ msgid "Sampling"
-#~ msgstr "Campionamento"
-
-#~ msgid "Project Rate (Hz)"
-#~ msgstr "Frequenza progetto (Hz)"
-
-#~ msgid "Snap To"
-#~ msgstr "Ancoraggio"
-
-#, c-format
-#~ msgid "Snap Clicks/Selections to %s"
-#~ msgstr "Aggancia clic/selezioni a %s"
-
-#, c-format
-#~ msgid "%s - driven"
-#~ msgstr "Controllato da %s"
-
-#, c-format
-#~ msgid "Selection %s. %s won't change."
-#~ msgstr "%s selezione. %s non cambierà."
-
-#~ msgid "Rename clip..."
-#~ msgstr "Rinomina clip..."


### PR DESCRIPTION
Here's the 100% translated strings for Italian.

Is there a standard formatting approach for .po files?

I mean, I translated those strings with Transifex, and I downloaded them.
But I don'l like the formatting they use.

For example, here's a section of the file generated by Transifex:

```po
msgid "Cannot check mutual sample rates without both devices.\n"
msgstr ""
"Impossibile verificare le frequenze di campionamento reciproche senza "
"entrambi i dispositivi.\n"
```

- Why the source string is right after `msgid` and the translation is on its own line?
- I don't want to break lines at random points: I'd like to break lines when the string contains `\n`.

So I reformatted the .po file this way:

```sh
cat downloaded-from-transifex.po \
    | sed -z 's/"\n"//g'  \
    | sed -z 's/\\n/\\n"\n"/g'  \
    | sed '/^""$/d' \
    > fixed.po
```

Where:
- the first `sed` make it so that we have just one line for every `msgid`/`msgstr`
- the second `sed` splits the strings when they contain the `\n` string
- the third `sed` removes lines containing only `""`

For example, let's consider this string (as downloaded from Transifex):

```po
msgid ""
"Running two copies of Audacity simultaneously may cause\n"
"data loss or cause your system to crash.\n"
"\n"
msgstr ""
"L'esecuzione contemporanea di due copie di Audacity può causare\n"
"perdita di dati o un blocco del sistema.\n"
"\n"
```

With the first `sed` we have:

```po
msgid "Running two copies of Audacity simultaneously may cause\ndata loss or cause your system to crash.\n\n"
msgstr "L'esecuzione contemporanea di due copie di Audacity può causare\nperdita di dati o un blocco del sistema.\n\n"
```

With the second `sed` we have:

```po
msgid "Running two copies of Audacity simultaneously may cause\n"
"data loss or cause your system to crash.\n"
"\n"
""
msgstr "L'esecuzione contemporanea di due copie di Audacity può causare\n"
"perdita di dati o un blocco del sistema.\n"
"\n"
""
```

With the final `sed` we have:

```po
msgid "Running two copies of Audacity simultaneously may cause\n"
"data loss or cause your system to crash.\n"
"\n"
msgstr "L'esecuzione contemporanea di due copie di Audacity può causare\n"
"perdita di dati o un blocco del sistema.\n"
"\n"
```

But everything seems rather arbitrary... I mean, it's ok for me, but others may have a different preference about formatting.

What about adding some specifics of the format of the .po files (or, even better, a script)?