### PR TITLE
Wide wave clip

### DIFF
--- a/libraries/lib-channel/Channel.cpp
+++ b/libraries/lib-channel/Channel.cpp
@@ -18,13 +18,6 @@ ChannelGroupInterval::~ChannelGroupInterval() = default;
 
 ChannelInterval::~ChannelInterval() = default;
 
-WideChannelGroupInterval::WideChannelGroupInterval(
-   const ChannelGroup &group
-)  : mNChannels{ group.NChannels() }
-{
-   assert(mNChannels >= 1); // Post of ChannelGroup::NChannels
-}
-
 WideChannelGroupInterval::~WideChannelGroupInterval() = default;
 
 Channel::~Channel() = default;

--- a/libraries/lib-channel/Channel.h
+++ b/libraries/lib-channel/Channel.h
@@ -55,19 +55,13 @@ class ChannelGroup;
  */
 class CHANNEL_API WideChannelGroupInterval : public ChannelGroupInterval {
 public:
-   //! Initialize immutable properties, constraining number of channels to
-   //! equal that of the containing group
-   /*!
-    @post `NChannels() == group.NChannels()`
-    */
-   explicit WideChannelGroupInterval(const ChannelGroup &group);
    ~WideChannelGroupInterval() override;
 
    //! Report the number of channels
    /*!
     @post result: `result >= 1`
     */
-   size_t NChannels() const { return mNChannels; }
+   virtual size_t NChannels() const = 0;
 
    //! Retrieve a channel, cast to the given type
    /*!
@@ -159,9 +153,6 @@ protected:
     @post result: `!(iChannel < NChannels()) || result`
     */
    virtual std::shared_ptr<ChannelInterval> DoGetChannel(size_t iChannel) = 0;
-
-private:
-   const size_t mNChannels;
 };
 
 class CHANNEL_API Channel

--- a/libraries/lib-channel/Channel.h
+++ b/libraries/lib-channel/Channel.h
@@ -521,6 +521,8 @@ public:
 
 protected:
    //! Retrieve a channel
+   //! For fixed iChannel, resulting address must be unchanging, if there has
+   //! been no other mutation of this ChannelGroup
    /*!
     @post result: `!(iChannel < NChannels()) || result`
     */

--- a/libraries/lib-channel/Channel.h
+++ b/libraries/lib-channel/Channel.h
@@ -508,7 +508,6 @@ public:
       @}
    */
 
-   // TODO wide wave tracks -- remove this
    //! For two tracks describes the type of the linkage
    enum class LinkType : int {
        None = 0, //!< No linkage

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -264,9 +264,10 @@ bool PerTrackEffect::ProcessPass(TrackList &outputs,
          assert(source.AcceptsBlockSize(inBuffers.BlockSize()));
 
          // Make "wide" or "narrow" copy of the track if generating
-         // For now EmptyCopy and WideEmptyCopy still return different types
+         // Old generator code may still proceed "interval-major" and later
+         // join mono into stereo
          auto wideTrack =
-            (pRight && isGenerator) ? wt.WideEmptyCopy() : nullptr;
+            (pRight && isGenerator) ? wt.EmptyCopy() : nullptr;
          auto narrowTrack =
             (!pRight && isGenerator) ? wt.EmptyCopy(1) : nullptr;
          const auto pGenerated = wideTrack

--- a/libraries/lib-mixer/Envelope.cpp
+++ b/libraries/lib-mixer/Envelope.cpp
@@ -364,7 +364,7 @@ void Envelope::Delete( int point )
    mEnv.erase(mEnv.begin() + point);
 }
 
-void Envelope::Insert(int point, const EnvPoint &p)
+void Envelope::Insert(int point, const EnvPoint &p) noexcept
 {
    mEnv.insert(mEnv.begin() + point, p);
 }
@@ -375,7 +375,7 @@ void Envelope::Insert(double when, double value)
 }
 
 /*! @excsafety{No-fail} */
-void Envelope::CollapseRegion( double t0, double t1, double sampleDur )
+void Envelope::CollapseRegion(double t0, double t1, double sampleDur) noexcept
 {
    if ( t1 <= t0 )
       return;
@@ -392,7 +392,7 @@ void Envelope::CollapseRegion( double t0, double t1, double sampleDur )
    bool leftPoint = true, rightPoint = true;
 
    // Determine the start of the range of points to remove from the array.
-   auto range0 = EqualRange( t0, 0 );
+   auto range0 = EqualRange(t0, 0);
    auto begin = range0.first;
    if ( begin == range0.second ) {
       if ( t0 > epsilon ) {
@@ -546,14 +546,14 @@ void Envelope::PasteEnvelope( double t0, const Envelope *e, double sampleDur )
 }
 
 /*! @excsafety{No-fail} */
-void Envelope::RemoveUnneededPoints
-   ( size_t startAt, bool rightward, bool testNeighbors )
+void Envelope::RemoveUnneededPoints(
+   size_t startAt, bool rightward, bool testNeighbors) noexcept
 {
    // startAt is the index of a recently inserted point which might make no
    // difference in envelope evaluation, or else might cause nearby points to
    // make no difference.
 
-   auto isDiscontinuity = [this]( size_t index ) {
+   auto isDiscontinuity = [this]( size_t index ) noexcept {
       // Assume array accesses are in-bounds
       const EnvPoint &point1 = mEnv[ index ];
       const EnvPoint &point2 = mEnv[ index + 1 ];
@@ -561,7 +561,7 @@ void Envelope::RemoveUnneededPoints
          fabs( point1.GetVal() - point2.GetVal() ) > VALUE_TOLERANCE;
    };
 
-   auto remove = [this]( size_t index, bool leftLimit ) {
+   auto remove = [this]( size_t index, bool leftLimit ) noexcept {
       // Assume array accesses are in-bounds
       const auto &point = mEnv[ index ];
       auto when = point.GetT();
@@ -726,7 +726,7 @@ void Envelope::Cap( double sampleDur )
  * @param value the envelope value to use at the given point.
  * @return the index of the NEW envelope point within array of envelope points.
  */
-int Envelope::InsertOrReplaceRelative(double when, double value)
+int Envelope::InsertOrReplaceRelative(double when, double value) noexcept
 {
 #if defined(_DEBUG)
    // in debug builds, do a spot of argument checking
@@ -760,7 +760,8 @@ int Envelope::InsertOrReplaceRelative(double when, double value)
    return index;
 }
 
-std::pair<int, int> Envelope::EqualRange( double when, double sampleDur ) const
+std::pair<int, int> Envelope::EqualRange(double when, double sampleDur)
+   const noexcept
 {
    // Find range of envelope points matching the given time coordinate
    // (within an interval of length sampleDur)
@@ -843,7 +844,7 @@ double Envelope::GetValue( double t, double sampleDur ) const
    return temp;
 }
 
-double Envelope::GetValueRelative(double t, bool leftLimit) const
+double Envelope::GetValueRelative(double t, bool leftLimit) const noexcept
 {
    double temp;
 
@@ -854,7 +855,7 @@ double Envelope::GetValueRelative(double t, bool leftLimit) const
 // relative time
 /// @param Lo returns last index at or before this time, maybe -1
 /// @param Hi returns first index after this time, maybe past the end
-void Envelope::BinarySearchForTime( int &Lo, int &Hi, double t ) const
+void Envelope::BinarySearchForTime(int &Lo, int &Hi, double t) const noexcept
 {
    // Optimizations for the usual pattern of repeated calls with
    // small increases of t.
@@ -901,7 +902,8 @@ void Envelope::BinarySearchForTime( int &Lo, int &Hi, double t ) const
 // relative time
 /// @param Lo returns last index before this time, maybe -1
 /// @param Hi returns first index at or after this time, maybe past the end
-void Envelope::BinarySearchForTime_LeftLimit( int &Lo, int &Hi, double t ) const
+void Envelope::BinarySearchForTime_LeftLimit(int &Lo, int &Hi, double t)
+   const noexcept
 {
    Lo = -1;
    Hi = mEnv.size();
@@ -925,7 +927,7 @@ void Envelope::BinarySearchForTime_LeftLimit( int &Lo, int &Hi, double t ) const
 /// or log interpolation.
 /// @param iPoint index in env array to look at.
 /// @return value there, or its (safe) log10.
-double Envelope::GetInterpolationStartValueAtPoint( int iPoint ) const
+double Envelope::GetInterpolationStartValueAtPoint(int iPoint) const noexcept
 {
    double v = mEnv[ iPoint ].GetVal();
    if( !mDB )
@@ -944,7 +946,7 @@ void Envelope::GetValues( double *buffer, int bufferLen,
 
 void Envelope::GetValuesRelative
    (double *buffer, int bufferLen, double t0, double tstep, bool leftLimit)
-   const
+   const noexcept
 {
    // JC: If bufferLen ==0 we have probably just allocated a zero sized buffer.
    // wxASSERT( bufferLen > 0 );

--- a/libraries/lib-mixer/Envelope.h
+++ b/libraries/lib-mixer/Envelope.h
@@ -29,12 +29,12 @@ class ZoomInfo;
 class EnvPoint final : public XMLTagHandler {
 
 public:
-   EnvPoint() {}
-   inline EnvPoint( double t, double val ) : mT{ t }, mVal{ val } {}
+   EnvPoint() noexcept {}
+   inline EnvPoint( double t, double val ) noexcept : mT{ t }, mVal{ val } {}
 
-   double GetT() const { return mT; }
-   void SetT(double t) { mT = t; }
-   double GetVal() const { return mVal; }
+   double GetT() const noexcept { return mT; }
+   void SetT(double t) noexcept { mT = t; }
+   double GetVal() const noexcept { return mVal; }
    inline void SetVal( Envelope *pEnvelope, double val );
 
    bool HandleXMLTag(const std::string_view& tag, const AttributesList& attrs) override
@@ -111,7 +111,7 @@ public:
    // Handling Cut/Copy/Paste events
    // sampleDur determines when the endpoint of the collapse is near enough
    // to an endpoint of the domain, that an extra control point is not needed.
-   void CollapseRegion(double t0, double t1, double sampleDur);
+   void CollapseRegion(double t0, double t1, double sampleDur) noexcept;
 
    // Envelope has no notion of rate and control point times are not quantized;
    // but a tolerance is needed in the Paste routine, and better to inform it
@@ -147,12 +147,12 @@ private:
       ( double t0, double tlen, double *pLeftVal, double *pRightVal );
 
    void RemoveUnneededPoints
-      ( size_t startAt, bool rightward, bool testNeighbors = true );
+      ( size_t startAt, bool rightward, bool testNeighbors = true ) noexcept;
 
-   double GetValueRelative(double t, bool leftLimit = false) const;
+   double GetValueRelative(double t, bool leftLimit = false) const noexcept;
    void GetValuesRelative
       (double *buffer, int len, double t0, double tstep, bool leftLimit = false)
-      const;
+      const noexcept;
    // relative time
    int NumberOfPointsAfter(double t) const;
    // relative time
@@ -185,7 +185,7 @@ public:
    void Delete(int point);
 
    /** \brief insert a point */
-   void Insert(int point, const EnvPoint &p);
+   void Insert(int point, const EnvPoint &p) noexcept;
 
    // Insert a point (without replacement)
    // for now assumed sequential.
@@ -201,9 +201,9 @@ public:
    }
 
 private:
-   int InsertOrReplaceRelative(double when, double value);
+   int InsertOrReplaceRelative(double when, double value) noexcept;
 
-   std::pair<int, int> EqualRange( double when, double sampleDur ) const;
+   std::pair<int, int> EqualRange(double when, double sampleDur) const noexcept;
 
 public:
    /** \brief Returns the sets of when and value pairs */
@@ -229,9 +229,10 @@ private:
    void AddPointAtEnd( double t, double val );
    void CopyRange(const Envelope &orig, size_t begin, size_t end);
    // relative time
-   void BinarySearchForTime( int &Lo, int &Hi, double t ) const;
-   void BinarySearchForTime_LeftLimit( int &Lo, int &Hi, double t ) const;
-   double GetInterpolationStartValueAtPoint( int iPoint ) const;
+   void BinarySearchForTime(int &Lo, int &Hi, double t) const noexcept;
+   void BinarySearchForTime_LeftLimit(int &Lo, int &Hi, double t)
+      const noexcept;
+   double GetInterpolationStartValueAtPoint(int iPoint) const noexcept;
 
    // The list of envelope control points.
    EnvArray mEnv;

--- a/libraries/lib-mixer/WideSampleSequence.h
+++ b/libraries/lib-mixer/WideSampleSequence.h
@@ -63,7 +63,6 @@ public:
    //! Retrieve samples of one of the channels from a sequence in a specified
    //! format
    /*!
-    @copydetails SampleTrack::GetFloats()
     @param format sample format of the destination buffer
     @param backward retrieves samples from `start` (inclusive) to `start + len`
     if false, else from `start` (exclusive) to `start - len` in reverse order.

--- a/libraries/lib-note-track/NoteTrack.cpp
+++ b/libraries/lib-note-track/NoteTrack.cpp
@@ -91,8 +91,7 @@ SONFNS(AutoSave)
 
 
 NoteTrack::Interval::Interval(const NoteTrack &track)
-   : WideChannelGroupInterval(track)
-   , mpTrack{ track.SharedPointer<const NoteTrack>() }
+   : mpTrack{ track.SharedPointer<const NoteTrack>() }
 {}
 
 NoteTrack::Interval::~Interval() = default;
@@ -105,6 +104,11 @@ double NoteTrack::Interval::Start() const
 double NoteTrack::Interval::End() const
 {
    return Start() + mpTrack->GetSeq().get_real_dur();
+}
+
+size_t NoteTrack::Interval::NChannels() const
+{
+   return 1;
 }
 
 std::shared_ptr<ChannelInterval>

--- a/libraries/lib-note-track/NoteTrack.h
+++ b/libraries/lib-note-track/NoteTrack.h
@@ -196,6 +196,7 @@ public:
       std::shared_ptr<ChannelInterval> DoGetChannel(size_t iChannel) override;
       double Start() const override;
       double End() const override;
+      size_t NChannels() const override;
    private:
       //! @invariant not null
       const std::shared_ptr<const NoteTrack> mpTrack;

--- a/libraries/lib-registries/ClientData.h
+++ b/libraries/lib-registries/ClientData.h
@@ -458,32 +458,32 @@ protected:
          auto &pOtherObject = *otherIter;
          // These lines might lock weak pointers, depending on template
          // arguments of the class
-         auto deref = Dereferenceable(pObject);
-         auto otherDeref = Dereferenceable(pOtherObject);
-         if (!deref && !otherDeref)
+         auto deref = &Dereferenceable(pObject);
+         auto otherDeref = &Dereferenceable(pOtherObject);
+         if (!*deref && !*otherDeref)
             continue;
-         else if (!deref && create) {
+         else if (!*deref && create) {
             // creation on demand
             auto factories = GetFactories();
             auto &factory = factories.mObject[ii];
             pObject = factory
                ? factory(static_cast<Host&>(*this))
                : DataPointer{};
-            deref = Dereferenceable(pObject);
+            deref = &Dereferenceable(pObject);
          }
-         else if (!otherDeref && create) {
+         else if (!*otherDeref && create) {
             // creation on demand
             auto factories = GetFactories();
             auto &factory = factories.mObject[ii];
             pOtherObject = factory
                ? factory(static_cast<Host&>(other))
                : DataPointer{};
-            otherDeref = Dereferenceable(pOtherObject);
+            otherDeref = &Dereferenceable(pOtherObject);
          }
 
          function(
-            (deref ? &*deref : nullptr),
-            (otherDeref ? &*otherDeref : nullptr));
+            (*deref ? &**deref : nullptr),
+            (*otherDeref ? &**otherDeref : nullptr));
       }
    }
 

--- a/libraries/lib-sample-track/SampleTrack.h
+++ b/libraries/lib-sample-track/SampleTrack.h
@@ -40,16 +40,6 @@ public:
    virtual sampleFormat GetSampleFormat() const = 0;
 
    using WideSampleSequence::GetFloats;
-
-   //! "narrow" overload fetches first channel only
-   bool GetFloats(float *buffer, sampleCount start, size_t len,
-      fillFormat fill = FillFormat::fillZero, bool mayThrow = true,
-      sampleCount * pNumWithinClips = nullptr) const
-   {
-      constexpr auto backwards = false;
-      return GetFloats(
-         0, 1, &buffer, start, len, backwards, fill, mayThrow, pNumWithinClips);
-   }
 };
 
 ENUMERATE_TRACK_TYPE(SampleTrack)

--- a/libraries/lib-stretching-sequence/AudioSegment.h
+++ b/libraries/lib-stretching-sequence/AudioSegment.h
@@ -37,7 +37,7 @@ public:
    /**
     * @brief The number of channels in the segment.
     */
-   virtual size_t GetWidth() const = 0;
+   virtual size_t NChannels() const = 0;
 
    /**
     * @brief Whether the segment has no more samples to provide.

--- a/libraries/lib-stretching-sequence/ClipInterface.h
+++ b/libraries/lib-stretching-sequence/ClipInterface.h
@@ -45,7 +45,7 @@ public:
       size_t iChannel, sampleCount start, size_t length,
       bool mayThrow = true) const = 0;
 
-   virtual size_t GetWidth() const = 0;
+   virtual size_t NChannels() const = 0;
 
    virtual int GetCentShift() const = 0;
 

--- a/libraries/lib-stretching-sequence/ClipSegment.cpp
+++ b/libraries/lib-stretching-sequence/ClipSegment.cpp
@@ -44,7 +44,7 @@ ClipSegment::ClipSegment(
          clip, durationToDiscard) }
     , mSource { clip, durationToDiscard, direction }
     , mStretcher { std::make_unique<StaffPadTimeAndPitch>(
-         clip.GetRate(), clip.GetWidth(), mSource,
+         clip.GetRate(), clip.NChannels(), mSource,
          GetStretchingParameters(clip)) }
     , mOnSemitoneShiftChangeSubscription { clip.SubscribeToCentShiftChange(
          [this](int cents) { mStretcher->OnCentShiftChange(cents); }) }
@@ -65,7 +65,7 @@ bool ClipSegment::Empty() const
    return mTotalNumSamplesProduced == mTotalNumSamplesToProduce;
 }
 
-size_t ClipSegment::GetWidth() const
+size_t ClipSegment::NChannels() const
 {
-   return mSource.GetWidth();
+   return mSource.NChannels();
 }

--- a/libraries/lib-stretching-sequence/ClipSegment.h
+++ b/libraries/lib-stretching-sequence/ClipSegment.h
@@ -36,7 +36,7 @@ public:
    // AudioSegment
    size_t GetFloats(float* const* buffers, size_t numSamples) override;
    bool Empty() const override;
-   size_t GetWidth() const override;
+   size_t NChannels() const override;
 
 private:
    const sampleCount mTotalNumSamplesToProduce;

--- a/libraries/lib-stretching-sequence/ClipTimeAndPitchSource.cpp
+++ b/libraries/lib-stretching-sequence/ClipTimeAndPitchSource.cpp
@@ -55,7 +55,7 @@ void ClipTimeAndPitchSource::Pull(
       constexpr auto mayThrow = false;
       const auto start =
          forward ? mLastReadSample : mLastReadSample - numSamplesToRead;
-      const auto nChannels = mClip.GetWidth();
+      const auto nChannels = mClip.NChannels();
       ChannelSampleViews newViews;
       for (auto i = 0u; i < nChannels; ++i)
       {
@@ -82,7 +82,7 @@ void ClipTimeAndPitchSource::Pull(
    }
 }
 
-size_t ClipTimeAndPitchSource::GetWidth() const
+size_t ClipTimeAndPitchSource::NChannels() const
 {
-   return mClip.GetWidth();
+   return mClip.NChannels();
 }

--- a/libraries/lib-stretching-sequence/ClipTimeAndPitchSource.h
+++ b/libraries/lib-stretching-sequence/ClipTimeAndPitchSource.h
@@ -30,7 +30,7 @@ public:
    // TimeAndPitchSource
    void Pull(float* const*, size_t samplesPerChannel) override;
 
-   size_t GetWidth() const;
+   size_t NChannels() const;
 
 private:
    const ClipInterface& mClip;

--- a/libraries/lib-stretching-sequence/SilenceSegment.cpp
+++ b/libraries/lib-stretching-sequence/SilenceSegment.cpp
@@ -38,7 +38,7 @@ bool SilenceSegment::Empty() const
    return mNumRemainingSamples == 0u;
 }
 
-size_t SilenceSegment::GetWidth() const
+size_t SilenceSegment::NChannels() const
 {
    return mNumChannels;
 }

--- a/libraries/lib-stretching-sequence/SilenceSegment.h
+++ b/libraries/lib-stretching-sequence/SilenceSegment.h
@@ -20,7 +20,7 @@ public:
    SilenceSegment(size_t numChannels, sampleCount numSamples);
    size_t GetFloats(float *const *buffers, size_t numSamples) override;
    bool Empty() const override;
-   size_t GetWidth() const override;
+   size_t NChannels() const override;
 
 private:
    const size_t mNumChannels;

--- a/libraries/lib-stretching-sequence/tests/FloatVectorClip.cpp
+++ b/libraries/lib-stretching-sequence/tests/FloatVectorClip.cpp
@@ -53,7 +53,7 @@ sampleCount FloatVectorClip::GetVisibleSampleCount() const
    return mAudio[0].size();
 }
 
-size_t FloatVectorClip::GetWidth() const
+size_t FloatVectorClip::NChannels() const
 {
    return mAudio.size();
 }

--- a/libraries/lib-stretching-sequence/tests/FloatVectorClip.h
+++ b/libraries/lib-stretching-sequence/tests/FloatVectorClip.h
@@ -28,7 +28,7 @@ public:
 
    sampleCount GetVisibleSampleCount() const override;
 
-   size_t GetWidth() const override;
+   size_t NChannels() const override;
 
    int GetRate() const override;
 

--- a/libraries/lib-stretching-sequence/tests/MockAudioSegmentFactory.h
+++ b/libraries/lib-stretching-sequence/tests/MockAudioSegmentFactory.h
@@ -21,7 +21,7 @@ public:
       return numSamples;
    }
 
-   size_t GetWidth() const override
+   size_t NChannels() const override
    {
       return 1u;
    }

--- a/libraries/lib-stretching-sequence/tests/TestWaveTrackMaker.cpp
+++ b/libraries/lib-stretching-sequence/tests/TestWaveTrackMaker.cpp
@@ -33,7 +33,7 @@ TestWaveTrackMaker::Track(const WaveClipHolders& clips) const
    tracks->Add(track);
    for (const auto& clip : clips)
       track->InsertInterval(
-         std::make_shared<WaveTrack::Interval>(*track, clip, nullptr), true);
+         std::make_shared<WaveTrack::Interval>(clip, nullptr), true);
    return track;
 }
 

--- a/libraries/lib-stretching-sequence/tests/TestWaveTrackMaker.cpp
+++ b/libraries/lib-stretching-sequence/tests/TestWaveTrackMaker.cpp
@@ -32,8 +32,7 @@ TestWaveTrackMaker::Track(const WaveClipHolders& clips) const
          mFactory, floatSample, mSampleRate);
    tracks->Add(track);
    for (const auto& clip : clips)
-      track->InsertInterval(
-         std::make_shared<WaveTrack::Interval>(clip, nullptr), true);
+      track->InsertInterval(clip, true);
    return track;
 }
 

--- a/libraries/lib-wave-track/WaveChannelUtilities.cpp
+++ b/libraries/lib-wave-track/WaveChannelUtilities.cpp
@@ -135,7 +135,7 @@ template <typename BufferType> struct SampleAccessArgs
 
 template <typename BufferType>
 SampleAccessArgs<BufferType> GetSampleAccessArgs(
-   const WaveChannelInterval& clip, double startOrEndTime /*absolute*/,
+   const Clip& clip, double startOrEndTime /*absolute*/,
    BufferType buffer,
    size_t totalToRead, size_t alreadyRead, bool forward)
 {
@@ -209,11 +209,10 @@ bool WaveChannelUtilities::GetFloatAtTime(const WaveChannel &channel,
    return GetFloatAtTime(*clip, t, value, mayThrow);
 }
 
-bool WaveChannelUtilities::GetFloatAtTime(const WaveChannelInterval &clip,
+bool WaveChannelUtilities::GetFloatAtTime(const Clip &clip,
    double t, float& value, bool mayThrow)
 {
-   // TODO wide wave tracks -- clip.GetChannelIndex()
-   constexpr size_t iChannel = 0;
+   const size_t iChannel = clip.GetChannelIndex();
    WaveClipUtilities::GetFloatAtTime(clip.GetClip(),
       t - clip.GetPlayStartTime(), iChannel, value, mayThrow);
    return true;
@@ -295,7 +294,7 @@ void WaveChannelUtilities::SetFloatsWithinTimeRange(WaveChannel &channel,
       std::vector<float> values(numSamples);
       for (auto i = 0u; i < numSamples; ++i)
          values[i] = producer(tt0 + clip->SamplesToTime(i));
-      constexpr size_t iChannel = 0;
+      const size_t iChannel = clip->GetChannelIndex();
       WaveClipUtilities::SetFloatsFromTime(clip->GetClip(),
          tt0 - clipStartTime, iChannel, values.data(), numSamples,
          effectiveFormat);

--- a/libraries/lib-wave-track/WaveChannelUtilities.h
+++ b/libraries/lib-wave-track/WaveChannelUtilities.h
@@ -17,7 +17,7 @@ class Envelope;
 enum class PlaybackDirection;
 enum class sampleFormat : unsigned;
 class WaveChannel;
-class WaveChannelInterval;
+class WaveClipChannel;
 
 #include <algorithm>
 #include <functional>
@@ -27,7 +27,7 @@ class WaveChannelInterval;
 
 namespace WaveChannelUtilities {
 
-using Clip = WaveChannelInterval;
+using Clip = WaveClipChannel;
 using ClipPointer = std::shared_ptr<Clip>;
 using ClipPointers = std::vector<ClipPointer>;
 using ClipConstPointer = std::shared_ptr<const Clip>;
@@ -111,7 +111,7 @@ WAVE_TRACK_API bool GetFloatAtTime(const WaveChannel &channel,
 /*!
  @copydoc GetFloatAtTime(const WaveChannel &, double, size_t, float &, bool)
  */
-WAVE_TRACK_API bool GetFloatAtTime(const WaveChannelInterval &clip,
+WAVE_TRACK_API bool GetFloatAtTime(const Clip &clip,
    double t, float& value, bool mayThrow);
 
 /*!
@@ -167,7 +167,7 @@ WAVE_TRACK_API void SetFloatsFromTime(WaveChannel &channel,
  @copydoc SetFloatsFromTime(WaveChannel &, double, const float *, size_t,
     sampleFormat, PlaybackDirection)
  */
-WAVE_TRACK_API void SetFloatsFromTime(WaveChannelInterval &channel,
+WAVE_TRACK_API void SetFloatsFromTime(Clip &channel,
    double t, const float* buffer, size_t numSamples,
    sampleFormat effectiveFormat, PlaybackDirection direction);
 

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1267,8 +1267,10 @@ void WaveClip::Clear(double t0, double t1)
       st1 = GetSequenceEndTime();
       SetTrimRight(.0);
    }
+   Transaction transaction{ *this };
    ClearSequence(st0, st1)
       .Commit();
+   transaction.Commit();
    MarkChanged();
 
    if (offset != .0)
@@ -1279,8 +1281,10 @@ void WaveClip::ClearLeft(double t)
 {
    if (t > GetPlayStartTime() && t < GetPlayEndTime())
    {
+      Transaction transaction{ *this };
       ClearSequence(GetSequenceStartTime(), t)
          .Commit();
+      transaction.Commit();
       SetTrimLeft(.0);
       SetSequenceStartTime(t);
       MarkChanged();
@@ -1291,8 +1295,10 @@ void WaveClip::ClearRight(double t)
 {
    if (t > GetPlayStartTime() && t < GetPlayEndTime())
    {
+      Transaction transaction{ *this };
       ClearSequence(t, GetSequenceEndTime())
          .Commit();
+      transaction.Commit();
       SetTrimRight(.0);
       MarkChanged();
    }
@@ -1301,7 +1307,6 @@ void WaveClip::ClearRight(double t)
 auto WaveClip::ClearSequence(double t0, double t1) -> ClearSequenceFinisher
 {
    StrongInvariantScope scope{ *this };
-   Transaction transaction{ *this };
 
    auto clip_t0 = std::max(t0, GetSequenceStartTime());
    auto clip_t1 = std::min(t1, GetSequenceEndTime());
@@ -1316,7 +1321,6 @@ auto WaveClip::ClearSequence(double t0, double t1) -> ClearSequenceFinisher
    for (auto &pSequence : mSequences)
       pSequence->Delete(s0, s1 - s0);
    
-   transaction.Commit();
    return { this, t0, t1, clip_t0, clip_t1 };
 }
 

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -399,6 +399,7 @@ void WaveClip::SetSamples(size_t ii,
 
 void WaveClip::SetEnvelope(std::unique_ptr<Envelope> p)
 {
+   assert(p);
    mEnvelope = move(p);
 }
 

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -49,6 +49,165 @@ bool WaveClipListener::HandleXMLAttribute(
 
 WaveClipChannel::~WaveClipChannel() = default;
 
+Envelope &WaveClipChannel::GetEnvelope()
+{
+   return *GetClip().GetEnvelope();
+}
+
+const Envelope &WaveClipChannel::GetEnvelope() const
+{
+   return *GetClip().GetEnvelope();
+}
+
+bool WaveClipChannel::Intersects(double t0, double t1) const
+{
+   return GetClip().IntersectsPlayRegion(t0, t1);
+}
+
+double WaveClipChannel::Start() const
+{
+   return GetClip().GetPlayStartTime();
+}
+
+double WaveClipChannel::End() const
+{
+   return GetClip().GetPlayEndTime();
+}
+
+AudioSegmentSampleView
+WaveClipChannel::GetSampleView(double t0, double t1, bool mayThrow) const
+{
+   return GetClip().GetSampleView(miChannel, t0, t1, mayThrow);
+}
+
+bool WaveClipChannel::WithinPlayRegion(double t) const
+{
+   return GetClip().WithinPlayRegion(t);
+}
+
+double WaveClipChannel::SamplesToTime(sampleCount s) const noexcept
+{
+   return GetClip().SamplesToTime(s);
+}
+
+bool WaveClipChannel::HasPitchOrSpeed() const
+{
+   return GetClip().HasPitchOrSpeed();
+}
+
+double WaveClipChannel::GetTrimLeft() const
+{
+   return GetClip().GetTrimLeft();
+}
+
+bool WaveClipChannel::GetSamples(samplePtr buffer, sampleFormat format,
+   sampleCount start, size_t len, bool mayThrow) const
+{
+   return GetClip().GetSamples(miChannel, buffer, format, start, len, mayThrow);
+}
+
+AudioSegmentSampleView WaveClipChannel::GetSampleView(
+   sampleCount start, size_t length, bool mayThrow) const
+{
+   return GetClip().GetSampleView(miChannel, start, length, mayThrow);
+}
+
+const Sequence &WaveClipChannel::GetSequence() const
+{
+   const auto pSequence = GetClip().GetSequence(miChannel);
+   // Assume sufficiently wide clip
+   assert(pSequence);
+   return *pSequence;
+}
+
+constSamplePtr WaveClipChannel::GetAppendBuffer() const
+{
+   return GetClip().GetAppendBuffer(miChannel);
+}
+
+size_t WaveClipChannel::GetAppendBufferLen() const
+{
+   return GetClip().GetAppendBufferLen(miChannel);
+}
+
+const BlockArray *WaveClipChannel::GetSequenceBlockArray() const
+{
+   return GetClip().GetSequenceBlockArray(miChannel);
+}
+
+std::pair<float, float>
+WaveClipChannel::GetMinMax(double t0, double t1, bool mayThrow) const
+{
+   return GetClip().GetMinMax(miChannel, t0, t1, mayThrow);
+}
+
+float WaveClipChannel::GetRMS(double t0, double t1, bool mayThrow) const
+{
+   return GetClip().GetRMS(miChannel, t0, t1, mayThrow);
+}
+
+sampleCount WaveClipChannel::GetPlayStartSample() const
+{
+   return GetClip().GetPlayStartSample();
+}
+
+sampleCount WaveClipChannel::GetPlayEndSample() const
+{
+   return GetClip().GetPlayEndSample();
+}
+
+void WaveClipChannel::SetSamples(constSamplePtr buffer, sampleFormat format,
+   sampleCount start, size_t len, sampleFormat effectiveFormat)
+{
+   return GetClip().SetSamples(miChannel,
+      buffer, format, start, len, effectiveFormat);
+}
+
+void WaveClipChannel::WriteXML(XMLWriter &xmlFile) const
+{
+   GetClip().WriteXML(miChannel, xmlFile);
+}
+
+double WaveClipChannel::GetTrimRight() const
+{
+   return GetClip().GetTrimRight();
+}
+
+sampleCount WaveClipChannel::GetVisibleSampleCount() const
+{
+   return GetClip().GetVisibleSampleCount();
+}
+
+int WaveClipChannel::GetRate() const
+{
+   return GetClip().GetRate();
+}
+
+double WaveClipChannel::GetPlayStartTime() const
+{
+   return GetClip().GetPlayStartTime();
+}
+
+double WaveClipChannel::GetPlayEndTime() const
+{
+   return GetClip().GetPlayEndTime();
+}
+
+double WaveClipChannel::GetPlayDuration() const
+{
+   return GetPlayEndTime() - GetPlayStartTime();
+}
+
+sampleCount WaveClipChannel::TimeToSamples(double time) const
+{
+   return GetClip().TimeToSamples(time);
+}
+
+double WaveClipChannel::GetStretchRatio() const
+{
+   return GetClip().GetStretchRatio();
+}
+
 WaveClip::WaveClip(size_t width,
    const SampleBlockFactoryPtr &factory,
    sampleFormat format, int rate)

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -825,6 +825,31 @@ void WaveClip::AppendLegacySharedBlock(
    mSequences[0]->AppendSharedBlock( pBlock );
 }
 
+bool WaveClip::Append(size_t iChannel, const size_t nChannels,
+   constSamplePtr buffers[], sampleFormat format,
+   size_t len, unsigned int stride, sampleFormat effectiveFormat)
+{
+   assert(iChannel < NChannels());
+   assert(iChannel + nChannels <= NChannels());
+
+   // No requirement or promise of the strong invariant, and therefore no
+   // need for Transaction
+
+   //wxLogDebug(wxT("Append: len=%lli"), (long long) len);
+
+   bool appended = false;
+   for (size_t ii = 0; ii < nChannels; ++ii)
+      appended = mSequences[iChannel + ii]->Append(
+         buffers[ii], format, len, stride, effectiveFormat)
+            || appended;
+
+   // use No-fail-guarantee
+   UpdateEnvelopeTrackLen();
+   MarkChanged();
+
+   return appended;
+}
+
 bool WaveClip::Append(constSamplePtr buffers[], sampleFormat format,
    size_t len, unsigned int stride, sampleFormat effectiveFormat)
 {

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -47,6 +47,8 @@ bool WaveClipListener::HandleXMLAttribute(
    return false;
 }
 
+WaveClipChannel::~WaveClipChannel() = default;
+
 WaveClip::WaveClip(size_t width,
    const SampleBlockFactoryPtr &factory,
    sampleFormat format, int rate)
@@ -65,10 +67,10 @@ WaveClip::WaveClip(size_t width,
 WaveClip::WaveClip(
    const WaveClip& orig, const SampleBlockFactoryPtr& factory,
    bool copyCutlines)
-    : mCentShift { orig.mCentShift }
-    , mClipStretchRatio { orig.mClipStretchRatio }
-    , mRawAudioTempo { orig.mRawAudioTempo }
-    , mProjectTempo { orig.mProjectTempo }
+   : mCentShift { orig.mCentShift }
+   , mClipStretchRatio { orig.mClipStretchRatio }
+   , mRawAudioTempo { orig.mRawAudioTempo }
+   , mProjectTempo { orig.mProjectTempo }
 {
    // essentially a copy constructor - but you must pass in the
    // current sample block factory, because we might be copying
@@ -105,10 +107,10 @@ WaveClip::WaveClip(
 WaveClip::WaveClip(
    const WaveClip& orig, const SampleBlockFactoryPtr& factory,
    bool copyCutlines, double t0, double t1)
-    : mCentShift { orig.mCentShift }
-    , mClipStretchRatio { orig.mClipStretchRatio }
-    , mRawAudioTempo { orig.mRawAudioTempo }
-    , mProjectTempo { orig.mProjectTempo }
+   : mCentShift { orig.mCentShift }
+   , mClipStretchRatio { orig.mClipStretchRatio }
+   , mRawAudioTempo { orig.mRawAudioTempo }
+   , mProjectTempo { orig.mProjectTempo }
 {
    assert(orig.CountSamples(t0, t1) > 0);
 
@@ -160,6 +162,21 @@ WaveClip::~WaveClip()
 {
 }
 
+double WaveClip::Start() const
+{
+   return GetPlayStartTime();
+}
+
+double WaveClip::End() const
+{
+   return GetPlayEndTime();
+}
+
+std::shared_ptr<ChannelInterval> WaveClip::DoGetChannel(size_t iChannel)
+{
+   return std::make_shared<Channel>(*this, iChannel);
+}
+
 AudioSegmentSampleView WaveClip::GetSampleView(
    size_t ii, sampleCount start, size_t length, bool mayThrow) const
 {
@@ -179,6 +196,11 @@ AudioSegmentSampleView WaveClip::GetSampleView(
 }
 
 size_t WaveClip::GetWidth() const
+{
+   return mSequences.size();
+}
+
+size_t WaveClip::NChannels() const
 {
    return mSequences.size();
 }

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1081,6 +1081,7 @@ bool WaveClip::Paste(double t0, const WaveClip& o)
    auto &other = *pOther;
 
    if (NChannels() != other.NChannels())
+      // post is satisfied
       return false;
 
    if (GetSequenceSamplesCount() == 0)
@@ -1091,6 +1092,7 @@ bool WaveClip::Paste(double t0, const WaveClip& o)
       mProjectTempo = other.mProjectTempo;
    }
    else if (GetStretchRatio() != other.GetStretchRatio())
+      // post is satisfied
       return false;
 
    StrongInvariantScope scope{ *this };

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -552,6 +552,26 @@ SampleFormats WaveClip::GetSampleFormats() const
    return mSequences[0]->GetSampleFormats();
 }
 
+size_t WaveClip::CountBlocks() const
+{
+   return std::accumulate(mSequences.begin(), mSequences.end(), size_t{},
+   [](size_t acc, auto &pSequence){
+      return acc + pSequence->GetBlockArray().size(); });
+}
+
+//! A hint for sizing of well aligned fetches
+size_t WaveClip::GetBestBlockSize(sampleCount t) const
+{
+   return mSequences[0]->GetBestBlockSize(t);
+}
+
+size_t WaveClip::GetMaxBlockSize() const
+{
+   return std::accumulate(mSequences.begin(), mSequences.end(), size_t{},
+   [](size_t acc, auto &pSequence){
+      return std::max(acc, pSequence->GetMaxBlockSize()); });
+}
+
 const SampleBlockFactoryPtr &WaveClip::GetFactory() const
 {
    // All sequences have the same factory by class invariant

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -47,6 +47,18 @@ bool WaveClipListener::HandleXMLAttribute(
    return false;
 }
 
+void WaveClipListener::MakeStereo(WaveClipListener &&, bool)
+{
+}
+
+void WaveClipListener::SwapChannels()
+{
+}
+
+void WaveClipListener::Erase(size_t)
+{
+}
+
 WaveClipChannel::~WaveClipChannel() = default;
 
 Envelope &WaveClipChannel::GetEnvelope()

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1180,8 +1180,8 @@ bool WaveClip::Paste(double t0, const WaveClip& o)
 
    finisher.Commit();
    transaction.Commit();
-
    MarkChanged();
+
    const auto sampleTime = 1.0 / GetRate();
    const auto timeOffsetInEnvelope =
       s0.as_double() * GetStretchRatio() / mRate + GetSequenceStartTime();
@@ -1269,7 +1269,8 @@ void WaveClip::Clear(double t0, double t1)
    }
    ClearSequence(st0, st1)
       .Commit();
-   
+   MarkChanged();
+
    if (offset != .0)
       ShiftBy(offset);
 }
@@ -1282,6 +1283,7 @@ void WaveClip::ClearLeft(double t)
          .Commit();
       SetTrimLeft(.0);
       SetSequenceStartTime(t);
+      MarkChanged();
    }
 }
 
@@ -1292,6 +1294,7 @@ void WaveClip::ClearRight(double t)
       ClearSequence(t, GetSequenceEndTime())
          .Commit();
       SetTrimRight(.0);
+      MarkChanged();
    }
 }
 
@@ -1361,7 +1364,6 @@ WaveClip::ClearSequenceFinisher::~ClearSequenceFinisher() noexcept
    // Collapse envelope
    auto sampleTime = 1.0 / pClip->GetRate();
    pClip->GetEnvelope().CollapseRegion(t0, t1, sampleTime);
-   pClip->MarkChanged();
 }
 
 /*! @excsafety{Weak}

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -474,9 +474,11 @@ void WaveClip::UpdateEnvelopeTrackLen()
 
 /*! @excsafety{Strong} */
 std::shared_ptr<SampleBlock>
-WaveClip::AppendNewBlock(constSamplePtr buffer, sampleFormat format, size_t len)
+WaveClip::AppendToChannel(size_t iChannel,
+   constSamplePtr buffer, sampleFormat format, size_t len)
 {
-   return mSequences[0]->AppendNewBlock( buffer, format, len );
+   assert(iChannel < GetWidth());
+   return mSequences[iChannel]->AppendNewBlock(buffer, format, len);
 }
 
 /*! @excsafety{Strong} */
@@ -486,7 +488,7 @@ WaveClip::AppendLegacyNewBlock(constSamplePtr buffer, sampleFormat format, size_
    // This is a special use function for legacy files only and this assertion
    // does not need to be relaxed.  The clip is in a still unzipped track.
    assert(GetWidth() == 1);
-   return mSequences[0]->AppendNewBlock( buffer, format, len );
+   return AppendToChannel(0, buffer, format, len);
 }
 
 /*! @excsafety{Strong} */

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -51,12 +51,12 @@ WaveClipChannel::~WaveClipChannel() = default;
 
 Envelope &WaveClipChannel::GetEnvelope()
 {
-   return *GetClip().GetEnvelope();
+   return GetClip().GetEnvelope();
 }
 
 const Envelope &WaveClipChannel::GetEnvelope() const
 {
-   return *GetClip().GetEnvelope();
+   return GetClip().GetEnvelope();
 }
 
 bool WaveClipChannel::Intersects(double t0, double t1) const
@@ -1048,21 +1048,21 @@ void WaveClip::InsertSilence( double t, double len, double *pEnvelopeValue )
    OffsetCutLines(t, len);
 
    const auto sampleTime = 1.0 / GetRate();
-   auto pEnvelope = GetEnvelope();
+   auto &envelope = GetEnvelope();
    if ( pEnvelopeValue ) {
 
       // Preserve limit value at the end
-      auto oldLen = pEnvelope->GetTrackLen();
+      auto oldLen = envelope.GetTrackLen();
       auto newLen = oldLen + len;
-      pEnvelope->Cap( sampleTime );
+      envelope.Cap( sampleTime );
 
       // Ramp across the silence to the given value
-      pEnvelope->SetTrackLen( newLen, sampleTime );
-      pEnvelope->InsertOrReplace
-         ( pEnvelope->GetOffset() + newLen, *pEnvelopeValue );
+      envelope.SetTrackLen( newLen, sampleTime );
+      envelope.InsertOrReplace
+         ( envelope.GetOffset() + newLen, *pEnvelopeValue );
    }
    else
-      pEnvelope->InsertSpace( t, len );
+      envelope.InsertSpace( t, len );
 
    MarkChanged();
 }
@@ -1171,7 +1171,7 @@ void WaveClip::ClearSequence(double t0, double t1)
       
       // Collapse envelope
       auto sampleTime = 1.0 / GetRate();
-      GetEnvelope()->CollapseRegion(t0, t1, sampleTime);
+      GetEnvelope().CollapseRegion(t0, t1, sampleTime);
    }
 
    transaction.Commit();
@@ -1236,7 +1236,7 @@ void WaveClip::ClearAndAddCutLine(double t0, double t1)
 
    // Collapse envelope
    auto sampleTime = 1.0 / GetRate();
-   GetEnvelope()->CollapseRegion( t0, t1, sampleTime );
+   GetEnvelope().CollapseRegion( t0, t1, sampleTime );
 
    transaction.Commit();
    MarkChanged();

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -221,12 +221,6 @@ void WaveClip::SetEnvelope(std::unique_ptr<Envelope> p)
    mEnvelope = move(p);
 }
 
-BlockArray* WaveClip::GetSequenceBlockArray(size_t ii)
-{
-   assert(ii < GetWidth());
-   return &mSequences[ii]->GetBlockArray();
-}
-
 const BlockArray* WaveClip::GetSequenceBlockArray(size_t ii) const
 {
    assert(ii < GetWidth());

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -229,7 +229,7 @@ public:
    /*!
     @param width how many sequences
     @pre `width > 0`
-    @post `GetWidth() == width`
+    @post `NChannels() == width`
     */
    WaveClip(size_t width,
       const SampleBlockFactoryPtr &factory, sampleFormat format,
@@ -239,7 +239,7 @@ public:
    //! current sample block factory, because we might be copying
    //! from one project to another
    /*!
-    @post `GetWidth() == orig.GetWidth()`
+    @post `NChannels() == orig.NChannels()`
     @post `!copyCutlines || NumCutLines() == orig.NumCutLines()`
     */
    WaveClip(const WaveClip& orig,
@@ -251,7 +251,7 @@ public:
    //! @brief Copy only a range from the given WaveClip
    /*!
     @pre CountSamples(t1, t0) > 0
-    @post `GetWidth() == orig.GetWidth()`
+    @post `NChannels() == orig.NChannels()`
     */
    WaveClip(const WaveClip& orig,
             const SampleBlockFactoryPtr &factory,
@@ -304,7 +304,6 @@ public:
    };
 
    //! How many Sequences the clip contains.
-   size_t GetWidth() const override;
    size_t NChannels() const override;
 
    void ConvertToSampleFormat(sampleFormat format,
@@ -463,7 +462,7 @@ public:
     * `AudioSegmentSampleView::GetSampleCount()`.
     *
     * @param start index of first clip sample from play start
-    * @pre `iChannel < GetWidth()`
+    * @pre `iChannel < NChannels()`
     */
    AudioSegmentSampleView GetSampleView(
       size_t iChannel, sampleCount start, size_t length,
@@ -477,7 +476,7 @@ public:
     * actual number of samples available from the returned view is queried
     * through `AudioSegmentSampleView::GetSampleCount()`.
     *
-    * @pre `iChannel < GetWidth()`
+    * @pre `iChannel < NChannels()`
     * @pre stretched samples in [t0, t1) can be counted in a `size_t`
     */
    AudioSegmentSampleView GetSampleView(
@@ -487,14 +486,14 @@ public:
    /*!
     @param ii identifies the channel
     @param start relative to clip play start sample
-    @pre `ii < GetWidth()`
+    @pre `ii < NChannels()`
     */
    bool GetSamples(size_t ii, samplePtr buffer, sampleFormat format,
                    sampleCount start, size_t len, bool mayThrow = true) const;
 
    //! Get (non-interleaved) samples from all channels
    /*!
-    assume as many buffers available as GetWidth()
+    assume as many buffers available as NChannels()
     @param start relative to clip play start sample
     */
    bool GetSamples(samplePtr buffers[], sampleFormat format,
@@ -502,7 +501,7 @@ public:
 
    //! @param ii identifies the channel
    /*!
-    @pre `ii < GetWidth()`
+    @pre `ii < NChannels()`
     @pre `StrongInvariant()`
     @post `StrongInvariant()`
     @param start relative to clip play start sample
@@ -527,7 +526,7 @@ public:
 
    //! @param ii identifies the channel
    /*!
-    @pre `ii < GetWidth()`
+    @pre `ii < NChannels()`
     */
    const BlockArray* GetSequenceBlockArray(size_t ii) const;
 
@@ -535,10 +534,10 @@ public:
    //! but use more high-level functions inside WaveClip (or add them if you
    //! think they are useful for general use)
    /*!
-    @pre `ii < GetWidth()`
+    @pre `ii < NChannels()`
     */
    Sequence* GetSequence(size_t ii) {
-      assert(ii < GetWidth());
+      assert(ii < NChannels());
       return mSequences[ii].get();
    }
    /*!
@@ -550,7 +549,7 @@ public:
     * calculations and Contrast */
    /*!
     @param ii identifies the channel
-    @pre `ii < GetWidth()`
+    @pre `ii < NChannels()`
     */
    std::pair<float, float> GetMinMax(size_t ii,
       double t0, double t1, bool mayThrow) const;
@@ -565,7 +564,7 @@ public:
    void UpdateEnvelopeTrackLen();
 
    /*!
-    * @pre `iChannel < GetWidth()`
+    * @pre `iChannel < NChannels()`
     */
    std::shared_ptr<SampleBlock>
    AppendToChannel(size_t iChannel,
@@ -573,14 +572,14 @@ public:
 
    //! For use in importing pre-version-3 projects to preserve sharing of
    //! blocks; no dithering applied
-   //! @pre `GetWidth() == 1`
+   //! @pre `NChannels() == 1`
    std::shared_ptr<SampleBlock>
    AppendLegacyNewBlock(constSamplePtr buffer, sampleFormat format, size_t len);
 
    //! For use in importing pre-version-3 projects to preserve sharing of
    //! blocks
    /*!
-    @pre `GetWidth() == 1`
+    @pre `NChannels() == 1`
     */
    void AppendLegacySharedBlock(const std::shared_ptr<SampleBlock> &pBlock);
 
@@ -614,7 +613,7 @@ public:
    //! You must call Flush after the last Append
    /*!
     @return true if at least one complete block was created
-    assume as many buffers available as GetWidth()
+    assume as many buffers available as NChannels()
     In case of failure or exceptions, the clip contents are unchanged but
     un-flushed data are lost
 
@@ -663,12 +662,12 @@ public:
     */
    void ClearAndAddCutLine(double t0, double t1);
 
-   //! @pre `GetWidth() == pClip->GetWidth()`
+   //! @pre `NChannels() == pClip->NChannels()`
    void AddCutLine(WaveClipHolder pClip);
 
    /*!
-    * @return true and succeed if and only if `this->GetWidth() ==
-    * other.GetWidth()` and either this is empty or `this->GetStretchRatio() ==
+    * @return true and succeed if and only if `this->NChannels() ==
+    * other.NChannels()` and either this is empty or `this->GetStretchRatio() ==
     * other.GetStretchRatio()`.
 
     @pre `StrongInvariant()`
@@ -729,7 +728,7 @@ public:
    //! is still done so for compatibility.  Therefore, the first argument.
    /*!
     @param ii identifies the channel
-    @pre `ii < GetWidth()`
+    @pre `ii < NChannels()`
     */
    void WriteXML(size_t ii, XMLWriter &xmlFile) const;
 
@@ -755,12 +754,12 @@ public:
    //! Get one channel of the append buffer
    /*!
     @param ii identifies the channel
-    @pre `ii < GetWidth()`
+    @pre `ii < NChannels()`
     */
    constSamplePtr GetAppendBuffer(size_t ii) const;
    /*!
     @param ii identifies the channel
-    @pre `ii < GetWidth()`
+    @pre `ii < NChannels()`
     */
    size_t GetAppendBufferLen(size_t ii) const;
 
@@ -773,19 +772,19 @@ public:
 
    //! Reduce width
    /*!
-    @post `GetWidth() == 1`
+    @post `NChannels() == 1`
     */
    void DiscardRightChannel();
 
-   //! @pre `GetWidth() == 2`
+   //! @pre `NChannels() == 2`
    void SwapChannels();
 
    //! A stereo WaveClip becomes mono, keeping the left side and returning a
    //! new clip with the right side samples
    /*!
-    @pre `GetWidth() == 2`
-    @post `GetWidth() == 1`
-    @post result: `result->GetWidth() == 1`
+    @pre `NChannels() == 2`
+    @post `NChannels() == 1`
+    @post result: `result->NChannels() == 1`
     */
    std::shared_ptr<WaveClip> SplitChannels();
 
@@ -795,8 +794,8 @@ public:
     Stating sufficient preconditions for the postondition.  Even stronger
     preconditions on matching offset, trims, and rates could be stated.
 
-    @pre `GetWidth() == 1`
-    @pre `other.GetWidth() == 1`
+    @pre `NChannels() == 1`
+    @pre `other.NChannels() == 1`
     @pre `GetSampleFormats() == other.GetSampleFormats()`
     @pre `GetSampleBlockFactory() == other.GetSampleBlockFactory()`
     @pre `!mustAlign || GetNumSamples() == other.GetNumSamples()`
@@ -820,7 +819,7 @@ public:
 
     @param emptyCopy if true, don't make sequences
 
-    @post `GetWidth() == (token.emptyCopy ? 0 : orig.GetWidth())`
+    @post `NChannels() == (token.emptyCopy ? 0 : orig.NChannels())`
     @post `!copyCutlines || NumCutLines() == orig.NumCutLines()`
     */
    WaveClip(const WaveClip& orig,

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -418,10 +418,6 @@ public:
    /*!
     @pre `ii < GetWidth()`
     */
-   BlockArray* GetSequenceBlockArray(size_t ii);
-   /*!
-    @copydoc GetSequenceBlockArray
-    */
    const BlockArray* GetSequenceBlockArray(size_t ii) const;
 
    //! Get low-level access to a sequence. Whenever possible, don't use this,

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -342,7 +342,7 @@ public:
     */
    bool CoversEntirePlayRegion(double t0, double t1) const;
 
-   //! Counts number of samples within t0 and t1 region. t0 and t1 are
+   //! Counts number of sample times within t0 and t1 region. t0 and t1 are
    //! rounded to the nearest clip sample boundary, i.e. relative to clips
    //! start time offset.
    //! @returns Number of samples within t0 and t1 if t1 > t0, 0 otherwise

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -538,6 +538,8 @@ public:
 
    Envelope &GetEnvelope() { return *mEnvelope; }
    const Envelope &GetEnvelope() const { return *mEnvelope; }
+
+   //! @pre `p`
    void SetEnvelope(std::unique_ptr<Envelope> p);
 
    //! @param ii identifies the channel

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -690,7 +690,7 @@ public:
    void AppendSilence( double len, double envelopeValue );
 
    /// Get access to cut lines list
-   WaveClipHolders &GetCutLines() { return mCutLines; }
+   const WaveClipHolders &GetCutLines() { return mCutLines; }
    const WaveClipConstHolders &GetCutLines() const
       { return reinterpret_cast< const WaveClipConstHolders& >( mCutLines ); }
    size_t NumCutLines() const { return mCutLines.size(); }

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -673,6 +673,10 @@ public:
     @pre `StrongInvariant()`
     @pre `other.StrongInvariant()`
     @post `StrongInvariant()`
+
+    This says, same widths and ratios are sufficient for success
+    @post result: `this->NChannels() != other.NChannels() ||
+       this->GetStretchRatio() != other.GetStretchRatio() || result`
     */
    bool Paste(double t0, const WaveClip& other);
 

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -453,8 +453,12 @@ public:
     * function to tell the envelope about it. */
    void UpdateEnvelopeTrackLen();
 
+   /*!
+    * @pre `iChannel < GetWidth()`
+    */
    std::shared_ptr<SampleBlock>
-   AppendNewBlock(constSamplePtr buffer, sampleFormat format, size_t len);
+   AppendToChannel(size_t iChannel,
+      constSamplePtr buffer, sampleFormat format, size_t len);
 
    //! For use in importing pre-version-3 projects to preserve sharing of
    //! blocks; no dithering applied

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -584,6 +584,32 @@ public:
     */
    void AppendLegacySharedBlock(const std::shared_ptr<SampleBlock> &pBlock);
 
+   //! Append (non-interleaved) samples to some or all channels
+   //! You must call Flush after the last Append
+   /*!
+    For stereo clips, typically this is invoked on left, then right channels,
+    either alternating (as when recording) or in two batches (channel-major
+    pattern of effect processing), which violates the strong invariant
+    condition, then restores it (either repeatedly, or once).
+
+    @return true if at least one complete block was created
+    In case of failure or exceptions, the clip contents are unchanged but
+    un-flushed data are lost
+
+    @pre `iChannel < NChannels()`
+    @pre `iChannel + nChannels <= NChannels()`
+    */
+   bool Append(size_t iChannel, size_t nChannels,
+      constSamplePtr buffers[], sampleFormat format,
+      size_t len, unsigned int stride,
+      sampleFormat effectiveFormat /*!<
+         Make the effective format of the data at least the minumum of this
+         value and `format`.  (Maybe wider, if merging with preexistent data.)
+         If the data are later narrowed from stored format, but not narrower
+         than the effective, then no dithering will occur.
+      */
+   );
+
    //! Append (non-interleaved) samples to all channels
    //! You must call Flush after the last Append
    /*!

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -51,7 +51,7 @@ CRTP_BASE(WaveClipListenerBase, struct,
    ClientData::Cloneable<WaveClipListener>);
 struct WaveClipListener : WaveClipListenerBase {
    virtual ~WaveClipListener() = 0;
-   virtual void MarkChanged() = 0;
+   virtual void MarkChanged() noexcept = 0;
    virtual void Invalidate() = 0;
 
    // Default implementation does nothing
@@ -518,8 +518,8 @@ public:
 
    //! @}
 
-   Envelope &GetEnvelope() { return *mEnvelope; }
-   const Envelope &GetEnvelope() const { return *mEnvelope; }
+   Envelope &GetEnvelope() noexcept { return *mEnvelope; }
+   const Envelope &GetEnvelope() const noexcept { return *mEnvelope; }
 
    //! @pre `p`
    void SetEnvelope(std::unique_ptr<Envelope> p);
@@ -839,7 +839,7 @@ private:
 
    //! Called by mutating operations; notifies listeners
    /*! @excsafety{No-fail} */
-   void MarkChanged();
+   void MarkChanged() noexcept;
 
    // Always gives non-negative answer, not more than sample sequence length
    // even if t0 really falls outside that range
@@ -858,6 +858,16 @@ private:
     @post `StrongInvariant()`
     */
    void ClearSequence(double t0, double t1);
+
+   //! Fix consistency of cutlines and envelope after deleting from Sequences
+   /*!
+    @param t0 start of deleted range
+    @param t1 end of deleted range
+    @param clip_t0 t0 clamped to previous play region
+    @param clip_t1 t1 clamped to previous play region
+    */
+   void FinishClearSequence(
+      double t0, double t1, double clip_t0, double clip_t1) noexcept;
 
    //! Restores state when an update loop over mSequences fails midway
    struct Transaction {

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -46,48 +46,6 @@ using WaveClipHolders = std::vector <WaveClipHolder>;
 using WaveClipConstHolders = std::vector<WaveClipConstHolder>;
 using ProgressReporter = std::function<void(double)>;
 
-// A bundle of arrays needed for drawing waveforms.  The object may or may not
-// own the storage for those arrays.  If it does, it destroys them.
-class WaveDisplay
-{
-public:
-   int width;
-   sampleCount *where;
-   float *min, *max, *rms;
-
-   std::vector<sampleCount> ownWhere;
-   std::vector<float> ownMin, ownMax, ownRms;
-
-public:
-   WaveDisplay(int w)
-      : width(w), where(0), min(0), max(0), rms(0)
-   {
-   }
-
-   // Create "own" arrays.
-   void Allocate()
-   {
-      ownWhere.resize(width + 1);
-      ownMin.resize(width);
-      ownMax.resize(width);
-      ownRms.resize(width);
-
-      where = &ownWhere[0];
-      if (width > 0) {
-         min = &ownMin[0];
-         max = &ownMax[0];
-         rms = &ownRms[0];
-      }
-      else {
-         min = max = rms = 0;
-      }
-   }
-
-   ~WaveDisplay()
-   {
-   }
-};
-
 struct WAVE_TRACK_API WaveClipListener;
 CRTP_BASE(WaveClipListenerBase, struct,
    ClientData::Cloneable<WaveClipListener>);

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -102,6 +102,26 @@ struct WaveClipListener : WaveClipListenerBase {
    // Default implementation just returns false
    virtual bool HandleXMLAttribute(
       const std::string_view &attr, const XMLAttributeValueView &valueView);
+
+   //! Append the other's attachments to this, assuming concrete subclasses are
+   //! the same
+   /*!
+    Default implementation does nothing
+    @param aligned whether the strong invariant condition on the clip may be
+    assumed
+    @pre `typeid(*this) == typeid(other)`
+    */
+   virtual void MakeStereo(WaveClipListener &&other, bool aligned);
+
+   //! Default implementation does nothing
+   virtual void SwapChannels();
+
+   //! Erase attachment at a given index, if it existed, moving later-indexed
+   //! attachments to earlier indices
+   /*!
+    Default implementation does nothing
+    */
+   virtual void Erase(size_t index);
 };
 
 class WAVE_TRACK_API WaveClipChannel

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -536,8 +536,8 @@ public:
 
    //! @}
 
-   Envelope* GetEnvelope() { return mEnvelope.get(); }
-   const Envelope* GetEnvelope() const { return mEnvelope.get(); }
+   Envelope &GetEnvelope() { return *mEnvelope; }
+   const Envelope &GetEnvelope() const { return *mEnvelope; }
    void SetEnvelope(std::unique_ptr<Envelope> p);
 
    //! @param ii identifies the channel
@@ -818,7 +818,7 @@ private:
     @invariant `CheckInvariants()`
     */
    std::vector<std::unique_ptr<Sequence>> mSequences;
-   //! Envelope is unique, not per-sequence
+   //! Envelope is unique, not per-sequence, and always non-null
    std::unique_ptr<Envelope> mEnvelope;
 
    //! Cut Lines are nothing more than ordinary wave clips, with the

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -195,7 +195,6 @@ public:
    };
 
    //! How many Sequences the clip contains.
-   //! Set at construction time; changes only if increased by deserialization
    size_t GetWidth() const override;
 
    void ConvertToSampleFormat(sampleFormat format,

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -787,6 +787,40 @@ public:
 
    size_t CountBlocks() const;
 
+   //! Reduce width
+   /*!
+    @post `GetWidth() == 1`
+    */
+   void DiscardRightChannel();
+
+   //! @pre `GetWidth() == 2`
+   void SwapChannels();
+
+   //! A stereo WaveClip becomes mono, keeping the left side and returning a
+   //! new clip with the right side samples
+   /*!
+    @pre `GetWidth() == 2`
+    @post `GetWidth() == 1`
+    @post result: `result->GetWidth() == 1`
+    */
+   std::shared_ptr<WaveClip> SplitChannels();
+
+   //! Steal the right side data from other
+   //! All cutlines are lost in `this`!  Cutlines are not copied from other.
+   /*!
+    Stating sufficient preconditions for the postondition.  Even stronger
+    preconditions on matching offset, trims, and rates could be stated.
+
+    @pre `GetWidth() == 1`
+    @pre `other.GetWidth() == 1`
+    @pre `GetSampleFormats() == other.GetSampleFormats()`
+    @pre `GetSampleBlockFactory() == other.GetSampleBlockFactory()`
+    @pre `!mustAlign || GetNumSamples() == other.GetNumSamples()`
+    
+    @post `!mustAlign || StrongInvariant()`
+    */
+   void MakeStereo(WaveClip &&other, bool mustAlign);
+
    // These return a nonnegative number of samples meant to size a memory buffer
    size_t GetBestBlockSize(sampleCount t) const;
    size_t GetMaxBlockSize() const;
@@ -810,6 +844,10 @@ public:
             bool copyCutlines, CreateToken token);
 
 private:
+   static void TransferSequence(WaveClip &origClip, WaveClip &newClip);
+   static void FixSplitCutlines(
+      WaveClipHolders &myCutlines, WaveClipHolders &newCutlines);
+
    size_t GreatestAppendBufferLen() const;
 
    //! Called by mutating operations; notifies listeners

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -760,6 +760,12 @@ public:
 
    SampleFormats GetSampleFormats() const;
 
+   size_t CountBlocks() const;
+
+   // These return a nonnegative number of samples meant to size a memory buffer
+   size_t GetBestBlockSize(sampleCount t) const;
+   size_t GetMaxBlockSize() const;
+
 private:
    size_t GreatestAppendBufferLen() const;
 

--- a/libraries/lib-wave-track/WaveClipUtilities.cpp
+++ b/libraries/lib-wave-track/WaveClipUtilities.cpp
@@ -46,21 +46,6 @@ void WaveClipUtilities::SetFloatsFromTime(WaveClip &clip,
       effectiveFormat);
 }
 
-void WaveClipUtilities::SetFloatsCenteredAroundTime(WaveClip &clip,
-   double t, size_t iChannel, const float* buffer, size_t numSideSamples,
-   sampleFormat effectiveFormat)
-{
-   SetFloatsFromTime(clip,
-      t - clip.SamplesToTime(numSideSamples), iChannel, buffer,
-      2 * numSideSamples + 1, effectiveFormat);
-}
-
-void WaveClipUtilities::SetFloatAtTime(WaveClip &clip,
-   double t, size_t iChannel, float value, sampleFormat effectiveFormat)
-{
-   SetFloatsCenteredAroundTime(clip, t, iChannel, &value, 0u, effectiveFormat);
-}
-
 bool WaveClipUtilities::SharesBoundaryWithNextClip(
    const WaveTrack::Interval &prev, const WaveTrack::Interval& next)
 {

--- a/libraries/lib-wave-track/WaveClipUtilities.h
+++ b/libraries/lib-wave-track/WaveClipUtilities.h
@@ -42,19 +42,6 @@ WAVE_TRACK_API void SetFloatsFromTime(WaveClip &clip,
    double t, size_t iChannel, const float* buffer, size_t numSamples,
    sampleFormat effectiveFormat);
 
-/*!
- @brief Same as `SetFloatsFromTime`, but with `buffer` starting at
- `TimeToSamples(t0 -  SamplesToTime(numSideSamples))`.
- `[buffer, buffer + 2 * numSizeSamples + 1)` is assumed to be a valid span
- of addresses.
- */
-WAVE_TRACK_API void SetFloatsCenteredAroundTime(WaveClip &clip,
-   double t, size_t iChannel, const float* buffer, size_t numSideSamples,
-   sampleFormat effectiveFormat);
-
-WAVE_TRACK_API void SetFloatAtTime(WaveClip &clip,
-   double t, size_t iChannel, float value, sampleFormat effectiveFormat);
-
 //! used by commands which interact with clips using the keyboard
 /*!
  When two clips are immediately next to each other, the GetPlayEndTime()

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -109,13 +109,13 @@ WaveChannelInterval::GetSampleView(double t0, double t1, bool mayThrow) const
 const Envelope &WaveChannelInterval::GetEnvelope() const
 {
    // Always the left clip's envelope
-   return *GetWideClip().GetEnvelope();
+   return GetWideClip().GetEnvelope();
 }
 
 Envelope &WaveChannelInterval::GetEnvelope()
 {
    // Always the left clip's envelope
-   return *GetWideClip().GetEnvelope();
+   return GetWideClip().GetEnvelope();
 }
 
 sampleCount WaveChannelInterval::GetVisibleSampleCount() const
@@ -897,12 +897,12 @@ void WaveTrack::Interval::SetIsPlaceholder(bool val)
 
 Envelope& WaveTrack::Interval::GetEnvelope()
 {
-   return *mpClip->GetEnvelope();
+   return mpClip->GetEnvelope();
 }
 
 const Envelope& WaveTrack::Interval::GetEnvelope() const
 {
-   return *mpClip->GetEnvelope();
+   return mpClip->GetEnvelope();
 }
 
 
@@ -3180,7 +3180,7 @@ void WaveTrack::CopyClipEnvelopes()
          assert(false);
          break;
       }
-      (*it2)->SetEnvelope(std::make_unique<Envelope>(*(*it)->GetEnvelope()));
+      (*it2)->SetEnvelope(std::make_unique<Envelope>((*it)->GetEnvelope()));
    }
 }
 
@@ -3293,7 +3293,7 @@ XMLTagHandler *WaveTrack::HandleXMLChild(const std::string_view& tag)
       if (tag == Sequence::Sequence_tag)
          return getClip().GetSequence(0);
       else if (tag == "envelope")
-         return getClip().GetEnvelope();
+         return &getClip().GetEnvelope();
    }
 
    // JKC... for 1.1.0, one step better than what we had, but still badly broken.

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -282,6 +282,44 @@ WaveTrack::Interval::Interval(
 {
 }
 
+WaveTrack::Interval::Interval(const ChannelGroup &group,
+   const Interval& orig,
+   const SampleBlockFactoryPtr &factory,
+   bool copyCutlines
+)  : WideChannelGroupInterval{ group }
+   , mpClip{
+      std::make_shared<WaveClip>(*orig.mpClip, factory, copyCutlines) }
+   , mpClip1{ orig.mpClip1
+      ? std::make_shared<WaveClip>(*orig.mpClip1, factory, copyCutlines)
+      : nullptr }
+{
+}
+
+WaveTrack::Interval::Interval(const ChannelGroup &group,
+   const Interval& orig,
+   const SampleBlockFactoryPtr &factory,
+   bool copyCutlines,
+   double t0, double t1
+)  : WideChannelGroupInterval{ group }
+   , mpClip{
+      std::make_shared<WaveClip>(*orig.mpClip, factory, copyCutlines, t0, t1) }
+   , mpClip1{ orig.mpClip1
+      ? std::make_shared<WaveClip>(*orig.mpClip1, factory, copyCutlines, t0, t1)
+      : nullptr }
+{
+}
+
+bool WaveTrack::Interval::IsEmpty() const
+{
+   return mpClip->IsEmpty() && (!mpClip1 || mpClip1->IsEmpty());
+}
+
+sampleCount WaveTrack::Interval::CountSamples(double t0, double t1) const
+{
+   // Sample times in the interval, independent of its width
+   return GetClip(0)->CountSamples(t0, t1);
+}
+
 WaveTrack::Interval::~Interval() = default;
 
 double WaveTrack::Interval::Start() const

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -522,11 +522,6 @@ void WaveTrack::CopyClips(WaveClipHolders &clips,
          false, backup, false);
 }
 
-size_t WaveTrack::GetWidth() const
-{
-   return NChannels();
-}
-
 size_t WaveChannel::NChannels() const
 {
    return 1;
@@ -2973,7 +2968,7 @@ auto WaveTrack::DoCreateClip(double offset, const wxString& name) const
    const auto& tempo = GetProjectTempo(*this);
    if (tempo.has_value())
       clip->OnProjectTempoChange(std::nullopt, *tempo);
-   assert(clip->GetWidth() == GetWidth());
+   assert(clip->NChannels() == NChannels());
    return clip;
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1837,12 +1837,12 @@ void WaveTrack::PasteWaveTrackAtSameTempo(
                // This branch only gets executed in `singleClipMode` - we've
                // already made sure that stretch ratios are equal, satisfying
                // `WaveClip::Paste`'s precondition.
+               assert(insideClip->GetStretchRatio() == pClip->GetStretchRatio());
+               // This too should follow from the assertion of the same number
+               // of channels in the tracks, near the top
+               assert(insideClip->NChannels() == pClip->NChannels());
                bool success = insideClip->Paste(t0, *pClip);
-               // TODO wide wave tracks -- prove success, or propagate failure,
-               // or we might throw a MessageBoxException
-               // (which would require a change in base class Track)
-               // for now it would be quiet failure if clip widths mismatched
-               // Can't yet assert(success);
+               assert(success);
             }
             return;
         }

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1511,41 +1511,6 @@ void WaveTrack::SplitDelete(double t0, double t1)
    HandleClear(t0, t1, addCutLines, split);
 }
 
-namespace
-{
-   WaveClipHolders::const_iterator
-      FindClip(const WaveClipHolders &list, const WaveClip *clip, int *distance = nullptr)
-   {
-      if (distance)
-         *distance = 0;
-      auto it = list.begin();
-      for (const auto end = list.end(); it != end; ++it)
-      {
-         if (it->get() == clip)
-            break;
-         if (distance)
-            ++*distance;
-      }
-      return it;
-   }
-
-   WaveClipHolders::iterator
-      FindClip(WaveClipHolders &list, const WaveClip *clip, int *distance = nullptr)
-   {
-      if (distance)
-         *distance = 0;
-      auto it = list.begin();
-      for (const auto end = list.end(); it != end; ++it)
-      {
-         if (it->get() == clip)
-            break;
-         if (distance)
-            ++*distance;
-      }
-      return it;
-   }
-}
-
 std::ptrdiff_t WaveTrack::FindWideClip(const Interval &clip)
 {
    auto clips = Intervals();

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -3021,7 +3021,7 @@ void WaveTrack::Join(
 
       // wxPrintf("Pasting at %.6f\n", t);
       bool success = newClip->Paste(t, *clip);
-      assert(success); // promise of CreateClip
+      assert(success); // promise of DoCreateClip
 
       t = newClip->GetPlayEndTime();
 
@@ -3802,9 +3802,9 @@ auto WaveTrack::CreateWideClip(double offset, const wxString& name,
          holders[iChannel++] = pNewClip;
       });
    else {
-      holders[iChannel++] = CreateClip(*this, offset, name);
+      holders[iChannel++] = DoCreateClip(offset, name);
       if (mRightChannel.has_value())
-         holders[iChannel++] = CreateClip(*this, offset, name);
+         holders[iChannel++] = DoCreateClip(offset, name);
    }
 
    return std::make_shared<Interval>(holders[0], holders[1]);
@@ -3823,22 +3823,21 @@ void WaveTrack::CreateRight()
    mRightClips.emplace();
 }
 
-auto WaveTrack::CreateClip(WaveTrack &track,
-   double offset, const wxString& name)
-      -> WaveClipHolder
+auto WaveTrack::DoCreateClip(double offset, const wxString& name) const
+   -> WaveClipHolder
 {
    // TODO wide wave tracks -- choose clip width correctly for the track
    auto clip = std::make_shared<WaveClip>(1,
-      track.mpFactory, track.GetSampleFormat(), track.GetRate());
+      mpFactory, GetSampleFormat(), GetRate());
    clip->SetName(name);
    clip->SetSequenceStartTime(offset);
 
-   const auto& tempo = GetProjectTempo(track);
+   const auto& tempo = GetProjectTempo(*this);
    if (tempo.has_value())
       clip->OnProjectTempoChange(std::nullopt, *tempo);
    // TODO wide wave tracks -- for now assertion is correct because widths are
    // always 1
-   assert(clip->GetWidth() == track.GetWidth());
+   assert(clip->GetWidth() == GetWidth());
    return clip;
 }
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -71,432 +71,22 @@ from the project that will own the track.
 
 using std::max;
 
-WaveChannelInterval::WaveChannelInterval(WaveClipHolder pWideClip,
-   WaveClipHolder pNarrowClip, size_t iChannel
-)  : mpWideClip{ move(pWideClip) }
-   , mpNarrowClip{ move(pNarrowClip) }
-   , miChannel{ iChannel }
-{
-   assert(mpWideClip != nullptr);
-   assert(mpNarrowClip != nullptr);
-}
-
-WaveChannelInterval::~WaveChannelInterval() = default;
-
-bool WaveChannelInterval::Intersects(double t0, double t1) const
-{
-   return GetNarrowClip().IntersectsPlayRegion(t0, t1);
-}
-
-double WaveChannelInterval::Start() const
-{
-   return GetNarrowClip().GetPlayStartTime();
-}
-
-double WaveChannelInterval::End() const
-{
-   return GetNarrowClip().GetPlayEndTime();
-}
-
-AudioSegmentSampleView
-WaveChannelInterval::GetSampleView(double t0, double t1, bool mayThrow) const
-{
-   constexpr auto iChannel = 0u;
-   // TODO wide wave tracks: use the real channel number.
-   return GetNarrowClip().GetSampleView(iChannel, t0, t1, mayThrow);
-}
-
-const Envelope &WaveChannelInterval::GetEnvelope() const
-{
-   // Always the left clip's envelope
-   return GetWideClip().GetEnvelope();
-}
-
-Envelope &WaveChannelInterval::GetEnvelope()
-{
-   // Always the left clip's envelope
-   return GetWideClip().GetEnvelope();
-}
-
-sampleCount WaveChannelInterval::GetVisibleSampleCount() const
-{
-   return GetNarrowClip().GetVisibleSampleCount();
-}
-
-int WaveChannelInterval::GetRate() const
-{
-   return GetNarrowClip().GetRate();
-}
-
-double WaveChannelInterval::GetPlayStartTime() const
-{
-   return GetNarrowClip().GetPlayStartTime();
-}
-
-double WaveChannelInterval::GetPlayEndTime() const
-{
-   return GetNarrowClip().GetPlayEndTime();
-}
-
-double WaveChannelInterval::GetPlayDuration() const
-{
-   return GetPlayEndTime() - GetPlayStartTime();
-}
-
-bool WaveChannelInterval::WithinPlayRegion(double t) const
-{
-   return GetNarrowClip().WithinPlayRegion(t);
-}
-
-sampleCount WaveChannelInterval::TimeToSamples(double time) const
-{
-   return GetNarrowClip().TimeToSamples(time);
-}
-
-double WaveChannelInterval::SamplesToTime(sampleCount s) const noexcept
-{
-   return GetNarrowClip().SamplesToTime(s);
-}
-
-double WaveChannelInterval::GetStretchRatio() const
-{
-   return GetNarrowClip().GetStretchRatio();
-}
-
-bool WaveChannelInterval::HasPitchOrSpeed() const
-{
-   return GetNarrowClip().HasPitchOrSpeed();
-}
-
-double WaveChannelInterval::GetTrimLeft() const
-{
-   return GetNarrowClip().GetTrimLeft();
-}
-
-double WaveChannelInterval::GetTrimRight() const
-{
-   return GetNarrowClip().GetTrimRight();
-}
-
-bool WaveChannelInterval::GetSamples(samplePtr buffer, sampleFormat format,
-   sampleCount start, size_t len, bool mayThrow) const
-{
-   // Not just a pass-through, but supply the first argument
-   // TODO wide wave tracks -- pass miChannel not 0
-   return GetNarrowClip().GetSamples(0, buffer, format, start, len, mayThrow);
-}
-
-AudioSegmentSampleView WaveChannelInterval::GetSampleView(
-   sampleCount start, size_t length, bool mayThrow) const
-{
-   // Not just a pass-through, but supply the first argument
-   // TODO wide wave tracks -- pass miChannel not 0
-   return GetNarrowClip().GetSampleView(0, start, length, mayThrow);
-}
-
-const Sequence &WaveChannelInterval::GetSequence() const
-{
-   // TODO wide wave tracks -- use miChannel
-   const auto pSequence = GetNarrowClip().GetSequence(0);
-   // Assume sufficiently wide clip
-   assert(pSequence);
-   return *pSequence;
-}
-
-constSamplePtr WaveChannelInterval::GetAppendBuffer() const
-{
-   // TODO wide wave tracks -- use miChannel
-   return GetNarrowClip().GetAppendBuffer(0);
-}
-
-size_t WaveChannelInterval::GetAppendBufferLen() const
-{
-   // TODO wide wave tracks -- use miChannel
-   return GetNarrowClip().GetAppendBufferLen(0);
-}
-
-const BlockArray *WaveChannelInterval::GetSequenceBlockArray() const
-{
-   return GetNarrowClip().GetSequenceBlockArray(
-      0
-      // TODO wide wave tracks -- miChannel
-   );
-}
-
-std::pair<float, float>
-WaveChannelInterval::GetMinMax(double t0, double t1, bool mayThrow) const
-{
-   return GetNarrowClip().GetMinMax(
-      // TODO wide wave tracks -- miChannel
-      0, t0, t1, mayThrow);
-}
-
-float WaveChannelInterval::GetRMS(double t0, double t1, bool mayThrow) const
-{
-   return GetNarrowClip().GetRMS(
-      // TODO wide wave tracks -- miChannel
-      0, t0, t1, mayThrow);
-}
-
-sampleCount WaveChannelInterval::GetPlayStartSample() const
-{
-   return GetNarrowClip().GetPlayStartSample();
-}
-
-sampleCount WaveChannelInterval::GetPlayEndSample() const
-{
-   return GetNarrowClip().GetPlayEndSample();
-}
-
-void WaveChannelInterval::SetSamples(constSamplePtr buffer, sampleFormat format,
-   sampleCount start, size_t len, sampleFormat effectiveFormat)
-{
-   return GetNarrowClip().SetSamples(
-      // TODO wide wave tracks -- miChannel
-      0, buffer, format, start, len, effectiveFormat);
-}
-
-void WaveChannelInterval::WriteXML(XMLWriter &xmlFile) const
-{
-   // TODO wide wave tracks -- use miChannel
-   GetNarrowClip().WriteXML(0, xmlFile);
-}
-
-WaveTrack::Interval::Interval(
-   const std::shared_ptr<WaveClip> &pClip,
-   const std::shared_ptr<WaveClip> &pClip1
-)  : mpClip{ pClip }
-   , mpClip1{ pClip1 }
-{
-}
-
-WaveTrack::Interval::Interval(size_t width,
-   const SampleBlockFactoryPtr& factory, int rate, sampleFormat format)
-    : Interval(std::make_shared<WaveClip>(1, factory, format, rate),
-         width == 2 ?
-            std::make_shared<WaveClip>(1, factory, format, rate) :
-            nullptr)
-{
-}
-
-WaveTrack::Interval::Interval(const Interval& orig,
-   const SampleBlockFactoryPtr &factory,
-   bool copyCutlines
-)  : mpClip{
-      std::make_shared<WaveClip>(*orig.mpClip, factory, copyCutlines) }
-   , mpClip1{ orig.mpClip1
-      ? std::make_shared<WaveClip>(*orig.mpClip1, factory, copyCutlines)
-      : nullptr }
-{
-}
-
-WaveTrack::Interval::Interval(
-   const Interval& orig,
-   const SampleBlockFactoryPtr &factory,
-   bool copyCutlines,
-   double t0, double t1
-)  : mpClip{
-      std::make_shared<WaveClip>(*orig.mpClip, factory, copyCutlines, t0, t1) }
-   , mpClip1{ orig.mpClip1
-      ? std::make_shared<WaveClip>(*orig.mpClip1, factory, copyCutlines, t0, t1)
-      : nullptr }
-{
-}
-
-bool WaveTrack::Interval::IsEmpty() const
-{
-   return mpClip->IsEmpty() && (!mpClip1 || mpClip1->IsEmpty());
-}
-
-sampleCount WaveTrack::Interval::CountSamples(double t0, double t1) const
-{
-   // Sample times in the interval, independent of its width
-   return GetClip(0)->CountSamples(t0, t1);
-}
-
-WaveTrack::Interval::~Interval() = default;
-
-double WaveTrack::Interval::Start() const
-{
-   return mpClip->GetPlayStartTime();
-}
-
-double WaveTrack::Interval::End() const
-{
-   return mpClip->GetPlayEndTime();
-}
-
-size_t WaveTrack::Interval::NChannels() const
-{
-   return mpClip1 ? 2u : 1u;
-}
-
-size_t WaveTrack::Interval::GetBestBlockSize(sampleCount start) const
-{
-   return GetClip(0)->GetSequence(0)->GetBestBlockSize(start);
-}
-
-size_t WaveTrack::Interval::GetMaxBlockSize() const
-{
-   auto result = GetClip(0)->GetSequence(0)->GetMaxBlockSize();
-   if (NChannels() > 1)
-      result =
-         std::max(result, GetClip(1)->GetSequence(0)->GetMaxBlockSize());
-   return result;
-}
-
-sampleCount WaveTrack::Interval::GetSequenceStartSample() const
-{
-   return GetClip(0)->GetSequenceStartSample();
-}
-
-bool WaveTrack::Interval::EqualSequenceLengthInvariant() const
-{
-   if (NChannels() < 2)
-      return true;
-   const auto &pClip0 = GetClip(0);
-   const auto &pClip1 = GetClip(1);
-   return
-      pClip0->GetSequenceStartTime() == pClip1->GetSequenceStartTime()
-   &&
-      pClip0->GetSequenceEndTime() == pClip1->GetSequenceEndTime()
-   &&
-      pClip0->GetPlayStartTime() == pClip1->GetPlayStartTime()
-   &&
-      pClip0->GetPlayEndTime() == pClip1->GetPlayEndTime()
-   ;
-}
-
-void WaveTrack::Interval::Append(
-   constSamplePtr buffer[], sampleFormat format, size_t len)
-{
-   for (unsigned channel = 0; channel < NChannels(); ++channel)
-      // TODO wide wave clips -- pass channel number
-      GetClip(channel)
-         ->AppendToChannel(0, buffer[channel], format, len);
-}
-
-void WaveTrack::Interval::Flush()
-{
-   ForEachClip([](auto& clip) { clip.Flush(); });
-}
-
-void WaveTrack::Interval::RepairChannels()
-{
-   ForEachClip([](auto& clip) { clip.RepairChannels(); });
-}
-
-void WaveTrack::Interval::Clear(double t0, double t1)
-{
-   ForEachClip([&](auto& clip) { clip.Clear(t0, t1); });
-}
-
-void WaveTrack::Interval::TrimLeftTo(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->TrimLeftTo(t);
-}
-
-void WaveTrack::Interval::TrimRightTo(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->TrimRightTo(t);
-}
-
-void WaveTrack::Interval::TrimQuarternotesFromRight(double quarters)
-{
-   ForEachClip(
-      [quarters](auto& clip) { clip.TrimQuarternotesFromRight(quarters); });
-}
-
-void WaveTrack::Interval::SetTrimLeft(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->SetTrimLeft(t);
-}
-
-void WaveTrack::Interval::SetTrimRight(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->SetTrimRight(t);
-}
-
-void WaveTrack::Interval::TrimLeft(double deltaTime)
-{
-   ForEachClip([&](auto &clip) { clip.TrimLeft(deltaTime); });
-}
-
-void WaveTrack::Interval::TrimRight(double deltaTime)
-{
-   ForEachClip([&](auto &clip) { clip.TrimRight(deltaTime); });
-}
-
-void WaveTrack::Interval::ClearLeft(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->ClearLeft(t);
-}
-
-void WaveTrack::Interval::ClearRight(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->ClearRight(t);
-}
-
-void WaveTrack::Interval::ClearAndAddCutLine(double t0, double t1)
-{
-   ForEachClip(
-      [&](auto& clip) { clip.ClearAndAddCutLine(t0, t1); });
-}
-
-void WaveTrack::Interval::AddCutLine(Interval &interval)
-{
-   assert(NChannels() == interval.NChannels());
-   size_t ii = 0;
-   ForEachClip([&](auto &clip) { clip.AddCutLine(interval.GetClip(ii++)); });
-}
-
-void WaveTrack::Interval::StretchLeftTo(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->StretchLeftTo(t);
-}
-
-void WaveTrack::Interval::StretchRightTo(double t)
-{
-   for(unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->StretchRightTo(t);
-}
-
-void WaveTrack::Interval::StretchBy(double ratio)
-{
-   for (unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->StretchBy(ratio);
-}
-
-bool WaveTrack::Interval::SetCentShift(int cents)
-{
-   for (unsigned channel = 0; channel < NChannels(); ++channel)
-      if (!GetClip(channel)->SetCentShift(cents))
-         return false;
-   return true;
-}
-
 /*!
  * @post result: `result->GetStretchRatio() == 1`
  */
 namespace {
-WaveTrack::IntervalHolder GetRenderedCopy(WaveTrack::Interval &interval,
+WaveTrack::IntervalHolder GetRenderedCopy(
+   const WaveTrack::IntervalHolder &pInterval,
    const std::function<void(double)>& reportProgress,
    const SampleBlockFactoryPtr& factory, sampleFormat format)
 {
+   auto &interval = *pInterval;
    using Interval = WaveTrack::Interval;
    if (!interval.HasPitchOrSpeed())
-      return std::make_shared<Interval>(
-         interval.GetClip(0), interval.GetClip(1));
+      return pInterval;
 
    const auto dst = std::make_shared<Interval>(
-      interval.NChannels(), factory, interval.GetRate(), format);
+      interval.NChannels(), factory, format, interval.GetRate());
 
    const auto originalPlayStartTime = interval.GetPlayStartTime();
    const auto originalPlayEndTime = interval.GetPlayEndTime();
@@ -549,7 +139,7 @@ WaveTrack::IntervalHolder GetRenderedCopy(WaveTrack::Interval &interval,
       data[0] = reinterpret_cast<constSamplePtr>(container.Get()[0]);
       if (interval.NChannels() == 2)
          data[1] = reinterpret_cast<constSamplePtr>(container.Get()[1]);
-      dst->Append(data, floatSample, numSamplesToGet);
+      dst->Append(data, floatSample, numSamplesToGet, 1, widestSampleFormat);
       numOutSamples += numSamplesToGet;
       if (reportProgress)
          reportProgress(
@@ -577,369 +167,6 @@ WaveTrack::IntervalHolder GetRenderedCopy(WaveTrack::Interval &interval,
    assert(!dst->HasPitchOrSpeed());
    return dst;
 }
-}
-
-bool WaveTrack::Interval::HasPitchOrSpeed() const
-{
-   // Assuming equal pitch and speed on both channels
-   return GetClip(0u)->HasPitchOrSpeed();
-}
-
-bool WaveTrack::Interval::HasEqualPitchAndSpeed(const Interval& other) const
-{
-   // Assuming equal pitch and speed on both channels
-   return GetClip(0u)->HasEqualPitchAndSpeed(*other.GetClip(0u));
-}
-
-void WaveTrack::Interval::OnProjectTempoChange(
-   const std::optional<double>& oldTempo, double newTempo)
-{
-   ForEachClip([&](WaveClip &clip){
-      clip.OnProjectTempoChange(oldTempo, newTempo); });
-}
-
-/** Insert silence at the end, and causes the envelope to ramp
-    linearly to the given value */
-void WaveTrack::Interval::AppendSilence(double len, double envelopeValue)
-{
-   ForEachClip([&](WaveClip &clip){ clip.AppendSilence(len, envelopeValue); });
-}
-
-bool WaveTrack::Interval::Paste(double t0, const Interval &src)
-{
-   bool result = true;
-   ForCorrespondingClips(*this, src,
-   [&](WaveClip &dstClip, const WaveClip &srcClip){
-      result = result && dstClip.Paste(t0, srcClip);
-   });
-   return result;
-}
-
-/** Insert silence - note that this is an efficient operation for large
- * amounts of silence */
-void WaveTrack::Interval::InsertSilence(
-   double t, double len, double *pEnvelopeValue)
-{
-   ForEachClip([&](auto& clip) { clip.InsertSilence(t, len, pEnvelopeValue); });
-}
-
-void WaveTrack::Interval::ShiftBy(double delta) noexcept
-{
-   ForEachClip([&](auto& clip) { clip.ShiftBy(delta); });
-}
-
-sampleCount WaveTrack::Interval::GetSequenceSamplesCount() const
-{
-   sampleCount result{};
-   ForEachClip([&](auto& clip) { result += clip.GetSequenceSamplesCount(); });
-   return result;
-}
-
-size_t WaveTrack::Interval::CountBlocks() const
-{
-   size_t result{};
-   ForEachClip([&](const WaveClip &clip){
-      const auto width = clip.GetWidth();
-      for (size_t ii = 0; ii < width; ++ii)
-         result += clip.GetSequenceBlockArray(ii)->size(); });
-   return result;
-}
-
-void WaveTrack::Interval::ConvertToSampleFormat(sampleFormat format,
-   const std::function<void(size_t)> & progressReport)
-{
-   // TODO fix progress denominator?
-   ForEachClip([&](auto& clip) {
-      clip.ConvertToSampleFormat(format, progressReport); });
-}
-
-//! Silences the 'length' amount of samples starting from 'offset'
-//! (relative to the play start)
-void WaveTrack::Interval::SetSilence(sampleCount offset, sampleCount length)
-{
-   ForEachClip([&](auto& clip) { clip.SetSilence(offset, length); });
-}
-
-void WaveTrack::Interval::CloseLock() noexcept
-{
-   ForEachClip(std::mem_fn(&WaveClip::CloseLock));
-}
-
-SampleFormats WaveTrack::Interval::GetSampleFormats() const
-{
-   return GetClip(0)->GetSampleFormats();
-}
-
-bool WaveTrack::Interval::RemoveCutLine(double cutLinePosition)
-{
-   bool result = false;
-   ForEachClip([&](auto& clip) {
-      result = clip.RemoveCutLine(cutLinePosition) || result; });
-   return true;
-}
-
-auto WaveTrack::Interval::GetCutLines() -> IntervalHolders
-{
-   if (!mpClip) {
-      assert(false);
-      return {};
-   }
-   auto &cutLines0 = mpClip->GetCutLines();
-   size_t nCutLines0 = cutLines0.size();
-   auto *pCutLines1 = mpClip1 ? &mpClip1->GetCutLines() : nullptr;
-   auto nCutLines1 = pCutLines1 ? pCutLines1->size() : 0;
-
-   std::vector<IntervalHolder> result;
-   result.reserve(nCutLines0);
-   for (size_t ii = 0; ii < nCutLines0; ++ii) {
-      auto pClip0 = cutLines0[ii];
-      auto pClip1 = ii < nCutLines1 ? (*pCutLines1)[ii] : nullptr;
-      auto pInterval = std::make_shared<Interval>(pClip0, pClip1);
-      result.emplace_back(move(pInterval));
-   }
-   return result;
-}
-
-auto WaveTrack::Interval::GetCutLines() const -> IntervalConstHolders
-{
-   auto results = const_cast<Interval&>(*this).GetCutLines();
-   return { results.begin(), results.end() };
-}
-
-void WaveTrack::Interval::Resample(int rate, BasicUI::ProgressDialog *progress)
-{
-   // TODO Progress denominator?
-   ForEachClip([&](auto& clip) { clip.Resample(rate, progress); });
-}
-
-void WaveTrack::Interval::SetName(const wxString& name)
-{
-   ForEachClip([&](auto& clip) { clip.SetName(name); });
-}
-
-const wxString& WaveTrack::Interval::GetName() const
-{
-   //TODO wide wave tracks:  assuming that all 'narrow' clips share common name
-   return mpClip->GetName();
-}
-
-int WaveTrack::Interval::GetRate() const
-{
-   return mpClip->GetRate();
-}
-
-sampleCount WaveTrack::Interval::GetVisibleSampleCount() const
-{
-   return mpClip->GetVisibleSampleCount();
-}
-
-size_t WaveTrack::Interval::NumCutLines() const
-{
-   return mpClip->NumCutLines();
-}
-
-void WaveTrack::Interval::SetPlayStartTime(double time)
-{
-   ForEachClip([&](auto& clip) { clip.SetPlayStartTime(time); });
-}
-
-double WaveTrack::Interval::GetPlayStartTime() const
-{
-   //TODO wide wave tracks:  assuming that all 'narrow' clips share common beginning
-   return mpClip->GetPlayStartTime();
-}
-
-double WaveTrack::Interval::GetPlayEndTime() const
-{
-   // TODO wide wave tracks:  assuming that all 'narrow' clips share common
-   // beginning
-   return mpClip->GetPlayEndTime();
-}
-
-sampleCount WaveTrack::Interval::GetPlayStartSample() const
-{
-   return mpClip->GetPlayStartSample();
-}
-
-sampleCount WaveTrack::Interval::GetPlayEndSample() const
-{
-   return mpClip->GetPlayEndSample();
-}
-
-bool WaveTrack::Interval::SplitsPlayRegion(double t) const
-{
-   return mpClip->SplitsPlayRegion(t);
-}
-
-bool WaveTrack::Interval::WithinPlayRegion(double t) const
-{
-   return mpClip->WithinPlayRegion(t);
-}
-
-bool WaveTrack::Interval::BeforePlayRegion(double t) const
-{
-   return mpClip->BeforePlayRegion(t);
-}
-
-bool WaveTrack::Interval::AtOrBeforePlayRegion(double t) const
-{
-   return mpClip->AtOrBeforePlayRegion(t);
-}
-
-bool WaveTrack::Interval::AfterPlayRegion(double t) const
-{
-   return mpClip->AfterPlayRegion(t);
-}
-
-bool WaveTrack::Interval::EntirelyWithinPlayRegion(double t0, double t1) const
-{
-   return mpClip->EntirelyWithinPlayRegion(t0, t1);
-}
-
-bool WaveTrack::Interval::PartlyWithinPlayRegion(double t0, double t1) const
-{
-   return mpClip->PartlyWithinPlayRegion(t0, t1);
-}
-
-bool WaveTrack::Interval::IntersectsPlayRegion(double t0, double t1) const
-{
-   return mpClip->IntersectsPlayRegion(t0, t1);
-}
-
-bool WaveTrack::Interval::CoversEntirePlayRegion(double t0, double t1) const
-{
-   return mpClip->CoversEntirePlayRegion(t0, t1);
-}
-
-double WaveTrack::Interval::GetStretchRatio() const
-{
-   //TODO wide wave tracks:  assuming that all 'narrow' clips share common stretch ratio
-   return mpClip->GetStretchRatio();
-}
-
-int WaveTrack::Interval::GetCentShift() const
-{
-   return mpClip->GetCentShift();
-}
-
-void WaveTrack::Interval::SetRawAudioTempo(double tempo)
-{
-   ForEachClip([&](auto& clip) { clip.SetRawAudioTempo(tempo); });
-}
-
-sampleCount WaveTrack::Interval::TimeToSamples(double time) const
-{
-   return mpClip->TimeToSamples(time);
-}
-
-double WaveTrack::Interval::SamplesToTime(sampleCount s) const
-{
-   return mpClip->SamplesToTime(s);
-}
-
-double WaveTrack::Interval::GetSequenceStartTime() const
-{
-   return mpClip->GetSequenceStartTime();
-}
-
-void WaveTrack::Interval::SetSequenceStartTime(double t)
-{
-   ForEachClip([t](auto& clip) { clip.SetSequenceStartTime(t); });
-}
-
-double WaveTrack::Interval::GetSequenceEndTime() const
-{
-   return mpClip->GetSequenceEndTime();
-}
-
-double WaveTrack::Interval::GetTrimLeft() const
-{
-   //TODO wide wave tracks:  assuming that all 'narrow' clips share common trims
-   return mpClip->GetTrimLeft();
-}
-
-double WaveTrack::Interval::GetTrimRight() const
-{
-   //TODO wide wave tracks:  assuming that all 'narrow' clips share common trims
-   return mpClip->GetTrimRight();
-}
-
-AudioSegmentSampleView WaveTrack::Interval::GetSampleView(
-   size_t ii, sampleCount start, size_t len, bool mayThrow) const
-{
-   return GetClip(ii)->GetSampleView(0u, start, len, mayThrow);
-}
-
-size_t WaveTrack::Interval::GetWidth() const
-{
-   return NChannels();
-}
-
-Observer::Subscription
-WaveTrack::Interval::SubscribeToCentShiftChange(std::function<void(int)> cb)
-const
-{
-   // On purpose set the publisher on the left channel only. This is not a clip
-   // property that is saved to disk, and else we'll get two callbacks for the
-   // same event.
-   return mpClip->SubscribeToCentShiftChange(std::move(cb));
-}
-
-bool WaveTrack::Interval::IsPlaceholder() const
-{
-   return mpClip->GetIsPlaceholder();
-}
-
-void WaveTrack::Interval::SetIsPlaceholder(bool val)
-{
-   ForEachClip([=](auto &clip){ clip.SetIsPlaceholder(val); });
-}
-
-Envelope& WaveTrack::Interval::GetEnvelope()
-{
-   return mpClip->GetEnvelope();
-}
-
-const Envelope& WaveTrack::Interval::GetEnvelope() const
-{
-   return mpClip->GetEnvelope();
-}
-
-
-bool WaveTrack::Interval::FindCutLine(double cutLinePosition,
-   double* cutLineStart, double *cutLineEnd) const
-{
-   return mpClip->FindCutLine(cutLinePosition, cutLineStart, cutLineEnd);
-}
-
-void WaveTrack::Interval::ExpandCutLine(double cutlinePosition)
-{
-   // TODO stronger exception safety guarantee in case the second expansion
-   // throws
-   ForEachClip([=](auto &clip){ clip.ExpandCutLine(cutlinePosition); });
-   assert(EqualSequenceLengthInvariant());
-}
-
-void WaveTrack::Interval::SetRate(int rate)
-{
-   ForEachClip([=](auto &clip){ clip.SetRate(rate); });
-}
-
-void WaveTrack::Interval::SetEnvelope(std::unique_ptr<Envelope> pEnvelope)
-{
-   assert(pEnvelope);
-   mpClip->SetEnvelope(move(pEnvelope));
-}
-
-std::shared_ptr<ChannelInterval>
-WaveTrack::Interval::DoGetChannel(size_t iChannel)
-{
-   if (iChannel < NChannels()) {
-      // TODO wide wave tracks: there will be only one, wide clip
-      const auto pClip = (iChannel == 0 ? mpClip : mpClip1);
-      return std::make_shared<WaveChannelInterval>(mpClip, pClip, iChannel);
-   }
-   return {};
 }
 
 std::shared_ptr<const WaveTrack::Interval>
@@ -1297,7 +524,7 @@ void WaveTrack::CopyClips(WaveClipHolders &clips,
 
 size_t WaveTrack::GetWidth() const
 {
-   return 1;
+   return NChannels();
 }
 
 size_t WaveChannel::NChannels() const
@@ -1479,16 +706,8 @@ auto WaveTrack::GetWideClip(size_t iInterval) const -> IntervalConstHolder
 std::shared_ptr<WideChannelGroupInterval>
 WaveTrack::DoGetInterval(size_t iInterval)
 {
-   if (iInterval < NIntervals()) {
-      WaveClipHolder pClip = NarrowClips()[iInterval],
-         pClip1;
-      if (NChannels() > 1) {
-         auto &rightClips = RightClips();
-         if (iInterval < rightClips.size())
-            pClip1 = rightClips[iInterval];
-      }
-      return std::make_shared<Interval>(pClip, pClip1);
-   }
+   if (iInterval < NIntervals())
+      return mClips[iInterval];
    return {};
 }
 
@@ -1517,6 +736,21 @@ ChannelGroup &WaveChannel::DoGetChannelGroup() const
    return mOwner;
 }
 
+std::shared_ptr<WaveClipChannel>
+WaveChannel::GetInterval(size_t iInterval) { return
+   ::Channel::GetInterval<WaveClipChannel>(iInterval); }
+
+std::shared_ptr<const WaveClipChannel>
+WaveChannel::GetInterval(size_t iInterval) const { return
+   ::Channel::GetInterval<const WaveClipChannel>(iInterval); }
+
+IteratorRange<Channel::IntervalIterator<WaveClipChannel>>
+WaveChannel::Intervals() { return ::Channel::Intervals<WaveClipChannel>(); }
+
+IteratorRange<Channel::IntervalIterator<const WaveClipChannel>>
+WaveChannel::Intervals() const {
+   return ::Channel::Intervals<const WaveClipChannel>(); }
+
 WaveClipHolders &WaveTrack::NarrowClips()
 {
    return mClips;
@@ -1527,26 +761,11 @@ const WaveClipHolders &WaveTrack::NarrowClips() const
    return mClips;
 }
 
-WaveClipHolders &WaveTrack::RightClips()
-{
-   return *mRightClips;
-}
-
-const WaveClipHolders &WaveTrack::RightClips() const
-{
-   return *mRightClips;
-}
-
 Track::Holder WaveTrack::Clone(bool backup) const
 {
    auto newTrack = EmptyCopy(NChannels());
    newTrack->CopyClips(newTrack->mClips,
       newTrack->mpFactory, this->mClips, backup);
-   if (mRightChannel) {
-      assert(newTrack->mRightClips.has_value());
-      newTrack->CopyClips(*newTrack->mRightClips,
-         newTrack->mpFactory, *this->mRightClips, backup);
-   }
    return newTrack;
 }
 
@@ -1801,16 +1020,15 @@ auto WaveTrack::WideEmptyCopy(
 void WaveTrack::MakeMono()
 {
    mRightChannel.reset();
-   mRightClips.reset();
+   for (auto &pClip : mClips)
+      pClip->DiscardRightChannel();
    EraseChannelAttachments(1);
 }
 
 auto WaveTrack::MonoToStereo() -> Holder
 {
    assert(!GetOwner());
-   mRightChannel.reset();
-   mRightClips.reset();
-   EraseChannelAttachments(1);
+   MakeMono();
 
    // Make temporary new mono track
    auto newTrack = Duplicate();
@@ -1827,14 +1045,13 @@ auto WaveTrack::MonoToStereo() -> Holder
 auto WaveTrack::SplitChannels() -> std::vector<Holder>
 {
    std::vector<Holder> result{ SharedPointer<WaveTrack>() };
-   if (NChannels() > 1) {
+   if (NChannels() == 2) {
       auto pOwner = GetOwner();
       assert(pOwner); // pre
-      CopyClipEnvelopes();
       auto pNewTrack = result.emplace_back(EmptyCopy(1));
-      pNewTrack->mClips = std::move(*this->mRightClips);
+      for (auto &pClip : mClips)
+         pNewTrack->mClips.emplace_back(pClip->SplitChannels());
       this->mRightChannel.reset();
-      this->mRightClips.reset();
       auto iter = pOwner->Find(this);
       pOwner->Insert(*++iter, pNewTrack);
       // Fix up the channel attachments to avoid waste of space
@@ -1847,8 +1064,8 @@ auto WaveTrack::SplitChannels() -> std::vector<Holder>
 void WaveTrack::SwapChannels()
 {
    assert(NChannels() == 2);
-   CopyClipEnvelopes();
-   mClips.swap(*mRightClips);
+   for (const auto &pClip: mClips)
+      pClip->SwapChannels();
    this->AttachedTrackObjects::ForEach([this](TrackAttachment &attachment){
       if (const auto pAttachments =
          dynamic_cast<ChannelAttachmentsBase *>(&attachment)) {
@@ -2278,7 +1495,7 @@ void WaveTrack::ClearAndPasteAtSameTempo(
             // this clips cutlines.
             if (cs >= st && cs <= et) {
                cut->SetSequenceStartTime(warper->Warp(cs) - st);
-               clip->AddCutLine(*cut);
+               clip->AddCutLine(cut);
                cut = {};
             }
          }
@@ -2333,10 +1550,7 @@ std::ptrdiff_t WaveTrack::FindWideClip(const Interval &clip)
 {
    auto clips = Intervals();
    const auto begin = clips.begin();
-   const auto pNarrowClip = clip.GetClip(0).get();
-   const auto pred = [pNarrowClip](auto pClip){
-      return pClip->GetClip(0).get() == pNarrowClip; };
-   // Don't use pointer identity of intervals yet TODO wide wave clips
+   const auto pred = [&](auto pClip){ return pClip.get() == &clip; };
    auto iter = std::find_if(begin, clips.end(), pred);
    return std::distance(begin, iter);
 }
@@ -2346,11 +1560,6 @@ void WaveTrack::RemoveWideClip(std::ptrdiff_t distance)
    auto &clips = NarrowClips();
    if (distance < clips.size())
       clips.erase(clips.begin() + distance);
-   if (NChannels() > 1) {
-      auto &rightClips = RightClips();
-      if (distance < rightClips.size())
-         rightClips.erase(rightClips.begin() + distance);
-   }
 }
 
 /*! @excsafety{Strong} */
@@ -2691,7 +1900,7 @@ void WaveTrack::PasteWaveTrackAtSameTempo(
 
     for (const auto& clip : other.Intervals()) {
         // AWD Oct. 2009: Don't actually paste in placeholder clips
-        if (!clip->IsPlaceholder()) {
+        if (!clip->GetIsPlaceholder()) {
             const auto name = (pastingFromTempTrack)
                 //Clips from the tracks which aren't bound to any TrackList are
                 //considered to be new entities, thus named using "new" name template
@@ -2842,7 +2051,6 @@ void WaveTrack::InsertSilence(double t, double len)
    auto &&clips = Intervals();
    if (clips.empty()) {
       // Special case if there is no clip yet
-      // TODO wide wave tracks -- match clip width
       auto clip = CreateWideClip(0);
       clip->InsertSilence(0, len);
       // use No-fail-guarantee
@@ -3061,15 +2269,11 @@ bool WaveTrack::Append(size_t iChannel,
    size_t len, unsigned int stride, sampleFormat effectiveFormat)
 {
    assert(iChannel < NChannels());
-   // TODO wide wave tracks -- there will be only one clip, and its `Append`
-   // (or an overload) must take iChannel
    auto pTrack = this;
    constSamplePtr buffers[]{ buffer };
    auto pClip = RightmostOrNewClip();
-   auto iter = pClip->Channels().begin();
-   std::advance(iter, iChannel);
-   return (*iter)->
-      GetClip().Append(buffers, format, len, stride, effectiveFormat);
+   return pClip->Append(iChannel, 1,
+      buffers, format, len, stride, effectiveFormat);
 }
 
 size_t WaveTrack::GetBestBlockSize(sampleCount s) const
@@ -3144,26 +2348,6 @@ void WaveTrack::RepairChannels()
 void WaveTrack::SetLegacyFormat(sampleFormat format)
 {
    mLegacyFormat = format;
-}
-
-void WaveTrack::CopyClipEnvelopes()
-{
-   if (NChannels() != 2)
-      return;
-   // Assume correspondence of clips
-   const auto leftClips = NarrowClips();
-   const auto rightClips = RightClips();
-   auto it = begin(leftClips),
-      last = end(leftClips);
-   auto it2 = begin(rightClips),
-      last2 = end(rightClips);
-   for (; it != last; ++it, ++it2) {
-      if (it2 == last2) {
-         assert(false);
-         break;
-      }
-      (*it2)->SetEnvelope(std::make_unique<Envelope>((*it)->GetEnvelope()));
-   }
 }
 
 const ChannelGroup *WaveTrack::FindChannelGroup() const
@@ -3376,13 +2560,12 @@ void WaveTrack::WriteOneXML(const WaveChannel &channel, XMLWriter &xmlFile,
 
 std::optional<TranslatableString> WaveTrack::GetErrorOpening() const
 {
-   const auto width = NChannels();
-   for (const auto &clip : Intervals())
-      // TODO wide wave clip -- inner loop over GetSequence() argument
+   for (const auto &pClip : Intervals()) {
+      const auto width = pClip->NChannels();
       for (size_t ii = 0; ii < width; ++ii)
-         if (auto pClip = clip->GetClip(ii);
-             pClip && pClip->GetSequence(0)->GetErrorOpening())
+         if (pClip->GetSequence(ii)->GetErrorOpening())
             return XO("A track has a corrupted sample sequence.");
+   }
 
    return {};
 }
@@ -3450,6 +2633,8 @@ bool WaveChannel::DoGet(size_t iChannel, size_t nBuffers,
    sampleCount start, size_t len, bool backwards, fillFormat fill,
    bool mayThrow, sampleCount* pNumWithinClips) const
 {
+   // These two assertions still remain after the great wide wave track and clip
+   // refactoring!
    assert(iChannel == 0);
    assert(nBuffers <= 1);
    return GetTrack().DoGet(GetChannelIndex(), std::min<size_t>(nBuffers, 1),
@@ -3469,16 +2654,14 @@ bool WaveTrack::DoGet(size_t iChannel, size_t nBuffers,
    const auto nChannels = NChannels();
    assert(iChannel + nBuffers <= nChannels); // precondition
    return std::all_of(buffers, buffers + nBuffers, [&](samplePtr buffer) {
-      const auto &clips = iChannel == 0 ? NarrowClips() : RightClips();
-      ++iChannel;
-      const auto result = GetOne(clips,
+      const auto result = GetOne(mClips, iChannel++,
          buffer, format, start, len, backwards, fill, mayThrow,
          pNumWithinClips);
       return result;
    });
 }
 
-bool WaveTrack::GetOne(const WaveClipHolders &clips,
+bool WaveTrack::GetOne(const WaveClipHolders &clips, size_t iChannel,
    samplePtr buffer, sampleFormat format, sampleCount start, size_t len,
    bool backwards, fillFormat fill, bool mayThrow,
    sampleCount* pNumWithinClips) const
@@ -3551,7 +2734,7 @@ bool WaveTrack::GetOne(const WaveClipHolders &clips,
             // samplesToCopy is positive and not more than len
          }
 
-         if (!clip->GetSamples(0,
+         if (!clip->GetSamples(iChannel,
                (samplePtr)(((char*)buffer) +
                            startDelta.as_size_t() *
                            SAMPLE_SIZE(format)),
@@ -3581,7 +2764,7 @@ WaveTrack::GetSampleView(double t0, double t1, bool mayThrow) const
 ChannelSampleView
 WaveChannel::GetSampleView(double t0, double t1, bool mayThrow) const
 {
-   std::vector<std::shared_ptr<const WaveChannelInterval>>
+   std::vector<std::shared_ptr<const WaveClipChannel>>
       intersectingIntervals;
    for (const auto &interval : Intervals())
       if (interval->Intersects(t0, t1))
@@ -3791,23 +2974,15 @@ auto WaveTrack::GetClipAtTime(double time) const -> IntervalConstHolder
 auto WaveTrack::CreateWideClip(double offset, const wxString& name,
    const Interval *pToCopy, bool copyCutlines) -> IntervalHolder
 {
-   WaveClipHolder holders[2];
-   size_t iChannel = 0;
-   if (pToCopy)
-      pToCopy->ForEachClip([&](const WaveClip &clip){
-         auto pNewClip =
-            std::make_shared<WaveClip>(clip, mpFactory, copyCutlines);
-         pNewClip->SetName(name);
-         pNewClip->SetSequenceStartTime(offset);
-         holders[iChannel++] = pNewClip;
-      });
-   else {
-      holders[iChannel++] = DoCreateClip(offset, name);
-      if (mRightChannel.has_value())
-         holders[iChannel++] = DoCreateClip(offset, name);
+   if (pToCopy) {
+      auto pNewClip =
+         std::make_shared<WaveClip>(*pToCopy, mpFactory, copyCutlines);
+      pNewClip->SetName(name);
+      pNewClip->SetSequenceStartTime(offset);
+      return pNewClip;
    }
-
-   return std::make_shared<Interval>(holders[0], holders[1]);
+   else
+      return DoCreateClip(offset, name);
 }
 
 auto WaveTrack::CopyClip(const Interval &toCopy, bool copyCutlines)
@@ -3820,14 +2995,12 @@ auto WaveTrack::CopyClip(const Interval &toCopy, bool copyCutlines)
 void WaveTrack::CreateRight()
 {
    mRightChannel.emplace(*this);
-   mRightClips.emplace();
 }
 
 auto WaveTrack::DoCreateClip(double offset, const wxString& name) const
    -> WaveClipHolder
 {
-   // TODO wide wave tracks -- choose clip width correctly for the track
-   auto clip = std::make_shared<WaveClip>(1,
+   auto clip = std::make_shared<WaveClip>(NChannels(),
       mpFactory, GetSampleFormat(), GetRate());
    clip->SetName(name);
    clip->SetSequenceStartTime(offset);
@@ -3835,8 +3008,6 @@ auto WaveTrack::DoCreateClip(double offset, const wxString& name) const
    const auto& tempo = GetProjectTempo(*this);
    if (tempo.has_value())
       clip->OnProjectTempoChange(std::nullopt, *tempo);
-   // TODO wide wave tracks -- for now assertion is correct because widths are
-   // always 1
    assert(clip->GetWidth() == GetWidth());
    return clip;
 }
@@ -3852,38 +3023,26 @@ auto WaveTrack::NewestOrNewClip() -> IntervalHolder
       return pInterval;
    }
    else
-      return std::make_shared<Interval>(NarrowClips().back(),
-         (NChannels() > 1 ? RightClips().back() : nullptr));
+      return mClips.back();
 }
 
 /*! @excsafety{No-fail} */
 auto WaveTrack::RightmostOrNewClip() -> IntervalHolder
 {
-   const auto &intervals = Intervals();
-   if (intervals.empty()) {
+   if (mClips.empty()) {
       auto pInterval = CreateWideClip(
          WaveTrackData::Get(*this).GetOrigin(), MakeNewClipName());
       InsertInterval(pInterval, true, true);
       return pInterval;
    }
    else {
-      auto &clips = NarrowClips();
-      WaveClipHolder newClips[2];
-      size_t iChannel = 0;
-      const auto makeClip = [&](auto &theClips){
-         auto end = theClips.end();
-         auto it = theClips.begin();
-         it = max_element(it, end,
+      auto end = mClips.end(),
+         it = max_element(mClips.begin(), end,
             [](const auto &pClip1, const auto &pClip2){
                return pClip1->GetPlayStartTime() < pClip2->GetPlayStartTime();
          });
-         assert(it != theClips.end());
-         newClips[iChannel++] = *it;
-      };
-      makeClip(clips);
-      if (NChannels() > 1)
-         makeClip(RightClips());
-      return std::make_shared<Interval>(newClips[0], newClips[1]);
+      assert(it != end);
+      return *it;
    }
 }
 
@@ -3891,16 +3050,9 @@ auto WaveTrack::RightmostOrNewClip() -> IntervalHolder
 int WaveTrack::GetClipIndex(const Interval &clip) const
 {
    int result = 0;
-   const auto &&clips = Intervals();
-   const auto test = [&](const auto &otherClip){
-      bool match0 = clip.GetClip(0) == otherClip->GetClip(0);
-      bool match1 = clip.GetClip(1) == otherClip->GetClip(1);
-      if (match0) {
-         assert(match1);
-         return true;
-      }
-      return false;
-   };
+   const auto &clips = Intervals();
+   const auto test =
+      [&](const auto &pOtherClip){ return &clip == pOtherClip.get(); };
    auto begin = clips.begin(),
       end = clips.end(),
       iter = std::find_if(begin, end, test);
@@ -3923,13 +3075,8 @@ bool WaveTrack::CanOffsetClips(
    const auto &moving = [&](Interval *clip){
       // linear search might be improved, but expecting few moving clips
       // compared with the fixed clips
-      // Don't use pointer identity of WaveTrack::Interval
-      // TODO wide wave clips -- maybe change that
-      const auto pred = [narrowClip = clip->GetClip(0).get()](auto *pInterval){
-         return pInterval->GetClip(0).get() == narrowClip;
-      };
       return movingClips.end() !=
-         std::find_if(movingClips.begin(), movingClips.end(), pred);
+         std::find(movingClips.begin(), movingClips.end(), clip);
    };
 
    for (const auto &c: Intervals()) {
@@ -4079,7 +3226,7 @@ void WaveTrack::ApplyPitchAndSpeedOnIntervals(
    std::transform(
       srcIntervals.begin(), srcIntervals.end(),
       std::back_inserter(dstIntervals), [&](const IntervalHolder& interval) {
-         return GetRenderedCopy(*interval,
+         return GetRenderedCopy(interval,
             reportProgress, mpFactory, GetSampleFormat());
       });
 
@@ -4098,46 +3245,29 @@ bool ClipsAreUnique(const WaveClipHolders &clips)
 }
 }
 
-void WaveTrack::InsertInterval(const IntervalHolder& interval,
+void WaveTrack::InsertInterval(const IntervalHolder& clip,
    bool newClip, bool allowEmpty)
 {
-   auto channel = 0;
-   for (const auto pChannel : Channels()) {
-      auto &clips = (channel == 0) ? mClips : *mRightClips;
-      const auto clip = interval->GetClip(channel);
-      if (clip) {
-         InsertClip(clips, clip, newClip, false, allowEmpty);
-         // Detect errors resulting in duplicate shared pointers to clips
-         assert(ClipsAreUnique(clips));
-      }
-      ++channel;
+   if (clip) {
+      constexpr bool backup = false;
+      InsertClip(mClips, clip, newClip, backup, allowEmpty);
+      // Detect errors resulting in duplicate shared pointers to clips
+      assert(ClipsAreUnique(mClips));
    }
 }
 
 void WaveTrack::RemoveInterval(const IntervalHolder& interval)
 {
-   const auto removeClip = [](WaveClipHolders &clips, size_t iClip) {
-      if (iClip < clips.size())
-         clips.erase(clips.begin() + iClip);
-   };
-
-   const auto clips = Intervals();
-   const auto begin = clips.begin();
-   const auto pred = [pClip = interval->GetClip(0)](const auto &pInterval){
-      return pInterval->GetClip(0) == pClip;
-   };
-   const auto iter = std::find_if(begin, clips.end(), pred);
-   if (iter != clips.end()) {
-      auto dist = std::distance(begin, iter);
-      removeClip(mClips, dist);
-      if (NChannels() > 1)
-         removeClip(*mRightClips, dist);
-   }
+   const auto end = mClips.end(),
+      iter = find(mClips.begin(), end, interval);
+   if (iter != end)
+      mClips.erase(iter);
 }
 
 void WaveTrack::ReplaceInterval(
    const IntervalHolder& oldOne, const IntervalHolder& newOne)
 {
+   assert(newOne == oldOne || FindWideClip(*newOne) == Intervals().size());
    assert(oldOne->NChannels() == newOne->NChannels());
    RemoveInterval(oldOne);
    InsertInterval(newOne, false);
@@ -4218,10 +3348,28 @@ void WaveTrack::ZipClips(bool mustAlign)
       !AreAligned(this->SortedClipArray(), pRight->SortedClipArray()))
       return;
 
-   // Still not actually "zipping" clips into single wide clip objects.
-   // But there is now a real wide track object.
    CreateRight();
-   mRightClips = move(pRight->mClips);
+
+   // Now steal right side sample data info.  When not requiring alignment,
+   // because this is a track that just keeps the sample counts of blocks
+   // above 0 for later purposes -- then there is laxity about consistent
+   // width of the clips.
+   auto iterMe = mClips.begin(),
+      endMe = mClips.end();
+   auto iterRight = pRight->mClips.begin(),
+      endRight = pRight->mClips.end();
+   while (iterMe != endMe && iterRight != endRight) {
+      (*iterMe)->MakeStereo(std::move(**iterRight), mustAlign);
+      ++iterMe;
+      ++iterRight;
+   }
+   assert(!mustAlign || (iterMe == endMe && iterRight == endRight));
+
+   while (iterRight != endRight) {
+      // Leftover misaligned mono clips
+      mClips.emplace_back(move(*iterRight));
+      ++iterRight;
+   }
 
    this->MergeChannelAttachments(std::move(*pRight));
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -215,7 +215,7 @@ size_t WaveChannelInterval::GetAppendBufferLen() const
    return GetNarrowClip().GetAppendBufferLen(0);
 }
 
-BlockArray *WaveChannelInterval::GetSequenceBlockArray()
+const BlockArray *WaveChannelInterval::GetSequenceBlockArray() const
 {
    return GetNarrowClip().GetSequenceBlockArray(
       0

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1422,19 +1422,10 @@ auto WaveTrack::GetWideClip(size_t iInterval) -> IntervalHolder
    if (iInterval < NIntervals()) {
       WaveClipHolder pClip = NarrowClips()[iInterval],
          pClip1;
-
-      // TODO wide wave tracks
-      // Empty clip creation is needed, transitionally, to fix the peculiar
-      // case of Nyquist generators
       if (NChannels() > 1) {
          auto &rightClips = RightClips();
-         while (iInterval >= rightClips.size())
-            CreateClip(*this, &rightClips,
-               WaveTrackData::Get(*this).GetOrigin(),
-               MakeNewClipName());
          pClip1 = rightClips[iInterval];
       }
-
       return std::make_shared<Interval>(*this, pClip, pClip1);
    }
    return {};

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -334,7 +334,9 @@ void WaveTrack::Interval::Append(
    constSamplePtr buffer[], sampleFormat format, size_t len)
 {
    for (unsigned channel = 0; channel < NChannels(); ++channel)
-      GetClip(channel)->AppendNewBlock(buffer[channel], format, len);
+      // TODO wide wave clips -- pass channel number
+      GetClip(channel)
+         ->AppendToChannel(0, buffer[channel], format, len);
 }
 
 void WaveTrack::Interval::Flush()

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -3762,11 +3762,6 @@ void WaveTrack::GetEnvelopeValues(
 
 // When the time is both the end of a clip and the start of the next clip, the
 // latter clip is returned.
-WaveClip* WaveTrack::GetClipAtTime(double time)
-{
-   return const_cast<WaveClip*>(std::as_const(*this).GetClipAtTime(time));
-}
-
 const WaveClip* WaveTrack::GetClipAtTime(double time) const
 {
    const auto clips = SortedClipArray();

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -999,7 +999,6 @@ WaveTrack::Holder WaveTrack::EmptyCopy(size_t nChannels,
    // channel group data.  The copy is not yet in a TrackList.  Reassign rate
    // in case the track needs to make WaveClips before it is properly joined
    // with the opposite channel in a TrackList.
-   // TODO wide wave tracks -- all of the comment above will be irrelevant!
    result->DoSetRate(rate);
    result->mpFactory = pFactory ? pFactory : mpFactory;
    WaveTrackData::Get(*result).SetOrigin(0);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1007,14 +1007,6 @@ public:
       //! @pre `NChannels() == interval.NChannels()`
       void AddCutLine(Interval &interval);
    
-      /*!
-       * @post result: `result->GetStretchRatio() == 1`
-       */
-      std::shared_ptr<Interval> GetRenderedCopy(
-         const std::function<void(double)>& reportProgress,
-         const ChannelGroup& group, const SampleBlockFactoryPtr& factory,
-         sampleFormat format);
-
       bool HasPitchOrSpeed() const;
       bool HasEqualPitchAndSpeed(const Interval& other) const;
 
@@ -1091,11 +1083,10 @@ public:
 
       void SetRate(int rate);
 
+      void SetEnvelope(const Envelope& envelope);
    private:
       // TODO wide wave tracks -- remove friend
       friend WaveTrack;
-
-      void SetEnvelope(const Envelope& envelope);
 
       // Helper function in time of migration to wide clips
       template<typename Callable> void ForEachClip(const Callable& op) {

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -717,14 +717,15 @@ private:
 
    void CreateRight();
 
-   //! Create new clip and add it to the clip array; publish on the track.
+   //! Create a new clip that can be inserted later into the track
    /*!
     Returns a pointer to the newly created clip. Optionally initial offset and
     clip name may be provided
 
     @post result: `result->GetWidth() == track.GetWidth()`
     */
-   static WaveClipHolder CreateClip(WaveTrack &track, double offset = .0, const wxString& name = wxEmptyString);
+   WaveClipHolder DoCreateClip(
+      double offset = .0, const wxString& name = wxEmptyString) const;
 
 public:
    /** @brief Get access to the most recently added clip, or create a clip,

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -740,7 +740,9 @@ public:
    IntervalHolder CopyClip(const Interval &toCopy, bool copyCutlines);
 
 private:
-   const WaveClip* GetClipAtTime(double time) const;
+   //! Return all WaveClips sorted by clip play start time.
+   IntervalConstHolders SortedClipArray() const;
+   IntervalConstHolder GetClipAtTime(double time) const;
 
    void CreateRight();
 
@@ -772,12 +774,6 @@ public:
 
    // Get number of clips in this WaveTrack
    int GetNumClips() const;
-
-private:
-   //! Return all WaveClips sorted by clip play start time.
-   WaveClipPointers SortedClipArray();
-   //! Return all WaveClips sorted by clip play start time.
-   WaveClipConstPointers SortedClipArray() const;
 
 public:
    //! Return all (wide) WaveClips sorted by clip play start time.

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -446,14 +446,9 @@ public:
    //! settings
    void Init(const WaveTrack &orig);
  private:
-   using IterPair = std::pair<
-      WaveClipHolders::iterator, WaveClipHolders::iterator>;
-   /*!
-    @copydoc FindWideClip(const WaveClip &, int *)
-    */
-   IterPair FindWideClip(const WaveClip &clip, int *pDistance = nullptr);
+   std::ptrdiff_t FindWideClip(const Interval &clip);
 
-   void RemoveWideClip(IterPair pair);
+   void RemoveWideClip(std::ptrdiff_t distance);
 
    Track::Holder Clone(bool backup) const override;
 

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -741,6 +741,10 @@ public:
    IntervalHolder CopyClip(const Interval &toCopy, bool copyCutlines);
 
 private:
+   static void CopyWholeClip(WaveChannel &newChannel,
+      const WaveClip &clip, double t0, bool forClipboard);
+   static void CopyPartOfClip(WaveChannel &newChannel,
+      const WaveClip &clip, double t0, double t1, bool forClipboard);
    void FinishCopy(double t0, double t1, double endTime, bool forClipboard);
 
    //! Return all WaveClips sorted by clip play start time.

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -349,9 +349,6 @@ public:
    bool InsertClip(WaveClipHolder clip, bool newClip, bool backup,
       bool allowEmpty);
 
-   //! Used only in assertions checking invariants
-   bool ClipsAreUnique() const;
-
    static void CopyOne(WaveChannel &newTrack, const WaveChannel &track,
       double t0, double t1, double endTime, bool forClipboard);
 private:

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -850,6 +850,15 @@ public:
 
       Interval(const Interval &) = delete;
       Interval& operator=(const Interval &) = delete;
+   
+      Interval(const ChannelGroup &group, const Interval& orig,
+         const SampleBlockFactoryPtr &factory,
+         bool copyCutlines);
+
+      Interval(const ChannelGroup &group, const Interval& orig,
+         const SampleBlockFactoryPtr &factory,
+         bool copyCutlines,
+         double t0, double t1);
 
       ~Interval() override;
 
@@ -862,6 +871,9 @@ public:
 
       //! An invariant condition, for assertions
       bool EqualSequenceLengthInvariant() const;
+
+      bool IsEmpty() const;
+      sampleCount CountSamples(double t0, double t1) const;
 
       void Append(constSamplePtr buffer[], sampleFormat format, size_t len);
       void Flush();

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -584,6 +584,7 @@ public:
     If there is an existing WaveClip in the WaveTrack,
     then the data are appended to that clip. If there are no WaveClips in the
     track, then a new one is created.
+    @pre `iChannel < NChannels()`
     @return true if at least one complete block was created
     */
    bool Append(size_t iChannel, constSamplePtr buffer, sampleFormat format,

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -755,11 +755,9 @@ private:
     Returns a pointer to the newly created clip. Optionally initial offset and
     clip name may be provided
 
-    @param pClips if not null, push new clip onto it and publish
     @post result: `result->GetWidth() == track.GetWidth()`
     */
-   static WaveClipHolder CreateClip(WaveTrack &track, WaveClipHolders *pClips,
-      double offset = .0, const wxString& name = wxEmptyString);
+   static WaveClipHolder CreateClip(WaveTrack &track, double offset = .0, const wxString& name = wxEmptyString);
 
 public:
    /** @brief Get access to the most recently added clip, or create a clip,

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -156,7 +156,7 @@ public:
    constSamplePtr GetAppendBuffer() const;
    size_t GetAppendBufferLen() const;
 
-   BlockArray *GetSequenceBlockArray();
+   const BlockArray *GetSequenceBlockArray() const;
 
    /*!
     Getting high-level data for one channel for screen display and clipping

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -834,23 +834,22 @@ public:
       /*!
        @pre `pClip != nullptr`
        */
-      Interval(const ChannelGroup &group,
+      Interval(
          const std::shared_ptr<WaveClip> &pClip,
          const std::shared_ptr<WaveClip> &pClip1);
 
-      Interval(
-         const ChannelGroup& group, size_t width,
+      Interval(size_t width,
          const SampleBlockFactoryPtr& factory, int rate,
          sampleFormat storedSampleFormat);
 
       Interval(const Interval &) = delete;
       Interval& operator=(const Interval &) = delete;
    
-      Interval(const ChannelGroup &group, const Interval& orig,
+      Interval(const Interval& orig,
          const SampleBlockFactoryPtr &factory,
          bool copyCutlines);
 
-      Interval(const ChannelGroup &group, const Interval& orig,
+      Interval(const Interval& orig,
          const SampleBlockFactoryPtr &factory,
          bool copyCutlines,
          double t0, double t1);
@@ -859,6 +858,7 @@ public:
 
       double Start() const override;
       double End() const override;
+      size_t NChannels() const override;
 
       size_t GetBestBlockSize(sampleCount start) const;
       size_t GetMaxBlockSize() const;
@@ -1035,16 +1035,12 @@ public:
 
       //! Construct an array of temporary Interval objects that point to
       //! the cutlines
-      /*!
-       @param track is required to construct new Intervals because this
-       Interval does not store a back-reference to its track
-       */
-      IntervalHolders GetCutLines(WaveTrack &track);
+      IntervalHolders GetCutLines();
 
       /*!
-       @copydoc GetCutLines(WaveTrack &)
+       @copydoc GetCutLines()
        */
-      IntervalConstHolders GetCutLines(const WaveTrack &track) const;
+      IntervalConstHolders GetCutLines() const;
 
       // Resample clip. This also will set the rate, but without changing
       // the length of the clip

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -271,9 +271,9 @@ public:
    //! settings
    void Init(const WaveTrack &orig);
  private:
-   std::ptrdiff_t FindWideClip(const Interval &clip);
+   std::ptrdiff_t FindClip(const Interval &clip);
 
-   void RemoveWideClip(std::ptrdiff_t distance);
+   void RemoveClip(std::ptrdiff_t distance);
 
    Track::Holder Clone(bool backup) const override;
 
@@ -353,7 +353,7 @@ public:
     another project or the clipboard.  For copies within one project, the
     default will do.
     */
-   Holder WideEmptyCopy(const SampleBlockFactoryPtr &pFactory = {})
+   Holder EmptyCopy(const SampleBlockFactoryPtr &pFactory = {})
    const;
 
    //! Simply discard any right channel
@@ -555,7 +555,7 @@ public:
     @param offset desired sequence (not play) start time
     */
    IntervalHolder
-   CreateWideClip(double offset = .0, const wxString& name = wxEmptyString,
+   CreateClip(double offset = .0, const wxString& name = wxEmptyString,
       const Interval *pToCopy = nullptr, bool copyCutlines = true);
 
    //! Create new clip and add it to this track.
@@ -607,9 +607,9 @@ public:
    int GetNumClips() const;
 
 public:
-   //! Return all (wide) WaveClips sorted by clip play start time.
+   //! Return all WaveClips sorted by clip play start time.
    IntervalHolders SortedIntervalArray();
-   //! Return all (wide) WaveClips sorted by clip play start time.
+   //! Return all WaveClips sorted by clip play start time.
    IntervalConstHolders SortedIntervalArray() const;
 
    //! Decide whether the clips could be offset (and inserted) together without overlapping other clips
@@ -686,8 +686,8 @@ public:
 
    size_t NIntervals() const override;
 
-   IntervalHolder GetWideClip(size_t iInterval);
-   IntervalConstHolder GetWideClip(size_t iInterval) const;
+   IntervalHolder GetClip(size_t iInterval);
+   IntervalConstHolder GetClip(size_t iInterval) const;
 
    //!< used only during deserialization
    void SetLegacyFormat(sampleFormat format);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -253,8 +253,6 @@ public:
    const SampleBlockFactoryPtr &GetSampleBlockFactory() const
    { return mpFactory; }
 
-   size_t GetWidth() const;
-
    size_t NChannels() const override;
 
    auto GetChannel(size_t iChannel) {
@@ -585,7 +583,7 @@ private:
     Returns a pointer to the newly created clip. Optionally initial offset and
     clip name may be provided
 
-    @post result: `result->GetWidth() == track.GetWidth()`
+    @post result: `result->NChannels() == track.NChannels()`
     */
    WaveClipHolder DoCreateClip(
       double offset = .0, const wxString& name = wxEmptyString) const;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -1079,7 +1079,8 @@ public:
 
       void SetRate(int rate);
 
-      void SetEnvelope(const Envelope& envelope);
+      //! @pre `pEnvelope`
+      void SetEnvelope(std::unique_ptr<Envelope> pEnvelope);
    private:
       // TODO wide wave tracks -- remove friend
       friend WaveTrack;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -349,8 +349,6 @@ public:
    bool InsertClip(WaveClipHolder clip, bool newClip, bool backup,
       bool allowEmpty);
 
-   static void CopyOne(WaveChannel &newTrack, const WaveChannel &track,
-      double t0, double t1, bool forClipboard);
 private:
    const WaveClipHolders &Clips() const;
    WaveClipHolders &Clips();
@@ -741,10 +739,9 @@ public:
    IntervalHolder CopyClip(const Interval &toCopy, bool copyCutlines);
 
 private:
-   static void CopyWholeClip(WaveChannel &newChannel,
-      const WaveClip &clip, double t0, bool forClipboard);
-   static void CopyPartOfClip(WaveChannel &newChannel,
-      const WaveClip &clip, double t0, double t1, bool forClipboard);
+   void CopyWholeClip(const Interval &clip, double t0, bool forClipboard);
+   void CopyPartOfClip(const Interval &clip,
+      double t0, double t1, bool forClipboard);
    void FinishCopy(double t0, double t1, double endTime, bool forClipboard);
 
    //! Return all WaveClips sorted by clip play start time.

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -350,7 +350,7 @@ public:
       bool allowEmpty);
 
    static void CopyOne(WaveChannel &newTrack, const WaveChannel &track,
-      double t0, double t1, double endTime, bool forClipboard);
+      double t0, double t1, bool forClipboard);
 private:
    const WaveClipHolders &Clips() const;
    WaveClipHolders &Clips();
@@ -725,6 +725,7 @@ public:
    /*!
     Returns a pointer to the newly created clip. Optionally initial offset and
     clip name may be provided, and a clip from which to copy all sample data.
+    The clip is not owned by the track.  Use InsertInterval to make it so.
     @param offset desired sequence (not play) start time
     */
    IntervalHolder
@@ -740,6 +741,8 @@ public:
    IntervalHolder CopyClip(const Interval &toCopy, bool copyCutlines);
 
 private:
+   void FinishCopy(double t0, double t1, double endTime, bool forClipboard);
+
    //! Return all WaveClips sorted by clip play start time.
    IntervalConstHolders SortedClipArray() const;
    IntervalConstHolder GetClipAtTime(double time) const;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -347,9 +347,6 @@ public:
    using IntervalConstHolder = std::shared_ptr<const Interval>;
    using IntervalConstHolders = std::vector<IntervalConstHolder>;
 
-   // Resolve ambiguous lookup
-   using SampleTrack::GetFloats;
-
    /// \brief Structure to hold region of a wavetrack and a comparison function
    /// for sortability.
    struct Region

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -25,8 +25,6 @@
 #include <wx/thread.h>
 #include <wx/longlong.h>
 
-#include "ClipInterface.h"
-
 class AudacityProject;
 class BlockArray;
 
@@ -40,6 +38,8 @@ class TimeWarper;
 class ClipInterface;
 class Sequence;
 class WaveClip;
+class WaveClipChannel;
+using WaveChannelInterval = WaveClipChannel;
 class AudioSegmentSampleView;
 
 //! Clips are held by shared_ptr, not for sharing, but to allow weak_ptr
@@ -68,139 +68,6 @@ using ProgressReporter = std::function<void(double)>;
 
 class Envelope;
 class WaveTrack;
-
-class WAVE_TRACK_API WaveChannelInterval final
-   : public ChannelInterval
-   , public ClipTimes
-{
-public:
-   /*!
-    @pre `pWideClip != nullptr`
-    @pre `pNarrowClip != nullptr`
-    */
-   WaveChannelInterval(WaveClipHolder pWideClip,
-      WaveClipHolder pNarrowClip, size_t iChannel);
-   ~WaveChannelInterval() override;
-
-   friend bool operator ==(
-      const WaveChannelInterval &x, const WaveChannelInterval &y
-   ) {
-      return x.mpWideClip == y.mpWideClip &&
-         x.mpNarrowClip == y.mpNarrowClip &&
-         x.miChannel == y.miChannel;
-   }
-   friend bool operator !=(
-      const WaveChannelInterval &x, const WaveChannelInterval &y
-   ) {
-      return !(x == y);
-   }
-
-   const WaveClip &GetWideClip() const { return *mpWideClip; }
-   WaveClip &GetClip() { return *mpNarrowClip; }
-   const WaveClip &GetClip() const { return *mpNarrowClip; }
-
-   const WaveClipHolder &GetClipPtr() { return mpNarrowClip; }
-   WaveClipConstHolder GetClipPtr() const { return mpNarrowClip; }
-
-   Envelope &GetEnvelope();
-   const Envelope &GetEnvelope() const;
-   size_t GetChannelIndex() const { return miChannel; }
-
-   bool Intersects(double t0, double t1) const;
-   double Start() const;
-   double End() const;
-
-   /*!
-    * @brief Request interval samples within [t0, t1). `t0` and `t1` are
-    * truncated to the interval start and end. Stretching influences the number
-    * of samples fitting into [t0, t1), i.e., half as many for twice as large a
-    * stretch ratio, due to a larger spacing of the raw samples. The actual
-    * number of samples available from the returned view is queried through
-    * `AudioSegmentSampleView::GetSampleCount()`.
-    *
-    * @pre samples in [t0, t1) can be counted with `size_t`
-    */
-   AudioSegmentSampleView
-   GetSampleView(double t0, double t1, bool mayThrow) const;
-
-   sampleCount GetVisibleSampleCount() const override;
-   int GetRate() const override;
-   double GetPlayStartTime() const override;
-   double GetPlayEndTime() const override;
-   double GetPlayDuration() const;
-
-   /*!
-    * @brief  t ∈ [...)
-    */
-   bool WithinPlayRegion(double t) const;
-
-   // TimeToSamples and SamplesToTime take clip stretch ratio into account.
-   // Use them to convert time / sample offsets.
-   sampleCount TimeToSamples(double time) const override;
-   double SamplesToTime(sampleCount s) const noexcept;
-
-   double GetStretchRatio() const override;
-   bool HasPitchOrSpeed() const;
-
-   double GetTrimLeft() const;
-   double GetTrimRight() const;
-
-   bool GetSamples(samplePtr buffer, sampleFormat format,
-      sampleCount start, size_t len, bool mayThrow = true) const;
-
-   AudioSegmentSampleView GetSampleView(
-      sampleCount start, size_t length, bool mayThrow) const;
-
-   const Sequence &GetSequence() const;
-
-   constSamplePtr GetAppendBuffer() const;
-   size_t GetAppendBufferLen() const;
-
-   const BlockArray *GetSequenceBlockArray() const;
-
-   /*!
-    Getting high-level data for one channel for screen display and clipping
-    calculations and Contrast
-    */
-   std::pair<float, float> GetMinMax(double t0, double t1, bool mayThrow) const;
-
-   /*!
-    @copydoc GetMinMax
-    */
-   float GetRMS(double t0, double t1, bool mayThrow) const;
-
-   //! Real start time of the clip, quantized to raw sample rate (track's rate)
-   sampleCount GetPlayStartSample() const;
-
-   //! Real end time of the clip, quantized to raw sample rate (track's rate)
-   sampleCount GetPlayEndSample() const;
-
-   /*!
-    @param start relative to clip play start sample
-    */
-   void SetSamples(constSamplePtr buffer, sampleFormat format,
-      sampleCount start, size_t len,
-      sampleFormat effectiveFormat /*!<
-         Make the effective format of the data at least the minumum of this
-         value and `format`.  (Maybe wider, if merging with preexistent data.)
-         If the data are later narrowed from stored format, but not narrower
-         than the effective, then no dithering will occur.
-      */
-   );
-
-   void WriteXML(XMLWriter &xmlFile) const;
-
-private:
-   WaveClip &GetWideClip() { return *mpWideClip; }
-   WaveClip &GetNarrowClip() { return *mpNarrowClip; }
-   const WaveClip &GetNarrowClip() const { return *mpNarrowClip; }
-
-   //! @invariant non-null
-   const WaveClipHolder mpWideClip;
-   //! @invariant non-null
-   const WaveClipHolder mpNarrowClip;
-   const size_t miChannel;
-};
 
 struct WaveTrackMessage {
    WaveClipHolder pClip{};
@@ -250,14 +117,11 @@ public:
 
    ChannelGroup &DoGetChannelGroup() const override;
 
-   auto GetInterval(size_t iInterval) { return
-      ::Channel::GetInterval<WaveChannelInterval>(iInterval); }
-   auto GetInterval(size_t iInterval) const { return
-      ::Channel::GetInterval<const WaveChannelInterval>(iInterval); }
+   std::shared_ptr<WaveClipChannel> GetInterval(size_t iInterval);
+   std::shared_ptr<const WaveClipChannel> GetInterval(size_t iInterval) const;
 
-   auto Intervals() { return ::Channel::Intervals<WaveChannelInterval>(); }
-   auto Intervals() const {
-      return ::Channel::Intervals<const WaveChannelInterval>(); }
+   IteratorRange<IntervalIterator<WaveClipChannel>> Intervals();
+   IteratorRange<IntervalIterator<const WaveClipChannel>> Intervals() const;
 
    using WideSampleSequence::GetFloats;
 
@@ -341,7 +205,7 @@ class WAVE_TRACK_API WaveTrack final
 public:
    static const char *WaveTrack_tag;
 
-   class Interval;
+   using Interval = WaveClip;
    using IntervalHolder = std::shared_ptr<Interval>;
    using IntervalHolders = std::vector<IntervalHolder>;
    using IntervalConstHolder = std::shared_ptr<const Interval>;
@@ -389,7 +253,6 @@ public:
    const SampleBlockFactoryPtr &GetSampleBlockFactory() const
    { return mpFactory; }
 
-   //! The width of every WaveClip in this track; for now always 1
    size_t GetWidth() const;
 
    size_t NChannels() const override;
@@ -794,299 +657,6 @@ public:
    const TypeInfo &GetTypeInfo() const override;
    static const TypeInfo &ClassTypeInfo();
 
-   class WAVE_TRACK_API Interval final
-      : public WideChannelGroupInterval
-      , public ClipInterface
-   {
-   public:
-      /*!
-       @pre `pClip != nullptr`
-       */
-      Interval(
-         const std::shared_ptr<WaveClip> &pClip,
-         const std::shared_ptr<WaveClip> &pClip1);
-
-      Interval(size_t width,
-         const SampleBlockFactoryPtr& factory, int rate,
-         sampleFormat storedSampleFormat);
-
-      Interval(const Interval &) = delete;
-      Interval& operator=(const Interval &) = delete;
-   
-      Interval(const Interval& orig,
-         const SampleBlockFactoryPtr &factory,
-         bool copyCutlines);
-
-      Interval(const Interval& orig,
-         const SampleBlockFactoryPtr &factory,
-         bool copyCutlines,
-         double t0, double t1);
-
-      ~Interval() override;
-
-      double Start() const override;
-      double End() const override;
-      size_t NChannels() const override;
-
-      size_t GetBestBlockSize(sampleCount start) const;
-      size_t GetMaxBlockSize() const;
-      sampleCount GetSequenceStartSample() const;
-
-      //! An invariant condition, for assertions
-      bool EqualSequenceLengthInvariant() const;
-
-      bool IsEmpty() const;
-      sampleCount CountSamples(double t0, double t1) const;
-
-      void Append(constSamplePtr buffer[], sampleFormat format, size_t len);
-      void Flush();
-      void RepairChannels();
-
-      /// This name is consistent with WaveTrack::Clear. It performs a "Cut"
-      /// operation (but without putting the cut audio to the clipboard)
-      void Clear(double t0, double t1);
-
-      int GetRate() const override;
-
-      sampleCount GetVisibleSampleCount() const override;
-
-      void SetName(const wxString& name);
-      const wxString& GetName() const;
-
-      size_t NumCutLines() const;
-
-      void SetPlayStartTime(double time);
-      double GetPlayStartTime() const override;
-      double GetPlayEndTime() const override;
-
-      //! Real start time of the clip, quantized to raw sample rate (track's rate)
-      sampleCount GetPlayStartSample() const;
-
-      //! Real end time of the clip, quantized to raw sample rate (track's rate)
-      sampleCount GetPlayEndSample() const;
-
-      /*!
-       * @brief [ < t and t < ), such that if the track were split at `t`, it would
-       * split this clip in two of lengths > 0.
-       */
-      bool SplitsPlayRegion(double t) const;
-      /*!
-       * @brief  t ∈ [...)
-       */
-      bool WithinPlayRegion(double t) const;
-      /*!
-       * @brief  t < [
-       */
-      bool BeforePlayRegion(double t) const;
-      /*!
-       * @brief  t <= [
-       */
-      bool AtOrBeforePlayRegion(double t) const;
-      /*!
-       * @brief  ) <= t
-       */
-      bool AfterPlayRegion(double t) const;
-      /*!
-       * @brief t0 and t1 both ∈ [...)
-       * @pre t0 <= t1
-       */
-      bool EntirelyWithinPlayRegion(double t0, double t1) const;
-      /*!
-       * @brief t0 xor t1 ∈ [...)
-       * @pre t0 <= t1
-       */
-      bool PartlyWithinPlayRegion(double t0, double t1) const;
-      /*!
-       * @brief [t0, t1) ∩ [...) != ∅
-       * @pre t0 <= t1
-       */
-      bool IntersectsPlayRegion(double t0, double t1) const;
-      /*!
-       * @brief t0 <= [ and ) <= t1, such that removing [t0, t1) from the track
-       * deletes this clip.
-       * @pre t0 <= t1
-       */
-      bool CoversEntirePlayRegion(double t0, double t1) const;
-
-      double GetStretchRatio() const override;
-      int GetCentShift() const override;
-      void SetRawAudioTempo(double tempo);
-
-      sampleCount TimeToSamples(double time) const override;
-      double SamplesToTime(sampleCount s) const;
-      double GetSequenceStartTime() const;
-      double GetSequenceEndTime() const;
-      double GetTrimLeft() const;
-      double GetTrimRight() const;
-
-      AudioSegmentSampleView GetSampleView(
-         size_t ii, sampleCount start, size_t len, bool mayThrow) const override;
-
-      size_t GetWidth() const override;
-
-      Observer::Subscription
-      SubscribeToCentShiftChange(std::function<void(int)> cb) const override;
-
-      auto GetChannel(size_t iChannel) { return
-         WideChannelGroupInterval::GetChannel<WaveChannelInterval>(iChannel); }
-      auto GetChannel(size_t iChannel) const { return
-         WideChannelGroupInterval::GetChannel<const WaveChannelInterval>(iChannel); }
-
-      auto Channels() { return
-         WideChannelGroupInterval::Channels<WaveChannelInterval>(); }
-
-      auto Channels() const { return
-         WideChannelGroupInterval::Channels<const WaveChannelInterval>(); }
-
-      bool IsPlaceholder() const;
-      void SetIsPlaceholder(bool val);
-
-      void SetSequenceStartTime(double t);
-      void TrimLeftTo(double t);
-      void TrimRightTo(double t);
-      void TrimQuarternotesFromRight(double numQuarternotes);
-      void StretchLeftTo(double t);
-      void StretchRightTo(double t);
-      void StretchBy(double ratio);
-      /*
-       * @post `true` if `TimeAndPitchInterface::MinCent <= cents && cents <=
-       * TimeAndPitchInterface::MaxCent`
-       */
-      bool SetCentShift(int cents);
-      void SetTrimLeft(double t);
-      void SetTrimRight(double t);
-
-      //! Moves play start position by deltaTime
-      void TrimLeft(double deltaTime);
-      //! Moves play end position by deltaTime
-      void TrimRight(double deltaTime);
-
-      //! Same as `TrimRight`, but expressed as quarter notes
-      void ClearLeft(double t);
-      void ClearRight(double t);
-
-      /*!
-       May assume precondition: t0 <= t1
-       */
-      void ClearAndAddCutLine(double t0, double t1);
-   
-      //! Argument is non-const because it must share mutative access to the
-      //! underlying clip data
-      //! @pre `NChannels() == interval.NChannels()`
-      void AddCutLine(Interval &interval);
-   
-      bool HasPitchOrSpeed() const;
-      bool HasEqualPitchAndSpeed(const Interval& other) const;
-
-      /*! @excsafety{No-fail} */
-      void ShiftBy(double delta) noexcept;
-
-      sampleCount GetSequenceSamplesCount() const;
-      size_t CountBlocks() const;
-
-      void ConvertToSampleFormat(sampleFormat format,
-         const std::function<void(size_t)> & progressReport = {});
-
-      //! Silences the 'length' amount of samples starting from 'offset'
-      //! (relative to the play start)
-      void SetSilence(sampleCount offset, sampleCount length);
-
-      void CloseLock() noexcept;
-
-      SampleFormats GetSampleFormats() const;
-
-      /// Remove cut line, without expanding the audio in it
-      /*!
-       @return whether any cutline existed at the position and was removed
-       */
-      bool RemoveCutLine(double cutLinePosition);
-
-      //! Construct an array of temporary Interval objects that point to
-      //! the cutlines
-      IntervalHolders GetCutLines();
-
-      /*!
-       @copydoc GetCutLines()
-       */
-      IntervalConstHolders GetCutLines() const;
-
-      // Resample clip. This also will set the rate, but without changing
-      // the length of the clip
-      void Resample(int rate, BasicUI::ProgressDialog *progress = nullptr);
-
-      void OnProjectTempoChange(
-         const std::optional<double>& oldTempo, double newTempo);
-
-      std::shared_ptr<const WaveClip> GetClip(size_t iChannel) const
-      { return iChannel == 0 ? mpClip : mpClip1; }
-      const std::shared_ptr<WaveClip> &GetClip(size_t iChannel)
-      { return iChannel == 0 ? mpClip : mpClip1; }
-
-      /** Insert silence at the end, and causes the envelope to ramp
-          linearly to the given value */
-      void AppendSilence(double len, double envelopeValue);
-
-      bool Paste(double t0, const Interval &src);
-
-      /** Insert silence - note that this is an efficient operation for large
-       * amounts of silence */
-      void
-      InsertSilence(double t, double len, double *pEnvelopeValue = nullptr);
-
-      Envelope& GetEnvelope();
-      const Envelope& GetEnvelope() const;
-
-      /** Find cut line at (approximately) this position. Returns true and fills
-       * in cutLineStart and cutLineEnd (if specified) if a cut line at this
-       * position could be found. Return false otherwise. */
-      bool FindCutLine(double cutLinePosition,
-         double* cutLineStart = nullptr,
-         double *cutLineEnd = nullptr) const;
-
-      void ExpandCutLine(double cutlinePosition);
-
-      void SetRate(int rate);
-
-      //! @pre `pEnvelope`
-      void SetEnvelope(std::unique_ptr<Envelope> pEnvelope);
-   private:
-      // TODO wide wave tracks -- remove friend
-      friend WaveTrack;
-
-      // Helper function in time of migration to wide clips
-      template<typename Callable> void ForEachClip(const Callable& op) {
-         for (size_t channel = 0, channelCount = NChannels();
-            channel < channelCount; ++channel)
-            op(*GetClip(channel));
-      }
-
-      // Helper function in time of migration to wide clips
-      template<typename Callable> void ForEachClip(const Callable& op) const {
-         for (size_t channel = 0, channelCount = NChannels();
-            channel < channelCount; ++channel)
-            op(*GetClip(channel));
-      }
-
-      // Helper function in time of migration to wide clips
-      /*!
-       @pre `src.NChannels() == dst.NChannels()`
-       */
-      template<typename Callable>
-      static void ForCorrespondingClips(Interval &dst, const Interval &src,
-         const Callable& binop)
-      {
-         const auto channelCount = src.NChannels();
-         assert(channelCount == dst.NChannels());
-         for (size_t channel = 0; channel < channelCount; ++channel)
-            binop(*dst.GetClip(channel), *src.GetClip(channel));
-      }
-
-      std::shared_ptr<ChannelInterval> DoGetChannel(size_t iChannel) override;
-      const std::shared_ptr<WaveClip> mpClip;
-      //! TODO wide wave tracks: eliminate this
-      const std::shared_ptr<WaveClip> mpClip1;
-   };
-
    ///@return Interval that starts after(before) the beginning of the passed interval
    IntervalConstHolder GetNextInterval(
       const Interval& interval, PlaybackDirection searchDirection) const;
@@ -1104,6 +674,7 @@ public:
 
    /*
     @param newClip false if clip has contents from another clip or track
+    @pre interval is not already owned by this or any other track
     */
    void InsertInterval(const IntervalHolder& interval,
       bool newClip, bool allowEmpty = false);
@@ -1144,9 +715,6 @@ private:
    //! Erase all attachments for a given index
    void EraseChannelAttachments(size_t index);
 
-   // TODO wide-wave-track: some other API
-   void CopyClipEnvelopes();
-
    //! Get the linear index of a given clip (== number of clips if not found)
    int GetClipIndex(const Interval &clip) const;
 
@@ -1176,7 +744,11 @@ private:
    void ApplyPitchAndSpeedOnIntervals(
       const std::vector<IntervalHolder>& intervals,
       const ProgressReporter& reportProgress);
-   //! @pre `oldOne->NChannels() == newOne->NChannels()`
+   /*!
+    @pre `oldOne->NChannels() == newOne->NChannels()`
+    @pre newOne and oldOne are the same, or else newOne is not already owned by
+    this or any other track
+    */
    void
    ReplaceInterval(const IntervalHolder& oldOne, const IntervalHolder& newOne);
 
@@ -1186,12 +758,6 @@ private:
 
    WaveClipHolders &NarrowClips();
    const WaveClipHolders &NarrowClips() const;
-
-   //! These functions exist while tracks are wide but clips are not yet
-   //! @pre `NChannels() > 1`
-   WaveClipHolders &RightClips();
-   //! @pre `NChannels() > 1`
-   const WaveClipHolders &RightClips() const;
 
    //
    // Protected variables
@@ -1207,7 +773,6 @@ private:
     * @invariant all are non-null
     */
    WaveClipHolders mClips;
-   std::optional<WaveClipHolders> mRightClips;
 
    mutable int  mLegacyRate{ 0 }; //!< used only during deserialization
    sampleFormat mLegacyFormat{ undefinedSample }; //!< used only during deserialization
@@ -1217,7 +782,7 @@ private:
    void DoSetRate(double newRate);
    [[nodiscard]] Holder DuplicateWithOtherTempo(double newTempo) const;
 
-   bool GetOne(const WaveClipHolders &clips,
+   bool GetOne(const WaveClipHolders &clips, size_t iChannel,
       samplePtr buffer, sampleFormat format, sampleCount start, size_t len,
       bool backwards, fillFormat fill, bool mayThrow,
       sampleCount* pNumWithinClips) const;
@@ -1254,6 +819,7 @@ public:
     @pre `GetOwner()`
     @pre next track in the list exists, is a WaveTrack, has one channel only
     @pre `NChannels() == 1`
+    @pre if mustAlign, then clips are aligned across the tracks
     @param mustAlign if false, clips may be of different number or not aligned.
     Do not use the resulting track normally!
     */

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -681,9 +681,6 @@ public:
       double* buffer, size_t bufferLen, double t0,
       bool backwards) const override;
 
-   const WaveClip* GetClipAtTime(double time) const;
-   WaveClip* GetClipAtTime(double time);
-
    //
    // Getting information about the track's internal block sizes
    // and alignment for efficiency
@@ -743,6 +740,8 @@ public:
    IntervalHolder CopyClip(const Interval &toCopy, bool copyCutlines);
 
 private:
+   const WaveClip* GetClipAtTime(double time) const;
+
    void CreateRight();
 
    //! Create new clip and add it to the clip array; publish on the track.

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -859,6 +859,10 @@ public:
       double Start() const override;
       double End() const override;
 
+      size_t GetBestBlockSize(sampleCount start) const;
+      size_t GetMaxBlockSize() const;
+      sampleCount GetSequenceStartSample() const;
+
       //! An invariant condition, for assertions
       bool EqualSequenceLengthInvariant() const;
 

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -399,14 +399,6 @@ void WaveTrackUtilities::InspectBlocks(const TrackList &tracks,
    VisitBlocks(const_cast<TrackList &>(tracks), move(inspector), pIDs);
 }
 
-bool WaveTrackUtilities::WideClipContains(
-   const WaveTrack::Interval &wideClip, const WaveChannelInterval &clip)
-{
-   const auto &waveClip = clip.GetClip();
-   return &waveClip == wideClip.GetClip(0).get()
-      || &waveClip == wideClip.GetClip(1).get();
-}
-
 WaveTrack::IntervalConstHolders
 WaveTrackUtilities::GetClipsIntersecting(const WaveTrack &track,
    double t0, double t1)

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -42,7 +42,7 @@ auto WaveTrackUtilities::AllClipsIterator::operator ++ () -> AllClipsIterator &
       if (++ii == intervals.size())
          mStack.pop_back();
       else
-         Push(intervals[ii]->GetCutLines(*mpTrack));
+         Push(intervals[ii]->GetCutLines());
    }
 
    return *this;
@@ -55,7 +55,7 @@ void WaveTrackUtilities::AllClipsIterator::Push(IntervalHolders clips)
 
    // Go depth first while there are cutlines
    while (!clips.empty()) {
-      auto nextClips = clips[0]->GetCutLines(*mpTrack);
+      auto nextClips = clips[0]->GetCutLines();
       mStack.push_back({ move(clips), 0 });
       clips = move(nextClips);
    }

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -179,9 +179,6 @@ WAVE_TRACK_API void VisitBlocks(TrackList &tracks, BlockVisitor visitor,
 WAVE_TRACK_API void InspectBlocks(const TrackList &tracks,
    BlockInspector inspector, SampleBlockIDSet *pIDs = nullptr);
 
-WAVE_TRACK_API bool WideClipContains(
-   const WaveTrack::Interval &wideClip, const WaveChannelInterval &clip);
-
 /*!
  @pre t0 <= t1
  */

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -1061,7 +1061,7 @@ bool AUPImportFileHandle::HandleEnvelope(XMLTagHandler *&handler)
    {
       WaveClip *waveclip = static_cast<WaveClip *>(node.handler);
 
-      handler = waveclip->GetEnvelope();
+      handler = &waveclip->GetEnvelope();
    }
 
    return true;

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -1018,7 +1018,7 @@ bool AUPImportFileHandle::HandleWaveClip(XMLTagHandler *&handler)
 
       const auto pInterval = wavetrack->CreateWideClip();
       wavetrack->InsertInterval(pInterval, true, true);
-      handler = pInterval->GetClip(0).get();
+      handler = pInterval.get();
    }
    else if (mParentTag == WaveClip::WaveClip_tag)
    {
@@ -1453,8 +1453,7 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
                                      sampleCount origin /* = 0 */,
                                      int channel /* = 0 */)
 {
-   auto pClip = mClip ? mClip
-      : &(*mWaveTrack->RightmostOrNewClip()->Channels().begin())->GetClip();
+   auto pClip = mClip ? mClip : mWaveTrack->RightmostOrNewClip().get();
    auto &pBlock = mFileMap[wxFileNameFromPath(blockFilename)].second;
    if (pBlock) {
       // Replicate the sharing of blocks

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -1457,7 +1457,7 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
    auto &pBlock = mFileMap[wxFileNameFromPath(blockFilename)].second;
    if (pBlock) {
       // Replicate the sharing of blocks
-      if (pClip->GetWidth() != 1)
+      if (pClip->NChannels() != 1)
          return false;
       pClip->AppendLegacySharedBlock( pBlock );
       return true;
@@ -1650,7 +1650,7 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
    // Add the samples to the clip/track
    if (pClip)
    {
-      if (pClip->GetWidth() != 1)
+      if (pClip->NChannels() != 1)
          return false;
       pBlock = pClip->AppendLegacyNewBlock(bufptr, format, cnt);
    }

--- a/modules/mod-aup/ImportAUP.cpp
+++ b/modules/mod-aup/ImportAUP.cpp
@@ -1016,7 +1016,7 @@ bool AUPImportFileHandle::HandleWaveClip(XMLTagHandler *&handler)
    {
       WaveTrack *wavetrack = static_cast<WaveTrack *>(node.handler);
 
-      const auto pInterval = wavetrack->CreateWideClip();
+      const auto pInterval = wavetrack->CreateClip();
       wavetrack->InsertInterval(pInterval, true, true);
       handler = pInterval.get();
    }

--- a/src/AnalyzedWaveClip.cpp
+++ b/src/AnalyzedWaveClip.cpp
@@ -11,6 +11,7 @@
 #include "AnalyzedWaveClip.h"
 
 #include "ClipMirAudioReader.h"
+#include "WaveClip.h"
 
 AnalyzedWaveClip::AnalyzedWaveClip(
    std::shared_ptr<ClipMirAudioReader> reader,

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -506,7 +506,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
 
    if (mBlockDetail) {
       // One remaining old direct use of narrow clips, only for debugging
-      auto seq = t->GetWideClip(0)->GetClip(0)->GetSequence(0);
+      auto seq = t->GetWideClip(0)->GetSequence(0);
       seq->DebugPrintf(seq->GetBlockArray(), seq->GetNumSamples(), &tempStr);
       mToPrint += tempStr;
    }

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -427,11 +427,11 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
    // as we're about to do).
    t->GetEndTime();
 
-   if (t->GetWideClip(0)->GetVisibleSampleCount() != nChunks * chunkSize) {
+   if (t->GetClip(0)->GetVisibleSampleCount() != nChunks * chunkSize) {
       Printf( XO("Expected len %lld, track len %lld.\n")
          .Format(
             nChunks * chunkSize,
-            t->GetWideClip(0)->GetVisibleSampleCount()
+            t->GetClip(0)->GetVisibleSampleCount()
                .as_long_long() ) );
       goto fail;
    }
@@ -465,7 +465,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
          Printf( XO("Expected len %lld, track len %lld.\n")
             .Format(
                nChunks * chunkSize,
-               t->GetWideClip(0)->GetVisibleSampleCount()
+               t->GetClip(0)->GetVisibleSampleCount()
                   .as_long_long() ) );
          goto fail;
       }
@@ -485,12 +485,12 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
          goto fail;
       }
 
-      if (t->GetWideClip(0)->GetVisibleSampleCount() != nChunks * chunkSize) {
+      if (t->GetClip(0)->GetVisibleSampleCount() != nChunks * chunkSize) {
          Printf( XO("Trial %d\n").Format( z ) );
          Printf( XO("Expected len %lld, track len %lld.\n")
             .Format(
                nChunks * chunkSize,
-               t->GetWideClip(0)->GetVisibleSampleCount()
+               t->GetClip(0)->GetVisibleSampleCount()
                   .as_long_long() ) );
          goto fail;
       }
@@ -506,7 +506,7 @@ void BenchmarkDialog::OnRun( wxCommandEvent & WXUNUSED(event))
 
    if (mBlockDetail) {
       // One remaining old direct use of narrow clips, only for debugging
-      auto seq = t->GetWideClip(0)->GetSequence(0);
+      auto seq = t->GetClip(0)->GetSequence(0);
       seq->DebugPrintf(seq->GetBlockArray(), seq->GetNumSamples(), &tempStr);
       mToPrint += tempStr;
    }

--- a/src/ClipMirAudioReader.cpp
+++ b/src/ClipMirAudioReader.cpp
@@ -20,18 +20,18 @@ ClipMirAudioReader::ClipMirAudioReader(
     : tags { std::move(tags) }
     , filename { std::move(filename) }
     , clip(*singleClipWaveTrack.Intervals().begin())
-    , mWideClip(singleClipWaveTrack.GetClipInterfaces()[0])
+    , mClip(singleClipWaveTrack.GetClipInterfaces()[0])
 {
 }
 
 double ClipMirAudioReader::GetSampleRate() const
 {
-   return mWideClip->GetRate();
+   return mClip->GetRate();
 }
 
 long long ClipMirAudioReader::GetNumSamples() const
 {
-   return mWideClip->GetVisibleSampleCount().as_long_long();
+   return mClip->GetVisibleSampleCount().as_long_long();
 }
 
 void ClipMirAudioReader::ReadFloats(
@@ -39,7 +39,7 @@ void ClipMirAudioReader::ReadFloats(
 {
    std::fill(buffer, buffer + numFrames, 0.f);
    AddChannel(0, buffer, where, numFrames);
-   if (mWideClip->NChannels() == 1)
+   if (mClip->NChannels() == 1)
       return;
    AddChannel(1, buffer, where, numFrames);
    std::transform(
@@ -52,7 +52,7 @@ void ClipMirAudioReader::AddChannel(
    constexpr auto mayThrow = false;
    const auto iCache = mUseFirst[iChannel] ? 0 : 1;
    auto& cache = mCache[iChannel][iCache];
-   auto view = mWideClip->GetSampleView(iChannel, start, len, mayThrow);
+   auto view = mClip->GetSampleView(iChannel, start, len, mayThrow);
    cache.emplace(std::move(view));
    cache->AddTo(buffer, len);
    mUseFirst[iChannel] = !mUseFirst[iChannel];

--- a/src/ClipMirAudioReader.cpp
+++ b/src/ClipMirAudioReader.cpp
@@ -39,7 +39,7 @@ void ClipMirAudioReader::ReadFloats(
 {
    std::fill(buffer, buffer + numFrames, 0.f);
    AddChannel(0, buffer, where, numFrames);
-   if (mWideClip->GetWidth() == 1)
+   if (mWideClip->NChannels() == 1)
       return;
    AddChannel(1, buffer, where, numFrames);
    std::transform(

--- a/src/ClipMirAudioReader.cpp
+++ b/src/ClipMirAudioReader.cpp
@@ -10,6 +10,7 @@
 **********************************************************************/
 #include "ClipMirAudioReader.h"
 #include "ClipInterface.h"
+#include "WaveClip.h"
 
 #include <cassert>
 

--- a/src/ClipMirAudioReader.h
+++ b/src/ClipMirAudioReader.h
@@ -45,7 +45,7 @@ private:
    void AddChannel(
       size_t iChannel, float* buffer, sampleCount start, size_t len) const;
 
-   const std::shared_ptr<const ClipInterface> mWideClip;
+   const std::shared_ptr<const ClipInterface> mClip;
 
    // An array with two entries because maybe two channels, and each channel has
    // two caches to cope with back-and-forth access between beginning and end

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -57,6 +57,11 @@ double LabelTrack::Interval::End() const
    return mpTrack->GetLabel(index)->selectedRegion.t1();
 }
 
+size_t LabelTrack::Interval::NChannels() const
+{
+   return 1;
+}
+
 std::shared_ptr<ChannelInterval>
 LabelTrack::Interval::DoGetChannel(size_t iChannel)
 {

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -177,14 +177,14 @@ public:
 
    struct Interval final : WideChannelGroupInterval {
       Interval(const LabelTrack &track, size_t index
-      )  : WideChannelGroupInterval{ track }
-         , mpTrack{ track.SharedPointer<const LabelTrack>() }
+      )  : mpTrack{ track.SharedPointer<const LabelTrack>() }
          , index{ index }
       {}
 
       ~Interval() override;
       double Start() const override;
       double End() const override;
+      size_t NChannels() const override;
       std::shared_ptr<ChannelInterval> DoGetChannel(size_t iChannel) override;
 
       size_t index;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -802,7 +802,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
             break;
       }
 
-      auto clip = track.CreateWideClip(t0, name);
+      auto clip = track.CreateClip(t0, name);
       // So that the empty clip is not skipped for insertion:
       clip->SetIsPlaceholder(true);
       track.InsertInterval(clip, true);

--- a/src/SpectralDataManager.cpp
+++ b/src/SpectralDataManager.cpp
@@ -78,7 +78,7 @@ bool SpectralDataManager::ProcessTracks(AudacityProject &project){
       const auto t0 = wt->LongSamplesToTime(startSample);
       const auto len = endSample - startSample;
       const auto tLen = wt->LongSamplesToTime(len);
-      auto tempTrack = wt->WideEmptyCopy();
+      auto tempTrack = wt->EmptyCopy();
       auto iter = tempTrack->Channels().begin();
       long long processed{};
       for (auto pChannel : wt->Channels()) {

--- a/src/VoiceKey.cpp
+++ b/src/VoiceKey.cpp
@@ -82,7 +82,7 @@ VoiceKey::~VoiceKey()
 
 //Move forward to find an ON region.
 sampleCount VoiceKey::OnForward (
-   const WaveTrack & t, sampleCount start, sampleCount len)
+   const WaveChannel & t, sampleCount start, sampleCount len)
 {
 
    if((mWindowSize) >= (len + 10).as_double() ){
@@ -234,7 +234,7 @@ sampleCount VoiceKey::OnForward (
 
 //Move backward from end to find an ON region.
 sampleCount VoiceKey::OnBackward (
-   const WaveTrack & t, sampleCount end, sampleCount len)
+   const WaveChannel & t, sampleCount end, sampleCount len)
 {
 
 
@@ -380,7 +380,7 @@ sampleCount VoiceKey::OnBackward (
 
 //Move forward from the start to find an OFF region.
 sampleCount VoiceKey::OffForward (
-   const WaveTrack & t, sampleCount start, sampleCount len)
+   const WaveChannel & t, sampleCount start, sampleCount len)
 {
 
    if((mWindowSize) >= (len + 10).as_double() ){
@@ -516,7 +516,7 @@ sampleCount VoiceKey::OffForward (
 
 //Move backward from the end to find an OFF region
 sampleCount VoiceKey::OffBackward (
-   const WaveTrack & t, sampleCount end, sampleCount len)
+   const WaveChannel & t, sampleCount end, sampleCount len)
 {
 
 
@@ -655,7 +655,7 @@ sampleCount VoiceKey::OffBackward (
 
 //This tests whether a specified block region is above or below threshold.
 bool VoiceKey::AboveThreshold(
-   const WaveTrack & t, sampleCount start, sampleCount len)
+   const WaveChannel & t, sampleCount start, sampleCount len)
 {
 
    double erg=0;
@@ -736,7 +736,7 @@ void VoiceKey::AdjustThreshold(double t)
 
 
 //This 'calibrates' the voicekey to noise
-void VoiceKey::CalibrateNoise(const WaveTrack & t, sampleCount start, sampleCount len)
+void VoiceKey::CalibrateNoise(const WaveChannel & t, sampleCount start, sampleCount len)
 {
    //To calibrate the noise, we need to scan the sample block just like in the voicekey and
    //calculate the mean and standard deviation of the test statistics.
@@ -852,7 +852,7 @@ void VoiceKey::SetKeyType(bool erg, bool scLow , bool scHigh,
 
 //This might continue over a number of blocks.
 double VoiceKey::TestEnergy (
-   const WaveTrack & t, sampleCount start, sampleCount len)
+   const WaveChannel & t, sampleCount start, sampleCount len)
 {
 
    double sum = 1;
@@ -893,7 +893,7 @@ void VoiceKey::TestEnergyUpdate (double & prevErg, int len, const float & drop, 
 
 
 double VoiceKey::TestSignChanges(
-   const WaveTrack & t, sampleCount start, sampleCount len)
+   const WaveChannel & t, sampleCount start, sampleCount len)
 {
 
 
@@ -949,7 +949,7 @@ void VoiceKey::TestSignChangesUpdate(double & currentsignchanges, int len,
 
 
 double VoiceKey::TestDirectionChanges(
-   const WaveTrack & t, sampleCount start, sampleCount len)
+   const WaveChannel & t, sampleCount start, sampleCount len)
 {
 
 

--- a/src/VoiceKey.h
+++ b/src/VoiceKey.h
@@ -18,7 +18,7 @@
 
 #include "SampleCount.h"
 
-class WaveTrack;
+class WaveChannel;
 
 enum VoiceKeyTypes
   {
@@ -35,16 +35,16 @@ class VoiceKey {
  public:
    VoiceKey();
    ~VoiceKey();
-   sampleCount OnForward   (const WaveTrack & t, sampleCount start, sampleCount len);
-   sampleCount OnBackward  (const WaveTrack & t, sampleCount start, sampleCount len);
-   sampleCount OffForward  (const WaveTrack & t, sampleCount start, sampleCount len);
-   sampleCount OffBackward (const WaveTrack & t, sampleCount start, sampleCount len);
+   sampleCount OnForward   (const WaveChannel & t, sampleCount start, sampleCount len);
+   sampleCount OnBackward  (const WaveChannel & t, sampleCount start, sampleCount len);
+   sampleCount OffForward  (const WaveChannel & t, sampleCount start, sampleCount len);
+   sampleCount OffBackward (const WaveChannel & t, sampleCount start, sampleCount len);
 
-   void CalibrateNoise(const WaveTrack & t, sampleCount start, sampleCount len);
+   void CalibrateNoise(const WaveChannel & t, sampleCount start, sampleCount len);
    void AdjustThreshold(double t);
 
 
-   bool AboveThreshold(const WaveTrack & t, sampleCount start,sampleCount len);
+   bool AboveThreshold(const WaveChannel & t, sampleCount start,sampleCount len);
 
    void SetKeyType(bool erg, bool scLow, bool scHigh,
                    bool dcLow, bool dcHigh);
@@ -79,11 +79,11 @@ class VoiceKey {
    double mSilentWindowSize;           //Time in milliseconds of below-threshold windows required for silence
    double mSignalWindowSize;           //Time in milliseconds of above-threshold windows required for speech
 
-   double TestEnergy (const WaveTrack & t, sampleCount start,sampleCount len);
+   double TestEnergy (const WaveChannel & t, sampleCount start,sampleCount len);
    double TestSignChanges (
-      const WaveTrack & t, sampleCount start, sampleCount len);
+      const WaveChannel & t, sampleCount start, sampleCount len);
    double TestDirectionChanges(
-      const WaveTrack & t, sampleCount start, sampleCount len);
+      const WaveChannel & t, sampleCount start, sampleCount len);
 
    void TestEnergyUpdate (double & prevErg, int length, const float & drop, const float & add);
    void TestSignChangesUpdate(double & currentsignchanges,int length, const float & a1,

--- a/src/WaveTrackLocation.cpp
+++ b/src/WaveTrackLocation.cpp
@@ -35,7 +35,7 @@ WaveTrackLocations FindWaveTrackLocations(const WaveTrack &track)
    int curpos = 0;
 
    for (const auto clip: clips) {
-      for (const auto &cc : clip->GetCutLines(track)) {
+      for (const auto &cc : clip->GetCutLines()) {
          auto cutlinePosition =
             clip->GetSequenceStartTime() + cc->GetSequenceStartTime();
          if (clip->WithinPlayRegion(cutlinePosition)) {

--- a/src/effects/AutoDuck.cpp
+++ b/src/effects/AutoDuck.cpp
@@ -243,11 +243,12 @@ bool EffectAutoDuck::Process(EffectInstance &, EffectSettings &)
 
       auto pos = start;
 
+      const auto pControlChannel = *pControlTrack->Channels().begin();
       while (pos < end)
       {
          const auto len = limitSampleBufferSize( kBufSize, end - pos );
 
-         pControlTrack->GetFloats(buf.get(), pos, len);
+         pControlChannel->GetFloats(buf.get(), pos, len);
 
          for (auto i = pos; i < pos + len; i++)
          {

--- a/src/effects/ChangePitch.cpp
+++ b/src/effects/ChangePitch.cpp
@@ -454,7 +454,8 @@ void EffectChangePitch::DeduceFrequencies()
       Floats freq{ windowSize / 2 };
       Floats freqa{ windowSize / 2, true };
 
-      track->GetFloats(buffer.get(), start, analyzeSize);
+      // Always used only the left channel for this deduction of initial pitch
+      (*track->Channels().begin())->GetFloats(buffer.get(), start, analyzeSize);
       for(unsigned i = 0; i < numWindows; i++) {
          ComputeSpectrum(
             buffer.get() + i * windowSize, windowSize, windowSize, freq.get(),

--- a/src/effects/ChangeSpeed.cpp
+++ b/src/effects/ChangeSpeed.cpp
@@ -249,7 +249,7 @@ bool EffectChangeSpeed::Process(EffectInstance &, EffectSettings &)
 
             const auto gaps = FindGaps(outWaveTrack, mCurT0, mCurT1);
 
-            auto pNewTrack = outWaveTrack.WideEmptyCopy();
+            auto pNewTrack = outWaveTrack.EmptyCopy();
             auto iter = pNewTrack->Channels().begin();
             for (const auto pChannel : outWaveTrack.Channels()) {
                // ProcessOne() (implemented below) processes a single channel

--- a/src/effects/Equalization.cpp
+++ b/src/effects/Equalization.cpp
@@ -418,7 +418,7 @@ bool EffectEqualization::Process(EffectInstance &, EffectSettings &)
          auto end = track->TimeToLongSamples(t1);
          auto len = end - start;
 
-         auto pTempTrack = track->WideEmptyCopy();
+         auto pTempTrack = track->EmptyCopy();
          pTempTrack->ConvertToSampleFormat(floatSample);
          auto iter0 = pTempTrack->Channels().begin();
 

--- a/src/effects/Generator.cpp
+++ b/src/effects/Generator.cpp
@@ -59,7 +59,7 @@ bool Generator::Process(EffectInstance &, EffectSettings &settings)
 
          if (duration > 0.0) {
             // Create a temporary track
-            auto copy = track.WideEmptyCopy();
+            auto copy = track.EmptyCopy();
             // Fill with data
             if (!GenerateTrack(settings, *copy))
                bGoodResult = false;

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -762,7 +762,7 @@ bool EffectNoiseReduction::Worker::Process(
          std::optional<ChannelGroup::ChannelIterator<WaveChannel>> pIter;
          WaveTrack *pFirstTrack{};
          if (!mSettings.mDoProfile) {
-            ppTempTrack.emplace(track->WideEmptyCopy());
+            ppTempTrack.emplace(track->EmptyCopy());
             pFirstTrack = ppTempTrack->get();
             pIter.emplace(pFirstTrack->Channels().begin());
          }

--- a/src/effects/Paulstretch.cpp
+++ b/src/effects/Paulstretch.cpp
@@ -158,7 +158,7 @@ bool EffectPaulstretch::Process(EffectInstance &, EffectSettings &)
       double t0 = mT0 < trackStart ? trackStart : mT0;
       double t1 = mT1 > trackEnd ? trackEnd : mT1;
       if (t1 > t0) {
-         auto tempTrack = track->WideEmptyCopy();
+         auto tempTrack = track->EmptyCopy();
          const auto channels = track->Channels();
          auto iter = tempTrack->Channels().begin();
          for (const auto pChannel : channels) {

--- a/src/effects/Repeat.cpp
+++ b/src/effects/Repeat.cpp
@@ -29,6 +29,7 @@
 #include "../LabelTrack.h"
 #include "ShuttleGui.h"
 #include "SyncLock.h"
+#include "WaveClip.h"
 #include "WaveTrack.h"
 #include "../widgets/NumericTextCtrl.h"
 #include "../widgets/valnum.h"

--- a/src/effects/SBSMSEffect.cpp
+++ b/src/effects/SBSMSEffect.cpp
@@ -350,7 +350,7 @@ bool EffectSBSMS::Process(EffectInstance &, EffectSettings &)
             const auto warper = createTimeWarper(
                mT0, mT1, maxDuration, rateStart, rateEnd, rateSlideType);
 
-            WaveTrack::Holder outputTrack = track.WideEmptyCopy();
+            WaveTrack::Holder outputTrack = track.EmptyCopy();
             auto iter = outputTrack->Channels().begin();
             rb.outputTrack = outputTrack.get();
             rb.outputLeftChannel = (*iter++).get();

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -121,7 +121,7 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
             const auto start = orig.TimeToLongSamples(mT0);
             const auto end = orig.TimeToLongSamples(mT1);
 
-            const auto tempTrack = orig.WideEmptyCopy();
+            const auto tempTrack = orig.EmptyCopy();
             auto &out = *tempTrack;
 
             const auto pSoundTouch = std::make_unique<soundtouch::SoundTouch>();

--- a/src/effects/SoundTouchEffect.cpp
+++ b/src/effects/SoundTouchEffect.cpp
@@ -144,8 +144,8 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
                pSoundTouch->setChannels(1);
 
                //ProcessOne() (implemented below) processes a single track
-               if (!ProcessOne(
-                  pSoundTouch.get(), orig, out, start, end, warper))
+               if (!ProcessOne(pSoundTouch.get(), **channels.begin(),
+                     out, start, end, warper))
                   bGoodResult = false;
             }
             // pSoundTouch is destroyed here
@@ -167,7 +167,7 @@ bool EffectSoundTouch::ProcessWithTimeWarper(InitFunction initer,
 //ProcessOne() takes a track, transforms it to bunch of buffer-blocks,
 //and executes ProcessSoundTouch on these blocks
 bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
-   WaveTrack &orig, WaveTrack &out,
+   WaveChannel &orig, WaveTrack &out,
    sampleCount start, sampleCount end,
    const TimeWarper &warper)
 {
@@ -232,7 +232,7 @@ bool EffectSoundTouch::ProcessOne(soundtouch::SoundTouch *pSoundTouch,
    }
 
    // Transfer output samples to the original
-   Finalize(orig, out, warper);
+   Finalize(orig.GetTrack(), out, warper);
 
    double newLength = out.GetEndTime();
    m_maxNewLength = std::max(m_maxNewLength, newLength);

--- a/src/effects/SoundTouchEffect.h
+++ b/src/effects/SoundTouchEffect.h
@@ -58,7 +58,7 @@ private:
    bool ProcessNoteTrack(NoteTrack *track, const TimeWarper &warper);
 #endif
    bool ProcessOne(soundtouch::SoundTouch *pSoundTouch,
-      WaveTrack &orig, WaveTrack &out, sampleCount start, sampleCount end,
+      WaveChannel &orig, WaveTrack &out, sampleCount start, sampleCount end,
       const TimeWarper &warper);
    bool ProcessStereo(soundtouch::SoundTouch *pSoundTouch,
       WaveTrack &orig, WaveTrack &out,

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -143,7 +143,7 @@ bool EffectStereoToMono::ProcessOne(TrackList &outputs,
       track.GetRate(),
       floatSample);
 
-   // Always make mono output; don't use WideEmptyCopy
+   // Always make mono output; don't use EmptyCopy
    auto outTrack = track.EmptyCopy(1);
    auto tempList = TrackList::Temporary(nullptr, outTrack);
    outTrack->ConvertToSampleFormat(floatSample);

--- a/src/effects/TwoPassSimpleMono.cpp
+++ b/src/effects/TwoPassSimpleMono.cpp
@@ -32,7 +32,7 @@ bool EffectTwoPassSimpleMono::Process(
 
    mWorkTracks = TrackList::Create(const_cast<AudacityProject*>(FindProject()));
    for (auto track : outputs.Get().Selected<WaveTrack>()) {
-      auto pNewTrack = track->WideEmptyCopy();
+      auto pNewTrack = track->EmptyCopy();
       mWorkTracks->Add(pNewTrack);
    }
    for (const auto pNewTrack : mWorkTracks->Any<WaveTrack>()) {

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -1710,7 +1710,7 @@ bool NyquistEffect::ProcessOne(
       return false;
    }
 
-   nyxContext.mOutputTrack = mCurChannelGroup->WideEmptyCopy();
+   nyxContext.mOutputTrack = mCurChannelGroup->EmptyCopy();
    auto out = nyxContext.mOutputTrack;
 
    // Now fully evaluate the sound

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -14,6 +14,7 @@
 #include "SyncLock.h"
 #include "../TrackPanel.h"
 #include "Viewport.h"
+#include "WaveClip.h"
 #include "WaveTrack.h"
 #include "WaveTrackUtilities.h"
 #include "../LabelTrack.h"

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -466,7 +466,7 @@ void DoSortTracks( AudacityProject &project, int flags )
 
             int ndx;
             for (ndx = 0; ndx < w.GetNumClips(); ndx++) {
-               const auto c = w.GetWideClip(ndx);
+               const auto c = w.GetClip(ndx);
                if (c->GetVisibleSampleCount() == 0)
                   continue;
                stime = std::min(stime, c->GetPlayStartTime());

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -261,8 +261,6 @@ void OnPunchAndRoll(const CommandContext &context)
    bool error = (t1 == 0.0);
 
    double newt1 = t1;
-   using Iterator =
-      ChannelGroup::IntervalIterator<const WideChannelGroupInterval>;
    for (const auto &wt : tracks) {
       auto rate = wt->GetRate();
       sampleCount testSample(floor(t1 * rate));

--- a/src/tracks/playabletrack/wavetrack/ui/ClipOverflowButtonHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/ClipOverflowButtonHandle.cpp
@@ -48,7 +48,7 @@ ClipOverflowButtonHandle::ClipOverflowButtonHandle(
 
 void ClipOverflowButtonHandle::DoDraw(const wxRect& rect, wxDC& dc)
 {
-   const ClipInterface& clip = *mClip->GetClip(0);
+   const ClipInterface& clip = *mClip;
    ClipButtonDrawingArgs args { rect, clip, dc };
    ClipButtonSpecializations<ClipButtonId::Overflow>::DrawOnClip(args);
 }

--- a/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
@@ -176,7 +176,7 @@ HitTestPreview ClipPitchAndSpeedButtonHandle::Preview(
 
 void ClipPitchAndSpeedButtonHandle::DoDraw(const wxRect& rect, wxDC& dc)
 {
-   const ClipInterface& clip = *mClip->GetClip(0);
+   const ClipInterface& clip = *mClip;
    ClipButtonDrawingArgs args { rect, clip, dc };
    if (mType == Type::Pitch)
       ClipButtonSpecializations<ClipButtonId::Pitch>::DrawOnClip(args);

--- a/src/tracks/playabletrack/wavetrack/ui/HighlitClipButtonHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/HighlitClipButtonHandle.cpp
@@ -45,7 +45,7 @@ void HighlitClipButtonHandle::Draw(
    const auto artist = TrackArtist::Get(context);
    const auto& zoomInfo = *artist->pZoomInfo;
    const auto rect = LowlitClipButton::Detail::GetButtonInnerRectangle(
-      mButtonId, { *mClip->GetClip(0), zoomInfo, affordanceRect });
+      mButtonId, { *mClip, zoomInfo, affordanceRect });
    if (!rect)
       return;
    Highlight(*rect, context.dc);
@@ -68,7 +68,7 @@ UIHandle::Result HighlitClipButtonHandle::Drag(
 
    // It's the right cell; check that the mouse is still over the button.
    const auto buttonRect = LowlitClipButton::Detail::GetButtonRectangle(
-      mButtonId, { *mClip->GetClip(0), ViewInfo::Get(*pProject), event.rect });
+      mButtonId, { *mClip, ViewInfo::Get(*pProject), event.rect });
    if (!buttonRect.has_value())
       return cancelCode;
 

--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
@@ -20,6 +20,7 @@
 
 #include "ShuttleGui.h"
 #include "SpinControl.h"
+#include "WaveClip.h"
 #include "wxWidgetsWindowPlacement.h"
 
 #include <regex>

--- a/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
@@ -26,6 +26,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "UndoManager.h"
 #include "ViewInfo.h"
 #include "WaveChannelUtilities.h"
+#include "WaveClip.h"
 #include "WaveTrack.h"
 #include "../../../../../images/Cursors.h"
 #include "AudacityMessageBox.h"

--- a/src/tracks/playabletrack/wavetrack/ui/SampleHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SampleHandle.h
@@ -20,7 +20,7 @@ class wxMouseState;
 class Track;
 class ViewInfo;
 class WaveChannel;
-class WaveChannelInterval;
+class WaveClipChannel;
 
 class SampleHandle final : public UIHandle
 {
@@ -71,7 +71,7 @@ private:
       (const wxMouseEvent &event, const ViewInfo &viewInfo, double t0);
 
    std::shared_ptr<WaveChannel> mClickedTrack;
-   std::shared_ptr<WaveChannelInterval> mClickedClip {};
+   std::shared_ptr<WaveClipChannel> mClickedClip {};
    wxRect mRect{};
 
    int mClickedStartPixel {};

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -591,7 +591,7 @@ std::unique_ptr<WaveClipListener> WaveClipSpectrumCache::Clone() const
 }
 
 static WaveClip::Attachments::RegisteredFactory sKeyS{ [](WaveClip &clip){
-   return std::make_unique<WaveClipSpectrumCache>(clip.GetWidth());
+   return std::make_unique<WaveClipSpectrumCache>(clip.NChannels());
 } };
 
 WaveClipSpectrumCache &

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -601,7 +601,7 @@ WaveClipSpectrumCache::Get(const WaveChannelInterval &clip)
       .Attachments::Get< WaveClipSpectrumCache >( sKeyS );
 }
 
-void WaveClipSpectrumCache::MarkChanged()
+void WaveClipSpectrumCache::MarkChanged() noexcept
 {
    ++mDirty;
 }

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -573,9 +573,8 @@ bool WaveClipSpectrumCache::GetSpectrogram(
 }
 
 WaveClipSpectrumCache::WaveClipSpectrumCache(size_t nChannels)
-   // TODO wide wave tracks -- won't need std::max here
-   : mSpecCaches(std::max<size_t>(2, nChannels))
-   , mSpecPxCaches(std::max<size_t>(2, nChannels))
+   : mSpecCaches(nChannels)
+   , mSpecPxCaches(nChannels)
 {
    for (auto &pCache : mSpecCaches)
       pCache = std::make_unique<SpecCache>();
@@ -598,7 +597,7 @@ static WaveClip::Attachments::RegisteredFactory sKeyS{ [](WaveClip &clip){
 WaveClipSpectrumCache &
 WaveClipSpectrumCache::Get(const WaveChannelInterval &clip)
 {
-   return const_cast<WaveClip&>(clip.GetWideClip()) // Consider it mutable data
+   return const_cast<WaveClip&>(clip.GetClip()) // Consider it mutable data
       .Attachments::Get< WaveClipSpectrumCache >( sKeyS );
 }
 

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
@@ -613,3 +613,27 @@ void WaveClipSpectrumCache::Invalidate()
    for (auto &pCache : mSpecCaches)
       pCache = std::make_unique<SpecCache>();
 }
+
+void WaveClipSpectrumCache::MakeStereo(WaveClipListener &&other, bool)
+{
+   auto pOther = dynamic_cast<WaveClipSpectrumCache *>(&other);
+   assert(pOther); // precondition
+   mSpecCaches.push_back(move(pOther->mSpecCaches[0]));
+   mSpecPxCaches.push_back(move(pOther->mSpecPxCaches[0]));
+}
+
+void WaveClipSpectrumCache::SwapChannels()
+{
+   mSpecCaches.resize(2);
+   std::swap(mSpecCaches[0], mSpecCaches[1]);
+   mSpecPxCaches.resize(2);
+   std::swap(mSpecPxCaches[0], mSpecPxCaches[1]);
+}
+
+void WaveClipSpectrumCache::Erase(size_t index)
+{
+   if (index < mSpecCaches.size())
+      mSpecCaches.erase(mSpecCaches.begin() + index);
+   if (index < mSpecPxCaches.size())
+      mSpecPxCaches.erase(mSpecPxCaches.begin() + index);
+}

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
@@ -116,7 +116,7 @@ struct WaveClipSpectrumCache final : WaveClipListener
 
    static WaveClipSpectrumCache &Get(const WaveChannelInterval &clip);
 
-   void MarkChanged() override; // NOFAIL-GUARANTEE
+   void MarkChanged() noexcept override; // NOFAIL-GUARANTEE
    void Invalidate() override; // NOFAIL-GUARANTEE
 
    /** Getting high-level data for screen display */

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
@@ -13,7 +13,8 @@
 
 class sampleCount;
 class SpectrogramSettings;
-class WaveChannelInterval;
+class WaveClipChannel;
+using WaveChannelInterval = WaveClipChannel;
 class WideSampleSequence;
 
 #include <vector>

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumCache.h
@@ -128,6 +128,10 @@ struct WaveClipSpectrumCache final : WaveClipListener
       SpectrogramSettings &spectrogramSettings,
       const sampleCount *&where, size_t numPixels,
       double t0 /*absolute time*/, double pixelsPerSecond);
+
+   void MakeStereo(WaveClipListener &&other, bool aligned) override;
+   void SwapChannels() override;
+   void Erase(size_t index) override;
 };
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
@@ -871,7 +871,7 @@ void SpectrumView::DoDraw(TrackPanelDrawingContext& context,
 
    for (const auto &pInterval : channel.Intervals()) {
       bool selected = selectedClip &&
-         WaveTrackUtilities::WideClipContains(*selectedClip, *pInterval);
+         selectedClip == &pInterval->GetClip();
       DrawClipSpectrum(context, channel, *pInterval, rect, mpSpectralData,
          selected);
    }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -897,7 +897,7 @@ auto WaveChannelSubView::GetMenuItems(
             viewInfo.selectedRegion.t0(), viewInfo.selectedRegion.t1())
                .empty())
          ||
-         track.GetClipAtTime(t))
+         WaveChannelUtilities::GetClipAtTime(**track.Channels().begin(), t))
       {
          return WaveClipUIUtilities::GetWaveClipMenuItems();
       }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -1034,8 +1034,7 @@ WaveChannelView::DoDetailedHitTest(
          results.push_back(
             AssignUIHandlePtr(
                waveChannelView.mAffordanceHandle,
-               std::make_shared<WaveTrackAffordanceHandle>(
-                  pTrack, clip->GetClipPtr())
+               std::make_shared<WaveTrackAffordanceHandle>(pTrack, clip)
             )
          );
       }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.cpp
@@ -393,7 +393,7 @@ UIHandlePtr WaveClipAdjustBorderHandle::HitAnywhere(
    //to determine which kind of adjustment is
    //more appropriate
    for (const auto &interval : waveTrack->Intervals()) {
-      const auto& clip = *interval->GetClip(0);
+      const auto& clip = *interval;
       if(!WaveChannelView::ClipDetailsVisible(clip, zoomInfo, rect))
          continue;
 
@@ -409,7 +409,7 @@ UIHandlePtr WaveClipAdjustBorderHandle::HitAnywhere(
    if (leftInterval && rightInterval)
    {
       //between adjacent clips
-      if(ClipParameters::GetClipRect(*leftInterval->GetClip(0), zoomInfo, rect).GetRight() > px)
+      if(ClipParameters::GetClipRect(*leftInterval, zoomInfo, rect).GetRight() > px)
       {
          adjustedInterval = leftInterval;
          adjustLeftBorder = false;
@@ -428,7 +428,7 @@ UIHandlePtr WaveClipAdjustBorderHandle::HitAnywhere(
          //single clip case, determine the border,
          //hit testing area differs from one
          //used for general case
-         const auto clipRect = ClipParameters::GetClipRect(*adjustedInterval->GetClip(0), zoomInfo, rect);
+         const auto clipRect = ClipParameters::GetClipRect(*adjustedInterval, zoomInfo, rect);
          if (std::abs(px - clipRect.GetLeft()) <= BoundaryThreshold)
             adjustLeftBorder = true;
          else if (std::abs(px - clipRect.GetRight()) <= BoundaryThreshold)

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipUIUtilities.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipUIUtilities.cpp
@@ -18,7 +18,7 @@
 #include "SampleCount.h"
 #include "UndoManager.h"
 #include "ViewInfo.h"
-#include "WaveTrack.h"
+#include "WaveClip.h"
 #include <algorithm>
 #include <cassert>
 #include <cmath>

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -213,7 +213,7 @@ std::vector<UIHandlePtr> WaveTrackAffordanceControls::HitTest(const TrackPanelMo
         if (it == mEditedInterval)
             continue;
 
-        const auto clip = (*it)->GetClip(0);
+        const auto clip = (*it);
         if (LowlitClipButton::HitTest<ClipButtonId::Overflow>(
                { *clip, zoomInfo, rect }, mousePoint))
         {
@@ -304,7 +304,7 @@ void WaveTrackAffordanceControls::Draw(TrackPanelDrawingContext& context, const 
          for(auto it = intervals.begin(); it != intervals.end(); ++it)
          {
              auto interval = *it;
-             const auto& clip = *interval->GetClip(0);
+             const auto& clip = *interval;
              const auto clipRect = ClipParameters::GetClipRect(
                 clip, zoomInfo, rect);
 
@@ -613,7 +613,7 @@ unsigned WaveTrackAffordanceControls::OnAffordanceClick(const TrackPanelMouseEve
     {
         if (auto interval = *mEditedInterval)
         {
-            auto affordanceRect = ClipParameters::GetClipRect(*interval->GetClip(0), viewInfo, event.rect);
+            auto affordanceRect = ClipParameters::GetClipRect(*interval, viewInfo, event.rect);
             if (!affordanceRect.Contains(event.event.GetPosition()))
                return ExitTextEditing();
         }
@@ -622,7 +622,7 @@ unsigned WaveTrackAffordanceControls::OnAffordanceClick(const TrackPanelMouseEve
     {
         if (event.event.LeftDClick())
         {
-            auto affordanceRect = ClipParameters::GetClipRect(*interval->GetClip(0), viewInfo, event.rect);
+            auto affordanceRect = ClipParameters::GetClipRect(*interval, viewInfo, event.rect);
             if (affordanceRect.Contains(event.event.GetPosition()) &&
                 StartEditClipName(*project, mFocusInterval))
             {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp
@@ -20,7 +20,7 @@
 
 #include <wx/event.h>
 
-WaveTrackAffordanceHandle::WaveTrackAffordanceHandle(const std::shared_ptr<Track>& track, const std::shared_ptr<WaveClip>& target)
+WaveTrackAffordanceHandle::WaveTrackAffordanceHandle(const std::shared_ptr<Track>& track, const std::shared_ptr<ClipTimes>& target)
    : AffordanceHandle(track), mTarget(target)
 { }
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.h
@@ -12,14 +12,14 @@
 
 #include "../../../ui/AffordanceHandle.h"
 
-class WaveClip;
+class ClipTimes;
 
 //! Implements some features which are specific to Wave Clips
 class WaveTrackAffordanceHandle final : public AffordanceHandle
 {
-   std::shared_ptr<WaveClip> mTarget;
+   std::shared_ptr<ClipTimes> mTarget;
 public:
-   WaveTrackAffordanceHandle(const std::shared_ptr<Track>& track, const std::shared_ptr<WaveClip>& target);
+   WaveTrackAffordanceHandle(const std::shared_ptr<Track>& track, const std::shared_ptr<ClipTimes>& target);
 
    Result Click(const TrackPanelMouseEvent& event, AudacityProject* project) override;
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -30,6 +30,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../../TrackPanel.h"
 #include "TrackFocus.h"
 #include "../../../../TrackPanelMouseEvent.h"
+#include "WaveClip.h"
 #include "WaveTrack.h"
 #include "WaveTrackUtilities.h"
 #include "RealtimeEffectManager.h"

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
@@ -149,7 +149,7 @@ const WaveColorAttachment &WaveColorAttachment::Get(const WaveChannelInterval &c
    return Get(clip.GetClip());
 }
 
-void WaveColorAttachment::MarkChanged() {}
+void WaveColorAttachment::MarkChanged() noexcept {}
 
 void WaveColorAttachment::Invalidate() {}
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
@@ -57,7 +57,7 @@ struct WaveColorAttachment final : WaveClipListener
    static WaveColorAttachment &Get(WaveChannelInterval &clip);
    static const WaveColorAttachment &Get(const WaveChannelInterval &clip);
 
-   void MarkChanged() override; // NOFAIL-GUARANTEE
+   void MarkChanged() noexcept override; // NOFAIL-GUARANTEE
    void Invalidate() override; // NOFAIL-GUARANTEE
 
    // Write color

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -269,8 +269,7 @@ bool WaveClipWaveformCache::GetWaveDisplay(
 }
 
 WaveClipWaveformCache::WaveClipWaveformCache(size_t nChannels)
-   // TODO wide wave tracks -- won't need std::max here
-   : mWaveCaches(std::max<size_t>(2, nChannels))
+   : mWaveCaches(nChannels)
 {
    for (auto &pCache : mWaveCaches)
       pCache = std::make_unique<WaveCache>();
@@ -293,7 +292,7 @@ static WaveClip::Attachments::RegisteredFactory sKeyW{ [](WaveClip &clip) {
 WaveClipWaveformCache &
 WaveClipWaveformCache::Get(const WaveChannelInterval &clip)
 {
-   return const_cast<WaveClip&>(clip.GetWideClip()) // Consider it mutable data
+   return const_cast<WaveClip&>(clip.GetClip()) // Consider it mutable data
       .Attachments::Get< WaveClipWaveformCache >( sKeyW );
 }
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -308,3 +308,22 @@ void WaveClipWaveformCache::Invalidate()
    for (auto &pCache : mWaveCaches)
       pCache = std::make_unique<WaveCache>();
 }
+
+void WaveClipWaveformCache::MakeStereo(WaveClipListener &&other, bool)
+{
+   auto pOther = dynamic_cast<WaveClipWaveformCache *>(&other);
+   assert(pOther); // precondition
+   mWaveCaches.push_back(move(pOther->mWaveCaches[0]));
+}
+
+void WaveClipWaveformCache::SwapChannels()
+{
+   mWaveCaches.resize(2);
+   std::swap(mWaveCaches[0], mWaveCaches[1]);
+}
+
+void WaveClipWaveformCache::Erase(size_t index)
+{
+   if (index < mWaveCaches.size())
+      mWaveCaches.erase(mWaveCaches.begin() + index);
+}

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -286,7 +286,7 @@ std::unique_ptr<WaveClipListener> WaveClipWaveformCache::Clone() const
 }
 
 static WaveClip::Attachments::RegisteredFactory sKeyW{ [](WaveClip &clip) {
-   return std::make_unique<WaveClipWaveformCache>(clip.GetWidth());
+   return std::make_unique<WaveClipWaveformCache>(clip.NChannels());
 } };
 
 WaveClipWaveformCache &

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.cpp
@@ -296,7 +296,7 @@ WaveClipWaveformCache::Get(const WaveChannelInterval &clip)
       .Attachments::Get< WaveClipWaveformCache >( sKeyW );
 }
 
-void WaveClipWaveformCache::MarkChanged()
+void WaveClipWaveformCache::MarkChanged() noexcept
 {
    ++mDirty;
 }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
@@ -71,7 +71,7 @@ struct WaveClipWaveformCache final : WaveClipListener
 
    static WaveClipWaveformCache &Get(const WaveChannelInterval &clip);
 
-   void MarkChanged() override; // NOFAIL-GUARANTEE
+   void MarkChanged() noexcept override; // NOFAIL-GUARANTEE
    void Invalidate() override; // NOFAIL-GUARANTEE
 
    ///Delete the wave cache - force redraw.  Thread-safe

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
@@ -12,9 +12,9 @@
 #define __AUDACITY_WAVEFORM_CACHE__
 
 #include "WaveClip.h"
+using WaveChannelInterval = WaveClipChannel;
 
 class WaveCache;
-class WaveChannelInterval;
 
 // A bundle of arrays needed for drawing waveforms.  The object may or may not
 // own the storage for those arrays.  If it does, it destroys them.

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
@@ -38,6 +38,10 @@ struct WaveClipWaveformCache final : WaveClipListener
    /** Getting high-level data for screen display */
    bool GetWaveDisplay(const WaveChannelInterval &clip,
       WaveDisplay &display, double t0, double pixelsPerSecond);
+
+   void MakeStereo(WaveClipListener &&other, bool aligned) override;
+   void SwapChannels() override;
+   void Erase(size_t index) override;
 };
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformCache.h
@@ -16,6 +16,48 @@
 class WaveCache;
 class WaveChannelInterval;
 
+// A bundle of arrays needed for drawing waveforms.  The object may or may not
+// own the storage for those arrays.  If it does, it destroys them.
+class WaveDisplay
+{
+public:
+   int width;
+   sampleCount *where;
+   float *min, *max, *rms;
+
+   std::vector<sampleCount> ownWhere;
+   std::vector<float> ownMin, ownMax, ownRms;
+
+public:
+   WaveDisplay(int w)
+      : width(w), where(0), min(0), max(0), rms(0)
+   {
+   }
+
+   // Create "own" arrays.
+   void Allocate()
+   {
+      ownWhere.resize(width + 1);
+      ownMin.resize(width);
+      ownMax.resize(width);
+      ownRms.resize(width);
+
+      where = &ownWhere[0];
+      if (width > 0) {
+         min = &ownMin[0];
+         max = &ownMax[0];
+         rms = &ownRms[0];
+      }
+      else {
+         min = max = rms = 0;
+      }
+   }
+
+   ~WaveDisplay()
+   {
+   }
+};
+
 struct WaveClipWaveformCache final : WaveClipListener
 {
    explicit WaveClipWaveformCache(size_t nChannels);

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -976,7 +976,7 @@ void WaveformView::DoDraw(TrackPanelDrawingContext &context,
 
    for (const auto &pInterval : channel.Intervals()) {
       bool selected = selectedClip &&
-         WaveTrackUtilities::WideClipContains(*selectedClip, *pInterval);
+         selectedClip == &pInterval->GetClip();
       DrawClipWaveform(context, channel, *pInterval, rect, dB, muted, selected);
    }
    DrawBoldBoundaries(context, channel, rect);


### PR DESCRIPTION
Resolves: #6086

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Re-test all in https://github.com/audacity/audacity/pull/5965
- [x] Re-test all in https://github.com/audacity/audacity/pull/6071

And some more specific areas for attention (apologies for any duplication):
- [x] Creating, expanding, deleting cutlines (including nested cutlines inside of cutlines)
- [x] Test cutlines again, after making them in a stereo track, splitting stereo to mono, then expanding or deleting
- [x] Joining mono tracks to stereo loses cutlines (as in master)
- [x] A Nyquist generator (Pluck)
- [x] Saving and reopening of projects
- [x] Reopening of 2.x projects into this branch, including cases with misaligned clips
- [x] Edit > Duplicate, undo/redo, cut-copy-paste of mono and stereo tracks
- [x] Create one each of label, time, MIDI tracks; undo and redo, (label and MIDI:) cut copy and paste
- [x] Rendering of a clip with stretch; paste into a clip with stretch ratio difference
- [x] Watch waveform, spectrum, split views, when splitting, joining, swapping channels
- [x] for a given track, right clicking on it where there is a clip and where there is none still behaves.
- [x] Stereo to mono, also in spectrogram view, also with envelopes and cutlines
- [x] Mono to stereo, also in spectrogram view, also with envelopes and cutlines
- [x] Swap channels, also in spectrogram view, also with envelopes and cutlines
- [x] Effects: auto-duck
- [x] Effects: change pitch
- [x] Edge cases of pasting:  hidden data on the source and target clips, pasting exactly at the start or end of the target as well as at some middle point
- [x] Generating silence in a clip, when cursor is exactly at start or end, destroys smart clip data, as in master
- [ ] 