### PR TITLE
Fix #7674: Unfocus from the clip should rename it when in Edit mode

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -451,6 +451,7 @@ Rectangle {
                     onFocusChanged: {
                         if (!titleEdit.focus) {
                             titleEdit.visible = false
+                            titleEdit.accepted()
                         }
                     }
                 }


### PR DESCRIPTION
Resolves: #7674

Previously, the onFocusChanged function in ClipItem.qml only hid the titleEdit field when it lost focus, without saving changes.

The expected behavior is that when titleEdit loses focus, it should save the changes automatically.

This fix ensures that clicking away commits the new title by calling titleEdit.accepted(), allowing future validations to be handled in the onAccepted function if needed.

This is the before and after:

### **Before:**

https://github.com/user-attachments/assets/ab98f92a-c145-46db-b2e7-608af75346fd

### **After:**

https://github.com/user-attachments/assets/d4dafdda-e798-477f-a688-fa4448ac267b


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
