### PR TITLE
Isolation mode for sample views

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -111,22 +111,15 @@ Rectangle {
     }
 
     function mousePressAndHold(x, y) {
-        if (!root.altPressed) {
-            waveView.setLastClickPos(x, y - header.height, x, y - header.height)
-        }
+        root.altPressed
+            ? waveView.smoothLastClickPos(x, y - header.height)
+            : waveView.setLastClickPos(x, y - header.height, x, y - header.height)
         waveView.update()
     }
 
     function mouseReleased() {
         waveView.isNearSample = false
         waveView.onWaveViewPositionChanged(lastSample.x, lastSample.y)
-    }
-
-    function mouseClicked(x, y) {
-        root.altPressed
-            ? waveView.smoothLastClickPos(x, y - header.height)
-            : waveView.setLastClickPos(x, y - header.height, x, y - header.height)
-        waveView.update()
     }
 
     function setLastSample(x, y) {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -85,6 +85,7 @@ Rectangle {
     property var lastSample: undefined
     property bool altPressed: false
     property bool isBrush: waveView.isStemPlot && root.altPressed
+    property bool isIsolationMode: false
     property alias isNearSample: waveView.isNearSample
     property alias currentChannel: waveView.currentChannel
     property alias leftTrimContainsMouse: leftTrimStretchEdgeHover.containsMouse
@@ -541,9 +542,13 @@ Rectangle {
 
             clipColor: root.clipColor
             clipSelected: root.clipSelected
+            isIsolationMode: root.isIsolationMode
 
             function onWaveViewPositionChanged(x, y) {
-                if (root.multiSampleEdit && !root.altPressed) {
+                if (waveView.isIsolationMode) {
+                    waveView.setIsolatedPoint(x,y)
+                    waveView.update()
+                } else if (root.multiSampleEdit && !root.altPressed) {
                     var lastX = root.lastSample.x
                     var lastY = root.lastSample.y
                     waveView.setLastClickPos(lastX, lastY, x, y)
@@ -568,6 +573,12 @@ Rectangle {
 
             onIsNearSampleChanged: {
                 if(root.isNearSample) {
+                    waveView.forceActiveFocus()
+                }
+            }
+
+            onIsIsolationModeChanged: {
+                if (waveView.isIsolationMode) {
                     waveView.forceActiveFocus()
                 }
             }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -126,29 +126,8 @@ Item {
 
             anchors.fill: parent
 
-            onClicked: function(e) {
-                if (clipsContainer.multiSampleEdit || clipsContainer.isIsolationMode) {
-                    // Handle release for multi sample edit and isolation mode on the next click event
-                    clipsContainer.multiSampleEdit = false
-                    clipsContainer.isIsolationMode = false
-
-                    clipsContainer.mapToAllClips(e, function(clipItem, mouseEvent) {
-                        clipItem.multiSampleEdit = false
-                        clipItem.isIsolationMode = false
-                        clipItem.mouseReleased(mouseEvent.x, mouseEvent.y)
-                    })
-                    //Do not process long press and holds as normal click events
-                    return
-                }
-
-                clipsContainer.mapToAllClips(e, function(clipItem, mouseEvent) {
-                    clipItem.mouseClicked(mouseEvent.x, mouseEvent.y)
-                })
-                e.accepted = false
-            }
-
             onDoubleClicked: function(e) {
-                e.accepted = false
+                e.accepted = true
             }
             
             onPressAndHold: function(e) {
@@ -177,6 +156,17 @@ Item {
                     clipsContainerMouseArea.hoverEnabled = true
                     e.accepted = false
                 }
+            }
+
+            onReleased: function(e) {
+                clipsContainer.multiSampleEdit = false
+                clipsContainer.isIsolationMode = false
+
+                clipsContainer.mapToAllClips(e, function(clipItem, mouseEvent) {
+                    clipItem.multiSampleEdit = false
+                    clipItem.isIsolationMode = false
+                    clipItem.mouseReleased(mouseEvent.x, mouseEvent.y)
+                })
             }
 
             onPositionChanged: function(e) {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -17,6 +17,7 @@ Rectangle {
     property bool tracksHovered: false
     property bool underSelection: false
     property bool altPressed: false
+    property bool ctrlPressed: false
 
     readonly property string pencilShape: ":/images/customCursorShapes/Pencil.png"
     readonly property string smoothShape: ":/images/customCursorShapes/Smooth.png"
@@ -131,11 +132,17 @@ Rectangle {
         if (event.key === Qt.Key_Alt) {
             root.altPressed = true
         }
+        else if (event.key === Qt.Key_Control) {
+            root.ctrlPressed = true
+        }
     }
 
     Keys.onReleased: (event) => {
         if (event.key === Qt.Key_Alt) {
             root.altPressed = false
+        }
+        else if (event.key === Qt.Key_Control) {
+            root.ctrlPressed = false
         }
     }
 
@@ -223,20 +230,20 @@ Rectangle {
 
     CustomCursor {
         id: customCursor
-        active: (content.isBrush || content.isNearSample || content.leftTrimContainsMouse || content.rightTrimContainsMouse
+        active: (content.isIsolationMode || content.isBrush || content.isNearSample || content.leftTrimContainsMouse || content.rightTrimContainsMouse
             || content.leftTrimPressedButtons || content.rightTrimPressedButtons)
         source: {
             if (content.isBrush) {
                 return smoothShape
             }
 
-            if (content.isNearSample) {
+            if (content.isNearSample || content.isIsolationMode) {
                 return pencilShape
             }
 
             return content.leftTrimContainsMouse || content.leftTrimPressedButtons ? leftTrimShape : rightTrimShape
         }
-        size: !content.isBrush && content.isNearSample ? 36 : 26
+        size: content.isIsolationMode || (!content.isBrush && content.isNearSample) ? 36 : 26
     }
 
     Rectangle {
@@ -249,6 +256,7 @@ Rectangle {
         anchors.right: parent.right
 
         property bool isBrush: false
+        property bool isIsolationMode: false
         property bool isNearSample: false
         property bool leftTrimContainsMouse: false
         property bool rightTrimContainsMouse: false
@@ -458,6 +466,7 @@ Rectangle {
                     moveActive: tracksClipsView.moveActive
                     underSelection: root.underSelection
                     altPressed: root.altPressed
+                    ctrlPressed: root.ctrlPressed
 
                     onTrackItemMousePositionChanged: function(xWithinTrack, yWithinTrack, clipKey) {
                         let xGlobalPosition = xWithinTrack
@@ -517,6 +526,12 @@ Rectangle {
                     onIsBrushChanged: function() {
                         content.isBrush = tracksClipsView.checkIfAnyTrack(function(track) {
                             return track.isBrush
+                        })
+                    }
+
+                    onIsIsolationModeChanged: function() {
+                        content.isIsolationMode = tracksClipsView.checkIfAnyTrack(function(track){
+                            return track.isIsolationMode
                         })
                     }
 

--- a/src/projectscene/view/clipsview/au3/samplespainterutils.h
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.h
@@ -24,4 +24,7 @@ void setLastClickPos(const unsigned int currentChannel, std::shared_ptr<au::proj
                      const IWavePainter::Params& params);
 void smoothLastClickPos(const unsigned int currentChannel, std::shared_ptr<au::project::IAudacityProject> project,
                         const trackedit::ClipKey& clipKey, const QPoint& currentPosition, const IWavePainter::Params& params);
+void setIsolatedPoint(const unsigned int currentChannel, const trackedit::ClipKey& clipKey,
+                      std::shared_ptr<au::project::IAudacityProject> project, const QPoint& isolatedPoint, const QPoint& currentPosition,
+                      const IWavePainter::Params& params);
 }

--- a/src/projectscene/view/clipsview/waveview.cpp
+++ b/src/projectscene/view/clipsview/waveview.cpp
@@ -277,6 +277,21 @@ void WaveView::setCurrentChannel(int currentChannel)
     m_currentChannel = currentChannel;
 }
 
+bool WaveView::isIsolationMode() const
+{
+    return m_isIsolationMode;
+}
+
+void WaveView::setIsIsolationMode(bool isIsolationMode)
+{
+    if (m_isIsolationMode == isIsolationMode) {
+        return;
+    }
+
+    m_isIsolationMode = isIsolationMode;
+    emit isIsolationModeChanged();
+}
+
 QColor WaveView::transformColor(const QColor& originalColor) const
 {
     int r = originalColor.red();
@@ -326,6 +341,8 @@ void WaveView::setLastClickPos(const unsigned lastX, const unsigned lastY, const
     samplespainterutils::setLastClickPos(
         m_currentChannel.value(),
         globalContext()->currentProject(), m_clipKey.key, lastPosition, currentPosition, params);
+
+    m_lastClickedPoint = currentPosition;
 }
 
 void WaveView::smoothLastClickPos(unsigned int x, const unsigned int y)
@@ -345,4 +362,31 @@ void WaveView::smoothLastClickPos(unsigned int x, const unsigned int y)
     samplespainterutils::smoothLastClickPos(
         m_currentChannel.value(),
         globalContext()->currentProject(), m_clipKey.key, currentPosition, params);
+}
+
+void WaveView::setIsolatedPoint(const unsigned int x, const unsigned int y)
+{
+    if (!m_isStemPlot) {
+        return;
+    }
+
+    if (!m_isIsolationMode) {
+        return;
+    }
+
+    if (!m_lastClickedPoint.has_value()) {
+        return;
+    }
+
+    const auto currentPosition = QPoint(x, y);
+    const auto params = getWavePainterParams();
+
+    if (!m_currentChannel.has_value()) {
+        m_currentChannel = samplespainterutils::hitChannelIndex(globalContext()->currentProject(), m_clipKey.key, currentPosition, params);
+        return;
+    }
+
+    samplespainterutils::setIsolatedPoint(
+        m_currentChannel.value(),
+        m_clipKey.key, globalContext()->currentProject(), m_lastClickedPoint.value(), currentPosition, params);
 }

--- a/src/projectscene/view/clipsview/waveview.h
+++ b/src/projectscene/view/clipsview/waveview.h
@@ -28,6 +28,7 @@ class WaveView : public QQuickPaintedItem
     Q_PROPERTY(bool isNearSample READ isNearSample WRITE setIsNearSample NOTIFY isNearSampleChanged FINAL)
     Q_PROPERTY(bool isStemPlot READ isStemPlot WRITE setIsStemPlot NOTIFY isStemPlotChanged FINAL)
     Q_PROPERTY(int currentChannel READ currentChannel WRITE setCurrentChannel FINAL)
+    Q_PROPERTY(bool isIsolationMode READ isIsolationMode WRITE setIsIsolationMode NOTIFY isIsolationModeChanged FINAL)
 
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<au::projectscene::IWavePainter> wavePainter;
@@ -55,11 +56,14 @@ public:
     void setIsStemPlot(bool isStemPlot);
     int currentChannel() const;
     void setCurrentChannel(int currentChannel);
+    bool isIsolationMode() const;
+    void setIsIsolationMode(bool isIsolationMode);
 
     Q_INVOKABLE QColor transformColor(const QColor& originalColor) const;
     Q_INVOKABLE void setLastMousePos(const unsigned int x, const unsigned int y);
     Q_INVOKABLE void setLastClickPos(unsigned lastX, unsigned lastY, unsigned int x, const unsigned int y);
     Q_INVOKABLE void smoothLastClickPos(unsigned int x, const unsigned int y);
+    Q_INVOKABLE void setIsolatedPoint(unsigned int x, unsigned int y);
 
     void paint(QPainter* painter) override;
 
@@ -72,6 +76,7 @@ signals:
     void channelHeightRatioChanged();
     void isNearSampleChanged();
     void isStemPlotChanged();
+    void isIsolationModeChanged();
 
 private:
 
@@ -89,7 +94,9 @@ private:
     ClipTime m_clipTime;
     bool m_isNearSample = false;
     bool m_isStemPlot = false;
+    bool m_isIsolationMode = false;
 
     std::optional<int> m_currentChannel;
+    std::optional<QPoint> m_lastClickedPoint;
 };
 }


### PR DESCRIPTION
Resolves: #8301 

[**Figma**](https://www.figma.com/design/01XLIICmy2AG6t1ieyTp66/02---Clips?node-id=521-68148&p=f&t=fk6lkpWdn4EbhcJa-0)

This PR implements the isolation mode for sample view.
The user can "isolate" a sample pressing Ctrl and click and holding the mouse button.
It will only work if on pencil cursor.

The solution tracks the last clicked position on the waveview and handle the isolation the same way we do for multi sample edit despite the fact the first one needs the ctrl button to be pressed.

We "activate" the isolation mode on the press and hold event and we "deactivate" it either on ctrl release or on mouse release.

The release is handled on the next click event to distinguish the release of a long press and hold from a normal click event.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
