### PR TITLE
Record new track can record at the wrong sampling rate

### DIFF
--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -672,10 +672,12 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
          // Try to find wave tracks to record into.  (If any are selected,
          // try to choose only from them; else if wave tracks exist, may record into any.)
          existingTracks = ChooseExistingRecordingTracks(*p, true, rateOfSelected);
-         if (!existingTracks.empty())
+         if (!existingTracks.empty()) {
             t0 = std::max(t0,
                TrackList::Get(*p).Selected<const WaveTrack>()
-                  .max(&Track::GetEndTime));
+               .max(&Track::GetEndTime));
+            options.rate = rateOfSelected;
+         }
          else {
             if (anySelected && rateOfSelected != options.rate) {
                AudacityMessageBox(XO(
@@ -739,9 +741,6 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
 
       std::copy(existingTracks.begin(), existingTracks.end(),
          back_inserter(transportTracks.captureSequences));
-
-      if (rateOfSelected != RATE_NOT_SELECTED)
-         options.rate = rateOfSelected;
 
       DoRecord(*p, transportTracks, t0, t1, altAppearance, options);
    }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6125

Problem:
If an audio track is selected, then when recording a new track, the actual sampling rate for the recording is the sampling rate of the selected track, rather than the sampling rate of the project. The sampling rate of the new track in the track control panel is the sampling rate of the project. So if these two sampling rates are different, this results in the recording with a changed speed.

Looks like the problem was introduced by this commit: 70b7487

Fix:
Only use the sampling rate of the selected track or tracks when appending to them.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
