### PR TITLE
Validate time range before calling std::clamp

### DIFF
--- a/src/DefaultPlaybackPolicy.cpp
+++ b/src/DefaultPlaybackPolicy.cpp
@@ -95,7 +95,10 @@ double DefaultPlaybackPolicy::OffsetSequenceTime(
       else {
          // this includes the case where the start time is after the
          // looped region, and mLoopEnabled is set to false
-         time = std::clamp(time + offset, *mpStartTime, schedule.mT1);
+         //
+         // Validate time range
+         if (schedule.mT1 > *mpStartTime)
+            time = std::clamp(time + offset, *mpStartTime, schedule.mT1);
       }
    }
 


### PR DESCRIPTION
Resolves: #7453

Range argument were invalid in the call to std::clamp.  Value for "high" was less than value for "low".  Validate time range before calling std::clamp.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
