### PR TITLE
Export dialog: keyboard navigation of radio buttons

### DIFF
--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -209,7 +209,6 @@ ExportAudioDialog::ExportAudioDialog(wxWindow* parent,
 
    if (!hasLabels && !hasMultipleWaveTracks)
    {
-      mRangeSplit->Disable();
       if (ExportAudioExportRange.Read() == "split")
          mRangeProject->SetValue(true);
       mSplitsPanel->Hide();


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5454

Problem:
Since commit https://github.com/audacity/audacity/pull/5447, the multiple files radio button can be unavailable. When this is the case and both the entire project and then current selection radio buttons are available, if the entire project radio button is the focus and selected, then pressing down arrow does not change the selection, but moves the focus to the edit metadata button.

Fix:
When there are not multiple audio tracks and no labels, leave the multiple files radio button available.

Resolves: https://github.com/audacity/audacity/issues/5454

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
