### PR TITLE
Time stretching 1 of 6 allow outward drag for stretch handles

### DIFF
--- a/libraries/lib-math/Spectrum.cpp
+++ b/libraries/lib-math/Spectrum.cpp
@@ -19,10 +19,9 @@
 
 #include "SampleFormat.h"
 
-bool ComputeSpectrum(const float * data, size_t width,
-                     size_t windowSize,
-                     double WXUNUSED(rate), float *output,
-                     bool autocorrelation, int windowFunc)
+bool ComputeSpectrum(
+   const float* data, size_t width, size_t windowSize, float* output,
+   bool autocorrelation, int windowFunc)
 {
    if (width < windowSize)
       return false;

--- a/libraries/lib-math/Spectrum.h
+++ b/libraries/lib-math/Spectrum.h
@@ -22,8 +22,8 @@
 */
 
 MATH_API
-bool ComputeSpectrum(const float * data, size_t width, size_t windowSize,
-                     double rate, float *out, bool autocorrelation,
-                     int windowFunc = eWinFuncHann);
+bool ComputeSpectrum(
+   const float* data, size_t width, size_t windowSize, float* out,
+   bool autocorrelation, int windowFunc = eWinFuncHann);
 
 #endif

--- a/libraries/lib-screen-geometry/ZoomInfo.cpp
+++ b/libraries/lib-screen-geometry/ZoomInfo.cpp
@@ -109,8 +109,8 @@ void ZoomInfo::ZoomBy(double multiplier)
    SetZoom(zoom * multiplier);
 }
 
-void ZoomInfo::FindIntervals
-   (double /*rate*/, Intervals &results, int64 width, int64 origin) const
+void ZoomInfo::FindIntervals(
+   Intervals& results, int64 width, int64 origin) const
 {
    results.clear();
    results.reserve(2);

--- a/libraries/lib-screen-geometry/ZoomInfo.h
+++ b/libraries/lib-screen-geometry/ZoomInfo.h
@@ -147,8 +147,7 @@ public:
    // It is guaranteed that there is at least one entry and the position of the
    // first entry equals origin.
    // @param origin specifies the pixel position corresponding to time ViewInfo::h.
-   void FindIntervals
-      (double rate, Intervals &results, int64 width, int64 origin = 0) const;
+   void FindIntervals(Intervals& results, int64 width, int64 origin = 0) const;
 
    enum FisheyeState {
       HIDDEN,

--- a/libraries/lib-stretching-sequence/ClipInterface.h
+++ b/libraries/lib-stretching-sequence/ClipInterface.h
@@ -22,7 +22,10 @@ public:
    virtual AudioSegmentSampleView
    GetSampleView(size_t iChannel, sampleCount start, size_t length) const = 0;
 
-   virtual sampleCount GetPlaySamplesCount() const = 0;
+   /*!
+    * The number of raw audio samples not hidden by trimming.
+    */
+   virtual sampleCount GetVisibleSampleCount() const = 0;
 
    virtual size_t GetWidth() const = 0;
 

--- a/libraries/lib-stretching-sequence/ClipSegment.cpp
+++ b/libraries/lib-stretching-sequence/ClipSegment.cpp
@@ -34,7 +34,7 @@ sampleCount GetLastReadSample(
          clip.GetRate() * durationToDiscard / clip.GetStretchRatio() + .5
       };
    else
-      return clip.GetPlaySamplesCount() - sampleCount {
+      return clip.GetVisibleSampleCount() - sampleCount {
          clip.GetRate() * durationToDiscard / clip.GetStretchRatio() + .5
       };
 }
@@ -42,7 +42,7 @@ sampleCount GetLastReadSample(
 sampleCount
 GetTotalNumSamplesToProduce(const ClipInterface& clip, double durationToDiscard)
 {
-   return sampleCount { (clip.GetPlaySamplesCount().as_double() -
+   return sampleCount { (clip.GetVisibleSampleCount().as_double() -
                          durationToDiscard * clip.GetRate()) *
                            clip.GetStretchRatio() +
                         .5 };
@@ -86,7 +86,8 @@ void ClipSegment::Pull(float* const* buffers, size_t samplesPerChannel)
 {
    const auto forward = mPlaybackDirection == PlaybackDirection::forward;
    const auto remainingSamplesInClip =
-      forward ? mClip.GetPlaySamplesCount() - mLastReadSample : mLastReadSample;
+      forward ? mClip.GetVisibleSampleCount() - mLastReadSample :
+                mLastReadSample;
    const auto numSamplesToRead =
       limitSampleBufferSize(samplesPerChannel, remainingSamplesInClip);
    if (numSamplesToRead > 0u)

--- a/libraries/lib-stretching-sequence/tests/FloatVectorClip.cpp
+++ b/libraries/lib-stretching-sequence/tests/FloatVectorClip.cpp
@@ -47,7 +47,7 @@ AudioSegmentSampleView FloatVectorClip::GetSampleView(
       std::move(blockViews), start.as_size_t(), sampleCount { len });
 }
 
-sampleCount FloatVectorClip::GetPlaySamplesCount() const
+sampleCount FloatVectorClip::GetVisibleSampleCount() const
 {
    return mAudio[0].size();
 }

--- a/libraries/lib-stretching-sequence/tests/FloatVectorClip.h
+++ b/libraries/lib-stretching-sequence/tests/FloatVectorClip.h
@@ -25,7 +25,7 @@ public:
    AudioSegmentSampleView
    GetSampleView(size_t iChannel, sampleCount start, size_t len) const override;
 
-   sampleCount GetPlaySamplesCount() const override;
+   sampleCount GetVisibleSampleCount() const override;
 
    size_t GetWidth() const override;
 

--- a/libraries/lib-stretching-sequence/tests/WaveClipSegmentTest.cpp
+++ b/libraries/lib-stretching-sequence/tests/WaveClipSegmentTest.cpp
@@ -63,7 +63,7 @@ TEST_CASE("ClipSegment")
    {
       const auto clip = std::make_shared<FloatVectorClip>(
          sampleRate, FloatVectorVector { { 1.f, 2.f, 3.f, 4.f, 5.f } });
-      const auto numSamples = clip->GetPlaySamplesCount().as_size_t(); // 5
+      const auto numSamples = clip->GetVisibleSampleCount().as_size_t(); // 5
       // Offset of two samples, in seconds.
       constexpr auto playbackOffset = 2 / static_cast<double>(sampleRate);
       ClipSegment sut { *clip, playbackOffset, direction };

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -803,7 +803,7 @@ bool WaveClip::FindCutLine(double cutLinePosition,
          if (cutlineStart)
             *cutlineStart = startTime;
          if (cutlineEnd)
-            *cutlineEnd = startTime + cutline->SamplesToTime(cutline->GetPlaySamplesCount());
+            *cutlineEnd = startTime + cutline->SamplesToTime(cutline->GetVisibleSampleCount());
          return true;
       }
    }
@@ -1005,7 +1005,7 @@ void WaveClip::Resample(int rate, BasicUI::ProgressDialog *progress)
 // be exactly equal due to rounding errors.
 bool WaveClip::SharesBoundaryWithNextClip(const WaveClip* next) const
 {
-   double endThis = GetRate() * GetPlayStartTime() + GetPlaySamplesCount().as_double();
+   double endThis = GetRate() * GetPlayStartTime() + GetVisibleSampleCount().as_double();
    double startNext = next->GetRate() * next->GetPlayStartTime();
 
    // given that a double has about 15 significant digits, using a criterion
@@ -1077,10 +1077,10 @@ sampleCount WaveClip::GetPlayStartSample() const
 
 sampleCount WaveClip::GetPlayEndSample() const
 {
-    return GetPlayStartSample() + GetPlaySamplesCount();
+   return GetPlayStartSample() + GetVisibleSampleCount();
 }
 
-sampleCount WaveClip::GetPlaySamplesCount() const
+sampleCount WaveClip::GetVisibleSampleCount() const
 {
     return GetNumSamples()
        - TimeToSamples(mTrimRight) - TimeToSamples(mTrimLeft);

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1154,11 +1154,6 @@ sampleCount WaveClip::GetSequenceStartSample() const
     return TimeToSamples(mSequenceOffset);
 }
 
-sampleCount WaveClip::GetSequenceEndSample() const
-{
-    return GetSequenceStartSample() + GetNumSamples();
-}
-
 void WaveClip::ShiftBy(double delta) noexcept
 {
     SetSequenceStartTime(GetSequenceStartTime() + delta);
@@ -1207,11 +1202,6 @@ sampleCount WaveClip::TimeToSequenceSamples(double t) const
     else if (t > GetSequenceEndTime())
         return GetNumSamples();
     return TimeToSamples(t - GetSequenceStartTime());
-}
-
-sampleCount WaveClip::ToSequenceSamples(sampleCount s) const
-{
-    return s - GetSequenceStartSample();
 }
 
 bool WaveClip::CheckInvariants() const

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -155,7 +155,6 @@ public:
    // Always gives non-negative answer, not more than sample sequence length
    // even if t0 really falls outside that range
    sampleCount TimeToSequenceSamples(double t) const;
-   sampleCount ToSequenceSamples(sampleCount s) const;
 
    int GetRate() const { return mRate; }
 
@@ -176,8 +175,6 @@ public:
    double GetSequenceEndTime() const;
    //! Returns the index of the first sample of the underlying sequence
    sampleCount GetSequenceStartSample() const;
-   //! Returns the index of the sample next after the last sample of the underlying sequence
-   sampleCount GetSequenceEndSample() const;
    //! Returns the total number of samples in all underlying sequences
    //! (but not counting the cutlines)
    sampleCount GetSequenceSamplesCount() const;

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -189,7 +189,7 @@ public:
 
    sampleCount GetPlayStartSample() const;
    sampleCount GetPlayEndSample() const;
-   sampleCount GetPlaySamplesCount() const override;
+   sampleCount GetVisibleSampleCount() const override;
 
    //! Sets the play start offset in seconds from the beginning of the underlying sequence
    void SetTrimLeft(double trim);

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -614,12 +614,12 @@ void WaveTrack::SetWaveColorIndex(int colorIndex)
    }
 }
 
-sampleCount WaveTrack::GetPlaySamplesCount() const
+sampleCount WaveTrack::GetVisibleSampleCount() const
 {
     sampleCount result{ 0 };
 
     for (const auto& clip : mClips)
-        result += clip->GetPlaySamplesCount();
+        result += clip->GetVisibleSampleCount();
 
     return result;
 }
@@ -2348,7 +2348,7 @@ bool WaveTrack::GetOne(
       {
          // Clip sample region and Get/Put sample region overlap
          auto samplesToCopy =
-            std::min( start+len - clipStart, clip->GetPlaySamplesCount() );
+            std::min( start+len - clipStart, clip->GetVisibleSampleCount() );
          auto startDelta = clipStart - start;
          decltype(startDelta) inclipDelta = 0;
          if (startDelta < 0)
@@ -2447,7 +2447,7 @@ ChannelSampleView WaveTrack::GetOneSampleView(
       const auto clipT0 = t0 - clipStartTime;
       const auto clipS0 = TimeToLongSamples(clipT0);
       const auto len =
-         limitSampleBufferSize(length, clip->GetPlaySamplesCount() - clipS0);
+         limitSampleBufferSize(length, clip->GetVisibleSampleCount() - clipS0);
       auto newSegment = clip->GetSampleView(0u, clipS0, len);
       t0 += newSegment.GetSampleCount().as_double() / GetRate();
       segments.push_back(std::move(newSegment));
@@ -2471,7 +2471,7 @@ void WaveTrack::Set(constSamplePtr buffer, sampleFormat format,
       {
          // Clip sample region and Get/Put sample region overlap
          auto samplesToCopy =
-            std::min( start+len - clipStart, clip->GetPlaySamplesCount() );
+            std::min( start+len - clipStart, clip->GetVisibleSampleCount() );
          auto startDelta = clipStart - start;
          decltype(startDelta) inclipDelta = 0;
          if (startDelta < 0)

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -11,6 +11,7 @@
 #ifndef __AUDACITY_WAVETRACK__
 #define __AUDACITY_WAVETRACK__
 
+#include "PlaybackDirection.h"
 #include "Prefs.h"
 #include "SampleCount.h"
 #include "SampleFormat.h"
@@ -398,7 +399,32 @@ private:
    //
    Envelope* GetEnvelopeAtTime(double time);
 
+   const WaveClip* GetClipAtTime(double time) const;
    WaveClip* GetClipAtTime(double time);
+
+   /*!
+    * @brief Returns clips next to `clip` in the given direction, or `nullptr`
+    * if there is none.
+    */
+   const WaveClip* GetNextClip(
+      const WaveClip& clip, PlaybackDirection searchDirection) const;
+   /*!
+    * @copydoc GetNextClip(const WaveClip&, PlaybackDirection) const
+    */
+   WaveClip*
+   GetNextClip(const WaveClip& clip, PlaybackDirection searchDirection);
+
+   /*!
+    * @brief Similar to GetNextClip, but returns `nullptr` if the neighbour
+    * clip is not adjacent.
+    */
+   const WaveClip* GetAdjacentClip(
+      const WaveClip& clip, PlaybackDirection searchDirection) const;
+   /*!
+    * @copydoc GetAdjacentClip(const WaveClip&, PlaybackDirection) const
+    */
+   WaveClip*
+   GetAdjacentClip(const WaveClip& clip, PlaybackDirection searchDirection);
 
    //
    // Getting information about the track's internal block sizes

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -158,7 +158,7 @@ private:
     */
    void SetWaveColorIndex(int colorIndex);
 
-   sampleCount GetPlaySamplesCount() const;
+   sampleCount GetVisibleSampleCount() const;
 
    /*!
     @return the total number of samples in all underlying sequences

--- a/libraries/lib-wave-track/WideClip.cpp
+++ b/libraries/lib-wave-track/WideClip.cpp
@@ -22,9 +22,9 @@ WideClip::GetSampleView(size_t ii, sampleCount start, size_t len) const
    return mChannels[ii]->GetSampleView(0u, start, len);
 }
 
-sampleCount WideClip::GetPlaySamplesCount() const
+sampleCount WideClip::GetVisibleSampleCount() const
 {
-   return mChannels[0u]->GetPlaySamplesCount();
+   return mChannels[0u]->GetVisibleSampleCount();
 }
 
 size_t WideClip::GetWidth() const

--- a/libraries/lib-wave-track/WideClip.h
+++ b/libraries/lib-wave-track/WideClip.h
@@ -32,7 +32,7 @@ public:
    AudioSegmentSampleView
    GetSampleView(size_t ii, sampleCount start, size_t len) const override;
 
-   sampleCount GetPlaySamplesCount() const override;
+   sampleCount GetVisibleSampleCount() const override;
 
    size_t GetWidth() const override;
 

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -424,11 +424,11 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
    // as we're about to do).
    t->GetEndTime();
 
-   if (t->GetClipByIndex(0)->GetPlaySamplesCount() != nChunks * chunkSize) {
+   if (t->GetClipByIndex(0)->GetVisibleSampleCount() != nChunks * chunkSize) {
       Printf( XO("Expected len %lld, track len %lld.\n")
          .Format(
             nChunks * chunkSize,
-            t->GetClipByIndex(0)->GetPlaySamplesCount()
+            t->GetClipByIndex(0)->GetVisibleSampleCount()
                .as_long_long() ) );
       goto fail;
    }
@@ -462,7 +462,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
          Printf( XO("Expected len %lld, track len %lld.\n")
             .Format(
                nChunks * chunkSize,
-               t->GetClipByIndex(0)->GetPlaySamplesCount()
+               t->GetClipByIndex(0)->GetVisibleSampleCount()
                   .as_long_long() ) );
          goto fail;
       }
@@ -482,12 +482,12 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
          goto fail;
       }
 
-      if (t->GetClipByIndex(0)->GetPlaySamplesCount() != nChunks * chunkSize) {
+      if (t->GetClipByIndex(0)->GetVisibleSampleCount() != nChunks * chunkSize) {
          Printf( XO("Trial %d\n").Format( z ) );
          Printf( XO("Expected len %lld, track len %lld.\n")
             .Format(
                nChunks * chunkSize,
-               t->GetClipByIndex(0)->GetPlaySamplesCount()
+               t->GetClipByIndex(0)->GetVisibleSampleCount()
                   .as_long_long() ) );
          goto fail;
       }

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -457,8 +457,9 @@ void EffectChangePitch::DeduceFrequencies()
 
       track->GetFloats(buffer.get(), start, analyzeSize);
       for(unsigned i = 0; i < numWindows; i++) {
-         ComputeSpectrum(buffer.get() + i * windowSize, windowSize,
-                         windowSize, rate, freq.get(), true);
+         ComputeSpectrum(
+            buffer.get() + i * windowSize, windowSize, windowSize, freq.get(),
+            true);
          for(size_t j = 0; j < windowSize / 2; j++)
             freqa[j] += freq[j];
       }

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -372,7 +372,7 @@ void EffectSoundTouch::Finalize(
    assert(out.IsLeader());
    assert(out.NChannels() == orig.NChannels());
    if (mPreserveLength) {
-      auto newLen = out.GetPlaySamplesCount();
+      auto newLen = out.GetVisibleSampleCount();
       auto oldLen = out.TimeToLongSamples(mT1) - out.TimeToLongSamples(mT0);
 
       // Pad output track to original length since SoundTouch may remove samples

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -66,7 +66,7 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
       // But before removing, determine the first track after the removal
       auto last = *trackRange.rbegin();
       auto insertionPoint = * ++ tracks.Find(last);
-      
+
       auto selectedCount = trackRange.size();
       wxString firstName;
       int firstColour = -1;
@@ -482,7 +482,7 @@ void DoSortTracks( AudacityProject &project, int flags )
             int ndx;
             for (ndx = 0; ndx < w.GetNumClips(); ndx++) {
                const auto c = w.GetClipByIndex(ndx);
-               if (c->GetPlaySamplesCount() == 0)
+               if (c->GetVisibleSampleCount() == 0)
                   continue;
                stime = std::min(stime, c->GetPlayStartTime());
             }
@@ -1139,7 +1139,7 @@ BaseItemSharedPtr TracksMenu()
 {
    // Tracks Menu (formerly Project Menu)
    using Options = CommandManager::Options;
-   
+
    static BaseItemSharedPtr menu{
    Menu( wxT("Tracks"), XXO("&Tracks"),
       Section( "Add",

--- a/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
@@ -95,7 +95,7 @@ namespace {
       const auto xx = std::max<ZoomInfo::int64>(0, viewInfo.TimeToPosition(time));
       ZoomInfo::Intervals intervals;
       const double rate = wt->GetRate();
-      viewInfo.FindIntervals(rate, intervals, width);
+      viewInfo.FindIntervals(intervals, width);
       ZoomInfo::Intervals::const_iterator it = intervals.begin(),
          end = intervals.end(), prev;
       wxASSERT(it != end && it->position == 0);
@@ -148,7 +148,7 @@ UIHandlePtr SampleHandle::HitTest
    const bool dB = !settings.isLinear();
    int yValue = GetWaveYPos(oneSample * envValue,
       zoomMin, zoomMax,
-      rect.height, dB, true, 
+      rect.height, dB, true,
       settings.dBRange, false) + rect.y;
 
    // Get y position of mouse (in pixels)
@@ -458,7 +458,7 @@ float SampleHandle::FindSampleEditingLevel
    auto &settings = WaveformSettings::Get(*mClickedTrack);
    const bool dB = !settings.isLinear();
    float newLevel =
-      ::ValueOfPixel(yy, height, false, dB, 
+      ::ValueOfPixel(yy, height, false, dB,
          settings.dBRange, zoomMin, zoomMax);
 
    //Take the envelope into account

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -199,8 +199,8 @@ bool SpecCache::CalculateOneSpectrum
          wxASSERT(xx >= 0);
          float *const results = &out[nBins * xx];
          // This function does not mutate useBuffer
-         ComputeSpectrum(useBuffer, windowSizeSetting, windowSizeSetting,
-            rate, results,
+         ComputeSpectrum(
+            useBuffer, windowSizeSetting, windowSizeSetting, results,
             autocorrelation, settings.windowType);
       }
       else if (reassignment) {

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -682,7 +682,7 @@ void DrawClipSpectrum(TrackPanelDrawingContext &context,
       specCache.Populate
          (settings, sequence,
           0, 0, numPixels,
-          clip->GetPlaySamplesCount(),
+          clip->GetVisibleSampleCount(),
           tOffset, rate,
           0 // FIXME: PRL -- make reassignment work with fisheye
        );

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -459,7 +459,7 @@ void DrawIndividualSamples(TrackPanelDrawingContext &context, size_t channel,
    double rate = clip->GetRate();
    const double t0 = std::max(0.0, zoomInfo.PositionToTime(0, -leftOffset) - toffset);
    const auto s0 = sampleCount(floor(t0 * rate));
-   const auto snSamples = clip->GetPlaySamplesCount();
+   const auto snSamples = clip->GetVisibleSampleCount();
    if (s0 > snSamples)
       return;
 
@@ -793,7 +793,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context, size_t channel,
       if (portion.inFisheye) {
          if (!showIndividualSamples) {
             fisheyeDisplay.Allocate();
-            const auto numSamples = clip->GetPlaySamplesCount();
+            const auto numSamples = clip->GetVisibleSampleCount();
             // Get wave display data for different magnification
             int jj = 0;
             for (; jj < rectPortion.width; ++jj) {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -308,7 +308,7 @@ void FindWavePortions
    // the fisheye.
 
    ZoomInfo::Intervals intervals;
-   zoomInfo.FindIntervals(params.rate, intervals, rect.width, rect.x);
+   zoomInfo.FindIntervals(intervals, rect.width, rect.x);
    ZoomInfo::Intervals::const_iterator it = intervals.begin(), end = intervals.end(), prev;
    wxASSERT(it != end && it->position == rect.x);
    const int rightmost = rect.x + rect.width;
@@ -1015,12 +1015,12 @@ void WaveformView::Draw(
       const auto hasSolo = artist->hasSolo;
       bool muted = (hasSolo || wt->GetMute()) &&
       !wt->GetSolo();
-      
+
 #if defined(__WXMAC__)
       wxAntialiasMode aamode = dc.GetGraphicsContext()->GetAntialiasMode();
       dc.GetGraphicsContext()->SetAntialiasMode(wxANTIALIAS_NONE);
 #endif
-      
+
       auto waveChannelView = GetWaveChannelView().lock();
       wxASSERT(waveChannelView.use_count());
 
@@ -1098,7 +1098,7 @@ BEGIN_POPUP_MENU(WaveColorMenuTable)
       const auto &track = *static_cast<WaveTrack*>(pData->pTrack);
       auto &project = pData->project;
       bool unsafe = ProjectAudioIO::Get( project ).IsAudioActive();
-      
+
       menu.Check( id, id == me.IdOfWaveColor( track.GetWaveColorIndex() ) );
       menu.Enable( id, !unsafe );
    };


### PR DESCRIPTION
Resolves: #4850 

QA:
- [x] Test smart clip dragging (hidden data at ends)
- [x] Test that trim handles turn into stretch handles when pressing ALT

Small intentional behavior change:
- [x] dragging of smart clip boundaries allows 2 samples minimum, not 1 as before

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
