### PR TITLE
Edit commands conditionally greyed out

### DIFF
--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -16,6 +16,7 @@ Paul Licameli split from Menus.cpp
 #include <wx/frame.h>
 
 #include "AudioIO.h"
+#include "Clipboard.h"
 #include "LabelTrack.h"
 #include "Menus.h"
 #include "Project.h"
@@ -299,8 +300,14 @@ const ReservedCommandFlag&
       CommandFlagOptions{}.QuickTest()
    }; return flag; }
 const ReservedCommandFlag&
+   ClipboardNotEmptyFlag() { static ReservedCommandFlag flag{
+      [](const AudacityProject& project) {
+         return !Clipboard::Get().GetTracks().empty();
+      },
+      CommandFlagOptions{}.QuickTest()
+   }; return flag; }
+const ReservedCommandFlag&
    NoAutoSelect() { static ReservedCommandFlag flag{
      [](const AudacityProject &){ return true; }
    }; return flag; } // jkc
-;
 

--- a/src/CommonCommandFlags.h
+++ b/src/CommonCommandFlags.h
@@ -53,6 +53,7 @@ extern AUDACITY_DLL_API const ReservedCommandFlag
    &IsSyncLockedFlag(),  //awd
    &NotMinimizedFlag(), // prl
    &PausedFlag(), // jkc
+   &ClipboardNotEmptyFlag(),
    &NoAutoSelect() // jkc
 ;
 

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -1066,7 +1066,7 @@ BaseItemSharedPtr EditMenu()
          // Basic Edit commands
          /* i18n-hint: (verb)*/
          Command( wxT("Cut"), XXO("Cu&t"), OnCut,
-            AudioIONotBusyFlag() | CutCopyAvailableFlag() | NoAutoSelect(),
+            AudioIONotBusyFlag() | CutCopyAvailableFlag(),
             wxT("Ctrl+X") ),
          Command( wxT("Delete"), XXO("&Delete"), OnDelete,
             AudioIONotBusyFlag() | EditableTracksSelectedFlag() | TimeSelectedFlag() | NoAutoSelect(),
@@ -1076,7 +1076,7 @@ BaseItemSharedPtr EditMenu()
             AudioIONotBusyFlag() | CutCopyAvailableFlag(), wxT("Ctrl+C") ),
          /* i18n-hint: (verb)*/
          Command( wxT("Paste"), XXO("&Paste"), OnPaste,
-            AudioIONotBusyFlag(), wxT("Ctrl+V") ),
+            AudioIONotBusyFlag() | ClipboardNotEmptyFlag(), wxT("Ctrl+V") ),
          /* i18n-hint: (verb)*/
          Command( wxT("Duplicate"), XXO("Duplic&ate"), OnDuplicate,
             NotBusyTimeAndTracksFlags, wxT("Ctrl+D") ),
@@ -1194,7 +1194,7 @@ RegisteredMenuItemEnabler selectAnyTracks{{
 
 RegisteredMenuItemEnabler selectWaveTracks{{
    []{ return WaveTracksExistFlag(); },
-   []{ return TimeSelectedFlag() | WaveTracksSelectedFlag() | CutCopyAvailableFlag(); },
+   []{ return TimeSelectedFlag() | WaveTracksSelectedFlag(); },
    canSelectAll,
    selectAll
 }};
@@ -1202,7 +1202,7 @@ RegisteredMenuItemEnabler selectWaveTracks{{
 // Also enable select for the noise reduction case.
 RegisteredMenuItemEnabler selectWaveTracks2{{
    []{ return WaveTracksExistFlag(); },
-   []{ return NoiseReductionTimeSelectedFlag() | WaveTracksSelectedFlag() | CutCopyAvailableFlag(); },
+   []{ return NoiseReductionTimeSelectedFlag() | WaveTracksSelectedFlag(); },
    canSelectAll,
    selectAll
 }};


### PR DESCRIPTION
Resolves: #5263 

Copy does not support auto-select option any more
Cut, Copy commands are made available only when audio data or label text selected
Paste command is made available when clipboard not empty

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
