### PR TITLE
Fix duplicated left channel spectrogram and most effect results...

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2285,7 +2285,8 @@ bool WaveTrack::Get(size_t iChannel, size_t nBuffers,
    std::optional<TrackIter<const WaveTrack>> iter;
    auto pTrack = this;
    if (pOwner) {
-      iter.emplace(TrackList::Channels(this).first.advance(iChannel));
+      const auto ppLeader = TrackList::Channels(this).first;
+      iter.emplace(ppLeader.advance(IsLeader() ? iChannel : 1));
       pTrack = **iter;
    }
    return std::all_of(buffers, buffers + nBuffers, [&](samplePtr buffer) {
@@ -2402,7 +2403,8 @@ std::vector<ChannelSampleView> WaveTrack::GetSampleView(
    std::optional<TrackIter<const WaveTrack>> iter;
    auto pTrack = this;
    if (pOwner) {
-      iter.emplace(TrackList::Channels(this).first.advance(iChannel));
+      const auto ppLeader = TrackList::Channels(this).first;
+      iter.emplace(ppLeader.advance(IsLeader() ? iChannel : 1));
       pTrack = **iter;
    }
    for (auto i = 0u; i < nBuffers; ++i)


### PR DESCRIPTION
... AutoDuck was affect too, but differently.  Right channel ended up with left channel's contents, with the fading applied twice.

Resolves: #5054
Resolves: #5055
Resolves: #5058

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
