### PR TITLE
EffectOutputTracks copies clip IDs when duplicating

### DIFF
--- a/au3/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/au3/libraries/lib-effects/EffectOutputTracks.cpp
@@ -11,6 +11,7 @@
 #include "BasicUI.h"
 #include "SyncLock.h"
 #include "UserException.h"
+#include "WaveClip.h"
 #include "WaveTrack.h"
 #include "TimeStretching.h"
 
@@ -41,6 +42,19 @@ EffectOutputTracks::EffectOutputTracks(
 
    for (auto aTrack : trackRange) {
       auto pTrack = aTrack->Duplicate();
+      if (auto aWaveTrack = dynamic_cast<WaveTrack*>(aTrack))
+      {
+         auto pWaveTrack = dynamic_cast<WaveTrack*>(pTrack.get());
+         for (auto i = 0; i < aWaveTrack->GetNumClips(); ++i)
+         {
+            auto aClip = aWaveTrack->GetClip(i);
+            auto pClip = pWaveTrack->GetClip(i);
+            if (aClip && pClip)
+               pClip->SetId(aClip->GetId());
+            else
+               assert(false);
+         }
+      }
       mIMap.push_back(aTrack);
       mOMap.push_back(pTrack.get());
       mOutputTracks->Add(pTrack);

--- a/au3/libraries/lib-wave-track/WaveClip.cpp
+++ b/au3/libraries/lib-wave-track/WaveClip.cpp
@@ -357,6 +357,11 @@ int64_t WaveClip::GetId() const
     return mId;
 }
 
+void WaveClip::SetId(int64_t id)
+{
+   mId = id;
+}
+
 double WaveClip::Start() const
 {
    return GetPlayStartTime();

--- a/au3/libraries/lib-wave-track/WaveClip.h
+++ b/au3/libraries/lib-wave-track/WaveClip.h
@@ -339,6 +339,7 @@ public:
    virtual ~WaveClip();
 
    int64_t GetId() const;
+   void SetId(int64_t id);
 
    // Satisfying WideChannelGroupInterval
    double Start() const override;
@@ -895,7 +896,7 @@ public:
     @pre `GetSampleFormats() == other.GetSampleFormats()`
     @pre `GetSampleBlockFactory() == other.GetSampleBlockFactory()`
     @pre `!mustAlign || GetNumSamples() == other.GetNumSamples()`
-    
+
     @post `!mustAlign || StrongInvariant()`
     */
    void MakeStereo(WaveClip &&other, bool mustAlign);


### PR DESCRIPTION
Resolves: #7799

Addresses the case of EffectOutputTracks, where, when duplicating the original track, the clip IDs should match the original.
Problem discussed internally [here](https://mu--se.slack.com/archives/C06RX437GJV/p1731925325477879).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
