### PR TITLE
2617 non blocking playback

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -1750,11 +1750,11 @@ double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
    return supportedRate;
 }
 
-double AudioIO::GetStreamTime()
+double AudioIO::GetStreamTime(bool ignorePlaybackState) const
 {
    // Sequence time readout for the main thread
 
-   if( !IsStreamActive() )
+   if (!ignorePlaybackState && !IsStreamActive())
       return BAD_STREAM_TIME;
 
    return mPlaybackSchedule.GetSequenceTime();

--- a/libraries/lib-audio-io/AudioIO.h
+++ b/libraries/lib-audio-io/AudioIO.h
@@ -565,7 +565,7 @@ public:
     * too. So the returned time should be always between
     * t0 and t1
     */
-   double GetStreamTime();
+   double GetStreamTime(bool ignorePlaybackState = false) const;
 
    static void AudioThread(std::atomic<bool> &finish);
 

--- a/libraries/lib-menus/CommandFlag.h
+++ b/libraries/lib-menus/CommandFlag.h
@@ -104,6 +104,7 @@ public:
 // then the enabler will be invoked (unless the menu item is constructed with
 // the useStrictFlags option, or the applicability test first returns false).
 // The item's full set of required flags is passed to the function.
+// The enabler may return an action to be executed after the command is run.
 
 // Computation of the flags is delayed inside a function -- because often you
 // need to name a statically allocated CommandFlag, or a bitwise OR of some,
@@ -111,7 +112,9 @@ public:
 struct MenuItemEnabler {
    using Flags = std::function< CommandFlag() >;
    using Test = std::function< bool( const AudacityProject& ) >;
-   using Action = std::function< void( AudacityProject&, CommandFlag ) >;
+   using PostCommandAction = std::function<void()>;
+   using Action =
+      std::function<PostCommandAction(AudacityProject&, CommandFlag)>;
 
    const Flags actualFlags;
    const Flags possibleFlags;

--- a/libraries/lib-menus/CommandManager.h
+++ b/libraries/lib-menus/CommandManager.h
@@ -80,14 +80,8 @@ public:
    CommandFlag GetUpdateFlags(bool quick = false) const;
    void UpdatePrefs() override;
 
-   // Command Handling
-   bool ReportIfActionNotAllowed(
-      const TranslatableString & Name, CommandFlag & flags, CommandFlag flagsRqd );
-   bool TryToMakeActionAllowed(
-      CommandFlag & flags, CommandFlag flagsRqd );
-
    CommandFlag mLastFlags = AlwaysEnabledFlag;
-   
+
    // Last effect applied to this project
    PluginID mLastGenerator{};
    PluginID mLastEffect{};
@@ -135,7 +129,7 @@ public:
       void DoVisit(const Registry::SingleItem &item);
       void DoEndGroup(
          const MenuRegistry::GroupItem<MenuRegistry::Traits> &item);
-      
+
       //! Called by DoBeginGroup
       //! Default implementation does nothing
       virtual void BeginMenu(const TranslatableString & tName);
@@ -310,7 +304,12 @@ public:
 private:
 
    static int NextIdentifier(int ID);
-   
+
+   // Command Handling
+   bool ReportIfActionNotAllowed(
+      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd);
+   bool TryToMakeActionAllowed(CommandFlag& flags, CommandFlag flagsRqd);
+
 protected:
    bool HandleCommandEntry(
       const CommandListEntry * entry, CommandFlag flags,

--- a/libraries/lib-menus/CommandManager.h
+++ b/libraries/lib-menus/CommandManager.h
@@ -307,8 +307,11 @@ private:
 
    // Command Handling
    bool ReportIfActionNotAllowed(
-      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd);
-   bool TryToMakeActionAllowed(CommandFlag& flags, CommandFlag flagsRqd);
+      const TranslatableString& Name, CommandFlag& flags, CommandFlag flagsRqd,
+      std::vector<MenuItemEnabler::PostCommandAction>& posts);
+   bool TryToMakeActionAllowed(
+      CommandFlag& flags, CommandFlag flagsRqd,
+      std::vector<MenuItemEnabler::PostCommandAction>& posts);
 
 protected:
    bool HandleCommandEntry(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,8 @@ set( SOURCES
       Diags.cpp
       Diags.h
       DropTarget.cpp
+      EditUtils.cpp
+      EditUtils.h
       EffectAndCommandPluginManager.cpp
       EffectAndCommandPluginManager.h
       DropoutDetector.cpp

--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -312,11 +312,9 @@ RegisteredMenuItemEnabler stopAudioStream {
         const auto wasPlaying = pam.Playing();
         if (wasPlaying)
            pam.Stop(stopStream);
-        return [&, wasPlaying = wasPlaying]
-        {
+        return [&, wasPlaying = wasPlaying] {
            if (wasPlaying && !pam.Playing())
-              ; // ResumePlayback in follow-up commit
-            //   ProjectAudioManager::Get(project).ResumePlayback();
+              ProjectAudioManager::Get(project).ResumePlayback();
         };
      } }
 };

--- a/src/CommonCommandFlags.h
+++ b/src/CommonCommandFlags.h
@@ -29,6 +29,7 @@ const CommandFlagOptions &cutCopyOptions();
 
 extern AUDACITY_DLL_API const ReservedCommandFlag
    &AudioIONotBusyFlag(),
+   &StopAudioIOIfBusyFlag(),
    &StereoRequiredFlag(),  //lda
    &NoiseReductionTimeSelectedFlag(),
    &TimeSelectedFlag(), // This is equivalent to check if there is a valid selection, so it's used for Zoom to Selection too

--- a/src/EditUtils.cpp
+++ b/src/EditUtils.cpp
@@ -1,0 +1,36 @@
+#include "EditUtils.h"
+#include "AudioIO.h"
+#include "ProjectAudioManager.h"
+#include <thread>
+
+void EditUtils::StopAndResumePlayback(AudacityProject& project)
+{
+   auto& pam = ProjectAudioManager::Get(project);
+   if (!pam.Playing())
+      return;
+   constexpr auto stopStream = true;
+   pam.Stop(stopStream);
+   const auto io = AudioIO::Get();
+   while (io->IsBusy())
+      std::this_thread::sleep_for(std::chrono::milliseconds { 10 });
+   pam.ResumePlayback();
+}
+
+[[nodiscard]] Finally<std::function<void()>>
+EditUtils::StopPlaybackWhileEditing(AudacityProject& project)
+{
+   auto pam = &ProjectAudioManager::Get(project);
+   const auto wasPlaying = pam->Playing();
+   if (wasPlaying)
+   {
+      constexpr auto stopStream = true;
+      pam->Stop(stopStream);
+      const auto io = AudioIO::Get();
+      while (io->IsBusy())
+         std::this_thread::sleep_for(std::chrono::milliseconds { 10 });
+   }
+   return Finally<std::function<void()>> { [=] {
+      if (wasPlaying)
+         pam->ResumePlayback();
+   } };
+}

--- a/src/EditUtils.h
+++ b/src/EditUtils.h
@@ -1,0 +1,16 @@
+// TODO header
+#pragma once
+
+#include "MemoryX.h"
+
+class AudacityProject;
+
+namespace EditUtils
+{
+//! Doesn't do anything if playback is already stopped.
+void StopAndResumePlayback(AudacityProject& project);
+
+// Assumes that `project` outlives the returned lambda.
+[[nodiscard]] Finally<std::function<void()>>
+StopPlaybackWhileEditing(AudacityProject& project);
+} // namespace EditUtils

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1310,16 +1310,18 @@ void ProjectAudioManager::DoPlayStopSelect()
    }
 }
 
-static RegisteredMenuItemEnabler stopIfPaused{{
-   []{ return PausedFlag(); },
-   []{ return AudioIONotBusyFlag(); },
-   []( const AudacityProject &project ){
-      return CommandManager::Get( project ).mStopIfWasPaused; },
-   []( AudacityProject &project, CommandFlag ){
-      if ( CommandManager::Get( project ).mStopIfWasPaused )
-         ProjectAudioManager::Get( project ).StopIfPaused();
-   }
-}};
+static RegisteredMenuItemEnabler stopIfPaused {
+   { [] { return PausedFlag(); }, [] { return AudioIONotBusyFlag(); },
+     [](const AudacityProject& project) {
+        return CommandManager::Get(project).mStopIfWasPaused;
+     },
+     [](AudacityProject& project,
+        CommandFlag) -> MenuItemEnabler::PostCommandAction {
+        if (CommandManager::Get(project).mStopIfWasPaused)
+           ProjectAudioManager::Get(project).StopIfPaused();
+        return {};
+     } }
+};
 
 // GetSelectedProperties collects information about
 // currently selected audio tracks

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -762,17 +762,6 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
 {
    auto &projectAudioManager = *this;
 
-   CommandFlag flags = AlwaysEnabledFlag; // 0 means recalc flags.
-
-   // NB: The call may have the side effect of changing flags.
-   bool allowed = CommandManager::Get(project).TryToMakeActionAllowed(
-      flags,
-      AudioIONotBusyFlag() | CanStopAudioStreamFlag());
-
-   if (!allowed)
-      return false;
-   // ...end of code from CommandHandler.
-
    auto gAudioIO = AudioIO::Get();
    if (gAudioIO->IsBusy())
       return false;

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -471,7 +471,12 @@ int ProjectAudioManager::PlayPlayRegion(const SelectedRegion &selectedRegion,
 void ProjectAudioManager::PlayCurrentRegion(bool newDefault /* = false */,
                                        bool cutpreview /* = false */)
 {
-   auto &projectAudioManager = *this;
+   DoPlayCurrentRegion(newDefault, cutpreview, false);
+}
+
+void ProjectAudioManager::DoPlayCurrentRegion(
+   bool newDefault, bool cutpreview, bool resume)
+{   auto &projectAudioManager = *this;
    bool canStop = projectAudioManager.CanStopAudioStream();
 
    if ( !canStop )
@@ -492,10 +497,22 @@ void ProjectAudioManager::PlayCurrentRegion(bool newDefault /* = false */,
          cutpreview ? PlayMode::cutPreviewPlay
          : newDefault ? PlayMode::loopedPlay
          : PlayMode::normalPlay;
+      if (const auto io = AudioIO::Get(); io && resume)
+      {
+         constexpr auto ignorePlaybackState = true;
+         options.pStartTime = io->GetStreamTime(true);
+      }
       PlayPlayRegion(SelectedRegion(playRegion.GetStart(), playRegion.GetEnd()),
                      options,
                      mode);
    }
+}
+
+void ProjectAudioManager::ResumePlayback()
+{
+   // What are these `cutpreview` and `newDefault` flags? Nowhere is
+   // PlayCurrentRegion called with any of them set to `trzue`.
+   DoPlayCurrentRegion(false, false, true);
 }
 
 void ProjectAudioManager::Stop(bool stopStream /* = true*/)

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -122,8 +122,10 @@ public:
       bool newDefault = false, //!< See ProjectAudioIO::GetDefaultOptions
       bool cutpreview = false);
 
+   void ResumePlayback();
+
    void OnPause();
-   
+
 
    // Stop playing or recording
    void Stop(bool stopStream = true);
@@ -136,6 +138,7 @@ public:
    PlayMode GetLastPlayMode() const { return mLastPlayMode; }
 
 private:
+   void DoPlayCurrentRegion(bool newDefault, bool cutpreview, bool resume);
 
    void TogglePaused();
    void SetPausedOff();

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -556,22 +556,6 @@ void EffectUIHost::OnApply(wxCommandEvent & evt)
       return;
    }
 
-   // Honor the "select all if none" preference...a little hackish, but whatcha gonna do...
-   if (!mIsBatch &&
-       mEffectUIHost.GetDefinition().GetType() != EffectTypeGenerate &&
-       mEffectUIHost.GetDefinition().GetType() != EffectTypeTool &&
-       ViewInfo::Get( project ).selectedRegion.isPoint())
-   {
-      auto flags = AlwaysEnabledFlag;
-      bool allowed =
-      CommandManager::Get( project ).ReportIfActionNotAllowed(
-         mEffectUIHost.GetDefinition().GetName(),
-         flags,
-         WaveTracksSelectedFlag() | TimeSelectedFlag());
-      if (!allowed)
-         return;
-   }
-
    if (!TransferDataFromWindow() ||
        // This is the main place where there is a side-effect on the config
        // file to remember the last-used settings of an effect, just before

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -1237,10 +1237,13 @@ auto ExtraEditMenu()
 
 auto canSelectAll = [](const AudacityProject &project){
    return CommandManager::Get( project ).mWhatIfNoSelection != 0; };
-auto selectAll = []( AudacityProject &project, CommandFlag flagsRqd ){
+auto selectAll =
+   [](AudacityProject& project,
+      CommandFlag flagsRqd) -> MenuItemEnabler::PostCommandAction {
    if ( CommandManager::Get( project ).mWhatIfNoSelection == 1 &&
       (flagsRqd & NoAutoSelect()).none() )
       SelectUtilities::DoSelectAllAudio(project);
+   return {};
 };
 
 RegisteredMenuItemEnabler selectTracks{{

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -461,11 +461,11 @@ auto FileMenu()
       Section( "Basic",
          /*i18n-hint: "New" is an action (verb) to create a NEW project*/
          Command( wxT("New"), XXO("&New"), OnNew,
-            AudioIONotBusyFlag(), wxT("Ctrl+N") ),
+            StopAudioIOIfBusyFlag(), wxT("Ctrl+N") ),
 
          /*i18n-hint: (verb)*/
          Command( wxT("Open"), XXO("&Open..."), OnOpen,
-            AudioIONotBusyFlag(), wxT("Ctrl+O") ),
+            StopAudioIOIfBusyFlag(), wxT("Ctrl+O") ),
 
    #ifdef EXPERIMENTAL_RESET
          // Empty the current project and forget its name and path.  DANGEROUS
@@ -473,7 +473,7 @@ auto FileMenu()
          // Do not translate this menu item (no XXO).
          // It MUST not be shown to regular users.
          Command( wxT("Reset"), XXO("&Dangerous Reset..."), OnProjectReset,
-            AudioIONotBusyFlag() ),
+            StopAudioIOIfBusyFlag() ),
    #endif
 
    /////////////////////////////////////////////////////////////////////////////

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -269,7 +269,7 @@ auto GenerateMenu()
    Menu( wxT("Generate"), XXO("&Generate"),
       Section( "Manage",
          Command( wxT("ManageGenerators"), XXO("Plugin Manager"),
-            OnManageGenerators, AudioIONotBusyFlag() )
+            OnManageGenerators, StopAudioIOIfBusyFlag() )
       ),
 
       Section("RepeatLast",
@@ -347,7 +347,7 @@ auto EffectMenu()
       Section(
          "Manage", Command(
                       wxT("ManageEffects"), XXO("Plugin Manager"),
-                      OnManageEffects, AudioIONotBusyFlag())),
+                      OnManageEffects, StopAudioIOIfBusyFlag())),
 
       Section(
          "RealtimeEffects",
@@ -429,7 +429,7 @@ auto AnalyzeMenu()
    Menu( wxT("Analyze"), XXO("&Analyze"),
       Section( "Manage",
          Command( wxT("ManageAnalyzers"), XXO("Plugin Manager"),
-            OnManageAnalyzers, AudioIONotBusyFlag() )
+            OnManageAnalyzers, StopAudioIOIfBusyFlag() )
       ),
 
       Section("RepeatLast",
@@ -481,7 +481,7 @@ auto ToolsMenu()
    Menu( wxT("Tools"), XXO("T&ools"),
       Section( "Manage",
          Command( wxT("ManageTools"), XXO("Plugin Manager"),
-            OnManageTools, AudioIONotBusyFlag() )
+            OnManageTools, StopAudioIOIfBusyFlag() )
 
          //Separator(),
       ),

--- a/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/ClipPitchAndSpeedButtonHandle.cpp
@@ -11,6 +11,7 @@
 #include "ClipPitchAndSpeedButtonHandle.h"
 #include "AllThemeResources.h"
 #include "BasicUI.h"
+#include "EditUtils.h"
 #include "HitTestResult.h"
 #include "LowlitClipButton.h"
 #include "PitchAndSpeedDialog.h"
@@ -18,8 +19,8 @@
 #include "ProjectHistory.h"
 #include "RefreshCode.h"
 #include "Theme.h"
-#include "TimeStretching.h"
 #include "TimeAndPitchInterface.h"
+#include "TimeStretching.h"
 #include "TrackPanelMouseEvent.h"
 #include "WaveClip.h"
 #include "WaveClipUIUtilities.h"
@@ -138,6 +139,7 @@ UIHandle::Result ClipPitchAndSpeedButtonHandle::DoRelease(
       else
       {
          WaveClipUIUtilities::SelectClip(*pProject, *mClip);
+         EditUtils::StopAndResumePlayback(*pProject);
          ProjectHistory::Get(*pProject).PushState(
             XO("Reset Clip Speed"), XO("Reset Clip Speed"));
       }

--- a/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.h
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveClipAdjustBorderHandle.h
@@ -8,7 +8,7 @@
 
  **********************************************************************/
 
-#pragma once 
+#pragma once
 
 #include "UIHandle.h"
 #include "WaveClip.h"
@@ -24,14 +24,14 @@ private:
 
     static constexpr int BoundaryThreshold = 5;
 
-    static HitTestPreview HitPreviewTrim(const AudacityProject*, bool unsafe, bool isLeftBorder);
-    static HitTestPreview HitPreviewStretch(const AudacityProject*, bool unsafe, bool isLeftBorder);
+    static HitTestPreview HitPreviewTrim(bool isLeftBorder);
+    static HitTestPreview HitPreviewStretch(bool isLeftBorder);
 
     std::unique_ptr<AdjustPolicy> mAdjustPolicy{};
     std::shared_ptr<const WaveTrack> mpTrack;
     bool mIsStretchMode;
     bool mIsLeftBorder;
-    
+
 public:
     WaveClipAdjustBorderHandle(std::unique_ptr<AdjustPolicy>& adjustPolicy,
         std::shared_ptr<const WaveTrack> pTrack,

--- a/src/tracks/ui/AffordanceHandle.cpp
+++ b/src/tracks/ui/AffordanceHandle.cpp
@@ -22,9 +22,8 @@
 #include <wx/cursor.h>
 #include <wx/event.h>
 
-HitTestPreview AffordanceHandle::HitPreview(const AudacityProject*, bool unsafe, bool moving)
+HitTestPreview AffordanceHandle::HitPreview(const AudacityProject*, bool moving)
 {
-    static wxCursor arrowCursor{ wxCURSOR_ARROW };
     static auto handOpenCursor =
         MakeCursor(wxCURSOR_HAND, RearrangeCursorXpm, 16, 16);
     static auto handClosedCursor =
@@ -33,8 +32,6 @@ HitTestPreview AffordanceHandle::HitPreview(const AudacityProject*, bool unsafe,
     auto message = XO("Drag clips to reposition them."\
         " Hold Shift and drag to move all clips on the same track.");
 
-    if (unsafe)
-        return { message, &arrowCursor };
     return {
         message,
         (moving
@@ -51,8 +48,7 @@ void AffordanceHandle::Enter(bool forward, AudacityProject* pProject)
 
 HitTestPreview AffordanceHandle::Preview(const TrackPanelMouseState& mouseState, AudacityProject* pProject)
 {
-    const bool unsafe = ProjectAudioIO::Get(*pProject).IsAudioActive();
-    return HitPreview(pProject, unsafe, Clicked());
+    return HitPreview(pProject, Clicked());
 }
 
 AffordanceHandle::AffordanceHandle(const std::shared_ptr<Track>& track)

--- a/src/tracks/ui/AffordanceHandle.h
+++ b/src/tracks/ui/AffordanceHandle.h
@@ -16,7 +16,7 @@ class AUDACITY_DLL_API AffordanceHandle : public TimeShiftHandle
 {
     constexpr static double MoveThreshold { 5.0 };
 
-    static HitTestPreview HitPreview(const AudacityProject*, bool unsafe, bool moving);
+    static HitTestPreview HitPreview(const AudacityProject*, bool moving);
 
     bool mMoving { false };
     wxPoint mClickPosition { };

--- a/src/tracks/ui/TimeShiftHandle.h
+++ b/src/tracks/ui/TimeShiftHandle.h
@@ -73,7 +73,7 @@ public:
 
    //! Return special intervals of the track that may move
    const Intervals &MovingIntervals() const { return mMoving; }
-   
+
    //! Change intervals satisfying a predicate from fixed to moving
    void UnfixIntervals(std::function<bool(const ChannelGroupInterval&)> pred);
 
@@ -88,7 +88,7 @@ public:
       TimeInterval(double start, double end)
          : mStart{ start }, mEnd{ std::max(start, end) }
       {}
-      
+
       double Start() const { return mStart; }
       double End() const { return mEnd; }
    private:
@@ -165,9 +165,9 @@ public:
 
    //! When dragging is done, do (once) the final steps of migration (which may be expensive)
    /*! @return success
-   
+
        In case of failure, track states are unspecified
-    
+
        Default implementation does nothing and returns true */
    virtual bool FinishMigration();
 
@@ -243,7 +243,7 @@ struct AUDACITY_DLL_API ClipMoveState {
    ClipMoveState& operator =(ClipMoveState&&) = default;
 
    using ShifterMap = std::unordered_map<Track*, std::unique_ptr<TrackShifter>>;
-   
+
    //! Will associate a TrackShifter with each track in the list
    void Init(
       AudacityProject &project,
@@ -292,8 +292,7 @@ struct AUDACITY_DLL_API ClipMoveState {
 class AUDACITY_DLL_API TimeShiftHandle : public UIHandle
 {
    TimeShiftHandle(const TimeShiftHandle&) = delete;
-   static HitTestPreview HitPreview
-      (const AudacityProject *pProject, bool unsafe);
+   static HitTestPreview HitPreview(const AudacityProject* pProject);
 
 public:
    TimeShiftHandle(std::shared_ptr<Track> pTrack, bool gripHit);


### PR DESCRIPTION
Resolves: #2617

This is the fun part: this PR will make available ideally all user interactions that were so far unavailable during playback. These actions will either just stop playback, or stop and resume once the interaction is complete.
Whether or not playback should resume automatically is for may interactions yet to be decided.

Most of these interactions are menu interactions. Yet some of them are UI interactions, such as stretching, trimming, dragging, etc. All menu interactions are affected. This PR may try to cover all UI interactions too.

### Interactions to consider
@LWinterberg @chinakov @saintmatthieu  below we intend to list all commands (or groups of commands) that are currently blocked by audio playback. Please help complete it and, for each list, use either
* 🟢 to remove the blocking constraint altogether (e.g., "plot spectrum" might not need playback to be stopped at all)
* 🟡 to automatically pause playback while the command is executed and resume afterwards
* 🔴 to automatically stop playback

The coloring should be guided by UX rather than technical feasibility. If feasibility isn't achievable (e.g. "Plot Spectrum" actually requires audio playback to be paused) the color will be downgraded.

(Tip: look in the repo for occurrences of `AudioIONotBusyFlag()` to get probably most of the concerned commands.)

#### Modals
For some modals, it's obvious that playback should stop (like "Open..."), but for others, less. Let's list here modals for which we may want playback to resume automatically once closed.
* Effects 🟡 

#### Misc
* External links (e.g. "Quick Help...", "Get more effects...") 🟢 (Already like this)
* Add track (audio, note, label or time) 🟢 (If safe)
* "Change Playback Device" 🟡 (?)
* "Plot Spectrum" 🟢  

To be continued ...

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
