### PR TITLE
Bump upload/download artifact build action versions

### DIFF
--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
           cmake --build .build.x64 --target package_source
     - name: Upload sources
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: audacity-sources
         path: |
@@ -157,7 +157,7 @@ jobs:
         OWNER=${{ github.repository_owner }}
         docker run --volume=$(pwd):/work_dir:rw --rm --network=none ghcr.io/${OWNER,,}/audacity-${{ matrix.config.name }}-build:${{ github.ref_name }}
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.config.name }}-package-${{ github.sha }}
         path: |


### PR DESCRIPTION
Resolves: -

Bump upload/download artifact build action versions for actions missed in the previous PR

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
