### PR TITLE
Fix importing AUP projects with custom named project data directory

### DIFF
--- a/modules/import-export/mod-aup/ImportAUP.cpp
+++ b/modules/import-export/mod-aup/ImportAUP.cpp
@@ -1341,10 +1341,7 @@ bool AUPImportFileHandle::HandleImport(XMLTagHandler *&handler)
    if (!XMLValueChecker::IsGoodPathName(strAttr))
    {
       // Maybe strAttr is just a fileName, not the full path. Try the project data directory.
-      wxFileNameWrapper fileName0{ GetFilename() };
-      fileName0.SetExt({});
-      wxFileNameWrapper fileName{
-         fileName0.GetFullPath() + wxT("_data"), strAttr };
+      wxFileNameWrapper fileName{ mProjDir.GetFullPath(), strAttr };
       if (XMLValueChecker::IsGoodFileName(strAttr, fileName.GetPath(wxPATH_GET_VOLUME)))
          strAttr = fileName.GetFullPath();
       else


### PR DESCRIPTION
Importing older AUP projects will fail, when the project data directory is not the default name "<projectname>_data". While reading the tag "project", the attribute "projname" is correctly read and stored in mProjDir, but when reading the data files this variable was not used.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
