### PR TITLE
Move the Timeline sub menu

### DIFF
--- a/src/menus/TimelineMenus.cpp
+++ b/src/menus/TimelineMenus.cpp
@@ -48,7 +48,7 @@ using namespace MenuRegistry;
 auto ExtraSelectionMenu()
 {
    static auto menu = std::shared_ptr{ Menu(
-      wxT("Timeline"), XXO("Ti&meline"),
+      wxT("Timeline"), XXO("Tim&eline"),
       Command(
          wxT("MinutesAndSeconds"), XXO("Minutes and Seconds"),
          OnSetMinutesSeconds, AlwaysEnabledFlag,
@@ -69,6 +69,6 @@ auto ExtraSelectionMenu()
 }
 
 AttachedItem sAttachment2 { Indirect(ExtraSelectionMenu()),
-   wxT("Optional/Extra/Part1") };
+   wxT("View/Other/Toolbars") };
 
 } // namespace

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -341,7 +341,7 @@ auto ViewMenu()
       Section( "Windows" ),
 
       Section( "Other",
-         Command( wxT("ShowExtraMenus"), XXO("Enable &Extra Menus"),
+         Command( wxT("ShowExtraMenus"), XXO("Enable E&xtra Menus"),
             OnShowExtraMenus, AlwaysEnabledFlag,
             Options{}.CheckTest( wxT("/GUI/ShowExtraMenus"), false ) ),
          Command( wxT("ShowTrackNameInWaveform"), XXO("Show Track &Name as overlay"),


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5932

Problem:
Timeline sub menu isn't easy to find in the extra menu, which isn't shown by default, and the timeline view has increased importance in the upcoming 3.5. release.

Fix:
Move the timeline sub menu to the View menu.
The only available access key for Timeline on the View menu was the letter l. Given that is not a desirable access key due to the shortness of the underline indicating the access key, the access key "e" was chosen, and the access key of another item changed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
