### PR TITLE
Attempt to fix crash when copy-pasting between projects

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -977,6 +977,14 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context, size_t channel,
    auto pLeader = *track.GetHolder()->Find(&track);
    assert(pLeader->IsLeader());
 
+   if(&track != pLeader && track.NIntervals() != pLeader->NIntervals())
+      //We don't have a guarantee that left and right channels have same number
+      //of intervals. Sometimes pasting a large amount of data may trigger
+      //UI event loop updates. When that happens it can well be that one
+      //channel has finished pasting while the other hasn't.
+      //TODO: The check would become unnecessary once wave-clip-refactoring is complete. 
+      return;
+
    for (const auto pInterval :
       static_cast<const WaveTrack*>(pLeader)->GetChannel(channel)->Intervals()
    ) {


### PR DESCRIPTION
Resolves: #5792

The bug seem to happen because `WaveChannel` intervals counting and interval access may happen on diffrenet objects due to inderection that may happen in `Channel::ReallyDoGetChannelGroup` when interval iterator dereferencing tries to access interval via `Channel::GetInterval`

NB: to reproduce bug you'll need to completely replace existing clip in the track with the pasted one

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
