### PR TITLE
Copy-paste bug fix

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2205,7 +2205,7 @@ void WaveTrack::PasteOne(
         WaveClip* insideClip = nullptr;
         for (const auto& clip : track.mClips) {
             if (editClipCanMove) {
-                if (clip->WithinPlayRegion(t0)) {
+                if (clip->SplitsPlayRegion(t0)) {
                     //wxPrintf("t0=%.6f: inside clip is %.6f ... %.6f\n",
                     //       t0, clip->GetStartTime(), clip->GetEndTime());
                     insideClip = clip.get();

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2194,11 +2194,13 @@ void WaveTrack::PasteOne(
        const auto t = clipAtT0 ? clipAtT0->GetPlayEndTime() : t0;
        if (!track.IsEmpty(t, t + insertDuration))
           throw notEnoughSpaceException;
-       if (clipAtT0 && clipAtT0->GetPlayStartTime() == t0)
-          clipAtT0->ShiftBy(insertDuration);
     }
 
-    if (singleClipMode) {
+    // See if the clipboard data is one clip only and if it should be merged. If
+    // edit-clip-can-move mode is checked, merging happens only if the pasting
+    // point splits a clip. If it isn't, merging also happens when the pasting
+    // point is at the exact beginning of a clip.
+    if (singleClipMode && merge) {
         // Single clip mode
         // wxPrintf("paste: checking for single clip mode!\n");
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2214,8 +2214,7 @@ void WaveTrack::PasteOne(
             }
             else {
                 // If clips are immovable we also allow prepending to clips
-                if (clip->WithinPlayRegion(t0) ||
-                    track.TimeToLongSamples(t0) == clip->GetPlayStartSample())
+                if (clip->WithinPlayRegion(t0))
                 {
                     insideClip = clip.get();
                     break;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1041,7 +1041,7 @@ private:
    // May assume precondition: t0 <= t1
    void HandleClear(
       double t0, double t1, bool addCutLines, bool split,
-      bool shiftClipAtT1ToT0 = false);
+      bool clearByTrimming = false);
    /*
     * @brief Copy/Paste operations must preserve beat durations, but time
     * boundaries are expressed in seconds. For pasting to work, source and

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -780,7 +780,10 @@ bool EffectNoiseReduction::Worker::Process(
          }
          if (ppTempList) {
             TrackSpectrumTransformer::PostProcess(*pFirstTrack, len);
-            track->ClearAndPaste(t0, t0 + tLen, **ppTempList, true, false);
+            constexpr auto preserveSplits = true;
+            constexpr auto merge = true;
+            track->ClearAndPaste(
+               t0, t0 + tLen, **ppTempList, preserveSplits, merge);
          }
       }
    }


### PR DESCRIPTION
Resolves: #5523
Resolves: #5599

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
This PR intends to restore the _exact same behaviour_ as that of 3.3.3 insofar as the "Always paste audio as new clips" option is disabled and no stretching is involved.

I put together this truth table:
| Always paste audio as new clips | Editing a clip can move other clips | One clip on clipboard only | Position  | Side effect on existing clip    |
| ------------------------------- | ----------------------------------- | -------------------------- | --------- | ------------------------------- |
| OFF                             | OFF                                 | False                      | Before    | not-enough-room error           |
| OFF                             | OFF                                 | False                      | Beginning | not-enough-room error           |
| OFF                             | OFF                                 | False                      | Middle    | not-enough-room error           |
| OFF                             | OFF                                 | True                       | Before    | not-enough-room error           |
| OFF                             | OFF                                 | True                       | Beginning | Shifts data to right and merges |
| OFF                             | OFF                                 | True                       | Middle    | Shifts data to right and merges |
| OFF                             | ON                                  | False                      | Before    | Shifts data to right            |
| OFF                             | ON                                  | False                      | Beginning | Shifts data to right            |
| OFF                             | ON                                  | False                      | Middle    | Shifts data to right            |
| OFF                             | ON                                  | True                       | Before    | Shifts data to right            |
| OFF                             | ON                                  | True                       | Beginning | Shifts data to right            |
| OFF                             | ON                                  | True                       | Middle    | Shifts data to right and merges |
| ON                              | OFF                                 | False                      | Before    | not-enough-room error           |
| ON                              | OFF                                 | False                      | Beginning | not-enough-room error           |
| ON                              | OFF                                 | False                      | Middle    | not-enough-room error           |
| ON                              | OFF                                 | True                       | Before    | not-enough-room error           |
| ON                              | OFF                                 | True                       | Beginning | not-enough-room error           |
| ON                              | OFF                                 | True                       | Middle    | not-enough-room error           |
| ON                              | ON                                  | False                      | Before    | Shifts data to right            |
| ON                              | ON                                  | False                      | Beginning | Shifts data to right            |
| ON                              | ON                                  | False                      | Middle    | Splits and moves to right       |
| ON                              | ON                                  | True                       | Before    | Shifts data to right            |
| ON                              | ON                                  | True                       | Beginning | Shifts data to right            |
| ON                              | ON                                  | True                       | Middle    | Splits and moves to right       |

There's a lot of redundance I didn't bother cleaning up, sorry about that.

Explanation of column names:
* "One clip on clipboard only": the region you selected before copying only contained one clip. It is important because pasting more than one clip should prohibit merging.
* "Position": the position of the cursor (cursor-paste) or the end of the selection (selection-paste):
* * "Before": strictly before the beginning of a clip
* * "Beginning": exactly at beginning of a clip
* * "Middle": within a clip

Besides that:
- [ ] Scenarios of that table relevant to selection-paste (as opposed to cursor-paste) also work
- [ ] Applying Noise Reduction doesn't create new boundaries (if unstretched)
- [ ] Nyquist effects that modify length (e.g. Delay) create new boundaries
- [ ] Nyquist effects that don't modify length (e.g. Tremolo) on unstretched clip don't create new boundaries
