### PR TITLE
Fix crash when GetInfo sends Preferences

### DIFF
--- a/src/export/FFmpegPrefs.cpp
+++ b/src/export/FFmpegPrefs.cpp
@@ -63,9 +63,10 @@ void AddControls( ShuttleGui &S )
 #endif
             .AddButton(XXO("Loca&te..."),
                        wxALL | wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL);
-         pFindButton->Bind(wxEVT_BUTTON, [pState](wxCommandEvent&){
-            OnFFmpegFindButton(*pState);
-         });
+         if (pFindButton)
+            pFindButton->Bind(wxEVT_BUTTON, [pState](wxCommandEvent&){
+               OnFFmpegFindButton(*pState);
+            });
 
          S.AddVariableText(XO("FFmpeg Library:"),
             true, wxALL | wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL);
@@ -77,10 +78,11 @@ void AddControls( ShuttleGui &S )
 #endif
             .AddButton(XXO("Dow&nload"),
                        wxALL | wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL);
-         pDownButton->Bind(wxEVT_BUTTON, [pState](wxCommandEvent&){
-            HelpSystem::ShowHelp(pState->parent,
-               wxT("FAQ:Installing_the_FFmpeg_Import_Export_Library"), true);
-         });
+         if (pDownButton)
+            pDownButton->Bind(wxEVT_BUTTON, [pState](wxCommandEvent&){
+               HelpSystem::ShowHelp(pState->parent,
+                  wxT("FAQ:Installing_the_FFmpeg_Import_Export_Library"), true);
+            });
       }
       S.EndTwoColumn();
    }

--- a/src/prefs/EffectsPrefs.cpp
+++ b/src/prefs/EffectsPrefs.cpp
@@ -128,13 +128,14 @@ void EffectsPrefs::PopulateOrExchange(ShuttleGui & S)
    S.EndStatic();
 #endif
 
-   S.AddButton(XO("Open Plugin Manager"), wxALIGN_LEFT)->Bind(wxEVT_BUTTON, [this](auto) {
-      //Adding dependency on PluginRegistrationDialog, not good. Alternatively
-      //that could be done with events, though event should be visible here too...
-      PluginRegistrationDialog dialog(wxGetTopLevelParent(this));
-      if(dialog.ShowModal() == wxID_OK)
-         MenuCreator::RebuildAllMenuBars();
-   });
+   if (auto pButton = S.AddButton(XO("Open Plugin Manager"), wxALIGN_LEFT))
+      pButton->Bind(wxEVT_BUTTON, [this](auto) {
+         //Adding dependency on PluginRegistrationDialog, not good. Alternatively
+         //that could be done with events, though event should be visible here too...
+         PluginRegistrationDialog dialog(wxGetTopLevelParent(this));
+         if(dialog.ShowModal() == wxID_OK)
+            MenuCreator::RebuildAllMenuBars();
+      });
 
    S.EndScroller();
 }

--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -156,11 +156,13 @@ void TracksBehaviorsPrefs::PopulateOrExchange(ShuttleGui & S)
             }
             S.EndVerticalLay();
 
-            S.AddVariableText(audioPasteModeText[i])->Bind(
-               wxEVT_LEFT_UP, [=](auto)
-               {
-                  radioButton->SetValue(true);
-               });
+            if (auto pText = S.AddVariableText(audioPasteModeText[i])) {
+               pText->Bind(
+                  wxEVT_LEFT_UP, [=](auto)
+                  {
+                     radioButton->SetValue(true);
+                  });
+            }
    #if wxUSE_ACCESSIBILITY
             safenew WindowAccessible(radioButton);
    #endif


### PR DESCRIPTION
Resolves: #4798

Fix crash in Extra > Scriptables II > Get Info, when the choice is Preferences


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
