### PR TITLE
Fix crash when pasting mono into stereo

### DIFF
--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -652,10 +652,24 @@ void OnPaste(const CommandContext &context)
                   const auto merge = newClipOnPaste ? false : true;
                   const auto preserveExistingBoundaries = newClipOnPaste ? false : true;
                   auto clearByTrimming = newClipOnPaste ? true : false;
-                  wn.ClearAndPaste(
-                     t0, t1, *static_cast<const WaveTrack*>(src),
-                     preserveExistingBoundaries, merge, &warper,
-                     clearByTrimming);
+                  if(src->NChannels() == 1 && wn.NChannels() == 2)
+                  {
+                     // When the source is mono, may paste its only channel
+                     // repeatedly into a stereo track
+                     const auto pastedTrack = std::static_pointer_cast<WaveTrack>(src->Duplicate());
+                     pastedTrack->MonoToStereo();
+                     wn.ClearAndPaste(
+                        t0, t1, *pastedTrack,
+                        preserveExistingBoundaries, merge, &warper,
+                        clearByTrimming);
+                  }
+                  else
+                  {
+                     wn.ClearAndPaste(
+                        t0, t1, *static_cast<const WaveTrack*>(src),
+                        preserveExistingBoundaries, merge, &warper,
+                        clearByTrimming);
+                  }
                },
                [&](LabelTrack &ln){
                   // Per Bug 293, users expect labels to move on a paste into


### PR DESCRIPTION
Fulfill the precondition of `WaveTrack::ClearAndPaste` by duplicating the only channel into two

Resolves: #6882 

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
