### PR TITLE
Export multiple confirmation dialog: make Enter close dialog

### DIFF
--- a/libraries/lib-wx-init/HelpSystem.cpp
+++ b/libraries/lib-wx-init/HelpSystem.cpp
@@ -96,8 +96,11 @@ void HelpSystem::ShowInfoDialog( wxWindow *parent,
    {
       S.AddTitle( shortMsg );
       S.Style( wxTE_MULTILINE | wxTE_READONLY | wxTE_RICH | wxTE_RICH2 |
-              wxTE_AUTO_URL | wxTE_NOHIDESEL | wxHSCROLL )
-         .AddTextWindow(message);
+              wxTE_AUTO_URL | wxTE_NOHIDESEL | wxHSCROLL | wxTE_PROCESS_ENTER)
+         .AddTextWindow(message)
+         ->Bind(wxEVT_TEXT_ENTER, [&dlog](auto&) {
+         dlog.EndModal(wxID_OK);
+         });
 
       S.SetBorder( 0 );
       S.StartHorizontalLay(wxALIGN_CENTER_HORIZONTAL, 0);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5947

Problem:
In this dialog, a read-only text box showing the files exported is the initial focus. A user would expect that pressing Enter would close the dialog without the need to first tab to the OK button, but this is not the case.

Fix:
Use the wxEVT_TEXT_ENTER event, to close the dialog when the text box is the focus, and the user presses Enter.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
