### PR TITLE
Issue 6340: wrong vertical scroll recording to new track...

### DIFF
--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -952,8 +952,15 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
          trackList.RegisterPendingNewTracks(std::move(*newTracks));
          // Bug 1548.  First of new tracks needs the focus.
          TrackFocus::Get(project).Set(first);
-         if (!trackList.empty())
-            Viewport::Get(project).ShowTrack(**trackList.rbegin());
+         if (!trackList.empty()) {
+            BasicUI::CallAfter([pProject = project.weak_from_this()]{
+               if (!pProject.expired()) {
+                  auto &project = *pProject.lock();
+                  auto &trackList = TrackList::Get(project);
+                  Viewport::Get(project).ShowTrack(**trackList.rbegin());
+               }
+            });
+         }
       }
 
       //Automated Input Level Adjustment Initialization


### PR DESCRIPTION
... Solution is to delay the scrolling until after TrackListEvent subscriptions fire and update the cumulative ChannelView heights.

Resolves: #6340

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
