### PR TITLE
Pass unscaled values to text validator

### DIFF
--- a/src/effects/CompressorEditor.cpp
+++ b/src/effects/CompressorEditor.cpp
@@ -28,10 +28,20 @@ public:
 
    double Min() const override
    {
-      return mParameter.min;
+      return mParameter.min / mParameter.scale;
    }
 
    double Max() const override
+   {
+      return mParameter.max / mParameter.scale;
+   }
+
+   double SliderMin() const override
+   {
+      return mParameter.min;
+   }
+
+   double SliderMax() const override
    {
       return mParameter.max;
    }

--- a/src/effects/DynamicRangeProcessorEditor.cpp
+++ b/src/effects/DynamicRangeProcessorEditor.cpp
@@ -107,17 +107,18 @@ auto SliderToTextValue(double value, const ExtendedCompressorParameter& setting)
    const auto scaled = value / setting.param->TextToSlider();
    return setting.attributes.exponentialSlider ?
              MapExponentially(
-                setting.param->Min(), setting.param->Max(), scaled) :
+                setting.param->SliderMin(), setting.param->SliderMax(),
+                scaled) :
              scaled;
 }
 
 auto TextToSliderValue(ExtendedCompressorParameter& setting)
 {
-   const auto unscaled =
-      setting.attributes.exponentialSlider ?
-         MapLogarithmically(
-            setting.param->Min(), setting.param->Max(), setting.value) :
-         setting.value;
+   const auto unscaled = setting.attributes.exponentialSlider ?
+                            MapLogarithmically(
+                               setting.param->SliderMin(),
+                               setting.param->SliderMax(), setting.value) :
+                            setting.value;
    return unscaled * setting.param->TextToSlider();
 }
 } // namespace
@@ -412,12 +413,13 @@ void DynamicRangeProcessorEditor::AddTextboxAndSlider(
       Publish(EffectSettingChanged {});
    });
 
-   setting.slider = S.Name(setting.attributes.caption)
-                       .Style(wxSL_HORIZONTAL)
-                       .MinSize({ 100, -1 })
-                       .AddSlider(
-                          {}, TextToSliderValue(setting), setting.param->Max(),
-                          setting.param->Min());
+   setting.slider =
+      S.Name(setting.attributes.caption)
+         .Style(wxSL_HORIZONTAL)
+         .MinSize({ 100, -1 })
+         .AddSlider(
+            {}, TextToSliderValue(setting), setting.param->SliderMax(),
+            setting.param->SliderMin());
 
    setting.slider->Bind(wxEVT_SLIDER, [&](wxCommandEvent& evt) {
       setting.value = SliderToTextValue(evt.GetInt(), setting);

--- a/src/effects/DynamicRangeProcessorEditor.h
+++ b/src/effects/DynamicRangeProcessorEditor.h
@@ -62,6 +62,8 @@ public:
    virtual ~DynamicRangeProcessorParameter() = default;
    virtual double Min() const = 0;
    virtual double Max() const = 0;
+   virtual double SliderMin() const = 0;
+   virtual double SliderMax() const = 0;
    virtual double TextToSlider() const = 0;
 };
 

--- a/src/effects/LimiterEditor.cpp
+++ b/src/effects/LimiterEditor.cpp
@@ -22,10 +22,20 @@ struct ParameterWrapper : public DynamicRangeProcessorParameter
 
    double Min() const override
    {
-      return mParameter.min;
+      return mParameter.min / mParameter.scale;
    }
 
    double Max() const override
+   {
+      return mParameter.max / mParameter.scale;
+   }
+
+   double SliderMin() const override
+   {
+      return mParameter.min;
+   }
+
+   double SliderMax() const override
    {
       return mParameter.max;
    }


### PR DESCRIPTION
Resolves: #6694

We were passing unscaled slider values to the text validator.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
