### PR TITLE
Fix random crashes during recording session

### DIFF
--- a/libraries/lib-wave-track/Sequence.h
+++ b/libraries/lib-wave-track/Sequence.h
@@ -11,8 +11,8 @@
 #ifndef __AUDACITY_SEQUENCE__
 #define __AUDACITY_SEQUENCE__
 
-
-#include <vector>
+#include <atomic>
+#include <deque>
 #include <functional>
 
 #include "SampleFormat.h"
@@ -47,8 +47,8 @@ class SeqBlock {
       return SeqBlock(sb, start + delta);
    }
 };
-class BlockArray : public std::vector<SeqBlock> {};
-using BlockPtrArray = std::vector<SeqBlock*>; // non-owning pointers
+class BlockArray : public std::deque<SeqBlock> {};
+using BlockPtrArray = std::deque<SeqBlock*>; // non-owning pointers
 
 class WAVE_TRACK_API Sequence final : public XMLTagHandler{
  public:
@@ -228,8 +228,6 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
    // This should only be used if you really, really know what
    // you're doing!
    //
-
-   BlockArray &GetBlockArray() { return mBlock; }
    const BlockArray &GetBlockArray() const { return mBlock; }
 
    size_t GetAppendBufferLen() const { return mAppendBufferLen; }
@@ -248,7 +246,7 @@ class WAVE_TRACK_API Sequence final : public XMLTagHandler{
    //
 
    SampleBlockFactoryPtr mpFactory;
-
+   std::atomic<size_t> mBlockCount{ 0 };
    BlockArray    mBlock;
    SampleFormats  mSampleFormats;
 


### PR DESCRIPTION
Resolves: [#7018](https://github.com/audacity/audacity/issues/7018)

Use deque instead of vector to prevent reallocations

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
