### PR TITLE
Do not exclude debug qml dlls from install target

### DIFF
--- a/au4/src/app/CMakeLists.txt
+++ b/au4/src/app/CMakeLists.txt
@@ -237,7 +237,6 @@ if (OS_IS_WIN)
     install(DIRECTORY
             ${QT_INSTALL_QML}
             DESTINATION .
-            REGEX ".*d\\.dll" EXCLUDE
             REGEX ".pdb" EXCLUDE
             REGEX ".*QtMultimedia.*" EXCLUDE
             REGEX ".*QtSensors.*" EXCLUDE


### PR DESCRIPTION
Debugging with VSCode or Visual Studio on windows in Debug mode, au4 exits on startup with
`/build/install/qml/QtQml/WorkerScript/workerscriptplugin.dll' uses incompatible Qt library. (Cannot mix debug and release libraries.)`

This PR intends to fix this.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
