### PR TITLE
C make cleanup

### DIFF
--- a/cmake-proxies/libscorealign/CMakeLists.txt
+++ b/cmake-proxies/libscorealign/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       ${TARGET_ROOT}/audioreader.cpp
       ${TARGET_ROOT}/comp_chroma.cpp
@@ -16,7 +16,7 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/fft3/FFT3.cpp
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PUBLIC
       ${TARGET_ROOT}
 )

--- a/cmake-proxies/libsoxr/CMakeLists.txt
+++ b/cmake-proxies/libsoxr/CMakeLists.txt
@@ -5,7 +5,7 @@ def_vars()
 
 set(CMAKE_MODULE_PATH ${TARGET_ROOT}/cmake/Modules )
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       ${TARGET_ROOT}/src/cr.c
       ${TARGET_ROOT}/src/cr32.c
@@ -23,21 +23,21 @@ list( APPEND SOURCES
       ${TARGET_ROOT}/src/vr32.c
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PRIVATE
       ${_PRVDIR}
    PUBLIC
       ${TARGET_ROOT}/src
 )
 
-list( APPEND DEFINES
+set( DEFINES
    PRIVATE
       _USE_MATH_DEFINES
       _CRT_SECURE_NO_WARNINGS
       SOXR_LIB
 )
 
-list( APPEND OPTIONS
+set( OPTIONS
    PRIVATE
       $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:
          -Wconversion

--- a/images/CMakeLists.txt
+++ b/images/CMakeLists.txt
@@ -8,7 +8,7 @@ def_vars()
 
 # This isn't really a target...
 
-list( APPEND PIXMAPS
+set( PIXMAPS
    ${_SRCDIR}/gnome-mime-application-x-audacity-project.xpm
    ${_SRCDIR}/icons/16x16/audacity16.xpm
    ${_SRCDIR}/icons/32x32/audacity32.xpm

--- a/lib-src/libnyquist/CMakeLists.txt
+++ b/lib-src/libnyquist/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library( ${TARGET} STATIC )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       # libnyquist
 
@@ -263,7 +263,7 @@ list( APPEND SOURCES
       nyquist/xlisp/xlsys.c
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/nyquist/cmt
       ${CMAKE_CURRENT_SOURCE_DIR}/nyquist/cmupv/src
@@ -279,7 +279,7 @@ list( APPEND INCLUDES
       ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-list( APPEND DEFINES
+set( DEFINES
    PUBLIC
       USE_NYQUIST=1
    PRIVATE
@@ -288,12 +288,12 @@ list( APPEND DEFINES
       $<$<PLATFORM_ID:Windows>:WIN32>
 )
 
-list( APPEND OPTIONS
+set( OPTIONS
    PRIVATE
       $<$<PLATFORM_ID:Darwin>:-fno-common>
 )
 
-list( APPEND LIBRARIES
+set( LIBRARIES
    PRIVATE
       portaudio::portaudio
       SndFile::sndfile

--- a/lib-src/portmixer/CMakeLists.txt
+++ b/lib-src/portmixer/CMakeLists.txt
@@ -38,7 +38,7 @@ elseif( WIN32 )
    )
 endif()
 
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       include/portmixer.h
 
@@ -71,14 +71,14 @@ list( APPEND SOURCES
       >
 )
 
-list( APPEND INCLUDES
+set( INCLUDES
    PRIVATE
       src
    PUBLIC
       include
 )
 
-list( APPEND DEFINES
+set( DEFINES
    PUBLIC
       USE_PORTMIXER=1
    PRIVATE
@@ -109,7 +109,7 @@ list( APPEND DEFINES
       >
 )
 
-list( APPEND LIBRARIES
+set( LIBRARIES
    PRIVATE
       portaudio::portaudio
 )

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A directory containing library targets
+]]
+
 # Include the libraries that we'll build
 
 # The list of modules is ordered so that each library occurs after any others

--- a/libraries/image-compiler/CMakeLists.txt
+++ b/libraries/image-compiler/CMakeLists.txt
@@ -2,7 +2,7 @@
 A small program that is run at build time of the application.  For each built-in
 theme it generates a header file from image files.  The images are part of the
 source code tree but not deployed with the program.
-]]#
+]]
 
 if( NOT IMAGE_COMPILER_EXECUTABLE )
    add_executable( image-compiler imageCompilerMain.cpp )

--- a/libraries/lib-audio-devices/CMakeLists.txt
+++ b/libraries/lib-audio-devices/CMakeLists.txt
@@ -8,7 +8,7 @@ Also abstract class Meter for communicating buffers of samples for display
 purposes.
 
 Does not contain an audio engine.
-]]#
+]]
 
 set( SOURCES
    AudioIOBase.cpp

--- a/libraries/lib-audio-unit/CMakeLists.txt
+++ b/libraries/lib-audio-unit/CMakeLists.txt
@@ -1,6 +1,6 @@
 #[[
 AudioUnit effect processing logic, minus user interface
-]]#
+]]
 
 if (USE_AUDIO_UNITS)
 

--- a/libraries/lib-basic-ui/CMakeLists.txt
+++ b/libraries/lib-basic-ui/CMakeLists.txt
@@ -11,7 +11,7 @@ There is a global pointer to an instance of Services, and the main program is
 expected, at startup, to create a static instance of a subclass of Services and
 set the pointer.  If it does not, then calls to the non-member functions in
 namespace BasicUI are no-ops.
-]]#
+]]
 
 set( SOURCES
    BasicUI.cpp

--- a/libraries/lib-breakpad-configurer/CMakeLists.txt
+++ b/libraries/lib-breakpad-configurer/CMakeLists.txt
@@ -1,5 +1,7 @@
-# This module provides an interface to configure and start Breakpad handler 
-# in a platform independent way.
+#[[
+This library provides an interface to configure and start Breakpad handler 
+in a platform independent way.
+]]
 
 set(SOURCES 
    BreakpadConfigurer.h

--- a/libraries/lib-crashpad-configurer/CMakeLists.txt
+++ b/libraries/lib-crashpad-configurer/CMakeLists.txt
@@ -1,5 +1,7 @@
-# This module provides an interface to configure and start Crashpad handler 
-# in a platform independent way.
+#[[
+This library provides an interface to configure and start Crashpad handler 
+in a platform independent way.
+]]
 
 set(SOURCES 
    CrashpadConfigurer.h

--- a/libraries/lib-crypto/tests/CMakeLists.txt
+++ b/libraries/lib-crypto/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-crypto
+]]
+
 add_unit_test(
    NAME
       lib-crypto

--- a/libraries/lib-exceptions/CMakeLists.txt
+++ b/libraries/lib-exceptions/CMakeLists.txt
@@ -15,7 +15,7 @@ to catch all otherwise uncaught exceptions. That is a responsibility of high
 level code.
 ]]#
 
-list( APPEND SOURCES
+set( SOURCES
    AudacityException.cpp
    AudacityException.h
    InconsistencyException.cpp

--- a/libraries/lib-exceptions/CMakeLists.txt
+++ b/libraries/lib-exceptions/CMakeLists.txt
@@ -13,7 +13,7 @@ enqueues the delayed action.
 But this library does NOT define a top-level handler for the whole application,
 to catch all otherwise uncaught exceptions. That is a responsibility of high
 level code.
-]]#
+]]
 
 set( SOURCES
    AudacityException.cpp

--- a/libraries/lib-fft/CMakeLists.txt
+++ b/libraries/lib-fft/CMakeLists.txt
@@ -4,7 +4,7 @@ A library for fast fourier transforms
 
 Note -- this cannot be combined with lib-math, which depends on libsoxr, which
 includes a different version of pffft.h
-]]#
+]]
 
 set( SOURCES
    FFT.cpp

--- a/libraries/lib-files/CMakeLists.txt
+++ b/libraries/lib-files/CMakeLists.txt
@@ -6,7 +6,7 @@ Also the definition of certain significant file paths, such as the directory
 for temporary projects.
 
 Also the global logger which can save to a file.
-]]#
+]]
 
 set( SOURCES
    AudacityLogger.cpp

--- a/libraries/lib-graphics/CMakeLists.txt
+++ b/libraries/lib-graphics/CMakeLists.txt
@@ -1,6 +1,6 @@
 #[[
 A library responsible for custom rendering in Audacity
-]]#
+]]
 
 set( SOURCES
    FrameStatistics.cpp

--- a/libraries/lib-import-export/riff-test-util/CMakeLists.txt
+++ b/libraries/lib-import-export/riff-test-util/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A command line testing program for tempo metadata in files
+]]
+
 add_executable(riff-test-util
    RiffTestUtil.cpp
 )

--- a/libraries/lib-import-export/tests/CMakeLists.txt
+++ b/libraries/lib-import-export/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-import-export
+]]
+
 add_unit_test(
    NAME
       lib-import-export

--- a/libraries/lib-math/CMakeLists.txt
+++ b/libraries/lib-math/CMakeLists.txt
@@ -1,6 +1,6 @@
 #[[
 A library of mathematical utilities and manipulation of samples
-]]#
+]]
 
 addlib( libsoxr            soxr        SOXR        YES   YES   "soxr >= 0.1.1" )
 

--- a/libraries/lib-math/tests/CMakeLists.txt
+++ b/libraries/lib-math/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-math
+]]
+
 add_unit_test(
    NAME
       lib-math

--- a/libraries/lib-module-manager/CMakeLists.txt
+++ b/libraries/lib-module-manager/CMakeLists.txt
@@ -5,6 +5,7 @@ effect, generator, and analyzer plug-ins.
 Maintains persistent data in the configuration file for enablement of modules
 and plug-ins, and preferred settings.
 ]]
+
 set( SOURCES
    AsyncPluginValidator.cpp
    AsyncPluginValidator.h

--- a/libraries/lib-music-information-retrieval/tests/CMakeLists.txt
+++ b/libraries/lib-music-information-retrieval/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-music-information-retrieval
+]]
+
 add_compile_definitions(
    CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
 )

--- a/libraries/lib-network-manager/CMakeLists.txt
+++ b/libraries/lib-network-manager/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Asynchronously send and receive requests and responses over internet
+]]
+
 set(TARGET lib-network-manager)
 set( TARGET_ROOT ${CMAKE_CURRENT_SOURCE_DIR} )
 

--- a/libraries/lib-numeric-formats/tests/CMakeLists.txt
+++ b/libraries/lib-numeric-formats/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
+#[[
+Unit tests for lib-numeric-formats
+]]
 
 add_unit_test(
    NAME

--- a/libraries/lib-preferences/CMakeLists.txt
+++ b/libraries/lib-preferences/CMakeLists.txt
@@ -12,7 +12,7 @@ PreferenceInitializer is a callback for the reinitialization of preferences.
 
 FileConfig decorates wxFileConfig, with a member function to
 alert the user of failure to initialize it (as when the file is read-only).
-]]#
+]]
 
 set( SOURCES
    BasicSettings.cpp

--- a/libraries/lib-preferences/tests/CMakeLists.txt
+++ b/libraries/lib-preferences/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-preferences
+]]
+
 add_unit_test(
    NAME
       lib-preferences

--- a/libraries/lib-project-history/CMakeLists.txt
+++ b/libraries/lib-project-history/CMakeLists.txt
@@ -2,6 +2,7 @@
 Management of undo and redo history of the project, stored as states, not
 deltas.  There is not yet persistency of undo history across sessions.
 ]]
+
 set( SOURCES
    ProjectHistory.cpp
    ProjectHistory.h

--- a/libraries/lib-project/CMakeLists.txt
+++ b/libraries/lib-project/CMakeLists.txt
@@ -7,7 +7,7 @@ Also a global array of existing projects.
 
 Also ProjectStatus, an abstraction of the status bar, just holding some strings
 and formatter functions, and emitting events when changed.
-]]#
+]]
 
 set( SOURCES
    Project.cpp

--- a/libraries/lib-registries/CMakeLists.txt
+++ b/libraries/lib-registries/CMakeLists.txt
@@ -25,7 +25,7 @@ Registry implements trees of objects identified by textual paths, and allows
 scattered code to insert items or subtrees at specified paths.  Registry
 computes the merging of trees, and supports visitation.  It is used notably
 by the tree of menus, allowing insertion of menu items in decoupled code.
-]]#
+]]
 
 set( SOURCES
    AttachedVirtualFunction.h

--- a/libraries/lib-screen-geometry/CMakeLists.txt
+++ b/libraries/lib-screen-geometry/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 Classes relating to the mappings between x or y coordinates of the screen, and
 times, or frequencies, or amplitudes.
-]]#
+]]
 
 set( SOURCES
    NumberScale.h

--- a/libraries/lib-sentry-reporting/CMakeLists.txt
+++ b/libraries/lib-sentry-reporting/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 A library, that allows sending error reports to a Sentry server
 using Exception and Message interfaces.
-]]#
+]]
 
 set( TARGET lib-sentry-reporting )
 set( TARGET_ROOT ${CMAKE_CURRENT_SOURCE_DIR} )

--- a/libraries/lib-snapping/CMakeLists.txt
+++ b/libraries/lib-snapping/CMakeLists.txt
@@ -8,6 +8,7 @@ This library:
 3. Provides a project extension that is responsible for snapping
 
 ]]
+
 set(TARGET lib-snapping)
 set(TARGET_ROOT ${CMAKE_CURRENT_SOURCE_DIR} )
 

--- a/libraries/lib-snapping/tests/CMakeLists.txt
+++ b/libraries/lib-snapping/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
+#[[
+Unit tests for lib-snapping
+]]
 
 add_unit_test(
    NAME

--- a/libraries/lib-sqlite-helpers/tests/CMakeLists.txt
+++ b/libraries/lib-sqlite-helpers/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-sqlite
+]]
+
 add_unit_test(
    NAME
       lib-sqlite-helpers

--- a/libraries/lib-stretching-sequence/CMakeLists.txt
+++ b/libraries/lib-stretching-sequence/CMakeLists.txt
@@ -1,8 +1,11 @@
 #[[
-A library providing a time-stretching-capable implementation of `PlayableSequence`.
+A library providing a time-stretching-capable implementation of
+`PlayableSequence`.
 
-Please refer to this directory's readme for a presentation of the constraints inherent to such an implementation.
+Please refer to this directory's readme for a presentation of the constraints
+inherent to such an implementation.
 ]]
+
 set( SOURCES
    AudioSegment.cpp
    AudioSegment.h

--- a/libraries/lib-stretching-sequence/tests/CMakeLists.txt
+++ b/libraries/lib-stretching-sequence/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-stretching-sequence
+]]
+
 add_compile_definitions(CMAKE_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
 add_unit_test(

--- a/libraries/lib-string-utils/CMakeLists.txt
+++ b/libraries/lib-string-utils/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+String encoding and formatting utilities
+]]
+
 set(TARGET lib-string-utils)
 set(TARGET_ROOT ${CMAKE_CURRENT_SOURCE_DIR} )
 

--- a/libraries/lib-string-utils/tests/CMakeLists.txt
+++ b/libraries/lib-string-utils/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-string-utils
+]]
+
 add_unit_test(
    NAME
       lib-string-utils

--- a/libraries/lib-strings/CMakeLists.txt
+++ b/libraries/lib-strings/CMakeLists.txt
@@ -11,7 +11,7 @@ even if the global choice of locale changes during its lifetime.  It does not
 implicitly interconvert with wxString.
 
 This library depends only on the wxBase subset of wxWidgets.
-]]#
+]]
 
 set( SOURCES
    Base64.h

--- a/libraries/lib-theme/CMakeLists.txt
+++ b/libraries/lib-theme/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 A library to hold a registry of image and color identifiers, and multiple themes
 associating data with those identifiers.
-]]#
+]]
 
 set( SOURCES
    AColor.cpp

--- a/libraries/lib-time-and-pitch/tests/CMakeLists.txt
+++ b/libraries/lib-time-and-pitch/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Unit tests for lib-time-and-pitch
+]]
+
 add_compile_definitions(CMAKE_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
 add_unit_test(

--- a/libraries/lib-url-schemes/CMakeLists.txt
+++ b/libraries/lib-url-schemes/CMakeLists.txt
@@ -2,6 +2,7 @@
 #[[
 Library, responsible for handling custom URL scemas.
 ]]
+
 set( SOURCES
    URLSchemesRegistry.cpp
    URLSchemesRegistry.h

--- a/libraries/lib-utility/CMakeLists.txt
+++ b/libraries/lib-utility/CMakeLists.txt
@@ -12,8 +12,7 @@ did not yet provide std::make_unique.  That explains the name.
 Audacity now uses C++17, and yet, need arose for other anticipations of future
 standards.  It also provides other pervasively used utilities that don't
 correspond to things in the standard.
-
-]]#
+]]
 
 set( SOURCES
    AppEvents.cpp

--- a/libraries/lib-utility/tests/CMakeLists.txt
+++ b/libraries/lib-utility/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
+#[[
+Unit tests for lib-utility
+]]
 
 add_unit_test(
    NAME

--- a/libraries/lib-uuid/CMakeLists.txt
+++ b/libraries/lib-uuid/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Generation of UUIDs
+]]
+
 set( TARGET lib-uuid )
 set( TARGET_ROOT ${CMAKE_CURRENT_SOURCE_DIR} )
 

--- a/libraries/lib-viewport/CMakeLists.txt
+++ b/libraries/lib-viewport/CMakeLists.txt
@@ -2,6 +2,7 @@
 Viewport defines a callback facade for horizontal and vertical scrollbars, and
 provides methods to scroll and zoom the view of tracks.
 ]]
+
 set( SOURCES
    Viewport.cpp
    Viewport.h

--- a/libraries/lib-vst/CMakeLists.txt
+++ b/libraries/lib-vst/CMakeLists.txt
@@ -1,6 +1,6 @@
 #[[
 VST 2 effect plugin discovery and processing logic, without user interface
-]]#
+]]
 
 set( SOURCES
    VSTEffectBase.cpp

--- a/libraries/lib-wx-init/CMakeLists.txt
+++ b/libraries/lib-wx-init/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 Startup time injections of wxWidgets based implementations of services behind
 toolkit-neutral facades
-]]#
+]]
 
 set( SOURCES
    AccessibleLinksFormatter.cpp

--- a/libraries/lib-xml/CMakeLists.txt
+++ b/libraries/lib-xml/CMakeLists.txt
@@ -3,7 +3,7 @@ Utilities to serialize and deserialize trees of objects in XML form, and a
 class template XMLMethodRegistry to generate registries for serializable
 objects attached to a host object.  The template is parametrized by the host
 type.
-]]#
+]]
 
 set( SOURCES
    XMLAttributeValueView.cpp

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,3 +1,9 @@
+#[[
+A directory of directories of module targets.  Sub-directories group modules in
+some common area of functionality, such as import/export, and each group becomes
+a cluster in the modules.dot file generated at configuration time.
+]]
+
 # Include the modules that we'll build
 
 # The list of module sub-folders is ordered so that each folder occurs after any

--- a/modules/etc/CMakeLists.txt
+++ b/modules/etc/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A subdirectory containing module targets
+]]
+
 # Include the modules that we'll build
 
 # The list of modules is ordered so that each module occurs after any others

--- a/modules/etc/mod-null/CMakeLists.txt
+++ b/modules/etc/mod-null/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A skeletal example module that does nothing
+]]
+
 set( TARGET mod-null )
 set( DEFINES
    PRIVATE

--- a/modules/import-export/CMakeLists.txt
+++ b/modules/import-export/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A subdirectory containing module targets
+]]
+
 # Include the modules that we'll build
 
 # The list of modules is ordered so that each module occurs after any others

--- a/modules/import-export/mod-aup/CMakeLists.txt
+++ b/modules/import-export/mod-aup/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Import of older Audacity project files, in .aup format, saved before version 3.0
+]]
+
 set( TARGET mod-aup )
 
 set( SOURCES

--- a/modules/import-export/mod-cl/CMakeLists.txt
+++ b/modules/import-export/mod-cl/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Export of files with a command passed to a command-line shell
+]]
+
 set( TARGET mod-cl )
 
 set( SOURCES

--- a/modules/import-export/mod-ffmpeg/CMakeLists.txt
+++ b/modules/import-export/mod-ffmpeg/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+FFmpeg import and export
+]]
+
 set( TARGET mod-ffmpeg )
 
 add_subdirectory(lib-ffmpeg-support)

--- a/modules/import-export/mod-ffmpeg/lib-ffmpeg-support/CMakeLists.txt
+++ b/modules/import-export/mod-ffmpeg/lib-ffmpeg-support/CMakeLists.txt
@@ -1,3 +1,6 @@
+#[[
+Various versions of FFmpeg and a facade to hide their binary incompatibilities
+]]
 
 if (${_OPT}use_ffmpeg)
    set( SOURCES

--- a/modules/import-export/mod-flac/CMakeLists.txt
+++ b/modules/import-export/mod-flac/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+FLAC import and export
+]]
+
 set( TARGET mod-flac )
 
 set( SOURCES

--- a/modules/import-export/mod-lof/CMakeLists.txt
+++ b/modules/import-export/mod-lof/CMakeLists.txt
@@ -1,3 +1,8 @@
+#[[
+Interpret .lof (list-of-files) format, a simple language that can name other
+files to import and then time-shift
+]]
+
 set( TARGET mod-lof )
 
 set( SOURCES

--- a/modules/import-export/mod-mp2/CMakeLists.txt
+++ b/modules/import-export/mod-mp2/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+MP2 export
+]]
+
 set( TARGET mod-mp2 )
 
 set( SOURCES

--- a/modules/import-export/mod-mp3/CMakeLists.txt
+++ b/modules/import-export/mod-mp3/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+MP3 export using the LAME library
+]]
+
 set( TARGET mod-mp3 )
 
 set( SOURCES

--- a/modules/import-export/mod-mpg123/CMakeLists.txt
+++ b/modules/import-export/mod-mpg123/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+MPG123 import
+]]
+
 set( TARGET mod-mpg123 )
 
 set( SOURCES

--- a/modules/import-export/mod-ogg/CMakeLists.txt
+++ b/modules/import-export/mod-ogg/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+OGG import and export
+]]
+
 set( TARGET mod-ogg )
 
 set( SOURCES

--- a/modules/import-export/mod-opus/CMakeLists.txt
+++ b/modules/import-export/mod-opus/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Opus import and export
+]]
+
 set( TARGET mod-opus )
 
 set( SOURCES

--- a/modules/import-export/mod-pcm/CMakeLists.txt
+++ b/modules/import-export/mod-pcm/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+PCM (that is .wav file) import and export
+]]
+
 set( TARGET mod-pcm )
 
 set( SOURCES

--- a/modules/import-export/mod-wavpack/CMakeLists.txt
+++ b/modules/import-export/mod-wavpack/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+WavPack import and export
+]]
+
 set( TARGET mod-wavpack )
 
 set( SOURCES

--- a/modules/nyquist/CMakeLists.txt
+++ b/modules/nyquist/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A directory containing modules related to the Nyquist language
+]]
+
 # Include the modules that we'll build
 
 # The list of modules is ordered so that each module occurs after any others

--- a/modules/nyquist/mod-nyq-bench/CMakeLists.txt
+++ b/modules/nyquist/mod-nyq-bench/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Experimental module for interactive development of Nyquist plugins
+]]
+
 set( TARGET mod-nyq-bench )
 set( SOURCES
       NyqBench.cpp

--- a/modules/scripting/CMakeLists.txt
+++ b/modules/scripting/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A directory containing module targets
+]]
+
 # Include the modules that we'll build
 
 # The list of modules is ordered so that each module occurs after any others

--- a/modules/scripting/mod-script-pipe/CMakeLists.txt
+++ b/modules/scripting/mod-script-pipe/CMakeLists.txt
@@ -1,3 +1,8 @@
+#[[
+Inter-process pipe allowing control of Audacity by sending macro commands and
+receiving responses
+]]
+
 set( SOURCES
    PipeServer.cpp
    ScripterCallback.cpp

--- a/modules/sharing/CMakeLists.txt
+++ b/modules/sharing/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A directory containing module targets
+]]
+
 # Include the modules that we'll build
 
 # The list of modules is ordered so that each module occurs after any others

--- a/modules/sharing/mod-cloud-audiocom/CMakeLists.txt
+++ b/modules/sharing/mod-cloud-audiocom/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+Upload and download of project files in the cloud
+]]
+
 set( TARGET mod-cloud-audiocom )
 
 set( SOURCES

--- a/modules/track-ui/CMakeLists.txt
+++ b/modules/track-ui/CMakeLists.txt
@@ -1,3 +1,7 @@
+#[[
+A directory of module targets
+]]
+
 # Include the modules that we'll build
 
 # The list of modules is ordered so that each module occurs after any others

--- a/nyquist/CMakeLists.txt
+++ b/nyquist/CMakeLists.txt
@@ -6,7 +6,7 @@ message( STATUS "========== Configuring ${TARGET} ==========" )
 
 def_vars()
 
-list( APPEND RUNTIME
+set( RUNTIME
    aud-do-support.lsp
    dspprims.lsp
    envelopes.lsp

--- a/plug-ins/CMakeLists.txt
+++ b/plug-ins/CMakeLists.txt
@@ -6,7 +6,7 @@ message( STATUS "========== Configuring ${TARGET} ==========" )
 
 def_vars()
 
-list( APPEND SOURCES
+set( SOURCES
    ShelfFilter.ny
    SpectralEditMulti.ny
    SpectralEditParametricEQ.ny

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,7 @@ set( USE_VST ${${_OPT}use_vst} CACHE INTERNAL "" )
 #
 #
 #
-list( APPEND SOURCES
+set( SOURCES
    PRIVATE
       ActiveProject.cpp
       ActiveProject.h
@@ -938,14 +938,14 @@ list( APPEND SOURCES
 #
 #
 #
-list( APPEND HEADERS
+set( HEADERS
    ../include/audacity/Types.h
 )
 
 #
 #
 #
-list( APPEND INCLUDES
+set( INCLUDES
    PUBLIC
       ${_PRVDIR}
       ${topdir}/include
@@ -955,14 +955,14 @@ list( APPEND INCLUDES
 #
 # Define resources
 #
-list( APPEND RESOURCES
+set( RESOURCES
    ${topdir}/resources/EffectsMenuDefaults.xml
 )
 
 #
 #
 #
-list( APPEND DEFINES
+set( DEFINES
    PRIVATE
       BUILDING_AUDACITY
       WXUSINGDLL
@@ -1002,7 +1002,7 @@ endif()
 
 audacity_append_common_compiler_options( OPTIONS "${${_OPT}use_pch}" )
 
-list( APPEND LDFLAGS
+set( LDFLAGS
    PRIVATE
       $<$<CXX_COMPILER_ID:MSVC>:/MANIFEST:NO>
       $<$<CXX_COMPILER_ID:GNU>:-Wl,--disable-new-dtags>
@@ -1063,7 +1063,7 @@ endif()
 
 if( CMAKE_SYSTEM_NAME MATCHES "Windows" )
    # Define the Windows specific resources
-   list( APPEND WIN_RESOURCES
+   set( WIN_RESOURCES
       ../win/audacity.rc
    )
 
@@ -1112,7 +1112,7 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
    endif()
 
    # Define Mac specific resources
-   list( APPEND MAC_RESOURCES
+   set( MAC_RESOURCES
       ../mac/Resources/Audacity.icns
       ../mac/Resources/AudacityAIFF.icns
       ../mac/Resources/AudacityAU.icns

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+#[[
+Configure the executable, modules, and libraries
+]]
 
 set( TARGET Audacity )
 set( TARGET_ROOT ${topdir}/src )


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

Make CMakeLists.txt files in src, libraries, and modules conform to these conventions:

1 Each begins with a multiline comment explaining its purpose

2 `set(...)` and not `list( APPEND ... )` is used for the first assignment of any CMake variable
meant to be local to the file; so that in case the variable was nonempty in the parent scope,
this does not contaminate the local scope's copy

QA:
Nothing -- this is likely a straight-to-merge change

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
