### PR TITLE
Pressed state of the "play" and "pause" buttons are not provided in Msaa

### DIFF
--- a/src/widgets/AButton.cpp
+++ b/src/widgets/AButton.cpp
@@ -811,13 +811,16 @@ wxAccStatus AButtonAx::GetName(int WXUNUSED(childId), wxString* name)
    /* In the MSAA frame work, there isn't such a thing as a toggle button.
    In particular, narrator does not read the wxACC_STATE_SYSTEM_PRESSED state at all.
    So to imitate a toggle button, include the role and the state in the name, and
-   create a name change event when the state changes. */
+   create a name change event when the state changes. To enable screen reader
+   scripts to determine the state of the toggle button in the absence of the
+   accessibility state indicating this, add the '\a' character to the end of the name
+   when the button is pressed. ('\a' is read silently by screen readers.) */
    if (ab->mToggle) {
       *name += wxT(" ") +
          _("Button")
          + wxT(" ") +
          /* i18n-hint: whether a button is pressed or not pressed */
-         (ab->IsDown() ? _("pressed") : _("not pressed"));
+         (ab->IsDown() ? _("pressed") + wxT('\a') : _("not pressed"));
    }
 
    return wxACC_OK;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4991

Problem:
In commit 67aad3504, the accessibility of AButtons when set to be toggle buttons was improved for all screen readers and for Narrator in particular. This involved both the role and state being included in the accessibility name. However, because the accessibility state no longer indicated the state of the toggle button, this made it difficult for screen reader scripts to robustly determine the state of the toggle button.

Fix:
Add the character '\a' to the end of the accessibility name when the toggle button is in the pressed state. Screen reader scripts can then check for this character.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
