### PR TITLE
change time track default values to 0.2, 2.0

### DIFF
--- a/libraries/lib-time-track/TimeTrack.cpp
+++ b/libraries/lib-time-track/TimeTrack.cpp
@@ -55,8 +55,8 @@ void TimeTrack::CleanState()
 {
    mEnvelope = std::make_unique<BoundedEnvelope>(true, TIMETRACK_MIN, TIMETRACK_MAX, 1.0);
 
-   SetRangeLower( 0.9 );
-   SetRangeUpper( 1.1 );
+   SetRangeLower( 0.2 );
+   SetRangeUpper( 2.0 );
    mDisplayLog = false;
 
    mEnvelope->SetTrackLen(DBL_MAX);


### PR DESCRIPTION
just makes time tracks a little bit more versatile by default