### PR TITLE
Waveform view rewrites

### DIFF
--- a/libraries/lib-stretching-sequence/ClipInterface.cpp
+++ b/libraries/lib-stretching-sequence/ClipInterface.cpp
@@ -1,3 +1,5 @@
 #include "ClipInterface.h"
 
+ClipTimes::~ClipTimes() = default;
+
 ClipInterface::~ClipInterface() = default;

--- a/libraries/lib-stretching-sequence/ClipInterface.h
+++ b/libraries/lib-stretching-sequence/ClipInterface.h
@@ -30,6 +30,8 @@ public:
 
    virtual double GetPlayEndTime() const = 0;
 
+   virtual sampleCount TimeToSamples(double time) const = 0;
+
    virtual double GetStretchRatio() const = 0;
 };
 

--- a/libraries/lib-stretching-sequence/ClipInterface.h
+++ b/libraries/lib-stretching-sequence/ClipInterface.h
@@ -14,21 +14,15 @@
 #include "SampleCount.h"
 #include "SampleFormat.h"
 
-class STRETCHING_SEQUENCE_API ClipInterface
+class STRETCHING_SEQUENCE_API ClipTimes
 {
 public:
-   virtual ~ClipInterface();
-
-   virtual AudioSegmentSampleView GetSampleView(
-      size_t iChannel, sampleCount start, size_t length,
-      bool mayThrow = true) const = 0;
+   virtual ~ClipTimes();
 
    /*!
     * The number of raw audio samples not hidden by trimming.
     */
    virtual sampleCount GetVisibleSampleCount() const = 0;
-
-   virtual size_t GetWidth() const = 0;
 
    virtual int GetRate() const = 0;
 
@@ -37,6 +31,18 @@ public:
    virtual double GetPlayEndTime() const = 0;
 
    virtual double GetStretchRatio() const = 0;
+};
+
+class STRETCHING_SEQUENCE_API ClipInterface : public ClipTimes
+{
+public:
+   ~ClipInterface() override;
+
+   virtual AudioSegmentSampleView
+   GetSampleView(size_t iChannel, sampleCount start, size_t length,
+      bool mayThrow = true) const = 0;
+
+   virtual size_t GetWidth() const = 0;
 };
 
 using ClipHolders = std::vector<std::shared_ptr<ClipInterface>>;

--- a/libraries/lib-stretching-sequence/tests/FloatVectorClip.cpp
+++ b/libraries/lib-stretching-sequence/tests/FloatVectorClip.cpp
@@ -10,6 +10,7 @@
 **********************************************************************/
 
 #include "FloatVectorClip.h"
+#include <cmath>
 
 FloatVectorClip::FloatVectorClip(
    int sampleRate, const std::vector<std::vector<float>>& audio)
@@ -60,6 +61,11 @@ size_t FloatVectorClip::GetWidth() const
 int FloatVectorClip::GetRate() const
 {
    return mSampleRate;
+}
+
+sampleCount FloatVectorClip::TimeToSamples(double time) const
+{
+   return sampleCount(floor(time * GetRate() + 0.5));
 }
 
 double FloatVectorClip::GetPlayDuration() const

--- a/libraries/lib-stretching-sequence/tests/FloatVectorClip.h
+++ b/libraries/lib-stretching-sequence/tests/FloatVectorClip.h
@@ -42,6 +42,8 @@ public:
       return playStartTime + GetPlayDuration();
    }
 
+   sampleCount TimeToSamples(double time) const override;
+
    double GetStretchRatio() const override
    {
       return stretchRatio;

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1144,7 +1144,7 @@ const wxString& WaveClip::GetName() const
    return mName;
 }
 
-sampleCount WaveClip::TimeToSamples(double time) const noexcept
+sampleCount WaveClip::TimeToSamples(double time) const
 {
    return sampleCount(floor(time * mRate / GetStretchRatio() + 0.5));
 }

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -177,8 +177,8 @@ public:
    // the length of the clip
    void Resample(int rate, BasicUI::ProgressDialog *progress = NULL);
 
-   void SetColourIndex( int index ){ mColourIndex = index;};
-   int GetColourIndex( ) const { return mColourIndex;};
+   void SetColourIndex(int index) { mColourIndex = index; }
+   int GetColourIndex() const { return mColourIndex; }
 
    double GetSequenceStartTime() const noexcept;
    void SetSequenceStartTime(double startTime);
@@ -493,7 +493,7 @@ public:
 
    // TimeToSamples and SamplesToTime take clip stretch ratio into account.
    // Use them to convert time / sample offsets.
-   sampleCount TimeToSamples(double time) const noexcept;
+   sampleCount TimeToSamples(double time) const override;
    double SamplesToTime(sampleCount s) const noexcept;
 
    //! Silences the 'length' amount of samples starting from 'offset'(relative to the play start)

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -185,6 +185,54 @@ WaveTrack::Interval::Interval(const ChannelGroup &group,
 
 WaveTrack::Interval::~Interval() = default;
 
+void WaveTrack::Interval::SetName(const wxString& name)
+{
+   ForEachClip([&](auto& clip) { clip.SetName(name); });
+}
+
+const wxString& WaveTrack::Interval::GetName() const
+{
+   //TODO wide wave tracks:  assuming that all 'narrow' clips share common name
+   return mpClip->GetName();
+}
+
+void WaveTrack::Interval::SetColorIndex(int index)
+{
+   ForEachClip([&](auto& clip) { clip.SetColourIndex(index); });
+}
+
+int WaveTrack::Interval::GetColorIndex() const
+{
+   //TODO wide wave tracks:  assuming that all 'narrow' clips share common color index
+   return mpClip->GetColourIndex();
+}
+
+void WaveTrack::Interval::SetPlayStartTime(double time)
+{
+   ForEachClip([&](auto& clip) { clip.SetPlayStartTime(time); });
+}
+
+double WaveTrack::Interval::GetPlayStartTime() const
+{
+   //TODO wide wave tracks:  assuming that all 'narrow' clips share common beginning
+   return mpClip->GetPlayStartTime();
+}
+
+bool WaveTrack::Interval::IsPlaceholder() const
+{
+   return mpClip->GetIsPlaceholder();
+}
+
+void WaveTrack::Interval::ForEachClip(const std::function<void(WaveClip&)>& op)
+{
+   for(unsigned channel = 0,
+      channelCount = NChannels();
+      channel < channelCount; ++channel)
+   {
+      op(*GetClip(channel));
+   }
+}
+
 std::shared_ptr<ChannelInterval>
 WaveTrack::Interval::DoGetChannel(size_t iChannel)
 {

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -86,6 +86,12 @@ WaveChannelInterval::GetSampleView(double t0, double t1, bool mayThrow) const
    return GetNarrowClip().GetSampleView(iChannel, t0, t1, mayThrow);
 }
 
+const Envelope &WaveChannelInterval::GetEnvelope() const
+{
+   // Always the left clip's envelope
+   return *mWideClip.GetEnvelope();
+}
+
 sampleCount WaveChannelInterval::GetVisibleSampleCount() const
 {
    return GetNarrowClip().GetVisibleSampleCount();
@@ -186,10 +192,7 @@ WaveTrack::Interval::DoGetChannel(size_t iChannel)
       // TODO wide wave tracks: there will be only one, wide clip
       const auto pClip = (iChannel == 0 ? mpClip : mpClip1);
       return std::make_shared<WaveChannelInterval>(*mpClip,
-         *pClip,
-         // Always the left clip's envelope
-         *mpClip->GetEnvelope(),
-         iChannel);
+         *pClip, iChannel);
    }
    return {};
 }

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -74,7 +74,6 @@ public:
    ~WaveChannelInterval() override;
 
    const WaveClip &GetClip() const { return mWideClip; }
-   const WaveClip &GetNarrowClip() const { return mNarrowClip; }
    const Envelope &GetEnvelope() const { return mEnvelope; }
    size_t GetChannelIndex() const { return miChannel; }
 
@@ -119,6 +118,8 @@ public:
    int GetColourIndex() const;
 
 private:
+   const WaveClip &GetNarrowClip() const { return mNarrowClip; }
+
    WaveClip &mWideClip;
    WaveClip &mNarrowClip;
    Envelope &mEnvelope;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -834,6 +834,15 @@ private:
 
       ~Interval() override;
 
+      void SetName(const wxString& name);
+      const wxString& GetName() const;
+
+      void SetColorIndex(int index);
+      int GetColorIndex() const;
+
+      void SetPlayStartTime(double time);
+      double GetPlayStartTime() const;
+
       auto GetChannel(size_t iChannel) { return
          WideChannelGroupInterval::GetChannel<WaveChannel>(iChannel); }
       auto GetChannel(size_t iChannel) const { return
@@ -845,11 +854,17 @@ private:
          WideChannelGroupInterval::Channels<const WaveChannel>();
       }
 
+      bool IsPlaceholder() const;
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)
       { return iChannel == 0 ? mpClip : mpClip1; }
    private:
+
+      // Helper function in time of migration to wide clips
+      void ForEachClip(const std::function<void(WaveClip&)>& op);
+
       std::shared_ptr<ChannelInterval> DoGetChannel(size_t iChannel) override;
       const std::shared_ptr<WaveClip> mpClip;
       //! TODO wide wave tracks: eliminate this

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -64,17 +64,15 @@ class WAVE_TRACK_API WaveChannelInterval final
 {
 public:
    //! Assume lifetime of this object nests in those of arguments
-   WaveChannelInterval(WaveClip &wideClip, WaveClip &narrowClip,
-      Envelope &envelope, size_t iChannel
+   WaveChannelInterval(WaveClip &wideClip, WaveClip &narrowClip, size_t iChannel
    )  : mWideClip{ wideClip }
       , mNarrowClip{ narrowClip }
-      , mEnvelope{ envelope }
       , miChannel{ iChannel }
    {}
    ~WaveChannelInterval() override;
 
    const WaveClip &GetClip() const { return mWideClip; }
-   const Envelope &GetEnvelope() const { return mEnvelope; }
+   const Envelope &GetEnvelope() const;
    size_t GetChannelIndex() const { return miChannel; }
 
    bool Intersects(double t0, double t1) const;
@@ -122,7 +120,6 @@ private:
 
    WaveClip &mWideClip;
    WaveClip &mNarrowClip;
-   Envelope &mEnvelope;
    const size_t miChannel;
 };
 

--- a/libraries/lib-wave-track/WideClip.cpp
+++ b/libraries/lib-wave-track/WideClip.cpp
@@ -47,6 +47,11 @@ double WideClip::GetPlayEndTime() const
    return mChannels[0u]->GetPlayEndTime();
 }
 
+sampleCount WideClip::TimeToSamples(double time) const
+{
+   return mChannels[0u]->TimeToSamples(time);
+}
+
 double WideClip::GetStretchRatio() const
 {
    return mChannels[0u]->GetStretchRatio();

--- a/libraries/lib-wave-track/WideClip.h
+++ b/libraries/lib-wave-track/WideClip.h
@@ -42,6 +42,8 @@ public:
 
    double GetPlayEndTime() const override;
 
+   sampleCount TimeToSamples(double time) const override;
+
    double GetStretchRatio() const override;
 
 private:

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -41,7 +41,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "TrackPanel.h"
 #include "UndoManager.h"
 #include "WaveTrack.h"
-#include "WaveClip.h"
 #include "wxFileNameWrapper.h"
 #include "Export.h"
 #include "Import.h"
@@ -1142,10 +1141,9 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
       newTrack->TypeSwitch([&](WaveTrack &wt) {
          if (newRate == 0)
             newRate = wt.GetRate();
-         auto trackName = wt.GetName();
-         for (const auto pChannel : TrackList::Channels(&wt))
-            for (auto& clip : pChannel->GetClips())
-               clip->SetName(trackName);
+         const auto trackName = wt.GetName();
+         for(const auto& interval : wt.Intervals())
+            interval->SetName(trackName);
       });
    }
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -886,13 +886,16 @@ std::vector<int> FindAdjustedChannelHeights(Track &t)
    int nAffordances = 0;
    int totalHeight = 0;
    std::vector<int> oldHeights;
+   bool first = true;
    for (auto pChannel : channels) {
       auto &view = ChannelView::Get(*pChannel);
       const auto height = view.GetHeight();
       totalHeight += height;
       oldHeights.push_back(height);
-      if (view.GetAffordanceControls())
+      // Only the first channel of a group may have an affordance
+      if (first && view.GetAffordanceControls())
          ++nAffordances;
+      first = false;
    }
 
    // Allocate results
@@ -1410,7 +1413,7 @@ struct HorizontalGroup final : TrackPanelGroup {
 };
 
 
-// optional affordance areas, and n channels with vertical rulers,
+// optional affordance area, and n channels with vertical rulers,
 // alternating with n - 1 resizers;
 // each channel-ruler pair might be divided into multiple views
 struct ChannelStack final : TrackPanelGroup {
@@ -1429,20 +1432,24 @@ struct ChannelStack final : TrackPanelGroup {
       wxCoord yy = rect.GetTop();
       auto heights = FindAdjustedChannelHeights(*mpTrack);
       auto pHeight = heights.begin();
+      bool first = true;
       for (auto pChannel : channels) {
-         auto &view = ChannelView::Get(*pChannel);
-         if (auto affordance = view.GetAffordanceControls()) {
-            auto panelRect = std::make_shared<EmptyPanelRect>(pChannel,
-               mpTrack->GetSelected()
-                  ? clrTrackInfoSelected : clrTrackInfo);
-            Refinement hgroup {
-               std::make_pair(rect.GetLeft() + 1, panelRect),
-               std::make_pair(mLeftOffset, affordance)
-            };
-            refinement
-               .emplace_back(yy, std::make_shared<HorizontalGroup>(hgroup));
-            yy += kAffordancesAreaHeight;
+         if (first) {
+            auto &view = ChannelView::Get(*pChannel);
+            if (auto affordance = view.GetAffordanceControls()) {
+               auto panelRect = std::make_shared<EmptyPanelRect>(pChannel,
+                  mpTrack->GetSelected()
+                     ? clrTrackInfoSelected : clrTrackInfo);
+               Refinement hgroup {
+                  std::make_pair(rect.GetLeft() + 1, panelRect),
+                  std::make_pair(mLeftOffset, affordance)
+               };
+               refinement
+                  .emplace_back(yy, std::make_shared<HorizontalGroup>(hgroup));
+               yy += kAffordancesAreaHeight;
+            }
          }
+         first = false;
 
          auto height = *pHeight++;
          rect.SetTop(yy);
@@ -1474,11 +1481,14 @@ struct ChannelStack final : TrackPanelGroup {
          assert(mpTrack->IsLeader()); // by construction
          auto heights = FindAdjustedChannelHeights(*mpTrack);
          auto pHeight = heights.begin();
+         bool first = true;
          for (auto pChannel : channels) {
             auto& view = ChannelView::Get(*pChannel);
             auto height = *pHeight++;
-            if (auto affordance = view.GetAffordanceControls())
-               height += kAffordancesAreaHeight;
+            if (first)
+               if (auto affordance = view.GetAffordanceControls())
+                  height += kAffordancesAreaHeight;
+            first = false;
             auto trackRect = wxRect(
                mLeftOffset,
                yy,

--- a/src/commands/SetClipCommand.cpp
+++ b/src/commands/SetClipCommand.cpp
@@ -19,11 +19,11 @@
 
 #include "SetClipCommand.h"
 
+#include "CommandContext.h"
 #include "CommandDispatch.h"
 #include "CommandManager.h"
 #include "../CommonCommandFlags.h"
 #include "LoadCommands.h"
-#include "WaveClip.h"
 #include "WaveTrack.h"
 #include "SettingsVisitor.h"
 #include "ShuttleGui.h"
@@ -85,34 +85,34 @@ void SetClipCommand::PopulateOrExchange(ShuttleGui & S)
    S.EndMultiColumn();
 }
 
-bool SetClipCommand::ApplyInner( const CommandContext &, Track * t )
+bool SetClipCommand::Apply(const CommandContext& context)
 {
-   // if no 'At' is specified, then any clip in any selected track will be set.
-   t->TypeSwitch([&](WaveTrack &waveTrack) {
-      WaveClipPointers ptrs( waveTrack.SortedClipArray());
-      for(auto it = ptrs.begin(); (it != ptrs.end()); it++ ){
-         WaveClip * pClip = *it;
-         bool bFound =
-            !bHasContainsTime || (
-               ( pClip->GetPlayStartTime() <= mContainsTime ) &&
-               ( pClip->GetPlayEndTime() >= mContainsTime )
-            );
-         if( bFound )
+   for(const auto track : TrackList::Get(context.project))
+   {
+      if(!track->GetSelected())
+         continue;
+
+      // if no 'At' is specified, then any clip in any selected track will be set.
+      track->TypeSwitch([&](WaveTrack &waveTrack) {
+         for(const auto& interval : waveTrack.Intervals())
          {
-            // Inside this IF is where we actually apply the command
-
-            if( bHasColour )
-               pClip->SetColourIndex(mColour);
-            // No validation of overlap yet.  We assume the user is sensible!
-            if( bHasT0 )
-               pClip->SetPlayStartTime(mT0);
-            // \todo Use SetClip to move a clip between tracks too.
-            if( bHasName )
-               pClip->SetName(mName);
-
+            if(!bHasContainsTime || 
+               (interval->Start() <= mContainsTime &&
+               interval->End() >= mContainsTime ))
+            {
+               // Inside this IF is where we actually apply the command
+               if( bHasColour )
+                  interval->SetColorIndex(mColour);
+               // No validation of overlap yet.  We assume the user is sensible!
+               if( bHasT0 )
+                  interval->SetPlayStartTime(mT0);
+               // \todo Use SetClip to move a clip between tracks too.
+               if( bHasName )
+                  interval->SetName(mName);
+            }
          }
-      }
-   } );
+      } );
+   }
    return true;
 }
 

--- a/src/commands/SetClipCommand.h
+++ b/src/commands/SetClipCommand.h
@@ -18,7 +18,7 @@
 
 #include "SetTrackInfoCommand.h"
 
-class SetClipCommand : public SetChannelsBase
+class SetClipCommand : public AudacityCommand
 {
 public:
    static const ComponentInterfaceSymbol Symbol;
@@ -34,7 +34,7 @@ public:
 
    // AudacityCommand overrides
    ManualPageID ManualPage() override {return L"Extra_Menu:_Scriptables_I#set_clip";}
-   bool ApplyInner( const CommandContext & context, Track * t ) override;
+   bool Apply( const CommandContext & context ) override;
 
 public:
    double mContainsTime;

--- a/src/commands/SetTrackInfoCommand.cpp
+++ b/src/commands/SetTrackInfoCommand.cpp
@@ -19,11 +19,6 @@ SetTrackVisualsCommand
 loops over selected tracks. Subclasses override ApplyInner() to change
 one track.
 
-\class SetChannelsBase
-\brief Base class for the various track modifying command classes, that
-loops over channels of selected tracks. Subclasses override ApplyInner() to
-change one channel.
-
 \class SetTrackStatusCommand
 \brief A SetChannelsBase that sets name, selected and focus.
 
@@ -64,17 +59,6 @@ bool SetTrackBase::Apply(const CommandContext & context)
    for (auto t : tracks) {
       if (t->GetSelected())
          ApplyInner(context, *t);
-   }
-   return true;
-}
-
-bool SetChannelsBase::Apply(const CommandContext & context)
-{
-   auto &tracks = TrackList::Get(context.project);
-   for (auto t : tracks) {
-      if (t->GetSelected())
-         for (Track *channel : TrackList::Channels(t))
-            ApplyInner(context, channel);
    }
    return true;
 }

--- a/src/commands/SetTrackInfoCommand.h
+++ b/src/commands/SetTrackInfoCommand.h
@@ -29,14 +29,6 @@ public:
    virtual bool ApplyInner(const CommandContext &context, Track &t) = 0;
 };
 
-class SetChannelsBase : public AudacityCommand
-{
-public:
-   bool Apply(const CommandContext & context) final;
-   virtual bool ApplyInner(const CommandContext &context, Track *t) = 0;
-};
-
-
 class SetTrackStatusCommand : public SetTrackBase
 {
 public:

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -30,7 +30,6 @@
 #include "ShuttleGui.h"
 #include "SyncLock.h"
 #include "WaveTrack.h"
-#include "WaveClip.h"
 #include "../widgets/NumericTextCtrl.h"
 #include "../widgets/valnum.h"
 
@@ -122,11 +121,7 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
          auto tempList = track.Copy(mT0, mT1);
          const auto firstTemp = *tempList->Any<const WaveTrack>().begin();
 
-         std::vector<wxString> clipNames;
-         for (auto clip : firstTemp->SortedClipArray()){
-            if (!clip->GetIsPlaceholder())
-               clipNames.push_back(clip->GetName());
-         }
+         
 
          auto t0 = tc;
          for (size_t j = 0; j < repeatCount; ++j) {
@@ -141,25 +136,40 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
          if (t0 > maxDestLen)
             maxDestLen = t0;
 
-         for (const auto pChannel : TrackList::Channels(&track)) {
-            auto clips = pChannel->SortedClipArray();
-            for (size_t i = 0; i < clips.size(); ++i) {
-               const auto eps = 0.5 / track.GetRate();
-               //Find first pasted clip
-               if (std::abs(clips[i]->GetPlayStartTime() - tc) > eps)
-                  continue;
+         const auto compareIntervals = [](const auto& a, const auto& b) {
+            return a->Start() < b->Start();
+         };
 
-               //Fix pasted clips names
-               for(size_t j = 0; j < repeatCount; ++j) {
-                  for (size_t k = 0; k < clipNames.size(); ++k)
-                     if (i + k < clips.size())
-                        clips[i + k]->SetName(clipNames[k]);
-                  i += clipNames.size();
+         const auto eps = 0.5 / track.GetRate();
+         auto sortedIntervals = std::vector(
+            track.Intervals().begin(),
+            track.Intervals().end()
+         );
+         auto sourceIntervals = std::vector(
+            firstTemp->Intervals().begin(),
+            firstTemp->Intervals().end()
+         );
+         std::sort(sortedIntervals.begin(), sortedIntervals.end(), compareIntervals);
+         std::sort(sourceIntervals.begin(), sourceIntervals.end(), compareIntervals);
+         for (auto it = sortedIntervals.begin(); it != sortedIntervals.end(); ++it)
+         {
+            const auto& interval = *it;
+            //Find first pasted interval
+            if (std::abs((*it)->GetPlayStartTime() - tc) > eps)
+               continue;
+
+            //Fix pasted clips names
+            for(int j = 0; j < repeatCount; ++j)
+            {
+               for (const auto& src : sourceIntervals)
+               {
+                  if(it == sortedIntervals.end())
+                     break;
+                  (*it++)->SetName(src->GetName());
                }
-               break;
             }
+            break;
          }
-
          nTrack++;
       }; },
       [&](Track &t)

--- a/src/tracks/playabletrack/wavetrack/WaveTrackUtils.h
+++ b/src/tracks/playabletrack/wavetrack/WaveTrackUtils.h
@@ -19,6 +19,7 @@ class WaveClip;
 
 namespace WaveTrackUtils
 {
+   //! Decide whether a clip is selected from its start and end times (only)
    bool IsClipSelected(const ViewInfo& viewInfo, const WaveClip& waveClip);
 
    template<typename Iter>

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -12,6 +12,7 @@
 
 #include "../../../../prefs/SpectrogramSettings.h"
 #include "RealFFTf.h"
+#include "Sequence.h"
 #include "Spectrum.h"
 #include "WaveClipUtilities.h"
 #include "WaveTrack.h"
@@ -91,8 +92,8 @@ bool SpecCache::Matches(
 }
 
 bool SpecCache::CalculateOneSpectrum(
-   const SpectrogramSettings& settings, const WaveClip& clip, const int xx,
-   double pixelsPerSecond, int lowerBoundX, int upperBoundX,
+   const SpectrogramSettings& settings, const WaveChannelInterval& clip,
+   const int xx, double pixelsPerSecond, int lowerBoundX, int upperBoundX,
    const std::vector<float>& gainFactors, float* __restrict scratch,
    float* __restrict out) const
 {
@@ -103,7 +104,7 @@ bool SpecCache::CalculateOneSpectrum(
 
    sampleCount from;
 
-   const auto numSamples = clip.GetSequenceSamplesCount() / clip.GetWidth();
+   const auto numSamples = clip.GetSequence().GetNumSamples();
    const auto sampleRate = clip.GetRate();
    const auto stretchRatio = clip.GetStretchRatio();
    const auto samplesPerPixel = sampleRate / pixelsPerSecond / stretchRatio;
@@ -169,7 +170,7 @@ bool SpecCache::CalculateOneSpectrum(
             constexpr auto iChannel = 0u;
             constexpr auto mayThrow = false; // Don't throw just for display
             mSampleCacheHolder.emplace(
-               clip.GetSampleView(iChannel, from, myLen, mayThrow));
+               clip.GetSampleView(from, myLen, mayThrow));
             floats.resize(myLen);
             mSampleCacheHolder->Copy(floats.data(), myLen);
             useBuffer = floats.data();
@@ -339,8 +340,8 @@ void SpecCache::Grow(
 }
 
 void SpecCache::Populate(
-   const SpectrogramSettings& settings, const WaveClip& clip, int copyBegin,
-   int copyEnd, size_t numPixels, double pixelsPerSecond)
+   const SpectrogramSettings& settings, const WaveChannelInterval& clip,
+   int copyBegin, int copyEnd, size_t numPixels, double pixelsPerSecond)
 {
    const auto sampleRate = clip.GetRate();
    const int &frequencyGainSetting = settings.frequencyGain;
@@ -458,14 +459,13 @@ void SpecCache::Populate(
 }
 
 bool WaveClipSpectrumCache::GetSpectrogram(
-   const WaveClip& clip,
+   const WaveChannelInterval &clip,
    const float*& spectrogram, SpectrogramSettings& settings,
    const sampleCount*& where, size_t numPixels, double t0,
    double pixelsPerSecond)
 
 {
-   // TODO vary the subscript
-   auto &mSpecCache = mSpecCaches[0];
+   auto &mSpecCache = mSpecCaches[clip.GetChannelIndex()];
 
    const auto sampleRate = clip.GetRate();
    const auto stretchRatio = clip.GetStretchRatio();

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -571,7 +571,6 @@ bool WaveClipSpectrumCache::GetSpectrogram(
 
 WaveClipSpectrumCache::WaveClipSpectrumCache()
 : mSpecCache{ std::make_unique<SpecCache>() }
-, mSpecPxCache{ std::make_unique<SpecPxCache>(1) }
 {
 }
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
@@ -85,7 +85,6 @@ public:
       : len{ cacheLen }
       , values{ len }
    {
-      valid = false;
       scaleType = 0;
       range = gain = -1;
       minFreq = maxFreq = -1;
@@ -93,7 +92,6 @@ public:
 
    size_t  len;
    Floats values;
-   bool         valid;
 
    int scaleType;
    int range;

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
@@ -13,6 +13,7 @@
 
 class sampleCount;
 class SpectrogramSettings;
+class WaveChannelInterval;
 class WideSampleSequence;
 
 #include <vector>
@@ -50,8 +51,8 @@ public:
 
    // Calculate the dirty columns at the begin and end of the cache
    void Populate(
-      const SpectrogramSettings& settings, const WaveClip& clip, int copyBegin,
-      int copyEnd, size_t numPixels, double pixelsPerSecond);
+      const SpectrogramSettings& settings, const WaveChannelInterval& clip,
+      int copyBegin, int copyEnd, size_t numPixels, double pixelsPerSecond);
 
    size_t       len { 0 }; // counts pixels, not samples
    int          algorithm;
@@ -71,8 +72,8 @@ public:
 private:
    // Calculate one column of the spectrum
    bool CalculateOneSpectrum(
-      const SpectrogramSettings& settings, const WaveClip& clip, const int xx,
-      double pixelsPerSecond, int lowerBoundX, int upperBoundX,
+      const SpectrogramSettings& settings, const WaveChannelInterval &clip,
+      const int xx, double pixelsPerSecond, int lowerBoundX, int upperBoundX,
       const std::vector<float>& gainFactors, float* __restrict scratch,
       float* __restrict out) const;
 
@@ -120,10 +121,11 @@ struct WaveClipSpectrumCache final : WaveClipListener
    // > only the 0th channel of sequence is really used
    // > In the interim, this still works correctly for WideSampleSequence backed
    // > by a right channel track, which always ignores its partner.
-   bool GetSpectrogram(const WaveClip &clip, const float *&spectrogram,
-                       SpectrogramSettings &spectrogramSettings,
-                       const sampleCount *&where, size_t numPixels,
-                       double t0 /*absolute time*/, double pixelsPerSecond);
+   bool GetSpectrogram(const WaveChannelInterval &clip,
+      const float *&spectrogram,
+      SpectrogramSettings &spectrogramSettings,
+      const sampleCount *&where, size_t numPixels,
+      double t0 /*absolute time*/, double pixelsPerSecond);
 };
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
@@ -102,12 +102,12 @@ public:
 
 struct WaveClipSpectrumCache final : WaveClipListener
 {
-   WaveClipSpectrumCache();
+   explicit WaveClipSpectrumCache(size_t nChannels);
    ~WaveClipSpectrumCache() override;
 
    // Cache of values to colour pixels of Spectrogram - used by TrackArtist
-   std::unique_ptr<SpecPxCache> mSpecPxCache;
-   std::unique_ptr<SpecCache> mSpecCache;
+   std::vector<std::unique_ptr<SpecPxCache>> mSpecPxCaches;
+   std::vector<std::unique_ptr<SpecCache>> mSpecCaches;
    int mDirty { 0 };
 
    static WaveClipSpectrumCache &Get( const WaveClip &clip );

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -479,13 +479,14 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context, const WaveTrack &track,
 #endif //EXPERIMENTAL_FFT_Y_GRID
 
    auto &clipCache = WaveClipSpectrumCache::Get(clip);
-   if (!updated && clipCache.mSpecPxCache->valid &&
-      ((int)clipCache.mSpecPxCache->len == hiddenMid.height * hiddenMid.width)
-      && scaleType == clipCache.mSpecPxCache->scaleType
-      && gain == clipCache.mSpecPxCache->gain
-      && range == clipCache.mSpecPxCache->range
-      && minFreq == clipCache.mSpecPxCache->minFreq
-      && maxFreq == clipCache.mSpecPxCache->maxFreq
+   auto &specPxCache = clipCache.mSpecPxCache;
+   if (!updated && specPxCache &&
+      ((int)specPxCache->len == hiddenMid.height * hiddenMid.width)
+      && scaleType == specPxCache->scaleType
+      && gain == specPxCache->gain
+      && range == specPxCache->range
+      && minFreq == specPxCache->minFreq
+      && maxFreq == specPxCache->maxFreq
 #ifdef EXPERIMENTAL_FFT_Y_GRID
    && fftYGrid==fftYGridOld
 #endif //EXPERIMENTAL_FFT_Y_GRID
@@ -501,13 +502,12 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context, const WaveTrack &track,
    }
    else {
       // Update the spectrum pixel cache
-      clipCache.mSpecPxCache = std::make_unique<SpecPxCache>(hiddenMid.width * hiddenMid.height);
-      clipCache.mSpecPxCache->valid = true;
-      clipCache.mSpecPxCache->scaleType = scaleType;
-      clipCache.mSpecPxCache->gain = gain;
-      clipCache.mSpecPxCache->range = range;
-      clipCache.mSpecPxCache->minFreq = minFreq;
-      clipCache.mSpecPxCache->maxFreq = maxFreq;
+      specPxCache = std::make_unique<SpecPxCache>(hiddenMid.width * hiddenMid.height);
+      specPxCache->scaleType = scaleType;
+      specPxCache->gain = gain;
+      specPxCache->range = range;
+      specPxCache->minFreq = minFreq;
+      specPxCache->maxFreq = maxFreq;
 #ifdef EXPERIMENTAL_FIND_NOTES
       artist->fftFindNotesOld = fftFindNotes;
       artist->findNotesMinAOld = findNotesMinA;
@@ -613,7 +613,7 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context, const WaveTrack &track,
             if (settings.scaleType != SpectrogramSettings::stLogarithmic) {
                const float value = findValue
                   (freq + nBins * xx, bin, nextBin, nBins, autocorrelation, gain, range);
-               clipCache.mSpecPxCache->values[xx * hiddenMid.height + yy] = value;
+               specPxCache->values[xx * hiddenMid.height + yy] = value;
             }
             else {
                float value;
@@ -651,7 +651,7 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context, const WaveTrack &track,
                   value = findValue
                      (freq + nBins * xx, bin, nextBin, nBins, autocorrelation, gain, range);
                }
-               clipCache.mSpecPxCache->values[xx * hiddenMid.height + yy] = value;
+               specPxCache->values[xx * hiddenMid.height + yy] = value;
             } // logF
          } // each yy
       } // each xx
@@ -817,7 +817,7 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context, const WaveTrack &track,
 
          const float value = uncached
             ? findValue(uncached, bin, nextBin, nBins, autocorrelation, gain, range)
-            : clipCache.mSpecPxCache->values[correctedX * hiddenMid.height + yy];
+            : specPxCache->values[correctedX * hiddenMid.height + yy];
 
          unsigned char rv, gv, bv;
          GetColorGradient(value, selected, colorScheme, &rv, &gv, &bv);

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -860,7 +860,7 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context, const WaveTrack &track,
 }
 }
 
-void SpectrumView::DoDraw(TrackPanelDrawingContext& context,
+void SpectrumView::DoDraw(TrackPanelDrawingContext& context, size_t channel,
    const WaveTrack &track, const WaveClip* selectedClip, const wxRect & rect)
 {
    const auto artist = TrackArtist::Get( context );
@@ -869,6 +869,18 @@ void SpectrumView::DoDraw(TrackPanelDrawingContext& context,
    TrackArt::DrawBackgroundWithSelection(
       context, rect, &track, blankSelectedBrush, blankBrush );
 
+   // Really useful channel numbers are not yet passed in
+   // TODO wide wave tracks -- really use channel
+   assert(channel == 0);
+   channel = (track.IsLeader() ? 0 : 1);
+
+   // TODO wide wave tracks -- remove this workaround
+   auto pLeader = *track.GetHolder()->Find(&track);
+   assert(pLeader->IsLeader());
+
+   // TODO this different iteration
+   //for (const auto pInterval :
+   // static_cast<const WaveTrack*>(pLeader)->GetChannel(channel)->Intervals())
    for (const auto &clip: track.GetClips())
       DrawClipSpectrum(context, track, *clip, rect, mpSpectralData,
          clip.get() == selectedClip);
@@ -906,7 +918,7 @@ void SpectrumView::Draw(
       wxASSERT(waveChannelView.use_count());
 
       auto selectedClip = waveChannelView->GetSelectedClip().lock();
-      DoDraw(context, *wt, selectedClip.get(), rect);
+      DoDraw(context, GetChannelIndex(), *wt, selectedClip.get(), rect);
 
 #if defined(__WXMAC__)
       dc.GetGraphicsContext()->SetAntialiasMode(aamode);

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -479,7 +479,8 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context, const WaveTrack &track,
 #endif //EXPERIMENTAL_FFT_Y_GRID
 
    auto &clipCache = WaveClipSpectrumCache::Get(clip);
-   auto &specPxCache = clipCache.mSpecPxCache;
+   // TODO vary the subscript
+   auto &specPxCache = clipCache.mSpecPxCaches[0];
    if (!updated && specPxCache &&
       ((int)specPxCache->len == hiddenMid.height * hiddenMid.width)
       && scaleType == specPxCache->scaleType

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -904,8 +904,8 @@ void SpectrumView::Draw(
       auto waveChannelView = GetWaveChannelView().lock();
       wxASSERT(waveChannelView.use_count());
 
-      auto seletedClip = waveChannelView->GetSelectedClip().lock();
-      DoDraw(context, *wt, seletedClip.get(), rect);
+      auto selectedClip = waveChannelView->GetSelectedClip().lock();
+      DoDraw(context, *wt, selectedClip.get(), rect);
 
 #if defined(__WXMAC__)
       dc.GetGraphicsContext()->SetAntialiasMode(aamode);

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.h
@@ -153,7 +153,7 @@ private:
       TrackPanelDrawingContext &context,
       const wxRect &rect, unsigned iPass ) override;
 
-   void DoDraw(TrackPanelDrawingContext &context,
+   void DoDraw(TrackPanelDrawingContext &context, size_t channel,
       const WaveTrack &track, const WaveClip* selectedClip,
       const wxRect & rect);
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.h
@@ -153,10 +153,9 @@ private:
       TrackPanelDrawingContext &context,
       const wxRect &rect, unsigned iPass ) override;
 
-   void DoDraw( TrackPanelDrawingContext &context,
-      const WaveTrack *track,
-      const WaveClip* selectedClip,
-      const wxRect & rect );
+   void DoDraw(TrackPanelDrawingContext &context,
+      const WaveTrack &track, const WaveClip* selectedClip,
+      const wxRect & rect);
 
    std::vector<UIHandlePtr> DetailedHitTest(
       const TrackPanelMouseState &state,

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -1424,7 +1424,7 @@ bool WaveChannelView::CopySelectedText(AudacityProject& project)
       AnyAffordance(project, *this, &WaveTrackAffordanceControls::OnTextCopy);
 }
 
-bool WaveChannelView::ClipDetailsVisible(const WaveClip& clip,
+bool WaveChannelView::ClipDetailsVisible(const ClipTimes& clip,
    const ZoomInfo& zoomInfo, const wxRect& viewRect)
 {
    //Do not fold clips to line at sample zoom level, as
@@ -1537,7 +1537,7 @@ double CalculateAdjustmentForZoomLevel(double avgPixPerSecond, bool showSamples)
    return .0;
 }
 
-double GetBlankSpaceBeforePlayEndTime(const WaveClip& clip)
+double GetBlankSpaceBeforePlayEndTime(const ClipTimes &clip)
 {
    return 0.99 * clip.GetStretchRatio() / clip.GetRate();
 }
@@ -1559,11 +1559,11 @@ bool ShowIndividualSamples(
 }
 
 ClipParameters::ClipParameters(
-   const WaveClip &clip, const wxRect& rect, const ZoomInfo& zoomInfo)
-    : trackRectT0 { zoomInfo.PositionToTime(0, 0, true) }
-    , averagePixelsPerSecond { GetPixelsPerSecond(rect, zoomInfo) }
-    , showIndividualSamples { ShowIndividualSamples(
-         clip.GetRate(), clip.GetStretchRatio(), averagePixelsPerSecond) }
+   const ClipTimes &clip, const wxRect& rect, const ZoomInfo& zoomInfo
+)  : trackRectT0 { zoomInfo.PositionToTime(0, 0, true) }
+   , averagePixelsPerSecond { GetPixelsPerSecond(rect, zoomInfo) }
+   , showIndividualSamples { ShowIndividualSamples(
+      clip.GetRate(), clip.GetStretchRatio(), averagePixelsPerSecond) }
 {
    const auto trackRectT1 = zoomInfo.PositionToTime(rect.width, 0, true);
    const auto stretchRatio = clip.GetStretchRatio();
@@ -1659,7 +1659,8 @@ ClipParameters::ClipParameters(
    }
 }
 
-wxRect ClipParameters::GetClipRect(const WaveClip& clip, const ZoomInfo& zoomInfo, const wxRect& viewRect, bool* outShowSamples)
+wxRect ClipParameters::GetClipRect(const ClipTimes& clip,
+   const ZoomInfo& zoomInfo, const wxRect& viewRect, bool* outShowSamples)
 {
    const auto pixelsPerSecond = GetPixelsPerSecond(viewRect, zoomInfo);
    const auto showIndividualSamples = ShowIndividualSamples(

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -826,7 +826,7 @@ std::pair<
 
 
 void WaveChannelSubView::DrawBoldBoundaries(
-   TrackPanelDrawingContext &context, const WaveTrack *track,
+   TrackPanelDrawingContext &context, const WaveTrack &track,
    const wxRect &rect)
 {
    auto &dc = context.dc;
@@ -837,11 +837,11 @@ void WaveChannelSubView::DrawBoldBoundaries(
 #ifdef EXPERIMENTAL_TRACK_PANEL_HIGHLIGHTING
    auto target2 = dynamic_cast<CutlineHandle*>(context.target.get());
 #endif
-   for (const auto loc : WaveTrackLocations::Get(*track).Get()) {
+   for (const auto loc : WaveTrackLocations::Get(track).Get()) {
       bool highlightLoc = false;
 #ifdef EXPERIMENTAL_TRACK_PANEL_HIGHLIGHTING
       highlightLoc =
-         target2 && target2->GetTrack().get() == track &&
+         target2 && target2->GetTrack().get() == &track &&
          target2->GetLocation() == loc;
 #endif
       const int xx = zoomInfo.TimeToPosition(loc.pos);
@@ -1559,23 +1559,23 @@ bool ShowIndividualSamples(
 }
 
 ClipParameters::ClipParameters(
-   const WaveClip* clip, const wxRect& rect, const ZoomInfo& zoomInfo)
+   const WaveClip &clip, const wxRect& rect, const ZoomInfo& zoomInfo)
     : trackRectT0 { zoomInfo.PositionToTime(0, 0, true) }
     , averagePixelsPerSecond { GetPixelsPerSecond(rect, zoomInfo) }
     , showIndividualSamples { ShowIndividualSamples(
-         clip->GetRate(), clip->GetStretchRatio(), averagePixelsPerSecond) }
+         clip.GetRate(), clip.GetStretchRatio(), averagePixelsPerSecond) }
 {
    const auto trackRectT1 = zoomInfo.PositionToTime(rect.width, 0, true);
-   const auto stretchRatio = clip->GetStretchRatio();
-   const auto playStartTime = clip->GetPlayStartTime();
+   const auto stretchRatio = clip.GetStretchRatio();
+   const auto playStartTime = clip.GetPlayStartTime();
 
-   const double clipLength = clip->GetPlayEndTime() - clip->GetPlayStartTime();
+   const double clipLength = clip.GetPlayEndTime() - clip.GetPlayStartTime();
 
    // Hidden duration because too far left.
    const auto tpre = trackRectT0 - playStartTime;
    const auto tpost = trackRectT1 - playStartTime;
 
-   const auto blank = GetBlankSpaceBeforePlayEndTime(*clip);
+   const auto blank = GetBlankSpaceBeforePlayEndTime(clip);
 
    // Calculate actual selection bounds so that t0 > 0 and t1 < the
    // end of the track

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -1396,19 +1396,16 @@ namespace {
 using PMF = bool (WaveTrackAffordanceControls::*)(AudacityProject &);
 bool AnyAffordance(AudacityProject& project, WaveChannelView &view, PMF pmf)
 {
-   const auto pLeader = *TrackList::Channels(view.FindTrack().get()).begin();
-   const auto channels = pLeader->Channels();
-   return std::any_of(channels.begin(), channels.end(),
-      [&](const std::shared_ptr<Channel> &pChannel) {
-         auto& channelView = ChannelView::Get(*pChannel);
-         if (const auto affordance =
-            std::dynamic_pointer_cast<WaveTrackAffordanceControls>(
-               channelView.GetAffordanceControls()).get()
-            ; affordance && (affordance->*pmf)(project)
-         )
-            return true;
-         return false;
-      });
+   const auto pLeader = static_cast<WaveTrack*>(
+      *TrackList::Channels(view.FindTrack().get()).begin());
+   auto& channelView = ChannelView::Get(*pLeader);
+   if (const auto affordance =
+      std::dynamic_pointer_cast<WaveTrackAffordanceControls>(
+         channelView.GetAffordanceControls()).get()
+      ; affordance && (affordance->*pmf)(project)
+   )
+      return true;
+   return false;
 }
 }
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.h
@@ -17,6 +17,7 @@ Paul Licameli split from class WaveTrack
 namespace WaveChannelViewConstants{ enum Display : int; }
 struct WaveChannelSubViewType;
 
+class ClipTimes;
 class CutlineHandle;
 class TranslatableString;
 class SampleTrack;
@@ -181,7 +182,8 @@ public:
 
    unsigned LoseFocus(AudacityProject *project) override;
 
-   static bool ClipDetailsVisible(const WaveClip& clip, const ZoomInfo& zoomInfo, const wxRect& viewRect);
+   static bool ClipDetailsVisible(
+      const ClipTimes& clip, const ZoomInfo& zoomInfo, const wxRect& viewRect);
    static wxRect ClipHitTestArea(const WaveClip& clip, const ZoomInfo& zoomInfo, const wxRect& viewRect);
    static bool HitTest(const WaveClip& clip, const ZoomInfo& zoomInfo, const wxRect& rect, const wxPoint& pos);
 
@@ -246,7 +248,7 @@ struct AUDACITY_DLL_API ClipParameters
 {
    // Do a bunch of calculations common to waveform and spectrum drawing.
    ClipParameters(
-      const WaveClip &clip, const wxRect& rect, const ZoomInfo& zoomInfo);
+      const ClipTimes &clip, const wxRect& rect, const ZoomInfo& zoomInfo);
 
    const double trackRectT0; // absolute time of left edge of track
 
@@ -266,7 +268,8 @@ struct AUDACITY_DLL_API ClipParameters
 
    // returns a clip rectangle restricted by viewRect,
    // and with clipOffsetX - clip horizontal origin offset within view rect
-   static wxRect GetClipRect(const WaveClip& clip, const ZoomInfo& zoomInfo,
+   static wxRect GetClipRect(
+      const ClipTimes& clip, const ZoomInfo& zoomInfo,
       const wxRect& viewRect, bool* outShowSamples = nullptr);
 };
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.h
@@ -63,8 +63,8 @@ public:
 
 protected:
    static void DrawBoldBoundaries(
-      TrackPanelDrawingContext &context, const WaveTrack *track,
-      const wxRect &rect );
+      TrackPanelDrawingContext &context, const WaveTrack &track,
+      const wxRect &rect);
 
    std::weak_ptr<WaveChannelView> GetWaveChannelView() const;
 
@@ -246,7 +246,7 @@ struct AUDACITY_DLL_API ClipParameters
 {
    // Do a bunch of calculations common to waveform and spectrum drawing.
    ClipParameters(
-      const WaveClip* clip, const wxRect& rect, const ZoomInfo& zoomInfo);
+      const WaveClip &clip, const wxRect& rect, const ZoomInfo& zoomInfo);
 
    const double trackRectT0; // absolute time of left edge of track
 
@@ -266,7 +266,8 @@ struct AUDACITY_DLL_API ClipParameters
 
    // returns a clip rectangle restricted by viewRect,
    // and with clipOffsetX - clip horizontal origin offset within view rect
-   static wxRect GetClipRect(const WaveClip& clip, const ZoomInfo& zoomInfo, const wxRect& viewRect, bool* outShowSamples = nullptr);
+   static wxRect GetClipRect(const WaveClip& clip, const ZoomInfo& zoomInfo,
+      const wxRect& viewRect, bool* outShowSamples = nullptr);
 };
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -162,6 +162,8 @@ std::vector<UIHandlePtr> WaveTrackAffordanceControls::HitTest(const TrackPanelMo
     const auto rect = state.rect;
 
     auto track = std::static_pointer_cast<WaveTrack>(FindTrack());
+    // Assume only leader channels have affordance areas
+    assert(track->IsLeader());
 
     {
         auto handle = WaveClipAdjustBorderHandle::HitAnywhere(

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -340,15 +340,13 @@ SelectedClipOfFocusedTrack(AudacityProject &project)
    // a track focus if there was none
    if (auto pWaveTrack =
       dynamic_cast<WaveTrack *>(TrackFocus::Get(project).Get())) {
-      for (auto pChannel : TrackList::Channels(pWaveTrack)) {
-         if (FindAffordance(*pChannel)) {
-            auto &viewInfo = ViewInfo::Get(project);
-            auto &clips = pChannel->GetClips();
-            auto begin = clips.begin(), end = clips.end(),
-               iter = WaveTrackUtils::SelectedClip(viewInfo, begin, end);
-            if (iter != end)
-               return { pChannel, *iter };
-         }
+      if (FindAffordance(*pWaveTrack)) {
+         auto &viewInfo = ViewInfo::Get(project);
+         auto &clips = pWaveTrack->GetClips();
+         auto begin = clips.begin(), end = clips.end(),
+            iter = WaveTrackUtils::SelectedClip(viewInfo, begin, end);
+         if (iter != end)
+            return { pWaveTrack, *iter };
       }
    }
    return { nullptr, nullptr };

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -67,8 +67,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
    const WaveChannelInterval &clip, WaveDisplay &display,
    double t0, double pixelsPerSecond)
 {
-   // TODO -- use clip.GetChannelIndex()
-   auto &waveCache = mWaveCaches[0];
+   auto &waveCache = mWaveCaches[clip.GetChannelIndex()];
 
    t0 += clip.GetTrimLeft();
 
@@ -270,7 +269,8 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 }
 
 WaveClipWaveformCache::WaveClipWaveformCache(size_t nChannels)
-   : mWaveCaches(nChannels)
+   // TODO wide wave tracks -- won't need std::max here
+   : mWaveCaches(std::max<size_t>(2, nChannels))
 {
    for (auto &pCache : mWaveCaches)
       pCache = std::make_unique<WaveCache>();

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -14,6 +14,7 @@
 #include "Sequence.h"
 #include "GetWaveDisplay.h"
 #include "WaveClipUtilities.h"
+#include "WaveTrack.h"
 
 class WaveCache {
 public:
@@ -63,13 +64,11 @@ public:
 //
 
 bool WaveClipWaveformCache::GetWaveDisplay(
-   const WaveClip &clip, size_t channel, WaveDisplay &display, double t0,
-   double pixelsPerSecond )
+   const WaveChannelInterval &clip, WaveDisplay &display,
+   double t0, double pixelsPerSecond)
 {
-   // TODO wide wave tracks -- don't reassign
-   channel = 0;
-
-   auto &waveCache = mWaveCaches[channel];
+   // TODO -- use clip.GetChannelIndex()
+   auto &waveCache = mWaveCaches[0];
 
    t0 += clip.GetTrimLeft();
 
@@ -178,8 +177,8 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 
       /* handle values in the append buffer */
 
-      const auto sequence = clip.GetSequence(channel);
-      auto numSamples = sequence->GetNumSamples();
+      const auto &sequence = clip.GetSequence();
+      auto numSamples = sequence.GetNumSamples();
       auto a = p0;
 
       // Not all of the required columns might be in the sequence.
@@ -193,8 +192,8 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       //compute the values that are outside the overlap from scratch.
       if (a < p1) {
          const auto appendBufferLen = clip.GetAppendBufferLen();
-         const auto &appendBuffer = clip.GetAppendBuffer(channel);
-         sampleFormat seqFormat = sequence->GetSampleFormats().Stored();
+         const auto &appendBuffer = clip.GetAppendBuffer();
+         sampleFormat seqFormat = sequence.GetSampleFormats().Stored();
          bool didUpdate = false;
          for(auto i = a; i < p1; i++) {
             auto left = std::max(sampleCount{ 0 },
@@ -251,11 +250,8 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       // Done with append buffer, now fetch the rest of the cache miss
       // from the sequence
       if (p1 > p0) {
-         if (!::GetWaveDisplay(*sequence, &min[p0],
-                                        &max[p0],
-                                        &rms[p0],
-                                        p1-p0,
-                                        &where[p0]))
+         if (!::GetWaveDisplay(sequence, &min[p0], &max[p0], &rms[p0], p1 - p0,
+            &where[p0]))
          {
             return false;
          }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
@@ -14,6 +14,7 @@
 #include "WaveClip.h"
 
 class WaveCache;
+class WaveChannelInterval;
 
 struct WaveClipWaveformCache final : WaveClipListener
 {
@@ -33,7 +34,7 @@ struct WaveClipWaveformCache final : WaveClipListener
    void Clear();
 
    /** Getting high-level data for screen display */
-   bool GetWaveDisplay(const WaveClip &clip, size_t channel,
+   bool GetWaveDisplay(const WaveChannelInterval &clip,
       WaveDisplay &display, double t0, double pixelsPerSecond);
 };
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -742,7 +742,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
    // Require at least 3 pixels per sample for drawing the draggable points.
    const double threshold2 = 3 * sampleRate / stretchRatio;
 
-   auto &clipCache = WaveClipWaveformCache::Get(clip.GetNarrowClip());
+   auto &clipCache = WaveClipWaveformCache::Get(clip.GetClip());
 
    {
       bool showIndividualSamples = false;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -640,7 +640,7 @@ void DrawEnvelope(TrackPanelDrawingContext &context,
 // Headers needed only for experimental drawing below
 //#include "tracks/playabletrack/wavetrack/ui/SampleHandle.h"
 //#include "tracks/ui/EnvelopeHandle.h"
-void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
+void DrawClipWaveform(TrackPanelDrawingContext &context,
    const WaveTrack &track, const WaveChannelInterval &clip,
    const wxRect &rect, bool dB, bool muted, bool selected)
 {
@@ -763,7 +763,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
          // fisheye moves over the background, there is then less to do when
          // redrawing.
 
-         if (!clipCache.GetWaveDisplay(clip.GetNarrowClip(), channel,
+         if (!clipCache.GetWaveDisplay(clip,
             display, t0, averagePixelsPerSecond))
             return;
       }
@@ -813,7 +813,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
             fisheyeDisplay.width -= skipped;
             // Get a wave display for the fisheye, uncached.
             if (rectPortion.width > 0)
-               if (!clipCache.GetWaveDisplay(clip.GetNarrowClip(), channel,
+               if (!clipCache.GetWaveDisplay(clip,
                      fisheyeDisplay, t0, -1.0)) // ignored
                   continue; // serious error.  just don't draw??
             useMin = fisheyeDisplay.min;
@@ -980,7 +980,7 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
    for (const auto pInterval :
       static_cast<const WaveTrack*>(pLeader)->GetChannel(channel)->Intervals()
    ) {
-      DrawClipWaveform(context, channel, track, *pInterval, rect,
+      DrawClipWaveform(context, track, *pInterval, rect,
          dB, muted, (&pInterval->GetNarrowClip() == selectedClip));
    }
    DrawBoldBoundaries(context, track, rect);

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -987,7 +987,7 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
    for (const auto pInterval :
       static_cast<const WaveTrack*>(pLeader)->GetChannel(channel)->Intervals()
    ) {
-      auto &clip = pInterval->GetClip();
+      auto &clip = pInterval->GetNarrowClip();
       DrawClipWaveform(context, channel, track,
          clip, pInterval->GetEnvelope(), rect,
          dB, muted, &clip == selectedClip);

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -981,7 +981,7 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
       static_cast<const WaveTrack*>(pLeader)->GetChannel(channel)->Intervals()
    ) {
       DrawClipWaveform(context, track, *pInterval, rect,
-         dB, muted, (&pInterval->GetNarrowClip() == selectedClip));
+         dB, muted, (&pInterval->GetClip() == selectedClip));
    }
    DrawBoldBoundaries(context, track, rect);
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -443,19 +443,17 @@ void DrawMinMaxRMS(
    }
 }
 
-void DrawIndividualSamples(TrackPanelDrawingContext &context, size_t channel,
+void DrawIndividualSamples(TrackPanelDrawingContext &context,
    int leftOffset, const wxRect &rect,
    float zoomMin, float zoomMax,
    bool dB, float dBRange,
-   const WaveClip &clip, const Envelope &envelope,
+   const WaveChannelInterval &clip,
    bool showPoints, bool muted,
    bool highlight)
 {
-   // TODO wide wave tracks -- don't reassign
-   channel = 0;
-
+   const Envelope &envelope = clip.GetEnvelope();
    auto &dc = context.dc;
-   const auto artist = TrackArtist::Get( context );
+   const auto artist = TrackArtist::Get(context);
    const auto &zoomInfo = *artist->pZoomInfo;
 
    const double toffset = clip.GetPlayStartTime();
@@ -477,7 +475,7 @@ void DrawIndividualSamples(TrackPanelDrawingContext &context, size_t channel,
       return;
 
    Floats buffer{ size_t(slen) };
-   clip.GetSamples(channel, (samplePtr)buffer.get(), floatSample, s0, slen,
+   clip.GetSamples((samplePtr)buffer.get(), floatSample, s0, slen,
                     // Suppress exceptions in this drawing operation:
                     false);
 
@@ -643,15 +641,12 @@ void DrawEnvelope(TrackPanelDrawingContext &context,
 //#include "tracks/playabletrack/wavetrack/ui/SampleHandle.h"
 //#include "tracks/ui/EnvelopeHandle.h"
 void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
-   const WaveTrack &track,
-   const WaveClip &clip, const Envelope &envelope,
-   const wxRect &rect,
-   bool dB,
-   bool muted,
-   bool selected)
+   const WaveTrack &track, const WaveChannelInterval &clip,
+   const wxRect &rect, bool dB, bool muted, bool selected)
 {
+   const Envelope &envelope = clip.GetEnvelope();
    auto &dc = context.dc;
-   const auto artist = TrackArtist::Get( context );
+   const auto artist = TrackArtist::Get(context);
    const auto &selectedRegion = *artist->pSelectedRegion;
    const auto &zoomInfo = *artist->pZoomInfo;
 
@@ -747,7 +742,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
    // Require at least 3 pixels per sample for drawing the draggable points.
    const double threshold2 = 3 * sampleRate / stretchRatio;
 
-   auto &clipCache = WaveClipWaveformCache::Get(clip);
+   auto &clipCache = WaveClipWaveformCache::Get(clip.GetNarrowClip());
 
    {
       bool showIndividualSamples = false;
@@ -768,8 +763,8 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
          // fisheye moves over the background, there is then less to do when
          // redrawing.
 
-         if (!clipCache.GetWaveDisplay(
-                clip, channel, display, t0, averagePixelsPerSecond))
+         if (!clipCache.GetWaveDisplay(clip.GetNarrowClip(), channel,
+            display, t0, averagePixelsPerSecond))
             return;
       }
    }
@@ -818,7 +813,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
             fisheyeDisplay.width -= skipped;
             // Get a wave display for the fisheye, uncached.
             if (rectPortion.width > 0)
-               if (!clipCache.GetWaveDisplay(clip, channel,
+               if (!clipCache.GetWaveDisplay(clip.GetNarrowClip(), channel,
                      fisheyeDisplay, t0, -1.0)) // ignored
                   continue; // serious error.  just don't draw??
             useMin = fisheyeDisplay.min;
@@ -859,10 +854,8 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
             highlight = target && target->GetTrack().get() == track;
 #endif
             DrawIndividualSamples(
-               context, channel, leftOffset, rectPortion, zoomMin, zoomMax,
-               dB, dBRange,
-               clip, envelope,
-               showPoints, muted, highlight);
+               context, leftOffset, rectPortion, zoomMin, zoomMax,
+               dB, dBRange, clip, showPoints, muted, highlight);
          }
       }
 
@@ -987,10 +980,8 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
    for (const auto pInterval :
       static_cast<const WaveTrack*>(pLeader)->GetChannel(channel)->Intervals()
    ) {
-      auto &clip = pInterval->GetNarrowClip();
-      DrawClipWaveform(context, channel, track,
-         clip, pInterval->GetEnvelope(), rect,
-         dB, muted, &clip == selectedClip);
+      DrawClipWaveform(context, channel, track, *pInterval, rect,
+         dB, muted, (&pInterval->GetNarrowClip() == selectedClip));
    }
    DrawBoldBoundaries(context, track, rect);
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -672,7 +672,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
       return;
    }
 
-   const ClipParameters params { &clip, rect, zoomInfo };
+   const ClipParameters params { clip, rect, zoomInfo };
    const wxRect &hiddenMid = params.hiddenMid;
    // The "hiddenMid" rect contains the part of the display actually
    // containing the waveform, as it appears without the fisheye.  If it's empty, we're done.
@@ -992,7 +992,7 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
          clip, pInterval->GetEnvelope(), rect,
          dB, muted, &clip == selectedClip);
    }
-   DrawBoldBoundaries(context, &track, rect);
+   DrawBoldBoundaries(context, track, rect);
 
    const auto drawSliders = artist->drawSliders;
    if (drawSliders) {


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Depends on:
- #5027
- #5041
- #5082

The WaveChannelInterval interface, introduced in the previous pull request, is extended,
sufficient to rewrite the details of waveform and spectrogram view painting in terms of it,
rather than assuming a "narrow" WaveClip is given.

Right channel affordance areas are no longer painted.

Waveform and spectrogram caches are now attached to the left channel clips only, but
contain the information for the right channel too.

QA:
- [x] Intentional behavior change: right channel clip handles are no longer shown or draggable after merging mono to stereo
- [x] Left channel clip handles work as before
- [x] Verify waveform and spectrogram and split views work as before, mono and stereo tracks
- [x] Magnified views showing individual samples, edit samples (only without stretch)
- [x] No recurrence in either kind of view of: #5082
- [x] Display and editing of envelopes, with and without stretch
- [x] Editing of clip names
- [x] Correct enabling of Edit > Rename Clip... in menus according to the time selection

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
