### PR TITLE
More registry type checking

### DIFF
--- a/libraries/lib-import-export/ExportPluginRegistry.cpp
+++ b/libraries/lib-import-export/ExportPluginRegistry.cpp
@@ -59,24 +59,13 @@ void ExportPluginRegistry::Initialize()
       { {wxT(""), wxT("PCM,MP3,OGG,Opus,FLAC,WavPack,FFmpeg,MP2,CommandLine") } },
    };
 
-   struct CreatePluginsVisitor final : Visitor {
-      CreatePluginsVisitor(ExportPlugins& plugins)
-         : mPlugins(plugins)
-      {
-      }
-
-      void Visit(const SingleItem &item, const Path &path) override
-      {
-         mPlugins.emplace_back(
-            static_cast<const ExportPluginRegistryItem&>(item).mFactory() );
-      }
-
-      ExportPlugins& mPlugins;
-   } visitor(mPlugins);
    // visit the registry to collect the plug-ins properly
    // sorted
    GroupItem<Traits> top{ PathStart };
-   Registry::Visit( visitor, &top, &ExportPluginRegistryItem::Registry() );
+   Registry::Visit(
+      [&](const ExportPluginRegistryItem &item, auto&){
+         mPlugins.emplace_back(item.mFactory()); },
+      &top, &ExportPluginRegistryItem::Registry());
 }
 
 std::tuple<ExportPlugin*, int>

--- a/libraries/lib-registries/Registry.cpp
+++ b/libraries/lib-registries/Registry.cpp
@@ -622,12 +622,12 @@ void CollectedItems::MergeItems(ItemOrdering &itemOrdering,
 
 // forward declaration for mutually recursive functions
 void VisitItem(
-   Registry::Visitor &visitor, CollectedItems &collection,
+   VisitorBase &visitor, CollectedItems &collection,
    Path &path, const BaseItem *pItem,
    const GroupItemBase *pToMerge, const OrderingHint &hint,
    bool &doFlush, void *pComputedItemContext);
 void VisitItems(
-   Registry::Visitor &visitor, CollectedItems &collection,
+   VisitorBase &visitor, CollectedItems &collection,
    Path &path, const GroupItemBase &group,
    const GroupItemBase *pToMerge, const OrderingHint &hint,
    bool &doFlush, void *pComputedItemContext)
@@ -676,7 +676,7 @@ void VisitItems(
    path.pop_back();
 }
 void VisitItem(
-   Registry::Visitor &visitor, CollectedItems &collection,
+   VisitorBase &visitor, CollectedItems &collection,
    Path &path, const BaseItem *pItem,
    const GroupItemBase *pToMerge, const OrderingHint &hint,
    bool &doFlush, void *pComputedItemContext)
@@ -720,13 +720,9 @@ SingleItem::~SingleItem() {}
 GroupItemBase::~GroupItemBase() {}
 auto GroupItemBase::GetOrdering() const -> Ordering { return Strong; }
 
-Visitor::~Visitor() = default;
+VisitorBase::~VisitorBase() = default;
 
-void Visitor::BeginGroup(const GroupItemBase &, const Path &) {}
-void Visitor::EndGroup(const GroupItemBase &, const Path &) {}
-void Visitor::Visit(const SingleItem &, const Path &) {}
-
-void detail::Visit(Visitor &visitor,
+void detail::Visit(VisitorBase &visitor,
    const GroupItemBase *pTopItem,
    const GroupItemBase *pRegistry, void *pComputedItemContext)
 {

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -149,7 +149,9 @@ namespace detail { using namespace TypeList;
 
    template<typename RegistryTraits> constexpr auto AcceptableTraits_v =
       TypeList::Every_v<TypeList::Fn<AcceptableBaseItem>,
-         AllTypes_t<RegistryTraits>>;
+         AllTypes_t<RegistryTraits>> &&
+      TypeSwitch::TypeListCheck_v<detail::VisitedNodeTypes<RegistryTraits>> &&
+      TypeSwitch::TypeListCheck_v<detail::VisitedLeafTypes<RegistryTraits>>;
 
 namespace detail {
    //! An item that delegates to another held in a shared pointer

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -73,6 +73,8 @@ namespace Registry {
    struct SingleItem;
 
 namespace detail { using namespace TypeList;
+   struct GroupItemBase;
+
    struct REGISTRIES_API BaseItem {
       // declare at least one virtual function so dynamic_cast will work
       explicit
@@ -129,7 +131,7 @@ namespace detail { using namespace TypeList;
    using BaseItemTypes = TypeList::List<
       detail::IndirectItemBase, detail::ComputedItemBase,
       // see below
-      struct SingleItem, struct GroupItemBase
+      struct SingleItem, struct detail::GroupItemBase
    >;
    template<typename Item> using AcceptableBaseItem =
       TypeList::HasBaseIn<Item, BaseItemTypes>;
@@ -226,11 +228,10 @@ namespace detail {
    //! Type-erased implementation details, don't call directly
    REGISTRIES_API void RegisterItem(GroupItemBase &registry,
       const Placement &placement, BaseItemPtr pItem);
-}
 
    //! Common abstract base class for items that group other items
    struct REGISTRIES_API GroupItemBase : Composite::Base<
-      detail::BaseItem, std::unique_ptr<detail::BaseItem>, const Identifier &
+      BaseItem, std::unique_ptr<BaseItem>, const Identifier &
    > {
       using Base::Base;
    
@@ -256,9 +257,10 @@ namespace detail {
       virtual Ordering GetOrdering() const;
 
    private:
-      friend REGISTRIES_API void detail::RegisterItem(GroupItemBase &registry,
-         const Placement &placement, detail::BaseItemPtr pItem);
+      friend REGISTRIES_API void RegisterItem(GroupItemBase &registry,
+         const Placement &placement, BaseItemPtr pItem);
    };
+}
 
    // Forward declarations necessary before customizing Composite::Traits
    template<typename RegistryTraits> struct GroupItem;
@@ -268,7 +270,7 @@ namespace detail {
 }
 
 template<typename RegistryTraits> struct Composite::Traits<
-   Registry::GroupItemBase, Registry::GroupItem<RegistryTraits>
+   Registry::detail::GroupItemBase, Registry::GroupItem<RegistryTraits>
 > {
    static constexpr auto ItemBuilder =
    Registry::detail::Builder<RegistryTraits>{};
@@ -278,17 +280,17 @@ template<typename RegistryTraits> struct Composite::Traits<
 };
 
 namespace Registry {
-   //! Extends GroupItemBase with a variadic constructor that checks types
+   //! Has variadic and range constructors that check types
    /*!
     @tparam RegistryTraits defines associated types
     */
    template<typename RegistryTraits>
    struct GroupItem : Composite::Builder<
-      GroupItemBase, GroupItem<RegistryTraits>, const Identifier &
+      detail::GroupItemBase, GroupItem<RegistryTraits>, const Identifier &
    > {
       ~GroupItem() override = default;
       using Composite::Builder<
-         GroupItemBase, GroupItem<RegistryTraits>, const Identifier &
+         detail::GroupItemBase, GroupItem<RegistryTraits>, const Identifier &
       >::Builder;
    };
 

--- a/libraries/lib-registries/Registry.h
+++ b/libraries/lib-registries/Registry.h
@@ -13,8 +13,11 @@ Paul Licameli split from CommandManager.h
 
 #include "Prefs.h"
 #include "Composite.h"
-#include "TypeList.h"
+#include "TypeSwitch.h"
+#include "Variant.h"
+#include <functional>
 #include <type_traits>
+#include <utility>
 
 // Define classes and functions that associate parts of the user interface
 // with path names
@@ -64,10 +67,12 @@ namespace Registry {
       }
    };
 
+   template<typename RegistryTraits> struct GroupItem;
+   using Path = std::vector<Identifier>;
    struct Placement;
-   struct GroupItemBase;
+   struct SingleItem;
 
-namespace detail {
+namespace detail { using namespace TypeList;
    struct REGISTRIES_API BaseItem {
       // declare at least one virtual function so dynamic_cast will work
       explicit
@@ -81,13 +86,8 @@ namespace detail {
       OrderingHint orderingHint;
    };
 
-   using BaseItemPtr = std::unique_ptr<detail::BaseItem>;
-}
+   using BaseItemPtr = std::unique_ptr<BaseItem>;
 
-   class Visitor;
-   
-
-namespace detail {
    using BaseItemSharedPtr = std::shared_ptr<BaseItem>;
 
    struct REGISTRIES_API IndirectItemBase : BaseItem {
@@ -101,6 +101,27 @@ namespace detail {
    };
 
    struct ComputedItemBase;
+
+   template<typename Type, typename List> struct ConsUnique {
+      template<typename L> struct NotAlready {
+         static constexpr bool value = !std::is_same_v<Type, Head_t<L>>;
+      };
+      using type = std::conditional_t<
+         std::disjunction<Null<List>, NotAlready<List>>::value,
+         Cons_t<Type, List>, List
+      >;
+   };
+   template<typename Type, typename List> using ConsUnique_t
+      = typename ConsUnique<Type, List>::type;
+
+   template<typename RegistryTraits> using VisitedNodeTypes =
+      ConsUnique_t<const GroupItem<RegistryTraits>, Map_t<Fn<std::add_const_t>,
+         typename RegistryTraits::NodeTypes>>;
+   template<typename RegistryTraits> using VisitedLeafTypes =
+      ConsUnique_t<const SingleItem, Map_t<Fn<std::add_const_t>,
+         typename RegistryTraits::LeafTypes>>;
+   template<typename Types> using VisitorFunction =
+      std::function<void(Head_t<Types> &, const Path &)>;
 }
 
    //! The underlying registry merging procedure assumes the listed types
@@ -369,26 +390,192 @@ namespace detail {
             RegisterItem(RegistryClass::Registry(), placement, move(pItem));
       }
    };
-   
-   // Define actions to be done in Visit.
-   // Default implementations do nothing
-   // The supplied path does not include the name of the item
-   class REGISTRIES_API Visitor
-   {
-   public:
-      virtual ~Visitor();
-      using Path = std::vector< Identifier >;
-      virtual void BeginGroup(const GroupItemBase &item, const Path &path);
-      virtual void EndGroup(const GroupItemBase &item, const Path &path);
-      virtual void Visit(const SingleItem &item, const Path &path);
-   };
 
 namespace detail {
+   // Helpers allowing a single callable instead of a tuple
+   template<typename V> auto ForwardTuple_(const V &visitor, std::false_type) {
+      // Visitor is not a tuple
+      return std::tuple<const V&>{ visitor };
+   }
+   template<typename V> auto ForwardTuple_(const V &visitor, std::true_type) {
+      // Visitor is a tuple
+      return Tuple::ForwardAll(visitor);
+   }
+   template<typename V> auto ForwardTuple(const V &visitor) {
+      return ForwardTuple_(visitor,
+         std::bool_constant<Tuple::is_tuple_like_v<V>>{});
+   }
+
+   template<typename V> auto MakeTuple_(const V &visitor, std::false_type) {
+      // Visitor is not a tuple
+      return std::tuple<V>{ visitor };
+   }
+   template<typename V> auto MakeTuple_(const V &visitor, std::true_type) {
+      // Visitor is a tuple
+      return Tuple::All(visitor);
+   }
+   template<typename V> auto MakeTuple(const V &visitor) {
+      return MakeTuple_(visitor,
+         std::bool_constant<Tuple::is_tuple_like_v<V>>{});
+   }
+
+   template<typename V> auto CaptureTuple_(const V &visitor, std::true_type) {
+      // Capture by reference
+      return ForwardTuple(visitor);
+   }
+   template<typename V> auto CaptureTuple_(const V &visitor, std::false_type) {
+      // Capture by value
+      return MakeTuple(visitor);
+   }
+   template<bool Reference, typename V> auto CaptureTuple(const V &visitor) {
+      return CaptureTuple_(visitor, std::bool_constant<Reference>{});
+   }
+
+   //! Capture a callable for Visit() in a std::function wrapper
+   template<typename Types, bool Reference, typename Visitor>
+   VisitorFunction<Types> MakeVisitorFunction(const Visitor &visitor) {
+      return [visitor = CaptureTuple<Reference>(visitor)](
+         Head_t<Types> &object, const Path &path
+      ){
+         // The compile time checking of reachability of cases still applies
+         // before the visitor is wrapped
+         TypeSwitch::Dispatch<void, Types>(object, visitor, path);
+      };
+   }
+
+   //! How large a tuple to make from Visitors
+   template<typename Visitors> static constexpr auto TupleSize =
+      std::conditional_t<
+         Tuple::is_tuple_like_v<Visitors>,
+         std::tuple_size<Visitors>,
+         std::integral_constant<size_t, 1>
+      >::value;
+
+   template<typename RegistryTraits> using NodeVisitorFunction =
+      VisitorFunction<VisitedNodeTypes<RegistryTraits>>;
+   template<typename RegistryTraits> using LeafVisitorFunction =
+      VisitorFunction<VisitedLeafTypes<RegistryTraits>>;
+   template<typename RegistryTraits> using VisitorFunctionTriple = std::tuple<
+      NodeVisitorFunction<RegistryTraits>,
+      LeafVisitorFunction<RegistryTraits>,
+      NodeVisitorFunction<RegistryTraits>
+   >;
+}
+
+   //! Adapt visitors, suitable to Visit(), as a std::function or a tuple
+   //! of three std::functions, which other visitors may decorate with other
+   //! steps
+   /*!
+    @tparam Reference if true, capture visitors by reference; else, move them
+    */
+   template<typename RegistryTraits, bool Reference = false>
+   struct VisitorFunctions : std::variant<
+      detail::LeafVisitorFunction<RegistryTraits>,
+      detail::VisitorFunctionTriple<RegistryTraits>
+   >{
+      using NodeTypes = detail::VisitedNodeTypes<RegistryTraits>;
+      using LeafTypes = detail::VisitedLeafTypes<RegistryTraits>;
+
+      //! Type-erasing constructor
+      /*!
+       @param visitors one callable, for leaves only; or else a tuple(-like) of
+       three callables (or type-switching tuples of callables), for group
+       pre-visit, leaf visit, and group post-visit
+       */
+      template<typename Visitors> VisitorFunctions(Visitors &&visitors) {
+         using namespace detail;
+         using namespace std;
+         decltype(auto) forwarded = forward<Visitors>(visitors);
+         static constexpr auto size = TupleSize<std::decay_t<Visitors>>;
+         static_assert(size == 1 || size == 3);
+         if constexpr (size == 1)
+            this->template emplace<0>(
+               MakeVisitorFunction<LeafTypes, Reference>(forwarded));
+         else if constexpr (size == 3)
+            this->template emplace<1>(
+               MakeVisitorFunction<NodeTypes, Reference>(get<0>(forwarded)),
+               MakeVisitorFunction<LeafTypes, Reference>(get<1>(forwarded)),
+               MakeVisitorFunction<NodeTypes, Reference>(get<2>(forwarded)));
+      }
+      //! Call-through for a decorating pre-visitor
+      void BeginGroup(const GroupItem<RegistryTraits> &item, const Path &path)
+      const {
+         if (const auto *pTriple = std::get_if<1>(this))
+            (std::get<0>(*pTriple))(item, path);
+      }
+      //! Call-through for a decorating leaf-visitor
+      void Visit(const SingleItem &item, const Path &path) const {
+         using Function = detail::LeafVisitorFunction<RegistryTraits>;
+         static const auto selector = Callable::OverloadSet{
+            [](const Function& fn) -> const Function & { return fn; },
+            [](auto &&self) -> const Function & {
+               return std::get<1>(self); }
+         };
+         const auto &function = Variant::Visit(selector, *this);
+         function(item, path);
+      }
+      //! Call-through for a decorating post-visitor
+      void EndGroup(const GroupItem<RegistryTraits> &item, const Path &path)
+      const {
+         if (const auto *pTriple = std::get_if<1>(this))
+            (std::get<2>(*pTriple))(item, path);
+      }
+   };
+
+   //! Supply this when one member of a visitor function triple isn't needed
+   constexpr auto NoOp = [](auto&, auto&){};
+
+namespace detail {
+   class REGISTRIES_API VisitorBase
+   {
+   public:
+      virtual ~VisitorBase();
+      virtual void BeginGroup(const GroupItemBase &item, const Path &path)
+         const = 0;
+      virtual void Visit(const SingleItem &item, const Path &path)
+         const = 0;
+      virtual void EndGroup(const GroupItemBase &item, const Path &path)
+         const = 0;
+   };
+
    REGISTRIES_API void Visit(
-      Visitor &visitor,
+      VisitorBase &visitor,
       const GroupItemBase *pTopItem,
       const GroupItemBase *pRegistry,
       void *pComputedItemContext);
+
+   //! Type-erasing adapter class (with no std::function overhead)
+   /*!
+    See TypeSwitch for details of function signatures
+    */
+   template<typename RegistryTraits, typename Visitors>
+   struct Visitor : VisitorBase {
+      using NodeTypes = ConsUnique_t<const GroupItemBase,
+         VisitedNodeTypes<RegistryTraits>>;
+      using LeafTypes = VisitedLeafTypes<RegistryTraits>;
+      static constexpr auto size = TupleSize<Visitors>;
+      static_assert(size == 1 || size == 3);
+      Visitor(const Visitors &visitors) : visitors{ visitors } {}
+
+      void BeginGroup(const GroupItemBase &item, const Path &path)
+      const override {
+         if constexpr (size == 3)
+            TypeSwitch::Dispatch<void, NodeTypes>(item,
+               ForwardTuple(std::get<0>(visitors)), path);
+      }
+      void Visit(const SingleItem &item, const Path &path) const override {
+         TypeSwitch::Dispatch<void, LeafTypes>(item,
+            ForwardTuple(std::get<size == 1 ? 0 : 1>(ForwardTuple(visitors))),
+            path);
+      }
+      void EndGroup(const GroupItemBase &item, const Path &path)
+      const override {
+         if constexpr (size == 3)
+            TypeSwitch::Dispatch<void, NodeTypes>(item,
+               ForwardTuple(std::get<2>(visitors)), path);
+      }
+      const Visitors &visitors;
+   };
 }
 
    //! Top-down visitation of all items and groups in a tree rooted in
@@ -402,17 +589,43 @@ namespace detail {
     ordering should be kept the same thereafter in later runs (which may add
     yet other previously unknown items).
 
+    @param visitors A tuple of size 1 or 3, or a callable.
+      - If a triple, the first member is for pre-visit of group nodes, the last
+         is for post-visit, and the middle for leaf visits.
+      - If single, or a callable, then visit leaves only.
+      - If a tuple, each member can be a tuple of callables (passed to
+        TypeSwitch::Dispatch), or simply a single callable.
+      - "tuple" means std::tuple or any other tuple-like type.
+    The callables take a reference to an object of a const
+    GroupItem<RegistryTraits> or a const SingleItem subtype, and the path up to
+    its parent node.
     @param computedItemContext is passed to factory functions of computed items
     */
-   template<typename RegistryTraits> void Visit(
-      Visitor &visitor,
+   template<typename RegistryTraits, typename Visitors>
+   void Visit(const Visitors &visitors,
       const GroupItem<RegistryTraits> *pTopItem,
       const GroupItem<RegistryTraits> *pRegistry = {},
       typename RegistryTraits::ComputedItemContextType &computedItemContext =
          RegistryTraits::ComputedItemContextType::Instance)
    {
       static_assert(AcceptableTraits_v<RegistryTraits>);
+      detail::Visitor<RegistryTraits, Visitors> visitor{ visitors };
       detail::Visit(visitor, pTopItem, pRegistry, &computedItemContext);
+   }
+
+   //! @copydoc Visit
+   //! Like Visit but passing function(s) wrapped in std::function
+   template<typename RegistryTraits>
+   void VisitWithFunctions(const VisitorFunctions<RegistryTraits> &visitors,
+      const GroupItem<RegistryTraits> *pTopItem,
+      const GroupItem<RegistryTraits> *pRegistry = {},
+      typename RegistryTraits::ComputedItemContextType &computedItemContext =
+         RegistryTraits::ComputedItemContextType::Instance)
+   {
+      static_assert(AcceptableTraits_v<RegistryTraits>);
+      Variant::Visit([&](auto &&visitor){
+         Visit(visitor, pTopItem, pRegistry, computedItemContext);
+      }, visitors);
    }
 
    // Typically a static object.  Constructor initializes certain preferences

--- a/libraries/lib-snapping/SnapUtils.h
+++ b/libraries/lib-snapping/SnapUtils.h
@@ -34,13 +34,6 @@ struct SnapRegistryGroup;
 struct SnapRegistryItem;
 struct SnapFunctionSuperGroup;
 
-struct SNAPPING_API SnapRegistryVisitor /* not final */
-{
-   virtual void BeginGroup(const SnapRegistryGroup& item) = 0;
-   virtual void EndGroup(const SnapRegistryGroup& item) = 0;
-   virtual void Visit(const SnapRegistryItem& item) = 0;
-};
-
 class AudacityProject;
 
 struct SNAPPING_API SnapResult final
@@ -60,6 +53,7 @@ struct SnapRegistryTraits : Registry::DefaultTraits{
    using LeafTypes = List<SnapRegistryItem>;
    using NodeTypes = List<SnapRegistryGroup, SnapFunctionSuperGroup>;
 };
+using SnapRegistryVisitor = Registry::VisitorFunctions<SnapRegistryTraits>;
 
 struct SnapRegistryGroupData {
    const TranslatableString label;
@@ -107,7 +101,7 @@ constexpr auto SnapFunctionGroup = Callable::UniqueMaker<
 struct SNAPPING_API SnapFunctionsRegistry final {
    static Registry::GroupItem<SnapRegistryTraits>& Registry();
 
-   static void Visit(SnapRegistryVisitor& visitor);
+   static void Visit(const SnapRegistryVisitor& visitor);
 
    static const SnapRegistryItem* Find(const Identifier& id);
 

--- a/libraries/lib-utility/tests/TupleTest.cpp
+++ b/libraries/lib-utility/tests/TupleTest.cpp
@@ -12,6 +12,7 @@
 
 #include "Tuple.h"
 #include "TypeList.h"
+#include <array>
 #include <memory>
 
 using namespace Tuple;
@@ -27,8 +28,16 @@ using ExampleList = List<unsigned char, int, double, unique_ptr<X>>;
 TEST_CASE("Tuple")
 {
    static_assert(is_same_v<Example, Apply_t<tuple, ExampleList>>);
+
    static_assert(is_tuple_v<Example>);
+   static_assert(!is_tuple_v<std::pair<int, double>>);
+   static_assert(!is_tuple_v<std::array<int, 2>>);
    static_assert(!is_tuple_v<ExampleList>);
+
+   static_assert(is_tuple_like_v<Example>);
+   static_assert(is_tuple_like_v<std::pair<int, double>>);
+   static_assert(is_tuple_like_v<std::array<int, 2>>);
+   static_assert(!is_tuple_like_v<ExampleList>);
 
    static_assert(Empty_v<tuple<>>);
    REQUIRE(Empty(tuple{}));

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -32,7 +32,10 @@ typedef wxString PluginID;
 typedef wxString MacroID;
 typedef wxArrayString PluginIDs;
 
-namespace Registry{ class Visitor; }
+namespace MenuTable {
+   struct Traits;
+   template<typename MenuTraits> struct Visitor;
+}
 
 class AUDACITY_DLL_API MenuCreator
 {
@@ -68,8 +71,6 @@ public:
    unsigned mRepeatToolFlags;
 };
 
-struct ProjectMenuVisitor;
-
 //! Sent when menus update (such as for changing enablement of items)
 struct MenuUpdateMessage {};
 
@@ -90,7 +91,8 @@ public:
    MenuManager &operator=( const MenuManager & ) = delete;
    ~MenuManager();
 
-   static void Visit(ProjectMenuVisitor &visitor);
+   static void Visit(
+      MenuTable::Visitor<MenuTable::Traits> &visitor, AudacityProject &project);
 
    static void ModifyUndoMenuItems(AudacityProject &project);
 

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -481,7 +481,8 @@ namespace detail {
          ConditionalGroupItem, MenuItem, MenuItems, MenuPart>;
    };
 
-   static inline bool IsSection(const GroupItemBase &item) {
+   template<typename RegistryTraits>
+   static inline bool IsSection(const GroupItem<RegistryTraits> &item) {
       auto pProperties = dynamic_cast<const MenuItemProperties *>(&item);
       return pProperties && pProperties->GetProperties() ==
          MenuItemProperties::Section;

--- a/src/menus/MenuHelper.h
+++ b/src/menus/MenuHelper.h
@@ -8,7 +8,7 @@ class PluginDescriptor;
 
 namespace MenuHelper
 {
-using Group = MenuTable::GroupItemBase;
+using Group = MenuTable::GroupItem<MenuTable::Traits>;
 
 /// The effects come from a plug in list
 /// This code iterates through the list, adding effects into

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -107,22 +107,12 @@ void LibraryPrefs::PopulateOrExchange(ShuttleGui & S)
    S.SetBorder(2);
    S.StartScroller();
 
-   struct MyVisitor final : Visitor {
-      MyVisitor( ShuttleGui &S ) : S{ S }
-      {
-         // visit the registry to collect the plug-ins properly
-         // sorted
-         GroupItem<Traits> top{ PathStart };
-         Registry::Visit( *this, &top, &PopulatorItem::Registry() );
-      }
-
-      void Visit(const Registry::SingleItem &item, const Path &path) override
-      {
-         static_cast<const PopulatorItem&>(item).mPopulator(S);
-      }
-
-      ShuttleGui &S;
-   } visitor{ S };
+   // visit the registry to collect the plug-ins properly
+   // sorted
+   GroupItem<Traits> top{ PathStart };
+   Registry::Visit(
+      [&](const PopulatorItem &item, auto &) { item.mPopulator(S); },
+      &top, &PopulatorItem::Registry());
 
    S.EndScroller();
 }

--- a/src/toolbars/SnappingToolBar.cpp
+++ b/src/toolbars/SnappingToolBar.cpp
@@ -50,83 +50,6 @@ TranslatableString GetSnapToLabel(Identifier snapTo)
    return item != nullptr ? item->label : XO("Unknown");
 }
 
-// Build a popup menu based on snap functions registry
-struct PopupMenuBuilder final : public SnapRegistryVisitor
-{
-   template<typename Callback>
-   PopupMenuBuilder(Callback callback)
-       : menuStack { &menu }
-       , snapModeUpdated { std::move(callback) }
-   {
-      SnapFunctionsRegistry::Visit(*this);
-   }
-
-   void BeginGroup(const SnapRegistryGroup& item) override
-   {
-      if (item.Inlined())
-         return;
-
-      auto menu = safenew wxMenu;
-
-      menuStack.back()->AppendSubMenu(menu, item.Label().Translation());
-      menuStack.push_back(menu);
-   }
-
-   void EndGroup(const SnapRegistryGroup& item) override
-   {
-      assert(!menuStack.empty());
-
-      if (item.Inlined())
-      {
-         menuStack.back()->AppendSeparator();
-         return;
-      }
-
-      menuStack.pop_back();
-   }
-
-   void Visit(const SnapRegistryItem& item) override
-   {
-      auto menuItem = menuStack.back()->AppendCheckItem(wxID_ANY, item.label.Translation());
-
-      if (ReadSnapTo() == item.name)
-         menuItem->Check();
-
-      menuStack.back()->Bind(
-         wxEVT_MENU,
-         [this, id = item.name](wxCommandEvent&) { snapModeUpdated(id); },
-         menuItem->GetId());
-   }
-
-   wxMenu menu;
-   std::vector<wxMenu*> menuStack;
-   std::function<void(const Identifier& id)> snapModeUpdated;
-};
-
-// Build a linear list from all the items in the snap functions registry
-struct SnapToListBuilder final : public SnapRegistryVisitor
-{
-   SnapToListBuilder()
-   {
-      SnapFunctionsRegistry::Visit(*this);
-   }
-
-   void BeginGroup(const SnapRegistryGroup& item) override
-   {
-   }
-
-   void EndGroup(const SnapRegistryGroup& item) override
-   {
-   }
-
-   void Visit(const SnapRegistryItem& item) override
-   {
-      List.push_back(item.name);
-   }
-
-   std::vector<Identifier> List;
-};
-
 /*
  * This class provides a hack to use popup menu instead of the dropdown list.
  * This allows to organize the list of items in a more user-friendly way.
@@ -152,7 +75,10 @@ public:
 
    void Init () override
    {
-      mSnapToList = std::move(SnapToListBuilder().List);
+      // Build a linear list from all the items in the snap functions registry
+      SnapFunctionsRegistry::Visit([this](const SnapRegistryItem& item, auto&) {
+         mSnapToList.push_back(item.name);
+      });
 
       UpdateCurrentIndex(ReadSnapTo());
    }
@@ -182,11 +108,49 @@ public:
 
    void OnPopup() override
    {
-      PopupMenuBuilder menuBuilder { [this](const auto& id) {
-         ProjectSnap::Get(mProject).SetSnapTo(id);
-      } };
+      // Build a popup menu based on snap functions registry
+      wxMenu menu;
+      std::vector<wxMenu*> menuStack{ &menu };
 
-      BasicMenu::Handle { &menuBuilder.menu }.Popup(
+      const auto visitor = std::tuple{
+         [&](const SnapRegistryGroup& item, auto &) {
+            if (item.Inlined())
+               return;
+
+            auto menu = safenew wxMenu;
+            
+            menuStack.back()->AppendSubMenu(menu, item.Label().Translation());
+            menuStack.push_back(menu);
+         },
+         [&, this](const SnapRegistryItem& item, auto &) {
+            auto menuItem = menuStack.back()->AppendCheckItem(wxID_ANY, item.label.Translation());
+
+            if (ReadSnapTo() == item.name)
+               menuItem->Check();
+
+            menuStack.back()->Bind(
+               wxEVT_MENU,
+               [this, id = item.name](wxCommandEvent&) {
+                  ProjectSnap::Get(mProject).SetSnapTo(id);
+               },
+               menuItem->GetId()
+            );
+         },
+         [&](const SnapRegistryGroup& item, auto &) {
+            assert(!menuStack.empty());
+            
+            if (item.Inlined())
+            {
+               menuStack.back()->AppendSeparator();
+               return;
+            }
+
+            menuStack.pop_back();
+         }
+      };
+      SnapFunctionsRegistry::Visit(visitor);
+
+      BasicMenu::Handle { &menu }.Popup(
          wxWidgetsWindowPlacement { GetComboCtrl() },
          { 0, GetComboCtrl()->GetSize().y });
 

--- a/src/widgets/PopupMenuTable.cpp
+++ b/src/widgets/PopupMenuTable.cpp
@@ -16,17 +16,22 @@ Paul Licameli split from TrackPanel.cpp
 PopupMenuTableEntry::~PopupMenuTableEntry()
 {}
 
-PopupSubMenu::~PopupSubMenu()
-{}
-
 PopupSubMenu::PopupSubMenu(const Identifier &stringId,
    const TranslatableString &caption, PopupMenuTable &table
 )  : GroupItem{ stringId }
-   , WholeMenu{ caption.empty() }
    , caption{ caption }
    , table{ table }
 {
 }
+
+PopupSubMenu::~PopupSubMenu()
+{}
+
+auto PopupSubMenu::GetProperties() const -> Properties
+{ return caption.empty() ? Extension : Whole; }
+
+PopupMenuSection::~PopupMenuSection()
+{}
 
 PopupMenuVisitor::~PopupMenuVisitor() = default;
 

--- a/src/widgets/PopupMenuTable.cpp
+++ b/src/widgets/PopupMenuTable.cpp
@@ -51,7 +51,7 @@ class PopupMenuBuilder : public PopupMenuVisitor {
 public:
    explicit
    PopupMenuBuilder( PopupMenuTable &table, PopupMenuImpl &menu, void *pUserData )
-      : PopupMenuVisitor{ table }
+      : PopupMenuVisitor{}
       , mMenu{ &menu }
       , mRoot{ mMenu }
       , mpUserData{ pUserData }
@@ -157,7 +157,7 @@ void PopupMenuTable::ExtendMenu( PopupMenu &menu, PopupMenuTable &table )
 
    PopupMenuBuilder visitor{ table, theMenu, theMenu.pUserData };
    Registry::Visit(visitor, table.Get( theMenu.pUserData ).get(),
-      table.GetRegistry(), visitor);
+      table.GetRegistry(), table);
 }
 
 void PopupMenuTable::Append(

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -72,7 +72,8 @@ struct AUDACITY_DLL_API PopupMenuTableEntry : Registry::SingleItem
    ~PopupMenuTableEntry() override;
 };
 
-struct AUDACITY_DLL_API PopupSubMenu : PopupMenuGroupItem, MenuTable::WholeMenu
+struct AUDACITY_DLL_API PopupSubMenu
+   : PopupMenuGroupItem, MenuTable::MenuItemProperties
 {
    TranslatableString caption;
    PopupMenuTable &table;
@@ -81,11 +82,15 @@ struct AUDACITY_DLL_API PopupSubMenu : PopupMenuGroupItem, MenuTable::WholeMenu
       const TranslatableString &caption_, PopupMenuTable &table );
 
    ~PopupSubMenu() override;
+   Properties GetProperties() const override;
 };
 
-struct PopupMenuSection : PopupMenuGroupItem, MenuTable::MenuSection
+struct PopupMenuSection
+   : PopupMenuGroupItem, MenuTable::MenuItemProperties
 {
    using PopupMenuGroupItem::PopupMenuGroupItem;
+   ~PopupMenuSection() override;
+   Properties GetProperties() const override { return Section; }
 };
 
 class PopupMenuHandler : public wxEvtHandler

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -32,10 +32,9 @@ class PopupMenuHandler;
 struct PopupMenuSection;
 class PopupMenuTable;
 struct PopupMenuTableEntry;
-struct PopupMenuVisitor;
 struct PopupSubMenu;
 struct PopupMenuTableTraits : Registry::DefaultTraits {
-   using ComputedItemContextType = PopupMenuVisitor;
+   using ComputedItemContextType = PopupMenuTable;
    using LeafTypes = List<PopupMenuTableEntry>;
    using NodeTypes = List<PopupMenuSection, PopupSubMenu>;
 };
@@ -107,9 +106,7 @@ public:
 };
 
 struct PopupMenuVisitor : public MenuVisitor {
-   explicit PopupMenuVisitor( PopupMenuTable &table ) : mTable{ table } {}
    ~PopupMenuVisitor() override;
-   PopupMenuTable &mTable;
 };
 
 // Opaque structure built by PopupMenuTable::BuildMenu
@@ -171,9 +168,8 @@ public:
    template<typename Table, typename Factory>
    static auto Adapt(const Factory &factory)
    {
-      return [factory](PopupMenuVisitor &visitor){
-         auto &table = static_cast<Table&>(visitor.mTable);
-         return std::shared_ptr{ factory(table) };
+      return [factory](PopupMenuTable &table){
+         return std::shared_ptr{ factory(static_cast<Table&>(table)) };
       };
    }
 

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -110,10 +110,6 @@ public:
    virtual void InitUserData(void *pUserData) = 0;
 };
 
-struct PopupMenuVisitor : public MenuVisitor {
-   ~PopupMenuVisitor() override;
-};
-
 // Opaque structure built by PopupMenuTable::BuildMenu
 class AUDACITY_DLL_API PopupMenu
 {


### PR DESCRIPTION
Resolves: #5436

Depends on:
- #4651

Simplify calls to visit registries.  (When only visiting leaf nodes of one type, the visitor can be just one lambda).

Eliminate many dynamic_casts.  Instead TypeSwitch hides all the casting.

This also makes better type safety.  GroupItemBase because a detail class that applications should not use.

QA:
- [x] All as for #4651 again
   - [x] Try some track context menu items
   - [x] Sequence of items in the entire tree of pull-down menus is unchanged
   - [x] Likewise, the tree in the left column of the Preferences dialog
   - [x] Sequence of controls on the Library page of Preferences
   - [x] Sequence of formats in timer controls of Selection toolbar
   - [x] ditto snapping toolbar
   - [x] sequence of choices for "Format" in File > Export Audio... dialog
- [x] Exercise at least one item of each context menu
   - [x] Common track drop-down items
   - [x] Special drop-down items of each of the four kinds of track
   - [x] Wave track color choices
   - [x] clip
   - [x] background area (adds tracks)
   - [x] Label box
   - [x] Vertical rulers of waveform, spectrum, and MIDI tracks
 
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
