### PR TITLE
[AU4] Hide context menu btn beyond the right edge of the screen

### DIFF
--- a/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/au4/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -218,7 +218,7 @@ Rectangle {
                 width: 16
                 height: 16
                 anchors.right: parent.right
-                anchors.rightMargin: root.rightVisibleMargin + 4
+                anchors.rightMargin: 4
                 anchors.verticalCenter: parent.verticalCenter
 
                 menuModel: contextMenuModel


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/7403

