### PR TITLE
Enable building Audacity for Windows running on ARM64 architecture

### DIFF
--- a/lib-src/libnyquist/nyquist/nyqsrc/convolve.c
+++ b/lib-src/libnyquist/nyquist/nyqsrc/convolve.c
@@ -61,12 +61,6 @@
  * Length of output is length of x input + length of h
  */
 
-// You can turn on debugging output with: #define D if (1)
-#define D if (0)
-
-#define MAX_IR_LEN 4000000 /* maximum impulse response length */
-#define MAX_LOG_FFT_SIZE 16 /* maximum fft size for convolution */
-//#define MAX_LOG_FFT_SIZE 4 /* maximum fft size for convolution */
 #define _USE_MATH_DEFINES 1 /* for Visual C++ to get M_LN2 */
 #include <assert.h>
 #include <math.h>
@@ -84,8 +78,17 @@
 #include "fftext.h"
 #include "convolve.h"
 
-void convolve_free(snd_susp_type a_susp);
+#ifdef D
+#undef D // We would like to use D in this file
+#endif   // D
 
+// You can turn on debugging output with: #define D if (1)
+#define D if (0)
+#define MAX_IR_LEN 4000000 /* maximum impulse response length */
+#define MAX_LOG_FFT_SIZE 16 /* maximum fft size for convolution */
+//#define MAX_LOG_FFT_SIZE 4 /* maximum fft size for convolution */
+
+void convolve_free(snd_susp_type a_susp);
 
 typedef struct convolve_susp_struct {
     snd_susp_node susp;

--- a/lib-src/libsbsms/src/fft.h
+++ b/lib-src/libsbsms/src/fft.h
@@ -6,7 +6,7 @@
 #include <string.h>
 #include "utils.h"
 
-#if defined(ENABLE_SSE) && !defined(APPLE_PPC)
+#if defined(ENABLE_SSE) && !defined(APPLE_PPC) && !defined(_M_ARM64)
 #include "sse.h"
 #endif
 
@@ -322,7 +322,7 @@ public:
   }
 };
 
-#if defined(ENABLE_SSE) && !defined(APPLE_PPC)
+#if defined(ENABLE_SSE) && !defined(APPLE_PPC) && !defined(_M_ARM64)
 
 template <int N, int dir> 
 class SSETwiddles {

--- a/lib-src/libsoxr/cmake/Modules/SetSystemProcessor.cmake
+++ b/lib-src/libsoxr/cmake/Modules/SetSystemProcessor.cmake
@@ -14,6 +14,7 @@ macro (set_system_processor)
         "#if defined __x86_64__ || defined _M_X64  /*\;x86_64\;*/"
         "#if defined __i386__   || defined _M_IX86 /*\;x86_32\;*/"
         "#if defined __arm__    || defined _M_ARM  /*\;arm\;*/"
+        "#if defined _M_ARM64  /*\;arm64\;*/"
         )
       foreach (CPU_LINE ${CPU_LINES})
         string (CONCAT CPU_SOURCE "${CPU_LINE}" "

--- a/lib-src/libsoxr/src/dev32s.h
+++ b/lib-src/libsoxr/src/dev32s.h
@@ -33,7 +33,11 @@ SIMD_INLINE(void) vStorSum(float * a, v4_t b) {
 
 #elif defined __arm__
 
+#if defined(_M_ARM64)
+#include <arm64_neon.h>
+#else
 #include <arm_neon.h>
+#endif
 
 #define vZero()      vdupq_n_f32(0)
 #define vMul(a,b)    vmulq_f32(a,b)

--- a/lib-src/libsoxr/src/pffft-wrap.c
+++ b/lib-src/libsoxr/src/pffft-wrap.c
@@ -40,7 +40,7 @@ static void pffft_zconvolve(PFFFT_Setup *s, const float *a, const float *b, floa
 
   float ar, ai, br, bi;
 
-#ifdef __arm__
+#if defined(__arm__) || defined (_M_ARM64)
   __builtin_prefetch(va);
   __builtin_prefetch(vb);
   __builtin_prefetch(va+2);

--- a/lib-src/libsoxr/src/pffft.c
+++ b/lib-src/libsoxr/src/pffft.c
@@ -157,8 +157,12 @@ typedef __m128 v4sf;
 /*
   ARM NEON support macros
 */
-#elif !defined(PFFFT_SIMD_DISABLE) && (defined(__arm__) || defined(__aarch64__))
+#elif !defined(PFFFT_SIMD_DISABLE) && (defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64))
+#if defined(_M_ARM64)
+#  include <arm64_neon.h>
+#  else
 #  include <arm_neon.h>
+#  endif
 typedef float32x4_t v4sf;
 #  define SIMD_SZ 4
 #  define VZERO() vdupq_n_f32(0)
@@ -182,7 +186,11 @@ typedef float32x4_t v4sf;
 #  define VALIGNED(ptr) ((((long)(ptr)) & 0x3) == 0)
 #else
 #  if !defined(PFFFT_SIMD_DISABLE)
-#    warning "building with simd disabled !\n";
+#   if defined(COMPILER_MSVC)
+#       pragma message ("building with simd disabled !\n")
+#   else
+#       warning "building with simd disabled !\n";
+#   endif
 #    define PFFFT_SIMD_DISABLE /* fallback to scalar code */
 #  endif
 #endif

--- a/lib-src/sqlite/shell.c
+++ b/lib-src/sqlite/shell.c
@@ -1445,7 +1445,7 @@ SQLITE_EXTENSION_INIT1
 # if defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
      defined(__x86_64) || defined(__x86_64__) || defined(_M_X64)  ||    \
      defined(_M_AMD64) || defined(_M_ARM)     || defined(__x86)   ||    \
-     defined(__arm__)
+     defined(__arm__)  || defined(_M_ARM64)
 #   define SHA3_BYTEORDER    1234
 # elif defined(sparc)    || defined(__ppc__)
 #   define SHA3_BYTEORDER    4321

--- a/libraries/lib-network-manager/curl/CurlHandleManager.cpp
+++ b/libraries/lib-network-manager/curl/CurlHandleManager.cpp
@@ -51,7 +51,7 @@ void GetOSString (std::ostringstream& output, const wxPlatformInfo& platformInfo
     output << "x64";
 #elif defined(__i386__) || defined(i386) || defined(_M_IX86) || defined(_X86_) || defined(__THW_INTEL)
     output << "x86";
-#elif defined(__arm64__) || defined(__aarch64__)
+#elif defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64)
     output << "arm64";
 #elif defined(arm) || defined(__arm__) || defined(ARM) || defined(_ARM_)
     output << "arm";


### PR DESCRIPTION
Resolves: 
[Investigate Windows on ARM64 build](https://github.com/audacity/audacity/issues/5557)

Build Audacity natively for Windows running on ARM64. Audacity build dependency like RapidJSON, WxWidgets, OpusFile recipes have already been merged into audacity/conan-recipes. This series of patches resolve compilation issues seen when compiling on a ARM64 machine running Windows 11 and MSVC 2022 community edition. Steps I followed to setup build environment are https://github.com/i-lina/audacity/releases/tag/v3.4.1-win-arm64.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
