### PR TITLE
7722 mute and solo implementation

### DIFF
--- a/src/au3audio/audiotypes.h
+++ b/src/au3audio/audiotypes.h
@@ -26,15 +26,13 @@ struct AudioOutputParams {
     balance_t balance = 0.f;
     bool solo = false;
     bool muted = false;
-    bool forceMute = false;
 
     bool operator ==(const AudioOutputParams& other) const
     {
         return muse::RealIsEqual(volume, other.volume)
                && muse::RealIsEqual(balance, other.balance)
                && solo == other.solo
-               && muted == other.muted
-               && forceMute == other.forceMute;
+               && muted == other.muted;
     }
 };
 }

--- a/src/playback/internal/au3/au3trackplaybackcontrol.h
+++ b/src/playback/internal/au3/au3trackplaybackcontrol.h
@@ -6,6 +6,7 @@
 #include "itrackplaybackcontrol.h"
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "trackedit/iprojecthistory.h"
 
 #include "au3wrap/au3types.h"
 
@@ -16,16 +17,27 @@ using au::audio::balance_t;
 class Au3TrackPlaybackControl : public ITrackPlaybackControl
 {
     muse::Inject<au::context::IGlobalContext> globalContext;
+    muse::Inject<au::trackedit::IProjectHistory> projectHistory;
 
 public:
     Au3TrackPlaybackControl() = default;
-    volume_dbfs_t volume(long trackId) override;
-    void setVolume(long trackId, volume_dbfs_t vol) override;
+    volume_dbfs_t volume(long trackId) const override;
+    void setVolume(long trackId, volume_dbfs_t vol, bool completed) override;
 
-    balance_t balance(long trackId) override;
-    void setBalance(long trackId, balance_t balance) override;
+    balance_t balance(long trackId) const override;
+    void setBalance(long trackId, au::audio::balance_t balance, bool completed) override;
+
+    bool solo(long trackId) const override;
+    void setSolo(long trackId, bool solo) override;
+
+    bool muted(long trackId) const override;
+    void setMuted(long trackId, bool mute) override;
+
+    muse::async::Channel<long> muteOrSoloChanged() const override;
 
 private:
     au3::Au3Project& projectRef() const;
+
+    muse::async::Channel<long> m_muteOrSoloChanged;
 };
 }

--- a/src/playback/itrackplaybackcontrol.h
+++ b/src/playback/itrackplaybackcontrol.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "au3audio/audiotypes.h"
+#include "async/channel.h"
 #include "modularity/imoduleinterface.h"
 
 namespace au::playback {
@@ -15,10 +16,18 @@ class ITrackPlaybackControl : MODULE_EXPORT_INTERFACE
 public:
     virtual ~ITrackPlaybackControl() = default;
 
-    virtual void setVolume(long trackId, au::audio::volume_dbfs_t volume) = 0;
-    virtual au::audio::volume_dbfs_t volume(long trackId) = 0;
+    virtual void setVolume(long trackId, au::audio::volume_dbfs_t volume, bool completed) = 0;
+    virtual au::audio::volume_dbfs_t volume(long trackId) const = 0;
 
-    virtual void setBalance(long trackId, au::audio::balance_t balance) = 0;
-    virtual au::audio::balance_t balance(long trackId) = 0;
+    virtual void setBalance(long trackId, au::audio::balance_t balance, bool completed) = 0;
+    virtual au::audio::balance_t balance(long trackId) const = 0;
+
+    virtual void setSolo(long trackId, bool solo) = 0;
+    virtual bool solo(long trackId) const = 0;
+
+    virtual void setMuted(long trackId, bool mute) = 0;
+    virtual bool muted(long trackId) const = 0;
+
+    virtual muse::async::Channel<long> muteOrSoloChanged() const = 0;
 };
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -31,6 +31,7 @@ Rectangle {
     property bool isMultiSelectionActive: false
     property bool multiClipsSelected: root.isMultiSelectionActive && root.clipSelected
     property bool moveActive: false
+    property bool isAudible: true
     property real selectionStart: 0
     property real selectionWidth: 0
 
@@ -77,7 +78,7 @@ Rectangle {
     radius: 4
     color: clipSelected ? "white" : clipColor
     border.color: "#000000"
-    opacity: root.moveActive && clipSelected ? 0.5 : 1.0
+    opacity: root.moveActive && clipSelected ? 0.5 : isAudible ? 1.0 : 0.3
 
     property int borderWidth: 1
     property bool hover: hoverArea.containsMouse || headerDragArea.containsMouse

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -16,6 +16,7 @@ Item {
     property bool isDataSelected: false
     property bool isTrackSelected: false
     property bool isMultiSelectionActive: false
+    property bool isTrackAudible: true
     property bool isStereo: clipsModel.isStereo
     property double channelHeightRatio: isStereo ? 0.5 : 1
     property bool moveActive: false
@@ -125,7 +126,7 @@ Item {
             onDoubleClicked: function(e) {
                 e.accepted = false
             }
-            
+
             onPressAndHold: function(e) {
                 if (clipsContainer.isNearSample) {
                     clipsContainer.multiSampleEdit = true
@@ -229,6 +230,7 @@ Item {
                 isMultiSelectionActive: root.isMultiSelectionActive
                 isDataSelected: root.isDataSelected
                 moveActive: root.moveActive
+                isAudible: root.isTrackAudible
                 multiSampleEdit: clipsContainer.multiSampleEdit
                 altPressed: root.altPressed
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -455,6 +455,7 @@ Rectangle {
                     isDataSelected: model.isDataSelected
                     isTrackSelected: model.isTrackSelected
                     isMultiSelectionActive: model.isMultiSelectionActive
+                    isTrackAudible: model.isTrackAudible
                     moveActive: tracksClipsView.moveActive
                     underSelection: root.underSelection
                     altPressed: root.altPressed

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -199,16 +199,16 @@ ListItemBlank {
                 BalanceKnob {
                     value: root.item.balance
 
-                    onNewValueRequested: function(newValue) {
-                        root.item.balance = newValue
+                    onNewBalanceRequested: function(newValue, completed) {
+                        root.item.setBalance(newValue, completed)
                     }
                 }
 
                 VolumeSlider {
                     value: root.item.volumeLevel
 
-                    onValueChanged: {
-                        root.item.volumeLevel = value
+                    onNewVolumeRequested: function(newValue, completed) {
+                        root.item.setVolumeLevel(newValue, completed)
                     }
                 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/BalanceKnob.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/BalanceKnob.qml
@@ -15,6 +15,12 @@ KnobControl {
     to: 100
     stepSize: 1
 
+    signal newBalanceRequested(real volume, bool completed)
+
+    onNewValueRequested: function(value) {
+        newBalanceRequested(value, false)
+    }
+
     BalanceTooltip {
         id: tooltip
         value: root.value
@@ -30,5 +36,13 @@ KnobControl {
 
     onMouseExited: {
         tooltip.hide(true)
+    }
+
+    onMouseReleased: {
+        newBalanceRequested(root.value, true)
+    }
+
+    mouseArea.onDoubleClicked: {
+        newBalanceRequested(root.value = 0, true)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/VolumeSlider.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/audio/VolumeSlider.qml
@@ -13,8 +13,14 @@ StyledSlider {
     property double snapPoint: 0.0
     property double snapRange: 2.0
 
+    signal newVolumeRequested(real volume, bool completed)
+
     from: -60.0
     to: 12.0
+
+    onValueChanged: {
+        newVolumeRequested(value, false)
+    }
 
     QtObject {
         id: prv
@@ -46,11 +52,16 @@ StyledSlider {
             tooltip.show(true)
         }
 
+        onDoubleClicked: {
+            root.newVolumeRequested(root.value = 0, true)
+        }
+
         onReleased: {
             prv.dragActive = false
             if (!containsMouse) {
                 tooltip.hide(true)
             }
+            root.newVolumeRequested(root.value, true)
         }
 
         onEntered: {

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.h
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.h
@@ -11,6 +11,7 @@
 #include "context/iglobalcontext.h"
 #include "iprojectsceneconfiguration.h"
 #include "trackedit/iselectioncontroller.h"
+#include "playback/itrackplaybackcontrol.h"
 
 #include "trackedit/dom/track.h"
 
@@ -26,6 +27,7 @@ class TracksListClipsModel : public QAbstractListModel, public muse::async::Asyn
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<IProjectSceneConfiguration> configuration;
     muse::Inject<trackedit::ISelectionController> selectionController;
+    muse::Inject<playback::ITrackPlaybackControl> trackPlaybackControl;
 
 public:
 
@@ -57,7 +59,8 @@ private:
         TrackIdRole,
         IsDataSelectedRole,
         IsTrackSelectedRole,
-        IsMultiSelectionActiveRole
+        IsMultiSelectionActiveRole,
+        IsTrackAudibleRole,
     };
 
     void updateTotalTracksHeight();

--- a/src/projectscene/view/trackspanel/trackitem.cpp
+++ b/src/projectscene/view/trackspanel/trackitem.cpp
@@ -42,10 +42,32 @@ void TrackItem::init(const trackedit::Track& track)
     m_trackId = track.id;
     m_trackType = track.type;
     m_title = track.title;
+    const auto ctrl = trackPlaybackControl();
     if (m_trackType != trackedit::TrackType::Label) {
-        m_outParams.volume = trackPlaybackControl()->volume(m_trackId);
-        m_outParams.balance = trackPlaybackControl()->balance(m_trackId);
+        m_outParams.volume = ctrl->volume(m_trackId);
+        m_outParams.balance = ctrl->balance(m_trackId);
+        m_outParams.solo = ctrl->solo(m_trackId);
+        m_outParams.muted = ctrl->muted(m_trackId);
     }
+    ctrl->muteOrSoloChanged().onReceive(this, [this](long trackId) {
+        if (trackId != m_trackId) {
+            return;
+        }
+        auto paramChanged = false;
+        if (m_outParams.solo != trackPlaybackControl()->solo(m_trackId)) {
+            m_outParams.solo = !m_outParams.solo;
+            paramChanged = true;
+            emit soloChanged();
+        }
+        if (m_outParams.muted != trackPlaybackControl()->muted(m_trackId)) {
+            m_outParams.muted = !m_outParams.muted;
+            paramChanged = true;
+            emit mutedChanged();
+        }
+        if (paramChanged) {
+            emit outputParamsChanged(m_outParams);
+        }
+    });
 }
 
 au::trackedit::TrackId TrackItem::trackId() const
@@ -138,19 +160,6 @@ void TrackItem::loadOutputParams(const audio::AudioOutputParams& newParams)
     }
 }
 
-// void TrackItem::loadSoloMuteState(const project::IProjectSoloMuteState::SoloMuteState& newState)
-// {
-//     if (m_outParams.muted != newState.mute) {
-//         m_outParams.muted = newState.mute;
-//         emit mutedChanged();
-//     }
-
-//     if (m_outParams.solo != newState.solo) {
-//         m_outParams.solo = newState.solo;
-//         emit soloChanged();
-//     }
-// }
-
 // void TrackItem::subscribeOnAudioSignalChanges(AudioSignalChanges&& audioSignalChanges)
 // {
 //     m_audioSignalChanges = audioSignalChanges;
@@ -204,70 +213,39 @@ void TrackItem::setRightChannelPressure(float rightChannelPressure)
     emit rightChannelPressureChanged(m_rightChannelPressure);
 }
 
-void TrackItem::setVolumeLevel(float volumeLevel)
+void TrackItem::setVolumeLevel(float volumeLevel, bool completed)
 {
-    if (qFuzzyCompare(m_outParams.volume, volumeLevel)) {
+    trackPlaybackControl()->setVolume(trackId(), volumeLevel, completed);
+
+    if (m_outParams.volume == volumeLevel) {
         return;
     }
-
-    trackPlaybackControl()->setVolume(trackId(), volumeLevel);
-
     m_outParams.volume = volumeLevel;
     emit volumeLevelChanged(m_outParams.volume);
     emit outputParamsChanged(m_outParams);
 }
 
-void TrackItem::setBalance(int balance)
+void TrackItem::setBalance(int balance, bool completed)
 {
-    if (m_outParams.balance * BALANCE_SCALING_FACTOR == balance) {
+    const float scaled = balance / BALANCE_SCALING_FACTOR;
+    trackPlaybackControl()->setBalance(trackId(), scaled, completed);
+
+    if (m_outParams.balance == scaled) {
         return;
     }
-
-    trackPlaybackControl()->setBalance(trackId(), balance / BALANCE_SCALING_FACTOR);
-
-    m_outParams.balance = balance / BALANCE_SCALING_FACTOR;
+    m_outParams.balance = scaled;
     emit balanceChanged(balance);
     emit outputParamsChanged(m_outParams);
 }
 
 void TrackItem::setSolo(bool solo)
 {
-    if (m_outParams.solo == solo) {
-        return;
-    }
-
-    m_outParams.solo = solo;
-
-    // project::IProjectSoloMuteState::SoloMuteState soloMuteState;
-    // soloMuteState.mute = m_outParams.muted;
-    // soloMuteState.solo = m_outParams.solo;
-
-    // emit soloMuteStateChanged(soloMuteState);
-    emit soloChanged();
-
-    if (solo && m_outParams.muted) {
-        setMuted(false);
-    }
+    trackPlaybackControl()->setSolo(trackId(), solo);
 }
 
 void TrackItem::setMuted(bool mute)
 {
-    if (m_outParams.muted == mute) {
-        return;
-    }
-
-    m_outParams.muted = mute;
-
-    // project::IProjectSoloMuteState::SoloMuteState soloMuteState;
-    // soloMuteState.mute = m_outParams.muted;
-    // soloMuteState.solo = m_outParams.solo;
-
-    // emit soloMuteStateChanged(soloMuteState);
-    emit mutedChanged();
-
-    if (mute && m_outParams.solo) {
-        setSolo(false);
-    }
+    trackPlaybackControl()->setMuted(trackId(), mute);
 }
 
 void TrackItem::setAudioChannelVolumePressure(const trackedit::audioch_t chNum, const float newValue)

--- a/src/projectscene/view/trackspanel/trackitem.cpp
+++ b/src/projectscene/view/trackspanel/trackitem.cpp
@@ -127,11 +127,6 @@ bool TrackItem::muted() const
     return m_outParams.muted;
 }
 
-bool TrackItem::forceMute() const
-{
-    return m_outParams.forceMute;
-}
-
 void TrackItem::loadOutputParams(const audio::AudioOutputParams& newParams)
 {
     if (!muse::RealIsEqual(m_outParams.volume, newParams.volume)) {
@@ -152,11 +147,6 @@ void TrackItem::loadOutputParams(const audio::AudioOutputParams& newParams)
     if (m_outParams.muted != newParams.muted) {
         m_outParams.muted = newParams.muted;
         emit mutedChanged();
-    }
-
-    if (m_outParams.forceMute != newParams.forceMute) {
-        m_outParams.forceMute = newParams.forceMute;
-        emit forceMuteChanged();
     }
 }
 

--- a/src/projectscene/view/trackspanel/trackitem.h
+++ b/src/projectscene/view/trackspanel/trackitem.h
@@ -29,8 +29,8 @@ class TrackItem : public QObject, public muse::async::Asyncable
     Q_PROPERTY(float leftChannelPressure READ leftChannelPressure NOTIFY leftChannelPressureChanged)
     Q_PROPERTY(float rightChannelPressure READ rightChannelPressure NOTIFY rightChannelPressureChanged)
 
-    Q_PROPERTY(float volumeLevel READ volumeLevel WRITE setVolumeLevel NOTIFY volumeLevelChanged)
-    Q_PROPERTY(int balance READ balance WRITE setBalance NOTIFY balanceChanged)
+    Q_PROPERTY(float volumeLevel READ volumeLevel NOTIFY volumeLevelChanged)
+    Q_PROPERTY(int balance READ balance NOTIFY balanceChanged)
     Q_PROPERTY(bool solo READ solo WRITE setSolo NOTIFY soloChanged)
     Q_PROPERTY(bool muted READ muted WRITE setMuted NOTIFY mutedChanged)
     Q_PROPERTY(bool forceMute READ forceMute NOTIFY forceMuteChanged)
@@ -56,7 +56,11 @@ public:
     float rightChannelPressure() const;
 
     float volumeLevel() const;
+    Q_INVOKABLE void setVolumeLevel(float volumeLevel, bool completed);
+
     int balance() const;
+    Q_INVOKABLE void setBalance(int balance, bool completed);
+
     bool solo() const;
     bool muted() const;
     bool forceMute() const;
@@ -80,8 +84,6 @@ public slots:
     void setLeftChannelPressure(float leftChannelPressure);
     void setRightChannelPressure(float rightChannelPressure);
 
-    void setVolumeLevel(float volumeLevel);
-    void setBalance(int balance);
     void setSolo(bool solo);
     void setMuted(bool mute);
 

--- a/src/projectscene/view/trackspanel/trackitem.h
+++ b/src/projectscene/view/trackspanel/trackitem.h
@@ -33,7 +33,6 @@ class TrackItem : public QObject, public muse::async::Asyncable
     Q_PROPERTY(int balance READ balance NOTIFY balanceChanged)
     Q_PROPERTY(bool solo READ solo WRITE setSolo NOTIFY soloChanged)
     Q_PROPERTY(bool muted READ muted WRITE setMuted NOTIFY mutedChanged)
-    Q_PROPERTY(bool forceMute READ forceMute NOTIFY forceMuteChanged)
 
     Q_PROPERTY(bool isSelected READ isSelected NOTIFY isSelectedChanged)
 
@@ -63,7 +62,6 @@ public:
 
     bool solo() const;
     bool muted() const;
-    bool forceMute() const;
 
     void loadOutputParams(const audio::AudioOutputParams& newParams);
 
@@ -97,7 +95,6 @@ signals:
     void balanceChanged(int balance);
     void soloChanged();
     void mutedChanged();
-    void forceMuteChanged();
 
     void outputParamsChanged(const audio::AudioOutputParams& params);
 


### PR DESCRIPTION
Resolves: #7722

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] changing a track's controls (volume, balance, mute, solo) makes the project dirty
- [x] the state of track controls is restored correctly when closing and re-opening a project
- [x] Mute & Solo is now implemented, please test feature thoroughly
- [x] Double-clicking on volume or balance resets to middle
- [x] Follows [Figma spec](https://www.figma.com/design/k5rS9tnZl60nYmhJhvI2vf/Track-headers?node-id=263-33437&t=kXBP8PLYRLD6twvK-4)