### PR TITLE
[lib-utility] Support libstdc++ on Windows

### DIFF
--- a/libraries/lib-utility/MemoryX.h
+++ b/libraries/lib-utility/MemoryX.h
@@ -486,7 +486,8 @@ OutContainer transform_container( InContainer &inContainer, Function &&fn )
  macOS builds under current limitations of the C++17 standard implementation.
  */
 struct UTILITY_API alignas(
-#ifdef _WIN32
+#if defined(_WIN32) && defined(_MSC_VER)
+   // MSVC supports this symbol in std, but MinGW uses libstdc++, which it does not.
    std::hardware_destructive_interference_size
 #else
    // That constant isn't defined for the other builds yet


### PR DESCRIPTION
MSVC supports `std::hardware_destructive_interference_size`, but MinGW uses libstdc++, which it does not.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
