### PR TITLE
6589 limiter graph pause interaction fix

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1701,6 +1701,7 @@ void AudioIO::SetPaused(bool state)
    }
 
    mPaused.store(state, std::memory_order_relaxed);
+   Publish({ mOwningProject.lock().get(), AudioIOEvent::PAUSE, state });
 }
 
 double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -62,6 +62,7 @@ struct AudioIOEvent {
       PLAYBACK,
       CAPTURE,
       MONITOR,
+      PAUSE,
    } type;
    bool on;
 };

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -169,7 +169,7 @@ public:
    std::shared_ptr< AudioIOListener > GetListener() const
       { return mListener.lock(); }
    void SetListener( const std::shared_ptr< AudioIOListener > &listener);
-   
+
    // Part of the callback
    int CallbackDoSeek();
 
@@ -195,7 +195,7 @@ public:
       float *outputMeterFloats
    );
    void DrainInputBuffers(
-      constSamplePtr inputBuffer, 
+      constSamplePtr inputBuffer,
       unsigned long framesPerBuffer,
       const PaStreamCallbackFlags statusFlags,
       float * tempFloats
@@ -204,7 +204,7 @@ public:
       unsigned long framesPerBuffer
    );
    void DoPlaythrough(
-      constSamplePtr inputBuffer, 
+      constSamplePtr inputBuffer,
       float *outputBuffer,
       unsigned long framesPerBuffer,
       float *outputMeterFloats
@@ -308,7 +308,7 @@ public:
    std::atomic<bool>   mAudioThreadShouldCallSequenceBufferExchangeOnce;
    std::atomic<bool>   mAudioThreadSequenceBufferExchangeLoopRunning;
    std::atomic<bool>   mAudioThreadSequenceBufferExchangeLoopActive;
-      
+
    std::atomic<Acknowledge>  mAudioThreadAcknowledge;
 
    // Async start/stop + wait of AudioThread processing.
@@ -480,7 +480,7 @@ public:
    void SeekStream(double seconds) { mSeek = seconds; }
 
    using PostRecordingAction = std::function<void()>;
-   
+
    //! Enqueue action for main thread idle time, not before the end of any recording in progress
    /*! This may be called from non-main threads */
    void CallAfterRecording(PostRecordingAction action);

--- a/libraries/lib-dynamic-range-processor/CMakeLists.txt
+++ b/libraries/lib-dynamic-range-processor/CMakeLists.txt
@@ -5,6 +5,8 @@ Dynamic-range processor and utilities
 set( SOURCES
    CompressorProcessor.cpp
    CompressorProcessor.h
+   DynamicRangeProcessorClock.cpp
+   DynamicRangeProcessorClock.h
    DynamicRangeProcessorHistory.cpp
    DynamicRangeProcessorHistory.h
    DynamicRangeProcessorTypes.h

--- a/libraries/lib-dynamic-range-processor/DynamicRangeProcessorClock.cpp
+++ b/libraries/lib-dynamic-range-processor/DynamicRangeProcessorClock.cpp
@@ -1,0 +1,30 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  DynamicRangeProcessorClock.cpp
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#include "DynamicRangeProcessorClock.h"
+
+std::chrono::steady_clock::time_point DynamicRangeProcessorClock::GetNow() const
+{
+   return std::chrono::steady_clock::now() -
+          std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+             mElapsedWhilePaused);
+}
+
+void DynamicRangeProcessorClock::Pause()
+{
+   mPauseBegin = std::chrono::steady_clock::now();
+}
+
+void DynamicRangeProcessorClock::Resume()
+{
+   if (!mPauseBegin.has_value())
+      return;
+   mElapsedWhilePaused += std::chrono::steady_clock::now() - *mPauseBegin;
+}

--- a/libraries/lib-dynamic-range-processor/DynamicRangeProcessorClock.h
+++ b/libraries/lib-dynamic-range-processor/DynamicRangeProcessorClock.h
@@ -1,0 +1,30 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  DynamicRangeProcessorClock.h
+
+  Matthieu Hodgkinson
+
+**********************************************************************/
+#pragma once
+
+#include <chrono>
+#include <optional>
+
+/*!
+ * \brief A clock that can be paused and resumed.
+ */
+class DYNAMIC_RANGE_PROCESSOR_API DynamicRangeProcessorClock final
+{
+public:
+   std::chrono::steady_clock::time_point GetNow() const;
+   void Pause();
+   void Resume();
+
+private:
+   std::optional<std::chrono::steady_clock::time_point> mPauseBegin;
+   std::chrono::duration<double> mElapsedWhilePaused =
+      std::chrono::duration<double>::zero();
+};

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.cpp
@@ -184,48 +184,6 @@ void RealtimeEffectManager::ProcessEnd(bool suspended) noexcept
    });
 }
 
-RealtimeEffectManager::
-AllListsLock::AllListsLock(RealtimeEffectManager *pManager)
-   : mpManager{ pManager }
-{
-   if (mpManager) {
-      // Paralleling VisitAll
-      RealtimeEffectList::Get(mpManager->mProject).GetLock().lock();
-      // And all group lists
-      for (auto group : mpManager->mGroups)
-         RealtimeEffectList::Get(*group).GetLock().lock();
-   }
-}
-
-RealtimeEffectManager::AllListsLock::AllListsLock(AllListsLock &&other)
-   : mpManager{ other.mpManager }
-{
-   other.mpManager = nullptr;
-}
-
-RealtimeEffectManager::AllListsLock&
-RealtimeEffectManager::AllListsLock::operator =(AllListsLock &&other)
-{
-   if (this != &other) {
-      Reset();
-      mpManager = other.mpManager;
-      other.mpManager = nullptr;
-   }
-   return *this;
-}
-
-void RealtimeEffectManager::AllListsLock::Reset()
-{
-   if (mpManager) {
-      // Paralleling VisitAll
-      RealtimeEffectList::Get(mpManager->mProject).GetLock().unlock();
-      // And all group lists
-      for (auto group : mpManager->mGroups)
-         RealtimeEffectList::Get(*group).GetLock().unlock();
-      mpManager = nullptr;
-   }
-}
-
 std::shared_ptr<RealtimeEffectState>
 RealtimeEffectManager::MakeNewState(
    RealtimeEffects::InitializationScope *pScope,
@@ -258,7 +216,7 @@ RealtimeEffectManager::MakeNewState(
          }
       }
 
-      
+
    }
    return pNewState;
 }

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.h
@@ -1,11 +1,11 @@
 /**********************************************************************
- 
+
  Audacity: A Digital Audio Editor
- 
+
  RealtimeEffectManager.h
- 
+
  Paul Licameli split from EffectManager.h
- 
+
  **********************************************************************/
 
 #ifndef __AUDACITY_REALTIME_EFFECT_MANAGER__

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.h
@@ -145,14 +145,6 @@ private:
    void Finalize() noexcept;
 
    friend RealtimeEffects::ProcessingScope;
-   struct REALTIME_EFFECTS_API AllListsLock {
-      RealtimeEffectManager *mpManager{};
-      AllListsLock(RealtimeEffectManager *pManager = nullptr);
-      AllListsLock(AllListsLock &&other);
-      AllListsLock& operator= (AllListsLock &&other);
-      void Reset();
-      ~AllListsLock() { Reset(); }
-   };
 
    void ProcessStart(bool suspended);
 
@@ -263,14 +255,6 @@ private:
 //! Brackets one block of processing in one thread
 class ProcessingScope {
 public:
-   ProcessingScope()
-   {
-      if (auto pProject = mwProject.lock()) {
-         auto &manager = RealtimeEffectManager::Get(*pProject);
-         mLocks = { &manager };
-         mSuspended = manager.GetSuspended();
-      }
-   }
    //! Require a prior InializationScope to ensure correct nesting
    explicit ProcessingScope(InitializationScope &,
       std::weak_ptr<AudacityProject> wProject)
@@ -306,7 +290,6 @@ public:
    }
 
 private:
-   RealtimeEffectManager::AllListsLock mLocks;
    std::weak_ptr<AudacityProject> mwProject;
    bool mSuspended{};
 };

--- a/libraries/lib-realtime-effects/RealtimeEffectManager.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectManager.h
@@ -261,7 +261,10 @@ public:
       : mwProject{ move(wProject) }
    {
       if (auto pProject = mwProject.lock())
+      {
+         mSuspended = RealtimeEffectManager::Get(*pProject).GetSuspended();
          RealtimeEffectManager::Get(*pProject).ProcessStart(mSuspended);
+      }
    }
    ProcessingScope( ProcessingScope &&other ) = default;
    ProcessingScope& operator=( ProcessingScope &&other ) = default;

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -11,7 +11,7 @@
 \class AdornedRulerPanel
 \brief This is an Audacity Specific ruler panel which additionally
   has border, selection markers, play marker.
-  
+
   Once TrackPanel uses wxSizers, we will derive it from some
   wxWindow and the GetSize and SetSize functions
   will then be wxWidgets functions instead.
@@ -85,7 +85,7 @@ enum : int {
 
    TopMargin = 1,
    BottomMargin = 2, // for bottom bevel and bottom line
-   LeftMargin = 1, 
+   LeftMargin = 1,
 
    RightMargin = 1,
 };
@@ -181,7 +181,7 @@ protected:
    void StartPlay(AudacityProject &project, const wxMouseEvent &event)
    {
       auto &ruler = AdornedRulerPanel::Get(project);
-   
+
       // Keep a shared pointer to self.  Otherwise *this might get deleted
       // in HandleQPRelease on Windows!  Because there is an event-loop yield
       // stopping playback, which caused OnCaptureLost to be called, which caused
@@ -196,7 +196,7 @@ protected:
    {
       return RefreshCode::DrawOverlays;
    }
-   
+
    void Enter(bool, AudacityProject *) override
    {
       mChangeHighlight = RefreshCode::DrawOverlays;
@@ -206,7 +206,7 @@ protected:
 
    wxCoord mX;
    wxCoord mClickedX;
-   
+
    MenuChoice mChoice;
 
    enum class Button { None, Left, Right };
@@ -265,7 +265,7 @@ public:
       auto &ruler = AdornedRulerPanel::Get(*pProject);
       mX = event.event.m_x;
       ruler.UpdateQuickPlayPos(event.event.m_x);
-   
+
       if (!mDragged) {
          if (fabs(mX - mClickedX) < SELECT_TOLERANCE_PIXEL)
             // Don't start a drag yet for a small mouse movement
@@ -283,7 +283,7 @@ public:
 
       return RefreshAll;
    }
-  
+
    Result Release(
       const TrackPanelMouseEvent &event,
       AudacityProject *pProject, wxWindow *pParent)
@@ -320,7 +320,7 @@ public:
       playRegion.SetTimes(mOldStart, mOldEnd);
       if (!mWasActive)
          playRegion.SetActive(false);
-   
+
       return RefreshAll;
    }
 
@@ -654,7 +654,7 @@ void AdornedRulerPanel::TrackPanelGuidelineOverlay::Draw(
             // Do not draw the quick-play guideline
             return;
       }
-   
+
       mOldPreviewingScrub
          ? AColor::IndicatorColor(&dc, true) // Draw green line for preview.
          : (mOldIndicatorSnapped >= 0)
@@ -733,7 +733,7 @@ public:
    : mParent{ parent }
    , mMenuChoice{ menuChoice }
    {}
-   
+
    HitTestPreview DefaultPreview(
       const TrackPanelMouseState &, const AudacityProject *)
       override
@@ -773,7 +773,7 @@ public:
    : CommonRulerHandle( pParent, xx, MenuChoice::QuickPlay )
    {
    }
-   
+
 private:
    Result Click(
       const TrackPanelMouseEvent &event, AudacityProject *pProject) override;
@@ -813,7 +813,7 @@ public:
       mParent->mQuickPlayOffset[0] = 0;
       mParent->mQuickPlayOffset[1] = 0;
    }
-   
+
 private:
    void DoStartAdjust(AudacityProject &project, double) override
    {
@@ -843,7 +843,7 @@ public:
    , mHitLeft{ hitLeft }
    {
    }
-   
+
 private:
    void DoStartAdjust(AudacityProject &project, double time) override
    {
@@ -873,7 +873,7 @@ public:
    : PlayRegionAdjustingHandle( pParent, xx, MenuChoice::QuickPlay, {wxCURSOR_DEFAULT} )
    {
    }
-   
+
 private:
    void DoStartAdjust(AudacityProject &project, double time) override
    {
@@ -933,7 +933,7 @@ public:
          return RefreshCode::DrawOverlays;
       return 0;
    }
-   
+
    static std::shared_ptr<PlayheadHandle>
    HitTest(
       const AudacityProject *pProject, AdornedRulerPanel &parent, wxCoord xx )
@@ -948,7 +948,7 @@ public:
       }
       return {};
    }
-   
+
 protected:
    Result Click(
       const TrackPanelMouseEvent &event, AudacityProject *) override
@@ -956,7 +956,7 @@ protected:
       if (event.event.LeftDClick()) {
          // Restore default position on double click
          TracksPrefs::SetPinnedHeadPositionPreference( 0.5, true );
-      
+
          return RefreshCode::DrawOverlays |
             // Do not start a drag
             RefreshCode::Cancelled;
@@ -987,7 +987,7 @@ protected:
       return {
          XO( "Click and drag to adjust, double-click to reset" ),
          &cursor,
-         /* i18n-hint: This text is a tooltip on the icon (of a pin) representing 
+         /* i18n-hint: This text is a tooltip on the icon (of a pin) representing
          the temporal position in the audio.  */
          XO( "Record/Playhead" )
       };
@@ -1007,7 +1007,7 @@ protected:
       TracksPrefs::SetPinnedHeadPositionPreference( mOrigPreference );
       return RefreshCode::DrawOverlays;
    }
-   
+
    void Enter(bool, AudacityProject *) override
    {
       mChangeHighlight = RefreshCode::DrawOverlays;
@@ -1027,11 +1027,11 @@ public:
    QPCell( AdornedRulerPanel *parent )
    : AdornedRulerPanel::CommonCell{ parent, MenuChoice::QuickPlay }
    {}
-   
+
    std::vector<UIHandlePtr> HitTest(
       const TrackPanelMouseState &state,
       const AudacityProject *pProject) override;
-   
+
    // Return shared_ptr to self, stored in parent
    std::shared_ptr<TrackPanelCell> ContextMenuDelegate() override
       { return mParent->mQPCell; }
@@ -1043,7 +1043,7 @@ public:
 #endif
       return false;
    }
-   
+
 #ifdef QUICK_PLAY_HANDLE
    std::weak_ptr<QPHandle> mHolder;
 #endif
@@ -1061,7 +1061,7 @@ std::vector<UIHandlePtr> AdornedRulerPanel::QPCell::HitTest(
    // Creation of overlays on demand here -- constructor of AdornedRulerPanel
    // is too early to do it
    mParent->CreateOverlays();
-   
+
    std::vector<UIHandlePtr> results;
    auto xx = state.state.m_x;
 
@@ -1074,7 +1074,7 @@ std::vector<UIHandlePtr> AdornedRulerPanel::QPCell::HitTest(
          results.push_back( result );
       }
    }
-   
+
    // Disable mouse actions on Timeline while recording.
    if (!mParent->mIsRecording) {
       mParent->UpdateQuickPlayPos( xx );
@@ -1191,7 +1191,7 @@ private:
       if (mClicked == Button::Left) {
          auto &scrubber = Scrubber::Get( *pProject );
          scrubber.Cancel();
-         
+
          ProjectAudioManager::Get( *pProject ).Stop();
       }
 
@@ -1206,22 +1206,22 @@ public:
    ScrubbingCell( AdornedRulerPanel *parent )
    : AdornedRulerPanel::CommonCell{ parent, MenuChoice::Scrub }
    {}
-   
+
    std::vector<UIHandlePtr> HitTest(
       const TrackPanelMouseState &state,
       const AudacityProject *pProject) override;
-   
+
    // Return shared_ptr to self, stored in parent
    std::shared_ptr<TrackPanelCell> ContextMenuDelegate() override
       { return mParent->mScrubbingCell; }
-   
+
    bool Hit() const { return !mHolder.expired(); }
    bool Clicked() const {
       if (auto ptr = mHolder.lock())
          return ptr->Clicked();
       return false;
    }
-   
+
 private:
    std::weak_ptr<ScrubbingHandle> mHolder;
 };
@@ -1232,9 +1232,9 @@ std::vector<UIHandlePtr> AdornedRulerPanel::ScrubbingCell::HitTest(
    // Creation of overlays on demand here -- constructor of AdornedRulerPanel
    // is too early to do it
    mParent->CreateOverlays();
-   
+
    std::vector<UIHandlePtr> results;
-   
+
    // Disable mouse actions on Timeline while recording.
    if (!mParent->mIsRecording) {
       auto xx = state.state.m_x;
@@ -1243,7 +1243,7 @@ std::vector<UIHandlePtr> AdornedRulerPanel::ScrubbingCell::HitTest(
       result = AssignUIHandlePtr( mHolder, result );
       results.push_back( result );
    }
-   
+
    return results;
 }
 
@@ -1291,13 +1291,13 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
 )  : CellularPanel(parent, id, pos, size, viewinfo)
    , mProject { project }
    , mUpdater { ProjectTimeRuler::Get(*project).GetUpdater() }
-   , mRuler { ProjectTimeRuler::Get(*project).GetRuler() }   
+   , mRuler { ProjectTimeRuler::Get(*project).GetRuler() }
 {
    SetLayoutDirection(wxLayout_LeftToRight);
 
    mQPCell = std::make_shared<QPCell>( this );
    mScrubbingCell = std::make_shared<ScrubbingCell>( this );
-   
+
    for (auto &button : mButtons)
       button = nullptr;
 
@@ -1324,7 +1324,7 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
 
    mIsRecording = false;
 
-   mPlayRegionDragsSelection = (gPrefs->Read(wxT("/QuickPlay/DragSelection"), 0L) == 1)? true : false; 
+   mPlayRegionDragsSelection = (gPrefs->Read(wxT("/QuickPlay/DragSelection"), 0L) == 1)? true : false;
 
 #if wxUSE_TOOLTIPS
    wxToolTip::Enable(true);
@@ -1345,7 +1345,7 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
 
    mRulerInvalidatedSubscription =
       mRuler.Subscribe([this](auto) { Refresh(); });
-   
+
    // And call it once to initialize it
    DoSelectionChange( mViewInfo->selectedRegion );
 }
@@ -1413,8 +1413,8 @@ void AdornedRulerPanel::ReCreateButtons()
 
    const auto button = ToolBar::MakeButton(
       this,
-      bmpRecoloredUpSmall, bmpRecoloredDownSmall, 
-      bmpRecoloredUpHiliteSmall, bmpRecoloredHiliteSmall, 
+      bmpRecoloredUpSmall, bmpRecoloredDownSmall,
+      bmpRecoloredUpHiliteSmall, bmpRecoloredHiliteSmall,
       bmpCogwheel, bmpCogwheel, bmpCogwheel,
       OnTogglePinnedStateID, position, true, size
    );
@@ -1756,7 +1756,7 @@ auto AdornedRulerPanel::QPHandle::Click(
          mParent->HandleQPDrag( event.event, mX );
       }
    }
-   
+
    return result;
 }
 
@@ -1937,7 +1937,7 @@ auto AdornedRulerPanel::QPHandle::Preview(
 
    static wxCursor cursorHand{ wxCURSOR_HAND };
    static wxCursor cursorSizeWE{ wxCURSOR_SIZEWE };
-   
+
    bool showArrows = false;
    if (mParent)
       showArrows =
@@ -1946,7 +1946,7 @@ auto AdornedRulerPanel::QPHandle::Preview(
                state.state.m_x, mParent->mOldPlayRegion.GetStart())
          || mParent->IsWithinMarker(
                state.state.m_x, mParent->mOldPlayRegion.GetEnd());
-   
+
    return {
       message,
       showArrows ? &cursorSizeWE : &cursorHand,
@@ -2319,7 +2319,7 @@ void AdornedRulerPanel::OnTimelineFormatChange(wxCommandEvent& event)
    wxASSERT(id == OnMinutesAndSecondsID || id == OnBeatsAndMeasuresID);
    mTimeDisplayMode = id == OnBeatsAndMeasuresID ? TimeDisplayMode::BeatsAndMeasures :
                                              TimeDisplayMode::MinutesAndSeconds;
-   
+
    TimeDisplayModePreference.WriteEnum(mTimeDisplayMode);
 
    if (changeFlag != mTimeDisplayMode)
@@ -2383,7 +2383,7 @@ void AdornedRulerPanel::ShowContextMenu(
 
    switch (choice) {
       case MenuChoice::QuickPlay:
-         ShowMenu(position); 
+         ShowMenu(position);
          UpdateButtonStates();
          break;
       case MenuChoice::Scrub:
@@ -2434,7 +2434,7 @@ void AdornedRulerPanel::DoDrawBackground(wxDC * dc)
 
    if (ShowingScrubRuler()) {
       // Let's distinguish the scrubbing area by using a themable
-      // colour and a line to set it off.  
+      // colour and a line to set it off.
       AColor::UseThemeColour(dc, clrScrubRuler, TimelineTextColor() );
       wxRect ScrubRect = mScrubZone;
       ScrubRect.Inflate( 1,0 );

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1528,7 +1528,7 @@ void AdornedRulerPanel::DoIdle()
 
 void AdornedRulerPanel::OnAudioStartStop(AudioIOEvent evt)
 {
-   if (evt.type == AudioIOEvent::MONITOR)
+   if (evt.type == AudioIOEvent::MONITOR || evt.type == AudioIOEvent::PAUSE)
       return;
    if ( evt.type == AudioIOEvent::CAPTURE ) {
       if (evt.on)

--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -238,7 +238,7 @@ void HistoryDialog::Populate(ShuttleGui & S)
 
 void HistoryDialog::OnAudioIO(AudioIOEvent evt)
 {
-   if (evt.type == AudioIOEvent::MONITOR)
+   if (evt.type == AudioIOEvent::MONITOR || evt.type == AudioIOEvent::PAUSE)
       return;
    mAudioIOBusy = evt.on;
 

--- a/src/SpectralDataDialog.cpp
+++ b/src/SpectralDataDialog.cpp
@@ -241,7 +241,7 @@ void SpectralDataDialog::Populate(ShuttleGui & S)
 
 void SpectralDataDialog::OnAudioIO(AudioIOEvent ev)
 {
-   if (ev.type != AudioIOEvent::MONITOR)
+   if (ev.type != AudioIOEvent::MONITOR && ev.type != AudioIOEvent::PAUSE)
       mAudioIOBusy = ev.on;
 }
 

--- a/src/SpectralDataDialog.cpp
+++ b/src/SpectralDataDialog.cpp
@@ -216,7 +216,7 @@ void SpectralDataDialog::Populate(ShuttleGui & S)
             .AddSlider( {}, 5, 10, 1);
 
       S.AddWindow(safenew wxStaticLine{ S.GetParent() });
-      
+
       S.Id(ID_CHECKBOX_OVERTONES)
          .AddCheckBox(
             XXO("Auto-select overtones (beta)"),

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -824,7 +824,7 @@ void TrackPanel::Refresh(bool eraseBackground /* = TRUE */,
 
 void TrackPanel::OnAudioIO(AudioIOEvent evt)
 {
-   if (evt.type == AudioIOEvent::MONITOR)
+   if (evt.type == AudioIOEvent::MONITOR || evt.type == AudioIOEvent::PAUSE)
       return;
    // Some hit tests want to change their cursor to and from the ban symbol
    CallAfter( [this]{ CellularPanel::HandleCursorForPresentMouseState(); } );

--- a/src/effects/DynamicRangeProcessorHistoryPanel.h
+++ b/src/effects/DynamicRangeProcessorHistoryPanel.h
@@ -10,6 +10,7 @@
 **********************************************************************/
 #pragma once
 
+#include "DynamicRangeProcessorClock.h"
 #include "DynamicRangeProcessorHistory.h"
 #include "Observer.h"
 #include "wxPanelWrapper.h"
@@ -62,9 +63,11 @@ private:
    std::shared_ptr<DynamicRangeProcessorOutputPacketQueue> mOutputQueue;
    std::vector<DynamicRangeProcessorOutputPacket> mPacketBuffer;
    std::optional<DynamicRangeProcessorHistory> mHistory;
+   DynamicRangeProcessorClock mClock;
    const std::function<void(float)> mOnDbRangeChanged;
    const Observer::Subscription mInitializeProcessingSettingsSubscription;
    const Observer::Subscription mRealtimeResumeSubscription;
+   const Observer::Subscription mPlaybackEventSubscription;
    wxTimer mTimer;
    std::optional<ClockSynchronization> mSync;
    std::vector<double> mX;

--- a/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/PitchAndSpeedDialog.cpp
@@ -195,6 +195,7 @@ PitchAndSpeedDialog::PitchAndSpeedDialog(AudacityProject& project)
                   child->Enable(!event.on);
                break;
             case AudioIOEvent::MONITOR:
+            case AudioIOEvent::PAUSE:
                break;
             default:
                // Unknown event type

--- a/src/widgets/MeterPanel.cpp
+++ b/src/widgets/MeterPanel.cpp
@@ -1816,6 +1816,9 @@ void MeterPanel::StopMonitoring(){
 
 void MeterPanel::OnAudioIOStatus(AudioIOEvent evt)
 {
+   if (evt.type == AudioIOEvent::PAUSE)
+      return;
+
    if (!mIsInput != (evt.type == AudioIOEvent::PLAYBACK))
       return;
 


### PR DESCRIPTION
Resolves: #6589

In addition to the strictly necessary changes to fix the problem reported in #6589, 115e46fa5f12101330ae6b1ff23e506201792796 and 4756b37334080f6adc642b3237ece04c1ec6f665 also address some apparent mistake:
`ProcessingScope` was always calling `RealtimeEffectManager::ProcessStart(bool suspended)` and `ProcessEnd(bool suspended)`  with `false`, while dead code nearby suggested that the correct value should be `true` when playback was paused.
Rectifying this has the (positive?) consequence that `RealtimeSuspend()` and `RealtimeResume()` is called on `EffectInstance` implementations also when pausing or un-pausing playback. Testing should therefore cover existing implementations (see QA list).

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

## QA
### Limiter-specific:
- [ ] Interactions of play/pause/bypass behave as expected on the graph
- [ ] If the editor is opened during playback/pause/bypass state, further play/pause/bypass interactions behave as expected.
### General
- [ ] Anything unusual when pausing/resuming playback with an effect from any of the following, please report:
* AU
* Ladspa
* LV2
* VST
* VST3