### PR TITLE
7369 au4 tone generator

### DIFF
--- a/au3/libraries/lib-exceptions/AudacityException.h
+++ b/au3/libraries/lib-exceptions/AudacityException.h
@@ -76,6 +76,7 @@ protected:
 
    MessageBoxException( const MessageBoxException& );
 
+public:
    //! %Format the error message for this exception.
    virtual TranslatableString ErrorMessage() const = 0;
    virtual wxString ErrorHelpUrl() const { return helpUrl; };
@@ -220,7 +221,7 @@ noexcept(
    catch ( AudacityException &e ) {
    #ifndef UNCAUGHT_EXCEPTIONS_UNAVAILABLE
       const auto uncaughtExceptionsCount = std::uncaught_exceptions();
-   #endif  
+   #endif
       auto end = finally( [&]()
       noexcept(noexcept(
          std::function<void(AudacityException*)>{
@@ -230,9 +231,9 @@ noexcept(
          // other exception object.
       #ifdef UNCAUGHT_EXCEPTIONS_UNAVAILABLE
          if (!std::uncaught_exception()) {
-      #else         
+      #else
          if (uncaughtExceptionsCount >= std::uncaught_exceptions()) {
-      #endif      
+      #endif
             auto pException = std::current_exception(); // This points to e
             AudacityException::EnqueueAction(
                pException, std::move(delayedHandler));

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -16,8 +16,6 @@ public:
 
     Au3ProjectAccessor();
 
-    static std::shared_ptr<Au3ProjectAccessor> create();
-
     void open() override;
     bool load(const muse::io::path_t& filePath) override;
     bool save(const muse::io::path_t& fileName) override;
@@ -30,7 +28,7 @@ public:
 
 private:
 
-    std::shared_ptr<Au3ProjectData> m_data;
+    const std::shared_ptr<Au3ProjectData> m_data;
     Observer::Subscription mTrackListSubstription;
 };
 

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "../iau3project.h"
+#include "libraries/lib-utility/Observer.h"
 
 namespace au::au3 {
 struct Au3ProjectData;
@@ -30,6 +31,7 @@ public:
 private:
 
     std::shared_ptr<Au3ProjectData> m_data;
+    Observer::Subscription mTrackListSubstription;
 };
 
 class Au3ProjectCreator : public IAu3ProjectCreator

--- a/src/au3wrap/vst3/CMakeLists.txt
+++ b/src/au3wrap/vst3/CMakeLists.txt
@@ -4,7 +4,7 @@
 declare_module(vst_sdk_3)
 
 if (NOT AU_MODULE_VST_VST3_SDK_PATH)
-    message(FATAL_ERROR "AU_MODULE_VST_VST3_SDK_PATH path is not setted")
+    message(FATAL_ERROR "AU_MODULE_VST_VST3_SDK_PATH path is not set")
 endif()
 
 set(VST3_SDK_PATH ${AU_MODULE_VST_VST3_SDK_PATH})

--- a/src/effects/builtin/CMakeLists.txt
+++ b/src/effects/builtin/CMakeLists.txt
@@ -17,6 +17,10 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/common/params.h
     ${CMAKE_CURRENT_LIST_DIR}/common/abstracteffectmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common/abstracteffectmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/common/generatoreffect.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/common/generatoreffect.h
+    ${CMAKE_CURRENT_LIST_DIR}/common/generatoreffectmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/common/generatoreffectmodel.h
 
     ${CMAKE_CURRENT_LIST_DIR}/general/generalviewmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/general/generalviewmodel.h
@@ -36,6 +40,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/reverb/reverbeffect.h
     ${CMAKE_CURRENT_LIST_DIR}/reverb/reverbviewmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/reverb/reverbviewmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/tonegen/toneviewmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/tonegen/toneviewmodel.h
     )
 
 # AU3

--- a/src/effects/builtin/common/generatoreffect.cpp
+++ b/src/effects/builtin/common/generatoreffect.cpp
@@ -1,0 +1,60 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "generatoreffect.h"
+#include "libraries/lib-components/EffectInterface.h"
+#include "log.h"
+
+using namespace au::effects;
+
+GeneratorEffect::GeneratorEffect(const double& projectRate, const double& t0, double& t1)
+    : m_projectRate{projectRate}
+    , m_t0{t0}
+    , m_t1{t1}
+{
+}
+
+void GeneratorEffect::init(EffectSettings* settings)
+{
+    IF_ASSERT_FAILED(settings) {
+        return;
+    }
+    m_settings = settings;
+    setDuration(settings->extra.GetDuration());
+    doInit();
+}
+
+double GeneratorEffect::sampleRate() const
+{
+    return m_projectRate;
+}
+
+double GeneratorEffect::duration() const
+{
+    // Rely on settings for the duration: we don't have a signal when it gets changed, so we can't expect `m_t1` to be up-to-date.
+    return m_settings ? m_settings->extra.GetDuration() : 0.0;
+}
+
+void GeneratorEffect::setDuration(double newDuration)
+{
+    m_t1 = m_t0 + newDuration;
+    if (m_settings) {
+        m_settings->extra.SetDuration(newDuration);
+    }
+}
+
+QString GeneratorEffect::durationFormat() const
+{
+    if (m_settings) {
+        return QString::fromStdString(
+            m_settings->extra.GetDurationFormat().GET().ToStdString());
+    }
+    return "";
+}
+
+void GeneratorEffect::setDurationFormat(const QString& newDurationFormat)
+{
+    if (m_settings) {
+        m_settings->extra.SetDurationFormat(NumericFormatID { newDurationFormat.toStdString() });
+    }
+}

--- a/src/effects/builtin/common/generatoreffect.h
+++ b/src/effects/builtin/common/generatoreffect.h
@@ -1,0 +1,30 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+struct EffectSettings;
+
+namespace au::effects {
+class GeneratorEffect
+{
+public:
+    GeneratorEffect(const double& projectRate, const double& t0, double& t1);
+
+    //! `settings` remain valid for the lifetime of the effect
+    void init(EffectSettings* settings);
+    double sampleRate() const;
+    double duration() const;
+    void setDuration(double newDuration);
+    QString durationFormat() const;
+    void setDurationFormat(const QString& newDurationFormat);
+
+private:
+    virtual void doInit() {}
+
+    const double& m_projectRate;
+    const double& m_t0;
+    double& m_t1;
+    EffectSettings* m_settings = nullptr;
+};
+}

--- a/src/effects/builtin/common/generatoreffectmodel.cpp
+++ b/src/effects/builtin/common/generatoreffectmodel.cpp
@@ -1,0 +1,73 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "generatoreffectmodel.h"
+#include "generatoreffect.h"
+#include "log.h"
+
+#include "libraries/lib-components/EffectInterface.h"
+#include "libraries/lib-effects/Effect.h"
+
+using namespace au::effects;
+
+void GeneratorEffectModel::init()
+{
+    auto* const ge = dynamic_cast<GeneratorEffect*>(effect());
+    IF_ASSERT_FAILED(ge) {
+        return;
+    }
+    ge->init(settings());
+    emit sampleRateChanged();
+    emit durationChanged();
+    emit durationFormatChanged();
+}
+
+double GeneratorEffectModel::sampleRate() const
+{
+    const auto ge = generatorEffect();
+    IF_ASSERT_FAILED(ge) {
+        return 1.0;
+    }
+    return ge->sampleRate();
+}
+
+double GeneratorEffectModel::duration() const
+{
+    const auto e = generatorEffect();
+    IF_ASSERT_FAILED(e) {
+        return 0.0;
+    }
+    return e->duration();
+}
+
+void GeneratorEffectModel::setDuration(double newDuration)
+{
+    auto e = generatorEffect();
+    IF_ASSERT_FAILED(e) {
+        return;
+    }
+    e->setDuration(newDuration);
+}
+
+QString GeneratorEffectModel::durationFormat() const
+{
+    const auto e = generatorEffect();
+    IF_ASSERT_FAILED(e) {
+        return "";
+    }
+    return e->durationFormat();
+}
+
+void GeneratorEffectModel::setDurationFormat(const QString& newDurationFormat)
+{
+    auto e = generatorEffect();
+    IF_ASSERT_FAILED(e) {
+        return;
+    }
+    e->setDurationFormat(newDurationFormat);
+}
+
+GeneratorEffect* GeneratorEffectModel::generatorEffect() const
+{
+    return dynamic_cast<GeneratorEffect*>(effect());
+}

--- a/src/effects/builtin/common/generatoreffectmodel.h
+++ b/src/effects/builtin/common/generatoreffectmodel.h
@@ -1,0 +1,39 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "../common/abstracteffectmodel.h"
+#include "../common/params.h"
+
+namespace au::effects {
+class GeneratorEffect;
+class ToneEffect;
+
+class GeneratorEffectModel : public AbstractEffectModel
+{
+    Q_OBJECT
+    Q_PROPERTY(
+        double duration READ duration WRITE setDuration NOTIFY durationChanged)
+    Q_PROPERTY(QString durationFormat READ durationFormat WRITE setDurationFormat
+               NOTIFY durationFormatChanged)
+    Q_PROPERTY(double sampleRate READ sampleRate NOTIFY sampleRateChanged)
+
+public:
+    Q_INVOKABLE void init();
+
+    double duration() const;
+    void setDuration(double newDuration);
+    double sampleRate() const;
+    QString durationFormat() const;
+    void setDurationFormat(const QString& newDurationFormat);
+
+signals:
+    void sampleRateChanged();
+    void durationChanged();
+    void durationFormatChanged();
+
+private:
+    GeneratorEffect* generatorEffect() const;
+};
+} // namespace au::effects

--- a/src/effects/builtin/internal/builtineffectsrepository.cpp
+++ b/src/effects/builtin/internal/builtineffectsrepository.cpp
@@ -21,6 +21,7 @@
 #include "tonegen/toneeffect.h"
 #include "reverb/reverbeffect.h"
 #include "reverb/reverbviewmodel.h"
+#include "tonegen/toneviewmodel.h"
 
 #include "log.h"
 
@@ -61,6 +62,7 @@ void BuiltinEffectsRepository::init()
             );
 
     static BuiltinEffectsModule::Registration< ToneEffect > regTone;
+    qmlRegisterType<ToneViewModel>("Audacity.Effects", 1, 0, "ToneViewModel");
     regView(ToneEffect::Symbol, u"qrc:/tonegen/ToneView.qml");
     regMeta(ToneEffect::Symbol,
             muse::mtrc("effects", "Tone"),

--- a/src/effects/builtin/tonegen/ToneView.qml
+++ b/src/effects/builtin/tonegen/ToneView.qml
@@ -21,6 +21,10 @@ EffectBase {
     width: 370
     height: 200
 
+    function preview() {
+        tone.preview()
+    }
+
     ToneViewModel {
         id: tone
     }

--- a/src/effects/builtin/tonegen/ToneView.qml
+++ b/src/effects/builtin/tonegen/ToneView.qml
@@ -1,7 +1,117 @@
-import QtQuick 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Muse.UiComponents
+import Audacity.Effects
+import Audacity.Playback
+import "../common"
 
-Rectangle {
+EffectBase {
 
-    color: "#009090"
+    // Helper function to format number
+    function formatNumber(value, maxDecimals) {
+        // Convert number to fixed decimal string and remove trailing zeros
+        return parseFloat(value.toFixed(maxDecimals)).toString();
+    }
 
+    property string title: qsTrc("effects", "Tone")
+    property alias instanceId: tone.instanceId
+    property alias isApplyAllowed: tone.isApplyAllowed
+
+    width: 370
+    height: 200
+
+    ToneViewModel {
+        id: tone
+    }
+
+    Component.onCompleted: {
+        tone.init()
+        timecode.currentFormatStr = tone.durationFormat
+    }
+
+    GridLayout {
+        columns: 2
+        rows: 4
+        columnSpacing: 4
+        rowSpacing: 16
+
+        // Ensure the items are left-aligned in their respective cells (suggested by ChatGPT, review this)
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.fill: parent
+        anchors.margins: 10
+
+        // First row
+        StyledTextLabel {
+            text: qsTrc("effects/tone", "Waveform:")
+        }
+
+        ComboBox {
+            width: 80
+            model: tone.waveforms
+            currentIndex: tone.waveform
+
+            onActivated: function (index) {
+                tone.waveform = index
+            }
+        }
+
+        // Second row
+        StyledTextLabel {
+            text: qsTrc("effects", "Frequency (Hz):")
+        }
+
+        TextInputField {
+            width: 80
+            currentText: formatNumber(tone.frequency, 6)
+
+            validator: DoubleInputValidator {
+                decimal: 6
+            }
+
+            onTextEdited: function (newTextValue) {
+                tone.frequency = parseFloat(newTextValue)
+            }
+        }
+
+        // Third row
+        StyledTextLabel {
+            text: qsTrc("effects/tone", "Amplitude (0-1):")
+        }
+
+        TextInputField {
+            width: 80
+            currentText: formatNumber(tone.amplitude, 6)
+
+            validator: DoubleInputValidator {
+                decimal: 6
+            }
+
+            onTextEdited: function (newTextValue) {
+                tone.amplitude = parseFloat(newTextValue)
+            }
+        }
+
+        // Fourth row
+        StyledTextLabel {
+            text: qsTrc("effects", "Duration:")
+        }
+
+        Timecode {
+            Layout.fillHeight: false
+            id: timecode
+            value: tone.duration
+            currentFormatStr: tone.durationFormat
+            sampleRate: tone.sampleRate
+            enabled: true
+
+            onValueChanged: {
+                tone.duration = timecode.value
+            }
+
+            onCurrentFormatChanged: {
+                tone.durationFormat = timecode.currentFormatStr
+            }
+        }
+    }
 }

--- a/src/effects/builtin/tonegen/toneeffect.cpp
+++ b/src/effects/builtin/tonegen/toneeffect.cpp
@@ -2,16 +2,100 @@
 * Audacity: A Digital Audio Editor
 */
 #include "toneeffect.h"
+#include "log.h"
 
 using namespace au::effects;
 
 const ComponentInterfaceSymbol ToneEffect::Symbol{ XO("Tone") };
 
 ToneEffect::ToneEffect()
-    : ToneGenBase(false)
+    : ToneGenBase(false), GeneratorEffect(mProjectRate, mT0, mT1)
 {}
 
 ComponentInterfaceSymbol ToneEffect::GetSymbol() const
 {
     return Symbol;
+}
+
+void ToneEffect::doInit()
+{
+    // The tone generator is a chirp with constant amplitude and frequency.
+    mAmplitude1 = mAmplitude0;
+    mFrequency1 = mFrequency0;
+}
+
+ToneEffect::Waveform ToneEffect::waveform() const
+{
+    switch (mWaveform) {
+    case kSine:
+        return Waveform::Sine;
+    case kSquare:
+        return Waveform::Square;
+    case kSawtooth:
+        return Waveform::Sawtooth;
+    case kSquareNoAlias:
+        return Waveform::SquareNoAlias;
+    case kTriangle:
+        return Waveform::Triangle;
+    }
+    DO_ASSERT(false);
+    return Waveform::Sine;
+}
+
+void ToneEffect::setWaveform(Waveform waveform)
+{
+    switch (waveform) {
+    case Waveform::Sine:
+        mWaveform = kSine;
+        break;
+    case Waveform::Square:
+        mWaveform = kSquare;
+        break;
+    case Waveform::Sawtooth:
+        mWaveform = kSawtooth;
+        break;
+    case Waveform::SquareNoAlias:
+        mWaveform = kSquareNoAlias;
+        break;
+    case Waveform::Triangle:
+        mWaveform = kTriangle;
+        break;
+    default:
+        DO_ASSERT(false);
+    }
+}
+
+double ToneEffect::amplitude() const
+{
+    return mAmplitude0;
+}
+
+void ToneEffect::setAmplitude(double amplitude)
+{
+    mAmplitude0 = mAmplitude1 = amplitude;
+}
+
+double ToneEffect::frequency() const
+{
+    return mFrequency0;
+}
+
+void ToneEffect::setFrequency(double frequency)
+{
+    mFrequency0 = mFrequency1 = frequency;
+}
+
+bool ToneEffect::isApplyAllowed() const
+{
+    // Doesn't matter which of start or end freq boundaries we use:
+    static_assert(StartFreq.min == EndFreq.min);
+    static_assert(StartFreq.max == EndFreq.max);
+    static_assert(StartAmp.min == EndAmp.min);
+    static_assert(StartAmp.max == EndAmp.max);
+    constexpr auto frequencyMin = StartFreq.min;
+    constexpr auto frequencyMax = StartFreq.max;
+    constexpr auto amplitudeMin = StartAmp.min;
+    constexpr auto amplitudeMax = StartAmp.max;
+    return frequencyMin <= frequency() && frequency() <= frequencyMax
+           && amplitudeMin <= amplitude() && amplitude() <= amplitudeMax;
 }

--- a/src/effects/builtin/tonegen/toneeffect.h
+++ b/src/effects/builtin/tonegen/toneeffect.h
@@ -4,15 +4,38 @@
 #pragma once
 
 #include "libraries/lib-builtin-effects/ToneGenBase.h"
+#include "../common/generatoreffect.h"
+
+struct EffectSettings;
 
 namespace au::effects {
-class ToneEffect : public ::ToneGenBase
+class ToneEffect : public ::ToneGenBase, public GeneratorEffect
 {
 public:
     ToneEffect();
 
+    enum class Waveform
+    {
+        Sine,
+        Square,
+        Sawtooth,
+        SquareNoAlias,
+        Triangle,
+    };
+
     static const ComponentInterfaceSymbol Symbol;
 
     ComponentInterfaceSymbol GetSymbol() const override;
+
+    Waveform waveform() const;
+    void setWaveform(Waveform waveform);
+    double amplitude() const;
+    void setAmplitude(double amplitude);
+    double frequency() const;
+    void setFrequency(double frequency);
+    bool isApplyAllowed() const;
+
+private:
+    void doInit() override;
 };
 }

--- a/src/effects/builtin/tonegen/toneviewmodel.cpp
+++ b/src/effects/builtin/tonegen/toneviewmodel.cpp
@@ -1,0 +1,101 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "toneviewmodel.h"
+#include "toneeffect.h"
+#include "log.h"
+
+#include "libraries/lib-components/EffectInterface.h"
+
+using namespace au::effects;
+
+ToneEffect* ToneViewModel::effect() const
+{
+    const auto instance = AbstractEffectModel::effect();
+    IF_ASSERT_FAILED(instance) {
+        return nullptr;
+    }
+    ToneEffect* const e = dynamic_cast<ToneEffect*>(instance);
+    IF_ASSERT_FAILED(e) {
+        return nullptr;
+    }
+    return e;
+}
+
+bool ToneViewModel::isApplyAllowed() const
+{
+    const ToneEffect* const te = effect();
+    IF_ASSERT_FAILED(te) {
+        return false;
+    }
+    return te->isApplyAllowed();
+}
+
+QList<QString> ToneViewModel::waveforms() const
+{
+    return {
+        tr("Sine"), tr("Square"), tr("Sawtooth"), tr("Square, not alias"), tr("Triangle")
+    };
+}
+
+double ToneViewModel::amplitude() const
+{
+    const ToneEffect* const te = effect();
+    IF_ASSERT_FAILED(te) {
+        return 0.0;
+    }
+    return te->amplitude();
+}
+
+void ToneViewModel::setAmplitude(double newAmplitude)
+{
+    const auto wasAllowed = isApplyAllowed();
+    ToneEffect* const te = effect();
+    IF_ASSERT_FAILED(te) {
+        return;
+    }
+    te->setAmplitude(newAmplitude);
+    if (wasAllowed != isApplyAllowed()) {
+        emit isApplyAllowedChanged();
+    }
+}
+
+double ToneViewModel::frequency() const
+{
+    const ToneEffect* const te = effect();
+    IF_ASSERT_FAILED(te) {
+        return 0.0;
+    }
+    return te->frequency();
+}
+
+void ToneViewModel::setFrequency(double newFrequency)
+{
+    const auto wasAllowed = isApplyAllowed();
+    ToneEffect* const te = effect();
+    IF_ASSERT_FAILED(te) {
+        return;
+    }
+    te->setFrequency(newFrequency);
+    if (wasAllowed != isApplyAllowed()) {
+        emit isApplyAllowedChanged();
+    }
+}
+
+int ToneViewModel::waveform() const
+{
+    const ToneEffect* const te = effect();
+    IF_ASSERT_FAILED(te) {
+        return 0;
+    }
+    return static_cast<int>(te->waveform());
+}
+
+void ToneViewModel::setWaveform(int newWaveform)
+{
+    ToneEffect* const te = effect();
+    IF_ASSERT_FAILED(te) {
+        return;
+    }
+    te->setWaveform(static_cast<ToneEffect::Waveform>(newWaveform));
+}

--- a/src/effects/builtin/tonegen/toneviewmodel.h
+++ b/src/effects/builtin/tonegen/toneviewmodel.h
@@ -1,0 +1,42 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "../common/generatoreffectmodel.h"
+#include "../common/params.h"
+
+namespace au::effects {
+class ToneEffect;
+class ToneViewModel : public GeneratorEffectModel
+{
+    Q_OBJECT
+    Q_PROPERTY(bool isApplyAllowed READ isApplyAllowed NOTIFY isApplyAllowedChanged)
+    Q_PROPERTY(double amplitude READ amplitude WRITE setAmplitude NOTIFY
+               amplitudeChanged)
+    Q_PROPERTY(double frequency READ frequency WRITE setFrequency NOTIFY
+               frequencyChanged)
+    Q_PROPERTY(
+        int waveform READ waveform WRITE setWaveform NOTIFY waveformChanged)
+    Q_PROPERTY(QList<QString> waveforms READ waveforms CONSTANT)
+
+public:
+    bool isApplyAllowed() const;
+    QList<QString> waveforms() const;
+    double amplitude() const;
+    void setAmplitude(double newAmplitude);
+    double frequency() const;
+    void setFrequency(double newFrequency);
+    int waveform() const;
+    void setWaveform(int newWaveform);
+
+signals:
+    void amplitudeChanged();
+    void frequencyChanged();
+    void waveformChanged();
+    void isApplyAllowedChanged();
+
+private:
+    ToneEffect* effect() const;
+};
+}

--- a/src/effects/effects_base/CMakeLists.txt
+++ b/src/effects/effects_base/CMakeLists.txt
@@ -9,6 +9,7 @@ set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
 
 set(MODULE_SRC
     # public
+    ${CMAKE_CURRENT_LIST_DIR}/effecterrors.h
     ${CMAKE_CURRENT_LIST_DIR}/effectsmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/effectsmodule.h
     ${CMAKE_CURRENT_LIST_DIR}/effectstypes.h

--- a/src/effects/effects_base/effecterrors.h
+++ b/src/effects/effects_base/effecterrors.h
@@ -1,0 +1,40 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+
+#pragma once
+
+#include "translation.h"
+#include "types/ret.h"
+
+namespace au::effects {
+static constexpr int EFFECTS_FIRST = 7000; // TODO This has to go in framework's ret.h
+enum class Err {
+    Undefined = int(muse::Ret::Code::Undefined),
+    NoError = int(muse::Ret::Code::Ok),
+    UnknownError = EFFECTS_FIRST,
+
+    EffectProcessFailed,
+};
+
+inline muse::Ret make_ret(Err e, std::string text = "", std::string caption = "")
+{
+    int retCode = static_cast<int>(e);
+
+    switch (e) {
+    case Err::Undefined:
+        return muse::Ret(retCode);
+    case Err::NoError:
+        return muse::Ret(retCode);
+    case Err::UnknownError:
+        return muse::Ret(retCode);
+    case Err::EffectProcessFailed: {
+        return muse::Ret(
+            retCode,
+            text.empty() ? muse::trc("effects", "Applying effect failed") : text);
+    }
+    }
+
+    return muse::Ret(static_cast<int>(e));
+}
+} // namespace au::effects

--- a/src/effects/effects_base/internal/effectexecutionscenario.h
+++ b/src/effects/effects_base/internal/effectexecutionscenario.h
@@ -10,6 +10,7 @@
 #include "context/iglobalcontext.h"
 #include "../ieffectsprovider.h"
 #include "../ieffectinstancesregister.h"
+#include "trackedit/iselectioncontroller.h"
 
 #include "au3wrap/au3types.h"
 
@@ -25,6 +26,7 @@ class EffectExecutionScenario : public IEffectExecutionScenario
     muse::Inject<context::IGlobalContext> globalContext;
     muse::Inject<IEffectsProvider> effectsProvider;
     muse::Inject<IEffectInstancesRegister> effectInstancesRegister;
+    muse::Inject<trackedit::ISelectionController> selectionController;
 
 public:
     EffectExecutionScenario() = default;

--- a/src/effects/effects_base/internal/effectsactionscontroller.cpp
+++ b/src/effects/effects_base/internal/effectsactionscontroller.cpp
@@ -26,7 +26,11 @@ void EffectsActionsController::doEffect(const muse::actions::ActionData& args)
 
     muse::String effectId = args.arg<muse::String>(0);
 
-    effectExecutionScenario()->performEffect(effectId);
+    const auto ret = effectExecutionScenario()->performEffect(effectId);
+    if (!ret && muse::Ret::Code(ret.code()) != muse::Ret::Code::Cancel) {
+        const auto& title = effectsProvider()->meta(effectId).title;
+        interactive()->error(title.toStdString(), ret.text());
+    }
 }
 
 void EffectsActionsController::repeatLastEffect()

--- a/src/effects/effects_base/internal/effectsactionscontroller.h
+++ b/src/effects/effects_base/internal/effectsactionscontroller.h
@@ -12,12 +12,15 @@
 #include "actions/iactionsdispatcher.h"
 #include "../ieffectexecutionscenario.h"
 #include "../ieffectsprovider.h"
+#include "iinteractive.h"
 
 namespace au::effects {
 class EffectsActionsController : public muse::actions::Actionable, public muse::async::Asyncable
 {
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
     muse::Inject<IEffectExecutionScenario> effectExecutionScenario;
+    muse::Inject<IEffectsProvider> effectsProvider;
+    muse::Inject<muse::IInteractive> interactive;
 
 public:
     void init();

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -5,6 +5,7 @@
 
 #include "modularity/ioc.h"
 #include "global/iinteractive.h"
+#include "context/iglobalcontext.h"
 #include "playback/iplayback.h"
 #include "effects/builtin/ibuiltineffectsrepository.h"
 #include "effects/vst/ivsteffectsrepository.h"
@@ -18,6 +19,7 @@ class EffectSettingsAccess;
 namespace au::effects {
 class EffectsProvider : public IEffectsProvider
 {
+    muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<IEffectsConfiguration> configuration;
     muse::Inject<IBuiltinEffectsRepository> builtinEffectsRepository;
     muse::Inject<IVstEffectsRepository> vstEffectsRepository;

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -235,6 +235,12 @@ void Au3Player::seek(const muse::secs_t newPosition)
     m_playbackPosition.set(newPosition);
 }
 
+void Au3Player::rewind()
+{
+    seek(0.0);
+    m_playbackRewound.notify();
+}
+
 void Au3Player::stop()
 {
     m_playbackStatus.set(PlaybackStatus::Stopped);
@@ -349,6 +355,11 @@ muse::secs_t Au3Player::playbackPosition() const
 muse::async::Channel<muse::secs_t> Au3Player::playbackPositionChanged() const
 {
     return m_playbackPosition.ch;
+}
+
+muse::async::Notification Au3Player::playbackRewound() const
+{
+    return m_playbackRewound;
 }
 
 Au3Project& Au3Player::projectRef() const

--- a/src/playback/internal/au3/au3player.h
+++ b/src/playback/internal/au3/au3player.h
@@ -30,6 +30,7 @@ public:
 
     void play() override;
     void seek(const muse::secs_t newPosition) override;
+    void rewind() override;
     void stop() override;
     void pause() override;
     void resume() override;
@@ -43,6 +44,7 @@ public:
 
     muse::secs_t playbackPosition() const override;
     muse::async::Channel<muse::secs_t> playbackPositionChanged() const override;
+    muse::async::Notification playbackRewound() const override;
 
     muse::Ret playTracks(TrackList& trackList, double startTime, double endTime, const PlayTracksOptions& options = {}) override;
 
@@ -61,6 +63,7 @@ private:
 
     muse::Timer m_positionUpdateTimer;
     muse::ValCh<muse::secs_t> m_playbackPosition;
+    muse::async::Notification m_playbackRewound;
     double m_startOffset = 0.0;
 };
 }

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -211,7 +211,10 @@ void PlaybackController::rewindToStart()
 {
     //! NOTE: In Audacity 3 we can't rewind while playing
     stop();
-    seek(0.0);
+    IF_ASSERT_FAILED(player()) {
+        return;
+    }
+    player()->rewind();
 }
 
 void PlaybackController::rewindToEnd()

--- a/src/playback/iplayer.h
+++ b/src/playback/iplayer.h
@@ -5,6 +5,7 @@
 #include "global/types/ret.h"
 #include "global/async/channel.h"
 #include "global/async/promise.h"
+#include "global/async/notification.h"
 
 #include "playbacktypes.h"
 
@@ -19,6 +20,7 @@ public:
 
     virtual void play() = 0;
     virtual void seek(const muse::secs_t newPosition) = 0;
+    virtual void rewind() = 0;
     virtual void stop() = 0;
     virtual void pause() = 0;
     virtual void resume() = 0;
@@ -32,6 +34,7 @@ public:
 
     virtual muse::secs_t playbackPosition() const = 0;
     virtual muse::async::Channel<muse::secs_t> playbackPositionChanged() const = 0;
+    virtual muse::async::Notification playbackRewound() const = 0;
 
     // tracks
     virtual muse::Ret playTracks(TrackList& trackList, double startTime, double endTime, const PlayTracksOptions& options = {}) = 0;

--- a/src/playback/qml/Audacity/Playback/components/Timecode.qml
+++ b/src/playback/qml/Audacity/Playback/components/Timecode.qml
@@ -21,6 +21,7 @@ RowLayout {
     property alias lowerTimeSignature: timecodeModel.lowerTimeSignature
 
     property alias currentFormat: timecodeModel.currentFormat
+    property alias currentFormatStr: timecodeModel.currentFormatStr
 
     property bool showMenu: true
     property int backgroundLeftRadius: 3

--- a/src/playback/view/toolbars/components/timecodemodel.cpp
+++ b/src/playback/view/toolbars/components/timecodemodel.cpp
@@ -235,7 +235,8 @@ void TimecodeModel::initFieldInteractionController()
 
 void TimecodeModel::updateValueString()
 {
-    QString newValueString = m_formatter->valueToString(m_value, false).valueString;
+    constexpr auto toNearest = true;
+    QString newValueString = m_formatter->valueToString(m_value, toNearest).valueString;
 
     if (newValueString.size() != m_valueString.size()) {
         beginResetModel();

--- a/src/playback/view/toolbars/components/timecodemodel.cpp
+++ b/src/playback/view/toolbars/components/timecodemodel.cpp
@@ -26,8 +26,8 @@ TimecodeModel::TimecodeModel(QObject* parent)
 {
     // translate all
     m_availableViewFormats = {
-        { ViewFormatType::Seconds, muse::qtrc("playback", "Seconds"), "01000,01000s" },
-        { ViewFormatType::SecondsMilliseconds, muse::qtrc("playback", "Seconds + milliseconds"), "01000,01000>01000 s" },
+        { ViewFormatType::Seconds, muse::qtrc("playback", "seconds"), "01000,01000s" },
+        { ViewFormatType::SecondsMilliseconds, muse::qtrc("playback", "seconds + milliseconds"), "01000,01000>01000 s" },
         { ViewFormatType::HHMMSS, muse::qtrc("playback", "hh:mm:ss"), "0100 h 060 m 060 s" },
         { ViewFormatType::DDHHMMSS, muse::qtrc("playback", "dd:hh:mm:ss"), "0100 d 024 h 060 m 060 s" },
 
@@ -35,7 +35,7 @@ TimecodeModel::TimecodeModel(QObject* parent)
         { ViewFormatType::HHMMSSMilliseconds, muse::qtrc("playback", "hh:mm:ss + milliseconds"), "0100 h 060 m 060>01000 s" },
 
         { ViewFormatType::HHMMSSSamples, muse::qtrc("playback", "hh:mm:ss + samples"), "0100 h 060 m 060 s+># samples" },
-        { ViewFormatType::Samples, muse::qtrc("playback", "Samples"), "01000,01000,01000 samples|#" },
+        { ViewFormatType::Samples, muse::qtrc("playback", "samples"), "01000,01000,01000 samples|#" },
 
         { ViewFormatType::HHMMSSFilmFrames, muse::qtrc("playback", "hh:mm:ss + film frames (24 fps)"), "0100 h 060 m 060 s+>24 frames" },
         { ViewFormatType::FilmFrames, muse::qtrc("playback", "Film frames (24 fps)"), "01000,01000 frames|24" },
@@ -161,6 +161,22 @@ void TimecodeModel::setCurrentFormat(int format)
     emit valueChanged();
 }
 
+QString TimecodeModel::currentFormatStr() const
+{
+    return m_availableViewFormats[m_currentFormat].title;
+}
+
+void TimecodeModel::setCurrentFormatStr(const QString& title)
+{
+    for (int i = 0; i < m_availableViewFormats.size(); ++i) {
+        if (m_availableViewFormats[i].title == title) {
+            setCurrentFormat(i);
+            return;
+        }
+    }
+    // TODO log error
+}
+
 int TimecodeModel::currentEditedFieldIndex() const
 {
     return m_fieldsInteractionController->currentEditedFieldIndex();
@@ -256,6 +272,7 @@ void TimecodeModel::setSampleRate(double sampleRate)
     updateValueString();
 
     emit sampleRateChanged();
+    emit currentFormatChanged();
 }
 
 double TimecodeModel::tempo() const

--- a/src/playback/view/toolbars/components/timecodemodel.h
+++ b/src/playback/view/toolbars/components/timecodemodel.h
@@ -23,6 +23,7 @@ class TimecodeModel : public QAbstractListModel
 
     Q_PROPERTY(QVariantList availableFormats READ availableFormats NOTIFY availableFormatsChanged)
     Q_PROPERTY(int currentFormat READ currentFormat WRITE setCurrentFormat NOTIFY currentFormatChanged FINAL)
+    Q_PROPERTY(QString currentFormatStr READ currentFormatStr WRITE setCurrentFormatStr NOTIFY currentFormatChanged FINAL)
 
     Q_PROPERTY(int currentEditedFieldIndex READ currentEditedFieldIndex
                WRITE setCurrentEditedFieldIndex NOTIFY currentEditedFieldIndexChanged FINAL)
@@ -70,6 +71,9 @@ public:
 
     int currentFormat() const;
     void setCurrentFormat(int format);
+
+    QString currentFormatStr() const;
+    void setCurrentFormatStr(const QString& formatStr);
 
     int currentEditedFieldIndex() const;
     void setCurrentEditedFieldIndex(int index);

--- a/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -47,8 +47,7 @@ void SelectionViewController::onPositionChanged(double x, double y)
         std::swap(x1, x2);
     }
 
-    selectionController()->setDataSelectedStartTime(m_context->positionToTime(x1, true /*withSnap*/), false);
-    selectionController()->setDataSelectedEndTime(m_context->positionToTime(x2, true /*withSnap*/), false);
+    setSelection(x1, x2, false);
 }
 
 void SelectionViewController::onReleased(double x, double y)
@@ -77,6 +76,7 @@ void SelectionViewController::onReleased(double x, double y)
         } else {
             selectionController()->resetSelectedTracks();
         }
+        setSelection(x1, x1, true);
         return;
     }
 
@@ -88,8 +88,7 @@ void SelectionViewController::onReleased(double x, double y)
     selectionController()->setSelectedTracks(tracks, true);
 
     // time
-    selectionController()->setDataSelectedStartTime(m_context->positionToTime(x1, true /*withSnap*/), true);
-    selectionController()->setDataSelectedEndTime(m_context->positionToTime(x2, true /*withSnap*/), true);
+    setSelection(x1, x2, true);
 }
 
 void SelectionViewController::onSelectionDraged(double x1, double x2, bool completed)
@@ -99,8 +98,7 @@ void SelectionViewController::onSelectionDraged(double x1, double x2, bool compl
         std::swap(x1, x2);
     }
 
-    selectionController()->setDataSelectedStartTime(m_context->positionToTime(x1, true /*withSnap*/), completed);
-    selectionController()->setDataSelectedEndTime(m_context->positionToTime(x2, true /*withSnap*/), completed);
+    setSelection(x1, x2, completed);
 }
 
 void SelectionViewController::selectTrackAudioData(double y)
@@ -222,4 +220,10 @@ void SelectionViewController::setSelectionActive(bool newSelectionActive)
     }
     m_selectionActive = newSelectionActive;
     emit selectionActiveChanged();
+}
+
+void SelectionViewController::setSelection(double x1, double x2, bool complete)
+{
+    selectionController()->setDataSelectedStartTime(m_context->positionToTime(x1, true /*withSnap*/), complete);
+    selectionController()->setDataSelectedEndTime(m_context->positionToTime(x2, true /*withSnap*/), complete);
 }

--- a/src/projectscene/view/clipsview/selectionviewcontroller.h
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.h
@@ -59,6 +59,7 @@ private:
 
     IProjectViewStatePtr viewState() const;
     trackedit::TrackIdList trackIdList() const;
+    void setSelection(double x1, double x2, bool complete);
 
     trackedit::TrackIdList determinateTracks(double y1, double y2) const;
 

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1189,7 +1189,7 @@ void Au3Interaction::duplicateTracks(const TrackIdList& trackIds)
         auto au3Clone = au3Track->Duplicate();
         Au3TrackList::AssignUniqueId(au3Clone);
 
-        tracks.Add(au3Clone, true);
+        tracks.Add(au3Clone, ::TrackList::DoAssignId::Yes);
 
         auto clone = DomConverter::track(au3Clone.get());
 

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -27,6 +27,15 @@ using namespace au::au3;
 
 // clip selection
 
+void Au3SelectionController::init()
+{
+    playback()->player()->playbackRewound().onNotify(this, [this] {
+        MYLOG() << "playback rewound";
+        setDataSelectedStartTime(0, true);
+        setDataSelectedEndTime(0, true);
+    });
+}
+
 void Au3SelectionController::resetSelectedTracks()
 {
     MYLOG() << "resetSelectedTrack";

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -160,8 +160,9 @@ void Au3SelectionController::resetDataSelection()
 {
     MYLOG() << "resetDataSelection";
 
-    m_selectedStartTime.set(-1.0, true);
-    m_selectedEndTime.set(-1.0, true);
+    const auto playbackPosition = playback()->player()->playbackPosition();
+    m_selectedStartTime.set(playbackPosition, true);
+    m_selectedEndTime.set(playbackPosition, true);
 }
 
 bool Au3SelectionController::timeSelectionIsNotEmpty() const

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -5,18 +5,23 @@
 
 #include "../../iselectioncontroller.h"
 
+#include "async/asyncable.h"
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "playback/iplayback.h"
 
 #include "au3wrap/au3types.h"
 
 namespace au::trackedit {
-class Au3SelectionController : public ISelectionController
+class Au3SelectionController : public ISelectionController, public muse::async::Asyncable
 {
     muse::Inject<au::context::IGlobalContext> globalContext;
+    muse::Inject<au::playback::IPlayback> playback;
 
 public:
     Au3SelectionController() = default;
+
+    void init();
 
     // track selection
     void resetSelectedTracks() override;

--- a/src/trackedit/internal/au3/au3trackeditproject.cpp
+++ b/src/trackedit/internal/au3/au3trackeditproject.cpp
@@ -97,11 +97,6 @@ void Au3TrackeditProject::onTrackListEvent(const TrackListEvent& e)
             onTrackDataChanged(trackId);
             m_impl->trackReplacing = false;
         }
-
-        const auto tempo = ProjectTimeSignature::Get(*m_impl->prj).GetTempo();
-        if (const auto track = e.mpTrack.lock()) {
-            DoProjectTempoChange(*track, tempo);
-        }
     } break;
     default:
         break;

--- a/src/trackedit/trackediterrors.h
+++ b/src/trackedit/trackediterrors.h
@@ -8,10 +8,12 @@
 #include "translation.h"
 
 namespace au::trackedit {
+static constexpr int TRACKEDIT_FIRST = 6000; // TODO This has to go in framework's ret.h
+
 enum class Err {
     Undefined       = int(muse::Ret::Code::Undefined),
     NoError         = int(muse::Ret::Code::Ok),
-    UnknownError    = int(muse::Ret::Code::UnknownError),
+    UnknownError    = TRACKEDIT_FIRST,
 
     WaveTrackNotFound,
     ClipNotFound,

--- a/src/trackedit/trackeditmodule.cpp
+++ b/src/trackedit/trackeditmodule.cpp
@@ -49,11 +49,12 @@ void TrackeditModule::registerExports()
 {
     m_trackeditController = std::make_shared<TrackeditActionsController>();
     m_trackeditUiActions = std::make_shared<TrackeditUiActions>(m_trackeditController);
+    m_selectionController = std::make_shared<Au3SelectionController>();
 
     ioc()->registerExport<ITrackeditActionsController>(moduleName(), m_trackeditController);
     ioc()->registerExport<ITrackeditProjectCreator>(moduleName(), new Au3TrackeditProjectCreator());
     ioc()->registerExport<ITrackeditInteraction>(moduleName(), new Au3Interaction());
-    ioc()->registerExport<ISelectionController>(moduleName(), new Au3SelectionController());
+    ioc()->registerExport<ISelectionController>(moduleName(), m_selectionController);
     ioc()->registerExport<IProjectHistory>(moduleName(), new Au3ProjectHistory());
     ioc()->registerExport<ITrackeditClipboard>(moduleName(), new Au3TrackeditClipboard());
 }
@@ -70,6 +71,7 @@ void TrackeditModule::onInit(const muse::IApplication::RunMode&)
 {
     m_trackeditController->init();
     m_trackeditUiActions->init();
+    m_selectionController->init();
 }
 
 void TrackeditModule::onDeinit()

--- a/src/trackedit/trackeditmodule.h
+++ b/src/trackedit/trackeditmodule.h
@@ -8,6 +8,7 @@
 namespace au::trackedit {
 class TrackeditActionsController;
 class TrackeditUiActions;
+class Au3SelectionController;
 class TrackeditModule : public muse::modularity::IModuleSetup
 {
 public:
@@ -21,5 +22,6 @@ public:
 private:
     std::shared_ptr<TrackeditActionsController> m_trackeditController;
     std::shared_ptr<TrackeditUiActions> m_trackeditUiActions;
+    std::shared_ptr<Au3SelectionController> m_selectionController;
 };
 }


### PR DESCRIPTION
Resolves: #7369
May resolve #7509 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

### QA:
Note that the tone generator is still to be found under **Effects > Built-in > Tone**. This must be addressed in a follow-up PR.

The UI is still unbalanced ; for now, please ignore as long as the functionality is here.

An effort was made to make it on-par with AU3's tone generator. Please use your AU3 tone-generator regression test plan and report missing bits.

Some things to make sure of (not exhaustive):
- [x] Generate on empty project creates new track
- [x] When no track is selected, generating also creates a new track.
- [x] Generate over existing clip replaces selection with tone.
- [x] If there isn't a time selection when invoking the effect, the duration format is `hh::mm::ss + milliseconds`.
- [x] If there is a time selection when invoking the effect, the duration format is `hh:mm:ss + samples`,
- [x] Generating when there is not enough room shows the expected error dialog,