### PR TITLE
Persist snap per project

### DIFF
--- a/src/au3wrap/CMakeLists.txt
+++ b/src/au3wrap/CMakeLists.txt
@@ -44,6 +44,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3commonsettings.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3basicui.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3basicui.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/projectsnap.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/projectsnap.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackcolor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackcolor.h
     )

--- a/src/au3wrap/internal/projectsnap.cpp
+++ b/src/au3wrap/internal/projectsnap.cpp
@@ -1,0 +1,90 @@
+#include "projectsnap.h"
+
+#include "XMLAttributeValueView.h"
+#include "XMLWriter.h"
+#include "Prefs.h"
+
+using namespace au::au3;
+
+static const AttachedProjectObjects::RegisteredFactory key
+{
+    [](AudacityProject&) {
+        return std::make_shared<ProjectSnap>();
+    }
+};
+
+ProjectSnap& ProjectSnap::Get(AudacityProject& project)
+{
+    return project.AttachedObjects::Get<ProjectSnap&>(key);
+}
+
+const ProjectSnap& ProjectSnap::Get(const AudacityProject& project)
+{
+    return Get(const_cast<AudacityProject&>(project));
+}
+
+ProjectSnap::ProjectSnap() {}
+
+ProjectSnap::~ProjectSnap() {}
+
+bool ProjectSnap::isSnapEnabled() const
+{
+    return m_snapEnabled;
+}
+
+void ProjectSnap::enableSnap(bool enable)
+{
+    if (m_snapEnabled != enable) {
+        m_snapEnabled = enable;
+    }
+}
+
+int ProjectSnap::snapType() const
+{
+    return m_snapType;
+}
+
+void ProjectSnap::setSnapType(unsigned int type)
+{
+    if (m_snapType != type) {
+        m_snapType = type;
+    }
+}
+
+bool ProjectSnap::isSnapTriplets() const
+{
+    return m_snapTriplets;
+}
+
+void ProjectSnap::setSnapTriplets(bool triplets)
+{
+    if (m_snapTriplets != triplets) {
+        m_snapTriplets = triplets;
+    }
+}
+
+static ProjectFileIORegistry::AttributeWriterEntry entry {
+    [](const AudacityProject& project, XMLWriter& xmlFile){
+        auto& snap = ProjectSnap::Get(project);
+        xmlFile.WriteAttr(wxT("snap_enabled"), snap.isSnapEnabled());
+        xmlFile.WriteAttr(wxT("snap_type"), snap.snapType());
+        xmlFile.WriteAttr(wxT("snap_triplets"), snap.isSnapTriplets());
+    }
+};
+
+static ProjectFileIORegistry::AttributeReaderEntries entries {
+    (ProjectSnap & (*)(AudacityProject&)) & ProjectSnap::Get, {
+        { "snap_enabled", [](auto& snap, auto value) {
+                const bool enabled = value.Get(snap.isSnapEnabled());
+                snap.enableSnap(enabled);
+            } },
+        { "snap_type", [](auto& snap, auto value) {
+                const int type = value.Get(snap.snapType());
+                snap.setSnapType(type);
+            } },
+        { "snap_triplets", [](auto& snap, auto value) {
+                const bool triplets = value.Get(snap.isSnapTriplets());
+                snap.setSnapTriplets(triplets);
+            } }
+    }
+};

--- a/src/au3wrap/internal/projectsnap.h
+++ b/src/au3wrap/internal/projectsnap.h
@@ -1,0 +1,34 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "ClientData.h"
+#include "Observer.h"
+#include "Project.h"
+
+class AudacityProject;
+
+namespace au::au3 {
+class ProjectSnap : public ClientData::Base
+{
+public:
+    static ProjectSnap& Get(AudacityProject& project);
+    static const ProjectSnap& Get(const AudacityProject& project);
+
+    ProjectSnap();
+    ~ProjectSnap();
+
+    void enableSnap(bool enable);
+    bool isSnapEnabled() const;
+    int snapType() const;
+    void setSnapType(unsigned int type);
+    bool isSnapTriplets() const;
+    void setSnapTriplets(bool triplets);
+
+private:
+    bool m_snapEnabled{ false };
+    int m_snapType{ 0 };
+    bool m_snapTriplets{ false };
+};
+}

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -27,7 +27,7 @@ Ret Audacity4Project::createNew()
     m_au3Project->open();
     m_trackeditProject = trackeditProjectCreator()->create(m_au3Project);
     m_isNewlyCreated = true;
-    m_viewState = viewStateCreator()->createViewState();
+    m_viewState = viewStateCreator()->createViewState(m_au3Project);
 
     return muse::make_ret(Ret::Code::Ok);
 }
@@ -106,7 +106,7 @@ muse::Ret Audacity4Project::doLoad(const io::path_t& path, bool forceMode, const
     m_trackeditProject = trackeditProjectCreator()->create(m_au3Project);
 
     //! NOTE At the moment, view state don't saved and loaded
-    m_viewState = viewStateCreator()->createViewState();
+    m_viewState = viewStateCreator()->createViewState(m_au3Project);
 
     return muse::make_ret(Ret::Code::Ok);
 }

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -105,7 +105,6 @@ muse::Ret Audacity4Project::doLoad(const io::path_t& path, bool forceMode, const
 
     m_trackeditProject = trackeditProjectCreator()->create(m_au3Project);
 
-    //! NOTE At the moment, view state don't saved and loaded
     m_viewState = viewStateCreator()->createViewState(m_au3Project);
 
     return muse::make_ret(Ret::Code::Ok);

--- a/src/projectscene/internal/projectviewstate.h
+++ b/src/projectscene/internal/projectviewstate.h
@@ -9,6 +9,7 @@
 #include "context/iglobalcontext.h"
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
+#include "au3wrap/iau3project.h"
 
 namespace au::projectscene {
 class ProjectViewState : public QObject, public IProjectViewState, public muse::async::Asyncable
@@ -19,7 +20,7 @@ class ProjectViewState : public QObject, public IProjectViewState, public muse::
     muse::Inject<IProjectSceneConfiguration> configuration;
 
 public:
-    ProjectViewState();
+    ProjectViewState(std::shared_ptr<au::au3::IAu3Project> project);
 
     // State of elements
     muse::ValCh<int> trackHeight(const trackedit::TrackId& trackId) const override;

--- a/src/projectscene/internal/projectviewstatecreator.cpp
+++ b/src/projectscene/internal/projectviewstatecreator.cpp
@@ -7,7 +7,7 @@
 
 using namespace au::projectscene;
 
-std::shared_ptr<IProjectViewState> ProjectViewStateCreator::createViewState() const
+std::shared_ptr<IProjectViewState> ProjectViewStateCreator::createViewState(std::shared_ptr<au::au3::IAu3Project> project) const
 {
-    return std::make_shared<ProjectViewState>();
+    return std::make_shared<ProjectViewState>(project);
 }

--- a/src/projectscene/internal/projectviewstatecreator.h
+++ b/src/projectscene/internal/projectviewstatecreator.h
@@ -11,6 +11,6 @@ class ProjectViewStateCreator : public IProjectViewStateCreator
 public:
     ProjectViewStateCreator() = default;
 
-    std::shared_ptr<IProjectViewState> createViewState() const override;
+    std::shared_ptr<IProjectViewState> createViewState(std::shared_ptr<au::au3::IAu3Project> project) const override;
 };
 }

--- a/src/projectscene/iprojectviewstate.h
+++ b/src/projectscene/iprojectviewstate.h
@@ -8,12 +8,6 @@
 #include "trackedit/trackedittypes.h"
 
 namespace au::projectscene {
-struct Snap {
-    SnapType type = SnapType::Bar;
-    bool enabled = false;
-    bool isSnapTriplets = false;
-};
-
 class IProjectViewState
 {
 public:

--- a/src/projectscene/iprojectviewstatecreator.h
+++ b/src/projectscene/iprojectviewstatecreator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "modularity/imoduleinterface.h"
+#include "au3wrap/iau3project.h"
 
 #include "iprojectviewstate.h"
 
@@ -11,6 +12,6 @@ class IProjectViewStateCreator : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IProjectViewStateCreator() = default;
 
-    virtual IProjectViewStatePtr createViewState() const = 0;
+    virtual IProjectViewStatePtr createViewState(std::shared_ptr<au::au3::IAu3Project> au3project) const = 0;
 };
 }

--- a/src/projectscene/types/projectscenetypes.h
+++ b/src/projectscene/types/projectscenetypes.h
@@ -79,8 +79,8 @@ public:
     Q_ENUM(Type)
 };
 
-enum class SnapType {
-    Bar,
+enum class SnapType : unsigned int {
+    Bar = 0,
 
     Half,
     Quarter,
@@ -102,6 +102,12 @@ enum class SnapType {
     PALFrames,
 
     CDDAFrames
+};
+
+struct Snap {
+    SnapType type = SnapType::Bar;
+    bool enabled = false;
+    bool isSnapTriplets = false;
 };
 
 enum class TimelineRulerMode {

--- a/src/projectscene/view/toolbars/snaptoolbaritem.cpp
+++ b/src/projectscene/view/toolbars/snaptoolbaritem.cpp
@@ -135,6 +135,7 @@ void SnapToolBarItem::onProjectChanged()
     });
 
     m_isSnapEnabled = projectViewState->isSnapEnabled();
+    m_isTripletsEnabled = projectViewState->isSnapTripletsEnabled();
     emit isSnapEnabledChanged();
 
     updateCheckedState();


### PR DESCRIPTION
Resolves: #8058

Persist snap information per project.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
