### PR TITLE
Destructive effects applied to stretched clips

### DIFF
--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -15,9 +15,13 @@
 int EffectOutputTracks::nEffectsDone = 0;
 
 EffectOutputTracks::EffectOutputTracks(
-   TrackList &tracks, bool allSyncLockSelected
-)  : mTracks{ tracks }
+   TrackList& tracks, std::optional<TimeInterval> effectTimeInterval,
+   bool allSyncLockSelected)
+    : mTracks { tracks }
 {
+   assert(
+      !effectTimeInterval.has_value() ||
+      effectTimeInterval->first <= effectTimeInterval->second);
    // Reset map
    mIMap.clear();
    mOMap.clear();

--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -12,6 +12,7 @@
 #include "SyncLock.h"
 #include "UserException.h"
 #include "WaveTrack.h"
+#include "WaveTrackUtilities.h"
 
 // Effect application counter
 int EffectOutputTracks::nEffectsDone = 0;
@@ -51,9 +52,13 @@ EffectOutputTracks::EffectOutputTracks(
       auto progress = MakeProgress(
          XO("Pre-processing"), XO("Rendering Time-Stretched Audio"),
          ProgressShowCancel);
-      const auto waveTracks = stretchSyncLocked
+      const auto waveTracks = (stretchSyncLocked
          ? mOutputTracks->Any<WaveTrack>()
-         : mOutputTracks->Selected<WaveTrack>();
+         : mOutputTracks->Selected<WaveTrack>())
+      + [&](const WaveTrack *pTrack){
+         return WaveTrackUtilities::HasStretch(*pTrack,
+            effectTimeInterval->first, effectTimeInterval->second);
+      };
       const auto numTracks = waveTracks.size();
       auto count = 0;
       auto reportProgress = [&](double progressFraction) {

--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -18,7 +18,7 @@ int EffectOutputTracks::nEffectsDone = 0;
 
 EffectOutputTracks::EffectOutputTracks(
    TrackList& tracks, std::optional<TimeInterval> effectTimeInterval,
-   bool allSyncLockSelected)
+   bool allSyncLockSelected, bool stretchSyncLocked)
     : mTracks { tracks }
 {
    assert(
@@ -51,7 +51,9 @@ EffectOutputTracks::EffectOutputTracks(
       auto progress = MakeProgress(
          XO("Pre-processing"), XO("Rendering Time-Stretched Audio"),
          ProgressShowCancel);
-      const auto waveTracks = mOutputTracks->Any<WaveTrack>();
+      const auto waveTracks = stretchSyncLocked
+         ? mOutputTracks->Any<WaveTrack>()
+         : mOutputTracks->Selected<WaveTrack>();
       const auto numTracks = waveTracks.size();
       auto count = 0;
       auto reportProgress = [&](double progressFraction) {

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -37,7 +37,7 @@ public:
     copies those clips are split, and new clips bounded by the interval, with
     the stretches applied, are inserted.
     @pre `!effectTimeInterval.has_value() ||
-       effectTimeInterval->first < effectTimeInterval->second`
+       effectTimeInterval->first <= effectTimeInterval->second`
     */
    EffectOutputTracks(
       TrackList& tracks, std::optional<TimeInterval> effectTimeInterval,

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -14,6 +14,7 @@ class Track;
 class TrackList;
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 //! Use this object to copy the input tracks to tentative outputTracks
@@ -29,7 +30,17 @@ public:
    static int nEffectsDone;
    static void IncEffectCounter() { ++nEffectsDone; }
 
-   EffectOutputTracks(TrackList &tracks,
+   using TimeInterval = std::pair<double, double>;
+   /*!
+    @param effectTimeInterval if given, and any copied tracks
+    have clips with non-unit stretch intersecting that interval, then in the
+    copies those clips are split, and new clips bounded by the interval, with
+    the stretches applied, are inserted.
+    @pre `!effectTimeInterval.has_value() ||
+       effectTimeInterval->first < effectTimeInterval->second`
+    */
+   EffectOutputTracks(
+      TrackList& tracks, std::optional<TimeInterval> effectTimeInterval,
       bool allSyncLockSelected = false);
    EffectOutputTracks(const EffectOutputTracks&) = delete;
 

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -36,12 +36,18 @@ public:
     have clips with non-unit stretch intersecting that interval, then in the
     copies those clips are split, and new clips bounded by the interval, with
     the stretches applied, are inserted.
+    @param allSyncLockSelected if true, unselected tracks that are sync-locked
+    with a selected track are copied too
+    @param stretchSyncLocked if false, do not apply the stretch interval to any
+    unselected WaveTrack that is copied
+
     @pre `!effectTimeInterval.has_value() ||
        effectTimeInterval->first <= effectTimeInterval->second`
     */
    EffectOutputTracks(
       TrackList& tracks, std::optional<TimeInterval> effectTimeInterval,
-      bool allSyncLockSelected = false);
+      bool allSyncLockSelected = false,
+      bool stretchSyncLocked = false);
    EffectOutputTracks(const EffectOutputTracks&) = delete;
 
    ~EffectOutputTracks();

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -65,7 +65,7 @@ bool PerTrackEffect::Process(
    EffectInstance &instance, EffectSettings &settings) const
 {
    auto pThis = const_cast<PerTrackEffect *>(this);
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
    bool bGoodResult = true;
    // mPass = 1;
    if (DoPass1()) {

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -286,7 +286,8 @@ bool PerTrackEffect::ProcessPass(TrackList &outputs,
             genLength, sampleRate, leader, inBuffers, outBuffers);
          if (bGoodResult) {
             sink.Flush(outBuffers);
-            if (tempList) {
+            bGoodResult = sink.IsOk();
+            if (bGoodResult && tempList) {
                if (!results)
                   results = tempList;
                else

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -31,8 +31,6 @@
 #include "WaveTrackSink.h"
 #include "WideSampleSource.h"
 
-AudioGraph::Sink::~Sink() = default;
-
 PerTrackEffect::Instance::~Instance() = default;
 
 bool PerTrackEffect::Instance::Process(EffectSettings &settings)

--- a/libraries/lib-math/SampleCount.cpp
+++ b/libraries/lib-math/SampleCount.cpp
@@ -14,8 +14,8 @@
 #include <wx/debug.h>
 
 size_t sampleCount::as_size_t() const {
-   wxASSERT(value >= 0);
-   wxASSERT(static_cast<std::make_unsigned_t<type>>(value) <= std::numeric_limits<size_t>::max());
+   assert(value >= 0);
+   assert(static_cast<std::make_unsigned_t<type>>(value) <= std::numeric_limits<size_t>::max());
    return value;
 }
 

--- a/libraries/lib-mixer/WideSampleSequence.cpp
+++ b/libraries/lib-mixer/WideSampleSequence.cpp
@@ -21,3 +21,8 @@ double WideSampleSequence::LongSamplesToTime(sampleCount pos) const
 {
    return pos.as_double() / GetRate();
 }
+
+double WideSampleSequence::SnapToSample(double t) const
+{
+   return LongSamplesToTime(TimeToLongSamples(t));
+}

--- a/libraries/lib-mixer/WideSampleSequence.h
+++ b/libraries/lib-mixer/WideSampleSequence.h
@@ -113,6 +113,11 @@ public:
     */
    double LongSamplesToTime(sampleCount pos) const;
 
+   /*!
+    @return `LongSamplesToTime(TimeToLongSamples(t))`
+    */
+   double SnapToSample(double t) const;
+
    //! @return widest effective SampleFormat in any part of the track
    virtual sampleFormat WidestEffectiveFormat() const = 0;
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -393,6 +393,9 @@ private:
    //! Subclass responsibility implements only a part of Duplicate(), copying
    //! the track data proper (not associated data such as for groups and views)
    /*!
+    @param unstretchInterval If set, this time interval's stretching must be applied.
+    @pre `!unstretchInterval.has_value() ||
+       unstretchInterval->first < unstretchInterval->second`
     @pre `IsLeader()`
     @post result: `NChannels() == result->NChannels()`
     */
@@ -581,7 +584,7 @@ public:
     @tparam F returns a shared pointer to Attachment (or some subtype of it)
 
     @pre `f` never returns null
-   
+
     `f` may assume the precondition that the given channel index is less than
     the given track's number of channels
     */

--- a/libraries/lib-wave-track/CMakeLists.txt
+++ b/libraries/lib-wave-track/CMakeLists.txt
@@ -29,6 +29,8 @@ set( SOURCES
    WaveTrack.h
    WaveTrackSink.cpp
    WaveTrackSink.h
+   WaveTrackUtilities.cpp
+   WaveTrackUtilities.h
    WideClip.cpp
    WideClip.h
 )

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1335,6 +1335,11 @@ bool WaveClip::BeforePlayRegion(double t) const
    return t < GetPlayStartTime();
 }
 
+bool WaveClip::AtOrBeforePlayRegion(double t) const
+{
+   return t <= GetPlayStartTime();
+}
+
 bool WaveClip::AfterPlayRegion(double t) const
 {
    return GetPlayEndTime() <= t;

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1130,7 +1130,7 @@ void WaveClip::Resample(int rate, BasicUI::ProgressDialog *progress)
    }
 }
 
-void WaveClip::ApplyStretchRatio()
+void WaveClip::ApplyStretchRatio(const ProgressReporter& reportProgress)
 {
    const auto stretchRatio = GetStretchRatio();
    if (stretchRatio == 1.0)
@@ -1187,6 +1187,9 @@ void WaveClip::ApplyStretchRatio()
             widestSampleFormat /* computed samples need dither */
          );
       numOutSamples += numSamplesToGet;
+      if (reportProgress)
+         reportProgress(
+            numOutSamples.as_double() / totalNumOutSamples.as_double());
    }
 
    std::swap(mSequences, newSequences);

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1210,9 +1210,7 @@ sampleCount WaveClip::GetPlayStartSample() const
 
 sampleCount WaveClip::GetPlayEndSample() const
 {
-   return GetPlayStartSample() +
-          sampleCount(
-             GetVisibleSampleCount().as_double() * GetStretchRatio() + 0.5);
+   return sampleCount { GetPlayEndTime() * mRate + 0.5 };
 }
 
 sampleCount WaveClip::GetVisibleSampleCount() const

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -21,13 +21,16 @@
 #include <vector>
 #include <wx/log.h>
 
+#include "AudioContainer.h"
 #include "BasicUI.h"
+#include "ClipTimeAndPitchSource.h"
 #include "Envelope.h"
 #include "InconsistencyException.h"
 #include "Prefs.h"
 #include "Resample.h"
 #include "Sequence.h"
-#include "TimeAndPitchInterface.h"
+#include "StaffPadTimeAndPitch.h"
+//#include "TimeAndPitchInterface.h"
 #include "UserException.h"
 
 #ifdef _OPENMP
@@ -320,6 +323,16 @@ const SampleBlockFactoryPtr &WaveClip::GetFactory()
 {
    // All sequences have the same factory by class invariant
    return mSequences[0]->GetFactory();
+}
+
+std::vector<std::unique_ptr<Sequence>> WaveClip::GetEmptySequenceCopies() const
+{
+   decltype(mSequences) newSequences;
+   newSequences.reserve(mSequences.size());
+   for (auto& pSequence : mSequences)
+      newSequences.push_back(std::make_unique<Sequence>(
+         pSequence->GetFactory(), pSequence->GetSampleFormats()));
+   return newSequences;
 }
 
 constSamplePtr WaveClip::GetAppendBuffer(size_t ii) const
@@ -1042,11 +1055,7 @@ void WaveClip::Resample(int rate, BasicUI::ProgressDialog *progress)
    const auto numSamples = GetNumSamples();
 
    // These sequences are appended to below
-   decltype(mSequences) newSequences;
-   newSequences.reserve(mSequences.size());
-   for (auto &pSequence : mSequences)
-      newSequences.push_back(std::make_unique<Sequence>(
-         pSequence->GetFactory(), pSequence->GetSampleFormats()));
+   auto newSequences = GetEmptySequenceCopies();
 
    /**
     * We want to keep going as long as we have something to feed the resampler
@@ -1119,6 +1128,73 @@ void WaveClip::Resample(int rate, BasicUI::ProgressDialog *progress)
       Flush();
       Caches::ForEach( std::mem_fn( &WaveClipListener::Invalidate ) );
    }
+}
+
+void WaveClip::ApplyStretchRatio()
+{
+   const auto stretchRatio = GetStretchRatio();
+   if (stretchRatio == 1.0)
+      return;
+
+   auto success = false;
+   auto newSequences = GetEmptySequenceCopies();
+   bool swappedOnce = false;
+
+   Finally Do { [&, trimLeftBeforeStretch = mTrimLeft,
+                 trimRightBeforeStretch = mTrimRight] {
+      // Whether successful or not, the right thing to do is to restore the
+      // original trim values.
+      this->SetTrimLeft(trimLeftBeforeStretch);
+      this->SetTrimRight(trimRightBeforeStretch);
+      if (success)
+      {
+         this->mClipStretchRatio = 1.0;
+         this->mRawAudioTempo = this->mProjectTempo;
+         assert(this->GetStretchRatio() == 1.0);
+      }
+      else if (swappedOnce)
+         std::swap(mSequences, newSequences);
+   } };
+
+   SetTrimLeft(0);
+   SetTrimRight(0);
+
+   constexpr auto durationToDiscard = 0.0;
+   constexpr auto blockSize = 1024;
+   const auto numChannels = GetWidth();
+
+   ClipTimeAndPitchSource stretcherSource { *this, durationToDiscard,
+                                        PlaybackDirection::forward };
+   TimeAndPitchInterface::Parameters params;
+   params.timeRatio = stretchRatio;
+   StaffPadTimeAndPitch stretcher { numChannels, stretcherSource,
+                                    std::move(params) };
+   const auto totalNumOutSamples =
+      sampleCount { GetVisibleSampleCount().as_double() * stretchRatio + .5 };
+
+   sampleCount numOutSamples { 0 };
+   AudioContainer container(blockSize, numChannels);
+   while (numOutSamples < totalNumOutSamples)
+   {
+      const auto numSamplesToGet =
+         limitSampleBufferSize(blockSize, totalNumOutSamples - numOutSamples);
+      stretcher.GetSamples(container.Get(), numSamplesToGet);
+      auto channel = 0u;
+      for (auto& newSequence : newSequences)
+         newSequence->Append(
+            reinterpret_cast<samplePtr>(container.Get()[channel++]),
+            floatSample, numSamplesToGet, 1,
+            widestSampleFormat /* computed samples need dither */
+         );
+      numOutSamples += numSamplesToGet;
+   }
+
+   std::swap(mSequences, newSequences);
+   swappedOnce = true;
+   Flush();
+   Caches::ForEach(std::mem_fn(&WaveClipListener::Invalidate));
+
+   success = true;
 }
 
 // Used by commands which interact with clips using the keyboard.

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -240,6 +240,10 @@ public:
     */
    bool BeforePlayRegion(double t) const;
    /*!
+    * @brief  t <= [
+    */
+   bool AtOrBeforePlayRegion(double t) const;
+   /*!
     * @brief  ) <= t
     */
    bool AfterPlayRegion(double t) const;

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -189,15 +189,25 @@ public:
    //! (but not counting the cutlines)
    sampleCount GetSequenceSamplesCount() const;
 
+   //! Closed-begin of play region. Always a multiple of the track's sample
+   //! period, whether the clip is stretched or not.
    double GetPlayStartTime() const noexcept override;
    void SetPlayStartTime(double time);
 
+   //! Open-end of play region. Always a multiple of the track's sample
+   //! period, whether the clip is stretched or not.
    double GetPlayEndTime() const override;
+
+   //! Always a multiple of the track's sample period, whether the clip is
+   //! stretched or not.
    double GetPlayDuration() const;
 
-   // todo comment
+   //! Real start time of the clip, quantized to raw sample rate (track's rate)
    sampleCount GetPlayStartSample() const;
+   //! Real end time of the clip, quantized to raw sample rate (track's rate)
    sampleCount GetPlayEndSample() const;
+
+   // todo comment
    sampleCount GetVisibleSampleCount() const override;
 
    //! Sets the play start offset in seconds from the beginning of the underlying sequence

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -45,6 +45,7 @@ class WaveClip;
 using WaveClipHolder = std::shared_ptr< WaveClip >;
 using WaveClipHolders = std::vector < WaveClipHolder >;
 using WaveClipConstHolders = std::vector < std::shared_ptr< const WaveClip > >;
+using ProgressReporter = std::function<void(double)>;
 
 // A bundle of arrays needed for drawing waveforms.  The object may or may not
 // own the storage for those arrays.  If it does, it destroys them.
@@ -181,7 +182,8 @@ public:
     * @brief Renders the stretching of the clip (preserving duration).
     * @post GetStretchRatio() == 1
     */
-   void ApplyStretchRatio();
+   void ApplyStretchRatio(
+      const std::function<void(double)>& reportProgress);
 
    void SetColourIndex(int index) { mColourIndex = index; }
    int GetColourIndex() const { return mColourIndex; }
@@ -454,7 +456,7 @@ public:
    /*!
     @return true and succeed if and only if `this->GetWidth() == other.GetWidth()`
     */
-   bool Paste(double t0, const WaveClip &other);
+   bool Paste(double t0, const WaveClip& other);
 
    /** Insert silence - note that this is an efficient operation for large
     * amounts of silence */

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -175,7 +175,13 @@ public:
 
    // Resample clip. This also will set the rate, but without changing
    // the length of the clip
-   void Resample(int rate, BasicUI::ProgressDialog *progress = NULL);
+   void Resample(int rate, BasicUI::ProgressDialog *progress = nullptr);
+
+   /*!
+    * @brief Renders the stretching of the clip (preserving duration).
+    * @post GetStretchRatio() == 1
+    */
+   void ApplyStretchRatio();
 
    void SetColourIndex(int index) { mColourIndex = index; }
    int GetColourIndex() const { return mColourIndex; }
@@ -532,6 +538,7 @@ private:
    sampleCount GetNumSamples() const;
    SampleFormats GetSampleFormats() const;
    const SampleBlockFactoryPtr &GetFactory();
+   std::vector<std::unique_ptr<Sequence>> GetEmptySequenceCopies() const;
    void StretchCutLines(double ratioChange);
    double SnapToTrackSample(double time) const noexcept;
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1715,6 +1715,8 @@ void WaveTrack::SyncLockAdjust(double oldT1, double newT1)
          for (const auto pChannel : channels) {
             auto tmp = std::make_shared<WaveTrack>(
                mpFactory, GetSampleFormat(), GetRate());
+            // tmpList exists only to fix assertion crashes in usage of tmp
+            auto tmpList = TrackList::Temporary(nullptr, tmp, nullptr);
             assert(tmp->IsLeader()); // It is not yet owned by a TrackList
             tmp->InsertSilence(0.0, duration);
             tmp->FlushOne();

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1398,7 +1398,7 @@ void WaveTrack::ClearAndPasteOne(WaveTrack &track, double t0, double t1,
             // Clips in split began as copies of a clip in the track,
             // therefore have the same width, satisfying preconditions to
             // attach
-            if (clip->WithinPlayRegion(at))//strictly inside
+            if (clip->SplitsPlayRegion(at))//strictly inside
             {
                auto newClip =
                   std::make_shared<WaveClip>(*clip, pFactory, true);

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1417,13 +1417,21 @@ void WaveTrack::ClearAndPasteOne(WaveTrack &track, double t0, double t1,
             }
             else if (clip->GetPlayStartSample() ==
                track.TimeToLongSamples(at) && split.right) {
-               // precondition satisfied because... ??
+               // Satisfy the precondition of attachLeft first!
+               const auto trim = clip->GetTrimLeft();
+               const auto seqStartTime = clip->GetSequenceStartTime();
+               clip->Clear(seqStartTime, seqStartTime + trim);
+               // This clearing, although only removing the hidden part, moved
+               // the clip leftwards. We don't want this in this case.
+               clip->ShiftBy(trim);
                attachLeft(*clip, *split.right);
                break;
             }
             else if (clip->GetPlayEndSample() ==
                track.TimeToLongSamples(at) && split.left) {
-               // precondition satisfied because... ??
+               // Satisfy the precondition of attachRight first!
+               clip->Clear(
+                  clip->GetPlayEndTime(), clip->GetSequenceEndTime());
                attachRight(*clip, *split.left);
                break;
             }

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1665,7 +1665,7 @@ void WaveTrack::HandleClear(double t0, double t1,
       // or we're using the "don't move other clips" mode
       for (const auto& clip : mClips)
       {
-         if (clip->BeforePlayRegion(t1))
+         if (clip->AtOrBeforePlayRegion(t1))
             clip->ShiftBy(-(t1 - t0));
       }
    }

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1309,52 +1309,54 @@ void WaveTrack::ClearAndPasteOne(WaveTrack &track, double t0, double t1,
 
    // First, merge the new clip(s) in with the existing clips
    if (merge && splits.size() > 0) {
-      // Now t1 represents the absolute end of the pasted data.
-      t1 = t0 + endTime;
-
-      // Get a sorted array of the clips
-      auto clips = track.SortedClipArray();
-
-      // Scan the sorted clips for the first clip whose start time
-      // exceeds the pasted regions end time.
       {
-         WaveClip *prev = nullptr;
-         for (const auto clip : clips) {
-            // Merge this clip and the previous clip if the end time
-            // falls within it and this isn't the first clip in the track.
-            if (fabs(t1 - clip->GetPlayStartTime()) < tolerance) {
-               if (prev)
-                  track.MergeOneClipPair(track.GetClipIndex(prev),
-                     track.GetClipIndex(clip));
-               break;
+         // Now t1 represents the absolute end of the pasted data.
+         t1 = t0 + endTime;
+
+         // Get a sorted array of the clips
+         auto clips = track.SortedClipArray();
+
+         // Scan the sorted clips for the first clip whose start time
+         // exceeds the pasted regions end time.
+         {
+            WaveClip *prev = nullptr;
+            for (const auto clip : clips) {
+               // Merge this clip and the previous clip if the end time
+               // falls within it and this isn't the first clip in the track.
+               if (fabs(t1 - clip->GetPlayStartTime()) < tolerance) {
+                  if (prev)
+                     track.MergeOneClipPair(track.GetClipIndex(prev),
+                        track.GetClipIndex(clip));
+                  break;
+               }
+               prev = clip;
             }
-            prev = clip;
          }
       }
-   }
 
-   {
-      // Refill the array since clips have changed.
-      auto clips = track.SortedClipArray();
+      {
+         // Refill the array since clips have changed.
+         auto clips = track.SortedClipArray();
 
-      // Scan the sorted clips to look for the start of the pasted
-      // region.
-      WaveClip *prev = nullptr;
-      for (const auto clip : clips) {
-         if (prev) {
-            // It must be that clip is what was pasted and it begins where
-            // prev ends.
-            // use Weak-guarantee
-            track.MergeOneClipPair(track.GetClipIndex(prev),
-               track.GetClipIndex(clip));
-            break;
+         // Scan the sorted clips to look for the start of the pasted
+         // region.
+         WaveClip *prev = nullptr;
+         for (const auto clip : clips) {
+            if (prev) {
+               // It must be that clip is what was pasted and it begins where
+               // prev ends.
+               // use Weak-guarantee
+               track.MergeOneClipPair(track.GetClipIndex(prev),
+                  track.GetClipIndex(clip));
+               break;
+            }
+            if (fabs(t0 - clip->GetPlayEndTime()) < tolerance)
+               // Merge this clip and the next clip if the start time
+               // falls within it and this isn't the last clip in the track.
+               prev = clip;
+            else
+               prev = nullptr;
          }
-         if (fabs(t0 - clip->GetPlayEndTime()) < tolerance)
-            // Merge this clip and the next clip if the start time
-            // falls within it and this isn't the last clip in the track.
-            prev = clip;
-         else
-            prev = nullptr;
       }
    }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1239,7 +1239,7 @@ void WaveTrack::ClearAndPasteOne(WaveTrack &track, double t0, double t1,
    const TimeWarper *warper = (effectWarper ? effectWarper : &localWarper);
 
    const auto roundTime = [&track](double t){
-      return track.LongSamplesToTime(track.TimeToLongSamples(t));
+      return track.SnapToSample(t);
    };
 
    // Align to a sample
@@ -3195,7 +3195,7 @@ void WaveTrack::SplitAt(double t)
    {
       if (c->WithinPlayRegion(t))
       {
-         t = LongSamplesToTime(TimeToLongSamples(t));
+         t = SnapToSample(t);
          auto newClip = std::make_shared<WaveClip>(*c, mpFactory, true);
          c->TrimRightTo(t);// put t on a sample
          newClip->TrimLeftTo(t);
@@ -3451,8 +3451,7 @@ bool WaveTrack::ReverseOne(WaveTrack &track,
             revClips.push_back(track.RemoveAndReturnClip(clip));
             // align time to a sample and set offset
             revClips.back()->SetPlayStartTime(
-               track.LongSamplesToTime(
-                  track.TimeToLongSamples(offsetStartTime)));
+               track.SnapToSample(offsetStartTime));
          }
       }
       else if (clipStart >= end) {

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -170,7 +170,7 @@ public:
    ChannelSampleView GetSampleView(double t0, double t1, bool mayThrow) const;
 
    //! Random-access assignment of a range of samples
-   void Set(constSamplePtr buffer, sampleFormat format,
+   [[nodiscard]] bool Set(constSamplePtr buffer, sampleFormat format,
       sampleCount start, size_t len,
       sampleFormat effectiveFormat = widestSampleFormat /*!<
          Make the effective format of the data at least the minumum of this

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -803,7 +803,7 @@ private:
    // Merge two clips, that is append data from clip2 to clip1,
    // then remove clip2 from track.
    // clipidx1 and clipidx2 are indices into the clip list.
-   void MergeClips(int clipidx1, int clipidx2);
+   bool MergeClips(int clipidx1, int clipidx2);
 
    //! Expand cut line (that is, re-insert audio, then delete audio saved in
    //! cut line)
@@ -930,7 +930,7 @@ private:
    void SplitAt(double t) /* not override */;
    void ExpandOneCutLine(double cutLinePosition,
       double* cutlineStart, double* cutlineEnd);
-   void MergeOneClipPair(int clipidx1, int clipidx2);
+   bool MergeOneClipPair(int clipidx1, int clipidx2);
 
    std::shared_ptr<WideChannelGroupInterval> DoGetInterval(size_t iInterval)
       override;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -50,6 +50,7 @@ using WaveClipConstPointers = std::vector < const WaveClip* >;
 using ChannelSampleView = std::vector<AudioSegmentSampleView>;
 using ChannelGroupSampleView = std::vector<ChannelSampleView>;
 
+using TimeInterval = std::pair<double, double>;
 //
 // Tolerance for merging wave tracks (in seconds)
 //
@@ -472,6 +473,15 @@ private:
     @pre `IsLeader()`
     */
    void Trim(double t0, double t1) /* not override */;
+
+   /*
+    * @param interval Entire track is rendered if nullopt, else only samples
+    * within [interval->first, interval->second), in which case clips are split
+    * at these boundaries before rendering - if rendering is needed.
+    *
+    * @pre `!interval.has_value() || interval->first <= interval->second`
+    */
+   void ApplyStretchRatio(std::optional<TimeInterval> interval);
 
    void SyncLockAdjust(double oldT1, double newT1) override;
 
@@ -989,6 +999,8 @@ private:
    //! Sets project tempo on clip upon push. Use this instead of
    //! `mClips.push_back`.
    void InsertClip(WaveClipHolder clip);
+
+   void ApplyStretchRatioOne(double t0, double t1);
 
    SampleBlockFactoryPtr mpFactory;
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -51,6 +51,8 @@ using ChannelSampleView = std::vector<AudioSegmentSampleView>;
 using ChannelGroupSampleView = std::vector<ChannelSampleView>;
 
 using TimeInterval = std::pair<double, double>;
+using ProgressReporter = std::function<void(double)>;
+
 //
 // Tolerance for merging wave tracks (in seconds)
 //
@@ -279,7 +281,7 @@ public:
     @pre `NChannels() == orig.NChannels()`
     */
    void Reinit(const WaveTrack &orig);
-private:
+ private:
    void Init(const WaveTrack &orig);
 
    TrackListHolder Clone() const override;
@@ -481,7 +483,8 @@ private:
     *
     * @pre `!interval.has_value() || interval->first <= interval->second`
     */
-   void ApplyStretchRatio(std::optional<TimeInterval> interval);
+   void ApplyStretchRatio(
+      std::optional<TimeInterval> interval, ProgressReporter reportProgress);
 
    void SyncLockAdjust(double oldT1, double newT1) override;
 
@@ -764,6 +767,7 @@ private:
 
    // Get number of clips in this WaveTrack
    int GetNumClips() const;
+   int GetNumClips(double t0, double t1) const;
 
    // Add all wave clips to the given array 'clips' and sort the array by
    // clip start time. The array is emptied prior to adding the clips.
@@ -1000,7 +1004,8 @@ private:
    //! `mClips.push_back`.
    void InsertClip(WaveClipHolder clip);
 
-   void ApplyStretchRatioOne(double t0, double t1);
+   void ApplyStretchRatioOne(
+      double t0, double t1, const ProgressReporter& reportProgress);
 
    SampleBlockFactoryPtr mpFactory;
 

--- a/libraries/lib-wave-track/WaveTrackSink.cpp
+++ b/libraries/lib-wave-track/WaveTrackSink.cpp
@@ -49,7 +49,7 @@ bool WaveTrackSink::Acquire(Buffers &data)
       // (less than one block remains; maybe nonzero because of samples
       // discarded for initial latency correction)
       DoConsume(data);
-   return true;
+   return IsOk();
 }
 
 bool WaveTrackSink::Release(const Buffers &, size_t)
@@ -66,11 +66,13 @@ void WaveTrackSink::DoConsume(Buffers &data)
    if (inputBufferCnt > 0) {
       // Some data still unwritten
       if (mIsProcessor) {
-         mLeft.Set(data.GetReadPosition(0),
-            floatSample, mOutPos, inputBufferCnt, mEffectiveFormat);
-         if (mpRight)
-            mpRight->Set(data.GetReadPosition(1),
+         mOk = mOk &&
+            mLeft.Set(data.GetReadPosition(0),
                floatSample, mOutPos, inputBufferCnt, mEffectiveFormat);
+         if (mpRight)
+            mOk = mOk &&
+               mpRight->Set(data.GetReadPosition(1),
+                  floatSample, mOutPos, inputBufferCnt, mEffectiveFormat);
       }
       else if (mGenLeft) {
          mGenLeft->Append(data.GetReadPosition(0),

--- a/libraries/lib-wave-track/WaveTrackSink.h
+++ b/libraries/lib-wave-track/WaveTrackSink.h
@@ -43,6 +43,9 @@ public:
     */
    void Flush(Buffers &data);
 
+   //! Whether any errors have occurred in writing data
+   bool IsOk() const { return mOk; }
+
 private:
    /*!
     @pre `data.Channels() > 0`
@@ -59,5 +62,6 @@ private:
    const sampleFormat mEffectiveFormat;
 
    sampleCount mOutPos;
+   bool mOk{ true };
 };
 #endif

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -1,0 +1,25 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  WaveTrackUtilities.cpp
+
+  Paul Licameli
+
+**********************************************************************/
+#include "WaveTrackUtilities.h"
+#include "WaveClip.h"
+#include "WaveTrack.h"
+#include <algorithm>
+
+bool WaveTrackUtilities::HasStretch(
+   const WaveTrack &track, double t0, double t1)
+{
+   auto &clips = track.GetClips();
+   return any_of(clips.begin(), clips.end(),
+      [&](auto &pClip){
+         return pClip->IntersectsPlayRegion(t0, t1) &&
+            pClip->GetStretchRatio() != 1.0;
+      });
+}

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -1,0 +1,24 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  WaveTrackUtilities.h
+
+  Paul Licameli
+
+  @brief some convenient iterations over clips, needing only the public
+ interface of WaveTrack
+
+**********************************************************************/
+
+class WaveTrack;
+
+namespace WaveTrackUtilities {
+
+//! Whether any clips, whose play regions intersect the interval, have non-unit
+//! stretch ratio
+WAVE_TRACK_API
+bool HasStretch(const WaveTrack &track, double t0, double t1);
+
+}

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -918,9 +918,9 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
             // Quantize bounds to the rate of the new track.
             if (c == 0) {
                if (t0 < DBL_MAX)
-                  t0 = newTrack->LongSamplesToTime(newTrack->TimeToLongSamples(t0));
+                  t0 = newTrack->SnapToSample(t0);
                if (t1 < DBL_MAX)
-                  t1 = newTrack->LongSamplesToTime(newTrack->TimeToLongSamples(t1));
+                  t1 = newTrack->SnapToSample(t1);
             }
 
             auto tempList = TrackList::Temporary(nullptr, newTrack, nullptr);

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -495,7 +495,10 @@ bool EffectAutoDuck::ApplyDuckFade(int trackNum, WaveChannel &track,
          buf[ ( i - pos ).as_size_t() ] *= DB_TO_LINEAR(gain);
       }
 
-      track.Set((samplePtr)buf.get(), floatSample, pos, len);
+      if (!track.Set((samplePtr)buf.get(), floatSample, pos, len)) {
+         cancel = true;
+         break;
+      }
 
       pos += len;
 

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -200,7 +200,7 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
             const auto pFirstTrack = *tempTracks->Any<WaveTrack>().begin();
             if (pFirstTrack) {
                // TODO a progress indicator?
-               pFirstTrack->ApplyStretchRatio({ { t0, t1 } });
+               pFirstTrack->ApplyStretchRatio({ { t0, t1 } }, {});
                pControlTrack = pFirstTrack;
             }
          }

--- a/src/effects/AutoDuck.h
+++ b/src/effects/AutoDuck.h
@@ -72,7 +72,7 @@ private:
    double mThresholdDb;
    double mMaximumPause;
 
-   const WaveTrack *mControlTrack;
+   const WaveTrack *mControlTrack{};
 
    wxTextCtrl *mDuckAmountDbBox;
    wxTextCtrl *mInnerFadeDownLenBox;
@@ -83,7 +83,7 @@ private:
    wxTextCtrl *mMaximumPauseBox;
 
    class Panel;
-   Panel *mPanel;
+   Panel *mPanel{};
 
    const EffectParameterMethods& Parameters() const override;
    DECLARE_EVENT_TABLE()

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -214,7 +214,7 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
    // Iterate over each track.
    // All needed because this effect needs to introduce
    // silence in the sync-lock group tracks to keep sync
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
    bool bGoodResult = true;
 
    mCurTrackNum = 0;

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -185,9 +185,7 @@ auto EffectChangeSpeed::FindGaps(
    // these gaps are for later deletion
    Gaps gaps;
    const auto newGap = [&](double st, double et){
-      gaps.emplace_back(
-         track.LongSamplesToTime(track.TimeToLongSamples(st)),
-         track.LongSamplesToTime(track.TimeToLongSamples(et)));
+      gaps.emplace_back(track.SnapToSample(st), track.SnapToSample(et));
    };
    double last = curT0;
    auto clips = track.SortedClipArray();

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -113,7 +113,7 @@ bool EffectClickRemoval::CheckWhetherSkipEffect(const EffectSettings &) const
 
 bool EffectClickRemoval::Process(EffectInstance &, EffectSettings &)
 {
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
    bool bGoodResult = true;
    mbDidSomething = false;
 

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -182,8 +182,14 @@ bool EffectClickRemoval::ProcessOne(
            buffer[i+j] = datawindow[j];
       }
 
-      if (mbDidSomething) // RemoveClicks() actually did something.
-         track.Set((samplePtr) buffer.get(), floatSample, start + s, block);
+      if (mbDidSomething) {
+         // RemoveClicks() actually did something.
+         if(!track.Set(
+            (samplePtr) buffer.get(), floatSample, start + s, block)) {
+            bResult = false;
+            break;
+         }
+      }
       s += block;
       if (TrackProgress(count, s.as_double() / len.as_double())) {
          bResult = false;

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -197,7 +197,7 @@ bool EffectEqualization::VisitSettings(
    // Curve point parameters -- how many isn't known statically
    {
       curves[0].points.clear();
-   
+
       for (int i = 0; i < 200; i++)
       {
          const wxString nameFreq = wxString::Format("f%i",i);
@@ -289,7 +289,7 @@ EffectEqualization::LoadFactoryPreset(int id, EffectSettings &settings) const
    if (index < 0)
       return {};
 
-   // mParams = 
+   // mParams =
    wxString params = FactoryPresets[index].values;
 
    CommandParameters eap(params);
@@ -403,7 +403,7 @@ struct EffectEqualization::Task {
 
 bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
 {
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
    mParameters.CalcFilter();
    bool bGoodResult = true;
 
@@ -424,7 +424,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
          auto pTempTrack = *temp->Any<WaveTrack>().begin();
          pTempTrack->ConvertToSampleFormat(floatSample);
          auto iter0 = pTempTrack->Channels().begin();
-   
+
          for (const auto pChannel : track->Channels()) {
             constexpr auto windowSize = EqualizationFilter::windowSize;
             const auto &M = mParameters.mM;

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -69,9 +69,15 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
                auto pProject = FindProject();
                const auto &selectedRegion =
                   ViewInfo::Get(*pProject).selectedRegion;
+               // According to https://manual.audacityteam.org/man/silence.html,
+               // generating silence with an audio selection should behave like
+               // the "Silence Audio" command, which doesn't affect track clip
+               // boundaries.
+               constexpr auto preserve = true;
+               constexpr auto merge = true;
                track.ClearAndPaste(
-                  selectedRegion.t0(), selectedRegion.t1(),
-                  *list, true, false, &warper);
+                  selectedRegion.t0(), selectedRegion.t1(), *list, preserve,
+                  merge, &warper);
             }
             else
                return;

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -30,7 +30,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
 
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
 
    // Iterate over the tracks
    bool bGoodResult = true;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -105,7 +105,7 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
    );
 
    // Iterate over each track
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
    bool bGoodResult = true;
    auto topMsg = XO("Normalizing Loudness...\n");
 

--- a/src/effects/Loudness.h
+++ b/src/effects/Loudness.h
@@ -72,13 +72,13 @@ private:
    void FreeBuffers();
    static bool GetTrackRMS(WaveChannel &track,
       double curT0, double curT1, float &rms);
-   bool ProcessOne(WaveChannel &track, size_t nChannels,
+   [[nodiscard]] bool ProcessOne(WaveChannel &track, size_t nChannels,
       double curT0, double curT1, float mult, EBUR128 *pLoudnessProcessor);
    void LoadBufferBlock(WaveChannel &track, size_t nChannels,
       sampleCount pos, size_t len);
    bool AnalyseBufferBlock(EBUR128 &loudnessProcessor);
    bool ProcessBufferBlock(float mult);
-   void StoreBufferBlock(WaveChannel &track, size_t nChannels,
+   [[nodiscard]] bool StoreBufferBlock(WaveChannel &track, size_t nChannels,
       sampleCount pos, size_t len);
 
    bool UpdateProgress();

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -637,7 +637,7 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
 {
    // This same code will either reduce noise or profile it
 
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
 
    auto track = *(outputs.Get().Selected<const WaveTrack>()).begin();
    if (!track)
@@ -701,13 +701,14 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
    };
    bool bGoodResult = worker.Process(inWindowType, outWindowType,
       outputs.Get(), mT0, mT1);
+   const auto wasProfile = mSettings->mDoProfile;
    if (mSettings->mDoProfile) {
       if (bGoodResult)
          mSettings->mDoProfile = false; // So that "repeat last effect" will reduce noise
       else
          mStatistics.reset(); // So that profiling must be done again before noise reduction
    }
-   if (bGoodResult)
+   if (bGoodResult && !wasProfile)
       outputs.Commit();
 
    return bGoodResult;

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -222,7 +222,7 @@ bool EffectNoiseRemoval::Process(EffectInstance &, EffectSettings &)
 
    // This same code will both remove noise and profile it,
    // depending on 'mDoProfile'
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
    bool bGoodResult = true;
 
    int count = 0;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -106,7 +106,7 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
    }
 
    //Iterate over each track
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
    bool bGoodResult = true;
    double progress = 0;
    TranslatableString topMsg;

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -433,7 +433,10 @@ bool EffectNormalize::ProcessOne(WaveChannel &track,
       ProcessData(buffer.get(), block, offset);
 
       //Copy the newly-changed samples back onto the track.
-      track.Set((samplePtr) buffer.get(), floatSample, s, block);
+      if (!track.Set((samplePtr) buffer.get(), floatSample, s, block)) {
+         rc = false;
+         break;
+      }
 
       //Increment s one blockfull of samples
       s += block;

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -41,7 +41,7 @@ const EffectParameterMethods& EffectPaulstretch::Parameters() const
    return parameters;
 }
 
-/// \brief Class that helps EffectPaulStretch.  It does the FFTs and inner loop 
+/// \brief Class that helps EffectPaulStretch.  It does the FFTs and inner loop
 /// of the effect.
 class PaulStretch
 {
@@ -147,7 +147,7 @@ double EffectPaulstretch::CalcPreviewInputLength(
 bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
 {
    // Pass true because sync lock adjustment is needed
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
    auto newT1 = mT1;
    int count = 0;
    // Process selected wave tracks first, to find the new t1 value

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -152,11 +152,12 @@ bool EffectRepair::ProcessOne(int count, WaveChannel &track,
    Floats buffer{ len };
    track.GetFloats(buffer.get(), start, len);
    InterpolateAudio(buffer.get(), len, repairStart, repairLen);
-   track.Set((samplePtr)&buffer[repairStart], floatSample,
+   if (!track.Set((samplePtr)&buffer[repairStart], floatSample,
       start + repairStart, repairLen,
       // little repairs shouldn't force dither on rendering:
       narrowestSampleFormat
-   );
+   ))
+      return false;
    return !TrackProgress(count, 1.0); // TrackProgress returns true on Cancel.
 }
 

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -19,19 +19,16 @@ renamed and focused on the smaller subproblem of repairing
 the audio, rather than actually finding the clicks.
 
 *//*******************************************************************/
-
-
-
 #include "Repair.h"
-#include "EffectOutputTracks.h"
 
 #include <math.h>
 
-#include "InterpolateAudio.h"
-#include "WaveTrack.h"
 #include "AudacityMessageBox.h"
-
+#include "EffectOutputTracks.h"
+#include "InterpolateAudio.h"
 #include "LoadEffects.h"
+#include "WaveTrack.h"
+#include "WaveTrackUtilities.h"
 
 const ComponentInterfaceSymbol EffectRepair::Symbol
 { XO("Repair") };
@@ -77,7 +74,9 @@ bool EffectRepair::Process(EffectInstance &, EffectSettings &)
    // This may be too much copying for EffectRepair. To support Cancel, may be
    // able to copy much less.
    // But for now, Cancel isn't supported without this.
-   EffectOutputTracks outputs{ *mTracks };
+   // Repair doesn't make sense for stretched clips, so don't pass a stretch
+   // interval.
+   EffectOutputTracks outputs { *mTracks, {} };
    bool bGoodResult = true;
 
    int count = 0;
@@ -91,6 +90,13 @@ bool EffectRepair::Process(EffectInstance &, EffectSettings &)
          const auto repair0 = track->TimeToLongSamples(repair_t0);
          const auto repair1 = track->TimeToLongSamples(repair_t1);
          const auto repairLen = repair1 - repair0;
+         if (WaveTrackUtilities::HasStretch(*track, repair_t0, repair_t1)) {
+            EffectUIServices::DoMessageBox(*this,
+               XO(
+"The Repair effect cannot be applied within stretched or shrunk clips") );
+            bGoodResult = false;
+            break;
+         }
          if (repairLen > 128) {
             EffectUIServices::DoMessageBox(*this,
                XO(

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -92,7 +92,7 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
 {
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
 
    int nTrack = 0;
    bool bGoodResult = true;

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -73,7 +73,7 @@ bool EffectReverse::IsInteractive() const
 bool EffectReverse::Process(EffectInstance &, EffectSettings &)
 {
    //all needed because Reverse should move the labels too
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true, true };
    bool bGoodResult = true;
    int count = 0;
 

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -73,7 +73,7 @@ bool EffectReverse::IsInteractive() const
 bool EffectReverse::Process(EffectInstance &, EffectSettings &)
 {
    //all needed because Reverse should move the labels too
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
    bool bGoodResult = true;
    int count = 0;
 

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -223,7 +223,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
 
    //Iterate over each track
    //all needed because this effect needs to introduce silence in the group tracks to keep sync
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
    mCurTrackNum = 0;
 
    double maxDuration = 0.0;
@@ -321,7 +321,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
                   0,
                   rb.quality.get());
             }
-            
+
             Resampler resampler(outResampleCB, &rb, outSlideType);
 
             audio outBuf[SBSMSOutBlockSize];

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -457,8 +457,8 @@ void EffectSBSMS::Finalize(
 
    // Finally, recreate the gaps
    for (auto gap : gaps) {
-      auto st = orig.LongSamplesToTime(orig.TimeToLongSamples(gap.first));
-      auto et = orig.LongSamplesToTime(orig.TimeToLongSamples(gap.second));
+      const auto st = orig.SnapToSample(gap.first);
+      const auto et = orig.SnapToSample(gap.second);
       if (st >= mT0 && et <= mT1 && st != et)
          orig.SplitDelete(warper.Warp(st), warper.Warp(et));
    }

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -419,8 +419,8 @@ void EffectSoundTouch::Finalize(
 
    // Finally, recreate the gaps
    for (auto gap : gaps) {
-      auto st = orig.LongSamplesToTime(orig.TimeToLongSamples(gap.first));
-      auto et = orig.LongSamplesToTime(orig.TimeToLongSamples(gap.second));
+      const auto st = orig.SnapToSample(gap.first);
+      const auto et = orig.SnapToSample(gap.second);
       if (st >= mT0 && et <= mT1 && st != et)
          orig.SplitDelete(warper.Warp(st), warper.Warp(et));
    }

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -87,7 +87,7 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
 
    //Iterate over each track
    // Needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
    bool bGoodResult = true;
 
    mPreserveLength = preserveLength;

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -79,13 +79,16 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
 {
    // Do not use mWaveTracks here.  We will possibly DELETE tracks,
    // so we must use the "real" tracklist.
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks,
+      // This effect ignores mT0 and mT1 but always mixes the entire tracks.
+      {{ mTracks->GetStartTime(), mTracks->GetEndTime() }}
+   };
    bool bGoodResult = true;
 
    // Determine the total time (in samples) used by all of the target tracks
    // only for progress dialog
    sampleCount totalTime = 0;
-   
+
    auto trackRange = outputs.Get().Selected<WaveTrack>();
    for (const auto left : trackRange) {
       if (left->Channels().size() > 1) {

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -273,7 +273,7 @@ bool EffectTruncSilence::ProcessIndependently()
    // Now do the work
 
    // Copy tracks
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true, true };
    double newT1 = 0.0;
 
    {
@@ -307,7 +307,7 @@ bool EffectTruncSilence::ProcessIndependently()
 bool EffectTruncSilence::ProcessAll()
 {
    // Copy tracks
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true, true };
 
    // Master list of silent regions.
    // This list should always be kept in order.

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -444,8 +444,8 @@ bool EffectTruncSilence::DoRemoval(const RegionList &silences,
             // In WaveTracks, clear with a cross-fade
             auto blendFrames = mBlendFrameCount;
             // Round start/end times to frame boundaries
-            cutStart = wt.LongSamplesToTime(wt.TimeToLongSamples(cutStart));
-            cutEnd = wt.LongSamplesToTime(wt.TimeToLongSamples(cutEnd));
+            cutStart = wt.SnapToSample(cutStart);
+            cutEnd = wt.SnapToSample(cutEnd);
 
             // Make sure the cross-fade does not affect non-silent frames
             if (wt.LongSamplesToTime(blendFrames) > inLength) {

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -28,7 +28,7 @@ bool EffectTwoPassSimpleMono::Process(
    mSecondPassDisabled = false;
 
    InitPass1();
-   EffectOutputTracks outputs{ *mTracks };
+   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
 
    mWorkTracks = TrackList::Create(const_cast<AudacityProject*>(FindProject()));
    for (auto track : outputs.Get().Selected<WaveTrack>()) {

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -171,9 +171,11 @@ bool EffectTwoPassSimpleMono::ProcessOne(WaveChannel &track,
 
       // Processing succeeded. copy the newly-changed samples back
       // onto the track.
-      if (mSecondPassDisabled || mPass != 0)
-         outTrack.Set((samplePtr)buffer1.get(), floatSample, s - samples1,
-            samples1);
+      if (mSecondPassDisabled || mPass != 0) {
+         if (!outTrack.Set((samplePtr)buffer1.get(), floatSample, s - samples1,
+            samples1))
+            return false;
+      }
       else
          outTrack.Append((samplePtr)buffer1.get(), floatSample, samples1);
 
@@ -211,9 +213,11 @@ bool EffectTwoPassSimpleMono::ProcessOne(WaveChannel &track,
 
    // Processing succeeded. copy the newly-changed samples back
    // onto the track.
-   if (mSecondPassDisabled || mPass != 0)
-      outTrack.Set((samplePtr)buffer1.get(), floatSample, s - samples1,
-         samples1);
+   if (mSecondPassDisabled || mPass != 0) {
+      if (!outTrack.Set((samplePtr)buffer1.get(), floatSample, s - samples1,
+         samples1))
+         return false;
+   }
    else
       outTrack.Append((samplePtr)buffer1.get(), floatSample, samples1);
 

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -769,7 +769,8 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
    // to operate on the selected wave tracks
    std::optional<EffectOutputTracks> oOutputs;
    if (!bOnePassTool)
-      oOutputs.emplace(*mTracks, true);
+      oOutputs.emplace(*mTracks,
+         EffectOutputTracks::TimeInterval{ mT0, mT1 }, true);
 
    mNumSelectedChannels = bOnePassTool
       ? 0

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -849,10 +849,8 @@ void OnSplitNew(const CommandContext &context)
          [&](WaveTrack &wt) {
             // Clips must be aligned to sample positions or the NEW clip will
             // not fit in the gap where it came from
-            double newt0 = wt.LongSamplesToTime(wt.TimeToLongSamples(
-               selectedRegion.t0()));
-            double newt1 = wt.LongSamplesToTime(wt.TimeToLongSamples(
-               selectedRegion.t1()));
+            const double newt0 = wt.SnapToSample(selectedRegion.t0());
+            const double newt1 = wt.SnapToSample(selectedRegion.t1());
             // Fix issue 2846 by calling copy with forClipboard = false.
             // This avoids creating the blank placeholder clips
             const auto dest = wt.Copy(newt0, newt1, false);

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
@@ -178,8 +178,9 @@ UIHandle::Result CutlineHandle::Click
          int idx = FindMergeLine(mLocations, *mpTrack, pos);
          if (idx >= 0) {
             auto location = mLocations[idx];
-            mpTrack->MergeClips(
-               location.clipidx1, location.clipidx2);
+            if (!mpTrack->MergeClips(
+               location.clipidx1, location.clipidx2))
+               return Cancelled;
          }
 
          mOperation = Merge;

--- a/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
@@ -290,10 +290,13 @@ UIHandle::Result SampleHandle::Click
       }
       //Set the sample to the point of the mouse event
       // Don't require dithering later
-      mClickedTrack->Set((samplePtr)newSampleRegion.get(), floatSample,
+      const bool success = mClickedTrack->Set(
+         (samplePtr)newSampleRegion.get(), floatSample,
          mClickedStartSample - SMOOTHING_BRUSH_RADIUS,
          1 + 2 * SMOOTHING_BRUSH_RADIUS,
          narrowestSampleFormat);
+      if (!success)
+         return Cancelled;
 
       // mLastDragSampleValue will not be used
    }
@@ -309,9 +312,11 @@ UIHandle::Result SampleHandle::Click
 
       //Set the sample to the point of the mouse event
       // Don't require dithering later
-      mClickedTrack->Set(
+      const bool success = mClickedTrack->Set(
          (samplePtr)&newLevel, floatSample, mClickedStartSample, 1,
          narrowestSampleFormat);
+      if (!success)
+         return Cancelled;
 
       mLastDragSampleValue = newLevel;
    }
@@ -385,8 +390,10 @@ UIHandle::Result SampleHandle::Drag
    const auto size = ( end - start + 1 ).as_size_t();
    if (size == 1) {
       // Don't require dithering later
-      mClickedTrack->Set(
+      const bool success = mClickedTrack->Set(
          (samplePtr)&newLevel, floatSample, start, size, narrowestSampleFormat);
+      if (!success)
+         return Cancelled;
    }
    else {
       std::vector<float> values(size);
@@ -399,8 +406,10 @@ UIHandle::Result SampleHandle::Drag
              (s0 - mLastDragSample).as_float();
       }
       // Don't require dithering later
-      mClickedTrack->Set(
+      const bool success = mClickedTrack->Set(
          (samplePtr)&values[0], floatSample, start, size, narrowestSampleFormat);
+      if (!success)
+         return Cancelled;
    }
 
    //Update the member data structures.

--- a/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
@@ -83,7 +83,7 @@ namespace {
    inline double adjustTime(const WaveTrack *wt, double time)
    {
       // Round to an exact sample time
-      return wt->LongSamplesToTime(wt->TimeToLongSamples(time));
+      return wt->SnapToSample(time);
    }
 
    // Is the sample horizontally nearest to the cursor sufficiently separated

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -713,10 +713,8 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
    {
       double tt0, tt1;
       if (SyncLock::IsSelectedOrSyncLockSelected(&track)) {
-         tt0 = track.LongSamplesToTime(
-            track.TimeToLongSamples(selectedRegion.t0()));
-         tt1 = track.LongSamplesToTime(
-            track.TimeToLongSamples(selectedRegion.t1()));
+         tt0 = track.SnapToSample(selectedRegion.t0());
+         tt1 = track.SnapToSample(selectedRegion.t1());
       }
       else
          tt0 = tt1 = 0.0;


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

## QA (copied from #5044)
All effects are supposed to work. Trying all of them may be too much, but a variety of types of effects should be tried (time-related effect, Nyquist, EQs and filters, noise removal, pitch shift, spectral tools, etc. Of course try them on stretched data, but also on stereo data, etc.

Note that applying an effect on a partial clip selection will create a new clip if the clip was stretched. That's wanted. The old behavior is only preserved on unstretched data.

- [x] AutoDuck
- [x] AutoDuck also works when there is stretch in the un-selected control track
- [x] Change Speed
- [x] Click Removal
- [x] EQ
- [x] Generate silence (in particular, does not create new clip boundaries at left and right edges of selection when generating over existing data and there is no stretching)
- [x] Loudness (in both modes)
- [x] Noise Reduction
- [x] Normalize
- [x] Paulstretch
- [x] Repair (Since this requires up to 128 samples only, the result will probably only be silence, and that's ok: it's a known limitation of the algorithm that rendering very tiny portions of audio only output silence)
- [x] Repeat
- [x] Reverse
- [x] Change Tempo and Sliding Scale, high and low quality
- [x] Stereo To Mono (previously reported by @dozzzzer as https://github.com/audacity/audacity/issues/5118)
- [x] Truncate Silence
- [x] Compressor
- [x] Some Nyquist effects and generators
- [x] At least one "Per Track Effect" example (any of the realtime capable, built-in or plug-in effects, but used destructively)

More for QA:
- [x] Effects applied to long enough areas, that the stretching progress indicator appears:  the indicator should fill up correctly, to 100% and then promptly vanish
- [x] Noise Reduction Analyze step, selecting stretched data and selections crossing clip boundaries with different stretch
- [x] Noise reduction analysis does not make unintended side-effects on tracks, or undo items
- [x] Test with and without the "Editing a clip can move other clips" preference (Track Behaviors)
- [x] Test all with selection of only a part of the track's duration, maybe with clip boundaries within, and different stretches
- [x] Test with silence generating a duration unequal to the selected duration
- [x] (Very minor) Click on clip boundary to merge isn't yet a hidden feature; it fails when stretch ratios differ, but makes no empty Undo item
- [x] Observe that new clip boundaries result when stretching is necessary, but if not, old behavior is preserved
- [x] Repair: stretch a mono clip by a factor of 2 and select 100 samples. You should get the error about not suitable to stretched data, not the other error that says you've selected too many samples.
- [x] #5135 is fixed by this PR
- [x] Apply a destructive effect to multiple tracks with stretch (maybe some without).  Observe just one progress bar proportioned to the number of wave tracks that have any stretch in the selection (maybe fewer than all the selected tracks).  The bar fills to completion and disappears at once, without jumping too fast over any part.
- [x] Use pencil tool _on unstretched clip(s)_ (getting this to work on stretched clips is for 3-of-6 to fix)
- [x] Effects that require sync-lock adjustment of other wave tracks that have some stretch or shrink in the selected interval
  - [x] In all of these, it should not insert splits in those tracks, and work when shortening a track, or widening a gap between clips; inserting silence into a clip is a KNOWN PROBLEM that is NOT IN THE SCOPE OF THIS PR but instead #5043 will do that
    - [x] Inserting generated silence
    - [x] Inserting generated tone, noise, chirp
    - [x] Nyquist generators, Change Speed, Paulstretch, Repeat, Change Tempo or Sliding Stretch (high and low quality)
  - [x] These two have some special case sync-lock handling and for now they WILL insert splits, though that might be reconsidered in future.
    - [x] Reverse
    - [x] Truncate Silence (Sync-locked tracks also shorten but with a cross-fade, unlike in other sync locks)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
