### PR TITLE
Playback cursor issues after seeking.

### DIFF
--- a/libraries/lib-audio-io/PlaybackSchedule.cpp
+++ b/libraries/lib-audio-io/PlaybackSchedule.cpp
@@ -75,7 +75,8 @@ bool PlaybackPolicy::Done( PlaybackSchedule &schedule,
 double PlaybackPolicy::OffsetSequenceTime(
    PlaybackSchedule &schedule, double offset )
 {
-   const auto time = schedule.GetSequenceTime() + offset;
+   auto time = schedule.GetSequenceTime() + offset;
+   time = std::clamp(time, schedule.mT0, schedule.mT1);
    schedule.RealTimeInit( time );
    return time;
 }

--- a/src/DefaultPlaybackPolicy.h
+++ b/src/DefaultPlaybackPolicy.h
@@ -23,7 +23,7 @@ class DefaultPlaybackPolicy final
 {
 public:
    DefaultPlaybackPolicy( AudacityProject &project,
-      double trackEndTime, double loopEndTime,
+      double trackEndTime, double loopEndTime, std::optional<double> pStartTime,
       bool loopEnabled, bool variableSpeed);
    ~DefaultPlaybackPolicy() override;
 
@@ -34,6 +34,8 @@ public:
    BufferTimes SuggestedBufferTimes(PlaybackSchedule &schedule) override;
 
    bool Done( PlaybackSchedule &schedule, unsigned long ) override;
+
+   double OffsetSequenceTime(PlaybackSchedule& schedule, double offset) override;
 
    PlaybackSlice GetPlaybackSlice(
       PlaybackSchedule &schedule, size_t available ) override;
@@ -71,6 +73,7 @@ private:
    double mLastPlaySpeed{ 1.0 };
    const double mTrackEndTime;
    double mLoopEndTime;
+   std::optional<double> mpStartTime;
    size_t mRemaining{ 0 };
    bool mProgress{ true };
    bool mLoopEnabled{ true };

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1207,7 +1207,7 @@ static ProjectAudioIO::DefaultOptions::Scope sScope {
             -> std::unique_ptr<PlaybackPolicy>
       {
          return std::make_unique<DefaultPlaybackPolicy>( project,
-            trackEndTime, loopEndTime,
+            trackEndTime, loopEndTime, options.pStartTime,
             options.loopEnabled, options.variableSpeed);
       };
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2133

Problem:
After seeking, there are a number of cases in which the playback does not correspond to the playback position. A number of these are listed in the issue: https://github.com/audacity/audacity/issues/2133

The problem was caused by this commit: 5af2a26, which removed the constraints on seeking in PlaybackPolicy::OffsetTrackTime().

Fix:
Reinstate the constraints for seeking in PlaybackPolicy(), and add DefaultPlaybackPolicy::OffsetSequenceTime() with appropriate constraints for this policy.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
