### PR TITLE
Crash report sending failure message

### DIFF
--- a/crashreporter/CrashReportApp.h
+++ b/crashreporter/CrashReportApp.h
@@ -24,6 +24,7 @@ class CrashReportApp final : public wxApp
     std::map<std::string, std::string> mArguments;
 
     bool mSilent{ false };
+    bool mShowError { false };
 public:
     bool OnInit() override;
     void OnInitCmdLine(wxCmdLineParser& parser) override;


### PR DESCRIPTION
Crashreporter program now can show error code/message on sending failure.

By defaul it continues to show generic message text. To enable error code/message run program manually with `/e` key. This is added mostly for internal testing purposes.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
