### PR TITLE
Play at speed slider: Problem with step sizes for keyboard users.

### DIFF
--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -234,8 +234,8 @@ void TranscriptionToolBar::Populate()
       ASlider::Options{}
          .Style( SPEED_SLIDER )
          //  6 steps using page up/down, and 60 using arrow keys
-         .Line( 0.16667f )
-         .Page( 1.6667f )
+         .Line( 0.16722f )
+         .Page( 1.6722f )
    );
    mPlaySpeedSlider->SetSizeHints(wxSize(100, 25), wxSize(2000, 25));
    mPlaySpeedSlider->Set(mPlaySpeed / 100.0);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4619

Problem:
Using the keyboard it can be not straightforward to get back to a speed of 1.00 after setting the slider to its minimum or maximum slider.

In void TranscriptionToolBar::Populate(), with the values set for options.Line() and options.Page(), and given how the step sizes are calculated in LWSlider::Increase() and LWSlider::Decrease(), the step sizes are 2.99/60, and 2.99/6.

Fix:
Change the values set for options.Line() and options.Page so that the step sizes are 3.00/60 and 3.00/6. Note: After this fix, a user will still encounter the same issue if they set the slider to the minimum value, and then try to return to 1.00, but they can work around this by setting the slider to the maximum value and then returning to 1.00. In addition most users will probably be using speeds of > 1.00.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
