### PR TITLE
Appending and flushing

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1525,19 +1525,19 @@ void AudioIO::StopStream()
             // many parts of Audacity that are not effects or editing
             // operations.  GuardedCall ensures that the user sees a warning.
 
-            // Also be sure to Flush each sequence, at the top of the guarded
-            // call, relying on the guarantee that the sequence will be left in
-            // a flushed state, though the append buffer may be lost.
+            // Also be sure to Flush each leader sequence, at the top of the
+            // guarded call, relying on the guarantee that the sequence will be
+            // left in a flushed state, though the append buffer may be lost.
 
-            GuardedCall( [&] {
-               auto sequence = mCaptureSequences[i].get();
-
-               // use No-fail-guarantee that sequence is flushed,
-               // Partial-guarantee that some initial length of the recording
-               // is saved.
-               // See comments in SequenceBufferExchange().
-               sequence->NarrowFlush();
-            } );
+            auto sequence = mCaptureSequences[i].get();
+            if (sequence->IsLeader())
+               GuardedCall( [&] {
+                  // use No-fail-guarantee that sequence is flushed,
+                  // Partial-guarantee that some initial length of the recording
+                  // is saved.
+                  // See comments in SequenceBufferExchange().
+                  sequence->Flush();
+               } );
          }
 
 

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1536,7 +1536,7 @@ void AudioIO::StopStream()
                // Partial-guarantee that some initial length of the recording
                // is saved.
                // See comments in SequenceBufferExchange().
-               sequence->Flush();
+               sequence->NarrowFlush();
             } );
          }
 

--- a/libraries/lib-effects/MixAndRender.cpp
+++ b/libraries/lib-effects/MixAndRender.cpp
@@ -164,9 +164,9 @@ TrackListHolder MixAndRender(const TrackIterRange<const WaveTrack> &trackRange,
       }
    }
 
-   mixLeft->Flush();
+   mixLeft->NarrowFlush();
    if (!mono)
-      mixRight->Flush();
+      mixRight->NarrowFlush();
    if (updateResult == ProgressResult::Cancelled ||
        updateResult == ProgressResult::Failed)
       return {};

--- a/libraries/lib-effects/MixAndRender.cpp
+++ b/libraries/lib-effects/MixAndRender.cpp
@@ -164,9 +164,7 @@ TrackListHolder MixAndRender(const TrackIterRange<const WaveTrack> &trackRange,
       }
    }
 
-   mixLeft->NarrowFlush();
-   if (!mono)
-      mixRight->NarrowFlush();
+   mixLeft->Flush();
    if (updateResult == ProgressResult::Cancelled ||
        updateResult == ProgressResult::Failed)
       return {};

--- a/libraries/lib-import-export/ImportUtils.cpp
+++ b/libraries/lib-import-export/ImportUtils.cpp
@@ -44,3 +44,12 @@ void ImportUtils::ShowMessageBox(const TranslatableString &message, const Transl
    BasicUI::ShowMessageBox(message,
                            BasicUI::MessageBoxOptions().Caption(caption));
 }
+
+std::shared_ptr<TrackList>
+ImportUtils::MakeTracks(const NewChannelGroup &channels)
+{
+   auto result = TrackList::Temporary(nullptr, channels);
+   for (const auto pTrack : result->Any<WaveTrack>())
+      pTrack->Flush();
+   return result;
+}

--- a/libraries/lib-import-export/ImportUtils.h
+++ b/libraries/lib-import-export/ImportUtils.h
@@ -13,11 +13,13 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 #include "SampleFormat.h"
 #include "Internat.h"
 
 class wxString;
 
+class TrackList;
 class WaveTrackFactory;
 class WaveTrack;
 
@@ -34,4 +36,9 @@ public:
    
    static void ShowMessageBox(const TranslatableString& message, const TranslatableString& caption = XO("Import Project"));
    
+   using NewChannelGroup = std::vector<std::shared_ptr<WaveTrack>>;
+
+   //! Flush the given channels and group them into tracks
+   static
+   std::shared_ptr<TrackList> MakeTracks(const NewChannelGroup &channels);
 };

--- a/libraries/lib-mixer/AudioIOSequences.h
+++ b/libraries/lib-mixer/AudioIOSequences.h
@@ -63,10 +63,16 @@ struct MIXER_API RecordableSequence {
       */
    ) = 0;
 
-   //! NarrowFlush must be called after last Append
+   virtual bool IsLeader() const = 0;
+
+   //! NarrowFlush or Flush of related leader must be called after last Append
    virtual void NarrowFlush() = 0;
 
-   virtual bool IsLeader() const = 0;
+   //! NarrowFlush or Flush of related leader must be called after last Append
+   /*!
+    @pre `IsLeader()`
+    */
+   virtual void Flush() = 0;
 
    /*!
     @pre `IsLeader()`

--- a/libraries/lib-mixer/AudioIOSequences.h
+++ b/libraries/lib-mixer/AudioIOSequences.h
@@ -65,10 +65,7 @@ struct MIXER_API RecordableSequence {
 
    virtual bool IsLeader() const = 0;
 
-   //! NarrowFlush or Flush of related leader must be called after last Append
-   virtual void NarrowFlush() = 0;
-
-   //! NarrowFlush or Flush of related leader must be called after last Append
+   //! Flush of related leader must be called after last Append
    /*!
     @pre `IsLeader()`
     */

--- a/libraries/lib-mixer/AudioIOSequences.h
+++ b/libraries/lib-mixer/AudioIOSequences.h
@@ -63,8 +63,8 @@ struct MIXER_API RecordableSequence {
       */
    ) = 0;
 
-   //! Flush must be called after last Append
-   virtual void Flush() = 0;
+   //! NarrowFlush must be called after last Append
+   virtual void NarrowFlush() = 0;
 
    virtual bool IsLeader() const = 0;
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1443,7 +1443,7 @@ void WaveTrack::SyncLockAdjust(double oldT1, double newT1)
                mpFactory, GetSampleFormat(), GetRate());
             assert(tmp->IsLeader()); // It is not yet owned by a TrackList
             tmp->InsertSilence(0.0, duration);
-            tmp->NarrowFlush();
+            tmp->FlushOne();
             PasteOne(*pChannel, oldT1, *tmp, 0.0, duration);
          }
       }
@@ -1944,7 +1944,7 @@ void WaveTrack::Flush()
 {
    assert(IsLeader());
    for (const auto pChannel : TrackList::Channels(this))
-      pChannel->NarrowFlush();
+      pChannel->FlushOne();
 }
 
 /*! @excsafety{Mixed} */
@@ -1952,7 +1952,7 @@ void WaveTrack::Flush()
 /*! @excsafety{Partial}
 -- Some initial portion (maybe none) of the append buffer of the rightmost
 clip gets appended; no previously saved contents are lost. */
-void WaveTrack::NarrowFlush()
+void WaveTrack::FlushOne()
 {
    // After appending, presumably.  Do this to the clip that gets appended.
    RightmostOrNewClip()->Flush();

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1940,6 +1940,18 @@ size_t WaveTrack::GetIdealBlockSize()
 /*! @excsafety{Partial}
 -- Some initial portion (maybe none) of the append buffer of the rightmost
 clip gets appended; no previously saved contents are lost. */
+void WaveTrack::Flush()
+{
+   assert(IsLeader());
+   for (const auto pChannel : TrackList::Channels(this))
+      pChannel->NarrowFlush();
+}
+
+/*! @excsafety{Mixed} */
+/*! @excsafety{No-fail} -- The rightmost clip will be in a flushed state. */
+/*! @excsafety{Partial}
+-- Some initial portion (maybe none) of the append buffer of the rightmost
+clip gets appended; no previously saved contents are lost. */
 void WaveTrack::NarrowFlush()
 {
    // After appending, presumably.  Do this to the clip that gets appended.

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1935,6 +1935,8 @@ size_t WaveTrack::GetIdealBlockSize()
    return NewestOrNewClip()->GetSequence(0)->GetIdealBlockSize();
 }
 
+// TODO restore a proper exception safety guarantee; comment below is false
+// because failure might happen after only one channel is done
 /*! @excsafety{Mixed} */
 /*! @excsafety{No-fail} -- The rightmost clip will be in a flushed state. */
 /*! @excsafety{Partial}

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1443,7 +1443,7 @@ void WaveTrack::SyncLockAdjust(double oldT1, double newT1)
                mpFactory, GetSampleFormat(), GetRate());
             assert(tmp->IsLeader()); // It is not yet owned by a TrackList
             tmp->InsertSilence(0.0, duration);
-            tmp->Flush();
+            tmp->NarrowFlush();
             PasteOne(*pChannel, oldT1, *tmp, 0.0, duration);
          }
       }
@@ -1940,7 +1940,7 @@ size_t WaveTrack::GetIdealBlockSize()
 /*! @excsafety{Partial}
 -- Some initial portion (maybe none) of the append buffer of the rightmost
 clip gets appended; no previously saved contents are lost. */
-void WaveTrack::Flush()
+void WaveTrack::NarrowFlush()
 {
    // After appending, presumably.  Do this to the clip that gets appended.
    RightmostOrNewClip()->Flush();

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -318,7 +318,6 @@ private:
       size_t len, unsigned int stride = 1,
       sampleFormat effectiveFormat = widestSampleFormat) override;
 
-   void NarrowFlush() override;
    void Flush() override;
 
    //! @name PlayableSequence implementation
@@ -685,6 +684,7 @@ private:
    size_t NIntervals() const override;
 
 private:
+   void FlushOne();
    // May assume precondition: t0 <= t1
    void HandleClear(double t0, double t1, bool addCutLines, bool split);
    static void ClearAndPasteOne(WaveTrack &track,

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -322,6 +322,7 @@ private:
       sampleFormat effectiveFormat = widestSampleFormat) override;
 
    void NarrowFlush() override;
+   void Flush() override;
 
    //! @name PlayableSequence implementation
    //! @{

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -321,7 +321,7 @@ private:
       size_t len, unsigned int stride = 1,
       sampleFormat effectiveFormat = widestSampleFormat) override;
 
-   void Flush() override;
+   void NarrowFlush() override;
 
    //! @name PlayableSequence implementation
    //! @{

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -299,9 +299,6 @@ private:
     */
    void Trim(double t0, double t1) /* not override */;
 
-   // May assume precondition: t0 <= t1
-   void HandleClear(double t0, double t1, bool addCutLines, bool split);
-
    void SyncLockAdjust(double oldT1, double newT1) override;
 
    /** @brief Returns true if there are no WaveClips in the specified region
@@ -687,7 +684,9 @@ private:
 
    size_t NIntervals() const override;
 
-protected:
+private:
+   // May assume precondition: t0 <= t1
+   void HandleClear(double t0, double t1, bool addCutLines, bool split);
    static void ClearAndPasteOne(WaveTrack &track,
       double t0, double t1, double startTime, double endTime,
       const WaveTrack &src,

--- a/libraries/lib-wave-track/WaveTrackSink.cpp
+++ b/libraries/lib-wave-track/WaveTrackSink.cpp
@@ -97,9 +97,9 @@ std::shared_ptr<TrackList> WaveTrackSink::Flush(Buffers &data)
 {
    DoConsume(data);
    if (mGenLeft) {
-      mGenLeft->Flush();
+      mGenLeft->NarrowFlush();
       if (mGenRight)
-         mGenRight->Flush();
+         mGenRight->NarrowFlush();
    }
    return mList;
 }

--- a/libraries/lib-wave-track/WaveTrackSink.cpp
+++ b/libraries/lib-wave-track/WaveTrackSink.cpp
@@ -96,10 +96,7 @@ void WaveTrackSink::DoConsume(Buffers &data)
 std::shared_ptr<TrackList> WaveTrackSink::Flush(Buffers &data)
 {
    DoConsume(data);
-   if (mGenLeft) {
-      mGenLeft->NarrowFlush();
-      if (mGenRight)
-         mGenRight->NarrowFlush();
-   }
+   if (mGenLeft)
+      mGenLeft->Flush();
    return mList;
 }

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -66,8 +66,6 @@ static const auto exts = {wxT("aup")};
 class AUPImportFileHandle;
 using ImportHandle = std::unique_ptr<ImportFileHandle>;
 
-using NewChannelGroup = std::vector<std::shared_ptr<WaveTrack>>;
-
 class AUPImportPlugin final : public ImportPlugin
 {
 public:

--- a/modules/mod-ffmpeg/ImportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ImportFFmpeg.cpp
@@ -554,7 +554,7 @@ void FFmpegImportFileHandle::Import(ImportProgressListener& progressListener,
    // Copy audio from mChannels to newly created tracks (destroying mChannels elements in process)
    for (auto &stream : mChannels)
       for(auto &channel : stream)
-         channel->Flush();
+         channel->NarrowFlush();
 
    for (auto &group : mChannels)
       // Now channels get grouped

--- a/modules/mod-ffmpeg/ImportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ImportFFmpeg.cpp
@@ -553,12 +553,8 @@ void FFmpegImportFileHandle::Import(ImportProgressListener& progressListener,
 
    // Copy audio from mChannels to newly created tracks (destroying mChannels elements in process)
    for (auto &stream : mChannels)
-      for(auto &channel : stream)
-         channel->NarrowFlush();
-
-   for (auto &group : mChannels)
-      // Now channels get grouped
-      outTracks.push_back(TrackList::Temporary(nullptr, group));
+      if (!stream.empty())
+         outTracks.push_back(ImportUtils::MakeTracks(stream));
 
    // Save metadata
    WriteMetadata(tags);

--- a/modules/mod-flac/ImportFLAC.cpp
+++ b/modules/mod-flac/ImportFLAC.cpp
@@ -63,7 +63,6 @@ extern "C" {
 
 
 class FLACImportFileHandle;
-using NewChannelGroup = std::vector<std::shared_ptr<WaveTrack>>;
 
 class MyFLACFile final : public FLAC::Decoder::File
 {
@@ -150,7 +149,7 @@ private:
    FLAC__uint64          mNumSamples;
    FLAC__uint64          mSamplesDone;
    bool                  mStreamInfoDone;
-   NewChannelGroup       mChannels;
+   ImportUtils::NewChannelGroup mChannels;
 };
 
 
@@ -429,11 +428,8 @@ void FLACImportFileHandle::Import(ImportProgressListener& progressListener,
       return;
    }
 
-   for (const auto &channel : mChannels)
-      channel->NarrowFlush();
-
    if (!mChannels.empty())
-      outTracks.push_back(TrackList::Temporary(nullptr, mChannels));
+      outTracks.push_back(ImportUtils::MakeTracks(mChannels));
 
    wxString comment;
    wxString description;

--- a/modules/mod-flac/ImportFLAC.cpp
+++ b/modules/mod-flac/ImportFLAC.cpp
@@ -430,7 +430,7 @@ void FLACImportFileHandle::Import(ImportProgressListener& progressListener,
    }
 
    for (const auto &channel : mChannels)
-      channel->Flush();
+      channel->NarrowFlush();
 
    if (!mChannels.empty())
       outTracks.push_back(TrackList::Temporary(nullptr, mChannels));

--- a/modules/mod-mpg123/ImportMP3_MPG123.cpp
+++ b/modules/mod-mpg123/ImportMP3_MPG123.cpp
@@ -341,7 +341,7 @@ void MP3ImportFileHandle::Import(ImportProgressListener &progressListener,
 
    // Flush and trim the channels
    for (const auto &channel : mChannels)
-      channel->Flush();
+      channel->NarrowFlush();
 
    // Copy the WaveTrack pointers into the Track pointer list that
    // we are expected to fill

--- a/modules/mod-mpg123/ImportMP3_MPG123.cpp
+++ b/modules/mod-mpg123/ImportMP3_MPG123.cpp
@@ -120,8 +120,6 @@ public:
    std::unique_ptr<ImportFileHandle> Open(const FilePath &Filename, AudacityProject*) override;
 }; // class MP3ImportPlugin
 
-using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
-
 class MP3ImportFileHandle final : public ImportFileHandleEx
 {
 public:
@@ -154,7 +152,7 @@ private:
    wxFileOffset mFileLen { 0 };
 
    WaveTrackFactory* mTrackFactory { nullptr };
-   NewChannelGroup mChannels;
+   ImportUtils::NewChannelGroup mChannels;
    unsigned mNumChannels { 0 };
 
    mpg123_handle* mHandle { nullptr };
@@ -339,13 +337,8 @@ void MP3ImportFileHandle::Import(ImportProgressListener &progressListener,
       return;
    }
 
-   // Flush and trim the channels
-   for (const auto &channel : mChannels)
-      channel->NarrowFlush();
-
-   // Copy the WaveTrack pointers into the Track pointer list that
-   // we are expected to fill
-   outTracks.push_back(TrackList::Temporary(nullptr, mChannels));
+   if (!mChannels.empty())
+      outTracks.push_back(ImportUtils::MakeTracks(mChannels));
 
    ReadTags(tags);
    

--- a/modules/mod-ogg/ImportOGG.cpp
+++ b/modules/mod-ogg/ImportOGG.cpp
@@ -340,7 +340,7 @@ void OggImportFileHandle::Import(ImportProgressListener &progressListener,
    for (auto &link : mChannels)
    {
       for (auto &channel : link)
-         channel->Flush();
+         channel->NarrowFlush();
       outTracks.push_back(TrackList::Temporary(nullptr, link));
    }
 

--- a/modules/mod-ogg/ImportOGG.cpp
+++ b/modules/mod-ogg/ImportOGG.cpp
@@ -53,8 +53,6 @@ static const auto exts = {
 #include "ImportProgressListener.h"
 #include "ImportUtils.h"
 
-using NewChannelGroup = std::vector<std::shared_ptr<WaveTrack>>;
-
 class OggImportPlugin final : public ImportPlugin
 {
 public:
@@ -133,7 +131,7 @@ private:
 
    ArrayOf<int> mStreamUsage;
    TranslatableStrings mStreamInfo;
-   std::list<NewChannelGroup> mChannels;
+   std::list<ImportUtils::NewChannelGroup> mChannels;
 };
 
 
@@ -338,11 +336,8 @@ void OggImportFileHandle::Import(ImportProgressListener &progressListener,
    }
 
    for (auto &link : mChannels)
-   {
-      for (auto &channel : link)
-         channel->NarrowFlush();
-      outTracks.push_back(TrackList::Temporary(nullptr, link));
-   }
+      if (!link.empty())
+         outTracks.push_back(ImportUtils::MakeTracks(link));
 
    //\todo { Extract comments from each stream? }
    if (mVorbisFile->vc[0].comments > 0) {

--- a/modules/mod-pcm/ImportPCM.cpp
+++ b/modules/mod-pcm/ImportPCM.cpp
@@ -277,8 +277,6 @@ struct id3_tag_deleter {
 using id3_tag_holder = std::unique_ptr<id3_tag, id3_tag_deleter>;
 #endif
 
-using NewChannelGroup = std::vector< std::shared_ptr<WaveTrack> >;
-
 void PCMImportFileHandle::Import(ImportProgressListener &progressListener,
                                  WaveTrackFactory *trackFactory,
                                  TrackHolders &outTracks,
@@ -290,7 +288,7 @@ void PCMImportFileHandle::Import(ImportProgressListener &progressListener,
 
    wxASSERT(mFile.get());
 
-   NewChannelGroup channels(mInfo.channels);
+   ImportUtils::NewChannelGroup channels(mInfo.channels);
 
    for (size_t c = 0; c < mInfo.channels; ++c)
       channels[c] =
@@ -384,11 +382,8 @@ void PCMImportFileHandle::Import(ImportProgressListener &progressListener,
       return;
    }
 
-   for(const auto &channel : channels)
-      channel->NarrowFlush();
-
    if (!channels.empty())
-      outTracks.push_back(TrackList::Temporary(nullptr, channels));
+      outTracks.push_back(ImportUtils::MakeTracks(channels));
 
    const char *str;
 

--- a/modules/mod-pcm/ImportPCM.cpp
+++ b/modules/mod-pcm/ImportPCM.cpp
@@ -385,7 +385,7 @@ void PCMImportFileHandle::Import(ImportProgressListener &progressListener,
    }
 
    for(const auto &channel : channels)
-      channel->Flush();
+      channel->NarrowFlush();
 
    if (!channels.empty())
       outTracks.push_back(TrackList::Temporary(nullptr, channels));

--- a/modules/mod-wavpack/ImportWavPack.cpp
+++ b/modules/mod-wavpack/ImportWavPack.cpp
@@ -248,7 +248,7 @@ void WavPackImportFileHandle::Import(ImportProgressListener &progressListener,
    }
 
    for (const auto &channel : channels)
-      channel->Flush();
+      channel->NarrowFlush();
 
    if (!channels.empty())
       outTracks.push_back(TrackList::Temporary(nullptr, channels));

--- a/modules/mod-wavpack/ImportWavPack.cpp
+++ b/modules/mod-wavpack/ImportWavPack.cpp
@@ -247,11 +247,8 @@ void WavPackImportFileHandle::Import(ImportProgressListener &progressListener,
       return;
    }
 
-   for (const auto &channel : channels)
-      channel->NarrowFlush();
-
    if (!channels.empty())
-      outTracks.push_back(TrackList::Temporary(nullptr, channels));
+      outTracks.push_back(ImportUtils::MakeTracks(channels));
 
    if (wavpackMode & MODE_VALID_TAG) {
       bool apeTag = wavpackMode & MODE_APETAG;

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -415,7 +415,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
 
       t->Append((samplePtr)block.get(), SampleFormat, chunkSize);
    }
-   t->Flush();
+   t->NarrowFlush();
 
    // This forces the WaveTrack to flush all of the appends (which is
    // only necessary if you want to access the Sequence class directly,

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -367,6 +367,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
       WaveTrackFactory{ mRate,
                     SampleBlockFactory::New( mProject )  }
          .Create(SampleFormat, mRate.GetRate());
+   assert(t->IsLeader()); // because it's new and not grouped
 
    t->SetRate(1);
 
@@ -415,7 +416,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
 
       t->Append((samplePtr)block.get(), SampleFormat, chunkSize);
    }
-   t->NarrowFlush();
+   t->Flush();
 
    // This forces the WaveTrack to flush all of the appends (which is
    // only necessary if you want to access the Sequence class directly,

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -367,6 +367,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
       WaveTrackFactory{ mRate,
                     SampleBlockFactory::New( mProject )  }
          .Create(SampleFormat, mRate.GetRate());
+   const auto tmp0 = TrackList::Temporary(nullptr, t, nullptr);
    assert(t->IsLeader()); // because it's new and not grouped
 
    t->SetRate(1);

--- a/src/SpectralDataManager.cpp
+++ b/src/SpectralDataManager.cpp
@@ -182,8 +182,8 @@ bool SpectralDataManager::Worker::Process(WaveTrack* wt,
    // a few initial windows that overlay the range only partially
    mStartHopNum = startSample / hopSize - (mStepsPerWindow - 1);
    mWindowCount = 0;
-   const auto len = mpSpectralData->GetLength();
-   return TrackSpectrumTransformer::Process(Processor, wt, 1, startSample, len);
+   return TrackSpectrumTransformer::Process(Processor, wt, 1,
+      mpSpectralData->GetCorrectedStartSample(), mpSpectralData->GetLength());
 }
 
 int SpectralDataManager::Worker::ProcessSnapping(WaveTrack *wt,

--- a/src/SpectrumTransformer.cpp
+++ b/src/SpectrumTransformer.cpp
@@ -350,7 +350,6 @@ bool TrackSpectrumTransformer::Process(const WindowProcessor &processor,
    if (!Start(queueLength))
       return false;
 
-   mLen = len;
    auto bufferSize = track->GetMaxBlockSize();
    FloatVector buffer(bufferSize);
 
@@ -376,14 +375,18 @@ bool TrackSpectrumTransformer::Process(const WindowProcessor &processor,
 
 bool TrackSpectrumTransformer::DoFinish()
 {
-   if (mOutputTrack) {
-      // Flush the output WaveTrack (since it's buffered)
-      mOutputTrack->NarrowFlush();
-      auto tLen = mOutputTrack->LongSamplesToTime(mLen);
-      // Filtering effects always end up with more data than they started with.
-      // Delete this 'tail'.
-      mOutputTrack->HandleClear(tLen, mOutputTrack->GetEndTime(), false, false);
-   }
+   return true;
+}
+
+bool TrackSpectrumTransformer::PostProcess(
+   WaveTrack &outputTrack, sampleCount len)
+{
+   assert(outputTrack.IsLeader());
+   outputTrack.Flush();
+   auto tLen = outputTrack.LongSamplesToTime(len);
+   // Filtering effects always end up with more data than they started with.
+   // Delete this 'tail'.
+   outputTrack.Clear(tLen, outputTrack.GetEndTime());
    return true;
 }
 

--- a/src/SpectrumTransformer.cpp
+++ b/src/SpectrumTransformer.cpp
@@ -378,7 +378,7 @@ bool TrackSpectrumTransformer::DoFinish()
 {
    if (mOutputTrack) {
       // Flush the output WaveTrack (since it's buffered)
-      mOutputTrack->Flush();
+      mOutputTrack->NarrowFlush();
       auto tLen = mOutputTrack->LongSamplesToTime(mLen);
       // Filtering effects always end up with more data than they started with.
       // Delete this 'tail'.

--- a/src/SpectrumTransformer.cpp
+++ b/src/SpectrumTransformer.cpp
@@ -375,7 +375,7 @@ bool TrackSpectrumTransformer::Process(const WindowProcessor &processor,
 
 bool TrackSpectrumTransformer::DoFinish()
 {
-   return true;
+   return SpectrumTransformer::DoFinish();
 }
 
 bool TrackSpectrumTransformer::PostProcess(

--- a/src/SpectrumTransformer.h
+++ b/src/SpectrumTransformer.h
@@ -75,7 +75,8 @@ public:
    bool ProcessSamples(const WindowProcessor &processor,
       const float *buffer, size_t len);
 
-   //! Call once after a sequence of calls to ProcessSamples; flushes the queue and Invokes DoFinish
+   //! Call once after a sequence of calls to ProcessSamples; flushes the queue
+   //! and Invokes DoFinish
    /*! @return success */
    bool Finish(const WindowProcessor &processor);
 
@@ -189,6 +190,12 @@ public:
    bool Process(const WindowProcessor &processor, const WaveTrack *track,
       size_t queueLength, sampleCount start, sampleCount len);
 
+   //! Final flush and trimming of tail samples
+   /*!
+    @pre `outputTrack.IsLeader()`
+    */
+   static bool PostProcess(WaveTrack &outputTrack, sampleCount len);
+
 protected:
    bool DoStart() override;
    void DoOutput(const float *outBuffer, size_t mStepSize) override;
@@ -196,7 +203,6 @@ protected:
 
    std::shared_ptr<WaveTrack> mOutputTrack;
 private:
-   sampleCount mLen = 0;
    const WaveTrack *mpTrack = nullptr;
 };
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -268,9 +268,10 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
                bGoodResult = false;
                return;
             }
+            const auto pNewTrack = *newTracks->Any<WaveTrack>().begin();
+            pNewTrack->Flush();
 
-            const double newLength =
-               (*newTracks->begin())->GetEndTime();
+            const double newLength = pNewTrack->GetEndTime();
             const LinearTimeWarper warper{
                mCurT0, mCurT0, mCurT1, mCurT0 + newLength };
 
@@ -560,11 +561,8 @@ std::shared_ptr<WaveTrack> EffectChangeSpeed::ProcessOne(
       }
    }
 
-   if (bResult) {
-      // Flush the output WaveTrack (since it's buffered, too)
-      outputTrack->NarrowFlush();
+   if (bResult)
       return outputTrack;
-   }
    return {};
 }
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -562,7 +562,7 @@ std::shared_ptr<WaveTrack> EffectChangeSpeed::ProcessOne(
 
    if (bResult) {
       // Flush the output WaveTrack (since it's buffered, too)
-      outputTrack->Flush();
+      outputTrack->NarrowFlush();
       return outputTrack;
    }
    return {};

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -426,7 +426,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
             temp->Add(pNewChannel);
             assert(pNewChannel->IsLeader() == pChannel->IsLeader());
          }
-         auto pTempTrack = *temp->Any<WaveTrack>().rbegin();
+         auto pTempTrack = *temp->Any<WaveTrack>().begin();
          pTempTrack->ConvertToSampleFormat(floatSample);
          auto iter0 = TrackList::Channels(pTempTrack).begin();
    
@@ -447,6 +447,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
             if (!bGoodResult)
                goto done;
          }
+         pTempTrack->Flush();
          PasteOverPreservingClips(data, *track, start, len,
             **temp->Any<WaveTrack>().begin());
       }
@@ -541,8 +542,7 @@ bool EffectEqualization::ProcessOne(Task &task,
       }
    }
 
-   if(bLoopSuccess)
-   {
+   if (bLoopSuccess) {
       // M-1 samples of 'tail' left in lastWindow, get them now
       if(wcopy < (M - 1)) {
          // Still have some overlap left to process
@@ -559,7 +559,6 @@ bool EffectEqualization::ProcessOne(Task &task,
             buffer[j] = lastWindow[wcopy + j];
       }
       task.AccumulateSamples((samplePtr)buffer.get(), M - 1);
-      output.NarrowFlush();
    }
    return bLoopSuccess;
 }

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -559,7 +559,7 @@ bool EffectEqualization::ProcessOne(Task &task,
             buffer[j] = lastWindow[wcopy + j];
       }
       task.AccumulateSamples((samplePtr)buffer.get(), M - 1);
-      output.Flush();
+      output.NarrowFlush();
    }
    return bLoopSuccess;
 }

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -71,7 +71,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
             if (bGoodResult) {
                for (const auto pChannel :
                   TrackList::Channels(*list->Any<WaveTrack>().begin()))
-                  pChannel->Flush();
+                  pChannel->NarrowFlush();
                PasteTimeWarper warper{ mT1, mT0 + duration };
                auto pProject = FindProject();
                const auto &selectedRegion =

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -69,9 +69,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
             if (!GenerateTrack(settings, *list))
                bGoodResult = false;
             if (bGoodResult) {
-               for (const auto pChannel :
-                  TrackList::Channels(*list->Any<WaveTrack>().begin()))
-                  pChannel->NarrowFlush();
+               (*list->Any<WaveTrack>().begin())->Flush();
                PasteTimeWarper warper{ mT1, mT0 + duration };
                auto pProject = FindProject();
                const auto &selectedRegion =

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -748,8 +748,11 @@ bool EffectNoiseReduction::Worker::Process(
             }
             ++mProgressTrackCount;
          }
-         if (tempList->Size())
+         if (tempList->Size()) {
+            const auto pTrack = *tempList->Any<WaveTrack>().begin();
+            TrackSpectrumTransformer::PostProcess(*pTrack, len);
             track->ClearAndPaste(t0, t0 + tLen, *tempList, true, false);
+         }
       }
    }
 

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -163,11 +163,13 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
             const auto outputTrack = ProcessOne(*pChannel, t0, t1, count++);
             if (!outputTrack)
                return false;
-            outputTrack->NarrowFlush();
             tempList->Add(outputTrack);
+            // because it was made by EmptyCopy():
+            assert(outputTrack->IsLeader() == pChannel->IsLeader());
          }
-         newT1 = std::max(newT1,
-            mT0 + (*tempList->begin())->GetEndTime());
+         const auto pNewTrack = *tempList->Any<WaveTrack>().begin();
+         pNewTrack->Flush();
+         newT1 = std::max(newT1, mT0 + pNewTrack->GetEndTime());
          track->Clear(t0, t1);
          track->Paste(t0, *tempList);
       }

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -163,7 +163,7 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
             const auto outputTrack = ProcessOne(*pChannel, t0, t1, count++);
             if (!outputTrack)
                return false;
-            outputTrack->Flush();
+            outputTrack->NarrowFlush();
             tempList->Add(outputTrack);
          }
          newT1 = std::max(newT1,

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -395,9 +395,9 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
                   std::rethrow_exception(pException);
             }
 
-            rb.outputLeftTrack->Flush();
+            rb.outputLeftTrack->NarrowFlush();
             if(rightTrack)
-               rb.outputRightTrack->Flush();
+               rb.outputRightTrack->NarrowFlush();
 
             Finalize(leftTrack, *rb.outputLeftTrack, *warper);
          }

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -395,10 +395,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
                   std::rethrow_exception(pException);
             }
 
-            rb.outputLeftTrack->NarrowFlush();
-            if(rightTrack)
-               rb.outputRightTrack->NarrowFlush();
-
+            rb.outputLeftTrack->Flush();
             Finalize(leftTrack, *rb.outputLeftTrack, *warper);
          }
          mCurTrackNum++;

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -228,8 +228,7 @@ bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
          outputTrack->Append((samplePtr)buffer2.get(), floatSample, outputCount);
       }
 
-      // Flush the output WaveTrack (since it's buffered, too)
-      outputTrack->NarrowFlush();
+      outputTrack->Flush();
    }
 
    // Allow TrackList::Channels to work on outputTrack
@@ -328,9 +327,7 @@ bool EffectSoundTouch::ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
          this->ProcessStereoResults(pSoundTouch,
             outputCount, outputLeftTrack.get(), outputRightTrack.get());
 
-      // Flush the output WaveTracks (since they're buffered, too)
-      outputLeftTrack->NarrowFlush();
-      outputRightTrack->NarrowFlush();
+      outputLeftTrack->Flush();
    }
 
    // Transfer output samples to the original

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -229,7 +229,7 @@ bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
       }
 
       // Flush the output WaveTrack (since it's buffered, too)
-      outputTrack->Flush();
+      outputTrack->NarrowFlush();
    }
 
    // Allow TrackList::Channels to work on outputTrack
@@ -329,8 +329,8 @@ bool EffectSoundTouch::ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
             outputCount, outputLeftTrack.get(), outputRightTrack.get());
 
       // Flush the output WaveTracks (since they're buffered, too)
-      outputLeftTrack->Flush();
-      outputRightTrack->Flush();
+      outputLeftTrack->NarrowFlush();
+      outputRightTrack->NarrowFlush();
    }
 
    // Transfer output samples to the original

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -189,7 +189,7 @@ bool EffectStereoToMono::ProcessOne(TrackList &outputs,
       if (TotalProgress(curTime.as_double() / totalTime.as_double()))
          return false;
    }
-   outTrack->NarrowFlush();
+   outTrack->Flush();
 
    outputs.UnlinkChannels(*left);
    // Should be a consequence of unlinking:

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -189,7 +189,7 @@ bool EffectStereoToMono::ProcessOne(TrackList &outputs,
       if (TotalProgress(curTime.as_double() / totalTime.as_double()))
          return false;
    }
-   outTrack->Flush();
+   outTrack->NarrowFlush();
 
    outputs.UnlinkChannels(*left);
    // Should be a consequence of unlinking:

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -214,7 +214,7 @@ bool EffectTwoPassSimpleMono::ProcessOne(WaveTrack &track, WaveTrack &outTrack,
          samples1);
    else {
       outTrack.Append((samplePtr)buffer1.get(), floatSample, samples1);
-      outTrack.Flush();
+      outTrack.NarrowFlush();
    }
 
    // Return true because the effect processing succeeded.

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -102,6 +102,8 @@ bool EffectTwoPassSimpleMono::ProcessPass(EffectSettings &settings)
          for (const auto pChannel : TrackList::Channels(track))
             if (!ProcessOne(*pChannel, **outIter++, start, end))
                return false;
+         if (!mSecondPassDisabled && mPass == 0)
+            outTrack->Flush();
       }
 
       ++mCurTrackNum;
@@ -212,10 +214,8 @@ bool EffectTwoPassSimpleMono::ProcessOne(WaveTrack &track, WaveTrack &outTrack,
    if (mSecondPassDisabled || mPass != 0)
       outTrack.Set((samplePtr)buffer1.get(), floatSample, s - samples1,
          samples1);
-   else {
+   else
       outTrack.Append((samplePtr)buffer1.get(), floatSample, samples1);
-      outTrack.NarrowFlush();
-   }
 
    // Return true because the effect processing succeeded.
    return true;

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1670,16 +1670,21 @@ bool NyquistEffect::ProcessOne(EffectOutputTracks *pOutputs)
          *this, XO("Nyquist returned nil audio.\n"));
       return false;
    }
-   for (int i = 0; i < outChannels; i++)
-      outputTrack[i]->NarrowFlush();
+
+   const auto &out = outputTrack[0];
+   std::shared_ptr<TrackList> tempList;
+   if (outChannels < static_cast<int>(mCurNumChannels)) {
+      // Be careful to do this before duplication
+      outputTrack[0]->Flush();
+      outputTrack[1] = (*out->Duplicate()->begin())->SharedPointer<WaveTrack>();
+      tempList = TrackList::Temporary(nullptr, outputTrack[0], outputTrack[1]);
+   }
+   else {
+      tempList = TrackList::Temporary(nullptr, outputTrack[0], outputTrack[1]);
+      outputTrack[0]->Flush();
+   }
 
    {
-      const auto &out = outputTrack[0];
-      if (outChannels < (int)mCurNumChannels)
-         outputTrack[1] =
-            (*out->Duplicate()->begin())->SharedPointer<WaveTrack>();
-      auto tempList =
-         TrackList::Temporary(nullptr, outputTrack[0], outputTrack[1]);
       const bool bMergeClips = (mMergeClips < 0)
          // Use sample counts to determine default behaviour - times will rarely
          // be equal.

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1671,7 +1671,7 @@ bool NyquistEffect::ProcessOne(EffectOutputTracks *pOutputs)
       return false;
    }
    for (int i = 0; i < outChannels; i++)
-      outputTrack[i]->Flush();
+      outputTrack[i]->NarrowFlush();
 
    {
       const auto &out = outputTrack[0];

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -260,7 +260,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
 
    if (!results.empty() && !results[0].empty()) {
       for (const auto &channel : results[0])
-         channel->Flush();
+         channel->NarrowFlush();
       for (auto &group : results)
          outTracks.push_back(TrackList::Temporary(nullptr, group));
    }

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -108,7 +108,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
 {
    outTracks.clear();
 
-   std::vector<std::vector<WaveTrack::Holder>> results;
+   ImportUtils::NewChannelGroup results;
    auto updateResult = ProgressResult::Success;
 
    {
@@ -178,18 +178,11 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
       const auto format = ImportUtils::ChooseFormat(
          sf_subtype_to_effective_format(encoding));
 
-      results.resize(1);
-      auto &channels = results[0];
-      channels.resize(numChannels);
+      results.resize(numChannels);
+      for (size_t c = 0; c < numChannels; ++c)
+         results[c] = trackFactory->Create(format, rate);
 
-      {
-         // iter not used outside this scope.
-         auto iter = channels.begin();
-         for (decltype(numChannels) c = 0; c < numChannels; ++iter, ++c)
-            *iter = trackFactory->Create(format, rate);
-      }
-      const auto firstChannel = channels.begin()->get();
-      auto maxBlockSize = firstChannel->GetMaxBlockSize();
+      const auto maxBlockSize = results[0]->GetMaxBlockSize();
 
       SampleBuffer srcbuffer(maxBlockSize * numChannels, format);
       SampleBuffer buffer(maxBlockSize, format);
@@ -226,21 +219,23 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
          }
 
          if (block) {
-            auto iter = channels.begin();
-            for(decltype(numChannels) c = 0; c < numChannels; ++iter, ++c) {
-               if (format==int16Sample) {
-                  for(decltype(block) j=0; j<block; j++)
+            size_t c = 0;
+            for (const auto &pChannel : results) {
+               if (format == int16Sample) {
+                  for (decltype(block) j = 0; j < block; ++j)
                      ((short *)buffer.ptr())[j] =
-                     ((short *)srcbuffer.ptr())[numChannels*j+c];
+                     ((short *)srcbuffer.ptr())[numChannels * j + c];
                }
                else {
-                  for(decltype(block) j=0; j<block; j++)
+                  for (decltype(block) j = 0; j < block; ++j)
                      ((float *)buffer.ptr())[j] =
-                     ((float *)srcbuffer.ptr())[numChannels*j+c];
+                     ((float *)srcbuffer.ptr())[numChannels * j + c];
                }
 
-               iter->get()->Append(buffer.ptr(), (format == int16Sample)?int16Sample:floatSample, block,
+               pChannel->Append(buffer.ptr(),
+                  ((format == int16Sample) ? int16Sample : floatSample), block,
                   1, sf_subtype_to_effective_format(encoding));
+               ++c;
             }
             framescompleted += block;
          }
@@ -258,12 +253,8 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
    if (updateResult == ProgressResult::Failed || updateResult == ProgressResult::Cancelled)
       throw UserException{};
 
-   if (!results.empty() && !results[0].empty()) {
-      for (const auto &channel : results[0])
-         channel->NarrowFlush();
-      for (auto &group : results)
-         outTracks.push_back(TrackList::Temporary(nullptr, group));
-   }
+   if (!results.empty())
+      outTracks.push_back(ImportUtils::MakeTracks(results));
 }
 
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.h
@@ -76,6 +76,16 @@ public:
       return mEndSample;
    }
 
+   long long GetCorrectedStartSample() const {
+      // Correct the start of range so that the first full window is
+      // centered at that position
+      return std::max<long long>(0, GetStartSample() - 2 * GetHopSize());
+   }
+
+   long long GetLength() const {
+      return GetEndSample() - GetCorrectedStartSample();
+   }
+
    // The double time points is quantized into long long
    void addHopBinData(int hopNum, int freqBin){
       // Update the start and end sampleCount of current selection


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Depends on:
- #4974

The next transformation calls Flush() after appending on leader tracks only.

This eliminates only one call to TrackList::Channels outside WaveTrack.cpp
(in Generator.cpp) but also eliminates many loops over channels in Import,
where those channels were not yet grouped into TrackLists.

However the work is incomplete because some exception safety guarantee
must still be implemented to maintain consistency of pairs of channels, as
in the case of exhausting drive space while recording.

The title of this branch suggests that rewriting of the appending before flushing
will be needed too, but this isn't done yet.

QA:  For each of these operations, make a stereo track, save the project, reopen, and don't see mismatched clip end times:
- [x] Recording
- [x] Mix and render
- [x] At least one built-in generator (e.g. Chirp)
- [x] Importing with FFmpeg, FLAC, MP3_MPG123, OGG, WAV, WavPack, Import Raw
- [x] Effects:  Change Speed, EQ (just test one UI), Silence generator, Paulstretch, Change Tempo (high quality and low), Stereo To Mono, Compressor, and any one Nyquist effect or generator

Also:
- [x] Benchmark diagnostic

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
