### PR TITLE
Round to the nearest integer

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -16,7 +16,7 @@ Rectangle {
     property alias clipTime: waveView.clipTime
     property alias title: titleLabel.text
     property int pitch: 0
-    property int speedPercentage: 0.0
+    property int speedPercentage: 0
     property alias showChannelSplitter: channelSplitter.visible
     property alias channelHeightRatio: channelSplitter.channelHeightRatio
     property var canvas: null
@@ -428,7 +428,7 @@ Rectangle {
                     id: speedBtn
 
                     icon: IconCode.CLOCK
-                    text: Math.floor(root.speedPercentage) + "%"
+                    text: root.speedPercentage + "%"
 
                     visible: root.speedPercentage !== 100.0
 

--- a/src/projectscene/view/clipsview/cliplistitem.cpp
+++ b/src/projectscene/view/clipsview/cliplistitem.cpp
@@ -134,7 +134,7 @@ int ClipListItem::pitch() const
     return m_clip.pitch;
 }
 
-double ClipListItem::speedPercentage() const
+int ClipListItem::speedPercentage() const
 {
-    return 100.0 / m_clip.speed;
+    return qRound(100.0 / m_clip.speed);
 }

--- a/src/projectscene/view/clipsview/cliplistitem.h
+++ b/src/projectscene/view/clipsview/cliplistitem.h
@@ -30,7 +30,7 @@ class ClipListItem : public QObject
     Q_PROPERTY(bool selected READ selected WRITE setSelected NOTIFY selectedChanged FINAL)
 
     Q_PROPERTY(int pitch READ pitch NOTIFY pitchChanged FINAL)
-    Q_PROPERTY(double speedPercentage READ speedPercentage NOTIFY speedPercentageChanged FINAL)
+    Q_PROPERTY(int speedPercentage READ speedPercentage NOTIFY speedPercentageChanged FINAL)
 
 public:
     ClipListItem(QObject* parent);
@@ -63,7 +63,7 @@ public:
     void setRightVisibleMargin(double newRightVisibleMargin);
 
     int pitch() const;
-    double speedPercentage() const;
+    int speedPercentage() const;
 
 signals:
     void titleChanged();


### PR DESCRIPTION
Resolves: #7887

Fix the speed indicator rounding.
The previous code was doing a floor and not rounding to the nearest integer. This is important while dealing with double values.
Apart from that, the speed qt/qml property was configured to be an int.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
