### PR TITLE
Mac backwards compatibility & usability tweaks

### DIFF
--- a/libraries/lib-wx-init/ProgressDialog.cpp
+++ b/libraries/lib-wx-init/ProgressDialog.cpp
@@ -52,6 +52,10 @@
 
 #include "MemoryX.h"
 
+#ifdef __WXOSX_COCOA__
+extern "C" void NSBeep(void);
+#endif
+
 // This really should be a Preferences setting
 static const unsigned char beep[] =
 {
@@ -1657,7 +1661,13 @@ void ProgressDialog::Beep() const
 
       if (name.empty())
       {
+#ifdef __WXOSX_COCOA__
+         // wxSound::Create(size_t,const void*) isn't implemented;
+         // use the system beep function.
+         NSBeep();
+#else
          s.Create(sizeof(beep), beep);
+#endif
       }
       else
       {

--- a/mac/Wrapper.c
+++ b/mac/Wrapper.c
@@ -23,6 +23,7 @@ executable.
 
 *//*******************************************************************/
 
+#include <stdio.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
@@ -43,8 +44,14 @@ int main(int argc, char *argv[])
    {
       strcpy(++slash, audacity);
    }
+   // change argv[0] so that `ps` will show the actually running binary
+   argv[0] = path;
 
-   unsetenv("DYLD_LIBRARY_PATH");
+   if (!getenv("AUDACITY_PRESERVE_LIBRARY_PATH")) {
+      unsetenv("DYLD_LIBRARY_PATH");
+   }
 
    execve(path, argv, environ);
+   perror(path);
+   exit(-1);
 }

--- a/src/AudacityApp.mm
+++ b/src/AudacityApp.mm
@@ -32,6 +32,7 @@ void AudacityApp::OnThemeChange(ThemeChangeMessage message)
 
    // This API only works 10.14+
    // Previous versions will always use Light appearance
+#if defined(__MAC_10_14) && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14
    if (@available(macOS 10.14, *))
    {
       NSAppearanceName appearanceName;
@@ -54,6 +55,7 @@ void AudacityApp::OnThemeChange(ThemeChangeMessage message)
       if (systemAppearance != nil)
          NSApp.appearance = systemAppearance;
    }
+#endif
 }
 
 #endif


### PR DESCRIPTION
- make src/AudacityApp.mm build on pre-10.14 systems which either don't have `@available()` or don't have the 10.14 SDK installed. (`@available` is a runtime operator.)
- make `ProgressDialog::Beep()` beep instead of printing an invisible failure message.
Use `NSBeep()` instead of calling a non-implemented wxWidgets method. (may fix https://github.com/audacity/audacity/issues/5018)
- Wrapper.c : change the process name (as it appears in `ps`) after forking, exit with an error if `execve()` fails and provide an env.var switch to preserve `DYLD_LIBRARY_PATH` for advanced users.
Contrary to comments in the code, setting `DYLD_LIBRARY_PATH` may also be what the user wants, and setting it doesn't necessarily interfere with loading the FFmpeg libraries just as it doesn't do that on Linux.

Committed from host : Portia.local

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
