### PR TITLE
Repaint waveform RMS and Show clipping on Reset Configuration

### DIFF
--- a/libraries/lib-preferences/Prefs.cpp
+++ b/libraries/lib-preferences/Prefs.cpp
@@ -555,8 +555,5 @@ bool SettingBase::Delete()
 bool BoolSetting::Toggle()
 {
    bool value = Read();
-   if ( Write( !value ) )
-      return !value;
-   else
-      return value;
+   return Write( !value );
 }

--- a/libraries/lib-preferences/Prefs.h
+++ b/libraries/lib-preferences/Prefs.h
@@ -347,7 +347,7 @@ class PREFERENCES_API BoolSetting final : public Setting< bool >
 public:
    using Setting::Setting;
 
-   //! Write the negation of the previous value, and then return the current value.
+   //! Write the negation of the previous value, and return true if successful
    bool Toggle();
 };
 

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -67,7 +67,6 @@ TrackArtist::TrackArtist( TrackPanel *parent_ )
    : parent( parent_ )
 {
    mdBrange = DecibelScaleCutoff.GetDefault();
-   mShowClipping = false;
    mSampleDisplay = 1;// Stem plots by default.
 
    SetColours(0);
@@ -155,18 +154,10 @@ void TrackArtist::SetColours( int iColorIndex)
    }
 }
 
-void TrackArtist::UpdateSelectedPrefs( int id )
-{
-   if( id == ShowClippingPrefsID())
-      mShowClipping = gPrefs->Read(wxT("/GUI/ShowClipping"), mShowClipping);
-}
-
 void TrackArtist::UpdatePrefs()
 {
    mdBrange = DecibelScaleCutoff.Read();
    mSampleDisplay = TracksPrefs::SampleViewChoice();
-
-   UpdateSelectedPrefs( ShowClippingPrefsID() );
 
    SetColours(0);
 }

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -61,13 +61,11 @@ public:
    void SetColours(int iColorIndex);
 
    void UpdatePrefs() override;
-   void UpdateSelectedPrefs( int id ) override;
 
    TrackPanel *parent;
 
    // Preference values
    float mdBrange;            // "/GUI/EnvdBRange"
-   bool mShowClipping;        // "/GUI/ShowClipping"
    int  mSampleDisplay;
 
    wxBrush blankBrush;

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -30,6 +30,7 @@
 #include "UndoManager.h"
 #include "Viewport.h"
 #include "prefs/EffectsPrefs.h"
+#include "prefs/GUIPrefs.h"
 
 // private helper classes and functions
 namespace {
@@ -93,7 +94,12 @@ void OnResetConfig(const CommandContext &context)
    SyncLockTracks.Reset();
    SoundActivatedRecord.Reset();
    SelectionToolbarMode.Reset();
+
+   ShowRMSPref().Reset();
+   ShowClippingPref().Reset();
+
    gPrefs->Flush();
+
    DoReloadPreferences(project);
 
    Viewport::Get(project).SetToDefaultSize();

--- a/src/menus/ViewMenus.cpp
+++ b/src/menus/ViewMenus.cpp
@@ -268,12 +268,8 @@ void OnShowClipping(const CommandContext &context)
    auto &commandManager = CommandManager::Get( project );
    auto &trackPanel = TrackPanel::Get( project );
 
-   bool checked = !gPrefs->Read(wxT("/GUI/ShowClipping"), 0L);
-   gPrefs->Write(wxT("/GUI/ShowClipping"), checked);
+   ShowClippingPref().Toggle();
    gPrefs->Flush();
-   commandManager.Check(wxT("ShowClipping"), checked);
-
-   PrefsListener::Broadcast(ShowClippingPrefsID());
 
    trackPanel.Refresh(false);
 }
@@ -345,7 +341,7 @@ auto ViewMenu()
             Options{}.CheckTest( wxT("/GUI/ShowExtraMenus"), false ) ),
          Command( wxT("ShowClipping"), XXO("&Show Clipping in Waveform"),
             OnShowClipping, AlwaysEnabledFlag,
-            Options{}.CheckTest( wxT("/GUI/ShowClipping"), false ) ),
+            Options{}.CheckTest( ShowClippingPref() ) ),
          Command( wxT("ShowRMS"), XXO("Show &RMS in Waveform"),
             OnShowRMS, AlwaysEnabledFlag,
             Options{}.CheckTest( ShowRMSPref() ) )

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -222,15 +222,15 @@ bool GUIPrefs::Commit()
    return true;
 }
 
-int ShowClippingPrefsID()
-{
-   static int value = wxNewId();
-   return value;
-}
-
 BoolSetting& ShowRMSPref()
 {
    static BoolSetting pref { "/GUI/ShowRMS", false };
+   return pref;
+}
+
+BoolSetting& ShowClippingPref()
+{
+   static BoolSetting pref { "/GUI/ShowClipping", false };
    return pref;
 }
 

--- a/src/prefs/GUIPrefs.h
+++ b/src/prefs/GUIPrefs.h
@@ -52,9 +52,7 @@ class AUDACITY_DLL_API GUIPrefs final : public PrefsPanel
    int mDefaultRangeIndex;
 };
 
-AUDACITY_DLL_API
-int ShowClippingPrefsID();
-
 AUDACITY_DLL_API BoolSetting& ShowRMSPref();
+AUDACITY_DLL_API BoolSetting& ShowClippingPref();
 
 #endif

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -351,7 +351,7 @@ void DrawWaveform(
 
    paintParameters
       .SetDisplayParameters(
-         rect.GetHeight(), zoomMin, zoomMax, artist->mShowClipping)
+         rect.GetHeight(), zoomMin, zoomMax, ShowClippingPref().Read())
       .SetDBParameters(dBRange, dB)
       .SetBlankColor(ColorFromWXBrush(artist->blankBrush))
       .SetZeroLineColor(graphics::Colors::Black)
@@ -604,7 +604,7 @@ void DrawIndividualSamples(TrackPanelDrawingContext &context,
    ArrayOf<int> clipped;
    int clipcnt = 0;
 
-   const auto bShowClipping = artist->mShowClipping;
+   const auto bShowClipping = ShowClippingPref().Read();
    if (bShowClipping)
       clipped.reinit( size_t(slen) );
 


### PR DESCRIPTION
  Resolves: [#6856](https://github.com/audacity/audacity/issues/6856)

- Reset `RMS` and `Show clipping` prefs on `Reset Configuration` command
- Repaint the waveform after settings were changed

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
