### PR TITLE
Compressor and limiter accessibility: using the non-linear sliders

### DIFF
--- a/src/effects/DynamicRangeProcessorEditor.cpp
+++ b/src/effects/DynamicRangeProcessorEditor.cpp
@@ -427,12 +427,34 @@ void DynamicRangeProcessorEditor::AddTextboxAndSlider(
             setting.param->SliderMin());
 
    setting.slider->Bind(wxEVT_SLIDER, [&](wxCommandEvent& evt) {
-      setting.value = SliderToTextValue(evt.GetInt(), setting);
+      setting.value = SliderToTextValue(setting.slider->GetValue(), setting);
       setting.text->GetValidator()->TransferToWindow();
       EnableApply(mUIParent, mUIParent->Validate());
       ValidateUI();
       UpdateUI();
       Publish(EffectSettingChanged {});
+   });
+
+   // For exponential slider, for right/down arrow keys, because
+   // the setting value has precision of 1, ensure that
+   // the change in slider position results a change in value of
+   // at least 0.1, otherwise the slider position and setting value
+   // may not change.
+   setting.slider->Bind(wxEVT_SCROLL_LINEDOWN, [&](wxScrollEvent& evt) {
+      if (setting.attributes.exponentialSlider
+         && setting.value == SliderToTextValue(evt.GetInt(), setting)) {
+         setting.value += 0.1;
+         setting.slider->SetValue(std::round(TextToSliderValue(setting)));
+      }
+   });
+
+   // And similarly for left/up arrow keys.
+   setting.slider->Bind(wxEVT_SCROLL_LINEUP, [&](wxScrollEvent& evt) {
+      if (setting.attributes.exponentialSlider
+         && setting.value == SliderToTextValue(evt.GetInt(), setting)) {
+         setting.value -= 0.1;
+         setting.slider->SetValue(std::round(TextToSliderValue(setting)));
+      }
    });
 }
 
@@ -457,7 +479,7 @@ bool DynamicRangeProcessorEditor::UpdateUI()
       *GetLimiterSettings() = *mAccess.Get().cast<LimiterSettings>();
 
    for (auto& setting : mParameters)
-      setting.slider->SetValue(TextToSliderValue(setting));
+      setting.slider->SetValue(std::round(TextToSliderValue(setting)));
 
    if (
       auto tfPanel =


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6714

Problem:
When using the exponential sliders with arrow keys, there are two issues: A. Right/down arrow key does not change the position.

B. When the position is near the left hand end of the slider, the arrow keys don't change the position of the slider. The setting value has a precision of 1 decimal place. Near the left hand end of the slider, a change is slider position by 1, may result in a change setting value, when "rounded" to 1 decimal place of zero. So the slider position and setting value is unchanged.

Fixes:
A. In bool DynamicRangeProcessorEditor::UpdateUI(), round the value when setting the slider positions.

B. Handle the wxEVT_SCROLL_LINEDOWN and wxEVT_SCROLL_LINEUP events, and ensure that the change in the slider position results in a change of setting value of at least 0.1.

Resolves: https://github.com/audacity/audacity/issues/6714


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
