### PR TITLE
5981 non modal pitch and speed dialog

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -695,7 +695,7 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions &options,
                (latencyDuration / 1000.0) :
                // Otherwise, use the (likely incorrect) latency reported by PA
                stream->outputLatency;
-         
+
          mHardwarePlaybackLatencyFrames = lrint(outputLatency * mRate);
 #ifdef __WXGTK__
          // DV: When using ALSA PortAudio does not report the buffer size.
@@ -1632,7 +1632,6 @@ void AudioIO::StopStream()
 
    mInputMeter.reset();
    mOutputMeter.reset();
-   ResetOwningProject();
 
    if (pListener && mNumCaptureChannels > 0)
       pListener->OnAudioIOStopRecording();
@@ -1669,6 +1668,8 @@ void AudioIO::StopStream()
                : AudioIOEvent::CAPTURE,
             false });
    }
+
+   ResetOwningProject();
 
    mNumCaptureChannels = 0;
    mNumPlaybackChannels = 0;

--- a/libraries/lib-shuttlegui/ShuttleGui.cpp
+++ b/libraries/lib-shuttlegui/ShuttleGui.cpp
@@ -100,6 +100,7 @@ for registering for changes.
 #include "IteratorX.h"
 #include "Prefs.h"
 #include "ShuttlePrefs.h"
+#include "SpinControl.h"
 #include "Theme.h"
 
 #include <wx/setup.h> // for wxUSE_* macros
@@ -631,6 +632,25 @@ wxSpinCtrl * ShuttleGuiBase::AddSpinCtrl(
       Min, Max, Value
       );
    mpWind->SetName(wxStripMenuCodes(translated));
+   miProp=1;
+   UpdateSizers();
+   return pSpinCtrl;
+}
+
+SpinControl* ShuttleGuiBase::AddSpinControl(
+   const wxSize& size, const TranslatableString& Prompt, double Value,
+   double Max, double Min)
+{
+   const auto translated = Prompt.Translation();
+   HandleOptionality( Prompt );
+   AddPrompt( Prompt );
+   UseUpId();
+   if( mShuttleMode != eIsCreating )
+      return dynamic_cast<SpinControl*>(wxWindow::FindWindowById(miId, mpDlg));
+   SpinControl * pSpinCtrl;
+   mpWind = pSpinCtrl = safenew SpinControl(
+      GetParent(), miId, Value, Min, Max, 1.0, true, wxDefaultPosition, size,
+      Prompt);
    miProp=1;
    UpdateSizers();
    return pSpinCtrl;
@@ -1372,6 +1392,45 @@ wxSpinCtrl * ShuttleGuiBase::DoTieSpinCtrl(
    return pSpinCtrl;
 }
 
+SpinControl* ShuttleGuiBase::DoTieSpinControl(
+   const wxSize& size, const TranslatableString& Prompt,
+   WrappedType& WrappedRef, const double max, const double min)
+{
+   HandleOptionality( Prompt );
+   // The Add function does a UseUpId(), so don't do it here in that case.
+   if( mShuttleMode == eIsCreating )
+      return AddSpinControl(size, Prompt, WrappedRef.ReadAsDouble(), max, min);
+
+   UseUpId();
+   SpinControl * pSpinCtrl=NULL;
+
+   wxWindow * pWnd  = wxWindow::FindWindowById( miId, mpDlg);
+   pSpinCtrl = dynamic_cast<SpinControl*>(pWnd);
+
+   switch( mShuttleMode )
+   {
+      // IF setting internal storage from the controls.
+   case eIsGettingMetadata:
+      break;
+   case eIsGettingFromDialog:
+      {
+         wxASSERT( pSpinCtrl );
+         WrappedRef.WriteToAsDouble( pSpinCtrl->GetValue() );
+      }
+      break;
+   case eIsSettingToDialog:
+      {
+         wxASSERT( pSpinCtrl );
+         pSpinCtrl->SetValue( WrappedRef.ReadAsDouble() );
+      }
+      break;
+   default:
+      wxASSERT( false );
+      break;
+   }
+   return pSpinCtrl;
+}
+
 wxTextCtrl * ShuttleGuiBase::DoTieTextBox(
    const TranslatableString &Prompt, WrappedType & WrappedRef, const int nChars)
 {
@@ -1653,6 +1712,14 @@ wxSpinCtrl * ShuttleGuiBase::TieSpinCtrl(
 {
    WrappedType WrappedRef(Value);
    return DoTieSpinCtrl( Prompt, WrappedRef, max, min );
+}
+
+SpinControl* ShuttleGuiBase::TieSpinControl(
+   const wxSize& size, const TranslatableString& Prompt, double& Value,
+   const double max, const double min)
+{
+   WrappedType WrappedRef(Value);
+   return DoTieSpinControl(size, Prompt, WrappedRef, max, min);
 }
 
 wxTextCtrl * ShuttleGuiBase::TieTextBox(
@@ -2091,7 +2158,7 @@ void ShuttleGuiBase::SetProportions( int Default )
 
 void ShuttleGuiBase::ApplyItem( int step, const DialogDefinition::Item &item,
    wxWindow *pWind, wxWindow *pDlg )
-{  
+{
    if ( step == 0 ) {
       // Do these steps before adding the window to the sizer
       if( item.mUseBestSize )
@@ -2277,7 +2344,7 @@ ShuttleGui & ShuttleGui::Id(int id )
 }
 
 ShuttleGui & ShuttleGui::Optional( bool &bVar ){
-   mpbOptionalFlag = &bVar; 
+   mpbOptionalFlag = &bVar;
    return *this;
 };
 
@@ -2303,7 +2370,7 @@ std::unique_ptr<wxSizer> CreateStdButtonSizer(wxWindow *parent, long buttons, wx
 
    wxButton *b = NULL;
    auto bs = std::make_unique<wxStdDialogButtonSizer>();
-   
+
    const auto makeButton =
    [parent]( wxWindowID id, const wxString label = {} ) {
       auto result = safenew wxButton( parent, id, label );

--- a/libraries/lib-shuttlegui/ShuttleGui.h
+++ b/libraries/lib-shuttlegui/ShuttleGui.h
@@ -72,6 +72,7 @@ class wxListBox;
 class wxGrid;
 class ShuttlePrefs;
 class ReadOnlyText;
+class SpinControl;
 
 class WrappedType;
 
@@ -260,6 +261,9 @@ public:
    wxSlider * AddVSlider(const TranslatableString &Prompt, int pos, int Max);
    wxSpinCtrl * AddSpinCtrl(const TranslatableString &Prompt,
       int Value, int Max, int Min);
+   SpinControl* AddSpinControl(
+      const wxSize& size, const TranslatableString& Prompt, double Value,
+      double Max, double Min);
    wxTreeCtrl * AddTree();
 
    // Pass the same initValue to the sequence of calls to AddRadioButton and
@@ -435,6 +439,9 @@ public:
 
    wxSpinCtrl * TieSpinCtrl( const TranslatableString &Prompt,
       int &Value, const int max, const int min = 0 );
+   SpinControl* TieSpinControl(
+      const wxSize& size, const TranslatableString& Prompt, double& Value,
+      const double max, const double min = 0);
 
 
 //-- Variants of the standard Tie functions which do two step exchange in one go
@@ -569,6 +576,9 @@ private:
       WrappedType & WrappedRef, const int max, const int min = 0 );
    wxSpinCtrl * DoTieSpinCtrl( const TranslatableString &Prompt,
       WrappedType & WrappedRef, const int max, const int min = 0 );
+   SpinControl* DoTieSpinControl(
+      const wxSize& size, const TranslatableString& Prompt,
+      WrappedType& WrappedRef, const double max, const double min = 0);
 
    std::vector<EnumValueSymbol> mRadioSymbols;
    wxString mRadioSettingName; /// The setting controlled by a group.

--- a/libraries/lib-viewport/Viewport.cpp
+++ b/libraries/lib-viewport/Viewport.cpp
@@ -209,9 +209,9 @@ void Viewport::SetHorizontalThumb(double scrollto, bool doScroll)
    const int pos = std::clamp<int>(floor(0.5 + unscaled * sbarScale), 0, max);
    mpCallbacks->SetHorizontalThumbPosition(pos);
    sbarH = floor(0.5 + unscaled - PixelWidthBeforeTime(0.0));
-   sbarH = std::clamp<wxInt64>(sbarH,
-      -PixelWidthBeforeTime(0.0),
-      sbarTotal - PixelWidthBeforeTime(0.0) - sbarScreen);
+   sbarH = std::clamp<wxInt64>(
+      sbarH, -PixelWidthBeforeTime(0.0),
+      std::max(sbarTotal - PixelWidthBeforeTime(0.0) - sbarScreen, 0.));
 
    if (doScroll)
       DoScroll();

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -105,11 +105,26 @@ struct CentShiftChange
    const int newValue;
 };
 
+struct StretchRatioChange
+{
+   explicit StretchRatioChange(double newValue)
+       : newValue(newValue)
+   {
+   }
+   const double newValue;
+};
+
+struct WaveClipDtorCalled
+{
+};
+
 class WAVE_TRACK_API WaveClip final :
     public ClipInterface,
     public XMLTagHandler,
     public ClientData::Site<WaveClip, WaveClipListener>,
-    public Observer::Publisher<CentShiftChange>
+    public Observer::Publisher<CentShiftChange>,
+    public Observer::Publisher<StretchRatioChange>,
+    public Observer::Publisher<WaveClipDtorCalled>
 {
 private:
    // It is an error to copy a WaveClip without specifying the

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -18,9 +18,9 @@ const TranslatableString WaveTrackUtilities::defaultStretchRenderingTitle =
    XO("Pre-processing");
 
 bool WaveTrackUtilities::HasPitchOrSpeed(
-   const WaveTrack &track, double t0, double t1)
+   const WaveTrack& track, double t0, double t1)
 {
-   auto &clips = track.GetClips();
+   auto& clips = track.GetClips();
    return any_of(clips.begin(), clips.end(), [&](auto& pClip) {
       return pClip->IntersectsPlayRegion(t0, t1) && pClip->HasPitchOrSpeed();
    });
@@ -61,4 +61,15 @@ bool WaveTrackUtilities::SetClipStretchRatio(
 
    interval.StretchRightTo(expectedEndTime);
    return true;
+}
+
+void WaveTrackUtilities::ExpandClipTillNextOne(
+   const WaveTrack& track, WaveTrack::Interval& interval)
+{
+   if (
+      const auto nextClip =
+         track.GetNextClip(*interval.GetClip(0), PlaybackDirection::forward))
+   {
+      interval.StretchRightTo(nextClip->GetPlayStartTime());
+   }
 }

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -19,12 +19,13 @@
 class WaveTrack;
 using ProgressReporter = std::function<void(double)>;
 
-namespace WaveTrackUtilities {
+namespace WaveTrackUtilities
+{
 
 //! Whether any clips, whose play regions intersect the interval, have non-unit
 //! stretch ratio
 WAVE_TRACK_API
-bool HasPitchOrSpeed(const WaveTrack &track, double t0, double t1);
+bool HasPitchOrSpeed(const WaveTrack& track, double t0, double t1);
 
 extern WAVE_TRACK_API const TranslatableString defaultStretchRenderingTitle;
 
@@ -35,4 +36,7 @@ WAVE_TRACK_API void WithClipRenderingProgress(
 
 WAVE_TRACK_API bool SetClipStretchRatio(
    const WaveTrack& track, WaveTrack::Interval& interval, double stretchRatio);
+
+WAVE_TRACK_API void
+ExpandClipTillNextOne(const WaveTrack& track, WaveTrack::Interval& interval);
 } // namespace WaveTrackUtilities

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -731,6 +731,7 @@ list( APPEND SOURCES
       tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.h
       tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
       tracks/playabletrack/wavetrack/ui/SampleHandle.h
+      tracks/playabletrack/wavetrack/ui/ShuttleGuiScopedSizer.h
       tracks/playabletrack/wavetrack/ui/SpectrumCache.cpp
       tracks/playabletrack/wavetrack/ui/SpectrumCache.h
       tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -317,7 +317,7 @@ AudacityProject *ProjectManager::New()
    bool bMaximized = false;
    bool bIconized = false;
    GetNextWindowPlacement(&wndRect, &bMaximized, &bIconized);
-   
+
    // Create and show a NEW project
    // Use a non-default deleter in the smart pointer!
    auto sp = AudacityProject::Create();
@@ -347,7 +347,7 @@ AudacityProject *ProjectManager::New()
 
    projectHistory.InitialState();
    projectManager.RestartTimer();
-   
+
    if(bMaximized) {
       window.Maximize(true);
    }
@@ -355,7 +355,7 @@ AudacityProject *ProjectManager::New()
       // if the user close down and iconized state we could start back up and iconized state
       // window.Iconize(TRUE);
    }
-   
+
    //Initialise the Listeners
    auto gAudioIO = AudioIO::Get();
    gAudioIO->SetListener(
@@ -363,15 +363,15 @@ AudacityProject *ProjectManager::New()
 
    //Set the NEW project as active:
    SetActiveProject(p);
-   
+
    // Okay, GetActiveProject() is ready. Now we can get its CommandManager,
    // and add the shortcut keys to the tooltips.
    ToolManager::Get( *p ).RegenerateTooltips();
-   
+
    ModuleManager::Get().Dispatch(ProjectInitialized);
-   
+
    window.Show(true);
-   
+
    return p;
 }
 
@@ -442,8 +442,8 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
 
    // We may not bother to prompt the user to save, if the
    // project is now empty.
-   if (!sbSkipPromptingForSave 
-      && event.CanVeto() 
+   if (!sbSkipPromptingForSave
+      && event.CanVeto()
       && (settings.EmptyCanBeDirty() || bHasTracks)) {
       if ( UndoManager::Get( project ).UnsavedChanges() ) {
          TitleRestorer Restorer( window, project );// RAII
@@ -766,7 +766,7 @@ void ProjectManager::OnTimer(wxTimerEvent& WXUNUSED(event))
 
    for (auto& meterToolBar : meterToolBars)
       meterToolBar.get().UpdateControls();
-   
+
    auto gAudioIO = AudioIO::Get();
    // gAudioIO->GetNumCaptureChannels() should only be positive
    // when we are recording.
@@ -804,7 +804,7 @@ void ProjectManager::OnStatusChange(StatusBarField field)
 
    const auto &msg = ProjectStatus::Get( project ).Get( field );
    SetStatusText( msg, field );
-   
+
    if ( field == mainStatusBarField )
       // When recording, let the NEW status message stay at least as long as
       // the timer interval (if it is not replaced again by this function),
@@ -862,7 +862,7 @@ int ProjectManager::GetEstimatedRecordingMinsLeftOnDisk(long lCaptureChannels) {
    double dRecTime = 0.0;
    double bytesOnDiskPerSample = SAMPLE_SIZE_DISK(oCaptureFormat);
    dRecTime = lFreeSpace.GetHi() * 4294967296.0 + lFreeSpace.GetLo();
-   dRecTime /= bytesOnDiskPerSample;   
+   dRecTime /= bytesOnDiskPerSample;
    dRecTime /= lCaptureChannels;
    dRecTime /= ProjectRate::Get( project ).GetRate();
 

--- a/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
@@ -143,14 +143,16 @@ UIHandle::Result ClipPitchAndSpeedButtonHandle::DoRelease(
    }
    else
    {
-      const auto focus = mType == Type::Pitch ?
-                            PitchAndSpeedDialogFocus::Pitch :
-                            PitchAndSpeedDialogFocus::Speed;
+      const auto focusedGroup = mType == Type::Pitch ?
+                                   PitchAndSpeedDialogGroup::Pitch :
+                                   PitchAndSpeedDialogGroup::Speed;
       BasicUI::CallAfter([project = pProject->weak_from_this(), track = mTrack,
-                          clip = mClip, focus] {
+                          clip = mClip, focusedGroup] {
          if (auto pProject = project.lock())
-            WaveClipUtilities::ShowClipPitchAndSpeedDialog(
-               *pProject, *track, *clip, focus);
+            PitchAndSpeedDialog::Get(*pProject)
+               .Retarget(track, clip)
+               .SetFocus(focusedGroup)
+               .Show();
       });
    }
    return RefreshCode::RefreshNone;

--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
@@ -19,6 +19,7 @@
 #include <wx/textctrl.h>
 
 #include "ShuttleGui.h"
+#include "ShuttleGuiScopedSizer.h"
 #include "SpinControl.h"
 #include "wxWidgetsWindowPlacement.h"
 
@@ -26,74 +27,6 @@
 
 namespace
 {
-template <typename ReturnType, typename... Args> class ScopedSizer
-{
-public:
-   ScopedSizer(
-      ShuttleGui& s, ReturnType (ShuttleGui::*startFunc)(Args...),
-      void (ShuttleGui::*endFunc)(), Args... args)
-       : mShuttleGui(s)
-       , mStartFunction(startFunc)
-       , mEndFunction(endFunc)
-   {
-      (mShuttleGui.*mStartFunction)(std::forward<Args>(args)...);
-   }
-
-   ~ScopedSizer()
-   {
-      (mShuttleGui.*mEndFunction)();
-   }
-
-private:
-   ShuttleGui& mShuttleGui;
-   ReturnType (ShuttleGui::*mStartFunction)(Args...);
-   void (ShuttleGui::*mEndFunction)();
-};
-
-class ScopedHorizontalLay : public ScopedSizer<void, int, int>
-{
-public:
-   ScopedHorizontalLay(
-      ShuttleGui& s, int PositionFlags = wxALIGN_CENTRE, int iProp = 1)
-       : ScopedSizer<void, int, int>(
-            s, &ShuttleGui::StartHorizontalLay, &ShuttleGui::EndHorizontalLay,
-            PositionFlags, iProp)
-   {
-   }
-};
-
-class ScopedInvisiblePanel : public ScopedSizer<wxPanel*, int>
-{
-public:
-   ScopedInvisiblePanel(ShuttleGui& s, int border = 0)
-       : ScopedSizer<wxPanel*, int>(
-            s, &ShuttleGui::StartInvisiblePanel, &ShuttleGui::EndInvisiblePanel,
-            border)
-   {
-   }
-};
-
-class ScopedVerticalLay : public ScopedSizer<void, int>
-{
-public:
-   ScopedVerticalLay(ShuttleGui& s, int iProp = 1)
-       : ScopedSizer<void, int>(
-            s, &ShuttleGui::StartVerticalLay, &ShuttleGui::EndVerticalLay,
-            iProp)
-   {
-   }
-};
-
-class ScopedStatic :
-    public ScopedSizer<wxStaticBox*, const TranslatableString&, int>
-{
-public:
-   ScopedStatic(ShuttleGui& s, const TranslatableString& label, int iProp = 0)
-       : ScopedSizer<wxStaticBox*, const TranslatableString&, int>(
-            s, &ShuttleGui::StartStatic, &ShuttleGui::EndStatic, label, iProp)
-   {
-   }
-};
 
 //! Returns true if and only if `output` was updated.
 auto GetInt(const wxCommandEvent& event, int& output)

--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
@@ -9,9 +9,21 @@
 
  **********************************************************************/
 #include "PitchAndSpeedDialog.h"
+#include "AudioIO.h"
+#include "Project.h"
+#include "ProjectAudioIO.h"
+#include "ProjectHistory.h"
+#include "ProjectWindow.h"
+#include "ProjectWindows.h"
 #include "TimeAndPitchInterface.h"
+#include "TrackPanel.h"
+#include "TrackPanelMouseEvent.h"
+#include "UndoManager.h"
+#include "ViewInfo.h"
+#include "WaveClip.h"
 #include "WaveClipUtilities.h"
 #include "WaveTrackUtilities.h"
+#include "WindowAccessible.h"
 
 #include <wx/button.h>
 #include <wx/layout.h>
@@ -27,80 +39,243 @@
 
 namespace
 {
+constexpr auto semitoneCtrlId = wxID_HIGHEST + 1;
+constexpr auto speedCtrlId = wxID_HIGHEST + 3;
 
-//! Returns true if and only if `output` was updated.
-auto GetInt(const wxCommandEvent& event, int& output)
+struct HitClip
 {
-   try
+   std::shared_ptr<WaveTrack> track;
+   std::shared_ptr<WaveTrack::Interval> clip;
+};
+
+std::optional<HitClip>
+GetHitClip(AudacityProject& project, const TrackPanelMouseEvent& event)
+{
+   const auto pos = event.event.GetPosition();
+   const auto& viewInfo = ViewInfo::Get(project);
+   const auto t = viewInfo.PositionToTime(pos.x, event.rect.GetX());
+   auto& trackPanel = TrackPanel::Get(project);
+   for (auto leader : TrackList::Get(project).Any<WaveTrack>())
    {
-      const auto str = event.GetString().ToStdString();
-      if (str.empty() || str == "-")
+      const auto trackRect = trackPanel.FindTrackRect(leader);
+      if (!trackRect.Contains(pos))
+         continue;
+      auto [begin, end] = leader->Intervals();
+      while (begin != end)
       {
-         output = 0;
-         return true;
+         auto clip = *begin++;
+         if (clip->WithinPlayRegion(t))
+            return HitClip { std::static_pointer_cast<WaveTrack>(
+                                leader->SharedPointer()),
+                             clip };
       }
-      // Exact integer match
-      if (!std::regex_match(str, std::regex { "^-?[0-9]+$" }))
-         return false;
-      output = std::stoi(str);
-      return true;
    }
-   catch (const std::exception&)
-   {
-      return false;
-   }
+   return {};
 }
+
+PitchAndSpeedDialog::PitchShift ToSemitonesAndCents(int oldCents, int newCents)
+{
+   // Rules:
+   // 1. cents must be in the range [-100, 100]
+   // 2. on semitone updates, keep semitone and cent sign consistent
+
+   PitchAndSpeedDialog::PitchShift shift { 0, newCents };
+   while (shift.cents <= -100)
+   {
+      --shift.semis;
+      shift.cents += 100;
+   }
+   while (shift.cents >= 100)
+   {
+      ++shift.semis;
+      shift.cents -= 100;
+   }
+
+   const auto onlySemitonesChanged = [](int oldCents, int newCents) {
+      while (oldCents < 0)
+         oldCents += 100;
+      while (newCents < 0)
+         newCents += 100;
+      return oldCents / 100 != newCents / 100;
+   }(oldCents, newCents);
+
+   if (onlySemitonesChanged && shift.cents > 0 && shift.semis < 0)
+      return { shift.semis + 1, shift.cents - 100 };
+   else if (onlySemitonesChanged && shift.cents < 0 && shift.semis > 0)
+      return { shift.semis - 1, shift.cents + 100 };
+   else
+      return shift;
+}
+
+void ClampPitchShift(PitchAndSpeedDialog::PitchShift& shift)
+{
+   static_assert(TimeAndPitchInterface::MaxCents % 100 == 0);
+   static_assert(TimeAndPitchInterface::MinCents % 100 == 0);
+   const auto cents = shift.semis * 100 + shift.cents;
+   if (cents > TimeAndPitchInterface::MaxCents)
+      shift = { TimeAndPitchInterface::MaxCents / 100, 0 };
+   else if (cents < TimeAndPitchInterface::MinCents)
+      shift = { TimeAndPitchInterface::MinCents / 100, 0 };
+}
+
+PitchAndSpeedDialog::PitchShift GetClipShift(const WaveClip& clip)
+{
+   const auto totalShift = clip.GetCentShift();
+   return { totalShift / 100, totalShift % 100 };
+}
+
+static const AttachedWindows::RegisteredFactory key {
+   [](AudacityProject& project) -> wxWeakRef<wxWindow> {
+      return safenew PitchAndSpeedDialog(project);
+   }
+};
 } // namespace
 
-PitchAndSpeedDialog::PitchAndSpeedDialog(
-   std::weak_ptr<AudacityProject> project, bool playbackOngoing,
-   WaveTrack& waveTrack, WaveTrack::Interval& interval, wxWindow* parent,
-   const std::optional<PitchAndSpeedDialogFocus>& focus)
+PitchAndSpeedDialog& PitchAndSpeedDialog::Get(AudacityProject& project)
+{
+   return GetAttachedWindows(project).Get<PitchAndSpeedDialog>(key);
+}
+
+const PitchAndSpeedDialog&
+PitchAndSpeedDialog::Get(const AudacityProject& project)
+{
+   return Get(const_cast<AudacityProject&>(project));
+}
+
+void PitchAndSpeedDialog::Destroy(AudacityProject& project)
+{
+   auto& attachedWindows = GetAttachedWindows(project);
+   auto* pPanel = attachedWindows.Find(key);
+   if (pPanel)
+   {
+      pPanel->wxWindow::Destroy();
+      attachedWindows.Assign(key, nullptr);
+   }
+}
+
+PitchAndSpeedDialog::PitchAndSpeedDialog(AudacityProject& project)
     : wxDialogWrapper(
-         parent, wxID_ANY, XO("Pitch and Speed"), wxDefaultPosition,
+         nullptr, wxID_ANY, XO("Pitch and Speed"), wxDefaultPosition,
          { 480, 250 }, wxDEFAULT_DIALOG_STYLE)
     , mProject { project }
-    , mPlaybackOngoing { playbackOngoing }
-    , mTrack { waveTrack }
-    , mTrackInterval { interval }
-    , mClipSpeed { 100.0 / interval.GetStretchRatio() }
-    , mOldClipSpeed { mClipSpeed }
+    , mProjectCloseSubscription { ProjectWindow::Get(mProject).Subscribe(
+         [this](ProjectWindowDestroyedMessage) { Destroy(mProject); }) }
+    , mTitle { GetTitle() }
 {
-   const auto totalShift = mTrackInterval.GetCentShift();
-   mShift.cents = totalShift % 100;
-   mShift.semis = (totalShift - mShift.cents) / 100;
+   Bind(wxEVT_CLOSE_WINDOW, [this](const auto&) { Show(false); });
+
+   Bind(wxEVT_CHAR_HOOK, [this](wxKeyEvent& event) {
+      if (event.GetKeyCode() == WXK_ESCAPE)
+         Show(false);
+      else
+         event.Skip();
+   });
+
+   if (const auto audioIo = AudioIO::Get())
+   {
+      mAudioIOSubscription =
+         audioIo->Subscribe([this](const AudioIOEvent& event) {
+            if (event.pProject != &mProject)
+               return;
+            switch (event.type)
+            {
+            case AudioIOEvent::CAPTURE:
+            case AudioIOEvent::PLAYBACK:
+               if (const auto child = wxDialog::FindWindowById(speedCtrlId))
+                  child->Enable(!event.on);
+               break;
+            case AudioIOEvent::MONITOR:
+               break;
+            default:
+               // Unknown event type
+               assert(false);
+            }
+         });
+   }
+}
+
+void PitchAndSpeedDialog::TryRetarget(const TrackPanelMouseEvent& event)
+{
+   const auto target = GetHitClip(mProject, event);
+   if (!target.has_value() || target->clip->GetClip(0) == mLeftClip.lock())
+      return;
+   Retarget(target->track, target->clip);
+}
+
+PitchAndSpeedDialog& PitchAndSpeedDialog::Retarget(
+   const std::shared_ptr<WaveTrack>& track,
+   const WaveTrack::IntervalHolder& clip)
+{
+   mConsolidateHistory = false;
+   wxDialog::SetTitle(mTitle + " - " + clip->GetName());
+   const auto leftClip = clip->GetClip(0);
+   mClipDeletedSubscription =
+      leftClip->Observer::Publisher<WaveClipDtorCalled>::Subscribe(
+         [this](WaveClipDtorCalled) { Show(false); });
+   mClipCentShiftChangeSubscription =
+      leftClip->Observer::Publisher<CentShiftChange>::Subscribe(
+         [this](const CentShiftChange& cents) {
+            mShift = ToSemitonesAndCents(
+               mShift.semis * 100 + mShift.cents, cents.newValue);
+            UpdateDialog();
+         });
+   mClipSpeedChangeSubscription =
+      leftClip->Observer::Publisher<StretchRatioChange>::Subscribe(
+         [this](const StretchRatioChange& stretchRatio) {
+            mClipSpeed = 100.0 / stretchRatio.newValue;
+            UpdateDialog();
+         });
+
+   mTrack = track;
+   mLeftClip = leftClip;
+   mRightClip = clip->GetClip(1);
+   mClipSpeed = 100.0 / leftClip->GetStretchRatio();
+   mOldClipSpeed = mClipSpeed;
+   mShift = GetClipShift(*leftClip);
    mOldShift = mShift;
 
-   ShuttleGui s(this, eIsCreating);
+   ShuttleGui s(this, mFirst ? eIsCreating : eIsSettingToDialog);
 
    {
       ScopedVerticalLay v { s };
-      PopulateOrExchange(s, focus);
+      PopulateOrExchange(s);
    }
 
-   // TODO: Tolerance?
-   // Stretch ratio of
-   assert(mOldClipSpeed > 0.0);
+   if (mFirst)
+   {
+      Layout();
+      Fit();
+      Centre();
+      mFirst = false;
+   }
 
-   Layout();
-   Fit();
-   Centre();
-
-   Bind(wxEVT_CHAR_HOOK, [this](auto& evt) {
-      if (!IsEscapeKey(evt))
-      {
-         evt.Skip();
-         return;
-      }
-
-      OnCancel();
-   });
+   return *this;
 }
 
-PitchAndSpeedDialog::~PitchAndSpeedDialog() = default;
+PitchAndSpeedDialog& PitchAndSpeedDialog::SetFocus(
+   const std::optional<PitchAndSpeedDialogGroup>& group)
+{
 
-void PitchAndSpeedDialog::PopulateOrExchange(
-   ShuttleGui& s, const std::optional<PitchAndSpeedDialogFocus>& focus)
+   const auto item =
+      group.has_value() ?
+         wxWindow::FindWindowById(
+            *group == PitchAndSpeedDialogGroup::Pitch ? semitoneCtrlId :
+                                                        speedCtrlId,
+            this) :
+         nullptr;
+   if (item)
+      item->SetFocus();
+   wxDialog::SetFocus();
+   return *this;
+}
+
+PitchAndSpeedDialog& PitchAndSpeedDialog::Show()
+{
+   Show(true);
+   return *this;
+}
+
+void PitchAndSpeedDialog::PopulateOrExchange(ShuttleGui& s)
 {
    {
       ScopedInvisiblePanel panel { s, 15 };
@@ -112,43 +287,36 @@ void PitchAndSpeedDialog::PopulateOrExchange(
             s.SetBorder(2);
             // Use `TieSpinCtrl` rather than `AddSpinCtrl`, too see updates
             // instantly when `UpdateDialog` is called.
-            s.TieSpinCtrl(
-                XO("semitones:"), mShift.semis,
-                TimeAndPitchInterface::MaxCents / 100,
-                TimeAndPitchInterface::MinCents / 100)
-               ->Bind(wxEVT_TEXT, [&](wxCommandEvent& event) {
+            s.Id(semitoneCtrlId)
+               .TieSpinCtrl(
+                  XO("semitones:"), mShift.semis,
+                  TimeAndPitchInterface::MaxCents / 100,
+                  TimeAndPitchInterface::MinCents / 100)
+               ->Bind(wxEVT_SPINCTRL, [this](wxSpinEvent& event) {
                   const auto prevSemis = mShift.semis;
-                  if (GetInt(event, mShift.semis))
+                  mShift.semis = event.GetInt();
+                  // If we have e.g. -3 semi, -1 cents, and the user
+                  // changes the sign of the semitones, the logic in
+                  // `SetSemitoneShift` would result in 2 semi, 99
+                  // cents. If the user changes sign again, we would now
+                  // get 1 semi, -1 cents. Mirrorring (e.g. -3 semi, -1
+                  // cents -> 3 semi, 1 cents) is not a good idea because
+                  // that would ruin the work of users painstakingly
+                  // adjusting the cents of an instrument. So instead, we
+                  // map -3 semi, -1 cents to 3 semi, 99 cents.
+                  if (mShift.cents != 0)
                   {
-                     // If we have e.g. -3 semi, -1 cents, and the user changes
-                     // the sign of the semitones, the logic in
-                     // `OnPitchShiftChange` would result in 2 semi, 99 cents.
-                     // If the user changes sign again, we would now get 1 semi,
-                     // -1 cents. Mirrorring (e.g. -3 semi, -1 cents -> 3 semi,
-                     // 1 cents) is not a good idea because that would ruin the
-                     // work of users painstakingly adjusting the cents of an
-                     // instrument. So instead, we map -3 semi, -1 cents to 3
-                     // semi, 99 cents.
-                     if (mShift.cents != 0)
-                     {
-                        if (prevSemis < 0 && mShift.semis > 0)
-                           ++mShift.semis;
-                        else if (prevSemis > 0 && mShift.semis < 0)
-                           --mShift.semis;
-                     }
-                     OnPitchShiftChange(true);
+                     if (prevSemis < 0 && mShift.semis > 0)
+                        ++mShift.semis;
+                     else if (prevSemis > 0 && mShift.semis < 0)
+                        --mShift.semis;
                   }
-                  else
-                     // Something silly was entered; reset dialog
-                     UpdateDialog();
+                  SetSemitoneShift();
                });
             s.TieSpinCtrl(XO("cents:"), mShift.cents, 100, -100)
-               ->Bind(wxEVT_TEXT, [&](wxCommandEvent& event) {
-                  if (GetInt(event, mShift.cents))
-                     OnPitchShiftChange(false);
-                  else
-                     // Something silly was entered; reset dialog
-                     UpdateDialog();
+               ->Bind(wxEVT_SPINCTRL, [this](wxSpinEvent& event) {
+                  mShift.cents = event.GetInt();
+                  SetSemitoneShift();
                });
          }
       }
@@ -160,130 +328,46 @@ void PitchAndSpeedDialog::PopulateOrExchange(
          ScopedStatic scopedStatic { s, XO("Clip Speed") };
          {
             ScopedHorizontalLay h { s, wxLeft };
-            auto txtCtrl = s.Name(XO("Clip Speed"))
-                              .NameSuffix(Verbatim("%"))
-                              .TieNumericTextBox({}, mClipSpeed, 14, true);
-            txtCtrl->Enable(!mPlaybackOngoing);
-            if (focus.has_value() && *focus == PitchAndSpeedDialogFocus::Speed)
-               txtCtrl->SetFocus();
-            if (!mPlaybackOngoing)
-            {
-               txtCtrl->Bind(wxEVT_TEXT_ENTER, [this](auto&) { OnOk(); });
-               txtCtrl->Bind(wxEVT_TEXT, [this](wxCommandEvent& event) {
-                  try
-                  {
-                     mClipSpeed = std::stod(event.GetString().ToStdString());
-                  }
-                  catch (const std::exception&)
-                  {
-                     // Something silly was entered; reset dialog
-                     UpdateDialog();
-                  }
+            const auto txtCtrl =
+               s.Id(speedCtrlId)
+                  .Name(XO("Clip Speed"))
+                  .TieSpinControl(
+                     wxSize(60, -1), XO("speed %: "), mClipSpeed, 1000.0, 1.0);
+#if wxUSE_ACCESSIBILITY
+            txtCtrl->SetAccessible(safenew WindowAccessible(txtCtrl));
+#endif
+            const auto playbackOngoing =
+               ProjectAudioIO::Get(mProject).IsAudioActive();
+            txtCtrl->Enable(!playbackOngoing);
+            txtCtrl->Bind(
+               wxEVT_SPINCTRL, [this, txtCtrl](wxCommandEvent& event) {
+                  mClipSpeed = txtCtrl->GetValue();
+                  if (!SetClipSpeed())
+                     if (auto target = LockTarget())
+                     {
+                        WaveTrackUtilities::ExpandClipTillNextOne(
+                           *target->track, target->clip);
+                        UpdateDialog();
+                     }
                });
-            }
-            s.AddFixedText(Verbatim("%"));
          }
       }
    }
-
-   ScopedHorizontalLay h { s, wxEXPAND, 0 };
-   {
-      ScopedInvisiblePanel panel { s, 10 };
-      s.SetBorder(2);
-      {
-         ScopedHorizontalLay h { s, wxALIGN_RIGHT, 0 };
-         s.AddSpace(270, 0, 0);
-         s.AddButton(XXO("&Cancel"))->Bind(wxEVT_BUTTON, [this](auto&) {
-            OnCancel();
-         });
-         auto okBtn = s.AddButton(XXO("&Ok"));
-         okBtn->Bind(wxEVT_BUTTON, [this](auto&) { OnOk(); });
-         okBtn->SetDefault();
-      }
-   }
 }
 
-void PitchAndSpeedDialog::OnOk()
+bool PitchAndSpeedDialog::SetClipSpeed()
 {
-   SetSemitoneShift();
-   if (SetClipSpeedFromDialog())
-      EndModal(wxID_OK);
-}
-
-void PitchAndSpeedDialog::OnCancel()
-{
-   mShift = mOldShift;
-   SetSemitoneShift();
-   EndModal(wxID_CANCEL);
-}
-
-bool PitchAndSpeedDialog::SetClipSpeedFromDialog()
-{
-   {
-      ShuttleGui S(this, eIsGettingFromDialog);
-      PopulateOrExchange(S);
-   }
-
-   if (mClipSpeed <= 0.0)
-   {
-      BasicUI::ShowErrorDialog(
-         /* i18n-hint: Title of an error message shown, when invalid clip speed
-            is set */
-         wxWidgetsWindowPlacement { this }, XO("Invalid clip speed"),
-         XO("Clip speed must be a positive value"), {});
-
+   auto target = LockTarget();
+   if (!target)
       return false;
-   }
 
    if (!WaveTrackUtilities::SetClipStretchRatio(
-          mTrack, mTrackInterval, 100 / mClipSpeed))
-   {
-      BasicUI::ShowErrorDialog(
-         wxWidgetsWindowPlacement { this }, XO("Invalid clip speed"),
-         XO("There is not enough space to stretch the clip to the selected speed"),
-         {});
-
+          *target->track, target->clip, 100 / mClipSpeed))
       return false;
-   }
-   else if (const auto project = mProject.lock())
-      WaveClipUtilities::SelectClip(*project, mTrackInterval);
 
-   {
-      ShuttleGui S(this, eIsSettingToDialog);
-      PopulateOrExchange(S);
-   }
+   UpdateHistory(XO("Changed Speed"));
 
    return true;
-}
-
-void PitchAndSpeedDialog::OnPitchShiftChange(bool semitonesChanged)
-{
-   // Rules:
-   // 1. total shift is clipped to [minSemis, maxSemis]
-   // 2. cents must be in the range [-100, 100]
-   // 3. on semitone updates, keep semitone and cent sign consistent
-   const auto newCentShift = mShift.semis * 100 + mShift.cents;
-   static_assert(TimeAndPitchInterface::MaxCents % 100 == 0);
-   static_assert(TimeAndPitchInterface::MinCents % 100 == 0);
-   std::optional<PitchShift> correctedShift;
-   if (newCentShift > TimeAndPitchInterface::MaxCents)
-      correctedShift = PitchShift { TimeAndPitchInterface::MaxCents / 100, 0 };
-   else if (newCentShift < TimeAndPitchInterface::MinCents)
-      correctedShift = PitchShift { TimeAndPitchInterface::MinCents / 100, 0 };
-   else if (mShift.cents == 100)
-      correctedShift = PitchShift { mShift.semis + 1, 0 };
-   else if (mShift.cents == -100)
-      correctedShift = PitchShift { mShift.semis - 1, 0 };
-   else if (semitonesChanged && mShift.cents > 0 && mShift.semis < 0)
-      correctedShift = PitchShift { mShift.semis + 1, mShift.cents - 100 };
-   else if (semitonesChanged && mShift.cents < 0 && mShift.semis > 0)
-      correctedShift = PitchShift { mShift.semis - 1, mShift.cents + 100 };
-
-   if (correctedShift.has_value())
-      mShift = *correctedShift;
-   SetSemitoneShift();
-   if (correctedShift.has_value())
-      UpdateDialog();
 }
 
 void PitchAndSpeedDialog::UpdateDialog()
@@ -292,9 +376,33 @@ void PitchAndSpeedDialog::UpdateDialog()
    PopulateOrExchange(S);
 }
 
+void PitchAndSpeedDialog::UpdateHistory(const TranslatableString& desc)
+{
+   ProjectHistory::Get(mProject).PushState(
+      desc, desc, mConsolidateHistory ? UndoPush::CONSOLIDATE : UndoPush::NONE);
+   mConsolidateHistory = true;
+}
+
+std::optional<PitchAndSpeedDialog::StrongTarget>
+PitchAndSpeedDialog::LockTarget()
+{
+   if (const auto track = mTrack.lock())
+      if (const auto leftClip = mLeftClip.lock())
+         return StrongTarget {
+            track, WaveTrack::Interval { *track, leftClip, mRightClip.lock() }
+         };
+   return {};
+}
+
 void PitchAndSpeedDialog::SetSemitoneShift()
 {
+   auto target = LockTarget();
+   if (!target)
+      return;
+   ClampPitchShift(mShift);
    const auto success =
-      mTrackInterval.SetCentShift(mShift.semis * 100 + mShift.cents);
+      target->clip.SetCentShift(mShift.semis * 100 + mShift.cents);
    assert(success);
+   TrackPanel::Get(mProject).RefreshTrack(target->track.get());
+   UpdateHistory(XO("Changed Pitch"));
 }

--- a/src/tracks/playabletrack/wavetrack/ui/ShuttleGuiScopedSizer.h
+++ b/src/tracks/playabletrack/wavetrack/ui/ShuttleGuiScopedSizer.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "ShuttleGui.h"
+
+template <typename ReturnType, typename... Args> class ScopedSizer
+{
+public:
+   ScopedSizer(
+      ShuttleGui& s, ReturnType (ShuttleGui::*startFunc)(Args...),
+      void (ShuttleGui::*endFunc)(), Args... args)
+       : mShuttleGui(s)
+       , mStartFunction(startFunc)
+       , mEndFunction(endFunc)
+   {
+      (mShuttleGui.*mStartFunction)(std::forward<Args>(args)...);
+   }
+
+   ~ScopedSizer()
+   {
+      (mShuttleGui.*mEndFunction)();
+   }
+
+private:
+   ShuttleGui& mShuttleGui;
+   ReturnType (ShuttleGui::*mStartFunction)(Args...);
+   void (ShuttleGui::*mEndFunction)();
+};
+
+class ScopedHorizontalLay : public ScopedSizer<void, int, int>
+{
+public:
+   ScopedHorizontalLay(
+      ShuttleGui& s, int PositionFlags = wxALIGN_CENTRE, int iProp = 1)
+       : ScopedSizer<void, int, int>(
+            s, &ShuttleGui::StartHorizontalLay, &ShuttleGui::EndHorizontalLay,
+            PositionFlags, iProp)
+   {
+   }
+};
+
+class ScopedInvisiblePanel : public ScopedSizer<wxPanel*, int>
+{
+public:
+   ScopedInvisiblePanel(ShuttleGui& s, int border = 0)
+       : ScopedSizer<wxPanel*, int>(
+            s, &ShuttleGui::StartInvisiblePanel, &ShuttleGui::EndInvisiblePanel,
+            border)
+   {
+   }
+};
+
+class ScopedVerticalLay : public ScopedSizer<void, int>
+{
+public:
+   ScopedVerticalLay(ShuttleGui& s, int iProp = 1)
+       : ScopedSizer<void, int>(
+            s, &ShuttleGui::StartVerticalLay, &ShuttleGui::EndVerticalLay,
+            iProp)
+   {
+   }
+};
+
+class ScopedStatic :
+    public ScopedSizer<wxStaticBox*, const TranslatableString&, int>
+{
+public:
+   ScopedStatic(ShuttleGui& s, const TranslatableString& label, int iProp = 0)
+       : ScopedSizer<wxStaticBox*, const TranslatableString&, int>(
+            s, &ShuttleGui::StartStatic, &ShuttleGui::EndStatic, label, iProp)
+   {
+   }
+};

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -25,19 +25,20 @@ Paul Licameli split from TrackPanel.cpp
 #include "../../../../../images/Cursors.h"
 #include "AllThemeResources.h"
 
-#include "CommandContext.h"
 #include "../../../../HitTestResult.h"
-#include "ProjectHistory.h"
 #include "../../../../RefreshCode.h"
-#include "SyncLock.h"
 #include "../../../../TrackArtist.h"
 #include "../../../../TrackPanel.h"
-#include "TrackFocus.h"
 #include "../../../../TrackPanelDrawingContext.h"
 #include "../../../../TrackPanelMouseEvent.h"
 #include "../../../../TrackPanelResizeHandle.h"
-#include "ViewInfo.h"
 #include "../../../../prefs/TracksPrefs.h"
+#include "CommandContext.h"
+#include "PitchAndSpeedDialog.h"
+#include "ProjectHistory.h"
+#include "SyncLock.h"
+#include "TrackFocus.h"
+#include "ViewInfo.h"
 
 #include "../../../ui/TimeShiftHandle.h"
 #include "../../../ui/ButtonHandle.h"
@@ -1191,6 +1192,10 @@ bool WaveChannelView::SelectNextClip(
    // create and send message to screen reader
    auto it = std::find(clips.begin(), clips.end(), clip);
    auto index = std::distance(clips.begin(), it);
+
+   auto wideClipIt = waveTrack->Intervals().first;
+   std::advance(wideClipIt, waveTrack->GetClipIndex(clip));
+   PitchAndSpeedDialog::Get(*project).Retarget(waveTrack, *wideClipIt);
 
    auto message = XP(
    /* i18n-hint:

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.cpp
@@ -10,10 +10,7 @@
 
 #include "WaveClipUtilities.h"
 #include "PitchAndSpeedDialog.h"
-#include "Project.h"
-#include "ProjectAudioIO.h"
 #include "ProjectHistory.h"
-#include "ProjectWindows.h"
 #include "SampleCount.h"
 #include "UndoManager.h"
 #include "ViewInfo.h"
@@ -107,19 +104,6 @@ void WaveClipUtilities::PushClipSpeedChangedUndoState(
          percent */
       XO("Changed Speed to %.01f%%").Format(speedInPercent),
       UndoPush::CONSOLIDATE);
-}
-
-void WaveClipUtilities::ShowClipPitchAndSpeedDialog(
-   AudacityProject& project, WaveTrack& track, WaveTrack::Interval& interval,
-   std::optional<PitchAndSpeedDialogFocus> focus)
-{
-   PitchAndSpeedDialog dlg(
-      project.weak_from_this(), ProjectAudioIO::Get(project).IsAudioActive(),
-      track, interval, &GetProjectFrame(project), focus);
-   if (wxID_OK == dlg.ShowModal())
-      ProjectHistory::Get(project).PushState(
-         XO("Changed Pitch and Speed"), XO("Changed Pitch and Speed"),
-         UndoPush::CONSOLIDATE);
 }
 
 void WaveClipUtilities::SelectClip(

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipUtilities.h
@@ -37,11 +37,8 @@ void fillWhere(
 
 std::vector<CommonTrackPanelCell::MenuItem> GetWaveClipMenuItems();
 
-void PushClipSpeedChangedUndoState(AudacityProject& project, double speedInPercent);
-
-void ShowClipPitchAndSpeedDialog(
-   AudacityProject& project, WaveTrack& track, WaveTrack::Interval& interval,
-   std::optional<PitchAndSpeedDialogFocus> focus = {});
+void PushClipSpeedChangedUndoState(
+   AudacityProject& project, double speedInPercent);
 
 void SelectClip(AudacityProject& project, const WaveTrack::Interval& clip);
 } // namespace WaveClipUtilities

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -408,22 +408,31 @@ auto FindAffordance(WaveTrack &track)
       pAffordance );
 }
 
-std::pair<WaveTrack*, ChannelGroup::IntervalIterator<WaveTrack::Interval>>
-SelectedIntervalOfFocusedTrack(AudacityProject &project)
+std::pair<std::shared_ptr<WaveTrack>, ChannelGroup::IntervalIterator<WaveTrack::Interval>>
+SelectedIntervalOfFocusedTrack(AudacityProject &project, bool wholeInterval = true)
 {
    // Note that TrackFocus may change its state as a side effect, defining
    // a track focus if there was none
-   if (auto pWaveTrack =
-      dynamic_cast<WaveTrack *>(TrackFocus::Get(project).Get())) {
+   auto track = TrackFocus::Get(project).Get();
+   if (!track)
+      return {};
+   if (
+      auto pWaveTrack =
+         std::dynamic_pointer_cast<WaveTrack>(track->shared_from_this()))
+   {
       if (FindAffordance(*pWaveTrack)) {
          auto &viewInfo = ViewInfo::Get(project);
          auto intervals = pWaveTrack->Intervals();
 
-         auto it = std::find_if(intervals.begin(), intervals.end(), [&](const auto& interval)
-         {
-            return interval->Start() == viewInfo.selectedRegion.t0() &&
-               interval->End() == viewInfo.selectedRegion.t1();
-         });
+         auto it = std::find_if(
+            intervals.begin(), intervals.end(), [&](const auto& interval) {
+               if (wholeInterval)
+                  return interval->Start() == viewInfo.selectedRegion.t0() &&
+                         interval->End() == viewInfo.selectedRegion.t1();
+               else
+                  return interval->Start() <= viewInfo.selectedRegion.t0() &&
+                         interval->End() > viewInfo.selectedRegion.t0();
+            });
 
          if(it != intervals.end())
             return { pWaveTrack, it };
@@ -629,7 +638,7 @@ unsigned WaveTrackAffordanceControls::OnAffordanceClick(const TrackPanelMouseEve
 void WaveTrackAffordanceControls::StartEditSelectedClipName(AudacityProject& project)
 {
    auto [track, it] = SelectedIntervalOfFocusedTrack(project);
-   if(track != FindTrack().get())
+   if(track != FindTrack())
       return;
    StartEditClipName(project, it);
 }
@@ -637,9 +646,10 @@ void WaveTrackAffordanceControls::StartEditSelectedClipName(AudacityProject& pro
 void WaveTrackAffordanceControls::StartEditSelectedClipSpeed(
    AudacityProject& project)
 {
-   auto [track, it] = SelectedIntervalOfFocusedTrack(project);
+   constexpr auto wholeInterval = false;
+   auto [track, it] = SelectedIntervalOfFocusedTrack(project, wholeInterval);
 
-   if (track != FindTrack().get())
+   if (track != FindTrack())
       return;
 
    auto interval = *it;
@@ -655,7 +665,7 @@ void WaveTrackAffordanceControls::OnRenderClipStretching(
 {
    const auto [track, it] = SelectedIntervalOfFocusedTrack(project);
 
-   if (track != FindTrack().get())
+   if (track != FindTrack())
       return;
 
    auto interval = *it;
@@ -776,7 +786,7 @@ AttachedItem sAttachment{
 AttachedItem sAttachment2 {
    Command(
       L"ChangePitchAndSpeed", XXO("&Pitch and Speed..."), OnChangePitchAndSpeed,
-      SomeClipIsSelectedFlag(), Options { wxT("Ctrl+Shift+P") }),
+      AlwaysEnabledFlag, Options { wxT("Ctrl+Shift+P") }),
    wxT("Edit/Other/Clip")
 };
 

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceControls.cpp
@@ -52,6 +52,7 @@
 #include "ClipOverflowButtonHandle.h"
 #include "ClipPitchAndSpeedButtonHandle.h"
 #include "LowlitClipButton.h"
+#include "PitchAndSpeedDialog.h"
 #include "WaveClipAdjustBorderHandle.h"
 #include "WaveClipUtilities.h"
 
@@ -657,7 +658,10 @@ void WaveTrackAffordanceControls::StartEditSelectedClipSpeed(
    if (!interval)
       return;
 
-   WaveClipUtilities::ShowClipPitchAndSpeedDialog(project, *track, *interval);
+   PitchAndSpeedDialog::Get(project)
+      .Retarget(track, interval)
+      .Show()
+      .SetFocus({});
 }
 
 void WaveTrackAffordanceControls::OnRenderClipStretching(

--- a/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveTrackAffordanceHandle.cpp
@@ -13,10 +13,11 @@
 #include "WaveChannelView.h"
 #include "ViewInfo.h"
 
-#include "WaveClip.h"
 #include "../../../../RefreshCode.h"
 #include "../../../../TrackPanelMouseEvent.h"
+#include "PitchAndSpeedDialog.h"
 #include "ProjectHistory.h"
+#include "WaveClip.h"
 
 #include <wx/event.h>
 
@@ -66,6 +67,7 @@ bool WaveTrackAffordanceHandle::HandlesRightClick()
 UIHandle::Result WaveTrackAffordanceHandle::Release(const TrackPanelMouseEvent& event, AudacityProject* pProject, wxWindow* pParent)
 {
     auto result = AffordanceHandle::Release(event, pProject, pParent);
+    PitchAndSpeedDialog::Get(*pProject).TryRetarget(event);
 
     if (event.event.RightUp())
         result |= event.pCell->DoContextMenu(event.rect, pParent, nullptr, pProject);

--- a/src/tracks/ui/SelectHandle.cpp
+++ b/src/tracks/ui/SelectHandle.cpp
@@ -18,6 +18,7 @@ Paul Licameli split from TrackPanel.cpp
 #include "CommandManager.h"
 #include "../../SpectrumAnalyst.h"
 #include "../../LabelTrack.h"
+#include "../playabletrack/wavetrack/ui/PitchAndSpeedDialog.h"
 #include "NumberScale.h"
 #include "Project.h"
 #include "ProjectAudioIO.h"
@@ -301,9 +302,9 @@ namespace
        TranslatableString &tip, wxCursor *&pCursor)
    {
 
-      static auto adjustLeftSelectionCursor = 
+      static auto adjustLeftSelectionCursor =
          ::MakeCursor(wxCURSOR_POINT_LEFT, SelectionLeftXpm, 16, 16);
-      static auto adjustRightSelectionCursor = 
+      static auto adjustRightSelectionCursor =
          ::MakeCursor(wxCURSOR_POINT_RIGHT, SelectionRightXpm, 16, 16);
       static auto bottomFrequencyCursor =
          ::MakeCursor(wxCURSOR_ARROW, BottomFrequencyCursorXpm, 16, 16);
@@ -567,7 +568,7 @@ UIHandle::Result SelectHandle::Click(
    if ( selectChange )
       // Do not start a drag
       return RefreshAll | Cancelled;
-   
+
    auto &selectionState = SelectionState::Get( *pProject );
    if (event.LeftDClick() && !event.ShiftDown()) {
       // Deselect all other tracks and select this one.
@@ -867,7 +868,7 @@ UIHandle::Result SelectHandle::Drag
                   static_cast<WaveTrack*>(pTrack.get()),
                   viewInfo, y, mRect.y, mRect.height);
    #endif
-         
+
          AdjustSelection(pProject, viewInfo, x, mRect.x, clickedTrack.get());
       }
    }
@@ -931,7 +932,7 @@ HitTestPreview SelectHandle::Preview
             // No keyboard preference defined for opening Preferences dialog
             /* i18n-hint: These are the names of a menu and a command in that menu */
             keyStr = _("Edit, Preferences...");
-         
+
          /* i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac */
          tip = XO("Multi-Tool Mode: %s for Mouse and Keyboard Preferences.")
             .Format( keyStr );
@@ -995,10 +996,10 @@ HitTestPreview SelectHandle::Preview
    return { tip, pCursor };
 }
 
-UIHandle::Result SelectHandle::Release
-(const TrackPanelMouseEvent &, AudacityProject *pProject,
- wxWindow *)
+UIHandle::Result SelectHandle::Release(
+   const TrackPanelMouseEvent& event, AudacityProject* pProject, wxWindow*)
 {
+   PitchAndSpeedDialog::Get(*pProject).TryRetarget(event);
    using namespace RefreshCode;
    ProjectHistory::Get( *pProject ).ModifyState(false);
    mFrequencySnapper.reset();
@@ -1007,7 +1008,7 @@ UIHandle::Result SelectHandle::Release
       mSelectionStateChanger->Commit();
       mSelectionStateChanger.reset();
    }
-   
+
    if (mUseSnap && (mSnapStart.outCoord != -1 || mSnapEnd.outCoord != -1))
       return RefreshAll;
    else

--- a/src/widgets/MeterPanel.cpp
+++ b/src/widgets/MeterPanel.cpp
@@ -126,7 +126,7 @@ public:
    // Returns the rectangle for this object (id = 0) or a child element (id > 0).
    // rect is in screen coordinates.
    wxAccStatus GetLocation(wxRect& rect, int elementId) override;
-   
+
    // Returns a role constant.
    wxAccStatus GetRole(int childId, wxAccRole *role) override;
 
@@ -361,7 +361,7 @@ MeterPanel::MeterPanel(AudacityProject *project,
    wxColour backgroundColour = theTheme.Colour( clrMedium);
    mBkgndBrush = wxBrush(backgroundColour, wxBRUSHSTYLE_SOLID);
    SetBackgroundColour( backgroundColour );
-   
+
    mPeakPeakPen = wxPen(theTheme.Colour( clrMeterPeak),        1, wxPENSTYLE_SOLID);
    mDisabledPen = wxPen(theTheme.Colour( clrMeterDisabledPen), 1, wxPENSTYLE_SOLID);
 
@@ -650,7 +650,7 @@ void MeterPanel::OnPaint(wxPaintEvent & WXUNUSED(event))
                   if( (i%7)<2 ){
                      AColor::Line( dc, i+r.x, r.y, i+r.x, r.y+r.height );
                   } else {
-                     // The LEDs have triangular ends.  
+                     // The LEDs have triangular ends.
                      // This code shapes the ends.
                      int j = abs( (i%7)-4);
                      AColor::Line( dc, i+r.x, r.y, i+r.x, r.y+j +1);
@@ -743,7 +743,7 @@ void MeterPanel::OnMouse(wxMouseEvent &evt)
       ShowMenu(evt.GetPosition());
    else
    {
-      
+
       if (mSlider)
          mSlider->OnMouseEvent(evt);
    }
@@ -1312,7 +1312,7 @@ void MeterPanel::HandleLayout(wxDC &dc)
       {
          SetActiveStyle(width > height ? HorizontalStereo : VerticalStereo);
       }
-   
+
       if (mStyle == HorizontalStereoCompact || mStyle == HorizontalStereo)
       {
          SetActiveStyle(height < 50 ? HorizontalStereoCompact : HorizontalStereo);
@@ -1321,7 +1321,7 @@ void MeterPanel::HandleLayout(wxDC &dc)
       {
          SetActiveStyle(width < 100 ? VerticalStereoCompact : VerticalStereo);
       }
-   
+
       if (mLeftSize.GetWidth() == 0)  // Not yet initialized to dc.
       {
          dc.GetTextExtent(mLeftText, &mLeftSize.x, &mLeftSize.y);
@@ -1471,7 +1471,7 @@ void MeterPanel::HandleLayout(wxDC &dc)
 
       // Add a gap between bottom of icon and bottom of window
       height -= gap;
-      
+
       left = gap;
 
       // Make sure there's room for icon and gap between the bottom of the meter and icon
@@ -1805,7 +1805,7 @@ void MeterPanel::DrawMeterBar(wxDC &dc, MeterBar *bar)
          // (w - 1) corresponds to the mRuler.SetBounds() in HandleLayout()
          wd = (int)(bar->rms * (w - 1) + 0.5);
 
-         // Draw the rms level 
+         // Draw the rms level
          // +1 to include the rms position
          dc.SetPen(*wxTRANSPARENT_PEN);
          dc.SetBrush(mMeterDisabled ? mDisabledBkgndBrush : mRMSBrush);
@@ -1863,7 +1863,7 @@ void MeterPanel::StartMonitoring()
    auto gAudioIO = AudioIO::Get();
    if (gAudioIO->IsMonitoring()){
       gAudioIO->StopStream();
-   } 
+   }
 
    if (start && !gAudioIO->IsBusy()){
       AudacityProject *p = mProject;
@@ -1881,7 +1881,7 @@ void MeterPanel::StopMonitoring(){
    auto gAudioIO = AudioIO::Get();
    if (gAudioIO->IsMonitoring()){
       gAudioIO->StopStream();
-   } 
+   }
 }
 
 void MeterPanel::OnAudioIOStatus(AudioIOEvent evt)
@@ -1907,7 +1907,9 @@ void MeterPanel::OnAudioIOStatus(AudioIOEvent evt)
 
 void MeterPanel::OnAudioCapture(AudioIOEvent event)
 {
-   if (event.type == AudioIOEvent::CAPTURE && event.pProject != mProject)
+   if (
+      event.type == AudioIOEvent::CAPTURE &&
+      (event.pProject != mProject || !event.on))
    {
       mEnabled = !event.on;
 
@@ -2083,7 +2085,7 @@ void MeterPanel::OnPreferences(wxCommandEvent & WXUNUSED(event))
 
       gPrefs->Flush();
 
-      // Currently, there are 2 playback meters and 2 record meters and any number of 
+      // Currently, there are 2 playback meters and 2 record meters and any number of
       // mixerboard meters, so we have to send out an preferences updated message to
       // ensure they all update themselves.
       PrefsListener::Broadcast(MeterPrefsID());


### PR DESCRIPTION
Resolves: #5981 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] While the P&S dialog is open, selecting another clip updates the title in the dialog. ("Selecting" means clicking either the clip's waveform or affordance bar or tabbing through the clips of a track.)
- [x] Ctrl+Shift+P opens dialog for last selected clip
- [x] History entries are added sensibly.
- [x] The lowest possible speed value is bound by the beginning of the following clip (preventing overlap)
- [x] The close button or pressing ESC close the dialog.
- [x] Deleting the clip that's represented in the dialog closes the dialog.
- [x] The dialog displays the name of the last clicked clip.
- [x] Changing the pitch value in the dialog updates the value displayed on the clip.
- [x] Starting playback/recording play greys out the speed box, which gets re-activated when playback/recording stops.
- [x] Playback start/stop events of one project doesn't activate/deactivate speed box in other project.
- [x] When clicking the arrow icon of a clip, the dialog still opens with focus on the semitone box, and when clicking the clock icon, on the speed box.
- [x] Accessibility still works
- [x] Changing speed with stretch handles updates the value in the dialog
- [x] Changing speed by changing project tempo updates the value in the dialog
- [x] Changing pitch semitone and cent values behaves as gracefully as before when going from positive to negative values. (Pardon me for not elaborating the subtleties, I think you'll notice if there is a difference in behaviour.)
- [x] Clicking on the right channel of a stereo clip behaves as when clicking on the left channel.
- [x] Maybe this resolves #5944 ?