### PR TITLE
7390 au4 amplify slider bug

### DIFF
--- a/au4/src/effects/builtin/amplify/AmplifyView.qml
+++ b/au4/src/effects/builtin/amplify/AmplifyView.qml
@@ -18,10 +18,12 @@ EffectBase {
 
     AmplifyViewModel {
         id: amplify
+        onAmpChanged: slider.value = amp
     }
 
     Component.onCompleted: {
         amplify.init()
+        slider.value = amplify.amp
     }
 
     Column {
@@ -59,9 +61,9 @@ EffectBase {
         }
 
         StyledSlider {
+            id: slider
             width: parent.width
 
-            value: amplify.amp
             to: amplify.ampMax
             from: amplify.ampMin
             stepSize: 0.1

--- a/au4/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/au4/src/effects/effects_base/internal/effectsprovider.cpp
@@ -78,7 +78,7 @@ muse::async::Notification EffectsProvider::effectMetaListChanged() const
 EffectCategoryList EffectsProvider::effectsCategoryList() const
 {
     EffectCategoryList list;
-    list.push_back({ BUILTIN_CATEGORY_ID, muse::mtrc("effects", "Build-in") });
+    list.push_back({ BUILTIN_CATEGORY_ID, muse::mtrc("effects", "Built-in") });
     if (isVstSupported()) {
         list.push_back({ VST_CATEGORY_ID, muse::mtrc("effects", "VST") });
     }


### PR DESCRIPTION
Resolves: #7390

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] Initial position of slider matches needed amplification to reach 0dB output amplitude,
- [ ] Slider behaves normally when moved left/right,
- [ ] Slider responds to textual update of the amplification value.
