### PR TITLE
Save to audio.com dialog: fix accessibility name

### DIFF
--- a/modules/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.cpp
+++ b/modules/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.cpp
@@ -42,6 +42,7 @@ CloudProjectPropertiesDialog::CloudProjectPropertiesDialog(
    mProjectName = new wxTextCtrl { this,          wxID_ANY,
                                    projectName,   wxDefaultPosition,
                                    wxDefaultSize, wxTE_PROCESS_ENTER };
+   mProjectName->SetName(XO("Project Name").Translation());
 
    mAnonStateText = safenew wxStaticText {
       this, wxID_ANY,


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6196

Fix the accessibility name of the Project Name text box.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
