### PR TITLE
8067 toggling effect makes project dirty

### DIFF
--- a/au3/libraries/lib-effects/MixAndRender.cpp
+++ b/au3/libraries/lib-effects/MixAndRender.cpp
@@ -232,11 +232,6 @@ static ProjectFileIORegistry::ObjectReaderEntry projectAccessor {
     [](AudacityProject& project) { return &RealtimeEffectList::Get(project); }
 };
 
-static ProjectFileIORegistry::ObjectWriterEntry projectWriter {
-    [](const AudacityProject& project, XMLWriter& xmlFile){
-        RealtimeEffectList::Get(project).WriteXML(xmlFile);
-    } };
-
 static WaveTrackIORegistry::ObjectReaderEntry waveTrackAccessor {
     RealtimeEffectList::XMLTag(),
     [](WaveTrack& track) { return &RealtimeEffectList::Get(track); }

--- a/au3/libraries/lib-project-file-io/ProjectFileIO.cpp
+++ b/au3/libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -40,6 +40,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "XMLFileReader.h"
 #include "SentryHelper.h"
 #include "MemoryX.h"
+#include "SavedMasterEffectList.h"
 
 #include "ProjectFileIOExtension.h"
 #include "ProjectFormatVersion.h"
@@ -1702,6 +1703,8 @@ void ProjectFileIO::WriteXML(XMLWriter& xmlFile,
         }
         useTrack->WriteXML(xmlFile);
     });
+
+    SavedMasterEffectList::Get(proj).List().WriteXML(xmlFile);
 
     xmlFile.EndTag(wxT("project"));
 

--- a/au3/libraries/lib-realtime-effects/RealtimeEffectList.cpp
+++ b/au3/libraries/lib-realtime-effects/RealtimeEffectList.cpp
@@ -34,8 +34,9 @@ std::unique_ptr<ClientData::Cloneable<> > RealtimeEffectList::Clone() const
 RealtimeEffectList& RealtimeEffectList::operator=(const RealtimeEffectList& other)
 {
     mStates.clear();
+    mStates.reserve(other.mStates.size());
     for (auto& pState : other.mStates) {
-        mStates.push_back(pState);
+        mStates.push_back(std::make_shared<RealtimeEffectState>(*pState));
     }
     SetActive(other.IsActive());
     return *this;

--- a/au3/libraries/lib-realtime-effects/RealtimeEffectList.h
+++ b/au3/libraries/lib-realtime-effects/RealtimeEffectList.h
@@ -48,7 +48,7 @@ class REALTIME_EFFECTS_API RealtimeEffectList final
 public:
     //! Should be called (for pushing undo states) only from main thread, to
     //! avoid races
-    //! These methods to not publish messages.
+    //! These methods do not publish messages.
     RealtimeEffectList(const RealtimeEffectList&);
     RealtimeEffectList& operator=(const RealtimeEffectList&);
     std::unique_ptr<ClientData::Cloneable<> > Clone() const override;

--- a/au3/libraries/lib-realtime-effects/RealtimeEffectState.cpp
+++ b/au3/libraries/lib-realtime-effects/RealtimeEffectState.cpp
@@ -348,6 +348,25 @@ RealtimeEffectState::RealtimeEffectState(const PluginID& id)
     BuildAll();
 }
 
+RealtimeEffectState::RealtimeEffectState(const RealtimeEffectState& other)
+    : RealtimeEffectState(other.mID)
+{
+    *this = other;
+}
+
+RealtimeEffectState& RealtimeEffectState::operator =(const RealtimeEffectState& other)
+{
+    assert(other.mID == mID);
+    SetActive(other.IsActive());
+    CommandParameters params;
+    if (other.mPlugin->SaveSettings(mMainSettings.settings, params)) {
+        mPlugin->LoadSettings(params, mMainSettings.settings);
+    } else {
+        assert(false);
+    }
+    return *this;
+}
+
 RealtimeEffectState::~RealtimeEffectState()
 {
 }

--- a/au3/libraries/lib-realtime-effects/RealtimeEffectState.h
+++ b/au3/libraries/lib-realtime-effects/RealtimeEffectState.h
@@ -41,8 +41,8 @@ public:
                                                            > {};
 
     explicit RealtimeEffectState(const PluginID& id);
-    RealtimeEffectState(const RealtimeEffectState& other) = delete;
-    RealtimeEffectState& operator =(const RealtimeEffectState& other) = delete;
+    RealtimeEffectState(const RealtimeEffectState& other);
+    RealtimeEffectState& operator =(const RealtimeEffectState& other);
     ~RealtimeEffectState();
 
     //! May be called with nonempty id at most once in the lifetime of a state

--- a/au3/libraries/lib-realtime-effects/SavedMasterEffectList.cpp
+++ b/au3/libraries/lib-realtime-effects/SavedMasterEffectList.cpp
@@ -1,0 +1,42 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "SavedMasterEffectList.h"
+#include "Project.h"
+
+SavedMasterEffectList::SavedMasterEffectList(AudacityProject& project)
+    : m_project(project)
+{
+    UpdateCopy();
+}
+
+void SavedMasterEffectList::UpdateCopy()
+{
+    mLastSavedList = std::make_unique<RealtimeEffectList>(RealtimeEffectList::Get(m_project));
+}
+
+static const AudacityProject::AttachedObjects::RegisteredFactory key2{
+    [](AudacityProject& project)
+    {
+        return std::make_shared<SavedMasterEffectList>(project);
+    } };
+
+SavedMasterEffectList& SavedMasterEffectList::Get(AudacityProject& project)
+{
+    return project.AttachedObjects::Get<SavedMasterEffectList>(key2);
+}
+
+const SavedMasterEffectList& SavedMasterEffectList::Get(const AudacityProject& project)
+{
+    return Get(const_cast<AudacityProject&>(project));
+}
+
+RealtimeEffectList& SavedMasterEffectList::List()
+{
+    return *mLastSavedList;
+}
+
+const RealtimeEffectList& SavedMasterEffectList::List() const
+{
+    return *mLastSavedList;
+}

--- a/au3/libraries/lib-realtime-effects/SavedMasterEffectList.h
+++ b/au3/libraries/lib-realtime-effects/SavedMasterEffectList.h
@@ -1,0 +1,29 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "ClientData.h"
+#include "RealtimeEffectList.h"
+#include <memory>
+
+class AudacityProject;
+class RealtimeEffectList;
+
+class SavedMasterEffectList final : public ClientData::Base
+{
+public:
+    SavedMasterEffectList(AudacityProject& project);
+
+    static SavedMasterEffectList& Get(AudacityProject& project);
+    static const SavedMasterEffectList& Get(const AudacityProject& project);
+
+    void UpdateCopy();
+    RealtimeEffectList& List();
+    const RealtimeEffectList& List() const;
+
+private:
+
+    AudacityProject& m_project;
+    std::unique_ptr<RealtimeEffectList> mLastSavedList;
+};

--- a/src/au3wrap/CMakeLists.txt
+++ b/src/au3wrap/CMakeLists.txt
@@ -342,6 +342,8 @@ set(AU3_SRC
     ${AU3_LIBRARIES}/lib-realtime-effects/RealtimeEffectManager.h
     ${AU3_LIBRARIES}/lib-realtime-effects/RealtimeEffectState.cpp
     ${AU3_LIBRARIES}/lib-realtime-effects/RealtimeEffectState.h
+    ${AU3_LIBRARIES}/lib-realtime-effects/SavedMasterEffectList.cpp
+    ${AU3_LIBRARIES}/lib-realtime-effects/SavedMasterEffectList.h
 
     ${AU3_LIBRARIES}/lib-mixer/Mix.cpp
     ${AU3_LIBRARIES}/lib-mixer/Mix.h

--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -23,7 +23,6 @@ public:
     virtual void close() = 0;
 
     virtual std::string title() const = 0;
-    virtual bool hasSavedVersion() const = 0;
 
     // internal
     virtual uintptr_t au3ProjectPtr() const = 0;

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -11,6 +11,7 @@
 #include "libraries/lib-wave-track/WaveClip.h"
 #include "libraries/lib-numeric-formats/ProjectTimeSignature.h"
 #include "libraries/lib-project-history/ProjectHistory.h"
+#include "libraries/lib-realtime-effects/SavedMasterEffectList.h"
 #include "domconverter.h"
 #include "TempoChange.h"
 
@@ -93,7 +94,7 @@ bool Au3ProjectAccessor::load(const muse::io::path_t& filePath)
         pTrack->LinkConsistencyFix();
     }
 
-    m_hasSavedVersion = true;
+    SavedMasterEffectList::Get(project).UpdateCopy();
 
     return true;
 }
@@ -102,6 +103,7 @@ bool Au3ProjectAccessor::save(const muse::io::path_t& filePath)
 {
     auto& project = m_data->projectRef();
 
+    SavedMasterEffectList::Get(project).UpdateCopy();
 
     auto& projectFileIO = ProjectFileIO::Get(project);
     auto result = projectFileIO.SaveProject(wxFromString(filePath.toString()), &TrackList::Get(project));

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -10,6 +10,7 @@
 #include "libraries/lib-wave-track/WaveTrack.h"
 #include "libraries/lib-wave-track/WaveClip.h"
 #include "libraries/lib-numeric-formats/ProjectTimeSignature.h"
+#include "libraries/lib-project-history/ProjectHistory.h"
 #include "domconverter.h"
 #include "TempoChange.h"
 
@@ -61,7 +62,8 @@ void Au3ProjectAccessor::open()
 
 bool Au3ProjectAccessor::load(const muse::io::path_t& filePath)
 {
-    auto& projectFileIO = ProjectFileIO::Get(m_data->projectRef());
+    auto& project = m_data->projectRef();
+    auto& projectFileIO = ProjectFileIO::Get(project);
     std::string sstr = filePath.toStdString();
     FilePath fileName = wxString::FromUTF8(sstr.c_str(), sstr.size());
 
@@ -86,7 +88,7 @@ bool Au3ProjectAccessor::load(const muse::io::path_t& filePath)
 
     //! TODO Look like, need doing all from method  ProjectFileManager::FixTracks
     //! and maybe what is done before this method (ProjectFileManager::ReadProjectFile)
-    Au3TrackList& tracks = Au3TrackList::Get(m_data->projectRef());
+    Au3TrackList& tracks = Au3TrackList::Get(project);
     for (auto pTrack : tracks) {
         pTrack->LinkConsistencyFix();
     }
@@ -98,22 +100,78 @@ bool Au3ProjectAccessor::load(const muse::io::path_t& filePath)
 
 bool Au3ProjectAccessor::save(const muse::io::path_t& filePath)
 {
-    auto& projectFileIO = ProjectFileIO::Get(m_data->projectRef());
-    Au3TrackList& tracks = Au3TrackList::Get(m_data->projectRef());
-    auto result = projectFileIO.SaveProject(wxFromString(filePath.toString()), &tracks);
+    auto& project = m_data->projectRef();
+
+
+    auto& projectFileIO = ProjectFileIO::Get(project);
+    auto result = projectFileIO.SaveProject(wxFromString(filePath.toString()), &TrackList::Get(project));
     if (result) {
-        UndoManager::Get(m_data->projectRef()).StateSaved();
-        // Project is now saved on disk - this isn't a new project anymore.
-        m_hasSavedVersion = true;
+        UndoManager::Get(project).StateSaved();
     }
+
     return result;
 }
 
 void Au3ProjectAccessor::close()
 {
-    auto& projectFileIO = ProjectFileIO::Get(m_data->projectRef());
+    auto& project = m_data->projectRef();
+    auto& tracks = TrackList::Get(project);
+
+    //! ============================================================================
+    //! NOTE Step 1 - Go back to the last saved state if needed
+    //! ============================================================================
+    auto& undoManager = UndoManager::Get(project);
+    if (undoManager.GetSavedState() >= 0) {
+        constexpr auto doAutoSave = false;
+        ProjectHistory::Get(project).SetStateTo(
+            undoManager.GetSavedState(), doAutoSave);
+    }
+
+    //! ============================================================================
+    //! NOTE Step 2 - We compact the project only around the tracks that were actually
+    //! saved. This will allow us to later on clear the UndoManager states bypassing
+    //! the deletion of blocks 1 by 1, which can take a long time for projects with
+    //!  large unsaved audio ; see https://github.com/audacity/audacity/issues/7382
+    //! ============================================================================
+    auto& projectFileIO = ProjectFileIO::Get(project);
+
+    // Lock all blocks in all tracks of the last saved version, so that
+    // the sample blocks aren't deleted from the database when we destroy the
+    // sample block objects in memory.
+    for (auto wt : tracks.Any<WaveTrack>()) {
+        WaveTrackUtilities::CloseLock(*wt);
+    }
+
+    // Attempt to compact the project
+    projectFileIO.Compact({ &tracks });
+
+    if (
+        !projectFileIO.WasCompacted() && undoManager.UnsavedChanges()) {
+        // If compaction failed, we must do some work in case of close
+        // without save.  Don't leave the document blob from the last
+        // push of undo history, when that undo state may get purged
+        // with deletion of some new sample blocks.
+        // REVIEW: UpdateSaved() might fail too.  Do we need to test
+        // for that and report it?
+        projectFileIO.UpdateSaved(&tracks);
+    }
+
+    //! ============================================================================
+    //! NOTE Step 3
+    //! Set (or not) the bypass flag to indicate that deletes that would happen
+    //! during undoManager.ClearStates() below are not necessary. Must be called
+    //! between `CompactProjectOnClose()` and `undoManager.ClearStates()`.
+    //! ============================================================================
+    projectFileIO.SetBypass();
+
+    // This can reduce reference counts of sample blocks in the project's
+    // tracks.
+    undoManager.ClearStates();
+
+    // Delete all the tracks to free up memory
+    tracks.Clear();
+
     projectFileIO.CloseProject();
-    m_hasSavedVersion = false;
 }
 
 std::string Au3ProjectAccessor::title() const
@@ -123,11 +181,6 @@ std::string Au3ProjectAccessor::title() const
     }
 
     return wxToStdSting(m_data->project->GetProjectName());
-}
-
-bool Au3ProjectAccessor::hasSavedVersion() const
-{
-    return m_hasSavedVersion;
 }
 
 uintptr_t Au3ProjectAccessor::au3ProjectPtr() const

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -22,7 +22,6 @@ public:
     void close() override;
 
     std::string title() const override;
-    bool hasSavedVersion() const override;
 
     // internal
     uintptr_t au3ProjectPtr() const override;
@@ -31,7 +30,6 @@ private:
 
     const std::shared_ptr<Au3ProjectData> m_data;
     Observer::Subscription mTrackListSubstription;
-    bool m_hasSavedVersion = false;
 };
 
 class Au3ProjectCreator : public IAu3ProjectCreator

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -8,6 +8,8 @@
 #include "../iau3project.h"
 #include "libraries/lib-utility/Observer.h"
 
+class TrackList;
+
 namespace au::au3 {
 struct Au3ProjectData;
 class Au3ProjectAccessor : public IAu3Project
@@ -27,9 +29,11 @@ public:
     uintptr_t au3ProjectPtr() const override;
 
 private:
+    void updateSavedState();
 
     const std::shared_ptr<Au3ProjectData> m_data;
     Observer::Subscription mTrackListSubstription;
+    std::shared_ptr<TrackList> m_lastSavedTracks;
 };
 
 class Au3ProjectCreator : public IAu3ProjectCreator

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -193,6 +193,9 @@ muse::Ret EffectsProvider::showEffect(const EffectId& effectId, const EffectInst
 
 void EffectsProvider::showEffect(const RealtimeEffectStatePtr& state) const
 {
+    IF_ASSERT_FAILED(state) {
+        return;
+    }
     const auto effectId = state->GetID().ToStdString();
     const auto type = muse::String::fromStdString(effectSymbol(effectId));
     const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(state->GetInstance());
@@ -225,6 +228,9 @@ void EffectsProvider::showEffect(const RealtimeEffectStatePtr& state) const
 
 void EffectsProvider::hideEffect(const RealtimeEffectStatePtr& state) const
 {
+    IF_ASSERT_FAILED(state) {
+        return;
+    }
     const auto effectId = state->GetID().ToStdString();
     const auto type = muse::String::fromStdString(effectSymbol(effectId));
     const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(state->GetInstance());
@@ -243,6 +249,9 @@ void EffectsProvider::hideEffect(const RealtimeEffectStatePtr& state) const
 
 void EffectsProvider::toggleShowEffect(const RealtimeEffectStatePtr& state) const
 {
+    IF_ASSERT_FAILED(state) {
+        return;
+    }
     const auto effectId = state->GetID().ToStdString();
     const auto type = muse::String::fromStdString(effectSymbol(effectId));
     const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(state->GetInstance());

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -336,6 +336,7 @@ void RealtimeEffectService::setIsActive(const RealtimeEffectStatePtr& stateId, b
         return;
     }
     stateId->SetActive(isActive);
+    projectHistory()->modifyState();
     m_isActiveChanged.send(stateId);
 }
 
@@ -353,8 +354,9 @@ bool RealtimeEffectService::trackEffectsActive(TrackId trackId) const
 void RealtimeEffectService::setTrackEffectsActive(TrackId trackId, bool active)
 {
     const auto list = realtimeEffectList(trackId);
-    if (list) {
+    if (list && list->IsActive() != active) {
         list->SetActive(active);
+        projectHistory()->modifyState();
     }
 }
 

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -92,21 +92,8 @@ muse::Ret Audacity4Project::doLoad(const io::path_t& path, bool forceMode, const
 void Audacity4Project::close()
 {
     m_aboutCloseBegin.notify();
-
-    const auto history = projectHistory();
-    history->undoUnsaved();
-    history->clearUnsaved();
-    // Do not save a project that has never explicitly been saved.
-    if (m_au3Project->hasSavedVersion()) {
-        //! Important!
-        //! If some unsaved changes were made and we don't save the project after having cleared the history,
-        //! the project will be corrupted and can't be opened again.
-        save();
-    }
-
     clipboard()->clearTrackData();
     m_au3Project->close();
-
     m_aboutCloseEnd.notify();
 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -190,6 +190,7 @@ ListItemBlank {
             RealtimeEffectListItemMenuModel {
                 id: menuModel
                 effectState: root.item ? root.item.effectState() : null
+                isMasterTrack: root.item && root.item.isMasterEffect
             }
 
             onClicked: {

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.h
@@ -36,7 +36,7 @@ signals:
     void isActiveChanged();
 
 private:
-    const effects::RealtimeEffectStatePtr m_effectState;
+    std::weak_ptr<RealtimeEffectState> m_effectState;
 };
 
 using RealtimeEffectListItemModelPtr = std::shared_ptr<RealtimeEffectListItemModel>;

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
@@ -18,22 +18,21 @@ RealtimeEffectListModel::RealtimeEffectListModel(QObject* parent)
 
 void RealtimeEffectListModel::onProjectChanged()
 {
-    const trackedit::ITrackeditProjectPtr project = globalContext()->currentTrackeditProject();
-    if (!project) {
+    if (const trackedit::ITrackeditProjectPtr project = globalContext()->currentTrackeditProject()) {
+        project->trackChanged().onReceive(this, [this](au::trackedit::Track track)
+        {
+            if (trackId() == track.id) {
+                emit trackNameChanged();
+            }
+        });
+    } else {
         beginResetModel();
         m_trackEffectLists.clear();
         endResetModel();
-        emit trackNameChanged();
-        emit trackEffectsActiveChanged();
-        return;
     }
 
-    project->trackChanged().onReceive(this, [this](au::trackedit::Track track)
-    {
-        if (trackId() == track.id) {
-            emit trackNameChanged();
-        }
-    });
+    emit trackNameChanged();
+    emit trackEffectsActiveChanged();
 }
 
 bool RealtimeEffectListModel::prop_isMasterTrack() const

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -72,6 +72,13 @@ void Au3ProjectHistory::pushHistoryState(const std::string& longDescription, con
     m_isUndoRedoAvailableChanged.notify();
 }
 
+void Au3ProjectHistory::modifyState(bool autoSave)
+{
+    auto& project = projectRef();
+    ::ProjectHistory::Get(project).ModifyState(autoSave);
+    ::UndoManager::Get(project).MarkUnsaved();
+}
+
 muse::async::Notification Au3ProjectHistory::isUndoRedoAvailableChanged() const
 {
     return m_isUndoRedoAvailableChanged;

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -54,26 +54,6 @@ void au::trackedit::Au3ProjectHistory::redo()
     m_isUndoRedoAvailableChanged.notify();
 }
 
-void au::trackedit::Au3ProjectHistory::undoUnsaved()
-{
-    auto& project = projectRef();
-    auto& undoManager = UndoManager::Get(project);
-    while (undoManager.UnsavedChanges())
-    {
-        undoManager.Undo(
-            [&]( const UndoStackElem& elem ){
-            ::ProjectHistory::Get(project).PopState(elem.state);
-        });
-    }
-}
-
-void au::trackedit::Au3ProjectHistory::clearUnsaved()
-{
-    auto& project = projectRef();
-    auto& undoManager = UndoManager::Get(project);
-    undoManager.ClearStates();
-}
-
 void au::trackedit::Au3ProjectHistory::pushHistoryState(const std::string& longDescription, const std::string& shortDescription)
 {
     auto& project = projectRef();

--- a/src/trackedit/internal/au3/au3projecthistory.h
+++ b/src/trackedit/internal/au3/au3projecthistory.h
@@ -29,6 +29,7 @@ public:
         const std::string& longDescription, const std::string& shortDescription) override;
     void pushHistoryState(
         const std::string& longDescription, const std::string& shortDescription, UndoPushType flags) override;
+    void modifyState(bool autoSave) override;
     muse::async::Notification isUndoRedoAvailableChanged() const override;
 
 private:

--- a/src/trackedit/internal/au3/au3projecthistory.h
+++ b/src/trackedit/internal/au3/au3projecthistory.h
@@ -25,8 +25,6 @@ public:
     void undo() override;
     bool redoAvailable() override;
     void redo() override;
-    void undoUnsaved() override;
-    void clearUnsaved() override;
     void pushHistoryState(
         const std::string& longDescription, const std::string& shortDescription) override;
     void pushHistoryState(

--- a/src/trackedit/iprojecthistory.h
+++ b/src/trackedit/iprojecthistory.h
@@ -24,6 +24,7 @@ public:
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription) = 0;
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription,
                                   trackedit::UndoPushType flags) = 0;
+    virtual void modifyState(bool autoSave = false) = 0;
     virtual muse::async::Notification isUndoRedoAvailableChanged() const = 0;
 };
 

--- a/src/trackedit/iprojecthistory.h
+++ b/src/trackedit/iprojecthistory.h
@@ -21,8 +21,6 @@ public:
     virtual void undo() = 0;
     virtual bool redoAvailable() = 0;
     virtual void redo() = 0;
-    virtual void undoUnsaved() = 0;
-    virtual void clearUnsaved() = 0;
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription) = 0;
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription,
                                   trackedit::UndoPushType flags) = 0;


### PR DESCRIPTION
Resolves: #8067 

The fix of 8067 for track effects was easy, only needed the project to be made dirty.

For master effects, however, this was more complicated, and also is a defect on AU3.
The reason is that track effects are attachments of wave tracks, whose management when opening, making the project dirty and saving, was carefully implemented. The track attachments benefit from this maintenance. The maintenance of the project effects needed its own implementation.

Also, this ticket addresses an issue we have on master: create an empty project, save it, generate a 1h tone, close without saving: the project size is still several hundred MBs. (see #7312 wrt AU3). This must be implemented with care, though, that it doesn't lead to another issue, see #7382. The logic seen is similar to what can be found in `./au3/src/ProjectManager.cpp`.
This is addressed in this PR because solving this also helps fixing the original purpose of this ticket or "toggling effect makes project dirty".

Another issue this solves (although there wasn't a ticket for it) is that, when closing a project with unsaved changes, the solution so far was to rewind the history, which sometimes was also visible in the UI and looking a bit silly.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Project is compacted on close: create new project, save, generate 1h tone, close without saving: the project file should be about 20KB, not several megs. (See #7312 for more information. Was fixed for AU3 but not implemented in AU4.)
- [x] When creating a new project or opening an empty project, the master effect power button is enabled.
- [x] Toggling the power button of either master or track effects makes the project dirty
- [x] When closing and re-opening project (including re-starting application), power button states is correct whether saving changes or not before closing