### PR TITLE
Consistensy checks added to AUP importer

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2435,6 +2435,11 @@ void WaveTrack::Flush()
       pChannel->FlushOne();
 }
 
+void WaveTrack::SetLegacyFormat(sampleFormat format)
+{
+   mLegacyFormat = format;
+}
+
 /*! @excsafety{Mixed} */
 /*! @excsafety{No-fail} -- The rightmost clip will be in a flushed state. */
 /*! @excsafety{Partial}
@@ -2512,7 +2517,7 @@ bool WaveTrack::HandleXMLTag(const std::string_view& tag, const AttributesList &
                   Sequence::IsValidSampleFormat(nValue))
          {
             //Remember sample format until consistency check is performed.
-            mLegacyFormat = static_cast<sampleFormat>(nValue);
+            SetLegacyFormat(static_cast<sampleFormat>(nValue));
          }
       } // while
       return true;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -999,6 +999,9 @@ public:
 
    size_t NIntervals() const override;
 
+   //!< used only during deserialization
+   void SetLegacyFormat(sampleFormat format);
+
 private:
    void FlushOne();
    // May assume precondition: t0 <= t1

--- a/src/ProjectFileManager.h
+++ b/src/ProjectFileManager.h
@@ -105,6 +105,16 @@ public:
    bool GetMenuClose() const { return mMenuClose; }
    void SetMenuClose(bool value) { mMenuClose = value; }
 
+   /*!
+    * \brief Attempts to find and fix problems in tracks.
+    * \param tracks A list of tracks to be fixed
+    * \param onError Called each time unrepairable error has been found.
+    * \param onUnlink Called when tracks unlinked due to link inconsistency.
+    */
+   static void FixTracks(TrackList& tracks,
+                         const std::function<void(const TranslatableString&/*errorMessage*/)>& onError,
+                         const std::function<void(const TranslatableString&/*unlinkReason*/)>& onUnlink);
+
 private:
    /*!
     @param fileName a path assumed to exist and contain an .aup3 project


### PR DESCRIPTION
Resolves: #5211
Resolves: #5304

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:  Might want to wait until this is rebased onto #5260 
   - [x] Save 2.4.2 projects with misaligned stereo, mismatched channel formats, mismatched channel rates
   - [x] Open them in 3.4, seeing similar warnings and same splitting, as when opening 3.x legacy projects with similar
   - [ ] 2.4.2 projects without those problems open with no warnings
