### PR TITLE
6510 limiter attenuation meter

### DIFF
--- a/libraries/lib-dynamic-range-processor/DynamicRangeProcessorTypes.h
+++ b/libraries/lib-dynamic-range-processor/DynamicRangeProcessorTypes.h
@@ -29,6 +29,14 @@ struct DynamicRangeProcessorOutputPacket
 using DynamicRangeProcessorOutputPacketQueue =
    LockFreeQueue<DynamicRangeProcessorOutputPacket>;
 
+struct MeterValues
+{
+   float compressionGainDb = 0;
+   float outputDb = 0;
+};
+
+using DynamicRangeProcessorMeterValuesQueue = LockFreeQueue<MeterValues>;
+
 struct InitializeProcessingSettings
 {
    explicit InitializeProcessingSettings(double sampleRate)

--- a/libraries/lib-dynamic-range-processor/DynamicRangeProcessorTypes.h
+++ b/libraries/lib-dynamic-range-processor/DynamicRangeProcessorTypes.h
@@ -32,7 +32,7 @@ using DynamicRangeProcessorOutputPacketQueue =
 struct MeterValues
 {
    float compressionGainDb = 0;
-   float outputDb = 0;
+   float outputDb = std::numeric_limits<float>::lowest();
 };
 
 using DynamicRangeProcessorMeterValuesQueue = LockFreeQueue<MeterValues>;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -333,6 +333,8 @@ set( SOURCES
       effects/ChangeTempo.h
       effects/ClickRemoval.cpp
       effects/ClickRemoval.h
+      effects/CompressionMeterPanel.cpp
+      effects/CompressionMeterPanel.h
       effects/Contrast.cpp
       effects/Contrast.h
       effects/Distortion.cpp

--- a/src/effects/CompressionMeterPanel.cpp
+++ b/src/effects/CompressionMeterPanel.cpp
@@ -131,7 +131,7 @@ void CompressionMeterPanel::PaintRectangle(
    const auto text = label.Translation();
    const auto t = dc.GetTextExtent(text);
    const auto x = left + (width + t.GetHeight()) / 2;
-   const auto y = (height - t.GetWidth()) / 2;
+   const auto y = height - t.GetWidth() - 5;
    dc.DrawRotatedText(text, x, y, 270);
 
    gc->SetPen(lineColor);

--- a/src/effects/CompressionMeterPanel.cpp
+++ b/src/effects/CompressionMeterPanel.cpp
@@ -9,16 +9,69 @@
 
 **********************************************************************/
 #include "CompressionMeterPanel.h"
+#include "CompressorInstance.h"
 #include "DynamicRangeProcessorPanelCommon.h"
+#include <algorithm>
 #include <wx/dcclient.h>
+#include <wx/graphics.h>
+
+namespace
+{
+using namespace DynamicRangeProcessorPanel;
+
+constexpr auto timerId = 7000;
+constexpr auto decayPerSecondDb = 10.f;
+constexpr auto decayPerTickDb =
+   decayPerSecondDb * CompressionMeterPanel::timerPeriodMs / 1000.f;
+// An overestimate: 44.1kHz and 512 samples per buffer, in frames per second,
+// would be 86.13.
+constexpr auto audioFramePerSec = 200;
+constexpr auto ticksPerSec = 1000 / CompressionMeterPanel::timerPeriodMs;
+// This will be set as max size for the lock-free queue.
+constexpr auto audioFramesPerTick = audioFramePerSec / ticksPerSec;
+
+constexpr auto w = 0.4;
+const wxColor compressionColor { 255, 219, 0 };
+const wxColor compressionMaxColor = compressionColor.ChangeLightness(70);
+const wxColor startColor = GetColorMix(backgroundColor, compressionColor, w);
+} // namespace
 
 BEGIN_EVENT_TABLE(CompressionMeterPanel, wxPanelWrapper)
 EVT_PAINT(CompressionMeterPanel::OnPaint)
+EVT_TIMER(timerId, CompressionMeterPanel::OnTimer)
 END_EVENT_TABLE()
 
-CompressionMeterPanel::CompressionMeterPanel(wxWindow* parent, wxWindowID winid)
-    : wxPanelWrapper { parent, winid }
+CompressionMeterPanel::CompressionMeterPanel(
+   wxWindow* parent, CompressorInstance& instance)
+    : wxPanelWrapper { parent, wxID_ANY }
+    , mCompressorInstance { instance }
+    , mCompressionValueQueue { std::make_unique<LockFreeQueue<float>>(
+         audioFramesPerTick) }
+    , mPlaybackStartStopSubscription {
+       static_cast<InitializeProcessingSettingsPublisher&>(instance).Subscribe(
+          [&](const std::optional<InitializeProcessingSettings>& evt) {
+             if (evt)
+                Reset();
+             else
+                mStopWhenZero = true;
+          })
+    }
 {
+   if (instance.GetSampleRate().has_value())
+      // Playback is ongoing, and so the `InitializeProcessingSettings` event
+      // was already fired.
+      Reset();
+   mCompressorInstance.SetCompressionValueQueue(mCompressionValueQueue);
+   mTimer.SetOwner(this, timerId);
+   SetDoubleBuffered(true);
+}
+
+void CompressionMeterPanel::Reset()
+{
+   mCompressionYMax = 0;
+   mCompressionRingBuffer.fill(0);
+   mStopWhenZero = false;
+   mTimer.Start(timerPeriodMs);
 }
 
 void CompressionMeterPanel::OnPaint(wxPaintEvent& evt)
@@ -27,19 +80,78 @@ void CompressionMeterPanel::OnPaint(wxPaintEvent& evt)
 
    wxPaintDC dc(this);
 
-   // Just plain background for now
-   dc.SetPen(lineColor);
-   dc.SetBrush(backgroundColor);
-   dc.DrawRectangle(GetClientRect());
+   const auto gc = MakeGraphicsContext(dc);
+
+   const auto width = GetSize().GetWidth();
+   const auto height = GetSize().GetHeight();
+   const auto frac =
+      std::clamp(-mSmoothedCompressionDb / compressorMeterRangeDb, 0., 1.);
+   const auto compressionY = height * frac;
+
+   mCompressionYMax = std::max(mCompressionYMax, compressionY);
+   const auto fracMax = mCompressionYMax / height;
+
+   gc->SetPen(wxNullPen);
+   gc->SetBrush(gc->CreateLinearGradientBrush(
+      0, 0, 0, height, startColor, compressionColor));
+   gc->DrawRectangle(0, 0, width, compressionY);
+   gc->SetBrush(backgroundColor);
+   gc->DrawRectangle(0, compressionY, width, height - compressionY);
+
+   const auto compressionLineColor =
+      GetColorMix(compressionMaxColor, startColor, frac);
+   gc->SetPen(wxPen { compressionLineColor, 2 });
+   gc->StrokeLine(0, compressionY, width, compressionY);
+   const auto maxCompressionLineColor =
+      GetColorMix(compressionMaxColor, startColor, fracMax);
+   gc->SetPen(wxPen { maxCompressionLineColor, 2 });
+   gc->StrokeLine(0, mCompressionYMax, width, mCompressionYMax);
 
    dc.SetFont(
       { 12, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL });
    dc.SetTextForeground({ 128, 128, 128 });
    const auto text = XO("compression").Translation();
    const auto t = dc.GetTextExtent(text);
-   const auto x = (GetClientSize().GetWidth() + t.GetHeight()) / 2;
-   const auto y = (GetClientSize().GetHeight() - t.GetWidth()) / 2;
+   const auto x = (width + t.GetHeight()) / 2;
+   const auto y = (height - t.GetWidth()) / 2;
    dc.DrawRotatedText(text, x, y, 270);
+
+   gc->SetPen(lineColor);
+   gc->SetBrush(wxNullBrush);
+   gc->DrawRectangle(0, 0, width, height);
+}
+
+void CompressionMeterPanel::OnTimer(wxTimerEvent& evt)
+{
+   const auto lastCompression =
+      mCompressionRingBuffer[mCompressionRingBufferIndex];
+
+   // Take the max of all values newly pushed by the audio frames - make sure we
+   // don't miss a peak.
+   auto compression = 0.f;
+   auto maxCompression = 0.f;
+   while (mCompressionValueQueue->Get(compression))
+      maxCompression = std::min(compression, maxCompression);
+
+   mCompressionRingBuffer[mCompressionRingBufferIndex] = maxCompression;
+   mCompressionRingBufferIndex =
+      (mCompressionRingBufferIndex + 1) % ringBufferLength;
+
+   if (lastCompression < mSmoothedCompressionDb)
+      mSmoothedCompressionDb = lastCompression;
+   else
+      mSmoothedCompressionDb =
+         std::min(0., mSmoothedCompressionDb + decayPerTickDb);
+
+   Refresh(false);
+
+   if (mSmoothedCompressionDb == 0 && mStopWhenZero)
+   {
+      // Decay is complete. Until playback starts again, no need for
+      // timer-triggered updates.
+      mTimer.Stop();
+      mStopWhenZero = false;
+   }
 }
 
 bool CompressionMeterPanel::AcceptsFocus() const

--- a/src/effects/CompressionMeterPanel.cpp
+++ b/src/effects/CompressionMeterPanel.cpp
@@ -1,0 +1,53 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CompressionMeterPanel.cpp
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#include "CompressionMeterPanel.h"
+#include "DynamicRangeProcessorPanelCommon.h"
+#include <wx/dcclient.h>
+
+BEGIN_EVENT_TABLE(CompressionMeterPanel, wxPanelWrapper)
+EVT_PAINT(CompressionMeterPanel::OnPaint)
+END_EVENT_TABLE()
+
+CompressionMeterPanel::CompressionMeterPanel(wxWindow* parent, wxWindowID winid)
+    : wxPanelWrapper { parent, winid }
+{
+}
+
+void CompressionMeterPanel::OnPaint(wxPaintEvent& evt)
+{
+   using namespace DynamicRangeProcessorPanel;
+
+   wxPaintDC dc(this);
+
+   // Just plain background for now
+   dc.SetPen(lineColor);
+   dc.SetBrush(backgroundColor);
+   dc.DrawRectangle(GetClientRect());
+
+   dc.SetFont(
+      { 12, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL });
+   dc.SetTextForeground({ 128, 128, 128 });
+   const auto text = XO("compression").Translation();
+   const auto t = dc.GetTextExtent(text);
+   const auto x = (GetClientSize().GetWidth() + t.GetHeight()) / 2;
+   const auto y = (GetClientSize().GetHeight() - t.GetWidth()) / 2;
+   dc.DrawRotatedText(text, x, y, 270);
+}
+
+bool CompressionMeterPanel::AcceptsFocus() const
+{
+   return false;
+}
+
+bool CompressionMeterPanel::AcceptsFocusFromKeyboard() const
+{
+   return false;
+}

--- a/src/effects/CompressionMeterPanel.h
+++ b/src/effects/CompressionMeterPanel.h
@@ -10,6 +10,7 @@
 **********************************************************************/
 #pragma once
 
+#include "DynamicRangeProcessorPanelCommon.h"
 #include "DynamicRangeProcessorTypes.h"
 #include "LockFreeQueue.h"
 #include "Observer.h"
@@ -36,10 +37,14 @@ private:
    static constexpr auto displayDelayMs = 100;
    static constexpr auto ringBufferLength = displayDelayMs / timerPeriodMs;
 
+   static constexpr auto outputColBottomValue =
+      -DynamicRangeProcessorPanel::compressorMeterRangeDb;
+
    void Reset();
    void PaintRectangle(
-      wxPaintDC& dc, const wxRect& rect, double value, double& yMax,
-      const TranslatableString& label);
+      wxPaintDC& dc, const wxRect& rect, double dB, double maxDb, bool upwards);
+   void PaintLabel(
+      wxPaintDC& dc, const wxRect& rect, const TranslatableString& label);
 
    void OnPaint(wxPaintEvent& evt);
    void OnTimer(wxTimerEvent& evt);
@@ -54,8 +59,8 @@ private:
    wxTimer mTimer;
    MeterValues mSmoothedValues;
    bool mStopWhenZero = false;
-   double mCompressionYMax = 0;
-   double mOutputYMax = 0;
-   std::array<double, ringBufferLength> mCompressionRingBuffer;
-   size_t mCompressionRingBufferIndex = 0;
+   float mCompressionColMin = 0;
+   float mOutputColMax = outputColBottomValue;
+   std::array<MeterValues, ringBufferLength> mRingBuffer;
+   size_t mRingBufferIndex = 0;
 };

--- a/src/effects/CompressionMeterPanel.h
+++ b/src/effects/CompressionMeterPanel.h
@@ -10,19 +10,46 @@
 **********************************************************************/
 #pragma once
 
+#include "LockFreeQueue.h"
+#include "Observer.h"
 #include "wxPanelWrapper.h"
+#include <array>
+#include <wx/timer.h>
+
+class CompressorInstance;
 
 class CompressionMeterPanel final : public wxPanelWrapper
 {
 public:
-   CompressionMeterPanel(wxWindow* parent, wxWindowID winid);
+   CompressionMeterPanel(wxWindow* parent, CompressorInstance& instance);
+
+   static constexpr auto timerPeriodMs = 1000 / 30;
 
    DECLARE_EVENT_TABLE();
 
 private:
+   //! The display tends to be earlier than the audio playback. We delay the
+   //! former by (approximately) this amount, for a tighter audiovisual
+   //! experience.
+   static constexpr auto displayDelayMs = 100;
+   static constexpr auto ringBufferLength = displayDelayMs / timerPeriodMs;
+
+   void Reset();
+
    void OnPaint(wxPaintEvent& evt);
+   void OnTimer(wxTimerEvent& evt);
 
    bool AcceptsFocus() const override;
    // So that wxPanel is not included in Tab traversal - see wxWidgets bug 15581
    bool AcceptsFocusFromKeyboard() const override;
+
+   CompressorInstance& mCompressorInstance;
+   const std::shared_ptr<LockFreeQueue<float>> mCompressionValueQueue;
+   const Observer::Subscription mPlaybackStartStopSubscription;
+   wxTimer mTimer;
+   double mSmoothedCompressionDb = 0;
+   bool mStopWhenZero = false;
+   double mCompressionYMax = 0;
+   std::array<double, ringBufferLength> mCompressionRingBuffer;
+   size_t mCompressionRingBufferIndex = 0;
 };

--- a/src/effects/CompressionMeterPanel.h
+++ b/src/effects/CompressionMeterPanel.h
@@ -1,0 +1,28 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CompressionMeterPanel.h
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#pragma once
+
+#include "wxPanelWrapper.h"
+
+class CompressionMeterPanel final : public wxPanelWrapper
+{
+public:
+   CompressionMeterPanel(wxWindow* parent, wxWindowID winid);
+
+   DECLARE_EVENT_TABLE();
+
+private:
+   void OnPaint(wxPaintEvent& evt);
+
+   bool AcceptsFocus() const override;
+   // So that wxPanel is not included in Tab traversal - see wxWidgets bug 15581
+   bool AcceptsFocusFromKeyboard() const override;
+};

--- a/src/effects/CompressionMeterPanel.h
+++ b/src/effects/CompressionMeterPanel.h
@@ -10,6 +10,7 @@
 **********************************************************************/
 #pragma once
 
+#include "DynamicRangeProcessorTypes.h"
 #include "LockFreeQueue.h"
 #include "Observer.h"
 #include "wxPanelWrapper.h"
@@ -17,6 +18,7 @@
 #include <wx/timer.h>
 
 class CompressorInstance;
+class wxPaintDC;
 
 class CompressionMeterPanel final : public wxPanelWrapper
 {
@@ -35,6 +37,9 @@ private:
    static constexpr auto ringBufferLength = displayDelayMs / timerPeriodMs;
 
    void Reset();
+   void PaintRectangle(
+      wxPaintDC& dc, const wxRect& rect, double value, double& yMax,
+      const TranslatableString& label);
 
    void OnPaint(wxPaintEvent& evt);
    void OnTimer(wxTimerEvent& evt);
@@ -43,13 +48,14 @@ private:
    // So that wxPanel is not included in Tab traversal - see wxWidgets bug 15581
    bool AcceptsFocusFromKeyboard() const override;
 
-   CompressorInstance& mCompressorInstance;
-   const std::shared_ptr<LockFreeQueue<float>> mCompressionValueQueue;
+   const std::shared_ptr<DynamicRangeProcessorMeterValuesQueue>
+      mMeterValuesQueue;
    const Observer::Subscription mPlaybackStartStopSubscription;
    wxTimer mTimer;
-   double mSmoothedCompressionDb = 0;
+   MeterValues mSmoothedValues;
    bool mStopWhenZero = false;
    double mCompressionYMax = 0;
+   double mOutputYMax = 0;
    std::array<double, ringBufferLength> mCompressionRingBuffer;
    size_t mCompressionRingBufferIndex = 0;
 };

--- a/src/effects/CompressorInstance.h
+++ b/src/effects/CompressorInstance.h
@@ -37,7 +37,8 @@ public:
    const std::optional<double>& GetSampleRate() const;
    float GetLatencyMs() const;
    void SetOutputQueue(std::weak_ptr<DynamicRangeProcessorOutputPacketQueue>);
-   void SetCompressionValueQueue(std::weak_ptr<LockFreeQueue<float>> queue);
+   void SetMeterValuesQueue(
+      std::weak_ptr<DynamicRangeProcessorMeterValuesQueue> queue);
 
 private:
    bool ProcessInitialize(
@@ -88,5 +89,5 @@ private:
    long long mSampleCounter = 0;
    std::optional<double> mSampleRate;
    std::weak_ptr<DynamicRangeProcessorOutputPacketQueue> mOutputQueue;
-   std::weak_ptr<LockFreeQueue<float>> mCompressionValueQueue;
+   std::weak_ptr<DynamicRangeProcessorMeterValuesQueue> mCompressionValueQueue;
 };

--- a/src/effects/CompressorInstance.h
+++ b/src/effects/CompressorInstance.h
@@ -37,6 +37,7 @@ public:
    const std::optional<double>& GetSampleRate() const;
    float GetLatencyMs() const;
    void SetOutputQueue(std::weak_ptr<DynamicRangeProcessorOutputPacketQueue>);
+   void SetCompressionValueQueue(std::weak_ptr<LockFreeQueue<float>> queue);
 
 private:
    bool ProcessInitialize(
@@ -87,4 +88,5 @@ private:
    long long mSampleCounter = 0;
    std::optional<double> mSampleRate;
    std::weak_ptr<DynamicRangeProcessorOutputPacketQueue> mOutputQueue;
+   std::weak_ptr<LockFreeQueue<float>> mCompressionValueQueue;
 };

--- a/src/effects/DynamicRangeProcessorEditor.cpp
+++ b/src/effects/DynamicRangeProcessorEditor.cpp
@@ -4,6 +4,7 @@
 #include "CompressionMeterPanel.h"
 #include "CompressorProcessor.h"
 #include "DynamicRangeProcessorHistoryPanel.h"
+#include "DynamicRangeProcessorPanelCommon.h"
 #include "DynamicRangeProcessorTransferFunctionPanel.h"
 #include "EffectInterface.h"
 #include "ShuttleGui.h"
@@ -261,12 +262,15 @@ void DynamicRangeProcessorEditor::PopulateLimiterUpperHalf(ShuttleGui& S)
             S.Prop(1)
                .Position(wxALIGN_LEFT | wxALIGN_TOP | wxEXPAND)
                .MinSize({ 30, height })
-               .AddWindow(safenew CompressionMeterPanel(mUIParent, wxID_ANY));
+               .AddWindow(safenew CompressionMeterPanel(
+                  mUIParent, mCompressorInstance));
 
             S.Prop(1)
                .Position(wxEXPAND | wxALIGN_TOP)
                .MinSize({ 30, height })
-               .AddWindow(MakeRulerPanel(mUIParent, wxVERTICAL, 60.0));
+               .AddWindow(MakeRulerPanel(
+                  mUIParent, wxVERTICAL,
+                  DynamicRangeProcessorPanel::compressorMeterRangeDb));
          }
          S.EndMultiColumn();
 

--- a/src/effects/DynamicRangeProcessorEditor.cpp
+++ b/src/effects/DynamicRangeProcessorEditor.cpp
@@ -240,7 +240,10 @@ void DynamicRangeProcessorEditor::PopulateLimiterUpperHalf(ShuttleGui& S)
       S.StartMultiColumn(3, wxEXPAND);
       {
          S.SetStretchyCol(0);
-         AddSliderSpaceAndMeterColums(S);
+
+         AddSliderPanel(S);
+         S.AddSpace(borderSize, 0);
+         AddCompressionMeterPanel(S);
       }
       S.EndMultiColumn();
    }
@@ -256,7 +259,10 @@ void DynamicRangeProcessorEditor::PopulateCompressorUpperHalf(
       S.StartMultiColumn(4, wxEXPAND);
       {
          S.SetStretchyCol(0);
-         AddSliderSpaceAndMeterColums(S);
+
+         AddSliderPanel(S);
+         S.AddSpace(borderSize, 0);
+         AddCompressionMeterPanel(S);
          AddCompressionCurvePanel(S, compressorSettings);
       }
       S.EndMultiColumn();
@@ -333,12 +339,8 @@ void DynamicRangeProcessorEditor::AddSliderPanel(ShuttleGui& S)
    S.EndPanel();
 }
 
-void DynamicRangeProcessorEditor::AddSliderSpaceAndMeterColums(ShuttleGui& S)
+void DynamicRangeProcessorEditor::AddCompressionMeterPanel(ShuttleGui& S)
 {
-   AddSliderPanel(S);
-
-   S.AddSpace(borderSize, 0);
-
    S.StartVerticalLay(0);
    {
       // Add vertical space above and below to align it with the slider

--- a/src/effects/DynamicRangeProcessorEditor.cpp
+++ b/src/effects/DynamicRangeProcessorEditor.cpp
@@ -1,6 +1,7 @@
 #include "DynamicRangeProcessorEditor.h"
 #include "AllThemeResources.h"
 #include "BasicUI.h"
+#include "CompressionMeterPanel.h"
 #include "CompressorProcessor.h"
 #include "DynamicRangeProcessorHistoryPanel.h"
 #include "DynamicRangeProcessorTransferFunctionPanel.h"
@@ -233,7 +234,47 @@ void DynamicRangeProcessorEditor::PopulateOrExchange(ShuttleGui& S)
 
 void DynamicRangeProcessorEditor::PopulateLimiterUpperHalf(ShuttleGui& S)
 {
-   AddSliders(S);
+   S.StartMultiColumn(3, wxEXPAND);
+   {
+      S.SetStretchyCol(0);
+      S.StartPanel();
+      {
+         AddSliders(S);
+      }
+      S.EndPanel();
+
+      S.AddSpace(borderSize, 0);
+
+      S.StartVerticalLay(0);
+      {
+         // Add vertical space above and below to align it with the slider
+         // static boxes.
+         S.AddSpace(0, 11);
+
+         S.SetSizerProportion(1);
+         S.StartMultiColumn(2, wxEXPAND);
+         {
+            S.SetStretchyCol(1);
+            S.SetStretchyRow(0);
+
+            constexpr auto height = 100;
+            S.Prop(1)
+               .Position(wxALIGN_LEFT | wxALIGN_TOP | wxEXPAND)
+               .MinSize({ 30, height })
+               .AddWindow(safenew CompressionMeterPanel(mUIParent, wxID_ANY));
+
+            S.Prop(1)
+               .Position(wxEXPAND | wxALIGN_TOP)
+               .MinSize({ 30, height })
+               .AddWindow(MakeRulerPanel(mUIParent, wxVERTICAL, 60.0));
+         }
+         S.EndMultiColumn();
+
+         S.AddSpace(0, 5);
+      }
+      S.EndVerticalLay();
+   }
+   S.EndMultiColumn();
 }
 
 void DynamicRangeProcessorEditor::PopulateCompressorUpperHalf(

--- a/src/effects/DynamicRangeProcessorEditor.h
+++ b/src/effects/DynamicRangeProcessorEditor.h
@@ -103,7 +103,9 @@ private:
    void PopulateLimiterUpperHalf(ShuttleGui& S);
    void PopulateCompressorUpperHalf(
       ShuttleGui& S, const CompressorSettings& compressorSettings);
-   void AddSliders(ShuttleGui& S);
+   void AddCompressionCurvePanel(ShuttleGui& S, const CompressorSettings&);
+   void AddSliderSpaceAndMeterColums(ShuttleGui& S);
+   void AddSliderPanel(ShuttleGui& S);
 
    virtual const CompressorSettings* GetCompressorSettings() const
    {

--- a/src/effects/DynamicRangeProcessorEditor.h
+++ b/src/effects/DynamicRangeProcessorEditor.h
@@ -104,7 +104,7 @@ private:
    void PopulateCompressorUpperHalf(
       ShuttleGui& S, const CompressorSettings& compressorSettings);
    void AddCompressionCurvePanel(ShuttleGui& S, const CompressorSettings&);
-   void AddSliderSpaceAndMeterColums(ShuttleGui& S);
+   void AddCompressionMeterPanel(ShuttleGui& S);
    void AddSliderPanel(ShuttleGui& S);
 
    virtual const CompressorSettings* GetCompressorSettings() const

--- a/src/effects/DynamicRangeProcessorEditor.h
+++ b/src/effects/DynamicRangeProcessorEditor.h
@@ -100,6 +100,11 @@ public:
    void PopulateOrExchange(ShuttleGui& S);
 
 private:
+   void PopulateLimiterUpperHalf(ShuttleGui& S);
+   void PopulateCompressorUpperHalf(
+      ShuttleGui& S, const CompressorSettings& compressorSettings);
+   void AddSliders(ShuttleGui& S);
+
    virtual const CompressorSettings* GetCompressorSettings() const
    {
       return nullptr;

--- a/src/effects/DynamicRangeProcessorHistoryPanel.cpp
+++ b/src/effects/DynamicRangeProcessorHistoryPanel.cpp
@@ -405,11 +405,7 @@ void DynamicRangeProcessorHistoryPanel::OnPaint(wxPaintEvent& evt)
          // Paint output first with opaque color.
          constexpr auto w = .4;
          // Circle color.
-         const wxColor cCol(
-            backgroundColor.Red() * w + outputColor.Red() * (1 - w),
-            backgroundColor.Green() * w + outputColor.Green() * (1 - w),
-            backgroundColor.Blue() * w + outputColor.Blue() * (1 - w),
-            backgroundColor.Alpha() * w + outputColor.Alpha() * (1 - w));
+         const wxColor cCol = GetColorMix(backgroundColor, outputColor, w);
          const auto xo = width * 0.9; // "o" for "origin"
          const auto yo = height * 0.1;
          const auto xf = width * 0.5; // "f" for "focus"

--- a/src/effects/DynamicRangeProcessorPanelCommon.cpp
+++ b/src/effects/DynamicRangeProcessorPanelCommon.cpp
@@ -22,4 +22,13 @@ std::unique_ptr<wxGraphicsContext> MakeGraphicsContext(const wxPaintDC& dc)
    gc->SetInterpolationQuality(wxINTERPOLATION_BEST);
    return std::unique_ptr<wxGraphicsContext>(gc);
 }
+
+wxColor GetColorMix(const wxColor& a, const wxColor& b, double aWeight)
+{
+   return wxColor(
+      a.Red() * aWeight + b.Red() * (1 - aWeight),
+      a.Green() * aWeight + b.Green() * (1 - aWeight),
+      a.Blue() * aWeight + b.Blue() * (1 - aWeight),
+      a.Alpha() * aWeight + b.Alpha() * (1 - aWeight));
+}
 } // namespace DynamicRangeProcessorPanel

--- a/src/effects/DynamicRangeProcessorPanelCommon.h
+++ b/src/effects/DynamicRangeProcessorPanelCommon.h
@@ -23,5 +23,9 @@ static const wxColour attackColor { 255, 0, 0, 100 };
 static const wxColour releaseColor { 190, 120, 255, 100 };
 static const wxColour lineColor { 96, 96, 96 };
 
+static constexpr auto compressorMeterRangeDb = 20.f;
+
 std::unique_ptr<wxGraphicsContext> MakeGraphicsContext(const wxPaintDC& dc);
+
+wxColor GetColorMix(const wxColor& a, const wxColor& b, double aWeight);
 } // namespace DynamicRangeProcessorPanel

--- a/src/effects/DynamicRangeProcessorPanelCommon.h
+++ b/src/effects/DynamicRangeProcessorPanelCommon.h
@@ -23,7 +23,7 @@ static const wxColour attackColor { 255, 0, 0, 100 };
 static const wxColour releaseColor { 190, 120, 255, 100 };
 static const wxColour lineColor { 96, 96, 96 };
 
-static constexpr auto compressorMeterRangeDb = 20.f;
+static constexpr auto compressorMeterRangeDb = 12.f;
 
 std::unique_ptr<wxGraphicsContext> MakeGraphicsContext(const wxPaintDC& dc);
 


### PR DESCRIPTION
Resolves: #6510

At the time of writing, results in
![image](https://github.com/audacity/audacity/assets/22740106/7bd5e7f2-0dab-4d38-99c7-f9274711dd72)
![image](https://github.com/audacity/audacity/assets/22740106/d26ca0e1-3a59-4c41-8d89-e68046fcd399)
![image](https://github.com/audacity/audacity/assets/22740106/e020b21e-0bcb-490f-ad60-cc77a5c60a5c)
![image](https://github.com/audacity/audacity/assets/22740106/607ef618-e636-4a19-b2c0-c843a3e26716)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

Some ideas for QA:
- [x] Animated elements (meter and graph) are only visible in realtime limiter and compressor
- [x] Compression curve is only visible in compressor
- [x] Interactions with playback and bypass buttons work (e.g. open before playback start, open during playback, open while bypassed, etc.)