### PR TITLE
Undo stack is cleared before project is compacted

### DIFF
--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -799,17 +799,6 @@ void ProjectFileManager::CompactProjectOnClose()
 
       // Attempt to compact the project
       projectFileIO.Compact( { mLastSavedTracks.get() } );
-
-      if ( !projectFileIO.WasCompacted() &&
-          UndoManager::Get( project ).UnsavedChanges() ) {
-         // If compaction failed, we must do some work in case of close
-         // without save.  Don't leave the document blob from the last
-         // push of undo history, when that undo state may get purged
-         // with deletion of some new sample blocks.
-         // REVIEW: UpdateSaved() might fail too.  Do we need to test
-         // for that and report it?
-         projectFileIO.UpdateSaved( mLastSavedTracks.get() );
-      }
    }
 }
 

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -530,17 +530,21 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    // TODO: Is there a Mac issue here??
    // SetMenuBar(NULL);
 
-   // Set (or not) the bypass flag to indicate that deletes that would happen during
-   // the UndoManager::ClearStates() below are not necessary.
-   projectFileIO.SetBypass();
-
    // This can reduce reference counts of sample blocks in the project's
-   // tracks. Do this before `CompactProjectOnClose` so that changes after the
-   // last save don't get written to the project file.
+   // tracks. No need to have `SetBypass()` called yet because the `tracks`
+   // object still holds strong references to the tracks.
+   // Do this before `CompactProjectOnClose()`, though, so that changes that are
+   // not track-specific (like project tempo) after the last save don't get
+   // written to the project file.
    UndoManager::Get(project).ClearStates();
 
    // Compact the project.
    projectFileManager.CompactProjectOnClose();
+
+   // Set (or not) the bypass flag to indicate that deletes that would happen
+   // during tracks.Clear() below are not necessary. Must be called after
+   // `CompactProjectOnClose()`.
+   projectFileIO.SetBypass();
 
    // Delete all the tracks to free up memory
    tracks.Clear();

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -530,21 +530,20 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    // TODO: Is there a Mac issue here??
    // SetMenuBar(NULL);
 
-   // Compact the project.
-   projectFileManager.CompactProjectOnClose();
-
    // Set (or not) the bypass flag to indicate that deletes that would happen during
    // the UndoManager::ClearStates() below are not necessary.
    projectFileIO.SetBypass();
 
-   {
-      // This can reduce reference counts of sample blocks in the project's
-      // tracks.
-      UndoManager::Get( project ).ClearStates();
+   // This can reduce reference counts of sample blocks in the project's
+   // tracks. Do this before `CompactProjectOnClose` so that changes after the
+   // last save don't get written to the project file.
+   UndoManager::Get(project).ClearStates();
 
-      // Delete all the tracks to free up memory
-      tracks.Clear();
-   }
+   // Compact the project.
+   projectFileManager.CompactProjectOnClose();
+
+   // Delete all the tracks to free up memory
+   tracks.Clear();
 
    // Some of the AdornedRulerPanel functions refer to the TrackPanel, so destroy this
    // before the TrackPanel is destroyed. This change was needed to stop Audacity
@@ -799,7 +798,7 @@ void ProjectManager::OnStatusChange(StatusBarField field)
 
    const auto &msg = ProjectStatus::Get( project ).Get( field );
    SetStatusText( msg, field );
-   
+
    if ( field == MainStatusBarField() )
       // When recording, let the NEW status message stay at least as long as
       // the timer interval (if it is not replaced again by this function),

--- a/src/TrackPanelResizeHandle.cpp
+++ b/src/TrackPanelResizeHandle.cpp
@@ -155,6 +155,9 @@ UIHandle::Result TrackPanelResizeHandle::Drag
 
    auto &view = ChannelView::Get(*theChannel);
 
+   if (view.GetMinimized() && mMode == IsResizingBetweenLinkedTracks)
+      return RefreshCode::Cancelled;
+
    const wxMouseEvent &event = evt.event;
 
    int delta = (event.m_y - mMouseClickY);
@@ -184,7 +187,7 @@ UIHandle::Result TrackPanelResizeHandle::Drag
    // Common pieces of code for MONO_WAVE_PAN and otherwise.
    auto doResizeBelow = [&] (Channel *prev) {
       // TODO: more-than-two-channels
-      
+
       auto &prevView = ChannelView::Get(*prev);
 
       double proportion = static_cast < double >(mInitialTrackHeight)


### PR DESCRIPTION
Resolves: #6453

This particular PR fixes actually [this problem](https://github.com/audacity/audacity/issues/6453#issuecomment-2186662391), but same ticket is reused.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] [this problem](https://github.com/audacity/audacity/issues/6453#issuecomment-2186662391) is fixed