### PR TITLE
Remove theme blending

### DIFF
--- a/libraries/image-compiler/imageCompilerMain.cpp
+++ b/libraries/image-compiler/imageCompilerMain.cpp
@@ -76,8 +76,6 @@ bool App::OnInit()
 {
    // Leave no persistent side-effect on preferences
    SettingScope scope;
-   // Don't blend colors
-   GUIBlendThemes.Write(false);
 
    // So that the program can interpret PNG
    wxInitAllImageHandlers();

--- a/libraries/lib-theme/Theme.cpp
+++ b/libraries/lib-theme/Theme.cpp
@@ -262,28 +262,6 @@ void ThemeBase::LoadTheme( teThemeType Theme )
    RotateImageInto( bmpRecordBeside, bmpRecordBelow, false );
    RotateImageInto( bmpRecordBesideDisabled, bmpRecordBelowDisabled, false );
 
-   // Other modifications of images happening only when the setting
-   // GUIBlendThemes is true
-   if ( mpSet->bRecolourOnLoad ) {
-      RecolourTheme();
-
-      wxColor Back        = theTheme.Colour( clrTrackInfo );
-      wxColor CurrentText = theTheme.Colour( clrTrackPanelText );
-      wxColor DesiredText = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT );
-
-      int TextColourDifference =  ColourDistance( CurrentText, DesiredText );
-
-      // Theming is very accepting of alternative text colours.  They just need to
-      // have decent contrast to the background colour, if we're blending themes.
-      if ( TextColourDifference != 0 ) {
-         int ContrastLevel        =  ColourDistance( Back, DesiredText );
-         if ( ContrastLevel > 250 )
-            Colour( clrTrackPanelText ) = DesiredText;
-      }
-      mpSet->bRecolourOnLoad = false;
-   }
-
-
    // Next line is not required as we haven't yet built the GUI
    // when this function is (or should be) called.
    // AColor::ApplyUpdatedImages();
@@ -309,42 +287,6 @@ int ThemeBase::ColourDistance( wxColour & From, wxColour & To ){
       abs( From.Red() - To.Red() )
       + abs( From.Green() - To.Green() )
       + abs( From.Blue() - To.Blue() );
-}
-
-// This function coerces a theme to be more like the system colours.
-// Only used for built in themes.  For custom themes a user
-// will choose a better theme for them and just not use a mismatching one.
-void ThemeBase::RecolourTheme()
-{
-   wxColour From = Colour( clrMedium );
-#if defined( __WXGTK__ )
-   wxColour To = wxSystemSettings::GetColour( wxSYS_COLOUR_BACKGROUND );
-#else
-   wxColour To = wxSystemSettings::GetColour( wxSYS_COLOUR_3DFACE );
-#endif
-   // only recolour if recolouring is slight.
-   int d = ColourDistance( From, To );
-
-   // Don't recolour if difference is too big.
-   if( d  > 120 )
-      return;
-
-   // A minor tint difference from standard does not need 
-   // to be recouloured either.  Includes case of d==0 which is nothing
-   // needs to be done.
-   if( d < 40 )
-      return;
-
-   Colour( clrMedium ) = To;
-   RecolourBitmap( bmpUpButtonLarge, From, To );
-   RecolourBitmap( bmpDownButtonLarge, From, To );
-   RecolourBitmap( bmpHiliteButtonLarge, From, To );
-   RecolourBitmap( bmpUpButtonSmall, From, To );
-   RecolourBitmap( bmpDownButtonSmall, From, To );
-   RecolourBitmap( bmpHiliteButtonSmall, From, To );
-
-   Colour( clrTrackInfo ) = To;
-   RecolourBitmap( bmpUpButtonExpand, From, To );
 }
 
 wxImage ThemeBase::MaskedImage( char const ** pXpm, char const ** pMask )
@@ -909,8 +851,6 @@ bool ThemeBase::ReadImageCache( teThemeType type, bool bOkIfNotFound)
 //      ImageCache.InitAlpha();
 //   }
 
-   mpSet->bRecolourOnLoad = GUIBlendThemes.Read();
-
    using namespace BasicUI;
 
    if( type.empty() || type == "custom" )
@@ -1377,5 +1317,3 @@ ChoiceSetting &GUITheme()
 
    return setting;
 }
-
-BoolSetting GUIBlendThemes{ wxT("/GUI/BlendThemes"), true };

--- a/libraries/lib-theme/Theme.h
+++ b/libraries/lib-theme/Theme.h
@@ -105,7 +105,6 @@ struct ThemeSet
    std::vector<wxColour> mColours;
 
    bool bInitialised = false;
-   bool bRecolourOnLoad = false;  // Request to recolour.
 };
 
 struct ThemeChangeMessage {
@@ -172,7 +171,6 @@ public:
    void WriteOneImageMap( teThemeType id );
    static bool LoadPreferredTheme();
    void RecolourBitmap( int iIndex, wxColour From, wxColour To );
-   void RecolourTheme();
 
    int ColourDistance( wxColour & From, wxColour & To );
    wxColour & Colour( int iIndex );
@@ -220,10 +218,6 @@ public:
 };
 
 extern THEME_API Theme theTheme;
-
-extern THEME_API BoolSetting
-     GUIBlendThemes
-;
 
 extern THEME_API ChoiceSetting
      &GUITheme()

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -177,8 +177,6 @@ void GUIPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(XXO("Re&tain labels if selection snaps to a label"),
                     {wxT("/GUI/RetainLabels"),
                      false});
-      S.TieCheckBox(XXO("B&lend system and Audacity theme"),
-                     GUIBlendThemes);
 #ifndef __WXMAC__
       /* i18n-hint: RTL stands for 'Right to Left'  */
       S.TieCheckBox(XXO("Use mostly Left-to-Right layouts in RTL languages"),
@@ -219,7 +217,6 @@ bool GUIPrefs::Commit()
    }
    AColor::ApplyUpdatedImages();
 
-   GUIBlendThemes.Invalidate();
    DecibelScaleCutoff.Invalidate();
 
    return true;

--- a/src/prefs/ThemePrefs.cpp
+++ b/src/prefs/ThemePrefs.cpp
@@ -57,21 +57,6 @@ BEGIN_EVENT_TABLE(ThemePrefs, PrefsPanel)
    EVT_BUTTON(idSaveThemeAsCode,     ThemePrefs::OnSaveThemeAsCode)
 END_EVENT_TABLE()
 
-static bool ConfirmSave()
-{
-   if (!GUIBlendThemes.Read())
-      return true;
-
-   using namespace BasicUI;
-   const auto message = Verbatim(
-"\"Blend system and Audacity theme\" in Interface Preferences was on.\n"
-"This may cause images to to be re-saved with slight changes of color."
-   );
-
-   return MessageBoxResult::Cancel != ShowMessageBox(message,
-      MessageBoxOptions{}.CancelButton().IconStyle(Icon::Warning));
-}
-
 ThemePrefs::ThemePrefs(wxWindow * parent, wxWindowID winid)
 /* i18n-hint: A theme is a consistent visual style across an application's
  graphical user interface, including choices of colors, and similarity of images
@@ -196,8 +181,6 @@ void ThemePrefs::OnLoadThemeComponents(wxCommandEvent & WXUNUSED(event))
 /// Save Theme to multiple png files.
 void ThemePrefs::OnSaveThemeComponents(wxCommandEvent & WXUNUSED(event))
 {
-   if (!ConfirmSave())
-      return;
    wxBusyCursor busy;
    theTheme.SaveThemeComponents();
 }
@@ -213,8 +196,6 @@ void ThemePrefs::OnLoadThemeCache(wxCommandEvent & WXUNUSED(event))
 /// Save Themes, each to a single png file.
 void ThemePrefs::OnSaveThemeCache(wxCommandEvent & WXUNUSED(event))
 {
-   if (!ConfirmSave())
-      return;
    wxBusyCursor busy;
    theTheme.CreateImageCache();
    theTheme.WriteImageMap();// bonus - give them the html version.
@@ -231,8 +212,6 @@ void ThemePrefs::OnReadThemeInternal(wxCommandEvent & WXUNUSED(event))
 /// Save Theme as C source code.
 void ThemePrefs::OnSaveThemeAsCode(wxCommandEvent & WXUNUSED(event))
 {
-   if (!ConfirmSave())
-      return;
    wxBusyCursor busy;
    theTheme.SaveThemeAsCode();
    theTheme.WriteImageDefs();// bonus - give them the Defs too.


### PR DESCRIPTION
Resolves: #6245

And probably the last cherry-pickable thing from the themes branch I have. 

QA: This removes a checkbox from the Interface preference tab and somewhat alters how themes are loaded.