### PR TITLE
Fix clip being incorrectly shifted after join/paste/apply effect operations (#8421)

### DIFF
--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1121,7 +1121,7 @@ bool WaveClip::Paste(double t0, const WaveClip& o)
       mClipStretchRatio = other.mClipStretchRatio;
       mProjectTempo = other.mProjectTempo;
    }
-   else if (GetStretchRatio() != other.GetStretchRatio())
+   else if (!HasEqualPitchAndSpeed(other))
       // post is satisfied
       return false;
 
@@ -1145,7 +1145,7 @@ bool WaveClip::Paste(double t0, const WaveClip& o)
    if (t0 == GetPlayStartTime())
    {
       pastePositionShift = t0;
-      startPositionShift = other.GetSequenceStartTime() + GetTrimLeft();
+      startPositionShift = GetTrimLeft() - other.GetTrimLeft();
 
       finisher = ClearSequence(GetSequenceStartTime(), t0);
       SetTrimLeft(other.GetTrimLeft());

--- a/libraries/lib-wave-track/WaveTrack.cpp
+++ b/libraries/lib-wave-track/WaveTrack.cpp
@@ -1860,7 +1860,7 @@ void WaveTrack::PasteWaveTrackAtSameTempo(
                // This branch only gets executed in `singleClipMode` - we've
                // already made sure that stretch ratios are equal, satisfying
                // `WaveClip::Paste`'s precondition.
-               assert(insideClip->GetStretchRatio() == pClip->GetStretchRatio());
+               assert(insideClip->HasEqualPitchAndSpeed(*pClip));
                // This too should follow from the assertion of the same number
                // of channels in the tracks, near the top
                assert(insideClip->NChannels() == pClip->NChannels());
@@ -2206,7 +2206,7 @@ void WaveTrack::Join(
    auto t = firstToDelete->GetPlayStartTime();
    //preserve left trim data if any
    newClip = CreateClip(
-      firstToDelete->GetSequenceStartTime(),
+      firstToDelete->GetPlayStartTime(),
       firstToDelete->GetName());
 
    for (const auto &clip : clipsToDelete) {


### PR DESCRIPTION
Fix clip being incorrectly shifted after join/paste/apply effect operations

Resolves: #8421 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
