### PR TITLE
Wait for thumbnail before closing project

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -157,32 +157,28 @@ bool ApplicationActionController::quit()
     if (m_quiting) {
         return false;
     }
-
     m_quiting = true;
-    DEFER {
+
+    projectFilesController()->closeOpenedProject().onResolve(this, [this](bool) {
         m_quiting = false;
-    };
+        QCoreApplication::exit();
+    });
 
-    constexpr auto quit = true;
-    if (!projectFilesController()->closeOpenedProject(quit)) {
-        return false;
-    }
-
-    QCoreApplication::exit();
     return true;
 }
 
 void ApplicationActionController::restart()
 {
-    if (projectFilesController()->closeOpenedProject()) {
-        // if (multiInstancesProvider()->instances().size() == 1) {
+    projectFilesController()->closeOpenedProject().onResolve(this, [this](bool) {
         application()->restart();
+        // if (multiInstancesProvider()->instances().size() == 1) {
+        //application()->restart();
         // } else {
         // multiInstancesProvider()->quitAllAndRestartLast();
 
         // QCoreApplication::exit();
         // }
-    }
+    });
 }
 
 void ApplicationActionController::toggleFullScreen()

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -57,6 +57,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/irecentfilescontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/imscmetareader.h
     ${CMAKE_CURRENT_LIST_DIR}/iprojectautosaver.h
+    ${CMAKE_CURRENT_LIST_DIR}/ithumbnailcreator.h
 
     ${CMAKE_CURRENT_LIST_DIR}/types/projecttypes.h
     ${CMAKE_CURRENT_LIST_DIR}/types/projectmeta.h
@@ -76,6 +77,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/iopensaveprojectscenario.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/opensaveprojectscenario.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/opensaveprojectscenario.h
+#include "global/async/channel.h"
+    ${CMAKE_CURRENT_LIST_DIR}/internal/thumbnailcreator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/thumbnailcreator.h
 
     ${PLATFORM_SRC}
 

--- a/src/project/iaudacityproject.h
+++ b/src/project/iaudacityproject.h
@@ -7,6 +7,7 @@
 #include "global/io/path.h"
 #include "global/types/retval.h"
 #include "global/async/notification.h"
+#include "global/async/promise.h"
 #include "trackedit/itrackeditproject.h"
 #include "types/projecttypes.h"
 #include "projectscene/iprojectviewstate.h"
@@ -38,8 +39,9 @@ public:
     virtual bool needAutoSave() const = 0;
     virtual void setNeedAutoSave(bool val) = 0;
     virtual muse::async::Notification needSaveChanged() const { return muse::async::Notification(); }
-    virtual muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
+    virtual muse::async::Promise<muse::Ret> save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
     virtual muse::async::Notification captureThumbnailRequested() const = 0;
+    virtual void onThumbnailCreated(bool success) = 0;
 
     virtual const au::trackedit::ITrackeditProjectPtr trackeditProject() const = 0;
 

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -2,6 +2,7 @@
 #define AU_PROJECT_AUDACITYPROJECT_H
 
 #include "../iaudacityproject.h"
+#include "../ithumbnailcreator.h"
 #include "context/iglobalcontext.h"
 #include "modularity/ioc.h"
 #include "au3wrap/iau3project.h"
@@ -38,7 +39,7 @@ namespace au::project {
 //! it cannot be used in parts, therefore, to avoid duplication of symbols,
 //! we can add (as source) it only to one library
 //! * Thanks to this wrapper we will see exactly what we are using from AU3
-class Audacity4Project : public IAudacityProject
+class Audacity4Project : public IAudacityProject, public muse::async::Asyncable
 {
     muse::Inject<au3::IAu3ProjectCreator> au3ProjectCreator;
     muse::Inject<trackedit::ITrackeditProjectCreator> trackeditProjectCreator;
@@ -47,6 +48,7 @@ class Audacity4Project : public IAudacityProject
     muse::Inject<context::IGlobalContext> globalContext;
     muse::Inject<au::trackedit::IProjectHistory> projectHistory;
     muse::Inject<au::trackedit::ITrackeditClipboard> clipboard;
+    muse::Inject<IThumbnailCreator> thumbnailCreator;
 
 public:
     Audacity4Project();
@@ -73,9 +75,9 @@ public:
     bool needAutoSave() const override;
     void setNeedAutoSave(bool val) override;
 
-    muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
-
+    muse::async::Promise<muse::Ret> save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
     muse::async::Notification captureThumbnailRequested() const override;
+    void onThumbnailCreated(bool success) override;
 
     const au::trackedit::ITrackeditProjectPtr trackeditProject() const override;
 
@@ -88,9 +90,9 @@ private:
 
     muse::Ret doLoad(const muse::io::path_t& path, bool forceMode, const std::string& format);
 
-    muse::Ret saveProject(const muse::io::path_t& path, const std::string& fileSuffix, bool generateBackup = true,
+    muse::async::Promise<muse::Ret> saveProject(const muse::io::path_t& path, const std::string& fileSuffix, bool generateBackup = true,
                           bool createThumbnail = true);
-    muse::Ret doSave(const muse::io::path_t& path, /*engraving::MscIoMode ioMode,*/ bool generateBackup = true,
+    muse::async::Promise<muse::Ret> doSave(const muse::io::path_t& path, /*engraving::MscIoMode ioMode,*/ bool generateBackup = true,
                      bool createThumbnail = true);
 
     void markAsSaved(const muse::io::path_t& path);
@@ -102,7 +104,6 @@ private:
     muse::io::path_t m_path;
     muse::async::Notification m_pathChanged;
     muse::async::Notification m_displayNameChanged;
-    muse::async::Notification m_captureThumbnailRequested;
 
     bool m_isNewlyCreated = false; /// true if the file has never been saved yet
     bool m_isImported = false;

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -43,9 +43,10 @@ public:
     muse::Ret openProject(const ProjectFile& file) override;
     bool isUrlSupported(const QUrl& url) const override;
     bool isFileSupported(const muse::io::path_t& path) const override;
-    bool closeOpenedProject(bool quitApp = false) override;
-    bool saveProject(const muse::io::path_t& path = muse::io::path_t()) override;
-    bool saveProjectLocally(const muse::io::path_t& filePath = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
+    muse::async::Promise<muse::Ret> closeOpenedProject() override;
+    
+    muse::async::Promise<muse::Ret> saveProject(SaveMode saveMode, SaveLocationType saveLocationType = SaveLocationType::Undefined, bool force = false);
+    muse::async::Promise<muse::Ret> saveProjectLocally(const muse::io::path_t& filePath = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
 
     const ProjectBeingDownloaded& projectBeingDownloaded() const override;
     muse::async::Notification projectBeingDownloadedChanged() const override;
@@ -60,6 +61,8 @@ private:
     void importProject();
     muse::Ret openProject(const muse::io::path_t& givenPath, const muse::String& displayNameOverride = muse::String());
     muse::Ret doOpenProject(const muse::io::path_t& filePath);
+    void closeCurrentProject();
+
     //! TODO AU4
     // muse::Ret openAudacityUrl(const QUrl& url);
     muse::RetVal<IAudacityProjectPtr> loadProject(const muse::io::path_t& filePath);
@@ -68,8 +71,7 @@ private:
     muse::IInteractive::Button askAboutSavingProject(IAudacityProjectPtr project);
 
     muse::Ret canSaveProject() const;
-    bool saveProject(SaveMode saveMode, SaveLocationType saveLocationType = SaveLocationType::Undefined, bool force = false);
-    bool saveProjectAt(const SaveLocation& saveLocation, SaveMode saveMode = SaveMode::Save, bool force = false);
+    muse::async::Promise<muse::Ret> saveProjectAt(const SaveLocation& saveLocation, SaveMode saveMode = SaveMode::Save, bool force = false);
 
     RecentFile makeRecentFile(IAudacityProjectPtr project);
     void clearRecentProjects();

--- a/src/project/internal/thumbnailcreator.cpp
+++ b/src/project/internal/thumbnailcreator.cpp
@@ -1,0 +1,31 @@
+#include "thumbnailcreator.h"
+
+using namespace au::project;
+
+void ThumbnailCreator::onThumbnailCreated(bool success)
+{
+    m_thumbnailCreated.send(success);
+}
+
+muse::async::Notification ThumbnailCreator::captureThumbnailRequested() const
+{
+    return m_createThumbnailRequested;
+}
+
+muse::async::Promise<muse::Ret> ThumbnailCreator::createThumbnail()
+{
+    return muse::async::Promise<muse::Ret>([this](auto resolve, auto reject) {
+        m_thumbnailCreated.onReceive(this, [resolve, reject](bool ok) {
+            if (ok) {
+                (void)resolve(muse::make_ret(muse::Ret::Code::Ok));
+            }
+            else {
+                muse::Ret ret = muse::make_ret(muse::Ret::Code::UnknownError);
+                (void)reject(ret.code(), ret.text());
+            }
+        });
+        m_createThumbnailRequested.notify();
+        return muse::async::Promise<muse::Ret>::Result::unchecked();
+    }, muse::async::Promise<muse::Ret>::AsynchronyType::ProvidedByBody);
+
+}

--- a/src/project/internal/thumbnailcreator.h
+++ b/src/project/internal/thumbnailcreator.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ithumbnailcreator.h"
+
+#include "global/async/asyncable.h"
+
+namespace au::project {
+
+class ThumbnailCreator : public IThumbnailCreator, public muse::async::Asyncable
+{
+public:
+    ThumbnailCreator() = default;
+    void onThumbnailCreated(bool success) override;
+    muse::async::Promise<muse::Ret> createThumbnail() override;
+    muse::async::Notification captureThumbnailRequested() const override;
+
+private:
+    muse::async::Notification m_createThumbnailRequested;
+    muse::async::Channel<bool> m_thumbnailCreated;
+};
+
+}

--- a/src/project/iprojectfilescontroller.h
+++ b/src/project/iprojectfilescontroller.h
@@ -23,6 +23,7 @@
 #define AU_PROJECT_IPROJECTFILESCONTROLLER_H
 
 #include "modularity/imoduleinterface.h"
+#include "global/async/promise.h"
 #include "types/ret.h"
 #include "io/path.h"
 
@@ -41,9 +42,9 @@ public:
     virtual bool isUrlSupported(const QUrl& url) const = 0;
     virtual bool isFileSupported(const muse::io::path_t& path) const = 0;
     virtual muse::Ret openProject(const ProjectFile& file) = 0;
-    virtual bool closeOpenedProject(bool quitApp = false) = 0;
-    virtual bool saveProject(const muse::io::path_t& path = muse::io::path_t()) = 0;
-    virtual bool saveProjectLocally(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
+    virtual muse::async::Promise<muse::Ret> closeOpenedProject() = 0;
+    virtual muse::async::Promise<muse::Ret> saveProject(SaveMode saveMode, SaveLocationType saveLocationType = SaveLocationType::Undefined, bool force = false) = 0;
+    virtual muse::async::Promise<muse::Ret> saveProjectLocally(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
 
     virtual const ProjectBeingDownloaded& projectBeingDownloaded() const = 0;
     virtual muse::async::Notification projectBeingDownloadedChanged() const = 0;

--- a/src/project/ithumbnailcreator.h
+++ b/src/project/ithumbnailcreator.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "modularity/imoduleinterface.h"
+#include "global/async/promise.h"
+#include "global/async/channel.h"
+#include "global/async/notification.h"
+#include "global/types/ret.h"
+
+namespace au::project {
+
+class IThumbnailCreator : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(au::project::ithumbnailcreator)
+    
+public:
+    virtual ~IThumbnailCreator() = default;
+    virtual void onThumbnailCreated(bool success) = 0;
+    virtual muse::async::Promise<muse::Ret> createThumbnail() = 0;
+    virtual muse::async::Notification captureThumbnailRequested() const = 0;
+};
+
+}

--- a/src/project/projectmodule.cpp
+++ b/src/project/projectmodule.cpp
@@ -25,6 +25,7 @@
 
 #include "internal/projectconfiguration.h"
 #include "internal/projectuiactions.h"
+#include "internal/thumbnailcreator.h"
 
 #include "ui/iuiactionsregister.h"
 #include "ui/iinteractiveuriregister.h"
@@ -67,6 +68,7 @@ void ProjectModule::registerExports()
 {
     m_configuration = std::make_shared<ProjectConfiguration>();
     m_actionsController = std::make_shared<ProjectActionsController>();
+    m_thumbnailCreator = std::make_shared<ThumbnailCreator>();
 
 #ifdef Q_OS_MAC
     m_recentFilesController = std::make_shared<MacOSRecentFilesController>();
@@ -80,6 +82,7 @@ void ProjectModule::registerExports()
     ioc()->registerExport<IRecentFilesController>(moduleName(), m_recentFilesController);
     ioc()->registerExport<IOpenSaveProjectScenario>(moduleName(), new OpenSaveProjectScenario());
     ioc()->registerExport<IProjectFilesController>(moduleName(), m_actionsController);
+    ioc()->registerExport<IThumbnailCreator>(moduleName(), m_thumbnailCreator);
 }
 
 void ProjectModule::resolveImports()

--- a/src/project/projectmodule.h
+++ b/src/project/projectmodule.h
@@ -30,6 +30,7 @@ namespace au::project {
 class ProjectConfiguration;
 class ProjectActionsController;
 class RecentFilesController;
+class ThumbnailCreator;
 class ProjectModule : public muse::modularity::IModuleSetup
 {
 public:
@@ -46,6 +47,7 @@ private:
     std::shared_ptr<ProjectConfiguration> m_configuration;
     std::shared_ptr<ProjectActionsController> m_actionsController;
     std::shared_ptr<RecentFilesController> m_recentFilesController;
+    std::shared_ptr<ThumbnailCreator> m_thumbnailCreator;
 };
 }
 

--- a/src/project/tests/mocks/audacityprojectmock.h
+++ b/src/project/tests/mocks/audacityprojectmock.h
@@ -32,8 +32,9 @@ public:
     MOCK_METHOD(bool, needAutoSave, (), (const, override));
     MOCK_METHOD(void, setNeedAutoSave, (bool val), (override));
     MOCK_METHOD(muse::async::Notification, needSaveChanged, (), (const, override));
-    MOCK_METHOD(muse::Ret, save, (const muse::io::path_t& path, SaveMode saveMode), (override));
+    MOCK_METHOD(muse::async::Promise<muse::Ret>, save, (const muse::io::path_t& path, SaveMode saveMode), (override));
     MOCK_METHOD(muse::async::Notification, captureThumbnailRequested, (), (const, override));
+    MOCK_METHOD(void, onThumbnailCreated, (bool success), (override));
 
     MOCK_METHOD(const au::trackedit::ITrackeditProjectPtr, trackeditProject, (), (const, override));
 

--- a/src/project/view/projectpropertiesmodel.cpp
+++ b/src/project/view/projectpropertiesmodel.cpp
@@ -56,6 +56,11 @@ void ProjectPropertiesModel::init()
     load();
 }
 
+void ProjectPropertiesModel::onThumbnailCreated(bool success)
+{
+   m_project->onThumbnailCreated(success);
+}
+
 void ProjectPropertiesModel::load()
 {
     beginResetModel();

--- a/src/project/view/projectpropertiesmodel.h
+++ b/src/project/view/projectpropertiesmodel.h
@@ -44,6 +44,7 @@ public:
     explicit ProjectPropertiesModel(QObject* parent = nullptr);
 
     Q_INVOKABLE void init();
+    Q_INVOKABLE void onThumbnailCreated(bool success);
 
     QVariant data(const QModelIndex& index, int role) const override;
     bool setData(const QModelIndex& index, const QVariant& value, int role) override;

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -34,7 +34,10 @@ Rectangle {
             playCursor.visible = false
             content.grabToImage(function(result) {
                 playCursor.visible = true
-                result.saveToFile(project.thumbnailUrl)
+                console.log("Grabbed image: " + result)
+                console.log("Thumbnail url" + project.thumbnailUrl)
+                var success = result.saveToFile(project.thumbnailUrl)
+                project.onThumbnailCreated(success)
             })
         }
     }


### PR DESCRIPTION
Resolves: #7874 

A callback is called once the thumbnail is ready to be saved on the disk.
Once this actions takes some time,  it was being executed after navigation was performed and the project closed.

The current solution create two actions:
- thumbnail_saved to acknowledge the thumbnail was saved on disk.
- project-close to inform the project was closed.

Now the workflow:
1. The user save the project.
2. The action to save the thumbnail is triggered and then a "thumbnail-saved" is dispatched.
3. The project is closed and a "project-closed" is dispatched.
4. According to project state we decide to navigate to home page, reload the app or quit it.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
