### PR TITLE
Remove the "click to merge clips" line

### DIFF
--- a/src/WaveTrackLocation.h
+++ b/src/WaveTrackLocation.h
@@ -18,23 +18,16 @@ class WaveTrack;
 
 struct WaveTrackLocation {
 
-   enum LocationType {
-      locationCutLine = 1,
-      locationMergePoint
-   };
-
    WaveTrackLocation() = default;
 
-   WaveTrackLocation(double pos, LocationType typ,
-    int clipidx1 = -1, int clipidx2 = -1
-   )  : pos{ pos }, typ{ typ }, clipidx1{ clipidx1 }, clipidx2{ clipidx2 }
+   WaveTrackLocation(double pos, int clipidx1 = -1, int clipidx2 = -1)
+       : pos { pos }
+       , clipidx1 { clipidx1 }
+       , clipidx2 { clipidx2 }
    {}
 
    // Position of track location
    double pos{ 0.0 };
-
-   // Type of track location
-   LocationType typ{ locationCutLine };
 
    // Only for typ==locationMergePoint
    int clipidx1{ -1 }; // first clip (left one)
@@ -45,7 +38,6 @@ inline
 bool operator == (const WaveTrackLocation &a, const WaveTrackLocation &b)
 {
    return a.pos == b.pos &&
-   a.typ == b.typ &&
    a.clipidx1 == b.clipidx1 &&
    a.clipidx2 == b.clipidx2;
 }

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
@@ -187,10 +187,6 @@ UIHandle::Result CutlineHandle::Release
    switch (mOperation) {
    default:
       wxASSERT(false);
-   case Merge:
-      ProjectHistory::Get( *pProject )
-         .PushState(XO("Merged Clips"), XO("Merge"), UndoPush::CONSOLIDATE);
-      break;
    case Expand:
       ProjectHistory::Get( *pProject )
          .PushState(XO("Expanded Cut Line"), XO("Expand"));

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
@@ -21,7 +21,7 @@ class WaveTrack;
 class CutlineHandle final : public UIHandle
 {
    CutlineHandle(const CutlineHandle&) = delete;
-   static HitTestPreview HitPreview(bool cutline, bool unsafe);
+   static HitTestPreview HitPreview(bool unsafe);
 
 public:
    explicit CutlineHandle(const std::shared_ptr<WaveTrack> &pTrack,

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.h
@@ -66,8 +66,8 @@ public:
 
 private:
    std::shared_ptr<WaveTrack> mpTrack{};
-   enum Operation { Merge, Expand, Remove };
-   Operation mOperation{ Merge };
+   enum Operation { Expand, Remove };
+   Operation mOperation{ Expand };
    double mStartTime{}, mEndTime{};
    WaveTrackLocations mLocations;
    WaveTrackLocation mLocation{};

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -848,17 +848,7 @@ void WaveChannelSubView::DrawBoldBoundaries(
       if (xx >= 0 && xx < rect.width) {
          dc.SetPen( highlightLoc ? AColor::uglyPen : *wxGREY_PEN );
          AColor::Line(dc, (int) (rect.x + xx - 1), rect.y, (int) (rect.x + xx - 1), rect.y + rect.height);
-         if (loc.typ == WaveTrackLocation::locationCutLine) {
-            dc.SetPen( highlightLoc ? AColor::uglyPen : *wxRED_PEN );
-         }
-         else {
-#ifdef EXPERIMENTAL_DA
-            // JKC Black does not show up enough.
-            dc.SetPen(highlightLoc ? AColor::uglyPen : *wxWHITE_PEN);
-#else
-            dc.SetPen(highlightLoc ? AColor::uglyPen : *wxBLACK_PEN);
-#endif
-         }
+         dc.SetPen( highlightLoc ? AColor::uglyPen : *wxRED_PEN );
          AColor::Line(dc, (int) (rect.x + xx), rect.y, (int) (rect.x + xx), rect.y + rect.height);
          dc.SetPen( highlightLoc ? AColor::uglyPen : *wxGREY_PEN );
          AColor::Line(dc, (int) (rect.x + xx + 1), rect.y, (int) (rect.x + xx + 1), rect.y + rect.height);


### PR DESCRIPTION
Resolves: #2330

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Does this PR fix https://github.com/audacity/audacity/issues/2263 ? If so, please close.
- [x] Bold vertical line between adjacent clips is not visible anymore, whether at sample-zoom level or not.
- [x] Clicking at junction of adjacent clips doesn't merge them anymore.
- [x] `Edit > Audio Clips > Join` still works (not with stretched clips, though - will be fixed by #5043
- [x] Cutlines still work
