### PR TITLE
TracksListModel doesn't modify track selection

### DIFF
--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -341,7 +341,12 @@ std::optional<au::trackedit::ClipId> EffectExecutionScenario::performEffectOnSin
     // It is possible that the backend decides to replace the processed clip with a new one.
     // Since the selection spans only one clip, we want the originally selected clip to remain selected in appearance.
     // Look for the clip on that track at that time - we should find the new one.
-    return selectionController()->setSelectedClip(trackId, effect.mT0);
+    const auto waveClip = au3::DomAccessor::findWaveClip(project, trackId, effect.mT0);
+    IF_ASSERT_FAILED(waveClip) {
+        return std::nullopt;
+    }
+    selectionController()->setSelectedClips({ trackedit::ClipKey { trackId, waveClip->GetId() } });
+    return waveClip->GetId();
 }
 
 muse::Ret EffectExecutionScenario::performEffectOnEachSelectedClip(au3::Au3Project& project, Effect& effect,

--- a/src/effects/effects_base/internal/mastereffectundoredo.cpp
+++ b/src/effects/effects_base/internal/mastereffectundoredo.cpp
@@ -49,8 +49,6 @@ public:
         }
     }
 
-    muse::async::Channel<TrackId> realtimeEffectStackChanged;
-
 private:
     const std::unique_ptr<RealtimeEffectList> m_targetList;
 };

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -746,6 +746,8 @@ void ClipsListModel::selectClip(const ClipKey& key)
 {
     Qt::KeyboardModifiers modifiers = keyboardModifiers();
 
+    constexpr auto complete = true;
+    constexpr auto modifyState = true;
     const auto clipGroupId = trackeditInteraction()->clipGroupId(key.key);
     if (clipGroupId != -1) {
         //! NOTE: clip belongs to a group, select the whole group
@@ -754,7 +756,7 @@ void ClipsListModel::selectClip(const ClipKey& key)
                 selectionController()->addSelectedClip(key);
             }
         } else {
-            selectionController()->setSelectedClips(trackeditInteraction()->clipsInGroup(clipGroupId));
+            selectionController()->setSelectedClips(trackeditInteraction()->clipsInGroup(clipGroupId), complete, modifyState);
         }
     } else {
         if (modifiers.testFlag(Qt::ShiftModifier)) {
@@ -763,7 +765,7 @@ void ClipsListModel::selectClip(const ClipKey& key)
             if (muse::contains(selectionController()->selectedClips(), key.key)) {
                 return;
             }
-            selectionController()->setSelectedClips(ClipKeyList({ key.key }));
+            selectionController()->setSelectedClips(ClipKeyList({ key.key }), complete, modifyState);
         }
     }
 }

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -97,10 +97,16 @@ void TracksListModel::load()
 
     listenTracksSelectionChanged();
 
+    loadTracks(prj->trackList());
+
+    emit isEmptyChanged();
+    emit isAddingAvailableChanged(true);
+}
+
+void TracksListModel::loadTracks(const std::vector<Track>& tracks)
+{
     beginResetModel();
     deleteItems();
-
-    std::vector<Track> tracks = prj->trackList();
 
     for (const Track& track : tracks) {
         m_trackList.push_back(buildTrackItem(track));
@@ -108,9 +114,6 @@ void TracksListModel::load()
 
     endResetModel();
     onSelectedTracks(selectionController()->selectedTracks());
-
-    emit isEmptyChanged();
-    emit isAddingAvailableChanged(true);
 }
 
 void TracksListModel::addTrack(TrackTypes::Type type)
@@ -567,7 +570,11 @@ void TracksListModel::onTracksChanged(const std::vector<au::trackedit::Track>& t
 {
     Q_UNUSED(tracks);
     muse::async::Async::call(this, [this]() {
-        load();
+        if (const auto prj = globalContext()->currentTrackeditProject()) {
+            loadTracks(prj->trackList());
+            emit isEmptyChanged();
+            emit isAddingAvailableChanged(true);
+        }
     });
 }
 

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -66,21 +66,10 @@ void TracksListModel::load()
 
     TRACEFUNC;
 
-    beginResetModel();
-    deleteItems();
-
     ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     if (!prj) {
         return;
     }
-
-    std::vector<Track> tracks = prj->trackList();
-
-    for (const Track& track : tracks) {
-        m_trackList.push_back(buildTrackItem(track));
-    }
-
-    onSelectedTracks(selectionController()->selectedTracks());
 
     prj->tracksChanged().onReceive(this, [this](std::vector<au::trackedit::Track> tracks) {
         onTracksChanged(tracks);
@@ -106,9 +95,19 @@ void TracksListModel::load()
         onTrackMoved(track, pos);
     });
 
-    endResetModel();
-
     listenTracksSelectionChanged();
+
+    beginResetModel();
+    deleteItems();
+
+    std::vector<Track> tracks = prj->trackList();
+
+    for (const Track& track : tracks) {
+        m_trackList.push_back(buildTrackItem(track));
+    }
+
+    endResetModel();
+    onSelectedTracks(selectionController()->selectedTracks());
 
     emit isEmptyChanged();
     emit isAddingAvailableChanged(true);
@@ -285,8 +284,6 @@ void TracksListModel::clear()
 
 void TracksListModel::deleteItems()
 {
-    m_selectionModel->clear();
-
     for (TrackItem* trackItem : m_trackList) {
         trackItem->deleteLater();
     }

--- a/src/projectscene/view/trackspanel/trackslistmodel.h
+++ b/src/projectscene/view/trackspanel/trackslistmodel.h
@@ -90,6 +90,7 @@ private:
 
     bool isProjectOpened() const;
 
+    void loadTracks(const std::vector<trackedit::Track>& tracks);
     bool removeRows(int row, int count, const QModelIndex& parent) override;
 
     void onProjectChanged();

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -39,6 +39,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3projecthistory.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3trackeditclipboard.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3trackeditclipboard.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/selectionrestorer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/selectionrestorer.h
     )
 
 # AU3

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -53,7 +53,6 @@ void Au3SelectionController::init()
             restorer.selectionSetter = [this](const ClipAndTimeSelection& selection) {
                 restoreSelection(selection);
             };
-
         } else {
             m_tracksSubc.Reset();
         }
@@ -247,7 +246,7 @@ ClipKeyList Au3SelectionController::selectedClipsInTrackOrder() const
     return sortedSelectedClips;
 }
 
-void Au3SelectionController::setSelectedClips(const ClipKeyList& clipKeys, bool complete)
+void Au3SelectionController::setSelectedClips(const ClipKeyList& clipKeys, bool complete, bool modifyState)
 {
     m_selectedClips.set(clipKeys, complete);
 
@@ -261,17 +260,9 @@ void Au3SelectionController::setSelectedClips(const ClipKeyList& clipKeys, bool 
         selectedTracks.push_back(key.trackId);
     }
     setSelectedTracks(selectedTracks, complete);
-}
-
-std::optional<au::trackedit::ClipId> Au3SelectionController::setSelectedClip(trackedit::TrackId trackId, secs_t time)
-{
-    const auto& clip = au3::DomAccessor::findWaveClip(projectRef(), trackId, time);
-    if (!clip) {
-        return std::nullopt;
+    if (complete && modifyState) {
+        projectHistory()->modifyState();
     }
-
-    setSelectedClips({ { trackId, clip->GetId() } }, true);
-    return clip->GetId();
 }
 
 void Au3SelectionController::addSelectedClip(const ClipKey& clipKey)

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -2,6 +2,7 @@
 * Audacity: A Digital Audio Editor
 */
 #include "au3selectioncontroller.h"
+#include "selectionrestorer.h"
 
 #include "global/containers.h"
 #include "global/realfn.h"
@@ -35,20 +36,38 @@ void Au3SelectionController::init()
         resetDataSelection();
 
         if (prj) {
-            //! NOTE: sync selectionControler with internal project state if trackList changed
-            auto trackList = &Au3TrackList::Get(projectRef());
-            m_tracksSubc = trackList->Subscribe([this](const TrackListEvent&) {
-                updateSelectionController();
-            });
-
             //! NOTE: load project's last saved selection state
             auto& selectedRegion = ViewInfo::Get(projectRef()).selectedRegion;
             m_selectedStartTime.set(selectedRegion.t0(), true);
             m_selectedEndTime.set(selectedRegion.t1(), true);
+
+            auto& restorer = SelectionRestorer::Get(projectRef());
+            restorer.selectionGetter = [this] {
+                return ClipAndTimeSelection {
+                    m_selectedClips.val,
+                    m_selectedStartTime.val,
+                    m_selectedEndTime.val
+                };
+            };
+
+            restorer.selectionSetter = [this](const ClipAndTimeSelection& selection) {
+                restoreSelection(selection);
+            };
+
         } else {
             m_tracksSubc.Reset();
         }
     });
+}
+
+void Au3SelectionController::restoreSelection(const ClipAndTimeSelection& selection)
+{
+    MYLOG() << "restoreSelection";
+
+    m_selectedClips.set(selection.selectedClips, true);
+    m_selectedStartTime.set(selection.dataSelectedStartTime, true);
+    m_selectedEndTime.set(selection.dataSelectedEndTime, true);
+    updateSelectionController();
 }
 
 void Au3SelectionController::resetSelectedTracks()

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../../iselectioncontroller.h"
+#include "../../iprojecthistory.h"
 
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
@@ -21,6 +22,7 @@ class Au3SelectionController : public ISelectionController, public muse::async::
 {
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<au::playback::IPlayback> playback;
+    muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
     Au3SelectionController() = default;
@@ -30,7 +32,7 @@ public:
     // track selection
     void resetSelectedTracks() override;
     trackedit::TrackIdList selectedTracks() const override;
-    void setSelectedTracks(const trackedit::TrackIdList& trackIds, bool complete = true) override;
+    void setSelectedTracks(const trackedit::TrackIdList& trackIds, bool complete) override;
     void addSelectedTrack(const trackedit::TrackId& trackId) override;
     muse::async::Channel<trackedit::TrackIdList> tracksSelected() const override;
     std::optional<TrackId> determinePointedTrack(double y) const override;
@@ -41,8 +43,7 @@ public:
     bool hasSelectedClips() const override;
     ClipKeyList selectedClips() const override;
     ClipKeyList selectedClipsInTrackOrder() const override;
-    void setSelectedClips(const ClipKeyList& clipKeys, bool complete = true) override;
-    std::optional<trackedit::ClipId> setSelectedClip(trackedit::TrackId trackId, secs_t time) override;
+    void setSelectedClips(const ClipKeyList& clipKeys, bool complete, bool modifyState) override;
     void addSelectedClip(const ClipKey& clipKey) override;
     void removeClipSelection(const ClipKey& clipKey) override;
     muse::async::Channel<ClipKeyList> clipsSelected() const override;

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -15,6 +15,8 @@
 #include "au3wrap/au3types.h"
 
 namespace au::trackedit {
+struct ClipAndTimeSelection;
+
 class Au3SelectionController : public ISelectionController, public muse::async::Asyncable
 {
     muse::Inject<au::context::IGlobalContext> globalContext;
@@ -75,6 +77,7 @@ public:
 
 private:
     void updateSelectionController();
+    void restoreSelection(const ClipAndTimeSelection& selection);
 
     au3::Au3Project& projectRef() const;
     Observer::Subscription m_tracksSubc;

--- a/src/trackedit/internal/au3/selectionrestorer.cpp
+++ b/src/trackedit/internal/au3/selectionrestorer.cpp
@@ -1,0 +1,43 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "selectionrestorer.h"
+
+#include "libraries/lib-project-history/UndoManager.h"
+#include "libraries/lib-project/Project.h"
+
+namespace au::trackedit {
+static const ::AudacityProject::AttachedObjects::RegisteredFactory key{
+    [](AudacityProject&)
+    {
+        return std::make_shared<SelectionRestorer>();
+    } };
+
+SelectionRestorer& SelectionRestorer::Get(AudacityProject& project)
+{
+    return project.AttachedObjects::Get<SelectionRestorer>(key);
+}
+
+class ClipAndTimeSelectionState final : public UndoStateExtension
+{
+public:
+    ClipAndTimeSelectionState(AudacityProject& project)
+        : m_selection(SelectionRestorer::Get(project).selectionGetter())
+    {
+    }
+
+private:
+    void RestoreUndoRedoState(AudacityProject& project) override
+    {
+        SelectionRestorer::Get(project).selectionSetter(m_selection);
+    }
+
+    const ClipAndTimeSelection m_selection;
+};
+
+UndoRedoExtensionRegistry::Entry sEntry {
+    [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
+        return std::make_shared<ClipAndTimeSelectionState>(project);
+    }
+};
+}

--- a/src/trackedit/internal/au3/selectionrestorer.h
+++ b/src/trackedit/internal/au3/selectionrestorer.h
@@ -1,0 +1,24 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "../../trackedittypes.h"
+#include "libraries/lib-registries/ClientData.h"
+
+class AudacityProject;
+
+namespace au::trackedit {
+struct ClipAndTimeSelection {
+    const ClipKeyList selectedClips;
+    const secs_t dataSelectedStartTime;
+    const secs_t dataSelectedEndTime;
+};
+
+struct SelectionRestorer : public ClientData::Base
+{
+    static SelectionRestorer& Get(AudacityProject& project);
+    std::function<ClipAndTimeSelection()> selectionGetter;
+    std::function<void(const ClipAndTimeSelection&)> selectionSetter;
+};
+}

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -38,8 +38,8 @@ public:
     virtual bool hasSelectedClips() const = 0;
     virtual ClipKeyList selectedClips() const = 0;
     virtual ClipKeyList selectedClipsInTrackOrder() const = 0;
-    virtual void setSelectedClips(const ClipKeyList& clipKeys, bool complete = true) = 0;
-    virtual std::optional<ClipId> setSelectedClip(trackedit::TrackId trackId, secs_t time) = 0;
+    //! Note: history state gets modified only if both `complete` and `modifyState` are true
+    virtual void setSelectedClips(const ClipKeyList& clipKeys, bool complete = true, bool modifyState = false) = 0;
     virtual void addSelectedClip(const ClipKey& clipKey) = 0;
     virtual void removeClipSelection(const ClipKey& clipKey) = 0;
     virtual muse::async::Channel<ClipKeyList> clipsSelected() const = 0;

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -24,8 +24,7 @@ public:
     MOCK_METHOD(bool, hasSelectedClips, (), (const, override));
     MOCK_METHOD(ClipKeyList, selectedClips, (), (const, override));
     MOCK_METHOD(ClipKeyList, selectedClipsInTrackOrder, (), (const, override));
-    MOCK_METHOD(void, setSelectedClips, (const ClipKeyList&, bool), (override));
-    MOCK_METHOD(std::optional<ClipId>, setSelectedClip, (trackedit::TrackId, secs_t), (override));
+    MOCK_METHOD(void, setSelectedClips, (const ClipKeyList&, bool, bool), (override));
     MOCK_METHOD(void, addSelectedClip, (const ClipKey& clipKey), (override));
     MOCK_METHOD(muse::async::Channel<ClipKeyList>, clipsSelected, (), (const, override));
     MOCK_METHOD(double, selectedClipStartTime, (), (const, override));


### PR DESCRIPTION
Resolves: #8088

`TracksListModel::deleteItems()`, called when undo/redo happens, calls `m_selectionModel->clear();`, which has for side effect to clear the selection, which in itself is a problem, but also it interfers with destructive effect workflows, which depend on selection.

Removing this call fixes the selection and effect issues, and I could not notice that it caused other sorts of undesired side effects.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] fixes #8088
- [x] Undo/Redo does not reset the selection like it used to
