### PR TITLE
Sync lock bug fixes

### DIFF
--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -172,9 +172,11 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
          mCurTrackNum++;
       },
       [&]( Track *t ) {
-         if (mustSync && SyncLock::IsSyncLockSelected(t)) {
-            t->SyncLockAdjust(mT1, warper.Warp(mT1));
-         }
+         // Outer loop is over leaders, so fall-through must check for
+         // multiple channels
+         for (auto *channel : TrackList::Channels(t))
+            if (mustSync && SyncLock::IsSyncLockSelected(channel))
+               channel->SyncLockAdjust(mT1, warper.Warp(mT1));
       }
    );
 


### PR DESCRIPTION
Resolves: #4713

Fix errors in sync lock for some time stretching effects:

PaulStretch wasn't doing it at all; Change Tempo (really two effects, depending on the high-quality checkbox) and Sliding Stretch sometimes omitted sync lock (depending on settings), and sometimes applied sync-lock only to the left channel of a stereo track.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
