### PR TITLE
Realtime effect panel: watch video link accessibility

### DIFF
--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -1444,7 +1444,7 @@ void RealtimeEffectPanel::MakeTrackEffectPane()
    auto effectList = safenew ThemedWindowWrapper<RealtimeEffectListWindow>(mTrackEffectsPanel, wxID_ANY);
    effectList->SetBackgroundColorIndex(clrMedium);
    {
-      auto footer = safenew ThemedWindowWrapper<wxWindow>(effectList, wxID_ANY);
+      auto footer = safenew ThemedWindowWrapper<wxPanel>(effectList, wxID_ANY);
       footer->SetBackgroundColorIndex(clrMedium);
 
       auto addEffectHint = safenew ThemedWindowWrapper<wxStaticText>(footer, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
@@ -1455,12 +1455,6 @@ void RealtimeEffectPanel::MakeTrackEffectPane()
          footer, wxID_ANY, _("Watch video"),
          "https://www.audacityteam.org/realtime-video", wxDefaultPosition,
          wxDefaultSize, wxHL_ALIGN_LEFT | wxHL_CONTEXTMENU);
-
-      //i18n-hint: Hyperlink to the effects stack panel tutorial video
-      addEffectTutorialLink->SetTranslatableLabel(XO("Watch video"));
-#if wxUSE_ACCESSIBILITY
-      safenew WindowAccessible(addEffectTutorialLink);
-#endif
 
       addEffectTutorialLink->Bind(
          wxEVT_HYPERLINK, [](wxHyperlinkEvent& event)


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6457
Resolves: https://github.com/audacity/audacity/issues/6520

Problems:
1. The link isn't in the Tab order.
2. Screen readers read its name as hyperlink, rather than "watch video"

Fixes:
1. Use a wxPanel rather than a wxWindow for footer.
2. Leave setting the accessibility name to wxWidgets.


*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
