### PR TITLE
fixed #7995: Multiple pitch and speed dialogs can be called for the same clip

### DIFF
--- a/src/projectscene/internal/projectsceneactionscontroller.cpp
+++ b/src/projectscene/internal/projectsceneactionscontroller.cpp
@@ -14,6 +14,8 @@ static const ActionCode MINUTES_SECONDS_RULER("minutes-seconds-ruler");
 static const ActionCode BEATS_MEASURES_RULER("beats-measures-ruler");
 static const ActionCode CLIP_PITCH_AND_SPEED_CODE("clip-pitch-speed");
 
+static const muse::Uri EDIT_PITCH_AND_SPEED_URI("audacity://projectscene/editpitchandspeed");
+
 void ProjectSceneActionsController::init()
 {
     dispatcher()->reg(this, MINUTES_SECONDS_RULER, this, &ProjectSceneActionsController::toggleMinutesSecondsRuler);
@@ -71,6 +73,10 @@ void ProjectSceneActionsController::pinnedPlayHead()
 
 void ProjectSceneActionsController::openClipPitchAndSpeedEdit(const ActionData& args)
 {
+    if (interactive()->isOpened(EDIT_PITCH_AND_SPEED_URI).val) {
+        return;
+    }
+
     IF_ASSERT_FAILED(args.count() == 1) {
         return;
     }
@@ -80,7 +86,7 @@ void ProjectSceneActionsController::openClipPitchAndSpeedEdit(const ActionData& 
         return;
     }
 
-    muse::UriQuery query("audacity://projectscene/editpitchandspeed");
+    muse::UriQuery query(EDIT_PITCH_AND_SPEED_URI);
     query.addParam("trackId", muse::Val(std::to_string(clipKey.trackId)));
     query.addParam("clipId", muse::Val(std::to_string(clipKey.clipId)));
     query.addParam("focusItemName", muse::Val("pitch"));


### PR DESCRIPTION
Resolves: #7995
