### PR TITLE
More time stretch hacks

### DIFF
--- a/libraries/lib-time-and-pitch/StaffPad/SimdComplexConversions_sse2.h
+++ b/libraries/lib-time-and-pitch/StaffPad/SimdComplexConversions_sse2.h
@@ -133,7 +133,6 @@ inline __m128 atan2_ps(__m128 y, __m128 x)
    __m128 zero = _mm_setzero_ps();
    __m128 x_eq_0 = _mm_cmpeq_ps(x, zero);
    __m128 x_gt_0 = _mm_cmpgt_ps(x, zero);
-   __m128 x_le_0 = _mm_cmple_ps(x, zero);
    __m128 y_eq_0 = _mm_cmpeq_ps(y, zero);
    __m128 x_lt_0 = _mm_cmplt_ps(x, zero);
    __m128 y_lt_0 = _mm_cmplt_ps(y, zero);
@@ -176,6 +175,13 @@ inline __m128 atan2_ps(__m128 y, __m128 x)
    result = _mm_or_ps(result, pi_result);
 
    return result;
+}
+
+// Computes atan2 for pairs of values, but inverting phase for odd subscripts
+inline __m128 atan2_ps_alternating(__m128 y, __m128 x)
+{
+   __m128 signs = _mm_setr_ps(1.f, -1.f, 1.f, -1.f);
+   return atan2_ps(_mm_mul_ps(y, signs), _mm_mul_ps(x, signs));
 }
 
 inline std::pair<__m128, __m128> sincos_ps(__m128 x)

--- a/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
+++ b/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
@@ -215,7 +215,7 @@ void _ms_to_lr(float* ch1, float* ch2, int n)
 template <class T>
 inline void multiply(T* dst, const T* src, int32_t n)
 {
-  audio::simd::perform_parallel_simd_aligned(dst, const_cast<T*>(src), n,
+  audio::simd::perform_parallel_simd_aligned(dst, src, n,
     [](auto& d, auto& s) { d = d * s; });
 }
 } // namespace

--- a/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
+++ b/libraries/lib-time-and-pitch/StaffPad/TimeAndPitch.cpp
@@ -212,6 +212,12 @@ void _ms_to_lr(float* ch1, float* ch2, int n)
   });
 }
 
+template <class T>
+inline void multiply(T* dst, const T* src, int32_t n)
+{
+  audio::simd::perform_parallel_simd_aligned(dst, const_cast<T*>(src), n,
+    [](auto& d, auto& s) { d = d * s; });
+}
 } // namespace
 
 // ----------------------------------------------------------------------------
@@ -329,7 +335,7 @@ void TimeAndPitch::_process_hop(int hop_a, int hop_s)
       _lr_to_ms(d->fft_timeseries.getPtr(0), d->fft_timeseries.getPtr(1), fftSize);
 
     for (int ch = 0; ch < _numChannels; ++ch)
-      vo::multiply(d->fft_timeseries.getPtr(ch), d->cosWindow.getPtr(0), d->fft_timeseries.getPtr(ch), fftSize);
+      multiply(d->fft_timeseries.getPtr(ch), d->cosWindow.getPtr(0), fftSize);
 
     // determine norm/phase
     d->fft.forwardReal(d->fft_timeseries, d->spectrum);
@@ -360,12 +366,12 @@ void TimeAndPitch::_process_hop(int hop_a, int hop_s)
       _ms_to_lr(d->fft_timeseries.getPtr(0), d->fft_timeseries.getPtr(1), fftSize);
 
     for (int ch = 0; ch < _numChannels; ++ch)
-      vo::multiply(d->fft_timeseries.getPtr(ch), d->cosWindow.getPtr(0), d->fft_timeseries.getPtr(ch), fftSize);
+      multiply(d->fft_timeseries.getPtr(ch), d->cosWindow.getPtr(0), fftSize);
   }
   else
   { // stretch factor == 1.0 => just apply window
     for (int ch = 0; ch < _numChannels; ++ch)
-      vo::multiply(d->fft_timeseries.getPtr(ch), d->sqWindow.getPtr(0), d->fft_timeseries.getPtr(ch), fftSize);
+      multiply(d->fft_timeseries.getPtr(ch), d->sqWindow.getPtr(0), fftSize);
   }
 
   {

--- a/libraries/lib-time-and-pitch/StaffPad/VectorOps.h
+++ b/libraries/lib-time-and-pitch/StaffPad/VectorOps.h
@@ -106,7 +106,7 @@ inline void calcPhases(const std::complex<float>* src, float* dst, int32_t n)
   simd_complex_conversions::perform_parallel_simd_aligned(
      src, dst, n,
      [](const __m128 rp, const __m128 ip, __m128& out)
-     { out = simd_complex_conversions::atan2_ps(ip, rp); });
+     { out = simd_complex_conversions::atan2_ps_alternating(ip, rp); });
 }
 
 inline void calcNorms(const std::complex<float>* src, float* dst, int32_t n)
@@ -128,7 +128,7 @@ inline void rotate(
 inline void calcPhases(const std::complex<float>* src, float* dst, int32_t n)
 {
   for (int32_t i = 0; i < n; i++)
-    dst[i] = std::arg(src[i]);
+    dst[i] = std::arg((i % 2) ? -src[i] : src[i]);
 }
 
 inline void calcNorms(const std::complex<float>* src, float* dst, int32_t n)

--- a/libraries/lib-time-and-pitch/StaffPad/VectorOps.h
+++ b/libraries/lib-time-and-pitch/StaffPad/VectorOps.h
@@ -71,13 +71,6 @@ inline void constantMultiplyAndAdd(const T* src, T constant, T* dst, int32_t n)
 }
 
 template <class T>
-inline void multiply(const T* src1, const T* src2, T* dst, int32_t n)
-{
-  for (int32_t i = 0; i < n; i++)
-    dst[i] = src1[i] * src2[i];
-}
-
-template <class T>
 inline void setToZero(T* dst, int32_t n)
 {
   std::fill(dst, dst + n, 0.f);


### PR DESCRIPTION
Still more performance squeezed from time stretching.

Eliminate unnecessary array rotation with an equivalent change of phase calculation; vectorize multiplication.

On my machine in release builds, first indications are another 10% saved.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
