### PR TITLE
Add catch to the list of dependencies in BUILDING.md.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,6 +5,7 @@
 * **python3** >= 3.8
 * **cmake** >= 3.16
 * A working C++ 17 compiler
+* catch2 (If building with conan.)
 * Graphviz (optional)
 
 For Windows see below for important installer settings.


### PR DESCRIPTION
Catch2 is a dependency of this project.
It remains to be determined what is the minimum and maximum version of the package.

##################################
Resolves:
CMake Error at build/find_package_include.cmake:18 (find_package):
  By not providing "FindCatch2.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Catch2", but
  CMake did not find one.
  
  Could not find a package configuration file provided by "Catch2" with any
  of the following names:
  
    Catch2Config.cmake
    catch2-config.cmake
  
  Add the installation prefix of "Catch2" to CMAKE_PREFIX_PATH or set
  "Catch2_DIR" to a directory containing one of the above files.  If "Catch2"
  provides a separate development package or SDK, be sure it has been
  installed.
##################################

It was easier for you guys then to open and issue and leave it for you to fix.

- [ ] I signed [CLA]-- Nope. My works are GPL. The CLA says that I give them the "... ability to use the Contributions in any way," and that's not GPL compatible. GPL is copyleft. Not copy anyway you want it.
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
