### PR TITLE
Have clips know project tempo

### DIFF
--- a/libraries/lib-mixer/Envelope.cpp
+++ b/libraries/lib-mixer/Envelope.cpp
@@ -29,6 +29,7 @@ a draggable point type.
 
 #include "Envelope.h"
 
+#include <float.h>
 #include <math.h>
 
 #include <wx/wxcrtvararg.h>
@@ -481,7 +482,7 @@ void Envelope::PasteEnvelope( double t0, const Envelope *e, double sampleDur )
       return;
    }
 
-   // Make t0 relative to the offset of the envelope we are pasting into, 
+   // Make t0 relative to the offset of the envelope we are pasting into,
    // and trim it to the domain of this
    t0 = std::min( mTrackLen, std::max( 0.0, t0 - mOffset ) );
 
@@ -637,7 +638,7 @@ std::pair< int, int > Envelope::ExpandRegion
    }
 
    mTrackLen += tlen;
-   
+
    // Preserve the right-side limit.
    if ( index < range.second )
       // There was a control point already.
@@ -822,6 +823,14 @@ void Envelope::RescaleTimes( double newLength )
          point.SetT( point.GetT() * ratio );
    }
    mTrackLen = newLength;
+}
+
+void Envelope::RescaleTimesBy(double ratio)
+{
+   for (auto& point : mEnv)
+      point.SetT(point.GetT() * ratio);
+   if (mTrackLen != DBL_MAX)
+      mTrackLen *= ratio;
 }
 
 // Accessors

--- a/libraries/lib-mixer/Envelope.h
+++ b/libraries/lib-mixer/Envelope.h
@@ -127,6 +127,7 @@ public:
    void SetTrackLen( double trackLen, double sampleDur = 0.0 );
    void RescaleValues(double minValue, double maxValue);
    void RescaleTimes( double newLength );
+   void RescaleTimesBy(double ratio);
 
    // Accessors
    /** \brief Get envelope value at time t */

--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -66,6 +66,15 @@ void TimeTrack::CleanState()
    SetName(GetDefaultName());
 }
 
+void TimeTrack::DoOnProjectTempoChange(
+   const std::optional<double>& oldTempo, double newTempo)
+{
+   if (!oldTempo.has_value())
+      return;
+   const auto ratio = *oldTempo / newTempo;
+   mEnvelope->RescaleTimesBy(ratio);
+}
+
 TimeTrack::TimeTrack(const TimeTrack &orig, ProtectedCreationArg &&a,
    double *pT0, double *pT1
 )  : UniqueChannelTrack{ orig, std::move(a) }

--- a/libraries/lib-time-track/TimeTrack.h
+++ b/libraries/lib-time-track/TimeTrack.h
@@ -103,6 +103,9 @@ class TIME_TRACK_API TimeTrack final
  private:
    void CleanState();
 
+   void DoOnProjectTempoChange(
+      const std::optional<double>& oldTempo, double newTempo) override;
+
    std::unique_ptr<BoundedEnvelope> mEnvelope;
    bool             mDisplayLog;
    bool             mRescaleXMLValues; // needed for backward-compatibility with older project files

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -80,7 +80,8 @@ Track::Track()
    mOffset = 0.0;
 }
 
-Track::Track(const Track &orig, ProtectedCreationArg&&)
+Track::Track(const Track& orig, ProtectedCreationArg&&)
+    : mProjectTempo { orig.mProjectTempo }
 {
    mIndex = 0;
    mOffset = orig.mOffset;
@@ -233,12 +234,12 @@ void Track::DoSetLinkType(LinkType linkType, bool completeList)
 
    if (oldType == LinkType::None) {
       // Becoming linked
-   
+
       // First ensure there is no partner
       if (auto partner = GetLinkedTrack())
          partner->mpGroupData.reset();
       assert(!GetLinkedTrack());
-   
+
       // Change the link type
       MakeGroupData().mLinkType = linkType;
 
@@ -766,11 +767,11 @@ void TrackList::Clear(bool sendEvent)
    for ( auto pTrack: *this )
    {
       pTrack->SetOwner({}, {});
-      
+
       if (sendEvent)
          DeletionEvent(pTrack->shared_from_this(), false);
    }
-   
+
    for ( auto pTrack: mPendingUpdates )
    {
       pTrack->SetOwner({}, {});
@@ -1355,6 +1356,12 @@ bool ChannelAttachmentsBase::HandleXMLAttribute(
    [&](auto &pAttachment) {
       return pAttachment && pAttachment->HandleXMLAttribute(attr, valueView);
    });
+}
+
+void Track::OnProjectTempoChange(double newTempo)
+{
+   DoOnProjectTempoChange(mProjectTempo, newTempo);
+   mProjectTempo = newTempo;
 }
 
 // Undo/redo handling of selection changes

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -24,8 +24,9 @@
 #include <wx/longlong.h>
 
 #include <cassert>
-#include <vector>
 #include <functional>
+#include <optional>
+#include <vector>
 
 class BlockArray;
 class Envelope;
@@ -444,6 +445,12 @@ public:
     */
    constSamplePtr GetAppendBuffer(size_t ii) const;
    size_t GetAppendBufferLen() const;
+
+   void
+   OnProjectTempoChange(const std::optional<double>& oldTempo, double newTempo)
+   {
+      // Planned for use in https://github.com/audacity/audacity/issues/4850
+   }
 
 private:
    sampleCount GetNumSamples() const;

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -312,6 +312,13 @@ void WaveTrack::SetOffset(double o)
    mOffset = o;
 }
 
+void WaveTrack::DoOnProjectTempoChange(
+   const std::optional<double>& oldTempo, double newTempo)
+{
+   for (const auto& clip : mClips)
+      clip->OnProjectTempoChange(oldTempo, newTempo);
+}
+
 bool WaveTrack::LinkConsistencyFix(bool doFix, bool completeList)
 {
    auto err = !WritableSampleTrack::LinkConsistencyFix(doFix, completeList);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -602,6 +602,8 @@ private:
 
 private:
    void SetClipRates(double newRate);
+   void DoOnProjectTempoChange(
+      const std::optional<double>& oldTempo, double newTempo) override;
 
    bool GetOne(
       samplePtr buffer, sampleFormat format, sampleCount start, size_t len,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,6 +165,7 @@ list( APPEND SOURCES
       ProjectSelectionManager.h
       ProjectSettings.cpp
       ProjectSettings.h
+      ProjectTempoListener.cpp
       ProjectWindow.cpp
       ProjectWindow.h
       ProjectWindowBase.cpp

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -174,6 +174,17 @@ void LabelTrack::SetOffset(double dOffset)
       labelStruct.selectedRegion.move(dOffset);
 }
 
+void LabelTrack::DoOnProjectTempoChange(
+   const std::optional<double>& oldTempo, double newTempo)
+{
+   if (!oldTempo.has_value())
+      return;
+   const auto ratio = *oldTempo / newTempo;
+   for (auto& label : mLabels)
+      label.selectedRegion.setTimes(
+         label.getT0() * ratio, label.getT1() * ratio);
+}
+
 void LabelTrack::Clear(double b, double e)
 {
    // May DELETE labels, so use subscripts to iterate
@@ -424,7 +435,7 @@ LabelStruct LabelStruct::Import(wxTextFile &file, int &index)
          token = toker.GetNextToken();
 
       sr.setTimes( t0, t1 );
-      
+
       title = token;
    }
 

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -122,6 +122,8 @@ class AUDACITY_DLL_API LabelTrack final
 
 private:
    Track::Holder Clone() const override;
+   void DoOnProjectTempoChange(
+      const std::optional<double>& oldTempo, double newTempo) override;
 
 public:
    bool HandleXMLTag(const std::string_view& tag, const AttributesList& attrs) override;

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -213,6 +213,21 @@ double NoteTrack::GetEndTime() const
    return GetStartTime() + GetSeq().get_real_dur();
 }
 
+void NoteTrack::DoOnProjectTempoChange(
+   const std::optional<double>& oldTempo, double newTempo)
+{
+   if (!oldTempo.has_value())
+      return;
+   const auto ratio = *oldTempo / newTempo;
+   auto& seq = GetSeq();
+   seq.convert_to_beats();
+   const auto b1 = seq.get_dur();
+   seq.convert_to_seconds();
+   const auto newDuration = seq.get_dur() * ratio;
+   seq.stretch_region(0, b1, newDuration);
+   seq.set_real_dur(newDuration);
+}
+
 void NoteTrack::WarpAndTransposeNotes(double t0, double t1,
                                       const TimeWarper &warper,
                                       double semitones)

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -73,7 +73,7 @@ public:
    virtual ~NoteTrack();
 
    using Holder = std::shared_ptr<NoteTrack>;
-   
+
 private:
    Track::Holder Clone() const override;
 
@@ -81,7 +81,6 @@ public:
    double GetOffset() const override;
    double GetStartTime() const override;
    double GetEndTime() const override;
-
    Alg_seq &GetSeq() const;
 
    void WarpAndTransposeNotes(double t0, double t1,
@@ -215,6 +214,8 @@ public:
 #endif
 
    void AddToDuration( double delta );
+   void DoOnProjectTempoChange(
+      const std::optional<double>& oldTempo, double newTempo) override;
 
    // These are mutable to allow NoteTrack to switch details of representation
    // in logically const methods

--- a/src/ProjectTempoListener.cpp
+++ b/src/ProjectTempoListener.cpp
@@ -1,0 +1,53 @@
+#include "ClientData.h"
+#include "Observer.h"
+#include "Project.h"
+#include "ProjectTimeSignature.h"
+#include "Track.h"
+
+#include <cassert>
+
+class ProjectTempoListener final : public ClientData::Base
+{
+public:
+   ProjectTempoListener(AudacityProject& project, TrackList& trackList);
+   void OnProjectTempoChange(double newTempo);
+
+private:
+   TrackList& mTrackList;
+   Observer::Subscription mTrackListSubstription;
+   Observer::Subscription mProjectTimeSignatureSubscription;
+};
+
+static const AttachedProjectObjects::RegisteredFactory key {
+   [](AudacityProject& project) {
+      return std::make_shared<ProjectTempoListener>(
+         project, TrackList::Get(project));
+   }
+};
+
+ProjectTempoListener::ProjectTempoListener(
+   AudacityProject& project, TrackList& trackList)
+    : mTrackList { trackList }
+    , mTrackListSubstription { trackList.Subscribe(
+         [&project](const TrackListEvent& event) {
+            if (event.mType == TrackListEvent::ADDITION)
+            {
+               const auto tempo = ProjectTimeSignature::Get(project).GetTempo();
+               if (const auto track = event.mpTrack.lock())
+                  track->OnProjectTempoChange(tempo);
+            }
+         }) }
+{
+   mProjectTimeSignatureSubscription =
+      ProjectTimeSignature::Get(project).Subscribe(
+         [this](const TimeSignatureChangedMessage& event) {
+            OnProjectTempoChange(event.newTempo);
+         });
+   assert(mTrackList.empty()); // No need to call `OnProjectTempoChange` yet ...
+}
+
+void ProjectTempoListener::OnProjectTempoChange(double newTempo)
+{
+   for (auto track : mTrackList)
+      track->OnProjectTempoChange(newTempo);
+}


### PR DESCRIPTION
Resolves: #4849 

Propose a publisher of project tempo changes. `Track` has an abstract method for `WaveTrack`, `LabelTrack`, `NoteTrack` and `TimeTrack` to implement.
Add the implementation in `WaveTrack`. `WaveClipList` is proposed as wrapper of `WaveTrack`'s `mClipList` to make sure that newly-added clips get the most up-to-date project tempo information.

This PR is a fresh start for https://github.com/audacity/audacity/pull/4853.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

Things to test:
- [x] Project tempo change now affects all tracks except the audio tracks. For non-audio tracks, changing the project tempo should result in the track's horizontal scaling staying in sync with the beats-and-measure ruler. 
- [x] Audio tracks should still stay in sync with the time ruler
- [x] Change project tempo for all track types, and make sure that this is correct.
- [x] Copy/paste between the projects
- [x] Undo/Redo
- [x] Save, close and reopen projects should work

... and everything else you deem worthwhile testing of course.
