### PR TITLE
Fix `WaveTrack` copy to clipboard

### DIFF
--- a/libraries/lib-channel/Channel.h
+++ b/libraries/lib-channel/Channel.h
@@ -295,6 +295,9 @@ public:
    //! Change start time by given duration
    void ShiftBy(double t) { MoveTo(GetStartTime() + t); }
 
+   //! Shift all intervals that starts after `t0` by `delta` seconds
+   virtual void ShiftBy(double t0, double delta) = 0;
+
    //! Change start time to given time point
    virtual void MoveTo(double o) = 0;
 

--- a/libraries/lib-note-track/NoteTrack.cpp
+++ b/libraries/lib-note-track/NoteTrack.cpp
@@ -217,6 +217,12 @@ Track::Holder NoteTrack::Clone(bool) const
    return duplicate;
 }
 
+void NoteTrack::ShiftBy(double t0, double delta)
+{
+   if(t0 <= mOrigin)
+      mOrigin += delta;
+}
+
 void NoteTrack::WarpAndTransposeNotes(double t0, double t1,
                                       const TimeWarper &warper,
                                       double semitones)

--- a/libraries/lib-note-track/NoteTrack.h
+++ b/libraries/lib-note-track/NoteTrack.h
@@ -96,6 +96,7 @@ private:
 
 public:
    void MoveTo(double origin) override { mOrigin = origin; }
+   void ShiftBy(double t0, double delta) override;
 
    Alg_seq &GetSeq() const;
 

--- a/libraries/lib-time-track/TimeTrack.h
+++ b/libraries/lib-time-track/TimeTrack.h
@@ -64,6 +64,7 @@ class TIME_TRACK_API TimeTrack final
    // TimeTrack parameters
 
    void MoveTo(double /* t */) override {}
+   void ShiftBy(double, double) override {}
 
    // XMLTagHandler callback methods for loading and saving
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1081,7 +1081,6 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
       THROW_INCONSISTENCY_EXCEPTION;
 
    auto newTrack = EmptyCopy(NChannels());
-   const auto endTime = std::max(GetEndTime(), t1);
    for (const auto pClip : Intervals()) {
       // PRL:  Why shouldn't cutlines be copied and pasted too?  I don't know,
       // but that was the old behavior.  But this function is also used by the
@@ -1096,7 +1095,7 @@ Track::Holder WaveTrack::Copy(double t0, double t1, bool forClipboard) const
          newTrack->CopyPartOfClip(*pClip, t0, t1, forClipboard);
       }
    }
-   newTrack->FinishCopy(t0, t1, endTime, forClipboard);
+   newTrack->FinishCopy(t0, t1, forClipboard);
    return newTrack;
 }
 
@@ -1124,13 +1123,13 @@ void WaveTrack::CopyPartOfClip(const Interval &clip,
 }
 
 void WaveTrack::FinishCopy(
-   double t0, double t1, double endTime, bool forClipboard)
+   double t0, double t1, bool forClipboard)
 {
    // AWD, Oct 2009: If the selection ends in whitespace, create a
    // placeholder clip representing that whitespace
    // PRL:  Only if we want the track for pasting into other tracks.  Not if
    // it goes directly into a project as in the Duplicate command.
-   if (forClipboard && endTime + 1.0 / GetRate() < t1 - t0) {
+   if (forClipboard && GetEndTime() + 1.0 / GetRate() < t1 - t0) {
       auto placeholder = CreateClip();
       placeholder->SetIsPlaceholder(true);
       placeholder->InsertSilence(0, (t1 - t0) - GetEndTime());

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -570,6 +570,22 @@ void WaveTrack::MoveTo(double origin)
    WaveTrackData::Get(*this).SetOrigin(origin);
 }
 
+/*! @excsafety{No-fail} */
+void WaveTrack::ShiftBy(double t0, double delta)
+{
+   for (const auto &pInterval : Intervals())
+   {   // assume No-fail-guarantee
+      if(pInterval->Start() >= t0)
+         pInterval->ShiftBy(delta);
+   }
+   const auto origin = WaveTrackData::Get(*this).GetOrigin();
+   if(t0 <= origin)
+   {
+      const auto offset = t0 >= 0 ? delta : t0 + delta;
+      WaveTrackData::Get(*this).SetOrigin(origin + offset);
+   }
+}
+
 auto WaveTrack::DuplicateWithOtherTempo(double newTempo) const -> Holder
 {
    const auto srcCopy = Duplicate();

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -570,7 +570,7 @@ private:
    void CopyWholeClip(const Interval &clip, double t0, bool forClipboard);
    void CopyPartOfClip(const Interval &clip,
       double t0, double t1, bool forClipboard);
-   void FinishCopy(double t0, double t1, double endTime, bool forClipboard);
+   void FinishCopy(double t0, double t1, bool forClipboard);
 
    //! Return all WaveClips sorted by clip play start time.
    IntervalConstHolders SortedClipArray() const;

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -287,6 +287,7 @@ public:
    virtual ~WaveTrack();
 
    void MoveTo(double o) override;
+   void ShiftBy(double t0, double delta) override;
 
    bool LinkConsistencyFix(bool doFix) override;
 

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -179,6 +179,7 @@ LabelTrack::~LabelTrack()
 {
 }
 
+
 void LabelTrack::MoveTo(double origin)
 {
    if (!mLabels.empty()) {
@@ -186,6 +187,17 @@ void LabelTrack::MoveTo(double origin)
       for (auto &labelStruct: mLabels) {
          labelStruct.selectedRegion.move(offset);
       }
+   }
+}
+
+void LabelTrack::ShiftBy(double t0, double delta)
+{
+   if (mLabels.empty())
+   return;
+   for (auto &labelStruct: mLabels)
+   {
+      if(labelStruct.selectedRegion.t0() >= t0)
+         labelStruct.selectedRegion.move(delta);
    }
 }
 

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -119,6 +119,7 @@ class AUDACITY_DLL_API LabelTrack final
    void SetLabel( size_t iLabel, const LabelStruct &newLabel );
 
    void MoveTo(double dOffset) override;
+   void ShiftBy(double t0, double delta) override;
 
    void SetSelected(bool s) override;
 

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -700,6 +700,25 @@ void OnPaste(const CommandContext &context)
    // TODO: What if we clicked past the end of the track?
 
    if (bPastedSomething) {
+
+      if(!isSyncLocked && GetEditClipsCanMove())
+      {
+         //Special case when pasting without sync lock and
+         //"...move other clips" option is 
+         //Also shift all intervals in all other tracks that
+         //starts after t0
+         const auto offset = srcTracks->GetEndTime() - (t1 - t0);
+         for(auto track : tracks.Any<Track>())
+         {
+            const auto it = std::find_if(correspondence.begin(), correspondence.end(),
+                                   [=](auto& p) { return p.first == track; });
+            if(it != correspondence.end())
+               continue;
+
+            track->ShiftBy(t0, offset);
+         }
+      }
+
       ViewInfo::Get(project).selectedRegion
          .setTimes( t0, t0 + clipboard.Duration() );
 

--- a/src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
@@ -317,7 +317,7 @@ void StretchHandle::Stretch(AudacityProject *pProject, int mouseXCoordinate, int
             return;
          nt.StretchRegion
             ( mStretchState.mBeat0, mStretchState.mBeat1, dur );
-         nt.ShiftBy(moveto - t0);
+         nt.ChannelGroup::ShiftBy(moveto - t0);
          mStretchState.mBeat0.first = moveto;
          viewInfo.selectedRegion.setT0(moveto);
          break;


### PR DESCRIPTION
Resolves: #7124 

Paste behaviour change: when pasting all clips and labels to the right from the beginning of selection intrval should move accordingly, if sync lock disabled and "...clips can move" option is enabled

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA: Please check operations that involve track copying with two types of selections - one that ends inside wave clip, second one that has ends with emptiness (it may also be an empty wave interval):
 - [x] Copy/Paste
 - [x] Cut/Paste
 - [x] Split cut/Paste
 - [x] Effect preview (!)
 - [x] Effect "Repeat"
