### PR TITLE
Fixes the unusually small quality slider in export audio panel when selecting ogg vorbis

### DIFF
--- a/src/export/ExportOptionsHandler.cpp
+++ b/src/export/ExportOptionsHandler.cpp
@@ -168,6 +168,7 @@ void ExportOptionsHandler::PopulateOptions(ShuttleGui& S)
                      {
                         mEditor->SetValue(id, evt.GetInt());
                      });
+                     control->SetMinSize({180, -1});
                   }
                   else
                   {


### PR DESCRIPTION
Resolves: *#5626*

*Manually set the quality slider size for any sliders that are added to the audio options area in export audio panel so we have a consistent slider size always.*

![oggvorbis](https://github.com/audacity/audacity/assets/29351098/28db4a59-4e61-46d4-8eda-25f9e7d01ee3)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
