### PR TITLE
[AU4] Zoom. Added zoom max limit and corrected zoom min limit

### DIFF
--- a/au4/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/au4/src/projectscene/view/timeline/timelinecontext.cpp
@@ -9,7 +9,8 @@
 
 #include "log.h"
 
-static constexpr double ZOOM_MIN = 0.1;
+static constexpr double ZOOM_MIN = 0.001;
+static constexpr double ZOOM_MAX = 6000000;
 static constexpr int PIXELSSTEPSFACTOR = 5;
 
 using namespace au::projectscene;
@@ -100,16 +101,6 @@ void TimelineContext::onWheel(const QPoint& pixelDelta, const QPoint& angleDelta
             emit shiftViewByY(dy* correction);
         }
     }
-}
-
-void TimelineContext::changeZoom(int direction)
-{
-    double step = m_zoom * 0.04;
-
-    double zoom = m_zoom + (step * direction);
-    zoom = std::max(zoom, ZOOM_MIN);
-
-    setZoom(zoom);
 }
 
 void TimelineContext::onResizeFrameWidth(double frameWidth)
@@ -236,6 +227,8 @@ double TimelineContext::zoom() const
 
 void TimelineContext::setZoom(double zoom)
 {
+    zoom = std::max(ZOOM_MIN, std::min(ZOOM_MAX, zoom));
+
     if (m_zoom != zoom) {
         m_zoom = zoom;
         emit zoomChanged();

--- a/au4/src/projectscene/view/timeline/timelinecontext.h
+++ b/au4/src/projectscene/view/timeline/timelinecontext.h
@@ -101,8 +101,6 @@ private:
     void setFrameEndTime(double newFrameEndTime);
     void updateFrameTime();
 
-    void changeZoom(int direction);
-
     void setSelectionStartTime(double time);
     void setSelectionEndTime(double time);
     void updateSelectionActive();


### PR DESCRIPTION
improves the situation with #6975, but with very fast zoom in and zoom out audacity still crashes