### PR TITLE
Extra menu: duplicate access key

### DIFF
--- a/src/menus/TimelineMenus.cpp
+++ b/src/menus/TimelineMenus.cpp
@@ -48,7 +48,7 @@ using namespace MenuRegistry;
 auto ExtraSelectionMenu()
 {
    static auto menu = std::shared_ptr{ Menu(
-      wxT("Timeline"), XXO("&Timeline"),
+      wxT("Timeline"), XXO("Ti&meline"),
       Command(
          wxT("MinutesAndSeconds"), XXO("Minutes and Seconds"),
          OnSetMinutesSeconds, AlwaysEnabledFlag,


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/audacity/audacity/issues/5928)

Change the access key of Timeline so that there isn't a duplicate access key.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
