### PR TITLE
EffectConfigSettings implementation fix

### DIFF
--- a/src/effects/effects_base/internal/effectconfigsettings.h
+++ b/src/effects/effects_base/internal/effectconfigsettings.h
@@ -70,7 +70,7 @@ private:
     bool WriteValue(const wxString& key, T value)
     {
         std::string full = fullKey(key);
-        m_vals.insert({ full, value });
+        m_vals[full] = value;
         return true;
     }
 


### PR DESCRIPTION
Resolves: no existing ticket yet

Currently, applying an effect or generator does not make the settings persistent, e.g. generate a tone with non-default square waveform, next time you generate a tone, the square waveform should have become the default.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
