### PR TITLE
Rewrite paste

### DIFF
--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -836,8 +836,7 @@ void OnPaste(const CommandContext &context)
 
    // TODO: What if we clicked past the end of the track?
 
-   if (bPastedSomething)
-   {
+   if (bPastedSomething) {
       ViewInfo::Get(project).selectedRegion
          .setTimes( t0, t0 + clipboard.Duration() );
 
@@ -847,7 +846,6 @@ void OnPaste(const CommandContext &context)
       if (ff) {
          TrackFocus::Get(project).Set(ff);
          ff->EnsureVisible();
-         ff->LinkConsistencyFix();
       }
    }
 }


### PR DESCRIPTION
Resolves: #4720
Resolves: #4714
Resolves: #4718

Rewrite the logic for pasting into tracks, fixing strange corner cases that sometimes pasted a copied track multiple times, sometimes never, and sometimes omitting needed sync-lock adjustments.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
