### PR TITLE
Time, clip and track selections are retained after undo

### DIFF
--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -337,6 +337,7 @@ void RealtimeEffectService::setIsActive(const RealtimeEffectStatePtr& stateId, b
     }
     stateId->SetActive(isActive);
     projectHistory()->modifyState();
+    projectHistory()->markUnsaved();
     m_isActiveChanged.send(stateId);
 }
 
@@ -357,6 +358,7 @@ void RealtimeEffectService::setTrackEffectsActive(TrackId trackId, bool active)
     if (list && list->IsActive() != active) {
         list->SetActive(active);
         projectHistory()->modifyState();
+        projectHistory()->markUnsaved();
     }
 }
 

--- a/src/playback/internal/au3/au3trackplaybackcontrol.cpp
+++ b/src/playback/internal/au3/au3trackplaybackcontrol.cpp
@@ -83,6 +83,7 @@ void Au3TrackPlaybackControl::setSolo(long trackId, bool solo)
 
     m_muteOrSoloChanged.send(trackId);
     projectHistory()->modifyState();
+    projectHistory()->markUnsaved();
 }
 
 bool Au3TrackPlaybackControl::solo(long trackId) const
@@ -112,6 +113,7 @@ void Au3TrackPlaybackControl::setMuted(long trackId, bool mute)
 
     m_muteOrSoloChanged.send(trackId);
     projectHistory()->modifyState();
+    projectHistory()->markUnsaved();
 }
 
 bool Au3TrackPlaybackControl::muted(long trackId) const

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -287,6 +287,9 @@ Rectangle {
                 }
 
                 if (e.button === Qt.LeftButton) {
+
+                    tracksModel.startUserInteraction()
+
                     if (root.clipHeaderHovered) {
                         tracksClipsView.clipStartEditRequested(hoveredClipKey)
                     } else {
@@ -340,6 +343,8 @@ Rectangle {
 
                     clipsSelection.visible = false
                 }
+
+                tracksModel.endUserInteraction()
             }
 
             onClicked: e => {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -347,6 +347,11 @@ Rectangle {
                 tracksModel.endUserInteraction()
             }
 
+            onCanceled: e => {
+                console.log("User interaction canceled")
+                tracksModel.endUserInteraction()
+            }
+
             onClicked: e => {
                 if (e.button !== Qt.LeftButton) {
                     return

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -747,7 +747,6 @@ void ClipsListModel::selectClip(const ClipKey& key)
     Qt::KeyboardModifiers modifiers = keyboardModifiers();
 
     constexpr auto complete = true;
-    constexpr auto modifyState = true;
     const auto clipGroupId = trackeditInteraction()->clipGroupId(key.key);
     if (clipGroupId != -1) {
         //! NOTE: clip belongs to a group, select the whole group
@@ -756,7 +755,7 @@ void ClipsListModel::selectClip(const ClipKey& key)
                 selectionController()->addSelectedClip(key);
             }
         } else {
-            selectionController()->setSelectedClips(trackeditInteraction()->clipsInGroup(clipGroupId), complete, modifyState);
+            selectionController()->setSelectedClips(trackeditInteraction()->clipsInGroup(clipGroupId), complete);
         }
     } else {
         if (modifiers.testFlag(Qt::ShiftModifier)) {
@@ -765,14 +764,13 @@ void ClipsListModel::selectClip(const ClipKey& key)
             if (muse::contains(selectionController()->selectedClips(), key.key)) {
                 return;
             }
-            selectionController()->setSelectedClips(ClipKeyList({ key.key }), complete, modifyState);
+            selectionController()->setSelectedClips(ClipKeyList({ key.key }), complete);
         }
     }
 }
 
 void ClipsListModel::resetSelectedClips()
 {
-    selectionController()->resetSelectedClips();
     clearSelectedItems();
 }
 

--- a/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -222,7 +222,7 @@ void SelectionViewController::resetDataSelection()
     selectionController()->resetDataSelection();
 }
 
-bool SelectionViewController::isLeftSelection(double x)
+bool SelectionViewController::isLeftSelection(double x) const
 {
     if (!isProjectOpened()) {
         return false;

--- a/src/projectscene/view/clipsview/selectionviewcontroller.h
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.h
@@ -42,7 +42,7 @@ public:
 
     Q_INVOKABLE void resetSelectedClip();
     Q_INVOKABLE void resetDataSelection();
-    Q_INVOKABLE bool isLeftSelection(double x);
+    Q_INVOKABLE bool isLeftSelection(double x) const;
 
     bool selectionActive() const;
     void setSelectionActive(bool newSelectionActive);

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
@@ -145,6 +145,16 @@ void TracksListClipsModel::load()
     updateTotalTracksHeight();
 }
 
+void TracksListClipsModel::startUserInteraction()
+{
+    projectHistory()->startUserInteraction();
+}
+
+void TracksListClipsModel::endUserInteraction()
+{
+    projectHistory()->endUserInteraction();
+}
+
 void TracksListClipsModel::handleDroppedFiles(const QStringList& fileUrls)
 {
     std::vector<muse::io::path_t> localPaths;

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.h
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.h
@@ -11,6 +11,7 @@
 #include "context/iglobalcontext.h"
 #include "iprojectsceneconfiguration.h"
 #include "trackedit/iselectioncontroller.h"
+#include "trackedit/iprojecthistory.h"
 #include "playback/itrackplaybackcontrol.h"
 
 #include "trackedit/dom/track.h"
@@ -27,6 +28,7 @@ class TracksListClipsModel : public QAbstractListModel, public muse::async::Asyn
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<IProjectSceneConfiguration> configuration;
     muse::Inject<trackedit::ISelectionController> selectionController;
+    muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<playback::ITrackPlaybackControl> trackPlaybackControl;
 
 public:
@@ -34,6 +36,8 @@ public:
     TracksListClipsModel(QObject* parent = nullptr);
 
     Q_INVOKABLE void load();
+    Q_INVOKABLE void startUserInteraction();
+    Q_INVOKABLE void endUserInteraction();
     Q_INVOKABLE void handleDroppedFiles(const QStringList& fileUrls);
 
     int rowCount(const QModelIndex& parent) const override;

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -151,6 +151,8 @@ void TracksListModel::selectRow(int row, bool exclusive)
     } else {
         m_selectionModel->select(index(row));
     }
+
+    projectHistory()->modifyState();
 }
 
 void TracksListModel::clearSelection()

--- a/src/projectscene/view/trackspanel/trackslistmodel.h
+++ b/src/projectscene/view/trackspanel/trackslistmodel.h
@@ -10,6 +10,7 @@
 #include "context/iglobalcontext.h"
 #include "types/projectscenetypes.h"
 #include "trackedit/iselectioncontroller.h"
+#include "trackedit/iprojecthistory.h"
 
 #include "trackitem.h"
 
@@ -34,6 +35,7 @@ class TracksListModel : public QAbstractListModel, public muse::async::Asyncable
 
     muse::Inject<trackedit::ISelectionController> selectionController;
     muse::Inject<trackedit::ITrackeditInteraction> trackeditInteraction;
+    muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
 
 public:

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -996,7 +996,7 @@ muse::Ret Au3Interaction::pasteFromClipboard(secs_t begin)
         ok = makeRoomForDataOnTracks(dstTracksIds, copiedData, begin);
     }
     if (!ok) {
-        make_ret(trackedit::Err::FailedToMakeRoomForClip);
+        return make_ret(trackedit::Err::FailedToMakeRoomForClip);
     }
 
     for (size_t i = 0; i < dstTracksIds.size(); ++i) {

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -58,19 +58,12 @@ void au::trackedit::Au3ProjectHistory::redo()
 
 void au::trackedit::Au3ProjectHistory::pushHistoryState(const std::string& longDescription, const std::string& shortDescription)
 {
-    LOGD() << "Push history state: " << shortDescription;
-
-    auto& project = projectRef();
-    ::ProjectHistory::Get(project).PushState(TranslatableString { longDescription, {} }, TranslatableString { shortDescription, {} });
-
-    m_interactionOngoing = false;
-    m_isUndoRedoAvailableChanged.notify();
+    pushHistoryState(longDescription, shortDescription, UndoPushType::NONE);
 }
 
 void Au3ProjectHistory::pushHistoryState(const std::string& longDescription, const std::string& shortDescription, UndoPushType flags)
 {
-    LOGD() << "Push history state: " << shortDescription;
-
+    LOGI() << "pushHistoryState(\"" << shortDescription << "\", " << flags << ")";
     auto& project = projectRef();
     UndoPush undoFlags = static_cast<UndoPush>(flags);
     ::ProjectHistory::Get(project).PushState(TranslatableString { longDescription, {} }, TranslatableString { shortDescription, {} },
@@ -82,9 +75,8 @@ void Au3ProjectHistory::pushHistoryState(const std::string& longDescription, con
 
 void Au3ProjectHistory::startUserInteraction()
 {
-    if (!m_interactionOngoing) {
-        // Please report if you hit this.
-        LOGW() << "An interaction is already ongoing";
+    LOGI() << "startUserInteraction()";
+    IF_ASSERT_FAILED(!m_interactionOngoing) {
         return;
     }
     m_interactionOngoing = true;
@@ -92,6 +84,7 @@ void Au3ProjectHistory::startUserInteraction()
 
 void Au3ProjectHistory::endUserInteraction()
 {
+    LOGI() << "endUserInteraction()";
     if (m_interactionOngoing) {
         m_interactionOngoing = false;
         // No new history entry was pushed -> update the state.
@@ -101,17 +94,18 @@ void Au3ProjectHistory::endUserInteraction()
 
 void Au3ProjectHistory::modifyState(bool autoSave)
 {
+    LOGI() << "modifyState(" << (autoSave ? "true" : "false") << ")";
     if (m_interactionOngoing) {
         LOGW() << "Attempt to modify state during undoable action";
         return;
     }
-    LOGD() << "Modify state";
     auto& project = projectRef();
     ::ProjectHistory::Get(project).ModifyState(autoSave);
 }
 
 void Au3ProjectHistory::markUnsaved()
 {
+    LOGI() << "markUnsaved()";
     auto& project = projectRef();
     ::UndoManager::Get(project).MarkUnsaved();
 }

--- a/src/trackedit/internal/au3/au3projecthistory.h
+++ b/src/trackedit/internal/au3/au3projecthistory.h
@@ -30,11 +30,15 @@ public:
     void pushHistoryState(
         const std::string& longDescription, const std::string& shortDescription, UndoPushType flags) override;
     void modifyState(bool autoSave) override;
+    void markUnsaved() override;
+    void startUserInteraction() override;
+    void endUserInteraction() override;
     muse::async::Notification isUndoRedoAvailableChanged() const override;
 
 private:
     au3::Au3Project& projectRef();
 
+    bool m_interactionOngoing = false;
     muse::async::Notification m_isUndoRedoAvailableChanged;
     ::Observer::Subscription m_undoRedoMessageSubscription;
 };

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -246,7 +246,7 @@ ClipKeyList Au3SelectionController::selectedClipsInTrackOrder() const
     return sortedSelectedClips;
 }
 
-void Au3SelectionController::setSelectedClips(const ClipKeyList& clipKeys, bool complete, bool modifyState)
+void Au3SelectionController::setSelectedClips(const ClipKeyList& clipKeys, bool complete)
 {
     m_selectedClips.set(clipKeys, complete);
 
@@ -260,9 +260,6 @@ void Au3SelectionController::setSelectedClips(const ClipKeyList& clipKeys, bool 
         selectedTracks.push_back(key.trackId);
     }
     setSelectedTracks(selectedTracks, complete);
-    if (complete && modifyState) {
-        projectHistory()->modifyState();
-    }
 }
 
 void Au3SelectionController::addSelectedClip(const ClipKey& clipKey)
@@ -365,20 +362,6 @@ void Au3SelectionController::setSelectedTrackAudioData(TrackId trackId)
 
     secs_t audioDataStartTime = au3Track->GetStartTime();
     secs_t audioDataEndTime = au3Track->GetEndTime();
-
-    setDataSelectedStartTime(audioDataStartTime, true);
-    setDataSelectedEndTime(audioDataEndTime, true);
-}
-
-void Au3SelectionController::setSelectedClipAudioData(trackedit::TrackId trackId, secs_t time)
-{
-    const auto& clip = au3::DomAccessor::findWaveClip(projectRef(), trackId, time);
-    if (!clip) {
-        return;
-    }
-
-    secs_t audioDataStartTime = clip->Start();
-    secs_t audioDataEndTime = clip->End();
 
     setDataSelectedStartTime(audioDataStartTime, true);
     setDataSelectedEndTime(audioDataEndTime, true);

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../../iselectioncontroller.h"
-#include "../../iprojecthistory.h"
 
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
@@ -22,7 +21,6 @@ class Au3SelectionController : public ISelectionController, public muse::async::
 {
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<au::playback::IPlayback> playback;
-    muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
     Au3SelectionController() = default;
@@ -33,7 +31,6 @@ public:
     void resetSelectedTracks() override;
     trackedit::TrackIdList selectedTracks() const override;
     void setSelectedTracks(const trackedit::TrackIdList& trackIds, bool complete) override;
-    void addSelectedTrack(const trackedit::TrackId& trackId) override;
     muse::async::Channel<trackedit::TrackIdList> tracksSelected() const override;
     std::optional<TrackId> determinePointedTrack(double y) const override;
     trackedit::TrackIdList determinateTracks(double y1, double y2) const override;
@@ -43,7 +40,7 @@ public:
     bool hasSelectedClips() const override;
     ClipKeyList selectedClips() const override;
     ClipKeyList selectedClipsInTrackOrder() const override;
-    void setSelectedClips(const ClipKeyList& clipKeys, bool complete, bool modifyState) override;
+    void setSelectedClips(const ClipKeyList& clipKeys, bool complete) override;
     void addSelectedClip(const ClipKey& clipKey) override;
     void removeClipSelection(const ClipKey& clipKey) override;
     muse::async::Channel<ClipKeyList> clipsSelected() const override;
@@ -52,7 +49,6 @@ public:
 
     // data selection
     void setSelectedTrackAudioData(trackedit::TrackId trackId) override;
-    void setSelectedClipAudioData(trackedit::TrackId trackId, secs_t time) override;
     void resetDataSelection() override;
     bool timeSelectionIsNotEmpty() const override;
     bool isDataSelectedOnTrack(TrackId trackId) const override;
@@ -77,6 +73,7 @@ public:
     void resetTimeSelection() override;
 
 private:
+    void addSelectedTrack(const trackedit::TrackId& trackId);
     void updateSelectionController();
     void restoreSelection(const ClipAndTimeSelection& selection);
 

--- a/src/trackedit/iprojecthistory.h
+++ b/src/trackedit/iprojecthistory.h
@@ -25,6 +25,27 @@ public:
     virtual void pushHistoryState(const std::string& longDescription, const std::string& shortDescription,
                                   trackedit::UndoPushType flags) = 0;
     virtual void modifyState(bool autoSave = false) = 0;
+    virtual void markUnsaved() = 0;
+
+    /**
+     * @brief Start and end user interaction.
+     *
+     * @details Use these methods when you know the user starts an interaction that will either
+     * - add a new history entry, or
+     * - modify the current state,
+     * but you don't know which one it will be.
+     *
+     * Calling `startUserInteraction()` will protect against inadvertent state modifications in the middle of an interaction,
+     * which can introduce bugs in subsequent usage of undo.
+     * If, by the time `endUserInteraction()` is called, no new history entry was pushed, the current state will be modified automatically.
+     */
+    virtual void startUserInteraction() = 0;
+
+    /**
+     * @ref startUserInteraction()
+     */
+    virtual void endUserInteraction() = 0;
+
     virtual muse::async::Notification isUndoRedoAvailableChanged() const = 0;
 };
 

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -28,7 +28,6 @@ public:
     virtual void resetSelectedTracks() = 0;
     virtual TrackIdList selectedTracks() const = 0;
     virtual void setSelectedTracks(const TrackIdList& trackIds, bool complete = true) = 0;
-    virtual void addSelectedTrack(const trackedit::TrackId& trackId) = 0;
     virtual muse::async::Channel<TrackIdList> tracksSelected() const = 0;
     virtual std::optional<trackedit::TrackId> determinePointedTrack(double y) const = 0;
     virtual trackedit::TrackIdList determinateTracks(double y1, double y2) const = 0;
@@ -38,8 +37,7 @@ public:
     virtual bool hasSelectedClips() const = 0;
     virtual ClipKeyList selectedClips() const = 0;
     virtual ClipKeyList selectedClipsInTrackOrder() const = 0;
-    //! Note: history state gets modified only if both `complete` and `modifyState` are true
-    virtual void setSelectedClips(const ClipKeyList& clipKeys, bool complete = true, bool modifyState = false) = 0;
+    virtual void setSelectedClips(const ClipKeyList& clipKeys, bool complete = true) = 0;
     virtual void addSelectedClip(const ClipKey& clipKey) = 0;
     virtual void removeClipSelection(const ClipKey& clipKey) = 0;
     virtual muse::async::Channel<ClipKeyList> clipsSelected() const = 0;
@@ -51,7 +49,6 @@ public:
 
     // data selection
     virtual void setSelectedTrackAudioData(trackedit::TrackId trackId) = 0;
-    virtual void setSelectedClipAudioData(trackedit::TrackId trackId, secs_t time) = 0;
     virtual void resetDataSelection() = 0;
     virtual bool timeSelectionIsNotEmpty() const = 0;
     virtual bool isDataSelectedOnTrack(TrackId trackId) const = 0;

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -14,7 +14,6 @@ public:
     MOCK_METHOD(void, resetSelectedTracks, (), (override));
     MOCK_METHOD(TrackIdList, selectedTracks, (), (const, override));
     MOCK_METHOD(void, setSelectedTracks, (const TrackIdList&, bool), (override));
-    MOCK_METHOD(void, addSelectedTrack, (const trackedit::TrackId&), (override));
     MOCK_METHOD(void, removeClipSelection, (const trackedit::ClipKey&), (override));
     MOCK_METHOD(muse::async::Channel<TrackIdList>, tracksSelected, (), (const, override));
     MOCK_METHOD(std::optional<trackedit::TrackId>, determinePointedTrack, (double y), (const, override));
@@ -24,14 +23,13 @@ public:
     MOCK_METHOD(bool, hasSelectedClips, (), (const, override));
     MOCK_METHOD(ClipKeyList, selectedClips, (), (const, override));
     MOCK_METHOD(ClipKeyList, selectedClipsInTrackOrder, (), (const, override));
-    MOCK_METHOD(void, setSelectedClips, (const ClipKeyList&, bool, bool), (override));
+    MOCK_METHOD(void, setSelectedClips, (const ClipKeyList&, bool), (override));
     MOCK_METHOD(void, addSelectedClip, (const ClipKey& clipKey), (override));
     MOCK_METHOD(muse::async::Channel<ClipKeyList>, clipsSelected, (), (const, override));
     MOCK_METHOD(double, selectedClipStartTime, (), (const, override));
     MOCK_METHOD(double, selectedClipEndTime, (), (const, override));
 
     MOCK_METHOD(void, setSelectedTrackAudioData, (TrackId), (override));
-    MOCK_METHOD(void, setSelectedClipAudioData, (TrackId, secs_t), (override));
     MOCK_METHOD(void, resetDataSelection, (), (override));
     MOCK_METHOD(bool, timeSelectionIsNotEmpty, (), (const, override));
     MOCK_METHOD(bool, isDataSelectedOnTrack, (TrackId), (const, override));

--- a/src/trackedit/trackedittypes.h
+++ b/src/trackedit/trackedittypes.h
@@ -61,3 +61,16 @@ inline muse::logger::Stream& operator<<(muse::logger::Stream& s, const au::track
     s << "{trackId: " << k.trackId << ", clip: " << k.clipId << "}";
     return s;
 }
+
+inline muse::logger::Stream& operator<<(muse::logger::Stream& s, au::trackedit::UndoPushType t)
+{
+    switch (t) {
+    case au::trackedit::UndoPushType::NONE: s << "UndoPushType::NONE";
+        break;
+    case au::trackedit::UndoPushType::CONSOLIDATE: s << "UndoPushType::CONSOLIDATE";
+        break;
+    case au::trackedit::UndoPushType::NOAUTOSAVE: s << "UndoPushType::NOAUTOSAVE";
+        break;
+    }
+    return s;
+}


### PR DESCRIPTION
Resolves: #8384

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] time selection is preserved after undo/redo
- [x] clip selection is preserved after undo/redo
- [x] track selection is preserved after undo/redo