### PR TITLE
Music import dialog: screen reader problem

### DIFF
--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -453,7 +453,7 @@ wxAccStatus TrackPanelAx::GetState( int childId, long* state )
       *state = wxACC_STATE_SYSTEM_FOCUSABLE | wxACC_STATE_SYSTEM_SELECTABLE;
       if (t)
       {
-         if (t == pFocus->PeekFocus())
+         if (t == pFocus->PeekFocus() && GetWindow() == wxWindow::FindFocus())
          {
             *state |= wxACC_STATE_SYSTEM_FOCUSED;
          }
@@ -466,7 +466,8 @@ wxAccStatus TrackPanelAx::GetState( int childId, long* state )
    }
    else     // childId == wxACC_SELF
    {
-      *state = wxACC_STATE_SYSTEM_FOCUSABLE + wxACC_STATE_SYSTEM_FOCUSED;
+      // let wxWidgets use a standard accessible object for the state
+      return wxACC_NOT_IMPLEMENTED;
    }
 #endif
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5757

When the Music import dialog opens, it's not automatically read by NVDA or Narrator, but it is by Jaws. Both NVDA and Narrator still think that the focus is the imported track.

Problem:
In TrackPanelAx::GetState(), the state of the list or a list item is given as focussed without checking whether it is actually focussed. Looks like this has always been the case, but hasn't been a problem up to now.

Fix:
Check whether focused: For the list item, explicitly check, and the for list, let wxWidgets do this using a standard accessible object.

QA:
This fix needs to be checked with NVDA and with Narrator.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
