### PR TITLE
Do not commit output of nyquist analyzers

### DIFF
--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -18,9 +18,11 @@
 int EffectOutputTracks::nEffectsDone = 0;
 
 EffectOutputTracks::EffectOutputTracks(
-   TrackList& tracks, std::optional<TimeInterval> effectTimeInterval,
-   bool allSyncLockSelected, bool stretchSyncLocked)
+   TrackList& tracks, EffectType effectType,
+   std::optional<TimeInterval> effectTimeInterval, bool allSyncLockSelected,
+   bool stretchSyncLocked)
     : mTracks { tracks }
+    , mEffectType { effectType }
 {
    assert(
       !effectTimeInterval.has_value() ||
@@ -136,9 +138,14 @@ void EffectOutputTracks::Commit()
       if (!mIMap[i])
          // This track was an addition to output tracks; add it to mTracks
          mTracks.AppendOne(std::move(*mOutputTracks));
-      else
+      else if (
+         mEffectType != EffectTypeNone && mEffectType != EffectTypeAnalyze)
          // Replace mTracks entry with the new track
          mTracks.ReplaceOne(*mIMap[i], std::move(*mOutputTracks));
+      else
+         // This output track was just a placeholder for pre-processing. Discard
+         // it.
+         mOutputTracks->Remove(*pOutputTrack);
       ++i;
    }
 

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -13,6 +13,8 @@
 class Track;
 class TrackList;
 
+#include "EffectInterface.h"
+
 #include <memory>
 #include <optional>
 #include <vector>
@@ -45,9 +47,9 @@ public:
        effectTimeInterval->first <= effectTimeInterval->second`
     */
    EffectOutputTracks(
-      TrackList& tracks, std::optional<TimeInterval> effectTimeInterval,
-      bool allSyncLockSelected = false,
-      bool stretchSyncLocked = false);
+      TrackList& tracks, EffectType effectType,
+      std::optional<TimeInterval> effectTimeInterval,
+      bool allSyncLockSelected = false, bool stretchSyncLocked = false);
    EffectOutputTracks(const EffectOutputTracks&) = delete;
 
    ~EffectOutputTracks();
@@ -81,6 +83,7 @@ public:
 
 private:
    TrackList &mTracks;
+   const EffectType mEffectType;
    /*!
     @invariant `mIMap.size() == mOutputTracks->Size()`
     @invariant `mIMap.size() == mOMap.size()`

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -65,7 +65,7 @@ bool PerTrackEffect::Process(
    EffectInstance &instance, EffectSettings &settings) const
 {
    auto pThis = const_cast<PerTrackEffect *>(this);
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } }, true };
    bool bGoodResult = true;
    // mPass = 1;
    if (DoPass1()) {

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -327,7 +327,7 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
    }
 
    if (!cancel) {
-      EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
+      EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } } };
 
       int trackNum = 0;
 

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -214,7 +214,7 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
    // Iterate over each track.
    // All needed because this effect needs to introduce
    // silence in the sync-lock group tracks to keep sync
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } }, true };
    bool bGoodResult = true;
 
    mCurTrackNum = 0;

--- a/src/effects/ClickRemoval.cpp
+++ b/src/effects/ClickRemoval.cpp
@@ -113,7 +113,7 @@ bool EffectClickRemoval::CheckWhetherSkipEffect(const EffectSettings &) const
 
 bool EffectClickRemoval::Process(EffectInstance &, EffectSettings &)
 {
-   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } } };
    bool bGoodResult = true;
    mbDidSomething = false;
 

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -402,7 +402,7 @@ struct EffectEqualization::Task {
 
 bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
 {
-   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } } };
    mParameters.CalcFilter();
    bool bGoodResult = true;
 

--- a/src/effects/FindClipping.cpp
+++ b/src/effects/FindClipping.cpp
@@ -101,7 +101,7 @@ bool EffectFindClipping::Process(EffectInstance &, EffectSettings &)
 
    // JC: Only process selected tracks.
    // PRL:  Compute the strech into temporary tracks.  Don't commit the stretch.
-   EffectOutputTracks temp{ *mTracks, { {mT0, mT1} } };
+   EffectOutputTracks temp { *mTracks, GetType(), { { mT0, mT1 } } };
    for (auto t : temp.Get().Selected<const WaveTrack>()) {
       double trackStart = t->GetStartTime();
       double trackEnd = t->GetEndTime();

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -30,7 +30,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
 
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } }, true };
 
    // Iterate over the tracks
    bool bGoodResult = true;

--- a/src/effects/Loudness.cpp
+++ b/src/effects/Loudness.cpp
@@ -105,7 +105,7 @@ bool EffectLoudness::Process(EffectInstance &, EffectSettings &)
    );
 
    // Iterate over each track
-   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } } };
    bool bGoodResult = true;
    auto topMsg = XO("Normalizing Loudness...\n");
 

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -637,7 +637,7 @@ bool EffectNoiseReduction::Process(EffectInstance &, EffectSettings &)
 {
    // This same code will either reduce noise or profile it
 
-   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } } };
 
    auto track = *(outputs.Get().Selected<const WaveTrack>()).begin();
    if (!track)

--- a/src/effects/Normalize.cpp
+++ b/src/effects/Normalize.cpp
@@ -106,7 +106,7 @@ bool EffectNormalize::Process(EffectInstance &, EffectSettings &)
    }
 
    //Iterate over each track
-   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } } };
    bool bGoodResult = true;
    double progress = 0;
    TranslatableString topMsg;

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -148,7 +148,7 @@ double EffectPaulstretch::CalcPreviewInputLength(
 bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
 {
    // Pass true because sync lock adjustment is needed
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } }, true };
    auto newT1 = mT1;
    int count = 0;
    // Process selected wave tracks first, to find the new t1 value

--- a/src/effects/Repair.cpp
+++ b/src/effects/Repair.cpp
@@ -76,7 +76,7 @@ bool EffectRepair::Process(EffectInstance &, EffectSettings &)
    // But for now, Cancel isn't supported without this.
    // Repair doesn't make sense for stretched clips, so don't pass a stretch
    // interval.
-   EffectOutputTracks outputs { *mTracks, {} };
+   EffectOutputTracks outputs { *mTracks, GetType(), {} };
    bool bGoodResult = true;
 
    int count = 0;

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -92,7 +92,7 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
 {
    // Set up mOutputTracks.
    // This effect needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } }, true };
 
    int nTrack = 0;
    bool bGoodResult = true;
@@ -121,7 +121,7 @@ bool EffectRepeat::Process(EffectInstance &, EffectSettings &)
          auto tempList = track.Copy(mT0, mT1);
          const auto firstTemp = *tempList->Any<const WaveTrack>().begin();
 
-         
+
 
          auto t0 = tc;
          for (size_t j = 0; j < repeatCount; ++j) {

--- a/src/effects/Reverse.cpp
+++ b/src/effects/Reverse.cpp
@@ -73,7 +73,9 @@ bool EffectReverse::IsInteractive() const
 bool EffectReverse::Process(EffectInstance &, EffectSettings &)
 {
    //all needed because Reverse should move the labels too
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true, true };
+   EffectOutputTracks outputs {
+      *mTracks, GetType(), { { mT0, mT1 } }, true, true
+   };
    bool bGoodResult = true;
    int count = 0;
 

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -224,7 +224,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
 
    //Iterate over each track
    //all needed because this effect needs to introduce silence in the group tracks to keep sync
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } }, true };
    mCurTrackNum = 0;
 
    double maxDuration = 0.0;

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -87,7 +87,7 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
 
    //Iterate over each track
    // Needs all for sync-lock grouping.
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } }, true };
    bool bGoodResult = true;
 
    mPreserveLength = preserveLength;

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -79,9 +79,11 @@ bool EffectStereoToMono::Process(EffectInstance &, EffectSettings &)
 {
    // Do not use mWaveTracks here.  We will possibly DELETE tracks,
    // so we must use the "real" tracklist.
-   EffectOutputTracks outputs { *mTracks,
+   EffectOutputTracks outputs {
+      *mTracks,
+      GetType(),
       // This effect ignores mT0 and mT1 but always mixes the entire tracks.
-      {{ mTracks->GetStartTime(), mTracks->GetEndTime() }}
+      { { mTracks->GetStartTime(), mTracks->GetEndTime() } }
    };
    bool bGoodResult = true;
 
@@ -180,7 +182,7 @@ bool EffectStereoToMono::ProcessOne(TrackList &outputs,
    const auto unlinkedTracks = outputs.UnlinkChannels(track);
    assert(unlinkedTracks.size() == 2);
    outputs.Remove(*unlinkedTracks[1]);
-   
+
    track.Clear(start, end);
    track.Paste(start, *outTrack);
    RealtimeEffectList::Get(track).Clear();

--- a/src/effects/TruncSilence.cpp
+++ b/src/effects/TruncSilence.cpp
@@ -273,7 +273,9 @@ bool EffectTruncSilence::ProcessIndependently()
    // Now do the work
 
    // Copy tracks
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true, true };
+   EffectOutputTracks outputs {
+      *mTracks, GetType(), { { mT0, mT1 } }, true, true
+   };
    double newT1 = 0.0;
 
    {
@@ -307,7 +309,9 @@ bool EffectTruncSilence::ProcessIndependently()
 bool EffectTruncSilence::ProcessAll()
 {
    // Copy tracks
-   EffectOutputTracks outputs{ *mTracks, {{ mT0, mT1 }}, true, true };
+   EffectOutputTracks outputs {
+      *mTracks, GetType(), { { mT0, mT1 } }, true, true
+   };
 
    // Master list of silent regions.
    // This list should always be kept in order.

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -28,7 +28,7 @@ bool EffectTwoPassSimpleMono::Process(
    mSecondPassDisabled = false;
 
    InitPass1();
-   EffectOutputTracks outputs { *mTracks, {{ mT0, mT1 }} };
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } } };
 
    mWorkTracks = TrackList::Create(const_cast<AudacityProject*>(FindProject()));
    for (auto track : outputs.Get().Selected<WaveTrack>()) {

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -770,8 +770,9 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
    // to operate on the selected wave tracks
    std::optional<EffectOutputTracks> oOutputs;
    if (!bOnePassTool)
-      oOutputs.emplace(*mTracks,
-         EffectOutputTracks::TimeInterval{ mT0, mT1 }, true);
+      oOutputs.emplace(
+         *mTracks, GetType(), EffectOutputTracks::TimeInterval { mT0, mT1 },
+         true, false);
 
    mNumSelectedChannels = bOnePassTool
       ? 0


### PR DESCRIPTION
Prior to this change, using Nyquist analysis tools on stretched clips replaced the selection with the stretch-rendered audio, which is not wanted.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Nyquist analysis tools (e.g., RMS) do not result in rendering the stretched clip. (The progress bar may show up, but that's only for analysis.)
- [x] Nyquist processing or generating tools still behave as before.