### PR TITLE
export dialog: center and max width

### DIFF
--- a/modules/mod-cl/ExportCL.cpp
+++ b/modules/mod-cl/ExportCL.cpp
@@ -217,6 +217,7 @@ public:
                   mLastCommand = event.GetString();
                });
                mLastCommand = mCommandBox->GetValue();
+               mCommandBox->SetMaxSize(wxSize(50,400));
 
                S.AddButton(XXO("Browse..."), wxALIGN_CENTER_VERTICAL)
                   ->Bind(wxEVT_BUTTON, &ExportOptionsCLEditor::OnBrowse, this);

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -231,6 +231,7 @@ ExportAudioDialog::ExportAudioDialog(wxWindow* parent,
 
    Layout();
    Fit();
+   Center();
 }
 
 ExportAudioDialog::~ExportAudioDialog() = default;


### PR DESCRIPTION
Resolves: #5515
Resolves: #5884

hey look it's the same PR again but for a different dialog and limiting the exciting direction of X this time instead of Y. 

It's intentional that the thing is not centered for the updates; the window should just extend downwards instead of shifting position to stay centered.