### PR TITLE
Execute bound checking before accessing vector

### DIFF
--- a/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -186,6 +186,10 @@ void SelectionViewController::selectTrackAudioData(double y)
     }
 
     const std::vector<TrackId> tracks = determinateTracks(m_startPoint.y(), y);
+    if (tracks.empty()) {
+        return;
+    }
+
     selectionController()->setSelectedTrackAudioData(tracks.at(0));
 }
 


### PR DESCRIPTION
Resolves: #7992 

Very simple PR to avoid crashing while accessing first position of an empty vector.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
