### PR TITLE
Fix issue CVE-2018-17096: Replace assert with runtime exception

### DIFF
--- a/au3/lib-src/soundtouch/source/SoundTouch/BPMDetect.cpp
+++ b/au3/lib-src/soundtouch/source/SoundTouch/BPMDetect.cpp
@@ -130,8 +130,11 @@ BPMDetect::BPMDetect(int numChannels, int aSampleRate)
 
     // choose decimation factor so that result is approx. 1000 Hz
     decimateBy = sampleRate / 1000;
-    assert(decimateBy > 0);
-    assert(INPUT_BLOCK_SAMPLES < decimateBy * DECIMATED_BLOCK_SAMPLES);
+    if ((decimateBy <= 0) || (decimateBy * DECIMATED_BLOCK_SIZE < INPUT_BLOCK_SIZE))
+    {
+        ST_THROW_RT_ERROR("Too small samplerate");
+    }
+
 
     // Calculate window length & starting item according to desired min & max bpms
     windowLen = (60 * sampleRate) / (decimateBy * MIN_BPM);


### PR DESCRIPTION
Resolves: Possible vulnerability in SoundTouch library

The function BPMDetect() in this repository is nearly identical to BPMDetect() from SoundTouch.
The original function was patched due to a vulnerability identified in https://gitlab.com/soundtouch/soundtouch/-/commit/a1c400eb2cff849c0e5f9d6916d69ffea3ad2c85.
The same issue exists in this repository's function but remains unpatched.
This PR applies the same patch as the one in SoundTouch to eliminate the vulnerability.

References
CVE: [CVE-2018-17096](https://nvd.nist.gov/vuln/detail/CVE-2018-17096)
Original Fix: [Original Fix](https://gitlab.com/soundtouch/soundtouch/-/commit/a1c400eb2cff849c0e5f9d6916d69ffea3ad2c85)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
