### PR TITLE
Wave color nonsense

### DIFF
--- a/libraries/lib-effects/MixAndRender.h
+++ b/libraries/lib-effects/MixAndRender.h
@@ -32,7 +32,9 @@ class WaveTrackFactory;
  * If the start and end times passed are the same this is taken as meaning
  * no explicit time range to process, and the whole occupied length of the
  * input tracks is processed.
- * Channel group properties of the result are copied from the first input track.
+ *
+ * Channel group properties of the result are copied from the first input track,
+ * except that `newTrackName` is applied when more than one track is mixed.
  *
  * @param newTrackName used only when there is more than one input track (one
  * mono channel or a stereo pair); else the unique track's name is copied

--- a/libraries/lib-stretching-sequence/tests/TestWaveClipMaker.cpp
+++ b/libraries/lib-stretching-sequence/tests/TestWaveClipMaker.cpp
@@ -24,7 +24,7 @@ WaveClipHolder TestWaveClipMaker::ClipFilledWith(
 {
    const auto numSamples = values[0].size();
    const auto clip = std::make_shared<WaveClip>(
-      values.size(), mFactory, floatSample, mSampleRate, colourIndex);
+      values.size(), mFactory, floatSample, mSampleRate);
    // Is there any more convenient way of doing this ?
    clip->InsertSilence(0, 1. * numSamples / mSampleRate);
    for (auto i = 0u; i < values.size(); ++i)

--- a/libraries/lib-stretching-sequence/tests/TestWaveClipMaker.h
+++ b/libraries/lib-stretching-sequence/tests/TestWaveClipMaker.h
@@ -37,7 +37,6 @@ public:
       Operations operations = [](WaveClip&) {}) const;
 
 private:
-   static constexpr int colourIndex = 0;
    static constexpr bool copyCutLines = false;
 
    const int mSampleRate;

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -47,11 +47,10 @@ bool WaveClipListener::HandleXMLAttribute(
 
 WaveClip::WaveClip(size_t width,
    const SampleBlockFactoryPtr &factory,
-   sampleFormat format, int rate, int colourIndex)
+   sampleFormat format, int rate)
 {
    assert(width > 0);
    mRate = rate;
-   mColourIndex = colourIndex;
    mSequences.resize(width);
    for (auto &pSequence : mSequences)
       pSequence = std::make_unique<Sequence>(factory,
@@ -77,7 +76,6 @@ WaveClip::WaveClip(
    mTrimLeft = orig.mTrimLeft;
    mTrimRight = orig.mTrimRight;
    mRate = orig.mRate;
-   mColourIndex = orig.mColourIndex;
 
    // Deep copy of attachments
    Attachments &attachments = *this;
@@ -132,8 +130,6 @@ WaveClip::WaveClip(
       mTrimRight = orig.mTrimRight;
 
    mRate = orig.mRate;
-
-   mColourIndex = orig.mColourIndex;
 
    // Deep copy of attachments
    Attachments &attachments = *this;
@@ -583,12 +579,6 @@ bool WaveClip::HandleXMLTag(const std::string_view& tag, const AttributesList &a
             if(value.IsStringView())
                SetName(value.ToWString());
          }
-         else if (attr == "colorindex")
-         {
-            if (!value.TryGet(longValue))
-               return false;
-            SetColourIndex(longValue);
-         }
          else if (Attachments::FindIf(
             [&](WaveClipListener &listener){
                return listener.HandleXMLAttribute(attr, value); }
@@ -637,7 +627,7 @@ XMLTagHandler *WaveClip::HandleXMLChild(const std::string_view& tag)
             // Make only one channel now, but recursive deserialization
             // increases the width later
             1, pFirst->GetFactory(),
-            format, mRate, 0 /*colourindex*/));
+            format, mRate));
       return mCutLines.back().get();
    }
    else
@@ -660,7 +650,6 @@ void WaveClip::WriteXML(XMLWriter &xmlFile) const
    xmlFile.WriteAttr(wxT("rawAudioTempo"), mRawAudioTempo.value_or(0.), 8);
    xmlFile.WriteAttr(wxT("clipStretchRatio"), mClipStretchRatio, 8);
    xmlFile.WriteAttr(wxT("name"), mName);
-   xmlFile.WriteAttr(wxT("colorindex"), mColourIndex );
    Attachments::ForEach([&](const WaveClipListener &listener){
       listener.WriteXMLAttributes(xmlFile);
    });

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -95,6 +95,13 @@ struct WaveClipListener : WaveClipListenerBase {
    virtual ~WaveClipListener() = 0;
    virtual void MarkChanged() = 0;
    virtual void Invalidate() = 0;
+
+   // Default implementation does nothing
+   virtual void WriteXMLAttributes(XMLWriter &writer) const;
+
+   // Default implementation just returns false
+   virtual bool HandleXMLAttribute(
+      const std::string_view &attr, const XMLAttributeValueView &valueView);
 };
 
 struct CentShiftChange
@@ -121,7 +128,7 @@ private:
    WaveClip& operator= (const WaveClip&) = delete;
 
 public:
-   using Caches = Site<WaveClip, WaveClipListener, ClientData::DeepCopying>;
+   using Attachments = Site<WaveClip, WaveClipListener, ClientData::DeepCopying>;
 
    //! typical constructor
    /*!

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -8,13 +8,11 @@
   ?? Markus Meyer
 
 *******************************************************************/
-
 #ifndef __AUDACITY_WAVECLIP__
 #define __AUDACITY_WAVECLIP__
 
-
-
 #include "ClientData.h"
+#include "CRTPBase.h"
 #include "SampleFormat.h"
 #include "ClipInterface.h"
 #include "XMLTagHandler.h"
@@ -90,8 +88,10 @@ public:
    }
 };
 
-struct WAVE_TRACK_API WaveClipListener
-{
+struct WAVE_TRACK_API WaveClipListener;
+CRTP_BASE(WaveClipListenerBase, struct,
+   ClientData::Cloneable<WaveClipListener>);
+struct WaveClipListener : WaveClipListenerBase {
    virtual ~WaveClipListener() = 0;
    virtual void MarkChanged() = 0;
    virtual void Invalidate() = 0;
@@ -109,7 +109,8 @@ struct CentShiftChange
 class WAVE_TRACK_API WaveClip final :
     public ClipInterface,
     public XMLTagHandler,
-    public ClientData::Site<WaveClip, WaveClipListener>,
+    public ClientData::Site<
+      WaveClip, WaveClipListener, ClientData::DeepCopying>,
     public Observer::Publisher<CentShiftChange>
 {
 private:
@@ -120,7 +121,7 @@ private:
    WaveClip& operator= (const WaveClip&) = delete;
 
 public:
-   using Caches = Site< WaveClip, WaveClipListener >;
+   using Caches = Site<WaveClip, WaveClipListener, ClientData::DeepCopying>;
 
    //! typical constructor
    /*!

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -138,7 +138,7 @@ public:
     */
    WaveClip(size_t width,
       const SampleBlockFactoryPtr &factory, sampleFormat format,
-      int rate, int colourIndex);
+      int rate);
 
    //! essentially a copy constructor - but you must pass in the
    //! current sample block factory, because we might be copying
@@ -207,9 +207,6 @@ public:
    // Resample clip. This also will set the rate, but without changing
    // the length of the clip
    void Resample(int rate, BasicUI::ProgressDialog *progress = nullptr);
-
-   void SetColourIndex(int index) { mColourIndex = index; }
-   int GetColourIndex() const { return mColourIndex; }
 
    double GetSequenceStartTime() const noexcept;
    void SetSequenceStartTime(double startTime);
@@ -613,7 +610,6 @@ private:
 
    //! Sample rate of the raw audio, i.e., before stretching.
    int mRate;
-   int mColourIndex;
 
    /*!
     @invariant `mSequences.size() > 0`

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -355,9 +355,6 @@ public:
    static Holder Create(
       const SampleBlockFactoryPtr &pFactory, sampleFormat format, double rate);
 
-   //! Copied only in WaveTrack::Clone() !
-   WaveTrack(const WaveTrack &orig, ProtectedCreationArg&&, bool backup);
-
    //! The width of every WaveClip in this track; for now always 1
    size_t GetWidth() const;
 
@@ -385,6 +382,8 @@ public:
     */
    void Reinit(const WaveTrack &orig);
  private:
+   void CopyClips(const WaveTrack &orig, bool backup);
+
    using ConstIterPair = std::pair<
       WaveClipHolders::const_iterator, WaveClipHolders::const_iterator>;
    /*!
@@ -1302,7 +1301,7 @@ private:
 
    wxCriticalSection mFlushCriticalSection;
    wxCriticalSection mAppendCriticalSection;
-   double mLegacyProjectFileOffset;
+   double mLegacyProjectFileOffset{ 0 };
 };
 
 ENUMERATE_TRACK_TYPE(WaveTrack);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -153,8 +153,6 @@ public:
    constSamplePtr GetAppendBuffer() const;
    size_t GetAppendBufferLen() const;
 
-   int GetColourIndex() const;
-
    BlockArray *GetSequenceBlockArray();
 
    /*!
@@ -200,7 +198,7 @@ private:
 };
 
 struct WaveTrackMessage {
-   const WaveClipHolder pClip{};
+   WaveClipHolder pClip{};
    const enum Type {
       New, //!< newly created and empty
       Deserialized, //!< being read from project file
@@ -452,12 +450,6 @@ public:
    //! Takes gain and pan into account
    float GetChannelGain(int channel) const override;
 
-   int GetWaveColorIndex() const;
-   /*!
-    @pre `IsLeader()`
-    */
-   void SetWaveColorIndex(int colorIndex);
-
    sampleCount GetVisibleSampleCount() const;
 
    sampleFormat GetSampleFormat() const override;
@@ -474,7 +466,7 @@ public:
 
    TrackListHolder Cut(double t0, double t1) override;
 
-   //! Make another track copying format, rate, color, etc. but containing no
+   //! Make another track copying format, rate, etc. but containing no
    //! clips; and always with a unique channel
    /*!
     It is important to pass the correct factory (that for the project
@@ -488,7 +480,7 @@ public:
    Holder EmptyCopy(const SampleBlockFactoryPtr &pFactory = {},
       bool keepLink = true) const;
 
-   //! Make another channel group copying format, rate, color, etc. but
+   //! Make another channel group copying format, rate, etc. but
    //! containing no clips; with as many channels as in `this`
    /*!
     It is important to pass the correct factory (that for the project
@@ -888,9 +880,6 @@ public:
 
       void SetName(const wxString& name);
       const wxString& GetName() const;
-
-      void SetColorIndex(int index);
-      int GetColorIndex() const;
 
       void SetPlayStartTime(double time);
       double GetPlayStartTime() const;

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -284,13 +284,13 @@ bool WaveTrackUtilities::Reverse(WaveTrack &track,
    // track is not elsewhere assumed to be by time
    for (auto it = revClips.rbegin(), revEnd = revClips.rend();
          it != revEnd; ++it)
-      track.InsertInterval(*it);
+      track.InsertInterval(*it, false);
 
    if (!rValue)
       return false;
 
    for (auto &clip : otherClips)
-      track.InsertInterval(clip);
+      track.InsertInterval(clip, false);
 
    return rValue;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -740,6 +740,8 @@ list( APPEND SOURCES
       tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
       tracks/playabletrack/wavetrack/ui/WaveClipUIUtilities.cpp
       tracks/playabletrack/wavetrack/ui/WaveClipUIUtilities.h
+      tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
+      tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
       tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
       tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.h
       tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -792,7 +792,8 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
 
    bool appendRecord = !sequences.captureSequences.empty();
 
-   auto insertEmptyInterval = [&](WaveTrack &track, double t0) {
+   auto insertEmptyInterval =
+   [&](WaveTrack &track, double t0, bool placeholder) {
       wxString name;
       for (auto i = 1; ; ++i) {
          //i18n-hint a numerical suffix added to distinguish otherwise like-named clips when new record started
@@ -806,7 +807,9 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
       // So that the empty clip is not skipped for insertion:
       clip->SetIsPlaceholder(true);
       track.InsertInterval(clip, true);
-      clip->SetIsPlaceholder(false);
+      if (!placeholder)
+         clip->SetIsPlaceholder(false);
+      return clip;
    };
 
    auto &pendingTracks = PendingTracks::Get(project);
@@ -851,22 +854,17 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
                dst.Reinit(src);
             };
 
-            // Get a copy of the track to be appended, to be pushed into
-            // undo history only later.
-            const auto pending = static_cast<WaveTrack*>(
-               pendingTracks.RegisterPendingChangedTrack(updater, wt)
-            );
             // End of current track is before or at recording start time.
             // Less than or equal, not just less than, to ensure a clip boundary.
             // when append recording.
             //const auto pending = static_cast<WaveTrack*>(newTrack);
-            const auto lastClip = pending->GetRightmostClip();
+            const auto lastClip = wt->GetRightmostClip();
             // RoundedT0 to have a new clip created when punch-and-roll
             // recording with the cursor in the second half of the space
             // between two samples
             // (https://github.com/audacity/audacity/issues/5113#issuecomment-1705154108)
             const auto recordingStart =
-               std::round(t0 * pending->GetRate()) / pending->GetRate();
+               std::round(t0 * wt->GetRate()) / wt->GetRate();
             const auto recordingStartsBeforeTrackEnd =
                lastClip && recordingStart < lastClip->GetPlayEndTime();
             // Recording doesn't start before the beginning of the last clip
@@ -875,9 +873,21 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
             assert(
                !recordingStartsBeforeTrackEnd ||
                lastClip->WithinPlayRegion(recordingStart));
+            WaveTrack::IntervalHolder newClip{};
             if (!recordingStartsBeforeTrackEnd ||
                lastClip->HasPitchOrSpeed())
-               insertEmptyInterval(*pending, t0);
+               newClip = insertEmptyInterval(*wt, t0, true);
+            // Get a copy of the track to be appended, to be pushed into
+            // undo history only later.
+            const auto pending = static_cast<WaveTrack*>(
+               pendingTracks.RegisterPendingChangedTrack(updater, wt)
+            );
+            // Source clip was marked as placeholder so that it would not be
+            // skipped in clip copying.  Un-mark it and its copy now
+            if (newClip)
+               newClip->SetIsPlaceholder(false);
+            if (auto copiedClip = pending->NewestOrNewClip())
+               copiedClip->SetIsPlaceholder(false);
             transportSequences.captureSequences
                .push_back(pending->SharedPointer<WaveTrack>());
          }
@@ -949,7 +959,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
                newTrack->SetName(baseTrackName + wxT("_") + nameSuffix);
 
             //create a new clip with a proper name before recording is started
-            insertEmptyInterval(*newTrack, t0);
+            insertEmptyInterval(*newTrack, t0, false);
 
             transportSequences.captureSequences.push_back(
                std::static_pointer_cast<WaveTrack>(newTrack->shared_from_this())

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -805,7 +805,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
       auto clip = track.CreateWideClip(t0, name);
       // So that the empty clip is not skipped for insertion:
       clip->SetIsPlaceholder(true);
-      track.InsertInterval(clip);
+      track.InsertInterval(clip, true);
       clip->SetIsPlaceholder(false);
    };
 

--- a/src/commands/GetInfoCommand.cpp
+++ b/src/commands/GetInfoCommand.cpp
@@ -35,6 +35,7 @@ This class now lists
 #include "TrackFocus.h"
 #include "../TrackPanel.h"
 #include "WaveClip.h"
+#include "../tracks/playabletrack/wavetrack/ui/WaveformAppearance.h"
 #include "ViewInfo.h"
 #include "WaveTrack.h"
 #include "prefs/WaveformSettings.h"
@@ -521,14 +522,16 @@ bool GetInfoCommand::SendClips(const CommandContext &context)
    context.StartArray();
    for (auto t : tracks) {
       t->TypeSwitch([&](WaveTrack &waveTrack) {
-         WaveClipPointers ptrs(waveTrack.SortedClipArray());
-         for (WaveClip * pClip : ptrs) {
+         for (const auto pInterval : waveTrack.Intervals()) {
             context.StartStruct();
             context.AddItem((double)i, "track");
-            context.AddItem(pClip->GetPlayStartTime(), "start");
-            context.AddItem(pClip->GetPlayEndTime(), "end");
-            context.AddItem(pClip->GetColourIndex(), "color");
-            context.AddItem(pClip->GetName(), "name");
+            context.AddItem(pInterval->GetPlayStartTime(), "start");
+            context.AddItem(pInterval->GetPlayEndTime(), "end");
+            // Assuming same colors, look at only left channel
+            const auto &colors =
+               WaveColorAttachment::Get(**pInterval->Channels().begin());
+            context.AddItem(colors.GetColorIndex(), "color");
+            context.AddItem(pInterval->GetName(), "name");
             context.EndStruct();
          }
       });

--- a/src/commands/SetClipCommand.cpp
+++ b/src/commands/SetClipCommand.cpp
@@ -24,6 +24,7 @@
 #include "MenuRegistry.h"
 #include "../CommonCommandFlags.h"
 #include "LoadCommands.h"
+#include "../tracks/playabletrack/wavetrack/ui/WaveformAppearance.h"
 #include "WaveTrack.h"
 #include "SettingsVisitor.h"
 #include "ShuttleGui.h"
@@ -100,8 +101,10 @@ bool SetClipCommand::Apply(const CommandContext& context)
                interval->End() >= mContainsTime ))
             {
                // Inside this IF is where we actually apply the command
-               if( bHasColour )
-                  interval->SetColorIndex(mColour);
+               if (bHasColour) {
+                  for (const auto channel : interval->Channels())
+                     WaveColorAttachment::Get(*channel).SetColorIndex(mColour);
+               }
                // No validation of overlap yet.  We assume the user is sensible!
                if( bHasT0 )
                   interval->SetPlayStartTime(mT0);

--- a/src/commands/SetTrackInfoCommand.cpp
+++ b/src/commands/SetTrackInfoCommand.cpp
@@ -11,7 +11,7 @@
 
 \file SetTrackCommand.cpp
 \brief Definitions for SetTrackCommand built up from 
-SetChannelsBase, SetTrackBase, SetTrackStatusCommand, SetTrackAudioCommand and
+SetTrackBase, SetTrackStatusCommand, SetTrackAudioCommand and
 SetTrackVisualsCommand
 
 \class SetTrackBase
@@ -20,17 +20,17 @@ loops over selected tracks. Subclasses override ApplyInner() to change
 one track.
 
 \class SetTrackStatusCommand
-\brief A SetChannelsBase that sets name, selected and focus.
+\brief A SetTrackBase that sets name, selected and focus.
 
 \class SetTrackAudioCommand
-\brief A SetChannelsBase that sets pan, gain, mute and solo.
+\brief A SetTrackBase that sets pan, gain, mute and solo.
 
 \class SetTrackVisualsCommand
-\brief A SetChannelsBase that sets appearance of a track.
+\brief A SetTrackBase that sets appearance of a track.
 
 \class SetTrackCommand
-\brief A SetChannelsBase that combines SetTrackStatusCommand,
-SetTrackAudioCommand and SetTrackVisualsCommand.
+\brief A SetTrackBase that combines SetTrackStatusCommand,
+SetTrackAudioConmmand and SetTrackVisualsCommand.
 
 *//*******************************************************************/
 
@@ -44,13 +44,15 @@ SetTrackAudioCommand and SetTrackVisualsCommand.
 #include "Project.h"
 #include "TrackFocus.h"
 #include "../TrackPanel.h"
-#include "WaveTrack.h"
+#include "tracks/playabletrack/wavetrack/ui/WaveformAppearance.h"
 #include "../prefs/WaveformSettings.h"
+#include "WaveTrack.h"
 #include "../prefs/SpectrogramSettings.h"
 #include "SettingsVisitor.h"
 #include "ShuttleGui.h"
 #include "../tracks/playabletrack/wavetrack/ui/WaveChannelView.h"
 #include "../tracks/playabletrack/wavetrack/ui/WaveChannelViewConstants.h"
+#include "../tracks/playabletrack/wavetrack/ui/WaveformView.h"
 #include "CommandContext.h"
 
 bool SetTrackBase::Apply(const CommandContext & context)
@@ -330,7 +332,7 @@ bool SetTrackVisualsCommand::ApplyInner(
    static const double ZOOMLIMIT = 0.001f;
 
    if (bHasColour)
-      wt->SetWaveColorIndex(mColour);
+      WaveformAppearance::Get(*wt).SetColorIndex(mColour);
 
    if (bHasHeight)
       for (auto pChannel : t.Channels<WaveTrack>())

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -66,12 +66,9 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
       auto insertionPoint = * ++ tracks.Find(last);
 
       auto selectedCount = trackRange.size();
-      wxString firstName;
       int firstColour = -1;
-      if (selectedCount > 0) {
-         firstName = (*trackRange.begin())->GetName();
+      if (selectedCount > 0)
          firstColour = (*trackRange.begin())->GetWaveColorIndex();
-      }
       if (!toNewTrack)  {
          // Beware iterator invalidation!
          while (!trackRange.empty())
@@ -81,12 +78,9 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
 
       // Add new tracks
       const bool stereo = newTracks->NChannels() > 1;
+      const auto firstName = (*newTracks->begin())->GetName();
       tracks.Append(std::move(*newTracks));
       const auto pNewTrack = *tracks.Any<WaveTrack>().rbegin();
-
-      // If we're just rendering (not mixing), keep the track name the same
-      if (selectedCount == 1)
-         pNewTrack->SetName(firstName);
 
       // Bug 2218, remember more things...
       if (selectedCount >= 1) {
@@ -114,8 +108,8 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
       }
 
       // Smart history/undo message
-      if (selectedCount==1) {
-         auto msg = XO("Rendered all audio in track '%s'").Format( firstName );
+      if (selectedCount == 1) {
+         auto msg = XO("Rendered all audio in track '%s'").Format(firstName);
          /* i18n-hint: Convert the audio into a more usable form, so apply
           * panning and amplification and write to some external file.*/
          ProjectHistory::Get( project ).PushState(msg, XO("Render"));

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -66,9 +66,6 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
       auto insertionPoint = * ++ tracks.Find(last);
 
       auto selectedCount = trackRange.size();
-      int firstColour = -1;
-      if (selectedCount > 0)
-         firstColour = (*trackRange.begin())->GetWaveColorIndex();
       if (!toNewTrack)  {
          // Beware iterator invalidation!
          while (!trackRange.empty())
@@ -83,10 +80,8 @@ void DoMixAndRender(AudacityProject &project, bool toNewTrack)
       const auto pNewTrack = *tracks.Any<WaveTrack>().rbegin();
 
       // Bug 2218, remember more things...
-      if (selectedCount >= 1) {
+      if (selectedCount >= 1)
          pNewTrack->SetSelected(!toNewTrack);
-         pNewTrack->SetWaveColorIndex(firstColour);
-      }
 
       // Permute the tracks as needed
       // The new track appears after the old tracks (or where the old tracks

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -585,6 +585,12 @@ WaveClipSpectrumCache::~WaveClipSpectrumCache()
 {
 }
 
+std::unique_ptr<WaveClipListener> WaveClipSpectrumCache::Clone() const
+{
+   // Don't need to copy contents
+   return std::make_unique<WaveClipSpectrumCache>(mSpecCaches.size());
+}
+
 static WaveClip::Caches::RegisteredFactory sKeyS{ [](WaveClip &clip){
    return std::make_unique<WaveClipSpectrumCache>(clip.GetWidth());
 } };

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -591,7 +591,7 @@ std::unique_ptr<WaveClipListener> WaveClipSpectrumCache::Clone() const
    return std::make_unique<WaveClipSpectrumCache>(mSpecCaches.size());
 }
 
-static WaveClip::Caches::RegisteredFactory sKeyS{ [](WaveClip &clip){
+static WaveClip::Attachments::RegisteredFactory sKeyS{ [](WaveClip &clip){
    return std::make_unique<WaveClipSpectrumCache>(clip.GetWidth());
 } };
 
@@ -599,7 +599,7 @@ WaveClipSpectrumCache &
 WaveClipSpectrumCache::Get(const WaveChannelInterval &clip)
 {
    return const_cast<WaveClip&>(clip.GetWideClip()) // Consider it mutable data
-      .Caches::Get< WaveClipSpectrumCache >( sKeyS );
+      .Attachments::Get< WaveClipSpectrumCache >( sKeyS );
 }
 
 void WaveClipSpectrumCache::MarkChanged()

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
@@ -106,6 +106,8 @@ struct WaveClipSpectrumCache final : WaveClipListener
    explicit WaveClipSpectrumCache(size_t nChannels);
    ~WaveClipSpectrumCache() override;
 
+   std::unique_ptr<WaveClipListener> Clone() const override;
+
    // Cache of values to colour pixels of Spectrogram - used by TrackArtist
    std::vector<std::unique_ptr<SpecPxCache>> mSpecPxCaches;
    std::vector<std::unique_ptr<SpecCache>> mSpecCaches;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
@@ -10,6 +10,9 @@
  **********************************************************************/
 
 #include "WaveformAppearance.h"
+#include "WaveClip.h"
+
+
 static const AttachedTrackObjects::RegisteredFactory keyWA{
    [](Track &track) -> std::shared_ptr<WaveformAppearance> {
       if (const auto pTrack = dynamic_cast<WaveTrack *>(&track))
@@ -19,9 +22,14 @@ static const AttachedTrackObjects::RegisteredFactory keyWA{
    }
 };
 
+WaveformAppearance &WaveformAppearance::GetFromTrack(Track &track)
+{
+   return track.AttachedObjects::Get<WaveformAppearance>(keyWA);
+}
+
 WaveformAppearance &WaveformAppearance::Get(WaveChannel &channel)
 {
-   return channel.GetTrack().AttachedObjects::Get<WaveformAppearance>(keyWA);
+   return GetFromTrack(channel.GetTrack());
 }
 
 const WaveformAppearance &WaveformAppearance::Get(const WaveChannel &channel)
@@ -33,11 +41,125 @@ WaveformAppearance::WaveformAppearance(WaveTrack &track)
    : mwTrack{
       std::static_pointer_cast<WaveTrack>(track.shared_from_this()) }
 {
+   Subscribe(mwTrack.lock());
 }
 
 WaveformAppearance::~WaveformAppearance() = default;
 
+void WaveformAppearance::Subscribe(const std::shared_ptr<WaveTrack> &pTrack)
+{
+   if (pTrack)
+      mSubscription =
+      pTrack->Subscribe([this](const WaveTrackMessage &message){
+         switch (message.type) {
+         case WaveTrackMessage::New:
+         case WaveTrackMessage::Deserialized:
+            WaveColorAttachment::Get(*message.pClip).SetColorIndex(mColorIndex);
+         default:
+            break;
+         }
+      });
+   else
+      mSubscription.Reset();
+}
+
+void WaveformAppearance::CopyTo(Track &track) const
+{
+   auto &other = GetFromTrack(track);
+   other.mColorIndex = mColorIndex;
+}
+
 void WaveformAppearance::Reparent(const std::shared_ptr<Track> &parent)
 {
    mwTrack = std::dynamic_pointer_cast<WaveTrack>(parent);
+   Subscribe(mwTrack.lock());
+}
+
+static constexpr auto ColorIndex_attr = "colorindex";
+
+void WaveformAppearance::WriteXMLAttributes(XMLWriter &writer) const
+{
+   writer.WriteAttr(ColorIndex_attr, mColorIndex);
+}
+
+bool WaveformAppearance::HandleXMLAttribute(
+   const std::string_view& attr, const XMLAttributeValueView& valueView)
+{
+   long nValue;
+   if (attr == ColorIndex_attr && valueView.TryGet(nValue))
+      mColorIndex = nValue;
+   return false;
+}
+
+void WaveformAppearance::SetColorIndex(int colorIndex)
+{
+   mColorIndex = colorIndex;
+   const auto pTrack = mwTrack.lock();
+   if (!pTrack)
+      return;
+   for (const auto &pInterval : pTrack->Intervals())
+      for (const auto &pChannel : pInterval->Channels())
+         WaveColorAttachment::Get(*pChannel)
+            .SetColorIndex(colorIndex);
+}
+
+WaveColorAttachment::WaveColorAttachment()
+{
+}
+
+WaveColorAttachment::~WaveColorAttachment()
+{
+}
+
+std::unique_ptr<WaveClipListener> WaveColorAttachment::Clone() const
+{
+   auto result = std::make_unique<WaveColorAttachment>(*this);
+   return result;
+}
+
+static WaveClip::Attachments::RegisteredFactory keyWCA{ [](WaveClip &clip) {
+   return std::make_unique<WaveColorAttachment>();
+} };
+
+WaveColorAttachment &WaveColorAttachment::Get(WaveClip &clip)
+{
+   return clip.Attachments::Get<WaveColorAttachment>(keyWCA);
+}
+
+const WaveColorAttachment &WaveColorAttachment::Get(const WaveClip &clip)
+{
+   return const_cast<WaveClip&>(clip)
+      .Attachments::Get<WaveColorAttachment>(keyWCA);
+}
+
+WaveColorAttachment &WaveColorAttachment::Get(WaveChannelInterval &clip)
+{
+   return Get(clip.GetClip());
+}
+
+const WaveColorAttachment &WaveColorAttachment::Get(const WaveChannelInterval &clip)
+{
+   return Get(clip.GetClip());
+}
+
+void WaveColorAttachment::MarkChanged() {}
+
+void WaveColorAttachment::Invalidate() {}
+
+void WaveColorAttachment::WriteXMLAttributes(XMLWriter &writer) const
+{
+   writer.WriteAttr(ColorIndex_attr, mColorIndex);
+}
+
+bool WaveColorAttachment::HandleXMLAttribute(const std::string_view &attr,
+   const XMLAttributeValueView &valueView)
+{
+   long longValue;
+   if (attr == ColorIndex_attr) {
+      if (!valueView.TryGet(longValue))
+         return false;
+      SetColorIndex(longValue);
+      return true;
+   }
+   return false;
 }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
@@ -1,0 +1,43 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file WaveformApperance.cpp
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+
+#include "WaveformAppearance.h"
+static const AttachedTrackObjects::RegisteredFactory keyWA{
+   [](Track &track) -> std::shared_ptr<WaveformAppearance> {
+      if (const auto pTrack = dynamic_cast<WaveTrack *>(&track))
+         return std::make_shared<WaveformAppearance>(*pTrack);
+      else
+         return nullptr;
+   }
+};
+
+WaveformAppearance &WaveformAppearance::Get(WaveChannel &channel)
+{
+   return channel.GetTrack().AttachedObjects::Get<WaveformAppearance>(keyWA);
+}
+
+const WaveformAppearance &WaveformAppearance::Get(const WaveChannel &channel)
+{
+   return Get(const_cast<WaveChannel &>(channel));
+}
+
+WaveformAppearance::WaveformAppearance(WaveTrack &track)
+   : mwTrack{
+      std::static_pointer_cast<WaveTrack>(track.shared_from_this()) }
+{
+}
+
+WaveformAppearance::~WaveformAppearance() = default;
+
+void WaveformAppearance::Reparent(const std::shared_ptr<Track> &parent)
+{
+   mwTrack = std::dynamic_pointer_cast<WaveTrack>(parent);
+}

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
@@ -1,0 +1,34 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/**********************************************************************
+ 
+ Audacity: A Digital Audio Editor
+ 
+ @file WaveformApperance.h
+ 
+ Paul Licameli
+ 
+ **********************************************************************/
+#ifndef __AUDACITY_WAVEFORM_APPEARANCE__
+#define __AUDACITY_WAVEFORM_APPEARANCE__
+
+#include "WaveTrack.h"
+
+#include "Track.h"
+
+//! Persistent appearance settings that apply to all channels of a track
+class WaveformAppearance : public TrackAttachment
+{
+public:
+   static WaveformAppearance &Get(WaveChannel &channel);
+   static const WaveformAppearance &Get(const WaveChannel &channel);
+
+   explicit WaveformAppearance(WaveTrack &track);
+   ~WaveformAppearance() override;
+
+   void Reparent(const std::shared_ptr<Track> &parent) override;
+
+private:
+   std::weak_ptr<WaveTrack> mwTrack;
+};
+
+#endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
@@ -11,9 +11,8 @@
 #ifndef __AUDACITY_WAVEFORM_APPEARANCE__
 #define __AUDACITY_WAVEFORM_APPEARANCE__
 
+#include "WaveClip.h"
 #include "WaveTrack.h"
-
-#include "Track.h"
 
 //! Persistent appearance settings that apply to all channels of a track
 class WaveformAppearance : public TrackAttachment
@@ -25,10 +24,52 @@ public:
    explicit WaveformAppearance(WaveTrack &track);
    ~WaveformAppearance() override;
 
+   void CopyTo(Track &track) const override;
    void Reparent(const std::shared_ptr<Track> &parent) override;
+   void WriteXMLAttributes(XMLWriter &writer) const override;
+   bool HandleXMLAttribute(
+      const std::string_view& attr, const XMLAttributeValueView& valueView)
+   override;
+
+   int GetColorIndex() const { return mColorIndex; }
+   void SetColorIndex(int colorIndex);
 
 private:
+   static WaveformAppearance &GetFromTrack(Track &track);
+   void Subscribe(const std::shared_ptr<WaveTrack> &pTrack);
+
    std::weak_ptr<WaveTrack> mwTrack;
+   Observer::Subscription mSubscription;
+   int mColorIndex{ 0 };
+};
+
+struct WaveColorAttachment final : WaveClipListener
+{
+   explicit WaveColorAttachment();
+   ~WaveColorAttachment() override;
+
+   std::unique_ptr<WaveClipListener> Clone() const override;
+
+   static WaveColorAttachment &Get(WaveClip &clip);
+   static const WaveColorAttachment &Get(const WaveClip &clip);
+   static WaveColorAttachment &Get(WaveChannelInterval &clip);
+   static const WaveColorAttachment &Get(const WaveChannelInterval &clip);
+
+   void MarkChanged() override; // NOFAIL-GUARANTEE
+   void Invalidate() override; // NOFAIL-GUARANTEE
+
+   // Write color
+   void WriteXMLAttributes(XMLWriter &writer) const override;
+
+   // Read color
+   bool HandleXMLAttribute(const std::string_view &attr,
+      const XMLAttributeValueView &valueView) override;
+
+   int GetColorIndex() const { return mColorIndex; }
+   void SetColorIndex(int colorIndex) { mColorIndex = colorIndex; }
+
+private:
+   int mColorIndex{};
 };
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -280,6 +280,12 @@ WaveClipWaveformCache::~WaveClipWaveformCache()
 {
 }
 
+std::unique_ptr<WaveClipListener> WaveClipWaveformCache::Clone() const
+{
+   // Don't need to copy contents
+   return std::make_unique<WaveClipWaveformCache>(mWaveCaches.size());
+}
+
 static WaveClip::Caches::RegisteredFactory sKeyW{ [](WaveClip &clip) {
    return std::make_unique<WaveClipWaveformCache>(clip.GetWidth());
 } };

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -286,7 +286,7 @@ std::unique_ptr<WaveClipListener> WaveClipWaveformCache::Clone() const
    return std::make_unique<WaveClipWaveformCache>(mWaveCaches.size());
 }
 
-static WaveClip::Caches::RegisteredFactory sKeyW{ [](WaveClip &clip) {
+static WaveClip::Attachments::RegisteredFactory sKeyW{ [](WaveClip &clip) {
    return std::make_unique<WaveClipWaveformCache>(clip.GetWidth());
 } };
 
@@ -294,7 +294,7 @@ WaveClipWaveformCache &
 WaveClipWaveformCache::Get(const WaveChannelInterval &clip)
 {
    return const_cast<WaveClip&>(clip.GetWideClip()) // Consider it mutable data
-      .Caches::Get< WaveClipWaveformCache >( sKeyW );
+      .Attachments::Get< WaveClipWaveformCache >( sKeyW );
 }
 
 void WaveClipWaveformCache::MarkChanged()

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
@@ -21,6 +21,8 @@ struct WaveClipWaveformCache final : WaveClipListener
    explicit WaveClipWaveformCache(size_t nChannels);
    ~WaveClipWaveformCache() override;
 
+   std::unique_ptr<WaveClipListener> Clone() const override;
+
    // Cache of values for drawing the waveform
    std::vector<std::unique_ptr<WaveCache>> mWaveCaches;
    int mDirty { 0 };

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -1158,4 +1158,3 @@ PopupMenuTable::AttachedItem sAttachment{
          } ) )
 };
 }
-

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -11,6 +11,7 @@ Paul Licameli split from WaveChannelView.cpp
 
 #include "WaveformView.h"
 
+#include "WaveformAppearance.h"
 #include "WaveformCache.h"
 #include "WaveformVRulerControls.h"
 #include "WaveChannelView.h"
@@ -691,7 +692,7 @@ void DrawClipWaveform(TrackPanelDrawingContext &context,
    const float dBRange = settings.dBRange;
 
    dc.SetPen(*wxTRANSPARENT_PEN);
-   int iColorIndex = clip.GetColourIndex();
+   int iColorIndex = WaveColorAttachment::Get(clip).GetColorIndex();
    artist->SetColours( iColorIndex );
 
    // The bounds (controlled by vertical zooming; -1.0...1.0
@@ -1084,7 +1085,8 @@ BEGIN_POPUP_MENU(WaveColorMenuTable)
       auto &project = pData->project;
       bool unsafe = ProjectAudioIO::Get( project ).IsAudioActive();
 
-      menu.Check( id, id == me.IdOfWaveColor( track.GetWaveColorIndex() ) );
+      menu.Check(id, id == me.IdOfWaveColor(
+         WaveformAppearance::Get(track).GetColorIndex()));
       menu.Enable( id, !unsafe );
    };
 
@@ -1124,7 +1126,7 @@ void WaveColorMenuTable::OnWaveColorChange(wxCommandEvent & event)
 
    AudacityProject *const project = &mpData->project;
 
-   track.SetWaveColorIndex(newWaveColor);
+   WaveformAppearance::Get(track).SetColorIndex(newWaveColor);
 
    ProjectHistory::Get( *project )
       .PushState(XO("Changed '%s' to %s")


### PR DESCRIPTION
Resolves: #5652
Depends on #5828

QA:
- [x] Changing of wave track color with the track's menu
- [x] Mixing-and-rendering keeps color setting of the first mixed track;  then splitting to mono channels keeps same in both
- [ ] Recording or generating into a track uses the wave track color
- [x] Dragging clips from track to track preserves clip color, even if one track then has multiple colors
- [x] Mix-and-render names the new track as before (either "Mix" + number or keeping name of the sole track)
- [x] "Get Info" macro command for clips reports correct colors
- [x] "Set Clip" macro command, for colors
- [x] "Set Track Visuals" macro command, for colors
- [x] Cut/Copy then Paste of tracks (in or cross-project) preserves colors
- [x] Pasting or generating sound into an existing clip does not change its color
- [x] When a clip lengthens for sync lock with another track, its color does not change
- [x] Splitting a clip colors both as the original
- [x] Undo and Redo of all of the above
- [x] Waveform, Spectrogram panning and zooming are not slower
- [x] Persistency of wave track color settings, and of clip color
- [x] Opening in 3.4, a project that was saved in 3.5, works with correct colors; and oppositely

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
