### PR TITLE
set minimum track height to 20

### DIFF
--- a/src/tracks/ui/ChannelView.cpp
+++ b/src/tracks/ui/ChannelView.cpp
@@ -212,7 +212,8 @@ void ChannelView::SetExpandedHeight(int h)
 
 void ChannelView::DoSetHeight(int h)
 {
-   mHeight = h;
+   //Minimum track height is 20
+   mHeight = std::max(h, 20);
 }
 
 std::shared_ptr<CommonTrackCell> ChannelView::GetAffordanceControls()


### PR DESCRIPTION
Resolves: #6642

It's arguable whether this should be done in ChannelView or in SetTrackVisualsCommand. I figured setting the safeguard at the lower level might be preferable as it might catch other sources as well. 