### PR TITLE
Clip resample crash fix

### DIFF
--- a/libraries/lib-math/Resample.h
+++ b/libraries/lib-math/Resample.h
@@ -39,6 +39,12 @@ class MATH_API Resample final
    Resample(const bool useBestMethod, const double dMinFactor, const double dMaxFactor);
    ~Resample();
 
+   Resample( Resample&&) noexcept = default;
+   Resample& operator=(Resample&&) noexcept = default;
+
+   Resample(const Resample&) = delete;
+   Resample& operator=(const Resample&) = delete;
+
    static EnumSetting< int > FastMethodSetting;
    static EnumSetting< int > BestMethodSetting;
 


### PR DESCRIPTION
As now clips may have multiple sequences in it we must create individual `Resample` instance for each of them to avoid internal state mixing that may happen in case of single `Resampler` is used to process every channel.

Resolves: #6810 

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
