### PR TITLE
Compressor: fix for when there is blank space before audio

### DIFF
--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -37,8 +37,6 @@ bool EffectTwoPassSimpleMono::Process(
    }
    for (const auto pNewTrack : mWorkTracks->Any<WaveTrack>()) {
       pNewTrack->ConvertToSampleFormat(floatSample);
-      if (mT0 > 0)
-         pNewTrack->InsertSilence(0, mT0);
    }
 
    mTrackLists[0] = &outputs.Get();
@@ -70,14 +68,19 @@ bool EffectTwoPassSimpleMono::ProcessPass(EffectSettings &settings)
    for (auto track : (*mTrackLists[mPass]).Selected<WaveTrack>()) {
       auto outTrack = *outTracks;
 
-      // Get start and end times from track
-      double trackStart = track->GetStartTime();
-      double trackEnd = track->GetEndTime();
+      // Get start and end times from the appropriate track
+      double trackStart = mPass == 0 ? track->GetStartTime() : (*outTracks)->GetStartTime();
+      double trackEnd = mPass == 0 ? track->GetEndTime() : (*outTracks)->GetEndTime();
 
       // Set the current bounds to whichever left marker is
       // greater and whichever right marker is less:
       mCurT0 = std::max(trackStart, mT0);
       mCurT1 = std::min(trackEnd, mT1);
+
+      // So that in ProcessOne(), when mPass == 0, samples are
+      // appended starting at mCurT0
+      if (mPass == 0 && mCurT0 > 0)
+            (*outTracks)->InsertSilence(0, mCurT0);
 
       // Process only if the right marker is to the right of the left marker
       if (mCurT1 > mCurT0) {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5670
Resolves: https://github.com/audacity/audacity/issues/3903

Problem:
When the time selection includes blank space before the audio, the results of the compressor effect are incorrect.

Relevant previous commits:
618106f1
0f830b44
The latter commit is a fix for the former. In the fix, a period of silence, mT0, is inserted into the WorkTracks, so that in ProcessOne() samples are appended starting at the same time as the start of processed audio in the original track. However, in ProcessPass(), the start of processing is given by std::max(trackStart, mT0), not mT0.

Fix:
Insert a period of silence based on std::max(trackStart, mT0). In addition, because after the addition of the silence the WorkTracks start from 0, the value of trackStart isn't calculated using WorkTracks, so avoiding unnecessary processing. trackEnd is handled similarly, just for consistency, although this isn't necessary.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
