### PR TITLE
Detect if libjpeg-turbo 3 is installed on Linux

### DIFF
--- a/cmake-proxies/cmake-modules/DependenciesList.cmake
+++ b/cmake-proxies/cmake-modules/DependenciesList.cmake
@@ -1,9 +1,24 @@
 # conan_package_options variable can be used to pass additional options to the conan install command.
+if( NOT CMAKE_SYSTEM_NAME MATCHES "Windows|Darwin" )
+   if( NOT libjpeg_turbo_probed )
+      message(STATUS "Probing for libjpeg-turbo 3")
+      find_package(libjpeg-turbo 3 QUIET)
+      set(libjpeg_turbo_probed True CACHE INTERNAL "")
+      mark_as_advanced(libjpeg_turbo_probed)
+
+      if(TARGET libjpeg-turbo::jpeg AND NOT ${_OPT}force_local_jpeg)
+         message(STATUS "Found libjpeg-turbo 3")
+         message(STATUS "Forcing system version of libjpeg-turbo 3")
+         set( ${_OPT}use_jpeg "system" CACHE STRING "Use system libjpeg-turbo" FORCE )
+      endif()
+   endif()
+endif()
 
 audacity_find_package(ZLIB REQUIRED)
-audacity_find_package(EXPAT REQUIRED)
 audacity_find_package(PNG QUIET CONAN_PACKAGE_NAME libpng)
 audacity_find_package(JPEG QUIET CONAN_PACKAGE_NAME libjpeg-turbo)
+
+audacity_find_package(EXPAT REQUIRED)
 
 audacity_find_package(wxWidgets REQUIRED FIND_PACKAGE_OPTIONS COMPONENTS adv base core html qa xml net)
 


### PR DESCRIPTION
Some of GTK libaries depend on libtiff, which uses new APIs from libjpeg-turbo 3, which breaks the build

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
