### PR TITLE
Reset layout and what's new dialog on upgrade to 3.6

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -422,6 +422,14 @@ void PopulatePreferences()
          gPrefs->DeleteEntry("/GUI/ShowSplashScreen");
    }
 
+   if (std::pair { vMajor, vMinor } < std::pair { 3, 6 })
+   {
+      if (gPrefs->Exists("/GUI/ShowSplashScreen"))
+         gPrefs->DeleteEntry("/GUI/ShowSplashScreen");
+      if (gPrefs->Exists(wxT("/GUI/ToolBars")))
+         gPrefs->DeleteGroup(wxT("/GUI/ToolBars"));
+   }
+
    // write out the version numbers to the prefs file for future checking
    gPrefs->Write(wxT("/Version/Major"), AUDACITY_VERSION);
    gPrefs->Write(wxT("/Version/Minor"), AUDACITY_RELEASE);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6679

QA: To test, open up 3.5 first, close it, then open this build. It should in particular make it such that the record and loop button don't get cut off. 