### PR TITLE
Attempt to fix stutters when overdubbing

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -2708,6 +2708,9 @@ bool AudioIoCallback::FillOutputBuffers(
             len = mPlaybackBuffers[iBuffer]->Discard(toGet);
             // keep going here.
             // we may still need to issue a paComplete.
+
+            // Keep tempBufs initialized to avoid NaNs and Infs
+            memset(tempBufs[c], 0, framesPerBuffer * sizeof(float));
          }
          else {
             len = mPlaybackBuffers[iBuffer]


### PR DESCRIPTION
(Probably) Resolves: #5106

This fixes the issue for me and looks quite sane: uninitialized memory can look like `NaN` or `Inf`, in both cases multiplying by 0 results in `NaN`, which is likely then converted to `INT_MAX`

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
