### PR TITLE
8309 crossfade track fix

### DIFF
--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1298,7 +1298,7 @@ void WaveTrack::ClearAndPasteAtSameTempo(
       // we need to copy clips, trims and names, because the original ones
       // could be changed later during Clear/Paste routines
       st = roundTime(clip->GetPlayStartTime());
-      if (st >= t0 && st <= t1) {
+      if (st > t0 && st < t1) {
          auto it = get_split(st);
          if (clip->GetTrimLeft() != 0) {
             //keep only hidden left part
@@ -1310,7 +1310,7 @@ void WaveTrack::ClearAndPasteAtSameTempo(
       }
 
       st = roundTime(clip->GetPlayEndTime());
-      if (st >= t0 && st <= t1) {
+      if (st > t0 && st < t1) {
          auto it = get_split(st);
          if (clip->GetTrimRight() != 0) {
             //keep only hidden right part


### PR DESCRIPTION
Resolves: #8309

When applying the crossfade-tracks effect (and probably others) over a time interval [t0, t1], clip "splits" within that interval are supposed to be preserved. In other words, if within the selection there are two clips one against the other, they should not be merged.

The clip-split detection and restoration algorithm was considering splits at the edge of this interval. This causing seemingly unnecessary clip manipulation (copying, inserting, trimming, shifting, etc) which, in that particular case, isn't handled properly. The exact reason as to why it isn't handled properly is still unknown to me. It may seem logically satisfying, however, not to try and restore splits at the edges of the time selection ; the "merge" argument to `WaveTrack::ClearAndPaste` alone should be responsible for that. Also, targeted testing around clip-split preservation may convince that this particular change isn't introducing new problems ?

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] Resolves #8309
- [ ] Applying effects preserve clip splits like they used to, whether the splits are strictly within the time selection or at the edges.