### PR TITLE
WaveformPainter::MarkChanged() schedules cache clean-up

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -49,6 +49,8 @@ Paul Licameli split from WaveChannelView.cpp
 #include "waveform/WaveDataCache.h"
 #include "waveform/WavePaintParameters.h"
 
+#include <atomic>
+
 
 static WaveChannelSubView::Type sType{
    WaveChannelViewConstants::Waveform,
@@ -216,7 +218,8 @@ public:
 
    WaveformPainter& EnsureClip (const WaveClip& clip)
    {
-      if (&clip != mWaveClip)
+      const auto changed = mChanged.exchange(false);
+      if (&clip != mWaveClip || changed)
          mChannelCaches.clear();
 
       const auto nChannels = clip.NChannels();
@@ -288,7 +291,7 @@ public:
    {
       //Triggered when any part of the waveform has changed
       //TODO: invalidate parts of the cache that intersect changes
-      mChannelCaches.clear();
+      mChanged.store(true);
    }
 
    void Invalidate() override
@@ -315,6 +318,7 @@ private:
    };
 
    std::vector<ChannelCaches> mChannelCaches;
+   std::atomic<bool> mChanged = false;
 };
 
 void DrawWaveform(


### PR DESCRIPTION
Resolves: #6678 

Changes introduced in #6391 exposed to a race condition, whereby the main thread might call `WaveformPainter::EnsureClip()`, the audio thread clear the cache vector (via `WaveformPainter::MarkChanged()`), and the main thread read the cache vector.
Proposed solution: `MarkChanged` only schedules the cache reset vial an atomic boolean, The actual reset happens on the main thread.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
