### PR TITLE
7382 bypass unnecessary sqlite block delete calls

### DIFF
--- a/libraries/lib-project-file-io/ProjectFileIO.cpp
+++ b/libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -88,10 +88,10 @@ static const int ProjectFileID = PACK('A', 'U', 'D', 'Y');
 
 // Navigation:
 //
-// Bindings are marked out in the code by, e.g. 
+// Bindings are marked out in the code by, e.g.
 // BIND SQL sampleblocks
 // A search for "BIND SQL" will find all bindings.
-// A search for "SQL sampleblocks" will find all SQL related 
+// A search for "SQL sampleblocks" will find all SQL related
 // to sampleblocks.
 
 static const char *ProjectFileSchema =
@@ -112,7 +112,7 @@ static const char *ProjectFileSchema =
    // This is all opaque to SQLite.  It just sees two
    // big binary blobs.
    // There is no limit to document blob size.
-   // dict will be smallish, with an entry for each 
+   // dict will be smallish, with an entry for each
    // kind of field.
    "CREATE TABLE IF NOT EXISTS <schema>.project"
    "("
@@ -132,7 +132,7 @@ static const char *ProjectFileSchema =
    // This is all opaque to SQLite.  It just sees two
    // big binary blobs.
    // There is no limit to document blob size.
-   // dict will be smallish, with an entry for each 
+   // dict will be smallish, with an entry for each
    // kind of field.
    "CREATE TABLE IF NOT EXISTS <schema>.autosave"
    "("
@@ -146,7 +146,7 @@ static const char *ProjectFileSchema =
    // The blocks may be partially empty.
    // The quantity of valid data in the blocks is
    // provided in the project blob.
-   // 
+   //
    // sampleformat specifies the format of the samples stored.
    //
    // blockID is a 64 bit number.
@@ -785,7 +785,7 @@ bool ProjectFileIO::CheckVersion()
       );
       return false;
    }
-   
+
    return true;
 }
 
@@ -1004,7 +1004,7 @@ bool ProjectFileIO::CopyTo(const FilePath &destpath,
       }
    });
 
-   // Attach the destination database 
+   // Attach the destination database
    wxString sql;
    wxString dbName = destpath;
    // Bug 2793: Quotes in name need escaping for sqlite3.
@@ -1192,7 +1192,7 @@ bool ProjectFileIO::ShouldCompact(const std::vector<const TrackList *> &tracks)
    // Get the number of blocks and total length from the project file.
    unsigned long long total = GetTotalUsage();
    unsigned long long blockcount = 0;
-   
+
    auto cb = [&blockcount](int cols, char **vals, char **)
    {
       // Convert
@@ -1428,7 +1428,7 @@ void ProjectFileIO::Compact(
             // PRL:  not clear what to do if the following fails, but the worst should
             // be, the project may reopen in its present state as a recovery file, not
             // at the last saved state.
-            // REVIEW: Could the autosave file be corrupt though at that point, and so 
+            // REVIEW: Could the autosave file be corrupt though at that point, and so
             // prevent recovery?
             // LLL: I believe Paul is correct since it's deleted with a single SQLite
             // transaction. The next time the file opens will just invoke recovery.
@@ -1698,7 +1698,7 @@ bool ProjectFileIO::HandleXMLTag(const std::string_view& tag, const AttributesLi
 
       ShowError( *ProjectFramePlacement(&project),
          XO("Can't open project file"),
-         msg, 
+         msg,
          "FAQ:Errors_opening_an_Audacity_project"
          );
 
@@ -2144,7 +2144,7 @@ bool ProjectFileIO::UpdateSaved(const TrackList *tracks)
    return true;
 }
 
-// REVIEW: This function is believed to report an error to the user in all cases 
+// REVIEW: This function is believed to report an error to the user in all cases
 // of failure.  Callers are believed not to need to do so if they receive 'false'.
 // LLL: All failures checks should now be displaying an error.
 bool ProjectFileIO::SaveProject(
@@ -2323,11 +2323,11 @@ bool ProjectFileIO::SaveProject(
       // saved database below.
       CloseProject();
 
-      // And make it the active project file 
+      // And make it the active project file
       UseConnection(std::move(newConn), fileName);
    }
 
-   if (!UpdateSaved(nullptr))
+   if (!UpdateSaved())
    {
       ShowError(
          {}, XO("Error Saving Project"),

--- a/libraries/lib-project-history/UndoManager.cpp
+++ b/libraries/lib-project-history/UndoManager.cpp
@@ -147,7 +147,7 @@ void UndoManager::RemoveStates(size_t begin, size_t end)
 
    // Success, commit the savepoint
    trans.Commit();
-   
+
    if (begin != end)
       EnqueueMessage({ UndoRedoMessage::Purge });
 }

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -798,7 +798,20 @@ void ProjectFileManager::CompactProjectOnClose()
          WaveTrackUtilities::CloseLock(*wt);
 
       // Attempt to compact the project
-      projectFileIO.Compact( { mLastSavedTracks.get() } );
+      projectFileIO.Compact({ mLastSavedTracks.get() });
+
+      if (
+         !projectFileIO.WasCompacted() &&
+         UndoManager::Get(project).UnsavedChanges())
+      {
+         // If compaction failed, we must do some work in case of close
+         // without save.  Don't leave the document blob from the last
+         // push of undo history, when that undo state may get purged
+         // with deletion of some new sample blocks.
+         // REVIEW: UpdateSaved() might fail too.  Do we need to test
+         // for that and report it?
+         projectFileIO.UpdateSaved(mLastSavedTracks.get());
+      }
    }
 }
 

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -533,18 +533,14 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    // Compact the project.
    projectFileManager.CompactProjectOnClose();
 
-   // This can reduce reference counts of sample blocks in the project's
-   // tracks. No need to have `SetBypass()` called yet because the `tracks`
-   // object still holds strong references to the tracks.
-   // Do this before `CompactProjectOnClose()`, though, so that changes that are
-   // not track-specific (like project tempo) after the last save don't get
-   // written to the project file.
-   UndoManager::Get(project).ClearStates();
-
    // Set (or not) the bypass flag to indicate that deletes that would happen
-   // during tracks.Clear() below are not necessary. Must be called after
-   // `CompactProjectOnClose()`.
+   // during undoManager.ClearStates() below are not necessary. Must be called
+   // between `CompactProjectOnClose()` and `undoManager.ClearStates()`.
    projectFileIO.SetBypass();
+
+   // This can reduce reference counts of sample blocks in the project's
+   // tracks.
+   UndoManager::Get(project).ClearStates();
 
    // Delete all the tracks to free up memory
    tracks.Clear();

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -530,6 +530,11 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    // TODO: Is there a Mac issue here??
    // SetMenuBar(NULL);
 
+   auto& undoManager = UndoManager::Get(project);
+   constexpr auto doAutoSave = false;
+   ProjectHistory::Get(project).SetStateTo(
+      undoManager.GetSavedState(), doAutoSave);
+
    // Compact the project.
    projectFileManager.CompactProjectOnClose();
 
@@ -540,7 +545,7 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
 
    // This can reduce reference counts of sample blocks in the project's
    // tracks.
-   UndoManager::Get(project).ClearStates();
+   undoManager.ClearStates();
 
    // Delete all the tracks to free up memory
    tracks.Clear();


### PR DESCRIPTION
Resolves: #7382

In https://github.com/audacity/audacity/pull/6745, I modified the order of method calls in the `ProjectManager::OnCloseWindow()` method, so that `ProjectFileManager::CompactProjectOnClose()` didn't call `projectFileIO.UpdateSaved( mLastSavedTracks.get() )` anymore, which was wronly saving project-wide settings such as project tempo even if the user didn't want to save the changes.

This had the unforeseen side effect that unnecessary `Delete()` calls to remove audio blocks from the database were now executed.

This PR restores the order of 3.5.1, and adds a preliminary step which rolls the history back to the last saved state.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
