### PR TITLE
Split into new track

### DIFF
--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1609,7 +1609,7 @@ bool Au3Interaction::splitRangeSelectionIntoNewTracks(const TrackIdList& tracksI
         prj->notifyAboutTrackAdded(DomConverter::track(newTrack.get()));
     }
 
-    projectHistory()->pushHistoryState("Split into new tracks", "Split into new tracks");
+    projectHistory()->pushHistoryState("Split into new track", "Split into new track");
 
     return true;
 }
@@ -1648,7 +1648,7 @@ bool Au3Interaction::splitClipsIntoNewTracks(const ClipKeyList& clipKeyList)
         prj->notifyAboutTrackAdded(DomConverter::track(newTrack.get()));
     }
 
-    projectHistory()->pushHistoryState("Split into new tracks", "Split into new tracks");
+    projectHistory()->pushHistoryState("Split into new track", "Split into new track");
 
     return true;
 }

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1577,6 +1577,82 @@ bool Au3Interaction::splitClipsAtSilences(const ClipKeyList& clipKeyList)
     return true;
 }
 
+bool Au3Interaction::splitRangeSelectionIntoNewTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
+{
+    for (const auto& trackId : tracksIds) {
+        Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
+        IF_ASSERT_FAILED(waveTrack) {
+            continue;
+        }
+
+        bool hasClipInSelection = false;
+        for (const auto& interval : waveTrack->Intervals()) {
+            if ((interval->GetPlayStartTime() < end) && (interval->GetPlayEndTime() > begin)) {
+                hasClipInSelection = true;
+                break;
+            }
+        }
+
+        if (!hasClipInSelection) {
+            continue;
+        }
+
+        auto newTrack = waveTrack->Copy(begin, end, false);
+        newTrack->MoveTo(begin);
+        waveTrack->SplitDelete(begin, end);
+
+        auto& projectTracks = Au3TrackList::Get(projectRef());
+        projectTracks.Add(newTrack);
+
+        trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+        prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
+        prj->notifyAboutTrackAdded(DomConverter::track(newTrack.get()));
+    }
+
+    projectHistory()->pushHistoryState("Split into new tracks", "Split into new tracks");
+
+    return true;
+}
+
+bool Au3Interaction::splitClipsIntoNewTracks(const ClipKeyList& clipKeyList)
+{
+    std::map<TrackId, std::vector<ClipKey> > clipsPerTrack;
+    for (const auto& clipKey : clipKeyList) {
+        clipsPerTrack[clipKey.trackId].push_back(clipKey);
+    }
+
+    for (const auto& [trackId, clips] : clipsPerTrack) {
+        Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
+        IF_ASSERT_FAILED(waveTrack) {
+            continue;
+        }
+
+        auto& trackFactory = WaveTrackFactory::Get(projectRef());
+        auto& pSampleBlockFactory = trackFactory.GetSampleBlockFactory();
+        auto newTrack = waveTrack->EmptyCopy(pSampleBlockFactory);
+        auto& projectTracks = Au3TrackList::Get(projectRef());
+
+        for (const auto& clipKey : clips) {
+            std::shared_ptr<Au3WaveClip> clip = DomAccessor::findWaveClip(waveTrack, clipKey.clipId);
+            IF_ASSERT_FAILED(clip) {
+                continue;
+            }
+
+            newTrack->InsertInterval(waveTrack->CopyClip(*clip, true), false);
+            waveTrack->SplitDelete(clip->Start(), clip->End());
+        }
+        projectTracks.Add(newTrack);
+
+        trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+        prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
+        prj->notifyAboutTrackAdded(DomConverter::track(newTrack.get()));
+    }
+
+    projectHistory()->pushHistoryState("Split into new tracks", "Split into new tracks");
+
+    return true;
+}
+
 bool Au3Interaction::mergeSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -61,6 +61,8 @@ public:
     bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
+    bool splitRangeSelectionIntoNewTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
+    bool splitClipsIntoNewTracks(const ClipKeyList& clipKeyList) override;
     bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateClip(const ClipKey& clipKey) override;

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -50,6 +50,7 @@ private:
     void doGlobalCut();
     void doGlobalDelete();
     void doGlobalSplit();
+    void doGlobalSplitIntoNewTrack();
     void doGlobalJoin();
     void doGlobalDisjoin();
     void doGlobalDuplicate();
@@ -82,6 +83,8 @@ private:
     void tracksSplitAt(const muse::actions::ActionData& args);
     void splitClipsAtSilences(const muse::actions::ActionData& args);
     void splitRangeSelectionAtSilences(const muse::actions::ActionData& args);
+    void splitRangeSelectionIntoNewTracks(const muse::actions::ActionData& args);
+    void splitClipsIntoNewTracks(const muse::actions::ActionData& args);
     void mergeSelectedOnTrack(const muse::actions::ActionData& args);
     void duplicateSelected(const muse::actions::ActionData& args);
     void duplicateClips(const muse::actions::ActionData& args);

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -154,6 +154,16 @@ bool TrackeditInteraction::splitRangeSelectionAtSilences(const TrackIdList& trac
     return withPlaybackStop(&ITrackeditInteraction::splitRangeSelectionAtSilences, tracksIds, begin, end);
 }
 
+bool TrackeditInteraction::splitRangeSelectionIntoNewTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
+{
+    return withPlaybackStop(&ITrackeditInteraction::splitRangeSelectionIntoNewTracks, tracksIds, begin, end);
+}
+
+bool TrackeditInteraction::splitClipsIntoNewTracks(const ClipKeyList& clipKeyList)
+{
+    return withPlaybackStop(&ITrackeditInteraction::splitClipsIntoNewTracks, clipKeyList);
+}
+
 bool TrackeditInteraction::mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
     return withPlaybackStop(&ITrackeditInteraction::mergeSelectedOnTracks, tracksIds, begin, end);

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -47,6 +47,8 @@ private:
     bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
+    bool splitRangeSelectionIntoNewTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
+    bool splitClipsIntoNewTracks(const ClipKeyList& clipKeyList) override;
     bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateClip(const ClipKey& clipKey) override;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -62,6 +62,8 @@ public:
     virtual bool splitTracksAt(const TrackIdList& tracksIds, secs_t pivot) = 0;
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
     virtual bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
+    virtual bool splitRangeSelectionIntoNewTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
+    virtual bool splitClipsIntoNewTracks(const ClipKeyList& clipKeyList) = 0;
     virtual bool mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool duplicateClip(const ClipKey& clipKey) = 0;


### PR DESCRIPTION
Resolves: #8484 

This PR implements the split into new tracks functionality.
It works "just" as au3. We can split by time range selection and clip selection.
It does not split with only the playback cursor and if the time selection does not contain clip data.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

-------
To QA:

- [x] Time range selection on a single and multiple tracks
- [x] Clip selection with a single or multiple clips
- [x] Time range selection without clip data should not create new tracks