### PR TITLE
remove x/1 time sigs as an option

### DIFF
--- a/src/toolbars/TimeSignatureToolBar.cpp
+++ b/src/toolbars/TimeSignatureToolBar.cpp
@@ -151,7 +151,7 @@ void TimeSignatureToolBar::Populate()
       wxString::Format(
          "%d", ProjectTimeSignature::Get(mProject).GetLowerTimeSignature()),
       wxDefaultPosition, timeSigSize,
-      wxArrayStringEx { L"1", L"2", L"4", L"8", L"16", L"32", L"64" },
+      wxArrayStringEx { L"2", L"4", L"8", L"16", L"32", L"64" },
       wxCB_READONLY);
 
    mLowerSignatureControl->SetName(XO("Lower Time Signature").Translation());


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5141

While x/1 time signatures are certainly possible, I'd wager they also are of low musical value and importance. Simply hiding it from the dropdown would be a very quick and easy fix for the bug in question.