### PR TITLE
Master-effect stack actions are undo- and redoable

### DIFF
--- a/libraries/lib-realtime-effects/RealtimeEffectList.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.h
@@ -13,9 +13,9 @@
 #include <optional>
 #include <vector>
 
+#include "ClientData.h"
 #include "PluginProvider.h" // for PluginID
 #include "spinlock.h"
-#include "UndoManager.h"
 #include "XMLTagHandler.h"
 #include "Observer.h"
 
@@ -45,7 +45,6 @@ class REALTIME_EFFECTS_API RealtimeEffectList final
    : public std::enable_shared_from_this<RealtimeEffectList>
    , public ClientData::Base
    , public ClientData::Cloneable<>
-   , public UndoStateExtension
    , public XMLTagHandler
    , public Observer::Publisher<RealtimeEffectListMessage>
 {
@@ -64,6 +63,7 @@ public:
    //! Should be called (for pushing undo states) only from main thread, to
    //! avoid races
    std::unique_ptr<ClientData::Cloneable<>> Clone() const override;
+   std::unique_ptr<RealtimeEffectList> Duplicate() const;
 
    static RealtimeEffectList &Get(AudacityProject &project);
    static const RealtimeEffectList &Get(const AudacityProject &project);
@@ -152,8 +152,6 @@ public:
 
    //! Use only in the main thread, to avoid races
    void WriteXML(XMLWriter &xmlFile) const;
-
-   void RestoreUndoRedoState(AudacityProject &project) noexcept override;
 
    //! Non-blocking atomic boolean load
    bool IsActive() const;

--- a/src/effects/EffectUI.cpp
+++ b/src/effects/EffectUI.cpp
@@ -33,6 +33,7 @@
 #include "RealtimeEffectManager.h"
 #include "RealtimeEffectState.h"
 #include "Theme.h"
+#include "UndoManager.h"
 #include "Viewport.h"
 #include "wxWidgetsWindowPlacement.h"
 


### PR DESCRIPTION
Resolves: #7571 

The `RealtimeEffectList` is an attachment to the `AudacityProject` class. It also implemented the `UndoStateExtension` API class, but its `void RestoreUndoRedoState(AudacityProject& project)` was trivial: it was just re-assigning itself as attachment to the project ...

This PR implements the `MasterEffectListRestorer`, inspired by the `TimeSignatureRestorer`, and necessary adaptations.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
