### PR TITLE
Set the correct number of output channels per track

### DIFF
--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -817,9 +817,7 @@ void ExportAudioDialog::UpdateTrackExportSettings(const ExportPlugin& plugin, in
       setting.t0 = skipSilenceAtBeginning ? tr->GetStartTime() : 0;
       setting.t1 = tr->GetEndTime();
 
-      // number of export channels?
-      // It's 1 only for a center-panned mono track
-      setting.channels = (IsMono(*tr) && tr->GetPan() == 0.0) ? 1 : 2;
+      setting.channels = mExportOptionsPanel->GetChannels();
       // Get name and title
       title = tr->GetName();
       if( title.empty() )


### PR DESCRIPTION
Resolves: #5750

QA:
Please check the following cases when "split by track" option choosen in Export Audio dialog
  1) Stereo tracks are correctly mixed down into mono
  2) Mono tracks are correctly exported as mono when panning is set to be off the center
  3) Mono tracks are expanded into stereo with panning being correctly applied.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
