### PR TITLE
Changed playback accuracy from up to two decimal places to three decimal places

### DIFF
--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -100,7 +100,7 @@ Identifier TranscriptionToolBar::ID()
 TranscriptionToolBar::TranscriptionToolBar( AudacityProject &project )
 : ToolBar( project, XO("Play-at-Speed"), ID(), true )
 {
-   SetPlaySpeed( 1.0 * 100.0 );
+   SetPlaySpeed( 1.0 * 1000.0 );
 #ifdef EXPERIMENTAL_VOICE_DETECTION
    mVk = std::make_unique<VoiceKey>();
 #endif
@@ -158,7 +158,7 @@ void TranscriptionToolBar::Create(wxWindow * parent)
    //JKC: Set speed this way is better, as we don't
    //then stop Audio if it is playing, so we can be playing
    //audio and open a second project.
-   SetPlaySpeed( (mPlaySpeedSlider->Get()) * 100 );
+   SetPlaySpeed( (mPlaySpeedSlider->Get()) * 1000 );
 
    // Simulate a size event to set initial placement/size
    wxSizeEvent event(GetSize(), GetId());
@@ -238,7 +238,7 @@ void TranscriptionToolBar::Populate()
          .Page( 1.6722f )
    );
    mPlaySpeedSlider->SetSizeHints(wxSize(100, 25), wxSize(2000, 25));
-   mPlaySpeedSlider->Set(mPlaySpeed / 100.0);
+   mPlaySpeedSlider->Set(mPlaySpeed / 1000.0);
    mPlaySpeedSlider->SetLabel(_("Playback Speed"));
    Add( mPlaySpeedSlider, 1, wxALIGN_CENTER );
    mPlaySpeedSlider->Bind(wxEVT_SET_FOCUS,
@@ -521,7 +521,7 @@ void TranscriptionToolBar::PlayAtSpeed(bool newDefault, bool cutPreview)
       // Set the speed range
       //mTimeTrack->SetRangeUpper((double)mPlaySpeed / 100.0);
       //mTimeTrack->SetRangeLower((double)mPlaySpeed / 100.0);
-      mEnvelope->Flatten((double)mPlaySpeed / 100.0);
+      mEnvelope->Flatten((double)mPlaySpeed / 1000.0);
    }
 
    // Pop up the button
@@ -571,7 +571,7 @@ void TranscriptionToolBar::OnPlaySpeed(wxCommandEvent & event)
 
 void TranscriptionToolBar::OnSpeedSlider(wxCommandEvent& WXUNUSED(event))
 {
-   SetPlaySpeed( (mPlaySpeedSlider->Get()) * 100 );
+   SetPlaySpeed( (mPlaySpeedSlider->Get()) * 1000 );
    RegenerateTooltips();
 
    // If IO is busy, abort immediately
@@ -1126,7 +1126,7 @@ void OnPlaySpeedInc(const CommandContext &context)
    auto tb = &TranscriptionToolBar::Get( project );
 
    if (tb) {
-      tb->AdjustPlaySpeed(0.1f);
+      tb->AdjustPlaySpeed(0.01f);
    }
 }
 
@@ -1136,7 +1136,7 @@ void OnPlaySpeedDec(const CommandContext &context)
    auto tb = &TranscriptionToolBar::Get( project );
 
    if (tb) {
-      tb->AdjustPlaySpeed(-0.1f);
+      tb->AdjustPlaySpeed(-0.01f);
    }
 }
 

--- a/src/toolbars/TranscriptionToolBar.h
+++ b/src/toolbars/TranscriptionToolBar.h
@@ -120,7 +120,7 @@ class TranscriptionToolBar final : public ToolBar {
    void SetEnabled(bool enabled);
    void SetPlaying(bool down, bool looped, bool cutPreview);
 
-   double GetPlaySpeed() const { return mPlaySpeed / 100.0; }
+   double GetPlaySpeed() const { return mPlaySpeed / 1000.0; }
 
  private:
 

--- a/src/widgets/ASlider.cpp
+++ b/src/widgets/ASlider.cpp
@@ -276,6 +276,11 @@ SliderDialog::SliderDialog(wxWindow * parent, wxWindowID id,
       prec = 1;
       trailing = NumValidatorStyle::ONE_TRAILING_ZERO;
    }
+   if (style == SPEED_SLIDER)
+   {
+      prec = 3;
+      trailing = NumValidatorStyle::THREE_TRAILING_ZEROES;
+   }
 
    ShuttleGui S(this, eIsCreating);
 
@@ -536,8 +541,8 @@ LWSlider::LWSlider(wxWindow *parent,
       stepValue = STEP_CONTINUOUS;
       break;
    case SPEED_SLIDER:
-      minValue = 0.01f;
-      maxValue = 3.0f;
+      minValue = 0.001f;
+      maxValue = 3.000f;
       stepValue = STEP_CONTINUOUS;
       break;
    case VEL_SLIDER:
@@ -1033,7 +1038,7 @@ TranslatableString LWSlider::GetTip(float value) const
 
       case SPEED_SLIDER:
          /* i18n-hint: "x" suggests a multiplicative factor */
-         val = XO("%.2fx").Format( value );
+         val = XO("%.3fx").Format( value );
          break;
 
       case VEL_SLIDER:
@@ -1573,7 +1578,7 @@ void LWSlider::Increase(float steps)
 
    if ( stepValue == 0.0 )
    {
-      stepValue = ( mMaxValue - mMinValue ) / 10.0;
+      stepValue = ( mMaxValue - mMinValue ) / 100.0;
    }
 
    mCurrentValue += ( steps * stepValue );
@@ -1596,7 +1601,7 @@ void LWSlider::Decrease(float steps)
 
    if ( stepValue == 0.0 )
    {
-      stepValue = ( mMaxValue - mMinValue ) / 10.0;
+      stepValue = ( mMaxValue - mMinValue ) / 100.0;
    }
 
    mCurrentValue -= ( steps * stepValue );

--- a/src/widgets/ASlider.h
+++ b/src/widgets/ASlider.h
@@ -42,8 +42,8 @@ class TipWindow;
 #define DB_MAX 36.0f
 #define FRAC_MIN 0.0f
 #define FRAC_MAX 1.0f
-#define SPEED_MIN 0.01f
-#define SPEED_MAX 3.0f
+#define SPEED_MIN 0.001f
+#define SPEED_MAX 3.000f
 #define VEL_MIN -50.0f
 #define VEL_MAX 50.0f
 


### PR DESCRIPTION
Resolves: #5222 

I just added an extra zero to all the 100s and 0.1s in ASlider and TranscriptionToolBar and also changed the precision for SPEED_SLIDER to up to three decimal places

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
