### PR TITLE
Fix translations (be, fa) for gettext 0.22 (#4847)

### DIFF
--- a/locale/ar.po
+++ b/locale/ar.po
@@ -2304,7 +2304,7 @@ msgstr "لم أتمكن من فتح ملف: \"%s\""
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "خطأ: %hs عند خط %lu"
+msgstr "خطأ: %s عند خط %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/be.po
+++ b/locale/be.po
@@ -2320,7 +2320,7 @@ msgstr "Не атрымалася адкрыць файл: \"%s\""
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Памылка: %hs у радку %lu"
+msgstr "Памылка: %s у радку %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format
@@ -4469,7 +4469,7 @@ msgstr "Больш не паказваць гэта папярэджанне"
 #: src/FileFormats.cpp
 #, c-format
 msgid "Error (file may not have been written): %s"
-msgstr "Памылка (магчыма, файл не запісаны): %hs"
+msgstr "Памылка (магчыма, файл не запісаны): %s"
 
 #: src/FileFormats.cpp
 #, fuzzy
@@ -20925,7 +20925,7 @@ msgstr ""
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, fuzzy, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
-msgstr "Памылка (магчыма, файл не запісаны): %hs"
+msgstr "Памылка (магчыма, файл не запісаны): %s"
 
 #: plug-ins/equalabel.ny
 msgid "Regular Interval Labels"

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -2328,7 +2328,7 @@ msgstr "Не бе възможно да се отвори файл: „%s“"
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Грешка: %hs на ред %lu"
+msgstr "Грешка: %s на ред %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -2299,7 +2299,7 @@ msgstr "No s'ha pogut obrir el fitxer: «%s»"
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Error: %hs a la línia %lu"
+msgstr "Error: %s a la línia %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/ca_ES@valencia.po
+++ b/locale/ca_ES@valencia.po
@@ -2319,7 +2319,7 @@ msgstr "No s'ha pogut obrir el fitxer: «%s»"
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Error: %hs en la línia %lu"
+msgstr "Error: %s en la línia %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/fa.po
+++ b/locale/fa.po
@@ -4413,7 +4413,7 @@ msgstr ""
 #: src/FileFormats.cpp
 #, c-format
 msgid "Error (file may not have been written): %s"
-msgstr "خطا (ممکن است در پرونده نوشته شده باشد) : %hs"
+msgstr "خطا (ممکن است در پرونده نوشته شده باشد) : %s"
 
 #: src/FileFormats.cpp
 msgid "&Copy uncompressed files into the project (safer)"
@@ -20567,7 +20567,7 @@ msgstr ""
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, fuzzy, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
-msgstr "خطا (ممکن است در پرونده نوشته شده باشد) : %hs"
+msgstr "خطا (ممکن است در پرونده نوشته شده باشد) : %s"
 
 #: plug-ins/equalabel.ny
 msgid "Regular Interval Labels"

--- a/locale/gl.po
+++ b/locale/gl.po
@@ -2325,7 +2325,7 @@ msgstr "Non foi posíbel abrir o ficheiro: «%s»"
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Erro: %hs na liña %lu"
+msgstr "Erro: %s na liña %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -2333,7 +2333,7 @@ msgstr "Pogrješka pri otvaranju datoteke: \"%s\""
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Pogrješka: %hs u retku %lu"
+msgstr "Pogrješka: %s u retku %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/hy.po
+++ b/locale/hy.po
@@ -2323,7 +2323,7 @@ msgstr "Չի ստացվում բացել ֆայլը՝ \"%s\""
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Սխալ՝ %hs  %lu գծում"
+msgstr "Սխալ՝ %s  %lu գծում"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/id.po
+++ b/locale/id.po
@@ -2326,7 +2326,7 @@ msgstr "Tidak bisa membuka file:\"%s\""
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Error: %hs pada garis %lu"
+msgstr "Error: %s pada garis %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/km.po
+++ b/locale/km.po
@@ -4432,7 +4432,7 @@ msgstr ""
 #: src/FileFormats.cpp
 #, fuzzy, c-format
 msgid "Error (file may not have been written): %s"
-msgstr "កំហុស (ឯកសារ​អាច​មិន​ទាន់​ត្រូវ​បាន​សរសេរ) ៖ %hs"
+msgstr "កំហុស (ឯកសារ​អាច​មិន​ទាន់​ត្រូវ​បាន​សរសេរ) ៖ %s"
 
 #: src/FileFormats.cpp
 msgid "&Copy uncompressed files into the project (safer)"
@@ -20656,7 +20656,7 @@ msgstr ""
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, fuzzy, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
-msgstr "កំហុស (ឯកសារ​អាច​មិន​ទាន់​ត្រូវ​បាន​សរសេរ) ៖ %hs"
+msgstr "កំហុស (ឯកសារ​អាច​មិន​ទាន់​ត្រូវ​បាន​សរសេរ) ៖ %s"
 
 #: plug-ins/equalabel.ny
 msgid "Regular Interval Labels"

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -2255,7 +2255,7 @@ msgstr "Nu s-a putut deschide fișierul: „%s”"
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Eroare: %hs la linia %lu"
+msgstr "Eroare: %s la linia %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/sr_RS@latin.po
+++ b/locale/sr_RS@latin.po
@@ -2330,7 +2330,7 @@ msgstr "Ne mogu da otvorim datoteku: „%s“"
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "Greška: %hs u redu %lu"
+msgstr "Greška: %s u redu %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/ta.po
+++ b/locale/ta.po
@@ -2308,7 +2308,7 @@ msgstr "கோப்பை திறக்க முடியவில்லை:
 #: libraries/lib-xml/XMLFileReader.cpp
 #, fuzzy, c-format
 msgid "Error: %s at line %lu"
-msgstr "பிழை: %hs வரிசை %lu"
+msgstr "பிழை: %s வரிசை %lu"
 
 #: libraries/lib-xml/XMLFileReader.cpp
 #, c-format

--- a/locale/tg.po
+++ b/locale/tg.po
@@ -4422,7 +4422,7 @@ msgstr ""
 #: src/FileFormats.cpp
 #, fuzzy, c-format
 msgid "Error (file may not have been written): %s"
-msgstr "Хато (файл сабт намешавад): %hs"
+msgstr "Хато (файл сабт намешавад): %s"
 
 #: src/FileFormats.cpp
 msgid "&Copy uncompressed files into the project (safer)"
@@ -20628,7 +20628,7 @@ msgstr ""
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, fuzzy, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
-msgstr "Хато (файл сабт намешавад): %hs"
+msgstr "Хато (файл сабт намешавад): %s"
 
 #: plug-ins/equalabel.ny
 msgid "Regular Interval Labels"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/909201

Resolves: #4847

gettext 0.22 is more pedantic with validating the destination string and ensuring that it represents a valid format string.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
