### PR TITLE
Rewrite cutline editing

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1276,7 +1276,7 @@ void WaveTrack::ClearAndPasteOne(WaveTrack &track, double t0, double t1,
             // falls within it and this isn't the first clip in the track.
             if (fabs(t1 - clip->GetPlayStartTime()) < tolerance) {
                if (prev)
-                  track.MergeClips(track.GetClipIndex(prev),
+                  track.MergeOneClipPair(track.GetClipIndex(prev),
                      track.GetClipIndex(clip));
                break;
             }
@@ -1297,7 +1297,7 @@ void WaveTrack::ClearAndPasteOne(WaveTrack &track, double t0, double t1,
             // It must be that clip is what was pasted and it begins where
             // prev ends.
             // use Weak-guarantee
-            track.MergeClips(track.GetClipIndex(prev),
+            track.MergeOneClipPair(track.GetClipIndex(prev),
                track.GetClipIndex(clip));
             break;
          }
@@ -3219,8 +3219,15 @@ bool WaveTrack::RemoveCutLine(double cutLinePosition)
    return removed;
 }
 
-/*! @excsafety{Strong} */
+// Can't promise strong exception safety for a pair of tracks together
 void WaveTrack::MergeClips(int clipidx1, int clipidx2)
+{
+   for (const auto pChannel : TrackList::Channels(this))
+      pChannel->MergeOneClipPair(clipidx1, clipidx2);
+}
+
+/*! @excsafety{Strong} */
+void WaveTrack::MergeOneClipPair(int clipidx1, int clipidx2)
 {
    WaveClip* clip1 = GetClipByIndex(clipidx1);
    WaveClip* clip2 = GetClipByIndex(clipidx2);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -801,10 +801,20 @@ private:
    // clipidx1 and clipidx2 are indices into the clip list.
    void MergeClips(int clipidx1, int clipidx2);
 
-   // Expand cut line (that is, re-insert audio, then DELETE audio saved in cut line)
-   void ExpandCutLine(double cutLinePosition, double* cutlineStart = NULL, double* cutlineEnd = NULL);
+   //! Expand cut line (that is, re-insert audio, then delete audio saved in
+   //! cut line)
+   /*
+    @pre `IsLeader()`
+    @param[out] cutlineStart start time of the insertion
+    @param[out] cutlineEnd end time of the insertion
+    */
+   void ExpandCutLine(double cutLinePosition,
+      double* cutlineStart = nullptr, double* cutlineEnd = nullptr);
 
-   // Remove cut line, without expanding the audio in it
+   //! Remove cut line, without expanding the audio in it
+   /*
+    @pre `IsLeader()`
+    */
    bool RemoveCutLine(double cutLinePosition);
 
    // This track has been merged into a stereo track.  Copy shared parameters
@@ -900,6 +910,8 @@ private:
       sampleCount start, sampleCount len, sampleCount originalStart,
       sampleCount originalEnd, const ProgressReport &report = {});
    void SplitAt(double t) /* not override */;
+   void ExpandOneCutLine(double cutLinePosition,
+      double* cutlineStart, double* cutlineEnd);
 
    std::shared_ptr<WideChannelGroupInterval> DoGetInterval(size_t iInterval)
       override;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -912,6 +912,7 @@ private:
    void SplitAt(double t) /* not override */;
    void ExpandOneCutLine(double cutLinePosition,
       double* cutlineStart, double* cutlineEnd);
+   void MergeOneClipPair(int clipidx1, int clipidx2);
 
    std::shared_ptr<WideChannelGroupInterval> DoGetInterval(size_t iInterval)
       override;

--- a/src/WaveTrackLocation.cpp
+++ b/src/WaveTrackLocation.cpp
@@ -8,32 +8,23 @@ Audacity: A Digital Audio Editor
 Paul Licameli -- split from WaveTrack.h
 
 **********************************************************************/
-
 #include "WaveTrackLocation.h"
 #include "WaveTrack.h"
 #include "WaveClip.h"
 
 #include <cmath>
 
-WaveTrackLocations::~WaveTrackLocations() = default;
-
-auto WaveTrackLocations::Clone() const -> PointerType
+WaveTrackLocations FindWaveTrackLocations(const WaveTrack &track)
 {
-   return std::make_unique<WaveTrackLocations>(*this);
-}
+   WaveTrackLocations locations;
 
-void WaveTrackLocations::Update( const WaveTrack &track )
-{
    auto clips = track.SortedClipArray();
-
-   mDisplayLocationsCache.clear();
 
    // Count number of display locations
    int num = 0;
    {
       const WaveClip *prev = nullptr;
-      for (const auto clip : clips)
-      {
+      for (const auto clip : clips) {
          num += clip->NumCutLines();
 
          if (prev && fabs(prev->GetPlayEndTime() -
@@ -45,45 +36,39 @@ void WaveTrackLocations::Update( const WaveTrack &track )
    }
 
    if (num == 0)
-      return;
+      return locations;
 
    // Alloc necessary number of display locations
-   mDisplayLocationsCache.reserve(num);
+   locations.reserve(num);
 
    // Add all display locations to cache
    int curpos = 0;
 
    const WaveClip *previousClip = nullptr;
-   for (const auto clip: clips)
-   {
-      for (const auto &cc : clip->GetCutLines())
-      {
-         auto cutlinePosition = clip->GetSequenceStartTime() + cc->GetSequenceStartTime();
-         if (clip->WithinPlayRegion(cutlinePosition))
-         {
+   for (const auto clip: clips) {
+      for (const auto &cc : clip->GetCutLines()) {
+         auto cutlinePosition =
+            clip->GetSequenceStartTime() + cc->GetSequenceStartTime();
+         if (clip->WithinPlayRegion(cutlinePosition)) {
              // Add cut line expander point
-             mDisplayLocationsCache.push_back(WaveTrackLocation{
-                cutlinePosition,
-                WaveTrackLocation::locationCutLine
-             });
+             locations.emplace_back(cutlinePosition,
+                WaveTrackLocation::locationCutLine);
          }
          // If cutline is skipped, we still need to count it
-         // so that curpos match num at the end
+         // so that curpos matches num at the end
          curpos++;
       }
 
-     if (previousClip)
-      {
+      if (previousClip) {
          if (fabs(previousClip->GetPlayEndTime() - clip->GetPlayStartTime())
-                                          < WAVETRACK_MERGE_POINT_TOLERANCE)
-         {
+            < WAVETRACK_MERGE_POINT_TOLERANCE
+         ) {
             // Add merge point
-            mDisplayLocationsCache.push_back(WaveTrackLocation{
-               previousClip->GetPlayEndTime(),
+            locations.emplace_back(previousClip->GetPlayEndTime(),
                WaveTrackLocation::locationMergePoint,
                track.GetClipIndex(previousClip),
                track.GetClipIndex(clip)
-            });
+            );
             curpos++;
          }
       }
@@ -91,17 +76,8 @@ void WaveTrackLocations::Update( const WaveTrack &track )
       previousClip = clip;
    }
 
-   wxASSERT(curpos == num);
-}
+   assert(curpos == num);
 
-static WaveTrack::Attachments::RegisteredFactory sKey{ []( SampleTrack& ){
-   return std::make_unique< WaveTrackLocations >();
-} };
-
-WaveTrackLocations &WaveTrackLocations::Get( const WaveTrack &track )
-{
-   // const_cast the track to get this cache of mutable attached display data
-   return const_cast< WaveTrack& >( track )
-      .Attachments::Get< WaveTrackLocations >( sKey );
+   return locations;
 }
 

--- a/src/WaveTrackLocation.h
+++ b/src/WaveTrackLocation.h
@@ -3,7 +3,7 @@
 Audacity: A Digital Audio Editor
 
 @file WaveTrackLocation.h
-@brief data cache for clip boundaries attached to WaveTrack
+@brief finds clip and cutline boundaries attached to WaveTrack
 
 Paul Licameli -- split from WaveTrack.h
 
@@ -12,7 +12,7 @@ Paul Licameli -- split from WaveTrack.h
 #ifndef __AUDACITY_WAVE_TRACK_LOCATION__
 #define __AUDACITY_WAVE_TRACK_LOCATION__
 
-#include "ClientData.h"
+#include <vector>
 
 class WaveTrack;
 
@@ -23,22 +23,22 @@ struct WaveTrackLocation {
       locationMergePoint
    };
 
-   explicit
-   WaveTrackLocation
-   (double pos_ = 0.0, LocationType typ_ = locationCutLine,
-    int clipidx1_ = -1, int clipidx2_ = -1)
-    : pos(pos_), typ(typ_), clipidx1(clipidx1_), clipidx2(clipidx2_)
+   WaveTrackLocation() = default;
+
+   WaveTrackLocation(double pos, LocationType typ,
+    int clipidx1 = -1, int clipidx2 = -1
+   )  : pos{ pos }, typ{ typ }, clipidx1{ clipidx1 }, clipidx2{ clipidx2 }
    {}
 
    // Position of track location
-   double pos;
+   double pos{ 0.0 };
 
    // Type of track location
-   LocationType typ;
+   LocationType typ{ locationCutLine };
 
    // Only for typ==locationMergePoint
-   int clipidx1; // first clip (left one)
-   int clipidx2; // second clip (right one)
+   int clipidx1{ -1 }; // first clip (left one)
+   int clipidx2{ -1 }; // second clip (right one)
 };
 
 inline
@@ -56,24 +56,9 @@ bool operator != (const WaveTrackLocation &a, const WaveTrackLocation &b)
    return !( a == b );
 }
 
-class AUDACITY_DLL_API WaveTrackLocations final
-   : public ClientData::Cloneable< ClientData::UniquePtr >
-{
-   using Location = WaveTrackLocation;
-   std::vector <Location> mDisplayLocationsCache;
- 
-public:
-   static WaveTrackLocations &Get( const WaveTrack &track );
+using WaveTrackLocations = std::vector<WaveTrackLocation>;
 
-   ~WaveTrackLocations() override;
-   PointerType Clone() const override;
-
-   // Cache special locations (e.g. cut lines) for later speedy access
-   void Update( const WaveTrack &track );
-
-   // Get cached locations
-   const std::vector<Location> &Get() const
-   { return mDisplayLocationsCache; }
-};
+AUDACITY_DLL_API
+WaveTrackLocations FindWaveTrackLocations(const WaveTrack &track);
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
@@ -59,9 +59,9 @@ HitTestPreview CutlineHandle::HitPreview(bool cutline, bool unsafe)
 namespace
 {
    int FindMergeLine(const WaveTrackLocations &locations,
-      WaveTrack *track, double time)
+      WaveTrack &track, double time)
    {
-      const double tolerance = 0.5 / track->GetRate();
+      const double tolerance = 0.5 / track.GetRate();
       int ii = 0;
       for (const auto loc: locations) {
          if (loc.typ == WaveTrackLocation::locationMergePoint &&
@@ -176,15 +176,11 @@ UIHandle::Result CutlineHandle::Click
       }
       else if (mLocation.typ == WaveTrackLocation::locationMergePoint) {
          const double pos = mLocation.pos;
-         for (auto channel :
-              TrackList::Channels(mpTrack.get())) {
-            // Don't assume correspondence of merge points across channels!
-            int idx = FindMergeLine(mLocations, channel, pos);
-            if (idx >= 0) {
-               auto location = mLocations[idx];
-               channel->MergeClips(
-                  location.clipidx1, location.clipidx2);
-            }
+         int idx = FindMergeLine(mLocations, *mpTrack, pos);
+         if (idx >= 0) {
+            auto location = mLocations[idx];
+            mpTrack->MergeClips(
+               location.clipidx1, location.clipidx2);
          }
 
          mOperation = Merge;

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
@@ -24,9 +24,8 @@ class CutlineHandle final : public UIHandle
    static HitTestPreview HitPreview(bool cutline, bool unsafe);
 
 public:
-   explicit CutlineHandle
-      ( const std::shared_ptr<WaveTrack> &pTrack,
-        WaveTrackLocation location );
+   explicit CutlineHandle(const std::shared_ptr<WaveTrack> &pTrack,
+      WaveTrackLocations locations, WaveTrackLocation location);
 
    CutlineHandle &operator=(const CutlineHandle&) = default;
 
@@ -70,7 +69,8 @@ private:
    enum Operation { Merge, Expand, Remove };
    Operation mOperation{ Merge };
    double mStartTime{}, mEndTime{};
-   WaveTrackLocation mLocation {};
+   WaveTrackLocations mLocations;
+   WaveTrackLocation mLocation{};
 };
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
@@ -29,13 +29,13 @@ public:
 
    CutlineHandle &operator=(const CutlineHandle&) = default;
 
-   static UIHandlePtr HitAnywhere
-      (const AudacityProject *pProject, bool cutline, UIHandlePtr ptr);
-   static UIHandlePtr HitTest
-      (std::weak_ptr<CutlineHandle> &holder,
-       const wxMouseState &state, const wxRect &rect,
-       const AudacityProject *pProject,
-       const std::shared_ptr<WaveTrack> &pTrack);
+   static UIHandlePtr HitAnywhere(
+      const AudacityProject *pProject, bool cutline, UIHandlePtr ptr);
+   static UIHandlePtr HitTest(
+      std::weak_ptr<CutlineHandle> &holder,
+      const wxMouseState &state, const wxRect &rect,
+      const AudacityProject *pProject,
+      std::shared_ptr<WaveTrack> pTrack);
 
    virtual ~CutlineHandle();
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -889,17 +889,7 @@ void SpectrumView::Draw(
 {
    if ( iPass == TrackArtist::PassTracks ) {
       auto &dc = context.dc;
-      // Update cache for locations, e.g. cutlines and merge points
-      // Bug2588: do this for both channels, even if one is not drawn, so that
-      // cut-line editing (which depends on the locations cache) works properly.
-      // If both channels are visible, we will duplicate this effort, but that
-      // matters little.
-      for( auto channel:
-          TrackList::Channels(static_cast<WaveTrack*>(FindTrack().get())) ) {
-         auto &locationsCache = WaveTrackLocations::Get( *channel );
-         locationsCache.Update( *channel );
-      }
-
+ 
       const auto wt = std::static_pointer_cast<const WaveTrack>(
          FindTrack()->SubstitutePendingChangedTrack());
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -837,7 +837,7 @@ void WaveChannelSubView::DrawBoldBoundaries(
 #ifdef EXPERIMENTAL_TRACK_PANEL_HIGHLIGHTING
    auto target2 = dynamic_cast<CutlineHandle*>(context.target.get());
 #endif
-   for (const auto loc : WaveTrackLocations::Get(track).Get()) {
+   for (const auto loc : FindWaveTrackLocations(track)) {
       bool highlightLoc = false;
 #ifdef EXPERIMENTAL_TRACK_PANEL_HIGHLIGHTING
       highlightLoc =

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -997,16 +997,6 @@ void WaveformView::Draw(
 {
    if ( iPass == TrackArtist::PassTracks ) {
       auto &dc = context.dc;
-      // Update cache for locations, e.g. cutlines and merge points
-      // Bug2588: do this for both channels, even if one is not drawn, so that
-      // cut-line editing (which depends on the locations cache) works properly.
-      // If both channels are visible, we will duplicate this effort, but that
-      // matters little.
-      for( auto channel:
-          TrackList::Channels(static_cast<WaveTrack*>(FindTrack().get())) ) {
-         auto &locationsCache = WaveTrackLocations::Get( *channel );
-         locationsCache.Update( *channel );
-      }
 
       const auto wt = std::static_pointer_cast<const WaveTrack>(
          FindTrack()->SubstitutePendingChangedTrack());


### PR DESCRIPTION
Rewrite click to expand or delete cutlines or to merge clips, and rewrite
the painting of clip boundaries and cutlines, to remove some calls to
TrackList::Channels and lower two others into WaveTrack.cpp.

QA:  Do all this for mono and stereo tracks, and undo and redo changes:
- [x] Observe no change of display of clip boundaries and splits and cutlines in waveform and spectrum
- [x] Click clip split to merge still works (although we do intend to hide this feature later)
- [x] Left-click on a cutline to expand it
- [x] Right-click on a cutline to delete it

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
