### PR TITLE
Pass instanceId as a parameter on the action query

### DIFF
--- a/src/effects/builtin/common/effectmanagemenu.cpp
+++ b/src/effects/builtin/common/effectmanagemenu.cpp
@@ -120,7 +120,7 @@ void EffectManageMenu::reload(const EffectId& effectId, const EffectInstanceId& 
     {
         ActionQuery q("action://effects/presets/export");
         q.addParam("instanceId", Val(instanceId));
-        MenuItem* item = makeMenuItem("action://effects/presets/export");
+        MenuItem* item = makeMenuItem(q.toString());
         items << item;
     }
 


### PR DESCRIPTION
Resolves: #8534 

We should pass the instanceId as a parameter on the action query.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
