### PR TITLE
Fix 8155: crash on opening mixer window during recording

### DIFF
--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -83,7 +83,7 @@ double WaveClipChannel::Start() const
 
 double WaveClipChannel::End() const
 {
-   return GetClip().GetPlayEndTime();
+   return GetClip().GetCommittedEndTime();
 }
 
 AudioSegmentSampleView
@@ -1787,6 +1787,17 @@ double WaveClip::GetPlayEndTime() const
     // it is a maximum value and can be negative; no clipping to 0
     return SnapToTrackSample(maxLen);
 }
+
+double WaveClip::GetCommittedEndTime() const
+{
+    const auto numSamples = GetNumSamples();
+    double maxLen = mSequenceOffset - mTrimRight +
+                    numSamples.as_double() * GetStretchRatio() / mRate;
+    // JS: calculated value is not the length;
+    // it is a maximum value and can be negative; no clipping to 0
+    return SnapToTrackSample(maxLen);
+}
+
 
 double WaveClip::GetPlayDuration() const
 {

--- a/libraries/lib-wave-track/WaveClip.h
+++ b/libraries/lib-wave-track/WaveClip.h
@@ -395,6 +395,11 @@ public:
    //! period, whether the clip is stretched or not.
    double GetPlayEndTime() const override;
 
+   //! Open-end of play region that is commited to the Sequence blocks
+   //! Always a multiple of the track's sample
+   //! period, whether the clip is stretched or not.
+   double GetCommittedEndTime() const;
+
    //! Always a multiple of the track's sample period, whether the clip is
    //! stretched or not.
    double GetPlayDuration() const;
@@ -835,7 +840,7 @@ public:
     @pre `GetSampleFormats() == other.GetSampleFormats()`
     @pre `GetSampleBlockFactory() == other.GetSampleBlockFactory()`
     @pre `!mustAlign || GetNumSamples() == other.GetNumSamples()`
-    
+
     @post `!mustAlign || StrongInvariant()`
     */
    void MakeStereo(WaveClip &&other, bool mustAlign);


### PR DESCRIPTION
Resolves: #8155

Do not process data that is not yet committed to sample blocks during recording.

While we can also append data from the AppendBuffer, it may have some undesirable implications because it may be flushed in another thread and we do not want to lock the recording thread.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
