### PR TITLE
Use dladdr when possible to setup modules paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,7 @@ check_include_file( "strings.h" HAVE_STRINGS_H )
 check_include_file( "unistd.h" HAVE_UNISTD_H )
 check_include_file( "sys/stat.h" HAVE_SYS_STAT_H )
 check_include_file( "sys/types.h" HAVE_SYS_TYPES_H )
+check_include_file( "dlfcn.h" HAVE_DLFCN_H )
 
 check_symbol_exists( fileno "stdio.h" HAVE_FILENO )
 check_symbol_exists( flock "sys/file.h" HAVE_FLOCK )

--- a/libraries/lib-files/PathList.cpp
+++ b/libraries/lib-files/PathList.cpp
@@ -15,6 +15,25 @@
 #include <wx/stdpaths.h>
 #include <wx/utils.h>
 
+#if HAVE_DLFCN_H && !defined(DISABLE_DLADDR)
+#  if __linux__ && !defined(_GNU_SOURCE)
+#    define _GNU_SOURCE
+#  endif
+#  include <dlfcn.h>
+#  define HAVE_GET_LIBRARY_PATH 1
+namespace
+{
+wxString GetLibraryPath()
+{
+   Dl_info info;
+   // This is a GNU extension, but it's also supported on FreeBSD, OpenBSD, macOS and Solaris.
+   if (dladdr(reinterpret_cast<const void*>(GetLibraryPath), &info))
+      return info.dli_fname;
+   return {};
+}
+}
+#endif
+
 void FileNames::InitializePathList()
 {
    auto &standardPaths = wxStandardPaths::Get();
@@ -85,6 +104,12 @@ void FileNames::InitializePathList()
       FileNames::AddUniquePathToPathList(progParentPath + L"/lib/audacity", audacityPathList);
       FileNames::AddUniquePathToPathList(progParentPath + L"/lib", audacityPathList);
    }
+
+#if HAVE_GET_LIBRARY_PATH
+   const wxString thisLibPath = GetLibraryPath();
+   if (!thisLibPath.IsEmpty())
+      FileNames::AddUniquePathToPathList(wxPathOnly(thisLibPath), audacityPathList);
+#endif
 #endif
 
    FileNames::AddUniquePathToPathList(FileNames::DataDir(), audacityPathList);

--- a/src/audacity_config.h.in
+++ b/src/audacity_config.h.in
@@ -13,6 +13,12 @@
 /* Define to 1 if you have the <alloca.h> header file. */
 #cmakedefine HAVE_ALLOCA_H 1
 
+/* Define to 1 if you have the <dlfcn.h> header file */
+#cmakedefine HAVE_DLFCN_H 1
+
+/* This is a quick hack to disable dladdr if it is not present in <dlfcn.h> */
+#cmakedefine DISABLE_DLADDR 1
+
 /* Define if GTK is available */
 #cmakedefine HAVE_GTK 1
 


### PR DESCRIPTION
On some Linux distros, modules go into a directory different from `/usr/lib/audacity`.

To handle this case, we try to find the path of the `lib-files` library on a disk and append this path to the search list.

Resolves: #5617

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
