### PR TITLE
Master effects

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1225,28 +1225,47 @@ bool AudioIO::AllocateBuffers(
             // Adjust mPlaybackRingBufferSecs correspondingly
             mPlaybackRingBufferSecs = PlaybackPolicy::Duration { playbackBufferSize / mRate };
 
-            const size_t totalWidth = std::accumulate(
-               mPlaybackSequences.begin(), mPlaybackSequences.end(), 0,
-               [](size_t acc, const auto &pSequence){
-                  return acc + pSequence->NChannels(); });
-
-            // mPlaybackBuffers buffers correspond many-to-one with
-            // mPlaybackSequences
-            // Except, always make at least one playback buffer, in case of
-            // MIDI playback without any audio
             mPlaybackBuffers.resize(0);
-            mPlaybackBuffers.resize(
-               std::max<size_t>(1, totalWidth));
-            // Number of scratch buffers depends on device playback channels
-            if (mNumPlaybackChannels > 0) {
-               mScratchBuffers.resize(mNumPlaybackChannels * 2 + 1);
-               mScratchPointers.clear();
-               for (auto &buffer : mScratchBuffers) {
-                  buffer.Allocate(playbackBufferSize, floatSample);
-                  mScratchPointers.push_back(
-                     reinterpret_cast<float*>(buffer.ptr()));
+            mProcessingBuffers.resize(0);
+            mMasterBuffers.resize(0);
+
+            // Always make at least one playback buffer, in case of
+            // MIDI playback without any audio
+            if(mPlaybackSequences.empty())
+               mPlaybackBuffers.resize(1);
+            else
+            {
+               mPlaybackBuffers.resize(mNumPlaybackChannels);
+               mProcessingBuffers.resize(std::accumulate(
+                  mPlaybackSequences.begin(),
+                  mPlaybackSequences.end(),
+                  0, [](int n, auto& seq) { return n + seq->NChannels(); }
+               ));
+               for(auto& buffer : mProcessingBuffers)
+                  buffer.reserve(playbackBufferSize);
+               
+               mMasterBuffers.resize(mNumPlaybackChannels);
+               for(auto& buffer : mMasterBuffers)
+                  buffer.reserve(playbackBufferSize);
+
+               // Number of scratch buffers depends on device playback channels
+               if (mNumPlaybackChannels > 0) {
+                  mScratchBuffers.resize(mNumPlaybackChannels * 2 + 1);
+                  mScratchPointers.clear();
+                  for (auto &buffer : mScratchBuffers) {
+                     buffer.Allocate(playbackBufferSize, floatSample);
+                     mScratchPointers.push_back(
+                        reinterpret_cast<float*>(buffer.ptr()));
+                  }
                }
             }
+
+            std::generate(
+               mPlaybackBuffers.begin(),
+               mPlaybackBuffers.end(),
+               [=]{ return std::make_unique<RingBuffer>(floatSample, playbackBufferSize); }
+            );
+
             mPlaybackMixers.clear();
 
             const auto &warpOptions =
@@ -1264,25 +1283,11 @@ bool AudioIO::AllocateBuffers(
             mPlaybackQueueMinimum = mPlaybackSamplesToCopy *
                ((mPlaybackQueueMinimum + mPlaybackSamplesToCopy - 1) / mPlaybackSamplesToCopy);
 
-            if (mPlaybackSequences.empty())
-               // Make at least one playback buffer
-               mPlaybackBuffers[0] =
-                  std::make_unique<RingBuffer>(floatSample, playbackBufferSize);
-
-            mOldChannelGains.resize(mPlaybackSequences.size());
-            size_t iBuffer = 0;
+            // Bug 1763 - We must fade in from zero to avoid a click on starting.
+            mOldPlaybackGain = 0.0f;
             for (unsigned int i = 0; i < mPlaybackSequences.size(); i++) {
                const auto &pSequence = mPlaybackSequences[i];
-               // Bug 1763 - We must fade in from zero to avoid a click on starting.
-               mOldChannelGains[i][0] = 0.0;
-               mOldChannelGains[i][1] = 0.0;
-
-               for (size_t jj = 0, nChannels = pSequence->NChannels();
-                  jj < nChannels; ++jj
-               )
-                  mPlaybackBuffers[iBuffer++] = std::make_unique<RingBuffer>(
-                     floatSample, playbackBufferSize);
-
+               
                // By the precondition of StartStream which is sole caller of
                // this function:
                assert(pSequence->FindChannelGroup());
@@ -1307,7 +1312,7 @@ bool AudioIO::AllocateBuffers(
                Mixer::Inputs mixSequences;
                mixSequences.push_back(Mixer::Input{ pSequence });
                mPlaybackMixers.emplace_back(std::make_unique<Mixer>(
-                  move(mixSequences),
+                  std::move(mixSequences),
                   // Don't throw for read errors, just play silence:
                   false,
                   warpOptions, startTime, endTime, pSequence->NChannels(),
@@ -1979,6 +1984,8 @@ void AudioIO::FillPlayBuffers()
    }
 }
 
+#define stackAllocate(T, count) static_cast<T*>(alloca(count * sizeof(T)))
+
 bool AudioIO::ProcessPlaybackSlices(
    std::optional<RealtimeEffects::ProcessingScope> &pScope, size_t available)
 {
@@ -1992,6 +1999,13 @@ bool AudioIO::ProcessPlaybackSlices(
    // user interface.
    bool done = false;
    bool progress = false;
+
+   // remember initial processing buffer offsets
+   // they may be different depending on latencies
+   const auto processingBufferOffsets = stackAllocate(size_t, mProcessingBuffers.size());
+   for(unsigned n = 0; n < mProcessingBuffers.size(); ++n)
+      processingBufferOffsets[n] = mProcessingBuffers[n].size();
+
    do {
       const auto slice =
          policy.GetPlaybackSlice(mPlaybackSchedule, available);
@@ -2015,104 +2029,220 @@ bool AudioIO::ProcessPlaybackSlices(
          // warping
          if (frames > 0) {
             size_t produced = 0;
+            
             if (toProduce)
                produced = mixer->Process(toProduce);
+
             //wxASSERT(produced <= toProduce);
             // Copy (non-interleaved) mixer outputs to one or more ring buffers
-            const auto nChannels = mPlaybackSequences[iSequence++]->NChannels();
-            for (size_t j = 0; j < nChannels; ++j) {
-               auto warpedSamples = mixer->GetBuffer(j);
-               const auto put = mPlaybackBuffers[iBuffer++]->Put(
-                  warpedSamples, floatSample, produced, frames - produced);
-               // wxASSERT(put == frames);
-               // but we can't assert in this thread
-               wxUnusedVar(put);
+            const auto nChannels = mPlaybackSequences[iSequence]->NChannels();
+
+            const auto toConsume = std::min(
+               frames,
+               mProcessingBuffers[iBuffer].capacity() - mProcessingBuffers[iBuffer].size()
+            );
+            //assert(toConsume == frames); //Sufficient size should have been reserved in AllocateBuffers
+            produced = std::min(produced, toConsume);
+
+            const auto appendPos = mProcessingBuffers[iBuffer].size();
+            for (size_t j = 0; j < nChannels; ++j)
+            {
+               // mPlaybackBuffers correspond many-to-one with mPlaybackSequences
+               auto& buffer = mProcessingBuffers[iBuffer + j];
+
+               //there could be leftovers from the previous pass, don't discard them
+               buffer.resize(buffer.size() + toConsume, 0);
+
+               const auto warpedSamples = mixer->GetBuffer(j);
+               std::copy_n(
+                  reinterpret_cast<const float*>(warpedSamples),
+                  produced,
+                  buffer.data() + appendPos);
+               std::fill_n(
+                  buffer.data() + appendPos + produced,
+                  toConsume - produced,
+                  .0f);
             }
+            
+            iBuffer += nChannels;
+            ++iSequence;
          }
       }
 
-      if (mPlaybackSequences.empty())
-         // Produce silence in the single ring buffer
-         mPlaybackBuffers[0]->Put(nullptr, floatSample, 0, frames);
-
       available -= frames;
       // wxASSERT(available >= 0); // don't assert on this thread
+      if(mPlaybackSequences.empty())
+         // Produce silence in the single ring buffer
+         mPlaybackBuffers[0]->Put(nullptr, floatSample, 0, frames);
 
       done = policy.RepositionPlayback( mPlaybackSchedule, mPlaybackMixers,
          frames, available );
    } while (available && !done);
 
-   // Do any realtime effect processing, more efficiently in at most
-   // two buffers per sequence, after all the little slices have been written.
-   TransformPlayBuffers(pScope);
-   return progress;
-}
+   //stop here if there are no sample sources to process...
+   if(mPlaybackSequences.empty())
+      return progress;
 
-#define stackAllocate(T, count) static_cast<T*>(alloca(count * sizeof(T)))
+   // Do any realtime effect processing for each individual sample source,
+   // after all the little slices have been written.
+   if (pScope) 
+   {
+      const auto pointers = stackAllocate(float*, mNumPlaybackChannels);
 
-void AudioIO::TransformPlayBuffers(
-   std::optional<RealtimeEffects::ProcessingScope> &pScope)
-{
-   // Transform written but un-flushed samples in the RingBuffers in-place.
-
-   // Avoiding std::vector
-   const auto pointers = stackAllocate(float*, mNumPlaybackChannels);
-
-   const auto numPlaybackSequences = mPlaybackSequences.size();
-   // mPlaybackBuffers correspond many-to-one with mPlaybackSequences
-   size_t iBuffer = 0;
-   for (const auto vt : mPlaybackSequences) {
-      if (!vt)
-         continue;
-      const auto pGroup = vt->FindChannelGroup();
-      if (!pGroup)
-         continue;
-      // vt is mono, or is the first of its group of channels
-      const auto nChannels = std::min<size_t>(
-         mNumPlaybackChannels, vt->NChannels());
-
-      // Loop over the blocks of unflushed data, at most two
-      for (unsigned iBlock : {0, 1}) {
-         size_t len = 0;
-         size_t iChannel = 0;
-         for (; iChannel < nChannels; ++iChannel) {
-            auto &ringBuffer = *mPlaybackBuffers[iBuffer + iChannel];
-            const auto pair = ringBuffer.GetUnflushed(iBlock);
-            // Playback RingBuffers have float format: see AllocateBuffers
-            pointers[iChannel] = reinterpret_cast<float*>(pair.first);
-            // The lengths of corresponding unflushed blocks should be
-            // the same for all channels
-            if (len == 0)
-               len = pair.second;
-            else
-               assert(len == pair.second);
-         }
+      int bufferIndex = 0;
+      for(const auto& seq : mPlaybackSequences)
+      {
+         if(!seq)
+            continue;//no similar check in convert-to-float part
+         const auto channelGroup = seq->FindChannelGroup();
+         if(!channelGroup)
+            continue;
 
          // Are there more output device channels than channels of vt?
          // Such as when a mono sequence is processed for stereo play?
          // Then supply some non-null fake input buffers, because the
          // various ProcessBlock overrides of effects may crash without it.
          // But it would be good to find the fixes to make this unnecessary.
-         float **scratch = &mScratchPointers[mNumPlaybackChannels + 1];
-         while (iChannel < mNumPlaybackChannels)
-            memset((pointers[iChannel++] = *scratch++), 0, len * sizeof(float));
+         auto scratch = &mScratchPointers[mNumPlaybackChannels + 1];
 
-         if (len && pScope) {
-            auto discardable = pScope->Process(*pGroup, &pointers[0],
+         //skip samples that are already processed
+         const auto offset = processingBufferOffsets[bufferIndex];
+         //number of newly written samples
+         const auto len = mProcessingBuffers[bufferIndex].size() - offset;
+
+         if(len > 0)
+         {
+            for(unsigned i = 0; i < seq->NChannels(); ++i)
+               pointers[i] = mProcessingBuffers[bufferIndex + i].data() + offset;
+            
+            for(unsigned i = seq->NChannels(); i < mNumPlaybackChannels; ++i)
+            {
+               pointers[i] = *scratch++;
+               std::fill_n(pointers[i], mProcessingBuffers[bufferIndex].size(), .0f);
+            }
+
+            const auto discardable = pScope->Process(channelGroup, &pointers[0],
                mScratchPointers.data(),
                // The single dummy output buffer:
                mScratchPointers[mNumPlaybackChannels],
                mNumPlaybackChannels, len);
-            iChannel = 0;
-            for (; iChannel < nChannels; ++iChannel) {
-               auto &ringBuffer = *mPlaybackBuffers[iBuffer + iChannel];
-               auto discarded = ringBuffer.Unput(discardable);
-               // assert(discarded == discardable);
+            // Check for asynchronous user changes in mute, solo status
+            const auto silenced = SequenceShouldBeSilent(*seq);
+            for(int i = 0; i < seq->NChannels(); ++i)
+            {
+               auto& buffer = mProcessingBuffers[bufferIndex + i];
+               buffer.erase(buffer.begin() + offset, buffer.begin() + offset + discardable);
+               if(silenced)
+               {
+                  //TODO: fade out smoothly
+                  std::fill_n(buffer.data() + offset, len - discardable, 0);
+               }
             }
          }
+
+         bufferIndex += seq->NChannels();
       }
-      iBuffer += vt->NChannels();
    }
+
+   //samples at the beginning could have been discarded
+   //in the previous step, proceed with the number of samples
+   //equal to the shortest buffer size available
+   auto samplesAvailable = std::min_element(
+      mProcessingBuffers.begin(),
+      mProcessingBuffers.end(),
+      [](auto& first, auto& second) { return first.size() < second.size(); }
+   )->size();
+
+   //introduced latency may be too high...
+   //but we don't discard what already was written
+   if(samplesAvailable == 0)
+      return progress;
+
+   //Prepare master buffers.
+   auto cleanup = finally([=] {
+      for(auto& buffer : mMasterBuffers)
+         buffer.clear();
+   });
+
+   for(auto& buffer : mMasterBuffers)
+   {
+      //assert(buffer.size() == 0);
+      //assert(buffer.capacity() >= samplesAvailable);
+      buffer.resize(samplesAvailable, 0);
+   }
+
+   {
+      unsigned bufferIndex = 0;
+      for(const auto& seq : mPlaybackSequences)
+      {
+         //TODO: apply micro-fades
+         const auto numChannels = seq->NChannels();
+         if(numChannels > 1)
+         {
+            for(unsigned n = 0; n < seq->NChannels(); ++n)
+            {
+               const auto gain = seq->GetChannelGain(n);
+               for(unsigned i = 0; i < samplesAvailable; ++i)
+                  mMasterBuffers[n][i] += mProcessingBuffers[bufferIndex + n][i] * gain;
+            }
+         }
+         else if(numChannels == 1)
+         {
+            //mono source is duplicated into every output channel
+            for(unsigned n = 0; n < mNumPlaybackChannels; ++n)
+            {
+               const auto gain = seq->GetChannelGain(n);
+               for(unsigned i = 0; i < samplesAvailable; ++i)
+                  mMasterBuffers[n][i] += mProcessingBuffers[bufferIndex][i] * gain;
+            }
+         }
+         bufferIndex += seq->NChannels();
+      }
+   }
+
+   //remove only samples that were processed in previous step
+   for(auto& buffer : mProcessingBuffers)
+      buffer.erase(buffer.begin(), buffer.begin() + samplesAvailable);
+
+   // Do any realtime effect processing, after all the little
+   // slices have been written. This time we use mixed source created in
+   // previous step
+   size_t masterBufferOffset = 0;//The amount of samples to be discarded
+   if(pScope)
+   {
+      const auto pointers = stackAllocate(float*, mNumPlaybackChannels);
+      for(unsigned i = 0; i < mNumPlaybackChannels; ++i)
+         pointers[i] = mMasterBuffers[i].data();
+
+      masterBufferOffset = pScope->Process(
+         RealtimeEffectManager::MasterGroup,
+         &pointers[0],
+         mScratchPointers.data(),
+         // The single dummy output buffer:
+         mScratchPointers[mNumPlaybackChannels],
+         mNumPlaybackChannels, samplesAvailable);
+
+      // wxASSERT(samplesAvailable >= masterBufferOffset); // don't assert on this thread
+      samplesAvailable -= masterBufferOffset;
+   }
+
+   if(samplesAvailable == 0)
+      return progress;
+
+   {
+      unsigned bufferIndex = 0;
+      for(auto& buffer : mMasterBuffers)
+      {
+         mPlaybackBuffers[bufferIndex++]->Put(
+            reinterpret_cast<constSamplePtr>(buffer.data()) + masterBufferOffset * sizeof(float),
+            floatSample,
+            samplesAvailable,
+            0
+         );
+      }
+   }
+   
+   return progress;
 }
 
 void AudioIO::DrainRecordBuffers()
@@ -2564,50 +2694,6 @@ void AudioIoCallback::CheckSoundActivatedRecordingLevel(
    }
 }
 
-// A function to apply the requested gain, fading up or down from the
-// most recently applied gain.
-void AudioIoCallback::AddToOutputChannel(unsigned int chan,
-   float * outputMeterFloats,
-   float * outputFloats,
-   const float * tempBuf,
-   bool drop,
-   const unsigned long len,
-   const PlayableSequence &ps,
-   float &channelGain)
-{
-   const auto numPlaybackChannels = mNumPlaybackChannels;
-
-   float gain = ps.GetChannelGain(chan);
-   if (drop || mForceFadeOut.load(std::memory_order_relaxed) || IsPaused())
-      gain = 0.0;
-
-   // Output volume emulation: possibly copy meter samples, then
-   // apply volume, then copy to the output buffer
-   if (outputMeterFloats != outputFloats)
-      for ( unsigned i = 0; i < len; ++i)
-         outputMeterFloats[numPlaybackChannels*i+chan] +=
-            gain*tempBuf[i];
-
-   // DV: We use gain to emulate panning.
-   // Let's keep the old behavior for panning.
-   gain *= ExpGain(GetMixerOutputVol());
-
-   float oldGain = channelGain;
-   channelGain = gain;
-   // if no microfades, jump in volume.
-   if (!mbMicroFades)
-      oldGain = gain;
-   wxASSERT(len > 0);
-
-   // Linear interpolate.
-   // PRL todo:  choose denominator differently, so it doesn't depend on
-   // framesPerBuffer, which is influenced by the portAudio implementation in
-   // opaque ways
-   float deltaGain = (gain - oldGain) / len;
-   for (unsigned i = 0; i < len; i++)
-      outputFloats[numPlaybackChannels*i+chan] += (oldGain + deltaGain * i) *tempBuf[i];
-};
-
 // Limit values to -1.0..+1.0
 void ClampBuffer(float * pBuffer, unsigned long len){
    for(unsigned i = 0; i < len; i++)
@@ -2621,28 +2707,25 @@ void ClampBuffer(float * pBuffer, unsigned long len){
 // from our intermediate playback buffers
 //
 bool AudioIoCallback::FillOutputBuffers(
-   float *outputBuffer,
+   float *outputFloats,
    unsigned long framesPerBuffer,
    float *outputMeterFloats
 )
 {
    const auto numPlaybackSequences = mPlaybackSequences.size();
    const auto numPlaybackChannels = mNumPlaybackChannels;
-   const auto numCaptureChannels = mNumCaptureChannels;
 
    mMaxFramesOutput = 0;
 
    // Quick returns if next to nothing to do.
    if (mStreamToken <= 0 ||
-       !outputBuffer ||
+       !outputFloats ||
        numPlaybackChannels <= 0) {
       // So that UpdateTimePosition() will be correct, in case of MIDI play with
       // no audio output channels
       mMaxFramesOutput = framesPerBuffer;
       return false;
    }
-
-   float *outputFloats = outputBuffer;
 
    if (mSeek && !mPlaybackSchedule.GetPolicy().AllowSeek(mPlaybackSchedule))
       mSeek = 0.0;
@@ -2652,20 +2735,20 @@ bool AudioIoCallback::FillOutputBuffers(
       return true;
    }
 
-   // ------ MEMORY ALLOCATION ----------------------
-   // These are small structures.
-   const auto tempBufs = stackAllocate(float *, numPlaybackChannels);
-
-   // And these are larger structures....
-   for (unsigned int c = 0; c < numPlaybackChannels; c++)
-      tempBufs[c] = stackAllocate(float, framesPerBuffer);
-   // ------ End of MEMORY ALLOCATION ---------------
-
    // Choose a common size to take from all ring buffers
    const auto toGet =
       std::min<size_t>(framesPerBuffer, GetCommonlyReadyPlayback());
 
-   // The drop and dropQuickly booleans are so named for historical reasons.
+   // Poke: If there are no playback sequences, then check playback
+   // completion condition and do early return
+   // PRL:  Also consume frbom the single playback ring buffer
+   if (numPlaybackSequences == 0) {
+      mMaxFramesOutput = mPlaybackBuffers[0]->Discard(toGet);
+      CallbackCheckCompletion(mCallbackReturn, 0);
+      mLastPlaybackTimeMillis = ::wxGetUTCTimeMillis();
+      return false;
+   }
+
    // JKC: The original code attempted to be faster by doing nothing on silenced audio.
    // This, IMHO, is 'premature optimisation'.  Instead clearer and cleaner code would
    // simply use a gain of 0.0 for silent audio and go on through to the stage of
@@ -2678,53 +2761,36 @@ bool AudioIoCallback::FillOutputBuffers(
    // I would expect us not to need the fast paths, since linearly interpolated gain
    // is very cheap to process.
 
-   bool drop = false;        // Sequence should become silent.
-   bool discardable = false; // Sequence has already been faded to silence.
-   // mPlaybackBuffers buffers correspond many-to-one with mPlaybackSequences
-   size_t iBuffer = 0;
-   for (unsigned tt = 0; tt < numPlaybackSequences; ++tt) {
-      auto vt = mPlaybackSequences[tt].get();
-      const auto width = vt->NChannels();
+   // ------ MEMORY ALLOCATION ----------------------
+   // These are small structures.
+   const auto tempBufs = stackAllocate(float *, numPlaybackChannels);
 
-      // IF mono THEN clear 'the other' channel.
-      if (width < numPlaybackChannels)
-         // TODO: more-than-two-channels
-         memset(tempBufs[1], 0, framesPerBuffer * sizeof(float));
+   // And these are larger structures....
+   for (unsigned int c = 0; c < numPlaybackChannels; c++)
+      tempBufs[c] = stackAllocate(float, framesPerBuffer);
+   // ------ End of MEMORY ALLOCATION ---------------
+   
+   auto gain = ExpGain(GetMixerOutputVol());
+   if (mForceFadeOut.load(std::memory_order_relaxed) || IsPaused())
+      gain = 0.0;
 
-      // Check for asynchronous user changes in mute, solo, pause status
-      discardable = drop = SequenceShouldBeSilent(*vt);
-
-      if (mbMicroFades)
-         // If micro fading, don't silence tracks instantaneously
-         discardable = discardable &&
-            SequenceHasBeenFadedOut(mOldChannelGains[tt]);
-
-      decltype(framesPerBuffer) len = 0;
-
-      for (size_t c = 0; c < width; ++c) {
-         if (discardable) {
-            len = mPlaybackBuffers[iBuffer]->Discard(toGet);
-            // keep going here.
-            // we may still need to issue a paComplete.
-
-            // Keep tempBufs initialized to avoid NaNs and Infs
-            memset(tempBufs[c], 0, framesPerBuffer * sizeof(float));
-         }
-         else {
-            len = mPlaybackBuffers[iBuffer]
-               ->Get((samplePtr)tempBufs[c], floatSample, toGet);
-            // wxASSERT( len == toGet );
-            if (len < framesPerBuffer)
-               // This used to happen normally at the end of non-looping
-               // plays, but it can also be an anomalous case where the
-               // supply from SequenceBufferExchange fails to keep up with the
-               // real-time demand in this thread (see bug 1932).  We
-               // must supply something to the sound card, so pad it with
-               // zeroes and not random garbage.
-               memset((void*)&tempBufs[c][len], 0,
-                  (framesPerBuffer - len) * sizeof(float));
-         }
-         ++iBuffer;
+   for(unsigned n = 0; n < numPlaybackChannels; ++n)
+   {
+      decltype(framesPerBuffer) len = mPlaybackBuffers[n]->Get(
+         reinterpret_cast<samplePtr>(tempBufs[n]),
+         floatSample,
+         toGet
+      );
+      if(len < framesPerBuffer)
+      {
+         // This used to happen normally at the end of non-looping
+         // plays, but it can also be an anomalous case where the
+         // supply from SequenceBufferExchange fails to keep up with the
+         // real-time demand in this thread (see bug 1932).  We
+         // must supply something to the sound card, so pad it with
+         // zeroes and not random garbage.
+         memset((void*)&tempBufs[n][len], 0,
+            (framesPerBuffer - len) * sizeof(float));
       }
 
       // PRL:  More recent rewrites of SequenceBufferExchange should guarantee a
@@ -2746,31 +2812,38 @@ bool AudioIoCallback::FillOutputBuffers(
       // Each channel in the sequences can output to more than one channel on
       // the device. For example mono channels output to both left and right
       // output channels.
-      if (len > 0) {
-         auto &gains = mOldChannelGains[tt];
-         AddToOutputChannel(0, outputMeterFloats, outputFloats,
-            tempBufs[0], drop, len, *vt, gains[0]);
+      if (len > 0)
+      {
+         // Output volume emulation: possibly copy meter samples, then
+         // apply volume, then copy to the output buffer
+         if(outputMeterFloats != outputFloats)
+         {
+            for ( unsigned i = 0; i < len; ++i)
+               outputMeterFloats[numPlaybackChannels*i+n] +=
+                  gain*tempBufs[n][i];
+         }
 
-         // If one of mPlaybackSequences is mono, this replicates it in both
-         // device channels
-         const auto iBuffer = std::min<size_t>(1, width - 1);
-         AddToOutputChannel(1, outputMeterFloats, outputFloats,
-            tempBufs[iBuffer], drop, len, *vt, gains[1]);
+         auto oldGain = mOldPlaybackGain;
+         // if no microfades, jump in volume.
+         if (!mbMicroFades)
+            oldGain = gain;
+
+         // Linear interpolate.
+         // PRL todo:  choose denominator differently, so it doesn't depend on
+         // framesPerBuffer, which is influenced by the portAudio implementation in
+         // opaque ways
+         const float deltaGain = (gain - oldGain) / len;
+         for (unsigned i = 0; i < len; i++)
+         {
+            outputFloats[numPlaybackChannels * i + n] +=
+               (oldGain + deltaGain * i) * tempBufs[n][i];
+         }
+
+         CallbackCheckCompletion(mCallbackReturn, len);
       }
-
-      CallbackCheckCompletion(mCallbackReturn, len);
-      if (discardable) // no samples to process, they've been discarded
-         continue;
    }
 
-   // Poke: If there are no playback sequences, then the earlier check
-   // about the time indicator being past the end won't happen;
-   // do it here instead (but not if looping or scrubbing)
-   // PRL:  Also consume from the single playback ring buffer
-   if (numPlaybackSequences == 0) {
-      mMaxFramesOutput = mPlaybackBuffers[0]->Discard(toGet);
-      CallbackCheckCompletion(mCallbackReturn, 0);
-   }
+   mOldPlaybackGain = gain;
 
    // wxASSERT( maxLen == toGet );
 
@@ -3059,29 +3132,12 @@ unsigned AudioIoCallback::CountSoloingSequences(){
 // fading out.
 bool AudioIoCallback::SequenceShouldBeSilent(const PlayableSequence &ps)
 {
-   return IsPaused() || (!ps.GetSolo() && (
+   return !ps.GetSolo() && (
       // Cut if somebody else is soloing
       mbHasSoloSequences ||
       // Cut if we're muted (and not soloing)
       ps.GetMute()
-   ));
-}
-
-// This is about micro-fades.
-bool AudioIoCallback::SequenceHasBeenFadedOut(const OldChannelGains &gains)
-{
-   return gains[0] == 0.0 && gains[1] == 0.0;
-}
-
-bool AudioIoCallback::AllSequencesAlreadySilent()
-{
-   for (size_t ii = 0, nn = mPlaybackSequences.size(); ii < nn; ++ii) {
-      auto vt = mPlaybackSequences[ii];
-      const auto &oldGains = mOldChannelGains[ii];
-      if (!(SequenceShouldBeSilent(*vt) && SequenceHasBeenFadedOut(oldGains)))
-         return false;
-   }
-   return true;
+   );
 }
 
 AudioIoCallback::AudioIoCallback()
@@ -3183,7 +3239,7 @@ int AudioIoCallback::AudioCallback(
 
    // Test for no sequence audio to play (because we are paused and have faded
    // out)
-   if( IsPaused() &&  (( !mbMicroFades ) || AllSequencesAlreadySilent() ))
+   if( IsPaused() &&  (( !mbMicroFades ) || mOldPlaybackGain == 0.0f ))
       return mCallbackReturn;
 
    // To add sequence output to output (to play sound on speaker)
@@ -3208,10 +3264,6 @@ int AudioIoCallback::AudioCallback(
 
    return mCallbackReturn;
 }
-
-
-
-
 
 int AudioIoCallback::CallbackDoSeek()
 {

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -182,31 +182,15 @@ public:
    // Helpers to determine if sequences have already been faded out.
    unsigned  CountSoloingSequences();
 
-   using OldChannelGains = std::array<float, 2>;
    bool SequenceShouldBeSilent(const PlayableSequence &ps);
-   //! Returns true when playback buffer data from both channels is discardable
-   bool SequenceHasBeenFadedOut(const OldChannelGains &gains);
-   bool AllSequencesAlreadySilent();
 
    void CheckSoundActivatedRecordingLevel(
       float *inputSamples,
       unsigned long framesPerBuffer
    );
 
-   /*!
-    @param[in,out] channelGain
-    */
-   void AddToOutputChannel( unsigned int chan, // index into gains
-      float * outputMeterFloats,
-      float * outputFloats,
-      const float * tempBuf,
-      bool drop,
-      unsigned long len,
-      const PlayableSequence &ps,
-      float &channelGain
-   );
    bool FillOutputBuffers(
-      float *outputBuffer,
+      float *outputFloats,
       unsigned long framesPerBuffer,
       float *outputMeterFloats
    );
@@ -271,12 +255,18 @@ public:
    using RingBuffers = std::vector<std::unique_ptr<RingBuffer>>;
    RingBuffers mCaptureBuffers;
    RecordableSequences mCaptureSequences;
+   //!Buffers that hold outcome of transformations applied to each individual sample source.
+   //!Number of buffers equals to the sum of number all source channels.
+   std::vector<std::vector<float>> mProcessingBuffers;
+   //!These buffers are used to mix and process the result of processed source channels.
+   //!Number of buffers equals to number of output channels.
+   std::vector<std::vector<float>> mMasterBuffers;
    /*! Read by worker threads but unchanging during playback */
    RingBuffers mPlaybackBuffers;
    ConstPlayableSequences      mPlaybackSequences;
    // Old gain is used in playback in linearly interpolating
    // the gain.
-   std::vector<OldChannelGains> mOldChannelGains;
+   float mOldPlaybackGain;
    // Temporary buffers, each as large as the playback buffers
    std::vector<SampleBuffer> mScratchBuffers;
    std::vector<float *> mScratchPointers; //!< pointing into mScratchBuffers
@@ -618,8 +608,7 @@ private:
 
    //! First part of SequenceBufferExchange
    void FillPlayBuffers();
-   void TransformPlayBuffers(
-      std::optional<RealtimeEffects::ProcessingScope> &scope);
+
    bool ProcessPlaybackSlices(
       std::optional<RealtimeEffects::ProcessingScope> &pScope,
       size_t available);

--- a/libraries/lib-effects/MixAndRender.h
+++ b/libraries/lib-effects/MixAndRender.h
@@ -16,6 +16,7 @@ Paul Licameli split from Mix.h
 #include "SampleFormat.h"
 #include "Track.h"
 
+class AudacityProject;
 class WaveTrack;
 class WaveTrackFactory;
 
@@ -53,5 +54,9 @@ using ChannelNames = const ChannelName *;
 EFFECTS_API
 std::vector<MixerOptions::StageSpecification>
 GetEffectStages(const WaveTrack &track);
+
+EFFECTS_API
+std::vector<MixerOptions::StageSpecification>
+GetMasterEffectStages(const AudacityProject& project);
 
 #endif

--- a/libraries/lib-effects/PerTrackEffect.cpp
+++ b/libraries/lib-effects/PerTrackEffect.cpp
@@ -130,7 +130,7 @@ bool PerTrackEffect::ProcessPass(TrackList &outputs,
          WaveChannel *pRight{};
 
          const int channel = (multichannel ? -1 : iChannel++);
-         const auto numChannels = MakeChannelMap(wt, channel, map);
+         const auto numChannels = MakeChannelMap(wt.NChannels(), channel, map);
          if (multichannel) {
             assert(numAudioIn > 1);
             if (numChannels == 2) {
@@ -369,8 +369,9 @@ bool PerTrackEffect::ProcessTrack(int channel, const Factory &factory,
    assert(upstream.AcceptsBlockSize(blockSize));
    assert(blockSize == outBuffers.BlockSize());
 
-   auto pSource = EffectStage::Create(channel, upstream, inBuffers,
-      factory, settings, sampleRate, genLength, wt);
+   auto pSource = EffectStage::Create(
+      channel, static_cast<const WideSampleSequence&>(wt).NChannels(), upstream,
+      inBuffers, factory, settings, sampleRate, genLength);
    if (!pSource)
       return false;
    assert(pSource->AcceptsBlockSize(blockSize)); // post of ctor

--- a/libraries/lib-import-export/ExportPluginHelpers.h
+++ b/libraries/lib-import-export/ExportPluginHelpers.h
@@ -3,7 +3,7 @@
   Audacity: A Digital Audio Editor
 
   ExportPluginHelpers.h
- 
+
   Dominic Mazzoni
 
   Vitaly Sverchinsky split from ExportPlugin.h
@@ -28,16 +28,14 @@ class Downmix;
 }
 
 ///\brief Utility class that provides helper functions for ExportPlugin
-class IMPORT_EXPORT_API ExportPluginHelpers final 
+class IMPORT_EXPORT_API ExportPluginHelpers final
 {
 public:
-
-   static std::unique_ptr<Mixer> CreateMixer(const TrackList &tracks,
-         bool selectionOnly,
-         double startTime, double stopTime,
-         unsigned numOutChannels, size_t outBufferSize, bool outInterleaved,
-         double outRate, sampleFormat outFormat,
-         MixerOptions::Downmix *mixerSpec);
+   static std::unique_ptr<Mixer> CreateMixer(
+      const AudacityProject& project, bool selectionOnly, double startTime,
+      double stopTime, unsigned numOutChannels, size_t outBufferSize,
+      bool outInterleaved, double outRate, sampleFormat outFormat,
+      MixerOptions::Downmix* mixerSpec);
 
    ///\brief Sends progress update to delegate and retrieves state update from it.
    ///Typically used inside each export iteration.

--- a/libraries/lib-mixer/EffectStage.h
+++ b/libraries/lib-mixer/EffectStage.h
@@ -41,17 +41,16 @@ public:
 
     @pre `channel < sequence.NChannels()`
     */
-   EffectStage(CreateToken, int channel, Source &upstream, Buffers &inBuffers,
-      const Factory &factory, EffectSettings &settings,
-      double sampleRate,
-      std::optional<sampleCount> genLength, const WideSampleSequence &sequence);
+   EffectStage(
+      CreateToken, int channel, int nInputChannels, Source& upstream,
+      Buffers& inBuffers, const Factory& factory, EffectSettings& settings,
+      double sampleRate, std::optional<sampleCount> genLength);
 
    //! Satisfies postcondition of constructor or returns null
-   static std::unique_ptr<EffectStage> Create(int channel,
-      Source &upstream, Buffers &inBuffers,
-      const Factory &factory, EffectSettings &settings,
-      double sampleRate,
-      std::optional<sampleCount> genLength, const WideSampleSequence &sequence);
+   static std::unique_ptr<EffectStage> Create(
+      int channel, int nInputChannels, Source& upstream, Buffers& inBuffers,
+      const Factory& factory, EffectSettings& settings, double sampleRate,
+      std::optional<sampleCount> genLength);
 
    EffectStage(const EffectStage&) = delete;
    EffectStage &operator =(const EffectStage &) = delete;
@@ -106,10 +105,11 @@ private:
  @param[out] map terminated with ChannelNameEOL
  @return 1 if `channel >= 0`, else the number of channels
 
- @pre `channel < sequence.NChannels()`
+ @pre `channel < nInputChannels`
  */
 MIXER_API
-unsigned MakeChannelMap(const WideSampleSequence &sequence, int channel,
+unsigned MakeChannelMap(
+   int nInputChannels, int channel,
    // TODO: more-than-two-channels
    ChannelName map[3]);
 

--- a/libraries/lib-mixer/Mix.cpp
+++ b/libraries/lib-mixer/Mix.cpp
@@ -43,9 +43,25 @@ initVector(size_t dim1, size_t dim2)
 }
 }
 
-namespace {
+namespace
+{
+void ConsiderStages(const Mixer::Stages& stages, size_t& blockSize)
+{
+   for (const auto& stage : stages)
+   {
+      // Need an instance to query acceptable block size
+      const auto pInstance = stage.factory();
+      if (pInstance)
+         blockSize = std::min(blockSize, pInstance->SetBlockSize(blockSize));
+      // Cache the first factory call
+      stage.mpFirstInstance = move(pInstance);
+   }
+}
+
 // Find a block size acceptable to all stages; side-effects on instances
-size_t FindBufferSize(const Mixer::Inputs &inputs, size_t bufferSize)
+size_t FindBufferSize(
+   const Mixer::Inputs& inputs,
+   const std::optional<Mixer::Stages>& masterEffects, size_t bufferSize)
 {
    size_t blockSize = bufferSize;
    for (const auto &input : inputs) {
@@ -55,56 +71,49 @@ size_t FindBufferSize(const Mixer::Inputs &inputs, size_t bufferSize)
          assert(false);
          break;
       }
-      for (const auto &stage : input.stages) {
-         // Need an instance to query acceptable block size
-         const auto pInstance = stage.factory();
-         if (pInstance)
-            blockSize = std::min(blockSize, pInstance->SetBlockSize(blockSize));
-         // Cache the first factory call
-         stage.mpFirstInstance = move(pInstance);
-      }
+      ConsiderStages(input.stages, blockSize);
    }
+   if (masterEffects)
+      ConsiderStages(*masterEffects, blockSize);
+
    return blockSize;
 }
-}
+} // namespace
 
-Mixer::Mixer(Inputs inputs,
-   const bool mayThrow,
-   const WarpOptions &warpOptions,
-   const double startTime, const double stopTime,
-   const unsigned numOutChannels,
-   const size_t outBufferSize, const bool outInterleaved,
-   double outRate, sampleFormat outFormat,
-   const bool highQuality, MixerSpec *const mixerSpec,
-   ApplyGain applyGain
-)  : mNumChannels{ numOutChannels }
-   , mInputs{ move(inputs) }
-   , mBufferSize{ FindBufferSize(mInputs, outBufferSize) }
-   , mApplyGain{ applyGain }
-   , mHighQuality{ highQuality }
-   , mFormat{ outFormat }
-   , mInterleaved{ outInterleaved }
+Mixer::Mixer(
+   Inputs inputs, std::optional<Stages> masterEffects, const bool mayThrow,
+   const WarpOptions& warpOptions, const double startTime,
+   const double stopTime, const unsigned numOutChannels,
+   const size_t outBufferSize, const bool outInterleaved, double outRate,
+   sampleFormat outFormat, const bool highQuality, MixerSpec* const mixerSpec,
+   ApplyGain applyGain)
+    : mNumChannels { numOutChannels }
+    , mInputs { move(inputs) }
+    , mMasterEffects { move(masterEffects) }
+    , mBufferSize { FindBufferSize(mInputs, mMasterEffects, outBufferSize) }
+    , mApplyGain { applyGain }
+    , mHighQuality { highQuality }
+    , mFormat { outFormat }
+    , mInterleaved { outInterleaved }
+    , mTimesAndSpeed { std::make_shared<TimesAndSpeed>(TimesAndSpeed {
+         startTime, stopTime, warpOptions.initialSpeed, startTime }) }
 
-   , mTimesAndSpeed{ std::make_shared<TimesAndSpeed>( TimesAndSpeed{
-      startTime, stopTime, warpOptions.initialSpeed, startTime
-   } ) }
+    // PRL:  Bug2536: see other comments below for the last, padding argument
+    // TODO: more-than-two-channels
+    // Issue 3565 workaround:  allocate one extra buffer when applying a
+    // GVerb effect stage.  It is simply discarded
+    // See also issue 3854, when the number of out channels expected by the
+    // plug-in is yet larger
+    , mFloatBuffers { 3, mBufferSize, 1, 1 }
 
-   // PRL:  Bug2536: see other comments below for the last, padding argument
-   // TODO: more-than-two-channels
-   // Issue 3565 workaround:  allocate one extra buffer when applying a
-   // GVerb effect stage.  It is simply discarded
-   // See also issue 3854, when the number of out channels expected by the
-   // plug-in is yet larger
-   , mFloatBuffers{ 3, mBufferSize, 1, 1 }
-
-   // non-interleaved
-   , mTemp{ initVector<float>(mNumChannels, mBufferSize) }
-   , mBuffer{ initVector<SampleBuffer>(mInterleaved ? 1 : mNumChannels,
-      [format = mFormat,
-         size = mBufferSize * (mInterleaved ? mNumChannels : 1)
-      ](auto &buffer){ buffer.Allocate(size, format); }
-   )}
-   , mEffectiveFormat{ floatSample }
+    // non-interleaved
+    , mTemp { 3, mBufferSize, 1, 1 }
+    , mBuffer { initVector<SampleBuffer>(
+         mInterleaved ? 1 : mNumChannels,
+         [format = mFormat,
+          size = mBufferSize * (mInterleaved ? mNumChannels : 1)](
+            auto& buffer) { buffer.Allocate(size, format); }) }
+    , mEffectiveFormat { floatSample }
 {
    assert(BufferSize() <= outBufferSize);
    const auto nChannelsIn =
@@ -120,6 +129,12 @@ Mixer::Mixer(Inputs inputs,
             [](const MixerOptions::StageSpecification &spec){
                return spec.mpFirstInstance &&
                   spec.mpFirstInstance->NeedsDither(); } ); } );
+   if (mMasterEffects)
+      needsDither |= std::any_of(
+         mMasterEffects->begin(), mMasterEffects->end(),
+         [](const MixerOptions::StageSpecification& spec) {
+            return spec.mpFirstInstance && spec.mpFirstInstance->NeedsDither();
+         });
 
    auto pMixerSpec = ( mixerSpec &&
       mixerSpec->GetNumChannels() == mNumChannels &&
@@ -129,9 +144,15 @@ Mixer::Mixer(Inputs inputs,
 
    // Reserve vectors first so we can take safe references to pushed elements
    mSources.reserve(nChannelsIn);
-   const auto nStages = std::accumulate(mInputs.begin(), mInputs.end(), 0,
-      [](auto sum, const auto &input){
-         return sum + input.stages.size() * input.pSequence->NChannels(); });
+   // One stereo-capable stage per effect.
+   const auto nMasterStages = mMasterEffects ? mMasterEffects->size() : 0;
+   const auto nStages =
+      std::accumulate(
+         mInputs.begin(), mInputs.end(), 0,
+         [](auto sum, const auto& input) {
+            return sum + input.stages.size() * input.pSequence->NChannels();
+         }) +
+      nMasterStages;
    mSettings.reserve(nStages);
    mStageBuffers.reserve(nStages);
 
@@ -148,35 +169,26 @@ Mixer::Mixer(Inputs inputs,
          warpOptions, highQuality, mayThrow, mTimesAndSpeed,
          (pMixerSpec ? &pMixerSpec->mMap[i] : nullptr));
       AudioGraph::Source *pDownstream = &source;
-      for (const auto &stage : input.stages) {
-         // Make a mutable copy of stage.settings
-         auto &settings = mSettings.emplace_back(stage.settings);
-         // TODO: more-than-two-channels
-         // Like mFloatBuffers but padding not needed for soxr
-         // Allocate one extra buffer to hold dummy zero inputs
-         // (Issue 3854)
-         auto &stageInput = mStageBuffers.emplace_back(3, mBufferSize, 1);
-         const auto &factory = [&stage]{
-            // Avoid unnecessary repeated calls to the factory
-            return stage.mpFirstInstance
-               ? move(stage.mpFirstInstance)
-               : stage.factory();
-         };
-         auto &pNewDownstream =
-         mStages.emplace_back(EffectStage::Create(-1,
-            *pDownstream, stageInput,
-            factory, settings, outRate, std::nullopt, *sequence
-         ));
-         if (pNewDownstream)
+      for (const auto &stage : input.stages)
+         if (
+            auto& pNewDownstream =
+               RegisterEffectStage(*pDownstream, stage, outRate))
+         {
             pDownstream = pNewDownstream.get();
-         else {
-            // Just omit the failed stage from rendering
-            // TODO propagate the error?
-            mStageBuffers.pop_back();
-            mSettings.pop_back();
          }
-      }
       mDecoratedSources.emplace_back(Source{ source, *pDownstream });
+   }
+
+   if (mMasterEffects)
+   {
+      AudioGraph::Source* pDownstream = this;
+      for (const auto& stage : *mMasterEffects)
+         if (
+            auto& pNewDownstream =
+               RegisterEffectStage(*pDownstream, stage, outRate))
+         {
+            mMasterStages.emplace_back(pDownstream = pNewDownstream.get());
+         }
    }
 
    // Decide once at construction time
@@ -202,7 +214,7 @@ Mixer::NeedsDither(bool needsDither, double rate) const
 
    for (const auto &input : mSources) {
       auto &sequence = input.GetSequence();
-      
+
       if (sequence.GetRate() != rate)
          // Also leads to MixVariableRates(), needs nontrivial resampling
          needsDither = true;
@@ -249,20 +261,21 @@ Mixer::NeedsDither(bool needsDither, double rate) const
 
 void Mixer::Clear()
 {
-   for (auto &buffer: mTemp)
-      std::fill(buffer.begin(), buffer.end(), 0);
+   for (auto c = 0; c < mTemp.Channels(); ++c)
+      mTemp.ClearBuffer(c, mBufferSize);
 }
 
 static void MixBuffers(unsigned numChannels,
    const unsigned char *channelFlags, const float *gains,
-   const float &src, std::vector<std::vector<float>> &dests, int len)
+   const float &src, AudioGraph::Buffers &dests, int len)
 {
    const auto pSrc = &src;
    for (unsigned int c = 0; c < numChannels; c++) {
       if (!channelFlags[c])
          continue;
+      auto dest = &dests.GetWritePosition(c);
       for (int j = 0; j < len; ++j)
-         dests[c][j] += pSrc[j] * gains[c];   // the actual mixing process
+         dest[j] += pSrc[j] * gains[c];   // the actual mixing process
    }
 }
 
@@ -277,78 +290,24 @@ size_t Mixer::Process(const size_t maxToProcess)
    //if (mT >= mT1)
    //   return 0;
 
-   size_t maxOut = 0;
-   const auto channelFlags = stackAllocate(unsigned char, mNumChannels);
-   const auto gains = stackAllocate(float, mNumChannels);
-   if (mApplyGain == ApplyGain::Discard)
-      std::fill(gains, gains + mNumChannels, 1.0f);
-
-   // Decides which output buffers an input channel accumulates into
-   auto findChannelFlags = [&channelFlags, numChannels = mNumChannels]
-   (const bool *map, const WideSampleSequence &sequence, size_t iChannel){
-      const auto end = channelFlags + numChannels;
-      std::fill(channelFlags, end, 0);
-      if (map)
-         // ignore left and right when downmixing is customized
-         std::copy(map, map + numChannels, channelFlags);
-      else if (IsMono(sequence))
-         std::fill(channelFlags, end, 1);
-      else if (iChannel == 0)
-         channelFlags[0] = 1;
-      else if (iChannel == 1) {
-         if (numChannels >= 2)
-            channelFlags[1] = 1;
-         else
-            channelFlags[0] = 1;
-      }
-      return channelFlags;
-   };
-
    auto &[mT0, mT1, _, mTime] = *mTimesAndSpeed;
    auto oldTime = mTime;
    // backwards (as possibly in scrubbing)
    const auto backwards = (mT0 > mT1);
 
    Clear();
-   // TODO: more-than-two-channels
-   auto maxChannels = std::max(2u, mFloatBuffers.Channels());
 
-   for (auto &[ upstream, downstream ] : mDecoratedSources) {
-      auto oResult = downstream.Acquire(mFloatBuffers, maxToProcess);
-      // One of MixVariableRates or MixSameRate assigns into mTemp[*][*] which
-      // are the sources for the CopySamples calls, and they copy into
-      // mBuffer[*][*]
-      if (!oResult)
-         return 0;
-      auto result = *oResult;
-      maxOut = std::max(maxOut, result);
-
-      // Insert effect stages here!  Passing them all channels of the track
-
-      const auto limit = std::min<size_t>(upstream.Channels(), maxChannels);
-      for (size_t j = 0; j < limit; ++j) {
-         const auto pFloat = (const float *)mFloatBuffers.GetReadPosition(j);
-         auto &sequence = upstream.GetSequence();
-         if (mApplyGain != ApplyGain::Discard) {
-            for (size_t c = 0; c < mNumChannels; ++c) {
-               if (mNumChannels > 1)
-                  gains[c] = sequence.GetChannelGain(c);
-               else
-                  gains[c] = sequence.GetChannelGain(j);
-            }
-            if(mApplyGain == ApplyGain::Mixdown && !mHasMixerSpec && mNumChannels == 1)
-               gains[0] /= static_cast<float>(limit);
-         }
-         
-         const auto flags =
-            findChannelFlags(upstream.MixerSpec(j), sequence, j);
-         MixBuffers(mNumChannels, flags, gains, *pFloat, mTemp, result);
-      }
-
-      downstream.Release();
-      mFloatBuffers.Advance(result);
-      mFloatBuffers.Rotate();
+   std::optional<size_t> maxOut;
+   if (mMasterStages.empty())
+      maxOut = Acquire(mTemp, maxToProcess);
+   else
+   {
+      const auto stage = mMasterStages.back();
+      maxOut = stage->Acquire(mTemp, maxToProcess);
+      stage->Release();
    }
+   if (!maxOut)
+      return 0;
 
    if (backwards)
       mTime = std::clamp(mTime, mT1, oldTime);
@@ -360,19 +319,19 @@ size_t Mixer::Process(const size_t maxToProcess)
       ? (mHighQuality ? gHighQualityDither : gLowQualityDither)
       : DitherType::none;
    for (size_t c = 0; c < mNumChannels; ++c)
-      CopySamples((constSamplePtr)mTemp[c].data(), floatSample,
+      CopySamples(mTemp.GetReadPosition(c), floatSample,
          (mInterleaved
             ? mBuffer[0].ptr() + (c * SAMPLE_SIZE(mFormat))
             : mBuffer[c].ptr()
          ),
-         mFormat, maxOut, ditherType,
+         mFormat, *maxOut, ditherType,
          1, dstStride);
 
    // MB: this doesn't take warping into account, replaced with code based on mSamplePos
    //mT += (maxOut / mRate);
 
-   assert(maxOut <= maxToProcess);
-   return maxOut;
+   assert(*maxOut <= maxToProcess);
+   return *maxOut;
 }
 
 constSamplePtr Mixer::GetBuffer()
@@ -443,4 +402,142 @@ void Mixer::SetSpeedForKeyboardScrubbing(double speed, double startTime)
    }
 
    mSpeed = fabs(speed);
+}
+
+bool Mixer::AcceptsBuffers(const Buffers& buffers) const
+{
+   return buffers.Channels() == mNumChannels &&
+          AcceptsBlockSize(buffers.BlockSize());
+}
+
+bool Mixer::AcceptsBlockSize(size_t blockSize) const
+{
+   return blockSize <= BufferSize();
+}
+
+sampleCount Mixer::Remaining() const
+{
+   return std::accumulate(
+      mDecoratedSources.begin(), mDecoratedSources.end(), sampleCount { 0 },
+      [](sampleCount sum, const Source& source) {
+         return std::max(sum, source.downstream.Remaining());
+      });
+}
+
+bool Mixer::Release()
+{
+   return true;
+}
+
+std::optional<size_t> Mixer::Acquire(Buffers& data, size_t maxToProcess)
+{
+   // TODO: more-than-two-channels
+   auto maxChannels = std::max(2u, mFloatBuffers.Channels());
+   const auto channelFlags = stackAllocate(unsigned char, mNumChannels);
+   const auto gains = stackAllocate(float, mNumChannels);
+   if (mApplyGain == ApplyGain::Discard)
+      std::fill(gains, gains + mNumChannels, 1.0f);
+
+   // Decides which output buffers an input channel accumulates into
+   auto findChannelFlags = [&channelFlags, numChannels = mNumChannels]
+   (const bool *map, const WideSampleSequence &sequence, size_t iChannel){
+      const auto end = channelFlags + numChannels;
+      std::fill(channelFlags, end, 0);
+      if (map)
+         // ignore left and right when downmixing is customized
+         std::copy(map, map + numChannels, channelFlags);
+      else if (IsMono(sequence))
+         std::fill(channelFlags, end, 1);
+      else if (iChannel == 0)
+         channelFlags[0] = 1;
+      else if (iChannel == 1) {
+         if (numChannels >= 2)
+            channelFlags[1] = 1;
+         else
+            channelFlags[0] = 1;
+      }
+      return channelFlags;
+   };
+
+   size_t maxOut = 0;
+   for (auto c = 0;c < data.Channels(); ++c)
+      data.ClearBuffer(c, maxToProcess);
+
+   for (auto& [upstream, downstream] : mDecoratedSources)
+   {
+      auto oResult = downstream.Acquire(mFloatBuffers, maxToProcess);
+      // One of MixVariableRates or MixSameRate assigns into mTemp[*][*]
+      // which are the sources for the CopySamples calls, and they copy into
+      // mBuffer[*][*]
+      if (!oResult)
+         return 0;
+      const auto result = *oResult;
+      maxOut = std::max(maxOut, result);
+
+      // Insert effect stages here!  Passing them all channels of the track
+
+      const auto limit = std::min<size_t>(upstream.Channels(), maxChannels);
+      for (size_t j = 0; j < limit; ++j)
+      {
+         const auto pFloat = (const float*)mFloatBuffers.GetReadPosition(j);
+         auto& sequence = upstream.GetSequence();
+         if (mApplyGain != ApplyGain::Discard)
+         {
+            for (size_t c = 0; c < mNumChannels; ++c)
+            {
+               if (mNumChannels > 1)
+                  gains[c] = sequence.GetChannelGain(c);
+               else
+                  gains[c] = sequence.GetChannelGain(j);
+            }
+            if (
+               mApplyGain == ApplyGain::Mixdown && !mHasMixerSpec &&
+               mNumChannels == 1)
+               gains[0] /= static_cast<float>(limit);
+         }
+
+         const auto flags =
+            findChannelFlags(upstream.MixerSpec(j), sequence, j);
+         MixBuffers(mNumChannels, flags, gains, *pFloat, data, result);
+      }
+
+      downstream.Release();
+      mFloatBuffers.Advance(result);
+      mFloatBuffers.Rotate();
+   }
+
+   // MB: this doesn't take warping into account, replaced with code based on mSamplePos
+   //mT += (maxOut / mRate);
+
+   assert(maxOut <= maxToProcess);
+   return maxOut;
+}
+
+std::unique_ptr<EffectStage>& Mixer::RegisterEffectStage(
+   AudioGraph::Source& upstream, const MixerOptions::StageSpecification& stage,
+   double outRate)
+{
+   // Make a mutable copy of stage.settings
+   auto& settings = mSettings.emplace_back(stage.settings);
+   // TODO: more-than-two-channels
+   // Like mFloatBuffers but padding not needed for soxr
+   // Allocate one extra buffer to hold dummy zero inputs
+   // (Issue 3854)
+   auto& stageInput = mStageBuffers.emplace_back(3, mBufferSize, 1);
+   const auto& factory = [&stage] {
+      // Avoid unnecessary repeated calls to the factory
+      return stage.mpFirstInstance ? move(stage.mpFirstInstance) :
+                                     stage.factory();
+   };
+   auto& pNewDownstream = mStages.emplace_back(EffectStage::Create(
+      -1, mNumChannels, upstream, stageInput, factory, settings, outRate,
+      std::nullopt));
+   if (!pNewDownstream)
+   {
+      // Just omit the failed stage from rendering
+      // TODO propagate the error?
+      mStageBuffers.pop_back();
+      mSettings.pop_back();
+   }
+   return pNewDownstream;
 }

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
@@ -51,7 +51,9 @@ bool RealtimeEffectManager::IsActive() const noexcept
 }
 
 void RealtimeEffectManager::Initialize(
-   RealtimeEffects::InitializationScope &scope, double sampleRate)
+   RealtimeEffects::InitializationScope &scope,
+   unsigned numPlaybackChannels,
+   double sampleRate)
 {
    // (Re)Set processor parameters
    mRates.clear();
@@ -68,6 +70,10 @@ void RealtimeEffectManager::Initialize(
 
    // Leave suspended state
    SetSuspended(false);
+
+   VisitGroup(MasterGroup, [&](RealtimeEffectState& state, bool) {
+      scope.mInstances.push_back(state.AddGroup(MasterGroup, numPlaybackChannels, sampleRate));
+   });
 }
 
 void RealtimeEffectManager::AddGroup(
@@ -77,9 +83,9 @@ void RealtimeEffectManager::AddGroup(
    mGroups.push_back(&group);
    mRates.insert({&group, rate});
 
-   VisitGroup(group,
+   VisitGroup(&group,
       [&](RealtimeEffectState & state, bool) {
-         scope.mInstances.push_back(state.AddGroup(group, chans, rate));
+         scope.mInstances.push_back(state.AddGroup(&group, chans, rate));
       }
    );
 }
@@ -88,9 +94,6 @@ void RealtimeEffectManager::Finalize() noexcept
 {
    // Reenter suspended state
    SetSuspended(true);
-
-   // Assume it is now safe to clean up
-   mLatency = std::chrono::microseconds(0);
 
    VisitAll([](RealtimeEffectState &state, bool){ state.Finalize(); });
 
@@ -114,12 +117,10 @@ void RealtimeEffectManager::ProcessStart(bool suspended)
    });
 }
 
-//
-
 // This will be called in a thread other than the main GUI thread.
 //
 size_t RealtimeEffectManager::Process(bool suspended,
-   const ChannelGroup &group,
+   const ChannelGroup *group,
    float *const *buffers, float *const *scratch, float *const dummy,
    unsigned nBuffers, size_t numSamples)
 {
@@ -127,10 +128,6 @@ size_t RealtimeEffectManager::Process(bool suspended,
    // effects have been suspended, so allow the samples to pass as-is.
    if (suspended)
       return 0;
-
-   // Remember when we started so we can calculate the amount of latency we
-   // are introducing
-   auto start = std::chrono::steady_clock::now();
 
    // Allocate the in and out buffer arrays
    const auto ibuf =
@@ -168,10 +165,6 @@ size_t RealtimeEffectManager::Process(bool suspended,
    if (called & 1)
       for (unsigned int i = 0; i < nBuffers; i++)
          memcpy(buffers[i], ibuf[i], numSamples * sizeof(float));
-
-   // Remember the latency
-   auto end = std::chrono::steady_clock::now();
-   mLatency = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
    //
    // This is wrong...needs to handle tails
@@ -246,17 +239,26 @@ RealtimeEffectManager::MakeNewState(
       // Adding a state while playback is in-flight
       auto pInstance = state.Initialize(pScope->mSampleRate);
       pScope->mInstances.push_back(pInstance);
-      for (const auto group : mGroups) {
-         // Add all groups to a per-project state, but add only the same
-         // group to a state in the per-group list
-         if (pGroup && pGroup != group)
-            continue;
-         auto rate = mRates[group];
-         auto pInstance2 =
-            state.AddGroup(*group, pScope->mNumPlaybackChannels, rate);
-         if (pInstance2 != pInstance)
+
+      if(pGroup == MasterGroup)
+      {
+         auto pInstance2 = state.AddGroup(MasterGroup, pScope->mNumPlaybackChannels, pScope->mSampleRate);
+         if(pInstance2 != pInstance)
             pScope->mInstances.push_back(pInstance2);
       }
+      else
+      {
+         for (const auto group : mGroups) {
+            if (pGroup != group)
+               continue;
+            auto pInstance2 =
+               state.AddGroup(group, pScope->mNumPlaybackChannels, mRates[group]);
+            if (pInstance2 != pInstance)
+               pScope->mInstances.push_back(pInstance2);
+         }
+      }
+
+      
    }
    return pNewState;
 }
@@ -284,7 +286,7 @@ std::shared_ptr<RealtimeEffectState> RealtimeEffectManager::AddState(
       return nullptr;
    Publish({
       RealtimeEffectManagerMessage::Type::EffectAdded,
-      pGroup ? pGroup : nullptr
+      pGroup ? pGroup : MasterGroup
    });
    return pState;
 }
@@ -325,7 +327,7 @@ void RealtimeEffectManager::RemoveState(
       pState->Finalize();
    Publish({
       RealtimeEffectManagerMessage::Type::EffectRemoved,
-      pGroup ? pGroup : nullptr
+      pGroup ? pGroup : MasterGroup
    });
 }
 
@@ -336,11 +338,3 @@ std::optional<size_t> RealtimeEffectManager::FindState(
    auto &states = FindStates(mProject, pGroup);
    return states.FindState(pState);
 }
-
-// Where is this used?
-#if 0
-auto RealtimeEffectManager::GetLatency() const -> Latency
-{
-   return mLatency; // should this be atomic?
-}
-#endif

--- a/libraries/lib-realtime-effects/RealtimeEffectState.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectState.cpp
@@ -456,7 +456,7 @@ void AllocateChannelsToProcessors(
 /*! The iteration over channels in AddGroup and Process must be the same */
 std::shared_ptr<EffectInstance>
 RealtimeEffectState::AddGroup(
-   const ChannelGroup &group, unsigned chans, float sampleRate)
+   const ChannelGroup *group, unsigned chans, float sampleRate)
 {
    auto pInstance = EnsureInstance(sampleRate);
    if (!pInstance)
@@ -481,7 +481,7 @@ RealtimeEffectState::AddGroup(
    if (mCurrentProcessor > first) {
       // Remember the sampleRate of the group, so latency can be computed
       // later
-      mGroups[&group] = { first, sampleRate };
+      mGroups[group] = { first, sampleRate };
       return pInstance;
    }
    return {};
@@ -533,13 +533,13 @@ bool RealtimeEffectState::ProcessStart(bool running)
 //! Visit the effect processors that were added in AddGroup
 /*! The iteration over channels in AddGroup and Process must be the same */
 size_t RealtimeEffectState::Process(
-   const ChannelGroup &group, unsigned chans,
+   const ChannelGroup *group, unsigned chans,
    const float *const *inbuf, float *const *outbuf, float *const dummybuf,
    size_t numSamples)
 {
 
    const auto pInstance = mwInstance.lock();
-   const auto& pair = mGroups[&group];
+   const auto& pair = mGroups[group];
    const float** const clientIn =
       pInstance ? stackAllocate(const float*, pInstance->GetAudioInCount()) :
                   nullptr;

--- a/libraries/lib-realtime-effects/RealtimeEffectState.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectState.h
@@ -71,7 +71,7 @@ public:
    //! Main thread sets up this state before adding it to lists
    std::shared_ptr<EffectInstance>
    AddGroup(
-      const ChannelGroup &group, unsigned chans, float sampleRate);
+      const ChannelGroup *group, unsigned chans, float sampleRate);
    //! Worker thread begins a batch of samples
    /*! @param running means no pause or deactivation of containing list */
    bool ProcessStart(bool running);
@@ -79,7 +79,7 @@ public:
    /*!
     @return how many leading samples are discardable for latency
     */
-   size_t Process(const ChannelGroup &group,
+   size_t Process(const ChannelGroup *group,
       unsigned chans, // How many channels the playback device needs
       const float *const *inbuf, //!< chans input buffers
       float *const *outbuf, //!< chans output buffers

--- a/modules/import-export/mod-cl/ExportCL.cpp
+++ b/modules/import-export/mod-cl/ExportCL.cpp
@@ -201,7 +201,7 @@ public:
 
       wxArrayStringEx cmds( mHistory.begin(), mHistory.end() );
       auto cmd = cmds[0];
-      
+
       S.StartVerticalLay();
       {
          S.StartHorizontalLay(wxEXPAND);
@@ -257,8 +257,8 @@ public:
             true);
          return false;
       }
-         
-      // Normalize the path (makes absolute and resolves variables)   
+
+      // Normalize the path (makes absolute and resolves variables)
       wxFileName cmd(argv[0]);
       cmd.Normalize(wxPATH_NORM_ALL & ~wxPATH_NORM_ABSOLUTE);
 
@@ -274,7 +274,7 @@ public:
 
          return true;
       }
-    
+
       // Search for the command in the PATH list
       wxPathList pathlist;
       pathlist.AddEnvList(wxT("PATH"));
@@ -308,7 +308,7 @@ public:
       }
       return false;
    }
-   
+
    SampleRateList GetSampleRateList() const override
    {
       return {};
@@ -455,7 +455,7 @@ public:
 
    int GetFormatCount() const override;
    FormatInfo GetFormatInfo(int) const override;
-   
+
    // Required
 
    std::unique_ptr<ExportOptionsEditor>
@@ -508,7 +508,7 @@ bool CLExportProcessor::Initialize(AudacityProject& project,
    context.cmd = wxString::FromUTF8(ExportPluginHelpers::GetParameterValue<std::string>(parameters, CLOptionIDCommand));
    context.showOutput = ExportPluginHelpers::GetParameterValue(parameters, CLOptionIDShowOutput, false);
 
-   // Bug 2178 - users who don't know what they are doing will 
+   // Bug 2178 - users who don't know what they are doing will
    // now get a file extension of .wav appended to their ffmpeg filename
    // and therefore ffmpeg will be able to choose a file type.
    if( context.cmd == wxT("ffmpeg -i - \"%f\"") && !fName.HasExt())
@@ -628,18 +628,9 @@ bool CLExportProcessor::Initialize(AudacityProject& project,
    os->Write(&data, sizeof(data));
 
    // Mix 'em up
-   const auto &tracks = TrackList::Get( project );
    context.mixer = ExportPluginHelpers::CreateMixer(
-                            tracks,
-                            selectionOnly,
-                            t0,
-                            t1,
-                            channels,
-                            maxBlockLen,
-                            true,
-                            rate,
-                            floatSample,
-                            mixerSpec);
+      project, selectionOnly, t0, t1, channels, maxBlockLen, true, rate,
+      floatSample, mixerSpec);
 
    context.status = selectionOnly
          ? XO("Exporting the selected audio using command-line encoder")

--- a/modules/import-export/mod-flac/ExportFLAC.cpp
+++ b/modules/import-export/mod-flac/ExportFLAC.cpp
@@ -212,7 +212,7 @@ public:
 
    int GetFormatCount() const override;
    FormatInfo GetFormatInfo(int) const override;
-   
+
    bool ParseConfig(int, const rapidjson::Value& config, ExportProcessor::Parameters& parameters) const override;
 
    std::vector<std::string> GetMimeTypes(int) const override;
@@ -303,14 +303,12 @@ bool FLACExportProcessor::Initialize(AudacityProject& project,
    context.numChannels = numChannels;
    context.fName = fName;
 
-   const auto &tracks = TrackList::Get( project );
-
    wxLogNull logNo;            // temporarily disable wxWidgets error messages
 
    long levelPref = std::stol(ExportPluginHelpers::GetParameterValue<std::string>(parameters, FlacOptionIDLevel));
    auto bitDepthPref = ExportPluginHelpers::GetParameterValue<std::string>(parameters, FlacOptionIDBitDepth);
 
-   
+
    auto& encoder = context.encoder;
 
    bool success = true;
@@ -338,7 +336,7 @@ bool FLACExportProcessor::Initialize(AudacityProject& project,
       success = encoder.set_metadata(&p, 1);
    }
 
-   
+
    if (bitDepthPref == "24") {
       context.format = int24Sample;
       success = success && encoder.set_bits_per_sample(24);
@@ -402,10 +400,9 @@ bool FLACExportProcessor::Initialize(AudacityProject& project,
 
    metadata.reset();
 
-   context.mixer = ExportPluginHelpers::CreateMixer(tracks, selectionOnly,
-                            t0, t1,
-                            numChannels, SAMPLES_PER_RUN, false,
-                            sampleRate, context.format, mixerSpec);
+   context.mixer = ExportPluginHelpers::CreateMixer(
+      project, selectionOnly, t0, t1, numChannels, SAMPLES_PER_RUN, false,
+      sampleRate, context.format, mixerSpec);
 
    context.status = selectionOnly
       ? XO("Exporting the selected audio as FLAC")

--- a/modules/import-export/mod-mp2/ExportMP2.cpp
+++ b/modules/import-export/mod-mp2/ExportMP2.cpp
@@ -72,7 +72,7 @@ namespace {
 // i18n-hint kbps abbreviates "thousands of bits per second"
 inline TranslatableString n_kbps( int n ) { return XO("%d kbps").Format( n ); }
 
-      
+
 const TranslatableStrings BitRateMPEG1Names {
    n_kbps(32),
    n_kbps(48),
@@ -120,7 +120,7 @@ const std::initializer_list<ExportOption> MP2Options {
       ExportOption::TypeEnum,
       { 0, 1 },
       { XO("MPEG2"), XO("MPEG1") },
-      
+
    },
    {
       MP2OptionIDBitRateMPEG1, XO("Bit Rate"),
@@ -187,14 +187,14 @@ public:
       if(id == MP2OptionIDVersion)
       {
          OnVersionChanged();
-         
+
          if(mListener != nullptr)
          {
             mListener->OnExportOptionChangeBegin();
             mListener->OnExportOptionChange(mOptions[MP2OptionIDBitRateMPEG1]);
             mListener->OnExportOptionChange(mOptions[MP2OptionIDBitRateMPEG2]);
             mListener->OnExportOptionChangeEnd();
-            
+
             mListener->OnSampleRateListChange();
          }
       }
@@ -289,7 +289,7 @@ public:
 
    int GetFormatCount() const override;
    FormatInfo GetFormatInfo(int) const override;
-   
+
    // Required
 
    std::unique_ptr<ExportOptionsEditor>
@@ -347,14 +347,13 @@ bool MP2ExportProcessor::Initialize(AudacityProject& project,
       ExportPluginHelpers::GetParameterValue(parameters,
          MP2OptionIDVersion, 1));
 
-   const auto bitrate = version == TWOLAME_MPEG1 
+   const auto bitrate = version == TWOLAME_MPEG1
       ? ExportPluginHelpers::GetParameterValue(
          parameters,
          MP2OptionIDBitRateMPEG1, 192)
       : ExportPluginHelpers::GetParameterValue(
          parameters,
          MP2OptionIDBitRateMPEG2, 96);
-   const auto &tracks = TrackList::Get( project );
 
    wxLogNull logNo;             /* temporarily disable wxWidgets error messages */
 
@@ -380,7 +379,7 @@ bool MP2ExportProcessor::Initialize(AudacityProject& project,
    if (!context.outFile->IsOpened()) {
       throw ExportException(_("Unable to open target file for writing"));
    }
-   
+
    bool endOfFile;
    context.id3len = AddTags(context.id3buffer, &endOfFile, metadata);
    if (context.id3len && !endOfFile) {
@@ -398,10 +397,9 @@ bool MP2ExportProcessor::Initialize(AudacityProject& project,
       : XO("Exporting the audio at %ld kbps")
            .Format( bitrate );
 
-   context.mixer = ExportPluginHelpers::CreateMixer(tracks, selectionOnly,
-         t0, t1,
-         stereo ? 2 : 1, pcmBufferSize, true,
-         sampleRate, int16Sample, mixerSpec);
+   context.mixer = ExportPluginHelpers::CreateMixer(
+      project, selectionOnly, t0, t1, stereo ? 2 : 1, pcmBufferSize, true,
+      sampleRate, int16Sample, mixerSpec);
 
    return true;
 }

--- a/modules/import-export/mod-mp3/ExportMP3.cpp
+++ b/modules/import-export/mod-mp3/ExportMP3.cpp
@@ -309,7 +309,7 @@ public:
       it->second = value;
 
       switch(id)
-      { 
+      {
       case MP3OptionIDMode:
          {
             const auto mode = *std::get_if<std::string>(&value);
@@ -322,7 +322,7 @@ public:
                mListener->OnExportOptionChange(mOptions[MP3OptionIDQualityCBR]);
                mListener->OnExportOptionChange(mOptions[MP3OptionIDQualityVBR]);
                mListener->OnExportOptionChangeEnd();
-               
+
                mListener->OnSampleRateListChange();
             }
          } break;
@@ -349,15 +349,15 @@ public:
       }
       return false;
    }
-   
+
    SampleRateList GetSampleRateList() const override
    {
       // Retrieve preferences
       int highrate = 48000;
       int lowrate = 8000;
-      
+
       const auto rmode = *std::get_if<std::string>(&mValues.find(MP3OptionIDMode)->second);
-      
+
       if (rmode == "ABR") {
          auto bitrate = *std::get_if<int>(&mValues.find(MP3OptionIDQualityABR)->second);
          if (bitrate > 160) {
@@ -383,7 +383,7 @@ public:
       for(auto rate : sampRates)
          if(rate >= lowrate && rate <= highrate)
             result.push_back(rate);
-      
+
       return result;
    }
 
@@ -404,7 +404,7 @@ public:
       config.Read(wxT("/FileFormats/MP3AbrRate"), std::get_if<int>(&mValues[MP3OptionIDQualityABR]));
       config.Read(wxT("/FileFormats/MP3CbrRate"), std::get_if<int>(&mValues[MP3OptionIDQualityCBR]));
       config.Read(wxT("/FileFormats/MP3VbrRate"), std::get_if<int>(&mValues[MP3OptionIDQualityVBR]));
-      
+
       OnModeChange(*std::get_if<std::string>(&mValues[MP3OptionIDMode]));
    }
 
@@ -422,7 +422,7 @@ public:
       it = mValues.find(MP3OptionIDQualityVBR);
       config.Write(wxT("/FileFormats/MP3VbrRate"), *std::get_if<int>(&it->second));
    }
-   
+
 private:
 
    void OnModeChange(const std::string& mode)
@@ -765,7 +765,7 @@ private:
    int mBitrate;
    int mQuality;
    //int mRoutine;
-   
+
 #ifndef DISABLE_DYNAMIC_LOADING_LAME
    /* function pointers to the symbols we get from the library */
    lame_init_t* lame_init;
@@ -979,7 +979,7 @@ bool MP3Exporter::InitLibraryInternal()
 
 // The global ::lame_something symbols only exist if LAME is built in.
 // So we don't reference them unless they are.
-#ifdef MP3_EXPORT_BUILT_IN 
+#ifdef MP3_EXPORT_BUILT_IN
 
    lame_init = ::lame_init;
    get_lame_version = ::get_lame_version;
@@ -1247,7 +1247,7 @@ int MP3Exporter::InitializeStream(unsigned channels, int sampleRate)
       mode = MONO;
    else
       mode = JOINT_STEREO;
-   
+
    lame_set_mode(mGF, mode);
 
    int rc = lame_init_params(mGF);
@@ -1424,7 +1424,7 @@ wxString MP3Exporter::GetLibraryPath()
    {
         return path;
    }
-    
+
    return wxT("/Library/Application Support/audacity/libs");
 }
 
@@ -1639,7 +1639,7 @@ public:
 
    int GetFormatCount() const override;
    FormatInfo GetFormatInfo(int) const override;
-   
+
    std::unique_ptr<ExportOptionsEditor>
    CreateOptionsEditor(int, ExportOptionsEditor::Listener* listener) const override;
 
@@ -1748,7 +1748,7 @@ bool ExportMP3::ParseConfig(
    }
    else
       return false;
-   
+
    return true;
 }
 
@@ -1785,7 +1785,6 @@ bool MP3ExportProcessor::Initialize(AudacityProject& project,
    context.channels = channels;
 
    int rate = lrint(sampleRate);
-   const auto &tracks = TrackList::Get( project );
    auto& exporter = context.exporter;
 
 #ifdef DISABLE_DYNAMIC_LOADING_LAME
@@ -1813,7 +1812,7 @@ bool MP3ExportProcessor::Initialize(AudacityProject& project,
    int lowrate = 8000;
    int bitrate = 0;
    int quality;
-   
+
    auto rmode = ExportPluginHelpers::GetParameterValue(
       parameters,
       MP3OptionIDMode,
@@ -1945,10 +1944,9 @@ bool MP3ExportProcessor::Initialize(AudacityProject& project,
             .Format( bitrate );
    }
 
-   context.mixer = ExportPluginHelpers::CreateMixer(tracks, selectionOnly,
-         t0, t1,
-         channels, context.inSamples, true,
-         rate, floatSample, mixerSpec);
+   context.mixer = ExportPluginHelpers::CreateMixer(
+      project, selectionOnly, t0, t1, channels, context.inSamples, true, rate,
+      floatSample, mixerSpec);
 
    return true;
 }
@@ -1964,7 +1962,7 @@ ExportResult MP3ExportProcessor::Process(ExportProcessorDelegate& delegate)
    wxASSERT(buffer);
 
    auto exportResult = ExportResult::Success;
-   
+
    {
       while (exportResult == ExportResult::Success) {
          auto blockLen = context.mixer->Process();

--- a/modules/import-export/mod-ogg/ExportOGG.cpp
+++ b/modules/import-export/mod-ogg/ExportOGG.cpp
@@ -15,7 +15,7 @@
 
 #include <wx/log.h>
 #include <wx/stream.h>
- 
+
 #include <vorbis/vorbisenc.h>
 
 #include "wxFileNameWrapper.h"
@@ -78,7 +78,7 @@ namespace
          }
          return false;
       }
-      
+
       SampleRateList GetSampleRateList() const override
       {
          return {};
@@ -180,7 +180,7 @@ OGGExportProcessor::~OGGExportProcessor()
       vorbis_block_clear(&context.block);
       vorbis_dsp_clear(&context.dsp);
    }
-   
+
    vorbis_info_clear(&context.info);
 }
 
@@ -197,7 +197,6 @@ bool OGGExportProcessor::Initialize(AudacityProject& project,
    context.t1 = t1;
    context.numChannels = numChannels;
 
-   const auto &tracks = TrackList::Get( project );
    double    quality = ExportPluginHelpers::GetParameterValue(parameters, 0, 5) / 10.0;
 
    wxLogNull logNo;            // temporarily disable wxWidgets error messages
@@ -208,7 +207,7 @@ bool OGGExportProcessor::Initialize(AudacityProject& project,
    // Encoding setup
 
    vorbis_info_init(&context.info);
-   
+
    if (vorbis_encode_init_vbr(&context.info, numChannels, (int)(sampleRate + 0.5), quality)) {
       // TODO: more precise message
       throw ExportException(_("Unable to export - rate or quality problem"));
@@ -269,10 +268,9 @@ bool OGGExportProcessor::Initialize(AudacityProject& project,
       }
    }
 
-   context.mixer = ExportPluginHelpers::CreateMixer(tracks, selectionOnly,
-         t0, t1,
-         numChannels, SAMPLES_PER_RUN, false,
-         sampleRate, floatSample, mixerSpec);
+   context.mixer = ExportPluginHelpers::CreateMixer(
+      project, selectionOnly, t0, t1, numChannels, SAMPLES_PER_RUN, false,
+      sampleRate, floatSample, mixerSpec);
 
    context.status = selectionOnly
       ? XO("Exporting the selected audio as Ogg Vorbis")
@@ -361,7 +359,7 @@ ExportResult OGGExportProcessor::Process(ExportProcessorDelegate& delegate)
       // TODO: more precise message
       throw ExportErrorException("OGG:366");
    }
-   
+
    return exportResult;
 }
 

--- a/modules/import-export/mod-opus/ExportOpus.cpp
+++ b/modules/import-export/mod-opus/ExportOpus.cpp
@@ -330,7 +330,7 @@ class OpusExportProcessor final : public ExportProcessor
       }
 
       ogg_packet packet {};
-  
+
    private:
       std::vector<byte_type> buffer;
       bool resizable { false };
@@ -368,7 +368,7 @@ class OpusExportProcessor final : public ExportProcessor
          uint8_t nbCoupled {};
          uint8_t streamMap[255] {};
       } opus;
-      
+
       // Bitstream properties
       struct OggState final
       {
@@ -755,10 +755,8 @@ bool OpusExportProcessor::Initialize(
 
    WriteTags();
 
-   const auto& tracks = TrackList::Get(project);
-
    context.mixer = ExportPluginHelpers::CreateMixer(
-      tracks, selectionOnly, t0, t1, numChannels, context.opus.frameSize, true,
+      project, selectionOnly, t0, t1, numChannels, context.opus.frameSize, true,
       sampleRate, floatSample, mixerSpec);
 
    return true;
@@ -836,7 +834,7 @@ ExportResult OpusExportProcessor::Process(ExportProcessorDelegate& delegate)
       context.ogg.WriteOut(context.outFile);
 
       context.ogg.audioStreamPacket.packet.packetno++;
-      
+
       exportResult = ExportPluginHelpers::UpdateProgress(
          delegate, *context.mixer, context.t0, context.t1);
    }

--- a/modules/import-export/mod-pcm/ExportPCM.cpp
+++ b/modules/import-export/mod-pcm/ExportPCM.cpp
@@ -96,7 +96,7 @@ void GetEncodings(int type, std::vector<ExportValue>& values, TranslatableString
    info.samplerate = 44100;
    info.channels = 1;
    info.sections = 1;
-   
+
    for (int i = 0, num = sf_num_encodings(); i < num; ++i)
    {
       int sub = sf_encoding_index_to_subtype(i);
@@ -165,7 +165,7 @@ public:
       }
       return false;
    }
-   
+
    SampleRateList GetSampleRateList() const override
    {
       return {};
@@ -187,7 +187,7 @@ class ExportOptionsSFEditor final : public ExportOptionsEditor
    Listener* const mListener;
    int mType;
    std::unordered_map<int, int> mEncodings;
-   
+
    std::vector<ExportOption> mOptions;
 
    bool IsValidType(const ExportValue& typeValue) const
@@ -201,7 +201,7 @@ class ExportOptionsSFEditor final : public ExportOptionsEditor
       }
       return false;
    }
-   
+
 
 public:
 
@@ -293,7 +293,7 @@ public:
          const auto newType = *std::get_if<int>(&value);
          if(newType == mType)
             return true;
-         
+
          if(mListener)
             mListener->OnExportOptionChangeBegin();
 
@@ -331,7 +331,7 @@ public:
       }
       return false;
    }
-   
+
    SampleRateList GetSampleRateList() const override
    {
       return {};
@@ -440,11 +440,11 @@ public:
 
    int GetFormatCount() const override;
    FormatInfo GetFormatInfo(int index) const override;
-   
+
    std::vector<std::string> GetMimeTypes(int formatIndex) const override;
 
    bool ParseConfig(int formatIndex, const rapidjson::Value&, ExportProcessor::Parameters& parameters) const override;
-   
+
    std::unique_ptr<ExportOptionsEditor>
    CreateOptionsEditor(int, ExportOptionsEditor::Listener*) const override;
 
@@ -545,8 +545,6 @@ bool PCMExportProcessor::Initialize(AudacityProject& project,
    context.t1 = t1;
    context.fName = fName;
 
-   const auto &tracks = TrackList::Get( project );
-
    // Set a default in case the settings aren't found
    int& sf_format = context.sf_format;
 
@@ -578,7 +576,7 @@ bool PCMExportProcessor::Initialize(AudacityProject& project,
 
    int& fileFormat = context.fileFormat;
    fileFormat = sf_format & SF_FORMAT_TYPEMASK;
-   
+
    {
       wxFile &f = context.f;
       SNDFILE* &sf = context.sf;
@@ -613,7 +611,7 @@ bool PCMExportProcessor::Initialize(AudacityProject& project,
 
       // If we can't export exactly the format they requested,
       // try the default format for that header type...
-      // 
+      //
       // LLL: I don't think this is valid since libsndfile checks
       // for all allowed subtypes explicitly and doesn't provide
       // for an unspecified subtype.
@@ -646,7 +644,7 @@ bool PCMExportProcessor::Initialize(AudacityProject& project,
          AddStrings(sf, metadata, sf_format);
       }
       context.metadata = std::make_unique<Tags>(*metadata);
-      
+
       if (sf_subtype_more_than_16_bits(info.format))
          context.format = floatSample;
       else
@@ -673,17 +671,16 @@ bool PCMExportProcessor::Initialize(AudacityProject& project,
          }
       }
 
-      
+
       context.status = (selectionOnly
          ? XO("Exporting the selected audio as %s")
          : XO("Exporting the audio as %s")).Format( formatStr );
 
-      
+
       wxASSERT(info.channels >= 0);
-      context.mixer = ExportPluginHelpers::CreateMixer(tracks, selectionOnly,
-                               t0, t1,
-                               info.channels, maxBlockLen, true,
-                               sampleRate, context.format, mixerSpec);
+      context.mixer = ExportPluginHelpers::CreateMixer(
+         project, selectionOnly, t0, t1, info.channels, maxBlockLen, true,
+         sampleRate, context.format, mixerSpec);
    }
 
    return true;
@@ -694,7 +691,7 @@ ExportResult PCMExportProcessor::Process(ExportProcessorDelegate& delegate)
    delegate.SetStatusString(context.status);
 
    auto exportResult = ExportResult::Success;
-   
+
    {
       std::vector<char> dither;
       if ((context.info.format & SF_FORMAT_SUBMASK) == SF_FORMAT_PCM_24) {
@@ -760,7 +757,7 @@ ExportResult PCMExportProcessor::Process(ExportProcessorDelegate& delegate)
                delegate, *context.mixer, context.t0, context.t1);
       }
    }
-   
+
    // Install the WAV metata in a "LIST" chunk at the end of the file
    if (exportResult != ExportResult::Cancelled && exportResult != ExportResult::Error) {
       if (context.fileFormat == SF_FORMAT_WAV ||

--- a/modules/import-export/mod-wavpack/ExportWavPack.cpp
+++ b/modules/import-export/mod-wavpack/ExportWavPack.cpp
@@ -53,7 +53,7 @@ const TranslatableStrings ExportBitDepthNames {
    XO("32 bit float"),
 };
 
-/* 
+/*
 Copied from ExportMP2.cpp by
    Joshua Haberman
    Markus Meyer
@@ -78,7 +78,7 @@ const TranslatableStrings BitRateNames {
 
 const std::initializer_list<ExportOption> ExportWavPackOptions {
    {
-      
+
       OptionIDQuality, XO("Quality"),
       1,
       ExportOption::TypeEnum,
@@ -171,7 +171,7 @@ public:
       }
       return true;
    }
-   
+
    SampleRateList GetSampleRateList() const override
    {
       return {};
@@ -190,7 +190,7 @@ public:
       config.Read(L"/FileFormats/WavPackHybridMode", hybridMode);
       config.Read(L"/FileFormats/WavPackCreateCorrectionFile", createCorrection);
       config.Read(L"/FileFormats/WavPackBitrate", bitRate);
-      
+
       OnHybridModeChange(*hybridMode);
    }
 
@@ -216,7 +216,7 @@ public:
       if(it != mValues.end())
          config.Write(L"/FileFormats/WavPackBitrate", *std::get_if<int>(&it->second));
    }
-   
+
 private:
    void OnHybridModeChange(bool hybridMode)
    {
@@ -317,7 +317,7 @@ std::vector<std::string> ExportWavPack::GetMimeTypes(int) const
 
 bool ExportWavPack::ParseConfig(int formatIndex, const rapidjson::Value& config, ExportProcessor::Parameters& parameters) const
 {
-   if(!config.IsObject() || 
+   if(!config.IsObject() ||
       !config.HasMember("quality") || !config["quality"].IsNumber() ||
       !config.HasMember("bit_rate") || !config["bit_rate"].IsNumber() ||
       !config.HasMember("bit_depth") || !config["bit_depth"].IsNumber() ||
@@ -397,8 +397,6 @@ bool WavPackExportProcessor::Initialize(AudacityProject& project,
    if (!outWvFile.file->Create(fName.GetFullPath(), true) || !outWvFile.file->IsOpened()) {
       throw ExportException(_("Unable to open target file for writing"));
    }
-   
-   const auto &tracks = TrackList::Get( project );
 
    const auto quality = ExportPluginHelpers::GetParameterValue<int>(
       parameters,
@@ -474,21 +472,20 @@ bool WavPackExportProcessor::Initialize(AudacityProject& project,
    if (!WavpackSetConfiguration64(context.wpc, &config, -1, nullptr) || !WavpackPackInit(context.wpc)) {
       throw ExportErrorException( WavpackGetErrorMessage(context.wpc) );
    }
-   
+
    context.status = selectionOnly
       ? XO("Exporting selected audio as WavPack")
       : XO("Exporting the audio as WavPack");
-   
+
    context.metadata = std::make_unique<Tags>(
       metadata == nullptr
          ? Tags::Get( project )
          : *metadata
       );
 
-   context.mixer = ExportPluginHelpers::CreateMixer(tracks, selectionOnly,
-         t0, t1,
-         numChannels, SAMPLES_PER_RUN, true,
-         sampleRate, context.format, mixerSpec);
+   context.mixer = ExportPluginHelpers::CreateMixer(
+      project, selectionOnly, t0, t1, numChannels, SAMPLES_PER_RUN, true,
+      sampleRate, context.format, mixerSpec);
 
    return true;
 }
@@ -509,7 +506,7 @@ ExportResult WavPackExportProcessor::Process(ExportProcessorDelegate& delegate)
 
          if (samplesThisRun == 0)
             break;
-         
+
          if (context.format == int16Sample) {
             const int16_t *mixed = reinterpret_cast<const int16_t*>(context.mixer->GetBuffer());
             for (decltype(samplesThisRun) j = 0; j < samplesThisRun; j++) {
@@ -537,7 +534,7 @@ ExportResult WavPackExportProcessor::Process(ExportProcessorDelegate& delegate)
    if (!WavpackFlushSamples(context.wpc)) {
       throw ExportErrorException( WavpackGetErrorMessage(context.wpc) );
    } else {
-      
+
 
       wxString n;
       for (const auto &pair : context.metadata->GetRange()) {
@@ -591,9 +588,9 @@ int WavPackExportProcessor::WriteBlock(void *id, void *data, int32_t length)
     WriteId *outId = static_cast<WriteId*>(id);
 
     if (!outId->file)
-        // This does not match the wavpack.c but in our case if file is nullptr - 
+        // This does not match the wavpack.c but in our case if file is nullptr -
         // the stream error has occured
-        return false; 
+        return false;
 
    //  if (!outId->file->Write(data, length).IsOk()) {
     if (outId->file->Write(data, length) != length) {

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1547,7 +1547,10 @@ bool ProjectFileManager::Import(
 
       if (newTracks.size() == 1)
       {
-         if (const auto waveTrack = dynamic_cast<WaveTrack*>(newTracks[0].get()))
+         const auto waveTrack = dynamic_cast<WaveTrack*>(newTracks[0].get());
+         // Also check that the track has a clip, as protection against empty
+         // file import.
+         if (waveTrack && !waveTrack->GetClipInterfaces().empty())
             resultingReader.reset(new ClipMirAudioReader {
                std::move(acidTags), fileName.ToStdString(),
                *waveTrack });

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -104,10 +104,147 @@ namespace
       }
    };
 
-   template <typename Visitor>
-   void VisitRealtimeEffectStateUIs(SampleTrack& track, Visitor&& visitor)
+   class EffectsMenuHelper final
+      : public PrefsListener
    {
-      auto& effects = RealtimeEffectList::Get(track);
+      std::shared_ptr<MenuRegistry::MenuItem> mCachedMenu;
+      Observer::Subscription mPluginsChangedSubscription;
+   public:
+
+      static std::optional<wxString> PickEffect(AudacityProject& project, wxWindow* parent, const wxString& selectedEffectID)
+      {
+         wxMenu menu;
+         if(!selectedEffectID.empty())
+         {
+            //no need to handle language change since menu creates its own event loop
+            menu.Append(wxID_REMOVE, _("No Effect"));
+            menu.AppendSeparator();
+         }
+
+         RealtimeEffectsMenuVisitor visitor { menu };
+
+         Get().Populate(project, visitor);
+
+         int commandId = wxID_NONE;
+
+#if defined(__WXMSW__) || defined(__WXMAC__)
+         menu.AppendSeparator();
+         menu.Append(wxID_MORE, _("Get more effects..."));
+#endif
+         menu.Bind(wxEVT_MENU, [&](wxCommandEvent evt) { commandId = evt.GetId(); });
+
+         if(parent->PopupMenu(&menu, parent->GetClientRect().GetLeftBottom()) && commandId != wxID_NONE)
+         {
+            if(commandId == wxID_REMOVE)
+               return wxString {};
+            if(commandId == wxID_MORE)
+               OpenInDefaultBrowser("https://www.musehub.com");
+            else
+               return visitor.GetPluginID(commandId).GET();
+         }
+
+         return {};
+      }
+
+   private:
+
+      static EffectsMenuHelper& Get()
+      {
+         static EffectsMenuHelper helper;
+         return helper;
+      }
+
+      void Populate(AudacityProject& project, Visitor<Traits>& visitor)
+      {
+         auto cachedMenuItem = GetMenuItem();
+         if(!cachedMenuItem)
+            return;
+
+         VisitWithFunctions(visitor, cachedMenuItem.get(), {}, project);
+      }
+
+      EffectsMenuHelper()
+      {
+         mPluginsChangedSubscription = PluginManager::Get().Subscribe(
+            [this](PluginsChangedMessage)
+            {
+               mCachedMenu.reset();
+            }
+         );
+      }
+
+      std::shared_ptr<MenuItem> GetMenuItem()
+      {
+         if(!mCachedMenu)
+            UpdateEffectMenuItems();
+
+         assert(mCachedMenu);
+         if(mCachedMenu)
+            return mCachedMenu;
+         return {};
+      }
+
+      void UpdatePrefs() override
+      {
+         mCachedMenu.reset();
+      }
+
+      void UpdateEffectMenuItems()
+      {
+         using namespace MenuRegistry;
+         auto root = std::shared_ptr{ Menu("", TranslatableString{}) };
+
+         static auto realtimeEffectPredicate = [](const PluginDescriptor& desc)
+         {
+            return desc.IsEffectRealtime();
+         };
+
+         const auto groupby = RealtimeEffectsGroupBy.Read();
+
+         auto analyzeSection = Section("", Menu("", XO("Analyze")));
+         auto submenu =
+            static_cast<MenuItem*>(analyzeSection->begin()->get());
+         MenuHelper::PopulateEffectsMenu(
+            *submenu,
+            EffectTypeAnalyze,
+            {}, groupby, nullptr,
+            realtimeEffectPredicate
+         );
+
+         if(!submenu->empty())
+         {
+            root->push_back(move(analyzeSection));
+         }
+
+         MenuHelper::PopulateEffectsMenu(
+            *root,
+            EffectTypeProcess,
+            {}, groupby, nullptr,
+            realtimeEffectPredicate
+         );
+
+         mCachedMenu.swap(root);
+      }
+   };
+
+   const PluginDescriptor *GetPlugin(const PluginID &ID) {
+      auto desc = PluginManager::Get().GetPlugin(ID);
+      return desc;
+   }
+
+   TranslatableString GetEffectName(RealtimeEffectState& state)
+   {
+      const auto &ID = state.GetID();
+      const auto desc = GetPlugin(ID);
+      return desc
+         ? desc->GetSymbol().Msgid()
+         : XO("%s (missing)")
+            .Format(PluginManager::GetEffectNameFromID(ID).GET());
+   }
+
+   template <typename Visitor>
+   void VisitRealtimeEffectStateUIs(const RealtimeEffectList& effects, Visitor&& visitor)
+   {
       effects.Visit(
          [visitor](auto& effectState, bool)
          {
@@ -116,16 +253,31 @@ namespace
          });
    }
 
-   void UpdateRealtimeEffectUIData(SampleTrack& track)
+   template <typename Visitor>
+   void VisitRealtimeEffectStateUIs(const Track& track, Visitor&& visitor)
    {
+      VisitRealtimeEffectStateUIs(RealtimeEffectList::Get(track), std::forward<Visitor>(visitor));
+   }
+
+   void UpdateRealtimeEffectUIData(const Track& track)
+   {
+      const auto& name = track.GetName();
       VisitRealtimeEffectStateUIs(
-         track, [&](auto& ui) { ui.UpdateTrackData(track); });
+         RealtimeEffectList::Get(track), [&](auto& ui) { ui.SetTargetName(name); });
+   }
+
+   void UpdateRealtimeEffectUIData(const AudacityProject& project)
+   {
+      const auto& name = project.GetProjectName();
+      VisitRealtimeEffectStateUIs(
+         RealtimeEffectList::Get(project), [&](auto& ui) { ui.SetTargetName(name); }
+      );
    }
 
    void ReopenRealtimeEffectUIData(AudacityProject& project, SampleTrack& track)
    {
       VisitRealtimeEffectStateUIs(
-         track,
+         RealtimeEffectList::Get(track),
          [&](auto& ui)
          {
             if (ui.IsShown())
@@ -277,21 +429,24 @@ namespace
    };
 #endif
 
-   class RealtimeEffectPicker
+   class EffectListUIDelegate
    {
    public:
-      virtual std::optional<wxString> PickEffect(wxWindow* parent, const wxString& selectedEffectID) = 0;
+      virtual ~EffectListUIDelegate() = default;
+
+      virtual RealtimeEffectList& GetEffectList() = 0;
+      virtual wxString GetSourceName() = 0;
+      virtual ChannelGroup* GetChannelGroup() = 0;
    };
 
    //UI control that represents individual effect from the effect list
    class RealtimeEffectControl : public ListNavigationEnabled<MovableControl>
    {
       wxWeakRef<AudacityProject> mProject;
-      std::shared_ptr<SampleTrack> mTrack;
+      std::shared_ptr<EffectListUIDelegate> mDelegate;
+      //std::shared_ptr<SampleTrack> mTrack;
       std::shared_ptr<RealtimeEffectState> mEffectState;
       std::shared_ptr<EffectSettingsAccess> mSettingsAccess;
-
-      RealtimeEffectPicker* mEffectPicker { nullptr };
 
       ThemedAButtonWrapper<AButton>* mChangeButton{nullptr};
       AButton* mEnableButton{nullptr};
@@ -303,21 +458,18 @@ namespace
       RealtimeEffectControl() = default;
 
       RealtimeEffectControl(wxWindow* parent,
-                   RealtimeEffectPicker* effectPicker,
                    wxWindowID winid,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize)
       {
-         Create(parent, effectPicker, winid, pos, size);
+         Create(parent, winid, pos, size);
       }
 
       void Create(wxWindow* parent,
-                   RealtimeEffectPicker* effectPicker,
                    wxWindowID winid,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize)
       {
-         mEffectPicker = effectPicker;
 
          //Prevents flickering and paint order issues
          MovableControl::SetBackgroundStyle(wxBG_STYLE_PAINT);
@@ -338,10 +490,15 @@ namespace
          mEnableButton = enableButton;
 
          enableButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
-
-            mEffectState->SetActive(mEnableButton->IsDown());
-            if (mProject)
-               UndoManager::Get(*mProject).MarkUnsaved();
+            if(mDelegate && mEffectState)
+            {
+               mEffectState->SetActive(mEnableButton->IsDown());
+               if (mProject)
+               {
+                  ProjectHistory::Get(*mProject).ModifyState(false);
+                  UndoManager::Get(*mProject).MarkUnsaved();
+               }
+            }
          });
 
          //Central button with effect name, show settings
@@ -383,42 +540,23 @@ namespace
 #endif
       }
 
-      static const PluginDescriptor *GetPlugin(const PluginID &ID) {
-         auto desc = PluginManager::Get().GetPlugin(ID);
-         return desc;
-      }
-
-      //! @pre `mEffectState != nullptr`
-      TranslatableString GetEffectName() const
-      {
-         const auto &ID = mEffectState->GetID();
-         const auto desc = GetPlugin(ID);
-         return desc
-            ? desc->GetSymbol().Msgid()
-            : XO("%s (missing)")
-               .Format(PluginManager::GetEffectNameFromID(ID).GET());
-      }
-
       void SetEffect(AudacityProject& project,
-         const std::shared_ptr<SampleTrack>& track,
-         const std::shared_ptr<RealtimeEffectState> &pState)
+                     const std::shared_ptr<EffectListUIDelegate>& delegate,
+                     const std::shared_ptr<RealtimeEffectState> &pState)
       {
          mProject = &project;
-         mTrack = track;
+         mDelegate = delegate;
          mEffectState = pState;
 
          mSubscription = mEffectState->Subscribe([this](RealtimeEffectStateChange state) {
             state == RealtimeEffectStateChange::EffectOn
                ? mEnableButton->PushDown()
                : mEnableButton->PopUp();
-
-            if (mProject)
-               ProjectHistory::Get(*mProject).ModifyState(false);
          });
 
          TranslatableString label;
          if (pState) {
-            label = GetEffectName();
+            label = GetEffectName(*mEffectState);
             mSettingsAccess = pState->GetAccess();
          }
          else
@@ -436,25 +574,23 @@ namespace
 
       void RemoveFromList()
       {
-         if(mProject == nullptr || mEffectState == nullptr)
+         if(!mDelegate || !mProject || mEffectState == nullptr)
             return;
 
          auto& ui = RealtimeEffectStateUI::Get(*mEffectState);
          // Don't need autosave for the effect that is being removed
          ui.Hide();
 
-         auto effectName = GetEffectName();
          //After AudioIO::RemoveState call this will be destroyed
-         auto project = mProject.get();
-         auto trackName = mTrack->GetName();
+         auto effectName = GetEffectName(*mEffectState);
 
-         AudioIO::Get()->RemoveState(*project, &*mTrack, mEffectState);
-         ProjectHistory::Get(*project).PushState(
+         AudioIO::Get()->RemoveState(*mProject, mDelegate->GetChannelGroup(), std::move(mEffectState));
+         ProjectHistory::Get(*mProject).PushState(
             /*! i18n-hint: undo history record
              first parameter - realtime effect name
              second parameter - track name
              */
-            XO("Removed %s from %s").Format(effectName, trackName),
+            XO("Removed %s from %s").Format(effectName, mDelegate->GetSourceName()),
             /*! i18n-hint: undo history record
              first parameter - realtime effect name */
             XO("Remove %s").Format(effectName)
@@ -463,7 +599,7 @@ namespace
 
       void OnOptionsClicked(wxCommandEvent& event)
       {
-         if(mProject == nullptr || mEffectState == nullptr)
+         if(!mDelegate || !mEffectState)
             return;//not initialized
 
          const auto ID = mEffectState->GetID();
@@ -475,53 +611,59 @@ namespace
             return;
          }
 
+         if(!mProject)
+            return;
          auto& effectStateUI = RealtimeEffectStateUI::Get(*mEffectState);
 
-         effectStateUI.UpdateTrackData(*mTrack);
-         effectStateUI.Toggle( *mProject );
+         effectStateUI.SetTargetName(mDelegate->GetSourceName());
+         effectStateUI.Toggle(*mProject);
       }
 
       void OnChangeButtonClicked(wxCommandEvent& event)
       {
-         if(!mTrack || mProject == nullptr)
+         if(!mDelegate || mProject == nullptr)
             return;
+
          if(mEffectState == nullptr)
             return;//not initialized
 
-         const auto effectID = mEffectPicker->PickEffect(mChangeButton, mEffectState->GetID());
+         const auto effectID = EffectsMenuHelper::PickEffect(
+            *mProject,
+            mChangeButton,
+            mEffectState->GetID()
+         );
          if(!effectID)
             return;//nothing
 
          if(effectID->empty())
-         {
             RemoveFromList();
-            return;
-         }
+         else
+         {
+            auto &project = *mProject;
+            auto &em = RealtimeEffectManager::Get(project);
+            auto oIndex = em.FindState(mDelegate->GetChannelGroup(), mEffectState);
+            if (!oIndex)
+               return;
 
-         auto &em = RealtimeEffectManager::Get(*mProject);
-         auto oIndex = em.FindState(&*mTrack, mEffectState);
-         if (!oIndex)
-            return;
+            auto oldName = GetEffectName(*mEffectState);
 
-         auto oldName = GetEffectName();
-         auto &project = *mProject;
-         auto trackName = mTrack->GetName();
-         if (auto state = AudioIO::Get()
-            ->ReplaceState(project, &*mTrack, *oIndex, *effectID)
-         ){
-            // Message subscription took care of updating the button text
-            // and destroyed `this`!
-            auto effect = state->GetEffect();
-            assert(effect); // postcondition of ReplaceState
-            ProjectHistory::Get(project).PushState(
-               /*i18n-hint: undo history,
-                first and second parameters - realtime effect names
-                */
-               XO("Replaced %s with %s")
-                  .Format(oldName, effect->GetName()),
-               /*! i18n-hint: undo history record
-                first parameter - realtime effect name */
-               XO("Replace %s").Format(oldName));
+            if (auto state = AudioIO::Get()
+               ->ReplaceState(project, mDelegate->GetChannelGroup(), *oIndex, *effectID)
+            ){
+               // Message subscription took care of updating the button text
+               // and destroyed `this`!
+               auto effect = state->GetEffect();
+               assert(effect); // postcondition of ReplaceState
+               ProjectHistory::Get(project).PushState(
+                  /*i18n-hint: undo history,
+                   first and second parameters - realtime effect names
+                   */
+                  XO("Replaced %s with %s")
+                     .Format(oldName, effect->GetName()),
+                  /*! i18n-hint: undo history record
+                   first parameter - realtime effect name */
+                  XO("Replace %s").Format(oldName));
+            }
          }
       }
 
@@ -558,22 +700,73 @@ namespace
    }
 }
 
+class TrackEffectListUIDelegate final
+   : public EffectListUIDelegate
+{
+   std::shared_ptr<SampleTrack> mTrack;
+public:
+
+   TrackEffectListUIDelegate(std::shared_ptr<SampleTrack> track)
+      : mTrack(std::move(track))
+   {
+      UpdateRealtimeEffectUIData(*mTrack);
+   }
+
+   RealtimeEffectList& GetEffectList() override
+   {
+      return RealtimeEffectList::Get(*mTrack);
+   }
+
+   wxString GetSourceName() override
+   {
+      return mTrack->GetName();
+   }
+
+   ChannelGroup* GetChannelGroup() override
+   {
+      return mTrack.get();
+   }
+};
+
+class ProjectEffectListDelegate final
+   : public EffectListUIDelegate
+{
+   std::shared_ptr<RealtimeEffectList> mEffectList;
+public:
+
+   ProjectEffectListDelegate(AudacityProject& project)
+   {
+      mEffectList = RealtimeEffectList::Get(project).shared_from_this();
+      UpdateRealtimeEffectUIData(project);
+   }
+
+   RealtimeEffectList& GetEffectList() override
+   {
+      return *mEffectList;
+   }
+
+   wxString GetSourceName() override
+   {
+      //i18n-hint: master channel display name
+      return _("Master");
+   }
+   ChannelGroup* GetChannelGroup() override
+   {
+      return nullptr;
+   }
+};
+
 class RealtimeEffectListWindow
    : public wxScrolledWindow
-   , public RealtimeEffectPicker
-   , public PrefsListener
 {
    wxWeakRef<AudacityProject> mProject;
-   std::shared_ptr<SampleTrack> mTrack;
    AButton* mAddEffect{nullptr};
-   wxStaticText* mAddEffectHint{nullptr};
-   wxWindow* mAddEffectTutorialLink{nullptr};
    wxWindow* mEffectListContainer{nullptr};
+   wxWindow* mFooter{nullptr};
 
-   std::unique_ptr<MenuRegistry::MenuItem> mEffectMenuRoot;
+   std::shared_ptr<EffectListUIDelegate> mDelegate;
 
    Observer::Subscription mEffectListItemMovedSubscription;
-   Observer::Subscription mPluginsChangedSubscription;
 
 public:
    RealtimeEffectListWindow(wxWindow *parent,
@@ -584,7 +777,6 @@ public:
                      const wxString& name = wxPanelNameStr)
       : wxScrolledWindow(parent, winid, pos, size, style, name)
    {
-      Bind(wxEVT_SIZE, &RealtimeEffectListWindow::OnSizeChanged, this);
 #ifdef __WXMSW__
       //Fixes flickering on redraw
       wxScrolledWindow::SetDoubleBuffered(true);
@@ -612,28 +804,6 @@ public:
       addEffect->Bind(wxEVT_BUTTON, &RealtimeEffectListWindow::OnAddEffectClicked, this);
       mAddEffect = addEffect;
 
-      auto addEffectHint = safenew ThemedWindowWrapper<wxStaticText>(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
-      //Workaround: text is set in the OnSizeChange
-      addEffectHint->SetForegroundColorIndex(clrTrackPanelText);
-      mAddEffectHint = addEffectHint;
-
-      auto addEffectTutorialLink = safenew ThemedWindowWrapper<wxHyperlinkCtrl>(
-         this, wxID_ANY, _("Watch video"),
-         "https://www.audacityteam.org/realtime-video", wxDefaultPosition,
-         wxDefaultSize, wxHL_ALIGN_LEFT | wxHL_CONTEXTMENU);
-
-      //i18n-hint: Hyperlink to the effects stack panel tutorial video
-      addEffectTutorialLink->SetTranslatableLabel(XO("Watch video"));
-#if wxUSE_ACCESSIBILITY
-      safenew WindowAccessible(addEffectTutorialLink);
-#endif
-
-      addEffectTutorialLink->Bind(
-         wxEVT_HYPERLINK, [](wxHyperlinkEvent& event)
-         { BasicUI::OpenInDefaultBrowser(event.GetURL()); });
-
-      mAddEffectTutorialLink = addEffectTutorialLink;
-
       //indicates the insertion position of the item
       auto dropHintLine = safenew ThemedWindowWrapper<DropHintLine>(effectListContainer, wxID_ANY);
       dropHintLine->SetBackgroundColorIndex(clrDropHintHighlight);
@@ -641,8 +811,6 @@ public:
 
       rootSizer->Add(mEffectListContainer, 0, wxEXPAND | wxBOTTOM, 10);
       rootSizer->Add(addEffect, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 20);
-      rootSizer->Add(addEffectHint, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 20);
-      rootSizer->Add(addEffectTutorialLink, 0, wxLEFT | wxRIGHT | wxEXPAND, 20);
 
       SetSizer(rootSizer.release());
       SetMinSize({});
@@ -682,18 +850,19 @@ public:
          else
             dropHintLine->SetPosition(item->GetRect().GetTopLeft());
       });
+
       Bind(EVT_MOVABLE_CONTROL_DRAG_FINISHED, [this, dropHintLine](const MovableControlEvent& event)
       {
          dropHintLine->Hide();
 
-         if(mProject == nullptr)
+         if(!mDelegate || !mProject)
             return;
 
-         auto& effectList = RealtimeEffectList::Get(*mTrack);
          const auto from = event.GetSourceIndex();
          const auto to = event.GetTargetIndex();
          if(from != to)
          {
+            auto& effectList = mDelegate->GetEffectList();
             auto effectName =
                effectList.GetStateAt(from)->GetEffect()->GetName();
             bool up = (to < from);
@@ -710,7 +879,7 @@ public:
                    second parameter - track name
                    */
                   : XO("Moved %s down in %s"))
-                  .Format(effectName, mTrack->GetName()),
+                  .Format(effectName, mDelegate->GetSourceName()),
                XO("Change effect order"), UndoPush::CONSOLIDATE);
          }
          else
@@ -719,121 +888,37 @@ public:
             Layout();
          }
       });
+
       SetScrollRate(0, 20);
-
-      mPluginsChangedSubscription = PluginManager::Get().Subscribe(
-         [this](PluginsChangedMessage)
-         {
-            UpdateEffectMenuItems();
-         });
-      UpdateEffectMenuItems();
-   }
-
-   void UpdatePrefs() override
-   {
-      UpdateEffectMenuItems();
-   }
-
-   std::optional<wxString> PickEffect(wxWindow* parent, const wxString& selectedEffectID) override
-   {
-      if (mProject == nullptr)
-         return {};
-
-      wxMenu menu;
-      if(!selectedEffectID.empty())
-      {
-         //no need to handle language change since menu creates its own event loop
-         menu.Append(wxID_REMOVE, _("No Effect"));
-         menu.AppendSeparator();
-      }
-
-      RealtimeEffectsMenuVisitor visitor { menu };
-
-      Registry::VisitWithFunctions(visitor, mEffectMenuRoot.get(), {}, *mProject);
-
-      int commandId = wxID_NONE;
-
-      menu.AppendSeparator();
 #if defined(__WXMSW__) || defined(__WXMAC__)
-      menu.Append(wxID_MORE, _("Get more effects..."));
 #endif
-
-      menu.Bind(wxEVT_MENU, [&](wxCommandEvent evt) { commandId = evt.GetId(); });
-
-      if(parent->PopupMenu(&menu, parent->GetClientRect().GetLeftBottom()) && commandId != wxID_NONE)
-      {
-         if(commandId == wxID_REMOVE)
-            return wxString {};
-         else if(commandId == wxID_MORE)
-            OpenInDefaultBrowser("https://www.musehub.com");
-         else
-            return visitor.GetPluginID(commandId).GET();
-      }
-
-      return {};
    }
 
-   void UpdateEffectMenuItems()
+   void SetFooter(wxWindow* footer)
    {
-      using namespace MenuRegistry;
-      auto root = Menu("", TranslatableString{});
+      if(footer == mFooter)
+         return;
 
-      static auto realtimeEffectPredicate = [](const PluginDescriptor& desc)
+      if(mFooter != nullptr)
       {
-         return desc.IsEffectRealtime();
-      };
-
-      const auto groupby = RealtimeEffectsGroupBy.Read();
-
-      auto analyzeSection = Section("", Menu("", XO("Analyze")));
-      auto submenu =
-         static_cast<MenuItem*>(analyzeSection->begin()->get());
-      MenuHelper::PopulateEffectsMenu(
-         *submenu,
-         EffectTypeAnalyze,
-         {}, groupby, nullptr,
-         realtimeEffectPredicate
-      );
-
-      if(!submenu->empty())
-      {
-         root->push_back(move(analyzeSection));
+         GetSizer()->Detach(mFooter);
+         mFooter->Destroy();
       }
 
-      MenuHelper::PopulateEffectsMenu(
-         *root,
-         EffectTypeProcess,
-         {}, groupby, nullptr,
-         realtimeEffectPredicate
-      );
+      mFooter = footer;
+      GetSizer()->Add(mFooter, 0, wxEXPAND);
 
-      mEffectMenuRoot.swap(root);
-   }
-
-   void OnSizeChanged(wxSizeEvent& event)
-   {
-      if(auto sizerItem = GetSizer()->GetItem(mAddEffectHint))
-      {
-         //We need to wrap the text whenever panel width changes and adjust widget height
-         //so that text is fully visible, but there is no height-for-width layout algorithm
-         //in wxWidgets yet, so for now we just do it manually
-
-         //Restore original text, because 'Wrap' will replace it with wrapped one
-         mAddEffectHint->SetLabel(_("Realtime effects are non-destructive and can be changed at any time."));
-         mAddEffectHint->Wrap(GetClientSize().x - sizerItem->GetBorder() * 2);
-         mAddEffectHint->InvalidateBestSize();
-      }
-      event.Skip();
+      Layout();
    }
 
    void OnEffectListItemChange(const RealtimeEffectListMessage& msg)
    {
       auto sizer = mEffectListContainer->GetSizer();
       const auto insertItem = [this, &msg](){
-         auto& effects = RealtimeEffectList::Get(*mTrack);
+         auto& effects = mDelegate->GetEffectList();
          InsertEffectRow(msg.srcIndex, effects.GetStateAt(msg.srcIndex));
-         mAddEffectHint->Hide();
-         mAddEffectTutorialLink->Hide();
+         if(mFooter != nullptr)
+            mFooter->Hide();
       };
       const auto removeItem = [&](){
          auto& ui = RealtimeEffectStateUI::Get(*msg.affectedState);
@@ -853,8 +938,8 @@ public:
                mAddEffect->SetFocus();
 
             mEffectListContainer->Hide();
-            mAddEffectHint->Show();
-            mAddEffectTutorialLink->Show();
+            if(mFooter != nullptr)
+               mFooter->Show();
          }
       };
 
@@ -897,85 +982,81 @@ public:
       SendSizeEventToParent();
    }
 
-   void ResetTrack()
+   void ResetDelegate()
    {
       mEffectListItemMovedSubscription.Reset();
 
-      mTrack.reset();
-      mProject = nullptr;
+      mProject.Release();
+      mDelegate.reset();
       ReloadEffectsList();
    }
 
-   void SetTrack(AudacityProject& project,
-      const std::shared_ptr<SampleTrack>& track)
+   void SetDelegate(AudacityProject& project, const std::shared_ptr<EffectListUIDelegate>& delegate)
    {
-      if (mTrack == track)
-         return;
-
       mEffectListItemMovedSubscription.Reset();
 
-      mTrack = track;
       mProject = &project;
+      mDelegate = delegate;
       ReloadEffectsList();
 
-      if (track)
+      if (mDelegate)
       {
-         auto& effects = RealtimeEffectList::Get(*mTrack);
-         mEffectListItemMovedSubscription = effects.Subscribe(
+         mEffectListItemMovedSubscription = mDelegate->GetEffectList().Subscribe(
             *this, &RealtimeEffectListWindow::OnEffectListItemChange);
-
-         UpdateRealtimeEffectUIData(*track);
       }
    }
 
    void EnableEffects(bool enable)
    {
-      if (mTrack)
-         RealtimeEffectList::Get(*mTrack).SetActive(enable);
+      if (mDelegate)
+         mDelegate->GetEffectList().SetActive(enable);
    }
 
    void ReloadEffectsList()
    {
       wxWindowUpdateLocker freeze(this);
 
-      const auto hadFocus = mEffectListContainer->IsDescendant(FindFocus());
       //delete items that were added to the sizer
       mEffectListContainer->Hide();
       mEffectListContainer->GetSizer()->Clear(true);
 
 
-      if(!mTrack || RealtimeEffectList::Get(*mTrack).GetStatesCount() == 0)
+      if(!mDelegate || mDelegate->GetEffectList().GetStatesCount() == 0)
          mEffectListContainer->Hide();
 
       auto isEmpty{true};
-      if(mTrack)
+      if(mDelegate)
       {
-         auto& effects = RealtimeEffectList::Get(*mTrack);
+         auto& effects = mDelegate->GetEffectList();
          isEmpty = effects.GetStatesCount() == 0;
          for(size_t i = 0, count = effects.GetStatesCount(); i < count; ++i)
             InsertEffectRow(i, effects.GetStateAt(i));
       }
-      mAddEffect->SetEnabled(!!mTrack);
+      mAddEffect->SetEnabled(!!mDelegate);
       //Workaround for GTK: Underlying GTK widget does not update
       //its size when wxWindow size is set to zero
       mEffectListContainer->Show(!isEmpty);
-      mAddEffectHint->Show(isEmpty);
-      mAddEffectTutorialLink->Show(isEmpty);
+      if(mFooter != nullptr)
+         mFooter->Show(isEmpty);
 
       SendSizeEventToParent();
    }
 
    void OnAddEffectClicked(const wxCommandEvent& event)
    {
-      if(!mTrack || mProject == nullptr)
+      if(!mDelegate || !mProject)
          return;
 
-      const auto effectID = PickEffect(dynamic_cast<wxWindow*>(event.GetEventObject()), {});
+      const auto effectId = EffectsMenuHelper::PickEffect(
+         *mProject,
+         dynamic_cast<wxWindow*>(event.GetEventObject()),
+         {}
+      );
 
-      if(!effectID || effectID->empty())
+      if(!effectId || effectId->empty())
          return;
 
-      auto plug = PluginManager::Get().GetPlugin(*effectID);
+      auto plug = PluginManager::Get().GetPlugin(*effectId);
       if(!plug)
          return;
 
@@ -988,7 +1069,7 @@ public:
          return;
       }
 
-      if(auto state = AudioIO::Get()->AddState(*mProject, &*mTrack, *effectID))
+      if(const auto state = AudioIO::Get()->AddState(*mProject, mDelegate->GetChannelGroup(), *effectId))
       {
          auto effect = state->GetEffect();
          assert(effect); // postcondition of AddState
@@ -998,7 +1079,7 @@ public:
              first parameter - realtime effect name
              second parameter - track name
              */
-            XO("Added %s to %s").Format(effectName, mTrack->GetName()),
+            XO("Added %s to %s").Format(effectName, mDelegate->GetSourceName()),
             //i18n-hint: undo history record
             XO("Add %s").Format(effectName));
       }
@@ -1007,16 +1088,16 @@ public:
    void InsertEffectRow(size_t index,
       const std::shared_ptr<RealtimeEffectState> &pState)
    {
-      if(mProject == nullptr)
+      if(!mDelegate || !mProject)
          return;
 
       // See comment in ReloadEffectsList
       if(!mEffectListContainer->IsShown())
          mEffectListContainer->Show();
 
-      auto row = safenew ThemedWindowWrapper<RealtimeEffectControl>(mEffectListContainer, this, wxID_ANY);
+      auto row = safenew ThemedWindowWrapper<RealtimeEffectControl>(mEffectListContainer, wxID_ANY);
       row->SetBackgroundColorIndex(clrEffectListItemBackground);
-      row->SetEffect(*mProject, mTrack, pState);
+      row->SetEffect(*mProject, mDelegate, pState);
       mEffectListContainer->GetSizer()->Insert(index, row, 0, wxEXPAND);
    }
 };
@@ -1045,7 +1126,13 @@ AttachedWindows::RegisteredFactory sKey{
 
    const auto pProjectWindow = &ProjectWindow::Get(project);
    auto effectsPanel = safenew ThemedWindowWrapper<RealtimeEffectPanel>(
-      project, pProjectWindow->GetContainerWindow(), wxID_ANY);
+      project,
+      pProjectWindow->GetContainerWindow(),
+      wxID_ANY,
+      wxDefaultPosition,
+      wxDefaultSize,
+      wxNO_BORDER | wxSP_LIVE_UPDATE | wxSP_THIN_SASH
+   );
    effectsPanel->SetMinSize({EffectsPanelMinWidth, -1});
    effectsPanel->SetName(_("Realtime effects"));
    effectsPanel->SetBackgroundColorIndex(clrMedium);
@@ -1070,75 +1157,25 @@ RealtimeEffectPanel::RealtimeEffectPanel(
    AudacityProject& project, wxWindow* parent, wxWindowID id, const wxPoint& pos,
    const wxSize& size,
    long style, const wxString& name)
-      : wxPanel(parent, id, pos, size, style, name)
+      : wxSplitterWindow(parent, id, pos, size, style, name)
       , mProject(project)
       , mPrefsListenerHelper(std::make_unique<PrefsListenerHelper>(project))
 {
-   auto vSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
+   SetSashInvisible();//Use custom sash
 
-   auto header = safenew ThemedWindowWrapper<ListNavigationPanel>(this, wxID_ANY);
-#if wxUSE_ACCESSIBILITY
-   safenew WindowAccessible(header);
-#endif
-   header->SetBackgroundColorIndex(clrMedium);
+   SetSashGravity(1.0);
+   MakeTrackEffectPane();
+   MakeMasterEffectPane();
    {
-      auto hSizer = std::make_unique<wxBoxSizer>(wxHORIZONTAL);
-      auto toggleEffects = safenew ThemedAButtonWrapper<AButton>(header);
-      toggleEffects->SetImageIndices(0, bmpEffectOff, bmpEffectOff, bmpEffectOn, bmpEffectOn, bmpEffectOff);
-      toggleEffects->SetButtonToggles(true);
-      toggleEffects->SetTranslatableLabel(XO("Power"));
-      toggleEffects->SetBackgroundColorIndex(clrMedium);
-      mToggleEffects = toggleEffects;
-
-      toggleEffects->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
-         if (mEffectList)
-         {
-            mEffectList->EnableEffects(mToggleEffects->IsDown());
-
-            ProjectHistory::Get(mProject).ModifyState(false);
-            UndoManager::Get(mProject).MarkUnsaved();
-         }
-      });
-
-      hSizer->Add(toggleEffects, 0, wxSTRETCH_NOT | wxALIGN_CENTER | wxLEFT, 5);
-      {
-         auto vSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
-
-         auto headerText = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString);
-         headerText->SetFont(wxFont(wxFontInfo().Bold()));
-         headerText->SetTranslatableLabel(XO("Realtime Effects"));
-         headerText->SetForegroundColorIndex(clrTrackPanelText);
-
-         auto trackTitle = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
-         trackTitle->SetForegroundColorIndex(clrTrackPanelText);
-         mTrackTitle = trackTitle;
-
-         vSizer->Add(headerText);
-         vSizer->Add(trackTitle);
-
-         hSizer->Add(vSizer.release(), 1, wxEXPAND | wxALL, 10);
-      }
-      auto close = safenew ThemedAButtonWrapper<AButton>(header);
-      close->SetTranslatableLabel(XO("Close"));
-      close->SetImageIndices(0, bmpCloseNormal, bmpCloseHover, bmpCloseDown, bmpCloseHover, bmpCloseDisabled);
-      close->SetBackgroundColorIndex(clrMedium);
-
-      close->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { Close(); });
-
-      hSizer->Add(close, 0, wxSTRETCH_NOT | wxALIGN_CENTER | wxRIGHT, 5);
-
-      header->SetSizer(hSizer.release());
+      RealtimeEffectList::Get(project).IsActive()
+         ? mToggleMasterEffects->PushDown()
+         : mToggleMasterEffects->PopUp();
+      mMasterEffectList->SetDelegate(mProject,
+         std::make_shared<ProjectEffectListDelegate>(mProject)
+      );
    }
-   vSizer->Add(header, 0, wxEXPAND);
-
-   auto effectList = safenew ThemedWindowWrapper<RealtimeEffectListWindow>(this, wxID_ANY);
-   effectList->SetBackgroundColorIndex(clrMedium);
-   vSizer->Add(effectList, 1, wxEXPAND);
-
-   mHeader = header;
-   mEffectList = effectList;
-
-   SetSizerAndFit(vSizer.release());
+   SetMinimumPaneSize(mTrackEffectsPanel->GetSizer()->CalcMin().y);
+   SplitHorizontally(mTrackEffectsPanel, mProjectEffectsPanel, -267);
 
    Bind(wxEVT_CHAR_HOOK, &RealtimeEffectPanel::OnCharHook, this);
    mTrackListChanged =
@@ -1312,15 +1349,18 @@ void RealtimeEffectPanel::SetTrack(const std::shared_ptr<SampleTrack>& track)
    if(track && dynamic_cast<WaveTrack*>(&*track) != nullptr)
    {
       mTrackTitle->SetLabel(track->GetName());
-      mToggleEffects->Enable();
+      mToggleTrackEffects->Enable();
       track && RealtimeEffectList::Get(*track).IsActive()
-         ? mToggleEffects->PushDown()
-         : mToggleEffects->PopUp();
-      mEffectList->SetTrack(mProject, track);
+         ? mToggleTrackEffects->PushDown()
+         : mToggleTrackEffects->PopUp();
+      mTrackEffectList->SetDelegate(
+         mProject,
+         std::make_shared<TrackEffectListUIDelegate>(track)
+      );
 
       mCurrentTrack = track;
       //i18n-hint: argument - track name
-      mHeader->SetName(wxString::Format(_("Realtime effects for %s"), track->GetName()));
+      mTrackEffectsHeader->SetName(wxString::Format(_("Realtime effects for %s"), track->GetName()));
    }
    else
       ResetTrack();
@@ -1329,15 +1369,282 @@ void RealtimeEffectPanel::SetTrack(const std::shared_ptr<SampleTrack>& track)
 void RealtimeEffectPanel::ResetTrack()
 {
    mTrackTitle->SetLabel(wxEmptyString);
-   mToggleEffects->Disable();
-   mEffectList->ResetTrack();
+   mToggleTrackEffects->Disable();
+   mTrackEffectList->ResetDelegate();
    mCurrentTrack.reset();
-   mHeader->SetName(wxEmptyString);
+   mTrackEffectsHeader->SetName(wxEmptyString);
 }
 
 void RealtimeEffectPanel::SetFocus()
 {
-   mHeader->SetFocus();
+   mTrackEffectsHeader->SetFocus();
+}
+
+void RealtimeEffectPanel::MakeTrackEffectPane()
+{
+   mTrackEffectsPanel = safenew wxPanel(this);
+
+   auto vSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
+
+   auto header = safenew ThemedWindowWrapper<ListNavigationPanel>(mTrackEffectsPanel, wxID_ANY);
+#if wxUSE_ACCESSIBILITY
+   safenew WindowAccessible(header);
+#endif
+   header->SetBackgroundColorIndex(clrMedium);
+   {
+      auto hSizer = std::make_unique<wxBoxSizer>(wxHORIZONTAL);
+      auto toggleEffects = safenew ThemedAButtonWrapper<AButton>(header);
+      toggleEffects->SetImageIndices(0, bmpEffectOff, bmpEffectOff, bmpEffectOn, bmpEffectOn, bmpEffectOff);
+      toggleEffects->SetButtonToggles(true);
+      toggleEffects->SetTranslatableLabel(XO("Power"));
+      toggleEffects->SetBackgroundColorIndex(clrMedium);
+      mToggleTrackEffects = toggleEffects;
+
+      toggleEffects->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+         if (mTrackEffectList)
+         {
+            mTrackEffectList->EnableEffects(mToggleTrackEffects->IsDown());
+
+            ProjectHistory::Get(mProject).ModifyState(false);
+            UndoManager::Get(mProject).MarkUnsaved();
+         }
+      });
+
+      hSizer->Add(toggleEffects, 0, wxSTRETCH_NOT | wxALIGN_CENTER | wxLEFT, 5);
+      {
+         auto vSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
+
+         auto headerText = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString);
+         headerText->SetFont(wxFont(wxFontInfo().Bold()));
+         headerText->SetTranslatableLabel(XO("Realtime Effects"));
+         headerText->SetForegroundColorIndex(clrTrackPanelText);
+
+         auto trackTitle = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
+         trackTitle->SetForegroundColorIndex(clrTrackPanelText);
+         mTrackTitle = trackTitle;
+
+         vSizer->Add(headerText);
+         vSizer->Add(trackTitle);
+
+         hSizer->Add(vSizer.release(), 1, wxEXPAND | wxALL, 10);
+      }
+      auto close = safenew ThemedAButtonWrapper<AButton>(header);
+      close->SetTranslatableLabel(XO("Close"));
+      close->SetImageIndices(0, bmpCloseNormal, bmpCloseHover, bmpCloseDown, bmpCloseHover, bmpCloseDisabled);
+      close->SetBackgroundColorIndex(clrMedium);
+
+      close->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { Close(); });
+
+      hSizer->Add(close, 0, wxSTRETCH_NOT | wxALIGN_CENTER | wxRIGHT, 5);
+
+      header->SetSizer(hSizer.release());
+   }
+   vSizer->Add(header, 0, wxEXPAND);
+
+   auto effectList = safenew ThemedWindowWrapper<RealtimeEffectListWindow>(mTrackEffectsPanel, wxID_ANY);
+   effectList->SetBackgroundColorIndex(clrMedium);
+   {
+      auto footer = safenew ThemedWindowWrapper<wxWindow>(effectList, wxID_ANY);
+      footer->SetBackgroundColorIndex(clrMedium);
+
+      auto addEffectHint = safenew ThemedWindowWrapper<wxStaticText>(footer, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+      //Workaround: text is set in the OnSizeChange
+      addEffectHint->SetForegroundColorIndex(clrTrackPanelText);
+
+      auto addEffectTutorialLink = safenew ThemedWindowWrapper<wxHyperlinkCtrl>(
+         footer, wxID_ANY, _("Watch video"),
+         "https://www.audacityteam.org/realtime-video", wxDefaultPosition,
+         wxDefaultSize, wxHL_ALIGN_LEFT | wxHL_CONTEXTMENU);
+
+      //i18n-hint: Hyperlink to the effects stack panel tutorial video
+      addEffectTutorialLink->SetTranslatableLabel(XO("Watch video"));
+#if wxUSE_ACCESSIBILITY
+      safenew WindowAccessible(addEffectTutorialLink);
+#endif
+
+      addEffectTutorialLink->Bind(
+         wxEVT_HYPERLINK, [](wxHyperlinkEvent& event)
+         { BasicUI::OpenInDefaultBrowser(event.GetURL()); });
+
+      auto footerSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
+      footerSizer->Add(addEffectHint, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 20);
+      footerSizer->Add(addEffectTutorialLink, 0, wxLEFT | wxRIGHT | wxEXPAND, 20);
+      footer->SetSizer(footerSizer.release());
+
+      footer->Bind(wxEVT_SIZE, [=](wxSizeEvent& event)
+      {
+         if(auto sizerItem = footer->GetSizer()->GetItem(addEffectHint))
+         {
+            //We need to wrap the text whenever panel width changes and adjust widget height
+            //so that text is fully visible, but there is no height-for-width layout algorithm
+            //in wxWidgets yet, so for now we just do it manually
+
+            //Restore original text, because 'Wrap' will replace it with wrapped one
+            addEffectHint->SetLabel(_("Realtime effects are non-destructive and can be changed at any time."));
+            addEffectHint->Wrap(mTrackEffectsPanel->GetClientSize().x - sizerItem->GetBorder() * 2);
+            addEffectHint->InvalidateBestSize();
+         }
+         event.Skip();
+      });
+
+      effectList->SetFooter(footer);
+   }
+   vSizer->Add(effectList, 1, wxEXPAND);
+
+   mTrackEffectsHeader = header;
+   mTrackEffectList = effectList;
+
+   mTrackEffectsPanel->SetSizer(vSizer.release());
+}
+
+class SashLine : public wxWindow
+{
+   wxWeakRef<wxSplitterWindow> mSplitter;
+   bool mDrag {false};
+public:
+   SashLine(wxWindow *parent,
+             wxWindowID id,
+             const wxPoint& pos = wxDefaultPosition,
+             const wxSize& size = wxDefaultSize)
+                : wxWindow(parent, id, pos, size, wxNO_BORDER, wxEmptyString)
+   {
+      wxWindow::SetBackgroundStyle(wxBG_STYLE_PAINT);
+      SetCursor(wxCursor(wxCURSOR_SIZENS));
+      
+      Bind(wxEVT_LEFT_DOWN, &SashLine::OnMouseDown, this);
+      Bind(wxEVT_LEFT_UP, &SashLine::OnMouseUp, this);
+      Bind(wxEVT_MOTION, &SashLine::OnMove, this);
+      Bind(wxEVT_MOUSE_CAPTURE_LOST, &SashLine::OnMouseCaptureLost, this);
+      Bind(wxEVT_PAINT, &SashLine::OnPaint, this);
+   }
+
+   void SetSplitterWindow(wxSplitterWindow* window)
+   {
+      mSplitter = window;
+   }
+
+   bool AcceptsFocus() const override { return false; }
+
+private:
+
+   void OnMouseCaptureLost(wxMouseCaptureLostEvent& event)
+   {
+      mDrag = false;
+   }
+
+   void OnMouseDown(wxMouseEvent& evt)
+   {
+      if(!mSplitter)
+         return;
+      CaptureMouse();
+      mDrag = true;
+   }
+
+   void OnMouseUp(wxMouseEvent& evt)
+   {
+      mDrag = false;
+      ReleaseMouse();
+   }
+
+   void OnMove(wxMouseEvent& evt)
+   {
+      if(!mDrag || !mSplitter)
+      {
+         evt.Skip();
+         return;
+      }
+      const auto pos = mSplitter->ScreenToClient(ClientToScreen(evt.GetPosition()));
+      mSplitter->SetSashPosition(
+         std::clamp(
+            pos.y,
+            mSplitter->GetMinimumPaneSize(),
+            mSplitter->GetSize().y - mSplitter->GetMinimumPaneSize()
+         ));
+   }
+   
+   void OnPaint(wxPaintEvent&)
+   {
+      wxBufferedPaintDC dc(this);
+      const auto rect = wxRect(GetSize());
+
+      dc.SetPen(*wxTRANSPARENT_PEN);
+      dc.SetBrush(GetBackgroundColour());
+      dc.DrawRectangle(rect);
+      
+      dc.SetPen(GetForegroundColour());
+      dc.SetBrush(*wxTRANSPARENT_BRUSH);
+      const auto yy = rect.GetTop() + rect.GetHeight() / 2;
+      dc.DrawLine(rect.GetLeft(), yy, rect.GetRight(), yy);
+   }
+};
+
+void RealtimeEffectPanel::MakeMasterEffectPane()
+{
+   mProjectEffectsPanel = safenew wxPanel(this);
+
+   auto vSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
+
+   const auto sash = safenew ThemedWindowWrapper<SashLine>(mProjectEffectsPanel, wxID_ANY);
+   sash->SetMinSize(wxSize{-1, 3});
+   sash->SetSplitterWindow(this);
+   sash->SetBackgroundColorIndex(clrMedium);
+   sash->SetForegroundColorIndex(clrDark);
+   vSizer->Add(sash, 0, wxEXPAND);
+
+   auto header = safenew ThemedWindowWrapper<ListNavigationPanel>(mProjectEffectsPanel, wxID_ANY);
+#if wxUSE_ACCESSIBILITY
+   safenew WindowAccessible(header);
+#endif
+   header->SetBackgroundColorIndex(clrMedium);
+   {
+      auto hSizer = std::make_unique<wxBoxSizer>(wxHORIZONTAL);
+      auto toggleEffects = safenew ThemedAButtonWrapper<AButton>(header);
+      toggleEffects->SetImageIndices(0, bmpEffectOff, bmpEffectOff, bmpEffectOn, bmpEffectOn, bmpEffectOff);
+      toggleEffects->SetButtonToggles(true);
+      toggleEffects->SetTranslatableLabel(XO("Power"));
+      toggleEffects->SetBackgroundColorIndex(clrMedium);
+      mToggleMasterEffects = toggleEffects;
+
+      toggleEffects->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+         if (mMasterEffectList)
+         {
+            mMasterEffectList->EnableEffects(mToggleMasterEffects->IsDown());
+
+            ProjectHistory::Get(mProject).ModifyState(false);
+            UndoManager::Get(mProject).MarkUnsaved();
+         }
+      });
+
+      hSizer->Add(toggleEffects, 0, wxSTRETCH_NOT | wxALIGN_CENTER | wxLEFT, 5);
+      {
+         auto vSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
+
+         auto headerText = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString);
+         headerText->SetFont(wxFont(wxFontInfo().Bold()));
+         headerText->SetTranslatableLabel(XO("Master effects"));
+         headerText->SetForegroundColorIndex(clrTrackPanelText);
+
+         auto desc = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
+         desc->SetForegroundColorIndex(clrTrackPanelText);
+         desc->SetTranslatableLabel(XO("Apply to all tracks"));
+
+         vSizer->Add(headerText);
+         vSizer->Add(desc);
+
+         hSizer->Add(vSizer.release(), 1, wxEXPAND | wxALL, 10);
+      }
+
+      header->SetSizer(hSizer.release());
+   }
+   vSizer->Add(header, 0, wxEXPAND | wxTOP, 5);
+
+   auto effectList = safenew ThemedWindowWrapper<RealtimeEffectListWindow>(mProjectEffectsPanel, wxID_ANY);
+   effectList->SetBackgroundColorIndex(clrMedium);
+   vSizer->Add(effectList, 1, wxEXPAND);
+
+   mMasterEffectList = effectList;
+
+   mProjectEffectsPanel->SetSizer(vSizer.release());
 }
 
 void RealtimeEffectPanel::OnCharHook(wxKeyEvent& evt)

--- a/src/RealtimeEffectPanel.h
+++ b/src/RealtimeEffectPanel.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <wx/scrolwin.h>
 #include <wx/weakref.h>
+#include <wx/splitter.h>
 
 #include "ThemedWrappers.h"
 #include "Observer.h"
@@ -31,12 +32,16 @@ class AudacityProject;
  * an individual track, provides controls for accessing effect settings,
  * stack manipulation (reorder, add, remove)
  */
-class RealtimeEffectPanel : public wxPanel
+class RealtimeEffectPanel : public wxSplitterWindow
 {
-   AButton* mToggleEffects{nullptr};
+   AButton* mToggleTrackEffects{nullptr};
+   AButton* mToggleMasterEffects{nullptr};
    wxStaticText* mTrackTitle {nullptr};
-   RealtimeEffectListWindow* mEffectList{nullptr};
-   wxWindow* mHeader{nullptr};
+   wxWindow* mTrackEffectsPanel{nullptr};
+   wxWindow* mProjectEffectsPanel{nullptr};
+   RealtimeEffectListWindow* mTrackEffectList{nullptr};
+   RealtimeEffectListWindow* mMasterEffectList{nullptr};
+   wxWindow* mTrackEffectsHeader{nullptr};
    AudacityProject& mProject;
 
    std::weak_ptr<SampleTrack> mCurrentTrack;
@@ -81,5 +86,9 @@ public:
    void SetFocus() override;
    
 private:
+
+   void MakeTrackEffectPane();
+   void MakeMasterEffectPane();
+
    void OnCharHook(wxKeyEvent& evt);
 };

--- a/src/effects/RealtimeEffectStateUI.cpp
+++ b/src/effects/RealtimeEffectStateUI.cpp
@@ -22,7 +22,6 @@
 #include "UndoManager.h"
 #include "ProjectHistory.h"
 #include "ProjectWindow.h"
-#include "Track.h"
 
 namespace
 {
@@ -140,10 +139,9 @@ void RealtimeEffectStateUI::Toggle(AudacityProject& project)
       Show(project);
 }
 
-void RealtimeEffectStateUI::UpdateTrackData(const Track& track)
+void RealtimeEffectStateUI::SetTargetName(const wxString& targetName)
 {
-   mTrackName = track.GetName();
-
+   mTargetName = targetName;
    UpdateTitle();
 }
 
@@ -173,10 +171,10 @@ void RealtimeEffectStateUI::UpdateTitle()
    }
 
    const auto title =
-      mTrackName.empty() ?
+      mTargetName.empty() ?
          mEffectName :
          /* i18n-hint: First %s is an effect name, second is a track name */
-         XO("%s - %s").Format(mEffectName, mTrackName);
+         XO("%s - %s").Format(mEffectName, mTargetName);
 
    mEffectUIHost->SetTitle(title);
    mEffectUIHost->SetName(title);

--- a/src/effects/RealtimeEffectStateUI.h
+++ b/src/effects/RealtimeEffectStateUI.h
@@ -19,7 +19,6 @@
 #include "Observer.h"
 
 class RealtimeEffectState;
-class Track;
 class EffectUIHost;
 class EffectInstance;
 
@@ -41,7 +40,9 @@ public:
    void Hide(AudacityProject* project = nullptr);
    void Toggle(AudacityProject& project);
 
-   void UpdateTrackData(const Track& track);
+   //! Sets the display name of the target, that will help
+   //! distinguish effect UI among others.
+   void SetTargetName(const wxString& name);
 
    static RealtimeEffectStateUI &Get(RealtimeEffectState &state);
    static const RealtimeEffectStateUI &Get(const RealtimeEffectState &state);
@@ -57,7 +58,7 @@ private:
    wxWeakRef<EffectUIHost> mEffectUIHost;
 
    TranslatableString mEffectName;
-   wxString mTrackName;
+   wxString mTargetName;
    AudacityProject *mpProject{};
 
    Observer::Subscription mProjectWindowDestroyedSubscription;

--- a/src/effects/StereoToMono.cpp
+++ b/src/effects/StereoToMono.cpp
@@ -132,16 +132,13 @@ bool EffectStereoToMono::ProcessOne(TrackList &outputs,
    tracks.emplace_back(
       track.SharedPointer<const SampleTrack>(), GetEffectStages(track));
 
-   Mixer mixer(move(tracks),
-      true,                // Throw to abort mix-and-render if read fails:
-      Mixer::WarpOptions{ inputTracks()->GetOwner() },
-      start,
-      end,
-      1,
+   Mixer mixer(
+      move(tracks), std::nullopt,
+      true, // Throw to abort mix-and-render if read fails:
+      Mixer::WarpOptions { inputTracks()->GetOwner() }, start, end, 1,
       idealBlockLen,
-      false,               // Not interleaved
-      track.GetRate(),
-      floatSample);
+      false, // Not interleaved
+      track.GetRate(), floatSample);
 
    // Always make mono output; don't use EmptyCopy
    auto outTrack = track.EmptyCopy(1);


### PR DESCRIPTION
Resolves: #6346

Known issues:
 - UI: Master effects section does not fit automatically to the contents
 - No micro fades applied to solo/gain change
 - Latency increased for track controls in real-time (delay between the moment you press TC button and the moment you hear changes is audiable)

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Several projects can be open at once, each with master channel effects, and behavior is as expected.
- [x] Real-time effects can be added and removed during playback - works for both track and master channel.
- [x] Real-time effect UI indicates track name or "Master", depending.
- [x] Playback of MIDI file in otherwise empty project works (i.e., MIDI messages are sent, and only silence is played back).
- [x] Mute / Solo during playback still works (there may be a click audible but that shouldn't be a regression)
- [x] Playback of several tracks, some with effects with latency and others without, within a loop, yield expected result.
- [x] Master track effects are applied when exporting but not rendering (in place or to new track) or stereo-to-mono
- [x] Export does delay compensation
- [x] Export works for files of 10 seconds or more
- [x] Master effects are persistent across closing/re-opening a project
- [x] Master effect stacks in several projects open at once do not interfere with each other (e.g. Reverb in project A isn't applied to tracks in project B).
- [x] Backward compatibility: a project with master effects can be opened in previous Audacity version, only without the master effects.
- [x] Scrubbing