### PR TITLE
Initial implementation of MTC

### DIFF
--- a/src/prefs/PlaybackPrefs.cpp
+++ b/src/prefs/PlaybackPrefs.cpp
@@ -152,6 +152,7 @@ void PlaybackPrefs::PopulateOrExchange(ShuttleGui & S)
          S.TieCheckBox(XXO("Always scrub un&pinned"),
             {UnpinnedScrubbingPreferenceKey(),
              UnpinnedScrubbingPreferenceDefault()});
+         S.TieCheckBox(XXO("Send MTC (MIDI Time Code)"), {"/AudioIO/SendMTC", true});
       }
       S.EndVerticalLay();
    }

--- a/src/toolbars/TimeToolBar.cpp
+++ b/src/toolbars/TimeToolBar.cpp
@@ -15,6 +15,7 @@
 
 // For compilers that support precompilation, includes "wx/wx.h".
 #include <wx/wxprec.h>
+#include <wx/log.h>
 
 #include <wx/setup.h> // for wxUSE_* macros
 

--- a/src/toolbars/TimeToolBar.h
+++ b/src/toolbars/TimeToolBar.h
@@ -12,6 +12,8 @@
 #define __AUDACITY_TIME_TOOLBAR__
 
 #include <wx/defs.h>
+#include <wx/menu.h>
+#include <portmidi.h>
 
 #include "ToolBar.h"
 #include "../widgets/NumericTextCtrl.h"
@@ -63,6 +65,20 @@ private:
 
    Observer::Subscription mFormatChangedToFitValueSubscription;
    Observer::Subscription mFormatsSubscription;
+
+   wxMenu *timeToolBarMenu;
+   wxMenuItem *sendMTCCheckBox;
+   void CreateDropdownMenu();
+   void OnCheckboxItemSelected(wxCommandEvent &event);
+   void OnRightClick(wxMouseEvent &event);
+
+   PortMidiStream *portMidiStream;
+   PmError portMidiError;
+   bool isPortMidiInitialized = false;
+   void InitializePortMidi();
+   void TerminatePortMidi();
+   void UpdatePortMidiAccordingToPreferences();
+   void SendMTC(double audioTime);
 
 public:
    


### PR DESCRIPTION
Resolves: #6159, #5418, #37, #2167, #1023, helps #5038

This enables Audacity to send MTC through PortMidi. Of course, I'm not sure if the TimeToolBar is the best place to put it, but for the user perspective, it make sense that it would be "sent" by the time toolbar. This adds a checkbox on a context menu and also adds an option on Playback panel on Preferences. We would need to find a way to expose the video framerate selection for the user, though. Another thing to consider is that it's selecting the "Default" device to send. Maybe we should expose an option for the user to choose..?

To test, open the audio of a video in Audacity and open XJadeo. In XJadeo, select the Sync mode to MTC (Portmidi) and enable the option on Audacity. If video is not sinchronized, that's probably because the video framerate is hardcoded to 29.97. Launching XJadeo with the option "-M 1" should work around this.

Of couse, PLEASE, give me feedback on the code as I'm a Python developer, not C++. Thanks!!

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
