### PR TITLE
Silence -Wexpansion-to-defined warning in BasicUI.cpp

### DIFF
--- a/libraries/lib-basic-ui/BasicUI.cpp
+++ b/libraries/lib-basic-ui/BasicUI.cpp
@@ -12,9 +12,11 @@ Paul Licameli
 #include <mutex>
 #include <vector>
 
-#define HAS_XDG_OPEN_HELPER (defined(__linux__) && !defined __ANDROID__) || defined (__FreeBSD__) || defined (__NetBSD__) || defined(__OpenBSD__)
+#if (defined(__linux__) && !defined(__ANDROID__)) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#define HAS_XDG_OPEN_HELPER
+#endif
 
-#if HAS_XDG_OPEN_HELPER
+#if defined(HAS_XDG_OPEN_HELPER)
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -243,7 +245,7 @@ void Yield()
 
 bool OpenInDefaultBrowser(const wxString &url)
 {
-#if HAS_XDG_OPEN_HELPER
+#if defined(HAS_XDG_OPEN_HELPER)
    if (RunXDGOpen(url.ToStdString()))
       return true;
 #endif


### PR DESCRIPTION
```
/home/ports/pobj/audacity-3.5.1/audacity-Audacity-3.5.1/libraries/lib-basic-ui/BasicUI.cpp:17:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
#if HAS_XDG_OPEN_HELPER
    ^
/home/ports/pobj/audacity-3.5.1/audacity-Audacity-3.5.1/libraries/lib-basic-ui/BasicUI.cpp:15:30: note: expanded from macro 'HAS_XDG_OPEN_HELPER'
#define HAS_XDG_OPEN_HELPER (defined(__linux__) && !defined __ANDROID__) || defined (__FreeBSD__) || defined (__NetBSD__) || defined(__OpenBSD__)
                             ^
```

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior
