### PR TITLE
Pitch and speed dialog: names read by screen readers are incorrect

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
@@ -156,17 +156,15 @@ void PitchAndSpeedDialog::PopulateOrExchange(ShuttleGui& s)
    {
       ScopedInvisiblePanel panel { s, 15 };
       s.SetBorder(0);
-      {
-         ScopedHorizontalLay h { s, wxLeft };
-         s.AddPrompt(XO("Clip Pitch"));
-      }
+
+      s.StartStatic(XO("Clip Pitch"));
       {
          ScopedHorizontalLay h { s, wxLeft };
          s.SetBorder(2);
          // Use `TieSpinCtrl` rather than `AddSpinCtrl`, too see updates
          // instantly when `UpdateDialog` is called.
          s.TieSpinCtrl(
-             Verbatim(""), mShift.semis, TimeAndPitchInterface::MaxCents / 100,
+            XO("semitones:"), mShift.semis, TimeAndPitchInterface::MaxCents / 100,
              TimeAndPitchInterface::MinCents / 100)
             ->Bind(wxEVT_TEXT, [&](wxCommandEvent& event) {
                const auto prevSemis = mShift.semis;
@@ -193,9 +191,7 @@ void PitchAndSpeedDialog::PopulateOrExchange(ShuttleGui& s)
                   // Something silly was entered; reset dialog
                   UpdateDialog();
             });
-         s.AddSpace(1, 0);
-         s.AddFixedText(XO("semitones,"));
-         s.TieSpinCtrl(Verbatim(""), mShift.cents, 100, -100)
+         s.TieSpinCtrl(XO("cents:"), mShift.cents, 100, -100)
             ->Bind(wxEVT_TEXT, [&](wxCommandEvent& event) {
                if (GetInt(event, mShift.cents))
                   OnPitchShiftChange(false);
@@ -203,8 +199,8 @@ void PitchAndSpeedDialog::PopulateOrExchange(ShuttleGui& s)
                   // Something silly was entered; reset dialog
                   UpdateDialog();
             });
-         s.AddFixedText(XO("cents"));
       }
+      s.EndStatic();
 
       s.AddSpace(0, 12);
       s.SetBorder(0);
@@ -215,7 +211,7 @@ void PitchAndSpeedDialog::PopulateOrExchange(ShuttleGui& s)
       }
       {
          ScopedHorizontalLay h { s, wxLeft };
-         auto txtCtrl = s.NameSuffix(Verbatim("%"))
+         auto txtCtrl = s.Name(XO("Clip Speed")).NameSuffix(Verbatim("%"))
                            .TieNumericTextBox({}, mClipSpeed, 14, true);
          txtCtrl->Enable(!mPlaybackOngoing);
          if (!mPlaybackOngoing)


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5912

Problem A:
The names of the first two controls are not read correctly by screen readers. These two controls are wxSpinCtrl, which on Windows create a text box which is a "buddy window", and which is the focus. This makes it very difficult to set a WindowAccessible so that the accessibility name can be made to include text coming after the control.

Fix A:
Change the layout of the labels of the controls so that Windows can automatically set the accessibility names such that they are useful.

Problem B:
The accessibility name of the third control is just "%", rather than "Clip Speed %".

Fix B:
Just add "Clip Speed" to the accessibility name using a standard ShuttleGui function.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
