### PR TITLE
Draw envelope area in the clip view

### DIFF
--- a/libraries/lib-theme-resources/light/Components/Colors.txt
+++ b/libraries/lib-theme-resources/light/Components/Colors.txt
@@ -37,7 +37,7 @@
                         HzPlot: #8c3cbe;
                 WavelengthPlot: #c83296;
                 EnvelopeColour: #677ce4;
-            EnvelopeBackground: #14151a;
+            EnvelopeBackground: #d5e3ff;
               MuteButtonActive: #a0aad2;
               MuteButtonVetoed: #d5e3ff;
                      CursorPen: #14151a;
@@ -80,7 +80,7 @@
                    GraphLabels: #14151a;
              SpectroBackground: #ffff14;
                     ScrubRuler: #e4e4e4;
-                 RulerSelected: #75a0ff; 
+                 RulerSelected: #75a0ff;
                      TimeHours: #323545;
                      MidiZebra: #808080;
                      MidiLines: #3c3c98;
@@ -96,7 +96,7 @@
                    Spectro4Sel: #bf0000;
                    Spectro5Sel: #bfbfbf;
       ClipAffordanceOutlinePen: #14151a;
- ClipAffordanceUnselectedBrush: #cfd6f4; 
+ ClipAffordanceUnselectedBrush: #cfd6f4;
    ClipAffordanceSelectedBrush: #aeb6db;
           ClipAffordanceStroke: #ffffff;
           ClipAffordanceButton: #949bba;
@@ -112,7 +112,7 @@
              BeatFillWeakBrush: #4B4F5F;
         BeatFillStrongSelBrush: #9cb7d2;
           BeatFillWeakSelBrush: #b4cfe9;
-                   LoopEnabled: #c4c6c8; 
+                   LoopEnabled: #c4c6c8;
                 LoopNotEnabled: #e9e9eb;
                        Grabber: #9295a6;
        TimelineRulerBackground: #e9e9eb;

--- a/libraries/lib-wave-track-paint/waveform/WaveBitmapCache.h
+++ b/libraries/lib-wave-track-paint/waveform/WaveBitmapCache.h
@@ -57,9 +57,9 @@ private:
 
    struct LookupHelper;
 
-   WavePaintParameters mPaintParamters;
+   WavePaintParameters mPaintParameters;
 
-   struct   
+   struct
    {
       int64_t FirstPixel { -1 };
       int64_t LastPixel { -1 };
@@ -69,7 +69,7 @@ private:
          return FirstPixel < LastPixel;
       }
    } mSelection;
- 
+
    std::unique_ptr<LookupHelper> mLookupHelper;
 
    const Envelope* mEnvelope { nullptr };

--- a/libraries/lib-wave-track-paint/waveform/WavePaintParameters.cpp
+++ b/libraries/lib-wave-track-paint/waveform/WavePaintParameters.cpp
@@ -73,6 +73,13 @@ WavePaintParameters& WavePaintParameters::SetClippingColors(
    return *this;
 }
 
+WavePaintParameters& WavePaintParameters::SetEnvelopeColors(
+   graphics::Color normal, graphics::Color selected) noexcept
+{
+   EnvelopeColors = { normal, selected };
+   return *this;
+}
+
 WavePaintParameters&
 WavePaintParameters::SetEnvelope(const Envelope& envelope) noexcept
 {
@@ -89,6 +96,12 @@ WavePaintParameters& WavePaintParameters::ResetEnvelope() noexcept
 WavePaintParameters& WavePaintParameters::SetShowRMS(bool showRMS) noexcept
 {
    ShowRMS = showRMS;
+   return *this;
+}
+
+WavePaintParameters& WavePaintParameters::SetDrawEnvelope(bool drawEnvelope) noexcept
+{
+   DrawEnvelope = drawEnvelope;
    return *this;
 }
 
@@ -111,11 +124,13 @@ bool operator==(
           lhs.Max == rhs.Max && lhs.DBRange == rhs.DBRange &&
           lhs.DBScale == rhs.DBScale && lhs.ShowClipping == rhs.ShowClipping &&
           lhs.ShowRMS == rhs.ShowRMS &&
+          lhs.DrawEnvelope == rhs.DrawEnvelope &&
           lhs.BlankColor == rhs.BlankColor &&
           lhs.BackgroundColors == rhs.BackgroundColors &&
           lhs.SampleColors == rhs.SampleColors &&
           lhs.RMSColors == rhs.RMSColors &&
-          lhs.ClippingColors == rhs.ClippingColors;
+          lhs.ClippingColors == rhs.ClippingColors &&
+          lhs.EnvelopeColors == rhs.EnvelopeColors;
 }
 
 bool operator!=(

--- a/libraries/lib-wave-track-paint/waveform/WavePaintParameters.h
+++ b/libraries/lib-wave-track-paint/waveform/WavePaintParameters.h
@@ -51,6 +51,9 @@ struct WAVE_TRACK_PAINT_API WavePaintParameters final
    //! True, if we mark clipped values
    bool ShowClipping { false };
 
+   //! True, if we paint envelope
+   bool DrawEnvelope { false };
+
    //! True, if we paint RMS values on top of min and max
    bool ShowRMS { false };
 
@@ -66,6 +69,8 @@ struct WAVE_TRACK_PAINT_API WavePaintParameters final
    ColorPair RMSColors;
    //! Color for the columns where clipping has occurred
    ColorPair ClippingColors;
+   //! Color for the envelope band
+   ColorPair EnvelopeColors;
 
    //! Sets the basic painting parameters
    WavePaintParameters& SetDisplayParameters(int height, double zoomMin, double zoomMax, bool showClipping) noexcept;
@@ -87,12 +92,17 @@ struct WAVE_TRACK_PAINT_API WavePaintParameters final
    //! Sets the clipping colors
    WavePaintParameters&
    SetClippingColors(graphics::Color normal, graphics::Color selected) noexcept;
+   //! Sets the envelope colors
+   WavePaintParameters&
+   SetEnvelopeColors(graphics::Color normal, graphics::Color selected) noexcept;
    //! Sets volume envelope
    WavePaintParameters& SetEnvelope(const Envelope& envelope) noexcept;
    //! Resets the envelope
    WavePaintParameters& ResetEnvelope() noexcept;
    //! Sets the ShowRMS flag
    WavePaintParameters& SetShowRMS(bool showRMS) noexcept;
+   //! Sets the DrawEnvelope flag
+   WavePaintParameters& SetDrawEnvelope(bool drawEnvelope) noexcept;
 
    friend WAVE_TRACK_PAINT_API bool operator==(
       const WavePaintParameters& lhs,

--- a/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -370,6 +370,11 @@ void DrawWaveform(
       .SetClippingColors(
          ColorFromWXPen(muted ? artist->muteClippedPen : artist->clippedPen),
          ColorFromWXPen(muted ? artist->muteClippedPen : artist->clippedPen))
+      .SetEnvelopeColors(
+         ColorFromWXBrush(artist->envelopeBackgroundBrush),
+         ColorFromWXBrush(artist->envelopeBackgroundBrush)
+      )
+      .SetDrawEnvelope(artist->drawEnvelope)
       .SetEnvelope(clip.GetEnvelope());
 
    clipPainter.SetSelection(


### PR DESCRIPTION
Resolves: [#8110](https://github.com/audacity/audacity/issues/8110)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] works with show-clipping ON (extra menus must be set in prefs, then it's under View)
- [x] rendering works for both selected and unselected samples
- [x] test with stretching
- [x] once envelope was drawn, select a tool other than the envelope tool to see if display is also correct
