### PR TITLE
Pending track nonsense

### DIFF
--- a/libraries/lib-project-file-io/ProjectFileIO.cpp
+++ b/libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -24,6 +24,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "CodeConversions.h"
 #include "DBConnection.h"
 #include "FileNames.h"
+#include "PendingTracks.h"
 #include "Project.h"
 #include "ProjectHistory.h"
 #include "ProjectSerializer.h"
@@ -1773,6 +1774,7 @@ void ProjectFileIO::WriteXML(XMLWriter &xmlFile,
 
    ProjectFileIORegistry::Get().CallWriters(proj, xmlFile);
 
+   auto &pendingTracks = PendingTracks::Get(proj);
    tracklist.Any().Visit([&](const Track &t) {
       auto useTrack = &t;
       if (recording) {
@@ -1781,7 +1783,7 @@ void ProjectFileIO::WriteXML(XMLWriter &xmlFile,
          // regular track list.  That is the one that we want to back up.
          // SubstitutePendingChangedTrack() fetches the shadow, if the track has
          // one, else it gives the same track back.
-         useTrack = t.SubstitutePendingChangedTrack().get();
+         useTrack = pendingTracks.SubstitutePendingChangedTrack(t).get();
       }
       else if (useTrack->GetId() == TrackId{}) {
          // This is a track added during a non-appending recording that is

--- a/libraries/lib-project-file-io/SqliteSampleBlock.cpp
+++ b/libraries/lib-project-file-io/SqliteSampleBlock.cpp
@@ -20,6 +20,7 @@ Paul Licameli -- split from SampleBlock.cpp and SampleBlock.h
 
 #include "SampleBlock.h" // to inherit
 #include "UndoManager.h"
+#include "UndoTracks.h"
 #include "WaveTrack.h"
 
 #include "SentryHelper.h"
@@ -1067,7 +1068,7 @@ static size_t EstimateRemovedBlocks(
    // Collect ids that survive
    SampleBlockIDSet wontDelete;
    auto f = [&](const UndoStackElem &elem) {
-      if (auto pTracks = TrackList::FindUndoTracks(elem))
+      if (auto pTracks = UndoTracks::Find(elem))
          InspectBlocks(*pTracks, {}, &wontDelete);
    };
    manager.VisitStates(f, 0, begin);
@@ -1079,7 +1080,7 @@ static size_t EstimateRemovedBlocks(
    // Collect ids that won't survive (and are not negative pseudo ids)
    SampleBlockIDSet seen, mayDelete;
    manager.VisitStates([&](const UndoStackElem &elem) {
-      if (auto pTracks = TrackList::FindUndoTracks(elem)) {
+      if (auto pTracks = UndoTracks::Find(elem)) {
          InspectBlocks(*pTracks,
             [&](const SampleBlock &block){
                auto id = block.GetBlockID();

--- a/libraries/lib-track-selection/SyncLock.cpp
+++ b/libraries/lib-track-selection/SyncLock.cpp
@@ -11,6 +11,7 @@ Paul Licameli split from Track.cpp
 
 #include "SyncLock.h"
 
+#include "PendingTracks.h"
 #include "Prefs.h"
 #include "Project.h"
 #include "Track.h"
@@ -91,7 +92,7 @@ bool SyncLock::IsSyncLockSelected(const Track *pTrack)
    if (!p || !SyncLockState::Get( *p ).IsSyncLocked())
       return false;
 
-   auto shTrack = pTrack->SubstituteOriginalTrack();
+   auto shTrack = PendingTracks::Get(*p).SubstituteOriginalTrack(*pTrack);
    if (!shTrack)
       return false;
 

--- a/libraries/lib-track/CMakeLists.txt
+++ b/libraries/lib-track/CMakeLists.txt
@@ -18,6 +18,8 @@ reapplied to another track that must stay synchronized.
 ]]
 
 set( SOURCES
+   PendingTracks.cpp
+   PendingTracks.h
    TimeWarper.cpp
    TimeWarper.h
    Track.cpp

--- a/libraries/lib-track/CMakeLists.txt
+++ b/libraries/lib-track/CMakeLists.txt
@@ -26,6 +26,8 @@ set( SOURCES
    Track.h
    TrackAttachment.cpp
    TrackAttachment.h
+   UndoTracks.cpp
+   UndoTracks.h
 )
 set( LIBRARIES
    lib-channel-interface

--- a/libraries/lib-track/PendingTracks.cpp
+++ b/libraries/lib-track/PendingTracks.cpp
@@ -30,6 +30,21 @@ const PendingTracks &PendingTracks::Get(const AudacityProject &project)
 
 PendingTracks::PendingTracks(AudacityProject &project)
    : mTracks{ TrackList::Get(project) }
+   , mTrackListSubscription { mTracks.Subscribe(
+      [this](const TrackListEvent &event){
+         switch (event.mType) {
+         case TrackListEvent::PERMUTED:
+         case TrackListEvent::RESIZING:
+         case TrackListEvent::ADDITION:
+         case TrackListEvent::DELETION:
+            UpdatePendingTracks();
+            break;
+         default:
+            break;
+         }
+         // Pass along to downstream listeners
+         Publish(event);
+   })}
 {}
 
 PendingTracks::~PendingTracks() = default;

--- a/libraries/lib-track/PendingTracks.cpp
+++ b/libraries/lib-track/PendingTracks.cpp
@@ -9,11 +9,12 @@
  **********************************************************************/
 #include "PendingTracks.h"
 #include "Project.h"
+#include "Track.h"
 
 static const AudacityProject::AttachedObjects::RegisteredFactory
 sPendingTracksKey{
   [](AudacityProject &project){
-     return std::make_shared<PendingTracks>();
+     return std::make_shared<PendingTracks>(project);
    }
 };
 
@@ -27,4 +28,51 @@ const PendingTracks &PendingTracks::Get(const AudacityProject &project)
    return Get(const_cast<AudacityProject &>(project));
 }
 
+PendingTracks::PendingTracks(AudacityProject &project)
+   : mTracks{ TrackList::Get(project) }
+{}
+
 PendingTracks::~PendingTracks() = default;
+
+void PendingTracks::RegisterPendingNewTracks(TrackList &&list)
+{
+   mTracks.RegisterPendingNewTracks(std::move(list));
+}
+
+std::shared_ptr<Track>
+PendingTracks::SubstitutePendingChangedTrack(Track &track) const
+{
+   return track.SubstitutePendingChangedTrack();
+}
+
+std::shared_ptr<const Track>
+PendingTracks::SubstitutePendingChangedTrack(const Track &track) const
+{
+   return track.SubstitutePendingChangedTrack();
+}
+
+std::shared_ptr<const Track>
+PendingTracks::SubstituteOriginalTrack(const Track &track) const
+{
+   return track.SubstituteOriginalTrack();
+}
+
+Track* PendingTracks::RegisterPendingChangedTrack(Updater updater, Track *src)
+{
+   return mTracks.RegisterPendingChangedTrack(move(updater), src);
+}
+
+void PendingTracks::UpdatePendingTracks()
+{
+   mTracks.UpdatePendingTracks();
+}
+
+void PendingTracks::ClearPendingTracks()
+{
+   mTracks.ClearPendingTracks();
+}
+
+bool PendingTracks::ApplyPendingTracks()
+{
+   return mTracks.ApplyPendingTracks();
+}

--- a/libraries/lib-track/PendingTracks.cpp
+++ b/libraries/lib-track/PendingTracks.cpp
@@ -74,5 +74,14 @@ void PendingTracks::ClearPendingTracks()
 
 bool PendingTracks::ApplyPendingTracks()
 {
-   return mTracks.ApplyPendingTracks();
+   std::vector<std::shared_ptr<TrackList>> additions;
+   std::shared_ptr<TrackList> pendingUpdates = TrackList::Temporary(nullptr);
+   {
+      // Always clear, even if one of the update functions throws
+      auto cleanup = finally([&]{
+         mTracks.ClearPendingTracks(&additions, &pendingUpdates);
+      });
+      UpdatePendingTracks();
+   }
+   return mTracks.ApplyPendingTracks(move(additions), move(pendingUpdates));
 }

--- a/libraries/lib-track/PendingTracks.cpp
+++ b/libraries/lib-track/PendingTracks.cpp
@@ -1,0 +1,30 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file PendingTracks.cpp
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+#include "PendingTracks.h"
+#include "Project.h"
+
+static const AudacityProject::AttachedObjects::RegisteredFactory
+sPendingTracksKey{
+  [](AudacityProject &project){
+     return std::make_shared<PendingTracks>();
+   }
+};
+
+PendingTracks &PendingTracks::Get(AudacityProject &project)
+{
+   return project.AttachedObjects::Get<PendingTracks>(sPendingTracksKey);
+}
+
+const PendingTracks &PendingTracks::Get(const AudacityProject &project)
+{
+   return Get(const_cast<AudacityProject &>(project));
+}
+
+PendingTracks::~PendingTracks() = default;

--- a/libraries/lib-track/PendingTracks.cpp
+++ b/libraries/lib-track/PendingTracks.cpp
@@ -51,7 +51,7 @@ PendingTracks::~PendingTracks() = default;
 
 void PendingTracks::RegisterPendingNewTracks(TrackList &&list)
 {
-   mTracks.RegisterPendingNewTracks(std::move(list));
+   mTracks.Append(std::move(list), false);
 }
 
 namespace {

--- a/libraries/lib-track/PendingTracks.h
+++ b/libraries/lib-track/PendingTracks.h
@@ -88,6 +88,8 @@ public:
    // Return true if the state of the track list really did change.
    bool ApplyPendingTracks();
 
+   bool HasPendingTracks() const;
+
 private:
    TrackList &mTracks;
    Observer::Subscription mTrackListSubscription;

--- a/libraries/lib-track/PendingTracks.h
+++ b/libraries/lib-track/PendingTracks.h
@@ -11,13 +11,16 @@
 #define __AUDACITY_PENDING_TRACKS__
 
 #include "ClientData.h"
+#include "Observer.h"
 
 class AudacityProject;
 class Track;
 class TrackList;
+struct TrackListEvent;
 
 class TRACK_API PendingTracks final
    : public ClientData::Base
+   , public Observer::Publisher<TrackListEvent>
 {
 public:
    static PendingTracks &Get(AudacityProject &project);
@@ -87,6 +90,7 @@ public:
 
 private:
    TrackList &mTracks;
+   Observer::Subscription mTrackListSubscription;
 };
 
 #endif

--- a/libraries/lib-track/PendingTracks.h
+++ b/libraries/lib-track/PendingTracks.h
@@ -13,6 +13,8 @@
 #include "ClientData.h"
 
 class AudacityProject;
+class Track;
+class TrackList;
 
 class TRACK_API PendingTracks final
    : public ClientData::Base
@@ -20,7 +22,71 @@ class TRACK_API PendingTracks final
 public:
    static PendingTracks &Get(AudacityProject &project);
    static const PendingTracks &Get(const AudacityProject &project);
+
+   explicit PendingTracks(AudacityProject &project);
+   PendingTracks(const PendingTracks&) = delete;
+   PendingTracks &operator=(const PendingTracks&) = delete;
    ~PendingTracks();
+
+   // Like RegisterPendingChangedTrack, but for a list of new tracks,
+   // not a replacement track.  Caller
+   // supplies the list, and there are no updates.
+   // Pending tracks will have an unassigned TrackId.
+   // Pending new tracks WILL occur in iterations, always after actual
+   // tracks, and in the sequence that they were added.  They can be
+   // distinguished from actual tracks by TrackId.
+   void RegisterPendingNewTracks(TrackList &&list);
+
+   // Find anything registered with TrackList::RegisterPendingChangedTrack and
+   // not yet cleared or applied; if no such exists, return the given track
+   std::shared_ptr<Track>
+      SubstitutePendingChangedTrack(Track &track) const;
+   std::shared_ptr<const Track>
+      SubstitutePendingChangedTrack(const Track &track) const;
+
+   // If the track is a pending changed track, return the corresponding
+   // original; else return the track
+   std::shared_ptr<const Track> SubstituteOriginalTrack(const Track &track)
+     const;
+
+   //! The tracks supplied to this function will be leaders with the same number
+   //! of channels
+   using Updater = std::function<void(Track &dest, const Track &src)>;
+   // Start a deferred update of the project.
+   // The return value is a duplicate of the given track.
+   // While ApplyPendingTracks or ClearPendingTracks is not yet called,
+   // there may be other direct changes to the project that push undo history.
+   // Meanwhile the returned object can accumulate other changes for a deferred
+   // push, and temporarily shadow the actual project track for display purposes.
+   // The Updater function, if not null, merges state (from the actual project
+   // into the pending track) which is not meant to be overridden by the
+   // accumulated pending changes.
+   // Pending track will have the same TrackId as the actual.
+   // Pending changed tracks will not occur in iterations.
+   /*!
+    @pre `src->IsLeader()`
+    @post result: `src->NChannels() == result.size()`
+    */
+   Track* RegisterPendingChangedTrack(
+      Updater updater,
+      Track *src
+   );
+
+   // Invoke the updaters of pending tracks.  Pass any exceptions from the
+   // updater functions.
+   void UpdatePendingTracks();
+
+   //! Forget pending track additions and changes
+   void ClearPendingTracks();
+
+   // Change the state of the project.
+   // Strong guarantee for project state in case of exceptions.
+   // Will always clear the pending updates.
+   // Return true if the state of the track list really did change.
+   bool ApplyPendingTracks();
+
+private:
+   TrackList &mTracks;
 };
 
 #endif

--- a/libraries/lib-track/PendingTracks.h
+++ b/libraries/lib-track/PendingTracks.h
@@ -1,0 +1,26 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file PendingTracks.h
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+#ifndef __AUDACITY_PENDING_TRACKS__
+#define __AUDACITY_PENDING_TRACKS__
+
+#include "ClientData.h"
+
+class AudacityProject;
+
+class TRACK_API PendingTracks final
+   : public ClientData::Base
+{
+public:
+   static PendingTracks &Get(AudacityProject &project);
+   static const PendingTracks &Get(const AudacityProject &project);
+   ~PendingTracks();
+};
+
+#endif

--- a/libraries/lib-track/PendingTracks.h
+++ b/libraries/lib-track/PendingTracks.h
@@ -91,6 +91,8 @@ public:
 private:
    TrackList &mTracks;
    Observer::Subscription mTrackListSubscription;
+   std::vector<Updater> mUpdaters;
+   std::vector<std::shared_ptr<Track>> mPendingUpdates;
 };
 
 #endif

--- a/libraries/lib-track/PendingTracks.h
+++ b/libraries/lib-track/PendingTracks.h
@@ -79,8 +79,15 @@ public:
    // updater functions.
    void UpdatePendingTracks();
 
-   //! Forget pending track additions and changes
-   void ClearPendingTracks();
+   //! Forget pending track additions and changes;
+   /*!
+    if requested, give back the pending added tracks, as channel groups,
+    stored in the vector at their original positions in iteration order and
+    nulls corresponding with non-added tracks in original iteration order; no
+    trailing nulls
+   */
+   void ClearPendingTracks(
+      std::vector<std::shared_ptr<TrackList>> *pAdded = nullptr);
 
    // Change the state of the project.
    // Strong guarantee for project state in case of exceptions.
@@ -94,7 +101,7 @@ private:
    TrackList &mTracks;
    Observer::Subscription mTrackListSubscription;
    std::vector<Updater> mUpdaters;
-   std::vector<std::shared_ptr<Track>> mPendingUpdates;
+   std::shared_ptr<TrackList> mPendingUpdates;
 };
 
 #endif

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -448,8 +448,6 @@ void TrackList::RecalcPositions(TrackNodePointer node)
       t = *n;
       t->SetIndex(i++);
    }
-
-   UpdatePendingTracks();
 }
 
 void TrackList::QueueEvent(TrackListEvent event)

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -390,13 +390,6 @@ void TrackList::Swap(TrackList &that)
    const auto self = shared_from_this();
    const auto otherSelf = that.shared_from_this();
    SwapLOTs( *this, self, that, otherSelf );
-
-   assert(!GetOwner() && !that.GetOwner()); // precondition
-   // which implies (see constructor)
-   assert(!this->mPendingUpdates);
-   assert(!that.mPendingUpdates);
-
-   mUpdaters.swap(that.mUpdaters);
 }
 
 TrackList::~TrackList()

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -741,8 +741,9 @@ bool TrackList::MakeMultiChannelTrack(Track& track, int nChannels)
    return true;
 }
 
-void TrackList::Remove(Track &track)
+std::shared_ptr<TrackList> TrackList::Remove(Track &track)
 {
+   auto result = TrackList::Temporary(nullptr);
    assert(track.IsLeader());
    auto *t = &track;
    const size_t nChannels = NChannels(*t);
@@ -764,8 +765,10 @@ void TrackList::Remove(Track &track)
          }
 
          DeletionEvent(t->shared_from_this(), false);
+         result->Add(move(holder));
       }
    }
+   return result;
 }
 
 void TrackList::Clear(bool sendEvent)

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -1128,48 +1128,6 @@ bool TrackList::ApplyPendingTracks(
    return result;
 }
 
-std::shared_ptr<Track> Track::SubstitutePendingChangedTrack()
-{
-   // Linear search.  Tracks in a project are usually very few.
-   auto pList = mList.lock();
-   if (pList && pList->mPendingUpdates) {
-      const auto id = GetId();
-      const auto end = pList->mPendingUpdates->ListOfTracks::end();
-      auto it = std::find_if(
-         pList->mPendingUpdates->ListOfTracks::begin(), end,
-         [=](const ListOfTracks::value_type &ptr){ return ptr->GetId() == id; } );
-      if (it != end)
-         return *it;
-   }
-   return SharedPointer();
-}
-
-std::shared_ptr<const Track> Track::SubstitutePendingChangedTrack() const
-{
-   return const_cast<Track*>(this)->SubstitutePendingChangedTrack();
-}
-
-std::shared_ptr<const Track> Track::SubstituteOriginalTrack() const
-{
-   auto pList = mList.lock();
-   if (pList && pList->mPendingUpdates) {
-      const auto id = GetId();
-      const auto pred = [=]( const ListOfTracks::value_type &ptr ) {
-         return ptr->GetId() == id; };
-      const auto end = pList->mPendingUpdates->ListOfTracks::end();
-      const auto it =
-         std::find_if(pList->mPendingUpdates->ListOfTracks::begin(), end, pred);
-      if (it != end) {
-         const auto &list2 = (const ListOfTracks &) *pList;
-         const auto end2 = list2.end();
-         const auto it2 = std::find_if( list2.begin(), end2, pred );
-         if ( it2 != end2 )
-            return *it2;
-      }
-   }
-   return SharedPointer();
-}
-
 auto Track::ClassTypeInfo() -> const TypeInfo &
 {
    static Track::TypeInfo info{
@@ -1231,17 +1189,6 @@ void Track::AdjustPositions()
       pList->RecalcPositions(mNode);
       pList->ResizingEvent(mNode);
    }
-}
-
-bool TrackList::HasPendingTracks() const
-{
-   if (mPendingUpdates && !mPendingUpdates->empty())
-      return true;
-   if (End() != std::find_if(Begin(), End(), [](const Track *t){
-      return t->GetId() == TrackId{};
-   }))
-      return true;
-   return false;
 }
 
 Track::LinkType Track::GetLinkType() const noexcept

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -1327,16 +1327,6 @@ void TrackList::Append(TrackList &&list, bool assignIds)
    }
 }
 
-void TrackList::RegisterPendingNewTracks(TrackList&& list)
-{
-   for(auto it = list.ListOfTracks::begin(); it != list.ListOfTracks::end();)
-   {
-      Add(*it);
-      (*it)->SetId({});
-      it = list.erase(it);
-   }
-}
-
 void TrackList::AppendOne(TrackList &&list)
 {
    auto iter = list.ListOfTracks::begin(),

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -542,13 +542,14 @@ Track* TrackList::SwapChannels(Track &track)
    return pPartner;
 }
 
-void TrackList::Insert(const Track* before, TrackList&& trackList)
+void TrackList::Insert(
+   const Track* before, TrackList&& trackList, bool assignIds)
 {
    assert(before == nullptr || (before->IsLeader() && Find(before) != EndIterator<const Track>()));
 
    if(before == nullptr)
    {
-      Append(std::move(trackList));
+      Append(std::move(trackList), assignIds);
       return;
    }
 
@@ -562,7 +563,7 @@ void TrackList::Insert(const Track* before, TrackList&& trackList)
       }
       arr.push_back(track);
    }
-   Append(std::move(trackList));
+   Append(std::move(trackList), assignIds);
    Permute(arr);
 }
 
@@ -607,7 +608,7 @@ Track *TrackList::DoAddToHead(const std::shared_ptr<Track> &t)
    return front().get();
 }
 
-Track *TrackList::DoAdd(const std::shared_ptr<Track> &t)
+Track *TrackList::DoAdd(const std::shared_ptr<Track> &t, bool assignIds)
 {
    if (!ListOfTracks::empty()) {
       auto &pLast = *ListOfTracks::rbegin();
@@ -626,7 +627,7 @@ Track *TrackList::DoAdd(const std::shared_ptr<Track> &t)
    auto n = getPrev( getEnd() );
 
    t->SetOwner(shared_from_this(), n);
-   if (mAssignsIds)
+   if (mAssignsIds && assignIds)
       t->SetId(TrackId{ ++sCounter });
    RecalcPositions(n);
    AdditionEvent(n);
@@ -1403,14 +1404,14 @@ TrackListHolder TrackList::Temporary(AudacityProject *pProject,
    return tempList;
 }
 
-void TrackList::Append(TrackList &&list)
+void TrackList::Append(TrackList &&list, bool assignIds)
 {
    auto iter = list.ListOfTracks::begin(),
       end = list.ListOfTracks::end();
    while (iter != end) {
       auto pTrack = *iter;
       iter = list.erase(iter);
-      this->Add(pTrack);
+      this->Add(pTrack, assignIds);
    }
 }
 

--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -146,18 +146,8 @@ void Track::SetIndex(int index)
 
 void Track::SetLinkType(LinkType linkType, bool completeList)
 {
-   auto pList = mList.lock();
-   if (pList && pList->mPendingUpdates && !pList->mPendingUpdates->empty()) {
-      auto orig = pList->FindById( GetId() );
-      if (orig && orig != this) {
-         orig->SetLinkType(linkType);
-         return;
-      }
-   }
-
    DoSetLinkType(linkType, completeList);
-
-   if (pList) {
+   if (const auto pList = mList.lock()) {
       pList->RecalcPositions(mNode);
       pList->ResizingEvent(mNode);
    }
@@ -1059,7 +1049,6 @@ void TrackList::UpdatePendingTracks()
             updater(*pendingTrack, *src);
       }
       ++pUpdater;
-      pendingTrack->DoSetLinkType(src->GetLinkType());
    }
 }
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1424,9 +1424,6 @@ private:
    static long sCounter;
 
 public:
-   //! The tracks supplied to this function will be leaders with the same number
-   //! of channels
-   using Updater = std::function<void(Track &dest, const Track &src)>;
    // Start a deferred update of the project.
    // The return value is a duplicate of the given track.
    // While ApplyPendingTracks or ClearPendingTracks is not yet called,
@@ -1446,14 +1443,7 @@ public:
     @pre `src->IsLeader()`
     @post result: `src->NChannels() == result.size()`
     */
-   Track* RegisterPendingChangedTrack(
-      Updater updater,
-      Track *src
-   );
-
-   // Invoke the updaters of pending tracks.  Pass any exceptions from the
-   // updater functions.
-   void UpdatePendingTracks();
+   Track* RegisterPendingChangedTrack(Track *src);
 
    /*
     Forget pending track additions and changes;
@@ -1482,8 +1472,6 @@ private:
    //! a list so that channel grouping works
    /*! Beware, they are in a disjoint iteration sequence from ordinary tracks */
    std::shared_ptr<TrackList> mPendingUpdates;
-   //! This is in correspondence with leader tracks in mPendingUpdates
-   std::vector< Updater > mUpdaters;
    //! Whether the list assigns unique ids to added tracks;
    //! false for temporaries
    bool mAssignsIds{ true };

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1215,11 +1215,11 @@ public:
     */
    TrackListHolder ReplaceOne(Track &t, TrackList &&with);
 
-   //! Remove a channel group, given the leader
+   //! Remove a channel group, given the leader, and return it
    /*!
     @pre `track.IsLeader()`
     */
-   void Remove(Track &track);
+   std::shared_ptr<TrackList> Remove(Track &track);
 
    /// Make the list empty
    void Clear(bool sendEvent = true);

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1459,16 +1459,19 @@ public:
     Forget pending track additions and changes;
     if requested, give back the pending added tracks, as channel groups,
     stored in the vector at their original positions in iteration order and
-    nulls corresponding with non-added tracks in original iteration order
+    nulls corresponding with non-added tracks in original iteration order; no
+    trailing nulls
     @pre `GetOwner()`
     */
-   void ClearPendingTracks(std::vector<TrackListHolder> *pAdded = nullptr);
+   void ClearPendingTracks(std::vector<TrackListHolder> *pAdded = nullptr,
+      std::shared_ptr<TrackList> *pPendingUpdates = nullptr);
 
    // Change the state of the project.
    // Strong guarantee for project state in case of exceptions.
    // Will always clear the pending updates.
    // Return true if the state of the track list really did change.
-   bool ApplyPendingTracks();
+   bool ApplyPendingTracks(std::vector<TrackListHolder> &&additions,
+      std::shared_ptr<TrackList> &&updates);
 
    bool HasPendingTracks() const;
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -298,10 +298,13 @@ private:
 
    //! public nonvirtual duplication function that invokes Clone()
    /*!
+    @param shallowCopyAttachments if true, then share AttachedTrackObjects
     @pre `IsLeader()`
     @post result: `NChannels() == result->NChannels()`
     */
-   virtual TrackListHolder Duplicate() const;
+   virtual TrackListHolder Duplicate(bool shallowCopyAttachments = false) const;
+
+   void ReparentAllAttachments();
 
    //! Name is always the same for all channels of a group
    const wxString &GetName() const;
@@ -1454,10 +1457,12 @@ public:
 
    /*
     Forget pending track additions and changes;
-    if requested, give back the pending added tracks.
+    if requested, give back the pending added tracks, as channel groups,
+    stored in the vector at their original positions in iteration order and
+    nulls corresponding with non-added tracks in original iteration order
     @pre `GetOwner()`
     */
-   void ClearPendingTracks(ListOfTracks *pAdded = nullptr);
+   void ClearPendingTracks(std::vector<TrackListHolder> *pAdded = nullptr);
 
    // Change the state of the project.
    // Strong guarantee for project state in case of exceptions.

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -183,15 +183,6 @@ private:
    static inline std::shared_ptr<Subclass> SharedPointer( const Track *pTrack )
    { return pTrack ? pTrack->SharedPointer<Subclass>() : nullptr; }
 
-   // Find anything registered with TrackList::RegisterPendingChangedTrack and
-   // not yet cleared or applied; if no such exists, return this track
-   std::shared_ptr<Track> SubstitutePendingChangedTrack();
-   std::shared_ptr<const Track> SubstitutePendingChangedTrack() const;
-
-   // If this track is a pending changed track, return the corresponding
-   // original; else return this track
-   std::shared_ptr<const Track> SubstituteOriginalTrack() const;
-
    //! Names of a track type for various purposes.
    /*! Some of the distinctions exist only for historical reasons. */
    struct TypeNames {
@@ -1463,8 +1454,6 @@ public:
    // Return true if the state of the track list really did change.
    bool ApplyPendingTracks(std::vector<TrackListHolder> &&additions,
       std::shared_ptr<TrackList> &&updates);
-
-   bool HasPendingTracks() const;
 
 private:
    AudacityProject *mOwner;

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1289,15 +1289,6 @@ public:
       return Temporary(pProject, temp);
    }
 
-   // Like RegisterPendingChangedTrack, but for a list of new tracks,
-   // not a replacement track.  Caller
-   // supplies the list, and there are no updates.
-   // Pending tracks will have an unassigned TrackId.
-   // Pending new tracks WILL occur in iterations, always after actual
-   // tracks, and in the sequence that they were added.  They can be
-   // distinguished from actual tracks by TrackId.
-   void RegisterPendingNewTracks(TrackList &&list);
-
    //! Remove all tracks from `list` and put them at the end of `this`
    /*!
     @param assignIds ignored if `this` is a temporary list; else if false,

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1355,9 +1355,7 @@ private:
    TrackIterRange< Track > EmptyRange() const;
 
    bool isNull(TrackNodePointer p) const
-   { return (p.second == this && p.first == ListOfTracks::end())
-      || (mPendingUpdates && p.second == &*mPendingUpdates &&
-          p.first == mPendingUpdates->ListOfTracks::end()); }
+   { return (p.second == this && p.first == ListOfTracks::end()); }
    TrackNodePointer getEnd() const
    { return { const_cast<TrackList*>(this)->ListOfTracks::end(),
               const_cast<TrackList*>(this)}; }
@@ -1406,53 +1404,8 @@ private:
    // Used to assign ids to added tracks.
    static long sCounter;
 
-public:
-   // Start a deferred update of the project.
-   // The return value is a duplicate of the given track.
-   // While ApplyPendingTracks or ClearPendingTracks is not yet called,
-   // there may be other direct changes to the project that push undo history.
-   // Meanwhile the returned object can accumulate other changes for a deferred
-   // push, and temporarily shadow the actual project track for display purposes.
-   // The Updater function, if not null, merges state (from the actual project
-   // into the pending track) which is not meant to be overridden by the
-   // accumulated pending changes.
-   // To keep the display consistent, the Y and Height values, minimized state,
-   // and Linked state must be copied, and this will be done even if the
-   // Updater does not do it.
-   // Pending track will have the same TrackId as the actual.
-   // Pending changed tracks will not occur in iterations.
-   /*!
-    @pre `GetOwner()`
-    @pre `src->IsLeader()`
-    @post result: `src->NChannels() == result.size()`
-    */
-   Track* RegisterPendingChangedTrack(Track *src);
-
-   /*
-    Forget pending track additions and changes;
-    if requested, give back the pending added tracks, as channel groups,
-    stored in the vector at their original positions in iteration order and
-    nulls corresponding with non-added tracks in original iteration order; no
-    trailing nulls
-    @pre `GetOwner()`
-    */
-   void ClearPendingTracks(std::vector<TrackListHolder> *pAdded = nullptr,
-      std::shared_ptr<TrackList> *pPendingUpdates = nullptr);
-
-   // Change the state of the project.
-   // Strong guarantee for project state in case of exceptions.
-   // Will always clear the pending updates.
-   // Return true if the state of the track list really did change.
-   bool ApplyPendingTracks(std::vector<TrackListHolder> &&additions,
-      std::shared_ptr<TrackList> &&updates);
-
-private:
    AudacityProject *mOwner;
 
-   //! Shadow tracks holding append-recording in progress; need to put them into
-   //! a list so that channel grouping works
-   /*! Beware, they are in a disjoint iteration sequence from ordinary tracks */
-   std::shared_ptr<TrackList> mPendingUpdates;
    //! Whether the list assigns unique ids to added tracks;
    //! false for temporaries
    bool mAssignsIds{ true };

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -82,9 +82,8 @@ template<typename T>
 //! An in-session identifier of track objects across undo states.  It does not persist between sessions
 /*!
     Default constructed value is not equal to the id of any track that has ever
-    been added to a TrackList, or (directly or transitively) copied from such.
-    (A track added by TrackList::RegisterPendingNewTrack() that is not yet applied is not
-    considered added.)
+    been added to a non-temporary TrackList, or (directly or transitively)
+    copied from such.
 
     TrackIds are assigned uniquely across projects. */
 class TrackId
@@ -397,12 +396,14 @@ public:
 private:
    //! Subclass responsibility implements only a part of Duplicate(), copying
    //! the track data proper (not associated data such as for groups and views)
+   //! including TrackId
    /*!
     @param unstretchInterval If set, this time interval's stretching must be applied.
     @pre `!unstretchInterval.has_value() ||
        unstretchInterval->first < unstretchInterval->second`
     @pre `IsLeader()`
     @post result: `NChannels() == result->NChannels()`
+    @post result tracks have same TrackIds as the channels of `this`
     */
    virtual TrackListHolder Clone() const = 0;
 
@@ -1266,7 +1267,7 @@ public:
 
    //! Construct a temporary list owned by `pProject` (if that is not null)
    //! so that `TrackList::Channels(left.get())` will enumerate the given
-   //! tracks
+   //! tracks; TrackIds are not changed
    /*!
     @pre `left == nullptr || left->GetOwner() == nullptr`
     @pre `right == nullptr || (left && right->GetOwner() == nullptr)`
@@ -1276,7 +1277,7 @@ public:
 
    //! Construct a temporary list whose first channel group contains the given
    //! channels, up to the limit of channel group size; excess channels go each
-   //! into a separate group
+   //! into a separate group; TrackIds are not changed
    static TrackListHolder Temporary(
       AudacityProject *pProject, const std::vector<Track::Holder> &channels);
 

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -41,7 +41,6 @@ using TrackArray = std::vector< Track* >;
 
 class TrackList;
 using TrackListHolder = std::shared_ptr<TrackList>;
-struct UndoStackElem;
 
 using ListOfTracks = std::list< std::shared_ptr< Track > >;
 
@@ -1004,8 +1003,6 @@ class TRACK_API TrackList final
  public:
    static TrackList &Get( AudacityProject &project );
    static const TrackList &Get( const AudacityProject &project );
-
-   static TrackList *FindUndoTracks(const UndoStackElem &state);
 
    // Create an empty TrackList
    // Don't call directly -- use Create() instead

--- a/libraries/lib-track/UndoTracks.cpp
+++ b/libraries/lib-track/UndoTracks.cpp
@@ -8,6 +8,7 @@
  
  **********************************************************************/
 #include "UndoTracks.h"
+#include "PendingTracks.h"
 #include "Track.h"
 #include "UndoManager.h"
 
@@ -31,7 +32,7 @@ struct TrackListRestorer final : UndoStateExtension {
          dstTracks.Append(std::move(*pTrack->Duplicate()));
    }
    bool CanUndoOrRedo(const AudacityProject &project) override {
-      return !TrackList::Get(project).HasPendingTracks();
+      return !PendingTracks::Get(project).HasPendingTracks();
    }
    const std::shared_ptr<TrackList> mpTracks;
 };

--- a/libraries/lib-track/UndoTracks.cpp
+++ b/libraries/lib-track/UndoTracks.cpp
@@ -1,0 +1,56 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file UndoTracks.cpp
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+#include "UndoTracks.h"
+#include "Track.h"
+#include "UndoManager.h"
+
+// Undo/redo handling of selection changes
+namespace {
+struct TrackListRestorer final : UndoStateExtension {
+   TrackListRestorer(AudacityProject &project)
+      : mpTracks{ TrackList::Create(nullptr) }
+   {
+      for (auto pTrack : TrackList::Get(project)) {
+         if (pTrack->GetId() == TrackId{})
+            // Don't copy a pending added track
+            continue;
+         mpTracks->Append(std::move(*pTrack->Duplicate()));
+      }
+   }
+   void RestoreUndoRedoState(AudacityProject &project) override {
+      auto &dstTracks = TrackList::Get(project);
+      dstTracks.Clear();
+      for (auto pTrack : *mpTracks)
+         dstTracks.Append(std::move(*pTrack->Duplicate()));
+   }
+   bool CanUndoOrRedo(const AudacityProject &project) override {
+      return !TrackList::Get(project).HasPendingTracks();
+   }
+   const std::shared_ptr<TrackList> mpTracks;
+};
+
+UndoRedoExtensionRegistry::Entry sEntry {
+   [](AudacityProject &project) -> std::shared_ptr<UndoStateExtension> {
+      return std::make_shared<TrackListRestorer>(project);
+   }
+};
+}
+
+TrackList *UndoTracks::Find(const UndoStackElem &state)
+{
+   auto &exts = state.state.extensions;
+   auto end = exts.end(),
+      iter = std::find_if(exts.begin(), end, [](auto &pExt){
+         return dynamic_cast<TrackListRestorer*>(pExt.get());
+      });
+   if (iter != end)
+      return static_cast<TrackListRestorer*>(iter->get())->mpTracks.get();
+   return nullptr;
+}

--- a/libraries/lib-track/UndoTracks.h
+++ b/libraries/lib-track/UndoTracks.h
@@ -1,0 +1,20 @@
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file UndoTracks.h
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+#ifndef __AUDACITY_UNDO_TRACKS__
+#define __AUDACITY_UNDO_TRACKS__
+
+class TrackList;
+struct UndoStackElem;
+
+namespace UndoTracks {
+TRACK_API TrackList *Find(const UndoStackElem &state);
+}
+
+#endif

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -79,6 +79,7 @@ It handles initialization and termination by subclassing wxApp.
 #include "Languages.h"
 #include "MenuCreator.h"
 #include "PathList.h"
+#include "PendingTracks.h"
 #include "PluginManager.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
@@ -1197,7 +1198,7 @@ bool AudacityApp::OnExceptionInMainLoop()
             ProjectHistory::Get( *pProject ).RollbackState();
 
             // Forget pending changes in the TrackList
-            TrackList::Get( *pProject ).ClearPendingTracks();
+            PendingTracks::Get(*pProject).ClearPendingTracks();
 
             ProjectWindow::Get( *pProject ).RedrawProject();
          }

--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -36,6 +36,7 @@ undo memory so as to free up space.
 #include "../images/Arrow.xpm"
 #include "../images/Empty9x16.xpm"
 #include "UndoManager.h"
+#include "UndoTracks.h"
 #include "Project.h"
 #include "ProjectFileIO.h"
 #include "ProjectHistory.h"
@@ -90,7 +91,7 @@ struct SpaceUsageCalculator {
       manager.VisitStates(
          [this, &seen](const UndoStackElem &elem) {
             // Scan all tracks at current level
-            if (auto pTracks = TrackList::FindUndoTracks(elem))
+            if (auto pTracks = UndoTracks::Find(elem))
                space.push_back(CalculateUsage(*pTracks, seen));
          },
          true // newest state first

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -37,6 +37,7 @@
 #include "CommonCommandFlags.h"
 #include "KeyboardCapture.h"
 #include "prefs/GUISettings.h" // for RTL_WORKAROUND
+#include "PendingTracks.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
 #include "ProjectAudioManager.h"
@@ -955,7 +956,7 @@ MixerBoard::MixerBoard(AudacityProject* pProject,
       .Subscribe(*this, &MixerBoard::OnTimer);
 
    mTrackPanelSubscription =
-   mTracks->Subscribe([this](const TrackListEvent &event){
+   PendingTracks::Get(*mProject).Subscribe([this](const TrackListEvent &event){
       switch (event.mType) {
       case TrackListEvent::SELECTION_CHANGE:
       case TrackListEvent::TRACK_DATA_CHANGE:

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -40,6 +40,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "TrackPanelAx.h"
 #include "TrackPanel.h"
 #include "UndoManager.h"
+#include "UndoTracks.h"
 #include "WaveTrack.h"
 #include "wxFileNameWrapper.h"
 #include "Export.h"
@@ -1521,7 +1522,7 @@ void ProjectFileManager::Compact()
    const auto greatest = std::max<size_t>(savedState, currentState);
    std::vector<const TrackList*> trackLists;
    auto fn = [&](const UndoStackElem& elem) {
-      if (auto pTracks = TrackList::FindUndoTracks(elem))
+      if (auto pTracks = UndoTracks::Find(elem))
          trackLists.push_back(pTracks);
    };
    undoManager.VisitStates(fn, least, 1 + least);

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -12,6 +12,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "ActiveProject.h"
 #include "AllThemeResources.h"
 #include "AudioIO.h"
+#include "PendingTracks.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
 #include "ProjectFileIO.h"
@@ -1106,7 +1107,8 @@ void ProjectWindow::FixScrollbars()
    auto LastTime = std::numeric_limits<double>::lowest();
    for (const Track *track : tracks) {
       // Iterate over pending changed tracks if present.
-      track = track->SubstitutePendingChangedTrack().get();
+      track = PendingTracks::Get(project)
+         .SubstitutePendingChangedTrack(*track).get();
       LastTime = std::max(LastTime, track->GetEndTime());
    }
    LastTime =

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -41,6 +41,7 @@
 #include "RealtimeEffectState.h"
 #include "effects/RealtimeEffectStateUI.h"
 #include "UndoManager.h"
+#include "PendingTracks.h"
 #include "Prefs.h"
 #include "BasicUI.h"
 #include "ListNavigationEnabled.h"
@@ -1140,7 +1141,8 @@ RealtimeEffectPanel::RealtimeEffectPanel(
    SetSizerAndFit(vSizer.release());
 
    Bind(wxEVT_CHAR_HOOK, &RealtimeEffectPanel::OnCharHook, this);
-   mTrackListChanged = TrackList::Get(mProject).Subscribe([this](const TrackListEvent& evt) {
+   mTrackListChanged =
+   PendingTracks::Get(mProject).Subscribe([this](const TrackListEvent& evt) {
          auto track = evt.mpTrack.lock();
          auto waveTrack = std::dynamic_pointer_cast<WaveTrack>(track);
 

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -28,6 +28,7 @@
 
 class wxRect;
 
+class PendingTracks;
 class TrackList;
 class TrackPanel;
 class SelectedRegion;
@@ -121,6 +122,7 @@ public:
 
    const SelectedRegion *pSelectedRegion{};
    ZoomInfo *pZoomInfo{};
+   const PendingTracks *pPendingTracks{};
 
    bool drawEnvelope{ false };
    bool bigPoints{ false };

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -300,8 +300,8 @@ TrackPanel::TrackPanel(wxWindow * parent, wxWindowID id,
       &TrackPanel::OnIdle, this);
 
    // Register for tracklist updates
-   mTrackListSubscription =
-   mTracks->Subscribe([this](const TrackListEvent &event){
+   mTrackListSubscription = PendingTracks::Get(*GetProject())
+   .Subscribe([this](const TrackListEvent &event){
       switch (event.mType) {
       case TrackListEvent::RESIZING:
       case TrackListEvent::ADDITION:

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -52,6 +52,7 @@ is time to refresh some aspect of the screen.
 #include "AdornedRulerPanel.h"
 #include "tracks/ui/CommonTrackPanelCell.h"
 #include "KeyboardCapture.h"
+#include "PendingTracks.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
 #include "ProjectAudioManager.h"
@@ -554,7 +555,7 @@ void TrackPanel::ProcessUIHandleResult
 
    // Copy data from the underlying tracks to the pending tracks that are
    // really displayed
-   TrackList::Get( *panel->GetProject() ).UpdatePendingTracks();
+   PendingTracks::Get(*panel->GetProject()).UpdatePendingTracks();
 
    using namespace RefreshCode;
 
@@ -831,6 +832,8 @@ void TrackPanel::DrawTracks(wxDC * dc)
 
    const SelectedRegion &sr = mViewInfo->selectedRegion;
    mTrackArtist->pSelectedRegion = &sr;
+   const auto &pendingTracks = PendingTracks::Get(*GetProject());
+   mTrackArtist->pPendingTracks = &pendingTracks;
    mTrackArtist->pZoomInfo = mViewInfo;
    TrackPanelDrawingContext context {
       *dc, Target(), mLastMouseState, mTrackArtist.get()
@@ -852,9 +855,9 @@ void TrackPanel::DrawTracks(wxDC * dc)
 #endif
 
    const bool hasSolo = GetTracks()->Any<PlayableTrack>()
-      .any_of( [](const PlayableTrack *pt) {
+      .any_of( [&](const PlayableTrack *pt) {
          pt = static_cast<const PlayableTrack *>(
-            pt->SubstitutePendingChangedTrack().get());
+            pendingTracks.SubstitutePendingChangedTrack(*pt).get());
          return (pt && pt->GetSolo());
       } );
 
@@ -1136,7 +1139,10 @@ void DrawTrackName(int leftOffset, TrackPanelDrawingContext &context,
 {
    if (!TrackArtist::Get(context)->mbShowTrackNameInTrack)
       return;
-   auto &track = *GetTrack(channel).SubstitutePendingChangedTrack();
+   const auto artist = TrackArtist::Get(context);
+   const auto &pendingTracks = *artist->pPendingTracks;
+   auto &track =
+      *pendingTracks.SubstitutePendingChangedTrack(GetTrack(channel));
    auto name = track.GetName();
    if (name.IsEmpty())
       return;

--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -21,6 +21,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../widgets/BasicMenu.h"
 #include "AllThemeResources.h"
 #include "../../../HitTestResult.h"
+#include "PendingTracks.h"
 #include "Project.h"
 #include "ProjectHistory.h"
 #include "ProjectNumericFormats.h"
@@ -782,6 +783,7 @@ void LabelTrackView::Draw
    auto &dc = context.dc;
    const auto artist = TrackArtist::Get( context );
    const auto &zoomInfo = *artist->pZoomInfo;
+   const auto &pendingTracks = *artist->pPendingTracks;
 
    auto pHit = findHit( artist->parent );
 
@@ -792,7 +794,7 @@ void LabelTrackView::Draw
       calculateFontHeight(dc);
 
    const auto pTrack = std::static_pointer_cast< const LabelTrack >(
-      FindTrack()->SubstitutePendingChangedTrack());
+      pendingTracks.SubstitutePendingChangedTrack(*FindTrack()));
    const auto &mLabels = pTrack->GetLabels();
 
    TrackArt::DrawBackgroundWithSelection( context, r, pTrack.get(),

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackAffordanceControls.cpp
@@ -26,7 +26,7 @@
 
 #include "../lib-src/header-substitutes/allegro.h"
 
-
+#include "PendingTracks.h"
 #include "ProjectHistory.h"
 #include "SelectionState.h"
 #include "../../../../ProjectSettings.h"
@@ -65,72 +65,77 @@ NoteTrackAffordanceControls::NoteTrackAffordanceControls(const std::shared_ptr<T
 
 std::vector<UIHandlePtr> NoteTrackAffordanceControls::HitTest(const TrackPanelMouseState& state, const AudacityProject* pProject)
 {
-    std::vector<UIHandlePtr> results;
-
-    auto track = std::static_pointer_cast<NoteTrack>(FindTrack());
-    const auto nt = std::static_pointer_cast<const NoteTrack>(track->SubstitutePendingChangedTrack());
-
-    const auto rect = state.rect;
-
-    auto& zoomInfo = ViewInfo::Get(*pProject);
-    auto left = zoomInfo.TimeToPosition(nt->GetStartTime(), rect.x);
-    auto right = zoomInfo.TimeToPosition(nt->GetStartTime() + nt->GetSeq().get_real_dur(), rect.x);
-    auto headerRect = wxRect(left, rect.y, right - left, rect.height);
-
-    auto px = state.state.m_x;
-    auto py = state.state.m_y;
-
-    if (px >= headerRect.GetLeft() && px <= headerRect.GetRight() &&
-        py >= headerRect.GetTop() && py <= headerRect.GetBottom())
-    {
-        results.push_back(NoteTrackAffordanceHandle::HitAnywhere(mAffordanceHandle, track));
-    }
-
-    const auto& settings = ProjectSettings::Get(*pProject);
-    const auto currentTool = settings.GetTool();
-    if (currentTool == ToolCodes::multiTool || currentTool == ToolCodes::selectTool)
-    {
-        results.push_back(
-            SelectHandle::HitTest(
-                mSelectHandle, state, pProject,
-                ChannelView::Get(*track).shared_from_this()
-            )
-        );
-    }
-
-    return results;
+   std::vector<UIHandlePtr> results;
+   
+   auto track = std::static_pointer_cast<NoteTrack>(FindTrack());
+   const auto nt = std::static_pointer_cast<const NoteTrack>(
+      PendingTracks::Get(*pProject).SubstitutePendingChangedTrack(*track));
+   
+   const auto rect = state.rect;
+   
+   auto& zoomInfo = ViewInfo::Get(*pProject);
+   auto left = zoomInfo.TimeToPosition(nt->GetStartTime(), rect.x);
+   auto right = zoomInfo.TimeToPosition(nt->GetStartTime() + nt->GetSeq().get_real_dur(), rect.x);
+   auto headerRect = wxRect(left, rect.y, right - left, rect.height);
+   
+   auto px = state.state.m_x;
+   auto py = state.state.m_y;
+   
+   if (px >= headerRect.GetLeft() && px <= headerRect.GetRight() &&
+       py >= headerRect.GetTop() && py <= headerRect.GetBottom())
+   {
+      results.push_back(NoteTrackAffordanceHandle::HitAnywhere(mAffordanceHandle, track));
+   }
+   
+   const auto& settings = ProjectSettings::Get(*pProject);
+   const auto currentTool = settings.GetTool();
+   if (currentTool == ToolCodes::multiTool || currentTool == ToolCodes::selectTool)
+   {
+      results.push_back(
+                        SelectHandle::HitTest(
+                                              mSelectHandle, state, pProject,
+                                              ChannelView::Get(*track).shared_from_this()
+                                              )
+                        );
+   }
+   
+   return results;
 }
 
 void NoteTrackAffordanceControls::Draw(TrackPanelDrawingContext& context, const wxRect& rect, unsigned iPass)
 {
-    if (iPass == TrackArtist::PassBackground) {
-        const auto nt = std::static_pointer_cast<const NoteTrack>(FindTrack()->SubstitutePendingChangedTrack());
-        const auto artist = TrackArtist::Get(context);
 
-        TrackArt::DrawBackgroundWithSelection(context, rect, nt.get(), AColor::labelSelectedBrush, AColor::labelUnselectedBrush);
+   if (iPass == TrackArtist::PassBackground) {
+      const auto artist = TrackArtist::Get(context);
+      const auto &pendingTracks = *artist->pPendingTracks;
 
-        const auto& zoomInfo = *artist->pZoomInfo;
-        auto left = zoomInfo.TimeToPosition(nt->GetStartTime(), rect.x);
-        auto right = zoomInfo.TimeToPosition(nt->GetStartTime() + nt->GetSeq().get_real_dur(), rect.x);
-        auto clipRect = wxRect(left, rect.y, right - left + 1, rect.height);
-
-        auto px = context.lastState.m_x;
-        auto py = context.lastState.m_y;
-
-        auto selected = IsSelected();
-        auto highlight = selected ||
-            (px >= clipRect.GetLeft() && px <= clipRect.GetRight() &&
-                py >= clipRect.GetTop() && py <= clipRect.GetBottom());
-
-        {
-            wxDCClipper clipper(context.dc, rect);
-            context.dc.SetTextBackground(wxTransparentColor);
-            context.dc.SetTextForeground(theTheme.Colour(clrClipNameText));
-            context.dc.SetFont(wxFont(wxFontInfo()));
-            const auto titleRect = TrackArt::DrawClipAffordance(context.dc, clipRect, highlight, selected);
-            TrackArt::DrawClipTitle(context.dc, titleRect, nt->GetName());
-        }
-    }
+      const auto nt = std::static_pointer_cast<const NoteTrack>(
+         pendingTracks.SubstitutePendingChangedTrack(*FindTrack()));
+      
+      TrackArt::DrawBackgroundWithSelection(context, rect, nt.get(), AColor::labelSelectedBrush, AColor::labelUnselectedBrush);
+      
+      const auto& zoomInfo = *artist->pZoomInfo;
+      auto left = zoomInfo.TimeToPosition(nt->GetStartTime(), rect.x);
+      auto right = zoomInfo.TimeToPosition(nt->GetStartTime() + nt->GetSeq().get_real_dur(), rect.x);
+      auto clipRect = wxRect(left, rect.y, right - left + 1, rect.height);
+      
+      auto px = context.lastState.m_x;
+      auto py = context.lastState.m_y;
+      
+      auto selected = IsSelected();
+      auto highlight = selected ||
+      (px >= clipRect.GetLeft() && px <= clipRect.GetRight() &&
+       py >= clipRect.GetTop() && py <= clipRect.GetBottom());
+      
+      {
+         wxDCClipper clipper(context.dc, rect);
+         context.dc.SetTextBackground(wxTransparentColor);
+         context.dc.SetTextForeground(theTheme.Colour(clrClipNameText));
+         context.dc.SetFont(wxFont(wxFontInfo()));
+         const auto titleRect = TrackArt::DrawClipAffordance(context.dc, clipRect, highlight, selected);
+         TrackArt::DrawClipTitle(context.dc, titleRect, nt->GetName());
+      }
+   }
 }
 
 bool NoteTrackAffordanceControls::IsSelected() const

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackView.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackView.cpp
@@ -18,6 +18,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "AColor.h"
 #include "AllThemeResources.h"
 #include "../../../../HitTestResult.h"
+#include "PendingTracks.h"
 #include "Theme.h"
 #include "../../../../TrackArt.h"
 #include "../../../../TrackArtist.h"
@@ -726,9 +727,12 @@ void NoteTrackView::Draw(
    TrackPanelDrawingContext &context,
    const wxRect &rect, unsigned iPass )
 {
+   const auto artist = TrackArtist::Get(context);
+   const auto &pendingTracks = *artist->pPendingTracks;
+
    if ( iPass == TrackArtist::PassTracks ) {
       const auto nt = std::static_pointer_cast<const NoteTrack>(
-         FindTrack()->SubstitutePendingChangedTrack());
+         pendingTracks.SubstitutePendingChangedTrack(*FindTrack()));
       bool muted = false;
 #ifdef EXPERIMENTAL_MIDI_OUT
       const auto artist = TrackArtist::Get( context );

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -24,6 +24,7 @@ Paul Licameli split from WaveChannelView.cpp
 #include "../../../ui/BrushHandle.h"
 
 #include "AColor.h"
+#include "PendingTracks.h"
 #include "Prefs.h"
 #include "NumberScale.h"
 #include "../../../../TrackArt.h"
@@ -888,12 +889,13 @@ void SpectrumView::Draw(
    TrackPanelDrawingContext &context, const wxRect &rect, unsigned iPass )
 {
    if ( iPass == TrackArtist::PassTracks ) {
+      const auto artist = TrackArtist::Get(context);
+      const auto &pendingTracks = *artist->pPendingTracks;
+
       auto &dc = context.dc;
  
       const auto wt = std::static_pointer_cast<const WaveTrack>(
-         FindTrack()->SubstitutePendingChangedTrack());
-
-      const auto artist = TrackArtist::Get( context );
+         pendingTracks.SubstitutePendingChangedTrack(*FindTrack()));
 
 #if defined(__WXMAC__)
       wxAntialiasMode aamode = dc.GetGraphicsContext()->GetAntialiasMode();

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -36,6 +36,7 @@
 #include "WaveChannelView.h"//need only ClipParameters
 #include "WaveTrackAffordanceHandle.h"
 
+#include "PendingTracks.h"
 #include "ProjectHistory.h"
 #include "../../../../ProjectSettings.h"
 #include "SelectionState.h"
@@ -192,7 +193,8 @@ std::vector<UIHandlePtr> WaveTrackAffordanceControls::HitTest(const TrackPanelMo
         );
     }
 
-    const auto waveTrack = std::static_pointer_cast<WaveTrack>(track->SubstitutePendingChangedTrack());
+    const auto waveTrack = std::static_pointer_cast<WaveTrack>(
+       PendingTracks::Get(*pProject).SubstitutePendingChangedTrack(*track));
     auto& zoomInfo = ViewInfo::Get(*pProject);
     const auto intervals = waveTrack->Intervals();
     for(auto it = intervals.begin(); it != intervals.end(); ++it)
@@ -234,12 +236,14 @@ void WaveTrackAffordanceControls::Draw(TrackPanelDrawingContext& context, const 
     if (iPass == TrackArtist::PassBackground) {
         auto track = FindTrack();
         const auto artist = TrackArtist::Get(context);
+        const auto &pendingTracks = *artist->pPendingTracks;
 
         TrackArt::DrawBackgroundWithSelection(context, rect, track.get(), artist->blankSelectedBrush, artist->blankBrush);
 
         mVisibleIntervals.clear();
 
-        const auto waveTrack = std::static_pointer_cast<WaveTrack>(track->SubstitutePendingChangedTrack());
+        const auto waveTrack = std::static_pointer_cast<WaveTrack>(
+           pendingTracks.SubstitutePendingChangedTrack(*track));
         const auto& zoomInfo = *artist->pZoomInfo;
         {
             wxDCClipper dcClipper(context.dc, rect);

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -18,6 +18,7 @@
 #include "CommandFlag.h"
 #include "CommandFunctors.h"
 #include "MenuRegistry.h"
+#include "PendingTracks.h"
 #include "../../../../TrackPanelMouseEvent.h"
 #include "../../../../TrackArt.h"
 #include "../../../../TrackArtist.h"
@@ -36,7 +37,6 @@
 #include "WaveChannelView.h"//need only ClipParameters
 #include "WaveTrackAffordanceHandle.h"
 
-#include "PendingTracks.h"
 #include "ProjectHistory.h"
 #include "../../../../ProjectSettings.h"
 #include "SelectionState.h"
@@ -144,19 +144,20 @@ WaveTrackAffordanceControls::WaveTrackAffordanceControls(const std::shared_ptr<T
     : CommonTrackCell{ pTrack, 0 }
     , mClipNameFont{ wxFontInfo{} }
 {
-    if (auto trackList = pTrack->GetOwner())
-    {
-        mTrackListEventSubscription = trackList->Subscribe(
+   if (auto trackList = pTrack->GetOwner()) {
+      if (auto pProject = trackList->GetOwner()) {
+         mTrackListEventSubscription = PendingTracks(*pProject).Subscribe(
             *this, &WaveTrackAffordanceControls::OnTrackListEvent);
-        if(auto project = trackList->GetOwner())
-        {
+         if(auto project = trackList->GetOwner())
+         {
             auto& viewInfo = ViewInfo::Get(*project);
             mSelectionChangeSubscription =
-                viewInfo.selectedRegion.Subscribe(
-                    *this,
-                    &WaveTrackAffordanceControls::OnSelectionChange);
-        }
-    }
+            viewInfo.selectedRegion.Subscribe(
+               *this,
+               &WaveTrackAffordanceControls::OnSelectionChange);
+         }
+      }
+   }
 }
 
 std::vector<UIHandlePtr> WaveTrackAffordanceControls::HitTest(const TrackPanelMouseState& state, const AudacityProject* pProject)

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -22,6 +22,7 @@ Paul Licameli split from WaveChannelView.cpp
 #include "AColor.h"
 #include "Envelope.h"
 #include "../../../../EnvelopeEditor.h"
+#include "PendingTracks.h"
 #include "../../../../ProjectSettings.h"
 #include "SelectedRegion.h"
 #include "SyncLock.h"
@@ -993,12 +994,13 @@ void WaveformView::Draw(
    TrackPanelDrawingContext &context, const wxRect &rect, unsigned iPass )
 {
    if ( iPass == TrackArtist::PassTracks ) {
+      const auto artist = TrackArtist::Get(context);
+      const auto &pendingTracks = *artist->pPendingTracks;
       auto &dc = context.dc;
 
       const auto wt = std::static_pointer_cast<const WaveTrack>(
-         FindTrack()->SubstitutePendingChangedTrack());
+         pendingTracks.SubstitutePendingChangedTrack(*FindTrack()));
 
-      const auto artist = TrackArtist::Get( context );
       const auto hasSolo = artist->hasSolo;
       bool muted = (hasSolo || wt->GetMute()) &&
       !wt->GetSolo();

--- a/src/tracks/timetrack/ui/TimeTrackView.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackView.cpp
@@ -19,6 +19,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "Envelope.h"
 #include "../../../EnvelopeEditor.h"
 #include "../../../HitTestResult.h"
+#include "PendingTracks.h"
 #include "Theme.h"
 #include "../../../TrackArtist.h"
 #include "../../../TrackPanelDrawingContext.h"
@@ -158,6 +159,8 @@ void TimeTrackView::Draw(
    const wxRect &rect, unsigned iPass )
 {
    if ( iPass == TrackArtist::PassTracks ) {
+      const auto artist = TrackArtist::Get(context);
+      const auto &pendingTracks = *artist->pPendingTracks;
       const auto pTrack = FindTrack();
       const auto pList = pTrack->GetOwner();
       if (!pList)
@@ -183,7 +186,7 @@ void TimeTrackView::Draw(
       ruler.SetLabelEdges(false);
 
       const auto tt = std::static_pointer_cast<const TimeTrack>(
-         pTrack->SubstitutePendingChangedTrack());
+         pendingTracks.SubstitutePendingChangedTrack(*pTrack));
       DrawTimeTrack(context, *tt, ruler, rect);
    }
    CommonChannelView::Draw(context, rect, iPass);

--- a/src/tracks/ui/ChannelView.cpp
+++ b/src/tracks/ui/ChannelView.cpp
@@ -12,6 +12,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "Track.h"
 
 #include "ClientData.h"
+#include "PendingTracks.h"
 #include "Project.h"
 #include "XMLTagHandler.h"
 #include "XMLWriter.h"
@@ -253,7 +254,7 @@ struct TrackPositioner final : ClientData::Base
    explicit TrackPositioner( AudacityProject &project )
       : mProject{ project }
    {
-      mSubscription = TrackList::Get( project )
+      mSubscription = PendingTracks::Get(project)
          .Subscribe(*this, &TrackPositioner::OnUpdate);
    }
    TrackPositioner( const TrackPositioner & ) = delete;

--- a/src/tracks/ui/CommonChannelView.cpp
+++ b/src/tracks/ui/CommonChannelView.cpp
@@ -16,6 +16,7 @@ Paul Licameli split from class TrackView (now called ChannelView)
 #include "ZoomHandle.h"
 #include "../ui/SelectHandle.h"
 #include "AColor.h"
+#include "PendingTracks.h"
 #include "../../ProjectSettings.h"
 #include "Track.h"
 #include "../../TrackArtist.h"
@@ -81,8 +82,14 @@ std::shared_ptr<TrackPanelCell> CommonChannelView::ContextMenuDelegate()
 int CommonChannelView::GetMinimizedHeight() const
 {
    auto height = TrackInfo::MinimumTrackHeight();
-   const auto pTrack = FindTrack();
-   auto channels = TrackList::Channels(pTrack->SubstituteOriginalTrack().get());
+   std::shared_ptr<const Track> pTrack = FindTrack();
+   if (const auto pList = pTrack->GetOwner()) {
+      if (const auto p = pList->GetOwner()) {
+         pTrack = PendingTracks::Get(*p).SubstituteOriginalTrack(*pTrack);
+      }
+   }
+
+   auto channels = TrackList::Channels(pTrack.get());
    auto nChannels = channels.size();
    auto begin = channels.begin();
    auto index =

--- a/src/tracks/ui/TrackButtonHandles.cpp
+++ b/src/tracks/ui/TrackButtonHandles.cpp
@@ -11,6 +11,7 @@ Paul Licameli split from TrackPanel.cpp
 
 #include "TrackButtonHandles.h"
 
+#include "PendingTracks.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
 #include "../../ProjectAudioManager.h"
@@ -155,7 +156,8 @@ UIHandle::Result CloseButtonHandle::CommitChanges
    auto pTrack = mpTrack.lock();
    if (pTrack)
    {
-      auto toRemove = pTrack->SubstitutePendingChangedTrack();
+      auto toRemove = PendingTracks::Get(*pProject)
+         .SubstitutePendingChangedTrack(*pTrack);
       ProjectAudioManager::Get( *pProject ).StopIfPaused();
       if (!ProjectAudioIO::Get( *pProject ).IsAudioActive()) {
          // This pushes an undo item:


### PR DESCRIPTION
Resolves: #5460

Clean up an old mess in TrackList, which predated the invention of ClientData.

Accomplish the same purpose non-intrusively now in TrackList.

That purpose is, to paint temporary recording tracks that are not the same as those in the project,
while the recording is not yet committed to undo history.  Some undo/redo items can be pushed or
modified during recording (as with Ctrl+B to drop a label), and those must be sequenced in undo
history entirely before the recording although they happened simultaneously with it.

QA: 
- Observe correct display updates during recording:
  - [x] recording to new tracks (Shift + R)
  - [x] append-recording (R key, when a track exists)
  - [x] Punch-and-roll recording
- Do things that push or modify undo history during recording; then observe undo-redo behavior.  The other changes are supposed to be sequenced all before the recording when you undo/redo
  - [x] changing the selection 
  - [x] Dropping a label (Ctrl+B, or Ctrl+M / MacOs Ctrl+.)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
