### PR TITLE
Selection toolbar: Window IDs of time controls

### DIFF
--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -101,6 +101,13 @@ std::pair<const TranslatableString&, const TranslatableString&> ModeNames[] = {
    { LengthTimeText, CenterTimeText },
 };
 
+std::unordered_map<TranslatableString, wxWindowID> WindowIDs {
+   { StartTimeText, 2705 },
+   { LengthTimeText, 2706 },
+   { CenterTimeText, 2707 },
+   { EndTimeText, 2708 }
+};
+
 const NumericConverterType TimeConverterType[][2] {
    { NumericConverterType_TIME(), NumericConverterType_TIME() },
    { NumericConverterType_TIME(), NumericConverterType_DURATION() },
@@ -514,14 +521,18 @@ void SelectionBar::SetSelectionMode(SelectionMode mode)
 {
    mSelectionMode = mode;
 
-   // Update names for the screen readers
+   // Update names and WindowIds for the screen readers
    auto& modeName = ModeNames[static_cast<size_t>(mode)];
 
-   if (mTimeControls[0])
+   if (mTimeControls[0]) {
       mTimeControls[0]->SetName(modeName.first);
+      mTimeControls[0]->SetId(WindowIDs.at(modeName.first));
+   }
 
-   if (mTimeControls[1])
+   if (mTimeControls[1]) {
       mTimeControls[1]->SetName(modeName.second);
+      mTimeControls[1]->SetId(WindowIDs.at(modeName.second));
+   }
 
    UpdateTimeControlsFormat(mTimeControls[0]->GetFormatName());
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4988

Prior to Audacity 3.3.0 the time controls in the Selection toolbar had Window IDs which were used by scripts for both the Jaws and NVDA screen readers. There were different IDs for each of start, length, center and end. These IDS were ommitted in Audacity 3.3.0

Fix:
Set the Window IDs for these controls

Resolves: https://github.com/audacity/audacity/issues/4988


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
