### PR TITLE
[AU4] Allow stereo track redistribution

### DIFF
--- a/au4/CMakeLists.txt
+++ b/au4/CMakeLists.txt
@@ -24,7 +24,7 @@ include(FetchContent)
 FetchContent_Declare(
   muse_framework
   GIT_REPOSITORY https://github.com/musescore/framework_tmp.git
-  GIT_TAG        u0829
+  GIT_TAG        u0829_2
 )
 
 FetchContent_GetProperties(muse_framework)

--- a/au4/src/au3wrap/internal/domconverter.cpp
+++ b/au4/src/au3wrap/internal/domconverter.cpp
@@ -55,6 +55,7 @@ au::trackedit::Clip DomConverter::clip(const WaveTrack* waveTrack, const WaveCli
     clip.startTime = au3clip->GetPlayStartTime();
     clip.endTime = au3clip->GetPlayEndTime();
     clip.color = trackColor(clip.key.trackId);
+    clip.stereo = au3clip->NChannels() > 1;
 
     return clip;
 }

--- a/au4/src/projectscene/projectscene.qrc
+++ b/au4/src/projectscene/projectscene.qrc
@@ -27,5 +27,6 @@
         <file>qml/Audacity/ProjectScene/toolbars/internal/PlaybackToolBarCustomisePopup.qml</file>
         <file>qml/Audacity/ProjectScene/clipsview/ClipItemSmall.qml</file>
         <file>qml/Audacity/ProjectScene/clipsview/ClipHandles.qml</file>
+        <file>qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml</file>
     </qresource>
 </RCC>

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
@@ -1,0 +1,62 @@
+import QtQuick
+
+Item {
+    id: root
+
+    property double channelHeightRatio: 0.5
+    property alias color : splitter.color
+    property alias thickness: splitter.height
+
+    opacity: 0.05
+
+    signal ratioChanged(double v)
+
+    QtObject {
+        id: prv
+
+        readonly property double minChannelHeight: 20
+        readonly property double minRatio: minChannelHeight / root.height
+        readonly property double maxRatio: (root.height - minChannelHeight) / root.height
+    }
+
+    Rectangle {
+        id: splitter
+
+        height: 1
+        width: root.width
+    }
+
+    MouseArea {
+        anchors.fill: splitter
+        anchors.margins: -2
+
+        drag.target: splitter
+        drag.axis: Drag.YAxis
+        drag.threshold: 0
+
+        cursorShape: Qt.SplitVCursor
+
+        onPositionChanged: {
+            let ratio = splitter.y / root.height
+            clampRatio(ratio)
+        }
+    }
+
+    Component.onCompleted: {
+        root.heightChanged.connect(function() {
+            clampRatio(root.channelHeightRatio)
+        });
+    }
+
+    function clampRatio(ratio) {
+        let newRatio = Math.max(prv.minRatio, Math.min(prv.maxRatio, ratio));
+        root.ratioChanged(newRatio)
+        splitter.y = Math.round(newRatio * root.height - 1)
+    }
+
+    Binding {
+        target: splitter
+        property: "y"
+        value: Math.round(root.channelHeightRatio * root.height - 1)
+    }
+}

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -14,6 +14,8 @@ Rectangle {
     property alias clipKey: waveView.clipKey
     property alias clipTime: waveView.clipTime
     property alias title: titleLabel.text
+    property alias showChannelSplitter: channelSplitter.visible
+    property alias channelHeightRatio: channelSplitter.channelHeightRatio
     property var canvas: null
     property color clipColor: "#677CE4"
     property bool clipSelected: false
@@ -27,6 +29,7 @@ Rectangle {
     signal clipLeftTrimmed(real deltaX, real posOnCanvas)
     signal clipRightTrimmed(real deltaX, real posOnCanvas)
     signal requestSelected()
+    signal ratioChanged(double val)
 
     signal titleEditStarted()
     signal titleEditAccepted(var newTitle)
@@ -233,8 +236,23 @@ Rectangle {
             anchors.right: parent.right
             anchors.bottom: parent.bottom
 
+            channelHeightRatio: showChannelSplitter ? root.channelHeightRatio : 1
+
             clipColor: root.clipColor
             clipSelected: root.clipSelected
+
+            ChannelSplitter {
+                id: channelSplitter
+
+                anchors.fill: parent
+
+                color: "#000000"
+                opacity: 0.10
+
+                onRatioChanged: function (ratio) {
+                    root.ratioChanged(ratio)
+                }
+            }
         }
 
         Rectangle {

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -232,6 +232,6 @@ Item {
         color: "#FFFFFF"
         opacity: 0.1
         anchors.bottom: parent.bottom
-        separatorWidth: 2
+        thickness: 2
     }
 }

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -13,6 +13,8 @@ Item {
     property var canvas: null
 
     property bool isDataSelected: false
+    property bool isStereo: clipsModel.isStereo
+    property double channelHeightRatio: isStereo ? 0.5 : 1
 
     signal interactionStarted()
     signal interactionEnded()
@@ -116,6 +118,8 @@ Item {
                 leftVisibleMargin: clipItem.leftVisibleMargin
                 rightVisibleMargin: clipItem.rightVisibleMargin
                 collapsed: trackViewState.isTrackCollapsed
+                channelHeightRatio: root.channelHeightRatio
+                showChannelSplitter: isStereo
 
                 onClipMoved: function(deltaX, completed) {
                     clipsModel.moveClip(clipItem.key, deltaX, completed)
@@ -150,6 +154,10 @@ Item {
 
                 onTitleEditCanceled: {
                     clipsModel.resetSelectedClip()
+                }
+
+                onRatioChanged: function (ratio) {
+                    root.channelHeightRatio = ratio
                 }
             }
         }
@@ -199,6 +207,23 @@ Item {
 
         onReleased: {
             root.interactionEnded()
+        }
+    }
+
+    ChannelSplitter {
+        id: channelSplitter
+
+        anchors.fill: parent
+        anchors.topMargin: trackViewState.isTrackCollapsed ? 1 : 21
+        anchors.bottomMargin: 3
+
+        channelHeightRatio: root.channelHeightRatio
+        color: "#FFFFFF"
+        opacity: 0.05
+        visible: isStereo
+
+        onRatioChanged: function(ratio) {
+            root.channelHeightRatio = ratio
         }
     }
 

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -246,6 +246,6 @@ ListItemBlank {
 
     SeparatorLine {
         anchors.bottom: parent.bottom
-        separatorWidth: 2
+        thickness: 2
     }
 }

--- a/au4/src/projectscene/view/clipsview/au3/au3wavepainter.cpp
+++ b/au4/src/projectscene/view/clipsview/au3/au3wavepainter.cpp
@@ -649,14 +649,17 @@ void Au3WavePainter::doPaint(QPainter& painter, const WaveTrack* _track, const W
 
     const Geometry& g = params.geometry;
 
-    const double channelHeight = (g.height) / static_cast<int>(clip->NChannels());
+    const std::vector<double> channelHeight {
+        g.height * params.channelHeightRatio,
+        g.height * (1 - params.channelHeightRatio),
+    };
 
-    wm.height = channelHeight;
     wm.width = g.width;
     wm.left = g.left;
     wm.top = 0.0;
     for (unsigned i = 0; i < clip->NChannels(); ++i) {
+        wm.height = channelHeight[i];
         DrawWaveform(i, painter, *track, *clip, wm, params.zoom, params.style, dB);
-        wm.top += channelHeight;
+        wm.top += wm.height;
     }
 }

--- a/au4/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/au4/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -154,7 +154,7 @@ void ClipsListModel::update()
     //! NOTE First we form a new list, and then we delete old objects,
     //! otherwise there will be errors in Qml
     QList<ClipListItem*> oldList = m_clipList;
-
+    bool isStereo = false;
     beginResetModel();
 
     m_clipList.clear();
@@ -163,6 +163,7 @@ void ClipsListModel::update()
         ClipListItem* item = new ClipListItem(this);
         item->setClip(c);
         m_clipList.append(item);
+        isStereo |= c.stereo;
     }
 
     updateItemsMetrics();
@@ -173,6 +174,11 @@ void ClipsListModel::update()
     onSelectedClip(selectionController()->selectedClip());
 
     endResetModel();
+
+    if (m_isStereo != isStereo) {
+        m_isStereo = isStereo;
+        emit isStereoChanged();
+    }
 
     muse::async::Async::call(this, [oldList]() {
         qDeleteAll(oldList);
@@ -372,6 +378,11 @@ void ClipsListModel::setTrackId(const QVariant& _newTrackId)
     }
     m_trackId = newTrackId;
     emit trackIdChanged();
+}
+
+bool ClipsListModel::isStereo() const
+{
+    return m_isStereo;
 }
 
 TimelineContext* ClipsListModel::timelineContext() const

--- a/au4/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/au4/src/projectscene/view/clipsview/clipslistmodel.h
@@ -26,6 +26,7 @@ class ClipsListModel : public QAbstractListModel, public muse::async::Asyncable,
 
     Q_PROPERTY(TimelineContext * context READ timelineContext WRITE setTimelineContext NOTIFY timelineContextChanged FINAL)
     Q_PROPERTY(QVariant trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged FINAL)
+    Q_PROPERTY(bool isStereo READ isStereo NOTIFY isStereoChanged FINAL)
 
     Q_PROPERTY(int cacheBufferPx READ cacheBufferPx CONSTANT)
 
@@ -43,6 +44,7 @@ public:
     void setTrackId(const QVariant& newTrackId);
     int selectedClipIdx() const;
     void setSelectedClipIdx(int newSelectedClipIdx);
+    bool isStereo() const;
 
     Q_INVOKABLE void init();
     Q_INVOKABLE void reload();
@@ -64,6 +66,7 @@ signals:
     void trackIdChanged();
     void timelineContextChanged();
     void selectedClipIdxChanged();
+    void isStereoChanged();
 
     void requestClipTitleEdit(int index);
 
@@ -94,5 +97,6 @@ private:
     muse::async::NotifyList<au::trackedit::Clip> m_allClipList;
     QList<ClipListItem*> m_clipList;
     ClipListItem* m_selectedItem = nullptr;
+    bool m_isStereo = false;
 };
 }

--- a/au4/src/projectscene/view/clipsview/iwavepainter.h
+++ b/au4/src/projectscene/view/clipsview/iwavepainter.h
@@ -33,6 +33,7 @@ public:
         double zoom = 0.0;
         double fromTime = 0.0;
         double toTime = 0.0;
+        double channelHeightRatio = 0.5;
         Style style;
     };
 

--- a/au4/src/projectscene/view/clipsview/waveview.cpp
+++ b/au4/src/projectscene/view/clipsview/waveview.cpp
@@ -48,6 +48,7 @@ void WaveView::paint(QPainter* painter)
     params.zoom = m_context->zoom();
     params.fromTime = (m_clipTime.itemStartTime - m_clipTime.clipStartTime);
     params.toTime = params.fromTime + (m_clipTime.itemEndTime - m_clipTime.itemStartTime);
+    params.channelHeightRatio = m_channelHeightRatio;
 
     // LOGDA() << " geometry.height: " << params.geometry.height
     //         << " geometry.width: " << params.geometry.width
@@ -150,5 +151,17 @@ void WaveView::setClipTime(const ClipTime& newClipTime)
     m_clipTime = newClipTime;
     emit clipTimeChanged();
 
+    update();
+}
+
+double WaveView::channelHeightRatio() const
+{
+    return m_channelHeightRatio;
+}
+
+void WaveView::setChannelHeightRatio(double channelHeightRatio)
+{
+    m_channelHeightRatio = channelHeightRatio;
+    emit channelHeightRatioChanged();
     update();
 }

--- a/au4/src/projectscene/view/clipsview/waveview.h
+++ b/au4/src/projectscene/view/clipsview/waveview.h
@@ -20,6 +20,7 @@ class WaveView : public QQuickPaintedItem
     Q_PROPERTY(ClipKey clipKey READ clipKey WRITE setClipKey NOTIFY clipKeyChanged FINAL)
     Q_PROPERTY(QColor clipColor READ clipColor WRITE setClipColor NOTIFY clipColorChanged FINAL)
     Q_PROPERTY(bool clipSelected READ clipSelected WRITE setClipSelected NOTIFY clipSelectedChanged FINAL)
+    Q_PROPERTY(double channelHeightRatio READ channelHeightRatio WRITE setChannelHeightRatio NOTIFY channelHeightRatioChanged FINAL)
 
     Q_PROPERTY(ClipTime clipTime READ clipTime WRITE setClipTime NOTIFY clipTimeChanged FINAL)
 
@@ -39,6 +40,8 @@ public:
     void setClipSelected(bool newClipSelected);
     ClipTime clipTime() const;
     void setClipTime(const ClipTime& newClipTime);
+    double channelHeightRatio() const;
+    void setChannelHeightRatio(double channelHeightRatio);
 
     void paint(QPainter* painter) override;
 
@@ -48,6 +51,7 @@ signals:
     void clipColorChanged();
     void clipTimeChanged();
     void clipSelectedChanged();
+    void channelHeightRatioChanged();
 
 private:
 
@@ -57,6 +61,7 @@ private:
     ClipKey m_clipKey;
     QColor m_clipColor;
     double m_clipLeft = 0;
+    double m_channelHeightRatio = 0.5;
     bool m_clipSelected = false;
     ClipTime m_clipTime;
 };

--- a/au4/src/trackedit/dom/clip.h
+++ b/au4/src/trackedit/dom/clip.h
@@ -16,6 +16,7 @@ struct Clip {
     muse::draw::Color color;
     double startTime = 0.0;
     double endTime = 0.0;
+    bool stereo = false;
 
     inline bool isValid() const { return key.isValid(); }
 };


### PR DESCRIPTION
Resolves: #6821

Known issues:
- During the resize, the mouse cursor can outrun the mouse area, resulting in the cursor changing its shape to a regular arrow
- Resize can't be initiated outside of the clip

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
