### PR TITLE
Update appimagetool

### DIFF
--- a/au3/linux/create_appimage.sh
+++ b/au3/linux/create_appimage.sh
@@ -59,7 +59,7 @@ function create_path()
 if create_path "appimagetool"; then
 (
     cd "appimagetool"
-    download_appimage_release AppImage/AppImageKit appimagetool continuous
+    download_appimage_release AppImage/appimagetool appimagetool continuous
 )
 fi
 export PATH="${PWD%/}/appimagetool:${PATH}"

--- a/buildscripts/ci/linux/make_appimage.sh
+++ b/buildscripts/ci/linux/make_appimage.sh
@@ -68,7 +68,7 @@ function download_appimage_release()
 if [[ ! -d $BUILD_TOOLS/appimagetool ]]; then
   mkdir $BUILD_TOOLS/appimagetool
   cd $BUILD_TOOLS/appimagetool
-  download_appimage_release AppImage/AppImageKit appimagetool continuous # use AppImage/appimagetool for the static runtime AppImage
+  download_appimage_release AppImage/appimagetool appimagetool continuous # use AppImage/appimagetool for the static runtime AppImage
   cd $ORIGIN_DIR
 fi
 export PATH="$BUILD_TOOLS/appimagetool:$PATH"


### PR DESCRIPTION
an update to the appimagetool version that will revert to building only one appimage for all systems (probably except musl-based, since ld-linux.so is still required)