### PR TITLE
Fix handling of unicode characters in the project name

### DIFF
--- a/modules/sharing/mod-cloud-audiocom/CloudProjectFileIOExtensions.cpp
+++ b/modules/sharing/mod-cloud-audiocom/CloudProjectFileIOExtensions.cpp
@@ -94,7 +94,7 @@ class IOExtension final : public ProjectFileIOExtension
          // Errors would be handled by the UI extension
          return OnSaveAction::Cancelled;
 
-      if (!projectSaveCallback(audacity::ToUTF8(filePath), fileRenamed))
+      if (!projectSaveCallback(filePath, fileRenamed))
       {
          if (result.Operation)
             result.Operation->Abort();
@@ -205,7 +205,7 @@ class IOExtension final : public ProjectFileIOExtension
       const auto filePath = sync::MakeSafeProjectPath(dir, result.second);
 
       return PerformCloudSave(
-         project, result.second, audacity::ToUTF8(filePath),
+         project, audacity::ToUTF8(result.second), audacity::ToUTF8(filePath),
          projectSaveCallback, true, mAudiocomTrace);
    }
 

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.cpp
@@ -76,7 +76,7 @@ CloudProjectPropertiesDialog::~CloudProjectPropertiesDialog()
    GetAuthorizationHandler().PopSuppressDialogs();
 }
 
-std::pair<CloudProjectPropertiesDialog::Action, std::string>
+std::pair<CloudProjectPropertiesDialog::Action, wxString>
 CloudProjectPropertiesDialog::Show(
    const ServiceConfig& serviceConfig, OAuthService& authService,
    UserService& userService, const wxString& projectName, wxWindow* parent,
@@ -201,11 +201,11 @@ void CloudProjectPropertiesDialog::SetupEvents()
    mProjectName->Bind(wxEVT_TEXT_ENTER, [this](auto&) { OnSubmit(); });
 }
 
-std::string CloudProjectPropertiesDialog::GetProjectName() const
+wxString CloudProjectPropertiesDialog::GetProjectName() const
 {
    wxString result { mProjectName->GetValue() };
    result.Trim(true).Trim(false);
-   return audacity::ToUTF8(result);
+   return result;
 }
 
 void CloudProjectPropertiesDialog::OnUpdateCloudSaveState()

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.h
@@ -50,7 +50,7 @@ public:
       SaveLocally
    };
 
-   static std::pair<Action, std::string> Show(
+   static std::pair<Action, wxString> Show(
       const ServiceConfig& serviceConfig, OAuthService& authService,
       UserService& userService, const wxString& projectName, wxWindow* parent,
       bool allowLocalSave, AudiocomTrace);
@@ -60,7 +60,7 @@ private:
    void LayoutControls();
    void SetupEvents();
 
-   std::string GetProjectName() const;
+   wxString GetProjectName() const;
    void OnUpdateCloudSaveState();
 
    UserPanel* mUserPanel {};


### PR DESCRIPTION
Resolves: #7452 
The project name was converted to Utf-8 twice during the save

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
