### PR TITLE
Disable linking unexisting RapidJSON libraries: fixes configure errors on Gentoo with RapidJSON 1.1.0 installed

### DIFF
--- a/libraries/lib-cloud-audiocom/CMakeLists.txt
+++ b/libraries/lib-cloud-audiocom/CMakeLists.txt
@@ -26,7 +26,7 @@ set ( LIBRARIES
    lib-strings-interface # Languages
 
    PRIVATE
-      rapidjson::rapidjson # Protocol is JSON based
+      #rapidjson::rapidjson # Protocol is JSON based
       wxwidgets::base # Required to retrieve the OS information
 )
 


### PR DESCRIPTION
Hello,

This is for when in the system there are only headers installed and no libraries of RapidJSON.

Tested on Gentoo GNU/Linux with RapidJSON 1.1.0 installed:
```
audacity_has_networking=on
audacity_has_audiocom_upload=on
```

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
