### PR TITLE
8472 avoid invisible timeline refresh and optimise history refresh

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/Timeline.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/Timeline.qml
@@ -14,9 +14,11 @@ Rectangle {
     color: ui.theme.backgroundSecondaryColor
 
     //! NOTE This element must be the same width as the track wave visible area.
-    //! If this is different, than appropriate changes must be made.
+    //! If this is different, then appropriate changes must be made.
     onWidthChanged: {
-        timelineContext.onResizeFrameWidth(root.width)
+        if (root.visible) {
+            timelineContext.onResizeFrameWidth(root.width)
+        }
     }
 
     function init() {

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -2331,14 +2331,19 @@ bool Au3Interaction::canRedo()
 
 bool Au3Interaction::undoRedoToIndex(size_t index)
 {
+    if (projectHistory()->currentStateIndex() == index) {
+        return false;
+    }
+
     auto trackeditProject = globalContext()->currentProject()->trackeditProject();
+
+    const TracksAndClips before = trackeditProject->buildTracksAndClips();
 
     projectHistory()->undoRedoToIndex(index);
 
-    // Redo removes all tracks from current state and
-    // inserts tracks from the previous state so we need
-    // to reload whole model
-    trackeditProject->reload();
+    const TracksAndClips after = trackeditProject->buildTracksAndClips();
+
+    changeDetection::notifyOfUndoRedo(before, after, trackeditProject);
 
     return true;
 }

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -26,7 +26,7 @@ class ITrackeditInteraction : MODULE_EXPORT_INTERFACE
     INTERFACE_ID(ITrackeditInteraction)
 
 public:
-    virtual ~ITrackeditInteraction() = default;
+    ~ITrackeditInteraction() override = default;
 
     virtual secs_t clipStartTime(const ClipKey& clipKey) const = 0;
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8472

This SHOULD resolve an occasional, hard to reproduce crash I used to see when closing audacity. Hard to test, but at least it shouldn't have any side effects.

I also piggy-backed an undo-redo to index commit which uses redraw optimisation here, both changes together are too simple to warrant dedicated PR's, they're one small commit each.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

- [ ] Use Audacity track and clip editing, do some undo/redo, and exit the program. It should no longer crash on close.
- [ ] Now undo/redo index jumping in history panel should properly use change detection, and so there should be less flashing.
