### PR TITLE
Import/Export preferences: accessibility issue

### DIFF
--- a/modules/mod-midi-import-export/ExportMIDI.cpp
+++ b/modules/mod-midi-import-export/ExportMIDI.cpp
@@ -32,9 +32,11 @@ void AddControls(ShuttleGui &S)
 {
    S.StartStatic(XO("Exported Allegro (.gro) files save time as:"));
    {
+#if defined(__WXMAC__)
       // Bug 2692: Place button group in panel so tabbing will work and,
       // on the Mac, VoiceOver will announce as radio buttons.
       S.StartPanel();
+#endif
       {
          S.StartRadioButtonGroup(NoteTrack::AllegroStyleSetting);
          {
@@ -43,7 +45,9 @@ void AddControls(ShuttleGui &S)
          }
          S.EndRadioButtonGroup();
       }
+#if defined(__WXMAC__)
       S.EndPanel();
+#endif
    }
    S.EndStatic();
 }

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -398,9 +398,11 @@ void AddControls(ShuttleGui &S)
 {
    S.StartStatic(XO("Exported Label Style:"));
    {
+#if defined(__WXMAC__)
       // Bug 2692: Place button group in panel so tabbing will work and,
       // on the Mac, VoiceOver will announce as radio buttons.
       S.StartPanel();
+#endif
       {
          S.StartRadioButtonGroup(LabelStyleSetting);
          {
@@ -409,7 +411,9 @@ void AddControls(ShuttleGui &S)
          }
          S.EndRadioButtonGroup();
       }
+#if defined(__WXMAC__)
       S.EndPanel();
+#endif
    }
    S.EndStatic();
 }

--- a/src/prefs/ImportExportPrefs.cpp
+++ b/src/prefs/ImportExportPrefs.cpp
@@ -140,7 +140,10 @@ void ImportExportPrefs::PopulateOrExchange(ShuttleGui & S)
          safenew WindowAccessible(musicImportsBox);
       }
 #endif
+#if defined(__WXMAC__)
+      // see https://bugzilla.audacityteam.org/show_bug.cgi?id=2692
       S.StartPanel();
+#endif
       {
          S.StartRadioButtonGroup(ImportExportPrefs::MusicFileImportSetting);
          {
@@ -150,7 +153,9 @@ void ImportExportPrefs::PopulateOrExchange(ShuttleGui & S)
          }
          S.EndRadioButtonGroup();
       }
+#if defined(__WXMAC__)
       S.EndPanel();
+#endif
    }
    S.EndStatic();
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5934

Problem:
The names of the group boxes are not read by Jaws or Narrator. But they are by NVDA.

The radio buttons are grandchildren of the group box, but they should be children. Extra panels where introduced by this commit: 7a55c90, to fix a problem with keyboard navigation of radio buttons on macOS: https://bugzilla.audacityteam.org/show_bug.cgi?id=2692 And I presume an extra panel was added in the Music imports group to follow this pattern.

Fix:
Only include the extra panel on Mac builds.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
