### PR TITLE
6857 fix: pitch-shift value not showing on Linux

### DIFF
--- a/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
@@ -189,7 +189,7 @@ int ClipButtonSpecializations<ClipButtonId::Pitch>::GetWidth(
    const ClipInterface& clip)
 {
    // If we are to show some decimals, reserve a bit more space.
-   return clip.GetCentShift() % 100 == 0 ? 30 : 50;
+   return clip.GetCentShift() % 100 == 0 ? 32 : 55;
 }
 
 int ClipButtonSpecializations<ClipButtonId::Speed>::GetWidth(


### PR DESCRIPTION
Resolves: #6857

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] #6857 is fixed
- [ ] also works for pitch shift values with cents (use the pitch and speed clip dialog for that)