### PR TITLE
5483 crossfade track bugs

### DIFF
--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -103,6 +103,15 @@ Track *EffectOutputTracks::AddToOutputTracks(TrackList &&list)
    return result;
 }
 
+const Track* EffectOutputTracks::GetMatchingInput(const Track& outTrack) const
+{
+   const auto it = std::find(mOMap.begin(), mOMap.end(), &outTrack);
+   if (it == mOMap.end())
+      return nullptr;
+   const auto index = it - mOMap.begin();
+   return mIMap[index];
+}
+
 // Replace tracks with successfully processed mOutputTracks copies.
 // Else clear and delete mOutputTracks copies.
 void EffectOutputTracks::Commit()

--- a/libraries/lib-effects/EffectOutputTracks.h
+++ b/libraries/lib-effects/EffectOutputTracks.h
@@ -69,6 +69,12 @@ public:
     */
    Track *AddToOutputTracks(TrackList &&list);
 
+   /*!
+    * @brief Gets the matching input track for the given output track if it
+    * finds its match, else nullptr.
+    */
+   const Track* GetMatchingInput(const Track& outTrack) const;
+
    //! Replace input tracks with temporaries only on commit
    /*
     @pre `Commit()` was not previously called

--- a/plug-ins/crossfadetracks.ny
+++ b/plug-ins/crossfadetracks.ny
@@ -62,13 +62,14 @@ $control DIRECTION (_ "Fade direction") choice (
     (sum 1
          (mult (/ -1 (- 1 epsilon))
                (diff logcurve epsilon)))))
- 
+
 (defun guessdirection ()
   ;;; If the selection is closer to the start of the
-  ;;; audio clip, fade in, otherwise fade out."
+  ;;; audio clip, fade in, otherwise fade out.
+  ;;; Use `inclips`, i.e., the clip boundaries before the stretch-rendering pre-processing step.
   (let* ((start (get '*selection* 'start))
          (end (get '*selection* 'end))
-         (clips (get '*track* 'clips))
+         (clips (get '*track* 'inclips))
          (in-dist end)
          (out-dist end))
     (if (arrayp clips)

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -894,10 +894,6 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
       wxString isPreviewing = (this->IsPreviewing())? wxT("T") : wxT("NIL");
       mProps += wxString::Format(wxT("(setf *PREVIEWP* %s)\n"), isPreviewing);
 
-      mProps += wxString::Format(wxT("(putprop '*SELECTION* (float %s) 'START)\n"),
-                                 Internat::ToString(mT0));
-      mProps += wxString::Format(wxT("(putprop '*SELECTION* (float %s) 'END)\n"),
-                                 Internat::ToString(mT1));
       mProps += wxString::Format(wxT("(putprop '*SELECTION* (list %s) 'TRACKS)\n"), waveTrackList);
       mProps += wxString::Format(wxT("(putprop '*SELECTION* %d 'CHANNELS)\n"), mNumSelectedChannels);
    }
@@ -1029,6 +1025,13 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
             mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'CENTER-HZ)\n"), centerHz);
             mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'HIGH-HZ)\n"), highHz);
             mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'BANDWIDTH)\n"), bandwidth);
+
+            mPerTrackProps += wxString::Format(
+                wxT("(putprop '*SELECTION* (float %s) 'START)\n"),
+                Internat::ToString(mCurChannelGroup->SnapToSample(mT0)));
+            mPerTrackProps += wxString::Format(
+                wxT("(putprop '*SELECTION* (float %s) 'END)\n"),
+                Internat::ToString(mCurChannelGroup->SnapToSample(mT1)));
          }
 
          success = ProcessOne(nyxContext, oOutputs ? &*oOutputs : nullptr);


### PR DESCRIPTION
Resolves: #5483

When applying an effect to a track, the selection first gets stretch-rendered, which may introduce new splits at the beginning and end of the selection.
The problem is: the split happens at times rounded to the sample period, meanwhile the selection is not rounded.
In the particular case of the crossfade, the nyquist script checks that, within the selection, there is exactly one split. Depending on the rounding, the new stretch-rendering splits may fall into the selection boundaries, yielding the error "Invalid selection. More than 2 audio clips selected."

Proposed solution: modify the selection start and end values passed to the script by rounding them to the current track rate.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA: Note that, to test this, make sure you don't have the snap option checked.