### PR TITLE
Weaken invariant for WaveClip; don't make a Transaction in Append

### DIFF
--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -645,8 +645,8 @@ private:
    /*!
     @invariant `mSequences.size() > 0`
     @invariant all are non-null
-    @invariant all sequences have the same lengths, append buffer lengths,
-      sample formats, and sample block factory
+    @invariant all sequences have the same sample formats, and sample block
+    factory
     @invariant all cutlines have the same width
     */
    std::vector<std::unique_ptr<Sequence>> mSequences;


### PR DESCRIPTION
Resolves: #4999

This change may relieve most of the performance problem for import now in 3.5.  I recommend it for release.  Maybe parts of #6107 could also be cherry picked, if in fact the other problem of channel iteration is significant too.

The wave-clip-refactoring branch has other changes that solve the import performance problem.  In my opinion that branch still is very large and possibly risky in spite of all the testing done so far.  I do not recommend merging that branch to 3.5.  It should merge into 3.6 alpha, and another development cycle should allow for discovery of any other subtle bugs that branch may have introduced.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
