### PR TITLE
Changed Insane to Excessive and deleted 2 comments

### DIFF
--- a/modules/import-export/mod-mp3/ExportMP3.cpp
+++ b/modules/import-export/mod-mp3/ExportMP3.cpp
@@ -181,16 +181,14 @@ static const TranslatableStrings varModeNames {
 };
 */
 static const TranslatableStrings setRateNames {
-   /* i18n-hint: Slightly humorous - as in use an insane precision with MP3.*/
-   XO("Insane, 320 kbps"),
+   XO("Excessive, 320 kbps"),
    XO("Extreme, 220-260 kbps"),
    XO("Standard, 170-210 kbps"),
    XO("Medium, 145-185 kbps"),
 };
 
 static const TranslatableStrings setRateNamesShort {
-   /* i18n-hint: Slightly humorous - as in use an insane precision with MP3.*/
-   XO("Insane"),
+   XO("Excessive"),
    XO("Extreme"),
    XO("Standard"),
    XO("Medium"),


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/7008

Thanks Leo and Peter for the superfast feedback.

- Changed the two "Insane" strings to "Excessive", and removed the comments above them
- Worked only in `ExportMP3.cpp`

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
