### PR TITLE
Fix reads of uninitialized data in lib-time-and-pitch...

### DIFF
--- a/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
+++ b/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
@@ -166,6 +166,7 @@ void TimeAndPitch::reset()
       d->outCircularBuffer[ch].reset();
    }
    d->normalizationBuffer.reset();
+   d->last_mag.zeroOut();
    d->last_phase.zeroOut();
    d->phase_accum.zeroOut();
    _outBufferWriteOffset = 0;


### PR DESCRIPTION
... These changes appear seem to make mix-and-render give repeatable results.

I don't understand why.  Possibly only some of these changes are sufficient.  I don't know which.

UPDATE:  I do understand why!  After more study of the algorithm.

Resolves: [5210](https://github.com/audacity/audacity/issues/5210)

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
