### PR TITLE
Exporting a single track selection sets filename to track name

### DIFF
--- a/src/export/Export.cpp
+++ b/src/export/Export.cpp
@@ -605,6 +605,17 @@ bool Exporter::GetFilename()
    //Bug 1304: Set a default path if none was given.  For Export.
    mFilename.SetPath(FileNames::FindDefaultPath(FileNames::Operation::Export));
    mFilename.SetName(mProject->GetProjectName());
+
+   // Exporting a single track selection
+   if (mSelectedOnly && mNumSelected == 1)
+   {
+      auto trackRange = TrackList::Get(*mProject).Selected<const Track>();
+      auto track = *trackRange.first;
+
+      if (track)
+         mFilename.SetName(track->GetName());
+   }
+
    if (mFilename.GetName().empty())
       mFilename.SetName(_("untitled"));
    while (true) {


### PR DESCRIPTION
Resolves: *(direct link to the issue)*
n/a

*(short description of the changes and the motivation to make the changes)*
perhaps it's just me, but i was expecting the filename to be the track name when exporting a single track selection. this isn't a complaint, just to be clear. i just want to offer some code and see what happens.

i'm guessing `TrackList::Selected::empty()` will not return `true` if `Export::mNumSelected` is greater than zero, which is why i didn't check. that being said, i don't know if there could be a null `Track` in the container, so i did check for that.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
