### PR TITLE
[AU4] Various fixes for record

### DIFF
--- a/au4/src/appshell/internal/applicationactioncontroller.cpp
+++ b/au4/src/appshell/internal/applicationactioncontroller.cpp
@@ -193,16 +193,15 @@ bool ApplicationActionController::quit(bool isAllInstances, const muse::io::path
 
 void ApplicationActionController::restart()
 {
-    //! TODO AU4
-    // if (projectFilesController()->closeOpenedProject()) {
-    //     if (multiInstancesProvider()->instances().size() == 1) {
-    //         application()->restart();
-    //     } else {
-    //         multiInstancesProvider()->quitAllAndRestartLast();
+    if (projectFilesController()->closeOpenedProject()) {
+        // if (multiInstancesProvider()->instances().size() == 1) {
+        // application()->restart();
+        // } else {
+        // multiInstancesProvider()->quitAllAndRestartLast();
 
-    //         QCoreApplication::exit();
-    //     }
-    // }
+        QCoreApplication::exit();
+        // }
+    }
 }
 
 void ApplicationActionController::toggleFullScreen()

--- a/au4/src/appshell/internal/applicationactioncontroller.h
+++ b/au4/src/appshell/internal/applicationactioncontroller.h
@@ -35,11 +35,11 @@
 #include "iinteractive.h"
 #include "iappshellconfiguration.h"
 #include "iapplication.h"
+#include "project/iprojectfilescontroller.h"
 
 //! TODO AU4
 // #include "languages/ilanguagesservice.h"
 // #include "multiinstances/imultiinstancesprovider.h"
-// #include "project/iprojectfilescontroller.h"
 // #include "audio/isoundfontrepository.h"
 // #include "istartupscenario.h"
 
@@ -54,10 +54,10 @@ class ApplicationActionController : public QObject, public IApplicationActionCon
     INJECT(muse::IInteractive, interactive)
     INJECT(muse::IApplication, application)
     INJECT(IAppShellConfiguration, configuration)
+    INJECT(project::IProjectFilesController, projectFilesController)
 //! TODO AU4
     // INJECT(languages::ILanguagesService, languagesService)
     // INJECT(mi::IMultiInstancesProvider, multiInstancesProvider)
-    // INJECT(project::IProjectFilesController, projectFilesController)
     // INJECT(audio::ISoundFontRepository, soundFontRepository)
     // INJECT(IStartupScenario, startupScenario)
 public:

--- a/au4/src/au3wrap/internal/au3commonsettings.cpp
+++ b/au4/src/au3wrap/internal/au3commonsettings.cpp
@@ -12,7 +12,12 @@ using namespace au::au3;
 
 static muse::Settings::Key make_key(const wxString& key)
 {
-    return muse::Settings::Key("au3wrap", wxToStdSting(key));
+    wxString _key = key;
+    if (!_key.starts_with("/")) {
+        _key += "/";
+    }
+
+    return muse::Settings::Key("au3wrap", wxToStdSting(_key));
 }
 
 Au3CommonSettings::Au3CommonSettings()

--- a/au4/src/projectscene/view/playcursor/playpositionactioncontroller.h
+++ b/au4/src/projectscene/view/playcursor/playpositionactioncontroller.h
@@ -43,18 +43,20 @@ class PlayPositionActionController : public QObject, public muse::actions::Actio
 public:
     PlayPositionActionController(QObject* parent = nullptr);
 
+    Q_INVOKABLE void init();
+
     TimelineContext* timelineContext() const;
     void setTimelineContext(TimelineContext* newContext);
 
     void playPositionDecrease();
     void playPositionIncrease();
 
-    Q_INVOKABLE void init();
-
 signals:
     void timelineContextChanged();
 
 private:
+    void onProjectChanged();
+
     void snapCurrentPosition();
     void applySingleStep(Direction direction);
 

--- a/au4/src/record/CMakeLists.txt
+++ b/au4/src/record/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MODULE_SRC
     #public
     ${CMAKE_CURRENT_LIST_DIR}/recordmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/recordmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/recorderrors.h
     ${CMAKE_CURRENT_LIST_DIR}/irecordconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/irecordcontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/irecord.h

--- a/au4/src/record/internal/au3/au3record.h
+++ b/au4/src/record/internal/au3/au3record.h
@@ -24,17 +24,17 @@ class Au3Record : public IRecord, public muse::async::Asyncable
 public:
     void init();
 
-    void start() override;
-    void pause() override;
-    void stop() override;
+    muse::Ret start() override;
+    muse::Ret pause() override;
+    muse::Ret stop() override;
 
     IAudioInputPtr audioInput() const override;
 
 private:
     AudacityProject& projectRef() const;
 
-    bool doRecord(AudacityProject& project, const TransportSequences& sequences, double t0, double t1, bool altAppearance,
-                  const AudioIOStartStreamOptions& options);
+    muse::Ret doRecord(AudacityProject& project, const TransportSequences& sequences, double t0, double t1, bool altAppearance,
+                       const AudioIOStartStreamOptions& options);
     void cancelRecording();
     bool canStopAudioStream() const;
 

--- a/au4/src/record/internal/recordcontroller.cpp
+++ b/au4/src/record/internal/recordcontroller.cpp
@@ -3,6 +3,8 @@
 */
 #include "recordcontroller.h"
 
+#include "translation.h"
+
 using namespace muse;
 using namespace au::audio;
 using namespace au::record;
@@ -67,8 +69,13 @@ void RecordController::start()
     IF_ASSERT_FAILED(record()) {
         return;
     }
-    
-    record()->start();
+
+    Ret ret = record()->start();
+    if (!ret) {
+        interactive()->error(muse::trc("record", "Recording error"), ret.text());
+        return;
+    }
+
     setCurrentRecordStatus(RecordStatus::Running);
 }
 
@@ -77,8 +84,13 @@ void RecordController::pause()
     IF_ASSERT_FAILED(record()) {
         return;
     }
-    
-    record()->pause();
+
+    Ret ret = record()->pause();
+    if (!ret) {
+        interactive()->error(muse::trc("record", "Recording error"), ret.text());
+        return;
+    }
+
     setCurrentRecordStatus(RecordStatus::Paused);
 }
 
@@ -87,8 +99,13 @@ void RecordController::stop()
     IF_ASSERT_FAILED(record()) {
         return;
     }
-    
-    record()->stop();
+
+    Ret ret = record()->stop();
+    if (!ret) {
+        interactive()->error(muse::trc("record", "Recording error"), ret.text());
+        return;
+    }
+
     setCurrentRecordStatus(RecordStatus::Stopped);
 }
 

--- a/au4/src/record/irecord.h
+++ b/au4/src/record/irecord.h
@@ -6,6 +6,8 @@
 
 #include <memory>
 
+#include "global/types/ret.h"
+
 #include "modularity/imoduleinterface.h"
 
 #include "iaudioinput.h"
@@ -17,9 +19,9 @@ class IRecord : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IRecord() = default;
 
-    virtual void start() = 0;
-    virtual void pause() = 0;
-    virtual void stop() = 0;
+    virtual muse::Ret start() = 0;
+    virtual muse::Ret pause() = 0;
+    virtual muse::Ret stop() = 0;
 
     virtual IAudioInputPtr audioInput() const = 0;
 };

--- a/au4/src/record/recorderrors.h
+++ b/au4/src/record/recorderrors.h
@@ -1,0 +1,45 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#pragma once
+
+#include "types/ret.h"
+#include "translation.h"
+
+namespace au::record {
+static constexpr int RECORD_FIRST = 5000;
+
+enum class Err {
+    Undefined       = int(muse::Ret::Code::Undefined),
+    NoError         = int(muse::Ret::Code::Ok),
+    UnknownError    = RECORD_FIRST,
+
+    RecordingError,
+    RecordingStopError,
+    MismatchedSamplingRatesError,
+    TooFewCompatibleTracksSelected
+};
+
+inline muse::Ret make_ret(Err e)
+{
+    int retCode = static_cast<int>(e);
+
+    switch (e) {
+    case Err::Undefined: return muse::Ret(retCode);
+    case Err::NoError: return muse::Ret(retCode);
+    case Err::UnknownError: return muse::Ret(retCode);
+    case Err::RecordingError: return muse::Ret(retCode, muse::trc("record", "Error opening recording device.\nError code: %1"));
+    case Err::RecordingStopError: return muse::Ret(retCode, muse::trc("record", "Cannot stop recording"));
+    case Err::MismatchedSamplingRatesError: return muse::Ret(retCode,
+                                                             muse::trc("record",
+                                                                       "The tracks selected for recording must all have the same sampling rate"));
+    case Err::TooFewCompatibleTracksSelected: return muse::Ret(retCode,
+                                                               muse::trc("record",
+                                                                         "Too few tracks are selected for recording at this sample rate.\n"
+                                                                         "(Audacity requires two channels at the same sample rate foreach stereo track)"));
+    }
+
+    return muse::Ret(static_cast<int>(e));
+}
+}


### PR DESCRIPTION
- now when selecting a track in au4 the corresponding tracks are selected in au3
- if an error occurred during the recording process, we now show a dialog with a description of this error
- enabled restart when reverting to factory settings 
- fixed crash on first launch (after reverting settings)
- fixed a bug when matching au3 keys in au4 settings