### PR TITLE
Time stretching 5 of 6 repair effects and generators for stretched audio

### DIFF
--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -15,8 +15,9 @@
 int EffectOutputTracks::nEffectsDone = 0;
 
 EffectOutputTracks::EffectOutputTracks(
-   TrackList &tracks, bool allSyncLockSelected
-)  : mTracks{ tracks }
+   TrackList& tracks, std::pair<double, double> effectTimeInterval,
+   bool allSyncLockSelected)
+    : mTracks { tracks }
 {
    // Reset map
    mIMap.clear();
@@ -31,7 +32,7 @@ EffectOutputTracks::EffectOutputTracks(
       };
 
    for (auto aTrack : trackRange) {
-      auto list = aTrack->Duplicate();
+      auto list = aTrack->Duplicate(effectTimeInterval);
       mIMap.push_back(aTrack);
       mOMap.push_back(*list->begin());
       mOutputTracks->Append(std::move(*list));

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -29,7 +29,8 @@ public:
    static int nEffectsDone;
    static void IncEffectCounter() { ++nEffectsDone; }
 
-   EffectOutputTracks(TrackList &tracks,
+   EffectOutputTracks(
+      TrackList& tracks, std::pair<double, double> effectTimeInterval,
       bool allSyncLockSelected = false);
    EffectOutputTracks(const EffectOutputTracks&) = delete;
 

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -67,7 +67,7 @@ bool PerTrackEffect::Process(
    EffectInstance &instance, EffectSettings &settings) const
 {
    auto pThis = const_cast<PerTrackEffect *>(this);
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    bool bGoodResult = true;
    // mPass = 1;
    if (DoPass1()) {

--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -233,7 +233,8 @@ void TimeTrack::InsertSilence(double t, double len)
    mEnvelope->InsertSpace(t, len);
 }
 
-TrackListHolder TimeTrack::Clone() const
+TrackListHolder TimeTrack::Clone(
+   std::optional<std::pair<double, double>> /* unstretchInterval */) const
 {
    assert(IsLeader());
    auto result = std::make_shared<TimeTrack>(*this, ProtectedCreationArg{});

--- a/libraries/lib-time-track/TimeTrack.h
+++ b/libraries/lib-time-track/TimeTrack.h
@@ -122,7 +122,7 @@ private:
    using Holder = std::unique_ptr<TimeTrack>;
 
 private:
-   TrackListHolder Clone() const override;
+   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
 };
 
 ENUMERATE_TRACK_TYPE(TimeTrack);

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -50,7 +50,7 @@ Track::Track(const Track& orig, ProtectedCreationArg&&)
 void Track::Init(const Track &orig)
 {
    mId = orig.mId;
-
+   mProjectTempo = orig.mProjectTempo;
    // Deep copy of any group data
    mpGroupData = orig.mpGroupData ?
       std::make_unique<ChannelGroupData>(*orig.mpGroupData) : nullptr;

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -93,11 +93,12 @@ void Track::EnsureVisible( bool modifyState )
       pList->EnsureVisibleEvent(SharedPointer(), modifyState);
 }
 
-TrackListHolder Track::Duplicate() const
+TrackListHolder Track::Duplicate(
+   std::optional<std::pair<double, double>> unstretchInterval) const
 {
    assert(IsLeader());
    // invoke "virtual constructor" to copy track object proper:
-   auto result = Clone();
+   auto result = Clone(std::move(unstretchInterval));
 
    auto iter = TrackList::Channels(*result->begin()).begin();
    const auto copyOne = [&](const Track *pChannel){
@@ -1004,7 +1005,7 @@ TrackList::RegisterPendingChangedTrack(Updater updater, Track *src)
    TrackListHolder tracks;
    std::vector<Track*> result;
    if (src) {
-      tracks = src->Clone(); // not duplicate
+      tracks = src->Clone(std::nullopt); // not duplicate
       assert(src->NChannels() == tracks->NChannels());
    }
    if (src) {

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -478,8 +478,10 @@ public:
    // Return true iff the attribute is recognized.
    bool HandleCommonXMLAttribute(const std::string_view& attr, const XMLAttributeValueView& valueView);
 
-protected:
    const std::optional<double>& GetProjectTempo() const;
+
+protected:
+   std::optional<double> mProjectTempo;
 
    /*!
     @pre `IsLeader()`
@@ -586,7 +588,7 @@ public:
     @tparam F returns a shared pointer to Attachment (or some subtype of it)
 
     @pre `f` never returns null
-   
+
     `f` may assume the precondition that the given channel index is less than
     the given track's number of channels
     */

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -305,7 +305,9 @@ private:
     @pre `IsLeader()`
     @post result: `NChannels() == result->NChannels()`
     */
-   virtual TrackListHolder Duplicate() const;
+   virtual TrackListHolder Duplicate(
+      std::optional<std::pair<double, double>> unstretchInterval =
+         std::nullopt) const;
 
    //! Name is always the same for all channels of a group
    const wxString &GetName() const;
@@ -398,10 +400,12 @@ private:
    //! Subclass responsibility implements only a part of Duplicate(), copying
    //! the track data proper (not associated data such as for groups and views)
    /*!
+    @param unstretchInterval If set, this time interval's stretching must be applied.
     @pre `IsLeader()`
     @post result: `NChannels() == result->NChannels()`
     */
-   virtual TrackListHolder Clone() const = 0;
+   virtual TrackListHolder
+   Clone(std::optional<std::pair<double, double>> unstretchInterval) const = 0;
 
    template<typename T>
       friend std::enable_if_t< std::is_pointer_v<T>, T >

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -175,7 +175,13 @@ public:
 
    // Resample clip. This also will set the rate, but without changing
    // the length of the clip
-   void Resample(int rate, BasicUI::ProgressDialog *progress = NULL);
+   void Resample(int rate, BasicUI::ProgressDialog *progress = nullptr);
+
+   /*!
+    * @brief Renders the stretching of the clip (preserving duration).
+    * @post GetStretchRatio() == 1
+    */
+   void ApplyStretchRatio();
 
    void SetColourIndex( int index ){ mColourIndex = index;};
    int GetColourIndex( ) const { return mColourIndex;};
@@ -189,10 +195,17 @@ public:
    //! (but not counting the cutlines)
    sampleCount GetSequenceSamplesCount() const;
 
+   //! Closed-begin of play region. Always a multiple of the track's sample
+   //! period, whether the clip is stretched or not.
    double GetPlayStartTime() const noexcept override;
    void SetPlayStartTime(double time);
 
+   //! Open-end of play region. Always a multiple of the track's sample
+   //! period, whether the clip is stretched or not.
    double GetPlayEndTime() const override;
+
+   //! Always a multiple of the track's sample period, whether the clip is
+   //! stretched or not.
    double GetPlayDuration() const;
 
    // todo comment
@@ -518,6 +531,7 @@ private:
    sampleCount GetNumSamples() const;
    SampleFormats GetSampleFormats() const;
    const SampleBlockFactoryPtr &GetFactory();
+   std::vector<std::unique_ptr<Sequence>> GetEmptySequenceCopies() const;
    void StretchCutLines(double ratioChange);
    double SnapToTrackSample(double time) const noexcept;
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -248,7 +248,8 @@ public:
 private:
    void Init(const WaveTrack &orig);
 
-   TrackListHolder Clone() const override;
+   TrackListHolder Clone(std::optional<std::pair<double, double>>
+                            unstretchInterval) const override;
 
    friend class WaveTrackFactory;
 
@@ -268,6 +269,8 @@ private:
    double GetStartTime() const override;
    //! Implement WideSampleSequence
    double GetEndTime() const override;
+
+   double SnapToSample(double t) const;
 
    //
    // Identifying the type of track
@@ -922,6 +925,9 @@ private:
    //! Sets project tempo on clip upon push. Use this instead of
    //! `mClips.push_back`.
    void InsertClip(WaveClipHolder clip);
+
+   void ApplyStretchRatio(std::optional<std::pair<double, double>>);
+   void ApplyStretchRatioOne(double t0, double t1);
 
    SampleBlockFactoryPtr mpFactory;
 

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -342,7 +342,8 @@ void LabelTrack::SetSelected( bool s )
          this->SharedPointer<LabelTrack>(), {}, -1, -1 });
 }
 
-TrackListHolder LabelTrack::Clone() const
+TrackListHolder LabelTrack::Clone(
+   std::optional<std::pair<double, double>> /* unstretchInterval */) const
 {
    assert(IsLeader());
    auto result = std::make_shared<LabelTrack>(*this, ProtectedCreationArg{});

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -117,7 +117,7 @@ class AUDACITY_DLL_API LabelTrack final
    using Holder = std::shared_ptr<LabelTrack>;
 
 private:
-   TrackListHolder Clone() const override;
+   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
    void DoOnProjectTempoChange(
       const std::optional<double>& oldTempo, double newTempo) override;
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -165,7 +165,8 @@ Alg_seq &NoteTrack::GetSeq() const
    return *mSeq;
 }
 
-TrackListHolder NoteTrack::Clone() const
+TrackListHolder NoteTrack::Clone(
+   std::optional<std::pair<double, double>> /* unstretchInterval */) const
 {
    auto duplicate = std::make_shared<NoteTrack>();
    duplicate->Init(*this);
@@ -983,7 +984,7 @@ void NoteTrack::WriteXML(XMLWriter &xmlFile) const
    if (!mSeq) {
       // replace saveme with an (unserialized) duplicate, which is
       // destroyed at end of function.
-      holder = (*Clone()->begin())->SharedPointer();
+      holder = (*Clone(std::nullopt)->begin())->SharedPointer();
       saveme = static_cast<NoteTrack*>(holder.get());
    }
    saveme->GetSeq().write(data, true);

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -75,7 +75,7 @@ public:
    using Holder = std::shared_ptr<NoteTrack>;
 
 private:
-   TrackListHolder Clone() const override;
+   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
 
 public:
    void MoveTo(double origin) override { mOrigin = origin; }

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -225,7 +225,7 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
       while (pos < end)
       {
          const auto len = limitSampleBufferSize( kBufSize, end - pos );
-         
+
          mControlTrack->GetFloats(buf.get(), pos, len);
 
          for (auto i = pos; i < pos + len; i++)
@@ -301,7 +301,7 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
    }
 
    if (!cancel) {
-      EffectOutputTracks outputs{ *mTracks };
+      EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
 
       int trackNum = 0;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -216,7 +216,7 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
    // Iterate over each track.
    // All needed because this effect needs to introduce
    // silence in the sync-lock group tracks to keep sync
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    bool bGoodResult = true;
 
    mCurTrackNum = 0;

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -113,7 +113,7 @@ bool EffectClickRemoval::CheckWhetherSkipEffect(const EffectSettings &) const
 
 bool EffectClickRemoval::Process(EffectInstance &, EffectSettings &)
 {
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
    mbDidSomething = false;
 

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -197,7 +197,7 @@ bool EffectEqualization::VisitSettings(
    // Curve point parameters -- how many isn't known statically
    {
       curves[0].points.clear();
-   
+
       for (int i = 0; i < 200; i++)
       {
          const wxString nameFreq = wxString::Format("f%i",i);
@@ -289,7 +289,7 @@ EffectEqualization::LoadFactoryPreset(int id, EffectSettings &settings) const
    if (index < 0)
       return {};
 
-   // mParams = 
+   // mParams =
    wxString params = FactoryPresets[index].values;
 
    CommandParameters eap(params);
@@ -403,7 +403,7 @@ struct EffectEqualization::Task {
 
 bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
 {
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    mParameters.CalcFilter();
    bool bGoodResult = true;
 
@@ -424,7 +424,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
          auto pTempTrack = *temp->Any<WaveTrack>().begin();
          pTempTrack->ConvertToSampleFormat(floatSample);
          auto iter0 = pTempTrack->Channels().begin();
-   
+
          for (const auto pChannel : track->Channels()) {
             constexpr auto windowSize = EqualizationFilter::windowSize;
             const auto &M = mParameters.mM;

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -30,7 +30,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
 
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
 
    // Iterate over the tracks
    bool bGoodResult = true;
@@ -71,7 +71,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
                   ViewInfo::Get(*pProject).selectedRegion;
                track.ClearAndPaste(
                   selectedRegion.t0(), selectedRegion.t1(),
-                  *list, true, false, &warper);
+                  *list, true, true, &warper);
             }
             else
                return;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -105,7 +105,7 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
    );
 
    // Iterate over each track
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
    auto topMsg = XO("Normalizing Loudness...\n");
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -637,7 +637,7 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
 {
    // This same code will either reduce noise or profile it
 
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
 
    auto track = *(outputs.Get().Selected<const WaveTrack>()).begin();
    if (!track)

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -222,7 +222,7 @@ bool EffectNoiseRemoval::Process(EffectInstance &, EffectSettings &)
 
    // This same code will both remove noise and profile it,
    // depending on 'mDoProfile'
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
 
    int count = 0;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -106,7 +106,7 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
    }
 
    //Iterate over each track
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
    double progress = 0;
    TranslatableString topMsg;

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -41,7 +41,7 @@ const EffectParameterMethods& EffectPaulstretch::Parameters() const
    return parameters;
 }
 
-/// \brief Class that helps EffectPaulStretch.  It does the FFTs and inner loop 
+/// \brief Class that helps EffectPaulStretch.  It does the FFTs and inner loop
 /// of the effect.
 class PaulStretch
 {
@@ -147,7 +147,7 @@ double EffectPaulstretch::CalcPreviewInputLength(
 bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
 {
    // Pass true because sync lock adjustment is needed
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    auto newT1 = mT1;
    int count = 0;
    // Process selected wave tracks first, to find the new t1 value

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -77,7 +77,7 @@ bool EffectRepair::Process(EffectInstance &, EffectSettings &)
    // This may be too much copying for EffectRepair. To support Cancel, may be
    // able to copy much less.
    // But for now, Cancel isn't supported without this.
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
 
    int count = 0;

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -93,7 +93,7 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
 {
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
 
    int nTrack = 0;
    bool bGoodResult = true;

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -73,7 +73,7 @@ bool EffectReverse::IsInteractive() const
 bool EffectReverse::Process(EffectInstance &, EffectSettings &)
 {
    //all needed because Reverse should move the labels too
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    bool bGoodResult = true;
    int count = 0;
 

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -223,7 +223,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
 
    //Iterate over each track
    //all needed because this effect needs to introduce silence in the group tracks to keep sync
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    mCurTrackNum = 0;
 
    double maxDuration = 0.0;
@@ -321,7 +321,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
                   0,
                   rb.quality.get());
             }
-            
+
             Resampler resampler(outResampleCB, &rb, outSlideType);
 
             audio outBuf[SBSMSOutBlockSize];

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -87,7 +87,7 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
 
    //Iterate over each track
    // Needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    bool bGoodResult = true;
 
    mPreserveLength = preserveLength;

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -79,13 +79,13 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
 {
    // Do not use mWaveTracks here.  We will possibly DELETE tracks,
    // so we must use the "real" tracklist.
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
 
    // Determine the total time (in samples) used by all of the target tracks
    // only for progress dialog
    sampleCount totalTime = 0;
-   
+
    auto trackRange = outputs.Get().Selected<WaveTrack>();
    for (const auto left : trackRange) {
       if (left->Channels().size() > 1) {

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -97,7 +97,7 @@ static const size_t DEF_BlendFrameCount = 100;
 
 // Lower bound on the amount of silence to find at a time -- this avoids
 // detecting silence repeatedly in low-frequency sounds.
-static const double DEF_MinTruncMs = 0.001; 
+static const double DEF_MinTruncMs = 0.001;
 
 // Typical fraction of total time taken by detection (better to guess low)
 const double detectFrac = 0.4;
@@ -189,7 +189,7 @@ bool EffectTruncSilence::LoadSettings(
       if (!parms.ReadAndVerify( ActIndex.key, &temp, ActIndex.def,
          kActionStrings, nActions, kObsoleteActions, nObsoleteActions))
          return false;
-   
+
       // TODO:  fix this when settings are really externalized
       const_cast<int&>(mActionIndex) = temp;
    }
@@ -272,7 +272,7 @@ bool EffectTruncSilence::ProcessIndependently()
    // Now do the work
 
    // Copy tracks
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    double newT1 = 0.0;
 
    {
@@ -306,7 +306,7 @@ bool EffectTruncSilence::ProcessIndependently()
 bool EffectTruncSilence::ProcessAll()
 {
    // Copy tracks
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
 
    // Master list of silent regions.
    // This list should always be kept in order.
@@ -427,7 +427,7 @@ bool EffectTruncSilence::DoRemoval(const RegionList &silences,
       // Don't waste time cutting nothing.
       if( cutLen == 0.0 )
          continue;
-      
+
       totalCutLen += cutLen;
 
       double cutStart = (r->start + r->end - cutLen) / 2;

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -28,7 +28,7 @@ bool EffectTwoPassSimpleMono::Process(
    mSecondPassDisabled = false;
 
    InitPass1();
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
 
    mWorkTracks = TrackList::Create(const_cast<AudacityProject*>(FindProject()));
    for (auto track : outputs.Get().Selected<WaveTrack>()) {

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -769,7 +769,7 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
    // to operate on the selected wave tracks
    std::optional<EffectOutputTracks> oOutputs;
    if (!bOnePassTool)
-      oOutputs.emplace(*mTracks, true);
+      oOutputs.emplace(*mTracks, std::pair<double, double> { mT0, mT1 }, true);
 
    mNumSelectedChannels = bOnePassTool
       ? 0

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
@@ -67,7 +67,7 @@ namespace
       }
       return -1;
    }
-   
+
    bool IsOverCutline
       (const ViewInfo &viewInfo, WaveTrack * track,
        const wxRect &rect, const wxMouseState &state,
@@ -169,7 +169,16 @@ UIHandle::Result CutlineHandle::Click
 
          viewInfo.selectedRegion.setTimes(cutlineStart, cutlineEnd);
       }
-      else if (mLocation.typ == WaveTrackLocation::locationMergePoint) {
+      // todo(mhodgkinson) Bluntly disabling this Join shortcut for now. There
+      // exists an issue that wants to do this properly:
+      // https://github.com/audacity/audacity/issues/2330
+      // With stretching, merging can lead to rendering the track, which can
+      // freeze the application for a noticeable time. At the time of writing
+      // there is no progress bar for that. Even if there were, in the case of
+      // an unintentional action that might be quite annoying.
+      else if (
+         false /* mLocation.typ == WaveTrackLocation::locationMergePoint */)
+      {
          const double pos = mLocation.pos;
          for (auto channel :
               TrackList::Channels(mpTrack.get())) {


### PR DESCRIPTION
Resolves: #4850

This PR repairs destructive effects for stretched clips.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

## QA
All effects are supposed to work. Trying all of them may be too much, but a variety of types of effects should be tried (time-related effect, Nyquist, EQs and filters, noise removal, pitch shift, spectral tools, etc. Of course try them on stretched data, but also on stereo data, etc.

Note that applying an effect on a partial clip selection will create a new clip if the clip was stretched. That's wanted. The old behavior is only preserved on unstretched data.

- [ ] AutoDuck
- [ ] Change Speed
- [ ] Click Removal
- [ ] EQ
- [ ] Generate silence
- [ ] Loudness
- [ ] Noise Reduction
- [ ] Normalize
- [ ] Paulstretch
- [ ] Repair (Since this requires up to 128 samples only, the result will probably only be silence, and that's ok: it's a known limitation of the algorithm that rendering very tiny portions of audio only output silence)
- [ ] Repeat
- [ ] Reverse
- [ ] Change Tempo and Sliding Scale, high and low quality
- [ ] Stereo To Mono (previously reported by @dozzer as https://github.com/audacity/audacity/issues/5118)
- [ ] Truncate Silence
- [ ] Compressor
- [ ] Some Nyquist effects and generators
- [ ] At least one "Per Track Effect" example (any of the realtime capable, built-in or plug-in effects, but used destructively)
