### PR TITLE
Remove mono track types

### DIFF
--- a/libraries/lib-audio-graph/AudioGraphChannel.cpp
+++ b/libraries/lib-audio-graph/AudioGraphChannel.cpp
@@ -1,0 +1,12 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file AudioGraphChannel.cpp
+
+ Paul Licameli
+ 
+ **********************************************************************/
+#include "AudioGraphChannel.h"
+
+AudioGraph::Channel::~Channel() = default;

--- a/libraries/lib-audio-graph/AudioGraphChannel.h
+++ b/libraries/lib-audio-graph/AudioGraphChannel.h
@@ -1,0 +1,49 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file AudioGraphChannel.h
+
+ @brief Abstraction of a channel of a wide stream that knows whether it is mono,
+ left, or right
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+#ifndef __AUDACITY_AUDIO_GRAPH_CHANNEL__
+#define __AUDACITY_AUDIO_GRAPH_CHANNEL__
+
+namespace AudioGraph {
+//! Mutually exclusive channel classifications
+enum ChannelType : unsigned
+{
+   MonoChannel,
+   LeftChannel,
+   RightChannel,
+};
+
+struct AUDIO_GRAPH_API Channel {
+   virtual ~Channel();
+   //! Classify this channel
+   virtual ChannelType GetChannelType() const = 0;
+};
+
+//! Whether the channel is mono
+inline bool IsMono(const Channel &channel) {
+   return channel.GetChannelType() == MonoChannel;
+}
+
+//! Whether the channel may play through a left speaker
+inline bool PlaysLeft(const Channel &channel) {
+   const auto type = channel.GetChannelType();
+   return type == MonoChannel || type == LeftChannel;
+}
+//! Whether the channel may play through a right speaker
+inline bool PlaysRight(const Channel &channel) {
+   const auto type = channel.GetChannelType();
+   return type == MonoChannel || type == RightChannel;
+}
+
+}
+
+#endif

--- a/libraries/lib-audio-graph/CMakeLists.txt
+++ b/libraries/lib-audio-graph/CMakeLists.txt
@@ -5,6 +5,8 @@ Utilities for construction of effect processing pipelines
 set( SOURCES
    AudioGraphBuffers.cpp
    AudioGraphBuffers.h
+   AudioGraphChannel.cpp
+   AudioGraphChannel.h
    AudioGraphSink.cpp
    AudioGraphSink.h
    AudioGraphSource.cpp

--- a/libraries/lib-audio-graph/CMakeLists.txt
+++ b/libraries/lib-audio-graph/CMakeLists.txt
@@ -11,12 +11,9 @@ set( SOURCES
    AudioGraphSource.h
    AudioGraphTask.cpp
    AudioGraphTask.h
-   EffectStage.cpp
-   EffectStage.h
 )
 set( LIBRARIES
    lib-math-interface
-   lib-track
 )
 audacity_library( lib-audio-graph "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -58,10 +58,7 @@ callbacks for these events.
 time warp info and AudioIOListener and whether the playback is looped.
 
 *//*******************************************************************/
-
 #include "AudioIO.h"
-
-
 
 #include "AudioIOExt.h"
 #include "AudioIOListener.h"
@@ -2710,13 +2707,11 @@ bool AudioIoCallback::FillOutputBuffers(
       {
          vt = chans[c];
 
-         if (vt->GetChannelIgnoringPan() == Track::LeftChannel ||
-               vt->GetChannelIgnoringPan() == Track::MonoChannel )
+         if (PlaysLeft(*vt))
             AddToOutputChannel( 0, outputMeterFloats, outputFloats,
                tempBufs[c], drop, len, vt, *oldgains[c % 2]);
 
-         if (vt->GetChannelIgnoringPan() == Track::RightChannel ||
-               vt->GetChannelIgnoringPan() == Track::MonoChannel  )
+         if (PlaysRight(*vt))
             AddToOutputChannel( 1, outputMeterFloats, outputFloats,
                tempBufs[c], drop, len, vt, *oldgains[c % 2]);
       }
@@ -3037,12 +3032,9 @@ bool AudioIoCallback::TrackShouldBeSilent( const SampleTrack &wt )
 bool AudioIoCallback::TrackHasBeenFadedOut(
    const SampleTrack &wt, const OldChannelGains &gains)
 {
-   const auto channel = wt.GetChannelIgnoringPan();
-   if ((channel == Track::LeftChannel  || channel == Track::MonoChannel) &&
-      gains[0] != 0.0)
+   if (PlaysLeft(wt) && gains[0] != 0.0)
       return false;
-   if ((channel == Track::RightChannel || channel == Track::MonoChannel) &&
-      gains[1] != 0.0)
+   if (PlaysRight(wt) && gains[1] != 0.0)
       return false;
    return true;
 }

--- a/libraries/lib-effects/MixAndRender.cpp
+++ b/libraries/lib-effects/MixAndRender.cpp
@@ -46,7 +46,7 @@ void MixAndRender(const TrackIterRange<const WaveTrack> &trackRange,
    int numMono = 0;  /* number of mono, centre-panned wave tracks in selection*/
    for(auto wt : trackRange) {
       numWaves++;
-      if (wt->GetChannel() == Track::MonoChannel && wt->GetPan() == 0)
+      if (IsMono(*wt) && wt->GetPan() == 0)
          numMono++;
    }
 

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -294,7 +294,7 @@ bool PerTrackEffect::ProcessTrack(bool multi, const Factory &factory,
    EffectSettings &settings,
    AudioGraph::Source &upstream, AudioGraph::Sink &sink,
    std::optional<sampleCount> genLength,
-   const double sampleRate, const Track &track,
+   const double sampleRate, const SampleTrack &track,
    Buffers &inBuffers, Buffers &outBuffers)
 {
    assert(upstream.AcceptsBuffers(inBuffers));

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -122,8 +122,7 @@ bool PerTrackEffect::ProcessPass(Instance &instance, EffectSettings &settings)
          sampleCount start = 0;
          WaveTrack *pRight{};
 
-         const auto numChannels =
-            AudioGraph::MakeChannelMap(left, multichannel, map);
+         const auto numChannels = MakeChannelMap(left, multichannel, map);
          if (multichannel) {
             assert(numAudioIn > 1);
             if (numChannels == 2) {
@@ -305,7 +304,7 @@ bool PerTrackEffect::ProcessTrack(bool multi, const Factory &factory,
    assert(upstream.AcceptsBlockSize(blockSize));
    assert(blockSize == outBuffers.BlockSize());
 
-   auto pSource = AudioGraph::EffectStage::Create( multi, upstream, inBuffers,
+   auto pSource = EffectStage::Create( multi, upstream, inBuffers,
       factory, settings, sampleRate, genLength, track );
    if (!pSource)
       return false;

--- a/libraries/lib-effects/PerTrackEffect.h
+++ b/libraries/lib-effects/PerTrackEffect.h
@@ -21,6 +21,8 @@
 #include "SampleCount.h"
 #include <functional>
 
+class SampleTrack;
+
 //! Base class for Effects that treat each (mono or stereo) track independently
 //! of other tracks.
 /*!
@@ -81,7 +83,7 @@ private:
       const Factory &factory, EffectSettings &settings,
       AudioGraph::Source &source, AudioGraph::Sink &sink,
       std::optional<sampleCount> genLength,
-      double sampleRate, const Track &track,
+      double sampleRate, const SampleTrack &track,
       Buffers &inBuffers, Buffers &outBuffers);
 };
 #endif

--- a/libraries/lib-sample-track/CMakeLists.txt
+++ b/libraries/lib-sample-track/CMakeLists.txt
@@ -14,21 +14,26 @@ handling resampling to different rates.
 
 These interfaces are sufficient for the audio engine to play and record tracks,
 so the engine will not depend on a particular realization of sample storage.
+
+There is also EffectStage which is used to construct effect processing
+pipelines.
 ]]
 
 set( SOURCES
-   SampleTrack.cpp
-   SampleTrack.h
-   SampleTrackCache.cpp
-   SampleTrackCache.h
-   SampleTrackSource.cpp
-   SampleTrackSource.h
+   EffectStage.cpp
+   EffectStage.h
    Mix.cpp
    Mix.h
    MixerOptions.cpp
    MixerOptions.h
    MixerSource.cpp
    MixerSource.h
+   SampleTrack.cpp
+   SampleTrack.h
+   SampleTrackCache.cpp
+   SampleTrackCache.h
+   SampleTrackSource.cpp
+   SampleTrackSource.h
 )
 set( LIBRARIES
    lib-audio-graph-interface

--- a/libraries/lib-sample-track/EffectStage.cpp
+++ b/libraries/lib-sample-track/EffectStage.cpp
@@ -11,8 +11,6 @@
   Paul Licameli split from PerTrackEffect.cpp
 
 **********************************************************************/
-
-
 #include "EffectStage.h"
 #include "AudacityException.h"
 #include "AudioGraphBuffers.h"

--- a/libraries/lib-sample-track/EffectStage.cpp
+++ b/libraries/lib-sample-track/EffectStage.cpp
@@ -21,7 +21,7 @@
 
 namespace {
 std::vector<std::shared_ptr<EffectInstance>> MakeInstances(
-   const AudioGraph::EffectStage::Factory &factory,
+   const EffectStage::Factory &factory,
    EffectSettings &settings, double sampleRate, const Track &track
    , std::optional<sampleCount> genLength, bool multi)
 {
@@ -41,7 +41,7 @@ std::vector<std::shared_ptr<EffectInstance>> MakeInstances(
          throw std::exception{};
       auto count = pInstance->GetAudioInCount();
       ChannelName map[3]{ ChannelNameEOL, ChannelNameEOL, ChannelNameEOL };
-      AudioGraph::MakeChannelMap(*channel, count > 1, map);
+      MakeChannelMap(*channel, count > 1, map);
       // Give the plugin a chance to initialize
       if (!pInstance->ProcessInitialize(settings, sampleRate, map))
          throw std::exception{};
@@ -66,7 +66,7 @@ std::vector<std::shared_ptr<EffectInstance>> MakeInstances(
 }
 }
 
-AudioGraph::EffectStage::EffectStage(CreateToken, bool multi,
+EffectStage::EffectStage(CreateToken, bool multi,
    Source &upstream, Buffers &inBuffers,
    const Factory &factory, EffectSettings &settings,
    double sampleRate, std::optional<sampleCount> genLength, const Track &track
@@ -84,7 +84,7 @@ AudioGraph::EffectStage::EffectStage(CreateToken, bool multi,
    mInBuffers.Rewind();
 }
 
-auto AudioGraph::EffectStage::Create(bool multi,
+auto EffectStage::Create(bool multi,
    Source &upstream, Buffers &inBuffers,
    const Factory &factory, EffectSettings &settings,
    double sampleRate, std::optional<sampleCount> genLength, const Track &track
@@ -99,7 +99,7 @@ auto AudioGraph::EffectStage::Create(bool multi,
    }
 }
 
-AudioGraph::EffectStage::~EffectStage()
+EffectStage::~EffectStage()
 {
    // Allow the instances to cleanup
    for (auto &pInstance : mInstances)
@@ -107,19 +107,18 @@ AudioGraph::EffectStage::~EffectStage()
          pInstance->ProcessFinalize();
 }
 
-bool AudioGraph::EffectStage::AcceptsBuffers(const Buffers &buffers) const
+bool EffectStage::AcceptsBuffers(const Buffers &buffers) const
 {
    return true;
 }
 
-bool AudioGraph::EffectStage::AcceptsBlockSize(size_t size) const
+bool EffectStage::AcceptsBlockSize(size_t size) const
 {
    // Test the equality of input and output block sizes
    return mInBuffers.BlockSize() == size;
 }
 
-std::optional<size_t>
-AudioGraph::EffectStage::Acquire(Buffers &data, size_t bound)
+std::optional<size_t> EffectStage::Acquire(Buffers &data, size_t bound)
 {
    assert(AcceptsBuffers(data));
    assert(AcceptsBlockSize(data.BlockSize()));
@@ -231,7 +230,7 @@ AudioGraph::EffectStage::Acquire(Buffers &data, size_t bound)
    return { result };
 }
 
-std::optional<size_t> AudioGraph::EffectStage::FetchProcessAndAdvance(
+std::optional<size_t> EffectStage::FetchProcessAndAdvance(
    Buffers &data, size_t bound, bool doZeroes, size_t outBufferOffset)
 {
    std::optional<size_t> oCurBlockSize;
@@ -301,7 +300,7 @@ std::optional<size_t> AudioGraph::EffectStage::FetchProcessAndAdvance(
    return oCurBlockSize;
 }
 
-bool AudioGraph::EffectStage::Process(EffectInstance &instance,
+bool EffectStage::Process(EffectInstance &instance,
    size_t channel, const Buffers &data, size_t curBlockSize,
    size_t outBufferOffset) const
 {
@@ -353,7 +352,7 @@ bool AudioGraph::EffectStage::Process(EffectInstance &instance,
    return (processed == curBlockSize);
 }
 
-sampleCount AudioGraph::EffectStage::Remaining() const
+sampleCount EffectStage::Remaining() const
 {
    // Not correct until at least one call to Acquire() so that mDelayRemaining
    // is assigned.
@@ -365,7 +364,7 @@ sampleCount AudioGraph::EffectStage::Remaining() const
       + DelayRemaining();
 }
 
-bool AudioGraph::EffectStage::Release()
+bool EffectStage::Release()
 {
    // Progress toward termination (Remaining() == 0),
    // if mLastProduced + mLastZeroes > 0,
@@ -376,7 +375,7 @@ bool AudioGraph::EffectStage::Release()
    return true;
 }
 
-unsigned AudioGraph::MakeChannelMap(
+unsigned MakeChannelMap(
    const Track &track, bool multichannel, ChannelName map[3])
 {
    // Iterate either over one track which could be any channel,

--- a/libraries/lib-sample-track/EffectStage.h
+++ b/libraries/lib-sample-track/EffectStage.h
@@ -20,7 +20,7 @@
 #include "SampleCount.h"
 #include <functional>
 
-class Track;
+class SampleTrack;
 
 //! Decorates a source with a non-timewarping effect, which may have latency
 class SAMPLE_TRACK_API EffectStage final : public AudioGraph::Source {
@@ -41,14 +41,14 @@ public:
    EffectStage(CreateToken, bool multi, Source &upstream, Buffers &inBuffers,
       const Factory &factory, EffectSettings &settings,
       double sampleRate,
-      std::optional<sampleCount> genLength, const Track &track);
+      std::optional<sampleCount> genLength, const SampleTrack &track);
 
    //! Satisfies postcondition of constructor or returns null
    static std::unique_ptr<EffectStage> Create(bool multi,
       Source &upstream, Buffers &inBuffers,
       const Factory &factory, EffectSettings &settings,
       double sampleRate,
-      std::optional<sampleCount> genLength, const Track &track);
+      std::optional<sampleCount> genLength, const SampleTrack &track);
 
    EffectStage(const EffectStage&) = delete;
    EffectStage &operator =(const EffectStage &) = delete;
@@ -104,7 +104,7 @@ private:
  @param[out] map terminated with ChannelNameEOL
  */
 SAMPLE_TRACK_API
-unsigned MakeChannelMap(const Track &track, bool multichannel,
+unsigned MakeChannelMap(const SampleTrack &track, bool multichannel,
    // TODO: more-than-two-channels
    ChannelName map[3]);
 

--- a/libraries/lib-sample-track/EffectStage.h
+++ b/libraries/lib-sample-track/EffectStage.h
@@ -22,10 +22,8 @@
 
 class Track;
 
-namespace AudioGraph {
-
 //! Decorates a source with a non-timewarping effect, which may have latency
-class AUDIO_GRAPH_API EffectStage final : public Source {
+class SAMPLE_TRACK_API EffectStage final : public AudioGraph::Source {
    // To force usage of Create() instead
    struct CreateToken {};
 public:
@@ -105,9 +103,9 @@ private:
     of track independently
  @param[out] map terminated with ChannelNameEOL
  */
-AUDIO_GRAPH_API
+SAMPLE_TRACK_API
 unsigned MakeChannelMap(const Track &track, bool multichannel,
    // TODO: more-than-two-channels
    ChannelName map[3]);
-}
+
 #endif

--- a/libraries/lib-sample-track/Mix.cpp
+++ b/libraries/lib-sample-track/Mix.cpp
@@ -299,8 +299,11 @@ size_t Mixer::Process(const size_t maxToProcess)
       else if (PlaysRight(track)) {
          if (numChannels >= 2)
             channelFlags[1] = 1;
-         else
+         else {
+            // !IsMono() and IsRight() implies there are multiple channels
+            assert(false);
             channelFlags[0] = 1;
+         }
       }
       return channelFlags;
    };

--- a/libraries/lib-sample-track/Mix.cpp
+++ b/libraries/lib-sample-track/Mix.cpp
@@ -20,9 +20,9 @@
 #include <cmath>
 #include "EffectStage.h"
 #include "Dither.h"
+#include "Resample.h"
 #include "SampleTrack.h"
 #include "SampleTrackCache.h"
-#include "Resample.h"
 #include "float_cast.h"
 #include <numeric>
 
@@ -286,26 +286,21 @@ size_t Mixer::Process(const size_t maxToProcess)
 
    // Decides which output buffers an input channel accumulates into
    auto findChannelFlags = [&channelFlags, numChannels = mNumChannels]
-   (const bool *map, Track::ChannelType channel){
+   (const bool *map, const SampleTrack &track){
       const auto end = channelFlags + numChannels;
       std::fill(channelFlags, end, 0);
       if (map)
          // ignore left and right when downmixing is customized
          std::copy(map, map + numChannels, channelFlags);
-      else switch(channel) {
-      case Track::MonoChannel:
-      default:
+      else if (IsMono(track))
          std::fill(channelFlags, end, 1);
-         break;
-      case Track::LeftChannel:
+      else if (PlaysLeft(track))
          channelFlags[0] = 1;
-         break;
-      case Track::RightChannel:
+      else if (PlaysRight(track)) {
          if (numChannels >= 2)
             channelFlags[1] = 1;
          else
             channelFlags[0] = 1;
-         break;
       }
       return channelFlags;
    };
@@ -339,7 +334,7 @@ size_t Mixer::Process(const size_t maxToProcess)
             for (size_t c = 0; c < mNumChannels; ++c)
                gains[c] = track->GetChannelGain(c);
          const auto flags =
-            findChannelFlags(upstream.MixerSpec(j), track->GetChannel());
+            findChannelFlags(upstream.MixerSpec(j), *track);
          MixBuffers(mNumChannels, flags, gains, *pFloat, mTemp, result);
       }
 

--- a/libraries/lib-sample-track/Mix.cpp
+++ b/libraries/lib-sample-track/Mix.cpp
@@ -163,7 +163,7 @@ Mixer::Mixer(Inputs inputs,
                : stage.factory();
          };
          auto &pNewDownstream =
-         mStages.emplace_back(AudioGraph::EffectStage::Create(true,
+         mStages.emplace_back(EffectStage::Create(true,
             *pDownstream, stageInput,
             factory, settings, outRate, std::nullopt, *leader
          ));

--- a/libraries/lib-sample-track/Mix.h
+++ b/libraries/lib-sample-track/Mix.h
@@ -18,7 +18,8 @@
 
 class sampleCount;
 class BoundedEnvelope;
-namespace AudioGraph{ class EffectStage; class Source; }
+class EffectStage;
+namespace AudioGraph{ class Source; }
 class MixerSource;
 class TrackList;
 class SampleTrack;
@@ -158,7 +159,7 @@ class SAMPLE_TRACK_API Mixer {
    std::vector<MixerSource> mSources;
    std::vector<EffectSettings> mSettings;
    std::vector<AudioGraph::Buffers> mStageBuffers;
-   std::vector<std::unique_ptr<AudioGraph::EffectStage>> mStages;
+   std::vector<std::unique_ptr<EffectStage>> mStages;
 
    struct Source { MixerSource &upstream; AudioGraph::Source &downstream; };
    std::vector<Source> mDecoratedSources;

--- a/libraries/lib-sample-track/SampleTrack.cpp
+++ b/libraries/lib-sample-track/SampleTrack.cpp
@@ -22,6 +22,17 @@ SampleTrack::SampleTrack(const SampleTrack &other, ProtectedCreationArg &&a)
 
 SampleTrack::~SampleTrack() = default;
 
+AudioGraph::ChannelType SampleTrack::GetChannelType() const
+{
+   if (TrackList::NChannels(*this) == 1)
+      return AudioGraph::MonoChannel;
+   else if (IsLeader())
+      return AudioGraph::LeftChannel;
+   else
+      // TODO more-than-two-channels
+      return AudioGraph::RightChannel;
+}
+
 static const Track::TypeInfo &typeInfo()
 {
    static const Track::TypeInfo info{

--- a/libraries/lib-sample-track/SampleTrack.h
+++ b/libraries/lib-sample-track/SampleTrack.h
@@ -12,6 +12,7 @@ Paul Licameli split from WaveTrack.h
 #ifndef __AUDACITY_SAMPLE_TRACK__
 #define __AUDACITY_SAMPLE_TRACK__
 
+#include "AudioGraphChannel.h"
 #include "SampleCount.h"
 #include "SampleFormat.h"
 #include "PlayableTrack.h"
@@ -29,6 +30,7 @@ using SampleTrackAttachments = ClientData::Site<
 class SAMPLE_TRACK_API SampleTrack /* not final */
    : public PlayableTrack
    , public SampleTrackAttachments
+   , public AudioGraph::Channel
 {
 public:
    using Attachments = SampleTrackAttachments;
@@ -36,6 +38,8 @@ public:
    SampleTrack();
    SampleTrack(const SampleTrack &other, ProtectedCreationArg&&);
    ~SampleTrack() override;
+
+   AudioGraph::ChannelType GetChannelType() const final;
 
    const TypeInfo &GetTypeInfo() const override;
    static const TypeInfo &ClassTypeInfo();

--- a/libraries/lib-sample-track/SampleTrack.h
+++ b/libraries/lib-sample-track/SampleTrack.h
@@ -46,9 +46,6 @@ public:
 
    virtual sampleFormat GetSampleFormat() const = 0;
 
-   /*! May be called from a worker thread */
-   virtual ChannelType GetChannelIgnoringPan() const = 0;
-
    virtual double GetRate() const = 0;
 
    //! @return widest effective SampleFormat in any part of the track

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -8,7 +8,6 @@
   Dominic Mazzoni
 
 **********************************************************************/
-
 #ifndef __AUDACITY_TRACK__
 #define __AUDACITY_TRACK__
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -211,13 +211,6 @@ private:
    //! Alias for my base type
    using AttachedObjects = ::AttachedTrackObjects;
 
-   enum ChannelType
-   {
-      LeftChannel = 0,
-      RightChannel = 1,
-      MonoChannel = 2
-   };
-   
    TrackId GetId() const { return mId; }
  private:
    void SetId( TrackId id ) { mId = id; }
@@ -352,7 +345,6 @@ protected:
     @param completeList only influences debug build consistency checking
     */
    void SetLinkType(LinkType linkType, bool completeList = true);
-   void SetChannel(ChannelType c) noexcept;
 
 private:
    int GetIndex() const;
@@ -377,7 +369,6 @@ private:
  // Keep in Track
 
  protected:
-   ChannelType         mChannel;
    double              mOffset;
 
  public:
@@ -407,7 +398,6 @@ private:
 
 public:
 
-   virtual ChannelType GetChannel() const { return mChannel;}
    virtual double GetOffset() const = 0;
 
    void Offset(double t) { SetOffset(GetOffset() + t); }

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -271,10 +271,6 @@ void WaveTrack::SetOffset(double o)
    mOffset = o;
 }
 
-auto WaveTrack::GetChannelIgnoringPan() const -> ChannelType {
-   return mChannel;
-}
-
 auto WaveTrack::GetChannel() const -> ChannelType
 {
    if( mChannel != Track::MonoChannel )

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -283,14 +283,6 @@ auto WaveTrack::GetChannel() const -> ChannelType
    return mChannel;
 }
 
-void WaveTrack::SetPanFromChannelType()
-{ 
-   if( mChannel == Track::LeftChannel )
-      SetPan( -1.0f );
-   else if( mChannel == Track::RightChannel )
-      SetPan( 1.0f );
-}
-
 bool WaveTrack::LinkConsistencyFix(bool doFix, bool completeList)
 {
    auto err = !WritableSampleTrack::LinkConsistencyFix(doFix, completeList);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -102,7 +102,6 @@ private:
 
    double GetOffset() const override;
    void SetOffset(double o) override;
-   ChannelType GetChannel() const override;
 
    bool LinkConsistencyFix(bool doFix, bool completeList) override;
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -103,7 +103,6 @@ private:
    double GetOffset() const override;
    void SetOffset(double o) override;
    ChannelType GetChannel() const override;
-   void SetPanFromChannelType();
 
    bool LinkConsistencyFix(bool doFix, bool completeList) override;
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -102,7 +102,6 @@ private:
 
    double GetOffset() const override;
    void SetOffset(double o) override;
-   ChannelType GetChannelIgnoringPan() const override;
    ChannelType GetChannel() const override;
    void SetPanFromChannelType();
 

--- a/src/cloud/audiocom/ShareAudioDialog.cpp
+++ b/src/cloud/audiocom/ShareAudioDialog.cpp
@@ -288,24 +288,10 @@ namespace
 {
 int CalculateChannels(const TrackList& trackList)
 {
-   for (auto track : trackList.Any<const WaveTrack>())
-   {
-      const auto channel = track->GetChannel();
-
-      // Looks like we have a stereo track
-      if (channel == Track::LeftChannel || channel == Track::RightChannel)
-         return 2;
-
-      const auto pan = track->GetPan();
-
-      // We found a mono track with non zero pan
-      // We treat equality in the same way Export
-      if (pan != 0.0)
-         return 2;
-   }
-
-   // All the wave tracks were mono with zero pan
-   return 1;
+   auto range = trackList.Any<const WaveTrack>();
+   return std::all_of(range.begin(), range.end(), [](const WaveTrack *track){
+      return IsMono(*track) && track->GetPan() == 0;
+   }) ? 1 : 2;
 }
 }
 

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -187,7 +187,8 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
       {
          // Target half the LUFS value if mono (or independent processed stereo)
          // shall be treated as dual mono.
-         if(range.size() == 1 && (mDualMono || track->GetChannel() != Track::MonoChannel))
+         if (range.size() == 1 &&
+            (mDualMono || !IsMono(*track)))
             mMult /= 2.0;
 
          // LUFS are related to square values so the multiplier must be the root.

--- a/src/effects/SimpleMono.cpp
+++ b/src/effects/SimpleMono.cpp
@@ -53,7 +53,6 @@ bool EffectSimpleMono::Process(EffectInstance &, EffectSettings &)
 
          //Get the track rate and samples
          mCurRate = pOutWaveTrack->GetRate();
-         mCurChannel = pOutWaveTrack->GetChannel();
 
          //NewTrackSimpleMono() will returns true by default
          //ProcessOne() processes a single track

--- a/src/effects/SimpleMono.h
+++ b/src/effects/SimpleMono.h
@@ -42,7 +42,6 @@ protected:
    double mCurRate;
    double mCurT0;
    double mCurT1;
-   int    mCurChannel;
 
 private:
    bool ProcessOne(WaveTrack * t, sampleCount start, sampleCount end);

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -85,7 +85,6 @@ bool EffectTwoPassSimpleMono::ProcessPass(EffectSettings &settings)
 
          //Get the track rate and samples
          mCurRate = track->GetRate();
-         mCurChannel = track->GetChannel();
 
          //NewTrackPass1/2() returns true by default
          bool ret;

--- a/src/effects/TwoPassSimpleMono.h
+++ b/src/effects/TwoPassSimpleMono.h
@@ -72,7 +72,6 @@ protected:
    double mCurRate;
    double mCurT0;
    double mCurT1;
-   int    mCurChannel;
    int    mPass;
    bool   mSecondPassDisabled;
 

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -1348,14 +1348,15 @@ ExportMixerDialog::ExportMixerDialog( const TrackList *tracks, bool selectedOnly
    ) {
       numTracks++;
       const wxString sTrackName = (t->GetName()).Left(20);
-      if( t->GetChannel() == Track::LeftChannel )
+      if (IsMono(*t))
+         // No matter whether it's panned hard left or right
+         mTrackNames.push_back(sTrackName);
+      else if (PlaysLeft(*t))
       /* i18n-hint: track name and L abbreviating Left channel */
          mTrackNames.push_back( wxString::Format( _( "%s - L" ), sTrackName ) );
-      else if( t->GetChannel() == Track::RightChannel )
+      else if (PlaysRight(*t))
       /* i18n-hint: track name and R abbreviating Right channel */
          mTrackNames.push_back( wxString::Format( _( "%s - R" ), sTrackName ) );
-      else
-         mTrackNames.push_back(sTrackName);
    }
 
    // JKC: This is an attempt to fix a 'watching brief' issue, where the slider is

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -494,9 +494,6 @@ bool Exporter::ExamineTracks()
 {
    // Init
    mNumSelected = 0;
-   mNumLeft = 0;
-   mNumRight = 0;
-   mNumMono = 0;
 
    // First analyze the selected audio, perform sanity checks, and provide
    // information as appropriate.
@@ -509,7 +506,8 @@ bool Exporter::ExamineTracks()
 
    auto &tracks = TrackList::Get( *mProject );
 
-   bool anySolo = !(( tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
+   bool anySolo =
+      !((tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo).empty());
 
    for (auto tr :
          tracks.Any< const WaveTrack >()
@@ -517,29 +515,6 @@ bool Exporter::ExamineTracks()
             - ( anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute)
    ) {
       mNumSelected++;
-
-      if (tr->GetChannel() == Track::LeftChannel) {
-         mNumLeft++;
-      }
-      else if (tr->GetChannel() == Track::RightChannel) {
-         mNumRight++;
-      }
-      else if (tr->GetChannel() == Track::MonoChannel) {
-         // It's a mono channel, but it may be panned
-         float pan = tr->GetPan();
-
-         if (pan == -1.0)
-            mNumLeft++;
-         else if (pan == 1.0)
-            mNumRight++;
-         else if (pan == 0)
-            mNumMono++;
-         else {
-            // Panned partially off-center. Mix as stereo.
-            mNumLeft++;
-            mNumRight++;
-         }
-      }
 
       if (tr->GetOffset() < earliestBegin) {
          earliestBegin = tr->GetOffset();

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -905,11 +905,8 @@ ProgressResult ExportMultipleDialog::ExportMultipleByTrack(bool byName,
       setting.t1 = channels.max( &Track::GetEndTime );
 
       // number of export channels?
-      setting.channels = channels.size();
-      if (setting.channels == 1 &&
-          !(tr->GetChannel() == WaveTrack::MonoChannel &&
-                  tr->GetPan() == 0.0))
-         setting.channels = 2;
+      // It's 1 only for a center-panned mono track
+      setting.channels = (IsMono(*tr) && tr->GetPan() == 0.0) ? 1 : 2;
 
       // Get name and title
       title = tr->GetName();

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -791,15 +791,22 @@ void WaveTrackMenuTable::SplitStereo(bool stereo)
    AudacityProject *const project = &mpData->project;
    auto channels = TrackList::Channels( pTrack );
 
-   // Unlink to make pan values independent, before changing them
-   TrackList::Get( *project ).UnlinkChannels( *pTrack );
-
    int totalHeight = 0;
    int nChannels = 0;
-   for (auto channel : channels) {
-      auto &view = TrackView::Get( *channel );
-      if (stereo)
-         channel->SetPanFromChannelType();
+
+   std::vector<WaveTrack *> tracks;
+   for (auto channel : channels)
+      tracks.push_back(channel);
+
+   TrackList::Get(*project).UnlinkChannels(*pTrack);
+
+   float pan = -1.0f;
+   for (auto track : tracks) {
+      auto &view = TrackView::Get(*track);
+      if (stereo) {
+         track->SetPan(pan);
+         pan += 2.0f;
+      }
 
       //make sure no channel is smaller than its minimum height
       if (view.GetHeight() < view.GetMinimizedHeight())

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -973,14 +973,8 @@ void Status1DrawFunction
       // TODO: more-than-two-channels-message
       // more appropriate strings
       s = XO("Stereo, %dHz");
-   else {
-      if (wt->GetChannel() == Track::MonoChannel)
-         s = XO("Mono, %dHz");
-      else if (wt->GetChannel() == Track::LeftChannel)
-         s = XO("Left, %dHz");
-      else if (wt->GetChannel() == Track::RightChannel)
-         s = XO("Right, %dHz");
-   }
+   else
+      s = XO("Mono, %dHz");
    s.Format( (int) (rate + 0.5) );
 
    StatusDrawFunction( s, dc, rect );

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -508,7 +508,6 @@ struct WaveTrackMenuTable
    void OnMultiView(wxCommandEvent & event);
    void OnSetDisplay(wxCommandEvent & event);
 
-   void OnChannelChange(wxCommandEvent & event);
    void OnMergeStereo(wxCommandEvent & event);
 
    // TODO: more-than-two-channels
@@ -631,29 +630,6 @@ BEGIN_POPUP_MENU(WaveTrackMenuTable)
    EndSection();
 
    BeginSection( "Channels" );
-   // If these are enabled again, choose a hot key for Mono that does not conflict
-   // with Multi View
-   //   AppendRadioItem(OnChannelMonoID, XXO("&Mono"),
-   //      POPUP_MENU_FN( OnChannelChange ),
-   //      []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-   //         menu.Enable( id, isMono( handler ) );
-   //         menu.Check( id, findTrack( handler ).GetChannel() == Track::MonoChannel );
-   //      }
-   //   );
-   //   AppendRadioItem(OnChannelLeftID, XXO("&Left Channel"),
-   //      POPUP_MENU_FN( OnChannelChange ),
-   //      []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-   //         menu.Enable( id, isMono( handler ) );
-   //         menu.Check( id, findTrack( handler ).GetChannel() == Track::LeftChannel );
-   //      }
-   //   );
-   //   AppendRadioItem(OnChannelRightID, XXO("R&ight Channel"),
-   //      POPUP_MENU_FN( OnChannelChange ),
-   //      []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-   //         menu.Enable( id, isMono( handler ) );
-   //         menu.Check( id, findTrack( handler ).GetChannel() == Track::RightChannel );
-   //      }
-   //   );
       AppendItem( "MakeStereo", OnMergeStereoID, XXO("Ma&ke Stereo Track"),
          POPUP_MENU_FN( OnMergeStereo ),
          []( PopupMenuHandler &handler, wxMenu &menu, int id ){
@@ -762,41 +738,6 @@ void WaveTrackMenuTable::OnSetDisplay(wxCommandEvent & event)
       }
    }
 }
-
-#if 0
-void WaveTrackMenuTable::OnChannelChange(wxCommandEvent & event)
-{
-   int id = event.GetId();
-   wxASSERT(id >= OnChannelLeftID && id <= OnChannelMonoID);
-   WaveTrack *const pTrack = static_cast<WaveTrack*>(mpData->pTrack);
-   wxASSERT(pTrack);
-   Track::ChannelType channel;
-   TranslatableString channelmsg;
-   switch (id) {
-   default:
-   case OnChannelMonoID:
-      channel = Track::MonoChannel;
-      channelmsg = XO("Mono");
-      break;
-   case OnChannelLeftID:
-      channel = Track::LeftChannel;
-      channelmsg = XO("Left Channel");
-      break;
-   case OnChannelRightID:
-      channel = Track::RightChannel;
-      channelmsg = XO("Right Channel");
-      break;
-   }
-   pTrack->SetChannel(channel);
-   AudacityProject *const project = &mpData->project;
-   ProjectHistory::Get( *project )
-      .PushState(
-/* i18n-hint: The strings name a track and a channel choice (mono, left, or right) */
-         XO("Changed '%s' to %s").Format( pTrack->GetName(), channelmsg ),
-         XO("Channel"));
-   mpData->result = RefreshCode::RefreshAll;
-}
-#endif
 
 /// Merge two tracks into one stereo track ??
 void WaveTrackMenuTable::OnMergeStereo(wxCommandEvent &)


### PR DESCRIPTION
Resolves: #4756

Remove another nuisance in the way of the restructuring for wide wave clips: a three-state distcintion among mono tracks.

Also makes lib-audio-graph not dependent on lib-track.

Besides fixing the recent regression issue 4756, it's not completely neutral behaviorally, as noted in commit comments.

The Track controls always say "Mono", not "Left" or "Right" when you make a hard pan in one direction.  Copy and paste of
hard-panned mono tracks no longer makes tracks with the legacy three-state set differently.

Phaser and WahWah might compute slightly different results for hard-right panned mono tracks, or
Loudness for hard left or right.

I don't care about those subtleties and I hope you don't either.

QA: besides the bug fix, exercise these things to be sure of no unintended changes of behavior
- Test export (especially "Export Multiple..."), mixing and rendering with some stacked effects in mono and stereo tracks
- Test all the above and also playback with changes of the pan slider
- Test the obscure Export Mixer dialog ("Use advanced mixing options" in Import/Export preferences)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
