### PR TITLE
Fix mistake in ChangeSpeed

### DIFF
--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -254,11 +254,9 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
             auto newTracks = TrackList::Create(nullptr);
             for (const auto pChannel : TrackList::Channels(&outWaveTrack)) {
                // ProcessOne() (implemented below) processes a single channel
-               if (const auto outputTrack =
-                  ProcessOne(outWaveTrack, start, end)
-               ){
+               if (const auto outputTrack = ProcessOne(*pChannel, start, end)) {
                   newTracks->Add(outputTrack);
-                  assert(outputTrack->IsLeader() == outWaveTrack.IsLeader());
+                  assert(outputTrack->IsLeader() == pChannel->IsLeader());
                   ++mCurTrackNum;
                }
                else {


### PR DESCRIPTION
Resolves: #5010

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
