### PR TITLE
Open from cloud dialog: fix up/down arrow bug in list

### DIFF
--- a/modules/mod-cloud-audiocom/ui/dialogs/ProjectsListDialog.cpp
+++ b/modules/mod-cloud-audiocom/ui/dialogs/ProjectsListDialog.cpp
@@ -685,7 +685,16 @@ void ProjectsListDialog::SetupHandlers()
       [this](auto& evt)
       {
          const auto keyCode = evt.GetKeyCode();
-
+         // prevent being able to up arrow past the first row (issue #6251)
+         if (keyCode == WXK_UP && mProjectsTable->GetGridCursorRow() == 0) {
+               return;
+         }
+         // prevent being able to down arrow past the last row (issue #6251)
+         if (keyCode == WXK_DOWN &&
+            mProjectsTable->GetGridCursorRow() ==
+            mProjectsTable->GetNumberRows() - 1) {
+               return;
+         }
          if (keyCode != WXK_RETURN && keyCode != WXK_NUMPAD_ENTER)
          {
             evt.Skip();


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6251

Problem:
You can arrow past the start and end of the list.

Fix:
Don't pass on to the wxGrid for normal processing the down arrow and up arrow keydown events when they are going to cause this problem.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
