### PR TITLE
Update WaveTrack clips naming scheme

### DIFF
--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -796,7 +796,7 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
       wxString name;
       for (auto i = 1; ; ++i) {
          //i18n-hint a numerical suffix added to distinguish otherwise like-named clips when new record started
-         name = XC("%s #%d", "clip name template")
+         name = XC("%s.%d", "clip name template")
             .Format(track.GetName(), i).Translation();
          if (!track.HasClipNamed(name))
             break;


### PR DESCRIPTION
Resolves: [#6926](https://github.com/audacity/audacity/issues/6926)

While discussing issue [#6926](https://github.com/audacity/audacity/issues/6926), @LWinterberg @dozzzzer @kryksyh came up with these changes to new clip naming:

Previous behavior:
- Recordings are named as `TrackName #TakeNo`
- Generated clips are named as `TrackName ClipNo` 
- Clip copies are named as "OriginalName.CopyNo`, which was broken since 3.5.0
- The numbering of recordings and generated clips was parallel, meaning there could be a recording named `TrackName #1` and a generated clip named `TrackName 1`

To unify and simplify naming, the behavior will be changed as follows:

- Recordings are named as `TrackName.ClipNo`
- Generated clips are named the same as recordings `TrackName.ClipNo`
- Clip copies keep the original name without additional numbering

---


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
