### PR TITLE
Fix crash on opening mixer with accessibility voiceover enabled

### DIFF
--- a/src/widgets/MeterPanel.cpp
+++ b/src/widgets/MeterPanel.cpp
@@ -618,7 +618,7 @@ void MeterPanel::OnPaint(wxPaintEvent & WXUNUSED(event))
    }
 
    destDC.SetTextForeground( clrText );
-   
+
    // We can have numbers over the bars, in which case we have to draw them each time.
    if(mStyle == HorizontalStereoCompact || mStyle == VerticalStereoCompact)
    {
@@ -1544,7 +1544,7 @@ void MeterPanel::DrawMeterBar(wxDC &dc, MeterBar *bar)
 
    // Setup for erasing the background
    dc.SetPen(*wxTRANSPARENT_PEN);
-   mMeterBkgndBrush.SetColour( theTheme.Colour(clrMeterBackground) ); 
+   mMeterBkgndBrush.SetColour( theTheme.Colour(clrMeterBackground) );
    dc.SetBrush(mMeterBkgndBrush);
 
    if (mGradient)
@@ -2196,6 +2196,11 @@ wxAccStatus MeterAx::GetState(int WXUNUSED(childId), long* state)
 wxAccStatus MeterAx::GetValue(int WXUNUSED(childId), wxString* strValue)
 {
    MeterPanel *m = wxDynamicCast(GetWindow(), MeterPanel);
+
+   if (!m || !m->mSlider)
+   {
+      return wxACC_NOT_IMPLEMENTED;
+   }
 
    *strValue = m->mSlider->GetStringValue();
    return wxACC_OK;


### PR DESCRIPTION
The mixer's meter does not have a slider, do not try to access it.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
