### PR TITLE
Export crash fix

### DIFF
--- a/libraries/lib-mixer/Mix.cpp
+++ b/libraries/lib-mixer/Mix.cpp
@@ -107,7 +107,7 @@ Mixer::Mixer(
     , mFloatBuffers { 3, mBufferSize, 1, 1 }
 
     // non-interleaved
-    , mTemp { 3, mBufferSize, 1, 1 }
+    , mTemp { mNumChannels, mBufferSize, 1, 1 }
     , mBuffer { initVector<SampleBuffer>(
          mInterleaved ? 1 : mNumChannels,
          [format = mFormat,


### PR DESCRIPTION
Crash was caused by an attempt to write outside of `mTemp` buffer when number of exported channels was more than 3.

Resolves: #6889

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
