### PR TITLE
5124 improve time stretching quality for high sample rates

### DIFF
--- a/libraries/lib-stretching-sequence/ClipSegment.cpp
+++ b/libraries/lib-stretching-sequence/ClipSegment.cpp
@@ -41,7 +41,8 @@ ClipSegment::ClipSegment(
          clip, durationToDiscard) }
     , mSource { clip, durationToDiscard, direction }
     , mStretcher { std::make_unique<StaffPadTimeAndPitch>(
-         clip.GetWidth(), mSource, GetStretchingParameters(clip)) }
+         clip.GetRate(), clip.GetWidth(), mSource,
+         GetStretchingParameters(clip)) }
 {
 }
 

--- a/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
+++ b/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
@@ -43,6 +43,17 @@ inline float lagrange6(const float (&smp)[6], float t)
   return (c0 + c1 * t) + (c2 + c3 * t) * t2 + (c4 + c5 * t) * t2 * t2;
 }
 
+inline int getFftSize(int sampleRate)
+{
+  // 44.1kHz maps to 4096 samples (i.e., 93ms).
+  // We grow the FFT size proportionally with the sample rate to keep the
+  // window duration roughly constant, with quantization due to the
+  // power-of-two constraint.
+  // If needed some time in the future, we can decouple analysis window and
+  // FFT sizes by zero-padding, allowing for very fine-grained window duration
+  // without compromising performance.
+  return 1 << (12 + (int)std::round(std::log2(sampleRate / 44100.)));
+}
 } // namespace
 
 struct TimeAndPitch::impl
@@ -75,6 +86,11 @@ struct TimeAndPitch::impl
 
   std::vector<int> peak_index, trough_index;
 };
+
+TimeAndPitch::TimeAndPitch(int sampleRate)
+    : fftSize(getFftSize(sampleRate))
+{
+}
 
 TimeAndPitch::~TimeAndPitch()
 {

--- a/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.h
+++ b/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.h
@@ -11,7 +11,7 @@ namespace staffpad {
 class TimeAndPitch
 {
 public:
-  TimeAndPitch() = default;
+  TimeAndPitch(int sampleRate);
   ~TimeAndPitch();
 
   /**
@@ -76,7 +76,7 @@ public:
   void reset();
 
 private:
-  static constexpr int fftSize = 4096;
+  const int fftSize;
   static constexpr int overlap = 4;
   static constexpr bool normalize_window = true; // compensate for ola window overlaps
   static constexpr bool modulate_synthesis_hop = true;

--- a/libraries/lib-time-and-pitch/StaffPadTimeAndPitch.cpp
+++ b/libraries/lib-time-and-pitch/StaffPadTimeAndPitch.cpp
@@ -22,7 +22,8 @@ GetOffsetBuffer(float* const* buffer, size_t numChannels, size_t offset)
 }
 
 std::unique_ptr<staffpad::TimeAndPitch> MaybeCreateTimeAndPitch(
-   size_t numChannels, const TimeAndPitchInterface::Parameters& params)
+   int sampleRate, size_t numChannels,
+   const TimeAndPitchInterface::Parameters& params)
 {
    const auto timeRatio = params.timeRatio.value_or(1.);
    const auto pitchRatio = params.pitchRatio.value_or(1.);
@@ -32,7 +33,7 @@ std::unique_ptr<staffpad::TimeAndPitch> MaybeCreateTimeAndPitch(
    {
       return nullptr;
    }
-   auto timeAndPitch = std::make_unique<staffpad::TimeAndPitch>();
+   auto timeAndPitch = std::make_unique<staffpad::TimeAndPitch>(sampleRate);
    timeAndPitch->setup(static_cast<int>(numChannels), maxBlockSize);
    timeAndPitch->setTimeStretchAndPitchFactor(timeRatio, pitchRatio);
    return timeAndPitch;
@@ -40,13 +41,14 @@ std::unique_ptr<staffpad::TimeAndPitch> MaybeCreateTimeAndPitch(
 } // namespace
 
 StaffPadTimeAndPitch::StaffPadTimeAndPitch(
-   size_t numChannels, TimeAndPitchSource& audioSource,
+   int sampleRate, size_t numChannels, TimeAndPitchSource& audioSource,
    const Parameters& parameters)
     : mAudioSource(audioSource)
     , mReadBuffer(maxBlockSize, numChannels)
     , mNumChannels(numChannels)
     , mTimeRatio(parameters.timeRatio.value_or(1.))
-    , mTimeAndPitch(MaybeCreateTimeAndPitch(numChannels, parameters))
+    , mTimeAndPitch(
+         MaybeCreateTimeAndPitch(sampleRate, numChannels, parameters))
 {
    BootStretcher();
 }

--- a/libraries/lib-time-and-pitch/StaffPadTimeAndPitch.h
+++ b/libraries/lib-time-and-pitch/StaffPadTimeAndPitch.h
@@ -9,7 +9,8 @@ class TIME_AND_PITCH_API StaffPadTimeAndPitch final :
 {
 public:
    StaffPadTimeAndPitch(
-      size_t numChannels, TimeAndPitchSource&, const Parameters&);
+      int sampleRate, size_t numChannels, TimeAndPitchSource&,
+      const Parameters&);
    void GetSamples(float* const*, size_t) override;
 
 private:

--- a/libraries/lib-time-and-pitch/tests/StaffPadTimeAndPitchTest.cpp
+++ b/libraries/lib-time-and-pitch/tests/StaffPadTimeAndPitchTest.cpp
@@ -61,7 +61,8 @@ TEST_CASE("StaffPadTimeAndPitch")
             params.timeRatio = tr;
             params.pitchRatio = pr;
             TimeAndPitchRealSource src(input);
-            StaffPadTimeAndPitch sut(info.numChannels, src, std::move(params));
+            StaffPadTimeAndPitch sut(
+               info.sampleRate, info.numChannels, src, std::move(params));
             constexpr size_t blockSize = 1234u;
             auto offset = 0u;
             while (offset < numOutputFrames)
@@ -104,7 +105,8 @@ TEST_CASE("StaffPadTimeAndPitch")
       AudioContainer container(info.numFrames, info.numChannels);
       TimeAndPitchInterface::Parameters params;
       TimeAndPitchRealSource src(input);
-      StaffPadTimeAndPitch sut(info.numChannels, src, std::move(params));
+      StaffPadTimeAndPitch sut(
+         info.sampleRate, info.numChannels, src, std::move(params));
       sut.GetSamples(container.Get(), info.numFrames);
       // Calling REQUIRE(container.channelVectors == input) directly for large
       // vectors might be rough on stdout in case of an error printout ...
@@ -114,16 +116,20 @@ TEST_CASE("StaffPadTimeAndPitch")
 
    SECTION("Extreme stretch ratios")
    {
-      constexpr auto originalDuration = 60.; // 1 minute
+      constexpr auto originalDuration = 60.;      // 1 minute
       constexpr auto targetDuration = 1. / 44100; // 1 sample
       constexpr auto superSmallRatio = targetDuration / originalDuration;
-      constexpr auto requestedNumSamples = 1; // ... a single sample, but which is the condensed form of one minute of audio :D
+      constexpr auto requestedNumSamples =
+         1; // ... a single sample, but which is the condensed form of one
+            // minute of audio :D
       constexpr auto numChannels = 1;
       TimeAndPitchFakeSource src;
       AudioContainer container(requestedNumSamples, numChannels);
       TimeAndPitchInterface::Parameters params;
       params.timeRatio = superSmallRatio;
-      StaffPadTimeAndPitch sut(numChannels, src, std::move(params));
-      sut.GetSamples(container.Get(), requestedNumSamples); // This is just not supposed to hang.
+      StaffPadTimeAndPitch sut(44100, numChannels, src, std::move(params));
+      sut.GetSamples(
+         container.Get(),
+         requestedNumSamples); // This is just not supposed to hang.
    }
 }

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1228,7 +1228,7 @@ void WaveClip::ApplyStretchRatio(const ProgressReporter& reportProgress)
                                             PlaybackDirection::forward };
    TimeAndPitchInterface::Parameters params;
    params.timeRatio = stretchRatio;
-   StaffPadTimeAndPitch stretcher { numChannels, stretcherSource,
+   StaffPadTimeAndPitch stretcher { GetRate(), numChannels, stretcherSource,
                                     std::move(params) };
 
    // Post-rendering sample counts, i.e., stretched units


### PR DESCRIPTION
Resolves: #5124

Please refer to detailed description in #5124 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Get an audio file of sample rate 88.2kHz or higher, with harmonically rich and low-frequency content. (Feel free to resample an audio file of 44.1 or 48kHz, or to use [this sample](https://1drv.ms/u/s!ArATSZ9esLBGx062RpVHSYiGBs0m?e=8BgGsj)) Stretch the audio in either direction. This should sound better with this build than on current master.