### PR TITLE
5390 stretch rendering always joint stereo

### DIFF
--- a/libraries/lib-wave-track/Sequence.h
+++ b/libraries/lib-wave-track/Sequence.h
@@ -158,7 +158,10 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
    /*! @excsafety{Strong} */
    void InsertSilence(sampleCount s0, sampleCount len);
 
-   const SampleBlockFactoryPtr &GetFactory() { return mpFactory; }
+   const SampleBlockFactoryPtr& GetFactory() const
+   {
+      return mpFactory;
+   }
 
    //
    // XMLTagHandler callback methods for loading and saving

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -22,13 +22,11 @@
 #include <wx/log.h>
 
 #include "BasicUI.h"
-#include "ClipTimeAndPitchSource.h"
 #include "Envelope.h"
 #include "InconsistencyException.h"
 #include "Resample.h"
 #include "Sequence.h"
-#include "StaffPadTimeAndPitch.h"
-//#include "TimeAndPitchInterface.h"
+#include "TimeAndPitchInterface.h"
 #include "UserException.h"
 
 #ifdef _OPENMP
@@ -1199,101 +1197,6 @@ void WaveClip::Resample(int rate, BasicUI::ProgressDialog *progress)
       Flush();
       Caches::ForEach( std::mem_fn( &WaveClipListener::Invalidate ) );
    }
-}
-
-void WaveClip::ApplyStretchRatio(const ProgressReporter& reportProgress)
-{
-   assert(mProjectTempo.has_value());
-
-   if (StretchRatioEquals(1))
-      return;
-   const auto stretchRatio = GetStretchRatio();
-
-   auto success = false;
-   auto newSequences = GetEmptySequenceCopies();
-   bool swappedOnce = false;
-
-   Finally Do { [&, oldTrimLeft = GetTrimLeft(), oldTrimRight = GetTrimRight(),
-                 oldOffset = GetSequenceStartTime(),
-                 oldRawAudioTempo = mRawAudioTempo,
-                 oldClipStretchRatio = mClipStretchRatio] {
-      if (success)
-         assert(GetStretchRatio() == 1);
-      else
-      {
-         this->mClipStretchRatio = oldClipStretchRatio;
-         this->mRawAudioTempo = oldRawAudioTempo;
-         this->SetTrimLeft(oldTrimLeft);
-         this->SetTrimRight(oldTrimRight);
-         this->SetSequenceStartTime(oldOffset);
-         if (swappedOnce)
-            std::swap(mSequences, newSequences);
-      }
-   } };
-
-   const auto originalPlayStartTime = GetPlayStartTime();
-   const auto originalPlayEndTime = GetPlayEndTime();
-
-   // Leave 1 second of raw, unstretched audio before and after visible region
-   // to ensure the algorithm is in a steady state when reaching the play
-   // boundaries.
-   SetTrimLeft(0);
-   SetTrimRight(0);
-   ClearLeft(originalPlayStartTime - stretchRatio);
-   ClearRight(originalPlayEndTime + stretchRatio);
-
-   // Let's not use the `durationToDiscard` functionality of the
-   // `TimeAndPitchSource`: this determines the source readout offset. We want
-   // to do better here: feed earlier samples, but discard the early output.
-   constexpr auto sourceDurationToDiscard = 0.;
-   constexpr auto blockSize = 1024;
-   const auto numChannels = GetWidth();
-
-   ClipTimeAndPitchSource stretcherSource { *this, sourceDurationToDiscard,
-                                            PlaybackDirection::forward };
-   TimeAndPitchInterface::Parameters params;
-   params.timeRatio = stretchRatio;
-   StaffPadTimeAndPitch stretcher { GetRate(), numChannels, stretcherSource,
-                                    std::move(params) };
-
-   // Post-rendering sample counts, i.e., stretched units
-   const auto totalNumOutSamples =
-      sampleCount { GetVisibleSampleCount().as_double() * stretchRatio };
-
-   sampleCount numOutSamples { 0 };
-   AudioContainer container(blockSize, numChannels);
-   while (numOutSamples < totalNumOutSamples)
-   {
-      const auto numSamplesToGet =
-         limitSampleBufferSize(blockSize, totalNumOutSamples - numOutSamples);
-      stretcher.GetSamples(container.Get(), numSamplesToGet);
-      auto channel = 0u;
-      for (auto& newSequence : newSequences)
-         newSequence->Append(
-            reinterpret_cast<samplePtr>(container.Get()[channel++]),
-            floatSample, numSamplesToGet, 1,
-            widestSampleFormat /* computed samples need dither */
-         );
-      numOutSamples += numSamplesToGet;
-      if (reportProgress)
-         reportProgress(
-            numOutSamples.as_double() / totalNumOutSamples.as_double());
-   }
-   for (const auto& sequence : newSequences)
-      sequence->Flush();
-
-   std::swap(mSequences, newSequences);
-   swappedOnce = true;
-   mRawAudioTempo = *mProjectTempo;
-   mClipStretchRatio = 1;
-
-   ClearLeft(originalPlayStartTime);
-   ClearRight(originalPlayEndTime);
-
-   Flush();
-   Caches::ForEach(std::mem_fn(&WaveClipListener::Invalidate));
-
-   success = true;
 }
 
 // Used by commands which interact with clips using the keyboard.

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -471,8 +471,8 @@ void WaveClip::UpdateEnvelopeTrackLen()
 }
 
 /*! @excsafety{Strong} */
-std::shared_ptr<SampleBlock> WaveClip::AppendNewBlock(
-   samplePtr buffer, sampleFormat format, size_t len)
+std::shared_ptr<SampleBlock>
+WaveClip::AppendNewBlock(constSamplePtr buffer, sampleFormat format, size_t len)
 {
    // This is a special use function for legacy files only and this assertion
    // does not need to be relaxed

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -448,8 +448,8 @@ public:
 
    //! For use in importing pre-version-3 projects to preserve sharing of blocks; no dithering applied
    //! @pre `GetWidth() == 1`
-   std::shared_ptr<SampleBlock> AppendNewBlock(
-      samplePtr buffer, sampleFormat format, size_t len);
+   std::shared_ptr<SampleBlock>
+   AppendNewBlock(constSamplePtr buffer, sampleFormat format, size_t len);
 
    //! For use in importing pre-version-3 projects to preserve sharing of blocks
    //! @pre `GetWidth() == 1`

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -178,14 +178,6 @@ public:
    // the length of the clip
    void Resample(int rate, BasicUI::ProgressDialog *progress = nullptr);
 
-   /*!
-    * @brief Renders the stretching of the clip (preserving duration). Clip must
-    * be part of a project and know its tempo.
-    * @pre mProjectTempo.has_value()
-    * @post GetStretchRatio() == 1
-    */
-   void ApplyStretchRatio(const ProgressReporter& reportProgress);
-
    void SetColourIndex(int index) { mColourIndex = index; }
    int GetColourIndex() const { return mColourIndex; }
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -613,7 +613,7 @@ void WaveTrackAffordanceControls::StartEditSelectedClipSpeed(
 void WaveTrackAffordanceControls::OnRenderClipStretching(
    AudacityProject& project)
 {
-   auto [track, it] = SelectedIntervalOfFocusedTrack(project);
+   const auto [track, it] = SelectedIntervalOfFocusedTrack(project);
 
    if (track != FindTrack().get())
       return;
@@ -624,8 +624,10 @@ void WaveTrackAffordanceControls::OnRenderClipStretching(
       return;
 
    WaveTrackUtilities::WithStretchRenderingProgress(
-      [&interval](const ProgressReporter& progress) {
-         interval->ApplyStretchRatio(progress);
+      [track = track, interval = interval](const ProgressReporter& progress) {
+         track->ApplyStretchRatio(
+            { { interval->GetPlayStartTime(), interval->GetPlayEndTime() } },
+            progress);
       },
       XO("Applying..."));
 


### PR DESCRIPTION
Resolves: #5390

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA :
- [x] Doesn't re-introduce https://github.com/audacity/audacity/issues/5313
- [x] If a clip has no trimming, rendering is with RMB or with mix-and-render command yields bit-exact result
- [x] Whether stretch-rendering a clip and then applying an effect or directly applying the effect yields bit-exact result
- [x] All the above was done in mono and stereo
- [x] Test tracks with other sample formats than float
- [x] Test with a non-trivial envelope and observe the correct placement of points on the timeline
- [x] Cut lines are NOT preserved.  Whether this is agreeable to design will be decided later.

