### PR TITLE
Avoid wrong fallback on default VST3 settings

### DIFF
--- a/au3/libraries/lib-vst3/VST3Wrapper.cpp
+++ b/au3/libraries/lib-vst3/VST3Wrapper.cpp
@@ -611,7 +611,7 @@ bool VST3Wrapper::IsActive() const noexcept
     return mActive;
 }
 
-void VST3Wrapper::FetchSettings(EffectSettings& settings)
+void VST3Wrapper::FetchSettings(EffectSettings& settings, bool resetState)
 {
     //TODO: perform version check
     {
@@ -622,7 +622,7 @@ void VST3Wrapper::FetchSettings(EffectSettings& settings)
 
         //Restore state
         const auto* vst3settings = &GetSettings(settings);
-        if (!vst3settings->processorState.has_value()) {
+        if (!vst3settings->processorState.has_value() && resetState) {
             vst3settings = &GetSettings(GetCache(mEffectClassInfo.ID())->defaultSettings);
         }
 
@@ -642,8 +642,8 @@ void VST3Wrapper::FetchSettings(EffectSettings& settings)
         }
     }
     //restore parameters if present
-    auto& vst3setting = GetSettings(settings);
-    for (auto& p : vst3setting.parameterChanges) {
+    const auto& vst3setting = GetSettings(settings);
+    for (const auto& p : vst3setting.parameterChanges) {
         mEditController->setParamNormalized(p.first, p.second);
     }
 }
@@ -778,7 +778,8 @@ bool VST3Wrapper::Initialize(EffectSettings& settings, Steinberg::Vst::SampleRat
 
     mSetup = setup;
 
-    FetchSettings(settings);
+    constexpr auto fallbackOnDefaults = false;
+    FetchSettings(settings, fallbackOnDefaults);
 
     if (mEffectComponent->setActive(true) == kResultOk) {
         if (mAudioProcessor->setProcessing(true) != kResultFalse) {

--- a/au3/libraries/lib-vst3/VST3Wrapper.h
+++ b/au3/libraries/lib-vst3/VST3Wrapper.h
@@ -86,7 +86,7 @@ public:
     bool IsActive() const noexcept;
 
     //!Fetch state from settings object, may change internal runtime data
-    void FetchSettings(EffectSettings&);
+    void FetchSettings(EffectSettings&, bool resetState);
     //!Saves current state inside settings object, clears all runtime data
     void StoreSettings(EffectSettings&) const;
 

--- a/src/effects/vst/view/vstviewmodel.cpp
+++ b/src/effects/vst/view/vstviewmodel.cpp
@@ -98,7 +98,8 @@ void VstViewModel::settingsToView()
 
     VST3Wrapper& w = m_auVst3Instance->GetWrapper();
     m_settingsAccess->ModifySettings([&w](EffectSettings& settings) {
-        w.FetchSettings(settings);
+        constexpr auto fallbackOnDefaults = true;
+        w.FetchSettings(settings, fallbackOnDefaults);
         return nullptr;
     });
 }


### PR DESCRIPTION
Resolves: #5680
Resolves: #4396 (with a bit of luck)

What normally happens when changing the parameters of a VST3 plugin via its UI:
1. `Steinberg::Vst::IComponentHandler::performEdit` gets called, adding entries in the `mParametersCache` map,
2. Our timer in `VstViewModel` "flushes" the cache into the `RealtimeEffectState::Access`,
3. since it detected that it wasn't the cache wasn't empty (and hence something changed), it calls `StoreSettings`, which gets the `RealtimeEffectState::Access` to commit the changes to `mMainSettings`.

Some VST3 implementations don't call `performEdit` ; hence nothing is stored in `mMainSettings`, and when playback initialization is called, `FetchSettings` falls back to the default values for that VST.

The solution proposed by [@RubisetCie](https://github.com/RubisetCie) in #5680 and replicated here on the Au4 branch allows fallback on the default settings only via the timer. I think it should work because when a project that has some VSTs is opened, the `mMainSettings` are set as the project file is de-serialized, so the timer won't get there before,

It nevertheless is horribly complicated code we are dealing with. I hope there are no unforeseen side effects to this, hence I propose to have this change on Au4 and, if it works satisfactorily, patch it to Au3 before the next release, which is later. This will give us a chance to catch any of these.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
