### PR TITLE
Improve nullptr handling

### DIFF
--- a/libraries/lib-registries/Registry.cpp
+++ b/libraries/lib-registries/Registry.cpp
@@ -726,7 +726,7 @@ void detail::Visit(VisitorBase &visitor,
    const GroupItemBase *pTopItem,
    const GroupItemBase *pRegistry, void *pComputedItemContext)
 {
-   assert(pComputedItemContext);
+   assert(pComputedItemContext && pRegistry);
    std::vector< BaseItemSharedPtr > computedItems;
    bool doFlush = false;
    CollectedItems collection{ {}, computedItems };

--- a/src/toolbars/MeterToolBar.cpp
+++ b/src/toolbars/MeterToolBar.cpp
@@ -223,13 +223,18 @@ void MeterToolBar::ReCreateButtons()
 
    ToolBar::ReCreateButtons();
 
-   mPlayMeter->RestoreState(playState);
-   if( playState.mSaved  ){
-      projectAudioIO.SetPlaybackMeter( mPlayMeter->GetMeter() );
+   if(mPlayMeter) {
+      mPlayMeter->RestoreState(playState);
+      if( playState.mSaved  ){
+         projectAudioIO.SetPlaybackMeter( mPlayMeter->GetMeter() );
+      }
    }
-   mRecordMeter->RestoreState(recordState);
-   if( recordState.mSaved ){
-      projectAudioIO.SetCaptureMeter( mRecordMeter->GetMeter() );
+
+   if(mRecordMeter) {
+      mRecordMeter->RestoreState(recordState);
+      if( recordState.mSaved ){
+         projectAudioIO.SetCaptureMeter( mRecordMeter->GetMeter() );
+      }
    }
 }
 


### PR DESCRIPTION
This line only demonstrates the problem with a nullptr access. It fails on audacity start for me:
assert(pComputedItemContext && pRegistry);

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
