### PR TITLE
Load default metadata if stored in the config

### DIFF
--- a/libraries/lib-tags/Tags.cpp
+++ b/libraries/lib-tags/Tags.cpp
@@ -265,21 +265,16 @@ Tags & Tags::operator=(const Tags & src)
 
 void Tags::LoadDefaults()
 {
-   wxString path;
-   wxString name;
    wxString value;
-   long ndx;
-   bool cont;
-
    auto tagsGroup = gPrefs->BeginGroup("/Tags");
    for(const auto& key : gPrefs->GetChildKeys())
    {
       gPrefs->Read(key, &value, {});
-      if(name == wxT("ID3V2")) {
+      if(key == wxT("ID3V2")) {
          // LLL:  This is obsolute, but it must be handled and ignored.
       }
       else {
-         SetTag(name, value);
+         SetTag(key, value);
       }
    }
 }


### PR DESCRIPTION
Resolves: [v3.4.0 Metadata set default not working on audio export](https://github.com/audacity/audacity/issues/5494)

Tags::LoadDefaults() needed some re-doing as it had some issues left while refactoring.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
