### PR TITLE
Last track iteration rewrites

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1551,9 +1551,10 @@ void AudioIO::StopStream()
                auto &start = interval.first;
                auto duration = interval.second;
                for (auto &sequence : mCaptureSequences) {
-                  GuardedCall([&] {
-                     sequence->InsertSilence(start, duration);
-                  });
+                  if (sequence->IsLeader())
+                     GuardedCall([&] {
+                        sequence->InsertSilence(start, duration);
+                     });
                }
             }
             if (pScope)

--- a/libraries/lib-effects/EffectBase.cpp
+++ b/libraries/lib-effects/EffectBase.cpp
@@ -230,7 +230,7 @@ const AudacityProject *EffectBase::FindProject() const
 
 void EffectBase::CountWaveTracks()
 {
-   const auto range = mTracks->SelectedLeaders<const WaveTrack>();
+   const auto range = mTracks->Selected<const WaveTrack>();
    mNumTracks = range.sum(&WaveTrack::NChannels);
    mNumGroups = range.size();
 }

--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -33,7 +33,7 @@ EffectOutputTracks::EffectOutputTracks(
    for (auto aTrack : trackRange) {
       auto list = aTrack->Duplicate();
       mIMap.push_back(aTrack);
-      mOMap.push_back(*list->Leaders().begin());
+      mOMap.push_back(*list->begin());
       mOutputTracks->Append(std::move(*list));
    }
    // Invariant is established
@@ -70,7 +70,7 @@ void EffectOutputTracks::Commit()
    size_t i = 0;
 
    while (!mOutputTracks->empty()) {
-      const auto pOutputTrack = *mOutputTracks->Leaders().begin();
+      const auto pOutputTrack = *mOutputTracks->begin();
 
       // If tracks were removed from mOutputTracks, then there will be
       // tracks in the map that must be removed from mTracks.

--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -23,7 +23,7 @@ EffectOutputTracks::EffectOutputTracks(
    mOMap.clear();
    mOutputTracks = TrackList::Create(mTracks.GetOwner());
 
-   auto trackRange = mTracks.Leaders() +
+   auto trackRange = mTracks.Any() +
       [&] (const Track *pTrack) {
          return allSyncLockSelected
          ? SyncLock::IsSelectedOrSyncLockSelected(pTrack)

--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -21,7 +21,6 @@ EffectOutputTracks::EffectOutputTracks(
    // Reset map
    mIMap.clear();
    mOMap.clear();
-
    mOutputTracks = TrackList::Create(mTracks.GetOwner());
 
    auto trackRange = mTracks.Leaders() +
@@ -33,16 +32,12 @@ EffectOutputTracks::EffectOutputTracks(
 
    for (auto aTrack : trackRange) {
       auto list = aTrack->Duplicate();
-      assert(aTrack->NChannels() == list->NChannels());
-      auto iter = TrackList::Channels(*list->Leaders().begin()).begin();
-      for (auto pChannel : TrackList::Channels(aTrack)) {
-         Track *o = *iter++;
-         mIMap.push_back(pChannel);
-         mOMap.push_back(o);
-      }
+      mIMap.push_back(aTrack);
+      mOMap.push_back(*list->Leaders().begin());
       mOutputTracks->Append(std::move(*list));
    }
    // Invariant is established
+   assert(mIMap.size() == mOutputTracks->Size());
    assert(mIMap.size() == mOMap.size());
 }
 
@@ -50,15 +45,18 @@ EffectOutputTracks::~EffectOutputTracks() = default;
 
 Track *EffectOutputTracks::AddToOutputTracks(const std::shared_ptr<Track> &t)
 {
-   assert(t && t->IsLeader());
+   assert(t && t->IsLeader() && t->NChannels() == 1);
    mIMap.push_back(nullptr);
    mOMap.push_back(t.get());
+   auto result = mOutputTracks->Add(t);
+   // Invariant is maintained
+   assert(mIMap.size() == mOutputTracks->Size());
    assert(mIMap.size() == mOMap.size());
-   return mOutputTracks->Add(t);
+   return result;
 }
 
-// If bGoodResult, replace mTracks tracks with successfully processed mOutputTracks copies.
-// Else clear and DELETE mOutputTracks copies.
+// Replace tracks with successfully processed mOutputTracks copies.
+// Else clear and delete mOutputTracks copies.
 void EffectOutputTracks::Commit()
 {
    if (!mOutputTracks) {
@@ -68,20 +66,11 @@ void EffectOutputTracks::Commit()
       return;
    }
 
-   auto range = mOutputTracks->Any();
-   std::vector<std::shared_ptr<Track>> channels;
-
    size_t cnt = mOMap.size();
    size_t i = 0;
 
-   while (!range.empty()) {
-      auto *const pOutputTrack = *range.first;
-      const auto nChannels = pOutputTrack->NChannels();
-
-      // Get shared pointers to keep the tracks alive after removal from list
-      channels.clear();
-      for (size_t iChannel = 0; iChannel < nChannels; ++iChannel)
-         channels.emplace_back((*range.first++)->shared_from_this());
+   while (!mOutputTracks->empty()) {
+      const auto pOutputTrack = *mOutputTracks->Leaders().begin();
 
       // If tracks were removed from mOutputTracks, then there will be
       // tracks in the map that must be removed from mTracks.
@@ -89,7 +78,7 @@ void EffectOutputTracks::Commit()
          const auto t = mIMap[i];
          // Class invariant justifies the assertion
          assert(t && t->IsLeader());
-         i += t->NChannels();
+         ++i;
          mTracks.Remove(*t);
       }
 
@@ -97,18 +86,14 @@ void EffectOutputTracks::Commit()
       // the map
       assert(i < cnt);
 
-      // Remove the track from the output list...don't delete it
-      mOutputTracks->Remove(*pOutputTrack);
-
       // Find the input track it corresponds to
       if (!mIMap[i])
-         for (auto &o : channels)
-            // This track was an addition to output tracks; add it to mTracks
-            ++i, mTracks.Add(o);
+         // This track was an addition to output tracks; add it to mTracks
+         mTracks.AppendOne(std::move(*mOutputTracks));
       else
-         for (auto &o : channels)
-            // Replace mTracks entry with the new track
-            mTracks.Replace(mIMap[i++], o);
+         // Replace mTracks entry with the new track
+         mTracks.ReplaceOne(*mIMap[i], std::move(*mOutputTracks));
+      ++i;
    }
 
    // If tracks were removed from mOutputTracks, then there may be tracks
@@ -117,7 +102,7 @@ void EffectOutputTracks::Commit()
       const auto t = mIMap[i];
       // Class invariant justifies the assertion
       assert(t && t->IsLeader());
-      i += t->NChannels();
+      ++i;
       mTracks.Remove(*t);
    }
 

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -37,7 +37,7 @@ public:
 
    //! Use this to add an output track, not corresponding to an input.
    /*!
-    @pre `t && t->IsLeader()`
+    @pre `t && t->IsLeader() && t->NChannels() == 1`
     @return a pointer to the given track
     */
    Track *AddToOutputTracks(const std::shared_ptr<Track> &t);
@@ -57,10 +57,9 @@ public:
 private:
    TrackList &mTracks;
    /*!
+    @invariant `mIMap.size() == mOutputTracks->Size()`
     @invariant `mIMap.size() == mOMap.size()`
-
-    TODO wide wave tracks -- remove this
-    @invariant mIMap is a concatenation of complete channel groups
+    @invariant mIMap points to leaders only, or nulls
     */
    std::vector<Track*> mIMap;
    std::vector<Track*> mOMap;

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -295,7 +295,7 @@ bool PerTrackEffect::ProcessPass(TrackList &outputs,
             t.SyncLockAdjust(mT1, mT0 + duration);
       };
 
-   outputs.Leaders().VisitWhile(bGoodResult,
+   outputs.Any().VisitWhile(bGoodResult,
       [&](auto &&fallthrough){ return [&](WaveTrack &wt) {
          if (!wt.GetSelected())
             return fallthrough();

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -120,7 +120,7 @@ bool PerTrackEffect::ProcessPass(TrackList &outputs,
             iChannel = 0;
          else
             leader =
-               static_cast<WaveTrack *>(*outputs.FindLeader(&left));
+               static_cast<WaveTrack *>(*outputs.Find(&left));
 
          sampleCount len = 0;
          sampleCount start = 0;

--- a/libraries/lib-import-export/ExportUtils.cpp
+++ b/libraries/lib-import-export/ExportUtils.cpp
@@ -18,9 +18,9 @@
 TrackIterRange<const WaveTrack> ExportUtils::FindExportWaveTracks(const TrackList& tracks, bool selectedOnly)
 {
    bool anySolo =
-      !(tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty();
+      !(tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo).empty();
 
-   return tracks.Leaders<const WaveTrack>()
+   return tracks.Any<const WaveTrack>()
       + (selectedOnly ? &Track::IsSelected : &Track::Any)
       - (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute);
 }

--- a/libraries/lib-import-export/Import.cpp
+++ b/libraries/lib-import-export/Import.cpp
@@ -49,8 +49,6 @@ ImportLOF.cpp, and ImportAUP.cpp.
 
 #include "ImportProgressListener.h"
 
-using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
-
 namespace {
 
 //Proxy class used by importer to capture import result
@@ -674,19 +672,17 @@ bool Importer::Import( AudacityProject &project,
             }
 
             auto end = tracks.end();
-            auto iter = std::remove_if( tracks.begin(), end,
-               std::mem_fn( &NewChannelGroup::empty ) );
-            if ( iter != end ) {
+            auto iter = std::remove_if(tracks.begin(), end,
+               [](auto &pList){ return pList->empty(); });
+            if (iter != end) {
                // importer shouldn't give us empty groups of channels!
-               wxASSERT(false);
+               assert(false);
                // But correct that and proceed anyway
-               tracks.erase( iter, end );
+               tracks.erase(iter, end);
             }
             if (tracks.size() > 0)
-            {
                // success!
                return true;
-            }
          }
 
          if (importResultProxy.GetResult() == ImportProgressListener::ImportResult::Cancelled)

--- a/libraries/lib-import-export/Import.h
+++ b/libraries/lib-import-export/Import.h
@@ -25,6 +25,7 @@ class AudacityProject;
 class Tags;
 class WaveTrackFactory;
 class Track;
+class TrackList;
 class ImportPlugin;
 class ImportProgressListener;
 class UnusableImportPlugin;
@@ -33,8 +34,8 @@ typedef bool (*progress_callback_t)( void *userData, float percent );
 class ExtImportItem;
 class WaveTrack;
 
-using ExtImportItems = std::vector< std::unique_ptr<ExtImportItem> >;
-using TrackHolders = std::vector< std::vector< std::shared_ptr<WaveTrack> > >;
+using ExtImportItems = std::vector<std::unique_ptr<ExtImportItem>>;
+using TrackHolders = std::vector<std::shared_ptr<TrackList>>;
 
 class ExtImportItem
 {

--- a/libraries/lib-import-export/ImportPlugin.h
+++ b/libraries/lib-import-export/ImportPlugin.h
@@ -55,6 +55,7 @@ but little else.
 class AudacityProject;
 class WaveTrackFactory;
 class Track;
+class TrackList;
 class TranslatableString;
 class Tags;
 
@@ -104,7 +105,7 @@ protected:
 
 
 class WaveTrack;
-using TrackHolders = std::vector< std::vector< std::shared_ptr<WaveTrack> > >;
+using TrackHolders = std::vector<std::shared_ptr<TrackList>>;
 
 class IMPORT_EXPORT_API ImportFileHandle /* not final */
 {

--- a/libraries/lib-mixer/AudioIOSequences.h
+++ b/libraries/lib-mixer/AudioIOSequences.h
@@ -66,6 +66,11 @@ struct MIXER_API RecordableSequence {
    //! Flush must be called after last Append
    virtual void Flush() = 0;
 
+   virtual bool IsLeader() const = 0;
+
+   /*!
+    @pre `IsLeader()`
+    */
    virtual void InsertSilence(double t, double len) = 0;
 };
 

--- a/libraries/lib-project-file-io/ProjectFileIO.cpp
+++ b/libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -1773,7 +1773,7 @@ void ProjectFileIO::WriteXML(XMLWriter &xmlFile,
 
    ProjectFileIORegistry::Get().CallWriters(proj, xmlFile);
 
-   tracklist.Leaders().Visit([&](const Track &t) {
+   tracklist.Any().Visit([&](const Track &t) {
       auto useTrack = &t;
       if (recording) {
          // When append-recording, there is a temporary "shadow" track accumulating

--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -229,6 +229,7 @@ void TimeTrack::Silence(double WXUNUSED(t0), double WXUNUSED(t1))
 
 void TimeTrack::InsertSilence(double t, double len)
 {
+   assert(IsLeader());
    mEnvelope->InsertSpace(t, len);
 }
 

--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -157,7 +157,7 @@ Track::Holder TimeTrack::PasteInto(AudacityProject &project, TrackList &list)
    assert(IsLeader());
    // Maintain uniqueness of the time track!
    std::shared_ptr<TimeTrack> pNewTrack;
-   if (auto pTrack = *TrackList::Get(project).Leaders<TimeTrack>().begin())
+   if (auto pTrack = *TrackList::Get(project).Any<TimeTrack>().begin())
       // leave list unchanged
       pNewTrack = pTrack->SharedPointer<TimeTrack>();
    else {
@@ -381,7 +381,7 @@ static Mixer::WarpOptions::DefaultWarp::Scope installer{
 {
    if (pProject) {
       auto &list = TrackList::Get(*pProject);
-      if (auto pTimeTrack = *list.Leaders<const TimeTrack>().begin())
+      if (auto pTimeTrack = *list.Any<const TimeTrack>().begin())
          return pTimeTrack->GetEnvelope();
    }
    return nullptr;

--- a/libraries/lib-track-selection/SelectionState.cpp
+++ b/libraries/lib-track-selection/SelectionState.cpp
@@ -82,7 +82,7 @@ void SelectionState::SelectRangeOfTracks(
 {
    Track *sTrack = &rsTrack, *eTrack = &reTrack;
    // Swap the track pointers if needed
-   auto begin = tracks.Leaders().begin(),
+   auto begin = tracks.begin(),
       iterS = tracks.Find(sTrack),
       iterE = tracks.Find(eTrack);
    // Be sure to substitute the leaders for given tracks
@@ -116,7 +116,7 @@ void SelectionState::ChangeSelectionOnShiftClick(
 
       // If our track is at or after the first, extend from the first.
       if (pFirst) {
-         auto begin = tracks.Leaders().begin(),
+         auto begin = tracks.begin(),
             iterT = tracks.Find(&track),
             iterF = tracks.Find(pFirst);
          auto indT = std::distance(begin, iterT),

--- a/libraries/lib-track-selection/SelectionState.cpp
+++ b/libraries/lib-track-selection/SelectionState.cpp
@@ -111,7 +111,7 @@ void SelectionState::ChangeSelectionOnShiftClick(
    auto pExtendFrom = tracks.Lock(mLastPickedTrack);
 
    if (!pExtendFrom) {
-      auto trackRange = tracks.SelectedLeaders();
+      auto trackRange = tracks.Selected();
       auto pFirst = *trackRange.begin();
 
       // If our track is at or after the first, extend from the first.
@@ -130,7 +130,7 @@ void SelectionState::ChangeSelectionOnShiftClick(
          pExtendFrom = Track::SharedPointer(*trackRange.rbegin());
    }
    // Either it's null, or mLastPickedTrack, or the first or last of
-   // SelectedLeaders()
+   // Selected()
    assert(!pExtendFrom || pExtendFrom->IsLeader());
 
    SelectNone(tracks);

--- a/libraries/lib-track-selection/SelectionState.cpp
+++ b/libraries/lib-track-selection/SelectionState.cpp
@@ -100,7 +100,7 @@ void SelectionState::SelectRangeOfTracks(
 
 void SelectionState::SelectNone(TrackList &tracks)
 {
-   for (auto t : tracks.Leaders())
+   for (auto t : tracks)
       SelectTrack(*t, false, false);
 }
 
@@ -185,7 +185,7 @@ SelectionStateChanger::~SelectionStateChanger()
          it = mInitialTrackSelection.begin(),
          end = mInitialTrackSelection.end();
 
-      for (auto track : mTracks.Leaders()) {
+      for (auto track : mTracks) {
          if (it == end)
             break;
          track->SetSelected( *it++ );

--- a/libraries/lib-track-selection/SelectionState.cpp
+++ b/libraries/lib-track-selection/SelectionState.cpp
@@ -83,8 +83,8 @@ void SelectionState::SelectRangeOfTracks(
    Track *sTrack = &rsTrack, *eTrack = &reTrack;
    // Swap the track pointers if needed
    auto begin = tracks.Leaders().begin(),
-      iterS = tracks.FindLeader(sTrack),
-      iterE = tracks.FindLeader(eTrack);
+      iterS = tracks.Find(sTrack),
+      iterE = tracks.Find(eTrack);
    // Be sure to substitute the leaders for given tracks
    sTrack = *iterS;
    eTrack = *iterE;
@@ -117,8 +117,8 @@ void SelectionState::ChangeSelectionOnShiftClick(
       // If our track is at or after the first, extend from the first.
       if (pFirst) {
          auto begin = tracks.Leaders().begin(),
-            iterT = tracks.FindLeader(&track),
-            iterF = tracks.FindLeader(pFirst);
+            iterT = tracks.Find(&track),
+            iterF = tracks.Find(pFirst);
          auto indT = std::distance(begin, iterT),
             indF = std::distance(begin, iterF);
          if (indT >= indF)

--- a/libraries/lib-track-selection/SelectionState.cpp
+++ b/libraries/lib-track-selection/SelectionState.cpp
@@ -94,7 +94,7 @@ void SelectionState::SelectRangeOfTracks(
       std::swap(sTrack, eTrack);
 
    for (auto track :
-        tracks.Leaders().StartingWith(sTrack).EndingAfter(eTrack))
+        tracks.Any().StartingWith(sTrack).EndingAfter(eTrack))
       SelectTrack(*track, true, false);
 }
 
@@ -167,7 +167,7 @@ SelectionStateChanger::SelectionStateChanger
    , mInitialLastPickedTrack{ state.mLastPickedTrack }
 {
    // Save initial state of track selections
-   const auto range = tracks.Leaders();
+   const auto range = tracks.Any();
    mInitialTrackSelection.clear();
    mInitialTrackSelection.reserve(range.size());
    for (const auto track : range) {

--- a/libraries/lib-track-selection/SyncLock.cpp
+++ b/libraries/lib-track-selection/SyncLock.cpp
@@ -162,7 +162,7 @@ TrackIterRange<Track> SyncLock::Group( Track *pTrack )
 {
    auto pList = pTrack->GetOwner();
    auto tracks = FindSyncLockGroup(const_cast<Track*>( pTrack ) );
-   return pList->Leaders()
+   return pList->Any()
       .StartingWith(tracks.first).EndingAfter(tracks.second);
 }
 

--- a/libraries/lib-track-selection/SyncLock.cpp
+++ b/libraries/lib-track-selection/SyncLock.cpp
@@ -126,7 +126,7 @@ std::pair<Track *, Track *> FindSyncLockGroup(Track *pMember)
 
    // Step back through any label tracks.
    auto pList = pMember->GetOwner();
-   auto member = pList->FindLeader(pMember);
+   auto member = pList->Find(pMember);
    while (*member && IsSeparatorTrack(*member))
       --member;
 
@@ -142,7 +142,7 @@ std::pair<Track *, Track *> FindSyncLockGroup(Track *pMember)
       // consider the track to be the sole member of a group.
       return { pMember, pMember };
 
-   auto last = pList->FindLeader(first);
+   auto last = pList->Find(first);
    auto next = last;
    bool inLabels = false;
 

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -1029,7 +1029,7 @@ void TrackList::UpdatePendingTracks()
    if (!mPendingUpdates)
       return;
    auto pUpdater = mUpdaters.begin();
-   for (const auto &pendingTrack : mPendingUpdates->Leaders()) {
+   for (const auto &pendingTrack : *mPendingUpdates) {
       auto src = FindById(pendingTrack->GetId());
       // Copy just a part of the track state, according to the update
       // function
@@ -1373,7 +1373,7 @@ struct TrackListRestorer final : UndoStateExtension {
    TrackListRestorer(AudacityProject &project)
       : mpTracks{ TrackList::Create(nullptr) }
    {
-      for (auto pTrack : TrackList::Get(project).Leaders()) {
+      for (auto pTrack : TrackList::Get(project)) {
          if (pTrack->GetId() == TrackId{})
             // Don't copy a pending added track
             continue;
@@ -1383,7 +1383,7 @@ struct TrackListRestorer final : UndoStateExtension {
    void RestoreUndoRedoState(AudacityProject &project) override {
       auto &dstTracks = TrackList::Get(project);
       dstTracks.Clear();
-      for (auto pTrack : mpTracks->Leaders())
+      for (auto pTrack : *mpTracks)
          dstTracks.Append(std::move(*pTrack->Duplicate()));
    }
    bool CanUndoOrRedo(const AudacityProject &project) override {

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -963,7 +963,7 @@ namespace {
          return 0.0;
 
       // Otherwise accumulate minimum or maximum of track values
-      return list.Leaders().accumulate(ident, combine, memfn);
+      return list.Any().accumulate(ident, combine, memfn);
    }
 }
 

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -436,15 +436,12 @@ TrackList::~TrackList()
 wxString TrackList::MakeUniqueTrackName(const wxString& baseTrackName) const
 {
    int n = 1;
-   while(true)
-   {
+   while(true) {
       auto name = wxString::Format("%s %d", baseTrackName, n++);
 
       bool found {false};
-      for(const auto track : Any())
-      {
-         if(track->GetName() == name)
-         {
+      for(const auto track : Tracks<const Track>()) {
+         if(track->GetName() == name) {
             found = true;
             break;
          }
@@ -468,7 +465,7 @@ void TrackList::RecalcPositions(TrackNodePointer node)
       i = t->GetIndex() + 1;
    }
 
-   const auto theEnd = end();
+   const auto theEnd = End();
    for (auto n = DoFind(node.first->get()); n != theEnd; ++n) {
       t = *n;
       t->SetIndex(i++);
@@ -711,7 +708,7 @@ bool TrackList::MakeMultiChannelTrack(Track& track, int nChannels, bool aligned)
       auto first = list->DoFind(&track);
       auto canLink = [&]() -> bool {
          int count = nChannels;
-         for (auto it = first, end = TrackList::end(); it != end && count; ++it)
+         for (auto it = first, end = TrackList::End(); it != end && count; ++it)
          {
             if ((*it)->HasLinkedTrack())
                return false;
@@ -762,8 +759,7 @@ void TrackList::Clear(bool sendEvent)
    // Null out the back-pointers to this in tracks, in case there
    // are outstanding shared_ptrs to those tracks, making them outlive
    // the temporary ListOfTracks below.
-   for ( auto pTrack: *this )
-   {
+   for (auto pTrack: Tracks<Track>()) {
       pTrack->SetOwner({}, {});
 
       if (sendEvent)
@@ -943,7 +939,7 @@ bool TrackList::MoveDown(Track * t)
 
 bool TrackList::empty() const
 {
-   return begin() == end();
+   return Begin() == End();
 }
 
 size_t TrackList::NChannels() const
@@ -1271,7 +1267,7 @@ bool TrackList::HasPendingTracks() const
 {
    if (mPendingUpdates && !mPendingUpdates->empty())
       return true;
-   if (end() != std::find_if(begin(), end(), [](const Track *t){
+   if (End() != std::find_if(Begin(), End(), [](const Track *t){
       return t->GetId() == TrackId{};
    }))
       return true;

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -1426,6 +1426,18 @@ TrackListHolder TrackList::Temporary(AudacityProject *pProject,
    return tempList;
 }
 
+TrackListHolder TrackList::Temporary(AudacityProject *pProject,
+   const std::vector<Track::Holder> &channels)
+{
+   auto nChannels = channels.size();
+   auto tempList = Temporary(pProject,
+      (nChannels > 0 ? channels[0] : nullptr),
+      (nChannels > 1 ? channels[1] : nullptr));
+   for (size_t iChannel = 2; iChannel < nChannels; ++iChannel)
+      tempList->Add(channels[iChannel]);
+   return tempList;
+}
+
 void TrackList::Append(TrackList &&list)
 {
    auto iter = list.ListOfTracks::begin(),

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -323,11 +323,12 @@ bool Track::IsSelectedLeader() const
 
 bool Track::LinkConsistencyFix(bool doFix)
 {
+   assert(!doFix || IsLeader());
    // Sanity checks for linked tracks; unsetting the linked property
    // doesn't fix the problem, but it likely leaves us with orphaned
    // sample blocks instead of much worse problems.
    bool err = false;
-   if (HasLinkedTrack()) {
+   if (HasLinkedTrack()) /* which implies IsLeader() */ {
       if (auto link = GetLinkedTrack()) {
          // A linked track's partner should never itself be linked
          if (link->HasLinkedTrack()) {

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -100,7 +100,7 @@ TrackListHolder Track::Duplicate() const
    // invoke "virtual constructor" to copy track object proper:
    auto result = Clone();
 
-   auto iter = TrackList::Channels(*result->Leaders().begin()).begin();
+   auto iter = TrackList::Channels(*result->begin()).begin();
    const auto copyOne = [&](const Track *pChannel){
       pChannel->AttachedTrackObjects::ForEach([&](auto &attachment){
          // Copy view state that might be important to undo/redo
@@ -288,7 +288,7 @@ void Track::Notify(bool allChannels, int code)
 
 void Track::Paste(double t, const TrackList &src)
 {
-   Paste(t, **src.Leaders().begin());
+   Paste(t, **src.begin());
 }
 
 void Track::SyncLockAdjust(double oldT1, double newT1)
@@ -650,7 +650,7 @@ TrackListHolder TrackList::ReplaceOne(Track &t, TrackList &&with)
    assert(t.IsLeader());
    assert(t.GetOwner().get() == this);
    auto nChannels = t.NChannels();
-   assert(nChannels == (*with.Leaders().begin())->NChannels());
+   assert(nChannels == (*with.begin())->NChannels());
    TrackListHolder result = Temporary(nullptr);
 
    const auto channels = TrackList::Channels(&t);
@@ -995,7 +995,7 @@ TrackList::RegisterPendingChangedTrack(Updater updater, Track *src)
       // Share the satellites with the original, though they do not point back
       // to the pending track
       const auto channels = TrackList::Channels(src);
-      auto iter = TrackList::Channels(*tracks->Leaders().begin()).begin();
+      auto iter = TrackList::Channels(*tracks->begin()).begin();
       for (const auto pChannel : channels)
          ((AttachedTrackObjects&)**iter++) = *pChannel; // shallow copy
    }

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -240,7 +240,7 @@ void Track::DoSetLinkType(LinkType linkType, bool completeList)
    }
 
    // Assertion checks only in a debug build, does not have side effects!
-   assert(LinkConsistencyCheck(completeList));
+   assert(!completeList || LinkConsistencyCheck());
 }
 
 Track *Track::GetLinkedTrack() const
@@ -321,13 +321,13 @@ bool Track::IsLeader() const
 bool Track::IsSelectedLeader() const
    { return IsSelected() && IsLeader(); }
 
-bool Track::LinkConsistencyFix(bool doFix, bool completeList)
+bool Track::LinkConsistencyFix(bool doFix)
 {
    // Sanity checks for linked tracks; unsetting the linked property
    // doesn't fix the problem, but it likely leaves us with orphaned
    // sample blocks instead of much worse problems.
    bool err = false;
-   if (completeList && HasLinkedTrack()) {
+   if (HasLinkedTrack()) {
       if (auto link = GetLinkedTrack()) {
          // A linked track's partner should never itself be linked
          if (link->HasLinkedTrack()) {

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1043,6 +1043,7 @@ class TRACK_API TrackList final
 
    // Iteration
 
+   private:
    // Hide the inherited begin() and end()
    using iterator = TrackIter<Track>;
    using const_iterator = TrackIter<const Track>;
@@ -1089,6 +1090,7 @@ class TRACK_API TrackList final
          return MakeTrackIterator<TrackType>( pTrack->GetNode() );
    }
 
+public:
    // If the track is not an audio track, or not one of a group of channels,
    // return the track itself; else return the first channel of its group --
    // in either case as an iterator that will only visit other leader tracks.
@@ -1103,6 +1105,7 @@ class TRACK_API TrackList final
    }
 
 
+private:
    template < typename TrackType = Track >
       auto Any()
          -> TrackIterRange< TrackType >
@@ -1137,6 +1140,7 @@ class TRACK_API TrackList final
    }
 
 
+public:
    template < typename TrackType = Track >
       auto Leaders()
          -> TrackIterRange< TrackType >

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -238,6 +238,8 @@ public:
    //! Check consistency of channel groups, and maybe fix it
    /*!
     @param doFix whether to make any changes to correct inconsistencies
+
+    @pre `!doFix || IsLeader()`
     @return true if no inconsistencies were found
     */
    virtual bool LinkConsistencyFix(bool doFix = true);
@@ -449,6 +451,7 @@ public:
    //! open the track from XML
    /*!
     May assume consistency of stereo channel grouping and examine other channels
+    @pre `IsLeader()`
     */
    virtual std::optional<TranslatableString> GetErrorOpening() const;
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1251,10 +1251,16 @@ public:
    */
    bool MakeMultiChannelTrack(Track& first, int nChannels, bool aligned);
 
-   /// Replace first track with second track, give back a holder
-   /// Give the replacement the same id as the replaced
-   ListOfTracks::value_type Replace(
-      Track * t, const ListOfTracks::value_type &with);
+   /*!
+    Replace channel group `t` with the first group in the given list, return a
+    temporary list of the removed tracks, modify given list by removing group
+    Give the replacements the same ids as the replaced
+
+    @pre `t.IsLeader()`
+    @pre `t.GetOwner().get() == this`
+    @pre `t.NChannels() == (*with.Leaders().begin())->NChannels()`
+    */
+   TrackListHolder ReplaceOne(Track &t, TrackList &&with);
 
    //! Remove a channel group, given the leader
    /*!
@@ -1307,6 +1313,10 @@ public:
 
    //! Remove all tracks from `list` and put them at the end of `this`
    void Append(TrackList &&list);
+
+   //! Remove first channel group (if any) from `list` and put it at the end of
+   //! `this`
+   void AppendOne(TrackList &&list);
 
 private:
    using ListOfTracks::size;

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1048,20 +1048,20 @@ class TRACK_API TrackList final
    using const_iterator = TrackIter<const Track>;
 
    using value_type = Track *;
-   iterator begin() { return Leaders().begin(); }
-   iterator end() { return Leaders().end(); }
-   const_iterator begin() const { return Leaders().begin(); }
-   const_iterator end() const { return Leaders().end(); }
+   iterator begin() { return Any().begin(); }
+   iterator end() { return Any().end(); }
+   const_iterator begin() const { return Any().begin(); }
+   const_iterator end() const { return Any().end(); }
    const_iterator cbegin() const { return begin(); }
    const_iterator cend() const { return end(); }
 
    // Reverse iteration
    using reverse_iterator = std::reverse_iterator<iterator>;
    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-   reverse_iterator rbegin() { return Leaders().rbegin(); }
-   reverse_iterator rend() { return Leaders().rend(); }
-   const_reverse_iterator rbegin() const { return Leaders().rbegin(); }
-   const_reverse_iterator rend() const { return Leaders().rend(); }
+   reverse_iterator rbegin() { return Any().rbegin(); }
+   reverse_iterator rend() { return Any().rend(); }
+   const_reverse_iterator rbegin() const { return Any().rbegin(); }
+   const_reverse_iterator rend() const { return Any().rend(); }
    const_reverse_iterator crbegin() const { return rbegin(); }
    const_reverse_iterator crend() const { return rend(); }
 
@@ -1095,14 +1095,14 @@ private:
 
 public:
    template < typename TrackType = Track >
-      auto Leaders()
+      auto Any()
          -> TrackIterRange< TrackType >
    {
       return Tracks< TrackType >( &Track::IsLeader );
    }
 
    template < typename TrackType = const Track >
-      auto Leaders() const
+      auto Any() const
          -> std::enable_if_t< std::is_const_v<TrackType>,
             TrackIterRange< TrackType >
          >
@@ -1253,7 +1253,7 @@ public:
 
    bool empty() const;
    size_t NChannels() const;
-   size_t Size() const { return Leaders().size(); }
+   size_t Size() const { return Any().size(); }
 
    //! Return the least start time of the tracks, or 0 when no tracks
    double GetStartTime() const;

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1043,27 +1043,28 @@ class TRACK_API TrackList final
 
    // Iteration
 
-   private:
+private:
    // Hide the inherited begin() and end()
    using iterator = TrackIter<Track>;
    using const_iterator = TrackIter<const Track>;
+
    using value_type = Track *;
-   iterator begin() { return Any().begin(); }
-   iterator end() { return Any().end(); }
-   const_iterator begin() const { return Any().begin(); }
-   const_iterator end() const { return Any().end(); }
-   const_iterator cbegin() const { return begin(); }
-   const_iterator cend() const { return end(); }
+   iterator begin() = delete; // { return Any().begin(); }
+   iterator end() = delete; // { return Any().end(); }
+   const_iterator begin() const = delete; // { return Any().begin(); }
+   const_iterator end() const = delete; // { return Any().end(); }
+   const_iterator cbegin() const = delete; // { return begin(); }
+   const_iterator cend() const = delete; // { return end(); }
 
    // Reverse iteration
    using reverse_iterator = std::reverse_iterator<iterator>;
    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-   reverse_iterator rbegin() { return Any().rbegin(); }
-   reverse_iterator rend() { return Any().rend(); }
-   const_reverse_iterator rbegin() const { return Any().rbegin(); }
-   const_reverse_iterator rend() const { return Any().rend(); }
-   const_reverse_iterator crbegin() const { return rbegin(); }
-   const_reverse_iterator crend() const { return rend(); }
+   reverse_iterator rbegin() = delete; // { return Any().rbegin(); }
+   reverse_iterator rend() = delete; // { return Any().rend(); }
+   const_reverse_iterator rbegin() const = delete; // { return Any().rbegin(); }
+   const_reverse_iterator rend() const = delete; // { return Any().rend(); }
+   const_reverse_iterator crbegin() const = delete; // { return rbegin(); }
+   const_reverse_iterator crend() const = delete; // { return rend(); }
 
    //! Turn a pointer into a TrackIter (constant time);
    //! get end iterator if this does not own the track
@@ -1084,21 +1085,15 @@ public:
 
 
 private:
-   template < typename TrackType = Track >
-      auto Any()
-         -> TrackIterRange< TrackType >
-   {
-      return Tracks< TrackType >();
-   }
+   //! This private function still iterates channels not tracks
+   iterator Begin() { return Tracks<Track>().begin(); }
+   //! This private function still iterates channels not tracks
+   iterator End() { return Tracks<Track>().end(); }
 
-   template < typename TrackType = const Track >
-      auto Any() const
-         -> std::enable_if_t< std::is_const_v<TrackType>,
-            TrackIterRange< TrackType >
-         >
-   {
-      return Tracks< TrackType >();
-   }
+   //! This private function still iterates channels not tracks
+   const_iterator Begin() const { return Tracks<const Track>().begin(); }
+   //! This private function still iterates channels not tracks
+   const_iterator End() const { return Tracks<const Track>().end(); }
 
 public:
    template < typename TrackType = Track >
@@ -1136,7 +1131,7 @@ public:
       static auto SingletonRange( TrackType *pTrack )
          -> TrackIterRange< TrackType >
    {
-      return pTrack->GetOwner()->template Any<TrackType>()
+      return pTrack->GetOwner()->template Tracks<TrackType>()
          .StartingWith( pTrack ).EndingAfter( pTrack );
    }
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -370,8 +370,8 @@ public:
    /*!
     Non-virtual overload that passes the first track of a given list
     @pre `IsLeader()`
-    @pre `SameKindAs(**src.Leaders().begin()).NChannels()`
-    @pre `NChannels == (**src.Leaders().begin()).NChannels()`
+    @pre `SameKindAs(**src.begin()).NChannels()`
+    @pre `NChannels == (**src.begin()).NChannels()`
     */
    void Paste(double t, const TrackList &src);
 
@@ -1043,34 +1043,32 @@ class TRACK_API TrackList final
 
    // Iteration
 
-private:
    // Hide the inherited begin() and end()
    using iterator = TrackIter<Track>;
    using const_iterator = TrackIter<const Track>;
 
    using value_type = Track *;
-   iterator begin() = delete; // { return Any().begin(); }
-   iterator end() = delete; // { return Any().end(); }
-   const_iterator begin() const = delete; // { return Any().begin(); }
-   const_iterator end() const = delete; // { return Any().end(); }
-   const_iterator cbegin() const = delete; // { return begin(); }
-   const_iterator cend() const = delete; // { return end(); }
+   iterator begin() { return Leaders().begin(); }
+   iterator end() { return Leaders().end(); }
+   const_iterator begin() const { return Leaders().begin(); }
+   const_iterator end() const { return Leaders().end(); }
+   const_iterator cbegin() const { return begin(); }
+   const_iterator cend() const { return end(); }
 
    // Reverse iteration
    using reverse_iterator = std::reverse_iterator<iterator>;
    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-   reverse_iterator rbegin() = delete; // { return Any().rbegin(); }
-   reverse_iterator rend() = delete; // { return Any().rend(); }
-   const_reverse_iterator rbegin() const = delete; // { return Any().rbegin(); }
-   const_reverse_iterator rend() const = delete; // { return Any().rend(); }
-   const_reverse_iterator crbegin() const = delete; // { return rbegin(); }
-   const_reverse_iterator crend() const = delete; // { return rend(); }
+   reverse_iterator rbegin() { return Leaders().rbegin(); }
+   reverse_iterator rend() { return Leaders().rend(); }
+   const_reverse_iterator rbegin() const { return Leaders().rbegin(); }
+   const_reverse_iterator rend() const { return Leaders().rend(); }
+   const_reverse_iterator crbegin() const { return rbegin(); }
+   const_reverse_iterator crend() const { return rend(); }
 
    //! Turn a pointer into a TrackIter (constant time);
    //! get end iterator if this does not own the track
    TrackIter<Track> DoFind(Track *pTrack);
 
-public:
    // If the track is not an audio track, or not one of a group of channels,
    // return the track itself; else return the first channel of its group --
    // in either case as an iterator that will only visit other leader tracks.
@@ -1219,7 +1217,7 @@ public:
 
     @pre `t.IsLeader()`
     @pre `t.GetOwner().get() == this`
-    @pre `t.NChannels() == (*with.Leaders().begin())->NChannels()`
+    @pre `t.NChannels() == (*with.begin())->NChannels()`
     */
    TrackListHolder ReplaceOne(Track &t, TrackList &&with);
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1100,24 +1100,6 @@ private:
       return Tracks< TrackType >();
    }
 
-   // Abbreviating some frequently used cases
-   template < typename TrackType = Track >
-      auto Selected()
-         -> TrackIterRange< TrackType >
-   {
-      return Tracks< TrackType >( &Track::IsSelected );
-   }
-
-   template < typename TrackType = const Track >
-      auto Selected() const
-         -> std::enable_if_t< std::is_const_v<TrackType>,
-            TrackIterRange< TrackType >
-         >
-   {
-      return Tracks< TrackType >( &Track::IsSelected );
-   }
-
-
 public:
    template < typename TrackType = Track >
       auto Leaders()
@@ -1136,20 +1118,17 @@ public:
    }
 
 
-   template < typename TrackType = Track >
-      auto SelectedLeaders()
-         -> TrackIterRange< TrackType >
+   template <typename TrackType = Track>
+   auto Selected() -> TrackIterRange<TrackType>
    {
-      return Tracks< TrackType >( &Track::IsSelectedLeader );
+      return Tracks<TrackType>(&Track::IsSelectedLeader);
    }
 
-   template < typename TrackType = const Track >
-      auto SelectedLeaders() const
-         -> std::enable_if_t< std::is_const_v<TrackType>,
-            TrackIterRange< TrackType >
-         >
+   template <typename TrackType = const Track>
+   auto Selected() const
+      -> std::enable_if_t<std::is_const_v<TrackType>, TrackIterRange<TrackType>>
    {
-      return Tracks< TrackType >( &Track::IsSelectedLeader );
+      return Tracks<TrackType>(&Track::IsSelectedLeader);
    }
 
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -388,8 +388,11 @@ public:
     */
    virtual void Silence(double t0, double t1) = 0;
 
-   // May assume precondition: t0 <= t1
-   virtual void InsertSilence(double WXUNUSED(t), double WXUNUSED(len)) = 0;
+   /*!
+    May assume precondition: t0 <= t1
+    @pre `IsLeader()`
+    */
+   virtual void InsertSilence(double t, double len) = 0;
 
 private:
    //! Subclass responsibility implements only a part of Duplicate(), copying

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -238,15 +238,13 @@ public:
    //! Check consistency of channel groups, and maybe fix it
    /*!
     @param doFix whether to make any changes to correct inconsistencies
-    @param completeList whether to assume that the TrackList containing this
-    is completely loaded; if false, skip some of the checks
     @return true if no inconsistencies were found
     */
-   virtual bool LinkConsistencyFix(bool doFix = true, bool completeList = true);
+   virtual bool LinkConsistencyFix(bool doFix = true);
 
    //! Do the non-mutating part of consistency fix only and return status
-   bool LinkConsistencyCheck(bool completeList)
-   { return const_cast<Track*>(this)->LinkConsistencyFix(false, completeList); }
+   bool LinkConsistencyCheck()
+   { return const_cast<Track*>(this)->LinkConsistencyFix(false); }
 
    bool HasOwner() const { return static_cast<bool>(GetOwner());}
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1065,43 +1065,21 @@ class TRACK_API TrackList final
    const_reverse_iterator crbegin() const { return rbegin(); }
    const_reverse_iterator crend() const { return rend(); }
 
-   //! Turn a pointer into a TrackIter (constant time); get end iterator if this does not own the track
-   template < typename TrackType = Track >
-      auto Find(Track *pTrack)
-         -> TrackIter< TrackType >
-   {
-      if (!pTrack || pTrack->GetHolder() != this)
-         return EndIterator<TrackType>();
-      else
-         return MakeTrackIterator<TrackType>( pTrack->GetNode() );
-   }
-
-   //! @copydoc Find
-   /*! const overload will only produce iterators over const TrackType */
-   template < typename TrackType = const Track >
-      auto Find(const Track *pTrack) const
-         -> std::enable_if_t< std::is_const_v<TrackType>,
-            TrackIter< TrackType >
-         >
-   {
-      if (!pTrack || pTrack->GetOwner().get() != this)
-         return EndIterator<TrackType>();
-      else
-         return MakeTrackIterator<TrackType>( pTrack->GetNode() );
-   }
+   //! Turn a pointer into a TrackIter (constant time);
+   //! get end iterator if this does not own the track
+   TrackIter<Track> DoFind(Track *pTrack);
 
 public:
    // If the track is not an audio track, or not one of a group of channels,
    // return the track itself; else return the first channel of its group --
    // in either case as an iterator that will only visit other leader tracks.
    // (Generalizing away from the assumption of at most stereo)
-   TrackIter< Track > FindLeader( Track *pTrack );
+   TrackIter<Track> Find(Track *pTrack);
 
-   TrackIter< const Track >
-      FindLeader( const Track *pTrack ) const
+   TrackIter<const Track> Find(const Track *pTrack) const
    {
       return const_cast<TrackList*>(this)->
-         FindLeader( const_cast<Track*>(pTrack) ).Filter< const Track >();
+         Find(const_cast<Track*>(pTrack)).Filter<const Track>();
    }
 
 
@@ -1216,7 +1194,7 @@ public:
          -> TrackIterRange< TrackType >
    {
       return Channels_<TrackType>(
-         static_cast<TrackList*>(pTrack->GetHolder())->FindLeader(pTrack));
+         static_cast<TrackList*>(pTrack->GetHolder())->Find(pTrack));
    }
 
    //! Count channels of a track

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -3178,7 +3178,7 @@ void WaveTrack::AllClipsIterator::push( WaveClipHolders &clips )
 void VisitBlocks(TrackList &tracks, BlockVisitor visitor,
    SampleBlockIDSet *pIDs)
 {
-   for (auto wt : tracks.Leaders<const WaveTrack>())
+   for (auto wt : tracks.Any<const WaveTrack>())
       for (const auto pChannel : TrackList::Channels(wt))
          // Scan all clips within current track
          for (const auto &clip : pChannel->GetAllClips())
@@ -3241,7 +3241,7 @@ void WaveTrackFactory::Destroy( AudacityProject &project )
 ProjectFormatExtensionsRegistry::Extension smartClipsExtension(
    [](const AudacityProject& project) -> ProjectFormatVersion {
       const TrackList& trackList = TrackList::Get(project);
-      for (auto wt : trackList.Leaders<const WaveTrack>())
+      for (auto wt : trackList.Any<const WaveTrack>())
          for (const auto pChannel : TrackList::Channels(wt))
             for (const auto& clip : pChannel->GetAllClips())
                if (clip->GetTrimLeft() > 0.0 || clip->GetTrimRight() > 0.0)

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -760,6 +760,19 @@ WaveTrack::Holder WaveTrack::EmptyCopy(
    return result;
 }
 
+TrackListHolder WaveTrack::WideEmptyCopy(
+   const SampleBlockFactoryPtr &pFactory, bool keepLink) const
+{
+   assert(IsLeader());
+   auto result = TrackList::Temporary(nullptr);
+   for (const auto pChannel : TrackList::Channels(this)) {
+      const auto pNewTrack =
+         result->Add(pChannel->EmptyCopy(pFactory, keepLink));
+      assert(!keepLink || pNewTrack->IsLeader() == pChannel->IsLeader());
+   }
+   return result;
+}
+
 TrackListHolder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
 {
    if (t1 < t0)

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -123,7 +123,7 @@ private:
 
    void MoveTo(double o) override;
 
-   bool LinkConsistencyFix(bool doFix, bool completeList) override;
+   bool LinkConsistencyFix(bool doFix) override;
 
    //! Implement WideSampleSequence
    double GetStartTime() const override;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -246,7 +246,7 @@ private:
       const TimeWarper *effectWarper = nullptr) /* not override */;
    /*!
     Overload that takes a TrackList and passes its first wave track
-    @pre `**src.Leaders<const WaveTrack>().begin()` satisfies preconditions
+    @pre `**src.Any<const WaveTrack>().begin()` satisfies preconditions
     of the other overload for `src`
     */
    void ClearAndPaste(double t0, double t1,
@@ -255,7 +255,7 @@ private:
       bool merge = true,
       const TimeWarper *effectWarper = nullptr)
    {
-      ClearAndPaste(t0, t1, **src.Leaders<const WaveTrack>().begin(),
+      ClearAndPaste(t0, t1, **src.Any<const WaveTrack>().begin(),
          preserve, merge, effectWarper);
    }
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -205,6 +205,22 @@ private:
    Holder EmptyCopy(const SampleBlockFactoryPtr &pFactory = {},
       bool keepLink = true) const;
 
+   //! Make another channel group copying format, rate, color, etc. but
+   //! containing no clips
+   /*!
+    It is important to pass the correct factory (that for the project
+    which will own the copy) in the unusual case that a track is copied from
+    another project or the clipboard.  For copies within one project, the
+    default will do.
+
+    @param keepLink if false, make the new track mono.  But always preserve
+    any other track group data.
+
+    @pre `IsLeader()`
+    */
+   TrackListHolder WideEmptyCopy(const SampleBlockFactoryPtr &pFactory = {},
+      bool keepLink = true) const;
+
    // If forClipboard is true,
    // and there is no clip at the end time of the selection, then the result
    // will contain a "placeholder" clip whose only purpose is to make

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -731,7 +731,10 @@ private:
    static void PasteOne(WaveTrack &track, double t0, const WaveTrack &other,
       double startTime, double insertDuration);
 
-   //! Whether all clips have a common rate
+   //! Whether all clips of a leader track have a common rate
+   /*!
+    @pre `IsLeader()`
+    */
    bool RateConsistencyCheck() const;
 
    //! Sets project tempo on clip upon push. Use this instead of

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -159,9 +159,23 @@ private:
    void SetWaveColorIndex(int colorIndex);
 
    sampleCount GetPlaySamplesCount() const;
-   //! Returns the total number of samples in all underlying sequences
-   //! of all clips (but not counting the cutlines)
+
+   /*!
+    @return the total number of samples in all underlying sequences
+   of all clips, across all channels (including hidden audio but not
+   counting the cutlines)
+
+    @pre `IsLeader()`
+    */
    sampleCount GetSequenceSamplesCount() const;
+
+   /*!
+    @return the total number of blocks in all underlying sequences of all clips,
+   across all channels (including hidden audio but not counting the cutlines)
+
+    @pre `IsLeader()`
+    */
+   size_t CountBlocks() const;
 
    sampleFormat GetSampleFormat() const override { return mFormat; }
 
@@ -558,6 +572,18 @@ private:
    // clip start time. The array is emptied prior to adding the clips.
    WaveClipPointers SortedClipArray();
    WaveClipConstPointers SortedClipArray() const;
+
+   //! Whether any clips have hidden audio
+   /*!
+    @pre `IsLeader()`
+    */
+   bool HasHiddenData() const;
+
+   //! Remove hidden audio from all clips
+   /*!
+    @pre `IsLeader()`
+    */
+   void DiscardTrimmed();
 
    //! Decide whether the clips could be offset (and inserted) together without overlapping other clips
    /*!

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -880,7 +880,7 @@ bool AUPImportFileHandle::HandleTimeTrack(XMLTagHandler *&handler)
 
    // Bypass this timetrack if the project already has one
    // (See HandleTimeEnvelope and HandleControlPoint also)
-   if (*tracks.Leaders<TimeTrack>().begin())
+   if (*tracks.Any<TimeTrack>().begin())
    {
       ImportUtils::ShowMessageBox(
          XO("The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."));
@@ -1364,7 +1364,7 @@ bool AUPImportFileHandle::HandleImport(XMLTagHandler *&handler)
    // Apply them to all new wave tracks.
    bool bSuccess = true;
 
-   auto range = tracks.Leaders();
+   auto range = tracks.Any();
    if (pLast) {
       range = range.StartingWith(pLast);
       ++range.first;

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -356,6 +356,9 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
    else if(!mErrorMsg.empty())//i.e. warning
       ImportUtils::ShowMessageBox(mErrorMsg);
    
+   // TODO wide wave tracks -- quit here if misaligned tracks are found.
+   // (If we keep this entire source file at all)
+
    sampleCount processed = 0;
    for (auto fi : mFiles)
    {
@@ -1421,7 +1424,10 @@ bool AUPImportFileHandle::AddSilence(sampleCount len)
    }
    else if (mWaveTrack)
    {
-      mWaveTrack->InsertSilence(mWaveTrack->GetEndTime(), mWaveTrack->LongSamplesToTime(len));
+      // Assume alignment of clips and insert silence into leader only
+      if (mWaveTrack->IsLeader())
+         mWaveTrack->InsertSilence(
+            mWaveTrack->GetEndTime(), mWaveTrack->LongSamplesToTime(len));
    }
 
    return true;

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -1084,8 +1084,10 @@ bool AUPImportFileHandle::HandleSequence(XMLTagHandler *&handler)
       waveclip = mClip;
    }
 
-   for (auto pair : mAttrs)
-   {
+   auto pSequence =
+      static_cast<Sequence*>(waveclip->HandleXMLChild("sequence"));
+
+   for (auto pair : mAttrs) {
       auto attr = pair.first;
       auto value = pair.second;
 
@@ -1117,7 +1119,7 @@ bool AUPImportFileHandle::HandleSequence(XMLTagHandler *&handler)
 
          mFormat = (sampleFormat) fValue;
          // Assume old AUP format file never had wide clips
-         waveclip->GetSequence(0)->ConvertToSampleFormat(mFormat);
+         pSequence->ConvertToSampleFormat(mFormat);
       }
       else if (attr == "numsamples")
       {

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -328,7 +328,7 @@ void AUPImportFileHandle::Import(ImportProgressListener& progressListener,
       if (mHasParseError || IsCancelled()) {
          // Revoke additions of tracks
          while (oldNumTracks < tracks.Size())
-            tracks.Remove(**tracks.Leaders().end().advance(-1));
+            tracks.Remove(**tracks.end().advance(-1));
       }
    });
 
@@ -1347,7 +1347,7 @@ bool AUPImportFileHandle::HandleImport(XMLTagHandler *&handler)
    auto oldNumTracks = tracks.Size();
    Track *pLast = nullptr;
    if (oldNumTracks > 0)
-      pLast = *tracks.Leaders().rbegin();
+      pLast = *tracks.rbegin();
 
    // Guard this call so that C++ exceptions don't propagate through
    // the expat library

--- a/modules/mod-ffmpeg/ImportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ImportFFmpeg.cpp
@@ -503,15 +503,13 @@ void FFmpegImportFileHandle::Import(ImportProgressListener& progressListener,
             s, (long long)streamStartTime, double(streamStartTime) / 1000);
       }
 
-      if (stream_delay > 0)
-      {
+      if (stream_delay > 0) {
          int c = -1;
-         for (auto &channel : stream)
-         {
+         for (auto &channel : stream) {
             ++c;
-
             WaveTrack *t = channel.get();
-            t->InsertSilence(0,double(stream_delay)/AUDACITY_AV_TIME_BASE);
+            assert(t->IsLeader()); // channels are not yet grouped
+            t->InsertSilence(0, double(stream_delay) / AUDACITY_AV_TIME_BASE);
          }
       }
    }
@@ -559,6 +557,7 @@ void FFmpegImportFileHandle::Import(ImportProgressListener& progressListener,
          channel->Flush();
 
    for (auto &group : mChannels)
+      // Now channels get grouped
       outTracks.push_back(TrackList::Temporary(nullptr, group));
 
    // Save metadata

--- a/modules/mod-ffmpeg/ImportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ImportFFmpeg.cpp
@@ -273,10 +273,10 @@ private:
    bool                  mCancelled = false;     //!< True if importing was canceled by user
    bool                  mStopped = false;       //!< True if importing was stopped by user
    const FilePath        mName;
-   TrackHolders mChannels;               //!< 2-dimensional array of WaveTracks.
-                                         //!< First dimension - streams,
-                                         //!< After Import(), same size as mStreamContexts;
-                                         //!< second - channels of a stream.
+   std::vector<std::vector<WaveTrack::Holder>> mChannels; //!< 2-dimensional array of WaveTracks.
+      //!< First dimension - streams,
+      //!< After Import(), same size as mStreamContexts;
+      //!< second - channels of a stream.
 };
 
 
@@ -558,7 +558,8 @@ void FFmpegImportFileHandle::Import(ImportProgressListener& progressListener,
       for(auto &channel : stream)
          channel->Flush();
 
-   outTracks.swap(mChannels);
+   for (auto &group : mChannels)
+      outTracks.push_back(TrackList::Temporary(nullptr, group));
 
    // Save metadata
    WriteMetadata(tags);

--- a/modules/mod-flac/ImportFLAC.cpp
+++ b/modules/mod-flac/ImportFLAC.cpp
@@ -63,7 +63,7 @@ extern "C" {
 
 
 class FLACImportFileHandle;
-using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
+using NewChannelGroup = std::vector<std::shared_ptr<WaveTrack>>;
 
 class MyFLACFile final : public FLAC::Decoder::File
 {
@@ -433,7 +433,7 @@ void FLACImportFileHandle::Import(ImportProgressListener& progressListener,
       channel->Flush();
 
    if (!mChannels.empty())
-      outTracks.push_back(std::move(mChannels));
+      outTracks.push_back(TrackList::Temporary(nullptr, mChannels));
 
    wxString comment;
    wxString description;

--- a/modules/mod-lof/ImportLOF.cpp
+++ b/modules/mod-lof/ImportLOF.cpp
@@ -506,7 +506,7 @@ void LOFImportFileHandle::lofOpenFiles(wxString* ln)
             else if (Internat::CompatibleToDouble(tokenholder, &offset))
             {
                auto &tracks = TrackList::Get( *mProject );
-               auto t = *tracks.Leaders().rbegin();
+               auto t = *tracks.rbegin();
 
                // t is now the last track in the project, unless the import of
                // all tracks failed, in which case it will be null. In that

--- a/modules/mod-mpg123/ImportMP3_MPG123.cpp
+++ b/modules/mod-mpg123/ImportMP3_MPG123.cpp
@@ -345,7 +345,7 @@ void MP3ImportFileHandle::Import(ImportProgressListener &progressListener,
 
    // Copy the WaveTrack pointers into the Track pointer list that
    // we are expected to fill
-   outTracks.push_back(std::move(mChannels));
+   outTracks.push_back(TrackList::Temporary(nullptr, mChannels));
 
    ReadTags(tags);
    

--- a/modules/mod-ogg/ImportOGG.cpp
+++ b/modules/mod-ogg/ImportOGG.cpp
@@ -53,7 +53,7 @@ static const auto exts = {
 #include "ImportProgressListener.h"
 #include "ImportUtils.h"
 
-using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
+using NewChannelGroup = std::vector<std::shared_ptr<WaveTrack>>;
 
 class OggImportPlugin final : public ImportPlugin
 {
@@ -341,7 +341,7 @@ void OggImportFileHandle::Import(ImportProgressListener &progressListener,
    {
       for (auto &channel : link)
          channel->Flush();
-      outTracks.push_back(std::move(link));
+      outTracks.push_back(TrackList::Temporary(nullptr, link));
    }
 
    //\todo { Extract comments from each stream? }

--- a/modules/mod-pcm/ImportPCM.cpp
+++ b/modules/mod-pcm/ImportPCM.cpp
@@ -292,12 +292,9 @@ void PCMImportFileHandle::Import(ImportProgressListener &progressListener,
 
    NewChannelGroup channels(mInfo.channels);
 
-   {
-      // iter not used outside this scope.
-      auto iter = channels.begin();
-      for (int c = 0; c < mInfo.channels; ++iter, ++c)
-         *iter = ImportUtils::NewWaveTrack(*trackFactory, mFormat, mInfo.samplerate);
-   }
+   for (size_t c = 0; c < mInfo.channels; ++c)
+      channels[c] =
+         ImportUtils::NewWaveTrack(*trackFactory, mFormat, mInfo.samplerate);
 
    auto fileTotalFrames =
       (sampleCount)mInfo.frames; // convert from sf_count_t
@@ -391,7 +388,7 @@ void PCMImportFileHandle::Import(ImportProgressListener &progressListener,
       channel->Flush();
 
    if (!channels.empty())
-      outTracks.push_back(std::move(channels));
+      outTracks.push_back(TrackList::Temporary(nullptr, channels));
 
    const char *str;
 

--- a/src/Clipboard.cpp
+++ b/src/Clipboard.cpp
@@ -53,6 +53,7 @@ void Clipboard::Clear()
 void Clipboard::Assign( TrackList && newContents,
    double t0, double t1, const std::weak_ptr<AudacityProject> &pProject )
 {
+   assert(!newContents.GetOwner());
    newContents.Swap( *mTracks );
    newContents.Clear();
    

--- a/src/Clipboard.h
+++ b/src/Clipboard.h
@@ -39,6 +39,9 @@ public:
 
    void Clear();
    
+   /*!
+    @pre `!newContents.GetOwner()`
+    */
    void Assign(
      TrackList && newContents, double t0, double t1,
      const std::weak_ptr<AudacityProject> &pProject );
@@ -54,6 +57,9 @@ private:
    Clipboard(const Clipboard &) = delete;
    Clipboard &operator=(const Clipboard &) = delete;
 
+   /*!
+    @invariant `!mTracks->GetOwner()`
+    */
    std::shared_ptr<TrackList> mTracks;
    std::weak_ptr<AudacityProject> mProject{};
    double mT0{ 0 };

--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -172,7 +172,7 @@ const ReservedCommandFlag&
 const ReservedCommandFlag&
    TracksExistFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project){
-         return !TrackList::Get(project).Leaders().empty();
+         return !TrackList::Get(project).Any().empty();
       },
       CommandFlagOptions{}.DisableDefaultMessage()
    }; return flag; }
@@ -245,7 +245,7 @@ const ReservedCommandFlag&
          return
             ViewInfo::Get(project).ZoomInAvailable()
          &&
-            !TrackList::Get(project).Leaders().empty()
+            !TrackList::Get(project).Any().empty()
          ;
       }
    }; return flag; }
@@ -255,14 +255,14 @@ const ReservedCommandFlag&
          return
             ViewInfo::Get(project).ZoomOutAvailable()
          &&
-            !TrackList::Get(project).Leaders().empty()
+            !TrackList::Get(project).Any().empty()
          ;
       }
    }; return flag; }
 const ReservedCommandFlag&
    WaveTracksExistFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project){
-         return !TrackList::Get(project).Leaders<const WaveTrack>().empty();
+         return !TrackList::Get(project).Any<const WaveTrack>().empty();
       }
    }; return flag; }
 const ReservedCommandFlag&

--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -44,7 +44,7 @@ cycles.
 // Strong predicate excludes tracks that do not support basic editing.
 bool EditableTracksSelectedPred(const AudacityProject &project)
 {
-   auto range = TrackList::Get(project).SelectedLeaders()
+   auto range = TrackList::Get(project).Selected()
      - [](const Track *pTrack){
         return !pTrack->SupportsBasicEditing(); };
    return !range.empty();
@@ -53,7 +53,7 @@ bool EditableTracksSelectedPred(const AudacityProject &project)
 // Weaker predicate.
 bool AnyTracksSelectedPred(const AudacityProject &project)
 {
-   auto range = TrackList::Get(project).SelectedLeaders();
+   auto range = TrackList::Get(project).Selected();
    return !range.empty();
 };
 
@@ -140,7 +140,7 @@ const ReservedCommandFlag&
       [](const AudacityProject &project){
          // TODO: more-than-two-channels
          auto range =
-            TrackList::Get(project).SelectedLeaders<const WaveTrack>();
+            TrackList::Get(project).Selected<const WaveTrack>();
          return std::any_of(range.begin(), range.end(),
             [](auto pTrack){ return pTrack->NChannels() > 1; });
       },
@@ -163,7 +163,7 @@ const ReservedCommandFlag&
    WaveTracksSelectedFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project){
          return
-            !TrackList::Get(project).SelectedLeaders<const WaveTrack>().empty();
+            !TrackList::Get(project).Selected<const WaveTrack>().empty();
       },
       { [](const TranslatableString&) { return
          XO("You must first select some audio to perform this action.\n(Selecting other kinds of track won't work.)");
@@ -224,7 +224,7 @@ const ReservedCommandFlag&
    LabelTracksExistFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project){
          return !TrackList::Get(project)
-            .SelectedLeaders<const LabelTrack>().empty();
+            .Selected<const LabelTrack>().empty();
       }
    }; return flag; }
 const ReservedCommandFlag&

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -587,7 +587,7 @@ void FrequencyPlotDialog::GetAudio()
    int selcount = 0;
    bool warning = false;
    for (auto track :
-      TrackList::Get(*mProject).SelectedLeaders<const WaveTrack>()
+      TrackList::Get(*mProject).Selected<const WaveTrack>()
    ) {
       auto &selectedRegion = ViewInfo::Get(*mProject).selectedRegion;
       auto start = track->TimeToLongSamples(selectedRegion.t0());

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -741,7 +741,7 @@ void LabelDialog::OnExport(wxCommandEvent & WXUNUSED(event))
 
 void LabelDialog::OnSelectCell(wxGridEvent &event)
 {
-   for (auto t: mTracks->Leaders())
+   for (auto t: *mTracks)
       t->SetSelected( true );
 
    if (!mData.empty())

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -374,7 +374,7 @@ bool LabelDialog::TransferDataFromWindow()
    int tndx = 0;
 
    // Clear label tracks of labels
-   for (auto lt : mTracks->Leaders<LabelTrack>()) {
+   for (auto lt : mTracks->Any<LabelTrack>()) {
       ++tndx;
       if (!mSelectedTrack) {
          for (i = lt->GetNumLabels() - 1; i >= 0 ; i--) {
@@ -409,7 +409,7 @@ bool LabelDialog::TransferDataFromWindow()
       // Look for track with matching index
       tndx = 1;
       LabelTrack *lt{};
-      for (auto t : mTracks->Leaders<LabelTrack>()) {
+      for (auto t : mTracks->Any<LabelTrack>()) {
          lt = t;
          if (rd.index == tndx++) {
             break;
@@ -452,7 +452,7 @@ wxString LabelDialog::TrackName(int & index, const wxString &dflt)
 void LabelDialog::FindAllLabels()
 {
    // Add labels from all label tracks
-   for (auto lt : mTracks->Leaders<const LabelTrack>()) {
+   for (auto lt : mTracks->Any<const LabelTrack>()) {
       AddLabels(lt);
    }
 

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -905,6 +905,7 @@ void LabelTrack::Silence(double t0, double t1)
 
 void LabelTrack::InsertSilence(double t, double len)
 {
+   assert(IsLeader());
    for (auto &labelStruct: mLabels) {
       double t0 = labelStruct.getT0();
       double t1 = labelStruct.getT1();

--- a/src/Lyrics.cpp
+++ b/src/Lyrics.cpp
@@ -505,7 +505,7 @@ void LyricsPanel::DoUpdateLyrics()
 
    // Lyrics come from only the first label track.
    auto pLabelTrack =
-      *TrackList::Get(*mProject).Leaders<const LabelTrack>().begin();
+      *TrackList::Get(*mProject).Any<const LabelTrack>().begin();
    if (!pLabelTrack)
       return;
 

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -984,7 +984,7 @@ void MixerBoard::UpdateTrackClusters()
    unsigned int nClusterIndex = 0;
    MixerTrackCluster* pMixerTrackCluster = NULL;
 
-   for (auto pPlayableTrack: mTracks->Leaders<PlayableTrack>()) {
+   for (auto pPlayableTrack: mTracks->Any<PlayableTrack>()) {
       // TODO: more-than-two-channels
       auto spTrack = pPlayableTrack->SharedPointer<PlayableTrack>();
       if (nClusterIndex < nClusterCount)
@@ -1112,7 +1112,7 @@ wxBitmap* MixerBoard::GetMusicalInstrumentBitmap(const Track* pTrack)
 bool MixerBoard::HasSolo()
 {
    return
-      !(mTracks->Leaders<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
+      !(mTracks->Any<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
 }
 
 void MixerBoard::RefreshTrackClusters(bool bEraseBackground /*= true*/)
@@ -1506,10 +1506,10 @@ const ReservedCommandFlag&
          auto &tracks = TrackList::Get( project );
          return
 #ifdef EXPERIMENTAL_MIDI_OUT
-            !tracks.Leaders<const NoteTrack>().empty()
+            !tracks.Any<const NoteTrack>().empty()
          ||
 #endif
-            !tracks.Leaders<const WaveTrack>().empty()
+            !tracks.Any<const WaveTrack>().empty()
          ;
       }
    }; return flag; }

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -629,6 +629,7 @@ void NoteTrack::Silence(double t0, double t1)
 
 void NoteTrack::InsertSilence(double t, double len)
 {
+   assert(IsLeader());
    if (len < 0)
       THROW_INCONSISTENCY_EXCEPTION;
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -983,7 +983,7 @@ void NoteTrack::WriteXML(XMLWriter &xmlFile) const
    if (!mSeq) {
       // replace saveme with an (unserialized) duplicate, which is
       // destroyed at end of function.
-      holder = (*Clone()->Leaders().begin())->SharedPointer();
+      holder = (*Clone()->begin())->SharedPointer();
       saveme = static_cast<NoteTrack*>(holder.get());
    }
    saveme->GetSeq().write(data, true);

--- a/src/Printing.cpp
+++ b/src/Printing.cpp
@@ -102,7 +102,7 @@ bool AudacityPrintout::OnPrintPage(int WXUNUSED(page))
    artist.pZoomInfo = &zoomInfo;
    int y = rulerPageHeight;
 
-   for (auto l : mTracks->Leaders()) {
+   for (auto l : *mTracks) {
       for (auto n : l->Channels()) {
          auto &view = ChannelView::Get(*n);
          wxRect r;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -336,9 +336,9 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
 
    bool hasaudio;
    if (nonWaveToo)
-      hasaudio = ! tracks.Leaders<PlayableTrack>().empty();
+      hasaudio = ! tracks.Any<PlayableTrack>().empty();
    else
-      hasaudio = ! tracks.Leaders<WaveTrack>().empty();
+      hasaudio = ! tracks.Any<WaveTrack>().empty();
 
    double latestEnd = tracks.GetEndTime();
 
@@ -591,7 +591,7 @@ WritableSampleTrackArray ProjectAudioManager::ChooseExistingRecordingTracks(
    auto &trackList = TrackList::Get( *p );
    std::vector<unsigned> channelCounts;
    WritableSampleTrackArray candidates;
-   const auto range = trackList.Leaders<WaveTrack>();
+   const auto range = trackList.Any<WaveTrack>();
    for ( auto candidate : selectedOnly ? range + &Track::IsSelected : range ) {
       if (targetRate != RATE_NOT_SELECTED && candidate->GetRate() != targetRate)
          continue;
@@ -877,7 +877,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
          wxString defaultTrackName, defaultRecordingTrackName;
 
          // Count the tracks.
-         auto numTracks = trackList.Leaders<const WaveTrack>().size();
+         auto numTracks = trackList.Any<const WaveTrack>().size();
 
          auto recordingChannels = std::max(1, AudioIORecordChannels.Read());
 

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -679,7 +679,7 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
          existingTracks = ChooseExistingRecordingTracks(*p, true, rateOfSelected);
          if (!existingTracks.empty())
             t0 = std::max(t0,
-               TrackList::Get(*p).SelectedLeaders<const WaveTrack>()
+               TrackList::Get(*p).Selected<const WaveTrack>()
                   .max(&Track::GetEndTime));
          else {
             if (anySelected && rateOfSelected != options.rate) {
@@ -1323,7 +1323,7 @@ GetPropertiesOfSelected(const AudacityProject &proj)
    result.allSameRate = true;
 
    const auto selectedTracks{
-      TrackList::Get(proj).SelectedLeaders<const WaveTrack>() };
+      TrackList::Get(proj).Selected<const WaveTrack>() };
 
    for (const auto & track : selectedTracks) {
       if (rateOfSelection != RATE_NOT_SELECTED &&

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -953,7 +953,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
          // Bug 1548.  First of new tracks needs the focus.
          TrackFocus::Get(project).Set(first);
          if (!trackList.empty())
-            (*trackList.Leaders().rbegin())->EnsureVisible();
+            (*trackList.rbegin())->EnsureVisible();
       }
 
       //Automated Input Level Adjustment Initialization

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -172,7 +172,7 @@ auto ProjectFileManager::ReadProjectFile(
    if (bParseSuccess)
    {
       auto &tracks = TrackList::Get(project);
-      for (auto t : tracks.Leaders()) {
+      for (auto t : tracks) {
          // Note, the next function may have an important upgrading side effect,
          // and return no error; or it may find a real error and repair it, but
          // that repaired track won't be used because opening will fail.
@@ -226,7 +226,7 @@ auto ProjectFileManager::ReadProjectFile(
          // the version saved on disk will be preserved until the
          // user selects Save().
          mLastSavedTracks = TrackList::Create( nullptr );
-         for (auto t : tracks.Leaders())
+         for (auto t : tracks)
             mLastSavedTracks->Append(std::move(*t->Duplicate()));
       }
    }
@@ -390,7 +390,7 @@ bool ProjectFileManager::DoSave(const FilePath & fileName, const bool fromSaveAs
    mLastSavedTracks = TrackList::Create(nullptr);
 
    auto &tracks = TrackList::Get(proj);
-   for (auto t : tracks.Leaders())
+   for (auto t : tracks)
       mLastSavedTracks->Append(std::move(*t->Duplicate()));
 
    // If we get here, saving the project was successful, so we can DELETE
@@ -1190,7 +1190,7 @@ bool ImportProject(AudacityProject &dest, const FilePath &fileName)
       return false;
    auto &srcTracks = TrackList::Get(project);
    auto &destTracks = TrackList::Get(dest);
-   for (const Track *pTrack : srcTracks.Leaders())
+   for (const Track *pTrack : srcTracks)
       pTrack->PasteInto(dest, destTracks);
    Tags::Get(dest).Merge(Tags::Get(project));
 

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -172,7 +172,7 @@ auto ProjectFileManager::ReadProjectFile(
    if (bParseSuccess)
    {
       auto &tracks = TrackList::Get(project);
-      for (auto t : tracks.Any()) {
+      for (auto t : tracks.Leaders()) {
          // Note, the next function may have an important upgrading side effect,
          // and return no error; or it may find a real error and repair it, but
          // that repaired track won't be used because opening will fail.

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1031,7 +1031,7 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
          formats.GetBandwidthSelectionFormatName());
       
       ProjectHistory::Get( project ).InitialState();
-      TrackFocus::Get(project).Set(*tracks.Leaders().begin());
+      TrackFocus::Get(project).Set(*tracks.begin());
       window.HandleResize();
       trackPanel.Refresh(false);
 

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -87,7 +87,7 @@ void ProjectFileManager::DiscardAutosave(const FilePath &filename)
    projectFileManager.ReadProjectFile(filename, true);
 
    if (projectFileManager.mLastSavedTracks) {
-      for (auto wt : projectFileManager.mLastSavedTracks->Leaders<WaveTrack>())
+      for (auto wt : projectFileManager.mLastSavedTracks->Any<WaveTrack>())
          wt->CloseLock();
       projectFileManager.mLastSavedTracks.reset();
    }
@@ -756,7 +756,7 @@ void ProjectFileManager::CompactProjectOnClose()
    // sample block objects in memory.
    if (mLastSavedTracks)
    {
-      for (auto wt : mLastSavedTracks->Leaders<WaveTrack>())
+      for (auto wt : mLastSavedTracks->Any<WaveTrack>())
          wt->CloseLock();
 
       // Attempt to compact the project
@@ -1064,7 +1064,7 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
       // may have spared the files at the expense of leaked memory).  But
       // here is a better way to accomplish the intent, doing like what happens
       // when the project closes:
-      for (auto pTrack : tracks.Leaders<WaveTrack>())
+      for (auto pTrack : tracks.Any<WaveTrack>())
          pTrack->CloseLock();
 
       tracks.Clear(); //tracks.Clear(true);
@@ -1104,10 +1104,10 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
    // In case the project had soloed tracks before importing,
    // all newly imported tracks are muted.
    const bool projectHasSolo =
-      !(tracks.Leaders<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
+      !(tracks.Any<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
    if (projectHasSolo) {
       for (auto &group : newTracks)
-         for (const auto pTrack : group->Leaders<WaveTrack>())
+         for (const auto pTrack : group->Any<WaveTrack>())
             pTrack->SetMute(true);
    }
 
@@ -1117,7 +1117,7 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
          assert(false);
          continue;
       }
-      for (const auto pTrack : group->Leaders<WaveTrack>())
+      for (const auto pTrack : group->Any<WaveTrack>())
          results.push_back(pTrack);
       tracks.Append(std::move(*group));
    }

--- a/src/ProjectFileManager.h
+++ b/src/ProjectFileManager.h
@@ -26,8 +26,7 @@ class TrackList;
 class WaveTrack;
 class XMLTagHandler;
 
-using WaveTrackArray = std::vector < std::shared_ptr < WaveTrack > >;
-using TrackHolders = std::vector< WaveTrackArray >;
+using TrackHolders = std::vector<std::shared_ptr<TrackList>>;
 
 class AUDACITY_DLL_API ProjectFileManager final
    : public ClientData::Base

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -148,7 +148,7 @@ double ProjectSelectionManager::SSBL_GetRate() const
    auto &tracks = TrackList::Get( project );
    // Return maximum of project rate and all track rates.
    return std::max( ProjectRate::Get( project ).GetRate(),
-      tracks.Leaders<const WaveTrack>().max(&WaveTrack::GetRate));
+      tracks.Any<const WaveTrack>().max(&WaveTrack::GetRate));
 }
 
 const NumericFormatSymbol &

--- a/src/ProjectTempoListener.cpp
+++ b/src/ProjectTempoListener.cpp
@@ -51,6 +51,6 @@ ProjectTempoListener::ProjectTempoListener(
 
 void ProjectTempoListener::OnProjectTempoChange(double newTempo)
 {
-   for (auto track : mTrackList.Leaders())
+   for (auto track : mTrackList)
       track->OnProjectTempoChange(newTempo);
 }

--- a/src/ProjectTempoListener.cpp
+++ b/src/ProjectTempoListener.cpp
@@ -35,7 +35,7 @@ ProjectTempoListener::ProjectTempoListener(
                const auto tempo = ProjectTimeSignature::Get(project).GetTempo();
                if (const auto track = event.mpTrack.lock()) {
                   // TODO wide wave tracks: just call on the track itself
-                  if (auto pLeader = *mTrackList.FindLeader(track.get()))
+                  if (auto pLeader = *mTrackList.Find(track.get()))
                      pLeader->OnProjectTempoChange(tempo);
                }
             }

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1692,7 +1692,7 @@ void ProjectWindow::ZoomAfterImport(Track *pTrack)
 
    trackPanel.SetFocus();
    if (!pTrack)
-      pTrack = *tracks.SelectedLeaders().begin();
+      pTrack = *tracks.Selected().begin();
    if (!pTrack)
       pTrack = *tracks.Leaders().begin();
    if (pTrack) {

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1107,7 +1107,7 @@ void ProjectWindow::FixScrollbars()
    }
 
    auto LastTime = std::numeric_limits<double>::lowest();
-   for (const Track *track : tracks.Leaders()) {
+   for (const Track *track : tracks) {
       // Iterate over pending changed tracks if present.
       track = track->SubstitutePendingChangedTrack().get();
       LastTime = std::max(LastTime, track->GetEndTime());

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1694,7 +1694,7 @@ void ProjectWindow::ZoomAfterImport(Track *pTrack)
    if (!pTrack)
       pTrack = *tracks.Selected().begin();
    if (!pTrack)
-      pTrack = *tracks.Leaders().begin();
+      pTrack = *tracks.begin();
    if (pTrack) {
       TrackFocus::Get(project).Set(pTrack);
       pTrack->EnsureVisible();

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -1044,7 +1044,7 @@ struct RealtimeEffectPanel::PrefsListenerHelper : PrefsListener
    void UpdatePrefs() override
    {
       auto& trackList = TrackList::Get(mProject);
-      for (auto waveTrack : trackList.Leaders<WaveTrack>())
+      for (auto waveTrack : trackList.Any<WaveTrack>())
          ReopenRealtimeEffectUIData(mProject, *waveTrack);
    }
 };
@@ -1192,7 +1192,7 @@ RealtimeEffectPanel::RealtimeEffectPanel(
          auto& trackList = TrackList::Get(mProject);
 
          // Realtime effect UI is only updated on Undo or Redo
-         auto waveTracks = trackList.Leaders<WaveTrack>();
+         auto waveTracks = trackList.Any<WaveTrack>();
          
          if (
             message.type == UndoRedoMessage::Type::UndoOrRedo ||

--- a/src/Screenshot.cpp
+++ b/src/Screenshot.cpp
@@ -768,7 +768,7 @@ void ScreenshotBigDialog::SizeTracks(int h)
    // each channel as high as for a stereo channel
 
    auto &tracks = TrackList::Get( mContext.project );
-   for (auto t : tracks.Leaders<WaveTrack>()) {
+   for (auto t : tracks.Any<WaveTrack>()) {
       auto channels = t->Channels();
       auto nChannels = channels.size();
       auto height = nChannels == 1 ? 2 * h : h;
@@ -780,7 +780,7 @@ void ScreenshotBigDialog::SizeTracks(int h)
 
 void ScreenshotBigDialog::OnShortTracks(wxCommandEvent & WXUNUSED(event))
 {
-   for (auto t : TrackList::Get(mContext.project).Leaders<WaveTrack>()) {
+   for (auto t : TrackList::Get(mContext.project).Any<WaveTrack>()) {
       for (auto pChannel : t->Channels()) {
          auto &view = ChannelView::Get(*pChannel);
          view.SetExpandedHeight(view.GetMinimizedHeight());

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -50,7 +50,7 @@ void DoSelectTimeAndAudioTracks(
       // Unselect all tracks before selecting audio.
       for (auto t : tracks)
          t->SetSelected(false);
-      for (auto t : tracks.Leaders<WaveTrack>())
+      for (auto t : tracks.Any<WaveTrack>())
          t->SetSelected(true);
       ProjectHistory::Get( project ).ModifyState(false);
    }

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -161,7 +161,7 @@ void DoSelectSomething(AudacityProject &project)
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
 
    bool bTime = selectedRegion.isPoint();
-   bool bTracks = tracks.SelectedLeaders().empty();
+   bool bTracks = tracks.Selected().empty();
 
    if (bTime || bTracks)
       DoSelectTimeAndTracks(project, bTime, bTracks);

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -48,7 +48,7 @@ void DoSelectTimeAndAudioTracks(
 
    if (bAllTracks) {
       // Unselect all tracks before selecting audio.
-      for (auto t : tracks.Leaders())
+      for (auto t : tracks)
          t->SetSelected(false);
       for (auto t : tracks.Leaders<WaveTrack>())
          t->SetSelected(true);
@@ -69,7 +69,7 @@ void DoSelectTimeAndTracks
       selectedRegion.setTimes(tracks.GetStartTime(), tracks.GetEndTime());
 
    if( bAllTracks ) {
-      for (auto t : tracks.Leaders())
+      for (auto t : tracks)
          t->SetSelected(true);
 
       ProjectHistory::Get( project ).ModifyState(false);
@@ -79,7 +79,7 @@ void DoSelectTimeAndTracks
 void SelectNone( AudacityProject &project )
 {
    auto &tracks = TrackList::Get( project );
-   for (auto t : tracks.Leaders())
+   for (auto t : tracks)
       t->SetSelected(false);
 
    auto &trackPanel = TrackPanel::Get( project );

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -125,7 +125,7 @@ void DoListSelection(
 
    auto isSyncLocked = SyncLockState::Get(project).IsSyncLocked();
    // Substitute the leader to satisfy precondition
-   auto pT = *tracks.FindLeader(&t);
+   auto pT = *tracks.Find(&t);
    if (!pT)
       return;
 

--- a/src/Snap.cpp
+++ b/src/Snap.cpp
@@ -45,7 +45,7 @@ namespace {
 SnapPointArray FindCandidates(
    SnapPointArray candidates, const TrackList &tracks )
 {
-   for (const auto track : tracks.Leaders())
+   for (const auto track : tracks)
       for (const auto &interval : track->Intervals()) {
          candidates.emplace_back(interval->Start(), track);
          if (interval->Start() != interval->End())

--- a/src/SpectralDataManager.cpp
+++ b/src/SpectralDataManager.cpp
@@ -58,7 +58,7 @@ bool SpectralDataManager::ProcessTracks(AudacityProject &project){
    int applyCount = 0;
    Setting setting;
    Worker worker(setting);
-   for (auto wt : tracks.Leaders<WaveTrack>()) {
+   for (auto wt : tracks.Any<WaveTrack>()) {
       using Type = long long;
       Type startSample{ std::numeric_limits<Type>::max() };
       Type endSample{ std::numeric_limits<Type>::min() };

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1010,7 +1010,7 @@ void TrackPanel::OnEnsureVisible(const TrackListEvent & e)
    assert(!t || t->IsLeader());
    int trackTop = 0;
    int trackHeight =0;
-   for (auto it : GetTracks()->Leaders()) {
+   for (auto it : *GetTracks()) {
       trackTop += trackHeight;
       trackHeight = ChannelView::GetChannelGroupHeight(it);
 
@@ -1625,7 +1625,7 @@ struct Subgroup final : TrackPanelGroup {
          refinement.emplace_back( yy, EmptyCell::Instance() ),
          yy += kTopMargin;
 
-      for (const auto leader : tracks.Leaders()) {
+      for (const auto leader : tracks) {
          wxCoord height = 0;
          for (auto pChannel : leader->Channels()) {
             auto &view = ChannelView::Get(*pChannel);

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -630,7 +630,7 @@ void TrackPanel::UpdateSelectionDisplay()
 // Counts selected tracks, counting stereo tracks as one track.
 size_t TrackPanel::GetSelectedTrackCount() const
 {
-   return GetTracks()->SelectedLeaders().size();
+   return GetTracks()->Selected().size();
 }
 
 void TrackPanel::UpdateViewIfNoTracks()

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -839,7 +839,7 @@ void TrackPanel::DrawTracks(wxDC * dc)
    brushFlag   = (ToolCodes::brushTool == settings.GetTool());
 #endif
 
-   const bool hasSolo = GetTracks()->Leaders<PlayableTrack>()
+   const bool hasSolo = GetTracks()->Any<PlayableTrack>()
       .any_of( [](const PlayableTrack *pt) {
          pt = static_cast<const PlayableTrack *>(
             pt->SubstitutePendingChangedTrack().get());
@@ -918,7 +918,7 @@ std::vector<int> FindAdjustedChannelHeights(Track &t)
 
 void TrackPanel::UpdateVRulers()
 {
-   for (auto t : GetTracks()->Leaders<WaveTrack>())
+   for (auto t : GetTracks()->Any<WaveTrack>())
       UpdateTrackVRuler(*t);
 
    UpdateVRulerSize();
@@ -974,7 +974,7 @@ void TrackPanel::UpdateTrackVRuler(Track &t)
 
 void TrackPanel::UpdateVRulerSize()
 {
-   auto trackRange = GetTracks()->Leaders();
+   auto trackRange = GetTracks()->Any();
    if (trackRange) {
       wxSize s{ 0, 0 };
       // Find maximum width over all channels
@@ -1050,7 +1050,7 @@ void TrackPanel::VerticalScroll( float fracPosition){
 
    auto tracks = GetTracks();
 
-   auto range = tracks->Leaders();
+   auto range = tracks->Any();
    if (!range.empty()) {
       trackHeight = ChannelView::GetChannelGroupHeight(*range.rbegin());
       --range.second;

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -747,7 +747,7 @@ void TrackPanel::RefreshTrack(Track *trk, bool refreshbacking)
 
    // Always move to the first channel of the group, and use only
    // the sum of channel heights, not the height of any channel alone!
-   trk = *GetTracks()->FindLeader(trk);
+   trk = *GetTracks()->Find(trk);
    auto height = ChannelView::GetChannelGroupHeight(trk);
 
    // Set rectangle top according to the scrolling position, `vpos`
@@ -1673,7 +1673,7 @@ std::shared_ptr<TrackPanelNode> TrackPanel::Root()
 // The given track is assumed to be the first channel
 wxRect TrackPanel::FindTrackRect( const Track * target )
 {
-   auto leader = *GetTracks()->FindLeader( target );
+   auto leader = *GetTracks()->Find( target );
    if (!leader) {
       return {};
    }

--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -108,7 +108,7 @@ std::shared_ptr<Track> TrackPanelAx::SetFocus( std::shared_ptr<Track> track )
 #endif
 
    if (!track)
-      track = Track::SharedPointer(*GetTracks().Leaders().begin());
+      track = Track::SharedPointer(*GetTracks().begin());
 
    if ( mFocusedTrack.lock() != track ) {
       mFocusedTrack = track;

--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -73,7 +73,7 @@ std::shared_ptr<Track> TrackPanelAx::GetFocus()
       }
       if (!focusedTrack) {
          focusedTrack =
-            Track::SharedPointer(*GetTracks().Leaders().first);
+            Track::SharedPointer(*GetTracks().Any().first);
          // only call SetFocus if the focus has changed to avoid
          // unnecessary focus events
          if (focusedTrack) 
@@ -248,7 +248,7 @@ wxAccStatus TrackPanelAx::GetChild( int childId, wxAccessible** child )
 // Gets the number of children.
 wxAccStatus TrackPanelAx::GetChildCount( int* childCount )
 {
-   *childCount = GetTracks().Leaders().size();
+   *childCount = GetTracks().Any().size();
    return wxACC_OK;
 }
 

--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -739,7 +739,7 @@ Track *TrackFocus::Get()
 void TrackFocus::Set( Track *pTrack )
 {
    if (mAx) {
-      pTrack = *TrackList::Get( mProject ).FindLeader( pTrack );
+      pTrack = *TrackList::Get( mProject ).Find( pTrack );
       mAx->SetFocus( Track::SharedPointer( pTrack ) );
    }
 }

--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -157,8 +157,7 @@ int TrackPanelAx::TrackNum( const std::shared_ptr<Track> &target )
    // found
    int ndx = 0;
 
-   for ( auto t : GetTracks().Leaders() )
-   {
+   for (auto t : GetTracks()) {
       ndx++;
       if( t == target.get() )
       {
@@ -173,8 +172,7 @@ std::shared_ptr<Track> TrackPanelAx::FindTrack( int num )
 {
    int ndx = 0;
 
-   for ( auto t : GetTracks().Leaders() )
-   {
+   for (auto t : GetTracks()) {
       ndx++;
       if( ndx == num )
          return t->SharedPointer();

--- a/src/TrackUtilities.cpp
+++ b/src/TrackUtilities.cpp
@@ -69,7 +69,7 @@ void DoTrackMute(AudacityProject &project, Track *t, bool exclusive)
 
    // "exclusive" mute means mute the chosen track and unmute all others.
    if (exclusive) {
-      for (auto leader : tracks.Leaders<PlayableTrack>()) {
+      for (auto leader : tracks.Any<PlayableTrack>()) {
          bool chosen = (t == leader);
          leader->SetMute(chosen);
          leader->SetSolo(false);
@@ -91,7 +91,7 @@ void DoTrackMute(AudacityProject &project, Track *t, bool exclusive)
          // in a group of more than one playable tracks.
          // otherwise clear solo on everything.
 
-         auto range = tracks.Leaders<PlayableTrack>();
+         auto range = tracks.Any<PlayableTrack>();
          auto nPlayableTracks = range.size();
          auto nPlaying = (range - &PlayableTrack::GetMute).size();
          for (auto track : range)
@@ -129,7 +129,7 @@ void DoTrackSolo(AudacityProject &project, Track *t, bool exclusive)
    else {
       // Normal click solo this track only, mute everything else.
       // OR unmute and unsolo everything.
-      for (auto leader : tracks.Leaders<PlayableTrack>()) {
+      for (auto leader : tracks.Any<PlayableTrack>()) {
          bool chosen = (t == leader);
          if (chosen) {
             leader->SetSolo(!bWasSolo);

--- a/src/TrackUtilities.cpp
+++ b/src/TrackUtilities.cpp
@@ -23,7 +23,7 @@ void DoRemoveTracks(AudacityProject &project)
    auto &tracks = TrackList::Get(project);
    auto &trackPanel = TrackPanel::Get(project);
 
-   auto range = tracks.SelectedLeaders();
+   auto range = tracks.Selected();
    using Iter = decltype(range.begin());
 
    // Capture the leader track preceding the first removed track

--- a/src/TrackUtilities.cpp
+++ b/src/TrackUtilities.cpp
@@ -40,7 +40,7 @@ void DoRemoveTracks(AudacityProject &project)
 
    if (!(focus.has_value() && **focus))
       // try to use the last leader track
-      focus.emplace(tracks.Leaders().end().advance(-1));
+      focus.emplace(tracks.end().advance(-1));
    assert(focus);
    Track *f = **focus;
    // Try to use the first track after the removal

--- a/src/TrackUtilities.cpp
+++ b/src/TrackUtilities.cpp
@@ -29,7 +29,7 @@ void DoRemoveTracks(AudacityProject &project)
    // Capture the leader track preceding the first removed track
    std::optional<Iter> focus;
    if (!range.empty()) {
-      auto iter = tracks.FindLeader(*range.begin());
+      auto iter = tracks.Find(*range.begin());
       // TrackIter allows decrement even of begin iterators
       focus.emplace(--iter);
    }
@@ -65,7 +65,7 @@ void DoTrackMute(AudacityProject &project, Track *t, bool exclusive)
    auto &tracks = TrackList::Get( project );
 
    // Whatever t is, replace with lead channel
-   t = *tracks.FindLeader(t);
+   t = *tracks.Find(t);
 
    // "exclusive" mute means mute the chosen track and unmute all others.
    if (exclusive) {
@@ -109,7 +109,7 @@ void DoTrackSolo(AudacityProject &project, Track *t, bool exclusive)
    auto &tracks = TrackList::Get( project );
    
    // Whatever t is, replace with lead channel
-   t = *tracks.FindLeader(t);
+   t = *tracks.Find(t);
 
    const auto pt = dynamic_cast<PlayableTrack *>( t );
    if (!pt)
@@ -157,7 +157,7 @@ void DoRemoveTrack(AudacityProject &project, Track *toRemove)
    auto &trackFocus = TrackFocus::Get(project);
    auto &window = ProjectWindow::Get(project);
 
-   const auto iter = tracks.FindLeader(toRemove);
+   const auto iter = tracks.Find(toRemove);
 
    // If it was focused, then NEW focus is the next or, if
    // unavailable, the previous track. (The NEW focus is set

--- a/src/TransportUtilities.cpp
+++ b/src/TransportUtilities.cpp
@@ -210,7 +210,7 @@ TransportSequences MakeTransportTracks(
 {
    TransportSequences result;
    {
-      const auto range = trackList.Leaders<WaveTrack>()
+      const auto range = trackList.Any<WaveTrack>()
          + (selectedOnly ? &Track::IsSelected : &Track::Any);
       for (auto pTrack : range)
          result.playbackSequences.push_back(
@@ -218,7 +218,7 @@ TransportSequences MakeTransportTracks(
    }
 #ifdef EXPERIMENTAL_MIDI_OUT
    if (nonWaveToo) {
-      const auto range = trackList.Leaders<const PlayableTrack>() +
+      const auto range = trackList.Any<const PlayableTrack>() +
          (selectedOnly ? &Track::IsSelected : &Track::Any);
       for (auto pTrack : range)
          if (!track_cast<const SampleTrack *>(pTrack))

--- a/src/cloud/ShareAudioToolbar.cpp
+++ b/src/cloud/ShareAudioToolbar.cpp
@@ -130,7 +130,7 @@ void ShareAudioToolbar::EnableDisableButtons()
 
    bool hasAudio = false;
 
-   for (const auto& track : TrackList::Get(mProject).Leaders<PlayableTrack>())
+   for (const auto& track : TrackList::Get(mProject).Any<PlayableTrack>())
    {
       if (track->GetStartTime() != track->GetEndTime())
       {

--- a/src/cloud/audiocom/ShareAudioDialog.cpp
+++ b/src/cloud/audiocom/ShareAudioDialog.cpp
@@ -304,7 +304,7 @@ namespace
 {
 int CalculateChannels(const TrackList& trackList)
 {
-   auto range = trackList.Leaders<const WaveTrack>();
+   auto range = trackList.Any<const WaveTrack>();
    return std::all_of(range.begin(), range.end(), [](const WaveTrack *track){
       return IsMono(*track) && track->GetPan() == 0;
    }) ? 1 : 2;

--- a/src/cloud/audiocom/ShareAudioDialog.cpp
+++ b/src/cloud/audiocom/ShareAudioDialog.cpp
@@ -304,7 +304,7 @@ namespace
 {
 int CalculateChannels(const TrackList& trackList)
 {
-   auto range = trackList.Any<const WaveTrack>();
+   auto range = trackList.Leaders<const WaveTrack>();
    return std::all_of(range.begin(), range.end(), [](const WaveTrack *track){
       return IsMono(*track) && track->GetPan() == 0;
    }) ? 1 : 2;

--- a/src/commands/CompareAudioCommand.cpp
+++ b/src/commands/CompareAudioCommand.cpp
@@ -86,7 +86,7 @@ bool CompareAudioCommand::GetSelection(const CommandContext &context, AudacityPr
 
    // Get the selected tracks and check that there are at least two to
    // compare
-   auto trackRange = TrackList::Get(proj).SelectedLeaders<const WaveTrack>();
+   auto trackRange = TrackList::Get(proj).Selected<const WaveTrack>();
    mTrack0 = *trackRange.first;
    if (!mTrack0) {
       context.Error(wxT("No tracks selected! Select two tracks to compare."));

--- a/src/commands/GetInfoCommand.cpp
+++ b/src/commands/GetInfoCommand.cpp
@@ -472,7 +472,7 @@ bool GetInfoCommand::SendTracks(const CommandContext & context)
 {
    auto &tracks = TrackList::Get( context.project );
    context.StartArray();
-   for (auto trk : tracks.Leaders())
+   for (auto trk : tracks)
    {
       auto &trackFocus = TrackFocus::Get( context.project );
       Track * fTrack = trackFocus.Get();
@@ -520,7 +520,7 @@ bool GetInfoCommand::SendClips(const CommandContext &context)
    auto &tracks = TrackList::Get( context.project );
    int i=0;
    context.StartArray();
-   for (auto t : tracks.Leaders()) {
+   for (auto t : tracks) {
       t->TypeSwitch([&](WaveTrack &waveTrack) {
          WaveClipPointers ptrs(waveTrack.SortedClipArray());
          for (WaveClip * pClip : ptrs) {
@@ -546,7 +546,7 @@ bool GetInfoCommand::SendEnvelopes(const CommandContext &context)
    int i=0;
    int j=0;
    context.StartArray();
-   for (auto t : tracks.Leaders()) {
+   for (auto t : tracks) {
       t->TypeSwitch([&](WaveTrack &waveTrack) {
          WaveClipPointers ptrs(waveTrack.SortedClipArray());
          j = 0;
@@ -587,7 +587,7 @@ bool GetInfoCommand::SendLabels(const CommandContext &context)
    auto &tracks = TrackList::Get( context.project );
    int i=0;
    context.StartArray();
-   for (auto t : tracks.Leaders()) {
+   for (auto t : tracks) {
       t->TypeSwitch( [&](LabelTrack &labelTrack) {
 #ifdef VERBOSE_LABELS_FORMATTING
          for (int nn = 0; nn< (int)labelTrack->mLabels.size(); nn++) {
@@ -709,7 +709,7 @@ void GetInfoCommand::ExploreTrackPanel( const CommandContext &context,
    AudacityProject * pProj = &context.project;
    auto &tp = TrackPanel::Get( *pProj );
    wxRect panelRect{ {}, tp.GetSize() };
-   for (auto leader : TrackList::Get(*pProj).Leaders()) {
+   for (auto leader : TrackList::Get(*pProj)) {
       for (auto t : leader->Channels()) {
          auto rulers = tp.FindRulerRects(*t);
          for (auto &R : rulers) {

--- a/src/commands/ScreenshotCommand.cpp
+++ b/src/commands/ScreenshotCommand.cpp
@@ -751,7 +751,7 @@ wxRect ScreenshotCommand::GetTrackRect( AudacityProject * pProj, TrackPanel * pa
    };
 
    int count = 0;
-   for (auto t : TrackList::Get( *pProj ).Leaders()) {
+   for (auto t : TrackList::Get( *pProj )) {
       count +=  1;
       if( count > n )
       {

--- a/src/commands/SelectCommand.cpp
+++ b/src/commands/SelectCommand.cpp
@@ -268,7 +268,7 @@ bool SelectTracksCommand::Apply(const CommandContext &context)
    double last = mFirstTrack + mNumTracks;
    double first = mFirstTrack;
 
-   for (auto t : tracks.Leaders()) {
+   for (auto t : tracks) {
       const bool sel = first <= index && index < last;
       if (mMode == 0) // Set
          t->SetSelected(sel);

--- a/src/commands/SetLabelCommand.cpp
+++ b/src/commands/SetLabelCommand.cpp
@@ -89,7 +89,7 @@ bool SetLabelCommand::Apply(const CommandContext & context)
    LabelTrack *labelTrack = nullptr;
    auto ii = mLabelIndex;
    if ( mLabelIndex >= 0 ) {
-      for (auto lt : tracks.Leaders<LabelTrack>()) {
+      for (auto lt : tracks.Any<LabelTrack>()) {
          const auto &labels = lt->GetLabels();
          const auto nLabels = labels.size();
          if( ii >= (int)nLabels )

--- a/src/commands/SetTrackInfoCommand.cpp
+++ b/src/commands/SetTrackInfoCommand.cpp
@@ -61,7 +61,7 @@ SetTrackAudioCommand and SetTrackVisualsCommand.
 bool SetTrackBase::Apply(const CommandContext & context)
 {
    auto &tracks = TrackList::Get(context.project);
-   for (auto t : tracks.Leaders()) {
+   for (auto t : tracks) {
       if (t->GetSelected())
          ApplyInner(context, *t);
    }
@@ -71,7 +71,7 @@ bool SetTrackBase::Apply(const CommandContext & context)
 bool SetChannelsBase::Apply(const CommandContext & context)
 {
    auto &tracks = TrackList::Get(context.project);
-   for (auto t : tracks.Leaders()) {
+   for (auto t : tracks) {
       if (t->GetSelected())
          for (Track *channel : TrackList::Channels(t))
             ApplyInner(context, channel);

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -182,7 +182,7 @@ OptionalMessage EffectAmplify::DoLoadFactoryDefaults(EffectSettings &settings)
 bool EffectAmplify::Init()
 {
    mPeak = 0.0;
-   for (auto t : inputTracks()->SelectedLeaders<const WaveTrack>()) {
+   for (auto t : inputTracks()->Selected<const WaveTrack>()) {
       for (const auto pChannel : TrackList::Channels(t)) {
          auto pair = pChannel->GetMinMax(mT0, mT1); // may throw
          const float min = pair.first, max = pair.second;

--- a/src/effects/AnalysisTracks.cpp
+++ b/src/effects/AnalysisTracks.cpp
@@ -65,7 +65,7 @@ ModifiedAnalysisTrack::ModifiedAnalysisTrack(
    // copy LabelTrack here, so it can be undone on cancel
    const auto startTime = origTrack.GetStartTime();
    auto list = origTrack.Copy(startTime, origTrack.GetEndTime());
-   auto newTrack = (*list->Leaders().begin())->SharedPointer();
+   auto newTrack = (*list->begin())->SharedPointer();
 
    mpTrack = static_cast<LabelTrack*>(newTrack.get());
 

--- a/src/effects/AnalysisTracks.cpp
+++ b/src/effects/AnalysisTracks.cpp
@@ -58,27 +58,27 @@ std::shared_ptr<AddedAnalysisTrack> AddAnalysisTrack(
       { safenew AddedAnalysisTrack{ &effect, name } };
 }
 
-ModifiedAnalysisTrack::ModifiedAnalysisTrack
-   (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name)
-   : mpEffect(pEffect)
+ModifiedAnalysisTrack::ModifiedAnalysisTrack(
+   Effect *pEffect, const LabelTrack &origTrack, const wxString &name
+)  : mpEffect(pEffect)
 {
    // copy LabelTrack here, so it can be undone on cancel
-   auto list =
-      pOrigTrack->Copy(pOrigTrack->GetStartTime(), pOrigTrack->GetEndTime());
+   const auto startTime = origTrack.GetStartTime();
+   auto list = origTrack.Copy(startTime, origTrack.GetEndTime());
    auto newTrack = (*list->Leaders().begin())->SharedPointer();
 
    mpTrack = static_cast<LabelTrack*>(newTrack.get());
 
    // Why doesn't LabelTrack::Copy complete the job? :
-   mpTrack->MoveTo(pOrigTrack->GetStartTime());
+   mpTrack->MoveTo(startTime);
    if (!name.empty())
       mpTrack->SetName(name);
 
    // mpOrigTrack came from mTracks which we own but expose as const to subclasses
    // So it's okay that we cast it back to const
    mpOrigTrack =
-      pEffect->mTracks->Replace(const_cast<LabelTrack*>(pOrigTrack),
-         newTrack);
+      pEffect->mTracks->ReplaceOne(const_cast<LabelTrack&>(origTrack),
+         std::move(*list));
 }
 
 ModifiedAnalysisTrack::ModifiedAnalysisTrack(ModifiedAnalysisTrack &&that)
@@ -96,16 +96,16 @@ void ModifiedAnalysisTrack::Commit()
 
 ModifiedAnalysisTrack::~ModifiedAnalysisTrack()
 {
-   if (mpEffect) {
+   if (mpEffect && mpTrack) {
       // not committed -- DELETE the label track
       // mpOrigTrack came from mTracks which we own but expose as const to subclasses
       // So it's okay that we cast it back to const
-      mpEffect->mTracks->Replace(mpTrack, mpOrigTrack);
+      mpEffect->mTracks->ReplaceOne(*mpTrack, std::move(*mpOrigTrack));
    }
 }
 
 ModifiedAnalysisTrack ModifyAnalysisTrack(
-   Effect &effect, const LabelTrack *pOrigTrack, const wxString &name)
+   Effect &effect, const LabelTrack &origTrack, const wxString &name)
 {
-   return{ &effect, pOrigTrack, name };
+   return{ &effect, origTrack, name };
 }

--- a/src/effects/AnalysisTracks.h
+++ b/src/effects/AnalysisTracks.h
@@ -19,6 +19,7 @@
 class Effect;
 class LabelTrack;
 class Track;
+class TrackList;
 
 // For the use of analyzers, which don't need to make output wave tracks,
 // but may need to add label tracks.
@@ -55,8 +56,8 @@ class AUDACITY_DLL_API ModifiedAnalysisTrack {
    ModifiedAnalysisTrack(const ModifiedAnalysisTrack&) = delete;
 
 public:
-   ModifiedAnalysisTrack
-      (Effect *pEffect, const LabelTrack *pOrigTrack, const wxString &name);
+   ModifiedAnalysisTrack(
+      Effect *pEffect, const LabelTrack &origTrack, const wxString &name);
    ModifiedAnalysisTrack();
 
    // So you can have a vector of them
@@ -73,11 +74,11 @@ public:
 private:
    Effect *mpEffect{};
    LabelTrack *mpTrack{};
-   std::shared_ptr<Track> mpOrigTrack{};
+   std::shared_ptr<TrackList> mpOrigTrack{};
 };
 
 // Set name to given value if that is not empty, else use default name
 ModifiedAnalysisTrack ModifyAnalysisTrack(Effect &effect,
-   const LabelTrack *pOrigTrack, const wxString &name = wxString());
+   const LabelTrack &origTrack, const wxString &name = wxString());
 
 #endif

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -305,7 +305,7 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
 
       int trackNum = 0;
 
-      for (auto iterTrack : outputs.Get().SelectedLeaders<WaveTrack>()) {
+      for (auto iterTrack : outputs.Get().Selected<WaveTrack>()) {
          for (const auto pChannel : TrackList::Channels(iterTrack))
             for (size_t i = 0; i < regions.size(); ++i) {
                const AutoDuckRegion& region = regions[i];

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -130,7 +130,7 @@ bool EffectAutoDuck::Init()
    // any selected track is not a wave track.
    bool lastWasSelectedWaveTrack = false;
    const WaveTrack *controlTrackCandidate = nullptr;
-   for (auto t : inputTracks()->Leaders()) {
+   for (auto t : *inputTracks()) {
       if (lastWasSelectedWaveTrack && !t->GetSelected())
          // This could be the control track, so remember it
          controlTrackCandidate = dynamic_cast<const WaveTrack *>(t);

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -421,7 +421,7 @@ void EffectChangePitch::DeduceFrequencies()
     auto FirstTrack = [&]()->const WaveTrack *{
       if( IsBatchProcessing() || !inputTracks() )
          return nullptr;
-      return *(inputTracks()->SelectedLeaders<const WaveTrack>()).first;
+      return *(inputTracks()->Selected<const WaveTrack>()).first;
    };
 
    m_dStartFrequency = 261.265;// Middle C.

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -270,7 +270,7 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
             }
 
             const double newLength =
-               (*newTracks->Leaders().begin())->GetEndTime();
+               (*newTracks->begin())->GetEndTime();
             const LinearTimeWarper warper{
                mCurT0, mCurT0, mCurT1, mCurT0 + newLength };
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -223,7 +223,7 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
 
    mFactor = 100.0 / (100.0 + m_PercentChange);
 
-   outputs.Get().Leaders().VisitWhile(bGoodResult,
+   outputs.Get().Any().VisitWhile(bGoodResult,
       [&](LabelTrack &lt) {
          if (SyncLock::IsSelectedOrSyncLockSelected(&lt)) {
             if (!ProcessLabelTrack(&lt))

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -118,7 +118,7 @@ bool EffectClickRemoval::Process(EffectInstance &, EffectSettings &)
    mbDidSomething = false;
 
    int count = 0;
-   for (auto track : outputs.Get().SelectedLeaders<WaveTrack>()) {
+   for (auto track : outputs.Get().Selected<WaveTrack>()) {
       double trackStart = track->GetStartTime();
       double trackEnd = track->GetEndTime();
       double t0 = std::max(mT0, trackStart);

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -350,7 +350,7 @@ bool EffectCompressor::InitPass1()
       DisableSecondPass();
 
    // Find the maximum block length required for any track
-   size_t maxlen = inputTracks()->SelectedLeaders<const WaveTrack>().max(
+   size_t maxlen = inputTracks()->Selected<const WaveTrack>().max(
       &WaveTrack::GetMaxBlockSize
    );
    mFollow1.reset();

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -60,7 +60,7 @@ bool ContrastDialog::GetDB(float &dB)
 
    auto p = FindProjectFromWindow( this );
    auto range =
-      TrackList::Get(*p).SelectedLeaders<const WaveTrack>();
+      TrackList::Get(*p).Selected<const WaveTrack>();
    auto numberSelectedTracks = range.size();
    if (numberSelectedTracks > 1) {
       AudacityMessageDialog m(
@@ -378,7 +378,7 @@ void ContrastDialog::OnGetForeground(wxCommandEvent & /*event*/)
    auto p = FindProjectFromWindow( this );
    auto &selectedRegion = ViewInfo::Get( *p ).selectedRegion;
 
-   if (TrackList::Get(*p).SelectedLeaders<const WaveTrack>()) {
+   if (TrackList::Get(*p).Selected<const WaveTrack>()) {
       mForegroundStartT->SetValue(selectedRegion.t0());
       mForegroundEndT->SetValue(selectedRegion.t1());
    }
@@ -394,7 +394,7 @@ void ContrastDialog::OnGetBackground(wxCommandEvent & /*event*/)
    auto p = FindProjectFromWindow( this );
    auto &selectedRegion = ViewInfo::Get( *p ).selectedRegion;
 
-   if (TrackList::Get(*p).SelectedLeaders<const WaveTrack>()) {
+   if (TrackList::Get(*p).Selected<const WaveTrack>()) {
       mBackgroundStartT->SetValue(selectedRegion.t0());
       mBackgroundEndT->SetValue(selectedRegion.t1());
    }

--- a/src/effects/EffectPreview.cpp
+++ b/src/effects/EffectPreview.cpp
@@ -121,7 +121,7 @@ void EffectPreview(EffectBase &effect,
    // Generators need to generate per track.
    if (isLinearEffect && !isGenerator) {
       auto newTracks = MixAndRender(
-         saveTracks->SelectedLeaders<const WaveTrack>(),
+         saveTracks->Selected<const WaveTrack>(),
          Mixer::WarpOptions{ saveTracks->GetOwner() },
          wxString{}, // Don't care about the name of the temporary tracks
          factory, rate, floatSample, mT0, t1);
@@ -134,7 +134,7 @@ void EffectPreview(EffectBase &effect,
       newTrack->SetSelected(true);
    }
    else {
-      for (auto src : saveTracks->SelectedLeaders<const WaveTrack>()) {
+      for (auto src : saveTracks->Selected<const WaveTrack>()) {
          auto dest = src->Copy(mT0, t1);
          (*dest->Leaders().begin())->SetSelected(true);
          mTracks->Append(std::move(*dest));

--- a/src/effects/EffectPreview.cpp
+++ b/src/effects/EffectPreview.cpp
@@ -136,7 +136,7 @@ void EffectPreview(EffectBase &effect,
    else {
       for (auto src : saveTracks->Selected<const WaveTrack>()) {
          auto dest = src->Copy(mT0, t1);
-         (*dest->Leaders().begin())->SetSelected(true);
+         (*dest->begin())->SetSelected(true);
          mTracks->Append(std::move(*dest));
       }
    }

--- a/src/effects/EffectPreview.cpp
+++ b/src/effects/EffectPreview.cpp
@@ -129,7 +129,7 @@ void EffectPreview(EffectBase &effect,
          return;
       mTracks->Append(std::move(*newTracks));
 
-      auto newTrack = *mTracks->Leaders<WaveTrack>().rbegin();
+      auto newTrack = *mTracks->Any<WaveTrack>().rbegin();
       newTrack->MoveTo(0);
       newTrack->SetSelected(true);
    }

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1198,7 +1198,7 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
 
    } );
 
-   const auto range = tracks.SelectedLeaders<const WaveTrack>();
+   const auto range = tracks.Selected<const WaveTrack>();
    bool anyTracks = !range.empty();
    bool clean = std::all_of(range.begin(), range.end(),
       [](const WaveTrack *t){ return t->GetEndTime() == 0; });
@@ -1327,7 +1327,7 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
       trackPanel.VerticalScroll( 1.0 );
    }
    else {
-      auto pTrack = *tracks.SelectedLeaders().begin();
+      auto pTrack = *tracks.Selected().begin();
       if (!pTrack)
          pTrack = *tracks.Leaders().begin();
       if (pTrack) {

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -1329,7 +1329,7 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
    else {
       auto pTrack = *tracks.Selected().begin();
       if (!pTrack)
-         pTrack = *tracks.Leaders().begin();
+         pTrack = *tracks.begin();
       if (pTrack) {
          TrackFocus::Get(project).Set(pTrack);
          pTrack->EnsureVisible();

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -324,7 +324,7 @@ bool EffectEqualization::Init()
 
    if (const auto project = FindProject()) {
       auto trackRange =
-         TrackList::Get(*project).SelectedLeaders<const WaveTrack>();
+         TrackList::Get(*project).Selected<const WaveTrack>();
       if (trackRange) {
          rate = (*(trackRange.first++)) -> GetRate();
          ++selcount;
@@ -408,7 +408,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
    bool bGoodResult = true;
 
    int count = 0;
-   for (auto track : outputs.Get().SelectedLeaders<WaveTrack>()) {
+   for (auto track : outputs.Get().Selected<WaveTrack>()) {
       double trackStart = track->GetStartTime();
       double trackEnd = track->GetEndTime();
       double t0 = mT0 < trackStart? trackStart: mT0;

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -115,7 +115,7 @@ EffectEqualization::EffectEqualization(int Options)
 #if 0
    auto trackList = inputTracks();
    const auto t = trackList
-      ? *trackList->Leaders<const WaveTrack>().first
+      ? *trackList->Any<const WaveTrack>().first
       : nullptr
    ;
    hiFreq =
@@ -426,7 +426,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
             temp->Add(pNewChannel);
             assert(pNewChannel->IsLeader() == pChannel->IsLeader());
          }
-         auto pTempTrack = *temp->Leaders<WaveTrack>().rbegin();
+         auto pTempTrack = *temp->Any<WaveTrack>().rbegin();
          pTempTrack->ConvertToSampleFormat(floatSample);
          auto iter0 = TrackList::Channels(pTempTrack).begin();
    
@@ -448,7 +448,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
                goto done;
          }
          PasteOverPreservingClips(data, *track, start, len,
-            **temp->Leaders<WaveTrack>().begin());
+            **temp->Any<WaveTrack>().begin());
       }
 
       count++;

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -93,7 +93,7 @@ bool EffectFindClipping::Process(EffectInstance &, EffectSettings &)
    if (!clt)
       addedTrack = (AddAnalysisTrack(*this, name)), lt = addedTrack->get();
    else
-      modifiedTrack.emplace(ModifyAnalysisTrack(*this, clt, name)),
+      modifiedTrack.emplace(ModifyAnalysisTrack(*this, *clt, name)),
       lt = modifiedTrack->get();
 
    int count = 0;

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -86,7 +86,7 @@ bool EffectFindClipping::Process(EffectInstance &, EffectSettings &)
    std::optional<ModifiedAnalysisTrack> modifiedTrack;
    const wxString name{ _("Clipping") };
 
-   auto clt = *inputTracks()->Leaders<const LabelTrack>().find_if(
+   auto clt = *inputTracks()->Any<const LabelTrack>().find_if(
       [&](const Track *track){ return track->GetName() == name; });
 
    LabelTrack *lt{};

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -99,7 +99,7 @@ bool EffectFindClipping::Process(EffectInstance &, EffectSettings &)
    int count = 0;
 
    // JC: Only process selected tracks.
-   for (auto t : inputTracks()->SelectedLeaders<const WaveTrack>()) {
+   for (auto t : inputTracks()->Selected<const WaveTrack>()) {
       double trackStart = t->GetStartTime();
       double trackEnd = t->GetEndTime();
       double t0 = std::max(trackStart, mT0);

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -61,18 +61,17 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
             auto list = TrackList::Create(nullptr);
             for (const auto pChannel : TrackList::Channels(&track)) {
                // Create a temporary track
-               auto tmp = track.EmptyCopy();
-               // Fill with data
-               if (!GenerateTrack(settings, &*tmp, track, ntrack))
-                  bGoodResult = false;
-               else {
-                  // Transfer the data from the temporary track to the actual one
-                  tmp->Flush();
-                  list->Add(tmp);
-                  assert(tmp->IsLeader() == pChannel->IsLeader());
-               }
+               auto tmp = pChannel->EmptyCopy();
+               list->Add(tmp);
+               assert(tmp->IsLeader() == pChannel->IsLeader());
             }
+            // Fill with data
+            if (!GenerateTrack(settings, *list))
+               bGoodResult = false;
             if (bGoodResult) {
+               for (const auto pChannel :
+                  TrackList::Channels(*list->Leaders<WaveTrack>().begin()))
+                  pChannel->Flush();
                PasteTimeWarper warper{ mT1, mT0 + duration };
                auto pProject = FindProject();
                const auto &selectedRegion =

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -4,10 +4,7 @@
 
   Generator.cpp
 
-  Two Abstract classes, Generator, and BlockGenerator, that effects which
-  generate audio should derive from.
-
-  Block Generator breaks the synthesis task up into smaller parts.
+  Effects that generate audio can derive from Generator.
 
   Dominic Mazzoni
   Vaughan Johnson
@@ -105,32 +102,5 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
       mT1 = mT0 + duration; // Update selection.
    }
 
-   return bGoodResult;
-}
-
-bool BlockGenerator::GenerateTrack(EffectSettings &settings,
-   WaveTrack *tmp, const WaveTrack &track, int ntrack)
-{
-   bool bGoodResult = true;
-   numSamples = track.TimeToLongSamples(settings.extra.GetDuration());
-   decltype(numSamples) i = 0;
-   Floats data{ tmp->GetMaxBlockSize() };
-
-   while ((i < numSamples) && bGoodResult) {
-      const auto block =
-         limitSampleBufferSize( tmp->GetBestBlockSize(i), numSamples - i );
-
-      GenerateBlock(data.get(), track, block);
-
-      // Add the generated data to the temporary track
-      tmp->Append((samplePtr)data.get(), floatSample, block);
-      i += block;
-
-      // Update the progress meter
-      if (TrackProgress(ntrack,
-                        i.as_double() /
-                        numSamples.as_double()))
-         bGoodResult = false;
-   }
    return bGoodResult;
 }

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -36,7 +36,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
    bool bGoodResult = true;
    int ntrack = 0;
 
-   outputs.Get().Leaders().VisitWhile(bGoodResult,
+   outputs.Get().Any().VisitWhile(bGoodResult,
       [&](auto &&fallthrough){ return [&](WaveTrack &track) {
          if (!track.GetSelected())
             return fallthrough();
@@ -70,7 +70,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
                bGoodResult = false;
             if (bGoodResult) {
                for (const auto pChannel :
-                  TrackList::Channels(*list->Leaders<WaveTrack>().begin()))
+                  TrackList::Channels(*list->Any<WaveTrack>().begin()))
                   pChannel->Flush();
                PasteTimeWarper warper{ mT1, mT0 + duration };
                auto pProject = FindProject();

--- a/src/effects/Generator.h
+++ b/src/effects/Generator.h
@@ -18,6 +18,8 @@
 #include "StatefulEffect.h"
 #include "SampleCount.h"
 
+class TrackList;
+
 // Base class for Generators (effects which fill a given duration)
 class Generator /* not final */ : public StatefulEffect
 {
@@ -25,11 +27,14 @@ public:
    Generator() { }
 
 protected:
-   // [ GenerateTrack() must be overridden by the actual generator class ]
-   // Precondition:  mDuration > 0.0
-   // Postcondition: <tmp> is filled with the data intended for <track>
-   virtual bool GenerateTrack(EffectSettings &settings,
-      WaveTrack *tmp, const WaveTrack &track, int ntrack) = 0;
+   //! GenerateTrack() must be overridden by the actual generator class
+   /*!
+    @pre `mDuration > 0.0`
+    @pre `tmp` contains exactly one channel group
+    @post `tmp` is filled with data
+    */
+   virtual bool GenerateTrack(const EffectSettings &settings, TrackList &tmp)
+      = 0;
 
    // Precondition:
    // mDuration is set to the amount of time to generate in seconds

--- a/src/effects/Generator.h
+++ b/src/effects/Generator.h
@@ -4,10 +4,7 @@
 
   Generator.h
 
-  Two Abstract classes, Generator, and BlockGenerator, that effects which
-  generate audio should derive from.
-
-  Block Generator breaks the synthesis task up into smaller parts.
+  Effects that generate audio can derive from Generator.
 
   Dominic Mazzoni
   Vaughan Johnson
@@ -40,25 +37,6 @@ protected:
    // If mDuration was valid (>= 0), then the tracks are replaced by the
    // generated results and true is returned. Otherwise, return false.
    AUDACITY_DLL_API bool Process(EffectInstance &instance, EffectSettings &settings) override;
-};
-
-// Abstract generator which creates the sound in discrete blocks, whilst
-// showing a progress bar
-class BlockGenerator /* not final */ : public Generator {
-public:
-   BlockGenerator() { }
-protected:
-   // Number of samples to generate
-   sampleCount numSamples;
-
-   // Postcondition: data[0..block) filled with generated samples
-   virtual void GenerateBlock(float *data,
-                              const WaveTrack &track,
-                              size_t block) = 0;
-
-   // Generate the track, one block at a time, & adding the results to tmp
-   bool GenerateTrack(EffectSettings &settings,
-      WaveTrack *tmp, const WaveTrack &track, int ntrack) override;
 };
 
 #endif

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -112,7 +112,7 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
    AllocBuffers(outputs.Get());
    mProgressVal = 0;
 
-   for (auto pTrack : outputs.Get().SelectedLeaders<WaveTrack>()) {
+   for (auto pTrack : outputs.Get().Selected<WaveTrack>()) {
       // Get start and end times from track
       double trackStart = pTrack->GetStartTime();
       double trackEnd = pTrack->GetEndTime();
@@ -355,7 +355,7 @@ void EffectLoudness::AllocBuffers(TrackList &outputs)
    double maxSampleRate = 0;
    mProcStereo = false;
 
-   for (auto track : outputs.SelectedLeaders<WaveTrack>() + &Track::Any) {
+   for (auto track : outputs.Selected<WaveTrack>() + &Track::Any) {
       mTrackBufferCapacity = std::max(mTrackBufferCapacity, track->GetMaxBlockSize());
       maxSampleRate = std::max(maxSampleRate, track->GetRate());
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -623,7 +623,7 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
 
    EffectOutputTracks outputs{ *mTracks };
 
-   auto track = *(outputs.Get().SelectedLeaders<const WaveTrack>()).begin();
+   auto track = *(outputs.Get().Selected<const WaveTrack>()).begin();
    if (!track)
       return false;
 
@@ -702,7 +702,7 @@ bool EffectNoiseReduction::Worker::Process(
    TrackList &tracks, double inT0, double inT1)
 {
    mProgressTrackCount = 0;
-   for (auto track : tracks.SelectedLeaders<WaveTrack>()) {
+   for (auto track : tracks.Selected<WaveTrack>()) {
       mProgressWindowCount = 0;
       if (track->GetRate() != mStatistics.mRate) {
          if (mDoProfile)

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -119,7 +119,7 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
    else if(!mDC && !mGain)
       topMsg = XO("Not doing anything...\n");   // shouldn't get here
 
-   for (auto track : outputs.Get().SelectedLeaders<WaveTrack>()) {
+   for (auto track : outputs.Get().Selected<WaveTrack>()) {
       // Get start and end times from track
       double trackStart = track->GetStartTime();
       double trackEnd = track->GetEndTime();

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -167,7 +167,7 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
             tempList->Add(outputTrack);
          }
          newT1 = std::max(newT1,
-            mT0 + (*tempList->Leaders().begin())->GetEndTime());
+            mT0 + (*tempList->begin())->GetEndTime());
          track->Clear(t0, t1);
          track->Paste(t0, *tempList);
       }

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -176,7 +176,7 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
    }
 
    // Sync lock adjustment of other tracks
-   outputs.Get().Leaders().Visit(
+   outputs.Get().Any().Visit(
       [&](auto &&fallthrough){ return [&](WaveTrack &track) {
          if (!track.IsSelected())
             fallthrough();

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -151,7 +151,7 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
    auto newT1 = mT1;
    int count = 0;
    // Process selected wave tracks first, to find the new t1 value
-   for (const auto track : outputs.Get().SelectedLeaders<WaveTrack>()) {
+   for (const auto track : outputs.Get().Selected<WaveTrack>()) {
       double trackStart = track->GetStartTime();
       double trackEnd = track->GetEndTime();
       double t0 = mT0 < trackStart ? trackStart : mT0;

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -81,7 +81,7 @@ bool EffectRepair::Process(EffectInstance &, EffectSettings &)
    bool bGoodResult = true;
 
    int count = 0;
-   for (auto track : outputs.Get().SelectedLeaders<WaveTrack>()) {
+   for (auto track : outputs.Get().Selected<WaveTrack>()) {
       const double trackStart = track->GetStartTime();
       const double repair_t0 = std::max(mT0, trackStart);
       const double trackEnd = track->GetEndTime();

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -99,7 +99,7 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
    bool bGoodResult = true;
    double maxDestLen = 0.0; // used to change selection to generated bit
 
-   outputs.Get().Leaders().VisitWhile(bGoodResult,
+   outputs.Get().Any().VisitWhile(bGoodResult,
       [&](LabelTrack &track) {
          if (SyncLock::IsSelectedOrSyncLockSelected(&track))
          {
@@ -120,7 +120,7 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
             return;
 
          auto tempList = track.Copy(mT0, mT1);
-         const auto firstTemp = *tempList->Leaders<const WaveTrack>().begin();
+         const auto firstTemp = *tempList->Any<const WaveTrack>().begin();
 
          std::vector<wxString> clipNames;
          for (auto clip : firstTemp->SortedClipArray()){

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -78,7 +78,7 @@ bool EffectReverse::Process(EffectInstance &, EffectSettings &)
    int count = 0;
 
    auto trackRange =
-      outputs.Get().Leaders() + &SyncLock::IsSelectedOrSyncLockSelected;
+      outputs.Get().Any() + &SyncLock::IsSelectedOrSyncLockSelected;
    trackRange.VisitWhile(bGoodResult,
       [&](WaveTrack &track) {
          const auto progress =

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -232,7 +232,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
    Slide pitchSlide(pitchSlideType,pitchStart,pitchEnd);
    mTotalStretch = rateSlide.getTotalStretch();
 
-   outputs.Get().Leaders().VisitWhile(bGoodResult,
+   outputs.Get().Any().VisitWhile(bGoodResult,
       [&](auto &&fallthrough){ return [&](LabelTrack &lt) {
          if (!(lt.GetSelected() || SyncLock::IsSyncLockSelected(&lt)))
             return fallthrough();

--- a/src/effects/ScienFilter.cpp
+++ b/src/effects/ScienFilter.cpp
@@ -225,7 +225,7 @@ bool EffectScienFilter::Init()
    int selcount = 0;
    double rate = 0.0;
 
-   auto trackRange = inputTracks()->SelectedLeaders<const WaveTrack>();
+   auto trackRange = inputTracks()->Selected<const WaveTrack>();
 
    {
       auto t = *trackRange.begin();

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -108,7 +108,7 @@ bool EffectSilence::TransferDataFromWindow(EffectSettings &settings)
 bool EffectSilence::GenerateTrack(
    const EffectSettings &settings, TrackList &tmp)
 {
-   (*tmp.Leaders<WaveTrack>().begin())
+   (*tmp.Any<WaveTrack>().begin())
       ->InsertSilence(0.0, settings.extra.GetDuration());
    return true;
 }

--- a/src/effects/Silence.cpp
+++ b/src/effects/Silence.cpp
@@ -105,9 +105,10 @@ bool EffectSilence::TransferDataFromWindow(EffectSettings &settings)
    return true;
 }
 
-bool EffectSilence::GenerateTrack(EffectSettings &settings,
-   WaveTrack *tmp, const WaveTrack &, int)
+bool EffectSilence::GenerateTrack(
+   const EffectSettings &settings, TrackList &tmp)
 {
-   tmp->InsertSilence(0.0, settings.extra.GetDuration());
+   (*tmp.Leaders<WaveTrack>().begin())
+      ->InsertSilence(0.0, settings.extra.GetDuration());
    return true;
 }

--- a/src/effects/Silence.h
+++ b/src/effects/Silence.h
@@ -46,8 +46,7 @@ public:
 protected:
    // Generator implementation
 
-   bool GenerateTrack(EffectSettings &settings,
-      WaveTrack *tmp, const WaveTrack &track, int ntrack) override;
+   bool GenerateTrack(const EffectSettings &settings, TrackList &tmp) override;
 
 private:
    NumericTextCtrl *mDurationT;

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -94,7 +94,7 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
    mCurTrackNum = 0;
    m_maxNewLength = 0.0;
 
-   outputs.Get().Leaders().VisitWhile(bGoodResult,
+   outputs.Get().Any().VisitWhile(bGoodResult,
       [&](auto &&fallthrough){ return [&](LabelTrack &lt) {
          if ( !(lt.GetSelected() ||
                 (mustSync && SyncLock::IsSyncLockSelected(&lt))) )

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -374,8 +374,6 @@ void EffectSoundTouch::Finalize(
    assert(orig.IsLeader());
    assert(out.IsLeader());
    assert(out.NChannels() == orig.NChannels());
-   auto outChannels = TrackList::Channels(&out);
-   auto origChannels = TrackList::Channels(&orig);
    if (mPreserveLength) {
       auto newLen = out.GetPlaySamplesCount();
       auto oldLen = out.TimeToLongSamples(mT1) - out.TimeToLongSamples(mT0);
@@ -384,8 +382,7 @@ void EffectSoundTouch::Finalize(
       if (newLen < oldLen) {
          const auto t = out.LongSamplesToTime(newLen - 1);
          const auto len = out.LongSamplesToTime(oldLen - newLen);
-         for (auto pChannel : outChannels)
-            pChannel->InsertSilence(t, len);
+         out.InsertSilence(t, len);
       }
       // Trim output track to original length since SoundTouch may add extra samples
       else if (newLen > oldLen) {

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -86,7 +86,7 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
    // only for progress dialog
    sampleCount totalTime = 0;
    
-   auto trackRange = outputs.Get().SelectedLeaders<WaveTrack>();
+   auto trackRange = outputs.Get().Selected<WaveTrack>();
    while (trackRange.first != trackRange.second)
    {
       auto left = *trackRange.first;
@@ -105,7 +105,7 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
 
    mProgress->SetMessage(XO("Mixing down to mono"));
 
-   trackRange = outputs.Get().SelectedLeaders<WaveTrack>();
+   trackRange = outputs.Get().Selected<WaveTrack>();
    while (trackRange.first != trackRange.second)
    {
       auto left = *trackRange.first;
@@ -127,7 +127,7 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
 
       if (refreshIter)
       {
-         trackRange = outputs.Get().SelectedLeaders<WaveTrack>();
+         trackRange = outputs.Get().Selected<WaveTrack>();
          refreshIter = false;
       }
       else

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -315,7 +315,7 @@ bool EffectTruncSilence::ProcessAll()
    if (FindSilences(silences,
       inputTracks()->Selected<const WaveTrack>())
    ) {
-      auto trackRange = outputs.Get().Leaders();
+      auto trackRange = outputs.Get().Any();
       double totalCutLen = 0.0;
       if (DoRemoval(silences, trackRange, 0, 1, totalCutLen)) {
          mT1 -= totalCutLen;

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -214,7 +214,7 @@ double EffectTruncSilence::CalcPreviewInputLength(
 
    int whichTrack = 0;
 
-   for (auto wt : inputTracks()->SelectedLeaders<const WaveTrack>()) {
+   for (auto wt : inputTracks()->Selected<const WaveTrack>()) {
       RegionList trackSilences;
 
       auto index = wt->TimeToLongSamples(mT0);
@@ -247,7 +247,7 @@ bool EffectTruncSilence::ProcessIndependently()
 
    // Check if it's permissible
    {
-      for (auto track : inputTracks()->SelectedLeaders<const WaveTrack>()) {
+      for (auto track : inputTracks()->Selected<const WaveTrack>()) {
          if (syncLock) {
             auto otherTracks =
                SyncLock::Group(track).Filter<const WaveTrack>()
@@ -277,7 +277,7 @@ bool EffectTruncSilence::ProcessIndependently()
 
    {
       unsigned iGroup = 0;
-      for (auto track : outputs.Get().SelectedLeaders<WaveTrack>()) {
+      for (auto track : outputs.Get().Selected<WaveTrack>()) {
          RegionList silences;
          if (!FindSilences(silences,
             TrackList::SingletonRange(&as_const(*track))))
@@ -313,7 +313,7 @@ bool EffectTruncSilence::ProcessAll()
    RegionList silences;
 
    if (FindSilences(silences,
-      inputTracks()->SelectedLeaders<const WaveTrack>())
+      inputTracks()->Selected<const WaveTrack>())
    ) {
       auto trackRange = outputs.Get().Leaders();
       double totalCutLen = 0.0;

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -31,9 +31,9 @@ bool EffectTwoPassSimpleMono::Process(
    EffectOutputTracks outputs{ *mTracks };
 
    mWorkTracks = TrackList::Create(const_cast<AudacityProject*>(FindProject()));
-   for (auto track : outputs.Get().Selected<WaveTrack>()) {
-      auto pNewTrack = track->EmptyCopy();
-      mWorkTracks->Add(pNewTrack);
+   for (auto track : outputs.Get().SelectedLeaders<WaveTrack>()) {
+      auto pNewTracks = track->WideEmptyCopy();
+      mWorkTracks->Append(std::move(*pNewTracks));
    }
    for (const auto pNewTrack : mWorkTracks->Leaders<WaveTrack>()) {
       pNewTrack->ConvertToSampleFormat(floatSample);

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -31,7 +31,7 @@ bool EffectTwoPassSimpleMono::Process(
    EffectOutputTracks outputs{ *mTracks };
 
    mWorkTracks = TrackList::Create(const_cast<AudacityProject*>(FindProject()));
-   for (auto track : outputs.Get().SelectedLeaders<WaveTrack>()) {
+   for (auto track : outputs.Get().Selected<WaveTrack>()) {
       auto pNewTracks = track->WideEmptyCopy();
       mWorkTracks->Append(std::move(*pNewTracks));
    }
@@ -66,8 +66,8 @@ bool EffectTwoPassSimpleMono::ProcessPass(EffectSettings &settings)
    mCurTrackNum = 0;
 
    auto outTracks =
-      (*mTrackLists[1 - mPass]).SelectedLeaders<WaveTrack>().begin();
-   for (auto track : (*mTrackLists[mPass]).SelectedLeaders<WaveTrack>()) {
+      (*mTrackLists[1 - mPass]).Selected<WaveTrack>().begin();
+   for (auto track : (*mTrackLists[mPass]).Selected<WaveTrack>()) {
       auto outTrack = *outTracks;
 
       // Get start and end times from track

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -30,15 +30,15 @@ bool EffectTwoPassSimpleMono::Process(
    InitPass1();
    EffectOutputTracks outputs{ *mTracks };
 
-   mWorkTracks = TrackList::Create(
-      const_cast<AudacityProject*>(FindProject()));
+   mWorkTracks = TrackList::Create(const_cast<AudacityProject*>(FindProject()));
    for (auto track : outputs.Get().Selected<WaveTrack>()) {
       auto pNewTrack = track->EmptyCopy();
       mWorkTracks->Add(pNewTrack);
-      if (pNewTrack->IsLeader())
-         pNewTrack->ConvertToSampleFormat(floatSample);
+   }
+   for (const auto pNewTrack : mWorkTracks->Leaders<WaveTrack>()) {
+      pNewTrack->ConvertToSampleFormat(floatSample);
       if (mT0 > 0)
-         (*mWorkTracks->rbegin())->InsertSilence(0, mT0);
+         pNewTrack->InsertSilence(0, mT0);
    }
 
    mTrackLists[0] = &outputs.Get();

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -35,7 +35,7 @@ bool EffectTwoPassSimpleMono::Process(
       auto pNewTracks = track->WideEmptyCopy();
       mWorkTracks->Append(std::move(*pNewTracks));
    }
-   for (const auto pNewTrack : mWorkTracks->Leaders<WaveTrack>()) {
+   for (const auto pNewTrack : mWorkTracks->Any<WaveTrack>()) {
       pNewTrack->ConvertToSampleFormat(floatSample);
       if (mT0 > 0)
          pNewTrack->InsertSilence(0, mT0);

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -814,7 +814,7 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
       wxString waveTrackList;   // track positions of selected audio tracks.
 
       {
-         auto countRange = TrackList::Get( *project ).Leaders();
+         auto countRange = TrackList::Get( *project ).Any();
          for (auto t : countRange) {
             t->TypeSwitch( [&](const WaveTrack &) {
                numWave++;
@@ -1585,7 +1585,7 @@ bool NyquistEffect::ProcessOne(EffectOutputTracks *pOutputs)
       mProjectChanged = true;
       unsigned int numLabels = nyx_get_num_labels();
       unsigned int l;
-      auto ltrack = *pOutputs->Get().Leaders<LabelTrack>().begin();
+      auto ltrack = *pOutputs->Get().Any<LabelTrack>().begin();
       if (!ltrack) {
          auto newTrack = std::make_shared<LabelTrack>();
          //new track name should be unique among the names in the list of input tracks, not output

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -592,7 +592,7 @@ bool NyquistEffect::Init()
          bool bAllowSpectralEditing = false;
          bool hasSpectral = false;
          for (auto t :
-            TrackList::Get( *project ).SelectedLeaders<const WaveTrack>()) {
+            TrackList::Get( *project ).Selected<const WaveTrack>()) {
             // Find() not Get() to avoid creation-on-demand of views in case we are
             // only previewing
             auto pView = WaveChannelView::Find(t);
@@ -733,7 +733,7 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
 
    mNumSelectedChannels = bOnePassTool
       ? 0
-      : oOutputs->Get().SelectedLeaders<const WaveTrack>()
+      : oOutputs->Get().Selected<const WaveTrack>()
          .sum(&WaveTrack::NChannels);
 
    mDebugOutput = {};
@@ -870,7 +870,7 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
 
    std::optional<TrackIterRange<WaveTrack>> pRange;
    if (!bOnePassTool)
-      pRange.emplace(oOutputs->Get().SelectedLeaders<WaveTrack>());
+      pRange.emplace(oOutputs->Get().Selected<WaveTrack>());
 
    // Keep track of whether the current track is first selected in its sync-lock group
    // (we have no idea what the length of the returned audio will be, so we have

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1677,7 +1677,7 @@ bool NyquistEffect::ProcessOne(EffectOutputTracks *pOutputs)
       const auto &out = outputTrack[0];
       if (outChannels < (int)mCurNumChannels)
          outputTrack[1] =
-            (*out->Duplicate()->Leaders().begin())->SharedPointer<WaveTrack>();
+            (*out->Duplicate()->begin())->SharedPointer<WaveTrack>();
       auto tempList =
          TrackList::Temporary(nullptr, outputTrack[0], outputTrack[1]);
       const bool bMergeClips = (mMergeClips < 0)

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -300,7 +300,7 @@ bool VampEffect::Init()
    if (inputTracks()->empty())
       mRate = mProjectRate;
    else
-      mRate = (*inputTracks()->Leaders<const WaveTrack>().begin())->GetRate();
+      mRate = (*inputTracks()->Any<const WaveTrack>().begin())->GetRate();
 
    // The plugin must be reloaded to allow changing parameters
 
@@ -339,7 +339,7 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
 
    std::vector<std::shared_ptr<AddedAnalysisTrack>> addedTracks;
 
-   for (auto leader : inputTracks()->Leaders<const WaveTrack>())
+   for (auto leader : inputTracks()->Any<const WaveTrack>())
    {
       auto channelGroup = TrackList::Channels(leader);
       auto left = *channelGroup.first++;

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -906,7 +906,7 @@ ExportResult ExportAudioDialog::DoExportSplitByTracks(const ExportPlugin& plugin
    
    /* Remember which tracks were selected, and set them to deselected */
    SelectionStateChanger changer{ selectionState, tracks };
-   for (auto tr : tracks.SelectedLeaders<WaveTrack>())
+   for (auto tr : tracks.Selected<WaveTrack>())
       tr->SetSelected(false);
 
    auto ok = ExportResult::Success;

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -896,7 +896,8 @@ ExportResult ExportAudioDialog::DoExportSplitByTracks(const ExportPlugin& plugin
 {
    auto& tracks = TrackList::Get(mProject);
    
-   bool anySolo = !(( tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
+   bool anySolo =
+      !((tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty());
    
    auto waveTracks = tracks.Leaders<WaveTrack>() -
       (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute);
@@ -905,7 +906,7 @@ ExportResult ExportAudioDialog::DoExportSplitByTracks(const ExportPlugin& plugin
    
    /* Remember which tracks were selected, and set them to deselected */
    SelectionStateChanger changer{ selectionState, tracks };
-   for (auto tr : tracks.Selected<WaveTrack>())
+   for (auto tr : tracks.SelectedLeaders<WaveTrack>())
       tr->SetSelected(false);
 
    auto ok = ExportResult::Success;

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -179,7 +179,7 @@ ExportAudioDialog::ExportAudioDialog(wxWindow* parent,
    mExportOptionsPanel->Init(filename, format, sampleRate);
 
    auto& tracks = TrackList::Get(mProject);
-   const auto labelTracks = tracks.Leaders<LabelTrack>();
+   const auto labelTracks = tracks.Any<LabelTrack>();
    const auto hasLabels = !labelTracks.empty() &&
       (*labelTracks.begin())->GetNumLabels() > 0;
 
@@ -556,7 +556,7 @@ void ExportAudioDialog::OnExport(wxCommandEvent &event)
          //all tracks regardless of their mute/solo state, but
          //muted channels should not be present in exported file - 
          //apply channel mask to exclude them
-         auto tracks = TrackList::Get(mProject).Leaders<WaveTrack>();
+         auto tracks = TrackList::Get(mProject).Any<WaveTrack>();
          std::vector<bool> channelMask(
             tracks.sum([](const auto track) { return track->NChannels(); }),
             false);
@@ -647,10 +647,10 @@ namespace {
 unsigned GetNumExportChannels( const TrackList &tracks )
 {
    bool anySolo =
-      !((tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty());
+      !((tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo).empty());
 
    // Want only unmuted wave tracks.
-   const auto range = tracks.Leaders<const WaveTrack>() -
+   const auto range = tracks.Any<const WaveTrack>() -
       (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute);
    return std::all_of(range.begin(), range.end(),
       [](auto *pTrack){ return IsMono(*pTrack); }
@@ -665,7 +665,7 @@ unsigned GetNumExportChannels( const TrackList &tracks )
 void ExportAudioDialog::UpdateLabelExportSettings(const ExportPlugin& plugin, int formatIndex, bool byName, bool addNumber, const wxString& prefix)
 {
    const auto& tracks = TrackList::Get(mProject);
-   const auto& labels = (*tracks.Leaders<const LabelTrack>().begin());
+   const auto& labels = (*tracks.Any<const LabelTrack>().begin());
    const auto numLabels = labels->GetNumLabels();
    
    auto numFiles = numLabels;
@@ -770,9 +770,9 @@ void ExportAudioDialog::UpdateTrackExportSettings(const ExportPlugin& plugin, in
 {
    auto& tracks = TrackList::Get(mProject);
    
-   bool anySolo = !(( tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
+   bool anySolo = !(( tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
    
-   auto waveTracks = tracks.Leaders<WaveTrack>() -
+   auto waveTracks = tracks.Any<WaveTrack>() -
       (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute);
    
    const auto numWaveTracks = waveTracks.size();
@@ -897,9 +897,9 @@ ExportResult ExportAudioDialog::DoExportSplitByTracks(const ExportPlugin& plugin
    auto& tracks = TrackList::Get(mProject);
    
    bool anySolo =
-      !((tracks.Leaders<const WaveTrack>() + &WaveTrack::GetSolo).empty());
+      !((tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo).empty());
    
-   auto waveTracks = tracks.Leaders<WaveTrack>() -
+   auto waveTracks = tracks.Any<WaveTrack>() -
       (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute);
 
    auto& selectionState = SelectionState::Get( mProject );

--- a/src/export/ExportFilePanel.cpp
+++ b/src/export/ExportFilePanel.cpp
@@ -422,7 +422,7 @@ void ExportFilePanel::OnChannelsConfigure(wxCommandEvent &event)
 {
    //Configure for all tracks, but some channels may turn out to be silent
    //if exported region does not contain audio samples
-   auto waveTracks = TrackList::Get(mProject).Leaders<const WaveTrack>();
+   auto waveTracks = TrackList::Get(mProject).Any<const WaveTrack>();
    
    auto mixerSpec = std::make_unique<MixerOptions::Downmix>(*mMixerSpec);
    
@@ -526,7 +526,7 @@ void ExportFilePanel::UpdateMaxChannels(unsigned maxChannels)
          MaxExportChannels);
       if(!mMixerSpec || mMixerSpec->GetMaxNumChannels() != mixerMaxChannels)
       {
-         auto waveTracks = TrackList::Get(mProject).Leaders<const WaveTrack>();
+         auto waveTracks = TrackList::Get(mProject).Any<const WaveTrack>();
          mMixerSpec = std::make_unique<MixerOptions::Downmix>(
             waveTracks.sum([](const auto track) { return track->NChannels(); }),
             mixerMaxChannels);

--- a/src/export/ExportMIDI.cpp
+++ b/src/export/ExportMIDI.cpp
@@ -47,7 +47,7 @@ void OnExportMIDI(const CommandContext &context)
 
    // Make sure that there is
    // exactly one NoteTrack selected.
-   const auto range = tracks.SelectedLeaders<const NoteTrack>();
+   const auto range = tracks.Selected<const NoteTrack>();
    const auto numNoteTracksSelected = range.size();
 
    if(numNoteTracksSelected > 1) {

--- a/src/export/ExportMIDI.cpp
+++ b/src/export/ExportMIDI.cpp
@@ -33,7 +33,7 @@ namespace {
 const ReservedCommandFlag&
    NoteTracksExistFlag() { static ReservedCommandFlag flag{
       [](const AudacityProject &project){
-         return !TrackList::Get(project).Leaders<const NoteTrack>().empty();
+         return !TrackList::Get(project).Any<const NoteTrack>().empty();
       }
    }; return flag; }  //gsw
 

--- a/src/import/ImportMIDI.cpp
+++ b/src/import/ImportMIDI.cpp
@@ -53,7 +53,7 @@ bool DoImportMIDI( AudacityProject &project, const FilePath &fileName )
       // In case the project had soloed tracks before importing,
       // the newly imported track is muted.
       const bool projectHasSolo =
-         !(tracks.Leaders<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
+         !(tracks.Any<PlayableTrack>() + &PlayableTrack::GetSolo).empty();
 #ifdef EXPERIMENTAL_MIDI_OUT
       if (projectHasSolo)
          pTrack->SetMute(true);

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -108,7 +108,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
 {
    outTracks.clear();
 
-   TrackHolders results;
+   std::vector<std::vector<WaveTrack::Holder>> results;
    auto updateResult = ProgressResult::Success;
 
    {
@@ -261,7 +261,8 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
    if (!results.empty() && !results[0].empty()) {
       for (const auto &channel : results[0])
          channel->Flush();
-      outTracks.swap(results);
+      for (auto &group : results)
+         outTracks.push_back(TrackList::Temporary(nullptr, group));
    }
 }
 

--- a/src/import/ImportRaw.h
+++ b/src/import/ImportRaw.h
@@ -14,18 +14,14 @@
 #include <memory>
 
 class AudacityProject;
+class TrackList;
 class WaveTrackFactory;
-class WaveTrack;
 class wxString;
 class wxWindow;
 
 #include <vector>
 
-// Newly constructed WaveTracks that are not yet owned by a TrackList
-// are held in unique_ptr not shared_ptr
-using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
-using TrackHolders = std::vector< NewChannelGroup >;
-
+using TrackHolders = std::vector<std::shared_ptr<TrackList>>;
 
 void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString &fileName,
    WaveTrackFactory *trackFactory, TrackHolders &outTracks);

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -216,7 +216,7 @@ int FindClipBoundaries
    auto &tracks = TrackList::Get( project );
    finalResults.clear();
 
-   bool anyWaveTracksSelected{ tracks.SelectedLeaders<const WaveTrack>() };
+   bool anyWaveTracksSelected{ tracks.Selected<const WaveTrack>() };
 
 
    // first search the tracks individually
@@ -445,7 +445,7 @@ int FindClips
    auto &tracks = TrackList::Get( project );
    finalResults.clear();
 
-   bool anyWaveTracksSelected{ tracks.SelectedLeaders<const WaveTrack>() };
+   bool anyWaveTracksSelected{ tracks.Selected<const WaveTrack>() };
 
    // first search the tracks individually
 

--- a/src/menus/ClipMenus.cpp
+++ b/src/menus/ClipMenus.cpp
@@ -224,7 +224,7 @@ int FindClipBoundaries
    std::vector<FoundClipBoundary> results;
 
    int nTracksSearched = 0;
-   auto leaders = tracks.Leaders();
+   auto leaders = tracks.Any();
    auto rangeLeaders = leaders.Filter<const WaveTrack>();
    if (anyWaveTracksSelected)
       rangeLeaders = rangeLeaders + &Track::GetSelected;
@@ -452,7 +452,7 @@ int FindClips
    std::vector<FoundClip> results;
 
    int nTracksSearched = 0;
-   auto leaders = tracks.Leaders();
+   auto leaders = tracks.Any();
    auto rangeLeaders = leaders.Filter<const WaveTrack>();
    if (anyWaveTracksSelected)
       rangeLeaders = rangeLeaders + &Track::GetSelected;

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -69,7 +69,7 @@ bool DoPasteText(AudacityProject &project)
 
    //Presumably, there might be not more than one track
    //that expects text input
-   for (auto wt : tracks.Any<WaveTrack>()) {
+   for (auto wt : tracks.Leaders<WaveTrack>()) {
       auto& view = WaveChannelView::Get(*wt);
       if (view.PasteText(project)) {
          auto &trackPanel = TrackPanel::Get(project);
@@ -272,7 +272,7 @@ void OnCut(const CommandContext &context)
 
    //Presumably, there might be not more than one track
    //that expects text input
-   for (auto wt : tracks.Any<WaveTrack>()) {
+   for (auto wt : tracks.Leaders<WaveTrack>()) {
       auto& view = WaveChannelView::Get(*wt);
       if (view.CutSelectedText(context.project)) {
          trackPanel.Refresh(false);
@@ -385,7 +385,7 @@ void OnCopy(const CommandContext &context)
    }
    //Presumably, there might be not more than one track
    //that expects text input
-   for (auto wt : tracks.Any<WaveTrack>()) {
+   for (auto wt : tracks.Leaders<WaveTrack>()) {
       auto& view = WaveChannelView::Get(*wt);
       if (view.CopySelectedText(context.project)) {
          return;

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -102,7 +102,7 @@ BlockArray::size_type EstimateCopiedBlocks(const TrackList& src, const TrackList
 
 std::shared_ptr<TrackList> DuplicateDiscardTrimmed(const TrackList& src) {
    auto result = TrackList::Create(nullptr);
-   for (auto track : src.Leaders()) {
+   for (auto track : src) {
       const auto copies =
          track->Copy(track->GetStartTime(), track->GetEndTime(), false);
       const auto pTrack = *copies->begin();
@@ -128,7 +128,7 @@ void DoPasteNothingSelected(AudacityProject &project, const TrackList& src, doub
    assert(tracks.Selected().empty());
 
    Track* pFirstNewTrack = NULL;
-   for (auto pClip : src.Leaders()) {
+   for (auto pClip : src) {
       auto pNewTrack = pClip->PasteInto(project, tracks);
       if (!pFirstNewTrack)
          pFirstNewTrack = pNewTrack.get();
@@ -326,7 +326,7 @@ void OnDelete(const CommandContext &context)
    auto &selectedRegion = ViewInfo::Get( project ).selectedRegion;
    auto &window = ProjectWindow::Get( project );
 
-   for (auto n : tracks.Leaders()) {
+   for (auto n : tracks) {
       if (!n->SupportsBasicEditing())
          continue;
       if (SyncLock::IsSelectedOrSyncLockSelected(n)) {

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -44,7 +44,7 @@ bool DoPasteText(AudacityProject &project)
    auto &window = ProjectWindow::Get( project );
 
    // Paste into the active label (if any)
-   for (auto pLabelTrack : tracks.Leaders<LabelTrack>()) {
+   for (auto pLabelTrack : tracks.Any<LabelTrack>()) {
       // Does this track have an active label?
       if (LabelTrackView::Get( *pLabelTrack ).GetTextEditIndex(project) != -1) {
 
@@ -69,7 +69,7 @@ bool DoPasteText(AudacityProject &project)
 
    //Presumably, there might be not more than one track
    //that expects text input
-   for (auto wt : tracks.Leaders<WaveTrack>()) {
+   for (auto wt : tracks.Any<WaveTrack>()) {
       auto& view = WaveChannelView::Get(*wt);
       if (view.PasteText(project)) {
          auto &trackPanel = TrackPanel::Get(project);
@@ -84,7 +84,7 @@ bool DoPasteText(AudacityProject &project)
 wxULongLong EstimateCopyBytesCount(const TrackList& src, const TrackList& dst)
 {
    wxULongLong result{};
-   for (auto waveTrack : src.Leaders<const WaveTrack>()) {
+   for (auto waveTrack : src.Any<const WaveTrack>()) {
       const auto samplesCount = waveTrack->GetSequenceSamplesCount();
       result += samplesCount.as_long_long() *
          SAMPLE_SIZE(waveTrack->GetSampleFormat());
@@ -95,7 +95,7 @@ wxULongLong EstimateCopyBytesCount(const TrackList& src, const TrackList& dst)
 BlockArray::size_type EstimateCopiedBlocks(const TrackList& src, const TrackList& dst)
 {
    BlockArray::size_type result{};
-   for (const auto waveTrack : src.Leaders<const WaveTrack>())
+   for (const auto waveTrack : src.Any<const WaveTrack>())
       result += waveTrack->CountBlocks();
    return result;
 }
@@ -157,7 +157,7 @@ void DoPasteNothingSelected(AudacityProject &project, const TrackList& src, doub
 
 bool HasHiddenData(const TrackList& trackList)
 {
-   const auto range = trackList.Leaders<const WaveTrack>();
+   const auto range = trackList.Any<const WaveTrack>();
    return std::any_of(range.begin(), range.end(),
       [](const WaveTrack *pTrack){ return pTrack->HasHiddenData(); });
 }
@@ -248,7 +248,7 @@ void OnCut(const CommandContext &context)
 
    //Presumably, there might be not more than one track
    //that expects text input
-   for (auto wt : tracks.Leaders<WaveTrack>()) {
+   for (auto wt : tracks.Any<WaveTrack>()) {
       auto& view = WaveChannelView::Get(*wt);
       if (view.CutSelectedText(context.project)) {
          trackPanel.Refresh(false);
@@ -289,7 +289,7 @@ void OnCut(const CommandContext &context)
    // Proceed to change the project.  If this throws, the project will be
    // rolled back by the top level handler.
 
-   (tracks.Leaders() + &SyncLock::IsSelectedOrSyncLockSelected).Visit(
+   (tracks.Any() + &SyncLock::IsSelectedOrSyncLockSelected).Visit(
 #if defined(USE_MIDI)
       [](NoteTrack&) {
          //if NoteTrack, it was cut, so do not clear anything
@@ -361,7 +361,7 @@ void OnCopy(const CommandContext &context)
    }
    //Presumably, there might be not more than one track
    //that expects text input
-   for (auto wt : tracks.Leaders<WaveTrack>()) {
+   for (auto wt : tracks.Any<WaveTrack>()) {
       auto& view = WaveChannelView::Get(*wt);
       if (view.CopySelectedText(context.project)) {
          return;
@@ -492,8 +492,8 @@ Correspondence FindCorrespondence(
    if (dstRange.size() == 1)
       // Special rule when only one track is selected interprets the user's
       // intent as pasting into that track and following ones
-      dstRange = dstTracks.Leaders().StartingWith(*dstRange.begin());
-   auto srcRange = srcTracks.Leaders();
+      dstRange = dstTracks.Any().StartingWith(*dstRange.begin());
+   auto srcRange = srcTracks.Any();
    while (!(dstRange.empty() || srcRange.empty())) {
       auto &dst = **dstRange.begin();
       auto &src = **srcRange.begin();
@@ -570,7 +570,7 @@ void OnPaste(const CommandContext &context)
 
    // Outer loop by sync-lock groups
    auto next = tracks.begin();
-   for (auto range = tracks.Leaders(); !range.empty();
+   for (auto range = tracks.Any(); !range.empty();
       // Skip to next sync lock group
      range.first = next
    ) {
@@ -979,7 +979,7 @@ void OnPasteOver(const CommandContext &context)
 const ReservedCommandFlag
 &CutCopyAvailableFlag() { static ReservedCommandFlag flag{
    [](const AudacityProject &project){
-      auto range = TrackList::Get(project).Leaders<const LabelTrack>()
+      auto range = TrackList::Get(project).Any<const LabelTrack>()
          + [&](const LabelTrack *pTrack){
             return LabelTrackView::Get( *pTrack ).IsTextSelected(
                // unhappy const_cast because track focus might be set

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -578,7 +578,7 @@ void OnPaste(const CommandContext &context)
          // Nothing more to paste
          break;
       auto group = SyncLock::Group(*range.first);
-      next = tracks.FindLeader(*group.rbegin());
+      next = tracks.Find(*group.rbegin());
       ++next;
 
       if (!group.contains(iPair->first))
@@ -774,7 +774,7 @@ void OnSplit(const CommandContext &context)
    auto &project = context.project;
    auto &tracks = TrackList::Get(project);
    auto [sel0, sel1] = FindSelection(context);
-   if (auto *pTrack = *tracks.FindLeader(context.temporarySelection.pTrack)) {
+   if (auto *pTrack = *tracks.Find(context.temporarySelection.pTrack)) {
       if (auto pWaveTrack = dynamic_cast<WaveTrack*>(pTrack))
          pWaveTrack->Split(sel0, sel1);
       else

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -105,7 +105,7 @@ std::shared_ptr<TrackList> DuplicateDiscardTrimmed(const TrackList& src) {
    for (auto track : src.Leaders()) {
       const auto copies =
          track->Copy(track->GetStartTime(), track->GetEndTime(), false);
-      const auto pTrack = *copies->Leaders().begin();
+      const auto pTrack = *copies->begin();
       pTrack->MoveTo(track->GetStartTime());
       if (const auto waveTrack = dynamic_cast<WaveTrack*>(pTrack))
          waveTrack->DiscardTrimmed();
@@ -188,7 +188,7 @@ void OnUndo(const CommandContext &context)
 
    auto t = *tracks.Selected().begin();
    if (!t)
-      t = *tracks.Leaders().begin();
+      t = *tracks.begin();
    TrackFocus::Get(project).Set(t);
    if (t) {
       t->EnsureVisible();
@@ -218,7 +218,7 @@ void OnRedo(const CommandContext &context)
 
    auto t = *tracks.Selected().begin();
    if (!t)
-      t = *tracks.Leaders().begin();
+      t = *tracks.begin();
    TrackFocus::Get(project).Set(t);
    if (t) {
       t->EnsureVisible();
@@ -569,7 +569,7 @@ void OnPaste(const CommandContext &context)
    const auto endPair = correspondence.cend();
 
    // Outer loop by sync-lock groups
-   auto next = tracks.Leaders().begin();
+   auto next = tracks.begin();
    for (auto range = tracks.Leaders(); !range.empty();
       // Skip to next sync lock group
      range.first = next
@@ -661,7 +661,7 @@ void OnDuplicate(const CommandContext &context)
 
       // Make copies not for clipboard but for direct addition to the project
       auto dest = n->Copy(selectedRegion.t0(), selectedRegion.t1(), false);
-      (*dest->Leaders().begin())
+      (*dest->begin())
          ->MoveTo(std::max(selectedRegion.t0(), n->GetStartTime()));
       tracks.Append(std::move(*dest));
 
@@ -859,7 +859,7 @@ void OnSplitNew(const CommandContext &context)
             if (dest) {
                // The copy function normally puts the clip at time 0
                // This offset lines it up with the original track's timing
-               (*dest->Leaders().begin())->MoveTo(newt0);
+               (*dest->begin())->MoveTo(newt0);
                tracks.Append(std::move(*dest));
             }
             wt.SplitDelete(newt0, newt1);

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -105,7 +105,7 @@ void DoExport(AudacityProject &project, const FileExtension &format)
       }
       fileName.Mkdir(0777, wxPATH_MKDIR_FULL); // make sure it exists
 
-      int nChannels = tracks.Leaders().max(&Track::NChannels);
+      int nChannels = tracks.Any().max(&Track::NChannels);
       auto [plugin, formatIndex] = ExportPluginRegistry::Get().FindFormat(format);
       if(plugin != nullptr)
       {
@@ -198,7 +198,7 @@ void OnOpen(const CommandContext &context )
    int unavailablePlugins = 0;
 
    auto &trackList = TrackList::Get(project);
-   for (auto track : trackList.Leaders<WaveTrack>())
+   for (auto track : trackList.Any<WaveTrack>())
    {
       auto& effects = RealtimeEffectList::Get(*track);
       effects.Visit([&unavailablePlugins](auto& state, bool)
@@ -302,7 +302,7 @@ void OnExportLabels(const CommandContext &context)
 
    /* i18n-hint: filename containing exported text from label tracks */
    wxString fName = _("labels.txt");
-   auto trackRange = tracks.Leaders<const LabelTrack>();
+   auto trackRange = tracks.Any<const LabelTrack>();
    auto numLabelTracks = trackRange.size();
 
    if (numLabelTracks == 0) {

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -185,7 +185,7 @@ void EditByLabel(AudacityProject &project,
    //Apply action on tracks starting from
    //labeled regions in the end. This is to correctly perform
    //actions like 'Delete' which collapse the track area.
-   for (auto t : tracks.Leaders()) {
+   for (auto t : tracks) {
       const bool playable = dynamic_cast<const PlayableTrack *>(t) != nullptr;
       if (SyncLock::IsSyncLockSelected(t) || (notLocked && playable)) {
          for (size_t i = regions.size(); i--;) {
@@ -230,7 +230,7 @@ void EditClipboardByLabel(AudacityProject &project,
    //labeled regions in the end. This is to correctly perform
    //actions like 'Cut' which collapse the track area.
 
-   for (auto t : tracks.Leaders()) {
+   for (auto t : tracks) {
       const bool playable = dynamic_cast<const PlayableTrack *>(t) != nullptr;
       if (SyncLock::IsSyncLockSelected(t) || (notLocked && playable)) {
          // These tracks accumulate the needed clips, right to left:

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -73,7 +73,7 @@ int DoAddLabel(
    const auto pFocusedTrack = trackFocus.Get();
 
    // Look for a label track at or after the focused track
-   auto begin = tracks.Leaders().begin();
+   auto begin = tracks.begin();
    auto iter = pFocusedTrack
       ? tracks.Find(pFocusedTrack)
       : begin;
@@ -241,7 +241,7 @@ void EditClipboardByLabel(AudacityProject &project,
                if (!merged)
                   merged = dest;
                else {
-                  const auto pMerged = *merged->Leaders().begin();
+                  const auto pMerged = *merged->begin();
                   // Paste to the beginning; unless this is the first region,
                   // offset the track to account for time between the regions
                   if (i + 1 < regions.size())
@@ -260,7 +260,7 @@ void EditClipboardByLabel(AudacityProject &project,
                // nothing copied but there is a 'region', so the 'region' must
                // be a 'point label' so offset
                if (i + 1 < regions.size() && merged)
-                  (*merged->Leaders().begin())
+                  (*merged->begin())
                      ->ShiftBy(regions.at(i + 1).start - region.end);
          }
          if (merged)

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -75,7 +75,7 @@ int DoAddLabel(
    // Look for a label track at or after the focused track
    auto begin = tracks.Leaders().begin();
    auto iter = pFocusedTrack
-      ? tracks.FindLeader(pFocusedTrack)
+      ? tracks.Find(pFocusedTrack)
       : begin;
    auto lt = * iter.Filter<LabelTrack>();
 

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -44,7 +44,7 @@ const ReservedCommandFlag
             }
          );
       };
-      auto range = TrackList::Get(project).SelectedLeaders<const LabelTrack>()
+      auto range = TrackList::Get(project).Selected<const LabelTrack>()
          + test;
       return !range.empty();
    }
@@ -126,7 +126,7 @@ void GetRegionsByLabel(
    Regions &regions )
 {
    //determine labeled regions
-   for (auto lt : tracks.SelectedLeaders< const LabelTrack >()) {
+   for (auto lt : tracks.Selected< const LabelTrack >()) {
       for (int i = 0; i < lt->GetNumLabels(); i++)
       {
          const LabelStruct *ls = lt->GetLabel(i);
@@ -180,7 +180,7 @@ void EditByLabel(AudacityProject &project,
       return;
 
    const bool notLocked = (!SyncLockState::Get(project).IsSyncLocked() &&
-                           (tracks.SelectedLeaders<PlayableTrack>()).empty());
+                           (tracks.Selected<PlayableTrack>()).empty());
 
    //Apply action on tracks starting from
    //labeled regions in the end. This is to correctly perform
@@ -218,7 +218,7 @@ void EditClipboardByLabel(AudacityProject &project,
       return;
 
    const bool notLocked = (!SyncLockState::Get(project).IsSyncLocked() &&
-                           (tracks.SelectedLeaders<PlayableTrack>()).empty());
+                           (tracks.Selected<PlayableTrack>()).empty());
 
    auto &clipboard = Clipboard::Get();
    clipboard.Clear();
@@ -319,12 +319,12 @@ void OnPasteNewLabel(const CommandContext &context)
    bool bPastedSomething = false;
 
    {
-      auto trackRange = tracks.SelectedLeaders<const LabelTrack>();
+      auto trackRange = tracks.Selected<const LabelTrack>();
       if (trackRange.empty())
       {
          // If there are no selected label tracks, try to choose the first label
          // track after some other selected track
-         Track *t = *tracks.SelectedLeaders().begin()
+         Track *t = *tracks.Selected().begin()
             .Filter(&Track::Any)
             .Filter<LabelTrack>();
 
@@ -338,7 +338,7 @@ void OnPasteNewLabel(const CommandContext &context)
    }
 
    LabelTrack *plt = NULL; // the previous track
-   for ( auto lt : tracks.SelectedLeaders<LabelTrack>() )
+   for ( auto lt : tracks.Selected<LabelTrack>() )
    {
       // Unselect the last label, so we'll have just one active label when
       // we're done

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -92,7 +92,7 @@ void DoPrevTrack(
    assert(t->IsLeader());
 
    if (shift) {
-      auto p = * -- tracks.FindLeader(t); // Get previous track
+      auto p = * -- tracks.Find(t); // Get previous track
       if (!p) {
          // On first track
          // JKC: wxBell() is probably for accessibility, so a blind
@@ -140,7 +140,7 @@ void DoPrevTrack(
       }
    }
    else {
-      auto p = * -- tracks.FindLeader(t); // Get previous track
+      auto p = * -- tracks.Find(t); // Get previous track
       if (!p) {
          // On first track so stay there?
          wxBell();
@@ -188,7 +188,7 @@ void DoNextTrack(
    assert(t->IsLeader());
 
    if (shift) {
-      auto n = * ++ tracks.FindLeader(t); // Get next track
+      auto n = * ++ tracks.Find(t); // Get next track
       if (!n) {
          // On last track so stay there
          wxBell();
@@ -234,7 +234,7 @@ void DoNextTrack(
       }
    }
    else {
-      auto n = * ++ tracks.FindLeader(t); // Get next track
+      auto n = * ++ tracks.Find(t); // Get next track
       if (!n) {
          // On last track so stay there
          wxBell();

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -83,7 +83,7 @@ void DoPrevTrack(
    const auto t = trackFocus.Get();
    if (!t) {
       // if there isn't one, focus on last
-      const auto last = *tracks.Leaders().rbegin();
+      const auto last = *tracks.rbegin();
       trackFocus.Set(last);
       if (last)
          last->EnsureVisible(true);
@@ -99,7 +99,7 @@ void DoPrevTrack(
          // user knows they were at the top track.
          wxBell();
          if (circularTrackNavigation)
-            p = *tracks.Leaders().rbegin();
+            p = *tracks.rbegin();
          else {
             t->EnsureVisible();
             return;
@@ -179,7 +179,7 @@ void DoNextTrack(
    const auto t = trackFocus.Get();
    if  (!t) {
       // if there isn't one, focus on first
-      const auto first = *tracks.Leaders().begin();
+      const auto first = *tracks.begin();
       trackFocus.Set(first);
       if (first)
          first->EnsureVisible(true);
@@ -193,7 +193,7 @@ void DoNextTrack(
          // On last track so stay there
          wxBell();
          if (circularTrackNavigation)
-            n = *tracks.Leaders().begin();
+            n = *tracks.begin();
          else {
             t->EnsureVisible();
             return;
@@ -239,7 +239,7 @@ void DoNextTrack(
          // On last track so stay there
          wxBell();
          if (circularTrackNavigation) {
-            n = *tracks.Leaders().begin();
+            n = *tracks.begin();
             trackFocus.Set(n);   // Wrap to the first track
             if (n)
                n->EnsureVisible( true );
@@ -433,7 +433,7 @@ void OnFirstTrack(const CommandContext &context)
    if (!t)
       return;
 
-   auto f = *tracks.Leaders().begin();
+   auto f = *tracks.begin();
    if (t != f)
       trackFocus.Set(f);
    if (f)
@@ -451,7 +451,7 @@ void OnLastTrack(const CommandContext &context)
    if (!t)
       return;
 
-   auto l = *tracks.Leaders().rbegin();
+   auto l = *tracks.rbegin();
    if (t != l)
       trackFocus.Set(l);
    if (l)

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -145,7 +145,7 @@ void DoPrevTrack(
          // On first track so stay there?
          wxBell();
          if (circularTrackNavigation) {
-            auto range = tracks.Leaders();
+            auto range = tracks.Any();
             p = * range.rbegin(); // null if range is empty
             trackFocus.Set(p);   // Wrap to the last track
             if (p)

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -436,7 +436,7 @@ void OnSelectAll(const CommandContext &context)
 
    //Presumably, there might be not more than one track
    //that expects text input
-   for (auto wt : tracks.Leaders<WaveTrack>()) {
+   for (auto wt : tracks.Any<WaveTrack>()) {
       auto& view = WaveChannelView::Get(*wt);
       if (view.SelectAllText(context.project)) {
          trackPanel.Refresh(false);
@@ -469,7 +469,7 @@ void OnSelectSyncLockSel(const CommandContext &context)
    auto &tracks = TrackList::Get( project );
 
    bool selected = false;
-   for (auto t : tracks.Leaders() + &Track::SupportsBasicEditing
+   for (auto t : tracks.Any() + &Track::SupportsBasicEditing
          + &SyncLock::IsSyncLockSelected - &Track::IsSelected) {
       t->SetSelected(true);
       selected = true;

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -37,7 +37,7 @@ double NearestZeroCrossing(AudacityProject &project, double t0)
    Floats dist{ windowSize, true };
 
    int nTracks = 0;
-   for (auto one : tracks.SelectedLeaders<const WaveTrack>()) {
+   for (auto one : tracks.Selected<const WaveTrack>()) {
       const auto nChannels = one->NChannels();
       auto oneWindowSize = size_t(std::max(1.0, one->GetRate() / 100));
       Floats buffer1{ oneWindowSize };
@@ -426,7 +426,7 @@ void OnSelectAll(const CommandContext &context)
    auto& trackPanel = TrackPanel::Get(context.project);
    auto& tracks = TrackList::Get(context.project);
 
-   for (auto lt : tracks.SelectedLeaders<LabelTrack>()) {
+   for (auto lt : tracks.Selected<LabelTrack>()) {
       auto& view = LabelTrackView::Get(*lt);
       if (view.SelectAllText(context.project)) {
          trackPanel.Refresh(false);
@@ -499,7 +499,7 @@ void OnSelectStartCursor(const CommandContext &context)
 
    double kWayOverToRight = std::numeric_limits<double>::max();
 
-   auto range = tracks.SelectedLeaders();
+   auto range = tracks.Selected();
    if (!range)
       return;
 
@@ -521,7 +521,7 @@ void OnSelectCursorEnd(const CommandContext &context)
 
    double kWayOverToLeft = std::numeric_limits<double>::lowest();
 
-   auto range = tracks.SelectedLeaders();
+   auto range = tracks.Selected();
    if (!range)
       return;
 
@@ -541,7 +541,7 @@ void OnSelectTrackStartToEnd(const CommandContext &context)
    auto &viewInfo = ViewInfo::Get(project);
    auto &tracks = TrackList::Get(project);
 
-   auto range = tracks.SelectedLeaders();
+   auto range = tracks.Selected();
    double maxEndOffset = range.max(&Track::GetEndTime);
    double minOffset = range.min(&Track::GetStartTime);
 
@@ -738,7 +738,7 @@ void OnCursorTrackStart(const CommandContext &context)
 
    double kWayOverToRight = std::numeric_limits<double>::max();
 
-   auto trackRange = tracks.SelectedLeaders() + &Track::SupportsBasicEditing;
+   auto trackRange = tracks.Selected() + &Track::SupportsBasicEditing;
    if (trackRange.empty())
       // This should have been prevented by command manager
       return;
@@ -764,7 +764,7 @@ void OnCursorTrackEnd(const CommandContext &context)
 
    double kWayOverToLeft = std::numeric_limits<double>::lowest();
 
-   auto trackRange = tracks.SelectedLeaders() + &Track::SupportsBasicEditing;
+   auto trackRange = tracks.Selected() + &Track::SupportsBasicEditing;
    if (trackRange.empty())
       // This should have been prevented by command manager
       return;

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -436,7 +436,7 @@ void OnSelectAll(const CommandContext &context)
 
    //Presumably, there might be not more than one track
    //that expects text input
-   for (auto wt : tracks.Any<WaveTrack>()) {
+   for (auto wt : tracks.Leaders<WaveTrack>()) {
       auto& view = WaveChannelView::Get(*wt);
       if (view.SelectAllText(context.project)) {
          trackPanel.Refresh(false);

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -65,7 +65,7 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
 
       // But before removing, determine the first track after the removal
       auto last = *trackRange.rbegin();
-      auto insertionPoint = * ++ tracks.FindLeader(last);
+      auto insertionPoint = * ++ tracks.Find(last);
       
       auto selectedCount = trackRange.size();
       wxString firstName;

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -54,7 +54,7 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
    auto &trackPanel = TrackPanel::Get(project);
    auto &window = ProjectWindow::Get(project);
 
-   auto trackRange = tracks.SelectedLeaders<WaveTrack>();
+   auto trackRange = tracks.Selected<WaveTrack>();
    auto newTracks = ::MixAndRender(trackRange.Filter<const WaveTrack>(),
       Mixer::WarpOptions{ tracks.GetOwner() },
       tracks.MakeUniqueTrackName(_("Mix")),
@@ -190,7 +190,7 @@ void DoAlign(AudacityProject &project, int index, bool moveSel)
    double delta = 0.0;
    double newPos = -1.0;
 
-   auto trackRange = tracks.SelectedLeaders<AudioTrack>();
+   auto trackRange = tracks.Selected<AudioTrack>();
 
    auto FindOffset =
       [](const Track *pTrack) { return pTrack->GetStartTime(); };
@@ -283,7 +283,7 @@ void DoAlign(AudacityProject &project, int index, bool moveSel)
 
    if ((unsigned)index >= kAlignLabelsCount()) {
       // This is an alignLabelsNoSync command.
-      for (auto t : tracks.SelectedLeaders<AudioTrack>()) {
+      for (auto t : tracks.Selected<AudioTrack>()) {
          // This shifts different tracks in different ways, so no sync-lock
          // move.
          // Only align Wave and Note tracks end to end.
@@ -657,7 +657,7 @@ void OnResample(const CommandContext &context)
 
    int ndx = 0;
    auto flags = UndoPush::NONE;
-   for (auto wt : tracks.SelectedLeaders<WaveTrack>()) {
+   for (auto wt : tracks.Selected<WaveTrack>()) {
       auto msg = XO("Resampling track %d").Format(++ndx);
 
       using namespace BasicUI;
@@ -701,7 +701,7 @@ static void MuteTracks(const CommandContext &context, bool mute, bool selected)
    const auto soloSimple = (solo == SoloBehaviorSimple);
    const auto soloNone = (solo == SoloBehaviorNone);
 
-   auto iter = selected ? tracks.SelectedLeaders<PlayableTrack>() : tracks.Leaders<PlayableTrack>();
+   auto iter = selected ? tracks.Selected<PlayableTrack>() : tracks.Leaders<PlayableTrack>();
    for (auto pt : iter) {
       pt->SetMute(mute);
       if (soloSimple || soloNone)
@@ -797,7 +797,7 @@ void OnScoreAlign(const CommandContext &context)
 
    // Iterate through once to make sure that there is exactly
    // one WaveTrack and one NoteTrack selected.
-   tracks.SelectedLeaders().Visit(
+   tracks.Selected().Visit(
       [&](WaveTrack *wt) {
          numWaveTracksSelected++;
          endTime = endTime > wt->GetEndTime() ? endTime : wt->GetEndTime();

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -84,7 +84,7 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
       // Add new tracks
       const bool stereo = newTracks->NChannels() > 1;
       tracks.Append(std::move(*newTracks));
-      const auto pNewTrack = *tracks.Leaders<WaveTrack>().rbegin();
+      const auto pNewTrack = *tracks.Any<WaveTrack>().rbegin();
 
       // If we're just rendering (not mixing), keep the track name the same
       if (selectedCount == 1)
@@ -143,7 +143,7 @@ void DoPanTracks(AudacityProject &project, float PanValue)
    auto &window = ProjectWindow::Get( project );
 
    // count selected wave tracks
-   const auto range = tracks.Leaders< WaveTrack >();
+   const auto range = tracks.Any< WaveTrack >();
    const auto selectedRange = range + &Track::IsSelected;
    auto count = selectedRange.size();
 
@@ -297,7 +297,7 @@ void DoAlign(AudacityProject &project, int index, bool moveSel)
 
    if (delta != 0.0) {
       // For a fixed-distance shift move sync-lock selected tracks also.
-      for (auto t : tracks.Leaders()
+      for (auto t : tracks.Any()
            + &SyncLock::IsSelectedOrSyncLockSelected )
          t->MoveTo(t->GetStartTime() + delta);
    }
@@ -701,7 +701,7 @@ static void MuteTracks(const CommandContext &context, bool mute, bool selected)
    const auto soloSimple = (solo == SoloBehaviorSimple);
    const auto soloNone = (solo == SoloBehaviorNone);
 
-   auto iter = selected ? tracks.Selected<PlayableTrack>() : tracks.Leaders<PlayableTrack>();
+   auto iter = selected ? tracks.Selected<PlayableTrack>() : tracks.Any<PlayableTrack>();
    for (auto pt : iter) {
       pt->SetMute(mute);
       if (soloSimple || soloNone)

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -103,7 +103,7 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
          std::vector<Track *> arr;
          arr.reserve(tracks.Size());
          size_t iBegin = 0, ii = 0;
-         for (const auto pTrack : tracks.Leaders()) {
+         for (const auto pTrack : tracks) {
             arr.push_back(pTrack);
             if (pTrack == insertionPoint)
                iBegin = ii;
@@ -499,7 +499,7 @@ void DoSortTracks( AudacityProject &project, int flags )
    arr.reserve(tracks.Size());
 
    // First find the permutation.
-   for (const auto pTrack : tracks.Leaders()) {
+   for (const auto pTrack : tracks) {
       auto &track = *pTrack;
       const auto size = arr.size();
       size_t ndx = 0;

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -88,7 +88,7 @@ void DoMoveToLabel(AudacityProject &project, bool next)
    else if (nLabelTrack > 1) {
       // find first label track, if any, starting at the focused track
       lt =
-         *tracks.FindLeader(trackFocus.Get()).Filter<LabelTrack>();
+         *tracks.Find(trackFocus.Get()).Filter<LabelTrack>();
       if (!lt)
          trackFocus.MessageForScreenReader(
             XO("no label track at or below focused track"));

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -78,7 +78,7 @@ void DoMoveToLabel(AudacityProject &project, bool next)
    auto &projectAudioManager = ProjectAudioManager::Get(project);
 
    // Find the number of label tracks, and ptr to last track found
-   auto trackRange = tracks.Leaders<LabelTrack>();
+   auto trackRange = tracks.Any<LabelTrack>();
    auto lt = *trackRange.rbegin();
    auto nLabelTrack = trackRange.size();
 

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -127,7 +127,7 @@ void DoZoomFitV(AudacityProject &project)
 
    // Only nonminimized audio tracks will be resized
    // Assume all channels of the track have the same minimization state
-   auto range = tracks.Leaders<AudioTrack>()
+   auto range = tracks.Any<AudioTrack>()
       - [](const Track *pTrack){
          return ChannelView::Get(*pTrack->GetChannel(0)).GetMinimized(); };
    auto count = range.sum(&Track::NChannels);
@@ -140,7 +140,7 @@ void DoZoomFitV(AudacityProject &project)
    
    // The height of minimized and non-audio tracks cannot be apportioned
    height -=
-      tracks.Leaders().sum(ChannelView::GetChannelGroupHeight)
+      tracks.Any().sum(ChannelView::GetChannelGroupHeight)
          - range.sum(ChannelView::GetChannelGroupHeight);
    
    // Give each resized track the average of the remaining height

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -263,7 +263,7 @@ void OnCollapseAllTracks(const CommandContext &context)
    auto &tracks = TrackList::Get( project );
    auto &window = ProjectWindow::Get( project );
 
-   for (auto t : tracks.Leaders())
+   for (auto t : tracks)
       for (auto pChannel : t->Channels())
          ChannelView::Get(*pChannel).SetMinimized(true);
 
@@ -276,7 +276,7 @@ void OnExpandAllTracks(const CommandContext &context)
    auto &tracks = TrackList::Get( project );
    auto &window = ProjectWindow::Get( project );
 
-   for (auto t : tracks.Leaders())
+   for (auto t : tracks)
       for (auto pChannel : t->Channels())
          ChannelView::Get(*pChannel).SetMinimized(false);
 

--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -449,7 +449,7 @@ void ControlToolBar::EnableDisableButtons()
    bool busy = gAudioIO->IsBusy();
 
    // Only interested in audio type tracks
-   bool tracks = p && TrackList::Get(*p).Leaders<AudioTrack>(); // PRL:  PlayableTrack ?
+   bool tracks = p && TrackList::Get(*p).Any<AudioTrack>(); // PRL:  PlayableTrack ?
 
    mPlay->SetEnabled( canStop && tracks && !recording );
    mRecord->SetEnabled(

--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -323,7 +323,7 @@ void TranscriptionToolBar::EnableDisableButtons()
    bool recording = gAudioIO->GetNumCaptureChannels() > 0;
 
    // Only interested in audio type tracks
-   bool tracks = p && TrackList::Get(*p).Leaders<AudioTrack>(); // PRL:  PlayableTrack ?
+   bool tracks = p && TrackList::Get(*p).Any<AudioTrack>(); // PRL:  PlayableTrack ?
    SetEnabled(canStopAudioStream && tracks && !recording);
 
 #ifdef EXPERIMENTAL_VOICE_DETECTION
@@ -506,7 +506,7 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
    // VariSpeed play reuses Scrubbing.
    bool bFixedSpeedPlay = !gPrefs->ReadBool(wxT("/AudioIO/VariSpeedPlay"), true);
    // Scrubbing doesn't support note tracks, but the fixed-speed method using time tracks does.
-   if (TrackList::Get(*p).Leaders<NoteTrack>())
+   if (TrackList::Get(*p).Any<NoteTrack>())
       bFixedSpeedPlay = true;
 
    // If cutPreview, we have to fall back to fixed speed.

--- a/src/tracks/labeltrack/ui/LabelDefaultClickHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelDefaultClickHandle.cpp
@@ -38,7 +38,7 @@ void LabelDefaultClickHandle::SaveState( AudacityProject *pProject )
    auto &pairs = mLabelState->mPairs;
    auto &tracks = TrackList::Get( *pProject );
 
-   for (auto lt : tracks.Leaders<LabelTrack>()) {
+   for (auto lt : tracks.Any<LabelTrack>()) {
       auto &view = LabelTrackView::Get( *lt );
       pairs.push_back( std::make_pair(
          lt->SharedPointer<LabelTrack>(), view.SaveFlags() ) );
@@ -69,7 +69,7 @@ UIHandle::Result LabelDefaultClickHandle::Click
       SaveState( pProject );
 
       const auto pLT = evt.pCell.get();
-      for (auto lt : TrackList::Get(*pProject).Leaders<LabelTrack>()) {
+      for (auto lt : TrackList::Get(*pProject).Any<LabelTrack>()) {
          if (pLT != &ChannelView::Get(*lt)) {
             auto &view = LabelTrackView::Get( *lt );
             view.ResetFlags();

--- a/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
@@ -320,7 +320,7 @@ bool LabelGlyphHandle::HandleGlyphDragRelease
               auto& selectionState = SelectionState::Get(project);
               auto& tracks = TrackList::Get(project);
 
-              bool done = tracks.SelectedLeaders().any_of(
+              bool done = tracks.Selected().any_of(
                   [&](const Track* track) { return track != static_cast<Track*>(pTrack.get()); }
               );
 

--- a/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+++ b/src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
@@ -326,7 +326,7 @@ bool LabelGlyphHandle::HandleGlyphDragRelease
 
               if (!done) {
                   //otherwise, select all tracks
-                  for (auto t : tracks.Leaders())
+                  for (auto t : tracks)
                       selectionState.SelectTrack(*t, true, true);
               }
 

--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -1683,7 +1683,7 @@ bool LabelTrackView::DoKeyDown(
       case WXK_NUMPAD_ENTER:
       case WXK_TAB:
          if (mRestoreFocus >= 0) {
-            auto track = *TrackList::Get(project).Leaders()
+            auto track = *TrackList::Get(project).Any()
                .begin().advance(mRestoreFocus);
             if (track)
                TrackFocus::Get( project ).Set(track);

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -154,7 +154,7 @@ void SpectrumView::ForAll( AudacityProject &project,
 {
    if (!fn)
       return;
-   for (const auto wt : TrackList::Get(project).Leaders<WaveTrack>()) {
+   for (const auto wt : TrackList::Get(project).Any<WaveTrack>()) {
       for (auto pChannel : wt->Channels()) {
          if (auto pWaveChannelView =
              dynamic_cast<WaveChannelView*>(&ChannelView::Get(*pChannel))) {

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -1109,7 +1109,7 @@ void DoNextPeakFrequency(AudacityProject &project, bool up)
 
    // Find the first selected wave track that is in a spectrogram view.
    const WaveTrack *pTrack {};
-   for (auto wt : tracks.SelectedLeaders<const WaveTrack>()) {
+   for (auto wt : tracks.Selected<const WaveTrack>()) {
       const auto displays = WaveChannelView::Get(*wt).GetDisplays();
       bool hasSpectrum = (displays.end() != std::find(
          displays.begin(), displays.end(),

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -138,8 +138,8 @@ private:
          for(const auto track : as_const(*trackList).Leaders())
          {
             const auto isSameTrack = (track == currentTrack) ||
-               (track->GetLinkType() == Track::LinkType::Aligned && *trackList->FindLeader(currentTrack) == track) ||
-               (currentTrack->GetLinkType() == Track::LinkType::Aligned && *trackList->FindLeader(track) == currentTrack);
+               (track->GetLinkType() == Track::LinkType::Aligned && *trackList->Find(currentTrack) == track) ||
+               (currentTrack->GetLinkType() == Track::LinkType::Aligned && *trackList->Find(track) == currentTrack);
             for(const auto& interval : track->Intervals())
             {
                if(isSameTrack)

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -135,7 +135,7 @@ private:
 
       if(const auto trackList = currentTrack->GetOwner())
       {
-         for(const auto track : as_const(*trackList).Leaders())
+         for(const auto track : as_const(*trackList))
          {
             const auto isSameTrack = (track == currentTrack) ||
                (track->GetLinkType() == Track::LinkType::Aligned && *trackList->Find(currentTrack) == track) ||

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -641,7 +641,7 @@ BEGIN_POPUP_MENU(WaveTrackMenuTable)
                auto &tracks = TrackList::Get( project );
                auto &table = static_cast< WaveTrackMenuTable& >( handler );
                auto &track = table.FindWaveTrack();
-               auto next = * ++ tracks.FindLeader(&track);
+               auto next = * ++ tracks.Find(&track);
                canMakeStereo =
                   (next &&
                    TrackList::NChannels(*next) == 1 &&
@@ -750,7 +750,7 @@ void WaveTrackMenuTable::OnMergeStereo(wxCommandEvent &)
    wxASSERT(pTrack);
 
    auto partner =
-      static_cast<WaveTrack*>(*tracks.FindLeader(pTrack).advance(1));
+      static_cast<WaveTrack*>(*tracks.Find(pTrack).advance(1));
 
    if (pTrack->GetRate() != partner->GetRate()) {
       using namespace BasicUI;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -259,12 +259,13 @@ void FormatMenuTable::OnFormatChange(wxCommandEvent & event)
                             XO("Processing...   0%%"),
                             pdlgHideStopButton };
 
+   // Safe assumption for tracks associated with the context menu
+   assert(pTrack->IsLeader());
+
    // Simply finding a denominator for the progress dialog
-   sampleCount totalSamples{ 0 };
-   for (const auto& channel : TrackList::Channels(pTrack))
-      // Hidden samples are processed too, they should be counted as well
-      // (Correctly counting all samples of all channels)
-      totalSamples += channel->GetSequenceSamplesCount();
+   // Hidden samples are processed too, they should be counted as well
+   // (Correctly counting all samples of all channels)
+   sampleCount totalSamples = pTrack->GetSequenceSamplesCount();
    sampleCount processedSamples{ 0 };
 
    // Below is the lambda function that is passed along the call chain to

--- a/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
@@ -29,7 +29,7 @@ void OnNewTimeTrack(const CommandContext &context)
    auto &window = ProjectWindow::Get( project );
    
 
-   if (*tracks.Leaders<TimeTrack>().begin()) {
+   if (*tracks.Any<TimeTrack>().begin()) {
       AudacityMessageBox(
          XO(
 "This version of Audacity only allows one time track for each project window.") );

--- a/src/tracks/ui/AffordanceHandle.cpp
+++ b/src/tracks/ui/AffordanceHandle.cpp
@@ -76,7 +76,7 @@ UIHandle::Result AffordanceHandle::Release(const TrackPanelMouseEvent& event, Au
         {
             auto& selectionState = SelectionState::Get(*pProject);
             selectionState.SelectNone(trackList);
-            if (auto pTrack = *trackList.FindLeader(track.get()))
+            if (auto pTrack = *trackList.Find(track.get()))
                selectionState.SelectTrack(*pTrack, true, true);
 
             result |= SelectAt(event, pProject);

--- a/src/tracks/ui/ChannelView.cpp
+++ b/src/tracks/ui/ChannelView.cpp
@@ -271,7 +271,7 @@ struct TrackPositioner final : ClientData::Base
          return;
       }
       auto iter =
-         TrackList::Get(mProject).FindLeader(e.mpTrack.lock().get());
+         TrackList::Get(mProject).Find(e.mpTrack.lock().get());
       if (!*iter)
          return;
 

--- a/src/tracks/ui/ChannelView.cpp
+++ b/src/tracks/ui/ChannelView.cpp
@@ -54,7 +54,7 @@ int ChannelView::GetCumulativeHeight(const Track *pTrack)
 
 int ChannelView::GetTotalHeight(const TrackList &list)
 {
-   return GetCumulativeHeight(*list.Leaders().rbegin());
+   return GetCumulativeHeight(*list.rbegin());
 }
 
 void ChannelView::CopyTo(Track &track) const

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -234,7 +234,7 @@ Scrubber::~Scrubber()
 
 static const auto HasWaveDataPred =
    [](const AudacityProject &project){
-      auto range = TrackList::Get(project).Leaders<const WaveTrack>()
+      auto range = TrackList::Get(project).Any<const WaveTrack>()
          + [](const WaveTrack *pTrack){
             return pTrack->GetEndTime() > pTrack->GetStartTime();
          };

--- a/src/tracks/ui/SelectHandle.cpp
+++ b/src/tracks/ui/SelectHandle.cpp
@@ -535,7 +535,7 @@ UIHandle::Result SelectHandle::Click(
    auto &trackList = TrackList::Get(*pProject);
    const auto sTrack = trackList.Lock(FindTrack());
    const auto pTrack = sTrack.get();
-   const auto pLeader = *trackList.FindLeader(pTrack);
+   const auto pLeader = *trackList.Find(pTrack);
    auto &trackPanel = TrackPanel::Get(*pProject);
    auto &viewInfo = ViewInfo::Get(*pProject);
 

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -313,7 +313,7 @@ void ClipMoveState::Init(
    state.shifters[&capturedTrack] = std::move( pHit );
 
    // Collect TrackShifters for the rest of the tracks
-   for (auto track : trackList.Leaders()) {
+   for (auto track : trackList) {
       auto &pShifter = state.shifters[track];
       if (!pShifter)
          pShifter = MakeTrackShifter::Call(*track, project);

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -34,7 +34,7 @@ TimeShiftHandle::TimeShiftHandle(std::shared_ptr<Track> pTrack, bool gripHit)
    //! Substitute the leader track before assigning mCapturedTrack
    if (pTrack)
       if (const auto pOwner = pTrack->GetOwner())
-         pTrack = (*pOwner->FindLeader(pTrack.get()))->SharedPointer();
+         pTrack = (*pOwner->Find(pTrack.get()))->SharedPointer();
    mClipMoveState.mCapturedTrack = pTrack;
 }
 
@@ -477,7 +477,7 @@ UIHandle::Result TimeShiftHandle::Click(
    auto &trackList = TrackList::Get(*pProject);
    // Substitute the leader track before giving it to MakeTrackShifter
    // and ClipMoveState::Init
-   const auto pTrack = *trackList.FindLeader(clickedTrack);
+   const auto pTrack = *trackList.Find(clickedTrack);
 
    mClipMoveState.clear();
    mDidSlideVertically = false;
@@ -612,9 +612,9 @@ namespace {
 
       // Find how far this track would shift down among those (signed)
       const auto myPosition =
-         std::distance(range.first, trackList.FindLeader(&capturedTrack));
+         std::distance(range.first, trackList.Find(&capturedTrack));
       const auto otherPosition =
-         std::distance(range.first, trackList.FindLeader(&track));
+         std::distance(range.first, trackList.Find(&track));
       auto diff = otherPosition - myPosition;
 
       // Point to destination track for first of range, when diff >= 0
@@ -736,7 +736,7 @@ void TimeShiftHandle::DoSlideVertical(
    Correspondence correspondence;
 
    // Substitute leader track before reassigning mCapturedTrack
-   dstTrack = *trackList.FindLeader(dstTrack);
+   dstTrack = *trackList.Find(dstTrack);
 
    // See if captured track corresponds to another
    auto &capturedTrack = *mClipMoveState.mCapturedTrack;
@@ -748,8 +748,8 @@ void TimeShiftHandle::DoSlideVertical(
    auto tryExtend = [&](bool forward) {
       auto range = trackList.Leaders();
       auto begin = range.begin(), end = range.end();
-      auto pCaptured = trackList.FindLeader(&capturedTrack);
-      auto pDst = trackList.FindLeader(dstTrack);
+      auto pCaptured = trackList.Find(&capturedTrack);
+      auto pDst = trackList.Find(dstTrack);
       // Scan for more correspondences
       while (true) {
          // Remember that TrackIter wraps circularly to the end iterator when
@@ -833,7 +833,7 @@ UIHandle::Result TimeShiftHandle::Drag
    auto &trackList = TrackList::Get(*pProject);
    ChannelView *trackView = dynamic_cast<ChannelView*>(evt.pCell.get());
    Track *track =
-      *trackList.FindLeader(trackView ? trackView->FindTrack().get() : nullptr);
+      *trackList.Find(trackView ? trackView->FindTrack().get() : nullptr);
 
    // Uncommenting this permits drag to continue to work even over the controls area
    /*

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -608,7 +608,7 @@ namespace {
          return false;
    
       // All tracks of the same kind as the captured track
-      auto range = trackList.Leaders() + sameType;
+      auto range = trackList.Any() + sameType;
 
       // Find how far this track would shift down among those (signed)
       const auto myPosition =
@@ -746,7 +746,7 @@ void TimeShiftHandle::DoSlideVertical(
 
    // Try to extend the correpondence
    auto tryExtend = [&](bool forward) {
-      auto range = trackList.Leaders();
+      auto range = trackList.Any();
       auto begin = range.begin(), end = range.end();
       auto pCaptured = trackList.Find(&capturedTrack);
       auto pDst = trackList.Find(dstTrack);

--- a/src/tracks/ui/TrackSelectHandle.cpp
+++ b/src/tracks/ui/TrackSelectHandle.cpp
@@ -227,7 +227,7 @@ void TrackSelectHandle::CalculateRearrangingThresholds(
       mMoveUpThreshold =
          event.m_y -
             ChannelView::GetChannelGroupHeight(
-               * -- tracks.FindLeader(mpTrack.get()));
+               * -- tracks.Find(mpTrack.get()));
    else
       mMoveUpThreshold = INT_MIN;
 
@@ -235,7 +235,7 @@ void TrackSelectHandle::CalculateRearrangingThresholds(
       mMoveDownThreshold =
          event.m_y +
             ChannelView::GetChannelGroupHeight(
-               * ++ tracks.FindLeader(mpTrack.get()));
+               * ++ tracks.Find(mpTrack.get()));
    else
       mMoveDownThreshold = INT_MAX;
 }

--- a/src/tracks/ui/TrackSelectHandle.cpp
+++ b/src/tracks/ui/TrackSelectHandle.cpp
@@ -156,12 +156,12 @@ HitTestPreview TrackSelectHandle::Preview
    //static auto clickedCursor =
    //   ::MakeCursor(wxCURSOR_HAND, RearrangingCursorXpm, 16, 16);
 
-   const auto trackCount = TrackList::Get( *project ).Leaders().size();
+   const auto trackCount = TrackList::Get( *project ).Any().size();
    auto message = Message(trackCount);
    if (mClicked) {
       const bool unsafe =
          ProjectAudioIO::Get( *project ).IsAudioActive();
-      const bool canMove = TrackList::Get( *project ).Leaders().size() > 1;
+      const bool canMove = TrackList::Get( *project ).Any().size() > 1;
       return {
          message,
          (unsafe


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Depends on:
- #4961

This very hopefully titled pull request is not complete but review may begin on the early commits.

When all is done, the last remaining uses of TrackList::Any, Selected, Find, and direct range-for
outside of class Track itself will be gone.

Then might follow renaming of Leaders, SelectedLeaders, and FindLeader back to Any, Selected, Find.

But after that still remains a large task:  Review all the uses of TrackList::Channels (many of them
recently introduced), and make them disappear except inside classes Track and WaveTrack.

QA:
- [x] Persistency of projects with stereo tracks
- [x] Ctrl+A, C, X, V keys, or corresponding menu commands, when there is an edit cursor in a clip title
- [x] Very old code in "Compare Audio" macro command was changed (so it really works on mono and stereo tracks) but maybe nobody cares
- [x] Append-record, and do Ctrl+B to add labels, and make some display changes (like track height), while recording; then stop and test Undo and Redo (All of the recording should be sequenced in undo history after the other changes)
- [x] Change Speed effect on a stereo track
- [x] A Nyquist generator
- [x] Find Clipping done with and without a label track called "Clipping" already present
- [x] Import mono, stereo, (and examples with more than two channels if you can find them??) using FFmpeg, FLAC, MPG 123 (How?  I don't know, ask Dmitry), OGG, WavPack; check correct muting when a solo track was already in the project; check numbers added to track names, in case more than one new track is made by one import
- [x] Import Raw making a stereo track (I'm not sure how you do this, but data-bending can be fun)
- [x] Recording dropout detection into stereo track (there is an alpha item in Tools to enable simulation of droupout errors)
- [x] FFmpeg import example with stream delay (how?)
- [x] Generate Silence into a selection in a stereo track
- [x] Compressor in stereo track
- [x] High quality Change Pitch on stereo
- [x] Save mono and stereo tracks in Audacity 2.4.2, then open the project in 3.4 (this crashes in master! but not in 3.3)
- [x] Cross-paste copy-paste with hidden data on stereo tracks, and long enough to cause progress dialogs, with appropriate scales; try with all the different "Pasted Audio" choices in the Tracks Behaviors preferences
- [x] Change format of a long mono or stereo track, with appropriate progress indicator
- [x] Opening of projects with mono and stereo tracks that were saved in 3.3
- [x] Compressor in a stereo track, again

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

**Noticed issues:**

- [x] Generate Silence into a selection in a stereo track
