### PR TITLE
include altivec.h for powerpc altivec usage

### DIFF
--- a/libraries/lib-time-and-pitch/StaffPad/pffft/pfsimd_macros.h
+++ b/libraries/lib-time-and-pitch/StaffPad/pffft/pfsimd_macros.h
@@ -61,6 +61,7 @@
    Altivec support macros 
 */
 #if !defined(PFFFT_SIMD_DISABLE) && (defined(__ppc__) || defined(__ppc64__))
+#include <altivec.h>
 typedef vector float v4sf;
 #  define SIMD_SZ 4
 #  define VREQUIRES_ALIGN 1  /* not sure, if really required */


### PR DESCRIPTION
using the vector functions (e.g. vec_lde) requires importing the platform simd header

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
