### PR TITLE
Use static_cast instead of converting constructor to handle `long long`

### DIFF
--- a/modules/mod-opus/ImportOpus.cpp
+++ b/modules/mod-opus/ImportOpus.cpp
@@ -331,7 +331,7 @@ opus_int64 OpusImportFileHandle::OpusTellCallback(void* pstream)
 {
    auto stream = static_cast<OpusImportFileHandle*>(pstream);
 
-   return opus_int64(stream->mFile.Tell());
+   return static_cast<opus_int64>(stream->mFile.Tell());
 }
 
 int OpusImportFileHandle::OpusCloseCallback(void* pstream)


### PR DESCRIPTION
Resolves: #5479 

Straight to merge

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
