### PR TITLE
Merged lower limit and upper limit dialog boxes in time track controls

### DIFF
--- a/src/tracks/timetrack/ui/TimeTrackControls.cpp
+++ b/src/tracks/timetrack/ui/TimeTrackControls.cpp
@@ -115,18 +115,19 @@ void TimeTrackMenuTable::OnSetTimeTrackRange(wxCommandEvent & /*event*/)
    if (dlg.ShowModal() == wxID_CANCEL)
       return;
 
-   lower = scLower->GetValue();
-   upper = scUpper->GetValue();
-
-   if(lower >= upper) {
+   while(scLower->GetValue() >= scUpper->GetValue()) {
       AudacityMessageBox(
          XO("Upper Speed Limit must be greater than the Lower Speed Limit"),
          XO("Invalid Limits"),
          wxOK | wxICON_ERROR,
          mpData->pParent);
 
-      return;
+      if (dlg.ShowModal() == wxID_CANCEL)
+         return;
    }
+
+   lower = scLower->GetValue();
+   upper = scUpper->GetValue();
 
    if (lower >= TimeTrackControls::kRangeMin &&
        upper <= TimeTrackControls::kRangeMax) {


### PR DESCRIPTION
Resolves: #6736

- Used wxDialogWrapper the Shuttle gui system to create a new dialog box with both the lower speed limit spinctrl and upper speed limit spinctrl in one place.
- Used AudacityMessageBox to show an error message and block the user from setting invalid limits.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
