### PR TITLE
Fix intermittent crash when append-recording in spectrum view...

### DIFF
--- a/libraries/lib-wave-track/Sequence.h
+++ b/libraries/lib-wave-track/Sequence.h
@@ -86,6 +86,10 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
    bool Get(samplePtr buffer, sampleFormat format,
             sampleCount start, size_t len, bool mayThrow) const;
 
+   /*!
+    Get a view of the lesser of `len` samples or what remains after `start`
+    @pre `start < GetNumSamples()`
+    */
    AudioSegmentSampleView
    GetFloatSampleView(sampleCount start, size_t len) const;
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2472,6 +2472,8 @@ ChannelSampleView WaveTrack::GetOneSampleView(
       t0 += newSegment.GetSampleCount().as_double() / GetRate();
       segments.push_back(std::move(newSegment));
       length -= len;
+      if (length == 0)
+         break;
    }
    if (length > 0u)
       segments.push_back(AudioSegmentSampleView{length});


### PR DESCRIPTION
... Don't violate precondition of Sequence::GetFloatSampleView().

Sometimes the crash doesn't reproduce and I think that's because of small roundoffs when choosing whether or not to add the second clip to `intersectingClips`

Resolves: #5094 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
