### PR TITLE
Fix bug #7672 by moving define statement to header so that subclasses…

### DIFF
--- a/libraries/lib-builtin-effects/NoiseReductionBase.cpp
+++ b/libraries/lib-builtin-effects/NoiseReductionBase.cpp
@@ -50,19 +50,6 @@
 
 typedef std::vector<float> FloatVector;
 
-// Define both of these to make the radio button three-way
-#define RESIDUE_CHOICE
-//#define ISOLATE_CHOICE
-
-// Define for Attack and release controls.
-// #define ATTACK_AND_RELEASE
-
-// Define to expose other advanced, experimental dialog controls
-//#define ADVANCED_SETTINGS
-
-// Define to make the old statistical methods an available choice
-//#define OLD_METHOD_AVAILABLE
-
 namespace
 {
 

--- a/libraries/lib-builtin-effects/NoiseReductionBase.h
+++ b/libraries/lib-builtin-effects/NoiseReductionBase.h
@@ -12,6 +12,19 @@
 
 #include "StatefulEffect.h"
 
+// Define both of these to make the radio button three-way
+#define RESIDUE_CHOICE
+//#define ISOLATE_CHOICE
+
+// Define for Attack and release controls.
+// #define ATTACK_AND_RELEASE
+
+// Define to expose other advanced, experimental dialog controls
+//#define ADVANCED_SETTINGS
+
+// Define to make the old statistical methods an available choice
+//#define OLD_METHOD_AVAILABLE
+
 enum NoiseReductionChoice
 {
    NRC_REDUCE_NOISE,


### PR DESCRIPTION

Resolves: #7672

Move the define statement for RESIDUE_CHOICE (and related comments) to the header file NoiseReductionBase.h so that it gets included into both NoiseReductionBase.cpp and src/effects/NoiseReduction.cpp

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
