### PR TITLE
Add RemoveDCOffset effect

### DIFF
--- a/RemoveDCOffset.cpp
+++ b/RemoveDCOffset.cpp
@@ -1,0 +1,355 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  RemoveDCOffset.h
+
+  Patrick Kallenbach
+
+  Adapted from Normalize
+  Dominic Mazzoni
+  Vaughan Johnson (Preview)
+
+*******************************************************************//**
+
+\class EffectRemoveDCOffset
+\brief An Effect to remove DC offset from a selection, adapted from Normalize.cpp
+
+*//*******************************************************************/
+#include "RemoveDCOffset.h"
+#include "EffectEditor.h"
+#include "EffectOutputTracks.h"
+#include "LoadEffects.h"
+
+#include <math.h>
+
+#include <wx/checkbox.h>
+#include <wx/stattext.h>
+#include <wx/valgen.h>
+
+#include "Prefs.h"
+#include "../ProjectFileManager.h"
+#include "ShuttleGui.h"
+#include "WaveTrack.h"
+#include "../widgets/valnum.h"
+#include "ProgressDialog.h"
+
+const EffectParameterMethods& EffectRemoveDCOffset::Parameters() const
+{
+   static CapturedParameters<EffectRemoveDCOffset> parameters;
+   return parameters;
+}
+
+const ComponentInterfaceSymbol EffectRemoveDCOffset::Symbol
+{ XO("RemoveDCOffset") };
+
+namespace{ BuiltinEffectsModule::Registration< EffectRemoveDCOffset > reg; }
+
+BEGIN_EVENT_TABLE(EffectRemoveDCOffset, wxEvtHandler)
+   //EVT_CHECKBOX(wxID_ANY, EffectRemoveDCOffset::OnUpdateUI)
+   //EVT_TEXT(wxID_ANY, EffectRemoveDCOffset::OnUpdateUI)
+END_EVENT_TABLE()
+
+EffectRemoveDCOffset::EffectRemoveDCOffset()
+{
+   Parameters().Reset(*this);
+   SetLinearEffectFlag(false);
+}
+
+EffectRemoveDCOffset::~EffectRemoveDCOffset()
+{
+}
+
+// ComponentInterface implementation
+
+ComponentInterfaceSymbol EffectRemoveDCOffset::GetSymbol() const
+{
+   return Symbol;
+}
+
+TranslatableString EffectRemoveDCOffset::GetDescription() const
+{
+   return XO("Removes DC Offset of selected region");
+}
+
+ManualPageID EffectRemoveDCOffset::ManualPage() const
+{
+   return L"RemoveDCOffset";
+}
+
+bool EffectRemoveDCOffset::IsInteractive() const
+{
+   return false;
+}
+
+// EffectDefinitionInterface implementation
+
+EffectType EffectRemoveDCOffset::GetType() const
+{
+   return EffectTypeProcess;
+}
+
+// Effect implementation
+
+bool EffectRemoveDCOffset::CheckWhetherSkipEffect(const EffectSettings &) const
+{
+   return false;
+}
+
+bool EffectRemoveDCOffset::Process(EffectInstance &, EffectSettings &)
+{
+   float ratio = 1;
+
+   //Iterate over each track
+   EffectOutputTracks outputs { *mTracks, GetType(), { { mT0, mT1 } } };
+   bool bGoodResult = true;
+   double progress = 0;
+   TranslatableString topMsg = XO("Removing DC offset...\n");
+
+   for (auto track : outputs.Get().Selected<WaveTrack>()) {
+      // Get start and end times from track
+      double trackStart = track->GetStartTime();
+      double trackEnd = track->GetEndTime();
+
+      // Set the current bounds to whichever left marker is
+      // greater and whichever right marker is less:
+      mCurT0 = std::max(trackStart, mT0);
+      mCurT1 = std::min(trackEnd, mT1);
+
+      // Process only if the right marker is to the right of the left marker
+      if (mCurT1 > mCurT0) {
+         wxString trackName = track->GetName();
+
+         std::vector<float> extents;
+         float maxExtent{ std::numeric_limits<float>::lowest() };
+         std::vector<float> offsets;
+
+         const auto channels = track->Channels();
+         // mono or 'stereo tracks independently'
+         const bool oneChannel = (channels.size() == 1);
+         auto msg = oneChannel
+            ? topMsg +
+               XO("Analyzing: %s").Format(trackName)
+            : topMsg +
+               // TODO: more-than-two-channels-message
+               XO("Analyzing first track of stereo pair: %s").Format(trackName);
+
+         const auto progressReport = [&](double fraction){
+            return !TotalProgress(
+               (progress + fraction / double(2 * GetNumWaveTracks())), msg);
+         };
+
+         // Analysis loop over channels collects offsets and extent
+         for (auto channel : channels) {
+            float offset = 0;
+            float extent = 0;
+            bGoodResult = AnalyseTrack(*channel, progressReport,
+               mCurT0, mCurT1, offset, extent);
+            if (!bGoodResult)
+               goto break2;
+            progress += 1.0 / double(2 * GetNumWaveTracks());
+            extents.push_back(extent);
+            maxExtent = std::max(maxExtent, extent);
+            offsets.push_back(offset);
+            // TODO: more-than-two-channels-message
+            if (!oneChannel)
+               msg = topMsg +
+                  XO("Analyzing second track of stereo pair: %s")
+                     .Format(trackName);
+         }
+
+         if (oneChannel) {
+            if (TrackList::NChannels(*track) == 1)
+               // really mono
+               msg = topMsg +
+                  XO("Processing: %s").Format(trackName);
+            else
+               //'stereo tracks independently'
+               // TODO: more-than-two-channels-message
+               msg = topMsg +
+                  XO("Processing stereo channels independently: %s")
+                     .Format(trackName);
+         }
+         else
+            msg = topMsg +
+               // TODO: more-than-two-channels-message
+               XO("Processing first track of stereo pair: %s")
+                  .Format(trackName);
+
+         // Use multiplier in the second, processing loop over channels
+         auto pOffset = offsets.begin();
+         auto pExtent = extents.begin();
+         for (const auto channel : channels) {
+            const auto extent = oneChannel ? *pExtent++: maxExtent;
+            if (false ==
+                (bGoodResult = ProcessOne(*channel, msg, progress, *pOffset++)))
+               goto break2;
+            // TODO: more-than-two-channels-message
+            msg = topMsg +
+               XO("Processing second track of stereo pair: %s")
+                  .Format(trackName);
+         }
+      }
+   }
+
+   break2:
+
+   if (bGoodResult)
+      outputs.Commit();
+
+   return bGoodResult;
+}
+
+// EffectRemoveDCOffset implementation
+
+bool EffectRemoveDCOffset::AnalyseTrack(const WaveChannel &track,
+   const ProgressReport &report,
+    const double curT0, const double curT1,
+   float &offset, float &extent)
+{
+   bool result = AnalyseTrackData(track, report, curT0, curT1, offset);;
+   float min = -1.0 + offset;
+   float max = 1.0 + offset;
+
+   extent = fmax(fabs(min), fabs(max));
+   return result;
+}
+
+//AnalyseTrackData() takes a track, transforms it to bunch of buffer-blocks,
+//and executes selected AnalyseOperation on it...
+bool EffectRemoveDCOffset::AnalyseTrackData(const WaveChannel &track,
+   const ProgressReport &report, const double curT0, const double curT1,
+   float &offset)
+{
+   bool rc = true;
+
+   //Transform the marker timepoints to samples
+   auto start = track.TimeToLongSamples(curT0);
+   auto end = track.TimeToLongSamples(curT1);
+
+   //Get the length of the buffer (as double). len is
+   //used simply to calculate a progress meter, so it is easier
+   //to make it a double now than it is to do it later
+   auto len = (end - start).as_double();
+
+   //Initiate a processing buffer.  This buffer will (most likely)
+   //be shorter than the length of the track being processed.
+   Floats buffer{ track.GetMaxBlockSize() };
+
+   double sum = 0.0; // dc offset inits
+
+   sampleCount blockSamples;
+   sampleCount totalSamples = 0;
+
+   //Go through the track one buffer at a time. s counts which
+   //sample the current buffer starts at.
+   auto s = start;
+   while (s < end) {
+      //Get a block of samples (smaller than the size of the buffer)
+      //Adjust the block size if it is the final block in the track
+      const auto block = limitSampleBufferSize(
+         track.GetBestBlockSize(s),
+         end - s
+      );
+
+      //Get the samples from the track and put them in the buffer
+      track.GetFloats(
+         buffer.get(), s, block, FillFormat::fillZero, true, &blockSamples);
+      totalSamples += blockSamples;
+
+      //Process the buffer.
+      sum = AnalyseDataDC(buffer.get(), block, sum);
+
+      //Increment s one blockfull of samples
+      s += block;
+
+      //Update the Progress meter
+      if (!report((s - start).as_double() / len)) {
+         rc = false; //lda .. break, not return, so that buffer is deleted
+         break;
+      }
+   }
+   if (totalSamples > 0)
+      // calculate actual offset (amount that needs to be added on)
+      offset = -sum / totalSamples.as_double();
+   else
+      offset = 0.0;
+
+   //Return true because the effect processing succeeded ... unless cancelled
+   return rc;
+}
+
+//ProcessOne() takes a track, transforms it to bunch of buffer-blocks,
+//and executes ProcessData, on it
+bool EffectRemoveDCOffset::ProcessOne(WaveChannel &track,
+   const TranslatableString &msg, double &progress, float offset)
+{
+   bool rc = true;
+
+   //Transform the marker timepoints to samples
+   auto start = track.TimeToLongSamples(mCurT0);
+   auto end = track.TimeToLongSamples(mCurT1);
+
+   //Get the length of the buffer (as double). len is
+   //used simply to calculate a progress meter, so it is easier
+   //to make it a double now than it is to do it later
+   auto len = (end - start).as_double();
+
+   //Initiate a processing buffer.  This buffer will (most likely)
+   //be shorter than the length of the track being processed.
+   Floats buffer{ track.GetMaxBlockSize() };
+
+   //Go through the track one buffer at a time. s counts which
+   //sample the current buffer starts at.
+   auto s = start;
+   while (s < end) {
+      //Get a block of samples (smaller than the size of the buffer)
+      //Adjust the block size if it is the final block in the track
+      const auto block = limitSampleBufferSize(
+         track.GetBestBlockSize(s),
+         end - s
+      );
+
+      //Get the samples from the track and put them in the buffer
+      track.GetFloats(buffer.get(), s, block);
+
+      //Process the buffer.
+      ProcessData(buffer.get(), block, offset);
+
+      //Copy the newly-changed samples back onto the track.
+      if (!track.Set((samplePtr) buffer.get(), floatSample, s, block)) {
+         rc = false;
+         break;
+      }
+
+      //Increment s one blockfull of samples
+      s += block;
+
+      //Update the Progress meter
+      if (TotalProgress(progress +
+                        ((s - start).as_double() / len)/double(2*GetNumWaveTracks()), msg)) {
+         rc = false; //lda .. break, not return, so that buffer is deleted
+         break;
+      }
+   }
+   progress += 1.0/double(2*GetNumWaveTracks());
+
+   //Return true because the effect processing succeeded ... unless cancelled
+   return rc;
+}
+
+/// @see AnalyseDataLoudnessDC
+double EffectRemoveDCOffset::AnalyseDataDC(float *buffer, size_t len, double sum)
+{
+   for(decltype(len) i = 0; i < len; i++)
+      sum += (double)buffer[i];
+   return sum;
+}
+
+void EffectRemoveDCOffset::ProcessData(float *buffer, size_t len, float offset)
+{
+   for(decltype(len) i = 0; i < len; i++) {
+      float adjFrame = (buffer[i] + offset);
+      buffer[i] = adjFrame;
+   }
+}

--- a/RemoveDCOffset.h
+++ b/RemoveDCOffset.h
@@ -1,0 +1,84 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  RemoveDCOffset.h
+
+  Patrick Kallenbach
+
+  Adapted from Normalize
+  Dominic Mazzoni
+  Vaughan Johnson (Preview)
+
+**********************************************************************/
+
+#ifndef __AUDACITY_EFFECT_REMOVEDCOFFSET__
+#define __AUDACITY_EFFECT_REMOVEDCOFFSET__
+
+#include "StatefulEffect.h"
+#include "Biquad.h"
+#include "ShuttleAutomation.h"
+#include <wx/weakref.h>
+#include <functional>
+
+class wxCheckBox;
+class wxStaticText;
+class wxTextCtrl;
+class ShuttleGui;
+class WaveChannel;
+
+class EffectRemoveDCOffset final : public StatefulEffect
+{
+public:
+   static inline EffectRemoveDCOffset *
+   FetchParameters(EffectRemoveDCOffset &e, EffectSettings &) { return &e; }
+   static const ComponentInterfaceSymbol Symbol;
+
+   EffectRemoveDCOffset();
+   virtual ~EffectRemoveDCOffset();
+
+   // ComponentInterface implementation
+
+   ComponentInterfaceSymbol GetSymbol() const override;
+   TranslatableString GetDescription() const override;
+   ManualPageID ManualPage() const override;
+   bool IsInteractive() const override;
+
+   // EffectDefinitionInterface implementation
+
+   EffectType GetType() const override;
+
+   // Effect implementation
+
+   bool CheckWhetherSkipEffect(const EffectSettings &settings) const override;
+   bool Process(EffectInstance &instance, EffectSettings &settings) override;
+
+private:
+   // EffectRemoveDCOffset implementation
+
+   bool ProcessOne(WaveChannel &track,
+      const TranslatableString &msg, double& progress, float offset);
+   using ProgressReport = std::function<bool(double fraction)>;
+   static bool AnalyseTrack(const WaveChannel &track,
+      const ProgressReport &report,
+      double curT0, double curT1,
+      float &offset, float &extent);
+   static bool AnalyseTrackData(const WaveChannel &track,
+      const ProgressReport &report, double curT0, double curT1,
+      float &offset);
+   static double AnalyseDataDC(float *buffer, size_t len, double sum);
+   void ProcessData(float *buffer, size_t len, float offset);
+
+private:
+   wxWeakRef<wxWindow> mUIParent{};
+
+   double mCurT0;
+   double mCurT1;
+   wxStaticText *mWarning;
+   bool mCreating;
+
+   const EffectParameterMethods& Parameters() const override;
+   DECLARE_EVENT_TABLE()
+};
+
+#endif


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2408

The original issue was requesting a DC Offset tool similar to what the Normalize effect can do before normalization. In my university class, we were assigned to find and contribute to an open source project, so I thought I should contribute to this project which I have used myself in the past. The new effect is modified from the existing Normalize effect to automatically remove the offset, bypassing the menu similar to the Invert effect. I am certain improvements could be made upon the modified files, perhaps adding more features, or removing steps that were required for the Normalize effect but not for DC offset removal. I also only added the effects to the src/effects folder, but I do not know if there is something else that needs to know of the updated effects, since it does not currently categorize with the other related effects.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
