### PR TITLE
Account for pitch ratio when evaluating time-and-pitch delay

### DIFF
--- a/libraries/lib-time-and-pitch/StaffPadTimeAndPitch.h
+++ b/libraries/lib-time-and-pitch/StaffPadTimeAndPitch.h
@@ -24,5 +24,6 @@ private:
    const int mSampleRate;
    const size_t mNumChannels;
    const double mTimeRatio;
+   double mPitchRatio;
    std::mutex mTimeAndPitchMutex;
 };


### PR DESCRIPTION
Resolves: #5905 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] pitch-shifting and time-stretching clips doesn't introduce delay, whether positive or negative. (If it is not obvious aurally, you may render the clip to observe the delay.)
