### PR TITLE
Tempo and upper time signature: problem with some keyboards

### DIFF
--- a/src/MenuCreator.cpp
+++ b/src/MenuCreator.cpp
@@ -310,6 +310,13 @@ FormatLabelWithDisabledAccel(const CommandManager::CommandListEntry &entry)
          if( key.StartsWith(",") ) break;
          if( key.StartsWith(".") ) break;
 
+         // https://github.com/audacity/audacity/issues/5868
+         // On German and Norwegian keyboards, [ and ] are
+         // AltGr 8 and AltGr 9. On Windows typing 8 or 9 match
+         // [ or ] repectively when they are accelerators in menus.
+         if ( key.StartsWith("[") ) break;
+         if ( key.StartsWith("]") ) break;
+
 #endif
          //wxLogDebug("Added Accel:[%s][%s]", entry.label, entry.key );
          // Normal accelerator.


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5868

Problem:
Tempo and upper time signature: using German or Norwegian keyboard, can't enter digits 8 or 9.

When the digits 8 or 9 are typed (or any digit) MenuCreator::FilterKeyEvent() returns these to wxWidgets for further processing, without them being matched to the shortcuts of any commands. However, on Windows, on being returned to wxWidgets, any keys are first matched with accelerators in the menus, before being given to the control which is the focus. In the German and Norwegian keyboard layouts, [ and ] are AltGr 8 and AltGr 9. Not sure quite why, but 8 and 9 match the keyboard accelerators [ and ].

Fix:
In FormatLabelWithDisabledAccel(), add [ and ] to the accelerators which are disabled.

Resolves: https://github.com/audacity/audacity/issues/5868


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
