### PR TITLE
Increase the contrast for GetEffects buttons

### DIFF
--- a/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
+++ b/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
@@ -45,8 +45,8 @@ static constexpr int effectPanelHeight = effectIconHeight;
 static constexpr int getEffectButtonWidth = 187;
 static constexpr int getEffectButtonHeight = 30;
 
-static const wxColor musehubButtonNormal = wxColor(0x73, 0x73, 0xE5);
-static const wxColor musehubButtonPressed = wxColor(0x63, 0x63, 0xD5);
+static const wxColor musehubButtonNormal = wxColor(0x63, 0x63, 0xd5);
+static const wxColor musehubButtonPressed = wxColor(0x53, 0x53, 0xc5);
 
 static const auto loadingPluginsTabText = XO("Loading...");
 static const auto loadingPluginsText = XO("Please wait...");


### PR DESCRIPTION
Resolves: #8247

The contrast now is `4.91:1` and `6.15:1`

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
