### PR TITLE
Channel iteration rewrites

### DIFF
--- a/libraries/lib-effects/MixAndRender.cpp
+++ b/libraries/lib-effects/MixAndRender.cpp
@@ -96,7 +96,9 @@ TrackListHolder MixAndRender(const TrackIterRange<const WaveTrack> &trackRange,
    // only one input track (either 1 mono or one linked stereo pair)
 
    // EmptyCopy carries over any interesting channel group information
-   // But make sure the left is unlinked before we re-link
+   // Maybe first is stereo, or it is mono, but some other input is stereo;
+   // therefore don't use WideEmptyCopy, but make and link a right channel as
+   // needed
    // And reset pan and gain
    auto mixLeft =
       first->EmptyCopy(trackFactory->GetSampleBlockFactory(), false);

--- a/libraries/lib-effects/PerTrackEffect.h
+++ b/libraries/lib-effects/PerTrackEffect.h
@@ -87,7 +87,7 @@ private:
       const Factory &factory, EffectSettings &settings,
       AudioGraph::Source &source, AudioGraph::Sink &sink,
       std::optional<sampleCount> genLength,
-      double sampleRate, const SampleTrack &track, const SampleTrack &leader,
+      double sampleRate, const SampleTrack &leader,
       Buffers &inBuffers, Buffers &outBuffers);
 };
 #endif

--- a/libraries/lib-mixer/AudioIOSequences.h
+++ b/libraries/lib-mixer/AudioIOSequences.h
@@ -18,7 +18,10 @@
  Extends the interface for random access into a sample stream with tests for
  muting and solo
  */
-struct MIXER_API PlayableSequence : WideSampleSequence {
+struct MIXER_API PlayableSequence
+   // TODO wide wave tracks -- remove virtual
+   : virtual WideSampleSequence
+{
    ~PlayableSequence() override;
 
    virtual bool IsLeader() const = 0; //!< To be removed

--- a/libraries/lib-sample-track/SampleTrack.h
+++ b/libraries/lib-sample-track/SampleTrack.h
@@ -66,7 +66,7 @@ ENUMERATE_TRACK_TYPE(SampleTrack)
 
 class SAMPLE_TRACK_API WritableSampleTrack /* not final */
    : public SampleTrack
-   , public RecordableSequence
+   , public virtual RecordableSequence
 {
 public:
    WritableSampleTrack();

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -887,7 +887,7 @@ void WaveClip::SetRate(int rate)
 {
    const auto trimLeftSampleNum = TimeToSamples(mTrimLeft);
    const auto trimRightSampleNum = TimeToSamples(mTrimRight);
-   auto ratio = mRate / rate;
+   auto ratio = static_cast<double>(mRate) / rate;
    mRate = rate;
    mTrimLeft = SamplesToTime(trimLeftSampleNum);
    mTrimRight = SamplesToTime(trimRightSampleNum);

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2197,7 +2197,7 @@ double WaveTrack::GetEndTime() const
 // expressed relative to t=0.0 at the track's sample rate.
 //
 
-std::pair<float, float> WaveTrack::GetMinMax(
+std::pair<float, float> WaveChannel::GetMinMax(
    double t0, double t1, bool mayThrow) const
 {
    std::pair<float, float> results {
@@ -2215,7 +2215,7 @@ std::pair<float, float> WaveTrack::GetMinMax(
    if (t0 == t1)
       return results;
 
-   for (const auto &clip: mClips)
+   for (const auto &clip: GetTrack().mClips)
    {
       if (t1 >= clip->GetPlayStartTime() && t0 <= clip->GetPlayEndTime())
       {
@@ -2237,7 +2237,7 @@ std::pair<float, float> WaveTrack::GetMinMax(
    return results;
 }
 
-float WaveTrack::GetRMS(double t0, double t1, bool mayThrow) const
+float WaveChannel::GetRMS(double t0, double t1, bool mayThrow) const
 {
    if (t0 > t1) {
       if (mayThrow)
@@ -2251,7 +2251,7 @@ float WaveTrack::GetRMS(double t0, double t1, bool mayThrow) const
    double sumsq = 0.0;
    sampleCount length = 0;
 
-   for (const auto &clip: mClips)
+   for (const auto &clip: GetTrack().mClips)
    {
       // If t1 == clip->GetStartTime() or t0 == clip->GetEndTime(), then the clip
       // is not inside the selection, so we don't want it.
@@ -2463,10 +2463,10 @@ ChannelSampleView WaveTrack::GetOneSampleView(
 }
 
 /*! @excsafety{Weak} */
-void WaveTrack::Set(constSamplePtr buffer, sampleFormat format,
+void WaveChannel::Set(constSamplePtr buffer, sampleFormat format,
    sampleCount start, size_t len, sampleFormat effectiveFormat)
 {
-   for (const auto &clip: mClips)
+   for (const auto &clip: GetTrack().mClips)
    {
       auto clipStart = clip->GetPlayStartSample();
       auto clipEnd = clip->GetPlayEndSample();

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -198,6 +198,8 @@ Track::LinkType ToLinkType(int value)
 
 static auto DefaultName = XO("Audio");
 
+WaveChannel::~WaveChannel() = default;
+
 wxString WaveTrack::GetDefaultAudioTrackNamePreference()
 {
    const auto name = AudioTrackNameSetting.ReadWithDefault(L"");

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1884,11 +1884,11 @@ void WaveTrack::JoinOne(WaveTrack &track, double t0, double t1)
 /*! @excsafety{Partial}
 -- Some prefix (maybe none) of the buffer is appended,
 and no content already flushed to disk is lost. */
-bool WaveTrack::Append(constSamplePtr buffer, sampleFormat format,
+bool WaveChannel::Append(constSamplePtr buffer, sampleFormat format,
    size_t len, unsigned int stride, sampleFormat effectiveFormat)
 {
    constSamplePtr buffers[]{ buffer };
-   return RightmostOrNewClip()
+   return GetTrack().RightmostOrNewClip()
       ->Append(buffers, format, len, stride, effectiveFormat);
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -310,7 +310,7 @@ void WaveTrack::Reinit(const WaveTrack &orig)
       pChannel->Init(**iter);
 
       // Copy attached data from orig.  Nullify data in this where orig had null.
-      Attachments &attachments = *pChannel;
+      SampleTrack::Attachments &attachments = *pChannel;
       attachments = **iter;
       ++iter;
    }
@@ -320,7 +320,7 @@ void WaveTrack::Merge(const Track &orig)
 {
    orig.TypeSwitch( [&](const WaveTrack &wt) {
       // Copy attached data from orig.  Nullify data in this where orig had null.
-      Attachments &attachments = *this;
+      SampleTrack::Attachments &attachments = *this;
       attachments = wt;
    });
 }

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -60,12 +60,23 @@ class WAVE_TRACK_API WaveChannel
    : public Channel
    // TODO wide wave tracks -- remove "virtual"
    , public virtual WideSampleSequence
+   , public virtual RecordableSequence
 {
 public:
    ~WaveChannel() override;
 
    inline WaveTrack &GetTrack();
    inline const WaveTrack &GetTrack() const;
+
+   /*!
+    If there is an existing WaveClip in the WaveTrack that owns the channel,
+    then the data are appended to that clip. If there are no WaveClips in the
+    track, then a new one is created.
+    @return true if at least one complete block was created
+    */
+   bool Append(constSamplePtr buffer, sampleFormat format,
+      size_t len, unsigned int stride = 1,
+      sampleFormat effectiveFormat = widestSampleFormat) override;
 };
 
 class WAVE_TRACK_API WaveTrack final
@@ -328,16 +339,6 @@ private:
     * false otherwise.
     */
    bool IsEmpty(double t0, double t1) const;
-
-   /*!
-    If there is an existing WaveClip in the WaveTrack then the data are
-    appended to that clip. If there are no WaveClips in the track, then a new
-    one is created.
-    @return true if at least one complete block was created
-    */
-   bool Append(constSamplePtr buffer, sampleFormat format,
-      size_t len, unsigned int stride = 1,
-      sampleFormat effectiveFormat = widestSampleFormat) override;
 
    void Flush() override;
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -53,10 +53,20 @@ using ChannelSampleView = std::vector<AudioSegmentSampleView>;
 #define WAVETRACK_MERGE_POINT_TOLERANCE 0.01
 
 class Envelope;
+class WaveTrack;
+
+class WAVE_TRACK_API WaveChannel : public Channel
+{
+public:
+   ~WaveChannel() override;
+
+   inline WaveTrack &GetTrack();
+   inline const WaveTrack &GetTrack() const;
+};
 
 class WAVE_TRACK_API WaveTrack final
    : public WritableSampleTrack
-   , public Channel
+   , public WaveChannel
 {
 public:
    /// \brief Structure to hold region of a wavetrack and a comparison function
@@ -96,6 +106,11 @@ public:
 
    //! May report more than one only when this is a leader track
    size_t NChannels() const override;
+
+   auto Channels() {
+      return this->ChannelGroup::Channels<WaveChannel>(); }
+   auto Channels() const {
+      return this->ChannelGroup::Channels<const WaveChannel>(); }
 
    AudioGraph::ChannelType GetChannelType() const override;
 
@@ -792,6 +807,20 @@ private:
 };
 
 ENUMERATE_TRACK_TYPE(WaveTrack);
+
+WaveTrack &WaveChannel::GetTrack() {
+   auto &result = static_cast<WaveTrack&>(DoGetChannelGroup());
+   // TODO wide wave tracks -- remove assertion
+   assert(&result == this);
+   return result;
+}
+
+const WaveTrack &WaveChannel::GetTrack() const {
+   auto &result = static_cast<const WaveTrack&>(DoGetChannelGroup());
+   // TODO wide wave tracks -- remove assertion
+   assert(&result == this);
+   return result;
+}
 
 #include <unordered_set>
 class SampleBlock;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -271,7 +271,7 @@ private:
    TrackListHolder Cut(double t0, double t1) override;
 
    //! Make another track copying format, rate, color, etc. but containing no
-   //! clips
+   //! clips; and always with a unique channel
    /*!
     It is important to pass the correct factory (that for the project
     which will own the copy) in the unusual case that a track is copied from
@@ -285,7 +285,7 @@ private:
       bool keepLink = true) const;
 
    //! Make another channel group copying format, rate, color, etc. but
-   //! containing no clips
+   //! containing no clips; with as many channels as in `this`
    /*!
     It is important to pass the correct factory (that for the project
     which will own the copy) in the unusual case that a track is copied from

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -16,6 +16,7 @@
 #include "SampleCount.h"
 #include "SampleFormat.h"
 #include "SampleTrack.h"
+#include "WideSampleSequence.h"
 
 #include <vector>
 #include <functional>
@@ -55,7 +56,10 @@ using ChannelSampleView = std::vector<AudioSegmentSampleView>;
 class Envelope;
 class WaveTrack;
 
-class WAVE_TRACK_API WaveChannel : public Channel
+class WAVE_TRACK_API WaveChannel
+   : public Channel
+   // TODO wide wave tracks -- remove "virtual"
+   , public virtual WideSampleSequence
 {
 public:
    ~WaveChannel() override;
@@ -66,6 +70,7 @@ public:
 
 class WAVE_TRACK_API WaveTrack final
    : public WritableSampleTrack
+   // TODO wide wave tracks -- remove this base class
    , public WaveChannel
 {
 public:

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -68,6 +68,18 @@ public:
    inline WaveTrack &GetTrack();
    inline const WaveTrack &GetTrack() const;
 
+   using WideSampleSequence::GetFloats;
+
+   //! "narrow" overload fetches from the unique channel
+   bool GetFloats(float *buffer, sampleCount start, size_t len,
+      fillFormat fill = FillFormat::fillZero, bool mayThrow = true,
+      sampleCount * pNumWithinClips = nullptr) const
+   {
+      constexpr auto backwards = false;
+      return GetFloats(
+         0, 1, &buffer, start, len, backwards, fill, mayThrow, pNumWithinClips);
+   }
+
    /*!
     If there is an existing WaveClip in the WaveTrack that owns the channel,
     then the data are appended to that clip. If there are no WaveClips in the
@@ -85,6 +97,9 @@ class WAVE_TRACK_API WaveTrack final
    , public WaveChannel
 {
 public:
+   // Resolve ambiguous lookup
+   using SampleTrack::GetFloats;
+
    /// \brief Structure to hold region of a wavetrack and a comparison function
    /// for sortability.
    struct Region

--- a/libraries/lib-wave-track/WaveTrackSink.h
+++ b/libraries/lib-wave-track/WaveTrackSink.h
@@ -20,13 +20,14 @@
 #include "SampleFormat.h"
 #include <memory>
 
+class WaveChannel;
 class WaveTrack;
 class TrackList;
 
 class WAVE_TRACK_API WaveTrackSink final : public AudioGraph::Sink {
 public:
-   WaveTrackSink(WaveTrack &left, WaveTrack *pRight,
-      sampleCount start, bool isGenerator, bool isProcessor,
+   WaveTrackSink(WaveChannel &left, WaveChannel *pRight,
+      WaveTrack *pGenerated, sampleCount start, bool isProcessor,
       //! This argument affects processors only, not generators
       sampleFormat effectiveFormat);
    ~WaveTrackSink() override;
@@ -39,9 +40,8 @@ public:
 
    /*!
     @copydoc DoConsume
-    @return accumulated data from all calls to Release
     */
-   std::shared_ptr<TrackList> Flush(Buffers &data);
+   void Flush(Buffers &data);
 
 private:
    /*!
@@ -50,10 +50,11 @@ private:
     */
    void DoConsume(Buffers &data);
 
-   WaveTrack &mLeft;
-   WaveTrack *const mpRight;
-   const std::shared_ptr<WaveTrack> mGenLeft, mGenRight;
-   const std::shared_ptr<TrackList> mList;
+   WaveChannel &mLeft;
+   WaveChannel *const mpRight;
+   WaveTrack *const mpGenerated;
+   WaveChannel *const mGenLeft;
+   WaveChannel *const mGenRight;
    const bool mIsProcessor;
    const sampleFormat mEffectiveFormat;
 

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -339,14 +339,14 @@ WaveTrack *MixerTrackCluster::GetWave() const
    return dynamic_cast< WaveTrack * >( mTrack.get() );
 }
 
-WaveTrack *MixerTrackCluster::GetRight() const
+WaveChannel *MixerTrackCluster::GetRight() const
 {
   // TODO: more-than-two-channels
    auto left = GetWave();
    if (left) {
-      auto channels = TrackList::Channels(left);
-      if ( channels.size() > 1 )
-         return * ++ channels.first;
+      auto channels = left->Channels();
+      if (channels.size() > 1)
+         return (* ++ channels.first).get();
    }
    return nullptr;
 }

--- a/src/MixerBoard.h
+++ b/src/MixerBoard.h
@@ -71,6 +71,7 @@ class NoteTrack;
 #endif
 class PlayableTrack;
 
+class WaveChannel;
 class WaveTrack;
 class auStaticText;
 
@@ -85,7 +86,7 @@ public:
    virtual ~MixerTrackCluster() {}
 
    WaveTrack *GetWave() const;
-   WaveTrack *GetRight() const;
+   WaveChannel *GetRight() const;
 #ifdef EXPERIMENTAL_MIDI_OUT
    NoteTrack *GetNote() const;
 #endif

--- a/src/SpectralDataManager.h
+++ b/src/SpectralDataManager.h
@@ -17,16 +17,15 @@
 #include "Effect.h"
 #include "tracks/playabletrack/wavetrack/ui/SpectrumView.h"
 
+class WaveChannel;
+
 class SpectralDataManager{
 public:
    SpectralDataManager();
    ~SpectralDataManager();
    static bool ProcessTracks(AudacityProject &project);
-   static int FindFrequencySnappingBin(WaveTrack *wt,
-                                  long long startSC,
-                                  int hopSize,
-                                  double threshold,
-                                  int targetFreqBin);
+   static int FindFrequencySnappingBin(const WaveChannel &channel,
+      long long startSC, int hopSize, double threshold, int targetFreqBin);
 
    static std::vector<int> FindHighestFrequencyBins(WaveTrack *wt,
                                           long long int startSC,
@@ -41,9 +40,8 @@ private:
 class SpectralDataManager::Worker
       : public TrackSpectrumTransformer{
 public:
-   Worker(const Setting &setting);
+   Worker(WaveChannel *pChannel, const Setting &setting);
    ~Worker();
-   using TrackSpectrumTransformer::mOutputTrack;
 
    struct MyWindow : public Window
    {
@@ -60,11 +58,14 @@ public:
       FloatVector mGains;
    };
 
-   bool Process(WaveTrack* wt, const std::shared_ptr<SpectralData> &sDataPtr);
-   int ProcessSnapping(WaveTrack *wt, long long int startSC, int hopSize, size_t winSize,
-                           double threshold, int targetFreqBin);
-   std::vector<int> ProcessOvertones(WaveTrack *wt, long long int startSC, int hopSize, size_t winSize,
-                       double threshold, int targetFreqBin);
+   bool Process(const WaveChannel &channel,
+      const std::shared_ptr<SpectralData> &sDataPtr);
+   int ProcessSnapping(const WaveChannel &channel,
+      long long int startSC, int hopSize, size_t winSize,
+      double threshold, int targetFreqBin);
+   std::vector<int> ProcessOvertones(const WaveChannel &channel,
+      long long int startSC, int hopSize, size_t winSize,
+      double threshold, int targetFreqBin);
 
 protected:
    MyWindow &NthWindow(int nn) {

--- a/src/SpectrumTransformer.cpp
+++ b/src/SpectrumTransformer.cpp
@@ -339,18 +339,15 @@ bool SpectrumTransformer::QueueIsFull() const
 }
 
 bool TrackSpectrumTransformer::Process(const WindowProcessor &processor,
-   const WaveTrack *track, size_t queueLength, sampleCount start,
+   const WaveChannel &channel, size_t queueLength, sampleCount start,
    sampleCount len)
 {
-   if (!track)
-      return false;
-
-   mpTrack = track;
+   mpChannel = &channel;
 
    if (!Start(queueLength))
       return false;
 
-   auto bufferSize = track->GetMaxBlockSize();
+   auto bufferSize = channel.GetMaxBlockSize();
    FloatVector buffer(bufferSize);
 
    bool bLoopSuccess = true;
@@ -358,11 +355,11 @@ bool TrackSpectrumTransformer::Process(const WindowProcessor &processor,
    while (bLoopSuccess && samplePos < start + len) {
       //Get a blockSize of samples (smaller than the size of the buffer)
       const auto blockSize = limitSampleBufferSize(
-         std::min(bufferSize, track->GetBestBlockSize(samplePos)),
+         std::min(bufferSize, channel.GetBestBlockSize(samplePos)),
          start + len - samplePos);
 
       //Get the samples from the track and put them in the buffer
-      track->GetFloats(buffer.data(), samplePos, blockSize);
+      channel.GetFloats(buffer.data(), samplePos, blockSize);
       samplePos += blockSize;
       bLoopSuccess = ProcessSamples(processor, buffer.data(), blockSize);
    }
@@ -398,6 +395,5 @@ TrackSpectrumTransformer::~TrackSpectrumTransformer() = default;
 
 bool TrackSpectrumTransformer::DoStart()
 {
-   mOutputTrack = NeedsOutput() && mpTrack ? mpTrack->EmptyCopy() : nullptr;
    return SpectrumTransformer::DoStart();
 }

--- a/src/SpectrumTransformer.h
+++ b/src/SpectrumTransformer.h
@@ -21,6 +21,8 @@ Paul Licameli
 
 enum eWindowFunctions : int;
 
+class WaveChannel;
+
 /*!
  @brief A class that transforms a portion of a wave track (preserving duration)
  by applying Fourier transform, then modifying coefficients, then inverse
@@ -183,11 +185,26 @@ class WaveTrack;
 //! Subclass of SpectrumTransformer that rewrites a track
 class TrackSpectrumTransformer /* not final */ : public SpectrumTransformer {
 public:
-   using SpectrumTransformer::SpectrumTransformer;
+   /*!
+    @copydoc SpectrumTransformer::SpectrumTransformer(bool,
+       eWindowFunctions, eWindowFunctions, size_t, unsigned, bool, bool)
+    @pre `!needsOutput || pOutputTrack != nullptr`
+    */
+   TrackSpectrumTransformer(WaveChannel *pOutputTrack,
+      bool needsOutput, eWindowFunctions inWindowType,
+      eWindowFunctions outWindowType, size_t windowSize,
+      unsigned stepsPerWindow, bool leadingPadding, bool trailingPadding
+   )  : SpectrumTransformer{ needsOutput, inWindowType, outWindowType,
+         windowSize, stepsPerWindow, leadingPadding, trailingPadding
+      }
+      , mOutputTrack{ pOutputTrack }
+   {
+      assert(!needsOutput || pOutputTrack != nullptr);
+   }
    ~TrackSpectrumTransformer() override;
 
    //! Invokes Start(), ProcessSamples(), and Finish()
-   bool Process(const WindowProcessor &processor, const WaveTrack *track,
+   bool Process(const WindowProcessor &processor, const WaveChannel &channel,
       size_t queueLength, sampleCount start, sampleCount len);
 
    //! Final flush and trimming of tail samples
@@ -201,9 +218,9 @@ protected:
    void DoOutput(const float *outBuffer, size_t mStepSize) override;
    bool DoFinish() override;
 
-   std::shared_ptr<WaveTrack> mOutputTrack;
 private:
-   const WaveTrack *mpTrack = nullptr;
+   WaveChannel *const mOutputTrack;
+   const WaveChannel *mpChannel = nullptr;
 };
 
 #endif

--- a/src/commands/CompareAudioCommand.cpp
+++ b/src/commands/CompareAudioCommand.cpp
@@ -138,8 +138,8 @@ bool CompareAudioCommand::Apply(const CommandContext & context)
    // Compare tracks block by block
    auto s0 = mTrack0->TimeToLongSamples(mT0);
    auto s1 = mTrack0->TimeToLongSamples(mT1);
-   const auto channels0 = TrackList::Channels(mTrack0);
-   auto iter = TrackList::Channels(mTrack1).begin();
+   const auto channels0 = mTrack0->Channels();
+   auto iter = mTrack1->Channels().begin();
    for (const auto pChannel0 : channels0) {
       const auto pChannel1 = *iter++;
       auto position = s0;
@@ -153,12 +153,8 @@ bool CompareAudioCommand::Apply(const CommandContext & context)
          pChannel1->GetFloats(buff1.get(), position, block);
 
          for (decltype(block) buffPos = 0; buffPos < block; ++buffPos)
-         {
             if (CompareSample(buff0[buffPos], buff1[buffPos]) > errorThreshold)
-            {
                ++errorCount;
-            }
-         }
 
          position += block;
          context.Progress(

--- a/src/effects/Amplify.cpp
+++ b/src/effects/Amplify.cpp
@@ -183,7 +183,7 @@ bool EffectAmplify::Init()
 {
    mPeak = 0.0;
    for (auto t : inputTracks()->Selected<const WaveTrack>()) {
-      for (const auto pChannel : TrackList::Channels(t)) {
+      for (const auto pChannel : t->Channels()) {
          auto pair = pChannel->GetMinMax(mT0, mT1); // may throw
          const float min = pair.first, max = pair.second;
          const float newpeak = std::max(fabs(min), fabs(max));

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -306,7 +306,7 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
       int trackNum = 0;
 
       for (auto iterTrack : outputs.Get().Selected<WaveTrack>()) {
-         for (const auto pChannel : TrackList::Channels(iterTrack))
+         for (const auto pChannel : iterTrack->Channels())
             for (size_t i = 0; i < regions.size(); ++i) {
                const AutoDuckRegion& region = regions[i];
                if (ApplyDuckFade(trackNum++, *pChannel, region.t0, region.t1)) {
@@ -434,7 +434,7 @@ bool EffectAutoDuck::TransferDataFromWindow(EffectSettings &)
 // EffectAutoDuck implementation
 
 // this currently does an exponential fade
-bool EffectAutoDuck::ApplyDuckFade(int trackNum, WaveTrack &track,
+bool EffectAutoDuck::ApplyDuckFade(int trackNum, WaveChannel &track,
    double t0, double t1)
 {
    bool cancel = false;

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -19,6 +19,7 @@
 class wxBitmap;
 class wxTextCtrl;
 class ShuttleGui;
+class WaveChannel;
 
 #define AUTO_DUCK_PANEL_NUM_CONTROL_POINTS 5
 
@@ -56,7 +57,7 @@ public:
 private:
    // EffectAutoDuck implementation
 
-   bool ApplyDuckFade(int trackNum, WaveTrack &track, double t0, double t1);
+   bool ApplyDuckFade(int trackNum, WaveChannel &track, double t0, double t1);
 
    void OnValueChanged(wxCommandEvent & evt);
 

--- a/src/effects/ChangeSpeed.h
+++ b/src/effects/ChangeSpeed.h
@@ -23,6 +23,7 @@ class wxTextCtrl;
 class LabelTrack;
 class NumericTextCtrl;
 class ShuttleGui;
+class WaveChannel;
 
 class EffectChangeSpeed final : public StatefulEffect
 {
@@ -66,8 +67,8 @@ private:
    Gaps FindGaps(
       const WaveTrack &track, const double curT0, const double curT1);
 
-   std::shared_ptr<WaveTrack> ProcessOne(
-      const WaveTrack &t, sampleCount start, sampleCount end);
+   bool ProcessOne(const WaveChannel &track, WaveChannel &outputTrack,
+      sampleCount start, sampleCount end);
    bool ProcessLabelTrack(LabelTrack *t);
 
    // handlers

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -128,7 +128,7 @@ bool EffectClickRemoval::Process(EffectInstance &, EffectSettings &)
          auto start = track->TimeToLongSamples(t0);
          auto end = track->TimeToLongSamples(t1);
          auto len = end - start;
-         for (const auto pChannel : TrackList::Channels(track))
+         for (const auto pChannel : track->Channels())
             if (!ProcessOne(count++, *pChannel, start, len)) {
                bGoodResult = false;
                goto done;
@@ -148,7 +148,7 @@ bool EffectClickRemoval::Process(EffectInstance &, EffectSettings &)
 }
 
 bool EffectClickRemoval::ProcessOne(
-   int count, WaveTrack &track, sampleCount start, sampleCount len)
+   int count, WaveChannel &track, sampleCount start, sampleCount len)
 {
    if (len <= windowSize / 2) {
       EffectUIServices::DoMessageBox(*this,

--- a/src/effects/ClickRemoval.h
+++ b/src/effects/ClickRemoval.h
@@ -24,6 +24,7 @@ class wxSlider;
 class wxTextCtrl;
 class Envelope;
 class ShuttleGui;
+class WaveChannel;
 
 class EffectClickRemoval final : public StatefulEffect
 {
@@ -56,7 +57,7 @@ public:
    bool TransferDataFromWindow(EffectSettings &settings) override;
 
 private:
-   bool ProcessOne(int count, WaveTrack &track,
+   bool ProcessOne(int count, WaveChannel &track,
       sampleCount start, sampleCount len);
 
    bool RemoveClicks(size_t len, float *buffer);

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -82,7 +82,7 @@ bool ContrastDialog::GetDB(float &dB)
    }
 
    const auto first = *range.begin();
-   const auto channels = TrackList::Channels(first);
+   const auto channels = first->Channels();
    assert(mT0 <= mT1);
    // Ignore whitespace beyond ends of track.
    mT0 = std::max(mT0, first->GetStartTime());

--- a/src/effects/Equalization.h
+++ b/src/effects/Equalization.h
@@ -17,6 +17,8 @@
 #include "StatefulEffect.h"
 #include "EqualizationUI.h"
 
+class WaveChannel;
+
 class EffectEqualization : public StatefulEffect
 {
 public:
@@ -67,7 +69,7 @@ private:
    // EffectEqualization implementation
 
    struct Task;
-   bool ProcessOne(Task &task, int count, const WaveTrack &t,
+   bool ProcessOne(Task &task, int count, const WaveChannel &t,
       sampleCount start, sampleCount len);
    
    wxWeakRef<wxWindow> mUIParent{};

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -109,7 +109,7 @@ bool EffectFindClipping::Process(EffectInstance &, EffectSettings &)
          auto end = t->TimeToLongSamples(t1);
          auto len = end - start;
 
-         for (const auto pChannel : TrackList::Channels(t))
+         for (const auto pChannel : t->Channels())
             if (!ProcessOne(*lt, count++, *pChannel, start, len))
                return false;
       }
@@ -124,7 +124,7 @@ bool EffectFindClipping::Process(EffectInstance &, EffectSettings &)
 }
 
 bool EffectFindClipping::ProcessOne(LabelTrack &lt,
-   int count, const WaveTrack &wt, sampleCount start, sampleCount len)
+   int count, const WaveChannel &wt, sampleCount start, sampleCount len)
 {
    bool bGoodResult = true;
    size_t blockSize = (mStart * 1000);

--- a/src/effects/FindClipping.h
+++ b/src/effects/FindClipping.h
@@ -15,6 +15,7 @@
 class wxString;
 
 class LabelTrack;
+class WaveChannel;
 
 #include "StatefulEffect.h"
 #include "ShuttleAutomation.h"
@@ -54,7 +55,7 @@ public:
 private:
    // EffectFindCliping implementation
 
-   bool ProcessOne(LabelTrack &lt, int count, const WaveTrack &wt,
+   bool ProcessOne(LabelTrack &lt, int count, const WaveChannel &wt,
       sampleCount start, sampleCount len);
 
    wxWeakRef<wxWindow> mUIParent{};

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -58,13 +58,8 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
          }
 
          if (duration > 0.0) {
-            auto list = TrackList::Create(nullptr);
-            for (const auto pChannel : TrackList::Channels(&track)) {
-               // Create a temporary track
-               auto tmp = pChannel->EmptyCopy();
-               list->Add(tmp);
-               assert(tmp->IsLeader() == pChannel->IsLeader());
-            }
+            // Create a temporary track
+            auto list = track.WideEmptyCopy();
             // Fill with data
             if (!GenerateTrack(settings, *list))
                bGoodResult = false;

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -26,6 +26,7 @@ class wxChoice;
 class wxSimplebook;
 class EBUR128;
 class ShuttleGui;
+class WaveChannel;
 using Floats = ArrayOf<float>;
 
 class EffectLoudness final : public StatefulEffect
@@ -69,15 +70,15 @@ private:
 
    void AllocBuffers(TrackList &outputs);
    void FreeBuffers();
-   static bool GetTrackRMS(WaveTrack &track,
+   static bool GetTrackRMS(WaveChannel &track,
       double curT0, double curT1, float &rms);
-   bool ProcessOne(WaveTrack &track, size_t nChannels,
+   bool ProcessOne(WaveChannel &track, size_t nChannels,
       double curT0, double curT1, float mult, EBUR128 *pLoudnessProcessor);
-   void LoadBufferBlock(WaveTrack &track, size_t nChannels,
+   void LoadBufferBlock(WaveChannel &track, size_t nChannels,
       sampleCount pos, size_t len);
    bool AnalyseBufferBlock(EBUR128 &loudnessProcessor);
    bool ProcessBufferBlock(float mult);
-   void StoreBufferBlock(WaveTrack &track, size_t nChannels,
+   void StoreBufferBlock(WaveChannel &track, size_t nChannels,
       sampleCount pos, size_t len);
 
    bool UpdateProgress();

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -218,6 +218,8 @@ public:
 
    size_t WindowSize() const { return 1u << (3 + mWindowSizeChoice); }
    unsigned StepsPerWindow() const { return 1u << (1 + mStepsPerWindowChoice); }
+   size_t SpectrumSize() const { return 1 + WindowSize() / 2; }
+   size_t StepSize() const { return WindowSize() / StepsPerWindow(); }
 
    bool      mDoProfile;
 
@@ -249,27 +251,19 @@ EffectNoiseReduction::Settings::Settings()
    PrefsIO(true);
 }
 
-//----------------------------------------------------------------------------
-// EffectNoiseReduction::Worker
-//----------------------------------------------------------------------------
-
-// This object holds information needed only during effect calculation
-class EffectNoiseReduction::Worker final
-   : public TrackSpectrumTransformer
-{
-public:
-   typedef EffectNoiseReduction::Settings Settings;
-   typedef  EffectNoiseReduction::Statistics Statistics;
-
-   Worker(eWindowFunctions inWindowType, eWindowFunctions outWindowType,
-      EffectNoiseReduction &effect, const Settings &settings,
-      Statistics &statistics
-#ifdef EXPERIMENTAL_SPECTRAL_EDITING
-      , double f0, double f1
-#endif
-      );
-   ~Worker();
-
+struct MyTransformer : TrackSpectrumTransformer {
+   MyTransformer(EffectNoiseReduction::Worker &worker,
+      WaveChannel *pOutputTrack,
+      bool needsOutput, eWindowFunctions inWindowType,
+      eWindowFunctions outWindowType, size_t windowSize,
+      unsigned stepsPerWindow, bool leadingPadding, bool trailingPadding
+   )  : TrackSpectrumTransformer{ pOutputTrack,
+         needsOutput, inWindowType, outWindowType,
+         windowSize, stepsPerWindow, leadingPadding, trailingPadding
+      }
+      , mWorker{ worker }
+   {
+   }
    struct MyWindow : public Window
    {
       explicit MyWindow(size_t windowSize)
@@ -283,27 +277,49 @@ public:
       FloatVector mGains;
    };
 
-   bool Process(TrackList &tracks, double mT0, double mT1);
-
-protected:
    MyWindow &NthWindow(int nn) { return static_cast<MyWindow&>(Nth(nn)); }
    std::unique_ptr<Window> NewWindow(size_t windowSize) override;
    bool DoStart() override;
-   static bool Processor(SpectrumTransformer &transformer);
    bool DoFinish() override;
 
-private:
-   void ApplyFreqSmoothing(FloatVector &gains);
-   void GatherStatistics();
-   inline bool Classify(unsigned nWindows, int band);
-   void ReduceNoise();
-   void FinishTrackStatistics();
+   EffectNoiseReduction::Worker &mWorker;
+};
 
-private:
+//----------------------------------------------------------------------------
+// EffectNoiseReduction::Worker
+//----------------------------------------------------------------------------
+
+// This object holds information needed only during effect calculation
+class EffectNoiseReduction::Worker final
+{
+public:
+   typedef EffectNoiseReduction::Settings Settings;
+   typedef  EffectNoiseReduction::Statistics Statistics;
+
+   Worker(EffectNoiseReduction &effect, const Settings &settings,
+      Statistics &statistics
+#ifdef EXPERIMENTAL_SPECTRAL_EDITING
+      , double f0, double f1
+#endif
+      );
+   ~Worker();
+
+   bool Process(eWindowFunctions inWindowType, eWindowFunctions outWindowType,
+      TrackList &tracks, double mT0, double mT1);
+
+   static bool Processor(SpectrumTransformer &transformer);
+
+   void ApplyFreqSmoothing(FloatVector &gains);
+   void GatherStatistics(MyTransformer &transformer);
+   inline bool Classify(
+      MyTransformer &transformer, unsigned nWindows, int band);
+   void ReduceNoise(MyTransformer &transformer);
+   void FinishTrackStatistics();
 
    const bool mDoProfile;
 
    EffectNoiseReduction &mEffect;
+   const Settings &mSettings;
    Statistics &mStatistics;
 
    FloatVector mFreqSmoothingScratch;
@@ -607,13 +623,13 @@ bool EffectNoiseReduction::Settings::Validate(EffectNoiseReduction *effect) cons
    return true;
 }
 
-auto EffectNoiseReduction::Worker::NewWindow(size_t windowSize)
+auto MyTransformer::NewWindow(size_t windowSize)
    -> std::unique_ptr<Window>
 {
    return std::make_unique<MyWindow>(windowSize);
 }
 
-EffectNoiseReduction::Worker::MyWindow::~MyWindow()
+MyTransformer::MyWindow::~MyWindow()
 {
 }
 
@@ -627,10 +643,13 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
    if (!track)
       return false;
 
+   const auto stepsPerWindow = mSettings->StepsPerWindow();
+   const auto stepSize = mSettings->WindowSize() / stepsPerWindow;
+
    // Initialize statistics if gathering them, or check for mismatched (advanced)
    // settings if reducing noise.
    if (mSettings->mDoProfile) {
-      size_t spectrumSize = 1 + mSettings->WindowSize() / 2;
+      const auto spectrumSize = mSettings->SpectrumSize();
       mStatistics = std::make_unique<Statistics>
          (spectrumSize, track->GetRate(), mSettings->mWindowTypes);
    }
@@ -675,13 +694,13 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
       inWindowType = outWindowType = eWinFuncHann;
       break;
    }
-   Worker worker{ inWindowType, outWindowType,
-      *this, *mSettings, *mStatistics
+   Worker worker{ *this, *mSettings, *mStatistics
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
       , mF0, mF1
 #endif
    };
-   bool bGoodResult = worker.Process(outputs.Get(), mT0, mT1);
+   bool bGoodResult = worker.Process(inWindowType, outWindowType,
+      outputs.Get(), mT0, mT1);
    if (mSettings->mDoProfile) {
       if (bGoodResult)
          mSettings->mDoProfile = false; // So that "repeat last effect" will reduce noise
@@ -699,6 +718,7 @@ EffectNoiseReduction::Worker::~Worker()
 }
 
 bool EffectNoiseReduction::Worker::Process(
+   eWindowFunctions inWindowType, eWindowFunctions outWindowType,
    TrackList &tracks, double inT0, double inT1)
 {
    mProgressTrackCount = 0;
@@ -725,7 +745,8 @@ bool EffectNoiseReduction::Worker::Process(
          auto end = track->TimeToLongSamples(t1);
          const auto len = end - start;
          mLen = len;
-         const auto extra = (mStepsPerWindow - 1) * mStepSize;
+         const auto extra =
+            (mSettings.StepsPerWindow() - 1) * mSettings.SpectrumSize();
          // Adjust denominator for presence or absence of padding,
          // which makes the number of windows visited either more or less
          // than the number of window steps in the data.
@@ -736,22 +757,29 @@ bool EffectNoiseReduction::Worker::Process(
 
          auto t0 = track->LongSamplesToTime(start);
          auto tLen = track->LongSamplesToTime(len);
-         auto tempList = TrackList::Create(nullptr);
-         for (const auto pChannel : TrackList::Channels(track)) {
-            if (!TrackSpectrumTransformer::Process(
-               Processor, pChannel, mHistoryLen, start, len))
+         std::optional<TrackListHolder> ppTempList;
+         std::optional<ChannelGroup::ChannelIterator<WaveChannel>> pIter;
+         WaveTrack *pFirstTrack{};
+         if (!mSettings.mDoProfile) {
+            ppTempList.emplace(track->WideEmptyCopy());
+            pFirstTrack = *(*ppTempList)->Any<WaveTrack>().begin();
+            pIter.emplace(pFirstTrack->Channels().begin());
+         }
+         for (const auto pChannel : track->Channels()) {
+            auto pOutputTrack = pIter ? *(*pIter)++ : nullptr;
+            MyTransformer transformer{ *this, pOutputTrack.get(),
+               !mSettings.mDoProfile, inWindowType, outWindowType,
+               mSettings.WindowSize(), mSettings.StepsPerWindow(),
+               !mSettings.mDoProfile, !mSettings.mDoProfile
+            };
+            if (!transformer
+               .Process(Processor, *pChannel, mHistoryLen, start, len))
                return false;
-            if (mOutputTrack) {
-               tempList->Add(mOutputTrack);
-               assert(mOutputTrack->IsLeader() == pChannel->IsLeader());
-               mOutputTrack.reset();
-            }
             ++mProgressTrackCount;
          }
-         if (tempList->Size()) {
-            const auto pTrack = *tempList->Any<WaveTrack>().begin();
-            TrackSpectrumTransformer::PostProcess(*pTrack, len);
-            track->ClearAndPaste(t0, t0 + tLen, *tempList, true, false);
+         if (ppTempList) {
+            TrackSpectrumTransformer::PostProcess(*pFirstTrack, len);
+            track->ClearAndPaste(t0, t0 + tLen, **ppTempList, true, false);
          }
       }
    }
@@ -776,49 +804,46 @@ void EffectNoiseReduction::Worker::ApplyFreqSmoothing(FloatVector &gains)
    if (mFreqSmoothingBins == 0)
       return;
 
+   const auto spectrumSize = mSettings.SpectrumSize();
+
    {
       auto pScratch = mFreqSmoothingScratch.data();
-      std::fill(pScratch, pScratch + mSpectrumSize, 0.0f);
+      std::fill(pScratch, pScratch + spectrumSize, 0.0f);
    }
 
-   for (size_t ii = 0; ii < mSpectrumSize; ++ii)
+   for (size_t ii = 0; ii < spectrumSize; ++ii)
       gains[ii] = log(gains[ii]);
 
    // ii must be signed
-   for (int ii = 0; ii < (int)mSpectrumSize; ++ii) {
+   for (int ii = 0; ii < (int)spectrumSize; ++ii) {
       const int j0 = std::max(0, ii - (int)mFreqSmoothingBins);
-      const int j1 = std::min(mSpectrumSize - 1, ii + mFreqSmoothingBins);
+      const int j1 = std::min(spectrumSize - 1, ii + mFreqSmoothingBins);
       for(int jj = j0; jj <= j1; ++jj) {
          mFreqSmoothingScratch[ii] += gains[jj];
       }
       mFreqSmoothingScratch[ii] /= (j1 - j0 + 1);
    }
 
-   for (size_t ii = 0; ii < mSpectrumSize; ++ii)
+   for (size_t ii = 0; ii < spectrumSize; ++ii)
       gains[ii] = exp(mFreqSmoothingScratch[ii]);
 }
 
-EffectNoiseReduction::Worker::Worker(eWindowFunctions inWindowType,
-   eWindowFunctions outWindowType,
-   EffectNoiseReduction &effect,
+EffectNoiseReduction::Worker::Worker(EffectNoiseReduction &effect,
    const Settings &settings, Statistics &statistics
 #ifdef EXPERIMENTAL_SPECTRAL_EDITING
    , double f0, double f1
 #endif
 )
-: TrackSpectrumTransformer{ !settings.mDoProfile, inWindowType, outWindowType,
-   settings.WindowSize(), settings.StepsPerWindow(),
-   !settings.mDoProfile, !settings.mDoProfile
-}
-, mDoProfile{ settings.mDoProfile }
+: mDoProfile{ settings.mDoProfile }
 
 , mEffect{ effect }
+, mSettings{ settings }
 , mStatistics{ statistics }
 
-, mFreqSmoothingScratch( mSpectrumSize )
+, mFreqSmoothingScratch(mSettings.SpectrumSize())
 , mFreqSmoothingBins{ size_t(std::max(0.0, settings.mFreqSmoothingBands)) }
 , mBinLow{ 0 }
-, mBinHigh{ mSpectrumSize }
+, mBinHigh{ mSettings.SpectrumSize() }
 
 , mNoiseReductionChoice{ settings.mNoiseReductionChoice }
 , mMethod{ settings.mMethod }
@@ -842,8 +867,10 @@ EffectNoiseReduction::Worker::Worker(eWindowFunctions inWindowType,
 #endif
 
    const double noiseGain = -settings.mNoiseGain;
-   const unsigned nAttackBlocks = 1 + (int)(settings.mAttackTime * sampleRate / mStepSize);
-   const unsigned nReleaseBlocks = 1 + (int)(settings.mReleaseTime * sampleRate / mStepSize);
+   const unsigned nAttackBlocks =
+      1 + (int)(settings.mAttackTime * sampleRate / mSettings.StepSize());
+   const unsigned nReleaseBlocks =
+      1 + (int)(settings.mReleaseTime * sampleRate / mSettings.StepSize());
    // Applies to amplitudes, divide by 20:
    mNoiseAttenFactor = DB_TO_LINEAR(noiseGain);
    // Apply to gain factors which apply to amplitudes, divide by 20:
@@ -853,8 +880,8 @@ EffectNoiseReduction::Worker::Worker(eWindowFunctions inWindowType,
    mOldSensitivityFactor = pow(10.0, settings.mOldSensitivity / 10.0);
 
    mNWindowsToExamine = (mMethod == DM_OLD_METHOD)
-      ? std::max(2, (int)(minSignalTime * sampleRate / mStepSize))
-      : 1 + mStepsPerWindow;
+      ? std::max(2, (int)(minSignalTime * sampleRate / mSettings.StepSize()))
+      : 1 + mSettings.StepsPerWindow();
 
    mCenter = mNWindowsToExamine / 2;
    wxASSERT(mCenter >= 1); // release depends on this assumption
@@ -873,27 +900,29 @@ EffectNoiseReduction::Worker::Worker(eWindowFunctions inWindowType,
    }
 }
 
-bool EffectNoiseReduction::Worker::DoStart()
+bool MyTransformer::DoStart()
 {
    for (size_t ii = 0, nn = TotalQueueSize(); ii < nn; ++ii) {
       MyWindow &record = NthWindow(ii);
       std::fill(record.mSpectrums.begin(), record.mSpectrums.end(), 0.0);
-      std::fill(record.mGains.begin(), record.mGains.end(), mNoiseAttenFactor);
+      std::fill(record.mGains.begin(), record.mGains.end(),
+         mWorker.mNoiseAttenFactor);
    }
    return TrackSpectrumTransformer::DoStart();
 }
 
-bool EffectNoiseReduction::Worker::Processor(SpectrumTransformer &transformer)
+bool EffectNoiseReduction::Worker::Processor(SpectrumTransformer &trans)
 {
-   auto &worker = static_cast<Worker &>(transformer);
+   auto &transformer = static_cast<MyTransformer &>(trans);
+   auto &worker = transformer.mWorker;
    // Compute power spectrum in the newest window
    {
-      MyWindow &record = worker.NthWindow(0);
+      auto &record = transformer.NthWindow(0);
       float *pSpectrum = &record.mSpectrums[0];
       const double dc = record.mRealFFTs[0];
       *pSpectrum++ = dc * dc;
       float *pReal = &record.mRealFFTs[1], *pImag = &record.mImagFFTs[1];
-      for (size_t nn = worker.mSpectrumSize - 2; nn--;) {
+      for (size_t nn = worker.mSettings.SpectrumSize() - 2; nn--;) {
          const double re = *pReal++, im = *pImag++;
          *pSpectrum++ = re * re + im * im;
       }
@@ -902,15 +931,15 @@ bool EffectNoiseReduction::Worker::Processor(SpectrumTransformer &transformer)
    }
 
    if (worker.mDoProfile)
-      worker.GatherStatistics();
+      worker.GatherStatistics(transformer);
    else
-      worker.ReduceNoise();
+      worker.ReduceNoise(transformer);
 
    // Update the Progress meter, let user cancel
    return !worker.mEffect.TrackProgress(worker.mProgressTrackCount,
       std::min(1.0,
-         ((++worker.mProgressWindowCount).as_double() * worker.mStepSize)
-            / worker.mLen.as_double()));
+         ((++worker.mProgressWindowCount).as_double() *
+          worker.mSettings.StepSize()) / worker.mLen.as_double()));
 }
 
 void EffectNoiseReduction::Worker::FinishTrackStatistics()
@@ -934,15 +963,15 @@ void EffectNoiseReduction::Worker::FinishTrackStatistics()
    }
 }
 
-void EffectNoiseReduction::Worker::GatherStatistics()
+void EffectNoiseReduction::Worker::GatherStatistics(MyTransformer &transformer)
 {
    ++mStatistics.mTrackWindows;
 
    {
       // NEW statistics
-      auto pPower = NthWindow(0).mSpectrums.data();
+      auto pPower = transformer.NthWindow(0).mSpectrums.data();
       auto pSum = mStatistics.mSums.data();
-      for (size_t jj = 0; jj < mSpectrumSize; ++jj) {
+      for (size_t jj = 0; jj < mSettings.SpectrumSize(); ++jj) {
          *pSum++ += *pPower++;
       }
    }
@@ -972,7 +1001,8 @@ void EffectNoiseReduction::Worker::GatherStatistics()
 // Return true iff the given band of the "center" window looks like noise.
 // Examine the band in a few neighboring windows to decide.
 inline
-bool EffectNoiseReduction::Worker::Classify(unsigned nWindows, int band)
+bool EffectNoiseReduction::Worker::Classify(
+   MyTransformer &transformer, unsigned nWindows, int band)
 {
    switch (mMethod) {
 #ifdef OLD_METHOD_AVAILABLE
@@ -1006,7 +1036,7 @@ bool EffectNoiseReduction::Worker::Classify(unsigned nWindows, int band)
       {
          float greatest = 0.0, second = 0.0, third = 0.0;
          for (unsigned ii = 0; ii < nWindows; ++ii) {
-            const float power = NthWindow(ii).mSpectrums[band];
+            const float power = transformer.NthWindow(ii).mSpectrums[band];
             if (power >= greatest)
                third = second, second = greatest, greatest = power;
             else if (power >= second)
@@ -1029,7 +1059,7 @@ bool EffectNoiseReduction::Worker::Classify(unsigned nWindows, int band)
          // chimes.
          float greatest = 0.0, second = 0.0;
          for (unsigned ii = 0; ii < nWindows; ++ii) {
-            const float power = NthWindow(ii).mSpectrums[band];
+            const float power = transformer.NthWindow(ii).mSpectrums[band];
             if (power >= greatest)
                second = greatest, greatest = power;
             else if (power >= second)
@@ -1043,42 +1073,44 @@ bool EffectNoiseReduction::Worker::Classify(unsigned nWindows, int band)
    }
 }
 
-void EffectNoiseReduction::Worker::ReduceNoise()
+void EffectNoiseReduction::Worker::ReduceNoise(MyTransformer &transformer)
 {
-   auto historyLen = CurrentQueueSize();
+   auto historyLen = transformer.CurrentQueueSize();
    auto nWindows = std::min<unsigned>(mNWindowsToExamine, historyLen);
+
+   const auto spectrumSize = mSettings.SpectrumSize();
 
    if (mNoiseReductionChoice != NRC_ISOLATE_NOISE)
    {
-      MyWindow &record = NthWindow(0);
+      auto &record = transformer.NthWindow(0);
       // Default all gains to the reduction factor,
       // until we decide to raise some of them later
       float *pGain = &record.mGains[0];
-      std::fill(pGain, pGain + mSpectrumSize, mNoiseAttenFactor);
+      std::fill(pGain, pGain + spectrumSize, mNoiseAttenFactor);
    }
 
    // Raise the gain for elements in the center of the sliding history
    // or, if isolating noise, zero out the non-noise
    if (nWindows > mCenter)
    {
-      auto pGain = NthWindow(mCenter).mGains.data();
+      auto pGain = transformer.NthWindow(mCenter).mGains.data();
       if (mNoiseReductionChoice == NRC_ISOLATE_NOISE) {
          // All above or below the selected frequency range is non-noise
          std::fill(pGain, pGain + mBinLow, 0.0f);
-         std::fill(pGain + mBinHigh, pGain + mSpectrumSize, 0.0f);
+         std::fill(pGain + mBinHigh, pGain + spectrumSize, 0.0f);
          pGain += mBinLow;
          for (size_t jj = mBinLow; jj < mBinHigh; ++jj) {
-               const bool isNoise = Classify(nWindows, jj);
+               const bool isNoise = Classify(transformer, nWindows, jj);
             *pGain++ = isNoise ? 1.0 : 0.0;
          }
       }
       else {
          // All above or below the selected frequency range is non-noise
          std::fill(pGain, pGain + mBinLow, 1.0f);
-         std::fill(pGain + mBinHigh, pGain + mSpectrumSize, 1.0f);
+         std::fill(pGain + mBinHigh, pGain + spectrumSize, 1.0f);
          pGain += mBinLow;
          for (size_t jj = mBinLow; jj < mBinHigh; ++jj) {
-            const bool isNoise = Classify(nWindows, jj);
+            const bool isNoise = Classify(transformer, nWindows, jj);
             if (!isNoise)
                *pGain = 1.0;
             ++pGain;
@@ -1094,12 +1126,12 @@ void EffectNoiseReduction::Worker::ReduceNoise()
 
       // First, the attack, which goes backward in time, which is,
       // toward higher indices in the queue.
-      for (size_t jj = 0; jj < mSpectrumSize; ++jj) {
+      for (size_t jj = 0; jj < spectrumSize; ++jj) {
          for (unsigned ii = mCenter + 1; ii < historyLen; ++ii) {
             const float minimum =
                std::max(mNoiseAttenFactor,
-                        NthWindow(ii - 1).mGains[jj] * mOneBlockAttack);
-            float &gain = NthWindow(ii).mGains[jj];
+                  transformer.NthWindow(ii - 1).mGains[jj] * mOneBlockAttack);
+            float &gain = transformer.NthWindow(ii).mGains[jj];
             if (gain < minimum)
                gain = minimum;
             else
@@ -1113,9 +1145,9 @@ void EffectNoiseReduction::Worker::ReduceNoise()
       // be visited again when we examine the next window, and
       // carry the decay further.
       {
-         auto pNextGain = NthWindow(mCenter - 1).mGains.data();
-         auto pThisGain = NthWindow(mCenter).mGains.data();
-         for (auto nn = mSpectrumSize; nn--;) {
+         auto pNextGain = transformer.NthWindow(mCenter - 1).mGains.data();
+         auto pThisGain = transformer.NthWindow(mCenter).mGains.data();
+         for (auto nn = mSettings.SpectrumSize(); nn--;) {
             *pNextGain =
                std::max(*pNextGain,
                         std::max(mNoiseAttenFactor,
@@ -1126,9 +1158,9 @@ void EffectNoiseReduction::Worker::ReduceNoise()
    }
 
 
-   if (QueueIsFull()) {
-      auto &record = NthWindow(historyLen - 1);  // end of the queue
-      const auto last = mSpectrumSize - 1;
+   if (transformer.QueueIsFull()) {
+      auto &record = transformer.NthWindow(historyLen - 1);  // end of the queue
+      const auto last = mSettings.SpectrumSize() - 1;
 
       if (mNoiseReductionChoice != NRC_ISOLATE_NOISE)
          // Apply frequency smoothing to output gain
@@ -1140,7 +1172,7 @@ void EffectNoiseReduction::Worker::ReduceNoise()
          const float *pGain = &record.mGains[1];
          float *pReal = &record.mRealFFTs[1];
          float *pImag = &record.mImagFFTs[1];
-         auto nn = mSpectrumSize - 2;
+         auto nn = mSettings.SpectrumSize() - 2;
          if (mNoiseReductionChoice == NRC_LEAVE_RESIDUE) {
             for (; nn--;) {
                // Subtract the gain we would otherwise apply from 1, and
@@ -1167,10 +1199,10 @@ void EffectNoiseReduction::Worker::ReduceNoise()
    }
 }
 
-bool EffectNoiseReduction::Worker::DoFinish()
+bool MyTransformer::DoFinish()
 {
-   if (mDoProfile)
-      FinishTrackStatistics();
+   if (mWorker.mDoProfile)
+      mWorker.FinishTrackStatistics();
    return TrackSpectrumTransformer::DoFinish();
 }
 

--- a/src/effects/NoiseReduction.h
+++ b/src/effects/NoiseReduction.h
@@ -47,9 +47,9 @@ public:
    class Settings;
    class Statistics;
    class Dialog;
+   class Worker;
 
 private:
-   class Worker;
    friend class Dialog;
 
    std::unique_ptr<Settings> mSettings;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -137,7 +137,7 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
          float maxExtent{ std::numeric_limits<float>::lowest() };
          std::vector<float> offsets;
 
-         const auto channels = TrackList::Channels(track);
+         const auto channels = track->Channels();
          // mono or 'stereo tracks independently'
          const bool oneChannel = (channels.size() == 1 || mStereoInd);
          auto msg = oneChannel
@@ -199,7 +199,7 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
             else
                mMult = 1.0;
             if (false ==
-                (bGoodResult = ProcessOne(channel, msg, progress, *pOffset++)))
+                (bGoodResult = ProcessOne(*channel, msg, progress, *pOffset++)))
                goto break2;
             // TODO: more-than-two-channels-message
             msg = topMsg +
@@ -296,7 +296,7 @@ bool EffectNormalize::TransferDataFromWindow(EffectSettings &)
 
 // EffectNormalize implementation
 
-bool EffectNormalize::AnalyseTrack(const WaveTrack &track,
+bool EffectNormalize::AnalyseTrack(const WaveChannel &track,
    const ProgressReport &report,
    const bool gain, const bool dc, const double curT0, const double curT1,
    float &offset, float &extent)
@@ -331,7 +331,7 @@ bool EffectNormalize::AnalyseTrack(const WaveTrack &track,
 
 //AnalyseTrackData() takes a track, transforms it to bunch of buffer-blocks,
 //and executes selected AnalyseOperation on it...
-bool EffectNormalize::AnalyseTrackData(const WaveTrack &track,
+bool EffectNormalize::AnalyseTrackData(const WaveChannel &track,
    const ProgressReport &report, const double curT0, const double curT1,
    float &offset)
 {
@@ -397,14 +397,14 @@ bool EffectNormalize::AnalyseTrackData(const WaveTrack &track,
 //and executes ProcessData, on it...
 // uses mMult and offset to normalize a track.
 // mMult must be set before this is called
-bool EffectNormalize::ProcessOne(
-   WaveTrack * track, const TranslatableString &msg, double &progress, float offset)
+bool EffectNormalize::ProcessOne(WaveChannel &track,
+   const TranslatableString &msg, double &progress, float offset)
 {
    bool rc = true;
 
    //Transform the marker timepoints to samples
-   auto start = track->TimeToLongSamples(mCurT0);
-   auto end = track->TimeToLongSamples(mCurT1);
+   auto start = track.TimeToLongSamples(mCurT0);
+   auto end = track.TimeToLongSamples(mCurT1);
 
    //Get the length of the buffer (as double). len is
    //used simply to calculate a progress meter, so it is easier
@@ -413,7 +413,7 @@ bool EffectNormalize::ProcessOne(
 
    //Initiate a processing buffer.  This buffer will (most likely)
    //be shorter than the length of the track being processed.
-   Floats buffer{ track->GetMaxBlockSize() };
+   Floats buffer{ track.GetMaxBlockSize() };
 
    //Go through the track one buffer at a time. s counts which
    //sample the current buffer starts at.
@@ -422,18 +422,18 @@ bool EffectNormalize::ProcessOne(
       //Get a block of samples (smaller than the size of the buffer)
       //Adjust the block size if it is the final block in the track
       const auto block = limitSampleBufferSize(
-         track->GetBestBlockSize(s),
+         track.GetBestBlockSize(s),
          end - s
       );
 
       //Get the samples from the track and put them in the buffer
-      track->GetFloats(buffer.get(), s, block);
+      track.GetFloats(buffer.get(), s, block);
 
       //Process the buffer.
       ProcessData(buffer.get(), block, offset);
 
       //Copy the newly-changed samples back onto the track.
-      track->Set((samplePtr) buffer.get(), floatSample, s, block);
+      track.Set((samplePtr) buffer.get(), floatSample, s, block);
 
       //Increment s one blockfull of samples
       s += block;

--- a/src/effects/Normalize.h
+++ b/src/effects/Normalize.h
@@ -22,6 +22,7 @@ class wxCheckBox;
 class wxStaticText;
 class wxTextCtrl;
 class ShuttleGui;
+class WaveChannel;
 
 class EffectNormalize final : public StatefulEffect
 {
@@ -56,14 +57,14 @@ public:
 private:
    // EffectNormalize implementation
 
-   bool ProcessOne(
-      WaveTrack * t, const TranslatableString &msg, double& progress, float offset);
+   bool ProcessOne(WaveChannel &track,
+      const TranslatableString &msg, double& progress, float offset);
    using ProgressReport = std::function<bool(double fraction)>;
-   static bool AnalyseTrack(const WaveTrack &track,
+   static bool AnalyseTrack(const WaveChannel &track,
       const ProgressReport &report,
       bool gain, bool dc, double curT0, double curT1,
       float &offset, float &extent);
-   static bool AnalyseTrackData(const WaveTrack &track,
+   static bool AnalyseTrackData(const WaveChannel &track,
       const ProgressReport &report, double curT0, double curT1,
       float &offset);
    static double AnalyseDataDC(float *buffer, size_t len, double sum);

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -157,15 +157,12 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
       double t0 = mT0 < trackStart ? trackStart : mT0;
       double t1 = mT1 > trackEnd ? trackEnd : mT1;
       if (t1 > t0) {
-         auto tempList = TrackList::Create(nullptr);
-         const auto channels = TrackList::Channels(track);
+         auto tempList = track->WideEmptyCopy();
+         const auto channels = track->Channels();
+         auto iter = (*tempList->Any<WaveTrack>().begin())->Channels().begin();
          for (const auto pChannel : channels) {
-            const auto outputTrack = ProcessOne(*pChannel, t0, t1, count++);
-            if (!outputTrack)
+            if (!ProcessOne(*pChannel, **iter++, t0, t1, count++))
                return false;
-            tempList->Add(outputTrack);
-            // because it was made by EmptyCopy():
-            assert(outputTrack->IsLeader() == pChannel->IsLeader());
          }
          const auto pNewTrack = *tempList->Any<WaveTrack>().begin();
          pNewTrack->Flush();
@@ -267,14 +264,13 @@ size_t EffectPaulstretch::GetBufferSize(double rate) const
    return std::max<size_t>(stmp, 128);
 }
 
-std::shared_ptr<WaveTrack>
-EffectPaulstretch::ProcessOne(
-   const WaveTrack &track, double t0, double t1, int count)
+bool EffectPaulstretch::ProcessOne(const WaveChannel &track,
+   WaveChannel &outputTrack, double t0, double t1, int count)
 {
    const auto badAllocMessage =
       XO("Requested value exceeds memory capacity.");
 
-   const auto rate = track.GetRate();
+   const auto rate = track.GetTrack().GetRate();
    const auto stretch_buf_size = GetBufferSize(rate);
    if (stretch_buf_size == 0) {
       EffectUIServices::DoMessageBox(*this, badAllocMessage);
@@ -340,13 +336,10 @@ EffectPaulstretch::ProcessOne(
       return {};
    }
 
-
    auto dlen = len.as_double();
    double adjust_amount = dlen /
       (dlen - ((double)stretch_buf_size * 2.0));
    amount = 1.0 + (amount - 1.0) * adjust_amount;
-
-   auto outputTrack = track.EmptyCopy();
 
    try {
       // This encloses all the allocations of buffers, including those in
@@ -398,7 +391,7 @@ EffectPaulstretch::ProcessOne(
                }
             }
 
-            outputTrack->Append((samplePtr)stretch.out_buf.get(), floatSample, stretch.out_bufsize);
+            outputTrack.Append((samplePtr)stretch.out_buf.get(), floatSample, stretch.out_bufsize);
 
             nget = stretch.get_nsamples();
             if (TrackProgress(count,
@@ -411,12 +404,12 @@ EffectPaulstretch::ProcessOne(
       }
 
       if (!cancelled)
-         return outputTrack;
+         return true;
    }
    catch ( const std::bad_alloc& ) {
       EffectUIServices::DoMessageBox(*this, badAllocMessage);
    }
-   return {};
+   return false;
 };
 
 /*************************************************************/

--- a/src/effects/Paulstretch.h
+++ b/src/effects/Paulstretch.h
@@ -16,6 +16,7 @@
 #include <wx/weakref.h>
 
 class ShuttleGui;
+class WaveChannel;
 
 class EffectPaulstretch final : public StatefulEffect
 {
@@ -54,8 +55,8 @@ private:
    void OnText(wxCommandEvent & evt);
    size_t GetBufferSize(double rate) const;
 
-   std::shared_ptr<WaveTrack>
-   ProcessOne(const WaveTrack &track, double t0, double t1, int count);
+   bool ProcessOne(const WaveChannel &track, WaveChannel &outputTrack,
+      double t0, double t1, int count);
 
    wxWeakRef<wxWindow> mUIParent;
 

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -119,7 +119,7 @@ bool EffectRepair::Process(EffectInstance &, EffectSettings &)
             break;
          }
 
-         for (const auto pChannel : TrackList::Channels(track))
+         for (const auto pChannel : track->Channels())
             if (!ProcessOne(count++, *pChannel, s0,
                // len is at most 5 * 128.
                len.as_size_t(),
@@ -140,7 +140,7 @@ done:
    return bGoodResult;
 }
 
-bool EffectRepair::ProcessOne(int count, WaveTrack &track,
+bool EffectRepair::ProcessOne(int count, WaveChannel &track,
    sampleCount start, size_t len, size_t repairStart, size_t repairLen)
 {
    Floats buffer{ len };

--- a/src/effects/Repair.h
+++ b/src/effects/Repair.h
@@ -13,7 +13,7 @@
 
 #include "StatefulEffect.h"
 
-class WaveTrack;
+class WaveChannel;
 
 class EffectRepair final : public StatefulEffect
 {
@@ -42,7 +42,7 @@ public:
 private:
    // EffectRepair implementation
 
-   bool ProcessOne(int count, WaveTrack &track,
+   bool ProcessOne(int count, WaveChannel &track,
       sampleCount start, size_t len,
       size_t repairStart, // offset relative to start
       size_t repairLen);

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -110,43 +110,41 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
             bGoodResult = false;
       }; },
 #endif
-      [&](auto &&fallthrough){ return [&](WaveTrack &leftTrack) {
-         if (!leftTrack.GetSelected())
+      [&](auto &&fallthrough){ return [&](WaveTrack &orig) {
+         if (!orig.GetSelected())
             return fallthrough();
 
          // Process only if the right marker is to the right of the left marker
          if (mT1 > mT0) {
+            //Transform the marker timepoints to samples
+            const auto start = orig.TimeToLongSamples(mT0);
+            const auto end = orig.TimeToLongSamples(mT1);
+
+            const auto tempList = orig.WideEmptyCopy();
+            auto &out = **tempList->Any<WaveTrack>().begin();
+
             const auto pSoundTouch = std::make_unique<soundtouch::SoundTouch>();
             initer(pSoundTouch.get());
 
             // TODO: more-than-two-channels
-            auto channels = TrackList::Channels(&leftTrack);
-            auto rightTrack = (channels.size() > 1)
-               ? * ++ channels.first
-               : nullptr;
-            if (rightTrack) {
-               //Transform the marker timepoints to samples
-               auto start = leftTrack.TimeToLongSamples(mT0);
-               auto end = leftTrack.TimeToLongSamples(mT1);
+            auto channels = orig.Channels();
+            if (channels.size() > 1) {
 
                //Inform soundtouch there's 2 channels
                pSoundTouch->setChannels(2);
 
                //ProcessStereo() (implemented below) processes a stereo track
                if (!ProcessStereo(pSoundTouch.get(),
-                  &leftTrack, rightTrack, start, end, warper))
+                  orig, out, start, end, warper))
                   bGoodResult = false;
                mCurTrackNum++; // Increment for rightTrack, too.
             } else {
-               //Transform the marker timepoints to samples
-               auto start = leftTrack.TimeToLongSamples(mT0);
-               auto end = leftTrack.TimeToLongSamples(mT1);
-
                //Inform soundtouch there's a single channel
                pSoundTouch->setChannels(1);
 
                //ProcessOne() (implemented below) processes a single track
-               if (!ProcessOne(pSoundTouch.get(), &leftTrack, start, end, warper))
+               if (!ProcessOne(
+                  pSoundTouch.get(), orig, out, start, end, warper))
                   bGoodResult = false;
             }
             // pSoundTouch is destroyed here
@@ -170,13 +168,12 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
 //ProcessOne() takes a track, transforms it to bunch of buffer-blocks,
 //and executes ProcessSoundTouch on these blocks
 bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
-   WaveTrack *track,
+   WaveTrack &orig, WaveTrack &out,
    sampleCount start, sampleCount end,
    const TimeWarper &warper)
 {
-   pSoundTouch->setSampleRate((unsigned int)(track->GetRate()+0.5));
-
-   auto outputTrack = track->EmptyCopy();
+   pSoundTouch->setSampleRate(
+      static_cast<unsigned int>((orig.GetRate() + 0.5)));
 
    //Get the length of the buffer (as double). len is
    //used simple to calculate a progress meter, so it is easier
@@ -186,7 +183,7 @@ bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
    {
       //Initiate a processing buffer.  This buffer will (most likely)
       //be shorter than the length of the track being processed.
-      Floats buffer{ track->GetMaxBlockSize() };
+      Floats buffer{ orig.GetMaxBlockSize() };
 
       //Go through the track one buffer at a time. s counts which
       //sample the current buffer starts at.
@@ -194,10 +191,10 @@ bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
       while (s < end) {
          //Get a block of samples (smaller than the size of the buffer)
          const auto block = std::min<size_t>(8192,
-            limitSampleBufferSize(track->GetBestBlockSize(s), end - s));
+            limitSampleBufferSize(orig.GetBestBlockSize(s), end - s));
 
          //Get the samples from the track and put them in the buffer
-         track->GetFloats(buffer.get(), s, block);
+         orig.GetFloats(buffer.get(), s, block);
 
          //Add samples to SoundTouch
          pSoundTouch->putSamples(buffer.get(), block);
@@ -207,7 +204,7 @@ bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
          if (outputCount > 0) {
             Floats buffer2{ outputCount };
             pSoundTouch->receiveSamples(buffer2.get(), outputCount);
-            outputTrack->Append((samplePtr)buffer2.get(), floatSample, outputCount);
+            out.Append((samplePtr)buffer2.get(), floatSample, outputCount);
          }
 
          //Increment s one blockfull of samples
@@ -225,19 +222,16 @@ bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
       if (outputCount > 0) {
          Floats buffer2{ outputCount };
          pSoundTouch->receiveSamples(buffer2.get(), outputCount);
-         outputTrack->Append((samplePtr)buffer2.get(), floatSample, outputCount);
+         out.Append((samplePtr)buffer2.get(), floatSample, outputCount);
       }
 
-      outputTrack->Flush();
+      out.Flush();
    }
 
-   // Allow TrackList::Channels to work on outputTrack
-   auto tempList = TrackList::Temporary(
-      nullptr, outputTrack, nullptr);
    // Transfer output samples to the original
-   Finalize(*track, *outputTrack, warper);
+   Finalize(orig, out, warper);
 
-   double newLength = outputTrack->GetEndTime();
+   double newLength = out.GetEndTime();
    m_maxNewLength = std::max(m_maxNewLength, newLength);
 
    //Return true because the effect processing succeeded.
@@ -245,15 +239,19 @@ bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
 }
 
 bool EffectSoundTouch::ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
-   WaveTrack* leftTrack, WaveTrack* rightTrack,
+   WaveTrack &orig, WaveTrack &outputTrack,
    sampleCount start, sampleCount end, const TimeWarper &warper)
 {
-   pSoundTouch->setSampleRate((unsigned int)(leftTrack->GetRate() + 0.5));
+   pSoundTouch->setSampleRate(
+      static_cast<unsigned int>(orig.GetRate() + 0.5));
 
-   auto outputLeftTrack = leftTrack->EmptyCopy();
-   auto outputRightTrack = rightTrack->EmptyCopy();
-   auto tempList = TrackList::Temporary(
-      nullptr, outputLeftTrack, outputRightTrack);
+   auto channels = orig.Channels();
+   auto &leftTrack = **channels.first++;
+   auto &rightTrack = **channels.first;
+
+   auto newChannels = outputTrack.Channels();
+   auto &outputLeftTrack = **newChannels.first++;
+   auto &outputRightTrack = **newChannels.first;
 
    //Get the length of the buffer (as double). len is
    //used simple to calculate a progress meter, so it is easier
@@ -265,7 +263,7 @@ bool EffectSoundTouch::ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
    // Make soundTouchBuffer twice as big as MaxBlockSize for each channel,
    // because Soundtouch wants them interleaved, i.e., each
    // Soundtouch sample is left-right pair.
-   auto maxBlockSize = leftTrack->GetMaxBlockSize();
+   auto maxBlockSize = orig.GetMaxBlockSize();
    {
       Floats leftBuffer{ maxBlockSize };
       Floats rightBuffer{ maxBlockSize };
@@ -277,13 +275,14 @@ bool EffectSoundTouch::ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
       auto sourceSampleCount = start;
       while (sourceSampleCount < end) {
          auto blockSize = limitSampleBufferSize(
-            leftTrack->GetBestBlockSize(sourceSampleCount),
+            orig.GetBestBlockSize(sourceSampleCount),
             end - sourceSampleCount
          );
 
          // Get the samples from the tracks and put them in the buffers.
-         leftTrack->GetFloats((leftBuffer.get()), sourceSampleCount, blockSize);
-         rightTrack->GetFloats((rightBuffer.get()), sourceSampleCount, blockSize);
+         leftTrack.GetFloats((leftBuffer.get()), sourceSampleCount, blockSize);
+         rightTrack
+            .GetFloats((rightBuffer.get()), sourceSampleCount, blockSize);
 
          // Interleave into soundTouchBuffer.
          for (decltype(blockSize) index = 0; index < blockSize; index++) {
@@ -298,7 +297,7 @@ bool EffectSoundTouch::ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
          unsigned int outputCount = pSoundTouch->numSamples();
          if (outputCount > 0)
             this->ProcessStereoResults(pSoundTouch,
-               outputCount, outputLeftTrack.get(), outputRightTrack.get());
+               outputCount, outputLeftTrack, outputRightTrack);
 
          //Increment sourceSampleCount one blockfull of samples
          sourceSampleCount += blockSize;
@@ -325,17 +324,17 @@ bool EffectSoundTouch::ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
       unsigned int outputCount = pSoundTouch->numSamples();
       if (outputCount > 0)
          this->ProcessStereoResults(pSoundTouch,
-            outputCount, outputLeftTrack.get(), outputRightTrack.get());
+            outputCount, outputLeftTrack, outputRightTrack);
 
-      outputLeftTrack->Flush();
+      outputTrack.Flush();
    }
 
    // Transfer output samples to the original
-   Finalize(*leftTrack, *outputLeftTrack, warper);
+   Finalize(orig, outputTrack, warper);
 
 
    // Track the longest result length
-   double newLength = outputLeftTrack->GetEndTime();
+   double newLength = outputTrack.GetEndTime();
    m_maxNewLength = std::max(m_maxNewLength, newLength);
 
    //Return true because the effect processing succeeded.
@@ -344,8 +343,8 @@ bool EffectSoundTouch::ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
 
 bool EffectSoundTouch::ProcessStereoResults(soundtouch::SoundTouch *pSoundTouch,
    const size_t outputCount,
-   WaveTrack* outputLeftTrack,
-   WaveTrack* outputRightTrack)
+   WaveChannel &outputLeftTrack,
+   WaveChannel &outputRightTrack)
 {
    Floats outputSoundTouchBuffer{ outputCount * 2 };
    pSoundTouch->receiveSamples(outputSoundTouchBuffer.get(), outputCount);
@@ -353,14 +352,15 @@ bool EffectSoundTouch::ProcessStereoResults(soundtouch::SoundTouch *pSoundTouch,
    // Dis-interleave outputSoundTouchBuffer into separate track buffers.
    Floats outputLeftBuffer{ outputCount };
    Floats outputRightBuffer{ outputCount };
-   for (unsigned int index = 0; index < outputCount; index++)
-   {
-      outputLeftBuffer[index] = outputSoundTouchBuffer[index*2];
-      outputRightBuffer[index] = outputSoundTouchBuffer[(index*2)+1];
+   for (unsigned int index = 0; index < outputCount; ++index) {
+      outputLeftBuffer[index] = outputSoundTouchBuffer[index * 2];
+      outputRightBuffer[index] = outputSoundTouchBuffer[(index * 2) + 1];
    }
 
-   outputLeftTrack->Append((samplePtr)outputLeftBuffer.get(), floatSample, outputCount);
-   outputRightTrack->Append((samplePtr)outputRightBuffer.get(), floatSample, outputCount);
+   outputLeftTrack.Append(
+      (samplePtr)outputLeftBuffer.get(), floatSample, outputCount);
+   outputRightTrack.Append(
+      (samplePtr)outputRightBuffer.get(), floatSample, outputCount);
 
    return true;
 }

--- a/src/effects/SoundTouchEffect.h
+++ b/src/effects/SoundTouchEffect.h
@@ -29,6 +29,7 @@ namespace soundtouch { class SoundTouch; }
 class TimeWarper;
 class LabelTrack;
 class NoteTrack;
+class WaveChannel;
 class WaveTrack;
 
 class EffectSoundTouch /* not final */ : public StatefulEffect
@@ -57,16 +58,16 @@ private:
    bool ProcessNoteTrack(NoteTrack *track, const TimeWarper &warper);
 #endif
    bool ProcessOne(soundtouch::SoundTouch *pSoundTouch,
-      WaveTrack * t, sampleCount start, sampleCount end,
+      WaveTrack &orig, WaveTrack &out, sampleCount start, sampleCount end,
       const TimeWarper &warper);
    bool ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
-      WaveTrack* leftTrack, WaveTrack* rightTrack,
+      WaveTrack &orig, WaveTrack &out,
       sampleCount start, sampleCount end,
       const TimeWarper &warper);
    bool ProcessStereoResults(soundtouch::SoundTouch *pSoundTouch,
       const size_t outputCount,
-      WaveTrack* outputLeftTrack,
-      WaveTrack* outputRightTrack);
+      WaveChannel &outputLeftTrack,
+      WaveChannel &outputRightTrack);
    /*!
     @pre `orig.IsLeader()`
     @pre `out.IsLeader()`

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -87,16 +87,12 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
    sampleCount totalTime = 0;
    
    auto trackRange = outputs.Get().Selected<WaveTrack>();
-   while (trackRange.first != trackRange.second)
-   {
-      auto left = *trackRange.first;
-      auto channels = TrackList::Channels(left);
-      if (channels.size() > 1) {
+   for (const auto left : trackRange) {
+      if (left->Channels().size() > 1) {
          auto start = left->TimeToLongSamples(left->GetStartTime());
          auto end = left->TimeToLongSamples(left->GetEndTime());
          totalTime += (end - start);
       }
-      ++trackRange.first;
    }
 
    // Process each stereo track
@@ -105,35 +101,23 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
 
    mProgress->SetMessage(XO("Mixing down to mono"));
 
-   trackRange = outputs.Get().Selected<WaveTrack>();
-   while (trackRange.first != trackRange.second)
-   {
-      auto left = *trackRange.first;
-      auto channels = TrackList::Channels(left);
-      if (channels.size() > 1)
-      {
-         auto right = *channels.rbegin();
-
-         bGoodResult =
-            ProcessOne(outputs.Get(), curTime, totalTime, left, right);
-         if (!bGoodResult)
-         {
+   // Don't use range-for, because iterators may be invalidated by erasure from
+   // the track list
+   while (trackRange.first != trackRange.second) {
+      auto track = *trackRange.first;
+      if (track->Channels().size() > 1) {
+         if (!ProcessOne(outputs.Get(), curTime, totalTime, *track))
             break;
-         }
-
          // The right channel has been deleted, so we must restart from the beginning
          refreshIter = true;
       }
 
-      if (refreshIter)
-      {
+      if (refreshIter) {
          trackRange = outputs.Get().Selected<WaveTrack>();
          refreshIter = false;
       }
       else
-      {
          ++trackRange.first;
-      }
    }
 
    if (bGoodResult)
@@ -143,19 +127,18 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
 }
 
 bool EffectStereoToMono::ProcessOne(TrackList &outputs,
-   sampleCount & curTime, sampleCount totalTime,
-   WaveTrack *left, WaveTrack *right)
+   sampleCount & curTime, sampleCount totalTime, WaveTrack &track)
 {
-   auto idealBlockLen = left->GetMaxBlockSize() * 2;
+   auto idealBlockLen = track.GetMaxBlockSize() * 2;
    bool bResult = true;
    sampleCount processed = 0;
 
-   const auto start = left->GetStartTime();
-   const auto end = left->GetEndTime();
+   const auto start = track.GetStartTime();
+   const auto end = track.GetEndTime();
 
    Mixer::Inputs tracks;
    tracks.emplace_back(
-      left->SharedPointer<const SampleTrack>(), GetEffectStages(*left));
+      track.SharedPointer<const SampleTrack>(), GetEffectStages(track));
 
    Mixer mixer(move(tracks),
       true,                // Throw to abort mix-and-render if read fails:
@@ -165,12 +148,11 @@ bool EffectStereoToMono::ProcessOne(TrackList &outputs,
       1,
       idealBlockLen,
       false,               // Not interleaved
-      left->GetRate(),     // Process() checks that left and right
-                           // rates are the same
+      track.GetRate(),
       floatSample);
 
    // Always make mono output; don't use WideEmptyCopy
-   auto outTrack = left->EmptyCopy();
+   auto outTrack = track.EmptyCopy();
    auto tempList = TrackList::Temporary(nullptr, outTrack, nullptr);
    assert(outTrack->IsLeader());
    outTrack->ConvertToSampleFormat(floatSample);
@@ -193,14 +175,15 @@ bool EffectStereoToMono::ProcessOne(TrackList &outputs,
    }
    outTrack->Flush();
 
-   outputs.UnlinkChannels(*left);
+   outputs.UnlinkChannels(track);
+   const auto right = * ++track.GetOwner()->Find(&track);
    // Should be a consequence of unlinking:
    assert(right->IsLeader());
    outputs.Remove(*right);
 
-   left->Clear(start, end);
-   left->Paste(start, *outTrack);
-   RealtimeEffectList::Get(*left).Clear();
+   track.Clear(start, end);
+   track.Paste(start, *outTrack);
+   RealtimeEffectList::Get(track).Clear();
 
    return bResult;
 }

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -169,6 +169,7 @@ bool EffectStereoToMono::ProcessOne(TrackList &outputs,
                            // rates are the same
       floatSample);
 
+   // Always make mono output; don't use WideEmptyCopy
    auto outTrack = left->EmptyCopy();
    auto tempList = TrackList::Temporary(nullptr, outTrack, nullptr);
    assert(outTrack->IsLeader());

--- a/src/effects/StereoToMono.h
+++ b/src/effects/StereoToMono.h
@@ -43,8 +43,7 @@ private:
    // EffectStereoToMono implementation
 
    bool ProcessOne(TrackList &outputs,
-      sampleCount & curTime, sampleCount totalTime,
-      WaveTrack *left, WaveTrack *right);
+      sampleCount & curTime, sampleCount totalTime, WaveTrack &track);
 
 };
 

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -465,7 +465,7 @@ bool EffectTruncSilence::DoRemoval(const RegionList &silences,
             auto t2 = wt.TimeToLongSamples(cutEnd) - blendFrames / 2;
 
             size_t iChannel = 0;
-            for (const auto pChannel : TrackList::Channels(&wt)) {
+            for (const auto pChannel : wt.Channels()) {
                auto &buffer = buffers[iChannel];
                pChannel->GetFloats(buffer.buf1.get(), t1, blendFrames);
                pChannel->GetFloats(buffer.buf2.get(), t2, blendFrames);
@@ -482,7 +482,7 @@ bool EffectTruncSilence::DoRemoval(const RegionList &silences,
             wt.Clear(cutStart, cutEnd);
 
             iChannel = 0;
-            for (const auto pChannel : TrackList::Channels(&wt)) {
+            for (const auto pChannel : wt.Channels()) {
                // Write cross-faded data
                auto &buffer = buffers[iChannel];
                pChannel->Set((samplePtr)buffer.buf1.get(), floatSample, t1,
@@ -612,7 +612,7 @@ bool EffectTruncSilence::Analyze(RegionList& silenceList,
 
       // Fill buffers
       size_t iChannel = 0;
-      for (const auto pChannel : TrackList::Channels(&wt))
+      for (const auto pChannel : wt.Channels())
          pChannel->GetFloats(buffers[iChannel++].get(), *index, count);
 
       // Look for silenceList in current block

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -98,8 +98,8 @@ bool EffectTwoPassSimpleMono::ProcessPass(EffectSettings &settings)
             return false;
 
          // ProcessOne() (implemented below) processes a single track
-         auto outIter = TrackList::Channels(outTrack).begin();
-         for (const auto pChannel : TrackList::Channels(track))
+         auto outIter = outTrack->Channels().begin();
+         for (const auto pChannel : track->Channels())
             if (!ProcessOne(*pChannel, **outIter++, start, end))
                return false;
          if (!mSecondPassDisabled && mPass == 0)
@@ -116,8 +116,8 @@ bool EffectTwoPassSimpleMono::ProcessPass(EffectSettings &settings)
 
 // ProcessOne() takes a track, transforms it to bunch of buffer-blocks,
 // and executes TwoBufferProcessPass1 or TwoBufferProcessPass2 on these blocks
-bool EffectTwoPassSimpleMono::ProcessOne(WaveTrack &track, WaveTrack &outTrack,
-   sampleCount start, sampleCount end)
+bool EffectTwoPassSimpleMono::ProcessOne(WaveChannel &track,
+   WaveChannel &outTrack, sampleCount start, sampleCount end)
 {
    bool ret;
 

--- a/src/effects/TwoPassSimpleMono.h
+++ b/src/effects/TwoPassSimpleMono.h
@@ -14,7 +14,7 @@
 
 #include "StatefulEffect.h"
 
-class WaveTrack;
+class WaveChannel;
 
 class AUDACITY_DLL_API EffectTwoPassSimpleMono /* not final */
    : public StatefulEffect
@@ -94,7 +94,7 @@ protected:
    TrackList *mTrackLists[2];
 
 private:
-   bool ProcessOne(WaveTrack &t, WaveTrack &outTrack,
+   bool ProcessOne(WaveChannel &t, WaveChannel &outTrack,
       sampleCount start, sampleCount end);
    bool ProcessPass(EffectSettings &settings);
 };

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -682,7 +682,7 @@ struct NyquistEffect::NyxContext {
       int64_t start, int64_t len, int64_t totlen, void *userdata);
 
    WaveTrack *mCurChannelGroup{};
-   WaveTrack         *mCurTrack[2]{};
+   WaveChannel       *mCurTrack[2]{};
    sampleCount       mCurStart[2]{};
 
    unsigned          mCurNumChannels{}; //!< Not used in the callbacks
@@ -943,7 +943,7 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
          if (bOnePassTool) {
          }
          else {
-            if (auto channels = TrackList::Channels(mCurChannelGroup)
+            if (auto channels = mCurChannelGroup->Channels()
                ; channels.size() > 1
             ) {
                // TODO: more-than-two-channels
@@ -951,7 +951,7 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
                // with the running tally made by this loop!
                mCurNumChannels = 2;
 
-               mCurTrack[1] = * ++ channels.first;
+               mCurTrack[1] = (* ++ channels.first).get();
                mCurStart[1] = mCurTrack[1]->TimeToLongSamples(mT0);
             }
 
@@ -2599,7 +2599,7 @@ int NyquistEffect::NyxContext::PutCallback(float *buffer, int channel,
       }
 
       auto iChannel =
-         TrackList::Channels(*mOutputTracks->Any<WaveTrack>().begin()).begin();
+         (*mOutputTracks->Any<WaveTrack>().begin())->Channels().begin();
       std::advance(iChannel, channel);
       const auto pChannel = *iChannel;
       pChannel->Append((samplePtr)buffer, floatSample, len);

--- a/src/effects/nyquist/Nyquist.h
+++ b/src/effects/nyquist/Nyquist.h
@@ -146,7 +146,8 @@ private:
    static int mReentryCount;
    // NyquistEffect implementation
 
-   bool ProcessOne(EffectOutputTracks *pOutputs);
+   struct NyxContext;
+   bool ProcessOne(NyxContext &nyxContext, EffectOutputTracks *pOutputs);
 
    void BuildPromptWindow(ShuttleGui & S);
    void BuildEffectWindow(ShuttleGui & S);
@@ -170,19 +171,9 @@ private:
    FileNames::FileType ParseFileType(const wxString & text);
    FileNames::FileTypes ParseFileTypes(const wxString & text);
 
-   static int StaticGetCallback(float *buffer, int channel,
-                                int64_t start, int64_t len, int64_t totlen,
-                                void *userdata);
-   static int StaticPutCallback(float *buffer, int channel,
-                                int64_t start, int64_t len, int64_t totlen,
-                                void *userdata);
    static void StaticOutputCallback(int c, void *userdata);
    static void StaticOSCallback(void *userdata);
 
-   int GetCallback(float *buffer, int channel,
-                   int64_t start, int64_t len, int64_t totlen);
-   int PutCallback(float *buffer, int channel,
-                   int64_t start, int64_t len, int64_t totlen);
    void OutputCallback(int c);
    void OSCallback();
 
@@ -281,27 +272,12 @@ private:
    int               mVersion;   // Syntactic version of Nyquist plug-in (not to be confused with mReleaseVersion)
    std::vector<NyqControl>   mControls;
 
-   unsigned          mCurNumChannels;
-   WaveTrack         *mCurTrack[2];
-   sampleCount       mCurStart[2];
-   sampleCount       mCurLen;
    sampleCount       mMaxLen;
    int               mTrackIndex;
    bool              mFirstInGroup;
    double            mOutputTime;
    unsigned          mCount;
    unsigned          mNumSelectedChannels;
-   double            mProgressIn;
-   double            mProgressOut;
-   double            mProgressTot;
-   double            mScale;
-
-   using Buffer = std::unique_ptr<float[]>;
-   Buffer            mCurBuffer[2];
-   sampleCount       mCurBufferStart[2];
-   size_t            mCurBufferLen[2];
-
-   WaveTrack        *mOutputTrack[2];
 
    wxArrayString     mCategories;
 
@@ -312,8 +288,6 @@ private:
    int               mMergeClips;
 
    wxTextCtrl *mCommandText;
-
-   std::exception_ptr mpException {};
 
    DECLARE_EVENT_TABLE()
 

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -341,13 +341,13 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
 
    for (auto leader : inputTracks()->Any<const WaveTrack>())
    {
-      auto channelGroup = TrackList::Channels(leader);
+      auto channelGroup = leader->Channels();
       auto left = *channelGroup.first++;
 
       unsigned channels = 1;
 
       // channelGroup now contains all but the first channel
-      const WaveTrack *right =
+      const auto right =
          channelGroup.size() ? *channelGroup.first++ : nullptr;
       if (right)
          channels = 2;
@@ -411,7 +411,7 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
       const auto effectName = GetSymbol().Translation();
       addedTracks.push_back(AddAnalysisTrack(*this,
          multiple
-         ? wxString::Format( _("%s: %s"), left->GetName(), effectName )
+         ? wxString::Format( _("%s: %s"), leader->GetName(), effectName )
          : effectName
       ));
       LabelTrack *ltrack = addedTracks.back()->get();
@@ -427,14 +427,10 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
          const auto request = limitSampleBufferSize( block, len );
 
          if (left)
-         {
             left->GetFloats(data[0].get(), pos, request);
-         }
 
          if (right)
-         {
             right->GetFloats(data[1].get(), pos, request);
-         }
 
          if (request < block)
          {

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -924,9 +924,7 @@ ExportResult ExportAudioDialog::DoExportSplitByTracks(const ExportPlugin& plugin
 
       /* Select the track */
       SelectionStateChanger changer2{ selectionState, tracks };
-      const auto range = TrackList::Channels(tr);
-      for (auto channel : range)
-         channel->SetSelected(true);
+      tr->SetSelected(true);
 
       // Export the data. "channels" are per track.
       ok = DoExport(plugin, formatIndex, parameters, activeSetting.filename, activeSetting.channels,

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -903,24 +903,24 @@ auto WaveChannelSubView::GetMenuItems(
       };
 }
 
-WaveChannelView &WaveChannelView::Get(WaveTrack &track)
+WaveChannelView &WaveChannelView::Get(WaveChannel &channel)
 {
-   return static_cast<WaveChannelView&>(ChannelView::Get(track));
+   return static_cast<WaveChannelView&>(ChannelView::Get(channel));
 }
 
-const WaveChannelView &WaveChannelView::Get(const WaveTrack &track)
+const WaveChannelView &WaveChannelView::Get(const WaveChannel &channel)
 {
-   return Get(const_cast<WaveTrack&>(track));
+   return Get(const_cast<WaveChannel&>(channel));
 }
 
-WaveChannelView *WaveChannelView::Find(WaveTrack *pTrack)
+WaveChannelView *WaveChannelView::Find(WaveChannel *pChannel)
 {
-   return static_cast<WaveChannelView*>(ChannelView::Find(pTrack));
+   return static_cast<WaveChannelView*>(ChannelView::Find(pChannel));
 }
 
-const WaveChannelView *WaveChannelView::Find(const WaveTrack *pTrack)
+const WaveChannelView *WaveChannelView::Find(const WaveChannel *pChannel)
 {
-   return Find(const_cast<WaveTrack*>(pTrack));
+   return Find(const_cast<WaveChannel*>(pChannel));
 }
 
 WaveChannelView::WaveChannelView(

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -1289,7 +1289,7 @@ unsigned WaveChannelView::CaptureKey(
 {
    unsigned result{ RefreshCode::RefreshNone };
    auto pTrack = static_cast<WaveTrack*>(FindTrack().get());
-   for (auto pChannel : TrackList::Channels(pTrack)) {
+   for (auto pChannel : pTrack->Channels()) {
       event.Skip(false);
       auto &waveChannelView = WaveChannelView::Get(*pChannel);
       // Give sub-views first chance to handle the event

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.h
@@ -20,6 +20,7 @@ struct WaveChannelSubViewType;
 class CutlineHandle;
 class TranslatableString;
 class SampleTrack;
+class WaveChannel;
 class WaveTrack;
 class WaveChannelView;
 class WaveClip;
@@ -104,10 +105,10 @@ public:
 
    using Display = WaveChannelViewConstants::Display;
 
-   static WaveChannelView &Get(WaveTrack &track);
-   static const WaveChannelView &Get(const WaveTrack &track);
-   static WaveChannelView *Find(WaveTrack *pTrack);
-   static const WaveChannelView *Find(const WaveTrack *pTrack);
+   static WaveChannelView &Get(WaveChannel &channel);
+   static const WaveChannelView &Get(const WaveChannel &channel);
+   static WaveChannelView *Find(WaveChannel *pChannel);
+   static const WaveChannelView *Find(const WaveChannel *pChannel);
 
    //! Construct a view of one channel
    /*!

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -841,6 +841,12 @@ void WaveTrackMenuTable::SplitStereo(bool stereo)
 /// Swap the left and right channels of a stero track...
 void WaveTrackMenuTable::OnSwapChannels(wxCommandEvent &)
 {
+   // Fix assertion violation in `TrackPanel::OnEnsureVisible` by
+   // dispatching any queued event
+   // TODO wide wave tracks -- remove this when there is no "leader" distinction
+   // any more
+   wxTheApp->Yield();
+
    AudacityProject *const project = &mpData->project;
 
    WaveTrack *const pTrack = static_cast<WaveTrack*>(mpData->pTrack);

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -802,13 +802,12 @@ void WaveTrackMenuTable::SplitStereo(bool stereo)
    wxASSERT(pTrack);
    AudacityProject *const project = &mpData->project;
 
-   // We can assume all channels of a WaveTrack are also WaveTrack
-   auto channelRange = pTrack->Channels<WaveTrack>();
+   auto channelRange = pTrack->Channels();
 
    int totalHeight = 0;
    int nChannels = 0;
 
-   std::vector<WaveTrack *> channels;
+   std::vector<WaveChannel *> channels;
    for (auto pChannel : channelRange)
       channels.push_back(pChannel.get());
 
@@ -820,7 +819,7 @@ void WaveTrackMenuTable::SplitStereo(bool stereo)
       assert(pChannel);
       auto &view = ChannelView::Get(*pChannel);
       if (stereo) {
-         pChannel->SetPan(pan);
+         pChannel->GetTrack().SetPan(pan);
          pan += 2.0f;
       }
 

--- a/src/tracks/ui/BrushHandle.cpp
+++ b/src/tracks/ui/BrushHandle.cpp
@@ -343,8 +343,9 @@ UIHandle::Result BrushHandle::Drag
          if(mIsSmartSelection){
             // Correct the y coord (snap to highest energy freq. bin)
             if(auto *sView = dynamic_cast<SpectrumView*>(pView.get())){
-               int resFreqBin = SpectralDataManager::FindFrequencySnappingBin(wt,
-                                 h0 * hopSize, hopSize, mFreqSnappingRatio, bm);
+               int resFreqBin =
+                  SpectralDataManager::FindFrequencySnappingBin(*wt,
+                     h0 * hopSize, hopSize, mFreqSnappingRatio, bm);
                if(resFreqBin != - 1)
                   bm = resFreqBin;
             }

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -197,8 +197,8 @@ bool TrackShifter::CommonMayMigrateTo(Track &otherTrack)
       // Can migrate to another track of the same kind...
       if (otherTrack.SameKindAs(track)) {
          // ... with the same number of channels
-         auto myChannels = TrackList::Channels(&track);
-         auto otherChannels = TrackList::Channels(&otherTrack);
+         auto myChannels = track.Channels();
+         auto otherChannels = otherTrack.Channels();
          return (myChannels.size() == otherChannels.size());
       }
    }


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Depends on:
- #4974 
- #4987 
- #5060

Begin to eliminate the uses of TrackList::Channels outside Track.cpp and WaveTrack.cpp,
including all except one (Repeat) in src/effects.

Instead use WaveTrack::Channels which return objects of the new WaveChannel class,
which does not inherit Track but has a sufficient interface for many purposes, including
getting and setting and appending of sample data, and queries of minimum, maximum,
and RMS values, which are used by effects and analyzers and display.

QA: test stereo and mono cases
- [x] Bug since commit 7d179623: changing track rate shifts track incorrectly
- [x] Recording & playback
- [x] Split stereo (track context menu); correctly panned resulting tracks
- [x] Chirp, tone, silence generation
- [x] EQ
- [x] Change Speed
- [x] Noise Reduction
- [x] Paulstretch
- [x] Change Pitch (high and low quality)
- [x] Sliding time scale (ditto)
- [x] Amplify
- [x] Auto Duck
- [x] Click Removal
- [x] Contrast
- [x] Find Clipping
- [x] Loudness
- [x] Normalize
- [x] Repair
- [x] Truncate Silence
- [x] Compressor
- [x] Any one Vamp plug-in (they make label tracks; see that track naming doesn't change)
- [x] Some Nyquist effects and generators, stereo and mono
- [x] Mixer board sliders and output meters
- [x] Our friend Stereo To Mono, again; cases of multiple selected tracks, some of them already mono, which should be unchanged, and each stereo track correctly mixed down
- [x] Dragging of clips from one track to another
- [x] Export, split-by-tracks
- [x] Compare Audio macro command
- [x] Set rate in the track context menu (not resampling from the Track pull-down menu)
- [x] Keystrokes to edit clip names (including Ctrl+A, C, V, X)
- [x] Correct naming of clips by Import
- [x] Correct naming of multiple new clips by the Repeat effect


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

**Noticed Issues:**

- [x] Setting a different sample rate in the track context menu results in misaligned audio clips in stereo tracks.
- [x] Splitting a Stereo track to Mono via the Track Context menu results in the last channel being 'unnamed'. 
