### PR TITLE
Clear Response list on sync cancellation to prevent a deadlock

### DIFF
--- a/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.h
+++ b/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.h
@@ -149,7 +149,6 @@ private:
    std::mutex mResponsesMutex;
    std::vector<std::shared_ptr<audacity::network_manager::IResponse>>
       mResponses;
-   std::condition_variable mResponsesEmptyCV;
 
    std::atomic<int64_t> mDownloadedBlocks { 0 };
    std::atomic<int64_t> mCopiedBlocks { 0 };


### PR DESCRIPTION
Resolves: #8013

~RemoteProjectSnapshot was waiting for all responses to be completed, which was impossible since the object had entered destruction (see #7126).

Aborting all responses and clearing the response list since they are not used when RemoteProjectSnapshot goes out of scope.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
