### PR TITLE
Fixed some crashes

### DIFF
--- a/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -18,6 +18,10 @@ SelectionViewController::SelectionViewController(QObject* parent)
 
 void SelectionViewController::onPressed(double x, double y)
 {
+    if (!isProjectOpened()) {
+        return;
+    }
+
     Qt::KeyboardModifiers modifiers = keyboardModifiers();
 
     m_selectionStarted = true;
@@ -59,6 +63,10 @@ void SelectionViewController::onPressed(double x, double y)
 
 void SelectionViewController::onPositionChanged(double x, double y)
 {
+    if (!isProjectOpened()) {
+        return;
+    }
+
     if (!m_selectionStarted) {
         return;
     }
@@ -89,6 +97,10 @@ void SelectionViewController::onPositionChanged(double x, double y)
 
 void SelectionViewController::onReleased(double x, double y)
 {
+    if (!isProjectOpened()) {
+        return;
+    }
+
     if (!m_selectionStarted) {
         return;
     }
@@ -137,6 +149,10 @@ void SelectionViewController::onReleased(double x, double y)
 
 void SelectionViewController::onSelectionDraged(double x1, double x2, bool completed)
 {
+    if (!isProjectOpened()) {
+        return;
+    }
+
     // time
     if (x1 > x2) {
         std::swap(x1, x2);
@@ -147,28 +163,47 @@ void SelectionViewController::onSelectionDraged(double x1, double x2, bool compl
 
 void SelectionViewController::selectTrackAudioData(double y)
 {
+    if (!isProjectOpened()) {
+        return;
+    }
+
     const std::vector<TrackId> tracks = determinateTracks(m_startPoint.y(), y);
     selectionController()->setSelectedTrackAudioData(tracks.at(0));
 }
 
-void SelectionViewController::selectClipAudioData(const ClipKey &clipKey)
+void SelectionViewController::selectClipAudioData(const ClipKey& clipKey)
 {
+    if (!isProjectOpened()) {
+        return;
+    }
+
     selectionController()->setSelectedClip(clipKey.key);
 }
 
 void SelectionViewController::resetSelectedClip()
 {
+    if (!isProjectOpened()) {
+        return;
+    }
+
     selectionController()->resetSelectedClip();
 }
 
 void SelectionViewController::resetDataSelection()
 {
+    if (!isProjectOpened()) {
+        return;
+    }
     setSelectionActive(false);
     selectionController()->resetDataSelection();
 }
 
 bool SelectionViewController::isLeftSelection(double x)
 {
+    if (!isProjectOpened()) {
+        return false;
+    }
+
     return m_startPoint.x() > x;
 }
 
@@ -248,6 +283,11 @@ Qt::KeyboardModifiers SelectionViewController::keyboardModifiers() const
     }
 
     return modifiers;
+}
+
+bool SelectionViewController::isProjectOpened() const
+{
+    return globalContext()->currentProject() != nullptr;
 }
 
 TimelineContext* SelectionViewController::timelineContext() const

--- a/src/projectscene/view/clipsview/selectionviewcontroller.h
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.h
@@ -38,7 +38,7 @@ public:
     Q_INVOKABLE void onSelectionDraged(double x, double x2, bool completed);
 
     Q_INVOKABLE void selectTrackAudioData(double y);
-    Q_INVOKABLE void selectClipAudioData(const ClipKey &clipKey);
+    Q_INVOKABLE void selectClipAudioData(const ClipKey& clipKey);
 
     Q_INVOKABLE void resetSelectedClip();
     Q_INVOKABLE void resetDataSelection();
@@ -63,6 +63,8 @@ private:
 
     trackedit::TrackIdList determinateTracks(double y1, double y2) const;
     Qt::KeyboardModifiers keyboardModifiers() const;
+
+    bool isProjectOpened() const;
 
     TimelineContext* m_context = nullptr;
 

--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -32,11 +32,6 @@ PlayCursorController::PlayCursorController(QObject* parent)
 {
 }
 
-au::context::IPlaybackStatePtr PlayCursorController::playbackState() const
-{
-    return globalContext()->playbackState();
-}
-
 void PlayCursorController::init()
 {
     playbackState()->playbackPositionChanged().onReceive(this, [this](muse::secs_t secs) {
@@ -46,8 +41,8 @@ void PlayCursorController::init()
 
 void PlayCursorController::seekToX(double x)
 {
-    IProjectViewStatePtr viewState = globalContext()->currentProject()->viewState();
-    bool snapEnabled = viewState->isSnapEnabled();
+    IProjectViewStatePtr viewState = projectViewState();
+    bool snapEnabled = viewState ? viewState->isSnapEnabled() : false;
 
     double secs = m_context->positionToTime(x, snapEnabled);
     if (muse::RealIsEqualOrMore(secs, 0.0)) {
@@ -55,6 +50,17 @@ void PlayCursorController::seekToX(double x)
     } else if (!muse::RealIsEqual(playbackState()->playbackPosition(), 0.0)) {
         dispatcher()->dispatch("playback_seek", ActionData::make_arg1<double>(0.0));
     }
+}
+
+au::context::IPlaybackStatePtr PlayCursorController::playbackState() const
+{
+    return globalContext()->playbackState();
+}
+
+IProjectViewStatePtr PlayCursorController::projectViewState() const
+{
+    project::IAudacityProjectPtr project = globalContext()->currentProject();
+    return project ? project->viewState() : nullptr;
 }
 
 void PlayCursorController::updatePositionX(muse::secs_t secs)

--- a/src/projectscene/view/playcursor/playcursorcontroller.h
+++ b/src/projectscene/view/playcursor/playcursorcontroller.h
@@ -61,8 +61,8 @@ private slots:
     void onFrameTimeChanged();
 
 private:
-
     context::IPlaybackStatePtr playbackState() const;
+    projectscene::IProjectViewStatePtr projectViewState() const;
 
     void updatePositionX(muse::secs_t secs);
 

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -23,7 +23,7 @@ TimelineContext::TimelineContext(QObject* parent)
 
 void TimelineContext::init(double frameWidth)
 {
-    double initialTimeRange = trackEditProject()->totalTime().to_double() * 2;
+    double initialTimeRange = trackEditProject() ? trackEditProject()->totalTime().to_double() * 2 : 0.0;
     if (muse::is_zero(initialTimeRange)) {
         m_zoom = configuration()->zoom();
     } else {

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -19,6 +19,10 @@ TracksListModel::TracksListModel(QObject* parent)
 
     connect(m_selectionModel, &muse::uicomponents::ItemMultiSelectionModel::selectionChanged,
             [this](const QItemSelection& selected, const QItemSelection& deselected) {
+        if (!isProjectOpened()) {
+            return;
+        }
+
         setItemsSelected(deselected.indexes(), false);
         setItemsSelected(selected.indexes(), true);
 
@@ -443,6 +447,11 @@ void TracksListModel::updateRemovingAvailability()
 {
     QModelIndexList selectedIndexes = m_selectionModel->selectedIndexes();
     setIsRemovingAvailable(!selectedIndexes.empty());
+}
+
+bool TracksListModel::isProjectOpened() const
+{
+    return globalContext()->currentProject() != nullptr;
 }
 
 bool TracksListModel::removeRows(int row, int count, const QModelIndex& parent)

--- a/src/projectscene/view/trackspanel/trackslistmodel.h
+++ b/src/projectscene/view/trackspanel/trackslistmodel.h
@@ -88,6 +88,8 @@ private:
         rItemData = Qt::UserRole + 1
     };
 
+    bool isProjectOpened() const;
+
     bool removeRows(int row, int count, const QModelIndex& parent) override;
 
     void onProjectChanged();

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -135,6 +135,9 @@ void Au3SelectionController::setSelectedTrackAudioData(TrackId trackId)
 {
     auto& tracks = ::TrackList::Get(projectRef());
     ::Track* au3Track = tracks.FindById(::TrackId(trackId));
+    if (!au3Track) {
+        return;
+    }
 
     secs_t audioDataStartTime = au3Track->GetStartTime();
     secs_t audioDataEndTime = au3Track->GetEndTime();
@@ -146,6 +149,9 @@ void Au3SelectionController::setSelectedTrackAudioData(TrackId trackId)
 void Au3SelectionController::setSelectedClipAudioData(trackedit::TrackId trackId, secs_t time)
 {
     const auto& clip = au3::DomAccessor::findWaveClip(projectRef(), trackId, time);
+    if (!clip) {
+        return;
+    }
 
     secs_t audioDataStartTime = clip->Start();
     secs_t audioDataEndTime = clip->End();


### PR DESCRIPTION
Resolves: #7664

also
fixed the crash when opening the project page without a project
fixed the crash when clicking on clips view without an open project
disabled selection interaction if the project is not open