### PR TITLE
7291 do not save unsaved changes on close

### DIFF
--- a/au4/src/appshell/internal/applicationactioncontroller.cpp
+++ b/au4/src/appshell/internal/applicationactioncontroller.cpp
@@ -68,7 +68,7 @@ void ApplicationActionController::onDragEnterEvent(QDragEnterEvent* event)
     onDragMoveEvent(event);
 }
 
-void ApplicationActionController::onDragMoveEvent(QDragMoveEvent* event)
+void ApplicationActionController::onDragMoveEvent(QDragMoveEvent*)
 {
     //! TODO AU4
     // const QMimeData* mime = event->mimeData();
@@ -83,7 +83,7 @@ void ApplicationActionController::onDragMoveEvent(QDragMoveEvent* event)
     // }
 }
 
-void ApplicationActionController::onDropEvent(QDropEvent* event)
+void ApplicationActionController::onDropEvent(QDropEvent*)
 {
     //! TODO AU4
     // const QMimeData* mime = event->mimeData();

--- a/au4/src/appshell/internal/applicationactioncontroller.cpp
+++ b/au4/src/appshell/internal/applicationactioncontroller.cpp
@@ -127,13 +127,12 @@ void ApplicationActionController::onDropEvent(QDropEvent*)
 bool ApplicationActionController::eventFilter(QObject* watched, QEvent* event)
 {
     //! TODO AU4
-    // if ((event->type() == QEvent::Close && watched == mainWindow()->qWindow())
-    //     || event->type() == QEvent::Quit) {
-    //     bool accepted = quit(false);
-    //     event->setAccepted(accepted);
-
-    //     return true;
-    // }
+    if ((event->type() == QEvent::Close && watched == mainWindow()->qWindow())
+        || event->type() == QEvent::Quit) {
+        const bool accepted = quit();
+        event->setAccepted(accepted);
+        return true;
+    }
 
     // if (event->type() == QEvent::FileOpen && watched == qApp) {
     //     const QFileOpenEvent* openEvent = static_cast<const QFileOpenEvent*>(event);
@@ -155,35 +154,19 @@ bool ApplicationActionController::eventFilter(QObject* watched, QEvent* event)
 
 bool ApplicationActionController::quit()
 {
-    //! TODO AU4
-//     if (m_quiting) {
-//         return false;
-//     }
+    if (m_quiting) {
+        return false;
+    }
 
-//     m_quiting = true;
-//     DEFER {
-//         m_quiting = false;
-//     };
+    m_quiting = true;
+    DEFER {
+        m_quiting = false;
+    };
 
-//     if (!projectFilesController()->closeOpenedProject()) {
-//         return false;
-//     }
-
-//     if (isAllInstances) {
-//         multiInstancesProvider()->quitForAll();
-//     }
-
-//     if (multiInstancesProvider()->instances().size() == 1 && !installerPath.empty()) {
-// #if defined(Q_OS_LINUX)
-//         interactive()->revealInFileBrowser(installerPath);
-// #else
-//         interactive()->openUrl(QUrl::fromLocalFile(installerPath.toQString()));
-// #endif
-//     }
-
-//     if (multiInstancesProvider()->instances().size() > 1) {
-//         multiInstancesProvider()->notifyAboutInstanceWasQuited();
-//     }
+    constexpr auto quit = true;
+    if (!projectFilesController()->closeOpenedProject(quit)) {
+        return false;
+    }
 
     QCoreApplication::exit();
     return true;
@@ -243,9 +226,10 @@ void ApplicationActionController::openPreferencesDialog()
 void ApplicationActionController::revertToFactorySettings()
 {
     std::string title = muse::trc("appshell", "Are you sure you want to revert to factory settings?");
-    std::string question = muse::trc("appshell", "This action will reset all your app preferences and delete all custom palettes and custom shortcuts. "
-                                                 "The list of recent scores will also be cleared.\n\n"
-                                                 "This action will not delete any of your scores.");
+    std::string question = muse::trc("appshell",
+                                     "This action will reset all your app preferences and delete all custom palettes and custom shortcuts. "
+                                     "The list of recent scores will also be cleared.\n\n"
+                                     "This action will not delete any of your scores.");
 
     int revertBtn = int(muse::IInteractive::Button::Apply);
     muse::IInteractive::Result result = interactive()->warning(title, question,

--- a/au4/src/appshell/internal/applicationactioncontroller.cpp
+++ b/au4/src/appshell/internal/applicationactioncontroller.cpp
@@ -44,10 +44,8 @@ void ApplicationActionController::preInit()
 
 void ApplicationActionController::init()
 {
-    dispatcher()->reg(this, "quit", [this](const ActionData& args) {
-        bool isAllInstances = args.count() > 0 ? args.arg<bool>(0) : true;
-        muse::io::path_t installatorPath = args.count() > 1 ? args.arg<muse::io::path_t>(1) : "";
-        quit(isAllInstances, installatorPath);
+    dispatcher()->reg(this, "quit", [this] {
+        quit();
     });
 
     dispatcher()->reg(this, "restart", [this]() {
@@ -155,7 +153,7 @@ bool ApplicationActionController::eventFilter(QObject* watched, QEvent* event)
     return QObject::eventFilter(watched, event);
 }
 
-bool ApplicationActionController::quit(bool isAllInstances, const muse::io::path_t& installerPath)
+bool ApplicationActionController::quit()
 {
     //! TODO AU4
 //     if (m_quiting) {

--- a/au4/src/appshell/internal/applicationactioncontroller.h
+++ b/au4/src/appshell/internal/applicationactioncontroller.h
@@ -75,7 +75,7 @@ private:
 
     void setupConnections();
 
-    bool quit(bool isAllInstances, const muse::io::path_t& installerPath = muse::io::path_t());
+    bool quit();
     void restart();
 
     void toggleFullScreen();

--- a/au4/src/au3wrap/internal/au3project.cpp
+++ b/au4/src/au3wrap/internal/au3project.cpp
@@ -96,8 +96,6 @@ bool Au3Project::save(const muse::io::path_t& filePath)
 
 void Au3Project::close()
 {
-    UndoManager::Get(m_data->projectRef()).ClearStates();
-
     auto& projectFileIO = ProjectFileIO::Get(m_data->projectRef());
     projectFileIO.CloseProject();
 }

--- a/au4/src/project/internal/audacityproject.cpp
+++ b/au4/src/project/internal/audacityproject.cpp
@@ -82,6 +82,11 @@ void Audacity4Project::close()
 {
     m_aboutCloseBegin.notify();
 
+    const auto history = projectHistory();
+    history->undoUnsaved();
+    history->clearUnsaved();
+    save();
+
     m_au3Project->close();
 
     m_aboutCloseEnd.notify();

--- a/au4/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/au4/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -49,6 +49,26 @@ void au::trackedit::Au3ProjectHistory::redo()
         });
 }
 
+void au::trackedit::Au3ProjectHistory::undoUnsaved()
+{
+    auto& project = projectRef();
+    auto& undoManager = UndoManager::Get(project);
+    while (undoManager.UnsavedChanges())
+    {
+        undoManager.Undo(
+            [&]( const UndoStackElem& elem ){
+            ::ProjectHistory::Get(project).PopState(elem.state);
+        });
+    }
+}
+
+void au::trackedit::Au3ProjectHistory::clearUnsaved()
+{
+    auto& project = projectRef();
+    auto& undoManager = UndoManager::Get(project);
+    undoManager.ClearStates();
+}
+
 void au::trackedit::Au3ProjectHistory::pushHistoryState(const std::string& longDescription, const std::string& shortDescription)
 {
     auto& project = projectRef();

--- a/au4/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/au4/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -13,44 +13,49 @@ using namespace au::trackedit;
 
 void au::trackedit::Au3ProjectHistory::init()
 {
-    auto project = reinterpret_cast<AudacityProject*>(globalContext()->currentProject()->au3ProjectPtr());
-    ::ProjectHistory::Get(*project).InitialState();
+    auto& project = projectRef();
+    ::ProjectHistory::Get(project).InitialState();
 }
 
 bool au::trackedit::Au3ProjectHistory::undoAvailable()
 {
-    auto project = reinterpret_cast<AudacityProject*>(globalContext()->currentProject()->au3ProjectPtr());
-    return ::ProjectHistory::Get(*project).UndoAvailable();
+    auto& project = projectRef();
+    return ::ProjectHistory::Get(project).UndoAvailable();
 }
 
 void au::trackedit::Au3ProjectHistory::undo()
 {
-    auto project = reinterpret_cast<AudacityProject*>(globalContext()->currentProject()->au3ProjectPtr());
-    auto& undoManager = UndoManager::Get(*project);
+    auto& project = projectRef();
+    auto& undoManager = UndoManager::Get(project);
     undoManager.Undo(
         [&]( const UndoStackElem& elem ){
-            ::ProjectHistory::Get(*project).PopState(elem.state);
-        });
+        ::ProjectHistory::Get(project).PopState(elem.state);
+    });
 }
 
 bool au::trackedit::Au3ProjectHistory::redoAvailable()
 {
-    auto project = reinterpret_cast<AudacityProject*>(globalContext()->currentProject()->au3ProjectPtr());
-    return ::ProjectHistory::Get(*project).RedoAvailable();
+    auto& project = projectRef();
+    return ::ProjectHistory::Get(project).RedoAvailable();
 }
 
 void au::trackedit::Au3ProjectHistory::redo()
 {
-    auto project = reinterpret_cast<AudacityProject*>(globalContext()->currentProject()->au3ProjectPtr());
-    auto& undoManager = UndoManager::Get(*project);
+    auto& project = projectRef();
+    auto& undoManager = UndoManager::Get(project);
     undoManager.Redo(
         [&]( const UndoStackElem& elem ){
-            ::ProjectHistory::Get(*project).PopState(elem.state);
+            ::ProjectHistory::Get(project).PopState(elem.state);
         });
 }
 
 void au::trackedit::Au3ProjectHistory::pushHistoryState(const std::string& longDescription, const std::string& shortDescription)
 {
-    auto project = reinterpret_cast<AudacityProject*>(globalContext()->currentProject()->au3ProjectPtr());
-    ::ProjectHistory::Get(*project).PushState(TranslatableString { longDescription, {} }, TranslatableString { shortDescription, {} });
+    auto& project = projectRef();
+    ::ProjectHistory::Get(project).PushState(TranslatableString { longDescription, {} }, TranslatableString { shortDescription, {} });
+}
+
+::AudacityProject& au::trackedit::Au3ProjectHistory::projectRef()
+{
+    return *reinterpret_cast<AudacityProject*>(globalContext()->currentProject()->au3ProjectPtr());
 }

--- a/au4/src/trackedit/internal/au3/au3projecthistory.h
+++ b/au4/src/trackedit/internal/au3/au3projecthistory.h
@@ -23,6 +23,8 @@ public:
     void undo() override;
     bool redoAvailable() override;
     void redo() override;
+    void undoUnsaved() override;
+    void clearUnsaved() override;
     void pushHistoryState(
         const std::string& longDescription, const std::string& shortDescription) override;
 

--- a/au4/src/trackedit/internal/au3/au3projecthistory.h
+++ b/au4/src/trackedit/internal/au3/au3projecthistory.h
@@ -6,9 +6,10 @@
 
 #include "iprojecthistory.h"
 
-#include "async/asyncable.h"
 #include "context/iglobalcontext.h"
 #include "modularity/ioc.h"
+
+class AudacityProject;
 
 namespace au::trackedit {
 class Au3ProjectHistory : public IProjectHistory
@@ -22,7 +23,10 @@ public:
     void undo() override;
     bool redoAvailable() override;
     void redo() override;
+    void pushHistoryState(
+        const std::string& longDescription, const std::string& shortDescription) override;
 
-    void pushHistoryState(const std::string& longDescription, const std::string& shortDescription) override;
+private:
+    ::AudacityProject& projectRef();
 };
 }

--- a/au4/src/trackedit/iprojecthistory.h
+++ b/au4/src/trackedit/iprojecthistory.h
@@ -18,7 +18,8 @@ public:
     virtual void undo() = 0;
     virtual bool redoAvailable() = 0;
     virtual void redo() = 0;
-
+    virtual void undoUnsaved() = 0;
+    virtual void clearUnsaved() = 0;
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription) = 0;
 };
 


### PR DESCRIPTION
Resolves: #7291 

* Hooks the global application close button to the "Do you want to save ..." modal,
* Rewinds history to last saved change.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Do any action that can be undone ; close project -> prompt appears
- [x] If saying no to the prompt and re-opening, the project is back to the state of the last save.
- [x] This works after closing the project or closing the entire application