### PR TITLE
Play Meter remains just right of AudioSetup when maximizing window

### DIFF
--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -535,10 +535,13 @@ static struct DefaultConfigEntry {
 #ifdef HAS_AUDIOCOM_UPLOAD
    { wxT("Share Audio"),       wxT("Audio Setup"),     {}                },
    { wxT("RecordMeter"),       wxT("Share Audio"),     {}                },
+   { wxT("PlayMeter"),         wxT("Share Audio"),     wxT("RecordMeter"),
+   },
 #else
    { wxT("RecordMeter"),       wxT("Audio Setup"),     {}                },
+   { wxT("PlayMeter"),         wxT("Audio Setup"),     wxT("RecordMeter"),
+   },
 #endif
-   { wxT("PlayMeter"),         wxT("RecordMeter"),     {}                },
 
    // start another top dock row
    { wxT("Device"),             {},                     wxT("Control")         },


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

QA:
Test this in builds configured with and without the Audio.com upload

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
