### PR TITLE
Fix bug introduced at 255880d -- unpanned mono exporting as stereo...

### DIFF
--- a/src/export/Export.h
+++ b/src/export/Export.h
@@ -263,9 +263,8 @@ private:
    int mFilterIndex;
    int mFormat;
    int mSubFormat;
-   int mNumSelected;
-   unsigned mNumLeft;
-   unsigned mNumRight;
+   int mNumSelected{};
+   bool mMono{};
    unsigned mNumMono;
    unsigned mChannels;
    bool mSelectedOnly;


### PR DESCRIPTION
... there were uninitialized member variables, now they are removed.

Resolves: #4792

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
