### PR TITLE
Timer Record: incorrect default number of channels.

### DIFF
--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -214,6 +214,7 @@ TimerRecordDialog::TimerRecordDialog(
    }
 
    m_iAutoExportSampleRate = ProjectRate::Get(mProject).GetRate();
+   m_iAutoExportChannels = AudioIORecordChannels.Read();
 
    ShuttleGui S(this, eIsCreating);
    this->PopulateOrExchange(S);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5580
May also at least help with: https://github.com/audacity/audacity/issues/4952

Timer Record automatic export defaults to mono when project is set to record in stereo

Problem:
In the TimerRecordDialog class, m_iAutoExportChannels is initialized to 0; In the TimerRecordDialog, if you enable automatic export, but don't press the Select button to open the Export Audio dialog, then this leads to the export failing. If you do press the Select button and open the Export Audio dialog, then initially channels is set to mono, even if you're going to record in stereo. (There's a a call to TimerRecordExportDialog::Bind with number of channels equal to 0, then a call to ExportFilePanel::Init, with number of channels 0. When this parameter is zero this Init function gets the correct number of channels from the tracks to be exported, but in this context, there are as yet no tracks.)

Fix:
Set m_iAutoExportChannels to the number of recording channels.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
