### PR TITLE
Generator views ignore signals before initialization

### DIFF
--- a/src/effects/builtin/common/abstracteffectmodel.h
+++ b/src/effects/builtin/common/abstracteffectmodel.h
@@ -77,8 +77,10 @@ protected:
         return *st;
     }
 
+protected:
+    bool m_inited = false;
+
 private:
     QString m_instanceId;
-    bool m_inited = false;
 };
 }

--- a/src/effects/builtin/common/generatoreffectmodel.cpp
+++ b/src/effects/builtin/common/generatoreffectmodel.cpp
@@ -73,8 +73,12 @@ double GeneratorEffectModel::duration() const
     return e->duration();
 }
 
-void GeneratorEffectModel::setDuration(double newDuration)
+void GeneratorEffectModel::prop_setDuration(double newDuration)
 {
+    if (!m_inited) {
+        return;
+    }
+
     auto e = generatorEffect();
     IF_ASSERT_FAILED(e) {
         return;
@@ -94,8 +98,12 @@ QString GeneratorEffectModel::durationFormat() const
     return e->durationFormat();
 }
 
-void GeneratorEffectModel::setDurationFormat(const QString& newDurationFormat)
+void GeneratorEffectModel::prop_setDurationFormat(const QString& newDurationFormat)
 {
+    if (!m_inited) {
+        return;
+    }
+
     auto e = generatorEffect();
     IF_ASSERT_FAILED(e) {
         return;

--- a/src/effects/builtin/common/generatoreffectmodel.h
+++ b/src/effects/builtin/common/generatoreffectmodel.h
@@ -12,8 +12,8 @@ class ToneEffect;
 class GeneratorEffectModel : public AbstractEffectModel
 {
     Q_OBJECT
-    Q_PROPERTY(double duration READ duration WRITE setDuration NOTIFY durationChanged)
-    Q_PROPERTY(QString durationFormat READ durationFormat WRITE setDurationFormat NOTIFY durationFormatChanged)
+    Q_PROPERTY(double duration READ duration WRITE prop_setDuration NOTIFY durationChanged)
+    Q_PROPERTY(QString durationFormat READ durationFormat WRITE prop_setDurationFormat NOTIFY durationFormatChanged)
     Q_PROPERTY(double sampleRate READ sampleRate NOTIFY sampleRateChanged FINAL)
     Q_PROPERTY(double tempo READ tempo NOTIFY tempoChanged FINAL)
     Q_PROPERTY(int upperTimeSignature READ upperTimeSignature NOTIFY upperTimeSignatureChanged FINAL)
@@ -23,13 +23,13 @@ class GeneratorEffectModel : public AbstractEffectModel
 public:
 
     double duration() const;
-    void setDuration(double newDuration);
+    void prop_setDuration(double newDuration);
     double sampleRate() const;
     double tempo() const;
     int upperTimeSignature() const;
     int lowerTimeSignature() const;
     QString durationFormat() const;
-    void setDurationFormat(const QString& newDurationFormat);
+    void prop_setDurationFormat(const QString& newDurationFormat);
     bool isApplyAllowed() const;
 
 signals:

--- a/src/effects/builtin/dtmfgen/DtmfView.qml
+++ b/src/effects/builtin/dtmfgen/DtmfView.qml
@@ -25,7 +25,6 @@ EffectBase {
 
     Component.onCompleted: {
         dtmf.init()
-        timecode.currentFormatStr = dtmf.durationFormat
     }
 
     GridLayout {
@@ -97,10 +96,6 @@ EffectBase {
 
             onValueChanged: {
                 dtmf.duration = timecode.value
-            }
-
-            onCurrentFormatChanged: {
-                dtmf.durationFormat = timecode.currentFormatStr
             }
         }
 

--- a/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
+++ b/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
@@ -28,8 +28,11 @@ QString DtmfViewModel::sequence() const
     return QString::fromStdString(settings<DtmfSettings>().dtmfSequence);
 }
 
-void DtmfViewModel::setSequence(const QString& newSequence)
+void DtmfViewModel::prop_setSequence(const QString& newSequence)
 {
+    if (!m_inited) {
+        return;
+    }
     mutSettings<DtmfSettings>().dtmfSequence = newSequence.toStdString();
     emit sequenceChanged();
     recalculateDurations();
@@ -40,8 +43,11 @@ double DtmfViewModel::amplitude() const
     return settings<DtmfSettings>().dtmfAmplitude;
 }
 
-void DtmfViewModel::setAmplitude(double newAmplitude)
+void DtmfViewModel::prop_setAmplitude(double newAmplitude)
 {
+    if (!m_inited) {
+        return;
+    }
     mutSettings<DtmfSettings>().dtmfAmplitude = newAmplitude;
     emit amplitudeChanged();
 }
@@ -51,8 +57,11 @@ double DtmfViewModel::dutyCycle() const
     return settings<DtmfSettings>().dtmfDutyCycle;
 }
 
-void DtmfViewModel::setDutyCycle(double newDutyCycle)
+void DtmfViewModel::prop_setDutyCycle(double newDutyCycle)
 {
+    if (!m_inited) {
+        return;
+    }
     mutSettings<DtmfSettings>().dtmfDutyCycle = newDutyCycle;
     emit dutyCycleChanged();
     recalculateDurations();

--- a/src/effects/builtin/dtmfgen/dtmfviewmodel.h
+++ b/src/effects/builtin/dtmfgen/dtmfviewmodel.h
@@ -13,9 +13,9 @@ class DtmfViewModel : public GeneratorEffectModel
 {
     Q_OBJECT
 
-    Q_PROPERTY(QString sequence READ sequence WRITE setSequence NOTIFY sequenceChanged)
-    Q_PROPERTY(double amplitude READ amplitude WRITE setAmplitude NOTIFY amplitudeChanged)
-    Q_PROPERTY(double dutyCycle READ dutyCycle WRITE setDutyCycle NOTIFY dutyCycleChanged)
+    Q_PROPERTY(QString sequence READ sequence WRITE prop_setSequence NOTIFY sequenceChanged)
+    Q_PROPERTY(double amplitude READ amplitude WRITE prop_setAmplitude NOTIFY amplitudeChanged)
+    Q_PROPERTY(double dutyCycle READ dutyCycle WRITE prop_setDutyCycle NOTIFY dutyCycleChanged)
     Q_PROPERTY(double toneDuration READ toneDuration NOTIFY toneDurationChanged)
     Q_PROPERTY(double silenceDuration READ silenceDuration NOTIFY silenceDurationChanged)
 
@@ -24,13 +24,13 @@ public:
     virtual ~DtmfViewModel();
 
     QString sequence() const;
-    void setSequence(const QString& newSequence);
+    void prop_setSequence(const QString& newSequence);
 
     double amplitude() const;
-    void setAmplitude(double newAmplitude);
+    void prop_setAmplitude(double newAmplitude);
 
     double dutyCycle() const;
-    void setDutyCycle(double newDutyCycle);
+    void prop_setDutyCycle(double newDutyCycle);
 
     double toneDuration() const;
     double silenceDuration() const;

--- a/src/effects/builtin/noisegen/NoiseView.qml
+++ b/src/effects/builtin/noisegen/NoiseView.qml
@@ -25,7 +25,6 @@ EffectBase {
 
     Component.onCompleted: {
         noise.init()
-        timecode.currentFormatStr = noise.durationFormat
     }
 
     GridLayout {
@@ -78,10 +77,6 @@ EffectBase {
 
             onValueChanged: {
                 noise.duration = timecode.value
-            }
-
-            onCurrentFormatChanged: {
-                noise.durationFormat = timecode.currentFormatStr
             }
         }
 

--- a/src/effects/builtin/noisegen/noiseviewmodel.cpp
+++ b/src/effects/builtin/noisegen/noiseviewmodel.cpp
@@ -39,8 +39,11 @@ double NoiseViewModel::amplitude() const
     return settings<NoiseSettings>().amplitude;
 }
 
-void NoiseViewModel::setAmplitude(double newAmplitude)
+void NoiseViewModel::prop_setAmplitude(double newAmplitude)
 {
+    if (!m_inited) {
+        return;
+    }
     mutSettings<NoiseSettings>().amplitude = newAmplitude;
     emit amplitudeChanged();
 }
@@ -50,8 +53,11 @@ int NoiseViewModel::type() const
     return static_cast<int>(settings<NoiseSettings>().type);
 }
 
-void NoiseViewModel::setType(int type)
+void NoiseViewModel::prop_setType(int type)
 {
+    if (!m_inited) {
+        return;
+    }
     mutSettings<NoiseSettings>().type = static_cast<NoiseSettings::Type>(type);
     emit typeChanged();
 }

--- a/src/effects/builtin/noisegen/noiseviewmodel.h
+++ b/src/effects/builtin/noisegen/noiseviewmodel.h
@@ -13,16 +13,16 @@ class NoiseViewModel : public GeneratorEffectModel
 {
     Q_OBJECT
 
-    Q_PROPERTY(double amplitude READ amplitude WRITE setAmplitude NOTIFY amplitudeChanged)
-    Q_PROPERTY(int type READ type WRITE setType NOTIFY typeChanged)
+    Q_PROPERTY(double amplitude READ amplitude WRITE prop_setAmplitude NOTIFY amplitudeChanged)
+    Q_PROPERTY(int type READ type WRITE prop_setType NOTIFY typeChanged)
     Q_PROPERTY(QVariantList types READ types CONSTANT)
 
 public:
     QVariantList types() const;
     double amplitude() const;
-    void setAmplitude(double newAmplitude);
+    void prop_setAmplitude(double newAmplitude);
     int type() const;
-    void setType(int type);
+    void prop_setType(int type);
 
 signals:
     void amplitudeChanged();

--- a/src/effects/builtin/tonegen/ToneView.qml
+++ b/src/effects/builtin/tonegen/ToneView.qml
@@ -25,7 +25,6 @@ EffectBase {
 
     Component.onCompleted: {
         tone.init()
-        timecode.currentFormatStr = tone.durationFormat
     }
 
     // Helper function to format number
@@ -114,10 +113,6 @@ EffectBase {
 
             onValueChanged: {
                 tone.duration = timecode.value
-            }
-
-            onCurrentFormatChanged: {
-                tone.durationFormat = timecode.currentFormatStr
             }
         }
     }

--- a/src/effects/builtin/tonegen/toneviewmodel.cpp
+++ b/src/effects/builtin/tonegen/toneviewmodel.cpp
@@ -48,8 +48,12 @@ double ToneViewModel::amplitude() const
     return te->amplitude();
 }
 
-void ToneViewModel::setAmplitude(double newAmplitude)
+void ToneViewModel::prop_setAmplitude(double newAmplitude)
 {
+    if (!m_inited) {
+        return;
+    }
+
     const auto wasAllowed = isApplyAllowed();
     ToneEffect* const te = effect();
     IF_ASSERT_FAILED(te) {
@@ -70,8 +74,12 @@ double ToneViewModel::frequency() const
     return te->frequency();
 }
 
-void ToneViewModel::setFrequency(double newFrequency)
+void ToneViewModel::prop_setFrequency(double newFrequency)
 {
+    if (!m_inited) {
+        return;
+    }
+
     const auto wasAllowed = isApplyAllowed();
     ToneEffect* const te = effect();
     IF_ASSERT_FAILED(te) {
@@ -92,8 +100,12 @@ int ToneViewModel::waveform() const
     return static_cast<int>(te->waveform());
 }
 
-void ToneViewModel::setWaveform(int newWaveform)
+void ToneViewModel::prop_setWaveform(int newWaveform)
 {
+    if (!m_inited) {
+        return;
+    }
+
     ToneEffect* const te = effect();
     IF_ASSERT_FAILED(te) {
         return;

--- a/src/effects/builtin/tonegen/toneviewmodel.h
+++ b/src/effects/builtin/tonegen/toneviewmodel.h
@@ -11,20 +11,20 @@ class ToneViewModel : public GeneratorEffectModel
 {
     Q_OBJECT
     Q_PROPERTY(bool isApplyAllowed READ isApplyAllowed NOTIFY isApplyAllowedChanged)
-    Q_PROPERTY(double amplitude READ amplitude WRITE setAmplitude NOTIFY amplitudeChanged)
-    Q_PROPERTY(double frequency READ frequency WRITE setFrequency NOTIFY frequencyChanged)
-    Q_PROPERTY(int waveform READ waveform WRITE setWaveform NOTIFY waveformChanged)
+    Q_PROPERTY(double amplitude READ amplitude WRITE prop_setAmplitude NOTIFY amplitudeChanged)
+    Q_PROPERTY(double frequency READ frequency WRITE prop_setFrequency NOTIFY frequencyChanged)
+    Q_PROPERTY(int waveform READ waveform WRITE prop_setWaveform NOTIFY waveformChanged)
     Q_PROPERTY(QList<QString> waveforms READ waveforms CONSTANT)
 
 public:
     bool isApplyAllowed() const;
     QList<QString> waveforms() const;
     double amplitude() const;
-    void setAmplitude(double newAmplitude);
+    void prop_setAmplitude(double newAmplitude);
     double frequency() const;
-    void setFrequency(double newFrequency);
+    void prop_setFrequency(double newFrequency);
     int waveform() const;
-    void setWaveform(int newWaveform);
+    void prop_setWaveform(int newWaveform);
 
 signals:
     void amplitudeChanged();


### PR DESCRIPTION
Resolves: #7859

Current problem: the duration format should be initialized by the setting value, but an early signal leads to it being overwritten with the default value of `TimecodeModel` (`hh:mm:ss`) :
```mermaid
sequenceDiagram
    Timecode ->> ToneViewModel: durationFormat()
    Note over ToneViewModel: not initialized yet
    ToneViewModel -->> Timecode: empty string
    ToneView ->> ToneViewModel: init()
    ToneViewModel ->> ToneViewModel: setDurationFormat("hh:mm:ss + msec")
    ToneViewModel ->> Timecode: emit sampleRateChanged()
    Note over Timecode: Unfortunately leads to ...
    Timecode ->> ToneViewModel: setDurationFormat("hh:mm:ss")
    Note over ToneViewModel: Undoes setDurationFormat("hh:mm:ss + msec")
    ToneViewModel ->> Timecode: emit durationFormatChanged() ...
```
Proposed solution:
* ignore signals coming from QML components while `AbstractEffectModel::m_inited == false`,
* prefix property setter methods with `prop_` in generator models to make it obvious that they are only called from Qt.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
