### PR TITLE
Delete Shortcut doesn't Delete Tracks #8115

### DIFF
--- a/au3/libraries/lib-theme-resources/dark/Components/Colors.txt
+++ b/au3/libraries/lib-theme-resources/dark/Components/Colors.txt
@@ -80,7 +80,7 @@
                     SliderMain: #484f57;
                     SliderDark: #484f57;
                TrackBackground: #23272b;
-                   GraphLabels: #000000;
+                   GraphLabels: #dddee4; // changed from #000000 to #dddee4
              SpectroBackground: #ffff14;
                     ScrubRuler: #6a6a6a;
                  RulerSelected: #9295a6;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8115

Before: (In the bug demo video)
In a single clip track, when you select the clip and press delete, only the clip would vanish via "multi-clip-delete" action while the empty track would not be deleted.

Now:
When you select a clip and press delete, the entire track is successfully deleted (provided track contains a single clip) via the "track-delete" action. Unlike before, the empty track doesn't remain.

Not just the clip, if you click on any non-track panel on the left including any empty/non-clip space in the track and press delete key, the entire track is successfully deleted.

What remains unsolved??
Keyboard triggered shortcuts are buggy once you click on the left side track panel. The delete key (and sometimes Ctrl+S too!) are not even recorded in the debug log for some reason.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
