### PR TITLE
Fix: 8115 track delete in AU4

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -287,6 +287,10 @@
         <seq>Del</seq>
         <seq>Backspace</seq>
     </SC>
+        <SC>
+        <key>track-delete</key>
+        <seq>Delete</seq>
+    </SC>
     <SC>
         <key>file-new</key>
         <seq>Ctrl+N</seq>


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8115

Earlier as shown in the bug demo video, when you select the clip and press delete key, only the clip would vanish via "multi-clip-delete" action but the empty track would remain undeleted.

Now: (I have made changes only within the audacity/src dir AU4 build only) 
Selecting a clip / any area in the track and pressing delete key successfully deletes the entire track (via track-delete action).

https://github.com/user-attachments/assets/f02fa3e6-ae63-45b9-af62-d7e9fb2d4c2c

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
