### PR TITLE
Fix out of bound access in waveform cache

### DIFF
--- a/libraries/lib-wave-track-paint/GraphicsDataCache.cpp
+++ b/libraries/lib-wave-track-paint/GraphicsDataCache.cpp
@@ -134,7 +134,7 @@ GraphicsDataCacheBase::PerformBaseLookup(
    const int64_t width = right - left;
 
    const int64_t cacheLeft       = left / CacheElementWidth;
-   const int64_t cacheRight      = right / CacheElementWidth + 1;
+   const int64_t cacheRight      = (right + CacheElementWidth - 1) / CacheElementWidth;
    const int64_t cacheItemsCount = cacheRight - cacheLeft;
 
    const int64_t cacheLeftColumn  = cacheLeft * CacheElementWidth;


### PR DESCRIPTION
Resolves: on a certain combination of wxWidgets versions and OS, waveform painting was corrupting the memory and resulted in a white screen.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
