### PR TITLE
6021 ctrl click clip pitch or speed button resets value

### DIFF
--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -12,7 +12,6 @@
 #include "BasicUI.h"
 #include "UserException.h"
 #include "WaveClip.h"
-#include "WaveTrack.h"
 #include <algorithm>
 
 const TranslatableString WaveTrackUtilities::defaultStretchRenderingTitle =
@@ -40,4 +39,26 @@ void WaveTrackUtilities::WithClipRenderingProgress(
          throw UserException {};
    };
    action(reportProgress);
+}
+
+bool WaveTrackUtilities::SetClipStretchRatio(
+   const WaveTrack& track, WaveTrack::Interval& interval, double stretchRatio)
+{
+   const auto nextClip =
+      track.GetNextInterval(interval, PlaybackDirection::forward);
+   const auto maxEndTime = nextClip != nullptr ?
+                              nextClip->Start() :
+                              std::numeric_limits<double>::infinity();
+
+   const auto start = interval.Start();
+   const auto end = interval.End();
+
+   const auto expectedEndTime =
+      start + (end - start) * stretchRatio / interval.GetStretchRatio();
+
+   if (expectedEndTime > maxEndTime)
+      return false;
+
+   interval.StretchRightTo(expectedEndTime);
+   return true;
 }

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -14,6 +14,7 @@
 
 #include "Internat.h"
 #include "TranslatableString.h"
+#include "WaveTrack.h"
 
 class WaveTrack;
 using ProgressReporter = std::function<void(double)>;
@@ -31,4 +32,7 @@ WAVE_TRACK_API void WithClipRenderingProgress(
    std::function<void(const ProgressReporter&)> action,
    TranslatableString title = defaultStretchRenderingTitle,
    TranslatableString message = XO("Rendering Clip"));
-}
+
+WAVE_TRACK_API bool SetClipStretchRatio(
+   const WaveTrack& track, WaveTrack::Interval& interval, double stretchRatio);
+} // namespace WaveTrackUtilities

--- a/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
@@ -159,10 +159,18 @@ UIHandle::Result ClipPitchAndSpeedButtonHandle::DoRelease(
 HitTestPreview ClipPitchAndSpeedButtonHandle::Preview(
    const TrackPanelMouseState& state, AudacityProject* pProject)
 {
+   const auto ctrlDown = state.state.CmdDown();
+   const bool macOs = wxPlatformInfo::Get().GetOperatingSystemId() & wxOS_MAC;
    if (mType == Type::Pitch)
-      return { XO("Click to change clip pitch."), nullptr };
+      return { ctrlDown ? XO("Click to reset clip pitch.") :
+               macOs ? XO("Click to change clip pitch, Cmd + click to reset.") :
+                       XO("Click to change clip pitch, Ctrl + click to reset."),
+               nullptr };
    else
-      return { XO("Click to change clip speed."), nullptr };
+      return { ctrlDown ? XO("Click to reset clip speed.") :
+               macOs ? XO("Click to change clip speed, Cmd + click to reset.") :
+                       XO("Click to change clip speed, Ctrl + click to reset."),
+               nullptr };
 }
 
 void ClipPitchAndSpeedButtonHandle::DoDraw(const wxRect& rect, wxDC& dc)

--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
@@ -10,6 +10,8 @@
  **********************************************************************/
 #include "PitchAndSpeedDialog.h"
 #include "TimeAndPitchInterface.h"
+#include "WaveClipUtilities.h"
+#include "WaveTrackUtilities.h"
 
 #include <wx/button.h>
 #include <wx/layout.h>
@@ -298,19 +300,8 @@ bool PitchAndSpeedDialog::SetClipSpeedFromDialog()
       return false;
    }
 
-   const auto nextClip =
-      mTrack.GetNextInterval(mTrackInterval, PlaybackDirection::forward);
-   const auto maxEndTime = nextClip != nullptr ?
-                              nextClip->Start() :
-                              std::numeric_limits<double>::infinity();
-
-   const auto start = mTrackInterval.Start();
-   const auto end = mTrackInterval.End();
-
-   const auto expectedEndTime =
-      start + (end - start) * mOldClipSpeed / mClipSpeed;
-
-   if (expectedEndTime > maxEndTime)
+   if (!WaveTrackUtilities::SetClipStretchRatio(
+          mTrack, mTrackInterval, 100 / mClipSpeed))
    {
       BasicUI::ShowErrorDialog(
          wxWidgetsWindowPlacement { this }, XO("Invalid clip speed"),

--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
@@ -120,11 +120,13 @@ auto GetInt(const wxCommandEvent& event, int& output)
 } // namespace
 
 PitchAndSpeedDialog::PitchAndSpeedDialog(
-   bool playbackOngoing, WaveTrack& waveTrack, WaveTrack::Interval& interval,
-   wxWindow* parent, const std::optional<PitchAndSpeedDialogFocus>& focus)
+   std::weak_ptr<AudacityProject> project, bool playbackOngoing,
+   WaveTrack& waveTrack, WaveTrack::Interval& interval, wxWindow* parent,
+   const std::optional<PitchAndSpeedDialogFocus>& focus)
     : wxDialogWrapper(
          parent, wxID_ANY, XO("Pitch and Speed"), wxDefaultPosition,
          { 480, 250 }, wxDEFAULT_DIALOG_STYLE)
+    , mProject { project }
     , mPlaybackOngoing { playbackOngoing }
     , mTrack { waveTrack }
     , mTrackInterval { interval }
@@ -310,8 +312,8 @@ bool PitchAndSpeedDialog::SetClipSpeedFromDialog()
 
       return false;
    }
-
-   mTrackInterval.StretchRightTo(expectedEndTime);
+   else if (const auto project = mProject.lock())
+      WaveClipUtilities::SelectClip(*project, mTrackInterval);
 
    {
       ShuttleGui S(this, eIsSettingToDialog);

--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.h
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.h
@@ -13,6 +13,7 @@
 #include "WaveTrack.h"
 #include "wxPanelWrapper.h"
 
+class AudacityProject;
 class ShuttleGui;
 
 enum class PitchAndSpeedDialogFocus
@@ -25,8 +26,8 @@ class PitchAndSpeedDialog final : public wxDialogWrapper
 {
 public:
    PitchAndSpeedDialog(
-      bool playbackOngoing, WaveTrack& track, WaveTrack::Interval& interval,
-      wxWindow* parent,
+      std::weak_ptr<AudacityProject> project, bool playbackOngoing,
+      WaveTrack& track, WaveTrack::Interval& interval, wxWindow* parent,
       const std::optional<PitchAndSpeedDialogFocus>& focus = {});
 
    ~PitchAndSpeedDialog() override;
@@ -45,6 +46,7 @@ private:
    void SetSemitoneShift();
    void UpdateDialog();
 
+   std::weak_ptr<AudacityProject> mProject;
    const bool mPlaybackOngoing;
    WaveTrack& mTrack;
    WaveTrack::Interval& mTrackInterval;

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -508,7 +508,7 @@ bool WaveClipSpectrumCache::GetSpectrogram(
 
    int copyBegin = 0, copyEnd = 0;
    if (match) {
-      findCorrection(
+      WaveClipUtilities::findCorrection(
          mSpecCache->where, mSpecCache->len, numPixels, t0, sampleRate,
          stretchRatio, samplesPerPixel, oldX0, correction);
       // Remember our first pixel maps to oldX0 in the old cache,
@@ -558,7 +558,7 @@ bool WaveClipSpectrumCache::GetSpectrogram(
    // purposely offset the display 1/2 sample to the left (as compared
    // to waveform display) to properly center response of the FFT
    constexpr auto addBias = true;
-   fillWhere(
+   WaveClipUtilities::fillWhere(
       mSpecCache->where, numPixels, addBias, correction, t0, sampleRate,
       stretchRatio, samplesPerPixel);
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -894,7 +894,7 @@ auto WaveChannelSubView::GetMenuItems(
          ||
          pTrack->GetClipAtTime(t))
       {
-         return GetWaveClipMenuItems();
+         return WaveClipUtilities::GetWaveClipMenuItems();
       }
    }
    return {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -273,7 +273,7 @@ public:
       {
          if (mIsStretchMode)
          {
-            PushClipSpeedChangedUndoState(
+            WaveClipUtilities::PushClipSpeedChangedUndoState(
                project, 100.0 / mInterval->GetStretchRatio());
          }
          else if (mAdjustingLeftBorder)

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.cpp
@@ -9,21 +9,20 @@
 **********************************************************************/
 
 #include "WaveClipUtilities.h"
-
+#include "PitchAndSpeedDialog.h"
+#include "Project.h"
+#include "ProjectAudioIO.h"
+#include "ProjectHistory.h"
+#include "ProjectWindows.h"
 #include "SampleCount.h"
+#include "UndoManager.h"
+#include "ViewInfo.h"
+#include "WaveTrack.h"
 #include <algorithm>
 #include <cassert>
 #include <cmath>
 
-#include "PitchAndSpeedDialog.h"
-#include "ProjectAudioIO.h"
-#include "ProjectHistory.h"
-#include "ProjectWindows.h"
-#include "UndoManager.h"
-#include "ViewInfo.h"
-#include "WaveTrack.h"
-
-void findCorrection(
+void WaveClipUtilities::findCorrection(
    const std::vector<sampleCount>& oldWhere, size_t oldLen, size_t newLen,
    double t0, double sampleRate, double stretchRatio, double samplesPerPixel,
    int& oldX0, double& correction)
@@ -66,7 +65,7 @@ void findCorrection(
    }
 }
 
-void fillWhere(
+void WaveClipUtilities::fillWhere(
    std::vector<sampleCount>& where, size_t len, bool addBias, double correction,
    double t0, double sampleRate, double stretchRatio, double samplesPerPixel)
 {
@@ -78,7 +77,8 @@ void fillWhere(
       where[x] = sampleCount(floor(w0 + double(x) * samplesPerPixel));
 }
 
-std::vector<CommonTrackPanelCell::MenuItem> GetWaveClipMenuItems()
+std::vector<CommonTrackPanelCell::MenuItem>
+WaveClipUtilities::GetWaveClipMenuItems()
 {
    return {
       { L"Cut", XO("Cut") },
@@ -96,7 +96,7 @@ std::vector<CommonTrackPanelCell::MenuItem> GetWaveClipMenuItems()
    ;
 }
 
-void PushClipSpeedChangedUndoState(
+void WaveClipUtilities::PushClipSpeedChangedUndoState(
    AudacityProject& project, double speedInPercent)
 {
    ProjectHistory::Get(project).PushState(
@@ -109,15 +109,23 @@ void PushClipSpeedChangedUndoState(
       UndoPush::CONSOLIDATE);
 }
 
-void ShowClipPitchAndSpeedDialog(
+void WaveClipUtilities::ShowClipPitchAndSpeedDialog(
    AudacityProject& project, WaveTrack& track, WaveTrack::Interval& interval,
    std::optional<PitchAndSpeedDialogFocus> focus)
 {
    PitchAndSpeedDialog dlg(
-      ProjectAudioIO::Get(project).IsAudioActive(), track, interval,
-      &GetProjectFrame(project), focus);
+      project.weak_from_this(), ProjectAudioIO::Get(project).IsAudioActive(),
+      track, interval, &GetProjectFrame(project), focus);
    if (wxID_OK == dlg.ShowModal())
       ProjectHistory::Get(project).PushState(
          XO("Changed Pitch and Speed"), XO("Changed Pitch and Speed"),
          UndoPush::CONSOLIDATE);
+}
+
+void WaveClipUtilities::SelectClip(
+   AudacityProject& project, const WaveTrack::Interval& clip)
+{
+   auto& viewInfo = ViewInfo::Get(project);
+   viewInfo.selectedRegion.setTimes(
+      clip.GetPlayStartTime(), clip.GetPlayEndTime());
 }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.h
@@ -22,6 +22,8 @@ class sampleCount;
 class AudacityProject;
 enum class PitchAndSpeedDialogFocus;
 
+namespace WaveClipUtilities
+{
 AUDACITY_DLL_API
 void findCorrection(
    const std::vector<sampleCount>& oldWhere, size_t oldLen, size_t newLen,
@@ -41,4 +43,6 @@ void ShowClipPitchAndSpeedDialog(
    AudacityProject& project, WaveTrack& track, WaveTrack::Interval& interval,
    std::optional<PitchAndSpeedDialogFocus> focus = {});
 
+void SelectClip(AudacityProject& project, const WaveTrack::Interval& clip);
+} // namespace WaveClipUtilities
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -634,16 +634,6 @@ void WaveTrackAffordanceControls::StartEditSelectedClipName(AudacityProject& pro
    StartEditClipName(project, it);
 }
 
-namespace
-{
-void SelectInterval(AudacityProject& project, const WaveTrack::Interval& interval)
-{
-   auto& viewInfo = ViewInfo::Get(project);
-   viewInfo.selectedRegion.setTimes(interval.GetPlayStartTime(), interval.GetPlayEndTime());
-   ProjectHistory::Get(project).ModifyState(false);
-}
-}
-
 void WaveTrackAffordanceControls::StartEditSelectedClipSpeed(
    AudacityProject& project)
 {
@@ -657,7 +647,7 @@ void WaveTrackAffordanceControls::StartEditSelectedClipSpeed(
    if (!interval)
       return;
 
-   ShowClipPitchAndSpeedDialog(project, *track, *interval);
+   WaveClipUtilities::ShowClipPitchAndSpeedDialog(project, *track, *interval);
 }
 
 void WaveTrackAffordanceControls::OnRenderClipStretching(
@@ -684,7 +674,7 @@ void WaveTrackAffordanceControls::OnRenderClipStretching(
    ProjectHistory::Get(project).PushState(
       XO("Rendered time-stretched audio"), XO("Render"));
 
-   SelectInterval(project, *interval);
+   WaveClipUtilities::SelectClip(project, *interval);
 }
 
 std::shared_ptr<TextEditHelper> WaveTrackAffordanceControls::MakeTextEditHelper(const wxString& text)
@@ -699,7 +689,7 @@ auto WaveTrackAffordanceControls::GetMenuItems(
    const wxRect &rect, const wxPoint *pPosition, AudacityProject *pProject)
       -> std::vector<MenuItem>
 {
-   return GetWaveClipMenuItems();
+   return WaveClipUtilities::GetWaveClipMenuItems();
 }
 
 // Register a menu item

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -124,7 +124,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       double correction = 0.0;
       size_t copyBegin = 0, copyEnd = 0;
       if (match) {
-         findCorrection(
+         WaveClipUtilities::findCorrection(
             oldCache->where, oldCache->len, numPixels, t0, sampleRate,
             stretchRatio, samplesPerPixel, oldX0, correction);
          // Remember our first pixel maps to oldX0 in the old cache,
@@ -146,7 +146,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
       pWhere = &waveCache->where;
 
       constexpr auto addBias = false;
-      fillWhere(
+      WaveClipUtilities::fillWhere(
          *pWhere, numPixels, addBias, correction, t0, sampleRate, stretchRatio,
          samplesPerPixel);
 


### PR DESCRIPTION
Resolves: #6021 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Ctrl+click on clip pitch or speed button resets the value to the default (causing the buttons to disappear)
- [x] Hovering over button shows tip in bottom left of Audacity window that Ctrl (Win, Linux) / Cmd (Mac) + click resets to default value.

Changing a clip's speed via the pitch-and-speed dialog or by ctrl-clicking the speed button ...
- [x] updates the selection to the new size of the clip (new behaviour)
- [x] throws a not-enough-room popup rather than overlapping with the following clip (like current master)
- [x] inserts an undo item in the project history, makes the project dirty and can be undone
