### PR TITLE
Context menus shortcuts

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -1093,7 +1093,7 @@
         <seq>Ctrl+F2</seq>
     </SC>
     <SC>
-        <key>change-pitch-and-speed</key>
+        <key>clip-pitch-speed-open</key>
         <seq>Ctrl+Shift+P</seq>
     </SC>
     <SC>

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -554,7 +554,9 @@ Rectangle {
 
                     onClicked: {
                         if (!root.multiClipsSelected) {
-                            root.requestSelectionReset()
+                            if (!root.clipSelected) {
+                                root.requestSelectionReset()
+                            }
                             root.requestSelected()
                         }
                     }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -231,6 +231,7 @@ Item {
             id: clipComp
 
             ClipItem {
+                id: item
 
                 context: root.context
                 canvas: root.canvas
@@ -404,6 +405,10 @@ Item {
                     target: clipItem
                     function onWaveChanged() {
                         updateWave()
+                    }
+
+                    function onTitleEditRequested() {
+                        item.editTitle()
                     }
                 }
             }

--- a/src/projectscene/view/clipsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/clipsview/clipcontextmenumodel.cpp
@@ -10,7 +10,6 @@ using namespace muse::uicomponents;
 using namespace muse::actions;
 
 static const ActionCode ENABLE_STRETCH_CODE("stretch-clip-to-match-tempo");
-static const ActionCode CLIP_REQUEST_TITLE_EDIT_CODE("clip-title-edit");
 
 namespace {
 //! NOTE: can be moved to the framework
@@ -32,17 +31,6 @@ void ClipContextMenuModel::load()
         return item;
     };
 
-    auto makeRenameClipItem = [this](const ActionCode& actionCode) {
-        muse::ui::UiAction action;
-        action.code = actionCode;
-        action.title = muse::TranslatableString("action", "Rename clip");
-
-        MenuItem* item = new MenuItem(action, this);
-        item->setState(muse::ui::UiActionState::make_enabled());
-
-        return item;
-    };
-
     auto enableStretchItem = makeItemWithArg(ENABLE_STRETCH_CODE);
     updateStretchEnabledState(*enableStretchItem);
 
@@ -50,19 +38,19 @@ void ClipContextMenuModel::load()
 
     MenuItemList items {
         makeItemWithArg("clip-properties"),
-        makeRenameClipItem(CLIP_REQUEST_TITLE_EDIT_CODE),
+        makeItemWithArg("rename-clip"),
         makeMenu(muse::TranslatableString("clip", "Clip color"), colorItems, "colorMenu"),
         makeSeparator(),
         makeItemWithArg("copy"),
         makeItemWithArg("duplicate"),
         makeItemWithArg("cut"),
         makeSeparator(),
-        makeItemWithArg("track-split"),
+        makeItemWithArg("split"),
         makeSeparator(),
         makeItemWithArg("clip-export"),
         makeSeparator(),
         enableStretchItem,
-        makeItemWithArg("clip-pitch-speed"),
+        makeItemWithArg("clip-pitch-speed-open"),
         makeItemWithArg("clip-render-pitch-speed"),
     };
 
@@ -74,11 +62,6 @@ void ClipContextMenuModel::load()
 
 void ClipContextMenuModel::handleMenuItem(const QString& itemId)
 {
-    if (itemId.toStdString() == CLIP_REQUEST_TITLE_EDIT_CODE) {
-        emit clipTitleEditRequested();
-        return;
-    }
-
     AbstractMenuModel::handleMenuItem(itemId);
 }
 

--- a/src/projectscene/view/clipsview/cliplistitem.h
+++ b/src/projectscene/view/clipsview/cliplistitem.h
@@ -81,6 +81,7 @@ signals:
     void pitchChanged();
     void speedPercentageChanged();
     void waveChanged();
+    void titleEditRequested();
 
 private:
     trackedit::Clip m_clip;

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -77,6 +77,8 @@ void ClipsListModel::init()
         emit asymmetricStereoHeightsPossibleChanged();
     });
 
+    dispatcher()->reg(this, "rename-clip", this, &ClipsListModel::requestClipTitleChange);
+
     reload();
 }
 
@@ -816,6 +818,25 @@ void ClipsListModel::selectClip(const ClipKey& key)
 void ClipsListModel::resetSelectedClips()
 {
     clearSelectedItems();
+}
+
+void ClipsListModel::requestClipTitleChange()
+{
+    auto selectedClips = selectionController()->selectedClips();
+
+    if (selectedClips.empty() || selectedClips.size() > 1) {
+        return;
+    }
+
+    trackedit::ClipKey clipKey = selectedClips.front();
+    if (!clipKey.isValid()) {
+        return;
+    }
+
+    ClipListItem* selectedItem = itemByKey(clipKey);
+    if (selectedItem != nullptr) {
+        emit selectedItem->titleEditRequested();
+    }
 }
 
 void ClipsListModel::onSelectedClip(const trackedit::ClipKey& k)

--- a/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/src/projectscene/view/clipsview/clipslistmodel.h
@@ -124,6 +124,7 @@ private:
     ClipListItem* itemByKey(const trackedit::ClipKey& k) const;
     int indexByKey(const trackedit::ClipKey& k) const;
     QVariant neighbor(const ClipKey& key, int offset) const;
+    void requestClipTitleChange();
 
     trackedit::secs_t calculateTimePositionOffset(const ClipListItem* item) const;
     int calculateTrackPositionOffset(const ClipKey& key, bool completed) const;

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -45,6 +45,7 @@ static const ActionCode CLIP_DELETE_CODE("clip-delete");
 static const ActionCode MULTI_CLIP_DELETE_CODE("multi-clip-delete");
 static const ActionCode RANGE_SELECTION_DELETE_CODE("clip-delete-selected");
 
+static const ActionCode OPEN_CLIP_AND_SPEED_CODE("clip-pitch-speed-open");
 static const ActionCode CLIP_RENDER_PITCH_AND_SPEED_CODE("clip-render-pitch-speed");
 static const ActionCode TRACK_SPLIT("track-split");
 static const ActionCode TRACK_SPLIT_AT("track-split-at");
@@ -168,6 +169,7 @@ void TrackeditActionsController::init()
     dispatcher()->reg(this, MULTI_CLIP_DELETE_CODE, this, &TrackeditActionsController::multiClipDelete);
     dispatcher()->reg(this, RANGE_SELECTION_DELETE_CODE, this, &TrackeditActionsController::rangeSelectionDelete);
 
+    dispatcher()->reg(this, OPEN_CLIP_AND_SPEED_CODE, this, &TrackeditActionsController::openClipPitchAndSpeed);
     dispatcher()->reg(this, CLIP_RENDER_PITCH_AND_SPEED_CODE, this, &TrackeditActionsController::renderClipPitchAndSpeed);
     dispatcher()->reg(this, TRACK_SPLIT, this, &TrackeditActionsController::trackSplit);
     dispatcher()->reg(this, TRACK_SPLIT_AT, this, &TrackeditActionsController::tracksSplitAt);
@@ -1119,6 +1121,17 @@ void TrackeditActionsController::toggleStretchClipToMatchTempo(const ActionData&
 
     trackeditInteraction()->toggleStretchToMatchProjectTempo(clipKey);
     notifyActionCheckedChanged(STRETCH_ENABLED_CODE);
+}
+
+void TrackeditActionsController::openClipPitchAndSpeed()
+{
+    auto selectedClips = selectionController()->selectedClips();
+
+    if (selectedClips.empty() || selectedClips.size() > 1) {
+        return;
+    }
+
+    dispatcher()->dispatch("clip-pitch-speed", ActionData::make_arg1<trackedit::ClipKey>(selectedClips.front()));
 }
 
 void TrackeditActionsController::renderClipPitchAndSpeed(const muse::actions::ActionData& args)

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -116,6 +116,7 @@ private:
     void silenceAudioSelection();
 
     void toggleStretchClipToMatchTempo(const muse::actions::ActionData& args);
+    void openClipPitchAndSpeed();
     void renderClipPitchAndSpeed(const muse::actions::ActionData& args);
 
     void groupClips();

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -281,6 +281,12 @@ const UiActionList TrackeditUiActions::m_actions = {
              TranslatableString("action", "Stretch with tempo changes"),
              Checkable::Yes
              ),
+    UiAction("clip-pitch-speed-open",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Open pitch and speed dialog"),
+             TranslatableString("action", "Open pitch and speed dialog")
+             ),
     UiAction("clip-render-pitch-speed",
              au::context::UiCtxAny,
              au::context::CTX_ANY,


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8194
Resolves: https://github.com/audacity/audacity/issues/8591

QA:
* added missing shortcuts to clip context menu: split, open pitch and speed dialog and rename clip
* fixed shortcut for renaming clip
* renaming clip or opening pitch and speed dialog via shortcut works only if single clip is selected
