### PR TITLE
Envelope display fix: pass absolute time value when querying envelope.

### DIFF
--- a/libraries/lib-wave-track-paint/waveform/WaveBitmapCache.cpp
+++ b/libraries/lib-wave-track-paint/waveform/WaveBitmapCache.cpp
@@ -155,7 +155,8 @@ struct WaveBitmapCache::LookupHelper final
       {
          envelope->GetValues(
             EnvelopeValues.data(), static_cast<int>(EnvelopeValues.size()),
-            key.FirstSample / cache->GetScaledSampleRate(),
+            key.FirstSample / cache->GetScaledSampleRate() +
+               envelope->GetOffset(),
             1.0 / key.PixelsPerSecond);
 
          for (size_t column = 0; column < columnsCount; ++column)


### PR DESCRIPTION
Resolves: #6927

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] #6927 is fixed
- [x] Also test that stretching clips still shows and plays the correct envelope