### PR TITLE
Remove `PROHIBITED`

### DIFF
--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -249,10 +249,6 @@ function( audacity_append_common_compiler_options var use_pch )
          # This value is used in the resource compiler for Windows
          -DAUDACITY_FILE_VERSION=L"${AUDACITY_VERSION},${AUDACITY_RELEASE},${AUDACITY_REVISION},${AUDACITY_MODLEVEL}"
 
-         # This renames a good use of this C++ keyword that we don't need
-	      # to review when hunting for leaks because of naked new and delete.
-	      -DPROHIBITED==delete
-
          # Reviewed, certified, non-leaky uses of NEW that immediately entrust
 	      # their results to RAII objects.
          # You may use it in NEW code when constructing a wxWindow subclass

--- a/libraries/lib-basic-ui/BasicUI.h
+++ b/libraries/lib-basic-ui/BasicUI.h
@@ -31,9 +31,9 @@ public:
    WindowPlacement() = default;
 
    //! Don't slice
-   WindowPlacement( const WindowPlacement& ) PROHIBITED;
+   WindowPlacement( const WindowPlacement& ) = delete;
    //! Don't slice
-   WindowPlacement &operator=( const WindowPlacement& ) PROHIBITED;
+   WindowPlacement &operator=( const WindowPlacement& ) = delete;
    //! Whether null; default in the base class returns false
    virtual explicit operator bool() const;
    virtual ~WindowPlacement();

--- a/libraries/lib-exceptions/AudacityException.h
+++ b/libraries/lib-exceptions/AudacityException.h
@@ -48,10 +48,10 @@ protected:
 
    //! Don't allow moves of this class or subclasses
    // see https://bugzilla.audacityteam.org/show_bug.cgi?id=2442
-   AudacityException( AudacityException&& ) PROHIBITED;
+   AudacityException( AudacityException&& ) = delete;
 
    //! Disallow assignment
-   AudacityException &operator = ( const AudacityException & ) PROHIBITED;
+   AudacityException &operator = ( const AudacityException & ) = delete;
 };
 
 //! Abstract AudacityException subclass displays a message, specified by further subclass
@@ -109,7 +109,7 @@ public:
 
    SimpleMessageBoxException( const SimpleMessageBoxException& ) = default;
    SimpleMessageBoxException &operator = (
-      SimpleMessageBoxException && ) PROHIBITED;
+      SimpleMessageBoxException && ) = delete;
 
    // Format a default, internationalized error message for this exception.
    virtual TranslatableString ErrorMessage() const override;

--- a/libraries/lib-import-export/Import.h
+++ b/libraries/lib-import-export/Import.h
@@ -100,8 +100,8 @@ public:
    Importer();
    ~Importer();
 
-   Importer( const Importer& ) PROHIBITED;
-   Importer &operator=( Importer& ) PROHIBITED;
+   Importer( const Importer& ) = delete;
+   Importer &operator=( Importer& ) = delete;
 
    /**
     * Return instance reference

--- a/libraries/lib-project-rate/ProjectRate.h
+++ b/libraries/lib-project-rate/ProjectRate.h
@@ -27,8 +27,8 @@ public:
    static const ProjectRate &Get( const AudacityProject &project );
    
    explicit ProjectRate(AudacityProject &project);
-   ProjectRate( const ProjectRate & ) PROHIBITED;
-   ProjectRate &operator=( const ProjectRate & ) PROHIBITED;
+   ProjectRate( const ProjectRate & ) = delete;
+   ProjectRate &operator=( const ProjectRate & ) = delete;
 
    void SetRate(double rate);
    double GetRate() const;

--- a/libraries/lib-registries/ClientData.h
+++ b/libraries/lib-registries/ClientData.h
@@ -255,7 +255,7 @@ public:
     Usually agrees with the size() of each site unless some registrations happened later
     than some Site's construction.
     */
-   static size_t slots() { return GetFactories().mObject.size(); }
+   static size_t numFactories() { return GetFactories().mObject.size(); }
 
    //! Client code makes static instance from a factory of attachments; passes it to @ref Get or @ref Find as a retrieval key
    /*!

--- a/libraries/lib-screen-geometry/ZoomInfo.h
+++ b/libraries/lib-screen-geometry/ZoomInfo.h
@@ -44,8 +44,8 @@ public:
    ~ZoomInfo();
 
    // Be sure we don't slice
-   ZoomInfo(const ZoomInfo&) PROHIBITED;
-   ZoomInfo& operator= (const ZoomInfo&) PROHIBITED;
+   ZoomInfo(const ZoomInfo&) = delete;
+   ZoomInfo& operator= (const ZoomInfo&) = delete;
 
    int vpos;                    // vertical scroll pos
 

--- a/libraries/lib-strings/Identifier.h
+++ b/libraries/lib-strings/Identifier.h
@@ -129,16 +129,16 @@ public:
 
    //! Copy prohibited for other Tag classes or case sensitivity
    template< typename Tag2, bool b >
-   TaggedIdentifier( const TaggedIdentifier<Tag2, b>& ) PROHIBITED;
+   TaggedIdentifier( const TaggedIdentifier<Tag2, b>& ) = delete;
    //! Move prohibited for other Tag classes or case sensitivity
    template< typename Tag2, bool b >
-   TaggedIdentifier( TaggedIdentifier<Tag2, b>&& ) PROHIBITED;
+   TaggedIdentifier( TaggedIdentifier<Tag2, b>&& ) = delete;
    //! Copy prohibited for other Tag classes or case sensitivity
    template< typename Tag2, bool b >
-   TaggedIdentifier& operator= ( const TaggedIdentifier<Tag2, b>& ) PROHIBITED;
+   TaggedIdentifier& operator= ( const TaggedIdentifier<Tag2, b>& ) = delete;
    //! Move prohibited for other Tag classes or case sensitivity
    template< typename Tag2, bool b >
-   TaggedIdentifier& operator= ( TaggedIdentifier<Tag2, b>&& ) PROHIBITED;
+   TaggedIdentifier& operator= ( TaggedIdentifier<Tag2, b>&& ) = delete;
 
    /*! Allow implicit conversion to this class from un-tagged Identifier,
       but not from; resolution will use other overloads above if argument has a tag */

--- a/libraries/lib-time-frequency-selection/ViewInfo.h
+++ b/libraries/lib-time-frequency-selection/ViewInfo.h
@@ -195,8 +195,8 @@ public:
    static const ViewInfo &Get( const AudacityProject &project );
 
    ViewInfo(double start, double screenDuration, double pixelsPerSecond);
-   ViewInfo( const ViewInfo & ) PROHIBITED;
-   ViewInfo &operator=( const ViewInfo & ) PROHIBITED;
+   ViewInfo( const ViewInfo & ) = delete;
+   ViewInfo &operator=( const ViewInfo & ) = delete;
 
    int GetHeight() const { return mHeight; }
    void SetHeight( int height ) { mHeight = height; }

--- a/libraries/lib-utility/MemoryX.h
+++ b/libraries/lib-utility/MemoryX.h
@@ -35,7 +35,7 @@ public:
       reinit(count, initialize);
    }
 
-   //ArrayOf(const ArrayOf&) PROHIBITED;
+   //ArrayOf(const ArrayOf&) = delete;
    ArrayOf(const ArrayOf&) = delete;
    ArrayOf(ArrayOf&& that)
       : std::unique_ptr < X[] >
@@ -97,7 +97,7 @@ public:
          (*this)[ii] = ArrayOf<X>{ M, initialize };
    }
 
-   //ArraysOf(const ArraysOf&) PROHIBITED;
+   //ArraysOf(const ArraysOf&) = delete;
    ArraysOf(const ArraysOf&) =delete;
    ArraysOf& operator= (ArraysOf&& that)
    {

--- a/libraries/lib-wave-track/Sequence.h
+++ b/libraries/lib-wave-track/Sequence.h
@@ -73,7 +73,7 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
    Sequence(const Sequence &orig, const SampleBlockFactoryPtr &pFactory);
 
    Sequence( const Sequence& ) = delete;
-   Sequence& operator= (const Sequence&) PROHIBITED;
+   Sequence& operator= (const Sequence&) = delete;
 
    ~Sequence();
 

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -104,8 +104,8 @@ private:
    // It is an error to copy a WaveClip without specifying the
    // sample block factory.
 
-   WaveClip(const WaveClip&) PROHIBITED;
-   WaveClip& operator= (const WaveClip&) PROHIBITED;
+   WaveClip(const WaveClip&) = delete;
+   WaveClip& operator= (const WaveClip&) = delete;
 
 public:
    using Caches = Site< WaveClip, WaveClipListener >;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -804,8 +804,8 @@ class WAVE_TRACK_API WaveTrackFactory final
        , mpFactory(pFactory)
    {
    }
-   WaveTrackFactory( const WaveTrackFactory & ) PROHIBITED;
-   WaveTrackFactory &operator=( const WaveTrackFactory & ) PROHIBITED;
+   WaveTrackFactory( const WaveTrackFactory & ) = delete;
+   WaveTrackFactory &operator=( const WaveTrackFactory & ) = delete;
 
    const SampleBlockFactoryPtr &GetSampleBlockFactory() const
    { return mpFactory; }

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -86,8 +86,8 @@ public:
 
    explicit
    MenuManager( AudacityProject &project );
-   MenuManager( const MenuManager & ) PROHIBITED;
-   MenuManager &operator=( const MenuManager & ) PROHIBITED;
+   MenuManager( const MenuManager & ) = delete;
+   MenuManager &operator=( const MenuManager & ) = delete;
    ~MenuManager();
 
    static void Visit(ProjectMenuVisitor &visitor);

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -76,8 +76,8 @@ public:
    static bool UseDuplex();
 
    explicit ProjectAudioManager( AudacityProject &project );
-   ProjectAudioManager( const ProjectAudioManager & ) PROHIBITED;
-   ProjectAudioManager &operator=( const ProjectAudioManager & ) PROHIBITED;
+   ProjectAudioManager( const ProjectAudioManager & ) = delete;
+   ProjectAudioManager &operator=( const ProjectAudioManager & ) = delete;
    ~ProjectAudioManager() override;
 
    bool IsTimerRecordCancelled() { return mTimerRecordCanceled; }

--- a/src/ProjectFileManager.h
+++ b/src/ProjectFileManager.h
@@ -39,8 +39,8 @@ public:
    static void DiscardAutosave(const FilePath &filename);
 
    explicit ProjectFileManager( AudacityProject &project );
-   ProjectFileManager( const ProjectFileManager & ) PROHIBITED;
-   ProjectFileManager &operator=( const ProjectFileManager & ) PROHIBITED;
+   ProjectFileManager( const ProjectFileManager & ) = delete;
+   ProjectFileManager &operator=( const ProjectFileManager & ) = delete;
    ~ProjectFileManager();
 
    bool OpenProject();

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -39,8 +39,8 @@ public:
    static const ProjectManager &Get( const AudacityProject &project );
 
    explicit ProjectManager( AudacityProject &project );
-   ProjectManager( const ProjectManager & ) PROHIBITED;
-   ProjectManager &operator=( const ProjectManager & ) PROHIBITED;
+   ProjectManager( const ProjectManager & ) = delete;
+   ProjectManager &operator=( const ProjectManager & ) = delete;
    ~ProjectManager() override;
 
    // This is the factory for projects:
@@ -74,7 +74,7 @@ public:
          , mReuseNonemptyProject{ reuseNonemptyProject }
       {}
       //! Don't copy.  Use std::ref to pass it to ProjectFileManager
-      ProjectChooser( const ProjectChooser& ) PROHIBITED;
+      ProjectChooser( const ProjectChooser& ) = delete;
       //! Destroy any fresh project, or rollback the existing project, unless committed
       ~ProjectChooser();
       //! May create a fresh project

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -30,9 +30,9 @@ public:
    static const ProjectSelectionManager &Get( const AudacityProject &project );
 
    explicit ProjectSelectionManager( AudacityProject &project );
-   ProjectSelectionManager( const ProjectSelectionManager & ) PROHIBITED;
+   ProjectSelectionManager( const ProjectSelectionManager & ) = delete;
    ProjectSelectionManager &operator=(
-      const ProjectSelectionManager & ) PROHIBITED;
+      const ProjectSelectionManager & ) = delete;
    ~ProjectSelectionManager() override;
 
    // SelectionBarListener callback methods

--- a/src/ProjectSettings.h
+++ b/src/ProjectSettings.h
@@ -60,8 +60,8 @@ public:
    };
 
    explicit ProjectSettings( AudacityProject &project );
-   ProjectSettings( const ProjectSettings & ) PROHIBITED;
-   ProjectSettings &operator=( const ProjectSettings & ) PROHIBITED;
+   ProjectSettings( const ProjectSettings & ) = delete;
+   ProjectSettings &operator=( const ProjectSettings & ) = delete;
 
 
    bool GetTracksFitVerticallyZoomed() const { return mTracksFitVerticallyZoomed; } //lda

--- a/src/TrackPanelAx.h
+++ b/src/TrackPanelAx.h
@@ -162,8 +162,8 @@ public:
    explicit TrackFocus( AudacityProject &project );
    ~TrackFocus() override;
 
-   TrackFocus( const TrackFocus & ) PROHIBITED;
-   TrackFocus& operator=( const TrackFocus & ) PROHIBITED;
+   TrackFocus( const TrackFocus & ) = delete;
+   TrackFocus& operator=( const TrackFocus & ) = delete;
 
    /*!
     @return the currently focused track, which may be null, otherwise is

--- a/src/TrackPanelCell.h
+++ b/src/TrackPanelCell.h
@@ -74,8 +74,8 @@ class AUDACITY_DLL_API TrackPanelCell /* not final */ : public TrackPanelNode
 {
 public:
    TrackPanelCell() = default;
-   TrackPanelCell( const TrackPanelCell & ) PROHIBITED;
-   TrackPanelCell &operator=( const TrackPanelCell & ) PROHIBITED;
+   TrackPanelCell( const TrackPanelCell & ) = delete;
+   TrackPanelCell &operator=( const TrackPanelCell & ) = delete;
 
    virtual ~TrackPanelCell () = 0;
 

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -78,8 +78,8 @@ class AUDACITY_DLL_API CommandManager final
    CommandManager();
    virtual ~CommandManager();
 
-   CommandManager(const CommandManager&) PROHIBITED;
-   CommandManager &operator= (const CommandManager&) PROHIBITED;
+   CommandManager(const CommandManager&) = delete;
+   CommandManager &operator= (const CommandManager&) = delete;
 
    void SetMaxList();
    void PurgeData();

--- a/src/commands/CommandSignature.h
+++ b/src/commands/CommandSignature.h
@@ -30,8 +30,8 @@ class AUDACITY_DLL_API CommandSignature
 private:
    ParamValueMap mDefaults;
    ValidatorMap mValidators;
-   CommandSignature(const CommandSignature &) PROHIBITED;
-   CommandSignature& operator=(const CommandSignature &) PROHIBITED;
+   CommandSignature(const CommandSignature &) = delete;
+   CommandSignature& operator=(const CommandSignature &) = delete;
 public:
    explicit CommandSignature();
    ~CommandSignature();

--- a/src/menus/NavigationMenus.cpp
+++ b/src/menus/NavigationMenus.cpp
@@ -499,8 +499,8 @@ Handler()
 {
    UpdatePrefs();
 }
-Handler( const Handler & ) PROHIBITED;
-Handler &operator=( const Handler & ) PROHIBITED;
+Handler( const Handler & ) = delete;
+Handler &operator=( const Handler & ) = delete;
 
 }; // struct Handler
 

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -881,8 +881,8 @@ Handler()
 {
    UpdatePrefs();
 }
-Handler( const Handler & ) PROHIBITED;
-Handler &operator=( const Handler & ) PROHIBITED;
+Handler( const Handler & ) = delete;
+Handler &operator=( const Handler & ) = delete;
 
 }; // struct Handler
 

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -372,8 +372,8 @@ Handler( AudacityProject &project )
       .Subscribe(*this, &Handler::OnUndoPushed);
 }
 
-Handler( const Handler & ) PROHIBITED;
-Handler &operator=( const Handler & ) PROHIBITED;
+Handler( const Handler & ) = delete;
+Handler &operator=( const Handler & ) = delete;
 
 Observer::Subscription mUndoSubscription;
 AudacityProject &mProject;

--- a/src/toolbars/ToolManager.h
+++ b/src/toolbars/ToolManager.h
@@ -65,8 +65,8 @@ class AUDACITY_DLL_API ToolManager final
    static const ToolManager &Get( const AudacityProject &project );
 
    ToolManager( AudacityProject *parent );
-   ToolManager( const ToolManager & ) PROHIBITED;
-   ToolManager &operator=( const ToolManager & ) PROHIBITED;
+   ToolManager( const ToolManager & ) = delete;
+   ToolManager &operator=( const ToolManager & ) = delete;
    ~ToolManager();
 
    void CreateWindows();

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -564,7 +564,7 @@ BEGIN_POPUP_MENU(WaveTrackMenuTable)
       // Multi-view check mark item, if more than one track sub-view type is
       // known
       Append(Adapt<My>([](My &table) {
-         return (WaveChannelSubViews::slots() > 1)
+         return (WaveChannelSubViews::numFactories() > 1)
             ? std::make_unique<Entry>(
                "MultiView", Entry::CheckItem, OnMultiViewID, XXO("&Multi-view"),
                POPUP_MENU_FN( OnMultiView ),

--- a/src/tracks/ui/ChannelView.cpp
+++ b/src/tracks/ui/ChannelView.cpp
@@ -256,8 +256,8 @@ struct TrackPositioner final : ClientData::Base
       mSubscription = TrackList::Get( project )
          .Subscribe(*this, &TrackPositioner::OnUpdate);
    }
-   TrackPositioner( const TrackPositioner & ) PROHIBITED;
-   TrackPositioner &operator=( const TrackPositioner & ) PROHIBITED;
+   TrackPositioner( const TrackPositioner & ) = delete;
+   TrackPositioner &operator=( const TrackPositioner & ) = delete;
 
    void OnUpdate(const TrackListEvent & e)
    {

--- a/src/tracks/ui/Scrubbing.h
+++ b/src/tracks/ui/Scrubbing.h
@@ -48,8 +48,8 @@ public:
 
    explicit
    Scrubber(AudacityProject *project);
-   Scrubber( const Scrubber & ) PROHIBITED;
-   Scrubber &operator=( const Scrubber & ) PROHIBITED;
+   Scrubber( const Scrubber & ) = delete;
+   Scrubber &operator=( const Scrubber & ) = delete;
    ~Scrubber();
 
    static bool ShouldScrubPinned();

--- a/src/tracks/ui/TimeShiftHandle.h
+++ b/src/tracks/ui/TimeShiftHandle.h
@@ -231,8 +231,8 @@ class ViewInfo;
 struct AUDACITY_DLL_API ClipMoveState {
    ClipMoveState() = default;
 
-   ClipMoveState(const ClipMoveState&) PROHIBITED;
-   ClipMoveState& operator =(const ClipMoveState&) PROHIBITED;
+   ClipMoveState(const ClipMoveState&) = delete;
+   ClipMoveState& operator =(const ClipMoveState&) = delete;
 
    ClipMoveState(ClipMoveState&&) = default;
    ClipMoveState& operator =(ClipMoveState&&) = default;

--- a/src/widgets/Overlay.h
+++ b/src/widgets/Overlay.h
@@ -94,8 +94,8 @@ class AUDACITY_DLL_API Overlay
 {
 public:
    Overlay() = default;
-   Overlay( const Overlay & ) PROHIBITED;
-   Overlay &operator=( const Overlay & ) PROHIBITED;
+   Overlay( const Overlay & ) = delete;
+   Overlay &operator=( const Overlay & ) = delete;
    virtual ~Overlay() = 0;
 
    ///\brief This number determines an ordering of overlays, so that those


### PR DESCRIPTION
Removes `PROHIBITED` keyword and fixes compilation issue in Qt branch caused by name conflict with Qt keyword

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
