### PR TITLE
Stretch-rendered clips preserve their name.

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -4124,6 +4124,7 @@ void WaveTrack::ReplaceInterval(
    assert(oldOne->NChannels() == newOne->NChannels());
    RemoveInterval(oldOne);
    InsertInterval(newOne);
+   newOne->SetName(oldOne->GetName());
 }
 
 /*! @excsafety{Weak} -- Partial completion may leave clips at differing sample rates!


### PR DESCRIPTION
Resolves: #5461

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
