### PR TITLE
Registry type checking

### DIFF
--- a/libraries/lib-import-export/ExportPluginRegistry.cpp
+++ b/libraries/lib-import-export/ExportPluginRegistry.cpp
@@ -65,10 +65,10 @@ void ExportPluginRegistry::Initialize()
       {
       }
 
-      void Visit( SingleItem &item, const Path &path ) override
+      void Visit(const SingleItem &item, const Path &path) override
       {
          mPlugins.emplace_back(
-            static_cast<ExportPluginRegistryItem&>( item ).mFactory() );
+            static_cast<const ExportPluginRegistryItem&>(item).mFactory() );
       }
 
       ExportPlugins& mPlugins;

--- a/libraries/lib-import-export/ExportPluginRegistry.cpp
+++ b/libraries/lib-import-export/ExportPluginRegistry.cpp
@@ -6,9 +6,10 @@ namespace {
    const auto PathStart = L"Exporters";
 }
 
-Registry::GroupItemBase &ExportPluginRegistry::ExportPluginRegistryItem::Registry()
+auto ExportPluginRegistry::ExportPluginRegistryItem::Registry()
+   -> Registry::GroupItem<Traits> &
 {
-   static Registry::GroupItem<Registry::DefaultTraits> registry{ PathStart };
+   static Registry::GroupItem<Traits> registry{ PathStart };
    return registry;
 }
 
@@ -74,7 +75,7 @@ void ExportPluginRegistry::Initialize()
    } visitor(mPlugins);
    // visit the registry to collect the plug-ins properly
    // sorted
-   GroupItem<Registry::DefaultTraits> top{ PathStart };
+   GroupItem<Traits> top{ PathStart };
    Registry::Visit( visitor, &top, &ExportPluginRegistryItem::Registry() );
 }
 

--- a/libraries/lib-import-export/ExportPluginRegistry.h
+++ b/libraries/lib-import-export/ExportPluginRegistry.h
@@ -107,8 +107,11 @@ public:
    std::tuple<ExportPlugin*, int> FindFormat(const wxString& format, bool compareWithCase = false) const;
 
 private:
+   struct Traits : Registry::DefaultTraits {
+      using LeafTypes = List<ExportPluginRegistryItem>;
+   };
    struct IMPORT_EXPORT_API ExportPluginRegistryItem final : Registry::SingleItem {
-      static Registry::GroupItemBase &Registry();
+      static Registry::GroupItem<Traits> &Registry();
       ExportPluginRegistryItem(const Identifier &id, Factory factory );
       Factory mFactory;
    };

--- a/libraries/lib-import-export/Import.cpp
+++ b/libraries/lib-import-export/Import.cpp
@@ -125,9 +125,9 @@ static const auto PathStart = L"Importers";
 
 }
 
-Registry::GroupItemBase &Importer::ImporterItem::Registry()
+auto Importer::ImporterItem::Registry() -> Registry::GroupItem<Traits> &
 {
-   static Registry::GroupItem<Registry::DefaultTraits> registry{ PathStart };
+   static Registry::GroupItem<Traits> registry{ PathStart };
    return registry;
 }
 
@@ -183,7 +183,7 @@ bool Importer::Initialize()
       {
          // Once only, visit the registry to collect the plug-ins properly
          // sorted
-         GroupItem<Registry::DefaultTraits> top{ PathStart };
+         GroupItem<Traits> top{ PathStart };
          Registry::Visit( *this, &top, &ImporterItem::Registry() );
       }
 

--- a/libraries/lib-import-export/Import.cpp
+++ b/libraries/lib-import-export/Import.cpp
@@ -187,10 +187,10 @@ bool Importer::Initialize()
          Registry::Visit( *this, &top, &ImporterItem::Registry() );
       }
 
-      void Visit( SingleItem &item, const Path &path ) override
+      void Visit(const SingleItem &item, const Path &path) override
       {
          sImportPluginList().push_back(
-            static_cast<ImporterItem&>( item ).mpPlugin.get() );
+            static_cast<const ImporterItem&>( item ).mpPlugin.get() );
       }
    } visitor;
 

--- a/libraries/lib-import-export/Import.h
+++ b/libraries/lib-import-export/Import.h
@@ -83,7 +83,7 @@ public:
    // Objects of this type are statically constructed in files implementing
    // subclasses of ImportPlugin
    struct IMPORT_EXPORT_API RegisteredImportPlugin final
-      : public Registry::RegisteredItem<ImporterItem>
+      : Registry::RegisteredItem<ImporterItem>
    {
       RegisteredImportPlugin(
          const Identifier &id, // an internal string naming the plug-in
@@ -179,8 +179,11 @@ public:
               TranslatableString &errorMessage);
 
 private:
+   struct Traits : Registry::DefaultTraits {
+      using LeafTypes = List<ImporterItem>;
+   };
    struct IMPORT_EXPORT_API ImporterItem final : Registry::SingleItem {
-      static Registry::GroupItemBase &Registry();
+      static Registry::GroupItem<Traits> &Registry();
 
       ImporterItem( const Identifier &id, std::unique_ptr<ImportPlugin> pPlugin );
       ~ImporterItem();

--- a/libraries/lib-numeric-formats/NumericConverterRegistry.cpp
+++ b/libraries/lib-numeric-formats/NumericConverterRegistry.cpp
@@ -92,7 +92,8 @@ struct RegistryVisitor : public Registry::Visitor
  {
  }
 
-Registry::GroupItemBase& NumericConverterRegistry::Registry()
+Registry::GroupItem<NumericConverterRegistryTraits>&
+   NumericConverterRegistry::Registry()
 {
    static Registry::GroupItem<NumericConverterRegistryTraits>
       registry { PathStart };
@@ -133,11 +134,5 @@ const NumericConverterRegistryItem* NumericConverterRegistry::Find(
 }
 
 NumericConverterRegistryGroup::~NumericConverterRegistryGroup()
-{
-}
-
-NumericConverterItemRegistrator::NumericConverterItemRegistrator(
-   const Registry::Placement& placement, Registry::BaseItemPtr pItem)
-    : RegisteredItem { std::move(pItem), placement }
 {
 }

--- a/libraries/lib-numeric-formats/NumericConverterRegistry.cpp
+++ b/libraries/lib-numeric-formats/NumericConverterRegistry.cpp
@@ -25,25 +25,27 @@ struct RegistryVisitor : public Registry::Visitor
    {
    }
 
-   void BeginGroup(Registry::GroupItemBase& item, const Path&) override
+   void BeginGroup(const Registry::GroupItemBase& item, const Path&) override
    {
-      auto concreteGroup = dynamic_cast<NumericConverterRegistryGroup*>(&item);
+      auto concreteGroup =
+         dynamic_cast<const NumericConverterRegistryGroup*>(&item);
 
       mInMatchingGroup =
          concreteGroup != nullptr && concreteGroup->GetType() == requestedType;
    }
 
-   void EndGroup(Registry::GroupItemBase&, const Path&) override
+   void EndGroup(const Registry::GroupItemBase&, const Path&) override
    {
       mInMatchingGroup = false;
    }
 
-   void Visit(Registry::SingleItem& item, const Path&) override
+   void Visit(const Registry::SingleItem& item, const Path&) override
    {
       if (!mInMatchingGroup)
          return;
 
-      auto concreteItem = dynamic_cast<NumericConverterRegistryItem*>(&item);
+      auto concreteItem =
+         dynamic_cast<const NumericConverterRegistryItem*>(&item);
 
       if (concreteItem == nullptr)
       {

--- a/libraries/lib-numeric-formats/NumericConverterRegistry.h
+++ b/libraries/lib-numeric-formats/NumericConverterRegistry.h
@@ -35,7 +35,15 @@ public:
 using NumericConverterFormatterFactoryPtr =
    std::unique_ptr<NumericConverterFormatterFactory>;
 
-struct NumericConverterRegistryTraits : Registry::DefaultTraits{};
+struct NumericConverterRegistryItem;
+struct NumericConverterRegistryGroup;
+struct NumericConverterRegistrySuperGroup;
+
+struct NumericConverterRegistryTraits : Registry::DefaultTraits{
+   using LeafTypes = List<NumericConverterRegistryItem>;
+   using NodeTypes =
+      List<NumericConverterRegistryGroup, NumericConverterRegistrySuperGroup>;
+};
 
 struct NumericConverterRegistryGroupData {
    NumericConverterType type;
@@ -78,7 +86,7 @@ struct NUMERIC_FORMATS_API NumericConverterRegistryItem : public Registry::Singl
 
 struct NUMERIC_FORMATS_API NumericConverterRegistry final
 {
-   static Registry::GroupItemBase& Registry();
+   static Registry::GroupItem<NumericConverterRegistryTraits>& Registry();
 
    using Visitor = std::function<void(const NumericConverterRegistryItem&)>;
    
@@ -98,21 +106,8 @@ constexpr auto NumericConverterFormatterGroup =
    Callable::UniqueMaker<NumericConverterRegistryGroup,
       const Identifier&, NumericConverterRegistryGroupData>();
 
-struct NUMERIC_FORMATS_API NumericConverterItemRegistrator final :
-    public Registry::RegisteredItem<
-       Registry::BaseItem, NumericConverterRegistry>
-{
-   NumericConverterItemRegistrator(
-      const Registry::Placement& placement, Registry::BaseItemPtr pItem);
-
-   NumericConverterItemRegistrator(
-      const wxString& path, Registry::BaseItemPtr pItem)
-       // Delegating constructor
-       : NumericConverterItemRegistrator(
-            Registry::Placement { path }, std::move(pItem))
-   {
-   }
-};
+using NumericConverterItemRegistrator =
+   Registry::RegisteredItem<NumericConverterRegistry>;
 
 struct NumericConverterRegistrySuperGroup : Composite::Extension<
    Registry::GroupItem<NumericConverterRegistryTraits>,

--- a/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
+++ b/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
@@ -383,7 +383,7 @@ private:
    const bool mTimeFormat;
 };
 
-Registry::BaseItemPtr BuildBeatsGroup(bool timeFormat)
+auto BuildBeatsGroup(bool timeFormat)
 {
    return NumericConverterFormatterGroup(
       timeFormat ? "beatsTime" : "beatsDuration",
@@ -400,13 +400,13 @@ Registry::BaseItemPtr BuildBeatsGroup(bool timeFormat)
 }
 
 NumericConverterItemRegistrator beatsTime {
-   Registry::Placement { "parsed", { Registry::OrderingHint::After, L"parsedTime" } },
-   BuildBeatsGroup(true)
+   BuildBeatsGroup(true),
+   Registry::Placement { "parsed", { Registry::OrderingHint::After, L"parsedTime" } }
 };
 
 NumericConverterItemRegistrator beatsDuration {
-   Registry::Placement { "parsed", { Registry::OrderingHint::After, L"parsedDuration" } },
-   BuildBeatsGroup(false)
+   BuildBeatsGroup(false),
+   Registry::Placement { "parsed", { Registry::OrderingHint::After, L"parsedDuration" } }
 };
 } // namespace
 

--- a/libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
+++ b/libraries/lib-numeric-formats/formatters/ParsedNumericConverterFormatter.cpp
@@ -1069,7 +1069,6 @@ static auto MakeGroup (const Identifier& identifier, NumericConverterType type,
 }
 
 static NumericConverterItemRegistrator sRegistration {
-   Registry::Placement { {}, {} },
    NumericConverterItems("parsed",
       // The sequence of these groups is unimportant because their numeric
       // converter types are all different

--- a/libraries/lib-registries/Registry.cpp
+++ b/libraries/lib-registries/Registry.cpp
@@ -635,7 +635,7 @@ auto CollectedItems::MergeItems(
 // forward declaration for mutually recursive functions
 void VisitItem(
    Registry::Visitor &visitor, CollectedItems &collection,
-   Path &path, BaseItem *pItem,
+   Path &path, const BaseItem *pItem,
    const GroupItemBase *pToMerge, const OrderingHint &hint,
    bool &doFlush );
 void VisitItems(
@@ -687,7 +687,7 @@ void VisitItems(
 }
 void VisitItem(
    Registry::Visitor &visitor, CollectedItems &collection,
-   Path &path, BaseItem *pItem,
+   Path &path, const BaseItem *pItem,
    const GroupItemBase *pToMerge, const OrderingHint &hint,
    bool &doFlush )
 {
@@ -695,14 +695,14 @@ void VisitItem(
       return;
 
    if (const auto pSingle =
-       dynamic_cast<SingleItem*>( pItem )) {
+       dynamic_cast<const SingleItem*>(pItem)) {
       wxASSERT( !pToMerge );
       visitor.Visit( *pSingle, path );
    }
    else
    if (const auto pGroup =
-       dynamic_cast<GroupItemBase*>( pItem )) {
-      visitor.BeginGroup( *pGroup, path );
+       dynamic_cast<const GroupItemBase*>(pItem)) {
+      visitor.BeginGroup(*pGroup, path);
       // recursion
       VisitItems(visitor, collection, path, *pGroup, pToMerge, hint, doFlush);
       visitor.EndGroup(*pGroup, path);
@@ -732,12 +732,12 @@ void *Visitor::GetComputedItemContext()
    static EmptyContext context;
    return &context;
 }
-void Visitor::BeginGroup(GroupItemBase &, const Path &) {}
-void Visitor::EndGroup(GroupItemBase &, const Path &) {}
-void Visitor::Visit(SingleItem &, const Path &) {}
+void Visitor::BeginGroup(const GroupItemBase &, const Path &) {}
+void Visitor::EndGroup(const GroupItemBase &, const Path &) {}
+void Visitor::Visit(const SingleItem &, const Path &) {}
 
 void detail::Visit(Visitor &visitor,
-   GroupItemBase *pTopItem, const GroupItemBase *pRegistry)
+   const GroupItemBase *pTopItem, const GroupItemBase *pRegistry)
 {
    std::vector< BaseItemSharedPtr > computedItems;
    bool doFlush = false;

--- a/libraries/lib-registries/Registry.cpp
+++ b/libraries/lib-registries/Registry.cpp
@@ -736,7 +736,8 @@ void Visitor::BeginGroup(GroupItemBase &, const Path &) {}
 void Visitor::EndGroup(GroupItemBase &, const Path &) {}
 void Visitor::Visit(SingleItem &, const Path &) {}
 
-void Visit( Visitor &visitor, BaseItem *pTopItem, const GroupItemBase *pRegistry )
+void Visit(Visitor &visitor,
+   GroupItemBase *pTopItem, const GroupItemBase *pRegistry)
 {
    std::vector< BaseItemSharedPtr > computedItems;
    bool doFlush = false;

--- a/libraries/lib-registries/Registry.cpp
+++ b/libraries/lib-registries/Registry.cpp
@@ -773,8 +773,8 @@ void OrderingPreferenceInitializer::operator () ()
       gPrefs->Flush();
 }
 
-void RegisterItem( GroupItemBase &registry, const Placement &placement,
-   BaseItemPtr pItem )
+void detail::RegisterItem(GroupItemBase &registry, const Placement &placement,
+   BaseItemPtr pItem)
 {
    // Since registration determines only an unordered tree of menu items,
    // we can sort children of each node lexicographically for our convenience.

--- a/libraries/lib-registries/Registry.cpp
+++ b/libraries/lib-registries/Registry.cpp
@@ -76,31 +76,24 @@ struct CollectedItems
 
    void SubordinateMultipleItems(Item &found, GroupItemBase &items);
 
-   auto MergeWithExistingItem(
-      Visitor &visitor, ItemOrdering &itemOrdering, BaseItem *pItem ) -> bool;
+   bool MergeWithExistingItem(ItemOrdering &itemOrdering, BaseItem *pItem);
 
    using NewItem = std::pair< BaseItem*, OrderingHint >;
    using NewItems = std::vector< NewItem >;
 
-   auto MergeLikeNamedItems(
-      Visitor &visitor, ItemOrdering &itemOrdering,
+   bool MergeLikeNamedItems(ItemOrdering &itemOrdering,
       NewItems::const_iterator left, NewItems::const_iterator right,
-      int iPass, size_t endItemsCount, bool force )
-         -> bool;
+      int iPass, size_t endItemsCount, bool force);
 
-   auto MergeItemsAscendingNamesPass(
-      Visitor &visitor, ItemOrdering &itemOrdering,
-      NewItems &newItems, int iPass, size_t endItemsCount, bool force )
-         -> void;
+   void MergeItemsAscendingNamesPass(ItemOrdering &itemOrdering,
+      NewItems &newItems, int iPass, size_t endItemsCount, bool force);
 
-   auto MergeItemsDescendingNamesPass(
-      Visitor &visitor, ItemOrdering &itemOrdering,
-      NewItems &newItems, int iPass, size_t endItemsCount, bool force )
-         -> void;
+   void MergeItemsDescendingNamesPass(ItemOrdering &itemOrdering,
+      NewItems &newItems, int iPass, size_t endItemsCount, bool force);
 
-   auto MergeItems(
-      Visitor &visitor, ItemOrdering &itemOrdering,
-      const GroupItemBase &toMerge, const OrderingHint &hint ) -> void;
+   void MergeItems(ItemOrdering &itemOrdering,
+      const GroupItemBase &toMerge, const OrderingHint &hint,
+      void *pComputedItemContext);
 };
 
 // When a computed or indirect item, or nameless grouping, specifies a hint and
@@ -119,18 +112,17 @@ const OrderingHint &ChooseHint(BaseItem *delegate, const OrderingHint &hint)
 // alternate as the entire tree is recursively visited.
 
 // forward declaration for mutually recursive functions
-void CollectItem( Registry::Visitor &visitor,
-   CollectedItems &collection, BaseItem *Item, const OrderingHint &hint );
-void CollectItems( Registry::Visitor &visitor,
-   CollectedItems &collection, const GroupItemBase &items,
-   const OrderingHint &hint )
+void CollectItem(CollectedItems &collection, BaseItem *Item,
+   const OrderingHint &hint, void *pComputedItemContext);
+void CollectItems(CollectedItems &collection, const GroupItemBase &items,
+   const OrderingHint &hint, void *pComputedItemContext)
 {
    for ( auto &item : items )
-      CollectItem( visitor, collection, item.get(),
-         ChooseHint( item.get(), hint ) );
+      CollectItem(collection, item.get(),
+         ChooseHint(item.get(), hint), pComputedItemContext);
 }
-void CollectItem( Registry::Visitor &visitor,
-   CollectedItems &collection, BaseItem *pItem, const OrderingHint &hint )
+void CollectItem(CollectedItems &collection,
+   BaseItem *pItem, const OrderingHint &hint, void *pComputedItemContext)
 {
    if (!pItem)
       return;
@@ -141,19 +133,20 @@ void CollectItem( Registry::Visitor &visitor,
       auto delegate = pIndirect->ptr.get();
       if (delegate)
          // recursion
-         CollectItem(visitor, collection, delegate,
-            ChooseHint(delegate, pIndirect->orderingHint));
+         CollectItem(collection, delegate,
+            ChooseHint(delegate, pIndirect->orderingHint), pComputedItemContext);
    }
    else
    if (const auto pComputed =
        dynamic_cast<ComputedItemBase*>(pItem)) {
-      auto result = pComputed->factory(visitor.GetComputedItemContext());
+      auto result = pComputed->factory(pComputedItemContext);
       if (result) {
          // Guarantee long enough lifetime of the result
          collection.computedItems.push_back( result );
          // recursion
-         CollectItem( visitor, collection, result.get(),
-            ChooseHint( result.get(), pComputed->orderingHint ) );
+         CollectItem(collection, result.get(),
+            ChooseHint(result.get(), pComputed->orderingHint),
+            pComputedItemContext);
       }
    }
    else
@@ -162,7 +155,8 @@ void CollectItem( Registry::Visitor &visitor,
          // anonymous grouping item is transparent to path calculations
          // collect group members now
          // recursion
-         CollectItems(visitor, collection, *pGroup, ChooseHint(pGroup, hint));
+         CollectItems(collection, *pGroup,
+            ChooseHint(pGroup, hint), pComputedItemContext);
       else
          // all other group items
          // defer collection of members until collecting at next lower level
@@ -373,8 +367,8 @@ void CollectedItems::SubordinateMultipleItems(Item &found, GroupItemBase &items)
          std::shared_ptr<BaseItem>(pItem.get(), [](void*){})));
 }
 
-auto CollectedItems::MergeWithExistingItem(
-   Visitor &visitor, ItemOrdering &itemOrdering, BaseItem *pItem ) -> bool
+bool CollectedItems::MergeWithExistingItem(
+   ItemOrdering &itemOrdering, BaseItem *pItem)
 {
    // Assume no null pointers remain after CollectItems:
    const auto &name = pItem->name;
@@ -440,11 +434,9 @@ auto CollectedItems::MergeWithExistingItem(
       return false;
 }
 
-auto CollectedItems::MergeLikeNamedItems(
-   Visitor &visitor, ItemOrdering &itemOrdering,
+bool CollectedItems::MergeLikeNamedItems(ItemOrdering &itemOrdering,
    NewItems::const_iterator left, NewItems::const_iterator right,
-   const int iPass, size_t endItemsCount, bool force )
-   -> bool
+   const int iPass, size_t endItemsCount, bool force)
 {
    // Try to place the first item of the range.
    // If such an item is a group, then we always retain the kind of
@@ -479,7 +471,7 @@ auto CollectedItems::MergeLikeNamedItems(
       while ( iter != right )
          // Re-invoke MergeWithExistingItem for this item, which is known
          // to have a name collision, so ignore the return value.
-         MergeWithExistingItem( visitor, itemOrdering, iter++ -> first );
+         MergeWithExistingItem(itemOrdering, iter++ -> first);
    }
 
    return success;
@@ -505,9 +497,8 @@ inline bool Comp(
    return MinorComp( a, b );
 };
 
-auto CollectedItems::MergeItemsAscendingNamesPass(
-  Visitor &visitor, ItemOrdering &itemOrdering, NewItems &newItems,
-  const int iPass, size_t endItemsCount, bool force ) -> void
+void CollectedItems::MergeItemsAscendingNamesPass(ItemOrdering &itemOrdering,
+   NewItems &newItems, const int iPass, size_t endItemsCount, bool force)
 {
    // Inner loop over ranges of like-named items.
    auto rright = newItems.rbegin();
@@ -518,9 +509,8 @@ auto CollectedItems::MergeItemsAscendingNamesPass(
       auto rleft = std::find_if(
          rright + 1, rend, std::bind( MajorComp, _1, *rright ) );
 
-      bool success = MergeLikeNamedItems(
-         visitor, itemOrdering, rleft.base(), rright.base(), iPass,
-         endItemsCount, force );
+      bool success = MergeLikeNamedItems(itemOrdering,
+         rleft.base(), rright.base(), iPass, endItemsCount, force);
 
       if ( success ) {
          auto diff = rend - rleft;
@@ -532,9 +522,8 @@ auto CollectedItems::MergeItemsAscendingNamesPass(
    }
 }
 
-auto CollectedItems::MergeItemsDescendingNamesPass(
-  Visitor &visitor, ItemOrdering &itemOrdering, NewItems &newItems,
-  const int iPass, size_t endItemsCount, bool force ) -> void
+void CollectedItems::MergeItemsDescendingNamesPass(ItemOrdering &itemOrdering,
+   NewItems &newItems, const int iPass, size_t endItemsCount, bool force)
 {
    // Inner loop over ranges of like-named items.
    auto left = newItems.begin();
@@ -544,8 +533,7 @@ auto CollectedItems::MergeItemsDescendingNamesPass(
       auto right = std::find_if(
          left + 1, newItems.end(), std::bind( MajorComp, *left, _1 ) );
 
-      bool success = MergeLikeNamedItems(
-         visitor, itemOrdering, left, right, iPass,
+      bool success = MergeLikeNamedItems(itemOrdering, left, right, iPass,
          endItemsCount, force );
 
       if ( success )
@@ -555,9 +543,9 @@ auto CollectedItems::MergeItemsDescendingNamesPass(
    }
 };
 
-auto CollectedItems::MergeItems(
-  Visitor &visitor, ItemOrdering &itemOrdering,
-  const GroupItemBase &toMerge, const OrderingHint &hint ) -> void
+void CollectedItems::MergeItems(ItemOrdering &itemOrdering,
+   const GroupItemBase &toMerge, const OrderingHint &hint,
+   void *pComputedItemContext)
 {
    NewItems newItems;
 
@@ -565,12 +553,12 @@ auto CollectedItems::MergeItems(
       // First do expansion of nameless groupings, and caching of computed
       // items, just as for the previously collected items.
       CollectedItems newCollection{ {}, computedItems };
-      CollectItems(visitor, newCollection, toMerge, hint);
+      CollectItems(newCollection, toMerge, hint, pComputedItemContext);
 
       // Try to merge each, resolving name collisions with items already in the
       // tree, and collecting those with names that don't collide.
       for (const auto &item : newCollection.items)
-         if (!MergeWithExistingItem(visitor, itemOrdering, item.visitNow))
+         if (!MergeWithExistingItem(itemOrdering, item.visitNow))
              newItems.push_back({ item.visitNow, item.hint });
    }
 
@@ -596,11 +584,11 @@ auto CollectedItems::MergeItems(
          ( iPass == OrderingHint::After || iPass == OrderingHint::Begin );
 
       if ( descending )
-         MergeItemsDescendingNamesPass(
-            visitor, itemOrdering, newItems, iPass, endItemsCount, force );
+         MergeItemsDescendingNamesPass(itemOrdering,
+            newItems, iPass, endItemsCount, force);
       else
-         MergeItemsAscendingNamesPass(
-            visitor, itemOrdering, newItems, iPass, endItemsCount, force );
+         MergeItemsAscendingNamesPass(itemOrdering,
+            newItems, iPass, endItemsCount, force);
 
       auto newSize = newItems.size();
       ++iPass;
@@ -637,19 +625,20 @@ void VisitItem(
    Registry::Visitor &visitor, CollectedItems &collection,
    Path &path, const BaseItem *pItem,
    const GroupItemBase *pToMerge, const OrderingHint &hint,
-   bool &doFlush );
+   bool &doFlush, void *pComputedItemContext);
 void VisitItems(
    Registry::Visitor &visitor, CollectedItems &collection,
    Path &path, const GroupItemBase &group,
    const GroupItemBase *pToMerge, const OrderingHint &hint,
-   bool &doFlush )
+   bool &doFlush, void *pComputedItemContext)
 {
    // Make a NEW collection for this subtree, sharing the memo cache
    CollectedItems newCollection{ {}, collection.computedItems };
 
    // Gather items at this level
    // (The ordering hint is irrelevant when not merging items in)
-   CollectItems(visitor, newCollection, group, {});
+   CollectItems(newCollection, group, {},
+      pComputedItemContext);
 
    path.push_back(group.name.GET());
 
@@ -657,7 +646,8 @@ void VisitItems(
    if ( pToMerge )
    {
       ItemOrdering itemOrdering{ path };
-      newCollection.MergeItems(visitor, itemOrdering, *pToMerge, hint);
+      newCollection.MergeItems(itemOrdering, *pToMerge, hint,
+         pComputedItemContext);
 
       // Remember the NEW ordering, if there was any need to use the old.
       // This makes a side effect in preferences.
@@ -679,9 +669,9 @@ void VisitItems(
 
    // Now visit them
    for ( const auto &item : newCollection.items )
-      VisitItem( visitor, collection, path,
+      VisitItem(visitor, collection, path,
          item.visitNow, item.mergeLater, item.hint,
-         doFlush );
+         doFlush, pComputedItemContext);
 
    path.pop_back();
 }
@@ -689,7 +679,7 @@ void VisitItem(
    Registry::Visitor &visitor, CollectedItems &collection,
    Path &path, const BaseItem *pItem,
    const GroupItemBase *pToMerge, const OrderingHint &hint,
-   bool &doFlush )
+   bool &doFlush, void *pComputedItemContext)
 {
    if (!pItem)
       return;
@@ -704,7 +694,9 @@ void VisitItem(
        dynamic_cast<const GroupItemBase*>(pItem)) {
       visitor.BeginGroup(*pGroup, path);
       // recursion
-      VisitItems(visitor, collection, path, *pGroup, pToMerge, hint, doFlush);
+      VisitItems(
+         visitor, collection, path, *pGroup, pToMerge, hint, doFlush,
+         pComputedItemContext);
       visitor.EndGroup(*pGroup, path);
    }
    else
@@ -714,6 +706,8 @@ void VisitItem(
 }
 
 namespace Registry {
+
+EmptyContext EmptyContext::Instance;
 
 BaseItem::~BaseItem() {}
 
@@ -726,26 +720,24 @@ SingleItem::~SingleItem() {}
 GroupItemBase::~GroupItemBase() {}
 auto GroupItemBase::GetOrdering() const -> Ordering { return Strong; }
 
-Visitor::~Visitor(){}
-void *Visitor::GetComputedItemContext()
-{
-   static EmptyContext context;
-   return &context;
-}
+Visitor::~Visitor() = default;
+
 void Visitor::BeginGroup(const GroupItemBase &, const Path &) {}
 void Visitor::EndGroup(const GroupItemBase &, const Path &) {}
 void Visitor::Visit(const SingleItem &, const Path &) {}
 
 void detail::Visit(Visitor &visitor,
-   const GroupItemBase *pTopItem, const GroupItemBase *pRegistry)
+   const GroupItemBase *pTopItem,
+   const GroupItemBase *pRegistry, void *pComputedItemContext)
 {
+   assert(pComputedItemContext);
    std::vector< BaseItemSharedPtr > computedItems;
    bool doFlush = false;
    CollectedItems collection{ {}, computedItems };
    Path emptyPath;
    VisitItem(
       visitor, collection, emptyPath, pTopItem,
-      pRegistry, pRegistry->orderingHint, doFlush );
+      pRegistry, pRegistry->orderingHint, doFlush, pComputedItemContext);
    // Flush any writes done by MergeItems()
    if (doFlush)
       gPrefs->Flush();

--- a/libraries/lib-registries/Registry.cpp
+++ b/libraries/lib-registries/Registry.cpp
@@ -736,7 +736,7 @@ void Visitor::BeginGroup(GroupItemBase &, const Path &) {}
 void Visitor::EndGroup(GroupItemBase &, const Path &) {}
 void Visitor::Visit(SingleItem &, const Path &) {}
 
-void Visit(Visitor &visitor,
+void detail::Visit(Visitor &visitor,
    GroupItemBase *pTopItem, const GroupItemBase *pRegistry)
 {
    std::vector< BaseItemSharedPtr > computedItems;

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -395,7 +395,7 @@ namespace detail {
    // yet other previously unknown items).
    REGISTRIES_API void Visit(
       Visitor &visitor,
-      detail::BaseItem *pTopItem,
+      GroupItemBase *pTopItem,
       const GroupItemBase *pRegistry = nullptr );
 
    // Typically a static object.  Constructor initializes certain preferences

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -384,6 +384,13 @@ namespace detail {
       virtual void Visit( SingleItem &item, const Path &path );
    };
 
+namespace detail {
+   REGISTRIES_API void Visit(
+      Visitor &visitor,
+      GroupItemBase *pTopItem,
+      const GroupItemBase *pRegistry);
+}
+
    // Top-down visitation of all items and groups in a tree rooted in
    // pTopItem, as merged with pRegistry.
    // The merger of the trees is recomputed in each call, not saved.
@@ -393,10 +400,13 @@ namespace detail {
    // seen in the registry for the first time is placed somehere, and that
    // ordering should be kept the same thereafter in later runs (which may add
    // yet other previously unknown items).
-   REGISTRIES_API void Visit(
-      Visitor &visitor,
-      GroupItemBase *pTopItem,
-      const GroupItemBase *pRegistry = nullptr );
+   template<typename RegistryTraits> void Visit(Visitor &visitor,
+      GroupItem<RegistryTraits> *pTopItem,
+      const GroupItem<RegistryTraits> *pRegistry = {})
+   {
+      static_assert(AcceptableTraits_v<RegistryTraits>);
+      detail::Visit(visitor, pTopItem, pRegistry);
+   }
 
    // Typically a static object.  Constructor initializes certain preferences
    // if they are not present.  These preferences determine an extrinsic

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -83,7 +83,6 @@ namespace detail {
 }
 
    using BaseItemPtr = std::unique_ptr<detail::BaseItem>;
-   using BaseItemPtrs = std::vector<BaseItemPtr>;
 
    class Visitor;
    

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -379,15 +379,15 @@ namespace detail {
        @post result: `result != nullptr`
        */
       virtual void *GetComputedItemContext();
-      virtual void BeginGroup( GroupItemBase &item, const Path &path );
-      virtual void EndGroup( GroupItemBase &item, const Path &path );
-      virtual void Visit( SingleItem &item, const Path &path );
+      virtual void BeginGroup(const GroupItemBase &item, const Path &path);
+      virtual void EndGroup(const GroupItemBase &item, const Path &path);
+      virtual void Visit(const SingleItem &item, const Path &path);
    };
 
 namespace detail {
    REGISTRIES_API void Visit(
       Visitor &visitor,
-      GroupItemBase *pTopItem,
+      const GroupItemBase *pTopItem,
       const GroupItemBase *pRegistry);
 }
 
@@ -401,7 +401,7 @@ namespace detail {
    // ordering should be kept the same thereafter in later runs (which may add
    // yet other previously unknown items).
    template<typename RegistryTraits> void Visit(Visitor &visitor,
-      GroupItem<RegistryTraits> *pTopItem,
+      const GroupItem<RegistryTraits> *pTopItem,
       const GroupItem<RegistryTraits> *pRegistry = {})
    {
       static_assert(AcceptableTraits_v<RegistryTraits>);

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -123,6 +123,10 @@ namespace detail {
    template<typename RegistryTraits> using AllTypes_t =
       typename AllTypes<RegistryTraits>::type;
 
+   template<typename RegistryTraits> constexpr auto AcceptableTraits_v =
+      TypeList::Every_v<TypeList::Fn<AcceptableBaseItem>,
+         AllTypes_t<RegistryTraits>>;
+
 namespace detail {
    //! An item that delegates to another held in a shared pointer
    /*!
@@ -337,6 +341,7 @@ namespace detail {
    void RegisterItem(GroupItem<RegistryTraits> &registry,
       const Placement &placement, std::unique_ptr<Item> pItem)
    {
+      static_assert(AcceptableTraits_v<RegistryTraits>);
       static_assert(AcceptableType_v<RegistryTraits, Item>,
          "Registered item must be of one of the types listed in the registry's "
          "traits");

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -98,7 +98,21 @@ namespace detail {
 
       BaseItemSharedPtr ptr;
    };
+
+   struct ComputedItemBase;
 }
+
+   //! The underlying registry merging procedure assumes the listed types
+   //! are an exhaustive partition
+   using BaseItemTypes = TypeList::List<
+      detail::IndirectItemBase, detail::ComputedItemBase,
+      // see below
+      struct SingleItem, struct GroupItemBase
+   >;
+   template<typename Item> using AcceptableBaseItem =
+      TypeList::HasBaseIn<Item, BaseItemTypes>;
+   template<typename Item> constexpr auto AcceptableBaseItem_v =
+      AcceptableBaseItem<Item>::value;
 
    template<typename RegistryTraits> struct AllTypes {
       using type = TypeList::Append_t<
@@ -119,7 +133,7 @@ namespace detail {
    template<typename Item>
    struct IndirectItem final : IndirectItemBase {
       using ItemType = Item;
-      static_assert(std::is_base_of_v<BaseItem, ItemType>);
+      static_assert(AcceptableBaseItem_v<ItemType>);
       explicit IndirectItem(const std::shared_ptr<Item> &ptr)
          : IndirectItemBase{ ptr }
       {}
@@ -156,7 +170,7 @@ namespace detail {
    template<typename Context, typename Item>
    struct ComputedItem final : ComputedItemBase {
       using ItemType = Item;
-      static_assert(std::is_base_of_v<BaseItem, ItemType>);
+      static_assert(AcceptableBaseItem_v<ItemType>);
 
       //! Type-erasing constructor template
       /*!

--- a/libraries/lib-snapping/SnapUtils.cpp
+++ b/libraries/lib-snapping/SnapUtils.cpp
@@ -336,7 +336,7 @@ private:
 
 }
 
-Registry::BaseItemPtr TimeInvariantSnapFunction(
+std::unique_ptr<SnapRegistryItem> TimeInvariantSnapFunction(
    const Identifier& functionId, const TranslatableString& label,
    MultiplierFunctor functor)
 {
@@ -344,7 +344,7 @@ Registry::BaseItemPtr TimeInvariantSnapFunction(
       functionId, label, std::move(functor));
 }
 
-Registry::BaseItemPtr TimeInvariantSnapFunction(
+std::unique_ptr<SnapRegistryItem> TimeInvariantSnapFunction(
    const Identifier& functionId, const TranslatableString& label,
    double multiplier)
 {

--- a/libraries/lib-snapping/SnapUtils.cpp
+++ b/libraries/lib-snapping/SnapUtils.cpp
@@ -32,25 +32,25 @@ struct RegistryVisitor : public Registry::Visitor
    {
    }
    
-   void BeginGroup(Registry::GroupItemBase& item, const Path&) final
+   void BeginGroup(const Registry::GroupItemBase& item, const Path&) final
    {
-      auto group = dynamic_cast<SnapRegistryGroup*>(&item);
+      auto group = dynamic_cast<const SnapRegistryGroup*>(&item);
 
       if (group != nullptr)
          visitor.BeginGroup(*group);
    }
 
-   void EndGroup(Registry::GroupItemBase& item, const Path&) final
+   void EndGroup(const Registry::GroupItemBase& item, const Path&) final
    {
-      auto group = dynamic_cast<SnapRegistryGroup*>(&item);
+      auto group = dynamic_cast<const SnapRegistryGroup*>(&item);
 
       if (group != nullptr)
          visitor.EndGroup(*group);
    }
 
-   void Visit(Registry::SingleItem& item, const Path&) final
+   void Visit(const Registry::SingleItem& item, const Path&) final
    {
-      auto concreteItem = dynamic_cast<SnapRegistryItem*>(&item);
+      auto concreteItem = dynamic_cast<const SnapRegistryItem*>(&item);
 
       if (concreteItem != nullptr)
          visitor.Visit(*concreteItem);
@@ -153,9 +153,9 @@ void SnapFunctionsRegistry::Visit(SnapRegistryVisitor& visitor)
    Registry::Visit(registryVisitor, &top, &Registry());
 }
 
-SnapRegistryItem* SnapFunctionsRegistry::Find(const Identifier& id)
+const SnapRegistryItem* SnapFunctionsRegistry::Find(const Identifier& id)
 {
-   using Cache = std::unordered_map<Identifier, SnapRegistryItem*>;
+   using Cache = std::unordered_map<Identifier, const SnapRegistryItem*>;
    static Cache cache;
 
    auto it = cache.find(id);
@@ -169,9 +169,9 @@ SnapRegistryItem* SnapFunctionsRegistry::Find(const Identifier& id)
       {
       }
 
-      void Visit(Registry::SingleItem& item, const Path&) override
+      void Visit(const Registry::SingleItem& item, const Path&) override
       {
-         auto concreteItem = dynamic_cast<SnapRegistryItem*>(&item);
+         auto concreteItem = dynamic_cast<const SnapRegistryItem*>(&item);
 
          if (concreteItem == nullptr)
             return;

--- a/libraries/lib-snapping/SnapUtils.cpp
+++ b/libraries/lib-snapping/SnapUtils.cpp
@@ -135,7 +135,7 @@ Identifier ReadSnapTo()
    return snapTo;
 }
 
-Registry::GroupItemBase& SnapFunctionsRegistry::Registry()
+Registry::GroupItem<SnapRegistryTraits>& SnapFunctionsRegistry::Registry()
 {
    static Registry::GroupItem<SnapRegistryTraits> registry { PathStart };
    return registry;
@@ -232,12 +232,6 @@ SnapRegistryItem::SnapRegistryItem(
 }
 
 SnapRegistryItem::~SnapRegistryItem()
-{
-}
-
-SnapRegistryItemRegistrator::SnapRegistryItemRegistrator(
-   const Registry::Placement& placement, Registry::BaseItemPtr pItem)
-    : RegisteredItem { std::move(pItem), placement }
 {
 }
 

--- a/libraries/lib-snapping/SnapUtils.h
+++ b/libraries/lib-snapping/SnapUtils.h
@@ -56,7 +56,10 @@ struct SNAPPING_API SnapResult final
    bool snapped {};
 };
 
-struct SnapRegistryTraits : Registry::DefaultTraits{};
+struct SnapRegistryTraits : Registry::DefaultTraits{
+   using LeafTypes = List<SnapRegistryItem>;
+   using NodeTypes = List<SnapRegistryGroup, SnapFunctionSuperGroup>;
+};
 
 struct SnapRegistryGroupData {
    const TranslatableString label;
@@ -102,7 +105,7 @@ constexpr auto SnapFunctionGroup = Callable::UniqueMaker<
    SnapRegistryGroup, const Identifier &, SnapRegistryGroupData>();
 
 struct SNAPPING_API SnapFunctionsRegistry final {
-   static Registry::GroupItemBase& Registry();
+   static Registry::GroupItem<SnapRegistryTraits>& Registry();
 
    static void Visit(SnapRegistryVisitor& visitor);
 
@@ -114,20 +117,8 @@ struct SNAPPING_API SnapFunctionsRegistry final {
       bool upwards);
 };
 
-struct SNAPPING_API SnapRegistryItemRegistrator final :
-    public Registry::RegisteredItem<Registry::BaseItem, SnapFunctionsRegistry>
-{
-   SnapRegistryItemRegistrator(
-      const Registry::Placement& placement, Registry::BaseItemPtr pItem);
-
-   SnapRegistryItemRegistrator(
-      const wxString& path, Registry::BaseItemPtr pItem)
-       // Delegating constructor
-       : SnapRegistryItemRegistrator(
-            Registry::Placement { path }, std::move(pItem))
-   {
-   }
-};
+using SnapRegistryItemRegistrator =
+   Registry::RegisteredItem<SnapFunctionsRegistry>;
 
 struct SnapFunctionSuperGroup : Composite::Extension<
    Registry::GroupItem<SnapRegistryTraits>, void, const Identifier&

--- a/libraries/lib-snapping/SnapUtils.h
+++ b/libraries/lib-snapping/SnapUtils.h
@@ -91,13 +91,13 @@ struct SNAPPING_API SnapRegistryItem : public Registry::SingleItem
    virtual SnapResult SingleStep(const AudacityProject& project, double time, bool upwards) const = 0;
 };
 
-SNAPPING_API Registry::BaseItemPtr TimeInvariantSnapFunction(
+std::unique_ptr<SnapRegistryItem> TimeInvariantSnapFunction(
    const Identifier& functionId, const TranslatableString& label,
    double multiplier);
 
 using MultiplierFunctor = std::function<double(const AudacityProject&)>;
 
-SNAPPING_API Registry::BaseItemPtr TimeInvariantSnapFunction(
+std::unique_ptr<SnapRegistryItem> TimeInvariantSnapFunction(
    const Identifier& functionId, const TranslatableString& label,
    MultiplierFunctor functor);
 

--- a/libraries/lib-snapping/SnapUtils.h
+++ b/libraries/lib-snapping/SnapUtils.h
@@ -109,7 +109,7 @@ struct SNAPPING_API SnapFunctionsRegistry final {
 
    static void Visit(SnapRegistryVisitor& visitor);
 
-   static SnapRegistryItem* Find(const Identifier& id);
+   static const SnapRegistryItem* Find(const Identifier& id);
 
    static SnapResult Snap(const Identifier& id, const AudacityProject& project, double time, bool nearest);
    static SnapResult SingleStep(

--- a/libraries/lib-snapping/details/BeatsSnapFunctions.cpp
+++ b/libraries/lib-snapping/details/BeatsSnapFunctions.cpp
@@ -64,7 +64,6 @@ MultiplierFunctor SnapToTriplets(int divisor)
 }
 
 SnapRegistryItemRegistrator beats {
-   Registry::Placement { {}, { Registry::OrderingHint::Begin } },
    SnapFunctionItems( "beats",
       SnapFunctionGroup(
          /* i18n-hint: The music theory "beat"*/
@@ -95,7 +94,8 @@ SnapRegistryItemRegistrator beats {
             "triplet_1_64", XO("1/64 (triplets)"), SnapToTriplets(64)),
          TimeInvariantSnapFunction(
             "triplet_1_128", XO("1/128 (triplets)"), SnapToTriplets(128)))
-   )
+   ),
+   Registry::Placement { {}, { Registry::OrderingHint::Begin } }
 };
 
 }

--- a/libraries/lib-snapping/details/FrameSnapFunctions.cpp
+++ b/libraries/lib-snapping/details/FrameSnapFunctions.cpp
@@ -15,7 +15,6 @@
 namespace
 {
 SnapRegistryItemRegistrator videoFrames {
-   Registry::Placement { {}, { Registry::OrderingHint::After, "time" } },
    SnapFunctionItems("frames",
       SnapFunctionGroup(
          "video", { XO("Video frames"), false },
@@ -29,6 +28,7 @@ SnapRegistryItemRegistrator videoFrames {
       SnapFunctionGroup(
          "cd", { XO("CD frames"), false },
          TimeInvariantSnapFunction("cd_75_fps", XO("CDDA frames (75 fps)"), 75.0))
-   )
+   ),
+   Registry::Placement { {}, { Registry::OrderingHint::After, "time" } }
 };
 }

--- a/libraries/lib-snapping/details/TimeSnapFunctions.cpp
+++ b/libraries/lib-snapping/details/TimeSnapFunctions.cpp
@@ -21,7 +21,6 @@ double SnapToSamples(const AudacityProject& project)
 }
 
 SnapRegistryItemRegistrator secondsAndSamples {
-   Registry::Placement { {}, { Registry::OrderingHint::After, "beats" } },
    SnapFunctionItems("time",
       SnapFunctionGroup(
          "time", { XO("Seconds && samples"), false },
@@ -30,6 +29,7 @@ SnapRegistryItemRegistrator secondsAndSamples {
          TimeInvariantSnapFunction("centiseconds", XO("Centiseconds"), 100.0),
          TimeInvariantSnapFunction("milliseconds", XO("Milliseconds"), 1000.0),
          TimeInvariantSnapFunction("samples", XO("Samples"), SnapToSamples))
-   )
+   ),
+   Registry::Placement { {}, { Registry::OrderingHint::After, "beats" } }
 };
 }

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2918,13 +2918,13 @@ void OnTogglePinnedHead(const CommandContext &context)
 using namespace MenuTable;
 using Options = CommandManager::Options;
 AttachedItem sAttachment{
-   { wxT("Transport/Other/Options/Part2"), { OrderingHint::Begin, {} } },
    Command( wxT("PinnedHead"), XXO("Enable pinned play &head"),
       OnTogglePinnedHead,
       // Switching of scrolling on and off is permitted
       // even during transport
       AlwaysEnabledFlag,
       Options{}.CheckTest([](const AudacityProject&){
-         return TracksPrefs::GetPinnedHeadPreference(); } ) )
+         return TracksPrefs::GetPinnedHeadPreference(); } ) ),
+   { wxT("Transport/Other/Options/Part2"), { OrderingHint::Begin, {} } }
 };
 }

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -1523,10 +1523,10 @@ const ReservedCommandFlag&
 
 using namespace MenuTable;
 
-BaseItemSharedPtr PluginMenuItems()
+auto PluginMenuItems()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    Items( "Macros",
       Section( "RepeatLast",
          // Delayed evaluation:
@@ -1572,37 +1572,32 @@ BaseItemSharedPtr PluginMenuItems()
    return items;
 }
 
-AttachedItem sAttachment1{
-   wxT("Tools/Manage"),
-   Indirect(PluginMenuItems())
-};
+AttachedItem sAttachment1{ Indirect(PluginMenuItems()), wxT("Tools/Manage") };
 
-BaseItemSharedPtr ExtraScriptablesIMenu()
+auto ExtraScriptablesIMenu()
 {
    // These are the more useful to VI user Scriptables.
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    // i18n-hint: Scriptables are commands normally used from Python, Perl etc.
    Menu( wxT("Scriptables1"), XXO("Script&ables I") )
    };
    return menu;
 }
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part2"),
-   Indirect(ExtraScriptablesIMenu())
+AttachedItem sAttachment2{ Indirect(ExtraScriptablesIMenu()),
+   wxT("Optional/Extra/Part2")
 };
 
-BaseItemSharedPtr ExtraScriptablesIIMenu()
+auto ExtraScriptablesIIMenu()
 {
    // Less useful to VI users.
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    // i18n-hint: Scriptables are commands normally used from Python, Perl etc.
    Menu( wxT("Scriptables2"), XXO("Scripta&bles II") )
    };
    return menu;
 }
 
-AttachedItem sAttachment3{
-   wxT("Optional/Extra/Part2"),
-   Indirect(ExtraScriptablesIIMenu())
+AttachedItem sAttachment3{ Indirect(ExtraScriptablesIIMenu()),
+   wxT("Optional/Extra/Part2")
 };

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -1253,10 +1253,11 @@ void OnPlotSpectrum(const CommandContext &context)
 // Register that menu item
 
 using namespace MenuTable;
-AttachedItem sAttachment{ wxT("Analyze/Analyzers/Windows"),
+AttachedItem sAttachment{
    Command( wxT("PlotSpectrum"), XXO("Plot Spectrum..."),
       OnPlotSpectrum,
-      AudioIONotBusyFlag() | WaveTracksSelectedFlag() | TimeSelectedFlag() )
+      AudioIONotBusyFlag() | WaveTracksSelectedFlag() | TimeSelectedFlag() ),
+   wxT("Analyze/Analyzers/Windows")
 };
 
 }

--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -511,7 +511,7 @@ void OnHistory(const CommandContext &context)
 // Register that menu item
 
 using namespace MenuTable;
-AttachedItem sAttachment{ wxT("View/Windows"),
+AttachedItem sAttachment{
    // History window should be available either for UndoAvailableFlag
    // or RedoAvailableFlag,
    // but we can't make the AddItem flags and mask have both,
@@ -551,7 +551,8 @@ AttachedItem sAttachment{ wxT("View/Windows"),
    /* i18n-hint: Clicking this menu item shows the various editing steps
       that have been taken.*/
    Command( wxT("UndoHistory"), XXO("&History"), OnHistory,
-      AudioIONotBusyFlag() )
+      AudioIONotBusyFlag() ),
+   wxT("View/Windows")
 };
 
 }

--- a/src/LyricsWindow.cpp
+++ b/src/LyricsWindow.cpp
@@ -219,9 +219,10 @@ void OnKaraoke(const CommandContext &context)
 // Register that menu item
 
 using namespace MenuTable;
-AttachedItem sAttachment{ wxT("View/Windows"),
+AttachedItem sAttachment{
    Command( wxT("Karaoke"), XXO("&Karaoke"), OnKaraoke,
-      LabelTracksExistFlag() )
+      LabelTracksExistFlag() ),
+   wxT("View/Windows")
 };
 
 }

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -105,19 +105,20 @@ void MenuManager::UpdatePrefs()
 
 MenuVisitor::~MenuVisitor() = default;
 
-void MenuVisitor::BeginGroup( Registry::GroupItemBase &item, const Path &path )
+void MenuVisitor::BeginGroup(
+   const Registry::GroupItemBase &item, const Path &path)
 {
    bool isMenu = false;
    bool isExtension = false;
    auto pItem = &item;
-   const bool inlined = dynamic_cast<MenuTable::MenuItems*>(pItem);
+   const bool inlined = dynamic_cast<const MenuTable::MenuItems*>(pItem);
    if (inlined) {
    }
-   else if (dynamic_cast<MenuTable::MenuSection*>(pItem)) {
+   else if (dynamic_cast<const MenuTable::MenuSection*>(pItem)) {
       if ( !needSeparator.empty() )
          needSeparator.back() = true;
    }
-   else if (auto pWhole = dynamic_cast<MenuTable::WholeMenu*>(pItem)) {
+   else if (auto pWhole = dynamic_cast<const MenuTable::WholeMenu*>(pItem)) {
       isMenu = true;
       isExtension = pWhole->extension;
       MaybeDoSeparator();
@@ -132,17 +133,18 @@ void MenuVisitor::BeginGroup( Registry::GroupItemBase &item, const Path &path )
    }
 }
 
-void MenuVisitor::EndGroup( Registry::GroupItemBase &item, const Path &path )
+void MenuVisitor::EndGroup(
+   const Registry::GroupItemBase &item, const Path &path)
 {
    auto pItem = &item;
-   const bool inlined = dynamic_cast<MenuTable::MenuItems*>(pItem);
+   const bool inlined = dynamic_cast<const MenuTable::MenuItems*>(pItem);
    if (inlined) {
    }
-   else if (dynamic_cast<MenuTable::MenuSection*>(pItem)) {
+   else if (dynamic_cast<const MenuTable::MenuSection*>(pItem)) {
       if ( !needSeparator.empty() )
          needSeparator.back() = true;
    }
-   else if ( dynamic_cast<MenuTable::WholeMenu*>(pItem)) {
+   else if ( dynamic_cast<const MenuTable::WholeMenu*>(pItem)) {
       firstItem.pop_back();
       needSeparator.pop_back();
    }
@@ -151,10 +153,10 @@ void MenuVisitor::EndGroup( Registry::GroupItemBase &item, const Path &path )
       DoEndGroup(item, path);
 }
 
-void MenuVisitor::Visit( Registry::SingleItem &item, const Path &path )
+void MenuVisitor::Visit(const Registry::SingleItem &item, const Path &path)
 {
    MaybeDoSeparator();
-   DoVisit( item, path );
+   DoVisit(item, path);
 }
 
 void MenuVisitor::MaybeDoSeparator()
@@ -170,15 +172,15 @@ void MenuVisitor::MaybeDoSeparator()
       DoSeparator();
 }
 
-void MenuVisitor::DoBeginGroup( Registry::GroupItemBase &, const Path & )
+void MenuVisitor::DoBeginGroup(const Registry::GroupItemBase &, const Path &)
 {
 }
 
-void MenuVisitor::DoEndGroup( Registry::GroupItemBase &, const Path & )
+void MenuVisitor::DoEndGroup(const Registry::GroupItemBase &, const Path &)
 {
 }
 
-void MenuVisitor::DoVisit( Registry::SingleItem &, const Path & )
+void MenuVisitor::DoVisit(const Registry::SingleItem &, const Path &)
 {
 }
 
@@ -272,7 +274,7 @@ struct MenuItemVisitor : ProjectMenuVisitor
    MenuItemVisitor( AudacityProject &proj, CommandManager &man )
       : ProjectMenuVisitor{ proj }, manager{ man } {}
 
-   void DoBeginGroup( GroupItemBase &item, const Path& ) override
+   void DoBeginGroup(const GroupItemBase &item, const Path&) override
    {
       auto pItem = &item;
       if (const auto pMenu = dynamic_cast<const MenuItem*>(pItem)) {
@@ -293,29 +295,29 @@ struct MenuItemVisitor : ProjectMenuVisitor
          wxASSERT( false );
    }
 
-   void DoEndGroup( GroupItemBase &item, const Path& ) override
+   void DoEndGroup(const GroupItemBase &item, const Path&) override
    {
       auto pItem = &item;
       if (const auto pMenu =
-          dynamic_cast<MenuItem*>( pItem )) {
+          dynamic_cast<const MenuItem*>( pItem )) {
          manager.EndMenu();
       }
       else
       if (const auto pConditionalGroup =
-          dynamic_cast<ConditionalGroupItem*>( pItem )) {
+          dynamic_cast<const ConditionalGroupItem*>( pItem )) {
          const bool flag = flags.back();
          if (!flag)
             manager.EndOccultCommands();
          flags.pop_back();
       }
       else
-      if ( const auto pGroup = dynamic_cast<MenuSection*>( pItem ) ) {
+      if ( const auto pGroup = dynamic_cast<const MenuSection*>( pItem ) ) {
       }
       else
          wxASSERT( false );
    }
 
-   void DoVisit( SingleItem &item, const Path& ) override
+   void DoVisit(const SingleItem &item, const Path&) override
    {
       const auto pCurrentMenu = manager.CurrentMenu();
       if ( !pCurrentMenu ) {
@@ -326,7 +328,7 @@ struct MenuItemVisitor : ProjectMenuVisitor
       }
       auto pItem = &item;
       if (const auto pCommand =
-          dynamic_cast<CommandItem*>( pItem )) {
+          dynamic_cast<const CommandItem*>(pItem)) {
          manager.AddItem(mProject,
             pCommand->name, pCommand->label_in,
             pCommand->finder, pCommand->callback,
@@ -335,7 +337,7 @@ struct MenuItemVisitor : ProjectMenuVisitor
       }
       else
       if (const auto pCommandList =
-         dynamic_cast<CommandGroupItem*>( pItem ) ) {
+         dynamic_cast<const CommandGroupItem*>(pItem)) {
          manager.AddItemList(pCommandList->name,
             pCommandList->items.data(), pCommandList->items.size(),
             pCommandList->finder, pCommandList->callback,
@@ -343,7 +345,7 @@ struct MenuItemVisitor : ProjectMenuVisitor
       }
       else
       if (const auto pSpecial =
-          dynamic_cast<SpecialItem*>( pItem )) {
+          dynamic_cast<const SpecialItem*>(pItem)) {
          wxASSERT( pCurrentMenu );
          pSpecial->fn(mProject, *pCurrentMenu);
       }

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -257,16 +257,10 @@ const auto MenuPathStart = wxT("MenuBar");
 
 }
 
-Registry::GroupItemBase &MenuTable::ItemRegistry::Registry()
+auto MenuTable::ItemRegistry::Registry() -> Registry::GroupItem<Traits> &
 {
    static GroupItem<Traits> registry{ MenuPathStart };
    return registry;
-}
-
-MenuTable::AttachedItem::AttachedItem(
-   const Placement &placement, BaseItemPtr pItem )
-   : RegisteredItem{ std::move(pItem), placement }
-{
 }
 
 namespace {

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -190,11 +190,6 @@ void MenuVisitor::DoSeparator()
 
 ProjectMenuVisitor::~ProjectMenuVisitor() = default;
 
-void *ProjectMenuVisitor::GetComputedItemContext()
-{
-   return &mProject;
-}
-
 namespace MenuTable {
 
 MenuItem::~MenuItem() {}
@@ -432,8 +427,8 @@ void MenuManager::Visit(ProjectMenuVisitor &visitor)
    static const auto menuTree = MenuTable::Items( MenuPathStart );
 
    wxLogNull nolog;
-   Registry::Visit( visitor, menuTree.get(),
-      &MenuTable::ItemRegistry::Registry() );
+   Registry::Visit(visitor, menuTree.get(),
+      &MenuTable::ItemRegistry::Registry(), visitor.mProject);
 }
 
 // TODO: This surely belongs in CommandManager?

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1571,9 +1571,10 @@ void OnMixerBoard(const CommandContext &context)
 // Register that menu item
 
 using namespace MenuTable;
-AttachedItem sAttachment{ wxT("View/Windows"),
+AttachedItem sAttachment{
    Command( wxT("MixerBoard"), XXO("&Mixer"), OnMixerBoard,
-      PlayableTracksExistFlag())
+      PlayableTracksExistFlag()),
+   wxT("View/Windows")
 };
 
 }

--- a/src/Printing.cpp
+++ b/src/Printing.cpp
@@ -216,9 +216,9 @@ void OnPrint(const CommandContext &context)
 }
 
 using namespace MenuTable;
-BaseItemSharedPtr PrintingItems()
+auto PrintingItems()
 {
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    Section( "Print",
       Command( wxT("PageSetup"), XXO("Pa&ge Setup..."), OnPageSetup,
          AudioIONotBusyFlag() | TracksExistFlag() ),
@@ -229,8 +229,8 @@ BaseItemSharedPtr PrintingItems()
    return items;
 }
 
-AttachedItem sAttachment{ { "File", { OrderingHint::Before, "Exit" } },
-   Indirect(PrintingItems())
+AttachedItem sAttachment{ Indirect(PrintingItems()),
+   { "File", { OrderingHint::Before, "Exit" } }
 };
 
 }

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -69,9 +69,9 @@ namespace
       RealtimeEffectsMenuVisitor(wxMenu& menu)
          : mMenu(menu), mMenuPtr(&mMenu) { }
       
-      void DoBeginGroup( MenuTable::GroupItemBase &item, const Path& ) override
+      void DoBeginGroup(const MenuTable::GroupItemBase &item, const Path&) override
       {
-         if(auto menuItem = dynamic_cast<MenuTable::MenuItem*>(&item))
+         if(auto menuItem = dynamic_cast<const MenuTable::MenuItem*>(&item))
          {
             //Don't create a group item for root
             if (mMenuLevelCounter != 0)
@@ -84,9 +84,9 @@ namespace
          }
       }
 
-      void DoEndGroup( MenuTable::GroupItemBase &item, const Path& ) override
+      void DoEndGroup(const MenuTable::GroupItemBase &item, const Path&) override
       {
-         if(auto menuItem = dynamic_cast<MenuTable::MenuItem*>(&item))
+         if(auto menuItem = dynamic_cast<const MenuTable::MenuItem*>(&item))
          {
             --mMenuLevelCounter;
             if (mMenuLevelCounter != 0)
@@ -97,9 +97,9 @@ namespace
          }
       }
 
-      void DoVisit( MenuTable::SingleItem &item, const Path& ) override
+      void DoVisit(const MenuTable::SingleItem &item, const Path&) override
       {
-         if(auto commandItem = dynamic_cast<MenuTable::CommandItem*>(&item))
+         if(auto commandItem = dynamic_cast<const MenuTable::CommandItem*>(&item))
          {
             mMenuPtr->Append(mMenuItemIdCounter, commandItem->label_in.Translation());
             mIndexedPluginList.push_back(commandItem->name);

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -752,6 +752,9 @@ public:
    
    std::optional<wxString> PickEffect(wxWindow* parent, const wxString& selectedEffectID) override
    {
+      if (mProject == nullptr)
+         return {};
+   
       wxMenu menu;
       if(!selectedEffectID.empty())
       {
@@ -762,7 +765,7 @@ public:
       
       RealtimeEffectsMenuVisitor visitor { menu };
       
-      Registry::Visit(visitor, mEffectMenuRoot.get());
+      Registry::Visit(visitor, mEffectMenuRoot.get(), {}, *mProject);
       
       int commandId = wxID_NONE;
       

--- a/src/Screenshot.cpp
+++ b/src/Screenshot.cpp
@@ -828,9 +828,9 @@ void OnScreenshot(const CommandContext &context )
 
 using namespace MenuTable;
 AttachedItem sAttachment{
-   { wxT("Tools/Other"), { OrderingHint::After, wxT("ConfigReset") } },
    Command( wxT("FancyScreenshot"), XXO("&Screenshot..."),
-      OnScreenshot, AudioIONotBusyFlag() )
+      OnScreenshot, AudioIONotBusyFlag() ),
+   { wxT("Tools/Other"), { OrderingHint::After, wxT("ConfigReset") } }
 };
 
 }

--- a/src/TagsEditor.cpp
+++ b/src/TagsEditor.cpp
@@ -1039,8 +1039,8 @@ void OnEditMetadata(const CommandContext &context)
 using namespace MenuTable;
 
 AttachedItem sAttachment{
-   wxT("Edit/Other"),
    Command( wxT("EditMetaData"), XXO("&Metadata Editor"), OnEditMetadata,
-      AudioIONotBusyFlag() )
+      AudioIONotBusyFlag() ),
+   wxT("Edit/Other")
 };
 }

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -1326,10 +1326,10 @@ const auto CanStopFlags = AudioIONotBusyFlag() | CanStopAudioStreamFlag();
 
 using namespace MenuTable;
 AttachedItem sAttachment{
-   { wxT("Transport/Basic/Record"),
-      { OrderingHint::After, wxT("Record2ndChoice") } },
    Command( wxT("TimerRecord"), XXO("&Timer Record..."),
-      OnTimerRecord, CanStopFlags, wxT("Shift+T") )
+      OnTimerRecord, CanStopFlags, wxT("Shift+T") ),
+   { wxT("Transport/Basic/Record"),
+      { OrderingHint::After, wxT("Record2ndChoice") } }
 };
 
 }

--- a/src/cloud/audiocom/LinkAccountDialog.cpp
+++ b/src/cloud/audiocom/LinkAccountDialog.cpp
@@ -142,9 +142,9 @@ void OnLinkAccount(const CommandContext&)
 
 using namespace MenuTable;
 AttachedItem sAttachment{
-   Placement{ wxT("Help/Extra"), { OrderingHint::Begin } },
       Command(
          wxT("LinkAccount"), XXO("L&ink audio.com account..."),
-         OnLinkAccount, AlwaysEnabledFlag) 
+         OnLinkAccount, AlwaysEnabledFlag),
+   Placement{ wxT("Help/Extra"), { OrderingHint::Begin } }
 };
 }

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -393,16 +393,19 @@ struct AUDACITY_DLL_API MenuVisitor : Registry::Visitor
    ~MenuVisitor() override;
 
    // final overrides
-   void BeginGroup( Registry::GroupItemBase &item, const Path &path ) final;
-   void EndGroup( Registry::GroupItemBase &item, const Path& ) final;
-   void Visit( Registry::SingleItem &item, const Path &path ) final;
+   void BeginGroup(const Registry::GroupItemBase &item, const Path &path )
+      final;
+   void EndGroup(const Registry::GroupItemBase &item, const Path& ) final;
+   void Visit(const Registry::SingleItem &item, const Path &path ) final;
 
    // added virtuals
    //! Groups of type MenuItems are excluded from this callback
-   virtual void DoBeginGroup( Registry::GroupItemBase &item, const Path &path );
+   virtual void DoBeginGroup(
+      const Registry::GroupItemBase &item, const Path &path);
    //! Groups of type MenuItems are excluded from this callback
-   virtual void DoEndGroup( Registry::GroupItemBase &item, const Path &path );
-   virtual void DoVisit( Registry::SingleItem &item, const Path &path );
+   virtual void DoEndGroup(
+      const Registry::GroupItemBase &item, const Path &path);
+   virtual void DoVisit(const Registry::SingleItem &item, const Path &path);
    virtual void DoSeparator();
 
 private:

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -418,7 +418,6 @@ struct ProjectMenuVisitor : MenuVisitor
 {
    explicit ProjectMenuVisitor(AudacityProject &p) : mProject{ p } {}
    ~ProjectMenuVisitor() override;
-   virtual void *GetComputedItemContext() override;
    AudacityProject &mProject;
 };
 

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -426,14 +426,17 @@ namespace MenuTable {
    using namespace Registry;
 
    struct CommandItem;
+   struct CommandGroupItem;
    struct ConditionalGroupItem;
    struct MenuItem;
    struct MenuItems;
+   struct SpecialItem;
    struct MenuPart;
 
    struct Traits : Registry::DefaultTraits {
       using ComputedItemContextType = AudacityProject;
-      using LeafTypes = List<CommandItem>;
+      using LeafTypes = List<
+         CommandItem, CommandGroupItem, SpecialItem>;
       using NodeTypes = List<
          ConditionalGroupItem, MenuItem, MenuItems, MenuPart>;
    };

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -423,8 +423,17 @@ struct ProjectMenuVisitor : MenuVisitor
 namespace MenuTable {
    using namespace Registry;
 
+   struct CommandItem;
+   struct ConditionalGroupItem;
+   struct MenuItem;
+   struct MenuItems;
+   struct MenuPart;
+
    struct Traits : Registry::DefaultTraits {
       using ComputedItemContextType = AudacityProject;
+      using LeafTypes = List<CommandItem>;
+      using NodeTypes = List<
+         ConditionalGroupItem, MenuItem, MenuItems, MenuPart>;
    };
 
    // These are found by dynamic_cast
@@ -685,22 +694,13 @@ namespace MenuTable {
    //! @}
 
    struct ItemRegistry {
-      static GroupItemBase &Registry();
+      static GroupItem<Traits> &Registry();
    };
 
    // Typically you make a static object of this type in the .cpp file that
    // also defines the added menu actions.
    // pItem can be specified by an expression using the inline functions above.
-   struct AUDACITY_DLL_API AttachedItem final
-      : public RegisteredItem<BaseItem, ItemRegistry>
-   {
-      AttachedItem( const Placement &placement, BaseItemPtr pItem );
-
-      AttachedItem( const wxString &path, BaseItemPtr pItem )
-         // Delegating constructor
-         : AttachedItem( Placement{ path }, std::move( pItem ) )
-      {}
-   };
+   using AttachedItem = RegisteredItem<ItemRegistry>;
 }
 
 #endif

--- a/src/commands/CompareAudioCommand.cpp
+++ b/src/commands/CompareAudioCommand.cpp
@@ -178,12 +178,12 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("CompareAudio"), XXO("Compare Audio..."),
       CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 }

--- a/src/commands/DragCommand.cpp
+++ b/src/commands/DragCommand.cpp
@@ -154,13 +154,13 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("Drag"), XXO("Move Mouse..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 
 }

--- a/src/commands/GetInfoCommand.cpp
+++ b/src/commands/GetInfoCommand.cpp
@@ -788,13 +788,13 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("GetInfo"), XXO("Get Info..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 
 }

--- a/src/commands/HelpCommand.cpp
+++ b/src/commands/HelpCommand.cpp
@@ -144,13 +144,13 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("Help"), XXO("Help..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 
 }

--- a/src/commands/ImportExportCommands.cpp
+++ b/src/commands/ImportExportCommands.cpp
@@ -164,7 +164,6 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    Items( wxT(""),
       // Note that the PLUGIN_SYMBOL must have a space between words,
       // whereas the short-form used here must not.
@@ -174,6 +173,7 @@ AttachedItem sAttachment{
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
       Command( wxT("Export2"), XXO("Export..."),
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
-   )
+   ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 }

--- a/src/commands/MessageCommand.cpp
+++ b/src/commands/MessageCommand.cpp
@@ -63,13 +63,13 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("Message"), XXO("Message..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 
 }

--- a/src/commands/OpenSaveCommands.cpp
+++ b/src/commands/OpenSaveCommands.cpp
@@ -230,7 +230,6 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    Items( wxT(""),
       // Note that the PLUGIN_SYMBOL must have a space between words,
       // whereas the short-form used here must not.
@@ -240,6 +239,7 @@ AttachedItem sAttachment{
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
       Command( wxT("SaveProject2"), XXO("Save Project..."),
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
-   )
+   ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 }

--- a/src/commands/PreferenceCommands.cpp
+++ b/src/commands/PreferenceCommands.cpp
@@ -115,7 +115,6 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment1{
-   wxT("Optional/Extra/Part2/Scriptables1"),
    Items( wxT(""),
       // Note that the PLUGIN_SYMBOL must have a space between words,
       // whereas the short-form used here must not.
@@ -125,6 +124,7 @@ AttachedItem sAttachment1{
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
       Command( wxT("SetPreference"), XXO("Set Preference..."),
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
-   )
+   ),
+   wxT("Optional/Extra/Part2/Scriptables1")
 };
 }

--- a/src/commands/ScreenshotCommand.cpp
+++ b/src/commands/ScreenshotCommand.cpp
@@ -882,13 +882,13 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    // i18n-hint: Screenshot in the help menu has a much bigger dialog.
    Command( wxT("Screenshot"), XXO("Screenshot (short format)..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 }

--- a/src/commands/SelectCommand.cpp
+++ b/src/commands/SelectCommand.cpp
@@ -311,7 +311,6 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment1{
-   wxT("Optional/Extra/Part2/Scriptables1"),
    Items( wxT(""),
       // Note that the PLUGIN_SYMBOL must have a space between words,
       // whereas the short-form used here must not.
@@ -323,16 +322,17 @@ AttachedItem sAttachment1{
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
       Command( wxT("SelectTracks"), XXO("Select Tracks..."),
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
-   )
+   ),
+   wxT("Optional/Extra/Part2/Scriptables1")
 };
 
 AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("Select"), XXO("Select..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 }

--- a/src/commands/SetClipCommand.cpp
+++ b/src/commands/SetClipCommand.cpp
@@ -122,12 +122,12 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment1{
-   wxT("Optional/Extra/Part2/Scriptables1"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("SetClip"), XXO("Set Clip..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables1")
 };
 }

--- a/src/commands/SetEnvelopeCommand.cpp
+++ b/src/commands/SetEnvelopeCommand.cpp
@@ -111,12 +111,12 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment1{
-   wxT("Optional/Extra/Part2/Scriptables1"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("SetEnvelope"), XXO("Set Envelope..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables1")
 };
 }

--- a/src/commands/SetLabelCommand.cpp
+++ b/src/commands/SetLabelCommand.cpp
@@ -146,12 +146,12 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment1{
-   wxT("Optional/Extra/Part2/Scriptables1"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("SetLabel"), XXO("Set Label..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables1")
 };
 }

--- a/src/commands/SetProjectCommand.cpp
+++ b/src/commands/SetProjectCommand.cpp
@@ -106,12 +106,12 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment1{
-   wxT("Optional/Extra/Part2/Scriptables1"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("SetProject"), XXO("Set Project..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables1")
 };
 }

--- a/src/commands/SetTrackInfoCommand.cpp
+++ b/src/commands/SetTrackInfoCommand.cpp
@@ -428,7 +428,6 @@ using namespace MenuTable;
 // Register menu items
 
 AttachedItem sAttachment1{
-   wxT("Optional/Extra/Part2/Scriptables1"),
    Items( wxT(""),
       // Note that the PLUGIN_SYMBOL must have a space between words,
       // whereas the short-form used here must not.
@@ -440,16 +439,17 @@ AttachedItem sAttachment1{
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
       Command( wxT("SetTrackVisuals"), XXO("Set Track Visuals..."),
          CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
-   )
+   ),
+   wxT("Optional/Extra/Part2/Scriptables1")
 };
 
 AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part2/Scriptables2"),
    // Note that the PLUGIN_SYMBOL must have a space between words,
    // whereas the short-form used here must not.
    // (So if you did write "Compare Audio" for the PLUGIN_SYMBOL name, then
    // you would have to use "CompareAudio" here.)
    Command( wxT("SetTrack"), XXO("Set Track..."),
-      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() )
+      CommandDispatch::OnAudacityCommand, AudioIONotBusyFlag() ),
+   wxT("Optional/Extra/Part2/Scriptables2")
 };
 }

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -687,11 +687,12 @@ namespace {
 // Register that menu item
 
 using namespace MenuTable;
-AttachedItem sAttachment{ wxT("Analyze/Analyzers/Windows"),
+AttachedItem sAttachment{
    Command( wxT("ContrastAnalyser"), XXO("Contrast..."),
       OnContrast,
       AudioIONotBusyFlag() | WaveTracksSelectedFlag() | TimeSelectedFlag(),
-      wxT("Ctrl+Shift+T") )
+      wxT("Ctrl+Shift+T") ),
+   wxT("Analyze/Analyzers/Windows")
 };
 
 }

--- a/src/export/ExportMIDI.cpp
+++ b/src/export/ExportMIDI.cpp
@@ -126,10 +126,10 @@ void OnExportMIDI(const CommandContext &context)
 }
 
 AttachedItem sAttachment{
-   { wxT("File/Import-Export/ExportOther"),
-      { OrderingHint::After, {"ExportLabels"} } },
    Command( wxT("ExportMIDI"), XXO("Export MI&DI..."), OnExportMIDI,
-      AudioIONotBusyFlag() | NoteTracksExistFlag() )
+      AudioIONotBusyFlag() | NoteTracksExistFlag() ),
+   { wxT("File/Import-Export/ExportOther"),
+      { OrderingHint::After, {"ExportLabels"} } }
 };
 
 }

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -162,10 +162,10 @@ void OnImportMIDI(const CommandContext &context)
 }
 
 AttachedItem sAttachment{
-   { wxT("File/Import-Export/Import"),
-      { OrderingHint::After, {"ImportAudio"} } },
    Command( wxT("ImportMIDI"), XXO("&MIDI..."), OnImportMIDI,
-      AudioIONotBusyFlag() )
+      AudioIONotBusyFlag() ),
+   { wxT("File/Import-Export/Import"),
+      { OrderingHint::After, {"ImportAudio"} } }
 };
 
 }

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -750,11 +750,11 @@ using namespace MenuTable;
 
 // Register menu items
 
-BaseItemSharedPtr ClipSelectMenu()
+auto ClipSelectMenu()
 {
    using Options = CommandManager::Options;
 
-   static BaseItemSharedPtr menu {
+   static auto menu = std::shared_ptr{
    Menu( wxT("Clip"), XXO("Audi&o Clips"),
       Command( wxT("SelPrevClipBoundaryToCursor"),
          XXO("Pre&vious Clip Boundary to Cursor"),
@@ -774,16 +774,12 @@ BaseItemSharedPtr ClipSelectMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   wxT("Select/Basic"),
-   Indirect(ClipSelectMenu())
-};
+AttachedItem sAttachment1{ Indirect(ClipSelectMenu()), wxT("Select/Basic") };
 
-BaseItemSharedPtr ClipCursorItems()
+auto ClipCursorItems()
 {
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    Items( wxT("Clip"),
       Command( wxT("CursPrevClipBoundary"), XXO("Pre&vious Clip Boundary"),
          OnCursorPrevClipBoundary,
@@ -797,16 +793,15 @@ BaseItemSharedPtr ClipCursorItems()
    return items;
 }
 
-AttachedItem sAttachment2{
+AttachedItem sAttachment2{ Indirect(ClipCursorItems()),
    { wxT("Transport/Basic/Cursor"),
-     { OrderingHint::Before, wxT("CursProjectStart") } },
-   Indirect(ClipCursorItems())
+     { OrderingHint::Before, wxT("CursProjectStart") } }
 };
 
-BaseItemSharedPtr ExtraTimeShiftItems()
+auto ExtraTimeShiftItems()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    Items( wxT("TimeShift"),
       Command( wxT("ClipLeft"), XXO("Time Shift &Left"), OnClipLeft,
          TracksExistFlag() | TrackPanelHasFocus(), Options{}.WantKeyUp() ),
@@ -816,9 +811,8 @@ BaseItemSharedPtr ExtraTimeShiftItems()
    return items;
 }
 
-AttachedItem sAttachment3{
-  { wxT("Optional/Extra/Part1/Edit"), { OrderingHint::End, {} } },
-   Indirect(ExtraTimeShiftItems())
+AttachedItem sAttachment3{ Indirect(ExtraTimeShiftItems()),
+  { wxT("Optional/Extra/Part1/Edit"), { OrderingHint::End, {} } }
 };
 
 }

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -1061,7 +1061,7 @@ const ReservedCommandFlag
 }; return flag; }
 
 using namespace MenuTable;
-BaseItemSharedPtr EditMenu()
+auto EditMenu()
 {
    using Options = CommandManager::Options;
 
@@ -1087,7 +1087,7 @@ BaseItemSharedPtr EditMenu()
 #endif
    ;
 
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Edit"), XXO("&Edit"),
       Section( "UndoRedo",
          Command( wxT("Undo"), XXO("&Undo"), OnUndo,
@@ -1188,17 +1188,14 @@ BaseItemSharedPtr EditMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(EditMenu())
-};
+AttachedItem sAttachment1{ Indirect(EditMenu()) };
 
-BaseItemSharedPtr ExtraEditMenu()
+auto ExtraEditMenu()
 {
    using Options = CommandManager::Options;
    static const auto flags =
       AudioIONotBusyFlag() | EditableTracksSelectedFlag() | TimeSelectedFlag();
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Edit"), XXO("&Edit"),
       Command( wxT("DeleteKey"), XXO("&Delete Key"), OnDelete,
          (flags | NoAutoSelect()),
@@ -1248,9 +1245,8 @@ RegisteredMenuItemEnabler selectWaveTracks2{{
    selectAll
 }};
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part1"),
-   Indirect(ExtraEditMenu())
+AttachedItem sAttachment2{ Indirect(ExtraEditMenu()),
+   wxT("Optional/Extra/Part1")
 };
 
 }

--- a/src/menus/ExtraMenus.cpp
+++ b/src/menus/ExtraMenus.cpp
@@ -29,7 +29,7 @@ void OnFullScreen(const CommandContext &context)
 
 using namespace MenuTable;
 
-BaseItemSharedPtr ExtraMenu()
+auto ExtraMenu()
 {
    static const auto pred =
       []{ return gPrefs->ReadBool(wxT("/GUI/ShowExtraMenus"), false); };
@@ -43,18 +43,15 @@ BaseItemSharedPtr ExtraMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(ExtraMenu())
-};
+AttachedItem sAttachment1{ Indirect(ExtraMenu()) };
 
 // Under /MenuBar/Optional/Extra/Part2
-BaseItemSharedPtr ExtraMiscItems()
+auto ExtraMiscItems()
 {
    using Options = CommandManager::Options;
 
    // Not a menu.
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    Items( wxT("Misc"),
       // Delayed evaluation
       []( AudacityProject &project ) {
@@ -81,9 +78,8 @@ BaseItemSharedPtr ExtraMiscItems()
    return items;
 }
 
-AttachedItem sAttachment2{
-   Placement{ wxT("Optional/Extra/Part2"), { OrderingHint::End } },
-   Indirect(ExtraMiscItems())
+AttachedItem sAttachment2{ Indirect(ExtraMiscItems()),
+   Placement{ wxT("Optional/Extra/Part2"), { OrderingHint::End } }
 };
 
 }

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -10,6 +10,7 @@
 #include "../ProjectManager.h"
 #include "../ProjectWindows.h"
 #include "../ProjectWindow.h"
+#include "Registry.h"
 #include "SelectFile.h"
 #include "../TagsEditor.h"
 #include "../SelectUtilities.h"
@@ -428,11 +429,10 @@ void OnExportFLAC(const CommandContext &context)
 
 using namespace MenuTable;
 
-BaseItemSharedPtr FileMenu()
+auto FileMenu()
 {
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("File"), XXO("&File"),
       Section( "Basic",
          /*i18n-hint: "New" is an action (verb) to create a NEW project*/
@@ -542,15 +542,11 @@ BaseItemSharedPtr FileMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(FileMenu())
-};
+AttachedItem sAttachment1{ Indirect(FileMenu()) };
 
-BaseItemSharedPtr HiddenFileMenu()
+auto HiddenFileMenu()
 {
-   static BaseItemSharedPtr menu
-   {
+   static auto menu = std::shared_ptr{
       ConditionalItems( wxT("HiddenFileItems"),
          []()
          {
@@ -568,14 +564,11 @@ BaseItemSharedPtr HiddenFileMenu()
    return menu;
 }
 
-AttachedItem sAttachment2{
-   wxT(""),
-   Indirect(HiddenFileMenu())
-};
+AttachedItem sAttachment2{ Indirect(HiddenFileMenu()) };
 
-BaseItemSharedPtr ExtraExportMenu()
+auto ExtraExportMenu()
 {
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
       Section( "Import-Export",
          Menu( wxT("Export"), XXO("&Export"),
             // Enable Export audio commands only when there are audio tracks.
@@ -593,8 +586,8 @@ BaseItemSharedPtr ExtraExportMenu()
 }
 
 AttachedItem sAttachment3{
-   wxT("Optional/Extra/Part1"),
-   Indirect( ExtraExportMenu() )
+   Indirect( ExtraExportMenu() ),
+   wxT("Optional/Extra/Part1")
 };
 
 }

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -330,9 +330,9 @@ void OnMenuTree(const CommandContext &context)
       using ProjectMenuVisitor::ProjectMenuVisitor;
 
       enum : unsigned { TAB = 3 };
-      void DoBeginGroup( GroupItemBase &item, const Path& ) override
+      void DoBeginGroup(const GroupItemBase &item, const Path&) override
       {
-         if ( dynamic_cast<MenuItem*>( &item ) ) {
+         if ( dynamic_cast<const MenuItem*>( &item ) ) {
             Indent();
             // using GET for alpha only diagnostic tool
             info += item.name.GET();
@@ -341,13 +341,13 @@ void OnMenuTree(const CommandContext &context)
          }
       }
 
-      void DoEndGroup( GroupItemBase &item, const Path& ) override
+      void DoEndGroup(const GroupItemBase &item, const Path&) override
       {
-         if ( dynamic_cast<MenuItem*>( &item ) )
+         if ( dynamic_cast<const MenuItem*>( &item ) )
             indentation = wxString{ ' ', TAB * --level };
       }
 
-      void DoVisit( SingleItem &item, const Path& ) override
+      void DoVisit(const SingleItem &item, const Path&) override
       {
          // using GET for alpha only diagnostic tool
          Indent();

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -428,9 +428,9 @@ void OnHelpWelcome(const CommandContext &context)
 // Menu definitions
 
 using namespace MenuTable;
-BaseItemSharedPtr HelpMenu()
+auto HelpMenu()
 {
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Help"), XXO("&Help"),
       Section( "Basic",
          // QuickFix menu item not in Audacity 2.3.1 whilst we discuss further.
@@ -511,9 +511,6 @@ BaseItemSharedPtr HelpMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(HelpMenu())
-};
+AttachedItem sAttachment1{ Indirect(HelpMenu()) };
 
 }

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -684,7 +684,7 @@ void OnNewLabelTrack(const CommandContext &context)
 // Menu definitions
 
 using namespace MenuTable;
-BaseItemSharedPtr LabelEditMenus()
+auto LabelEditMenus()
 {
    using namespace MenuTable;
    using Options = CommandManager::Options;
@@ -695,7 +695,7 @@ BaseItemSharedPtr LabelEditMenus()
 
    // Returns TWO menus.
 
-   static BaseItemSharedPtr menus{
+   static auto menus = std::shared_ptr{
    Items( wxT("LabelEditMenus"),
 
    Menu( wxT("Labels"), XXO("&Labels"),
@@ -783,15 +783,15 @@ BaseItemSharedPtr LabelEditMenus()
    return menus;
 }
 
-AttachedItem sAttachment1{
+AttachedItem sAttachment1{ Indirect(LabelEditMenus()),
    { wxT("Edit/Other"),
-     { OrderingHint::Before, wxT("EditMetaData") } },
-   Indirect(LabelEditMenus())
+     { OrderingHint::Before, wxT("EditMetaData") } }
 };
 
-AttachedItem sAttachment2{ wxT("Tracks/Add/Add"),
+AttachedItem sAttachment2{
    Command( wxT("NewLabelTrack"), XXO("&Label Track"),
-      OnNewLabelTrack, AudioIONotBusyFlag() )
+      OnNewLabelTrack, AudioIONotBusyFlag() ),
+   wxT("Tracks/Add/Add")
 };
 
 }

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -522,12 +522,11 @@ static CommandHandlerObject &findCommandHandler(AudacityProject &project) {
 
 namespace {
 using namespace MenuTable;
-BaseItemSharedPtr ExtraGlobalCommands()
+auto ExtraGlobalCommands()
 {
    // Ceci n'est pas un menu
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    Items( wxT("Navigation"),
       Command( wxT("PrevWindow"), XXO("Move Backward Through Active Windows"),
@@ -540,16 +539,15 @@ BaseItemSharedPtr ExtraGlobalCommands()
    return items;
 }
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part2"),
-   Indirect(ExtraGlobalCommands())
+AttachedItem sAttachment2{ Indirect(ExtraGlobalCommands()),
+   wxT("Optional/Extra/Part2")
 };
 
-BaseItemSharedPtr ExtraFocusMenu()
+auto ExtraFocusMenu()
 {
-   static const auto FocusedTracksFlags = TracksExistFlag() | TrackPanelHasFocus();
-
-   static BaseItemSharedPtr menu{
+   static const auto FocusedTracksFlags =
+      TracksExistFlag() | TrackPanelHasFocus();
+   static auto menu = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    Menu( wxT("Focus"), XXO("Foc&us"),
       Command( wxT("PrevFrame"),
@@ -578,9 +576,8 @@ BaseItemSharedPtr ExtraFocusMenu()
    return menu;
 }
 
-AttachedItem sAttachment3{
-   wxT("Optional/Extra/Part2"),
-   Indirect(ExtraFocusMenu())
+AttachedItem sAttachment3{ Indirect(ExtraFocusMenu()),
+   wxT("Optional/Extra/Part2")
 };
 
 }

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -269,14 +269,12 @@ const ReservedCommandFlag&
       }
    }; return flag; }
 
-BaseItemSharedPtr GenerateMenu()
+auto GenerateMenu()
 {
    // All of this is a bit hacky until we can get more things connected into
    // the plugin manager...sorry! :-(
-
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Generate"), XXO("&Generate"),
       Section( "Manage",
          Command( wxT("ManageGenerators"), XXO("Plugin Manager"),
@@ -327,10 +325,7 @@ static const ReservedCommandFlag
    }
 }; return flag; }  //lll
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(GenerateMenu())
-};
+AttachedItem sAttachment1{ Indirect(GenerateMenu()) };
 
 const ReservedCommandFlag&
    HasLastEffectFlag() { static ReservedCommandFlag flag{
@@ -350,12 +345,11 @@ static const ReservedCommandFlag&
    return flag;
 }
 
-BaseItemSharedPtr EffectMenu()
+auto EffectMenu()
 {
    // All of this is a bit hacky until we can get more things connected into
    // the plugin manager...sorry! :-(
-
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Effect"), XXO("Effe&ct"),
       Section( "Manage",
          Command( wxT("ManageEffects"), XXO("Plugin Manager"),
@@ -404,10 +398,7 @@ BaseItemSharedPtr EffectMenu()
    return menu;
 }
 
-AttachedItem sAttachment2{
-   wxT(""),
-   Indirect(EffectMenu())
-};
+AttachedItem sAttachment2{ Indirect(EffectMenu()) };
 
 const ReservedCommandFlag&
    HasLastAnalyzerFlag() { static ReservedCommandFlag flag{
@@ -418,14 +409,12 @@ const ReservedCommandFlag&
    }; return flag;
 }
 
-BaseItemSharedPtr AnalyzeMenu()
+auto AnalyzeMenu()
 {
    // All of this is a bit hacky until we can get more things connected into
    // the plugin manager...sorry! :-(
-
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Analyze"), XXO("&Analyze"),
       Section( "Manage",
          Command( wxT("ManageAnalyzers"), XXO("Plugin Manager"),
@@ -471,16 +460,12 @@ BaseItemSharedPtr AnalyzeMenu()
    return menu;
 }
 
-AttachedItem sAttachment3{
-   wxT(""),
-   Indirect(AnalyzeMenu())
-};
+AttachedItem sAttachment3{ Indirect(AnalyzeMenu()) };
 
-BaseItemSharedPtr ToolsMenu()
+auto ToolsMenu()
 {
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Tools"), XXO("T&ools"),
       Section( "Manage",
          Command( wxT("ManageTools"), XXO("Plugin Manager"),
@@ -557,9 +542,6 @@ BaseItemSharedPtr ToolsMenu()
    return menu;
 }
 
-AttachedItem sAttachment4{
-   wxT(""),
-   Indirect(ToolsMenu())
-};
+AttachedItem sAttachment4{ Indirect(ToolsMenu()) };
 
 }

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -940,10 +940,10 @@ static CommandHandlerObject &findCommandHandler(AudacityProject &project) {
 
 namespace {
 using namespace MenuTable;
-BaseItemSharedPtr SelectMenu()
+auto SelectMenu()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    /* i18n-hint: (verb) It's an item on a menu. */
    Menu( wxT("Select"), XXO("&Select"),
@@ -1029,15 +1029,12 @@ BaseItemSharedPtr SelectMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(SelectMenu())
-};
+AttachedItem sAttachment1{ Indirect(SelectMenu()) };
 
-BaseItemSharedPtr ExtraSelectionMenu()
+auto ExtraSelectionMenu()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    Menu( wxT("Select"), XXO("&Selection"),
       Command( wxT("SnapToOff"), XXO("Snap-To &Off"), FN(OnSnapToOff),
@@ -1076,14 +1073,13 @@ BaseItemSharedPtr ExtraSelectionMenu()
    return menu;
 }
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part1"),
-   Indirect(ExtraSelectionMenu())
+AttachedItem sAttachment2{ Indirect(ExtraSelectionMenu()),
+   wxT("Optional/Extra/Part1")
 };
 }
 
 namespace {
-BaseItemSharedPtr CursorMenu()
+auto CursorMenu()
 {
    using Options = CommandManager::Options;
    static const auto CanStopFlags = AudioIONotBusyFlag() | CanStopAudioStreamFlag();
@@ -1093,7 +1089,7 @@ BaseItemSharedPtr CursorMenu()
    // GA: 'Skip to' moves the viewpoint to center of the track and preserves the
    // selection. 'Cursor to' does neither. 'Center at' might describe it better
    // than 'Skip'.
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    Menu( wxT("Cursor"), XXO("&Cursor to"),
       Command( wxT("CursSelStart"), XXO("Selection Star&t"),
@@ -1125,15 +1121,14 @@ BaseItemSharedPtr CursorMenu()
    return menu;
 }
 
-AttachedItem sAttachment0{
-   wxT("Transport/Basic"),
-   Indirect(CursorMenu())
+AttachedItem sAttachment0{ Indirect(CursorMenu()),
+   wxT("Transport/Basic")
 };
 
-BaseItemSharedPtr ExtraCursorMenu()
+auto ExtraCursorMenu()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    Menu( wxT("Cursor"), XXO("&Cursor"),
       Command( wxT("CursorLeft"), XXO("Cursor &Left"), FN(OnCursorLeft),
@@ -1158,15 +1153,14 @@ BaseItemSharedPtr ExtraCursorMenu()
    return menu;
 }
 
-AttachedItem sAttachment4{
-   wxT("Optional/Extra/Part2"),
-   Indirect(ExtraCursorMenu())
+AttachedItem sAttachment4{ Indirect(ExtraCursorMenu()),
+   wxT("Optional/Extra/Part2")
 };
 
-BaseItemSharedPtr ExtraSeekMenu()
+auto ExtraSeekMenu()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    Menu( wxT("Seek"), XXO("See&k"),
       Command( wxT("SeekLeftShort"), XXO("Short Seek &Left During Playback"),
@@ -1186,9 +1180,8 @@ BaseItemSharedPtr ExtraSeekMenu()
    return menu;
 }
 
-AttachedItem sAttachment5{
-   wxT("Optional/Extra/Part1"),
-   Indirect(ExtraSeekMenu())
+AttachedItem sAttachment5{ Indirect(ExtraSeekMenu()),
+   wxT("Optional/Extra/Part1")
 };
 
 }

--- a/src/menus/TimelineMenus.cpp
+++ b/src/menus/TimelineMenus.cpp
@@ -45,10 +45,10 @@ TimeDisplayMode GetTimeDisplayMode(const AudacityProject& project)
 
 using namespace MenuTable;
 
-BaseItemSharedPtr ExtraSelectionMenu()
+auto ExtraSelectionMenu()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr menu { Menu(
+   static auto menu = std::shared_ptr{ Menu(
       wxT("Timeline"), XXO("&Timeline"),
       Command(
          wxT("MinutesAndSeconds"), XXO("Minutes and Seconds"),
@@ -69,7 +69,7 @@ BaseItemSharedPtr ExtraSelectionMenu()
    return menu;
 }
 
-AttachedItem sAttachment2 { wxT("Optional/Extra/Part1"),
-   Indirect(ExtraSelectionMenu()) };
+AttachedItem sAttachment2 { Indirect(ExtraSelectionMenu()),
+   wxT("Optional/Extra/Part1") };
 
 } // namespace

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -10,11 +10,10 @@ namespace {
 
 using namespace MenuTable;
 
-BaseItemSharedPtr ToolbarsMenu()
+auto ToolbarsMenu()
 {
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Section( wxT("Toolbars"),
       Menu( wxT("Toolbars"), XXO("&Toolbars"),
          Section( "Reset",
@@ -29,8 +28,7 @@ BaseItemSharedPtr ToolbarsMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   Placement{ wxT("View/Other"), { OrderingHint::Begin } },
-   Indirect(ToolbarsMenu())
+AttachedItem sAttachment1{ Indirect(ToolbarsMenu()),
+   Placement{ wxT("View/Other"), { OrderingHint::Begin } }
 };
 }

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -1135,12 +1135,11 @@ void OnTrackMoveBottom(const CommandContext &context)
 
 // Under /MenuBar
 using namespace MenuTable;
-BaseItemSharedPtr TracksMenu()
+auto TracksMenu()
 {
    // Tracks Menu (formerly Project Menu)
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Tracks"), XXO("&Tracks"),
       Section( "Add",
          Menu( wxT("Add"), XXO("Add &New") )
@@ -1282,15 +1281,12 @@ BaseItemSharedPtr TracksMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(TracksMenu())
-};
+AttachedItem sAttachment1{ Indirect(TracksMenu()) };
 
-BaseItemSharedPtr ExtraTrackMenu()
+auto ExtraTrackMenu()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Track"), XXO("&Track"),
       Command( wxT("TrackPan"), XXO("Change P&an on Focused Track..."),
          OnTrackPan,
@@ -1340,9 +1336,8 @@ BaseItemSharedPtr ExtraTrackMenu()
    return menu;
 }
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part2"),
-   Indirect(ExtraTrackMenu())
+AttachedItem sAttachment2{ Indirect(ExtraTrackMenu()),
+   wxT("Optional/Extra/Part2")
 };
 
 }

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -1153,7 +1153,7 @@ auto TracksMenu()
             // Stereo to Mono is an oddball command that is also subject to control
             // by the plug-in manager, as if an effect.  Decide whether to show or
             // hide it.
-            [](AudacityProject&) -> BaseItemPtr {
+            [](AudacityProject&) -> std::unique_ptr<CommandItem> {
                const PluginID ID =
                   EffectManager::Get().GetEffectByIdentifier(wxT("StereoToMono"));
                const PluginDescriptor *plug = PluginManager::Get().GetPlugin(ID);

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -734,13 +734,12 @@ void OnStopSelect(const CommandContext &context)
 
 // Under /MenuBar
 using namespace MenuTable;
-BaseItemSharedPtr TransportMenu()
+auto TransportMenu()
 {
    using Options = CommandManager::Options;
-
-   static const auto CanStopFlags = AudioIONotBusyFlag() | CanStopAudioStreamFlag();
-
-   static BaseItemSharedPtr menu{
+   static const auto CanStopFlags =
+      AudioIONotBusyFlag() | CanStopAudioStreamFlag();
+   static auto menu = std::shared_ptr{
    /* i18n-hint: 'Transport' is the name given to the set of controls that
       play, record, pause etc. */
    Menu( wxT("Transport"), XXO("Tra&nsport"),
@@ -865,14 +864,11 @@ BaseItemSharedPtr TransportMenu()
    return menu;
 }
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(TransportMenu())
-};
+AttachedItem sAttachment1{ Indirect(TransportMenu()) };
 
-BaseItemSharedPtr ExtraTransportMenu()
+auto ExtraTransportMenu()
 {
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Transport"), XXO("T&ransport"),
       // PlayStop is already in the menus.
       /* i18n-hint: (verb) Start playing audio*/
@@ -913,15 +909,14 @@ BaseItemSharedPtr ExtraTransportMenu()
    return menu;
 }
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part1"),
-   Indirect(ExtraTransportMenu())
+AttachedItem sAttachment2{ Indirect(ExtraTransportMenu()),
+   wxT("Optional/Extra/Part1")
 };
 
-BaseItemSharedPtr ExtraSelectionItems()
+auto ExtraSelectionItems()
 {
    using Options = CommandManager::Options;
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    Items(wxT("MoveToLabel"),
       Command(wxT("MoveToPrevLabel"), XXO("Move to Pre&vious Label"),
          OnMoveToPrevLabel,
@@ -933,9 +928,8 @@ BaseItemSharedPtr ExtraSelectionItems()
    return items;
 }
 
-AttachedItem sAttachment4{
-  { wxT("Optional/Extra/Part1/Select"), { OrderingHint::End, {} } },
-   Indirect(ExtraSelectionItems())
+AttachedItem sAttachment4{ Indirect(ExtraSelectionItems()),
+  { wxT("Optional/Extra/Part1/Select"), { OrderingHint::End, {} } }
 };
 
 }

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -399,11 +399,10 @@ static CommandHandlerObject &findCommandHandler(AudacityProject &project) {
 // Under /MenuBar
 namespace {
 using namespace MenuTable;
-BaseItemSharedPtr ViewMenu()
+auto ViewMenu()
 {
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    Menu( wxT("View"), XXO("&View"),
       Section( "Basic",
@@ -463,13 +462,9 @@ BaseItemSharedPtr ViewMenu()
       )
    ) ) };
    return menu;
-   
 }
 
-AttachedItem sAttachment1{
-   wxT(""),
-   Indirect(ViewMenu())
-};
+AttachedItem sAttachment1{ Indirect(ViewMenu()) };
 }
 
 #undef FN

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -116,9 +116,9 @@ void LibraryPrefs::PopulateOrExchange(ShuttleGui & S)
          Registry::Visit( *this, &top, &PopulatorItem::Registry() );
       }
 
-      void Visit( Registry::SingleItem &item, const Path &path ) override
+      void Visit(const Registry::SingleItem &item, const Path &path) override
       {
-         static_cast<PopulatorItem&>(item).mPopulator(S);
+         static_cast<const PopulatorItem&>(item).mPopulator(S);
       }
 
       ShuttleGui &S;

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -27,9 +27,9 @@ MP3 and FFmpeg encoding libraries.
 ////////////////////////////////////////////////////////////////////////////////
 static const auto PathStart = wxT("LibraryPreferences");
 
-Registry::GroupItemBase &LibraryPrefs::PopulatorItem::Registry()
+auto LibraryPrefs::PopulatorItem::Registry() -> Registry::GroupItem<Traits> &
 {
-   static Registry::GroupItem<Registry::DefaultTraits> registry{ PathStart };
+   static Registry::GroupItem<Traits> registry{ PathStart };
    return registry;
 }
 
@@ -112,7 +112,7 @@ void LibraryPrefs::PopulateOrExchange(ShuttleGui & S)
       {
          // visit the registry to collect the plug-ins properly
          // sorted
-         GroupItem<Registry::DefaultTraits> top{ PathStart };
+         GroupItem<Traits> top{ PathStart };
          Registry::Visit( *this, &top, &PopulatorItem::Registry() );
       }
 

--- a/src/prefs/LibraryPrefs.h
+++ b/src/prefs/LibraryPrefs.h
@@ -34,7 +34,7 @@ class LibraryPrefs final : public PrefsPanel
 
    //! To be statically constructed, it registers additions to the Library preference page
    struct AUDACITY_DLL_API RegisteredControls
-      : public Registry::RegisteredItem<PopulatorItem>
+      : Registry::RegisteredItem<PopulatorItem>
    {
       // Whether any controls have been registered
       static bool Any();
@@ -56,8 +56,11 @@ class LibraryPrefs final : public PrefsPanel
 
 
  private:
+   struct Traits : Registry::DefaultTraits {
+      using LeafTypes = List<PopulatorItem>;
+   };
    struct AUDACITY_DLL_API PopulatorItem final : Registry::SingleItem {
-      static Registry::GroupItemBase &Registry();
+      static Registry::GroupItem<Traits> &Registry();
    
       PopulatorItem(const Identifier &id, Populator populator);
 

--- a/src/prefs/PrefsPanel.cpp
+++ b/src/prefs/PrefsPanel.cpp
@@ -34,9 +34,9 @@ struct PrefsPanel::PrefsItem::Visitor final : Registry::Visitor {
    {
       childCounts.push_back( 0 );
    }
-   void BeginGroup( Registry::GroupItemBase &item, const Path & ) override
+   void BeginGroup(const Registry::GroupItemBase &item, const Path &) override
    {
-      auto pItem = dynamic_cast<PrefsItem*>( &item );
+      auto pItem = dynamic_cast<const PrefsItem*>( &item );
       if (!pItem || !pItem->factory)
          return;
       indices.push_back( factories.size() );
@@ -44,9 +44,9 @@ struct PrefsPanel::PrefsItem::Visitor final : Registry::Visitor {
       ++childCounts.back();
       childCounts.push_back( 0 );
    }
-   void EndGroup( Registry::GroupItemBase &item, const Path & ) override
+   void EndGroup(const Registry::GroupItemBase &item, const Path &) override
    {
-      auto pItem = dynamic_cast<PrefsItem*>( &item );
+      auto pItem = dynamic_cast<const PrefsItem*>( &item );
       if (!pItem || !pItem->factory)
          return;
       auto &factory = factories[ indices.back() ];

--- a/src/prefs/PrefsPanel.cpp
+++ b/src/prefs/PrefsPanel.cpp
@@ -13,9 +13,10 @@ Paul Licameli split from PrefsDialog.cpp
 
 static const auto PathStart = L"Preferences";
 
-Registry::GroupItemBase &PrefsPanel::PrefsItem::Registry()
+
+auto PrefsPanel::PrefsItem::Registry() -> Registry::GroupItem<Traits>&
 {
-   static Registry::GroupItem<Registry::DefaultTraits> registry{ PathStart };
+   static Registry::GroupItem<Traits> registry{ PathStart };
    return registry;
 }
 
@@ -120,7 +121,7 @@ PrefsPanel::Factories
 
    std::call_once( flag, []{
       PrefsItem::Visitor visitor{ factories };
-      Registry::GroupItem<Registry::DefaultTraits> top{ PathStart };
+      Registry::GroupItem<Traits> top{ PathStart };
       Registry::Visit( visitor, &top, &PrefsItem::Registry() );
    } );
    return factories;

--- a/src/prefs/PrefsPanel.h
+++ b/src/prefs/PrefsPanel.h
@@ -84,7 +84,7 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
    // Typically you make a static object of this type in the .cpp file that
    // also implements the PrefsPanel subclass.
    struct AUDACITY_DLL_API Registration final
-      : public Registry::RegisteredItem<PrefsItem>
+      : Registry::RegisteredItem<PrefsItem>
    {
       Registration( const wxString &name, const Factory &factory,
          bool expanded = true,
@@ -126,12 +126,15 @@ class AUDACITY_DLL_API PrefsPanel /* not final */
    virtual void Cancel();
 
  private:
+   struct Traits : Registry::DefaultTraits {
+      using NodeTypes = List<PrefsItem>;
+   };
    struct AUDACITY_DLL_API PrefsItem final
-      : Registry::GroupItem<Registry::DefaultTraits> {
+      : Registry::GroupItem<Traits> {
       PrefsPanel::Factory factory;
       bool expanded{ false };
 
-      static Registry::GroupItemBase &Registry();
+      static Registry::GroupItem<Traits> &Registry();
 
       PrefsItem(const wxString &name,
          const PrefsPanel::Factory &factory, bool expanded);

--- a/src/toolbars/DeviceToolBar.cpp
+++ b/src/toolbars/DeviceToolBar.cpp
@@ -806,9 +806,9 @@ void OnAudioHost(const CommandContext &context)
 
 using namespace MenuTable;
 // Under /MenuBar/Optional/Extra/Part1
-BaseItemSharedPtr ExtraDeviceMenu()
+auto ExtraDeviceMenu()
 {
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Device"), XXO("De&vice"),
       Command( wxT("InputDevice"), XXO("Change &Recording Device..."),
          OnInputDevice,
@@ -825,9 +825,8 @@ BaseItemSharedPtr ExtraDeviceMenu()
    return menu;
 }
 
-AttachedItem sAttachment2{
-   Placement{ wxT("Optional/Extra/Part1"), { OrderingHint::End } },
-   Indirect(ExtraDeviceMenu())
+AttachedItem sAttachment2{ Indirect(ExtraDeviceMenu()),
+   Placement{ wxT("Optional/Extra/Part1"), { OrderingHint::End } }
 };
 
 }

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -592,9 +592,9 @@ void OnInputGainDec(const CommandContext &context)
 }
    
 using namespace MenuTable;
-BaseItemSharedPtr ExtraMixerMenu()
+auto ExtraMixerMenu()
 {
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Mixer"), XXO("Mi&xer"),
       Command( wxT("OutputGain"), XXO("Ad&just Playback Volume..."),
          OnOutputGain, AlwaysEnabledFlag ),
@@ -612,9 +612,8 @@ BaseItemSharedPtr ExtraMixerMenu()
    return menu;
 }
 
-AttachedItem sAttachment4{
-   wxT("Optional/Extra/Part1"),
-   Indirect(ExtraMixerMenu())
+AttachedItem sAttachment4{ Indirect(ExtraMixerMenu()),
+   wxT("Optional/Extra/Part1")
 };
 
 }

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -1565,7 +1565,6 @@ AttachedToolBarMenuItem::AttachedToolBarMenuItem(
    std::vector< Identifier > excludeIDs
 )  : mId{ id }
    , mAttachedItem{
-      Registry::Placement{ wxT("View/Other/Toolbars/Toolbars/Other"), hint },
       (  MenuTable::FinderScope(
             [this](AudacityProject &) -> CommandHandlerObject&
                { return *this; } ),
@@ -1574,7 +1573,9 @@ AttachedToolBarMenuItem::AttachedToolBarMenuItem(
             AlwaysEnabledFlag,
             CommandManager::Options{}.CheckTest( [id](AudacityProject &project){
                auto &toolManager = ToolManager::Get( project );
-               return toolManager.IsVisible( id ); } ) ) ) }
+               return toolManager.IsVisible( id ); } ) ) ),
+      Registry::Placement{ wxT("View/Other/Toolbars/Toolbars/Other"), hint }
+   }
    , mExcludeIds{ std::move( excludeIDs ) }
 {}
 

--- a/src/toolbars/ToolsToolBar.cpp
+++ b/src/toolbars/ToolsToolBar.cpp
@@ -334,9 +334,9 @@ void OnNextTool(const CommandContext &context)
 }
 
 using namespace MenuTable;
-BaseItemSharedPtr ExtraToolsMenu()
+auto ExtraToolsMenu()
 {
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    Menu( wxT("Tools"), XXO("T&ools"),
       Command( wxT("SelectTool"), XXO("&Selection Tool"), OnSelectTool,
          AlwaysEnabledFlag, wxT("F1") ),
@@ -354,8 +354,7 @@ BaseItemSharedPtr ExtraToolsMenu()
    return menu;
 }
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part1"),
-   Indirect(ExtraToolsMenu())
+AttachedItem sAttachment2{ Indirect(ExtraToolsMenu()),
+   wxT("Optional/Extra/Part1")
 };
 }

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -1148,21 +1148,20 @@ void OnPlaySpeedDec(const CommandContext &context)
 
 using namespace MenuTable;
 
-BaseItemSharedPtr ExtraPlayAtSpeedMenu()
+auto ExtraPlayAtSpeedMenu()
 {
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
       Menu( wxT("PlayAtSpeed"), XXO("&Play-at-Speed") ) };
    return menu;
 }
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part1"),
-   Indirect(ExtraPlayAtSpeedMenu())
+AttachedItem sAttachment2{ Indirect(ExtraPlayAtSpeedMenu()),
+   wxT("Optional/Extra/Part1")
 };
 
-BaseItemSharedPtr ExtraPlayAtSpeedItems()
+auto ExtraPlayAtSpeedItems()
 {
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    Items( "",
       /* i18n-hint: 'Normal Play-at-Speed' doesn't loop or cut preview. */
       Command( wxT("PlayAtSpeedLooped"), XXO("&Play-at-Speed"),
@@ -1181,10 +1180,9 @@ BaseItemSharedPtr ExtraPlayAtSpeedItems()
    return items;
 }
 
-AttachedItem sAttachment3{
+AttachedItem sAttachment3{ Indirect(ExtraPlayAtSpeedItems()),
    Placement{ wxT("Optional/Extra/Part1/PlayAtSpeed"),
-     OrderingHint::Begin },
-   Indirect(ExtraPlayAtSpeedItems())
+     OrderingHint::Begin }
 };
 
 }

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackMenuItems.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackMenuItems.cpp
@@ -36,10 +36,10 @@ void OnMidiDeviceInfo(const CommandContext &context)
 
 using namespace MenuTable;
 AttachedItem sAttachment{
-   { wxT("Help/Other/Diagnostics"),
-      { OrderingHint::After, wxT("DeviceInfo") } },
    Command( wxT("MidiDeviceInfo"), XXO("&MIDI Device Info..."),
-      OnMidiDeviceInfo, AudioIONotBusyFlag() )
+      OnMidiDeviceInfo, AudioIONotBusyFlag() ),
+   { wxT("Help/Other/Diagnostics"),
+      { OrderingHint::After, wxT("DeviceInfo") } }
 };
 }
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -1181,9 +1181,9 @@ static CommandHandlerObject &findCommandHandler(AudacityProject &project) {
 using namespace MenuTable;
 #define FN(X) (& Handler :: X)
 
-BaseItemSharedPtr SpectralSelectionMenu()
+auto SpectralSelectionMenu()
 {
-   static BaseItemSharedPtr menu{
+   static auto menu = std::shared_ptr{
    ( FinderScope{ findCommandHandler },
    Menu( wxT("Spectral"), XXO("S&pectral"),
       Command( wxT("ToggleSpectralSelection"),
@@ -1201,9 +1201,8 @@ BaseItemSharedPtr SpectralSelectionMenu()
 
 #undef FN
 
-AttachedItem sAttachment2{
-   Placement{ wxT("Select/Basic"), { OrderingHint::After, wxT("Region") } },
-   Indirect(SpectralSelectionMenu())
+AttachedItem sAttachment2{ Indirect(SpectralSelectionMenu()),
+   Placement{ wxT("Select/Basic"), { OrderingHint::After, wxT("Region") } }
 };
 
 }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -701,18 +701,21 @@ using namespace MenuTable;
 
 // Register menu items
 
-AttachedItem sAttachment{ wxT("Edit/Other/Clip"),
+AttachedItem sAttachment{
    Command( L"RenameClip", XXO("&Rename Clip..."),
-      OnEditClipName, SomeClipIsSelectedFlag(), wxT("Ctrl+F2") )
+      OnEditClipName, SomeClipIsSelectedFlag(), wxT("Ctrl+F2") ),
+   wxT("Edit/Other/Clip")
 };
 
-AttachedItem sAttachment2{ wxT("Edit/Other/Clip"),
+AttachedItem sAttachment2{
    Command( L"ChangeClipSpeed", XXO("Change &Speed..."),
-      OnChangeClipSpeed, SomeClipIsSelectedFlag() )
+      OnChangeClipSpeed, SomeClipIsSelectedFlag() ),
+   wxT("Edit/Other/Clip")
 };
 
-AttachedItem sAttachment3{ wxT("Edit/Other/Clip"),
+AttachedItem sAttachment3{
    Command( L"RenderClipStretching", XXO("Render Clip S&tretching"),
-      OnRenderClipStretching, StretchedClipIsSelectedFlag())
+      OnRenderClipStretching, StretchedClipIsSelectedFlag()),
+   wxT("Edit/Other/Clip")
 };
 }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackMenuItems.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackMenuItems.cpp
@@ -71,13 +71,14 @@ void OnNewStereoTrack(const CommandContext &context)
    (*tracks.rbegin())->EnsureVisible();
 }
 
-AttachedItem sAttachment{ wxT("Tracks/Add/Add"),
+AttachedItem sAttachment{
    Items( "",
       Command( wxT("NewMonoTrack"), XXO("&Mono Track"), OnNewWaveTrack,
          AudioIONotBusyFlag(), wxT("Ctrl+Shift+N") ),
       Command( wxT("NewStereoTrack"), XXO("&Stereo Track"),
          OnNewStereoTrack, AudioIONotBusyFlag() )
-   )
+   ),
+   wxT("Tracks/Add/Add")
 };
 
 }

--- a/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
@@ -49,10 +49,11 @@ void OnNewTimeTrack(const CommandContext &context)
    t->EnsureVisible();
 }
 
-AttachedItem sAttachment{ wxT("Tracks/Add/Add"),
-     Command( wxT("NewTimeTrack"), XXO("&Time Track"),
+AttachedItem sAttachment{
+   Command( wxT("NewTimeTrack"), XXO("&Time Track"),
         OnNewTimeTrack, AudioIONotBusyFlag()
- )
+   ),
+   wxT("Tracks/Add/Add")
 };
 
 }

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -1133,7 +1133,7 @@ static const auto finder =
      { return Scrubber::Get( project ); };
 
 using namespace MenuTable;
-BaseItemSharedPtr ToolbarMenu()
+auto ToolbarMenu()
 {
    using Options = CommandManager::Options;
    static auto menu = []{
@@ -1156,16 +1156,12 @@ BaseItemSharedPtr ToolbarMenu()
    return menu;
 }
 
-AttachedItem sAttachment{
-   wxT("Transport/Basic"),
-   Indirect(ToolbarMenu())
-};
+AttachedItem sAttachment{ Indirect(ToolbarMenu()), wxT("Transport/Basic") };
 
-BaseItemSharedPtr KeyboardScrubbingItems()
+auto KeyboardScrubbingItems()
 {
    using Options = CommandManager::Options;
-
-   static BaseItemSharedPtr items{
+   static auto items = std::shared_ptr{
    ( FinderScope{ finder },
    Items( wxT("KeyboardScrubbing"),
       Command(wxT("KeyboardScrubBackwards"), XXO("Scrub Bac&kwards"),
@@ -1180,9 +1176,8 @@ BaseItemSharedPtr KeyboardScrubbingItems()
    return items;
 }
 
-AttachedItem sAttachment2{
-   wxT("Optional/Extra/Part1/Transport"),
-   Indirect(KeyboardScrubbingItems())
+AttachedItem sAttachment2{ Indirect(KeyboardScrubbingItems()),
+   wxT("Optional/Extra/Part1/Transport")
 };
 
 }

--- a/src/widgets/PopupMenuTable.cpp
+++ b/src/widgets/PopupMenuTable.cpp
@@ -160,12 +160,6 @@ void PopupMenuTable::ExtendMenu( PopupMenu &menu, PopupMenuTable &table )
       visitor, table.Get( theMenu.pUserData ).get(), table.GetRegistry() );
 }
 
-void PopupMenuTable::RegisterItem(
-   const Registry::Placement &placement, Registry::BaseItemPtr pItem )
-{
-   Registry::RegisterItem( *mRegistry, placement, std::move( pItem ) );
-}
-
 void PopupMenuTable::Append(
    const Identifier &stringId, PopupMenuTableEntry::Type type, int id,
    const TranslatableString &string, wxCommandEventFunction memFn,

--- a/src/widgets/PopupMenuTable.cpp
+++ b/src/widgets/PopupMenuTable.cpp
@@ -30,11 +30,6 @@ PopupSubMenu::PopupSubMenu(const Identifier &stringId,
 
 PopupMenuVisitor::~PopupMenuVisitor() = default;
 
-void *PopupMenuVisitor::GetComputedItemContext()
-{
-   return this;
-}
-
 PopupMenu::~PopupMenu() = default;
 
 namespace {
@@ -161,8 +156,8 @@ void PopupMenuTable::ExtendMenu( PopupMenu &menu, PopupMenuTable &table )
    auto &theMenu = dynamic_cast<PopupMenuImpl&>(menu);
 
    PopupMenuBuilder visitor{ table, theMenu, theMenu.pUserData };
-   Registry::Visit(
-      visitor, table.Get( theMenu.pUserData ).get(), table.GetRegistry() );
+   Registry::Visit(visitor, table.Get( theMenu.pUserData ).get(),
+      table.GetRegistry(), visitor);
 }
 
 void PopupMenuTable::Append(

--- a/src/widgets/PopupMenuTable.cpp
+++ b/src/widgets/PopupMenuTable.cpp
@@ -62,9 +62,11 @@ public:
       , mpUserData{ pUserData }
    {}
 
-   void DoBeginGroup( Registry::GroupItemBase &item, const Path &path ) override;
-   void DoEndGroup( Registry::GroupItemBase &item, const Path &path ) override;
-   void DoVisit( Registry::SingleItem &item, const Path &path ) override;
+   void DoBeginGroup(const Registry::GroupItemBase &item, const Path &path)
+      override;
+   void DoEndGroup(const Registry::GroupItemBase &item, const Path &path)
+      override;
+   void DoVisit(const Registry::SingleItem &item, const Path &path) override;
    void DoSeparator() override;
 
    std::vector< std::unique_ptr<PopupMenuImpl> > mMenus;
@@ -72,9 +74,10 @@ public:
    void *const mpUserData;
 };
 
-void PopupMenuBuilder::DoBeginGroup( Registry::GroupItemBase &item, const Path &path )
+void PopupMenuBuilder::DoBeginGroup(
+   const Registry::GroupItemBase &item, const Path &path)
 {
-   if ( auto pItem = dynamic_cast<PopupSubMenu*>(&item) ) {
+   if ( auto pItem = dynamic_cast<const PopupSubMenu*>(&item) ) {
       if ( !pItem->caption.empty() ) {
          auto newMenu =
             std::make_unique<PopupMenuImpl>( mMenu->pUserData );
@@ -84,9 +87,10 @@ void PopupMenuBuilder::DoBeginGroup( Registry::GroupItemBase &item, const Path &
    }
 }
 
-void PopupMenuBuilder::DoEndGroup( Registry::GroupItemBase &item, const Path &path )
+void PopupMenuBuilder::DoEndGroup(
+   const Registry::GroupItemBase &item, const Path &path)
 {
-   if ( auto pItem = dynamic_cast<PopupSubMenu*>(&item) ) {
+   if ( auto pItem = dynamic_cast<const PopupSubMenu*>(&item) ) {
       if ( !pItem->caption.empty() ) {
          auto subMenu = std::move( mMenus.back() );
          mMenus.pop_back();
@@ -96,9 +100,10 @@ void PopupMenuBuilder::DoEndGroup( Registry::GroupItemBase &item, const Path &pa
    }
 }
 
-void PopupMenuBuilder::DoVisit( Registry::SingleItem &item, const Path &path )
+void PopupMenuBuilder::DoVisit(
+   const Registry::SingleItem &item, const Path &path)
 {
-   auto pEntry = static_cast<PopupMenuTableEntry*>( &item );
+   auto pEntry = static_cast<const PopupMenuTableEntry*>( &item );
    switch (pEntry->type) {
       case PopupMenuTable::Entry::Item:
       {

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -227,7 +227,7 @@ protected:
    void BeginSection( const Identifier &name );
    void EndSection();
 
-   std::shared_ptr<PopupMenuGroupItem> mTop;
+   std::shared_ptr<PopupSubMenu> mTop;
    std::vector<PopupMenuGroupItem*> mStack;
    Identifier mId;
    TranslatableString mCaption;

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -33,10 +33,11 @@ struct PopupMenuSection;
 class PopupMenuTable;
 struct PopupMenuTableEntry;
 struct PopupMenuVisitor;
+struct PopupSubMenu;
 struct PopupMenuTableTraits : Registry::DefaultTraits {
    using ComputedItemContextType = PopupMenuVisitor;
    using LeafTypes = List<PopupMenuTableEntry>;
-   using NodeTypes = List<PopupMenuSection>;
+   using NodeTypes = List<PopupMenuSection, PopupSubMenu>;
 };
 using PopupMenuGroupItem = Registry::GroupItem<PopupMenuTableTraits>;
 

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -109,7 +109,6 @@ public:
 struct PopupMenuVisitor : public MenuVisitor {
    explicit PopupMenuVisitor( PopupMenuTable &table ) : mTable{ table } {}
    ~PopupMenuVisitor() override;
-   void *GetComputedItemContext() override;
    PopupMenuTable &mTable;
 };
 

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -29,10 +29,14 @@ class wxCommandEvent;
 #include "../commands/CommandManager.h"
 
 class PopupMenuHandler;
+struct PopupMenuSection;
 class PopupMenuTable;
+struct PopupMenuTableEntry;
 struct PopupMenuVisitor;
 struct PopupMenuTableTraits : Registry::DefaultTraits {
    using ComputedItemContextType = PopupMenuVisitor;
+   using LeafTypes = List<PopupMenuTableEntry>;
+   using NodeTypes = List<PopupMenuSection>;
 };
 using PopupMenuGroupItem = Registry::GroupItem<PopupMenuTableTraits>;
 
@@ -122,7 +126,7 @@ public:
    using Entry = PopupMenuTableEntry;
 
    // Supply a nonempty caption for sub-menu tables
-   PopupMenuTable( const Identifier &id, const TranslatableString &caption = {} )
+   PopupMenuTable(const Identifier &id, const TranslatableString &caption = {})
       : mId{ id }
       , mCaption{ caption }
       , mRegistry{
@@ -139,9 +143,9 @@ public:
    const auto *GetRegistry() const { return mRegistry.get(); }
 
    // Typically statically constructed:
-   struct AttachedItem {
+   template<typename Ptr> struct AttachedItem {
       AttachedItem( PopupMenuTable &table,
-         const Registry::Placement &placement, Registry::BaseItemPtr pItem )
+         const Registry::Placement &placement, Ptr pItem )
       { table.RegisterItem( placement, std::move( pItem ) ); }
    };
 
@@ -174,8 +178,11 @@ public:
    }
 
 private:
-   void RegisterItem(
-      const Registry::Placement &placement, Registry::BaseItemPtr pItem );
+   template<typename Ptr> void RegisterItem(
+      const Registry::Placement &placement, Ptr pItem)
+   {
+      Registry::RegisterItem(*mRegistry, placement, move(pItem));
+   }
 
 protected:
    // This convenience function composes a label, with the following optional


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

QA:
- [x] Try some track context menu items
- [x] Sequence of items in the entire tree of pull-down menus is unchanged
- [x] Likewise, the tree in the left column of the Preferences dialog
- [x] Sequence of controls on the Library page of Preferences
- [x] Sequence of formats in timer controls of Selection toolbar
- [x] ditto snapping toolbar
- [x] sequence of choices for "Format" in File > Export Audio... dialog

Depends on
 - #4623
 - #4624 

Each Registry specifies an exhaustive list of its leaf and node item types in its Traits.

Registry trees are checked for type correctness as they are constructed or registered for later
merge, although this check can still be evaded by (deprecated) use of GroupItemBase::push_back
to build a tree by other means.

Visitors of registry items are allowed only const access to items.

This pull request is not mostly about simplification of the use of registries, but some of that
happened too.  See for instance how the definition of class `NumericConverterItemRegistrator`
simplifies to a type alias.

There is still more type checking to do, and significant simplifications to achieve, in registry
visiting, making use of the TypeSwitch utility to be extracted from Track.h (see #4650).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
