### PR TITLE
Native Opus support

### DIFF
--- a/cmake-proxies/cmake-modules/DependenciesList.cmake
+++ b/cmake-proxies/cmake-modules/DependenciesList.cmake
@@ -17,6 +17,7 @@ audacity_find_package(WavPack)
 audacity_find_package(Ogg OPTION_NAME libogg)
 audacity_find_package(FLAC OPTION_NAME libflac)
 audacity_find_package(Opus OPTION_NAME libopus)
+audacity_find_package(opusfile OPTION_NAME opusfile)
 audacity_find_package(Vorbis OPTION_NAME libvorbis)
 audacity_find_package(SndFile CONAN_PACKAGE_NAME libsndfile OPTION_NAME libsndfile)
 

--- a/cmake-proxies/cmake-modules/Findopusfile.cmake
+++ b/cmake-proxies/cmake-modules/Findopusfile.cmake
@@ -1,0 +1,36 @@
+#[[
+A module to look for Opus
+]]
+
+if( NOT opusfile_FOUND )
+   include( FindPackageHandleStandardArgs)
+
+   find_path( opusfile_INCLUDE_DIR opus/opusfile.h
+      HINTS
+         ${OPUSFILE_ROOT}
+   )
+
+   find_library( opusfile_LIBRARIES
+      NAMES
+         opusfile
+      HINTS
+         ${OPUSFILE_ROOT}
+   )
+
+   find_package_handle_standard_args( opusfile DEFAULT_MSG opusfile_INCLUDE_DIR opusfile_LIBRARIES )
+
+   if( opusfile_FOUND )
+      if( NOT TARGET opusfile::opusfile )
+         add_library( opusfile::opusfile INTERFACE IMPORTED GLOBAL )
+
+         target_include_directories( opusfile::opusfile INTERFACE ${opusfile_INCLUDE_DIR} "${opusfile_INCLUDE_DIR}/opus" )
+         target_link_libraries( opusfile::opusfile INTERFACE ${Oopusfile_LIBRARIES} )
+      endif()
+
+      mark_as_advanced(
+         opusfile_FOUND
+         opusfile_INCLUDE_DIR
+         opusfile_LIBRARIES
+      )
+   endif()
+endif()

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -163,6 +163,7 @@ class AudacityConan(ConanFile):
         AudacityDependency("ogg", "1.3.5"),
         AudacityDependency("flac", "1.4.2"),
         AudacityDependency("opus", "1.3.1"),
+        AudacityDependency("opusfile", "0.12", package_options={ "shared": False, "http": False }),
         AudacityDependency("vorbis", "1.3.7"),
         AudacityDependency("libsndfile", "1.0.31", package_options={ "programs": False }),
 

--- a/libraries/lib-import-export/ExportPluginRegistry.cpp
+++ b/libraries/lib-import-export/ExportPluginRegistry.cpp
@@ -55,7 +55,7 @@ void ExportPluginRegistry::Initialize()
    using namespace Registry;
    static OrderingPreferenceInitializer init{
       PathStart,
-      { {wxT(""), wxT("PCM,MP3,OGG,FLAC,MP2,CommandLine,FFmpeg") } },
+      { {wxT(""), wxT("PCM,MP3,OGG,Opus,FLAC,WavPack,FFmpeg,MP2,CommandLine") } },
    };
 
    struct CreatePluginsVisitor final : Visitor {

--- a/libraries/lib-import-export/Import.cpp
+++ b/libraries/lib-import-export/Import.cpp
@@ -173,7 +173,7 @@ bool Importer::Initialize()
    using namespace Registry;
    static OrderingPreferenceInitializer init{
       PathStart,
-      { {wxT(""), wxT("AUP,PCM,OGG,FLAC,MP3,LOF,WavPack,FFmpeg") } }
+      { {wxT(""), wxT("AUP,PCM,OGG,Opus,FLAC,MP3,LOF,WavPack,FFmpeg") } }
       // QT and GStreamer are only conditionally compiled and would get
       // placed at the end if present
    };

--- a/libraries/lib-module-manager/ModuleSettings.cpp
+++ b/libraries/lib-module-manager/ModuleSettings.cpp
@@ -31,6 +31,7 @@ static const std::unordered_set<wxString> &autoEnabledModules()
       "mod-cl",
       "mod-lof",
       "mod-aup",
+      "mod-opus",
    };
    return modules;
 }

--- a/libraries/lib-tags/Tags.cpp
+++ b/libraries/lib-tags/Tags.cpp
@@ -301,6 +301,11 @@ void Tags::Clear()
    mMap.clear();
 }
 
+size_t Tags::Count() const
+{
+   return mMap.size();
+}
+
 namespace {
    bool EqualMaps(const TagMap &map1, const TagMap &map2)
    {

--- a/libraries/lib-tags/Tags.h
+++ b/libraries/lib-tags/Tags.h
@@ -118,6 +118,8 @@ class TAGS_API Tags final
    bool IsEmpty();
    void Clear();
 
+   size_t Count() const;
+
    // UndoStateExtension implementation
    void RestoreUndoRedoState(AudacityProject &) override;
 

--- a/linux/packages/arch/dependencies.sh
+++ b/linux/packages/arch/dependencies.sh
@@ -45,6 +45,8 @@ deps=(
    wxwidgets-gtk3
    vst3sdk
    rapidjson
+   opusfile
+   opus
 )
 
 pacman -Syu --noconfirm \

--- a/linux/packages/fedora34/dependencies.sh
+++ b/linux/packages/fedora34/dependencies.sh
@@ -55,6 +55,8 @@ deps=(
    mpg123-devel
    wavpack-devel
    rapidjson
+   opusfile-devel
+   opus-devel
 )
 
 dnf install -y \

--- a/linux/packages/ubuntu-20.04/dependencies.sh
+++ b/linux/packages/ubuntu-20.04/dependencies.sh
@@ -62,6 +62,7 @@ deps=(
    libegl1-mesa-dev
    libmpg123-dev
    libwavpack-dev
+   libopusfile-dev
 )
 
 apt-get update

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -41,6 +41,10 @@ if ( USE_FFMPEG )
    list ( APPEND MODULES mod-ffmpeg )
 endif()
 
+if ( USE_LIBOPUS AND USE_OPUSFILE AND USE_LIBOGG )
+   list ( APPEND MODULES mod-opus )
+endif()
+
 foreach( MODULE ${MODULES} )
    add_subdirectory("${MODULE}")
 endforeach()

--- a/modules/mod-ffmpeg/ExportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ExportFFmpeg.cpp
@@ -199,6 +199,7 @@ const std::initializer_list<PlainExportOptionsEditor::OptionDesc> AMRNBOptions {
    }
 };
 
+#ifdef SHOW_FFMPEG_OPUS_EXPORT
 enum : int
 {
    OPUSOptionIDBitRate = 0,
@@ -322,6 +323,7 @@ const std::initializer_list<PlainExportOptionsEditor::OptionDesc> OPUSOptions {
       }, wxT("/FileFormats/OPUSCutoff")
    },
 };
+#endif
 
 enum : int
 {
@@ -794,8 +796,10 @@ ExportFFmpeg::CreateOptionsEditor(int format, ExportOptionsEditor::Listener* lis
          AMRNBOptions,
          ExportOptionsEditor::SampleRateList {8000},
          listener);
+#ifdef SHOW_FFMPEG_OPUS_EXPORT
    case FMT_OPUS:
       return std::make_unique<PlainExportOptionsEditor>(OPUSOptions, listener);
+#endif
    case FMT_WMA2:
       return std::make_unique<PlainExportOptionsEditor>(
          WMAOptions,
@@ -1019,6 +1023,7 @@ bool FFmpegExporter::InitCodecs(int sampleRate,
       mSampleRate = 8000;
       mEncAudioCodecCtx->SetBitRate(ExportPluginHelpers::GetParameterValue(parameters, AMRNBOptionIDBitRate, 12200));
       break;
+#ifdef SHOW_FFMPEG_OPUS_EXPORT
    case FMT_OPUS:
       options.Set("b", ExportPluginHelpers::GetParameterValue<std::string>(parameters, OPUSOptionIDBitRate, "128000"), 0);
       options.Set("vbr", ExportPluginHelpers::GetParameterValue<std::string>(parameters, OPUSOptionIDVBRMode, "on"), 0);
@@ -1028,6 +1033,7 @@ bool FFmpegExporter::InitCodecs(int sampleRate,
       options.Set("cutoff", ExportPluginHelpers::GetParameterValue<std::string>(parameters, OPUSOptionIDCutoff, "0"), 0);
       options.Set("mapping_family", mChannels <= 2 ? "0" : "255", 0);
       break;
+#endif
    case FMT_WMA2:
       mEncAudioCodecCtx->SetBitRate(ExportPluginHelpers::GetParameterValue(parameters, WMAOptionIDBitRate, 198000));
       if (!CheckSampleRate(

--- a/modules/mod-ffmpeg/ExportFFmpegOptions.cpp
+++ b/modules/mod-ffmpeg/ExportFFmpegOptions.cpp
@@ -358,7 +358,9 @@ ExposedFormat ExportFFmpegOptions::fmts[] =
    {FMT_M4A,   wxT("M4A"),    wxT("m4a"),  wxT("ipod"), 48,  AV_CANMETA,              true,  XO("M4A (AAC) Files (FFmpeg)"),         AUDACITY_AV_CODEC_ID_AAC,    true},
    {FMT_AC3,   wxT("AC3"),    wxT("ac3"),  wxT("ac3"),  7,   AV_VERSION_INT(0,0,0),   false, XO("AC3 Files (FFmpeg)"),               AUDACITY_AV_CODEC_ID_AC3,    true},
    {FMT_AMRNB, wxT("AMRNB"),  wxT("amr"),  wxT("amr"),  1,   AV_VERSION_INT(0,0,0),   false, XO("AMR (narrow band) Files (FFmpeg)"), AUDACITY_AV_CODEC_ID_AMR_NB, true},
+   #ifdef SHOW_FFMPEG_OPUS_EXPORT
    {FMT_OPUS,  wxT("OPUS"),   wxT("opus"), wxT("opus"), 255, AV_CANMETA,              true,  XO("Opus (OggOpus) Files (FFmpeg)"),    AUDACITY_AV_CODEC_ID_OPUS,   true},
+   #endif
    {FMT_WMA2,  wxT("WMA"),    wxT("wma"),  wxT("asf"),  2,   AV_VERSION_INT(52,53,0), false, XO("WMA (version 2) Files (FFmpeg)"),   AUDACITY_AV_CODEC_ID_WMAV2,  true},
    {FMT_OTHER, wxT("FFMPEG"), wxT(""),     wxT(""),     255, AV_CANMETA,              true,  XO("Custom FFmpeg Export"),             AUDACITY_AV_CODEC_ID_NONE,   true}
 };

--- a/modules/mod-ffmpeg/ExportFFmpegOptions.h
+++ b/modules/mod-ffmpeg/ExportFFmpegOptions.h
@@ -30,7 +30,9 @@ enum FFmpegExposedFormat
    FMT_M4A,
    FMT_AC3,
    FMT_AMRNB,
+#ifdef SHOW_FFMPEG_OPUS_EXPORT
    FMT_OPUS,
+#endif
    FMT_WMA2,
    FMT_OTHER,
    FMT_LAST

--- a/modules/mod-opus/CMakeLists.txt
+++ b/modules/mod-opus/CMakeLists.txt
@@ -1,0 +1,17 @@
+set( TARGET mod-opus )
+
+set( SOURCES
+      ImportOpus.cpp
+      ExportOpus.cpp
+      Opus.cpp
+)
+
+set( LIBRARIES
+   PRIVATE
+      lib-import-export-interface
+      Opus::opus
+      opusfile::opusfile
+      Ogg::ogg
+)
+
+audacity_module( ${TARGET} "${SOURCES}" "${LIBRARIES}" "" "" )

--- a/modules/mod-opus/ExportOpus.cpp
+++ b/modules/mod-opus/ExportOpus.cpp
@@ -1,0 +1,904 @@
+/**********************************************************************
+
+   SPDX-License-Identifier: GPL-2.0-or-later
+
+   Audacity: A Digital Audio Editor
+
+   ExportOpus.cpp
+
+   Dmitry Vedenko
+
+**********************************************************************/
+
+#include "Export.h"
+
+#include <random>
+#include <string_view>
+
+#include <ogg/ogg.h>
+#include <opus/opus.h>
+#include <opus/opus_multistream.h>
+
+#include "wxFileNameWrapper.h"
+#include "Mix.h"
+
+#include "Track.h"
+#include "Tags.h"
+
+#include "ExportPluginHelpers.h"
+#include "ExportOptionsEditor.h"
+#include "ExportPluginRegistry.h"
+
+#include "PlainExportOptionsEditor.h"
+
+#include "CodeConversions.h"
+
+
+namespace
+{
+// Detect this computer's endianness
+// This should go to utils?
+bool IsLittleEndian()
+{
+   const std::uint32_t x = 1u;
+   return static_cast<const unsigned char*>(static_cast<const void*>(&x))[0];
+   // We will assume the same for other widths!
+}
+
+TranslatableString GetOpusEncErrorString(int error)
+{
+   switch (error)
+   {
+   case OPUS_OK:
+      return XO("no error");
+   case OPUS_BAD_ARG:
+      return XO("invalid argument");
+   case OPUS_BUFFER_TOO_SMALL:
+      return XO("buffer too small");
+   case OPUS_INTERNAL_ERROR:
+      return XO("internal error");
+   case OPUS_INVALID_PACKET:
+      return XO("invalid packet");
+   case OPUS_UNIMPLEMENTED:
+      return XO("not implemented");
+   case OPUS_INVALID_STATE:
+      return XO("invalid state");
+   case OPUS_ALLOC_FAIL:
+      return XO("memory allocation has failed");
+   default:
+      return XO("Unknown error");
+   }
+}
+
+[[noreturn]] void FailExport(const TranslatableString& title, int errorCode = 0)
+{
+   if (errorCode != 0)
+   {
+      throw ExportException(Verbatim("%s: %s")
+                               .Format(title, GetOpusEncErrorString(errorCode))
+                               .Translation());
+   }
+
+   throw ExportException(title.Translation());
+}
+
+/* i18n-hint: kbps abbreviates "thousands of bits per second" */
+TranslatableString n_kbps(int n)
+{
+   return XO("%d kbps").Format(n);
+}
+
+enum : int
+{
+   OPUSOptionIDBitRate = 0,
+   OPUSOptionIDQuality,
+   OPUSOptionIDFrameDuration,
+   OPUSOptionIDVBRMode,
+   OPUSOptionIDApplication,
+   OPUSOptionIDCutoff
+};
+
+namespace VBRMode
+{
+enum : int
+{
+   CBR,
+   VBR,
+   CVBR
+};
+}
+
+const std::initializer_list<PlainExportOptionsEditor::OptionDesc> OPUSOptions {
+   {
+      {
+         OPUSOptionIDBitRate, XO("Bit Rate"),
+         OPUS_AUTO,
+         ExportOption::TypeEnum,
+         {
+            6000,
+            8000,
+            16000,
+            24000,
+            32000,
+            40000,
+            48000,
+            64000,
+            80000,
+            96000,
+            128000,
+            160000,
+            192000,
+            256000,
+            OPUS_AUTO,
+            OPUS_BITRATE_MAX,
+         },
+         {
+            n_kbps( 6 ),
+            n_kbps( 8 ),
+            n_kbps( 16 ),
+            n_kbps( 24 ),
+            n_kbps( 32 ),
+            n_kbps( 40 ),
+            n_kbps( 48 ),
+            n_kbps( 64 ),
+            n_kbps( 80 ),
+            n_kbps( 96 ),
+            n_kbps( 128 ),
+            n_kbps( 160 ),
+            n_kbps( 192 ),
+            n_kbps( 256 ),
+            XO("Auto"),
+            XO("Maximum")
+         }
+      }, wxT("/FileFormats/OPUS/Bitrate")
+   },
+   {
+      {
+         OPUSOptionIDQuality, XO("Quality"),
+         10,
+         ExportOption::TypeRange,
+         { 0, 10 }
+      }, wxT("/FileFormats/OPUS/Quality")
+   },
+   {
+      {
+         OPUSOptionIDFrameDuration, XO("Frame Duration"),
+         200,
+         ExportOption::TypeEnum,
+         {
+            25,
+            50,
+            100,
+            200,
+            400,
+            600,
+         },
+         {
+            XO("2.5 ms"),
+            XO("5 ms"),
+            XO("10 ms"),
+            XO("20 ms"),
+            XO("40 ms"),
+            XO("60 ms"),
+         }
+      }, wxT("/FileFormats/OPUS/FrameDuration")
+   },
+   {
+      {
+         OPUSOptionIDVBRMode, XO("VBR Mode"),
+         VBRMode::VBR,
+         ExportOption::TypeEnum,
+         { VBRMode::CBR, VBRMode::VBR, VBRMode::CVBR },
+         { XO("Off"), XO("On"), XO("Constrained") }
+      }, wxT("/FileFormats/OPUS/VbrMode")
+   },
+   {
+      {
+         OPUSOptionIDApplication, XO("Optimize for"),
+         OPUS_APPLICATION_AUDIO,
+         ExportOption::TypeEnum,
+         { OPUS_APPLICATION_VOIP, OPUS_APPLICATION_AUDIO, OPUS_APPLICATION_RESTRICTED_LOWDELAY },
+         { XO("Speech"), XO("Audio"), XO("Low Delay") }
+      }, wxT("/FileFormats/OPUS/Application")
+   },
+   {
+      {
+         OPUSOptionIDCutoff, XO("Cutoff"),
+         OPUS_AUTO,
+         ExportOption::TypeEnum,
+         {
+            OPUS_AUTO,
+            OPUS_BANDWIDTH_NARROWBAND,
+            OPUS_BANDWIDTH_MEDIUMBAND,
+            OPUS_BANDWIDTH_WIDEBAND,
+            OPUS_BANDWIDTH_SUPERWIDEBAND,
+            OPUS_BANDWIDTH_FULLBAND,
+         },
+         {
+            XO("Auto"),
+            XO("Narrowband"),
+            XO("Mediumband"),
+            XO("Wideband"),
+            XO("Super Wideband"),
+            XO("Fullband")
+         }
+      }, wxT("/FileFormats/OPUS/Cutoff")
+   },
+};
+
+constexpr int supportedSampleRates[] = { 8000, 12000, 16000, 24000, 48000 };
+
+bool IsValidSampleRate(int sampleRate) noexcept
+{
+   for (auto sr : supportedSampleRates)
+      if (sr == sampleRate)
+         return true;
+   return false;
+}
+}
+
+class OpusExportProcessor final : public ExportProcessor
+{
+   struct OggPacket final
+   {
+      using byte_type = std::remove_pointer_t<decltype(ogg_packet::packet)>;
+      static_assert(sizeof(byte_type) == 1);
+
+      OggPacket(int64_t packetNo, bool resizable)
+          : resizable { resizable }
+      {
+         packet.packetno = packetNo;
+      }
+
+      explicit OggPacket(int64_t packetNo)
+          : OggPacket { packetNo, false }
+      {
+      }
+
+      OggPacket(int64_t packetNo, long size, bool resizable)
+          : OggPacket { packetNo, resizable }
+      {
+         Resize(size);
+      }
+
+      void Resize(long size)
+      {
+         buffer.resize(size);
+         packet.packet = buffer.data();
+      }
+
+      void Reset() noexcept
+      {
+         packet.bytes = 0;
+      }
+
+      void MarkBOS() noexcept
+      {
+         packet.b_o_s = 1;
+      }
+
+      void MarkEOS() noexcept
+      {
+         packet.e_o_s = 1;
+      }
+
+      void Write(const void* data, const long length)
+      {
+         const auto nextPos = packet.bytes + length;
+
+         if (nextPos > buffer.size())
+         {
+            if (resizable)
+               Resize(std::max<size_t>(1024, buffer.size() * 2));
+            else
+               FailExport(
+                  XO("Buffer overflow in OGG packet"), OPUS_BUFFER_TOO_SMALL);
+         }
+
+         std::copy(
+            reinterpret_cast<const byte_type*>(data),
+            reinterpret_cast<const byte_type*>(data) + length,
+            buffer.data() + packet.bytes);
+
+         packet.bytes = nextPos;
+      }
+
+      template<typename IntType>
+      void Write(IntType value)
+      {
+         static_assert(std::is_integral_v<IntType>);
+         if constexpr (sizeof (IntType) == 1)
+         {
+            Write(&value, 1);
+         }
+         else
+         {
+            if (IsLittleEndian ())
+            {
+               Write(&value, sizeof (IntType));
+            }
+            else
+            {
+               IntType swapped = 0;
+               for (size_t i = 0; i < sizeof (IntType); ++i)
+               {
+                  swapped <<= 8;
+                  swapped |= (value >> (i * 8)) & 0xFF;
+               }
+               Write(&swapped, sizeof (IntType));
+            }
+         }
+      }
+
+      byte_type* GetBuffer()
+      {
+         return buffer.data();
+      }
+
+      size_t GetBufferSize() const
+      {
+         return buffer.size();
+      }
+
+      ogg_packet packet {};
+  
+   private:
+      std::vector<byte_type> buffer;
+      bool resizable { false };
+   };
+
+   struct
+   {
+      TranslatableString status;
+      int32_t sampleRate {};
+
+      double t0 {};
+      double t1 {};
+      unsigned numChannels {};
+      wxFileNameWrapper fName;
+      wxFile outFile;
+      std::unique_ptr<Mixer> mixer;
+      std::unique_ptr<Tags> metadata;
+
+      // Encoder properties
+      struct OpusState final
+      {
+         ~OpusState()
+         {
+            if (encoder != nullptr)
+               opus_multistream_encoder_destroy(encoder);
+         }
+
+         OpusMSEncoder* encoder {};
+
+         int32_t frameSize {};
+         int32_t sampleRateFactor {};
+         uint16_t preskip {};
+         uint8_t channelMapping {};
+         uint8_t nbStreams {};
+         uint8_t nbCoupled {};
+         uint8_t streamMap[255] {};
+      } opus;
+      
+      // Bitstream properties
+      struct OggState final
+      {
+         OggState()
+             // Audio always starts in the packet #3.
+             // The first one is for opus header, the second one is for tags,
+             // both are mandatory
+             : audioStreamPacket(2)
+         {
+            // As per OGG docs - stream serialno should be a random
+            // number. It is used to stitch the streams, this doesn't
+            // matter much for Audacity
+            std::mt19937 gen(std::time(nullptr));
+            ogg_stream_init(&stream, gen());
+         }
+
+         void PacketIn(const OggPacket& packet)
+         {
+            ogg_stream_packetin(&stream,
+               // C libraries are not always const-correct
+               const_cast<ogg_packet*>(&packet.packet));
+         }
+
+         void WriteOut(wxFile& outputStream)
+         {
+            ogg_page page {};
+
+            while (ogg_stream_pageout(&stream, &page))
+               WritePage(outputStream, page);
+         }
+
+         void Flush(wxFile& outputStream)
+         {
+            ogg_page page {};
+
+            while (ogg_stream_flush(&stream, &page))
+               WritePage(outputStream, page);
+         }
+
+         ogg_stream_state stream;
+
+         OggPacket audioStreamPacket;
+
+      private:
+         void WritePage(wxFile& outputStream, const ogg_page& page)
+         {
+            if (
+               outputStream.Write(page.header, page.header_len) !=
+               page.header_len)
+               FailExport(XO("Unable to write OGG page header"));
+
+            if (outputStream.Write(page.body, page.body_len) != page.body_len)
+               FailExport(XO("Unable to write OGG page"));
+         }
+      } ogg;
+
+      std::vector<float> encodeBuffer;
+   } context;
+
+   void WriteOpusHeader();
+   void WriteTags();
+
+   int32_t GetBestFrameSize(int32_t samplesCount) const noexcept
+   {
+      static const int32_t multipliers[] = {
+         25, 50, 100, 200, 400, 600,
+      };
+
+      const auto sampleRate = context.sampleRate;
+
+      for (auto multiplier : multipliers)
+      {
+         const auto frameSize = multiplier * sampleRate / 10000;
+
+         if (samplesCount <= frameSize)
+            return frameSize;
+      }
+
+      return 60 * sampleRate / 1000;
+   }
+
+public:
+
+   ~OpusExportProcessor();
+
+   bool Initialize(AudacityProject& project,
+      const Parameters& parameters,
+      const wxFileNameWrapper& filename,
+      double t0, double t1, bool selectedOnly,
+      double sampleRate, unsigned channels,
+      MixerOptions::Downmix* mixerSpec,
+      const Tags* tags) override;
+
+   ExportResult Process(ExportProcessorDelegate& delegate) override;
+
+};
+
+class ExportOpus final : public ExportPlugin
+{
+public:
+
+   ExportOpus();
+
+   int GetFormatCount() const override;
+   FormatInfo GetFormatInfo(int) const override;
+
+   std::vector<std::string> GetMimeTypes(int) const override;
+
+   std::unique_ptr<ExportOptionsEditor>
+   CreateOptionsEditor(int, ExportOptionsEditor::Listener*) const override;
+
+   std::unique_ptr<ExportProcessor> CreateProcessor(int format) const override;
+};
+
+ExportOpus::ExportOpus() = default;
+
+int ExportOpus::GetFormatCount() const
+{
+   return 1;
+}
+
+FormatInfo ExportOpus::GetFormatInfo(int) const
+{
+   return {
+      wxT("Opus"), XO("Opus Files"), { wxT("opus") }, 255, true
+   };
+}
+
+std::vector<std::string> ExportOpus::GetMimeTypes(int) const
+{
+   return { "audio/opus" };
+}
+
+std::unique_ptr<ExportOptionsEditor>
+ExportOpus::CreateOptionsEditor(int, ExportOptionsEditor::Listener* listener) const
+{
+   return std::make_unique<PlainExportOptionsEditor>(
+      OPUSOptions,
+      ExportOptionsEditor::SampleRateList { 8000, 12000, 16000, 24000, 48000 },
+      listener);
+}
+
+std::unique_ptr<ExportProcessor> ExportOpus::CreateProcessor(int) const
+{
+   return std::make_unique<OpusExportProcessor>();
+}
+
+
+void OpusExportProcessor::WriteOpusHeader()
+{
+   const auto headerSize =
+      // "OpusHead"
+      8 +
+      // Version number (always 1)
+      1 +
+      // Channels count
+      1 +
+      // Preskip
+      2 +
+      // Input sample rate
+      4 +
+      // Output gain (always 0)
+      2 +
+      // Channel mapping
+      1 +
+      (context.opus.channelMapping == 0 ? 0 :
+         (
+            // Stream count
+            1 +
+            // Two channel stream count
+            1 +
+            // Channel mapping
+            context.numChannels));
+
+   OggPacket headerPacket(0, headerSize, false);
+   // Header must have beginning-of-stream marker
+   headerPacket.MarkBOS();
+
+   headerPacket.Write("OpusHead", 8);
+   headerPacket.Write<uint8_t>(1);
+   headerPacket.Write<uint8_t>(context.numChannels);
+   headerPacket.Write(context.opus.preskip);
+   // Should we put the project sample rate here?
+   headerPacket.Write(context.sampleRate);
+   // Opus docs recommend encoders to use 0 as a gain
+   headerPacket.Write<uint16_t>(0);
+   headerPacket.Write(context.opus.channelMapping);
+
+   if (context.opus.channelMapping > 0)
+   {
+      headerPacket.Write(context.opus.nbStreams);
+      headerPacket.Write(context.opus.nbCoupled);
+
+      for (int i = 0; i < context.numChannels; ++i)
+         headerPacket.Write<uint8_t>(context.opus.streamMap[i]);
+   }
+
+   // This is guaranteed by the way we calculate the header size
+   assert(headerPacket.packet.bytes == headerSize);
+
+   context.ogg.PacketIn(headerPacket);
+   context.ogg.Flush(context.outFile);
+}
+
+void OpusExportProcessor::WriteTags()
+{
+   OggPacket commentsPacket { 1, true };
+
+   commentsPacket.Write("OpusTags", 8);
+
+   const std::string_view vendor { opus_get_version_string() };
+
+   commentsPacket.Write<uint32_t>(vendor.size());
+   commentsPacket.Write(vendor.data(), vendor.size());
+
+   commentsPacket.Write<uint32_t>(context.metadata->Count());
+
+   for (const auto& pair : context.metadata->GetRange())
+   {
+      const auto key = pair.first == TAG_YEAR ? std::string("DATE") :
+                                                audacity::ToUTF8(pair.first);
+
+      const auto value = audacity::ToUTF8(pair.second);
+
+      commentsPacket.Write<uint32_t>(key.size() + value.size() + 1);
+      commentsPacket.Write(key.data(), key.size());
+      commentsPacket.Write("=", 1);
+      commentsPacket.Write(value.data(), value.size());
+   }
+
+   context.ogg.PacketIn(commentsPacket);
+   context.ogg.Flush(context.outFile);
+}
+
+OpusExportProcessor::~OpusExportProcessor()
+{
+
+}
+
+bool OpusExportProcessor::Initialize(
+   AudacityProject& project, const Parameters& parameters,
+   const wxFileNameWrapper& fName, double t0, double t1, bool selectionOnly,
+   double sampleRate, unsigned numChannels, MixerOptions::Downmix* mixerSpec,
+   const Tags* metadata)
+{
+   context.sampleRate = int32_t(sampleRate);
+
+   if (!IsValidSampleRate(context.sampleRate))
+      throw ExportException(XO("Unsupported sample rate").Translation());
+
+   context.t0 = t0;
+   context.t1 = t1;
+   context.numChannels = numChannels;
+   context.fName = fName;
+
+   // Internally the Opus is always in 48k, find out the multiplier for
+   // values, that expect 48k sample rate
+   context.opus.sampleRateFactor = 48000 / context.sampleRate;
+
+   const auto bitRate = ExportPluginHelpers::GetParameterValue<int>(
+      parameters, OPUSOptionIDBitRate, OPUS_AUTO);
+   const auto vbrMode = ExportPluginHelpers::GetParameterValue<int>(
+      parameters, OPUSOptionIDVBRMode, VBRMode::VBR);
+   const int complexity = ExportPluginHelpers::GetParameterValue<int>(
+      parameters, OPUSOptionIDQuality, 10);
+   const int frameMultiplier = ExportPluginHelpers::GetParameterValue<int>(
+      parameters, OPUSOptionIDFrameDuration, 200);
+   const int application = ExportPluginHelpers::GetParameterValue<int>(
+      parameters, OPUSOptionIDApplication, OPUS_APPLICATION_AUDIO);
+   const int cutoff = ExportPluginHelpers::GetParameterValue<int>(
+      parameters, OPUSOptionIDCutoff, OPUS_AUTO);
+
+   // Number of samples per frame per channel
+   context.opus.frameSize = frameMultiplier * context.sampleRate / 10000;
+
+   context.status = selectionOnly ? XO("Exporting selected audio as Opus") :
+                                    XO("Exporting the audio as Opus");
+
+   // Create opus encoder
+   int error;
+
+   if (numChannels <= 2)
+   {
+      context.opus.channelMapping = 0;
+      context.opus.nbStreams = 1;
+      context.opus.nbCoupled = numChannels - 1;
+      context.opus.streamMap[0] = 0;
+      context.opus.streamMap[1] = 1;
+
+      context.opus.encoder = opus_multistream_encoder_create(
+         sampleRate, numChannels, context.opus.nbStreams,
+         context.opus.nbCoupled, context.opus.streamMap, application, &error);
+   }
+   else
+   {
+      context.opus.channelMapping = numChannels <= 8 ? 1 : 255;
+
+      int nbStreams {}, nbCoupled {};
+
+      context.opus.encoder = opus_multistream_surround_encoder_create(
+         sampleRate, numChannels, context.opus.channelMapping,
+         &nbStreams, &nbCoupled,
+         context.opus.streamMap, application, &error);
+
+      // opus_multistream_surround_encoder_create is expected to fill
+      // stream count with values in [0, 255]
+      context.opus.nbStreams = uint8_t(nbStreams);
+      context.opus.nbCoupled = uint8_t(nbCoupled);
+   }
+
+   if (error != OPUS_OK)
+      FailExport(XO("Unable to create Opus encoder"), error);
+
+   error = opus_multistream_encoder_ctl(
+      context.opus.encoder, OPUS_SET_BITRATE(bitRate));
+
+   if (error != OPUS_OK)
+      FailExport(XO("Unable to set bitrate"), error);
+
+   error = opus_multistream_encoder_ctl(
+      context.opus.encoder, OPUS_SET_COMPLEXITY(complexity));
+
+   if (error != OPUS_OK)
+      FailExport(XO("Unable to set complexity"), error);
+
+   error = opus_multistream_encoder_ctl(
+      context.opus.encoder, OPUS_SET_BANDWIDTH(cutoff));
+
+   if (error != OPUS_OK)
+      FailExport(XO("Unable to set bandwidth"), error);
+
+   error = opus_multistream_encoder_ctl(
+      context.opus.encoder, OPUS_SET_VBR(vbrMode == VBRMode::CBR ? 0 : 1));
+
+   if (error != OPUS_OK)
+      FailExport(XO("Unable to set VBR mode"), error);
+
+   if (vbrMode == VBRMode::CVBR)
+   {
+      error = opus_multistream_encoder_ctl(
+         context.opus.encoder, OPUS_SET_VBR_CONSTRAINT(1));
+
+      if (error != OPUS_OK)
+         FailExport(XO("Unable to set CVBR mode"), error);
+   }
+
+   // Calculate the encoder latency. This value is needed in header
+   // and to flush the encoder
+   int lookahead {};
+   error = opus_multistream_encoder_ctl(
+      context.opus.encoder, OPUS_GET_LOOKAHEAD(&lookahead));
+
+   if (error != OPUS_OK)
+      FailExport(XO("Unable to get lookahead"), error);
+
+   // Latency is always in 48k encoded samples
+   const auto calculatedPreskip = lookahead * context.opus.sampleRateFactor;
+   if (
+      calculatedPreskip < 0 ||
+      calculatedPreskip >= std::numeric_limits<uint16_t>::max())
+      FailExport(XO("Failed to calculate correct preskip"), OPUS_BAD_ARG);
+   // It is safe to cast to uint16_t here
+   context.opus.preskip = uint16_t(calculatedPreskip);
+
+   // Resize the audio packet so it can contain all the raw data.
+   // This is overkill, but should be enough to hold all the data from
+   // the encode float
+   context.ogg.audioStreamPacket.Resize(
+      context.opus.frameSize * sizeof(float) * numChannels);
+
+
+   // Try to open the file for writing
+   if (
+      !context.outFile.Create(fName.GetFullPath(), true) ||
+      !context.outFile.IsOpened())
+   {
+      throw ExportException(_("Unable to open target file for writing"));
+   }
+
+   WriteOpusHeader();
+
+   context.metadata = std::make_unique<Tags>(
+      metadata == nullptr ? Tags::Get(project) : *metadata);
+
+   WriteTags();
+
+   const auto& tracks = TrackList::Get(project);
+
+   context.mixer = ExportPluginHelpers::CreateMixer(
+      tracks, selectionOnly, t0, t1, numChannels, context.opus.frameSize, true,
+      sampleRate, floatSample, mixerSpec);
+
+   return true;
+}
+
+ExportResult OpusExportProcessor::Process(ExportProcessorDelegate& delegate)
+{
+   delegate.SetStatusString(context.status);
+
+   auto exportResult = ExportResult::Success;
+
+   int64_t granulePos = 0;
+
+   int32_t latencyLeft = context.opus.preskip;
+
+   while (exportResult == ExportResult::Success)
+   {
+      auto samplesThisRun = context.mixer->Process();
+
+      if (samplesThisRun == 0)
+         break;
+
+      auto mixedAudioBuffer =
+         reinterpret_cast<const float*>(context.mixer->GetBuffer());
+
+      // bestFrameSize <= context.opus.frameSize by design
+      auto bestFrameSize = GetBestFrameSize(samplesThisRun);
+
+      if (samplesThisRun < bestFrameSize)
+      {
+         // Opus expects that the full frame is passed to the encoder, fill missing data with zeroes
+         context.encodeBuffer.resize(bestFrameSize * context.numChannels);
+
+         std::copy(
+            mixedAudioBuffer, mixedAudioBuffer + samplesThisRun * context.numChannels,
+            context.encodeBuffer.begin());
+
+         std::fill(
+            context.encodeBuffer.begin() + samplesThisRun * context.numChannels,
+            context.encodeBuffer.begin() + bestFrameSize * context.numChannels,
+            0);
+
+         mixedAudioBuffer = context.encodeBuffer.data();
+
+         auto zeroesCount = bestFrameSize - int32_t(samplesThisRun);
+
+         if (zeroesCount < latencyLeft)
+            samplesThisRun += zeroesCount;
+         else
+            samplesThisRun += latencyLeft;
+
+         // Reduce the latency by the number of zeroes pushed (potentially
+         // removing the need to flush the encoder)
+         latencyLeft = std::max(0, latencyLeft - zeroesCount);
+      }
+
+      auto result = opus_multistream_encode_float(
+         context.opus.encoder, mixedAudioBuffer, bestFrameSize,
+         context.ogg.audioStreamPacket.GetBuffer(),
+         context.ogg.audioStreamPacket.GetBufferSize());
+
+      if (result < 0)
+         FailExport(XO("Failed to encode input buffer"), result);
+
+      // granulePos is the index of the last real sample in the packet at 48k rate
+      granulePos += samplesThisRun * context.opus.sampleRateFactor;
+
+      context.ogg.audioStreamPacket.packet.bytes = result;
+      context.ogg.audioStreamPacket.packet.granulepos = granulePos;
+
+      if (latencyLeft == 0)
+         context.ogg.audioStreamPacket.MarkEOS();
+
+      context.ogg.PacketIn(context.ogg.audioStreamPacket);
+      context.ogg.WriteOut(context.outFile);
+
+      context.ogg.audioStreamPacket.packet.packetno++;
+      
+      exportResult = ExportPluginHelpers::UpdateProgress(
+         delegate, *context.mixer, context.t0, context.t1);
+   }
+
+   // Flush the encoder
+
+   while (latencyLeft > 0)
+   {
+      auto frameSize = GetBestFrameSize(latencyLeft);
+
+      context.encodeBuffer.resize(frameSize * context.numChannels);
+
+      std::fill(
+         context.encodeBuffer.begin(),
+         context.encodeBuffer.begin() + frameSize * context.numChannels, 0);
+
+      auto samplesOut = std::min(latencyLeft, frameSize);
+
+      auto result = opus_multistream_encode_float(
+         context.opus.encoder, context.encodeBuffer.data(),
+         frameSize, context.ogg.audioStreamPacket.GetBuffer(),
+         context.ogg.audioStreamPacket.GetBufferSize());
+
+      if (result < 0)
+         FailExport(XO("Failed to encode input buffer"), result);
+
+      granulePos += samplesOut * context.opus.sampleRateFactor;
+
+      context.ogg.audioStreamPacket.packet.bytes = result;
+      context.ogg.audioStreamPacket.packet.granulepos = granulePos;
+
+      if (latencyLeft == samplesOut)
+         context.ogg.audioStreamPacket.MarkEOS();
+
+      context.ogg.PacketIn(context.ogg.audioStreamPacket);
+      context.ogg.WriteOut(context.outFile);
+
+      context.ogg.audioStreamPacket.packet.packetno++;
+
+      latencyLeft -= samplesOut;
+   }
+
+   context.ogg.Flush(context.outFile);
+
+   if (!context.outFile.Close())
+      return ExportResult::Error;
+
+   return exportResult;
+}
+
+
+static ExportPluginRegistry::RegisteredPlugin sRegisteredPlugin{ "Opus",
+   []{ return std::make_unique< ExportOpus >(); }
+};

--- a/modules/mod-opus/ImportOpus.cpp
+++ b/modules/mod-opus/ImportOpus.cpp
@@ -1,0 +1,421 @@
+/**********************************************************************
+
+   SPDX-License-Identifier: GPL-2.0-or-later
+
+   Audacity: A Digital Audio Editor
+
+   ImportOpus.cpp
+
+   Dmitry Vedenko
+
+**********************************************************************/
+
+
+#include "Import.h"
+#include "ImportPlugin.h"
+
+#include <string_view>
+
+#include<wx/string.h>
+#include<wx/log.h>
+
+#include<stdlib.h>
+
+#include "Tags.h"
+#include "WaveTrack.h"
+#include "CodeConversions.h"
+#include "ImportUtils.h"
+#include "ImportProgressListener.h"
+#include "CodeConversions.h"
+
+#include <opus/opusfile.h>
+
+#define DESC XO("Opus files")
+
+static const auto exts = { L"opus", L"ogg" };
+
+class OpusImportPlugin final : public ImportPlugin
+{
+public:
+   OpusImportPlugin();
+   ~OpusImportPlugin();
+
+   wxString GetPluginStringID() override;
+   TranslatableString GetPluginFormatDescription() override; 
+   std::unique_ptr<ImportFileHandle> Open(
+     const FilePath &Filename, AudacityProject*) override;
+};
+
+class OpusImportFileHandle final : public ImportFileHandleEx
+{
+public:
+   explicit OpusImportFileHandle(const FilePath& filename);
+   ~OpusImportFileHandle();
+
+   bool IsOpen() const;
+
+   TranslatableString GetFileDescription() override;
+   ByteCount GetFileUncompressedBytes() override;
+   void Import(ImportProgressListener &progressListener,
+               WaveTrackFactory *trackFactory,
+               TrackHolders &outTracks,
+               Tags *tags) override;
+   
+   wxInt32 GetStreamCount() override;
+   const TranslatableStrings &GetStreamInfo() override;
+   void SetStreamUsage(wxInt32 StreamID, bool Use) override;
+
+private:
+   static int OpusReadCallback(void* stream, unsigned char* ptr, int nbytes);
+   static int OpusSeekCallback(void* stream, opus_int64 offset, int whence);
+   static opus_int64 OpusTellCallback(void* stream);
+   static int OpusCloseCallback(void* stream);
+
+   static TranslatableString GetOpusErrorString(int error);
+   void LogOpusError(const char* method, int error);
+   void NotifyImportFailed(ImportProgressListener& progressListener, int error);
+   void NotifyImportFailed(ImportProgressListener& progressListener, const TranslatableString& error);
+
+   wxFile mFile;
+
+   OpusFileCallbacks mCallbacks;
+   OggOpusFile* mOpusFile {};
+   int mNumChannels {};
+   int64_t mNumSamples {};
+
+   // Opus internally uses 48kHz sample rate
+   // The file header contains the sample rate of the original audio.
+   // We ignore it and let Audacity resample the audio to the project sample rate.
+   const double mSampleRate { 48000.0 };
+
+   // Opus decodes to float samples internally, optionally converting them to int16.
+   // We let Audacity to convert the stream to the project sample format.
+   const sampleFormat mFormat { floatSample };
+};
+
+// ============================================================================
+// OpusImportPlugin
+// ============================================================================
+
+OpusImportPlugin::OpusImportPlugin()
+:  ImportPlugin(FileExtensions(exts.begin(), exts.end()))
+{
+}
+
+OpusImportPlugin::~OpusImportPlugin()
+{
+}
+
+wxString OpusImportPlugin::GetPluginStringID()
+{
+   return wxT("libopus");
+}
+
+TranslatableString OpusImportPlugin::GetPluginFormatDescription()
+{
+   return DESC;
+}
+
+std::unique_ptr<ImportFileHandle> OpusImportPlugin::Open(const FilePath &filename, AudacityProject*)
+{   
+   auto handle = std::make_unique<OpusImportFileHandle>(filename);
+
+   if (!handle->IsOpen())
+      return {};
+
+   return std::move(handle);
+}
+
+static Importer::RegisteredImportPlugin registered{ "Opus",
+   std::make_unique< OpusImportPlugin >()
+};
+
+// ============================================================================
+// OpusImportFileHandle
+// ============================================================================
+
+OpusImportFileHandle::OpusImportFileHandle(const FilePath& filename)
+    : ImportFileHandleEx { filename }
+{
+   // Try to open the file for reading
+   if (!mFile.Open(filename, wxFile::read))
+      return;
+
+   OpusFileCallbacks callbacks = {
+      OpusReadCallback,
+      OpusSeekCallback,
+      OpusTellCallback,
+      OpusCloseCallback
+   };
+
+   int error = 0;
+   mOpusFile = op_open_callbacks(this, &callbacks, nullptr, 0, &error);
+
+   if (mOpusFile == nullptr)
+   {
+      LogOpusError("Error while opening Opus file", error);
+      return;
+   }
+
+   mNumChannels = op_channel_count(mOpusFile, -1);
+   mNumSamples = op_pcm_total(mOpusFile, -1);
+}
+
+TranslatableString OpusImportFileHandle::GetFileDescription()
+{
+   return DESC;
+}
+
+auto OpusImportFileHandle::GetFileUncompressedBytes() -> ByteCount
+{
+   return 0;
+}
+
+void OpusImportFileHandle::Import(ImportProgressListener &progressListener,
+                                     WaveTrackFactory *trackFactory,
+                                     TrackHolders &outTracks,
+                                     Tags *tags)
+{
+   BeginImport();
+   
+   outTracks.clear();
+
+   auto trackList = ImportUtils::NewWaveTrack(
+      *trackFactory,
+      mNumChannels,
+      mFormat,
+      mSampleRate);
+
+   /* The number of samples to read in each loop */
+   const size_t SAMPLES_TO_READ = (*trackList->Any<WaveTrack>().begin())->GetMaxBlockSize();
+   uint64_t totalSamplesRead = 0;
+
+   const auto bufferSize = mNumChannels * SAMPLES_TO_READ;
+
+   ArrayOf<float> floatBuffer { bufferSize };
+
+   uint64_t samplesRead = 0;
+
+   do
+   {
+      int linkIndex { -1 };
+      auto samplesPerChannelRead = op_read_float(mOpusFile, floatBuffer.get(), SAMPLES_TO_READ, &linkIndex);
+
+      if (samplesPerChannelRead < 0 && samplesPerChannelRead != OP_HOLE)
+      {
+         NotifyImportFailed(progressListener, samplesPerChannelRead);
+         return;
+      }
+
+      auto linkChannels = op_head(mOpusFile, linkIndex)->channel_count;
+
+      if (linkChannels != mNumChannels)
+      {
+         NotifyImportFailed(progressListener, XO("file has changed the number of channels in the middle."));
+         return;
+      }
+
+      unsigned chn = 0;
+      ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
+      {
+         channel.AppendBuffer(
+            reinterpret_cast<constSamplePtr>(floatBuffer.get() +
+            chn), mFormat, samplesRead, mNumChannels, mFormat
+         );
+         ++chn;
+      });
+
+      samplesRead = samplesPerChannelRead;
+      totalSamplesRead += samplesRead;
+
+      progressListener.OnImportProgress(double(totalSamplesRead) / mNumSamples);
+   } while (!IsCancelled() && !IsStopped() && samplesRead != 0);
+
+   if (IsCancelled())
+   {
+      progressListener.OnImportResult(
+         ImportProgressListener::ImportResult::Cancelled);
+      return;
+   }
+
+   if (totalSamplesRead < mNumSamples && !IsStopped())
+   {
+      progressListener.OnImportResult(ImportProgressListener::ImportResult::Error);
+      return;
+   }
+
+   ImportUtils::FinalizeImport(outTracks, trackList);
+
+   auto opusTags = op_tags(mOpusFile, -1);
+
+   if (opusTags != nullptr)
+   {
+         for (int i = 0; i < opusTags->comments; ++i)
+         {
+            const auto comment = opusTags->user_comments[i];
+            const auto commentLength = opusTags->comment_lengths[i];
+
+            std::string_view tag { comment,
+                                   std::string_view::size_type(commentLength) };
+
+            const auto separator = tag.find('=');
+
+            if (separator != std::string_view::npos)
+            {
+               auto name = audacity::ToWXString(tag.substr(0, separator));
+               const auto value = audacity::ToWXString(tag.substr(separator + 1));
+
+               // See: ImportOGG.cpp tags parsing
+               if (name.Upper() == wxT("DATE") && !tags->HasTag(TAG_YEAR))
+               {
+                  long val;
+
+                  if (value.length() == 4 && value.ToLong(&val))
+                     name = TAG_YEAR;
+               }
+
+               tags->SetTag(name, value);
+            }
+         }
+   }
+
+   progressListener.OnImportResult(IsStopped()
+                                   ? ImportProgressListener::ImportResult::Stopped
+                                   : ImportProgressListener::ImportResult::Success);
+}
+
+wxInt32 OpusImportFileHandle::GetStreamCount()
+{
+   return 1;
+}
+
+const TranslatableStrings &OpusImportFileHandle::GetStreamInfo()
+{
+   static TranslatableStrings empty;
+   return empty;
+}
+
+void OpusImportFileHandle::SetStreamUsage(wxInt32, bool)
+{
+}
+
+int OpusImportFileHandle::OpusReadCallback(
+   void* pstream, unsigned char* ptr, int nbytes)
+{
+   auto stream = static_cast<OpusImportFileHandle*>(pstream);
+
+   if (!stream->mFile.IsOpened())
+      return EOF;
+
+   // OpusFile never reads more than 2^31 bytes at a time,
+   // so we can safely cast ssize_t to int.
+   return int(stream->mFile.Read(ptr, nbytes));
+}
+
+int OpusImportFileHandle::OpusSeekCallback(
+   void* pstream, opus_int64 offset, int whence)
+{
+   auto stream = static_cast<OpusImportFileHandle*>(pstream);
+
+   if (!stream->mFile.IsOpened())
+      return -1;
+
+   wxSeekMode wxWhence = whence == SEEK_SET ? wxFromStart :
+                         whence == SEEK_CUR ? wxFromCurrent :
+                         whence == SEEK_END ? wxFromEnd : wxFromStart;
+
+   return stream->mFile.Seek(offset, wxWhence) != wxInvalidOffset ? 0 : -1;
+}
+
+opus_int64 OpusImportFileHandle::OpusTellCallback(void* pstream)
+{
+   auto stream = static_cast<OpusImportFileHandle*>(pstream);
+
+   return opus_int64(stream->mFile.Tell());
+}
+
+int OpusImportFileHandle::OpusCloseCallback(void* pstream)
+{
+   auto stream = static_cast<OpusImportFileHandle*>(pstream);
+
+   if (stream->mFile.IsOpened())
+      return stream->mFile.Close() ? 0 : EOF;
+
+   return 0;
+}
+
+TranslatableString OpusImportFileHandle::GetOpusErrorString (int error)
+{
+   switch (error)
+   {
+   case OP_EREAD:
+      return XO("IO error reading from file");
+   case OP_EFAULT:
+      return XO("internal error");
+   case OP_EIMPL:
+      return XO("not implemented");
+   case OP_EINVAL:
+      return XO("invalid argument");
+   case OP_ENOTFORMAT:
+      return XO("not an Opus file");
+   case OP_EBADHEADER:
+      return XO("invalid header");
+   case OP_EVERSION:
+      return XO("unsupported version");
+   case OP_EBADPACKET:
+      return XO("invalid packet");
+   case OP_EBADLINK:
+      return XO("invalid stream structure");
+   case OP_ENOSEEK:
+      return XO("stream is not seekable");
+   case OP_EBADTIMESTAMP:
+      return XO("invalid timestamp");
+   default:
+      return {};
+   }
+}
+
+void OpusImportFileHandle::LogOpusError(const char* method, int error)
+{
+   if (error == 0)
+      return;
+
+   if (error == OP_ENOTFORMAT)
+      wxLogDebug("%s: Not Opus format", GetOpusErrorString(error).Translation());
+   else
+      wxLogError("%s: %s", method, GetOpusErrorString(error).Translation());
+}
+
+void OpusImportFileHandle::NotifyImportFailed(
+   ImportProgressListener& progressListener, int error)
+{
+   NotifyImportFailed(progressListener, GetOpusErrorString(error));
+}
+
+void OpusImportFileHandle::NotifyImportFailed(
+   ImportProgressListener& progressListener, const TranslatableString& error)
+{
+   ImportUtils::ShowMessageBox(
+      XO("Failed to decode Opus file: %s").Format(error));
+
+   if (IsCancelled())
+      progressListener.OnImportResult(
+         ImportProgressListener::ImportResult::Cancelled);
+   else if (!IsStopped())
+      progressListener.OnImportResult(
+         ImportProgressListener::ImportResult::Error);
+   else
+      progressListener.OnImportResult(
+         ImportProgressListener::ImportResult::Stopped);
+}
+
+bool OpusImportFileHandle::IsOpen() const
+{
+   return mOpusFile != nullptr;
+}
+
+OpusImportFileHandle::~OpusImportFileHandle()
+{
+   if (mOpusFile != nullptr)
+      op_free(mOpusFile);
+}

--- a/modules/mod-opus/Opus.cpp
+++ b/modules/mod-opus/Opus.cpp
@@ -1,0 +1,13 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Opus.cpp
+
+  Dmitry Vedenko
+
+**********************************************************************/
+
+#include "ModuleConstants.h"
+
+DEFINE_MODULE_ENTRIES

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -606,10 +606,24 @@ void AboutDialog::PopulateInformationPage( ShuttleGui & S )
    informationStr
       << wxT("<table>");   // start table of file formats supported
 
-   #if defined(USE_LIBID3TAG)
-   AddBuildinfoRow(&informationStr, wxT("libmpg123"), XO("MP3 Importing"), enabled);
+   #if defined(USE_LIBMPG123)
+   AddBuildinfoRow(&informationStr, wxT("libmpg123"), XO("MP3 Import"), enabled);
    #else
-   AddBuildinfoRow(&informationStr, wxT("libmad"), XO("MP3 Importing"), disabled);
+   AddBuildinfoRow(&informationStr, wxT("libmpg123"), XO("MP3 Import"), disabled);
+   #endif
+
+   #if USE_LIBMP3LAME
+   AddBuildinfoRow(
+      &informationStr, wxT("libmp3lame"),
+      /* i18n-hint: LAME is the codec name. This name should not be translated
+       */
+      XO("MP3 Export"), enabled);
+   #else
+   AddBuildinfoRow(
+      &informationStr, wxT("libopus"),
+      /* i18n-hint: Opus is the codec name. This name should not be translated
+       */
+      XO("Opus Import and Export"), disabled);
    #endif
 
    #ifdef USE_LIBVORBIS
@@ -620,6 +634,19 @@ void AboutDialog::PopulateInformationPage( ShuttleGui & S )
    #else
    AddBuildinfoRow(&informationStr, wxT("libvorbis"),
          XO("Ogg Vorbis Import and Export"), disabled);
+   #endif
+
+   #if USE_LIBVORBIS && USE_LIBOPUS && USE_OPUSFILE
+   AddBuildinfoRow(
+      &informationStr, wxT("libopus"),
+      /* i18n-hint: Opus is the codec name. This name should not be translated */
+      XO("Opus Import and Export"), enabled);
+   #else
+   AddBuildinfoRow(
+      &informationStr, wxT("libopus"),
+      /* i18n-hint: Opus is the codec name. This name should not be translated
+       */
+      XO("Opus Import and Export"), disabled);
    #endif
 
    #ifdef USE_LIBID3TAG
@@ -645,14 +672,6 @@ void AboutDialog::PopulateInformationPage( ShuttleGui & S )
          enabled);
    # else
    AddBuildinfoRow(&informationStr, wxT("libtwolame"), XO("MP2 export"),
-         disabled);
-   # endif
-
-   # if USE_QUICKTIME
-   AddBuildinfoRow(&informationStr, wxT("QuickTime"), XO("Import via QuickTime"),
-         enabled);
-   # else
-   AddBuildinfoRow(&informationStr, wxT("QuickTime"), XO("Import via QuickTime"),
          disabled);
    # endif
 

--- a/src/audacity_config.h.in
+++ b/src/audacity_config.h.in
@@ -60,6 +60,9 @@
 /* Define if mp3 support is implemented with the libmpg123 library */
 #cmakedefine USE_LIBMPG123 1
 
+/* Define if mp3 export support is implemented with the libmpg123 library */
+#cmakedefine USE_LIBMP3LAME 1
+
 /* Define if wavpack support is implemented with the wavpack library */
 #cmakedefine USE_WAVPACK 1
 
@@ -80,9 +83,6 @@
 
 /* Define if PortMixer support should be enabled */
 #cmakedefine USE_PORTMIXER 1
-
-/* Define if QuickTime importing is enabled (Mac OS X only) */
-#cmakedefine USE_QUICKTIME 1
 
 /* Define if SBSMS support should be enabled */
 #cmakedefine USE_SBSMS 1
@@ -107,3 +107,9 @@
 
 /* Use the Aqua theme on Mac */
 #cmakedefine USE_AQUA_THEME 1
+
+/* Define if libopus support should be enabled */
+#cmakedefine USE_LIBOPUS 1
+
+/* Define if opusfile support should be enabled */
+#cmakedefine USE_OPUSFILE 1

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -77,7 +77,7 @@ ChoiceSetting ExportAudioSplitNamePolicy { L"/ExportAudioDialog/SplitNamePolicy"
    0
 };
 
-IntSetting ExportAudioSampleRate { "L/ExportAudioDialog/SampleRate", 0 };//use project rate until overwritten
+IntSetting ExportAudioSampleRate { L"/ExportAudioDialog/SampleRate", 0 }; // use project rate until overwritten
 
 BoolSetting ExportAudioIncludeAudioBeforeFirstLabel { L"/ExportAudioDialog/IncludeAudioBeforeFirstLabel", false };
 

--- a/src/export/ExportFilePanel.cpp
+++ b/src/export/ExportFilePanel.cpp
@@ -576,7 +576,14 @@ void ExportFilePanel::UpdateSampleRateList()
    }
    else if(customRate != 0)//sample rate not in the list
    {
-      mSampleRate = (*rates)[preferredItemIndex];
+      auto selectedRate = (*rates)[preferredItemIndex];
+      if (selectedRate < customRate)
+      {
+         if ((preferredItemIndex + 1) < rates->size())
+            selectedRate = (*rates)[++preferredItemIndex];
+      }
+
+      mSampleRate = selectedRate;
       selectedItemIndex = preferredItemIndex;
    }
    mRates->SetSelection(selectedItemIndex);


### PR DESCRIPTION
Resolves: #443 (yes, a three digits issue!)
Resolves: #4709 (probably)
Resolves: #5364

This PR introduces built-in support for Opus files. 

Opus is a peculiar codec, always encoding 48kHz sample rate. Opus allow to store the "original" sample rate in the header, but recommends not to resample to that rate whenever possible. 

Despite that Opus encodes at fixed sample rate - it allows to feed the data at few other sample rates and allows to set the cutoff frequencies independently.

Opus allows to select from a fixed list of frame sizes. Audacity will never create larger frames, but at the end of the file smaller frames can be used.

Please note, that while the options list has a bit different values compared to `Opus (OggOpus) Files (FFmpeg)`, this is intentional and better reflects the codec setup.

* Importing uses `libopus` and `opusfile`.
* Exporting uses `libopus` and `libogg`.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
