### PR TITLE
Fix freeze during the project download

### DIFF
--- a/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.h
+++ b/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.h
@@ -114,6 +114,7 @@ private:
 
    void ReportProgress();
 
+   void StartSync();
    bool InProgress() const;
    void RequestsThread();
 


### PR DESCRIPTION
When the download thread was scheduled before shared_ptr to RemoteProjectSnapshot was created, lambda failed to acquire a weak_ptr to self, resulting in the request not being processed.

Now dispatch threads after the shared_ptr is initialized.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
