### PR TITLE
Fixes crash on attempt to select (external program) in export format

### DIFF
--- a/modules/mod-cl/ExportCL.cpp
+++ b/modules/mod-cl/ExportCL.cpp
@@ -173,25 +173,29 @@ class ExportOptionsCLEditor final
 {
    wxString mCommand {wxT("lame - \"%f\"")};
    bool mShowOutput {false};
+   bool mInitialized {false};
 public:
 
    ExportOptionsCLEditor() = default;
 
    void PopulateUI(ShuttleGui& S) override
    {
-      mHistory.Clear();
+      if(!mInitialized)
+      {
+         mHistory.Load(*gPrefs, wxT("/FileFormats/ExternalProgramHistory"));
 
-      mHistory.Load(*gPrefs, wxT("/FileFormats/ExternalProgramHistory"));
+         if (mHistory.empty()) {
+            mHistory.Append(wxT("ffmpeg -i - \"%f.opus\""));
+            mHistory.Append(wxT("ffmpeg -i - \"%f.wav\""));
+            mHistory.Append(wxT("ffmpeg -i - \"%f\""));
+            mHistory.Append(wxT("lame - \"%f\""));
+         }
 
-      if (mHistory.empty()) {
-         mHistory.Append(wxT("ffmpeg -i - \"%f.opus\""));
-         mHistory.Append(wxT("ffmpeg -i - \"%f.wav\""));
-         mHistory.Append(wxT("ffmpeg -i - \"%f\""));
-         mHistory.Append(wxT("lame - \"%f\""));
+         if(!mCommand.empty())
+            mHistory.Append(mCommand);
+
+         mInitialized = true;
       }
-
-      if(!mCommand.empty())
-         mHistory.Append(mCommand);
 
       mParent = wxGetTopLevelParent(S.GetParent());
 


### PR DESCRIPTION
Resolves: #5417
Resolves: #5480

Attempt to call `FileHistory::Clear` before `FileHistory::Load` causes deletion of all settings in `gPrefs`

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
