### PR TITLE
Fixes Audacity hanging after clearing the loop region

### DIFF
--- a/libraries/lib-time-frequency-selection/ViewInfo.h
+++ b/libraries/lib-time-frequency-selection/ViewInfo.h
@@ -173,7 +173,7 @@ private:
    void Notify();
 
    // Times:
-   static constexpr auto invalidValue = std::numeric_limits<double>::min();
+   static constexpr auto invalidValue = -std::numeric_limits<double>::infinity();
 
    double mStart { invalidValue };
    double mEnd { invalidValue };

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2574,11 +2574,12 @@ void AdornedRulerPanel::DoDrawPlayRegion(
    wxDC * dc, const wxRect &rectP, const wxRect &rectL, const wxRect &rectR)
 {
    const auto &viewInfo = ViewInfo::Get(*mProject);
-   const auto &playRegion = viewInfo.playRegion;
-   if (playRegion.IsLastActiveRegionClear())
-      return;
+   const auto& playRegion = viewInfo.playRegion;
 
    const bool isActive = (mLastPlayRegionActive = playRegion.Active());
+
+   if (playRegion.IsLastActiveRegionClear())
+      return;
 
    // Paint the selected region bolder if independently varying, else dim
    const auto color = TimelineLoopRegionColor(isActive);

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -2743,7 +2743,7 @@ void AdornedRulerPanel::ClearPlayRegion()
 
    auto &viewInfo = ViewInfo::Get( *GetProject() );
    auto &playRegion = viewInfo.playRegion;
-   playRegion.SetTimes( -1, -1 );
+   playRegion.Clear();
 
    Refresh();
 }

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -216,6 +216,9 @@ void ClearPlayRegion(AudacityProject &project)
    auto &viewInfo = ViewInfo::Get( project );
    auto &playRegion = viewInfo.playRegion;
    playRegion.Clear();
+
+   if (playRegion.Active())
+      InactivatePlayRegion(project);
 }
 
 void SetPlayRegionToSelection(AudacityProject &project)


### PR DESCRIPTION
Resolves: #5543 

@LWinterberg, this PR changes the Audacity behavior: clear the looping region disables looping. 

It looks sane to me, but please let me know if you disagree, and I will fix the issue differently then.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
