### PR TITLE
Add the link to the manual on the cloud preferences page

### DIFF
--- a/modules/sharing/mod-cloud-audiocom/ui/AudioComPrefsPanel.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/AudioComPrefsPanel.cpp
@@ -185,6 +185,11 @@ public:
       return XO("Preferences for Cloud");
    }
 
+   ManualPageID HelpPageName() override
+   {
+      return "Cloud_Preferences";
+   }
+
    void Browse()
    {
       const auto currentPath = CloudProjectsSavePath.Read();


### PR DESCRIPTION
Fixes the missing help button on the cloud preferences page: https://manual.audacityteam.org/man/cloud_preferences.html

![image](https://github.com/user-attachments/assets/0b5b9aee-e7ec-457b-88b7-a89a54f55c24)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
