### PR TITLE
Fix crossfade commands for unstretched clips

### DIFF
--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1367,13 +1367,11 @@ bool NyquistEffect::ProcessOne(
       auto &mCurTrack = nyxContext.mCurTrack;
       for (size_t i = 0; i < mCurNumChannels; i++) {
          float maxPeak = 0.0;
-
-         // A list of clips for mono, or an array of lists for multi-channel.
          if (mCurNumChannels > 1)
-            clips = wxT("(list ") + clipBoundaries + wxT(" )");
-         else
-            clips = clipBoundaries;
-
+            clips += wxT("(list ");
+         clips += clipBoundaries;
+         if (mCurNumChannels > 1)
+            clips += wxT(" )");
          float min, max;
          auto pair = mCurTrack[i]->GetMinMax(mT0, mT1); // may throw
          min = pair.first, max = pair.second;


### PR DESCRIPTION
Resolves: #5471

Refactoring in 88370f3 changed behavior in code generating the LISP command in text form. crossfadeclips.ny rejected the new command in that form.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] Crossfade clips and crossfade tracks commands succeed on both mono and stereo data, so long as it is not stretched.