### PR TITLE
Fix CI automated tests

### DIFF
--- a/libraries/lib-audio-devices/AudioIOBase.cpp
+++ b/libraries/lib-audio-devices/AudioIOBase.cpp
@@ -802,7 +802,7 @@ int AudioIOBase::getRecordDevIndex(const wxString &devNameArg)
       // JKC: This will happen if you run with no config file
       // This happens once.  Config file will exist on the next run.
       // TODO: Look into this a bit more.  Could be relevant to blank Device Toolbar.
-      wxLogWarning("PortAudio returns -1, cannot find a suitable default device, so we just use the first one available");
+      wxLogDebug("PortAudio returns -1, cannot find a suitable default device, so we just use the first one available");
       deviceNum = 0;
    }
 


### PR DESCRIPTION
In continuation of #7215. Replace Warning with Debug, as Warning produces a modal dialog on windows, which not useful for the user, and may interfere with CI tests

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
