### PR TITLE
7832 effect panel discrepancies

### DIFF
--- a/src/au3wrap/vst3/CMakeLists.txt
+++ b/src/au3wrap/vst3/CMakeLists.txt
@@ -49,6 +49,8 @@ if (OS_IS_WIN)
         ${VST3_SDK_PATH}/public.sdk/source/common/threadchecker_win32.cpp
         ${VST3_SDK_PATH}/public.sdk/source/common/systemclipboard_win32.cpp
         ${VST3_SDK_PATH}/public.sdk/source/common/systemclipboard.h
+        ${VST3_SDK_PATH}/public.sdk/source/common/commonstringconvert.cpp
+        ${VST3_SDK_PATH}/public.sdk/source/common/commonstringconvert.h
         )
 elseif(OS_IS_LIN)
     set(PLATFORM_SRC

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -292,6 +292,16 @@ RealtimeEffectStatePtr RealtimeEffectService::replaceRealtimeEffect(TrackId trac
     return nullptr;
 }
 
+RealtimeEffectStatePtr RealtimeEffectService::replaceRealtimeEffect(TrackId trackId, const RealtimeEffectStatePtr& state,
+                                                                    const muse::String& newEffectId)
+{
+    const auto index = utils::effectIndex(globalContext()->currentProject(), state);
+    if (!index.has_value()) {
+        return nullptr;
+    }
+    return replaceRealtimeEffect(trackId, *index, newEffectId);
+}
+
 void RealtimeEffectService::moveRealtimeEffect(const RealtimeEffectStatePtr& state, int newIndex)
 {
     const auto tId = trackId(state);

--- a/src/effects/effects_base/internal/realtimeeffectservice.h
+++ b/src/effects/effects_base/internal/realtimeeffectservice.h
@@ -40,6 +40,7 @@ public:
 
     RealtimeEffectStatePtr addRealtimeEffect(TrackId, const EffectId&) override;
     void removeRealtimeEffect(TrackId, const RealtimeEffectStatePtr&) override;
+    RealtimeEffectStatePtr replaceRealtimeEffect(TrackId, const RealtimeEffectStatePtr&, const EffectId& newEffectId) override;
     RealtimeEffectStatePtr replaceRealtimeEffect(TrackId, int effectListIndex, const EffectId& newEffectId) override;
     void moveRealtimeEffect(const RealtimeEffectStatePtr& state, int newIndex) override;
 

--- a/src/effects/effects_base/irealtimeeffectservice.h
+++ b/src/effects/effects_base/irealtimeeffectservice.h
@@ -29,6 +29,8 @@ public:
     virtual RealtimeEffectStatePtr addRealtimeEffect(TrackId trackId, const EffectId& effectId) = 0;
     virtual void removeRealtimeEffect(TrackId trackId, const RealtimeEffectStatePtr& state) = 0;
     virtual RealtimeEffectStatePtr replaceRealtimeEffect(TrackId trackId, int effectListIndex, const EffectId& newEffectId) = 0;
+    virtual RealtimeEffectStatePtr replaceRealtimeEffect(TrackId trackId, const RealtimeEffectStatePtr& state,
+                                                         const EffectId& newEffectId) = 0;
     virtual void moveRealtimeEffect(const RealtimeEffectStatePtr& state, int newIndex) = 0;
 
     virtual muse::async::Channel<TrackId, RealtimeEffectStatePtr> realtimeEffectAdded() const = 0;

--- a/src/projectscene/CMakeLists.txt
+++ b/src/projectscene/CMakeLists.txt
@@ -39,6 +39,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/common/customcursor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/common/customcursor.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/addeffectmenumodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/addeffectmenumodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/trackitem.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/trackitem.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/trackcontextmenumodel.cpp
@@ -47,8 +49,6 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistitemmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistitemmodel.h
-    ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectmenumodel.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectmenumodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectmenumodelbase.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectmenumodelbase.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectsectionmodel.cpp

--- a/src/projectscene/CMakeLists.txt
+++ b/src/projectscene/CMakeLists.txt
@@ -45,6 +45,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/trackitem.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/trackcontextmenumodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/trackcontextmenumodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistitemmenumodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/realtimeeffectlistitemmodel.cpp

--- a/src/projectscene/projectscene.qrc
+++ b/src/projectscene/projectscene.qrc
@@ -8,6 +8,7 @@
         <file>qml/Audacity/ProjectScene/clipsview/ClipsSelection.qml</file>
         <file>qml/Audacity/ProjectScene/trackspanel/AddNewTrackPopup.qml</file>
         <file>qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml</file>
+        <file>qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItemButtonBackground.qml</file>
         <file>qml/Audacity/ProjectScene/trackspanel/TrackItem.qml</file>
         <file>qml/Audacity/ProjectScene/trackspanel/TrackSelectionBar.qml</file>
         <file>qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml</file>

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -24,7 +24,7 @@
 #include "view/toolbars/projecttoolbarmodel.h"
 #include "view/toolbars/undoredotoolbarmodel.h"
 
-#include "view/trackspanel/realtimeeffectmenumodel.h"
+#include "view/trackspanel/addeffectmenumodel.h"
 #include "view/trackspanel/realtimeeffectlistmodel.h"
 #include "view/trackspanel/realtimeeffectsectionmodel.h"
 #include "view/trackspanel/trackslistmodel.h"
@@ -130,7 +130,7 @@ void ProjectSceneModule::registerUiTypes()
                                                              "Cannot create");
 
     // tracks panel
-    qmlRegisterType<RealtimeEffectMenuModel>("Audacity.ProjectScene", 1, 0, "RealtimeEffectMenuModel");
+    qmlRegisterType<AddEffectMenuModel>("Audacity.ProjectScene", 1, 0, "AddEffectMenuModel");
     qmlRegisterType<RealtimeEffectListModel>("Audacity.ProjectScene", 1, 0, "RealtimeEffectListModel");
     qmlRegisterType<RealtimeEffectSectionModel>("Audacity.ProjectScene", 1, 0, "RealtimeEffectSectionModel");
     qmlRegisterType<TracksListModel>("Audacity.ProjectScene", 1, 0, "TracksListModel");

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -26,6 +26,7 @@
 
 #include "view/trackspanel/addeffectmenumodel.h"
 #include "view/trackspanel/realtimeeffectlistmodel.h"
+#include "view/trackspanel/realtimeeffectlistitemmenumodel.h"
 #include "view/trackspanel/realtimeeffectsectionmodel.h"
 #include "view/trackspanel/trackslistmodel.h"
 #include "view/trackspanel/trackcontextmenumodel.h"
@@ -132,6 +133,7 @@ void ProjectSceneModule::registerUiTypes()
     // tracks panel
     qmlRegisterType<AddEffectMenuModel>("Audacity.ProjectScene", 1, 0, "AddEffectMenuModel");
     qmlRegisterType<RealtimeEffectListModel>("Audacity.ProjectScene", 1, 0, "RealtimeEffectListModel");
+    qmlRegisterType<RealtimeEffectListItemMenuModel>("Audacity.ProjectScene", 1, 0, "RealtimeEffectListItemMenuModel");
     qmlRegisterType<RealtimeEffectSectionModel>("Audacity.ProjectScene", 1, 0, "RealtimeEffectSectionModel");
     qmlRegisterType<TracksListModel>("Audacity.ProjectScene", 1, 0, "TracksListModel");
     qmlRegisterType<TrackContextMenuModel>("Audacity.ProjectScene", 1, 0, "TrackContextMenuModel");

--- a/src/projectscene/qml/Audacity/ProjectScene/qmldir
+++ b/src/projectscene/qml/Audacity/ProjectScene/qmldir
@@ -3,6 +3,7 @@ ProjectToolBar 1.0 toolbars/ProjectToolBar.qml
 UndoRedoToolBar 1.0 toolbars/UndoRedoToolBar.qml
 PlaybackToolBar 1.0 toolbars/PlaybackToolBar.qml
 RealtimeEffectListItem 1.0 trackspanel/RealtimeEffectListItem.qml
+RealtimeEffectListItemButtonBackground 1.0 trackspanel/RealtimeEffectListItemButtonBackground.qml
 TracksPanel 1.0 trackspanel/TracksPanel.qml
 TrackEffectList 1.0 trackspanel/TrackEffectList.qml
 TrackEffectsSection 1.0 trackspanel/TrackEffectsSection.qml

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -155,6 +155,7 @@ ListItemBlank {
         Rectangle {
             id: effectNameRect
 
+            color: "transparent"
             border.color: ui.theme.strokeColor
             border.width: 1
             radius: effectNameButton.backgroundRadius
@@ -166,7 +167,6 @@ ListItemBlank {
                 id: effectNameButton
 
                 anchors.fill: parent
-                normalColor: ui.theme.backgroundPrimaryColor
 
                 StyledTextLabel {
                     anchors.fill: parent
@@ -188,6 +188,7 @@ ListItemBlank {
         Rectangle {
             id: chooseEffectRect
 
+            color: "transparent"
             border.color: ui.theme.strokeColor
             border.width: 1
             radius: effectNameButton.backgroundRadius
@@ -198,7 +199,6 @@ ListItemBlank {
                 id: chooseEffectDropdown
 
                 anchors.fill: parent
-                normalColor: ui.theme.backgroundPrimaryColor
                 icon: IconCode.SMALL_ARROW_DOWN
 
                 RealtimeEffectListItemMenuModel {

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -72,8 +72,9 @@ ListItemBlank {
 
             visible: true
             transparent: true
-            hoverHitColor: ui.theme.buttonColor
-            mouseArea.cursorShape: Qt.SizeAllCursor
+            hoverHitColor: normalColor
+            accentColor: normalColor
+            mouseArea.cursorShape: Qt.SizeVerCursor
 
             mouseArea.drag.target: content
             mouseArea.drag.axis: Drag.YAxis

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -6,6 +6,7 @@ import Muse.Ui
 import Muse.UiComponents
 
 import Audacity.Effects
+import Audacity.ProjectScene
 
 ListItemBlank {
     id: root
@@ -28,6 +29,10 @@ ListItemBlank {
     clip: false // should be true?
     background.color: "transparent"
     hoverHitColor: "transparent"
+
+    Component.onCompleted: {
+        menuModel.load()
+    }
 
     Behavior on y {
         NumberAnimation {
@@ -197,15 +202,20 @@ ListItemBlank {
                 normalColor: ui.theme.backgroundPrimaryColor
                 icon: IconCode.SMALL_ARROW_DOWN
 
+                RealtimeEffectListItemMenuModel {
+                    id: menuModel
+                    effectState: root.item ? root.item.effectState() : null
+                }
+
                 onClicked: {
-                    effectMenuLoader.toggleOpened(root.availableEffects)
+                    effectMenuLoader.toggleOpened(menuModel.availableEffects)
                 }
 
                 StyledMenuLoader {
                     id: effectMenuLoader
 
                     onHandleMenuItem: function(menuItem) {
-                        root.handleMenuItemWithState(menuItem, root.item)
+                        menuModel.handleMenuItem(menuItem)
                     }
                 }
             }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -14,7 +14,6 @@ ListItemBlank {
     property var item: null
     property var listView: null
     property var availableEffects: null
-    property var handleMenuItemWithState: null
     property int index: -1
     property int scrollOffset: 0
     property int topMargin: 0

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -150,73 +150,57 @@ ListItemBlank {
             }
         }
 
-        // Wrappinng a FlatButton in a Rectangle because of two bad reasons:
-        // * I don't find a `border` property for `FlatButton`
-        // * Somehow, the button's color is a bit darkened it direct child of the RowLayout
-        Rectangle {
-            id: effectNameRect
+        FlatButton {
+            id: effectNameButton
 
-            color: "transparent"
-            border.color: ui.theme.strokeColor
-            border.width: 1
-            radius: effectNameButton.backgroundRadius
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.preferredWidth: 148
 
-            FlatButton {
-                id: effectNameButton
+            backgroundItem: RealtimeEffectListItemButtonBackground {
+                mouseArea: effectNameButton.mouseArea
+            }
 
+            StyledTextLabel {
                 anchors.fill: parent
+                anchors.leftMargin: 6
+                anchors.rightMargin: 6
+                id: trackNameLabel
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+                text: root.item ? root.item.effectName() : ""
+            }
 
-                StyledTextLabel {
-                    anchors.fill: parent
-                    anchors.leftMargin: 6
-                    anchors.rightMargin: 6
-                    id: trackNameLabel
-                    horizontalAlignment: Text.AlignLeft
-                    verticalAlignment: Text.AlignVCenter
-                    text: root.item ? root.item.effectName() : ""
-                }
-
-                onClicked: {
-                    root.item.toggleDialog()
-                }
+            onClicked: {
+                root.item.toggleDialog()
             }
         }
 
-        // Wrapping a FlatButton for the same reasons as above.
-        Rectangle {
-            id: chooseEffectRect
+        FlatButton {
+            id: chooseEffectDropdown
 
-            color: "transparent"
-            border.color: ui.theme.strokeColor
-            border.width: 1
-            radius: effectNameButton.backgroundRadius
             Layout.fillHeight: true
             Layout.preferredWidth: height
 
-            FlatButton {
-                id: chooseEffectDropdown
+            icon: IconCode.SMALL_ARROW_DOWN
+            backgroundItem: RealtimeEffectListItemButtonBackground {
+                mouseArea: chooseEffectDropdown.mouseArea
+            }
 
-                anchors.fill: parent
-                icon: IconCode.SMALL_ARROW_DOWN
+            RealtimeEffectListItemMenuModel {
+                id: menuModel
+                effectState: root.item ? root.item.effectState() : null
+            }
 
-                RealtimeEffectListItemMenuModel {
-                    id: menuModel
-                    effectState: root.item ? root.item.effectState() : null
-                }
+            onClicked: {
+                effectMenuLoader.toggleOpened(menuModel.availableEffects)
+            }
 
-                onClicked: {
-                    effectMenuLoader.toggleOpened(menuModel.availableEffects)
-                }
+            StyledMenuLoader {
+                id: effectMenuLoader
 
-                StyledMenuLoader {
-                    id: effectMenuLoader
-
-                    onHandleMenuItem: function(menuItem) {
-                        menuModel.handleMenuItem(menuItem)
-                    }
+                onHandleMenuItem: function(menuItem) {
+                    menuModel.handleMenuItem(menuItem)
                 }
             }
         }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItemButtonBackground.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItemButtonBackground.qml
@@ -1,0 +1,38 @@
+import QtQuick
+
+import Muse.Ui
+
+Rectangle {
+    id: root
+
+    property var mouseArea: null
+
+    color: ui.theme.backgroundPrimaryColor
+    radius: 3
+    border.width: 1
+    border.color: ui.theme.strokeColor
+
+    states: [
+        State {
+            name: "HOVERED"
+            when: mouseArea.containsMouse && !mouseArea.pressed
+
+            PropertyChanges {
+                target: root
+                color: ui.theme.buttonColor
+                opacity: 0.4
+            }
+        },
+
+        State {
+            name: "PRESSED"
+            when: mouseArea.pressed
+
+            PropertyChanges {
+                target: root
+                color: ui.theme.buttonColor
+                opacity: 0.7
+            }
+        }
+    ]
+}

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
@@ -57,7 +57,6 @@ Rectangle {
             index: model.index
             listView: trackEffectList
             availableEffects: trackEffectList.model.availableEffects
-            handleMenuItemWithState: trackEffectList.model.handleMenuItemWithState
             width: trackEffectList.width - scrollbarContainer.width
         }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
@@ -39,9 +39,9 @@ Rectangle {
         anchors.fill: parent
         spacing: 6
         cacheBuffer: 3000
-        interactive: true
+        interactive: trackEffectList.contentHeight > trackEffectList.height
         model: trackEffectListModel
-        boundsBehavior: Flickable.DragAndOvershootBounds
+        boundsBehavior: Flickable.StopAtBounds
         boundsMovement: Flickable.FollowBoundsBehavior
         flickDeceleration: 10000
         footer: listMargin

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
@@ -104,7 +104,7 @@ Rectangle {
 
             text: qsTrc("projectscene", "Add effect")
 
-            RealtimeEffectMenuModel {
+            AddEffectMenuModel {
                 id: menuModel
                 isMasterTrack: effectList.isMasterTrack
             }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
@@ -48,7 +48,7 @@ KDDW.TitleBarBase {
             Layout.preferredHeight: root.implicitHeight
 
             StyledTextLabel {
-                text: qsTr("Effects")
+                text: qsTrc("projectscene", "Realtime effects")
                 anchors.fill: parent
                 padding: effectsTitleBar.padding
                 horizontalAlignment: Text.AlignLeft

--- a/src/projectscene/view/trackspanel/addeffectmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/addeffectmenumodel.cpp
@@ -1,22 +1,22 @@
 /*
  * Audacity: A Digital Audio Editor
  */
-#include "realtimeeffectmenumodel.h"
+#include "addeffectmenumodel.h"
 #include "log.h"
 
 using namespace muse;
 using namespace au::projectscene;
 using namespace muse::uicomponents;
 
-RealtimeEffectMenuModel::RealtimeEffectMenuModel(QObject* parent)
+AddEffectMenuModel::AddEffectMenuModel(QObject* parent)
     : RealtimeEffectMenuModelBase(parent) {}
 
-void RealtimeEffectMenuModel::doLoad()
+void AddEffectMenuModel::doLoad()
 {
     doPopulateMenu();
 }
 
-void RealtimeEffectMenuModel::doPopulateMenu()
+void AddEffectMenuModel::doPopulateMenu()
 {
     MenuItemList items;
 
@@ -40,7 +40,7 @@ void RealtimeEffectMenuModel::doPopulateMenu()
     setItems(items);
 }
 
-void RealtimeEffectMenuModel::handleMenuItem(const QString& itemId)
+void AddEffectMenuModel::handleMenuItem(const QString& itemId)
 {
     const MenuItem& menuItem = findItem(itemId);
     const auto tId = trackId();

--- a/src/projectscene/view/trackspanel/addeffectmenumodel.h
+++ b/src/projectscene/view/trackspanel/addeffectmenumodel.h
@@ -7,12 +7,12 @@
 #include "realtimeeffectmenumodelbase.h"
 
 namespace au::projectscene {
-class RealtimeEffectMenuModel : public RealtimeEffectMenuModelBase
+class AddEffectMenuModel : public RealtimeEffectMenuModelBase
 {
     Q_OBJECT
 
 public:
-    explicit RealtimeEffectMenuModel(QObject* parent = nullptr);
+    explicit AddEffectMenuModel(QObject* parent = nullptr);
 
 private:
     void handleMenuItem(const QString& itemId) override;

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
@@ -1,0 +1,92 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "realtimeeffectlistitemmenumodel.h"
+#include "global/defer.h"
+#include "log.h"
+
+using namespace muse;
+using namespace au::projectscene;
+using namespace muse::uicomponents;
+using namespace au::effects;
+
+RealtimeEffectListItemMenuModel::RealtimeEffectListItemMenuModel(QObject* parent)
+    : RealtimeEffectMenuModelBase(parent)
+{
+}
+
+bool RealtimeEffectListItemMenuModel::belongsWithMe(effects::TrackId trackId) const
+{
+    return isMasterTrack() == (trackId == IRealtimeEffectService::masterTrackId);
+}
+
+void RealtimeEffectListItemMenuModel::doLoad()
+{
+    doPopulateMenu();
+}
+
+void RealtimeEffectListItemMenuModel::doPopulateMenu()
+{
+    MenuItemList items;
+
+    const auto categoryList = effectsProvider()->effectsCategoryList();
+    std::unordered_map<String, MenuItemList> menuCategories;
+
+    items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "No effect")) << makeSeparator();
+
+    // Populate with available realtime effect.
+    for (const effects::EffectMeta& meta : effectsProvider()->effectMetaList()) {
+        if (!meta.isRealtimeCapable) {
+            continue;
+        }
+        MenuItem* item = makeMenuItem("realtimeeffect-replace", muse::TranslatableString::untranslatable(meta.title));
+        item->setArgs(actions::ActionData::make_arg1(effects::EffectId { meta.id }));
+        menuCategories[meta.categoryId].push_back(item);
+    }
+
+    for (const auto& entry : menuCategories) {
+        items << makeMenu(muse::TranslatableString::untranslatable(entry.first), entry.second);
+    }
+
+    setItems(items);
+}
+
+void RealtimeEffectListItemMenuModel::handleMenuItem(const QString& itemId)
+{
+    const MenuItem& menuItem = findItem(itemId);
+    const auto tId = trackId();
+    IF_ASSERT_FAILED(tId.has_value() && m_effectState) {
+        return;
+    }
+
+    if (menuItem.id() == "realtimeeffect-replace") {
+        const auto effectId = menuItem.args().arg<effects::EffectId>(0);
+        if (const RealtimeEffectStatePtr newState = realtimeEffectService()->replaceRealtimeEffect(*tId, m_effectState, effectId)) {
+            effectsProvider()->showEffect(newState);
+        }
+    } else if (menuItem.id() == "realtimeeffect-remove") {
+        realtimeEffectService()->removeRealtimeEffect(*tId, m_effectState);
+    } else {
+        assert(false);
+        LOGE() << "Unknown menu item id: " << itemId.toStdString();
+    }
+}
+
+QVariantList RealtimeEffectListItemMenuModel::availableEffects() const
+{
+    return menuItemListToVariantList(items());
+}
+
+au::effects::RealtimeEffectStatePtr RealtimeEffectListItemMenuModel::prop_effectState() const
+{
+    return m_effectState;
+}
+
+void RealtimeEffectListItemMenuModel::prop_setEffectState(effects::RealtimeEffectStatePtr effectState)
+{
+    if (m_effectState == effectState) {
+        return;
+    }
+    m_effectState = effectState;
+    emit effectStateChanged();
+}

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.h
@@ -35,6 +35,7 @@ private:
     void doPopulateMenu() override;
 
     bool belongsWithMe(effects::TrackId) const;
+    void updateEffectCheckmarks();
 
     effects::RealtimeEffectStatePtr m_effectState;
 };

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.h
@@ -1,0 +1,41 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "realtimeeffectmenumodelbase.h"
+#include "effects/effects_base/effectstypes.h"
+#include "context/iglobalcontext.h"
+#include <QObject>
+#include <map>
+
+namespace au::projectscene {
+class RealtimeEffectListItemMenuModel : public RealtimeEffectMenuModelBase
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QVariantList availableEffects READ availableEffects)
+    Q_PROPERTY(effects::RealtimeEffectStatePtr effectState READ prop_effectState WRITE prop_setEffectState NOTIFY effectStateChanged)
+
+public:
+    explicit RealtimeEffectListItemMenuModel(QObject* parent = nullptr);
+
+    QVariantList availableEffects() const;
+
+    effects::RealtimeEffectStatePtr prop_effectState() const;
+    void prop_setEffectState(effects::RealtimeEffectStatePtr);
+
+signals:
+    void effectStateChanged();
+
+private:
+    void handleMenuItem(const QString& itemId) override;
+
+    void doLoad() override;
+    void doPopulateMenu() override;
+
+    bool belongsWithMe(effects::TrackId) const;
+
+    effects::RealtimeEffectStatePtr m_effectState;
+};
+}

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.cpp
@@ -4,12 +4,12 @@
 #include "realtimeeffectlistitemmodel.h"
 
 namespace au::projectscene {
-RealtimeEffectListItemModel::RealtimeEffectListItemModel(QObject* parent, effects::RealtimeEffectStatePtr effectStateId)
-    : QObject{parent}, effectStateId{std::move(effectStateId)}
+RealtimeEffectListItemModel::RealtimeEffectListItemModel(QObject* parent, effects::RealtimeEffectStatePtr effectState)
+    : QObject{parent}, m_effectState{std::move(effectState)}
 {
-    realtimeEffectService()->isActiveChanged().onReceive(this, [this](effects::RealtimeEffectStatePtr stateId)
+    realtimeEffectService()->isActiveChanged().onReceive(this, [this](effects::RealtimeEffectStatePtr state)
     {
-        if (stateId == this->effectStateId) {
+        if (state == this->m_effectState) {
             emit isActiveChanged();
         }
     });
@@ -17,31 +17,36 @@ RealtimeEffectListItemModel::RealtimeEffectListItemModel(QObject* parent, effect
 
 RealtimeEffectListItemModel::~RealtimeEffectListItemModel()
 {
-    effectsProvider()->hideEffect(effectStateId);
+    effectsProvider()->hideEffect(m_effectState);
 }
 
 bool RealtimeEffectListItemModel::prop_isMasterEffect() const
 {
-    return realtimeEffectService()->trackId(effectStateId) == effects::IRealtimeEffectService::masterTrackId;
+    return realtimeEffectService()->trackId(m_effectState) == effects::IRealtimeEffectService::masterTrackId;
 }
 
 QString RealtimeEffectListItemModel::effectName() const
 {
-    return QString::fromStdString(effectsProvider()->effectName(*effectStateId));
+    return QString::fromStdString(effectsProvider()->effectName(*m_effectState));
+}
+
+effects::RealtimeEffectStatePtr RealtimeEffectListItemModel::effectState() const
+{
+    return m_effectState;
 }
 
 void RealtimeEffectListItemModel::toggleDialog()
 {
-    effectsProvider()->toggleShowEffect(effectStateId);
+    effectsProvider()->toggleShowEffect(m_effectState);
 }
 
 bool RealtimeEffectListItemModel::prop_isActive() const
 {
-    return realtimeEffectService()->isActive(effectStateId);
+    return realtimeEffectService()->isActive(m_effectState);
 }
 
 void RealtimeEffectListItemModel::prop_setIsActive(bool isActive)
 {
-    realtimeEffectService()->setIsActive(effectStateId, isActive);
+    realtimeEffectService()->setIsActive(m_effectState, isActive);
 }
 }

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.h
@@ -24,7 +24,7 @@ public:
     RealtimeEffectListItemModel(QObject* parent, effects::RealtimeEffectStatePtr effectState);
     ~RealtimeEffectListItemModel();
 
-    const effects::RealtimeEffectStatePtr effectStateId;
+    Q_INVOKABLE effects::RealtimeEffectStatePtr effectState() const;
     Q_INVOKABLE QString effectName() const;
     Q_INVOKABLE void toggleDialog();
 
@@ -34,6 +34,9 @@ public:
 
 signals:
     void isActiveChanged();
+
+private:
+    const effects::RealtimeEffectStatePtr m_effectState;
 };
 
 using RealtimeEffectListItemModelPtr = std::shared_ptr<RealtimeEffectListItemModel>;

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
@@ -225,7 +225,7 @@ void RealtimeEffectListModel::doPopulateMenu()
     const auto categoryList = effectsProvider()->effectsCategoryList();
     std::unordered_map<String, MenuItemList> menuCategories;
 
-    items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "No effect"));
+    items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "No effect")) << makeSeparator();
 
     // Populate with available realtime effect.
     for (const effects::EffectMeta& meta : effectsProvider()->effectMetaList()) {

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
@@ -135,7 +135,7 @@ void RealtimeEffectListModel::onRemoved(effects::TrackId trackId, const Realtime
 
     const auto& list = it->second;
     const auto it2 = std::find_if(list.begin(), list.end(), [state](const RealtimeEffectListItemModelPtr& item) {
-        return item->effectStateId == state;
+        return item->effectState() == state;
     });
     IF_ASSERT_FAILED(it2 != list.end()) {
         return;
@@ -197,7 +197,7 @@ void RealtimeEffectListModel::handleMenuItemWithState(const QString& itemId, con
     const MenuItem& menuItem = findItem(itemId);
 
     if (itemId == "realtimeeffect-remove") {
-        realtimeEffectService()->removeRealtimeEffect(*tId, item->effectStateId);
+        realtimeEffectService()->removeRealtimeEffect(*tId, item->effectState());
         return;
     }
 
@@ -265,7 +265,7 @@ void RealtimeEffectListModel::onChanged(effects::TrackId trackId)
         for (auto i = 0; i < static_cast<int>(newStack->size()); ++i) {
             const auto& state = newStack->at(i);
             const auto it = std::find_if(oldList.begin(), oldList.end(), [state](const RealtimeEffectListItemModelPtr& item) {
-                return item->effectStateId == state;
+                return item->effectState() == state;
             });
             if (it != oldList.end()) {
                 newList[i] = *it;
@@ -308,7 +308,7 @@ void RealtimeEffectListModel::moveRow(int from, int to)
         return;
     }
 
-    realtimeEffectService()->moveRealtimeEffect(list[from]->effectStateId, to);
+    realtimeEffectService()->moveRealtimeEffect(list[from]->effectState(), to);
 }
 
 void RealtimeEffectListModel::onSelectedTrackIdChanged()

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
@@ -4,15 +4,15 @@
 #include "realtimeeffectlistmodel.h"
 #include "realtimeeffectlistitemmodel.h"
 #include "global/defer.h"
+#include "global/types/translatablestring.h"
 #include "log.h"
 
 using namespace muse;
 using namespace au::projectscene;
-using namespace muse::uicomponents;
 using namespace au::effects;
 
 RealtimeEffectListModel::RealtimeEffectListModel(QObject* parent)
-    : RealtimeEffectMenuModelBase(parent)
+    : QAbstractListModel(parent)
 {
 }
 
@@ -36,13 +36,34 @@ void RealtimeEffectListModel::onProjectChanged()
     });
 }
 
-bool RealtimeEffectListModel::belongsWithMe(effects::TrackId trackId) const
+bool RealtimeEffectListModel::prop_isMasterTrack() const
 {
-    return isMasterTrack() == (trackId == IRealtimeEffectService::masterTrackId);
+    return m_isMasterTrack;
 }
 
-void RealtimeEffectListModel::doLoad()
+void RealtimeEffectListModel::prop_setIsMasterTrack(bool isMasterTrack)
 {
+    if (m_isMasterTrack == isMasterTrack) {
+        return;
+    }
+    m_isMasterTrack = isMasterTrack;
+    emit isMasterTrackChanged();
+}
+
+bool RealtimeEffectListModel::belongsWithMe(effects::TrackId trackId) const
+{
+    return m_isMasterTrack == (trackId == IRealtimeEffectService::masterTrackId);
+}
+
+void RealtimeEffectListModel::load()
+{
+    trackSelection()->selectedTrackIdChanged().onNotify(this, [this]
+    {
+        beginResetModel();
+        endResetModel();
+        onSelectedTrackIdChanged();
+    });
+
     //! Note: we listen to the individual effect-list changes because `onChanged` and its layout change reset the scrollbar position. Unless ...
     //! the RealtimeEffectListItem.qml listens to layoutAboutToBeChanged and layoutChanged signals and saves and restores the `contentY` property.
     //! At the time of writing, we actually do this (see RealtimeEffectListItem.qml), but it may have some unexpected drawback, so for now we call less drastic
@@ -91,8 +112,6 @@ void RealtimeEffectListModel::doLoad()
         onProjectChanged();
     });
     onProjectChanged();
-
-    doPopulateMenu();
 }
 
 void RealtimeEffectListModel::onAdded(effects::TrackId trackId, const effects::RealtimeEffectStatePtr& newState)
@@ -185,67 +204,6 @@ void RealtimeEffectListModel::onMoved(effects::TrackId trackId, effects::EffectC
     emit layoutChanged();
 }
 
-void RealtimeEffectListModel::handleMenuItemWithState(const QString& itemId, const RealtimeEffectListItemModel* item)
-{
-    TRACEFUNC;
-
-    const auto tId = trackId();
-    IF_ASSERT_FAILED(tId.has_value()) {
-        return;
-    }
-
-    const MenuItem& menuItem = findItem(itemId);
-
-    if (itemId == "realtimeeffect-remove") {
-        realtimeEffectService()->removeRealtimeEffect(*tId, item->effectState());
-        return;
-    }
-
-    if (itemId == "realtimeeffect-replace") {
-        const auto& list = m_trackEffectLists.at(*tId);
-        const auto it = std::find_if(list.begin(), list.end(), [item](const RealtimeEffectListItemModelPtr& listItem) {
-            return listItem.get() == item;
-        });
-        IF_ASSERT_FAILED(it != list.end()) {
-            return;
-        }
-        const int itemIndex = it - list.begin();
-        const auto effectId = menuItem.args().arg<effects::EffectId>(0);
-        if (const RealtimeEffectStatePtr newState = realtimeEffectService()->replaceRealtimeEffect(*tId, itemIndex, effectId)) {
-            effectsProvider()->showEffect(newState);
-        }
-        return;
-    }
-}
-
-void RealtimeEffectListModel::doPopulateMenu()
-{
-    MenuItemList items;
-
-    const auto categoryList = effectsProvider()->effectsCategoryList();
-    std::unordered_map<String, MenuItemList> menuCategories;
-
-    items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "No effect")) << makeSeparator();
-
-    // Populate with available realtime effect.
-    for (const effects::EffectMeta& meta : effectsProvider()->effectMetaList()) {
-        if (!meta.isRealtimeCapable) {
-            continue;
-        }
-        MenuItem* item = makeMenuItem("realtimeeffect-replace", muse::TranslatableString::untranslatable(meta.title));
-        item->setArgs(actions::ActionData::make_arg1(effects::EffectId { meta.id }));
-        menuCategories[meta.categoryId].push_back(item);
-    }
-
-    for (const auto& entry : menuCategories) {
-        items << makeMenu(muse::TranslatableString::untranslatable(entry.first), entry.second);
-    }
-
-    setItems(items);
-
-    emit availableEffectsChanged();
-}
-
 void RealtimeEffectListModel::onChanged(effects::TrackId trackId)
 {
     const std::optional<std::vector<RealtimeEffectStatePtr> > newStack = realtimeEffectService()->effectStack(trackId);
@@ -277,11 +235,6 @@ void RealtimeEffectListModel::onChanged(effects::TrackId trackId)
     }
 
     emit layoutChanged();
-}
-
-QVariantList RealtimeEffectListModel::availableEffects()
-{
-    return menuItemListToVariantList(items());
 }
 
 int RealtimeEffectListModel::count() const
@@ -317,11 +270,16 @@ void RealtimeEffectListModel::onSelectedTrackIdChanged()
     emit trackEffectsActiveChanged();
 }
 
+std::optional<au::effects::TrackId> RealtimeEffectListModel::trackId() const
+{
+    return m_isMasterTrack ? IRealtimeEffectService::masterTrackId : trackSelection()->selectedTrackId();
+}
+
 QString RealtimeEffectListModel::prop_trackName() const
 {
     if (!trackId().has_value()) {
         return QString();
-    } else if (isMasterTrack()) {
+    } else if (m_isMasterTrack) {
         return muse::TranslatableString("projectScene", "Master").translated().toQString();
     }
 


### PR DESCRIPTION
Resolves: #7832

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] The selected realtime effect is checked in the replace/no-effect menu: 
![image](https://github.com/user-attachments/assets/e8100cd6-073e-45ce-8a2b-83aad00536f9)

- [x] The realtime effect panel is renamed "Realtime effects" (previously was just "Effects")
- [x] The realtime effect show-effect and replace/remove-effect button colors are consistent with the [design](https://www.figma.com/design/w2kAh1gKKV5bu7htY7158W/08---Effects?node-id=1-4&p=f&t=lRQVgpNaTb0HCWEP-0): 
- [x] The mouse pointer when hovering over the grip button is a vertical sizer