### PR TITLE
5231 fix error msg when dragging pencil beyond right boundary

### DIFF
--- a/libraries/lib-screen-geometry/ZoomInfo.cpp
+++ b/libraries/lib-screen-geometry/ZoomInfo.cpp
@@ -109,10 +109,10 @@ void ZoomInfo::ZoomBy(double multiplier)
    SetZoom(zoom * multiplier);
 }
 
-void ZoomInfo::FindIntervals(
-   Intervals& results, int64 width, int64 origin) const
+ZoomInfo::Intervals
+ZoomInfo::FindIntervals(int64 width, int64 origin) const
 {
-   results.clear();
+   ZoomInfo::Intervals results;
    results.reserve(2);
 
    const int64 rightmost(origin + (0.5 + width));
@@ -124,4 +124,5 @@ void ZoomInfo::FindIntervals(
    if (origin < rightmost)
       results.push_back(Interval(rightmost, 0, false));
    assert(!results.empty() && results[0].position == origin);
+   return results;
 }

--- a/libraries/lib-screen-geometry/ZoomInfo.h
+++ b/libraries/lib-screen-geometry/ZoomInfo.h
@@ -147,7 +147,7 @@ public:
    // It is guaranteed that there is at least one entry and the position of the
    // first entry equals origin.
    // @param origin specifies the pixel position corresponding to time ViewInfo::h.
-   void FindIntervals(Intervals& results, int64 width, int64 origin = 0) const;
+   Intervals FindIntervals(int64 width, int64 origin = 0) const;
 
    enum FisheyeState {
       HIDDEN,

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -3122,7 +3122,8 @@ void WaveTrack::SetFloatsWithinTimeRange(
    const std::function<float(double sampleTime)>& producer,
    sampleFormat effectiveFormat)
 {
-   assert(t0 <= t1);
+   if (t0 >= t1)
+      return;
    const auto sortedClips = SortedClipArray();
    if (sortedClips.empty())
       return;
@@ -3137,7 +3138,7 @@ void WaveTrack::SetFloatsWithinTimeRange(
          std::round((t0 - clipStartTime) * sampsPerSec) / sampsPerSec +
          clipStartTime;
       const auto roundedT1 =
-         std::round((t1 - clipStartTime) * sampsPerSec + 1) / sampsPerSec +
+         std::round((t1 - clipStartTime) * sampsPerSec) / sampsPerSec +
          clipStartTime;
       if (clipStartTime > roundedT1)
          break;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -580,11 +580,10 @@ public:
 
    /*!
     * @brief Provides a means of setting clip values as a function of time.
-    * Included are closest sample to t0 up to closest sample to t1, inclusively.
-    * Given that `t0 <= t1`, always at least one sample is included.
+    * Included are closest sample to t0 up to closest sample to t1, exclusively.
+    * If the given interval is empty, i.e., `t0 >= t1`, no action is taken.
     * @param producer a function taking sample (absolute, not clip-relative)
     * time and returning the desired value for the sample at that time.
-    * @pre t0 <= t1
     */
    void SetFloatsWithinTimeRange(
       double t0, double t1, size_t iChannel,

--- a/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
@@ -81,12 +81,12 @@ UIHandlePtr SampleHandle::HitAnywhere
 }
 
 namespace {
-   inline double adjustTime(const WaveTrack *wt, double time)
+   inline double adjustTime(const WaveTrack& wt, double time)
    {
       // Round to an exact sample time
-      const auto clip = wt->GetClipAtTime(time);
+      const auto clip = wt.GetClipAtTime(time);
       if (!clip)
-         return wt->SnapToSample(time);
+         return wt.SnapToSample(time);
       const auto sampleOffset =
          clip->TimeToSamples(time - clip->GetPlayStartTime());
       return clip->SamplesToTime(sampleOffset) + clip->GetPlayStartTime();
@@ -94,17 +94,14 @@ namespace {
 
    // Is the sample horizontally nearest to the cursor sufficiently separated
    // from its neighbors that the pencil tool should be allowed to drag it?
-   bool SampleResolutionTest
-      ( const ViewInfo &viewInfo, const WaveTrack *wt, double time, int width )
+   bool SampleResolutionTest(
+      const ViewInfo& viewInfo, const WaveClip& clip, int width)
    {
       // Require more than 3 pixels per sample
-      const auto xx = std::max<ZoomInfo::int64>(0, viewInfo.TimeToPosition(time));
-      const auto clip = wt->GetClipAtTime(time);
-      if (!clip)
-         // Don't bother the user about that with a pop-up.
-         return true;
+      const auto xx = std::max<ZoomInfo::int64>(
+         0, viewInfo.TimeToPosition(clip.GetPlayStartTime()));
       ZoomInfo::Intervals intervals;
-      const double rate = clip->GetRate() / clip->GetStretchRatio();
+      const double rate = clip.GetRate() / clip.GetStretchRatio();
       viewInfo.FindIntervals(intervals, width);
       ZoomInfo::Intervals::const_iterator it = intervals.begin(),
          end = intervals.end(), prev;
@@ -129,9 +126,12 @@ UIHandlePtr SampleHandle::HitTest
    /// editable sample
    const auto wavetrack = pTrack.get();
    const auto time = viewInfo.PositionToTime(state.m_x, rect.x);
+   const auto clickedClip = wavetrack->GetClipAtTime(time);
+   if (!clickedClip)
+      return {};
 
-   const double tt = adjustTime(wavetrack, time);
-   if (!SampleResolutionTest(viewInfo, wavetrack, tt, rect.width))
+   const double tt = adjustTime(*wavetrack, time);
+   if (!SampleResolutionTest(viewInfo, *clickedClip, rect.width))
       return {};
 
    // Just get one sample.
@@ -174,28 +174,6 @@ SampleHandle::~SampleHandle()
 {
 }
 
-namespace {
-   /// Determines if we can edit samples in a wave track.
-   /// Also pops up warning messages in certain cases where we can't.
-   ///  @return true if we can edit the samples, false otherwise.
-   bool IsSampleEditingPossible
-      (const wxMouseEvent &event,
-       const wxRect &rect, const ViewInfo &viewInfo, WaveTrack *wt, int width)
-   {
-      //If we aren't zoomed in far enough, show a message dialog.
-      const double time = adjustTime(wt, viewInfo.PositionToTime(event.m_x, rect.x));
-      if (!SampleResolutionTest(viewInfo, wt, time, width))
-      {
-         AudacityMessageBox(
-            XO(
-"To use Draw, zoom in further until you can see the individual samples."),
-            XO("Draw Tool"));
-         return false;
-      }
-      return true;
-   }
-}
-
 UIHandle::Result SampleHandle::Click
 (const TrackPanelMouseEvent &evt, AudacityProject *pProject)
 {
@@ -210,11 +188,18 @@ UIHandle::Result SampleHandle::Click
 
    const double t0 = viewInfo.PositionToTime(event.m_x, rect.x);
    const auto pTrack = mClickedTrack.get();
+   mClickedClip = pTrack->GetClipAtTime(t0);
+   if (!mClickedClip)
+      return Cancelled;
 
    /// Someone has just clicked the mouse.  What do we do?
-   if (!IsSampleEditingPossible(
-         event, rect, viewInfo, pTrack, rect.width))
+   if (!SampleResolutionTest(viewInfo, *mClickedClip, rect.width))
+   {
+      AudacityMessageBox(
+         XO("To use Draw, zoom in further until you can see the individual samples."),
+         XO("Draw Tool"));
       return Cancelled;
+   }
 
    /// We're in a track view and zoomed enough to see the samples.
    mRect = rect;
@@ -333,6 +318,28 @@ UIHandle::Result SampleHandle::Click
    return RefreshCell;
 }
 
+namespace
+{
+size_t GetLastEditableClipStartingFromNthClip(
+   size_t n, bool forward, const WaveClipPointers& sortedClips,
+   const ViewInfo& viewInfo, int rectWidth)
+{
+   assert(n < sortedClips.size());
+   const auto increment = forward ? 1 : -1;
+   int last = n + increment;
+   const auto limit = forward ? sortedClips.size() : -1;
+   while (last != limit)
+   {
+      if (!SampleResolutionTest(viewInfo, *sortedClips[last], rectWidth))
+         break;
+      last += increment;
+   }
+   last -= increment;
+   assert(last >= 0 && last < sortedClips.size());
+   return last;
+}
+} // namespace
+
 UIHandle::Result SampleHandle::Drag
 (const TrackPanelMouseEvent &evt, AudacityProject *pProject)
 {
@@ -341,16 +348,16 @@ UIHandle::Result SampleHandle::Drag
    const auto &viewInfo = ViewInfo::Get( *pProject );
 
    const bool unsafe = ProjectAudioIO::Get( *pProject ).IsAudioActive();
-
-   /// Someone has just clicked the mouse.  What do we do?
-   const auto samplesVisible = IsSampleEditingPossible(
-      event, mRect, viewInfo, mClickedTrack.get(), mRect.width);
-
-   if (unsafe || !samplesVisible)
+   if (unsafe)
    {
       this->Cancel(pProject);
       return RefreshCell | Cancelled;
    }
+
+   // There must have been some clicking before dragging ...
+   assert(mClickedTrack && mClickedClip);
+   if (!(mClickedTrack && mClickedClip))
+      return Cancelled;
 
    //*************************************************
    //***    DRAG-DRAWING                           ***
@@ -369,6 +376,26 @@ UIHandle::Result SampleHandle::Drag
    const float newLevel = FindSampleEditingLevel(event, viewInfo, t0);
    const auto start = std::min(t0, t1);
    const auto end = std::max(t0, t1);
+
+   // Starting from the originally clicked clip, restrict the editing boundaries
+   // to the succession of clips with visible samples. If, of clips A, B and C,
+   // only B had invisible samples, it'd mean one could not drag-draw from A
+   // into C, but that probably isn't a behavior worthwhile much implementation
+   // complications.
+   const auto clips = mClickedTrack->SortedClipArray();
+   const auto clickedClipIndex = std::distance(
+      clips.begin(), std::find(clips.begin(), clips.end(), mClickedClip));
+   constexpr auto forward = true;
+   const size_t leftmostEditable = GetLastEditableClipStartingFromNthClip(
+      clickedClipIndex, !forward, clips, viewInfo, mRect.width);
+   const size_t rightmostEditable = GetLastEditableClipStartingFromNthClip(
+      clickedClipIndex, forward, clips, viewInfo, mRect.width);
+
+   const auto editStart =
+      std::max(start, clips[leftmostEditable]->GetPlayStartTime());
+   const auto editEnd =
+      std::min(end, clips[rightmostEditable]->GetPlayEndTime());
+
    // For fast pencil movements covering more than one sample between two
    // updates, we draw a line going from v0 at t0 to v1 at t1.
    const auto interpolator = [t0, t1, v0 = mLastDragSampleValue,
@@ -382,7 +409,7 @@ UIHandle::Result SampleHandle::Drag
    };
    constexpr auto iChannel = 0u;
    mClickedTrack->SetFloatsWithinTimeRange(
-      start, end, iChannel, interpolator, narrowestSampleFormat);
+      editStart, editEnd, iChannel, interpolator, narrowestSampleFormat);
 
    mLastDragPixel = x1;
    mLastDragSampleValue = newLevel;
@@ -410,6 +437,7 @@ UIHandle::Result SampleHandle::Release
    //*************************************************
    //On up-click, send the state to the undo stack
    mClickedTrack.reset();       //Set this to NULL so it will catch improper drag events.
+   mClickedClip = nullptr;
    ProjectHistory::Get( *pProject ).PushState(XO("Moved Samples"),
       XO("Sample Edit"),
       UndoPush::CONSOLIDATE);

--- a/src/tracks/playabletrack/wavetrack/ui/SampleHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SampleHandle.h
@@ -19,6 +19,7 @@ class wxMouseState;
 
 class Track;
 class ViewInfo;
+class WaveClip;
 class WaveTrack;
 
 class SampleHandle final : public UIHandle
@@ -69,6 +70,7 @@ private:
       (const wxMouseEvent &event, const ViewInfo &viewInfo, double t0);
 
    std::shared_ptr<WaveTrack> mClickedTrack;
+   WaveClip* mClickedClip {};
    wxRect mRect{};
 
    int mClickedStartPixel {};

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -307,8 +307,7 @@ void FindWavePortions
    // (except when they are squeezed to zero width), and at least one for inside
    // the fisheye.
 
-   ZoomInfo::Intervals intervals;
-   zoomInfo.FindIntervals(intervals, rect.width, rect.x);
+   const auto intervals = zoomInfo.FindIntervals(rect.width, rect.x);
    ZoomInfo::Intervals::const_iterator it = intervals.begin(), end = intervals.end(), prev;
    wxASSERT(it != end && it->position == rect.x);
    const int rightmost = rect.x + rect.width;


### PR DESCRIPTION
Resolves: #5231

Please refer to #5231 for details.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Fixes #5231
- [x] Make a track with an alternation of clips with and without visible samples, drag-draw across them and ensure behaviour is acceptable. Please consult @LWinterberg if you have doubts.
