### PR TITLE
Changed the realtime effects button from "Effects" to "Realtime Effects"

### DIFF
--- a/src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+++ b/src/tracks/playabletrack/ui/PlayableTrackControls.cpp
@@ -113,7 +113,7 @@ void EffectsDrawFunction
 {   
    wxCoord textWidth, textHeight;
    
-   const auto str = _("Effects");
+   const auto str = _("Realtime Effects");
 
    const auto selected = pTrack ? pTrack->GetSelected() : true;
 


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/audacity/audacity/issues/6492)

I changed the realtime effects button title from “Effects” to “Realtime Effects” to better clarify what the button did and differentiate it from the non-realtime effects button in the top menu bar.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
