### PR TITLE
5053 clip stretch ratio indicator

### DIFF
--- a/libraries/lib-time-and-pitch/CMakeLists.txt
+++ b/libraries/lib-time-and-pitch/CMakeLists.txt
@@ -25,6 +25,7 @@ set( SOURCES
    AudioContainer.h
    StaffPadTimeAndPitch.cpp
    StaffPadTimeAndPitch.h
+   TimeAndPitchInterface.cpp
    TimeAndPitchInterface.h
 )
 set( LIBRARIES

--- a/libraries/lib-time-and-pitch/StaffPadTimeAndPitch.cpp
+++ b/libraries/lib-time-and-pitch/StaffPadTimeAndPitch.cpp
@@ -26,7 +26,9 @@ std::unique_ptr<staffpad::TimeAndPitch> MaybeCreateTimeAndPitch(
 {
    const auto timeRatio = params.timeRatio.value_or(1.);
    const auto pitchRatio = params.pitchRatio.value_or(1.);
-   if (timeRatio == 1. && pitchRatio == 1.)
+   if (
+      TimeAndPitchInterface::IsPassThroughMode(timeRatio) &&
+      TimeAndPitchInterface::IsPassThroughMode(pitchRatio))
    {
       return nullptr;
    }

--- a/libraries/lib-time-and-pitch/TimeAndPitchInterface.cpp
+++ b/libraries/lib-time-and-pitch/TimeAndPitchInterface.cpp
@@ -1,0 +1,12 @@
+#include "TimeAndPitchInterface.h"
+
+#include <cmath>
+
+TimeAndPitchSource::~TimeAndPitchSource() = default;
+
+TimeAndPitchInterface::~TimeAndPitchInterface() = default;
+
+bool TimeAndPitchInterface::IsPassThroughMode(double stretchRatio)
+{
+   return std::fabs(stretchRatio - 1.) < 1e-6;
+}

--- a/libraries/lib-time-and-pitch/TimeAndPitchInterface.h
+++ b/libraries/lib-time-and-pitch/TimeAndPitchInterface.h
@@ -18,13 +18,15 @@
 class TIME_AND_PITCH_API TimeAndPitchSource
 {
 public:
-   virtual ~TimeAndPitchSource() = default;
+   virtual ~TimeAndPitchSource();
    virtual void Pull(float* const*, size_t samplesPerChannel) = 0;
 };
 
 class TIME_AND_PITCH_API TimeAndPitchInterface
 {
 public:
+   static bool IsPassThroughMode(double stretchRatio);
+
    struct Parameters
    {
       std::optional<double> timeRatio;
@@ -33,5 +35,5 @@ public:
 
    virtual void GetSamples(float* const*, size_t) = 0;
 
-   virtual ~TimeAndPitchInterface() = default;
+   virtual ~TimeAndPitchInterface();
 };

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -22,11 +22,12 @@
 #include <wx/log.h>
 
 #include "BasicUI.h"
-#include "Sequence.h"
-#include "Prefs.h"
 #include "Envelope.h"
-#include "Resample.h"
 #include "InconsistencyException.h"
+#include "Prefs.h"
+#include "Resample.h"
+#include "Sequence.h"
+#include "TimeAndPitchInterface.h"
 #include "UserException.h"
 
 #ifdef _OPENMP
@@ -299,7 +300,8 @@ bool WaveClip::HasEqualStretchRatio(const WaveClip& other) const
 
 bool WaveClip::StretchRatioEquals(double value) const
 {
-   return fabs(GetStretchRatio() - value) < 1e-6;
+   return TimeAndPitchInterface::IsPassThroughMode(
+      1 + GetStretchRatio() - value);
 }
 
 sampleCount WaveClip::GetNumSamples() const

--- a/src/TrackArt.cpp
+++ b/src/TrackArt.cpp
@@ -289,9 +289,15 @@ wxString GetPlaybackSpeedFullText(double clipStretchRatio)
    return fullText;
 }
 
+enum class HAlign
+{
+   left,
+   right
+};
+
 struct ClipTitle {
    const wxString text;
-   const int alignment;
+   const HAlign alignment;
 };
 
 std::optional<ClipTitle> DoDrawAudioTitle(
@@ -300,16 +306,18 @@ std::optional<ClipTitle> DoDrawAudioTitle(
    if(titleRect.IsEmpty())
       return std::nullopt;
    const auto hAlign = wxTheApp->GetLayoutDirection() == wxLayout_RightToLeft ?
-                          wxALIGN_RIGHT :
-                          wxALIGN_LEFT;
-   const auto alignment = hAlign | wxALIGN_CENTER_VERTICAL;
+                          HAlign::right :
+                          HAlign::left;
    if(title.empty())
-      return ClipTitle { "", alignment  };
+      return ClipTitle { "", hAlign  };
    auto truncatedTitle = TrackArt::TruncateText(dc, title, titleRect.GetWidth());
    if (!truncatedTitle.empty())
    {
-      dc.DrawLabel(truncatedTitle, titleRect, alignment);
-      return ClipTitle{ truncatedTitle, alignment };
+      dc.DrawLabel(
+         truncatedTitle, titleRect,
+         (hAlign == HAlign::left ? wxALIGN_LEFT : wxALIGN_RIGHT) |
+            wxALIGN_CENTER_VERTICAL);
+      return ClipTitle{ truncatedTitle, hAlign };
    }
    return std::nullopt;
 }
@@ -337,12 +345,10 @@ bool TrackArt::DrawAudioClipTitle(
          titleRect.GetWidth() - dc.GetTextExtent(clipTitle->text).GetWidth() -
             minSpaceBetweenTitleAndSpeed,
          0);
-      const auto horizontalAlign =
-         (clipTitle->alignment & wxHORIZONTAL) == wxALIGN_LEFT ? wxALIGN_RIGHT :
-                                                                 wxALIGN_LEFT;
       dc.DrawLabel(
          TrackArt::TruncateText(dc, fullText, remainingWidth), titleRect,
-         horizontalAlign | wxALIGN_CENTER_VERTICAL);
+         (clipTitle->alignment == HAlign::left ? wxALIGN_RIGHT : wxALIGN_LEFT) |
+            wxALIGN_CENTER_VERTICAL);
    }
    return true;
 }

--- a/src/TrackArt.cpp
+++ b/src/TrackArt.cpp
@@ -15,6 +15,7 @@
 #include "SelectedRegion.h"
 #include "SyncLock.h"
 #include "Theme.h"
+#include "TimeAndPitchInterface.h"
 #include "Track.h"
 #include "TrackArtist.h"
 #include "TrackPanelDrawingContext.h"
@@ -248,21 +249,102 @@ wxRect TrackArt::DrawClipAffordance(wxDC& dc, const wxRect& rect, bool highlight
    return titleRect;
 }
 
-bool TrackArt::DrawClipTitle(wxDC &dc, const wxRect &titleRect, const wxString &title)
+namespace{
+wxString GetPlaybackSpeedFullText(double clipStretchRatio)
+{
+   // clang-format off
+   // We reckon that most of the time, a rounded percentage value is sufficient.
+   // There are two exceptions:
+   // - The clip is only slightly stretched such that the rounded value is 100.
+   //   There should be an indicator if and only if the clip is stretched, this
+   //   must be reliable. Yet showing "100%" would be confusing. Hence in that
+   //   case we constrain the values to [99.1, ..., 99.9, 100.1,
+   //   ..., 100.9], i.e., omitting 100.0.
+   // - The clip is stretched so much that the playback speed is less than 1%.
+   //   Make sure in that case that we never show 0%, but always at least 0.1%.
+   // clang-format on
+
+   const auto playbackSpeed = 100 / clipStretchRatio;
+   wxString fullText;
+
+   // We compare with .95 rather than 1, since playback speeds within [100.95,
+   // 101) get rounded to 101.0 and (99, 99.05] to 99.0 by `wxString::Format`.
+   // Let these be processed by the integer-display branch of this if statement
+   // instead.
+   if (fabs(playbackSpeed - 100.) < .95)
+      // Never show 100.0%
+      fullText = wxString::Format(
+         "Speed : %.1f%%", playbackSpeed > 100 ?
+                              std::max(playbackSpeed, 100.1) :
+                              std::min(playbackSpeed, 99.9));
+   else if (playbackSpeed < 1)
+      // Never show 0.0%
+      fullText =
+         wxString::Format("Speed : %.1f%%", std::max(playbackSpeed, 0.1));
+   else {
+      const auto roundedPlaybackSpeed =
+         static_cast<int>(std::round(playbackSpeed));
+      fullText = wxString::Format("Speed : %d%%", roundedPlaybackSpeed);
+   }
+   return fullText;
+}
+
+struct ClipTitle {
+   const wxString text;
+   const int alignment;
+};
+
+std::optional<ClipTitle> DoDrawAudioTitle(
+   wxDC& dc, const wxRect& titleRect, const wxString& title)
 {
    if(titleRect.IsEmpty())
-      return false;
+      return std::nullopt;
+   const auto hAlign = wxTheApp->GetLayoutDirection() == wxLayout_RightToLeft ?
+                          wxALIGN_RIGHT :
+                          wxALIGN_LEFT;
+   const auto alignment = hAlign | wxALIGN_CENTER_VERTICAL;
    if(title.empty())
-      return true;
-
+      return ClipTitle { "", alignment  };
    auto truncatedTitle = TrackArt::TruncateText(dc, title, titleRect.GetWidth());
    if (!truncatedTitle.empty())
    {
-      auto hAlign = wxTheApp->GetLayoutDirection() == wxLayout_RightToLeft ? wxALIGN_RIGHT : wxALIGN_LEFT;
-      dc.DrawLabel(truncatedTitle, titleRect, hAlign | wxALIGN_CENTER_VERTICAL);
-      return true;
+      dc.DrawLabel(truncatedTitle, titleRect, alignment);
+      return ClipTitle{ truncatedTitle, alignment };
    }
-   return false;
+   return std::nullopt;
+}
+
+}
+
+bool TrackArt::DrawClipTitle(
+   wxDC& dc, const wxRect& titleRect, const wxString& title)
+{
+   return DoDrawAudioTitle(dc, titleRect, title).has_value();
+}
+
+bool TrackArt::DrawAudioClipTitle(
+   wxDC& dc, const wxRect& titleRect, const wxString& title,
+   double clipStretchRatio)
+{
+   const auto clipTitle = DoDrawAudioTitle(dc, titleRect, title);
+   if (!clipTitle.has_value())
+      return false;
+   if (!TimeAndPitchInterface::IsPassThroughMode(clipStretchRatio))
+   {
+      const auto fullText = GetPlaybackSpeedFullText(clipStretchRatio);
+      constexpr auto minSpaceBetweenTitleAndSpeed = 12; // pixels
+      const auto remainingWidth = std::max(
+         titleRect.GetWidth() - dc.GetTextExtent(clipTitle->text).GetWidth() -
+            minSpaceBetweenTitleAndSpeed,
+         0);
+      const auto horizontalAlign =
+         (clipTitle->alignment & wxHORIZONTAL) == wxALIGN_LEFT ? wxALIGN_RIGHT :
+                                                                 wxALIGN_LEFT;
+      dc.DrawLabel(
+         TrackArt::TruncateText(dc, fullText, remainingWidth), titleRect,
+         horizontalAlign | wxALIGN_CENTER_VERTICAL);
+   }
+   return true;
 }
 
 void TrackArt::DrawClipEdges(wxDC& dc, const wxRect& clipRect, bool selected)
@@ -500,7 +582,7 @@ void DrawBackground (
       dc.DrawRectangle(subRect);
       return;
    }
-   
+
    auto [firstIndex, lastIndex] =
       GetBoundaries (subRect, fullRect, noteWidth);
 
@@ -539,7 +621,7 @@ private:
 
       return *track.GetOwner()->GetOwner();
    }
-   
+
    int64_t CalculateNotesInBeat() const
    {
       if (UseAlternatingColors())
@@ -555,7 +637,7 @@ private:
 
       if (notesInMajorTick == 0)
          return false;
-      
+
       return noteIndex % notesInMajorTick == 0;
    }
 
@@ -593,7 +675,7 @@ private:
                                 subdivision.minor;
 
       while (minorMinorLength <= minSubdivisionWidth)
-      {         
+      {
          tick.lower /= 2;
          tick.duration *= 2.0;
          minorMinorLength *= 2.0;
@@ -617,7 +699,7 @@ void TrackArt::DrawBackgroundWithSelection(
    const auto &selectedRegion = *artist->pSelectedRegion;
    const auto& zoomInfo = *artist->pZoomInfo;
 
-   
+
    //MM: Draw background. We should optimize that a bit more.
    const double sel0 = useSelection ? selectedRegion.t0() : 0.0;
    const double sel1 = useSelection ? selectedRegion.t1() : 0.0;
@@ -711,7 +793,7 @@ void TrackArt::DrawCursor(TrackPanelDrawingContext& context,
    const auto dc = &context.dc;
    const auto artist = TrackArtist::Get(context);
    const auto& selectedRegion = *artist->pSelectedRegion;
-   
+
    if (selectedRegion.isPoint())
    {
        const auto& zoomInfo = *artist->pZoomInfo;

--- a/src/TrackArt.cpp
+++ b/src/TrackArt.cpp
@@ -345,10 +345,16 @@ bool TrackArt::DrawAudioClipTitle(
          titleRect.GetWidth() - dc.GetTextExtent(clipTitle->text).GetWidth() -
             minSpaceBetweenTitleAndSpeed,
          0);
-      dc.DrawLabel(
-         TrackArt::TruncateText(dc, fullText, remainingWidth), titleRect,
-         (clipTitle->alignment == HAlign::left ? wxALIGN_RIGHT : wxALIGN_LEFT) |
-            wxALIGN_CENTER_VERTICAL);
+      const auto truncatedText =
+         TrackArt::TruncateText(dc, fullText, remainingWidth);
+      if (truncatedText.find('%') != std::string::npos)
+         // Only show if there is room for the % sign, or else it can be hard to
+         // interpret.
+         dc.DrawLabel(
+            TrackArt::TruncateText(dc, fullText, remainingWidth), titleRect,
+            (clipTitle->alignment == HAlign::left ? wxALIGN_RIGHT :
+                                                    wxALIGN_LEFT) |
+               wxALIGN_CENTER_VERTICAL);
    }
    return true;
 }

--- a/src/TrackArt.cpp
+++ b/src/TrackArt.cpp
@@ -274,17 +274,17 @@ wxString GetPlaybackSpeedFullText(double clipStretchRatio)
    if (fabs(playbackSpeed - 100.) < .95)
       // Never show 100.0%
       fullText = wxString::Format(
-         "Speed : %.1f%%", playbackSpeed > 100 ?
+         "%.1f%% speed", playbackSpeed > 100 ?
                               std::max(playbackSpeed, 100.1) :
                               std::min(playbackSpeed, 99.9));
    else if (playbackSpeed < 1)
       // Never show 0.0%
       fullText =
-         wxString::Format("Speed : %.1f%%", std::max(playbackSpeed, 0.1));
+         wxString::Format("%.1f%% speed", std::max(playbackSpeed, 0.1));
    else {
       const auto roundedPlaybackSpeed =
          static_cast<int>(std::round(playbackSpeed));
-      fullText = wxString::Format("Speed : %d%%", roundedPlaybackSpeed);
+      fullText = wxString::Format("%d%% speed", roundedPlaybackSpeed);
    }
    return fullText;
 }

--- a/src/TrackArt.h
+++ b/src/TrackArt.h
@@ -30,6 +30,11 @@ namespace TrackArt {
    bool DrawClipTitle(wxDC& dc, const wxRect& titleRect, const wxString& title);
 
    AUDACITY_DLL_API
+   bool DrawAudioClipTitle(
+      wxDC& dc, const wxRect& titleRect, const wxString& title,
+      double clipStretchRatio);
+
+   AUDACITY_DLL_API
    void DrawClipEdges(wxDC& dc, const wxRect& clipRect, bool selected = false);
 
    //Used to draw clip boundaries without contents/details when it's not

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -86,7 +86,7 @@ public:
     WaveClipTitleEditHandle(const std::shared_ptr<TextEditHelper>& helper)
         : mHelper(helper)
     { }
-   
+
    ~WaveClipTitleEditHandle()
    {
    }
@@ -231,7 +231,7 @@ void WaveTrackAffordanceControls::Draw(TrackPanelDrawingContext& context, const 
         TrackArt::DrawBackgroundWithSelection(context, rect, track.get(), artist->blankSelectedBrush, artist->blankBrush);
 
         mLastVisibleClips.clear();
-       
+
         const auto waveTrack = std::static_pointer_cast<WaveTrack>(track->SubstitutePendingChangedTrack());
         const auto& zoomInfo = *artist->pZoomInfo;
         {
@@ -263,11 +263,15 @@ void WaveTrackAffordanceControls::Draw(TrackPanelDrawingContext& context, const 
                     if(!mTextEditHelper->Draw(context.dc, titleRect))
                     {
                         mTextEditHelper->Cancel(nullptr);
-                        TrackArt::DrawClipTitle(context.dc, titleRect, clip->GetName());
+                        TrackArt::DrawAudioClipTitle(
+                           context.dc, titleRect, clip->GetName(),
+                           clip->GetStretchRatio());
                     }
                 }
-                else if(TrackArt::DrawClipTitle(context.dc, titleRect, clip->GetName()))
-                    mLastVisibleClips.push_back(clip.get());
+                else if (TrackArt::DrawAudioClipTitle(
+                            context.dc, titleRect, clip->GetName(),
+                            clip->GetStretchRatio()))
+                   mLastVisibleClips.push_back(clip.get());
             }
         }
 
@@ -303,14 +307,14 @@ bool WaveTrackAffordanceControls::StartEditClipName(AudacityProject& project, co
     {
         if(!IsClipNameVisible(*clip))
            return false;
-       
+
         if (mTextEditHelper)
             mTextEditHelper->Finish(&project);
 
         mEditedClip = clip;
         mTextEditHelper = MakeTextEditHelper(clip->GetName());
     }
-   
+
     return true;
 }
 
@@ -370,7 +374,7 @@ const ReservedCommandFlag &SomeClipIsSelectedFlag()
 
 unsigned WaveTrackAffordanceControls::CaptureKey(wxKeyEvent& event, ViewInfo& viewInfo, wxWindow* pParent, AudacityProject* project)
 {
-    if (!mTextEditHelper 
+    if (!mTextEditHelper
        || !mTextEditHelper->CaptureKey(event.GetKeyCode(), event.GetModifiers()))
        // Handle the event if it can be processed by the text editor (if any)
        event.Skip();
@@ -381,10 +385,10 @@ unsigned WaveTrackAffordanceControls::CaptureKey(wxKeyEvent& event, ViewInfo& vi
 unsigned WaveTrackAffordanceControls::KeyDown(wxKeyEvent& event, ViewInfo& viewInfo, wxWindow*, AudacityProject* project)
 {
     auto keyCode = event.GetKeyCode();
-    
+
     if (mTextEditHelper)
     {
-       if (!mTextEditHelper->OnKeyDown(keyCode, event.GetModifiers(), project) 
+       if (!mTextEditHelper->OnKeyDown(keyCode, event.GetModifiers(), project)
           && !TextEditHelper::IsGoodEditKeyCode(keyCode))
           event.Skip();
 
@@ -546,7 +550,7 @@ std::shared_ptr<TextEditHelper> WaveTrackAffordanceControls::MakeTextEditHelper(
     auto helper = std::make_shared<TextEditHelper>(shared_from_this(), text, mClipNameFont);
     helper->SetTextColor(theTheme.Colour(clrClipNameText));
     helper->SetTextSelectionColor(theTheme.Colour(clrClipNameTextSelection));
-    return helper; 
+    return helper;
 }
 
 // Register a menu item
@@ -558,7 +562,7 @@ namespace {
 void OnEditClipName(const CommandContext &context)
 {
    auto &project = context.project;
-   
+
    if(auto pWaveTrack = dynamic_cast<WaveTrack *>(TrackFocus::Get(project).Get()))
    {
       if(auto pAffordance = FindAffordance(*pWaveTrack))


### PR DESCRIPTION
Resolves: #5053

Add a stretch indicator to the clips.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Create a new clip with reasonable width: no stretching hence no indicator.
- [x] Change project tempo: the indicator appears
- [x] Restore original project tempo: the indicator disappears
- [x] Stretch the clip: the indicator re-appears
- [x] When the clip becomes too small, the indicator should get truncated (E.g. "100% sp...") or completely disappear
- [x] The indicator disappears if there isn't enough room for the "%" symbol. In other words, you never see a number without the % symbol, e.g., "123%" is possible, but not "123".
- [x] There is always a little space between clip title and speed indicator.
- [x] When `101 < speed < 99` %, either no indicator because there is no stretching, or the indicator shows a value with 1 decimal place, e.g. 100.7, or 99.4 %.
- [x] When `speed < 1%`, the indicator shows a value with 1 decimal place, e.g. 0.4 %. It never goes to 0%, and stays at least at 0.1%.
- [x] Renaming a clip is still ok. Giving an empty string to the clip title is also ok.
- [x] Try Arabic or Hebrew locale and verify the numbers don't overlap text with right-to-left languages