### PR TITLE
7801 effect on discontinuous selection

### DIFF
--- a/au3/libraries/lib-builtin-effects/Generator.cpp
+++ b/au3/libraries/lib-builtin-effects/Generator.cpp
@@ -23,7 +23,7 @@
 
 #include "TimeWarper.h"
 
-bool Generator::Process(EffectInstance &, EffectSettings &settings)
+bool Generator::Process(EffectInstance &, EffectSettings &settings, std::vector<int64_t> /* whichClips */)
 {
    const auto duration = settings.extra.GetDuration();
 

--- a/au3/libraries/lib-builtin-effects/Generator.h
+++ b/au3/libraries/lib-builtin-effects/Generator.h
@@ -40,7 +40,9 @@ protected:
    // Postcondition:
    // If mDuration was valid (>= 0), then the tracks are replaced by the
    // generated results and true is returned. Otherwise, return false.
-   bool Process(EffectInstance &instance, EffectSettings &settings) override;
+   bool Process(
+      EffectInstance& instance, EffectSettings& settings,
+      std::vector<int64_t> whichClips) override;
 };
 
 #endif

--- a/au3/libraries/lib-effects/EffectOutputTracks.h
+++ b/au3/libraries/lib-effects/EffectOutputTracks.h
@@ -49,7 +49,8 @@ public:
    EffectOutputTracks(
       TrackList& tracks, EffectType effectType,
       std::optional<TimeInterval> effectTimeInterval,
-      bool allSyncLockSelected = false, bool stretchSyncLocked = false);
+      bool allSyncLockSelected = false, bool stretchSyncLocked = false,
+      std::vector<int64_t>* oldClipIds = nullptr);
    EffectOutputTracks(const EffectOutputTracks&) = delete;
 
    ~EffectOutputTracks();

--- a/au3/libraries/lib-effects/EffectPlugin.h
+++ b/au3/libraries/lib-effects/EffectPlugin.h
@@ -106,7 +106,7 @@ public:
    /*!
     @return success
     */
-   virtual bool Process(EffectSettings &settings) = 0;
+   virtual bool Process(EffectSettings &settings, std::vector<int64_t> whichClips = {}) = 0;
 
    ~EffectInstanceEx() override;
 };

--- a/au3/libraries/lib-effects/PerTrackEffect.h
+++ b/au3/libraries/lib-effects/PerTrackEffect.h
@@ -46,9 +46,9 @@ public:
          : mProcessor{ processor }
       {}
       ~Instance() override;
-   
+
       //! Uses the other virtual functions of this class
-      bool Process(EffectSettings &settings) final;
+      bool Process(EffectSettings &settings, std::vector<int64_t> whichClips) final;
 
       bool ProcessInitialize(EffectSettings &settings,
          double sampleRate, ChannelNames chanMap) override;
@@ -64,7 +64,7 @@ protected:
    /* virtual */ bool DoPass2() const;
 
    // non-virtual
-   bool Process(EffectInstance &instance, EffectSettings &settings) const;
+   bool Process(EffectInstance &instance, EffectSettings &settings, std::vector<int64_t> whichClips) const;
 
    sampleCount    mSampleCnt{};
 
@@ -78,7 +78,7 @@ private:
    using Buffers = AudioGraph::Buffers;
 
    bool ProcessPass(TrackList &outputs,
-      Instance &instance, EffectSettings &settings);
+      Instance &instance, EffectSettings &settings, const std::vector<int64_t>& whichClips);
    using Factory = std::function<std::shared_ptr<EffectInstance>()>;
    /*!
     Previous contents of inBuffers and outBuffers are ignored
@@ -91,12 +91,12 @@ private:
 
     @pre `channel < track.NChannels()`
     */
-   static bool ProcessTrack(int channel,
-      const Factory &factory, EffectSettings &settings,
-      AudioGraph::Source &source, AudioGraph::Sink &sink,
-      std::optional<sampleCount> genLength,
-      double sampleRate, const SampleTrack &wt,
-      Buffers &inBuffers, Buffers &outBuffers);
+   static bool ProcessTrack(
+      int channel, const Factory& factory, EffectSettings& settings,
+      AudioGraph::Source& source, AudioGraph::Sink& sink,
+      std::optional<sampleCount> genLength, double sampleRate,
+      const SampleTrack& wt, Buffers& inBuffers, Buffers& outBuffers,
+      const std::vector<int64_t>& whichClips);
 
    // TODO: put this in struct EffectContext? (Which doesn't exist yet)
    mutable std::shared_ptr<EffectOutputTracks> mpOutputTracks;

--- a/au3/libraries/lib-effects/StatefulEffect.cpp
+++ b/au3/libraries/lib-effects/StatefulEffect.cpp
@@ -14,9 +14,9 @@
 #include "StatefulEffect.h"
 #include "SampleCount.h"
 
-bool StatefulEffect::Instance::Process(EffectSettings &settings)
+bool StatefulEffect::Instance::Process(EffectSettings &settings, std::vector<int64_t> whichClips)
 {
-   return GetEffect().Process(*this, settings);
+   return GetEffect().Process(*this, settings, std::move(whichClips));
 }
 
 auto StatefulEffect::Instance::GetLatency(const EffectSettings &, double) const

--- a/au3/libraries/lib-effects/StatefulEffect.h
+++ b/au3/libraries/lib-effects/StatefulEffect.h
@@ -25,7 +25,7 @@ public:
    class EFFECTS_API Instance : public StatefulEffectBase::Instance {
    public:
       using StatefulEffectBase::Instance::Instance;
-      bool Process(EffectSettings &settings) override;
+      bool Process(EffectSettings &settings, std::vector<int64_t> whichClips) override;
       SampleCount GetLatency(
          const EffectSettings &settings, double sampleRate) const override;
       //! Default implementation fails (returns 0 always)

--- a/au3/libraries/lib-effects/StatefulEffectBase.h
+++ b/au3/libraries/lib-effects/StatefulEffectBase.h
@@ -32,7 +32,7 @@ public:
 
       size_t GetBlockSize() const override;
       size_t SetBlockSize(size_t maxBlockSize) override;
-   
+
       bool RealtimeInitialize(EffectSettings &settings, double sampleRate)
          override;
       bool RealtimeAddProcessor(EffectSettings &settings,
@@ -51,7 +51,7 @@ public:
       unsigned GetAudioOutCount() const override;
 
       bool NeedsDither() const override;
-      
+
       bool ProcessInitialize(EffectSettings &settings,
          double sampleRate, ChannelNames chanMap) override;
 
@@ -71,7 +71,7 @@ public:
    /*!
     @copydoc EffectInstance::Process
     */
-   virtual bool Process(EffectInstance &instance, EffectSettings &settings) = 0;
+   virtual bool Process(EffectInstance &instance, EffectSettings &settings, std::vector<int64_t> whichClips) = 0;
 
    /*!
      @copydoc StatefulEffectBase::Instance::RealtimeInitialize()

--- a/au3/libraries/lib-effects/StatefulPerTrackEffect.cpp
+++ b/au3/libraries/lib-effects/StatefulPerTrackEffect.cpp
@@ -51,10 +51,10 @@ std::shared_ptr<EffectInstance> StatefulPerTrackEffect::MakeInstance() const
 }
 
 bool StatefulPerTrackEffect::Process(
-   EffectInstance &instance, EffectSettings &settings)
+   EffectInstance &instance, EffectSettings &settings, std::vector<int64_t> whichClips)
 {
    // Call through to a non-virtual function
-   return PerTrackEffect::Process(instance, settings);
+   return PerTrackEffect::Process(instance, settings, std::move(whichClips));
 }
 
 size_t StatefulPerTrackEffect::SetBlockSize(size_t maxBlockSize)

--- a/au3/libraries/lib-effects/StatefulPerTrackEffect.h
+++ b/au3/libraries/lib-effects/StatefulPerTrackEffect.h
@@ -78,7 +78,7 @@ public:
       const float *const *inBlock, float *const *outBlock, size_t blockLen) = 0;
 
 private:
-   bool Process(EffectInstance &instance, EffectSettings &settings) final;
+   bool Process(EffectInstance &instance, EffectSettings &settings, std::vector<int64_t> whichClips) final;
 
    size_t mBlockSize{};
 };

--- a/au3/libraries/lib-mixer/EffectStage.cpp
+++ b/au3/libraries/lib-mixer/EffectStage.cpp
@@ -59,7 +59,8 @@ std::vector<std::shared_ptr<EffectInstance>> MakeInstances(
 EffectStage::EffectStage(
    CreateToken, int channel, int nInputChannels, Source& upstream,
    Buffers& inBuffers, const Factory& factory, EffectSettings& settings,
-   double sampleRate, std::optional<sampleCount> genLength)
+   double sampleRate, std::optional<sampleCount> genLength,
+   const std::vector<int64_t>& whichClips)
     : mUpstream { upstream }
     , mInBuffers { inBuffers }
     , mInstances { MakeInstances(
@@ -68,6 +69,7 @@ EffectStage::EffectStage(
     , mSampleRate { sampleRate }
     , mIsProcessor { !genLength.has_value() }
     , mDelayRemaining { genLength ? *genLength : sampleCount::max() }
+    , mWhichClips { whichClips }
 {
    assert(upstream.AcceptsBlockSize(inBuffers.BlockSize()));
    assert(this->AcceptsBlockSize(inBuffers.BlockSize()));
@@ -79,12 +81,13 @@ EffectStage::EffectStage(
 auto EffectStage::Create(
    int channel, int nInputChannels, Source& upstream, Buffers& inBuffers,
    const Factory& factory, EffectSettings& settings, double sampleRate,
-   std::optional<sampleCount> genLength) -> std::unique_ptr<EffectStage>
+   std::optional<sampleCount> genLength, std::vector<int64_t> whichClips)
+   -> std::unique_ptr<EffectStage>
 {
    try {
       return std::make_unique<EffectStage>(
          CreateToken {}, channel, nInputChannels, upstream, inBuffers, factory,
-         settings, sampleRate, genLength);
+         settings, sampleRate, genLength, std::move(whichClips));
    }
    catch (const std::exception &) {
       return nullptr;

--- a/au3/libraries/lib-mixer/EffectStage.h
+++ b/au3/libraries/lib-mixer/EffectStage.h
@@ -44,13 +44,15 @@ public:
    EffectStage(
       CreateToken, int channel, int nInputChannels, Source& upstream,
       Buffers& inBuffers, const Factory& factory, EffectSettings& settings,
-      double sampleRate, std::optional<sampleCount> genLength);
+      double sampleRate, std::optional<sampleCount> genLength,
+      const std::vector<int64_t>& whichClips);
 
    //! Satisfies postcondition of constructor or returns null
    static std::unique_ptr<EffectStage> Create(
       int channel, int nInputChannels, Source& upstream, Buffers& inBuffers,
       const Factory& factory, EffectSettings& settings, double sampleRate,
-      std::optional<sampleCount> genLength);
+      std::optional<sampleCount> genLength,
+      std::vector<int64_t> whichClips = {});
 
    EffectStage(const EffectStage&) = delete;
    EffectStage &operator =(const EffectStage &) = delete;
@@ -98,6 +100,7 @@ private:
    size_t mLastZeroes{};
    bool mLatencyDone{ false };
    bool mCleared{ false };
+   const std::vector<int64_t> mWhichClips;
 };
 
 /*

--- a/au3/libraries/lib-mixer/MixerSource.cpp
+++ b/au3/libraries/lib-mixer/MixerSource.cpp
@@ -129,8 +129,9 @@ size_t MixerSource::MixVariableRates(
                dst.push_back(queue.data() + queueLen);
             constexpr auto iChannel = 0u;
             if (!mpSeq->GetFloats(
-                   iChannel, nChannels, dst.data(), pos, getLen, backwards,
-                   FillFormat::fillZero, mMayThrow)) {
+                   iChannel, nChannels, dst.data(), pos, getLen, nullptr,
+                   backwards, FillFormat::fillZero, mMayThrow))
+            {
                // Now redundant in case of failure
                // for (size_t iChannel = 0; iChannel < nChannels; ++iChannel)
                   // memset(dst[i], 0, sizeof(float) * getLen);
@@ -251,13 +252,12 @@ size_t MixerSource::MixSameRate(unsigned nChannels, const size_t maxOut,
 
    constexpr auto iChannel = 0u;
    if (!mpSeq->GetFloats(
-      iChannel, nChannels, floatBuffers, pos, slen, backwards,
-      FillFormat::fillZero, mMayThrow)
-   ) {
+          iChannel, nChannels, floatBuffers, pos, slen, nullptr, backwards,
+          FillFormat::fillZero, mMayThrow))
+   {
       // Now redundant in case of failure
       // for (size_t iChannel = 0; iChannel < nChannels; ++iChannel)
          // memset(floatBuffers[iChannel], 0, sizeof(float) * slen);
-      
    }
 
    mpSeq->GetEnvelopeValues(mEnvValues.data(), slen, t, backwards);

--- a/au3/libraries/lib-mixer/WideSampleSequence.cpp
+++ b/au3/libraries/lib-mixer/WideSampleSequence.cpp
@@ -27,17 +27,17 @@ double WideSampleSequence::SnapToSample(double t) const
    return LongSamplesToTime(TimeToLongSamples(t));
 }
 
-bool WideSampleSequence::GetFloats(size_t iChannel, size_t nBuffers,
-   float *const buffers[], sampleCount start, size_t len,
-   bool backwards, fillFormat fill,
-   bool mayThrow, sampleCount* pNumWithinClips) const
+bool WideSampleSequence::GetFloats(
+   size_t iChannel, size_t nBuffers, float* const buffers[], sampleCount start,
+   size_t len, const std::vector<int64_t>* whichClips, bool backwards,
+   fillFormat fill, bool mayThrow, sampleCount* pNumWithinClips) const
 {
    // Cast the pointers to pass them to DoGet() which handles multiple
    // destination formats
    const auto castBuffers = reinterpret_cast<const samplePtr*>(buffers);
    const auto result = DoGet(
-      iChannel, nBuffers, castBuffers,
-      floatSample, start, len, backwards, fill, mayThrow, pNumWithinClips);
+      iChannel, nBuffers, castBuffers, floatSample, start, len, whichClips,
+      backwards, fill, mayThrow, pNumWithinClips);
    if (!result)
       while (nBuffers--)
          ClearSamples(castBuffers[nBuffers], floatSample, 0, len);

--- a/au3/libraries/lib-mixer/WideSampleSequence.h
+++ b/au3/libraries/lib-mixer/WideSampleSequence.h
@@ -43,6 +43,8 @@ public:
     @param buffers receive the samples
     @param start starting sample, relative to absolute time zero
     @param len how many samples to get.  buffers are assumed sufficiently large
+    @param whichClips if not null, clips whose IDs are in this vector shall be
+    omitted from the fetch
     @param fill how to assign values for sample positions between clips
     @param mayThrow if false, fill buffer with zeros when there is failure to
        retrieve samples; else throw
@@ -55,10 +57,12 @@ public:
        retrieved
     @post if return value is false, buffers are zero-filled
     */
-   bool GetFloats(size_t iChannel, size_t nBuffers,
-      float *const buffers[], sampleCount start, size_t len,
-      bool backwards = false, fillFormat fill = FillFormat::fillZero,
-      bool mayThrow = true, sampleCount* pNumWithinClips = nullptr) const;
+   bool GetFloats(
+      size_t iChannel, size_t nBuffers, float* const buffers[],
+      sampleCount start, size_t len,
+      const std::vector<int64_t>* whichClips = nullptr, bool backwards = false,
+      fillFormat fill = FillFormat::fillZero, bool mayThrow = true,
+      sampleCount* pNumWithinClips = nullptr) const;
 
    //! Retrieve samples of one of the channels from a sequence in a specified
    //! format
@@ -70,7 +74,8 @@ public:
     */
    virtual bool DoGet(
       size_t iChannel, size_t nBuffers, const samplePtr buffers[],
-      sampleFormat format, sampleCount start, size_t len, bool backward,
+      sampleFormat format, sampleCount start, size_t len,
+      const std::vector<int64_t>* whichClips, bool backward,
       fillFormat fill = FillFormat::fillZero, bool mayThrow = true,
       // Report how many samples were copied from within clips, rather than
       // filled according to fillFormat; but these were not necessarily one

--- a/au3/libraries/lib-mixer/WideSampleSource.cpp
+++ b/au3/libraries/lib-mixer/WideSampleSource.cpp
@@ -22,10 +22,15 @@
 #include "WideSampleSequence.h"
 #include <cassert>
 
-WideSampleSource::WideSampleSource(const WideSampleSequence &sequence,
-   size_t nChannels, sampleCount start, sampleCount len, Poller pollUser
-)  : mSequence{ sequence }, mnChannels{ nChannels }, mPollUser{ move(pollUser) }
-   , mPos{ start }, mOutputRemaining{ len  }
+WideSampleSource::WideSampleSource(
+   const WideSampleSequence& sequence, size_t nChannels, sampleCount start,
+   sampleCount len, Poller pollUser, std::vector<int64_t> whichClips)
+    : mSequence { sequence }
+    , mnChannels { nChannels }
+    , mPollUser { move(pollUser) }
+    , mPos { start }
+    , mOutputRemaining { len }
+    , mWhichClips { move(whichClips) }
 {
    assert(nChannels <= sequence.NChannels());
 }
@@ -69,7 +74,9 @@ std::optional<size_t> WideSampleSource::Acquire(Buffers &data, size_t bound)
          buffers[0] = &data.GetWritePosition(0) + mFetched;
       if (mnChannels > 1)
          buffers[1] = &data.GetWritePosition(1) + mFetched;
-      mSequence.GetFloats(0, mnChannels, buffers, mPos, fetch);
+      mSequence.GetFloats(
+         0, mnChannels, buffers, mPos, fetch,
+         mWhichClips.empty() ? nullptr : &mWhichClips);
       mPos += fetch;
       mFetched += fetch;
       mInitialized = true;

--- a/au3/libraries/lib-mixer/WideSampleSource.h
+++ b/au3/libraries/lib-mixer/WideSampleSource.h
@@ -30,8 +30,9 @@ public:
     @pre `nChannels <= sequence.NChannels()`
     @post `Remaining()` == len
     */
-   WideSampleSource(const WideSampleSequence &sequence, size_t nChannels,
-      sampleCount start, sampleCount len, Poller pollUser);
+   WideSampleSource(
+      const WideSampleSequence& sequence, size_t nChannels, sampleCount start,
+      sampleCount len, Poller pollUser, std::vector<int64_t> whichClips);
    ~WideSampleSource() override;
 
    //! If constructed with positive length, then accepts buffers only when
@@ -55,5 +56,6 @@ private:
    size_t mLastProduced{};
    size_t mFetched{};
    bool mInitialized{ false };
+   const std::vector<int64_t> mWhichClips;
 };
 #endif

--- a/au3/libraries/lib-stretching-sequence/StretchingSequence.cpp
+++ b/au3/libraries/lib-stretching-sequence/StretchingSequence.cpp
@@ -96,8 +96,11 @@ float StretchingSequence::GetChannelVolume(int channel) const
 
 bool StretchingSequence::DoGet(
    size_t iChannel, size_t nBuffers, const samplePtr buffers[],
-   sampleFormat format, sampleCount start, size_t len, bool backwards,
-   fillFormat fill, bool mayThrow, sampleCount* pNumWithinClips) const
+   sampleFormat format, sampleCount start, size_t len,
+   const std::vector<
+      int64_t>* /* whichClips not (yet) used for playback or rendering*/,
+   bool backwards, fillFormat fill, bool mayThrow,
+   sampleCount* pNumWithinClips) const
 {
    return const_cast<StretchingSequence&>(*this).MutableGet(
       iChannel, nBuffers, buffers, format, start, len, backwards);
@@ -165,7 +168,7 @@ bool StretchingSequence::GetFloats(
    constexpr auto iChannel = 0u;
    return DoGet(
       iChannel, nChannels, charBuffers.data(), sampleFormat::floatSample, start,
-      len, backwards);
+      len, nullptr, backwards);
 }
 
 bool StretchingSequence::MutableGet(

--- a/au3/libraries/lib-stretching-sequence/StretchingSequence.h
+++ b/au3/libraries/lib-stretching-sequence/StretchingSequence.h
@@ -47,7 +47,8 @@ public:
       bool backwards) const override;
    bool DoGet(
       size_t iChannel, size_t nBuffers, const samplePtr buffers[],
-      sampleFormat format, sampleCount start, size_t len, bool backwards,
+      sampleFormat format, sampleCount start, size_t len,
+      const std::vector<int64_t>* whichClips, bool backwards,
       fillFormat fill = FillFormat::fillZero, bool mayThrow = true,
       sampleCount* pNumWithinClips = nullptr) const override;
 

--- a/au3/libraries/lib-wave-track/WaveTrackSink.h
+++ b/au3/libraries/lib-wave-track/WaveTrackSink.h
@@ -26,10 +26,11 @@ class TrackList;
 
 class WAVE_TRACK_API WaveTrackSink final : public AudioGraph::Sink {
 public:
-   WaveTrackSink(WaveChannel &left, WaveChannel *pRight,
-      WaveTrack *pGenerated, sampleCount start, bool isProcessor,
+   WaveTrackSink(
+      WaveChannel& left, WaveChannel* pRight, WaveTrack* pGenerated,
+      sampleCount start, bool isProcessor,
       //! This argument affects processors only, not generators
-      sampleFormat effectiveFormat);
+      sampleFormat effectiveFormat, const std::vector<int64_t>& whichClips);
    ~WaveTrackSink() override;
 
    //! Accepts buffers only if there is at least one channel
@@ -63,5 +64,6 @@ private:
 
    sampleCount mOutPos;
    bool mOk{ true };
+   const std::vector<int64_t> mWhichClips;
 };
 #endif

--- a/src/effects/effects_base/ieffectsprovider.h
+++ b/src/effects/effects_base/ieffectsprovider.h
@@ -12,6 +12,7 @@
 #include "au3wrap/au3types.h"
 
 #include "effectstypes.h"
+#include "trackedit/trackedittypes.h"
 
 struct EffectSettings;
 namespace au::effects {
@@ -34,7 +35,7 @@ public:
     virtual muse::Ret showEffect(const muse::String& type, const EffectInstanceId& instanceId) = 0;
 
     virtual muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
-                                    EffectSettings& settings) = 0;
+                                    EffectSettings& settings, const trackedit::ClipKeyList& selectedClips) = 0;
 
     virtual muse::Ret previewEffect(au3::Au3Project& project, Effect* effect, EffectSettings& settings) = 0;
 };

--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -111,8 +111,7 @@ muse::Ret EffectExecutionScenario::doPerformEffect(au3::Au3Project& project, con
         }
 
         //! NOTE Step 1.3 - check selection
-        trackedit::ClipKeyList selectedClips = selectionController()->selectedClips();
-        if (selectedClips.size() == 1) {
+        if (!selectionController()->selectedClips().empty()) {
             t0 = selectionController()->selectedClipStartTime();
             t1 = selectionController()->selectedClipEndTime();
         } else {
@@ -259,7 +258,7 @@ muse::Ret EffectExecutionScenario::doPerformEffect(au3::Au3Project& project, con
     // common things used below
     Ret success;
     {
-        success = effectsProvider()->performEffect(project, effect, pInstanceEx, *settings);
+        success = effectsProvider()->performEffect(project, effect, pInstanceEx, *settings, selectionController()->selectedClips());
     }
 
     //! ============================================================================

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -133,7 +133,7 @@ muse::Ret EffectsProvider::showEffect(const muse::String& type, const EffectInst
 }
 
 muse::Ret EffectsProvider::performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> pInstanceEx,
-                                         EffectSettings& settings)
+                                         EffectSettings& settings, const trackedit::ClipKeyList& selectedClips)
 {
     //! ============================================================================
     //! NOTE Step 1 - add new a track if need
@@ -183,7 +183,11 @@ muse::Ret EffectsProvider::performEffect(au3::Au3Project& project, Effect* effec
 
             assert(pInstanceEx); // null check above
             try {
-                if (pInstanceEx->Process(settings) == false) {
+                std::vector<int64_t> selectedClipIds(selectedClips.size());
+                std::transform(selectedClips.begin(), selectedClips.end(), selectedClipIds.begin(), [](const auto& clipKey) {
+                    return clipKey.clipId;
+                });
+                if (pInstanceEx->Process(settings, std::move(selectedClipIds)) == false) {
                     // It failed but we don't know why.
                     success = make_ret(Err::EffectProcessFailed);
                 }

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -42,7 +42,7 @@ public:
     muse::Ret showEffect(const muse::String& type, const EffectInstanceId& instanceId) override;
 
     muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
-                            EffectSettings& settings) override;
+                            EffectSettings& settings, const trackedit::ClipKeyList& selectedClips) override;
 
     muse::Ret previewEffect(au3::Au3Project& project, Effect* effect, EffectSettings& settings) override;
 

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -60,6 +60,7 @@ public:
 
 private:
     void updateSelectionController();
+    std::vector<std::shared_ptr<const WaveClip> > selectedWaveClips() const;
 
     au3::Au3Project& projectRef() const;
     Observer::Subscription m_tracksSubc;


### PR DESCRIPTION
Resolves: #7801

For a list of requirements of this feature (which may provide a rationale to the chosen changes), please refer to the QA list below.

There are three commits to this PR:
1. An AU3 capability extension whereby which clips should be read from or written to can be specified. (@kryksyh this one is for you)
2. A change in AU4 which changes the behavior of `selectedClipStartTime()` and `selectedClipEndTime()`: now it returns start of earliest selected clips / end of last-ending selected clip. This change should not affect the places where this method was used before, but @grliszas14 please double-check.
3. A change in the effect provider API and implementation to communicate the list of selected clips. @igorkorsukov I could also have injected the selection controller into the effects provider, not sure which approach is generally preferred, please let me know.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] Applying effects with time selection (as opposed to clip selection) works as before
- [ ] Whether selecting contiguous clips or using a time selection over the same clips should yield the same result
- [ ] In the case of discontinuous selection, clips _between_ should _not influence the effect_. It should behave as though there were no clips (i.e., silence) in between. For instance, in the situation of clip sequence A, B, C, with A and C being selected, B should not _leak_ into C (even if the effect has a long tail, e.g. a strong reverb). (Please approach me for clarification if needed.)
- [ ] Effect preview should work like before
- [ ] After selecting clips and applying an effect, clips are deselected and a time selection appears instead. Please check that this is not a regression. (Should be addressed at some stage, but not in this PR if it isn't below.)
- [ ] Works also when selected clips are on different tracks