### PR TITLE
Added github warning annotation for linux and windows builds

### DIFF
--- a/.github/problem_matchers/gcc.json
+++ b/.github/problem_matchers/gcc.json
@@ -1,0 +1,22 @@
+{
+  "problemMatcher": [
+    {
+      "name": "gcc",
+      "owner": "gcc",
+      "source": "gcc",
+      "fileLocation": [
+        "relative"
+      ],
+      "pattern": [
+        {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem_matchers/msvc.json
+++ b/.github/problem_matchers/msvc.json
@@ -1,0 +1,20 @@
+{
+  "problemMatcher": [
+    {
+      "name": "msvc",
+      "owner": "msvc",
+      "source": "msvc",
+      "pattern": [
+        {
+          "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "code": 5,
+          "message": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/au4_build_linux.yml
+++ b/.github/workflows/au4_build_linux.yml
@@ -88,6 +88,8 @@ jobs:
     - name: Install Conan
       id: conan
       uses: turtlebrowser/get-conan@main
+    - name: Register gcc problem matcher
+      run: echo "::add-matcher::.github/problem_matchers/gcc.json"
     - name: Setup environment
       if: env.DO_BUILD == 'true'
       run: |

--- a/.github/workflows/au4_build_windows.yml
+++ b/.github/workflows/au4_build_windows.yml
@@ -85,7 +85,8 @@ jobs:
         echo "SENTRY_PROJECT: $SENTRY_PROJECT"
         echo "SENTRY_URL=$SENTRY_URL" >> $GITHUB_ENV
         echo "SENTRY_URL: $SENTRY_URL"
-
+    - name: Register msvc problem matcher
+      run: echo "::add-matcher::.github/problem_matchers/msvc.json"
     - name: Setup environment
       if: env.DO_BUILD == 'true'
       shell: bash


### PR DESCRIPTION
What this does:

Now in any PR “files changed” tab, at the bottom, any new build warnings will appear (you can see them in the “Unchanged files with check annotations section”).
With this, we can at least make sure our PR's don't introduce new warnings, and as a separate task we can eventually also address / suppress the very many legacy ones.

I can't take credit for this - I just copied over the changes into the corresponding Audacity build-script sections, from this MSS community contribution:
https://github.com/musescore/MuseScore/pull/27050

From the PR preview it appears to work fine, and will be an excellent tool for future PR's!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
