### PR TITLE
Return empty selection when no tracks are selected

### DIFF
--- a/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -223,11 +223,11 @@ TrackIdList SelectionViewController::determinateTracks(double y1, double y2) con
 {
     IProjectViewStatePtr vs = viewState();
     if (!vs) {
-        return { -1, -1 };
+        return {};
     }
 
     if (y1 < 0 && y2 < 0) {
-        return { -1, -1 };
+        return {};
     }
 
     if (y1 > y2) {
@@ -240,7 +240,7 @@ TrackIdList SelectionViewController::determinateTracks(double y1, double y2) con
 
     TrackIdList tracks = trackIdList();
     if (tracks.empty()) {
-        return { -1, -1 };
+        return {};
     }
 
     TrackIdList ret;


### PR DESCRIPTION
determinateTracks should return a list of selected tracks, not a selection range

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
