### PR TITLE
New Export Audio dialog: missing accessibility names

### DIFF
--- a/modules/mod-ffmpeg/ExportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ExportFFmpeg.cpp
@@ -422,9 +422,11 @@ public:
             S.StartMultiColumn(2, wxCENTER);
             {
                S.AddPrompt(XXO("Current Format:"));
-               mFormat = S.Style(wxTE_READONLY).AddTextBox({}, wxT(""), 25);
+               mFormat = S.Name(XXO("Current Format:"))
+                  .Style(wxTE_READONLY).AddTextBox({}, wxT(""), 25);
                S.AddPrompt(XXO("Current Codec:"));
-               mCodec = S.Style(wxTE_READONLY).AddTextBox({}, wxT(""), 25);
+               mCodec = S.Name(XXO("Current Codec:"))
+                  .Style(wxTE_READONLY).AddTextBox({}, wxT(""), 25);
             }
             S.EndMultiColumn();
          }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4955

Problem:
In the Export Audio dialog, if the format is set to Custom FFmpeg Export, then the Current format and Curren Codec text boxes have empty accessibility names.

Fix:
Set the accessibility names.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
