### PR TITLE
7980 closing while recording

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -63,6 +63,16 @@ void ApplicationActionController::init()
     dispatcher()->reg(this, "revert-factory", this, &ApplicationActionController::revertToFactorySettings);
 }
 
+const std::vector<muse::actions::ActionCode>& ApplicationActionController::prohibitedActionsWhileRecording() const
+{
+    static const std::vector<ActionCode> PROHIBITED_WHILE_RECORDING {
+        "quit",
+        "restart",
+    };
+
+    return PROHIBITED_WHILE_RECORDING;
+}
+
 void ApplicationActionController::onDragEnterEvent(QDragEnterEvent* event)
 {
     onDragMoveEvent(event);
@@ -122,6 +132,14 @@ void ApplicationActionController::onDropEvent(QDropEvent*)
     //         event->ignore();
     //     }
     // }
+}
+
+bool ApplicationActionController::canReceiveAction(const ActionCode& code) const
+{
+    if (recordController()->isRecording()) {
+        return !muse::contains(prohibitedActionsWhileRecording(), code);
+    }
+    return true;
 }
 
 bool ApplicationActionController::eventFilter(QObject* watched, QEvent* event)

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -36,6 +36,7 @@
 #include "iappshellconfiguration.h"
 #include "iapplication.h"
 #include "project/iprojectfilescontroller.h"
+#include "record/irecordcontroller.h"
 
 //! TODO AU4
 // #include "languages/ilanguagesservice.h"
@@ -55,6 +56,7 @@ class ApplicationActionController : public QObject, public IApplicationActionCon
     INJECT(muse::IApplication, application)
     INJECT(IAppShellConfiguration, configuration)
     INJECT(project::IProjectFilesController, projectFilesController)
+    INJECT(record::IRecordController, recordController)
 //! TODO AU4
     // INJECT(languages::ILanguagesService, languagesService)
     // INJECT(mi::IMultiInstancesProvider, multiInstancesProvider)
@@ -63,12 +65,15 @@ class ApplicationActionController : public QObject, public IApplicationActionCon
 public:
     void preInit();
     void init();
+    const std::vector<muse::actions::ActionCode>& prohibitedActionsWhileRecording() const;
 
     muse::ValCh<bool> isFullScreen() const;
 
     void onDragEnterEvent(QDragEnterEvent* event) override;
     void onDragMoveEvent(QDragMoveEvent* event) override;
     void onDropEvent(QDropEvent* event) override;
+
+    bool canReceiveAction(const muse::actions::ActionCode& code) const override;
 
 private:
     bool eventFilter(QObject* watched, QEvent* event) override;

--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -236,6 +236,10 @@ void ApplicationUiActions::init()
     dockWindowProvider()->windowChanged().onNotify(this, [this]() {
         listenOpenedDocksChanged(dockWindowProvider()->window());
     });
+
+    recordController()->isRecordingChanged().onNotify(this, [this]() {
+        m_actionEnabledChanged.send(m_controller->prohibitedActionsWhileRecording());
+    });
 }
 
 void ApplicationUiActions::listenOpenedDocksChanged(IDockWindow* window)

--- a/src/appshell/internal/applicationuiactions.h
+++ b/src/appshell/internal/applicationuiactions.h
@@ -28,6 +28,7 @@
 #include "context/iuicontextresolver.h"
 #include "async/asyncable.h"
 #include "ui/imainwindow.h"
+#include "record/irecordcontroller.h"
 
 //! TODO AU4
 // #include "view/preferences/braillepreferencesmodel.h"
@@ -40,6 +41,7 @@ class ApplicationUiActions : public muse::ui::IUiActionsModule, public muse::asy
     INJECT(muse::ui::IMainWindow, mainWindow)
     INJECT(muse::dock::IDockWindowProvider, dockWindowProvider)
     INJECT(IAppShellConfiguration, configuration)
+    INJECT(record::IRecordController, recordController)
 //! TODO AU4
 //    INJECT(braille::IBrailleConfiguration, brailleConfiguration)
 

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -97,9 +97,12 @@ void Audacity4Project::close()
     history->undoUnsaved();
     history->clearUnsaved();
     // Do not save a project that has never explicitly been saved.
-    //if (m_au3Project->hasSavedVersion()) {
-    //    save();
-    //}
+    if (m_au3Project->hasSavedVersion()) {
+        //! Important!
+        //! If some unsaved changes were made and we don't save the project after having cleared the history,
+        //! the project will be corrupted and can't be opened again.
+        save();
+    }
 
     clipboard()->clearTrackData();
     m_au3Project->close();

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -48,6 +48,24 @@ void ProjectActionsController::init()
     });
 }
 
+const muse::actions::ActionCodeList& ProjectActionsController::prohibitedActionsWhileRecording() const
+{
+    static const std::vector<muse::actions::ActionCode> PROHIBITED_WHILE_RECORDING {
+        "file-new",
+        "file-open",
+        "file-close",
+        "project-import",
+        "file-save",
+        "file-save-as",
+        "file-save-backup",
+        "export-audio",
+        "export-labels",
+        "export-midi",
+    };
+
+    return PROHIBITED_WHILE_RECORDING;
+}
+
 bool ProjectActionsController::canReceiveAction(const muse::actions::ActionCode& code) const
 {
     if (!currentProject()) {
@@ -59,6 +77,8 @@ bool ProjectActionsController::canReceiveAction(const muse::actions::ActionCode&
         };
 
         return muse::contains(DONT_REQUIRE_OPEN_PROJECT, code);
+    } else if (recordController()->isRecording()) {
+        return !muse::contains(prohibitedActionsWhileRecording(), code);
     }
 
     return true;

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -16,6 +16,7 @@
 #include "irecentfilescontroller.h"
 #include "iprojectautosaver.h"
 #include "iopensaveprojectscenario.h"
+#include "record/irecordcontroller.h"
 
 #include "../iaudacityproject.h"
 #include "trackedit/iprojecthistory.h"
@@ -32,6 +33,7 @@ class ProjectActionsController : public IProjectFilesController, public muse::ac
     muse::Inject<IProjectAutoSaver> projectAutoSaver;
     muse::Inject<IOpenSaveProjectScenario> openSaveProjectScenario;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
+    muse::Inject<record::IRecordController> recordController;
 
 public:
     ProjectActionsController() = default;
@@ -51,6 +53,7 @@ public:
     muse::async::Notification projectBeingDownloadedChanged() const override;
 
     bool isProjectOpened(const muse::io::path_t& projectPath) const;
+    const muse::actions::ActionCodeList& prohibitedActionsWhileRecording() const;
 
 private:
     project::IAudacityProjectPtr currentProject() const;
@@ -89,6 +92,7 @@ private:
 
     ProjectBeingDownloaded m_projectBeingDownloaded;
     muse::async::Notification m_projectBeingDownloadedChanged;
+    muse::async::Channel<muse::actions::ActionCodeList> m_actionEnabledChanged;
 };
 }
 

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -773,6 +773,13 @@ ProjectUiActions::ProjectUiActions(std::shared_ptr<ProjectActionsController> con
 {
 }
 
+void ProjectUiActions::init()
+{
+    recordController()->isRecordingChanged().onNotify(this, [this]() {
+        m_actionEnabledChanged.send(m_controller->prohibitedActionsWhileRecording());
+    });
+}
+
 const UiActionList& ProjectUiActions::actionsList() const
 {
     return m_actions;

--- a/src/project/internal/projectuiactions.h
+++ b/src/project/internal/projectuiactions.h
@@ -4,15 +4,20 @@
 #include "ui/iuiactionsmodule.h"
 #include "context/iuicontextresolver.h"
 #include "projectactionscontroller.h"
+#include "record/irecordcontroller.h"
+#include "async/asyncable.h"
 
 namespace au::project {
-class ProjectUiActions : public muse::ui::IUiActionsModule
+class ProjectUiActions : public muse::ui::IUiActionsModule, public muse::async::Asyncable
 {
     muse::Inject<context::IUiContextResolver> uicontextResolver;
+    muse::Inject<record::IRecordController> recordController;
 
 public:
 
     ProjectUiActions(std::shared_ptr<ProjectActionsController> controller);
+
+    void init();
 
     const muse::ui::UiActionList& actionsList() const override;
 

--- a/src/project/projectmodule.cpp
+++ b/src/project/projectmodule.cpp
@@ -68,6 +68,7 @@ void ProjectModule::registerExports()
 {
     m_configuration = std::make_shared<ProjectConfiguration>();
     m_actionsController = std::make_shared<ProjectActionsController>();
+    m_uiActions = std::make_shared<ProjectUiActions>(m_actionsController);
     m_thumbnailCreator = std::make_shared<ThumbnailCreator>();
 
 #ifdef Q_OS_MAC
@@ -89,7 +90,7 @@ void ProjectModule::resolveImports()
 {
     auto ar = ioc()->resolve<muse::ui::IUiActionsRegister>(moduleName());
     if (ar) {
-        ar->reg(std::make_shared<ProjectUiActions>(m_actionsController));
+        ar->reg(m_uiActions);
     }
     auto ir = ioc()->resolve<muse::ui::IInteractiveUriRegister>(moduleName());
     if (ir) {
@@ -123,6 +124,7 @@ void ProjectModule::onInit(const muse::IApplication::RunMode&)
 {
     m_configuration->init();
     m_actionsController->init();
+    m_uiActions->init();
     m_recentFilesController->init();
 }
 

--- a/src/project/projectmodule.h
+++ b/src/project/projectmodule.h
@@ -29,6 +29,7 @@
 namespace au::project {
 class ProjectConfiguration;
 class ProjectActionsController;
+class ProjectUiActions;
 class RecentFilesController;
 class ThumbnailCreator;
 class ProjectModule : public muse::modularity::IModuleSetup
@@ -48,6 +49,7 @@ private:
     std::shared_ptr<ProjectActionsController> m_actionsController;
     std::shared_ptr<RecentFilesController> m_recentFilesController;
     std::shared_ptr<ThumbnailCreator> m_thumbnailCreator;
+    std::shared_ptr<ProjectUiActions> m_uiActions;
 };
 }
 


### PR DESCRIPTION
Resolves: #7980

Actions leading to a loss of recording should be disabled during recording.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] Actions that can lead to losing an ongoing recording are disabled until the recording is finished. (Please raise those which still aren't.)
- [ ] On a saved project: recording, stopping recording and closing without saving does not corrupt the project.
