### PR TITLE
6618 audiocom redirect tagging

### DIFF
--- a/libraries/lib-cloud-audiocom/OAuthService.h
+++ b/libraries/lib-cloud-audiocom/OAuthService.h
@@ -18,6 +18,8 @@
 
 #include "Observer.h"
 
+enum class AudiocomTrace;
+
 namespace audacity::cloud::audiocom
 {
 class ServiceConfig;
@@ -29,6 +31,7 @@ struct CLOUD_AUDIOCOM_API AuthStateChangedMessage final
    std::string_view accessToken;
    //! Error message returned by the server in case of oauth error.
    std::string_view errorMessage;
+   AudiocomTrace trace;
    //! Flag that indicates if user is authorised.
    bool authorised;
    bool silent;
@@ -56,7 +59,9 @@ public:
 
       Callback argument will contain an access token, if any, or an empty view.
    */
-   void ValidateAuth(std::function<void(std::string_view)> completedHandler, bool silent);
+   void ValidateAuth(
+      std::function<void(std::string_view)> completedHandler, AudiocomTrace,
+      bool silent);
 
    //! Handle the OAuth callback
    /*
@@ -71,11 +76,11 @@ public:
       \returns true if the URL was handled, false otherwise.
    */
    bool HandleLinkURI(
-      std::string_view uri,
+      std::string_view uri, AudiocomTrace,
       std::function<void(std::string_view)> completedHandler);
 
    //! Removes access and refresh token, notifies about the logout.
-   void UnlinkAccount();
+   void UnlinkAccount(AudiocomTrace);
 
    //! Return the current access token, if any.
    std::string GetAccessToken() const;
@@ -83,23 +88,24 @@ public:
 private:
    void AuthorisePassword(
       const ServiceConfig& config, std::string_view userName,
-      std::string_view password,
+      std::string_view password, AudiocomTrace,
       std::function<void(std::string_view)> completedHandler);
 
    void AuthoriseRefreshToken(
       const ServiceConfig& config, std::string_view refreshToken,
-      std::function<void(std::string_view)> completedHandler, bool silent);
+      AudiocomTrace, std::function<void(std::string_view)> completedHandler,
+      bool silent);
 
    void AuthoriseRefreshToken(
-      const ServiceConfig& config,
+      const ServiceConfig& config, AudiocomTrace,
       std::function<void(std::string_view)> completedHandler, bool silent);
 
    void AuthoriseCode(
       const ServiceConfig& config, std::string_view authorizationCode,
-      std::function<void(std::string_view)> completedHandler);
+      AudiocomTrace, std::function<void(std::string_view)> completedHandler);
 
    void DoAuthorise(
-      const ServiceConfig& config, std::string_view payload,
+      const ServiceConfig& config, std::string_view payload, AudiocomTrace,
       std::function<void(std::string_view)> completedHandler, bool silent);
 
    void SafePublish(const AuthStateChangedMessage& message);

--- a/libraries/lib-cloud-audiocom/ServiceConfig.h
+++ b/libraries/lib-cloud-audiocom/ServiceConfig.h
@@ -15,6 +15,8 @@
 #include <vector>
 #include <rapidjson/fwd.h>
 
+enum class AudiocomTrace;
+
 namespace audacity::cloud::audiocom
 {
 
@@ -26,7 +28,7 @@ public:
    //! API endpoint
    std::string GetAPIEndpoint() const;
    //! Page to open in browser to initiate OAuth
-   std::string GetOAuthLoginPage() const;
+   std::string GetOAuthLoginPage(AudiocomTrace) const;
    //! OAuth2 client ID
    std::string GetOAuthClientID() const;
    //! OAuth2 client secret
@@ -36,9 +38,13 @@ public:
    //! Helper to construct the full URLs for the API
    std::string GetAPIUrl(std::string_view apiURI) const;
    //! Helper to construct the page URL for the anonymous upload last stage
-   std::string GetFinishUploadPage(std::string_view audioID, std::string_view token) const;
+   std::string GetFinishUploadPage(
+      std::string_view audioID, std::string_view token,
+      AudiocomTrace) const;
    //! Helper to construct the page URL for the authorised upload
-   std::string GetAudioURL(std::string_view userSlug, std::string_view audioSlug) const;
+   std::string GetAudioURL(
+      std::string_view userSlug, std::string_view audioSlug,
+      AudiocomTrace) const;
    //! Timeout between progress callbacks
    std::chrono::milliseconds GetProgressCallbackTimeout() const;
    //! Preferred audio format
@@ -64,10 +70,11 @@ public:
       std::string_view projectId, std::string_view snapshotId) const;
 
    std::string GetNetworkStatsUrl(std::string_view projectId) const;
+   std::string GetProjectPageUrl(
+      std::string_view userId, std::string_view projectId,
+      AudiocomTrace) const;
    std::string
-   GetProjectPageUrl(std::string_view userId, std::string_view projectId) const;
-   std::string
-   GetProjectsPageUrl(std::string_view userId) const;
+   GetProjectsPageUrl(std::string_view userId, AudiocomTrace) const;
 
 private:
    std::string mApiEndpoint;

--- a/libraries/lib-cloud-audiocom/UploadService.h
+++ b/libraries/lib-cloud-audiocom/UploadService.h
@@ -18,6 +18,8 @@
 
 #include <wx/string.h>
 
+enum class AudiocomTrace;
+
 namespace audacity::cloud::audiocom
 {
 class ServiceConfig;
@@ -141,7 +143,8 @@ public:
    */
    UploadOperationHandle Upload(
       const wxString& fileName, const wxString& projectName, bool isPublic,
-      CompletedCallback completedCallback, ProgressCallback progressCallback);
+      CompletedCallback completedCallback, ProgressCallback progressCallback,
+      AudiocomTrace);
 
 private:
    const ServiceConfig& mServiceConfig;

--- a/libraries/lib-cloud-audiocom/sync/LocalProjectSnapshot.h
+++ b/libraries/lib-cloud-audiocom/sync/LocalProjectSnapshot.h
@@ -25,6 +25,7 @@
 #include "concurrency/CancellationContext.h"
 
 class AudacityProject;
+enum class AudiocomTrace;
 
 namespace audacity::cloud::audiocom
 {
@@ -64,12 +65,14 @@ public:
 
    LocalProjectSnapshot(
       Tag, const ServiceConfig& config, const OAuthService& oauthService,
-      ProjectCloudExtension& extension, std::string name, UploadMode mode);
+      ProjectCloudExtension& extension, std::string name, UploadMode mode,
+      AudiocomTrace trace);
    ~LocalProjectSnapshot() override;
 
    static Future Create(
       const ServiceConfig& config, const OAuthService& oauthService,
-      ProjectCloudExtension& extension, std::string name, UploadMode mode);
+      ProjectCloudExtension& extension, std::string name, UploadMode mode,
+      AudiocomTrace trace);
 
    bool IsCompleted() const override;
 
@@ -103,6 +106,7 @@ private:
 
    const ServiceConfig& mServiceConfig;
    const OAuthService& mOAuthService;
+   const AudiocomTrace mAudiocomTrace;
 
    std::string mProjectName;
 

--- a/libraries/lib-cloud-audiocom/sync/ProjectCloudExtension.cpp
+++ b/libraries/lib-cloud-audiocom/sync/ProjectCloudExtension.cpp
@@ -28,6 +28,7 @@
 #include "ProjectSerializer.h"
 
 #include "BasicUI.h"
+#include "ExportUtils.h"
 
 #include "MemoryX.h"
 
@@ -281,7 +282,7 @@ void ProjectCloudExtension::OnBlockUploaded(
 
 void ProjectCloudExtension::OnSyncCompleted(
    const ProjectUploadOperation* uploadOperation,
-   std::optional<CloudSyncError> error)
+   std::optional<CloudSyncError> error, AudiocomTrace trace)
 {
    auto lock = std::lock_guard { mUploadQueueMutex };
 
@@ -337,14 +338,18 @@ void ProjectCloudExtension::OnSyncCompleted(
    MarkProjectSynced(!error.has_value());
 
    Publish(
-      { error.has_value() ? ProjectSyncStatus::Failed :
+      { trace,
+        error.has_value() ? ProjectSyncStatus::Failed :
                             ProjectSyncStatus::Synced,
         {},
         error },
       false);
 
    if (!IsCloudProject())
-      Publish({ ProjectSyncStatus::Local }, false);
+      Publish(
+         { AudiocomTrace::ignore, // All right
+           ProjectSyncStatus::Local },
+         false);
 }
 
 void ProjectCloudExtension::CancelSync()
@@ -437,7 +442,10 @@ void ProjectCloudExtension::OnUpdateSaved(const ProjectSerializer& serializer)
       }
    }
    else
-      Publish({ ProjectSyncStatus::Failed }, false);
+      Publish(
+         { AudiocomTrace::ignore, // TODO Is this correct ?
+           ProjectSyncStatus::Failed },
+         false);
 }
 
 std::weak_ptr<AudacityProject> ProjectCloudExtension::GetProject() const
@@ -489,6 +497,8 @@ void ProjectCloudExtension::UpdateIdFromDatabase()
 
    Publish(
       {
+         AudiocomTrace::ignore, // OK here because we're not publishing an
+                                 // error
          projectData->SyncStatus ==
                DBProjectData::SyncStatusType::SyncStatusSynced ?
             ProjectSyncStatus::Synced :
@@ -515,7 +525,8 @@ void ProjectCloudExtension::UnsafeUpdateProgress()
    assert(totalElements > 0);
 
    Publish(
-      { ProjectSyncStatus::Syncing,
+      { AudiocomTrace::ignore, // All right
+        ProjectSyncStatus::Syncing,
         double(handledElements) / double(totalElements) },
       true);
 }
@@ -608,10 +619,11 @@ void ProjectCloudExtension::OnProjectPathChanged()
    UpdateIdFromDatabase();
 
    if (mProjectId.empty() && wasCloudProject)
-      Publish({ ProjectSyncStatus::Local }, false);
+      Publish({ AudiocomTrace::ignore, ProjectSyncStatus::Local }, false);
 }
 
-std::string ProjectCloudExtension::GetCloudProjectPage() const
+std::string
+ProjectCloudExtension::GetCloudProjectPage(AudiocomTrace trace) const
 {
    const auto projectId =
       ProjectCloudExtension::Get(mProject).GetCloudProjectId();
@@ -619,7 +631,7 @@ std::string ProjectCloudExtension::GetCloudProjectPage() const
    const auto userSlug =
       CloudProjectsDatabase::Get().GetProjectUserSlug(projectId);
 
-   return GetServiceConfig().GetProjectPageUrl(userSlug, projectId);
+   return GetServiceConfig().GetProjectPageUrl(userSlug, projectId, trace);
 }
 
 bool ProjectCloudExtension::IsBlockLocked(int64_t blockID) const

--- a/libraries/lib-cloud-audiocom/sync/ProjectCloudExtension.h
+++ b/libraries/lib-cloud-audiocom/sync/ProjectCloudExtension.h
@@ -30,6 +30,8 @@
 class AudacityProject;
 class ProjectSerializer;
 
+enum class AudiocomTrace;
+
 namespace audacity::cloud::audiocom::sync
 {
 class ProjectUploadOperation;
@@ -45,6 +47,7 @@ enum class ProjectSyncStatus
 
 struct CLOUD_AUDIOCOM_API CloudStatusChangedMessage final
 {
+   AudiocomTrace audiocomTrace;
    ProjectSyncStatus Status { ProjectSyncStatus::Local };
    double Progress {};
    std::optional<CloudSyncError> Error {};
@@ -89,7 +92,7 @@ public:
    //! This method is called from any thread
    void OnSyncCompleted(
       const ProjectUploadOperation* uploadOperation,
-      std::optional<CloudSyncError> error);
+      std::optional<CloudSyncError> error, AudiocomTrace trace);
 
    void AbortLastUploadOperation();
 
@@ -110,7 +113,7 @@ public:
       std::function<void(const CloudStatusChangedMessage&)> callback,
       bool onUIThread);
 
-   std::string GetCloudProjectPage() const;
+   std::string GetCloudProjectPage(AudiocomTrace) const;
 
    bool IsBlockLocked(int64_t blockID) const;
 

--- a/libraries/lib-cloud-audiocom/sync/ResumedSnaphotUploadOperation.cpp
+++ b/libraries/lib-cloud-audiocom/sync/ResumedSnaphotUploadOperation.cpp
@@ -25,6 +25,7 @@
 #include "ProjectUploadOperation.h"
 #include "ServiceConfig.h"
 
+#include "ExportUtils.h"
 #include "SampleBlock.h"
 #include "WaveTrack.h"
 
@@ -171,13 +172,15 @@ private:
    void CompleteSync()
    {
       if (!mCompleted.exchange(true))
-         mProjectCloudExtension.OnSyncCompleted(this, {});
+         mProjectCloudExtension.OnSyncCompleted(
+            this, {}, AudiocomTrace::ProjectOpenedAndUploadResumed);
    }
 
    void FailSync(CloudSyncError error)
    {
       if (!mCompleted.exchange(true))
-         mProjectCloudExtension.OnSyncCompleted(this, error);
+         mProjectCloudExtension.OnSyncCompleted(
+            this, error, AudiocomTrace::ProjectOpenedAndUploadResumed);
    }
 
    void FailSync(ResponseResult result)
@@ -442,7 +445,7 @@ private:
 
 void ResumeProjectUpload(
    ProjectCloudExtension& projectCloudExtension,
-   std::function<void()> onBeforeUploadStarts)
+   std::function<void(AudiocomTrace)> onBeforeUploadStarts)
 {
    auto& cloudProjectsDatabase = CloudProjectsDatabase::Get();
 
@@ -450,7 +453,7 @@ void ResumeProjectUpload(
       projectCloudExtension.GetCloudProjectId());
 
    if (!pendingSnapshots.empty() && onBeforeUploadStarts)
-      onBeforeUploadStarts();
+      onBeforeUploadStarts(AudiocomTrace::ProjectOpenedAndUploadResumed);
 
    for (const auto& snapshot : pendingSnapshots)
       ResumedSnaphotUploadOperation::Perform(

--- a/libraries/lib-cloud-audiocom/sync/ResumedSnaphotUploadOperation.h
+++ b/libraries/lib-cloud-audiocom/sync/ResumedSnaphotUploadOperation.h
@@ -13,12 +13,14 @@
 
 #include <functional>
 
+enum class AudiocomTrace;
+
 namespace audacity::cloud::audiocom::sync
 {
 class ProjectCloudExtension;
 
 void CLOUD_AUDIOCOM_API ResumeProjectUpload(
    ProjectCloudExtension& projectCloudExtension,
-   std::function<void()> onBeforeUploadStarts);
+   std::function<void(AudiocomTrace)> onBeforeUploadStarts);
 
 } // namespace audacity::cloud::audiocom::sync

--- a/libraries/lib-import-export/ExportUtils.cpp
+++ b/libraries/lib-import-export/ExportUtils.cpp
@@ -5,7 +5,7 @@
   ExportUtils.cpp
 
   Dominic Mazzoni
- 
+
   Vitaly Sverchinsky split from ExportPlugin.h
 
 **********************************************************************/
@@ -76,12 +76,15 @@ void ExportUtils::RegisterExportHook(ExportHook hook, Priority priority)
 }
 
 void ExportUtils::PerformInteractiveExport(
-   AudacityProject& project, const FileExtension& format, bool selectedOnly)
+   AudacityProject& project, const FileExtension& format, AudiocomTrace trace,
+   bool selectedOnly)
 {
    auto& hooks = ExportHooks();
    for (auto& hook : hooks)
    {
-      if(hook.hook(project, format, selectedOnly) != ExportHookResult::Continue)
+      if (
+         hook.hook(project, format, trace, selectedOnly) !=
+         ExportHookResult::Continue)
          return;
    }
 }

--- a/libraries/lib-import-export/ExportUtils.h
+++ b/libraries/lib-import-export/ExportUtils.h
@@ -3,7 +3,7 @@
   Audacity: A Digital Audio Editor
 
   ExportUtils.h
- 
+
   Dominic Mazzoni
 
   Vitaly Sverchinsky split from ExportPlugin.h
@@ -23,6 +23,23 @@ class WaveTrack;
 
 template <typename TrackType> struct TrackIterRange;
 
+enum class AudiocomTrace
+{
+   ignore,
+   ShareAudioButton,
+   ShareAudioMenu,
+   ShareAudioExportMenu,
+   ShareAudioExportExtraMenu,
+   SaveToCloudMenu,
+   SaveProjectSaveToCloudMenu, // user chose "Save Project" and then saw the
+                               // dialog and chose "Save to Cloud"
+   PrefsPanel, // The Cloud preference panel also has a "Link Account" button
+   ProjectOpenedAndUploadResumed,
+   UpdateCloudAudioPreviewMenu,
+   LinkAudiocomAccountHelpMenu,
+   OpenFromCloudMenu,
+};
+
 class IMPORT_EXPORT_API ExportUtils final
 {
 public:
@@ -35,17 +52,21 @@ public:
 
    enum class ExportHookResult
    {
-      Handled, 
+      Handled,
       Continue,
       Cancel,
    };
 
-   using ExportHook = std::function<ExportHookResult(AudacityProject&, const FileExtension&, bool)>;
+   using ExportHook = std::function<ExportHookResult(
+      AudacityProject&, const FileExtension&,
+      AudiocomTrace, bool)>;
 
    using Priority = unsigned;
    static constexpr Priority DEFAULT_EXPORT_HOOK_PRIORITY = 0;
 
    static void RegisterExportHook(ExportHook hook, Priority = DEFAULT_EXPORT_HOOK_PRIORITY);
-   static void PerformInteractiveExport(AudacityProject& project, const FileExtension& format, bool selectedOnly);
+   static void PerformInteractiveExport(
+      AudacityProject& project, const FileExtension& format,
+      AudiocomTrace trace, bool selectedOnly);
 };
 

--- a/modules/sharing/mod-cloud-audiocom/AuthorizationHandler.h
+++ b/modules/sharing/mod-cloud-audiocom/AuthorizationHandler.h
@@ -16,6 +16,7 @@
 #include "TranslatableString.h"
 
 class AudacityProject;
+enum class AudiocomTrace;
 
 namespace audacity::cloud::audiocom
 {
@@ -53,6 +54,7 @@ struct AuthResult final
    std::string ErrorMessage;
 };
 
-AuthResult
-PerformBlockingAuth(AudacityProject* project, const TranslatableString& alternativeActionLabel = {});
+AuthResult PerformBlockingAuth(
+   AudacityProject* project, AudiocomTrace trace,
+   const TranslatableString& alternativeActionLabel = {});
 } // namespace audacity::cloud::audiocom

--- a/modules/sharing/mod-cloud-audiocom/CloudProjectOpenUtils.h
+++ b/modules/sharing/mod-cloud-audiocom/CloudProjectOpenUtils.h
@@ -15,6 +15,8 @@
 
 class AudacityProject;
 
+enum class AudiocomTrace;
+
 namespace audacity::cloud::audiocom::sync
 {
 AudacityProject* GetPotentialTarget();
@@ -25,7 +27,8 @@ AudacityProject* OpenProjectFromCloud(
    std::string_view snapshotId, bool forceNew);
 
 bool SyncCloudProject(
-   AudacityProject& project, std::string_view path, bool force = false);
+   AudacityProject& project, std::string_view path, AudiocomTrace,
+   bool force = false);
 
 bool HandleProjectLink(std::string_view link);
 

--- a/modules/sharing/mod-cloud-audiocom/LinkUrlHandler.cpp
+++ b/modules/sharing/mod-cloud-audiocom/LinkUrlHandler.cpp
@@ -13,6 +13,7 @@
 
 #include "CloudProjectMixdownUtils.h"
 #include "CloudProjectOpenUtils.h"
+#include "ExportUtils.h"
 #include "OAuthService.h"
 
 namespace
@@ -22,7 +23,10 @@ auto subscription = URLSchemesRegistry::Get().Subscribe(
    {
       using namespace audacity::cloud::audiocom;
 
-      if (GetOAuthService().HandleLinkURI(message.url, {}))
+      if (GetOAuthService().HandleLinkURI(
+             message.url,
+             // TODO Is this correct?
+             AudiocomTrace::ignore, {}))
          return;
 
       if (sync::HandleProjectLink(message.url))

--- a/modules/sharing/mod-cloud-audiocom/menus/AudioComMenus.cpp
+++ b/modules/sharing/mod-cloud-audiocom/menus/AudioComMenus.cpp
@@ -13,6 +13,7 @@
 #include "CloudProjectFileIOExtensions.h"
 #include "CloudProjectMixdownUtils.h"
 #include "CommandContext.h"
+#include "ExportUtils.h"
 #include "MenuRegistry.h"
 
 #include "sync/MixdownUploader.h"
@@ -55,7 +56,8 @@ void OnUpdateMixdown(const CommandContext& context)
          auto& projectCloudExtension = ProjectCloudExtension::Get(project);
 
          BasicUI::OpenInDefaultBrowser(
-            projectCloudExtension.GetCloudProjectPage());
+            projectCloudExtension.GetCloudProjectPage(
+               AudiocomTrace::UpdateCloudAudioPreviewMenu));
       });
 }
 
@@ -63,6 +65,7 @@ void OnShareAudio(const CommandContext& context)
 {
    ShareAudioDialog dialog {
       context.project,
+      AudiocomTrace::ShareAudioMenu,
       ProjectWindow::Find(&context.project),
    };
 

--- a/modules/sharing/mod-cloud-audiocom/ui/AudioComPrefsPanel.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/AudioComPrefsPanel.cpp
@@ -20,6 +20,7 @@
 
 #include "CloudLibrarySettings.h"
 #include "CloudModuleSettings.h"
+#include "ExportUtils.h"
 #include "ShuttleGui.h"
 #include "UserPanel.h"
 
@@ -81,7 +82,8 @@ public:
             S.SetBorder(8);
             S.AddWindow(
                safenew UserPanel { GetServiceConfig(), GetOAuthService(),
-                                   GetUserService(), true, S.GetParent() },
+                                   GetUserService(), true,
+                                   AudiocomTrace::PrefsPanel, S.GetParent() },
                wxEXPAND);
          }
          S.EndStatic();

--- a/modules/sharing/mod-cloud-audiocom/ui/ProjectCloudUIExtension.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/ProjectCloudUIExtension.cpp
@@ -131,7 +131,7 @@ void ProjectCloudUIExtension::OnCloudStatusChanged(
    {
    case CloudSyncError::Authorization:
       // How do we got here? Probable auth_token is invalid?
-      GetOAuthService().UnlinkAccount();
+      GetOAuthService().UnlinkAccount(message.audiocomTrace);
       SaveToCloud(mProject, UploadMode::Normal);
       break;
    case CloudSyncError::ProjectLimitReached:
@@ -145,7 +145,7 @@ void ProjectCloudUIExtension::OnCloudStatusChanged(
          const auto slug = audacity::ToUTF8(GetUserService().GetUserSlug());
 
          BasicUI::OpenInDefaultBrowser(
-            GetServiceConfig().GetProjectsPageUrl(slug));
+            GetServiceConfig().GetProjectsPageUrl(slug, message.audiocomTrace));
 
          WaitForActionDialog {
             &mProject,

--- a/modules/sharing/mod-cloud-audiocom/ui/ShareAudioToolbar.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/ShareAudioToolbar.cpp
@@ -20,12 +20,13 @@
 #endif
 
 #include "AColor.h"
-#include "AudioIOBase.h"
 #include "AllThemeResources.h"
+#include "AudioIOBase.h"
+#include "ExportUtils.h"
+#include "PlayableTrack.h"
 #include "Prefs.h"
 #include "ProjectWindow.h"
 #include "Theme.h"
-#include "PlayableTrack.h"
 
 #include "dialogs/ShareAudioDialog.h"
 #include "toolbars/ToolManager.h"
@@ -162,12 +163,11 @@ void ShareAudioToolbar::MakeShareAudioButton()
    mShareAudioButton->SetIcon(theTheme.Image(bmpShareAudio));
    mShareAudioButton->SetForegroundColour(theTheme.Colour(clrTrackPanelText));
 
-   mShareAudioButton->Bind(
-      wxEVT_BUTTON,
-      [this](auto)
-      {
-         audiocom::ShareAudioDialog dlg(mProject, &ProjectWindow::Get(mProject));
-         dlg.ShowModal();
+   mShareAudioButton->Bind(wxEVT_BUTTON, [this](auto) {
+      audiocom::ShareAudioDialog dlg(
+         mProject, AudiocomTrace::ShareAudioButton,
+         &ProjectWindow::Get(mProject));
+      dlg.ShowModal();
 
          mShareAudioButton->PopUp();
       });
@@ -178,7 +178,7 @@ void ShareAudioToolbar::MakeShareAudioButton()
 void ShareAudioToolbar::ArrangeButtons()
 {
    Add(mShareAudioButton, 0, wxALIGN_CENTRE | wxALL, toolbarSpacing);
-   
+
    SetMinSize({ std::max(76, GetSizer()->GetMinSize().GetWidth()), -1 });
    SetMaxSize({ -1, -1 });
 

--- a/modules/sharing/mod-cloud-audiocom/ui/UserPanel.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/UserPanel.h
@@ -10,11 +10,13 @@
 **********************************************************************/
 #pragma once
 
-#include "wxPanelWrapper.h"
+#include "NetworkUtils.h"
 #include "Observer.h"
+#include "wxPanelWrapper.h"
 
 class wxStaticText;
 class wxButton;
+enum class AudiocomTrace;
 
 namespace audacity::cloud::audiocom
 {
@@ -34,10 +36,9 @@ class UserPanel final
 {
 public:
    UserPanel(
-      const ServiceConfig& serviceConfig,
-      OAuthService& authService, UserService& userService,
-      bool hasLinkButton, wxWindow* parent = nullptr,
-      const wxPoint& pos = wxDefaultPosition,
+      const ServiceConfig& serviceConfig, OAuthService& authService,
+      UserService& userService, bool hasLinkButton, AudiocomTrace,
+      wxWindow* parent = nullptr, const wxPoint& pos = wxDefaultPosition,
       const wxSize& size = wxDefaultSize);
 
    ~UserPanel() override;
@@ -53,6 +54,7 @@ private:
    const ServiceConfig& mServiceConfig;
    OAuthService& mAuthService;
    UserService& mUserService;
+   const AudiocomTrace mAudiocomTrace;
 
    UserImage* mUserImage {};
    wxStaticText* mUserName {};

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.cpp
@@ -28,13 +28,14 @@ namespace audacity::cloud::audiocom::sync
 {
 CloudProjectPropertiesDialog::CloudProjectPropertiesDialog(
    const ServiceConfig& serviceConfig, OAuthService& authService,
-   UserService& userService, const wxString& projectName, wxWindow* parent)
+   UserService& userService, const wxString& projectName, wxWindow* parent,
+   AudiocomTrace trace)
     : wxDialogWrapper { parent, wxID_ANY, XO("Save to audio.com") }
 {
    GetAuthorizationHandler().PushSuppressDialogs();
 
    mUserPanel =
-      new UserPanel(serviceConfig, authService, userService, true, this);
+      new UserPanel(serviceConfig, authService, userService, true, trace, this);
 
    mUserStateChangedSubscription =
       mUserPanel->Subscribe([this](auto) { OnUpdateCloudSaveState(); });
@@ -87,10 +88,11 @@ std::pair<CloudProjectPropertiesDialog::Action, std::string>
 CloudProjectPropertiesDialog::Show(
    const ServiceConfig& serviceConfig, OAuthService& authService,
    UserService& userService, const wxString& projectName, wxWindow* parent,
-   bool allowLocalSave)
+   bool allowLocalSave, AudiocomTrace trace)
 {
    CloudProjectPropertiesDialog dialog { serviceConfig, authService,
-                                         userService, projectName, parent };
+                                         userService,   projectName,
+                                         parent,        trace };
 
    dialog.mSaveLocally->Show(allowLocalSave);
 

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.h
@@ -21,6 +21,7 @@ class wxTextCtrl;
 class wxChoice;
 class wxButton;
 class wxStaticText;
+enum class AudiocomTrace;
 
 namespace audacity::cloud::audiocom
 {
@@ -37,7 +38,8 @@ class CloudProjectPropertiesDialog final : public wxDialogWrapper
 {
    CloudProjectPropertiesDialog(
       const ServiceConfig& serviceConfig, OAuthService& authService,
-      UserService& userService, const wxString& projectName, wxWindow* parent);
+      UserService& userService, const wxString& projectName, wxWindow* parent,
+      AudiocomTrace);
    ~CloudProjectPropertiesDialog() override;
 
 public:
@@ -50,7 +52,8 @@ public:
 
    static std::pair<Action, std::string> Show(
       const ServiceConfig& serviceConfig, OAuthService& authService,
-      UserService& userService, const wxString& projectName, wxWindow* parent, bool allowLocalSave);
+      UserService& userService, const wxString& projectName, wxWindow* parent,
+      bool allowLocalSave, AudiocomTrace);
 
 private:
    bool OnSubmit();

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkFailedDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkFailedDialog.cpp
@@ -23,7 +23,7 @@
 namespace audacity::cloud::audiocom
 {
 
-LinkFailedDialog::LinkFailedDialog(wxWindow* parent)
+LinkFailedDialog::LinkFailedDialog(wxWindow* parent, AudiocomTrace trace)
     : wxDialogWrapper(
          parent, wxID_ANY, XO("Link account"), wxDefaultPosition, { 442, -1 },
          wxDEFAULT_DIALOG_STYLE)
@@ -52,14 +52,11 @@ LinkFailedDialog::LinkFailedDialog(wxWindow* parent)
 
             auto btn = s.AddButton(XO("&Try again"));
 
-            btn->Bind(
-               wxEVT_BUTTON,
-               [this](auto)
-               {
-                  OpenInDefaultBrowser({ audacity::ToWXString(
-                     GetServiceConfig().GetOAuthLoginPage()) });
-                  EndModal(wxID_RETRY);
-               });
+            btn->Bind(wxEVT_BUTTON, [this, trace](auto) {
+               OpenInDefaultBrowser({ audacity::ToWXString(
+                  GetServiceConfig().GetOAuthLoginPage(trace)) });
+               EndModal(wxID_RETRY);
+            });
 
             btn->SetDefault();
          }

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkFailedDialog.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkFailedDialog.h
@@ -12,12 +12,14 @@
 
 #include "wxPanelWrapper.h"
 
+enum class AudiocomTrace;
+
 namespace audacity::cloud::audiocom
 {
 class LinkFailedDialog final : public wxDialogWrapper
 {
 public:
-   explicit LinkFailedDialog(wxWindow* parent);
+   LinkFailedDialog(wxWindow* parent, AudiocomTrace trace);
    ~LinkFailedDialog() override;
 
 

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkWithTokenDialog.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkWithTokenDialog.h
@@ -14,13 +14,14 @@
 
 class wxButton;
 class wxTextCtrl;
+enum class AudiocomTrace;
 
 namespace audacity::cloud::audiocom
 {
 class LinkWithTokenDialog final : public wxDialogWrapper
 {
 public:
-   explicit LinkWithTokenDialog(wxWindow* parent = nullptr);
+   explicit LinkWithTokenDialog(AudiocomTrace, wxWindow* parent = nullptr);
    ~LinkWithTokenDialog() override;
 
 private:
@@ -29,5 +30,6 @@ private:
 
    wxButton* mContinueButton { nullptr };
    wxTextCtrl* mToken { nullptr };
+   const AudiocomTrace mAudiocomTrace;
 };
 } // namespace audacity::cloud::audiocom

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/ProjectsListDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/ProjectsListDialog.cpp
@@ -23,6 +23,7 @@
 
 #include "BasicUI.h"
 #include "CodeConversions.h"
+#include "ExportUtils.h"
 #include "Internat.h"
 #include "wxWidgetsWindowPlacement.h"
 
@@ -144,7 +145,8 @@ public:
    {
       using namespace std::chrono_literals;
 
-      auto authResult = PerformBlockingAuth(mOwner.mProject);
+      auto authResult = PerformBlockingAuth(
+         mOwner.mProject, AudiocomTrace::OpenFromCloudMenu);
 
       switch (authResult.Result)
       {
@@ -274,7 +276,8 @@ public:
 
       auto& item = mResponse.Items[selectedRow[0]];
 
-      return GetServiceConfig().GetProjectPageUrl(item.Username, item.Id);
+      return GetServiceConfig().GetProjectPageUrl(
+         item.Username, item.Id, AudiocomTrace::OpenFromCloudMenu);
    }
 
 private:

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/ShareAudioDialog.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/ShareAudioDialog.h
@@ -28,6 +28,7 @@ class wxPanel;
 class wxStaticText;
 class wxTextCtrl;
 class wxRadioButton;
+enum class AudiocomTrace;
 
 namespace audacity::cloud::audiocom
 {
@@ -40,7 +41,8 @@ class ShareAudioDialog final :
     public wxDialogWrapper
 {
 public:
-   ShareAudioDialog(AudacityProject& project, wxWindow* parent = nullptr);
+   ShareAudioDialog(
+      AudacityProject& project, AudiocomTrace, wxWindow* parent = nullptr);
    ~ShareAudioDialog() override;
 
 private:
@@ -106,6 +108,7 @@ private:
 
    struct Services;
    std::unique_ptr<Services> mServices;
+   const AudiocomTrace mAudiocomTrace;
 
    class ExportProgressUpdater;
    std::unique_ptr<ExportProgressUpdater> mExportProgressUpdater;

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -3,7 +3,7 @@
   Audacity: A Digital Audio Editor
 
   ExportAudioDialog.cpp
- 
+
   Dominic Mazzoni
 
   Vitaly Sverchinsky split from ExportMultiple.cpp and ExportAudioDialog.cpp
@@ -73,7 +73,7 @@ ChoiceSetting ExportAudioExportRange { L"/ExportAudioDialog/ExportRange",
       { "project", XO("Entire &Project") },
       { "split", XO("M&ultiple Files") },
       { "selection", XO("Curren&t Selection") }
-      
+
    },
    0, //project
 };
@@ -126,7 +126,7 @@ enum {
    FileNamePrefixID,
 
    OverwriteExistingFilesID,
-   
+
    EditMetadataID,
 };
 
@@ -169,9 +169,9 @@ ExportAudioDialog::ExportAudioDialog(wxWindow* parent,
 
    ShuttleGui S(this, eIsCreatingFromPrefs);
    PopulateOrExchange(S);
-   
+
    SetMinSize({GetBestSize().GetWidth(), -1});
-   
+
    wxFileName filename;
    auto exportPath = ExportAudioDefaultPath.Read();
    if(exportPath.empty())
@@ -240,7 +240,7 @@ ExportAudioDialog::ExportAudioDialog(wxWindow* parent,
    mExportOptionsPanel->SetCustomMappingEnabled(!mRangeSplit->GetValue());
 
    mIncludeAudioBeforeFirstLabel->Enable(mSplitByLabels->GetValue());
-   
+
    if(ExportAudioSplitNamePolicy.Read() != "num_and_prefix")
       mSplitFileNamePrefix->Disable();
 
@@ -256,7 +256,7 @@ bool ExportAudioDialog::Show(bool show)
 {
    bool ret = wxDialogWrapper::Show(show);
 
-#if defined(__WXMSW__) 
+#if defined(__WXMSW__)
    if (show)
       mExportOptionsPanel->SetInitialFocus();
 #endif
@@ -324,7 +324,7 @@ void ExportAudioDialog::PopulateOrExchange(ShuttleGui& S)
          S.EndTwoColumn();
       }
       S.EndPanel();
-      
+
       S.SetBorder(5);
       mSplitsPanel = S.StartPanel();
       {
@@ -340,7 +340,7 @@ void ExportAudioDialog::PopulateOrExchange(ShuttleGui& S)
                      mSplitByLabels = S.Id(ExportModeLabelsID).TieRadioButton();
                   }
                   S.EndRadioButtonGroup();
-               
+
                   S.StartHorizontalLay(wxALIGN_TOP);
                   {
                      S.AddSpace(10, 1);
@@ -353,7 +353,7 @@ void ExportAudioDialog::PopulateOrExchange(ShuttleGui& S)
                S.EndVerticalLay();
             }
             S.EndStatic();
-            
+
             S.StartStatic(XO("Name files:"));
             {
                S.StartVerticalLay();
@@ -379,17 +379,17 @@ void ExportAudioDialog::PopulateOrExchange(ShuttleGui& S)
             S.EndStatic();
          }
          S.EndMultiColumn();
-         
+
          mOverwriteExisting = S
             .Id(OverwriteExistingFilesID)
             .TieCheckBox(XO("Overwrite existing files"), ExportAudioOverwriteExisting);
       }
       S.EndPanel();
-      
+
       S.AddSpace(1, 10);
-      
+
       S.SetBorder(5);
-      
+
       S.SetBorder(5);
       S.StartHorizontalLay(wxEXPAND);
       {
@@ -412,7 +412,7 @@ void ExportAudioDialog::OnExportRangeChange(wxCommandEvent& event)
    {
       mExportSettingsDirty = true;
       mSplitsPanel->Show(enableSplits);
-      
+
       Layout();
       Fit();
    }
@@ -488,7 +488,7 @@ void ExportAudioDialog::OnExport(wxCommandEvent &event)
 
    if(!wxDirExists(path))
       wxFileName::Mkdir(path, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-   
+
    if(!wxDirExists(path))
    {
       AudacityMessageBox(XO("Unable to create destination folder"),
@@ -497,9 +497,9 @@ void ExportAudioDialog::OnExport(wxCommandEvent &event)
                          this);
       return;
    }
-   
+
    auto result = ExportResult::Error;
-   
+
    if(mRangeSplit->GetValue())
    {
       FilePaths exportedFiles;
@@ -510,7 +510,7 @@ void ExportAudioDialog::OnExport(wxCommandEvent &event)
          result = DoExportSplitByLabels(*selectedPlugin, selectedFormat, *parameters, exportedFiles);
       else if(mSplitByTracks->GetValue())
          result = DoExportSplitByTracks(*selectedPlugin, selectedFormat, *parameters, exportedFiles);
-      
+
       auto msg = (result == ExportResult::Success
          ? XO("Successfully exported the following %lld file(s).")
          : result == ExportResult::Error
@@ -538,7 +538,7 @@ void ExportAudioDialog::OnExport(wxCommandEvent &event)
    else
    {
       wxFileName filename(path, mExportOptionsPanel->GetFullName());
-      
+
       if (filename.FileExists()) {
          auto result = AudacityMessageBox(
             XO("A file named \"%s\" already exists. Replace?")
@@ -549,21 +549,21 @@ void ExportAudioDialog::OnExport(wxCommandEvent &event)
             return;
          }
       }
-      
+
       ExportTaskBuilder builder;
       builder.SetFileName(filename)
          .SetPlugin(selectedPlugin, selectedFormat)
          .SetParameters(*parameters)
          .SetSampleRate(mExportOptionsPanel->GetSampleRate());
-      
+
       const auto& viewInfo = ViewInfo::Get(mProject);
-      
+
       const auto selectedOnly = mRangeSelection->GetValue();
-      
+
       auto t0 = selectedOnly
          ? std::max(.0, viewInfo.selectedRegion.t0())
          : .0;
-      
+
       auto t1 = selectedOnly
          ? std::min(TrackList::Get(mProject).GetEndTime(), viewInfo.selectedRegion.t1())
          : TrackList::Get(mProject).GetEndTime();
@@ -582,14 +582,14 @@ void ExportAudioDialog::OnExport(wxCommandEvent &event)
          t0 = std::max(t0, exportedTracks.min(&Track::GetStartTime));
 
       builder.SetRange(t0, t1, selectedOnly);
-      
+
       std::unique_ptr<MixerOptions::Downmix> tempMixerSpec;
       const auto channels = mExportOptionsPanel->GetChannels();
       if(channels == 0)
       {
          //Figure out the final channel mapping: mixer dialog shows
          //all tracks regardless of their mute/solo state, but
-         //muted channels should not be present in exported file - 
+         //muted channels should not be present in exported file -
          //apply channel mask to exclude them
          auto tracks = TrackList::Get(mProject).Any<WaveTrack>();
          std::vector<bool> channelMask(
@@ -613,19 +613,19 @@ void ExportAudioDialog::OnExport(wxCommandEvent &event)
             else
                trackIndex += track->NChannels();
          }
-         
+
          tempMixerSpec = std::make_unique<MixerOptions::Downmix>(*mExportOptionsPanel->GetMixerSpec(), channelMask);
          builder.SetMixerSpec(tempMixerSpec.get());
       }
       else
          builder.SetNumChannels(channels);
-      
+
       ExportProgressUI::ExceptionWrappedCall([&]
       {
          result = ExportProgressUI::Show(builder.Build(mProject));
       });
    }
-   
+
    if(result == ExportResult::Success || result == ExportResult::Stopped)
    {
       ImportExport::Get(mProject).SetPreferredExportRate(mExportOptionsPanel->GetSampleRate());
@@ -643,7 +643,7 @@ void ExportAudioDialog::OnFormatChange(wxCommandEvent& event)
 {
    Layout();
    Fit();
-   
+
    auto enableMeta = false;
    if(auto plugin = mExportOptionsPanel->GetPlugin())
       enableMeta = plugin->GetFormatInfo(mExportOptionsPanel->GetFormat()).canMetaData;
@@ -682,7 +682,7 @@ void ExportAudioDialog::UpdateLabelExportSettings(const ExportPlugin& plugin, in
    const auto& tracks = TrackList::Get(mProject);
    const auto& labels = (*tracks.Any<const LabelTrack>().begin());
    const auto numLabels = labels->GetNumLabels();
-   
+
    auto numFiles = numLabels;
    auto fileIndex = 0;        // counter for files done
    std::vector<ExportSetting> exportSettings; // dynamic array for settings.
@@ -693,19 +693,19 @@ void ExportAudioDialog::UpdateLabelExportSettings(const ExportPlugin& plugin, in
       fileIndex = -1;
       numFiles++;
    }
-   
+
    const auto formatInfo = plugin.GetFormatInfo(formatIndex);
-   
+
    FilePaths otherNames;  // keep track of file names we will use, so we
    // don't duplicate them
    ExportSetting setting;   // the current batch of settings
    setting.filename.SetPath(mExportOptionsPanel->GetPath());
    setting.channels = mExportOptionsPanel->GetChannels();
    setting.filename.SetFullName(mExportOptionsPanel->GetFullName());
-   
+
    wxString name;    // used to hold file name whilst we mess with it
    wxString title;   // un-messed-with title of file for tagging with
-   
+
    const LabelStruct *info = NULL;
    /* Examine all labels a first time, sort out all data but don't do any
     * exporting yet (so this run is quick but interactive) */
@@ -784,14 +784,14 @@ void ExportAudioDialog::UpdateTrackExportSettings(const ExportPlugin& plugin, in
    const wxString& prefix)
 {
    auto& tracks = TrackList::Get(mProject);
-   
+
    bool anySolo = !(( tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo ).empty());
-   
+
    auto waveTracks = tracks.Any<WaveTrack>() -
       (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute);
-   
+
    const auto numWaveTracks = waveTracks.size();
-   
+
    auto fileIndex = 0;     // track counter
    FilePaths otherNames;
    auto formatInfo = plugin.GetFormatInfo(formatIndex);
@@ -834,7 +834,7 @@ void ExportAudioDialog::UpdateTrackExportSettings(const ExportPlugin& plugin, in
       Internat::SanitiseFilename(name, wxT("_"));
       // store sanitised and user checked name in object
       setting.filename.SetName(name);
-      
+
       // FIXME: TRAP_ERR User could have given an illegal track name.
       // in that case we should tell them, not fail silently.
       wxASSERT(setting.filename.IsOk());     // burp if file name is broke
@@ -852,7 +852,7 @@ void ExportAudioDialog::UpdateTrackExportSettings(const ExportPlugin& plugin, in
       }
       else
          setting.tags = exportSettings.back().tags;
-      
+
       // over-ride with values
       setting.tags.SetTag(TAG_TITLE, title);
       setting.tags.SetTag(TAG_TRACK, fileIndex + 1);
@@ -882,7 +882,7 @@ ExportResult ExportAudioDialog::DoExportSplitByLabels(const ExportPlugin& plugin
       // Export it
       ok = DoExport(plugin, formatIndex, parameters, activeSetting.filename, activeSetting.channels,
          activeSetting.t0, activeSetting.t1, false, activeSetting.tags, exporterFiles);
-      
+
       if (ok == ExportResult::Stopped) {
          AudacityMessageDialog dlgMessage(
             nullptr,
@@ -908,15 +908,15 @@ ExportResult ExportAudioDialog::DoExportSplitByTracks(const ExportPlugin& plugin
                                                       FilePaths& exporterFiles)
 {
    auto& tracks = TrackList::Get(mProject);
-   
+
    bool anySolo =
       !((tracks.Any<const WaveTrack>() + &WaveTrack::GetSolo).empty());
-   
+
    auto waveTracks = tracks.Any<WaveTrack>() -
       (anySolo ? &WaveTrack::GetNotSolo : &WaveTrack::GetMute);
 
    auto& selectionState = SelectionState::Get( mProject );
-   
+
    /* Remember which tracks were selected, and set them to deselected */
    SelectionStateChanger changer{ selectionState, tracks };
    for (auto tr : tracks.Selected<WaveTrack>())
@@ -942,7 +942,7 @@ ExportResult ExportAudioDialog::DoExportSplitByTracks(const ExportPlugin& plugin
       // Export the data. "channels" are per track.
       ok = DoExport(plugin, formatIndex, parameters, activeSetting.filename, activeSetting.channels,
          activeSetting.t0, activeSetting.t1, true, activeSetting.tags, exporterFiles);
-      
+
       if (ok == ExportResult::Stopped) {
          AudacityMessageDialog dlgMessage(
             nullptr,
@@ -954,15 +954,15 @@ ExportResult ExportAudioDialog::DoExportSplitByTracks(const ExportPlugin& plugin
             break;
          }
       }
-      
+
       else if (ok != ExportResult::Success) {
          break;
       }
       // increment export counter
       count++;
    }
-   
-   
+
+
    return ok ;
 }
 
@@ -1027,7 +1027,7 @@ ExportResult ExportAudioDialog::DoExport(const ExportPlugin& plugin,
             ::wxRemoveFile(fullPath);
       }
    } );
-   
+
    auto result = ExportResult::Error;
    ExportProgressUI::ExceptionWrappedCall([&]
    {
@@ -1045,7 +1045,7 @@ ExportResult ExportAudioDialog::DoExport(const ExportPlugin& plugin,
 
    if(success)
       exportedFiles.push_back(fullPath);
-   
+
    return result;
 }
 

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -53,8 +53,8 @@ namespace
 {
 const bool hookRegistered = [] {
    ExportUtils::RegisterExportHook(
-      [](AudacityProject& project, const FileExtension& format, bool selectedOnly)
-      {
+      [](AudacityProject& project, const FileExtension& format,
+         AudiocomTrace /*ignore*/, bool selectedOnly) {
          ExportAudioDialog dialog { &GetProjectFrame(project), project,
                                     project.GetProjectName(), format,
                                     selectedOnly

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -27,8 +27,9 @@
 #include "../widgets/MissingPluginsErrorDialog.h"
 #include "wxPanelWrapper.h"
 
-#include "ExportUtils.h"
 #include "ExportProgressUI.h"
+#include "ExportUtils.h"
+#include "NetworkUtils.h"
 
 #include <wx/app.h>
 #include <wx/menu.h>
@@ -41,7 +42,8 @@
 // private helper classes and functions
 namespace {
 
-void DoExport(AudacityProject &project, const FileExtension &format)
+void DoExport(
+   AudacityProject& project, const FileExtension& format, AudiocomTrace trace)
 {
    auto &tracks = TrackList::Get( project );
 
@@ -62,7 +64,7 @@ void DoExport(AudacityProject &project, const FileExtension &format)
          return;
       }
 
-      ExportUtils::PerformInteractiveExport(project, format, false);
+      ExportUtils::PerformInteractiveExport(project, format, trace, false);
    }
    else {
       // We either use a configured output path,
@@ -274,25 +276,33 @@ void OnSaveCopy(const CommandContext &context )
 void OnExportMp3(const CommandContext &context)
 {
    auto &project = context.project;
-   DoExport(project, "MP3");
+   DoExport(
+      project, "MP3",
+      AudiocomTrace::ShareAudioExportExtraMenu);
 }
 
 void OnExportWav(const CommandContext &context)
 {
    auto &project = context.project;
-   DoExport(project, "WAV");
+   DoExport(
+      project, "WAV",
+      AudiocomTrace::ShareAudioExportExtraMenu);
 }
 
 void OnExportOgg(const CommandContext &context)
 {
    auto &project = context.project;
-   DoExport(project, "OGG");
+   DoExport(
+      project, "OGG",
+      AudiocomTrace::ShareAudioExportExtraMenu);
 }
 
 void OnExportAudio(const CommandContext &context)
 {
    auto &project = context.project;
-   DoExport(project, "");
+   DoExport(
+      project, "",
+      AudiocomTrace::ShareAudioExportMenu);
 }
 
 void OnExportLabels(const CommandContext &context)
@@ -425,7 +435,9 @@ void OnExit(const CommandContext &WXUNUSED(context) )
 
 void OnExportFLAC(const CommandContext &context)
 {
-   DoExport(context.project, "FLAC");
+   DoExport(
+      context.project, "FLAC",
+      AudiocomTrace::ShareAudioExportExtraMenu);
 }
 
 void OnExportSelectedAudio(const CommandContext &context)
@@ -433,7 +445,10 @@ void OnExportSelectedAudio(const CommandContext &context)
    if(!ExportUtils::HasSelectedAudio(context.project))
       return;
 
-   ExportUtils::PerformInteractiveExport(context.project, "", true);
+   ExportUtils::PerformInteractiveExport(
+      context.project, "",
+      AudiocomTrace::ignore, // Local save, no need.
+      true);
 }
 
 // Menu definitions


### PR DESCRIPTION
Resolves: #6618

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

## QA

When redirected to audio.com, the actions below should lead to the URL opened in the browser ending with
`mtm_campaign=Audacity&mtm_source=<audacity version>&mtm_content=<see below>`,
e.g. `https://audio.com/matthieu-hodgkinson/audio/french-break-136-bpm-pl/edit?mtm_campaign=Audacity&mtm_source=Audacity-3.6.0-alpha-20240610&mtm_content=Share_Audio_Button`
Note that this should also apply to the "link-account" button associated with these actions, as well as to the 
"Visit audio.com" button in case the max number of projects was exceeded.

### Example
I want to save my project to the cloud,
![image](https://github.com/audacity/audacity/assets/22740106/23c5b092-d1ae-4a77-9812-ca9441006b13)

but there have to link my account: 
![image](https://github.com/audacity/audacity/assets/22740106/defcf838-19fc-4fdd-ba04-406e10ffab07)

It leads me to audio.com and the link has `Save_to_Cloud_Menu` appended:
![image](https://github.com/audacity/audacity/assets/22740106/e6228408-f009-4aa0-b994-d9ced2ccd649)

Once I have linked my account, upload begins and then I see the success dialog, and clicking on "view my project" leads me to 
![image](https://github.com/audacity/audacity/assets/22740106/67b0871d-2b6c-4744-a7a1-4fd73c8a17ab), which also has that `Save_to_Cloud_Menu` appended.

I save another project, and say I reached my limit. I see 
![image](https://github.com/audacity/audacity/assets/22740106/275b5cef-9fea-423e-b2e9-ea7d23e54209)
and clicking "Visit audio.com" leads me to my projects page, 
![image](https://github.com/audacity/audacity/assets/22740106/6c405916-d254-4ae4-b7ab-033c4b1da5d9), and the link also has `Save_to_Cloud_Menu` appended.

### Actions (to be checked by QA)

| Action                            | string                            | notes |
| --------------------------------- | --------------------------------- |---|
|![image](https://github.com/audacity/audacity/assets/22740106/1bdcb768-953c-4f93-91d7-3d0029e91d44) | `Share_Audio_Button`                | |
| ![image](https://github.com/audacity/audacity/assets/22740106/50fb33fd-97d9-44f9-b945-d2c780bcd97a)                  | `Share_Audio_Menu`                  | |
| ![image](https://github.com/audacity/audacity/assets/22740106/06fdf9cf-5c82-4302-8bee-e968d0158b1a)           | `Share_Audio_Export_Menu`           | |
| ![image](https://github.com/audacity/audacity/assets/22740106/4b083114-6579-402e-ac88-8dfbb1953767)| `Share_Audio_Export_Extra_Menu`     | mp3 or any other format but not "selected audio" |
| ![image](https://github.com/audacity/audacity/assets/22740106/b33eda05-b6b3-46c4-be3c-09a6ffdb3c88)               | `Save_to_Cloud_Menu`                | |
| ![image](https://github.com/audacity/audacity/assets/22740106/86389bf8-2802-4ea2-bc18-9d958f9e1de2)  | `Save_Project_Save_to_Cloud_Menu`   | and then when the modal opens, use the cloud option |
| ![image](https://github.com/audacity/audacity/assets/22740106/b0a2f206-22f8-450c-9f20-dc0d7311b8e4)                       | `Prefs_Panel`                       |  |
| ![image](https://github.com/audacity/audacity/assets/22740106/97e2b751-5b4d-439c-a121-921cf893a3a7)   | `Update_Cloud_Audio_Preview_Menu`   | |
| ![image](https://github.com/audacity/audacity/assets/22740106/5888556e-bc33-482c-8253-8515fc9a878d)   | `Link_Audiocom_Account_Help_Menu`   | If done successfully, there shouldn't be a redirect. If it fails, though, then there should, and the string should be in the URL. One way of failing it is to give some random token. (There are several other reasons why this might fail but testing them all would probably be an overkill. |
| ![image](https://github.com/audacity/audacity/assets/22740106/176f23ee-6335-4294-bbc6-1d98debaf9cb)              | Open_From_Cloud_Menu              | |

