### PR TITLE
View menu: duplicate access key.

### DIFF
--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -346,7 +346,7 @@ auto ViewMenu()
          Command( wxT("ShowClipping"), XXO("&Show Clipping in Waveform"),
             OnShowClipping, AlwaysEnabledFlag,
             Options{}.CheckTest( wxT("/GUI/ShowClipping"), false ) ),
-         Command( wxT("ShowRMS"), XXO("Show &RMS in Waveform"),
+         Command( wxT("ShowRMS"), XXO("Sho&w RMS in Waveform"),
             OnShowRMS, AlwaysEnabledFlag,
             Options{}.CheckTest( ShowRMSPref() ) )
       )


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6813

Changed the access key of "Show RMS waveform" so that there isn't a duplicate access key.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
