### PR TITLE
Add missing Findlibmad.cmake file to resolve the system installed libmad

### DIFF
--- a/cmake-proxies/cmake-modules/Findlibmad.cmake
+++ b/cmake-proxies/cmake-modules/Findlibmad.cmake
@@ -1,0 +1,35 @@
+#[[
+A module to look for libmad
+]]
+
+if( NOT libmad_FOUND )
+   find_path( libmad_INCLUDE_DIR mad.h )
+   find_library( libmad_LIBRARIES NAMES mad )
+
+   if( libmad_INCLUDE_DIR AND libmad_LIBRARIES )
+      set( libmad_FOUND Yes )
+   endif()
+
+   if( libmad_FOUND )
+      if( NOT libmad_FIND_QUIETLY )
+         message( STATUS "Found mad: \n\tlibmad_INCLUDE_DIR: ${libmad_INCLUDE_DIR}\n\tlibmad_LIBRARIES: ${libmad_LIBRARIES}" )
+      endif()
+
+      if( NOT TARGET libmad::libmad )
+         add_library( libmad::libmad INTERFACE IMPORTED GLOBAL)
+
+         target_include_directories( libmad::libmad INTERFACE ${libmad_INCLUDE_DIR} )
+         target_link_libraries( libmad::libmad INTERFACE ${libmad_LIBRARIES} )
+      endif()
+   else()
+      if( libmad_FIND_REQUIRED )
+         message( FATAL_ERROR "Could not find libmad")
+      endif()
+   endif()
+
+   mark_as_advanced(
+      libmad_FOUND
+      libmad_INCLUDE_DIR
+      libmad_LIBRARIES
+   )
+endif()


### PR DESCRIPTION
Hello,

This allows compiling against the system installed `libmad`, that otherwise cannot be found.

Tested on Gentoo GNU/Linux with libmad 0.15.1b installed:
```
audacity_use_libmpg123=off
audacity_use_libmad=system
```

The `Findlibmad.cmake` file is an edited copy of `Findlibmp3lame.cmake`.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
