### PR TITLE
Copy selection toolbar start and stop time string into clipboard

### DIFF
--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -1018,6 +1018,7 @@ auto SelectMenu()
                Command( wxT("SelRestore"), XXO("Retrieve Selectio&n"),
                   FN(OnSelectionRestore), TracksExistFlag() )
             )
+         )
 
          //////////////////////////////////////////////////////////////////////////
 
@@ -1037,8 +1038,7 @@ auto SelectMenu()
 
          Command( wxT("CopySelTimestamp"), XXO("Copy &Selection Timestamp"),
             FN(OnCopySelTimestamp), AlwaysEnabledFlag,
-            Options{}.LongName( XO("Copy Selection Timestamp to Clipboard")))
-         )
+            Options{}.LongName( XO("Copy Selection Timestamp to Clipboard") ) )
       ),
 
       Section( "",

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -20,6 +20,7 @@
 #include "CommandContext.h"
 #include "MenuRegistry.h"
 #include "../toolbars/ControlToolBar.h"
+#include "../toolbars/SelectionBar.h"
 #include "../tracks/ui/SelectHandle.h"
 #include "../tracks/labeltrack/ui/LabelTrackView.h"
 #include "../tracks/playabletrack/wavetrack/ui/WaveChannelView.h"
@@ -593,6 +594,13 @@ void OnSelectionRestore(const CommandContext &context)
    ProjectHistory::Get( project ).ModifyState(false);
 }
 
+void OnSelStrToClipboard(const CommandContext &context)
+{
+   auto &project = context.project;
+   auto &selectionBar = SelectionBar::Get( project );
+   selectionBar.SelectionToClipboard();
+}
+
 // Handler state:
 bool mCursorPositionHasBeenStored{ false };
 double mCursorPositionStored{ 0.0 };
@@ -1009,6 +1017,12 @@ auto SelectMenu()
                // Audacity had 'Retrieve Regio&n' here previously.
                Command( wxT("SelRestore"), XXO("Retrieve Selectio&n"),
                   FN(OnSelectionRestore), TracksExistFlag() )
+            ),
+
+            Section("",
+               Command(wxT("SelStrToClipboard"), XXO("Selection String to &Clipboard"),
+                  FN(OnSelStrToClipboard), AlwaysEnabledFlag,
+                  Options{}.LongName(XO("Selection Time Range String to Clipboard")))
             )
          )
 

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -594,7 +594,7 @@ void OnSelectionRestore(const CommandContext &context)
    ProjectHistory::Get( project ).ModifyState(false);
 }
 
-void OnSelStrToClipboard(const CommandContext &context)
+void OnCopySelTimestamp(const CommandContext &context)
 {
    auto &project = context.project;
    auto &selectionBar = SelectionBar::Get( project );
@@ -1017,14 +1017,7 @@ auto SelectMenu()
                // Audacity had 'Retrieve Regio&n' here previously.
                Command( wxT("SelRestore"), XXO("Retrieve Selectio&n"),
                   FN(OnSelectionRestore), TracksExistFlag() )
-            ),
-
-            Section("",
-               Command(wxT("SelStrToClipboard"), XXO("Selection String to &Clipboard"),
-                  FN(OnSelStrToClipboard), AlwaysEnabledFlag,
-                  Options{}.LongName(XO("Selection Time Range String to Clipboard")))
             )
-         )
 
          //////////////////////////////////////////////////////////////////////////
 
@@ -1038,9 +1031,14 @@ auto SelectMenu()
 
          Command( wxT("StoreCursorPosition"), XXO("Store Cursor Pos&ition"),
             FN(OnCursorPositionStore),
-            WaveTracksExistFlag() )
+            WaveTracksExistFlag() ),
          // Save cursor position is used in some selections.
          // Maybe there should be a restore for it?
+
+         Command( wxT("CopySelTimestamp"), XXO("Copy &Selection Timestamp"),
+            FN(OnCopySelTimestamp), AlwaysEnabledFlag,
+            Options{}.LongName( XO("Copy Selection Timestamp to Clipboard")))
+         )
       ),
 
       Section( "",

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -209,6 +209,7 @@ void SelectionBar::AddTitle(
    auStaticText * pTitle = safenew auStaticText(this, translated );
    pTitle->SetBackgroundColour( theTheme.Colour( clrMedium ));
    pTitle->SetForegroundColour( theTheme.Colour( clrTrackPanelText ) );
+   pTitle->SetToolTip( XO("Right click copy timestamp").Translation() );
    pSizer->Add( pTitle, 0, wxEXPAND | wxRIGHT, 5 );
 
    pTitle->Bind(

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -228,15 +228,6 @@ void SelectionBar::AddTime(int id, wxSizer * pSizer)
       wxEVT_TEXT,
       [this, id](auto& evt) { ModifySelection(id, evt.GetInt() != 0); });
 
-   pCtrl->Bind(
-      wxEVT_CHAR_HOOK,
-      [this, id](auto& evt) {
-         if (evt.GetKeyCode() == wxS('C') && evt.ControlDown())
-            SelectionToClipboard();
-         else
-            evt.Skip();
-      });
-
    pSizer->Add(pCtrl, 0, wxALIGN_TOP | wxRIGHT, 5);
 
    mTimeControls[id] = pCtrl;

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -211,10 +211,6 @@ void SelectionBar::AddTitle(
    pSizer->Add( pTitle, 0, wxEXPAND | wxRIGHT, 5 );
 
    pTitle->Bind(
-      wxEVT_LEFT_DCLICK,
-      [this](auto& evt) { SelectionToClipboard(); });
-
-   pTitle->Bind(
       wxEVT_RIGHT_UP,
       [this](auto& evt) { SelectionToClipboard(); });
 }

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -45,6 +45,7 @@ selection range.
 #include <wx/notifmsg.h>
 #include <wx/regex.h>
 
+
 #include "AudioIO.h"
 #include "AColor.h"
 #include "../KeyboardCapture.h"

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -659,47 +659,17 @@ void SelectionBar::FitToTimeControls()
    Updated();
 }
 
-void SelectionBar::SelectionToClipboard() {
+void SelectionBar::SelectionToClipboard()
+{
    wxString timeRange = wxT("");
-   const static wxRegEx reHead(wxT(R"(^(00[^\d\.]+)[\d\.])"), wxRE_ADVANCED);
-   const static wxRegEx reTail(wxT(R"((\.\d{3})[^\d]*$)"), wxRE_ADVANCED);
-   const static wxRegEx reLead0(wxT(R"(0(\d[^\d]*))"), wxRE_ADVANCED);
    int i = 0;
-   for (auto& ctrl : mTimeControls)
+   for (auto ctrl : mTimeControls)
    {
       if (ctrl == nullptr)
          continue;
       auto tmStr = ctrl->GetString();
       tmStr.Replace(wxT(" "), wxT(""));
-      // remove 00h00m 00时00分(zh_CN) 00時00分(zh_TW) 00時間00分(Japanese)
-      while (reHead.Matches(tmStr))
-         tmStr.Replace(reHead.GetMatch(tmStr, 1), wxT(""));
-      // replace 0.000=>''  0.100=>0.1  0.010=>0.01
-      if (reTail.Matches(tmStr)) {
-         auto dotnum = reTail.GetMatch(tmStr, 1);
-         const auto dncopy = dotnum;
-         if (dotnum[3] == wxS('0')) {
-            dotnum.erase(3, 1);
-            if (dotnum[2] == wxS('0')) {
-               dotnum.erase(2, 1);
-               if (dotnum[1] == wxS('0')) {
-                  dotnum.erase(1, 1);
-               }
-            }
-         }
-         if (dotnum == wxT(".")) dotnum = wxT("");
-         tmStr.Replace(dncopy, dotnum);
-      }
-      // replace 1m00s => 1m0s 05.123s => 5.123s 00.003s => 0.003s
-      wxString tmStrBeforeDot = tmStr;
-      wxString tmStrDotTail = wxT("");
-      const auto dotLoc = tmStr.Find(wxT("."));
-      if (dotLoc >= 0) {
-         tmStrBeforeDot = tmStr.substr(0, dotLoc);
-         tmStrDotTail = tmStr.Mid(dotLoc);
-      }
-      reLead0.ReplaceAll(&tmStrBeforeDot, wxT("\\1"));
-      timeRange += tmStrBeforeDot + tmStrDotTail;
+      timeRange += tmStr;
       timeRange += (i == 0)? wxT("-"): wxT("");
       ++i;
    }

--- a/src/toolbars/SelectionBar.cpp
+++ b/src/toolbars/SelectionBar.cpp
@@ -227,6 +227,15 @@ void SelectionBar::AddTime(int id, wxSizer * pSizer)
       wxEVT_TEXT,
       [this, id](auto& evt) { ModifySelection(id, evt.GetInt() != 0); });
 
+   pCtrl->Bind(
+      wxEVT_CHAR_HOOK,
+      [this, id](auto& evt) {
+         if (evt.GetKeyCode() == wxS('C') && evt.ControlDown())
+            SelectionToClipboard();
+         else
+            evt.Skip();
+      });
+
    pSizer->Add(pCtrl, 0, wxALIGN_TOP | wxRIGHT, 5);
 
    mTimeControls[id] = pCtrl;

--- a/src/toolbars/SelectionBar.h
+++ b/src/toolbars/SelectionBar.h
@@ -66,6 +66,7 @@ class AUDACITY_DLL_API SelectionBar final : public ToolBar {
    void SetTimes(double start, double end);
 
    void SetSelectionFormat(const NumericFormatID & format);
+   void SelectionToClipboard();
    void RegenerateTooltips() override;
 
  private:


### PR DESCRIPTION
Copy selection toolbar start and stop time string into clipboard.

Resolves: [issues 5759](https://github.com/audacity/audacity/issues/5759)

Double click or right click selection toolbar label, or from menu "Select" -> "Region" -> "Selection String to Clipboard", or assign a hotkey to above menu item. It output time range string like "1m3.221s-1h22m16.331s" to clipboard, and a notify from system tray.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
