### PR TITLE
When TrackPanel::OnPaint detects selection change - repaint all

### DIFF
--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -331,7 +331,7 @@ TrackPanel::TrackPanel(wxWindow * parent, wxWindowID id,
       .Subscribe([this](const RealtimeEffectManagerMessage& msg)
       {
          if (auto pTrack = dynamic_cast<Track *>(msg.group))
-            //update "effects" button 
+            //update "effects" button
             RefreshTrack(pTrack);
       });
 
@@ -475,7 +475,13 @@ void TrackPanel::OnUndoReset(UndoRedoMessage message)
 ///  completing a repaint operation.
 void TrackPanel::OnPaint(wxPaintEvent & /* event */)
 {
-   mLastDrawnSelectedRegion = mViewInfo->selectedRegion;
+   // If the selected region changes - we must repaint the tracks, because the
+   // selection is baked into track image
+   if (mLastDrawnSelectedRegion != mViewInfo->selectedRegion)
+   {
+      mRefreshBacking = true;
+      mLastDrawnSelectedRegion = mViewInfo->selectedRegion;
+   }
 
    auto sw =
       FrameStatistics::CreateStopwatch(FrameStatistics::SectionID::TrackPanel);
@@ -1443,7 +1449,7 @@ struct ChannelStack final : TrackPanelGroup {
                .emplace_back(yy, std::make_shared<HorizontalGroup>(hgroup));
             yy += kAffordancesAreaHeight;
          }
-         
+
          auto height = *pHeight++;
          rect.SetTop(yy);
          rect.SetHeight(height - kChannelSeparatorThickness);


### PR DESCRIPTION
Selection is baked into the track bitmaps, so we must repaint them

Resolves: #5309

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
