### PR TITLE
Fix bar formats when using a screen reader.

### DIFF
--- a/src/widgets/NumericTextCtrl.cpp
+++ b/src/widgets/NumericTextCtrl.cpp
@@ -1137,6 +1137,11 @@ wxAccStatus NumericTextCtrlAx::GetName(int childId, wxString *name)
 
    wxString ctrlString = mCtrl->GetString();
    int field = mDigits[mCtrl->GetFocusedDigit()].field + 1;
+   // In bar formats, the size of the first field can automatically
+   // increase. So use the position of the focused digit from
+   // the end, rather than the start, to determine whether
+   // the focus has changed. See issue #5344.
+   int childIdFromEnd = mCtrl->mBoxes.size() - childId + 1;
 
    // Return the entire string including the control label
    // when the requested child ID is wxACC_SELF.  (Mainly when
@@ -1161,7 +1166,7 @@ wxAccStatus NumericTextCtrlAx::GetName(int childId, wxString *name)
    // when the focus has been moved to another digit. This else if statement
    // ensures that this is the case, by using a cached value if nothing
    // has changed.
-   else if (childId == mLastDigit && ctrlString.IsSameAs(mLastCtrlString)) {
+   else if (childIdFromEnd == mLastDigit && ctrlString.IsSameAs(mLastCtrlString)) {
       *name = mCachedName;
    }
    else {
@@ -1194,13 +1199,13 @@ wxAccStatus NumericTextCtrlAx::GetName(int childId, wxString *name)
                  wxT(", ") +     // comma inserts a slight pause
                  mCtrl->GetString().at(mDigits[childId - 1].pos);
          mLastField = field;
-         mLastDigit = childId;
+         mLastDigit = childIdFromEnd;
       }
       // The user has moved from one digit to another within a field so
       // just report the digit under the cursor.
-      else if (mLastDigit != childId) {
+      else if (mLastDigit != childIdFromEnd) {
          *name = mCtrl->GetString().at(mDigits[childId - 1].pos);
-         mLastDigit = childId;
+         mLastDigit = childIdFromEnd;
       }
       // The user has updated the value of a field, so report the field's
       // value only.


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5344

Bar formats in time controls have been changed so that the size of the first field can automatically increase. This enables bar numbers greater than 999.

Problem:
NumericTextCtrlAx::GetName() uses the position of the focused digit from the start of the digits to determine whether the focus has moved to a different digit. However this doesn't work if extra digits are added at the start of the first field, and can cause screen readers to read the wrong value as described in issue #5344.

Fix:
Use the position of the focused digit from the end of the digits to determine whether the focus has moved to a different digit.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
