### PR TITLE
Use deep copy for realtime effect states when cloning a ReatimeEffectList

### DIFF
--- a/libraries/lib-realtime-effects/RealtimeEffectList.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.cpp
@@ -23,7 +23,11 @@ RealtimeEffectList::~RealtimeEffectList()
 
 std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
 {
-   return Duplicate();
+   auto result = std::make_unique<RealtimeEffectList>();
+   for (auto &pState : mStates)
+      result->mStates.push_back(pState->Clone());
+   result->SetActive(this->IsActive());
+   return result;
 }
 
 // Deep copy of states

--- a/libraries/lib-realtime-effects/RealtimeEffectState.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectState.cpp
@@ -324,6 +324,14 @@ RealtimeEffectState::~RealtimeEffectState()
 
 }
 
+std::shared_ptr<RealtimeEffectState> RealtimeEffectState::Clone() const
+{
+   auto pNewState{RealtimeEffectState::make_shared(GetID())};
+   pNewState->mPlugin = mPlugin;
+   pNewState->mMainSettings.Set(mMainSettings);
+   return pNewState;
+}
+
 void RealtimeEffectState::SetID(const PluginID & id)
 {
    bool empty = id.empty();

--- a/libraries/lib-realtime-effects/RealtimeEffectState.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectState.h
@@ -46,6 +46,9 @@ public:
    RealtimeEffectState &operator =(const RealtimeEffectState &other) = delete;
    ~RealtimeEffectState();
 
+   //! Create a deep copy of the effect state
+   std::shared_ptr<RealtimeEffectState> Clone() const;
+
    //! May be called with nonempty id at most once in the lifetime of a state
    /*!
     Call with empty id is ignored.

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -495,8 +495,17 @@ namespace
                mEffectState->SetActive(mEnableButton->IsDown());
                if (mProject)
                {
-                  ProjectHistory::Get(*mProject).ModifyState(false);
-                  UndoManager::Get(*mProject).MarkUnsaved();
+                  auto const effectName{GetEffectName(*mEffectState)};
+                  ProjectHistory::Get(*mProject).PushState(
+                     /*! i18n-hint: undo history record
+                     first parameter - realtime effect name
+                     */
+                     XO("Change settings for effect %s").Format(effectName),
+                     /*! i18n-hint: undo history record
+                     first parameter - realtime effect name
+                     */
+                     XO("Change effect %s").Format(effectName),
+                     UndoPush::CONSOLIDATE);
                }
             }
          });

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -500,11 +500,11 @@ namespace
                      /*! i18n-hint: undo history record
                      first parameter - realtime effect name
                      */
-                     XO("Change settings for effect %s").Format(effectName),
+                     XO("Change settings for realtime effect %s on %s").Format(effectName, mDelegate->GetSourceName()),
                      /*! i18n-hint: undo history record
                      first parameter - realtime effect name
                      */
-                     XO("Change effect %s").Format(effectName),
+                     XO("Change realtime effect %s on %s").Format(effectName, mDelegate->GetSourceName()),
                      UndoPush::CONSOLIDATE);
                }
             }

--- a/src/effects/RealtimeEffectStateUI.cpp
+++ b/src/effects/RealtimeEffectStateUI.cpp
@@ -182,6 +182,16 @@ void RealtimeEffectStateUI::UpdateTitle()
 
 void RealtimeEffectStateUI::AutoSave(AudacityProject &project)
 {
+   ProjectHistory::Get(project).PushState(
+      /*! i18n-hint: undo history record
+      first parameter - realtime effect name
+      */
+      XO("Change settings for effect %s").Format(mEffectName),
+      /*! i18n-hint: undo history record
+      first parameter - realtime effect name
+      */
+      XO("Change effect %s").Format(mEffectName),
+      UndoPush::CONSOLIDATE);
    ProjectHistory::AutoSave::Call(project);
 }
 

--- a/src/effects/RealtimeEffectStateUI.cpp
+++ b/src/effects/RealtimeEffectStateUI.cpp
@@ -186,11 +186,11 @@ void RealtimeEffectStateUI::AutoSave(AudacityProject &project)
       /*! i18n-hint: undo history record
       first parameter - realtime effect name
       */
-      XO("Change settings for effect %s").Format(mEffectName),
+      XO("Change settings for realtime effect %s on %s").Format(mEffectName, mTargetName),
       /*! i18n-hint: undo history record
       first parameter - realtime effect name
       */
-      XO("Change effect %s").Format(mEffectName),
+      XO("Change realtime effect %s on %s").Format(mEffectName, mTargetName),
       UndoPush::CONSOLIDATE);
    ProjectHistory::AutoSave::Call(project);
 }


### PR DESCRIPTION
Resolves: #4169 

By cloning a RealtimeEffectList a shallow copy of the effect state is created.
In the current implementation if the user copy and paste a track the effect list state for both tracks will point to the same memory location.

This PR modifies the code to use a deep copy instead.
We should also add the effect settings change to the history to avoid just losing the modification after undoing some other action.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
