### PR TITLE
skip confirmation dialog when upgrading audacity

### DIFF
--- a/win/Inno_Setup_Wizard/audacity.iss.in
+++ b/win/Inno_Setup_Wizard/audacity.iss.in
@@ -58,8 +58,8 @@ VersionInfoCopyright={#GetFileCopyright(AppExe)}
 ; Audacity is already installed.
 DisableDirPage=no
 
-; Always warn if dir exists, because we'll overwrite previous Audacity.
-DirExistsWarning=yes
+; Don't warn if dir exists, because we'll upgrade previous Audacity.
+DirExistsWarning=no
 DisableProgramGroupPage=yes
 UninstallDisplayIcon="{app}\audacity.exe"
 


### PR DESCRIPTION
Resolves: #6568

QA: the normal CI build doesn't work for this. It's only the installer which no longer should display this warning: 
![image](https://github.com/audacity/audacity/assets/87814144/eeacbf8e-7ab1-4745-967b-0e6b891e66e4)

This build should have installers: https://github.com/LWinterberg/audacity/actions/runs/9345991660