### PR TITLE
Audio io does not use track

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -2492,7 +2492,7 @@ void AudioIoCallback::AddToOutputChannel(unsigned int chan,
    bool drop,
    unsigned long len,
    const PlayableSequence &ps,
-   OldChannelGains &gains)
+   float &channelGain)
 {
    const auto numPlaybackChannels = mNumPlaybackChannels;
 
@@ -2511,12 +2511,11 @@ void AudioIoCallback::AddToOutputChannel(unsigned int chan,
    // Let's keep the old behavior for panning.
    gain *= ExpGain(GetMixerOutputVol());
 
-   float oldGain = gains[chan];
-   if( gain != oldGain )
-      gains[chan] = gain;
+   float oldGain = channelGain;
+   channelGain = gain;
    // if no microfades, jump in volume.
-   if( !mbMicroFades )
-      oldGain =gain;
+   if (!mbMicroFades)
+      oldGain = gain;
    wxASSERT(len > 0);
 
    // Linear interpolate.
@@ -2700,11 +2699,11 @@ bool AudioIoCallback::FillOutputBuffers(
 
          if (PlaysLeft(*vt))
             AddToOutputChannel(0, outputMeterFloats, outputFloats,
-               tempBufs[c], drop, len, *vt, *oldgains[c % 2]);
+               tempBufs[c], drop, len, *vt, (*oldgains[c % 2])[0]);
 
          if (PlaysRight(*vt))
             AddToOutputChannel(1, outputMeterFloats, outputFloats,
-               tempBufs[c], drop, len, *vt, *oldgains[c % 2]);
+               tempBufs[c], drop, len, *vt, (*oldgains[c % 2])[1]);
       }
 
       CallbackCheckCompletion(mCallbackReturn, len);

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1477,14 +1477,11 @@ void AudioIO::StopStream()
    // Everything is taken care of.  Now, just free all the resources
    // we allocated in StartStream()
    //
-   if (mPlaybackSequences.size() > 0)
-   {
-      mPlaybackBuffers.clear();
-      mScratchBuffers.clear();
-      mScratchPointers.clear();
-      mPlaybackMixers.clear();
-      mPlaybackSchedule.mTimeQueue.Clear();
-   }
+   mPlaybackBuffers.clear();
+   mScratchBuffers.clear();
+   mScratchPointers.clear();
+   mPlaybackMixers.clear();
+   mPlaybackSchedule.mTimeQueue.Clear();
 
    if (mStreamToken > 0)
    {

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -886,7 +886,7 @@ int AudioIO::StartStream(const TransportTracks &tracks,
    auto pListener = GetListener();
 
    if (tracks.playbackTracks.size() > 0
-      || tracks.otherPlayableTracks.size() > 0)
+      || tracks.otherPlayableSequences.size() > 0)
       playbackChannels = 2;
 
    if (mSoftwarePlaythrough)

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -147,7 +147,7 @@ struct AudioIoCallback::TransportState {
             unsigned chanCnt = TrackList::NChannels(*vt);
             i += chanCnt; // Visit leaders only
             mpRealtimeInitialization
-               ->AddTrack(*vt, numPlaybackChannels, sampleRate);
+               ->AddSequence(*vt, numPlaybackChannels, sampleRate);
          }
       }
    }
@@ -342,35 +342,37 @@ AudioIO::~AudioIO()
 }
 
 std::shared_ptr<RealtimeEffectState>
-AudioIO::AddState(AudacityProject &project, Track *pTrack, const PluginID & id)
+AudioIO::AddState(AudacityProject &project,
+   WideSampleSequence *pSequence, const PluginID & id)
 {
    RealtimeEffects::InitializationScope *pInit = nullptr;
    if (mpTransportState && mpTransportState->mpRealtimeInitialization)
       if (auto pProject = GetOwningProject(); pProject.get() == &project)
          pInit = &*mpTransportState->mpRealtimeInitialization;
-   return RealtimeEffectManager::Get(project).AddState(pInit, pTrack, id);
+   return RealtimeEffectManager::Get(project).AddState(pInit, pSequence, id);
 }
 
 std::shared_ptr<RealtimeEffectState>
 AudioIO::ReplaceState(AudacityProject &project,
-   Track *pTrack, size_t index, const PluginID & id)
+   WideSampleSequence *pSequence, size_t index, const PluginID & id)
 {
    RealtimeEffects::InitializationScope *pInit = nullptr;
    if (mpTransportState && mpTransportState->mpRealtimeInitialization)
       if (auto pProject = GetOwningProject(); pProject.get() == &project)
          pInit = &*mpTransportState->mpRealtimeInitialization;
    return RealtimeEffectManager::Get(project)
-      .ReplaceState(pInit, pTrack, index, id);
+      .ReplaceState(pInit, pSequence, index, id);
 }
 
 void AudioIO::RemoveState(AudacityProject &project,
-   Track *pTrack, const std::shared_ptr<RealtimeEffectState> pState)
+   WideSampleSequence *pSequence,
+   const std::shared_ptr<RealtimeEffectState> pState)
 {
    RealtimeEffects::InitializationScope *pInit = nullptr;
    if (mpTransportState && mpTransportState->mpRealtimeInitialization)
       if (auto pProject = GetOwningProject(); pProject.get() == &project)
          pInit = &*mpTransportState->mpRealtimeInitialization;
-   RealtimeEffectManager::Get(project).RemoveState(pInit, pTrack, pState);
+   RealtimeEffectManager::Get(project).RemoveState(pInit, pSequence, pState);
 }
 
 void AudioIO::SetMixer(int inputSource, float recordVolume,

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1523,8 +1523,7 @@ void AudioIO::StopStream()
          }
 
 
-         if (!mLostCaptureIntervals.empty())
-         {
+         if (!mLostCaptureIntervals.empty()) {
             // This scope may combine many splittings of wave tracks
             // into one transaction, lessening the number of checkpoints
             std::optional<TransactionScope> pScope;
@@ -1535,7 +1534,7 @@ void AudioIO::StopStream()
                auto duration = interval.second;
                for (auto &track : mCaptureTracks) {
                   GuardedCall([&] {
-                     track->SyncLockAdjust(start, start + duration);
+                     track->InsertSilence(start, duration);
                   });
                }
             }

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -263,11 +263,13 @@ public:
    std::thread mAudioThread;
    std::atomic<bool> mFinishAudioThread{ false };
 
-   ArrayOf<std::unique_ptr<Resample>> mResample;
-   ArrayOf<std::unique_ptr<RingBuffer>> mCaptureBuffers;
+   std::vector<std::unique_ptr<Resample>> mResample;
+
+   using RingBuffers = std::vector<std::unique_ptr<RingBuffer>>;
+   RingBuffers mCaptureBuffers;
    RecordableSequences mCaptureSequences;
    /*! Read by worker threads but unchanging during playback */
-   ArrayOf<std::unique_ptr<RingBuffer>> mPlaybackBuffers;
+   RingBuffers mPlaybackBuffers;
    ConstPlayableSequences      mPlaybackSequences;
    // Old gain is used in playback in linearly interpolating
    // the gain.
@@ -336,6 +338,8 @@ public:
    PaError             mLastPaError;
 
 protected:
+   static size_t MinValue(
+      const RingBuffers &buffers, size_t (RingBuffer::*pmf)() const);
 
    float GetMixerOutputVol() {
       return mMixerOutputVol.load(std::memory_order_relaxed); }

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -193,6 +193,9 @@ public:
       unsigned long framesPerBuffer
    );
 
+   /*!
+    @param[in,out] channelGain
+    */
    void AddToOutputChannel( unsigned int chan, // index into gains
       float * outputMeterFloats,
       float * outputFloats,
@@ -200,7 +203,7 @@ public:
       bool drop,
       unsigned long len,
       const PlayableSequence &ps,
-      OldChannelGains &gains
+      float &channelGain
    );
    bool FillOutputBuffers(
       float *outputBuffer,

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -184,8 +184,8 @@ public:
 
    using OldChannelGains = std::array<float, 2>;
    bool SequenceShouldBeSilent(const PlayableSequence &ps);
-   bool SequenceHasBeenFadedOut(
-      const PlayableSequence &ps, const OldChannelGains &gains);
+   //! Returns true when playback buffer data from both channels is discardable
+   bool SequenceHasBeenFadedOut(const OldChannelGains &gains);
    bool AllSequencesAlreadySilent();
 
    void CheckSoundActivatedRecordingLevel(

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -33,14 +33,11 @@ class AudioIOBase;
 class AudioIO;
 class RingBuffer;
 class Mixer;
+class OtherPlayableSequence;
 class RealtimeEffectState;
 class Resample;
 
 class AudacityProject;
-
-class PlayableTrack;
-using PlayableTrackConstArray =
-   std::vector < std::shared_ptr < const PlayableTrack > >;
 
 class Track;
 class SampleTrack;
@@ -80,7 +77,8 @@ struct AudioIOEvent {
 struct AUDIO_IO_API TransportTracks final {
    SampleTrackConstArray playbackTracks;
    WritableSampleTrackArray captureTracks;
-   PlayableTrackConstArray otherPlayableTracks;
+   std::vector<std::shared_ptr<const OtherPlayableSequence>>
+      otherPlayableSequences;
 
    // This is a subset of playbackTracks
    SampleTrackConstArray prerollTracks;

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -438,7 +438,8 @@ public:
     @post result: `!result || result->GetEffect() != nullptr`
     */
    std::shared_ptr<RealtimeEffectState>
-   AddState(AudacityProject &project, Track *pTrack, const PluginID & id);
+   AddState(AudacityProject &project,
+      WideSampleSequence *pSequence, const PluginID & id);
 
    //! Forwards to RealtimeEffectManager::ReplaceState with proper init scope
    /*!
@@ -446,11 +447,12 @@ public:
     */
    std::shared_ptr<RealtimeEffectState>
    ReplaceState(AudacityProject &project,
-      Track *pTrack, size_t index, const PluginID & id);
+      WideSampleSequence *pSequence, size_t index, const PluginID & id);
 
    //! Forwards to RealtimeEffectManager::RemoveState with proper init scope
    void RemoveState(AudacityProject &project,
-      Track *pTrack, std::shared_ptr<RealtimeEffectState> pState);
+      WideSampleSequence *pSequence,
+      std::shared_ptr<RealtimeEffectState> pState);
 
    /** \brief Start up Portaudio for capture and recording as needed for
     * input monitoring and software playthrough only

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -465,7 +465,11 @@ public:
     * Allocates buffers for recording and playback, gets the Audio thread to
     * fill them, and sets the stream rolling.
     * If successful, returns a token identifying this particular stream
-    * instance.  For use with IsStreamActive() */
+    * instance.  For use with IsStreamActive()
+    *
+    * @pre `p && p->IsLeader()` for all pointers `p` in
+    * `sequences.playbackSequences`
+    */
 
    int StartStream(const TransportSequences &sequences,
       double t0, double t1,

--- a/libraries/lib-audio-io/AudioIOExt.h
+++ b/libraries/lib-audio-io/AudioIOExt.h
@@ -23,7 +23,7 @@
 struct PaStreamCallbackTimeInfo;
 struct PaStreamInfo;
 struct PlaybackSchedule;
-struct TransportTracks;
+struct TransportSequences;
 
 class AUDIO_IO_API AudioIOExt : public AudioIOExtBase
 {
@@ -49,7 +49,7 @@ public:
    virtual unsigned CountOtherSoloTracks() const = 0;
 
    // Formerly in AudioIO
-   virtual bool StartOtherStream(const TransportTracks &tracks,
+   virtual bool StartOtherStream(const TransportSequences &tracks,
       const PaStreamInfo* info, double startTime, double rate) = 0;
    virtual void AbortOtherStream() = 0;
    virtual void FillOtherBuffers(

--- a/libraries/lib-audio-io/AudioIOExt.h
+++ b/libraries/lib-audio-io/AudioIOExt.h
@@ -46,7 +46,7 @@ public:
       const PaStreamCallbackTimeInfo *timeInfo,
       unsigned long framesPerBuffer) = 0;
    virtual void SignalOtherCompletion() = 0;
-   virtual unsigned CountOtherSoloTracks() const = 0;
+   virtual unsigned CountOtherSolo() const = 0;
 
    // Formerly in AudioIO
    virtual bool StartOtherStream(const TransportSequences &tracks,

--- a/libraries/lib-audio-io/AudioIOListener.cpp
+++ b/libraries/lib-audio-io/AudioIOListener.cpp
@@ -1,0 +1,12 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  AudioIOListener.cpp
+
+  Dominic Mazzoni
+
+**********************************************************************/
+#include "AudioIOListener.h"
+
+AudioIOListener::~AudioIOListener() = default;

--- a/libraries/lib-audio-io/AudioIOListener.h
+++ b/libraries/lib-audio-io/AudioIOListener.h
@@ -15,9 +15,8 @@
 #include <memory>
 #include <vector>
 
-class WritableSampleTrack;
-using WritableSampleTrackArray =
-   std::vector<std::shared_ptr<WritableSampleTrack>>;
+class RecordableSequence;
+using RecordableSequences = std::vector<std::shared_ptr<RecordableSequence>>;
 
 class AUDIO_IO_API AudioIOListener /* not final */ {
 public:
@@ -29,7 +28,7 @@ public:
 
    virtual void OnAudioIOStartRecording() = 0;
    virtual void OnAudioIOStopRecording() = 0;
-   virtual void OnAudioIONewBlocks(const WritableSampleTrackArray *tracks) = 0;
+   virtual void OnAudioIONewBlocks(const RecordableSequences &sequences) = 0;
 
    // Commit the addition of temporary recording tracks into the project
    virtual void OnCommitRecording() = 0;

--- a/libraries/lib-audio-io/AudioIOListener.h
+++ b/libraries/lib-audio-io/AudioIOListener.h
@@ -9,18 +9,20 @@
   Use the PortAudio library to play and record sound
 
 **********************************************************************/
-
 #ifndef __AUDACITY_AUDIO_IO_LISTENER__
 #define __AUDACITY_AUDIO_IO_LISTENER__
 
+#include <memory>
+#include <vector>
+
 class WritableSampleTrack;
 using WritableSampleTrackArray =
-   std::vector < std::shared_ptr < WritableSampleTrack > >;
+   std::vector<std::shared_ptr<WritableSampleTrack>>;
 
 class AUDIO_IO_API AudioIOListener /* not final */ {
 public:
    AudioIOListener() {}
-   virtual ~AudioIOListener() {}
+   virtual ~AudioIOListener();
 
    // Pass 0 when audio stops, positive when it starts:
    virtual void OnAudioIORate(int rate) = 0;

--- a/libraries/lib-audio-io/CMakeLists.txt
+++ b/libraries/lib-audio-io/CMakeLists.txt
@@ -12,6 +12,7 @@ set( SOURCES
    AudioIO.h
    AudioIOExt.cpp
    AudioIOExt.h
+   AudioIOListener.cpp
    AudioIOListener.h
    PlaybackSchedule.cpp
    PlaybackSchedule.h

--- a/libraries/lib-audio-io/CMakeLists.txt
+++ b/libraries/lib-audio-io/CMakeLists.txt
@@ -24,7 +24,6 @@ set( SOURCES
 set( LIBRARIES
    lib-project-rate-interface
    lib-realtime-effects
-   lib-sample-track-interface
 )
 audacity_library( lib-audio-io "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-audio-io/PlaybackSchedule.cpp
+++ b/libraries/lib-audio-io/PlaybackSchedule.cpp
@@ -63,8 +63,8 @@ bool PlaybackPolicy::AllowSeek(PlaybackSchedule &)
 bool PlaybackPolicy::Done( PlaybackSchedule &schedule,
    unsigned long outputFrames)
 {
-   // Called from portAudio thread, use GetTrackTime()
-   auto diff = schedule.GetTrackTime() - schedule.mT1;
+   // Called from portAudio thread, use GetSequenceTime()
+   auto diff = schedule.GetSequenceTime() - schedule.mT1;
    if (schedule.ReversedTime())
       diff *= -1;
    return sampleCount(floor(diff * mRate + 0.5)) >= 0 &&
@@ -72,10 +72,10 @@ bool PlaybackPolicy::Done( PlaybackSchedule &schedule,
       outputFrames == 0;
 }
 
-double PlaybackPolicy::OffsetTrackTime(
+double PlaybackPolicy::OffsetSequenceTime(
    PlaybackSchedule &schedule, double offset )
 {
-   const auto time = schedule.GetTrackTime() + offset;
+   const auto time = schedule.GetSequenceTime() + offset;
    schedule.RealTimeInit( time );
    return time;
 }
@@ -192,7 +192,7 @@ void PlaybackSchedule::Init(
       mT1 -= pRecordingSchedule->mLatencyCorrection;
 
    // Main thread's initialization of mTime
-   SetTrackTime( mT0 );
+   SetSequenceTime( mT0 );
 
    if (options.policyFactory)
       mpPlaybackPolicy = options.policyFactory(options);

--- a/libraries/lib-audio-io/PlaybackSchedule.h
+++ b/libraries/lib-audio-io/PlaybackSchedule.h
@@ -33,7 +33,7 @@ struct RecordingSchedule {
    PRCrossfadeData mCrossfadeData;
 
    // These are initialized by the main thread, then updated
-   // only by the thread calling TrackBufferExchange:
+   // only by the thread calling SequenceBufferExchange:
    double mPosition{};
    bool mLatencyCorrected{};
 
@@ -99,20 +99,20 @@ public:
    //! Whether repositioning commands are allowed during playback
    virtual bool AllowSeek( PlaybackSchedule &schedule );
 
-   //! Returns true if schedule.GetTrackTime() has reached the end of playback
+   //! Returns true if schedule.GetSequenceTime() has reached the end of playback
    virtual bool Done( PlaybackSchedule &schedule,
       unsigned long outputFrames //!< how many playback frames were taken from RingBuffers
    );
 
    //! Called when the play head needs to jump a certain distance
-   /*! @param offset signed amount requested to be added to schedule::GetTrackTime()
+   /*! @param offset signed amount requested to be added to schedule::GetSequenceTime()
       @return the new value that will be set as the schedule's track time
     */
-   virtual double OffsetTrackTime( PlaybackSchedule &schedule, double offset );
+   virtual double OffsetSequenceTime( PlaybackSchedule &schedule, double offset );
 
-   //! @section Called by the AudioIO::TrackBufferExchange thread
+   //! @section Called by the AudioIO::SequenceBufferExchange thread
 
-   //! How long to wait between calls to AudioIO::TrackBufferExchange
+   //! How long to wait between calls to AudioIO::SequenceBufferExchange
    virtual std::chrono::milliseconds
       SleepInterval( PlaybackSchedule &schedule );
 
@@ -214,7 +214,7 @@ struct AUDIO_IO_API PlaybackSchedule {
       void Clear();
       void Resize(size_t size);
 
-      //! @section Called by the AudioIO::TrackBufferExchange thread
+      //! @section Called by the AudioIO::SequenceBufferExchange thread
 
       //! Enqueue track time value advanced by the slice according to `schedule`'s PlaybackPolicy
       void Producer( PlaybackSchedule &schedule, PlaybackSlice slice );
@@ -289,12 +289,12 @@ struct AUDIO_IO_API PlaybackSchedule {
     *
     * Returns a time in seconds.
     */
-   double GetTrackTime() const
+   double GetSequenceTime() const
    { return mTime.load(std::memory_order_relaxed); }
 
    /** \brief Set current track time value, unadjusted
     */
-   void SetTrackTime( double time )
+   void SetSequenceTime( double time )
    { mTime.store(time, std::memory_order_relaxed); }
 
    void ResetMode() {

--- a/libraries/lib-audio-io/RingBuffer.cpp
+++ b/libraries/lib-audio-io/RingBuffer.cpp
@@ -43,12 +43,12 @@ RingBuffer::~RingBuffer()
 // Calculations of free and filled space, given snapshots taken of the start
 // and end values
 
-size_t RingBuffer::Filled( size_t start, size_t end )
+size_t RingBuffer::Filled(size_t start, size_t end) const
 {
    return (end + mBufferSize - start) % mBufferSize;
 }
 
-size_t RingBuffer::Free( size_t start, size_t end )
+size_t RingBuffer::Free(size_t start, size_t end) const
 {
    return std::max<size_t>(mBufferSize - Filled( start, end ), 4) - 4;
 }
@@ -61,7 +61,7 @@ size_t RingBuffer::Free( size_t start, size_t end )
 // so that any reading done in Get() happens-before any reuse of the space.
 //
 
-size_t RingBuffer::AvailForPut()
+size_t RingBuffer::AvailForPut() const
 {
    auto start = mStart.load( std::memory_order_relaxed );
    return Free( start, mWritten );
@@ -70,7 +70,7 @@ size_t RingBuffer::AvailForPut()
    // never decrease it, so writer can safely assume this much at least
 }
 
-size_t RingBuffer::WrittenForGet()
+size_t RingBuffer::WrittenForGet() const
 {
    auto start = mStart.load( std::memory_order_relaxed );
    return Filled( start, mWritten );
@@ -223,7 +223,7 @@ void RingBuffer::Flush()
 // if we do more than merely query the size or throw samples away
 //
 
-size_t RingBuffer::AvailForGet()
+size_t RingBuffer::AvailForGet() const
 {
    auto end = mEnd.load( std::memory_order_relaxed ); // get away with it here
    auto start = mStart.load( std::memory_order_relaxed );

--- a/libraries/lib-audio-io/RingBuffer.h
+++ b/libraries/lib-audio-io/RingBuffer.h
@@ -23,9 +23,9 @@ class RingBuffer final : public NonInterferingBase {
    // For the writer only:
    //
 
-   size_t AvailForPut();
+   size_t AvailForPut() const;
    //! Reader may concurrently cause a decrease of what this returns
-   size_t WrittenForGet();
+   size_t WrittenForGet() const;
    //! Does not apply dithering
    size_t Put(constSamplePtr buffer, sampleFormat format, size_t samples,
               // optional number of trailing zeroes
@@ -46,14 +46,14 @@ class RingBuffer final : public NonInterferingBase {
    // For the reader only:
    //
 
-   size_t AvailForGet();
+   size_t AvailForGet() const;
    //! Does not apply dithering
    size_t Get(samplePtr buffer, sampleFormat format, size_t samples);
    size_t Discard(size_t samples);
 
  private:
-   size_t Filled( size_t start, size_t end );
-   size_t Free( size_t start, size_t end );
+   size_t Filled(size_t start, size_t end) const;
+   size_t Free(size_t start, size_t end) const;
 
    size_t mWritten{0};
    size_t mLastPadding{0};

--- a/libraries/lib-mixer/AudioIOSequences.cpp
+++ b/libraries/lib-mixer/AudioIOSequences.cpp
@@ -1,0 +1,14 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  AudioIOSequences.cpp
+
+  Paul Licameli
+
+**********************************************************************/
+#include "AudioIOSequences.h"
+
+PlayableSequence::~PlayableSequence() = default;
+
+RecordableSequence::~RecordableSequence() = default;

--- a/libraries/lib-mixer/AudioIOSequences.cpp
+++ b/libraries/lib-mixer/AudioIOSequences.cpp
@@ -12,3 +12,5 @@
 PlayableSequence::~PlayableSequence() = default;
 
 RecordableSequence::~RecordableSequence() = default;
+
+OtherPlayableSequence::~OtherPlayableSequence() = default;

--- a/libraries/lib-mixer/AudioIOSequences.h
+++ b/libraries/lib-mixer/AudioIOSequences.h
@@ -71,4 +71,11 @@ struct MIXER_API RecordableSequence {
 
 using RecordableSequences = std::vector<std::shared_ptr<RecordableSequence>>;
 
+//! This is defined just to enable `dynamic_cast` on it
+class MIXER_API OtherPlayableSequence
+{
+public:
+   virtual ~OtherPlayableSequence();
+};
+
 #endif

--- a/libraries/lib-mixer/AudioIOSequences.h
+++ b/libraries/lib-mixer/AudioIOSequences.h
@@ -1,0 +1,74 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  AudioIOSequences.h
+
+  Paul Licameli
+
+  @brief interfaces for playable and recordable sample channel groups
+
+**********************************************************************/
+#ifndef __AUDACITY_AUDIO_IO_SEQUENCES__
+#define __AUDACITY_AUDIO_IO_SEQUENCES__
+
+#include "WideSampleSequence.h"
+
+/*!
+ Extends the interface for random access into a sample stream with tests for
+ muting and solo
+ */
+struct MIXER_API PlayableSequence : WideSampleSequence {
+   ~PlayableSequence() override;
+
+   virtual bool IsLeader() const = 0; //!< To be removed
+
+   //! May vary asynchronously
+   virtual bool GetSolo() const = 0;
+
+   //! May vary asynchronously
+   virtual bool GetMute() const = 0;
+};
+
+using ConstPlayableSequences =
+   std::vector<std::shared_ptr<const PlayableSequence>>;
+
+/*!
+ An interface for recording, by appending sequentially
+ (but it also requires random access for insertion of silence)
+ */
+struct MIXER_API RecordableSequence {
+   virtual ~RecordableSequence();
+   virtual sampleFormat GetSampleFormat() const = 0;
+   virtual double GetRate() const = 0;
+
+   //! A constant property
+   /*!
+    @post result: `result > 0`
+    */
+   virtual size_t NChannels() const = 0;
+
+   /** @brief Append the sample data to the track. You must call Flush()
+    * after the last Append.
+    *
+    * @return true in case a block was flushed from memory to underlying DB
+    */
+   virtual bool Append(constSamplePtr buffer, sampleFormat format,
+      size_t len, unsigned int stride = 1,
+      sampleFormat effectiveFormat = widestSampleFormat /*!<
+         Make the effective format of the data at least the minumum of this
+         value and `format`.  (Maybe wider, if merging with preexistent data.)
+         If the data are later narrowed from stored format, but not narrower
+         than the effective, then no dithering will occur.
+      */
+   ) = 0;
+
+   //! Flush must be called after last Append
+   virtual void Flush() = 0;
+
+   virtual void InsertSilence(double t, double len) = 0;
+};
+
+using RecordableSequences = std::vector<std::shared_ptr<RecordableSequence>>;
+
+#endif

--- a/libraries/lib-mixer/CMakeLists.txt
+++ b/libraries/lib-mixer/CMakeLists.txt
@@ -1,4 +1,8 @@
 #[[
+AudioIOSequences defines interfaces to random-access readable, and sequentially
+writable, sequences of samples, that are sufficient for the needs of the audio
+engine.
+
 SampleTrackCache holds a buffer in memory fetched from a SampleTrack, so
 repeated fetches of small but nearby sub-ranges can be satisfied with fewer
 but larger fetches from SampleTrack, aligned to underlying database block
@@ -16,6 +20,8 @@ class Curve should be extracted from it and lowered into lib-math.
 ]]
 
 set( SOURCES
+   AudioIOSequences.cpp
+   AudioIOSequences.h
    EffectStage.cpp
    EffectStage.h
    Envelope.cpp

--- a/libraries/lib-mixer/CMakeLists.txt
+++ b/libraries/lib-mixer/CMakeLists.txt
@@ -35,6 +35,7 @@ set( SOURCES
 )
 set( LIBRARIES
    lib-audio-graph-interface
+   lib-registries-interface
    lib-xml-interface
 )
 audacity_library( lib-mixer "${SOURCES}" "${LIBRARIES}"

--- a/libraries/lib-mixer/WideSampleSequence.h
+++ b/libraries/lib-mixer/WideSampleSequence.h
@@ -11,16 +11,27 @@ Paul Licameli split from SampleFrame.h
 #define __AUDACITY_WIDE_SAMPLE_SEQUENCE_
 
 #include "AudioGraphChannel.h"
+#include "ClientData.h"
 #include "SampleCount.h"
 #include "SampleFormat.h"
+
+struct WideSampleSequence;
+
+//! Hosting of objects attached by higher level code
+using SequenceAttachments = ClientData::Site<
+   WideSampleSequence, ClientData::Cloneable<>, ClientData::DeepCopying
+>;
 
 //! An interface for random-access fetches from a collection of streams of
 //! samples, associated with the same time; also defines an envelope that
 //! applies to all the streams.
 class MIXER_API WideSampleSequence
    : public AudioGraph::Channel
+   , public SequenceAttachments
 {
 public:
+   using Attachments = SequenceAttachments;
+
    virtual ~WideSampleSequence();
 
    //! A constant property

--- a/libraries/lib-mixer/WideSampleSequence.h
+++ b/libraries/lib-mixer/WideSampleSequence.h
@@ -40,7 +40,8 @@ public:
     */
    virtual size_t NChannels() const = 0;
 
-   //! Extra gain factor to apply to a channel when mixing
+   //! Extra gain factor to apply to a channel when mixing,
+   //! may change asynchronously
    virtual float GetChannelGain(int channel) const = 0;
 
    /*!

--- a/libraries/lib-realtime-effects/CMakeLists.txt
+++ b/libraries/lib-realtime-effects/CMakeLists.txt
@@ -12,9 +12,9 @@ set( SOURCES
    RealtimeEffectState.h
 )
 set( LIBRARIES
-   lib-math-interface
+   lib-mixer-interface
    lib-module-manager-interface
-   lib-track-interface
+   lib-project-history-interface
 )
 audacity_library( lib-realtime-effects "${SOURCES}" "${LIBRARIES}"
    "" ""

--- a/libraries/lib-realtime-effects/RealtimeEffectList.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.cpp
@@ -10,7 +10,7 @@
 #include "RealtimeEffectState.h"
 
 #include "Project.h"
-#include "Track.h"
+#include "WideSampleSequence.h"
 
 RealtimeEffectList::RealtimeEffectList()
 {
@@ -52,29 +52,30 @@ RealtimeEffectList &RealtimeEffectList::Set(
    return result;
 }
 
-const RealtimeEffectList &RealtimeEffectList::Get(const AudacityProject &project)
+const RealtimeEffectList &
+RealtimeEffectList::Get(const AudacityProject &project)
 {
    return Get(const_cast<AudacityProject &>(project));
 }
 
-static const Track::ChannelGroupAttachments::RegisteredFactory trackEffects
+static const SequenceAttachments::RegisteredFactory sequenceEffects
 { 
-   [](Track::ChannelGroupData &)
+   [](WideSampleSequence &)
    {
       return std::make_unique<RealtimeEffectList>();
    }
 };
 
-// Access for per-track effect list
-RealtimeEffectList &RealtimeEffectList::Get(Track &track)
+// Access for per-sequence effect list
+RealtimeEffectList &RealtimeEffectList::Get(WideSampleSequence &sequence)
 {
-   return track.GetGroupData()
-      .Track::ChannelGroupAttachments::Get<RealtimeEffectList>(trackEffects);
+   return sequence.Attachments::Get<RealtimeEffectList>(sequenceEffects);
 }
 
-const RealtimeEffectList &RealtimeEffectList::Get(const Track &track)
+const RealtimeEffectList &RealtimeEffectList::Get(
+   const WideSampleSequence &sequence)
 {
-   return Get(const_cast<Track &>(track));
+   return Get(const_cast<WideSampleSequence &>(sequence));
 }
 
 bool
@@ -218,7 +219,8 @@ void RealtimeEffectList::MoveEffect(size_t fromIndex, size_t toIndex)
    }
    else
    {
-      const auto first = shallowCopy.rbegin() + (shallowCopy.size() - (fromIndex + 1));
+      const auto first =
+         shallowCopy.rbegin() + (shallowCopy.size() - (fromIndex + 1));
       const auto last = shallowCopy.rbegin() + (shallowCopy.size() - toIndex);
       std::rotate(first, first + 1, last);
    }

--- a/libraries/lib-realtime-effects/RealtimeEffectList.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.h
@@ -23,7 +23,7 @@ class AudacityProject;
 
 class RealtimeEffectState;
 
-class Track;
+class WideSampleSequence;
 
 struct RealtimeEffectListMessage final
 {
@@ -43,7 +43,7 @@ struct RealtimeEffectListMessage final
 
 class REALTIME_EFFECTS_API RealtimeEffectList final
    // Inheritance from std::enable_shared_from_this must be public
-   // but the per-track lists are managed by unique not shared pointers
+   // but the per-sequence lists are managed by unique not shared pointers
    : public std::enable_shared_from_this<RealtimeEffectList>
    , public ClientData::Base
    , public ClientData::Cloneable<>
@@ -73,8 +73,8 @@ public:
       AudacityProject &project,
       const std::shared_ptr<RealtimeEffectList> &list);
 
-   static RealtimeEffectList &Get(Track &track);
-   static const RealtimeEffectList &Get(const Track &track);
+   static RealtimeEffectList &Get(WideSampleSequence &sequence);
+   static const RealtimeEffectList &Get(const WideSampleSequence &sequence);
 
    // Type that state visitor functions would have for out-of-line definition
    // of Visit

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
@@ -7,13 +7,12 @@
  Paul Licameli split from EffectManager.cpp
  
  **********************************************************************/
-
 #include "RealtimeEffectManager.h"
 #include "RealtimeEffectState.h"
+#include "WideSampleSequence.h"
 
 #include <memory>
 #include "Project.h"
-#include "Track.h"
 
 #include <atomic>
 #include <wx/time.h>
@@ -31,7 +30,8 @@ RealtimeEffectManager &RealtimeEffectManager::Get(AudacityProject &project)
    return project.AttachedObjects::Get<RealtimeEffectManager&>(manager);
 }
 
-const RealtimeEffectManager &RealtimeEffectManager::Get(const AudacityProject &project)
+const RealtimeEffectManager &
+RealtimeEffectManager::Get(const AudacityProject &project)
 {
    return Get(const_cast<AudacityProject &>(project));
 }
@@ -55,7 +55,7 @@ void RealtimeEffectManager::Initialize(
 {
    // (Re)Set processor parameters
    mRates.clear();
-   mGroupLeaders.clear();
+   mSequences.clear();
 
    // RealtimeAdd/RemoveEffect() needs to know when we're active so it can
    // initialize newly added effects
@@ -70,19 +70,16 @@ void RealtimeEffectManager::Initialize(
    SetSuspended(false);
 }
 
-void RealtimeEffectManager::AddTrack(
+void RealtimeEffectManager::AddSequence(
    RealtimeEffects::InitializationScope &scope,
-   const Track &track, unsigned chans, float rate)
+   const WideSampleSequence &sequence, unsigned chans, float rate)
 {
-   auto leader = *track.GetOwner()->FindLeader(&track);
-   // This should never return a null
-   wxASSERT(leader);
-   mGroupLeaders.push_back(leader);
-   mRates.insert({leader, rate});
+   mSequences.push_back(&sequence);
+   mRates.insert({&sequence, rate});
 
-   VisitGroup(*leader,
+   VisitGroup(sequence,
       [&](RealtimeEffectState & state, bool) {
-         scope.mInstances.push_back(state.AddTrack(*leader, chans, rate));
+         scope.mInstances.push_back(state.AddSequence(sequence, chans, rate));
       }
    );
 }
@@ -98,7 +95,7 @@ void RealtimeEffectManager::Finalize() noexcept
    VisitAll([](RealtimeEffectState &state, bool){ state.Finalize(); });
 
    // Reset processor parameters
-   mGroupLeaders.clear();
+   mSequences.clear();
    mRates.clear();
 
    // No longer active
@@ -110,8 +107,8 @@ void RealtimeEffectManager::Finalize() noexcept
 //
 void RealtimeEffectManager::ProcessStart(bool suspended)
 {
-   // Can be suspended because of the audio stream being paused or because effects
-   // have been suspended.
+   // Can be suspended because of the audio stream being paused or because
+   // effects have been suspended.
    VisitAll([suspended](RealtimeEffectState &state, bool listIsActive){
       state.ProcessStart(!suspended && listIsActive);
    });
@@ -121,12 +118,13 @@ void RealtimeEffectManager::ProcessStart(bool suspended)
 
 // This will be called in a thread other than the main GUI thread.
 //
-size_t RealtimeEffectManager::Process(bool suspended, const Track &track,
+size_t RealtimeEffectManager::Process(bool suspended,
+   const WideSampleSequence &sequence,
    float *const *buffers, float *const *scratch, float *const dummy,
    unsigned nBuffers, size_t numSamples)
 {
-   // Can be suspended because of the audio stream being paused or because effects
-   // have been suspended, so allow the samples to pass as-is.
+   // Can be suspended because of the audio stream being paused or because
+   // effects have been suspended, so allow the samples to pass as-is.
    if (suspended)
       return 0;
 
@@ -147,16 +145,16 @@ size_t RealtimeEffectManager::Process(bool suspended, const Track &track,
       obuf[i] = scratch[i];
    }
 
-   // Now call each effect in the chain while swapping buffer pointers to feed the
-   // output of one effect as the input to the next effect
+   // Now call each effect in the chain while swapping buffer pointers to feed
+   // the output of one effect as the input to the next effect
    // Tracks how many processors were called
    size_t called = 0;
    size_t discardable = 0;
-   VisitGroup(track,
+   VisitGroup(sequence,
       [&](RealtimeEffectState &state, bool)
       {
          discardable +=
-            state.Process(track, nBuffers, ibuf, obuf, dummy, numSamples);
+            state.Process(sequence, nBuffers, ibuf, obuf, dummy, numSamples);
          for (auto i = 0; i < nBuffers; ++i)
             std::swap(ibuf[i], obuf[i]);
          called++;
@@ -186,8 +184,8 @@ size_t RealtimeEffectManager::Process(bool suspended, const Track &track,
 //
 void RealtimeEffectManager::ProcessEnd(bool suspended) noexcept
 {
-   // Can be suspended because of the audio stream being paused or because effects
-   // have been suspended.
+   // Can be suspended because of the audio stream being paused or because
+   // effects have been suspended.
    VisitAll([suspended](RealtimeEffectState &state, bool){
       state.ProcessEnd();
    });
@@ -200,9 +198,9 @@ AllListsLock::AllListsLock(RealtimeEffectManager *pManager)
    if (mpManager) {
       // Paralleling VisitAll
       RealtimeEffectList::Get(mpManager->mProject).GetLock().lock();
-      // And all track lists
-      for (auto leader : mpManager->mGroupLeaders)
-         RealtimeEffectList::Get(*leader).GetLock().lock();
+      // And all sequence lists
+      for (auto sequence : mpManager->mSequences)
+         RealtimeEffectList::Get(*sequence).GetLock().lock();
    }
 }
 
@@ -228,9 +226,9 @@ void RealtimeEffectManager::AllListsLock::Reset()
    if (mpManager) {
       // Paralleling VisitAll
       RealtimeEffectList::Get(mpManager->mProject).GetLock().unlock();
-      // And all track lists
-      for (auto leader : mpManager->mGroupLeaders)
-         RealtimeEffectList::Get(*leader).GetLock().unlock();
+      // And all sequence lists
+      for (auto sequence : mpManager->mSequences)
+         RealtimeEffectList::Get(*sequence).GetLock().unlock();
       mpManager = nullptr;
    }
 }
@@ -238,7 +236,7 @@ void RealtimeEffectManager::AllListsLock::Reset()
 std::shared_ptr<RealtimeEffectState>
 RealtimeEffectManager::MakeNewState(
    RealtimeEffects::InitializationScope *pScope,
-   Track *pLeader, const PluginID &id)
+   WideSampleSequence *pSequence, const PluginID &id)
 {
    if (!pScope && mActive)
       return nullptr;
@@ -248,14 +246,14 @@ RealtimeEffectManager::MakeNewState(
       // Adding a state while playback is in-flight
       auto pInstance = state.Initialize(pScope->mSampleRate);
       pScope->mInstances.push_back(pInstance);
-      for (auto &leader : mGroupLeaders) {
-         // Add all tracks to a per-project state, but add only the same track
-         // to a state in the per-track list
-         if (pLeader && pLeader != leader)
+      for (auto &sequence : mSequences) {
+         // Add all sequences to a per-project state, but add only the same
+         // sequence to a state in the per-sequence list
+         if (pSequence && pSequence != sequence)
             continue;
-         auto rate = mRates[leader];
+         auto rate = mRates[sequence];
          auto pInstance2 =
-            state.AddTrack(*leader, pScope->mNumPlaybackChannels, rate);
+            state.AddSequence(*sequence, pScope->mNumPlaybackChannels, rate);
          if (pInstance2 != pInstance)
             pScope->mInstances.push_back(pInstance2);
       }
@@ -264,23 +262,20 @@ RealtimeEffectManager::MakeNewState(
 }
 
 namespace {
-std::pair<Track *, RealtimeEffectList &>
-FindStates(AudacityProject &project, Track *pTrack) {
-   auto pLeader = pTrack ? *TrackList::Channels(pTrack).begin() : nullptr;
-   return { pLeader,
-      pLeader
-         ? RealtimeEffectList::Get(*pLeader)
-         : RealtimeEffectList::Get(project)
-   };
+RealtimeEffectList &
+FindStates(AudacityProject &project, WideSampleSequence *pSequence) {
+   return pSequence
+      ? RealtimeEffectList::Get(*pSequence)
+      : RealtimeEffectList::Get(project);
 }
 }
 
 std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
    RealtimeEffects::InitializationScope *pScope,
-   Track *pTrack, const PluginID & id)
+   WideSampleSequence *pSequence, const PluginID & id)
 {
-   auto [pLeader, states] = FindStates(mProject, pTrack);
-   auto pState = MakeNewState(pScope, pTrack, id);
+   auto &states = FindStates(mProject, pSequence);
+   auto pState = MakeNewState(pScope, pSequence, id);
    if (!pState)
       return nullptr;
 
@@ -289,20 +284,20 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
       return nullptr;
    Publish({
       RealtimeEffectManagerMessage::Type::EffectAdded,
-      pLeader ? pLeader : nullptr
+      pSequence ? pSequence : nullptr
    });
    return pState;
 }
 
 std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::ReplaceState(
    RealtimeEffects::InitializationScope *pScope,
-   Track *pTrack, size_t index, const PluginID & id)
+   WideSampleSequence *pSequence, size_t index, const PluginID & id)
 {
-   auto [pLeader, states] = FindStates(mProject, pTrack);
+   auto &states = FindStates(mProject, pSequence);
    auto pOldState = states.GetStateAt(index);
    if (!pOldState)
       return nullptr;
-   auto pNewState = MakeNewState(pScope, pTrack, id);
+   auto pNewState = MakeNewState(pScope, pSequence, id);
    if (!pNewState)
       return nullptr;
 
@@ -312,16 +307,17 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::ReplaceState(
    if (mActive)
       pOldState->Finalize();
    Publish({
-      RealtimeEffectManagerMessage::Type::EffectReplaced, pLeader
+      RealtimeEffectManagerMessage::Type::EffectReplaced, pSequence
    });
    return pNewState;
 }
 
 void RealtimeEffectManager::RemoveState(
    RealtimeEffects::InitializationScope *pScope,
-   Track *pTrack, const std::shared_ptr<RealtimeEffectState> pState)
+   WideSampleSequence *pSequence,
+   const std::shared_ptr<RealtimeEffectState> pState)
 {
-   auto [pLeader, states] = FindStates(mProject, pTrack);
+   auto &states = FindStates(mProject, pSequence);
 
    // Remove the state from processing (under the lock guard) before finalizing
    states.RemoveState(pState);
@@ -329,14 +325,15 @@ void RealtimeEffectManager::RemoveState(
       pState->Finalize();
    Publish({
       RealtimeEffectManagerMessage::Type::EffectRemoved,
-      pLeader ? pLeader : nullptr
+      pSequence ? pSequence : nullptr
    });
 }
 
 std::optional<size_t> RealtimeEffectManager::FindState(
-   Track *pTrack, const std::shared_ptr<RealtimeEffectState> &pState) const
+   WideSampleSequence *pSequence,
+   const std::shared_ptr<RealtimeEffectState> &pState) const
 {
-   auto [_, states] = FindStates(mProject, pTrack);
+   auto &states = FindStates(mProject, pSequence);
    return states.FindState(pState);
 }
 

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
@@ -289,7 +289,7 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
       return nullptr;
    Publish({
       RealtimeEffectManagerMessage::Type::EffectAdded,
-      pLeader ? pLeader->shared_from_this() : nullptr
+      pLeader ? pLeader : nullptr
    });
    return pState;
 }
@@ -312,8 +312,7 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::ReplaceState(
    if (mActive)
       pOldState->Finalize();
    Publish({
-      RealtimeEffectManagerMessage::Type::EffectReplaced,
-      pLeader ? pLeader->shared_from_this() : nullptr
+      RealtimeEffectManagerMessage::Type::EffectReplaced, pLeader
    });
    return pNewState;
 }
@@ -330,7 +329,7 @@ void RealtimeEffectManager::RemoveState(
       pState->Finalize();
    Publish({
       RealtimeEffectManagerMessage::Type::EffectRemoved,
-      pLeader ? pLeader->shared_from_this() : nullptr
+      pLeader ? pLeader : nullptr
    });
 }
 

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.h
@@ -40,8 +40,8 @@ struct RealtimeEffectManagerMessage
       EffectReplaced,
       EffectRemoved
    };
-   Type type;
-   std::shared_ptr<Track> track; ///< null, if changes happened in the project scope
+   Type type{};
+   Track *track{}; ///< null, if changes happened in the project scope
 };
 
 class REALTIME_EFFECTS_API RealtimeEffectManager final :

--- a/libraries/lib-realtime-effects/RealtimeEffectState.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectState.h
@@ -25,7 +25,7 @@
 #include "XMLTagHandler.h"
 
 class EffectSettingsAccess;
-class Track;
+class WideSampleSequence;
 
 enum class RealtimeEffectStateChange { EffectOff, EffectOn };
 
@@ -70,7 +70,8 @@ public:
    std::shared_ptr<EffectInstance> Initialize(double rate);
    //! Main thread sets up this state before adding it to lists
    std::shared_ptr<EffectInstance>
-   AddTrack(const Track &track, unsigned chans, float sampleRate);
+   AddSequence(
+      const WideSampleSequence &sequence, unsigned chans, float sampleRate);
    //! Worker thread begins a batch of samples
    /*! @param running means no pause or deactivation of containing list */
    bool ProcessStart(bool running);
@@ -78,7 +79,7 @@ public:
    /*!
     @return how many leading samples are discardable for latency
     */
-   size_t Process(const Track &track,
+   size_t Process(const WideSampleSequence &sequence,
       unsigned chans, // How many channels the playback device needs
       const float *const *inbuf, //!< chans input buffers
       float *const *outbuf, //!< chans output buffers
@@ -184,7 +185,8 @@ private:
     @{
     */
     
-   std::unordered_map<const Track *, std::pair<size_t, double>> mGroups;
+   std::unordered_map<const WideSampleSequence *, std::pair<size_t, double>>
+      mGroups;
 
    // This must not be reset to nullptr while a worker thread is running.
    // In fact it is never yet reset to nullptr, before destruction.

--- a/libraries/lib-sample-track/SampleTrack.h
+++ b/libraries/lib-sample-track/SampleTrack.h
@@ -12,10 +12,10 @@ Paul Licameli split from WaveTrack.h
 #ifndef __AUDACITY_SAMPLE_TRACK__
 #define __AUDACITY_SAMPLE_TRACK__
 
+#include "AudioIOSequences.h"
 #include "PlayableTrack.h"
 #include "SampleCount.h"
 #include "SampleFormat.h"
-#include "WideSampleSequence.h"
 
 enum class sampleFormat : unsigned;
 
@@ -30,7 +30,7 @@ using SampleTrackAttachments = ClientData::Site<
 class SAMPLE_TRACK_API SampleTrack /* not final */
    : public PlayableTrack
    , public SampleTrackAttachments
-   , public WideSampleSequence
+   , public PlayableSequence
 {
 public:
    using Attachments = SampleTrackAttachments;
@@ -64,6 +64,7 @@ ENUMERATE_TRACK_TYPE(SampleTrack)
 
 class SAMPLE_TRACK_API WritableSampleTrack /* not final */
    : public SampleTrack
+   , public RecordableSequence
 {
 public:
    WritableSampleTrack();
@@ -71,26 +72,13 @@ public:
       const WritableSampleTrack &other, ProtectedCreationArg&&);
    ~WritableSampleTrack() override;
 
+   // Needed to resolve ambiguity with WideSampleSequence::GetRate, when this
+   // abstract interface is used directly.
+   // Expect the concrete subclass to define a common override for them.
+   using RecordableSequence::GetRate;
+
    const TypeInfo &GetTypeInfo() const override;
    static const TypeInfo &ClassTypeInfo();
-
-   /** @brief Append the sample data to the track. You must call Flush()
-    * after the last Append.
-    *
-    * @return true in case a block was flushed from memory to underlying DB
-    */
-   virtual bool Append(constSamplePtr buffer, sampleFormat format,
-      size_t len, unsigned int stride=1,
-      sampleFormat effectiveFormat = widestSampleFormat /*!<
-         Make the effective format of the data at least the minumum of this
-         value and `format`.  (Maybe wider, if merging with preexistent data.)
-         If the data are later narrowed from stored format, but not narrower
-         than the effective, then no dithering will occur.
-      */
-   ) = 0;
-
-   //! Flush must be called after last Append
-   virtual void Flush() = 0;
 };
 
 ENUMERATE_TRACK_TYPE(WritableSampleTrack)

--- a/libraries/lib-sample-track/SampleTrack.h
+++ b/libraries/lib-sample-track/SampleTrack.h
@@ -72,6 +72,9 @@ public:
       const WritableSampleTrack &other, ProtectedCreationArg&&);
    ~WritableSampleTrack() override;
 
+   // Resolve lookup ambiguity
+   using Track::IsLeader;
+
    // Needed to resolve ambiguity with WideSampleSequence::GetRate, when this
    // abstract interface is used directly.
    // Expect the concrete subclass to define a common override for them.

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1827,6 +1827,21 @@ void WaveTrack::Flush()
    RightmostOrNewClip()->Flush();
 }
 
+bool WaveTrack::IsLeader() const
+{
+   return Track::IsLeader();
+}
+
+bool WaveTrack::GetMute() const
+{
+   return PlayableTrack::GetMute();
+}
+
+bool WaveTrack::GetSolo() const
+{
+   return PlayableTrack::GetSolo();
+}
+
 bool WaveTrack::HandleXMLTag(const std::string_view& tag, const AttributesList &attrs)
 {
    if (tag == "wavetrack") {

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -240,6 +240,13 @@ private:
 
    void Flush() override;
 
+   //! @name PlayableSequence implementation
+   //! @{
+   bool IsLeader() const override;
+   bool GetMute() const override;
+   bool GetSolo() const override;
+   //! @}
+
    ///
    /// MM: Now that each wave track can contain multiple clips, we don't
    /// have a continuous space of samples anymore, but we simulate it,

--- a/src/DefaultPlaybackPolicy.cpp
+++ b/src/DefaultPlaybackPolicy.cpp
@@ -70,7 +70,7 @@ bool DefaultPlaybackPolicy::Done(
    PlaybackSchedule &schedule, unsigned long outputFrames )
 {
    if (RevertToOldDefault(schedule)) {
-      auto diff = schedule.GetTrackTime() - schedule.mT1;
+      auto diff = schedule.GetSequenceTime() - schedule.mT1;
       if (schedule.ReversedTime())
          diff *= -1;
       return sampleCount(floor(diff * mRate + 0.5)) >= 0;
@@ -151,7 +151,7 @@ bool DefaultPlaybackPolicy::RepositionPlayback(
    PlaybackSchedule &schedule, const Mixers &playbackMixers,
    size_t frames, size_t available )
 {
-   // This executes in the TrackBufferExchange thread
+   // This executes in the SequenceBufferExchange thread
    auto data = mMessageChannel.Read();
 
    bool speedChange = false;

--- a/src/MIDIPlay.cpp
+++ b/src/MIDIPlay.cpp
@@ -551,7 +551,7 @@ MIDIPlay::~MIDIPlay()
    Pm_Terminate();
 }
 
-bool MIDIPlay::StartOtherStream(const TransportTracks &tracks,
+bool MIDIPlay::StartOtherStream(const TransportSequences &tracks,
    const PaStreamInfo* info, double, double rate)
 {
    mMidiPlaybackTracks.clear();

--- a/src/MIDIPlay.cpp
+++ b/src/MIDIPlay.cpp
@@ -555,12 +555,12 @@ bool MIDIPlay::StartOtherStream(const TransportTracks &tracks,
    const PaStreamInfo* info, double, double rate)
 {
    mMidiPlaybackTracks.clear();
-   for (const auto &pTrack : tracks.otherPlayableTracks) {
-      pTrack->TypeSwitch( [&](const NoteTrack *pNoteTrack){
+   for (const auto &pSequence : tracks.otherPlayableSequences)
+      if (const auto pNoteTrack =
+         dynamic_cast<const NoteTrack *>(pSequence.get())
+      )
          mMidiPlaybackTracks.push_back(
             pNoteTrack->SharedPointer<const NoteTrack>());
-      } );
-   }
 
    streamStartTime = 0;
    streamStartTime = SystemTime(mUsingAlsa);

--- a/src/MIDIPlay.cpp
+++ b/src/MIDIPlay.cpp
@@ -1190,7 +1190,7 @@ void MIDIPlay::ComputeOtherTimings(double rate, bool paused,
       mMidiPaused = false;
 }
 
-unsigned MIDIPlay::CountOtherSoloTracks() const
+unsigned MIDIPlay::CountOtherSolo() const
 {
    return std::count_if(
       mMidiPlaybackTracks.begin(), mMidiPlaybackTracks.end(),

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -169,7 +169,7 @@ struct MIDIPlay : AudioIOExt
    void SignalOtherCompletion() override;
    unsigned CountOtherSoloTracks() const override;
 
-   bool StartOtherStream(const TransportTracks &tracks,
+   bool StartOtherStream(const TransportSequences &tracks,
       const PaStreamInfo* info, double startTime, double rate) override;
    void AbortOtherStream() override;
    void FillOtherBuffers(double rate, unsigned long pauseFrames,

--- a/src/MIDIPlay.h
+++ b/src/MIDIPlay.h
@@ -167,7 +167,7 @@ struct MIDIPlay : AudioIOExt
       const PaStreamCallbackTimeInfo *timeInfo,
       unsigned long framesPerBuffer) override;
    void SignalOtherCompletion() override;
-   unsigned CountOtherSoloTracks() const override;
+   unsigned CountOtherSolo() const override;
 
    bool StartOtherStream(const TransportSequences &tracks,
       const PaStreamInfo* info, double startTime, double rate) override;

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -12,6 +12,7 @@
 #define __AUDACITY_NOTETRACK__
 
 #include <utility>
+#include "AudioIOSequences.h"
 #include "Prefs.h"
 #include "PlayableTrack.h"
 
@@ -60,6 +61,7 @@ class TimeWarper;
 
 class AUDACITY_DLL_API NoteTrack final
    : public NoteTrackBase
+   , public OtherPlayableSequence
 {
 public:
    // Construct and also build all attachments

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -824,6 +824,9 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
             // remember the original in preroll tracks, before making the
             // pending replacement.
             const auto shared = wt->SharedPointer<WaveTrack>();
+            // playbackSequences contains only leaders; prerollSequences should
+            // be a subset of it.  Non-leader might not be found, but that is
+            // all right.
             bool prerollTrack =
                make_iterator_range(transportSequences.playbackSequences)
                   .contains(shared);

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -113,7 +113,7 @@ public:
 
    bool Done(PlaybackSchedule &schedule, unsigned long) override;
 
-   double OffsetTrackTime( PlaybackSchedule &schedule, double offset ) override;
+   double OffsetSequenceTime( PlaybackSchedule &schedule, double offset ) override;
 
    PlaybackSlice GetPlaybackSlice(
       PlaybackSchedule &schedule, size_t available) override;
@@ -184,17 +184,17 @@ void CutPreviewPlaybackPolicy::Initialize(
 bool CutPreviewPlaybackPolicy::Done(PlaybackSchedule &schedule, unsigned long)
 {
    //! Called in the PortAudio thread
-   auto diff = schedule.GetTrackTime() - mEnd;
+   auto diff = schedule.GetSequenceTime() - mEnd;
    if (mReversed)
       diff *= -1;
    return sampleCount(diff * mRate) >= 0;
 }
 
-double CutPreviewPlaybackPolicy::OffsetTrackTime(
+double CutPreviewPlaybackPolicy::OffsetSequenceTime(
    PlaybackSchedule &schedule, double offset )
 {
    // Compute new time by applying the offset, jumping over the gap
-   auto time = schedule.GetTrackTime();
+   auto time = schedule.GetSequenceTime();
    if (offset >= 0) {
       auto space = std::clamp(mGapLeft - time, 0.0, offset);
       time += space;
@@ -280,7 +280,7 @@ bool CutPreviewPlaybackPolicy::RepositionPlayback( PlaybackSchedule &,
       auto newTime = GapEnd();
       for (auto &pMixer : playbackMixers)
          pMixer->Reposition(newTime, true);
-      // Tell TrackBufferExchange that we aren't done yet
+      // Tell SequenceBufferExchange that we aren't done yet
       return false;
    }
    return true;
@@ -731,15 +731,15 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
          transportTracks =
             MakeTransportTracks(TrackList::Get( *p ), false, true);
          for (const auto &wt : existingTracks) {
-            auto end = transportTracks.playbackTracks.end();
-            auto it = std::find(transportTracks.playbackTracks.begin(), end, wt);
+            auto end = transportTracks.playbackSequences.end();
+            auto it = std::find(transportTracks.playbackSequences.begin(), end, wt);
             if (it != end)
-               transportTracks.playbackTracks.erase(it);
+               transportTracks.playbackSequences.erase(it);
          }
       }
 
       std::copy(existingTracks.begin(), existingTracks.end(),
-         back_inserter(transportTracks.captureTracks));
+         back_inserter(transportTracks.captureSequences));
 
       if (rateOfSelected != RATE_NOT_SELECTED)
          options.rate = rateOfSelected;
@@ -762,7 +762,7 @@ bool ProjectAudioManager::UseDuplex()
 }
 
 bool ProjectAudioManager::DoRecord(AudacityProject &project,
-   const TransportSequences &tracks,
+   const TransportSequences &sequences,
    double t0, double t1,
    bool altAppearance,
    const AudioIOStartStreamOptions &options)
@@ -788,14 +788,14 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
 
    bool success = false;
 
-   auto transportTracks = tracks;
+   auto transportSequences = sequences;
 
    // Will replace any given capture tracks with temporaries
-   transportTracks.captureTracks.clear();
+   transportSequences.captureSequences.clear();
 
    const auto p = &project;
 
-   bool appendRecord = !tracks.captureTracks.empty();
+   bool appendRecord = !sequences.captureSequences.empty();
 
    auto makeNewClipName = [&](WaveTrack* track) {
        for (auto i = 1;; ++i)
@@ -811,7 +811,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
       if (appendRecord) {
          // Append recording:
          // Pad selected/all wave tracks to make them all the same length
-         for (const auto &sequence : tracks.captureTracks)
+         for (const auto &sequence : sequences.captureSequences)
          {
             WaveTrack *wt{};
             if (!(wt = dynamic_cast<WaveTrack *>(sequence.get()))) {
@@ -825,10 +825,10 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
             // pending replacement.
             const auto shared = wt->SharedPointer<WaveTrack>();
             bool prerollTrack =
-               make_iterator_range(transportTracks.playbackTracks)
+               make_iterator_range(transportSequences.playbackSequences)
                   .contains(shared);
             if (prerollTrack)
-               transportTracks.prerollTracks.push_back(shared);
+               transportSequences.prerollSequences.push_back(shared);
 
             // A function that copies all the non-sample data between
             // wave tracks; in case the track recorded to changes scale
@@ -851,12 +851,12 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
             if (endTime <= t0) {
                pending->CreateClip(t0, makeNewClipName(pending.get()));
             }
-            transportTracks.captureTracks.push_back(pending);
+            transportSequences.captureSequences.push_back(pending);
          }
          TrackList::Get( *p ).UpdatePendingTracks();
       }
 
-      if( transportTracks.captureTracks.empty() )
+      if (transportSequences.captureSequences.empty())
       {   // recording to NEW track(s).
          bool recordingNameCustom, useTrackNumber, useDateStamp, useTimeStamp;
          wxString defaultTrackName, defaultRecordingTrackName;
@@ -932,7 +932,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
                TrackView::Get( *newTrack ).SetMinimized(true);
             }
 
-            transportTracks.captureTracks.push_back(newTrack);
+            transportSequences.captureSequences.push_back(newTrack);
          }
          TrackList::Get( *p ).MakeMultiChannelTrack(*first, recordingChannels, true);
          // Bug 1548.  First of new tracks needs the focus.
@@ -946,7 +946,8 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
          gAudioIO->AILAInitialize();
       #endif
 
-      int token = gAudioIO->StartStream(transportTracks, t0, t1, t1, options);
+      int token =
+         gAudioIO->StartStream(transportSequences, t0, t1, t1, options);
 
       success = (token != 0);
 

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -67,7 +67,8 @@ public:
    static ProjectAudioManager &Get( AudacityProject &project );
    static const ProjectAudioManager &Get( const AudacityProject &project );
 
-   // Find suitable tracks to record into, or return an empty array.
+   //! Find suitable tracks to record into, or return an empty array.
+   //! Not always leader tracks
    static WritableSampleTrackArray ChooseExistingRecordingTracks(
       AudacityProject &proj, bool selectedOnly,
       double targetRate = RATE_NOT_SELECTED);

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -105,7 +105,8 @@ public:
    void OnRecord(bool altAppearance);
 
    bool DoRecord(AudacityProject &project,
-      const TransportSequences &transportTracks, // If captureTracks is empty, then tracks are created
+      //! If captureSequences is empty, then tracks are created
+      const TransportSequences &transportSequences,
       double t0, double t1,
       bool altAppearance,
       const AudioIOStartStreamOptions &options);

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -38,7 +38,7 @@ enum class PlayMode : int {
    cutPreviewPlay
 };
 
-struct TransportTracks;
+struct TransportSequences;
 
 enum StatusBarField : int;
 enum class ProjectFileIOMessage : int;
@@ -105,7 +105,7 @@ public:
    void OnRecord(bool altAppearance);
 
    bool DoRecord(AudacityProject &project,
-      const TransportTracks &transportTracks, // If captureTracks is empty, then tracks are created
+      const TransportSequences &transportTracks, // If captureTracks is empty, then tracks are created
       double t0, double t1,
       bool altAppearance,
       const AudioIOStartStreamOptions &options);
@@ -151,7 +151,7 @@ private:
    void OnAudioIORate(int rate) override;
    void OnAudioIOStartRecording() override;
    void OnAudioIOStopRecording() override;
-   void OnAudioIONewBlocks(const WritableSampleTrackArray *tracks) override;
+   void OnAudioIONewBlocks(const RecordableSequences &sequences) override;
    void OnCommitRecording() override;
    void OnSoundActivationThreshold() override;
 

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -17,7 +17,7 @@
 #include "ThemedWrappers.h"
 #include "Observer.h"
 
-class Track;
+class SampleTrack;
 
 class wxButton;
 class wxStaticText;
@@ -39,13 +39,13 @@ class RealtimeEffectPanel : public wxPanel
    wxWindow* mHeader{nullptr};
    AudacityProject& mProject;
 
-   std::weak_ptr<Track> mCurrentTrack;
+   std::weak_ptr<SampleTrack> mCurrentTrack;
 
    Observer::Subscription mTrackListChanged;
    Observer::Subscription mUndoSubscription;
    Observer::Subscription mFocusChangeSubscription;
 
-   std::vector<std::shared_ptr<Track>> mPotentiallyRemovedTracks;
+   std::vector<std::shared_ptr<SampleTrack>> mPotentiallyRemovedTracks;
 
    // RealtimeEffectPanel is wrapped using ThemedWindowWrapper,
    // so we cannot subscribe to Prefs directly
@@ -66,14 +66,14 @@ public:
 
    ~RealtimeEffectPanel() override;
 
-   void ShowPanel(Track* track, bool focus);
+   void ShowPanel(SampleTrack* track, bool focus);
    void HidePanel();
 
    /**
     * \brief Shows effects from the effect stack of the track
     * \param track Pointer to the existing track, or null
     */
-   void SetTrack(const std::shared_ptr<Track>& track);
+   void SetTrack(const std::shared_ptr<SampleTrack>& track);
    void ResetTrack();
 
    bool IsTopNavigationDomain(NavigationKind) const override { return true; }

--- a/src/ScrubState.cpp
+++ b/src/ScrubState.cpp
@@ -42,7 +42,7 @@ struct ScrubQueue : NonInterferingBase
    void Get(sampleCount &startSample, sampleCount &endSample,
          sampleCount inDuration, sampleCount &duration)
    {
-      // Called by the thread that calls AudioIO::TrackBufferExchange
+      // Called by the thread that calls AudioIO::SequenceBufferExchange
       startSample = endSample = duration = -1LL;
       sampleCount s0Init;
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -329,9 +329,9 @@ TrackPanel::TrackPanel(wxWindow * parent, wxWindowID id,
    mRealtimeEffectManagerSubscription = RealtimeEffectManager::Get(*theProject)
       .Subscribe([this](const RealtimeEffectManagerMessage& msg)
       {
-         if(msg.track)
+         if (auto pTrack = dynamic_cast<Track *>(msg.sequence))
             //update "effects" button 
-            RefreshTrack(msg.track);
+            RefreshTrack(pTrack);
       });
 
    UpdatePrefs();

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -331,7 +331,7 @@ TrackPanel::TrackPanel(wxWindow * parent, wxWindowID id,
       {
          if(msg.track)
             //update "effects" button 
-            RefreshTrack(msg.track.get());
+            RefreshTrack(msg.track);
       });
 
    UpdatePrefs();

--- a/src/TransportUtilities.cpp
+++ b/src/TransportUtilities.cpp
@@ -13,6 +13,7 @@
 
 #include <thread>
 #include "AudioIO.h"
+#include "AudioIOSequences.h"
 #include "commands/CommandContext.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
@@ -218,8 +219,11 @@ TransportTracks MakeTransportTracks(
          (selectedOnly ? &Track::IsSelected : &Track::Any);
       for (auto pTrack : range)
          if (!track_cast<const SampleTrack *>(pTrack))
-            result.otherPlayableTracks.push_back(
-               pTrack->SharedPointer<const PlayableTrack>() );
+            if (auto pSequence =
+               std::dynamic_pointer_cast<const OtherPlayableSequence>(
+                  pTrack->shared_from_this())
+            )
+               result.otherPlayableSequences.push_back(pSequence);
    }
 #endif
    return result;

--- a/src/TransportUtilities.cpp
+++ b/src/TransportUtilities.cpp
@@ -211,7 +211,7 @@ TransportSequences MakeTransportTracks(
       const auto range = trackList.Any<SampleTrack>()
          + (selectedOnly ? &Track::IsSelected : &Track::Any);
       for (auto pTrack : range)
-         result.playbackTracks.push_back(pTrack->SharedPointer<SampleTrack>());
+         result.playbackSequences.push_back(pTrack->SharedPointer<SampleTrack>());
    }
 #ifdef EXPERIMENTAL_MIDI_OUT
    if (nonWaveToo) {

--- a/src/TransportUtilities.cpp
+++ b/src/TransportUtilities.cpp
@@ -203,10 +203,10 @@ void TransportUtilities::DoStartPlaying(
    }
 }
 
-TransportTracks MakeTransportTracks(
+TransportSequences MakeTransportTracks(
    TrackList &trackList, bool selectedOnly, bool nonWaveToo)
 {
-   TransportTracks result;
+   TransportSequences result;
    {
       const auto range = trackList.Any<SampleTrack>()
          + (selectedOnly ? &Track::IsSelected : &Track::Any);

--- a/src/TransportUtilities.cpp
+++ b/src/TransportUtilities.cpp
@@ -208,14 +208,15 @@ TransportSequences MakeTransportTracks(
 {
    TransportSequences result;
    {
-      const auto range = trackList.Any<SampleTrack>()
+      const auto range = trackList.Leaders<SampleTrack>()
          + (selectedOnly ? &Track::IsSelected : &Track::Any);
       for (auto pTrack : range)
-         result.playbackSequences.push_back(pTrack->SharedPointer<SampleTrack>());
+         result.playbackSequences
+            .push_back(pTrack->SharedPointer<SampleTrack>());
    }
 #ifdef EXPERIMENTAL_MIDI_OUT
    if (nonWaveToo) {
-      const auto range = trackList.Any<const PlayableTrack>() +
+      const auto range = trackList.Leaders<const PlayableTrack>() +
          (selectedOnly ? &Track::IsSelected : &Track::Any);
       for (auto pTrack : range)
          if (!track_cast<const SampleTrack *>(pTrack))

--- a/src/TransportUtilities.h
+++ b/src/TransportUtilities.h
@@ -16,7 +16,7 @@ struct AudioIOStartStreamOptions;
 class CommandContext;
 class SelectedRegion;
 class TrackList;
-class TransportTracks;
+class TransportSequences;
 enum class PlayMode : int;
 
 struct AUDACITY_DLL_API TransportUtilities
@@ -42,7 +42,7 @@ struct AUDACITY_DLL_API TransportUtilities
 /*!
  @param nonWaveToo if true, collect all PlayableTracks
  */
-TransportTracks MakeTransportTracks(
+TransportSequences MakeTransportTracks(
    TrackList &trackList, bool selectedOnly, bool nonWaveToo = false);
 
 #endif

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -1,5 +1,3 @@
-
-
 #include "AudioIO.h"
 #include "../Benchmark.h"
 #include "../commands/CommandDispatch.h"
@@ -17,6 +15,7 @@
 #include "../ProjectWindows.h"
 #include "../ProjectSelectionManager.h"
 #include "RealtimeEffectPanel.h"
+#include "SampleTrack.h"
 #include "SyncLock.h"
 #include "../toolbars/ToolManager.h"
 #include "../toolbars/SelectionBar.h"
@@ -58,8 +57,8 @@ void DoManageRealtimeEffectsSidePanel(AudacityProject &project)
    auto &panel = RealtimeEffectPanel::Get(project);
    if (panel.IsShown())
       panel.HidePanel();
-   else
-      panel.ShowPanel(trackFocus.Get(), true);
+   else if (auto pTrack = dynamic_cast<SampleTrack *>(trackFocus.Get()))
+      panel.ShowPanel(pTrack, true);
 }
 
 

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -330,8 +330,9 @@ void OnPunchAndRoll(const CommandContext &context)
          TrackList::Get( project ), false, true);
    else
       // play recording tracks only
-      std::copy(tracks.begin(), tracks.end(),
-         std::back_inserter(transportTracks.playbackSequences));
+      for (auto &pTrack : tracks)
+         if (pTrack->IsLeader())
+            transportTracks.playbackSequences.push_back(pTrack);
       
    // Unlike with the usual recording, a track may be chosen both for playback
    // and recording.

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -331,12 +331,12 @@ void OnPunchAndRoll(const CommandContext &context)
    else
       // play recording tracks only
       std::copy(tracks.begin(), tracks.end(),
-         std::back_inserter(transportTracks.playbackTracks));
+         std::back_inserter(transportTracks.playbackSequences));
       
    // Unlike with the usual recording, a track may be chosen both for playback
    // and recording.
    std::copy(tracks.begin(), tracks.end(),
-      back_inserter(transportTracks.captureTracks));
+      back_inserter(transportTracks.captureSequences));
 
    // Try to start recording
    auto options = ProjectAudioIO::GetDefaultOptions(project);

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -322,7 +322,7 @@ void OnPunchAndRoll(const CommandContext &context)
    }
 
    // Choose the tracks for playback.
-   TransportTracks transportTracks;
+   TransportSequences transportTracks;
    const auto duplex = ProjectAudioManager::UseDuplex();
    if (duplex)
       // play all
@@ -335,7 +335,8 @@ void OnPunchAndRoll(const CommandContext &context)
       
    // Unlike with the usual recording, a track may be chosen both for playback
    // and recording.
-   transportTracks.captureTracks = std::move(tracks);
+   std::copy(tracks.begin(), tracks.end(),
+      back_inserter(transportTracks.captureTracks));
 
    // Try to start recording
    auto options = ProjectAudioIO::GetDefaultOptions(project);

--- a/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
@@ -14,6 +14,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "Project.h"
 #include "../../../RefreshCode.h"
 #include "../../../RealtimeEffectPanel.h"
+#include "SampleTrack.h"
 #include "../../../TrackPanelAx.h"
 #include "../../../TrackInfo.h"
 #include "../../../TrackPanelMouseEvent.h"
@@ -146,7 +147,8 @@ EffectsButtonHandle::~EffectsButtonHandle()
 UIHandle::Result EffectsButtonHandle::CommitChanges
 (const wxMouseEvent &event, AudacityProject *pProject, wxWindow *pParent)
 {
-   RealtimeEffectPanel::Get(*pProject).ShowPanel(mpTrack.lock().get(), true);
+   RealtimeEffectPanel::Get(*pProject).ShowPanel(
+      dynamic_cast<SampleTrack *>(mpTrack.lock().get()), true);
    return RefreshCode::RefreshNone;
 }
 


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Depends on
- #4746

Break dependency of lib-audio-io and lib-realtime-effects on lib-track.

Instead, use only the interfaces defined in lib-mixer, which WaveTrack implements,
and caching or time-stretching decorators of WaveTrack might reimplement.

AudioIO::StartStream accepts an array of PlayableSequence objects (which inherit
WideSampleSequence), which know their stereo width; instead of taking inputs
each of mono, left, or right channel data only.

Decorators can be constructed elsewhere than in the libraries, where more
implementation detail of WaveTrack and its division into clips is available.

QA:
- [x] playback and rendering of stackable effects
- [x] Changes of pan, gain, mute, solo of tracks while playing
- [x] Same with Micro-fade option enabled (Playback preferences)
- [x] Recording, including Punch-and-roll


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
