### PR TITLE
Effect panel can be toggled from menu

### DIFF
--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -24,6 +24,7 @@
 
 #include "modularity/imoduleinterface.h"
 #include "types/ret.h"
+#include "types/retval.h"
 
 #include "io/path.h"
 #include "appshelltypes.h"
@@ -74,6 +75,9 @@ public:
 
     virtual muse::io::paths_t sessionProjectsPaths() const = 0;
     virtual muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) = 0;
+
+    virtual muse::ValCh<bool> isEffectsPanelVisible() const = 0;
+    virtual void setIsEffectsPanelVisible(bool visible) = 0;
 };
 }
 

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -292,3 +292,13 @@ muse::io::paths_t AppShellConfiguration::parseSessionProjectsPaths(const QByteAr
 
     return result;
 }
+
+muse::ValCh<bool> AppShellConfiguration::isEffectsPanelVisible() const
+{
+    return projectSceneConfiguration()->isEffectsPanelVisible();
+}
+
+void AppShellConfiguration::setIsEffectsPanelVisible(bool visible)
+{
+    projectSceneConfiguration()->setIsEffectsPanelVisible(visible);
+}

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -29,6 +29,7 @@
 #include "io/ifilesystem.h"
 // #include "multiinstances/imultiinstancesprovider.h"
 #include "ui/iuiconfiguration.h"
+#include "projectscene/iprojectsceneconfiguration.h"
 // #include "project/iprojectconfiguration.h"
 // #include "playback/iplaybackconfiguration.h"
 // #include "languages/ilanguagesconfiguration.h"
@@ -40,6 +41,7 @@ class AppShellConfiguration : public IAppShellConfiguration, public muse::async:
 {
     muse::Inject<muse::IGlobalConfiguration> globalConfiguration;
     muse::Inject<muse::io::IFileSystem> fileSystem;
+    muse::Inject<projectscene::IProjectSceneConfiguration> projectSceneConfiguration;
     // INJECT(mi::IMultiInstancesProvider, multiInstancesProvider)
     // INJECT(ui::IUiConfiguration, uiConfiguration)
     // INJECT(project::IProjectConfiguration, projectConfiguration)
@@ -87,6 +89,9 @@ public:
 
     muse::io::paths_t sessionProjectsPaths() const override;
     muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) override;
+
+    muse::ValCh<bool> isEffectsPanelVisible() const override;
+    void setIsEffectsPanelVisible(bool visible) override;
 
 private:
     std::string utmParameters(const std::string& utmMedium) const;

--- a/src/appshell/qml/ProjectPage/ProjectPage.qml
+++ b/src/appshell/qml/ProjectPage/ProjectPage.qml
@@ -188,11 +188,17 @@ DockPage {
             property bool showEffectsSection: false
             property int titleBarHeight: 39
 
+            // For some reason, I cannot refer to `tp` from anywhere other than `tp` itself
+            // without getting a "tp is not defined" error. Maybe because this `DockPanel`
+            // is within that array thingy ?
+            signal effectsSectionVisibilityChanged(show: bool)
+
             onShowEffectsSectionChanged: {
                 const newWidth = root.verticalPanelDefaultWidth + (tracksPanel.showEffectsSection ? tracksPanel.effectsSectionWidth : 0)
                 tracksPanel.width = newWidth
                 tracksPanel.minimumWidth = newWidth
                 tracksPanel.maximumWidth = newWidth
+                effectsSectionVisibilityChanged(showEffectsSection)
             }
 
             signal add(type: int)
@@ -230,7 +236,16 @@ DockPage {
                 id: tp
                 navigationSection: tracksPanel.navigationSection
                 effectsSectionWidth: tracksPanel.effectsSectionWidth
-                showEffectsSection: tracksPanel.showEffectsSection
+
+                Component.onCompleted: {
+                    tracksPanel.effectsSectionVisibilityChanged.connect(function(show) {
+                        tp.showEffectsSection = show
+                    })
+                }
+
+                onShowEffectsSectionChanged: {
+                    tracksPanel.showEffectsSection = showEffectsSection
+                }
 
                 onOpenEffectsRequested: {
                     tracksPanel.showEffectsSection = true

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -77,6 +77,13 @@ void AppMenuModel::load()
     //! NOTE: removes some undesired platform-specific items
     //! (such as "Start Dictation" and "Special Characters" on macOS)
     appMenuModelHook()->onAppMenuInited();
+
+    muse::ValCh<bool> isEffectsPanelVisible = configuration()->isEffectsPanelVisible();
+    isEffectsPanelVisible.ch.onReceive(this, [this](bool visible)
+    {
+        setItemIsChecked("toggle-effects", visible);
+    });
+    setItemIsChecked("toggle-effects", isEffectsPanelVisible.val);
 }
 
 bool AppMenuModel::isGlobalMenuAvailable()
@@ -127,6 +134,14 @@ void AppMenuModel::setupConnections()
         MenuItem& effectsItem = findMenu("menu-effect");
         effectsItem.setSubitems(makeEffectsItems());
     });
+}
+
+void AppMenuModel::setItemIsChecked(const QString& itemId, bool checked)
+{
+    MenuItem& item = findMenu(itemId);
+    auto state = item.state();
+    state.checked = checked;
+    item.setState(state);
 }
 
 MenuItem* AppMenuModel::makeMenuItem(const actions::ActionCode& actionCode, MenuItemRole menuRole)

--- a/src/appshell/view/appmenumodel.h
+++ b/src/appshell/view/appmenumodel.h
@@ -113,6 +113,8 @@ private:
     muse::uicomponents::MenuItemList makeWorkspacesItems();
     muse::uicomponents::MenuItemList makeShowItems();
     muse::uicomponents::MenuItemList makeEffectsItems();
+
+    void setItemIsChecked(const QString& itemId, bool checked);
 };
 }
 

--- a/src/projectscene/internal/projectsceneconfiguration.cpp
+++ b/src/projectscene/internal/projectsceneconfiguration.cpp
@@ -100,3 +100,16 @@ muse::async::Channel<TimelineRulerMode> ProjectSceneConfiguration::timelineRuler
 {
     return m_timelineRulerModeChanged;
 }
+
+muse::ValCh<bool> ProjectSceneConfiguration::isEffectsPanelVisible() const
+{
+    return m_effectsPanelVisible;
+}
+
+void ProjectSceneConfiguration::setIsEffectsPanelVisible(bool visible)
+{
+    if (m_effectsPanelVisible.val == visible) {
+        return;
+    }
+    m_effectsPanelVisible.set(visible);
+}

--- a/src/projectscene/internal/projectsceneconfiguration.h
+++ b/src/projectscene/internal/projectsceneconfiguration.h
@@ -37,8 +37,13 @@ public:
     virtual void setTimelineRulerMode(const TimelineRulerMode mode) override;
     virtual muse::async::Channel<TimelineRulerMode> timelineRulerModeChanged() const override;
 
+    muse::ValCh<bool> isEffectsPanelVisible() const override;
+    void setIsEffectsPanelVisible(bool visible) override;
+
 private:
     muse::async::Channel<bool> m_isVerticalRulersVisibleChanged;
     muse::async::Channel<TimelineRulerMode> m_timelineRulerModeChanged;
+
+    muse::ValCh<bool> m_effectsPanelVisible;
 };
 }

--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -9,6 +9,11 @@ constexpr int DEFAULT_HEIGHT = 116;
 constexpr int MIN_HEIGHT = 44;
 constexpr int COLLAPSE_HEIGHT = 72;
 
+ProjectViewState::ProjectViewState()
+{
+    configuration()->setIsEffectsPanelVisible(false);
+}
+
 muse::ValCh<int> ProjectViewState::tracksVericalY() const
 {
     return m_tracksVericalY;

--- a/src/projectscene/internal/projectviewstate.h
+++ b/src/projectscene/internal/projectviewstate.h
@@ -4,17 +4,20 @@
 #pragma once
 
 #include "../iprojectviewstate.h"
+#include "../iprojectsceneconfiguration.h"
 
 #include "context/iglobalcontext.h"
 #include "modularity/ioc.h"
+#include "async/asyncable.h"
 
 namespace au::projectscene {
-class ProjectViewState : public IProjectViewState
+class ProjectViewState : public IProjectViewState, public muse::async::Asyncable
 {
     muse::Inject<au::context::IGlobalContext> globalContext;
+    muse::Inject<IProjectSceneConfiguration> configuration;
 
 public:
-    ProjectViewState() = default;
+    ProjectViewState();
 
     // context of all tracks
     muse::ValCh<int> tracksVericalY() const override;

--- a/src/projectscene/internal/realtimeeffectpaneltrackselection.cpp
+++ b/src/projectscene/internal/realtimeeffectpaneltrackselection.cpp
@@ -9,9 +9,16 @@ void RealtimeEffectPanelTrackSelection::init()
         }
     });
     globalContext()->currentTrackeditProjectChanged().onNotify(this, [this] {
-        if (!globalContext()->currentProject()) {
-            setTrackId({});
+        // Show effects of top-most track if there isn't one selected already and the project isn't empty.
+        const trackedit::ITrackeditProjectPtr project = globalContext()->currentTrackeditProject();
+        std::optional<trackedit::TrackId> trackId;
+        if (project && !m_trackId.has_value()) {
+            const std::vector<trackedit::TrackId> list = project->trackIdList();
+            if (!list.empty()) {
+                trackId = list.front();
+            }
         }
+        setTrackId(trackId);
     });
 }
 

--- a/src/projectscene/iprojectsceneconfiguration.h
+++ b/src/projectscene/iprojectsceneconfiguration.h
@@ -3,6 +3,7 @@
 #include "async/channel.h"
 #include "modularity/imoduleinterface.h"
 #include "types/projectscenetypes.h"
+#include "types/retval.h"
 
 namespace au::projectscene {
 class IProjectSceneConfiguration : MODULE_EXPORT_INTERFACE
@@ -28,5 +29,8 @@ public:
     virtual TimelineRulerMode timelineRulerMode() const = 0;
     virtual void setTimelineRulerMode(const TimelineRulerMode mode) = 0;
     virtual muse::async::Channel<TimelineRulerMode> timelineRulerModeChanged() const = 0;
+
+    virtual muse::ValCh<bool> isEffectsPanelVisible() const = 0;
+    virtual void setIsEffectsPanelVisible(bool visible) = 0;
 };
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
@@ -16,6 +16,7 @@ Rectangle {
     property alias preferredHeight: trackEffectList.height
     property alias trackName: trackEffectListModel.trackName
     property alias trackEffectsActive: trackEffectListModel.trackEffectsActive
+    property alias showEffectsSection: trackEffectListModel.showEffectsSection
 
     Component.onCompleted: {
         trackEffectListModel.load()

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
@@ -14,6 +14,7 @@ Rectangle {
     id: root
 
     property int selectedTrackIndex: -1
+    property alias showEffectsSection: effectList.showEffectsSection
 
     enabled: effectList.trackName !== ""
     color: ui.theme.backgroundPrimaryColor

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -20,7 +20,7 @@ Item {
 
     // property alias contextMenuModel: contextMenuModel
     property int effectsSectionWidth: 240 // TODO: can this be set as a constant that can be imported?
-    property alias showEffectsSection: trackEffectsSection.visible
+    property alias showEffectsSection: trackEffectsSection.showEffectsSection
     property alias selectedTrackIndex: trackEffectsSection.selectedTrackIndex
 
     TracksListModel {
@@ -57,7 +57,7 @@ Item {
             Layout.maximumWidth: root.effectsSectionWidth
             Layout.minimumWidth: root.effectsSectionWidth
             Layout.fillHeight: true
-            visible: false
+            visible: showEffectsSection
         }
 
         SeparatorLine { }
@@ -143,6 +143,7 @@ Item {
 
                     onOpenEffectsRequested: {
                         root.selectedTrackIndex = index
+                        trackEffectsSection.showEffectsSection = true
                         root.openEffectsRequested()
                     }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
@@ -16,7 +16,7 @@ KDDW.TitleBarBase {
 
     property int effectsSectionWidth: 0
     property bool showEffectsSection: false
- 
+
     signal effectsSectionCloseButtonClicked()
 
     signal addRequested(type: int)
@@ -31,20 +31,14 @@ KDDW.TitleBarBase {
         }
     }
 
-    onShowEffectsSectionChanged: {
-        rowLayout.effectsTitleBar.visible = showEffectsSection
-    }
-
     RowLayout {
         id: rowLayout
         anchors.fill: parent
         spacing: 0
 
-        property alias effectsTitleBar: effectsTitleBar
-
         Rectangle {
             id: effectsTitleBar
-            visible: false
+            visible: root.showEffectsSection
             color: ui.theme.backgroundPrimaryColor
             property int padding: parent.height / 4
             border.color: "transparent"

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
@@ -57,8 +57,24 @@ void RealtimeEffectListModel::doLoad()
         insertEffect(trackId, index, newItem);
     });
 
-    globalContext()->currentTrackeditProjectChanged().onNotify(this, [this] { onProjectChanged(); });
+    globalContext()->currentTrackeditProjectChanged().onNotify(this, [this]
+    {
+        onProjectChanged();
+    });
     onProjectChanged();
+
+    configuration()->isEffectsPanelVisible().ch.onReceive(this, [this](bool)
+    {
+        emit showEffectsSectionChanged();
+    });
+
+    dispatcher()->reg(this, "toggle-effects", [this] {
+        configuration()->setIsEffectsPanelVisible(!configuration()->isEffectsPanelVisible().val);
+    });
+
+    dispatcher()->reg(this, "add-realtime-effects", [this] {
+        configuration()->setIsEffectsPanelVisible(true);
+    });
 
     populateMenu();
 }
@@ -255,4 +271,14 @@ void RealtimeEffectListModel::prop_setTrackEffectsActive(bool active)
         return;
     }
     realtimeEffectService()->setTrackEffectsActive(*tId, active);
+}
+
+bool RealtimeEffectListModel::prop_showEffectsSection() const
+{
+    return configuration()->isEffectsPanelVisible().val;
+}
+
+void RealtimeEffectListModel::prop_setShowEffectsSection(bool show)
+{
+    configuration()->setIsEffectsPanelVisible(show);
 }

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.h
@@ -3,22 +3,28 @@
  */
 #pragma once
 
+#include "iprojectsceneconfiguration.h"
 #include "realtimeeffectmenumodelbase.h"
 #include "realtimeeffectlistitemmodel.h"
 #include "context/iglobalcontext.h"
+#include "actions/iactionsdispatcher.h"
+#include "actions/actionable.h"
 #include <QObject>
 #include <map>
 
 namespace au::projectscene {
-class RealtimeEffectListModel : public RealtimeEffectMenuModelBase
+class RealtimeEffectListModel : public RealtimeEffectMenuModelBase, public muse::actions::Actionable
 {
     Q_OBJECT
 
     Q_PROPERTY(QVariantList availableEffects READ availableEffects NOTIFY availableEffectsChanged)
     Q_PROPERTY(QString trackName READ prop_trackName NOTIFY trackNameChanged)
     Q_PROPERTY(bool trackEffectsActive READ prop_trackEffectsActive WRITE prop_setTrackEffectsActive NOTIFY trackEffectsActiveChanged)
+    Q_PROPERTY(bool showEffectsSection READ prop_showEffectsSection WRITE prop_setShowEffectsSection NOTIFY showEffectsSectionChanged)
 
     muse::Inject<context::IGlobalContext> globalContext;
+    muse::Inject<IProjectSceneConfiguration> configuration;
+    muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
 
 public:
     explicit RealtimeEffectListModel(QObject* parent = nullptr);
@@ -30,10 +36,14 @@ public:
     bool prop_trackEffectsActive() const;
     void prop_setTrackEffectsActive(bool active);
 
+    bool prop_showEffectsSection() const;
+    void prop_setShowEffectsSection(bool show);
+
 signals:
     void availableEffectsChanged();
     void trackNameChanged();
     void trackEffectsActiveChanged();
+    void showEffectsSectionChanged();
 
 private:
     QHash<int, QByteArray> roleNames() const override;


### PR DESCRIPTION
Resolves: #7960 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Effect panel can be opened from "Effect > Add realtime effects" (as well as its shortcut
- [x] Effect panel is togglable via "View / Show effects"
- [x] Effect panel can still be opened and closed the way it could before.
- [x] "View / Show effects" is checked when the panel is visible, unchecked when it isn't
- [x] The panel is always hidden when I open a project.