### PR TITLE
6505 fix graph delay when using lookahead

### DIFF
--- a/src/effects/CompressorInstance.cpp
+++ b/src/effects/CompressorInstance.cpp
@@ -34,6 +34,12 @@ const std::optional<double>& CompressorInstance::GetSampleRate() const
    return mSampleRate;
 }
 
+float CompressorInstance::GetLatencyMs() const
+{
+   return mSlaves.empty() ? mCompressor->GetSettings().lookaheadMs :
+                        mSlaves.front().mCompressor->GetSettings().lookaheadMs;
+}
+
 void CompressorInstance::SetOutputQueue(
    std::weak_ptr<DynamicRangeProcessorOutputPacketQueue> outputQueue)
 {

--- a/src/effects/CompressorInstance.h
+++ b/src/effects/CompressorInstance.h
@@ -35,6 +35,7 @@ public:
    explicit CompressorInstance(CompressorInstance&& other);
 
    const std::optional<double>& GetSampleRate() const;
+   float GetLatencyMs() const;
    void SetOutputQueue(std::weak_ptr<DynamicRangeProcessorOutputPacketQueue>);
 
 private:

--- a/src/effects/DynamicRangeProcessorEditor.cpp
+++ b/src/effects/DynamicRangeProcessorEditor.cpp
@@ -135,19 +135,6 @@ DynamicRangeProcessorEditor::DynamicRangeProcessorEditor(
     , mUIParent { parent }
     , mTopLevelParent(static_cast<wxDialog&>(*wxGetTopLevelParent(parent)))
 {
-   mTopLevelParent.Bind(wxEVT_SIZE, [this](wxSizeEvent& evt) {
-      evt.Skip();
-      // Once the parent dialog reaches its final size as indicated by
-      // a non-default minimum size, we set the maximum size to match.
-      wxWindow* const w = static_cast<wxWindow*>(evt.GetEventObject());
-      const wxSize sz = w->GetMinSize();
-      if (sz != wxDefaultSize)
-         w->SetMaxSize(sz);
-   });
-   // Disable resize arrows for top parent:
-   mTopLevelParent.SetWindowStyleFlag(
-      mTopLevelParent.GetWindowStyleFlag() & ~wxRESIZE_BORDER &
-      ~wxMAXIMIZE_BOX);
    if (isRealtime)
       MakeHistoryPanels(parent, instance, access, [parent](float newDbRange) {
          if (

--- a/src/effects/DynamicRangeProcessorEditor.cpp
+++ b/src/effects/DynamicRangeProcessorEditor.cpp
@@ -135,6 +135,19 @@ DynamicRangeProcessorEditor::DynamicRangeProcessorEditor(
     , mUIParent { parent }
     , mTopLevelParent(static_cast<wxDialog&>(*wxGetTopLevelParent(parent)))
 {
+   mTopLevelParent.Bind(wxEVT_SIZE, [this](wxSizeEvent& evt) {
+      evt.Skip();
+      // Once the parent dialog reaches its final size as indicated by
+      // a non-default minimum size, we set the maximum size to match.
+      wxWindow* const w = static_cast<wxWindow*>(evt.GetEventObject());
+      const wxSize sz = w->GetMinSize();
+      if (sz != wxDefaultSize)
+         w->SetMaxSize(sz);
+   });
+   // Disable resize arrows for top parent:
+   mTopLevelParent.SetWindowStyleFlag(
+      mTopLevelParent.GetWindowStyleFlag() & ~wxRESIZE_BORDER &
+      ~wxMAXIMIZE_BOX);
    if (isRealtime)
       MakeHistoryPanels(parent, instance, access, [parent](float newDbRange) {
          if (

--- a/src/effects/DynamicRangeProcessorHistoryPanel.cpp
+++ b/src/effects/DynamicRangeProcessorHistoryPanel.cpp
@@ -92,10 +92,10 @@ constexpr auto followLineWidth =
    DynamicRangeProcessorPanel::transferFunctionLineWidth + 2;
 constexpr auto topMargin = (followLineWidth + 1) / 2;
 
-int GetDisplayPixel(float elapsedSincePacket, int panelWidth)
+double GetDisplayPixel(float elapsedSincePacket, int panelWidth)
 {
    const auto secondsPerPixel =
-      1.f * DynamicRangeProcessorHistory::maxTimeSeconds / panelWidth;
+      1. * DynamicRangeProcessorHistory::maxTimeSeconds / panelWidth;
    // A display delay to avoid the display to tremble near time zero because the
    // data hasn't arrived yet.
    // This is a trade-off between visual comfort and timely update. It was set
@@ -133,10 +133,10 @@ void DrawHistory(
       {
          const auto elapsedSincePacket =
             elapsedTimeSinceFirstPacket - (it->time - firstPacketTime);
-         const int x =
+         const double x =
             GetDisplayPixel(elapsedSincePacket, panelSize.GetWidth());
-         const int yt = topMargin - it->target / dbPerPixel;
-         const int yf = topMargin - it->follower / dbPerPixel;
+         const auto yt = topMargin - it->target / dbPerPixel;
+         const auto yf = topMargin - it->follower / dbPerPixel;
          followPoints.emplace_back(x, yf);
          targetPoints.emplace_back(x, yt);
       }

--- a/src/effects/DynamicRangeProcessorHistoryPanel.h
+++ b/src/effects/DynamicRangeProcessorHistoryPanel.h
@@ -50,6 +50,7 @@ private:
    // So that wxPanel is not included in Tab traversal - see wxWidgets bug 15581
    bool AcceptsFocusFromKeyboard() const override;
 
+   CompressorInstance& mCompressorInstance;
    std::shared_ptr<DynamicRangeProcessorOutputPacketQueue> mOutputQueue;
    std::vector<DynamicRangeProcessorOutputPacket> mPacketBuffer;
    std::optional<DynamicRangeProcessorHistory> mHistory;


### PR DESCRIPTION
Resolves: #6505

In addition to fixing the delay issue, this PR also modifies the aspect of the graph, using one line for the actual compression and a filled area to denote the difference between target and actual compression.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

