### PR TITLE
Snapping guidelines

### DIFF
--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -257,6 +257,16 @@ au::trackedit::ClipKey ProjectViewState::lastEditedClip() const
     return m_lastEditedClip;
 }
 
+void ProjectViewState::setClipsBoundaries(const std::set<muse::secs_t>& boundaries)
+{
+    m_clipsBoundaries = boundaries;
+}
+
+std::set<muse::secs_t> ProjectViewState::clipsBoundaries() const
+{
+    return m_clipsBoundaries;
+}
+
 muse::ValCh<bool> ProjectViewState::altPressed() const
 {
     return m_altPressed;

--- a/src/projectscene/internal/projectviewstate.h
+++ b/src/projectscene/internal/projectviewstate.h
@@ -63,6 +63,9 @@ public:
     void setLastEditedClip(const trackedit::ClipKey& clipKey) override;
     trackedit::ClipKey lastEditedClip() const override;
 
+    void setClipsBoundaries(const std::set<muse::secs_t>& boundaries) override;
+    std::set<muse::secs_t> clipsBoundaries() const override;
+
     muse::ValCh<bool> altPressed() const override;
     muse::ValCh<bool> ctrlPressed() const override;
 
@@ -93,6 +96,9 @@ private:
     bool m_moveInitiated = false;
 
     trackedit::ClipKey m_lastEditedClip = trackedit::ClipKey{};
+
+    //! clips start/end times the currently moved/trimmed/stretched clip can snap to
+    std::set<muse::secs_t> m_clipsBoundaries;
 
     muse::ValCh<bool> m_altPressed;
     muse::ValCh<bool> m_ctrlPressed;

--- a/src/projectscene/iprojectviewstate.h
+++ b/src/projectscene/iprojectviewstate.h
@@ -4,8 +4,9 @@
 
 #include "global/types/retval.h"
 
-#include "types/projectscenetypes.h"
 #include "trackedit/trackedittypes.h"
+#include "types/projectscenetypes.h"
+#include "types/secs.h"
 
 namespace au::projectscene {
 class IProjectViewState
@@ -53,6 +54,9 @@ public:
 
     virtual void setLastEditedClip(const trackedit::ClipKey& clipKey) = 0;
     virtual trackedit::ClipKey lastEditedClip() const = 0;
+
+    virtual void setClipsBoundaries(const std::set<muse::secs_t>& boundaries) = 0;
+    virtual std::set<muse::secs_t> clipsBoundaries() const = 0;
 
     virtual muse::ValCh<bool> altPressed() const = 0;
     virtual muse::ValCh<bool> ctrlPressed() const = 0;

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -123,6 +123,7 @@ void ProjectSceneModule::registerUiTypes()
     qmlRegisterUncreatableType<ClipStyles>("Audacity.ProjectScene", 1, 0, "ClipStyle", "Not creatable from QML");
     qmlRegisterUncreatableType<StereoHeightsPref>("Audacity.ProjectScene", 1, 0, "AsymmetricStereoHeights", "Not creatable from QML");
     qmlRegisterUncreatableType<ClipBoundary>("Audacity.ProjectScene", 1, 0, "ClipBoundaryAction", "Not creatable from QML");
+    qmlRegisterUncreatableType<DirectionType>("Audacity.ProjectScene", 1, 0, "Direction", "Not creatable from QML");
 
     // common
     qmlRegisterType<TracksViewStateModel>("Audacity.ProjectScene", 1, 0, "TracksViewStateModel");

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -54,6 +54,8 @@ Item {
 
     signal clipHeaderHoveredChanged(bool val)
 
+    signal triggerGuideline(real x, bool completed)
+
     height: trackViewState.trackHeight
 
     ClipsListModel {
@@ -347,22 +349,32 @@ Item {
 
                 onClipEndEditRequested: function() {
                     clipsModel.endEditClip(clipItem.key)
+
+                    root.triggerGuideline(false, -1)
                 }
 
                 onClipLeftTrimRequested: function(completed, action) {
                     clipsModel.trimLeftClip(clipItem.key, completed, action)
+
+                    handleGuideline(clipItem.key, Direction.Left, completed)
                 }
 
                 onClipRightTrimRequested: function(completed, action) {
                     clipsModel.trimRightClip(clipItem.key, completed, action)
+
+                    handleGuideline(clipItem.key, Direction.Right, completed)
                 }
 
                 onClipLeftStretchRequested: function(completed, action) {
                     clipsModel.stretchLeftClip(clipItem.key, completed, action)
+
+                    handleGuideline(clipItem.key, Direction.Left, completed)
                 }
 
                 onClipRightStretchRequested: function(completed, action) {
                     clipsModel.stretchRightClip(clipItem.key, completed, action)
+
+                    handleGuideline(clipItem.key, Direction.Right, completed)
                 }
 
                 onStartAutoScroll: {
@@ -556,8 +568,11 @@ Item {
 
             // clip might change its' track, we need to update grabbed clipKey
             if (clipMovedToOtherTrack) {
+                clipKey = clipsModel.updateClipTrack(clipKey)
                 setHoveredClipKey(clipsModel.updateClipTrack(clipKey));
             }
+
+            handleGuideline(clipKey, Direction.Auto, completed)
         }
 
         function onClipStartEditRequested(clipKey) {
@@ -574,6 +589,13 @@ Item {
 
         function onStopAutoScroll() {
             root.context.stopAutoScroll()
+        }
+    }
+
+    function handleGuideline(clipKey, direction, completed) {
+        let guidelinePos = clipsModel.findGuideline(clipKey, direction)
+        if (guidelinePos) {
+            triggerGuideline(guidelinePos, completed)
         }
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -17,6 +17,7 @@ Rectangle {
     property bool clipHeaderHovered: false
     property var hoveredClipKey: null
     property bool tracksHovered: false
+    property bool guidelineActive: false
     property alias altPressed: tracksViewState.altPressed
     property alias ctrlPressed: tracksViewState.ctrlPressed
 
@@ -570,6 +571,11 @@ Rectangle {
                         })
                     }
 
+                    onTriggerGuideline: function(x, completed) {
+                        clipGuideline.x = timeline.context.timeToPosition(x)
+                        root.guidelineActive = x != -1 && !completed
+                    }
+
                     function calculateVerticalScrollDelta(viewTop, viewBottom, clipTop, clipBottom, padding = 10) {
                         // clip fully visible
                         if (clipTop >= viewTop && clipBottom <= viewBottom) {
@@ -632,6 +638,19 @@ Rectangle {
             onPlayCursorMousePositionChanged: function(ix) {
                 timeline.updateCursorPosition(ix, -1)
             }
+        }
+
+        Rectangle {
+            id: clipGuideline
+
+            anchors.top: content.top
+            anchors.bottom: content.bottom
+
+            width: 1
+
+            color: tracksViewState.snapEnabled ? "#00E5FF" : "#FFF200"
+
+            visible: root.guidelineActive
         }
 
         VerticalRulersPanel {

--- a/src/projectscene/types/projectscenetypes.h
+++ b/src/projectscene/types/projectscenetypes.h
@@ -126,9 +126,16 @@ public:
     Q_ENUM(Style)
 };
 
-enum class Direction {
-    Left = 0,
-    Right
+class DirectionType
+{
+    Q_GADGET
+public:
+    enum class Direction {
+        Left = 0,
+        Right,
+        Auto
+    };
+    Q_ENUM(Direction);
 };
 
 class ClipBoundary

--- a/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/src/projectscene/view/clipsview/clipslistmodel.h
@@ -78,6 +78,8 @@ public:
     Q_INVOKABLE void openClipSpeedEdit(const ClipKey& key);
     Q_INVOKABLE void resetClipSpeed(const ClipKey& key);
 
+    Q_INVOKABLE QVariant findGuideline(const ClipKey& key, Direction direction);
+
     // update clip after moving to other track
     Q_INVOKABLE projectscene::ClipKey updateClipTrack(ClipKey clipKey) const;
 

--- a/src/projectscene/view/common/tracksviewstatemodel.cpp
+++ b/src/projectscene/view/common/tracksviewstatemodel.cpp
@@ -40,6 +40,14 @@ void TracksViewStateModel::init()
         emit tracksVerticalScrollLockedChanged();
     });
 
+    m_snapEnabled = vs->isSnapEnabled();
+    vs->snap().ch.onReceive(this, [this](const Snap& snap) {
+        if (m_snapEnabled != snap.enabled) {
+            m_snapEnabled = snap.enabled;
+            emit snapEnabledChanged();
+        }
+    });
+
     if (m_trackId != -1) {
         m_trackHeight = vs->trackHeight(m_trackId);
         m_trackHeight.ch.onReceive(this, [this](int h) {
@@ -84,6 +92,16 @@ void TracksViewStateModel::changeTrackHeight(int deltaY)
     if (vs) {
         vs->changeTrackHeight(m_trackId, deltaY);
     }
+}
+
+bool TracksViewStateModel::snapEnabled()
+{
+    IProjectViewStatePtr vs = viewState();
+    if (vs) {
+        return vs->isSnapEnabled();
+    }
+
+    return false;
 }
 
 void TracksViewStateModel::changeTracksVericalY(int deltaY)

--- a/src/projectscene/view/common/tracksviewstatemodel.h
+++ b/src/projectscene/view/common/tracksviewstatemodel.h
@@ -33,6 +33,7 @@ class TracksViewStateModel : public QObject, public muse::async::Asyncable
     Q_PROPERTY(bool ctrlPressed READ ctrlPressed NOTIFY ctrlPressedChanged FINAL)
 
     Q_PROPERTY(bool isPlaying READ isPlaying NOTIFY isPlayingChanged FINAL)
+    Q_PROPERTY(bool snapEnabled READ snapEnabled NOTIFY snapEnabledChanged FINAL)
 
     muse::Inject<context::IGlobalContext> globalContext;
     muse::Inject<playback::IPlaybackController> playbackController;
@@ -64,6 +65,8 @@ public:
 
     Q_INVOKABLE void changeTrackHeight(int deltaY);
 
+    Q_INVOKABLE bool snapEnabled();
+
 signals:
     // Context of elements
     void trackIdChanged();
@@ -76,6 +79,8 @@ signals:
     void altPressedChanged();
     void ctrlPressedChanged();
     void isPlayingChanged();
+
+    void snapEnabledChanged();
 
 private:
     static constexpr int m_tracksVerticalScrollPadding = 228;
@@ -93,5 +98,7 @@ private:
 
     muse::ValCh<bool> m_altPressed;
     muse::ValCh<bool> m_ctrlPressed;
+
+    bool m_snapEnabled;
 };
 }

--- a/src/projectscene/view/timeline/snaptimeformatter.cpp
+++ b/src/projectscene/view/timeline/snaptimeformatter.cpp
@@ -120,6 +120,39 @@ muse::secs_t SnapTimeFormatter::singleStep(muse::secs_t time, const Snap& snap, 
     return 0.0;
 }
 
+muse::secs_t SnapTimeFormatter::snapToClip(muse::secs_t time,
+                                           muse::secs_t tolerance,
+                                           const std::set<muse::secs_t> clipsBoundaries) const
+{
+    if (clipsBoundaries.empty()) {
+        return time;
+    }
+
+    auto it = clipsBoundaries.lower_bound(time);
+
+    muse::secs_t closest = time;
+    muse::secs_t minDist = std::numeric_limits<double>::max();
+
+    if (it != clipsBoundaries.end()) {
+        muse::secs_t dist = std::abs(*it - time);
+        if (dist <= tolerance && dist < minDist) {
+            closest = *it;
+            minDist = dist;
+        }
+    }
+
+    if (it != clipsBoundaries.begin()) {
+        auto prev = std::prev(it);
+        muse::secs_t dist = std::abs(*prev - time);
+        if (dist <= tolerance && dist < minDist) {
+            closest = *prev;
+            minDist = dist;
+        }
+    }
+
+    return (minDist <= tolerance) ? closest : time;
+}
+
 double SnapTimeFormatter::snapTypeMultiplier(SnapType type, bool triplets, trackedit::TimeSignature timeSig) const
 {
     double multiplier = 0.0;

--- a/src/projectscene/view/timeline/snaptimeformatter.h
+++ b/src/projectscene/view/timeline/snaptimeformatter.h
@@ -10,6 +10,7 @@
 #include "../../types/projectscenetypes.h"
 
 namespace au::projectscene {
+using Direction = DirectionType::Direction;
 class SnapTimeFormatter
 {
     muse::Inject<playback::IPlayback> playback;
@@ -17,6 +18,8 @@ class SnapTimeFormatter
 public:
     muse::secs_t snapTime(muse::secs_t time, const Snap& snap, trackedit::TimeSignature timeSig) const;
     muse::secs_t singleStep(muse::secs_t time, const Snap& snap, Direction direction, trackedit::TimeSignature timeSig) const;
+
+    muse::secs_t snapToClip(muse::secs_t time, muse::secs_t tolerance, const std::set<muse::secs_t> clipsBoundaries) const;
 
 private:
     double snapTypeMultiplier(SnapType type, bool triplets, trackedit::TimeSignature timeSig) const;

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -20,6 +20,8 @@ static constexpr double SCROLL_MARGIN_PX = 40.0;
 static constexpr double SCROLL_MIN_SPEED = 0.00001;
 static constexpr double SCROLL_MAX_SPEED = 0.025;
 
+static constexpr int SNAP_TO_CLIP_TOLERANCE_PX = 4;
+
 using namespace au::projectscene;
 
 namespace {
@@ -535,6 +537,24 @@ double TimelineContext::applySnapToTime(double time) const
 
     trackedit::TimeSignature timeSig = project->timeSignature();
     return m_snapTimeFormatter->snapTime(time, viewState->snap().val, timeSig);
+}
+
+double TimelineContext::applySnapToClip(double time) const
+{
+    auto viewState = this->viewState();
+    if (!viewState || viewState->isSnapEnabled()) {
+        return time;
+    }
+
+    auto project = globalContext()->currentTrackeditProject();
+    if (!project) {
+        return time;
+    }
+
+    muse::secs_t tolerance = SNAP_TO_CLIP_TOLERANCE_PX / zoom();
+    std::set<muse::secs_t> clipsBoundaries = viewState->clipsBoundaries();
+
+    return m_snapTimeFormatter->snapToClip(time, tolerance, clipsBoundaries);
 }
 
 void TimelineContext::updateMousePositionTime(double mouseX)

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -20,6 +20,8 @@
 //! then we should split it into two separate classes.
 
 namespace au::projectscene {
+using Direction = DirectionType::Direction;
+
 class SnapTimeFormatter;
 class TimelineContext : public QObject, public muse::async::Asyncable, public muse::actions::Actionable
 {
@@ -105,6 +107,7 @@ public:
     Q_INVOKABLE double positionToTime(double position, bool withSnap = false) const;
     double singleStepToTime(double position, Direction direction, const Snap& snap) const;
     double applySnapToTime(double time) const;
+    double applySnapToClip(double time) const;
 
     Q_INVOKABLE void updateMousePositionTime(double mouseX);
     Q_INVOKABLE double mousePositionTime() const;

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -674,7 +674,22 @@ muse::secs_t Au3Interaction::clipStartTime(const trackedit::ClipKey& clipKey) co
         return -1.0;
     }
 
-    return clip->Start();
+    return clip->GetPlayStartTime();
+}
+
+muse::secs_t au::trackedit::Au3Interaction::clipEndTime(const ClipKey& clipKey) const
+{
+    Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(clipKey.trackId));
+    IF_ASSERT_FAILED(waveTrack) {
+        return -1.0;
+    }
+
+    std::shared_ptr<Au3WaveClip> clip = DomAccessor::findWaveClip(waveTrack, clipKey.clipId);
+    IF_ASSERT_FAILED(clip) {
+        return -1.0;
+    }
+
+    return clip->GetPlayEndTime();
 }
 
 bool Au3Interaction::changeClipStartTime(const trackedit::ClipKey& clipKey, secs_t newStartTime, bool completed)

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -33,6 +33,7 @@ public:
     Au3Interaction();
 
     muse::secs_t clipStartTime(const trackedit::ClipKey& clipKey) const override;
+    muse::secs_t clipEndTime(const trackedit::ClipKey& clipKey) const override;
 
     bool changeClipStartTime(const trackedit::ClipKey& clipKey, secs_t newStartTime, bool completed) override;
     muse::async::Channel<trackedit::ClipKey, secs_t /*newStartTime*/, bool /*completed*/> clipStartTimeChanged() const override;

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -11,6 +11,11 @@ muse::secs_t TrackeditInteraction::clipStartTime(const trackedit::ClipKey& clipK
     return m_interaction->clipStartTime(clipKey);
 }
 
+muse::secs_t TrackeditInteraction::clipEndTime(const ClipKey& clipKey) const
+{
+    return m_interaction->clipEndTime(clipKey);
+}
+
 bool TrackeditInteraction::changeClipStartTime(const trackedit::ClipKey& clipKey, secs_t newStartTime, bool completed)
 {
     return withPlaybackStop(&ITrackeditInteraction::changeClipStartTime, clipKey, newStartTime, completed);

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -19,6 +19,7 @@ public:
 
 private:
     muse::secs_t clipStartTime(const trackedit::ClipKey& clipKey) const override;
+    muse::secs_t clipEndTime(const trackedit::ClipKey& clipKey) const override;
     bool changeClipStartTime(const trackedit::ClipKey& clipKey, secs_t newStartTime, bool completed) override;
     muse::async::Channel<trackedit::ClipKey, secs_t /*newStartTime*/, bool /*completed*/> clipStartTimeChanged() const override;
     bool trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -12,6 +12,11 @@ secs_t TrackeditOperationController::clipStartTime(const ClipKey& clipKey) const
     return trackAndClipOperations()->clipStartTime(clipKey);
 }
 
+secs_t TrackeditOperationController::clipEndTime(const ClipKey& clipKey) const
+{
+    return trackAndClipOperations()->clipEndTime(clipKey);
+}
+
 bool TrackeditOperationController::changeClipStartTime(const ClipKey& clipKey, secs_t newStartTime, bool completed)
 {
     return trackAndClipOperations()->changeClipStartTime(clipKey, newStartTime, completed);

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -18,6 +18,7 @@ public:
     ~TrackeditOperationController() override = default;
 
     secs_t clipStartTime(const ClipKey& clipKey) const override;
+    secs_t clipEndTime(const trackedit::ClipKey& clipKey) const override;
 
     bool changeClipStartTime(const ClipKey& clipKey, secs_t newStartTime, bool completed) override;
     muse::async::Channel<ClipKey, secs_t /*newStartTime*/, bool /*completed*/> clipStartTimeChanged() const override;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -22,6 +22,7 @@ public:
     ~ITrackAndClipOperations() override = default;
 
     virtual secs_t clipStartTime(const ClipKey& clipKey) const = 0;
+    virtual secs_t clipEndTime(const trackedit::ClipKey& clipKey) const = 0;
 
     virtual bool changeClipStartTime(const ClipKey& clipKey, secs_t newStartTime, bool completed) = 0;
     virtual muse::async::Channel<ClipKey, secs_t /*newStartTime*/, bool /*completed*/> clipStartTimeChanged() const = 0;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -22,6 +22,7 @@ public:
     ~ITrackeditInteraction() override = default;
 
     virtual secs_t clipStartTime(const ClipKey& clipKey) const = 0;
+    virtual secs_t clipEndTime(const trackedit::ClipKey& clipKey) const = 0;
 
     //! NOTE Can be called by moving a clip
     //! if the changes is completed, then it is necessary to pass: `completed = true`


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8045

clip-to-clip snapping algo:
1. If you start edit a clip, a list of current clips start/end times (clipsBoundaries) is saved in a set (so the timepoints are unique and sorted)
2. When you move/trim/time-stretch you check if current clip's start/end time is within 4px threshold to any timepoint in clipsBoundaries set (checked with binary search)
3. When you end editing clip (mouse release) clipsBoundaries variable is reset.

When moving a clip: clip-to-clip snap is both-sided, clip-to-grid is left-sided -> that's on purpose