### PR TITLE
Time Controls `bar:beats` resizing fixes

### DIFF
--- a/libraries/lib-numeric-formats/NumericConverter.cpp
+++ b/libraries/lib-numeric-formats/NumericConverter.cpp
@@ -80,7 +80,7 @@ void NumericConverter::ValueToControls(double rawValue, bool nearest /* = true *
    if (!mFormatter)
       return;
 
-   mFormatter->UpdateFormatForValue(rawValue);
+   UpdateFormatToFit(rawValue);
    auto result = mFormatter->ValueToString(rawValue, nearest);
 
    mValueString = std::move(result.valueString);
@@ -200,6 +200,11 @@ wxString NumericConverter::GetString()
 {
    ValueToControls();
    return mValueString;
+}
+
+void NumericConverter::UpdateFormatToFit(double value)
+{
+   mFormatter->UpdateFormatForValue(value, false);
 }
 
 int NumericConverter::GetSafeFocusedDigit(int focusedDigit) const noexcept

--- a/libraries/lib-numeric-formats/NumericConverter.cpp
+++ b/libraries/lib-numeric-formats/NumericConverter.cpp
@@ -248,14 +248,17 @@ bool NumericConverter::UpdateFormatter()
    if (mFormatter)
    {
       mFormatUpdatedSubscription =
-         mFormatter->Subscribe([this](auto) { OnFormatUpdated(); });
+         mFormatter->Subscribe([this](const auto& msg) {
+            OnFormatUpdated(false);
+            Publish({ msg.value });
+      });
    }
 
-   OnFormatUpdated();
+   OnFormatUpdated(true);
    return mFormatter != nullptr;
 }
 
-void NumericConverter::OnFormatUpdated()
+void NumericConverter::OnFormatUpdated(bool)
 {
    if (!mFormatter)
       return;

--- a/libraries/lib-numeric-formats/NumericConverter.h
+++ b/libraries/lib-numeric-formats/NumericConverter.h
@@ -26,8 +26,10 @@
 #include "ComponentInterfaceSymbol.h"
 #include "TranslatableString.h"
 
+struct FormatChangedToFitValueMessage final { double value; };
 
-class NUMERIC_FORMATS_API NumericConverter /* not final */
+class NUMERIC_FORMATS_API NumericConverter /* not final */ :
+    public Observer::Publisher<FormatChangedToFitValueMessage>
 {
 public:
    NumericConverter(const FormatterContext& context, NumericConverterType type,
@@ -79,7 +81,7 @@ public:
 
 protected:
    bool UpdateFormatter();
-   virtual void OnFormatUpdated();
+   virtual void OnFormatUpdated(bool resetFocus);
 
    FormatterContext mContext;
 

--- a/libraries/lib-numeric-formats/NumericConverter.h
+++ b/libraries/lib-numeric-formats/NumericConverter.h
@@ -68,6 +68,8 @@ public:
    double GetValue();
    wxString GetString();
 
+   void UpdateFormatToFit(double value);
+
    // Adjust the value by the number "steps" in the active format.
    // Increment if "dir" is 1, decrement if "dir" is -1.
    void Adjust(int steps, int dir, int focusedDigit);

--- a/libraries/lib-numeric-formats/NumericConverterFormatter.cpp
+++ b/libraries/lib-numeric-formats/NumericConverterFormatter.cpp
@@ -58,7 +58,7 @@ NumericConverterFormatter::~NumericConverterFormatter()
 {
 }
 
-void NumericConverterFormatter::UpdateFormatForValue(double) 
+void NumericConverterFormatter::UpdateFormatForValue(double, bool)
 {
 }
 

--- a/libraries/lib-numeric-formats/NumericConverterFormatter.h
+++ b/libraries/lib-numeric-formats/NumericConverterFormatter.h
@@ -53,6 +53,8 @@ using DigitInfos = std::vector<DigitInfo>;
 
 struct NumericConverterFormatChangedMessage final
 {
+   double value;
+   bool shrunk;
 };
 
 struct NUMERIC_FORMATS_API NumericConverterFormatter /* not final */ :
@@ -67,7 +69,7 @@ struct NUMERIC_FORMATS_API NumericConverterFormatter /* not final */ :
    };
 
    //! Potentially updates the format so it can fit the `value`. Default implementation is empty.
-   virtual void UpdateFormatForValue(double value);
+   virtual void UpdateFormatForValue(double value, bool canShrink);
    //! @post result: `GetFields().size() == result.fieldValueStrings.size()`
    virtual ConversionResult
    ValueToString(double value, bool nearest) const = 0;

--- a/libraries/lib-numeric-formats/tests/NumericConverterTests.cpp
+++ b/libraries/lib-numeric-formats/tests/NumericConverterTests.cpp
@@ -213,7 +213,7 @@ TEST_CASE("BeatsNumericConverterFormatter", "")
             const auto value = bar * timeSignature.GetBarDuration() +
                                beat * timeSignature.GetBeatDuration();
 
-            basicFormatter->UpdateFormatForValue(value);
+            basicFormatter->UpdateFormatForValue(value, true);
 
             const auto formattedString =
                wxString::Format("%03d bar %02d beat", bar + 1, beat + 1);

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -234,6 +234,16 @@ void SelectionBar::AddTime(
    pSizer->Add(pCtrl, 0, wxALIGN_TOP | wxRIGHT, 5);
 
    mTimeControls[id] = pCtrl;
+
+   mFormatChangedToFitValueSubscription[id] = pCtrl->Subscribe(
+      [this, id](const auto& msg)
+      {
+         auto altCtrl = mTimeControls[id == 0 ? 1 : 0];
+         if (altCtrl != nullptr)
+            altCtrl->UpdateFormatToFit(msg.value);
+
+         FitToTimeControls();
+      });
 }
 
 void SelectionBar::AddSelectionSetupButton(wxSizer* pSizer)
@@ -506,12 +516,7 @@ void SelectionBar::SelectionModeUpdated()
    // We just changed the mode.  Remember it.
    UpdateSelectionMode(mSelectionMode);
 
-   wxSize sz = GetMinSize();
-   sz.SetWidth( 10 );
-   SetMinSize( sz );
-   Fit();
-   Layout();
-   Updated();
+   FitToTimeControls();
 }
 
 // We used to have 8 modes which showed different combinations of the
@@ -631,6 +636,16 @@ void SelectionBar::UpdateTimeControlsFormat(const NumericFormatSymbol& format)
                   format :
                   NumericConverterFormats::GetBestDurationFormat(format));
    }
+}
+
+void SelectionBar::FitToTimeControls()
+{
+   wxSize sz = GetMinSize();
+   sz.SetWidth(10);
+   SetMinSize(sz);
+   Fit();
+   Layout();
+   Updated();
 }
 
 static RegisteredToolbarFactory factory{

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -92,6 +92,8 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
 
    void UpdateTimeControlsFormat(const NumericFormatSymbol& format);
 
+   void FitToTimeControls();
+
    SelectionBarListener * mListener;
    double mRate;
    double mStart, mEnd, mLength, mCenter;
@@ -101,6 +103,8 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
 
    std::array<NumericTextCtrl*, 2> mTimeControls {};
    AButton* mSetupButton{};
+
+   Observer::Subscription mFormatChangedToFitValueSubscription[2];
 
    wxString mLastValidText;
    

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -107,7 +107,13 @@ void TimeToolBar::Populate()
    mSettingInitialSize = true;
 
    // Establish initial resizing limits
-//   SetResizingLimits();
+   //   SetResizingLimits();
+   mFormatChangedToFitValueSubscription = mAudioTime->Subscribe(
+      [this](auto)
+      {
+         wxSizeEvent e;
+         OnSize(e);
+      });
 }
 
 void TimeToolBar::UpdatePrefs()
@@ -369,6 +375,11 @@ void TimeToolBar::OnIdle(wxIdleEvent &evt)
    }
 
    mAudioTime->SetValue(wxMax(0.0, audioTime));
+}
+
+wxSize TimeToolBar::ComputeSizing(int digitH)
+{
+   return mAudioTime->ComputeSizing(false, digitH * mDigitRatio, digitH);
 }
 
 static RegisteredToolbarFactory factory{

--- a/src/toolbars/TimeToolBar.h
+++ b/src/toolbars/TimeToolBar.h
@@ -62,16 +62,13 @@ private:
 
    static const int minDigitH = 17;
    static const int maxDigitH = 100;
-   
+
+   Observer::Subscription mFormatChangedToFitValueSubscription;
+
 public:
    
    DECLARE_CLASS(TimeToolBar)
    DECLARE_EVENT_TABLE()
 };
-
-inline wxSize TimeToolBar::ComputeSizing(int digitH)
-{
-   return mAudioTime->ComputeSizing(false, digitH * mDigitRatio, digitH);
-}
 
 #endif

--- a/src/widgets/NumericTextCtrl.h
+++ b/src/widgets/NumericTextCtrl.h
@@ -112,8 +112,8 @@ class AUDACITY_DLL_API NumericTextCtrl final
    int GetFocusedDigit() { return mFocusedDigit; }
 
 private:
-   void OnFormatUpdated() override;
-   void HandleFormatterChanged();
+   void OnFormatUpdated(bool resetFocus) override;
+   void HandleFormatterChanged(bool resetFocus);
 
    void OnCaptureKey(wxCommandEvent &event);
    void OnKeyDown(wxKeyEvent &event);


### PR DESCRIPTION
Resolves: #5270
Resolves: #5232

This PR addresses issues introduced when the `bar:beats` formats were allowed to resize to always fit the number of bars needed.

Fixes implemented:

* Format can only "grow", simplifying the keyboard interaction. This helps to address 5270 cases A and C. Case B is intentionally kept so the behavior matches the one Audacity has now.
* In the selection bar, we always use the widest format, addressing 5232.
* Both toolbars now correctly adapt to the Time Control size.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
