### PR TITLE
Adding a realtime effect makes the plugin ui open immediately

### DIFF
--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -56,6 +56,22 @@
 
 namespace
 {
+
+   void ToggleUi(
+      AudacityProject& project, RealtimeEffectState& state, wxString sourceName)
+   {
+      const auto ID = state.GetID();
+      const auto effectPlugin = EffectManager::Get().GetEffect(ID);
+
+      if (effectPlugin == nullptr)
+         return;
+
+      auto& effectStateUI = RealtimeEffectStateUI::Get(state);
+
+      effectStateUI.SetTargetName(sourceName);
+      effectStateUI.Toggle(project);
+   }
+
    using namespace MenuRegistry;
    class RealtimeEffectsMenuVisitor final : public Visitor<Traits> {
       wxMenu& mMenu;
@@ -665,6 +681,8 @@ namespace
                   /*! i18n-hint: undo history record
                    first parameter - realtime effect name */
                   XO("Replace %s").Format(oldName));
+
+                  ToggleUi(project, *state, mDelegate->GetSourceName());
             }
          }
       }
@@ -1084,6 +1102,8 @@ public:
             XO("Added %s to %s").Format(effectName, mDelegate->GetSourceName()),
             //i18n-hint: undo history record
             XO("Add %s").Format(effectName));
+
+            ToggleUi(*mProject, *state, mDelegate->GetSourceName());
       }
    }
 
@@ -1506,7 +1526,7 @@ public:
    {
       wxWindow::SetBackgroundStyle(wxBG_STYLE_PAINT);
       SetCursor(wxCursor(wxCURSOR_SIZENS));
-      
+
       Bind(wxEVT_LEFT_DOWN, &SashLine::OnMouseDown, this);
       Bind(wxEVT_LEFT_UP, &SashLine::OnMouseUp, this);
       Bind(wxEVT_MOTION, &SashLine::OnMove, this);
@@ -1557,7 +1577,7 @@ private:
             mSplitter->GetSize().y - mSplitter->GetMinimumPaneSize()
          ));
    }
-   
+
    void OnPaint(wxPaintEvent&)
    {
       wxBufferedPaintDC dc(this);
@@ -1566,7 +1586,7 @@ private:
       dc.SetPen(*wxTRANSPARENT_PEN);
       dc.SetBrush(GetBackgroundColour());
       dc.DrawRectangle(rect);
-      
+
       dc.SetPen(GetForegroundColour());
       dc.SetBrush(*wxTRANSPARENT_BRUSH);
       const auto yy = rect.GetTop() + rect.GetHeight() / 2;


### PR DESCRIPTION
Resolves:  #7076

Used the RealtimeEffectState to open effect UI as soon as user adds an effect or changes to a new effect. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
