### PR TITLE
leaked progress dialog window fix

### DIFF
--- a/libraries/lib-project-file-io/SqliteSampleBlock.cpp
+++ b/libraries/lib-project-file-io/SqliteSampleBlock.cpp
@@ -167,6 +167,11 @@ public:
    SampleBlockPtr DoCreateFromId(
       sampleFormat srcformat, SampleBlockID id) override;
 
+   SampleBlock::DeletionCallback GetSampleBlockDeletionCallback() const
+   {
+      return mSampleBlockDeletionCallback;
+   }
+
 private:
    void OnBeginPurge(size_t begin, size_t end);
    void OnEndPurge();
@@ -175,7 +180,7 @@ private:
 
    AudacityProject &mProject;
    Observer::Subscription mUndoSubscription;
-   std::optional<SampleBlock::DeletionCallback::Scope> mScope;
+   SampleBlock::DeletionCallback mSampleBlockDeletionCallback;
    const std::shared_ptr<ConnectionPtr> mppConnection;
 
    // Track all blocks that this factory has created, but don't control
@@ -286,7 +291,7 @@ SampleBlockPtr SqliteSampleBlockFactory::DoCreateFromId(
    // This may throw database errors
    // It initializes the rest of the fields
    ssb->Load(static_cast<SampleBlockID>(id));
-   
+
    return ssb;
 }
 
@@ -338,7 +343,12 @@ SqliteSampleBlock::SqliteSampleBlock(
 
 SqliteSampleBlock::~SqliteSampleBlock()
 {
-   DeletionCallback::Call(*this);
+   if (
+      const auto cb = mpFactory ? mpFactory->GetSampleBlockDeletionCallback() :
+                                  SampleBlock::DeletionCallback {})
+   {
+      cb(*this);
+   }
 
    if (IsSilent()) {
       // The block object was constructed but failed to Load() or Commit().
@@ -1100,7 +1110,7 @@ void SqliteSampleBlockFactory::OnBeginPurge(size_t begin, size_t end)
        return;
    auto purgeStartTime = std::chrono::system_clock::now();
    std::shared_ptr<ProgressDialog> progressDialog;
-   mScope.emplace([=, nDeleted = 0](auto&) mutable {
+   mSampleBlockDeletionCallback = [=, nDeleted = 0](auto&) mutable {
       ++nDeleted;
       if(!progressDialog)
       {
@@ -1111,12 +1121,12 @@ void SqliteSampleBlockFactory::OnBeginPurge(size_t begin, size_t end)
       }
       else
          progressDialog->Poll(nDeleted, nToDelete);
-   });
+   };
 }
 
 void SqliteSampleBlockFactory::OnEndPurge()
 {
-   mScope.reset();
+   mSampleBlockDeletionCallback = {};
 }
 
 // Inject our database implementation at startup

--- a/libraries/lib-wave-track/SampleBlock.h
+++ b/libraries/lib-wave-track/SampleBlock.h
@@ -45,10 +45,7 @@ public:
 class WAVE_TRACK_API SampleBlock
 {
 public:
-   //! Type of function that is informed when a block is about to be deleted
-   struct DeletionCallback : GlobalHook<DeletionCallback,
-      void(const SampleBlock&)
-   >{};
+   using DeletionCallback = std::function<void(const SampleBlock &)>;
 
    virtual ~SampleBlock();
 


### PR DESCRIPTION
Resolves: #6321

All instances of `SqliteSampleBlockFactory` stored their progress-window instances onto the same singleton. They did so using the `Scope` mechanism, which works by temporarily swapping its state with that of the singleton.

When two objects use this mechanism in an interleaved way, things go wrong. Say `s` is our singleton, `a` our factory A, and `b`, our factory `B`:
```
s = "S"; a = "A"; b = "B";
swap(a, s); // s == "A", a == "S"
swap(b, s); // s == "B", b == "A"
swap(a, s); a.clear(); // s == "S", a == ""
swap(b, s); b.clear() // s == "A", b == ""
```
"A" is still alive. In this case, it's a modal dialog, which is in a weird, half-dead state, blocking everything else.

I don't see the need for a singleton in this particular case: `SqliteSampleBlock` instances have a reference to their factory, and can just ask them for their callback directly.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
Please try macro-processing heavy files and/or lots of them at once, and see if you observe something weird with the progress bar.