### PR TITLE
Bugfix: silence audio does not delete clips

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -266,11 +266,11 @@ WaveTrack::IntervalHolder WaveTrack::Interval::GetStretchRenderedCopy(
    const std::function<void(double)>& reportProgress, const ChannelGroup& group,
    const SampleBlockFactoryPtr& factory, sampleFormat format)
 {
+   if (GetStretchRatio() == 1)
+      return std::make_shared<Interval>(group, mpClip, mpClip1);
+
    const auto dst = std::make_shared<Interval>(
       group, NChannels(), factory, mpClip->GetRate(), format);
-
-   if (GetStretchRatio() == 1)
-      return dst;
 
    const auto originalPlayStartTime = GetPlayStartTime();
    const auto originalPlayEndTime = GetPlayEndTime();
@@ -2352,7 +2352,8 @@ void WaveTrack::ApplyStretchRatio(
    auto clip = GetIntervalAtTime(startTime);
    while (clip && clip->GetPlayStartTime() < endTime)
    {
-      srcIntervals.push_back(clip);
+      if (clip->GetStretchRatio() != 1)
+         srcIntervals.push_back(clip);
       clip = GetNextInterval(*clip, PlaybackDirection::forward);
    }
 


### PR DESCRIPTION
Resolves: #5456

When stretch-rendering an interval (stereo clip) that didn't have any stretch, we mistakenly replaced the clips with empty clips.
Now not only do we check that we don't stretch-render intervals that are already unstretched, but we also return proper clip copies if `GetStretchRenderedCopy` is called on an unstretched interval.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
