### PR TITLE
Allow running update_po_files.sh from anywhere

### DIFF
--- a/locale/update_po_files.sh
+++ b/locale/update_po_files.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
-# Run this script with locale as the current directory
 set -o errexit
+
+# Enter the script directory
+CDPATH= cd -- "$(dirname -- "$0")"
+
 echo ";; Recreating audacity.pot using .h, .cpp and .mm files"
 for path in ../modules/* ../libraries/lib-* ../include ../src ../crashreports ; do
    find $path -name \*.h -o -name \*.cpp -o -name \*.mm


### PR DESCRIPTION
The script `locale/update_po_files.sh` assumes it's executed when the current directory is `locale`.

How about you can do it from any position?

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
