### PR TITLE
Realtime effects accessibility

### DIFF
--- a/src/ListNavigationEnabled.cpp
+++ b/src/ListNavigationEnabled.cpp
@@ -39,9 +39,10 @@ void ListNavigationEnabled_HandleKeyDown(wxWindow* self, wxKeyEvent& evt)
       evt.Skip();
 }
 
-void ListNavigationEnabled_HandleNavigationKeyEvent(wxWindow* self, wxNavigationKeyEvent& evt)
+void ListNavigationEnabled_HandleNavigationKeyEvent(wxWindow* self,
+   wxNavigationKeyEvent& evt, bool inTabOrder)
 {
-   if(evt.GetEventObject() == self->GetParent() && !evt.IsFromTab())
+   if(evt.GetEventObject() == self->GetParent() && (!evt.IsFromTab() || inTabOrder))
       self->SetFocusFromKbd();
    else if(evt.GetEventObject() == self && evt.GetCurrentFocus() == self && evt.IsFromTab())
    {

--- a/src/ListNavigationEnabled.h
+++ b/src/ListNavigationEnabled.h
@@ -25,7 +25,8 @@ class ListNavigationEnabled : public wxNavigationEnabled<WindowBase>
 {
    friend void ListNavigationEnabled_HandleCharHook(wxWindow* self, wxKeyEvent& evt);
    friend void ListNavigationEnabled_HandleKeyDown(wxWindow* self, wxKeyEvent& evt);
-   friend void ListNavigationEnabled_HandleNavigationKeyEvent(wxWindow* self, wxNavigationKeyEvent& evt);
+   friend void ListNavigationEnabled_HandleNavigationKeyEvent(wxWindow* self,
+      wxNavigationKeyEvent& evt, bool inTabOrder);
    friend void ListNavigationEnabled_HandleDestroy(wxWindow* self);
 
 public:
@@ -35,6 +36,8 @@ public:
       WindowBase::Bind(wxEVT_KEY_DOWN, &ListNavigationEnabled::OnKeyDown, this);
       WindowBase::Bind(wxEVT_CHAR_HOOK, &ListNavigationEnabled::OnCharHook, this);
    }
+
+   void SetInTabOrder(bool inTabOrder) { mInTabOrder = inTabOrder; }
 
 private:
    void SetFocus() override
@@ -55,7 +58,7 @@ private:
 
    void OnNavigationKeyEvent(wxNavigationKeyEvent& evt)
    {
-      ListNavigationEnabled_HandleNavigationKeyEvent(this, evt);
+      ListNavigationEnabled_HandleNavigationKeyEvent(this, evt, mInTabOrder);
    }
    
    bool Destroy() override
@@ -63,4 +66,6 @@ private:
       ListNavigationEnabled_HandleDestroy(this);
       return wxNavigationEnabled<WindowBase>::Destroy();
    }
+
+   bool mInTabOrder{ true };
 };

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -535,6 +535,8 @@ namespace
 
          SetSizer(vSizer.release());
 
+         SetInTabOrder(false);
+
 #if wxUSE_ACCESSIBILITY
          SetAccessible(safenew RealtimeEffectControlAx(this));
 #endif
@@ -1623,6 +1625,7 @@ void RealtimeEffectPanel::MakeMasterEffectPane()
          headerText->SetFont(wxFont(wxFontInfo().Bold()));
          headerText->SetTranslatableLabel(XO("Master effects"));
          headerText->SetForegroundColorIndex(clrTrackPanelText);
+         header->SetName(headerText->GetLabel());
 
          auto desc = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
          desc->SetForegroundColorIndex(clrTrackPanelText);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6456

Problem:
As you tab through the controls in the realtime effects pane, there is no indication which controls are for the focused track and which for master.

Fix:
1. Include the header windows in the Tab order.

2. Set the accessibility name of the header window for master effects.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
