### PR TITLE
Undo/Redo preserves clip IDs

### DIFF
--- a/au3/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/au3/libraries/lib-effects/EffectOutputTracks.cpp
@@ -41,23 +41,10 @@ EffectOutputTracks::EffectOutputTracks(
       };
 
    for (auto aTrack : trackRange) {
-      auto pTrack = aTrack->Duplicate();
-      if (auto aWaveTrack = dynamic_cast<WaveTrack*>(aTrack))
-      {
-         auto pWaveTrack = dynamic_cast<WaveTrack*>(pTrack.get());
-         for (auto i = 0; i < aWaveTrack->GetNumClips(); ++i)
-         {
-            auto aClip = aWaveTrack->GetClip(i);
-            auto pClip = pWaveTrack->GetClip(i);
-            if (aClip && pClip)
-               pClip->SetId(aClip->GetId());
-            else
-               assert(false);
-         }
-      }
+      auto pTrack = aTrack->Duplicate(Track::DuplicateOptions{}.Backup());
       mIMap.push_back(aTrack);
       mOMap.push_back(pTrack.get());
-      mOutputTracks->Add(pTrack);
+      mOutputTracks->Add(pTrack, TrackList::DoAssignId::No);
    }
 
    if (
@@ -96,7 +83,7 @@ Track *EffectOutputTracks::AddToOutputTracks(const std::shared_ptr<Track> &t)
 {
    mIMap.push_back(nullptr);
    mOMap.push_back(t.get());
-   auto result = mOutputTracks->Add(t);
+   auto result = mOutputTracks->Add(t, TrackList::DoAssignId::No);
    // Invariant is maintained
    assert(mIMap.size() == mOutputTracks->Size());
    assert(mIMap.size() == mOMap.size());

--- a/au3/libraries/lib-track/UndoTracks.cpp
+++ b/au3/libraries/lib-track/UndoTracks.cpp
@@ -1,11 +1,11 @@
 /**********************************************************************
- 
+
  Audacity: A Digital Audio Editor
- 
+
  @file UndoTracks.cpp
- 
+
  Paul Licameli
- 
+
  **********************************************************************/
 #include "UndoTracks.h"
 #include "PendingTracks.h"
@@ -22,18 +22,25 @@ struct TrackListRestorer final : UndoStateExtension {
          if (pTrack->GetId() == TrackId{})
             // Don't copy a pending added track
             continue;
-         mpTracks->Add(pTrack->Duplicate());
+         mpTracks->Add(
+            pTrack->Duplicate(Track::DuplicateOptions {}.Backup()),
+            TrackList::DoAssignId::No);
       }
    }
+
    void RestoreUndoRedoState(AudacityProject &project) override {
       auto &dstTracks = TrackList::Get(project);
       dstTracks.Clear();
       for (auto pTrack : *mpTracks)
-         dstTracks.Add(pTrack->Duplicate());
+         dstTracks.Add(
+            pTrack->Duplicate(Track::DuplicateOptions {}.Backup()),
+            TrackList::DoAssignId::No);
    }
+
    bool CanUndoOrRedo(const AudacityProject &project) override {
       return !PendingTracks::Get(project).HasPendingTracks();
    }
+
    const std::shared_ptr<TrackList> mpTracks;
 };
 

--- a/au3/libraries/lib-wave-track/WaveClip.h
+++ b/au3/libraries/lib-wave-track/WaveClip.h
@@ -309,31 +309,40 @@ public:
     @post `NChannels() == orig.NChannels()`
     @post `!copyCutlines || NumCutLines() == orig.NumCutLines()`
     */
-   static WaveClip* NewFrom(const WaveClip& orig, const SampleBlockFactoryPtr &factory, bool copyCutlines)
+   static WaveClip* NewFrom(
+      const WaveClip& orig, const SampleBlockFactoryPtr& factory,
+      bool copyCutlines, bool backup)
    {
-       WaveClip* clip = new WaveClip(orig, factory, copyCutlines);
-       clip->mId = NewID();
-       return clip;
+      WaveClip* clip = new WaveClip(orig, factory, copyCutlines);
+      if (!backup)
+         clip->mId = NewID();
+      return clip;
    }
 
-   static std::shared_ptr<WaveClip> NewSharedFrom(const WaveClip& orig, const SampleBlockFactoryPtr &factory,
-                                                  bool copyCutlines)
+   static std::shared_ptr<WaveClip> NewSharedFrom(
+      const WaveClip& orig, const SampleBlockFactoryPtr& factory,
+      bool copyCutlines, bool backup)
    {
-       return std::shared_ptr<WaveClip>(NewFrom(orig, factory, copyCutlines));
+      return std::shared_ptr<WaveClip>(
+         NewFrom(orig, factory, copyCutlines, backup));
    }
 
-   static WaveClip* NewFromRange(const WaveClip& orig, const SampleBlockFactoryPtr &factory, bool copyCutlines,
-                            double t0, double t1)
+   static WaveClip* NewFromRange(
+      const WaveClip& orig, const SampleBlockFactoryPtr& factory,
+      bool copyCutlines, bool backup, double t0, double t1)
    {
-       WaveClip* clip = new WaveClip(orig, factory, copyCutlines, t0, t1);
-       clip->mId = NewID();
-       return clip;
+      WaveClip* clip = new WaveClip(orig, factory, copyCutlines, t0, t1);
+      if (!backup)
+         clip->mId = NewID();
+      return clip;
    }
 
-   static std::shared_ptr<WaveClip> NewSharedFromRange(const WaveClip& orig, const SampleBlockFactoryPtr &factory,
-                                                       bool copyCutlines, double t0, double t1)
+   static std::shared_ptr<WaveClip> NewSharedFromRange(
+      const WaveClip& orig, const SampleBlockFactoryPtr& factory,
+      bool copyCutlines, bool backup, double t0, double t1)
    {
-       return std::shared_ptr<WaveClip>(NewFromRange(orig, factory, copyCutlines, t0, t1));
+      return std::shared_ptr<WaveClip>(
+         NewFromRange(orig, factory, copyCutlines, backup, t0, t1));
    }
 
    virtual ~WaveClip();

--- a/au3/libraries/lib-wave-track/WaveTrack.h
+++ b/au3/libraries/lib-wave-track/WaveTrack.h
@@ -573,9 +573,11 @@ public:
    IntervalConstHolders GetSortedClipsIntersecting(double t0, double t1) const;
 
 private:
-   void CopyWholeClip(const Interval &clip, double t0, bool forClipboard);
-   void CopyPartOfClip(const Interval &clip,
-      double t0, double t1, bool forClipboard);
+   void CopyWholeClip(
+      const Interval& clip, double t0, bool forClipboard, bool backup);
+   void CopyPartOfClip(
+      const Interval& clip, double t0, double t1, bool forClipboard,
+      bool backup);
    void FinishCopy(double t0, double t1, bool forClipboard);
 
    //! Return all WaveClips sorted by clip play start time.


### PR DESCRIPTION
Resolves: #7358

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA: Please verify if it's also fixed other undo/redo-related bugs, such as
- [x] #7802
- [x] #7838
- [x] #7845