### PR TITLE
Fix beats formatter with weird tempos or when the time is large.

### DIFF
--- a/libraries/lib-numeric-formats/NumericConverter.cpp
+++ b/libraries/lib-numeric-formats/NumericConverter.cpp
@@ -80,6 +80,7 @@ void NumericConverter::ValueToControls(double rawValue, bool nearest /* = true *
    if (!mFormatter)
       return;
 
+   mFormatter->UpdateFormatForValue(rawValue);
    auto result = mFormatter->ValueToString(rawValue, nearest);
 
    mValueString = std::move(result.valueString);

--- a/libraries/lib-numeric-formats/NumericConverter.h
+++ b/libraries/lib-numeric-formats/NumericConverter.h
@@ -17,6 +17,7 @@
 #define __AUDACITY_NUMERIC_CONVERTER__
 
 #include <memory>
+#include <numeric>
 
 #include "NumericConverterType.h"
 #include "NumericConverterFormatter.h"
@@ -82,11 +83,11 @@ protected:
 
    NumericConverterType mType;
 
-   double         mValue;
-
-   double         mMinValue;
-   double         mMaxValue;
+   double         mMinValue { 0.0 };
+   double         mMaxValue { std::numeric_limits<double>::max() };
    double         mInvalidValue { -1 };
+
+   double         mValue { mInvalidValue };
 
    std::unique_ptr<NumericConverterFormatter>
                  mFormatter;

--- a/libraries/lib-numeric-formats/NumericConverterFormatter.cpp
+++ b/libraries/lib-numeric-formats/NumericConverterFormatter.cpp
@@ -42,10 +42,11 @@ NumericField::NumericField(size_t _digits, bool zeropad)
       formatStr = "%d";
 }
 
-NumericField NumericField::ForRange(size_t range, bool zeropad)
+NumericField NumericField::ForRange(size_t range, bool zeropad, size_t minDigits)
 {
    // Previously, Audacity used 5 digits by default (why?)
-   return NumericField(range > 1 ? CalculateDigits(range) : 5, zeropad);
+   return NumericField(
+      range > 1 ? std::max(minDigits, CalculateDigits(range)) : 5, zeropad);
 }
 
 NumericField NumericField::WithDigits(size_t digits, bool zeropad)
@@ -54,6 +55,10 @@ NumericField NumericField::WithDigits(size_t digits, bool zeropad)
 }
 
 NumericConverterFormatter::~NumericConverterFormatter()
+{
+}
+
+void NumericConverterFormatter::UpdateFormatForValue(double) 
 {
 }
 

--- a/libraries/lib-numeric-formats/NumericConverterFormatter.h
+++ b/libraries/lib-numeric-formats/NumericConverterFormatter.h
@@ -25,9 +25,9 @@ private:
    NumericField(size_t digits, bool zeropad);
 
 public:
-   static NumericField ForRange(size_t range, bool zeropad = true);
+   static NumericField ForRange(size_t range, bool zeropad = true, size_t minDigits = 0);
    static NumericField WithDigits(size_t digits, bool zeropad = true);
-   
+
    NumericField(const NumericField&) = default;
    NumericField& operator=(const NumericField&) = default;
    // NumericField( NumericField && ) = default;
@@ -66,6 +66,8 @@ struct NUMERIC_FORMATS_API NumericConverterFormatter /* not final */ :
       std::vector<wxString> fieldValueStrings;
    };
 
+   //! Potentially updates the format so it can fit the `value`. Default implementation is empty.
+   virtual void UpdateFormatForValue(double value);
    //! @post result: `GetFields().size() == result.fieldValueStrings.size()`
    virtual ConversionResult
    ValueToString(double value, bool nearest) const = 0;
@@ -74,7 +76,7 @@ struct NUMERIC_FORMATS_API NumericConverterFormatter /* not final */ :
    StringToValue(const wxString& value) const = 0;
 
    virtual double SingleStep(double value, int digitIndex, bool upwards) const = 0;
-   
+
    const wxString& GetPrefix() const;
    const NumericFields& GetFields() const;
    const DigitInfos& GetDigitInfos() const;

--- a/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
+++ b/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
@@ -249,7 +249,8 @@ public:
       for (size_t fieldIndex = 0; fieldIndex < mFields.size(); ++fieldIndex)
       {
          const auto fieldLength = mFieldLengths[fieldIndex];
-         const auto fieldValue = static_cast<int>(std::floor(value * eps / fieldLength));
+         const auto fieldValue = std::max(
+            0, static_cast<int>(std::floor(value * eps / fieldLength)));
 
          result.fieldValueStrings[fieldIndex] = wxString::Format(
             mFields[fieldIndex].formatStr, fieldValue + mFieldValueOffset);

--- a/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
+++ b/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
@@ -101,6 +101,53 @@ public:
          return mFields.size() == 2;
    }
 
+   void UpdateFields (size_t barsDigits)
+   {
+      mFields.clear();
+      mDigits.clear();
+
+      // Range is assumed to allow 999 bars.
+      auto& barsField =
+         mFields.emplace_back(NumericField::WithDigits(barsDigits));
+
+      barsField.label = L" " + mBarString + L" ";
+
+      // Beats format is 1 based. For the time point "0" the expected output is
+      // "1 bar 1 beat [1]" For this reason we use (uts + 1) as the "range". On
+      // top of that, we want at least two digits to be shown. NumericField
+      // accepts range as in [0, range), so add 1.
+
+      auto& beatsField = mFields.emplace_back(NumericField::ForRange(
+         std::max<size_t>(UPPER_BOUNDS[1], mUpperTimeSignature + 1)));
+
+      beatsField.label = L" " + mBeatString;
+
+      const auto hasFracPart = mFracPart > mLowerTimeSignature;
+
+      if (hasFracPart)
+      {
+         beatsField.label += L" ";
+         // See the reasoning above about the range
+         auto& fracField = mFields.emplace_back(NumericField::ForRange(
+            std::max(11, mFracPart / mLowerTimeSignature + 1)));
+      }
+
+      // Fill the aux mDigits structure
+      size_t pos = 0;
+      for (size_t i = 0; i < mFields.size(); i++)
+      {
+         mFields[i].pos = pos;
+
+         for (size_t j = 0; j < mFields[i].digits; j++)
+         {
+            mDigits.push_back(DigitInfo { i, j, pos });
+            pos++;
+         }
+
+         pos += mFields[i].label.length();
+      }
+   }
+
    void UpdateFormat(const AudacityProject& project)
    {
       auto& timeSignature = ProjectTimeSignature::Get(project);
@@ -137,47 +184,32 @@ public:
       if (formatOk)
          return ;
       
-      mFields.clear();
-      mDigits.clear();
-      
-      // Range is assumed to allow 999 bars.
-      auto& barsField =
-         mFields.emplace_back(NumericField::WithDigits(MIN_DIGITS[0]));
-      
-      barsField.label = L" " + mBarString + L" ";
+      UpdateFields(MIN_DIGITS[0]);
+   }
 
-      // Beats format is 1 based. For the time point "0" the expected output is
-      // "1 bar 1 beat [1]" For this reason we use (uts + 1) as the "range". On
-      // top of that, we want at least two digits to be shown. NumericField
-      // accepts range as in [0, range), so add 1.
+   void UpdateFormatForValue(double value) override
+   {
+      const bool negativeValue = value < 0;
 
-      auto& beatsField = mFields.emplace_back(NumericField::ForRange(
-         std::max<size_t>(UPPER_BOUNDS[1], mUpperTimeSignature + 1)));
-      
-      beatsField.label = L" " + mBeatString;
+      if (negativeValue)
+         value = -value;
 
-      if (hasFracPart)
-      {
-         beatsField.label += L" ";
-         // See the reasoning above about the range
-         auto& fracField = mFields.emplace_back(NumericField::ForRange(
-            std::max(11, mFracPart / mLowerTimeSignature + 1)));
-      }
+      // ForRange has a preserved weird behavior
+      const auto barsCount =
+         // Range is not inclusive
+         1 +
+         // Bars can start from 1
+         mFieldValueOffset +
+         static_cast<int>(std::floor(value / mFieldLengths[0]));
 
-      // Fill the aux mDigits structure
-      size_t pos = 0;
-      for (size_t i = 0; i < mFields.size(); i++)
-      {
-         mFields[i].pos = pos;
+      const auto barsField = NumericField::ForRange(
+         barsCount, true, MIN_DIGITS[0] + (negativeValue ? 1 : 0));
 
-         for (size_t j = 0; j < mFields[i].digits; j++)
-         {
-            mDigits.push_back(DigitInfo { i, j, pos });
-            pos++;
-         }
+      if (mFields[0].digits == barsField.digits)
+         return;
 
-         pos += mFields[i].label.length();
-      }
+      UpdateFields(barsField.digits);
+      Publish({});
    }
 
    void UpdateResultString(ConversionResult& result) const

--- a/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
+++ b/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
@@ -269,24 +269,28 @@ public:
          return std::nullopt;
 
       double t = 0.0;
-
+      size_t lastIndex = 0;
+      
       for (size_t i = 0; i < mFields.size(); i++)
       {
-         const auto pos = mFields[i].pos;
-         const auto digits = mFields[i].digits;
+         const auto& field = mFields[i];
 
-         if (pos >= valueString.size() || pos + digits > valueString.size())
-            return std::nullopt;
-
+         const size_t labelIndex = field.label.empty() ?
+                                      wxString::npos :
+                                      valueString.find(field.label, lastIndex); 
+            
          long val;
 
-         const auto fieldStringValue =
-            valueString.Mid(mFields[i].pos, mFields[i].digits);
+         const auto fieldStringValue = valueString.Mid(
+            lastIndex,
+            labelIndex == wxString::npos ? labelIndex : labelIndex - lastIndex);
 
          if (!fieldStringValue.ToLong(&val))
             return std::nullopt;
 
          t += (val - mFieldValueOffset) * mFieldLengths[i];
+
+         lastIndex = labelIndex + field.label.Length();
       }
 
       return t;

--- a/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
+++ b/libraries/lib-numeric-formats/formatters/BeatsNumericConverterFormatter.cpp
@@ -241,10 +241,15 @@ public:
          return result;
       }
 
+      // Calculate the epsilon only once, so the total loss of precision is addressed.
+      // This is a "multiplicative" epsilon, so there is no need to calculate 1 + eps every time.
+      const auto eps =
+         1.0 + std::max(1.0, value) * std::numeric_limits<double>::epsilon();
+
       for (size_t fieldIndex = 0; fieldIndex < mFields.size(); ++fieldIndex)
       {
          const auto fieldLength = mFieldLengths[fieldIndex];
-         const auto fieldValue = static_cast<int>(std::floor(value / fieldLength));
+         const auto fieldValue = static_cast<int>(std::floor(value * eps / fieldLength));
 
          result.fieldValueStrings[fieldIndex] = wxString::Format(
             mFields[fieldIndex].formatStr, fieldValue + mFieldValueOffset);

--- a/libraries/lib-numeric-formats/tests/NumericConverterTests.cpp
+++ b/libraries/lib-numeric-formats/tests/NumericConverterTests.cpp
@@ -194,6 +194,38 @@ TEST_CASE("BeatsNumericConverterFormatter", "")
    REQUIRE(durationFormatter->SingleStep(0.0, 1, true) == Approx(15.0));
    REQUIRE(durationFormatter->SingleStep(0.0, 4, true) == Approx(0.5));
    REQUIRE(durationFormatter->SingleStep(0.0, 3, true) == Approx(5));
+
+   timeSignature.SetTempo(117);
+   timeSignature.SetUpperTimeSignature(4);
+   timeSignature.SetLowerTimeSignature(4);
+
+   const auto t = *basicFormatter->StringToValue("009 bar 02 beat");
+   const auto r = basicFormatter->ValueToString(t, true).valueString;
+
+   REQUIRE("009 bar 02 beat" == r);
+
+   for (int32_t bar = 0; bar < 100000; ++bar)
+   {
+      for (int32_t beat = 0; beat < 4; ++beat)
+      {
+         const auto value =
+            bar * timeSignature.GetBarDuration() + beat * timeSignature.GetBeatDuration();
+         
+         basicFormatter->UpdateFormatForValue(value);
+         
+         const auto formattedString =
+            wxString::Format("%03d bar %02d beat", bar + 1, beat + 1);
+
+         REQUIRE(
+            *basicFormatter->StringToValue(formattedString) == Approx(value));
+
+         REQUIRE(
+            basicFormatter
+               ->ValueToString(
+                  *basicFormatter->StringToValue(formattedString), true)
+               .valueString == formattedString);
+      }
+   }
 }
 
 

--- a/libraries/lib-numeric-formats/tests/NumericConverterTests.cpp
+++ b/libraries/lib-numeric-formats/tests/NumericConverterTests.cpp
@@ -195,37 +195,44 @@ TEST_CASE("BeatsNumericConverterFormatter", "")
    REQUIRE(durationFormatter->SingleStep(0.0, 4, true) == Approx(0.5));
    REQUIRE(durationFormatter->SingleStep(0.0, 3, true) == Approx(5));
 
-   timeSignature.SetTempo(117);
-   timeSignature.SetUpperTimeSignature(4);
-   timeSignature.SetLowerTimeSignature(4);
-
-   const auto t = *basicFormatter->StringToValue("009 bar 02 beat");
-   const auto r = basicFormatter->ValueToString(t, true).valueString;
-
-   REQUIRE("009 bar 02 beat" == r);
-
-   for (int32_t bar = 0; bar < 100000; ++bar)
+   auto longFormatterTest = [&](double tempo)
    {
-      for (int32_t beat = 0; beat < 4; ++beat)
+      timeSignature.SetTempo(tempo);
+      timeSignature.SetUpperTimeSignature(4);
+      timeSignature.SetLowerTimeSignature(4);
+
+      //const auto t = *basicFormatter->StringToValue("009 bar 02 beat");
+      //const auto r = basicFormatter->ValueToString(t, true).valueString;
+
+      //REQUIRE("009 bar 02 beat" == r);
+
+      for (int32_t bar = 0; bar < 100000; ++bar)
       {
-         const auto value =
-            bar * timeSignature.GetBarDuration() + beat * timeSignature.GetBeatDuration();
-         
-         basicFormatter->UpdateFormatForValue(value);
-         
-         const auto formattedString =
-            wxString::Format("%03d bar %02d beat", bar + 1, beat + 1);
+         for (int32_t beat = 0; beat < 4; ++beat)
+         {
+            const auto value = bar * timeSignature.GetBarDuration() +
+                               beat * timeSignature.GetBeatDuration();
 
-         REQUIRE(
-            *basicFormatter->StringToValue(formattedString) == Approx(value));
+            basicFormatter->UpdateFormatForValue(value);
 
-         REQUIRE(
-            basicFormatter
-               ->ValueToString(
-                  *basicFormatter->StringToValue(formattedString), true)
-               .valueString == formattedString);
+            const auto formattedString =
+               wxString::Format("%03d bar %02d beat", bar + 1, beat + 1);
+
+            REQUIRE(
+               *basicFormatter->StringToValue(formattedString) ==
+               Approx(value));
+
+            REQUIRE(
+               basicFormatter
+                  ->ValueToString(
+                     *basicFormatter->StringToValue(formattedString), true)
+                  .valueString == formattedString);
+         }
       }
-   }
+   };
+
+   longFormatterTest(88);
+   longFormatterTest(117);
 }
 
 

--- a/libraries/lib-snapping/SnapUtils.cpp
+++ b/libraries/lib-snapping/SnapUtils.cpp
@@ -315,13 +315,25 @@ public:
          return { time, false };
       
       const auto multiplier = mMultiplierFunctor(project);
-      const auto step = (upwards ? 1.0 : -1.0) / multiplier;
-      const double result = time + step;
+
+      const auto eps =
+         std::max(1.0, time) * std::numeric_limits<double>::epsilon();
+
+      const auto current = static_cast<int>(std::floor(time * (1.0 + eps) * multiplier));
+      const auto next = upwards ? current + 1 : current - 1;
+
+      double result = next / multiplier;
 
       if (result < 0.0)
          return { 0.0, false };
 
-      return SnapWithMultiplier(result, multiplier, true);
+      while (static_cast<int>(std::floor(result * multiplier)) < next)
+         result += eps;
+
+      while (static_cast<int>(std::floor(result * multiplier)) > next)
+         result -= eps;
+
+      return { result, true };
    }
 
 private:

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -221,8 +221,6 @@ void MoveWhenAudioInactive
    // If TIME_UNIT_SECONDS, snap-to will be off.
    auto snapMode = settings.GetSnapMode();
    const double t0 = viewInfo.selectedRegion.t0();
-   const double end = std::max(
-      tracks.GetEndTime(), viewInfo.GetScreenEndTime());
 
    // Move the cursor
    // Already in cursor mode?
@@ -232,7 +230,6 @@ void MoveWhenAudioInactive
          t0, seekStep, timeUnit, snapMode);
       // constrain.
       newT = std::max(0.0, newT);
-      newT = std::min(newT, end);
       // Move
       viewInfo.selectedRegion.setT0(
          newT,


### PR DESCRIPTION
Resolves: #5039
Resolves: #4560

This PR fixes two issues with the beat formatter:

* Formatter was unable to handle more than 998 bars (little over half an hour with 120 BPM 4/4)
* `StringToValue(ValueToString(str)) == str`

To fix the keyboard navigation when snapping time clamping was tweaked a bit: `MoveWhenAudioInactive` updates the screen boundaries, but was breaking the snapping needlessly. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
