### PR TITLE
Fix timeline quick play while recording

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -292,7 +292,7 @@ public:
       using namespace RefreshCode;
       auto result = CommonRulerHandle::Release(event, pProject, pParent);
 
-      if (mClicked == Button::Left && !mDragged)
+      if (mClicked == Button::Left && !mDragged && !mParent->mIsRecording)
          StartPlay(*pProject, event.event);
 
       if (!mDragged || 0 != (result & Cancelled))


### PR DESCRIPTION
Resolves: #7028

Disables timeline quick play during active recording.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
