### PR TITLE
Fix paste on start of clip

### DIFF
--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1139,11 +1139,13 @@ bool WaveClip::Paste(double t0, const WaveClip& o)
    ClearSequenceFinisher finisher;
 
    //seems like edge cases cannot happen, see WaveTrack::PasteWaveTrack
+   double leftTrimDueToPaste = 0.0;
    auto &factory = GetFactory();
    if (t0 == GetPlayStartTime())
    {
       finisher = ClearSequence(GetSequenceStartTime(), t0);
       SetTrimLeft(other.GetTrimLeft());
+      leftTrimDueToPaste = other.GetTrimLeft();
 
       auto copy = std::make_shared<WaveClip>(other, factory, true);
       copy->ClearSequence(copy->GetPlayEndTime(), copy->GetSequenceEndTime())
@@ -1211,6 +1213,8 @@ bool WaveClip::Paste(double t0, const WaveClip& o)
    finisher.Commit();
    transaction.Commit();
    MarkChanged();
+
+   SetSequenceStartTime(GetSequenceStartTime() - leftTrimDueToPaste);
 
    const auto sampleTime = 1.0 / GetRate();
    const auto timeOffsetInEnvelope =


### PR DESCRIPTION
Resolves: #7410 

The paste operation on the begging of the track can be handle as a paste on the middle but with t0 = 0.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
