### PR TITLE
Time stretching 6 of 6 progress bars for stretching operations

### DIFF
--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -15,8 +15,9 @@
 int EffectOutputTracks::nEffectsDone = 0;
 
 EffectOutputTracks::EffectOutputTracks(
-   TrackList &tracks, bool allSyncLockSelected
-)  : mTracks{ tracks }
+   TrackList& tracks, std::pair<double, double> effectTimeInterval,
+   bool allSyncLockSelected)
+    : mTracks { tracks }
 {
    // Reset map
    mIMap.clear();
@@ -31,7 +32,7 @@ EffectOutputTracks::EffectOutputTracks(
       };
 
    for (auto aTrack : trackRange) {
-      auto list = aTrack->Duplicate();
+      auto list = aTrack->Duplicate(effectTimeInterval);
       mIMap.push_back(aTrack);
       mOMap.push_back(*list->begin());
       mOutputTracks->Append(std::move(*list));

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -29,7 +29,8 @@ public:
    static int nEffectsDone;
    static void IncEffectCounter() { ++nEffectsDone; }
 
-   EffectOutputTracks(TrackList &tracks,
+   EffectOutputTracks(
+      TrackList& tracks, std::pair<double, double> effectTimeInterval,
       bool allSyncLockSelected = false);
    EffectOutputTracks(const EffectOutputTracks&) = delete;
 

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -67,7 +67,7 @@ bool PerTrackEffect::Process(
    EffectInstance &instance, EffectSettings &settings) const
 {
    auto pThis = const_cast<PerTrackEffect *>(this);
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    bool bGoodResult = true;
    // mPass = 1;
    if (DoPass1()) {

--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -233,7 +233,8 @@ void TimeTrack::InsertSilence(double t, double len)
    mEnvelope->InsertSpace(t, len);
 }
 
-TrackListHolder TimeTrack::Clone() const
+TrackListHolder TimeTrack::Clone(
+   std::optional<std::pair<double, double>> /* unstretchInterval */) const
 {
    assert(IsLeader());
    auto result = std::make_shared<TimeTrack>(*this, ProtectedCreationArg{});

--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -234,7 +234,8 @@ void TimeTrack::InsertSilence(double t, double len)
 }
 
 TrackListHolder TimeTrack::Clone(
-   std::optional<std::pair<double, double>> /* unstretchInterval */) const
+   std::optional<TimeInterval> /* unstretchInterval */,
+   std::function<void(double)> /* reportProgress */) const
 {
    assert(IsLeader());
    auto result = std::make_shared<TimeTrack>(*this, ProtectedCreationArg{});

--- a/libraries/lib-time-track/TimeTrack.h
+++ b/libraries/lib-time-track/TimeTrack.h
@@ -122,7 +122,7 @@ private:
    using Holder = std::unique_ptr<TimeTrack>;
 
 private:
-   TrackListHolder Clone() const override;
+   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
 };
 
 ENUMERATE_TRACK_TYPE(TimeTrack);

--- a/libraries/lib-time-track/TimeTrack.h
+++ b/libraries/lib-time-track/TimeTrack.h
@@ -122,7 +122,9 @@ private:
    using Holder = std::unique_ptr<TimeTrack>;
 
 private:
-   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
+   TrackListHolder Clone(
+      std::optional<TimeInterval> unstretchInterval,
+      ProgressReporter reportProgress) const override;
 };
 
 ENUMERATE_TRACK_TYPE(TimeTrack);

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -50,7 +50,7 @@ Track::Track(const Track& orig, ProtectedCreationArg&&)
 void Track::Init(const Track &orig)
 {
    mId = orig.mId;
-
+   mProjectTempo = orig.mProjectTempo;
    // Deep copy of any group data
    mpGroupData = orig.mpGroupData ?
       std::make_unique<ChannelGroupData>(*orig.mpGroupData) : nullptr;

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -93,11 +93,12 @@ void Track::EnsureVisible( bool modifyState )
       pList->EnsureVisibleEvent(SharedPointer(), modifyState);
 }
 
-TrackListHolder Track::Duplicate() const
+TrackListHolder Track::Duplicate(
+   std::optional<std::pair<double, double>> unstretchInterval) const
 {
    assert(IsLeader());
    // invoke "virtual constructor" to copy track object proper:
-   auto result = Clone();
+   auto result = Clone(std::move(unstretchInterval));
 
    auto iter = TrackList::Channels(*result->begin()).begin();
    const auto copyOne = [&](const Track *pChannel){
@@ -1004,7 +1005,7 @@ TrackList::RegisterPendingChangedTrack(Updater updater, Track *src)
    TrackListHolder tracks;
    std::vector<Track*> result;
    if (src) {
-      tracks = src->Clone(); // not duplicate
+      tracks = src->Clone(std::nullopt); // not duplicate
       assert(src->NChannels() == tracks->NChannels());
    }
    if (src) {

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -94,11 +94,12 @@ void Track::EnsureVisible( bool modifyState )
 }
 
 TrackListHolder Track::Duplicate(
-   std::optional<std::pair<double, double>> unstretchInterval) const
+   std::optional<TimeInterval> unstretchInterval,
+   ProgressReporter reportProgress) const
 {
    assert(IsLeader());
    // invoke "virtual constructor" to copy track object proper:
-   auto result = Clone(std::move(unstretchInterval));
+   auto result = Clone(std::move(unstretchInterval), std::move(reportProgress));
 
    auto iter = TrackList::Channels(*result->begin()).begin();
    const auto copyOne = [&](const Track *pChannel){

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -44,6 +44,8 @@ using TrackListHolder = std::shared_ptr<TrackList>;
 struct UndoStackElem;
 
 using ListOfTracks = std::list< std::shared_ptr< Track > >;
+using TimeInterval = std::pair<double, double>;
+using ProgressReporter = std::function<void(double)>;
 
 //! Pairs a std::list iterator and a pointer to a list, for comparison purposes
 /*! Compare owning lists first, and only if same, then the iterators;
@@ -306,8 +308,8 @@ private:
     @post result: `NChannels() == result->NChannels()`
     */
    virtual TrackListHolder Duplicate(
-      std::optional<std::pair<double, double>> unstretchInterval =
-         std::nullopt) const;
+      std::optional<TimeInterval> unstretchInterval = std::nullopt,
+      ProgressReporter reportProgress = {}) const;
 
    //! Name is always the same for all channels of a group
    const wxString &GetName() const;
@@ -404,8 +406,9 @@ private:
     @pre `IsLeader()`
     @post result: `NChannels() == result->NChannels()`
     */
-   virtual TrackListHolder
-   Clone(std::optional<std::pair<double, double>> unstretchInterval) const = 0;
+   virtual TrackListHolder Clone(
+      std::optional<TimeInterval> unstretchInterval = {},
+      ProgressReporter reportProgress = {}) const = 0;
 
    template<typename T>
       friend std::enable_if_t< std::is_pointer_v<T>, T >

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -478,8 +478,10 @@ public:
    // Return true iff the attribute is recognized.
    bool HandleCommonXMLAttribute(const std::string_view& attr, const XMLAttributeValueView& valueView);
 
-protected:
    const std::optional<double>& GetProjectTempo() const;
+
+protected:
+   std::optional<double> mProjectTempo;
 
    /*!
     @pre `IsLeader()`
@@ -586,7 +588,7 @@ public:
     @tparam F returns a shared pointer to Attachment (or some subtype of it)
 
     @pre `f` never returns null
-   
+
     `f` may assume the precondition that the given channel index is less than
     the given track's number of channels
     */

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -305,7 +305,9 @@ private:
     @pre `IsLeader()`
     @post result: `NChannels() == result->NChannels()`
     */
-   virtual TrackListHolder Duplicate() const;
+   virtual TrackListHolder Duplicate(
+      std::optional<std::pair<double, double>> unstretchInterval =
+         std::nullopt) const;
 
    //! Name is always the same for all channels of a group
    const wxString &GetName() const;
@@ -398,10 +400,12 @@ private:
    //! Subclass responsibility implements only a part of Duplicate(), copying
    //! the track data proper (not associated data such as for groups and views)
    /*!
+    @param unstretchInterval If set, this time interval's stretching must be applied.
     @pre `IsLeader()`
     @post result: `NChannels() == result->NChannels()`
     */
-   virtual TrackListHolder Clone() const = 0;
+   virtual TrackListHolder
+   Clone(std::optional<std::pair<double, double>> unstretchInterval) const = 0;
 
    template<typename T>
       friend std::enable_if_t< std::is_pointer_v<T>, T >

--- a/libraries/lib-wave-track/PasteOverPreservingClips.cpp
+++ b/libraries/lib-wave-track/PasteOverPreservingClips.cpp
@@ -50,9 +50,9 @@ ClipData CollectClipData(
    return results;
 }
 
-void PasteOverPreservingClips(const ClipData &data,
-   WaveTrack &oldTrack, sampleCount start, sampleCount len,
-   const WaveTrack &newContents)
+void PasteOverPreservingClips(
+   const ClipData& data, WaveTrack& oldTrack, sampleCount start,
+   sampleCount len, const WaveTrack& newContents)
 {
    assert(oldTrack.IsLeader());
    assert(newContents.IsLeader());
@@ -76,7 +76,7 @@ void PasteOverPreservingClips(const ClipData &data,
       //remove the old audio and get the NEW
       auto [start, end] = clipStartEndTimes[i];
       oldTrack.Clear(start, end);
-   
+
       auto toClipOutput = newContents.Copy(start - startT, end - startT);
       oldTrack.Paste(start, *toClipOutput);
 
@@ -91,6 +91,12 @@ void PasteOverPreservingClips(const ClipData &data,
       auto [realStart, realEnd] = clipRealStartEndTimes[i];
       if ((realStart  != start || realEnd != end) &&
          !(realStart <= startT && realEnd >= startT + lenT))
-         oldTrack.Join(realStart, realEnd);
+         oldTrack.Join(
+            realStart, realEnd,
+            // At the time of writing, PasteOverPreservingClips is only used by
+            // the equalization effect. The equalized region of the track
+            // already had its stretching applied, so there shouldn't be a need
+            // for stretching now and hence we don't bother with a progress bar.
+            {});
    }
 }

--- a/libraries/lib-wave-track/PasteOverPreservingClips.h
+++ b/libraries/lib-wave-track/PasteOverPreservingClips.h
@@ -13,6 +13,7 @@
 #ifndef __AUDACITY_PASTE_OVER_PRESERVING_CLIPS__
 #define __AUDACITY_PASTE_OVER_PRESERVING_CLIPS__
 
+#include <functional>
 #include <vector>
 
 class sampleCount;
@@ -21,6 +22,7 @@ class wxString;
 
 using Gap = std::pair<double, double>;
 using Gaps = std::vector<Gap>;
+using ProgressReporter = std::function<void(double)>;
 
 struct ClipData {
    //Find the bits of clips that need replacing
@@ -50,8 +52,8 @@ WAVE_TRACK_API ClipData CollectClipData(
  @pre `newContents.IsLeader()`
  @pre `oldTrack.NChannels() == newContents.NChannels()`
  */
-WAVE_TRACK_API void PasteOverPreservingClips(const ClipData &data,
-   WaveTrack &oldTrack, sampleCount start, sampleCount len,
-   const WaveTrack &newContents);
+WAVE_TRACK_API void PasteOverPreservingClips(
+   const ClipData& data, WaveTrack& oldTrack, sampleCount start,
+   sampleCount len, const WaveTrack& newContents);
 
 #endif

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -609,7 +609,8 @@ void WaveClip::WriteXML(XMLWriter &xmlFile) const
 }
 
 /*! @excsafety{Strong} */
-bool WaveClip::Paste(double t0, const WaveClip &other)
+bool WaveClip::Paste(
+   double t0, const WaveClip& other, ProgressReporter reportProgress)
 {
    if (GetWidth() != other.GetWidth())
       return false;
@@ -618,10 +619,15 @@ bool WaveClip::Paste(double t0, const WaveClip &other)
 
    Transaction transaction{ *this };
 
+   const auto otherStretchRatio = other.GetStretchRatio();
+   if (GetSequenceSamplesCount() == sampleCount{0})
+      // This is empty: use stretch ratio of other clip to avoid unnecessary stretching.
+      ApplyStretchRatio(otherStretchRatio, {});
+   const auto thisStretchRatio = GetStretchRatio();
+   const bool clipNeedsStretching = !other.StretchRatioEquals(thisStretchRatio);
    const bool clipNeedsResampling = other.mRate != mRate;
    // For performance, apply time stretching onto the other clip while at its
    // lowest rate.
-   const auto stretchOtherBeforeResampling = other.mRate < mRate;
    const bool clipNeedsNewFormat =
       other.GetSampleFormats().Stored() != GetSampleFormats().Stored();
    std::shared_ptr<WaveClip> newClip;
@@ -659,23 +665,29 @@ bool WaveClip::Paste(double t0, const WaveClip &other)
       newClip->SetTrimRight(0);
    }
 
-   if (clipNeedsResampling || clipNeedsNewFormat)
+   if (clipNeedsResampling || clipNeedsNewFormat || clipNeedsStretching)
    {
       auto copy = std::make_shared<WaveClip>(*newClip.get(), factory, true);
+
+      // For computational efficiency, apply stretching while or once at lowest
+      // sample rate.
+      const auto stretchBeforeResampling = other.mRate < mRate;
+
+      if (clipNeedsStretching && stretchBeforeResampling)
+         copy->ApplyStretchRatio(thisStretchRatio, reportProgress);
+
       if (clipNeedsResampling)
-      {
-         if (stretchOtherBeforeResampling)
-            copy->ApplyStretchRatio([](double) {});
          // The other clip's rate is different from ours, so resample
          copy->Resample(mRate);
-      }
+
+      if (clipNeedsStretching && !stretchBeforeResampling)
+         copy->ApplyStretchRatio(thisStretchRatio, reportProgress);
+
       if (clipNeedsNewFormat)
          // Force sample formats to match.
          copy->ConvertToSampleFormat(GetSampleFormats().Stored());
       newClip = std::move(copy);
    }
-   ApplyStretchRatio([](double) {});
-   newClip->ApplyStretchRatio([](double) {});
 
    // Paste cut lines contained in pasted clip
    WaveClipHolders newCutlines;
@@ -971,10 +983,13 @@ void WaveClip::ExpandCutLine(double cutLinePosition)
       // Envelope::Paste takes offset into account, WaveClip::Paste doesn't!
       // Do this to get the right result:
       cutline->mEnvelope->SetOffset(0);
-
-      bool success =
-         Paste(GetSequenceStartTime() + cutline->GetSequenceStartTime(),
-            *cutline);
+      // Normally, cutline stretch ratios are kept equal to that of the hosting
+      // clip, so no need for stretching or a progress bar. Nevertheless do not
+      // assert this : maybe the cutline was imported from a buggy project.
+      const ProgressReporter reportProgress = {};
+      bool success = Paste(
+         GetSequenceStartTime() + cutline->GetSequenceStartTime(), *cutline,
+         reportProgress);
       assert(success); // class invariant promises cutlines have correct width
 
       // Now erase the cutline,
@@ -1140,11 +1155,11 @@ void WaveClip::Resample(int rate, BasicUI::ProgressDialog *progress)
 }
 
 void WaveClip::ApplyStretchRatio(
-   const std::function<void(double)>& reportProgress)
+   double targetRatio, const std::function<void(double)>& reportProgress)
 {
-   const auto stretchRatio = GetStretchRatio();
-   if (stretchRatio == 1.0)
+   if (StretchRatioEquals(targetRatio))
       return;
+   const auto stretchRatio = GetStretchRatio();
 
    auto success = false;
    auto newSequences = GetEmptySequenceCopies();
@@ -1157,9 +1172,9 @@ void WaveClip::ApplyStretchRatio(
       this->SetTrimRight(trimRightBeforeStretch);
       if (success)
       {
-         this->mClipStretchRatio = 1.0;
+         this->mClipStretchRatio = targetRatio;
          this->mRawAudioTempo = this->mProjectTempo;
-         assert(this->GetStretchRatio() == 1.0);
+         assert(this->StretchRatioEquals(targetRatio));
       }
       else
          std::swap(mSequences, newSequences);
@@ -1175,11 +1190,12 @@ void WaveClip::ApplyStretchRatio(
    ClipTimeAndPitchSource stretcherSource { *this, durationToDiscard,
                                         PlaybackDirection::forward };
    TimeAndPitchInterface::Parameters params;
-   params.timeRatio = stretchRatio;
+   params.timeRatio = stretchRatio / targetRatio;
    StaffPadTimeAndPitch stretcher { numChannels, stretcherSource,
                                     std::move(params) };
-   const auto totalNumOutSamples =
-      sampleCount { GetVisibleSampleCount().as_double() * stretchRatio + .5 };
+   const auto totalNumOutSamples = sampleCount {
+      GetVisibleSampleCount().as_double() * stretchRatio / targetRatio + .5
+   };
 
    sampleCount numOutSamples { 0 };
    AudioContainer container(blockSize, numChannels);

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -45,6 +45,7 @@ class WaveClip;
 using WaveClipHolder = std::shared_ptr< WaveClip >;
 using WaveClipHolders = std::vector < WaveClipHolder >;
 using WaveClipConstHolders = std::vector < std::shared_ptr< const WaveClip > >;
+using ProgressReporter = std::function<void(double)>;
 
 // A bundle of arrays needed for drawing waveforms.  The object may or may not
 // own the storage for those arrays.  If it does, it destroys them.
@@ -181,7 +182,8 @@ public:
     * @brief Renders the stretching of the clip (preserving duration).
     * @post GetStretchRatio() == 1
     */
-   void ApplyStretchRatio();
+   void ApplyStretchRatio(
+      const std::function<void(double)>& reportProgress);
 
    void SetColourIndex( int index ){ mColourIndex = index;};
    int GetColourIndex( ) const { return mColourIndex;};
@@ -447,7 +449,8 @@ public:
    /*!
     @return true and succeed if and only if `this->GetWidth() == other.GetWidth()`
     */
-   bool Paste(double t0, const WaveClip &other);
+   bool
+   Paste(double t0, const WaveClip& other, ProgressReporter reportProgress);
 
    /** Insert silence - note that this is an efficient operation for large
     * amounts of silence */

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -175,7 +175,13 @@ public:
 
    // Resample clip. This also will set the rate, but without changing
    // the length of the clip
-   void Resample(int rate, BasicUI::ProgressDialog *progress = NULL);
+   void Resample(int rate, BasicUI::ProgressDialog *progress = nullptr);
+
+   /*!
+    * @brief Renders the stretching of the clip (preserving duration).
+    * @post GetStretchRatio() == 1
+    */
+   void ApplyStretchRatio();
 
    void SetColourIndex( int index ){ mColourIndex = index;};
    int GetColourIndex( ) const { return mColourIndex;};
@@ -189,10 +195,17 @@ public:
    //! (but not counting the cutlines)
    sampleCount GetSequenceSamplesCount() const;
 
+   //! Closed-begin of play region. Always a multiple of the track's sample
+   //! period, whether the clip is stretched or not.
    double GetPlayStartTime() const noexcept override;
    void SetPlayStartTime(double time);
 
+   //! Open-end of play region. Always a multiple of the track's sample
+   //! period, whether the clip is stretched or not.
    double GetPlayEndTime() const override;
+
+   //! Always a multiple of the track's sample period, whether the clip is
+   //! stretched or not.
    double GetPlayDuration() const;
 
    // todo comment
@@ -518,6 +531,7 @@ private:
    sampleCount GetNumSamples() const;
    SampleFormats GetSampleFormats() const;
    const SampleBlockFactoryPtr &GetFactory();
+   std::vector<std::unique_ptr<Sequence>> GetEmptySequenceCopies() const;
    void StretchCutLines(double ratioChange);
    double SnapToTrackSample(double time) const noexcept;
 

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -180,10 +180,10 @@ public:
 
    /*!
     * @brief Renders the stretching of the clip (preserving duration).
-    * @post GetStretchRatio() == 1
+    * @post StretchRatioEquals(targetRatio)
     */
    void ApplyStretchRatio(
-      const std::function<void(double)>& reportProgress);
+      double targetRatio, const std::function<void(double)>& reportProgress);
 
    void SetColourIndex( int index ){ mColourIndex = index;};
    int GetColourIndex( ) const { return mColourIndex;};

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1578,7 +1578,8 @@ void WaveTrack::ApplyStretchRatioOne(
    };
    while (clip && clip->GetPlayStartTime() < t1)
    {
-      clip->ApplyStretchRatio(reportClipProgress);
+      constexpr auto targetStretchRatio = 1.0;
+      clip->ApplyStretchRatio(targetStretchRatio, reportClipProgress);
       clip = GetNextClip(*clip, PlaybackDirection::forward);
       ++count;
    }
@@ -1746,16 +1747,27 @@ void WaveTrack::Disjoin(double t0, double t1)
 }
 
 /*! @excsafety{Weak} */
-void WaveTrack::Join(double t0, double t1)
+void WaveTrack::Join(
+   double t0, double t1, const std::function<void(double)>& reportProgress)
 {
    assert(IsLeader());
    // Merge all WaveClips overlapping selection into one
 
+   const auto numChannels = NChannels();
+   auto count = 0;
+   const auto reportChannelProgress = [&](double channelProgress) {
+      reportProgress((count + channelProgress) / numChannels);
+   };
    for (const auto pChannel : TrackList::Channels(this))
-      JoinOne(*pChannel, t0, t1);
+   {
+      JoinOne(*pChannel, t0, t1, reportChannelProgress);
+      ++count;
+   }
 }
 
-void WaveTrack::JoinOne(WaveTrack &track, double t0, double t1)
+void WaveTrack::JoinOne(
+   WaveTrack& track, double t0, double t1,
+   const std::function<void(double)>& reportProgress)
 {
    WaveClipPointers clipsToDelete;
    WaveClip* newClip{};
@@ -1784,6 +1796,11 @@ void WaveTrack::JoinOne(WaveTrack &track, double t0, double t1)
    newClip = track.CreateClip(clipsToDelete[0]->GetSequenceStartTime(),
       clipsToDelete[0]->GetName());
 
+   auto count = 0;
+   const auto reportClipProgress = [&](double clipProgress) {
+      reportProgress((count + clipProgress) / clipsToDelete.size());
+   };
+
    for (const auto &clip : clipsToDelete) {
       //wxPrintf("t=%.6f adding clip (offset %.6f, %.6f ... %.6f)\n",
       //       t, clip->GetOffset(), clip->GetStartTime(), clip->GetEndTime());
@@ -1798,7 +1815,8 @@ void WaveTrack::JoinOne(WaveTrack &track, double t0, double t1)
       }
 
       //wxPrintf("Pasting at %.6f\n", t);
-      bool success = newClip->Paste(t, *clip);
+      bool success = newClip->Paste(t, *clip, reportClipProgress);
+      ++count;
       assert(success); // promise of CreateClip
 
       t = newClip->GetPlayEndTime();
@@ -2909,7 +2927,10 @@ void WaveTrack::MergeClips(int clipidx1, int clipidx2)
 
    // Append data from second clip to first clip
    // use Strong-guarantee
-   bool success = clip1->Paste(clip1->GetPlayEndTime(), *clip2);
+   bool success = clip1->Paste(
+      clip1->GetPlayEndTime(), *clip2,
+      // No stretching needed -> no progress bar needed
+      {});
    assert(success);  // assuming clips of the same track must have same width
 
    // use No-fail-guarantee for the rest

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -537,7 +537,8 @@ ChannelGroup &WaveTrack::ReallyDoGetChannelGroup() const
 }
 
 TrackListHolder WaveTrack::Clone(
-   std::optional<std::pair<double, double>> unstretchInterval) const
+   std::optional<TimeInterval> unstretchInterval,
+   ProgressReporter reportProgress) const
 {
    assert(IsLeader());
    auto result = TrackList::Temporary(nullptr);
@@ -554,7 +555,7 @@ TrackListHolder WaveTrack::Clone(
       cloneOne(this);
    if (unstretchInterval)
       dynamic_cast<WaveTrack*>(*result->begin())
-         ->ApplyStretchRatio(unstretchInterval);
+         ->ApplyStretchRatio(unstretchInterval, std::move(reportProgress));
    return result;
 }
 
@@ -1486,7 +1487,7 @@ void WaveTrack::BlindlyMergeClipFromOtherTrackInto(
    double t0, WaveClip& myClip, const WaveClip& otherTrackClip)
 {
    assert(myClip.HasEqualStretchRatio(otherTrackClip));
-   myClip.Paste(t0 - myClip.GetPlayStartTime(), otherTrackClip);
+   myClip.Paste(t0 - myClip.GetPlayStartTime(), otherTrackClip, {});
 }
 
 void WaveTrack::ShiftBackAllClips(double t0, double duration)
@@ -1530,7 +1531,7 @@ void WaveTrack::InsertClip(WaveClipHolder clip)
 }
 
 void WaveTrack::ApplyStretchRatio(
-   std::optional<std::pair<double, double>> interval)
+   std::optional<TimeInterval> interval, ProgressReporter reportProgress)
 {
    assert(IsLeader());
    if (GetNumClips() == 0)
@@ -1543,11 +1544,23 @@ void WaveTrack::ApplyStretchRatio(
                  GetEndTime();
    if (startTime == endTime)
       return;
+   const auto numChannels = NChannels();
+   auto count = 0;
+   const ProgressReporter reportChannelProgress =
+      reportProgress ?
+         [&](double progress) {
+            reportProgress((count + progress) / numChannels);
+         } :
+         ProgressReporter {};
    for (const auto pChannel : TrackList::Channels(this))
-      pChannel->ApplyStretchRatioOne(startTime, endTime);
+   {
+      pChannel->ApplyStretchRatioOne(startTime, endTime, reportChannelProgress);
+      ++count;
+   }
 }
 
-void WaveTrack::ApplyStretchRatioOne(double t0, double t1)
+void WaveTrack::ApplyStretchRatioOne(
+   double t0, double t1, const std::function<void(double)>& reportProgress)
 {
    if (auto clipAtT0 = GetClipAtTime(t0); clipAtT0 &&
                                           clipAtT0->SplitsPlayRegion(t0) &&
@@ -1558,10 +1571,16 @@ void WaveTrack::ApplyStretchRatioOne(double t0, double t1)
                                           !clipAtT1->StretchRatioEquals(1))
       SplitAt(t1);
    auto clip = GetClipAtTime(t0);
+   const auto numClips = GetNumClips(t0, t1);
+   auto count = 0;
+   auto reportClipProgress = [&](double progress) {
+      reportProgress((count + progress) / numClips);
+   };
    while (clip && clip->GetPlayStartTime() < t1)
    {
-      clip->ApplyStretchRatio();
+      clip->ApplyStretchRatio(reportClipProgress);
       clip = GetNextClip(*clip, PlaybackDirection::forward);
+      ++count;
    }
 }
 
@@ -2670,6 +2689,19 @@ const WaveClip* WaveTrack::GetClipByIndex(int index) const
 int WaveTrack::GetNumClips() const
 {
    return mClips.size();
+}
+
+int WaveTrack::GetNumClips(double t0, double t1) const
+{
+   const auto clips = SortedClipArray();
+   const auto firstIn =
+      std::find_if(clips.begin(), clips.end(), [t0](const auto& clip) {
+         return t0 < clip->GetPlayEndTime();
+      });
+   const auto firstOut = std::find_if(firstIn, clips.end(), [t1](const auto& clip) {
+      return t1 < clip->GetPlayStartTime();
+   });
+   return std::distance(firstIn, firstOut);
 }
 
 bool WaveTrack::CanOffsetClips(

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -245,11 +245,13 @@ public:
     @pre `NChannels() == orig.NChannels()`
     */
    void Reinit(const WaveTrack &orig);
-private:
-   void Init(const WaveTrack &orig);
 
-   TrackListHolder Clone(std::optional<std::pair<double, double>>
-                            unstretchInterval) const override;
+private:
+   void Init(const WaveTrack& orig);
+
+   TrackListHolder Clone(
+      std::optional<TimeInterval> unstretchInterval,
+      ProgressReporter reportProgress) const override;
 
    friend class WaveTrackFactory;
 
@@ -719,6 +721,7 @@ private:
 
    // Get number of clips in this WaveTrack
    int GetNumClips() const;
+   int GetNumClips(double t0, double t1) const;
 
    // Add all wave clips to the given array 'clips' and sort the array by
    // clip start time. The array is emptied prior to adding the clips.
@@ -926,8 +929,12 @@ private:
    //! `mClips.push_back`.
    void InsertClip(WaveClipHolder clip);
 
-   void ApplyStretchRatio(std::optional<std::pair<double, double>>);
-   void ApplyStretchRatioOne(double t0, double t1);
+   void ApplyStretchRatio(
+      std::optional<TimeInterval> interval,
+      ProgressReporter reportProgress);
+   void ApplyStretchRatioOne(
+      double t0, double t1,
+      const std::function<void(double)>& reportProgress);
 
    SampleBlockFactoryPtr mpFactory;
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -431,7 +431,9 @@ private:
    /*!
     @pre `IsLeader()`
     */
-   void Join(double t0, double t1) /* not override */;
+   void Join(
+      double t0, double t1,
+      const std::function<void(double)>& reportProgress) /* not override */;
    // May assume precondition: t0 <= t1
    /*!
     @pre `IsLeader()`
@@ -848,7 +850,9 @@ private:
       const WaveTrack &src,
       bool preserve, bool merge, const TimeWarper *effectWarper);
 
-   static void JoinOne(WaveTrack &track, double t0, double t1);
+   static void JoinOne(
+      WaveTrack& track, double t0, double t1,
+      const std::function<void(double)>& reportProgress);
    static Holder CopyOne(const WaveTrack &track,
       double t0, double t1, bool forClipboard);
    static void WriteOneXML(const WaveTrack &track, XMLWriter &xmlFile);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -248,7 +248,8 @@ public:
 private:
    void Init(const WaveTrack &orig);
 
-   TrackListHolder Clone() const override;
+   TrackListHolder Clone(std::optional<std::pair<double, double>>
+                            unstretchInterval) const override;
 
    friend class WaveTrackFactory;
 
@@ -268,6 +269,8 @@ private:
    double GetStartTime() const override;
    //! Implement WideSampleSequence
    double GetEndTime() const override;
+
+   double SnapToSample(double t) const;
 
    //
    // Identifying the type of track
@@ -922,6 +925,9 @@ private:
    //! Sets project tempo on clip upon push. Use this instead of
    //! `mClips.push_back`.
    void InsertClip(WaveClipHolder clip);
+
+   void ApplyStretchRatio(std::optional<std::pair<double, double>>);
+   void ApplyStretchRatioOne(double t0, double t1);
 
    SampleBlockFactoryPtr mpFactory;
 

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -342,7 +342,8 @@ void LabelTrack::SetSelected( bool s )
          this->SharedPointer<LabelTrack>(), {}, -1, -1 });
 }
 
-TrackListHolder LabelTrack::Clone() const
+TrackListHolder LabelTrack::Clone(
+   std::optional<std::pair<double, double>> /* unstretchInterval */) const
 {
    assert(IsLeader());
    auto result = std::make_shared<LabelTrack>(*this, ProtectedCreationArg{});

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -343,7 +343,8 @@ void LabelTrack::SetSelected( bool s )
 }
 
 TrackListHolder LabelTrack::Clone(
-   std::optional<std::pair<double, double>> /* unstretchInterval */) const
+   std::optional<TimeInterval> /* unstretchInterval */,
+   std::function<void(double)> /* reportProgress */) const
 {
    assert(IsLeader());
    auto result = std::make_shared<LabelTrack>(*this, ProtectedCreationArg{});

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -117,7 +117,7 @@ class AUDACITY_DLL_API LabelTrack final
    using Holder = std::shared_ptr<LabelTrack>;
 
 private:
-   TrackListHolder Clone() const override;
+   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
    void DoOnProjectTempoChange(
       const std::optional<double>& oldTempo, double newTempo) override;
 

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -117,7 +117,9 @@ class AUDACITY_DLL_API LabelTrack final
    using Holder = std::shared_ptr<LabelTrack>;
 
 private:
-   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
+   TrackListHolder Clone(
+      std::optional<TimeInterval> unstretchInterval,
+      ProgressReporter reportProgress) const override;
    void DoOnProjectTempoChange(
       const std::optional<double>& oldTempo, double newTempo) override;
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -166,7 +166,8 @@ Alg_seq &NoteTrack::GetSeq() const
 }
 
 TrackListHolder NoteTrack::Clone(
-   std::optional<std::pair<double, double>> /* unstretchInterval */) const
+   std::optional<TimeInterval> /* unstretchInterval */,
+   std::function<void(double)> /* reportProgress */) const
 {
    auto duplicate = std::make_shared<NoteTrack>();
    duplicate->Init(*this);
@@ -205,7 +206,6 @@ TrackListHolder NoteTrack::Clone(
 #endif
    return TrackList::Temporary(nullptr, duplicate, nullptr);
 }
-
 
 void NoteTrack::DoOnProjectTempoChange(
    const std::optional<double>& oldTempo, double newTempo)
@@ -984,7 +984,7 @@ void NoteTrack::WriteXML(XMLWriter &xmlFile) const
    if (!mSeq) {
       // replace saveme with an (unserialized) duplicate, which is
       // destroyed at end of function.
-      holder = (*Clone(std::nullopt)->begin())->SharedPointer();
+      holder = (*Clone()->begin())->SharedPointer();
       saveme = static_cast<NoteTrack*>(holder.get());
    }
    saveme->GetSeq().write(data, true);

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -165,7 +165,8 @@ Alg_seq &NoteTrack::GetSeq() const
    return *mSeq;
 }
 
-TrackListHolder NoteTrack::Clone() const
+TrackListHolder NoteTrack::Clone(
+   std::optional<std::pair<double, double>> /* unstretchInterval */) const
 {
    auto duplicate = std::make_shared<NoteTrack>();
    duplicate->Init(*this);
@@ -983,7 +984,7 @@ void NoteTrack::WriteXML(XMLWriter &xmlFile) const
    if (!mSeq) {
       // replace saveme with an (unserialized) duplicate, which is
       // destroyed at end of function.
-      holder = (*Clone()->begin())->SharedPointer();
+      holder = (*Clone(std::nullopt)->begin())->SharedPointer();
       saveme = static_cast<NoteTrack*>(holder.get());
    }
    saveme->GetSeq().write(data, true);

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -75,7 +75,7 @@ public:
    using Holder = std::shared_ptr<NoteTrack>;
 
 private:
-   TrackListHolder Clone() const override;
+   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
 
 public:
    void MoveTo(double origin) override { mOrigin = origin; }

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -75,7 +75,9 @@ public:
    using Holder = std::shared_ptr<NoteTrack>;
 
 private:
-   TrackListHolder Clone(std::optional<std::pair<double, double>> unstretchInterval) const override;
+   TrackListHolder Clone(
+      std::optional<TimeInterval> unstretchInterval = std::nullopt,
+      ProgressReporter reportProgress = {}) const override;
 
 public:
    void MoveTo(double origin) override { mOrigin = origin; }

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -225,7 +225,7 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
       while (pos < end)
       {
          const auto len = limitSampleBufferSize( kBufSize, end - pos );
-         
+
          mControlTrack->GetFloats(buf.get(), pos, len);
 
          for (auto i = pos; i < pos + len; i++)
@@ -301,7 +301,7 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
    }
 
    if (!cancel) {
-      EffectOutputTracks outputs{ *mTracks };
+      EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
 
       int trackNum = 0;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -216,7 +216,7 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
    // Iterate over each track.
    // All needed because this effect needs to introduce
    // silence in the sync-lock group tracks to keep sync
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    bool bGoodResult = true;
 
    mCurTrackNum = 0;

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -113,7 +113,7 @@ bool EffectClickRemoval::CheckWhetherSkipEffect(const EffectSettings &) const
 
 bool EffectClickRemoval::Process(EffectInstance &, EffectSettings &)
 {
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
    mbDidSomething = false;
 

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -197,7 +197,7 @@ bool EffectEqualization::VisitSettings(
    // Curve point parameters -- how many isn't known statically
    {
       curves[0].points.clear();
-   
+
       for (int i = 0; i < 200; i++)
       {
          const wxString nameFreq = wxString::Format("f%i",i);
@@ -289,7 +289,7 @@ EffectEqualization::LoadFactoryPreset(int id, EffectSettings &settings) const
    if (index < 0)
       return {};
 
-   // mParams = 
+   // mParams =
    wxString params = FactoryPresets[index].values;
 
    CommandParameters eap(params);
@@ -403,7 +403,7 @@ struct EffectEqualization::Task {
 
 bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
 {
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    mParameters.CalcFilter();
    bool bGoodResult = true;
 
@@ -424,7 +424,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
          auto pTempTrack = *temp->Any<WaveTrack>().begin();
          pTempTrack->ConvertToSampleFormat(floatSample);
          auto iter0 = pTempTrack->Channels().begin();
-   
+
          for (const auto pChannel : track->Channels()) {
             constexpr auto windowSize = EqualizationFilter::windowSize;
             const auto &M = mParameters.mM;

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -443,8 +443,8 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
                goto done;
          }
          pTempTrack->Flush();
-         PasteOverPreservingClips(data, *track, start, len,
-            **temp->Any<WaveTrack>().begin());
+         PasteOverPreservingClips(
+            data, *track, start, len, **temp->Any<WaveTrack>().begin());
       }
 
       count++;

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -30,7 +30,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
 
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
 
    // Iterate over the tracks
    bool bGoodResult = true;
@@ -71,7 +71,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
                   ViewInfo::Get(*pProject).selectedRegion;
                track.ClearAndPaste(
                   selectedRegion.t0(), selectedRegion.t1(),
-                  *list, true, false, &warper);
+                  *list, true, true, &warper);
             }
             else
                return;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -105,7 +105,7 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
    );
 
    // Iterate over each track
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
    auto topMsg = XO("Normalizing Loudness...\n");
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -637,7 +637,7 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
 {
    // This same code will either reduce noise or profile it
 
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
 
    auto track = *(outputs.Get().Selected<const WaveTrack>()).begin();
    if (!track)

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -222,7 +222,7 @@ bool EffectNoiseRemoval::Process(EffectInstance &, EffectSettings &)
 
    // This same code will both remove noise and profile it,
    // depending on 'mDoProfile'
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
 
    int count = 0;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -106,7 +106,7 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
    }
 
    //Iterate over each track
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
    double progress = 0;
    TranslatableString topMsg;

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -41,7 +41,7 @@ const EffectParameterMethods& EffectPaulstretch::Parameters() const
    return parameters;
 }
 
-/// \brief Class that helps EffectPaulStretch.  It does the FFTs and inner loop 
+/// \brief Class that helps EffectPaulStretch.  It does the FFTs and inner loop
 /// of the effect.
 class PaulStretch
 {
@@ -147,7 +147,7 @@ double EffectPaulstretch::CalcPreviewInputLength(
 bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
 {
    // Pass true because sync lock adjustment is needed
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    auto newT1 = mT1;
    int count = 0;
    // Process selected wave tracks first, to find the new t1 value

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -77,7 +77,7 @@ bool EffectRepair::Process(EffectInstance &, EffectSettings &)
    // This may be too much copying for EffectRepair. To support Cancel, may be
    // able to copy much less.
    // But for now, Cancel isn't supported without this.
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
 
    int count = 0;

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -93,7 +93,7 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
 {
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
 
    int nTrack = 0;
    bool bGoodResult = true;

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -73,7 +73,7 @@ bool EffectReverse::IsInteractive() const
 bool EffectReverse::Process(EffectInstance &, EffectSettings &)
 {
    //all needed because Reverse should move the labels too
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    bool bGoodResult = true;
    int count = 0;
 

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -223,7 +223,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
 
    //Iterate over each track
    //all needed because this effect needs to introduce silence in the group tracks to keep sync
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    mCurTrackNum = 0;
 
    double maxDuration = 0.0;
@@ -321,7 +321,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
                   0,
                   rb.quality.get());
             }
-            
+
             Resampler resampler(outResampleCB, &rb, outSlideType);
 
             audio outBuf[SBSMSOutBlockSize];

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -87,7 +87,7 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
 
    //Iterate over each track
    // Needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    bool bGoodResult = true;
 
    mPreserveLength = preserveLength;

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -79,13 +79,13 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
 {
    // Do not use mWaveTracks here.  We will possibly DELETE tracks,
    // so we must use the "real" tracklist.
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
    bool bGoodResult = true;
 
    // Determine the total time (in samples) used by all of the target tracks
    // only for progress dialog
    sampleCount totalTime = 0;
-   
+
    auto trackRange = outputs.Get().Selected<WaveTrack>();
    for (const auto left : trackRange) {
       if (left->Channels().size() > 1) {

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -97,7 +97,7 @@ static const size_t DEF_BlendFrameCount = 100;
 
 // Lower bound on the amount of silence to find at a time -- this avoids
 // detecting silence repeatedly in low-frequency sounds.
-static const double DEF_MinTruncMs = 0.001; 
+static const double DEF_MinTruncMs = 0.001;
 
 // Typical fraction of total time taken by detection (better to guess low)
 const double detectFrac = 0.4;
@@ -189,7 +189,7 @@ bool EffectTruncSilence::LoadSettings(
       if (!parms.ReadAndVerify( ActIndex.key, &temp, ActIndex.def,
          kActionStrings, nActions, kObsoleteActions, nObsoleteActions))
          return false;
-   
+
       // TODO:  fix this when settings are really externalized
       const_cast<int&>(mActionIndex) = temp;
    }
@@ -272,7 +272,7 @@ bool EffectTruncSilence::ProcessIndependently()
    // Now do the work
 
    // Copy tracks
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
    double newT1 = 0.0;
 
    {
@@ -306,7 +306,7 @@ bool EffectTruncSilence::ProcessIndependently()
 bool EffectTruncSilence::ProcessAll()
 {
    // Copy tracks
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {mT0, mT1}, true };
 
    // Master list of silent regions.
    // This list should always be kept in order.
@@ -427,7 +427,7 @@ bool EffectTruncSilence::DoRemoval(const RegionList &silences,
       // Don't waste time cutting nothing.
       if( cutLen == 0.0 )
          continue;
-      
+
       totalCutLen += cutLen;
 
       double cutStart = (r->start + r->end - cutLen) / 2;

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -28,7 +28,7 @@ bool EffectTwoPassSimpleMono::Process(
    mSecondPassDisabled = false;
 
    InitPass1();
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, { mT0, mT1 } };
 
    mWorkTracks = TrackList::Create(const_cast<AudacityProject*>(FindProject()));
    for (auto track : outputs.Get().Selected<WaveTrack>()) {

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -769,7 +769,7 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
    // to operate on the selected wave tracks
    std::optional<EffectOutputTracks> oOutputs;
    if (!bOnePassTool)
-      oOutputs.emplace(*mTracks, true);
+      oOutputs.emplace(*mTracks, std::pair<double, double> { mT0, mT1 }, true);
 
    mNumSelectedChannels = bOnePassTool
       ? 0

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -903,9 +903,18 @@ void OnJoin(const CommandContext &context)
    auto &tracks = TrackList::Get(project);
    auto &selectedRegion = ViewInfo::Get(project).selectedRegion;
    auto &window = ProjectWindow::Get(project);
-
-   for (auto wt : tracks.Selected<WaveTrack>())
-      wt->Join(selectedRegion.t0(), selectedRegion.t1());
+   const auto progress = BasicUI::MakeProgress(
+      XO("Pre-processing"), XO("Rendering Time-Stretched Audio"), 0);
+   const auto selectedTracks = tracks.Selected<WaveTrack>();
+   auto count = 0;
+   for (auto wt : selectedTracks)
+      wt->Join(
+         selectedRegion.t0(), selectedRegion.t1(), [&](double trackProgress) {
+            const auto overallProgress =
+               (count + trackProgress) / selectedTracks.size();
+            progress->Poll(overallProgress * 1000, 1000);
+            ++count;
+         });
 
    ProjectHistory::Get(project).PushState(
       XO("Joined %.2f seconds at t=%.2f")

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
@@ -67,7 +67,7 @@ namespace
       }
       return -1;
    }
-   
+
    bool IsOverCutline
       (const ViewInfo &viewInfo, WaveTrack * track,
        const wxRect &rect, const wxMouseState &state,
@@ -169,7 +169,16 @@ UIHandle::Result CutlineHandle::Click
 
          viewInfo.selectedRegion.setTimes(cutlineStart, cutlineEnd);
       }
-      else if (mLocation.typ == WaveTrackLocation::locationMergePoint) {
+      // todo(mhodgkinson) Bluntly disabling this Join shortcut for now. There
+      // exists an issue that wants to do this properly:
+      // https://github.com/audacity/audacity/issues/2330
+      // With stretching, merging can lead to rendering the track, which can
+      // freeze the application for a noticeable time. At the time of writing
+      // there is no progress bar for that. Even if there were, in the case of
+      // an unintentional action that might be quite annoying.
+      else if (
+         false /* mLocation.typ == WaveTrackLocation::locationMergePoint */)
+      {
          const double pos = mLocation.pos;
          for (auto channel :
               TrackList::Channels(mpTrack.get())) {


### PR DESCRIPTION
Resolves: #4850

Since #5043, merging clips of different stretch ratios works again, by applying stretching to get consistent data before merging.
Since #5044, a similar principle is used to repair effects: the selected audio's time-stretching is first computed, then the effect applied.

In both cases, the time stretching can take noticeable time if the amount of data to stretch is big. Before this PR, no notification of this was given to the user, and she might wonder why Audacity is frozen until e.g. the join operation is complete.

This PR introduces progress dialogs for these situations.

QA (try these with large clips, i.e., maybe one minute long at least):
- [ ] a progress bar shows up when joining clips of contrasting stretch ratios.
- [ ] Joining of clips of equal stretch ratios should involve no stretching and hence be super fast. To stretch several clips by the same amount, easiest is to change project tempo. (Both Edit > Labeled Audio > Join and Edit > Audio Clips > Join)
- [ ] Applying an effect on a stretched clip brings a new progress bar reporting stretching progress.
- [ ] The progress bar filling-up is correctly proportioned to the number of tracks that are affected by the operation

Programmatically, the progress bars pop up whether stretching or not, but when not stretched, that should be barely noticeable.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
