### PR TITLE
Fix Windows build; include missing <chrono> header

### DIFF
--- a/au3/libraries/lib-project-file-io/DBConnection.h
+++ b/au3/libraries/lib-project-file-io/DBConnection.h
@@ -19,6 +19,7 @@ Paul Licameli -- split from ProjectFileIO.h
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <chrono>
 
 #include "ClientData.h"
 #include "Identifier.h"


### PR DESCRIPTION
Resolves: Windows build issue

Add missing "#include <chrono>".  Windows build fails without this.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
