### PR TITLE
A "wide track" overload of EffectOutputTracks::AddToOutputTracks

### DIFF
--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -93,6 +93,19 @@ Track *EffectOutputTracks::AddToOutputTracks(const std::shared_ptr<Track> &t)
    return result;
 }
 
+Track *EffectOutputTracks::AddToOutputTracks(TrackList &&list)
+{
+   assert(list.Size() == 1);
+   mIMap.push_back(nullptr);
+   auto result = *list.begin();
+   mOMap.push_back(result);
+   mOutputTracks->Append(std::move(list));
+   // Invariant is maintained
+   assert(mIMap.size() == mOutputTracks->Size());
+   assert(mIMap.size() == mOMap.size());
+   return result;
+}
+
 // Replace tracks with successfully processed mOutputTracks copies.
 // Else clear and delete mOutputTracks copies.
 void EffectOutputTracks::Commit()

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -59,6 +59,14 @@ public:
     */
    Track *AddToOutputTracks(const std::shared_ptr<Track> &t);
 
+   //! An overload to add a "wide" output track, now represented as a TrackList,
+   //! which will be moved-from.
+   /*!
+    @pre `list.Size() == 1`
+    @return a pointer to the given (leader) track
+    */
+   Track *AddToOutputTracks(TrackList &&list);
+
    //! Replace input tracks with temporaries only on commit
    /*
     @pre `Commit()` was not previously called


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

@RyanMetcalfeInt8 needs this to rebase the AI source separation module.

QA:
nothing.  Straight to merge.  Release 3.4 will contain no calls to this new function.

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
