### PR TITLE
Avoid text change due binding while editing

### DIFF
--- a/src/effects/builtin/amplify/AmplifyView.qml
+++ b/src/effects/builtin/amplify/AmplifyView.qml
@@ -45,11 +45,19 @@ EffectBase {
                 text: qsTrc("effects/amplify", "Amplification (dB):")
             }
 
+            Binding {
+                target: ampInput
+                property: "currentText"
+                value: +amplify.amp.toFixed(4)
+                when: !ampInput.focus
+                restoreMode: Binding.RestoreNone
+            }
+
             TextInputField {
+                id: ampInput
+
                 anchors.verticalCenter: parent.verticalCenter
                 width: 80
-
-                currentText: amplify.amp.toFixed(4)
 
                 validator: DoubleInputValidator {
                     top: amplify.ampMax
@@ -87,11 +95,19 @@ EffectBase {
                 text: qsTrc("effects/amplify", "New Peak Amplitude (dB):")
             }
 
+            Binding {
+                target: newPeakInput
+                property: "currentText"
+                value: +amplify.newPeak.toFixed(4)
+                when: !newPeakInput.focus
+                restoreMode: Binding.RestoreNone
+            }
+
             TextInputField {
+                id: newPeakInput
+
                 anchors.verticalCenter: parent.verticalCenter
                 width: 80
-
-                currentText: amplify.newPeak.toFixed(4)
 
                 validator: DoubleInputValidator {
                     top: amplify.newPeakMax

--- a/src/effects/builtin/amplify/AmplifyView.qml
+++ b/src/effects/builtin/amplify/AmplifyView.qml
@@ -48,7 +48,7 @@ EffectBase {
             Binding {
                 target: ampInput
                 property: "currentText"
-                value: +amplify.amp.toFixed(4)
+                value: amplify.amp.toFixed(4)
                 // Remove binding while editing the text to avoid toFixed to override the input
                 when: !ampInput.focus
                 restoreMode: Binding.RestoreNone
@@ -99,7 +99,7 @@ EffectBase {
             Binding {
                 target: newPeakInput
                 property: "currentText"
-                value: +amplify.newPeak.toFixed(4)
+                value: amplify.newPeak.toFixed(4)
                 // Remove binding while editing the text to avoid toFixed to override the input
                 when: !newPeakInput.focus
                 restoreMode: Binding.RestoreNone

--- a/src/effects/builtin/amplify/AmplifyView.qml
+++ b/src/effects/builtin/amplify/AmplifyView.qml
@@ -49,6 +49,7 @@ EffectBase {
                 target: ampInput
                 property: "currentText"
                 value: +amplify.amp.toFixed(4)
+                // Remove binding while editing the text to avoid toFixed to override the input
                 when: !ampInput.focus
                 restoreMode: Binding.RestoreNone
             }
@@ -99,6 +100,7 @@ EffectBase {
                 target: newPeakInput
                 property: "currentText"
                 value: +amplify.newPeak.toFixed(4)
+                // Remove binding while editing the text to avoid toFixed to override the input
                 when: !newPeakInput.focus
                 restoreMode: Binding.RestoreNone
             }


### PR DESCRIPTION
Resolves: #7925

Remove the binding while user is editing the text.
This avoids a text change to trigger a call to toFixed and a change in the text itself due the binding.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
