### PR TITLE
Fix "Split stereo track" operation

### DIFF
--- a/libraries/lib-track/Track.cpp
+++ b/libraries/lib-track/Track.cpp
@@ -867,6 +867,11 @@ TrackListHolder TrackList::Temporary(AudacityProject *pProject,
    return tempList;
 }
 
+void TrackList::AssignUniqueId(const Track::Holder &track)
+{
+   track->SetId(TrackId{ ++sCounter });
+}
+
 void TrackList::Append(TrackList &&list, bool assignIds)
 {
    auto iter = list.ListOfTracks::begin(),

--- a/libraries/lib-track/Track.h
+++ b/libraries/lib-track/Track.h
@@ -1104,6 +1104,9 @@ public:
    static TrackListHolder Temporary(AudacityProject *pProject,
       const Track::Holder &pTrack = {});
 
+   //! Assigns a new unique non-persistent id to a track
+   static void AssignUniqueId(const Track::Holder &track);
+
    //! Remove all tracks from `list` and put them at the end of `this`
    /*!
     @param assignIds ignored if `this` is a temporary list; else if false,

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1052,6 +1052,7 @@ auto WaveTrack::SplitChannels() -> std::vector<Holder>
       for (auto &pClip : mClips)
          pNewTrack->mClips.emplace_back(pClip->SplitChannels());
       this->mRightChannel.reset();
+      TrackList::AssignUniqueId(pNewTrack);
       auto iter = pOwner->Find(this);
       pOwner->Insert(*++iter, pNewTrack);
       // Fix up the channel attachments to avoid waste of space


### PR DESCRIPTION
Due to regression, after the stereo-to-mono split, both new tracks were assigned the same ID, which should be unique to all tracks. This was causing weird behavior, including data loss and crashes.

Resolves: #7048, #7050, #6886

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes in behavior
