### PR TITLE
Fix Cloud preferences accessibility issues

### DIFF
--- a/modules/mod-cloud-audiocom/ui/AudioComPrefsPanel.cpp
+++ b/modules/mod-cloud-audiocom/ui/AudioComPrefsPanel.cpp
@@ -79,7 +79,7 @@ public:
          {
             S.SetBorder(8);
             auto checkBox = S.AddCheckBox(
-               XO("Show 'How would you like to export?' dialog"),
+               XO("S&how 'How would you like to export?' dialog"),
                sync::ExportLocationMode.ReadEnum() ==
                   sync::CloudLocationMode::Ask);
 
@@ -115,17 +115,17 @@ public:
             S.StartInvisiblePanel(4);
             {
                BindRadioButton(S.AddRadioButton(
-                  XO("Always ask"),
+                  XO("Always &ask"),
                      static_cast<int>(sync::CloudLocationMode::Ask),
                      initialMode),
                   sync::CloudLocationMode::Ask);
                BindRadioButton(S.AddRadioButtonToGroup(
-                  XO("Always save to cloud"),
+                  XO("Always &save to cloud"),
                   static_cast<int>(sync::CloudLocationMode::Cloud),
                      initialMode),
                   sync::CloudLocationMode::Cloud);
                BindRadioButton(S.AddRadioButtonToGroup(
-                  XO("Always save to the computer"),
+                  XO("Always save to the co&mputer"),
                   static_cast<int>(sync::CloudLocationMode::Local),
                      initialMode),
                   sync::CloudLocationMode::Local);
@@ -142,7 +142,7 @@ public:
                S.SetStretchyCol(1);
 
                mCloudProjectsSavePath = S.TieTextBox(XXO("&Location:"), CloudProjectsSavePath, 30);
-               S.AddButton(XXO("Brow&se..."))
+               S.AddButton(XXO("&Browse..."))
                   ->Bind(wxEVT_BUTTON, [this](auto&) { Browse(); });
             }
             S.EndMultiColumn();
@@ -150,8 +150,9 @@ public:
             S.SetBorder(8);
             S.StartMultiColumn(3);
             {
-               S.TieIntegerTextBox(
-                  XXO("Remove temporary files after:"), DaysToKeepFiles, 10);
+               S.NameSuffix(XO("days"))
+                  .TieIntegerTextBox(
+                  XXO("&Remove temporary files after:"), DaysToKeepFiles, 10);
                S.AddFixedText(XO("days"), true);
             }
             S.EndMultiColumn();

--- a/modules/mod-cloud-audiocom/ui/UserPanel.cpp
+++ b/modules/mod-cloud-audiocom/ui/UserPanel.cpp
@@ -59,6 +59,7 @@ UserPanel::UserPanel(
          [this](const auto&) { UpdateUserData(); }) }
 {
    mUserImage = safenew UserImage(this, avatarSize);
+   mUserImage->SetLabel(anonymousText);      // for screen readers
    mUserName =
       safenew wxStaticText(this, wxID_ANY, anonymousText.Translation());
    mLinkButton =
@@ -135,8 +136,10 @@ void UserPanel::UpdateUserData()
 
    const auto displayName = userService.GetDisplayName();
 
-   if (!displayName.empty())
+   if (!displayName.empty()) {
       mUserName->SetLabel(displayName);
+      mUserImage->wxPanel::SetLabel(displayName);  // for screen readers
+   }
 
    const auto avatarPath = userService.GetAvatarPath();
 
@@ -175,6 +178,7 @@ void UserPanel::SetAnonymousState()
 {
    mUserName->SetLabel(anonymousText.Translation());
    mUserImage->SetBitmap(theTheme.Bitmap(bmpAnonymousUser));
+   mUserImage->SetLabel(anonymousText);   // for screen readers
    mLinkButton->SetLabel(XXO("&Link Account").Translation());
 
    OnStateChaged(false);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6208

Fixed:
1. All controls now have access keys.
2. In the Account group box, the label of the person icon is now read by screen readers.
3. The accessibility name of the "Remove temporary file after" text box now includes the word days.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
