### PR TITLE
Fix HiDPI text rendering on Windows

### DIFF
--- a/win/Audacity.exe.manifest
+++ b/win/Audacity.exe.manifest
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0' xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity
       version="2.3.0.0"
       processorArchitecture="x86"
@@ -19,4 +19,9 @@
       <assemblyIdentity type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*' />
     </dependentAssembly>
   </dependency>
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">
+      <gdiScaling>true</gdiScaling>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </assembly>


### PR DESCRIPTION
Resolves: #4788 (partially)
Resolves: #6427 on windows

This PR fixes rendering of text on HiDPI monitors on Windows.

## Before
![Screenshot 2024-05-17 143322](https://github.com/audacity/audacity/assets/33201674/904ad5a7-2cd1-4e3e-ab2b-6dc861eac32f)

## After
![Screenshot 2024-05-17 143432](https://github.com/audacity/audacity/assets/33201674/0ac1066c-c9d0-4907-ba8d-f0c04997af53)

The issue is fixed by letting GDI automatically scale the text according to the current DPI: [source](https://blogs.windows.com/windowsdeveloper/2017/05/19/improving-high-dpi-experience-gdi-based-desktop-apps/).

What's not fixed:

- Drawing bitmaps according to scale

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
