### PR TITLE
History dialog: fix accessibility names of text boxes

### DIFF
--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -187,7 +187,8 @@ void HistoryDialog::Populate(ShuttleGui & S)
          S.StartMultiColumn(3, wxCENTRE);
          {
             S.AddPrompt(XXO("&Total space used"));
-            mTotal = S.Id(ID_TOTAL).Style(wxTE_READONLY).AddTextBox({}, wxT(""), 10);
+            mTotal = S.Id(ID_TOTAL).Style(wxTE_READONLY)
+               .Name(XXO("&Total space used")).AddTextBox({}, wxT(""), 10);
             S.AddVariableText( {} )->Hide();
 
 #if defined(ALLOW_DISCARD)
@@ -210,7 +211,8 @@ void HistoryDialog::Populate(ShuttleGui & S)
             mDiscard = S.Id(ID_DISCARD).AddButton(XXO("&Discard"));
 #endif
             S.AddPrompt(XXO("Clip&board space used"));
-            mClipboard = S.Style(wxTE_READONLY).AddTextBox({}, wxT(""), 10);
+            mClipboard = S.Style(wxTE_READONLY)
+               .Name(XXO("Clip&board space used")).AddTextBox({}, wxT(""), 10);
 
 #if defined(ALLOW_DISCARD)
             S.Id(ID_DISCARD_CLIPBOARD).AddButton(XXO("D&iscard"));


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8196

Problem:
The accessibility names of the two read-only text boxes are empty.

Fix:
Set the accessibility names.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
