### PR TITLE
Add Selection to Nyquist get-aud-info command

### DIFF
--- a/nyquist/init.lsp
+++ b/nyquist/init.lsp
@@ -58,8 +58,8 @@
   ;;; 'Commands+' is not supported in Audacity 2.3.0
   (let (type
         info
-        (types '("Commands" "Menus" "Preferences"
-                "Tracks" "Clips" "Envelopes" "Labels" "Boxes")))
+        (types '("Commands" "Menus" "Preferences" "Tracks" "Clips"
+				 "Envelopes" "Labels" "Boxes" "Selection")))
     ;Case insensitive search, then set 'type' with correct case string, or  NIL.
     (setf type (first (member str types :test 'string-equal)))
     (if (not type)


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/audacity/audacity/pull/6165)

*(short description of the changes and the motivation to make the changes)*
Adds the new "GetInfo: Selection" to Nyquist's AUD-GET-INFO command, thus making the feature conveniently available to Nyquist code.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
