### PR TITLE
Revert global ripple for paste

### DIFF
--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -705,10 +705,10 @@ void OnPaste(const CommandContext &context)
       {
          //Special case when pasting without sync lock and
          //"...move other clips" option is 
-         //Also shift all intervals in all other tracks that
+         //Also shift all intervals in all other selected tracks that
          //starts after t0
          const auto offset = srcTracks->GetEndTime() - (t1 - t0);
-         for(auto track : tracks.Any<Track>())
+         for(auto track : tracks.Selected<Track>())
          {
             const auto it = std::find_if(correspondence.begin(), correspondence.end(),
                                    [=](auto& p) { return p.first == track; });


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/7293

Problem:
In commit aa12de9, which was part of a PR to fix issue #7124, all other tracks, rather than all other selected tracks, were potentially moved, thus introducing a global ripple.

Fix:
Move only other selected tracks.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
