### PR TITLE
improve misleading diagnostics on mod load failure

### DIFF
--- a/libraries/lib-module-manager/ModuleManager.cpp
+++ b/libraries/lib-module-manager/ModuleManager.cpp
@@ -108,7 +108,13 @@ bool Module::Load(wxString &deferredErrorMessage)
 
    auto ShortName = wxFileName(mName).GetName();
 
-   if (!mLib->Load(mName, wxDL_NOW | wxDL_QUIET | wxDL_GLOBAL)) {
+￼  // If we hit an error in libdl, it doesn't set errno; you instead
+￼  // have to use dlerror(), and there is no public integer representation.
+￼  // Similarly, if Load() fails for anything else that isn't a system
+￼  // call, errno won't be set, but wxSysErrorMsg() uses errno. So at
+￼  // least 0 it out beforehand, and let wxDynamicLibrary log errors.
+￼  errno = 0;
+￼  if (!mLib->Load(mName, wxDL_NOW | wxDL_GLOBAL)) {
       // For this failure path, only, there is a possibility of retrial
       // after some other dependency of this module is loaded.  So the
       // error is not immediately reported.


### PR DESCRIPTION
wxSysErrorMsg() uses strerror(errno) on Unix platforms. If Load() failed due to something other than a system call failure, this will be a misleading diagnostic (such failures happen in practice due to libdl failures in wxDynamicLibrary). Zero out errno before calling Load(), so at worst we'll get "Error: Operation succeeded" or whatever, so the confusion is at least tightly constrained. In addition, remove wxDL_QUIET, so that we get a diagnostic printed to stderr on a libdl failure; this ought make the true problem obvious.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
