### PR TITLE
Get effects dialog: fix tab order

### DIFF
--- a/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
+++ b/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
@@ -169,7 +169,7 @@ void GetEffectsDialog::FetchImage(RoundedStaticBitmap* bitmap, const std::string
 void GetEffectsDialog::AddLoadingPage() {
    wxPanel* page = safenew wxPanel();
    page->Hide();
-   page->Create(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+   page->Create(m_treebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
 
    wxBoxSizer* sizer = safenew wxBoxSizer(wxVERTICAL);
    page->SetSizer(sizer);
@@ -187,7 +187,7 @@ void GetEffectsDialog::AddLoadingPage() {
 void GetEffectsDialog::AddBecomeAPartnerPage() {
    wxPanel* page = safenew wxPanel();
    page->Hide();
-   page->Create(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+   page->Create(m_treebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
 
    wxBoxSizer* sizer = safenew wxBoxSizer(wxVERTICAL);
 
@@ -227,7 +227,7 @@ void GetEffectsDialog::AddBecomeAPartnerPage() {
 void GetEffectsDialog::AddLoadingErrorPage() {
    wxPanel* page = safenew wxPanel();
    page->Hide();
-   page->Create(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+   page->Create(m_treebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
 
    wxBoxSizer* sizer = safenew wxBoxSizer(wxVERTICAL);
 


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/audacity/audacity/issues/8252)

Problem:
On the Become a partner page, the OK button comes before the become a partner button in the tab order.

Fix:
In void GetEffectsDialog::AddBecomeAPartnerPage(), the page should have the treebook as parent, rather than the dialog. Fixing this, fixes the incorrect tab order. I also fixed the same error for other pages, even though they were not causing obvious problems.
(In GetEffectsDialog::AddEffectsPage(), the parent was already correctly the treebook.)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior
