### PR TITLE
Do not use the latency reported by PortAudio if Jack is a host

### DIFF
--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -364,6 +364,7 @@ protected:
    std::weak_ptr< AudioIOListener > mListener;
 
    bool mUsingAlsa { false };
+   bool mUsingJack { false };
 
    // For cacheing supported sample rates
    static double mCachedBestRateOut;


### PR DESCRIPTION
Resolves: #4646 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
