### PR TITLE
[AU4] Moving clips. New approach

### DIFF
--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -25,7 +25,10 @@ Rectangle {
 
     property bool collapsed: false
 
-    signal clipMoved(real deltaX, bool completed)
+    signal clipStartMoveRequested()
+    signal clipMoveRequested(bool completed)
+    signal clipEndMoveRequested()
+
     signal clipLeftTrimmed(real deltaX, real posOnCanvas)
     signal clipRightTrimmed(real deltaX, real posOnCanvas)
     signal requestSelected()
@@ -120,29 +123,27 @@ Rectangle {
                 cursorShape: Qt.OpenHandCursor
 
                 property bool moveActive: false
-                property real moveLastX: 0.0
 
                 onPositionChanged: function(e) {
                     root.clipItemMousePositionChanged(e.x, e.y)
 
                     if (headerDragArea.moveActive) {
-                        var gx = mapToGlobal(e.x, e.y).x
-                        root.clipMoved(gx - headerDragArea.moveLastX, false)
-                        headerDragArea.moveLastX = gx
+                        root.clipMoveRequested(false)
                     }
                 }
 
                 onPressed: function(e) {
                     root.requestSelected()
 
-                    headerDragArea.moveLastX = mapToGlobal(e.x, e.y).x
+                    root.clipStartMoveRequested()
                     headerDragArea.moveActive = true
                 }
 
                 onReleased: function(e) {
-                    var gx = mapToGlobal(e.x, e.y).x
-                    root.clipMoved(gx - headerDragArea.moveLastX, true)
+                    root.clipMoveRequested(true)
                     headerDragArea.moveActive = false
+
+                    root.clipEndMoveRequested()
                 }
 
                 onDoubleClicked: root.editTitle()

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -121,8 +121,16 @@ Item {
                 channelHeightRatio: root.channelHeightRatio
                 showChannelSplitter: isStereo
 
-                onClipMoved: function(deltaX, completed) {
-                    clipsModel.moveClip(clipItem.key, deltaX, completed)
+                onClipStartMoveRequested: function() {
+                    clipsModel.startMoveClip(clipItem.key)
+                }
+
+                onClipMoveRequested: function(completed) {
+                    clipsModel.moveClip(clipItem.key, completed)
+                }
+
+                onClipEndMoveRequested: function() {
+                    clipsModel.endMoveClip(clipItem.key)
                 }
 
                 onClipLeftTrimmed: function(deltaX, posOnCanvas) {

--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -113,13 +113,19 @@ Rectangle {
 
         height: 77
 
+        function updateCursorPosition(x) {
+            lineCursor.x = x
+            timeline.context.updateMousePositionTime(x)
+        }
+
         MouseArea {
             id: timelineMouseArea
             anchors.fill: parent
             hoverEnabled: true
 
             onPositionChanged: function(e) {
-                lineCursor.x = e.x
+                timeline.updateCursorPosition(e.x)
+
                 if (pressed) {
                     playCursorController.seekToX(e.x)
                 }
@@ -190,7 +196,9 @@ Rectangle {
             onPositionChanged: function(e) {
                 mouseOnTracks = e.y < tracksClipsView.visibleContentHeight
                 selectionController.onPositionChanged(e.x, e.y)
-                lineCursor.x = e.x
+
+                timeline.updateCursorPosition(e.x)
+
                 if (root.clipHovered) {
                     root.clipHovered = false
                 }
@@ -282,7 +290,8 @@ Rectangle {
                     isDataSelected: model.isDataSelected
 
                     onTrackItemMousePositionChanged: function(xWithinTrack, yWithinTrack) {
-                        lineCursor.x = xWithinTrack
+                        timeline.updateCursorPosition(xWithinTrack)
+
                         if (!root.clipHovered) {
                             root.clipHovered = true
                         }
@@ -327,7 +336,7 @@ Rectangle {
             }
 
             onPlayCursorMousePositionChanged: function(ix) {
-                lineCursor.x = ix
+                timeline.updateCursorPosition(ix)
             }
         }
 

--- a/au4/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/au4/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -303,6 +303,8 @@ bool ClipsListModel::moveClip(const ClipKey& key, bool completed)
 
     double newStartTime = m_context->mousePositionTime() - m_moveStartTimeOffset;
 
+    newStartTime = m_context->applySnapToTime(newStartTime);
+
     bool ok = trackeditInteraction()->changeClipStartTime(key.key, newStartTime, completed);
     return ok;
 }

--- a/au4/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/au4/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -284,17 +284,34 @@ bool ClipsListModel::changeClipTitle(const ClipKey& key, const QString& newTitle
     return ok;
 }
 
-bool ClipsListModel::moveClip(const ClipKey& key, double deltaX, bool completed)
+void ClipsListModel::startMoveClip(const ClipKey& key)
+{
+    ClipListItem* item = itemByKey(key.key);
+    IF_ASSERT_FAILED(item) {
+        return;
+    }
+
+    m_moveStartTimeOffset = m_context->mousePositionTime() - item->clip().startTime;
+}
+
+bool ClipsListModel::moveClip(const ClipKey& key, bool completed)
 {
     ClipListItem* item = itemByKey(key.key);
     IF_ASSERT_FAILED(item) {
         return false;
     }
 
-    double deltaSec = deltaX / m_context->zoom();
+    double newStartTime = m_context->mousePositionTime() - m_moveStartTimeOffset;
 
-    bool ok = trackeditInteraction()->changeClipStartTime(key.key, item->clip().startTime + deltaSec, completed);
+    bool ok = trackeditInteraction()->changeClipStartTime(key.key, newStartTime, completed);
     return ok;
+}
+
+void ClipsListModel::endMoveClip(const ClipKey& key)
+{
+    UNUSED(key);
+
+    m_moveStartTimeOffset = -1.0;
 }
 
 bool ClipsListModel::trimLeftClip(const ClipKey& key, double deltaX, double posOnCanvas)

--- a/au4/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/au4/src/projectscene/view/clipsview/clipslistmodel.h
@@ -48,7 +48,11 @@ public:
 
     Q_INVOKABLE void init();
     Q_INVOKABLE void reload();
-    Q_INVOKABLE bool moveClip(const ClipKey& key, double deltaX, bool completed);
+
+    Q_INVOKABLE void startMoveClip(const ClipKey& key);
+    Q_INVOKABLE bool moveClip(const ClipKey& key, bool completed);
+    Q_INVOKABLE void endMoveClip(const ClipKey& key);
+
     Q_INVOKABLE bool trimLeftClip(const ClipKey& key, double deltaX, double posOnCanvas);
     Q_INVOKABLE bool trimRightClip(const ClipKey& key, double deltaX, double posOnCanvas);
     Q_INVOKABLE void selectClip(const ClipKey& key);
@@ -98,5 +102,8 @@ private:
     QList<ClipListItem*> m_clipList;
     ClipListItem* m_selectedItem = nullptr;
     bool m_isStereo = false;
+
+    //! Offset between mouse click position on clip's header and clip's start time
+    double m_moveStartTimeOffset = -1.0;
 };
 }

--- a/au4/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/au4/src/projectscene/view/timeline/timelinecontext.cpp
@@ -417,6 +417,16 @@ double TimelineContext::singleStepToTime(double position, Direction direction, c
     return result;
 }
 
+void TimelineContext::updateMousePositionTime(double mouseX)
+{
+    m_mousePositionTime = positionToTime(mouseX);
+}
+
+double TimelineContext::mousePositionTime() const
+{
+    return m_mousePositionTime;
+}
+
 double TimelineContext::zoom() const
 {
     return m_zoom;

--- a/au4/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/au4/src/projectscene/view/timeline/timelinecontext.cpp
@@ -384,16 +384,7 @@ double TimelineContext::positionToTime(double position, bool withSnap) const
     double result = m_frameStartTime + position / m_zoom;
 
     if (withSnap) {
-        auto viewState = this->viewState();
-        if (viewState && viewState->isSnapEnabled()) {
-            auto project = globalContext()->currentTrackeditProject();
-            if (!project) {
-                return 0.0;
-            }
-
-            trackedit::TimeSignature timeSig = project->timeSignature();
-            result = m_snapTimeFormatter->snapTime(result, viewState->snap().val, timeSig);
-        }
+        result = applySnapToTime(result);
     }
 
     return result;
@@ -415,6 +406,22 @@ double TimelineContext::singleStepToTime(double position, Direction direction, c
     }
 
     return result;
+}
+
+double TimelineContext::applySnapToTime(double time) const
+{
+    auto viewState = this->viewState();
+    if (!viewState || !viewState->isSnapEnabled()) {
+        return time;
+    }
+
+    auto project = globalContext()->currentTrackeditProject();
+    if (!project) {
+        return time;
+    }
+
+    trackedit::TimeSignature timeSig = project->timeSignature();
+    return m_snapTimeFormatter->snapTime(time, viewState->snap().val, timeSig);
 }
 
 void TimelineContext::updateMousePositionTime(double mouseX)

--- a/au4/src/projectscene/view/timeline/timelinecontext.h
+++ b/au4/src/projectscene/view/timeline/timelinecontext.h
@@ -86,6 +86,7 @@ public:
     Q_INVOKABLE double timeToPosition(double time) const;
     Q_INVOKABLE double positionToTime(double position, bool withSnap = false) const;
     double singleStepToTime(double position, Direction direction, const Snap& snap) const;
+    double applySnapToTime(double time) const;
 
     Q_INVOKABLE void updateMousePositionTime(double mouseX);
     double mousePositionTime() const;

--- a/au4/src/projectscene/view/timeline/timelinecontext.h
+++ b/au4/src/projectscene/view/timeline/timelinecontext.h
@@ -87,6 +87,9 @@ public:
     Q_INVOKABLE double positionToTime(double position, bool withSnap = false) const;
     double singleStepToTime(double position, Direction direction, const Snap& snap) const;
 
+    Q_INVOKABLE void updateMousePositionTime(double mouseX);
+    double mousePositionTime() const;
+
     void moveToFrameTime(double startTime);
     void shiftFrameTime(double secs);
 
@@ -177,5 +180,7 @@ private:
     qreal m_previousHorizontalScrollPosition = 0.0;
 
     qreal m_startVerticalScrollPosition = 0.0;
+
+    double m_mousePositionTime = 0.0;
 };
 }


### PR DESCRIPTION
The approach of determining the mouse position when performing various operations on clips is complicated because you have to calculate the current mouse position(using global position) each time, determine the position delta, convert it to time and apply it to the clip.
I suggest storing the current time of the mouse position in the context of the timeline and using it as a reference.

An example using snapping shows how easy it can be to apply.