### PR TITLE
Fix: combinedinto -> combined into

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -760,7 +760,7 @@ void WaveTrackMenuTable::OnMergeStereo(wxCommandEvent &)
    if(pTrack->GetSampleFormat() != partner->GetSampleFormat())
    {
       BasicUI::ShowMessageBox(XO(
-"Mono tracks must have the same sample format in order to be combined"
+"Mono tracks must have the same sample format in order to be combined "
 "into a stereo track"),
          BasicUI::MessageBoxOptions{}
             .Caption(XO("Error"))


### PR DESCRIPTION
Fix: combinedinto -> combined into
Should be a single space after 'combined', because both words are combined into one.

Greetings,
Gootector

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
