### PR TITLE
Hide channel iteration loop inside `WaveTrack::SetRate`

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -311,6 +311,8 @@ private:
    //
 
    double GetRate() const override;
+   ///!brief Sets the new rate for the track without resampling it
+   ///!pre newRate > 0
    void SetRate(double newRate);
 
    // Multiplicative factor.  Only converted to dB for display.
@@ -922,6 +924,8 @@ private:
    sampleFormat mLegacyFormat; //!< used only during deserialization
 
 private:
+   //Updates rate parameter only in WaveTrackData
+   void DoSetRate(double newRate);
    void SetClipRates(double newRate);
    void DoOnProjectTempoChange(
       const std::optional<double>& oldTempo, double newTempo) override;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -43,10 +43,7 @@ Paul Licameli split from TrackPanel.cpp
 #include <wx/frame.h>
 #include <wx/sizer.h>
 
-WaveTrackControls::~WaveTrackControls()
-{
-}
-
+WaveTrackControls::~WaveTrackControls() = default;
 
 std::vector<UIHandlePtr> WaveTrackControls::HitTest
 (const TrackPanelMouseState & st,
@@ -318,6 +315,7 @@ struct RateMenuTable : PopupMenuTable
    PlayableTrackControls::InitMenuData *mpData{};
 
    static int IdOfRate(int rate);
+   /// Sets the sample rate for a track
    void SetRate(WaveTrack * pTrack, double rate);
 
    void OnRateChange(wxCommandEvent & event);
@@ -378,13 +376,10 @@ int RateMenuTable::IdOfRate(int rate)
    return OnRateOtherID;
 }
 
-/// Sets the sample rate for a track, and if it is linked to
-/// another track, that one as well.
 void RateMenuTable::SetRate(WaveTrack * pTrack, double rate)
 {
    AudacityProject *const project = &mpData->project;
-   for (auto channel : TrackList::Channels(pTrack))
-      channel->SetRate(rate);
+   pTrack->SetRate(rate);
 
    // Separate conversion of "rate" enables changing the decimals without affecting i18n
    wxString rateString = wxString::Format(wxT("%.3f"), rate);

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.h
@@ -34,7 +34,7 @@ public:
    explicit
    WaveTrackControls( std::shared_ptr<Track> pTrack )
       : PlayableTrackControls( pTrack ) {}
-   ~WaveTrackControls();
+   ~WaveTrackControls() override;
 
    std::vector<UIHandlePtr> HitTest
       (const TrackPanelMouseState &state,


### PR DESCRIPTION
Resolves: #5131

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
