### PR TITLE
Revert preconditions for paste command

### DIFF
--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -296,13 +296,6 @@ const ReservedCommandFlag&
       CommandFlagOptions{}.QuickTest()
    }; return flag; }
 const ReservedCommandFlag&
-   ClipboardNotEmptyFlag() { static ReservedCommandFlag flag{
-      [](const AudacityProject& project) {
-         return !Clipboard::Get().GetTracks().empty();
-      },
-      CommandFlagOptions{}.QuickTest()
-   }; return flag; }
-const ReservedCommandFlag&
    NoAutoSelect() { static ReservedCommandFlag flag{
      [](const AudacityProject &){ return true; }
    }; return flag; } // jkc

--- a/src/CommonCommandFlags.h
+++ b/src/CommonCommandFlags.h
@@ -53,7 +53,6 @@ extern AUDACITY_DLL_API const ReservedCommandFlag
    &IsSyncLockedFlag(),  //awd
    &NotMinimizedFlag(), // prl
    &PausedFlag(), // jkc
-   &ClipboardNotEmptyFlag(),
    &NoAutoSelect() // jkc
 ;
 

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -1117,7 +1117,7 @@ BaseItemSharedPtr EditMenu()
             AudioIONotBusyFlag() | CutCopyAvailableFlag(), wxT("Ctrl+C") ),
          /* i18n-hint: (verb)*/
          Command( wxT("Paste"), XXO("&Paste"), OnPaste,
-            AudioIONotBusyFlag() | ClipboardNotEmptyFlag(), wxT("Ctrl+V") ),
+            AudioIONotBusyFlag(), wxT("Ctrl+V") ),
          /* i18n-hint: (verb)*/
          Command( wxT("Duplicate"), XXO("Duplic&ate"), OnDuplicate,
             NotBusyTimeAndTracksFlags, wxT("Ctrl+D") ),


### PR DESCRIPTION
Resolves: #5518 

Simple check for clipboard contents turned out to be not enough and text pasiting became imposible. But more complete check is very complicated and leads to attempts to modify many const-qulified structures.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
