### PR TITLE
2617 perpetual playback

### DIFF
--- a/libraries/lib-audio-devices/AudioIOBase.h
+++ b/libraries/lib-audio-devices/AudioIOBase.h
@@ -262,6 +262,8 @@ public:
 
    virtual void StopStream() = 0;
 
+   virtual bool IsPlayheadMoving(std::optional<int> token) /* const */ = 0;
+
    /** \brief  Returns true if audio i/o is busy starting, stopping, playing,
     * or recording.
     *

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1313,6 +1313,7 @@ bool AudioIO::AllocateBuffers(
 
                Mixer::Inputs mixSequences;
                mixSequences.push_back(Mixer::Input{ pSequence });
+               auto pullFromTracks = [this] { return !mLetRing; };
                mPlaybackMixers.emplace_back(std::make_unique<Mixer>(
                   std::move(mixSequences), std::nullopt,
                   // Don't throw for read errors, just play silence:
@@ -1323,8 +1324,8 @@ bool AudioIO::AllocateBuffers(
                   mRate, floatSample,
                   false,   // low quality dithering and resampling
                   nullptr, // no custom mix-down
-                  Mixer::ApplyVolume::Discard // don't apply volume
-                  ));
+                  Mixer::ApplyVolume::Discard, // don't apply volume
+                  std::move(pullFromTracks)));
             }
 
             const auto timeQueueSize = 1 +

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1750,11 +1750,11 @@ double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
    return supportedRate;
 }
 
-double AudioIO::GetStreamTime()
+double AudioIO::GetStreamTime(bool ignorePlaybackState) const
 {
    // Sequence time readout for the main thread
 
-   if( !IsStreamActive() )
+   if (!ignorePlaybackState && !IsStreamActive())
       return BAD_STREAM_TIME;
 
    return mPlaybackSchedule.GetSequenceTime();

--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1761,7 +1761,7 @@ double AudioIO::GetStreamTime(bool ignorePlaybackState) const
 {
    // Sequence time readout for the main thread
 
-   if (!ignorePlaybackState && !IsStreamActive())
+   if(!ignorePlaybackState && (!IsStreamActive() || mLetRing) )
       return BAD_STREAM_TIME;
 
    return mPlaybackSchedule.GetSequenceTime();

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -565,7 +565,7 @@ public:
     * too. So the returned time should be always between
     * t0 and t1
     */
-   double GetStreamTime();
+   double GetStreamTime(bool ignorePlaybackState = false) const;
 
    static void AudioThread(std::atomic<bool> &finish);
 

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -477,6 +477,8 @@ public:
     * by the specified amount from where it is now */
    void SeekStream(double seconds) { mSeek = seconds; }
 
+   bool IsPlayheadMoving(std::optional<int> token) /* const */ override;
+
    // To be called from main thread only.
    void SetLetRing(bool value);
 

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -481,6 +481,9 @@ public:
     * by the specified amount from where it is now */
    void SeekStream(double seconds) { mSeek = seconds; }
 
+   // To be called from main thread only.
+   void SetLetRing(bool value);
+
    using PostRecordingAction = std::function<void()>;
 
    //! Enqueue action for main thread idle time, not before the end of any recording in progress
@@ -652,6 +655,7 @@ private:
    PostRecordingAction mPostRecordingAction;
 
    bool mDelayingActions{ false };
+   bool mLetRing { false };
 };
 
 AUDIO_IO_API extern BoolSetting SoundActivatedRecord;

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -175,10 +175,6 @@ public:
    // Part of the callback
    int CallbackDoSeek();
 
-   // Part of the callback
-   void CallbackCheckCompletion(
-      int &callbackReturn, unsigned long len);
-
    int mbHasSoloSequences;
    int mCallbackReturn;
    // Helpers to determine if sequences have already been faded out.

--- a/libraries/lib-effects/MixAndRender.cpp
+++ b/libraries/lib-effects/MixAndRender.cpp
@@ -66,8 +66,10 @@ Track::Holder MixAndRender(const TrackIterRange<const WaveTrack> &trackRange,
    Mixer::Inputs waveArray;
 
    for (auto wt : trackRange) {
-      const auto stretchingSequence =
-         StretchingSequence::Create(*wt, wt->GetClipInterfaces());
+      const auto stretchingSequence = StretchingSequence::Create(
+         std::dynamic_pointer_cast<const PlayableSequence>(
+            wt->shared_from_this()),
+         wt->GetClipInterfaces());
       waveArray.emplace_back(stretchingSequence, GetEffectStages(*wt));
       tstart = wt->GetStartTime();
       tend = wt->GetEndTime();

--- a/libraries/lib-import-export/ExportPluginHelpers.cpp
+++ b/libraries/lib-import-export/ExportPluginHelpers.cpp
@@ -30,7 +30,10 @@ std::unique_ptr<Mixer> ExportPluginHelpers::CreateMixer(
    const auto& tracks = TrackList::Get(project);
    for (auto pTrack: ExportUtils::FindExportWaveTracks(tracks, selectionOnly))
       inputs.emplace_back(
-         StretchingSequence::Create(*pTrack, pTrack->GetClipInterfaces()),
+         StretchingSequence::Create(
+            std::dynamic_pointer_cast<const PlayableSequence>(
+               pTrack->shared_from_this()),
+            pTrack->GetClipInterfaces()),
          GetEffectStages(*pTrack));
    // MB: the stop time should not be warped, this was a bug.
    return std::make_unique<Mixer>(

--- a/libraries/lib-menus/CommandFlag.h
+++ b/libraries/lib-menus/CommandFlag.h
@@ -104,6 +104,7 @@ public:
 // then the enabler will be invoked (unless the menu item is constructed with
 // the useStrictFlags option, or the applicability test first returns false).
 // The item's full set of required flags is passed to the function.
+// The enabler may return an action to be executed after the command is run.
 
 // Computation of the flags is delayed inside a function -- because often you
 // need to name a statically allocated CommandFlag, or a bitwise OR of some,
@@ -111,7 +112,9 @@ public:
 struct MenuItemEnabler {
    using Flags = std::function< CommandFlag() >;
    using Test = std::function< bool( const AudacityProject& ) >;
-   using Action = std::function< void( AudacityProject&, CommandFlag ) >;
+   using PostCommandAction = std::function<void()>;
+   using Action =
+      std::function<PostCommandAction(AudacityProject&, CommandFlag)>;
 
    const Flags actualFlags;
    const Flags possibleFlags;

--- a/libraries/lib-menus/CommandManager.h
+++ b/libraries/lib-menus/CommandManager.h
@@ -80,14 +80,8 @@ public:
    CommandFlag GetUpdateFlags(bool quick = false) const;
    void UpdatePrefs() override;
 
-   // Command Handling
-   bool ReportIfActionNotAllowed(
-      const TranslatableString & Name, CommandFlag & flags, CommandFlag flagsRqd );
-   bool TryToMakeActionAllowed(
-      CommandFlag & flags, CommandFlag flagsRqd );
-
    CommandFlag mLastFlags = AlwaysEnabledFlag;
-   
+
    // Last effect applied to this project
    PluginID mLastGenerator{};
    PluginID mLastEffect{};
@@ -135,7 +129,7 @@ public:
       void DoVisit(const Registry::SingleItem &item);
       void DoEndGroup(
          const MenuRegistry::GroupItem<MenuRegistry::Traits> &item);
-      
+
       //! Called by DoBeginGroup
       //! Default implementation does nothing
       virtual void BeginMenu(const TranslatableString & tName);
@@ -310,7 +304,12 @@ public:
 private:
 
    static int NextIdentifier(int ID);
-   
+
+   // Command Handling
+   bool ReportIfActionNotAllowed(
+      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd);
+   bool TryToMakeActionAllowed(CommandFlag& flags, CommandFlag flagsRqd);
+
 protected:
    bool HandleCommandEntry(
       const CommandListEntry * entry, CommandFlag flags,

--- a/libraries/lib-menus/CommandManager.h
+++ b/libraries/lib-menus/CommandManager.h
@@ -307,8 +307,11 @@ private:
 
    // Command Handling
    bool ReportIfActionNotAllowed(
-      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd);
-   bool TryToMakeActionAllowed(CommandFlag& flags, CommandFlag flagsRqd);
+      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd,
+      std::vector<MenuItemEnabler::PostCommandAction>& posts);
+   bool TryToMakeActionAllowed(
+      CommandFlag& flags, CommandFlag flagsRqd,
+      std::vector<MenuItemEnabler::PostCommandAction>& posts);
 
 protected:
    bool HandleCommandEntry(

--- a/libraries/lib-mixer/Mix.h
+++ b/libraries/lib-mixer/Mix.h
@@ -69,7 +69,8 @@ public:
       double outRate, sampleFormat outFormat, bool highQuality = true,
       //! Null or else must have a lifetime enclosing this object's
       MixerSpec* mixerSpec = nullptr,
-      ApplyVolume applyVolume = ApplyVolume::MapChannels);
+      ApplyVolume applyVolume = ApplyVolume::MapChannels,
+      std::function<bool()> pullFromTracks = {});
 
    Mixer(const Mixer&) = delete;
    Mixer &operator=(const Mixer&) = delete;
@@ -182,5 +183,6 @@ private:
 
    struct Source { MixerSource &upstream; AudioGraph::Source &downstream; };
    std::vector<Source> mDecoratedSources;
+   const std::function<bool()> mPullFromTracks;
 };
 #endif

--- a/libraries/lib-mixer/MixerSource.h
+++ b/libraries/lib-mixer/MixerSource.h
@@ -38,13 +38,12 @@ public:
    /*!
     @pre `pTimesAndSpeed != nullptr`
     */
-   MixerSource(const std::shared_ptr<const WideSampleSequence> &seq,
-      size_t bufferSize,
-      double rate, const MixerOptions::Warp &options, bool highQuality,
+   MixerSource(
+      const std::shared_ptr<const WideSampleSequence>& seq, size_t bufferSize,
+      double rate, const MixerOptions::Warp& options, bool highQuality,
       bool mayThrow, std::shared_ptr<TimesAndSpeed> pTimesAndSpeed,
       //! Null or else must have a lifetime enclosing this objects's
-      const ArrayOf<bool> *pMap
-   );
+      const ArrayOf<bool>* pMap, const std::function<bool()>& pullFromTrack);
    MixerSource(MixerSource&&) = default;
    MixerSource &operator=(MixerSource&&) = delete;
    ~MixerSource();
@@ -137,5 +136,7 @@ private:
    //! Remember how many channels were passed to Acquire()
    unsigned mMaxChannels{};
    size_t mLastProduced{};
+
+   const std::function<bool()>& mPullFromTrack;
 };
 #endif

--- a/libraries/lib-stretching-sequence/StretchingSequence.h
+++ b/libraries/lib-stretching-sequence/StretchingSequence.h
@@ -28,10 +28,10 @@ class STRETCHING_SEQUENCE_API StretchingSequence final : public PlayableSequence
 {
 public:
    static std::shared_ptr<StretchingSequence>
-   Create(const PlayableSequence&, const ClipConstHolders& clips);
+   Create(std::shared_ptr<const PlayableSequence>, const ClipConstHolders& clips);
 
    StretchingSequence(
-      const PlayableSequence&, int sampleRate, size_t numChannels,
+      std::shared_ptr<const PlayableSequence>, int sampleRate, size_t numChannels,
       std::unique_ptr<AudioSegmentFactoryInterface>);
 
    // WideSampleSequence
@@ -52,7 +52,7 @@ public:
       sampleCount* pNumWithinClips = nullptr) const override;
 
    // PlayableSequence
-   const ChannelGroup *FindChannelGroup() const override;
+   const ChannelGroup* FindChannelGroup() const override;
    bool GetSolo() const override;
    bool GetMute() const override;
 
@@ -67,12 +67,12 @@ private:
    using AudioSegments = std::vector<std::shared_ptr<AudioSegment>>;
 
    void ResetCursor(double t, PlaybackDirection);
-   bool GetNext(float *const buffers[], size_t numChannels, size_t numSamples);
+   bool GetNext(float* const buffers[], size_t numChannels, size_t numSamples);
    bool MutableGet(
       size_t iChannel, size_t nBuffers, const samplePtr buffers[],
       sampleFormat format, sampleCount start, size_t len, bool backwards);
 
-   const PlayableSequence& mSequence;
+   std::shared_ptr<const PlayableSequence> mSequence;
    const std::unique_ptr<AudioSegmentFactoryInterface> mAudioSegmentFactory;
    AudioSegments mAudioSegments;
    AudioSegments::const_iterator mActiveAudioSegmentIt = mAudioSegments.end();

--- a/libraries/lib-stretching-sequence/tests/StretchingSequenceIntegrationTest.cpp
+++ b/libraries/lib-stretching-sequence/tests/StretchingSequenceIntegrationTest.cpp
@@ -51,7 +51,7 @@ TEST_CASE("StretchingSequence integration tests")
          [](auto& clip) { clip.SetPlayStartTime(3.0); });
 
       const auto sut = StretchingSequence::Create(
-         *mockSequence, ClipConstHolders { minusClip, plusClip });
+         mockSequence, ClipConstHolders { minusClip, plusClip });
       const auto track = trackMaker.Track({ minusClip, plusClip });
       constexpr auto backwards = false;
       AudioContainer sutOutput(totalLength, numChannels);

--- a/libraries/lib-stretching-sequence/tests/StretchingSequenceTest.cpp
+++ b/libraries/lib-stretching-sequence/tests/StretchingSequenceTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE("StretchingSequence unit tests")
          const auto mockSequence =
             std::make_shared<MockPlayableSequence>(sampleRate, numChannels);
          const auto sut = StretchingSequence::Create(
-            *mockSequence, ClipConstHolders { clip1, clip3 });
+            mockSequence, ClipConstHolders { clip1, clip3 });
 
          constexpr auto len = 2;
          const std::array<std::vector<float>, 6> expected { { { 6.f, 5.f },
@@ -77,7 +77,7 @@ TEST_CASE("StretchingSequence unit tests")
          const auto mockSequence =
             std::make_shared<MockPlayableSequence>(sampleRate, numChannels);
          StretchingSequence sut(
-            *mockSequence, sampleRate, numChannels,
+            mockSequence, sampleRate, numChannels,
             std::unique_ptr<AudioSegmentFactoryInterface> { factory });
          constexpr auto numSamples = 3;
          constexpr auto numChannels = 1;
@@ -136,7 +136,7 @@ TEST_CASE("StretchingSequence with real audio")
       const auto mockSequence = std::make_shared<MockPlayableSequence>(
          info.sampleRate, info.numChannels);
       const auto sut =
-         StretchingSequence::Create(*mockSequence, ClipConstHolders { clip });
+         StretchingSequence::Create(mockSequence, ClipConstHolders { clip });
       const size_t numOutputSamples = clip->stretchRatio * input[0].size() + .5;
       AudioContainer container(numOutputSamples, input.size());
       sut->GetFloats(
@@ -173,7 +173,7 @@ TEST_CASE("StretchingSequence with real audio")
       const auto mockSequence =
          std::make_shared<MockPlayableSequence>(info.sampleRate, 2u);
       const auto sut = StretchingSequence::Create(
-         *mockSequence, ClipConstHolders { clip1, clip2 });
+         mockSequence, ClipConstHolders { clip1, clip2 });
       const size_t numOutputSamples =
          totalDuration * info.sampleRate /*assuming both have same sample rate*/
          + .5;

--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -312,11 +312,9 @@ RegisteredMenuItemEnabler stopAudioStream {
         const auto wasPlaying = pam.Playing();
         if (wasPlaying)
            pam.Stop(stopStream);
-        return [&, wasPlaying = wasPlaying]
-        {
+        return [&, wasPlaying = wasPlaying] {
            if (wasPlaying && !pam.Playing())
-              ; // ResumePlayback in follow-up commit
-            //   ProjectAudioManager::Get(project).ResumePlayback();
+              ProjectAudioManager::Get(project).ResumePlayback();
         };
      } }
 };

--- a/src/DefaultPlaybackPolicy.cpp
+++ b/src/DefaultPlaybackPolicy.cpp
@@ -88,14 +88,14 @@ double DefaultPlaybackPolicy::OffsetSequenceTime(
    if (mpStartTime) {
       if (mLoopEnabled) {
          if (time < schedule.mT0)
-            time = std::clamp(time + offset, *mpStartTime, schedule.mT1);
+            time = std::min(std::max(time + offset, schedule.mT1), *mpStartTime);
          else
-            time = std::clamp(time + offset, schedule.mT0, schedule.mT1);
+            time = std::min(std::max(time + offset, schedule.mT0), *mpStartTime);
       }
       else {
          // this includes the case where the start time is after the
          // looped region, and mLoopEnabled is set to false
-         time = std::clamp(time + offset, *mpStartTime, schedule.mT1);
+         time = std::min(std::max(time + offset, schedule.mT1), *mpStartTime);
       }
    }
 

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -324,7 +324,9 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
 
    auto gAudioIO = AudioIO::Get();
    if (gAudioIO->IsBusy())
-      return -1;
+      // Brute-force approach. Maybe there's a slicker way, but for now we keep
+      // things simple.
+      gAudioIO->StopStream();
 
    const bool cutpreview = mode == PlayMode::cutPreviewPlay;
    if (cutpreview && t0==t1)
@@ -1174,6 +1176,7 @@ bool ProjectAudioManager::Playing() const
 {
    auto gAudioIO = AudioIO::Get();
    return
+      gAudioIO->IsPlayheadMoving({}) &&
       gAudioIO->IsBusy() &&
       CanStopAudioStream() &&
       // ... and not merely monitoring
@@ -1194,7 +1197,7 @@ bool ProjectAudioManager::Recording() const
 bool ProjectAudioManager::CanStopAudioStream() const
 {
    auto gAudioIO = AudioIO::Get();
-   return (!gAudioIO->IsStreamActive() ||
+   return (!gAudioIO->IsPlayheadMoving({}) ||
            gAudioIO->IsMonitoring() ||
            gAudioIO->GetOwningProject().get() == &mProject );
 }

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1310,16 +1310,18 @@ void ProjectAudioManager::DoPlayStopSelect()
    }
 }
 
-static RegisteredMenuItemEnabler stopIfPaused{{
-   []{ return PausedFlag(); },
-   []{ return AudioIONotBusyFlag(); },
-   []( const AudacityProject &project ){
-      return CommandManager::Get( project ).mStopIfWasPaused; },
-   []( AudacityProject &project, CommandFlag ){
-      if ( CommandManager::Get( project ).mStopIfWasPaused )
-         ProjectAudioManager::Get( project ).StopIfPaused();
-   }
-}};
+static RegisteredMenuItemEnabler stopIfPaused {
+   { [] { return PausedFlag(); }, [] { return AudioIONotBusyFlag(); },
+     [](const AudacityProject& project) {
+        return CommandManager::Get(project).mStopIfWasPaused;
+     },
+     [](AudacityProject& project,
+        CommandFlag) -> MenuItemEnabler::PostCommandAction {
+        if (CommandManager::Get(project).mStopIfWasPaused)
+           ProjectAudioManager::Get(project).StopIfPaused();
+        return {};
+     } }
+};
 
 // GetSelectedProperties collects information about
 // currently selected audio tracks

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -762,17 +762,6 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
 {
    auto &projectAudioManager = *this;
 
-   CommandFlag flags = AlwaysEnabledFlag; // 0 means recalc flags.
-
-   // NB: The call may have the side effect of changing flags.
-   bool allowed = CommandManager::Get(project).TryToMakeActionAllowed(
-      flags,
-      AudioIONotBusyFlag() | CanStopAudioStreamFlag());
-
-   if (!allowed)
-      return false;
-   // ...end of code from CommandHandler.
-
    auto gAudioIO = AudioIO::Get();
    if (gAudioIO->IsBusy())
       return false;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -471,7 +471,12 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
 void ProjectAudioManager::PlayCurrentRegion(bool newDefault /* = false */,
                                        bool cutpreview /* = false */)
 {
-   auto &projectAudioManager = *this;
+   DoPlayCurrentRegion(newDefault, cutpreview, false);
+}
+
+void ProjectAudioManager::DoPlayCurrentRegion(
+   bool newDefault, bool cutpreview, bool resume)
+{   auto &projectAudioManager = *this;
    bool canStop = projectAudioManager.CanStopAudioStream();
 
    if ( !canStop )
@@ -492,10 +497,22 @@ void ProjectAudioManager::PlayCurrentRegion(bool newDefault /* = false */,
          cutpreview ? PlayMode::cutPreviewPlay
          : newDefault ? PlayMode::loopedPlay
          : PlayMode::normalPlay;
+      if (const auto io = AudioIO::Get(); io && resume)
+      {
+         constexpr auto ignorePlaybackState = true;
+         options.pStartTime = io->GetStreamTime(true);
+      }
       PlayPlayRegion(SelectedRegion(playRegion.GetStart(), playRegion.GetEnd()),
                      options,
                      mode);
    }
+}
+
+void ProjectAudioManager::ResumePlayback()
+{
+   // What are these `cutpreview` and `newDefault` flags? Nowhere is
+   // PlayCurrentRegion called with any of them set to `trzue`.
+   DoPlayCurrentRegion(false, false, true);
 }
 
 void ProjectAudioManager::Stop(bool stopStream /* = true*/)

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -546,6 +546,8 @@ void ProjectAudioManager::Stop(bool stopStream /* = true*/)
 
    if(stopStream)
       gAudioIO->StopStream();
+   else
+      gAudioIO->SetLetRing(true);
 
    projectAudioManager.SetLooping( false );
    projectAudioManager.SetCutting( false );

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -122,8 +122,10 @@ public:
       bool newDefault = false, //!< See ProjectAudioIO::GetDefaultOptions
       bool cutpreview = false);
 
+   void ResumePlayback();
+
    void OnPause();
-   
+
 
    // Stop playing or recording
    void Stop(bool stopStream = true);
@@ -136,6 +138,7 @@ public:
    PlayMode GetLastPlayMode() const { return mLastPlayMode; }
 
 private:
+   void DoPlayCurrentRegion(bool newDefault, bool cutpreview, bool resume);
 
    void TogglePaused();
    void SetPausedOff();

--- a/src/TransportUtilities.cpp
+++ b/src/TransportUtilities.cpp
@@ -220,8 +220,10 @@ TransportSequences MakeTransportTracks(
       const auto range = trackList.Any<WaveTrack>()
          + (selectedOnly ? &Track::IsSelected : &Track::Any);
       for (auto pTrack : range)
-         result.playbackSequences.push_back(
-            StretchingSequence::Create(*pTrack, pTrack->GetClipInterfaces()));
+         result.playbackSequences.push_back(StretchingSequence::Create(
+            std::dynamic_pointer_cast<const PlayableSequence>(
+               pTrack->shared_from_this()),
+            pTrack->GetClipInterfaces()));
    }
    if (nonWaveToo) {
       const auto range = trackList.Any<const PlayableTrack>() +

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -556,22 +556,6 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
       return;
    }
 
-   // Honor the "select all if none" preference...a little hackish, but whatcha gonna do...
-   if (!mIsBatch &&
-       mEffectUIHost.GetDefinition().GetType() != EffectTypeGenerate &&
-       mEffectUIHost.GetDefinition().GetType() != EffectTypeTool &&
-       ViewInfo::Get( project ).selectedRegion.isPoint())
-   {
-      auto flags = AlwaysEnabledFlag;
-      bool allowed =
-      CommandManager::Get( project ).ReportIfActionNotAllowed(
-         mEffectUIHost.GetDefinition().GetName(),
-         flags,
-         WaveTracksSelectedFlag() | TimeSelectedFlag());
-      if (!allowed)
-         return;
-   }
-
    if (!TransferDataFromWindow() ||
        // This is the main place where there is a side-effect on the config
        // file to remember the last-used settings of an effect, just before

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -1237,10 +1237,13 @@ auto ExtraEditMenu()
 
 auto canSelectAll = [](const AudacityProject &project){
    return CommandManager::Get( project ).mWhatIfNoSelection != 0; };
-auto selectAll = []( AudacityProject &project, CommandFlag flagsRqd ){
+auto selectAll =
+   [](AudacityProject& project,
+      CommandFlag flagsRqd) -> MenuItemEnabler::PostCommandAction {
    if ( CommandManager::Get( project ).mWhatIfNoSelection == 1 &&
       (flagsRqd & NoAutoSelect()).none() )
       SelectUtilities::DoSelectAllAudio(project);
+   return {};
 };
 
 RegisteredMenuItemEnabler selectTracks{{

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -61,7 +61,7 @@ bool MakeReadyToPlay(AudacityProject &project)
 
    // If it didn't stop playing quickly, or if some other
    // project is playing, return
-   if (gAudioIO->IsBusy())
+   if (gAudioIO->IsPlayheadMoving({}))
       return false;
 
    return true;
@@ -335,7 +335,7 @@ void OnPunchAndRoll(const CommandContext &context)
       // play recording tracks only
       for (auto &pTrack : tracks)
          transportTracks.playbackSequences.push_back(pTrack);
-      
+
    // Unlike with the usual recording, a track may be chosen both for playback
    // and recording.
    std::copy(tracks.begin(), tracks.end(),


### PR DESCRIPTION
Resolves: #2617

Depends on #7148 and other PR items listed in #2617.

This PR let's audio playback continue after the cursor has reached the end or the stop button is pressed. Only exercising commands that require playback to stop will stop the stream (and maybe resume automatically afterwards).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
