### PR TITLE
Import slowdown fix

### DIFF
--- a/libraries/lib-import-export/ImportUtils.cpp
+++ b/libraries/lib-import-export/ImportUtils.cpp
@@ -63,13 +63,11 @@ void ImportUtils::FinalizeImport(TrackHolders& outTracks, TrackListHolder trackL
    outTracks.push_back(std::move(trackList));
 }
 
-void ImportUtils::ForEachChannel(TrackList& trackList, const std::function<void(WaveChannel&)>& op)
+std::vector<std::shared_ptr<WaveChannel>> ImportUtils::GetAllChannels(TrackList& trackList)
 {
-   for(auto track : trackList.Any<WaveTrack>())
-   {
+   std::vector<std::shared_ptr<WaveChannel>> channels;
+   for(const auto track : trackList.Any<WaveTrack>())
       for(auto channel : track->Channels())
-      {
-         op(*channel);
-      }
-   }
+         channels.push_back(std::move(channel));
+   return channels;
 }

--- a/libraries/lib-import-export/ImportUtils.h
+++ b/libraries/lib-import-export/ImportUtils.h
@@ -41,9 +41,8 @@ public:
    
    static void ShowMessageBox(const TranslatableString& message, const TranslatableString& caption = XO("Import Project"));
 
-   //! Iterates over channels in each wave track from the list
    static
-   void ForEachChannel(TrackList& trackList, const std::function<void(WaveChannel&)>& op);
+   std::vector<std::shared_ptr<WaveChannel>> GetAllChannels(TrackList& trackList);
 
    //! Flushes the given channels and moves them to \p outTracks
    static

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -536,6 +536,22 @@ bool WaveClip::Append(constSamplePtr buffers[], sampleFormat format,
    return appended;
 }
 
+bool WaveClip::AppendUnsafe(constSamplePtr buffers[], sampleFormat format, size_t len, unsigned stride,
+   sampleFormat effectiveFormat)
+{
+   size_t ii = 0;
+   bool appended = false;
+   for (auto &pSequence : mSequences)
+      appended =
+         pSequence->Append(buffers[ii++], format, len, stride, effectiveFormat)
+         || appended;
+
+   UpdateEnvelopeTrackLen();
+   MarkChanged();
+
+   return appended;
+}
+
 void WaveClip::Flush()
 {
    //wxLogDebug(wxT("WaveClip::Flush"));

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -488,6 +488,14 @@ public:
       */
    );
 
+   //! Same as Append but less guarantees on preserving original data
+   //! in case of emergencies like memory allocation failures. Useful
+   //! when clip is being piece-wise constructed and intermediate
+   //! states are not meaningful.
+   bool AppendUnsafe(constSamplePtr buffers[], sampleFormat format,
+      size_t len, unsigned int stride,
+      sampleFormat effectiveFormat);
+
    //! Flush must be called after last Append
    /*!
     In case of exceptions, the clip contents are unchanged but

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2692,6 +2692,12 @@ bool WaveChannel::AppendBuffer(constSamplePtr buffer, sampleFormat format,
    return GetTrack().Append(buffer, format, len, stride, effectiveFormat);
 }
 
+bool WaveChannel::AppendBufferUnsafe(constSamplePtr buffer, sampleFormat format, size_t len, unsigned stride,
+   sampleFormat effectiveFormat)
+{
+   return GetTrack().AppendUnsafe(buffer, format, len, stride, effectiveFormat);
+}
+
 /*! @excsafety{Partial}
 -- Some prefix (maybe none) of the buffer is appended,
 and no content already flushed to disk is lost. */
@@ -2699,6 +2705,11 @@ bool WaveChannel::Append(constSamplePtr buffer, sampleFormat format,
    size_t len)
 {
    return GetTrack().Append(buffer, format, len, 1, widestSampleFormat);
+}
+
+bool WaveChannel::AppendUnsafe(constSamplePtr buffer, sampleFormat format, size_t len)
+{
+   return GetTrack().AppendUnsafe(buffer, format, len, 1, widestSampleFormat);
 }
 
 /*! @excsafety{Partial}
@@ -2716,6 +2727,19 @@ bool WaveTrack::Append(constSamplePtr buffer, sampleFormat format,
    constSamplePtr buffers[]{ buffer };
    return pTrack->RightmostOrNewClip()
       ->Append(buffers, format, len, stride, effectiveFormat);
+}
+
+bool WaveTrack::AppendUnsafe(constSamplePtr buffer, sampleFormat format, size_t len, unsigned stride,
+   sampleFormat effectiveFormat, size_t iChannel)
+{
+   // TODO wide wave tracks -- there will be only one clip, and its `Append`
+   // (or an overload) must take iChannel
+   auto pTrack = this;
+   if (GetOwner() && iChannel == 1)
+      pTrack = *TrackList::Channels(this).rbegin();
+   constSamplePtr buffers[]{ buffer };
+   return pTrack->RightmostOrNewClip()
+      ->AppendUnsafe(buffers, format, len, stride, effectiveFormat);
 }
 
 size_t WaveTrack::GetBestBlockSize(sampleCount s) const

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -189,6 +189,8 @@ public:
    );
 
    bool AppendBuffer(constSamplePtr buffer, sampleFormat format, size_t len, unsigned stride, sampleFormat effectiveFormat);
+   bool AppendBufferUnsafe(constSamplePtr buffer, sampleFormat format, size_t len, unsigned stride, sampleFormat effectiveFormat);
+
 
    /*!
     If there is an existing WaveClip in the WaveTrack that owns the channel,
@@ -197,6 +199,9 @@ public:
     @return true if at least one complete block was created
     */
    bool Append(constSamplePtr buffer, sampleFormat format, size_t len);
+
+   //! Same as WaveChannel::Append but less safety guarantees, see WaveClip::Unsafe
+   bool AppendUnsafe(constSamplePtr buffer, sampleFormat format, size_t len);
 
    // Get signed min and max sample values
    /*!
@@ -517,6 +522,11 @@ public:
       size_t len, unsigned int stride = 1,
       sampleFormat effectiveFormat = widestSampleFormat, size_t iChannel = 0)
    override;
+
+   //! Same as WaveTrack::Append but less safety guarantees, see WaveClip::Unsafe
+   bool AppendUnsafe(constSamplePtr buffer, sampleFormat format,
+      size_t len, unsigned int stride = 1,
+      sampleFormat effectiveFormat = widestSampleFormat, size_t iChannel = 0);
 
    void Flush() override;
 

--- a/modules/mod-ffmpeg/ImportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ImportFFmpeg.cpp
@@ -596,7 +596,7 @@ void FFmpegImportFileHandle::WriteData(StreamContext *sc, const AVPacketWrapper*
          if(chn >= nChannels)
             return;
 
-         channel.AppendBuffer(
+         channel.AppendBufferUnsafe(
             reinterpret_cast<samplePtr>(data.data() + chn),
             sc->SampleFormat,
             samplesPerChannel,
@@ -618,7 +618,7 @@ void FFmpegImportFileHandle::WriteData(StreamContext *sc, const AVPacketWrapper*
          if(channelIndex >= nChannels)
             return;
 
-         channel.AppendBuffer(
+         channel.AppendBufferUnsafe(
             reinterpret_cast<samplePtr>(data.data() + channelIndex),
             sc->SampleFormat,
             samplesPerChannel,

--- a/modules/mod-ffmpeg/ImportFFmpeg.cpp
+++ b/modules/mod-ffmpeg/ImportFFmpeg.cpp
@@ -582,6 +582,7 @@ void FFmpegImportFileHandle::WriteData(StreamContext *sc, const AVPacketWrapper*
    auto stream = mStreams[std::distance(mStreamContexts.begin(), streamIt)];
 
    const auto nChannels = std::min(sc->CodecContext->GetChannels(), sc->InitialChannels);
+   auto channels = ImportUtils::GetAllChannels(*stream);
 
    // Write audio into WaveTracks
    if (sc->SampleFormat == int16Sample)
@@ -591,12 +592,12 @@ void FFmpegImportFileHandle::WriteData(StreamContext *sc, const AVPacketWrapper*
       const auto samplesPerChannel = data.size() / channelsCount;
 
       unsigned chn = 0;
-      ImportUtils::ForEachChannel(*stream, [&](auto& channel)
+      std::for_each(channels.begin(), channels.end(), [&](auto& channel)
       {
          if(chn >= nChannels)
             return;
 
-         channel.AppendBufferUnsafe(
+         channel->AppendBufferUnsafe(
             reinterpret_cast<samplePtr>(data.data() + chn),
             sc->SampleFormat,
             samplesPerChannel,
@@ -613,12 +614,12 @@ void FFmpegImportFileHandle::WriteData(StreamContext *sc, const AVPacketWrapper*
       const auto samplesPerChannel = data.size() / channelsCount;
 
       auto channelIndex = 0;
-      ImportUtils::ForEachChannel(*stream, [&](auto& channel)
+      std::for_each(channels.begin(), channels.end(), [&](auto& channel)
       {
          if(channelIndex >= nChannels)
             return;
 
-         channel.AppendBufferUnsafe(
+         channel->AppendBufferUnsafe(
             reinterpret_cast<samplePtr>(data.data() + channelIndex),
             sc->SampleFormat,
             samplesPerChannel,

--- a/modules/mod-flac/ImportFLAC.cpp
+++ b/modules/mod-flac/ImportFLAC.cpp
@@ -237,13 +237,13 @@ FLAC__StreamDecoderWriteStatus MyFLACFile::write_callback(const FLAC__Frame *fra
                }
             }
 
-            channel.AppendBuffer((samplePtr)tmp.get(),
+            channel.AppendBufferUnsafe((samplePtr)tmp.get(),
                      int16Sample,
                      frame->header.blocksize, 1,
                      int16Sample);
          }
          else {
-            channel.AppendBuffer((samplePtr)buffer[chn],
+            channel.AppendBufferUnsafe((samplePtr)buffer[chn],
                      int24Sample,
                      frame->header.blocksize, 1,
                      int24Sample);

--- a/modules/mod-mpg123/ImportMP3_MPG123.cpp
+++ b/modules/mod-mpg123/ImportMP3_MPG123.cpp
@@ -323,7 +323,7 @@ void MP3ImportFileHandle::Import(
       unsigned chn = 0;
       ImportUtils::ForEachChannel(*mTrackList, [&](auto& channel)
       {
-         channel.AppendBuffer(
+         channel.AppendBufferUnsafe(
             samples + sizeof(float) * chn,
             floatSample, samplesCount,
             mNumChannels,

--- a/modules/mod-mpg123/ImportMP3_MPG123.cpp
+++ b/modules/mod-mpg123/ImportMP3_MPG123.cpp
@@ -288,6 +288,8 @@ void MP3ImportFileHandle::Import(
 
    int ret = MPG123_OK;
 
+   auto channels = ImportUtils::GetAllChannels(*mTrackList);
+
    while ((ret = mpg123_decode_frame(mHandle, &frameIndex, &data, &dataSize)) ==
                  MPG123_OK)
    {
@@ -321,9 +323,9 @@ void MP3ImportFileHandle::Import(
       }
       // Just copy the interleaved data to the channels
       unsigned chn = 0;
-      ImportUtils::ForEachChannel(*mTrackList, [&](auto& channel)
+      std::for_each(channels.begin(), channels.end(), [&](auto& channel)
       {
-         channel.AppendBufferUnsafe(
+         channel->AppendBufferUnsafe(
             samples + sizeof(float) * chn,
             floatSample, samplesCount,
             mNumChannels,

--- a/modules/mod-ogg/ImportOGG.cpp
+++ b/modules/mod-ogg/ImportOGG.cpp
@@ -304,7 +304,7 @@ void OggImportFileHandle::Import(
             unsigned chn = 0;
             ImportUtils::ForEachChannel(**std::next(mStreams.begin(), bitstream), [&](auto& channel)
             {
-               channel.AppendBuffer(
+               channel.AppendBufferUnsafe(
                   (char *)(mainBuffer.get() + chn),
                   int16Sample,
                   samplesRead,

--- a/modules/mod-opus/ImportOpus.cpp
+++ b/modules/mod-opus/ImportOpus.cpp
@@ -218,7 +218,7 @@ void OpusImportFileHandle::Import(
       unsigned chn = 0;
       ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
       {
-         channel.AppendBuffer(
+         channel.AppendBufferUnsafe(
             reinterpret_cast<constSamplePtr>(floatBuffer.get() +
             chn), mFormat, samplesRead, mNumChannels, mFormat
          );

--- a/modules/mod-opus/ImportOpus.cpp
+++ b/modules/mod-opus/ImportOpus.cpp
@@ -196,6 +196,7 @@ void OpusImportFileHandle::Import(
 
    uint64_t samplesRead = 0;
 
+   auto channels = ImportUtils::GetAllChannels(*trackList);
    do
    {
       int linkIndex { -1 };
@@ -216,9 +217,9 @@ void OpusImportFileHandle::Import(
       }
 
       unsigned chn = 0;
-      ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
+      std::for_each(channels.begin(), channels.end(), [&](auto& channel)
       {
-         channel.AppendBufferUnsafe(
+         channel->AppendBufferUnsafe(
             reinterpret_cast<constSamplePtr>(floatBuffer.get() +
             chn), mFormat, samplesRead, mNumChannels, mFormat
          );

--- a/modules/mod-pcm/ImportPCM.cpp
+++ b/modules/mod-pcm/ImportPCM.cpp
@@ -337,6 +337,7 @@ void PCMImportFileHandle::Import(
       decltype(fileTotalFrames) framescompleted = 0;
 
       long block;
+      auto channels = ImportUtils::GetAllChannels(*trackList);
       do {
          block = maxBlock;
 
@@ -353,7 +354,7 @@ void PCMImportFileHandle::Import(
 
          if (block) {
             unsigned c = 0;
-            ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
+            std::for_each(channels.begin(), channels.end(), [&](auto& channel)
             {
                if (mFormat==int16Sample) {
                   for(int j=0; j<block; j++)
@@ -366,7 +367,7 @@ void PCMImportFileHandle::Import(
                         ((float *)srcbuffer.ptr())[mInfo.channels*j+c];
                }
 
-               channel.AppendBufferUnsafe(
+               channel->AppendBufferUnsafe(
                   buffer.ptr(),
                   (mFormat == int16Sample) ? int16Sample : floatSample,
                   block, 1, mEffectiveFormat

--- a/modules/mod-pcm/ImportPCM.cpp
+++ b/modules/mod-pcm/ImportPCM.cpp
@@ -366,7 +366,7 @@ void PCMImportFileHandle::Import(
                         ((float *)srcbuffer.ptr())[mInfo.channels*j+c];
                }
 
-               channel.AppendBuffer(
+               channel.AppendBufferUnsafe(
                   buffer.ptr(),
                   (mFormat == int16Sample) ? int16Sample : floatSample,
                   block, 1, mEffectiveFormat

--- a/modules/mod-wavpack/ImportWavPack.cpp
+++ b/modules/mod-wavpack/ImportWavPack.cpp
@@ -191,6 +191,7 @@ void WavPackImportFileHandle::Import(
          floatBuffer.reinit(bufferSize);
       }
 
+      auto channels = ImportUtils::GetAllChannels(*trackList);
       do {
          samplesRead = WavpackUnpackSamples(mWavPackContext, wavpackBuffer.get(), SAMPLES_TO_READ);
 
@@ -203,9 +204,9 @@ void WavPackImportFileHandle::Import(
                   int16Buffer[c] = static_cast<int16_t>(wavpackBuffer[c]);
 
             unsigned chn = 0;
-            ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
+            std::for_each(channels.begin(), channels.end(), [&](auto& channel)
             {
-               channel.AppendBufferUnsafe(
+               channel->AppendBufferUnsafe(
                   reinterpret_cast<constSamplePtr>(int16Buffer.get() + chn),
                   mFormat,
                   samplesRead,
@@ -216,9 +217,9 @@ void WavPackImportFileHandle::Import(
             });
          } else if (mFormat == int24Sample || (wavpackMode & MODE_FLOAT) == MODE_FLOAT) {
             unsigned chn = 0;
-            ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
+            std::for_each(channels.begin(), channels.end(), [&](auto& channel)
             {
-               channel.AppendBufferUnsafe(
+               channel->AppendBufferUnsafe(
                   reinterpret_cast<constSamplePtr>(wavpackBuffer.get() + chn),
                   mFormat,
                   samplesRead,
@@ -232,9 +233,9 @@ void WavPackImportFileHandle::Import(
                floatBuffer[c] = static_cast<float>(wavpackBuffer[c] / static_cast<double>(std::numeric_limits<int32_t>::max()));
 
             unsigned chn = 0;
-            ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
+            std::for_each(channels.begin(), channels.end(), [&](auto& channel)
             {
-               channel.AppendBufferUnsafe(
+               channel->AppendBufferUnsafe(
                   reinterpret_cast<constSamplePtr>(floatBuffer.get() + chn),
                   mFormat,
                   samplesRead,

--- a/modules/mod-wavpack/ImportWavPack.cpp
+++ b/modules/mod-wavpack/ImportWavPack.cpp
@@ -205,7 +205,7 @@ void WavPackImportFileHandle::Import(
             unsigned chn = 0;
             ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
             {
-               channel.AppendBuffer(
+               channel.AppendBufferUnsafe(
                   reinterpret_cast<constSamplePtr>(int16Buffer.get() + chn),
                   mFormat,
                   samplesRead,
@@ -218,7 +218,7 @@ void WavPackImportFileHandle::Import(
             unsigned chn = 0;
             ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
             {
-               channel.AppendBuffer(
+               channel.AppendBufferUnsafe(
                   reinterpret_cast<constSamplePtr>(wavpackBuffer.get() + chn),
                   mFormat,
                   samplesRead,
@@ -234,7 +234,7 @@ void WavPackImportFileHandle::Import(
             unsigned chn = 0;
             ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
             {
-               channel.AppendBuffer(
+               channel.AppendBufferUnsafe(
                   reinterpret_cast<constSamplePtr>(floatBuffer.get() + chn),
                   mFormat,
                   samplesRead,

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -231,7 +231,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
                      ((float *)srcbuffer.ptr())[numChannels * j + c];
                }
 
-               channel.AppendBuffer(buffer.ptr(),
+               channel.AppendBufferUnsafe(buffer.ptr(),
                   ((format == int16Sample) ? int16Sample : floatSample), block,
                   1, sf_subtype_to_effective_format(encoding));
                ++c;

--- a/src/import/ImportRaw.cpp
+++ b/src/import/ImportRaw.cpp
@@ -197,6 +197,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
       ProgressDialog progress(XO("Import Raw"), msg);
 
       size_t block;
+      auto channels = ImportUtils::GetAllChannels(*trackList);
       do {
          block =
             limitSampleBufferSize( maxBlockSize, totalFrames - framescompleted );
@@ -218,7 +219,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
 
          if (block) {
             size_t c = 0;
-            ImportUtils::ForEachChannel(*trackList, [&](auto& channel)
+            std::for_each(channels.begin(), channels.end(), [&](auto& channel)
             {
                if (format == int16Sample) {
                   for (size_t j = 0; j < block; ++j)
@@ -231,7 +232,7 @@ void ImportRaw(const AudacityProject &project, wxWindow *parent, const wxString 
                      ((float *)srcbuffer.ptr())[numChannels * j + c];
                }
 
-               channel.AppendBufferUnsafe(buffer.ptr(),
+               channel->AppendBufferUnsafe(buffer.ptr(),
                   ((format == int16Sample) ? int16Sample : floatSample), block,
                   1, sf_subtype_to_effective_format(encoding));
                ++c;


### PR DESCRIPTION
Resolves: #4999 

There were two major reasons for import slowdown: 
1) Channel iterator dereference operation that was called repeatedly for each chunk/block in sequence adds a noticeable overhead to the import. As `TrackList` doesn't change during import channels could be enumerated in advance and stored in local variable.
2) Overhead added by data preservation performed by `Transaction` object in `WaveClip`. This is solved by introducing `AppendUnsafe` that omits this kind of safety, which not seem to be useful in case of import because data is appended to a temporary object that will be destroyed in case if `Sequence` throws an exception.

- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
