### PR TITLE
Clear the track in a non desctrutive way

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1160,7 +1160,7 @@ void WaveTrack::FinishCopy(
 /*! @excsafety{Strong} */
 void WaveTrack::Clear(double t0, double t1)
 {
-   HandleClear(t0, t1, false, false);
+   HandleClear(t0, t1, false, false, true);
 }
 
 /*! @excsafety{Strong} */


### PR DESCRIPTION
Resolves: #7700

This changes clear the track in a non desctrutive way.
We can restore the content expading the track for delete and cut operation.
Apart from that,  if we cut and past the track in another position we can also recovery the missing data.


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
