### PR TITLE
issue 4677: Can't disable GUI mode for VST2 plugins

### DIFF
--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -135,7 +135,7 @@ std::unique_ptr<EffectEditor> VSTEffect::PopulateUI(const EffectPlugin &,
 
 
    // Build the appropriate dialog type
-   if (mGui)
+   if (gui)
    {
       editor->BuildFancy(instance);
    }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4677

Problem: in commit 8b58069, the condition for the appropriate dialog was not updated to reflect the prior changes in the function.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
