### PR TITLE
Get Effects Dialog resize to fit the content

### DIFF
--- a/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
+++ b/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
@@ -34,6 +34,9 @@
 namespace audacity::musehub
 {
 
+static constexpr int dialogMinWidth = 920;
+static constexpr int dialogMinHeight = 650;
+
 static constexpr int iconRadius = 12;
 
 static constexpr int effectIconWidth = 118;
@@ -66,7 +69,7 @@ static const auto becomeAPartnerDescription =
       "on MuseHub, you can apply today.");
 
 GetEffectsDialog::GetEffectsDialog(wxWindow *parent) :
-   wxDialogWrapper(parent, wxID_ANY, XO("Get Effects"), wxDefaultPosition, {500, 500}, wxDEFAULT_DIALOG_STYLE)
+   wxDialogWrapper(parent, wxID_ANY, XO("Get Effects"), wxDefaultPosition, wxSize(dialogMinWidth, dialogMinHeight), wxDEFAULT_DIALOG_STYLE)
 {
    m_treebook = new wxTreebook(this, wxID_ANY);
    m_treebook->GetTreeCtrl()->SetIndent(0);
@@ -97,7 +100,7 @@ GetEffectsDialog::GetEffectsDialog(wxWindow *parent) :
 
    SetSizer(vSizer);
 
-   SetSize(920, 650);
+   SetMinSize(wxSize(dialogMinWidth, dialogMinHeight));
    CenterOnParent();
 
    ReloadEffectList();
@@ -127,6 +130,7 @@ void GetEffectsDialog::ReloadEffectList()
          AddBecomeAPartnerPage();
 
          Thaw();
+         Fit();
          Layout();
       });
    });


### PR DESCRIPTION
Resolves: #8288, #8360

Allow the dialog to resize according to the content width

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
