### PR TITLE
Update wxwidgets dependency

### DIFF
--- a/buildscripts/cmake/SetupDependencies.cmake
+++ b/buildscripts/cmake/SetupDependencies.cmake
@@ -62,7 +62,7 @@ function(populate name remote_suffix)
 
 endfunction()
 
-populate(wxwidgets "wxwidgets/3.1.3.4")
+populate(wxwidgets "wxwidgets/3.1.3.6")
 populate(expat "expat/2.0.5")
 populate(portaudio "portaudio/19.7.0")
 


### PR DESCRIPTION
Fixes linking issues on macos 

The previous version had an absolute path to libexpat.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
