### PR TITLE
Nyquist: do not assume that a track is selected

### DIFF
--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1026,12 +1026,16 @@ bool NyquistEffect::Process(EffectInstance &, EffectSettings &settings)
             mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'HIGH-HZ)\n"), highHz);
             mPerTrackProps += wxString::Format(wxT("(putprop '*SELECTION* %s 'BANDWIDTH)\n"), bandwidth);
 
+            const auto t0 =
+               mCurChannelGroup ? mCurChannelGroup->SnapToSample(mT0) : mT0;
+            const auto t1 =
+               mCurChannelGroup ? mCurChannelGroup->SnapToSample(mT1) : mT1;
             mPerTrackProps += wxString::Format(
-                wxT("(putprop '*SELECTION* (float %s) 'START)\n"),
-                Internat::ToString(mCurChannelGroup->SnapToSample(mT0)));
+               wxT("(putprop '*SELECTION* (float %s) 'START)\n"),
+               Internat::ToString(t0));
             mPerTrackProps += wxString::Format(
-                wxT("(putprop '*SELECTION* (float %s) 'END)\n"),
-                Internat::ToString(mCurChannelGroup->SnapToSample(mT1)));
+               wxT("(putprop '*SELECTION* (float %s) 'END)\n"),
+               Internat::ToString(t1));
          }
 
          success = ProcessOne(nyxContext, oOutputs ? &*oOutputs : nullptr);
@@ -1291,7 +1295,7 @@ bool NyquistEffect::ProcessOne(
       cmd += mPerTrackProps;
    }
 
-   auto &mCurChannelGroup = nyxContext.mCurChannelGroup;
+   const auto& mCurChannelGroup = nyxContext.mCurChannelGroup;
 
    if( (mVersion >= 4) && (GetType() != EffectTypeTool) ) {
       // Set the track TYPE and VIEW properties


### PR DESCRIPTION
Resolves: #5547

#eb11014 introduced the readout of a pointer without nullptr check. This is null if the Nyquist effect is a `bOnePassTool`.
The scope of this problem isn't yet clear. In any case, that pointer must be checked before usage.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
