### PR TITLE
Tempo detection: cache miss minimization

### DIFF
--- a/src/ClipMirAudioReader.cpp
+++ b/src/ClipMirAudioReader.cpp
@@ -44,8 +44,10 @@ void ClipMirAudioReader::AddChannel(
    size_t iChannel, float* buffer, sampleCount start, size_t len) const
 {
    constexpr auto mayThrow = false;
-   auto& cache =
-      const_cast<std::optional<AudioSegmentSampleView>&>(mCache[iChannel]);
-   cache.emplace(mClip.GetSampleView(iChannel, start, len, mayThrow));
+   const auto iCache = mUseFirst[iChannel] ? 0 : 1;
+   auto& cache = mCache[iChannel][iCache];
+   auto view = mClip.GetSampleView(iChannel, start, len, mayThrow);
+   cache.emplace(std::move(view));
    cache->AddTo(buffer, len);
+   mUseFirst[iChannel] = !mUseFirst[iChannel];
 }

--- a/src/ClipMirAudioReader.h
+++ b/src/ClipMirAudioReader.h
@@ -38,5 +38,10 @@ private:
       size_t iChannel, float* buffer, sampleCount start, size_t len) const;
 
    const ClipInterface& mClip;
-   std::array<std::optional<AudioSegmentSampleView>, 2> mCache;
+   // An array with two entries because maybe two channels, and each channel has
+   // two caches to cope with back-and-forth access between beginning and end
+   // of clip data, in case samples are queried circularly.
+   using ChannelCache = std::array<std::optional<AudioSegmentSampleView>, 2>;
+   mutable std::array<ChannelCache, 2> mCache;
+   mutable std::array<bool, 2> mUseFirst { true, true };
 };


### PR DESCRIPTION
Resolves: #5854 

I tested this by adding logging to the `SqliteSampleBlock`. I imported an 8-second mono file, which needs two sqlite blocks. Without this change, there were 11 sqlite queries, against only just 3 with.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Smoke-testing the tempo detection feature looks fine. (Most noticeable speed improvement would be on a weak, weak machine for clips between 6 and 10 seconds. Maybe even this may not be noticeable, but the code change was easy.)