### PR TITLE
Pitch and speed dialog: make it reachable via the Alt + F6 shortcut

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
@@ -156,8 +156,8 @@ void PitchAndSpeedDialog::Destroy(AudacityProject& project)
 
 PitchAndSpeedDialog::PitchAndSpeedDialog(AudacityProject& project)
     : wxDialogWrapper(
-         nullptr, wxID_ANY, XO("Pitch and Speed"), wxDefaultPosition,
-         { 480, 250 }, wxDEFAULT_DIALOG_STYLE)
+         FindProjectFrame(&project), wxID_ANY, XO("Pitch and Speed"),
+         wxDefaultPosition, { 480, 250 }, wxDEFAULT_DIALOG_STYLE)
     , mProject { project }
     , mProjectCloseSubscription { ProjectWindow::Get(mProject).Subscribe(
          [this](ProjectWindowDestroyedMessage) { Destroy(mProject); }) }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6170

Problem:
With the full default shortcuts enabled, pressing Alt + F6 or Shift Alt + F6 cycles you round the main window and any open modeless dialogs. However, the Pitch and speed dialog is not included in this cycle. For this to be the case the dialog's parent should be the project window. (See in NavigationMenus.cpp, OnPrevWindow() and OnNextWindow().) This isn't the case for the Pitch and speed dialog, the parent is nullptr.

Fix:
Change the parent of the Pitch and speed dialog to be the project window.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
