### PR TITLE
Ignore right channel envelope

### DIFF
--- a/libraries/lib-channel/Channel.cpp
+++ b/libraries/lib-channel/Channel.cpp
@@ -49,6 +49,19 @@ int Channel::FindChannelIndex() const
    return index;
 }
 
+size_t Channel::ReallyGetChannelIndex() const
+{
+   auto &group = ReallyDoGetChannelGroup();
+   int index = -1;
+   for (size_t ii = 0, nn = group.NChannels(); ii < nn; ++ii)
+      if (group.GetChannel(ii).get() == this) {
+         index = ii;
+         break;
+      }
+   assert(index >= 0);
+   return index;
+}
+
 const ChannelGroup &Channel::GetChannelGroup() const
 {
    assert(FindChannelIndex() >= 0);
@@ -64,6 +77,11 @@ ChannelGroup &Channel::GetChannelGroup()
 size_t Channel::GetChannelIndex() const
 {
    return FindChannelIndex();
+}
+
+ChannelGroup &Channel::ReallyDoGetChannelGroup() const
+{
+   return DoGetChannelGroup();
 }
 
 ChannelGroup::~ChannelGroup() = default;

--- a/libraries/lib-channel/Channel.h
+++ b/libraries/lib-channel/Channel.h
@@ -190,6 +190,8 @@ public:
     */
    size_t GetChannelIndex() const;
 
+   size_t ReallyGetChannelIndex() const;
+
    /*!
       @name Acesss to intervals
       @{
@@ -289,6 +291,9 @@ protected:
        `this == result.GetChannel(ii).get()`
     */
    virtual ChannelGroup &DoGetChannelGroup() const = 0;
+
+   //! This is temporary!  It defaults to call the above
+   virtual ChannelGroup &ReallyDoGetChannelGroup() const;
 
 private:
    int FindChannelIndex() const;
@@ -578,8 +583,8 @@ inline size_t Channel::NIntervals() const
 template<typename IntervalType>
 std::shared_ptr<IntervalType> Channel::GetInterval(size_t iInterval)
 {
-   return GetChannelGroup().GetInterval(iInterval)
-      ->template GetChannel<IntervalType>(GetChannelIndex());
+   return ReallyDoGetChannelGroup().GetInterval(iInterval)
+      ->template GetChannel<IntervalType>(ReallyGetChannelIndex());
 }
 
 template<typename IntervalType>
@@ -587,7 +592,7 @@ auto Channel::GetInterval(size_t iInterval) const
    -> std::enable_if_t<std::is_const_v<IntervalType>,
       std::shared_ptr<IntervalType>>
 {
-   return GetChannelGroup().GetInterval(iInterval)
-      ->template GetChannel<IntervalType>(GetChannelIndex());
+   return ReallyDoGetChannelGroup().GetInterval(iInterval)
+      ->template GetChannel<IntervalType>(ReallyGetChannelIndex());
 }
 #endif

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -61,6 +61,8 @@ from the project that will own the track.
 
 using std::max;
 
+WaveChannelInterval::~WaveChannelInterval() = default;
+
 WaveTrack::Interval::Interval(const ChannelGroup &group,
    const std::shared_ptr<WaveClip> &pClip,
    const std::shared_ptr<WaveClip> &pClip1
@@ -77,7 +79,7 @@ std::shared_ptr<ChannelInterval>
 WaveTrack::Interval::DoGetChannel(size_t iChannel)
 {
    if (iChannel < NChannels())
-      return std::make_shared<ChannelInterval>();
+      return std::make_shared<WaveChannelInterval>();
    return {};
 }
 
@@ -445,7 +447,7 @@ WaveTrack::DoGetInterval(size_t iInterval)
          pClip1;
       // TODO wide wave tracks
       // This assumed correspondence of clips may be wrong if they misalign
-      if (auto right = GetChannel<WaveTrack>(1)
+      if (auto right = ChannelGroup::GetChannel<WaveTrack>(1)
          ; right && iInterval < right->mClips.size()
       )
          pClip1 = right->mClips[iInterval];

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -484,6 +484,15 @@ ChannelGroup &WaveTrack::DoGetChannelGroup() const
    return const_cast<ChannelGroup&>(group);
 }
 
+ChannelGroup &WaveTrack::ReallyDoGetChannelGroup() const
+{
+   const Track *pTrack = this;
+   if (const auto pOwner = GetOwner())
+      pTrack = *pOwner->Find(this);
+   const ChannelGroup &group = *pTrack;
+   return const_cast<ChannelGroup&>(group);
+}
+
 TrackListHolder WaveTrack::Clone() const
 {
    assert(IsLeader());

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2537,7 +2537,11 @@ sampleFormat WaveTrack::WidestEffectiveFormat() const
 
 bool WaveTrack::HasTrivialEnvelope() const
 {
-   auto &clips = GetClips();
+   auto pTrack = this;
+   if (GetOwner())
+      // Substitute the leader track
+      pTrack = *TrackList::Channels(this).begin();
+   auto &clips = pTrack->GetClips();
    return std::all_of(clips.begin(), clips.end(),
       [](const auto &pClip){ return pClip->GetEnvelope()->IsTrivial(); });
 }
@@ -2545,6 +2549,11 @@ bool WaveTrack::HasTrivialEnvelope() const
 void WaveTrack::GetEnvelopeValues(
    double* buffer, size_t bufferLen, double t0, bool backwards) const
 {
+   auto pTrack = this;
+   if (GetOwner())
+      // Substitute the leader track
+      pTrack = *TrackList::Channels(this).begin();
+
    if (backwards)
       t0 -= bufferLen / GetRate();
    // The output buffer corresponds to an unbroken span of time which the callers expect
@@ -2566,7 +2575,7 @@ void WaveTrack::GetEnvelopeValues(
    const auto rate = GetRate();
    auto tstep = 1.0 / rate;
    double endTime = t0 + tstep * bufferLen;
-   for (const auto &clip: mClips)
+   for (const auto &clip: pTrack->mClips)
    {
       // IF clip intersects startTime..endTime THEN...
       auto dClipStartTime = clip->GetPlayStartTime();

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -78,8 +78,11 @@ WaveTrack::Interval::~Interval() = default;
 std::shared_ptr<ChannelInterval>
 WaveTrack::Interval::DoGetChannel(size_t iChannel)
 {
-   if (iChannel < NChannels())
-      return std::make_shared<WaveChannelInterval>();
+   if (iChannel < NChannels()) {
+      const auto pClip = (iChannel == 0 ? mpClip : mpClip1);
+      return std::make_shared<WaveChannelInterval>(
+         *pClip, *pClip->GetEnvelope());
+   }
    return {};
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -81,7 +81,9 @@ WaveTrack::Interval::DoGetChannel(size_t iChannel)
    if (iChannel < NChannels()) {
       const auto pClip = (iChannel == 0 ? mpClip : mpClip1);
       return std::make_shared<WaveChannelInterval>(
-         *pClip, *pClip->GetEnvelope());
+         *pClip,
+         // Always the left clip's envelope
+         *mpClip->GetEnvelope());
    }
    return {};
 }
@@ -2699,7 +2701,11 @@ const WaveClip* WaveTrack::GetClipAtTime(double time) const
 
 Envelope* WaveTrack::GetEnvelopeAtTime(double time)
 {
-   WaveClip* clip = GetClipAtTime(time);
+   auto pTrack = this;
+   if (GetOwner())
+      // Substitute the leader track
+      pTrack = *TrackList::Channels(this).begin();
+   WaveClip* clip = pTrack->GetClipAtTime(time);
    if (clip)
       return clip->GetEnvelope();
    else

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -773,6 +773,7 @@ private:
    std::shared_ptr<::Channel> DoGetChannel(size_t iChannel) override;
 
    ChannelGroup &DoGetChannelGroup() const override;
+   ChannelGroup &ReallyDoGetChannelGroup() const override;
 
    //
    // Protected variables

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -58,7 +58,19 @@ class WaveTrack;
 
 class WAVE_TRACK_API WaveChannelInterval final : public ChannelInterval {
 public:
+   //! Assume lifetime of this object nests in those of arguments
+   WaveChannelInterval(WaveClip &clip, Envelope &envelope)
+      : mClip{ clip }
+      , mEnvelope{ envelope }
+   {}
    ~WaveChannelInterval() override;
+
+   const WaveClip &GetClip() const { return mClip; }
+   const Envelope &GetEnvelope() const { return mEnvelope; }
+
+private:
+   WaveClip &mClip;
+   Envelope &mEnvelope;
 };
 
 class WAVE_TRACK_API WaveChannel

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -56,6 +56,11 @@ using ChannelSampleView = std::vector<AudioSegmentSampleView>;
 class Envelope;
 class WaveTrack;
 
+class WAVE_TRACK_API WaveChannelInterval final : public ChannelInterval {
+public:
+   ~WaveChannelInterval() override;
+};
+
 class WAVE_TRACK_API WaveChannel
    : public Channel
    // TODO wide wave tracks -- remove "virtual"
@@ -67,6 +72,15 @@ public:
 
    inline WaveTrack &GetTrack();
    inline const WaveTrack &GetTrack() const;
+
+   auto GetInterval(size_t iInterval) { return
+      ::Channel::GetInterval<WaveChannelInterval>(iInterval); }
+   auto GetInterval(size_t iInterval) const { return
+      ::Channel::GetInterval<const WaveChannelInterval>(iInterval); }
+
+   auto Intervals() { return ::Channel::Intervals<WaveChannelInterval>(); }
+   auto Intervals() const {
+      return ::Channel::Intervals<const WaveChannelInterval>(); }
 
    using WideSampleSequence::GetFloats;
 
@@ -169,6 +183,11 @@ public:
 
    //! May report more than one only when this is a leader track
    size_t NChannels() const override;
+
+   auto GetChannel(size_t iChannel) {
+      return this->ChannelGroup::GetChannel<WaveChannel>(iChannel); }
+   auto GetChannel(size_t iChannel) const {
+      return this->ChannelGroup::GetChannel<const WaveChannel>(iChannel); }
 
    auto Channels() {
       return this->ChannelGroup::Channels<WaveChannel>(); }
@@ -730,6 +749,17 @@ private:
 
       ~Interval() override;
 
+      auto GetChannel(size_t iChannel) { return
+         WideChannelGroupInterval::GetChannel<WaveChannel>(iChannel); }
+      auto GetChannel(size_t iChannel) const { return
+         WideChannelGroupInterval::GetChannel<const WaveChannel>(iChannel); }
+
+      auto Channels() { return
+         WideChannelGroupInterval::Channels<WaveChannel>(); }
+      auto Channels() const { return
+         WideChannelGroupInterval::Channels<const WaveChannel>();
+      }
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)
@@ -740,6 +770,9 @@ private:
       //! TODO wide wave tracks: eliminate this
       const std::shared_ptr<WaveClip> mpClip1;
    };
+
+   auto Intervals() { return ChannelGroup::Intervals<Interval>(); }
+   auto Intervals() const { return ChannelGroup::Intervals<const Interval>(); }
 
    Track::Holder PasteInto(AudacityProject &project, TrackList &list)
       const override;

--- a/src/commands/SetEnvelopeCommand.cpp
+++ b/src/commands/SetEnvelopeCommand.cpp
@@ -69,29 +69,26 @@ void SetEnvelopeCommand::PopulateOrExchange(ShuttleGui & S)
    S.EndMultiColumn();
 }
 
-bool SetEnvelopeCommand::ApplyInner( const CommandContext &context, Track * t )
+bool SetEnvelopeCommand::ApplyInner(const CommandContext &context, Track &t)
 {
    // if no time is specified, then
    //   - delete deletes any envelope in selected tracks.
    //   - value is not set for any clip
-   t->TypeSwitch([&](WaveTrack &waveTrack) {
-      WaveClipPointers ptrs( waveTrack.SortedClipArray());
-      for(auto it = ptrs.begin(); (it != ptrs.end()); it++ ){
-         WaveClip * pClip = *it;
+   t.TypeSwitch([&](WaveTrack &waveTrack) {
+      for (const auto pClip : waveTrack.SortedClipArray()) {
          bool bFound =
             !bHasT || (
-               ( pClip->GetPlayStartTime() <= mT) &&
-               ( pClip->GetPlayEndTime() >= mT )
+               (pClip->GetPlayStartTime() <= mT) &&
+               (pClip->GetPlayEndTime() >= mT)
             );
-         if( bFound )
-         {
+         if (bFound) {
             // Inside this IF is where we actually apply the command
             Envelope* pEnv = pClip->GetEnvelope();
             bool didSomething = false;
-            if( bHasDelete && mbDelete )
+            if (bHasDelete && mbDelete)
                pEnv->Clear(), didSomething = true;
-            if( bHasT && bHasV )
-               pEnv->InsertOrReplace( mT, pEnv->ClampValue( mV ) ),
+            if (bHasT && bHasV)
+               pEnv->InsertOrReplace(mT, pEnv->ClampValue(mV)),
                didSomething = true;
 
             if (didSomething)
@@ -103,6 +100,7 @@ bool SetEnvelopeCommand::ApplyInner( const CommandContext &context, Track * t )
          }
       }
    } );
+
 
    return true;
 }

--- a/src/commands/SetEnvelopeCommand.h
+++ b/src/commands/SetEnvelopeCommand.h
@@ -18,7 +18,7 @@
 
 #include "SetTrackInfoCommand.h"
 
-class SetEnvelopeCommand : public SetChannelsBase
+class SetEnvelopeCommand : public SetTrackBase
 {
 public:
    static const ComponentInterfaceSymbol Symbol;
@@ -34,7 +34,7 @@ public:
 
    // AudacityCommand overrides
    ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_envelope";}
-   bool ApplyInner( const CommandContext & context, Track * t ) override;
+   bool ApplyInner(const CommandContext & context, Track &t) override;
 
 public:
    double mT;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackShifter.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackShifter.cpp
@@ -123,7 +123,8 @@ public:
 
    Intervals Detach() override
    {
-      auto pRight = mpTrack->GetChannel<WaveTrack>(1);
+      // TODO wide wave tracks -- simplify when clips are really wide
+      auto pRight = mpTrack->ChannelGroup::GetChannel<WaveTrack>(1);
       for (auto &interval: mMoving) {
          auto &data = static_cast<WaveTrack::Interval&>(*interval);
          auto pClip = data.GetClip(0).get();
@@ -160,7 +161,8 @@ public:
          auto &data = static_cast<WaveTrack::Interval&>(*interval);
          WaveClipHolder clips[2];
          for (size_t ii : { 0, 1 }) {
-            auto pTrack = mpTrack->GetChannel<WaveTrack>(ii);
+            // TODO wide wave tracks -- simplify when clips are really wide
+            auto pTrack = mpTrack->ChannelGroup::GetChannel<WaveTrack>(ii);
             auto &pClip = clips[ii] = data.GetClip(ii);
             if (pClip) {
                // TODO wide wave tracks -- guarantee matching clip width

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -66,6 +66,9 @@ bool WaveClipWaveformCache::GetWaveDisplay(
    const WaveClip &clip, size_t channel, WaveDisplay &display, double t0,
    double pixelsPerSecond )
 {
+   // TODO wide wave tracks -- don't reassign
+   channel = 0;
+
    auto &waveCache = mWaveCaches[channel];
 
    t0 += clip.GetTrimLeft();

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -447,7 +447,7 @@ void DrawIndividualSamples(TrackPanelDrawingContext &context, size_t channel,
    int leftOffset, const wxRect &rect,
    float zoomMin, float zoomMax,
    bool dB, float dBRange,
-   const WaveClip *clip,
+   const WaveClip &clip, const Envelope &envelope,
    bool showPoints, bool muted,
    bool highlight)
 {
@@ -455,11 +455,11 @@ void DrawIndividualSamples(TrackPanelDrawingContext &context, size_t channel,
    const auto artist = TrackArtist::Get( context );
    const auto &zoomInfo = *artist->pZoomInfo;
 
-   const double toffset = clip->GetPlayStartTime();
-   double rate = clip->GetRate();
+   const double toffset = clip.GetPlayStartTime();
+   double rate = clip.GetRate();
    const double t0 = std::max(0.0, zoomInfo.PositionToTime(0, -leftOffset) - toffset);
    const auto s0 = sampleCount(floor(t0 * rate));
-   const auto snSamples = clip->GetVisibleSampleCount();
+   const auto snSamples = clip.GetVisibleSampleCount();
    if (s0 > snSamples)
       return;
 
@@ -474,7 +474,7 @@ void DrawIndividualSamples(TrackPanelDrawingContext &context, size_t channel,
       return;
 
    Floats buffer{ size_t(slen) };
-   clip->GetSamples(channel, (samplePtr)buffer.get(), floatSample, s0, slen,
+   clip.GetSamples(channel, (samplePtr)buffer.get(), floatSample, s0, slen,
                     // Suppress exceptions in this drawing operation:
                     false);
 
@@ -500,8 +500,7 @@ void DrawIndividualSamples(TrackPanelDrawingContext &context, size_t channel,
       xpos[s] = xx;
 
       // Calculate sample as it would be rendered, so quantize time
-      double value =
-         clip->GetEnvelope()->GetValue( time, 1.0 / clip->GetRate() );
+      double value = envelope.GetValue(time, 1.0 / clip.GetRate());
       const double tt = buffer[s] * value;
 
       if (clipped && bShowClipping && ((tt <= -MAX_AUDIO) || (tt >= MAX_AUDIO)))
@@ -641,9 +640,9 @@ void DrawEnvelope(TrackPanelDrawingContext &context,
 //#include "tracks/playabletrack/wavetrack/ui/SampleHandle.h"
 //#include "tracks/ui/EnvelopeHandle.h"
 void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
-   const WaveTrack *track,
-   const WaveClip *clip,
-   const wxRect & rect,
+   const WaveTrack &track,
+   const WaveClip &clip, const Envelope &envelope,
+   const wxRect &rect,
    bool dB,
    bool muted,
    bool selected)
@@ -663,15 +662,15 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
 
    //If clip is "too small" draw a placeholder instead of
    //attempting to fit the contents into a few pixels
-   if (!WaveChannelView::ClipDetailsVisible(*clip, zoomInfo, rect))
+   if (!WaveChannelView::ClipDetailsVisible(clip, zoomInfo, rect))
    {
-      auto clipRect = ClipParameters::GetClipRect(*clip, zoomInfo, rect);
+      auto clipRect = ClipParameters::GetClipRect(clip, zoomInfo, rect);
       TrackArt::DrawClipFolded(dc, clipRect);
       return;
    }
 
    const ClipParameters params{
-      false, track, clip, rect, selectedRegion, zoomInfo };
+      false, &track, &clip, rect, selectedRegion, zoomInfo };
    const wxRect &hiddenMid = params.hiddenMid;
    // The "hiddenMid" rect contains the part of the display actually
    // containing the waveform, as it appears without the fisheye.  If it's empty, we're done.
@@ -690,22 +689,22 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
    double leftOffset = params.leftOffset;
    const wxRect &mid = params.mid;
 
-   auto &settings = WaveformSettings::Get(*track);
+   auto &settings = WaveformSettings::Get(track);
    const float dBRange = settings.dBRange;
 
    dc.SetPen(*wxTRANSPARENT_PEN);
-   int iColorIndex = clip->GetColourIndex();
+   int iColorIndex = clip.GetColourIndex();
    artist->SetColours( iColorIndex );
 
    // The bounds (controlled by vertical zooming; -1.0...1.0
    // by default)
    float zoomMin, zoomMax;
-   auto &cache = WaveformScale::Get(*track);
+   auto &cache = WaveformScale::Get(track);
    cache.GetDisplayBounds(zoomMin, zoomMax);
 
    std::vector<double> vEnv(mid.width);
    double *const env = &vEnv[0];
-   CommonChannelView::GetEnvelopeValues(*clip->GetEnvelope(),
+   CommonChannelView::GetEnvelopeValues(envelope,
        tOffset,
 
         // PRL: change back to make envelope evaluate only at sample times
@@ -719,9 +718,11 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
    // part of the waveform
    {
       double tt0, tt1;
-      if (SyncLock::IsSelectedOrSyncLockSelected(track)) {
-         tt0 = track->LongSamplesToTime(track->TimeToLongSamples(selectedRegion.t0())),
-            tt1 = track->LongSamplesToTime(track->TimeToLongSamples(selectedRegion.t1()));
+      if (SyncLock::IsSelectedOrSyncLockSelected(&track)) {
+         tt0 = track.LongSamplesToTime(
+            track.TimeToLongSamples(selectedRegion.t0()));
+         tt1 = track.LongSamplesToTime(
+            track.TimeToLongSamples(selectedRegion.t1()));
       }
       else
          tt0 = tt1 = 0.0;
@@ -731,7 +732,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
          cache.ZeroLevelYCoordinate(mid),
          dB, dBRange,
          tt0, tt1,
-         !track->GetSelected(), highlightEnvelope);
+         !track.GetSelected(), highlightEnvelope);
    }
 
    WaveDisplay display(hiddenMid.width);
@@ -750,7 +751,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
    // Require at least 3 pixels per sample for drawing the draggable points.
    const double threshold2 = 3 * rate;
 
-   auto &clipCache = WaveClipWaveformCache::Get(*clip);
+   auto &clipCache = WaveClipWaveformCache::Get(clip);
 
    {
       bool showIndividualSamples = false;
@@ -771,7 +772,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
          // fisheye moves over the background, there is then less to do when
          // redrawing.
 
-         if (!clipCache.GetWaveDisplay(*clip, channel, display,
+         if (!clipCache.GetWaveDisplay(clip, channel, display,
             t0, pps))
             return;
       }
@@ -793,7 +794,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
       if (portion.inFisheye) {
          if (!showIndividualSamples) {
             fisheyeDisplay.Allocate();
-            const auto numSamples = clip->GetVisibleSampleCount();
+            const auto numSamples = clip.GetVisibleSampleCount();
             // Get wave display data for different magnification
             int jj = 0;
             for (; jj < rectPortion.width; ++jj) {
@@ -821,7 +822,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
             fisheyeDisplay.width -= skipped;
             // Get a wave display for the fisheye, uncached.
             if (rectPortion.width > 0)
-               if (!clipCache.GetWaveDisplay(*clip, channel,
+               if (!clipCache.GetWaveDisplay(clip, channel,
                      fisheyeDisplay, t0, -1.0)) // ignored
                   continue; // serious error.  just don't draw??
             useMin = fisheyeDisplay.min;
@@ -842,11 +843,11 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
          if (!showIndividualSamples) {
             std::vector<double> vEnv2(rectPortion.width);
             double *const env2 = &vEnv2[0];
-            CommonChannelView::GetEnvelopeValues(*clip->GetEnvelope(),
+            CommonChannelView::GetEnvelopeValues(envelope,
                 tOffset,
 
-                 // PRL: change back to make envelope evaluate only at sample times
-                 // and then interpolate the display
+                 // PRL: change back to make envelope evaluate only at sample
+                 // times and then interpolate the display
                  0, // 1.0 / rate,
 
                  env2, rectPortion.width, leftOffset, zoomInfo);
@@ -865,8 +866,8 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
             DrawIndividualSamples(
                context, channel, leftOffset, rectPortion, zoomMin, zoomMax,
                dB, dBRange,
-               clip,
-               showPoints, muted, highlight );
+               clip, envelope,
+               showPoints, muted, highlight);
          }
       }
 
@@ -876,9 +877,9 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
    const auto drawEnvelope = artist->drawEnvelope;
    if (drawEnvelope) {
       DrawEnvelope(
-         context, mid, env, zoomMin, zoomMax, dB, dBRange, highlightEnvelope );
-      EnvelopeEditor::DrawPoints( *clip->GetEnvelope(),
-          context, mid, dB, dBRange, zoomMin, zoomMax, true, rect.x - mid.x );
+         context, mid, env, zoomMin, zoomMax, dB, dBRange, highlightEnvelope);
+      EnvelopeEditor::DrawPoints(envelope,
+          context, mid, dB, dBRange, zoomMin, zoomMax, true, rect.x - mid.x);
    }
 
    // Draw arrows on the left side if the track extends to the left of the
@@ -887,7 +888,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
       TrackArt::DrawNegativeOffsetTrackArrows( context, rect );
    }
    {
-      auto clipRect = ClipParameters::GetClipRect(*clip, zoomInfo, rect);
+      auto clipRect = ClipParameters::GetClipRect(clip, zoomInfo, rect);
       TrackArt::DrawClipEdges(dc, clipRect, selected);
    }
 }
@@ -955,7 +956,7 @@ void DrawTimeSlider( TrackPanelDrawingContext &context,
 // Header needed only for experimental drawing below
 //#include "tracks/ui/TimeShiftHandle.h"
 void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
-   const WaveTrack *track,
+   const WaveTrack &track,
    const WaveClip* selectedClip,
    const wxRect& rect,
    bool muted)
@@ -971,19 +972,19 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
    highlight = target && target->GetTrack().get() == track;
 #endif
 
-   const bool dB = !WaveformSettings::Get(*track).isLinear();
+   const bool dB = !WaveformSettings::Get(track).isLinear();
 
    const auto &blankSelectedBrush = artist->blankSelectedBrush;
    const auto &blankBrush = artist->blankBrush;
    TrackArt::DrawBackgroundWithSelection(
-      context, rect, track, blankSelectedBrush, blankBrush );
+      context, rect, &track, blankSelectedBrush, blankBrush );
 
-   for (const auto& clip : track->GetClips())
-   {
-      DrawClipWaveform(context, channel, track, clip.get(), rect,
+   for (const auto& clip : track.GetClips()) {
+      DrawClipWaveform(context, channel, track,
+         *clip, *clip->GetEnvelope(), rect,
          dB, muted, clip.get() == selectedClip);
    }
-   DrawBoldBoundaries( context, track, rect );
+   DrawBoldBoundaries(context, &track, rect);
 
    const auto drawSliders = artist->drawSliders;
    if (drawSliders) {
@@ -1025,8 +1026,7 @@ void WaveformView::Draw(
       wxASSERT(waveChannelView.use_count());
 
       auto selectedClip = waveChannelView->GetSelectedClip().lock();
-      DoDraw(context, GetChannelIndex(),
-         wt.get(), selectedClip.get(), rect, muted);
+      DoDraw(context, GetChannelIndex(), *wt, selectedClip.get(), rect, muted);
 
 #if defined(__WXMAC__)
       dc.GetGraphicsContext()->SetAntialiasMode(aamode);

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.h
@@ -37,7 +37,7 @@ private:
       TrackPanelDrawingContext &context,
       const wxRect &rect, unsigned iPass ) override;
    static void DoDraw(TrackPanelDrawingContext &context, size_t channel,
-      const WaveTrack *track,
+      const WaveTrack &track,
       const WaveClip* selectedClip,
       const wxRect & rect,
       bool muted);

--- a/src/tracks/ui/EnvelopeHandle.h
+++ b/src/tracks/ui/EnvelopeHandle.h
@@ -88,7 +88,7 @@ private:
    double mdBRange{};
 
    Envelope *mEnvelope{};
-   std::vector< std::unique_ptr<EnvelopeEditor> > mEnvelopeEditors;
+   std::unique_ptr<EnvelopeEditor> mpEnvelopeEditor;
 
    bool mTimeTrack{};
 };


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Depends on:
- #5008 

Use only the Envelope stored in the leader channel (while we don't yet have proper wide wave clips),
for drawing, hit-testing, all details of Mixer, and the Set Envelope command.

There are still useless Envelopes in clips of the right channel, but they are ignored.

This eliminates one use of TrackList::Channels outside WaveTrack.cpp or Track.cpp.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

Test checklist:
- [x] Display and editing of envelopes in stereo tracks; click and drag works in either channel, curves are same in each
- [x] Pencil tool (and alt-key paintbrush) works in both channels, when there is nontrivial envelope
- [x] Test envelope and pencil also with the "*" multi-tool
- [x] Swap stereo channels
- [x] Mix-and-render and playback with nontrivial envelope is correct in both channels
- [x] "Set Envelope" macro command

