### PR TITLE
Fixes the assertion in `WaveClipAdjustBorderHandle`

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -86,16 +86,19 @@ double GetLeftAdjustLimit(const WaveTrack::Interval& interval,
                           bool isStretchMode)
 {
    if (!adjustingLeftBorder)
-      return interval.Start() + 1.0 / track.GetRate();
+      return std::min(
+         interval.GetSequenceEndTime(),
+         interval.Start() + 1.0 / track.GetRate()
+      );
 
    const auto prevInterval = track.GetNextInterval(interval, PlaybackDirection::backward);
    if(isStretchMode)
       return prevInterval ? prevInterval->End() :
                             std::numeric_limits<double>::lowest();
    if(prevInterval)
-      return std::max(interval.GetClip(0)->GetSequenceStartTime(),
+      return std::max(interval.GetSequenceStartTime(),
                 prevInterval->End());
-   return interval.GetClip(0)->GetSequenceStartTime();
+   return interval.GetSequenceStartTime();
 }
 
 double GetRightAdjustLimit(
@@ -103,7 +106,10 @@ double GetRightAdjustLimit(
    bool isStretchMode)
 {
    if (adjustingLeftBorder)
-      return interval.End() - 1.0 / track.GetRate();
+      return std::max(
+         interval.GetSequenceStartTime(),
+         interval.End() - 1.0 / track.GetRate()
+      );
 
    const auto nextInterval = track.GetNextInterval(interval, PlaybackDirection::forward);
    if (isStretchMode)
@@ -111,9 +117,9 @@ double GetRightAdjustLimit(
                             std::numeric_limits<double>::max();
 
    if(nextInterval)
-      return std::min(interval.GetClip(0)->GetSequenceEndTime(),
+      return std::min(interval.GetSequenceEndTime(),
                       nextInterval->Start());
-   return interval.GetClip(0)->GetSequenceEndTime();
+   return interval.GetSequenceEndTime();
 }
 } // namespace
 


### PR DESCRIPTION
Make sure that adjustment range boundaries does not exceed actual clip boundaries

QA:
 - User can't create clips that are shorter than 1 sample length long with trim/stretch 
 - Correct trim boundaries detected (trims are limited by the trimmed clip length itself and other clips)

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
