### PR TITLE
Add entry on history on stem plot edit

### DIFF
--- a/au3/libraries/lib-wave-track/WaveClip.cpp
+++ b/au3/libraries/lib-wave-track/WaveClip.cpp
@@ -442,6 +442,9 @@ void WaveClip::SetSamples(size_t ii,
 {
     StrongInvariantScope scope{ *this };
     assert(ii < NChannels());
+
+    mVersion++;
+
     // use Strong-guarantee
     mSequences[ii]->SetSamples(buffer, format,
                                start + TimeToSamples(mTrimLeft), len, effectiveFormat);

--- a/au3/libraries/lib-wave-track/WaveClip.h
+++ b/au3/libraries/lib-wave-track/WaveClip.h
@@ -1016,7 +1016,7 @@ private:
     };
 
     int64_t mId = -1;
-    const int64_t mVersion = 0;
+    int64_t mVersion = 0;
 
     //! Real-time durations, i.e., stretching the clip modifies these.
     //! @{

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -572,6 +572,8 @@ Rectangle {
             clipColor: root.clipColor
             clipSelected: root.clipSelected
             isIsolationMode: root.isIsolationMode
+            multiSampleEdit: root.multiSampleEdit
+            isBrush: root.isBrush
 
             function onWaveViewPositionChanged(x, y) {
                 if (waveView.isIsolationMode) {

--- a/src/projectscene/view/clipsview/waveview.h
+++ b/src/projectscene/view/clipsview/waveview.h
@@ -7,6 +7,7 @@
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "trackedit/iprojecthistory.h"
 
 #include "iwavepainter.h"
 #include "../timeline/timelinecontext.h"
@@ -29,10 +30,13 @@ class WaveView : public QQuickPaintedItem
     Q_PROPERTY(bool isStemPlot READ isStemPlot WRITE setIsStemPlot NOTIFY isStemPlotChanged FINAL)
     Q_PROPERTY(int currentChannel READ currentChannel WRITE setCurrentChannel FINAL)
     Q_PROPERTY(bool isIsolationMode READ isIsolationMode WRITE setIsIsolationMode NOTIFY isIsolationModeChanged FINAL)
+    Q_PROPERTY(bool multiSampleEdit READ multiSampleEdit WRITE setMultiSampleEdit NOTIFY multiSampleEditChanged FINAL)
+    Q_PROPERTY(bool isBrush READ isBrush WRITE setIsBrush NOTIFY isBrushChanged FINAL)
 
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<au::projectscene::IWavePainter> wavePainter;
     muse::Inject<IProjectSceneConfiguration> configuration;
+    muse::Inject<au::trackedit::IProjectHistory> projectHistory;
 
 public:
     WaveView(QQuickItem* parent = nullptr);
@@ -58,6 +62,10 @@ public:
     void setCurrentChannel(int currentChannel);
     bool isIsolationMode() const;
     void setIsIsolationMode(bool isIsolationMode);
+    bool multiSampleEdit() const;
+    void setMultiSampleEdit(bool multiSampleEdit);
+    bool isBrush() const;
+    void setIsBrush(bool isBrush);
 
     Q_INVOKABLE QColor transformColor(const QColor& originalColor) const;
     Q_INVOKABLE void setLastMousePos(const unsigned int x, const unsigned int y);
@@ -77,6 +85,8 @@ signals:
     void isNearSampleChanged();
     void isStemPlotChanged();
     void isIsolationModeChanged();
+    void multiSampleEditChanged();
+    void isBrushChanged();
 
 private:
 
@@ -84,6 +94,7 @@ private:
     IWavePainter::Params getWavePainterParams() const;
     void applyColorfulStyle(IWavePainter::Params& params, const QColor& clipColor, bool selected) const;
     void applyClassicStyle(IWavePainter::Params& params, bool selected) const;
+    void pushProjectHistorySampleEdit();
 
     TimelineContext* m_context = nullptr;
     ClipKey m_clipKey;
@@ -95,6 +106,8 @@ private:
     bool m_isNearSample = false;
     bool m_isStemPlot = false;
     bool m_isIsolationMode = false;
+    bool m_multiSampleEdit = false;
+    bool m_isBrush = false;
 
     std::optional<int> m_currentChannel;
     std::optional<QPoint> m_lastClickedPoint;


### PR DESCRIPTION
Resolves: #8501

Implemented history entries for sample edits. The versioning system has been adjusted: previously, the clip version was incremented only upon new clip creation. Now, it also tracks changes to the internal data. This enhancement allows us to efficiently determine if a clip has been modified without needing to compare the samples directly.

Currently, the history does not differentiate between sample edit types, and consecutive edits are always consolidated, regardless of the time interval. A separate ticket will be created to address and improve this behavior.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
