### PR TITLE
`MenuItemEnabler `s have an optional post-command action

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1750,11 +1750,11 @@ double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
    return supportedRate;
 }
 
-double AudioIO::GetStreamTime()
+double AudioIO::GetStreamTime(bool ignorePlaybackState) const
 {
    // Sequence time readout for the main thread
 
-   if( !IsStreamActive() )
+   if (!ignorePlaybackState && !IsStreamActive())
       return BAD_STREAM_TIME;
 
    return mPlaybackSchedule.GetSequenceTime();

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -565,7 +565,7 @@ public:
     * too. So the returned time should be always between
     * t0 and t1
     */
-   double GetStreamTime();
+   double GetStreamTime(bool ignorePlaybackState = false) const;
 
    static void AudioThread(std::atomic<bool> &finish);
 

--- a/libraries/lib-menus/CommandFlag.h
+++ b/libraries/lib-menus/CommandFlag.h
@@ -104,6 +104,7 @@ public:
 // then the enabler will be invoked (unless the menu item is constructed with
 // the useStrictFlags option, or the applicability test first returns false).
 // The item's full set of required flags is passed to the function.
+// The enabler may return an action to be executed after the command is run.
 
 // Computation of the flags is delayed inside a function -- because often you
 // need to name a statically allocated CommandFlag, or a bitwise OR of some,
@@ -111,7 +112,9 @@ public:
 struct MenuItemEnabler {
    using Flags = std::function< CommandFlag() >;
    using Test = std::function< bool( const AudacityProject& ) >;
-   using Action = std::function< void( AudacityProject&, CommandFlag ) >;
+   using PostCommandAction = std::function<void()>;
+   using Action =
+      std::function<PostCommandAction(AudacityProject&, CommandFlag)>;
 
    const Flags actualFlags;
    const Flags possibleFlags;

--- a/libraries/lib-menus/CommandManager.h
+++ b/libraries/lib-menus/CommandManager.h
@@ -80,14 +80,8 @@ public:
    CommandFlag GetUpdateFlags(bool quick = false) const;
    void UpdatePrefs() override;
 
-   // Command Handling
-   bool ReportIfActionNotAllowed(
-      const TranslatableString & Name, CommandFlag & flags, CommandFlag flagsRqd );
-   bool TryToMakeActionAllowed(
-      CommandFlag & flags, CommandFlag flagsRqd );
-
    CommandFlag mLastFlags = AlwaysEnabledFlag;
-   
+
    // Last effect applied to this project
    PluginID mLastGenerator{};
    PluginID mLastEffect{};
@@ -135,7 +129,7 @@ public:
       void DoVisit(const Registry::SingleItem &item);
       void DoEndGroup(
          const MenuRegistry::GroupItem<MenuRegistry::Traits> &item);
-      
+
       //! Called by DoBeginGroup
       //! Default implementation does nothing
       virtual void BeginMenu(const TranslatableString & tName);
@@ -310,7 +304,12 @@ public:
 private:
 
    static int NextIdentifier(int ID);
-   
+
+   // Command Handling
+   bool ReportIfActionNotAllowed(
+      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd);
+   bool TryToMakeActionAllowed(CommandFlag& flags, CommandFlag flagsRqd);
+
 protected:
    bool HandleCommandEntry(
       const CommandListEntry * entry, CommandFlag flags,

--- a/libraries/lib-menus/CommandManager.h
+++ b/libraries/lib-menus/CommandManager.h
@@ -307,8 +307,11 @@ private:
 
    // Command Handling
    bool ReportIfActionNotAllowed(
-      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd);
-   bool TryToMakeActionAllowed(CommandFlag& flags, CommandFlag flagsRqd);
+      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd,
+      std::vector<MenuItemEnabler::PostCommandAction>& posts);
+   bool TryToMakeActionAllowed(
+      CommandFlag& flags, CommandFlag flagsRqd,
+      std::vector<MenuItemEnabler::PostCommandAction>& posts);
 
 protected:
    bool HandleCommandEntry(

--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -312,11 +312,9 @@ RegisteredMenuItemEnabler stopAudioStream {
         const auto wasPlaying = pam.Playing();
         if (wasPlaying)
            pam.Stop(stopStream);
-        return [&, wasPlaying = wasPlaying]
-        {
+        return [&, wasPlaying = wasPlaying] {
            if (wasPlaying && !pam.Playing())
-              ; // ResumePlayback in follow-up commit
-            //   ProjectAudioManager::Get(project).ResumePlayback();
+              ProjectAudioManager::Get(project).ResumePlayback();
         };
      } }
 };

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1310,16 +1310,18 @@ void ProjectAudioManager::DoPlayStopSelect()
    }
 }
 
-static RegisteredMenuItemEnabler stopIfPaused{{
-   []{ return PausedFlag(); },
-   []{ return AudioIONotBusyFlag(); },
-   []( const AudacityProject &project ){
-      return CommandManager::Get( project ).mStopIfWasPaused; },
-   []( AudacityProject &project, CommandFlag ){
-      if ( CommandManager::Get( project ).mStopIfWasPaused )
-         ProjectAudioManager::Get( project ).StopIfPaused();
-   }
-}};
+static RegisteredMenuItemEnabler stopIfPaused {
+   { [] { return PausedFlag(); }, [] { return AudioIONotBusyFlag(); },
+     [](const AudacityProject& project) {
+        return CommandManager::Get(project).mStopIfWasPaused;
+     },
+     [](AudacityProject& project,
+        CommandFlag) -> MenuItemEnabler::PostCommandAction {
+        if (CommandManager::Get(project).mStopIfWasPaused)
+           ProjectAudioManager::Get(project).StopIfPaused();
+        return {};
+     } }
+};
 
 // GetSelectedProperties collects information about
 // currently selected audio tracks

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -762,17 +762,6 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
 {
    auto &projectAudioManager = *this;
 
-   CommandFlag flags = AlwaysEnabledFlag; // 0 means recalc flags.
-
-   // NB: The call may have the side effect of changing flags.
-   bool allowed = CommandManager::Get(project).TryToMakeActionAllowed(
-      flags,
-      AudioIONotBusyFlag() | CanStopAudioStreamFlag());
-
-   if (!allowed)
-      return false;
-   // ...end of code from CommandHandler.
-
    auto gAudioIO = AudioIO::Get();
    if (gAudioIO->IsBusy())
       return false;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -471,7 +471,12 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
 void ProjectAudioManager::PlayCurrentRegion(bool newDefault /* = false */,
                                        bool cutpreview /* = false */)
 {
-   auto &projectAudioManager = *this;
+   DoPlayCurrentRegion(newDefault, cutpreview, false);
+}
+
+void ProjectAudioManager::DoPlayCurrentRegion(
+   bool newDefault, bool cutpreview, bool resume)
+{   auto &projectAudioManager = *this;
    bool canStop = projectAudioManager.CanStopAudioStream();
 
    if ( !canStop )
@@ -492,10 +497,22 @@ void ProjectAudioManager::PlayCurrentRegion(bool newDefault /* = false */,
          cutpreview ? PlayMode::cutPreviewPlay
          : newDefault ? PlayMode::loopedPlay
          : PlayMode::normalPlay;
+      if (const auto io = AudioIO::Get(); io && resume)
+      {
+         constexpr auto ignorePlaybackState = true;
+         options.pStartTime = io->GetStreamTime(true);
+      }
       PlayPlayRegion(SelectedRegion(playRegion.GetStart(), playRegion.GetEnd()),
                      options,
                      mode);
    }
+}
+
+void ProjectAudioManager::ResumePlayback()
+{
+   // What are these `cutpreview` and `newDefault` flags? Nowhere is
+   // PlayCurrentRegion called with any of them set to `trzue`.
+   DoPlayCurrentRegion(false, false, true);
 }
 
 void ProjectAudioManager::Stop(bool stopStream /* = true*/)

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -122,8 +122,10 @@ public:
       bool newDefault = false, //!< See ProjectAudioIO::GetDefaultOptions
       bool cutpreview = false);
 
+   void ResumePlayback();
+
    void OnPause();
-   
+
 
    // Stop playing or recording
    void Stop(bool stopStream = true);
@@ -136,6 +138,7 @@ public:
    PlayMode GetLastPlayMode() const { return mLastPlayMode; }
 
 private:
+   void DoPlayCurrentRegion(bool newDefault, bool cutpreview, bool resume);
 
    void TogglePaused();
    void SetPausedOff();

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -556,22 +556,6 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
       return;
    }
 
-   // Honor the "select all if none" preference...a little hackish, but whatcha gonna do...
-   if (!mIsBatch &&
-       mEffectUIHost.GetDefinition().GetType() != EffectTypeGenerate &&
-       mEffectUIHost.GetDefinition().GetType() != EffectTypeTool &&
-       ViewInfo::Get( project ).selectedRegion.isPoint())
-   {
-      auto flags = AlwaysEnabledFlag;
-      bool allowed =
-      CommandManager::Get( project ).ReportIfActionNotAllowed(
-         mEffectUIHost.GetDefinition().GetName(),
-         flags,
-         WaveTracksSelectedFlag() | TimeSelectedFlag());
-      if (!allowed)
-         return;
-   }
-
    if (!TransferDataFromWindow() ||
        // This is the main place where there is a side-effect on the config
        // file to remember the last-used settings of an effect, just before

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -1237,10 +1237,13 @@ auto ExtraEditMenu()
 
 auto canSelectAll = [](const AudacityProject &project){
    return CommandManager::Get( project ).mWhatIfNoSelection != 0; };
-auto selectAll = []( AudacityProject &project, CommandFlag flagsRqd ){
+auto selectAll =
+   [](AudacityProject& project,
+      CommandFlag flagsRqd) -> MenuItemEnabler::PostCommandAction {
    if ( CommandManager::Get( project ).mWhatIfNoSelection == 1 &&
       (flagsRqd & NoAutoSelect()).none() )
       SelectUtilities::DoSelectAllAudio(project);
+   return {};
 };
 
 RegisteredMenuItemEnabler selectTracks{{


### PR DESCRIPTION
Resolves: #2617 (Not completely...)

A follow-up PR will enable this new functionality on the `AudioIONotBusyFlag`, which will allow us to choose whether actions that are currently blocked by playback should just automatically stop playback or stop _and_ resume once the command is executed. This, however, will require a big involvement from our designers and may take a while. In the meantime, review of the functionality underneath may begin.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA: No behavioral change must be observed. In particular,
- [ ] All recording-related commands should still be disabled during playback. Also check that interactions between projects (e.g. playback ongoing in project A ; can I start recording in project B ?) remains unchanged.