### PR TITLE
Effect preview progress

### DIFF
--- a/libraries/lib-wx-init/ProgressDialog.cpp
+++ b/libraries/lib-wx-init/ProgressDialog.cpp
@@ -1104,6 +1104,7 @@ void ProgressDialog::Reinit()
       button->Enable();
 
    wxDialogWrapper::Show(true);
+   wxDialogWrapper::Raise();
 
    mTotalPollTime = {};
    mPollsCount = {};

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -385,17 +385,7 @@ void EffectUIHost::BuildButtonBar(ShuttleGui &S, bool graphicalUI)
 
          if (!mIsBatch)
          {
-            if (mSupportsRealtime)
-            {
-               if (mpTempProjectState)
-               {
-                  mPlayToggleBtn = S.Id(kPlayID)
-                     .ToolTip(XO("Start and stop preview"))
-                     .AddButton( { },
-                                 wxALIGN_CENTER | wxTOP | wxBOTTOM );
-               }
-            }
-            else if (
+            if (
                (mEffectUIHost.GetDefinition().GetType() != EffectTypeAnalyze) &&
                (mEffectUIHost.GetDefinition().GetType() != EffectTypeTool) )
             {
@@ -537,9 +527,6 @@ void EffectUIHost::OnPaint(wxPaintEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnClose(wxCloseEvent & WXUNUSED(evt))
 {
-   if (mPlaying)
-      StopPlayback();
-
    DoCancel();
    CleanupRealtime();
 
@@ -568,9 +555,6 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
       return;
    }
 
-   if (mPlaying)
-      StopPlayback();
-   
    // Honor the "select all if none" preference...a little hackish, but whatcha gonna do...
    if (!mIsBatch &&
        mEffectUIHost.GetDefinition().GetType() != EffectTypeGenerate &&
@@ -770,84 +754,25 @@ void EffectUIHost::OnEnable(wxCommandEvent & WXUNUSED(evt))
 
 void EffectUIHost::OnPlay(wxCommandEvent & WXUNUSED(evt))
 {
-   if (!mSupportsRealtime)
-   {
-      if (!TransferDataFromWindow())
-         return;
-      
-      auto updater = [this]{ TransferDataToWindow(); };
-      mEffectUIHost.Preview(*mpAccess, updater, false);
-      // After restoration of settings and effect state:
-      // In case any dialog control depends on mT1 or mDuration:
-      updater();
-
+   if (!TransferDataFromWindow())
       return;
-   }
    
-   if (mPlaying)
-   {
-      StopPlayback();
-   }
-   else
-   {
-      auto &viewInfo = ViewInfo::Get( mProject );
-      const auto &selectedRegion = viewInfo.selectedRegion;
-      const auto &playRegion = viewInfo.playRegion;
-      if ( playRegion.Active() )
-      {
-         mRegion.setTimes(playRegion.GetStart(), playRegion.GetEnd());
-         mPlayPos = mRegion.t0();
-      }
-      else if (selectedRegion.t0() != mRegion.t0() ||
-               selectedRegion.t1() != mRegion.t1())
-      {
-         mRegion = selectedRegion;
-         mPlayPos = mRegion.t0();
-      }
-      
-      if (mPlayPos > mRegion.t1())
-      {
-         mPlayPos = mRegion.t1();
-      }
-      
-      auto &projectAudioManager = ProjectAudioManager::Get( mProject );
-      projectAudioManager.PlayPlayRegion(
-         SelectedRegion{ mPlayPos, mRegion.t1() },
-         ProjectAudioIO::GetDefaultOptions(mProject),
-         PlayMode::normalPlay);
-   }
-}
+   auto updater = [this]{ TransferDataToWindow(); };
+   mEffectUIHost.Preview(*mpAccess, updater, false);
+   // After restoration of settings and effect state:
+   // In case any dialog control depends on mT1 or mDuration:
+   updater();
 
-void EffectUIHost::OnPlayback(AudioIOEvent evt)
-{
-   if (evt.on) {
-      if (evt.pProject != &mProject)
-         mDisableTransport = true;
-      else
-         mPlaying = true;
-   }
-   else {
-      mDisableTransport = false;
-      mPlaying = false;
-   }
-   
-   if (mPlaying) {
-      mRegion = ViewInfo::Get( mProject ).selectedRegion;
-      mPlayPos = mRegion.t0();
-   }
-   UpdateControls();
+   return;
 }
 
 void EffectUIHost::OnCapture(AudioIOEvent evt)
 {
    if (evt.on) {
-      if (evt.pProject != &mProject)
-         mDisableTransport = true;
-      else
+      if (evt.pProject == &mProject)
          mCapturing = true;
    }
    else {
-      mDisableTransport = false;
       mCapturing = false;
    }
    UpdateControls();
@@ -1093,26 +1018,6 @@ void EffectUIHost::UpdateControls()
    }
 
    mApplyBtn->Enable(!mCapturing);
-
-   if (mSupportsRealtime)
-   {
-      mPlayToggleBtn->Enable(!(mCapturing || mDisableTransport));
-
-      if (mPlaying)
-      {
-         /* i18n-hint: The access key "&P" should be the same in
-          "Stop &Preview" and "Start &Preview" */
-         mPlayToggleBtn->SetLabel(_("Stop &Preview"));
-         mPlayToggleBtn->Refresh();
-      }
-      else
-      {
-         /* i18n-hint: The access key "&P" should be the same in
-          "Stop &Preview" and "Start &Preview" */
-         mPlayToggleBtn->SetLabel(_("&Preview"));
-         mPlayToggleBtn->Refresh();
-      }
-   }
 }
 
 void EffectUIHost::LoadUserPresets()
@@ -1137,8 +1042,6 @@ std::shared_ptr<EffectInstance> EffectUIHost::InitializeInstance()
    bool priorState = (mpState != nullptr);
    if (!priorState) {
       auto gAudioIO = AudioIO::Get();
-      mDisableTransport = !gAudioIO->IsAvailable(mProject);
-      mPlaying = gAudioIO->IsStreamActive(); // not exactly right, but will suffice
       mCapturing = gAudioIO->IsStreamActive() && gAudioIO->GetNumCaptureChannels() > 0 && !gAudioIO->IsMonitoring();
    }
 
@@ -1166,8 +1069,6 @@ std::shared_ptr<EffectInstance> EffectUIHost::InitializeInstance()
       if (!priorState) {
          mAudioIOSubscription = AudioIO::Get()->Subscribe([this](AudioIOEvent event){
             switch (event.type) {
-            case AudioIOEvent::PLAYBACK:
-               OnPlayback(event); break;
             case AudioIOEvent::CAPTURE:
                OnCapture(event); break;
             default:
@@ -1203,17 +1104,6 @@ void EffectUIHost::CleanupRealtime()
       }
       mInitialized = false;
    }
-}
-
-void EffectUIHost::StopPlayback()
-{
-   if (!mPlaying)
-      return;
-   
-   auto gAudioIO = AudioIO::Get();
-   mPlayPos = gAudioIO->GetStreamTime();
-   auto& projectAudioManager = ProjectAudioManager::Get(mProject);
-   projectAudioManager.Stop();
 }
 
 DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,

--- a/src/effects/EffectUI.h
+++ b/src/effects/EffectUI.h
@@ -110,8 +110,6 @@ private:
 
    void CleanupRealtime();
 
-   void StopPlayback();
-
 private:
    Observer::Subscription mAudioIOSubscription, mEffectStateSubscription;
 
@@ -141,8 +139,6 @@ private:
 
    bool mEnabled{ true };
 
-   bool mDisableTransport{ true };
-   bool mPlaying{};
    bool mCapturing{};
 
    SelectedRegion mRegion;


### PR DESCRIPTION
Resolves: #4323
Resolves: #4307
Resolves: #4587

Fix bugs related to progress dialogs when previewing effects, and a minor inconsistency in button tooltips.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
