### PR TITLE
Join is broken for pitched clips (fix #8559 )

### DIFF
--- a/libraries/lib-wave-track/WaveClip.cpp
+++ b/libraries/lib-wave-track/WaveClip.cpp
@@ -1116,9 +1116,11 @@ bool WaveClip::Paste(double t0, const WaveClip& o)
 
    if (GetSequenceSamplesCount() == 0)
    {
-      // Empty clip: we're flexible and adopt the other's stretching.
-      mRawAudioTempo = other.mRawAudioTempo;
+      // Empty clip: we're flexible and adopt the other's pitch and stretch.
+      mPitchAndSpeedPreset = other.mPitchAndSpeedPreset;
+      mCentShift = other.mCentShift;
       mClipStretchRatio = other.mClipStretchRatio;
+      mRawAudioTempo = other.mRawAudioTempo;
       mProjectTempo = other.mProjectTempo;
    }
    else if (!HasEqualPitchAndSpeed(other))


### PR DESCRIPTION
Resolves: #8559

Copy the clip's pitch settings when pasting into an empty clip.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
