### PR TITLE
7885 selection fixes for effect on clip selection

### DIFF
--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -267,7 +267,7 @@ muse::Ret EffectExecutionScenario::doPerformEffect(au3::Au3Project& project, con
         //! NOTE Step 7.2 - update selected region after process
 
         //! Generators, and even some processors (e.g. tempo change), need an update of the selection.
-        if (success && numSelectedClips < 2 && (effect->mT1 >= effect->mT0)) {
+        if (success && numSelectedClips == 0 && (effect->mT1 >= effect->mT0)) {
             selectionController()->setDataSelectedStartTime(effect->mT0, true);
             selectionController()->setDataSelectedEndTime(effect->mT1, true);
         }

--- a/src/effects/effects_base/internal/effectexecutionscenario.h
+++ b/src/effects/effects_base/internal/effectexecutionscenario.h
@@ -48,6 +48,9 @@ private:
     std::pair<std::string, std::string> makeErrorMsg(const muse::Ret& ret, const EffectId& effectId);
     muse::Ret performEffectWithShowError(au3::Au3Project& project, const EffectId& effectId, unsigned int flags);
     muse::Ret doPerformEffect(au3::Au3Project& project, const EffectId& effectId, unsigned int flags);
+    muse::Ret performEffectOnTimeSelection(au3::Au3Project& project, Effect&, const std::shared_ptr<EffectInstanceEx>&, EffectSettings&);
+    std::optional<trackedit::ClipId> performEffectOnSingleClip(au3::Au3Project&, Effect&, const std::shared_ptr<EffectInstanceEx>&,
+                                                               EffectSettings&, trackedit::TrackId trackId, muse::Ret&);
     muse::Ret performEffectOnEachSelectedClip(au3::Au3Project& project, Effect&, const std::shared_ptr<EffectInstanceEx>&, EffectSettings&);
     au3::Au3Project& projectRef();
 

--- a/src/projectscene/view/clipsview/au3/au3wavepainter.cpp
+++ b/src/projectscene/view/clipsview/au3/au3wavepainter.cpp
@@ -632,7 +632,8 @@ void Au3WavePainter::paint(QPainter& painter, const trackedit::ClipKey& clipKey,
     }
 
     std::shared_ptr<WaveClip> clip = DomAccessor::findWaveClip(track, clipKey.clipId);
-    IF_ASSERT_FAILED(clip) {
+    if (!clip) {
+        // A clip-replacement operation may be ongoing, it's okay to return ; a new paint event will be triggered when it's done.
         return;
     }
 

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -584,11 +584,24 @@ void ClipsListModel::onSelectedClip(const trackedit::ClipKey& k)
     }
 }
 
-void ClipsListModel::onSelectedClips(const trackedit::ClipKeyList &keyList)
+void ClipsListModel::onSelectedClips(const trackedit::ClipKeyList& keyList)
 {
-    for (const auto& clip : keyList) {
-        onSelectedClip(clip);
+    if (keyList.size() == 1) {
+        onSelectedClip(keyList.front());
+        return;
     }
+
+    // Multiple-clip selection can only be done programmatically, hence there is no need to check for the Shift key ;
+    // we can begin by clearing everything.
+    clearSelectedItems();
+
+    QList<ClipListItem*> items;
+    for (const auto& k : keyList) {
+        if (const auto item = itemByKey(k)) {
+            items.append(item);
+        }
+    }
+    setSelectedItems(items);
 }
 
 QVariant ClipsListModel::trackId() const

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -135,7 +135,18 @@ void Au3SelectionController::setSelectedClips(const ClipKeyList& clipKeys, bool 
     setSelectedTracks(selectedTracks, complete);
 }
 
-void Au3SelectionController::addSelectedClip(const ClipKey &clipKey)
+std::optional<au::trackedit::ClipId> Au3SelectionController::setSelectedClip(trackedit::TrackId trackId, secs_t time)
+{
+    const auto& clip = au3::DomAccessor::findWaveClip(projectRef(), trackId, time);
+    if (!clip) {
+        return std::nullopt;
+    }
+
+    setSelectedClips({ { trackId, clip->GetId() } }, true);
+    return clip->GetId();
+}
+
+void Au3SelectionController::addSelectedClip(const ClipKey& clipKey)
 {
     auto selectedClips = m_selectedClips.val;
 

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -37,6 +37,7 @@ public:
     bool hasSelectedClips() const override;
     ClipKeyList selectedClips() const override;
     void setSelectedClips(const ClipKeyList& clipKeys, bool complete = true) override;
+    std::optional<trackedit::ClipId> setSelectedClip(trackedit::TrackId trackId, secs_t time) override;
     void addSelectedClip(const ClipKey& clipKey) override;
     muse::async::Channel<ClipKeyList> clipsSelected() const override;
     double selectedClipStartTime() const override;

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -6,6 +6,8 @@
 
 #include "trackedit/trackedittypes.h"
 
+#include <optional>
+
 namespace au::trackedit {
 //! NOTE Currently implemented in the au3wrap module
 class ISelectionController : MODULE_EXPORT_INTERFACE
@@ -34,6 +36,7 @@ public:
     virtual bool hasSelectedClips() const = 0;
     virtual ClipKeyList selectedClips() const = 0;
     virtual void setSelectedClips(const ClipKeyList& clipKeys, bool complete = true) = 0;
+    virtual std::optional<ClipId> setSelectedClip(trackedit::TrackId trackId, secs_t time) = 0;
     virtual void addSelectedClip(const ClipKey& clipKey) = 0;
     virtual muse::async::Channel<ClipKeyList> clipsSelected() const = 0;
 

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -21,6 +21,7 @@ public:
     MOCK_METHOD(bool, hasSelectedClips, (), (const, override));
     MOCK_METHOD(ClipKeyList, selectedClips, (), (const, override));
     MOCK_METHOD(void, setSelectedClips, (const ClipKeyList&, bool), (override));
+    MOCK_METHOD(std::optional<ClipId>, setSelectedClip, (trackedit::TrackId, secs_t), (override));
     MOCK_METHOD(void, addSelectedClip, (const ClipKey& clipKey), (override));
     MOCK_METHOD(muse::async::Channel<ClipKeyList>, clipsSelected, (), (const, override));
     MOCK_METHOD(double, selectedClipStartTime, (), (const, override));


### PR DESCRIPTION
Resolves: #7885

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
Selection should now be preserved whether the effect is applied on
- [ ] a time selection
- [ ] a single-selected clip
- [ ] multiple selected clips