### PR TITLE
Usability of various sliders for keyboard users

### DIFF
--- a/src/toolbars/TranscriptionToolBar.cpp
+++ b/src/toolbars/TranscriptionToolBar.cpp
@@ -1126,7 +1126,7 @@ void OnPlaySpeedInc(const CommandContext &context)
    auto tb = &TranscriptionToolBar::Get( project );
 
    if (tb) {
-      tb->AdjustPlaySpeed(0.01f);
+      tb->AdjustPlaySpeed(0.1f);
    }
 }
 
@@ -1136,7 +1136,7 @@ void OnPlaySpeedDec(const CommandContext &context)
    auto tb = &TranscriptionToolBar::Get( project );
 
    if (tb) {
-      tb->AdjustPlaySpeed(-0.01f);
+      tb->AdjustPlaySpeed(-0.1f);
    }
 }
 

--- a/src/widgets/ASlider.cpp
+++ b/src/widgets/ASlider.cpp
@@ -541,7 +541,7 @@ LWSlider::LWSlider(wxWindow *parent,
       stepValue = STEP_CONTINUOUS;
       break;
    case SPEED_SLIDER:
-      minValue = 0.001f;
+      minValue = 0.01f;
       maxValue = 3.000f;
       stepValue = STEP_CONTINUOUS;
       break;
@@ -1578,7 +1578,7 @@ void LWSlider::Increase(float steps)
 
    if ( stepValue == 0.0 )
    {
-      stepValue = ( mMaxValue - mMinValue ) / 100.0;
+      stepValue = ( mMaxValue - mMinValue ) / 10.0;
    }
 
    mCurrentValue += ( steps * stepValue );
@@ -1601,7 +1601,7 @@ void LWSlider::Decrease(float steps)
 
    if ( stepValue == 0.0 )
    {
-      stepValue = ( mMaxValue - mMinValue ) / 100.0;
+      stepValue = ( mMaxValue - mMinValue ) / 10.0;
    }
 
    mCurrentValue -= ( steps * stepValue );


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6801

A number of bugs were introduced by a PR for changing the play-at-speed accuracy back to 3 decimal places (commit: 37330d6). These bugs are all fixed by reverting some of the unnecessary changes in that PR.

A
Problem: the step size for keyboard users of ASliders is too small (For example the recording and playback level sliders). This is fixed by reverting the constant 100.0 to 10.0 in LWSlider::Increase() and LWSLider::Decrease().

B
Problem: For the play-at-speed slider, using the keyboard, it's not easy to get back to a speed of exactly 1.000. This was caused by the change of the minimum of the speed slider being changed from 0.01 to 0.001, and the dependence of LWSlider::Increase() and LWSlider::Decrease() on that value. So the minimum value of the speed slider was reverted to 0.01 (which I think is quite slow enough).

C
Problem: The commands Extra > Play at speed > Increase/Decrease playback speed, result in very small changes of speed. Fixed by reverting the constant 0.01 to 0.1 in OnPlaySpeedInc() and OnPlaySpeedDec()


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
