### PR TITLE
Fix freeze when canceling a project download on unstable connection

### DIFF
--- a/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.cpp
+++ b/libraries/lib-cloud-audiocom/sync/RemoteProjectSnapshot.cpp
@@ -376,6 +376,15 @@ void RemoteProjectSnapshot::DownloadBlob(
    }
 
    assert(!weak_from_this().expired());
+
+   response->setDownloadProgressCallback([this, self = weak_from_this()](int64_t current, int64_t expected) {
+      auto strong = self.lock();
+      if(!strong) {
+         return;
+      }
+      ReportProgress();
+   });
+
    response->setRequestFinishedCallback(
       [this, self = weak_from_this(), onSuccess = std::move(onSuccess), retries, response](auto)
       {

--- a/modules/sharing/mod-cloud-audiocom/CloudProjectOpenUtils.cpp
+++ b/modules/sharing/mod-cloud-audiocom/CloudProjectOpenUtils.cpp
@@ -38,7 +38,7 @@ namespace
 auto MakeProgress()
 {
    return BasicUI::MakeProgress(
-      XO("Open trace audio.com"), XO("Synchronizing project"),
+      XO("Open from audio.com"), XO("Synchronizing project"),
       BasicUI::ProgressShowCancel);
 }
 


### PR DESCRIPTION
Resolves: #8009

On an unstable connection libcurl may wait for data to come for quite some time. During this ProgressDialog state is not checked and clicking on the "Cancel" button is not handled. 

Now update the state on each [CURLOPT_XFERINFOFUNCTION](https://curl.se/libcurl/c/CURLOPT_XFERINFOFUNCTION.html) callback call.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
