### PR TITLE
Don't split source stereo track, dragging clip into another track...

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -947,10 +947,15 @@ bool WaveTrack::LinkConsistencyFix(bool doFix)
       // Set the common channel group rate from the leader's rate
       if (mLegacyRate > 0)
       {
+         auto next = *TrackList::Channels(this).first.advance(1);
          SetRate(mLegacyRate);
          mLegacyRate = 0;
+         if (next)
+            next->mLegacyRate = 0;
          if (mLegacyFormat != undefinedSample)
             WaveTrackData::Get(*this).SetSampleFormat(mLegacyFormat);
+         if (next && next->mLegacyFormat != undefinedSample)
+            WaveTrackData::Get(*next).SetSampleFormat(mLegacyFormat);
       }
       removeZeroClips(mClips);
    }


### PR DESCRIPTION
... the bug occurred only for tracks deserialized from a project file, and only the first time (not again, after undo and repetition of the drag)

Resolves: #5389 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
