### PR TITLE
Crash fix on cloud download failure

### DIFF
--- a/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.cpp
+++ b/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.cpp
@@ -381,8 +381,12 @@ void RemoteProjectSnapshot::DownloadBlob(
    }
 
    response->setRequestFinishedCallback(
-      [this, onSuccess = std::move(onSuccess), retries, response](auto)
+      [this, self = weak_from_this(), onSuccess = std::move(onSuccess), retries, response](auto)
       {
+         auto strong = self.lock();
+         if(!strong)
+            return;
+
          mDownloadedBytes.fetch_add(
             response->getBytesAvailable(), std::memory_order_acq_rel);
 

--- a/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.h
+++ b/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.h
@@ -49,6 +49,7 @@ using RemoteProjectSnapshotStateCallback =
    std::function<void(RemoteProjectSnapshotState)>;
 
 class RemoteProjectSnapshot final
+   : public std::enable_shared_from_this<RemoteProjectSnapshot>
 {
    struct Tag
    {


### PR DESCRIPTION

QA: attempt to sync with remote project when there is no local copy could crash the app when something goes wrong. Should be more or less reproducible with remote project created in 32 bit 3.6.1 and clean `CloudProjects` directory

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
