### PR TITLE
8521 reuse preset bar for realtime effects

### DIFF
--- a/src/effects/effects_base/effects_base.qrc
+++ b/src/effects/effects_base/effects_base.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/">
         <file>qml/Audacity/Effects/qmldir</file>
         <file>qml/Audacity/Effects/BypassEffectButton.qml</file>
+        <file>qml/Audacity/Effects/EffectPresetsBar.qml</file>
         <file>qml/Audacity/Effects/EffectsViewerDialog.qml</file>
         <file>qml/Audacity/Effects/StyledDialogViewWithoutNavigationSection.qml</file>
         <file>qml/Audacity/Effects/RealtimeEffectViewerDialog.qml</file>

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectPresetsBar.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectPresetsBar.qml
@@ -1,0 +1,98 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+import QtQuick
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+import Audacity.Effects
+
+RowLayout {
+    id: root
+
+    property var instanceId
+
+    spacing: 4
+
+    function manage(button) {
+        var pos = Qt.point(button.x, button.y + button.height)
+        menuLoader.show(pos, manageMenuModel)
+    }
+
+    Component.onCompleted: {
+        Qt.callLater(manageMenuModel.load)
+    }
+
+    EffectManageMenu {
+        id: manageMenuModel
+        instanceId: root.instanceId
+    }
+
+    ContextMenuLoader {
+        id: menuLoader
+
+        onHandleMenuItem: function (itemId) {
+            manageMenuModel.handleMenuItem(itemId)
+        }
+    }
+
+    StyledDropdown {
+        id: presetSelector
+
+        Layout.fillWidth: true
+        background.color: ui.theme.backgroundPrimaryColor
+        background.border.width: 1
+        itemColor: "transparent"
+
+        textRole: "name"
+        valueRole: "id"
+
+        indeterminateText: qsTrc("effects", "Select preset")
+
+        model: manageMenuModel.presets
+
+        onActivated: function (index, value) {
+            manageMenuModel.preset = value
+            currentIndex = manageMenuModel.presets.findIndex(
+                        preset => preset.id === value)
+        }
+    }
+
+    FlatButton {
+        Layout.alignment: Qt.AlignVCenter
+        icon: IconCode.SAVE
+
+        onClicked: {
+            manageMenuModel.savePresetAs()
+        }
+    }
+
+    FlatButton {
+        Layout.alignment: Qt.AlignVCenter
+
+        icon: IconCode.UNDO
+
+        onClicked: {
+            if (manageMenuModel.preset === "") {
+                manageMenuModel.preset = "default"
+                presetSelector.currentIndex = 0
+            }
+
+            manageMenuModel.resetPreset()
+        }
+    }
+
+    FlatButton {
+        id: manageButton
+
+        Layout.alignment: Qt.AlignVCenter
+
+        icon: IconCode.MENU_THREE_DOTS
+
+        onClicked: {
+            root.manage(manageButton)
+        }
+    }
+}

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -22,14 +22,9 @@ StyledDialogView {
     title: viewer ? viewer.title : ""
 
     contentWidth: Math.max(viewerLoader.width, 300)
-    contentHeight: presetRow.height + separator.height + viewerLoader.height + btnBarLoader.height + margins * 3
+    contentHeight: presetsBar.height + separator.height + viewerLoader.height + btnBarLoader.height + margins * 3
 
     margins: 16
-
-    EffectManageMenu {
-        id: manageMenuModel
-        instanceId: root.instanceId
-    }
 
     onWindowChanged: {
         // Wait until the window is set: VstView needs it for intialization
@@ -40,20 +35,6 @@ StyledDialogView {
         // Delay loading of ButtonBox because it needs to know the final width before executing its layout
         // (which it only does once)
         btnBarLoader.sourceComponent = bboxComponent
-        Qt.callLater(manageMenuModel.load)
-    }
-
-    function manage(button) {
-        var pos = Qt.point(button.x, button.y + button.height)
-        menuLoader.show(pos, manageMenuModel)
-    }
-
-    ContextMenuLoader {
-        id: menuLoader
-
-        onHandleMenuItem: function (itemId) {
-            manageMenuModel.handleMenuItem(itemId)
-        }
     }
 
     Column {
@@ -62,69 +43,11 @@ StyledDialogView {
 
         spacing: 16
 
-        RowLayout {
-            id: presetRow
-            spacing: 4
+        EffectPresetsBar {
+            id: presetsBar
+            instanceId: root.instanceId
             anchors.left: parent.left
             anchors.right: parent.right
-
-            StyledDropdown {
-                id: presetSelector
-
-                Layout.fillWidth: true
-                background.color: ui.theme.backgroundPrimaryColor
-                background.border.width: 1
-                itemColor: "transparent"
-
-                textRole: "name"
-                valueRole: "id"
-
-                indeterminateText: qsTrc("effects", "Select preset")
-
-                model: manageMenuModel.presets
-
-                onActivated: function (index, value) {
-                    manageMenuModel.preset = value
-                    currentIndex = manageMenuModel.presets.findIndex(
-                                preset => preset.id === value)
-                }
-            }
-
-            FlatButton {
-                Layout.alignment: Qt.AlignVCenter
-                icon: IconCode.SAVE
-
-                onClicked: {
-                    manageMenuModel.savePresetAs()
-                }
-            }
-
-            FlatButton {
-                Layout.alignment: Qt.AlignVCenter
-
-                icon: IconCode.UNDO
-
-                onClicked: {
-                    if (manageMenuModel.preset === "") {
-                        manageMenuModel.preset = "default"
-                        presetSelector.currentIndex = 0
-                    }
-
-                    manageMenuModel.resetPreset()
-                }
-            }
-
-            FlatButton {
-                id: manageButton
-
-                Layout.alignment: Qt.AlignVCenter
-
-                icon: IconCode.MENU_THREE_DOTS
-
-                onClicked: {
-                    root.manage(manageButton)
-                }
-            }
         }
 
         SeparatorLine {
@@ -144,7 +67,7 @@ StyledDialogView {
                 instanceId: root.instanceId
                 height: implicitHeight
                 x: root.margins
-                y: root.margins * 3 + presetRow.height + separator.height
+                y: root.margins * 3 + presetsBar.height + separator.height
             }
         }
 

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -2,6 +2,7 @@
  * Audacity: A Digital Audio Editor
  */
 import QtQuick
+import QtQuick.Layouts
 
 import Muse.Ui
 import Muse.UiComponents
@@ -20,7 +21,7 @@ StyledDialogViewWithoutNavigationSection {
     title: viewerModel.title + " - " + viewerModel.trackName
 
     contentWidth: viewItem ? Math.max(viewItem.implicitWidth, headerBar.width) : headerBar.width
-    contentHeight: viewItem ? headerBar.height + viewItem.implicitHeight : headerBar.height
+    contentHeight: 2 * 16 + headerBar.height + (viewItem ? viewItem.implicitHeight : 0)
     alwaysOnTop: true
 
     Component.onCompleted: {
@@ -38,56 +39,57 @@ StyledDialogViewWithoutNavigationSection {
         VstViewer {
             id: view
             instanceId: root.instanceId
-            x: 0
-            y: headerBar.height
+            y: 62
         }
     }
 
     Component {
         id: builtinViewerComponent
-        Row {
-            padding: 8
+        Column {
+            topPadding: 0
+            leftPadding: 16
+            rightPadding: 16
+            bottomPadding: 16
+
             EffectsViewer {
                 id: view
                 instanceId: root.instanceId
-                x: (root.width - view.width) / 2
-                y: headerBar.height
             }
         }
     }
 
-    Row {
-        id: headerBar
+    ColumnLayout {
+        spacing: 0
 
-        padding: 8
-        spacing: 8
+        RowLayout {
+            id: headerBar
 
-        BypassEffectButton {
-            id: bypassBtn
+            Layout.fillWidth: true
+            Layout.margins: 16
+            spacing: presetsBar.spacing
 
-            size: 36
-            isMasterEffect: viewerModel.isMasterEffect
-            accentButton: viewerModel.isActive
+            BypassEffectButton {
+                id: bypassBtn
 
-            onClicked: {
-                viewerModel.isActive = !viewerModel.isActive
+                size: presetsBar.implicitHeight
+                isMasterEffect: viewerModel.isMasterEffect
+                accentButton: viewerModel.isActive
+
+                onClicked: {
+                    viewerModel.isActive = !viewerModel.isActive
+                }
+            }
+
+            EffectPresetsBar {
+                id: presetsBar
+                instanceId: root.instanceId
+                Layout.fillWidth: true
             }
         }
 
-        FlatButton {
-            id: manageBtn
-
-            width: implicitWidth
-            height: bypassBtn.size
-
-            text: qsTrc("effects", "Presets & settings")
-            buttonRole: ButtonBoxModel.CustomRole
-            buttonId: ButtonBoxModel.CustomButton + 1
-            onClicked: viewItem.manage(manageBtn)
+        Loader {
+            id: viewLoader
+            Layout.fillWidth: true
         }
-    }
-
-    Loader {
-        id: viewLoader
     }
 }

--- a/src/effects/effects_base/qml/Audacity/Effects/qmldir
+++ b/src/effects/effects_base/qml/Audacity/Effects/qmldir
@@ -1,4 +1,5 @@
 module Audacity.Effects
 BypassEffectButton 1.0 BypassEffectButton.qml
 EffectsViewer 1.0 EffectsViewer.qml
+EffectPresetsBar 1.0 EffectPresetsBar.qml
 StyledDialogViewWithoutNavigationSection 1.0 StyledDialogViewWithoutNavigationSection.qml


### PR DESCRIPTION
Resolves: #8619

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA: please note that this ticket does not solve #8521.