### PR TITLE
Rewrite WaveTrack pasting as interval-major

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -3867,18 +3867,6 @@ const WaveClip* WaveTrack::GetClipAtTime(double time) const
       clips.rbegin(), clips.rend(), [&](const WaveClip* const& clip) {
          return clip->WithinPlayRegion(time);
       });
-
-   // When two clips are immediately next to each other, the GetPlayEndTime() of the first clip
-   // and the GetPlayStartTime() of the second clip may not be exactly equal due to rounding errors.
-   // If "time" is the end time of the first of two such clips, and the end time is slightly
-   // less than the start time of the second clip, then the first rather than the
-   // second clip is found by the above code. So correct this.
-   if (p != clips.rend() && p != clips.rbegin() &&
-      time == (*p)->GetPlayEndTime() &&
-      (*p)->SharesBoundaryWithNextClip(*(p-1))) {
-      p--;
-   }
-
    return p != clips.rend() ? *p : nullptr;
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1349,7 +1349,7 @@ bool WaveTrack::IsEmpty(double t0, double t1) const
       return true;
 
    //wxPrintf("Searching for overlap in %.6f...%.6f\n", t0, t1);
-   for (const auto &clip : mClips)
+   for (const auto &&clip : Intervals())
    {
       if (clip->IntersectsPlayRegion(t0, t1)) {
          //wxPrintf("Overlapping clip: %.6f...%.6f\n",

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -380,6 +380,11 @@ bool WaveTrack::Interval::StretchRatioEquals(double value) const
    return true;
 }
 
+bool WaveTrack::Interval::HasEqualStretchRatio(const Interval& other) const
+{
+   return StretchRatioEquals(other.GetStretchRatio());
+}
+
 /** Insert silence at the end, and causes the envelope to ramp
     linearly to the given value */
 void WaveTrack::Interval::AppendSilence(double len, double envelopeValue)
@@ -520,6 +525,11 @@ bool WaveTrack::Interval::WithinPlayRegion(double t) const
    return mpClip->WithinPlayRegion(t);
 }
 
+bool WaveTrack::Interval::SplitsPlayRegion(double t) const
+{
+   return mpClip->SplitsPlayRegion(t);
+}
+
 double WaveTrack::Interval::GetStretchRatio() const
 {
    //TODO wide wave tracks:  assuming that all 'narrow' clips share common stretch ratio
@@ -566,6 +576,11 @@ double WaveTrack::Interval::GetTrimRight() const
 bool WaveTrack::Interval::IsPlaceholder() const
 {
    return mpClip->GetIsPlaceholder();
+}
+
+void WaveTrack::Interval::MarkChanged()
+{
+   ForEachClip([](auto &clip){ clip.MarkChanged(); });
 }
 
 const Envelope& WaveTrack::Interval::GetEnvelope() const
@@ -1070,19 +1085,11 @@ Track::Holder WaveTrack::PasteInto(
    assert(IsLeader());
    auto &trackFactory = WaveTrackFactory::Get(project);
    auto &pSampleBlockFactory = trackFactory.GetSampleBlockFactory();
-   Track::Holder pFirstTrack;
-   const WaveTrack *pFirstChannel{};
-   for (const auto pChannel : TrackList::Channels(this)) {
-      auto pNewTrack = pChannel->EmptyCopy(pSampleBlockFactory);
-      list.Add(pNewTrack);
-      assert(pNewTrack->IsLeader() == pChannel->IsLeader());
-      if (!pFirstTrack) {
-         pFirstTrack = pNewTrack;
-         pFirstChannel = pChannel;
-      }
-   }
-   pFirstTrack->Paste(0.0, *pFirstChannel);
-   return pFirstTrack;
+   auto tmpList = WideEmptyCopy(pSampleBlockFactory);
+   auto pFirstTrack = *tmpList->Any<WaveTrack>().begin();
+   list.Append(std::move(*tmpList));
+   pFirstTrack->Paste(0.0, *this);
+   return pFirstTrack->SharedPointer();
 }
 
 size_t WaveTrack::NIntervals() const
@@ -2259,18 +2266,9 @@ void WaveTrack::PasteWaveTrackAtSameTempo(
       GetProjectTempo() == other.GetProjectTempo());
    const auto startTime = other.GetStartTime();
    const auto endTime = other.GetEndTime();
-   auto iter = TrackList::Channels(&other).begin();
-   for (const auto pChannel : TrackList::Channels(this)) {
-      PasteOne(*pChannel, t0, **iter, startTime, endTime, merge);
-      if (otherNChannels > 1)
-         ++iter;
-   }
-}
 
-void WaveTrack::PasteOne(
-   WaveTrack& track, double t0, const WaveTrack& other, const double startTime,
-   const double insertDuration, bool merge)
-{
+   const auto insertDuration = endTime;
+   auto &track = *this;
     //
     // Pasting is a bit complicated, because with the existence of multiclip mode,
     // we must guess the behaviour the user wants.
@@ -2299,9 +2297,9 @@ void WaveTrack::PasteOne(
 
     //wxPrintf("paste: we have at least one clip\n");
 
-    const auto clipAtT0 = track.GetClipAtTime(t0);
-    const auto otherFirstClip = other.GetLeftmostNarrowClip();
-    const auto otherLastClip = other.GetRightmostNarrowClip();
+    const auto clipAtT0 = track.GetIntervalAtTime(t0);
+    const auto otherFirstClip = other.GetLeftmostClip();
+    const auto otherLastClip = other.GetRightmostClip();
     const auto stretchRatiosMatch =
        !clipAtT0 || (clipAtT0->HasEqualStretchRatio(*otherFirstClip) &&
                      clipAtT0->HasEqualStretchRatio(*otherLastClip));
@@ -2334,21 +2332,21 @@ void WaveTrack::PasteOne(
 
     // Make room for the pasted data
     if (editClipCanMove) {
-        if (!singleClipMode) {
+        if (!singleClipMode)
             // We need to insert multiple clips, so split the current clip and ...
-            track.SplitOneAt(t0);
-        }
+            track.SplitAt(t0);
+
         //else if there is a clip at t0 insert new clip inside it and ...
 
         // ... move everything to the right
-        for (const auto& clip : track.mClips)
+        for (const auto& clip : track.Intervals())
             if (clip->GetPlayStartTime() > t0 - (1.0 / rate))
                 clip->ShiftBy(insertDuration);
     }
     else
     {
        if (!merge)
-          track.SplitOneAt(t0);
+          track.SplitAt(t0);
        const auto clipAtT0 = track.GetClipAtTime(t0);
        const auto t = clipAtT0 ? clipAtT0->GetPlayEndTime() : t0;
        if (!track.IsEmpty(t, t + insertDuration))
@@ -2363,13 +2361,13 @@ void WaveTrack::PasteOne(
         // Single clip mode
         // wxPrintf("paste: checking for single clip mode!\n");
 
-        WaveClip* insideClip = nullptr;
-        for (const auto& clip : track.mClips) {
+        IntervalHolder insideClip{};
+        for (const auto& clip : track.Intervals()) {
             if (editClipCanMove) {
                 if (clip->SplitsPlayRegion(t0)) {
                     //wxPrintf("t0=%.6f: inside clip is %.6f ... %.6f\n",
                     //       t0, clip->GetStartTime(), clip->GetEndTime());
-                    insideClip = clip.get();
+                    insideClip = clip;
                     break;
                 }
             }
@@ -2377,7 +2375,7 @@ void WaveTrack::PasteOne(
                 // If clips are immovable we also allow prepending to clips
                 if (clip->WithinPlayRegion(t0))
                 {
-                    insideClip = clip.get();
+                    insideClip = clip;
                     break;
                 }
             }
@@ -2389,7 +2387,7 @@ void WaveTrack::PasteOne(
             if (!editClipCanMove) {
                 // We did not move other clips out of the way already, so
                 // check if we can paste without having to move other clips
-                for (const auto& clip : track.mClips) {
+                for (const auto& clip : track.Intervals()) {
                     if (clip->GetPlayStartTime() > insideClip->GetPlayStartTime() &&
                         insideClip->GetPlayEndTime() + insertDuration >
                         clip->GetPlayStartTime())
@@ -2398,7 +2396,7 @@ void WaveTrack::PasteOne(
                         throw notEnoughSpaceException;
                 }
             }
-            if (auto *pClip = other.GetClipByIndex(0)) {
+            if (auto pClip = other.GetWideClip(0)) {
                // This branch only gets executed in `singleClipMode` - we've
                // already made sure that stretch ratios are equal, satisfying
                // `WaveClip::Paste`'s precondition.
@@ -2423,21 +2421,19 @@ void WaveTrack::PasteOne(
         // not that it matters.
         throw notEnoughSpaceException;
 
-    for (const auto& clip : other.mClips) {
+    for (const auto& clip : other.Intervals()) {
         // AWD Oct. 2009: Don't actually paste in placeholder clips
-        if (!clip->GetIsPlaceholder()) {
-            auto newClip =
-                std::make_shared<WaveClip>(*clip, track.mpFactory, true);
-            newClip->Resample(rate);
-            newClip->ShiftBy(t0);
-            newClip->MarkChanged();
-            if (pastingFromTempTrack)
+        if (!clip->IsPlaceholder()) {
+            const auto name = (pastingFromTempTrack)
                 //Clips from the tracks which aren't bound to any TrackList are
                 //considered to be new entities, thus named using "new" name template
-                newClip->SetName(track.MakeNewClipName());
-            else
-                newClip->SetName(track.MakeClipCopyName(clip->GetName()));
-            track.InsertClip(std::move(newClip)); // transfer ownership
+                ? track.MakeNewClipName()
+                : track.MakeClipCopyName(clip->GetName());
+            const auto newClip =
+               CreateWideClip(t0 - clip->GetTrimLeft(), name, clip.get());
+            newClip->Resample(rate);
+            newClip->MarkChanged();
+            track.InsertInterval(move(newClip));
         }
     }
 }
@@ -2606,6 +2602,180 @@ void WaveTrack::InsertSilence(double t, double len)
                clip->ShiftBy(len);
       }
    }
+}
+
+void WaveTrack::PasteOne(
+   WaveTrack& track, double t0, const WaveTrack& other, const double startTime,
+   const double insertDuration, bool merge)
+{
+    //
+    // Pasting is a bit complicated, because with the existence of multiclip mode,
+    // we must guess the behaviour the user wants.
+    //
+    // Currently, two modes are implemented:
+    //
+    // - If a single clip should be pasted, and it should be pasted inside another
+    //   clip, no NEW clips are generated. The audio is simply inserted.
+    //   This resembles the old (pre-multiclip support) behaviour. However, if
+    //   the clip is pasted outside of any clip, a NEW clip is generated. This is
+    //   the only behaviour which is different to what was done before, but it
+    //   shouldn't confuse users too much.
+    //
+    // - If multiple clips should be pasted, or a single clip that does not fill
+    // the duration of the pasted track, these are always pasted as single
+    // clips, and the current clip is split, when necessary. This may seem
+    // strange at first, but it probably is better than trying to auto-merge
+    // anything. The user can still merge the clips by hand (which should be a
+    // simple command reachable by a hotkey or single mouse click).
+    //
+
+    if (other.GetNumClips() == 0)
+        return;
+
+    t0 = track.SnapToSample(t0);
+
+    //wxPrintf("paste: we have at least one clip\n");
+
+    const auto clipAtT0 = track.GetIntervalAtTime(t0);
+    const auto otherFirstClip = other.GetLeftmostClip();
+    const auto otherLastClip = other.GetRightmostClip();
+    const auto stretchRatiosMatch =
+       !clipAtT0 || (clipAtT0->HasEqualStretchRatio(*otherFirstClip) &&
+                     clipAtT0->HasEqualStretchRatio(*otherLastClip));
+
+    // `singleClipMode` will try to merge. Only allow this if clips on both ends
+    // of the selection have equal stretch ratio.
+    const bool singleClipMode =
+       other.GetNumClips() == 1 &&
+       std::abs(startTime) < track.LongSamplesToTime(1) * 0.5 &&
+       stretchRatiosMatch && merge;
+
+    const auto rate = track.GetRate();
+    if (insertDuration != 0 && insertDuration < 1.0 / rate)
+        // PRL:  I added this check to avoid violations of preconditions in other WaveClip and Sequence
+        // methods, but allow the value 0 so I don't subvert the purpose of commit
+        // 739422ba70ceb4be0bb1829b6feb0c5401de641e which causes append-recording always to make
+        // a new clip.
+        return;
+
+    //wxPrintf("Check if we need to make room for the pasted data\n");
+
+    auto pastingFromTempTrack = !other.GetOwner();
+    bool editClipCanMove = GetEditClipsCanMove();
+
+    const SimpleMessageBoxException notEnoughSpaceException {
+       ExceptionType::BadUserAction,
+       XO("There is not enough room available to paste the selection"),
+       XO("Warning"), "Error:_Insufficient_space_in_track"
+    };
+
+    // Make room for the pasted data
+    if (editClipCanMove) {
+        if (!singleClipMode) {
+            // We need to insert multiple clips, so split the current clip and ...
+            track.SplitAt(t0);
+        }
+        //else if there is a clip at t0 insert new clip inside it and ...
+
+        // ... move everything to the right
+        for (const auto& clip : track.mClips)
+            if (clip->GetPlayStartTime() > t0 - (1.0 / rate))
+                clip->ShiftBy(insertDuration);
+    }
+    else
+    {
+       if (!merge)
+          track.SplitAt(t0);
+       const auto clipAtT0 = track.GetClipAtTime(t0);
+       const auto t = clipAtT0 ? clipAtT0->GetPlayEndTime() : t0;
+       if (!track.IsEmpty(t, t + insertDuration))
+          throw notEnoughSpaceException;
+       if (clipAtT0 && clipAtT0->GetPlayStartTime() == t0)
+          clipAtT0->ShiftBy(insertDuration);
+    }
+
+    if (singleClipMode) {
+        // Single clip mode
+        // wxPrintf("paste: checking for single clip mode!\n");
+
+        WaveClip* insideClip = nullptr;
+        for (const auto& clip : track.mClips) {
+            if (editClipCanMove) {
+                if (clip->WithinPlayRegion(t0)) {
+                    //wxPrintf("t0=%.6f: inside clip is %.6f ... %.6f\n",
+                    //       t0, clip->GetStartTime(), clip->GetEndTime());
+                    insideClip = clip.get();
+                    break;
+                }
+            }
+            else {
+                // If clips are immovable we also allow prepending to clips
+                if (clip->WithinPlayRegion(t0) ||
+                    track.TimeToLongSamples(t0) == clip->GetPlayStartSample())
+                {
+                    insideClip = clip.get();
+                    break;
+                }
+            }
+        }
+
+        if (insideClip) {
+            // Exhibit traditional behaviour
+            //wxPrintf("paste: traditional behaviour\n");
+            if (!editClipCanMove) {
+                // We did not move other clips out of the way already, so
+                // check if we can paste without having to move other clips
+                for (const auto& clip : track.mClips) {
+                    if (clip->GetPlayStartTime() > insideClip->GetPlayStartTime() &&
+                        insideClip->GetPlayEndTime() + insertDuration >
+                        clip->GetPlayStartTime())
+                        // Strong-guarantee in case of this path
+                        // not that it matters.
+                        throw notEnoughSpaceException;
+                }
+            }
+            if (auto *pClip = other.GetClipByIndex(0)) {
+               // This branch only gets executed in `singleClipMode` - we've
+               // already made sure that stretch ratios are equal, satisfying
+               // `WaveClip::Paste`'s precondition.
+               bool success = insideClip->Paste(t0, *pClip);
+               // TODO wide wave tracks -- prove success, or propagate failure,
+               // or we might throw a MessageBoxException
+               // (which would require a change in base class Track)
+               // for now it would be quiet failure if clip widths mismatched
+               // Can't yet assert(success);
+            }
+            return;
+        }
+        // Just fall through and exhibit NEW behaviour
+    }
+
+    // Insert NEW clips
+    //wxPrintf("paste: multi clip mode!\n");
+
+    if (!editClipCanMove &&
+        !track.IsEmpty(t0, t0 + insertDuration - 1.0 / rate))
+        // Strong-guarantee in case of this path
+        // not that it matters.
+        throw notEnoughSpaceException;
+
+    for (const auto& clip : other.mClips) {
+        // AWD Oct. 2009: Don't actually paste in placeholder clips
+        if (!clip->GetIsPlaceholder()) {
+            auto newClip =
+                std::make_shared<WaveClip>(*clip, track.mpFactory, true);
+            newClip->Resample(rate);
+            newClip->ShiftBy(t0);
+            newClip->MarkChanged();
+            if (pastingFromTempTrack)
+                //Clips from the tracks which aren't bound to any TrackList are
+                //considered to be new entities, thus named using "new" name template
+                newClip->SetName(track.MakeNewClipName());
+            else
+                newClip->SetName(track.MakeClipCopyName(clip->GetName()));
+            track.InsertClip(std::move(newClip)); // transfer ownership
+        }
+    }
 }
 
 //Performs the opposite of Join
@@ -3883,13 +4053,22 @@ Envelope* WaveTrack::GetEnvelopeAtTime(double time)
       return NULL;
 }
 
-auto WaveTrack::CreateWideClip(double offset, const wxString& name)
-   -> IntervalHolder
+auto WaveTrack::CreateWideClip(double offset, const wxString& name,
+   const Interval *pToCopy) -> IntervalHolder
 {
    assert(IsLeader());
    WaveClipHolders holders;
-   for (auto channel : TrackList::Channels(this))
-      holders.emplace_back(channel->CreateClip(offset, name));
+   if (pToCopy)
+      pToCopy->ForEachClip([&](const WaveClip &clip){
+         auto pNewClip = std::make_shared<WaveClip>(clip, mpFactory, true);
+         pNewClip->SetName(name);
+         pNewClip->SetSequenceStartTime(offset);
+         holders.emplace_back(pNewClip);
+      });
+   else
+      for (auto channel : TrackList::Channels(this))
+         holders.emplace_back(channel->CreateClip(offset, name));
+
    return std::make_shared<Interval>(*this,
       holders[0], (holders.size() > 1) ? holders[1] : nullptr);
 }
@@ -4107,16 +4286,28 @@ auto WaveTrack::SplitAt(double t0) -> std::pair<IntervalHolder, IntervalHolder>
    for (const auto pChannel : TrackList::Channels(this)) {
       pairs.emplace_back(pChannel->SplitOneAt(t0));
    }
+
+   // Assume one channel at least!
+   assert(pairs.size() >= 1);
+   const auto firstfirst = pairs[0].first;
+
+   // Maybe SplitOneAt did not split, as when t0 is an endpoint.
+   if (!firstfirst) {
+      // If the first channel didn't split, neither should have the other
+      assert(!pairs[1].first);
+      return {};
+   }
+
    // Convert one or two channel-major "narrow" pairs to one interval-major
    // "wide" pair
    if (pairs.size() == 1)
       return {
-         std::make_shared<Interval>(*this, pairs[0].first, nullptr),
+         std::make_shared<Interval>(*this, firstfirst, nullptr),
          std::make_shared<Interval>(*this, pairs[0].second, nullptr),
       };
    else
       return {
-         std::make_shared<Interval>(*this, pairs[0].first, pairs[1].first),
+         std::make_shared<Interval>(*this, firstfirst, pairs[1].first),
          std::make_shared<Interval>(*this, pairs[0].second, pairs[1].second)
       };
 }

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -829,10 +829,12 @@ public:
    //! Create new clip and add it to this track.
    /*!
     Returns a pointer to the newly created clip. Optionally initial offset and
-    clip name may be provided
+    clip name may be provided, and a clip from which to copy all sample data.
+    @param offset desired sequence (not play) start time
     */
    IntervalHolder
-   CreateWideClip(double offset = .0, const wxString& name = wxEmptyString);
+   CreateWideClip(double offset = .0, const wxString& name = wxEmptyString,
+      const Interval *pToCopy = nullptr);
 
    //! Create new clip and add it to this track.
    /*!
@@ -994,6 +996,12 @@ public:
       bool IntersectsPlayRegion(double t0, double t1) const;
       bool WithinPlayRegion(double t) const;
 
+      /*!
+       * @brief [ < t and t < ), such that if the track were split at `t`, it would
+       * split this clip in two of lengths > 0.
+       */
+      bool SplitsPlayRegion(double t) const;
+
       double GetStretchRatio() const;
 
       sampleCount TimeToSamples(double time) const;
@@ -1016,6 +1024,8 @@ public:
 
       bool IsPlaceholder() const;
 
+      void MarkChanged();
+
       void SetSequenceStartTime(double t);
       void TrimLeftTo(double t);
       void TrimRightTo(double t);
@@ -1033,7 +1043,12 @@ public:
          const std::function<void(double)>& reportProgress,
          const ChannelGroup& group, const SampleBlockFactoryPtr& factory,
          sampleFormat format);
+
+      //! Checks for stretch-ratio equality, accounting for rounding errors.
+      //! @{
+      bool HasEqualStretchRatio(const Interval& other) const;
       bool StretchRatioEquals(double value) const;
+      //! @}
 
       /*! @excsafety{No-fail} */
       void ShiftBy(double delta) noexcept;
@@ -1085,6 +1100,9 @@ public:
       void ExpandCutLine(double cutlinePosition);
 
    private:
+      // TODO wide wave tracks -- remove friend
+      friend WaveTrack;
+
       void SetEnvelope(const Envelope& envelope);
 
       // Helper function in time of migration to wide clips


### PR DESCRIPTION
Resolves: #5585

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

QA:  all the clip edge cases, mono and stereo...
- [x] Pasted-into track becomes selected
- [x] Cross-project paste, with and without project tempo differences
- [x] Paste with and without stretch ratio differences
- [x] With and without the new merging preference
- [x] Pasting into a clip, within one sample interval of time 0
- [x] With and without the "Edit clips can move" preference; test the prohibition
- [x] Moving of multiple other clips rightward to make room for the paste
- [x] New clips get correct names, and also when splitting to mono after the paste

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
