### PR TITLE
Fix black corners on images that already have rounded corners

### DIFF
--- a/libraries/lib-wx-wrappers/RoundedStaticBitmap.cpp
+++ b/libraries/lib-wx-wrappers/RoundedStaticBitmap.cpp
@@ -39,46 +39,53 @@ RoundedStaticBitmap::RoundedStaticBitmap(wxWindow *parent,
    for (int y = 0; y < h; y++) {
       for (int x = 0; x < w; x++) {
 
-            bool inCorner = false;
-            float dx = 0, dy = 0;
-            float alpha = 1.0f;
+         bool inCorner = false;
+         float dx = 0, dy = 0;
+         float alpha = 1.0f;
 
-            // top left
-            if (x < radius && y < radius) {
-               dx = radius - x - 1;
-               dy = radius - y - 1;
-               inCorner = true;
-            }
-            // top right
-            else if (x >= w - radius && y < radius) {
-               dx = x - (w - radius);
-               dy = radius - y - 1;
-               inCorner = true;
-            }
-            // bottom left
-            else if (x < radius && y >= h - radius) {
-               dx = radius - x - 1;
-               dy = y - (h - radius);
-               inCorner = true;
-            }
-            // bottom right
-            else if (x >= w - radius && y >= h - radius) {
-               dx = x - (w - radius);
-               dy = y - (h - radius);
-               inCorner = true;
-            }
+         // top left
+         if (x < radius && y < radius) {
+            dx = radius - x - 1;
+            dy = radius - y - 1;
+            inCorner = true;
+         }
+         // top right
+         else if (x >= w - radius && y < radius) {
+            dx = x - (w - radius);
+            dy = radius - y - 1;
+            inCorner = true;
+         }
+         // bottom left
+         else if (x < radius && y >= h - radius) {
+            dx = radius - x - 1;
+            dy = y - (h - radius);
+            inCorner = true;
+         }
+         // bottom right
+         else if (x >= w - radius && y >= h - radius) {
+            dx = x - (w - radius);
+            dy = y - (h - radius);
+            inCorner = true;
+         }
 
-            if (inCorner) {
-               const float distance = std::hypot(dx, dy);
-               if (distance > radius) {
-                  alpha = 0.0f;
-               }
-               else if (distance > radius - feather) {
-                  const float t = (radius - distance) / feather;
-                  alpha = t * t * (3.0f - 2.0f * t);
-               }
+         if (inCorner) {
+            const float distance = std::hypot(dx, dy);
+            if (distance > radius) {
+               alpha = 0.0f;
             }
-            image.SetAlpha(x, y, wxIMAGE_ALPHA_OPAQUE * alpha);
+            else if (distance > radius - feather) {
+               const float t = (radius - distance) / feather;
+               alpha = t * t * (3.0f - 2.0f * t);
+            }
+         }
+
+         const unsigned char currentAlpha = image.GetAlpha(x, y);
+         const unsigned char newAlpha = static_cast<unsigned char>(wxIMAGE_ALPHA_OPAQUE * alpha);
+
+         // do not increase the opacity
+         if (currentAlpha > newAlpha) {
+            image.SetAlpha(x, y, newAlpha);
+         }
       }
    }
    return image;


### PR DESCRIPTION
Do not increase the opacity when rounding the corners of an image to prevent artifacts.

Before:
![image](https://github.com/user-attachments/assets/651f6cbe-c839-4ab2-aba0-ecbc7b11809d)


After:
![image](https://github.com/user-attachments/assets/a7d43d4b-bb43-4ef9-b978-575281c0a2d2)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
