### PR TITLE
7938 summonable realtime effect dialogs

### DIFF
--- a/src/effects/builtin/common/abstracteffectmodel.cpp
+++ b/src/effects/builtin/common/abstracteffectmodel.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<au::effects::EffectInstance> AbstractEffectModel::instance() con
     return instancesRegister()->instanceById(id);
 }
 
-EffectSettings* AbstractEffectModel::settings() const
+const EffectSettings* AbstractEffectModel::settings() const
 {
     EffectInstanceId id = this->instanceId();
     if (id == 0) {
@@ -54,6 +54,16 @@ EffectSettings* AbstractEffectModel::settings() const
     }
 
     return instancesRegister()->settingsById(id);
+}
+
+EffectSettingsAccess* AbstractEffectModel::settingsAccess() const
+{
+    EffectInstanceId id = this->instanceId();
+    if (id == 0) {
+        return nullptr;
+    }
+
+    return instancesRegister()->settingsAccessById(id);
 }
 
 EffectInstanceId AbstractEffectModel::instanceId() const
@@ -68,7 +78,12 @@ EffectId AbstractEffectModel::effectId() const
 
 void AbstractEffectModel::preview()
 {
-    executionScenario()->previewEffect(this->instanceId(), *this->settings());
+    if (EffectSettingsAccess* access = this->settingsAccess()) {
+        access->ModifySettings([this](EffectSettings& settings) {
+            executionScenario()->previewEffect(instanceId(), settings);
+            return nullptr;
+        });
+    }
 }
 
 QString AbstractEffectModel::instanceId_prop() const

--- a/src/effects/builtin/common/abstracteffectmodel.h
+++ b/src/effects/builtin/common/abstracteffectmodel.h
@@ -48,31 +48,18 @@ protected:
     virtual void doReload() = 0;
 
     std::shared_ptr<effects::EffectInstance> instance() const;
-    EffectSettings* settings() const;
+    const EffectSettings* settings() const;
+    EffectSettingsAccess* settingsAccess() const;
 
     template<typename T>
     const T& settings() const
     {
-        EffectSettings* s = this->settings();
+        const EffectSettings* s = this->settings();
         if (!s) {
             static T null;
             return null;
         }
-        T* st = s->cast<T>();
-        assert(st);
-        return *st;
-    }
-
-    template<typename T>
-    T& mutSettings()
-    {
-        EffectSettings* s = this->settings();
-        assert(s);
-        if (!s) {
-            static T null;
-            return null;
-        }
-        T* st = s->cast<T>();
+        const T* st = s->cast<T>();
         assert(st);
         return *st;
     }

--- a/src/effects/builtin/common/generatoreffectmodel.cpp
+++ b/src/effects/builtin/common/generatoreffectmodel.cpp
@@ -16,7 +16,7 @@ void GeneratorEffectModel::doReload()
     IF_ASSERT_FAILED(ge) {
         return;
     }
-    ge->init(settings());
+    ge->init(&mutSettings());
     emit sampleRateChanged();
     emit tempoChanged();
     emit upperTimeSignatureChanged();

--- a/src/effects/builtin/common/generatoreffectmodel.h
+++ b/src/effects/builtin/common/generatoreffectmodel.h
@@ -45,6 +45,27 @@ signals:
     void durationFormatChanged();
     void isApplyAllowedChanged();
 
+protected:
+    template<typename T>
+    T& mutSettings()
+    {
+        // Generators have singleton usage ; no risk of concurrency, settings may be returned without protection.
+        EffectSettings* s = const_cast<EffectSettings*>(this->settings());
+        assert(s);
+        if (!s) {
+            static T null;
+            return null;
+        }
+        T* st = s->cast<T>();
+        assert(st);
+        return *st;
+    }
+
+    EffectSettings& mutSettings()
+    {
+        return *const_cast<EffectSettings*>(this->settings());
+    }
+
 private:
     void doReload() final override;
     virtual void doEmitSignals() = 0;

--- a/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
+++ b/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
@@ -105,7 +105,12 @@ double DtmfViewModel::silenceDuration() const
 
 void DtmfViewModel::recalculateDurations()
 {
-    mutSettings<DtmfSettings>().Recalculate(*AbstractEffectModel::settings());
-    emit toneDurationChanged();
-    emit silenceDurationChanged();
+    if (EffectSettingsAccess* access = settingsAccess()) {
+        access->ModifySettings([this](EffectSettings& settings) {
+            mutSettings<DtmfSettings>().Recalculate(settings);
+            return nullptr;
+        });
+        emit toneDurationChanged();
+        emit silenceDurationChanged();
+    }
 }

--- a/src/effects/builtin/reverb/reverbviewmodel.h
+++ b/src/effects/builtin/reverb/reverbviewmodel.h
@@ -29,7 +29,7 @@ private:
 
     void doReload() override;
 
-    using Setter = std::function<void (double)>;
+    using Setter = std::function<void (ReverbSettings&, double)>;
 
     QVariantList m_paramsList;
     QMap<QString, Setter> m_setters;

--- a/src/effects/effects_base/CMakeLists.txt
+++ b/src/effects/effects_base/CMakeLists.txt
@@ -52,6 +52,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/effectsuiengine.h
     ${CMAKE_CURRENT_LIST_DIR}/view/effectviewloader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/effectviewloader.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/realtimeeffectviewerdialogmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/realtimeeffectviewerdialogmodel.h
     )
 
 # AU3

--- a/src/effects/effects_base/effects_base.qrc
+++ b/src/effects/effects_base/effects_base.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file>qml/Audacity/Effects/EffectsViewerDialog.qml</file>
+        <file>qml/Audacity/Effects/RealtimeEffectViewerDialog.qml</file>
         <file>qml/Audacity/Effects/EffectsViewer.qml</file>
         <file>qml/Audacity/Effects/PresetNameDialog.qml</file>
     </qresource>

--- a/src/effects/effects_base/effectsmodule.cpp
+++ b/src/effects/effects_base/effectsmodule.cpp
@@ -22,6 +22,7 @@
 #include "view/effectsviewregister.h"
 #include "view/effectviewloader.h"
 #include "view/effectsuiengine.h"
+#include "view/realtimeeffectviewerdialogmodel.h"
 
 using namespace au::effects;
 
@@ -58,6 +59,7 @@ void EffectsModule::resolveImports()
     auto ir = ioc()->resolve<muse::ui::IInteractiveUriRegister>(moduleName());
     if (ir) {
         ir->registerQmlUri(muse::Uri("audacity://effects/viewer"), "Audacity/Effects/EffectsViewerDialog.qml");
+        ir->registerQmlUri(muse::Uri("audacity://effects/realtime_viewer"), "Audacity/Effects/RealtimeEffectViewerDialog.qml");
         ir->registerQmlUri(muse::Uri("audacity://effects/presets/input_name"), "Audacity/Effects/PresetNameDialog.qml");
     }
 }
@@ -70,6 +72,7 @@ void EffectsModule::registerResources()
 void EffectsModule::registerUiTypes()
 {
     qmlRegisterType<EffectViewLoader>("Audacity.Effects", 1, 0, "EffectViewLoader");
+    qmlRegisterType<RealtimeEffectViewerDialogModel>("Audacity.Effects", 1, 0, "RealtimeEffectViewerDialogModel");
 }
 
 void EffectsModule::onInit(const muse::IApplication::RunMode&)

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -11,6 +11,7 @@
 
 class Effect;
 class EffectInstanceEx;
+class RealtimeEffectState;
 struct EffectSettings;
 class wxString;
 namespace au::effects {
@@ -25,6 +26,8 @@ using Effect = ::Effect;                    // Effect from AU3
 using EffectInstanceId = uint64_t;
 using EffectInstance = ::EffectInstanceEx;  // EffectInstanceEx from AU3
 using EffectSettings = ::EffectSettings;
+using RealtimeEffectState = ::RealtimeEffectState;
+using RealtimeEffectStatePtr = std::shared_ptr<RealtimeEffectState>;
 using EffectStateId = uintptr_t;
 using TrackId = long;
 using EffectChainLinkIndex = int;
@@ -63,15 +66,6 @@ using EffectCategoryList = std::vector<EffectCategory>;
 
 constexpr const char16_t* VST_CATEGORY_ID = u"vst";
 constexpr const char16_t* BUILTIN_CATEGORY_ID = u"builtin";
-
-struct EffectChainLink {
-    EffectChainLink(std::string effectName, EffectStateId effectStateId)
-        : effectName{std::move(effectName)}, effectStateId{effectStateId} {}
-    const std::string effectName;
-    const EffectStateId effectStateId;
-};
-
-using EffectChainLinkPtr = std::shared_ptr<EffectChainLink>;
 
 using PresetId = wxString;
 using PresetIdList = std::vector<PresetId>;

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -12,6 +12,7 @@
 class Effect;
 class EffectInstanceEx;
 class RealtimeEffectState;
+class EffectSettingsAccess;
 struct EffectSettings;
 class wxString;
 namespace au::effects {
@@ -26,6 +27,8 @@ using Effect = ::Effect;                    // Effect from AU3
 using EffectInstanceId = uint64_t;
 using EffectInstance = ::EffectInstanceEx;  // EffectInstanceEx from AU3
 using EffectSettings = ::EffectSettings;
+using EffectSettingsAccess = ::EffectSettingsAccess;
+using EffectSettingsAccessPtr = std::shared_ptr<EffectSettingsAccess>;
 using RealtimeEffectState = ::RealtimeEffectState;
 using RealtimeEffectStatePtr = std::shared_ptr<RealtimeEffectState>;
 using EffectStateId = uintptr_t;

--- a/src/effects/effects_base/ieffectinstancesregister.h
+++ b/src/effects/effects_base/ieffectinstancesregister.h
@@ -19,7 +19,7 @@ class IEffectInstancesRegister : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IEffectInstancesRegister() = default;
 
-    virtual EffectInstanceId regInstance(const EffectId& effectId, const std::shared_ptr<EffectInstance>& i, EffectSettings* s) = 0;
+    virtual EffectInstanceId regInstance(const EffectId& effectId, const std::shared_ptr<EffectInstance>& i, EffectSettingsAccessPtr s) = 0;
     virtual void unregInstance(const std::shared_ptr<EffectInstance>& i) = 0;
     virtual void unregInstance(const EffectInstanceId& instanceId) = 0;
 
@@ -27,7 +27,8 @@ public:
     virtual std::shared_ptr<EffectInstance> instanceById(const EffectInstanceId& instanceId) const = 0;
     virtual EffectId effectIdByInstanceId(const EffectInstanceId& instanceId) const = 0;
 
-    virtual EffectSettings* settingsById(const EffectInstanceId& instanceId) const = 0;
+    virtual const EffectSettings* settingsById(const EffectInstanceId& instanceId) const = 0;
+    virtual EffectSettingsAccess* settingsAccessById(const EffectInstanceId& instanceId) const = 0;
     virtual void notifyAboutSettingsChanged(const EffectInstanceId& instanceId) = 0;
     virtual muse::async::Notification settingsChanged(const EffectInstanceId& instanceId) const = 0;
 };

--- a/src/effects/effects_base/ieffectsprovider.h
+++ b/src/effects/effects_base/ieffectsprovider.h
@@ -29,12 +29,15 @@ public:
 
     virtual EffectMeta meta(const EffectId& effectId) const = 0;
     virtual std::string effectName(const std::string& effectId) const = 0;
+    virtual std::string effectName(const effects::RealtimeEffectState& state) const = 0;
+    virtual std::string effectSymbol(const std::string& effectId) const = 0;
     virtual Effect* effect(const EffectId& effectId) const = 0;
 
     virtual bool supportsMultipleClipSelection(const EffectId& effectId) const = 0;
 
     // type - is Symbol of effect
     virtual muse::Ret showEffect(const muse::String& type, const EffectInstanceId& instanceId) = 0;
+    virtual muse::Ret showEffect(effects::RealtimeEffectState* state) const = 0;
 
     virtual muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
                                     EffectSettings& settings) = 0;

--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -225,7 +225,8 @@ muse::Ret EffectExecutionScenario::doPerformEffect(au3::Au3Project& project, con
     {
         if (effect->IsInteractive() && (flags& EffectManager::kConfigured) == 0) {
             muse::String type = au3::wxToString(effect->GetSymbol().Internal());
-            EffectInstanceId instanceId = effectInstancesRegister()->regInstance(effectId, pInstanceEx, settings);
+            const auto access = std::make_shared<SimpleEffectSettingsAccess>(*settings);
+            EffectInstanceId instanceId = effectInstancesRegister()->regInstance(effectId, pInstanceEx, access);
             muse::Ret ret = effectsProvider()->showEffect(type, instanceId);
             effectInstancesRegister()->unregInstance(instanceId);
             if (ret) {

--- a/src/effects/effects_base/internal/effectinstancesregister.h
+++ b/src/effects/effects_base/internal/effectinstancesregister.h
@@ -13,7 +13,7 @@ class EffectInstancesRegister : public IEffectInstancesRegister
 public:
     EffectInstancesRegister() = default;
 
-    EffectInstanceId regInstance(const EffectId& effectId, const std::shared_ptr<EffectInstance>& i, EffectSettings* s) override;
+    EffectInstanceId regInstance(const EffectId& effectId, const std::shared_ptr<EffectInstance>& i, EffectSettingsAccessPtr) override;
     void unregInstance(const std::shared_ptr<EffectInstance>& i) override;
     void unregInstance(const EffectInstanceId& instanceId) override;
 
@@ -21,7 +21,8 @@ public:
     std::shared_ptr<EffectInstance> instanceById(const EffectInstanceId& instanceId) const override;
     EffectId effectIdByInstanceId(const EffectInstanceId& instanceId) const override;
 
-    EffectSettings* settingsById(const EffectInstanceId& instanceId) const override;
+    const EffectSettings* settingsById(const EffectInstanceId& instanceId) const override;
+    EffectSettingsAccess* settingsAccessById(const EffectInstanceId& instanceId) const override;
     void notifyAboutSettingsChanged(const EffectInstanceId& instanceId) override;
     muse::async::Notification settingsChanged(const EffectInstanceId& instanceId) const override;
 
@@ -30,7 +31,7 @@ private:
     struct RegisteredEffectInstance {
         EffectId effectId;
         std::shared_ptr<EffectInstance> instance = nullptr;
-        EffectSettings* settings = nullptr;
+        EffectSettingsAccessPtr access = nullptr;
         muse::async::Notification settingsChanged;
     };
 

--- a/src/effects/effects_base/internal/effectsactionscontroller.cpp
+++ b/src/effects/effects_base/internal/effectsactionscontroller.cpp
@@ -82,7 +82,9 @@ void EffectsActionsController::addRealtimeEffect(const muse::actions::ActionData
 
     const auto effectId = args.arg<EffectId>(0);
     const auto trackId = args.arg<TrackId>(1);
-    realtimeEffectService()->addRealtimeEffect(*project, trackId, effectId);
+    if (const RealtimeEffectStatePtr state = realtimeEffectService()->addRealtimeEffect(*project, trackId, effectId)) {
+        effectsProvider()->showEffect(state.get());
+    }
 }
 
 void EffectsActionsController::removeRealtimeEffect(const muse::actions::ActionData& args)

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -38,11 +38,14 @@ public:
 
     EffectMeta meta(const EffectId& effectId) const override;
     std::string effectName(const std::string& effectId) const override;
+    std::string effectName(const effects::RealtimeEffectState& state) const override;
+    std::string effectSymbol(const std::string& effectId) const override;
     Effect* effect(const EffectId& effectId) const override;
 
     bool supportsMultipleClipSelection(const EffectId& effectId) const override;
 
     muse::Ret showEffect(const muse::String& type, const EffectInstanceId& instanceId) override;
+    muse::Ret showEffect(effects::RealtimeEffectState* state) const override;
 
     muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
                             EffectSettings& settings) override;

--- a/src/effects/effects_base/internal/realtimeeffectservice.h
+++ b/src/effects/effects_base/internal/realtimeeffectservice.h
@@ -37,13 +37,14 @@ class RealtimeEffectService : public IRealtimeEffectService, muse::async::Asynca
 public:
     void init();
 
-    void addRealtimeEffect(project::IAudacityProject&, TrackId, const EffectId&) override;
+    RealtimeEffectStatePtr addRealtimeEffect(project::IAudacityProject&, TrackId, const EffectId&) override;
     void removeRealtimeEffect(project::IAudacityProject&, TrackId, EffectStateId) override;
-    void replaceRealtimeEffect(project::IAudacityProject&, TrackId, int effectListIndex, const EffectId& newEffectId) override;
+    RealtimeEffectStatePtr replaceRealtimeEffect(project::IAudacityProject&, TrackId, int effectListIndex,
+                                                 const EffectId& newEffectId) override;
 
-    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr> realtimeEffectAdded() const override;
-    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr> realtimeEffectRemoved() const override;
-    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr, EffectChainLinkPtr> realtimeEffectReplaced() const override;
+    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId> realtimeEffectAdded() const override;
+    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId> realtimeEffectRemoved() const override;
+    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId, EffectStateId> realtimeEffectReplaced() const override;
 
 private:
     Observer::Subscription subscribeToRealtimeEffectList(WaveTrack&, RealtimeEffectList&);
@@ -53,9 +54,9 @@ private:
     std::string getEffectName(const RealtimeEffectState& state) const;
     std::string getTrackName(const au::au3::Au3Project& project, au::effects::TrackId trackId) const;
 
-    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr> m_realtimeEffectAdded;
-    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr> m_realtimeEffectRemoved;
-    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr, EffectChainLinkPtr> m_realtimeEffectReplaced;
+    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId> m_realtimeEffectAdded;
+    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId> m_realtimeEffectRemoved;
+    muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId, EffectStateId> m_realtimeEffectReplaced;
 
     Observer::Subscription m_tracklistSubscription;
     std::unordered_map<TrackId, Observer::Subscription> m_rtEffectSubscriptions;

--- a/src/effects/effects_base/irealtimeeffectservice.h
+++ b/src/effects/effects_base/irealtimeeffectservice.h
@@ -22,13 +22,13 @@ class IRealtimeEffectService : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IRealtimeEffectService() = default;
 
-    virtual void addRealtimeEffect(project::IAudacityProject& project, TrackId trackId, const EffectId& effectId) = 0;
+    virtual RealtimeEffectStatePtr addRealtimeEffect(project::IAudacityProject& project, TrackId trackId, const EffectId& effectId) = 0;
     virtual void removeRealtimeEffect(project::IAudacityProject& project, TrackId trackId, EffectStateId stateId) = 0;
-    virtual void replaceRealtimeEffect(project::IAudacityProject& project, TrackId trackId, int effectListIndex,
-                                       const EffectId& newEffectId) = 0;
+    virtual RealtimeEffectStatePtr replaceRealtimeEffect(project::IAudacityProject& project, TrackId trackId, int effectListIndex,
+                                                         const EffectId& newEffectId) = 0;
 
-    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr> realtimeEffectAdded() const = 0;
-    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr> realtimeEffectRemoved() const = 0;
-    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectChainLinkPtr, EffectChainLinkPtr> realtimeEffectReplaced() const = 0;
+    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId> realtimeEffectAdded() const = 0;
+    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId> realtimeEffectRemoved() const = 0;
+    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId, EffectStateId> realtimeEffectReplaced() const = 0;
 };
 }

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewer.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewer.qml
@@ -11,6 +11,7 @@ Rectangle {
 
     property string type: ""
     property string instanceId: ""
+    property string effectState: ""
 
     property string title: builder.contentItem ? builder.contentItem.title : ""
     property bool isApplyAllowed: builder.contentItem ? builder.contentItem.isApplyAllowed : false
@@ -26,7 +27,7 @@ Rectangle {
     height: implicitHeight
 
     Component.onCompleted: {
-        builder.load(root.type, root.instanceId, root)
+        builder.load(root.type, root.instanceId, root.effectState, root)
     }
 
     function manage(parent) {

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -1,0 +1,79 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+import QtQuick
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+import Audacity.Effects
+
+StyledDialogView {
+    id: root
+
+    property alias type: viewer.type
+    property alias instanceId: viewer.instanceId
+    property alias effectState: viewer.effectState
+
+    title: viewer.title
+
+    contentWidth: viewer.implicitWidth
+    contentHeight: layout.implicitHeight + 16
+
+    margins: 16
+
+    RealtimeEffectViewerDialogModel {
+        id: viewerModel
+        effectState: root.effectState
+    }
+
+    ColumnLayout {
+        id: layout
+
+        anchors.fill: parent
+
+        RowLayout {
+            id: headerBar
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: 40
+
+            spacing: 8
+
+            FlatButton {
+                id: powerButton
+
+                Layout.margins: 0
+                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                Layout.preferredWidth: headerBar.height
+
+                icon: IconCode.BYPASS
+                iconFont: ui.theme.toolbarIconsFont
+                accentButton: true
+
+                onClicked: {
+                    accentButton = !accentButton
+                }
+            }
+
+            FlatButton {
+                id: manageBtn
+
+                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                Layout.preferredWidth: implicitWidth
+
+                text: qsTrc("effects", "Presets & settings")
+                buttonRole: ButtonBoxModel.CustomRole
+                buttonId: ButtonBoxModel.CustomButton + 1
+                onClicked: viewer.manage(manageBtn)
+            }
+        }
+
+        EffectsViewer {
+            id: viewer
+            width: parent.width
+        }
+    }
+
+}

--- a/src/effects/effects_base/view/effectviewloader.cpp
+++ b/src/effects/effects_base/view/effectviewloader.cpp
@@ -33,7 +33,7 @@ EffectViewLoader::EffectViewLoader(QObject* parent)
     : QObject(parent)
 {}
 
-void EffectViewLoader::load(const QString& type, const QString& instanceId, QObject* itemParent)
+void EffectViewLoader::load(const QString& type, const QString& instanceId, const QString& effectState, QObject* itemParent)
 {
     LOGD() << "type: " << type << ", instanceId: " << instanceId;
 
@@ -58,7 +58,8 @@ void EffectViewLoader::load(const QString& type, const QString& instanceId, QObj
     QObject* obj = component.createWithInitialProperties(
     {
         { "parent", QVariant::fromValue(itemParent) },
-        { "instanceId", QVariant::fromValue(instanceId) }
+        { "instanceId", QVariant::fromValue(instanceId) },
+        { "effectState", QVariant::fromValue(effectState) }
     });
 
     m_contentItem = qobject_cast<QQuickItem*>(obj);

--- a/src/effects/effects_base/view/effectviewloader.h
+++ b/src/effects/effects_base/view/effectviewloader.h
@@ -28,7 +28,7 @@ public:
 
     QQuickItem* contentItem() const;
 
-    Q_INVOKABLE void load(const QString& type, const QString& instanceId, QObject* itemParent);
+    Q_INVOKABLE void load(const QString& type, const QString& instanceId, const QString& effectState, QObject* itemParent);
 
 signals:
     void titleChanged();

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
@@ -1,0 +1,58 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "realtimeeffectviewerdialogmodel.h"
+#include "libraries/lib-realtime-effects/RealtimeEffectState.h"
+#include "libraries/lib-effects/EffectPlugin.h"
+
+namespace au::effects {
+RealtimeEffectViewerDialogModel::RealtimeEffectViewerDialogModel(QObject* parent)
+    : QObject(parent)
+{
+}
+
+RealtimeEffectViewerDialogModel::~RealtimeEffectViewerDialogModel()
+{
+    unregisterState();
+}
+
+QString RealtimeEffectViewerDialogModel::prop_effectState() const
+{
+    if (!m_effectState) {
+        return {};
+    }
+    return QString::number(reinterpret_cast<uintptr_t>(m_effectState.get()));
+}
+
+void RealtimeEffectViewerDialogModel::prop_setEffectState(const QString& effectState)
+{
+    if (effectState == prop_effectState()) {
+        return;
+    }
+
+    unregisterState();
+
+    if (effectState.isEmpty()) {
+        return;
+    }
+
+    m_effectState = reinterpret_cast<RealtimeEffectState*>(effectState.toULongLong())->shared_from_this();
+    const auto effectId = m_effectState->GetID().ToStdString();
+    const auto type = effectsProvider()->effectSymbol(effectId);
+    const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(m_effectState->GetInstance());
+    instancesRegister()->regInstance(muse::String::fromStdString(effectId), instance,
+                                     // TODO solve this const_cast
+                                     const_cast<EffectSettings*>(&m_effectState->GetSettings()));
+}
+
+void RealtimeEffectViewerDialogModel::unregisterState()
+{
+    if (!m_effectState) {
+        return;
+    }
+
+    const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(m_effectState->GetInstance());
+    instancesRegister()->unregInstance(instance);
+    m_effectState.reset();
+}
+}

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
@@ -40,9 +40,7 @@ void RealtimeEffectViewerDialogModel::prop_setEffectState(const QString& effectS
     const auto effectId = m_effectState->GetID().ToStdString();
     const auto type = effectsProvider()->effectSymbol(effectId);
     const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(m_effectState->GetInstance());
-    instancesRegister()->regInstance(muse::String::fromStdString(effectId), instance,
-                                     // TODO solve this const_cast
-                                     const_cast<EffectSettings*>(&m_effectState->GetSettings()));
+    instancesRegister()->regInstance(muse::String::fromStdString(effectId), instance, m_effectState->GetAccess());
 }
 
 void RealtimeEffectViewerDialogModel::unregisterState()

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
@@ -1,0 +1,34 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "modularity/ioc.h"
+#include "ieffectinstancesregister.h"
+#include "ieffectsprovider.h"
+#include "effectstypes.h"
+
+#include <QObject>
+
+namespace au::effects {
+class RealtimeEffectViewerDialogModel : public QObject, public muse::Injectable
+{
+    Q_OBJECT
+    Q_PROPERTY(QString effectState READ prop_effectState WRITE prop_setEffectState FINAL)
+
+    muse::Inject<IEffectInstancesRegister> instancesRegister;
+    muse::Inject<IEffectsProvider> effectsProvider;
+
+public:
+    RealtimeEffectViewerDialogModel(QObject* parent = nullptr);
+    ~RealtimeEffectViewerDialogModel() override;
+
+    QString prop_effectState() const;
+    void prop_setEffectState(const QString& effectState);
+
+private:
+    void unregisterState();
+
+    RealtimeEffectStatePtr m_effectState;
+};
+}

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -95,7 +95,7 @@ ListItemBlank {
                 }
 
                 onClicked: {
-                    console.log("not implemented")
+                    root.item.showDialog()
                 }
             }
         }

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.h
@@ -7,21 +7,23 @@
 #include "context/iglobalcontext.h"
 #include "realtimeeffectmenumodelbase.h"
 #include "effects/effects_base/irealtimeeffectservice.h"
+#include "effects/effects_base/ieffectsprovider.h"
 #include <QObject>
 #include <map>
 
 namespace au::projectscene {
-class ModelEffectItem : public QObject
+class ModelEffectItem : public QObject, public muse::Injectable
 {
     Q_OBJECT
+
+    muse::Inject<effects::IEffectsProvider> effectsProvider;
+
 public:
-    ModelEffectItem(QObject* parent, std::string effectName, effects::EffectStateId effectState);
+    ModelEffectItem(QObject* parent, effects::EffectStateId effectState);
 
     const effects::EffectStateId effectStateId;
     Q_INVOKABLE QString effectName() const;
-
-private:
-    const std::string m_effectName;
+    Q_INVOKABLE void showDialog();
 };
 
 class RealtimeEffectListModel : public RealtimeEffectMenuModelBase
@@ -57,8 +59,8 @@ private:
     void populateMenu() override;
 
     void setListenerOnCurrentTrackeditProject();
-    void insertEffect(effects::TrackId trackId, effects::EffectChainLinkIndex index, const effects::EffectChainLink& item);
-    void removeEffect(effects::TrackId trackId, effects::EffectChainLinkIndex index, const effects::EffectChainLink& item);
+    void insertEffect(effects::TrackId trackId, effects::EffectChainLinkIndex index, const effects::EffectStateId& item);
+    void removeEffect(effects::TrackId trackId, effects::EffectChainLinkIndex index, const effects::EffectStateId& item);
 
     using EffectList = std::vector<ModelEffectItem*>;
     std::map<effects::TrackId, EffectList> m_trackEffectLists;


### PR DESCRIPTION
Resolves: #7938

Clicking on a realtime-effect's name in the effect panel now opens the UI.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
Note that:
* power button not yet functional
* the dialogs are yet modal, will implement them as floating window in a follow-up PR.

In particular, please test
- [x] Realtime effect parameters can be changed during playback with audible effect.
- [x] Regression testing of the effects, both realtime and destructive (some refactoring was necessary)
