### PR TITLE
Fix project not being compacted on close

### DIFF
--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -530,6 +530,9 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    // TODO: Is there a Mac issue here??
    // SetMenuBar(NULL);
 
+   // Compact the project.
+   projectFileManager.CompactProjectOnClose();
+
    // This can reduce reference counts of sample blocks in the project's
    // tracks. No need to have `SetBypass()` called yet because the `tracks`
    // object still holds strong references to the tracks.
@@ -537,9 +540,6 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    // not track-specific (like project tempo) after the last save don't get
    // written to the project file.
    UndoManager::Get(project).ClearStates();
-
-   // Compact the project.
-   projectFileManager.CompactProjectOnClose();
 
    // Set (or not) the bypass flag to indicate that deletes that would happen
    // during tracks.Clear() below are not necessary. Must be called after


### PR DESCRIPTION
Resolves: #7312 

After the call to UndoManager::ClearStates, the project is considered not to contain any unused data and is not compacted.

An additional issue to provide a more robust approach was created: #7313

To QA: please also confirm that there is no regression on #6745 / #6453, which introduced this issue.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
