### PR TITLE
Fix crash when locating FFmpeg library during export

### DIFF
--- a/modules/mod-ffmpeg/ExportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ExportFFmpeg.cpp
@@ -405,7 +405,6 @@ public:
    ExportOptionsFFmpegCustomEditor(ExportOptionsEditor::Listener* listener = nullptr)
       : mListener(listener)
    {
-      
    }
 
    void PopulateUI(ShuttleGui& S) override
@@ -479,8 +478,10 @@ public:
          if(it == mValues.end())
             return {};
 
-         const auto codecId = *std::get_if<std::string>(&it->second); 
-         mAVCodec = mFFmpeg->CreateEncoder(codecId.c_str());
+         const auto codecId = *std::get_if<std::string>(&it->second);
+         if (mFFmpeg) {
+            mAVCodec = mFFmpeg->CreateEncoder(codecId.c_str());
+         }
       }
       if(!mAVCodec)
          return {};
@@ -714,6 +715,9 @@ FFmpegExporter::FFmpegExporter(std::shared_ptr<FFmpegFunctions> ffmpeg,
    , mChannels(numChannels)
    , mSubFormat(subFormat)
 {
+   if (!mFFmpeg) {
+      mFFmpeg = FFmpegFunctions::Load();
+   }
 }
 
 std::unique_ptr<Mixer> FFmpegExporter::CreateMixer(const TrackList& tracks, bool selectionOnly, double startTime, double stopTime, MixerOptions::Downmix* mixerSpec)


### PR DESCRIPTION
Resolves: #5639

1) Add null check to GetSampleRateList().
2) Ensure ffmpeg is loaded in FFmpegExporter class.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
