### PR TITLE
Fix duplicate access keys in Help menu.

### DIFF
--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -426,7 +426,7 @@ auto HelpMenu()
             AlwaysEnabledFlag ),
          Command( wxT("Manual"), XXO("&Manual"), OnManual,
             AlwaysEnabledFlag ),
-         Command( wxT("AudacitySupport"), XXO("&Audacity Support"), OnAudacitySupport,
+         Command( wxT("AudacitySupport"), XXO("Audacity &Support"), OnAudacitySupport,
             AlwaysEnabledFlag )
       ),
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8099

Commit:bcab46f introduced a duplicate use of the access key A.

Fix: Change the access key for the new menu item.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
