### PR TITLE
Windows: New export dialog: initial focus is not the first control

### DIFF
--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -218,6 +218,19 @@ ExportAudioDialog::ExportAudioDialog(wxWindow* parent,
 
 ExportAudioDialog::~ExportAudioDialog() = default;
 
+// Fix for issue #4960, which only affects Windows
+bool ExportAudioDialog::Show(bool show)
+{
+   bool ret = wxDialogWrapper::Show(show);
+
+#if defined(__WXMSW__) 
+   if (show)
+      mExportOptionsPanel->SetInitialFocus();
+#endif
+
+   return ret;
+}
+
 void ExportAudioDialog::PopulateOrExchange(ShuttleGui& S)
 {
    S.SetBorder(5);

--- a/src/export/ExportAudioDialog.h
+++ b/src/export/ExportAudioDialog.h
@@ -57,6 +57,8 @@ public:
                      const wxString& defaultName,
                      const wxString& defaultFormat);
    ~ExportAudioDialog() override;
+
+   bool Show(bool show = true) override;
 private:
    
    void PopulateOrExchange(ShuttleGui& S);

--- a/src/export/ExportFilePanel.cpp
+++ b/src/export/ExportFilePanel.cpp
@@ -293,6 +293,13 @@ void ExportFilePanel::Init(const wxFileName& filename,
       mCustomizeChannels->Enable(mCustomMapping->GetValue());
 }
 
+// Used as part of fix for issue #4960
+void ExportFilePanel::SetInitialFocus()
+{
+   mFullName->SetFocus();
+   mFullName->SelectAll();
+}
+
 void ExportFilePanel::SetCustomMappingEnabled(bool enabled)
 {
    if(mMonoStereoMode)

--- a/src/export/ExportFilePanel.h
+++ b/src/export/ExportFilePanel.h
@@ -53,6 +53,7 @@ public:
              int channels = 0,
              const ExportProcessor::Parameters& parameters = {},
              const MixerOptions::Downmix* mixerSpec = nullptr);
+   void SetInitialFocus();
 
    void SetCustomMappingEnabled(bool enabled);
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4960

Problem:
This appears to be caused by a bug in wxWidgets 3.1.3, and only affects Windows. Issue #1561 is probably caused by the same bug.

Fix:
For Windows only, explicitly set the initial focus.




<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
