### PR TITLE
Add "Insert Silence" as a standalone action out of "Effects" framework

### DIFF
--- a/au3/libraries/lib-wave-track/WaveTrack.cpp
+++ b/au3/libraries/lib-wave-track/WaveTrack.cpp
@@ -2054,6 +2054,7 @@ void WaveTrack::InsertSilence(double t, double len)
       auto clip = CreateClip(0);
       clip->InsertSilence(0, len);
       // use No-fail-guarantee
+      clip->SetPlayStartTime(t);
       InsertInterval(move(clip), true);
    }
    else

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -733,6 +733,7 @@ MenuItemList AppMenuModel::makeEffectsItems()
         makeMenuItem("favourite-effect-1"),
         makeMenuItem("favourite-effect-2"),
         makeMenuItem("favourite-effect-3"),
+        makeMenuItem("insert-silence"),
         makeSeparator(),
     };
 

--- a/src/projectscene/CMakeLists.txt
+++ b/src/projectscene/CMakeLists.txt
@@ -30,6 +30,8 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/view/common/tracksviewstatemodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/common/tracksviewstatemodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/common/insertsilencemodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/common/insertsilencemodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/common/customcursor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/common/customcursor.h
 

--- a/src/projectscene/internal/projectsceneactionscontroller.cpp
+++ b/src/projectscene/internal/projectsceneactionscontroller.cpp
@@ -22,6 +22,7 @@ void ProjectSceneActionsController::init()
     dispatcher()->reg(this, "update-display-while-playing", this, &ProjectSceneActionsController::updateDisplayWhilePlaying);
     dispatcher()->reg(this, "pinned-play-head", this, &ProjectSceneActionsController::pinnedPlayHead);
     dispatcher()->reg(this, CLIP_PITCH_AND_SPEED_CODE, this, &ProjectSceneActionsController::openClipPitchAndSpeedEdit);
+    dispatcher()->reg(this, "insert-silence", this, &ProjectSceneActionsController::insertSilence);
 }
 
 void ProjectSceneActionsController::notifyActionCheckedChanged(const ActionCode& actionCode)
@@ -85,6 +86,13 @@ void ProjectSceneActionsController::openClipPitchAndSpeedEdit(const ActionData& 
     query.addParam("focusItemName", muse::Val("pitch"));
 
     interactive()->open(query);
+}
+
+void ProjectSceneActionsController::insertSilence(const muse::actions::ActionData& args)
+{
+    muse::UriQuery query("audacity://projectscene/insertsilence");
+
+    auto rv = interactive()->open(query);
 }
 
 bool ProjectSceneActionsController::actionChecked(const ActionCode& actionCode) const

--- a/src/projectscene/internal/projectsceneactionscontroller.h
+++ b/src/projectscene/internal/projectsceneactionscontroller.h
@@ -40,6 +40,8 @@ private:
 
     void openClipPitchAndSpeedEdit(const muse::actions::ActionData& args);
 
+    void insertSilence(const muse::actions::ActionData& args);
+
     muse::async::Channel<muse::actions::ActionCode> m_actionCheckedChanged;
 };
 }

--- a/src/projectscene/internal/projectsceneconfiguration.cpp
+++ b/src/projectscene/internal/projectsceneconfiguration.cpp
@@ -2,6 +2,7 @@
 * Audacity: A Digital Audio Editor
 */
 #include "projectsceneconfiguration.h"
+#include "NumericConverterFormats.h"
 #include "types/projectscenetypes.h"
 
 #include "settings.h"
@@ -13,6 +14,8 @@ static const std::string moduleName("projectscene");
 static const muse::Settings::Key IS_VERTICAL_RULERS_VISIBLE(moduleName, "projectscene/verticalRulersVisible");
 static const muse::Settings::Key TIMELINE_RULER_MODE(moduleName, "projectscene/timelineRulerMode");
 static const muse::Settings::Key MOUSE_ZOOM_PRECISION(moduleName, "projectscene/zoomPrecisionMouse");
+static const muse::Settings::Key INSERT_SILENCE_DURATION(moduleName, "projectscene/insertSilenceDuration");
+static const muse::Settings::Key INSERT_SILENCE_DURATION_FORMAT(moduleName, "projectscene/insertSilenceDurationFormat");
 
 void ProjectSceneConfiguration::init()
 {
@@ -22,6 +25,10 @@ void ProjectSceneConfiguration::init()
     });
 
     muse::settings()->setDefaultValue(MOUSE_ZOOM_PRECISION, muse::Val(6));
+
+    muse::settings()->setDefaultValue(INSERT_SILENCE_DURATION, muse::Val(30));
+    muse::settings()->setDefaultValue(INSERT_SILENCE_DURATION_FORMAT,
+                                      muse::Val(NumericConverterFormats::DefaultSelectionFormat().Translation().ToStdString()));
 
     muse::settings()->setDefaultValue(TIMELINE_RULER_MODE, muse::Val(TimelineRulerMode::MINUTES_AND_SECONDS));
     muse::settings()->valueChanged(TIMELINE_RULER_MODE).onReceive(nullptr, [this](const muse::Val& val) {
@@ -42,6 +49,26 @@ void ProjectSceneConfiguration::setVerticalRulersVisible(bool visible)
 muse::async::Channel<bool> ProjectSceneConfiguration::isVerticalRulersVisibleChanged() const
 {
     return m_isVerticalRulersVisibleChanged;
+}
+
+au::trackedit::secs_t ProjectSceneConfiguration::insertSilenceDuration() const
+{
+    return muse::settings()->value(INSERT_SILENCE_DURATION).toDouble();
+}
+
+void ProjectSceneConfiguration::setInsertSilenceDuration(const trackedit::secs_t duration)
+{
+    muse::settings()->setSharedValue(INSERT_SILENCE_DURATION, muse::Val(duration));
+}
+
+std::string ProjectSceneConfiguration::insertSilenceDurationFormat() const
+{
+    return muse::settings()->value(INSERT_SILENCE_DURATION_FORMAT).toString();
+}
+
+void ProjectSceneConfiguration::setInsertSilenceDurationFormat(const std::string& format)
+{
+    muse::settings()->setSharedValue(INSERT_SILENCE_DURATION_FORMAT, muse::Val(format));
 }
 
 double ProjectSceneConfiguration::zoom() const

--- a/src/projectscene/internal/projectsceneconfiguration.h
+++ b/src/projectscene/internal/projectsceneconfiguration.h
@@ -23,6 +23,12 @@ public:
     void setVerticalRulersVisible(bool visible) override;
     muse::async::Channel<bool> isVerticalRulersVisibleChanged() const override;
 
+    trackedit::secs_t insertSilenceDuration() const override;
+    void setInsertSilenceDuration(const trackedit::secs_t duration) override;
+
+    std::string insertSilenceDurationFormat() const override;
+    void setInsertSilenceDurationFormat(const std::string &format) override;
+
     double zoom() const override;
 
     int mouseZoomPrecision() const override;

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -128,6 +128,12 @@ const UiActionList ProjectSceneUiActions::m_actions = {
              TranslatableString("action", "Pinned play head"),
              Checkable::Yes
              ),
+    UiAction("insert-silence",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Insert Silence"),
+             TranslatableString("action", "Insert Silence")
+             ),
     // clip
     UiAction("clip-properties",
              au::context::UiCtxAny,

--- a/src/projectscene/iprojectsceneconfiguration.h
+++ b/src/projectscene/iprojectsceneconfiguration.h
@@ -17,6 +17,12 @@ public:
 
     virtual double zoom() const = 0;
 
+    virtual trackedit::secs_t insertSilenceDuration() const = 0;
+    virtual void setInsertSilenceDuration(const trackedit::secs_t duration) = 0;
+
+    virtual std::string insertSilenceDurationFormat() const = 0;
+    virtual void setInsertSilenceDurationFormat(const std::string &format) = 0;
+
     virtual int mouseZoomPrecision() const = 0;
     virtual void setMouseZoomPrecision(int precision) = 0;
     virtual TimelineRulerMode timelineRulerMode() const = 0;

--- a/src/projectscene/projectscene.qrc
+++ b/src/projectscene/projectscene.qrc
@@ -51,5 +51,6 @@
         <file>qml/Audacity/ProjectScene/clipsview/pitchandspeed/PitchSection.qml</file>
         <file>qml/Audacity/ProjectScene/clipsview/pitchandspeed/GeneralSection.qml</file>
         <file>qml/Audacity/ProjectScene/clipsview/pitchandspeed/SpeedSection.qml</file>
+        <file>qml/Audacity/ProjectScene/common/InsertSilence.qml</file>
     </qresource>
 </RCC>

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -18,6 +18,7 @@
 
 #include "view/common/tracksviewstatemodel.h"
 #include "view/common/customcursor.h"
+#include "view/common/insertsilencemodel.h"
 
 #include "view/toolbars/projecttoolbarmodel.h"
 #include "view/toolbars/undoredotoolbarmodel.h"
@@ -95,6 +96,8 @@ void ProjectSceneModule::resolveImports()
     if (ir) {
         ir->registerQmlUri(muse::Uri("audacity://projectscene/editpitchandspeed"),
                            "Audacity/ProjectScene/clipsview/pitchandspeed/PitchAndSpeedChangeDialog.qml");
+        ir->registerQmlUri(muse::Uri("audacity://projectscene/insertsilence"),
+                           "Audacity/ProjectScene/common/InsertSilence.qml");
     }
 }
 
@@ -107,6 +110,7 @@ void ProjectSceneModule::registerUiTypes()
     // common
     qmlRegisterType<TracksViewStateModel>("Audacity.ProjectScene", 1, 0, "TracksViewStateModel");
     qmlRegisterType<CustomCursor>("Audacity.ProjectScene", 1, 0, "CustomCursor");
+    qmlRegisterType<InsertSilenceModel>("Audacity.ProjectScene", 1, 0, "InsertSilenceModel");
 
     // toolbars
     qmlRegisterType<ProjectToolBarModel>("Audacity.ProjectScene", 1, 0, "ProjectToolBarModel");

--- a/src/projectscene/qml/Audacity/ProjectScene/common/InsertSilence.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/common/InsertSilence.qml
@@ -1,0 +1,92 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Muse.UiComponents
+import Audacity.Playback
+import Audacity.ProjectScene
+
+StyledDialogView {
+    id: root
+
+    title: qsTrc("projectscene/silence", "Silence")
+
+    contentWidth: 380
+    contentHeight: 150
+
+    function preview() {
+        silence.preview()
+    }
+
+    InsertSilenceModel {
+        id: silence
+    }
+
+    Component.onCompleted: {
+        silence.init()
+    }
+
+    GridLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+
+        rows: 2
+        columns: 2
+
+        StyledTextLabel {
+            text: qsTrc("projectscene/silence", "Duration:")
+        }
+
+        Timecode {
+            id: timecode
+
+            Layout.fillHeight: false
+
+            value: silence.duration
+            currentFormatStr: silence.durationFormat
+            sampleRate: silence.sampleRate
+
+            onValueChanged: {
+                silence.duration = timecode.value
+            }
+
+            onCurrentFormatChanged: {
+                silence.durationFormat = timecode.currentFormatStr
+            }
+        }
+
+        ButtonBox {
+            Layout.columnSpan: 2
+            Layout.fillWidth: true
+
+            buttons: [ ButtonBoxModel.Cancel ]
+
+            navigationPanel.section: root.navigationSection
+            navigationPanel.order: 2
+
+            FlatButton {
+                text: qsTrc("projectscene/silence", "Generate")
+                buttonRole: ButtonBoxModel.CustomRole
+                buttonId: ButtonBoxModel.CustomButton + 1
+
+                onClicked: {
+                    silence.apply()
+                    root.ret = {
+                        errcode: 0,
+                        value: {
+                            duration: silence.duration,
+                            durationFormat: silence.durationFormat
+                        }
+                    }
+
+                    root.hide()
+                }
+            }
+
+            onStandardButtonClicked: function(buttonId) {
+                if (buttonId === ButtonBoxModel.Cancel) {
+                    root.reject()
+                }
+            }
+        }
+    }
+}

--- a/src/projectscene/view/common/insertsilencemodel.cpp
+++ b/src/projectscene/view/common/insertsilencemodel.cpp
@@ -1,0 +1,84 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#include "AudacityException.h"
+#include "NumericConverterFormats.h"
+#include "playback/iaudiooutput.h"
+#include "translation.h"
+#include "insertsilencemodel.h"
+
+using namespace au::projectscene;
+
+void InsertSilenceModel::init()
+{
+    muse::secs_t begin = selectionController()->dataSelectedStartTime();
+    muse::secs_t end = selectionController()->dataSelectedEndTime();
+
+    m_duration = end - begin;
+    m_durationFormat = QString::fromStdString(configuration()->insertSilenceDurationFormat());
+
+    if (muse::is_zero(m_duration)) {
+        m_duration = configuration()->insertSilenceDuration().to_double();
+    } else {
+        m_durationFormat = QString::fromStdString(NumericConverterFormats::TimeAndSampleFormat().Translation().ToStdString());
+    }
+
+    emit durationChanged();
+    emit durationFormatChanged();
+}
+
+int InsertSilenceModel::sampleRate() const
+{
+    return playback()->audioOutput()->sampleRate();
+}
+
+double au::projectscene::InsertSilenceModel::duration() const
+{
+    return m_duration;
+}
+
+void au::projectscene::InsertSilenceModel::setDuration(double duration)
+{
+    if (muse::is_equal(m_duration, duration)) {
+        return;
+    }
+    m_duration = duration;
+    emit durationChanged();
+}
+
+QString InsertSilenceModel::durationFormat() const
+{
+    return m_durationFormat;
+}
+
+void InsertSilenceModel::setDurationFormat(const QString& newDurationFormat)
+{
+    if (m_durationFormat == newDurationFormat) {
+        return;
+    }
+    m_durationFormat = newDurationFormat;
+    emit durationFormatChanged();
+}
+
+void InsertSilenceModel::apply()
+{
+    trackedit::TrackIdList trackIds = selectionController()->selectedTracks();
+    muse::secs_t begin = selectionController()->dataSelectedStartTime();
+    muse::secs_t end = selectionController()->dataSelectedEndTime();
+
+    try {
+        trackeditInteraction()->insertSilence(trackIds, begin, end, m_duration);
+        selectionController()->setDataSelectedStartTime(begin, false);
+        selectionController()->setDataSelectedEndTime(begin + m_duration, true);
+
+        configuration()->setInsertSilenceDuration(m_duration);
+        configuration()->setInsertSilenceDurationFormat(m_durationFormat.toStdString());
+    }
+    catch (::AudacityException& e) {
+        if (const auto msg = dynamic_cast<MessageBoxException*>(&e)) {
+            std::string title = muse::trc("projectscene/silence", "Action cannot be completed");
+            interactive()->warning(title, msg->ErrorMessage().Translation().ToStdString());
+        }
+    }
+}

--- a/src/projectscene/view/common/insertsilencemodel.h
+++ b/src/projectscene/view/common/insertsilencemodel.h
@@ -1,0 +1,50 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <QObject>
+
+#include "modularity/ioc.h"
+#include "iinteractive.h"
+#include "iprojectsceneconfiguration.h"
+#include "playback/iplayback.h"
+#include "trackedit/itrackeditinteraction.h"
+#include "trackedit/iselectioncontroller.h"
+
+namespace au::projectscene {
+class InsertSilenceModel : public QObject
+{
+    Q_OBJECT
+
+    muse::Inject<playback::IPlayback> playback;
+    muse::Inject<trackedit::ITrackeditInteraction> trackeditInteraction;
+    muse::Inject<trackedit::ISelectionController> selectionController;
+    muse::Inject<IProjectSceneConfiguration> configuration;
+    muse::Inject<muse::IInteractive> interactive;
+
+    Q_PROPERTY(double duration READ duration WRITE setDuration NOTIFY durationChanged)
+    Q_PROPERTY(QString durationFormat READ durationFormat WRITE setDurationFormat NOTIFY durationFormatChanged)
+    Q_PROPERTY(int sampleRate READ sampleRate NOTIFY sampleRateChanged)
+
+public:
+    Q_INVOKABLE void init();
+
+    int sampleRate() const;
+    double duration() const;
+    void setDuration(double duration);
+    QString durationFormat() const;
+    void setDurationFormat(const QString& newDurationFormat);
+
+    Q_INVOKABLE void apply();
+
+signals:
+    void durationChanged();
+    void durationFormatChanged();
+    void sampleRateChanged();
+
+private:
+    double m_duration = 0.0;
+    QString m_durationFormat = "";
+};
+}

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -79,6 +79,8 @@ public:
     void moveTracks(const TrackIdList& trackIds, const TrackMoveDirection direction) override;
     void moveTracksTo(const TrackIdList& trackIds, int to) override;
 
+    void insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration) override;
+
     void undo() override;
     bool canUndo() override;
     void redo() override;
@@ -103,6 +105,7 @@ private:
     bool cutTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end);
     bool mergeSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
     bool duplicateSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
+    void doInsertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration);
 
     bool splitCutSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
     bool splitDeleteSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -68,6 +68,9 @@ public:
     virtual bool splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool trimClipLeft(const ClipKey& clipKey, secs_t deltaSec, bool completed) = 0;
     virtual bool trimClipRight(const ClipKey& clipKey, secs_t deltaSec, bool completed) = 0;
+    virtual secs_t clipDuration(const ClipKey& clipKey) const = 0;
+    virtual std::optional<secs_t> getMostLeftClipStartTime(const ClipKeyList& clipKeys) const = 0;
+
     virtual void newMonoTrack() = 0;
     virtual void newStereoTrack() = 0;
     virtual void newLabelTrack() = 0;
@@ -75,12 +78,13 @@ public:
     virtual void duplicateTracks(const TrackIdList& trackIds) = 0;
     virtual void moveTracks(const TrackIdList& trackIds, TrackMoveDirection direction) = 0;
     virtual void moveTracksTo(const TrackIdList& trackIds, int pos) = 0;
-    virtual secs_t clipDuration(const ClipKey& clipKey) const = 0;
-    virtual std::optional<secs_t> getMostLeftClipStartTime(const ClipKeyList& clipKeys) const = 0;
+
     virtual void undo() = 0;
     virtual bool canUndo() = 0;
     virtual void redo() = 0;
     virtual bool canRedo() = 0;
+
+    virtual void insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration) = 0;
 
     virtual void toggleStretchToMatchProjectTempo(const ClipKey& clipKey) = 0;
 


### PR DESCRIPTION
Resolves: [Effects - Generate Silence](https://github.com/audacity/audacity/issues/7685)	https://github.com/audacity/audacity/issues/7685


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
