### PR TITLE
Open from cloud dialog: fix focus issues.

### DIFF
--- a/modules/mod-cloud-audiocom/ui/dialogs/ProjectsListDialog.cpp
+++ b/modules/mod-cloud-audiocom/ui/dialogs/ProjectsListDialog.cpp
@@ -693,6 +693,29 @@ void ProjectsListDialog::SetupHandlers()
          }
       });
 
+   mProjectsTable->Bind(
+      wxEVT_GRID_TABBING,
+      [this](auto& evt)
+      {
+         // needed for correct tabbing - see issue #6190
+         NavigateIn(evt.ShiftDown() ? wxNavigationKeyEvent::IsBackward :
+            wxNavigationKeyEvent::IsForward);
+      });
+
+   mProjectsTable->Bind(
+      wxEVT_SET_FOCUS,
+      [this](auto& evt)
+      {
+         // needed so that for screen readers a row rather than the whole
+         // table is the initial focus - see issue #6190
+#if wxUSE_ACCESSIBILITY
+         int row = mProjectsTable->GetGridCursorRow();
+         if (row != -1)
+            mAccessible->SetSelectedRow(row);
+#endif
+         evt.Skip();
+      });
+
    mSearchCtrl->Bind(wxEVT_TEXT, [this](auto&) { OnSearchTextChanged(); });
 
    mSearchCtrl->Bind(


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6190

Problems:
1. When there are projects in the table, you have to press Tab twice to move to the next control.
2. When there are no projects in the table, pressing Tab does not leave the table.
3. When the table becomes the focus, for screen readers the whole table is the focus, rather than a row.

Fixes:
1. Handle the wxEVT_GRID_TABBING event to provide the correct tabbing behaviour.
2. When the wxGrid control becomes the focus, create a focus event for the row which should be the focus, by the call mAccessible->SetSelectedRow(row).



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
