### PR TITLE
Detecting audiocallback invocation after a pause, and purging residual samples

### DIFF
--- a/au3/libraries/lib-audio-devices/AudioIOBase.h
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.h
@@ -302,6 +302,7 @@ protected:
 
     /// True if audio playback is paused
     std::atomic<bool> mPaused{ false };
+    std::atomic<bool> mWasPaused{ false };
 
     /*! Read by worker threads but unchanging during playback */
     std::atomic<int> mStreamToken{ 0 };

--- a/au3/libraries/lib-audio-devices/AudioIOBase.h
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.h
@@ -302,7 +302,6 @@ protected:
 
     /// True if audio playback is paused
     std::atomic<bool> mPaused{ false };
-    std::atomic<bool> mWasPaused{ false };
 
     /*! Read by worker threads but unchanging during playback */
     std::atomic<int> mStreamToken{ 0 };

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -373,6 +373,17 @@ protected:
     //! Holds some state for duration of playback or recording
     std::unique_ptr<TransportState> mpTransportState;
 
+    /*!
+     * When re-starting playback after pause, there will be samples in the queue from before.
+     * Since those are stale, this method purges them.
+     * That way resuming from pause only plays back newly rendered samples.
+     * @param framesPerBuffer
+     * @param sampleBuffer Buffer for reading purged samples
+     */
+    void PurgeAfterPause(unsigned long framesPerBuffer, float** sampleBuffer);
+
+    std::atomic<bool> mPurgeIsNeeded{ false };
+
 private:
     /*!
      Privatize the inherited array but give access by Extensions().
@@ -528,7 +539,6 @@ public:
     void DelayActions(bool recording);
 
 private:
-
     bool DelayingActions() const;
 
     /** \brief Set the current VU meters - this should be done once after


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8469

Only when pausing, setting track volume to 0, and unpausing, there is playback from the mPlaybackBuffer RingBuffer samples that is a residual from the previous playback.

With full start/stop, this doesn't happen.

Identified cause:
While the buffers written to the RingBuffers in ProcessPlaybackSlices are 0-value samples, for a few callbacks the samples consumed in FillOutputBuffers from the RingBuffers are non-zero, because they are residuals from before the pause.
With pause, the RingBuffer content is intact, with stop/start these are cleared, hence the difference in behaviour.

Solution:
When resuming playback from pause, any samples pending from before pause, are now purged and not used.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

Test cases:
- [ ] Play back audio, press spacebar/pause, and change volume to 0, and then press spacebar again. The sound should immediately reflect the new volume.
- [ ] Optionally try the above with a few audio interfaces and buffer size settings to be sure it's stable across the spectrum.
