### PR TITLE
Realtime limiter

### DIFF
--- a/libraries/lib-effects/CMakeLists.txt
+++ b/libraries/lib-effects/CMakeLists.txt
@@ -19,6 +19,13 @@ set( SOURCES
    PerTrackEffect.h
    StatefulEffectBase.cpp
    StatefulEffectBase.h
+
+   processors/CompressorProcessor.cpp
+   processors/CompressorProcessor.h
+   processors/SimpleCompressor/GainReductionComputer.cpp
+   processors/SimpleCompressor/GainReductionComputer.h
+   processors/SimpleCompressor/LookAheadGainReduction.cpp
+   processors/SimpleCompressor/LookAheadGainReduction.h
 )
 set( LIBRARIES
    lib-command-parameters-interface

--- a/libraries/lib-effects/processors/CompressorProcessor.cpp
+++ b/libraries/lib-effects/processors/CompressorProcessor.cpp
@@ -1,0 +1,157 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CompressorProcessor.cpp
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+
+#include "CompressorProcessor.h"
+#include "SimpleCompressor/GainReductionComputer.h"
+#include "SimpleCompressor/LookAheadGainReduction.h"
+#include <algorithm>
+#include <cassert>
+
+CompressorProcessor::CompressorProcessor(const CompressorSettings& settings)
+    : mGainReductionComputer { std::make_unique<
+         DanielRudrich::GainReductionComputer>() }
+    , mLookAheadGainReduction { std::make_unique<
+         DanielRudrich::LookAheadGainReduction>() }
+    , mSettings { settings }
+{
+}
+
+CompressorProcessor::~CompressorProcessor() = default;
+
+void CompressorProcessor::ApplySettingsIfNeeded(
+   const CompressorSettings& settings)
+{
+   if (settings == mSettings)
+      return;
+
+   const auto needsReinit = settings.lookaheadMs != mSettings.lookaheadMs;
+   mSettings = settings;
+
+   mGainReductionComputer->setThreshold(settings.thresholdDb);
+   mGainReductionComputer->setKnee(settings.kneeDb);
+   mGainReductionComputer->setAttackTime(settings.attackMs / 1000);
+   mGainReductionComputer->setReleaseTime(settings.releaseMs / 1000);
+   mGainReductionComputer->setRatio(settings.ratio);
+   mGainReductionComputer->setMakeUpGain(settings.makeUpDb);
+   mLookAheadGainReduction->setDelayTime(settings.lookaheadMs / 1000);
+
+   if (needsReinit)
+      Reinit();
+}
+
+void CompressorProcessor::Init(int sampleRate, int numChannels, int blockSize)
+{
+   mSampleRate = sampleRate;
+   mNumChannels = numChannels;
+   mBlockSize = std::min(blockSize, maxBlockSize);
+   Reinit();
+}
+
+const CompressorSettings& CompressorProcessor::GetSettings() const
+{
+   return mSettings;
+}
+
+void CompressorProcessor::Process(
+   const float* const* inBlock, float* const* outBlock, int blockLen)
+{
+   assert(Initialized());
+   if (!Initialized())
+      return;
+
+   auto processed = 0;
+   std::vector<const float*> in(mNumChannels);
+   std::vector<float*> out(mNumChannels);
+   while (processed < blockLen)
+   {
+      for (auto i = 0; i < mNumChannels; ++i)
+      {
+         in[i] = inBlock[i] + processed;
+         out[i] = outBlock[i] + processed;
+      }
+      const auto toProcess = std::min(blockLen - processed, mBlockSize);
+      UpdateEnvelope(in.data(), toProcess);
+      CopyWithDelay(in.data(), toProcess);
+      ApplyEnvelope(out.data(), toProcess);
+      processed += toProcess;
+   }
+}
+
+void CompressorProcessor::UpdateEnvelope(const float* const* in, int blockLen)
+{
+   // Fill mEnvelope with max of all in channels;
+   for (auto i = 0; i < blockLen; ++i)
+   {
+      auto max = 0.f;
+      for (auto j = 0; j < mNumChannels; ++j)
+      {
+         const auto x = std::abs(in[j][i]);
+         if (x > max)
+            max = x;
+      }
+      mEnvelope[i] = max;
+   }
+
+   // TODO: uses std::log10 ; use log2 optimization instead.
+   mGainReductionComputer->computeGainInDecibelsFromSidechainSignal(
+      mEnvelope.data(), mEnvelope.data(), blockLen);
+
+   if (mSettings.lookaheadMs <= 0)
+      return;
+
+   mLookAheadGainReduction->pushSamples(mEnvelope.data(), blockLen);
+   mLookAheadGainReduction->process();
+   mLookAheadGainReduction->readSamples(mEnvelope.data(), blockLen);
+}
+
+void CompressorProcessor::CopyWithDelay(const float* const* in, int blockLen)
+{
+   const auto d = +mLookAheadGainReduction->getDelayInSamples();
+   for (auto i = 0; i < mNumChannels; ++i)
+      std::copy(in[i], in[i] + blockLen, mDelayedInput[i].data() + d);
+}
+
+void CompressorProcessor::ApplyEnvelope(float* const* out, int blockLen)
+{
+   const auto makeupGainDb = mGainReductionComputer->getMakeUpGain();
+   const auto d = +mLookAheadGainReduction->getDelayInSamples();
+   for (auto i = 0; i < mNumChannels; ++i)
+   {
+      const auto in = mDelayedInput[i].data();
+      for (auto j = 0; j < blockLen; ++j)
+         out[i][j] =
+            in[j] * std::pow(10.f, 0.05f * (mEnvelope[j] + makeupGainDb));
+      std::move(in + blockLen, in + blockLen + d, in);
+   }
+}
+
+void CompressorProcessor::Reinit()
+{
+   if (!Initialized())
+      // Not there yet.
+      return;
+   mGainReductionComputer->prepare(mSampleRate);
+   // In this order: setDelayTime, then prepare:
+   mLookAheadGainReduction->setDelayTime(mSettings.lookaheadMs / 1000);
+   mLookAheadGainReduction->prepare(mSampleRate, mBlockSize);
+   const auto d = mLookAheadGainReduction->getDelayInSamples();
+   mDelayedInput.resize(mNumChannels);
+   std::for_each(mDelayedInput.begin(), mDelayedInput.end(), [&](auto& v) {
+      v.resize(d + mBlockSize);
+      std::fill(v.begin(), v.end(), 0.f);
+   });
+   std::fill(mEnvelope.begin(), mEnvelope.end(), 0.f);
+}
+
+bool CompressorProcessor::Initialized() const
+{
+   return mSampleRate != 0 && mNumChannels != 0 && mBlockSize != 0;
+}

--- a/libraries/lib-effects/processors/CompressorProcessor.h
+++ b/libraries/lib-effects/processors/CompressorProcessor.h
@@ -23,34 +23,49 @@ class LookAheadGainReduction;
 
 struct LimiterSettings
 {
+   static constexpr double thresholdDbDefault = -3;
+   static constexpr double kneeDbDefault = 0;
+   static constexpr double lookaheadMsDefault = 0;
+   static constexpr double releaseMsDefault = 15;
+   static constexpr double ceilingDbDefault = -1;
+
+   double thresholdDb { thresholdDbDefault };
+   double kneeDb { kneeDbDefault };
+   double lookaheadMs { lookaheadMsDefault };
+   double releaseMs { releaseMsDefault };
+   double ceilingDb { ceilingDbDefault };
+};
+
+struct CompressorSettings
+{
    static constexpr double thresholdDbDefault = -10;
    static constexpr double kneeDbDefault = 0;
    static constexpr double lookaheadMsDefault = 0;
    static constexpr double releaseMsDefault = 150;
    static constexpr double makeUpDbDefault = 0;
+   static constexpr double attackMsDefault = 30;
+   static constexpr double ratioDefault = 10;
+   static constexpr double infRatio = std::numeric_limits<double>::infinity();
 
    double thresholdDb { thresholdDbDefault };
    double kneeDb { kneeDbDefault };
    double lookaheadMs { lookaheadMsDefault };
    double releaseMs { releaseMsDefault };
    double makeUpDb { makeUpDbDefault };
-};
-
-struct CompressorSettings : LimiterSettings
-{
-   static constexpr double attackMsDefault = 30;
-   static constexpr double ratioDefault = 10;
-   static constexpr double infRatio = std::numeric_limits<double>::infinity();
-
    double attackMs { attackMsDefault };
    double ratio { ratioDefault };
 
    CompressorSettings() = default;
-   CompressorSettings(const LimiterSettings& settings)
-       : LimiterSettings(settings)
+
+   CompressorSettings(const LimiterSettings& limiterSettings)
+       : thresholdDb { limiterSettings.thresholdDb }
+       , kneeDb { limiterSettings.kneeDb }
+       , lookaheadMs { limiterSettings.lookaheadMs }
+       , releaseMs { limiterSettings.releaseMs }
+       , makeUpDb { limiterSettings.ceilingDb - limiterSettings.thresholdDb }
+       , attackMs { 0. }
+       , ratio { infRatio }
    {
-      attackMs = 0;
-      ratio = infRatio;
    }
 };
 

--- a/libraries/lib-effects/processors/CompressorProcessor.h
+++ b/libraries/lib-effects/processors/CompressorProcessor.h
@@ -1,0 +1,108 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CompressorProcessor.h
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#pragma once
+
+#include <array>
+#include <memory>
+#include <vector>
+
+namespace DanielRudrich
+{
+class GainReductionComputer;
+class LookAheadGainReduction;
+} // namespace DanielRudrich
+
+struct LimiterSettings
+{
+   static constexpr double thresholdDbDefault = -10;
+   static constexpr double kneeDbDefault = 0;
+   static constexpr double lookaheadMsDefault = 0;
+   static constexpr double releaseMsDefault = 150;
+   static constexpr double makeUpDbDefault = 0;
+
+   double thresholdDb { thresholdDbDefault };
+   double kneeDb { kneeDbDefault };
+   double lookaheadMs { lookaheadMsDefault };
+   double releaseMs { releaseMsDefault };
+   double makeUpDb { makeUpDbDefault };
+};
+
+struct CompressorSettings : LimiterSettings
+{
+   static constexpr double attackMsDefault = 30;
+   static constexpr double ratioDefault = 10;
+   static constexpr double infRatio = std::numeric_limits<double>::infinity();
+
+   double attackMs { attackMsDefault };
+   double ratio { ratioDefault };
+
+   CompressorSettings() = default;
+   CompressorSettings(const LimiterSettings& settings)
+       : LimiterSettings(settings)
+   {
+      attackMs = 0;
+      ratio = infRatio;
+   }
+};
+
+constexpr bool
+operator==(const CompressorSettings& lhs, const CompressorSettings& rhs)
+{
+   return lhs.thresholdDb == rhs.thresholdDb && lhs.kneeDb == rhs.kneeDb &&
+          lhs.lookaheadMs == rhs.lookaheadMs && lhs.attackMs == rhs.attackMs &&
+          lhs.releaseMs == rhs.releaseMs && lhs.ratio == rhs.ratio &&
+          lhs.makeUpDb == rhs.makeUpDb;
+}
+
+constexpr bool
+operator!=(const CompressorSettings& lhs, const CompressorSettings& rhs)
+{
+   return !(lhs == rhs);
+}
+
+class EFFECTS_API CompressorProcessor
+{
+public:
+   CompressorProcessor(const CompressorSettings& settings = {});
+   CompressorProcessor(const CompressorProcessor& other) = delete;
+   ~CompressorProcessor();
+
+   void ApplySettingsIfNeeded(const CompressorSettings& settings);
+   void Init(int sampleRate, int numChannels, int blockSize);
+   void Reinit();
+   const CompressorSettings& GetSettings() const;
+   void
+   Process(const float* const* inBlock, float* const* outBlock, int blockLen);
+
+private:
+   void UpdateEnvelope(const float* const* inBlock, int blockLen);
+   void CopyWithDelay(const float* const* inBlock, int blockLen);
+   void ApplyEnvelope(float* const* outBlock, int blockLen);
+   bool Initialized() const;
+
+   static constexpr auto maxBlockSize = 512;
+
+   const std::unique_ptr<DanielRudrich::GainReductionComputer>
+      mGainReductionComputer;
+   const std::unique_ptr<DanielRudrich::LookAheadGainReduction>
+      mLookAheadGainReduction;
+   CompressorSettings mSettings;
+   int mSampleRate = 0;
+   int mNumChannels = 0;
+   int mBlockSize = 0;
+   std::array<float, maxBlockSize> mEnvelope;
+   std::vector<std::vector<float>>
+      mDelayedInput; // Can't conveniently use an array here, because neither
+                     // delay time nor sample rate are known at compile time.
+                     // Re-allocation during playback is only done if the user
+                     // changes the look-ahead settings, in which case glitches
+                     // are hardly avoidable anyway.
+};

--- a/libraries/lib-effects/processors/CompressorProcessor.h
+++ b/libraries/lib-effects/processors/CompressorProcessor.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <array>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.cpp
+++ b/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.cpp
@@ -1,0 +1,143 @@
+/*
+ This file is part of the SimpleCompressor project.
+ https://github.com/DanielRudrich/SimpleCompressor
+ Copyright (c) 2019 Daniel Rudrich
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "GainReductionComputer.h"
+
+GainReductionComputer::GainReductionComputer()
+{
+    sampleRate = 0.0f;
+
+    threshold = -10.0f;
+    knee = 0.0f;
+    kneeHalf = 0.0f;
+    attackTime = 0.01f;
+    releaseTime = 0.15f;
+    setRatio (2); // 2 : 1
+    makeUpGain = 0.0f;
+    reset();
+}
+
+void GainReductionComputer::prepare (const double newSampleRate)
+{
+    sampleRate = newSampleRate;
+
+    alphaAttack = 1.0f - timeToGain (attackTime);
+    alphaRelease = 1.0f - timeToGain (releaseTime);
+}
+
+void GainReductionComputer::setAttackTime (const float attackTimeInSeconds)
+{
+    attackTime = attackTimeInSeconds;
+    alphaAttack = 1.0f - timeToGain (attackTime);
+}
+
+void GainReductionComputer::setReleaseTime (const float releaseTimeInSeconds)
+{
+    releaseTime = releaseTimeInSeconds;
+    alphaRelease = 1.0f - timeToGain (releaseTime);
+}
+
+const float GainReductionComputer::timeToGain (const float timeInSeconds)
+{
+    return std::exp (-1.0f / (static_cast<float> (sampleRate) * timeInSeconds));
+}
+
+void GainReductionComputer::setKnee (const float kneeInDecibels)
+{
+    knee = kneeInDecibels;
+    kneeHalf = knee / 2.0f;
+}
+
+void GainReductionComputer::setThreshold (const float thresholdInDecibels)
+{
+    threshold = thresholdInDecibels;
+}
+
+void GainReductionComputer::setMakeUpGain (const float makeUpGainInDecibels)
+{
+    makeUpGain = makeUpGainInDecibels;
+}
+
+void GainReductionComputer::setRatio (const float ratio)
+{
+    slope = 1.0f / ratio - 1.0f;
+}
+
+
+inline const float GainReductionComputer::applyCharacteristicToOverShoot (const float overShootInDecibels)
+{
+    if (overShootInDecibels <= -kneeHalf)
+        return 0.0f;
+    else if (overShootInDecibels > -kneeHalf && overShootInDecibels <= kneeHalf)
+        return 0.5f * slope * (overShootInDecibels + kneeHalf) * (overShootInDecibels + kneeHalf) / knee;
+    else
+        return slope * overShootInDecibels;
+}
+
+void GainReductionComputer::computeGainInDecibelsFromSidechainSignal (const float* sideChainSignal, float* destination, const int numSamples)
+{
+    maxInputLevel = -std::numeric_limits<float>::infinity();
+    maxGainReduction = 0.0f;
+
+    for (int i = 0; i < numSamples; ++i)
+    {
+        // convert sample to decibels
+        const float levelInDecibels = 20.0f * std::log10 (abs (sideChainSignal[i]));
+
+        if (levelInDecibels > maxInputLevel)
+            maxInputLevel = levelInDecibels;
+
+        // calculate overshoot and apply knee and ratio
+        const float overShoot = levelInDecibels - threshold;
+        const float gainReduction = applyCharacteristicToOverShoot (overShoot);
+
+        // apply ballistics
+        const float diff = gainReduction - state;
+        if (diff < 0.0f) // wanted gain reduction is below state -> attack phase
+            state += alphaAttack * diff;
+        else // release phase
+            state += alphaRelease * diff;
+
+        // write back gain reduction
+        destination[i] = state;
+
+        if (state < maxGainReduction)
+            maxGainReduction = state;
+    }
+}
+
+void GainReductionComputer::computeLinearGainFromSidechainSignal (const float* sideChainSignal, float* destination, const int numSamples)
+{
+    computeGainInDecibelsFromSidechainSignal (sideChainSignal, destination, numSamples);
+    for (int i = 0; i < numSamples; ++i)
+        destination[i] = std::pow (10.0f, 0.05f * (destination[i] + makeUpGain));
+}
+
+
+void GainReductionComputer::getCharacteristic (float* inputLevelsInDecibels, float* dest, const int numSamples)
+{
+    for (int i = 0; i < numSamples; ++i)
+        dest[i] = getCharacteristicSample (inputLevelsInDecibels[i]);
+}
+
+float GainReductionComputer::getCharacteristicSample (const float inputLevelInDecibels)
+{
+    float overShoot = inputLevelInDecibels - threshold;
+    overShoot = applyCharacteristicToOverShoot (overShoot);
+    return overShoot + inputLevelInDecibels + makeUpGain;
+}

--- a/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.cpp
+++ b/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.cpp
@@ -18,6 +18,8 @@
 
 #include "GainReductionComputer.h"
 
+#include "MathApprox.h"
+
 namespace DanielRudrich {
 GainReductionComputer::GainReductionComputer()
 {
@@ -98,7 +100,8 @@ void GainReductionComputer::computeGainInDecibelsFromSidechainSignal (const floa
     for (int i = 0; i < numSamples; ++i)
     {
         // convert sample to decibels
-        const float levelInDecibels = 20.0f * std::log10 (abs (sideChainSignal[i]));
+        constexpr auto C = 20 / 3.321928094887362; // 20 / log2(10)
+        const float levelInDecibels = C * FastLog2(abs(sideChainSignal[i]));
 
         if (levelInDecibels > maxInputLevel)
             maxInputLevel = levelInDecibels;

--- a/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.cpp
+++ b/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.cpp
@@ -18,6 +18,7 @@
 
 #include "GainReductionComputer.h"
 
+namespace DanielRudrich {
 GainReductionComputer::GainReductionComputer()
 {
     sampleRate = 0.0f;
@@ -141,3 +142,4 @@ float GainReductionComputer::getCharacteristicSample (const float inputLevelInDe
     overShoot = applyCharacteristicToOverShoot (overShoot);
     return overShoot + inputLevelInDecibels + makeUpGain;
 }
+} // namespace DanielRudrich

--- a/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.h
+++ b/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.h
@@ -1,0 +1,126 @@
+/*
+ This file is part of the SimpleCompressor project.
+ https://github.com/DanielRudrich/SimpleCompressor
+ Copyright (c) 2019 Daniel Rudrich
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <vector>
+#include <limits>
+#include <cmath>
+#include <atomic>
+
+/**
+ This class acts as the side-chain path of a dynamic range compressor. It processes a given side-chain signal and computes the gain reduction samples depending on the parameters threshold, knee, attack-time, release-time, ratio, and make-up gain.
+ */
+class GainReductionComputer
+{
+public:
+    GainReductionComputer();
+    ~GainReductionComputer() {}
+
+    // ======================================================================
+    /**
+     Sets the attack time of the compressor in seconds.
+     */
+    void setAttackTime (const float attackTimeInSeconds);
+
+    /**
+     Sets the release time of the compressorin seconds
+     */
+    void setReleaseTime (const float releaseTimeInSeconds);
+
+    /**
+     Sets the knee-width in decibels.
+     */
+    void setKnee (const float kneeInDecibels);
+    const float getKnee() { return knee; }
+
+    /**
+     Sets the threshold above which the compressor will start to compress the signal.
+     */
+    void setThreshold (const float thresholdInDecibels);
+    const float getThreshold() { return threshold; }
+
+    /**
+     Sets the make-up-gain of the compressor in decibels.
+     */
+    void setMakeUpGain (const float makeUpGainInDecibels);
+    const float getMakeUpGain()  { return makeUpGain; }
+
+    /**
+     Sets the ratio of input-output signal above threshold. Set to 1 for no compression, up to infinity for a brickwall limiter.
+     */
+    void setRatio (const float ratio);
+
+    // ======================================================================
+    /**
+     Computes the static output levels for an array of input levels in decibels. Useful for visualization of the compressor's characteristic. Will contain make-up gain.
+     */
+    void getCharacteristic (float* inputLevelsInDecibels, float* destination, const int numSamples);
+
+    /**
+     Computes the static output levels for a given input level in decibels. Useful for visualization of the compressor's characteristic. Will contain make-up gain.
+     */
+    float getCharacteristicSample (const float inputLevelInDecibels);
+
+    // ======================================================================
+    /**
+     Prepares the compressor with sampleRate and expected blockSize. Make sure you call this before you do any processing!
+     */
+    void prepare (const double sampleRate);
+
+    /**
+     Resets the internal state of the compressor.
+     */
+    void reset() { state = 0.0f; }
+
+    /**
+     Computes the gain reduction for a given side-chain signal. The values will be in decibels and will NOT contain the make-up gain.
+     */
+    void computeGainInDecibelsFromSidechainSignal (const float* sideChainSignal, float* destination, const int numSamples);
+
+    /**
+     Computes the linear gain including make-up gain for a given side-chain signal. The gain written to the destination can be directly applied to the signals which should be compressed.
+     */
+    void computeLinearGainFromSidechainSignal (const float* sideChainSignal, float* destination, const int numSamples);
+
+    const float getMaxInputLevelInDecibels() { return maxInputLevel; }
+    const float getMaxGainReductionInDecibels() { return maxGainReduction; }
+
+private:
+    inline const float timeToGain (const float timeInSeconds);
+    inline const float applyCharacteristicToOverShoot (const float overShootInDecibels);
+
+    double sampleRate;
+
+    // parameters
+    float knee, kneeHalf;
+    float threshold;
+    float attackTime;
+    float releaseTime;
+    float slope;
+    float makeUpGain;
+
+    std::atomic<float> maxInputLevel {-std::numeric_limits<float>::infinity()};
+    std::atomic<float> maxGainReduction {0};
+
+    //state variable
+    float state;
+
+    float alphaAttack;
+    float alphaRelease;
+};

--- a/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.h
+++ b/libraries/lib-effects/processors/SimpleCompressor/GainReductionComputer.h
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <atomic>
 
+namespace DanielRudrich {
 /**
  This class acts as the side-chain path of a dynamic range compressor. It processes a given side-chain signal and computes the gain reduction samples depending on the parameters threshold, knee, attack-time, release-time, ratio, and make-up gain.
  */
@@ -124,3 +125,4 @@ private:
     float alphaAttack;
     float alphaRelease;
 };
+} // namespace DanielRudrich

--- a/libraries/lib-effects/processors/SimpleCompressor/LookAheadGainReduction.cpp
+++ b/libraries/lib-effects/processors/SimpleCompressor/LookAheadGainReduction.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <algorithm>
 
+namespace DanielRudrich {
 void LookAheadGainReduction::setDelayTime (float delayTimeInSeconds)
 {
     if (delayTimeInSeconds <= 0.0f)
@@ -271,3 +272,4 @@ inline void LookAheadGainReduction::getReadPositions (int numSamples, int& start
         blockSize2 = numSamples <= 0 ? 0 : numSamples;
     }
 }
+} // namespace DanielRudrich

--- a/libraries/lib-effects/processors/SimpleCompressor/LookAheadGainReduction.cpp
+++ b/libraries/lib-effects/processors/SimpleCompressor/LookAheadGainReduction.cpp
@@ -1,0 +1,273 @@
+/*
+ This file is part of the SimpleCompressor project.
+ https://github.com/DanielRudrich/SimpleCompressor
+ Copyright (c) 2019 Daniel Rudrich
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "LookAheadGainReduction.h"
+#include <cmath>
+#include <algorithm>
+
+void LookAheadGainReduction::setDelayTime (float delayTimeInSeconds)
+{
+    if (delayTimeInSeconds <= 0.0f)
+        delay = 0.0f;
+    else
+        delay = delayTimeInSeconds;
+
+    if (sampleRate != 0.0)
+        prepare (sampleRate, blockSize);
+}
+
+void LookAheadGainReduction::prepare (const double newSampleRate, const int newBlockSize)
+{
+    sampleRate = newSampleRate;
+    blockSize = newBlockSize;
+
+    delayInSamples = static_cast<int> (delay * sampleRate);
+
+    buffer.resize (blockSize + delayInSamples);
+    std::fill (buffer.begin(), buffer.end(), 0.0f);
+    writePosition = 0;
+}
+
+void LookAheadGainReduction::pushSamples (const float* src, const int numSamples)
+{
+    int startIndex, blockSize1, blockSize2;
+
+    // write in delay line
+    getWritePositions (numSamples, startIndex, blockSize1, blockSize2);
+
+    for (int i = 0; i < blockSize1; ++i)
+        buffer[startIndex + i] = src[i];
+
+    if (blockSize2 > 0)
+        for (int i = 0; i < blockSize2; ++i)
+            buffer[i] = src[blockSize1 + i];
+
+    writePosition += numSamples;
+    writePosition = writePosition % buffer.size();
+
+    lastPushedSamples = numSamples;
+}
+
+void LookAheadGainReduction::process()
+{
+    /** The basic idea here is to look for high gain-reduction values in the signal, and apply a fade which starts exactly  `delayInSamples` many samples before that value appears. Depending on the value itself, the slope of the fade will vary.
+
+     Some things to note:
+        - as the samples are gain-reduction values in decibel, we actually look for negative peaks or local minima.
+        - it's easier for us to time-reverse our search, so we start with the last sample
+        - once we find a minimum, we calculate the slope, which will be called `step`
+        - with that slope, we can calculate the next value of our fade-in `nextGainReductionValue`
+        - once a value in the buffer is below our fade-in value, we found a new minimum, which might not be as deep as the previous one, but as it comes in earlier, it needs more attention, so we update our fade-in slope
+        - our buffer is a ring-buffer which makes things a little bit messy
+     */
+
+
+    // As we don't know any samples of the future, yet, we assume we don't have to apply a fade-in right now, and initialize both `nextGainReductionValue` and step (slope of the fade-in) with zero.
+    float nextGainReductionValue = 0.0f;
+    float step = 0.0f;
+
+
+    // Get the position of the last sample in the buffer, which is the sample right before our new write position.
+    int index = writePosition - 1;
+    if (index < 0) // in case it's negative...
+        index += static_cast<int> (buffer.size()); // ... add the buffersize so we wrap around.
+
+    // == FIRST STEP: Process all recently pushed samples.
+
+    // We want to process all `lastPushedSamples` many samples, so let's find out, how many we can process in a first run before we have to wrap around our `index` variable (ring-buffer).
+    int size1, size2;
+    getProcessPositions (index, lastPushedSamples, size1, size2);
+
+    // first run
+    for (int i = 0; i < size1; ++i)
+    {
+        const float smpl = buffer[index];
+
+        if (smpl > nextGainReductionValue) // in case the sample is above our ramp...
+        {
+            buffer[index] = nextGainReductionValue; // ... replace it with the current ramp value
+            nextGainReductionValue += step; // and update the next ramp value
+        }
+        else // otherwise... (new peak)
+        {
+            step = - smpl / delayInSamples; // calculate the new slope
+            nextGainReductionValue = smpl + step; // and also the new ramp value
+        }
+        --index;
+    }
+
+    // second run
+    if (size2 > 0) // in case we have some samples left for the second run
+    {
+        index = static_cast<int> (buffer.size()) - 1; // wrap around: start from the last sample of the buffer
+
+        // exactly the same procedure as before... I guess I could have written that better...
+        for (int i = 0; i < size2; ++i)
+        {
+            const float smpl = buffer[index];
+
+            if (smpl > nextGainReductionValue)
+            {
+                buffer[index] = nextGainReductionValue;
+                nextGainReductionValue += step;
+            }
+            else
+            {
+                step = - smpl / delayInSamples;
+                nextGainReductionValue = smpl + step;
+            }
+            --index;
+        }
+    }
+
+    /*
+     At this point, we have processed all the new gain-reduction values. For this, we actually don't need a delay/lookahead at all.
+     !! However, we are not finished, yet !!
+     What if the first pushed sample has such a high gain-reduction value, that itself needs a fade-in? So we have to apply a gain-ramp even further into the past. And that is exactly the reason why we need lookahead, why we need to buffer our signal for a short amount of time: so we can apply that gain ramp for the first handful of gain-reduction samples.
+     */
+
+    if (index < 0) // it's possible the index is exactly -1
+        index = static_cast<int> (buffer.size()) - 1; // so let's take care of that
+
+    /*
+     This time we only need to check `delayInSamples` many samples.
+     And there's another cool thing!
+        We know that the samples have been processed already, so in case one of the samples is below our ramp value, that's the new minimum, which has been faded-in already! So what we do is hit the break, and call it a day!
+     */
+    getProcessPositions (index, delayInSamples, size1, size2);
+    bool breakWasUsed = false;
+
+    // first run
+    for (int i = 0; i < size1; ++i) // we iterate over the first size1 samples
+    {
+        const float smpl = buffer[index];
+
+        if (smpl > nextGainReductionValue) // in case the sample is above our ramp...
+        {
+            buffer[index] = nextGainReductionValue; // ... replace it with the current ramp value
+            nextGainReductionValue += step; // and update the next ramp value
+        }
+        else // otherwise... JACKPOT! Nothing left to do here!
+        {
+            breakWasUsed = true; // let the guys know we are finished
+            break;
+        }
+        --index;
+    }
+
+    // second run
+    if (! breakWasUsed && size2 > 0) // is there still some work to do?
+    {
+        index = static_cast<int> (buffer.size()) - 1; // wrap around (ring-buffer)
+        for (int i = 0; i < size2; ++i)
+        {
+            const float smpl = buffer[index];
+
+            // same as before
+            if (smpl > nextGainReductionValue) // in case the sample is above our ramp...
+            {
+                buffer[index] = nextGainReductionValue; // ... replace it with the current ramp value
+                nextGainReductionValue += step; // and update the next ramp value
+            }
+            else // otherwise... already processed -> byebye!
+                break;
+            --index;
+        }
+    }
+}
+
+
+void LookAheadGainReduction::readSamples (float* dest, int numSamples)
+{
+    int startIndex, blockSize1, blockSize2;
+
+    // read from delay line
+    getReadPositions (numSamples, startIndex, blockSize1, blockSize2);
+
+    for (int i = 0; i < blockSize1; ++i)
+        dest[i] = buffer[startIndex + i];
+
+    if (blockSize2 > 0)
+        for (int i = 0; i < blockSize2; ++i)
+            dest[blockSize1 + i] = buffer[i];
+}
+
+
+inline void LookAheadGainReduction::getProcessPositions (int startIndex, int numSamples, int& blockSize1, int& blockSize2)
+{
+    if (numSamples <= 0)
+    {
+        blockSize1 = 0;
+        blockSize2 = 0;
+    }
+    else
+    {
+        blockSize1 = std::min (startIndex + 1, numSamples);
+        numSamples -= blockSize1;
+        blockSize2 = numSamples <= 0 ? 0 : numSamples;
+    }
+}
+
+inline void LookAheadGainReduction::getWritePositions (int numSamples, int& startIndex, int& blockSize1, int& blockSize2)
+{
+    const int L = static_cast<int> (buffer.size());
+    int pos = writePosition;
+
+    if (pos < 0)
+        pos = pos + L;
+    pos = pos % L;
+
+    if (numSamples <= 0)
+    {
+        startIndex = 0;
+        blockSize1 = 0;
+        blockSize2 = 0;
+    }
+    else
+    {
+        startIndex = pos;
+        blockSize1 = std::min (L - pos, numSamples);
+        numSamples -= blockSize1;
+        blockSize2 = numSamples <= 0 ? 0 : numSamples;
+    }
+}
+
+inline void LookAheadGainReduction::getReadPositions (int numSamples, int& startIndex, int& blockSize1, int& blockSize2)
+{
+    const int L = static_cast<int> (buffer.size());
+    int pos = writePosition - lastPushedSamples - delayInSamples;
+
+    if (pos < 0)
+        pos = pos + L;
+    pos = pos % L;
+
+    if (numSamples <= 0)
+    {
+        startIndex = 0;
+        blockSize1 = 0;
+        blockSize2 = 0;
+    }
+    else
+    {
+        startIndex = pos;
+        blockSize1 = std::min (L - pos, numSamples);
+        numSamples -= blockSize1;
+        blockSize2 = numSamples <= 0 ? 0 : numSamples;
+    }
+}

--- a/libraries/lib-effects/processors/SimpleCompressor/LookAheadGainReduction.h
+++ b/libraries/lib-effects/processors/SimpleCompressor/LookAheadGainReduction.h
@@ -20,6 +20,7 @@
 #pragma once
 #include <vector>
 
+namespace DanielRudrich {
 /** This class acts as a delay line for gain-reduction samples, which additionally fades in high gain-reduction values in order to avoid distortion when limiting an audio signal.
  */
 class LookAheadGainReduction
@@ -70,3 +71,4 @@ private:
     int lastPushedSamples = 0;
     std::vector<float> buffer;
 };
+} // namespace DanielRudrich

--- a/libraries/lib-effects/processors/SimpleCompressor/LookAheadGainReduction.h
+++ b/libraries/lib-effects/processors/SimpleCompressor/LookAheadGainReduction.h
@@ -1,0 +1,72 @@
+/*
+ This file is part of the SimpleCompressor project.
+ https://github.com/DanielRudrich/SimpleCompressor
+ Copyright (c) 2019 Daniel Rudrich
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+#include <vector>
+
+/** This class acts as a delay line for gain-reduction samples, which additionally fades in high gain-reduction values in order to avoid distortion when limiting an audio signal.
+ */
+class LookAheadGainReduction
+{
+public:
+    LookAheadGainReduction() : sampleRate (0.0) {}
+    ~LookAheadGainReduction() {}
+
+    void setDelayTime (float delayTimeInSeconds);
+
+    const int getDelayInSamples() { return delayInSamples; }
+
+    /** Prepares the processor so it can resize the buffers depending on samplerate and the expected buffersize.
+     */
+    void prepare (const double sampleRate, const int blockSize);
+
+    /** Writes gain-reduction samples into the delay-line. Make sure you call process() afterwards, and read the same amount of samples with the readSamples method. Make also sure the pushed samples are decibel values.
+     */
+    void pushSamples (const float* src, const int numSamples);
+
+    /** Processes the data within the delay line, i.e. fades-in high gain-reduction, in order to reduce distortions.
+     */
+    void process();
+
+    /** Reads smoothed gain-reduction samples back to the destination. Make sure you read as many samples as you've pushed before!
+     */
+    void readSamples (float* dest, const int numSamples);
+
+
+private:
+    /** A little helper-function which calulcates how many samples we should process in a first step before we have to wrap around, as our buffer is a ring-buffer.
+     */
+    inline void getProcessPositions (int startIndex, int numSamples, int& blockSize1, int& blockSize2);
+
+    inline void getWritePositions (int numSamples, int& startIndex, int& blockSize1, int& blockSize2);
+
+    inline void getReadPositions (int numSamples, int& startIndex, int& blockSize1, int& blockSize2);
+
+
+private:
+    //==============================================================================
+    double sampleRate;
+    int blockSize;
+
+    float delay;
+    int delayInSamples = 0;
+    int writePosition = 0;
+    int lastPushedSamples = 0;
+    std::vector<float> buffer;
+};

--- a/libraries/lib-effects/tests/CMakeLists.txt
+++ b/libraries/lib-effects/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_unit_test(
+   NAME
+      lib-effects
+   SOURCES
+      CompressorProcessorTests.cpp
+   LIBRARIES
+      lib-effects
+)

--- a/libraries/lib-effects/tests/CompressorProcessorTests.cpp
+++ b/libraries/lib-effects/tests/CompressorProcessorTests.cpp
@@ -1,0 +1,47 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CompressorProcessorTests.cpp
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#pragma once
+
+#include "processors/CompressorProcessor.h"
+#include <catch2/catch.hpp>
+
+TEST_CASE("CompressorProcessor", "smoke test")
+{
+   CompressorSettings settings;
+   settings.lookaheadMs = 5;
+   CompressorProcessor sut { settings };
+   constexpr auto sampleRate = 44100;
+   constexpr auto numChannels = 2;
+   constexpr auto blockSize = 44100;
+   constexpr auto signalSize = 2 * blockSize;
+   sut.Init(sampleRate, numChannels, blockSize);
+   std::vector<std::vector<float>> buffer(numChannels);
+   std::vector<float*> pointers(numChannels);
+   for (auto i = 0; i < numChannels; ++i)
+   {
+      auto& in = buffer[i];
+      in.resize(signalSize);
+      std::fill(in.begin(), in.begin() + signalSize / 2, 0.0f);
+      std::fill(in.begin() + signalSize / 2, in.end(), 1.0f);
+   }
+   auto progress = 0;
+   while (progress < signalSize)
+   {
+      const auto remaining = signalSize - progress;
+      const auto toProcess = std::min(remaining, blockSize);
+      std::transform(
+         buffer.begin(), buffer.end(), pointers.begin(),
+         [progress](std::vector<float>& v) { return v.data() + progress; });
+      const auto p = pointers.data();
+      sut.Process(p, p, toProcess);
+      progress += toProcess;
+   }
+}

--- a/resources/EffectsMenuDefaults.xml
+++ b/resources/EffectsMenuDefaults.xml
@@ -9,6 +9,8 @@
             <Effect>Normalize</Effect>
             <Effect>Loudness Normalization</Effect>
             <Effect>Auto Duck</Effect>
+            <Effect>Real-time Compressor</Effect>
+            <Effect>Real-time Limiter</Effect>
         </Effects>
     </Group>
     <Group>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -333,6 +333,7 @@ list( APPEND SOURCES
       effects/Distortion.h
       effects/DtmfGen.cpp
       effects/DtmfGen.h
+      effects/DynamicRangeProcessorEditor.h
       effects/EBUR128.cpp
       effects/EBUR128.h
       effects/Echo.cpp
@@ -376,6 +377,10 @@ list( APPEND SOURCES
       effects/Generator.h
       effects/Invert.cpp
       effects/Invert.h
+      effects/Limiter.cpp
+      effects/Limiter.h
+      effects/LimiterEditor.cpp
+      effects/LimiterEditor.h
       effects/Loudness.cpp
       effects/Loudness.h
       effects/Noise.cpp
@@ -390,6 +395,12 @@ list( APPEND SOURCES
       effects/Paulstretch.h
       effects/Phaser.cpp
       effects/Phaser.h
+      effects/Compressor.cpp
+      effects/Compressor.h
+      effects/CompressorEditor.cpp
+      effects/CompressorEditor.h
+      effects/CompressorInstance.cpp
+      effects/CompressorInstance.h
       effects/RealtimeEffectStateUI.cpp
       effects/RealtimeEffectStateUI.h
       effects/Repair.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,8 +327,6 @@ list( APPEND SOURCES
       effects/ChangeTempo.h
       effects/ClickRemoval.cpp
       effects/ClickRemoval.h
-      effects/Compressor.cpp
-      effects/Compressor.h
       effects/Contrast.cpp
       effects/Contrast.h
       effects/Distortion.cpp
@@ -386,12 +384,14 @@ list( APPEND SOURCES
       effects/NoiseReduction.h
       effects/Normalize.cpp
       effects/Normalize.h
+      effects/OfflineCompressor.cpp
+      effects/OfflineCompressor.h
       effects/Paulstretch.cpp
       effects/Paulstretch.h
       effects/Phaser.cpp
       effects/Phaser.h
-      effects/RealtimeEffectStateUI.h
       effects/RealtimeEffectStateUI.cpp
+      effects/RealtimeEffectStateUI.h
       effects/Repair.cpp
       effects/Repair.h
       effects/Repeat.cpp

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -1,0 +1,96 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Compressor.cpp
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+
+#include "Compressor.h"
+#include "CompressorEditor.h"
+#include "CompressorInstance.h"
+#include "LoadEffects.h"
+#include "ShuttleAutomation.h"
+
+const ComponentInterfaceSymbol EffectCompressor::Symbol { XO(
+   "Real-time Compressor") };
+
+namespace
+{
+BuiltinEffectsModule::Registration<EffectCompressor> reg;
+} // namespace
+
+const EffectParameterMethods& EffectCompressor::Parameters() const
+{
+   static CapturedParameters<
+      EffectCompressor, CompressorEditor::thresholdDb, CompressorEditor::kneeDb,
+      CompressorEditor::lookaheadMs, CompressorEditor::attackMs,
+      CompressorEditor::releaseMs, CompressorEditor::ratio,
+      CompressorEditor::makeUpDb>
+      parameters;
+   return parameters;
+}
+
+std::shared_ptr<EffectInstance> EffectCompressor::MakeInstance() const
+{
+   return std::make_shared<CompressorInstance>(*this);
+}
+
+bool EffectCompressor::CheckWhetherSkipEffect(
+   const EffectSettings& settings) const
+{
+   // TODO
+   return Effect::CheckWhetherSkipEffect(settings);
+}
+
+EffectCompressor::EffectCompressor()
+{
+   SetLinearEffectFlag(true);
+}
+
+EffectCompressor::~EffectCompressor()
+{
+}
+
+ComponentInterfaceSymbol EffectCompressor::GetSymbol() const
+{
+   return Symbol;
+}
+
+TranslatableString EffectCompressor::GetDescription() const
+{
+   return XO("A compressor");
+}
+
+ManualPageID EffectCompressor::ManualPage() const
+{
+   // TODO
+   return L"";
+}
+
+EffectType EffectCompressor::GetType() const
+{
+   return EffectTypeProcess;
+}
+
+auto EffectCompressor::RealtimeSupport() const -> RealtimeSince
+{
+   return RealtimeSince::After_3_1;
+}
+
+// Effect implementation
+
+std::unique_ptr<EffectEditor> EffectCompressor::MakeEditor(
+   ShuttleGui& S, EffectInstance&, EffectSettingsAccess& access,
+   const EffectOutputs*) const
+{
+   auto& settings = access.Get();
+   auto& myEffSettings = GetSettings(settings);
+   auto result =
+      std::make_unique<CompressorEditor>(*this, access, myEffSettings);
+   result->PopulateOrExchange(S);
+   return result;
+}

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -78,7 +78,7 @@ EffectType EffectCompressor::GetType() const
 
 auto EffectCompressor::RealtimeSupport() const -> RealtimeSince
 {
-   return RealtimeSince::After_3_1;
+   return RealtimeSince::Always;
 }
 
 // Effect implementation

--- a/src/effects/Compressor.cpp
+++ b/src/effects/Compressor.cpp
@@ -42,17 +42,16 @@ std::shared_ptr<EffectInstance> EffectCompressor::MakeInstance() const
 bool EffectCompressor::CheckWhetherSkipEffect(
    const EffectSettings& settings) const
 {
-   // TODO
-   return Effect::CheckWhetherSkipEffect(settings);
+   const auto& compressorSettings = GetSettings(settings);
+   return compressorSettings.ratio == 1 && compressorSettings.makeUpDb == 0 &&
+          // Also look-ahead, as this adds delay when used on a real-time input
+          // (mic).
+          compressorSettings.lookaheadMs == 0;
 }
 
 EffectCompressor::EffectCompressor()
 {
-   SetLinearEffectFlag(true);
-}
-
-EffectCompressor::~EffectCompressor()
-{
+   SetLinearEffectFlag(false);
 }
 
 ComponentInterfaceSymbol EffectCompressor::GetSymbol() const
@@ -62,12 +61,13 @@ ComponentInterfaceSymbol EffectCompressor::GetSymbol() const
 
 TranslatableString EffectCompressor::GetDescription() const
 {
-   return XO("A compressor");
+   return XO(
+      "Reduces \"dynamic range\", or differences between loud and quiet parts.");
 }
 
 ManualPageID EffectCompressor::ManualPage() const
 {
-   // TODO
+   // TODO: add manual page
    return L"";
 }
 

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -1,0 +1,49 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Compressor.h
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#pragma once
+
+#include "StatelessPerTrackEffect.h"
+#include "processors/CompressorProcessor.h"
+
+class ShuttleGui;
+
+class EffectCompressor final :
+    public EffectWithSettings<CompressorSettings, StatelessPerTrackEffect>
+{
+public:
+   static const ComponentInterfaceSymbol Symbol;
+
+   EffectCompressor();
+   virtual ~EffectCompressor();
+
+   // ComponentInterface implementation
+
+   ComponentInterfaceSymbol GetSymbol() const override;
+   TranslatableString GetDescription() const override;
+   ManualPageID ManualPage() const override;
+
+   // EffectDefinitionInterface implementation
+
+   EffectType GetType() const override;
+   RealtimeSince RealtimeSupport() const override;
+
+   // Effect implementation
+
+   std::unique_ptr<EffectEditor> MakeEditor(
+      ShuttleGui& S, EffectInstance& instance, EffectSettingsAccess& access,
+      const EffectOutputs* pOutputs) const override;
+
+   std::shared_ptr<EffectInstance> MakeInstance() const override;
+
+   bool CheckWhetherSkipEffect(const EffectSettings& settings) const override;
+
+   const EffectParameterMethods& Parameters() const override;
+};

--- a/src/effects/Compressor.h
+++ b/src/effects/Compressor.h
@@ -22,7 +22,6 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    EffectCompressor();
-   virtual ~EffectCompressor();
 
    // ComponentInterface implementation
 

--- a/src/effects/CompressorEditor.cpp
+++ b/src/effects/CompressorEditor.cpp
@@ -1,0 +1,86 @@
+#include "CompressorEditor.h"
+#include "ShuttleGui.h"
+
+void CompressorEditor::PopulateOrExchange(ShuttleGui& S)
+{
+   mUIParent = S.GetParent();
+   auto& ms = mSettings;
+
+   S.SetBorder(5);
+   S.AddSpace(0, 5);
+
+   S.StartMultiColumn(3, wxEXPAND);
+   {
+      S.SetStretchyCol(2);
+
+      AddTextboxAndSlider(
+         S, mThresholdDbCtrl, XXO("&Threshold (Db):"), XXO("Threshold in dB"));
+
+      AddTextboxAndSlider(
+         S, mKneeDbCtrl, XXO("&Knee (dB):"), XXO("Knee width in dB"));
+
+      AddTextboxAndSlider(
+         S, mLookaheadMsCtrl, XXO("&Lookahead (ms):"),
+         XXO("Lookahead time in ms"),
+         [&](wxCommandEvent& evt) { OnLookaheadMsSlider(evt); });
+
+      AddTextboxAndSlider(
+         S, mAttackMsCtrl, XXO("&Attack (ms):"), XXO("Attack time in ms"));
+
+      AddTextboxAndSlider(
+         S, mReleaseMsCtrl, XXO("&Release (ms):"), XXO("Release time in ms"));
+
+      AddTextboxAndSlider(
+         S, mRatioCtrl, XXO("&Ratio:"), XXO("Compression ratio"),
+         [&](wxCommandEvent& evt) { OnRatioSlider(evt); },
+         CompressorSettings::infRatio);
+
+      AddTextboxAndSlider(
+         S, mMakeUpCtrl, XXO("&Make-up gain (dB):"), XXO("Make-up gain in dB"));
+   }
+   S.EndMultiColumn();
+}
+
+namespace
+{
+// Assumes x to be in [0, 1]
+auto MapExponentially(double x)
+{
+   constexpr auto C = 5.;
+   return (std::exp(C * x) - 1) / (std::exp(C) - 1.);
+}
+
+auto MapExponentially(double min, double max, double x)
+{
+   // Map min and max to 0 and 1, and x accordingly, before applying
+   // exponential, or we may run into NaNs.
+   const auto a = 1.0 / (max - min);
+   const auto b = -min / (max - min);
+   const auto result = MapExponentially(a * x + b);
+   return (result - b) / a;
+}
+} // namespace
+
+void CompressorEditor::OnLookaheadMsSlider(wxCommandEvent& evt)
+{
+   auto& ms = mSettings;
+   ms.lookaheadMs = MapExponentially(
+      lookaheadMs.min, lookaheadMs.max, evt.GetInt() / lookaheadMs.scale);
+}
+
+void CompressorEditor::OnRatioSlider(wxCommandEvent& evt)
+{
+   auto& ms = mSettings;
+   ms.ratio = evt.GetInt() / ratio.scale;
+   if (ms.ratio == ratio.max)
+      ms.ratio = CompressorSettings::infRatio;
+}
+
+bool CompressorEditor::UpdateUI()
+{
+   auto& ms = mSettings;
+   mAttackMsCtrl.slider->SetValue((int)(ms.attackMs * attackMs.scale));
+   mRatioCtrl.slider->SetValue((int)(ms.ratio * ratio.scale));
+   return DynamicRangeProcessorEditor<
+      CompressorEditor, CompressorSettings>::UpdateUI();
+}

--- a/src/effects/CompressorEditor.cpp
+++ b/src/effects/CompressorEditor.cpp
@@ -36,7 +36,8 @@ void CompressorEditor::PopulateOrExchange(ShuttleGui& S)
          CompressorSettings::infRatio);
 
       AddTextboxAndSlider(
-         S, mMakeUpCtrl, XXO("&Make-up gain (dB):"), XXO("Make-up gain in dB"));
+         S, mMakeupDbCtrl, XXO("&Make-up gain (dB):"),
+         XXO("Make-up gain in dB"));
    }
    S.EndMultiColumn();
 }

--- a/src/effects/CompressorEditor.h
+++ b/src/effects/CompressorEditor.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "DynamicRangeProcessorEditor.h"
+#include "processors/CompressorProcessor.h"
+
+class ShuttleGui;
+
+class CompressorEditor :
+    public DynamicRangeProcessorEditor<CompressorEditor, CompressorSettings>
+{
+public:
+   CompressorEditor(
+      const EffectUIServices& services, EffectSettingsAccess& access,
+      const CompressorSettings& settings)
+       : DynamicRangeProcessorEditor<CompressorEditor, CompressorSettings> {
+          services, access, settings
+       }
+   {
+   }
+   virtual ~CompressorEditor() = default;
+
+   void PopulateOrExchange(ShuttleGui& S);
+
+   static constexpr Parameter thresholdDb {
+      &CompressorSettings::thresholdDb,
+      L"thresholdDb",
+      CompressorSettings::thresholdDbDefault,
+      -50,
+      10,
+      1
+   };
+
+   static constexpr Parameter kneeDb { &CompressorSettings::kneeDb,
+                                       L"kneeDb",
+                                       CompressorSettings::kneeDbDefault,
+                                       0,
+                                       30,
+                                       1 };
+
+   static constexpr Parameter lookaheadMs {
+      &CompressorSettings::lookaheadMs,
+      L"lookaheadMs",
+      CompressorSettings::lookaheadMsDefault,
+      0,
+      1000,
+      1
+   };
+
+   static constexpr Parameter attackMs { &CompressorSettings::attackMs,
+                                         L"attackMs",
+                                         CompressorSettings::attackMsDefault,
+                                         0,
+                                         100,
+                                         1 };
+
+   static constexpr Parameter releaseMs { &CompressorSettings::releaseMs,
+                                          L"releaseMs",
+                                          CompressorSettings::releaseMsDefault,
+                                          0,
+                                          1000,
+                                          1 };
+
+   static constexpr Parameter ratio { &CompressorSettings::ratio,
+                                      L"ratio",
+                                      CompressorSettings::ratioDefault,
+                                      1,
+                                      20,
+                                      1 };
+
+   static constexpr Parameter makeUpDb { &CompressorSettings::makeUpDb,
+                                         L"makeUpDb",
+                                         CompressorSettings::makeUpDbDefault,
+                                         -10,
+                                         20,
+                                         1 };
+
+private:
+   bool UpdateUI() override;
+
+   void OnLookaheadMsSlider(wxCommandEvent& evt);
+   void OnRatioSlider(wxCommandEvent& evt);
+
+   Control mAttackMsCtrl { attackMs, mSettings.attackMs };
+   Control mRatioCtrl { ratio, mSettings.ratio };
+};

--- a/src/effects/CompressorEditor.h
+++ b/src/effects/CompressorEditor.h
@@ -17,7 +17,6 @@ public:
        }
    {
    }
-   virtual ~CompressorEditor() = default;
 
    void PopulateOrExchange(ShuttleGui& S);
 

--- a/src/effects/CompressorEditor.h
+++ b/src/effects/CompressorEditor.h
@@ -81,4 +81,5 @@ private:
 
    Control mAttackMsCtrl { attackMs, mSettings.attackMs };
    Control mRatioCtrl { ratio, mSettings.ratio };
+   Control mMakeupDbCtrl { makeUpDb, mSettings.makeUpDb };
 };

--- a/src/effects/CompressorInstance.cpp
+++ b/src/effects/CompressorInstance.cpp
@@ -63,7 +63,7 @@ bool CompressorInstance::RealtimeAddProcessor(
    EffectSettings& settings, EffectOutputs*, unsigned numChannels,
    float sampleRate)
 {
-   mSlaves.emplace_back(std::move(mProcessor));
+   mSlaves.emplace_back(mProcessor);
    InstanceInit(settings, *mSlaves.back().mCompressor, numChannels, sampleRate);
    return true;
 }

--- a/src/effects/CompressorInstance.cpp
+++ b/src/effects/CompressorInstance.cpp
@@ -117,10 +117,10 @@ size_t CompressorInstance::InstanceProcess(
 EffectInstance::SampleCount CompressorInstance::GetLatency(
    const EffectSettings& settings, double sampleRate) const
 {
-   const LimiterSettings* pSettings = settings.cast<LimiterSettings>();
-   if (!pSettings)
-      pSettings = settings.cast<CompressorSettings>();
-   return pSettings->lookaheadMs * sampleRate / 1000;
+   if (const auto* pSettings = settings.cast<LimiterSettings>())
+      return pSettings->lookaheadMs * sampleRate / 1000;
+   else
+      settings.cast<CompressorSettings>()->lookaheadMs* sampleRate / 1000;
 }
 
 unsigned CompressorInstance::GetAudioOutCount() const

--- a/src/effects/CompressorInstance.cpp
+++ b/src/effects/CompressorInstance.cpp
@@ -1,0 +1,134 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CompressorInstance.cpp
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#include "CompressorInstance.h"
+#include "processors/CompressorProcessor.h"
+
+CompressorInstance::CompressorInstance(const PerTrackEffect& effect)
+    : PerTrackEffect::Instance { effect }
+    , mCompressor { std::make_unique<CompressorProcessor>() }
+{
+}
+
+CompressorInstance::CompressorInstance(CompressorInstance&& other)
+    : PerTrackEffect::Instance { other }
+    , mCompressor { std::move(other.mCompressor) }
+    , mSlaves { std::move(other.mSlaves) }
+{
+}
+
+bool CompressorInstance::ProcessInitialize(
+   EffectSettings& settings, double sampleRate, ChannelNames chanMap)
+{
+   InstanceInit(settings, *mCompressor, GetAudioInCount(), sampleRate);
+   return true;
+}
+
+size_t CompressorInstance::ProcessBlock(
+   EffectSettings& settings, const float* const* inBlock,
+   float* const* outBlock, size_t blockLen)
+{
+   return InstanceProcess(settings, *mCompressor, inBlock, outBlock, blockLen);
+}
+
+bool CompressorInstance::RealtimeInitialize(EffectSettings&, double)
+{
+   SetBlockSize(512);
+   mSlaves.clear();
+   return true;
+}
+
+bool CompressorInstance::RealtimeSuspend()
+{
+   return true;
+}
+
+bool CompressorInstance::RealtimeResume()
+{
+   for (auto& slave : mSlaves)
+      // Neither block size nore sample rate or any other parameter has changed,
+      // so `Reinit()` should not reallocate memory.
+      slave.mCompressor->Reinit();
+   return true;
+}
+
+bool CompressorInstance::RealtimeAddProcessor(
+   EffectSettings& settings, EffectOutputs*, unsigned numChannels,
+   float sampleRate)
+{
+   mSlaves.emplace_back(std::move(mProcessor));
+   InstanceInit(settings, *mSlaves.back().mCompressor, numChannels, sampleRate);
+   return true;
+}
+
+bool CompressorInstance::RealtimeFinalize(EffectSettings&) noexcept
+{
+   mSlaves.clear();
+   return true;
+}
+
+size_t CompressorInstance::RealtimeProcess(
+   size_t group, EffectSettings& settings, const float* const* inbuf,
+   float* const* outbuf, size_t numSamples)
+{
+   if (group >= mSlaves.size())
+      return 0;
+   return InstanceProcess(
+      settings, *mSlaves[group].mCompressor, inbuf, outbuf, numSamples);
+}
+
+namespace
+{
+void CheckSettings(
+   const EffectSettings& settings, CompressorProcessor& instance)
+{
+   if (
+      const CompressorSettings* pSettings = settings.cast<CompressorSettings>())
+      instance.ApplySettingsIfNeeded(*pSettings);
+   else
+      instance.ApplySettingsIfNeeded(*settings.cast<LimiterSettings>());
+}
+} // namespace
+
+void CompressorInstance::InstanceInit(
+   EffectSettings& settings, CompressorProcessor& instance, int numChannels,
+   float sampleRate)
+{
+   CheckSettings(settings, instance);
+   instance.Init(sampleRate, numChannels, GetBlockSize());
+}
+
+size_t CompressorInstance::InstanceProcess(
+   EffectSettings& settings, CompressorProcessor& instance,
+   const float* const* inBlock, float* const* outBlock, size_t blockLen)
+{
+   CheckSettings(settings, instance);
+   instance.Process(inBlock, outBlock, blockLen);
+   return blockLen;
+}
+
+EffectInstance::SampleCount CompressorInstance::GetLatency(
+   const EffectSettings& settings, double sampleRate) const
+{
+   const LimiterSettings* pSettings = settings.cast<LimiterSettings>();
+   if (!pSettings)
+      pSettings = settings.cast<CompressorSettings>();
+   return pSettings->lookaheadMs * sampleRate / 1000;
+}
+
+unsigned CompressorInstance::GetAudioOutCount() const
+{
+   return 2;
+}
+
+unsigned CompressorInstance::GetAudioInCount() const
+{
+   return 2;
+}

--- a/src/effects/CompressorInstance.h
+++ b/src/effects/CompressorInstance.h
@@ -58,7 +58,6 @@ private:
       EffectSettings& settings, CompressorProcessor& instance,
       const float* const* inBlock, float* const* outBlock, size_t blockLen);
 
-   // TODO study other virtual functions and see if there's something important.
    EffectInstance::SampleCount
    GetLatency(const EffectSettings& settings, double sampleRate) const override;
 

--- a/src/effects/CompressorInstance.h
+++ b/src/effects/CompressorInstance.h
@@ -1,0 +1,70 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CompressorInstance.h
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#pragma once
+
+#include "EffectInterface.h"
+#include "PerTrackEffect.h"
+#include <memory>
+#include <vector>
+
+class CompressorProcessor;
+
+class CompressorInstance final :
+    public PerTrackEffect::Instance,
+    public EffectInstanceWithBlockSize
+{
+public:
+   explicit CompressorInstance(const PerTrackEffect& effect);
+   explicit CompressorInstance(CompressorInstance&& other);
+
+private:
+   bool ProcessInitialize(
+      EffectSettings& settings, double sampleRate,
+      ChannelNames chanMap) override;
+
+   size_t ProcessBlock(
+      EffectSettings& settings, const float* const* inBlock,
+      float* const* outBlock, size_t blockLen) override;
+
+   bool RealtimeInitialize(EffectSettings& settings, double) override;
+
+   bool RealtimeSuspend() override;
+
+   bool RealtimeResume() override;
+
+   bool RealtimeAddProcessor(
+      EffectSettings& settings, EffectOutputs* pOutputs, unsigned numChannels,
+      float sampleRate) override;
+
+   bool RealtimeFinalize(EffectSettings& settings) noexcept override;
+
+   size_t RealtimeProcess(
+      size_t group, EffectSettings& settings, const float* const* inbuf,
+      float* const* outbuf, size_t numSamples) override;
+
+   void InstanceInit(
+      EffectSettings& settings, CompressorProcessor& instance, int numChannels,
+      float sampleRate);
+
+   size_t InstanceProcess(
+      EffectSettings& settings, CompressorProcessor& instance,
+      const float* const* inBlock, float* const* outBlock, size_t blockLen);
+
+   // TODO study other virtual functions and see if there's something important.
+   EffectInstance::SampleCount
+   GetLatency(const EffectSettings& settings, double sampleRate) const override;
+
+   unsigned GetAudioInCount() const override;
+   unsigned GetAudioOutCount() const override;
+
+   std::unique_ptr<CompressorProcessor> mCompressor;
+   std::vector<CompressorInstance> mSlaves;
+};

--- a/src/effects/DynamicRangeProcessorEditor.h
+++ b/src/effects/DynamicRangeProcessorEditor.h
@@ -141,13 +141,14 @@ bool DynamicRangeProcessorEditor<EditorType, SettingType>::UpdateUI()
    mSettings = GetSettings(settings);
    auto& ms = mSettings;
    mThresholdDbCtrl.slider->SetValue(
-      (int)(ms.thresholdDb * EditorType::thresholdDb.scale));
-   mKneeDbCtrl.slider->SetValue((int)(ms.kneeDb * EditorType::kneeDb.scale));
+      static_cast<int>(ms.thresholdDb * EditorType::thresholdDb.scale));
+   mKneeDbCtrl.slider->SetValue(
+      static_cast<int>(ms.kneeDb * EditorType::kneeDb.scale));
    mLookaheadMsCtrl.slider->SetValue(
-      (int)(ms.lookaheadMs * EditorType::lookaheadMs.scale));
+      static_cast<int>(ms.lookaheadMs * EditorType::lookaheadMs.scale));
    mReleaseMsCtrl.slider->SetValue(
-      (int)(ms.releaseMs * EditorType::releaseMs.scale));
+      static_cast<int>(ms.releaseMs * EditorType::releaseMs.scale));
    mMakeUpCtrl.slider->SetValue(
-      (int)(ms.makeUpDb * EditorType::makeUpDb.scale));
+      static_cast<int>(ms.makeUpDb * EditorType::makeUpDb.scale));
    return true;
 }

--- a/src/effects/DynamicRangeProcessorEditor.h
+++ b/src/effects/DynamicRangeProcessorEditor.h
@@ -23,8 +23,6 @@ public:
    {
    }
 
-   virtual ~DynamicRangeProcessorEditor() = default;
-
    using Parameter = EffectParameter<SettingType, double, double>;
 
 protected:

--- a/src/effects/DynamicRangeProcessorEditor.h
+++ b/src/effects/DynamicRangeProcessorEditor.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include "../widgets/valnum.h"
+#include "EffectEditor.h"
+#include "EffectInterface.h"
+#include "SettingsVisitor.h"
+#include "ShuttleGui.h"
+#include "processors/CompressorProcessor.h"
+#include <optional>
+#include <wx/slider.h>
+#include <wx/textctrl.h>
+#include <wx/weakref.h>
+
+template <typename EditorType, typename SettingType>
+class DynamicRangeProcessorEditor : public EffectEditor
+{
+public:
+   DynamicRangeProcessorEditor(
+      const EffectUIServices& services, EffectSettingsAccess& access,
+      const SettingType& settings)
+       : EffectEditor { services, access }
+       , mSettings { settings }
+   {
+   }
+
+   virtual ~DynamicRangeProcessorEditor() = default;
+
+   using Parameter = EffectParameter<SettingType, double, double>;
+
+protected:
+   struct Control
+   {
+      const Parameter& param;
+      double& value;
+      wxTextCtrl* text = nullptr;
+      wxSlider* slider = nullptr;
+   };
+
+   Control mThresholdDbCtrl { EditorType::thresholdDb, mSettings.thresholdDb };
+   Control mKneeDbCtrl { EditorType::kneeDb, mSettings.kneeDb };
+   Control mLookaheadMsCtrl { EditorType::lookaheadMs, mSettings.lookaheadMs };
+   Control mReleaseMsCtrl { EditorType::releaseMs, mSettings.releaseMs };
+   Control mMakeUpCtrl { EditorType::makeUpDb, mSettings.makeUpDb };
+
+   bool ValidateUI() override;
+   bool UpdateUI() override;
+
+   void AddTextboxAndSlider(
+      ShuttleGui& S, Control& ctrl, const TranslatableString& textCaption,
+      const TranslatableString& sliderCaption,
+      std::function<void(wxCommandEvent&)> onSlider = {},
+      std::optional<double> alternativeMax = std::nullopt);
+
+   void OnParameterSlider(
+      wxCommandEvent& evt, wxTextCtrl& textCtrl, double& setting,
+      const Parameter& param,
+      const std::optional<double>& alternativeMax = std::nullopt);
+
+   static SettingType& GetSettings(EffectSettings& settings)
+   {
+      auto pSettings = settings.cast<SettingType>();
+      assert(pSettings);
+      return *pSettings;
+   }
+
+   static const SettingType& GetSettings(const EffectSettings& settings)
+   {
+      auto pSettings = settings.cast<SettingType>();
+      assert(pSettings);
+      return *pSettings;
+   }
+
+   SettingType mSettings;
+   wxWeakRef<wxWindow> mUIParent;
+};
+
+template <typename EditorType, typename SettingType>
+void DynamicRangeProcessorEditor<EditorType, SettingType>::AddTextboxAndSlider(
+   ShuttleGui& S, Control& ctrl, const TranslatableString& textCaption,
+   const TranslatableString& sliderCaption,
+   std::function<void(wxCommandEvent&)> onSlider,
+   std::optional<double> alternativeMax)
+{
+   ctrl.text = S.Validator<FloatingPointValidator<double>>(
+                   1, &ctrl.value, NumValidatorStyle::ONE_TRAILING_ZERO,
+                   ctrl.param.min, alternativeMax.value_or(ctrl.param.max))
+                  .AddTextBox(textCaption, L"", 12);
+
+   ctrl.text->Bind(wxEVT_TEXT, [&](wxCommandEvent& evt) {
+      if (!EnableApply(mUIParent, mUIParent->TransferDataFromWindow()))
+         return;
+      ctrl.slider->SetValue((int)(ctrl.value * ctrl.param.scale));
+      ValidateUI();
+      Publish(EffectSettingChanged {});
+   });
+
+   ctrl.slider = S.Name(sliderCaption)
+                    .Style(wxSL_HORIZONTAL)
+                    .MinSize({ 100, -1 })
+                    .AddSlider(
+                       {}, ctrl.param.def * ctrl.param.scale,
+                       ctrl.param.max * ctrl.param.scale,
+                       ctrl.param.min * ctrl.param.scale);
+
+   ctrl.slider->Bind(wxEVT_SLIDER, [&, onSlider](wxCommandEvent& evt) {
+      onSlider ? onSlider(evt) :
+                 OnParameterSlider(evt, *ctrl.text, ctrl.value, ctrl.param);
+      ctrl.text->GetValidator()->TransferToWindow();
+      EnableApply(mUIParent, mUIParent->Validate());
+      ValidateUI();
+      Publish(EffectSettingChanged {});
+   });
+}
+
+template <typename EditorType, typename SettingType>
+void DynamicRangeProcessorEditor<EditorType, SettingType>::OnParameterSlider(
+   wxCommandEvent& evt, wxTextCtrl& textCtrl, double& setting,
+   const Parameter& param, const std::optional<double>& alternativeMax)
+{
+   auto& ms = mSettings;
+   setting = evt.GetInt() / param.scale;
+   if (alternativeMax.has_value() && setting == param.max)
+      setting = *alternativeMax;
+}
+
+template <typename EditorType, typename SettingType>
+bool DynamicRangeProcessorEditor<EditorType, SettingType>::ValidateUI()
+{
+   mAccess.ModifySettings([this](EffectSettings& settings) {
+      // pass back the modified settings to the MessageBuffer
+      GetSettings(settings) = mSettings;
+      return nullptr;
+   });
+   return true;
+}
+
+template <typename EditorType, typename SettingType>
+bool DynamicRangeProcessorEditor<EditorType, SettingType>::UpdateUI()
+{
+   // get the settings from the MessageBuffer and write them to our local
+   // copy
+   const auto& settings = mAccess.Get();
+   mSettings = GetSettings(settings);
+   auto& ms = mSettings;
+   mThresholdDbCtrl.slider->SetValue(
+      (int)(ms.thresholdDb * EditorType::thresholdDb.scale));
+   mKneeDbCtrl.slider->SetValue((int)(ms.kneeDb * EditorType::kneeDb.scale));
+   mLookaheadMsCtrl.slider->SetValue(
+      (int)(ms.lookaheadMs * EditorType::lookaheadMs.scale));
+   mReleaseMsCtrl.slider->SetValue(
+      (int)(ms.releaseMs * EditorType::releaseMs.scale));
+   mMakeUpCtrl.slider->SetValue(
+      (int)(ms.makeUpDb * EditorType::makeUpDb.scale));
+   return true;
+}

--- a/src/effects/DynamicRangeProcessorEditor.h
+++ b/src/effects/DynamicRangeProcessorEditor.h
@@ -38,7 +38,6 @@ protected:
    Control mKneeDbCtrl { EditorType::kneeDb, mSettings.kneeDb };
    Control mLookaheadMsCtrl { EditorType::lookaheadMs, mSettings.lookaheadMs };
    Control mReleaseMsCtrl { EditorType::releaseMs, mSettings.releaseMs };
-   Control mMakeUpCtrl { EditorType::makeUpDb, mSettings.makeUpDb };
 
    bool ValidateUI() override;
    bool UpdateUI() override;
@@ -148,7 +147,5 @@ bool DynamicRangeProcessorEditor<EditorType, SettingType>::UpdateUI()
       static_cast<int>(ms.lookaheadMs * EditorType::lookaheadMs.scale));
    mReleaseMsCtrl.slider->SetValue(
       static_cast<int>(ms.releaseMs * EditorType::releaseMs.scale));
-   mMakeUpCtrl.slider->SetValue(
-      static_cast<int>(ms.makeUpDb * EditorType::makeUpDb.scale));
    return true;
 }

--- a/src/effects/Limiter.cpp
+++ b/src/effects/Limiter.cpp
@@ -28,7 +28,7 @@ const EffectParameterMethods& EffectLimiter::Parameters() const
    static CapturedParameters<
       EffectLimiter, LimiterEditor::thresholdDb, LimiterEditor::kneeDb,
       LimiterEditor::lookaheadMs, LimiterEditor::releaseMs,
-      LimiterEditor::makeUpDb>
+      LimiterEditor::ceilingDb>
       parameters;
    return parameters;
 }

--- a/src/effects/Limiter.cpp
+++ b/src/effects/Limiter.cpp
@@ -73,7 +73,7 @@ EffectType EffectLimiter::GetType() const
 
 auto EffectLimiter::RealtimeSupport() const -> RealtimeSince
 {
-   return RealtimeSince::After_3_1;
+   return RealtimeSince::Always;
 }
 
 // Effect implementation

--- a/src/effects/Limiter.cpp
+++ b/src/effects/Limiter.cpp
@@ -1,0 +1,93 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Limiter.cpp
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+
+#include "Limiter.h"
+#include "CompressorInstance.h" // A limiter is just a compressor with hard-coded parameters.
+#include "LimiterEditor.h"
+#include "LoadEffects.h"
+#include "ShuttleAutomation.h"
+
+const ComponentInterfaceSymbol EffectLimiter::Symbol { XO(
+   "Real-time Limiter") };
+
+namespace
+{
+BuiltinEffectsModule::Registration<EffectLimiter> reg;
+} // namespace
+
+const EffectParameterMethods& EffectLimiter::Parameters() const
+{
+   static CapturedParameters<
+      EffectLimiter, LimiterEditor::thresholdDb, LimiterEditor::kneeDb,
+      LimiterEditor::lookaheadMs, LimiterEditor::releaseMs,
+      LimiterEditor::makeUpDb>
+      parameters;
+   return parameters;
+}
+
+std::shared_ptr<EffectInstance> EffectLimiter::MakeInstance() const
+{
+   return std::make_shared<CompressorInstance>(*this);
+}
+
+bool EffectLimiter::CheckWhetherSkipEffect(const EffectSettings& settings) const
+{
+   // TODO
+   return Effect::CheckWhetherSkipEffect(settings);
+}
+
+EffectLimiter::EffectLimiter()
+{
+   SetLinearEffectFlag(true);
+}
+
+EffectLimiter::~EffectLimiter()
+{
+}
+
+ComponentInterfaceSymbol EffectLimiter::GetSymbol() const
+{
+   return Symbol;
+}
+
+TranslatableString EffectLimiter::GetDescription() const
+{
+   return XO("A limiter");
+}
+
+ManualPageID EffectLimiter::ManualPage() const
+{
+   // TODO
+   return L"";
+}
+
+EffectType EffectLimiter::GetType() const
+{
+   return EffectTypeProcess;
+}
+
+auto EffectLimiter::RealtimeSupport() const -> RealtimeSince
+{
+   return RealtimeSince::After_3_1;
+}
+
+// Effect implementation
+
+std::unique_ptr<EffectEditor> EffectLimiter::MakeEditor(
+   ShuttleGui& S, EffectInstance&, EffectSettingsAccess& access,
+   const EffectOutputs*) const
+{
+   auto& settings = access.Get();
+   auto& myEffSettings = GetSettings(settings);
+   auto result = std::make_unique<LimiterEditor>(*this, access, myEffSettings);
+   result->PopulateOrExchange(S);
+   return result;
+}

--- a/src/effects/Limiter.cpp
+++ b/src/effects/Limiter.cpp
@@ -40,17 +40,14 @@ std::shared_ptr<EffectInstance> EffectLimiter::MakeInstance() const
 
 bool EffectLimiter::CheckWhetherSkipEffect(const EffectSettings& settings) const
 {
-   // TODO
-   return Effect::CheckWhetherSkipEffect(settings);
+   // Given the infinite ratio, a limiter is always susceptible to modifying the
+   // audio.
+   return false;
 }
 
 EffectLimiter::EffectLimiter()
 {
-   SetLinearEffectFlag(true);
-}
-
-EffectLimiter::~EffectLimiter()
-{
+   SetLinearEffectFlag(false);
 }
 
 ComponentInterfaceSymbol EffectLimiter::GetSymbol() const
@@ -60,7 +57,7 @@ ComponentInterfaceSymbol EffectLimiter::GetSymbol() const
 
 TranslatableString EffectLimiter::GetDescription() const
 {
-   return XO("A limiter");
+   return XO("Augments loudness while minimizing distortion.");
 }
 
 ManualPageID EffectLimiter::ManualPage() const

--- a/src/effects/Limiter.h
+++ b/src/effects/Limiter.h
@@ -1,0 +1,49 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  Limiter.h
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#pragma once
+
+#include "StatelessPerTrackEffect.h"
+#include "processors/CompressorProcessor.h"
+
+class ShuttleGui;
+
+class EffectLimiter final :
+    public EffectWithSettings<LimiterSettings, StatelessPerTrackEffect>
+{
+public:
+   static const ComponentInterfaceSymbol Symbol;
+
+   EffectLimiter();
+   virtual ~EffectLimiter();
+
+   // ComponentInterface implementation
+
+   ComponentInterfaceSymbol GetSymbol() const override;
+   TranslatableString GetDescription() const override;
+   ManualPageID ManualPage() const override;
+
+   // EffectDefinitionInterface implementation
+
+   EffectType GetType() const override;
+   RealtimeSince RealtimeSupport() const override;
+
+   // Effect implementation
+
+   std::unique_ptr<EffectEditor> MakeEditor(
+      ShuttleGui& S, EffectInstance& instance, EffectSettingsAccess& access,
+      const EffectOutputs* pOutputs) const override;
+
+   std::shared_ptr<EffectInstance> MakeInstance() const override;
+
+   bool CheckWhetherSkipEffect(const EffectSettings& settings) const override;
+
+   const EffectParameterMethods& Parameters() const override;
+};

--- a/src/effects/Limiter.h
+++ b/src/effects/Limiter.h
@@ -22,7 +22,6 @@ public:
    static const ComponentInterfaceSymbol Symbol;
 
    EffectLimiter();
-   virtual ~EffectLimiter();
 
    // ComponentInterface implementation
 

--- a/src/effects/LimiterEditor.cpp
+++ b/src/effects/LimiterEditor.cpp
@@ -27,7 +27,7 @@ void LimiterEditor::PopulateOrExchange(ShuttleGui& S)
          S, mReleaseMsCtrl, XXO("&Release (ms):"), XXO("Release time in ms"));
 
       AddTextboxAndSlider(
-         S, mMakeUpCtrl, XXO("&Make-up gain (dB):"), XXO("Make-up gain in dB"));
+         S, mCeilingDbCtrl, XXO("&Ceiling (dB):"), XXO("Ceiling in dB"));
    }
    S.EndMultiColumn();
 }

--- a/src/effects/LimiterEditor.cpp
+++ b/src/effects/LimiterEditor.cpp
@@ -1,0 +1,33 @@
+#include "LimiterEditor.h"
+#include "ShuttleGui.h"
+
+void LimiterEditor::PopulateOrExchange(ShuttleGui& S)
+{
+   mUIParent = S.GetParent();
+   auto& ms = mSettings;
+
+   S.SetBorder(5);
+   S.AddSpace(0, 5);
+
+   S.StartMultiColumn(3, wxEXPAND);
+   {
+      S.SetStretchyCol(2);
+
+      AddTextboxAndSlider(
+         S, mThresholdDbCtrl, XXO("&Threshold (Db):"), XXO("Threshold in dB"));
+
+      AddTextboxAndSlider(
+         S, mKneeDbCtrl, XXO("&Knee (dB):"), XXO("Knee width in dB"));
+
+      AddTextboxAndSlider(
+         S, mLookaheadMsCtrl, XXO("&Lookahead (ms):"),
+         XXO("Lookahead time in ms"));
+
+      AddTextboxAndSlider(
+         S, mReleaseMsCtrl, XXO("&Release (ms):"), XXO("Release time in ms"));
+
+      AddTextboxAndSlider(
+         S, mMakeUpCtrl, XXO("&Make-up gain (dB):"), XXO("Make-up gain in dB"));
+   }
+   S.EndMultiColumn();
+}

--- a/src/effects/LimiterEditor.h
+++ b/src/effects/LimiterEditor.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "DynamicRangeProcessorEditor.h"
+#include "processors/CompressorProcessor.h"
+
+class ShuttleGui;
+
+class LimiterEditor :
+    public DynamicRangeProcessorEditor<LimiterEditor, LimiterSettings>
+{
+public:
+   LimiterEditor(
+      const EffectUIServices& services, EffectSettingsAccess& access,
+      const LimiterSettings& settings)
+       : DynamicRangeProcessorEditor<LimiterEditor, LimiterSettings> {
+          services, access, settings
+       }
+   {
+   }
+   virtual ~LimiterEditor() = default;
+
+   void PopulateOrExchange(ShuttleGui& S);
+
+   static constexpr Parameter thresholdDb { &LimiterSettings::thresholdDb,
+                                            L"thresholdDb",
+                                            LimiterSettings::thresholdDbDefault,
+                                            -50,
+                                            10,
+                                            1 };
+
+   static constexpr Parameter kneeDb { &LimiterSettings::kneeDb,
+                                       L"kneeDb",
+                                       LimiterSettings::kneeDbDefault,
+                                       0,
+                                       30,
+                                       1 };
+
+   static constexpr Parameter lookaheadMs { &LimiterSettings::lookaheadMs,
+                                            L"lookaheadMs",
+                                            LimiterSettings::lookaheadMsDefault,
+                                            0,
+                                            1000,
+                                            1 };
+
+   static constexpr Parameter releaseMs { &LimiterSettings::releaseMs,
+                                          L"releaseMs",
+                                          LimiterSettings::releaseMsDefault,
+                                          0,
+                                          1000,
+                                          1 };
+
+   static constexpr Parameter makeUpDb { &LimiterSettings::makeUpDb,
+                                         L"makeUpDb",
+                                         LimiterSettings::makeUpDbDefault,
+                                         -10,
+                                         20,
+                                         1 };
+};

--- a/src/effects/LimiterEditor.h
+++ b/src/effects/LimiterEditor.h
@@ -17,7 +17,6 @@ public:
        }
    {
    }
-   virtual ~LimiterEditor() = default;
 
    void PopulateOrExchange(ShuttleGui& S);
 

--- a/src/effects/LimiterEditor.h
+++ b/src/effects/LimiterEditor.h
@@ -23,8 +23,8 @@ public:
    static constexpr Parameter thresholdDb { &LimiterSettings::thresholdDb,
                                             L"thresholdDb",
                                             LimiterSettings::thresholdDbDefault,
-                                            -50,
-                                            10,
+                                            -20,
+                                            0,
                                             1 };
 
    static constexpr Parameter kneeDb { &LimiterSettings::kneeDb,
@@ -38,20 +38,22 @@ public:
                                             L"lookaheadMs",
                                             LimiterSettings::lookaheadMsDefault,
                                             0,
-                                            1000,
+                                            20,
                                             1 };
 
    static constexpr Parameter releaseMs { &LimiterSettings::releaseMs,
                                           L"releaseMs",
                                           LimiterSettings::releaseMsDefault,
                                           0,
-                                          1000,
+                                          100,
                                           1 };
 
-   static constexpr Parameter makeUpDb { &LimiterSettings::makeUpDb,
-                                         L"makeUpDb",
-                                         LimiterSettings::makeUpDbDefault,
-                                         -10,
-                                         20,
-                                         1 };
+   static constexpr Parameter ceilingDb { &LimiterSettings::ceilingDb,
+                                          L"ceilingDb",
+                                          LimiterSettings::ceilingDbDefault,
+                                          -20,
+                                          0,
+                                          1 };
+
+   Control mCeilingDbCtrl { ceilingDb, mSettings.ceilingDb };
 };

--- a/src/effects/OfflineCompressor.cpp
+++ b/src/effects/OfflineCompressor.cpp
@@ -2,7 +2,7 @@
 
   Audacity: A Digital Audio Editor
 
-  Compressor.cpp
+  OfflineCompressor.cpp
 
   Dominic Mazzoni
   Martyn Shaw
@@ -10,7 +10,7 @@
 
 *******************************************************************//**
 
-\class EffectCompressor
+\class EffectOfflineCompressor
 \brief An Effect derived from EffectTwoPassSimpleMono
 
  - Martyn Shaw made it inherit from EffectTwoPassSimpleMono 10/2005.
@@ -20,10 +20,10 @@
 *//****************************************************************//**
 
 \class CompressorPanel
-\brief Panel used within the EffectCompressor for EffectCompressor.
+\brief Panel used within the EffectOfflineCompressor for EffectOfflineCompressor.
 
 *//*******************************************************************/
-#include "Compressor.h"
+#include "OfflineCompressor.h"
 #include "EffectEditor.h"
 #include "LoadEffects.h"
 
@@ -57,9 +57,9 @@ enum
    ID_Decay
 };
 
-const EffectParameterMethods& EffectCompressor::Parameters() const
+const EffectParameterMethods& EffectOfflineCompressor::Parameters() const
 {
-   static CapturedParameters<EffectCompressor,
+   static CapturedParameters<EffectOfflineCompressor,
       Threshold, NoiseFloor, Ratio, // positive number > 1.0
       AttackTime, // seconds
       ReleaseTime, // seconds
@@ -69,19 +69,19 @@ const EffectParameterMethods& EffectCompressor::Parameters() const
 }
 
 //----------------------------------------------------------------------------
-// EffectCompressor
+// EffectOfflineCompressor
 //----------------------------------------------------------------------------
 
-const ComponentInterfaceSymbol EffectCompressor::Symbol
+const ComponentInterfaceSymbol EffectOfflineCompressor::Symbol
 { XO("Compressor") };
 
-namespace{ BuiltinEffectsModule::Registration< EffectCompressor > reg; }
+namespace{ BuiltinEffectsModule::Registration< EffectOfflineCompressor > reg; }
 
-BEGIN_EVENT_TABLE(EffectCompressor, wxEvtHandler)
-   EVT_SLIDER(wxID_ANY, EffectCompressor::OnSlider)
+BEGIN_EVENT_TABLE(EffectOfflineCompressor, wxEvtHandler)
+   EVT_SLIDER(wxID_ANY, EffectOfflineCompressor::OnSlider)
 END_EVENT_TABLE()
 
-EffectCompressor::EffectCompressor()
+EffectOfflineCompressor::EffectOfflineCompressor()
 {
    Parameters().Reset(*this);
 
@@ -93,30 +93,30 @@ EffectCompressor::EffectCompressor()
    SetLinearEffectFlag(false);
 }
 
-EffectCompressor::~EffectCompressor()
+EffectOfflineCompressor::~EffectOfflineCompressor()
 {
 }
 
 // ComponentInterface implementation
 
-ComponentInterfaceSymbol EffectCompressor::GetSymbol() const
+ComponentInterfaceSymbol EffectOfflineCompressor::GetSymbol() const
 {
    return Symbol;
 }
 
-TranslatableString EffectCompressor::GetDescription() const
+TranslatableString EffectOfflineCompressor::GetDescription() const
 {
    return XO("Compresses the dynamic range of audio");
 }
 
-ManualPageID EffectCompressor::ManualPage() const
+ManualPageID EffectOfflineCompressor::ManualPage() const
 {
    return L"Compressor";
 }
 
 // EffectDefinitionInterface implementation
 
-EffectType EffectCompressor::GetType() const
+EffectType EffectOfflineCompressor::GetType() const
 {
    return EffectTypeProcess;
 }
@@ -157,7 +157,7 @@ TranslatableString RatioLabelFormat( int sliderValue, double value )
 
 }
 
-std::unique_ptr<EffectEditor> EffectCompressor::PopulateOrExchange(
+std::unique_ptr<EffectEditor> EffectOfflineCompressor::PopulateOrExchange(
    ShuttleGui & S, EffectInstance &, EffectSettingsAccess &,
    const EffectOutputs *)
 {
@@ -167,7 +167,7 @@ std::unique_ptr<EffectEditor> EffectCompressor::PopulateOrExchange(
    S.StartHorizontalLay(wxEXPAND, true);
    {
       S.SetBorder(10);
-      mPanel = safenew EffectCompressorPanel(S.GetParent(), wxID_ANY,
+      mPanel = safenew EffectOfflineCompressorPanel(S.GetParent(), wxID_ANY,
                                          mThresholdDB,
                                          mNoiseFloorDB,
                                          mRatio);
@@ -278,7 +278,7 @@ std::unique_ptr<EffectEditor> EffectCompressor::PopulateOrExchange(
    return nullptr;
 }
 
-bool EffectCompressor::TransferDataToWindow(const EffectSettings &)
+bool EffectOfflineCompressor::TransferDataToWindow(const EffectSettings &)
 {
    mThresholdSlider->SetValue(lrint(mThresholdDB));
    mNoiseFloorSlider->SetValue(lrint(mNoiseFloorDB * NoiseFloor.scale));
@@ -293,7 +293,7 @@ bool EffectCompressor::TransferDataToWindow(const EffectSettings &)
    return true;
 }
 
-bool EffectCompressor::TransferDataFromWindow(EffectSettings &)
+bool EffectOfflineCompressor::TransferDataFromWindow(EffectSettings &)
 {
    if (!mUIParent->Validate())
    {
@@ -302,7 +302,7 @@ bool EffectCompressor::TransferDataFromWindow(EffectSettings &)
    return DoTransferDataFromWindow();
 }
 
-bool EffectCompressor::DoTransferDataFromWindow()
+bool EffectOfflineCompressor::DoTransferDataFromWindow()
 {
    // To do:  eliminate this by using control validators instead
    mThresholdDB = (double) mThresholdSlider->GetValue();
@@ -318,7 +318,7 @@ bool EffectCompressor::DoTransferDataFromWindow()
 
 // EffectTwoPassSimpleMono implementation
 
-bool EffectCompressor::NewTrackPass1()
+bool EffectOfflineCompressor::NewTrackPass1()
 {
    mThreshold = DB_TO_LINEAR(mThresholdDB);
    mNoiseFloor = DB_TO_LINEAR(mNoiseFloorDB);
@@ -343,7 +343,7 @@ bool EffectCompressor::NewTrackPass1()
    return true;
 }
 
-bool EffectCompressor::InitPass1()
+bool EffectOfflineCompressor::InitPass1()
 {
    mMax=0.0;
    if (!mNormalize)
@@ -365,7 +365,7 @@ bool EffectCompressor::InitPass1()
    return true;
 }
 
-bool EffectCompressor::InitPass2()
+bool EffectOfflineCompressor::InitPass2()
 {
    // Actually, this should not even be called, because we call
    // DisableSecondPass() before, if mNormalize is false.
@@ -375,7 +375,7 @@ bool EffectCompressor::InitPass2()
 // Process the input with 2 buffers available at a time
 // buffer1 will be written upon return
 // buffer2 will be passed as buffer1 on the next call
-bool EffectCompressor::TwoBufferProcessPass1
+bool EffectOfflineCompressor::TwoBufferProcessPass1
    (float *buffer1, size_t len1, float *buffer2, size_t len2)
 {
    // If buffers are bigger than allocated, then abort
@@ -418,7 +418,7 @@ bool EffectCompressor::TwoBufferProcessPass1
    return true;
 }
 
-bool EffectCompressor::ProcessPass2(float *buffer, size_t len)
+bool EffectOfflineCompressor::ProcessPass2(float *buffer, size_t len)
 {
    if (mMax != 0)
    {
@@ -429,7 +429,7 @@ bool EffectCompressor::ProcessPass2(float *buffer, size_t len)
    return true;
 }
 
-void EffectCompressor::FreshenCircle()
+void EffectOfflineCompressor::FreshenCircle()
 {
    // Recompute the RMS sum periodically to prevent accumulation of rounding errors
    // during long waveforms
@@ -438,7 +438,7 @@ void EffectCompressor::FreshenCircle()
       mRMSSum += mCircle[i];
 }
 
-float EffectCompressor::AvgCircle(float value)
+float EffectOfflineCompressor::AvgCircle(float value)
 {
    float level;
 
@@ -453,7 +453,7 @@ float EffectCompressor::AvgCircle(float value)
    return level;
 }
 
-void EffectCompressor::Follow(float *buffer, float *env, size_t len, float *previous, size_t previous_len)
+void EffectOfflineCompressor::Follow(float *buffer, float *env, size_t len, float *previous, size_t previous_len)
 {
    /*
 
@@ -566,7 +566,7 @@ void EffectCompressor::Follow(float *buffer, float *env, size_t len, float *prev
    }
 }
 
-float EffectCompressor::DoCompression(float value, double env)
+float EffectOfflineCompressor::DoCompression(float value, double env)
 {
    float out;
    if(mUsePeak) {
@@ -584,13 +584,13 @@ float EffectCompressor::DoCompression(float value, double env)
    return out;
 }
 
-void EffectCompressor::OnSlider(wxCommandEvent & WXUNUSED(evt))
+void EffectOfflineCompressor::OnSlider(wxCommandEvent & WXUNUSED(evt))
 {
    DoTransferDataFromWindow();
    UpdateUI();
 }
 
-void EffectCompressor::UpdateUI()
+void EffectOfflineCompressor::UpdateUI()
 {
    mThresholdLabel->SetName(wxString::Format(_("Threshold %d dB"), (int) mThresholdDB));
    mThresholdText->SetLabel(ThresholdFormat((int) mThresholdDB).Translation());
@@ -620,15 +620,15 @@ void EffectCompressor::UpdateUI()
 }
 
 //----------------------------------------------------------------------------
-// EffectCompressorPanel
+// EffectOfflineCompressorPanel
 //----------------------------------------------------------------------------
 
-BEGIN_EVENT_TABLE(EffectCompressorPanel, wxPanelWrapper)
-   EVT_PAINT(EffectCompressorPanel::OnPaint)
-   EVT_SIZE(EffectCompressorPanel::OnSize)
+BEGIN_EVENT_TABLE(EffectOfflineCompressorPanel, wxPanelWrapper)
+   EVT_PAINT(EffectOfflineCompressorPanel::OnPaint)
+   EVT_SIZE(EffectOfflineCompressorPanel::OnSize)
 END_EVENT_TABLE()
 
-EffectCompressorPanel::EffectCompressorPanel(wxWindow *parent, wxWindowID winid,
+EffectOfflineCompressorPanel::EffectOfflineCompressorPanel(wxWindow *parent, wxWindowID winid,
                                              double & threshold,
                                              double & noiseFloor,
                                              double & ratio)
@@ -639,7 +639,7 @@ EffectCompressorPanel::EffectCompressorPanel(wxWindow *parent, wxWindowID winid,
 {
 }
 
-void EffectCompressorPanel::OnPaint(wxPaintEvent & WXUNUSED(evt))
+void EffectOfflineCompressorPanel::OnPaint(wxPaintEvent & WXUNUSED(evt))
 {
    wxPaintDC dc(this);
 
@@ -731,7 +731,7 @@ void EffectCompressorPanel::OnPaint(wxPaintEvent & WXUNUSED(evt))
    hRuler.Draw(dc);
 }
 
-void EffectCompressorPanel::OnSize(wxSizeEvent & WXUNUSED(evt))
+void EffectOfflineCompressorPanel::OnSize(wxSizeEvent & WXUNUSED(evt))
 {
    Refresh(false);
 }

--- a/src/effects/OfflineCompressor.h
+++ b/src/effects/OfflineCompressor.h
@@ -2,7 +2,7 @@
 
   Audacity: A Digital Audio Editor
 
-  Compressor.h
+  OfflineCompressor.h
 
   Dominic Mazzoni
 
@@ -19,22 +19,22 @@
 class wxCheckBox;
 class wxSlider;
 class wxStaticText;
-class EffectCompressorPanel;
+class EffectOfflineCompressorPanel;
 class ShuttleGui;
 
 using Floats = ArrayOf<float>;
 using Doubles = ArrayOf<double>;
 
-class EffectCompressor final : public EffectTwoPassSimpleMono
+class EffectOfflineCompressor final : public EffectTwoPassSimpleMono
 {
 public:
-   static inline EffectCompressor *
-   FetchParameters(EffectCompressor &e, EffectSettings &) { return &e; }
+   static inline EffectOfflineCompressor *
+   FetchParameters(EffectOfflineCompressor &e, EffectSettings &) { return &e; }
 
    static const ComponentInterfaceSymbol Symbol;
 
-   EffectCompressor();
-   virtual ~EffectCompressor();
+   EffectOfflineCompressor();
+   virtual ~EffectOfflineCompressor();
 
    // ComponentInterface implementation
 
@@ -66,7 +66,7 @@ protected:
       (float *buffer1, size_t len1, float *buffer2, size_t len2) override;
 
 private:
-   // EffectCompressor implementation
+   // EffectOfflineCompressor implementation
 
    void FreshenCircle();
    float AvgCircle(float x);
@@ -106,7 +106,7 @@ private:
 
    double    mMax;			//MJS
 
-   EffectCompressorPanel *mPanel;
+   EffectOfflineCompressorPanel *mPanel;
 
    wxStaticText *mThresholdLabel;
    wxSlider *mThresholdSlider;
@@ -134,26 +134,26 @@ private:
    const EffectParameterMethods& Parameters() const override;
    DECLARE_EVENT_TABLE()
 
-static constexpr EffectParameter Threshold{ &EffectCompressor::mThresholdDB,
+static constexpr EffectParameter Threshold{ &EffectOfflineCompressor::mThresholdDB,
    L"Threshold",     -12.0,   -60.0,   -1.0,    1   };
-static constexpr EffectParameter NoiseFloor{ &EffectCompressor::mNoiseFloorDB,
+static constexpr EffectParameter NoiseFloor{ &EffectOfflineCompressor::mNoiseFloorDB,
    L"NoiseFloor",    -40.0,   -80.0,   -20.0,   0.2   };
-static constexpr EffectParameter Ratio{ &EffectCompressor::mRatio,
+static constexpr EffectParameter Ratio{ &EffectOfflineCompressor::mRatio,
    L"Ratio",         2.0,     1.1,     10.0,    10  };
-static constexpr EffectParameter AttackTime{ &EffectCompressor::mAttackTime,
+static constexpr EffectParameter AttackTime{ &EffectOfflineCompressor::mAttackTime,
    L"AttackTime",    0.2,     0.1,     5.0,     100 };
-static constexpr EffectParameter ReleaseTime{ &EffectCompressor::mDecayTime,
+static constexpr EffectParameter ReleaseTime{ &EffectOfflineCompressor::mDecayTime,
    L"ReleaseTime",   1.0,     1.0,     30.0,    10  };
-static constexpr EffectParameter Normalize{ &EffectCompressor::mNormalize,
+static constexpr EffectParameter Normalize{ &EffectOfflineCompressor::mNormalize,
    L"Normalize",     true,    false,   true,    1   };
-static constexpr EffectParameter UsePeak{ &EffectCompressor::mUsePeak,
+static constexpr EffectParameter UsePeak{ &EffectOfflineCompressor::mUsePeak,
    L"UsePeak",       false,   false,   true,    1   };
 };
 
-class EffectCompressorPanel final : public wxPanelWrapper
+class EffectOfflineCompressorPanel final : public wxPanelWrapper
 {
 public:
-   EffectCompressorPanel(wxWindow *parent, wxWindowID winid,
+   EffectOfflineCompressorPanel(wxWindow *parent, wxWindowID winid,
                          double & threshold,
                          double & noiseFloor,
                          double & ratio);


### PR DESCRIPTION
Resolves: #6305

This PR wraps [Daniel Rudrich's SimpleCompressor](https://github.com/DanielRudrich/SimpleCompressor) in two new real-time capable built-in effects, namely "Real-time Compressor" and "Real-time Limiter".

The limiter is the same as the compressor but with a reduced set of parameters, ratio and attack time being hard-coded to infinity and 0ms.

The legacy, offline compressor files were renamed, but for now stays found in the same place in the menu (`Volume and Compression > Compressor` and `Volume and Compression > Limiter`). Removal from default list is planned in #6319. At that stage the new versions should also find their final place in the menu.

UI currently only consists of sliders. Real-time visual indicators are essential for this type of effect, but their introduction can be postponed to a follow-up PR.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] Changing parameters in real time works
- [ ] Latency compensation works (use look-ahead for this to be non-trivial)
- [ ] Effect preview works
Channel routing tests:
- [ ] Mono track is processed properly
- [ ] Stereo track is processed properly (use a clip with contrasting left/right content)