### PR TITLE
Add command flag to grey out time track menu option if time track exists

### DIFF
--- a/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
@@ -10,6 +10,7 @@ Paul Licameli split from TrackMenus.cpp
 **********************************************************************/
 
 #include "CommonCommandFlags.h"
+#include "CommandContext.h"
 #include "ProjectHistory.h"
 
 #include "SelectUtilities.h"
@@ -28,12 +29,12 @@ void OnNewTimeTrack(const CommandContext &context)
    auto &project = context.project;
    auto &tracks = TrackList::Get( project );
 
-   if (*tracks.Any<TimeTrack>().begin()) {
-      AudacityMessageBox(
-         XO(
-"This version of Audacity only allows one time track for each project window.") );
-      return;
-   }
+//    if (*tracks.Any<TimeTrack>().begin()) {
+//       AudacityMessageBox(
+//          XO(
+// "This version of Audacity only allows one time track for each project window.") );
+//       return;
+//    }
 
    auto t = tracks.AddToHead(std::make_shared<TimeTrack>());
 
@@ -48,9 +49,19 @@ void OnNewTimeTrack(const CommandContext &context)
    Viewport::Get(project).ShowTrack(*t);
 }
 
+const ReservedCommandFlag &TimeTrackDoesNotExistFlag()
+{
+   static ReservedCommandFlag flag{
+      [](const AudacityProject &project){
+         return TrackList::Get(project).Any<const TimeTrack>().empty();
+      }
+   };
+   return flag;
+}
+
 AttachedItem sAttachment{
    Command( wxT("NewTimeTrack"), XXO("&Time Track"),
-        OnNewTimeTrack, AudioIONotBusyFlag()
+        OnNewTimeTrack, AudioIONotBusyFlag() | TimeTrackDoesNotExistFlag()
    ),
    wxT("Tracks/Add/Add")
 };

--- a/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackMenuItems.cpp
@@ -29,13 +29,6 @@ void OnNewTimeTrack(const CommandContext &context)
    auto &project = context.project;
    auto &tracks = TrackList::Get( project );
 
-//    if (*tracks.Any<TimeTrack>().begin()) {
-//       AudacityMessageBox(
-//          XO(
-// "This version of Audacity only allows one time track for each project window.") );
-//       return;
-//    }
-
    auto t = tracks.AddToHead(std::make_shared<TimeTrack>());
 
    SelectUtilities::SelectNone( project );


### PR DESCRIPTION
Resolves: #6052 

Added a new command flag in TimeTrackMenuItems.cpp and commented out the previous error message that popped up if a time track already existed. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
