### PR TITLE
Symmetric vertical zoom

### DIFF
--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -206,18 +206,6 @@ void OnZoomFitV(const CommandContext &context)
    ProjectHistory::Get( project ).ModifyState(true);
 }
 
-void OnAdvancedVZoom(const CommandContext &context)
-{
-   auto &project = context.project;
-   auto &commandManager = CommandManager::Get( project );
-
-   bool checked = !gPrefs->Read(wxT("/GUI/VerticalZooming"), 0L);
-   gPrefs->Write(wxT("/GUI/VerticalZooming"), checked);
-   gPrefs->Flush();
-   commandManager.Check(wxT("AdvancedVZoom"), checked);
-   MenuCreator::RebuildAllMenuBars();
-}
-
 void OnCollapseAllTracks(const CommandContext &context)
 {
    auto &project = context.project;
@@ -317,7 +305,6 @@ auto ViewMenu()
    Menu( wxT("View"), XXO("&View"),
       Section( "Basic",
          Menu( wxT("Zoom"), XXO("&Zoom"),
-            Section( "",
                Command( wxT("ZoomIn"), XXO("Zoom &In"), OnZoomIn,
                   ZoomInAvailableFlag(), wxT("Ctrl+1") ),
                Command( wxT("ZoomNormal"), XXO("Zoom &Normal"), OnZoomNormal,
@@ -328,12 +315,6 @@ auto ViewMenu()
                   TimeSelectedFlag(), wxT("Ctrl+E") ),
                Command( wxT("ZoomToggle"), XXO("Zoom &Toggle"), OnZoomToggle,
                   TracksExistFlag(), wxT("Shift+Z") )
-            ),
-            Section( "",
-               Command( wxT("AdvancedVZoom"), XXO("Advanced &Vertical Zooming"),
-                  OnAdvancedVZoom, AlwaysEnabledFlag,
-                  Options{}.CheckTest( wxT("/GUI/VerticalZooming"), false ) )
-            )
          ),
 
          Menu( wxT("TrackSize"), XXO("T&rack Size"),

--- a/src/prefs/TracksBehaviorsPrefs.cpp
+++ b/src/prefs/TracksBehaviorsPrefs.cpp
@@ -119,9 +119,6 @@ void TracksBehaviorsPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(XXO("Enable scrolling left of &zero"),
                     ScrollingPreference);
 #endif
-      S.TieCheckBox(XXO("Advanced &vertical zooming"),
-                    {wxT("/GUI/VerticalZooming"),
-                     false});
 
       S.AddSpace(10);
 

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -182,8 +182,6 @@ protected:
 // Note that these can be with or without spectrum view which
 // adds a constant.
 //const int kZoom1to1 = 1;
-//const int kZoomTimes2 = 2;
-//const int kZoomDiv2 = 3;
 //const int kZoomHalfWave = 4;
 //const int kZoomInByDrag = 5;
       kZoomIn = 6,
@@ -198,8 +196,6 @@ protected:
    void OnZoom( int iZoomCode );
 // void OnZoomFitVertical(wxCommandEvent&){ OnZoom( kZoom1to1 );};
    void OnZoomReset(wxCommandEvent&){ OnZoom( kZoomReset );};
-// void OnZoomDiv2Vertical(wxCommandEvent&){ OnZoom( kZoomDiv2 );};
-// void OnZoomTimes2Vertical(wxCommandEvent&){ OnZoom( kZoomTimes2 );};
 // void OnZoomHalfWave(wxCommandEvent&){ OnZoom( kZoomHalfWave );};
    void OnZoomInVertical(wxCommandEvent&){ OnZoom( kZoomIn );};
    void OnZoomOutVertical(wxCommandEvent&){ OnZoom( kZoomOut );};

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
@@ -42,9 +42,7 @@ namespace
    bool IsDragZooming(int zoomStart, int zoomEnd)
    {
       const int DragThreshold = 3;// Anything over 3 pixels is a drag, else a click.
-      bool bVZoom;
-      gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
-      return bVZoom && (abs(zoomEnd - zoomStart) > DragThreshold);
+      return abs(zoomEnd - zoomStart) > DragThreshold;
    }
 
 }
@@ -72,17 +70,12 @@ HitTestPreview NoteTrackVZoomHandle::HitPreview(const wxMouseState &state)
       ::MakeCursor(wxCURSOR_MAGNIFIER, ZoomOutCursorXpm, 19, 15);
    static  wxCursor arrowCursor{ wxCURSOR_ARROW };
 
-   bool bVZoom;
-   gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
-   bVZoom &= !state.RightIsDown();
-   const auto message = bVZoom ? 
-      XO("Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region.") :
-      XO("Right-click for menu.");
+   const auto message = 
+      XO("Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region.");
 
    return {
       message,
-      bVZoom ? (state.ShiftDown() ? &*zoomOutCursor : &*zoomInCursor) : &arrowCursor
-      // , message
+      state.ShiftDown() ? &*zoomOutCursor : &*zoomInCursor
    };
 }
 
@@ -256,8 +249,7 @@ void NoteTrackVRulerMenuTable::OnZoom( int iZoomCode ){
 BEGIN_POPUP_MENU(NoteTrackVRulerMenuTable)
 
    // Accelerators only if zooming enabled.
-   bool bVZoom;
-   gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
+   bool bVZoom = true;
 
    BeginSection( "Zoom" );
       BeginSection( "Basic" );
@@ -320,10 +312,7 @@ UIHandle::Result NoteTrackVZoomHandle::Release
       return data.result;
    }
 
-   bool bVZoom;
-   gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
-   bVZoom &= event.GetId() != kCaptureLostEventId;
-   if( !bVZoom )
+   if( event.GetId() == kCaptureLostEventId )
       return RefreshAll;
 
    NoteTrackDisplayData data{ *pTrack, evt.rect };

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
@@ -297,21 +297,10 @@ EndSection();
 
 
 BeginSection( "Zoom" );
-   // Accelerators only if zooming enabled.
-   bool bVZoom;
-   gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
-
-   AppendItem( "Reset", OnZoomResetID,         XXO("Zoom Reset"),
-              POPUP_MENU_FN( OnZoomReset ) );
-   AppendItem( "Fit", OnZoomFitVerticalID,
-      MakeLabel( XXO("Zoom to Fit"), bVZoom, XXO("Shift-Right-Click") ),
-      POPUP_MENU_FN( OnZoomFitVertical ) );
-   AppendItem( "In", OnZoomInVerticalID,
-      MakeLabel( XXO("Zoom In"), bVZoom, XXO("Left-Click/Left-Drag") ),
-      POPUP_MENU_FN( OnZoomInVertical ) );
-   AppendItem( "Out", OnZoomOutVerticalID,
-      MakeLabel( XXO("Zoom Out"), bVZoom, XXO("Shift-Left-Click") ),
-      POPUP_MENU_FN( OnZoomOutVertical ) );
+   AppendItem( "Reset", OnZoomResetID, XXO("Zoom Reset"),POPUP_MENU_FN( OnZoomReset ) );
+   AppendItem( "Fit", OnZoomFitVerticalID, XXO("Zoom to Fit"), POPUP_MENU_FN( OnZoomFitVertical ) );
+   AppendItem( "In", OnZoomInVerticalID, XXO("Zoom In"),POPUP_MENU_FN( OnZoomInVertical ) );
+   AppendItem( "Out", OnZoomOutVerticalID, XXO("Zoom Out"), POPUP_MENU_FN( OnZoomOutVertical ) );
 EndSection();
 
 END_POPUP_MENU()

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
@@ -60,13 +60,13 @@ UIHandle::Result SpectrumVZoomHandle::Drag
    auto pTrack = TrackList::Get( *pProject ).Lock(mpTrack);
    if (!pTrack)
       return Cancelled;
-   return WaveChannelVZoomHandle::DoDrag(evt, pProject, mZoomStart, mZoomEnd);
+   return WaveChannelVZoomHandle::DoDrag(evt, pProject, mZoomStart, mZoomEnd, true);
 }
 
 HitTestPreview SpectrumVZoomHandle::Preview
 (const TrackPanelMouseState &st, AudacityProject *)
 {
-   return WaveChannelVZoomHandle::HitPreview(st.state);
+   return WaveChannelVZoomHandle::HitPreview(true);
 }
 
 UIHandle::Result SpectrumVZoomHandle::Release
@@ -94,7 +94,7 @@ void SpectrumVZoomHandle::Draw(
    if (!mpTrack.lock()) //? TrackList::Lock()
       return;
    return WaveChannelVZoomHandle::DoDraw(
-      context, rect, iPass, mZoomStart, mZoomEnd );
+      context, rect, iPass, mZoomStart, mZoomEnd, true );
 }
 
 wxRect SpectrumVZoomHandle::DrawingArea(
@@ -133,8 +133,7 @@ void SpectrumVZoomHandle::DoZoom(
    const bool spectrumLinear =
       (SpectrogramSettings::Get(*pTrack).scaleType == SpectrogramSettings::stLinear);
 
-
-   bool bDragZoom = WaveChannelVZoomHandle::IsDragZooming(zoomStart, zoomEnd);
+   bool bDragZoom = WaveChannelVZoomHandle::IsDragZooming(zoomStart, zoomEnd, true);
    // Add 100 if spectral to separate the kinds of zoom.
    const int kSpectral = 100;
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
@@ -177,8 +177,6 @@ void SpectrumVZoomHandle::DoZoom(
       }
       break;
    case kZoom1to1:
-   case kZoomDiv2:
-   case kZoomTimes2:
    case kZoomHalfWave:
       {
          // Zoom out full
@@ -272,34 +270,30 @@ PopupMenuTable &SpectrumVRulerMenuTable::Instance()
 }
 
 BEGIN_POPUP_MENU(SpectrumVRulerMenuTable)
-
-BeginSection( "Scales" );
-   {
-      const auto & names = SpectrogramSettings::GetScaleNames();
-      for (int ii = 0, nn = names.size(); ii < nn; ++ii) {
-         AppendRadioItem( names[ii].Internal(),
-            OnFirstSpectrumScaleID + ii, names[ii].Msgid(),
-            POPUP_MENU_FN( OnSpectrumScaleType ),
-            []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-               WaveTrack *const wt =
-                  static_cast<SpectrumVRulerMenuTable&>( handler )
-                     .mpData->pTrack;
-               if ( id ==
-                  OnFirstSpectrumScaleID +
-                      static_cast<int>(SpectrogramSettings::Get(*wt).scaleType))
-                  menu.Check(id, true);
-            }
-         );
-      }
+   //Generate scales (Mel, Logarithmic, etc)
+   const auto & names = SpectrogramSettings::GetScaleNames();
+   for (int ii = 0, nn = names.size(); ii < nn; ++ii) {
+      AppendRadioItem( names[ii].Internal(),
+         OnFirstSpectrumScaleID + ii, names[ii].Msgid(),
+         POPUP_MENU_FN( OnSpectrumScaleType ),
+         []( PopupMenuHandler &handler, wxMenu &menu, int id ){
+            WaveTrack *const wt =
+               static_cast<SpectrumVRulerMenuTable&>( handler )
+                  .mpData->pTrack;
+            if ( id ==
+               OnFirstSpectrumScaleID +
+                     static_cast<int>(SpectrogramSettings::Get(*wt).scaleType))
+               menu.Check(id, true);
+         }
+      );
    }
-EndSection();
 
 
 BeginSection( "Zoom" );
-   AppendItem( "Reset", OnZoomResetID, XXO("Zoom Reset"),POPUP_MENU_FN( OnZoomReset ) );
-   AppendItem( "Fit", OnZoomFitVerticalID, XXO("Zoom to Fit"), POPUP_MENU_FN( OnZoomFitVertical ) );
    AppendItem( "In", OnZoomInVerticalID, XXO("Zoom In"),POPUP_MENU_FN( OnZoomInVertical ) );
    AppendItem( "Out", OnZoomOutVerticalID, XXO("Zoom Out"), POPUP_MENU_FN( OnZoomOutVertical ) );
+   AppendItem( "Fit", OnZoomFitVerticalID, XXO("Zoom to Fit"), POPUP_MENU_FN( OnZoomFitVertical ) );
+   AppendItem( "Reset", OnZoomResetID, XXO("Reset Zoom"),POPUP_MENU_FN( OnZoomReset ) );
 EndSection();
 
 END_POPUP_MENU()

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelVZoomHandle.cpp
@@ -21,12 +21,10 @@ Paul Licameli split from TrackPanel.cpp
 #include "WaveTrack.h"
 #include "../../../../../images/Cursors.h"
 
-bool WaveChannelVZoomHandle::IsDragZooming(int zoomStart, int zoomEnd)
+bool WaveChannelVZoomHandle::IsDragZooming(int zoomStart, int zoomEnd, bool hasDragZoom)
 {
    const int DragThreshold = 3;// Anything over 3 pixels is a drag, else a click.
-   bool bVZoom;
-   gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
-   return bVZoom && (abs(zoomEnd - zoomStart) > DragThreshold);
+   return hasDragZoom && (abs(zoomEnd - zoomStart) > DragThreshold);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -58,30 +56,24 @@ void WaveTrackVRulerMenuTable::UpdatePrefs()
 
 ///////////////////////////////////////////////////////////////////////////////
 
-HitTestPreview WaveChannelVZoomHandle::HitPreview(const wxMouseState &state)
+HitTestPreview WaveChannelVZoomHandle::HitPreview(const bool bVZoom)
 {
-   static auto zoomInCursor =
-      ::MakeCursor(wxCURSOR_MAGNIFIER, ZoomInCursorXpm, 19, 15);
-   static auto zoomOutCursor =
-      ::MakeCursor(wxCURSOR_MAGNIFIER, ZoomOutCursorXpm, 19, 15);
+   static wxCursor crossCursor{wxCURSOR_CROSS};
    static  wxCursor arrowCursor{ wxCURSOR_ARROW };
-   bool bVZoom;
-   gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
-   bVZoom &= !state.RightIsDown();
    const auto message = bVZoom ? 
-      XO("Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region.") :
-      XO("Right-click for menu.");
+      XO("Drag to specify a zoom region. Right-click for menu. Ctrl+scroll to zoom.") :
+      XO("Right-click for menu. Ctrl+scroll to zoom.");
 
    return {
       message,
-      bVZoom ? (state.ShiftDown() ? &*zoomOutCursor : &*zoomInCursor) : &arrowCursor
+      bVZoom ? &crossCursor : &arrowCursor
       // , message
    };
 }
 
 UIHandle::Result WaveChannelVZoomHandle::DoDrag(
    const TrackPanelMouseEvent &evt, AudacityProject *pProject,
-   const int zoomStart, int &zoomEnd)
+   const int zoomStart, int &zoomEnd, bool hasDragZooming)
 {
    using namespace RefreshCode;
 
@@ -89,7 +81,7 @@ UIHandle::Result WaveChannelVZoomHandle::DoDrag(
    if ( event.RightIsDown() )
       return RefreshNone;
    zoomEnd = event.m_y;
-   if (IsDragZooming( zoomStart, zoomEnd ))
+   if (IsDragZooming( zoomStart, zoomEnd, hasDragZooming))
       return RefreshAll;
    return RefreshNone;
 }
@@ -125,23 +117,14 @@ UIHandle::Result WaveChannelVZoomHandle::DoRelease(
       return data.result;
    }
    else {
-      bool bVZoom;
-      gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
       // Ignore Capture Lost event 
-      bVZoom &= event.GetId() != kCaptureLostEventId;
-      // shiftDown | rightUp | ZoomKind
-      //    T      |    T    | 1to1
-      //    T      |    F    | Out
-      //    F      |    -    | In
-      if( bVZoom ) {
-         if( shiftDown )
-            zoomStart = zoomEnd;
-         doZoom(pProject, pTrack,
-            shiftDown
-               ? (rightUp ? kZoom1to1 : kZoomOut)
-               : kZoomIn,
-            rect, zoomStart, zoomEnd, !shiftDown);
-      }
+      bool notLost = event.GetId() != kCaptureLostEventId;
+      // Shift+rightclick to reset zoom
+      if( shiftDown && notLost)
+         zoomStart = zoomEnd;
+      doZoom(pProject, pTrack, kZoom1to1,
+         rect, zoomStart, zoomEnd, !shiftDown);
+      
    }
 
    return UpdateVRuler | RefreshAll;
@@ -149,10 +132,10 @@ UIHandle::Result WaveChannelVZoomHandle::DoRelease(
 
 void WaveChannelVZoomHandle::DoDraw(
    TrackPanelDrawingContext &context,
-   const wxRect &rect, unsigned iPass, const int zoomStart, const int zoomEnd)
+   const wxRect &rect, unsigned iPass, const int zoomStart, const int zoomEnd, bool hasDragZoom)
 {
    if (iPass == TrackArtist::PassZooming) {
-      if (IsDragZooming(zoomStart, zoomEnd))
+      if (IsDragZooming(zoomStart, zoomEnd, hasDragZoom))
          ChannelVRulerControls::DrawZooming(context, rect, zoomStart, zoomEnd);
    }
 }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelVZoomHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelVZoomHandle.h
@@ -24,10 +24,10 @@ namespace WaveChannelVZoomHandle
    using Result = unsigned;
 
    AUDACITY_DLL_API
-   HitTestPreview HitPreview(const wxMouseState &state);
+   HitTestPreview HitPreview(const bool bVZoom);
 
    AUDACITY_DLL_API
-   bool IsDragZooming(int zoomStart, int zoomEnd);
+   bool IsDragZooming(int zoomStart, int zoomEnd, bool hasDragZoom);
 
    using DoZoomFunction = void (*)(AudacityProject *pProject,
        WaveTrack *pTrack,
@@ -38,7 +38,7 @@ namespace WaveChannelVZoomHandle
    AUDACITY_DLL_API
    Result DoDrag(
       const TrackPanelMouseEvent &event, AudacityProject *pProject,
-      int zoomStart, int &zoomEnd );
+      int zoomStart, int &zoomEnd, bool hasDragZoom );
 
    AUDACITY_DLL_API
    Result DoRelease(
@@ -50,7 +50,7 @@ namespace WaveChannelVZoomHandle
    AUDACITY_DLL_API
    void DoDraw(
       TrackPanelDrawingContext &context,
-      const wxRect &rect, unsigned iPass, int zoomStart, int zoomEnd );
+      const wxRect &rect, unsigned iPass, int zoomStart, int zoomEnd, bool hasDragZoom );
 
    AUDACITY_DLL_API
    wxRect DoDrawingArea(

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelVZoomHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelVZoomHandle.h
@@ -90,10 +90,6 @@ protected:
       { OnZoom(WaveChannelViewConstants::kZoom1to1); }
    void OnZoomReset(wxCommandEvent&)
       { OnZoom(WaveChannelViewConstants::kZoomReset); }
-   void OnZoomDiv2Vertical(wxCommandEvent&)
-      { OnZoom(WaveChannelViewConstants::kZoomDiv2); }
-   void OnZoomTimes2Vertical(wxCommandEvent&)
-      { OnZoom(WaveChannelViewConstants::kZoomTimes2); }
    void OnZoomHalfWave(wxCommandEvent&)
       { OnZoom(WaveChannelViewConstants::kZoomHalfWave); }
    void OnZoomInVertical(wxCommandEvent&)
@@ -107,8 +103,6 @@ protected:
 enum {
    OnZoomFitVerticalID = 20000,
    OnZoomResetID,
-   OnZoomDiv2ID,
-   OnZoomTimes2ID,
    OnZoomHalfWaveID,
    OnZoomInVerticalID,
    OnZoomOutVerticalID,

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelViewConstants.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelViewConstants.h
@@ -68,8 +68,6 @@ namespace WaveChannelViewConstants
       // Note that these can be with or without spectrum view which
       // adds a constant.
       kZoom1to1 = 1,
-      kZoomTimes2,
-      kZoomDiv2,
       kZoomHalfWave,
       kZoomInByDrag,
       kZoomIn,

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
@@ -206,51 +206,26 @@ void WaveformVZoomHandle::DoZoom(
       break;
    case kZoomIn:
       {
-         // Enforce maximum vertical zoom
-         const float oldRange = max - min;
-         const float l = std::max(ZOOMLIMIT, 0.5f * oldRange);
-         const float ratio = l / (max - min);
+         const float zoomFactor = 0.5f;
+         const float currentRange = max - min;
 
-         const float p1 = (zoomStart - ypos) / (float)height;
-         float c = (max * (1.0 - p1) + min * p1);
-         if (fixedMousePoint)
-            min = c - ratio * (1.0f - p1) * oldRange,
-            max = c + ratio * p1 * oldRange;
-         else
-            min = c - 0.5 * l,
-            max = c + 0.5 * l;
+         const float nextRange = zoomFactor * currentRange; 
+
+         if (nextRange > ZOOMLIMIT) {
+            min = -(0.5f * nextRange);
+            max = 0.5f * nextRange;
+         }
       }
       break;
    case kZoomOut:
       {
-         // Zoom out
-         if (min <= -1.0 && max >= 1.0) {
-            min = -top;
-            max = top;
-         }
-         else {
-            // limit to +/- 1 range unless already outside that range...
-            float minRange = (min < -1) ? -top : -1.0;
-            float maxRange = (max > 1) ? top : 1.0;
-            // and enforce vertical zoom limits.
-            const float p1 = (zoomStart - ypos) / (float)height;
-            if (fixedMousePoint) {
-               const float oldRange = max - min;
-               const float c = (max * (1.0 - p1) + min * p1);
-               min = std::min(maxRange - ZOOMLIMIT,
-                  std::max(minRange, c - 2 * (1.0f - p1) * oldRange));
-               max = std::max(minRange + ZOOMLIMIT,
-                  std::min(maxRange, c + 2 * p1 * oldRange));
-            }
-            else {
-               const float c = p1 * min + (1 - p1) * max;
-               const float l = (max - min);
-               min = std::min(maxRange - ZOOMLIMIT,
-                              std::max(minRange, c - l));
-               max = std::max(minRange + ZOOMLIMIT,
-                              std::min(maxRange, c + l));
-            }
-         }
+         const float zoomFactor = 2.0f;
+         const float currentRange = max - min;
+
+         const float nextRange = zoomFactor * currentRange; 
+
+         min = std::max(-2.0f, -(0.5f * nextRange));
+         max = std::min(2.0f, 0.5f * nextRange);
       }
       break;
    }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
@@ -248,10 +248,6 @@ PopupMenuTable &WaveformVRulerMenuTable::Instance()
 }
 
 BEGIN_POPUP_MENU(WaveformVRulerMenuTable)
-   // Accelerators only if zooming enabled.
-   bool bVZoom;
-   gPrefs->Read(wxT("/GUI/VerticalZooming"), &bVZoom, false);
-
    BeginSection( "Scales" );
    {
       const auto & names = WaveformSettings::GetScaleNames();
@@ -275,25 +271,18 @@ BEGIN_POPUP_MENU(WaveformVRulerMenuTable)
 
    BeginSection( "Zoom" );
       BeginSection( "Basic" );
-         AppendItem( "Reset", OnZoomFitVerticalID,
-            MakeLabel( XXO("Zoom Reset"), bVZoom, XXO("Shift-Right-Click") ),
-            POPUP_MENU_FN( OnZoomReset ) );
-         AppendItem( "TimesHalf", OnZoomDiv2ID,        XXO("Zoom x1/2"),
-            POPUP_MENU_FN( OnZoomDiv2Vertical ) );
-         AppendItem( "TimesTwo", OnZoomTimes2ID,      XXO("Zoom x2"),                       POPUP_MENU_FN( OnZoomTimes2Vertical ) );
+         AppendItem( "Reset", OnZoomFitVerticalID, XXO("Zoom Reset"), POPUP_MENU_FN( OnZoomReset ) );
+         AppendItem( "TimesHalf", OnZoomDiv2ID, XXO("Zoom x1/2"), POPUP_MENU_FN( OnZoomDiv2Vertical ) );
+         AppendItem( "TimesTwo", OnZoomTimes2ID, XXO("Zoom x2"), POPUP_MENU_FN( OnZoomTimes2Vertical ) );
 
    #ifdef EXPERIMENTAL_HALF_WAVE
-         AppendItem( "HalfWave", OnZoomHalfWaveID,    XXO("Half Wave"),                     POPUP_MENU_FN( OnZoomHalfWave ) );
+         AppendItem( "HalfWave", OnZoomHalfWaveID, XXO("Half Wave"), POPUP_MENU_FN( OnZoomHalfWave ) );
    #endif
       EndSection();
 
       BeginSection( "InOut" );
-         AppendItem( "In", OnZoomInVerticalID,
-            MakeLabel( XXO("Zoom In"), bVZoom, XXO("Left-Click/Left-Drag") ),
-            POPUP_MENU_FN( OnZoomInVertical ) );
-         AppendItem( "Out", OnZoomOutVerticalID,
-            MakeLabel( XXO("Zoom Out"), bVZoom, XXO("Shift-Left-Click") ),
-            POPUP_MENU_FN( OnZoomOutVertical ) );
+         AppendItem( "In", OnZoomInVerticalID, XXO("Zoom In"), POPUP_MENU_FN( OnZoomInVertical ) );
+         AppendItem( "Out", OnZoomOutVerticalID, XXO("Zoom Out"), POPUP_MENU_FN( OnZoomOutVertical ) );
       EndSection();
    EndSection();
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
@@ -161,21 +161,6 @@ void WaveformVZoomHandle::DoZoom(
          max = 1.0;
       }
       break;
-   case kZoomDiv2:
-      {
-         // Zoom out even more than full :-)
-         // -2.0..+2.0 (or logarithmic equivalent)
-         min = -top;
-         max = top;
-      }
-      break;
-   case kZoomTimes2:
-      {
-         // Zoom in to -0.5..+0.5
-         min = -half;
-         max = half;
-      }
-      break;
    case kZoomHalfWave:
       {
          // Zoom to show fractionally more than the top half of the wave.
@@ -243,42 +228,36 @@ PopupMenuTable &WaveformVRulerMenuTable::Instance()
 }
 
 BEGIN_POPUP_MENU(WaveformVRulerMenuTable)
-   BeginSection( "Scales" );
-   {
-      const auto & names = WaveformSettings::GetScaleNames();
-      for (int ii = 0, nn = names.size(); ii < nn; ++ii) {
-         AppendRadioItem( names[ii].Internal(),
-            OnFirstWaveformScaleID + ii, names[ii].Msgid(),
-            POPUP_MENU_FN( OnWaveformScaleType ),
-            []( PopupMenuHandler &handler, wxMenu &menu, int id ){
-               const auto pData =
-                  static_cast< WaveformVRulerMenuTable& >( handler ).mpData;
-               WaveTrack *const wt = pData->pTrack;
-               if ( id ==
-                  OnFirstWaveformScaleID +
-                  static_cast<int>(WaveformSettings::Get(*wt).scaleType) )
-                  menu.Check(id, true);
-            }
-          );
-      }
+   // this generates the linear(amp), log(dB), linear(dB) entries
+   const auto & names = WaveformSettings::GetScaleNames();
+   for (int ii = 0, nn = names.size(); ii < nn; ++ii) {
+      AppendRadioItem( names[ii].Internal(),
+         OnFirstWaveformScaleID + ii, names[ii].Msgid(),
+         POPUP_MENU_FN( OnWaveformScaleType ),
+         []( PopupMenuHandler &handler, wxMenu &menu, int id ){
+            const auto pData =
+               static_cast< WaveformVRulerMenuTable& >( handler ).mpData;
+            WaveTrack *const wt = pData->pTrack;
+            if ( id ==
+               OnFirstWaveformScaleID +
+               static_cast<int>(WaveformSettings::Get(*wt).scaleType) )
+               menu.Check(id, true);
+         }
+         );
    }
-   EndSection();
 
    BeginSection( "Zoom" );
       BeginSection( "Basic" );
-         AppendItem( "Reset", OnZoomFitVerticalID, XXO("Zoom Reset"), POPUP_MENU_FN( OnZoomReset ) );
-         AppendItem( "TimesHalf", OnZoomDiv2ID, XXO("Zoom x1/2"), POPUP_MENU_FN( OnZoomDiv2Vertical ) );
-         AppendItem( "TimesTwo", OnZoomTimes2ID, XXO("Zoom x2"), POPUP_MENU_FN( OnZoomTimes2Vertical ) );
-
-   #ifdef EXPERIMENTAL_HALF_WAVE
-         AppendItem( "HalfWave", OnZoomHalfWaveID, XXO("Half Wave"), POPUP_MENU_FN( OnZoomHalfWave ) );
-   #endif
-      EndSection();
-
-      BeginSection( "InOut" );
          AppendItem( "In", OnZoomInVerticalID, XXO("Zoom In"), POPUP_MENU_FN( OnZoomInVertical ) );
          AppendItem( "Out", OnZoomOutVerticalID, XXO("Zoom Out"), POPUP_MENU_FN( OnZoomOutVertical ) );
+         AppendItem( "Reset", OnZoomFitVerticalID, XXO("Reset Zoom"), POPUP_MENU_FN( OnZoomReset ) );
       EndSection();
+
+   #ifdef EXPERIMENTAL_HALF_WAVE
+      BeginSection( "InOut" );
+         AppendItem( "HalfWave", OnZoomHalfWaveID, XXO("Half Wave"), POPUP_MENU_FN( OnZoomHalfWave ) );
+      EndSection();
+   #endif
    EndSection();
 
 END_POPUP_MENU()

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
@@ -60,13 +60,13 @@ UIHandle::Result WaveformVZoomHandle::Drag
    auto pTrack = TrackList::Get( *pProject ).Lock(mpTrack);
    if (!pTrack)
       return Cancelled;
-   return WaveChannelVZoomHandle::DoDrag(evt, pProject, mZoomStart, mZoomEnd);
+   return WaveChannelVZoomHandle::DoDrag(evt, pProject, mZoomStart, mZoomEnd, false);
 }
 
 HitTestPreview WaveformVZoomHandle::Preview
 (const TrackPanelMouseState &st, AudacityProject *)
 {
-   return WaveChannelVZoomHandle::HitPreview(st.state);
+   return WaveChannelVZoomHandle::HitPreview(false);
 }
 
 UIHandle::Result WaveformVZoomHandle::Release
@@ -94,7 +94,7 @@ void WaveformVZoomHandle::Draw(
    if (!mpTrack.lock()) //? TrackList::Lock()
       return;
    return WaveChannelVZoomHandle::DoDraw(
-      context, rect, iPass, mZoomStart, mZoomEnd);
+      context, rect, iPass, mZoomStart, mZoomEnd, false);
 }
 
 wxRect WaveformVZoomHandle::DrawingArea(
@@ -129,11 +129,6 @@ void WaveformVZoomHandle::DoZoom(
    const float halfrate = rate / 2;
    float maxFreq = 8000.0;
 
-   bool bDragZoom = WaveChannelVZoomHandle::IsDragZooming(zoomStart, zoomEnd);
-
-   // Possibly override the zoom kind.
-   if( bDragZoom )
-      ZoomKind = kZoomInByDrag;
 
    float top=2.0;
    float half=0.5;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
@@ -188,24 +188,22 @@ void WaveformVZoomHandle::DoZoom(
       {
          const float zoomFactor = 0.5f;
          const float currentRange = max - min;
+         const float nextRange = std::max(zoomFactor * currentRange, ZOOMLIMIT);
 
-         const float nextRange = zoomFactor * currentRange; 
-
-         if (nextRange > ZOOMLIMIT) {
-            min = -(0.5f * nextRange);
-            max = 0.5f * nextRange;
-         }
+         const float center = min + (currentRange / 2.0);
+         min = center - (nextRange / 2.0);
+         max = center + (nextRange / 2.0);
       }
       break;
    case kZoomOut:
       {
          const float zoomFactor = 2.0f;
          const float currentRange = max - min;
+         const float nextRange = zoomFactor * currentRange;
 
-         const float nextRange = zoomFactor * currentRange; 
-
-         min = std::max(-2.0f, -(0.5f * nextRange));
-         max = std::min(2.0f, 0.5f * nextRange);
+         const float center = min + (currentRange / 2.0);
+         min = std::max(-top, center - (0.5f * nextRange));
+         max = std::min(top, center + (0.5f * nextRange));
       }
       break;
    }


### PR DESCRIPTION
Resolves: #5715

This is a companion to #5675.

It

* Always disables "advanced vertical zoom" for waveforms
* Always enables "advanced vertical zoom" for spectrograms and MIDI tracks
* uses a somewhat more appropriate cursor to drag selections in spectrograms
* uses simpler mouse gestures (click/shift-click to zoom in/out replaced with ctrl+scroll, shift+rightclick to reset replaced with simple click)
* Always zooms on the center in waveforms

It's still possible to create offset waveforms (half-wave zoom preset or shift+scroll), but zooming resets it. It'd be a nice-to-have if half-wave was a toggle, in which case zooming would keep 0 at the bottom. I don't think either of those things are blockers though.