### PR TITLE
Fixes  GTK detection when using system wxWidgets

### DIFF
--- a/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
+++ b/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
@@ -123,22 +123,6 @@ if( ${_OPT}use_wxwidgets STREQUAL "system" OR NOT ${_OPT}conan_enabled )
         >
     )
 
-    set( toolkit "${wxWidgets_LIBRARIES}" )
-
-    message(STATUS "Trying to retrieve GTK version from ${toolkit}")
-
-    if( "${toolkit}" MATCHES ".*gtk2.*" )
-        set( gtk gtk+-2.0 )
-        set( glib glib-2.0 )
-    elseif( "${toolkit}" MATCHES ".*gtk3.*" )
-        set( gtk gtk+-3.0 )
-        set( glib glib-2.0 )
-    elseif( "${toolkit}" MATCHES ".*gtk4.*" )
-        set( gtk gtk+-4.0 )
-        set( glib glib-2.0 )
-    endif()
-
-
     if( NOT TARGET wxBase )
         # add_library( wxBase ALIAS wxwidgets::wxwidgets )
         make_wxBase(wxwidgets::wxwidgets)
@@ -149,10 +133,46 @@ else()
 endif()
 
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Windows|Darwin" )
+set( toolkit "${wxWidgets_LIBRARIES}" )
+
+message(STATUS "Trying to retrieve GTK version from ${toolkit}")
+
+    if( "${toolkit}" MATCHES ".*gtk2.*" )
+       set( gtk gtk+-2.0 )
+       set( glib glib-2.0 )
+    elseif( "${toolkit}" MATCHES ".*gtk3.*" )
+       set( gtk gtk+-3.0 )
+       set( glib glib-2.0 )
+    elseif( "${toolkit}" MATCHES ".*gtk4.*" )
+       set( gtk gtk+-4.0 )
+       set( glib glib-2.0 )
+    endif()
 
     if( NOT DEFINED gtk )
-        set( gtk gtk+-2.0 )
-        set( glib glib-2.0 )
+       execute_process(
+         COMMAND
+           wx-config --query-toolkit
+         OUTPUT_VARIABLE
+            wx_config_toolkit
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+       )
+
+       message(STATUS "wx-config --query-toolkit --> ${wx_config_toolkit}")
+
+       if( "${wx_config_toolkit}" STREQUAL "gtk2" )
+          set( gtk gtk+-2.0 )
+          set( glib glib-2.0 )
+       elseif( "${wx_config_toolkit}" STREQUAL "gtk3" )
+          set( gtk gtk+-3.0 )
+          set( glib glib-2.0 )
+       elseif( "${wx_config_toolkit}" STREQUAL "gtk4" )
+          set( gtk gtk+-4.0 )
+          set( glib glib-2.0 )
+       endif()
+    endif()
+
+    if( NOT DEFINED gtk )
+       message(FATAL_ERROR "Could not determine GTK version from ${toolkit}")
     endif()
 
     find_package(PkgConfig)

--- a/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
+++ b/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
@@ -127,13 +127,18 @@ if( ${_OPT}use_wxwidgets STREQUAL "system" OR NOT ${_OPT}conan_enabled )
         # add_library( wxBase ALIAS wxwidgets::wxwidgets )
         make_wxBase(wxwidgets::wxwidgets)
     endif()
+
+    set ( toolkit ${wxWidgets_LIBRARIES} )
 else()
     set_target_properties(wxwidgets::base PROPERTIES IMPORTED_GLOBAL On)
     make_wxbase(wxwidgets::base)
+
+    # Assume that Conan package is built with GTK2 for now
+    # TODO: Find a way to autodetect the toolkit used by the Conan package
+    set( toolkit "libwx_gtk2u_core-3.1.so" )
 endif()
 
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Windows|Darwin" )
-    set( toolkit "${wxWidgets_LIBRARIES}" )
     message(STATUS "Trying to retrieve GTK version from ${toolkit}")
 
     if( "${toolkit}" MATCHES ".*gtk2.*" )

--- a/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
+++ b/cmake-proxies/cmake-modules/dependencies/wxwidgets.cmake
@@ -133,9 +133,8 @@ else()
 endif()
 
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Windows|Darwin" )
-set( toolkit "${wxWidgets_LIBRARIES}" )
-
-message(STATUS "Trying to retrieve GTK version from ${toolkit}")
+    set( toolkit "${wxWidgets_LIBRARIES}" )
+    message(STATUS "Trying to retrieve GTK version from ${toolkit}")
 
     if( "${toolkit}" MATCHES ".*gtk2.*" )
        set( gtk gtk+-2.0 )


### PR DESCRIPTION
`wx-config` is now used to get the toolkit when
it can't be determined from the libraries name

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
