### PR TITLE
Fix silence audio command

### DIFF
--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -222,7 +222,8 @@ void TimeTrack::Paste(double t, const Track &src)
       (void)0;// intentionally do nothing.
 }
 
-void TimeTrack::Silence(double WXUNUSED(t0), double WXUNUSED(t1))
+void TimeTrack::Silence(
+   double WXUNUSED(t0), double WXUNUSED(t1), ProgressReporter)
 {
    assert(IsLeader());
 }

--- a/libraries/lib-time-track/TimeTrack.h
+++ b/libraries/lib-time-track/TimeTrack.h
@@ -57,7 +57,8 @@ class TIME_TRACK_API TimeTrack final
    TrackListHolder Copy(double t0, double t1, bool forClipboard) const override;
    void Clear(double t0, double t1) override;
    void Paste(double t, const Track &src) override;
-   void Silence(double t0, double t1) override;
+   void
+   Silence(double t0, double t1, ProgressReporter reportProgress = {}) override;
    void InsertSilence(double t, double len) override;
 
    // TimeTrack parameters

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -51,6 +51,8 @@ using ListOfTracks = std::list< std::shared_ptr< Track > >;
 using TrackNodePointer =
 std::pair< ListOfTracks::iterator, ListOfTracks* >;
 
+using ProgressReporter = std::function<void(double)>;
+
 inline bool operator == (const TrackNodePointer &a, const TrackNodePointer &b)
 { return a.second == b.second && a.first == b.first; }
 
@@ -381,7 +383,8 @@ public:
    /*!
     @pre `IsLeader()`
     */
-   virtual void Silence(double t0, double t1) = 0;
+   virtual void
+   Silence(double t0, double t1, ProgressReporter reportProgress = {}) = 0;
 
    /*!
     May assume precondition: t0 <= t1

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2027,11 +2027,13 @@ void WaveTrack::Paste(double t0, const Track &src)
       (void)0;// Empty if intentional.
 }
 
-void WaveTrack::Silence(double t0, double t1)
+void WaveTrack::Silence(double t0, double t1, ProgressReporter reportProgress)
 {
    assert(IsLeader());
    if (t1 < t0)
       THROW_INCONSISTENCY_EXCEPTION;
+
+   ApplyStretchRatio({ { t0, t1 } }, std::move(reportProgress));
 
    auto start = TimeToLongSamples(t0);
    auto end = TimeToLongSamples(t1);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -436,7 +436,7 @@ public:
          preserve, merge, effectWarper);
    }
 
-   void Silence(double t0, double t1) override;
+   void Silence(double t0, double t1, ProgressReporter reportProgress) override;
    void InsertSilence(double t, double len) override;
 
    /*!

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -855,8 +855,7 @@ void LabelTrack::SyncLockAdjust(double oldT1, double newT1)
    }
 }
 
-
-void LabelTrack::Silence(double t0, double t1)
+void LabelTrack::Silence(double t0, double t1, ProgressReporter)
 {
    assert(IsLeader());
    int len = mLabels.size();

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -134,7 +134,8 @@ public:
    bool Repeat(double t0, double t1, int n);
    void SyncLockAdjust(double oldT1, double newT1) override;
 
-   void Silence(double t0, double t1) override;
+   void
+   Silence(double t0, double t1, ProgressReporter reportProgress = {}) override;
    void InsertSilence(double t, double len) override;
 
    void Import(wxTextFile & f);

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -611,7 +611,7 @@ void NoteTrack::Paste(double t, const Track &src)
       (void)0;// intentionally do nothing
 }
 
-void NoteTrack::Silence(double t0, double t1)
+void NoteTrack::Silence(double t0, double t1, ProgressReporter)
 {
    assert(IsLeader());
    if (t1 < t0)

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -105,7 +105,8 @@ public:
    bool Trim (double t0, double t1) /* not override */;
    void Clear(double t0, double t1) override;
    void Paste(double t, const Track &src) override;
-   void Silence(double t0, double t1) override;
+   void
+   Silence(double t0, double t1, ProgressReporter reportProgress = {}) override;
    void InsertSilence(double t, double len) override;
    bool Shift(double t) /* not override */;
 

--- a/src/menus/LabelMenus.cpp
+++ b/src/menus/LabelMenus.cpp
@@ -525,7 +525,9 @@ void OnSilenceLabels(const CommandContext &context)
 
    auto editfunc = [&](Track &track, double t0, double t1) {
       assert(track.IsLeader());
-      track.TypeSwitch( [&](WaveTrack &t) { t.Silence(t0, t1); } );
+      // TODO use progress-bar utilities pending in
+      // https://github.com/audacity/audacity/pull/5043
+      track.TypeSwitch([&](WaveTrack& t) { t.Silence(t0, t1, {}); });
    };
    EditByLabel(project, tracks, selectedRegion, editfunc);
 
@@ -663,10 +665,10 @@ BaseItemSharedPtr LabelEditMenus()
       LabelsSelectedFlag() | WaveTracksExistFlag() | TimeSelectedFlag();
 
    // Returns TWO menus.
-   
+
    static BaseItemSharedPtr menus{
    Items( wxT("LabelEditMenus"),
-   
+
    Menu( wxT("Labels"), XXO("&Labels"),
       Section( "",
          Command( wxT("EditLabels"), XXO("Label &Editor"), OnEditLabels,


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Bug description: https://github.com/audacity/audacity/pull/5138#issuecomment-1713591482

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] "Silence Audio" command, across tracks and clips both stretched and unstretched. New clip boundaries should appear at an edge of the selection only if the clip underneath is stretched.
- [x] `Edit > Labeled Audio > Silence Audio` also works. (Note, though, that there isn't a progress bar for this yet. It's a bit trickier to introduce there, but #5043 has a utility that we will reuse for this once the utility is merged.)
