### PR TITLE
Hide some lesser known preferences

### DIFF
--- a/libraries/lib-playable-track/PlayableTrack.cpp
+++ b/libraries/lib-playable-track/PlayableTrack.cpp
@@ -189,9 +189,9 @@ EnumSetting<SoloBehavior> TracksBehaviorsSolo{
    wxT("/GUI/Solo"),
    {
       ByColumns,
-      { XO("Multi-track"), XO("Simple"),  XO("None") },
-      { wxT("Multi"),     wxT("Simple"), wxT("None") }
+      { XO("Multi-track"), XO("Simple")},
+      { wxT("Multi"),     wxT("Simple")}
    },
-   0, // "Simple"
-   { SoloBehaviorMulti, SoloBehaviorSimple, SoloBehaviorNone },
+   0, // "Multi-track"
+   { SoloBehaviorMulti, SoloBehaviorSimple },
 };

--- a/libraries/lib-playable-track/PlayableTrack.h
+++ b/libraries/lib-playable-track/PlayableTrack.h
@@ -68,8 +68,7 @@ ENUMERATE_TRACK_TYPE(PlayableTrack);
 
 enum SoloBehavior {
    SoloBehaviorSimple,
-   SoloBehaviorMulti,
-   SoloBehaviorNone,
+   SoloBehaviorMulti
 };
 
 extern PLAYABLE_TRACK_API EnumSetting<SoloBehavior> TracksBehaviorsSolo;

--- a/modules/mod-cl/ExportCL.cpp
+++ b/modules/mod-cl/ExportCL.cpp
@@ -462,7 +462,6 @@ public:
 
    std::unique_ptr<ExportProcessor> CreateProcessor(int format) const override;
 
-   bool CheckFileName(wxFileName &filename, int format) const override;
 };
 
 int ExportCL::GetFormatCount() const
@@ -855,21 +854,6 @@ std::vector<char> CLExportProcessor::GetMetaChunk(const Tags *tags)
 #endif
 
    return buffer;
-}
-
-bool ExportCL::CheckFileName(wxFileName &filename, int WXUNUSED(format)) const
-{
-   ExtendPath ep;
-
-   if (filename.GetExt().empty()) {
-      if (ShowWarningDialog(NULL,
-                            wxT("MissingExtension"),
-                            XO("You've specified a file name without an extension. Are you sure?"),
-                            true) == wxID_CANCEL) {
-         return false;
-      }
-   }
-   return true;
 }
 
 static ExportPluginRegistry::RegisteredPlugin sRegisteredPlugin{ "CommandLine",

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -741,8 +741,7 @@ public:
       // May come here when recording is in progress, so hit tests are turned
       // off.
       TranslatableString tooltip;
-      if (mParent->mTimelineToolTip)
-         tooltip = XO("Timeline actions disabled during recording");
+      tooltip = XO("Timeline actions disabled during recording");
 
       static wxCursor cursor{ wxCURSOR_DEFAULT };
       return {
@@ -1328,7 +1327,6 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
 
    mIsRecording = false;
 
-   mTimelineToolTip = !!gPrefs->Read(wxT("/QuickPlay/ToolTips"), 1L);
    mPlayRegionDragsSelection = (gPrefs->Read(wxT("/QuickPlay/DragSelection"), 0L) == 1)? true : false; 
 
 #if wxUSE_TOOLTIPS
@@ -1377,8 +1375,6 @@ void AdornedRulerPanel::UpdatePrefs()
 
    // Update button texts for language change
    UpdateButtonStates();
-
-   mTimelineToolTip = !!gPrefs->Read(wxT("/QuickPlay/ToolTips"), 1L);
 
 #ifdef EXPERIMENTAL_SCROLLING_LIMITS
 #ifdef EXPERIMENTAL_TWO_TONE_TIME_RULER
@@ -1949,7 +1945,7 @@ auto AdornedRulerPanel::ScrubbingHandle::Preview(
       message,
       {},
       // Tooltip is same as status message, or blank
-      ((mParent && mParent->mTimelineToolTip) ? message : TranslatableString{}),
+      (mParent ? message : TranslatableString{}),
    };
 }
 
@@ -1961,7 +1957,7 @@ auto AdornedRulerPanel::QPHandle::Preview(
    mParent->SetNumGuides(1);
    TranslatableString tooltip;
    #if 0
-   if (mParent && mParent->mTimelineToolTip) {
+   if (mParent) {
       if (!mParent->mQuickPlayEnabled)
          tooltip = XO("Quick-Play disabled");
       else
@@ -2384,16 +2380,6 @@ void AdornedRulerPanel::OnSyncSelToQuickPlay(wxCommandEvent&)
    gPrefs->Write(wxT("/QuickPlay/DragSelection"), mPlayRegionDragsSelection);
    gPrefs->Flush();
 }
-
-#if 0
-void AdornedRulerPanel::OnTimelineToolTips(wxCommandEvent&)
-{
-   mTimelineToolTip = (mTimelineToolTip)? false : true;
-   gPrefs->Write(wxT("/QuickPlay/ToolTips"), mTimelineToolTip);
-   gPrefs->Flush();
-}
-#endif
-
 
 void AdornedRulerPanel::OnAutoScroll(wxCommandEvent&)
 {

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -297,17 +297,15 @@ MixerTrackCluster::MixerTrackCluster(wxWindow* parent,
                   *(mMixerBoard->mImageSoloDisabled),
                   true); // toggle button
    mToggleButton_Solo->SetName(_("Solo"));
-   bool bSoloNone = (TracksBehaviorsSolo.ReadEnum() == SoloBehaviorNone);
-   mToggleButton_Solo->Show(!bSoloNone);
 
 
    // meter
-   ctrlPos.y += (bSoloNone ? 0 : MUTE_SOLO_HEIGHT) + kDoubleInset;
+   ctrlPos.y += MUTE_SOLO_HEIGHT + kDoubleInset;
    const int nMeterHeight =
       nGainSliderHeight -
       (MUSICAL_INSTRUMENT_HEIGHT_AND_WIDTH + kDoubleInset) -
       (PAN_HEIGHT + kDoubleInset) -
-      (MUTE_SOLO_HEIGHT + (bSoloNone ? 0 : MUTE_SOLO_HEIGHT) + kDoubleInset);
+      (MUTE_SOLO_HEIGHT + MUTE_SOLO_HEIGHT + kDoubleInset);
    ctrlSize.Set(kRightSideStackWidth, nMeterHeight);
 
    mMeter.Release();
@@ -396,14 +394,10 @@ void MixerTrackCluster::HandleResize() // For wxSizeEvents, update gain slider a
    mSlider_Velocity->SetSize(-1, nGainSliderHeight);
 #endif
 
-   bool bSoloNone = TracksBehaviorsSolo.ReadEnum() == SoloBehaviorNone;
-
-   mToggleButton_Solo->Show(!bSoloNone);
-
    const int nRequiredHeightAboveMeter =
       MUSICAL_INSTRUMENT_HEIGHT_AND_WIDTH + kDoubleInset +
       PAN_HEIGHT + kDoubleInset +
-      MUTE_SOLO_HEIGHT + (bSoloNone ? 0 : MUTE_SOLO_HEIGHT) + kDoubleInset;
+      MUTE_SOLO_HEIGHT + MUTE_SOLO_HEIGHT + kDoubleInset;
    const int nMeterY =
       kDoubleInset + // margin at top
       TRACK_NAME_HEIGHT + kDoubleInset +

--- a/src/TrackUtilities.cpp
+++ b/src/TrackUtilities.cpp
@@ -85,7 +85,7 @@ void DoTrackMute(AudacityProject &project, Track *t, bool exclusive)
       pt->SetMute(!wasMute);
 
       if (auto value = TracksBehaviorsSolo.ReadEnum();
-         value == SoloBehaviorSimple || value == SoloBehaviorNone)
+         value == SoloBehaviorSimple)
       {
          // We also set a solo indicator if we have just one track / stereo pair playing.
          // in a group of more than one playable tracks.

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -696,12 +696,11 @@ static void MuteTracks(const CommandContext &context, bool mute, bool selected)
 
    const auto solo = TracksBehaviorsSolo.ReadEnum();
    const auto soloSimple = (solo == SoloBehaviorSimple);
-   const auto soloNone = (solo == SoloBehaviorNone);
 
    auto iter = selected ? tracks.Selected<PlayableTrack>() : tracks.Any<PlayableTrack>();
    for (auto pt : iter) {
       pt->SetMute(mute);
-      if (soloSimple || soloNone)
+      if (soloSimple)
          pt->SetSolo(false);
    }
 

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -317,7 +317,6 @@ auto ViewMenu()
    Menu( wxT("View"), XXO("&View"),
       Section( "Basic",
          Menu( wxT("Zoom"), XXO("&Zoom"),
-            Section( "",
                Command( wxT("ZoomIn"), XXO("Zoom &In"), OnZoomIn,
                   ZoomInAvailableFlag(), wxT("Ctrl+1") ),
                Command( wxT("ZoomNormal"), XXO("Zoom &Normal"), OnZoomNormal,
@@ -328,12 +327,6 @@ auto ViewMenu()
                   TimeSelectedFlag(), wxT("Ctrl+E") ),
                Command( wxT("ZoomToggle"), XXO("Zoom &Toggle"), OnZoomToggle,
                   TracksExistFlag(), wxT("Shift+Z") )
-            ),
-            Section( "",
-               Command( wxT("AdvancedVZoom"), XXO("Advanced &Vertical Zooming"),
-                  OnAdvancedVZoom, AlwaysEnabledFlag,
-                  Options{}.CheckTest( wxT("/GUI/VerticalZooming"), false ) )
-            )
          ),
 
          Menu( wxT("TrackSize"), XXO("T&rack Size"),

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -193,17 +193,6 @@ void GUIPrefs::PopulateOrExchange(ShuttleGui & S)
    }
    S.EndStatic();
 
-   S.StartStatic(XO("Timeline"));
-   {
-      S.TieCheckBox(XXO("Show Timeline Tooltips"),
-                    {wxT("/QuickPlay/ToolTips"),
-                     true});
-      S.TieCheckBox(XXO("Show Scrub Ruler"),
-                    {wxT("/QuickPlay/ScrubbingEnabled"),
-                     false});
-   }
-   S.EndStatic();
-
    S.EndScroller();
 }
 

--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -98,9 +98,6 @@ void TracksBehaviorsPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(XXO("Enable cut &lines"),
                     {wxT("/GUI/EnableCutLines"),
                      false});
-      S.TieCheckBox(XXO("Enable &dragging selection edges"),
-                    {wxT("/GUI/AdjustSelectionEdges"),
-                     true});
       S.TieCheckBox(XXO("Editing a clip can &move other clips"),
             EditClipsCanMove);
       S.TieCheckBox(
@@ -110,17 +107,10 @@ void TracksBehaviorsPrefs::PopulateOrExchange(ShuttleGui & S)
                     {wxT("/GUI/CircularTrackNavigation"),
                      false});
       S.TieCheckBox(XXO("&Type to create a label"),
-                    {wxT("/GUI/TypeToCreateLabel"),
+                     {wxT("/GUI/TypeToCreateLabel"),
                      false});
       S.TieCheckBox(XXO("Use dialog for the &name of a new label"),
                     {wxT("/GUI/DialogForNameNewLabel"),
-                     false});
-#ifdef EXPERIMENTAL_SCROLLING_LIMITS
-      S.TieCheckBox(XXO("Enable scrolling left of &zero"),
-                    ScrollingPreference);
-#endif
-      S.TieCheckBox(XXO("Advanced &vertical zooming"),
-                    {wxT("/GUI/VerticalZooming"),
                      false});
 
       S.AddSpace(10);

--- a/src/prefs/WarningsPrefs.cpp
+++ b/src/prefs/WarningsPrefs.cpp
@@ -85,9 +85,6 @@ void WarningsPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(XXO("Mixing down on export (&Custom FFmpeg or external program)"),
                     {wxT("/Warnings/MixUnknownChannels"),
                      true});
-      S.TieCheckBox(XXO("Missing file &name extension during export"),
-                    {wxT("/Warnings/MissingExtension"),
-                     true});
    }
    S.EndStatic();
    S.EndScroller();

--- a/src/prefs/WarningsPrefs.cpp
+++ b/src/prefs/WarningsPrefs.cpp
@@ -76,15 +76,6 @@ void WarningsPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(XXO("Saving &empty project"),
                     {wxT("/GUI/EmptyCanBeDirty"),
                      true});
-      S.TieCheckBox(XXO("Mixing down to &mono during export"),
-                    {wxT("/Warnings/MixMono"),
-                     true});
-      S.TieCheckBox(XXO("Mixing down to &stereo during export"),
-                    {wxT("/Warnings/MixStereo"),
-                     true});
-      S.TieCheckBox(XXO("Mixing down on export (&Custom FFmpeg or external program)"),
-                    {wxT("/Warnings/MixUnknownChannels"),
-                     true});
    }
    S.EndStatic();
    S.EndScroller();

--- a/src/toolbars/ScrubbingToolBar.cpp
+++ b/src/toolbars/ScrubbingToolBar.cpp
@@ -298,12 +298,3 @@ static RegisteredToolbarFactory factory{
    []( AudacityProject &project ){
       return ToolBar::Holder{ safenew ScrubbingToolBar{ project } }; }
 };
-
-namespace {
-AttachedToolBarMenuItem sAttachment{
-   /* i18n-hint: Clicking this menu item shows the toolbar
-      that enables Scrub or Seek playback and Scrub Ruler */
-   ScrubbingToolBar::ID(), wxT("ShowScrubbingTB"), XXO("Scru&b Toolbar")
-};
-}
-

--- a/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
@@ -63,7 +63,7 @@ UIHandlePtr MuteButtonHandle::HitTest
    wxRect buttonRect;
    if ( pTrack )
       PlayableTrackControls::GetMuteSoloRect(rect, buttonRect, false,
-         (TracksBehaviorsSolo.ReadEnum() != SoloBehaviorNone), pTrack.get());
+          pTrack.get());
    if ( CommonTrackInfo::HideTopItem( rect, buttonRect ) )
       return {};
 
@@ -119,7 +119,7 @@ UIHandlePtr SoloButtonHandle::HitTest
    wxRect buttonRect;
    if ( pTrack )
       PlayableTrackControls::GetMuteSoloRect(rect, buttonRect, true,
-         (TracksBehaviorsSolo.ReadEnum() != SoloBehaviorNone), pTrack.get());
+          pTrack.get());
 
    if ( CommonTrackInfo::HideTopItem( rect, buttonRect ) )
       return {};

--- a/src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackControls.cpp
@@ -157,13 +157,10 @@ void MuteAndSoloDrawFunction
   const wxRect &rect, const Track *pTrack )
 {
    auto dc = &context.dc;
-   bool bHasSoloButton = (TracksBehaviorsSolo.ReadEnum() != SoloBehaviorNone);
 
    wxRect bev = rect;
-   if ( bHasSoloButton )
-      GetNarrowMuteHorizontalBounds( rect, bev );
-   else
-      GetWideMuteSoloHorizontalBounds( rect, bev );
+
+   GetNarrowMuteHorizontalBounds( rect, bev );
    {
       auto target = dynamic_cast<MuteButtonHandle*>( context.target.get() );
       bool hit = target && target->GetTrack().get() == pTrack;
@@ -171,9 +168,6 @@ void MuteAndSoloDrawFunction
       bool down = captured && bev.Contains( context.lastState.GetPosition());
       MuteOrSoloDrawFunction( dc, bev, pTrack, down, captured, false, hit );
    }
-
-   if( !bHasSoloButton )
-      return;
 
    GetNarrowSoloHorizontalBounds( rect, bev );
    {
@@ -205,7 +199,7 @@ void EffectsDrawFunction
 }
 
 void PlayableTrackControls::GetMuteSoloRect
-(const wxRect & rect, wxRect & dest, bool solo, bool bHasSoloButton,
+(const wxRect & rect, wxRect & dest, bool solo,
  const Track *pTrack)
 {
    auto &trackControl = static_cast<const CommonTrackControls&>(
@@ -218,7 +212,7 @@ void PlayableTrackControls::GetMuteSoloRect
    int ySolo = resultsS.first;
 
    bool bSameRow = ( yMute == ySolo );
-   bool bNarrow = bSameRow && bHasSoloButton;
+   bool bNarrow = bSameRow;
 
    if( bNarrow )
    {

--- a/src/tracks/playabletrack/ui/PlayableTrackControls.h
+++ b/src/tracks/playabletrack/ui/PlayableTrackControls.h
@@ -25,7 +25,7 @@ public:
    static const TCPLines& StaticWaveTCPLines();
 
    static void GetMuteSoloRect(
-      const wxRect & rect, wxRect & dest, bool solo, bool bHasSoloButton,
+      const wxRect & rect, wxRect & dest, bool solo,
       const Track *pTrack);
 
    static void GetEffectsRect(


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5714
Resolves: https://github.com/audacity/audacity/issues/4341

This PR removes or hides some preferences which I expect to not be very relevant these days. 

* Removes the "no solo" button case and removes supporting code. 
* Hides "Enable dragging selection edges". I don't expect there to be a major use case where you *don't* want to be able to adjust an existing selection and only make new ones.
* Hides "Advanced Vertical Zooming". See #5685 for a new implementation
* Hides "Enable scrolling left of zero". This Resolves: https://github.com/audacity/audacity/issues/4185 Resolves: https://github.com/audacity/audacity/issues/3511 Resolves: https://github.com/audacity/audacity/issues/4440 Resolves: https://github.com/audacity/audacity/issues/5666
* Hides scrub toolbar and scrub bar. Resolves: https://github.com/audacity/audacity/issues/5683 
* removes timeline tooltip option. Resolves: https://github.com/audacity/audacity/issues/2880
* Removes leftover warnings for mixing down to mono/stereo which don't do anything anymore

