### PR TITLE
Fix label editor not closing on OK when editing

### DIFF
--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -924,7 +924,6 @@ void LabelDialog::OnOK(wxCommandEvent & WXUNUSED(event))
    if (mGrid->IsCellEditControlShown()) {
       mGrid->SaveEditControlValue();
       mGrid->HideCellEditControl();
-      return;
    }
 
    // Standard handling


### PR DESCRIPTION
Resolves: #8234 

The OK button in the label editor now closes the dialog and applies the changes even if a track is being edited. This behavior is now in line with the rest of the boxes in the label editor. Clicking OK after making a change will close the dialog and apply the change immediately.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
