### PR TITLE
Importing audio files: do not change time selection

### DIFF
--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1356,7 +1356,7 @@ bool ProjectFileManager::Import(wxArrayString fileNames, bool addToHistory)
           addToHistory))
       return false;
    // Last track in the project is the one that was just added. Use it for
-   // focus, selection, etc.
+   // focus, etc.
    Track* lastTrack = nullptr;
    const auto range = TrackList::Get(mProject).Any<Track>();
    assert(!range.empty());
@@ -1373,8 +1373,6 @@ bool ProjectFileManager::Import(wxArrayString fileNames, bool addToHistory)
       viewPort.ZoomFitHorizontally();
       viewPort.ShowTrack(*track);
       viewPort.HandleResize(); // Adjust scrollers for NEW track sizes.
-      ViewInfo::Get(*project).selectedRegion.setTimes(
-         track->GetStartTime(), track->GetEndTime());
    });
    return true;
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6929

Problem:
In 3.6.0, when importing audio files, the time selection is set to cover the audio in the last imported file. This is a change wrt previous versions, can means that users loose any previously set time selection. It was introduced by the commit: 4532f561db

Fix:
Remove the setting of the time selection when importing audio files.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
