### PR TITLE
8201 Snap to sample on audio selection

### DIFF
--- a/src/projectscene/view/clipsview/au3/samplespainter.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainter.cpp
@@ -84,7 +84,7 @@ void SamplesPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKey,
     const bool dB = !settings.isLinear();
     const double trimLeft = waveClip->GetTrimLeft();
 
-    auto waveMetrics = wavepainterutils::getWaveMetrics(globalContext()->currentProject(), clipKey, params);
+    auto waveMetrics = wavepainterutils::getWaveMetrics(globalContext()->currentProject(), clipKey, params, true);
 
     for (size_t index = 0; index < waveClip->NChannels(); index++) {
         waveMetrics.height = channelHeight[index];

--- a/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
@@ -71,7 +71,7 @@ std::vector<QPoint> interpolatePoints(const QPoint& previousPosition, const QPoi
     std::vector<QPoint> container;
     if (previousPosition.x() == finalPosition.x()) {
         container.push_back(finalPosition);
-        return std::move(container);
+        return container;
     }
 
     container.reserve(std::abs(previousPosition.x() - finalPosition.x()));
@@ -96,7 +96,7 @@ std::vector<QPoint> interpolatePoints(const QPoint& previousPosition, const QPoi
         }
     }
 
-    return std::move(container);
+    return container;
 }
 }
 

--- a/src/projectscene/view/clipsview/au3/wavepainterutils.h
+++ b/src/projectscene/view/clipsview/au3/wavepainterutils.h
@@ -8,5 +8,5 @@
 namespace au::projectscene::wavepainterutils {
 IWavePainter::PlotType getPlotType(std::shared_ptr<au::project::IAudacityProject> project, const trackedit::ClipKey& clipKey, double zoom);
 WaveMetrics getWaveMetrics(std::shared_ptr<au::project::IAudacityProject> project, const trackedit::ClipKey& clipKey,
-                           const IWavePainter::Params& params);
+                           const IWavePainter::Params& params, bool snapToSamples = false);
 }


### PR DESCRIPTION
Resolves: #8201 

Snap to samples when selecting audio on sample view.
It also works for stretched clips (this is not working on AU3)

![image](https://github.com/user-attachments/assets/9441acb3-1c2d-4c0e-8167-0441a7ded41d)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
