### PR TITLE
Create PluginManager instance as function-local static

### DIFF
--- a/libraries/lib-module-manager/PluginManager.cpp
+++ b/libraries/lib-module-manager/PluginManager.cpp
@@ -321,9 +321,6 @@ bool PluginManager::RemoveConfig(ConfigurationType type, const PluginID & ID,
 //
 // ============================================================================
 
-// The one and only PluginManager
-std::unique_ptr<PluginManager> PluginManager::mInstance{};
-
 // ----------------------------------------------------------------------------
 // Creation/Destruction
 // ----------------------------------------------------------------------------
@@ -379,12 +376,8 @@ static PluginManager::ConfigFactory sFactory;
 
 PluginManager & PluginManager::Get()
 {
-   if (!mInstance)
-   {
-      mInstance.reset(safenew PluginManager);
-   }
-
-   return *mInstance;
+   static PluginManager instance;
+   return instance;
 }
 
 void PluginManager::Initialize(ConfigFactory factory)

--- a/libraries/lib-module-manager/PluginManager.h
+++ b/libraries/lib-module-manager/PluginManager.h
@@ -231,8 +231,6 @@ private:
    wxString ConvertID(const PluginID & ID);
 
 private:
-   friend std::default_delete<PluginManager>;
-   static std::unique_ptr<PluginManager> mInstance;
 
    bool IsDirty();
    void SetDirty(bool dirty = true);


### PR DESCRIPTION
Resolves: #7397

Global statics get destroyed last during the exit sequence, at that time static local wxConvFileName is already destroyed.

PluginManager flushes the config file to the disk during destruction, resulting in accessing the deleted object.
By making PluginManager function-local static, we ensure that it will be deleted before wxConvFileName

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior