### PR TITLE
fix opusfile::opusfile library link

### DIFF
--- a/cmake-proxies/cmake-modules/Findopusfile.cmake
+++ b/cmake-proxies/cmake-modules/Findopusfile.cmake
@@ -24,7 +24,7 @@ if( NOT opusfile_FOUND )
          add_library( opusfile::opusfile INTERFACE IMPORTED GLOBAL )
 
          target_include_directories( opusfile::opusfile INTERFACE ${opusfile_INCLUDE_DIR} "${opusfile_INCLUDE_DIR}/opus" )
-         target_link_libraries( opusfile::opusfile INTERFACE ${Oopusfile_LIBRARIES} )
+         target_link_libraries( opusfile::opusfile INTERFACE ${opusfile_LIBRARIES} )
       endif()
 
       mark_as_advanced(


### PR DESCRIPTION
this typo makes it link nothing since it expands to nothing, so libopusfile.so is missing and the module is broken

---

unrelated, but the failing `mod-opus.so` load from this reports the error in the popup as ENOTTY, which is pretty funny

also, you might want to pass `-Wl,--no-undefined` to the linker, because it catches these things early instead of at runtime:

```
ld: error: undefined symbol: op_open_callbacks
>>> referenced by ImportOpus.cpp:152 (./build/../modules/mod-opus/ImportOpus.cpp:152)
>>>               /cbuild_cache/link-cache/llvmcache-F1896CD3EF81FBF5FBCCAB14131C909985BE8802:(OpusImportFileHandle::OpusImportFileHandle(wxString const&))

ld: error: undefined symbol: op_channel_count
>>> referenced by ImportOpus.cpp:160 (./build/../modules/mod-opus/ImportOpus.cpp:160)
>>>               /cbuild_cache/link-cache/llvmcache-F1896CD3EF81FBF5FBCCAB14131C909985BE8802:(OpusImportFileHandle::OpusImportFileHandle(wxString const&))

ld: error: undefined symbol: op_pcm_total
>>> referenced by ImportOpus.cpp:161 (./build/../modules/mod-opus/ImportOpus.cpp:161)
>>>               /cbuild_cache/link-cache/llvmcache-F1896CD3EF81FBF5FBCCAB14131C909985BE8802:(OpusImportFileHandle::OpusImportFileHandle(wxString const&))

ld: error: undefined symbol: op_read_float
>>> referenced by ImportOpus.cpp:202 (./build/../modules/mod-opus/ImportOpus.cpp:202)
>>>               /cbuild_cache/link-cache/llvmcache-F1896CD3EF81FBF5FBCCAB14131C909985BE8802:(OpusImportFileHandle::Import(ImportProgressListener&, WaveTrackFactory*, std::__1::vector<std::__1::shared_ptr<TrackList>, std::__1::allocator<std::__1::shared_ptr<TrackList>>>&, Tags*))

ld: error: undefined symbol: op_head
>>> referenced by ImportOpus.cpp:210 (./build/../modules/mod-opus/ImportOpus.cpp:210)
>>>               /cbuild_cache/link-cache/llvmcache-F1896CD3EF81FBF5FBCCAB14131C909985BE8802:(OpusImportFileHandle::Import(ImportProgressListener&, WaveTrackFactory*, std::__1::vector<std::__1::shared_ptr<TrackList>, std::__1::allocator<std::__1::shared_ptr<TrackList>>>&, Tags*))

ld: error: undefined symbol: op_tags
>>> referenced by ImportOpus.cpp:249 (./build/../modules/mod-opus/ImportOpus.cpp:249)
>>>               /cbuild_cache/link-cache/llvmcache-F1896CD3EF81FBF5FBCCAB14131C909985BE8802:(OpusImportFileHandle::Import(ImportProgressListener&, WaveTrackFactory*, std::__1::vector<std::__1::shared_ptr<TrackList>, std::__1::allocator<std::__1::shared_ptr<TrackList>>>&, Tags*))

ld: error: undefined symbol: op_free
>>> referenced by ImportOpus.cpp:420 (./build/../modules/mod-opus/ImportOpus.cpp:420)
>>>               /cbuild_cache/link-cache/llvmcache-F1896CD3EF81FBF5FBCCAB14131C909985BE8802:(OpusImportFileHandle::~OpusImportFileHandle())
```
---

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
