### PR TITLE
Time stretching 3 of 6 repair drawing tools for stretched audio

### DIFF
--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -201,6 +201,55 @@ void WaveClip::SetSamples(size_t ii,
    MarkChanged();
 }
 
+bool WaveClip::GetFloatAtTime(
+   double t, size_t iChannel, float& value, bool mayThrow) const
+{
+   if (!WithinPlayRegion(t))
+      return false;
+   const auto start = TimeToSamples(t);
+   return GetSamples(
+      iChannel, reinterpret_cast<samplePtr>(&value), floatSample, start, 1u,
+      mayThrow);
+}
+
+void WaveClip::SetFloatsFromTime(
+   double t, size_t iChannel, const float* buffer, size_t numFloats,
+   sampleFormat effectiveFormat)
+{
+   const auto maybeNegativeStart = TimeToSamples(t);
+   const auto maybeOutOfBoundEnd = maybeNegativeStart + numFloats;
+   const auto effectiveStart = std::max(sampleCount { 0 }, maybeNegativeStart);
+   const auto effectiveEnd =
+      std::min(GetVisibleSampleCount(), maybeOutOfBoundEnd);
+   if (effectiveStart >= effectiveEnd)
+      return;
+   // Cannot be greater than `numFloats` -> safe cast
+   const auto effectiveLen = (effectiveEnd - effectiveStart).as_size_t();
+   // Cannot be greater than `numFloats` -> safe cast
+   const auto numLeadingZeros =
+      (effectiveStart - maybeNegativeStart).as_size_t();
+   const auto offsetBuffer =
+      reinterpret_cast<const char*>(buffer + numLeadingZeros);
+   SetSamples(
+      iChannel, offsetBuffer, floatSample, effectiveStart, effectiveLen,
+      effectiveFormat);
+}
+
+void WaveClip::SetFloatsCenteredAroundTime(
+   double t, size_t iChannel, const float* buffer, size_t numSideSamples,
+   sampleFormat effectiveFormat)
+{
+   SetFloatsFromTime(
+      t - SamplesToTime(numSideSamples), iChannel, buffer,
+      2 * numSideSamples + 1, effectiveFormat);
+}
+
+void WaveClip::SetFloatAtTime(
+   double t, size_t iChannel, float value, sampleFormat effectiveFormat)
+{
+   SetFloatsCenteredAroundTime(t, iChannel, &value, 0u, effectiveFormat);
+}
+
 BlockArray* WaveClip::GetSequenceBlockArray(size_t ii)
 {
    assert(ii < GetWidth());

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -35,11 +35,12 @@ from the project that will own the track.
 #include <wx/debug.h>
 #include <wx/log.h>
 
+#include <algorithm>
 #include <float.h>
 #include <math.h>
-#include <algorithm>
-#include <optional>
 #include <numeric>
+#include <optional>
+#include <type_traits>
 
 #include "float_cast.h"
 
@@ -2716,6 +2717,200 @@ bool WaveTrack::Get(size_t iChannel, size_t nBuffers,
          pTrack = *(++ *iter);
       return result;
    });
+}
+
+namespace {
+void RoundToNearestClipSample(const WaveTrack& track, double& t)
+{
+   const auto clip = track.GetClipAtTime(t);
+   if (!clip)
+      return;
+   t = clip->SamplesToTime(clip->TimeToSamples(t - clip->GetPlayStartTime())) +
+       clip->GetPlayStartTime();
+}
+}
+
+std::pair<size_t, size_t> WaveTrack::GetFloatsCenteredAroundTime(
+   double t, size_t iChannel, float* buffer, size_t numSideSamples,
+   bool mayThrow) const
+{
+   const auto numSamplesReadLeft = GetFloatsFromTime(
+      t, iChannel, buffer, numSideSamples, mayThrow, PlaybackDirection::backward);
+   const auto numSamplesReadRight = GetFloatsFromTime(
+      t, iChannel, buffer + numSideSamples, numSideSamples + 1, mayThrow,
+      PlaybackDirection::forward);
+   return { numSideSamples - numSamplesReadLeft,
+            numSideSamples + numSamplesReadRight };
+}
+
+namespace
+{
+template <typename FloatType>
+using BufferCharType = std::conditional_t<
+   std::is_const_v<std::remove_pointer_t<FloatType>>, constSamplePtr,
+   samplePtr>;
+
+template <typename BufferType> struct SampleAccessArgs
+{
+   const BufferCharType<BufferType> offsetBuffer;
+   const sampleCount start;
+   const size_t len;
+};
+
+template <typename BufferType>
+SampleAccessArgs<BufferType> GetSampleAccessArgs(
+   const WaveClip& clip, double startOrEndTime /*absolute*/, BufferType buffer,
+   size_t totalToRead, size_t alreadyRead, bool forward)
+{
+   assert(totalToRead >= alreadyRead);
+   const auto remainingToRead = totalToRead - alreadyRead;
+   const auto sampsInClip = clip.GetVisibleSampleCount();
+   const auto sampsPerSec = clip.GetRate() / clip.GetStretchRatio();
+   if (forward)
+   {
+      const auto startTime =
+         std::max(startOrEndTime - clip.GetPlayStartTime(), 0.);
+      const sampleCount startSamp { std::round(startTime * sampsPerSec) };
+      if (startSamp >= sampsInClip)
+         return { nullptr, sampleCount { 0u }, 0u };
+      const auto len =
+         limitSampleBufferSize(remainingToRead, sampsInClip - startSamp);
+      return { reinterpret_cast<BufferCharType<BufferType>>(
+                  buffer + alreadyRead),
+               startSamp, len };
+   }
+   else
+   {
+      const auto endTime = std::min(
+         startOrEndTime - clip.GetPlayStartTime(), clip.GetPlayDuration());
+      const sampleCount endSamp { std::round(endTime * sampsPerSec) };
+      const auto startSamp =
+         std::max(endSamp - remainingToRead, sampleCount { 0 });
+      // `len` cannot be greater than `remainingToRead`, itself a `size_t` ->
+      // safe cast.
+      const auto len = (endSamp - startSamp).as_size_t();
+      if (len == 0 || startSamp >= sampsInClip)
+         return { nullptr, sampleCount { 0u }, 0u };
+      const auto bufferEnd = buffer + remainingToRead;
+      return { reinterpret_cast<BufferCharType<BufferType>>(bufferEnd - len),
+               startSamp, len };
+   }
+}
+} // namespace
+
+size_t WaveTrack::GetFloatsFromTime(
+   double t, size_t iChannel, float* buffer, size_t numSamples, bool mayThrow,
+   PlaybackDirection direction) const
+{
+   RoundToNearestClipSample(*this, t);
+   auto clip = GetClipAtTime(t);
+   auto numSamplesRead = 0u;
+   const auto forward = direction == PlaybackDirection::forward;
+   while (clip)
+   {
+      const auto args = GetSampleAccessArgs(
+         *clip, t, buffer, numSamples, numSamplesRead, forward);
+      if (!clip->GetSamples(
+             iChannel, args.offsetBuffer, floatSample, args.start, args.len,
+             mayThrow))
+         return 0u;
+      numSamplesRead += args.len;
+      if (numSamplesRead >= numSamples)
+         break;
+      clip = GetAdjacentClip(*clip, direction);
+   }
+   return numSamplesRead;
+}
+
+bool WaveTrack::GetFloatAtTime(
+   double t, size_t iChannel, float& value, bool mayThrow) const
+{
+   const auto clip = GetClipAtTime(t);
+   if (!clip)
+      return false;
+   clip->GetFloatAtTime(
+      t - clip->GetPlayStartTime(), iChannel, value, mayThrow);
+   return true;
+}
+
+void WaveTrack::SetFloatsCenteredAroundTime(
+   double t, size_t iChannel, const float* buffer, size_t numSideSamples,
+   sampleFormat effectiveFormat)
+{
+   SetFloatsFromTime(
+      t, iChannel, buffer, numSideSamples, effectiveFormat,
+      PlaybackDirection::backward);
+   SetFloatsFromTime(
+      t, iChannel, buffer + numSideSamples, numSideSamples + 1, effectiveFormat,
+      PlaybackDirection::forward);
+}
+
+void WaveTrack::SetFloatsFromTime(
+   double t, size_t iChannel, const float* buffer, size_t numSamples,
+   sampleFormat effectiveFormat, PlaybackDirection direction)
+{
+   RoundToNearestClipSample(*this, t);
+   auto clip = GetClipAtTime(t);
+   auto numSamplesWritten = 0u;
+   const auto forward = direction == PlaybackDirection::forward;
+   while (clip)
+   {
+      const auto args = GetSampleAccessArgs(
+         *clip, t, buffer, numSamples, numSamplesWritten, forward);
+      if (args.len > 0u)
+      {
+         clip->SetSamples(
+            iChannel, args.offsetBuffer, floatSample, args.start, args.len,
+            effectiveFormat);
+         numSamplesWritten += args.len;
+         if (numSamplesWritten >= numSamples)
+            break;
+      }
+      clip = GetAdjacentClip(*clip, direction);
+   }
+}
+
+void WaveTrack::SetFloatAtTime(
+   double t, size_t iChannel, float value, sampleFormat effectiveFormat)
+{
+   SetFloatsCenteredAroundTime(t, iChannel, &value, 0u, effectiveFormat);
+}
+
+void WaveTrack::SetFloatsWithinTimeRange(
+   double t0, double t1, size_t iChannel,
+   const std::function<float(double sampleTime)>& producer,
+   sampleFormat effectiveFormat)
+{
+   assert(t0 <= t1);
+   const auto sortedClips = SortedClipArray();
+   if (sortedClips.empty())
+      return;
+   t0 = std::max(t0, (*sortedClips.begin())->GetPlayStartTime());
+   t1 = std::min(t1, (*sortedClips.rbegin())->GetPlayEndTime());
+   auto clip = GetClipAtTime(t0);
+   while (clip) {
+      const auto clipStartTime = clip->GetPlayStartTime();
+      const auto clipEndTime = clip->GetPlayEndTime();
+      const auto sampsPerSec = clip->GetRate() / clip->GetStretchRatio();
+      const auto roundedT0 =
+         std::round((t0 - clipStartTime) * sampsPerSec) / sampsPerSec +
+         clipStartTime;
+      const auto roundedT1 =
+         std::round((t1 - clipStartTime) * sampsPerSec + 1) / sampsPerSec +
+         clipStartTime;
+      if (clipStartTime > roundedT1)
+         break;
+      const auto tt0 = std::max(clipStartTime, roundedT0);
+      const auto tt1 = std::min(clipEndTime, roundedT1);
+      const size_t numSamples = (tt1 - tt0) * sampsPerSec + .5;
+      std::vector<float> values(numSamples);
+      for (auto i = 0u; i < numSamples; ++i)
+         values[i] = producer(tt0 + clip->SamplesToTime(i));
+      clip->SetFloatsFromTime(
+         tt0 - clipStartTime, iChannel, values.data(), numSamples,
+         effectiveFormat);
+      clip = GetNextClip(*clip, PlaybackDirection::forward);
+   }
 }
 
 bool WaveTrack::GetOne(

--- a/src/tracks/playabletrack/wavetrack/ui/SampleHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SampleHandle.h
@@ -71,8 +71,8 @@ private:
    std::shared_ptr<WaveTrack> mClickedTrack;
    wxRect mRect{};
 
-   sampleCount mClickedStartSample{};
-   sampleCount mLastDragSample{};
+   int mClickedStartPixel {};
+   int mLastDragPixel {};
    float mLastDragSampleValue{};
    bool mAltKey{};
 };


### PR DESCRIPTION
Resolves: #4850

This PR repairs drawing operations on stretched clips.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

## QA
- [x] editing one sample at a time by clicking with pencil,
- [x] editing many samples by dragging pencil across clips, some stretched, others not, some mono, others stereo.
- [x] same exercise with brush tool (select pencil then press alt)
- [x] trying to draw samples when individual samples are not visible (because zoomed out) issues the usual error message.
- [x] (Paul) test all in the pencil tool mode and again in multi-tool mode
- [x] (Paul) hit-testing on samples in multi tool with nontrivial envelope (this doesn’t work quite right in last release, but be sure it is not worse)
- [x] (Paul) include paintbrush cases where there is hidden smart clip data, and where clips (maybe with hidden data, maybe with different stretches) are touching or nearly touching
- [x] (Paul) I think we're also fixing an old misbehavior:  click and drag with the pencil sometimes did nothing but made a vacuous undo/redo item
- [x] (Paul) also remember (I had forgot!) that a drag with Ctrl key down adjusts only one pixel
- [x] Clicking or dragging edits nearest sample (not previous or next - nearest)
- [x] Drag-drawing on a clip's rectangle (not out-of-bound) always updates the nearest sample, not just when the pencil crosses its x-location
- [x] Works as well for stereo

