### PR TITLE
Deterministic zero-fill whenever WaveTrack::Get[Floats] fails...

### DIFF
--- a/libraries/lib-mixer/MixerSource.cpp
+++ b/libraries/lib-mixer/MixerSource.cpp
@@ -130,9 +130,11 @@ size_t MixerSource::MixVariableRates(
             constexpr auto iChannel = 0u;
             if (!mpLeader->GetFloats(
                    iChannel, nChannels, dst.data(), pos, getLen, backwards,
-                   FillFormat::fillZero, mMayThrow))
-               for (size_t iChannel = 0; iChannel < nChannels; ++iChannel)
-                  memset(dst[i], 0, sizeof(float) * getLen);
+                   FillFormat::fillZero, mMayThrow)) {
+               // Now redundant in case of failure
+               // for (size_t iChannel = 0; iChannel < nChannels; ++iChannel)
+                  // memset(dst[i], 0, sizeof(float) * getLen);
+            }
             mpLeader->GetEnvelopeValues(
                mEnvValues.data(), getLen, (pos).as_double() / sequenceRate,
                backwards);
@@ -251,9 +253,12 @@ size_t MixerSource::MixSameRate(unsigned nChannels, const size_t maxOut,
    if (!mpLeader->GetFloats(
       iChannel, nChannels, floatBuffers, pos, slen, backwards,
       FillFormat::fillZero, mMayThrow)
-   )
-      for (size_t iChannel = 0; iChannel < nChannels; ++iChannel)
-         memset(floatBuffers[iChannel], 0, sizeof(float) * slen);
+   ) {
+      // Now redundant in case of failure
+      // for (size_t iChannel = 0; iChannel < nChannels; ++iChannel)
+         // memset(floatBuffers[iChannel], 0, sizeof(float) * slen);
+      
+   }
 
    mpLeader->GetEnvelopeValues(mEnvValues.data(), slen, t, backwards);
 

--- a/libraries/lib-mixer/WideSampleSequence.cpp
+++ b/libraries/lib-mixer/WideSampleSequence.cpp
@@ -26,3 +26,20 @@ double WideSampleSequence::SnapToSample(double t) const
 {
    return LongSamplesToTime(TimeToLongSamples(t));
 }
+
+bool WideSampleSequence::GetFloats(size_t iChannel, size_t nBuffers,
+   float *const buffers[], sampleCount start, size_t len,
+   bool backwards, fillFormat fill,
+   bool mayThrow, sampleCount* pNumWithinClips) const
+{
+   // Cast the pointers to pass them to DoGet() which handles multiple
+   // destination formats
+   const auto castBuffers = reinterpret_cast<const samplePtr*>(buffers);
+   const auto result = DoGet(
+      iChannel, nBuffers, castBuffers,
+      floatSample, start, len, backwards, fill, mayThrow, pNumWithinClips);
+   if (!result)
+      while (nBuffers--)
+         ClearSamples(castBuffers[nBuffers], floatSample, 0, len);
+   return result;
+}

--- a/libraries/lib-mixer/WideSampleSequence.h
+++ b/libraries/lib-mixer/WideSampleSequence.h
@@ -53,18 +53,12 @@ public:
     @pre `iChannel + nBuffers <= NChannels()`
     @return false when `mayThrow` is false and not all samples could be
        retrieved
+    @post if return value is false, buffers are zero-filled
     */
    bool GetFloats(size_t iChannel, size_t nBuffers,
       float *const buffers[], sampleCount start, size_t len,
       bool backwards = false, fillFormat fill = FillFormat::fillZero,
-      bool mayThrow = true, sampleCount* pNumWithinClips = nullptr) const
-   {
-      // Cast the pointers to pass them to Get() which handles multiple
-      // destination formats
-      return Get(
-         iChannel, nBuffers, reinterpret_cast<const samplePtr*>(buffers),
-         floatSample, start, len, backwards, fill, mayThrow, pNumWithinClips);
-   }
+      bool mayThrow = true, sampleCount* pNumWithinClips = nullptr) const;
 
    //! Retrieve samples of one of the channels from a sequence in a specified
    //! format
@@ -73,8 +67,9 @@ public:
     @param format sample format of the destination buffer
     @param backward retrieves samples from `start` (inclusive) to `start + len`
     if false, else from `start` (exclusive) to `start - len` in reverse order.
+    @return whether successful; if not, assume nothing about buffer contents
     */
-   virtual bool Get(
+   virtual bool DoGet(
       size_t iChannel, size_t nBuffers, const samplePtr buffers[],
       sampleFormat format, sampleCount start, size_t len, bool backward,
       fillFormat fill = FillFormat::fillZero, bool mayThrow = true,

--- a/libraries/lib-stretching-sequence/StretchingSequence.cpp
+++ b/libraries/lib-stretching-sequence/StretchingSequence.cpp
@@ -89,7 +89,7 @@ float StretchingSequence::GetChannelGain(int channel) const
    return mSequence.GetChannelGain(channel);
 }
 
-bool StretchingSequence::Get(size_t iChannel, size_t nBuffers,
+bool StretchingSequence::DoGet(size_t iChannel, size_t nBuffers,
    const samplePtr buffers[], sampleFormat format, sampleCount start,
    size_t len, bool backwards, fillFormat fill,
    bool mayThrow, sampleCount* pNumWithinClips) const
@@ -158,7 +158,7 @@ bool StretchingSequence::GetFloats(
    for (auto i = 0u; i < nChannels; ++i)
       charBuffers.push_back(reinterpret_cast<samplePtr>(buffers[i]));
    constexpr auto iChannel = 0u;
-   return Get(
+   return DoGet(
       iChannel, nChannels, charBuffers.data(), sampleFormat::floatSample, start,
       len, backwards);
 }

--- a/libraries/lib-stretching-sequence/StretchingSequence.h
+++ b/libraries/lib-stretching-sequence/StretchingSequence.h
@@ -48,7 +48,7 @@ public:
    void GetEnvelopeValues(
       double* buffer, size_t bufferLen, double t0,
       bool backwards) const override;
-   bool Get(
+   bool DoGet(
       size_t iChannel, size_t nBuffers, const samplePtr buffers[],
       sampleFormat format, sampleCount start, size_t len, bool backwards,
       fillFormat fill = FillFormat::fillZero, bool mayThrow = true,

--- a/libraries/lib-stretching-sequence/tests/MockPlayableSequence.h
+++ b/libraries/lib-stretching-sequence/tests/MockPlayableSequence.h
@@ -22,7 +22,7 @@ public:
    }
 
    // WideSampleSequence
-   bool Get(
+   bool DoGet(
       size_t iChannel, size_t nBuffers, const samplePtr buffers[],
       sampleFormat format, sampleCount start, size_t len, bool backwards,
       fillFormat fill = FillFormat::fillZero, bool mayThrow = true,

--- a/libraries/lib-stretching-sequence/tests/StretchingSequenceIntegrationTest.cpp
+++ b/libraries/lib-stretching-sequence/tests/StretchingSequenceIntegrationTest.cpp
@@ -55,13 +55,13 @@ TEST_CASE("StretchingSequence integration tests")
       const auto track = trackMaker.Track({ minusClip, plusClip });
       constexpr auto backwards = false;
       AudioContainer sutOutput(totalLength, numChannels);
-      REQUIRE(sut->Get(
+      REQUIRE(sut->DoGet(
          iChannel, numChannels,
          AudioContainerHelper::GetData<char>(sutOutput).data(), floatSample, 0u,
          totalLength, backwards));
 
       AudioContainer waveTrackOutput(totalLength, numChannels);
-      REQUIRE(track->Get(
+      REQUIRE(track->DoGet(
          iChannel, numChannels,
          AudioContainerHelper::GetData<char>(waveTrackOutput).data(),
          floatSample, 0u, totalLength, backwards));

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2689,7 +2689,7 @@ float WaveChannel::GetRMS(double t0, double t1, bool mayThrow) const
    return duration > 0 ? sqrt(sumsq / duration) : 0.0;
 }
 
-bool WaveTrack::Get(size_t iChannel, size_t nBuffers,
+bool WaveTrack::DoGet(size_t iChannel, size_t nBuffers,
    const samplePtr buffers[], sampleFormat format,
    sampleCount start, size_t len, bool backwards, fillFormat fill,
    bool mayThrow, sampleCount* pNumWithinClips) const

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -518,7 +518,7 @@ public:
    ///
 
    //! This fails if any clip overlapping the range has non-unit stretch ratio!
-   bool Get(
+   bool DoGet(
       size_t iChannel, size_t nBuffers, const samplePtr buffers[],
       sampleFormat format, sampleCount start, size_t len, bool backwards,
       fillFormat fill = FillFormat::fillZero, bool mayThrow = true,

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -528,7 +528,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
       v = small1[i];
       auto pBlock = reinterpret_cast<samplePtr>(block.get());
       constexpr auto backwards = false;
-      t->Get(0, 1, &pBlock, SampleFormat, i * chunkSize, chunkSize, backwards);
+      t->DoGet(0, 1, &pBlock, SampleFormat, i * chunkSize, chunkSize, backwards);
       for (uint64_t b = 0; b < chunkSize; b++)
          if (block[b] != v) {
             bad++;
@@ -556,7 +556,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
       v = small1[i];
       auto pBlock = reinterpret_cast<samplePtr>(block.get());
       constexpr auto backwards = false;
-      t->Get(0, 1, &pBlock, SampleFormat, i * chunkSize, chunkSize, backwards);
+      t->DoGet(0, 1, &pBlock, SampleFormat, i * chunkSize, chunkSize, backwards);
       for (uint64_t b = 0; b < chunkSize; b++)
          if (block[b] != v)
             bad++;


### PR DESCRIPTION
... This simple fix will make plot spectrum show blank instead of garbage for a selection with any stretch.

Make zero-fill on failure part of the WideSampleSequence contract too, removing a redundant defense in MixerSource.

Unproblematic un-checked uses are in:
- effects (where there will be pre-rendering of the selection)
- WideSampleSource (using new promise of WideSampleSequence; and anyway where we assume an upstream stretching sequence decorator)
- NearestZeroCrossing() (there are tests before it is called)

Problematic uses:

- [x] WaveTrack::ReverseOneClip -- won't generally work, but it happens to be called only from an effect now ; fixed by https://github.com/audacity/audacity/pull/5138

- [x] [Find clipping](https://github.com/audacity/audacity/issues/5176) (in src/effects but an analyzer, not an effect)
- [x] Punch and Roll Recording (only to find crossfade data)
- [x] [Snapping to frequency peaks](https://github.com/audacity/audacity/issues/5179) (drag of spectral box centerline, and "Next Higher/Lower Peak Frequency" menu commands; see SelectHandle)
- [x] Compare Audio macro command
- [x] SpectrumTransformer as used by experimental brush tool (ok in Noise Reduction)

Resolves: *(direct link to the issue)*

QA:  Try the things enumerated above.  They may not work, but behave differently, always using zeroes instead of unpreditable data.

Issues:

- [x] Find Clipping does not generate labels in the Clipping label track on stretched clips.
- [x] Reverse audio on a stretched clip hangs Audacity.

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
