### PR TITLE
Count tracks not channels

### DIFF
--- a/libraries/lib-track-selection/SelectionState.cpp
+++ b/libraries/lib-track-selection/SelectionState.cpp
@@ -76,12 +76,17 @@ void SelectionState::SelectTrack(
 */
 }
 
-void SelectionState::SelectRangeOfTracks
-( TrackList &tracks, Track &rsTrack, Track &reTrack )
+void SelectionState::SelectRangeOfTracks(
+   TrackList &tracks, Track &rsTrack, Track &reTrack )
 {
    Track *sTrack = &rsTrack, *eTrack = &reTrack;
    // Swap the track pointers if needed
-   if (eTrack->GetIndex() < sTrack->GetIndex())
+   auto begin = tracks.Leaders().begin(),
+      iterS = tracks.FindLeader(sTrack),
+      iterE = tracks.FindLeader(eTrack);
+   auto indS = std::distance(begin, iterS),
+      indE = std::distance(begin, iterE);
+   if (indE < indS)
       std::swap(sTrack, eTrack);
 
    for (auto track :
@@ -95,22 +100,29 @@ void SelectionState::SelectNone( TrackList &tracks )
       SelectTrack( *t, false, false );
 }
 
-void SelectionState::ChangeSelectionOnShiftClick
-( TrackList &tracks, Track &track )
+void SelectionState::ChangeSelectionOnShiftClick(
+   TrackList &tracks, Track &track)
 {
    // We will either extend from the first or from the last.
    auto pExtendFrom = tracks.Lock(mLastPickedTrack);
 
-   if( !pExtendFrom ) {
+   if (!pExtendFrom) {
       auto trackRange = tracks.Selected();
       auto pFirst = *trackRange.begin();
 
       // If our track is at or after the first, extend from the first.
-      if( pFirst && track.GetIndex() >= pFirst->GetIndex() )
-         pExtendFrom = pFirst->SharedPointer();
+      if (pFirst) {
+         auto begin = tracks.Leaders().begin(),
+            iterT = tracks.FindLeader(&track),
+            iterF = tracks.FindLeader(pFirst);
+         auto indT = std::distance(begin, iterT),
+            indF = std::distance(begin, iterF);
+         if (indT >= indF)
+            pExtendFrom = pFirst->SharedPointer();
+      }
 
       // Our track was earlier than the first.  Extend from the last.
-      if( !pExtendFrom )
+      if (!pExtendFrom)
          pExtendFrom = Track::SharedPointer( *trackRange.rbegin() );
    }
 

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -919,7 +919,7 @@ bool TrackList::empty() const
    return begin() == end();
 }
 
-size_t TrackList::size() const
+size_t TrackList::NChannels() const
 {
    int cnt = 0;
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1494,7 +1494,8 @@ public:
    }
 
    bool empty() const;
-   size_t size() const;
+   size_t NChannels() const;
+   size_t Size() const { return Leaders().size(); }
 
    double GetStartTime() const;
    double GetEndTime() const;
@@ -1502,6 +1503,7 @@ public:
    double GetMinOffset() const;
 
 private:
+   using ListOfTracks::size;
 
    // Visit all tracks satisfying a predicate, mutative access
    template <

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -320,9 +320,6 @@ private:
  public:
    mutable std::pair<int, int> vrulerSize;
 
-   int GetIndex() const;
-   void SetIndex(int index);
-
 public:
    static void FinishCopy (const Track *n, Track *dest);
 
@@ -359,6 +356,9 @@ protected:
    void SetChannel(ChannelType c) noexcept;
 
 private:
+   int GetIndex() const;
+   void SetIndex(int index);
+
    ChannelGroupData &MakeGroupData();
    /*!
     @param completeList only influences debug build consistency checking

--- a/src/commands/ScreenshotCommand.cpp
+++ b/src/commands/ScreenshotCommand.cpp
@@ -785,7 +785,7 @@ bool ScreenshotCommand::Apply(const CommandContext & context)
    TrackPanel *panel = &TrackPanel::Get( context.project );
    AdornedRulerPanel *ruler = panel->GetRuler();
 
-   int nTracks = TrackList::Get( context.project ).size();
+   int nTracks = TrackList::Get(context.project).Size();
 
    int x1,y1,x2,y2;
    w->ClientToScreen(&x1, &y1);

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1179,7 +1179,7 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
       }
    }
 
-   auto nTracksOriginally = tracks.size();
+   auto nTracksOriginally = tracks.Size();
    wxWindow *focus = wxWindow::FindFocus();
    wxWindow *parent = nullptr;
    if (focus != nullptr) {
@@ -1325,7 +1325,7 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
    // New tracks added?  Scroll them into view so that user sees them.
    // Don't care what track type.  An analyser might just have added a
    // Label track and we want to see it.
-   if( tracks.size() > nTracksOriginally ){
+   if (tracks.Size() > nTracksOriginally) {
       // 0.0 is min scroll position, 1.0 is max scroll position.
       trackPanel.VerticalScroll( 1.0 );
    }

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -313,11 +313,11 @@ ProgressResult AUPImportFileHandle::Import(WaveTrackFactory *WXUNUSED(trackFacto
    auto &settings = ProjectSettings::Get(mProject);
    auto &selman = ProjectSelectionManager::Get(mProject);
 
-   auto oldNumTracks = tracks.size();
+   auto oldNumTracks = tracks.Size();
    auto cleanup = finally([this, &tracks, oldNumTracks]{
       if (mUpdateResult != ProgressResult::Success) {
          // Revoke additions of tracks
-         while (oldNumTracks < tracks.size()) {
+         while (oldNumTracks < tracks.Size()) {
             Track *lastTrack = *tracks.Any().rbegin();
             tracks.Remove(lastTrack);
          }
@@ -1356,7 +1356,7 @@ bool AUPImportFileHandle::HandleImport(XMLTagHandler *&handler)
    }
 
    auto &tracks = TrackList::Get(mProject);
-   auto oldNumTracks = tracks.size();
+   auto oldNumTracks = tracks.Size();
    Track *pLast = nullptr;
    if (oldNumTracks > 0)
       pLast = *tracks.Any().rbegin();
@@ -1369,7 +1369,7 @@ bool AUPImportFileHandle::HandleImport(XMLTagHandler *&handler)
       [&] (AudacityException*) {}
    );
 
-   if (oldNumTracks == tracks.size())
+   if (oldNumTracks == tracks.Size())
       return false;
 
    // Handle other attributes, now that we have the tracks.

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -71,10 +71,11 @@ int DoAddLabel(
    const auto pFocusedTrack = trackFocus.Get();
 
    // Look for a label track at or after the focused track
+   auto begin = tracks.Leaders().begin();
    auto iter = pFocusedTrack
-      ? tracks.Find(pFocusedTrack)
-      : tracks.Any().begin();
-   auto lt = * iter.Filter< LabelTrack >();
+      ? tracks.FindLeader(pFocusedTrack)
+      : begin;
+   auto lt = * iter.Filter<LabelTrack>();
 
    // If none found, start a NEW label track and use it
    if (!lt)
@@ -98,7 +99,7 @@ int DoAddLabel(
          // Must remember the track to re-focus after finishing a label edit.
          // do NOT identify it by a pointer, which might dangle!  Identify
          // by position.
-         focusTrackNumber = pFocusedTrack->GetIndex();
+         focusTrackNumber = std::distance(begin, iter);
       }
       index =
          LabelTrackView::Get( *lt ).AddLabel(region, title, focusTrackNumber);

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -110,7 +110,7 @@ void DoMixAndRender
       if (insertionPoint)
       {
          std::vector<TrackNodePointer> arr;
-         arr.reserve( tracks.size() );
+         arr.reserve(tracks.NChannels());
          size_t begin = 0, ii = 0;
          for (auto iter = tracks.ListOfTracks::begin(),
               end = tracks.ListOfTracks::end(); iter != end; ++iter) {
@@ -519,7 +519,7 @@ void DoSortTracks( AudacityProject &project, int flags )
    // std::list iterators!  Avoid this elsewhere!
    std::vector<TrackNodePointer> arr;
    auto &tracks = TrackList::Get( project );
-   arr.reserve(tracks.size());
+   arr.reserve(tracks.NChannels());
 
    // First find the permutation.
    // This routine, very unusually, deals with the underlying stl list

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -885,10 +885,7 @@ int DoAddLabel(
 //   SelectNone();
    lt->SetSelected(true);
 
-   int index;
-   int focusTrackNumber = -1;
-   index =
-      LabelTrackView::Get( *lt ).AddLabel(region, title, focusTrackNumber);
+   auto index = LabelTrackView::Get(*lt).AddLabel(region, title);
 
    ProjectHistory::Get( project )
       .PushState(XO("Added label"), XO("Label"));

--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -1684,7 +1684,7 @@ bool LabelTrackView::DoKeyDown(
       case WXK_NUMPAD_ENTER:
       case WXK_TAB:
          if (mRestoreFocus >= 0) {
-            auto track = *TrackList::Get( project ).Any()
+            auto track = *TrackList::Get(project).Leaders()
                .begin().advance(mRestoreFocus);
             if (track)
                TrackFocus::Get( project ).Set(track);
@@ -2077,7 +2077,8 @@ int LabelTrackView::GetLabelIndex(double t, double t1)
 
 // restoreFocus of -1 is the default, and sets the focus to this label.
 // restoreFocus of -2 or other value leaves the focus unchanged.
-// restoreFocus >= 0 will later cause focus to move to that track.
+// restoreFocus >= 0 will later cause focus to move to that track (counting
+// tracks, not channels)
 int LabelTrackView::AddLabel(const SelectedRegion &selectedRegion,
                          const wxString &title, int restoreFocus)
 {


### PR DESCRIPTION
Resolves: #4716 

One of the lesser problems solved, for fixing iterations over tracks:
Outside Track.h, do not use the position of a channel in the total track list; but only use position of a leader track
among leaders.

Do not use the total number of channels (except for some initial array capacities).  Use the number of leader tracks.

QA:  besides verifying #4716, verify no changes in these things, when stereo tracks are present in the project:
- [x] Shift-click in track control panels to extend the range of selected tracks works, upwards and downwards.
- [x] Adding a label during playback (Ctrl + B) restores focus to the correct track after RETURN key.
- [x] If an Analyzer adds a label track that would have been off the bottom of the screen, vertical scrolling of it into view still happens

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
