### PR TITLE
issue #5357: Change of format of a duration in a generator can cause …

### DIFF
--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -156,7 +156,6 @@ NumericTextCtrl::NumericTextCtrl(
    mBackgroundBitmap{},
    mDigitFont{},
    mLabelFont{},
-   mLastField(1),
    mAutoPos(options.autoPos)
    , mType(type)
 {
@@ -913,7 +912,6 @@ void NumericTextCtrl::SetFieldFocus(int  digit)
       return;
    }
    mFocusedDigit = digit;
-   mLastField = mFormatter->GetDigitInfos()[mFocusedDigit].field + 1;
 
    GetAccessible()->NotifyEvent(wxACC_EVENT_OBJECT_FOCUS,
                                 this,
@@ -1138,7 +1136,7 @@ wxAccStatus NumericTextCtrlAx::GetName(int childId, wxString *name)
    auto & mFieldValueStrings = mCtrl->mFieldValueStrings;
 
    wxString ctrlString = mCtrl->GetString();
-   int field = mCtrl->GetFocusedField();
+   int field = mDigits[mCtrl->GetFocusedDigit()].field + 1;
 
    // Return the entire string including the control label
    // when the requested child ID is wxACC_SELF.  (Mainly when

--- a/src/widgets/NumericTextCtrl.h
+++ b/src/widgets/NumericTextCtrl.h
@@ -108,7 +108,6 @@ class AUDACITY_DLL_API NumericTextCtrl final
    // this control returns to the program, so you can specify.
    void SetInvalidValue(double invalidValue);
 
-   int GetFocusedField() { return mLastField; }
    int GetFocusedDigit() { return mFocusedDigit; }
 
 private:
@@ -165,8 +164,6 @@ private:
    int            mWidth;
    int            mHeight;
    int            mButtonWidth;
-
-   int            mLastField;
 
    int            mFocusedDigit { 0 };
 


### PR DESCRIPTION
…crash

Resolves: https://github.com/audacity/audacity/issues/5337

With a screen reader running, in one of the the built in generators, for example chirp, changing the format of the duration can crash Audacity.

Problem:
NumericTextCtrlAx::GetName(), uses NumericTextCtrl::GetFocusedField() to get the focused field. It then uses that as in index for a vector. However, NumericTextCtrl::UpdateAutoFocus() does not update the value of mLastField, which is returned by NumericTextCtrl::GetFocusedField(). So after a change of format, GetFocusedField() can return a value which does not exist in the new format. This can cause Audacity to crash. This happens from Audacity 3.3.0, and I don't know why it didn't in versions before this.

Possible fixes:
1. Change NumericTextCtrl::UpdateAutoFocus() so that it updates mLastField.
2. Given that NumericTextCtrl::GetFocusedField() is only used by the accessibility object, and that the focused field can be derived from NumericTextCtrl::GetFocusedDigit(), remove NumericTextCtrl::GetFocusedField() and NumericTextCtrl::mLastField.

The second fix was implemented, as it will reduce the chance of errors in this area in the future.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
