### PR TITLE
Don't compute interpolation of samples when no pitch shifting

### DIFF
--- a/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
+++ b/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
@@ -456,7 +456,7 @@ void TimeAndPitch::feedAudio(const float* const* input_smp, int numSamples)
     {
       float smp[6];
       d->inResampleInputBuffer[ch].readBlock(int_pos - 6, 6, smp);
-      float s = lagrange6(smp, frac_pos);
+      float s = (frac_pos == 0) ? smp[2] : lagrange6(smp, frac_pos);
       d->inCircularBuffer[ch].writeOffset0(s);
       d->inCircularBuffer[ch].advance(1);
     }


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

This one-line change skips a calculation that is needed only when shifting pitch as well as time.

QA can confirm exactly 0 difference in before and after calculations of time stretch.

This may be worth testing for further performance improvement.  My own preliminary, rough tests suggest it might save a few percent in a macOS release build.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
