### PR TITLE
Share audio and preferences page use new login dialog

### DIFF
--- a/libraries/lib-cloud-audiocom/ServiceConfig.cpp
+++ b/libraries/lib-cloud-audiocom/ServiceConfig.cpp
@@ -188,13 +188,13 @@ std::string ServiceConfig::GetFinishUploadPage(
         { "button_name", GetButtonName(trace) } });
 }
 
-std::string ServiceConfig::GetAudioURL(
+std::string ServiceConfig::GetAudioPagePath(
    std::string_view userSlug, std::string_view audioSlug,
    AudiocomTrace trace) const
 {
    return Substitute(
-      "{frontend_url}/{user_slug}/audio/{audio_slug}/edit?" MTM_CAMPAIGN,
-      { { "frontend_url", mFrontendURL },
+      "/{user_slug}/audio/{audio_slug}/edit?" MTM_CAMPAIGN,
+      {
         { "user_slug", userSlug },
         { "audio_slug", audioSlug },
         { "version_number", audacity::ToUTF8(AUDACITY_VERSION_STRING) },

--- a/libraries/lib-cloud-audiocom/ServiceConfig.h
+++ b/libraries/lib-cloud-audiocom/ServiceConfig.h
@@ -35,7 +35,7 @@ public:
    std::string GetOAuthClientSecret() const;
    //! OAuth2 redirect URL. Only used to satisfy the protocol
    std::string GetOAuthRedirectURL() const;
-   //! Audio.com authorization API to automatically login current user 
+   //! Audio.com authorization API to automatically login current user
    //  in the default browser when opening the project from audacity
    std::string GetAuthWithRedirectURL() const;
    //! Helper to construct the full URLs for the API
@@ -45,7 +45,7 @@ public:
       std::string_view audioID, std::string_view token,
       AudiocomTrace) const;
    //! Helper to construct the page URL for the authorised upload
-   std::string GetAudioURL(
+   std::string GetAudioPagePath(
       std::string_view userSlug, std::string_view audioSlug,
       AudiocomTrace) const;
    //! Timeout between progress callbacks

--- a/libraries/lib-cloud-audiocom/UploadService.cpp
+++ b/libraries/lib-cloud-audiocom/UploadService.cpp
@@ -24,6 +24,7 @@
 
 #include "OAuthService.h"
 #include "ServiceConfig.h"
+#include "UserService.h"
 
 #include "IResponse.h"
 #include "MultipartData.h"
@@ -268,11 +269,18 @@ struct AudiocomUploadOperation final :
 
       if (mCompletedCallback)
       {
+
+         auto& userService = GetUserService();
+         auto& oauthService = GetOAuthService();
+
+         auto userId = audacity::ToUTF8(userService.GetUserId());
+         auto audioPage = mServiceConfig.GetAudioPagePath(
+                                      mUserName, mAudioSlug, mAudiocomTrace);
+
          const auto uploadURL = mAuthToken.empty() ?
                                    mServiceConfig.GetFinishUploadPage(
                                       mAudioID, mUploadToken, mAudiocomTrace) :
-                                   mServiceConfig.GetAudioURL(
-                                      mUserName, mAudioSlug, mAudiocomTrace);
+                                   oauthService.MakeAudioComAuthorizeURL(userId, audioPage);
 
          mCompletedCallback(
             { UploadOperationCompleted::Result::Success,

--- a/modules/sharing/mod-cloud-audiocom/ui/AudioComPrefsPanel.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/AudioComPrefsPanel.cpp
@@ -82,7 +82,7 @@ public:
             S.SetBorder(8);
             S.AddWindow(
                safenew UserPanel { GetServiceConfig(), GetOAuthService(),
-                                   GetUserService(), UserPanel::LinkMode::Link,
+                                   GetUserService(), true,
                                    AudiocomTrace::PrefsPanel, S.GetParent() },
                wxEXPAND);
          }

--- a/modules/sharing/mod-cloud-audiocom/ui/UserPanel.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/UserPanel.h
@@ -35,17 +35,9 @@ class UserPanel final
    , public Observer::Publisher<UserPanelStateChangedMessage>
 {
 public:
-
-   // TODO this will use different text depending on user panel location,
-   // due to discrepancies in cloud login flow, to be unified
-   enum class LinkMode {
-      Link,
-      SignIn,
-   };
-
    UserPanel(
       const ServiceConfig& serviceConfig, OAuthService& authService,
-      UserService& userService, LinkMode linkMode, AudiocomTrace,
+      UserService& userService, bool linkButtonVisible, AudiocomTrace,
       wxWindow* parent = nullptr, const wxPoint& pos = wxDefaultPosition,
       const wxSize& size = wxDefaultSize);
 
@@ -71,7 +63,7 @@ private:
    Observer::Subscription mUserDataChangedSubscription;
 
    bool mIsAuthorized { false };
-   const LinkMode mLinkMode;
+   const bool mLinkButtonVisible;
 }; // class UserPanel
 
 } // namespace audacity::cloud::audiocom

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/CloudProjectPropertiesDialog.cpp
@@ -34,11 +34,9 @@ CloudProjectPropertiesDialog::CloudProjectPropertiesDialog(
    AudiocomTrace trace)
     : wxDialogWrapper { parent, wxID_ANY, XO("Save to audio.com") }
 {
-   GetAuthorizationHandler().PushSuppressDialogs();
-
    mUserPanel =
       new UserPanel(serviceConfig, authService, userService,
-                    UserPanel::LinkMode::SignIn, trace, this);
+                    false, trace, this);
 
    mProjectName = new wxTextCtrl { this,          wxID_ANY,
                                    projectName,   wxDefaultPosition,

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/ShareAudioDialog.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/ShareAudioDialog.h
@@ -72,15 +72,11 @@ private:
       wxWindow* root { nullptr };
 
       UserPanel* userPanel { nullptr };
-      wxPanel* anonInfoPanel { nullptr };
-      wxPanel* authorizedInfoPanel { nullptr };
       wxTextCtrl* trackTitle { nullptr };
 
       Observer::Subscription mUserDataChangedSubscription;
 
       void PopulateInitialStatePanel(ShuttleGui& s);
-
-      void UpdateUserData(bool authorized);
 
       wxString GetTrackTitle() const;
       bool HasValidTitle() const;
@@ -123,7 +119,6 @@ private:
 
    std::function<void()> mContinueAction;
 
-   bool mIsAuthorised { false };
    bool mInProgress { false };
 };
 } // namespace audacity::cloud::audiocom


### PR DESCRIPTION
Resolves: #7828

Use new login dialog in Share Audio and Preferences

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
