### PR TITLE
Fix bug in Noise Gate

### DIFF
--- a/plug-ins/noisegate.ny
+++ b/plug-ins/noisegate.ny
@@ -102,7 +102,7 @@ $control DECAY (_ "Decay (ms)") float "" 100 10 4000
       (let ((peakL (peak (aref sig 0) test-len))
             (peakR (peak (aref sig 1) test-len)))
         (linear-to-db (max peakL peakR)))
-      (linear-to-db test-len)))
+      (linear-to-db (peak sig test-len))))
 
 
 ;;; Utility functions


### PR DESCRIPTION
Typo in peak-db() causing incorrect level measurement for mono tracks.

Resolves: Incorrect level measurement when analyzing mono track noise.

*Fixes typo*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
