### PR TITLE
allow building the tests without using conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,15 +228,12 @@ cmd_option( ${_OPT}has_url_schemes_support
    "Build custom URL schemes support into Audacity"
    Off)
 
-include( CMakeDependentOption )
-
-cmake_dependent_option(
+cmd_option(
    ${_OPT}has_tests
    "Enables automated testing support"
-   On
-   "${_OPT}conan_enabled"
-   Off
-)
+   On)
+
+include( CMakeDependentOption )
 
 cmake_dependent_option(
    ${_OPT}has_audiocom_upload


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/discussions/5841

This change allows to build the tests even though conan is not used.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] ~~If changes are extensive, then there is a sequence of easily reviewable commits~~
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

---

Related to https://github.com/audacity/audacity/issues/5771
cc @matoro since they initially wrote the patch