### PR TITLE
Add 32 bit handling for flac

### DIFF
--- a/modules/import-export/mod-flac/ImportFLAC.cpp
+++ b/modules/import-export/mod-flac/ImportFLAC.cpp
@@ -242,11 +242,17 @@ FLAC__StreamDecoderWriteStatus MyFLACFile::write_callback(const FLAC__Frame *fra
                      frame->header.blocksize, 1,
                      int16Sample);
          }
-         else {
+         else if(frame->header.bits_per_sample <= 24){
             channel.AppendBuffer((samplePtr)buffer[chn],
                      int24Sample,
                      frame->header.blocksize, 1,
                      int24Sample);
+         }
+         else {
+            channel.AppendBuffer((samplePtr)buffer[chn],
+                     floatSample,
+                     frame->header.blocksize, 1,
+                     floatSample);
          }
          ++chn;
       });


### PR DESCRIPTION
Resolves: #6606

Well, it doesn't yet. I see that in line 171 following, 32 bit is handled while in the bit I changed here it wasn't, but when I try the file provided in the bug, it doesn't quite work and runs into an assert violation in `WaveCacheSampleBlock::Summary WaveCacheSampleBlock::GetSummary` for `assert(summary.Min <= summary.Max);` (because min is +inf while max is -inf). So there's something here I'm not understanding. 

Edit: One of the issues is that 32-bit int is not 32-bit float. 