### PR TITLE
Namespace composite

### DIFF
--- a/libraries/lib-utility/CMakeLists.txt
+++ b/libraries/lib-utility/CMakeLists.txt
@@ -24,6 +24,8 @@ set( SOURCES
    Callable.h
    CommandLineArgs.cpp
    CommandLineArgs.h
+   Composite.cpp
+   Composite.h
    GlobalVariable.h
    MemoryX.cpp
    MemoryX.h

--- a/libraries/lib-utility/Composite.cpp
+++ b/libraries/lib-utility/Composite.cpp
@@ -1,0 +1,11 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file Composite.cpp
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+#include "Composite.h"

--- a/libraries/lib-utility/Composite.h
+++ b/libraries/lib-utility/Composite.h
@@ -12,6 +12,8 @@
 #ifndef __AUDACITY_COMPOSITE__
 #define __AUDACITY_COMPOSITE__
 
+#include <cassert>
+#include <iterator>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -62,6 +64,78 @@ public:
 
 protected:
    Items items;
+};
+
+//! You may specialize this template, defining ItemBuilder that converts
+//! other types to Base::value_type
+/*!
+ A trait lets the Builder and Extension templates have parameter packs for other
+ purposes.
+ enables_item_type_v may be redefined to return false for certain types, which
+ removes the overload resolution candidate for push_back taking those types.
+ */
+template<typename Base, typename Derived> struct Traits {
+   static constexpr auto ItemBuilder = std::move<typename Base::value_type>;
+   template<typename T> static constexpr auto enables_item_type_v = true;
+};
+
+namespace detail {
+template<bool Deprecate> struct This;
+template<> struct This<false> {};
+template<> struct [[deprecated(
+   "Composite::Builder specialization does not enable Base::value_type"
+)]] This<true> {};
+}
+
+//! Specialization of Traits can wrap the push_back of the base class
+//! with a type-erasing gate-keeper, which can also do other value
+//! transformations
+/*!
+ This class comes between Base and Derived in the inheritance graph
+ */
+template<typename Base, typename Derived, typename... BaseArgs>
+struct Builder : Base
+{
+   using BaseType = Base;
+
+   //! Define a push_back, which makes this work also with back_inserter
+   //! Traits can determine whether to enable the overloads
+   template<typename Arg> auto push_back(Arg &&arg)
+      -> std::enable_if_t<Traits<Base, Derived>
+            ::template enables_item_type_v<Arg>,
+         void
+      >
+   {
+      static constexpr auto ItemBuilder = Traits<Base, Derived>::ItemBuilder;
+      Base::push_back(ItemBuilder(std::forward<Arg>(arg)));
+   }
+   //! This non-template overload is also needed so overload resolution does
+   //! not select the private inherited function
+   void push_back(typename Base::value_type arg) {
+      constexpr auto enable = Traits<Base, Derived>
+         ::template enables_item_type_v<typename Base::value_type>;
+      // We can't sfinae this overload away when traits want to disable it, but
+      // we can make a deprecation
+      static const detail::This<!enable> deprecator;
+      if constexpr(!enable) {
+         assert(false);
+      }
+      else {
+         static constexpr auto ItemBuilder = Traits<Base, Derived>::ItemBuilder;
+         Base::push_back(ItemBuilder(move(arg)));
+      }
+   }
+
+   //! Variadic constructor
+   template<typename... Items>
+   Builder(BaseArgs... args, Items&&... items)
+      : Base{ std::forward<BaseArgs>(args)... }
+   {
+      (..., push_back(std::forward<Items>(items)));
+   }
+
+private:
+   using BaseType::push_back;
 };
 
 //! Extend Base with extra fields, in a second, protected base class

--- a/libraries/lib-utility/Composite.h
+++ b/libraries/lib-utility/Composite.h
@@ -1,0 +1,69 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file Composite.h
+ @brief Support for the Composite pattern
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+#ifndef __AUDACITY_COMPOSITE__
+#define __AUDACITY_COMPOSITE__
+
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace Composite {
+
+//! Generates a base class for internal nodes of tree structures, which acts
+//! like a standard container (including compatibility with range-for and
+//! back_inserter)
+/*!
+ @tparam Component common base class of nodes and leaves (and of Base itself),
+ which must have a virtual destructor
+ @tparam ComponentPointer type of pointer to Components to be stored
+ @tparam ComponentArgs... passed to constructor of Component
+ */
+template<
+   typename Component,
+   typename ComponentPointer,
+   typename... ComponentArgs
+>
+class Base : public Component
+{
+public:
+   using value_type = ComponentPointer;
+   using Items = std::vector<value_type>;
+
+   explicit Base(ComponentArgs... args)
+      : Component{ std::forward<ComponentArgs>(args)... }
+   {
+      static_assert(std::has_virtual_destructor_v<Component>);
+   }
+
+   Base(const Base&) = delete;
+   Base& operator =(const Base&) = delete;
+
+   auto begin() const { return items.begin(); }
+   auto end() const { return items.end(); }
+   auto cbegin() const { return items.cbegin(); }
+   auto cend() const { return items.cend(); }
+   auto rbegin() const { return items.rbegin(); }
+   auto rend() const { return items.rend(); }
+   auto crbegin() const { return items.crbegin(); }
+   auto crend() const { return items.crend(); }
+
+   void push_back(value_type ptr){ items.push_back(move(ptr)); }
+
+   [[nodiscard]] bool empty() const { return items.empty(); }
+
+protected:
+   Items items;
+};
+
+}
+
+#endif

--- a/libraries/lib-utility/Composite.h
+++ b/libraries/lib-utility/Composite.h
@@ -64,6 +64,45 @@ protected:
    Items items;
 };
 
+//! Extend Base with extra fields, in a second, protected base class
+template<
+   typename Base,
+   typename Base2,
+   typename... RequiredBaseArgs
+>
+struct Extension
+   : public Base
+   , protected Base2
+{
+   template<typename... OtherBaseArgs>
+   Extension(RequiredBaseArgs... args, Base2 arg2,
+      OtherBaseArgs &&...otherArgs
+   )  : Base{ std::forward<RequiredBaseArgs>(args)...,
+         std::forward<OtherBaseArgs>(otherArgs)...
+      }
+      , Base2{ std::move(arg2) }
+   {}
+};
+
+//! Specialization when there is no need for the second base
+template<
+   typename Base,
+   typename... RequiredBaseArgs
+> struct Extension<
+   Base,
+   void,
+   RequiredBaseArgs...
+>
+   : public Base
+{
+   template<typename... OtherBaseArgs>
+   Extension(RequiredBaseArgs... args, OtherBaseArgs &&...otherArgs)
+      : Base{ std::forward<RequiredBaseArgs>(args)...,
+         std::forward<OtherBaseArgs>(otherArgs)...
+      }
+   {}
+};
+
 }
 
 #endif

--- a/libraries/lib-utility/tests/CMakeLists.txt
+++ b/libraries/lib-utility/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_unit_test(
       lib-utility
    SOURCES
       CallableTest.cpp
+      CompositeTest.cpp
       TupleTest.cpp
       TypeEnumeratorTest.cpp
       VariantTest.cpp

--- a/libraries/lib-utility/tests/CompositeTest.cpp
+++ b/libraries/lib-utility/tests/CompositeTest.cpp
@@ -1,0 +1,99 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CompositeTest.cpp
+
+  Paul Licameli
+
+**********************************************************************/
+#include <catch2/catch.hpp>
+#include "Composite.h"
+#include <algorithm>
+#include <iterator>
+#include <numeric>
+
+using namespace Composite;
+using namespace std;
+
+namespace {
+struct MyComponent {
+   MyComponent(int value) : value{ value } {}
+   virtual ~MyComponent() = default;
+   const int value;
+   operator int() const { return value; }
+};
+
+using MyCompositeBase = Base<MyComponent, unique_ptr<MyComponent>, int>;
+
+inline bool operator== (int n, const unique_ptr<MyComponent> &p)
+{
+   return n == *p;
+}
+
+// Test that two sequences are equal, several ways, which also exercises
+// compilation of all the STL style accessors
+template<bool members = true, typename Container1, typename Container2>
+bool compareSequences(const Container1 &c1, const Container2 &c2)
+{
+   bool result = true;
+   if constexpr(members) {
+      result =
+         (equal(c1.begin(), c1.end(), c2.begin(), c2.end()))
+      &&
+         (equal(c1.cbegin(), c1.cend(), c2.cbegin(), c2.cend()))
+      &&
+         (equal(c1.rbegin(), c1.rend(), c2.rbegin(), c2.rend()))
+      &&
+         (equal(c1.crbegin(), c1.crend(), c2.crbegin(), c2.crend()));
+   }
+   result = result &&
+      (equal(begin(c1), end(c1), begin(c2), end(c2)))
+   &&
+      (equal(cbegin(c1), cend(c1), cbegin(c2), cend(c2)))
+   &&
+      (equal(rbegin(c1), rend(c1), rbegin(c2), rend(c2)))
+   &&
+      (equal(crbegin(c1), crend(c1), crbegin(c2), crend(c2)))
+   ;
+   return result;
+}
+}
+
+TEST_CASE("Composite")
+{
+   // CompositeBase passes constructor arguments to its Component
+   MyCompositeBase compositeBase{ 0 };
+   REQUIRE(0 == compositeBase);
+   REQUIRE(compositeBase.empty());
+
+   constexpr int N = 4;
+
+   // Values for comparison
+   vector<int> values(N);
+   iota(values.begin(), values.end(), 1);
+
+   // Make some components
+   vector<unique_ptr<MyComponent>> components;
+   // Not yet equal
+   REQUIRE(!compareSequences(values, components));
+
+   for (size_t ii = 1; ii <= N; ++ii)
+      components.push_back(make_unique<MyComponent>(ii));
+
+   // Equal values so far
+   REQUIRE(compareSequences(values, components));
+
+   // Composite works with push_back and back_inserter
+   move(components.begin(), components.end(),
+      back_inserter(compositeBase));
+   REQUIRE(!compositeBase.empty());
+   REQUIRE(compareSequences(values, compositeBase));
+   // Break equality of sequences
+   values.push_back(N + 1);
+   REQUIRE(!compareSequences(values, compositeBase));
+   // Restore it
+   compositeBase.push_back(make_unique<MyComponent>(N + 1));
+   REQUIRE(compareSequences(values, compositeBase));
+}

--- a/libraries/lib-utility/tests/CompositeTest.cpp
+++ b/libraries/lib-utility/tests/CompositeTest.cpp
@@ -12,6 +12,7 @@
 #include "Composite.h"
 #include "Callable.h"
 #include <algorithm>
+#include <array>
 #include <iterator>
 #include <numeric>
 
@@ -69,9 +70,18 @@ bool compareSequences(const Container1 &c1, const Container2 &c2)
 }
 }
 
-template<typename Container, typename... Args>
+template<typename Container, auto Maker = nullptr, typename... Args>
 void DoTest(Args ...args)
 {
+   auto Make = [](int value){
+      if constexpr (!bool(Maker))
+         return Component(value, Ignore{});
+      else
+         return Maker(value);
+   };
+
+   using ComponentType = decltype(Make(0));
+   
    // CompositeBase passes constructor arguments to its Component
    Container container{ args... };
    REQUIRE(0 == container);
@@ -84,15 +94,16 @@ void DoTest(Args ...args)
    iota(values.begin(), values.end(), 1);
 
    // Make some components
-   vector<unique_ptr<MyComponent>> components;
+   vector<ComponentType> components;
    // Not yet equal
    REQUIRE(!compareSequences(values, components));
 
    for (size_t ii = 1; ii <= N; ++ii)
-      components.push_back(make_unique<MyComponent>(ii));
+      components.push_back(Make(ii));
 
    // Equal values so far
-   REQUIRE(compareSequences(values, components));
+   if (!bool(Maker))
+      REQUIRE(compareSequences(values, components));
 
    // Composite works with push_back and back_inserter
    move(components.begin(), components.end(), back_inserter(container));
@@ -104,7 +115,7 @@ void DoTest(Args ...args)
    REQUIRE(!compareSequences(values, container));
 
    // Restore equality (and note, Component can take more arguments)
-   container.push_back(Component(N + 1, Ignore{}));
+   container.push_back(Make(N + 1));
    REQUIRE(compareSequences(values, container));
 }
 
@@ -113,6 +124,52 @@ TEST_CASE("Composite::Base")
    DoTest<MyCompositeBase>(0);
    // Also test the extra arguments of MyComponent
    DoTest<MyCompositeBase2>(0, Ignore{});
+}
+
+namespace {
+struct MyComponentEx : MyComponent{
+   // Scramble the given value!!
+   MyComponentEx(int value) : MyComponent{ -value } {}
+};
+inline bool operator== (int n, const std::unique_ptr<MyComponentEx> &p)
+{
+   return n == *p;
+}
+static auto Maker (int value){return std::make_unique<MyComponentEx>(value); };
+struct MyBuilder;
+}
+
+// But define a trait that negates it again to unscramble it!
+// This specialization must be in the global namespace and precede the complete
+// definition of Builder
+template<> struct Composite::Traits<MyCompositeBase, MyBuilder> {
+   struct ItemBuilderType {
+      auto operator () (std::unique_ptr<MyComponent> ptr) const {
+         return std::make_unique<MyComponentEx>(ptr->value); };
+      auto operator () (int value) const {
+         return std::make_unique<MyComponentEx>(-value); };
+   };
+   static constexpr auto ItemBuilder = ItemBuilderType{};
+   template<typename T> static constexpr auto enables_item_type_v = true;
+};
+
+namespace {
+struct MyBuilder : Composite::Builder<MyCompositeBase, MyBuilder, int> {
+   using Builder::Builder;
+};
+}
+
+TEST_CASE("Composite::Builder")
+{
+   std::array values{ 0, 1, 2, 3, 4 };
+
+   DoTest<MyBuilder, Maker>(0);
+   // Test compilation of the variadic constructor and the overload of
+   // ItemBuilderType::operator ()
+   // Remember first 0 is not an element
+   MyBuilder builder{ 0, 0, 1, 2, 3, 4 };
+
+   REQUIRE(compareSequences(values, builder));
 }
 
 TEST_CASE("Composite::Extension")
@@ -131,4 +188,3 @@ TEST_CASE("Composite::Extension specialized for void")
    using Container2 = Extension<MyCompositeBase2, void, int, Ignore>;
    DoTest<Container2>(0, Ignore{});
 }
-

--- a/libraries/lib-utility/tests/CompositeTest.cpp
+++ b/libraries/lib-utility/tests/CompositeTest.cpp
@@ -13,6 +13,7 @@
 #include "Callable.h"
 #include <algorithm>
 #include <array>
+#include <functional>
 #include <iterator>
 #include <numeric>
 
@@ -161,6 +162,7 @@ struct MyBuilder : Composite::Builder<MyCompositeBase, MyBuilder, int> {
 
 TEST_CASE("Composite::Builder")
 {
+   using namespace placeholders;
    std::array values{ 0, 1, 2, 3, 4 };
 
    DoTest<MyBuilder, Maker>(0);
@@ -170,6 +172,16 @@ TEST_CASE("Composite::Builder")
    MyBuilder builder{ 0, 0, 1, 2, 3, 4 };
 
    REQUIRE(compareSequences(values, builder));
+
+   // Forward range
+   MyBuilder builder2{ 0, begin(values), end(values) };
+   REQUIRE(compareSequences(values, builder2));
+
+   // Transform range
+   std::array values2{ 1, 2, 3, 4, 5 };
+   MyBuilder builder3{ 0, begin(values2), end(values2),
+      bind( minus{}, _1, -1 ) };
+   REQUIRE(compareSequences(values, builder2));
 }
 
 TEST_CASE("Composite::Extension")


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Utility class templates that can simplify some Registry code

Implement the Composite pattern of a container of nodes that is also of the node type.

Variadic and range constructors can take many components, also interposing type checks.

A template for easy definition of extensions that inherit the variadic and range constructors.

QA:  Nothing to do.  This introduces utilities but uses them nowhere yet but in unit tests.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
