### PR TITLE
Speed indicator now remains visible

### DIFF
--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -360,8 +360,31 @@ double WaveClip::GetStretchRatio() const
          *mRawAudioTempo / *mProjectTempo :
          1.0;
    double stretchRatio = mClipStretchRatio * dstSrcRatio;
+
+   auto projectTempo = mProjectTempo;
+   auto rawAudioTempo = mRawAudioTempo;
+
    double lowestStretchRatio = 100 / (double)99999;
-   return std::max(stretchRatio, lowestStretchRatio);
+
+   if (stretchRatio < lowestStretchRatio) {
+      stretchRatio = lowestStretchRatio;
+
+      if (projectTempo.has_value()) {
+         rawAudioTempo = projectTempo.value() * (lowestStretchRatio / mClipStretchRatio);
+      }
+      else if (rawAudioTempo.has_value()) {
+         projectTempo = rawAudioTempo.value() / (lowestStretchRatio / mClipStretchRatio);
+      }
+   }
+
+   if (mProjectTempo.has_value()) {
+      const_cast<std::optional<double>&>(mRawAudioTempo) = rawAudioTempo;
+   }
+   if (mRawAudioTempo.has_value()) {
+      const_cast<std::optional<double>&>(mProjectTempo) = projectTempo;
+   }
+
+   return stretchRatio;
 }
 
 int WaveClip::GetCentShift() const

--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -359,7 +359,9 @@ double WaveClip::GetStretchRatio() const
       mProjectTempo.has_value() && mRawAudioTempo.has_value() ?
          *mRawAudioTempo / *mProjectTempo :
          1.0;
-   return mClipStretchRatio * dstSrcRatio;
+   double stretchRatio = mClipStretchRatio * dstSrcRatio;
+   double lowestStretchRatio = 100 / (double)99999;
+   return std::max(stretchRatio, lowestStretchRatio);
 }
 
 int WaveClip::GetCentShift() const

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -204,6 +204,8 @@ public:
    void StretchBy(double ratio);
 
    double GetStretchRatio() const override;
+   double GetStretchRatio();
+   void UpdateTemposForLowestRatio(double stretchRatio);
 
    //! Checks for stretch-ratio equality, accounting for rounding errors.
    //! @{


### PR DESCRIPTION
Resolves: #6032 

When shrunk to near absolute minimum, the audio clip's speed indicator would disappear. This is not the case anymore, as the lowest stretch ratio is now set to 100 / (double)99999. Such change ensures that the clip's speed never exceeds 99999%.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
