### PR TITLE
ctrl+v can import files from clipboard

### DIFF
--- a/src/DropTarget.cpp
+++ b/src/DropTarget.cpp
@@ -17,7 +17,6 @@
 #include "Project.h"
 #include "ProjectFileManager.h"
 #include "TrackPanel.h"
-#include "Viewport.h"
 
 #if wxUSE_DRAG_AND_DROP
 class FileObject final : public wxFileDataObject
@@ -157,22 +156,9 @@ public:
    {
       // Experiment shows that this function can be reached while there is no
       // catch block above in wxWidgets.  So stop all exceptions here.
-      return GuardedCall< bool > ( [&] {
-         wxArrayString sortednames(filenames);
-         sortednames.Sort(FileNames::CompareNoCase);
-
-         auto cleanup = finally( [&] {
-            Viewport::Get(*mProject).HandleResize(); // Adjust scrollers for NEW track sizes.
-         } );
-
-         ProjectFileManager::Get(*mProject).Import(
-            std::vector<FilePath> { sortednames.begin(), sortednames.end() });
-
-         auto &viewport = Viewport::Get(*mProject);
-         viewport.ZoomFitHorizontallyAndShowTrack(nullptr);
-
-         return true;
-      } );
+      return GuardedCall<bool>([&] {
+         return ProjectFileManager::Get(*mProject).ImportAndArrange(filenames);
+      });
    }
 
 private:

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1441,7 +1441,10 @@ bool ProjectFileManager::Import(
             resultingReaders.push_back(std::move(resultingReader));
          return success;
       });
-   if (success && !resultingReaders.empty())
+   // At the moment, one failing import doesn't revert the project state, hence
+   // we still run the analysis on what was successfully imported.
+   // TODO implement reverting of the project state on failure.
+   if (!resultingReaders.empty())
    {
       const auto pProj = mProject.shared_from_this();
       BasicUI::CallAfter([=] {

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -284,7 +284,6 @@ bool ProjectFileManager::Save()
 {
    auto &projectFileIO = ProjectFileIO::Get(mProject);
 
-   
    if (auto action = ProjectFileIOExtensionRegistry::OnSave(
           mProject, [this](auto& path, bool rename)
           { return DoSave(audacity::ToWXString(path), rename); });
@@ -1363,6 +1362,18 @@ private:
 bool ProjectFileManager::Import(const FilePath& fileName, bool addToHistory)
 {
    return Import(std::vector<FilePath> { fileName }, addToHistory);
+}
+
+bool ProjectFileManager::ImportAndArrange(wxArrayString fileNames)
+{
+   fileNames.Sort(FileNames::CompareNoCase);
+   if (!ProjectFileManager::Get(mProject).Import(
+          std::vector<wxString> { fileNames.begin(), fileNames.end() }))
+      return false;
+   auto& viewport = Viewport::Get(mProject);
+   viewport.ZoomFitHorizontallyAndShowTrack(nullptr);
+   viewport.HandleResize(); // Adjust scrollers for NEW track sizes.
+   return true;
 }
 
 namespace

--- a/src/ProjectFileManager.h
+++ b/src/ProjectFileManager.h
@@ -98,6 +98,10 @@ public:
    bool
    Import(const std::vector<FilePath>& fileNames, bool addToHistory = true);
    bool Import(const FilePath& fileName, bool addToHistory = true);
+   bool ImportAndArrange(
+      // wxArrayString because that's the readily available type where this
+      // method is used, no other reason
+      wxArrayString fileNames);
 
    void Compact();
 


### PR DESCRIPTION
Resolves: #6028

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
Basically, copy-pasting from the clipboard behaves the exact same as drag-dropping. In particular,
- [x] files are sorted alphabetically
- [x] there is one history entry per imported file, even if several were copied and pasted in one go (@LWinterberg shouldn't this be changed?)
- [x] Not effective during playback
- [x] A mixture of file types can be imported, e.g. audio and midi.
- [x] The bottom-most track gets focus and is fully selected.

Besides:
- [x] Copy a track, then copy a wav file, paste: the wav file is pasted. Vice versa. (It is important that this is tested on all Windows, Mac and Linux, as implementation interacts with the OS clipboard).
- [x] If import of one of the files fails, then entire operation is aborted.
