### PR TITLE
8528 plugin scanning speed up

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,10 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${config:cmake.installPrefix}/bin/audacity.exe",
+            "args": [
+                // Comment this out to run audacity in plugin registration mode
+                // "--register-audio-plugin", "C:/Program Files/Common Files/VST3/Your plugin.vst3"
+            ],
             "preLaunchTask": "CMake: install",
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -46,7 +46,7 @@ public:
 
     void addModule(muse::modularity::IModuleSetup* module);
 
-    int run(int argc, char** argv);
+    int run(QCoreApplication& app, CommandLineParser& parser);
 
 private:
     void applyCommandLineOptions(const CommandLineParser::Options& options);


### PR DESCRIPTION
Resolves: #8528
Resolves: #8509

Implement way of selecting which modules are to be loaded depending on the run mode.

I am aware of a similar effort by @igorkorsukov in MuseScore in [this PR](https://github.com/musescore/MuseScore/pull/22678), but I do not know the context, and would like first to showcase this least-effort approach before undertaking something bigger I didn't know the motivation of.

Loading of the Au3WrapModule was causing initialization of `AudioIO` and is the biggest bottleneck.
Other modules cumulate to non-negligible times, too, when several tens or hundreds of plugins get scanned.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
