### PR TITLE
Ensures that untrimming in group doesn't cause any clip to extend beyond the track start

### DIFF
--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -428,6 +428,15 @@ secs_t Au3Interaction::clampLeftTrimDelta(const ClipKeyList& clipKeys,
             || (muse::RealIsEqualOrLess(deltaSec, 0.0) && anyLeftFullyUntrimmed(clipKeys))) {
             return 0.0;
         }
+
+        //! NOTE: check that no clip in selection extends beyond its track start
+        std::optional<secs_t> leftmostClipStartTime = getLeftmostClipStartTime(selectionController()->selectedClips());
+
+        if (leftmostClipStartTime.has_value()) {
+            if (muse::RealIsEqualOrLess(leftmostClipStartTime.value() + deltaSec, 0.0)) {
+                return 0.0;
+            }
+        }
     }
 
     return deltaSec;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8090

I added a check in 'Au3Interaction::clampLeftTrimDelta' to ensure that no clip in selection extends beyond its track start.

I don't see any place where this class is unit-tested, so that I can add a specific check for the case I addressed.
Let me know if I missing something, but I am assuming there are no tests for this class.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
