### PR TITLE
Hot fix for broken realtime effects

### DIFF
--- a/libraries/lib-mixer/WideSampleSequence.cpp
+++ b/libraries/lib-mixer/WideSampleSequence.cpp
@@ -21,3 +21,16 @@ double WideSampleSequence::LongSamplesToTime(sampleCount pos) const
 {
    return pos.as_double() / GetRate();
 }
+
+const WideSampleSequence& WideSampleSequence::GetDecorated() const
+{
+   const WideSampleSequence* innermost = this;
+   while (const auto newP = innermost->DoGetDecorated())
+      innermost = newP;
+   return *innermost;
+}
+
+const WideSampleSequence* WideSampleSequence::DoGetDecorated() const
+{
+   return nullptr;
+}

--- a/libraries/lib-mixer/WideSampleSequence.h
+++ b/libraries/lib-mixer/WideSampleSequence.h
@@ -15,7 +15,7 @@ Paul Licameli split from SampleFrame.h
 #include "SampleCount.h"
 #include "SampleFormat.h"
 
-struct WideSampleSequence;
+class WideSampleSequence;
 
 //! Hosting of objects attached by higher level code
 using SequenceAttachments = ClientData::Site<
@@ -33,6 +33,8 @@ public:
    using Attachments = SequenceAttachments;
 
    virtual ~WideSampleSequence();
+
+   const WideSampleSequence& GetDecorated() const;
 
    //! A constant property
    /*!
@@ -128,6 +130,9 @@ public:
    //! starting at the given time
    virtual void GetEnvelopeValues(double *buffer, size_t bufferLen,
                          double t0) const = 0;
+
+private:
+   virtual const WideSampleSequence* DoGetDecorated() const;
 };
 
 #endif

--- a/libraries/lib-realtime-effects/RealtimeEffectList.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.cpp
@@ -1,9 +1,9 @@
 /**********************************************************************
- 
+
   Audacity: A Digital Audio Editor
- 
+
   RealtimeEffectList.cpp
- 
+
  *********************************************************************/
 
 #include "RealtimeEffectList.h"
@@ -59,7 +59,7 @@ RealtimeEffectList::Get(const AudacityProject &project)
 }
 
 static const SequenceAttachments::RegisteredFactory sequenceEffects
-{ 
+{
    [](WideSampleSequence &)
    {
       return std::make_unique<RealtimeEffectList>();
@@ -69,7 +69,8 @@ static const SequenceAttachments::RegisteredFactory sequenceEffects
 // Access for per-sequence effect list
 RealtimeEffectList &RealtimeEffectList::Get(WideSampleSequence &sequence)
 {
-   return sequence.Attachments::Get<RealtimeEffectList>(sequenceEffects);
+   return const_cast<WideSampleSequence&>(sequence.GetDecorated())
+      .Attachments::Get<RealtimeEffectList>(sequenceEffects);
 }
 
 const RealtimeEffectList &RealtimeEffectList::Get(
@@ -109,7 +110,7 @@ RealtimeEffectList::ReplaceState(size_t index,
    if (index >= mStates.size())
       return false;
    const auto &id = pState->GetID();
-   if (pState->GetEffect() != nullptr) {     
+   if (pState->GetEffect() != nullptr) {
       auto shallowCopy = mStates;
 
       Publisher<RealtimeEffectListMessage>::Publish({
@@ -144,7 +145,7 @@ void RealtimeEffectList::RemoveState(
    auto end = shallowCopy.end(),
       found = std::find(shallowCopy.begin(), end, pState);
    if (found != end)
-   {      
+   {
       const auto index = std::distance(shallowCopy.begin(), found);
       shallowCopy.erase(found);
 
@@ -163,7 +164,7 @@ void RealtimeEffectList::RemoveState(
 void RealtimeEffectList::Clear()
 {
    decltype(mStates) temp;
-   
+
    // Swap an empty list in as a whole, not removing one at a time
    // Lock for only a short time
    (LockGuard{ mLock }, swap(temp, mStates));

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
@@ -1,11 +1,11 @@
 /**********************************************************************
- 
+
  Audacity: A Digital Audio Editor
- 
+
  RealtimeEffectManager.cpp
- 
+
  Paul Licameli split from EffectManager.cpp
- 
+
  **********************************************************************/
 #include "RealtimeEffectManager.h"
 #include "RealtimeEffectState.h"
@@ -249,7 +249,8 @@ RealtimeEffectManager::MakeNewState(
       for (auto &sequence : mSequences) {
          // Add all sequences to a per-project state, but add only the same
          // sequence to a state in the per-sequence list
-         if (pSequence && pSequence != sequence)
+         if (
+            pSequence && &pSequence->GetDecorated() != &sequence->GetDecorated())
             continue;
          auto rate = mRates[sequence];
          auto pInstance2 =

--- a/libraries/lib-wave-track/CachingPlayableSequence.cpp
+++ b/libraries/lib-wave-track/CachingPlayableSequence.cpp
@@ -35,6 +35,11 @@ CachingPlayableSequence::CachingPlayableSequence(const WaveTrack& waveTrack)
 {
 }
 
+const WideSampleSequence* CachingPlayableSequence::DoGetDecorated() const
+{
+   return &mWaveTrack;
+}
+
 size_t CachingPlayableSequence::NChannels() const
 {
    return mWaveTrack.NChannels();

--- a/libraries/lib-wave-track/CachingPlayableSequence.h
+++ b/libraries/lib-wave-track/CachingPlayableSequence.h
@@ -31,6 +31,7 @@ public:
    CachingPlayableSequence(const WaveTrack&);
 
    // WideSampleSequence
+   const WideSampleSequence* DoGetDecorated() const override;
    size_t NChannels() const override;
    float GetChannelGain(int channel) const override;
    bool Get(

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -712,7 +712,7 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
             // If suitable tracks still not found, will record into NEW ones,
             // starting with t0
          }
-         
+
          // Whether we decided on NEW tracks or not:
          if (t1 <= selectedRegion.t0() && selectedRegion.t1() > selectedRegion.t0()) {
             t1 = selectedRegion.t1();   // record within the selection
@@ -732,7 +732,12 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
             MakeTransportTracks(TrackList::Get( *p ), false, true);
          for (const auto &wt : existingTracks) {
             auto end = transportTracks.playbackSequences.end();
-            auto it = std::find(transportTracks.playbackSequences.begin(), end, wt);
+            auto it = std::find_if(
+               transportTracks.playbackSequences.begin(), end,
+               [&wt](const auto& playbackSequence) {
+                  return &playbackSequence->GetDecorated() ==
+                         &wt->GetDecorated();
+               });
             if (it != end)
                transportTracks.playbackSequences.erase(it);
          }
@@ -1176,7 +1181,7 @@ static ProjectAudioIO::DefaultOptions::Scope sScope {
 
    //! Decorate with more info
    options.listener = ProjectAudioManager::Get(project).shared_from_this();
-   
+
    bool loopEnabled = ViewInfo::Get(project).playRegion.Active();
    options.loopEnabled = loopEnabled;
 
@@ -1300,7 +1305,7 @@ static RegisteredMenuItemEnabler stopIfPaused{{
    }
 }};
 
-// GetSelectedProperties collects information about 
+// GetSelectedProperties collects information about
 // currently selected audio tracks
 PropertiesOfSelected
 GetPropertiesOfSelected(const AudacityProject &proj)
@@ -1310,10 +1315,10 @@ GetPropertiesOfSelected(const AudacityProject &proj)
    PropertiesOfSelected result;
    result.allSameRate = true;
 
-   const auto selectedTracks{ 
+   const auto selectedTracks{
       TrackList::Get(proj).Selected< const WaveTrack >() };
 
-   for (const auto & track : selectedTracks) 
+   for (const auto & track : selectedTracks)
    {
       if (rateOfSelection != RATE_NOT_SELECTED &&
          track->GetRate() != rateOfSelection)


### PR DESCRIPTION
Resolves: #4859 

Realtime effects work by AudioIO getting the realtime-effect list attachment onto its playback sequences.

Problem : those are now injected, attachment-less `CachingPlayableSequence`s, which decorate the `WaveTrack`.

Quick fix : we give `WideSampleSequence` a method to return it's decorated version, which can then be used by AudioIO.

Longer term fix (maybe) : this is another incarnation of the problem we had with `GetMute/GetSolo`, also implemented as `WaveTrack` attachments. The solution was to find the right place for an abstract API, which internally is implemented by `WaveTrack` through query of its attachment. Now it's an abstraction for `RealtimeEffectList` that is needed, at least the part of it needed by AudioIO to apply real-time effects.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
