### PR TITLE
Set project tempo on tracks in import

### DIFF
--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -31,6 +31,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "ProjectRate.h"
 #include "ProjectSettings.h"
 #include "ProjectStatus.h"
+#include "ProjectTimeSignature.h"
 #include "ProjectWindow.h"
 #include "SelectFile.h"
 #include "SelectUtilities.h"
@@ -1404,6 +1405,11 @@ bool ProjectFileManager::Import(
       }
       if (!success)
          return false;
+
+      const auto projectTempo = ProjectTimeSignature::Get(project).GetTempo();
+      for (auto trackList : newTracks)
+         for (auto track : *trackList)
+            track->OnProjectTempoChange(projectTempo);
 
       if (addToHistory) {
          FileHistory::Global().Append(fileName);


### PR DESCRIPTION
Resolves: #5604 

Applying a macro to files is one method call which creates a provisional wave track, does stuff with it, exports the result and then remove the track from the project.

On the one hand, this is calling some `WaveTrack` method which queries clip boundaries and hence project tempo. On the other hand, the project tempo is set onto tracks _asynchronously_, i.e., an event is queued when adding a track to the track list to do that. When manually interacting with a project, the queued event has all the time to get executed before any of these boundary-querying calls are made. But not here.

This is a quick fix, which gets the `ProjectFileManager` to synchronously get `OnProjectTempoChange` to the tracks resulting from the import. I wonder if there is a way of making the call to `OnProjectTempoChange` when adding a track to a track list synchronous, but that would bypass the current publisher/observer construct. I don't have another idea so far.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
