### PR TITLE
bug 6448: Do not use wxWidget env-variable expand flag when adding to `audacityPathList`

### DIFF
--- a/libraries/lib-files/FileNames.cpp
+++ b/libraries/lib-files/FileNames.cpp
@@ -172,7 +172,7 @@ bool FileNames::HardLinkFile( const FilePath& file1, const FilePath& file2 )
 #ifdef __WXMSW__
 
    // Fix forced ASCII conversions and wrong argument order - MJB - 29/01/2019
-   //return ::CreateHardLinkA( file1.c_str(), file2.c_str(), NULL );  
+   //return ::CreateHardLinkA( file1.c_str(), file2.c_str(), NULL );
    return ( 0 != ::CreateHardLink( file2, file1, NULL ) );
 
 #else
@@ -504,7 +504,7 @@ wxFileNameWrapper FileNames::DefaultToDocumentsFolder(const wxString &preference
 
    // MJB: Bug 1899 & Bug 2007.  Only create directory if the result is the default path
    bool bIsDefaultPath = result == defaultPath;
-   if( !bIsDefaultPath ) 
+   if( !bIsDefaultPath )
    {
       // IF the prefs directory doesn't exist - (Deleted by our user perhaps?)
       //    or exists as a file
@@ -626,7 +626,12 @@ void FileNames::AddUniquePathToPathList(const FilePath &pathArg,
                                           FilePaths &pathList)
 {
    wxFileNameWrapper pathNorm { pathArg };
-   pathNorm.Normalize();
+   // https://github.com/audacity/audacity/issues/6448 :
+   // Do not seek to expand environment variables here: it is not needed, and
+   // wxWidgets has an issue doing so - See
+   // https://github.com/wxWidgets/wxWidgets/issues/19214
+   const auto flags = wxPATH_NORM_ALL & ~wxPATH_NORM_ENV_VARS;
+   pathNorm.Normalize(flags);
    const wxString newpath{ pathNorm.GetFullPath() };
 
    for(const auto &path : pathList) {

--- a/src/AudacityFileConfig.cpp
+++ b/src/AudacityFileConfig.cpp
@@ -32,6 +32,12 @@ AudacityFileConfig::AudacityFileConfig(
 : wxFileConfig{ appName, vendorName, localFilename, globalFilename, style, conv }
 , mLocalFilename(localFilename)
 {
+  // https://github.com/audacity/audacity/issues/6448 :
+  // We do not write environment variable names in the config files, and
+  // wxWidgets' implementation of environment variable expansion thinks a dollar
+  // sign at the beginning of a directory name is an environment variable - see
+  // https://github.com/wxWidgets/wxWidgets/issues/19214
+  SetExpandEnvVars(false);
 }
 
 void AudacityFileConfig::Init()


### PR DESCRIPTION
Resolves: #6448 

`wxFileName::Normalize()` by default uses (among others) the `wxPATH_NORM_ENV_VARS`.
On Windows, this environment-variable path expansion option has a [bug](https://github.com/wxWidgets/wxWidgets/issues/19214), causing #6448. (Note that the way this was resolved by wxWidgets was by discouraging the use of that option, rather than fixing the problem itself.)

We are using `Normalize` as Audacity collects paths where to look for modules. Looking at the code ending at the place where we make this call to `Normalize`, it seems to me that environment variable expansion is not needed, and can hence be disabled (see diff).

We make other calls to `Normalize` in other contexts, which I reviewed. There seems not to be a need to disable this option there, but I would like to have the opinions of the reviewers.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
