### PR TITLE
normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,13 @@
 # Normalize line endings of all files that Git considers to be text
-* text=auto
+* text eol=lf
+#except images and sounds
+*.png -text 
+*.jpg -text 
+*.icns -text 
+*.wav -text 
+*.au -text 
+*.ico -text 
+# and weird stuff in lib-src
+*.ttl text=auto
+*.aps text=auto
+*.trig text=auto


### PR DESCRIPTION
This allows locale/update_po_files.sh to be ran on WSL even if development happens on Windows. It may break compatibility with windows text editors which don't do LF, but I don't know any off the top of my head (Notepad++ and VSCode handle it just fine anyway)

Let's hope CI is kind to it too