### PR TITLE
Attempt to fix jumping playhead

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1328,7 +1328,7 @@ bool AudioIO::AllocateBuffers(
             const auto timeQueueSize = 1 +
                (playbackBufferSize + TimeQueueGrainSize - 1)
                   / TimeQueueGrainSize;
-            mPlaybackSchedule.mTimeQueue.Resize( timeQueueSize );
+            mPlaybackSchedule.mTimeQueue.Init( timeQueueSize );
          }
 
          if( mNumCaptureChannels > 0 )


### PR DESCRIPTION
Resolves: #6536, #6844

With large latency values `TimeQueue` buffer values could have become overwritten. The issue is temporary fixed by buffer reallocation in case if overwrite is detected.

QA:
Please also check scrubbing and seek.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
