### PR TITLE
Easy track iteration rewrites

### DIFF
--- a/libraries/lib-effects/EffectBase.cpp
+++ b/libraries/lib-effects/EffectBase.cpp
@@ -225,8 +225,9 @@ const AudacityProject *EffectBase::FindProject() const
 
 void EffectBase::CountWaveTracks()
 {
-   mNumTracks = mTracks->Selected< const WaveTrack >().size();
-   mNumGroups = mTracks->SelectedLeaders< const WaveTrack >().size();
+   const auto range = mTracks->SelectedLeaders<const WaveTrack>();
+   mNumTracks = range.sum(&WaveTrack::NChannels);
+   mNumGroups = range.size();
 }
 
 std::any EffectBase::BeginPreview(const EffectSettings &)

--- a/libraries/lib-sample-track/SampleTrack.h
+++ b/libraries/lib-sample-track/SampleTrack.h
@@ -42,6 +42,7 @@ public:
    // Fix the otherwise ambiguous lookup of these virtual function names
    using Track::GetStartTime;
    using Track::GetEndTime;
+   using Track::IsLeader;
 
    const TypeInfo &GetTypeInfo() const override;
    static const TypeInfo &ClassTypeInfo();

--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -150,11 +150,11 @@ bool TimeTrack::SupportsBasicEditing() const
    return false;
 }
 
-Track::Holder TimeTrack::PasteInto( AudacityProject &project ) const
+Track::Holder TimeTrack::PasteInto(AudacityProject &project) const
 {
    // Maintain uniqueness of the time track!
    std::shared_ptr<TimeTrack> pNewTrack;
-   if( auto pTrack = *TrackList::Get( project ).Any<TimeTrack>().begin() )
+   if (auto pTrack = *TrackList::Get(project).Leaders<TimeTrack>().begin())
       pNewTrack = pTrack->SharedPointer<TimeTrack>();
    else
       pNewTrack = std::make_shared<TimeTrack>();
@@ -358,7 +358,7 @@ static Mixer::WarpOptions::DefaultWarp::Scope installer{
 {
    if (pProject) {
       auto &list = TrackList::Get(*pProject);
-      if (auto pTimeTrack = *list.Any<const TimeTrack>().begin())
+      if (auto pTimeTrack = *list.Leaders<const TimeTrack>().begin())
          return pTimeTrack->GetEnvelope();
    }
    return nullptr;

--- a/libraries/lib-track-selection/SelectionState.h
+++ b/libraries/lib-track-selection/SelectionState.h
@@ -32,6 +32,9 @@ public:
    static void SelectTrackLength
       ( ViewInfo &viewInfo, Track &track, bool syncLocked );
 
+   /*!
+    @pre `track.IsLeader()`
+    */
    void SelectTrack(
       Track &track, bool selected, bool updateLastPicked );
    // Inclusive range of tracks, the limits specified in either order:
@@ -40,13 +43,19 @@ public:
    void SelectNone( TrackList &tracks );
    void ChangeSelectionOnShiftClick
       ( TrackList &tracks, Track &track );
-   void HandleListSelection
-      ( TrackList &tracks, ViewInfo &viewInfo, Track &track,
-        bool shift, bool ctrl, bool syncLocked );
+   /*!
+    @pre `track.IsLeader()`
+    */
+   void HandleListSelection(TrackList &tracks, ViewInfo &viewInfo,
+      Track &track, bool shift, bool ctrl, bool syncLocked);
 
 private:
    friend class SelectionStateChanger;
 
+   /*!
+    @invariant `mLastPickedTrack.expired() ||
+       mLastPickedTrack.lock()->IsLeader()`
+    */
    std::weak_ptr<Track> mLastPickedTrack;
 };
 

--- a/libraries/lib-track-selection/SyncLock.cpp
+++ b/libraries/lib-track-selection/SyncLock.cpp
@@ -54,7 +54,7 @@ void SyncLockState::SetSyncLock(bool flag)
 }
 
 namespace {
-inline bool IsSyncLockableNonSeparatorTrack( const Track *pTrack )
+inline bool IsSyncLockableNonSeparatorTrack(const Track *pTrack)
 {
    return pTrack && GetSyncLockPolicy::Call(*pTrack) == SyncLockPolicy::Grouped;
 }
@@ -75,11 +75,11 @@ bool IsGoodNextSyncLockTrack(const Track *t, bool inSeparatorSection)
    else if (isSeparator)
       return true;
    else
-      return IsSyncLockableNonSeparatorTrack( t );
+      return IsSyncLockableNonSeparatorTrack(t);
 }
 }
 
-bool SyncLock::IsSyncLockSelected( const Track *pTrack )
+bool SyncLock::IsSyncLockSelected(const Track *pTrack)
 {
    if (!pTrack)
       return false;
@@ -115,7 +115,7 @@ bool SyncLock::IsSelectedOrSyncLockSelected( const Track *pTrack )
 }
 
 namespace {
-std::pair<Track *, Track *> FindSyncLockGroup(  Track *pMember)
+std::pair<Track *, Track *> FindSyncLockGroup(Track *pMember)
 {
    if (!pMember)
       return { nullptr, nullptr };
@@ -126,8 +126,8 @@ std::pair<Track *, Track *> FindSyncLockGroup(  Track *pMember)
 
    // Step back through any label tracks.
    auto pList = pMember->GetOwner();
-   auto member = pList->Find(pMember);
-   while (*member && IsSeparatorTrack(*member) )
+   auto member = pList->FindLeader(pMember);
+   while (*member && IsSeparatorTrack(*member))
       --member;
 
    // Step back through the wave and note tracks before the label tracks.
@@ -142,12 +142,12 @@ std::pair<Track *, Track *> FindSyncLockGroup(  Track *pMember)
       // consider the track to be the sole member of a group.
       return { pMember, pMember };
 
-   auto last = pList->Find(first);
+   auto last = pList->FindLeader(first);
    auto next = last;
    bool inLabels = false;
 
    while (*++next) {
-      if ( ! IsGoodNextSyncLockTrack(*next, inLabels) )
+      if (!IsGoodNextSyncLockTrack(*next, inLabels))
          break;
       last = next;
       inLabels = IsSeparatorTrack(*last);

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -131,7 +131,7 @@ void Track::EnsureVisible( bool modifyState )
 {
    auto pList = mList.lock();
    if (pList)
-      pList->EnsureVisibleEvent( SharedPointer(), modifyState );
+      pList->EnsureVisibleEvent(SharedPointer(), modifyState);
 }
 
 Track::Holder Track::Duplicate() const
@@ -535,8 +535,11 @@ void TrackList::DataEvent(
 void TrackList::EnsureVisibleEvent(
    const std::shared_ptr<Track> &pTrack, bool modifyState )
 {
+   // Substitute leader track
+   const auto pLeader = *FindLeader(pTrack.get());
    QueueEvent({ TrackListEvent::TRACK_REQUEST_VISIBLE,
-      pTrack, static_cast<int>(modifyState) });
+      pLeader ? pLeader->SharedPointer() : nullptr,
+      static_cast<int>(modifyState) });
 }
 
 void TrackList::PermutationEvent(TrackNodePointer node)

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -527,9 +527,13 @@ private:
    bool GetSelected() const;
    virtual void SetSelected(bool s);
 
-   // The argument tells whether the last undo history state should be
-   // updated for the appearance change
-   void EnsureVisible( bool modifyState = false );
+   /*!
+    The owning TrackList emits a TRACK_REQUEST_VISIBLE event with the leader of
+    this track
+    The argument tells whether the last undo history state should be
+    updated for the appearance change
+    */
+   void EnsureVisible(bool modifyState = false);
 
 public:
 
@@ -1117,7 +1121,7 @@ struct TrackListEvent
       //! Posted when certain fields of a track change.
       TRACK_DATA_CHANGE,
 
-      //! Posted when a track needs to be scrolled into view.
+      //! Posted when a track needs to be scrolled into view; leader track only
       TRACK_REQUEST_VISIBLE,
 
       //! Posted when tracks are reordered but otherwise unchanged.

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2014,8 +2014,10 @@ std::optional<TranslatableString> WaveTrack::GetErrorOpening() const
 
 bool WaveTrack::CloseLock() noexcept
 {
-   for (const auto &clip : mClips)
-      clip->CloseLock();
+   assert(IsLeader());
+   for (const auto pChannel : TrackList::Channels(this))
+      for (const auto &clip : pChannel->mClips)
+         clip->CloseLock();
 
    return true;
 }

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2814,10 +2814,11 @@ void WaveTrack::MergeClips(int clipidx1, int clipidx2)
 */
 void WaveTrack::Resample(int rate, BasicUI::ProgressDialog *progress)
 {
-   for (const auto &clip : mClips)
-      clip->Resample(rate, progress);
-
-   SetRate(rate);
+   for (const auto pChannel : TrackList::Channels(this)) {
+      for (const auto &clip : pChannel->mClips)
+         clip->Resample(rate, progress);
+      pChannel->SetRate(rate);
+   }
 }
 
 namespace {

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -356,7 +356,10 @@ private:
    //
 
    //! Should be called upon project close.  Not balanced by unlocking calls.
-   /*! @excsafety{No-fail} */
+   /*!
+    @pre `IsLeader()`
+    @excsafety{No-fail}
+    */
    bool CloseLock() noexcept;
 
    //! Get access to the (visible) clips in the tracks, in unspecified order

--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -223,7 +223,7 @@ const ReservedCommandFlag&
 const ReservedCommandFlag&
    LabelTracksExistFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project){
-         return !TrackList::Get( project ).Any<const LabelTrack>().empty();
+         return !TrackList::Get(project).Leaders<const LabelTrack>().empty();
       }
    }; return flag; }
 const ReservedCommandFlag&

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -374,7 +374,7 @@ bool LabelDialog::TransferDataFromWindow()
    int tndx = 0;
 
    // Clear label tracks of labels
-   for (auto lt : mTracks->Any<LabelTrack>()) {
+   for (auto lt : mTracks->Leaders<LabelTrack>()) {
       ++tndx;
       if (!mSelectedTrack) {
          for (i = lt->GetNumLabels() - 1; i >= 0 ; i--) {
@@ -409,7 +409,7 @@ bool LabelDialog::TransferDataFromWindow()
       // Look for track with matching index
       tndx = 1;
       LabelTrack *lt{};
-      for (auto t : mTracks->Any<LabelTrack>()) {
+      for (auto t : mTracks->Leaders<LabelTrack>()) {
          lt = t;
          if (rd.index == tndx++) {
             break;
@@ -452,7 +452,7 @@ wxString LabelDialog::TrackName(int & index, const wxString &dflt)
 void LabelDialog::FindAllLabels()
 {
    // Add labels from all label tracks
-   for (auto lt : mTracks->Any<const LabelTrack>()) {
+   for (auto lt : mTracks->Leaders<const LabelTrack>()) {
       AddLabels(lt);
    }
 

--- a/src/Lyrics.cpp
+++ b/src/Lyrics.cpp
@@ -505,7 +505,7 @@ void LyricsPanel::DoUpdateLyrics()
 
    // Lyrics come from only the first label track.
    auto pLabelTrack =
-      *TrackList::Get( *mProject ).Any< const LabelTrack >().begin();
+      *TrackList::Get(*mProject).Leaders<const LabelTrack>().begin();
    if (!pLabelTrack)
       return;
 

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1505,7 +1505,7 @@ const ReservedCommandFlag&
          auto &tracks = TrackList::Get( project );
          return
 #ifdef EXPERIMENTAL_MIDI_OUT
-            !tracks.Any<const NoteTrack>().empty()
+            !tracks.Leaders<const NoteTrack>().empty()
          ||
 #endif
             !tracks.Any<const WaveTrack>().empty()

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -673,7 +673,7 @@ wxColour MixerTrackCluster::GetTrackColor()
 void MixerTrackCluster::HandleSelect(bool bShiftDown, bool bControlDown)
 {
    SelectUtilities::DoListSelection(*mProject,
-      mTrack.get(), bShiftDown, bControlDown, true);
+      *mTrack, bShiftDown, bControlDown, true);
 }
 
 void MixerTrackCluster::OnMouseEvent(wxMouseEvent& event)

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1111,7 +1111,8 @@ wxBitmap* MixerBoard::GetMusicalInstrumentBitmap(const Track* pTrack)
 
 bool MixerBoard::HasSolo()
 {
-   return !(( mTracks->Any<PlayableTrack>() + &PlayableTrack::GetSolo ).empty());
+   return
+      !(mTracks->Leaders<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
 }
 
 void MixerBoard::RefreshTrackClusters(bool bEraseBackground /*= true*/)
@@ -1508,7 +1509,7 @@ const ReservedCommandFlag&
             !tracks.Leaders<const NoteTrack>().empty()
          ||
 #endif
-            !tracks.Any<const WaveTrack>().empty()
+            !tracks.Leaders<const WaveTrack>().empty()
          ;
       }
    }; return flag; }

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -660,7 +660,7 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
       // making sure they all have the same rate
       const auto selectedTracks{ GetPropertiesOfSelected(*p) };
       const int rateOfSelected{ selectedTracks.rateOfSelected };
-      const int numberOfSelected{ selectedTracks.numberOfSelected };
+      const bool anySelected{ selectedTracks.anySelected };
       const bool allSameRate{ selectedTracks.allSameRate };
 
       if (!allSameRate) {
@@ -683,7 +683,7 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
                (trackRange + &Track::IsSelected).max(&Track::GetEndTime));
          }
          else {
-            if (numberOfSelected > 0 && rateOfSelected != options.rate) {
+            if (anySelected && rateOfSelected != options.rate) {
                AudacityMessageBox(XO(
                   "Too few tracks are selected for recording at this sample rate.\n"
                   "(Audacity requires two channels at the same sample rate for\n"
@@ -1314,10 +1314,9 @@ GetPropertiesOfSelected(const AudacityProject &proj)
    result.allSameRate = true;
 
    const auto selectedTracks{
-      TrackList::Get(proj).Selected< const WaveTrack >() };
+      TrackList::Get(proj).SelectedLeaders<const WaveTrack>() };
 
-   for (const auto & track : selectedTracks)
-   {
+   for (const auto & track : selectedTracks) {
       if (rateOfSelection != RATE_NOT_SELECTED &&
          track->GetRate() != rateOfSelection)
          result.allSameRate = false;
@@ -1325,7 +1324,7 @@ GetPropertiesOfSelected(const AudacityProject &proj)
          rateOfSelection = track->GetRate();
    }
 
-   result.numberOfSelected = selectedTracks.size();
+   result.anySelected = !selectedTracks.empty();
    result.rateOfSelected = rateOfSelection;
 
    return  result;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -335,9 +335,9 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
 
    bool hasaudio;
    if (nonWaveToo)
-      hasaudio = ! tracks.Any<PlayableTrack>().empty();
+      hasaudio = ! tracks.Leaders<PlayableTrack>().empty();
    else
-      hasaudio = ! tracks.Any<WaveTrack>().empty();
+      hasaudio = ! tracks.Leaders<WaveTrack>().empty();
 
    double latestEnd = tracks.GetEndTime();
 

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -188,7 +188,7 @@ struct PropertiesOfSelected
 {
    bool allSameRate{ false };
    int rateOfSelected{ RATE_NOT_SELECTED };
-   int numberOfSelected{ 0 };
+   bool anySelected{ false };
 };
 
 AUDACITY_DLL_API

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -84,7 +84,7 @@ void ProjectFileManager::DiscardAutosave(const FilePath &filename)
    projectFileManager.ReadProjectFile(filename, true);
 
    if (projectFileManager.mLastSavedTracks) {
-      for (auto wt : projectFileManager.mLastSavedTracks->Any<WaveTrack>())
+      for (auto wt : projectFileManager.mLastSavedTracks->Leaders<WaveTrack>())
          wt->CloseLock();
       projectFileManager.mLastSavedTracks.reset();
    }
@@ -755,10 +755,8 @@ void ProjectFileManager::CompactProjectOnClose()
    // sample block objects in memory.
    if (mLastSavedTracks)
    {
-      for (auto wt : mLastSavedTracks->Any<WaveTrack>())
-      {
+      for (auto wt : mLastSavedTracks->Leaders<WaveTrack>())
          wt->CloseLock();
-      }
 
       // Attempt to compact the project
       projectFileIO.Compact( { mLastSavedTracks.get() } );
@@ -1065,7 +1063,7 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
       // may have spared the files at the expense of leaked memory).  But
       // here is a better way to accomplish the intent, doing like what happens
       // when the project closes:
-      for ( auto pTrack : tracks.Any< WaveTrack >() )
+      for (auto pTrack : tracks.Leaders<WaveTrack>())
          pTrack->CloseLock();
 
       tracks.Clear(); //tracks.Clear(true);

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1032,7 +1032,7 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
          formats.GetBandwidthSelectionFormatName());
       
       ProjectHistory::Get( project ).InitialState();
-      TrackFocus::Get( project ).Set( *tracks.Any().begin() );
+      TrackFocus::Get(project).Set(*tracks.Leaders().begin());
       window.HandleResize();
       trackPanel.Refresh(false);
 

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -298,7 +298,7 @@ bool ProjectFileManager::DoSave(const FilePath & fileName, const bool fromSaveAs
       }
 
       auto &tracks = TrackList::Get( proj );
-      if (!tracks.Any())
+      if (tracks.empty())
       {
          if (UndoManager::Get( proj ).UnsavedChanges() &&
                settings.EmptyCanBeDirty())
@@ -1105,7 +1105,7 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
    // In case the project had soloed tracks before importing,
    // all newly imported tracks are muted.
    const bool projectHasSolo =
-      !(tracks.Any<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
+      !(tracks.Leaders<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
    if (projectHasSolo)
    {
       // Iterate vector of vectors of pointers to tracks that are not yet

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -148,7 +148,7 @@ double ProjectSelectionManager::SSBL_GetRate() const
    auto &tracks = TrackList::Get( project );
    // Return maximum of project rate and all track rates.
    return std::max( ProjectRate::Get( project ).GetRate(),
-      tracks.Any<const WaveTrack>().max( &WaveTrack::GetRate ) );
+      tracks.Leaders<const WaveTrack>().max(&WaveTrack::GetRate));
 }
 
 const NumericFormatSymbol &

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1698,9 +1698,9 @@ void ProjectWindow::ZoomAfterImport(Track *pTrack)
 
    trackPanel.SetFocus();
    if (!pTrack)
-      pTrack = *tracks.Selected().begin();
+      pTrack = *tracks.SelectedLeaders().begin();
    if (!pTrack)
-      pTrack = *tracks.Any().begin();
+      pTrack = *tracks.Leaders().begin();
    if (pTrack) {
       TrackFocus::Get(project).Set(pTrack);
       pTrack->EnsureVisible();

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -123,6 +123,8 @@ namespace
    template <typename Visitor>
    void VisitRealtimeEffectStateUIs(SampleTrack& track, Visitor&& visitor)
    {
+      if (!track.IsLeader())
+         return;
       auto& effects = RealtimeEffectList::Get(track);
       effects.Visit(
          [visitor](auto& effectState, bool)
@@ -1042,7 +1044,7 @@ struct RealtimeEffectPanel::PrefsListenerHelper : PrefsListener
    void UpdatePrefs() override
    {
       auto& trackList = TrackList::Get(mProject);
-      for (auto waveTrack : trackList.Any<WaveTrack>())
+      for (auto waveTrack : trackList.Leaders<WaveTrack>())
          ReopenRealtimeEffectUIData(mProject, *waveTrack);
    }
 };
@@ -1190,7 +1192,7 @@ RealtimeEffectPanel::RealtimeEffectPanel(
          auto& trackList = TrackList::Get(mProject);
 
          // Realtime effect UI is only updated on Undo or Redo
-         auto waveTracks = trackList.Any<WaveTrack>();
+         auto waveTracks = trackList.Leaders<WaveTrack>();
          
          if (
             message.type == UndoRedoMessage::Type::UndoOrRedo ||

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -118,25 +118,29 @@ bool SelectAllIfNoneAndAllowed( AudacityProject &project )
    return true;
 }
 
-void DoListSelection
-(AudacityProject &project, Track *t, bool shift, bool ctrl, bool modifyState)
+void DoListSelection(
+   AudacityProject &project, Track &t, bool shift, bool ctrl, bool modifyState)
 {
-   auto &tracks = TrackList::Get( project );
-   auto &selectionState = SelectionState::Get( project );
-   auto &viewInfo = ViewInfo::Get( project );
-   auto &window = GetProjectFrame( project );
+   auto &tracks = TrackList::Get(project);
+   auto &selectionState = SelectionState::Get(project);
+   auto &viewInfo = ViewInfo::Get(project);
+   auto &window = GetProjectFrame(project);
 
    auto isSyncLocked = SyncLockState::Get(project).IsSyncLocked();
+   // Substitute the leader to satisfy precondition
+   auto pT = *tracks.FindLeader(&t);
+   if (!pT)
+      return;
 
    selectionState.HandleListSelection(
-      tracks, viewInfo, *t,
-      shift, ctrl, isSyncLocked );
+      tracks, viewInfo, *pT,
+      shift, ctrl, isSyncLocked);
 
-   if (! ctrl )
-      TrackFocus::Get( project ).Set( t );
+   if (!ctrl)
+      TrackFocus::Get(project).Set(&t);
    window.Refresh(false);
    if (modifyState)
-      ProjectHistory::Get( project ).ModifyState(true);
+      ProjectHistory::Get(project).ModifyState(true);
 }
 
 void DoSelectAll(AudacityProject &project)

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -160,10 +160,10 @@ void DoSelectSomething(AudacityProject &project)
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
 
    bool bTime = selectedRegion.isPoint();
-   bool bTracks = tracks.Selected().empty();
+   bool bTracks = tracks.SelectedLeaders().empty();
 
-   if( bTime || bTracks )
-      DoSelectTimeAndTracks( project, bTime, bTracks );
+   if (bTime || bTracks)
+      DoSelectTimeAndTracks(project, bTime, bTracks);
 }
 
 void ActivatePlayRegion(AudacityProject &project)

--- a/src/SelectUtilities.h
+++ b/src/SelectUtilities.h
@@ -23,9 +23,8 @@ AUDACITY_DLL_API void DoSelectTimeAndTracks(
 AUDACITY_DLL_API void SelectAllIfNone( AudacityProject &project );
 AUDACITY_DLL_API bool SelectAllIfNoneAndAllowed( AudacityProject &project );
 AUDACITY_DLL_API void SelectNone( AudacityProject &project );
-AUDACITY_DLL_API void DoListSelection(
-   AudacityProject &project, Track *t,
-   bool shift, bool ctrl, bool modifyState );
+AUDACITY_DLL_API void DoListSelection(AudacityProject &project, Track &t,
+   bool shift, bool ctrl, bool modifyState);
 AUDACITY_DLL_API void DoSelectAll( AudacityProject &project );
 AUDACITY_DLL_API void DoSelectAllAudio( AudacityProject &project );
 AUDACITY_DLL_API void DoSelectSomething( AudacityProject &project );

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -1130,7 +1130,7 @@ void OnTimerRecord(const CommandContext &context)
    // preventing issues surrounding "dirty" projects when Automatic Save/Export
    // is used in Timer Recording.
    if ((undoManager.UnsavedChanges()) &&
-       (TrackList::Get( project ).Any() || settings.EmptyCanBeDirty())) {
+       (!TrackList::Get(project).empty() || settings.EmptyCanBeDirty())) {
       AudacityMessageBox(
          XO(
 "Timer Recording cannot be used while you have unsaved changes.\n\nPlease save or close this project and try again."),

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -1145,7 +1145,7 @@ void OnTimerRecord(const CommandContext &context)
    // but we want to warn the user about potential problems from the very start.
    const auto selectedTracks{ GetPropertiesOfSelected(project) };
    const int rateOfSelected{ selectedTracks.rateOfSelected };
-   const int numberOfSelected{ selectedTracks.numberOfSelected };
+   const bool anySelected{ selectedTracks.anySelected };
    const bool allSameRate{ selectedTracks.allSameRate };
 
    if (!allSameRate) {
@@ -1159,7 +1159,7 @@ void OnTimerRecord(const CommandContext &context)
 
    const auto existingTracks{ ProjectAudioManager::ChooseExistingRecordingTracks(project, true, rateOfSelected) };
    if (existingTracks.empty()) {
-      if (numberOfSelected > 0 && rateOfSelected !=
+      if (anySelected && rateOfSelected !=
           ProjectRate::Get(project).GetRate()) {
          AudacityMessageBox(XO(
             "Too few tracks are selected for recording at this sample rate.\n"

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1696,15 +1696,15 @@ wxRect TrackPanel::FindFocusedTrackRect( const Track * target )
    return rect;
 }
 
-std::vector<wxRect> TrackPanel::FindRulerRects( const Track *target )
+std::vector<wxRect> TrackPanel::FindRulerRects(const Channel &target)
 {
    std::vector<wxRect> results;
-   if (target)
-      VisitCells( [&]( const wxRect &rect, TrackPanelCell &visited ) {
-         if (auto pRuler = dynamic_cast<const ChannelVRulerControls*>(&visited);
-             pRuler && pRuler->FindTrack().get() == target)
-            results.push_back(rect);
-      } );
+   VisitCells( [&](const wxRect &rect, TrackPanelCell &visited) {
+      if (auto pRuler = dynamic_cast<const ChannelVRulerControls*>(&visited))
+         if (auto pView = pRuler->GetChannelView())
+            if (pView->FindChannel().get() == &target)
+               results.push_back(rect);
+   } );
    return results;
 }
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -839,10 +839,10 @@ void TrackPanel::DrawTracks(wxDC * dc)
    brushFlag   = (ToolCodes::brushTool == settings.GetTool());
 #endif
 
-   const bool hasSolo = GetTracks()->Any< PlayableTrack >()
-      .any_of( []( const PlayableTrack *pt ) {
-         pt = static_cast< const PlayableTrack * >(
-            pt->SubstitutePendingChangedTrack().get() );
+   const bool hasSolo = GetTracks()->Leaders<PlayableTrack>()
+      .any_of( [](const PlayableTrack *pt) {
+         pt = static_cast<const PlayableTrack *>(
+            pt->SubstitutePendingChangedTrack().get());
          return (pt && pt->GetSolo());
       } );
 
@@ -1603,7 +1603,7 @@ struct Subgroup final : TrackPanelGroup {
       Refinement refinement;
 
       auto &tracks = *mPanel.GetTracks();
-      if (tracks.Any())
+      if (!tracks.empty())
          refinement.emplace_back( yy, EmptyCell::Instance() ),
          yy += kTopMargin;
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1006,14 +1006,15 @@ void TrackPanel::OnEnsureVisible(const TrackListEvent & e)
    bool modifyState = e.mExtra;
    auto pTrack = e.mpTrack.lock();
    auto t = pTrack.get();
+   // Promised by TrackListEvent for this event type:
+   assert(!t || t->IsLeader());
    int trackTop = 0;
    int trackHeight =0;
    for (auto it : GetTracks()->Leaders()) {
       trackTop += trackHeight;
       trackHeight = ChannelView::GetChannelGroupHeight(it);
 
-      // TODO wide wave tracks -- will need just one equality test
-      if (TrackList::Channels(it).contains(t)) {
+      if (it == t) {
          //We have found the track we want to ensure is visible.
 
          //Get the size of the trackpanel.
@@ -1036,8 +1037,8 @@ void TrackPanel::OnEnsureVisible(const TrackListEvent & e)
    }
    Refresh(false);
 
-   if ( modifyState )
-      ProjectHistory::Get( *GetProject() ).ModifyState( false );
+   if (modifyState)
+      ProjectHistory::Get(*GetProject()).ModifyState(false);
 }
 
 // 0.0 scrolls to top

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -35,6 +35,7 @@ struct AudioIOEvent;
 // All cells of the TrackPanel are subclasses of this
 class CommonTrackPanelCell;
 
+class Channel;
 class SpectrumAnalyst;
 class Track;
 class TrackList;
@@ -158,7 +159,7 @@ public:
     (There may be multiple sub-views, each with a ruler.)
     If target is nullptr, returns an empty vector.
     */
-   std::vector<wxRect> FindRulerRects( const Track * target );
+   std::vector<wxRect> FindRulerRects(const Channel &target);
 
 protected:
    // Get the root object defining a recursive subdivision of the panel's

--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -73,7 +73,7 @@ std::shared_ptr<Track> TrackPanelAx::GetFocus()
       }
       if (!focusedTrack) {
          focusedTrack =
-            Track::SharedPointer( *GetTracks().Any().first );
+            Track::SharedPointer(*GetTracks().Leaders().first);
          // only call SetFocus if the focus has changed to avoid
          // unnecessary focus events
          if (focusedTrack) 
@@ -107,8 +107,8 @@ std::shared_ptr<Track> TrackPanelAx::SetFocus( std::shared_ptr<Track> track )
    }
 #endif
 
-   if( !track )
-      track = Track::SharedPointer( *GetTracks().Any().begin() );
+   if (!track)
+      track = Track::SharedPointer(*GetTracks().Leaders().begin());
 
    if ( mFocusedTrack.lock() != track ) {
       mFocusedTrack = track;

--- a/src/TrackPanelAx.h
+++ b/src/TrackPanelAx.h
@@ -165,10 +165,13 @@ public:
    TrackFocus( const TrackFocus & ) PROHIBITED;
    TrackFocus& operator=( const TrackFocus & ) PROHIBITED;
 
-   // Report the currently focused track, which may be null, otherwise is
-   // a leader track
-   // This function is not const, because it may have a side effect of setting
-   // a focus if none was already set
+   /*!
+    @return the currently focused track, which may be null, otherwise is
+    a leader track
+   
+    This function is not const, because it may have a side effect of setting
+    a focus if none was already set
+    */
    Track *Get();
 
    // Set the track focus to a given track or to null

--- a/src/commands/GetInfoCommand.cpp
+++ b/src/commands/GetInfoCommand.cpp
@@ -709,24 +709,26 @@ void GetInfoCommand::ExploreTrackPanel( const CommandContext &context,
    AudacityProject * pProj = &context.project;
    auto &tp = TrackPanel::Get( *pProj );
    wxRect panelRect{ {}, tp.GetSize() };
-   for ( auto t : TrackList::Get( *pProj ).Any() ) {
-      auto rulers = tp.FindRulerRects(t);
-      for (auto &R : rulers) {
-         if (!R.Intersects(panelRect))
-            continue;
-         R.SetPosition( R.GetPosition() + P );
-         context.StartStruct();
-         context.AddItem( depth, "depth" );
-         context.AddItem( "VRuler", "label" );
-         context.StartField("box");
-         context.StartArray();
-         context.AddItem( R.GetLeft() );
-         context.AddItem( R.GetTop() );
-         context.AddItem( R.GetRight() );
-         context.AddItem( R.GetBottom() );
-         context.EndArray();
-         context.EndField();
-         context.EndStruct();
+   for (auto leader : TrackList::Get(*pProj).Leaders()) {
+      for (auto t : leader->Channels()) {
+         auto rulers = tp.FindRulerRects(*t);
+         for (auto &R : rulers) {
+            if (!R.Intersects(panelRect))
+               continue;
+            R.SetPosition( R.GetPosition() + P );
+            context.StartStruct();
+            context.AddItem( depth, "depth" );
+            context.AddItem( "VRuler", "label" );
+            context.StartField("box");
+            context.StartArray();
+            context.AddItem( R.GetLeft() );
+            context.AddItem( R.GetTop() );
+            context.AddItem( R.GetRight() );
+            context.AddItem( R.GetBottom() );
+            context.EndArray();
+            context.EndField();
+            context.EndStruct();
+         }
       }
    }
 }

--- a/src/commands/ImportExportCommands.cpp
+++ b/src/commands/ImportExportCommands.cpp
@@ -61,7 +61,7 @@ void ImportCommand::PopulateOrExchange(ShuttleGui & S)
 
 bool ImportCommand::Apply(const CommandContext & context)
 {
-   bool wasEmpty = TrackList::Get( context.project ).Any().empty();
+   bool wasEmpty = TrackList::Get(context.project).empty();
    bool success = ProjectFileManager::Get( context.project )
       .Import(mFileName, false);
 

--- a/src/commands/SetLabelCommand.cpp
+++ b/src/commands/SetLabelCommand.cpp
@@ -89,7 +89,7 @@ bool SetLabelCommand::Apply(const CommandContext & context)
    LabelTrack *labelTrack = nullptr;
    auto ii = mLabelIndex;
    if ( mLabelIndex >= 0 ) {
-      for (auto lt : tracks.Any<LabelTrack>()) {
+      for (auto lt : tracks.Leaders<LabelTrack>()) {
          const auto &labels = lt->GetLabels();
          const auto nLabels = labels.size();
          if( ii >= (int)nLabels )

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -421,7 +421,7 @@ void EffectChangePitch::DeduceFrequencies()
     auto FirstTrack = [&]()->const WaveTrack *{
       if( IsBatchProcessing() || !inputTracks() )
          return nullptr;
-      return *( inputTracks()->Selected< const WaveTrack >() ).first;
+      return *(inputTracks()->SelectedLeaders<const WaveTrack>()).first;
    };
 
    m_dStartFrequency = 261.265;// Middle C.

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -350,7 +350,7 @@ bool EffectCompressor::InitPass1()
       DisableSecondPass();
 
    // Find the maximum block length required for any track
-   size_t maxlen = inputTracks()->Selected< const WaveTrack >().max(
+   size_t maxlen = inputTracks()->SelectedLeaders<const WaveTrack>().max(
       &WaveTrack::GetMaxBlockSize
    );
    mFollow1.reset();

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -380,7 +380,7 @@ void ContrastDialog::OnGetForeground(wxCommandEvent & /*event*/)
    auto p = FindProjectFromWindow( this );
    auto &selectedRegion = ViewInfo::Get( *p ).selectedRegion;
 
-   if( TrackList::Get( *p ).Selected< const WaveTrack >() ) {
+   if (TrackList::Get(*p).SelectedLeaders<const WaveTrack>()) {
       mForegroundStartT->SetValue(selectedRegion.t0());
       mForegroundEndT->SetValue(selectedRegion.t1());
    }
@@ -396,7 +396,7 @@ void ContrastDialog::OnGetBackground(wxCommandEvent & /*event*/)
    auto p = FindProjectFromWindow( this );
    auto &selectedRegion = ViewInfo::Get( *p ).selectedRegion;
 
-   if( TrackList::Get( *p ).Selected< const WaveTrack >() ) {
+   if (TrackList::Get(*p).SelectedLeaders<const WaveTrack>()) {
       mBackgroundStartT->SetValue(selectedRegion.t0());
       mBackgroundEndT->SetValue(selectedRegion.t1());
    }

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1330,9 +1330,9 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
       trackPanel.VerticalScroll( 1.0 );
    }
    else {
-      auto pTrack = *tracks.Selected().begin();
+      auto pTrack = *tracks.SelectedLeaders().begin();
       if (!pTrack)
-         pTrack = *tracks.Any().begin();
+         pTrack = *tracks.Leaders().begin();
       if (pTrack) {
          TrackFocus::Get(project).Set(pTrack);
          pTrack->EnsureVisible();

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -323,7 +323,8 @@ bool EffectEqualization::Init()
    double rate = 0.0;
 
    if (const auto project = FindProject()) {
-      auto trackRange = TrackList::Get(*project).Selected<const WaveTrack>();
+      auto trackRange =
+         TrackList::Get(*project).SelectedLeaders<const WaveTrack>();
       if (trackRange) {
          rate = (*(trackRange.first++)) -> GetRate();
          ++selcount;

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -86,7 +86,7 @@ bool EffectFindClipping::Process(EffectInstance &, EffectSettings &)
    std::optional<ModifiedAnalysisTrack> modifiedTrack;
    const wxString name{ _("Clipping") };
 
-   auto clt = *inputTracks()->Any< const LabelTrack >().find_if(
+   auto clt = *inputTracks()->Leaders<const LabelTrack>().find_if(
       [&]( const Track *track ){ return track->GetName() == name; } );
 
    LabelTrack *lt{};

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -346,7 +346,7 @@ void EffectLoudness::AllocBuffers(TrackList &outputs)
    double maxSampleRate = 0;
    mProcStereo = false;
 
-   for (auto track : outputs.Selected<WaveTrack>() + &Track::Any) {
+   for (auto track : outputs.SelectedLeaders<WaveTrack>() + &Track::Any) {
       mTrackBufferCapacity = std::max(mTrackBufferCapacity, track->GetMaxBlockSize());
       maxSampleRate = std::max(maxSampleRate, track->GetRate());
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -623,7 +623,7 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
 
    EffectOutputTracks outputs{ *mTracks };
 
-   auto track = *(outputs.Get().Selected<const WaveTrack>()).begin();
+   auto track = *(outputs.Get().SelectedLeaders<const WaveTrack>()).begin();
    if (!track)
       return false;
 

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -225,7 +225,7 @@ bool EffectScienFilter::Init()
    int selcount = 0;
    double rate = 0.0;
 
-   auto trackRange = inputTracks()->Selected< const WaveTrack >();
+   auto trackRange = inputTracks()->SelectedLeaders<const WaveTrack>();
 
    {
       auto t = *trackRange.begin();
@@ -236,23 +236,18 @@ bool EffectScienFilter::Init()
          / 2.0;
    }
 
-   for (auto t : trackRange)
-   {
+   for (auto t : trackRange) {
       if (selcount == 0)
-      {
          rate = t->GetRate();
-      }
-      else
-      {
-         if (t->GetRate() != rate)
-         {
+      else {
+         if (t->GetRate() != rate) {
             EffectUIServices::DoMessageBox(*this,
                XO(
 "To apply a filter, all selected tracks must have the same sample rate.") );
             return false;
          }
       }
-      selcount++;
+      ++selcount;
    }
 
    return true;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1593,7 +1593,7 @@ bool NyquistEffect::ProcessOne(EffectOutputTracks *pOutputs)
       mProjectChanged = true;
       unsigned int numLabels = nyx_get_num_labels();
       unsigned int l;
-      auto ltrack = *pOutputs->Get().Any<LabelTrack>().begin();
+      auto ltrack = *pOutputs->Get().Leaders<LabelTrack>().begin();
       if (!ltrack) {
          auto newTrack = std::make_shared<LabelTrack>();
          //new track name should be unique among the names in the list of input tracks, not output

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -733,7 +733,8 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
 
    mNumSelectedChannels = bOnePassTool
       ? 0
-      : oOutputs->Get().Selected<const WaveTrack>().size();
+      : oOutputs->Get().SelectedLeaders<const WaveTrack>()
+         .sum(&WaveTrack::NChannels);
 
    mDebugOutput = {};
    if (!mHelpFile.empty() && !mHelpFileExists) {

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -229,7 +229,8 @@ std::unique_ptr<Mixer> ExportPlugin::CreateMixer(const TrackList &tracks,
 {
    Mixer::Inputs inputs;
 
-   bool anySolo = !(( tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
+   bool anySolo =
+      !(tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
    const auto range = tracks.Leaders<const WaveTrack>()
       + (selectionOnly ? &Track::IsSelected : &Track::Any)
@@ -509,7 +510,7 @@ bool Exporter::ExamineTracks()
    auto &tracks = TrackList::Get(*mProject);
 
    bool anySolo =
-      !((tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo).empty());
+      !(tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
    const auto range = tracks.Leaders<const WaveTrack>()
       + (mSelectedOnly ? &Track::IsSelected : &Track::Any)
@@ -1338,7 +1339,8 @@ ExportMixerDialog::ExportMixerDialog( const TrackList *tracks, bool selectedOnly
 
    unsigned numTracks = 0;
 
-   bool anySolo = !(( tracks->Any<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
+   bool anySolo =
+      !(tracks->Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
    for (auto t :
          tracks->Any< const WaveTrack >()

--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -1343,21 +1343,21 @@ ExportMixerDialog::ExportMixerDialog( const TrackList *tracks, bool selectedOnly
       !(tracks->Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
    for (auto t :
-         tracks->Any< const WaveTrack >()
-            + ( selectedOnly ? &Track::IsSelected : &Track::Any  )
-            - ( anySolo ? &WaveTrack::GetNotSolo :  &WaveTrack::GetMute)
+      tracks->Leaders<const WaveTrack>()
+         + (selectedOnly ? &Track::IsSelected : &Track::Any)
+         - (anySolo ? &WaveTrack::GetNotSolo :  &WaveTrack::GetMute)
    ) {
-      numTracks++;
+      numTracks += t->NChannels();
       const wxString sTrackName = (t->GetName()).Left(20);
       if (IsMono(*t))
          // No matter whether it's panned hard left or right
          mTrackNames.push_back(sTrackName);
-      else if (PlaysLeft(*t))
-      /* i18n-hint: track name and L abbreviating Left channel */
-         mTrackNames.push_back( wxString::Format( _( "%s - L" ), sTrackName ) );
-      else if (PlaysRight(*t))
-      /* i18n-hint: track name and R abbreviating Right channel */
-         mTrackNames.push_back( wxString::Format( _( "%s - R" ), sTrackName ) );
+      else {
+         /* i18n-hint: track name and L abbreviating Left channel */
+         mTrackNames.push_back(XO("%s - L").Format(sTrackName).Translation());
+         /* i18n-hint: track name and R abbreviating Right channel */
+         mTrackNames.push_back(XO("%s - R").Format(sTrackName).Translation());
+      }
    }
 
    // JKC: This is an attempt to fix a 'watching brief' issue, where the slider is

--- a/src/export/ExportMIDI.cpp
+++ b/src/export/ExportMIDI.cpp
@@ -33,7 +33,7 @@ namespace {
 const ReservedCommandFlag&
    NoteTracksExistFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project){
-         return !TrackList::Get( project ).Any<const NoteTrack>().empty();
+         return !TrackList::Get(project).Leaders<const NoteTrack>().empty();
       }
    }; return flag; }  //gsw
 
@@ -47,7 +47,7 @@ void OnExportMIDI(const CommandContext &context)
 
    // Make sure that there is
    // exactly one NoteTrack selected.
-   const auto range = tracks.Selected< const NoteTrack >();
+   const auto range = tracks.SelectedLeaders<const NoteTrack>();
    const auto numNoteTracksSelected = range.size();
 
    if(numNoteTracksSelected > 1) {

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -704,7 +704,7 @@ static unsigned GetNumExportChannels( const TrackList &tracks )
       !(tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
    // Want only unmuted wave tracks.
-   const auto range = tracks.Any<const WaveTrack>() -
+   const auto range = tracks.Leaders<const WaveTrack>() -
       (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute);
    return std::all_of(range.begin(), range.end(),
       [](auto *pTrack){ return IsMono(*pTrack); }

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -172,7 +172,7 @@ void ExportMultipleDialog::CountTracksAndLabels()
       (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute)).size();
 
    // only the first label track
-   mLabels = *mTracks->Any< const LabelTrack >().begin();
+   mLabels = *mTracks->Leaders<const LabelTrack>().begin();
    mNumLabels = mLabels ? mLabels->GetNumLabels() : 0;
 }
 

--- a/src/export/ExportMultiple.cpp
+++ b/src/export/ExportMultiple.cpp
@@ -165,7 +165,8 @@ ExportMultipleDialog::~ExportMultipleDialog()
 
 void ExportMultipleDialog::CountTracksAndLabels()
 {
-   bool anySolo = !(( mTracks->Any<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
+   bool anySolo =
+      !(mTracks->Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
    mNumWaveTracks =
       (mTracks->Leaders< const WaveTrack >() - 
@@ -700,7 +701,7 @@ bool ExportMultipleDialog::DirOk()
 static unsigned GetNumExportChannels( const TrackList &tracks )
 {
    bool anySolo =
-      !((tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo).empty());
+      !(tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
    // Want only unmuted wave tracks.
    const auto range = tracks.Any<const WaveTrack>() -
@@ -890,7 +891,8 @@ ProgressResult ExportMultipleDialog::ExportMultipleByTrack(bool byName,
    for (auto tr : mTracks->SelectedLeaders<WaveTrack>())
       tr->SetSelected(false);
 
-   bool anySolo = !(( mTracks->Any<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
+   bool anySolo =
+      !(mTracks->Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
    bool skipSilenceAtBeginning;
    gPrefs->Read(wxT("/AudioFiles/SkipSilenceAtBeginning"), &skipSilenceAtBeginning, false);

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -890,7 +890,7 @@ bool AUPImportFileHandle::HandleTimeTrack(XMLTagHandler *&handler)
 
    // Bypass this timetrack if the project already has one
    // (See HandleTimeEnvelope and HandleControlPoint also)
-   if (*tracks.Any<TimeTrack>().begin())
+   if (*tracks.Leaders<TimeTrack>().begin())
    {
       AudacityMessageBox(
          XO("The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."),

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -53,7 +53,7 @@ bool DoImportMIDI( AudacityProject &project, const FilePath &fileName )
       // In case the project had soloed tracks before importing,
       // the newly imported track is muted.
       const bool projectHasSolo =
-         !(tracks.Any<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
+         !(tracks.Leaders<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
 #ifdef EXPERIMENTAL_MIDI_OUT
       if (projectHasSolo)
          pTrack->SetMute(true);

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -264,7 +264,7 @@ int FindClipBoundaries
    auto &tracks = TrackList::Get( project );
    finalResults.clear();
 
-   bool anyWaveTracksSelected{ tracks.Selected< const WaveTrack >() };
+   bool anyWaveTracksSelected{ tracks.SelectedLeaders<const WaveTrack>() };
 
 
    // first search the tracks individually
@@ -502,7 +502,7 @@ int FindClips
    auto &tracks = TrackList::Get( project );
    finalResults.clear();
 
-   bool anyWaveTracksSelected{ tracks.Selected< const WaveTrack >() };
+   bool anyWaveTracksSelected{ tracks.SelectedLeaders<const WaveTrack>() };
 
    // first search the tracks individually
 

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -51,7 +51,7 @@ bool DoPasteText(AudacityProject &project)
    auto &window = ProjectWindow::Get( project );
 
    // Paste into the active label (if any)
-   for (auto pLabelTrack : tracks.Any<LabelTrack>()) {
+   for (auto pLabelTrack : tracks.Leaders<LabelTrack>()) {
       // Does this track have an active label?
       if (LabelTrackView::Get( *pLabelTrack ).GetTextEditIndex(project) != -1) {
 
@@ -281,7 +281,7 @@ void OnCut(const CommandContext &context)
    // cutting the _text_ inside of labels, i.e. if you're
    // in the middle of editing the label text and select "Cut".
 
-   for (auto lt : tracks.Selected< LabelTrack >()) {
+   for (auto lt : tracks.SelectedLeaders<LabelTrack>()) {
       auto &view = LabelTrackView::Get( *lt );
       if (view.CutSelectedText( context.project )) {
          trackPanel.Refresh(false);
@@ -400,7 +400,7 @@ void OnCopy(const CommandContext &context)
    auto &trackPanel = TrackPanel::Get( project );
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
 
-   for (auto lt : tracks.Selected< LabelTrack >()) {
+   for (auto lt : tracks.SelectedLeaders<LabelTrack>()) {
       auto &view = LabelTrackView::Get( *lt );
       if (view.CopySelectedText( context.project )) {
          //trackPanel.Refresh(false);
@@ -1068,7 +1068,7 @@ void OnPasteOver(const CommandContext &context)
 const ReservedCommandFlag
 &CutCopyAvailableFlag() { static ReservedCommandFlag flag{
    [](const AudacityProject &project){
-      auto range = TrackList::Get( project ).Any<const LabelTrack>()
+      auto range = TrackList::Get(project).Leaders<const LabelTrack>()
          + [&](const LabelTrack *pTrack){
             return LabelTrackView::Get( *pTrack ).IsTextSelected(
                // unhappy const_cast because track focus might be set

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -229,9 +229,9 @@ void OnUndo(const CommandContext &context)
       [&]( const UndoStackElem &elem ){
          ProjectHistory::Get( project ).PopState( elem.state ); } );
 
-   auto t = *tracks.Selected().begin();
+   auto t = *tracks.SelectedLeaders().begin();
    if (!t)
-      t = *tracks.Any().begin();
+      t = *tracks.Leaders().begin();
    TrackFocus::Get(project).Set(t);
    if (t) {
       t->EnsureVisible();
@@ -259,9 +259,9 @@ void OnRedo(const CommandContext &context)
       [&]( const UndoStackElem &elem ){
          ProjectHistory::Get( project ).PopState( elem.state ); } );
 
-   auto t = *tracks.Selected().begin();
+   auto t = *tracks.SelectedLeaders().begin();
    if (!t)
-      t = *tracks.Any().begin();
+      t = *tracks.Leaders().begin();
    TrackFocus::Get(project).Set(t);
    if (t) {
       t->EnsureVisible();

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -584,7 +584,7 @@ void OnPaste(const CommandContext &context)
 
    auto &tracks = TrackList::Get(project);
    // If nothing's selected, we just insert new tracks.
-   if (!tracks.Selected()) {
+   if (!tracks.SelectedLeaders()) {
       DoPasteNothingSelected(
          project, *srcTracks, clipboard.T0(), clipboard.T1());
       return;

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -154,7 +154,7 @@ void DoPasteNothingSelected(AudacityProject &project, const TrackList& src, doub
    auto &viewInfo = ViewInfo::Get( project );
    auto &window = ProjectWindow::Get( project );
    
-   assert(!tracks.Selected());
+   assert(tracks.SelectedLeaders().empty());
 
    Track* pFirstNewTrack = NULL;
    for (auto pClip : src) {

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -288,7 +288,7 @@ void OnExportLabels(const CommandContext &context)
 
    /* i18n-hint: filename containing exported text from label tracks */
    wxString fName = _("labels.txt");
-   auto trackRange = tracks.Any<const LabelTrack>();
+   auto trackRange = tracks.Leaders<const LabelTrack>();
    auto numLabelTracks = trackRange.size();
 
    if (numLabelTracks == 0) {

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -42,7 +42,7 @@ const ReservedCommandFlag
             }
          );
       };
-      auto range = TrackList::Get( project ).Selected<const LabelTrack>()
+      auto range = TrackList::Get(project).SelectedLeaders<const LabelTrack>()
          + test;
       return !range.empty();
    }
@@ -124,7 +124,7 @@ void GetRegionsByLabel(
    Regions &regions )
 {
    //determine labeled regions
-   for (auto lt : tracks.Selected< const LabelTrack >()) {
+   for (auto lt : tracks.SelectedLeaders< const LabelTrack >()) {
       for (int i = 0; i < lt->GetNumLabels(); i++)
       {
          const LabelStruct *ls = lt->GetLabel(i);
@@ -184,7 +184,7 @@ void EditByLabel(AudacityProject &project,
    {
       const bool playable = dynamic_cast<const PlayableTrack *>(t) != nullptr;
 
-      if (SyncLock::IsSyncLockSelected(t) || notLocked && playable)
+      if (SyncLock::IsSyncLockSelected(t) || (notLocked && playable))
       {
          for (int i = (int)regions.size() - 1; i >= 0; i--)
          {
@@ -230,7 +230,7 @@ void EditClipboardByLabel( AudacityProject &project,
    {
       const bool playable = dynamic_cast<const PlayableTrack *>(t) != nullptr;
 
-      if (SyncLock::IsSyncLockSelected(t) || notLocked && playable)
+      if (SyncLock::IsSyncLockSelected(t) || (notLocked && playable))
       {
          // This track accumulates the needed clips, right to left:
          Track::Holder merged;
@@ -323,7 +323,7 @@ void OnPasteNewLabel(const CommandContext &context)
    bool bPastedSomething = false;
 
    {
-      auto trackRange = tracks.Selected< const LabelTrack >();
+      auto trackRange = tracks.SelectedLeaders<const LabelTrack>();
       if (trackRange.empty())
       {
          // If there are no selected label tracks, try to choose the first label
@@ -342,7 +342,7 @@ void OnPasteNewLabel(const CommandContext &context)
    }
 
    LabelTrack *plt = NULL; // the previous track
-   for ( auto lt : tracks.Selected< LabelTrack >() )
+   for ( auto lt : tracks.SelectedLeaders<LabelTrack>() )
    {
       // Unselect the last label, so we'll have just one active label when
       // we're done

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -175,7 +175,7 @@ void EditByLabel(AudacityProject &project,
       return;
 
    const bool notLocked = (!SyncLockState::Get(project).IsSyncLocked() &&
-                           (tracks.Selected<PlayableTrack>()).empty());
+                           (tracks.SelectedLeaders<PlayableTrack>()).empty());
 
    //Apply action on tracks starting from
    //labeled regions in the end. This is to correctly perform
@@ -214,7 +214,7 @@ void EditClipboardByLabel( AudacityProject &project,
       return;
 
    const bool notLocked = (!SyncLockState::Get(project).IsSyncLocked() &&
-                           (tracks.Selected<PlayableTrack>()).empty());
+                           (tracks.SelectedLeaders<PlayableTrack>()).empty());
 
    auto &clipboard = Clipboard::Get();
    clipboard.Clear();

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -328,8 +328,8 @@ void OnPasteNewLabel(const CommandContext &context)
       {
          // If there are no selected label tracks, try to choose the first label
          // track after some other selected track
-         Track *t = *tracks.Selected().begin()
-            .Filter( &Track::Any )
+         Track *t = *tracks.SelectedLeaders().begin()
+            .Filter(&Track::Any)
             .Filter<LabelTrack>();
 
          // If no match found, add one

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -73,107 +73,93 @@ void NextOrPrevFrame(AudacityProject &project, bool forward)
 
 /// \todo Merge related methods, OnPrevTrack and OnNextTrack.
 void DoPrevTrack(
-   AudacityProject &project, bool shift, bool circularTrackNavigation )
+   AudacityProject &project, bool shift, bool circularTrackNavigation)
 {
-   auto &projectHistory = ProjectHistory::Get( project );
-   auto &trackFocus = TrackFocus::Get( project );
-   auto &tracks = TrackList::Get( project );
-   auto &selectionState = SelectionState::Get( project );
+   auto &projectHistory = ProjectHistory::Get(project);
+   auto &trackFocus = TrackFocus::Get(project);
+   auto &tracks = TrackList::Get(project);
+   auto &selectionState = SelectionState::Get(project);
 
-   auto t = trackFocus.Get();
-   if( t == NULL )   // if there isn't one, focus on last
-   {
-      t = *tracks.Any().rbegin();
-      trackFocus.Set( t );
-      if (t)
-         t->EnsureVisible( true );
+   const auto t = trackFocus.Get();
+   if (!t) {
+      // if there isn't one, focus on last
+      const auto last = *tracks.Leaders().rbegin();
+      trackFocus.Set(last);
+      if (last)
+         last->EnsureVisible(true);
       return;
    }
+   assert(t->IsLeader());
 
-   Track* p = NULL;
-   bool tSelected = false;
-   bool pSelected = false;
-   if( shift )
-   {
-      p = * -- tracks.FindLeader( t ); // Get previous track
-      if( p == NULL )   // On first track
-      {
+   if (shift) {
+      auto p = * -- tracks.FindLeader(t); // Get previous track
+      if (!p) {
+         // On first track
          // JKC: wxBell() is probably for accessibility, so a blind
          // user knows they were at the top track.
          wxBell();
-         if( circularTrackNavigation )
-            p = *tracks.Any().rbegin();
-         else
-         {
+         if (circularTrackNavigation)
+            p = *tracks.Leaders().rbegin();
+         else {
             t->EnsureVisible();
             return;
          }
       }
-      tSelected = t->GetSelected();
-      if (p)
-         pSelected = p->GetSelected();
-      if( tSelected && pSelected )
-      {
-         selectionState.SelectTrack
-            ( *t, false, false );
-         trackFocus.Set( p );   // move focus to next track up
+      // If here, then there is a nonempty list and a previous track
+      // (maybe circularly)
+      assert(p && p->IsLeader());
+      auto tSelected = t->GetSelected();
+      auto pSelected = p->GetSelected();
+      if (tSelected && pSelected) {
+         selectionState.SelectTrack(*t, false, false);
+         trackFocus.Set(p);   // move focus to next track up
          if (p)
-            p->EnsureVisible( true );
+            p->EnsureVisible(true);
          return;
       }
-      if( tSelected && !pSelected )
-      {
-         selectionState.SelectTrack
-            ( *p, true, false );
-         trackFocus.Set( p );   // move focus to next track up
+      if (tSelected && !pSelected) {
+         selectionState.SelectTrack(*p, true, false);
+         trackFocus.Set(p);   // move focus to next track up
          if (p)
-            p->EnsureVisible( true );
+            p->EnsureVisible(true);
          return;
       }
-      if( !tSelected && pSelected )
-      {
-         selectionState.SelectTrack
-            ( *p, false, false );
-         trackFocus.Set( p );   // move focus to next track up
+      if (!tSelected && pSelected) {
+         selectionState.SelectTrack(*p, false, false);
+         trackFocus.Set(p);   // move focus to next track up
          if (p)
-            p->EnsureVisible( true );
+            p->EnsureVisible(true);
          return;
       }
-      if( !tSelected && !pSelected )
-      {
-         selectionState.SelectTrack
-            ( *t, true, false );
-         trackFocus.Set( p );   // move focus to next track up
+      if (!tSelected && !pSelected) {
+         selectionState.SelectTrack(*t, true, false);
+         trackFocus.Set(p);   // move focus to next track up
          if (p)
-            p->EnsureVisible( true );
+            p->EnsureVisible(true);
          return;
       }
    }
-   else
-   {
-      p = * -- tracks.FindLeader( t ); // Get previous track
-      if( p == NULL )   // On first track so stay there?
-      {
+   else {
+      auto p = * -- tracks.FindLeader(t); // Get previous track
+      if (!p) {
+         // On first track so stay there?
          wxBell();
-         if( circularTrackNavigation )
-         {
+         if (circularTrackNavigation) {
             auto range = tracks.Leaders();
             p = * range.rbegin(); // null if range is empty
-            trackFocus.Set( p );   // Wrap to the last track
+            trackFocus.Set(p);   // Wrap to the last track
             if (p)
-               p->EnsureVisible( true );
+               p->EnsureVisible(true);
             return;
          }
-         else
-         {
+         else {
             t->EnsureVisible();
             return;
          }
       }
-      else
-      {
-         trackFocus.Set( p );   // move focus to next track up
-         p->EnsureVisible( true );
+      else {
+         trackFocus.Set(p);   // move focus to next track up
+         p->EnsureVisible(true);
          return;
       }
    }
@@ -185,98 +171,88 @@ void DoPrevTrack(
 void DoNextTrack(
    AudacityProject &project, bool shift, bool circularTrackNavigation )
 {
-   auto &projectHistory = ProjectHistory::Get( project );
-   auto &trackFocus = TrackFocus::Get( project );
-   auto &tracks = TrackList::Get( project );
-   auto &selectionState = SelectionState::Get( project );
+   auto &projectHistory = ProjectHistory::Get(project);
+   auto &trackFocus = TrackFocus::Get(project);
+   auto &tracks = TrackList::Get(project);
+   auto &selectionState = SelectionState::Get(project);
 
-   auto t = trackFocus.Get();   // Get currently focused track
-   if( t == NULL )   // if there isn't one, focus on first
-   {
-      t = *tracks.Any().begin();
-      trackFocus.Set( t );
-      if (t)
-         t->EnsureVisible( true );
+   const auto t = trackFocus.Get();
+   if  (!t) {
+      // if there isn't one, focus on first
+      const auto first = *tracks.Leaders().begin();
+      trackFocus.Set(first);
+      if (first)
+         first->EnsureVisible(true);
       return;
    }
+   assert(t->IsLeader());
 
-   if( shift )
-   {
-      auto n = * ++ tracks.FindLeader( t ); // Get next track
-      if( n == NULL )   // On last track so stay there
-      {
+   if (shift) {
+      auto n = * ++ tracks.FindLeader(t); // Get next track
+      if (!n) {
+         // On last track so stay there
          wxBell();
-         if( circularTrackNavigation )
-            n = *tracks.Any().begin();
-         else
-         {
+         if (circularTrackNavigation)
+            n = *tracks.Leaders().begin();
+         else {
             t->EnsureVisible();
             return;
          }
       }
+      // If here, then there is a nonempty list and a next track
+      // (maybe circularly)
+      assert(n && n->IsLeader());
       auto tSelected = t->GetSelected();
       auto nSelected = n->GetSelected();
-      if( tSelected && nSelected )
-      {
-         selectionState.SelectTrack
-            ( *t, false, false );
-         trackFocus.Set( n );   // move focus to next track down
+      if (tSelected && nSelected) {
+         selectionState.SelectTrack(*t, false, false);
+         trackFocus.Set(n);   // move focus to next track down
          if (n)
-            n->EnsureVisible( true );
+            n->EnsureVisible(true);
          return;
       }
-      if( tSelected && !nSelected )
-      {
-         selectionState.SelectTrack
-            ( *n, true, false );
-         trackFocus.Set( n );   // move focus to next track down
+      if (tSelected && !nSelected) {
+         selectionState.SelectTrack(*n, true, false);
+         trackFocus.Set(n);   // move focus to next track down
          if (n)
-            n->EnsureVisible( true );
+            n->EnsureVisible(true);
          return;
       }
-      if( !tSelected && nSelected )
-      {
-         selectionState.SelectTrack
-            ( *n, false, false );
-         trackFocus.Set( n );   // move focus to next track down
+      if (!tSelected && nSelected) {
+         selectionState.SelectTrack(*n, false, false);
+         trackFocus.Set(n);   // move focus to next track down
          if (n)
-            n->EnsureVisible( true );
+            n->EnsureVisible(true);
          return;
       }
-      if( !tSelected && !nSelected )
-      {
-         selectionState.SelectTrack
-            ( *t, true, false );
-         trackFocus.Set( n );   // move focus to next track down
+      if (!tSelected && !nSelected) {
+         selectionState.SelectTrack(*t, true, false);
+         trackFocus.Set(n);   // move focus to next track down
          if (n)
-            n->EnsureVisible( true );
+            n->EnsureVisible(true);
          return;
       }
    }
-   else
-   {
-      auto n = * ++ tracks.FindLeader( t ); // Get next track
-      if( n == NULL )   // On last track so stay there
-      {
+   else {
+      auto n = * ++ tracks.FindLeader(t); // Get next track
+      if (!n) {
+         // On last track so stay there
          wxBell();
-         if( circularTrackNavigation )
-         {
-            n = *tracks.Any().begin();
-            trackFocus.Set( n );   // Wrap to the first track
+         if (circularTrackNavigation) {
+            n = *tracks.Leaders().begin();
+            trackFocus.Set(n);   // Wrap to the first track
             if (n)
                n->EnsureVisible( true );
             return;
          }
-         else
-         {
+         else {
             t->EnsureVisible();
             return;
          }
       }
-      else
-      {
-         trackFocus.Set( n );   // move focus to next track down
-         n->EnsureVisible( true );
+      else {
+         trackFocus.Set(n);   // move focus to next track down
+         n->EnsureVisible(true);
          return;
       }
    }
@@ -497,17 +473,16 @@ void OnShiftDown(const CommandContext &context)
 void OnToggle(const CommandContext &context)
 {
    auto &project = context.project;
-   auto &trackFocus = TrackFocus::Get( project );
-   auto &selectionState = SelectionState::Get( project );
+   auto &trackFocus = TrackFocus::Get(project);
+   auto &selectionState = SelectionState::Get(project);
 
    Track *t;
 
    t = trackFocus.Get();   // Get currently focused track
    if (!t)
       return;
-
-   selectionState.SelectTrack
-      ( *t, !t->GetSelected(), true );
+   assert(t->IsLeader()); // TrackFocus promises this
+   selectionState.SelectTrack(*t, !t->GetSelected(), true);
    t->EnsureVisible( true );
 
    trackFocus.UpdateAccessibility();

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -457,7 +457,7 @@ void OnFirstTrack(const CommandContext &context)
    if (!t)
       return;
 
-   auto f = *tracks.Any().begin();
+   auto f = *tracks.Leaders().begin();
    if (t != f)
       trackFocus.Set(f);
    if (f)

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -471,14 +471,15 @@ void OnLastTrack(const CommandContext &context)
    auto &tracks = TrackList::Get( project );
 
    Track *t = trackFocus.Get();
+   assert(t->IsLeader());
    if (!t)
       return;
 
-   auto l = *tracks.Any().rbegin();
+   auto l = *tracks.Leaders().rbegin();
    if (t != l)
       trackFocus.Set(l);
    if (l)
-      l->EnsureVisible( t != l );
+      l->EnsureVisible(t != l);
 }
 
 void OnShiftUp(const CommandContext &context)

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -426,7 +426,7 @@ void OnSelectAll(const CommandContext &context)
    auto& trackPanel = TrackPanel::Get(context.project);
    auto& tracks = TrackList::Get(context.project);
 
-   for (auto lt : tracks.Selected< LabelTrack >()) {
+   for (auto lt : tracks.SelectedLeaders<LabelTrack>()) {
       auto& view = LabelTrackView::Get(*lt);
       if (view.SelectAllText(context.project)) {
          trackPanel.Refresh(false);

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -604,14 +604,13 @@ void OnResample(const CommandContext &context)
 {
    auto &project = context.project;
    auto projectRate = ProjectRate::Get(project).GetRate();
-   auto &tracks = TrackList::Get( project );
-   auto &undoManager = UndoManager::Get( project );
-   auto &window = ProjectWindow::Get( project );
+   auto &tracks = TrackList::Get(project);
+   auto &undoManager = UndoManager::Get(project);
+   auto &window = ProjectWindow::Get(project);
 
    int newRate;
 
-   while (true)
-   {
+   while (true) {
       wxDialogWrapper dlg(&window, wxID_ANY, XO("Resample"));
       ShuttleGui S(&dlg, eIsCreating);
       wxString rate;
@@ -658,13 +657,10 @@ void OnResample(const CommandContext &context)
       dlg.Center();
 
       if (dlg.ShowModal() != wxID_OK)
-      {
          return;  // user cancelled dialog
-      }
 
       long lrate;
-      if (cb->GetValue().ToLong(&lrate) && lrate >= 1 && lrate <= 1000000)
-      {
+      if (cb->GetValue().ToLong(&lrate) && lrate >= 1 && lrate <= 1000000) {
          newRate = (int)lrate;
          break;
       }
@@ -678,9 +674,8 @@ void OnResample(const CommandContext &context)
 
    int ndx = 0;
    auto flags = UndoPush::NONE;
-   for (auto wt : tracks.Selected< WaveTrack >())
-   {
-      auto msg = XO("Resampling track %d").Format( ++ndx );
+   for (auto wt : tracks.SelectedLeaders<WaveTrack>()) {
+      auto msg = XO("Resampling track %d").Format(++ndx);
 
       using namespace BasicUI;
       auto progress = MakeProgress(XO("Resample"), msg);
@@ -696,7 +691,7 @@ void OnResample(const CommandContext &context)
       // commit that to the undo stack.  The second and later times,
       // consolidate.
 
-      ProjectHistory::Get( project ).PushState(
+      ProjectHistory::Get(project).PushState(
          XO("Resampled audio track(s)"), XO("Resample Track"), flags);
       flags = flags | UndoPush::CONSOLIDATE;
    }

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -88,7 +88,7 @@ void DoMoveToLabel(AudacityProject &project, bool next)
    else if (nLabelTrack > 1) {
       // find first label track, if any, starting at the focused track
       lt =
-         *tracks.Find(trackFocus.Get()).Filter<LabelTrack>();
+         *tracks.FindLeader(trackFocus.Get()).Filter<LabelTrack>();
       if (!lt)
          trackFocus.MessageForScreenReader(
             XO("no label track at or below focused track"));

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -78,7 +78,7 @@ void DoMoveToLabel(AudacityProject &project, bool next)
    auto &projectAudioManager = ProjectAudioManager::Get(project);
 
    // Find the number of label tracks, and ptr to last track found
-   auto trackRange = tracks.Any<LabelTrack>();
+   auto trackRange = tracks.Leaders<LabelTrack>();
    auto lt = *trackRange.rbegin();
    auto nLabelTrack = trackRange.size();
 

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -449,7 +449,7 @@ void ControlToolBar::EnableDisableButtons()
    bool busy = gAudioIO->IsBusy();
 
    // Only interested in audio type tracks
-   bool tracks = p && TrackList::Get( *p ).Any<AudioTrack>(); // PRL:  PlayableTrack ?
+   bool tracks = p && TrackList::Get(*p).Leaders<AudioTrack>(); // PRL:  PlayableTrack ?
 
    mPlay->SetEnabled( canStop && tracks && !recording );
    mRecord->SetEnabled(

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -323,8 +323,8 @@ void TranscriptionToolBar::EnableDisableButtons()
    bool recording = gAudioIO->GetNumCaptureChannels() > 0;
 
    // Only interested in audio type tracks
-   bool tracks = p && TrackList::Get( *p ).Any<AudioTrack>(); // PRL:  PlayableTrack ?
-   SetEnabled( canStopAudioStream && tracks && !recording );
+   bool tracks = p && TrackList::Get(*p).Leaders<AudioTrack>(); // PRL:  PlayableTrack ?
+   SetEnabled(canStopAudioStream && tracks && !recording);
 
 #ifdef EXPERIMENTAL_VOICE_DETECTION
    if (!p)

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -506,7 +506,7 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
    // VariSpeed play reuses Scrubbing.
    bool bFixedSpeedPlay = !gPrefs->ReadBool(wxT("/AudioIO/VariSpeedPlay"), true);
    // Scrubbing doesn't support note tracks, but the fixed-speed method using time tracks does.
-   if ( TrackList::Get( *p ).Any< NoteTrack >() )
+   if (TrackList::Get(*p).Leaders<NoteTrack>())
       bFixedSpeedPlay = true;
 
    // If cutPreview, we have to fall back to fixed speed.

--- a/src/tracks/labeltrack/ui/LabelDefaultClickHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelDefaultClickHandle.cpp
@@ -38,7 +38,7 @@ void LabelDefaultClickHandle::SaveState( AudacityProject *pProject )
    auto &pairs = mLabelState->mPairs;
    auto &tracks = TrackList::Get( *pProject );
 
-   for (auto lt : tracks.Any<LabelTrack>()) {
+   for (auto lt : tracks.Leaders<LabelTrack>()) {
       auto &view = LabelTrackView::Get( *lt );
       pairs.push_back( std::make_pair(
          lt->SharedPointer<LabelTrack>(), view.SaveFlags() ) );
@@ -69,7 +69,7 @@ UIHandle::Result LabelDefaultClickHandle::Click
       SaveState( pProject );
 
       const auto pLT = evt.pCell.get();
-      for (auto lt : TrackList::Get( *pProject ).Any<LabelTrack>()) {
+      for (auto lt : TrackList::Get(*pProject).Leaders<LabelTrack>()) {
          if (pLT != &ChannelView::Get(*lt)) {
             auto &view = LabelTrackView::Get( *lt );
             view.ResetFlags();

--- a/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
@@ -28,6 +28,8 @@ Paul Licameli split from TrackPanel.cpp
 #include <wx/event.h>
 #include <wx/translation.h>
 
+#include <cassert>
+
 LabelTrackHit::LabelTrackHit( const std::shared_ptr<LabelTrack> &pLT )
    : mpLT{ pLT }
 {
@@ -331,7 +333,8 @@ bool LabelGlyphHandle::HandleGlyphDragRelease
 
               // Do this after, for its effect on TrackPanel's memory of last selected
               // track (which affects shift-click actions)
-              selectionState.SelectTrack(*pTrack.get(), true, true);
+              assert(pTrack->IsLeader()); // It's a label track
+              selectionState.SelectTrack(*pTrack, true, true);
 
               // PRL: bug1659 -- make selection change undo correctly
               updated = !ProjectAudioIO::Get(project).IsAudioActive();

--- a/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
@@ -319,13 +319,13 @@ bool LabelGlyphHandle::HandleGlyphDragRelease
               auto& selectionState = SelectionState::Get(project);
               auto& tracks = TrackList::Get(project);
 
-              bool done = tracks.Selected().any_of(
+              bool done = tracks.SelectedLeaders().any_of(
                   [&](const Track* track) { return track != static_cast<Track*>(pTrack.get()); }
               );
 
               if (!done) {
                   //otherwise, select all tracks
-                  for (auto t : tracks.Any())
+                  for (auto t : tracks.Leaders())
                       selectionState.SelectTrack(*t, true, true);
               }
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -1109,14 +1109,14 @@ void DoNextPeakFrequency(AudacityProject &project, bool up)
 
    // Find the first selected wave track that is in a spectrogram view.
    const WaveTrack *pTrack {};
-   for ( auto wt : tracks.Selected< const WaveTrack >() ) {
+   for (auto wt : tracks.SelectedLeaders<const WaveTrack>()) {
       const auto displays = WaveChannelView::Get(*wt).GetDisplays();
       bool hasSpectrum = (displays.end() != std::find(
          displays.begin(), displays.end(),
          WaveChannelSubView::Type{
             WaveChannelViewConstants::Spectrum, {} }
       ) );
-      if ( hasSpectrum ) {
+      if (hasSpectrum) {
          pTrack = wt;
          break;
       }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -22,7 +22,6 @@
 #include "../../../../TrackArt.h"
 #include "../../../../TrackArtist.h"
 #include "../../../../TrackPanelDrawingContext.h"
-#include "../../../../TrackPanelResizeHandle.h"
 #include "ViewInfo.h"
 #include "WaveTrack.h"
 #include "WaveClip.h"
@@ -173,24 +172,6 @@ std::vector<UIHandlePtr> WaveTrackAffordanceControls::HitTest(const TrackPanelMo
 
         if (handle)
             results.push_back(handle);
-    }
-
-    auto trackList = track->GetOwner();
-    if ((std::abs(rect.GetTop() - py) <=
-          WaveChannelView::kChannelSeparatorThickness / 2) 
-        && trackList
-        && !track->IsLeader())
-    {
-        //given that track is not a leader there always should be
-        //another track before this one
-        auto prev = std::prev(trackList->Find(track.get()));
-        results.push_back(
-            AssignUIHandlePtr(
-                mResizeHandle, 
-                std::make_shared<TrackPanelResizeHandle>(
-                  (*prev)->GetChannel(0), py)
-            )
-        );
     }
 
     if (mTextEditHelper && mTextEditHelper->GetBBox().Contains(px, py))

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -639,7 +639,7 @@ BEGIN_POPUP_MENU(WaveTrackMenuTable)
                auto &tracks = TrackList::Get( project );
                auto &table = static_cast< WaveTrackMenuTable& >( handler );
                auto &track = table.FindWaveTrack();
-               auto next = * ++ tracks.Find(&track);
+               auto next = * ++ tracks.FindLeader(&track);
                canMakeStereo =
                   (next &&
                    TrackList::NChannels(*next) == 1 &&
@@ -747,8 +747,8 @@ void WaveTrackMenuTable::OnMergeStereo(wxCommandEvent &)
    WaveTrack *const pTrack = static_cast<WaveTrack*>(mpData->pTrack);
    wxASSERT(pTrack);
 
-   auto partner = static_cast< WaveTrack * >
-      ( *tracks.Find( pTrack ).advance( 1 ) );
+   auto partner =
+      static_cast<WaveTrack*>(*tracks.FindLeader(pTrack).advance(1));
 
    if (pTrack->GetRate() != partner->GetRate()) {
       using namespace BasicUI;

--- a/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
@@ -29,7 +29,7 @@ void OnNewTimeTrack(const CommandContext &context)
    auto &window = ProjectWindow::Get( project );
    
 
-   if ( *tracks.Any<TimeTrack>().begin() ) {
+   if (*tracks.Leaders<TimeTrack>().begin()) {
       AudacityMessageBox(
          XO(
 "This version of Audacity only allows one time track for each project window.") );

--- a/src/tracks/ui/AffordanceHandle.cpp
+++ b/src/tracks/ui/AffordanceHandle.cpp
@@ -76,7 +76,8 @@ UIHandle::Result AffordanceHandle::Release(const TrackPanelMouseEvent& event, Au
         {
             auto& selectionState = SelectionState::Get(*pProject);
             selectionState.SelectNone(trackList);
-            selectionState.SelectTrack(*track, true, true);
+            if (auto pTrack = *trackList.FindLeader(track.get()))
+               selectionState.SelectTrack(*pTrack, true, true);
 
             result |= SelectAt(event, pProject);
         }

--- a/src/tracks/ui/ChannelVRulerControls.h
+++ b/src/tracks/ui/ChannelVRulerControls.h
@@ -47,6 +47,11 @@ public:
    // cached in the associated track
    virtual void UpdateRuler( const wxRect &rect ) = 0;
 
+   std::shared_ptr<const ChannelView> GetChannelView() const
+   {
+      return mwChannelView.lock();
+   }
+
 protected:
    std::shared_ptr<Track> DoFindTrack() override;
 

--- a/src/tracks/ui/CommonTrackPanelCell.cpp
+++ b/src/tracks/ui/CommonTrackPanelCell.cpp
@@ -141,3 +141,8 @@ std::shared_ptr<Channel> CommonTrackCell::FindChannel()
       return pTrack->GetChannel(miChannel);
    return {};
 }
+
+std::shared_ptr<const Channel> CommonTrackCell::FindChannel() const
+{
+   return const_cast<CommonTrackCell*>(this)->FindChannel();
+}

--- a/src/tracks/ui/CommonTrackPanelCell.h
+++ b/src/tracks/ui/CommonTrackPanelCell.h
@@ -114,6 +114,9 @@ public:
    //! May return null
    std::shared_ptr<Channel> FindChannel();
 
+   //! May return null
+   std::shared_ptr<const Channel> FindChannel() const;
+
 private:
    std::weak_ptr< Track > mwTrack;
    const size_t miChannel;

--- a/src/tracks/ui/TrackButtonHandles.cpp
+++ b/src/tracks/ui/TrackButtonHandles.cpp
@@ -100,7 +100,7 @@ UIHandle::Result SelectButtonHandle::CommitChanges
    {
       const bool unsafe = ProjectAudioIO::Get( *pProject ).IsAudioActive();
       SelectUtilities::DoListSelection(*pProject,
-         pTrack.get(), event.ShiftDown(), event.ControlDown(), !unsafe);
+         *pTrack, event.ShiftDown(), event.ControlDown(), !unsafe);
 //    return RefreshAll ;
    }
 

--- a/src/tracks/ui/TrackSelectHandle.cpp
+++ b/src/tracks/ui/TrackSelectHandle.cpp
@@ -100,7 +100,7 @@ UIHandle::Result TrackSelectHandle::Click
    }
 
    SelectUtilities::DoListSelection(*pProject,
-      pTrack.get(), event.ShiftDown(), event.ControlDown(), !unsafe);
+      *pTrack, event.ShiftDown(), event.ControlDown(), !unsafe);
 
    mClicked = true;
    return result;


### PR DESCRIPTION
EdResolves: *(direct link to the issue)*

All uses of TrackList::Any(), Selected(), and Find() need to be replaced, ultimately,
with Leaders(), SelectedLeaders(), and FindLeader().

This cleans up many of the easier uses.

Known minor changed behavior:
- text of progress dialog in resampling
- When misaligned tracks exist, the hit area for the separator between channels is smaller top to bottom

QA: verify unchanged behavior
- [x] Play with time track
- [x] Label editing dialog
- [x] I changed Karaoke too?  ha ha ha. what didn't change?
- [x] Mixer board, with mono, stereo, and MIDI tracks
- [x] "Set Label" macro command
- [x] Find Clipping, and Nyquist analyzers, reuse existing label track if present
- [x] Export MIDI
- [x] Export multiple by labels
- [x] Cut, copy, paste, select-all of text in focused label of label track
- [x] Export labels
- [x] Edit > Labeled Audio > etc. commands; and when no tracks are selected, then they apply to all wave and MIDI tracks
- [x] Edit > Labels > Paste Text to New Label
- [x] Extra > Selection > Move to previous or next label
- [x] Multiple tracks:  click in one changes label selection; but ESC before button up, restores label selection
- [x] More than one time track cannot be created
- [x] Muted or not-solo track in mixer board has inactive meter
- [x] Exactly when wave or MIDI tracks exist: View > MixerBoard available, playback available, 
- [x] Warning when attempting to save a project with no tracks
- [x] When there is a solo track, new imported audio or MIDI tracks are mute
- [x] Timer Recording diallowed when there are any tracks
- [x] When any track is solo, other MIDI and wave tracks are colored as mute
- [x] Import macro command, into empty project, selects all tracks afterward
- [x] Start and end times update in Contrast when you measure foreground or background
- [x] Export (including Export Mixer dialog and Export Multiple) correctly applies solo button
- [x] Select > Clip menu items, when some wave tracks were selected, and when none
- [x] Paste anything into a project when nothing was selected
- [x] Transport and play-at-speed toolbar buttons enable and disable for presence or absence of wave or MIDI tracks
- [x] Recording or timer recording into selected tracks disallowed when their rate doesn't match recording rate
- [x] Top of available spectral selection toolbar values is 1/2 of greatest rate of any of the tracks
- [x] EQ and classic filter effects disallowed when tracks of different rates are selected
- [x] First track is focused when file opens, or after undo or redo
- [x] First selected track, or first of all tracks when none selected, is focused after import
- [x] After destructive effect is applied, first selected track scrolls into view if it was offscreen
- [x] Noise reduction, compressor, loudness effects
- [x] Edit > Labels > Paste New Label uses the first seledcted label track or if none, then the first one after the first selected track of any kind
- [x] Ctrl + Home navigates focus to the first track
- [x] Ctrl + End focuses last track
- [x] Showing and hiding of stackable effect sidebar, including when undo and redo make the track disappear
- [x] When you click a label bar, and no tracks were selected, then all become selected
- [x] Select > Spectral > Next higher and next lower (might want to bind to keystrokes)
- [x] Correct progress dialog scale when doing Normalize or a Nyquist effect, with mono and stereo tracks
- [x] Persistency of non-empty mono and stereo track data
- [x] Resampling of mono and stereo tracks... there may be a small change in progress dialog text (numbering the tracks) and I don't care
- [x] Track selection changes: Shift + Click on track control panel (range of tracks), also in Mixer board, also Ctrl + click
- [x] Select None menu command
- [x] Up and down arrow keys to change track focus, including "Move track focus cycles repeatedly through tracks" preference, mono and stereo tracks present
- [x] Track is selected after dragging affordance handle
- [x] Shift + Click inside a track extends set of selected tracks; test Ctrl + click too
- [x] Sync lock grouping rules are unchanged (a group is maximal range of wave and/or note tracks plus one or more label tracks below)
- [x] Make Stereo command in Track's drop-down menu

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
