### PR TITLE
onClicked doesn't thwart onReleased anymore

### DIFF
--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -223,7 +223,6 @@ Rectangle {
                 if (!root.clipHovered) {
                     selectionController.resetSelectedClip()
                 }
-                selectionController.onClicked(e.x, e.y)
             }
         }
 

--- a/au4/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/au4/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -72,14 +72,20 @@ void SelectionViewController::onReleased(double x, double y)
         std::swap(x1, x2);
     }
 
+    const std::vector<TrackId> tracks = determinateTracks(m_startPoint.y(), y);
+
     if ((x2 - x1) < MIN_SELECTION_PX) {
+        // Click without drag
+        if (!tracks.empty()) {
+            selectionController()->setSelectedTrack(tracks[0]);
+        } else {
+            selectionController()->resetSelectedTrack();
+        }
         return;
     }
 
     setSelectionActive(true);
 
-    // tracks
-    std::vector<TrackId> tracks = determinateTracks(m_startPoint.y(), y);
     if (!tracks.empty()) {
         selectionController()->setSelectedTrack(tracks[0]);
     }
@@ -88,17 +94,6 @@ void SelectionViewController::onReleased(double x, double y)
     // time
     selectionController()->setDataSelectedStartTime(m_context->positionToTime(x1, true /*withSnap*/), true);
     selectionController()->setDataSelectedEndTime(m_context->positionToTime(x2, true /*withSnap*/), true);
-}
-
-void SelectionViewController::onClicked(double x, double y)
-{
-    Q_UNUSED(x);
-    std::vector<TrackId> tracks = determinateTracks(m_startPoint.y(), y);
-    if (!tracks.empty()) {
-        selectionController()->setSelectedTrack(tracks[0]);
-    } else {
-        selectionController()->resetSelectedTrack();
-    }
 }
 
 void SelectionViewController::onSelectionDraged(double x1, double x2, bool completed)

--- a/au4/src/projectscene/view/clipsview/selectionviewcontroller.h
+++ b/au4/src/projectscene/view/clipsview/selectionviewcontroller.h
@@ -34,7 +34,6 @@ public:
     Q_INVOKABLE void onPressed(double x, double y);
     Q_INVOKABLE void onPositionChanged(double x, double y);
     Q_INVOKABLE void onReleased(double x, double y);
-    Q_INVOKABLE void onClicked(double x, double y);
     Q_INVOKABLE void onSelectionDraged(double x, double x2, bool completed);
     Q_INVOKABLE void resetSelectedClip();
     Q_INVOKABLE void resetDataSelection();


### PR DESCRIPTION
Resolves: #7416 

The `SelectionViewController::onClicked` method undid `SelectionViewController::onReleased` when the click was dragged.
We relocate the body of `onClicked` in the branch of `onReleased` which detects that the click wasn't dragged.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] #7416 is resolved,
- [x] Track panel edits (e.g. copying a clip, clicking outside existing tracks and pasting should still work).
