### PR TITLE
Revert global ripple for paste

### DIFF
--- a/libraries/lib-channel/Channel.h
+++ b/libraries/lib-channel/Channel.h
@@ -295,9 +295,6 @@ public:
    //! Change start time by given duration
    void ShiftBy(double t) { MoveTo(GetStartTime() + t); }
 
-   //! Shift all intervals that starts after `t0` by `delta` seconds
-   virtual void ShiftBy(double t0, double delta) = 0;
-
    //! Change start time to given time point
    virtual void MoveTo(double o) = 0;
 

--- a/libraries/lib-label-track/LabelTrack.cpp
+++ b/libraries/lib-label-track/LabelTrack.cpp
@@ -193,7 +193,6 @@ LabelTrack::~LabelTrack()
 {
 }
 
-
 void LabelTrack::MoveTo(double origin)
 {
    if (!mLabels.empty()) {
@@ -201,17 +200,6 @@ void LabelTrack::MoveTo(double origin)
       for (auto &labelStruct: mLabels) {
          labelStruct.selectedRegion.move(offset);
       }
-   }
-}
-
-void LabelTrack::ShiftBy(double t0, double delta)
-{
-   if (mLabels.empty())
-   return;
-   for (auto &labelStruct: mLabels)
-   {
-      if(labelStruct.selectedRegion.t0() >= t0)
-         labelStruct.selectedRegion.move(delta);
    }
 }
 

--- a/libraries/lib-label-track/LabelTrack.h
+++ b/libraries/lib-label-track/LabelTrack.h
@@ -122,7 +122,6 @@ class LABEL_TRACK_API LabelTrack final
    void SetLabel( size_t iLabel, const LabelStruct &newLabel );
 
    void MoveTo(double dOffset) override;
-   void ShiftBy(double t0, double delta) override;
 
    void SetSelected(bool s) override;
 

--- a/libraries/lib-note-track/NoteTrack.cpp
+++ b/libraries/lib-note-track/NoteTrack.cpp
@@ -217,12 +217,6 @@ Track::Holder NoteTrack::Clone(bool) const
    return duplicate;
 }
 
-void NoteTrack::ShiftBy(double t0, double delta)
-{
-   if(t0 <= mOrigin)
-      mOrigin += delta;
-}
-
 void NoteTrack::WarpAndTransposeNotes(double t0, double t1,
                                       const TimeWarper &warper,
                                       double semitones)

--- a/libraries/lib-note-track/NoteTrack.h
+++ b/libraries/lib-note-track/NoteTrack.h
@@ -96,7 +96,6 @@ private:
 
 public:
    void MoveTo(double origin) override { mOrigin = origin; }
-   void ShiftBy(double t0, double delta) override;
 
    Alg_seq &GetSeq() const;
 

--- a/libraries/lib-time-track/TimeTrack.h
+++ b/libraries/lib-time-track/TimeTrack.h
@@ -64,7 +64,6 @@ class TIME_TRACK_API TimeTrack final
    // TimeTrack parameters
 
    void MoveTo(double /* t */) override {}
-   void ShiftBy(double, double) override {}
 
    // XMLTagHandler callback methods for loading and saving
 

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -570,22 +570,6 @@ void WaveTrack::MoveTo(double origin)
    WaveTrackData::Get(*this).SetOrigin(origin);
 }
 
-/*! @excsafety{No-fail} */
-void WaveTrack::ShiftBy(double t0, double delta)
-{
-   for (const auto &pInterval : Intervals())
-   {   // assume No-fail-guarantee
-      if(pInterval->Start() >= t0)
-         pInterval->ShiftBy(delta);
-   }
-   const auto origin = WaveTrackData::Get(*this).GetOrigin();
-   if(t0 <= origin)
-   {
-      const auto offset = t0 >= 0 ? delta : t0 + delta;
-      WaveTrackData::Get(*this).SetOrigin(origin + offset);
-   }
-}
-
 auto WaveTrack::DuplicateWithOtherTempo(double newTempo) const -> Holder
 {
    const auto srcCopy = Duplicate();

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -287,7 +287,6 @@ public:
    virtual ~WaveTrack();
 
    void MoveTo(double o) override;
-   void ShiftBy(double t0, double delta) override;
 
    bool LinkConsistencyFix(bool doFix) override;
 

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -700,25 +700,6 @@ void OnPaste(const CommandContext &context)
    // TODO: What if we clicked past the end of the track?
 
    if (bPastedSomething) {
-
-      if(!isSyncLocked && GetEditClipsCanMove())
-      {
-         //Special case when pasting without sync lock and
-         //"...move other clips" option is 
-         //Also shift all intervals in all other tracks that
-         //starts after t0
-         const auto offset = srcTracks->GetEndTime() - (t1 - t0);
-         for(auto track : tracks.Any<Track>())
-         {
-            const auto it = std::find_if(correspondence.begin(), correspondence.end(),
-                                   [=](auto& p) { return p.first == track; });
-            if(it != correspondence.end())
-               continue;
-
-            track->ShiftBy(t0, offset);
-         }
-      }
-
       ViewInfo::Get(project).selectedRegion
          .setTimes( t0, t0 + clipboard.Duration() );
 

--- a/src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
@@ -317,7 +317,7 @@ void StretchHandle::Stretch(AudacityProject *pProject, int mouseXCoordinate, int
             return;
          nt.StretchRegion
             ( mStretchState.mBeat0, mStretchState.mBeat1, dur );
-         nt.ChannelGroup::ShiftBy(moveto - t0);
+         nt.ShiftBy(moveto - t0);
          mStretchState.mBeat0.first = moveto;
          viewInfo.selectedRegion.setT0(moveto);
          break;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/7293

Problem:
When the preference "Track Behaviors: Editing a clip can move other clips" is set, the commit aa12de91 changed the behaviour of paste from per track ripple to global ripple. Issues with this change:
1. A user no longer has the option of per track ripple for pasting.
2. Before the change, a user could already paste with gobal ripple by enabling synchronized tracks.
3. Paste became inconsistent with all the other actions which could move other clips, which remained per track ripple.

Fix:
Revert commit aa12de9184ced9be0d6c7667bc547ad939cd8340.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
