### PR TITLE
Only load needed plugins on project-open

### DIFF
--- a/au3/libraries/lib-realtime-effects/RealtimeEffectState.cpp
+++ b/au3/libraries/lib-realtime-effects/RealtimeEffectState.cpp
@@ -358,6 +358,9 @@ RealtimeEffectState& RealtimeEffectState::operator =(const RealtimeEffectState& 
 {
     assert(other.mID == mID);
     SetActive(other.IsActive());
+    if (!mPlugin || !other.mPlugin) {
+        return *this;
+    }
     CommandParameters params;
     if (other.mPlugin->SaveSettings(mMainSettings.settings, params)) {
         mPlugin->LoadSettings(params, mMainSettings.settings);

--- a/src/effects/builtin/internal/builtineffectsrepository.cpp
+++ b/src/effects/builtin/internal/builtineffectsrepository.cpp
@@ -70,6 +70,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                           bool supportsMultipleClipSelection) {
         EffectMeta meta;
         meta.id = au3::wxToString(desc.GetID());
+        meta.family = EffectFamily::Builtin;
         meta.categoryId = BUILTIN_CATEGORY_ID;
         meta.title = title;
         meta.description = description;

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -34,8 +34,15 @@ using RealtimeEffectStatePtr = std::shared_ptr<RealtimeEffectState>;
 using TrackId = long;
 using EffectChainLinkIndex = int;
 
+enum class EffectFamily {
+    Unknown = -1,
+    Builtin,
+    VST3,
+};
+
 struct EffectMeta {
     EffectId id;
+    EffectFamily family = EffectFamily::Unknown;
     muse::String title;
     muse::String description;
     muse::String version;

--- a/src/effects/effects_base/ieffectsprovider.h
+++ b/src/effects/effects_base/ieffectsprovider.h
@@ -28,6 +28,7 @@ public:
     virtual EffectCategoryList effectsCategoryList() const = 0;
 
     virtual EffectMeta meta(const EffectId& effectId) const = 0;
+    virtual bool loadEffect(const EffectId& effectId) const = 0;
     virtual std::string effectName(const std::string& effectId) const = 0;
     virtual std::string effectName(const effects::RealtimeEffectState& state) const = 0;
     virtual std::string effectSymbol(const std::string& effectId) const = 0;

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -108,6 +108,25 @@ EffectMeta EffectsProvider::meta(const EffectId& effectId) const
     return EffectMeta();
 }
 
+bool EffectsProvider::loadEffect(const EffectId& effectId) const
+{
+    const auto it = std::find_if(m_effects.begin(), m_effects.end(), [&](const EffectMeta& meta) {
+        return meta.id == effectId;
+    });
+    if (it == m_effects.end()) {
+        return false;
+    }
+    const auto isVst = it->categoryId == VST_CATEGORY_ID;
+    if (!isVst) {
+        // If an effect is not a VST and is in m_effects, then it's a built-in effect and it's loaded already.
+        return true;
+    }
+    IF_ASSERT_FAILED(vstEffectsRepository()) {
+        return false;
+    }
+    return vstEffectsRepository()->ensurePluginIsLoaded(effectId);
+}
+
 std::string EffectsProvider::effectName(const std::string& effectId) const
 {
     const auto desc = PluginManager::Get().GetPlugin(effectId);
@@ -145,6 +164,9 @@ bool EffectsProvider::supportsMultipleClipSelection(const EffectId& effectId) co
 
 Effect* EffectsProvider::effect(const EffectId& effectId) const
 {
+    if (!loadEffect(effectId)) {
+        return nullptr;
+    }
     PluginID pluginID = effectId.toStdString();
     const PluginDescriptor* plug = PluginManager::Get().GetPlugin(pluginID);
     if (!plug || !PluginManager::IsPluginAvailable(*plug)) {
@@ -195,6 +217,10 @@ void callOnLauncher(const RealtimeEffectStatePtr& state, const IEffectViewLaunch
 muse::Ret EffectsProvider::showEffect(const EffectId& effectId, const EffectInstanceId& instanceId)
 {
     LOGD() << "try open effect: " << effectId << ", instanceId: " << instanceId;
+
+    if (!loadEffect(effectId)) {
+        return muse::make_ret(muse::Ret::Code::NotSupported);
+    }
 
     const auto launcher = getLauncher(effectId, *viewLaunchRegister());
     if (!launcher) {

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -116,10 +116,13 @@ bool EffectsProvider::loadEffect(const EffectId& effectId) const
     if (it == m_effects.end()) {
         return false;
     }
-    const auto isVst = it->categoryId == VST_CATEGORY_ID;
-    if (!isVst) {
+    if (it->family == EffectFamily::Builtin) {
         // If an effect is not a VST and is in m_effects, then it's a built-in effect and it's loaded already.
         return true;
+    }
+    IF_ASSERT_FAILED(it->family == EffectFamily::VST3) {
+        LOGE() << "unknown family: " << static_cast<int>(it->family);
+        return false;
     }
     IF_ASSERT_FAILED(vstEffectsRepository()) {
         return false;

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -39,6 +39,7 @@ public:
     EffectCategoryList effectsCategoryList() const override;
 
     EffectMeta meta(const EffectId& effectId) const override;
+    bool loadEffect(const EffectId& effectId) const override;
     std::string effectName(const std::string& effectId) const override;
     std::string effectName(const effects::RealtimeEffectState& state) const override;
     std::string effectSymbol(const std::string& effectId) const override;

--- a/src/effects/vst/internal/vsteffectsrepository.cpp
+++ b/src/effects/vst/internal/vsteffectsrepository.cpp
@@ -31,6 +31,7 @@ EffectMetaList VstEffectsRepository::effectMetaList() const
 
         EffectMeta meta;
         meta.id = muse::String(info.meta.id.c_str());
+        meta.family = EffectFamily::VST3;
         meta.title = muse::io::completeBasename(info.path).toString();
         meta.isRealtimeCapable = true;
         meta.categoryId = VST_CATEGORY_ID;
@@ -59,6 +60,10 @@ bool VstEffectsRepository::ensurePluginIsLoaded(const EffectId& effectId) const
     }
     if (!it->enabled) {
         LOGW() << "plugin disabled: " << effectId;
+        return false;
+    }
+    if (it->meta.type != muse::audio::AudioResourceType::VstPlugin) {
+        LOGE() << "not a VST plugin: " << effectId;
         return false;
     }
     const auto& path = it->path;

--- a/src/effects/vst/internal/vsteffectsrepository.h
+++ b/src/effects/vst/internal/vsteffectsrepository.h
@@ -17,8 +17,6 @@ public:
     VstEffectsRepository() = default;
 
     EffectMetaList effectMetaList() const override;
-
-private:
-    bool registerPlugin(const muse::io::path_t& path) const;
+    bool ensurePluginIsLoaded(const EffectId&) const override;
 };
 }

--- a/src/effects/vst/ivsteffectsrepository.h
+++ b/src/effects/vst/ivsteffectsrepository.h
@@ -15,5 +15,6 @@ public:
     virtual ~IVstEffectsRepository() = default;
 
     virtual EffectMetaList effectMetaList() const = 0;
+    virtual bool ensurePluginIsLoaded(const EffectId&) const = 0;
 };
 }


### PR DESCRIPTION
Resolves: #8473

Partially solving the problem described in #8473 by postponing loading of effects when opening project, and only loading those needed by the project.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
To test this, please first read the description of #8473 on how to reproduce.
With this PR, crashing should "only" occur when opening a project that contains a MH plugin while being signed out from the hub, not on app start-up anymore. Please contact me if there are unclarities.