### PR TITLE
Only disambiguate effects of the same family, type, category and title

### DIFF
--- a/src/effects/effects_base/internal/effectsuiactions.cpp
+++ b/src/effects/effects_base/internal/effectsuiactions.cpp
@@ -82,10 +82,14 @@ UiAction makeUiAction(const char16_t* uri, const EffectMeta& meta)
 // To mitigate this, we replace the title with the path of the plugin.
 void replaceIdenticalTitlesWithPaths(EffectMetaList& effects)
 {
-    std::unordered_map<muse::String, std::vector<size_t> > duplicateMap;
+    using DuplicationKey = std::tuple<EffectFamily, EffectType, muse::String, muse::String>;
+
+    std::map<DuplicationKey, std::vector<size_t> > duplicateMap;
 
     for (auto i = 0u; i < effects.size(); ++i) {
-        duplicateMap[effects[i].title].push_back(i);
+        const auto& effect = effects[i];
+        DuplicationKey key{ effect.family, effect.type, effect.category, effect.title };
+        duplicateMap[key].push_back(i);
     }
 
     for (const auto&[_, indices] : duplicateMap) {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8659

Do not disambiguate effects that fall into different submenus

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
