### PR TITLE
Attemp to prevent zero clips from being created

### DIFF
--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1437,6 +1437,11 @@ void WaveClip::TrimRightTo(double to)
    mTrimRight = std::max(mTrimRight + delta, .0);
 }
 
+double WaveClip::GetPivot() const noexcept
+{
+   return mSequenceOffset + mTrimLeft;
+}
+
 double WaveClip::GetSequenceStartTime() const noexcept
 {
     // JS: mSequenceOffset is the minimum value and it is returned; no clipping to 0

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1373,6 +1373,11 @@ double WaveClip::GetPlayDuration() const
    return GetPlayEndTime() - GetPlayStartTime();
 }
 
+bool WaveClip::IsEmpty() const
+{
+   return GetPlayDuration() < 0.5 / GetRate();
+}
+
 sampleCount WaveClip::GetPlayStartSample() const
 {
    return sampleCount { GetPlayStartTime() * mRate + 0.5 };

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -644,6 +644,11 @@ XMLTagHandler *WaveClip::HandleXMLChild(const std::string_view& tag)
 void WaveClip::WriteXML(XMLWriter &xmlFile) const
 // may throw
 {
+   if (GetSequenceSamplesCount() <= 0)
+      // Oops, I'm empty? How did that happen? Anyway, I do nothing but causing
+      // problems, don't save me.
+      return;
+
    xmlFile.StartTag(wxT("waveclip"));
    xmlFile.WriteAttr(wxT("offset"), mSequenceOffset, 8);
    xmlFile.WriteAttr(wxT("trimLeft"), mTrimLeft, 8);

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -161,10 +161,10 @@ public:
    // Set rate without resampling. This will change the length of the clip
    void SetRate(int rate);
 
+   void Stretch(double duration, bool toLeft = false);
+
    //! Stretches from left to the absolute time (if in expected range)
-   void StretchLeftTo(double to);
    //! Sets from the right to the absolute time (if in expected range)
-   void StretchRightTo(double to);
 
    double GetStretchRatio() const override;
 

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -211,6 +211,8 @@ public:
    //! stretched or not.
    double GetPlayDuration() const;
 
+   bool IsEmpty() const;
+
    //! Real start time of the clip, quantized to raw sample rate (track's rate)
    sampleCount GetPlayStartSample() const;
    //! Real end time of the clip, quantized to raw sample rate (track's rate)

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -189,6 +189,7 @@ public:
    void SetColourIndex(int index) { mColourIndex = index; }
    int GetColourIndex() const { return mColourIndex; }
 
+   double GetPivot() const noexcept;
    double GetSequenceStartTime() const noexcept;
    void SetSequenceStartTime(double startTime);
    double GetSequenceEndTime() const;

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2687,6 +2687,12 @@ void WaveTrack::HandleXMLEndTag(const std::string_view&  WXUNUSED(tag))
    // File compatibility breaks have intervened long since, and the line above
    // would now have undesirable side effects
 #endif
+   // Check for zero-length clips and remove them
+   for (auto it = mClips.begin(); it != mClips.end();)
+      if ((*it)->IsEmpty())
+         it = mClips.erase(it);
+      else
+         ++it;
 }
 
 XMLTagHandler *WaveTrack::HandleXMLChild(const std::string_view& tag)

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -201,16 +201,10 @@ void WaveTrack::Interval::TrimRightTo(double t)
       GetClip(channel)->TrimRightTo(t);
 }
 
-void WaveTrack::Interval::StretchLeftTo(double t)
+void WaveTrack::Interval::Stretch(double duration, bool toLeft)
 {
    for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->StretchLeftTo(t);
-}
-
-void WaveTrack::Interval::StretchRightTo(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->StretchRightTo(t);
+      GetClip(channel)->Stretch(duration, toLeft);
 }
 
 void WaveTrack::Interval::ApplyStretchRatio(

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1191,6 +1191,9 @@ auto WaveTrack::CopyOne(
    // Duplicate command and I changed its behavior in that case.
 
    for (const auto &clip : track.mClips) {
+      if(clip->IsEmpty())
+         continue;
+
       if (t0 <= clip->GetPlayStartTime() && t1 >= clip->GetPlayEndTime()) {
          // Whole clip is in copy region
          //wxPrintf("copy: clip %i is in copy region\n", (int)clip);
@@ -2141,6 +2144,10 @@ bool WaveTrack::FormatConsistencyCheck() const
 
 void WaveTrack::InsertClip(WaveClipHolder clip)
 {
+   assert(clip->GetIsPlaceholder() || !clip->IsEmpty());
+   if(!clip->GetIsPlaceholder() && clip->IsEmpty())
+      return;
+
    const auto& tempo = GetProjectTempo();
    if (tempo.has_value())
       clip->OnProjectTempoChange(std::nullopt, *tempo);
@@ -2725,7 +2732,7 @@ XMLTagHandler *WaveTrack::HandleXMLChild(const std::string_view& tag)
       auto clip = std::make_shared<WaveClip>(1,
          mpFactory, mLegacyFormat, mLegacyRate, GetWaveColorIndex());
       const auto xmlHandler = clip.get();
-      InsertClip(std::move(clip));
+      mClips.push_back(std::move(clip));
       return xmlHandler;
    }
 
@@ -3584,7 +3591,11 @@ WaveClip* WaveTrack::CreateClip(double offset, const wxString& name)
       mpFactory, GetSampleFormat(), GetRate(), GetWaveColorIndex());
    clip->SetName(name);
    clip->SetSequenceStartTime(offset);
-   InsertClip(std::move(clip));
+
+   const auto& tempo = GetProjectTempo();
+   if (tempo.has_value())
+      clip->OnProjectTempoChange(std::nullopt, *tempo);
+   mClips.push_back(std::move(clip));
 
    auto result = mClips.back().get();
    // TODO wide wave tracks -- for now assertion is correct because widths are

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -959,8 +959,7 @@ public:
 
       void TrimLeftTo(double t);
       void TrimRightTo(double t);
-      void StretchLeftTo(double t);
-      void StretchRightTo(double t);
+      void Stretch(double duration, bool toLeft = false);
 
       void ApplyStretchRatio(const std::function<void(double)>& reportProgress);
       bool StretchRatioEquals(double value) const;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1138,6 +1138,7 @@ private:
 
    //! Sets project tempo on clip upon push. Use this instead of
    //! `mClips.push_back`.
+   //! @pre clip->GetIsPlaceholder() || !clip->IsEmpty()
    void InsertClip(WaveClipHolder clip);
 
    void ApplyStretchRatioOne(

--- a/libraries/lib-wave-track/tests/CMakeLists.txt
+++ b/libraries/lib-wave-track/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+#  SPDX-License-Identifier: GPL-2.0-or-later
+
+add_unit_test(
+   NAME
+      lib-wave-track
+   MOCK_PREFS
+   MOCK_AUDIO
+   SOURCES
+      MockSampleBlock.cpp
+      MockSampleBlock.h
+      WaveClipTests.cpp
+   LIBRARIES
+      lib-wave-track
+      wxBase
+)

--- a/libraries/lib-wave-track/tests/MockSampleBlock.cpp
+++ b/libraries/lib-wave-track/tests/MockSampleBlock.cpp
@@ -1,0 +1,95 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  MockSampleBlock.cpp
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#include "MockSampleBlock.h"
+
+namespace
+{
+std::vector<char>
+copyToVector(constSamplePtr src, size_t numsamples, sampleFormat srcformat)
+{
+   const auto numChars = numsamples * SAMPLE_SIZE(srcformat);
+   std::vector<char> data(numChars);
+   std::copy(src, src + numChars, data.begin());
+   return data;
+}
+} // namespace
+
+MockSampleBlock::MockSampleBlock(
+   long long id, constSamplePtr src, size_t numsamples, sampleFormat srcformat)
+    : id { id }
+    , srcFormat { srcformat }
+    , data { copyToVector(src, numsamples, srcformat) }
+{
+}
+
+void MockSampleBlock::CloseLock() noexcept
+{
+}
+
+SampleBlockID MockSampleBlock::GetBlockID() const
+{
+   return id;
+}
+
+size_t MockSampleBlock::GetSampleCount() const
+{
+   return data.size() / SAMPLE_SIZE(srcFormat);
+}
+
+bool MockSampleBlock::GetSummary256(
+   float* dest, size_t frameoffset, size_t numframes)
+{
+   return true;
+}
+
+bool MockSampleBlock::GetSummary64k(
+   float* dest, size_t frameoffset, size_t numframes)
+{
+   return true;
+}
+
+size_t MockSampleBlock::GetSpaceUsage() const
+{
+   return data.size();
+}
+
+void MockSampleBlock::SaveXML(XMLWriter&)
+{
+}
+
+size_t MockSampleBlock::DoGetSamples(
+   samplePtr dest, sampleFormat destformat, size_t sampleoffset,
+   size_t numsamples)
+{
+   const auto charOffset = sampleoffset * SAMPLE_SIZE(srcFormat);
+   const auto numChars = numsamples * SAMPLE_SIZE(destformat);
+   std::copy(
+      data.data() + charOffset, data.data() + charOffset + numChars, dest);
+   return numsamples;
+}
+
+MinMaxRMS MockSampleBlock::DoGetMinMaxRMS(size_t start, size_t len)
+{
+   return { 0, 0, 0 };
+}
+
+MinMaxRMS MockSampleBlock::DoGetMinMaxRMS() const
+{
+   return { 0, 0, 0 };
+}
+
+BlockSampleView MockSampleBlock::GetFloatSampleView(bool mayThrow)
+{
+   std::vector<float> floatData { reinterpret_cast<const float*>(data.data()),
+                                  reinterpret_cast<const float*>(
+                                     data.data() + data.size()) };
+   return std::make_shared<std::vector<float>>(floatData);
+}

--- a/libraries/lib-wave-track/tests/MockSampleBlock.h
+++ b/libraries/lib-wave-track/tests/MockSampleBlock.h
@@ -1,0 +1,51 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  MockSampleBlock.h
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#pragma once
+
+#include "SampleBlock.h"
+
+class MockSampleBlock final : public SampleBlock
+{
+public:
+   MockSampleBlock(
+      long long id, constSamplePtr src, size_t numsamples,
+      sampleFormat srcformat);
+
+   void CloseLock() noexcept override;
+
+   SampleBlockID GetBlockID() const override;
+
+   size_t GetSampleCount() const override;
+
+   bool
+   GetSummary256(float* dest, size_t frameoffset, size_t numframes) override;
+
+   bool
+   GetSummary64k(float* dest, size_t frameoffset, size_t numframes) override;
+
+   size_t GetSpaceUsage() const override;
+
+   void SaveXML(XMLWriter&) override;
+
+   size_t DoGetSamples(
+      samplePtr dest, sampleFormat destformat, size_t sampleoffset,
+      size_t numsamples) override;
+
+   MinMaxRMS DoGetMinMaxRMS(size_t start, size_t len) override;
+
+   MinMaxRMS DoGetMinMaxRMS() const override;
+
+   BlockSampleView GetFloatSampleView(bool mayThrow) override;
+
+   const long long id;
+   const sampleFormat srcFormat;
+   const std::vector<char> data;
+};

--- a/libraries/lib-wave-track/tests/WaveClipTests.cpp
+++ b/libraries/lib-wave-track/tests/WaveClipTests.cpp
@@ -1,0 +1,176 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  NumericConverterTests.cpp
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#include <iostream>
+#include <numeric>
+#include <catch2/catch.hpp>
+
+#include "MockedAudio.h"
+#include "MockedPrefs.h"
+#include "MockSampleBlock.h"
+#include "Project.h"
+#include "SampleBlock.h"
+#include "WaveClip.h"
+
+namespace
+{
+   class MockSampleBlockFactory final : public SampleBlockFactory
+   {
+      SampleBlockIDs GetActiveBlockIDs() override
+      {
+         std::vector<long long> ids(blockIdCount);
+         std::iota(ids.begin(), ids.end(), 1LL);
+         return { ids.begin(), ids.end() };
+      }
+
+      SampleBlockPtr DoCreate(
+         constSamplePtr src, size_t numsamples, sampleFormat srcformat) override
+      {
+         return std::make_shared<MockSampleBlock>(
+            blockIdCount++, src, numsamples, srcformat);
+      }
+
+      SampleBlockPtr
+      DoCreateSilent(size_t numsamples, sampleFormat srcformat) override
+      {
+         std::vector<char> silence(numsamples * SAMPLE_SIZE(srcformat));
+         return std::make_shared<MockSampleBlock>(
+            blockIdCount++, silence.data(), numsamples, srcformat);
+      }
+
+      SampleBlockPtr
+      DoCreateFromXML(sampleFormat srcformat, const AttributesList& attrs) override
+      {
+         return nullptr;
+      }
+
+      long long blockIdCount = 0;
+   };
+
+   constexpr double rate = 192000;
+
+   bool eq(double t, double sample)
+   {
+      auto d = std::abs(t - sample / rate);
+      return d < 0.5 / rate;
+   }
+}
+
+bool TestClipTrimLengthInvariant(WaveClip& clip)
+{
+   auto offset = .0;
+   auto trim = .0;
+   const auto targetOffset = 0.5 / clip.GetRate();
+   const auto targetTrim = 1.0 / clip.GetRate();
+   const auto eps = 0.000001 / clip.GetRate();
+
+   const auto duration = clip.GetPlayDuration();
+   const auto durationEps = duration * std::numeric_limits<double>::epsilon();
+
+   do 
+   {
+      // Clips could have arbitrary offset,
+      // length of the clip should not depend on position
+      clip.SetSequenceStartTime(offset);
+      if(std::abs(clip.GetPlayDuration() - duration) > durationEps)
+         return false;
+
+      // Trim reduces the length of the clip.
+      // Clip length should stay multiple of the sample length,
+      // and not exceed the length of a trimmed sequence
+      
+      while (targetTrim - trim > eps)
+      {
+         trim = (targetTrim + trim) * 0.5;
+         clip.SetTrimRight(trim);
+         clip.SetTrimLeft(targetTrim - trim);
+         if(std::abs(clip.GetPlayDuration() - (duration - targetTrim)) > durationEps)
+            return false;
+      }
+
+      clip.SetTrimLeft(targetTrim);
+      clip.SetTrimRight(.0);
+      if(std::abs(clip.GetPlayDuration() - (duration - targetTrim)) > durationEps)
+         return false;
+
+      clip.SetTrimLeft(.0);
+      clip.SetTrimRight(targetTrim);
+      if(std::abs(clip.GetPlayDuration() - (duration - targetTrim)) > durationEps)
+         return false;
+
+      clip.SetTrimLeft(.0);
+      clip.SetTrimRight(.0);
+      trim = .0;
+
+      offset = (targetOffset + offset) * 0.5;
+   } while (targetOffset - offset > eps);
+
+   return true;
+}
+
+
+TEST_CASE("ParsedNumericConverterFormatter", "")
+{
+   MockedPrefs mockedPrefs;
+   MockedAudio mockedAudio;
+
+   auto sampleBlockFactory = std::make_shared<MockSampleBlockFactory>();
+
+   SECTION("Test clip length invariant")
+   {
+      auto stretchFactors =
+      {
+         1.0, // no stretching applied
+         3.0 / 10.0, // stretched sample length is more than twice shorter compared to unstretched sample
+         25.0 / 10.0  // stretched sample length is more than twice longer compared to unstretched sample
+      };
+
+      for(auto factor : stretchFactors)
+      {
+         const auto clip = std::make_unique<WaveClip>(1, sampleBlockFactory, floatSample, rate, 0);
+         clip->InsertSilence(0, 10.0 / rate);
+         clip->Stretch(clip->GetPlayDuration() / factor);
+
+         REQUIRE(TestClipTrimLengthInvariant(*clip));
+         //TODO: check sequence sample mapping
+      }
+   }
+
+   SECTION("Sample grid alignment")
+   {
+      auto clip = std::make_unique<WaveClip>(1, sampleBlockFactory, floatSample, rate, 0);
+
+      clip->InsertSilence(0, 10.0 / rate);
+      REQUIRE(eq(clip->GetPlayStartTime(), 0));
+      REQUIRE(eq(clip->GetPlayEndTime(), 10));
+      REQUIRE(eq(clip->GetPlayDuration(), 10));
+
+      clip->SetPlayStartTime(0.25 / rate);
+      REQUIRE(eq(clip->GetPlayStartTime(), 0));
+      REQUIRE(eq(clip->GetPlayEndTime(), 10));
+      REQUIRE(eq(clip->GetPlayDuration(), 10));
+
+      clip->SetPlayStartTime(0.5 / rate);
+      REQUIRE(eq(clip->GetPlayStartTime(), 1));
+      REQUIRE(eq(clip->GetPlayEndTime(), 11));
+      REQUIRE(eq(clip->GetPlayDuration(), 10));
+
+      clip->SetTrimLeft(1.0 / rate);
+      REQUIRE(eq(clip->GetPlayStartTime(), 2));
+      REQUIRE(eq(clip->GetPlayEndTime(), 11));
+      REQUIRE(eq(clip->GetPlayDuration(), 9));
+
+      clip->SetTrimRight(1.0 / rate);
+      REQUIRE(eq(clip->GetPlayStartTime(), 2));
+      REQUIRE(eq(clip->GetPlayEndTime(), 10));
+      REQUIRE(eq(clip->GetPlayDuration(), 8));
+   }
+}

--- a/src/tracks/playabletrack/wavetrack/ui/ChangeClipSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/ChangeClipSpeedDialog.cpp
@@ -136,8 +136,11 @@ bool ChangeClipSpeedDialog::SetClipSpeedFromDialog()
    const auto start = mTrackInterval.Start();
    const auto end = mTrackInterval.End();
 
+   const auto rate = mTrack.GetRate();
+   const auto newDuration = std::floor((end - start) * mOldClipSpeed / mClipSpeed * rate + 0.5) / rate;
+
    const auto expectedEndTime =
-      start + (end - start) * mOldClipSpeed / mClipSpeed;
+      start + std::max(newDuration, 1.0 / rate);
 
    if (expectedEndTime >= maxEndTime)
    {
@@ -148,7 +151,7 @@ bool ChangeClipSpeedDialog::SetClipSpeedFromDialog()
       return false;
    }
 
-   mTrackInterval.StretchRightTo(expectedEndTime);
+   mTrackInterval.Stretch(newDuration);
    mOldClipSpeed = mClipSpeed = 100 / mTrackInterval.GetStretchRatio();
 
    {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -83,8 +83,7 @@ double GetLeftAdjustLimit(const WaveTrack::Interval& interval,
                           bool isStretchMode)
 {
    if (!adjustingLeftBorder)
-      // A clip of one sample is invisible - who needs that ? Leave at least 2.
-      return interval.Start() + 2.0 / track.GetRate();
+      return interval.Start() + 1.0 / track.GetRate();
 
    const auto prevInterval = track.GetNextInterval(interval, PlaybackDirection::backward);
    if(isStretchMode)
@@ -101,8 +100,7 @@ double GetRightAdjustLimit(
    bool isStretchMode)
 {
    if (adjustingLeftBorder)
-      // A clip of one sample is invisible - who needs that ? Leave at least 2.
-      return interval.End() - 2.0 / track.GetRate();
+      return interval.End() - 1.0 / track.GetRate();
 
    const auto nextInterval = track.GetNextInterval(interval, PlaybackDirection::forward);
    if (isStretchMode)
@@ -199,6 +197,7 @@ public:
                  GetRightAdjustLimit(*mInterval, *mTrack, adjustLeftBorder, isStretchMode) }
       , mAdjustHandler { std::move(adjustHandler) }
    {
+      assert(mRange.first <= mRange.second);
       if(const auto trackList = mTrack->GetOwner())
       {
          mSnapManager = std::make_unique<SnapManager>(


### PR DESCRIPTION
Resolves: #5292

The issue isn't yet completely resolved - though it seem that zero clips are not a problem any more, but it's still very hard to use stretching with copy-paste approach, (especially when snapping enabled) as it often results in attempt to paste into preceding clip.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
