### PR TITLE
Issue 4846: Keyboard scrubbing bug if you reverse direction

### DIFF
--- a/libraries/lib-mixer/MixerSource.cpp
+++ b/libraries/lib-mixer/MixerSource.cpp
@@ -417,6 +417,8 @@ bool MixerSource::Terminates() const
 void MixerSource::Reposition(double time, bool skipping)
 {
    mSamplePos = GetSequence().TimeToLongSamples(time);
+   mQueueStart = 0;
+   mQueueLen = 0;
 
    // Bug 2025:  libsoxr 0.1.3, first used in Audacity 2.3.0, crashes with
    // constant rate resampling if you try to reuse the resampler after it has


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4846

If you are holding down one of the keyboard scrubbing keys, U and I, you can change the direction of scrubbing, without stopping the scrubbing, by also holding down the other key and sometime after that releasing the original key. However this no longer works correctly, the wrong audio is scrubbed.

In commit e0acd57, there is the following change:
```
void MixerSource::Reposition(double time, bool skipping)
 {
-   for (size_t j = 0; j < mnChannels; ++j) {
-      mSamplePos[j] = GetChannel(j)->TimeToLongSamples(time);
-      mQueueStart[j] = 0;
-      mQueueLen[j] = 0;
-   }
+   mSamplePos = GetChannel(0)->TimeToLongSamples(time);
```

Fix: add the new equivalents for  mQueueStart[j] = 0;, and mQueueLen[j] = 0;


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
