### PR TITLE
Fix behavior of Scriptables II > GetInfo on Windows...

### DIFF
--- a/libraries/lib-menus/CommandContext.h
+++ b/libraries/lib-menus/CommandContext.h
@@ -36,7 +36,7 @@ struct TemporarySelection {
 
 class MENUS_API CommandContext {
 public:
-   struct TargetFactory : DefaultedGlobalHook< TargetFactory,
+   struct MENUS_API TargetFactory : DefaultedGlobalHook< TargetFactory,
       Callable::UniquePtrFactory<CommandOutputTargets>::Function
    >{};
 


### PR DESCRIPTION
... Apparently a Microsoft compiler bug, mistakenly optimizing away the construction of an object marked static but also inside an anonymous namespace.

Resolves: #5615

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
