### PR TITLE
[AU4] Add dynamic tooltip to the balance knob

### DIFF
--- a/au4/CMakeLists.txt
+++ b/au4/CMakeLists.txt
@@ -24,7 +24,7 @@ include(FetchContent)
 FetchContent_Declare(
   muse_framework
   GIT_REPOSITORY https://github.com/musescore/framework_tmp.git
-  GIT_TAG        u0801_2
+  GIT_TAG        u0806
 )
 
 FetchContent_GetProperties(muse_framework)

--- a/au4/src/projectscene/projectscene.qrc
+++ b/au4/src/projectscene/projectscene.qrc
@@ -11,6 +11,8 @@
         <file>qml/Audacity/ProjectScene/trackspanel/TracksControlPanel.qml</file>
         <file>qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml</file>
         <file>qml/Audacity/ProjectScene/trackspanel/audio/KnobControl.qml</file>
+        <file>qml/Audacity/ProjectScene/trackspanel/audio/BalanceKnob.qml</file>
+        <file>qml/Audacity/ProjectScene/trackspanel/audio/BalanceTooltip.qml</file>
         <file>qml/Audacity/ProjectScene/trackspanel/audio/VolumePressureMeter.qml</file>
         <file>qml/Audacity/ProjectScene/toolbars/ProjectToolBar.qml</file>
         <file>qml/Audacity/ProjectScene/clipsview/PlayCursor.qml</file>

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -109,6 +109,21 @@ ListItemBlank {
 
                 spacing: 16
 
+                BalanceKnob {
+                    value: root.item.balance
+
+                    onNewValueRequested: function(newValue) {
+                        root.item.balance = newValue
+                    }
+                }
+
+                StyledSlider {
+                    Layout.fillWidth: true
+
+                    value: root.item.volumeLevel
+                }
+
+
                 RowLayout {
                     Layout.fillWidth: true
 
@@ -136,24 +151,6 @@ ListItemBlank {
                         onToggled: {
                             root.item.solo = !checked
                         }
-                    }
-                }
-
-                StyledSlider {
-                    Layout.fillWidth: true
-
-                    value: root.item.volumeLevel
-                }
-
-                KnobControl {
-                    from: -100
-                    to: 100
-                    value: root.item.balance
-                    stepSize: 1
-                    isBalanceKnob: true
-
-                    onNewValueRequested: function(newValue) {
-                        root.item.balance = newValue
                     }
                 }
             }

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/BalanceKnob.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/BalanceKnob.qml
@@ -1,0 +1,30 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+KnobControl {
+    id: root
+    isBalanceKnob: true
+
+    from: -100
+    to: 100
+    stepSize: 1
+
+    BalanceTooltip {
+        id: tooltip
+        value: root.value
+    }
+
+    onMouseEntered: {
+        tooltip.show()
+    }
+
+    onMouseExited: {
+        tooltip.hide()
+    }
+}

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/BalanceTooltip.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/BalanceTooltip.qml
@@ -1,0 +1,72 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+StyledPopupView {
+    id: root
+    placement: PopupView.Above
+    openPolicies: PopupView.NoActivateFocus
+    padding: 8
+    margins: 8
+    contentWidth: contentRect.width
+    contentHeight: contentRect.height
+
+    property rect contentRect: fontMetrics.boundingRect("Pan: 100R")
+    property double value: 0
+
+    Item {
+        anchors.fill: parent
+        id: content
+        Text {
+            anchors.fill: parent
+            text: "Pan:"
+        }
+
+        Text {
+            anchors.right: parent.right
+            text: {
+                let value = Math.round(root.value);
+                let direction = value < 0 ? 'L' : value > 0 ? 'R' : '';
+                return `${Math.abs(value)}${direction}`;
+            }
+        }
+    }
+
+    FontMetrics {
+        id: fontMetrics
+        font: content.font
+    }
+
+    Timer {
+        id: openTimer
+        interval: ui.theme.tooltipDelay
+        repeat: false
+        onTriggered: {
+            open()
+        }
+    }
+
+    Timer {
+        id: closeTimer
+        interval: ui.theme.tooltipDelay
+        repeat: false
+        onTriggered: {
+            close()
+        }
+    }
+
+    function show() {
+        openTimer.restart()
+        closeTimer.stop()
+    }
+
+    function hide() {
+        closeTimer.restart()
+        openTimer.stop()
+    }
+}


### PR DESCRIPTION
Resolves: [#6748](https://github.com/audacity/audacity/issues/6748)

* added a knob with tooltip  as a separate element
* slightly changed KnobControl to handle hover and drag states properly, which is required for the tooltip display

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
