### PR TITLE
Wave clip invariants

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -2138,6 +2138,8 @@ void AudioIO::DrainRecordBuffers()
       // boxes.
       StopStream();
       DefaultDelayedHandlerAction( pException );
+      for (auto &pSequence: mCaptureSequences)
+         pSequence->RepairChannels();
    };
 
    GuardedCall( [&] {

--- a/libraries/lib-mixer/AudioIOSequences.h
+++ b/libraries/lib-mixer/AudioIOSequences.h
@@ -70,6 +70,10 @@ struct MIXER_API RecordableSequence {
    //! Flush must be called after last Append
    virtual void Flush() = 0;
 
+   //! Called in exception handling after possibly unbalanced calls to Append
+   //! in different channels. Allows the sequence to repair consistency.
+   virtual void RepairChannels() = 0;
+
    virtual void InsertSilence(double t, double len) = 0;
 };
 

--- a/libraries/lib-wave-track/Sequence.h
+++ b/libraries/lib-wave-track/Sequence.h
@@ -86,6 +86,17 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
 
    sampleCount GetNumSamples() const { return mNumSamples; }
 
+   //! Get a range of samples from the sequence
+   /*
+    If the requested range is not all defined, the buffer may still contain
+    valid results, with zero filling
+
+    @param start offset into sequence
+    @param len number of samples to put in buffer
+    @param mayThrow if true, propagate read error exceptions
+    @return whether [start, start + len) was within the defined range of the
+    sequence and there were no read errors
+    */
    bool Get(samplePtr buffer, sampleFormat format,
             sampleCount start, size_t len, bool mayThrow) const;
 

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -475,17 +475,25 @@ void WaveClip::UpdateEnvelopeTrackLen()
 std::shared_ptr<SampleBlock>
 WaveClip::AppendNewBlock(constSamplePtr buffer, sampleFormat format, size_t len)
 {
+   return mSequences[0]->AppendNewBlock( buffer, format, len );
+}
+
+/*! @excsafety{Strong} */
+std::shared_ptr<SampleBlock>
+WaveClip::AppendLegacyNewBlock(constSamplePtr buffer, sampleFormat format, size_t len)
+{
    // This is a special use function for legacy files only and this assertion
-   // does not need to be relaxed
+   // does not need to be relaxed.  The clip is in a still unzipped track.
    assert(GetWidth() == 1);
    return mSequences[0]->AppendNewBlock( buffer, format, len );
 }
 
 /*! @excsafety{Strong} */
-void WaveClip::AppendSharedBlock(const std::shared_ptr<SampleBlock> &pBlock)
+void WaveClip::AppendLegacySharedBlock(
+   const std::shared_ptr<SampleBlock> &pBlock)
 {
    // This is a special use function for legacy files only and this assertion
-   // does not need to be relaxed
+   // does not need to be relaxed.  The clip is in a still unzipped track.
    assert(GetWidth() == 1);
    mSequences[0]->AppendSharedBlock( pBlock );
 }

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -372,7 +372,7 @@ SampleFormats WaveClip::GetSampleFormats() const
    return mSequences[0]->GetSampleFormats();
 }
 
-const SampleBlockFactoryPtr &WaveClip::GetFactory()
+const SampleBlockFactoryPtr &WaveClip::GetFactory() const
 {
    // All sequences have the same factory by class invariant
    return mSequences[0]->GetFactory();

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -469,6 +469,9 @@ public:
     */
    void Flush();
 
+   //! Ensure that all sequences have the same sample count
+   void RepairChannels();
+
    /// This name is consistent with WaveTrack::Clear. It performs a "Cut"
    /// operation (but without putting the cut audio to the clipboard)
    void Clear(double t0, double t1);

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -164,8 +164,35 @@ public:
 
    virtual ~WaveClip();
 
-   //! Check invariant conditions on mSequences and mCutlines
+   //! Check weak invariant conditions on mSequences and mCutlines
+   /*! Conditions are
+    `mSequences.size() > 0`
+    all sequences are non-null
+    all sequences have the same sample formats
+       and sample block factory
+    all cutlines satisfy the strong invariant
+    */
    bool CheckInvariants() const;
+
+   /*!
+    A precondition for some mutating operations
+    CheckInvariants() is true, and also all sequences have the same length
+    */
+   bool StrongInvariant() const;
+
+   //! When `StrongInvariant()` is false, violate an assertion in debug, but
+   //! in release, establish it (or fail, propagating an exception)
+   /*! @excsafety{Strong} */
+   void AssertOrRepairStrongInvariant();
+
+   //! Assert or repair strong invariant before mutating the sequence;
+   //! assert the strong invariant again at exit
+   struct StrongInvariantScope {
+      explicit StrongInvariantScope(WaveClip &clip);
+      ~StrongInvariantScope();
+   private:
+      WaveClip &mClip;
+   };
 
    //! How many Sequences the clip contains.
    //! Set at construction time; changes only if increased by deserialization
@@ -206,8 +233,8 @@ public:
    [[nodiscard]] Observer::Subscription
    SubscribeToCentShiftChange(std::function<void(int)> cb) const override;
 
-   // Resample clip. This also will set the rate, but without changing
-   // the length of the clip
+   //! Resample clip. This also will set the rate, but without changing
+   //! the length of the clip
    void Resample(int rate, BasicUI::ProgressDialog *progress = nullptr);
 
    double GetSequenceStartTime() const noexcept;
@@ -367,6 +394,8 @@ public:
    //! @param ii identifies the channel
    /*!
     @pre `ii < GetWidth()`
+    @pre `StrongInvariant()`
+    @post `StrongInvariant()`
     @param start relative to clip play start sample
     */
    void SetSamples(size_t ii, constSamplePtr buffer, sampleFormat format,
@@ -451,6 +480,9 @@ public:
     assume as many buffers available as GetWidth()
     In case of failure or exceptions, the clip contents are unchanged but
     un-flushed data are lost
+
+    @pre `StrongInvariant()`
+    @post `StrongInvariant()`
     */
    bool Append(constSamplePtr buffers[], sampleFormat format,
       size_t len, unsigned int stride,
@@ -486,8 +518,12 @@ public:
    /// data, if present. Destructive operation.
    void ClearRight(double t);
 
-   /// Clear, and add cut line that starts at t0 and contains everything until t1
-   /// if there is at least one clip sample between t0 and t1, noop otherwise.
+   //! Clear, and add cut line that starts at t0 and contains everything until t1
+   //! if there is at least one clip sample between t0 and t1, noop otherwise.
+   /*!
+    @pre `StrongInvariant()`
+    @post `StrongInvariant()`
+    */
    void ClearAndAddCutLine(double t0, double t1);
 
    //! @pre `GetWidth() == pClip->GetWidth()`
@@ -497,11 +533,19 @@ public:
     * @return true and succeed if and only if `this->GetWidth() ==
     * other.GetWidth()` and either this is empty or `this->GetStretchRatio() ==
     * other.GetStretchRatio()`.
+
+    @pre `StrongInvariant()`
+    @pre `other.StrongInvariant()`
+    @post `StrongInvariant()`
     */
    bool Paste(double t0, const WaveClip& other);
 
-   /** Insert silence - note that this is an efficient operation for large
-    * amounts of silence */
+   //! Insert silence - note that this is an efficient operation for large
+   //! amounts of silence
+   /*!
+    @pre `StrongInvariant()`
+    @post `StrongInvariant()`
+    */
    void InsertSilence( double t, double len, double *pEnvelopeValue = nullptr );
 
    /** Insert silence at the end, and causes the envelope to ramp
@@ -565,6 +609,10 @@ public:
    double SamplesToTime(sampleCount s) const noexcept;
 
    //! Silences the 'length' amount of samples starting from 'offset'(relative to the play start)
+   /*!
+    @pre `StrongInvariant()`
+    @post `StrongInvariant()`
+    */
    void SetSilence(sampleCount offset, sampleCount length);
 
    //! Get one channel of the append buffer
@@ -601,8 +649,12 @@ private:
    void StretchCutLines(double ratioChange);
    double SnapToTrackSample(double time) const noexcept;
 
-   /// This name is consistent with WaveTrack::Clear. It performs a "Cut"
-   /// operation (but without putting the cut audio to the clipboard)
+   //! This name is consistent with WaveTrack::Clear. It performs a "Cut"
+   //! operation (but without putting the cut audio to the clipboard)
+   /*!
+    @pre `StrongInvariant()`
+    @post `StrongInvariant()`
+    */
    void ClearSequence(double t0, double t1);
 
    //! Restores state when an update loop over mSequences fails midway
@@ -637,11 +689,7 @@ private:
    int mRate;
 
    /*!
-    @invariant `mSequences.size() > 0`
-    @invariant all are non-null
-    @invariant all sequences have the same lengths,
-      sample formats, and sample block factory
-    @invariant all cutlines have the same width
+    @invariant `CheckInvariants()`
     */
    std::vector<std::unique_ptr<Sequence>> mSequences;
    //! Envelope is unique, not per-sequence

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -428,14 +428,21 @@ public:
     * function to tell the envelope about it. */
    void UpdateEnvelopeTrackLen();
 
-   //! For use in importing pre-version-3 projects to preserve sharing of blocks; no dithering applied
-   //! @pre `GetWidth() == 1`
    std::shared_ptr<SampleBlock>
    AppendNewBlock(constSamplePtr buffer, sampleFormat format, size_t len);
 
-   //! For use in importing pre-version-3 projects to preserve sharing of blocks
+   //! For use in importing pre-version-3 projects to preserve sharing of
+   //! blocks; no dithering applied
    //! @pre `GetWidth() == 1`
-   void AppendSharedBlock(const std::shared_ptr<SampleBlock> &pBlock);
+   std::shared_ptr<SampleBlock>
+   AppendLegacyNewBlock(constSamplePtr buffer, sampleFormat format, size_t len);
+
+   //! For use in importing pre-version-3 projects to preserve sharing of
+   //! blocks
+   /*!
+    @pre `GetWidth() == 1`
+    */
+   void AppendLegacySharedBlock(const std::shared_ptr<SampleBlock> &pBlock);
 
    //! Append (non-interleaved) samples to all channels
    //! You must call Flush after the last Append

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -563,7 +563,11 @@ public:
     @pre `ii < GetWidth()`
     */
    constSamplePtr GetAppendBuffer(size_t ii) const;
-   size_t GetAppendBufferLen() const;
+   /*!
+    @param ii identifies the channel
+    @pre `ii < GetWidth()`
+    */
+   size_t GetAppendBufferLen(size_t ii) const;
 
    void
    OnProjectTempoChange(const std::optional<double>& oldTempo, double newTempo);
@@ -571,6 +575,8 @@ public:
    SampleFormats GetSampleFormats() const;
 
 private:
+   size_t GreatestAppendBufferLen() const;
+
    //! Called by mutating operations; notifies listeners
    /*! @excsafety{No-fail} */
    void MarkChanged();
@@ -623,7 +629,7 @@ private:
    /*!
     @invariant `mSequences.size() > 0`
     @invariant all are non-null
-    @invariant all sequences have the same lengths, append buffer lengths,
+    @invariant all sequences have the same lengths,
       sample formats, and sample block factory
     @invariant all cutlines have the same width
     */
@@ -641,7 +647,6 @@ private:
    // AWD, Oct. 2009: for whitespace-at-end-of-selection pasting
    bool mIsPlaceholder { false };
 
-private:
    wxString mName;
 };
 

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -586,7 +586,7 @@ private:
    sampleCount TimeToSequenceSamples(double t) const;
    bool StretchRatioEquals(double value) const;
    sampleCount GetNumSamples() const;
-   const SampleBlockFactoryPtr &GetFactory();
+   const SampleBlockFactoryPtr &GetFactory() const;
    std::vector<std::unique_ptr<Sequence>> GetEmptySequenceCopies() const;
    void StretchCutLines(double ratioChange);
    double SnapToTrackSample(double time) const noexcept;

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -211,7 +211,8 @@ constSamplePtr WaveChannelInterval::GetAppendBuffer() const
 
 size_t WaveChannelInterval::GetAppendBufferLen() const
 {
-   return GetNarrowClip().GetAppendBufferLen();
+   // TODO wide wave tracks -- use miChannel
+   return GetNarrowClip().GetAppendBufferLen(0);
 }
 
 BlockArray *WaveChannelInterval::GetSequenceBlockArray()

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -323,6 +323,11 @@ void WaveTrack::Interval::Flush()
    ForEachClip([](auto& clip) { clip.Flush(); });
 }
 
+void WaveTrack::Interval::RepairChannels()
+{
+   ForEachClip([](auto& clip) { clip.RepairChannels(); });
+}
+
 void WaveTrack::Interval::Clear(double t0, double t1)
 {
    ForEachClip([&](auto& clip) { clip.Clear(t0, t1); });
@@ -3117,6 +3122,12 @@ void WaveTrack::Flush()
       return;
    // After appending, presumably.  Do this to the clip that gets appended.
    GetRightmostClip()->Flush();
+}
+
+void WaveTrack::RepairChannels()
+{
+   for (auto pInterval : Intervals())
+      pInterval->RepairChannels();
 }
 
 void WaveTrack::SetLegacyFormat(sampleFormat format)

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -637,6 +637,8 @@ public:
 
    void Flush() override;
 
+   void RepairChannels() override;
+
    //! @name PlayableSequence implementation
    //! @{
    const ChannelGroup *FindChannelGroup() const override;
@@ -865,6 +867,7 @@ public:
 
       void Append(constSamplePtr buffer[], sampleFormat format, size_t len);
       void Flush();
+      void RepairChannels();
 
       /// This name is consistent with WaveTrack::Clear. It performs a "Cut"
       /// operation (but without putting the cut audio to the clipboard)

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -1460,7 +1460,7 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
       // Replicate the sharing of blocks
       if (pClip->GetWidth() != 1)
          return false;
-      pClip->AppendSharedBlock( pBlock );
+      pClip->AppendLegacySharedBlock( pBlock );
       return true;
    }
 
@@ -1653,7 +1653,7 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
    {
       if (pClip->GetWidth() != 1)
          return false;
-      pBlock = pClip->AppendNewBlock(bufptr, format, cnt);
+      pBlock = pClip->AppendLegacyNewBlock(bufptr, format, cnt);
    }
 
    // Let the finally block know everything is good


### PR DESCRIPTION
Resolves: #5156

Depends on:
- #6071

WaveClips are not yet ever stereo, but this is a preparation.

Weaken the WaveClip invariant, not to require equal lengths of all sequences.

That stronger condition is called the "strong" invariant.  It is required for certain mutating
operations that insert or delete in the sequences.  There is a method to repair the
WaveClip when this is not so by appending silence to the shorter sequence.

The strong condition will be violated often, as appending to stereo tracks is still
done in many places in a channel-major fashion, alternating channels.

In most cases this temporary misalignment is soon repaired.  In generators (including
Nyquist), new mono tracks are zipped, and the zipping function refuses to do it if
it would violate the strong condition.

The one possible gap is in exception handling during recording, which attempts to
save as much as possible of the recording.  There is an attempt now to repair the
misalignment in that contingency too.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Record
- [x] Pencil tool
- [x] Generators, and some destructive effects
- [x] cut,  with and without the making of cut lines
- [x] paste, including pasting exactly at the start or end of a clip
- [x] Lengthening sync Lock adjustment
- [x] Silence command (not generator) or the Silence edit toolbar button
- [x] Recording interrupted by exhaustion of drive space loses at most one block (about 5.9 seconds with default sample format and rate)


