### PR TITLE
track and clip title changes can now be undo-redone

### DIFF
--- a/src/projectscene/view/clipsview/cliplistitem.h
+++ b/src/projectscene/view/clipsview/cliplistitem.h
@@ -34,7 +34,7 @@ class ClipListItem : public QObject
     Q_PROPERTY(int speedPercentage READ speedPercentage NOTIFY speedPercentageChanged FINAL)
 
 public:
-    ClipListItem(QObject* parent);
+    explicit ClipListItem(QObject* parent);
 
     void setClip(const trackedit::Clip& clip);
     const trackedit::Clip& clip() const;

--- a/src/projectscene/view/trackspanel/trackitem.cpp
+++ b/src/projectscene/view/trackspanel/trackitem.cpp
@@ -40,7 +40,11 @@ TrackItem::~TrackItem()
 void TrackItem::init(const trackedit::Track& track)
 {
     m_trackId = track.id;
-    m_title = track.title;
+
+    if (m_title != track.title) {
+        m_title = track.title;
+        emit titleChanged(m_title);
+    }
 
     if (m_trackType != track.type) {
         m_trackType = track.type;

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -743,6 +743,8 @@ bool Au3Interaction::changeTrackTitle(const TrackId trackId, const muse::String&
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     prj->notifyAboutTrackChanged(DomConverter::track(track));
 
+    pushProjectHistoryChangeTrackTitle();
+
     return true;
 }
 
@@ -763,6 +765,8 @@ bool Au3Interaction::changeClipTitle(const trackedit::ClipKey& clipKey, const mu
 
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     prj->notifyAboutClipChanged(DomConverter::clip(waveTrack, clip.get()));
+
+    pushProjectHistoryChangeClipTitle();
 
     return true;
 }
@@ -2535,6 +2539,16 @@ void Au3Interaction::pushProjectHistoryResetClipSpeedState()
 void Au3Interaction::pushProjectHistoryRenderClipStretchingState()
 {
     projectHistory()->pushHistoryState("Rendered time-stretched audio", "Render");
+}
+
+void Au3Interaction::pushProjectHistoryChangeTrackTitle()
+{
+    projectHistory()->pushHistoryState("Track Title", "Changed Track Title");
+}
+
+void Au3Interaction::pushProjectHistoryChangeClipTitle()
+{
+    projectHistory()->pushHistoryState("Clip Title", "Changed Clip Title");
 }
 
 bool Au3Interaction::doChangeClipSpeed(const ClipKey& clipKey, double speed)

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -163,6 +163,8 @@ private:
     void pushProjectHistoryChangeClipSpeedState();
     void pushProjectHistoryResetClipSpeedState();
     void pushProjectHistoryRenderClipStretchingState();
+    void pushProjectHistoryChangeTrackTitle();
+    void pushProjectHistoryChangeClipTitle();
 
     bool canMoveTrack(const TrackId trackId, const TrackMoveDirection direction);
     int trackPosition(const TrackId trackId);

--- a/src/trackedit/internal/changedetection.cpp
+++ b/src/trackedit/internal/changedetection.cpp
@@ -104,11 +104,11 @@ bool clipsPair(ITrackeditProjectPtr trackeditProjectPtr,
                && first.endTime == second.endTime
                && first.stereo == second.stereo
                && first.pitch == second.pitch
-               && first.speed == second.speed;
+               && first.speed == second.speed
+               && first.title == second.title;
         //! For now these do not result in "autosave",
         //  and so should not be criteria under undo/redo refresh.
         //  This might change in future AU4 versions.
-        // first.title == second.title &&
         // first.color == second.color &&
         // first.hasCustomColor == second.hasCustomColor &&
         // first.optimizeForVoice == second.optimizeForVoice &&
@@ -186,12 +186,12 @@ void notifyOfUndoRedo(const TracksAndClips& before,
     //! Checking for Track field change - brute force I'm afraid:
     {
         auto trackFieldComparison = [](const Track& first, const Track& second) {
-            return first.type == second.type;
+            return first.type == second.type
+                   && first.title == second.title;
 
             //! For now these do not result in "autosave",
             //  and so should not be criteria under undo/redo.
             //  This might change in future AU4 versions.
-            // first.title == second.title &&
             // first.color == second.color;
         };
 

--- a/src/trackedit/tests/changedetection_tests.cpp
+++ b/src/trackedit/tests/changedetection_tests.cpp
@@ -248,6 +248,27 @@ TEST_F(ChangeDetectionTests, TestTrackNotificationsForReordering)
     changeDetection::notifyOfUndoRedo(before, after, m_trackEditProject);
 }
 
+TEST_F(ChangeDetectionTests, TestTrackNotificationForTitleChange)
+{
+    TracksAndClips before = buildTracksAndClips();
+    TracksAndClips after = buildTracksAndClips();
+
+    EXPECT_EQ(before.tracks.size(), after.tracks.size());
+
+    before.tracks.back().title = "new title";
+
+    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(1);
+    EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
+
+    EXPECT_CALL(*m_trackEditProject, notifyAboutClipAdded(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutClipRemoved(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutClipChanged(_)).Times(0);
+
+    changeDetection::notifyOfUndoRedo(before, after, m_trackEditProject);
+}
+
 ////////////////////////////////////////////////
 /// Tests for clip change notification:
 ////////////////////////////////////////////////
@@ -518,6 +539,25 @@ TEST_F(ChangeDetectionTests, TestClipNotificationAddingTwoAndRemovingTwo)
     EXPECT_CALL(*m_trackEditProject, notifyAboutClipAdded(_)).Times(2);
     EXPECT_CALL(*m_trackEditProject, notifyAboutClipRemoved(_)).Times(2);
     EXPECT_CALL(*m_trackEditProject, notifyAboutClipChanged(_)).Times(0);
+
+    changeDetection::notifyOfUndoRedo(before, after, m_trackEditProject);
+}
+
+TEST_F(ChangeDetectionTests, TestClipNotificationChangeTitle)
+{
+    TracksAndClips before = buildTracksAndClips();
+    TracksAndClips after = buildTracksAndClips();
+
+    after.clips.back().back().title = "new clip title";
+
+    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
+
+    EXPECT_CALL(*m_trackEditProject, notifyAboutClipAdded(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutClipRemoved(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutClipChanged(_)).Times(1);
 
     changeDetection::notifyOfUndoRedo(before, after, m_trackEditProject);
 }


### PR DESCRIPTION
Resolves: [https://github.com/audacity/audacity/issues/8430]

This enables undo/redo for clip and title changes, which were present in AU3 but not AU4.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

For testing:
- [ ] Try renaming tracks, and undo/redo that action.
- [ ] Try renaming clips, and undo/redo that action.