### PR TITLE
VstViewModel owns settings-access pointer

### DIFF
--- a/src/effects/builtin/common/abstracteffectmodel.cpp
+++ b/src/effects/builtin/common/abstracteffectmodel.cpp
@@ -60,7 +60,7 @@ const EffectSettings* AbstractEffectModel::settings() const
     return instancesRegister()->settingsById(id);
 }
 
-EffectSettingsAccess* AbstractEffectModel::settingsAccess() const
+EffectSettingsAccessPtr AbstractEffectModel::settingsAccess() const
 {
     EffectInstanceId id = this->instanceId();
     if (id == 0) {
@@ -82,7 +82,7 @@ EffectId AbstractEffectModel::effectId() const
 
 void AbstractEffectModel::preview()
 {
-    if (EffectSettingsAccess* access = this->settingsAccess()) {
+    if (const EffectSettingsAccessPtr access = this->settingsAccess()) {
         access->ModifySettings([this](EffectSettings& settings) {
             executionScenario()->previewEffect(instanceId(), settings);
             return nullptr;
@@ -92,7 +92,7 @@ void AbstractEffectModel::preview()
 
 void AbstractEffectModel::modifySettings(const std::function<void(EffectSettings& settings)>& modifier)
 {
-    EffectSettingsAccess* const access = this->settingsAccess();
+    const EffectSettingsAccessPtr access = this->settingsAccess();
     IF_ASSERT_FAILED(access) {
         return;
     }
@@ -104,7 +104,7 @@ void AbstractEffectModel::modifySettings(const std::function<void(EffectSettings
 
 void AbstractEffectModel::commitSettings()
 {
-    EffectSettingsAccess* const access = this->settingsAccess();
+    const EffectSettingsAccessPtr access = this->settingsAccess();
     IF_ASSERT_FAILED(access) {
         return;
     }

--- a/src/effects/builtin/common/abstracteffectmodel.h
+++ b/src/effects/builtin/common/abstracteffectmodel.h
@@ -74,7 +74,7 @@ protected:
     bool m_inited = false;
 
 private:
-    EffectSettingsAccess* settingsAccess() const;
+    EffectSettingsAccessPtr settingsAccess() const;
     QString m_instanceId;
 };
 }

--- a/src/effects/effects_base/ieffectinstancesregister.h
+++ b/src/effects/effects_base/ieffectinstancesregister.h
@@ -33,7 +33,7 @@ public:
     virtual muse::async::Notification updateSettingsRequested(const EffectInstanceId& instanceId) const = 0;
 
     virtual const EffectSettings* settingsById(const EffectInstanceId& instanceId) const = 0;
-    virtual EffectSettingsAccess* settingsAccessById(const EffectInstanceId& instanceId) const = 0;
+    virtual EffectSettingsAccessPtr settingsAccessById(const EffectInstanceId& instanceId) const = 0;
     virtual void notifyAboutSettingsChanged(const EffectInstanceId& instanceId) = 0;
     virtual muse::async::Notification settingsChanged(const EffectInstanceId& instanceId) const = 0;
 };

--- a/src/effects/effects_base/internal/effectinstancesregister.cpp
+++ b/src/effects/effects_base/internal/effectinstancesregister.cpp
@@ -84,11 +84,11 @@ const EffectSettings* EffectInstancesRegister::settingsById(const EffectInstance
     return nullptr;
 }
 
-EffectSettingsAccess* EffectInstancesRegister::settingsAccessById(const EffectInstanceId& instanceId) const
+EffectSettingsAccessPtr EffectInstancesRegister::settingsAccessById(const EffectInstanceId& instanceId) const
 {
     auto it = m_data.find(instanceId);
     if (it != m_data.end()) {
-        return it->second.access.get();
+        return it->second.access;
     }
 
     return nullptr;

--- a/src/effects/effects_base/internal/effectinstancesregister.h
+++ b/src/effects/effects_base/internal/effectinstancesregister.h
@@ -25,7 +25,7 @@ public:
     muse::async::Notification updateSettingsRequested(const EffectInstanceId& instanceId) const override;
 
     const EffectSettings* settingsById(const EffectInstanceId& instanceId) const override;
-    EffectSettingsAccess* settingsAccessById(const EffectInstanceId& instanceId) const override;
+    EffectSettingsAccessPtr settingsAccessById(const EffectInstanceId& instanceId) const override;
     void notifyAboutSettingsChanged(const EffectInstanceId& instanceId) override;
     muse::async::Notification settingsChanged(const EffectInstanceId& instanceId) const override;
 

--- a/src/effects/effects_base/internal/effectpresetsprovider.cpp
+++ b/src/effects/effects_base/internal/effectpresetsprovider.cpp
@@ -53,7 +53,7 @@ Ret EffectPresetsProvider::applyPreset(const EffectInstanceId& effectInstanceId,
 {
     const EffectId effectId = instancesRegister()->effectIdByInstanceId(effectInstanceId);
     const EffectSettingsManager& sm = settingsManager(effectId);
-    EffectSettingsAccess* access = instancesRegister()->settingsAccessById(effectInstanceId);
+    const EffectSettingsAccessPtr access = instancesRegister()->settingsAccessById(effectInstanceId);
 
     Ret ret;
 
@@ -164,7 +164,7 @@ muse::Ret EffectPresetsProvider::importPreset(const EffectInstanceId& effectInst
         return make_ret(Err::InternalError);
     }
 
-    EffectSettingsAccess* access = instancesRegister()->settingsAccessById(effectInstanceId);
+    const EffectSettingsAccessPtr access = instancesRegister()->settingsAccessById(effectInstanceId);
     IF_ASSERT_FAILED(access) {
         return make_ret(Err::InternalError);
     }

--- a/src/effects/vst/view/vstviewmodel.h
+++ b/src/effects/vst/view/vstviewmodel.h
@@ -44,7 +44,7 @@ signals:
 
 private:
 
-    EffectSettingsAccess* settingsAccess() const;
+    std::shared_ptr<EffectSettingsAccess> settingsAccess() const;
     void settingsToView();
     void settingsFromView();
     void checkSettingChangesFromUiWhileIdle();
@@ -52,7 +52,7 @@ private:
 
     EffectInstanceId m_instanceId = -1;
     std::shared_ptr<VST3Instance> m_auVst3Instance;
-    EffectSettingsAccess* m_settingsAccess = nullptr;
+    std::shared_ptr<EffectSettingsAccess> m_settingsAccess;
     QTimer m_settingUpdateTimer;
 };
 }


### PR DESCRIPTION
Resolves: #8690

When closing a VST UI destructively, the settings-access object was destroyed before the VstViewModel, causing the crash.
I see no reason why VstViewModel could not own the object.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] fixes the crash
- [x] VSTs still work when applied in realtime (UI can be opened and closed during playback)