### PR TITLE
Remove TrackList::Channels in ImportAUP.cpp...

### DIFF
--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -1371,20 +1371,18 @@ bool AUPImportFileHandle::HandleImport(XMLTagHandler *&handler)
    mAttrs.erase(mAttrs.begin());
 
    for (auto pTrack: range.Filter<WaveTrack>()) {
-      for (const auto pChannel : TrackList::Channels(pTrack)) {
-         // Most of the "import" tag attributes are the same as for "wavetrack" tags,
-         // so apply them via WaveTrack::HandleXMLTag().
-         bSuccess = pChannel->HandleXMLTag("wavetrack", mAttrs);
+      // Most of the "import" tag attributes are the same as for "wavetrack" tags,
+      // so apply them via WaveTrack::HandleXMLTag().
+      bSuccess = pTrack->HandleXMLTag("wavetrack", mAttrs);
 
-         // "offset" tag is ignored in WaveTrack::HandleXMLTag except for legacy projects,
-         // so handle it here.
-         double dblValue;
-         for (auto pair : mAttrs) {
-            auto attr = pair.first;
-            auto value = pair.second;
-            if (attr == "offset" && value.TryGet(dblValue) && pChannel->IsLeader())
-               pChannel->MoveTo(dblValue);
-         }
+      // "offset" tag is ignored in WaveTrack::HandleXMLTag except for legacy projects,
+      // so handle it here.
+      double dblValue;
+      for (auto pair : mAttrs) {
+         auto attr = pair.first;
+         auto value = pair.second;
+         if (attr == "offset" && value.TryGet(dblValue))
+            pTrack->MoveTo(dblValue);
       }
    }
    return bSuccess;


### PR DESCRIPTION
... This function only restored track properties that are now all de-duplicated and never varied independently between channels -- with one unimportant exception -- so visiting leader tracks only is all we need.

The exception is that wave channel view heights might vary independently. But experiment with 2.4.2 shows that wave channel view height differences were lost anyway when File > Save Lossless Copy or Save Compressed Copy commands were used.

Only files saved with those commands can cause this function to be visited when importing into 3.4.

Resolves: *(direct link to the issue)*

QA: First follow steps in #5211.  (This PR is NOT the fix for that issue.)
Then verify that opening the compressed and lossless 2.4.2 projects still makes good 3.4 projects.

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
