### PR TITLE
Fix unpredictable splitting of stereo tracks to mono...

### DIFF
--- a/libraries/lib-math/SampleFormat.h
+++ b/libraries/lib-math/SampleFormat.h
@@ -28,6 +28,7 @@ extern MATH_API DitherType gLowQualityDither, gHighQualityDither;
 //! The ordering of these values with operator < agrees with the order of increasing bit width
 /*! These values persist in saved project files, so must not be changed in later program versions */
 enum class sampleFormat : unsigned {
+   undefinedSample = 0,
    int16Sample = 0x00020001,
    int24Sample = 0x00040001,
    floatSample = 0x0004000F,
@@ -38,6 +39,7 @@ enum class sampleFormat : unsigned {
 };
 
 // C++20 using enum sampleFormat;
+constexpr sampleFormat undefinedSample = sampleFormat::undefinedSample;
 constexpr sampleFormat int16Sample = sampleFormat::int16Sample;
 constexpr sampleFormat int24Sample = sampleFormat::int24Sample;
 constexpr sampleFormat floatSample = sampleFormat::floatSample;

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -905,7 +905,8 @@ bool WaveTrack::LinkConsistencyFix(bool doFix)
       {
          SetRate(mLegacyRate);
          mLegacyRate = 0;
-         WaveTrackData::Get(*this).SetSampleFormat(mLegacyFormat);
+         if (mLegacyFormat != undefinedSample)
+            WaveTrackData::Get(*this).SetSampleFormat(mLegacyFormat);
       }
 
       // Check for zero-length clips and remove them

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1103,7 +1103,7 @@ private:
    WaveClipHolders mClips;
 
    mutable int  mLegacyRate{ 0 }; //!< used only during deserialization
-   sampleFormat mLegacyFormat; //!< used only during deserialization
+   sampleFormat mLegacyFormat{ undefinedSample }; //!< used only during deserialization
 
 private:
    //Updates rate parameter only in WaveTrackData


### PR DESCRIPTION
... when dragging clips from track to track.

WaveTrack::mLegacyFormat was uninitialized, which explains the intermittency.

Resolves: #5389

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
