### PR TITLE
Export fixes

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -2110,7 +2110,7 @@ bool AudioIO::ProcessPlaybackSlices(
 
          if(len > 0)
          {
-            for(unsigned i = 0; i < seq->NChannels(); ++i)
+            for(unsigned i = 0, cnt = std::min(seq->NChannels(), mNumPlaybackChannels); i < cnt; ++i)
                pointers[i] = mProcessingBuffers[bufferIndex + i].data() + offset;
 
             for(unsigned i = seq->NChannels(); i < mNumPlaybackChannels; ++i)
@@ -2178,7 +2178,7 @@ bool AudioIO::ProcessPlaybackSlices(
          const auto numChannels = seq->NChannels();
          if(numChannels > 1)
          {
-            for(unsigned n = 0; n < seq->NChannels(); ++n)
+            for(unsigned n = 0, cnt = std::min(numChannels, mNumPlaybackChannels); n < cnt; ++n)
             {
                const auto gain = seq->GetChannelGain(n);
                for(unsigned i = 0; i < samplesAvailable; ++i)
@@ -2240,9 +2240,6 @@ bool AudioIO::ProcessPlaybackSlices(
          );
       }
    }
-
-   for(auto& buffer : mMasterBuffers)
-      buffer.clear();
 
    return progress;
 }

--- a/libraries/lib-import-export/ExportPluginHelpers.cpp
+++ b/libraries/lib-import-export/ExportPluginHelpers.cpp
@@ -32,9 +32,12 @@ std::unique_ptr<Mixer> ExportPluginHelpers::CreateMixer(
       inputs.emplace_back(
          StretchingSequence::Create(*pTrack, pTrack->GetClipInterfaces()),
          GetEffectStages(*pTrack));
+   auto masterEffectStages = GetMasterEffectStages(project);
+   //custom channel mapping isn't support with master effects on
+   assert(masterEffectStages.empty() || (numOutChannels <= 2 && mixerSpec == nullptr));
    // MB: the stop time should not be warped, this was a bug.
    return std::make_unique<Mixer>(
-      move(inputs), GetMasterEffectStages(project),
+      std::move(inputs), std::move(masterEffectStages),
       // Throw, to stop exporting, if read fails:
       true, Mixer::WarpOptions { tracks.GetOwner() }, startTime, stopTime,
       numOutChannels, outBufferSize, outInterleaved, outRate, outFormat, true,

--- a/libraries/lib-mixer/CMakeLists.txt
+++ b/libraries/lib-mixer/CMakeLists.txt
@@ -22,6 +22,10 @@ class Curve should be extracted from it and lowered into lib-math.
 set( SOURCES
    AudioIOSequences.cpp
    AudioIOSequences.h
+   DownmixSource.cpp
+   DownmixSource.h
+   DownmixStage.cpp
+   DownmixStage.h
    EffectStage.cpp
    EffectStage.h
    Envelope.cpp

--- a/libraries/lib-mixer/DownmixSource.cpp
+++ b/libraries/lib-mixer/DownmixSource.cpp
@@ -1,0 +1,104 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  DownmixSource.cpp
+
+  Dominic Mazzoni
+  Markus Meyer
+  Vaughan Johnson
+
+*******************************************************************/
+
+
+#include "DownmixSource.h"
+
+#include "AudioGraphChannel.h"
+#include "WideSampleSequence.h"
+
+SequenceDownmixSource::SequenceDownmixSource(AudioGraph::Source& downstream,
+                                             const WideSampleSequence& sequence,
+                                             const ArrayOf<bool> *channelMap)
+   : mDownstream(downstream)
+   , mSequence(sequence)
+   , mpMap(channelMap)
+{
+}
+
+AudioGraph::Source& SequenceDownmixSource::GetDownstream() const
+{
+   return mDownstream;
+}
+
+size_t SequenceDownmixSource::NChannels() const
+{
+   return mSequence.NChannels();
+}
+
+float SequenceDownmixSource::GetChannelGain(size_t channel) const
+{
+   return mSequence.GetChannelGain(channel);
+}
+
+void SequenceDownmixSource::FindChannelFlags(unsigned char *channelFlags, size_t numChannels, size_t iChannel)
+{
+   const bool* map = mpMap ? mpMap[iChannel].get() : nullptr;
+   const auto end = channelFlags + numChannels;
+   std::fill(channelFlags, end, 0);
+   if (map)
+      // ignore left and right when downmixing is customized
+      std::copy(map, map + numChannels, channelFlags);
+   else if (AudioGraph::IsMono(mSequence))
+      std::fill(channelFlags, end, 1);
+   else if (iChannel == 0)
+      channelFlags[0] = 1;
+   else if (iChannel == 1) {
+      if (numChannels >= 2)
+         channelFlags[1] = 1;
+      else
+         channelFlags[0] = 1;
+   }
+}
+bool SequenceDownmixSource::CanMakeMono() const
+{
+   return mpMap == nullptr;
+}
+
+SimpleDonwmixSource::SimpleDonwmixSource(AudioGraph::Source& downstream, size_t channels)
+   : mDownstream(downstream), mNChannels(channels)
+{
+}
+
+AudioGraph::Source& SimpleDonwmixSource::GetDownstream() const
+{
+   return mDownstream;
+}
+
+size_t SimpleDonwmixSource::NChannels() const
+{
+   return mNChannels;
+}
+
+float SimpleDonwmixSource::GetChannelGain(size_t) const
+{
+   return 1.0f;
+}
+
+void SimpleDonwmixSource::FindChannelFlags(unsigned char* channelFlags, size_t numChannels, size_t iChannel)
+{
+   if(mNChannels == 1)
+   {
+      for(size_t i = 0; i < numChannels; ++i)
+         channelFlags[i] = true;
+   }
+   else
+   {
+      for(size_t i = 0; i < numChannels; ++i)
+         channelFlags[i] = i == iChannel;
+   }
+}
+
+bool SimpleDonwmixSource::CanMakeMono() const
+{
+   return true;
+}

--- a/libraries/lib-mixer/DownmixSource.h
+++ b/libraries/lib-mixer/DownmixSource.h
@@ -1,0 +1,81 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  DownmixSource.h
+
+*******************************************************************/
+
+#pragma once
+#include "MemoryX.h"
+
+class WideSampleSequence;
+
+namespace AudioGraph
+{
+   class Source;
+}
+
+/** @brief Describes an input source for DownmixStage
+ * Decorates an AudioGraph::Source with operations
+ * that are necessary to perform down mixing, which are: number
+ * of source channels, per-channel gain, channel mapping
+ */
+class DownmixSource
+{
+public:
+   DownmixSource() = default;
+
+   virtual ~DownmixSource() = default;
+   //! Returns underlying `AudioGraph::Source` processed by Mixer
+   virtual AudioGraph::Source& GetDownstream() const = 0;
+   //! Number of output channels of the underlying Source
+   virtual size_t NChannels() const = 0;
+   //! Gain multiplier that should be applied to the channel
+   virtual float GetChannelGain(size_t channel) const = 0;
+   //! For the given `iChannel` fills the channelFlags array, that describes
+   //! to which output it should go.
+   virtual void FindChannelFlags(unsigned char *channelFlags, size_t numChannels, size_t iChannel) = 0;
+   //! Returns true if source channels could be combined into mono if needed
+   virtual bool CanMakeMono() const = 0;
+};
+
+//! Downmix source that uses `Sequence` as a source for channel
+//! operations.
+class SequenceDownmixSource final : public DownmixSource
+{
+   AudioGraph::Source& mDownstream;
+   const WideSampleSequence& mSequence;
+   //! many-to-one mixing of channels
+   //! Pointer into array of arrays
+   const ArrayOf<bool> * mpMap {};
+public:
+
+   SequenceDownmixSource(AudioGraph::Source& downstream,
+                         const WideSampleSequence& sequence,
+                         //! Null or else must have a lifetime enclosing this objects's
+                         const ArrayOf<bool> *channelMap);
+
+   AudioGraph::Source& GetDownstream() const override;
+   size_t NChannels() const override;
+   float GetChannelGain(size_t channel) const override;
+   void FindChannelFlags(unsigned char *channelFlags, size_t numChannels, size_t iChannel) override;
+   bool CanMakeMono() const override;
+};
+
+//! No gain applied, channels are either mapped to corresponding
+//! ones or combined into mono, depending on FindChannelFlags input
+class SimpleDonwmixSource final : public DownmixSource
+{
+   AudioGraph::Source& mDownstream;
+   size_t mNChannels;
+public:
+
+   SimpleDonwmixSource(AudioGraph::Source& downstream, size_t channels);
+
+   AudioGraph::Source& GetDownstream() const override;
+   size_t NChannels() const override;
+   float GetChannelGain(size_t channel) const override;
+   void FindChannelFlags(unsigned char* channelFlags, size_t numChannels, size_t iChannel) override;
+   bool CanMakeMono() const override;
+};

--- a/libraries/lib-mixer/DownmixStage.cpp
+++ b/libraries/lib-mixer/DownmixStage.cpp
@@ -1,0 +1,147 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  DownmixStage.cpp
+
+  Dominic Mazzoni
+  Markus Meyer
+  Vaughan Johnson
+
+*******************************************************************/
+
+#include "DownmixStage.h"
+
+#include <cassert>
+#include <numeric>
+
+#include "SampleCount.h"
+#include "DownmixSource.h"
+
+#define stackAllocate(T, count) static_cast<T*>(alloca(count * sizeof(T)))
+
+namespace
+{
+
+void MixBuffers(unsigned numChannels,
+   const unsigned char *channelFlags, const float *gains,
+   const float &src, AudioGraph::Buffers &dests, int len)
+{
+   const auto pSrc = &src;
+   for (unsigned int c = 0; c < numChannels; c++) {
+      if (!channelFlags[c])
+         continue;
+      auto dest = &dests.GetWritePosition(c);
+      for (int j = 0; j < len; ++j)
+         dest[j] += pSrc[j] * gains[c];   // the actual mixing process
+   }
+}
+
+}
+
+DownmixStage::DownmixStage(std::vector<std::unique_ptr<DownmixSource>> downmixSources,
+             size_t numChannels,
+             size_t bufferSize,
+             ApplyGain applyGain)
+   : mDownmixSources(std::move(downmixSources))
+ // PRL:  Bug2536: see other comments below for the last, padding argument
+ // TODO: more-than-two-channels
+ // Issue 3565 workaround:  allocate one extra buffer when applying a
+ // GVerb effect stage.  It is simply discarded
+ // See also issue 3854, when the number of out channels expected by the
+ // plug-in is yet larger
+   , mFloatBuffers { 3, bufferSize, 1, 1 }
+   , mNumChannels(numChannels)
+   , mApplyGain(applyGain)
+{
+   
+}
+
+DownmixStage::~DownmixStage() = default;
+
+bool DownmixStage::AcceptsBuffers(const Buffers& buffers) const
+{
+   return buffers.Channels() == mNumChannels &&
+      AcceptsBlockSize(buffers.BlockSize());  
+}
+
+bool DownmixStage::AcceptsBlockSize(size_t blockSize) const
+{
+   return blockSize <= mFloatBuffers.BufferSize();
+}
+
+std::optional<size_t> DownmixStage::Acquire(Buffers& data, size_t maxToProcess)
+{
+   // TODO: more-than-two-channels
+   auto maxChannels = std::max(2u, mFloatBuffers.Channels());
+   const auto channelFlags = stackAllocate(unsigned char, mNumChannels);
+   const auto gains = stackAllocate(float, mNumChannels);
+   if (mApplyGain == ApplyGain::Discard)
+      std::fill(gains, gains + mNumChannels, 1.0f);
+
+   size_t maxOut = 0;
+   for (auto c = 0;c < data.Channels(); ++c)
+      data.ClearBuffer(c, maxToProcess);
+
+   for (auto& downmixSource : mDownmixSources)
+   {
+      auto oResult = downmixSource->GetDownstream().Acquire(mFloatBuffers, maxToProcess);
+      // One of MixVariableRates or MixSameRate assigns into mTemp[*][*]
+      // which are the sources for the CopySamples calls, and they copy into
+      // mBuffer[*][*]
+      if (!oResult)
+         return 0;
+      const auto result = *oResult;
+      maxOut = std::max(maxOut, result);
+
+      // Insert effect stages here!  Passing them all channels of the track
+
+      const auto limit = std::min<size_t>(downmixSource->NChannels(), maxChannels);
+      for (size_t j = 0; j < limit; ++j)
+      {
+         const auto pFloat = (const float*)mFloatBuffers.GetReadPosition(j);
+         if (mApplyGain != ApplyGain::Discard)
+         {
+            for (size_t c = 0; c < mNumChannels; ++c)
+            {
+               if (mNumChannels > 1)
+                  gains[c] = downmixSource->GetChannelGain(c);
+               else
+                  gains[c] = downmixSource->GetChannelGain(j);
+            }
+            if (mApplyGain == ApplyGain::Mixdown &&
+                mNumChannels == 1 &&
+                downmixSource->CanMakeMono())
+            {
+               gains[0] /= static_cast<float>(limit);
+            }
+         }
+
+         downmixSource->FindChannelFlags(channelFlags, mNumChannels, j);
+         MixBuffers(mNumChannels, channelFlags, gains, *pFloat, data, result);
+      }
+
+      downmixSource->GetDownstream().Release();
+      mFloatBuffers.Advance(result);
+      mFloatBuffers.Rotate();
+   }
+
+   // MB: this doesn't take warping into account, replaced with code based on mSamplePos
+   //mT += (maxOut / mRate);
+
+   assert(maxOut <= maxToProcess);
+   return maxOut;
+}
+sampleCount DownmixStage::Remaining() const
+{
+   return std::accumulate(
+      mDownmixSources.begin(), mDownmixSources.end(), sampleCount { 0 },
+      [](sampleCount sum, const auto& source) {
+         return std::max(sum, source->GetDownstream().Remaining());
+      });
+}
+
+bool DownmixStage::Release()
+{
+   return true;
+}

--- a/libraries/lib-mixer/DownmixStage.h
+++ b/libraries/lib-mixer/DownmixStage.h
@@ -1,0 +1,54 @@
+/**********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  DownmixStage.h
+
+*******************************************************************/
+
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include "AudioGraphBuffers.h"
+#include "AudioGraphSource.h"
+
+class DownmixSource;
+
+//! Combines multiple audio graph sources into a single source
+class DownmixStage final : public AudioGraph::Source
+{
+public:
+   enum class ApplyGain
+   {
+      Discard,//< No source gain is applied
+      MapChannels, //< Apply gains per source's channel
+      Mixdown, //< Average gains from all channels in the source, numOutChannels should be 1
+   };
+
+private:
+   std::vector<std::unique_ptr<DownmixSource>> mDownmixSources;
+   // Resample into these buffers, or produce directly when not resampling
+   AudioGraph::Buffers mFloatBuffers;
+   size_t mNumChannels;
+   ApplyGain mApplyGain;
+
+public:
+
+   DownmixStage(std::vector<std::unique_ptr<DownmixSource>> downmixSources,
+                size_t numChannels,
+                size_t bufferSize,
+                ApplyGain applyGain);
+
+   ~DownmixStage() override;
+
+   bool AcceptsBuffers(const Buffers& buffers) const override;
+
+   bool AcceptsBlockSize(size_t blockSize) const override;
+
+   std::optional<size_t> Acquire(Buffers& data, size_t maxToProcess) override;
+   sampleCount Remaining() const override;
+
+   bool Release() override;
+};

--- a/libraries/lib-mixer/Mix.cpp
+++ b/libraries/lib-mixer/Mix.cpp
@@ -25,6 +25,8 @@
 #include "float_cast.h"
 #include <numeric>
 
+#include "DownmixSource.h"
+
 namespace {
 template<typename T, typename F> std::vector<T>
 initVector(size_t dim1, const F &f)
@@ -45,6 +47,8 @@ initVector(size_t dim1, size_t dim2)
 
 namespace
 {
+
+
 void ConsiderStages(const Mixer::Stages& stages, size_t& blockSize)
 {
    for (const auto& stage : stages)
@@ -78,6 +82,11 @@ size_t FindBufferSize(
 
    return blockSize;
 }
+
+auto NeedsDitherPred(const MixerOptions::StageSpecification &spec) {
+   return spec.mpFirstInstance && spec.mpFirstInstance->NeedsDither();
+};
+
 } // namespace
 
 Mixer::Mixer(
@@ -98,14 +107,6 @@ Mixer::Mixer(
     , mTimesAndSpeed { std::make_shared<TimesAndSpeed>(TimesAndSpeed {
          startTime, stopTime, warpOptions.initialSpeed, startTime }) }
 
-    // PRL:  Bug2536: see other comments below for the last, padding argument
-    // TODO: more-than-two-channels
-    // Issue 3565 workaround:  allocate one extra buffer when applying a
-    // GVerb effect stage.  It is simply discarded
-    // See also issue 3854, when the number of out channels expected by the
-    // plug-in is yet larger
-    , mFloatBuffers { 3, mBufferSize, 1, 1 }
-
     // non-interleaved
     , mTemp { mNumChannels, mBufferSize, 1, 1 }
     , mBuffer { initVector<SampleBuffer>(
@@ -125,16 +126,11 @@ Mixer::Mixer(
    // This finds a sufficient, but not necessary, condition to do dithering
    bool needsDither = std::any_of(mInputs.begin(), mInputs.end(),
       [](const Input &input){
-         return std::any_of(input.stages.begin(), input.stages.end(),
-            [](const MixerOptions::StageSpecification &spec){
-               return spec.mpFirstInstance &&
-                  spec.mpFirstInstance->NeedsDither(); } ); } );
+         return std::any_of(input.stages.begin(), input.stages.end(), NeedsDitherPred); }
+   );
    if (mMasterEffects)
       needsDither |= std::any_of(
-         mMasterEffects->begin(), mMasterEffects->end(),
-         [](const MixerOptions::StageSpecification& spec) {
-            return spec.mpFirstInstance && spec.mpFirstInstance->NeedsDither();
-         });
+         mMasterEffects->begin(), mMasterEffects->end(), NeedsDitherPred);
 
    auto pMixerSpec = ( mixerSpec &&
       mixerSpec->GetNumChannels() == mNumChannels &&
@@ -150,45 +146,76 @@ Mixer::Mixer(
       std::accumulate(
          mInputs.begin(), mInputs.end(), 0,
          [](auto sum, const auto& input) {
-            return sum + input.stages.size() * input.pSequence->NChannels();
+            return sum + input.stages.size();
          }) +
       nMasterStages;
    mSettings.reserve(nStages);
    mStageBuffers.reserve(nStages);
 
    size_t i = 0;
+   std::vector<std::unique_ptr<DownmixSource>> downmixSources;
    for (auto &input : mInputs) {
       const auto &sequence = input.pSequence;
       if (!sequence) {
          assert(false);
          break;
       }
-      auto increment = finally([&]{ i += sequence->NChannels(); });
 
       auto &source = mSources.emplace_back(sequence, BufferSize(), outRate,
-         warpOptions, highQuality, mayThrow, mTimesAndSpeed,
-         (pMixerSpec ? &pMixerSpec->mMap[i] : nullptr));
+         warpOptions, highQuality, mayThrow, mTimesAndSpeed);
       AudioGraph::Source *pDownstream = &source;
       for (const auto &stage : input.stages)
          if (
             auto& pNewDownstream =
-               RegisterEffectStage(*pDownstream, stage, outRate))
+               RegisterEffectStage(*pDownstream, sequence->NChannels(), stage, outRate))
          {
             pDownstream = pNewDownstream.get();
          }
-      mDecoratedSources.emplace_back(Source{ source, *pDownstream });
-   }
+      downmixSources.emplace_back(
+         std::make_unique<SequenceDownmixSource>(
+            *pDownstream,
+            *sequence,
+            pMixerSpec ? &pMixerSpec->mMap[i] : nullptr
+         )
+      );
 
-   if (mMasterEffects)
+      i += sequence->NChannels();
+   }
+   
+   if (mMasterEffects && !mMasterEffects->empty())
    {
-      AudioGraph::Source* pDownstream = this;
+      mDownmixStage = std::make_unique<DownmixStage>(
+         std::move(downmixSources), mNumChannels, mBufferSize, ApplyGain::MapChannels
+      );
+
+      AudioGraph::Source* pDownstream = mDownmixStage.get();
       for (const auto& stage : *mMasterEffects)
+      {
          if (
             auto& pNewDownstream =
-               RegisterEffectStage(*pDownstream, stage, outRate))
+               RegisterEffectStage(*pDownstream, mNumChannels, stage, outRate))
          {
-            mMasterStages.emplace_back(pDownstream = pNewDownstream.get());
+            pDownstream = pNewDownstream.get();
          }
+      }
+
+      //Effect stage could have more than mNumChannels output
+      //and expect at least 3 float buffers input to work correctly...
+      std::vector<std::unique_ptr<DownmixSource>> masterDownmixSources;
+      masterDownmixSources.push_back(std::make_unique<SimpleDonwmixSource>(*pDownstream, mNumChannels));
+      mMasterDownmixStage = std::make_unique<DownmixStage>(
+         std::move(masterDownmixSources), mNumChannels, mBufferSize, ApplyGain::Mixdown);
+      mDownstream = mMasterDownmixStage.get();
+   }
+   else
+   {
+      mDownmixStage = std::make_unique<DownmixStage>(
+         std::move(downmixSources),
+         mNumChannels,
+         mBufferSize,
+         mApplyGain
+      );
+      mDownstream = mDownmixStage.get();
    }
 
    // Decide once at construction time
@@ -265,22 +292,6 @@ void Mixer::Clear()
       mTemp.ClearBuffer(c, mBufferSize);
 }
 
-static void MixBuffers(unsigned numChannels,
-   const unsigned char *channelFlags, const float *gains,
-   const float &src, AudioGraph::Buffers &dests, int len)
-{
-   const auto pSrc = &src;
-   for (unsigned int c = 0; c < numChannels; c++) {
-      if (!channelFlags[c])
-         continue;
-      auto dest = &dests.GetWritePosition(c);
-      for (int j = 0; j < len; ++j)
-         dest[j] += pSrc[j] * gains[c];   // the actual mixing process
-   }
-}
-
-#define stackAllocate(T, count) static_cast<T*>(alloca(count * sizeof(T)))
-
 size_t Mixer::Process(const size_t maxToProcess)
 {
    assert(maxToProcess <= BufferSize());
@@ -298,14 +309,10 @@ size_t Mixer::Process(const size_t maxToProcess)
    Clear();
 
    std::optional<size_t> maxOut;
-   if (mMasterStages.empty())
-      maxOut = Acquire(mTemp, maxToProcess);
-   else
-   {
-      const auto stage = mMasterStages.back();
-      maxOut = stage->Acquire(mTemp, maxToProcess);
-      stage->Release();
-   }
+   
+   maxOut = mDownstream->Acquire(mTemp, maxToProcess);
+   mDownstream->Release();
+
    if (!maxOut)
       return 0;
 
@@ -404,117 +411,9 @@ void Mixer::SetSpeedForKeyboardScrubbing(double speed, double startTime)
    mSpeed = fabs(speed);
 }
 
-bool Mixer::AcceptsBuffers(const Buffers& buffers) const
-{
-   return buffers.Channels() == mNumChannels &&
-          AcceptsBlockSize(buffers.BlockSize());
-}
-
-bool Mixer::AcceptsBlockSize(size_t blockSize) const
-{
-   return blockSize <= BufferSize();
-}
-
-sampleCount Mixer::Remaining() const
-{
-   return std::accumulate(
-      mDecoratedSources.begin(), mDecoratedSources.end(), sampleCount { 0 },
-      [](sampleCount sum, const Source& source) {
-         return std::max(sum, source.downstream.Remaining());
-      });
-}
-
-bool Mixer::Release()
-{
-   return true;
-}
-
-std::optional<size_t> Mixer::Acquire(Buffers& data, size_t maxToProcess)
-{
-   // TODO: more-than-two-channels
-   auto maxChannels = std::max(2u, mFloatBuffers.Channels());
-   const auto channelFlags = stackAllocate(unsigned char, mNumChannels);
-   const auto gains = stackAllocate(float, mNumChannels);
-   if (mApplyGain == ApplyGain::Discard)
-      std::fill(gains, gains + mNumChannels, 1.0f);
-
-   // Decides which output buffers an input channel accumulates into
-   auto findChannelFlags = [&channelFlags, numChannels = mNumChannels]
-   (const bool *map, const WideSampleSequence &sequence, size_t iChannel){
-      const auto end = channelFlags + numChannels;
-      std::fill(channelFlags, end, 0);
-      if (map)
-         // ignore left and right when downmixing is customized
-         std::copy(map, map + numChannels, channelFlags);
-      else if (IsMono(sequence))
-         std::fill(channelFlags, end, 1);
-      else if (iChannel == 0)
-         channelFlags[0] = 1;
-      else if (iChannel == 1) {
-         if (numChannels >= 2)
-            channelFlags[1] = 1;
-         else
-            channelFlags[0] = 1;
-      }
-      return channelFlags;
-   };
-
-   size_t maxOut = 0;
-   for (auto c = 0;c < data.Channels(); ++c)
-      data.ClearBuffer(c, maxToProcess);
-
-   for (auto& [upstream, downstream] : mDecoratedSources)
-   {
-      auto oResult = downstream.Acquire(mFloatBuffers, maxToProcess);
-      // One of MixVariableRates or MixSameRate assigns into mTemp[*][*]
-      // which are the sources for the CopySamples calls, and they copy into
-      // mBuffer[*][*]
-      if (!oResult)
-         return 0;
-      const auto result = *oResult;
-      maxOut = std::max(maxOut, result);
-
-      // Insert effect stages here!  Passing them all channels of the track
-
-      const auto limit = std::min<size_t>(upstream.Channels(), maxChannels);
-      for (size_t j = 0; j < limit; ++j)
-      {
-         const auto pFloat = (const float*)mFloatBuffers.GetReadPosition(j);
-         auto& sequence = upstream.GetSequence();
-         if (mApplyGain != ApplyGain::Discard)
-         {
-            for (size_t c = 0; c < mNumChannels; ++c)
-            {
-               if (mNumChannels > 1)
-                  gains[c] = sequence.GetChannelGain(c);
-               else
-                  gains[c] = sequence.GetChannelGain(j);
-            }
-            if (
-               mApplyGain == ApplyGain::Mixdown && !mHasMixerSpec &&
-               mNumChannels == 1)
-               gains[0] /= static_cast<float>(limit);
-         }
-
-         const auto flags =
-            findChannelFlags(upstream.MixerSpec(j), sequence, j);
-         MixBuffers(mNumChannels, flags, gains, *pFloat, data, result);
-      }
-
-      downstream.Release();
-      mFloatBuffers.Advance(result);
-      mFloatBuffers.Rotate();
-   }
-
-   // MB: this doesn't take warping into account, replaced with code based on mSamplePos
-   //mT += (maxOut / mRate);
-
-   assert(maxOut <= maxToProcess);
-   return maxOut;
-}
-
 std::unique_ptr<EffectStage>& Mixer::RegisterEffectStage(
-   AudioGraph::Source& upstream, const MixerOptions::StageSpecification& stage,
+   AudioGraph::Source& upstream, size_t numChannels,
+   const MixerOptions::StageSpecification& stage,
    double outRate)
 {
    // Make a mutable copy of stage.settings
@@ -530,7 +429,7 @@ std::unique_ptr<EffectStage>& Mixer::RegisterEffectStage(
                                      stage.factory();
    };
    auto& pNewDownstream = mStages.emplace_back(EffectStage::Create(
-      -1, mNumChannels, upstream, stageInput, factory, settings, outRate,
+      -1, numChannels, upstream, stageInput, factory, settings, outRate,
       std::nullopt));
    if (!pNewDownstream)
    {

--- a/libraries/lib-mixer/Mix.h
+++ b/libraries/lib-mixer/Mix.h
@@ -18,6 +18,8 @@
 #include "SampleFormat.h"
 #include <optional>
 
+#include "DownmixStage.h"
+
 class sampleCount;
 class BoundedEnvelope;
 class EffectStage;
@@ -25,7 +27,7 @@ class MixerSource;
 class TrackList;
 class WideSampleSequence;
 
-class MIXER_API Mixer : public AudioGraph::Source
+class MIXER_API Mixer final
 {
 public:
    using WarpOptions = MixerOptions::Warp;
@@ -46,21 +48,16 @@ public:
    };
    using Inputs = std::vector<Input>;
 
-   enum class ApplyGain
-   {
-      Discard,//< No source gain is applied
-      MapChannels, //< Apply gains per source's channel
-      Mixdown, //< Average gains from all channels in the source, numOutChannels should be 1
-   };
+   using ApplyGain = DownmixStage::ApplyGain;
 
    //
    // Constructor / Destructor
    //
 
    /*!
+    * When creating with master effects stages `applyGain` is ignored
     @pre all sequences in `inputs` are non-null
-    @pre any left channels in inputs are immediately followed by their
-       partners
+    @pre !!masterEffects && mixerSpec == nullptr && numOutChannels <= 2
     @post `BufferSize() <= outBufferSize` (equality when no inputs have stages)
     */
    Mixer(
@@ -73,9 +70,11 @@ public:
       ApplyGain applyGain = ApplyGain::MapChannels);
 
    Mixer(const Mixer&) = delete;
+   Mixer(Mixer&&) noexcept = delete;
    Mixer &operator=(const Mixer&) = delete;
+   Mixer &operator=(Mixer&&) noexcept = delete;
 
-   virtual ~ Mixer();
+   ~Mixer();
 
    size_t BufferSize() const { return mBufferSize; }
 
@@ -123,17 +122,8 @@ public:
 
    void Clear();
 
-   // AudioGraph::Source
-private:
-   bool AcceptsBuffers(const Buffers& buffers) const override;
-   bool AcceptsBlockSize(size_t blockSize) const override;
-   std::optional<size_t> Acquire(Buffers& data, size_t bound) override;
-   sampleCount Remaining() const override;
-   bool Release() override;
-
-private:
    std::unique_ptr<EffectStage>& RegisterEffectStage(
-      AudioGraph::Source& upstream,
+      AudioGraph::Source& upstream, size_t numChannels,
       const MixerOptions::StageSpecification& stage, double outRate);
 
    // Input
@@ -164,9 +154,6 @@ private:
 
    // BUFFERS
 
-   // Resample into these buffers, or produce directly when not resampling
-   AudioGraph::Buffers mFloatBuffers;
-
    // Each channel's data is transformed, including application of
    // gains and pans, and then (maybe many-to-one) mixer specifications
    // determine where in mTemp it is accumulated
@@ -179,9 +166,8 @@ private:
    std::vector<EffectSettings> mSettings;
    std::vector<AudioGraph::Buffers> mStageBuffers;
    std::vector<std::unique_ptr<EffectStage>> mStages;
-   std::vector<AudioGraph::Source*> mMasterStages;
-
-   struct Source { MixerSource &upstream; AudioGraph::Source &downstream; };
-   std::vector<Source> mDecoratedSources;
+   std::unique_ptr<AudioGraph::Source> mDownmixStage;
+   std::unique_ptr<AudioGraph::Source> mMasterDownmixStage;
+   AudioGraph::Source* mDownstream{};
 };
 #endif

--- a/libraries/lib-mixer/MixerSource.cpp
+++ b/libraries/lib-mixer/MixerSource.cpp
@@ -289,8 +289,7 @@ void MixerSource::ZeroFill(
 MixerSource::MixerSource(
    const std::shared_ptr<const WideSampleSequence> &seq, size_t bufferSize,
    double rate, const MixerOptions::Warp &options, bool highQuality,
-   bool mayThrow, std::shared_ptr<TimesAndSpeed> pTimesAndSpeed,
-   const ArrayOf<bool> *pMap
+   bool mayThrow, std::shared_ptr<TimesAndSpeed> pTimesAndSpeed
 )  : mpSeq{ seq }
    , mnChannels{ mpSeq->NChannels() }
    , mRate{ rate }
@@ -303,7 +302,6 @@ MixerSource::MixerSource(
    , mResampleParameters{ highQuality, mpSeq->GetRate(), rate, options }
    , mResample( mnChannels )
    , mEnvValues( std::max(sQueueMaxLen, bufferSize) )
-   , mpMap{ pMap }
 {
    assert(mTimesAndSpeed);
    auto t0 = mTimesAndSpeed->mT0;
@@ -316,11 +314,6 @@ MixerSource::~MixerSource() = default;
 const WideSampleSequence &MixerSource::GetSequence() const
 {
    return *mpSeq;
-}
-
-const bool *MixerSource::MixerSpec(unsigned iChannel) const
-{
-   return mpMap ? mpMap[iChannel].get() : nullptr;
 }
 
 bool MixerSource::AcceptsBuffers(const Buffers &buffers) const

--- a/libraries/lib-mixer/MixerSource.h
+++ b/libraries/lib-mixer/MixerSource.h
@@ -41,17 +41,13 @@ public:
    MixerSource(const std::shared_ptr<const WideSampleSequence> &seq,
       size_t bufferSize,
       double rate, const MixerOptions::Warp &options, bool highQuality,
-      bool mayThrow, std::shared_ptr<TimesAndSpeed> pTimesAndSpeed,
-      //! Null or else must have a lifetime enclosing this objects's
-      const ArrayOf<bool> *pMap
+      bool mayThrow, std::shared_ptr<TimesAndSpeed> pTimesAndSpeed
    );
-   MixerSource(MixerSource&&) = default;
-   MixerSource &operator=(MixerSource&&) = delete;
-   ~MixerSource();
+   MixerSource(MixerSource&&) noexcept = default;
+   ~MixerSource() override;
 
    unsigned Channels() const { return mnChannels; }
    const WideSampleSequence &GetSequence() const;
-   const bool *MixerSpec(unsigned iChannel) const;
 
    bool AcceptsBuffers(const Buffers &buffers) const override;
    bool AcceptsBlockSize(size_t blockSize) const override;
@@ -129,10 +125,6 @@ private:
 
    //! Gain envelopes are applied to input before other transformations
    std::vector<double> mEnvValues;
-
-   //! many-to-one mixing of channels
-   //! Pointer into array of arrays
-   const ArrayOf<bool> *const mpMap;
 
    //! Remember how many channels were passed to Acquire()
    unsigned mMaxChannels{};

--- a/src/export/ExportAudioDialog.cpp
+++ b/src/export/ExportAudioDialog.cpp
@@ -43,6 +43,7 @@
 #include "ExportFilePanel.h"
 #include "ExportProgressUI.h"
 #include "ImportExport.h"
+#include "RealtimeEffectList.h"
 #include "WindowAccessible.h"
 
 #if wxUSE_ACCESSIBILITY
@@ -237,7 +238,11 @@ ExportAudioDialog::ExportAudioDialog(wxWindow* parent,
    if (ExportAudioExportRange.Read() != "split" || (!hasLabels && !hasMultipleWaveTracks))
       mSplitsPanel->Hide();
 
-   mExportOptionsPanel->SetCustomMappingEnabled(!mRangeSplit->GetValue());
+   mExportOptionsPanel->SetCustomMappingEnabled(
+      !mRangeSplit->GetValue() &&
+      //Custom channel export isn't available when master channel has effects assigned
+      RealtimeEffectList::Get(project).GetStatesCount() == 0
+   );
 
    mIncludeAudioBeforeFirstLabel->Enable(mSplitByLabels->GetValue());
 


### PR DESCRIPTION
Resolves: #7002, #7001, #7059

Channel maps disabled when exporting with master effects on.

QA: Check stereo to mono and mono to stereo export. Additionally please check for regression: Mix and Render and Stereo to Mono

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
