### PR TITLE
Audacity does not depend on lib-cloud-audiocom

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1355,12 +1355,6 @@ if( ${_OPT}has_url_schemes_support )
    )
 endif()
 
-if( ${_OPT}has_audiocom_upload )
-   list( APPEND AUDACITY_LIBRARIES
-      lib-cloud-audiocom-interface
-   )
-endif()
-
 if( ${_OPT}has_crashreports )
    if( ${_OPT}crashreport_backend STREQUAL "crashpad" )
       list(APPEND DEFINES


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
