### PR TITLE
Get effects dialog: set a default button for the dialog

### DIFF
--- a/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
+++ b/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
@@ -72,13 +72,24 @@ GetEffectsDialog::GetEffectsDialog(wxWindow *parent) :
    wxBoxSizer* vSizer = new wxBoxSizer(wxVERTICAL);
    vSizer->Add(m_treebook, 1, wxEXPAND);
 
+   // Needed so that when the tree is the focus, pressing the Enter key
+   // does close the dialog, in accordance with the OK button being
+   // the default button.
+   m_treebook->Bind(wxEVT_TREE_KEY_DOWN, [this](wxTreeEvent& event) {
+      if (event.GetKeyCode() == WXK_RETURN)
+         EndModal(wxID_OK);
+      else
+         event.Skip();
+      });
+
    wxPanel* bottomPanel = new wxPanel(this, wxID_ANY);
    wxBoxSizer* hSizer = new wxBoxSizer(wxHORIZONTAL);
 
    hSizer->AddStretchSpacer(1);
 
-   auto* okButton = new GradientButton(bottomPanel, wxID_OK, XO("OK").Translation());
+   auto* okButton = new wxButton(bottomPanel, wxID_OK, XO("OK").Translation());
    hSizer->Add(okButton, 0, wxALL, 10);
+   okButton->SetDefault();
 
    bottomPanel->SetSizer(hSizer);
    vSizer->Add(bottomPanel, 0, wxEXPAND | wxBOTTOM | wxLEFT | wxRIGHT, 0);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8258

Problem:
No button is set as the default button:

Fix:
1. Set the OK button to be the default button.
2. Change the OK button to be a wxButton rather than a Gradient button. This was done because a Gradient button does not currently give any visual indication when it is a default button, and it not obvious that this could easily be fixed.
3. Handle the wxEVT_TREE_KEY_DOWN event so that when the tree is the focus, pressing the Enter key closes the dialog. Similar code to this is used in the Preferences dialog.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
