### PR TITLE
Some easy channel iteration rewrites

### DIFF
--- a/libraries/lib-channel/Channel.cpp
+++ b/libraries/lib-channel/Channel.cpp
@@ -123,7 +123,7 @@ auto ChannelGroup::GetGroupData() const -> const ChannelGroupData &
 
 double ChannelGroup::GetStartTime() const
 {
-   auto range = Intervals();
+   const auto &&range = Intervals();
    if (range.empty())
       return 0;
    return std::accumulate(range.first, range.second,
@@ -134,7 +134,7 @@ double ChannelGroup::GetStartTime() const
 
 double ChannelGroup::GetEndTime() const
 {
-   auto range = Intervals();
+   const auto &&range = Intervals();
    if (range.empty())
       return 0;
    return std::accumulate(range.first, range.second,

--- a/libraries/lib-snapping/Snap.cpp
+++ b/libraries/lib-snapping/Snap.cpp
@@ -46,7 +46,7 @@ SnapPointArray FindCandidates(
    SnapPointArray candidates, const TrackList &tracks )
 {
    for (const auto track : tracks)
-      for (const auto &interval : track->Intervals()) {
+      for (const auto &&interval : track->Intervals()) {
          candidates.emplace_back(interval->Start(), track);
          if (interval->Start() != interval->End())
             candidates.emplace_back(interval->End(), track);

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -571,13 +571,14 @@ public:
    void
    OnProjectTempoChange(const std::optional<double>& oldTempo, double newTempo);
 
+   SampleFormats GetSampleFormats() const;
+
 private:
    // Always gives non-negative answer, not more than sample sequence length
    // even if t0 really falls outside that range
    sampleCount TimeToSequenceSamples(double t) const;
 
    sampleCount GetNumSamples() const;
-   SampleFormats GetSampleFormats() const;
    const SampleBlockFactoryPtr &GetFactory();
    std::vector<std::unique_ptr<Sequence>> GetEmptySequenceCopies() const;
    void StretchCutLines(double ratioChange);

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -402,6 +402,14 @@ size_t WaveTrack::Interval::CountBlocks() const
    return result;
 }
 
+void WaveTrack::Interval::ConvertToSampleFormat(sampleFormat format,
+   const std::function<void(size_t)> & progressReport)
+{
+   // TODO fix progress denominator?
+   ForEachClip([&](auto& clip) {
+      clip.ConvertToSampleFormat(format, progressReport); });
+}
+
 void WaveTrack::Interval::SetName(const wxString& name)
 {
    ForEachClip([&](auto& clip) { clip.SetName(name); });
@@ -1240,10 +1248,8 @@ void WaveTrack::ConvertToSampleFormat(sampleFormat format,
    const std::function<void(size_t)> & progressReport)
 {
    assert(IsLeader());
-   for (const auto pChannel : TrackList::Channels(this)) {
-      for (const auto& clip : pChannel->mClips)
-         clip->ConvertToSampleFormat(format, progressReport);
-   }
+   for (const auto &&pClip : Intervals())
+      pClip->ConvertToSampleFormat(format, progressReport);
    WaveTrackData::Get(*this).SetSampleFormat(format);
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -385,6 +385,13 @@ void WaveTrack::Interval::ShiftBy(double delta) noexcept
    ForEachClip([&](auto& clip) { clip.ShiftBy(delta); });
 }
 
+sampleCount WaveTrack::Interval::GetSequenceSamplesCount() const
+{
+   sampleCount result{};
+   ForEachClip([&](auto& clip) { result += clip.GetSequenceSamplesCount(); });
+   return result;
+}
+
 void WaveTrack::Interval::SetName(const wxString& name)
 {
    ForEachClip([&](auto& clip) { clip.SetName(name); });
@@ -1217,11 +1224,8 @@ sampleCount WaveTrack::GetSequenceSamplesCount() const
 {
    assert(IsLeader());
    sampleCount result{ 0 };
-
-   for (const auto pChannel : TrackList::Channels(this))
-      for (const auto& clip : pChannel->mClips)
-         result += clip->GetSequenceSamplesCount();
-
+   for (const auto &&pInterval : Intervals())
+      result += pInterval->GetSequenceSamplesCount();
    return result;
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -3064,14 +3064,6 @@ std::optional<TranslatableString> WaveTrack::GetErrorOpening() const
    return {};
 }
 
-bool WaveTrack::CloseLock() noexcept
-{
-   assert(IsLeader());
-   for (const auto &&pClip : Intervals())
-      pClip->CloseLock();
-   return true;
-}
-
 const WaveClip* WaveTrack::GetLeftmostNarrowClip() const {
    if (mClips.empty())
       return nullptr;

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -380,6 +380,11 @@ bool WaveTrack::Interval::Paste(double t0, const Interval &src)
    return result;
 }
 
+void WaveTrack::Interval::ShiftBy(double delta) noexcept
+{
+   ForEachClip([&](auto& clip) { clip.ShiftBy(delta); });
+}
+
 void WaveTrack::Interval::SetName(const wxString& name)
 {
    ForEachClip([&](auto& clip) { clip.SetName(name); });
@@ -862,11 +867,9 @@ void WaveTrack::MoveTo(double origin)
 {
    double delta = origin - GetStartTime();
    assert(IsLeader());
-   for (const auto pChannel : TrackList::Channels(this)) {
-      for (const auto &clip : pChannel->mClips)
-         // assume No-fail-guarantee
-         clip->ShiftBy(delta);
-   }
+   for (const auto &&pInterval : Intervals())
+      // assume No-fail-guarantee
+      pInterval->ShiftBy(delta);
    WaveTrackData::Get(*this).SetOrigin(origin);
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2812,8 +2812,10 @@ clip gets appended; no previously saved contents are lost. */
 void WaveTrack::Flush()
 {
    assert(IsLeader());
-   for (const auto pChannel : TrackList::Channels(this))
-      pChannel->FlushOne();
+   if (NIntervals() == 0)
+      return;
+   // After appending, presumably.  Do this to the clip that gets appended.
+   GetRightmostClip()->Flush();
 }
 
 void WaveTrack::SetLegacyFormat(sampleFormat format)

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -392,6 +392,16 @@ sampleCount WaveTrack::Interval::GetSequenceSamplesCount() const
    return result;
 }
 
+size_t WaveTrack::Interval::CountBlocks() const
+{
+   size_t result{};
+   ForEachClip([&](const WaveClip &clip){
+      const auto width = clip.GetWidth();
+      for (size_t ii = 0; ii < width; ++ii)
+         result += clip.GetSequenceBlockArray(ii)->size(); });
+   return result;
+}
+
 void WaveTrack::Interval::SetName(const wxString& name)
 {
    ForEachClip([&](auto& clip) { clip.SetName(name); });
@@ -1224,10 +1234,8 @@ size_t WaveTrack::CountBlocks() const
 {
    assert(IsLeader());
    size_t result{};
-   for (const auto pChannel : TrackList::Channels(this)) {
-      for (auto& clip : pChannel->GetClips())
-         result += clip->GetWidth() * clip->GetSequenceBlockArray(0)->size();
-   }
+   for (const auto &&pInterval : Intervals())
+      result += pInterval->CountBlocks();
    return result;
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -4183,18 +4183,6 @@ void WaveTrack::ExpandOneCutLine(double cutLinePosition,
    }
 }
 
-bool WaveTrack::RemoveCutLine(double cutLinePosition)
-{
-   assert(IsLeader());
-   bool removed = false;
-   for (const auto &&pClip : Intervals())
-      if (pClip->RemoveCutLine(cutLinePosition)) {
-         removed = true;
-         break;
-      }
-   return removed;
-}
-
 // Can't promise strong exception safety for a pair of tracks together
 bool WaveTrack::MergeClips(int clipidx1, int clipidx2)
 {

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -422,6 +422,11 @@ void WaveTrack::Interval::CloseLock() noexcept
    ForEachClip(std::mem_fn(&WaveClip::CloseLock));
 }
 
+SampleFormats WaveTrack::Interval::GetSampleFormats() const
+{
+   return GetClip(0)->GetSampleFormats();
+}
+
 void WaveTrack::Interval::SetName(const wxString& name)
 {
    ForEachClip([&](auto& clip) { clip.SetName(name); });
@@ -3656,18 +3661,8 @@ bool WaveChannel::Set(constSamplePtr buffer, sampleFormat format,
 sampleFormat WaveTrack::WidestEffectiveFormat() const
 {
    auto result = narrowestSampleFormat;
-   const auto accumulate = [&](const WaveTrack &track) {
-      for (const auto &pClip : track.GetClips())
-         for (size_t ii = 0, width = pClip->GetWidth(); ii < width; ++ii)
-            result = std::max(result,
-               pClip->GetSequence(ii)->GetSampleFormats().Effective());
-   };
-   if (auto pOwner = GetOwner()) {
-      for (auto channel : TrackList::Channels(this))
-         accumulate(*channel);
-   }
-   else
-      accumulate(*this);
+   for (const auto &pClip : Intervals())
+      result = std::max(result, pClip->GetSampleFormats().Effective());
    return result;
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -435,6 +435,12 @@ bool WaveTrack::Interval::RemoveCutLine(double cutLinePosition)
    return true;
 }
 
+void WaveTrack::Interval::Resample(int rate, BasicUI::ProgressDialog *progress)
+{
+   // TODO Progress denominator?
+   ForEachClip([&](auto& clip) { clip.Resample(rate, progress); });
+}
+
 void WaveTrack::Interval::SetName(const wxString& name)
 {
    ForEachClip([&](auto& clip) { clip.SetName(name); });
@@ -4276,10 +4282,8 @@ void WaveTrack::ReplaceInterval(
 */
 void WaveTrack::Resample(int rate, BasicUI::ProgressDialog *progress)
 {
-   for (const auto pChannel : TrackList::Channels(this)) {
-      for (const auto &clip : pChannel->mClips)
-         clip->Resample(rate, progress);
-   }
+   for (const auto &&pClip : Intervals())
+      pClip->Resample(rate, progress);
    DoSetRate(rate);
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1230,15 +1230,6 @@ sampleCount WaveTrack::GetVisibleSampleCount() const
     return result;
 }
 
-size_t WaveTrack::CountBlocks() const
-{
-   assert(IsLeader());
-   size_t result{};
-   for (const auto &&pInterval : Intervals())
-      result += pInterval->CountBlocks();
-   return result;
-}
-
 sampleFormat WaveTrack::GetSampleFormat() const
 {
    return WaveTrackData::Get(*this).GetSampleFormat();

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -520,8 +520,7 @@ WaveTrack::GetNextInterval(const Interval& interval, PlaybackDirection searchDir
       ? std::numeric_limits<double>::max()
       : std::numeric_limits<double>::lowest();
 
-   for(const auto& other : Intervals())
-   {
+   for (const auto &&other : Intervals()) {
       if((searchDirection == PlaybackDirection::forward &&
          (other->Start() > interval.Start() && other->Start() < bestMatchTime))
          ||
@@ -545,7 +544,7 @@ WaveTrack::IntervalHolder WaveTrack::GetNextInterval(
 WaveTrack::IntervalHolder WaveTrack::GetIntervalAtTime(double t)
 {
    IntervalHolder result;
-   for (const auto& interval : Intervals())
+   for (const auto &&interval : Intervals())
       if (interval->WithinPlayRegion(t))
          return interval;
    return nullptr;
@@ -2540,7 +2539,7 @@ void WaveTrack::Disjoin(double t0, double t1)
 
    const size_t width = NChannels();
 
-   for (const auto &interval : Intervals()) {
+   for (const auto &&interval : Intervals()) {
       double startTime = interval->Start();
       double endTime = interval->End();
 
@@ -2622,11 +2621,11 @@ void WaveTrack::Join(
 {
    assert(IsLeader());
    // Merge all WaveClips overlapping selection into one
-   const auto intervals = Intervals();
+   const auto &&intervals = Intervals();
 
    {
       IntervalHolders intervalsToJoin;
-      for (const auto &interval : intervals)
+      for (const auto &&interval : intervals)
          if (interval->IntersectsPlayRegion(t0, t1))
             intervalsToJoin.push_back(interval);
       if (intervalsToJoin.size() < 2u)
@@ -2644,7 +2643,7 @@ void WaveTrack::Join(
    IntervalHolder newClip{};
 
    const auto rate = GetRate();
-   for (const auto &clip: intervals) {
+   for (const auto &&clip: intervals) {
       if (clip->IntersectsPlayRegion(t0, t1)) {
          // Put in sorted order
          auto it = clipsToDelete.begin(), end = clipsToDelete.end();
@@ -3514,7 +3513,7 @@ WaveChannel::GetSampleView(double t0, double t1, bool mayThrow) const
 {
    std::vector<std::shared_ptr<const WaveChannelInterval>>
       intersectingIntervals;
-   for (const auto& interval : Intervals())
+   for (const auto &&interval : Intervals())
       if (interval->Intersects(t0, t1))
          intersectingIntervals.push_back(interval);
    if (intersectingIntervals.empty())
@@ -4281,7 +4280,7 @@ WaveClipConstPointers WaveTrack::SortedClipArray() const
 
 auto WaveTrack::SortedIntervalArray() -> IntervalHolders
 {
-   auto intervals = Intervals();
+   const auto &&intervals = Intervals();
    IntervalHolders result;
    copy(intervals.begin(), intervals.end(), back_inserter(result));
    sort(result.begin(), result.end(), [](const auto &pA, const auto &pB){
@@ -4291,7 +4290,7 @@ auto WaveTrack::SortedIntervalArray() -> IntervalHolders
 
 auto WaveTrack::SortedIntervalArray() const -> IntervalConstHolders
 {
-   auto intervals = Intervals();
+   const auto &&intervals = Intervals();
    IntervalConstHolders result;
    copy(intervals.begin(), intervals.end(), back_inserter(result));
    sort(result.begin(), result.end(), [](const auto &pA, const auto &pB){

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -427,6 +427,14 @@ SampleFormats WaveTrack::Interval::GetSampleFormats() const
    return GetClip(0)->GetSampleFormats();
 }
 
+bool WaveTrack::Interval::RemoveCutLine(double cutLinePosition)
+{
+   bool result = false;
+   ForEachClip([&](auto& clip) {
+      result = clip.RemoveCutLine(cutLinePosition) || result; });
+   return true;
+}
+
 void WaveTrack::Interval::SetName(const wxString& name)
 {
    ForEachClip([&](auto& clip) { clip.SetName(name); });
@@ -4178,15 +4186,12 @@ void WaveTrack::ExpandOneCutLine(double cutLinePosition,
 bool WaveTrack::RemoveCutLine(double cutLinePosition)
 {
    assert(IsLeader());
-
    bool removed = false;
-   for (const auto pChannel : TrackList::Channels(this))
-      for (const auto &clip : pChannel->mClips)
-         if (clip->RemoveCutLine(cutLinePosition)) {
-            removed = true;
-            break;
-         }
-
+   for (const auto &&pClip : Intervals())
+      if (pClip->RemoveCutLine(cutLinePosition)) {
+         removed = true;
+         break;
+      }
    return removed;
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -417,6 +417,11 @@ void WaveTrack::Interval::SetSilence(sampleCount offset, sampleCount length)
    ForEachClip([&](auto& clip) { clip.SetSilence(offset, length); });
 }
 
+void WaveTrack::Interval::CloseLock() noexcept
+{
+   ForEachClip(std::mem_fn(&WaveClip::CloseLock));
+}
+
 void WaveTrack::Interval::SetName(const wxString& name)
 {
    ForEachClip([&](auto& clip) { clip.SetName(name); });
@@ -3062,10 +3067,8 @@ std::optional<TranslatableString> WaveTrack::GetErrorOpening() const
 bool WaveTrack::CloseLock() noexcept
 {
    assert(IsLeader());
-   for (const auto pChannel : TrackList::Channels(this))
-      for (const auto &clip : pChannel->mClips)
-         clip->CloseLock();
-
+   for (const auto &&pClip : Intervals())
+      pClip->CloseLock();
    return true;
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1220,15 +1220,6 @@ sampleCount WaveTrack::GetVisibleSampleCount() const
     return result;
 }
 
-sampleCount WaveTrack::GetSequenceSamplesCount() const
-{
-   assert(IsLeader());
-   sampleCount result{ 0 };
-   for (const auto &&pInterval : Intervals())
-      result += pInterval->GetSequenceSamplesCount();
-   return result;
-}
-
 size_t WaveTrack::CountBlocks() const
 {
    assert(IsLeader());

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1055,6 +1055,9 @@ public:
       sampleCount GetSequenceSamplesCount() const;
       size_t CountBlocks() const;
 
+      void ConvertToSampleFormat(sampleFormat format,
+         const std::function<void(size_t)> & progressReport = {});
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1065,6 +1065,10 @@ public:
        */
       bool RemoveCutLine(double cutLinePosition);
 
+      // Resample clip. This also will set the rate, but without changing
+      // the length of the clip
+      void Resample(int rate, BasicUI::ProgressDialog *progress = nullptr);
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -942,13 +942,6 @@ public:
    void ExpandCutLine(double cutLinePosition,
       double* cutlineStart = nullptr, double* cutlineEnd = nullptr);
 
-   //! Remove cut line, without expanding the audio in it
-   /*
-    @pre `IsLeader()`
-    @return whether any cutline existed at the position and was removed
-    */
-   bool RemoveCutLine(double cutLinePosition);
-
    // Resample track (i.e. all clips in the track)
    void Resample(int rate, BasicUI::ProgressDialog *progress = NULL);
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1063,6 +1063,8 @@ public:
 
       void CloseLock() noexcept;
 
+      SampleFormats GetSampleFormats() const;
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1069,6 +1069,8 @@ public:
       /*! @excsafety{No-fail} */
       void ShiftBy(double delta) noexcept;
 
+      sampleCount GetSequenceSamplesCount() const;
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)
@@ -1087,6 +1089,13 @@ public:
 
       // Helper function in time of migration to wide clips
       template<typename Callable> void ForEachClip(const Callable& op) {
+         for (size_t channel = 0, channelCount = NChannels();
+            channel < channelCount; ++channel)
+            op(*GetClip(channel));
+      }
+
+      // Helper function in time of migration to wide clips
+      template<typename Callable> void ForEachClip(const Callable& op) const {
          for (size_t channel = 0, channelCount = NChannels();
             channel < channelCount; ++channel)
             op(*GetClip(channel));

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -728,8 +728,14 @@ public:
    const WaveClipConstHolders &GetClips() const
       { return reinterpret_cast< const WaveClipConstHolders& >( mClips ); }
 
-   const WaveClip* GetLeftmostClip() const;
-   const WaveClip* GetRightmostClip() const;
+   const WaveClip* GetLeftmostNarrowClip() const;
+   const WaveClip* GetRightmostNarrowClip() const;
+
+   IntervalHolder GetLeftmostClip();
+   IntervalConstHolder GetLeftmostClip() const;
+
+   IntervalHolder GetRightmostClip();
+   IntervalConstHolder GetRightmostClip() const;
 
    /**
     * @brief Get access to the (visible) clips in the tracks, in unspecified
@@ -1140,6 +1146,15 @@ public:
    const WaveClip* FindClipByName(const wxString& name) const;
 
    size_t NIntervals() const override;
+
+   /*!
+    @pre `IsLeader()`
+    */
+   IntervalHolder GetWideClip(size_t iInterval);
+   /*!
+    @pre `IsLeader()`
+    */
+   IntervalConstHolder GetWideClip(size_t iInterval) const;
 
    //!< used only during deserialization
    void SetLegacyFormat(sampleFormat format);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -945,6 +945,7 @@ public:
    //! Remove cut line, without expanding the audio in it
    /*
     @pre `IsLeader()`
+    @return whether any cutline existed at the position and was removed
     */
    bool RemoveCutLine(double cutLinePosition);
 
@@ -1064,6 +1065,12 @@ public:
       void CloseLock() noexcept;
 
       SampleFormats GetSampleFormats() const;
+
+      /// Remove cut line, without expanding the audio in it
+      /*!
+       @return whether any cutline existed at the position and was removed
+       */
+      bool RemoveCutLine(double cutLinePosition);
 
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -381,14 +381,6 @@ public:
 
    sampleCount GetVisibleSampleCount() const;
 
-   /*!
-    @return the total number of blocks in all underlying sequences of all clips,
-   across all channels (including hidden audio but not counting the cutlines)
-
-    @pre `IsLeader()`
-    */
-   size_t CountBlocks() const;
-
    sampleFormat GetSampleFormat() const override;
 
    /*!

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -382,15 +382,6 @@ public:
    sampleCount GetVisibleSampleCount() const;
 
    /*!
-    @return the total number of samples in all underlying sequences
-   of all clips, across all channels (including hidden audio but not
-   counting the cutlines)
-
-    @pre `IsLeader()`
-    */
-   sampleCount GetSequenceSamplesCount() const;
-
-   /*!
     @return the total number of blocks in all underlying sequences of all clips,
    across all channels (including hidden audio but not counting the cutlines)
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1068,6 +1068,8 @@ public:
       //! (relative to the play start)
       void SetSilence(sampleCount offset, sampleCount length);
 
+      void CloseLock() noexcept;
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -709,13 +709,6 @@ public:
    // doing a copy and paste between projects.
    //
 
-   //! Should be called upon project close.  Not balanced by unlocking calls.
-   /*!
-    @pre `IsLeader()`
-    @excsafety{No-fail}
-    */
-   bool CloseLock() noexcept;
-
    //! Get access to the (visible) clips in the tracks, in unspecified order
    //! (not necessarily sequenced in time).
    /*!

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1061,6 +1061,7 @@ public:
       void ShiftBy(double delta) noexcept;
 
       sampleCount GetSequenceSamplesCount() const;
+      size_t CountBlocks() const;
 
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1058,6 +1058,10 @@ public:
       void ConvertToSampleFormat(sampleFormat format,
          const std::function<void(size_t)> & progressReport = {});
 
+      //! Silences the 'length' amount of samples starting from 'offset'
+      //! (relative to the play start)
+      void SetSilence(sampleCount offset, sampleCount length);
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1066,6 +1066,9 @@ public:
          sampleFormat format);
       bool StretchRatioEquals(double value) const;
 
+      /*! @excsafety{No-fail} */
+      void ShiftBy(double delta) noexcept;
+
       std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
       { return iChannel == 0 ? mpClip : mpClip1; }
       const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -248,3 +248,12 @@ bool WaveTrackUtilities::Reverse(WaveTrack &track,
 
    return rValue;
 }
+
+sampleCount WaveTrackUtilities::GetSequenceSamplesCount(const WaveTrack &track)
+{
+   assert(track.IsLeader());
+   sampleCount result{ 0 };
+   for (const auto &&pInterval : track.Intervals())
+      result += pInterval->GetSequenceSamplesCount();
+   return result;
+}

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -267,3 +267,10 @@ size_t WaveTrackUtilities::CountBlocks(const WaveTrack &track)
       result += pInterval->CountBlocks();
    return result;
 }
+
+void WaveTrackUtilities::CloseLock(WaveTrack &track) noexcept
+{
+   assert(track.IsLeader());
+   for (const auto &&pClip : track.Intervals())
+      pClip->CloseLock();
+}

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -257,3 +257,12 @@ sampleCount WaveTrackUtilities::GetSequenceSamplesCount(const WaveTrack &track)
       result += pInterval->GetSequenceSamplesCount();
    return result;
 }
+
+size_t WaveTrackUtilities::CountBlocks(const WaveTrack &track)
+{
+   assert(track.IsLeader());
+   size_t result{};
+   for (const auto &&pInterval : track.Intervals())
+      result += pInterval->CountBlocks();
+   return result;
+}

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -10,6 +10,7 @@
 **********************************************************************/
 #include "WaveTrackUtilities.h"
 #include "BasicUI.h"
+#include "Sequence.h"
 #include "UserException.h"
 #include "WaveClip.h"
 #include "WaveTrack.h"

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -274,3 +274,15 @@ void WaveTrackUtilities::CloseLock(WaveTrack &track) noexcept
    for (const auto &&pClip : track.Intervals())
       pClip->CloseLock();
 }
+
+bool WaveTrackUtilities::RemoveCutLine(WaveTrack &track, double cutLinePosition)
+{
+   assert(track.IsLeader());
+   bool removed = false;
+   for (const auto &&pClip : track.Intervals())
+      if (pClip->RemoveCutLine(cutLinePosition)) {
+         removed = true;
+         break;
+      }
+   return removed;
+}

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -47,4 +47,12 @@ counting the cutlines)
  @pre `track.IsLeader()`
  */
 WAVE_TRACK_API sampleCount GetSequenceSamplesCount(const WaveTrack &track);
+
+/*!
+ @return the total number of blocks in all underlying sequences of all clips,
+across all channels (including hidden audio but not counting the cutlines)
+
+ @pre `track.IsLeader()`
+ */
+WAVE_TRACK_API size_t CountBlocks(const WaveTrack &track);
 }

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -62,4 +62,11 @@ WAVE_TRACK_API size_t CountBlocks(const WaveTrack &track);
  @excsafety{No-fail}
  */
 WAVE_TRACK_API void CloseLock(WaveTrack &track) noexcept;
+
+//! Remove cut line, without expanding the audio in it
+/*
+ @pre `track.IsLeader()`
+ @return whether any cutline existed at the position and was removed
+ */
+WAVE_TRACK_API bool RemoveCutLine(WaveTrack &track, double cutLinePosition);
 }

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -38,4 +38,13 @@ using ProgressReport = std::function<bool(double)>;
 
 WAVE_TRACK_API bool Reverse(WaveTrack &track,
    sampleCount start, sampleCount len, const ProgressReport &report = {});
+
+/*!
+ @return the total number of samples in all underlying sequences
+of all clips, across all channels (including hidden audio but not
+counting the cutlines)
+
+ @pre `track.IsLeader()`
+ */
+WAVE_TRACK_API sampleCount GetSequenceSamplesCount(const WaveTrack &track);
 }

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -55,4 +55,11 @@ across all channels (including hidden audio but not counting the cutlines)
  @pre `track.IsLeader()`
  */
 WAVE_TRACK_API size_t CountBlocks(const WaveTrack &track);
+
+//! Should be called upon project close.  Not balanced by unlocking calls.
+/*!
+ @pre `track.IsLeader()`
+ @excsafety{No-fail}
+ */
+WAVE_TRACK_API void CloseLock(WaveTrack &track) noexcept;
 }

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -41,6 +41,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "UndoManager.h"
 #include "UndoTracks.h"
 #include "WaveTrack.h"
+#include "WaveTrackUtilities.h"
 #include "wxFileNameWrapper.h"
 #include "Export.h"
 #include "Import.h"
@@ -88,7 +89,7 @@ void ProjectFileManager::DiscardAutosave(const FilePath &filename)
 
    if (projectFileManager.mLastSavedTracks) {
       for (auto wt : projectFileManager.mLastSavedTracks->Any<WaveTrack>())
-         wt->CloseLock();
+         WaveTrackUtilities::CloseLock(*wt);
       projectFileManager.mLastSavedTracks.reset();
    }
 
@@ -761,7 +762,7 @@ void ProjectFileManager::CompactProjectOnClose()
    if (mLastSavedTracks)
    {
       for (auto wt : mLastSavedTracks->Any<WaveTrack>())
-         wt->CloseLock();
+         WaveTrackUtilities::CloseLock(*wt);
 
       // Attempt to compact the project
       projectFileIO.Compact( { mLastSavedTracks.get() } );
@@ -1104,7 +1105,7 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
       // here is a better way to accomplish the intent, doing like what happens
       // when the project closes:
       for (auto pTrack : tracks.Any<WaveTrack>())
-         pTrack->CloseLock();
+         WaveTrackUtilities::CloseLock(*pTrack);
 
       tracks.Clear(); //tracks.Clear(true);
 

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1182,7 +1182,7 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
          if (newRate == 0)
             newRate = wt.GetRate();
          const auto trackName = wt.GetName();
-         for(const auto& interval : wt.Intervals())
+         for (const auto &&interval : wt.Intervals())
             interval->SetName(trackName);
       });
    }

--- a/src/commands/SetClipCommand.cpp
+++ b/src/commands/SetClipCommand.cpp
@@ -94,8 +94,7 @@ bool SetClipCommand::Apply(const CommandContext& context)
 
       // if no 'At' is specified, then any clip in any selected track will be set.
       track->TypeSwitch([&](WaveTrack &waveTrack) {
-         for(const auto& interval : waveTrack.Intervals())
-         {
+         for (const auto &&interval : waveTrack.Intervals()) {
             if(!bHasContainsTime || 
                (interval->Start() <= mContainsTime &&
                interval->End() >= mContainsTime ))

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -89,7 +89,8 @@ wxULongLong EstimateCopyBytesCount(const TrackList& src, const TrackList& dst)
 {
    wxULongLong result{};
    for (auto waveTrack : src.Any<const WaveTrack>()) {
-      const auto samplesCount = waveTrack->GetSequenceSamplesCount();
+      const auto samplesCount =
+         WaveTrackUtilities::GetSequenceSamplesCount(*waveTrack);
       result += samplesCount.as_long_long() *
          SAMPLE_SIZE(waveTrack->GetSampleFormat());
    }

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -101,7 +101,7 @@ BlockArray::size_type EstimateCopiedBlocks(const TrackList& src, const TrackList
 {
    BlockArray::size_type result{};
    for (const auto waveTrack : src.Any<const WaveTrack>())
-      result += waveTrack->CountBlocks();
+      result += WaveTrackUtilities::CountBlocks(*waveTrack);
    return result;
 }
 

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -266,7 +266,7 @@ void OnPunchAndRoll(const CommandContext &context)
    for (const auto &wt : tracks) {
       auto rate = wt->GetRate();
       sampleCount testSample(floor(t1 * rate));
-      const auto intervals = as_const(*wt).Intervals();
+      const auto &&intervals = as_const(*wt).Intervals();
       auto pred = [rate](sampleCount testSample){ return
          [rate, testSample](const auto &pInterval){
             auto start = floor(pInterval->Start() * rate + 0.5);

--- a/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
@@ -23,6 +23,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "UndoManager.h"
 #include "ViewInfo.h"
 #include "WaveTrack.h"
+#include "WaveTrackUtilities.h"
 #include "../../../../../images/Cursors.h"
 
 CutlineHandle::CutlineHandle(
@@ -158,7 +159,7 @@ UIHandle::Result CutlineHandle::Click
    }
    else if (event.RightDown())
    {
-      bool removed = mpTrack->RemoveCutLine(mLocation.pos);
+      bool removed = WaveTrackUtilities::RemoveCutLine(*mpTrack, mLocation.pos);
       if (!removed)
          // Nothing happened, make no Undo item
          return Cancelled;

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -876,7 +876,7 @@ void SpectrumView::DoDraw(TrackPanelDrawingContext& context, size_t channel,
    auto pLeader = *track.GetHolder()->Find(&track);
    assert(pLeader->IsLeader());
 
-   for (const auto pInterval :
+   for (const auto &&pInterval :
       static_cast<const WaveTrack*>(pLeader)->GetChannel(channel)->Intervals())
       DrawClipSpectrum(context, track, *pInterval, rect, mpSpectralData,
          &pInterval->GetClip() == selectedClip);

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -171,8 +171,7 @@ private:
                continue;
             }
 
-            for(const auto& interval : track->Intervals())
-            {
+            for (const auto &&interval : track->Intervals()) {
                addSnapPoint(interval->Start(), track);
                if(interval->Start() != interval->End())
                   addSnapPoint(interval->End(), track);
@@ -395,8 +394,7 @@ UIHandlePtr WaveClipAdjustBorderHandle::HitAnywhere(
    //Test left and right boundaries of each clip
    //to determine which kind of adjustment is
    //more appropriate
-   for(const auto& interval : waveTrack->Intervals())
-   {
+   for (const auto &&interval : waveTrack->Intervals()) {
       const auto& clip = *interval->GetClip(0);
       if(!WaveChannelView::ClipDetailsVisible(clip, zoomInfo, rect))
          continue;

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -206,7 +206,7 @@ std::vector<UIHandlePtr> WaveTrackAffordanceControls::HitTest(const TrackPanelMo
     const auto waveTrack = std::static_pointer_cast<WaveTrack>(
        PendingTracks::Get(*pProject).SubstitutePendingChangedTrack(*track));
     auto& zoomInfo = ViewInfo::Get(*pProject);
-    const auto intervals = waveTrack->Intervals();
+    const auto &&intervals = waveTrack->Intervals();
     for(auto it = intervals.begin(); it != intervals.end(); ++it)
     {
         if (it == mEditedInterval)
@@ -265,7 +265,7 @@ void WaveTrackAffordanceControls::Draw(TrackPanelDrawingContext& context, const 
             auto px = context.lastState.m_x;
             auto py = context.lastState.m_y;
 
-            const auto intervals = waveTrack->Intervals();
+            const auto &&intervals = waveTrack->Intervals();
             for(auto it = intervals.begin(); it != intervals.end(); ++it)
             {
                 auto interval = *it;
@@ -375,7 +375,7 @@ SelectedIntervalOfFocusedTrack(AudacityProject &project)
       dynamic_cast<WaveTrack *>(TrackFocus::Get(project).Get())) {
       if (FindAffordance(*pWaveTrack)) {
          auto &viewInfo = ViewInfo::Get(project);
-         auto intervals = pWaveTrack->Intervals();
+         const auto &&intervals = pWaveTrack->Intervals();
 
          auto it = std::find_if(intervals.begin(), intervals.end(), [&](const auto& interval)
          {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -31,6 +31,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "TrackFocus.h"
 #include "../../../../TrackPanelMouseEvent.h"
 #include "WaveTrack.h"
+#include "WaveTrackUtilities.h"
 #include "RealtimeEffectManager.h"
 #include "../../../../prefs/PrefsDialog.h"
 #include "../../../../prefs/ThemePrefs.h"
@@ -265,7 +266,8 @@ void FormatMenuTable::OnFormatChange(wxCommandEvent & event)
    // Simply finding a denominator for the progress dialog
    // Hidden samples are processed too, they should be counted as well
    // (Correctly counting all samples of all channels)
-   sampleCount totalSamples = pTrack->GetSequenceSamplesCount();
+   const sampleCount totalSamples =
+      WaveTrackUtilities::GetSequenceSamplesCount(*pTrack);
    sampleCount processedSamples{ 0 };
 
    // Below is the lambda function that is passed along the call chain to

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -766,9 +766,8 @@ void WaveTrackMenuTable::OnMergeStereo(wxCommandEvent &)
             std::numeric_limits<double>::epsilon() * std::max(a, b);
       };
       const auto eps = 0.5 / left.GetRate();
-      const auto rightIntervals = right.Intervals();
-      for(const auto& a : left.Intervals())
-      {
+      const auto &&rightIntervals = right.Intervals();
+      for (const auto &&a : left.Intervals()) {
          auto it = std::find_if(
             rightIntervals.begin(),
             rightIntervals.end(),

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -977,7 +977,7 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
    auto pLeader = *track.GetHolder()->Find(&track);
    assert(pLeader->IsLeader());
 
-   for (const auto pInterval :
+   for (const auto &&pInterval :
       static_cast<const WaveTrack*>(pLeader)->GetChannel(channel)->Intervals()
    ) {
       DrawClipWaveform(context, track, *pInterval, rect,

--- a/src/tracks/ui/TimeShiftHandle.cpp
+++ b/src/tracks/ui/TimeShiftHandle.cpp
@@ -248,7 +248,7 @@ void TrackShifter::InitIntervals()
    auto &track = GetTrack();
    assert(track.IsLeader()); // postcondition
    mMoving.clear();
-   auto range = track.Intervals();
+   const auto &&range = track.Intervals();
    std::copy(range.begin(), range.end(), back_inserter(mFixed));
 }
 


### PR DESCRIPTION
Resolves: #5691

QA: Try with mono and stereo tracks:
- [x] Dragging clips
- [x] Changing sample format on a long enough track -- observe progress indicator filling up
- [x] Unchanged size estimation in the dialog that performs cross-document copy-paste with hidden samples
- [x] Filling of progress dialog for cross-document copy-paste with hidden samples
- [x] Silence command (Ctrl+L -- not the generator)
- [x] Recording; nothing lost at the end
- [x] Save, reopen project with wave data; nothing lost
- [x] Correct non-application of dither, when you import 16 or 24 bit audio to default float, and export again.  (To test, import both files, invert one, mix, and then use Contrast to verify all is really silence)
- [x] Delete an unexpanded cutline (right click)
- [x] Tracks > Resample

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
