### PR TITLE
Add gettext header to .mo files even if it's marked as fuzzy

### DIFF
--- a/locale/msgfmt.py
+++ b/locale/msgfmt.py
@@ -48,7 +48,8 @@ def usage(code, msg=''):
 def add(ctxt, id, str, fuzzy):
     "Add a non-fuzzy translation to the dictionary."
     global MESSAGES
-    if not fuzzy and str:
+    # Add a string if it's not fuzzy, or if it's the header (that is, empty ctxt and empty id)
+    if str and (not fuzzy or (not ctxt and not id)):
         if ctxt is None:
             MESSAGES[id] = str
         else:


### PR DESCRIPTION
Resolves: #6279

The gettext header should be present in the compiled .mo files even if in the source .po files it's marked as fuzzy.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
