### PR TITLE
Fix build with -Daudacity_use_lv2=off

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -50,7 +50,6 @@ set( LIBRARIES
    lib-vst3
    lib-snapping
    lib-vst
-   lib-lv2
    lib-ladspa
    lib-audio-unit
    lib-playable-track
@@ -61,6 +60,10 @@ set( LIBRARIES
    lib-menus
    lib-note-track
 )
+
+if ( ${_OPT}use_lv2 )
+   list( APPEND LIBRARIES lib-lv2)
+endif()
 
 if ( ${_OPT}has_networking )
    list( APPEND LIBRARIES lib-network-manager)


### PR DESCRIPTION
libraries/lib-lv2/LV2Utils.h:18:10: fatal error: lilv/lilv.h: No such file or directory
   18 | #include "lilv/lilv.h" // for lilv_free
      |          ^~~~~~~~~~~~~
compilation terminated.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior - I've successfully built without lv2 installed, and checked that without lv2 -Daudacity_use_lv2=system still fails on checking for lv2. I hope the CI here will show it builds with lv2 installed and selected.

