### PR TITLE
Accessibility name of list of tracks accidentally changed from TrackView

### DIFF
--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -332,7 +332,7 @@ wxAccStatus TrackPanelAx::GetName( int childId, wxString* name )
    {
       if( childId == wxACC_SELF )
       {
-         *name = _("ChannelView");
+         *name = _("TrackView");
       }
       else
       {
@@ -535,7 +535,7 @@ wxAccStatus TrackPanelAx::GetValue( int WXUNUSED(childId), wxString* WXUNUSED(st
 #if defined(__WXMAC__)
    if( childId == wxACC_SELF )
    {
-      *strValue = _("ChannelView");
+      *strValue = _("TrackView");
    }
    else
    {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5072

Issue #5072. In the commit https://github.com/audacity/audacity/pull/4825, the two instances of the string "TrackView" used in the accessibility object for the TrackPanel were accidentally changed to "ChannelView".

Fix:
Change the strings back to "TrackView".




<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
