### PR TITLE
String tweaks

### DIFF
--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudLocationDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudLocationDialog.cpp
@@ -61,8 +61,8 @@ const DialogDescription SaveDialogDescription = {
       user to select Cloud or local save. */
    XO("How would you like to save?"),
    &bin2c_SaveRemote_png,
-   XO("Save to the Cloud"),
-   XO("Your project is backed up privately on audio.com. You can access your work from any device and collaborate on your project with others."),
+   XO("Save to the Cloud (free)"),
+   XO("Your project is backed up privately on audio.com. You can access your work from any device and collaborate on your project with others. Cloud saving is free for a limited number of projects."),
    XXO("&Save to Cloud"),
    &bin2c_SaveLocally_png,
    XO("On your computer"),

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudLocationDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudLocationDialog.cpp
@@ -66,7 +66,7 @@ const DialogDescription SaveDialogDescription = {
    XXO("&Save to Cloud"),
    &bin2c_SaveLocally_png,
    XO("On your computer"),
-   XO("Files are saved on your device."),
+   XO("Files are saved on your device.\nNote: To export MP3 and WAV files, use File > Export Audio instead."),
    XXO("Save to &computer"),
    XO("&Remember my choice and don't show again"),
    SaveLocationMode,

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/SyncSucceededDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/SyncSucceededDialog.cpp
@@ -20,13 +20,7 @@ SyncSucceededDialog::SyncSucceededDialog(const AudacityProject* project)
    AddParagraph(
       XO("All saved changes will now update to the cloud. You can manage this file from your uploaded projects page on audio.com"));
 
-   AddButton(ViewOnlineIdentifier(), XO("View online"));
-   AddButton(DoneIdentifier(), XO("Done"), DefaultButton | EscButton);
-}
-
-DialogButtonIdentifier SyncSucceededDialog::DoneIdentifier()
-{
-   return { L"done" };
+   AddButton(ViewOnlineIdentifier(), XO("Done"), DefaultButton);
 }
 
 DialogButtonIdentifier SyncSucceededDialog::ViewOnlineIdentifier()

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -137,7 +137,6 @@ void AboutDialog::CreateCreditsList()
    AddCredit(wxT("Dilson's Pickles"), designerFormat, roleTeamMember);
    AddCredit(wxT("Anita Sudan"), roleTeamMember);
    AddCredit(wxT("Vitaly Sverchinsky"), developerFormat, roleTeamMember);
-   AddCredit(wxT("Dmitry Vedenko"), developerFormat, roleTeamMember);
    AddCredit(wxT("Leo Wattenberg"), designerFormat, roleTeamMember);
    AddCredit(wxT("Jessica Williamson"), designerFormat, roleTeamMember);
    
@@ -171,6 +170,7 @@ void AboutDialog::CreateCreditsList()
    AddCredit(wxT("Alexandre Prokoudine"), documentationAndSupportFormat, roleEmeritusTeam);
    AddCredit(wxT("Peter Sampson"), qaDocumentationAndSupportFormat, roleEmeritusTeam);
    AddCredit(wxT("Martyn Shaw"), developerFormat, roleEmeritusTeam);
+   AddCredit(wxT("Dmitry Vedenko"), developerFormat, roleEmeritusTeam);
    AddCredit(wxT("Bill Wharrie"), documentationAndSupportFormat, roleEmeritusTeam);
 
    // Contributors

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -504,13 +504,6 @@ bool ProjectFileManager::SaveAs(bool allowOverwrite /* = false */)
 
    TranslatableString title = XO("%sSave Project \"%s\" As...")
       .Format( Restorer.sProjNumber, Restorer.sProjName );
-   TranslatableString message = XO("\
-'Save Project' is for an Audacity project, not an audio file.\n\
-For an audio file that will open in other apps, use 'Export'.\n");
-
-   if (ShowWarningDialog(&window, wxT("FirstProjectSave"), message, true) != wxID_OK) {
-      return false;
-   }
 
    bool bPrompt = (project.mBatchMode == 0) || (projectFileIO.GetFileName().empty());
    FilePath fName;

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -1621,12 +1621,12 @@ void RealtimeEffectPanel::MakeMasterEffectPane()
 
          auto headerText = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString);
          headerText->SetFont(wxFont(wxFontInfo().Bold()));
-         headerText->SetTranslatableLabel(XO("Master effects"));
+         headerText->SetTranslatableLabel(XO("Master Effects"));
          headerText->SetForegroundColorIndex(clrTrackPanelText);
 
          auto desc = safenew ThemedWindowWrapper<wxStaticText>(header, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
          desc->SetForegroundColorIndex(clrTrackPanelText);
-         desc->SetTranslatableLabel(XO("Apply to all tracks"));
+         desc->SetTranslatableLabel(XO("Applies to all tracks"));
 
          vSizer->Add(headerText);
          vSizer->Add(desc);

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -1298,7 +1298,7 @@ auto ExtraTrackMenu()
       Command( wxT("TrackSolo"), XXO("&Solo/Unsolo Focused Track"),
          OnTrackSolo,
          TracksExistFlag() | TrackPanelHasFocus(), wxT("Shift+S") ),
-      Command( wxT("TrackClose"), XXO("&Close Focused Track"),
+      Command( wxT("TrackClose"), XXO("Delete Fo&cused Track"),
          OnTrackClose,
          AudioIONotBusyFlag() | TrackPanelHasFocus() | TracksExistFlag(),
          wxT("Shift+C") ),

--- a/src/prefs/WarningsPrefs.cpp
+++ b/src/prefs/WarningsPrefs.cpp
@@ -70,9 +70,6 @@ void WarningsPrefs::PopulateOrExchange(ShuttleGui & S)
 
    S.StartStatic(XO("Show Warnings/Prompts for"));
    {
-      S.TieCheckBox(XXO("Saving &projects versus exporting audio"),
-                    {wxT("/Warnings/FirstProjectSave"),
-                     true});
       S.TieCheckBox(XXO("Saving &empty project"),
                     {wxT("/GUI/EmptyCanBeDirty"),
                      true});


### PR DESCRIPTION
Resolves: #6477

Also simplifies the cloud sync success dialog by removing a button. (expected behavior: done opens the project online, X only closes the dialog)

Also clarifies the cloud save option in the save dialog more. 

Also removes the "Save project is for project files not audio files" warning, instead it's now included in the save dialog directly.

Also renames Extra -> Tracks -> Close track... to Delete track...

Also moves Dmitry to emeritus.