### PR TITLE
Fixes OpenBSD/powerpc build

### DIFF
--- a/lib-src/pffft/pfsimd_macros.h
+++ b/lib-src/pffft/pfsimd_macros.h
@@ -60,7 +60,7 @@
 /*
    Altivec support macros 
 */
-#if !defined(PFFFT_SIMD_DISABLE) && (defined(__ppc__) || defined(__ppc64__))
+#if !defined(PFFFT_SIMD_DISABLE) && ((defined(__ppc__) || defined(__ppc64__)) && defined(__ALTIVEC__))
 #include <altivec.h>
 typedef vector float v4sf;
 #  define SIMD_SZ 4


### PR DESCRIPTION
Do not assume AltiVec when building on 32-bit PowerPC unless the compiler is
targeting a newer processor. OpenBSD/powerpc targets the G3. Both Clang and
GCC's AltiVec headers check for the compiler having AltiVec mode enabled.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
