### PR TITLE
Bugfix: Wrong display of time when punch and roll recording on an expanded clip

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2220,6 +2220,17 @@ bool WaveTrack::CloseLock() noexcept
    return true;
 }
 
+const WaveClip* WaveTrack::GetRightmostClip() const {
+   if (mClips.empty())
+      return nullptr;
+   return std::max_element(
+             mClips.begin(), mClips.end(),
+             [](const auto& a, const auto b) {
+                return a->GetPlayEndTime() < b->GetPlayEndTime();
+             })
+      ->get();
+}
+
 ClipConstHolders WaveTrack::GetClipInterfaces() const
 {
   // We're constructing possibly wide clips here, and for this we need to have

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -581,6 +581,8 @@ private:
    const WaveClipConstHolders &GetClips() const
       { return reinterpret_cast< const WaveClipConstHolders& >( mClips ); }
 
+   const WaveClip* GetRightmostClip() const;
+
    /**
     * @brief Get access to the (visible) clips in the tracks, in unspecified
     * order.


### PR DESCRIPTION
Resolves: #5113

Fix punch-n-roll for stretched (and unstretched) clips - see bug report for more detail.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] As in current release, a new clip is created when starting recording on a non-empty track.
- [x] Punch-n-Roll recording creates a new clip whether the cursor is in the left or right half of the space between samples ([demo](https://github.com/audacity/audacity/issues/5113#issuecomment-1705154108))
- [x] Punch-n-roll on a stretched clip doesn't have the issue reported in #5113 