### PR TITLE
Switch off waveform drawing when samples view should kick-in

### DIFF
--- a/src/projectscene/view/clipsview/au3/au3wavepainter.cpp
+++ b/src/projectscene/view/clipsview/au3/au3wavepainter.cpp
@@ -543,7 +543,7 @@ void DrawMinMaxRMS(int channelIndex, QPainter& painter,
     waveformPainter.Draw(channelIndex, painter, paintParameters, _metrics);
 }
 
-static bool showIndividualSamples(const Au3WaveClip& clip, bool zoom)
+static bool showIndividualSamples(const Au3WaveClip& clip, double zoom)
 {
     const double sampleRate = clip.GetRate();
     const double stretchRatio = clip.GetStretchRatio();


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/7811
