### PR TITLE
Horizontal autoscrolling fix

### DIFF
--- a/libraries/lib-basic-ui/BasicUI.cpp
+++ b/libraries/lib-basic-ui/BasicUI.cpp
@@ -243,6 +243,27 @@ void Yield()
    while ( !sActions.empty() );
 }
 
+void ProcessIdle()
+{
+   do {
+      // Dispatch anything in the queue, added while there were no Services
+      {
+         auto guard = std::lock_guard{ sActionsMutex };
+         std::vector<Action> actions;
+         actions.swap(sActions);
+         for (auto &action : actions)
+            action();
+      }
+
+      // Dispatch according to Services, if present
+      if (auto p = Get())
+         p->DoProcessIdle();
+   }
+   // Re-test for more actions that might have been enqueued by actions just
+   // dispatched
+   while ( !sActions.empty() );
+}
+
 bool OpenInDefaultBrowser(const wxString &url)
 {
 #if defined(HAS_XDG_OPEN_HELPER)

--- a/libraries/lib-basic-ui/BasicUI.h
+++ b/libraries/lib-basic-ui/BasicUI.h
@@ -201,6 +201,7 @@ public:
    virtual ~Services();
    virtual void DoCallAfter(const Action &action) = 0;
    virtual void DoYield() = 0;
+   virtual void DoProcessIdle() = 0;
    virtual void DoShowErrorDialog(const WindowPlacement &placement,
       const TranslatableString &dlogTitle,
       const TranslatableString &message,
@@ -262,6 +263,9 @@ BASIC_UI_API void CallAfter(Action action);
  dispatching.
  */
 BASIC_UI_API void Yield();
+
+//! Dispatch waiting events only (no pending mouse, keyboard, or timer events)
+BASIC_UI_API void ProcessIdle();
 
 //! Open an URL in default browser
 /*! This function may be called in other threads than the main.

--- a/libraries/lib-viewport/Viewport.cpp
+++ b/libraries/lib-viewport/Viewport.cpp
@@ -414,7 +414,7 @@ void Viewport::OnScroll()
    // This keeps the time ruler in sync with horizontal scrolling, without
    // making an undesirable compilation dependency of this source file on
    // the ruler
-   BasicUI::Yield();
+   BasicUI::ProcessIdle();
 #endif
 }
 

--- a/libraries/lib-wx-init/wxWidgetsBasicUI.cpp
+++ b/libraries/lib-wx-init/wxWidgetsBasicUI.cpp
@@ -36,6 +36,11 @@ void wxWidgetsBasicUI::DoYield()
    wxTheApp->Yield();
 }
 
+void wxWidgetsBasicUI::DoProcessIdle()
+{
+   wxTheApp->ProcessIdle();
+}
+
 void wxWidgetsBasicUI::DoShowErrorDialog(
    const BasicUI::WindowPlacement &placement,
    const TranslatableString &dlogTitle,

--- a/libraries/lib-wx-init/wxWidgetsBasicUI.h
+++ b/libraries/lib-wx-init/wxWidgetsBasicUI.h
@@ -24,6 +24,7 @@ public:
 protected:
    void DoCallAfter(const BasicUI::Action &action) override;
    void DoYield() override;
+   void DoProcessIdle() override;
    void DoShowErrorDialog(const BasicUI::WindowPlacement &placement,
       const TranslatableString &dlogTitle,
       const TranslatableString &message,


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/6342

When scrolling we need to make use of ProcessIdle() instead of Yield(): 
- Yield() processes all pending events and can lead to skipping events (skipping "mouse button released" event in that particular case) 
- ProcessIdle() process only idle events (so it doesn’t process mouse/keyboard/timer events)