### PR TITLE
Enable cloud status in status bar to be read by NVDA

### DIFF
--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -890,11 +890,6 @@ wxStatusBar* ProjectWindow::CreateProjectStatusBar()
    // be an event handler to send them to the appropriate field.
    statusBar = CreateStatusBar(
          1 + ProjectStatusFieldsRegistry::Count(pProject.get()));
-#if wxUSE_ACCESSIBILITY
-   // so that name can be set on a standard control
-   statusBar->SetAccessible(safenew WindowAccessible(statusBar));
-#endif
-   statusBar->SetName(wxT("status_line")); // not localized
 
    statusBar->Bind(
       wxEVT_SIZE,


### PR DESCRIPTION
Partially Resolves: https://github.com/audacity/audacity/issues/6065

Problem:
Using either Jaws or NVDA the cloud status is not read when reading the status line. Using the Inspect tool, in its tree view it can be seen that there is no child of the status line which has an accessibility name which is the cloud status. The status line has a WindowAccessible set, so that the accessibility name of the status line can be set to "status_line". WindowAccessible is dealing with the accessibility objects of the status bar's children, and not doing a very good job. (It's not written to be able to do this.)

Fix for NVDA only:
Don't set a WindowAccessible for the status line, and let Windows provide the accessible objects for the status line, and for all the children for which an accessibility object is not set. This means that the status line no longer has the accessibility name of "status_line". I'm not sure when this was introduced and why. But neither the current Jaws or NVDA scripts make use of the name, so I don't see any problem.

Note on Jaws:
This fix does not fix the issue for the Jaws screen reader. It looks like it is not using the accessibility objects of the status line for its information about the text on the status line.

Partially Resolves: https://github.com/audacity/audacity/issues/6065


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
