### PR TITLE
Fix cursor shape under clip data selection

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
@@ -6,6 +6,7 @@ Item {
     property double channelHeightRatio: 0.5
     property alias color : splitter.color
     property alias thickness: splitter.height
+    property alias editable: dragArea.visible
 
     opacity: 0.05
 
@@ -27,6 +28,8 @@ Item {
     }
 
     MouseArea {
+        id: dragArea
+
         anchors.fill: splitter
         anchors.margins: -2
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -91,8 +91,8 @@ Rectangle {
     property bool isIsolationMode: false
     property alias isNearSample: waveView.isNearSample
     property alias currentChannel: waveView.currentChannel
-    property alias leftTrimContainsMouse: leftTrimStretchEdgeHover.containsMouse
-    property alias rightTrimContainsMouse: rightTrimStretchEdgeHover.containsMouse
+    property bool leftTrimContainsMouse: false
+    property bool rightTrimContainsMouse: false
     property alias leftTrimPressedButtons: leftTrimStretchEdgeHover.pressedButtons
     property alias rightTrimPressedButtons: rightTrimStretchEdgeHover.pressedButtons
 
@@ -165,6 +165,16 @@ Rectangle {
         multiClipContextMenuModel.load()
     }
 
+    Component.onDestruction: {
+        //! NOTE The outer component uses this information to handle the current cursor.
+        // It is important to cleanup this state before removing the component
+        // to prevent the cursor from being stuck in the wrong state.
+        waveView.isNearSample = false
+        waveView.isStemPlot = false
+        root.leftTrimContainsMouse = false
+        root.rightTrimContainsMouse = false
+    }
+
     MouseArea {
         id: hoverArea
         anchors.fill: parent
@@ -213,6 +223,7 @@ Rectangle {
 
         // make sure cursor is visible on top of nearby clips
         onContainsMouseChanged: {
+            root.leftTrimContainsMouse = containsMouse
             if (containsMouse || pressedButtons) {
                 root.parent.z = 1
             } else {
@@ -269,6 +280,7 @@ Rectangle {
 
         // make sure cursor is visible on top of nearby clips
         onContainsMouseChanged: {
+            root.rightTrimContainsMouse = containsMouse
             if (containsMouse || pressedButtons) {
                 root.parent.z = 1
             } else {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -34,6 +34,8 @@ Rectangle {
     property bool isAudible: true
     property real selectionStart: 0
     property real selectionWidth: 0
+    property bool selectionInProgress: false
+    property bool enableCursorInteraction: !selectionInProgress && !isBrush
 
     property real distanceToLeftNeighbor: -1
     property real distanceToRightNeighbor: -1
@@ -171,6 +173,8 @@ Rectangle {
         cursorShape: Qt.IBeamCursor
         acceptedButtons: Qt.RightButton
 
+        visible: root.enableCursorInteraction
+
         onClicked: function(e) {
             if (root.multiClipsSelected) {
                 multiClipContextMenuLoader.show(Qt.point(e.x, e.y), multiClipContextMenuModel.items)
@@ -195,8 +199,6 @@ Rectangle {
     MouseArea {
         id: leftTrimStretchEdgeHover
 
-        enabled: !root.isBrush
-
         x: distanceToLeftNeighbor >= -0.5 && distanceToLeftNeighbor <= 10 ? root.x - Math.min(distanceToLeftNeighbor / 2, 5) : root.x - 5
         width: distanceToLeftNeighbor >= -0.5 && distanceToLeftNeighbor <= 10 ? 6 + Math.min(distanceToLeftNeighbor / 2, 5) : 11
         z: headerDragArea.z + 1
@@ -205,7 +207,7 @@ Rectangle {
         anchors.top: root.top
 
         hoverEnabled: true
-        visible: !root.clipSelected
+        visible: !root.clipSelected && root.enableCursorInteraction
 
         cursorShape: Qt.BlankCursor
 
@@ -253,8 +255,6 @@ Rectangle {
     MouseArea {
         id: rightTrimStretchEdgeHover
 
-        enabled: !root.isBrush
-
         x: root.width - 5
         z: headerDragArea.z + 1
         width: distanceToRightNeighbor >= -0.5 && distanceToRightNeighbor <= 10 ? 6 + Math.min(distanceToRightNeighbor / 2, 5): 11
@@ -263,7 +263,7 @@ Rectangle {
         anchors.top: root.top
 
         hoverEnabled: true
-        visible: !root.clipSelected
+        visible: !root.clipSelected && root.enableCursorInteraction
 
         cursorShape: Qt.BlankCursor
 
@@ -351,7 +351,7 @@ Rectangle {
                 id: headerDragArea
                 anchors.fill: parent
 
-                enabled:  !root.isBrush
+                visible: root.enableCursorInteraction
 
                 acceptedButtons: Qt.LeftButton
                 hoverEnabled: true
@@ -468,6 +468,8 @@ Rectangle {
                 ClipItemPropertyButton {
                     id: pitchBtn
 
+                    mouseArea.visible: root.enableCursorInteraction
+
                     text: {
                         let semis = Math.trunc(root.pitch / 100)
                         let cents = Math.abs(root.pitch % 100).toString().padStart(2, "0")
@@ -489,6 +491,8 @@ Rectangle {
                 ClipItemPropertyButton {
                     id: speedBtn
 
+                    mouseArea.visible: root.enableCursorInteraction
+
                     icon: IconCode.CLOCK
                     text: root.speedPercentage + "%"
 
@@ -508,6 +512,8 @@ Rectangle {
                     width: 16
                     height: 16
                     anchors.verticalCenter: parent.verticalCenter
+
+                    mouseArea.visible: root.enableCursorInteraction
 
                     menuModel: (root.multiClipsSelected || root.groupId != -1) ? multiClipContextMenuModel : singleClipContextMenuModel
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -575,6 +575,8 @@ Rectangle {
 
                 anchors.fill: parent
 
+                editable: root.enableCursorInteraction
+
                 color: "#000000"
                 opacity: 0.10
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipsSelection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipsSelection.qml
@@ -4,6 +4,7 @@ Item {
     id: root
 
     property bool isDataSelected: false
+    property bool selectionInProgress: false
     property alias active: selRect.visible
     property var context: null
     //! NOTE: sync with SelectionViewController's MIN_SELECTION_PX
@@ -11,6 +12,11 @@ Item {
 
     signal selectionDraged(var x1, var x2, var completed)
     signal requestSelectionContextMenu(real x, real y)
+
+    onSelectionInProgressChanged: {
+        leftMa.cursorShape = root.selectionInProgress ? Qt.IBeamCursor : Qt.SizeHorCursor
+        rightMa.cursorShape = root.selectionInProgress ? Qt.IBeamCursor : Qt.SizeHorCursor
+    }
 
     Rectangle {
         id: selRect
@@ -64,10 +70,10 @@ Item {
             if (mouse.button !== Qt.LeftButton) {
                 return
             }
-            leftMa.cursorShape = Qt.ArrowCursor
             leftMa.startX = selRect.x
             leftMa.startW = selRect.width
             leftMa.x = selRect.x
+            centerMa.cursorShape = Qt.SizeHorCursor
         }
 
         onPositionChanged: function(mouse) {
@@ -89,6 +95,7 @@ Item {
             root.selectionDraged(selRect.x, selRect.x + selRect.width, true)
             leftMa.x = Qt.binding(function() { return selRect.x })
             leftMa.cursorShape = Qt.SizeHorCursor
+            centerMa.cursorShape = Qt.IBeamCursor
         }
 
         onClicked: function(mouse) {
@@ -120,9 +127,9 @@ Item {
             if (mouse.button !== Qt.LeftButton) {
                 return
             }
-            rightMa.cursorShape = Qt.ArrowCursor
             rightMa.startW = selRect.width
             rightMa.x = selRect.x + selRect.width - rightMa.width
+            centerMa.cursorShape = Qt.SizeHorCursor
         }
 
         onPositionChanged: function(mouse) {
@@ -143,6 +150,7 @@ Item {
             root.selectionDraged(selRect.x, selRect.x + selRect.width, true)
             rightMa.x = Qt.binding(function() {return selRect.x + selRect.width - rightMa.width })
             rightMa.cursorShape = Qt.SizeHorCursor
+            centerMa.cursorShape = Qt.IBeamCursor
         }
 
         onClicked: function(mouse) {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipsSelection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipsSelection.qml
@@ -43,6 +43,8 @@ Item {
 
         visible: isDataSelected
 
+        cursorShape: Qt.IBeamCursor
+
         onClicked: function(mouse) {
             let position = mapToItem(root.parent, Qt.point(mouse.x, mouse.y))
             root.requestSelectionContextMenu(position.x, position.y)

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -20,7 +20,6 @@ Item {
     property bool isStereo: clipsModel.isStereo
     property double channelHeightRatio: isStereo ? 0.5 : 1
     property bool moveActive: false
-    property bool underSelection: false
     property bool altPressed: false
     property bool ctrlPressed: false
     property alias isNearSample: clipsContainer.isNearSample
@@ -30,6 +29,8 @@ Item {
     property alias rightTrimContainsMouse: clipsContainer.rightTrimContainsMouse
     property alias leftTrimPressedButtons: clipsContainer.leftTrimPressedButtons
     property alias rightTrimPressedButtons: clipsContainer.rightTrimPressedButtons
+    property bool selectionEditInProgress: false
+    property bool selectionInProgress: false
 
     signal interactionStarted()
     signal interactionEnded()
@@ -123,7 +124,8 @@ Item {
             propagateComposedEvents: true
             hoverEnabled: true
             pressAndHoldInterval: 0
-            enabled: !root.underSelection && (clipsContainer.isNearSample || clipsContainer.isBrush)
+            enabled: !root.selectionInProgress && (clipsContainer.isNearSample || clipsContainer.isBrush)
+            cursorShape: root.selectionEditInProgress ? Qt.SizeHorCursor : Qt.IBeamCursor 
 
             anchors.fill: parent
 
@@ -251,6 +253,7 @@ Item {
                 isAudible: root.isTrackAudible
                 multiSampleEdit: clipsContainer.multiSampleEdit
                 altPressed: root.altPressed
+                selectionInProgress: root.selectionInProgress || root.selectionEditInProgress
 
                 //! NOTE: use the same integer rounding as in WaveBitmapCache
                 selectionStart: root.context.selectionStartPosition < clipItem.x ? 0 : Math.floor(root.context.selectionStartPosition - clipItem.x + 0.5)
@@ -409,6 +412,7 @@ Item {
         id: clipsSelection
 
         isDataSelected: root.isDataSelected
+        selectionInProgress: root.selectionInProgress
         context: root.context
 
         anchors.fill: parent

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -465,6 +465,8 @@ Item {
 
         cursorShape: Qt.SizeVerCursor
 
+        visible: !root.selectionInProgress
+
         onPressed: {
             root.interactionStarted()
         }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -285,37 +285,37 @@ Item {
                         if (clipItem.isNearSample) {
                             clipsContainer.currentChannel = clipItem.currentChannel
                         }
-                        return clipItem.isNearSample
+                        return clipItem && clipItem.isNearSample
                     })
                 }
 
                 onIsBrushChanged: function() {
                     clipsContainer.isBrush = clipsContainer.checkIfAnyClip(function(clipItem) {
-                        return clipItem.isBrush
+                        return clipItem && clipItem.isBrush
                     })
                 }
 
                 onLeftTrimContainsMouseChanged: function() {
                     clipsContainer.leftTrimContainsMouse = clipsContainer.checkIfAnyClip(function(clipItem) {
-                        return clipItem.leftTrimContainsMouse
+                        return clipItem && clipItem.leftTrimContainsMouse
                     })
                 }
 
                 onRightTrimContainsMouseChanged: function() {
                     clipsContainer.rightTrimContainsMouse = clipsContainer.checkIfAnyClip(function(clipItem) {
-                        return clipItem.rightTrimContainsMouse
+                        return clipItem && clipItem.rightTrimContainsMouse
                     })
                 }
 
                 onLeftTrimPressedButtonsChanged: function() {
                     clipsContainer.leftTrimPressedButtons = clipsContainer.checkIfAnyClip(function(clipItem) {
-                        return clipItem.leftTrimPressedButtons
+                        return clipItem && clipItem.leftTrimPressedButtons
                     })
                 }
 
                 onRightTrimPressedButtonsChanged: function() {
                     clipsContainer.rightTrimPressedButtons = clipsContainer.checkIfAnyClip(function(clipItem) {
-                        return clipItem.rightTrimPressedButtons
+                        return clipItem && clipItem.rightTrimPressedButtons
                     })
                 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -15,7 +15,6 @@ Rectangle {
     property bool clipHeaderHovered: false
     property var hoveredClipKey: null
     property bool tracksHovered: false
-    property bool underSelection: false
     property bool altPressed: false
     property bool ctrlPressed: false
 
@@ -97,14 +96,6 @@ Rectangle {
     SelectionViewController {
         id: selectionController
         context: timeline.context
-
-        onSelectionStarted: {
-            underSelection = true
-        }
-
-        onSelectionEnded: {
-            underSelection = false
-        }
     }
 
     Component.onCompleted: {
@@ -274,6 +265,7 @@ Rectangle {
 
             preventStealing: true
             acceptedButtons: Qt.LeftButton | Qt.RightButton
+            cursorShape: Qt.IBeamCursor
 
             hoverEnabled: true
 
@@ -475,9 +467,10 @@ Rectangle {
                     isMultiSelectionActive: model.isMultiSelectionActive
                     isTrackAudible: model.isTrackAudible
                     moveActive: tracksClipsView.moveActive
-                    underSelection: root.underSelection
                     altPressed: root.altPressed
                     ctrlPressed: root.ctrlPressed
+                    selectionEditInProgress: selectionController.selectionEditInProgress
+                    selectionInProgress: selectionController.selectionInProgress
 
                     onTrackItemMousePositionChanged: function(xWithinTrack, yWithinTrack, clipKey) {
                         let xGlobalPosition = xWithinTrack
@@ -574,15 +567,6 @@ Rectangle {
                         content.rightTrimPressedButtons = tracksClipsView.checkIfAnyTrack(function(track){
                             return track.rightTrimPressedButtons
                         })
-                    }
-                }
-
-                HoverHandler {
-                    property bool isNeedSelectionCursor: !selectionController.selectionActive
-                    cursorShape: isNeedSelectionCursor ? Qt.IBeamCursor : Qt.ArrowCursor
-
-                    onHoveredChanged: {
-                        root.tracksHovered = hovered
                     }
                 }
             }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -529,43 +529,43 @@ Rectangle {
 
                     onIsBrushChanged: function() {
                         content.isBrush = tracksClipsView.checkIfAnyTrack(function(track) {
-                            return track.isBrush
+                            return track && track.isBrush
                         })
                     }
 
                     onIsIsolationModeChanged: function() {
                         content.isIsolationMode = tracksClipsView.checkIfAnyTrack(function(track){
-                            return track.isIsolationMode
+                            return track && track.isIsolationMode
                         })
                     }
 
                     onIsNearSampleChanged: function() {
                         content.isNearSample = tracksClipsView.checkIfAnyTrack(function(track){
-                            return track.isNearSample
+                            return track &&track.isNearSample
                         })
                     }
 
                     onLeftTrimContainsMouseChanged: function() {
                         content.leftTrimContainsMouse = tracksClipsView.checkIfAnyTrack(function(track){
-                            return track.leftTrimContainsMouse
+                            return track && track.leftTrimContainsMouse
                         })
                     }
 
                     onRightTrimContainsMouseChanged: function() {
                         content.rightTrimContainsMouse = tracksClipsView.checkIfAnyTrack(function(track){
-                            return track.rightTrimContainsMouse
+                            return track && track.rightTrimContainsMouse
                         })
                     }
 
                     onLeftTrimPressedButtonsChanged: function() {
                         content.leftTrimPressedButtons = tracksClipsView.checkIfAnyTrack(function(track){
-                            return track.leftTrimPressedButtons
+                            return track && track.leftTrimPressedButtons
                         })
                     }
 
                     onRightTrimPressedButtonsChanged: function() {
                         content.rightTrimPressedButtons = tracksClipsView.checkIfAnyTrack(function(track){
-                            return track.rightTrimPressedButtons
+                            return track && track.rightTrimPressedButtons
                         })
                     }
                 }

--- a/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -34,6 +34,7 @@ void SelectionViewController::onPressed(double x, double y)
         selectionController()->setSelectionStartTime(m_context->positionToTime(m_startPoint.x()));
     }
     emit selectionStarted();
+    emit selectionInProgressChanged();
     resetDataSelection();
 
     TrackIdList tracks;
@@ -131,6 +132,7 @@ void SelectionViewController::onReleased(double x, double y)
 
     // point
     emit selectionEnded(m_startPoint, QPointF(x, y));
+    emit selectionInProgressChanged();
 
     double x1 = m_startPoint.x();
     double x2 = x;
@@ -179,6 +181,8 @@ void SelectionViewController::onSelectionDraged(double x1, double x2, bool compl
     }
 
     setSelection(x1, x2, completed);
+    m_selectionEditInProgress = !completed;
+    emit selectionEditInProgressChanged();
 }
 
 void SelectionViewController::selectTrackAudioData(double y)
@@ -277,6 +281,16 @@ void SelectionViewController::setTimelineContext(TimelineContext* newContext)
 bool SelectionViewController::selectionActive() const
 {
     return m_selectionActive;
+}
+
+bool SelectionViewController::selectionEditInProgress() const
+{
+    return m_selectionEditInProgress;
+}
+
+bool SelectionViewController::selectionInProgress() const
+{
+    return m_selectionStarted;
 }
 
 void SelectionViewController::setSelectionActive(bool newSelectionActive)

--- a/src/projectscene/view/clipsview/selectionviewcontroller.h
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.h
@@ -18,6 +18,8 @@ class SelectionViewController : public QObject
     Q_PROPERTY(TimelineContext * context READ timelineContext WRITE setTimelineContext NOTIFY timelineContextChanged FINAL)
 
     Q_PROPERTY(bool selectionActive READ selectionActive NOTIFY selectionActiveChanged FINAL)
+    Q_PROPERTY(bool selectionEditInProgress READ selectionEditInProgress NOTIFY selectionEditInProgressChanged FINAL)
+    Q_PROPERTY(bool selectionInProgress READ selectionInProgress NOTIFY selectionInProgressChanged FINAL)
 
     muse::Inject<context::IGlobalContext> globalContext;
     muse::Inject<trackedit::ISelectionController> selectionController;
@@ -45,11 +47,15 @@ public:
     Q_INVOKABLE bool isLeftSelection(double x) const;
 
     bool selectionActive() const;
+    bool selectionEditInProgress() const;
+    bool selectionInProgress() const;
     void setSelectionActive(bool newSelectionActive);
 
 signals:
     void timelineContextChanged();
     void selectionActiveChanged();
+    void selectionEditInProgressChanged();
+    void selectionInProgressChanged();
 
     void selectionStarted();
     void selectionChanged(QPointF p1, QPointF p2);
@@ -70,6 +76,7 @@ private:
 
     bool m_selectionStarted = false;
     bool m_selectionActive = false;
+    bool m_selectionEditInProgress = false;
     QPointF m_startPoint;
     QPointF m_lastPoint;
 };


### PR DESCRIPTION
Resolves: #8146 

Added two properties on selectioncontroller (selectionInProgress and selectionEditInProgress)
We use it to disable other mouseAreas during selection to avoid cursor change on hovering.
Apart from that, we ensure the correct cursor while editing the selection area and after a selection is done.

To QA:
- [ ]  IBeam cursor during the whole selection process.
- [ ] SizeHor cursor during selection edit
- [ ] After a selection is done the cursor should continue on IBeam

---

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
