### PR TITLE
Fixed visibility of edit button when managing macros

### DIFF
--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -427,6 +427,15 @@ auto MacroCommandsCatalog::ByCommandId( const CommandID &commandId ) const
          { return entry.name.Internal() == commandId; });
 }
 
+// linear search
+auto MacroCommandsCatalog::ByTranslation( const wxString &translation ) const
+   -> Entries::const_iterator
+{
+   return std::find_if(begin(), end(),
+      [&](const Entry &entry)
+      { return entry.name.Translation() == translation; });
+}
+
 wxString MacroCommands::GetCurrentParamsFor(const CommandID & command)
 {
    const PluginID & ID =

--- a/src/BatchCommands.h
+++ b/src/BatchCommands.h
@@ -41,6 +41,8 @@ public:
    Entries::const_iterator ByFriendlyName( const TranslatableString &friendlyName ) const;
    // linear search
    Entries::const_iterator ByCommandId( const CommandID &commandId ) const;
+   // linear search
+   Entries::const_iterator ByTranslation( const wxString &translation ) const;
 
    // Lookup by position as sorted by friendly name
    const Entry &operator[] ( size_t index ) const { return mCommands[index]; }

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -47,6 +47,7 @@
 #include "Track.h"
 #include "CommandManager.h"
 #include "Effect.h"
+#include "effects/EffectManager.h"
 #include "effects/EffectUI.h"
 #include "../images/Arrow.xpm"
 #include "../images/Empty9x16.xpm"
@@ -665,7 +666,7 @@ void MacrosWindow::PopulateOrExchange(ShuttleGui & S)
             S.StartVerticalLay(wxALIGN_TOP, 0);
             {
                S.Id(InsertButtonID).AddButton(XXO("&Insert"), wxALIGN_LEFT);
-               S.Id(EditButtonID).AddButton(XXO("&Edit..."), wxALIGN_LEFT);
+               mEdit = S.Id(EditButtonID).AddButton(XXO("&Edit..."), wxALIGN_LEFT);
                S.Id(DeleteButtonID).AddButton(XXO("De&lete"), wxALIGN_LEFT);
                S.Id(UpButtonID).AddButton(XXO("Move &Up"), wxALIGN_LEFT);
                S.Id(DownButtonID).AddButton(XXO("Move &Down"), wxALIGN_LEFT);
@@ -890,6 +891,15 @@ void MacrosWindow::ShowActiveMacro()
 /// An item in the macros list has been selected.
 void MacrosWindow::OnListSelected(wxListEvent & WXUNUSED(event))
 {
+   const auto &command = mCatalog.ByTranslation(mList->GetItemText(event.GetIndex(), ActionColumn));
+
+   if (command != mCatalog.end()) {
+      EffectManager& em = EffectManager::Get();
+      PluginID ID = em.GetEffectByIdentifier(command->name.Internal());
+
+      mEdit->Enable(!ID.empty());
+   }
+
    FitColumns();
 }
 

--- a/src/BatchProcessDialog.h
+++ b/src/BatchProcessDialog.h
@@ -139,6 +139,7 @@ private:
    wxButton *mRestore;
    wxButton *mImport;
    wxButton *mExport;
+   wxButton *mEdit;
    wxButton *mSave;
 
    int mSelectedCommand;


### PR DESCRIPTION
Resolves: #3825

*Tweaked MacrosWindow::OnListSelected based on MacroCommandDialog::OnItemSelected to achieve desirable effect*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
