### PR TITLE
fixed #7640: When zooming in, current cursor position is ignored

### DIFF
--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -324,8 +324,8 @@ qreal TimelineContext::findZoomFocusPosition() const
     double result = 0.0;
 
     if (!hasSelection()) {
-        // No selection: zoom at the center of the view
-        result = frameCenterPosition();
+        // No selection: zoom at the current playback position
+        result = timeToPosition(globalContext()->playbackState()->playbackPosition());
     } else {
         // Selection: zoom at the center of the selection
         result = selectionCenterPosition();
@@ -379,7 +379,7 @@ void TimelineContext::updateViewOnProjectTempoChange(double ratio)
     setFrameEndTime(m_frameEndTime / ratio);
 
     dispatcher()->dispatch("playback-seek", muse::actions::ActionData::make_arg1<double>(
-                                                globalContext()->playbackState()->playbackPosition() / ratio));
+                               globalContext()->playbackState()->playbackPosition() / ratio));
 }
 
 void TimelineContext::shiftFrameTimeOnStep(int direction)


### PR DESCRIPTION
Resolves: #7640