### PR TITLE
Fix multi sample edit for slow mouse movements

### DIFF
--- a/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
@@ -76,8 +76,8 @@ std::vector<QPoint> interpolatePoints(const QPoint& previousPosition, const QPoi
 
     container.reserve(std::abs(previousPosition.x() - finalPosition.x()));
 
-    // We do a simple linear interpolation if the move more than 1 pixel to avoid missing point due mouse fast movement
-    if (std::abs(previousPosition.x() - finalPosition.x()) > 1) {
+    // We do a simple linear interpolation to handle fast mouse movements
+    if (previousPosition.x() != finalPosition.x()) {
         const auto xdiff = std::abs(finalPosition.x() - previousPosition.x());
         const auto ydiff = finalPosition.y() - previousPosition.y();
         const auto rate = static_cast<double>(ydiff) / xdiff;


### PR DESCRIPTION
Resolves: #8446 

The code was not handling multi sample edits when the previous and last position differ in a single pixel on x axis.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
