### PR TITLE
Configure custom FFmpeg options dialog: accessibility names

### DIFF
--- a/modules/mod-ffmpeg/ExportFFmpegOptions.cpp
+++ b/modules/mod-ffmpeg/ExportFFmpegOptions.cpp
@@ -25,6 +25,10 @@
 #include "AudacityMessageBox.h"
 #include "HelpSystem.h"
 
+#if wxUSE_ACCESSIBILITY
+#include "WindowAccessible.h"
+#endif
+
 BEGIN_EVENT_TABLE(ExportFFmpegOptions, wxDialogWrapper)
    EVT_BUTTON(wxID_OK,ExportFFmpegOptions::OnOK)
    EVT_BUTTON(wxID_HELP,ExportFFmpegOptions::OnGetURL)
@@ -595,10 +599,17 @@ void ExportFFmpegOptions::PopulateOrExchange(ShuttleGui & S)
             S.SetStretchyRow(1);
             S.Id(FEAllFormatsID).AddButton(XXO("Show All Formats"));
             S.Id(FEAllCodecsID).AddButton(XXO("Show All Codecs"));
-            mFormatList = S.Id(FEFormatID).AddListBox(mFormatNames);
+            mFormatList = S.Id(FEFormatID).Name(XO("Formats")).
+               AddListBox(mFormatNames);
             mFormatList->DeselectAll();
-            mCodecList = S.Id(FECodecID).AddListBox(mCodecNames);
+            mCodecList = S.Id(FECodecID).Name(XO("Codecs")).
+               AddListBox(mCodecNames);
             mCodecList->DeselectAll();
+#if wxUSE_ACCESSIBILITY
+            // so that names can be set on standard controls
+            safenew WindowAccessible(mFormatList);
+            safenew WindowAccessible(mCodecList);
+#endif
          }
          S.EndMultiColumn();
          S.StartVerticalLay();


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4956

Problem:
Lists of formats and codecs don't have accessibility names. (For sighted users, the nature of the lists is obvious from the layout.)

Fix:
Add accessibility names for these lists.

Resolves: https://github.com/audacity/audacity/issues/4956

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
