### PR TITLE
Fix for TCP UI Breaks when dragging waveform splitter

### DIFF
--- a/src/TrackPanelResizeHandle.cpp
+++ b/src/TrackPanelResizeHandle.cpp
@@ -155,6 +155,9 @@ UIHandle::Result TrackPanelResizeHandle::Drag
 
    auto &view = ChannelView::Get(*theChannel);
 
+   if (view.GetMinimized() && mMode == IsResizingBetweenLinkedTracks)
+      return RefreshCode::Cancelled;
+
    const wxMouseEvent &event = evt.event;
 
    int delta = (event.m_y - mMouseClickY);
@@ -184,7 +187,7 @@ UIHandle::Result TrackPanelResizeHandle::Drag
    // Common pieces of code for MONO_WAVE_PAN and otherwise.
    auto doResizeBelow = [&] (Channel *prev) {
       // TODO: more-than-two-channels
-      
+
       auto &prevView = ChannelView::Get(*prev);
 
       double proportion = static_cast < double >(mInitialTrackHeight)


### PR DESCRIPTION
Resolves: #6751 

I think the perfect fix would be to fail the hit test when the track is minimized and the cursor is above the left/right channel horizontal line, but I couldn't figure out how to make this work, and I think this simple fix does the trick UX-wise.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
