### PR TITLE
Fix freeze on openning a corrupted project

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -91,7 +91,7 @@ class wxWidgetsAudacityDependency:
     override: bool = False
 
     def reference(self, conanfile):
-        return f"{self.name}/3.1.3.5-audacity@audacity/stable"
+        return f"{self.name}/3.1.3.6-audacity@audacity/stable"
 
     def apply_options(self, conanfile, package):
         opts = [


### PR DESCRIPTION
Resolves: #8005 

This PR updates wxWidgets version to include [this fix](https://github.com/audacity/conan-recipes/commit/5796d989b8016af4a8b85febc45d36406dc86044)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
