### PR TITLE
Toolkit neutral command manager

### DIFF
--- a/libraries/lib-basic-ui/BasicUI.h
+++ b/libraries/lib-basic-ui/BasicUI.h
@@ -221,6 +221,8 @@ public:
 
    virtual std::unique_ptr<WindowPlacement> DoFindFocus() = 0;
    virtual void DoSetFocus(const WindowPlacement &focus) = 0;
+
+   virtual bool IsUsingRtlLayout() const = 0;
 };
 
 //! Fetch the global instance, or nullptr if none is yet installed
@@ -381,6 +383,14 @@ inline void SetFocus(const WindowPlacement &focus)
 {
    if (auto p = Get())
       p->DoSetFocus(focus);
+}
+
+//! Whether using a right-to-left language layout
+inline bool IsUsingRtlLayout()
+{
+   if (auto p = Get())
+      return p->IsUsingRtlLayout();
+   return false;
 }
 
 //! @}

--- a/libraries/lib-menus/CMakeLists.txt
+++ b/libraries/lib-menus/CMakeLists.txt
@@ -2,10 +2,11 @@
 Vocabulary to describe toolbar menu items, their grouping, conditions to enable
 them, and their actions.
 
-A global registry of menu descriptions and a visitor function.
+A global MenuRegistry of menu descriptions and a visitor function.
 
-It does not contain a visitor to build menus, becuase that is not
-toolkit-neutral.
+A per-project CommandManager with a nested Populator type that visits the
+registry, and can build menus, if a subclass overrides certain virtual functions
+appropriately for the UI toolkit.
 ]]
 
 set(SOURCES
@@ -14,6 +15,8 @@ set(SOURCES
    CommandFlag.cpp
    CommandFlag.h
    CommandFunctors.h
+   CommandManager.cpp
+   CommandManager.h
    CommandTargets.cpp
    CommandTargets.h
    Keyboard.cpp
@@ -23,7 +26,7 @@ set(SOURCES
 )
 
 set( LIBRARIES
-   lib-project-interface
+   lib-project-history-interface
 )
 
 audacity_library(lib-menus "${SOURCES}" "${LIBRARIES}"

--- a/libraries/lib-menus/CommandManager.cpp
+++ b/libraries/lib-menus/CommandManager.cpp
@@ -62,8 +62,6 @@ CommandManager.  It holds the callback for one command.
 #include "BasicUI.h"
 #include "Project.h"
 #include "ProjectHistory.h"
-#include "AudacityMessageBox.h"
-#include "HelpSystem.h"
 #include "UndoManager.h"
 
 #include <cassert>

--- a/libraries/lib-menus/CommandManager.h
+++ b/libraries/lib-menus/CommandManager.h
@@ -46,7 +46,7 @@ class CommandContext;
 //! Sent when menus update (such as for changing enablement of items)
 struct MenuUpdateMessage {};
 
-class AUDACITY_DLL_API CommandManager /* not final */
+class MENUS_API CommandManager /* not final */
    : public XMLTagHandler
    , public ClientData::Base
    , public Observer::Publisher<MenuUpdateMessage>
@@ -67,7 +67,7 @@ public:
 
    // Interception of menu item handling.
    // If it returns true, bypass the usual dispatch of commands.
-   struct AUDACITY_DLL_API GlobalMenuHook : GlobalHook<GlobalMenuHook,
+   struct MENUS_API GlobalMenuHook : GlobalHook<GlobalMenuHook,
       bool(const CommandID&)
    >{};
 
@@ -119,7 +119,7 @@ public:
 
    void PurgeData();
 
-   struct AUDACITY_DLL_API Populator
+   struct MENUS_API Populator
       : MenuRegistry::Visitor<MenuRegistry::Traits>
    {
       using LeafVisitor = std::function<
@@ -373,7 +373,7 @@ protected:
    AudacityProject &mProject;
 
 public:
-   struct CommandListEntry
+   struct MENUS_API CommandListEntry
    {
       static wxString FormatLabelForMenu(
          const TranslatableString &translatableLabel,

--- a/libraries/lib-wx-init/wxWidgetsBasicUI.cpp
+++ b/libraries/lib-wx-init/wxWidgetsBasicUI.cpp
@@ -229,3 +229,8 @@ void wxWidgetsBasicUI::DoSetFocus(const BasicUI::WindowPlacement &focus)
    auto pWindow = wxWidgetsWindowPlacement::GetParent(focus);
    pWindow->SetFocus();
 }
+
+bool wxWidgetsBasicUI::IsUsingRtlLayout() const
+{
+   return wxLayout_RightToLeft == wxTheApp->GetLayoutDirection();
+}

--- a/libraries/lib-wx-init/wxWidgetsBasicUI.h
+++ b/libraries/lib-wx-init/wxWidgetsBasicUI.h
@@ -51,6 +51,8 @@ protected:
 
    std::unique_ptr<BasicUI::WindowPlacement> DoFindFocus() override;
    void DoSetFocus(const BasicUI::WindowPlacement &focus) override;
+
+   bool IsUsingRtlLayout() const override;
 };
 
 #endif

--- a/modules/mod-nyq-bench/NyqBench.h
+++ b/modules/mod-nyq-bench/NyqBench.h
@@ -17,7 +17,7 @@
 #include <ostream>
 #include <sstream>
 
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "effects/nyquist/Nyquist.h"
 
 class wxFileName;

--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -32,7 +32,6 @@ processing.  See also MacrosWindow and ApplyMacroDialog.
 #include "effects/EffectManager.h"
 #include "effects/EffectUI.h"
 #include "FileNames.h"
-#include "MenuCreator.h"
 #include "PluginManager.h"
 #include "Prefs.h"
 #include "SelectFile.h"
@@ -47,6 +46,7 @@ processing.  See also MacrosWindow and ApplyMacroDialog.
 
 #include "CommandContext.h"
 #include "commands/CommandDispatch.h"
+#include "commands/CommandManager.h"
 
 MacroCommands::MacroCommands( AudacityProject &project )
 : mProject{ project }
@@ -584,7 +584,7 @@ bool MacroCommands::ApplyCommandInBatchMode(
    AudacityProject *project = &mProject;
    auto &settings = ProjectSettings::Get( *project );
    // Recalc flags and enable items that may have become enabled.
-   MenuCreator::Get(*project).UpdateMenus(false);
+   CommandManager::Get(*project).UpdateMenus(false);
    // enter batch mode...
    project->mBatchMode++;
    auto cleanup = finally( [&] {

--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -46,7 +46,7 @@ processing.  See also MacrosWindow and ApplyMacroDialog.
 
 #include "CommandContext.h"
 #include "commands/CommandDispatch.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 
 MacroCommands::MacroCommands( AudacityProject &project )
 : mProject{ project }

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -1477,7 +1477,7 @@ void OnApplyMacroDirectlyByName(const CommandContext& context, const MacroID& Na
 #endif
    /* i18n-hint: %s will be the name of the macro which will be
     * repeated if this menu item is chosen */
-   MenuCreator::Get(project).ModifyUndoMenuItems();
+   CommandManager::Get(project).ModifyUndoMenuItems();
 
    TranslatableString desc;
    EffectManager& em = EffectManager::Get();

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -44,7 +44,7 @@
 #include "ProjectWindow.h"
 #include "SelectUtilities.h"
 #include "Track.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "Effect.h"
 #include "effects/EffectUI.h"
 #include "../images/Arrow.xpm"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -258,8 +258,6 @@ list( APPEND SOURCES
       commands/CommandDispatch.h
       commands/CommandHandler.cpp
       commands/CommandHandler.h
-      commands/CommandManager.cpp
-      commands/CommandManager.h
       commands/CommandManagerWindowClasses.cpp
       commands/CommandManagerWindowClasses.h
       commands/CommandMisc.h

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -1220,7 +1220,7 @@ void FreqPlot::OnMouseEvent(wxMouseEvent & event)
 
 // Remaining code hooks this add-on into the application
 #include "CommandContext.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "ProjectWindows.h"
 
 namespace {

--- a/src/MenuCreator.cpp
+++ b/src/MenuCreator.cpp
@@ -122,8 +122,10 @@ struct MenuItemVisitor final : CommandManager::Populator {
          }
       }},
 
-      [this]() {
-         AddSeparator();
+      [this]{
+         if (mbSeparatorAllowed)
+            CurrentMenu()->AppendSeparator();
+         Populator::DoSeparator();
       }
    }
    {

--- a/src/MenuCreator.cpp
+++ b/src/MenuCreator.cpp
@@ -97,23 +97,12 @@ struct MenuItemVisitor final : CommandManager::Populator {
             assert(false);
          }
          else TypeSwitch::VDispatch<void, LeafTypes>(item,
-            [&](const CommandItem &command) {
-               AddItem(
-                  command.name, command.label_in,
-                  command.finder, command.callback,
-                  command.flags, command.options);
-            },
-            [&](const CommandGroupItem &commandList) {
-               AddItemList(commandList.name,
-                  commandList.items.data(), commandList.items.size(),
-                  commandList.finder, commandList.callback,
-                  commandList.flags, commandList.isEffect);
-            },
             [&](const SpecialItem &special) {
                if (auto pSpecial =
                   dynamic_cast<const MenuCreator::SpecialItem*>(&special))
                   pSpecial->fn(mProject, *pCurrentMenu);
-            }
+            },
+            [this](auto &item){ DoVisit(item); }
          );
       },
 

--- a/src/MenuCreator.cpp
+++ b/src/MenuCreator.cpp
@@ -264,7 +264,8 @@ void MenuCreator::UpdateMenus( bool checkActive )
 {
    auto &project = mProject;
 
-   auto flags = GetUpdateFlags(checkActive);
+   bool quick = checkActive && !GetProjectFrame(mProject).IsActive();
+   auto flags = GetUpdateFlags(quick);
    // Return from this function if nothing's changed since
    // the last time we were here.
    if (flags == mLastFlags)

--- a/src/MenuCreator.h
+++ b/src/MenuCreator.h
@@ -13,7 +13,7 @@
 #define __AUDACITY_MENU_CREATOR__
 
 #include "Callable.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 
 class AUDACITY_DLL_API MenuCreator final : public CommandManager
 {

--- a/src/MenuCreator.h
+++ b/src/MenuCreator.h
@@ -50,20 +50,15 @@ public:
    void RebuildMenuBar();
    static void RebuildAllMenuBars();
 
-   void ModifyUndoMenuItems();
-
-   // checkActive is a temporary hack that should be removed as soon as we
+   // a temporary hack that should be removed as soon as we
    // get multiple effect preview working
-   void UpdateMenus( bool checkActive = true );
+   bool ReallyDoQuickCheck() override;
 
    void RemoveDuplicateShortcuts();
 
 private:
    void ExecuteCommand(const CommandContext &context,
       const wxEvent *evt, const CommandListEntry &entry) override;
-
-   void OnUndoRedo(struct UndoRedoMessage);
-   Observer::Subscription mUndoSubscription;
 };
 
 struct NormalizedKeyString;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -19,7 +19,7 @@ Paul Licameli split from ProjectManager.cpp
 
 #include "AudioIO.h"
 #include "BasicUI.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "CommonCommandFlags.h"
 #include "DefaultPlaybackPolicy.h"
 #include "Meter.h"

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -12,7 +12,6 @@ Paul Licameli split from AudacityProject.cpp
 #include "ActiveProject.h"
 #include "AllThemeResources.h"
 #include "AudioIO.h"
-#include "MenuCreator.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
 #include "ProjectFileIO.h"
@@ -27,6 +26,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "WaveClip.h"
 #include "WaveTrack.h"
 #include "CommandContext.h"
+#include "commands/CommandManager.h"
 #include "prefs/ThemePrefs.h"
 #include "prefs/TracksPrefs.h"
 #include "toolbars/ToolManager.h"
@@ -1223,7 +1223,7 @@ void ProjectWindow::FixScrollbars()
       trackPanel.Refresh(false);
    }
 
-   MenuCreator::Get( project ).UpdateMenus();
+   CommandManager::Get(project).UpdateMenus();
 
    if (oldhstate != newhstate || oldvstate != newvstate) {
       UpdateLayout();
@@ -1623,7 +1623,7 @@ void ProjectWindow::OnUpdateUI(wxUpdateUIEvent & WXUNUSED(event))
    if (!pProject)
       return;
    auto &project = *pProject;
-   MenuCreator::Get( project ).UpdateMenus();
+   CommandManager::Get(project).UpdateMenus();
 }
 
 void ProjectWindow::OnActivate(wxActivateEvent & event)

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -26,7 +26,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "WaveClip.h"
 #include "WaveTrack.h"
 #include "CommandContext.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "prefs/ThemePrefs.h"
 #include "prefs/TracksPrefs.h"
 #include "toolbars/ToolManager.h"

--- a/src/Screenshot.cpp
+++ b/src/Screenshot.cpp
@@ -814,7 +814,7 @@ void ScreenshotBigDialog::UpdatePrefs()
 }
 
 #include "CommonCommandFlags.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 
 namespace {
 void OnScreenshot(const CommandContext &context )

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -30,7 +30,7 @@
 #include "ViewInfo.h"
 #include "WaveTrack.h"
 
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 
 namespace {
 

--- a/src/SpectralDataDialog.cpp
+++ b/src/SpectralDataDialog.cpp
@@ -42,7 +42,7 @@
 #include "ClientData.h"
 #include "Clipboard.h"
 #include "CommandContext.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "UndoManager.h"
 #include "Prefs.h"
 #include "Project.h"

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -313,6 +313,11 @@ auto CommandManager::Populator::AllocateEntry(const MenuRegistry::Options &)
    return std::make_unique<CommandListEntry>();
 }
 
+void CommandManager::Populator::VisitEntry(CommandListEntry &,
+   const MenuRegistry::Options *)
+{
+}
+
 ///
 /// Makes a NEW menubar for placement on the top of a project
 /// Names it according to the passed-in string argument.
@@ -520,22 +525,9 @@ void CommandManager::Populator::AddItem(const CommandID &name,
          {}, 0, 0,
          options);
    entry->useStrictFlags = options.useStrictFlags;
-   int ID = entry->id;
-   wxString label = FormatLabelWithDisabledAccel(entry);
-
    Get(mProject).SetCommandFlags(name, flags);
-
-
-   auto &checker = options.checker;
-   if (checker) {
-      CurrentMenu()->AppendCheckItem(ID, label);
-      CurrentMenu()->Check(ID, checker(mProject));
-   }
-   else {
-      CurrentMenu()->Append(ID, label);
-   }
-
    mbSeparatorAllowed = true;
+   VisitEntry(*entry, &options);
 }
 
 ///
@@ -564,8 +556,8 @@ void CommandManager::Populator::AddItemList(const CommandID & name,
             MenuRegistry::Options{}
                .IsEffect(bIsEffect));
       entry->flags = flags;
-      CurrentMenu()->Append(entry->id, entry->FormatLabelForMenu());
       mbSeparatorAllowed = true;
+      VisitEntry(*entry, nullptr);
    }
 }
 
@@ -582,6 +574,7 @@ void CommandManager::Populator::AddGlobalCommand(const CommandID &name,
    entry->enabled = false;
    entry->isGlobal = true;
    entry->flags = AlwaysEnabledFlag;
+   VisitEntry(*entry, &options);
 }
 
 void CommandManager::Populator::AddSeparator()
@@ -635,10 +628,7 @@ auto CommandManager::Populator::NewIdentifier(const CommandID & nameIn,
 
    // If we have the identifier already, reuse it.
    CommandListEntry *prev = cm.mCommandNameHash[name];
-   if (!prev);
-   else if( prev->label != label );
-   else if( multi );
-   else
+   if (prev && prev->label == label && !multi)
       return prev;
 
    {
@@ -790,70 +780,6 @@ wxString CommandManager::CommandListEntry::FormatLabelForMenu(
       label += wxT("\t") + key;
    }
 
-   return label;
-}
-
-// A label that may have its accelerator disabled.
-// The problem is that as soon as we show accelerators in the menu, the menu might
-// catch them in normal wxWidgets processing, rather than passing the key presses on
-// to the controls that had the focus.  We would like all the menu accelerators to be
-// disabled, in fact.
-wxString
-CommandManager::FormatLabelWithDisabledAccel(const CommandListEntry *entry)
-{
-   auto label = entry->label.Translation();
-#if 1
-   wxString Accel;
-   do{
-      if (!entry->key.empty())
-      {
-         // Dummy accelerator that looks Ok in menus but is non functional.
-         // Note the space before the key.
-#ifdef __WXMSW__
-         // using GET to compose menu item name for wxWidgets
-         auto key = entry->key.GET();
-         Accel = wxString("\t ") + key;
-         if( key.StartsWith("Left" )) break;
-         if( key.StartsWith("Right")) break;
-         if( key.StartsWith("Up" )) break;
-         if( key.StartsWith("Down")) break;
-         if( key.StartsWith("Return")) break;
-         if( key.StartsWith("Tab")) break;
-         if( key.StartsWith("Shift+Tab")) break;
-         if( key.StartsWith("0")) break;
-         if( key.StartsWith("1")) break;
-         if( key.StartsWith("2")) break;
-         if( key.StartsWith("3")) break;
-         if( key.StartsWith("4")) break;
-         if( key.StartsWith("5")) break;
-         if( key.StartsWith("6")) break;
-         if( key.StartsWith("7")) break;
-         if( key.StartsWith("8")) break;
-         if( key.StartsWith("9")) break;
-         // Uncomment the below so as not to add the illegal accelerators.
-         // Accel = "";
-         //if( entry->key.StartsWith("Space" )) break;
-         // These ones appear to be illegal already and mess up accelerator processing.
-         if( key.StartsWith("NUMPAD_ENTER" )) break;
-         if( key.StartsWith("Backspace" )) break;
-         if( key.StartsWith("Delete" )) break;
-
-         // https://github.com/audacity/audacity/issues/4457
-         // This code was proposed by David Bailes to fix
-         // the decimal separator input in wxTextCtrls that
-         // are children of the main window. 
-         if( key.StartsWith(",") ) break;
-         if( key.StartsWith(".") ) break;
-
-#endif
-         //wxLogDebug("Added Accel:[%s][%s]", entry->label, entry->key );
-         // Normal accelerator.
-         // using GET to compose menu item name for wxWidgets
-         Accel = wxString("\t") + entry->key.GET();
-      }
-   } while (false );
-   label += Accel;
-#endif
    return label;
 }
 

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -307,6 +307,28 @@ void CommandManager::PurgeData()
    mCommandNumericIDHash.clear();
 }
 
+void CommandManager::Populator::DoVisit(const Registry::SingleItem &item)
+{
+   using namespace MenuRegistry;
+   auto pItem = &item;
+   if (const auto pCommand = dynamic_cast<const CommandItem*>(pItem)) {
+      auto &options = pCommand->options;
+      AddItem(
+         pCommand->name, pCommand->label_in,
+         pCommand->finder, pCommand->callback,
+         pCommand->flags, options);
+   }
+   else
+   if (const auto pCommandList = dynamic_cast<const CommandGroupItem*>(pItem)) {
+      AddItemList(pCommandList->name,
+         pCommandList->items.data(), pCommandList->items.size(),
+         pCommandList->finder, pCommandList->callback,
+         pCommandList->flags, pCommandList->isEffect);
+   }
+   else
+      wxASSERT( false );
+}
+
 auto CommandManager::Populator::AllocateEntry(const MenuRegistry::Options &)
    -> std::unique_ptr<CommandListEntry>
 {

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -75,10 +75,8 @@ CommandManager.  It holds the callback for one command.
 
 *//******************************************************************/
 #include "CommandManager.h"
-
 #include "CommandContext.h"
 
-#include <wx/app.h>
 #include <wx/defs.h>
 #include <wx/frame.h>
 #include <wx/hash.h>
@@ -89,7 +87,6 @@ CommandManager.  It holds the callback for one command.
 #include "Project.h"
 #include "AudacityMessageBox.h"
 #include "HelpSystem.h"
-
 
 // On wxGTK, there may be many many many plugins, but the menus don't automatically
 // allow for scrolling, so we build sub-menus.  If the menu gets longer than
@@ -996,8 +993,7 @@ TranslatableString CommandManager::DescribeCommandsAndShortcuts(
    wxString mark;
    // This depends on the language setting and may change in-session after
    // change of preferences:
-   bool rtl = (wxLayout_RightToLeft == wxTheApp->GetLayoutDirection());
-   if (rtl)
+   if (BasicUI::IsUsingRtlLayout())
       mark = wxT("\u200f");
 
    static const wxString &separatorFormat = wxT("%s / %s");

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -87,7 +87,6 @@ CommandManager.  It holds the callback for one command.
 
 #include "BasicUI.h"
 #include "Project.h"
-#include "ProjectWindows.h"
 #include "AudacityMessageBox.h"
 #include "HelpSystem.h"
 
@@ -1516,7 +1515,7 @@ TranslatableString CommandManager::ReportDuplicateShortcuts()
    return disabledShortcuts;
 }
 
-CommandFlag CommandManager::GetUpdateFlags( bool checkActive ) const
+CommandFlag CommandManager::GetUpdateFlags(bool quick) const
 {
    // This method determines all of the flags that determine whether
    // certain menu items and commands should be enabled or disabled,
@@ -1539,7 +1538,7 @@ CommandFlag CommandManager::GetUpdateFlags( bool checkActive ) const
       ++ii;
    }
 
-   if ( checkActive && !GetProjectFrame( mProject ).IsActive() )
+   if (quick)
       // quick 'short-circuit' return.
       flags = (lastFlags & ~quickFlags) | flags;
    else {

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -599,10 +599,8 @@ void CommandManager::Populator::AddGlobalCommand(const CommandID &name,
    VisitEntry(*entry, &options);
 }
 
-void CommandManager::Populator::AddSeparator()
+void CommandManager::Populator::DoSeparator()
 {
-   if( mbSeparatorAllowed )
-      CurrentMenu()->AppendSeparator();
    mbSeparatorAllowed = false; // boolean to prevent too many separators.
 }
 

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -319,6 +319,16 @@ public:
    wxString FormatLabelForMenu(
       const CommandID &id, const TranslatableString *pLabel) const;
 
+   void ModifyUndoMenuItems();
+
+   // checkActive is a temporary hack that should be removed as soon as we
+   // get multiple effect preview working
+   void UpdateMenus(bool checkActive = true);
+
+protected:
+   //! Default implementation returns true
+   virtual bool ReallyDoQuickCheck();
+
 private:
    wxString FormatLabelForMenu(const CommandListEntry *entry) const;
    wxString FormatLabelForMenu(
@@ -336,6 +346,8 @@ private:
 
    void TellUserWhyDisallowed(const TranslatableString & Name, CommandFlag flagsGot,
       CommandFlag flagsRequired);
+
+   void OnUndoRedo(struct UndoRedoMessage);
 
 protected:
    AudacityProject &mProject;
@@ -409,5 +421,7 @@ private:
 
    bool bMakingOccultCommands;
    std::unique_ptr< wxMenuBar > mTempMenuBar;
+
+   const Observer::Subscription mUndoSubscription;
 };
 #endif

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -144,6 +144,13 @@ public:
        */
       virtual std::unique_ptr<CommandListEntry>
          AllocateEntry(const MenuRegistry::Options &options);
+      //! Override to intercept all visits of items;
+      //! default implementation is noop
+      /*!
+       @param options null if a member of a list of commands
+       */
+      virtual void VisitEntry(CommandListEntry &entry,
+         const MenuRegistry::Options *options);
 
       std::unique_ptr<wxMenuBar> AddMenuBar(const wxString & sMenu);
       wxMenu *BeginMenu(const TranslatableString & tName);
@@ -343,7 +350,6 @@ protected:
    virtual bool ReallyDoQuickCheck();
 
 private:
-   static wxString FormatLabelWithDisabledAccel(const CommandListEntry *entry);
 
    //
    // Loading/Saving

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -35,17 +35,10 @@
 #include <unordered_map>
 
 class wxEvent;
-class wxMenu;
-class wxMenuBar;
 
 class BoolSetting;
 
-struct MenuBarListEntry;
 using PluginID = wxString;
-struct SubMenuListEntry;
-
-using MenuBarList = std::vector < MenuBarListEntry >;
-using SubMenuList = std::vector < SubMenuListEntry >;
 
 class AudacityProject;
 class CommandContext;
@@ -144,6 +137,22 @@ public:
       void DoVisit(const Registry::SingleItem &item);
       void DoEndGroup(
          const MenuRegistry::GroupItem<MenuRegistry::Traits> &item);
+      
+      //! Called by DoBeginGroup
+      //! Default implementation does nothing
+      virtual void BeginMenu(const TranslatableString & tName);
+
+      //! Called by DoBeginGroup
+      //! Default implementation does nothing
+      virtual void BeginOccultCommands();
+
+      //! Called by DoEndGroup
+      //! Default implementation does nothing
+      virtual void EndMenu();
+
+      //! Called by DoEndGroup
+      //! Default implementation does nothing
+      virtual void EndOccultCommands();
 
       //! Called by DoVisit
       //! Override to make entries that carry extra information.
@@ -164,9 +173,6 @@ public:
 
       void DoSeparator();
 
-      std::unique_ptr<wxMenuBar> AddMenuBar(const wxString & sMenu);
-      wxMenu *BeginMenu(const TranslatableString & tName);
-      void EndMenu();
    private:
       void AddItemList(const CommandID & name,
                        const ComponentInterfaceSymbol items[],
@@ -181,11 +187,6 @@ public:
                    CommandFunctorPointer callback,
                    CommandFlag flags,
                    const MenuRegistry::Options &options = {});
-      void PopMenuBar();
-   protected:
-      void BeginOccultCommands();
-      void EndOccultCommands();
-   private:
       CommandListEntry *NewIdentifier(const CommandID & name,
                                       const TranslatableString & label,
                                       CommandHandlerFinder finder,
@@ -199,15 +200,7 @@ public:
                             CommandHandlerFinder finder,
                             CommandFunctorPointer callback,
                             const MenuRegistry::Options &options = {});
-      wxMenu *BeginMainMenu(const TranslatableString & tName);
-      void EndMainMenu();
-      wxMenu* BeginSubMenu(const TranslatableString & tName);
-      void EndSubMenu();
-      wxMenuBar * CurrentMenuBar() const;
-      wxMenuBar * GetMenuBar(const wxString & sMenu) const;
-      wxMenu * CurrentSubMenu() const;
    protected:
-      wxMenu * CurrentMenu() const;
       //! Stack of names of menus that were begun and not yet ended
       const TranslatableStrings &MenuNames() const { return mMenuNames; }
    private:
@@ -215,18 +208,13 @@ public:
       // mMaxList only holds shortcuts that should not be added (by default)
       // and is sorted.
       std::vector<NormalizedKeyString> mMaxListOnly;
-      MenuBarList  mMenuBarList;
-      SubMenuList  mSubMenuList;
       TranslatableStrings mMenuNames;
       int mCurrentID{ 17000 };
    protected:
       // false at the start of a menu and immediately after a separator.
       bool mbSeparatorAllowed{ false };
    private:
-      std::unique_ptr<wxMenu> uCurrentMenu;
-      wxMenu *mCurrentMenu {};
       bool bMakingOccultCommands{ false };
-      std::unique_ptr< wxMenuBar > mTempMenuBar;
       std::vector<bool> mFlags;
    };
 

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -117,6 +117,7 @@ public:
    bool mStopIfWasPaused{ true };
 
    AudacityProject &GetProject() { return mProject; }
+   size_t NCommands() const { return mCommandList.size(); }
 
    void SetMaxList();
    void PurgeData();
@@ -170,6 +171,7 @@ public:
    //
 
    void SetKeyFromName(const CommandID &name, const NormalizedKeyString &key);
+   //! @pre `0 <= i && i < NCommands()`
    void SetKeyFromIndex(int i, const NormalizedKeyString &key);
 
    //
@@ -215,15 +217,15 @@ public:
 
    // Each command is assigned a numerical ID for use in wxMenu and wxEvent,
    // which need not be the same across platforms or sessions
-   CommandID GetNameFromNumericID( int id );
+   CommandID GetNameFromNumericID(int id) const;
 
-   TranslatableString GetLabelFromName(const CommandID &name);
-   TranslatableString GetPrefixedLabelFromName(const CommandID &name);
-   TranslatableString GetCategoryFromName(const CommandID &name);
+   TranslatableString GetLabelFromName(const CommandID &name) const;
+   TranslatableString GetPrefixedLabelFromName(const CommandID &name) const;
+   TranslatableString GetCategoryFromName(const CommandID &name) const;
    NormalizedKeyString GetKeyFromName(const CommandID &name) const;
-   NormalizedKeyString GetDefaultKeyFromName(const CommandID &name);
+   NormalizedKeyString GetDefaultKeyFromName(const CommandID &name) const;
 
-   bool GetEnabled(const CommandID &name);
+   bool GetEnabled(const CommandID &name) const;
    int GetNumberOfKeysRead() const;
 
 #if defined(_DEBUG)
@@ -387,6 +389,8 @@ protected:
    };
    using CommandKeyHash =
       std::unordered_map<NormalizedKeyString, CommandListEntry*>;
+   //! @invariant for each [key, value]: for some 0 <= i < NCommands():
+   //! `value == mCommandList[i].get()`
    CommandKeyHash mCommandKeyHash;
 
 private:
@@ -401,12 +405,17 @@ private:
    // point to them,
    // so we don't want the structures to relocate with vector operations.
    using CommandList = std::vector<std::unique_ptr<CommandListEntry>>;
+   //! @invariant for all 0 <= i < NCommands(): `mCommandList[i] != nullptr`
    CommandList  mCommandList;
 
    using CommandNameHash = std::unordered_map<CommandID, CommandListEntry*>;
+   //! @invariant for each [key, value]: for some 0 <= i < NCommands():
+   //! `value == mCommandList[i].get()`
    CommandNameHash  mCommandNameHash;
 
    using CommandNumericIDHash = std::unordered_map<int, CommandListEntry*>;
+   //! @invariant for each [key, value]: for some 0 <= i < NCommands():
+   //! `value == mCommandList[i].get()`
    CommandNumericIDHash  mCommandNumericIDHash;
    int mCurrentID;
    int mXMLKeysRead;

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -156,6 +156,8 @@ public:
       virtual void VisitEntry(CommandListEntry &entry,
          const MenuRegistry::Options *options);
 
+      void DoSeparator();
+
       std::unique_ptr<wxMenuBar> AddMenuBar(const wxString & sMenu);
       wxMenu *BeginMenu(const TranslatableString & tName);
       void EndMenu();
@@ -173,9 +175,6 @@ public:
                    CommandFunctorPointer callback,
                    CommandFlag flags,
                    const MenuRegistry::Options &options = {});
-   protected:
-      void AddSeparator();
-   private:
       void PopMenuBar();
    protected:
       void BeginOccultCommands();
@@ -211,8 +210,10 @@ public:
       MenuBarList  mMenuBarList;
       SubMenuList  mSubMenuList;
       int mCurrentID{ 17000 };
+   protected:
       // false at the start of a menu and immediately after a separator.
       bool mbSeparatorAllowed{ false };
+   private:
       TranslatableString mCurrentMenuName{ COMMAND };
       std::unique_ptr<wxMenu> uCurrentMenu;
       wxMenu *mCurrentMenu {};

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -78,9 +78,8 @@ public:
    CommandManager &operator=(const CommandManager &) = delete;
    ~CommandManager() override;
 
-   // If checkActive, do not do complete flags testing on an
-   // inactive project as it is needlessly expensive.
-   CommandFlag GetUpdateFlags( bool checkActive = false ) const;
+   // If quick, skip some needlessly expensive checks.
+   CommandFlag GetUpdateFlags(bool quick = false) const;
    void UpdatePrefs() override;
 
    // Command Handling

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -137,6 +137,9 @@ public:
    protected:
       AudacityProject &mProject;
 
+      void DoVisit(const Registry::SingleItem &item);
+
+      //! Called by DoVisit
       //! Override to make entries that carry extra information.
       //! Not called for every visit, because existing items may be reused
       /*!
@@ -144,6 +147,7 @@ public:
        */
       virtual std::unique_ptr<CommandListEntry>
          AllocateEntry(const MenuRegistry::Options &options);
+      //! Called by DoVisit
       //! Override to intercept all visits of items;
       //! default implementation is noop
       /*!
@@ -155,6 +159,7 @@ public:
       std::unique_ptr<wxMenuBar> AddMenuBar(const wxString & sMenu);
       wxMenu *BeginMenu(const TranslatableString & tName);
       void EndMenu();
+   private:
       void AddItemList(const CommandID & name,
                        const ComponentInterfaceSymbol items[],
                        size_t nItems,
@@ -168,6 +173,7 @@ public:
                    CommandFunctorPointer callback,
                    CommandFlag flags,
                    const MenuRegistry::Options &options = {});
+   protected:
       void AddSeparator();
    private:
       void PopMenuBar();

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -208,6 +208,8 @@ public:
       wxMenu * CurrentSubMenu() const;
    protected:
       wxMenu * CurrentMenu() const;
+      //! Stack of names of menus that were begun and not yet ended
+      const TranslatableStrings &MenuNames() const { return mMenuNames; }
    private:
       void SetMaxList();
       // mMaxList only holds shortcuts that should not be added (by default)
@@ -215,12 +217,12 @@ public:
       std::vector<NormalizedKeyString> mMaxListOnly;
       MenuBarList  mMenuBarList;
       SubMenuList  mSubMenuList;
+      TranslatableStrings mMenuNames;
       int mCurrentID{ 17000 };
    protected:
       // false at the start of a menu and immediately after a separator.
       bool mbSeparatorAllowed{ false };
    private:
-      TranslatableString mCurrentMenuName{ COMMAND };
       std::unique_ptr<wxMenu> uCurrentMenu;
       wxMenu *mCurrentMenu {};
       bool bMakingOccultCommands{ false };

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -130,8 +130,6 @@ public:
       virtual ~Populator();
 
    protected:
-      AudacityProject &mProject;
-
       void DoBeginGroup(
          const MenuRegistry::GroupItem<MenuRegistry::Traits> &item);
       void DoVisit(const Registry::SingleItem &item);
@@ -173,6 +171,9 @@ public:
 
       void DoSeparator();
 
+      //! Stack of names of menus that were begun and not yet ended
+      const TranslatableStrings &MenuNames() const { return mMenuNames; }
+
    private:
       void AddItemList(const CommandID & name,
                        const ComponentInterfaceSymbol items[],
@@ -200,22 +201,22 @@ public:
                             CommandHandlerFinder finder,
                             CommandFunctorPointer callback,
                             const MenuRegistry::Options &options = {});
-   protected:
-      //! Stack of names of menus that were begun and not yet ended
-      const TranslatableStrings &MenuNames() const { return mMenuNames; }
-   private:
       void SetMaxList();
+
+   protected:
+      AudacityProject &mProject;
+
+      // false at the start of a menu and immediately after a separator.
+      bool mbSeparatorAllowed{ false };
+
+   private:
       // mMaxList only holds shortcuts that should not be added (by default)
       // and is sorted.
       std::vector<NormalizedKeyString> mMaxListOnly;
       TranslatableStrings mMenuNames;
-      int mCurrentID{ 17000 };
-   protected:
-      // false at the start of a menu and immediately after a separator.
-      bool mbSeparatorAllowed{ false };
-   private:
-      bool bMakingOccultCommands{ false };
       std::vector<bool> mFlags;
+      int mCurrentID{ 17000 };
+      bool bMakingOccultCommands{ false };
    };
 
 public:

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -129,15 +129,21 @@ public:
    struct AUDACITY_DLL_API Populator
       : MenuRegistry::Visitor<MenuRegistry::Traits>
    {
+      using LeafVisitor = std::function<
+         void(const Registry::SingleItem &, const Registry::Path&)>;
       Populator(AudacityProject &project,
-         VisitorFunctions<MenuRegistry::Traits> functions,
+         LeafVisitor leafVisitor,
          std::function<void()> doSeparator);
       virtual ~Populator();
 
    protected:
       AudacityProject &mProject;
 
+      void DoBeginGroup(
+         const MenuRegistry::GroupItem<MenuRegistry::Traits> &item);
       void DoVisit(const Registry::SingleItem &item);
+      void DoEndGroup(
+         const MenuRegistry::GroupItem<MenuRegistry::Traits> &item);
 
       //! Called by DoVisit
       //! Override to make entries that carry extra information.
@@ -219,6 +225,7 @@ public:
       wxMenu *mCurrentMenu {};
       bool bMakingOccultCommands{ false };
       std::unique_ptr< wxMenuBar > mTempMenuBar;
+      std::vector<bool> mFlags;
    };
 
 public:

--- a/src/commands/CommandManager.h
+++ b/src/commands/CommandManager.h
@@ -295,7 +295,7 @@ protected:
    //
 
 private:
-   void Enable(CommandListEntry *entry, bool enabled);
+   void Enable(CommandListEntry &entry, bool enabled);
    wxMenu *BeginMainMenu(const TranslatableString & tName);
    void EndMainMenu();
    wxMenu* BeginSubMenu(const TranslatableString & tName);
@@ -332,10 +332,6 @@ protected:
    virtual bool ReallyDoQuickCheck();
 
 private:
-   wxString FormatLabelForMenu(const CommandListEntry *entry) const;
-   wxString FormatLabelForMenu(
-      const TranslatableString &translatableLabel,
-      const NormalizedKeyString &keyStr) const;
    wxString FormatLabelWithDisabledAccel(const CommandListEntry *entry) const;
 
    //
@@ -356,6 +352,23 @@ protected:
 
    struct CommandListEntry
    {
+      static wxString FormatLabelForMenu(
+         const TranslatableString &translatableLabel,
+         const NormalizedKeyString &keyStr);
+
+      virtual ~CommandListEntry();
+
+      virtual void UpdateCheckmark(AudacityProject &project);
+      virtual void Modify(const TranslatableString &newLabel);
+      virtual bool GetEnabled() const;
+      virtual void Check(bool checked);
+      virtual void Enable(bool enabled);
+      virtual void EnableMultiItem(bool enabled);
+
+      wxString FormatLabelForMenu() const {
+         return FormatLabelForMenu(label, key);
+      }
+
       int id;
       CommandID name;
       TranslatableString longLabel;

--- a/src/commands/ScreenshotCommand.cpp
+++ b/src/commands/ScreenshotCommand.cpp
@@ -44,7 +44,7 @@ small calculations of rectangles.
 #include "Track.h"
 #include "../widgets/VetoDialogHook.h"
 #include "CommandContext.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "CommandDispatch.h"
 #include "../CommonCommandFlags.h"
 

--- a/src/effects/Contrast.cpp
+++ b/src/effects/Contrast.cpp
@@ -652,7 +652,7 @@ void ContrastDialog::OnReset(wxCommandEvent & /*event*/)
 
 // Remaining code hooks this add-on into the application
 #include "CommandContext.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "ProjectWindows.h"
 
 namespace {

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -19,6 +19,7 @@
 #include "AllThemeResources.h"
 #include "widgets/BasicMenu.h"
 #include "BasicUI.h"
+#include "../commands/CommandManager.h"
 #include "ConfigInterface.h"
 #include "EffectManager.h"
 #include "PluginManager.h"
@@ -96,7 +97,6 @@ private:
 #include "../../images/Effect.h"
 #include "AudioIO.h"
 #include "../CommonCommandFlags.h"
-#include "../MenuCreator.h"
 #include "../prefs/GUISettings.h" // for RTL_WORKAROUND
 #include "Project.h"
 #include "../ProjectAudioManager.h"
@@ -1195,7 +1195,7 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
          // For now, we're limiting realtime preview to a single effect, so
          // make sure the menus reflect that fact that one may have just been
          // opened.
-         MenuCreator::Get(project).UpdateMenus( false );
+         CommandManager::Get(project).UpdateMenus( false );
       }
 
    } );

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -19,7 +19,7 @@
 #include "AllThemeResources.h"
 #include "widgets/BasicMenu.h"
 #include "BasicUI.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "ConfigInterface.h"
 #include "EffectManager.h"
 #include "PluginManager.h"
@@ -1135,7 +1135,7 @@ DialogFactoryResults EffectUI::DialogFactory(wxWindow &parent,
 #include "../SelectUtilities.h"
 #include "../TrackPanel.h"
 #include "WaveTrack.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 
 /// DoEffect() takes a PluginID and executes the associated effect.
 ///

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -1095,7 +1095,7 @@ auto EditMenu()
          MenuCreator::Special( wxT("UndoItemsUpdateStep"),
          [](AudacityProject &project, wxMenu&) {
             // Change names in the CommandManager as a side-effect
-            MenuCreator::Get(project).ModifyUndoMenuItems();
+            CommandManager::Get(project).ModifyUndoMenuItems();
          })
       ),
 

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -23,7 +23,7 @@
 #include "TempDirectory.h"
 #include "UndoManager.h"
 #include "CommandContext.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../effects/EffectManager.h"
 #include "../effects/EffectUI.h"
 #include "RealtimeEffectManager.h"

--- a/src/menus/TimelineMenus.cpp
+++ b/src/menus/TimelineMenus.cpp
@@ -12,7 +12,7 @@
 
 #include "Project.h"
 
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "CommandContext.h"
 
 namespace

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -11,7 +11,7 @@
 #include "UndoManager.h"
 #include "ViewInfo.h"
 #include "CommandContext.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../prefs/GUIPrefs.h"
 #include "../prefs/TracksPrefs.h"
 #include "../tracks/ui/ChannelView.h"

--- a/src/prefs/PrefsDialog.cpp
+++ b/src/prefs/PrefsDialog.cpp
@@ -33,7 +33,7 @@
 #include "Prefs.h"
 #include "ProjectWindows.h"
 #include "ShuttleGui.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 
 #include "PrefsPanel.h"
 

--- a/src/toolbars/CutCopyPasteToolBar.cpp
+++ b/src/toolbars/CutCopyPasteToolBar.cpp
@@ -53,7 +53,7 @@
 #include "../widgets/AButton.h"
 
 #include "CommandContext.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../commands/CommandDispatch.h"
 
 #include "ToolManager.h"

--- a/src/toolbars/EditToolBar.cpp
+++ b/src/toolbars/EditToolBar.cpp
@@ -52,7 +52,7 @@
 #include "../widgets/AButton.h"
 
 #include "CommandContext.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../commands/CommandDispatch.h"
 
 enum {

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -48,7 +48,7 @@ in which buttons can be placed.
 #include "AColor.h"
 #include "ImageManipulation.h"
 #include "Project.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../widgets/AButton.h"
 #include "../widgets/Grabber.h"
 #include "Prefs.h"

--- a/src/toolbars/ToolBarButtons.cpp
+++ b/src/toolbars/ToolBarButtons.cpp
@@ -19,7 +19,7 @@
 #include "Project.h"
 
 #include "CommandContext.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../commands/CommandDispatch.h"
 
 // flags so 1,2,4,8 etc.

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -50,7 +50,7 @@
 
 #include "AColor.h"
 #include "AllThemeResources.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "ImageManipulation.h"
 #include "Prefs.h"
 #include "Project.h"
@@ -1538,7 +1538,7 @@ void ToolManager::ModifyAllProjectToolbarMenus()
    }
 }
 
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 void ToolManager::ModifyToolbarMenus(AudacityProject &project)
 {
    // Refreshes can occur during shutdown and the toolmanager may already

--- a/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
@@ -10,7 +10,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "PlayableTrackButtonHandles.h"
 #include "PlayableTrack.h"
 #include "PlayableTrackControls.h"
-#include "../../../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "Project.h"
 #include "../../../RefreshCode.h"
 #include "../../../RealtimeEffectPanel.h"

--- a/src/tracks/ui/CommonTrackControls.cpp
+++ b/src/tracks/ui/CommonTrackControls.cpp
@@ -24,7 +24,7 @@ Paul Licameli split from TrackControls.cpp
 #include "../../TrackUtilities.h"
 #include <wx/textdlg.h>
 #include "../../commands/AudacityCommand.h"
-#include "../../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "ShuttleGui.h"
 #include "Track.h"
 #include "../../widgets/PopupMenuTable.h"

--- a/src/tracks/ui/CommonTrackPanelCell.cpp
+++ b/src/tracks/ui/CommonTrackPanelCell.cpp
@@ -17,8 +17,8 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../widgets/BasicMenu.h"
 #include "BasicUI.h"
 #include "CommandContext.h"
+#include "../../commands/CommandManager.h"
 #include "../../HitTestResult.h"
-#include "MenuCreator.h"
 #include "../../RefreshCode.h"
 #include "../../TrackPanelMouseEvent.h"
 #include "Track.h"
@@ -50,8 +50,8 @@ unsigned CommonTrackPanelCell::DoContextMenu( const wxRect &rect,
    if (items.empty())
       return RefreshCode::RefreshNone;
 
-   auto& menuCreator = MenuCreator::Get(*pProject);
-   menuCreator.UpdateMenus();
+   auto &commandManager = CommandManager::Get(*pProject);
+   commandManager.UpdateMenus();
 
    // Set up command context with extras
    CommandContext context{ *pProject };
@@ -63,8 +63,7 @@ unsigned CommonTrackPanelCell::DoContextMenu( const wxRect &rect,
    }
    context.temporarySelection.pTrack = FindTrack().get();
 
-   auto &commandManager = CommandManager::Get(*pProject);
-   auto flags = CommandManager::Get(*pProject).GetUpdateFlags();
+   auto flags = commandManager.GetUpdateFlags();
 
    // Common dispatcher for the menu items
    auto dispatcher = [&]( wxCommandEvent &evt ){

--- a/src/tracks/ui/CommonTrackPanelCell.cpp
+++ b/src/tracks/ui/CommonTrackPanelCell.cpp
@@ -17,7 +17,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../widgets/BasicMenu.h"
 #include "BasicUI.h"
 #include "CommandContext.h"
-#include "../../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../../HitTestResult.h"
 #include "../../RefreshCode.h"
 #include "../../TrackPanelMouseEvent.h"

--- a/src/tracks/ui/Scrubbing.cpp
+++ b/src/tracks/ui/Scrubbing.cpp
@@ -14,7 +14,7 @@ Paul Licameli split from TrackPanel.cpp
 #include <functional>
 
 #include "AudioIO.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../../CommonCommandFlags.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"

--- a/src/tracks/ui/SelectHandle.cpp
+++ b/src/tracks/ui/SelectHandle.cpp
@@ -15,7 +15,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "ChannelView.h"
 
 #include "AColor.h"
-#include "commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../../SpectrumAnalyst.h"
 #include "../../LabelTrack.h"
 #include "NumberScale.h"

--- a/src/tracks/ui/TrackButtonHandles.cpp
+++ b/src/tracks/ui/TrackButtonHandles.cpp
@@ -22,7 +22,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../TrackInfo.h"
 #include "../../TrackPanel.h"
 #include "../../TrackUtilities.h"
-#include "../../commands/CommandManager.h"
+#include "CommandManager.h"
 #include "../../tracks/ui/ChannelView.h"
 
 MinimizeButtonHandle::MinimizeButtonHandle

--- a/src/widgets/KeyView.cpp
+++ b/src/widgets/KeyView.cpp
@@ -21,7 +21,7 @@
 
 #include "AColor.h"
 #include "ShuttleGui.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 
 #include <wx/dc.h>
 #include <wx/menu.h>

--- a/src/widgets/PopupMenuTable.h
+++ b/src/widgets/PopupMenuTable.h
@@ -26,7 +26,7 @@ class wxCommandEvent;
 #include <memory>
 
 #include "Internat.h"
-#include "../commands/CommandManager.h"
+#include "CommandManager.h"
 
 class PopupMenuHandler;
 struct PopupMenuSection;


### PR DESCRIPTION
Resolves: #5442

Depends on
- #5415

Move CommandManager into toolkit-neutral libraries.

Lower toolkit-neutral menu visitation logic from MenuCreator to CommandManager.

Lift wxWidgets-specific implementations of menu building steps from CommandManager
to MenuCreator and invoke them by virtual function calls.

Thus CommandManager now includes a "facade" for menu population.

QA:  This should be quick to do, now that you know how:
- [x] Again, verify menu tree is unchanged
- [x] Again, verify shortcut keys are unchanged

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
