### PR TITLE
Fix resetting preferences

### DIFF
--- a/au3/libraries/lib-audio-devices/AudioIOBase.cpp
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.cpp
@@ -293,6 +293,21 @@ void AudioIOBase::HandleDeviceChange()
 #endif   // USE_PORTMIXER
 }
 
+int AudioIOBase::GetHostIndex(const std::string& hostName)
+{
+    int index = -1;
+    int nHosts = Pa_GetHostApiCount();
+    for (int i = 0; i < nHosts; ++i) {
+        wxString name = wxSafeConvertMB2WX(Pa_GetHostApiInfo(i)->name);
+        if (name == hostName) {
+            index = i;
+            break;
+        }
+    }
+
+    return index;
+}
+
 void AudioIOBase::SetCaptureMeter(
     const std::shared_ptr<AudacityProject>& project, const std::weak_ptr<Meter>& wMeter)
 {

--- a/au3/libraries/lib-audio-devices/AudioIOBase.h
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.h
@@ -125,6 +125,8 @@ public:
      * GetSupported*Rate functions considerably */
     void HandleDeviceChange();
 
+    static int GetHostIndex(const std::string& hostName);
+
     /** \brief Get a list of sample rates the output (playback) device
      * supports.
      *

--- a/src/appshell/qml/Preferences/internal/TemporaryFilesSection.qml
+++ b/src/appshell/qml/Preferences/internal/TemporaryFilesSection.qml
@@ -31,6 +31,10 @@ BaseSection {
 
     property string temporaryPath: ""
 
+    onTemporaryPathChanged: {
+        dirPicker.path = temporaryPath
+    }
+
     signal temporaryFilesLocationChanged(string newPath)
 
     Column {

--- a/src/appshell/view/preferences/commonaudioapiconfigurationmodel.cpp
+++ b/src/appshell/view/preferences/commonaudioapiconfigurationmodel.cpp
@@ -42,14 +42,20 @@ CommonAudioApiConfigurationModel::CommonAudioApiConfigurationModel(QObject* pare
 
 void CommonAudioApiConfigurationModel::load()
 {
-    audioDevicesProvider()->audioApiChanged().onNotify(this, [this]() { emit currentAudioApiIndexChanged(); });
-    audioDevicesProvider()->audioOutputDeviceChanged().onNotify(this, [this]() { emit currentOutputDeviceIdChanged(); });
-    audioDevicesProvider()->audioInputDeviceChanged().onNotify(this, [this]() { emit currentInputDeviceIdChanged(); });
-    audioDevicesProvider()->audioApiChanged().onNotify(this, [this](){
+    audioDevicesProvider()->audioApiChanged().onNotify(this, [this]() {
+        emit currentAudioApiIndexChanged();
         emit outputDeviceListChanged();
         emit inputDeviceListChanged();
         emit longestDeviceNameLengthChanged();
+
+        emit currentOutputDeviceIdChanged();
+        emit currentInputDeviceIdChanged();
+
+        emit inputChannelsListChanged();
+        emit currentInputChannelsChanged();
     });
+    audioDevicesProvider()->audioOutputDeviceChanged().onNotify(this, [this]() { emit currentOutputDeviceIdChanged(); });
+    audioDevicesProvider()->audioInputDeviceChanged().onNotify(this, [this]() { emit currentInputDeviceIdChanged(); });
     audioDevicesProvider()->inputChannelsListChanged().onNotify(this, [this](){ emit inputChannelsListChanged(); });
     audioDevicesProvider()->inputChannelsChanged().onNotify(this, [this](){ emit currentInputChannelsChanged(); });
     audioDevicesProvider()->bufferLengthChanged().onNotify(this, [this](){ emit bufferLengthChanged(); });
@@ -134,7 +140,7 @@ QVariantList CommonAudioApiConfigurationModel::inputDeviceList() const
 
 void CommonAudioApiConfigurationModel::inputDeviceSelected(const QString& deviceId)
 {
-    if (deviceId == currentOutputDeviceId()) {
+    if (deviceId == currentInputDeviceId()) {
         return;
     }
     audioDevicesProvider()->setAudioInputDevice(deviceId.toStdString());

--- a/src/appshell/view/preferences/generalpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/generalpreferencesmodel.cpp
@@ -46,6 +46,10 @@ void GeneralPreferencesModel::load()
     languagesService()->needRestartToApplyLanguageChangeChanged().onReceive(this, [this](bool need) {
         setIsNeedRestart(need);
     });
+
+    projectConfiguration()->temporaryDirChanged().onReceive(this, [this](muse::io::path_t) {
+        emit temporaryDirChanged();
+    });
 }
 
 void GeneralPreferencesModel::checkUpdateForCurrentLanguage()

--- a/src/au3wrap/internal/au3audiodevicesprovider.cpp
+++ b/src/au3wrap/internal/au3audiodevicesprovider.cpp
@@ -613,16 +613,7 @@ std::string Au3AudioDevicesProvider::defaultOutputDevice()
         return "";
     }
 
-    int index = -1;
-    auto apiName = currentAudioApi();
-    int nHosts = Pa_GetHostApiCount();
-    for (int i = 0; i < nHosts; ++i) {
-        wxString name = wxSafeConvertMB2WX(Pa_GetHostApiInfo(i)->name);
-        if (name == apiName) {
-            index = i;
-            break;
-        }
-    }
+    int index = AudioIO::GetHostIndex(currentAudioApi());
 
     const auto currentOutputDevice = currentAudioOutputDevice();
     const auto outputDevices = audioOutputDevices();
@@ -648,16 +639,7 @@ std::string Au3AudioDevicesProvider::defaultInputDevice()
         return "";
     }
 
-    int index = -1;
-    auto apiName = currentAudioApi();
-    int nHosts = Pa_GetHostApiCount();
-    for (int i = 0; i < nHosts; ++i) {
-        wxString name = wxSafeConvertMB2WX(Pa_GetHostApiInfo(i)->name);
-        if (name == apiName) {
-            index = i;
-            break;
-        }
-    }
+    int index = AudioIO::GetHostIndex(currentAudioApi());
 
     const auto currentInputDevice = currentAudioInputDevice();
     const auto inputDevices = audioInputDevices();

--- a/src/au3wrap/internal/au3audiodevicesprovider.h
+++ b/src/au3wrap/internal/au3audiodevicesprovider.h
@@ -71,6 +71,10 @@ private:
     void initInputChannels();
 
     void updateInputOutputDevices();
+    void setupRecordingDevice(const std::string& newDevice);
+
+    std::string defaultOutputDevice();
+    std::string defaultInputDevice();
 
     class Choices
     {

--- a/src/au3wrap/internal/au3commonsettings.cpp
+++ b/src/au3wrap/internal/au3commonsettings.cpp
@@ -13,8 +13,8 @@ using namespace au::au3;
 static muse::Settings::Key make_key(const wxString& key)
 {
     wxString _key = key;
-    if (!_key.starts_with("/")) {
-        _key += "/";
+    if (_key.starts_with("/")) {
+        _key.Remove(0, 1);
     }
 
     return muse::Settings::Key("au3wrap", wxToStdSting(_key));

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -195,9 +195,6 @@ muse::io::path_t ProjectConfiguration::temporaryDir() const
 void ProjectConfiguration::setTemporaryDir(const muse::io::path_t& path)
 {
     muse::settings()->setSharedValue(TEMPORARY_FILES_PATH, muse::Val(path));
-    UpdateDefaultPath(FileNames::Operation::Temp, au3::wxFromString(path.toString()));
-
-    m_temporaryDirChanged.send(path);
 }
 
 muse::async::Channel<muse::io::path_t> ProjectConfiguration::temporaryDirChanged() const
@@ -265,4 +262,8 @@ void ProjectConfiguration::initTempDir()
         }
     }
     muse::settings()->setDefaultValue(TEMPORARY_FILES_PATH, muse::Val(appDataLocation));
+    muse::settings()->valueChanged(TEMPORARY_FILES_PATH).onReceive(nullptr, [this](const muse::Val& val) {
+        UpdateDefaultPath(FileNames::Operation::Temp, au3::wxFromString(val.toPath().toString()));
+        m_temporaryDirChanged.send(val.toString());
+    });
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8467

This fixes: resetting preferences to default + remembering settings after app restart
All of this is done via migrating to muse::settings

QA:
* all of the settings should be reset immediately without need to re-open preferences dialog
* please check if these settings still work properly (these were modified): every preference in "audio settings" tab, temporary files location
* all of the settings should be remembered on app restart
* bonus: this may fix https://github.com/audacity/audacity/issues/8505 