### PR TITLE
VST3 realtime effects: force setting commit when closing dialog

### DIFF
--- a/src/effects/vst/view/vstviewmodel.h
+++ b/src/effects/vst/view/vstviewmodel.h
@@ -47,7 +47,8 @@ private:
     EffectSettingsAccess* settingsAccess() const;
     void settingsToView();
     void settingsFromView();
-    void checkSettingChangesFromUi();
+    void checkSettingChangesFromUiWhileIdle();
+    void checkSettingChangesFromUi(bool forceCommitting);
 
     EffectInstanceId m_instanceId = -1;
     std::shared_ptr<VST3Instance> m_auVst3Instance;


### PR DESCRIPTION
Resolves: #8640

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
