### PR TITLE
Implement disjoin command (split clips at silences)

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -517,7 +517,7 @@ MenuItemList AppMenuModel::makeClipItems()
         makeSeparator(),
         makeMenuItem("split"),
         makeMenuItem("split-into-new-track"),
-        makeMenuItem("split-clips-at-silences"),
+        makeMenuItem("disjoin"),
         makeMenuItem("join"),
         makeSeparator(),
         makeMenuItem("group-clips"),

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -113,12 +113,6 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "Split into new track"),
              TranslatableString("action", "Split into new track")
              ),
-    UiAction("split-clips-at-silences",
-             au::context::UiCtxAny,
-             au::context::CTX_ANY,
-             TranslatableString("action", "Split clips at silences"),
-             TranslatableString("action", "Split clips at silences")
-             ),
     UiAction("silence-audio",
              au::context::UiCtxAny,
              au::context::CTX_ANY,

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1502,6 +1502,25 @@ NeedsDownmixing Au3Interaction::moveSelectedClipsUpOrDown(int offset)
     return needsDownmixing;
 }
 
+bool Au3Interaction::splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end)
+{
+    for (const auto& trackId : tracksIds) {
+        Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
+        IF_ASSERT_FAILED(waveTrack) {
+            continue;
+        }
+
+        waveTrack->Disjoin(begin, end);
+
+        trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+        prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
+    }
+
+    projectHistory()->pushHistoryState("Split clips at silence", "Split at silence");
+
+    return true;
+}
+
 bool Au3Interaction::mergeSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1502,7 +1502,7 @@ NeedsDownmixing Au3Interaction::moveSelectedClipsUpOrDown(int offset)
     return needsDownmixing;
 }
 
-bool Au3Interaction::splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end)
+bool Au3Interaction::splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
     for (const auto& trackId : tracksIds) {
         Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
@@ -1511,6 +1511,30 @@ bool Au3Interaction::splitClipsAtSilences(const TrackIdList& tracksIds, secs_t b
         }
 
         waveTrack->Disjoin(begin, end);
+
+        trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+        prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
+    }
+
+    projectHistory()->pushHistoryState("Split clips at silence", "Split at silence");
+
+    return true;
+}
+
+bool Au3Interaction::splitClipsAtSilences(const ClipKeyList& clipKeyList)
+{
+    for (const auto& clipKey : clipKeyList) {
+        Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(clipKey.trackId));
+        IF_ASSERT_FAILED(waveTrack) {
+            continue;
+        }
+
+        std::shared_ptr<Au3WaveClip> clip = DomAccessor::findWaveClip(waveTrack, clipKey.clipId);
+        IF_ASSERT_FAILED(clip) {
+            continue;
+        }
+
+        waveTrack->Disjoin(clip->Start(), clip->End());
 
         trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
         prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -59,6 +59,7 @@ public:
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) override;
     bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) override;
+    bool splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateClip(const ClipKey& clipKey) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -59,7 +59,8 @@ public:
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) override;
     bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) override;
-    bool splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
+    bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
+    bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateClip(const ClipKey& clipKey) override;

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -73,6 +73,7 @@ private:
     void trackSplit(const muse::actions::ActionData& args);
     void tracksSplitAt(const muse::actions::ActionData& args);
     void splitClipsAtSilences(const muse::actions::ActionData& args);
+    void splitRangeSelectionAtSilences(const muse::actions::ActionData& args);
     void mergeSelectedOnTrack(const muse::actions::ActionData& args);
     void duplicateSelected(const muse::actions::ActionData& args);
     void duplicateClips(const muse::actions::ActionData& args);

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -53,6 +53,7 @@ private:
     void doGlobalSplitDelete();
     void doGlobalSplit();
     void doGlobalJoin();
+    void doGlobalDisjoin();
     void doGlobalDuplicate();
 
     void clipCut(const muse::actions::ActionData& args);
@@ -71,6 +72,7 @@ private:
 
     void trackSplit(const muse::actions::ActionData& args);
     void tracksSplitAt(const muse::actions::ActionData& args);
+    void splitClipsAtSilences(const muse::actions::ActionData& args);
     void mergeSelectedOnTrack(const muse::actions::ActionData& args);
     void duplicateSelected(const muse::actions::ActionData& args);
     void duplicateClips(const muse::actions::ActionData& args);

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -144,6 +144,11 @@ bool TrackeditInteraction::splitTracksAt(const TrackIdList& tracksIds, secs_t pi
     return withPlaybackStop(&ITrackeditInteraction::splitTracksAt, tracksIds, pivot);
 }
 
+bool TrackeditInteraction::splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end)
+{
+    return withPlaybackStop(&ITrackeditInteraction::splitClipsAtSilences, tracksIds, begin, end);
+}
+
 bool TrackeditInteraction::mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
     return withPlaybackStop(&ITrackeditInteraction::mergeSelectedOnTracks, tracksIds, begin, end);

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -144,9 +144,14 @@ bool TrackeditInteraction::splitTracksAt(const TrackIdList& tracksIds, secs_t pi
     return withPlaybackStop(&ITrackeditInteraction::splitTracksAt, tracksIds, pivot);
 }
 
-bool TrackeditInteraction::splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end)
+bool TrackeditInteraction::splitClipsAtSilences(const ClipKeyList& clipKeyList)
 {
-    return withPlaybackStop(&ITrackeditInteraction::splitClipsAtSilences, tracksIds, begin, end);
+    return withPlaybackStop(&ITrackeditInteraction::splitClipsAtSilences, clipKeyList);
+}
+
+bool TrackeditInteraction::splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end)
+{
+    return withPlaybackStop(&ITrackeditInteraction::splitRangeSelectionAtSilences, tracksIds, begin, end);
 }
 
 bool TrackeditInteraction::mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -45,6 +45,7 @@ private:
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) override;
     bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) override;
+    bool splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateClip(const ClipKey& clipKey) override;

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -45,7 +45,8 @@ private:
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) override;
     bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) override;
-    bool splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
+    bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
+    bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateClip(const ClipKey& clipKey) override;

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -109,6 +109,12 @@ const UiActionList TrackeditUiActions::m_actions = {
              TranslatableString("action", "Merge selected clips"),
              TranslatableString("action", "Merge selected clips")
              ),
+    UiAction("disjoin",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Split clips at silences"),
+             TranslatableString("action", "Split clips at silences")
+             ),
     UiAction("undo",
              au::context::UiCtxAny,
              au::context::CTX_ANY,

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -60,7 +60,8 @@ public:
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) = 0;
-    virtual bool splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
+    virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
+    virtual bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool duplicateClip(const ClipKey& clipKey) = 0;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -60,6 +60,7 @@ public:
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) = 0;
+    virtual bool splitClipsAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool duplicateClip(const ClipKey& clipKey) = 0;


### PR DESCRIPTION
Resolves: #8404 

Implement split clips on silence command

The command can be triggered by the shortcut Ctrl + Alt + j or on the menu (Edit -> Clip -> Split clips at silences)
The operation will also be added to the history.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior


---

QA

- [x] Trigger the command using the menu
- [x] Trigger the command using the shortcut
- [x] Time range
- [x] Single clip
- [x] Multi clip
