### PR TITLE
6158 buzz when toggling formant preservation

### DIFF
--- a/libraries/lib-stretching-sequence/ClipSegment.cpp
+++ b/libraries/lib-stretching-sequence/ClipSegment.cpp
@@ -65,6 +65,12 @@ ClipSegment::ClipSegment(
 {
 }
 
+ClipSegment::~ClipSegment()
+{
+   mOnSemitoneShiftChangeSubscription.Reset();
+   mOnFormantPreservationChangeSubscription.Reset();
+}
+
 size_t ClipSegment::GetFloats(float* const* buffers, size_t numSamples)
 {
    // Check if formant preservation of pitch shift needs to be updated.

--- a/libraries/lib-stretching-sequence/ClipSegment.cpp
+++ b/libraries/lib-stretching-sequence/ClipSegment.cpp
@@ -12,7 +12,6 @@
 #include "ClipInterface.h"
 #include "SampleFormat.h"
 #include "StaffPadTimeAndPitch.h"
-
 #include <cassert>
 #include <cmath>
 #include <functional>
@@ -44,20 +43,23 @@ ClipSegment::ClipSegment(
     : mTotalNumSamplesToProduce { GetTotalNumSamplesToProduce(
          clip, durationToDiscard) }
     , mSource { clip, durationToDiscard, direction }
+    , mPreserveFormants { clip.GetPitchAndSpeedPreset() ==
+                          PitchAndSpeedPreset::OptimizeForVoice }
+    , mCentShift { clip.GetCentShift() }
     , mStretcher { std::make_unique<StaffPadTimeAndPitch>(
          clip.GetRate(), clip.GetWidth(), mSource,
          GetStretchingParameters(clip)) }
     , mOnSemitoneShiftChangeSubscription { clip.SubscribeToCentShiftChange(
          [this](int cents) {
-            std::lock_guard<std::mutex> lock(mStretcherMutex);
-            mStretcher->OnCentShiftChange(cents);
+            mCentShift = cents;
+            mUpdateCentShift = true;
          }) }
     , mOnFormantPreservationChangeSubscription {
        clip.SubscribeToPitchAndSpeedPresetChange(
           [this](PitchAndSpeedPreset preset) {
-             std::lock_guard<std::mutex> lock(mStretcherMutex);
-             mStretcher->OnFormantPreservationChange(
-                preset == PitchAndSpeedPreset::OptimizeForVoice);
+             mPreserveFormants =
+                preset == PitchAndSpeedPreset::OptimizeForVoice;
+             mUpdateFormantPreservation = true;
           })
     }
 {
@@ -65,7 +67,17 @@ ClipSegment::ClipSegment(
 
 size_t ClipSegment::GetFloats(float* const* buffers, size_t numSamples)
 {
-   std::lock_guard<std::mutex> lock(mStretcherMutex);
+   // Check if formant preservation of pitch shift needs to be updated.
+   // This approach is not immune to a race condition, but it is unlikely and
+   // not critical, as it would only affect one playback pass, during which the
+   // user could easily correct the mistake if needed. On the other hand, we
+   // cannot trust that the observer subscriptions do not get called after
+   // destruction of this object, so better not do anything too sophisticated
+   // there.
+   if (mUpdateFormantPreservation.exchange(false))
+      mStretcher->OnFormantPreservationChange(mPreserveFormants);
+   if (mUpdateCentShift.exchange(false))
+      mStretcher->OnCentShiftChange(mCentShift);
    const auto numSamplesToProduce = limitSampleBufferSize(
       numSamples, mTotalNumSamplesToProduce - mTotalNumSamplesProduced);
    mStretcher->GetSamples(buffers, numSamplesToProduce);

--- a/libraries/lib-stretching-sequence/ClipSegment.h
+++ b/libraries/lib-stretching-sequence/ClipSegment.h
@@ -14,8 +14,8 @@
 #include "ClipTimeAndPitchSource.h"
 #include "Observer.h"
 #include "PlaybackDirection.h"
+#include <atomic>
 #include <memory>
-#include <mutex>
 
 class ClipInterface;
 class TimeAndPitchInterface;
@@ -41,7 +41,10 @@ private:
    const sampleCount mTotalNumSamplesToProduce;
    sampleCount mTotalNumSamplesProduced = 0;
    ClipTimeAndPitchSource mSource;
-   std::mutex mStretcherMutex;
+   bool mPreserveFormants;
+   int mCentShift;
+   std::atomic<bool> mUpdateFormantPreservation = false;
+   std::atomic<bool> mUpdateCentShift = false;
    // Careful that this guy is constructed after `mSource`, which it refers to
    // in its ctor.
    // todo(mhodgkinson) make this safe.

--- a/libraries/lib-stretching-sequence/ClipSegment.h
+++ b/libraries/lib-stretching-sequence/ClipSegment.h
@@ -31,6 +31,7 @@ class STRETCHING_SEQUENCE_API ClipSegment final : public AudioSegment
 {
 public:
    ClipSegment(ClipInterface&, double durationToDiscard, PlaybackDirection);
+   ~ClipSegment() override;
 
    // AudioSegment
    size_t GetFloats(float* const* buffers, size_t numSamples) override;

--- a/libraries/lib-stretching-sequence/ClipTimeAndPitchSource.cpp
+++ b/libraries/lib-stretching-sequence/ClipTimeAndPitchSource.cpp
@@ -80,6 +80,11 @@ void ClipTimeAndPitchSource::Pull(
             // become a reasonably small value again :)
             -sampleCount { numSamplesToRead };
    }
+   else
+   {
+      for (auto i = 0u; i < mClip.GetWidth(); ++i)
+         std::fill(buffers[i], buffers[i] + samplesPerChannel, 0.f);
+   }
 }
 
 size_t ClipTimeAndPitchSource::GetWidth() const


### PR DESCRIPTION
Resolves: #6158 

The buzz was due to the readout of an uninitialized buffer, which occurred when the stretcher has to reboot during playback. This easy fix is to zero it out instead, which makes the imperfection less audible. A proper fix would be to resynchronize the time stretcher's sample provider, but the effort is probably not worth it: allowing formant preservation toggling during playback is just a convenience for the user to hear with and without with just one click, but is by no means intended for actual music production.

Working on this ticket also uncovered a potential crash, due to a race condition between stretcher initialization on the audio thread and formant-preservation callbacks from the main thread. One could crash rather easily by selecting a very short loop of a few hundred ms, playback and toggling fast formant preservation on and off. A fix is proposed.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
