### PR TITLE
fix 4231: do not set sample rate for AudioUnit global scope

### DIFF
--- a/libraries/lib-audio-unit/AudioUnitWrapper.cpp
+++ b/libraries/lib-audio-unit/AudioUnitWrapper.cpp
@@ -453,13 +453,11 @@ bool AudioUnitWrapper::SetRateAndChannels(
       sizeof(float) * 8,
    };
 
-   unsigned one = 1u;
    const struct Info{
       unsigned &nChannels;
       AudioUnitScope scope;
       const char *const msg; // used only in log messages
    } infos[]{
-      { one, kAudioUnitScope_Global, "global" },
       { mAudioIns, kAudioUnitScope_Input, "input" },
       { mAudioOuts, kAudioUnitScope_Output, "output" },
    };
@@ -471,21 +469,20 @@ bool AudioUnitWrapper::SetRateAndChannels(
                identifier.wx_str(), msg);
             return false;
          }
-         if (scope != kAudioUnitScope_Global) {
-            bool failed = true;
-            ++nChannels;
-            do {
-               --nChannels;
-               streamFormat.mChannelsPerFrame = nChannels;
-               failed = SetProperty(kAudioUnitProperty_StreamFormat,
-                  streamFormat, scope);
-            } while(failed && nChannels > 0);
-            if (failed) {
-               wxLogError("%ls didn't accept stream format on %s\n",
-                  // Exposing internal name only in logging
-                  identifier.wx_str(), msg);
-               return false;
-            }
+
+         bool failed = true;
+         ++nChannels;
+         do {
+            --nChannels;
+            streamFormat.mChannelsPerFrame = nChannels;
+            failed = SetProperty(kAudioUnitProperty_StreamFormat,
+               streamFormat, scope);
+         } while(failed && nChannels > 0);
+         if (failed) {
+            wxLogError("%ls didn't accept stream format on %s\n",
+               // Exposing internal name only in logging
+               identifier.wx_str(), msg);
+            return false;
          }
       }
    }


### PR DESCRIPTION
Resolves: #4231

According to the [spec](https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/AudioUnitProgrammingGuide/TheAudioUnit/TheAudioUnit.html#//apple_ref/doc/uid/TP40003278-CH12-SW21) sample rate should only be set on "Input" and "Output" scopes.
Some effects like AUSoundIsolation may fail when setting the sample rate on "Global" scope.


To QA: Please check that there are no side-effects for other AudioUnit effects.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
