### PR TITLE
move join shortcut to standard set

### DIFF
--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -242,7 +242,7 @@ const std::vector<NormalizedKeyString> &CommandManager::ExcludedList()
       const char *const strings[] = {
          // "Ctrl+I",
          "Ctrl+Alt+I",
-         "Ctrl+J",
+         //"Ctrl+J",
          "Ctrl+Alt+J",
          "Ctrl+Alt+V",
          "Alt+X",


### PR DESCRIPTION
this is probably fair given that the line clicking got axed