### PR TITLE
Fix #8204: Playcursor flickers on zoom in/out while recording audio.

### DIFF
--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -105,8 +105,17 @@ void PlayCursorController::updatePositionX(muse::secs_t secs)
 
 void PlayCursorController::onFrameTimeChanged()
 {
-    m_positionX = m_context->timeToPosition(playbackState()->playbackPosition());
-    emit positionXChanged();
+    double newPosition;
+    if (globalContext()->isRecording()) {
+        newPosition = m_context->timeToPosition(globalContext()->recordPosition());
+    } else {
+        newPosition = m_context->timeToPosition(playbackState()->playbackPosition());
+    }
+
+    if (m_positionX != newPosition) {
+        m_positionX = newPosition;
+        emit positionXChanged();
+    }
 }
 
 double PlayCursorController::positionX() const


### PR DESCRIPTION
Resolves: #8204

The onFrameTimeChanged() function was updating the play cursor position based on the playback position, even during recording. 

While recording, the playback position defaulted to the start of the audio file. This would cause the cursor to flicker when zooming in or out during recording.

I modified the onFrameTimeChanged() function to differentiate between playback and recording states. During recording, the play cursor position is now updated based on the actual recording position rather than the playback position.

Tested both in macOS and Linux.

 I have attached a before and after comparison.
 
## Before:

https://github.com/user-attachments/assets/150bc205-8d2f-44f6-9119-a52568acdf78

## After:
https://github.com/user-attachments/assets/d17ad9f2-a1cd-43eb-a232-363d6aa3dad3

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
