### PR TITLE
Set project tempo on clip when added to track

### DIFF
--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -1364,6 +1364,11 @@ void Track::OnProjectTempoChange(double newTempo)
    mProjectTempo = newTempo;
 }
 
+const std::optional<double>& Track::GetProjectTempo() const
+{
+   return mProjectTempo;
+}
+
 // Undo/redo handling of selection changes
 namespace {
 struct TrackListRestorer final : UndoStateExtension {

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -652,6 +652,9 @@ public:
    // Return true iff the attribute is recognized.
    bool HandleCommonXMLAttribute(const std::string_view& attr, const XMLAttributeValueView& valueView);
 
+protected:
+   const std::optional<double>& GetProjectTempo() const;
+
 private:
    virtual void DoOnProjectTempoChange(
       const std::optional<double>& oldTempo, double newTempo) = 0;

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -233,7 +233,7 @@ WaveTrack::WaveTrack(const WaveTrack &orig, ProtectedCreationArg &&a)
 {
    mLegacyProjectFileOffset = 0;
    for (const auto &clip : orig.mClips)
-      mClips.push_back(std::make_shared<WaveClip>(*clip, mpFactory, true));
+      InsertClip(std::make_shared<WaveClip>(*clip, mpFactory, true));
 }
 
 size_t WaveTrack::GetWidth() const
@@ -718,7 +718,7 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
          // Whole clip is in copy region
          //wxPrintf("copy: clip %i is in copy region\n", (int)clip);
 
-         newTrack->mClips.push_back(
+         newTrack->InsertClip(
             std::make_shared<WaveClip>(*clip, mpFactory, !forClipboard));
          WaveClip *const newClip = newTrack->mClips.back().get();
          newClip->Offset(-t0);
@@ -736,7 +736,7 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
          if (newClip->GetPlayStartTime() < 0)
             newClip->SetPlayStartTime(0);
 
-         newTrack->mClips.push_back(std::move(newClip)); // transfer ownership
+         newTrack->InsertClip(std::move(newClip)); // transfer ownership
       }
    }
 
@@ -755,7 +755,7 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
       placeholder->SetIsPlaceholder(true);
       placeholder->InsertSilence(0, (t1 - t0) - newTrack->GetEndTime());
       placeholder->Offset(newTrack->GetEndTime());
-      newTrack->mClips.push_back(std::move(placeholder)); // transfer ownership
+      newTrack->InsertClip(std::move(placeholder)); // transfer ownership
    }
 
    return result;
@@ -1164,7 +1164,7 @@ bool WaveTrack::AddClip(const std::shared_ptr<WaveClip> &clip)
 
    // Uncomment the following line after we correct the problem of zero-length clips
    //if (CanInsertClip(clip))
-      mClips.push_back(clip); // transfer ownership
+   InsertClip(clip); // transfer ownership
 
    return true;
 }
@@ -1306,7 +1306,7 @@ void WaveTrack::HandleClear(double t0, double t1,
    }
 
    for (auto &clip: clipsToAdd)
-      mClips.push_back(std::move(clip)); // transfer ownership
+      InsertClip(std::move(clip)); // transfer ownership
 }
 
 void WaveTrack::SyncLockAdjust(double oldT1, double newT1)
@@ -1508,7 +1508,7 @@ void WaveTrack::PasteWaveTrack(double t0, const WaveTrack* other)
                 newClip->SetName(MakeNewClipName());
             else
                 newClip->SetName(MakeClipCopyName(clip->GetName()));
-            mClips.push_back(std::move(newClip)); // transfer ownership
+            InsertClip(std::move(newClip)); // transfer ownership
         }
     }
 }
@@ -1539,6 +1539,14 @@ bool WaveTrack::RateConsistencyCheck() const
          return std::all_of(clips.begin(), clips.end(),
             [rate](auto &pClip){ return pClip->GetRate() == rate; });
       });
+}
+
+void WaveTrack::InsertClip(WaveClipHolder clip)
+{
+   const auto& tempo = GetProjectTempo();
+   if (tempo.has_value())
+      clip->OnProjectTempoChange(std::nullopt, *tempo);
+   mClips.push_back(std::move(clip));
 }
 
 /*! @excsafety{Weak} */
@@ -1593,7 +1601,7 @@ void WaveTrack::InsertSilence(double t, double len)
          mpFactory, mFormat, GetRate(), this->GetWaveColorIndex());
       clip->InsertSilence(0, len);
       // use No-fail-guarantee
-      mClips.push_back( std::move( clip ) );
+      InsertClip(std::move(clip));
       return;
    }
    else {
@@ -2527,7 +2535,7 @@ WaveClip* WaveTrack::CreateClip(double offset, const wxString& name)
       mpFactory, mFormat, GetRate(), GetWaveColorIndex());
    clip->SetName(name);
    clip->SetSequenceStartTime(offset);
-   mClips.push_back(std::move(clip));
+   InsertClip(std::move(clip));
 
    auto result = mClips.back().get();
    // TODO wide wave tracks -- for now assertion is correct because widths are
@@ -2710,7 +2718,7 @@ void WaveTrack::SplitAt(double t)
 
          // This could invalidate the iterators for the loop!  But we return
          // at once so it's okay
-         mClips.push_back(std::move(newClip)); // transfer ownership
+         InsertClip(std::move(newClip)); // transfer ownership
          return;
       }
    }

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -592,7 +592,8 @@ private:
    //
 
    /*!
-    @invariant all are non-null and match `this->GetWidth()`
+    * Do not call `mClips.push_back` directly. Use `InsertClip` instead.
+    * @invariant all are non-null and match `this->GetWidth()`
     */
    WaveClipHolders mClips;
 
@@ -619,6 +620,10 @@ private:
 
    //! Whether all clips have a common rate
    bool RateConsistencyCheck() const;
+
+   //! Sets project tempo on clip upon push. Use this instead of
+   //! `mClips.push_back`.
+   void InsertClip(WaveClipHolder clip);
 
    SampleBlockFactoryPtr mpFactory;
 


### PR DESCRIPTION
Resolves: #4869 

A small PR for a private method in `WaveTrack`, `InsertClip`.
This method inserts clips in order -> various places where the list was sorted are now obsolete.
The method also maintains project tempo information on a `WaveTrack`'s clips.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

Things to test:
Changes are rather limited, and so could be testing. Checked should nevertheless at least be
- [x] Creating clips on a track in random places should not break
- [x] Reordering them by means of copy-paste
- [x] Export and mix-and-rendering after the previous two steps.