### PR TITLE
Fix crash upon closing realtime Reverb effect on Windows

### DIFF
--- a/src/effects/RealtimeEffectStateUI.cpp
+++ b/src/effects/RealtimeEffectStateUI.cpp
@@ -115,7 +115,10 @@ void RealtimeEffectStateUI::Show(AudacityProject& project)
       });
 
    mParameterChangedSubscription = mEffectUIHost->GetEditor()->Subscribe(
-      [this](auto) { UndoManager::Get(*mpProject).MarkUnsaved(); });
+      [this](auto) { if (mpProject) {  // This can be null if closing an effect without making changes.
+                        UndoManager::Get(*mpProject).MarkUnsaved();
+                     }
+                   });
 }
 
 void RealtimeEffectStateUI::Hide(AudacityProject* project)


### PR DESCRIPTION
Resolves: #5860

Add null check before calling MarkUnsaved on project.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
