### PR TITLE
MD5 checksum added by default on wavpack exports

### DIFF
--- a/modules/mod-wavpack/ExportWavPack.cpp
+++ b/modules/mod-wavpack/ExportWavPack.cpp
@@ -442,6 +442,7 @@ bool WavPackExportProcessor::Initialize(AudacityProject& project,
    else
       config.channel_mask = 0x3FFFF;
 
+   config.flags |= CONFIG_MD5_CHECKSUM;
    if (quality == 0) {
       config.flags |= CONFIG_FAST_FLAG;
    } else if (quality == 2) {


### PR DESCRIPTION
Resolves: [WavPack export: include MD5 audio checksum (-m option)](https://github.com/audacity/audacity/issues/5635)

The Flag 'CONFIG_MD5_CHECKSUM' set to the exporter API config. The exported wavpack files should have MD5 checksums by default after this fix.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
