### PR TITLE
Fix: only the pause command gets AudioIO to publish a pause event

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1688,7 +1688,7 @@ void AudioIO::StopStream()
    mPlaybackSchedule.ResetMode();
 }
 
-void AudioIO::SetPaused(bool state)
+void AudioIO::SetPaused(bool state, bool publish)
 {
    if (state != IsPaused())
    {
@@ -1701,7 +1701,9 @@ void AudioIO::SetPaused(bool state)
    }
 
    mPaused.store(state, std::memory_order_relaxed);
-   Publish({ mOwningProject.lock().get(), AudioIOEvent::PAUSE, state });
+
+   if (publish)
+      Publish({ mOwningProject.lock().get(), AudioIOEvent::PAUSE, state });
 }
 
 double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
@@ -2113,7 +2115,7 @@ bool AudioIO::ProcessPlaybackSlices(
 
             for(unsigned i = seq->NChannels(); i < mNumPlaybackChannels; ++i)
             {
-               
+
                pointers[i] = *scratch++;
                std::fill_n(pointers[i], len, .0f);
             }

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -494,7 +494,7 @@ public:
    { return mOwningProject.lock(); }
 
    /** \brief Pause and un-pause playback and recording */
-   void SetPaused(bool state);
+   void SetPaused(bool state, bool publish = false);
 
    /* Mixer services are always available.  If no stream is running, these
     * methods use whatever device is specified by the preferences.  If a

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1040,7 +1040,8 @@ void ProjectAudioManager::OnPause()
       scrubber.Pause(paused);
    else
    {
-      gAudioIO->SetPaused(paused);
+      constexpr auto publish = true;
+      gAudioIO->SetPaused(paused, publish);
    }
 }
 


### PR DESCRIPTION
Resolves: #6589 

This PR fixes a regression introduced in the previous PR for that ticket, #6657

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Pressing stop freezes the graph, pressing play clears it and it starts again
- [x] Pausing freezes the graph, un-pausing starts it again where it stopped (without clearing)