### PR TITLE
Use shortcut for single and multi track removal

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -201,6 +201,10 @@ Item {
                         root.openEffectsRequested()
                     }
 
+                    onRemoveSelectionRequested: {
+                        tracksModel.removeSelection()
+                    }
+
                     Component.onCompleted: {
                         mousePressed.connect(dragHandler.startDrag)
                         mouseReleased.connect(dragHandler.endDrag)

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -152,6 +152,9 @@ void TracksListModel::selectRow(int row, bool exclusive)
         m_selectionModel->select(index(row));
     }
 
+    //! NOTE: Selecting a track unselects all clips
+    selectionController()->resetSelectedClips();
+
     projectHistory()->modifyState();
 }
 
@@ -218,6 +221,11 @@ void TracksListModel::removeSelectedRows()
     });
 
     removeRows(firstIndex.row(), selectedIndexList.size(), firstIndex.parent());
+}
+
+void TracksListModel::removeSelection()
+{
+    dispatcher()->dispatch("delete");
 }
 
 void TracksListModel::requestTracksMove(QVariantList trackIndexes, int to)

--- a/src/projectscene/view/trackspanel/trackslistmodel.h
+++ b/src/projectscene/view/trackspanel/trackslistmodel.h
@@ -53,6 +53,7 @@ public:
     Q_INVOKABLE void moveSelectedRowsUp();
     Q_INVOKABLE void moveSelectedRowsDown();
     Q_INVOKABLE void removeSelectedRows();
+    Q_INVOKABLE void removeSelection();
 
     Q_INVOKABLE void requestTracksMove(QVariantList trackIndexes, int to);
 

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -359,6 +359,11 @@ void TrackeditActionsController::doGlobalDelete()
         return;
     }
 
+    if (!selectionController()->selectedTracks().empty()) {
+        dispatcher()->dispatch(TRACK_DELETE);
+        return;
+    }
+
     interactive()->error(muse::trc("trackedit", "No audio selected"),
                          muse::trc("trackedit", "Select the audio for Delete then try again."));
 }


### PR DESCRIPTION
Resolves: #8115 #8592

Use removeSelectionRequested signal from TrackItem to dispatch the delete operation.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
