### PR TITLE
Temporary disable Ubuntu 20.04 gcc 11 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,10 +123,10 @@ jobs:
           os: ubuntu-20.04
           force_gcc11: false
           postfix: '-20.04'
-        - name: Ubuntu 20.04 AppImage (x86_64, gcc 11)
-          os: ubuntu-20.04
-          force_gcc11: true
-          postfix: '-20.04-gcc11'
+#        - name: Ubuntu 20.04 AppImage (x86_64, gcc 11)
+#          os: ubuntu-20.04
+#          force_gcc11: true
+#          postfix: '-20.04-gcc11'
         - name: Ubuntu 22.04 AppImage (x86_64)
           os: ubuntu-22.04
           force_gcc11: false


### PR DESCRIPTION
`apt install` fails to install gcc11

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
