### PR TITLE
What's new window: fix controls not being in tab order.

### DIFF
--- a/src/WhatsNewDialog.cpp
+++ b/src/WhatsNewDialog.cpp
@@ -214,11 +214,11 @@ const wxSize infoWindowSize(746, 176);
 #else
 const wxSize infoWindowSize(1050, 250);
 #endif
-class InfoWindow : public wxWindow
+class InfoWindow : public wxPanel
 {
 public:
     InfoWindow(wxWindow* parent)
-        : wxWindow(parent, wxID_ANY, wxDefaultPosition, infoWindowSize)
+        : wxPanel(parent, wxID_ANY, wxDefaultPosition, infoWindowSize)
     {
        ShuttleGui S( this, eIsCreating);
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8103

Problem: The "text" control and the button related to cloud storage are not in the tab order.

Fix: Change InfoWindow to inherit from wxPanel rather than wxWindow, so that the focus of its children is automatically taken care of.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
