### PR TITLE
freeze-after-undo fix: make sure the deletion callback isn't copied.

### DIFF
--- a/libraries/lib-wave-track/SampleBlock.h
+++ b/libraries/lib-wave-track/SampleBlock.h
@@ -46,8 +46,6 @@ public:
 class WAVE_TRACK_API SampleBlock
 {
 public:
-   using DeletionCallback = std::function<void(const SampleBlock &)>;
-
    virtual ~SampleBlock();
 
    virtual void CloseLock() noexcept = 0;


### PR DESCRIPTION
Resolves: #6995 

https://github.com/audacity/audacity/pull/6333 fixed what it intended to fix but incorrectly : where it intended there to be only one sample-block-deletion callback instance, it was accidentally copied, defeating the purpose of the design.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] fixes #6995 (it may still take a long time, but now there is the progress dialog that was supposed to be there)
- [ ] #6321 is still fixed