### PR TITLE
Support macOS promise file handling

### DIFF
--- a/libraries/lib-basic-ui/BasicUI.h
+++ b/libraries/lib-basic-ui/BasicUI.h
@@ -144,6 +144,13 @@ enum ProgressDialogOptions : unsigned {
    ProgressConfirmStopOrCancel = (1 << 3),
 };
 
+enum GenericProgressDialogStyle : int {
+   ProgressCanAbort            = (1 << 0),
+   ProgressAppModal            = (1 << 1),
+   ProgressShowElapsedTime     = (1 << 2),
+   ProgressSmooth              = (1 << 3),
+};
+
 enum class ProgressResult : unsigned
 {
    Cancelled = 0, //<! User says that whatever is happening is undesirable and shouldn't have happened at all
@@ -210,7 +217,8 @@ public:
    virtual std::unique_ptr<GenericProgressDialog>
    DoMakeGenericProgress(const WindowPlacement &placement,
       const TranslatableString &title,
-      const TranslatableString &message) = 0;
+      const TranslatableString &message,
+      int style) = 0;
    virtual int DoMultiDialog(const TranslatableString &message,
       const TranslatableString &title,
       const TranslatableStrings &buttons,
@@ -311,10 +319,10 @@ inline std::unique_ptr<ProgressDialog> MakeProgress(
  */
 inline std::unique_ptr<GenericProgressDialog> MakeGenericProgress(
    const WindowPlacement &placement,
-   const TranslatableString &title, const TranslatableString &message)
+   const TranslatableString &title, const TranslatableString &message, int style = (ProgressAppModal | ProgressShowElapsedTime | ProgressSmooth))
 {
    if (auto p = Get())
-      return p->DoMakeGenericProgress(placement, title, message);
+      return p->DoMakeGenericProgress(placement, title, message, style);
    else
       return nullptr;
 }

--- a/libraries/lib-wx-init/wxWidgetsBasicUI.cpp
+++ b/libraries/lib-wx-init/wxWidgetsBasicUI.cpp
@@ -182,12 +182,13 @@ namespace {
 struct MyGenericProgress : wxGenericProgressDialog, GenericProgressDialog {
    MyGenericProgress(const TranslatableString &title,
       const TranslatableString &message,
-      wxWindow *parent = nullptr)
+      wxWindow *parent = nullptr,
+      int style = ProgressAppModal | ProgressShowElapsedTime | ProgressSmooth)
       : wxGenericProgressDialog{
          title.Translation(), message.Translation(),
          300000,     // range
          parent,
-         wxPD_APP_MODAL | wxPD_ELAPSED_TIME | wxPD_SMOOTH
+         style
       }
    {}
    ~MyGenericProgress() override = default;
@@ -207,10 +208,22 @@ std::unique_ptr<GenericProgressDialog>
 wxWidgetsBasicUI::DoMakeGenericProgress(
    const BasicUI::WindowPlacement &placement,
    const TranslatableString &title,
-   const TranslatableString &message)
+   const TranslatableString &message,
+   int style)
 {
+   // Compute the style argument to pass to wxWidgets
+   int flags = 0;
+   if ((style & ProgressCanAbort))
+      flags |= wxPD_CAN_ABORT;
+   if ((style & ProgressAppModal))
+      flags |= wxPD_APP_MODAL;
+   if ((style & ProgressShowElapsedTime))
+      flags |= wxPD_ELAPSED_TIME;
+   if ((style & ProgressSmooth))
+      flags |= wxPD_SMOOTH;
+
    return std::make_unique<MyGenericProgress>(
-      title, message, wxWidgetsWindowPlacement::GetParent(placement));
+      title, message, wxWidgetsWindowPlacement::GetParent(placement), flags);
 }
 
 int wxWidgetsBasicUI::DoMultiDialog(const TranslatableString &message,

--- a/libraries/lib-wx-init/wxWidgetsBasicUI.h
+++ b/libraries/lib-wx-init/wxWidgetsBasicUI.h
@@ -40,7 +40,8 @@ protected:
    std::unique_ptr<BasicUI::GenericProgressDialog>
    DoMakeGenericProgress(const BasicUI::WindowPlacement &placement,
       const TranslatableString &title,
-      const TranslatableString &message) override;
+      const TranslatableString &message,
+      int style) override;
    int DoMultiDialog(const TranslatableString &message,
       const TranslatableString &title,
       const TranslatableStrings &buttons,


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6376

Getting file handle of file that hasn't been downloaded yet (in the middle of download) is a blocking call. If file is big or internet connection is slow this call freezes whole app. 
Moved blocking call to a separate thread and allowed user to cancel import (if so, user goes back to usual flow, thread is going to finish it's job but the result is ignored, thread cleans up after itself)

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
