### PR TITLE
Standardizes "OK" Buttons by Fixing Sole "Ok" Outlier

### DIFF
--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkSucceededDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkSucceededDialog.cpp
@@ -46,7 +46,7 @@ LinkSucceededDialog::LinkSucceededDialog(wxWindow* parent)
          {
             s.AddSpace(1, 0, 1);
 
-            auto btn = s.AddButton(XO("&Ok"));
+            auto btn = s.AddButton(XO("&OK"));
 
             btn->Bind(wxEVT_BUTTON, [this](auto) { EndModal(wxID_OK); });
             btn->SetDefault();


### PR DESCRIPTION
This is the only instance of a button being labeled "Ok" in all of GitHub. Every other button is labeled "OK".

Resolves: https://github.com/audacity/audacity/issues/3612

In all of Audacity, every single "OK" button is labeled exactly that: "OK" in all caps. However, there is a single button labeled "Ok", which appears when a user links their audio.com account. This pull request remedies this and standardizes the "OK" buttons.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior