### PR TITLE
Attach color on a track

### DIFF
--- a/src/au3wrap/CMakeLists.txt
+++ b/src/au3wrap/CMakeLists.txt
@@ -49,6 +49,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3commonsettings.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3basicui.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3basicui.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/trackcolor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/trackcolor.h
     )
 
 

--- a/src/au3wrap/internal/domconverter.cpp
+++ b/src/au3wrap/internal/domconverter.cpp
@@ -1,6 +1,7 @@
 #include "domconverter.h"
 
 #include "au3types.h"
+#include "trackcolor.h"
 #include "libraries/lib-track/Track.h"
 #include "libraries/lib-wave-track/WaveClip.h"
 #include "libraries/lib-wave-track/WaveTrack.h"
@@ -27,28 +28,6 @@ static au::trackedit::TrackType trackType(const Au3Track* track)
 
     return au::trackedit::TrackType::Undefined;
 }
-
-static muse::draw::Color trackColor(const au::trackedit::TrackId& trackId)
-{
-    //! TODO AU4 Just for tests
-    static std::vector<muse::draw::Color> colors = {
-        muse::draw::Color::fromString("#66A3FF"),
-        muse::draw::Color::fromString("#9996FC"),
-        muse::draw::Color::fromString("#DA8CCC"),
-        muse::draw::Color::fromString("#F08080"),
-        muse::draw::Color::fromString("#FF9E65"),
-        muse::draw::Color::fromString("#E8C050"),
-        muse::draw::Color::fromString("#74BE59"),
-        muse::draw::Color::fromString("#34B494"),
-        muse::draw::Color::fromString("#48BECF")
-    };
-    size_t colorIdx = std::llabs(trackId);
-    if (colorIdx >= colors.size()) {
-        colorIdx = colorIdx % colors.size();
-    }
-
-    return colors.at(colorIdx);
-}
 }
 
 au::trackedit::Clip DomConverter::clip(const Au3WaveTrack* waveTrack, const Au3WaveClip* au3clip)
@@ -59,7 +38,7 @@ au::trackedit::Clip DomConverter::clip(const Au3WaveTrack* waveTrack, const Au3W
     clip.title = wxToString(au3clip->GetName());
     clip.startTime = au3clip->GetPlayStartTime();
     clip.endTime = au3clip->GetPlayEndTime();
-    clip.color = trackColor(clip.key.trackId);
+    clip.color = TrackColor::Get(waveTrack).GetColor();
     clip.stereo = au3clip->NChannels() > 1;
 
     clip.pitch = au3clip->GetCentShift();
@@ -77,7 +56,7 @@ au::trackedit::Track DomConverter::track(const Au3Track* waveTrack)
     au4t.id = waveTrack->GetId();
     au4t.title = wxToString(waveTrack->GetName());
     au4t.type = trackType(waveTrack);
-    au4t.color = trackColor(au4t.id);
+    au4t.color = TrackColor::Get(waveTrack).GetColor();
 
     return au4t;
 }

--- a/src/au3wrap/internal/trackcolor.cpp
+++ b/src/au3wrap/internal/trackcolor.cpp
@@ -1,0 +1,62 @@
+#include "trackcolor.h"
+
+using namespace au::au3;
+
+//! TODO AU4 Just for tests
+static std::vector<muse::draw::Color> colors = {
+    muse::draw::Color::fromString("#66A3FF"),
+    muse::draw::Color::fromString("#9996FC"),
+    muse::draw::Color::fromString("#DA8CCC"),
+    muse::draw::Color::fromString("#F08080"),
+    muse::draw::Color::fromString("#FF9E65"),
+    muse::draw::Color::fromString("#E8C050"),
+    muse::draw::Color::fromString("#74BE59"),
+    muse::draw::Color::fromString("#34B494"),
+    muse::draw::Color::fromString("#48BECF")
+};
+
+static const AttachedTrackObjects::RegisteredFactory keyTrackColor{
+    [](Track &track) -> std::shared_ptr<TrackColor>{ return std::make_shared<TrackColor>(track); }
+};
+
+TrackColor &TrackColor::Get(Track *track)
+{
+    return track->AttachedTrackObjects::Get<TrackColor>(keyTrackColor);
+}
+
+TrackColor &TrackColor::Get(const Track *track)
+{
+    return Get(const_cast<Track *>(track));
+}
+
+TrackColor::TrackColor(Track& track)
+    : mTrack{ track.shared_from_this() }
+{
+    size_t colorIdx = std::llabs(track.GetId());
+    if (colorIdx >= colors.size()) {
+        colorIdx = colorIdx % colors.size();
+    }
+    mColor = colors.at(colorIdx);
+}
+
+void TrackColor::Reparent(const std::shared_ptr<Track> &parent)
+{
+    mTrack = parent;
+}
+
+void TrackColor::WriteXMLAttributes(XMLWriter &writer) const
+{
+    writer.WriteAttr("color", mColor.toString());
+}
+
+bool TrackColor::HandleXMLAttribute(const std::string_view &attr, const XMLAttributeValueView &valueView)
+{
+    if (attr == "color") {
+        mColor = muse::draw::Color::fromString(valueView.ToWString());
+        return true;
+    }
+
+    return false;
+}
+
+muse::draw::Color TrackColor::GetColor() const { return mColor; }

--- a/src/au3wrap/internal/trackcolor.cpp
+++ b/src/au3wrap/internal/trackcolor.cpp
@@ -19,6 +19,8 @@ static const AttachedTrackObjects::RegisteredFactory keyTrackColor{
     [](Track &track) -> std::shared_ptr<TrackColor>{ return std::make_shared<TrackColor>(track); }
 };
 
+static constexpr auto ColorAttr = "color";
+
 TrackColor &TrackColor::Get(Track *track)
 {
     return track->AttachedTrackObjects::Get<TrackColor>(keyTrackColor);
@@ -46,12 +48,12 @@ void TrackColor::Reparent(const std::shared_ptr<Track> &parent)
 
 void TrackColor::WriteXMLAttributes(XMLWriter &writer) const
 {
-    writer.WriteAttr("color", mColor.toString());
+    writer.WriteAttr(ColorAttr, mColor.toString());
 }
 
 bool TrackColor::HandleXMLAttribute(const std::string_view &attr, const XMLAttributeValueView &valueView)
 {
-    if (attr == "color") {
+    if (attr == ColorAttr) {
         mColor = muse::draw::Color::fromString(valueView.ToWString());
         return true;
     }

--- a/src/au3wrap/internal/trackcolor.h
+++ b/src/au3wrap/internal/trackcolor.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "libraries/lib-track/Track.h"
+#include "draw/types/color.h"
+
+namespace au::au3 {
+
+class TrackColor : public TrackAttachment
+{
+public:
+    static TrackColor &Get(const Track *track);
+    static TrackColor &Get(Track *track);
+
+    TrackColor(Track& track);
+    void Reparent(const std::shared_ptr<Track> &parent) override;
+    void WriteXMLAttributes(XMLWriter &writer) const override;
+    bool HandleXMLAttribute(const std::string_view &attr, const XMLAttributeValueView &valueView) override;
+
+    muse::draw::Color GetColor() const;
+private:
+    std::weak_ptr<Track> mTrack;
+    muse::draw::Color mColor;
+};
+
+}


### PR DESCRIPTION
Resolves: #7879 

In the current version, the clip color is determined by the trackId, which is generated using an ever-increasing counter. However, when a project is closed and reopened, the counter is not reinitialized, resulting in different colors being assigned each time.

To address this issue we now save this information as an attachment in the track. This allows the color to be retrieved consistently when the project is reopened.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
