### PR TITLE
Fix Multi-View close button alignment

### DIFF
--- a/src/tracks/ui/CommonTrackInfo.cpp
+++ b/src/tracks/ui/CommonTrackInfo.cpp
@@ -199,9 +199,9 @@ void CommonTrackInfo::DrawCloseButton(
    else
       memDC.SelectObject(theTheme.Bitmap(bmpCloseNormal));
 
-   dc->Blit(bev.GetLeft(), bev.GetRight(), bev.width, bev.height, &memDC, 0, 0);
+   AColor::Bevel2(*dc, !down, bev, selected, hit);
 
-   AColor::Bevel2(*dc, !down, bev, selected, hit );
+   dc->Blit(bev.GetLeft(), bev.GetTop(), bev.width, bev.height, &memDC, 2, 2);
 }
 
 namespace


### PR DESCRIPTION
Resolves: #7186

The Blit function was using the incorrect y coordinate value, leading to the strange positioning. I took the liberty of centering the X and drawing the bevel first.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
