### PR TITLE
Fixes the Release builds on MSVC

### DIFF
--- a/libraries/lib-menus/MenuRegistry.cpp
+++ b/libraries/lib-menus/MenuRegistry.cpp
@@ -165,8 +165,6 @@ auto MenuItems::GetOrdering() const -> Ordering {
 }
 auto MenuItems::GetProperties() const -> Properties { return Inline; }
 
-ItemProperties::~ItemProperties() {}
-
 CommandHandlerFinder FinderScope::sFinder =
    [](AudacityProject &project) -> CommandHandlerObject & {
       // If this default finder function is reached, then FinderScope should

--- a/libraries/lib-menus/MenuRegistry.h
+++ b/libraries/lib-menus/MenuRegistry.h
@@ -111,7 +111,7 @@ namespace MenuRegistry {
          Whole,
          Extension,
       };
-      virtual ~ItemProperties();
+      virtual ~ItemProperties() = default;
       virtual Properties GetProperties() const = 0;
    };
 


### PR DESCRIPTION
It seems there is a bug in the compiler or linker, that optimizes out ItemProperties destructor from the binary, along with the VTable

Resolves: #6127 

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
