### PR TITLE
Fix crash pasting range with no wave tracks into a range with some

### DIFF
--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -135,7 +135,7 @@ void ForEachCopiedWaveTrack(const TrackList& src,
       }
       while(dstTrack != dstTrackRange.end())
       {
-         if((*dstTrack)->GetSelected())
+         if((*dstTrack)->GetSelected() && *lastCopiedTrack)
             f(**lastCopiedTrack);
          ++dstTrack;
       }


### PR DESCRIPTION
Resolves: #4721

A one-line fix for a crash in one of the copy-paste edge cases

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
