### PR TITLE
Bump Opus version to 1.4.0

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -41,6 +41,7 @@ class AudacityDependency:
     channel: str = None
     package_options: dict = None
     default_enabled: bool = False
+    override: bool = False
 
     def apply_options(self, conanfile, package):
         if self.package_options is not None:
@@ -59,6 +60,7 @@ class AudacityDependency:
 class wxWidgetsAudacityDependency:
     name: str = "wxwidgets"
     default_enabled: bool = False
+    override: bool = False
 
     def reference(self, conanfile):
         return f"{self.name}/3.1.3.4-audacity@audacity/stable"
@@ -162,7 +164,7 @@ class AudacityConan(ConanFile):
         AudacityDependency("wavpack", "5.6.0"),
         AudacityDependency("ogg", "1.3.5"),
         AudacityDependency("flac", "1.4.2"),
-        AudacityDependency("opus", "1.3.1"),
+        AudacityDependency("opus", "1.4.0", override=True),
         AudacityDependency("opusfile", "0.12", package_options={ "shared": False, "http": False }),
         AudacityDependency("vorbis", "1.3.7"),
         AudacityDependency("libsndfile", "1.0.31", package_options={ "programs": False }),
@@ -193,7 +195,10 @@ class AudacityConan(ConanFile):
     def requirements(self):
         for dependency in self._dependencies:
             if getattr(self.options, f"use_{dependency.name}"):
-                self.requires(dependency.reference(self))
+                if dependency.override:
+                    self.requires(dependency.reference(self), override=True)
+                else:
+                    self.requires(dependency.reference(self))
 
     def build_requirements(self):
         if self.settings.os not in ["Windows", "Macos"]:


### PR DESCRIPTION
Opus 1.3.1 had a broken build system in which it wasn't possible to control the instruction set used, which resulted in AVX being used. 

Resolves: #5516 
Resolves: #5496

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
