### PR TITLE
7826 effect on stretched clip fix

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1951,16 +1951,22 @@ void WaveTrack::ApplyPitchAndSpeed(
           interval->first <= interval->second);
    if (GetNumClips() == 0)
       return;
-   const auto startTime =
-      interval ? std::max(SnapToSample(interval->first), GetStartTime()) :
-                 GetStartTime();
-   const auto endTime =
-      interval ? std::min(SnapToSample(interval->second), GetEndTime()) :
-                 GetEndTime();
-   if (startTime >= endTime)
+
+   // If there is no specified interval, we look at all clips in the track.
+   const auto examinedClips =
+      interval ? GetSortedClipsIntersecting(interval->first, interval->second) :
+                 SortedClipArray();
+   if (examinedClips.empty())
       return;
 
-   // Here we assume that left- and right clips are aligned.
+   const auto startTime = examinedClips.front()->GetPlayStartTime();
+   const auto endTime = examinedClips.back()->GetPlayEndTime();
+   if (startTime >= endTime)
+   {
+      assert(false);
+      return;
+   }
+
    if (auto clipAtT0 = GetClipAtTime(startTime);
        clipAtT0 && clipAtT0->SplitsPlayRegion(startTime) &&
        clipAtT0->HasPitchOrSpeed())

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -2958,6 +2958,18 @@ auto WaveTrack::GetClipAtTime(double time) const -> IntervalConstHolder
    return p != clips.rend() ? *p : nullptr;
 }
 
+WaveTrack::IntervalConstHolders
+WaveTrack::GetSortedClipsIntersecting(double t0, double t1) const
+{
+   assert(t0 <= t1);
+   WaveTrack::IntervalConstHolders result;
+   const auto clips = SortedClipArray();
+   std::copy_if(
+      clips.begin(), clips.end(), back_inserter(result),
+      [&](const auto& pClip) { return pClip->IntersectsPlayRegion(t0, t1); });
+   return result;
+}
+
 auto WaveTrack::CreateClip(double offset, const wxString& name,
    const Interval *pToCopy, bool copyCutlines) -> IntervalHolder
 {

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1952,6 +1952,10 @@ void WaveTrack::ApplyPitchAndSpeed(
    if (GetNumClips() == 0)
       return;
 
+   if (interval)
+      interval.emplace(
+         SnapToSample(interval->first), SnapToSample(interval->second));
+
    // If there is no specified interval, we look at all clips in the track.
    const auto examinedClips =
       interval ? GetSortedClipsIntersecting(interval->first, interval->second) :
@@ -1959,8 +1963,14 @@ void WaveTrack::ApplyPitchAndSpeed(
    if (examinedClips.empty())
       return;
 
-   const auto startTime = examinedClips.front()->GetPlayStartTime();
-   const auto endTime = examinedClips.back()->GetPlayEndTime();
+   const auto startTime =
+      interval ?
+         std::max(examinedClips.front()->GetPlayStartTime(), interval->first) :
+         examinedClips.front()->GetPlayStartTime();
+   const auto endTime =
+      interval ?
+         std::min(examinedClips.back()->GetPlayEndTime(), interval->second) :
+         examinedClips.back()->GetPlayEndTime();
    if (startTime >= endTime)
    {
       assert(false);

--- a/libraries/lib-wave-track/WaveTrack.h
+++ b/libraries/lib-wave-track/WaveTrack.h
@@ -567,6 +567,11 @@ public:
     */
    IntervalHolder CopyClip(const Interval &toCopy, bool copyCutlines);
 
+   /*!
+   @pre t0 <= t1
+   */
+   IntervalConstHolders GetSortedClipsIntersecting(double t0, double t1) const;
+
 private:
    void CopyWholeClip(const Interval &clip, double t0, bool forClipboard);
    void CopyPartOfClip(const Interval &clip,

--- a/libraries/lib-wave-track/WaveTrackUtilities.cpp
+++ b/libraries/lib-wave-track/WaveTrackUtilities.cpp
@@ -400,19 +400,6 @@ void WaveTrackUtilities::InspectBlocks(const TrackList &tracks,
    VisitBlocks(const_cast<TrackList &>(tracks), move(inspector), pIDs);
 }
 
-WaveTrack::IntervalConstHolders
-WaveTrackUtilities::GetClipsIntersecting(const WaveTrack &track,
-   double t0, double t1)
-{
-   assert(t0 <= t1);
-   WaveTrack::IntervalConstHolders result;
-   const auto &intervals = track.Intervals();
-   copy_if(intervals.begin(), intervals.end(), back_inserter(result),
-      [&](const auto &pClip){
-         return pClip->IntersectsPlayRegion(t0, t1); });
-   return result;
-}
-
 void WaveTrackUtilities::ExpandClipTillNextOne(
    const WaveTrack& track, WaveTrack::Interval& interval)
 {

--- a/libraries/lib-wave-track/WaveTrackUtilities.h
+++ b/libraries/lib-wave-track/WaveTrackUtilities.h
@@ -181,12 +181,6 @@ WAVE_TRACK_API void VisitBlocks(TrackList &tracks, BlockVisitor visitor,
 WAVE_TRACK_API void InspectBlocks(const TrackList &tracks,
    BlockInspector inspector, SampleBlockIDSet *pIDs = nullptr);
 
-/*!
- @pre t0 <= t1
- */
-WAVE_TRACK_API WaveTrack::IntervalConstHolders
-GetClipsIntersecting(const WaveTrack &track, double t0, double t1);
-
 WAVE_TRACK_API void
 ExpandClipTillNextOne(const WaveTrack& track, WaveTrack::Interval& interval);
 } // namespace WaveTrackUtilities

--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -704,7 +704,7 @@ void OnPaste(const CommandContext &context)
       if(!isSyncLocked && GetEditClipsCanMove())
       {
          //Special case when pasting without sync lock and
-         //"...move other clips" option is 
+         //"...move other clips" option is
          //Also shift all intervals in all other selected tracks that
          //starts after t0
          const auto offset = srcTracks->GetEndTime() - (t1 - t0);
@@ -1106,9 +1106,8 @@ const ReservedCommandFlag
       const auto selectedTracks = TrackList::Get(project).Selected<const WaveTrack>();
       for (const auto track : selectedTracks)
       {
-         const auto selectedClips =
-            WaveTrackUtilities::GetClipsIntersecting(*track,
-               viewInfo.selectedRegion.t0(), viewInfo.selectedRegion.t1());
+         const auto selectedClips = track->GetSortedClipsIntersecting(
+            viewInfo.selectedRegion.t0(), viewInfo.selectedRegion.t1());
          if(selectedClips.size() > 1)
             return true;
       }

--- a/src/menus/SelectMenus.cpp
+++ b/src/menus/SelectMenus.cpp
@@ -16,7 +16,6 @@
 #include "Viewport.h"
 #include "WaveClip.h"
 #include "WaveTrack.h"
-#include "WaveTrackUtilities.h"
 #include "LabelTrack.h"
 #include "CommandContext.h"
 #include "MenuRegistry.h"
@@ -643,13 +642,14 @@ void OnZeroCrossing(const CommandContext &context)
    const auto projectRate = ProjectRate(project).GetRate();
    const auto searchWindowDuration = GetWindowSize(projectRate) / projectRate;
    const auto wouldSearchClipWithPitchOrSpeed =
-      [searchWindowDuration](const WaveTrack& track, double t) {
-         const auto clips = WaveTrackUtilities::GetClipsIntersecting(track,
-            t - searchWindowDuration / 2, t + searchWindowDuration / 2);
-         return any_of(
-            clips.begin(), clips.end(),
-            [](const auto& clip) { return clip->HasPitchOrSpeed(); });
-      };
+      [searchWindowDuration](const WaveTrack& track, double t)
+   {
+      const auto clips = track.GetSortedClipsIntersecting(
+         t - searchWindowDuration / 2, t + searchWindowDuration / 2);
+      return any_of(
+         clips.begin(), clips.end(),
+         [](const auto& clip) { return clip->HasPitchOrSpeed(); });
+   };
    const auto selected = tracks.Selected<const WaveTrack>();
    if (std::any_of(
           selected.begin(), selected.end(), [&](const WaveTrack* track) {

--- a/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveChannelView.cpp
@@ -47,7 +47,6 @@ Paul Licameli split from TrackPanel.cpp
 #include "WaveChannelUtilities.h"
 #include "WaveTrackAffordanceControls.h"
 #include "WaveTrackAffordanceHandle.h"
-#include "WaveTrackUtilities.h"
 #include "WaveClipAdjustBorderHandle.h"
 #include "WaveClipUIUtilities.h"
 
@@ -892,12 +891,13 @@ auto WaveChannelSubView::GetMenuItems(
       auto &track = pChannel->GetTrack();
       const auto &viewInfo = ViewInfo::Get(*pProject);
       const auto t = viewInfo.PositionToTime(pPosition->x, rect.x);
-      if ((track.IsSelected() &&
-         t > viewInfo.selectedRegion.t0() && t < viewInfo.selectedRegion.t1() &&
-         !WaveTrackUtilities::GetClipsIntersecting(track,
-            viewInfo.selectedRegion.t0(), viewInfo.selectedRegion.t1())
-               .empty())
-         ||
+      if (
+         (track.IsSelected() && t > viewInfo.selectedRegion.t0() &&
+          t < viewInfo.selectedRegion.t1() &&
+          !track
+              .GetSortedClipsIntersecting(
+                 viewInfo.selectedRegion.t0(), viewInfo.selectedRegion.t1())
+              .empty()) ||
          WaveChannelUtilities::GetClipAtTime(**track.Channels().begin(), t))
       {
          return WaveClipUIUtilities::GetWaveClipMenuItems();


### PR DESCRIPTION
Resolves: #7826 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] #7826 is resolved
- [x] There is no regression wrt applying an effect on stretched clips (whether whole track is selected, a portion of a clip is selected, a clip is exactly selected, there is a mixture of stretched and unstretched clips, etc.)
