### PR TITLE
Boy-scouting on clips and tracks list models, and minor optimisations to avoid copying in lambda arguments.

### DIFF
--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -184,7 +184,7 @@ void ClipsListModel::update()
     m_clipList.clear();
 
     for (const au::trackedit::Clip& c : m_allClipList) {
-        ClipListItem* item = new ClipListItem(this);
+        auto* item = new ClipListItem(this);
         item->setClip(c);
         m_clipList.append(item);
         isStereo |= c.stereo;
@@ -864,7 +864,7 @@ void ClipsListModel::setTimelineContext(TimelineContext* newContext)
     emit timelineContextChanged();
 }
 
-int ClipsListModel::cacheBufferPx() const
+int ClipsListModel::cacheBufferPx()
 {
     return CACHE_BUFFER_PX;
 }

--- a/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/src/projectscene/view/clipsview/clipslistmodel.h
@@ -39,15 +39,13 @@ class ClipsListModel : public QAbstractListModel, public muse::async::Asyncable,
     muse::Inject<trackedit::ISelectionController> selectionController;
 
 public:
-    ClipsListModel(QObject* parent = nullptr);
-    ~ClipsListModel();
+    explicit ClipsListModel(QObject* parent = nullptr);
+    ~ClipsListModel() override;
 
     TimelineContext* timelineContext() const;
     void setTimelineContext(TimelineContext* newContext);
     QVariant trackId() const;
     void setTrackId(const QVariant& newTrackId);
-    int selectedClipIdx() const;
-    void setSelectedClipIdx(int newSelectedClipIdx);
     bool isStereo() const;
 
     Q_INVOKABLE void init();
@@ -82,7 +80,7 @@ public:
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex& index, int role) const override;
 
-    int cacheBufferPx() const;
+    static int cacheBufferPx();
 
 signals:
     void trackIdChanged();

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
@@ -35,13 +35,17 @@ void TracksListClipsModel::load()
         if (m_trackList.empty()) {
             return;
         }
-        emit dataChanged(index(0), index(m_trackList.size() - 1), { IsTrackSelectedRole });
-        emit dataChanged(index(0), index(m_trackList.size() - 1), { IsDataSelectedRole });
+
+        const int lastIndex = static_cast<int>(m_trackList.size()) - 1;
+        emit dataChanged(index(0), index(lastIndex), { IsTrackSelectedRole });
+        emit dataChanged(index(0), index(lastIndex), { IsDataSelectedRole });
     });
 
     selectionController()->clipsSelected().onReceive(this, [this](const trackedit::ClipKeyList& clipKeys) {
         Q_UNUSED(clipKeys);
-        emit dataChanged(index(0), index(m_trackList.size() - 1), { IsMultiSelectionActiveRole });
+
+        const int lastIndex = static_cast<int>(m_trackList.size()) - 1;
+        emit dataChanged(index(0), index(lastIndex), { IsMultiSelectionActiveRole });
     });
 
     selectionController()->dataSelectedStartTimeChanged().onReceive(this, [this](trackedit::secs_t begin) {
@@ -49,7 +53,9 @@ void TracksListClipsModel::load()
         if (m_trackList.empty()) {
             return;
         }
-        emit dataChanged(index(0), index(m_trackList.size() - 1), { IsDataSelectedRole });
+
+        const int lastIndex = static_cast<int>(m_trackList.size()) - 1;
+        emit dataChanged(index(0), index(lastIndex), { IsDataSelectedRole });
     });
 
     selectionController()->dataSelectedEndTimeChanged().onReceive(this, [this](trackedit::secs_t end) {
@@ -57,10 +63,12 @@ void TracksListClipsModel::load()
         if (m_trackList.empty()) {
             return;
         }
-        emit dataChanged(index(0), index(m_trackList.size() - 1), { IsDataSelectedRole });
+
+        const int lastIndex = static_cast<int>(m_trackList.size()) - 1;
+        emit dataChanged(index(0), index(lastIndex), { IsDataSelectedRole });
     });
 
-    prj->tracksChanged().onReceive(this, [this](const std::vector<au::trackedit::Track> tracks) {
+    prj->tracksChanged().onReceive(this, [this](const std::vector<au::trackedit::Track>& tracks) {
         Q_UNUSED(tracks);
         muse::async::Async::call(this, [this]() {
             load();
@@ -68,7 +76,8 @@ void TracksListClipsModel::load()
     });
 
     prj->trackAdded().onReceive(this, [this](const trackedit::Track& track) {
-        beginInsertRows(QModelIndex(), m_trackList.size(), m_trackList.size());
+        const int size = static_cast<int>(m_trackList.size());
+        beginInsertRows(QModelIndex(), size, size);
         m_trackList.push_back(track);
         endInsertRows();
 
@@ -77,7 +86,8 @@ void TracksListClipsModel::load()
     });
 
     prj->trackInserted().onReceive(this, [this](const trackedit::Track& track, const int pos) {
-        int index = pos >= 0 && pos <= static_cast<int>(m_trackList.size()) ? pos : m_trackList.size();
+        const int size = static_cast<int>(m_trackList.size());
+        const int index = ((pos >= 0) && (pos <= size)) ? pos : size;
 
         beginInsertRows(QModelIndex(), index, index);
         m_trackList.insert(m_trackList.begin() + index, track);
@@ -89,17 +99,20 @@ void TracksListClipsModel::load()
     });
 
     prj->trackMoved().onReceive(this, [this](const trackedit::Track& track, const int pos) {
-        auto it = std::find_if(m_trackList.begin(), m_trackList.end(), [&track](const trackedit::Track& it) { return it.id == track.id; });
+        const auto iterator = std::find_if(m_trackList.begin(), m_trackList.end(), [&track](const trackedit::Track& it)
+        {
+            return it.id == track.id;
+        });
 
-        if (it == m_trackList.end()) {
+        if (iterator == m_trackList.end()) {
             return;
         }
 
-        int from = std::distance(m_trackList.begin(), it);
-        int to = std::clamp(pos, 0, static_cast<int>(m_trackList.size()));
+        const int from = static_cast<int>(std::distance(m_trackList.begin(), iterator));
+        const int to = std::clamp(pos, 0, static_cast<int>(m_trackList.size()));
 
         beginMoveRows(QModelIndex(), from, from, QModelIndex(), to > from ? to + 1 : to);
-        m_trackList.erase(it);
+        m_trackList.erase(iterator);
         m_trackList.insert(m_trackList.begin() + to, track);
         endMoveRows();
 
@@ -149,7 +162,7 @@ int TracksListClipsModel::rowCount(const QModelIndex&) const
 QVariant TracksListClipsModel::data(const QModelIndex& index, int role) const
 {
     if (!index.isValid()) {
-        return QVariant();
+        return {};
     }
 
     const au::trackedit::Track& track = m_trackList.at(index.row());
@@ -169,7 +182,7 @@ QVariant TracksListClipsModel::data(const QModelIndex& index, int role) const
         break;
     }
 
-    return QVariant();
+    return {};
 }
 
 QHash<int, QByteArray> TracksListClipsModel::roleNames() const
@@ -202,8 +215,8 @@ void TracksListClipsModel::setIsVerticalRulersVisible(bool isVerticalRulersVisib
 
 void TracksListClipsModel::updateTotalTracksHeight()
 {
-    project::IAudacityProjectPtr prj = globalContext()->currentProject();
-    IProjectViewStatePtr viewState = prj ? prj->viewState() : nullptr;
+    const project::IAudacityProjectPtr prj = globalContext()->currentProject();
+    const IProjectViewStatePtr viewState = prj ? prj->viewState() : nullptr;
     if (!viewState) {
         return;
     }
@@ -219,8 +232,8 @@ void TracksListClipsModel::updateTotalTracksHeight()
 
 void TracksListClipsModel::subscribeOnTrackHeightChanges(const trackedit::TrackId trackId)
 {
-    project::IAudacityProjectPtr prj = globalContext()->currentProject();
-    IProjectViewStatePtr viewState = prj ? prj->viewState() : nullptr;
+    const project::IAudacityProjectPtr prj = globalContext()->currentProject();
+    const IProjectViewStatePtr viewState = prj ? prj->viewState() : nullptr;
 
     muse::ValCh<int> trackHeightCh = viewState->trackHeight(trackId);
     trackHeightCh.ch.onReceive(this, [this](int) {
@@ -230,8 +243,8 @@ void TracksListClipsModel::subscribeOnTrackHeightChanges(const trackedit::TrackI
 
 void TracksListClipsModel::unsubscribeFromTrackHeightChanges(const trackedit::TrackId trackId)
 {
-    project::IAudacityProjectPtr prj = globalContext()->currentProject();
-    IProjectViewStatePtr viewState = prj ? prj->viewState() : nullptr;
+    const project::IAudacityProjectPtr prj = globalContext()->currentProject();
+    const IProjectViewStatePtr viewState = prj ? prj->viewState() : nullptr;
     viewState->trackHeight(trackId).ch.resetOnReceive(this);
 }
 

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.h
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.h
@@ -28,8 +28,7 @@ class TracksListClipsModel : public QAbstractListModel, public muse::async::Asyn
     muse::Inject<trackedit::ISelectionController> selectionController;
 
 public:
-
-    TracksListClipsModel(QObject* parent = nullptr);
+    explicit TracksListClipsModel(QObject* parent = nullptr);
 
     Q_INVOKABLE void load();
 

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -69,12 +69,12 @@ void TracksListModel::load()
     beginResetModel();
     deleteItems();
 
-    ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     if (!prj) {
         return;
     }
 
-    std::vector<Track> tracks = prj->trackList();
+    const std::vector<Track> tracks = prj->trackList();
 
     for (const Track& track : tracks) {
         m_trackList.push_back(buildTrackItem(track));
@@ -82,8 +82,8 @@ void TracksListModel::load()
 
     onSelectedTracks(selectionController()->selectedTracks());
 
-    prj->tracksChanged().onReceive(this, [this](std::vector<au::trackedit::Track> tracks) {
-        onTracksChanged(tracks);
+    prj->tracksChanged().onReceive(this, [this](const std::vector<au::trackedit::Track>& tr) {
+        onTracksChanged(tr);
     });
 
     prj->trackAdded().onReceive(this, [this](const Track& track) {
@@ -501,7 +501,7 @@ void TracksListModel::onProjectChanged()
 
 TrackItem* TracksListModel::buildTrackItem(const Track& track)
 {
-    TrackItem* item = new TrackItem(this);
+    auto item = new TrackItem(this);
     item->init(track);
 
     return item;
@@ -576,7 +576,8 @@ void TracksListModel::onTracksChanged(const std::vector<au::trackedit::Track>& t
 
 void TracksListModel::onTrackAdded(const trackedit::Track& track)
 {
-    beginInsertRows(QModelIndex(), m_trackList.size(), m_trackList.size());
+    const int size = static_cast<int>(m_trackList.size());
+    beginInsertRows(QModelIndex(), size, size);
     m_trackList.push_back(buildTrackItem(track));
     onTrackChanged(track);
     endInsertRows();
@@ -625,8 +626,8 @@ void TracksListModel::onTrackMoved(const trackedit::Track& track, int pos)
         return;
     }
 
-    int from = m_trackList.indexOf(item);
-    int to = std::clamp(pos, 0, static_cast<int>(m_trackList.size()));
+    const int from = static_cast<int>(m_trackList.indexOf(item));
+    const int to = std::clamp(pos, 0, static_cast<int>(m_trackList.size()));
 
     beginMoveRows(QModelIndex(), from, from, QModelIndex(), to > from ? to + 1 : to);
     m_trackList.removeAt(from);

--- a/src/projectscene/view/trackspanel/trackslistmodel.h
+++ b/src/projectscene/view/trackspanel/trackslistmodel.h
@@ -37,7 +37,7 @@ class TracksListModel : public QAbstractListModel, public muse::async::Asyncable
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
 
 public:
-    TracksListModel(QObject* parent = nullptr);
+    explicit TracksListModel(QObject* parent = nullptr);
     ~TracksListModel() override;
 
     Q_INVOKABLE void load();


### PR DESCRIPTION
Relates to (but does not resolve): [[AU4] Improve project state reloading on undo/redo #7328
](https://github.com/audacity/audacity/issues/7328)

I did NOT address the issue in the story - rather I did some cleanup and minor optimisation. Below is my understanding of WHY there isn't much to do:

After reading the code, my conclusion is that this is AU3 legacy that we have to live with for now.

The reason is that the AU3 UndoManager does not follow the (in my view) best practice of the “Command” design pattern (often pairing well together with the “Composite” structure for the model). If that had been done, each “state” stored, could granularly contain only single changes. And when those are undone, notifications could be triggered to relevant “observers”, meaning that only affected elements (in UI or otherwise) would need updating.

But as it is now, the entire state, of all tracks, is stored for each action. And, restored, for each Undo/Redo. So we don’t know what has changed. And thus need to refresh everything.

Concrete example:
1. A clip is dragged 
1.1 The state is stored for each UndoStageExtension
1.1.1 One of these is also the TrackListRestorer - which stores copies of all tracks, not only the modified one(!).
2. Undo is called
2.1 RestoreUndoRedoState is called on each UndoStateExtension
2.1.1 Including TrackListRestorer, which will replace the state of all the tracks.

This is an unsustainable sledgehammer everything-and-the-kitchen-sink approach to undo-redo. 

I’ve looked at ClipsListModel, TracksListClipsModel, and TracksListModel, to see if there’s anything to optimise. The methods invoked in each - necessarily - are those for re-setting the entire view, since the UndoManager doesn’t notify of detailed changes, there’s nothing else to do.

I’ve made some very minor optimisations, but really I don’t see what can be done to vastly improve the performance other than re-implementing the change storage and notification. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
