### PR TITLE
Get effects dialog: fix screen readers not reading text

### DIFF
--- a/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
+++ b/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
@@ -29,6 +29,7 @@
 #include "Theme.h"
 #include "AllThemeResources.h"
 #include "GradientButton.h"
+#include "WindowAccessible.h"
 
 namespace audacity::musehub
 {
@@ -195,6 +196,12 @@ void GetEffectsDialog::AddBecomeAPartnerPage() {
    button->Bind(wxEVT_BUTTON, [](auto) {
       BasicUI::OpenInDefaultBrowser(GetBecomeAPartnerUrl());
    });
+#if wxUSE_ACCESSIBILITY
+   safenew WindowAccessible(button);
+   button->SetName(becomeAPartnerTitle.Translation() + wxT(", ")
+      + becomeAPartnerDescription.Translation() + wxT(", ")
+      + becomeAPartnerButtonText.Translation());
+#endif
 
    sizer->AddSpacer(35);
    sizer->Add(title, 0, wxLEFT, 25);
@@ -284,6 +291,11 @@ void GetEffectsDialog::AddEffectsPage(const std::string& group, const std::vecto
       });
       button->SetNormalColor(musehubButtonNormal);
       button->SetPressedColor(musehubButtonPressed);
+#if wxUSE_ACCESSIBILITY
+      safenew WindowAccessible(button);
+      button->SetName(elem.title + wxT(", ") + elem.subtitle + wxT(", ")
+         + getItOnMusehubButtonText.Translation());
+#endif
 
       wxBoxSizer* vSizer = safenew wxBoxSizer(wxVERTICAL);
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8251
Resolves: https://github.com/audacity/audacity/issues/8253

Problems:
1. On pages of effects, screen readers don't read the name and description of effects.
2. On Become a partner page, screen readers don't read the page title and descriptive text.

Fix:
In both cases, add the unread text to the accessibility name of the button immediately after the text.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
