### PR TITLE
7573 crash on close due to undoable unsaved changes

### DIFF
--- a/libraries/lib-project-history/ProjectHistory.cpp
+++ b/libraries/lib-project-history/ProjectHistory.cpp
@@ -117,8 +117,12 @@ void ProjectHistory::PopState(const UndoState &state, bool doAutosave)
          pExtension->RestoreUndoRedoState(project);
 }
 
-void ProjectHistory::SetStateTo(unsigned int n, bool doAutosave)
+void ProjectHistory::SetStateTo(int n, bool doAutosave)
 {
+   assert(n >= 0);
+   if (n < 0)
+      return;
+
    auto &project = mProject;
    auto &undoManager = UndoManager::Get( project );
 

--- a/libraries/lib-project-history/ProjectHistory.h
+++ b/libraries/lib-project-history/ProjectHistory.h
@@ -43,7 +43,8 @@ public:
    ~ProjectHistory() override;
 
    void InitialState();
-   void SetStateTo(unsigned int n, bool doAutosave = true);
+   //! @pre n >= 0
+   void SetStateTo(int n, bool doAutosave = true);
    bool UndoAvailable() const;
    bool RedoAvailable() const;
    void PushState(

--- a/libraries/lib-project-history/UndoManager.h
+++ b/libraries/lib-project-history/UndoManager.h
@@ -171,7 +171,6 @@ class PROJECT_HISTORY_API UndoManager final
    void RenameState( int state,
       const TranslatableString &longDescription,
       const TranslatableString &shortDescription);
-   void AbandonRedo();
    void ClearStates();
    void RemoveStates(
       size_t begin, //!< inclusive start of range
@@ -215,6 +214,7 @@ class PROJECT_HISTORY_API UndoManager final
 
    void EnqueueMessage(UndoRedoMessage message);
    void RemoveStateAt(int n);
+   void AbandonRedo();
 
    AudacityProject &mProject;
  

--- a/libraries/lib-project-history/UndoManager.h
+++ b/libraries/lib-project-history/UndoManager.h
@@ -156,7 +156,7 @@ class PROJECT_HISTORY_API UndoManager final
  public:
    static UndoManager &Get( AudacityProject &project );
    static const UndoManager &Get( const AudacityProject &project );
- 
+
    explicit
    UndoManager( AudacityProject &project );
    ~UndoManager();

--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -698,7 +698,6 @@ bool MacroCommands::ApplyMacro(
             undoManager.Undo(
                [&]( const UndoStackElem &elem ){
                   history.PopState( elem.state ); } );
-            undoManager.AbandonRedo();
          });
       }
    });

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -531,9 +531,12 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
    // SetMenuBar(NULL);
 
    auto& undoManager = UndoManager::Get(project);
-   constexpr auto doAutoSave = false;
-   ProjectHistory::Get(project).SetStateTo(
-      undoManager.GetSavedState(), doAutoSave);
+   if (undoManager.GetSavedState() >= 0)
+   {
+      constexpr auto doAutoSave = false;
+      ProjectHistory::Get(project).SetStateTo(
+         undoManager.GetSavedState(), doAutoSave);
+   }
 
    // Compact the project.
    projectFileManager.CompactProjectOnClose();


### PR DESCRIPTION
Resolves: #7573 

`UndoManager::MarkUnsaved()` resets its `int state` member to -1. `MarkUnsaved()` is used when toggling realtime effects on or off. On the other hand, 99f1314b16bcb74d0c52a3135bf7bde541f3b72f introduced a call to
```
ProjectHistory::Get(project).SetStateTo(undoManager.GetSavedState(), ...);
``` 
but `GetSavedState()` was now returning -1 meanwhile `SetStateTo` was expecting an `unsigned int` ... Hence the crash.

`MarkUnsaved()` resetting `state` to -1 makes the undo manager loose track of the last saved state. Simply making `SetStateTo` robust against calls with `-1` is sufficient to fix the crash but leaves the possibility that the user changes something (e.g. project tempo), toggles a realtime effect, says "No, I don't want to save" when closing, and yet, when reopening her project, sees that the change was saved nevertheless.

 , thereby loosing track of particular unsaved actions. When closing and saying "No, don't save changes", the state of the project can't be reverted to the last saved change anymore because `GetSavedState()` returns -1 and is hence unusable.

The proposed solution gets `MarkUnsaved` not to reset `state` to -1. Reviewers should verify that this doesn't have unintended side effects.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior