### PR TITLE
7876 stereo to mono pasting

### DIFF
--- a/au3/libraries/lib-track/Track.cpp
+++ b/au3/libraries/lib-track/Track.cpp
@@ -337,6 +337,21 @@ TrackListHolder TrackList::Create(AudacityProject* pOwner)
     return std::make_shared<TrackList>(pOwner);
 }
 
+TrackListHolder TrackList::Duplicate() const
+{
+    const auto duplicate = TrackList::Create(nullptr);
+    for (auto pTrack : *this) {
+        if (pTrack->GetId() == TrackId{}) {
+            // Don't copy a pending added track
+            continue;
+        }
+        duplicate->Add(
+            pTrack->Duplicate(Track::DuplicateOptions {}.Backup()),
+            TrackList::DoAssignId::No);
+    }
+    return duplicate;
+}
+
 #if 0
 TrackList& TrackList::operator=(TrackList&& that)
 {

--- a/au3/libraries/lib-track/Track.cpp
+++ b/au3/libraries/lib-track/Track.cpp
@@ -564,7 +564,7 @@ void TrackList::Permute(const std::vector<Track*>& tracks)
     PermutationEvent(n);
 }
 
-Track* TrackList::FindById(TrackId id)
+Track* TrackList::FindById(TrackId id) const
 {
     // Linear search.  Tracks in a project are usually very few.
     // Search only the non-pending tracks.

--- a/au3/libraries/lib-track/Track.cpp
+++ b/au3/libraries/lib-track/Track.cpp
@@ -929,10 +929,10 @@ TrackListHolder TrackList::Temporary(AudacityProject* pProject,
     assert(pTrack == nullptr || pTrack->GetOwner() == nullptr);
     // Make a well formed channel group from these tracks
     auto tempList = Create(pProject);
+    tempList->mAssignsIds = false;
     if (pTrack) {
         tempList->Add(pTrack);
     }
-    tempList->mAssignsIds = false;
     return tempList;
 }
 

--- a/au3/libraries/lib-track/Track.h
+++ b/au3/libraries/lib-track/Track.h
@@ -1069,7 +1069,7 @@ public:
      */
     void Permute(const std::vector<Track*>& tracks);
 
-    Track* FindById(TrackId id);
+    Track* FindById(TrackId id) const;
 
     /// Add a Track, giving it a fresh id if `this` is not temporary
     template<typename TrackKind>

--- a/au3/libraries/lib-track/Track.h
+++ b/au3/libraries/lib-track/Track.h
@@ -17,6 +17,7 @@
 #include <list>
 #include <optional>
 #include <functional>
+#include <thread>
 #include <wx/longlong.h>
 
 #include "Channel.h"
@@ -1257,6 +1258,8 @@ private:
     static long sCounter;
 
     AudacityProject* mOwner;
+    //! Needed for debugging purposes - see use in TrackList::QueueEvent
+    const std::thread::id mCtorThread;
 
     //! Whether the list assigns unique ids to added tracks;
     //! false for temporaries

--- a/au3/libraries/lib-track/Track.h
+++ b/au3/libraries/lib-track/Track.h
@@ -906,6 +906,13 @@ public:
     static TrackListHolder Create(AudacityProject* pOwner);
 
     /*!
+     * @brief Creates a copy without an owner.
+     * Refer to the `Track::Clone` overrides of each track type for more detail about
+     * the kind of copy that is made (e.g. deep or shallow).
+     */
+    TrackListHolder Duplicate() const;
+
+    /*!
      @pre `!GetOwner() && !that.GetOwner()`
      */
     void Swap(TrackList& that);

--- a/au3/libraries/lib-track/UndoTracks.cpp
+++ b/au3/libraries/lib-track/UndoTracks.cpp
@@ -16,17 +16,8 @@
 namespace {
 struct TrackListRestorer final : UndoStateExtension {
     TrackListRestorer(AudacityProject& project)
-        : mpTracks{TrackList::Create(nullptr)}
+        : mpTracks{TrackList::Get(project).Duplicate()}
     {
-        for (auto pTrack : TrackList::Get(project)) {
-            if (pTrack->GetId() == TrackId{}) {
-                // Don't copy a pending added track
-                continue;
-            }
-            mpTracks->Add(
-                pTrack->Duplicate(Track::DuplicateOptions {}.Backup()),
-                TrackList::DoAssignId::No);
-        }
     }
 
     void RestoreUndoRedoState(AudacityProject& project) override

--- a/au3/libraries/lib-wave-track/TimeStretching.cpp
+++ b/au3/libraries/lib-wave-track/TimeStretching.cpp
@@ -95,6 +95,8 @@ DEFINE_ATTACHED_VIRTUAL_OVERRIDE(OnWaveTrackProjectTempoChange) {
             pClip->OnProjectTempoChange(oldTempo, newTempo);
         }
 
-        trimRightOverlapping(track);
+        if (oldTempo != newTempo) {
+            trimRightOverlapping(track);
+        }
     };
 }

--- a/au3/libraries/lib-wave-track/WaveClip.h
+++ b/au3/libraries/lib-wave-track/WaveClip.h
@@ -902,6 +902,13 @@ public:
      */
     void MakeStereo(WaveClip&& other, bool mustAlign);
 
+    void MakeStereo();
+
+    /*!
+     * @brief Returns true if the clip is already mono or if it was successfully made mono.
+     */
+    bool MakeMono(const std::function<void(double)>& progress, const std::function<bool()>& cancel);
+
     // These return a nonnegative number of samples meant to size a memory buffer
     size_t GetBestBlockSize(sampleCount t) const;
     size_t GetMaxBlockSize() const;

--- a/au3/libraries/lib-wave-track/WaveTrack.h
+++ b/au3/libraries/lib-wave-track/WaveTrack.h
@@ -371,6 +371,20 @@ public:
     void MakeMono();
 
     /*!
+     * @brief Mixes down to mono by averaging. Returns `true` on complete conversion.
+     * @details Converts all clips to mono by mixdown.
+     * No care is taken to restore the initial state if convertion gets interrupted between clips,
+     * in which case `false` is returned and the track should be disposed of.
+     */
+    bool MixDownToMono(const std::function<void(double)>& progress, const std::function<bool()>& cancel);
+
+    /*!
+     * @brief If stereo/mono, ensures all clips within it are stereo/mono, converting them if necessary.
+     */
+    bool FixClipChannels(
+        const std::function<void(double)>& progress, const std::function<bool()>& cancel);
+
+    /*!
      @pre `!GetOwner()`
      */
     Holder MonoToStereo();

--- a/au3/libraries/lib-wave-track/WaveTrack.h
+++ b/au3/libraries/lib-wave-track/WaveTrack.h
@@ -443,6 +443,12 @@ public:
 
     void SyncLockAdjust(double oldT1, double newT1) override;
 
+    /** @brief Returns true if there are no WaveClips
+     *
+     * @return true if there are no clips in the track, false otherwise.
+     */
+    bool IsEmpty() const;
+
     /** @brief Returns true if there are no WaveClips in the specified region
      *
      * @return true if no clips in the track overlap the specified time range,
@@ -686,6 +692,7 @@ public:
     void InsertInterval(const IntervalHolder& interval, bool newClip, bool allowEmpty = false);
 
     void RemoveInterval(const IntervalHolder& interval);
+    void RemoveInterval(const IntervalConstHolder& interval);
 
     Track::Holder PasteInto(AudacityProject& project, TrackList& list)
     const override;
@@ -896,7 +903,7 @@ public:
      * \brief Creates an unnamed empty WaveTrack with default sample format and default rate
      * \return Orphaned WaveTrack
      */
-    std::shared_ptr<WaveTrack> Create();
+    std::shared_ptr<WaveTrack> Create() const;
 
     /**
      * \brief Creates an unnamed empty WaveTrack with custom sample format and custom rate
@@ -904,7 +911,7 @@ public:
      * \param rate Desired sample rate
      * \return Orphaned WaveTrack
      */
-    std::shared_ptr<WaveTrack> Create(sampleFormat format, double rate);
+    std::shared_ptr<WaveTrack> Create(sampleFormat format, double rate) const;
 
     /**
      * \brief Creates a new track with project's default rate and format and the
@@ -912,13 +919,13 @@ public:
      * @pre `nChannels > 0`
      * @pre `nChannels <= 2`
      */
-    WaveTrack::Holder Create(size_t nChannels);
+    WaveTrack::Holder Create(size_t nChannels) const;
 
     /**
      * \brief Creates tracks with project's default rate and format and the
      * given number of channels.
      */
-    TrackListHolder CreateMany(size_t nChannels);
+    TrackListHolder CreateMany(size_t nChannels) const;
 
     /**
      * \brief Creates a new \p track with specified \p format and
@@ -926,23 +933,23 @@ public:
      * @pre `nChannels > 0`
      * @pre `nChannels <= 2`
      */
-    WaveTrack::Holder Create(size_t nChannels, sampleFormat format, double rate);
+    WaveTrack::Holder Create(size_t nChannels, sampleFormat format, double rate) const;
 
     /**
      * \brief Creates tracks with specified \p format and
      * \p rate and number of channels
      */
-    TrackListHolder CreateMany(size_t nChannels, sampleFormat format, double rate);
+    TrackListHolder CreateMany(size_t nChannels, sampleFormat format, double rate) const;
 
     /**
      * \brief Creates an empty copy of \p proto with the specified number
      * of channels.
      */
-    WaveTrack::Holder Create(size_t nChannels, const WaveTrack& proto);
+    WaveTrack::Holder Create(size_t nChannels, const WaveTrack& proto) const;
 
 private:
     std::shared_ptr<WaveTrack> DoCreate(
-        size_t nChannels, sampleFormat format, double rate);
+        size_t nChannels, sampleFormat format, double rate) const;
 
     const ProjectRate& mRate;
     SampleBlockFactoryPtr mpFactory;

--- a/au3/libraries/lib-wave-track/WaveTrack.h
+++ b/au3/libraries/lib-wave-track/WaveTrack.h
@@ -280,6 +280,13 @@ private:
 
     void RemoveClip(std::ptrdiff_t distance);
 
+    /**
+     * @brief Creates a deep copy of this track, except for the database sample blocks,
+     * shallow-copied (i.e. project size may not increase dramatically).
+     *
+     * @param backup Preserves track IDs if `true`, generates new ones if `false`
+     * @return Track::Holder
+     */
     Track::Holder Clone(bool backup) const override;
 
     friend class WaveTrackFactory;

--- a/src/appshell/CMakeLists.txt
+++ b/src/appshell/CMakeLists.txt
@@ -91,6 +91,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/playbackpreferencesmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/commonaudioapiconfigurationmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/commonaudioapiconfigurationmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/preferences/editpreferencesmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/preferences/editpreferencesmodel.h
     # ${CMAKE_CURRENT_LIST_DIR}/view/preferences/braillepreferencesmodel.cpp
     # ${CMAKE_CURRENT_LIST_DIR}/view/preferences/braillepreferencesmodel.h
 

--- a/src/appshell/appshell.qrc
+++ b/src/appshell/appshell.qrc
@@ -32,6 +32,7 @@
         <file>qml/Preferences/FoldersPreferencesPage.qml</file>
         <file>qml/Preferences/AdvancedPreferencesPage.qml</file>
         <file>qml/Preferences/CanvasPreferencesPage.qml</file>
+        <file>qml/Preferences/EditPreferencesPage.qml</file>
         <file>qml/Preferences/ScorePreferencesPage.qml</file>
         <file>qml/Preferences/ShortcutsPreferencesPage.qml</file>
         <file>qml/Preferences/ImportPreferencesPage.qml</file>
@@ -50,6 +51,7 @@
         <file>qml/Preferences/internal/ImportStyleSection.qml</file>
         <file>qml/Preferences/internal/CharsetsSection.qml</file>
         <file>qml/Preferences/internal/MidiSection.qml</file>
+        <file>qml/Preferences/internal/MonoStereoConversionSection.qml</file>
         <file>qml/Preferences/internal/MusicXmlSection.qml</file>
         <file>qml/Preferences/internal/MidiDevicesSection.qml</file>
         <file>qml/Preferences/internal/AudioEngineSection.qml</file>

--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -44,6 +44,7 @@
 #include "view/firstlaunchsetup/themespagemodel.h"
 #include "view/preferences/preferencesmodel.h"
 #include "view/preferences/generalpreferencesmodel.h"
+#include "view/preferences/editpreferencesmodel.h"
 // #include "view/preferences/updatepreferencesmodel.h"
 #include "view/preferences/appearancepreferencesmodel.h"
 // #include "view/preferences/folderspreferencesmodel.h"
@@ -145,6 +146,7 @@ void AppShellModule::registerUiTypes()
     qmlRegisterType<SettingListModel>("Audacity.Preferences", 1, 0, "SettingListModel");
     qmlRegisterType<PreferencesModel>("Audacity.Preferences", 1, 0, "PreferencesModel");
     qmlRegisterType<GeneralPreferencesModel>("Audacity.Preferences", 1, 0, "GeneralPreferencesModel");
+    qmlRegisterType<EditPreferencesModel>("Audacity.Preferences", 1, 0, "EditPreferencesModel");
     // qmlRegisterType<UpdatePreferencesModel>("MuseScore.Preferences", 1, 0, "UpdatePreferencesModel");
     qmlRegisterType<AppearancePreferencesModel>("Audacity.Preferences", 1, 0, "AppearancePreferencesModel");
     // qmlRegisterType<FoldersPreferencesModel>("MuseScore.Preferences", 1, 0, "FoldersPreferencesModel");

--- a/src/appshell/qml/Preferences/EditPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/EditPreferencesPage.qml
@@ -1,0 +1,37 @@
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import Audacity.Preferences 1.0
+
+import "internal"
+
+PreferencesPage {
+    id: root
+
+    EditPreferencesModel {
+        id: editPreferencesModel
+    }
+
+    Component.onCompleted: {
+        editPreferencesModel.init()
+    }
+
+    Column {
+
+        width: parent.width
+        spacing: root.sectionsSpacing
+
+        MonoStereoConversionSection {
+            id: monoStereoConversionSection
+            askBeforeConverting: editPreferencesModel.askBeforeConvertingToMonoOrStereo
+            navigation.section: root.navigationSection
+            navigation.order: root.navigationOrderStart
+            onAskBeforeConvertingChanged: {
+                editPreferencesModel.askBeforeConvertingToMonoOrStereo = askBeforeConverting
+            }
+         }
+
+        SeparatorLine { }
+    }
+}

--- a/src/appshell/qml/Preferences/internal/MonoStereoConversionSection.qml
+++ b/src/appshell/qml/Preferences/internal/MonoStereoConversionSection.qml
@@ -1,0 +1,30 @@
+
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+BaseSection {
+    id: root
+
+    title: qsTrc("appshell/preferences", "Mono & stereo conversion")
+
+    property bool askBeforeConverting: true
+
+    Column {
+        width: parent.width
+        spacing: 24
+
+        CheckBox {
+            id: checkbox
+            width: parent.width
+            text: qsTrc("appshell/preferences", "Always convert to mono without prompt")
+            checked: !root.askBeforeConverting
+            navigation.name: "StereoToMonoBox"
+            navigation.panel: root.navigation
+            onClicked: {
+                root.askBeforeConverting = !root.askBeforeConverting
+            }
+        }
+    }
+}

--- a/src/appshell/view/preferences/editpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/editpreferencesmodel.cpp
@@ -1,0 +1,27 @@
+#include "editpreferencesmodel.h"
+
+#include "settings.h"
+
+namespace au::appshell {
+EditPreferencesModel::EditPreferencesModel(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void EditPreferencesModel::init()
+{
+    trackeditConfiguration()->askBeforeConvertingToMonoOrStereoChanged().onNotify(this, [this]{
+        emit askBeforeConvertingToMonoOrStereoChanged();
+    });
+}
+
+bool EditPreferencesModel::askBeforeConvertingToMonoOrStereo() const
+{
+    return trackeditConfiguration()->askBeforeConvertingToMonoOrStereo();
+}
+
+void EditPreferencesModel::setAskBeforeConvertingToMonoOrStereo(bool value)
+{
+    trackeditConfiguration()->setAskBeforeConvertingToMonoOrStereo(value);
+}
+}

--- a/src/appshell/view/preferences/editpreferencesmodel.h
+++ b/src/appshell/view/preferences/editpreferencesmodel.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "trackedit/itrackeditconfiguration.h"
+#include "modularity/ioc.h"
+#include "async/asyncable.h"
+
+#include <QObject>
+
+namespace au::appshell {
+class EditPreferencesModel : public QObject, public muse::async::Asyncable
+{
+    Q_OBJECT
+    Q_PROPERTY(
+        bool askBeforeConvertingToMonoOrStereo READ askBeforeConvertingToMonoOrStereo WRITE setAskBeforeConvertingToMonoOrStereo NOTIFY askBeforeConvertingToMonoOrStereoChanged)
+
+    muse::Inject<au::trackedit::ITrackeditConfiguration> trackeditConfiguration;
+
+public:
+    explicit EditPreferencesModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void init();
+
+    bool askBeforeConvertingToMonoOrStereo() const;
+    void setAskBeforeConvertingToMonoOrStereo(bool value);
+
+signals:
+    void askBeforeConvertingToMonoOrStereoChanged();
+};
+}

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -162,7 +162,8 @@ void PreferencesModel::load(const QString& currentPageId)
 
         makeItem("spectral-display", QT_TRANSLATE_NOOP("appshell/preferences", "Spectral display"), IconCode::Code::SPECTROGRAM, ""),
 
-        makeItem("editing", QT_TRANSLATE_NOOP("appshell/preferences", "Editing"), IconCode::Code::EDIT, ""),
+        makeItem("editing", QT_TRANSLATE_NOOP("appshell/preferences",
+                                              "Editing"), IconCode::Code::EDIT, "Preferences/EditPreferencesPage.qml"),
 
         makeItem("effects", QT_TRANSLATE_NOOP("appshell/preferences", "Effects"), IconCode::Code::WAVEFORM, ""),
 

--- a/src/au3wrap/au3types.h
+++ b/src/au3wrap/au3types.h
@@ -11,6 +11,7 @@ class TrackId;
 class Track;
 class TrackList;
 class WaveTrack;
+class WaveTrackFactory;
 
 class WaveClip;
 
@@ -21,6 +22,7 @@ using Au3TrackId = ::TrackId;
 using Au3Track = ::Track;
 using Au3TrackList = ::TrackList;
 using Au3WaveTrack = ::WaveTrack;
+using Au3WaveTrackFactory = ::WaveTrackFactory;
 
 using Au3ClipId = int64_t;
 using Au3WaveClip = ::WaveClip;

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -72,6 +72,10 @@ void ClipsListModel::init()
 
 void ClipsListModel::reload()
 {
+    if (m_trackId < 0) {
+        return;
+    }
+
     ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     if (!prj) {
         return;
@@ -80,6 +84,12 @@ void ClipsListModel::reload()
     prj->trackChanged().onReceive(this, [this](const au::trackedit::Track& track) {
         if (track.id == m_trackId) {
             reload();
+        }
+    });
+
+    prj->trackRemoved().onReceive(this, [this](const au::trackedit::Track& track) {
+        if (track.id == m_trackId) {
+            m_trackId = -1;
         }
     });
 

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
@@ -211,9 +211,6 @@ void RealtimeEffectListModel::onChanged(effects::TrackId trackId)
 
     if (!newStack.has_value()) {
         m_trackEffectLists.erase(trackId);
-        // Track was deleted, apparently.
-        emit trackNameChanged();
-        emit trackEffectsActiveChanged();
     } else {
         // Do not brute-force delete and re-create everything: in case the dialog for a RealtimeEffectListItemModel is open,
         // we don't want it to close unless the effect state it refers to was removed.

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/itrackeditactionscontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/iselectioncontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/iprojecthistory.h
+    ${CMAKE_CURRENT_LIST_DIR}/itrackeditconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/itrackeditclipboard.h
     ${CMAKE_CURRENT_LIST_DIR}/trackediterrors.h
 
@@ -24,6 +25,8 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackeditinteraction.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackeditinteraction.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/trackeditconfiguration.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/trackeditconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackedituiactions.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackedituiactions.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackeditactionscontroller.cpp

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -37,7 +37,10 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3selectioncontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3selectioncontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3interaction.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3interactiontypes.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3interaction.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3interactionutils.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3interactionutils.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3projecthistory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3projecthistory.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3trackeditclipboard.cpp

--- a/src/trackedit/internal/au3/au3interactiontypes.h
+++ b/src/trackedit/internal/au3/au3interactiontypes.h
@@ -1,0 +1,32 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace au::trackedit {
+struct TrackListInfo {
+    TrackListInfo(size_t size, std::vector<size_t> stereoTrackIndices, std::vector<size_t> emptyTrackIndices)
+        : size{size}
+        , stereoTrackIndices{std::move(stereoTrackIndices)}
+        , emptyTrackIndices{std::move(emptyTrackIndices)}
+    {
+    }
+
+    const size_t size;
+    const std::vector<size_t> stereoTrackIndices;
+    const std::vector<size_t> emptyTrackIndices;
+};
+
+enum class NeedsDownmixing {
+    Yes,
+    No,
+};
+
+constexpr NeedsDownmixing operator|=(NeedsDownmixing& lhs, NeedsDownmixing rhs)
+{
+    return lhs = lhs == NeedsDownmixing::Yes || rhs == NeedsDownmixing::Yes ? NeedsDownmixing::Yes : NeedsDownmixing::No;
+}
+}

--- a/src/trackedit/internal/au3/au3interactionutils.cpp
+++ b/src/trackedit/internal/au3/au3interactionutils.cpp
@@ -1,0 +1,283 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "au3interactionutils.h"
+#include "../../trackedittypes.h"
+#include "au3wrap/internal/domaccessor.h"
+#include "libraries/lib-wave-track/WaveTrack.h"
+#include "libraries/lib-wave-track/WaveClip.h"
+#include "libraries/lib-project-rate/ProjectRate.h"
+#include "libraries/lib-project-rate/QualitySettings.h"
+#include "global/containers.h"
+#include "log.h"
+#include <unordered_set>
+
+namespace {
+std::vector<size_t> getEmptyWaveTrackIndices(const au::au3::Au3TrackList& tracks)
+{
+    using namespace au::au3;
+    std::vector<size_t> indices;
+    auto i = 0;
+    for (const Au3Track* track : tracks) {
+        const Au3WaveTrack* const waveTrack = dynamic_cast<const Au3WaveTrack*>(track);
+        if (waveTrack && waveTrack->IsEmpty()) {
+            indices.push_back(i);
+        }
+        ++i;
+    }
+    return indices;
+}
+
+au::trackedit::NeedsDownmixing addClipToTrack(const std::shared_ptr<au::au3::Au3WaveClip>& clip,
+                                              au::au3::Au3WaveTrack& dstWaveTrack,
+                                              au::au3::Au3TrackList& copy)
+{
+    using namespace au::trackedit::utils;
+
+    const size_t dstTrackIndex = getTrackIndex(copy, dstWaveTrack);
+    auto ptr = &dstWaveTrack;
+
+    // All clips in movement were removed from `copy` before the move-clip iteration began,
+    // so it's using `copy` as reference that we must check whether toggling the entire track is allowed.
+    const auto emptyTrackIndices = getEmptyWaveTrackIndices(copy);
+    if (muse::contains(emptyTrackIndices, dstTrackIndex) && dstWaveTrack.NChannels() != clip->NChannels()) {
+        ptr = toggleStereo(copy, getTrackIndex(copy, dstWaveTrack));
+    }
+
+    ptr->InsertInterval(clip, false);
+
+    if (clip->NChannels() == 2 && ptr->NChannels() == 1) {
+        return au::trackedit::NeedsDownmixing::Yes;
+    } else {
+        return au::trackedit::NeedsDownmixing::No;
+    }
+}
+}
+
+au::au3::Au3WaveTrack* au::trackedit::utils::getWaveTrack(au3::Au3TrackList& tracks, const au3::Au3TrackId& trackId)
+{
+    return dynamic_cast<au3::Au3WaveTrack*>(tracks.FindById(trackId));
+}
+
+au::au3::Au3WaveTrack* au::trackedit::utils::getWaveTrack(au3::Au3TrackList& tracks, const ClipKey& clip)
+{
+    return getWaveTrack(tracks, au3::Au3TrackId { clip.trackId });
+}
+
+const au::au3::Au3WaveTrack* au::trackedit::utils::getWaveTrack(const au3::Au3TrackList& tracks, TrackIndex index)
+{
+    auto it = tracks.begin();
+    std::advance(it, index.value);
+    if (it == tracks.end()) {
+        return nullptr;
+    }
+    return dynamic_cast<const au3::Au3WaveTrack*>(*it);
+}
+
+au::au3::Au3WaveTrack* au::trackedit::utils::getWaveTrack(au3::Au3TrackList& tracks, TrackIndex index)
+{
+    return const_cast<au3::Au3WaveTrack*>(getWaveTrack(const_cast<const au3::Au3TrackList&>(tracks), index));
+}
+
+size_t au::trackedit::utils::getTrackIndex(const au3::Au3TrackList& tracks, const au3::Au3Track& track)
+{
+    return std::distance(tracks.begin(), tracks.Find(&track));
+}
+
+size_t au::trackedit::utils::getTrackIndex(const au3::Au3TrackList& tracks, const trackedit::TrackId& id)
+{
+    return std::distance(tracks.begin(), tracks.Find(tracks.FindById(au3::Au3TrackId { id })));
+}
+
+void au::trackedit::utils::exchangeTrack(au3::Au3TrackList& tracks, au3::Au3WaveTrack& oldOne, au3::Au3WaveTrack& newOne)
+{
+    const auto i = getTrackIndex(tracks, oldOne);
+    tracks.Remove(oldOne);
+    constexpr auto assignId = false;
+    tracks.Insert(getWaveTrack(tracks, TrackIndex { i }), newOne.shared_from_this(), assignId);
+}
+
+au::au3::Au3WaveTrack* au::trackedit::utils::toggleStereo(au3::Au3TrackList& tracks, size_t trackIndex)
+{
+    au::au3::Au3WaveTrack* const track = getWaveTrack(tracks, TrackIndex { trackIndex });
+    IF_ASSERT_FAILED(track) {
+        return nullptr;
+    }
+
+    return toggleStereo(tracks, *track);
+}
+
+au::au3::Au3WaveTrack* au::trackedit::utils::toggleStereo(au3::Au3TrackList& tracks, au3::Au3WaveTrack& track)
+{
+    IF_ASSERT_FAILED(track.IsEmpty()) {
+        return &track;
+    }
+
+    const auto replacement = std::static_pointer_cast<au3::Au3WaveTrack>(track.Duplicate(au3::Au3Track::DuplicateOptions {}.Backup()));
+    const auto wasStereo = track.NChannels() == 2;
+    if (wasStereo) {
+        replacement->MakeMono();
+    } else {
+        replacement->MonoToStereo();
+    }
+
+    exchangeTrack(tracks, track, *replacement);
+
+    return replacement.get();
+}
+
+/*!
+ * @pre (trackFactory != nullptr && projectRate > 0) || tracks.GetOwner() != nullptr
+ */
+au::au3::Au3WaveTrack* au::trackedit::utils::appendWaveTrack(au3::Au3TrackList& tracks, size_t nChannels,
+                                                             const ::WaveTrackFactory* trackFactory,
+                                                             double projectRate)
+{
+    if (!trackFactory || projectRate == 0.) {
+        const au3::Au3Project* project = tracks.GetOwner();
+        IF_ASSERT_FAILED(project) {
+            return nullptr;
+        }
+        trackFactory = &WaveTrackFactory::Get(*project);
+        projectRate = ProjectRate::Get(*project).GetRate();
+    }
+    sampleFormat defaultFormat = QualitySettings::SampleFormatChoice();
+    const au3::Au3WaveTrack::Holder track = trackFactory->Create(nChannels, defaultFormat, projectRate);
+    track->SetName(tracks.MakeUniqueTrackName(au3::Au3WaveTrack::GetDefaultAudioTrackNamePreference()));
+    tracks.Add(track);
+    return track.get();
+}
+
+au::trackedit::NeedsDownmixing au::trackedit::utils::moveClipsUpOrDown(int offset, const au3::Au3TrackList& orig,
+                                                                       au3::Au3TrackList& copy,
+                                                                       const trackedit::ClipKeyList& selectedClips)
+{
+    const auto& project = *orig.GetOwner();
+    const auto& factory = ::WaveTrackFactory::Get(project);
+    const auto rate = ::ProjectRate::Get(project).GetRate();
+
+    NeedsDownmixing needsDownmixing = NeedsDownmixing::No;
+
+    struct MovedClip {
+        MovedClip(const std::shared_ptr<au3::Au3WaveClip>& ptr, size_t origTrackIndex)
+            : ptr(ptr)
+            , origTrackIndex(origTrackIndex)
+        {
+        }
+
+        const std::shared_ptr<au3::Au3WaveClip> ptr;
+        const size_t origTrackIndex;
+    };
+
+    std::vector<MovedClip> movedClips;
+    movedClips.reserve(selectedClips.size());
+    for (const auto& selectedClip : selectedClips) {
+        au3::Au3WaveTrack* srcWaveTrack = getWaveTrack(copy, selectedClip);
+        IF_ASSERT_FAILED(srcWaveTrack) {
+            continue;
+        }
+        const auto srcTrackIndex = getTrackIndex(copy, *srcWaveTrack);
+        movedClips.emplace_back(au3::DomAccessor::findWaveClip(srcWaveTrack, selectedClip.clipId), srcTrackIndex);
+        srcWaveTrack->RemoveInterval(movedClips.back().ptr);
+    }
+
+    for (const auto& clip : movedClips) {
+        const au3::Au3WaveTrack* waveTrack = getWaveTrack(copy, TrackIndex { clip.origTrackIndex });
+        IF_ASSERT_FAILED(waveTrack) {
+            continue;
+        }
+
+        ::TrackList::iterator it = copy.begin();
+        const auto dstTrackIndex = static_cast<int>(clip.origTrackIndex) + offset;
+        IF_ASSERT_FAILED(dstTrackIndex >= 0) {
+            continue;
+        }
+        std::advance(it, dstTrackIndex);
+        au3::Au3WaveTrack* const dstTrack = it != copy.end() ? dynamic_cast<au3::Au3WaveTrack*>(*it) : appendWaveTrack(copy,
+                                                                                                                       waveTrack->NChannels(), &factory,
+                                                                                                                       rate);
+
+        needsDownmixing |= addClipToTrack(clip.ptr, *dstTrack, copy);
+    }
+
+    return needsDownmixing;
+}
+
+au::trackedit::TrackListInfo au::trackedit::utils::getTrackListInfo(const au3::Au3TrackList& tracks)
+{
+    std::vector<size_t> stereoTrackIndices;
+    std::vector<size_t> emptyTrackIndices;
+    auto i = 0;
+    for (const au3::Au3Track* track : tracks) {
+        const au3::Au3WaveTrack* waveTrack = dynamic_cast<const au3::Au3WaveTrack*>(track);
+        if (waveTrack) {
+            if (waveTrack->NChannels() == 2) {
+                stereoTrackIndices.push_back(i);
+            }
+            if (waveTrack->IsEmpty()) {
+                emptyTrackIndices.push_back(i);
+            }
+        }
+        ++i;
+    }
+    return { tracks.Size(), std::move(stereoTrackIndices), std::move(emptyTrackIndices) };
+}
+
+bool au::trackedit::utils::clipIdSetsAreEqual(const au3::Au3WaveTrack& track1, const au3::Au3WaveTrack& track2)
+{
+    const auto numClips = track1.GetNumClips();
+    if (numClips != track2.GetNumClips()) {
+        return false;
+    }
+    std::unordered_set<au3::Au3ClipId> clipIds1;
+    for (auto i = 0; i < numClips; ++i) {
+        clipIds1.insert(track1.GetClip(i)->GetId());
+    }
+    for (auto i = 0; i < numClips; ++i) {
+        if (!clipIds1.count(track2.GetClip(i)->GetId())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::vector<const au::trackedit::Clip*> au::trackedit::utils::clipSetDifference(const Clips& set1, const Clips& set2)
+{
+    std::vector<const Clip*> result;
+    for (const auto& clip : set1) {
+        if (std::find_if(set2.begin(), set2.end(), [&clip](const Clip& c) { return c.key == clip.key; }) == set2.end()) {
+            result.push_back(&clip);
+        }
+    }
+    return result;
+}
+
+using ProgressCb = std::function<void (double)>;
+using CancelCb = std::function<bool ()>;
+
+muse::Ret au::trackedit::utils::withProgress(muse::IInteractive& interactive, const std::string& title, const std::function<bool(ProgressCb,
+                                                                                                                                 CancelCb)>& action)
+{
+    muse::Progress progress;
+    interactive.showProgress(title, &progress);
+    progress.started();
+
+    ProgressCb progressCb = [&](double progressFraction)
+    {
+        progress.progress(progressFraction * 1000, 1000, "");
+        QCoreApplication::processEvents();
+        return !progress.isCanceled();
+    };
+
+    CancelCb cancelCb = [&progress] { return progress.isCanceled(); };
+
+    const bool result = action(std::move(progressCb), std::move(cancelCb));
+
+    if (progress.isCanceled()) {
+        return muse::make_ret(muse::Ret::Code::Cancel);
+    }
+
+    progress.finish(muse::make_ok());
+
+    return result;
+}

--- a/src/trackedit/internal/au3/au3interactionutils.h
+++ b/src/trackedit/internal/au3/au3interactionutils.h
@@ -1,0 +1,52 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "au3interactiontypes.h"
+#include "trackedittypes.h"
+#include "dom/clip.h"
+#include "au3wrap/au3types.h"
+#include "global/types/ret.h"
+#include "global/iinteractive.h"
+#include <cstddef>
+
+namespace au::trackedit::utils {
+//! To avoid risk of `getWaveTrack(myTracks, myClipKey.trackId)` ...
+struct TrackIndex {
+    const size_t value;
+};
+
+using ProgressCb = std::function<void (double)>;
+using CancelCb = std::function<bool ()>;
+
+au3::Au3WaveTrack* getWaveTrack(au3::Au3TrackList& tracks, const au3::Au3TrackId& trackId);
+au3::Au3WaveTrack* getWaveTrack(au3::Au3TrackList& tracks, const ClipKey& clip);
+au3::Au3WaveTrack* getWaveTrack(au3::Au3TrackList& tracks, TrackIndex index);
+const au3::Au3WaveTrack* getWaveTrack(const au3::Au3TrackList& tracks, TrackIndex index);
+
+size_t getTrackIndex(const au3::Au3TrackList& tracks, const au3::Au3Track& track);
+size_t getTrackIndex(const au3::Au3TrackList& tracks, const trackedit::TrackId& id);
+
+void exchangeTrack(au3::Au3TrackList& tracks, au3::Au3WaveTrack& oldOne, au3::Au3WaveTrack& newOne);
+
+au3::Au3WaveTrack* toggleStereo(au3::Au3TrackList& tracks, au3::Au3WaveTrack& track);
+au3::Au3WaveTrack* toggleStereo(au3::Au3TrackList& tracks, size_t trackIndex);
+
+/*!
+ * @pre (trackFactory != nullptr && projectRate > 0) || tracks.GetOwner() != nullptr
+ */
+au3::Au3WaveTrack* appendWaveTrack(au3::Au3TrackList& tracks, size_t nChannels, const au3::Au3WaveTrackFactory* trackFactory = nullptr,
+                                   double projectRate = 0.);
+
+NeedsDownmixing moveClipsUpOrDown(int offset, const au3::Au3TrackList& orig, au3::Au3TrackList& copy,
+                                  const trackedit::ClipKeyList& selectedClips);
+
+au::trackedit::TrackListInfo getTrackListInfo(const au3::Au3TrackList& tracks);
+
+bool clipIdSetsAreEqual(const au3::Au3WaveTrack& track1, const au3::Au3WaveTrack& track2);
+
+std::vector<const Clip*> clipSetDifference(const Clips& set1, const Clips& set2);
+
+muse::Ret withProgress(muse::IInteractive& interactive, const std::string& title, const std::function<bool(ProgressCb, CancelCb)>& action);
+}

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -73,6 +73,12 @@ void Au3ProjectHistory::pushHistoryState(const std::string& longDescription, con
     m_isUndoRedoAvailableChanged.notify();
 }
 
+void au::trackedit::Au3ProjectHistory::rollbackState()
+{
+    auto& project = projectRef();
+    ::ProjectHistory::Get(project).RollbackState();
+}
+
 void Au3ProjectHistory::startUserInteraction()
 {
     LOGI() << "startUserInteraction()";

--- a/src/trackedit/internal/au3/au3projecthistory.h
+++ b/src/trackedit/internal/au3/au3projecthistory.h
@@ -29,6 +29,7 @@ public:
         const std::string& longDescription, const std::string& shortDescription) override;
     void pushHistoryState(
         const std::string& longDescription, const std::string& shortDescription, UndoPushType flags) override;
+    void rollbackState() override;
     void modifyState(bool autoSave) override;
     void markUnsaved() override;
     void startUserInteraction() override;

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -33,9 +33,10 @@ void Au3SelectionController::init()
     globalContext()->currentTrackeditProjectChanged().onNotify(this, [this]() {
         ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
 
-        resetDataSelection();
-
         if (prj) {
+            resetSelectedClips();
+            resetSelectedTracks();
+
             //! NOTE: load project's last saved selection state
             auto& selectedRegion = ViewInfo::Get(projectRef()).selectedRegion;
             m_selectedStartTime.set(selectedRegion.t0(), true);

--- a/src/trackedit/internal/au3/au3trackeditproject.cpp
+++ b/src/trackedit/internal/au3/au3trackeditproject.cpp
@@ -172,7 +172,7 @@ void Au3TrackeditProject::onProjectTempoChange(double newTempo)
 muse::async::NotifyList<au::trackedit::Clip> Au3TrackeditProject::clipList(const au::trackedit::TrackId& trackId) const
 {
     const Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(*m_impl->prj, Au3TrackId(trackId));
-    IF_ASSERT_FAILED(waveTrack) {
+    if (!waveTrack) {
         return muse::async::NotifyList<au::trackedit::Clip>();
     }
 
@@ -230,7 +230,7 @@ void Au3TrackeditProject::notifyAboutTrackMoved(const Track& track, int pos)
 au::trackedit::Clip Au3TrackeditProject::clip(const ClipKey& key) const
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(*m_impl->prj, Au3TrackId(key.trackId));
-    IF_ASSERT_FAILED(waveTrack) {
+    if (!waveTrack) {
         return Clip();
     }
 

--- a/src/trackedit/internal/trackeditconfiguration.cpp
+++ b/src/trackedit/internal/trackeditconfiguration.cpp
@@ -1,0 +1,38 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "trackeditconfiguration.h"
+
+#include "settings.h"
+
+namespace au::trackedit {
+static const std::string moduleName("trackedit");
+
+static const muse::Settings::Key ASK_BEFORE_CONVERTING_TO_MONO_OR_STEREO(moduleName, "trackedit/askBeforeConvertingToMonoOrStereo");
+
+void TrackeditConfiguration::init()
+{
+    muse::settings()->setDefaultValue(ASK_BEFORE_CONVERTING_TO_MONO_OR_STEREO, muse::Val(true));
+    muse::settings()->valueChanged(ASK_BEFORE_CONVERTING_TO_MONO_OR_STEREO).onReceive(nullptr, [this](const muse::Val& val) {
+        m_askBeforeConvertingToMonoOrStereoChanged.notify();
+    });
+}
+
+bool TrackeditConfiguration::askBeforeConvertingToMonoOrStereo() const
+{
+    return muse::settings()->value(ASK_BEFORE_CONVERTING_TO_MONO_OR_STEREO).toBool();
+}
+
+void TrackeditConfiguration::setAskBeforeConvertingToMonoOrStereo(bool ask)
+{
+    if (askBeforeConvertingToMonoOrStereo() == ask) {
+        return;
+    }
+    muse::settings()->setSharedValue(ASK_BEFORE_CONVERTING_TO_MONO_OR_STEREO, muse::Val(ask));
+}
+
+muse::async::Notification TrackeditConfiguration::askBeforeConvertingToMonoOrStereoChanged() const
+{
+    return m_askBeforeConvertingToMonoOrStereoChanged;
+}
+}

--- a/src/trackedit/internal/trackeditconfiguration.h
+++ b/src/trackedit/internal/trackeditconfiguration.h
@@ -1,0 +1,23 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include "../itrackeditconfiguration.h"
+
+namespace au::trackedit {
+class TrackeditConfiguration : public ITrackeditConfiguration
+{
+public:
+    TrackeditConfiguration() = default;
+
+    void init();
+
+    bool askBeforeConvertingToMonoOrStereo() const override;
+    void setAskBeforeConvertingToMonoOrStereo(bool value) override;
+    muse::async::Notification askBeforeConvertingToMonoOrStereoChanged() const override;
+
+private:
+    muse::async::Notification m_askBeforeConvertingToMonoOrStereoChanged;
+};
+}

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -21,11 +21,6 @@ muse::async::Channel<trackedit::ClipKey, secs_t /*newStartTime*/, bool /*complet
     return m_interaction->clipStartTimeChanged();
 }
 
-bool TrackeditInteraction::moveClipToTrack(const ClipKey& clipKey, TrackId trackId, bool completed)
-{
-    return m_interaction->moveClipToTrack(clipKey, trackId, completed);
-}
-
 bool TrackeditInteraction::trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end)
 {
     return withPlaybackStop(&ITrackeditInteraction::trimTracksData, tracksIds, begin, end);

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -21,7 +21,6 @@ private:
     muse::secs_t clipStartTime(const trackedit::ClipKey& clipKey) const override;
     bool changeClipStartTime(const trackedit::ClipKey& clipKey, secs_t newStartTime, bool completed) override;
     muse::async::Channel<trackedit::ClipKey, secs_t /*newStartTime*/, bool /*completed*/> clipStartTimeChanged() const override;
-    bool moveClipToTrack(const trackedit::ClipKey& clipKey, TrackId trackId, bool completed) override;
     bool trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;
     bool silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;
     bool changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title) override;

--- a/src/trackedit/iprojecthistory.h
+++ b/src/trackedit/iprojecthistory.h
@@ -24,6 +24,7 @@ public:
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription) = 0;
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription,
                                   trackedit::UndoPushType flags) = 0;
+    virtual void rollbackState() = 0;
     virtual void modifyState(bool autoSave = false) = 0;
     virtual void markUnsaved() = 0;
 

--- a/src/trackedit/itrackeditconfiguration.h
+++ b/src/trackedit/itrackeditconfiguration.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "modularity/imoduleinterface.h"
+
+#include "async/channel.h"
+#include "async/notification.h"
+
+namespace au::trackedit {
+class ITrackeditConfiguration : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(ITrackeditConfiguration)
+
+public:
+
+    virtual ~ITrackeditConfiguration() = default;
+
+    virtual bool askBeforeConvertingToMonoOrStereo() const = 0;
+    virtual void setAskBeforeConvertingToMonoOrStereo(bool value) = 0;
+    virtual muse::async::Notification askBeforeConvertingToMonoOrStereoChanged() const = 0;
+};
+}

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -35,8 +35,6 @@ public:
     virtual bool changeClipStartTime(const ClipKey& clipKey, secs_t newStartTime, bool completed) = 0;
     virtual muse::async::Channel<ClipKey, secs_t /*newStartTime*/, bool /*completed*/> clipStartTimeChanged() const = 0;
 
-    virtual bool moveClipToTrack(const trackedit::ClipKey& clipKey, TrackId trackId, bool completed) = 0;
-
     virtual bool trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title) = 0;

--- a/src/trackedit/trackediterrors.h
+++ b/src/trackedit/trackediterrors.h
@@ -19,7 +19,6 @@ enum class Err {
     ClipNotFound,
     TrackEmpty,
     NotEnoughSpaceForPaste,
-    StereoClipIntoMonoTrack,
     FailedToMakeRoomForClip,
     NotEnoughDataInClipboard,
     DisallowedDuringRecording,
@@ -37,10 +36,6 @@ inline muse::Ret make_ret(Err e)
     case Err::ClipNotFound: return muse::Ret(retCode);
     case Err::TrackEmpty: return muse::Ret(retCode);
     case Err::NotEnoughSpaceForPaste: return muse::Ret(retCode, muse::trc("trackedit", "Not enough space to paste clip into"));
-    case Err::StereoClipIntoMonoTrack: return muse::Ret(retCode,
-                                                        muse::trc("trackedit",
-                                                                  "Stereo audio clips cannot be pasted onto mono tracks. "
-                                                                  "Please convert the stereo clip to mono before pasting."));
     case Err::FailedToMakeRoomForClip: return muse::Ret(retCode);
     case Err::NotEnoughDataInClipboard: return muse::Ret(retCode);
     }

--- a/src/trackedit/trackeditmodule.cpp
+++ b/src/trackedit/trackeditmodule.cpp
@@ -26,6 +26,7 @@
 #include "internal/trackedituiactions.h"
 #include "internal/trackeditactionscontroller.h"
 #include "internal/trackeditinteraction.h"
+#include "internal/trackeditconfiguration.h"
 
 #include "internal/au3/au3trackeditproject.h"
 #include "internal/au3/au3interaction.h"
@@ -51,6 +52,7 @@ void TrackeditModule::registerExports()
     m_trackeditController = std::make_shared<TrackeditActionsController>();
     m_trackeditUiActions = std::make_shared<TrackeditUiActions>(m_trackeditController);
     m_selectionController = std::make_shared<Au3SelectionController>();
+    m_configuration = std::make_shared<TrackeditConfiguration>();
 
     ioc()->registerExport<ITrackeditActionsController>(moduleName(), m_trackeditController);
     ioc()->registerExport<ITrackeditProjectCreator>(moduleName(), new Au3TrackeditProjectCreator());
@@ -58,6 +60,7 @@ void TrackeditModule::registerExports()
     ioc()->registerExport<ISelectionController>(moduleName(), m_selectionController);
     ioc()->registerExport<IProjectHistory>(moduleName(), new Au3ProjectHistory());
     ioc()->registerExport<ITrackeditClipboard>(moduleName(), new Au3TrackeditClipboard());
+    ioc()->registerExport<ITrackeditConfiguration>(moduleName(), m_configuration);
 }
 
 void TrackeditModule::resolveImports()
@@ -73,6 +76,7 @@ void TrackeditModule::onInit(const muse::IApplication::RunMode&)
     m_trackeditController->init();
     m_trackeditUiActions->init();
     m_selectionController->init();
+    m_configuration->init();
 
     TimeSignatureRestorer::reg();
 }

--- a/src/trackedit/trackeditmodule.h
+++ b/src/trackedit/trackeditmodule.h
@@ -9,6 +9,7 @@ namespace au::trackedit {
 class TrackeditActionsController;
 class TrackeditUiActions;
 class Au3SelectionController;
+class TrackeditConfiguration;
 class TrackeditModule : public muse::modularity::IModuleSetup
 {
 public:
@@ -23,5 +24,6 @@ private:
     std::shared_ptr<TrackeditActionsController> m_trackeditController;
     std::shared_ptr<TrackeditUiActions> m_trackeditUiActions;
     std::shared_ptr<Au3SelectionController> m_selectionController;
+    std::shared_ptr<TrackeditConfiguration> m_configuration;
 };
 }


### PR DESCRIPTION
Resolves: #7876

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Pasting a stereo/mono clip on empty mono/stereo track converts the track to stereo/mono
- [x] Pasting a stereo/mono clip on a non-empty mono/stereo track asks the user and either cancels or convert the clip
- [x] Pasting long stereo clip on other clip in mono track and cancelling stereo-to-mono conversion behaves. (Clip color changes is I think unrelated.)
- [x] Drag-dropping a stereo/mono clip on empty mono/stereo track converts the track to stereo/mono
- [x] Drag-dropping a stereo/mono clip on a non-empty mono/stereo track asks the user and either cancels or convert the clip
- [x] If new tracks are created while dragging down, these tracks get deleted as soon as dragging back up.
- [x] Choice of the warning dialog is remembered if "Don't ask again is checked".
- [x] Choice of the warning dialog is **not** remembered if user cancels.
- [x] This choice can also be set in the "Edit" preferences.
- [x] Stereo-to-mono conversion of one or more long clips shows a progress bar that can be canceled.
- [x] Drag-dropping across tracks of different formats works (sample rate & format)
- [x] Please try the above again after having closed and re-opened your project
- [x] Stress-test the thing: drag clips like crazy up and down
- [x] The above works with time selection, single-clip selection or multiple-clip selection