### PR TITLE
7991 floating realtime effect dialogs

### DIFF
--- a/au3/libraries/lib-transactions/TransactionScope.cpp
+++ b/au3/libraries/lib-transactions/TransactionScope.cpp
@@ -26,8 +26,8 @@ TransactionScope::TransactionScope(
    if ( !mInTrans )
       // To do, improve the message
       throw SimpleMessageBoxException( ExceptionType::Internal,
-         XO("Database error.  Sorry, but we don't have more details."), 
-         XO("Warning"), 
+         XO("Database error.  Sorry, but we don't have more details."),
+         XO("Warning"),
          "Error:_Disk_full_or_not_writable"
       );
 }
@@ -47,7 +47,9 @@ TransactionScope::~TransactionScope()
 
 bool TransactionScope::Commit()
 {
-   if (mpImpl && !mInTrans) {
+   if (!mpImpl)
+      return false;
+   else if (!mInTrans) {
       wxLogMessage("No active transaction to commit");
       // Misuse of this class
       THROW_INCONSISTENCY_EXCEPTION;

--- a/src/effects/builtin/common/abstracteffectmodel.cpp
+++ b/src/effects/builtin/common/abstracteffectmodel.cpp
@@ -86,6 +86,19 @@ void AbstractEffectModel::preview()
     }
 }
 
+void AbstractEffectModel::modifySettings(const std::function<void(EffectSettings& settings)>& modifier)
+{
+    EffectSettingsAccess* const access = this->settingsAccess();
+    IF_ASSERT_FAILED(access) {
+        return;
+    }
+    access->ModifySettings([&](EffectSettings& settings) {
+        modifier(settings);
+        return nullptr;
+    });
+    access->Flush();
+}
+
 QString AbstractEffectModel::instanceId_prop() const
 {
     return m_instanceId;

--- a/src/effects/builtin/common/abstracteffectmodel.h
+++ b/src/effects/builtin/common/abstracteffectmodel.h
@@ -49,7 +49,7 @@ protected:
 
     std::shared_ptr<effects::EffectInstance> instance() const;
     const EffectSettings* settings() const;
-    EffectSettingsAccess* settingsAccess() const;
+    void modifySettings(const std::function<void(EffectSettings& settings)>&);
 
     template<typename T>
     const T& settings() const
@@ -68,6 +68,7 @@ protected:
     bool m_inited = false;
 
 private:
+    EffectSettingsAccess* settingsAccess() const;
     QString m_instanceId;
 };
 }

--- a/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
+++ b/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
@@ -105,12 +105,9 @@ double DtmfViewModel::silenceDuration() const
 
 void DtmfViewModel::recalculateDurations()
 {
-    if (EffectSettingsAccess* access = settingsAccess()) {
-        access->ModifySettings([this](EffectSettings& settings) {
-            mutSettings<DtmfSettings>().Recalculate(settings);
-            return nullptr;
-        });
-        emit toneDurationChanged();
-        emit silenceDurationChanged();
-    }
+    modifySettings([this](EffectSettings& settings) {
+        mutSettings<DtmfSettings>().Recalculate(settings);
+    });
+    emit toneDurationChanged();
+    emit silenceDurationChanged();
 }

--- a/src/effects/builtin/reverb/reverbeffect.cpp
+++ b/src/effects/builtin/reverb/reverbeffect.cpp
@@ -130,10 +130,10 @@ bool ReverbEffect::Instance::ProcessInitialize(
 }
 
 bool ReverbEffect::Instance::InstanceInit(
-    EffectSettings& settings, double sampleRate, ReverbState& state,
+    const EffectSettings& settings, double sampleRate, ReverbState& state,
     ChannelNames chanMap, bool forceStereo)
 {
-    auto& rs = GetSettings(settings);
+    const auto& rs = GetSettings(settings);
 
     bool isStereo = false;
     state.mNumChans = 1;

--- a/src/effects/builtin/reverb/reverbeffect.h
+++ b/src/effects/builtin/reverb/reverbeffect.h
@@ -116,7 +116,7 @@ public:
         unsigned GetAudioInCount() const override;
 
         bool InstanceInit(
-            EffectSettings& settings, double sampleRate, ReverbState& data, ChannelNames chanMap, bool forceStereo);
+            const EffectSettings& settings, double sampleRate, ReverbState& data, ChannelNames chanMap, bool forceStereo);
 
         size_t InstanceProcess(
             EffectSettings& settings, ReverbState& data, const float* const* inBlock, float* const* outBlock, size_t blockLen);

--- a/src/effects/builtin/reverb/reverbviewmodel.cpp
+++ b/src/effects/builtin/reverb/reverbviewmodel.cpp
@@ -119,12 +119,11 @@ void ReverbViewModel::setParam(const QString& key, double val)
     IF_ASSERT_FAILED(s) {
         return;
     }
-    settingsAccess()->ModifySettings([s, val](EffectSettings& settings)
+    modifySettings([s, val](EffectSettings& settings)
     {
         s(*settings.cast<ReverbSettings>(), val);
         // saintmatthieu: Looks like non-null Message returns are only necessary for VST2 and AU effects but I haven't figured out why.
         // In any case, changing the settings during playback gets reflected in the audio output.
-        return nullptr;
     });
 }
 
@@ -135,10 +134,9 @@ bool ReverbViewModel::wetOnly() const
 
 void ReverbViewModel::setWetOnly(bool newWetOnly)
 {
-    settingsAccess()->ModifySettings([newWetOnly](EffectSettings& settings)
+    modifySettings([newWetOnly](EffectSettings& settings)
     {
         settings.cast<ReverbSettings>()->mWetOnly = newWetOnly;
-        return nullptr;
     });
     emit wetOnlyChanged();
 }

--- a/src/effects/effects_base/CMakeLists.txt
+++ b/src/effects/effects_base/CMakeLists.txt
@@ -40,6 +40,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectexecutionscenario.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectservice.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectservice.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectstackmanager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectstackmanager.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectpresetsprovider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectpresetsprovider.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectpresetsscenario.cpp

--- a/src/effects/effects_base/effects_base.qrc
+++ b/src/effects/effects_base/effects_base.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file>qml/Audacity/Effects/EffectsViewerDialog.qml</file>
+        <file>qml/Audacity/Effects/StyledDialogViewWithoutNavigationSection.qml</file>
         <file>qml/Audacity/Effects/RealtimeEffectViewerDialog.qml</file>
         <file>qml/Audacity/Effects/EffectsViewer.qml</file>
         <file>qml/Audacity/Effects/PresetNameDialog.qml</file>

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -31,7 +31,6 @@ using EffectSettingsAccess = ::EffectSettingsAccess;
 using EffectSettingsAccessPtr = std::shared_ptr<EffectSettingsAccess>;
 using RealtimeEffectState = ::RealtimeEffectState;
 using RealtimeEffectStatePtr = std::shared_ptr<RealtimeEffectState>;
-using EffectStateId = uintptr_t;
 using TrackId = long;
 using EffectChainLinkIndex = int;
 

--- a/src/effects/effects_base/ieffectsprovider.h
+++ b/src/effects/effects_base/ieffectsprovider.h
@@ -36,7 +36,10 @@ public:
     virtual bool supportsMultipleClipSelection(const EffectId& effectId) const = 0;
 
     virtual muse::Ret showEffect(const EffectId& effectId, const EffectInstanceId& instanceId) = 0;
-    virtual muse::Ret showEffect(effects::RealtimeEffectState* state) const = 0;
+
+    virtual void showEffect(const RealtimeEffectStatePtr& state) const = 0;
+    virtual void hideEffect(const RealtimeEffectStatePtr& state) const = 0;
+    virtual void toggleShowEffect(const RealtimeEffectStatePtr& state) const = 0;
 
     virtual muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
                                     EffectSettings& settings) = 0;

--- a/src/effects/effects_base/internal/effectsactionscontroller.cpp
+++ b/src/effects/effects_base/internal/effectsactionscontroller.cpp
@@ -4,6 +4,7 @@
 #include "effectsactionscontroller.h"
 #include "effects/effects_base/effectstypes.h"
 #include "effectsuiactions.h"
+#include "playback/iplayer.h"
 
 #include "wx/string.h"
 
@@ -39,9 +40,6 @@ void EffectsActionsController::registerActions()
     }
 
     dispatcher()->reg(this, "repeat-last-effect", this, &EffectsActionsController::repeatLastEffect);
-    dispatcher()->reg(this, "realtimeeffect-add", this, &EffectsActionsController::addRealtimeEffect);
-    dispatcher()->reg(this, "realtimeeffect-remove", this, &EffectsActionsController::removeRealtimeEffect);
-    dispatcher()->reg(this, "realtimeeffect-replace", this, &EffectsActionsController::replaceRealtimeEffect);
 
     // presets
     dispatcher()->reg(this, "action://effects/presets/apply", this, &EffectsActionsController::applyPreset);
@@ -70,53 +68,6 @@ void EffectsActionsController::repeatLastEffect()
 {
     playback()->player()->stop();
     effectExecutionScenario()->repeatLastProcessor();
-}
-
-void EffectsActionsController::addRealtimeEffect(const muse::actions::ActionData& args)
-{
-    const auto project = globalContext()->currentProject();
-    IF_ASSERT_FAILED(project) {
-        // Command issued without an open project ?..
-        return;
-    }
-
-    const auto effectId = args.arg<EffectId>(0);
-    const auto trackId = args.arg<TrackId>(1);
-    if (const RealtimeEffectStatePtr state = realtimeEffectService()->addRealtimeEffect(*project, trackId, effectId)) {
-        effectsProvider()->showEffect(state.get());
-    }
-}
-
-void EffectsActionsController::removeRealtimeEffect(const muse::actions::ActionData& args)
-{
-    const auto project = globalContext()->currentProject();
-    IF_ASSERT_FAILED(project) {
-        // Command issued without an open project ?..
-        return;
-    }
-
-    const auto trackId = args.arg<TrackId>(0);
-    const auto effectStateId = args.arg<EffectStateId>(1);
-    realtimeEffectService()->removeRealtimeEffect(*project, trackId, effectStateId);
-}
-
-void EffectsActionsController::replaceRealtimeEffect(const muse::actions::ActionData& args)
-{
-    IF_ASSERT_FAILED(args.count() == 3) {
-        return;
-    }
-
-    const auto project = globalContext()->currentProject();
-    IF_ASSERT_FAILED(project) {
-        // Command issued without an open project ?..
-        return;
-    }
-
-    const auto trackId = args.arg<TrackId>(0);
-    const auto srcIndex = args.arg<int>(1);
-    const auto dstEffectId = args.arg<EffectId>(2);
-
-    realtimeEffectService()->replaceRealtimeEffect(*project, trackId, srcIndex, dstEffectId);
 }
 
 void EffectsActionsController::applyPreset(const muse::actions::ActionData& args)

--- a/src/effects/effects_base/internal/effectsactionscontroller.h
+++ b/src/effects/effects_base/internal/effectsactionscontroller.h
@@ -13,8 +13,6 @@
 #include "ui/iuiactionsregister.h"
 #include "../ieffectexecutionscenario.h"
 #include "../ieffectsprovider.h"
-#include "effects/effects_base/irealtimeeffectservice.h"
-#include "context/iglobalcontext.h"
 #include "../ieffectpresetsscenario.h"
 #include "iinteractive.h"
 #include "playback/iplayback.h"
@@ -27,11 +25,9 @@ class EffectsActionsController : public muse::actions::Actionable, public muse::
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
     muse::Inject<muse::ui::IUiActionsRegister> uiActionsRegister;
     muse::Inject<IEffectExecutionScenario> effectExecutionScenario;
-    muse::Inject<IRealtimeEffectService> realtimeEffectService;
     muse::Inject<IEffectsProvider> effectsProvider;
     muse::Inject<IEffectPresetsScenario> presetsScenario;
     muse::Inject<muse::IInteractive> interactive;
-    muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<au::playback::IPlayback> playback;
 
 public:
@@ -44,9 +40,6 @@ private:
 
     void onEffectTriggered(const muse::actions::ActionQuery& q);
     void repeatLastEffect();
-    void addRealtimeEffect(const muse::actions::ActionData& args);
-    void removeRealtimeEffect(const muse::actions::ActionData& args);
-    void replaceRealtimeEffect(const muse::actions::ActionData& args);
 
     void applyPreset(const muse::actions::ActionData& args);
     void saveAsPreset(const muse::actions::ActionData& args);

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -45,7 +45,10 @@ public:
     bool supportsMultipleClipSelection(const EffectId& effectId) const override;
 
     muse::Ret showEffect(const EffectId& effectId, const EffectInstanceId& instanceId) override;
-    muse::Ret showEffect(effects::RealtimeEffectState* state) const override;
+
+    void showEffect(const RealtimeEffectStatePtr& state) const override;
+    void hideEffect(const RealtimeEffectStatePtr& state) const override;
+    void toggleShowEffect(const RealtimeEffectStatePtr& state) const override;
 
     muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
                             EffectSettings& settings) override;

--- a/src/effects/effects_base/internal/realtimeeffectstackmanager.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectstackmanager.cpp
@@ -1,0 +1,105 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "realtimeeffectstackmanager.h"
+
+namespace au::effects {
+void StackManager::refresh(TrackId trackId, const std::vector<RealtimeEffectStatePtr>& newStates)
+{
+    auto& stack = m_stacks[trackId];
+
+    // Store in a vector not to modify the stack size while iterating.
+    std::vector<RealtimeEffectStatePtr> removedStates;
+    for (auto i = 0u; i < stack.size(); ++i) {
+        const auto& state = stack[i];
+        if (std::find(newStates.begin(), newStates.end(), state) == newStates.end()) {
+            removedStates.push_back(state);
+        }
+    }
+    for (const auto& state : removedStates) {
+        remove(state);
+    }
+
+    for (auto i = 0u; i < newStates.size(); ++i) {
+        const auto& state = newStates[i];
+        if (std::find(stack.begin(), stack.end(), state) == stack.end()) {
+            insert(trackId, i, state);
+        }
+    }
+}
+
+void StackManager::insert(TrackId trackId, EffectChainLinkIndex index, const RealtimeEffectStatePtr& state)
+{
+    auto& stack = m_stacks[trackId];
+    if (index > stack.size()) {
+        stack.resize(index);
+    }
+    stack.insert(stack.begin() + index, state);
+    realtimeEffectAdded.send(trackId, index, state);
+}
+
+void StackManager::remove(const RealtimeEffectStatePtr& state)
+{
+    const auto stackIt = findStack(state);
+    if (stackIt == m_stacks.end()) {
+        return;
+    }
+    const TrackId trackId = stackIt->first;
+    Stack& stack = stackIt->second;
+    const auto it = std::find(stack.begin(), stack.end(), state);
+    stack.erase(it);
+    realtimeEffectRemoved.send(trackId, state);
+}
+
+void StackManager::replace(const RealtimeEffectStatePtr& oldState, const RealtimeEffectStatePtr& newState)
+{
+    const auto stackIt = findStack(oldState);
+    if (stackIt == m_stacks.end()) {
+        return;
+    }
+    const TrackId trackId = stackIt->first;
+    Stack& stack = stackIt->second;
+    const auto it = std::find(stack.begin(), stack.end(), oldState);
+    const auto index = it - stack.begin();
+    stack[index] = newState;
+    realtimeEffectReplaced.send(trackId, index, oldState, newState);
+}
+
+void StackManager::clear()
+{
+    auto stackIt = m_stacks.begin();
+    while (stackIt != m_stacks.end()) {
+        const TrackId trackId = stackIt->first;
+        auto& stack = stackIt->second;
+        for (auto i = 0u; i < stack.size(); ++i) {
+            realtimeEffectRemoved.send(trackId, stack[i]);
+        }
+        stackIt = m_stacks.erase(stackIt);
+    }
+}
+
+std::optional<TrackId> StackManager::trackId(const RealtimeEffectStatePtr& state) const
+{
+    const auto stackIt = findStack(state);
+    if (stackIt == m_stacks.end()) {
+        return {};
+    }
+    return stackIt->first;
+}
+
+StackManager::TrackStacks::const_iterator StackManager::findStack(const RealtimeEffectStatePtr& state) const
+{
+    return std::find_if(m_stacks.begin(), m_stacks.end(), [state](const auto& pair) {
+        const Stack& stack = pair.second;
+        return std::find(stack.begin(), stack.end(), state) != stack.end();
+    });
+}
+
+StackManager::TrackStacks::iterator StackManager::findStack(const RealtimeEffectStatePtr& state)
+{
+    return std::find_if(m_stacks.begin(), m_stacks.end(), [state](const auto& pair) {
+        const Stack& stack = pair.second;
+        return std::find(stack.begin(), stack.end(), state) != stack.end();
+    });
+}
+}

--- a/src/effects/effects_base/internal/realtimeeffectstackmanager.h
+++ b/src/effects/effects_base/internal/realtimeeffectstackmanager.h
@@ -1,0 +1,35 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "effectstypes.h"
+#include "async/channel.h"
+
+namespace au::effects {
+class StackManager
+{
+public:
+    void insert(TrackId trackId, EffectChainLinkIndex index, const RealtimeEffectStatePtr& state);
+    void remove(const RealtimeEffectStatePtr& state);
+    void replace(const RealtimeEffectStatePtr& oldState, const RealtimeEffectStatePtr& newState);
+    void clear();
+    void refresh(TrackId trackId, const std::vector<RealtimeEffectStatePtr>& newStates);
+
+    std::optional<TrackId> trackId(const RealtimeEffectStatePtr& state) const;
+
+    muse::async::Channel<TrackId, EffectChainLinkIndex, RealtimeEffectStatePtr> realtimeEffectAdded;
+    muse::async::Channel<TrackId, RealtimeEffectStatePtr> realtimeEffectRemoved;
+    muse::async::Channel<TrackId, EffectChainLinkIndex, RealtimeEffectStatePtr, RealtimeEffectStatePtr> realtimeEffectReplaced;
+
+private:
+    using Stack = std::vector<RealtimeEffectStatePtr>;
+    using TrackStacks = std::unordered_map<TrackId, Stack>;
+
+    TrackStacks::const_iterator findStack(const RealtimeEffectStatePtr& state) const;
+    TrackStacks::iterator findStack(const RealtimeEffectStatePtr& state);
+
+    // Models how effects are stacked on a track, i.e., the order of the effects in the vectors matters.
+    TrackStacks m_stacks;
+};
+}

--- a/src/effects/effects_base/irealtimeeffectservice.h
+++ b/src/effects/effects_base/irealtimeeffectservice.h
@@ -7,6 +7,7 @@
 #include "async/channel.h"
 #include "global/modularity/imoduleinterface.h"
 #include "effectstypes.h"
+#include <optional>
 
 struct TransportSequences;
 struct AudioIOStartStreamOptions;
@@ -22,13 +23,21 @@ class IRealtimeEffectService : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IRealtimeEffectService() = default;
 
-    virtual RealtimeEffectStatePtr addRealtimeEffect(project::IAudacityProject& project, TrackId trackId, const EffectId& effectId) = 0;
-    virtual void removeRealtimeEffect(project::IAudacityProject& project, TrackId trackId, EffectStateId stateId) = 0;
-    virtual RealtimeEffectStatePtr replaceRealtimeEffect(project::IAudacityProject& project, TrackId trackId, int effectListIndex,
-                                                         const EffectId& newEffectId) = 0;
+    virtual RealtimeEffectStatePtr addRealtimeEffect(TrackId trackId, const EffectId& effectId) = 0;
+    virtual void removeRealtimeEffect(TrackId trackId, const RealtimeEffectStatePtr& state) = 0;
+    virtual RealtimeEffectStatePtr replaceRealtimeEffect(TrackId trackId, int effectListIndex, const EffectId& newEffectId) = 0;
 
-    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId> realtimeEffectAdded() const = 0;
-    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId> realtimeEffectRemoved() const = 0;
-    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, EffectStateId, EffectStateId> realtimeEffectReplaced() const = 0;
+    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, RealtimeEffectStatePtr> realtimeEffectAdded() const = 0;
+    virtual muse::async::Channel<TrackId, RealtimeEffectStatePtr> realtimeEffectRemoved() const = 0;
+    virtual muse::async::Channel<TrackId, EffectChainLinkIndex, RealtimeEffectStatePtr, RealtimeEffectStatePtr> realtimeEffectReplaced() const = 0;
+
+    virtual std::optional<TrackId> trackId(const RealtimeEffectStatePtr& state) const = 0;
+
+    virtual bool isActive(const RealtimeEffectStatePtr& state) const = 0;
+    virtual void setIsActive(const RealtimeEffectStatePtr& state, bool) = 0;
+    virtual muse::async::Channel<RealtimeEffectStatePtr> isActiveChanged() const = 0;
+
+    virtual bool trackEffectsActive(TrackId trackId) const = 0;
+    virtual void setTrackEffectsActive(TrackId trackId, bool active) = 0;
 };
 }

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -1,6 +1,6 @@
 /*
-* Audacity: A Digital Audio Editor
-*/
+ * Audacity: A Digital Audio Editor
+ */
 import QtQuick
 import QtQuick.Layouts
 
@@ -9,23 +9,28 @@ import Muse.UiComponents
 
 import Audacity.Effects
 
-StyledDialogView {
+StyledDialogViewWithoutNavigationSection {
     id: root
 
     property alias type: viewer.type
     property alias instanceId: viewer.instanceId
     property alias effectState: viewer.effectState
 
-    title: viewer.title
+    title: viewer.title + " - " + viewerModel.trackName
 
     contentWidth: viewer.implicitWidth
     contentHeight: layout.implicitHeight + 16
-
+    alwaysOnTop: true
     margins: 16
+
+    Component.onCompleted: {
+        viewerModel.load()
+    }
 
     RealtimeEffectViewerDialogModel {
         id: viewerModel
         effectState: root.effectState
+        onTrackRemoved: root.close()
     }
 
     ColumnLayout {
@@ -50,10 +55,10 @@ StyledDialogView {
 
                 icon: IconCode.BYPASS
                 iconFont: ui.theme.toolbarIconsFont
-                accentButton: true
+                accentButton: viewerModel.isActive
 
                 onClicked: {
-                    accentButton = !accentButton
+                    viewerModel.isActive = !viewerModel.isActive
                 }
             }
 

--- a/src/effects/effects_base/qml/Audacity/Effects/StyledDialogViewWithoutNavigationSection.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/StyledDialogViewWithoutNavigationSection.qml
@@ -1,0 +1,78 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+ import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+
+/*
+ * Copied from StyledDialogView, just removing the NavigationSection, which, when calling `requestActive()`, breaks the shortcut context.
+ * This is a temporary solution. We will soon need realtime effect dialogs to be navigable with the keyboard, at which point a proper
+ * solution will be needed.
+ */
+DialogView {
+    id: root
+
+    default property alias contentData: contentBody.data
+
+    property alias background: contentBackground
+
+    property alias width: rootContainer.width
+    property alias height: rootContainer.height
+
+    property int margins: 0
+
+    property bool closeOnEscape : true
+
+    contentWidth: 240
+    contentHeight: contentBody.childrenRect.height
+
+    onOpened: {
+        accessibilityActiveTimer.start()
+    }
+
+    signal accessibilityActivateRequested()
+
+    property Timer accessibilityActiveTimer: Timer {
+        interval: 500
+        repeat: false
+
+        onTriggered: {
+            root.accessibilityActivateRequested()
+        }
+    }
+
+    contentItem: FocusScope {
+        id: rootContainer
+        width: contentBody.width + root.margins * 2
+        height: contentBody.height + root.margins * 2
+
+        implicitWidth: contentBody.implicitWidth + root.margins * 2
+        implicitHeight: contentBody.implicitHeight + root.margins * 2
+
+        ItemWithDropShadow {
+            anchors.fill: parent
+            shadow.visible: root.frameless
+
+            Rectangle {
+                id: contentBackground
+                anchors.fill: parent
+                color: ui.theme.backgroundPrimaryColor
+                radius: root.frameless ? 4 : 0
+                border.width: root.frameless ? 1 : 0
+                border.color: ui.theme.strokeColor
+            }
+        }
+
+        Item {
+            id: contentBody
+            anchors.fill: parent
+            anchors.margins: root.margins
+
+            implicitWidth: root.contentWidth
+            implicitHeight: root.contentHeight
+        }
+    }
+}

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
@@ -4,6 +4,8 @@
 #include "realtimeeffectviewerdialogmodel.h"
 #include "libraries/lib-realtime-effects/RealtimeEffectState.h"
 #include "libraries/lib-effects/EffectPlugin.h"
+#include "trackedit/trackedittypes.h"
+#include "trackedit/itrackeditproject.h"
 
 namespace au::effects {
 RealtimeEffectViewerDialogModel::RealtimeEffectViewerDialogModel(QObject* parent)
@@ -14,6 +16,32 @@ RealtimeEffectViewerDialogModel::RealtimeEffectViewerDialogModel(QObject* parent
 RealtimeEffectViewerDialogModel::~RealtimeEffectViewerDialogModel()
 {
     unregisterState();
+}
+
+void RealtimeEffectViewerDialogModel::load()
+{
+    globalContext()->currentTrackeditProjectChanged().onNotify(this, [this]
+    {
+        subscribe();
+    });
+    subscribe();
+
+    realtimeEffectService()->isActiveChanged().onReceive(this, [this](RealtimeEffectStatePtr stateId)
+    {
+        if (stateId == m_effectState) {
+            emit isActiveChanged();
+        }
+    });
+}
+
+bool RealtimeEffectViewerDialogModel::prop_isActive() const
+{
+    return realtimeEffectService()->isActive(m_effectState);
+}
+
+void RealtimeEffectViewerDialogModel::prop_setIsActive(bool isActive)
+{
+    realtimeEffectService()->setIsActive(m_effectState, isActive);
 }
 
 QString RealtimeEffectViewerDialogModel::prop_effectState() const
@@ -41,6 +69,9 @@ void RealtimeEffectViewerDialogModel::prop_setEffectState(const QString& effectS
     const auto type = effectsProvider()->effectSymbol(effectId);
     const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(m_effectState->GetInstance());
     instancesRegister()->regInstance(muse::String::fromStdString(effectId), instance, m_effectState->GetAccess());
+
+    emit isActiveChanged();
+    emit trackNameChanged();
 }
 
 void RealtimeEffectViewerDialogModel::unregisterState()
@@ -52,5 +83,53 @@ void RealtimeEffectViewerDialogModel::unregisterState()
     const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(m_effectState->GetInstance());
     instancesRegister()->unregInstance(instance);
     m_effectState.reset();
+}
+
+QString RealtimeEffectViewerDialogModel::prop_trackName() const
+{
+    const std::optional<trackedit::TrackId> trackId = realtimeEffectService()->trackId(m_effectState);
+    IF_ASSERT_FAILED(trackId.has_value()) {
+        return {};
+    }
+
+    const trackedit::ITrackeditProjectPtr project = globalContext()->currentTrackeditProject();
+    IF_ASSERT_FAILED(project) {
+        return {};
+    }
+
+    const auto trackName = project->trackName(*trackId);
+    IF_ASSERT_FAILED(trackName.has_value()) {
+        return QString();
+    }
+
+    return QString::fromStdString(*trackName);
+}
+
+void RealtimeEffectViewerDialogModel::subscribe()
+{
+    const trackedit::ITrackeditProjectPtr project = globalContext()->currentTrackeditProject();
+    if (!project) {
+        return;
+    }
+    project->trackChanged().onReceive(this, [this](const trackedit::Track& track) {
+        const std::optional<trackedit::TrackId> trackId = realtimeEffectService()->trackId(m_effectState);
+        IF_ASSERT_FAILED(trackId.has_value()) {
+            return;
+        }
+
+        if (track.id == trackId) {
+            emit trackNameChanged();
+        }
+    });
+    project->trackRemoved().onReceive(this, [this](const trackedit::Track& track) {
+        const std::optional<trackedit::TrackId> trackId = realtimeEffectService()->trackId(m_effectState);
+        IF_ASSERT_FAILED(trackId.has_value()) {
+            return;
+        }
+
+        if (track.id == trackId) {
+            emit trackRemoved();
+        }
+    });
 }
 }

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
@@ -7,26 +7,47 @@
 #include "ieffectinstancesregister.h"
 #include "ieffectsprovider.h"
 #include "effectstypes.h"
+#include "effects/effects_base/irealtimeeffectservice.h"
+#include "context/iglobalcontext.h"
+#include "actions/actionable.h"
+#include "async/asyncable.h"
 
 #include <QObject>
 
 namespace au::effects {
-class RealtimeEffectViewerDialogModel : public QObject, public muse::Injectable
+class RealtimeEffectViewerDialogModel : public QObject, public muse::Injectable, public muse::async::Asyncable,
+    public muse::actions::Actionable
 {
     Q_OBJECT
     Q_PROPERTY(QString effectState READ prop_effectState WRITE prop_setEffectState FINAL)
+    Q_PROPERTY(QString trackName READ prop_trackName NOTIFY trackNameChanged);
+    Q_PROPERTY(bool isActive READ prop_isActive WRITE prop_setIsActive NOTIFY isActiveChanged);
 
     muse::Inject<IEffectInstancesRegister> instancesRegister;
     muse::Inject<IEffectsProvider> effectsProvider;
+    muse::Inject<effects::IRealtimeEffectService> realtimeEffectService;
+    muse::Inject<context::IGlobalContext> globalContext;
 
 public:
+    Q_INVOKABLE void load();
+
     RealtimeEffectViewerDialogModel(QObject* parent = nullptr);
     ~RealtimeEffectViewerDialogModel() override;
 
     QString prop_effectState() const;
     void prop_setEffectState(const QString& effectState);
+    QString prop_trackName() const;
+
+    bool prop_isActive() const;
+    void prop_setIsActive(bool isActive);
+
+signals:
+    void trackNameChanged();
+    void trackRemoved();
+    void isActiveChanged();
 
 private:
+    void subscribe();
     void unregisterState();
 
     RealtimeEffectStatePtr m_effectState;

--- a/src/projectscene/CMakeLists.txt
+++ b/src/projectscene/CMakeLists.txt
@@ -16,6 +16,10 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/types/projectscenetypes.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/internal/irealtimeeffectpaneltrackselection.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectpaneltrackselection.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectpaneltrackselection.h
+
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectsceneconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectsceneconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectviewstate.cpp
@@ -41,6 +45,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/trackcontextmenumodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistitemmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistitemmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectmenumodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectmenumodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectmenumodelbase.cpp

--- a/src/projectscene/internal/irealtimeeffectpaneltrackselection.h
+++ b/src/projectscene/internal/irealtimeeffectpaneltrackselection.h
@@ -1,0 +1,22 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "async/notification.h"
+#include "global/modularity/imoduleinterface.h"
+#include "trackedit/trackedittypes.h"
+#include <optional>
+
+namespace au::projectscene {
+class IRealtimeEffectPanelTrackSelection : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(IRealtimeEffectPanelTrackSelection);
+
+public:
+    virtual ~IRealtimeEffectPanelTrackSelection() = default;
+
+    virtual std::optional<au::trackedit::TrackId> selectedTrackId() const = 0;
+    virtual muse::async::Notification selectedTrackIdChanged() const = 0;
+};
+}

--- a/src/projectscene/internal/realtimeeffectpaneltrackselection.cpp
+++ b/src/projectscene/internal/realtimeeffectpaneltrackselection.cpp
@@ -1,0 +1,36 @@
+#include "realtimeeffectpaneltrackselection.h"
+
+namespace au::projectscene {
+void RealtimeEffectPanelTrackSelection::init()
+{
+    selectionController()->tracksSelected().onReceive(this, [this](const au::trackedit::TrackIdList& tracks) {
+        if (!tracks.empty()) {
+            setTrackId(tracks.back());
+        }
+    });
+    globalContext()->currentTrackeditProjectChanged().onNotify(this, [this] {
+        if (!globalContext()->currentProject()) {
+            setTrackId({});
+        }
+    });
+}
+
+std::optional<au::trackedit::TrackId> RealtimeEffectPanelTrackSelection::selectedTrackId() const
+{
+    return m_trackId;
+}
+
+muse::async::Notification RealtimeEffectPanelTrackSelection::selectedTrackIdChanged() const
+{
+    return m_selectedTrackIdChanged;
+}
+
+void RealtimeEffectPanelTrackSelection::setTrackId(std::optional<au::trackedit::TrackId> trackId)
+{
+    if (m_trackId == trackId) {
+        return;
+    }
+    m_trackId = trackId;
+    m_selectedTrackIdChanged.notify();
+}
+}

--- a/src/projectscene/internal/realtimeeffectpaneltrackselection.h
+++ b/src/projectscene/internal/realtimeeffectpaneltrackselection.h
@@ -1,0 +1,29 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "irealtimeeffectpaneltrackselection.h"
+#include "trackedit/iselectioncontroller.h"
+#include "context/iglobalcontext.h"
+#include "modularity/ioc.h"
+#include "async/asyncable.h"
+
+namespace au::projectscene {
+class RealtimeEffectPanelTrackSelection : public IRealtimeEffectPanelTrackSelection, muse::async::Asyncable
+{
+    muse::Inject<trackedit::ISelectionController> selectionController;
+    muse::Inject<context::IGlobalContext> globalContext;
+
+public:
+    void init();
+
+    std::optional<au::trackedit::TrackId> selectedTrackId() const override;
+    muse::async::Notification selectedTrackIdChanged() const override;
+
+private:
+    void setTrackId(std::optional<au::trackedit::TrackId>);
+    std::optional<au::trackedit::TrackId> m_trackId;
+    muse::async::Notification m_selectedTrackIdChanged;
+};
+}

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -15,6 +15,7 @@
 #include "internal/projectsceneactionscontroller.h"
 #include "internal/projectsceneconfiguration.h"
 #include "internal/projectviewstatecreator.h"
+#include "internal/realtimeeffectpaneltrackselection.h"
 
 #include "view/common/tracksviewstatemodel.h"
 #include "view/common/customcursor.h"
@@ -79,11 +80,13 @@ void ProjectSceneModule::registerExports()
     m_projectSceneActionsController = std::make_shared<ProjectSceneActionsController>();
     m_uiActions = std::make_shared<ProjectSceneUiActions>(m_projectSceneActionsController);
     m_configuration = std::make_shared<ProjectSceneConfiguration>();
+    m_realtimeEffectPanelTrackSelection = std::make_shared<RealtimeEffectPanelTrackSelection>();
 
     ioc()->registerExport<IProjectSceneConfiguration>(moduleName(), m_configuration);
     ioc()->registerExport<IProjectViewStateCreator>(moduleName(), new ProjectViewStateCreator());
     ioc()->registerExport<IProjectSceneActionsController>(moduleName(), m_projectSceneActionsController);
     ioc()->registerExport<IWavePainter>(moduleName(), new Au3WavePainter());
+    ioc()->registerExport<IRealtimeEffectPanelTrackSelection>(moduleName(), m_realtimeEffectPanelTrackSelection);
 }
 
 void ProjectSceneModule::resolveImports()
@@ -164,4 +167,5 @@ void ProjectSceneModule::onInit(const muse::IApplication::RunMode& mode)
     m_configuration->init();
     m_uiActions->init();
     m_projectSceneActionsController->init();
+    m_realtimeEffectPanelTrackSelection->init();
 }

--- a/src/projectscene/projectscenemodule.h
+++ b/src/projectscene/projectscenemodule.h
@@ -12,6 +12,7 @@ namespace au::projectscene {
 class ProjectSceneUiActions;
 class ProjectSceneActionsController;
 class ProjectSceneConfiguration;
+class RealtimeEffectPanelTrackSelection;
 class ProjectSceneModule : public muse::modularity::IModuleSetup
 {
 public:
@@ -27,6 +28,7 @@ private:
     std::shared_ptr<ProjectSceneUiActions> m_uiActions;
     std::shared_ptr<ProjectSceneActionsController> m_projectSceneActionsController;
     std::shared_ptr<ProjectSceneConfiguration> m_configuration;
+    std::shared_ptr<RealtimeEffectPanelTrackSelection> m_realtimeEffectPanelTrackSelection;
 };
 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -58,10 +58,10 @@ ListItemBlank {
             icon: IconCode.BYPASS
             iconFont: ui.theme.toolbarIconsFont
 
-            accentButton: true
+            accentButton: item.isActive
 
             onClicked: {
-                accentButton = !accentButton
+                item.isActive = !item.isActive
             }
         }
 
@@ -95,7 +95,7 @@ ListItemBlank {
                 }
 
                 onClicked: {
-                    root.item.showDialog()
+                    root.item.toggleDialog()
                 }
             }
         }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
@@ -14,16 +14,15 @@ Rectangle {
     id: root
 
     property alias preferredHeight: trackEffectList.height
-
-    visible: trackEffectList.count > 0
+    property alias trackName: trackEffectListModel.trackName
+    property alias trackEffectsActive: trackEffectListModel.trackEffectsActive
 
     Component.onCompleted: {
-            trackEffectListModel.load()
-        }
+        trackEffectListModel.load()
+    }
 
     RealtimeEffectListModel {
         id: trackEffectListModel
-        trackId: view.itemAtIndex(effectsPanel.selectedTrackIndex).item.trackId
     }
 
     StyledListView {

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
@@ -11,21 +11,16 @@ import Muse.UiComponents
 import Audacity.ProjectScene
 
 Rectangle {
-    id: effectsPanel
+    id: root
 
     property int selectedTrackIndex: -1
 
+    enabled: effectList.trackName !== ""
     color: ui.theme.backgroundPrimaryColor
-
-    onSelectedTrackIndexChanged: {
-        const selectedTrackItem = view.itemAtIndex(selectedTrackIndex)
-        trackEffects.trackName = selectedTrackItem.item.title
-    }
 
     ColumnLayout {
         id: trackEffects
         spacing: 0
-        property alias trackName: trackEffectsHeader.trackName
         readonly property int itemSpacing: 12
         Layout.fillWidth: true
 
@@ -33,7 +28,6 @@ Rectangle {
 
         RowLayout {
             id: trackEffectsHeader
-            property alias trackName: trackNameLabel.text
             readonly property int headerHeight: 40
 
             spacing: trackEffects.itemSpacing
@@ -52,18 +46,22 @@ Rectangle {
                 icon: IconCode.BYPASS
                 iconFont: ui.theme.toolbarIconsFont
 
-                accentButton: true
+                enabled: root.enabled
+                accentButton: effectList.trackEffectsActive
 
                 onClicked: {
                     accentButton = !accentButton
+                    effectList.trackEffectsActive = accentButton
                 }
             }
 
             StyledTextLabel {
                 id: trackNameLabel
+                visible: root.enabled
+                text: effectList.trackName
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                Layout.maximumWidth: effectsPanel.width - trackEffectsPowerButton.width - trackEffectsHeader.spacing - trackEffects.itemSpacing
+                Layout.maximumWidth: root.width - trackEffectsPowerButton.width - trackEffectsHeader.spacing - trackEffects.itemSpacing
                 horizontalAlignment: Text.AlignLeft
             }
         }
@@ -74,6 +72,7 @@ Rectangle {
         }
 
         Rectangle {
+            visible: root.enabled
             color: ui.theme.backgroundSecondaryColor
             Layout.preferredHeight: effectList.preferredHeight == 0 ? 0 : effectList.preferredHeight + (effectList.anchors.topMargin + effectList.anchors.bottomMargin)
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
@@ -91,11 +90,14 @@ Rectangle {
                     topMargin: 8
                     bottomMargin: 8
                 }
+                onTrackEffectsActiveChanged: {
+                    trackEffectsPowerButton.accentButton = trackEffectsActive
+                }
             }
         }
 
         SeparatorLine {
-            visible: effectList.visible
+            visible: root.enabled
         }
 
         FlatButton {
@@ -108,7 +110,6 @@ Rectangle {
 
             RealtimeEffectMenuModel {
                 id: menuModel
-                trackId: view.itemAtIndex(effectsPanel.selectedTrackIndex).item.trackId
             }
 
             onClicked: function() {

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.cpp
@@ -1,0 +1,42 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "realtimeeffectlistitemmodel.h"
+
+namespace au::projectscene {
+RealtimeEffectListItemModel::RealtimeEffectListItemModel(QObject* parent, effects::RealtimeEffectStatePtr effectStateId)
+    : QObject{parent}, effectStateId{std::move(effectStateId)}
+{
+    realtimeEffectService()->isActiveChanged().onReceive(this, [this](effects::RealtimeEffectStatePtr stateId)
+    {
+        if (stateId == this->effectStateId) {
+            emit isActiveChanged();
+        }
+    });
+}
+
+RealtimeEffectListItemModel::~RealtimeEffectListItemModel()
+{
+    effectsProvider()->hideEffect(effectStateId);
+}
+
+QString RealtimeEffectListItemModel::effectName() const
+{
+    return QString::fromStdString(effectsProvider()->effectName(*effectStateId));
+}
+
+void RealtimeEffectListItemModel::toggleDialog()
+{
+    effectsProvider()->toggleShowEffect(effectStateId);
+}
+
+bool RealtimeEffectListItemModel::prop_isActive() const
+{
+    return realtimeEffectService()->isActive(effectStateId);
+}
+
+void RealtimeEffectListItemModel::prop_setIsActive(bool isActive)
+{
+    realtimeEffectService()->setIsActive(effectStateId, isActive);
+}
+}

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.h
@@ -1,0 +1,38 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "modularity/ioc.h"
+#include "async/asyncable.h"
+#include "effects/effects_base/ieffectsprovider.h"
+#include "effects/effects_base/irealtimeeffectservice.h"
+
+#include <QObject>
+
+namespace au::projectscene {
+class RealtimeEffectListItemModel : public QObject, public muse::Injectable, public muse::async::Asyncable
+{
+    Q_OBJECT
+    Q_PROPERTY(bool isActive READ prop_isActive WRITE prop_setIsActive NOTIFY isActiveChanged)
+
+    muse::Inject<effects::IEffectsProvider> effectsProvider;
+    muse::Inject<effects::IRealtimeEffectService> realtimeEffectService;
+
+public:
+    RealtimeEffectListItemModel(QObject* parent, effects::RealtimeEffectStatePtr effectState);
+    ~RealtimeEffectListItemModel();
+
+    const effects::RealtimeEffectStatePtr effectStateId;
+    Q_INVOKABLE QString effectName() const;
+    Q_INVOKABLE void toggleDialog();
+
+    bool prop_isActive() const;
+    void prop_setIsActive(bool isActive);
+
+signals:
+    void isActiveChanged();
+};
+
+using RealtimeEffectListItemModelPtr = std::shared_ptr<RealtimeEffectListItemModel>;
+}

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.h
@@ -3,51 +3,46 @@
  */
 #pragma once
 
-#include "modularity/ioc.h"
-#include "context/iglobalcontext.h"
 #include "realtimeeffectmenumodelbase.h"
-#include "effects/effects_base/irealtimeeffectservice.h"
-#include "effects/effects_base/ieffectsprovider.h"
+#include "realtimeeffectlistitemmodel.h"
+#include "context/iglobalcontext.h"
 #include <QObject>
 #include <map>
 
 namespace au::projectscene {
-class ModelEffectItem : public QObject, public muse::Injectable
-{
-    Q_OBJECT
-
-    muse::Inject<effects::IEffectsProvider> effectsProvider;
-
-public:
-    ModelEffectItem(QObject* parent, effects::EffectStateId effectState);
-
-    const effects::EffectStateId effectStateId;
-    Q_INVOKABLE QString effectName() const;
-    Q_INVOKABLE void showDialog();
-};
-
 class RealtimeEffectListModel : public RealtimeEffectMenuModelBase
 {
     Q_OBJECT
 
     Q_PROPERTY(QVariantList availableEffects READ availableEffects NOTIFY availableEffectsChanged)
+    Q_PROPERTY(QString trackName READ prop_trackName NOTIFY trackNameChanged)
+    Q_PROPERTY(bool trackEffectsActive READ prop_trackEffectsActive WRITE prop_setTrackEffectsActive NOTIFY trackEffectsActiveChanged)
 
     muse::Inject<context::IGlobalContext> globalContext;
-    muse::Inject<effects::IRealtimeEffectService> realtimeEffectService;
 
 public:
     explicit RealtimeEffectListModel(QObject* parent = nullptr);
 
-    Q_INVOKABLE void handleMenuItemWithState(const QString& menuItemId, const ModelEffectItem*);
+    Q_INVOKABLE void handleMenuItemWithState(const QString& menuItemId, const RealtimeEffectListItemModel*);
     QVariantList availableEffects();
+    QString prop_trackName() const;
+
+    bool prop_trackEffectsActive() const;
+    void prop_setTrackEffectsActive(bool active);
 
 signals:
     void availableEffectsChanged();
+    void trackNameChanged();
+    void trackEffectsActiveChanged();
 
 private:
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex& index, int role) const override;
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+
+    void doResetList() override;
+    void doRemoveTrack(const au::trackedit::TrackId& trackId) override;
+    void onTrackIdChanged() override;
 
 private:
     enum RoleNames
@@ -57,12 +52,11 @@ private:
 
     void doLoad() override;
     void populateMenu() override;
+    void onProjectChanged();
+    void insertEffect(effects::TrackId trackId, effects::EffectChainLinkIndex index, const effects::RealtimeEffectStatePtr& item);
+    void removeEffect(effects::TrackId trackId, const effects::RealtimeEffectStatePtr& item);
 
-    void setListenerOnCurrentTrackeditProject();
-    void insertEffect(effects::TrackId trackId, effects::EffectChainLinkIndex index, const effects::EffectStateId& item);
-    void removeEffect(effects::TrackId trackId, effects::EffectChainLinkIndex index, const effects::EffectStateId& item);
-
-    using EffectList = std::vector<ModelEffectItem*>;
+    using EffectList = std::vector<RealtimeEffectListItemModelPtr>;
     std::map<effects::TrackId, EffectList> m_trackEffectLists;
 };
 }

--- a/src/projectscene/view/trackspanel/realtimeeffectmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectmenumodel.cpp
@@ -18,8 +18,6 @@ void RealtimeEffectMenuModel::doLoad()
 
 void RealtimeEffectMenuModel::populateMenu()
 {
-    TRACEFUNC;
-
     MenuItemList items;
 
     const auto metaList = effectsProvider()->effectMetaList();
@@ -31,7 +29,7 @@ void RealtimeEffectMenuModel::populateMenu()
             continue;
         }
         MenuItem* item = makeMenuItem("realtimeeffect-add", TranslatableString::untranslatable(meta.title));
-        item->setArgs(actions::ActionData::make_arg2<String, au::trackedit::TrackId>(meta.id, m_trackId));
+        item->setArgs(actions::ActionData::make_arg1(meta.id));
         menuCategories[meta.categoryId].push_back(item);
     }
 
@@ -40,4 +38,18 @@ void RealtimeEffectMenuModel::populateMenu()
     }
 
     setItems(items);
+}
+
+void RealtimeEffectMenuModel::handleMenuItem(const QString& itemId)
+{
+    const MenuItem& menuItem = findItem(itemId);
+    const auto tId = trackId();
+    IF_ASSERT_FAILED(tId.has_value()) {
+        return;
+    }
+
+    const auto effectId = menuItem.args().arg<effects::EffectId>(0);
+    if (const auto state = realtimeEffectService()->addRealtimeEffect(*tId, effectId)) {
+        effectsProvider()->showEffect(state);
+    }
 }

--- a/src/projectscene/view/trackspanel/realtimeeffectmenumodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectmenumodel.h
@@ -15,6 +15,8 @@ public:
     explicit RealtimeEffectMenuModel(QObject* parent = nullptr);
 
 private:
+    void handleMenuItem(const QString& itemId) override;
+
     void doLoad() override;
     void populateMenu() override;
 };

--- a/src/projectscene/view/trackspanel/realtimeeffectmenumodelbase.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectmenumodelbase.cpp
@@ -6,7 +6,9 @@
 using namespace au::projectscene;
 
 RealtimeEffectMenuModelBase::RealtimeEffectMenuModelBase(QObject* parent)
-    : AbstractMenuModel(parent) {}
+    : AbstractMenuModel(parent)
+{
+}
 
 void RealtimeEffectMenuModelBase::load()
 {
@@ -15,22 +17,41 @@ void RealtimeEffectMenuModelBase::load()
     effectsProvider()->effectMetaListChanged().onNotify(this, [this]
     { populateMenu(); });
 
+    trackSelection()->selectedTrackIdChanged().onNotify(this, [this]
+    {
+        beginResetModel();
+        endResetModel();
+        onTrackIdChanged();
+    });
+
     doLoad();
 }
 
-au::trackedit::TrackId RealtimeEffectMenuModelBase::trackId() const
+std::optional<au::trackedit::TrackId> RealtimeEffectMenuModelBase::trackId() const
 {
-    return m_trackId;
+    return trackSelection()->selectedTrackId();
 }
 
-void RealtimeEffectMenuModelBase::setTrackId(au::trackedit::TrackId trackId)
+void RealtimeEffectMenuModelBase::resetList()
 {
-    if (trackId < 0 || m_trackId == trackId) {
-        return;
-    }
     beginResetModel();
-    m_trackId = trackId;
+    doResetList();
     endResetModel();
-    // TODO: I don't think this is necessary
-    emit trackIdChanged();
+}
+
+void RealtimeEffectMenuModelBase::removeTrack(const au::trackedit::TrackId& trackId)
+{
+    beginResetModel();
+    doRemoveTrack(trackId);
+    endResetModel();
+}
+
+void RealtimeEffectMenuModelBase::beginResetModel()
+{
+    AbstractMenuModel::beginResetModel();
+}
+
+void RealtimeEffectMenuModelBase::endResetModel()
+{
+    AbstractMenuModel::endResetModel();
 }

--- a/src/projectscene/view/trackspanel/realtimeeffectmenumodelbase.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectmenumodelbase.h
@@ -3,34 +3,39 @@
  */
 #pragma once
 
+#include "internal/irealtimeeffectpaneltrackselection.h"
 #include "uicomponents/view/abstractmenumodel.h"
 #include "trackedit/trackedittypes.h"
 #include "effects/effects_base/ieffectsprovider.h"
+#include "effects/effects_base/irealtimeeffectservice.h"
 #include <QObject>
 
 namespace au::projectscene {
 class RealtimeEffectMenuModelBase : public muse::uicomponents::AbstractMenuModel
 {
     Q_OBJECT
-    Q_PROPERTY(au::trackedit::TrackId trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged)
-
+    muse::Inject<IRealtimeEffectPanelTrackSelection> trackSelection;
 public:
     explicit RealtimeEffectMenuModelBase(QObject* parent = nullptr);
 
-    au::trackedit::TrackId trackId() const;
-    void setTrackId(au::trackedit::TrackId trackId);
-
     Q_INVOKABLE void load() final override;
 
-signals:
-    void trackIdChanged();
-
 protected:
+    std::optional<au::trackedit::TrackId> trackId() const;
+    void resetList();
+    void removeTrack(const au::trackedit::TrackId& trackId);
+
     muse::Inject<effects::IEffectsProvider> effectsProvider;
-    au::trackedit::TrackId m_trackId = -1;
+    muse::Inject<effects::IRealtimeEffectService> realtimeEffectService;
 
 private:
+    void beginResetModel();
+    void endResetModel();
+
     virtual void doLoad() = 0;
     virtual void populateMenu() = 0;
+    virtual void doResetList() {}
+    virtual void doRemoveTrack(const au::trackedit::TrackId&) {}
+    virtual void onTrackIdChanged() {}
 };
 }

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1508,7 +1508,7 @@ bool Au3Interaction::newMonoTrack()
 {
     auto track = createMonoTrack();
 
-    selectionController()->setSelectedTracks(TrackIdList(TrackId(track->GetId())));
+    selectionController()->setSelectedTracks({track->GetId()});
 
     pushProjectHistoryTrackAddedState();
 
@@ -1519,7 +1519,7 @@ bool Au3Interaction::newStereoTrack()
 {
     auto track = createStereoTrack();
 
-    selectionController()->setSelectedTracks(TrackIdList(TrackId(track->GetId())));
+    selectionController()->setSelectedTracks({track->GetId()});
 
     pushProjectHistoryTrackAddedState();
 

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -16,6 +16,14 @@ void au::trackedit::Au3ProjectHistory::init()
 {
     auto& project = projectRef();
     ::ProjectHistory::Get(project).InitialState();
+    m_undoRedoMessageSubscription = UndoManager::Get(project).Subscribe(
+        [this](const UndoRedoMessage& message){
+        switch (message.type) {
+        case UndoRedoMessage::Type::UndoOrRedo:
+            m_undoOrRedoCalled.notify();
+            return;
+        }
+    });
 }
 
 bool au::trackedit::Au3ProjectHistory::undoAvailable()
@@ -95,6 +103,11 @@ void Au3ProjectHistory::pushHistoryState(const std::string& longDescription, con
 muse::async::Notification Au3ProjectHistory::isUndoRedoAvailableChanged() const
 {
     return m_isUndoRedoAvailableChanged;
+}
+
+muse::async::Notification Au3ProjectHistory::undoOrRedoCalled() const
+{
+    return m_undoOrRedoCalled;
 }
 
 Au3Project& au::trackedit::Au3ProjectHistory::projectRef()

--- a/src/trackedit/internal/au3/au3projecthistory.h
+++ b/src/trackedit/internal/au3/au3projecthistory.h
@@ -11,6 +11,8 @@
 
 #include "au3wrap/au3types.h"
 
+#include "libraries/lib-utility/Observer.h"
+
 namespace au::trackedit {
 class Au3ProjectHistory : public IProjectHistory
 {
@@ -30,10 +32,13 @@ public:
     void pushHistoryState(
         const std::string& longDescription, const std::string& shortDescription, UndoPushType flags) override;
     muse::async::Notification isUndoRedoAvailableChanged() const override;
+    muse::async::Notification undoOrRedoCalled() const override;
 
 private:
     au3::Au3Project& projectRef();
 
     muse::async::Notification m_isUndoRedoAvailableChanged;
+    muse::async::Notification m_undoOrRedoCalled;
+    ::Observer::Subscription m_undoRedoMessageSubscription;
 };
 }

--- a/src/trackedit/internal/au3/au3trackeditproject.cpp
+++ b/src/trackedit/internal/au3/au3trackeditproject.cpp
@@ -184,9 +184,13 @@ muse::async::NotifyList<au::trackedit::Clip> Au3TrackeditProject::clipList(const
     return clips;
 }
 
-std::string Au3TrackeditProject::trackName(const TrackId& trackId) const
+std::optional<std::string> Au3TrackeditProject::trackName(const TrackId& trackId) const
 {
-    return au::au3::DomConverter::track(au::au3::DomAccessor::findTrack(*m_impl->prj, au::au3::Au3TrackId { trackId })).title.toStdString();
+    const Au3Track* au3Track = au::au3::DomAccessor::findTrack(*m_impl->prj, au::au3::Au3TrackId { trackId });
+    if (au3Track == nullptr) {
+        return std::nullopt;
+    }
+    return au::au3::DomConverter::track(au3Track).title.toStdString();
 }
 
 void Au3TrackeditProject::reload()

--- a/src/trackedit/internal/au3/au3trackeditproject.h
+++ b/src/trackedit/internal/au3/au3trackeditproject.h
@@ -26,7 +26,7 @@ public:
     Clip clip(const ClipKey& key) const override;
     muse::async::NotifyList<Clip> clipList(const TrackId& trackId) const override;
     std::vector<int64_t> groupsIdsList() const override;
-    std::string trackName(const TrackId& trackId) const override;
+    std::optional<std::string> trackName(const TrackId& trackId) const override;
 
     void reload() override;
 

--- a/src/trackedit/iprojecthistory.h
+++ b/src/trackedit/iprojecthistory.h
@@ -27,6 +27,7 @@ public:
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription,
                                   trackedit::UndoPushType flags) = 0;
     virtual muse::async::Notification isUndoRedoAvailableChanged() const = 0;
+    virtual muse::async::Notification undoOrRedoCalled() const = 0;
 };
 
 using IProjectHistoryPtr = std::shared_ptr<IProjectHistory>;

--- a/src/trackedit/itrackeditproject.h
+++ b/src/trackedit/itrackeditproject.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "modularity/imoduleinterface.h"
 
@@ -28,7 +29,7 @@ public:
     virtual Clip clip(const ClipKey& key) const = 0;
     virtual muse::async::NotifyList<Clip> clipList(const TrackId& trackId) const = 0;
     virtual std::vector<int64_t> groupsIdsList() const = 0;
-    virtual std::string trackName(const TrackId& trackId) const = 0;
+    virtual std::optional<std::string> trackName(const TrackId& trackId) const = 0;
 
     virtual void reload() = 0;
 

--- a/src/trackedit/tests/mocks/trackeditprojectmock.h
+++ b/src/trackedit/tests/mocks/trackeditprojectmock.h
@@ -16,7 +16,7 @@ public:
     MOCK_METHOD(Clip, clip, (const ClipKey& key), (const, override));
     MOCK_METHOD(muse::async::NotifyList<Clip>, clipList, (const TrackId& trackId), (const, override));
     MOCK_METHOD(std::vector<int64_t>, groupsIdsList, (), (const, override));
-    MOCK_METHOD(std::string, trackName, (const TrackId& trackId), (const, override));
+    MOCK_METHOD(std::optional<std::string>, trackName, (const TrackId& trackId), (const, override));
 
     MOCK_METHOD(void, reload, (), (override));
 


### PR DESCRIPTION
Resolves: #7991
Resolves: #7892
Resolves: #7996

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Adding an effect opens the UI
- [x] Clicking on the button in the panel with the effect's name toggle the dialog into view or hiding
- [x] I can open an effect and interact with the project window without having to close it
- [x] Opening effect A while effect B is open closes B before opening A. (Having several dialogs open at once will be addressed later.)
- [x] Realtime effect lists are preserved and work properly after closing and opening a new project
- [x] Effect panel is disabled if no track is selected
- [x] Effect panel shows effects of selected track
- [x] Changing a track's name is reflected in the effect panel and realtime effect dialogs
- [x] I can play and pause with the keyboard while focus is on a realtime effect
- [x] Deleting a track closes the corresponding effect dialog(s)
- [x] Selecting "No effect" closes the corresponding dialog if it is open.
- [x] DTMF tone generator still works
- [x] https://github.com/audacity/audacity/issues/8046 is fixed
- [x] power buttons for realtime effects are synchronized between panel and dialogs,
- [x] power button for all-track effect also works
- [x] power button states are effective, toggable in real time and persistent across project close/open and application restart.
- [x] Undo / Redo works
