### PR TITLE
[AU4] Make VolumePressureMeter depend on the number of channels

### DIFF
--- a/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -174,25 +174,52 @@ ListItemBlank {
         SeparatorLine {}
 
         Row {
-            Layout.alignment: Qt.AlignTop
-            Layout.preferredWidth: childrenRect.width
-            Layout.margins: 5
-            Layout.bottomMargin: 20
+            id: volumePressureContainer
+            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+            Layout.preferredWidth: 24
             Layout.preferredHeight: root.height
+            topPadding: 5
 
             spacing: 2
-
-            VolumePressureMeter {
-                id: leftPressure
-                height: parent.height
-                currentVolumePressure: root.item.leftChannelPressure
+            Repeater {
+                id: volumePressureMeters
+                model: root.item.channelCount
+                VolumePressureMeter {
+                    currentVolumePressure: index === 0 ? root.item.leftChannelPressure :
+                                                         root.item.rightChannelPressure
+                }
             }
 
-            VolumePressureMeter {
-                id: rightPressure
-                height: parent.height
-                currentVolumePressure: root.item.rightChannelPressure
-            }
+            states: [
+                State {
+                    when: root.item.channelCount === 1
+                    name: "mono"
+                    PropertyChanges {
+                        target: volumePressureContainer
+                        leftPadding: 8
+                    }
+                    PropertyChanges {
+                        target: volumePressureMeters.itemAt(0)
+                        indicatorWidth: 8
+                    }
+                },
+                State {
+                    when: root.item.channelCount === 2
+                    name: "stereo"
+                    PropertyChanges {
+                        target: volumePressureContainer
+                        leftPadding: 4
+                    }
+                    PropertyChanges {
+                        target: volumePressureMeters.itemAt(0)
+                        indicatorWidth: 7
+                    }
+                    PropertyChanges {
+                        target: volumePressureMeters.itemAt(1)
+                        indicatorWidth: 7
+                    }
+                }
+            ]
         }
     }
 

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/VolumePressureMeter.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/VolumePressureMeter.qml
@@ -18,13 +18,14 @@ Canvas {
     property real minDisplayedVolumePressure: -60.0
     property real maxDisplayedVolumePressure: 0.0
 
+    property real indicatorWidth
     property bool showRuler: false
     property int style: VolumePressureMeter.Style.Solid
     property color meterColor: "#7689E6" // TODO: Use the track color
 
     property bool isClipping: currentVolumePressure >= maxDisplayedVolumePressure
 
-    width: root.showRuler ? prv.indicatorWidth + 20 : prv.indicatorWidth
+    width: root.showRuler ? indicatorWidth + 20 : indicatorWidth
     height: parent.height
 
     QtObject {
@@ -34,7 +35,7 @@ Canvas {
         readonly property int overloadHeight: 4
 
         readonly property real indicatorHeight: root.height - prv.overloadHeight - 6
-        readonly property real indicatorWidth: 8
+
 
         // value ranges
         readonly property int fullValueRangeLength: root.maxDisplayedVolumePressure - root.minDisplayedVolumePressure
@@ -144,7 +145,7 @@ Canvas {
     }
 
     function drawRuler(ctx, originHPos, originVPos) {
-        ctx.clearRect(prv.indicatorWidth, 0, root.width - prv.indicatorWidth, root.height)
+        ctx.clearRect(indicatorWidth, 0, root.width - indicatorWidth, root.height)
         ctx.font = prv.unitTextFont
 
         // Minimal height of a single full step
@@ -196,14 +197,14 @@ Canvas {
             }
         }
 
-        ctx.clearRect(0, 0, prv.indicatorWidth, prv.indicatorHeight)
+        ctx.clearRect(0, 0, indicatorWidth, prv.indicatorHeight)
 
         // Filling the background of the meter
-        drawRoundedRect(ctx, ui.theme.strokeColor, 0, 0, prv.indicatorWidth, prv.indicatorHeight, 2, "both")
+        drawRoundedRect(ctx, ui.theme.strokeColor, 0, 0, indicatorWidth, prv.indicatorHeight, 2, "both")
 
         // Drawing the Overload indicator
         const overloadStyle = root.isClipping ? "#EF476F" : ui.theme.buttonColor
-        drawRoundedRect(ctx, overloadStyle, 0, 0, prv.indicatorWidth, prv.overloadHeight, 2, "top")
+        drawRoundedRect(ctx, overloadStyle, 0, 0, indicatorWidth, prv.overloadHeight, 2, "top")
 
         // Clamping the current volume pressure
         const volumePressure = Math.max(minDisplayedVolumePressure,
@@ -215,13 +216,13 @@ Canvas {
             // Drawing the volume pressure
             drawRoundedRect(ctx, getMeterFillStyle(ctx),
                             0, root.height - 10 - meterHeight,
-                            prv.indicatorWidth, meterHeight,
+                            indicatorWidth, meterHeight,
                             /* radius */ 2, /* rounded edge */ "bottom")
         }
 
         if (prv.rulerNeedsPaint) {
             var originVPos = prv.overloadHeight
-            var originHPos = prv.indicatorWidth + prv.strokeHorizontalMargin
+            var originHPos = indicatorWidth + prv.strokeHorizontalMargin
 
             drawRuler(ctx, originHPos, originVPos)
         }

--- a/au4/src/projectscene/view/trackspanel/trackitem.cpp
+++ b/au4/src/projectscene/view/trackspanel/trackitem.cpp
@@ -38,6 +38,7 @@ TrackItem::~TrackItem()
 void TrackItem::init(const processing::Track& track)
 {
     m_trackId = track.id;
+    m_trackType = track.type;
     setTitle(track.title);
 }
 
@@ -54,6 +55,17 @@ QVariant TrackItem::trackId_property() const
 QString TrackItem::title() const
 {
     return m_title;
+}
+
+int TrackItem::channelCount() const {
+    switch (m_trackType) {
+    case processing::TrackType::Mono:
+        return 1;
+    case processing::TrackType::Stereo:
+        return 2;
+    default:
+       return 0;
+    }
 }
 
 float TrackItem::leftChannelPressure() const

--- a/au4/src/projectscene/view/trackspanel/trackitem.h
+++ b/au4/src/projectscene/view/trackspanel/trackitem.h
@@ -21,6 +21,7 @@ class TrackItem : public QObject, public muse::async::Asyncable
 
     Q_PROPERTY(QVariant trackId READ trackId_property CONSTANT)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
+    Q_PROPERTY(int channelCount READ channelCount CONSTANT)
 
     Q_PROPERTY(float leftChannelPressure READ leftChannelPressure NOTIFY leftChannelPressureChanged)
     Q_PROPERTY(float rightChannelPressure READ rightChannelPressure NOTIFY rightChannelPressureChanged)
@@ -43,6 +44,7 @@ public:
     processing::TrackId trackId() const;
     QVariant trackId_property() const;
     QString title() const;
+    int channelCount() const;
 
     float leftChannelPressure() const;
     float rightChannelPressure() const;
@@ -112,6 +114,7 @@ protected:
     audio::AudioOutputParams m_outParams;
 
     processing::TrackId m_trackId = -1;
+    processing::TrackType m_trackType = processing::TrackType::Undefined;
     QString m_title;
     bool m_outputOnly = false;
 


### PR DESCRIPTION
Resolves: [#6573](https://github.com/audacity/audacity/issues/6573)

Adjust visuals depending on the number of channels for the track

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
