### PR TITLE
Get ChannelGroupData from holder, not owner

### DIFF
--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -183,7 +183,7 @@ Track::ChannelGroupData &Track::MakeGroupData()
 Track::ChannelGroupData &Track::GetGroupData()
 {
    auto pTrack = this;
-   if (auto pList = GetOwner())
+   if (auto pList = GetHolder())
       if (auto pLeader = *pList->Find(pTrack))
          pTrack = pLeader;
    // May make on demand


### PR DESCRIPTION
Resolves: #5098

When clips are added to `TrackList::mPendingTracks` attemp to access `ChannelGroupData` of the (right)track results in a new instance of `ChannelGroupData` being created with default sample rate that could be different from the sample rate of the original track. Not the case for the first track's copy as it already contains a copy of `ChannelGroupData` originated from the source track.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
