### PR TITLE
Prevent the ruler panel to call Refresh if the app is minimized

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1504,6 +1504,7 @@ void AdornedRulerPanel::DoIdle()
 
    auto &project = *mProject;
    auto &viewInfo = ViewInfo::Get( project );
+   const bool isIconized = ProjectWindow::Get(project).IsIconized();
    const auto &selectedRegion = viewInfo.selectedRegion;
    const auto &playRegion = viewInfo.playRegion;
 
@@ -1515,7 +1516,7 @@ void AdornedRulerPanel::DoIdle()
      || mLastDrawnZoom != viewInfo.GetZoom()
      || mLastPlayRegionActive != viewInfo.playRegion.Active()
    ;
-   if (changed)
+   if (changed && !isIconized)
       // Cause ruler redraw anyway, because we may be zooming or scrolling,
       // showing or hiding the scrub bar, etc.
       Refresh();


### PR DESCRIPTION
Resolves: #7093, #4781

If the window is minimized, the ruler panel tries to repaint itself infinitely.
The reason is that the horizontal position is updated if auto-scrolling is enabled (`mLastDrawnH != viewInfo.hpos`), but the OnPaint method is not called because the window is not visible.  As a result, "bool changed" is always true, resulting in high CPU usage.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
