### PR TITLE
Fix start and end time on clip selection

### DIFF
--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -347,8 +347,11 @@ void TrackeditActionsController::doGlobalDuplicate()
     auto selectedTracks = selectionController()->selectedTracks();
 
     if (!selectedTracks.empty()) {
-        secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
-        secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
+        const auto selectedClips = selectionController()->selectedClips();
+        const auto isClipSelected = !selectedClips.empty();
+
+        secs_t selectedStartTime = isClipSelected ? secs_t(selectionController()->selectedClipStartTime()) : selectionController()->dataSelectedStartTime();
+        secs_t selectedEndTime = isClipSelected ? secs_t(selectionController()->selectedClipEndTime()) : selectionController()->dataSelectedEndTime();
 
         dispatcher()->dispatch(DUPLICATE_SELECTED,
                                ActionData::make_arg3<TrackIdList, secs_t, secs_t>(selectedTracks, selectedStartTime, selectedEndTime));


### PR DESCRIPTION
Resolves: #8002 

After selecting a clip we should use its start and end information on the duplicate action.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
