### PR TITLE
issue 4626: pasting label track to another project

### DIFF
--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<TrackList> DuplicateDiscardTrimmed(const TrackList& src) {
    {
       auto trackCopy = track->Copy(track->GetStartTime(), track->GetEndTime(), false);
       trackCopy->Init(*track);
-      trackCopy->SetOffset(track->GetOffset());
+      trackCopy->SetOffset(track->GetStartTime());
       
       if(auto waveTrack = dynamic_cast<WaveTrack*>(trackCopy.get()))
       {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4626

Problem:
When pasting a label track to a different project using the "selected audio only" option, the label track can be time shifted.

Fix:
In DuplicateDiscardTrimmed(), in the call to trackCopy->SetOffset(), which restores the start times after the copy, pass track->GetStartTime(), rather than track->GetOffset(). For tracks other than a label track, GetOffset() and GetStartTime() return the same value. (So these tracks are not affected by this fix.) However, for a label track, GetOffset() return 0.0.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
