### PR TITLE
Fix crash on close if playback is active

### DIFF
--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -23,7 +23,7 @@ using namespace au::playback;
 using namespace au::au3;
 
 Au3Player::Au3Player()
-    : m_positionUpdateTimer(std::chrono::microseconds(1000))
+    : m_positionUpdateTimer(std::chrono::milliseconds(16))
 {
     m_positionUpdateTimer.onTimeout(this, [this]() {
         updatePlaybackState();
@@ -344,6 +344,14 @@ void Au3Player::resetLoop()
 
 void Au3Player::updatePlaybackState()
 {
+    if (m_playbackStatus.val != PlaybackStatus::Running) {
+        return;
+    }
+
+    IF_ASSERT_FAILED(globalContext()->currentProject()) {
+        return;
+    }
+
     int token = ProjectAudioIO::Get(projectRef()).GetAudioIOToken();
     bool isActive = AudioIO::Get()->IsStreamActive(token);
     double time = AudioIO::Get()->GetStreamTime() + m_startOffset;


### PR DESCRIPTION

Resolves: #7807

Skip events that were sent before the timer was stopped


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
