### PR TITLE
Fix modules were automatically enabled if portable installation was m…

### DIFF
--- a/libraries/lib-module-manager/ModuleSettings.cpp
+++ b/libraries/lib-module-manager/ModuleSettings.cpp
@@ -102,9 +102,11 @@ int ModuleSettings::GetModuleStatus(const FilePath &fname)
    wxString StatusPref = wxString( wxT("/Module/") ) + ShortName;
    wxString DateTimePref = wxString( wxT("/ModuleDateTime/") ) + ShortName;
 
-   wxString ModulePath = gPrefs->Read( PathPref, wxEmptyString );
-   if( ModulePath.IsSameAs( fname ) )
+   if( gPrefs->Exists(StatusPref) )
    {
+      // Update module path in case it was changed
+      gPrefs->Write( PathPref, fname );
+
       gPrefs->Read( StatusPref, &iStatus, static_cast<int>(kModuleNew) );
 
       wxDateTime DateTime = FileName.GetModificationTime();


### PR DESCRIPTION
Resolves: #7620

Fix the issue when the modules are automatically enabled when audacity is used in portable mode and the installation is moved. 

Do not check for path changes; a datetime check should be enough. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
