### PR TITLE
Use titlebar implicit height to set inner components height

### DIFF
--- a/src/appshell/qml/ProjectPage/ProjectPage.qml
+++ b/src/appshell/qml/ProjectPage/ProjectPage.qml
@@ -186,6 +186,7 @@ DockPage {
             id: tracksPanel
             readonly property int effectsSectionWidth: 240
             property bool showEffectsSection: false
+            property int titleBarHeight: 39
 
             onShowEffectsSectionChanged: {
                 const newWidth = root.verticalPanelDefaultWidth + (tracksPanel.showEffectsSection ? tracksPanel.effectsSectionWidth : 0)
@@ -214,6 +215,7 @@ DockPage {
                 id: titleBarItem
                 effectsSectionWidth: tracksPanel.effectsSectionWidth
                 showEffectsSection: tracksPanel.showEffectsSection
+                implicitHeight: tracksPanel.titleBarHeight
 
                 onAddRequested: function(type) {
                     tracksPanel.add(type)

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
@@ -19,13 +19,10 @@ KDDW.TitleBarBase {
  
     signal effectsSectionCloseButtonClicked()
 
-    property int expectedHeight: 39
-
     signal addRequested(type: int)
 
     anchors.fill: parent
-    implicitHeight: gripButton.implicitHeight
-    heightWhenVisible: expectedHeight
+    heightWhenVisible: implicitHeight
 
     Component.onCompleted: {
         if (effectsSectionWidth == 0) {
@@ -54,7 +51,7 @@ KDDW.TitleBarBase {
             border.width: padding
 
             Layout.preferredWidth: root.effectsSectionWidth
-            Layout.preferredHeight: root.expectedHeight
+            Layout.preferredHeight: root.implicitHeight
 
             StyledTextLabel {
                 text: qsTr("Effects")
@@ -70,8 +67,8 @@ KDDW.TitleBarBase {
 
             Rectangle {
                 color: effectsTitleBar.color
-                width: root.expectedHeight
-                height: root.expectedHeight
+                width: root.implicitHeight
+                height: root.implicitHeight
                 anchors.right: parent.right
                 FlatButton {
                     transparent: true
@@ -91,7 +88,7 @@ KDDW.TitleBarBase {
         FlatButton {
             id: gripButton
 
-            Layout.preferredHeight: root.expectedHeight
+            Layout.preferredHeight: root.implicitHeight
             Layout.preferredWidth: 28
             backgroundRadius: 0
 
@@ -124,7 +121,7 @@ KDDW.TitleBarBase {
 
             width: root.verticalPanelDefaultWidth - gripButton.width
             Layout.fillWidth: true
-            Layout.preferredHeight: root.expectedHeight
+            Layout.preferredHeight: root.implicitHeight
 
             accessible.name: qsTrc("projectscene", "Add Track")
             backgroundRadius: 0


### PR DESCRIPTION
Resolves: #8012 

This modification was possible after the framework update  here: https://github.com/musescore/MuseScore/pull/26110

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
