### PR TITLE
Wide wave clip

### DIFF
--- a/libraries/lib-math/SampleFormat.h
+++ b/libraries/lib-math/SampleFormat.h
@@ -104,6 +104,17 @@ private:
    sampleFormat m_Stored;
 };
 
+inline bool operator == (SampleFormats a, SampleFormats b)
+{
+   return a.Effective() == b.Effective() &&
+      a.Stored() == b.Stored();
+}
+
+inline bool operator != (SampleFormats a, SampleFormats b)
+{
+   return !(a == b);
+}
+
 //
 // Allocating/Freeing Samples
 //

--- a/libraries/lib-project-file-io/SqliteSampleBlock.cpp
+++ b/libraries/lib-project-file-io/SqliteSampleBlock.cpp
@@ -35,7 +35,7 @@ public:
       const std::shared_ptr<SqliteSampleBlockFactory> &pFactory);
    ~SqliteSampleBlock() override;
 
-   void CloseLock() override;
+   void CloseLock() noexcept override;
 
    void SetSamples(
       constSamplePtr src, size_t numsamples, sampleFormat srcformat);
@@ -348,7 +348,7 @@ DBConnection *SqliteSampleBlock::Conn() const
    return pConnection.get();
 }
 
-void SqliteSampleBlock::CloseLock()
+void SqliteSampleBlock::CloseLock() noexcept
 {
    mLocked = true;
 }

--- a/libraries/lib-wave-track/SampleBlock.h
+++ b/libraries/lib-wave-track/SampleBlock.h
@@ -51,7 +51,7 @@ public:
 
    virtual ~SampleBlock();
 
-   virtual void CloseLock() = 0;
+   virtual void CloseLock() noexcept = 0;
    
    virtual SampleBlockID GetBlockID() const = 0;
 

--- a/libraries/lib-wave-track/Sequence.cpp
+++ b/libraries/lib-wave-track/Sequence.cpp
@@ -84,7 +84,7 @@ size_t Sequence::GetIdealBlockSize() const
    return mMaxSamples;
 }
 
-bool Sequence::CloseLock()
+bool Sequence::CloseLock() noexcept
 {
    for (unsigned int i = 0; i < mBlock.size(); i++)
       mBlock[i].sb->CloseLock();

--- a/libraries/lib-wave-track/Sequence.h
+++ b/libraries/lib-wave-track/Sequence.h
@@ -175,7 +175,7 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
 
    SampleFormats GetSampleFormats() const;
 
-   //! @return whether there was a change
+   //! @return whether there was a change of format
    /*! @excsafety{Strong} */
    bool ConvertToSampleFormat(sampleFormat format,
       const std::function<void(size_t)> & progressReport = {});

--- a/libraries/lib-wave-track/Sequence.h
+++ b/libraries/lib-wave-track/Sequence.h
@@ -166,8 +166,9 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
    // Lock all of this sequence's sample blocks, keeping them
    // from being destroyed when closing.
 
-   bool CloseLock();//should be called upon project close.
-   // not balanced by unlocking calls.
+   //! Should be called upon project close.  Not balanced by unlocking calls.
+   /*! @excsafety{No-fail} */
+   bool CloseLock() noexcept;
 
    //
    // Manipulating Sample Format

--- a/libraries/lib-wave-track/Sequence.h
+++ b/libraries/lib-wave-track/Sequence.h
@@ -68,6 +68,7 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
 
    Sequence(const SampleBlockFactoryPtr &pFactory, SampleFormats formats);
 
+   //! Does not copy un-flushed append buffer data
    Sequence(const Sequence &orig, const SampleBlockFactoryPtr &pFactory);
 
    Sequence( const Sequence& ) = delete;

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -838,7 +838,7 @@ void WaveClip::OffsetCutLines(double t0, double len)
    }
 }
 
-void WaveClip::CloseLock()
+void WaveClip::CloseLock() noexcept
 {
    for (auto &pSequence : mSequences)
       pSequence->CloseLock();

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1221,6 +1221,8 @@ bool WaveClip::CheckInvariants() const
 
 WaveClip::Transaction::Transaction(WaveClip &clip)
    : clip{ clip }
+   , mTrimLeft{ clip.mTrimLeft }
+   , mTrimRight{ clip.mTrimRight }
 {
    sequences.reserve(clip.mSequences.size());
    auto &factory = clip.GetFactory();
@@ -1234,5 +1236,7 @@ WaveClip::Transaction::~Transaction()
 {
    if (!committed) {
       clip.mSequences.swap(sequences);
+      clip.mTrimLeft = mTrimLeft;
+      clip.mTrimRight = mTrimRight;
    }
 }

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -395,11 +395,11 @@ void WaveClip::WriteXML(XMLWriter &xmlFile) const
 }
 
 /*! @excsafety{Strong} */
-void WaveClip::Paste(double t0, const WaveClip* other)
+void WaveClip::Paste(double t0, const WaveClip &other)
 {
-   const bool clipNeedsResampling = other->mRate != mRate;
+   const bool clipNeedsResampling = other.mRate != mRate;
    const bool clipNeedsNewFormat =
-      other->mSequence->GetSampleFormats().Stored()
+      other.mSequence->GetSampleFormats().Stored()
          != mSequence->GetSampleFormats().Stored();
    std::shared_ptr<WaveClip> newClip;
 
@@ -409,27 +409,27 @@ void WaveClip::Paste(double t0, const WaveClip* other)
    if (t0 == GetPlayStartTime())
    {
        ClearSequence(GetSequenceStartTime(), t0);
-       SetTrimLeft(other->GetTrimLeft());
+       SetTrimLeft(other.GetTrimLeft());
 
        auto copy =
-         std::make_shared<WaveClip>(*other, mSequence->GetFactory(), true);
+         std::make_shared<WaveClip>(other, mSequence->GetFactory(), true);
        copy->ClearSequence(copy->GetPlayEndTime(), copy->GetSequenceEndTime());
        newClip = std::move(copy);
    }
    else if (t0 == GetPlayEndTime())
    {
        ClearSequence(GetPlayEndTime(), GetSequenceEndTime());
-       SetTrimRight(other->GetTrimRight());
+       SetTrimRight(other.GetTrimRight());
 
        auto copy =
-         std::make_shared<WaveClip>(*other, mSequence->GetFactory(), true);
+         std::make_shared<WaveClip>(other, mSequence->GetFactory(), true);
        copy->ClearSequence(copy->GetSequenceStartTime(), copy->GetPlayStartTime());
        newClip = std::move(copy);
    }
    else
    {
       newClip =
-         std::make_shared<WaveClip>(*other, mSequence->GetFactory(), true);
+         std::make_shared<WaveClip>(other, mSequence->GetFactory(), true);
       newClip->ClearSequence(newClip->GetPlayEndTime(), newClip->GetSequenceEndTime());
       newClip->ClearSequence(newClip->GetSequenceStartTime(), newClip->GetPlayStartTime());
       newClip->SetTrimLeft(0);
@@ -722,7 +722,8 @@ void WaveClip::ExpandCutLine(double cutLinePosition)
       // Do this to get the right result:
       cutline->mEnvelope->SetOffset(0);
 
-      Paste(GetSequenceStartTime()+cutline->GetSequenceStartTime(), cutline);
+      Paste(GetSequenceStartTime() + cutline->GetSequenceStartTime(),
+         *cutline);
       // Now erase the cutline,
       // but be careful to find it again, because Paste above may
       // have modified the array of cutlines (if our cutline contained

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -50,15 +50,13 @@ public:
    int width;
    sampleCount *where;
    float *min, *max, *rms;
-   int* bl;
 
    std::vector<sampleCount> ownWhere;
    std::vector<float> ownMin, ownMax, ownRms;
-   std::vector<int> ownBl;
 
 public:
    WaveDisplay(int w)
-      : width(w), where(0), min(0), max(0), rms(0), bl(0)
+      : width(w), where(0), min(0), max(0), rms(0)
    {
    }
 
@@ -69,18 +67,15 @@ public:
       ownMin.resize(width);
       ownMax.resize(width);
       ownRms.resize(width);
-      ownBl.resize(width);
 
       where = &ownWhere[0];
       if (width > 0) {
          min = &ownMin[0];
          max = &ownMax[0];
          rms = &ownRms[0];
-         bl = &ownBl[0];
       }
       else {
          min = max = rms = 0;
-         bl = 0;
       }
    }
 

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -105,8 +105,14 @@ private:
 public:
    using Caches = Site< WaveClip, WaveClipListener >;
 
-   // typical constructor
-   WaveClip(const SampleBlockFactoryPtr &factory, sampleFormat format,
+   //! typical constructor
+   /*!
+    @param width how many sequences
+    @pre `width > 0`
+    @post `GetWidth() == width`
+    */
+   WaveClip(size_t width,
+      const SampleBlockFactoryPtr &factory, sampleFormat format,
       int rate, int colourIndex);
 
    //! essentially a copy constructor - but you must pass in the

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -137,6 +137,9 @@ public:
 
    virtual ~WaveClip();
 
+   //! Check invariant conditions on mSequences and mCutlines
+   bool CheckInvariants() const;
+
    //! How many Sequences the clip contains.
    //! Set at construction time; changes only if increased by deserialization
    size_t GetWidth() const;
@@ -433,8 +436,6 @@ private:
    /// This name is consistent with WaveTrack::Clear. It performs a "Cut"
    /// operation (but without putting the cut audio to the clipboard)
    void ClearSequence(double t0, double t1);
-
-   bool CheckInvariants() const;
 
    //! Restores state when an update loop over mSequences fails midway
    struct Transaction {

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -361,8 +361,11 @@ protected:
    std::unique_ptr<Sequence> mSequence;
    std::unique_ptr<Envelope> mEnvelope;
 
-   // Cut Lines are nothing more than ordinary wave clips, with the
-   // offset relative to the start of the clip.
+   //! Cut Lines are nothing more than ordinary wave clips, with the
+   //! offset relative to the start of the clip.
+   /*!
+    @invariant all are non-null
+    */
    WaveClipHolders mCutLines {};
 
    // AWD, Oct. 2009: for whitespace-at-end-of-selection pasting

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -108,15 +108,21 @@ public:
    WaveClip(const SampleBlockFactoryPtr &factory, sampleFormat format,
       int rate, int colourIndex);
 
-   // essentially a copy constructor - but you must pass in the
-   // current sample block factory, because we might be copying
-   // from one project to another
+   //! essentially a copy constructor - but you must pass in the
+   //! current sample block factory, because we might be copying
+   //! from one project to another
+   /*!
+    @post `GetWidth() == orig.GetWidth()`
+    */
    WaveClip(const WaveClip& orig,
             const SampleBlockFactoryPtr &factory,
             bool copyCutlines);
 
    //! @brief Copy only a range from the given WaveClip
-   //! @pre CountSamples(t1, t0) > 0
+   /*!
+    @pre CountSamples(t1, t0) > 0
+    @post `GetWidth() == orig.GetWidth()`
+    */
    WaveClip(const WaveClip& orig,
             const SampleBlockFactoryPtr &factory,
             bool copyCutlines,
@@ -320,8 +326,11 @@ public:
    /// if there is at least one clip sample between t0 and t1, noop otherwise.
    void ClearAndAddCutLine(double t0, double t1);
 
-   /// Paste data from other clip, resampling it if not equal rate
-   void Paste(double t0, const WaveClip &other);
+   //! Paste data from other clip, resampling it if not equal rate
+   /*!
+    @return true and succeed if and only if `this->GetWidth() == other.GetWidth()`
+    */
+   bool Paste(double t0, const WaveClip &other);
 
    /** Insert silence - note that this is an efficient operation for large
     * amounts of silence */

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -300,12 +300,14 @@ public:
    //! @pre `GetWidth() == 1`
    void AppendSharedBlock(const std::shared_ptr<SampleBlock> &pBlock);
 
+   //! Append (non-interleaved) samples to all channels
    //! You must call Flush after the last Append
    /*!
     @return true if at least one complete block was created
     @pre `GetWidth() == 1`
+    assume as many buffers available as GetWidth()
     */
-   bool Append(constSamplePtr buffer, sampleFormat format,
+   bool Append(constSamplePtr buffers[], sampleFormat format,
       size_t len, unsigned int stride,
       sampleFormat effectiveFormat /*!<
          Make the effective format of the data at least the minumum of this

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -437,6 +437,8 @@ private:
 
       WaveClip &clip;
       std::vector<std::unique_ptr<Sequence>> sequences;
+      const double mTrimLeft,
+         mTrimRight;
       bool committed{ false };
    };
 

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -379,8 +379,9 @@ public:
    /// Offset cutlines right to time 't0' by time amount 'len'
    void OffsetCutLines(double t0, double len);
 
-   void CloseLock(); //should be called when the project closes.
-   // not balanced by unlocking calls.
+   //! Should be called upon project close.  Not balanced by unlocking calls.
+   /*! @excsafety{No-fail} */
+   void CloseLock() noexcept;
 
    //
    // XMLTagHandler callback methods for loading and saving

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -321,7 +321,7 @@ public:
    void ClearAndAddCutLine(double t0, double t1);
 
    /// Paste data from other clip, resampling it if not equal rate
-   void Paste(double t0, const WaveClip* other);
+   void Paste(double t0, const WaveClip &other);
 
    /** Insert silence - note that this is an efficient operation for large
     * amounts of silence */

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -131,7 +131,8 @@ public:
 
    virtual ~WaveClip();
 
-   //! How many Sequences the clip contains; for now always returns 1
+   //! How many Sequences the clip contains.
+   //! Set at construction time; changes only if increased by deserialization
    size_t GetWidth() const;
 
    void ConvertToSampleFormat(sampleFormat format,

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2257,15 +2257,6 @@ Envelope* WaveTrack::GetEnvelopeAtTime(double time)
       return NULL;
 }
 
-Sequence* WaveTrack::GetSequenceAtTime(double time)
-{
-   WaveClip* clip = GetClipAtTime(time);
-   if (clip)
-      return clip->GetSequence();
-   else
-      return NULL;
-}
-
 WaveClip* WaveTrack::CreateClip(double offset, const wxString& name)
 {
    auto clip = std::make_unique<WaveClip>(

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1721,8 +1721,9 @@ and no content already flushed to disk is lost. */
 bool WaveTrack::Append(constSamplePtr buffer, sampleFormat format,
    size_t len, unsigned int stride, sampleFormat effectiveFormat)
 {
+   constSamplePtr buffers[]{ buffer };
    return RightmostOrNewClip()
-      ->Append(buffer, format, len, stride, effectiveFormat);
+      ->Append(buffers, format, len, stride, effectiveFormat);
 }
 
 sampleCount WaveTrack::GetBlockStart(sampleCount s) const

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -699,7 +699,8 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
    if (forClipboard &&
        newTrack->GetEndTime() + 1.0 / newTrack->GetRate() < t1 - t0)
    {
-      auto placeholder = std::make_shared<WaveClip>(mpFactory,
+      // TODO wide wave tracks -- match clip width of newTrack
+      auto placeholder = std::make_shared<WaveClip>(1, mpFactory,
          newTrack->GetSampleFormat(),
          static_cast<int>(newTrack->GetRate()),
          0 /*colourindex*/);
@@ -1538,7 +1539,8 @@ void WaveTrack::InsertSilence(double t, double len)
    if (mClips.empty())
    {
       // Special case if there is no clip yet
-      auto clip = std::make_shared<WaveClip>(
+      // TODO wide wave tracks -- match clip width
+      auto clip = std::make_shared<WaveClip>(1,
          mpFactory, mFormat, GetRate(), this->GetWaveColorIndex());
       clip->InsertSilence(0, len);
       // use No-fail-guarantee
@@ -2323,7 +2325,8 @@ Envelope* WaveTrack::GetEnvelopeAtTime(double time)
 
 WaveClip* WaveTrack::CreateClip(double offset, const wxString& name)
 {
-   auto clip = std::make_shared<WaveClip>(
+   // TODO wide wave tracks -- choose clip width correctly for the track
+   auto clip = std::make_shared<WaveClip>(1,
       mpFactory, mFormat, GetRate(), GetWaveColorIndex());
    clip->SetName(name);
    clip->SetSequenceStartTime(offset);

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1955,7 +1955,7 @@ std::optional<TranslatableString> WaveTrack::GetErrorOpening() const
    return {};
 }
 
-bool WaveTrack::CloseLock()
+bool WaveTrack::CloseLock() noexcept
 {
    for (const auto &clip : mClips)
       clip->CloseLock();

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -504,6 +504,7 @@ private:
    //! as this track, and `this->GetWidth() == clip->GetWidth()`; return success
    /*!
     @pre `clip != nullptr`
+    @pre `this->GetWidth() == clip->GetWidth()`
     */
    bool AddClip(const std::shared_ptr<WaveClip> &clip);
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -273,11 +273,9 @@ private:
 
    //
    // MM: We now have more than one sequence and envelope per track, so
-   // instead of GetSequence() and GetEnvelope() we have the following
-   // function which give the sequence and envelope which contains the given
-   // time.
+   // instead of GetEnvelope() we have the following function which gives the
+   // envelope that contains the given time.
    //
-   Sequence* GetSequenceAtTime(double time);
    Envelope* GetEnvelopeAtTime(double time);
 
    WaveClip* GetClipAtTime(double time);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -143,6 +143,8 @@ private:
    void SetWaveColorIndex(int colorIndex);
 
    sampleCount GetPlaySamplesCount() const;
+   //! Returns the total number of samples in all underlying sequences
+   //! of all clips (but not counting the cutlines)
    sampleCount GetSequenceSamplesCount() const;
 
    sampleFormat GetSampleFormat() const override { return mFormat; }
@@ -240,6 +242,10 @@ private:
    /// guaranteed that the same samples are affected.
    ///
 
+   /*!
+    Get from the unique channel
+    TODO wide wave tracks -- overloads to get from one or from all channels
+    */
    bool Get(samplePtr buffer, sampleFormat format,
       sampleCount start, size_t len,
       fillFormat fill = fillZero,
@@ -248,6 +254,10 @@ private:
       // filled according to fillFormat; but these were not necessarily one
       // contiguous range.
       sampleCount * pNumWithinClips = nullptr) const override;
+   /*!
+    Set samples in the unique channel
+    TODO wide wave tracks -- overloads to set one or all channels
+    */
    void Set(constSamplePtr buffer, sampleFormat format,
       sampleCount start, size_t len,
       sampleFormat effectiveFormat = widestSampleFormat /*!<
@@ -265,10 +275,19 @@ private:
    void GetEnvelopeValues(double *buffer, size_t bufferLen,
                          double t0) const override;
 
-   // May assume precondition: t0 <= t1
+   // Get min and max from the unique channel
+   /*!
+    @pre `t0 <= t1`
+    TODO wide wave tracks -- require a channel number
+    */
    std::pair<float, float> GetMinMax(
       double t0, double t1, bool mayThrow = true) const;
-   // May assume precondition: t0 <= t1
+
+   // Get RMS from the unique channel
+   /*!
+    @pre `t0 <= t1`
+    TODO wide wave tracks -- require a channel number
+    */
    float GetRMS(double t0, double t1, bool mayThrow = true) const;
 
    //

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -330,8 +330,9 @@ private:
    // doing a copy and paste between projects.
    //
 
-   bool CloseLock(); //should be called when the project closes.
-   // not balanced by unlocking calls.
+   //! Should be called upon project close.  Not balanced by unlocking calls.
+   /*! @excsafety{No-fail} */
+   bool CloseLock() noexcept;
 
    //! Get access to the (visible) clips in the tracks, in unspecified order
    //! (not necessarily sequenced in time).

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -82,6 +82,9 @@ public:
    //! Copied only in WaveTrack::Clone() !
    WaveTrack(const WaveTrack &orig, ProtectedCreationArg&&);
 
+   //! The width of every WaveClip in this track; for now always 1
+   size_t GetWidth() const;
+
    // overwrite data excluding the sample sequence but including display
    // settings
    void Reinit(const WaveTrack &orig);
@@ -431,9 +434,13 @@ private:
       return { AllClipsConstIterator{ *this }, AllClipsConstIterator{ } };
    }
    
-   // Create NEW clip and add it to this track. Returns a pointer
-   // to the newly created clip. Optionally initial offset and
-   // clip name may be provided
+   //! Create new clip and add it to this track.
+   /*!
+    Returns a pointer to the newly created clip. Optionally initial offset and
+    clip name may be provided
+
+    @post result: `result->GetWidth() == GetWidth()`
+    */
    WaveClip* CreateClip(double offset = .0, const wxString& name = wxEmptyString);
 
    /** @brief Get access to the most recently added clip, or create a clip,
@@ -492,7 +499,8 @@ private:
    // You assume responsibility for its memory!
    std::shared_ptr<WaveClip> RemoveAndReturnClip(WaveClip* clip);
 
-   //! Append a clip to the track; which must have the same block factory as this track; return success
+   //! Append a clip to the track; to succeed, must have the same block factory
+   //! as this track and the correct width; return success
    /*!
     @pre `clip != nullptr`
     */
@@ -546,7 +554,7 @@ private:
    //
 
    /*!
-    @invariant all are non-null
+    @invariant all are non-null and match `this->GetWidth()`
     */
    WaveClipHolders mClips;
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -226,6 +226,7 @@ private:
     If there is an existing WaveClip in the WaveTrack then the data are
     appended to that clip. If there are no WaveClips in the track, then a new
     one is created.
+    @return true if at least one complete block was created
     */
    bool Append(constSamplePtr buffer, sampleFormat format,
       size_t len, unsigned int stride = 1,

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -453,10 +453,15 @@ private:
    // Get the linear index of a given clip (-1 if the clip is not found)
    int GetClipIndex(const WaveClip* clip) const;
 
-   // Get the nth clip in this WaveTrack (will return NULL if not found).
-   // Use this only in special cases (like getting the linked clip), because
-   // it is much slower than GetClipIterator().
+   //! Get the nth clip in this WaveTrack (will return nullptr if not found).
+   /*!
+    Use this only in special cases (like getting the linked clip), because
+    it is much slower than GetClipIterator().
+    */
    WaveClip *GetClipByIndex(int index);
+   /*!
+    @copydoc GetClipByIndex
+    */
    const WaveClip* GetClipByIndex(int index) const;
 
    // Get number of clips in this WaveTrack

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -500,7 +500,7 @@ private:
    std::shared_ptr<WaveClip> RemoveAndReturnClip(WaveClip* clip);
 
    //! Append a clip to the track; to succeed, must have the same block factory
-   //! as this track and the correct width; return success
+   //! as this track, and `this->GetWidth() == clip->GetWidth()`; return success
    /*!
     @pre `clip != nullptr`
     */

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -222,11 +222,10 @@ private:
     */
    bool IsEmpty(double t0, double t1) const;
 
-   /*
-    * If there is an existing WaveClip in the WaveTrack then the data is
-    * appended to that clip. If there are no WaveClips in the track, then a NEW
-    * one is created.
-    *
+   /*!
+    If there is an existing WaveClip in the WaveTrack then the data are
+    appended to that clip. If there are no WaveClips in the track, then a new
+    one is created.
     */
    bool Append(constSamplePtr buffer, sampleFormat format,
       size_t len, unsigned int stride = 1,

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -499,7 +499,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
    elapsed = timer.Time();
 
    if (mBlockDetail) {
-      auto seq = t->GetClipByIndex(0)->GetSequence();
+      auto seq = t->GetClipByIndex(0)->GetSequence(0);
       seq->DebugPrintf(seq->GetBlockArray(), seq->GetNumSamples(), &tempStr);
       mToPrint += tempStr;
    }

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -1131,7 +1131,8 @@ bool AUPImportFileHandle::HandleSequence(XMLTagHandler *&handler)
          }
 
          mFormat = (sampleFormat) fValue;
-         waveclip->GetSequence()->ConvertToSampleFormat( mFormat );
+         // Assume old AUP format file never had wide clips
+         waveclip->GetSequence(0)->ConvertToSampleFormat(mFormat);
       }
       else if (attr == "numsamples")
       {

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -385,8 +385,9 @@ ProgressResult AUPImportFileHandle::Import(WaveTrackFactory *WXUNUSED(trackFacto
       }
       else
       {
-         AddSamples(fi.blockFile, fi.audioFile,
-                    fi.len, fi.format, fi.origin, fi.channel);
+         if (!AddSamples(fi.blockFile, fi.audioFile,
+                    fi.len, fi.format, fi.origin, fi.channel))
+            return ProgressResult::Failed;
       }
 
       processed += fi.len;
@@ -1458,6 +1459,8 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
    auto &pBlock = mFileMap[wxFileNameFromPath(blockFilename)].second;
    if (pBlock) {
       // Replicate the sharing of blocks
+      if (pClip->GetWidth() != 1)
+         return false;
       pClip->AppendSharedBlock( pBlock );
       return true;
    }
@@ -1649,6 +1652,8 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
    // Add the samples to the clip/track
    if (pClip)
    {
+      if (pClip->GetWidth() != 1)
+         return false;
       pBlock = pClip->AppendNewBlock(bufptr, format, cnt);
    }
 

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -159,7 +159,7 @@ wxULongLong EstimateCopyBytesCount(const TrackList& src, const TrackList& dst)
    wxULongLong result{};
    ForEachCopiedWaveTrack(src, dst, [&](const WaveTrack& waveTrack) {
       sampleCount samplesCount = 0;
-      for(auto& clip : waveTrack.GetClips())
+      for (auto& clip : waveTrack.GetClips())
          samplesCount += clip->GetSequenceSamplesCount();
       result += samplesCount.as_long_long() * SAMPLE_SIZE(waveTrack.GetSampleFormat());
    });
@@ -171,7 +171,8 @@ BlockArray::size_type EstimateCopiedBlocks(const TrackList& src, const TrackList
    BlockArray::size_type result{};
    ForEachCopiedWaveTrack(src, dst, [&](const WaveTrack& waveTrack) {
       for(auto& clip : waveTrack.GetClips())
-         result += clip->GetSequenceBlockArray()->size();
+         result +=
+            clip->GetWidth() * clip->GetSequenceBlockArray(0)->size();
    });
    return result;
 }

--- a/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.cpp
@@ -62,7 +62,7 @@ struct MinMaxSumsq
 }
 
 bool GetWaveDisplay(const Sequence &sequence,
-   float *min, float *max, float *rms, int* bl,
+   float *min, float *max, float *rms,
    size_t len, const sampleCount *where)
 {
    wxASSERT(len > 0);
@@ -141,8 +141,6 @@ bool GetWaveDisplay(const Sequence &sequence,
          : (samplesPerPixel >= 256) ? 256
          : 1;
 
-      int blockStatus = b;
-
       // How many samples or triples are needed?
 
       const size_t startPosition =
@@ -159,7 +157,6 @@ bool GetWaveDisplay(const Sequence &sequence,
          // Do some defense against this case anyway
          while (pixel < nextPixel) {
             min[pixel] = max[pixel] = rms[pixel] = 0;
-            bl[pixel] = blockStatus;//MC
             ++pixel;
          }
          continue;
@@ -243,7 +240,6 @@ bool GetWaveDisplay(const Sequence &sequence,
          // Assign results
          std::fill(&min[pixel], &min[pixelX], values.min);
          std::fill(&max[pixel], &max[pixelX], values.max);
-         std::fill(&bl[pixel], &bl[pixelX], blockStatus);
          std::fill(&rms[pixel], &rms[pixelX], (float)sqrt(values.sumsq / rmsDenom));
 
          pixel = pixelX;

--- a/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.h
+++ b/src/tracks/playabletrack/wavetrack/ui/GetWaveDisplay.h
@@ -20,10 +20,9 @@ class sampleCount;
 // Each position in the output arrays corresponds to one column of pixels.
 // The column for pixel p covers samples from
 // where[p] up to (but excluding) where[p + 1].
-// bl is negative wherever data are not yet available.
 // Return true if successful.
 bool GetWaveDisplay(const Sequence &sequence,
-   float *min, float *max, float *rms, int* bl,
+   float *min, float *max, float *rms,
    size_t len, const sampleCount *where);
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -578,7 +578,8 @@ bool WaveClipSpectrumCache::GetSpectrogram(const WaveClip &clip,
 
    mSpecCache->Populate
       (settings, waveTrackCache, copyBegin, copyEnd, numPixels,
-       clip.GetSequenceSamplesCount(),
+       // We want the length of only one channel of samples:
+       clip.GetSequenceSamplesCount() / clip.GetWidth(),
        clip.GetSequenceStartTime(), rate, pixelsPerSecond);
 
    mSpecCache->dirty = mDirty;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -259,9 +259,11 @@ void FormatMenuTable::OnFormatChange(wxCommandEvent & event)
                             XO("Processing...   0%%"),
                             pdlgHideStopButton };
 
+   // Simply finding a denominator for the progress dialog
    sampleCount totalSamples{ 0 };
    for (const auto& channel : TrackList::Channels(pTrack))
       // Hidden samples are processed too, they should be counted as well
+      // (Correctly counting all samples of all channels)
       totalSamples += channel->GetSequenceSamplesCount();
    sampleCount processedSamples{ 0 };
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackShifter.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackShifter.cpp
@@ -158,6 +158,7 @@ public:
       for (auto &interval : intervals) {
          auto pData = static_cast<WaveTrack::IntervalData*>( interval.Extra() );
          auto pClip = pData->GetClip();
+         // TODO wide wave tracks -- guarantee matching clip width
          if ( !mpTrack->AddClip( pClip ) )
             return false;
          mMigrated.insert( pClip.get() );

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
@@ -919,13 +919,16 @@ const WaveTrackView *WaveTrackView::Find( const WaveTrack *pTrack )
    return Find( const_cast<WaveTrack*>( pTrack ) );
 }
 
-WaveTrackView::WaveTrackView( const std::shared_ptr<Track> &pTrack )
-   : CommonTrackView{ pTrack }
+WaveTrackView::WaveTrackView(
+   const std::shared_ptr<Track> &pTrack, size_t channel
+)  : CommonTrackView{ pTrack }
+   , mChannel{ channel }
 {
 }
 
-WaveTrackSubView::WaveTrackSubView( WaveTrackView &waveTrackView )
-   : CommonTrackView( waveTrackView.FindTrack() )
+WaveTrackSubView::WaveTrackSubView(WaveTrackView &waveTrackView)
+   : CommonTrackView(waveTrackView.FindTrack())
+   , mChannel(waveTrackView.GetChannel())
 {
    mwWaveTrackView = std::static_pointer_cast<WaveTrackView>(
       waveTrackView.shared_from_this() );
@@ -1504,7 +1507,8 @@ std::shared_ptr<CommonTrackCell> WaveTrackView::DoGetAffordance(const std::share
 using DoGetWaveTrackView = DoGetView::Override< WaveTrack >;
 DEFINE_ATTACHED_VIRTUAL_OVERRIDE(DoGetWaveTrackView) {
    return [](WaveTrack &track) {
-      return std::make_shared<WaveTrackView>( track.SharedPointer() );
+      // TODO wide wave tracks
+      return std::make_shared<WaveTrackView>(track.SharedPointer(), 0);
    };
 }
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackView.h
@@ -44,7 +44,7 @@ public:
    using Type = WaveTrackSubViewType;
 
    explicit
-   WaveTrackSubView( WaveTrackView &waveTrackView );
+   WaveTrackSubView(WaveTrackView &waveTrackView);
    
    virtual const Type &SubViewType() const = 0;
 
@@ -70,6 +70,9 @@ protected:
    std::vector<MenuItem> GetMenuItems(
       const wxRect &rect, const wxPoint *pPosition, AudacityProject *pProject )
    override;
+
+   // Which channel of a WaveTrack (it may contain wide clips)
+   const size_t mChannel;
 
 private:
    std::weak_ptr<SubViewCloseHandle> mCloseHandle;
@@ -109,9 +112,14 @@ public:
    static WaveTrackView *Find( WaveTrack *pTrack );
    static const WaveTrackView *Find( const WaveTrack *pTrack );
 
-   explicit
-   WaveTrackView( const std::shared_ptr<Track> &pTrack );
+   //! Construct a view of one channel
+   /*!
+    @param channel which channel of a possibly wide wave track
+    */
+   WaveTrackView(const std::shared_ptr<Track> &pTrack, size_t channel);
    ~WaveTrackView() override;
+
+   size_t GetChannel() const { return mChannel; }
 
    // Preserve some view state too for undo/redo purposes
    void CopyTo( Track &track ) const override;
@@ -231,6 +239,8 @@ private:
    std::weak_ptr<TrackPanelCell> mKeyEventDelegate;
 
    std::weak_ptr<WaveTrackAffordanceHandle> mAffordanceHandle;
+
+   const size_t mChannel;
 };
 
 // Helper for drawing routines

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -26,7 +26,6 @@ public:
       , min(0)
       , max(0)
       , rms(0)
-      , bl(0)
    {
    }
 
@@ -40,7 +39,6 @@ public:
       , min(len)
       , max(len)
       , rms(len)
-      , bl(len)
    {
    }
 
@@ -57,7 +55,6 @@ public:
    std::vector<float> min;
    std::vector<float> max;
    std::vector<float> rms;
-   std::vector<int> bl;
 };
 
 //
@@ -81,7 +78,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
    float *min;
    float *max;
    float *rms;
-   int *bl;
    std::vector<sampleCount> *pWhere;
 
    if (allocated) {
@@ -89,7 +85,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       min = &display.min[0];
       max = &display.max[0];
       rms = &display.rms[0];
-      bl = &display.bl[0];
       pWhere = &display.ownWhere;
    }
    else {
@@ -117,7 +112,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          display.min = &mWaveCache->min[0];
          display.max = &mWaveCache->max[0];
          display.rms = &mWaveCache->rms[0];
-         display.bl = &mWaveCache->bl[0];
          display.where = &mWaveCache->where[0];
          return true;
       }
@@ -146,7 +140,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       min = &mWaveCache->min[0];
       max = &mWaveCache->max[0];
       rms = &mWaveCache->rms[0];
-      bl = &mWaveCache->bl[0];
       pWhere = &mWaveCache->where;
 
       fillWhere(*pWhere, numPixels, 0.0, correction,
@@ -169,7 +162,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          memcpy(&min[copyBegin], &oldCache->min[srcIdx], sizeFloats);
          memcpy(&max[copyBegin], &oldCache->max[srcIdx], sizeFloats);
          memcpy(&rms[copyBegin], &oldCache->rms[srcIdx], sizeFloats);
-         memcpy(&bl[copyBegin], &oldCache->bl[srcIdx], length * sizeof(int));
       }
    }
 
@@ -239,7 +231,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
                min[i] = theMin;
                max[i] = theMax;
                rms[i] = (float)sqrt(sumsq / len);
-               bl[i] = 1; //for now just fake it.
 
                didUpdate=true;
             }
@@ -256,7 +247,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
          if (!::GetWaveDisplay(*sequence, &min[p0],
                                         &max[p0],
                                         &rms[p0],
-                                        &bl[p0],
                                         p1-p0,
                                         &where[p0]))
          {
@@ -270,7 +260,6 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       display.min = min;
       display.max = max;
       display.rms = rms;
-      display.bl = bl;
       display.where = &(*pWhere)[0];
    }
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
@@ -17,11 +17,11 @@ class WaveCache;
 
 struct WaveClipWaveformCache final : WaveClipListener
 {
-   WaveClipWaveformCache();
+   explicit WaveClipWaveformCache(size_t nChannels);
    ~WaveClipWaveformCache() override;
 
    // Cache of values for drawing the waveform
-   std::unique_ptr<WaveCache> mWaveCache;
+   std::vector<std::unique_ptr<WaveCache>> mWaveCaches;
    int mDirty { 0 };
 
    static WaveClipWaveformCache &Get( const WaveClip &clip );
@@ -33,8 +33,8 @@ struct WaveClipWaveformCache final : WaveClipListener
    void Clear();
 
    /** Getting high-level data for screen display */
-   bool GetWaveDisplay(const WaveClip &clip, WaveDisplay &display,
-                       double t0, double pixelsPerSecond);
+   bool GetWaveDisplay(const WaveClip &clip, size_t channel,
+      WaveDisplay &display, double t0, double pixelsPerSecond);
 };
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.h
@@ -19,8 +19,8 @@ class EnvelopeHandle;
 
 class WaveformView final : public WaveTrackSubView
 {
-   WaveformView( const WaveformView& ) = delete;
-   WaveformView &operator=( const WaveformView& ) = delete;
+   WaveformView(const WaveformView&) = delete;
+   WaveformView &operator=(const WaveformView&) = delete;
 
 public:
    using WaveTrackSubView::WaveTrackSubView;
@@ -36,11 +36,11 @@ private:
    void Draw(
       TrackPanelDrawingContext &context,
       const wxRect &rect, unsigned iPass ) override;
-   static void DoDraw(TrackPanelDrawingContext &context,
-                               const WaveTrack *track,
-                               const WaveClip* selectedClip,
-                               const wxRect & rect,
-                               bool muted);
+   static void DoDraw(TrackPanelDrawingContext &context, size_t channel,
+      const WaveTrack *track,
+      const WaveClip* selectedClip,
+      const wxRect & rect,
+      bool muted);
 
    std::vector<UIHandlePtr> DetailedHitTest(
       const TrackPanelMouseState &state,


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

WaveClips can be "wide," spanning multiple channels.

Make WaveClip capable of storing multiple Sequences, and maintaining consistency of their sizes, formats, etc., though
they do not yet ever store more than one.

<!-- Use "x" to fill the checkboxes below like [x] -->

QA:
- [x]  smoke-test playing, recording, generating, applying effects with mono and stereo tracks
- [x] Waveform, spectrogram views scroll and magnify as before
- [x] pasting into mono and stereo wave tracks, also with hidden smart clip data
- [x] Saving, reopening of mono and stereo tracks

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
