### PR TITLE
7860 disable apply button for generators when selection is zero

### DIFF
--- a/src/effects/builtin/common/generatoreffect.cpp
+++ b/src/effects/builtin/common/generatoreffect.cpp
@@ -59,6 +59,11 @@ void GeneratorEffect::setDuration(double newDuration)
     }
 }
 
+bool GeneratorEffect::isApplyAllowed() const
+{
+    return m_settings ? m_settings->extra.GetDuration() > 0 : false;
+}
+
 QString GeneratorEffect::durationFormat() const
 {
     if (m_settings) {

--- a/src/effects/builtin/common/generatoreffect.h
+++ b/src/effects/builtin/common/generatoreffect.h
@@ -28,6 +28,7 @@ public:
     void setDuration(double newDuration);
     QString durationFormat() const;
     void setDurationFormat(const QString& newDurationFormat);
+    bool isApplyAllowed() const;
 
 private:
     virtual void doInit() {}

--- a/src/effects/builtin/common/generatoreffectmodel.cpp
+++ b/src/effects/builtin/common/generatoreffectmodel.cpp
@@ -24,6 +24,8 @@ void GeneratorEffectModel::doReload()
     emit durationChanged();
     emit durationFormatChanged();
     doEmitSignals();
+
+    update();
 }
 
 double GeneratorEffectModel::sampleRate() const
@@ -79,6 +81,8 @@ void GeneratorEffectModel::setDuration(double newDuration)
     }
     e->setDuration(newDuration);
     emit durationChanged();
+
+    update();
 }
 
 QString GeneratorEffectModel::durationFormat() const
@@ -98,6 +102,22 @@ void GeneratorEffectModel::setDurationFormat(const QString& newDurationFormat)
     }
     e->setDurationFormat(newDurationFormat);
     emit durationFormatChanged();
+
+    update();
+}
+
+bool GeneratorEffectModel::isApplyAllowed() const
+{
+    return generatorEffect()->isApplyAllowed();
+}
+
+void GeneratorEffectModel::update()
+{
+    const auto wasAllowed = m_isApplyAllowed;
+    m_isApplyAllowed = isApplyAllowed();
+    if (m_isApplyAllowed != wasAllowed) {
+        emit isApplyAllowedChanged();
+    }
 }
 
 GeneratorEffect* GeneratorEffectModel::generatorEffect() const

--- a/src/effects/builtin/common/generatoreffectmodel.h
+++ b/src/effects/builtin/common/generatoreffectmodel.h
@@ -18,6 +18,7 @@ class GeneratorEffectModel : public AbstractEffectModel
     Q_PROPERTY(double tempo READ tempo NOTIFY tempoChanged FINAL)
     Q_PROPERTY(int upperTimeSignature READ upperTimeSignature NOTIFY upperTimeSignatureChanged FINAL)
     Q_PROPERTY(int lowerTimeSignature READ lowerTimeSignature NOTIFY lowerTimeSignatureChanged FINAL)
+    Q_PROPERTY(bool isApplyAllowed READ isApplyAllowed NOTIFY isApplyAllowedChanged FINAL)
 
 public:
 
@@ -29,6 +30,7 @@ public:
     int lowerTimeSignature() const;
     QString durationFormat() const;
     void setDurationFormat(const QString& newDurationFormat);
+    bool isApplyAllowed() const;
 
 signals:
     void sampleRateChanged();
@@ -37,11 +39,15 @@ signals:
     void lowerTimeSignatureChanged();
     void durationChanged();
     void durationFormatChanged();
+    void isApplyAllowedChanged();
 
 private:
     void doReload() final override;
     virtual void doEmitSignals() = 0;
+    void update();
 
     GeneratorEffect* generatorEffect() const;
+
+    bool m_isApplyAllowed = false;
 };
 } // namespace au::effects

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -26,6 +26,7 @@ StyledDialogView {
 
         onIsApplyAllowedChanged: {
             bbox.buttonById(ButtonBoxModel.Apply).enabled = isApplyAllowed
+            bbox.buttonById(previewBtn.buttonId).enabled = isApplyAllowed
         }
     }
 
@@ -60,6 +61,7 @@ StyledDialogView {
         }
 
         FlatButton {
+            id: previewBtn
             text: qsTrc("effects", "Preview")
             buttonRole: ButtonBoxModel.CustomRole
             buttonId: ButtonBoxModel.CustomButton + 2


### PR DESCRIPTION
Resolves: #7860

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
