### PR TITLE
Hide and fadeout the splash screen only after the main window is visible

### DIFF
--- a/src/AudacityApp.h
+++ b/src/AudacityApp.h
@@ -21,6 +21,7 @@
 #include "AppEvents.h"
 
 #include <wx/app.h> // to inherit
+#include <wx/splash.h> // member variable
 #include <wx/timer.h> // member variable
 
 #include <memory>
@@ -119,11 +120,15 @@ class AudacityApp final
    std::unique_ptr<wxSingleInstanceChecker> mChecker;
 
    wxTimer mTimer;
+   wxTimer mSplashTimer;
+   std::unique_ptr<wxSplashScreen> mSplashScreen;
 
    void InitCommandHandler();
 
    bool InitTempDir();
    bool CreateSingleInstanceChecker(const wxString &dir);
+   void ShowSplashScreen();
+   void HideSplashScreen(bool fadeOut=true);
 
    std::unique_ptr<wxCmdLineParser> ParseCommandLine();
 


### PR DESCRIPTION
Resolves: #7134

* Wait until the main window is visible before hiding the splash screen
* Fade-out splash screen instead of simply hiding it

To QA: please test this PR on all available platforms, as it may behave differently depending on the system

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
