### PR TITLE
8606 extract clipboard and project history from au3interaction

### DIFF
--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -748,7 +748,7 @@ bool ClipsListModel::moveSelectedClips(const ClipKey& key, bool completed)
     bool clipsMovedToOtherTrack = false;
     MoveOffset moveOffset = calculateMoveOffset(item, key, completed);
     if (vs->moveInitiated()) {
-        clipsMovedToOtherTrack = trackeditInteraction()->moveClips(moveOffset.timeOffset, moveOffset.trackOffset, completed);
+        trackeditInteraction()->moveClips(moveOffset.timeOffset, moveOffset.trackOffset, completed, clipsMovedToOtherTrack);
     }
 
     if ((completed && m_autoScrollConnection)) {

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -16,6 +16,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/iprojecthistory.h
     ${CMAKE_CURRENT_LIST_DIR}/itrackeditconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/itrackeditclipboard.h
+    ${CMAKE_CURRENT_LIST_DIR}/timespan.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/timespan.h
     ${CMAKE_CURRENT_LIST_DIR}/trackediterrors.h
     ${CMAKE_CURRENT_LIST_DIR}/trackeditutils.cpp
     ${CMAKE_CURRENT_LIST_DIR}/trackeditutils.h

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1207,22 +1207,21 @@ ITrackDataPtr Au3Interaction::cutTrackData(const TrackId trackId, secs_t begin, 
     return data;
 }
 
-bool Au3Interaction::copyClipIntoClipboard(const ClipKey& clipKey)
+ITrackDataPtr Au3Interaction::copyClip(const ClipKey& clipKey)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(clipKey.trackId));
     IF_ASSERT_FAILED(waveTrack) {
-        return false;
+        return nullptr;
     }
 
     std::shared_ptr<Au3WaveClip> clip = DomAccessor::findWaveClip(waveTrack, clipKey.clipId);
     IF_ASSERT_FAILED(clip) {
-        return false;
+        return nullptr;
     }
 
     auto track = waveTrack->Copy(clip->Start(), clip->End());
-    clipboard()->addTrackData(std::make_shared<Au3TrackData>(std::move(track)));
 
-    return true;
+    return std::make_shared<Au3TrackData>(std::move(track));
 }
 
 bool Au3Interaction::copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset)

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1168,29 +1168,27 @@ muse::Ret Au3Interaction::pasteFromClipboard(secs_t begin, bool moveClips, bool 
     return ok;
 }
 
-bool Au3Interaction::cutClipIntoClipboard(const ClipKey& clipKey)
+ITrackDataPtr Au3Interaction::cutClip(const ClipKey& clipKey)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(clipKey.trackId));
     IF_ASSERT_FAILED(waveTrack) {
-        return false;
+        return nullptr;
     }
 
     std::shared_ptr<Au3WaveClip> clip = DomAccessor::findWaveClip(waveTrack, clipKey.clipId);
     IF_ASSERT_FAILED(clip) {
-        return false;
+        return nullptr;
     }
 
-    bool moveClips = true;
+    constexpr bool moveClips = true;
     auto track = waveTrack->Cut(clip->Start(), clip->End(), moveClips);
-    clipboard()->addTrackData(std::make_shared<Au3TrackData>(std::move(track)));
+    const auto data = std::make_shared<Au3TrackData>(std::move(track));
 
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     prj->notifyAboutClipRemoved(DomConverter::clip(waveTrack, clip.get()));
     prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
 
-    projectHistory()->pushHistoryState("Cut to the clipboard", "Cut");
-
-    return true;
+    return data;
 }
 
 bool Au3Interaction::cutClipDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips)

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1247,17 +1247,15 @@ ITrackDataPtr Au3Interaction::copyNonContinuousTrackData(const TrackId trackId, 
     return std::make_shared<Au3TrackData>(std::move(clipboardTrack));
 }
 
-bool Au3Interaction::copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end)
+ITrackDataPtr Au3Interaction::copyContinuousTrackData(const TrackId trackId, secs_t begin, secs_t end)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
     IF_ASSERT_FAILED(waveTrack) {
-        return false;
+        return nullptr;
     }
 
     auto track = waveTrack->Copy(begin, end);
-    clipboard()->addTrackData(std::make_shared<Au3TrackData>(std::move(track)));
-
-    return true;
+    return std::make_shared<Au3TrackData>(std::move(track));
 }
 
 bool Au3Interaction::removeClip(const trackedit::ClipKey& clipKey)

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1845,27 +1845,25 @@ bool Au3Interaction::duplicateClips(const ClipKeyList& clipKeyList)
     return true;
 }
 
-bool Au3Interaction::clipSplitCut(const ClipKey& clipKey)
+ITrackDataPtr Au3Interaction::clipSplitCut(const ClipKey& clipKey)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(clipKey.trackId));
     IF_ASSERT_FAILED(waveTrack) {
-        return false;
+        return nullptr;
     }
 
     std::shared_ptr<Au3WaveClip> clip = DomAccessor::findWaveClip(waveTrack, clipKey.clipId);
     IF_ASSERT_FAILED(clip) {
-        return false;
+        return nullptr;
     }
 
     auto track = waveTrack->SplitCut(clip->Start(), clip->End());
-    clipboard()->addTrackData(std::make_shared<Au3TrackData>(std::move(track)));
+    const auto data = std::make_shared<Au3TrackData>(std::move(track));
 
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
 
-    projectHistory()->pushHistoryState("Split-cut to the clipboard", "Split cut");
-
-    return true;
+    return data;
 }
 
 bool Au3Interaction::clipSplitDelete(const ClipKey& clipKey)

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1017,19 +1017,11 @@ void notifyAboutTrackToggledStereo(au::trackedit::ITrackeditProject& prj, const 
 }
 }
 
-muse::Ret Au3Interaction::pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks)
+muse::Ret Au3Interaction::paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks)
 {
-    if (clipboard()->trackDataEmpty()) {
-        return make_ret(trackedit::Err::TrackEmpty);
-    }
-
-    std::vector<std::shared_ptr<Au3TrackData> > copiedData;
-    {
-        const std::vector<ITrackDataPtr> trackData = clipboard()->trackDataCopy();
-        copiedData.reserve(trackData.size());
-        for (const auto& trackDataHolder : trackData) {
-            copiedData.push_back(std::static_pointer_cast<Au3TrackData>(trackDataHolder));
-        }
+    std::vector<std::shared_ptr<Au3TrackData> > copiedData(data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        copiedData[i] = std::static_pointer_cast<Au3TrackData>(data[i]);
     }
 
     project::IAudacityProjectPtr project = globalContext()->currentProject();

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -896,8 +896,6 @@ bool Au3Interaction::changeTrackColor(const TrackId trackId, const std::string& 
         prj->notifyAboutClipChanged(DomConverter::clip(waveTrack, clips.get()));
     }
 
-    projectHistory()->pushHistoryState("Changed track color", "Changed track color");
-
     return true;
 }
 

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1019,6 +1019,10 @@ void notifyAboutTrackToggledStereo(au::trackedit::ITrackeditProject& prj, const 
 
 muse::Ret Au3Interaction::paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks, bool isMultiSelectionCopy)
 {
+    if (data.empty()) {
+        return make_ret(trackedit::Err::TrackEmpty);
+    }
+
     std::vector<std::shared_ptr<Au3TrackData> > copiedData(data.size());
     for (size_t i = 0; i < data.size(); ++i) {
         copiedData[i] = std::static_pointer_cast<Au3TrackData>(data[i]);

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1191,35 +1191,20 @@ ITrackDataPtr Au3Interaction::cutClip(const ClipKey& clipKey)
     return data;
 }
 
-bool Au3Interaction::cutClipDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips)
-{
-    for (const auto& trackId : tracksIds) {
-        bool ok = cutTrackDataIntoClipboard(trackId, begin, end, moveClips);
-        if (!ok) {
-            return false;
-        }
-    }
-
-    trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-    projectHistory()->pushHistoryState("Cut to the clipboard", "Cut");
-
-    return true;
-}
-
-bool Au3Interaction::cutTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end, bool moveClips)
+ITrackDataPtr Au3Interaction::cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
     IF_ASSERT_FAILED(waveTrack) {
-        return false;
+        return nullptr;
     }
 
     auto track = waveTrack->Cut(begin, end, moveClips);
-    clipboard()->addTrackData(std::make_shared<Au3TrackData>(std::move(track)));
+    const auto data = std::make_shared<Au3TrackData>(std::move(track));
 
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
 
-    return true;
+    return data;
 }
 
 bool Au3Interaction::copyClipIntoClipboard(const ClipKey& clipKey)

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1219,11 +1219,11 @@ ITrackDataPtr Au3Interaction::copyClip(const ClipKey& clipKey)
     return std::make_shared<Au3TrackData>(std::move(track));
 }
 
-bool Au3Interaction::copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset)
+ITrackDataPtr Au3Interaction::copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
     IF_ASSERT_FAILED(waveTrack) {
-        return false;
+        return nullptr;
     }
 
     auto& trackFactory = WaveTrackFactory::Get(projectRef());
@@ -1234,7 +1234,7 @@ bool Au3Interaction::copyNonContinuousTrackDataIntoClipboard(const TrackId track
     for (const auto& clipKey : clipKeys) {
         std::shared_ptr<Au3WaveClip> clip = DomAccessor::findWaveClip(waveTrack, clipKey.clipId);
         IF_ASSERT_FAILED(clip) {
-            return false;
+            return nullptr;
         }
 
         clipboardTrack->InsertInterval(waveTrack->CopyClip(*clip, true), false);
@@ -1244,12 +1244,7 @@ bool Au3Interaction::copyNonContinuousTrackDataIntoClipboard(const TrackId track
         clip->SetPlayStartTime(clip->GetPlayStartTime() + offset);
     }
 
-    clipboard()->addTrackData(std::make_shared<Au3TrackData>(std::move(clipboardTrack)));
-    if (clipKeys.size() > 1) {
-        clipboard()->setMultiSelectionCopy(true);
-    }
-
-    return true;
+    return std::make_shared<Au3TrackData>(std::move(clipboardTrack));
 }
 
 bool Au3Interaction::copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end)

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -984,11 +984,6 @@ bool Au3Interaction::renderClipPitchAndSpeed(const ClipKey& clipKey)
     return true;
 }
 
-void Au3Interaction::clearClipboard()
-{
-    clipboard()->clearTrackData();
-}
-
 bool Au3Interaction::clipTransferNeedsDownmixing(const std::vector<Au3TrackDataPtr>& srcTracks,
                                                  const TrackIdList& dstTracks) const
 {

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -56,7 +56,7 @@ public:
     ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) override;
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;
     ITrackDataPtr copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;
-    bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) override;
+    ITrackDataPtr copyContinuousTrackData(const TrackId trackId, secs_t begin, secs_t end) override;
     bool removeClip(const trackedit::ClipKey& clipKey) override;
     bool removeClips(const trackedit::ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -49,8 +49,8 @@ public:
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
     bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;
-    muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks,
-                    bool isMultiSelectionCopy) override;
+    muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks, bool isMultiSelectionCopy,
+                    bool& projectWasModified) override;
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
     ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) override;
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;
@@ -145,8 +145,6 @@ private:
 
     ITrackDataPtr splitCutSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
     bool splitDeleteSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
-
-    void pushProjectHistoryPasteState();
 
     bool canMoveTrack(const TrackId trackId, const TrackMoveDirection direction);
     int trackPosition(const TrackId trackId);

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -48,7 +48,7 @@ public:
     bool changeClipColor(const ClipKey& clipKey, const std::string& color) override;
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
-    bool renderClipPitchAndSpeed(const ClipKey& clipKey, std::function<void()> onComplete) override;
+    bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;
     muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks,
                     bool isMultiSelectionCopy) override;
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
@@ -147,10 +147,6 @@ private:
     bool splitDeleteSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
 
     void pushProjectHistoryPasteState();
-    void pushProjectHistoryResetClipPitchState();
-    void pushProjectHistoryChangeClipSpeedState();
-    void pushProjectHistoryResetClipSpeedState();
-    void pushProjectHistoryRenderClipStretchingState();
 
     bool canMoveTrack(const TrackId trackId, const TrackMoveDirection direction);
     int trackPosition(const TrackId trackId);

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -6,7 +6,6 @@
 #include "au3interactiontypes.h"
 
 #include "../../itrackandclipoperations.h"
-#include "../../iprojecthistory.h"
 #include "../../iselectioncontroller.h"
 #include "../../itrackeditconfiguration.h"
 #include "context/iglobalcontext.h"
@@ -24,7 +23,6 @@ class Au3Interaction : public ITrackAndClipOperations
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<au::trackedit::ISelectionController> selectionController;
     muse::Inject<muse::IInteractive> interactive;
-    muse::Inject<au::trackedit::IProjectHistory> projectHistory;
     muse::Inject<au::trackedit::ITrackeditConfiguration> configuration;
 
 public:

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -51,7 +51,6 @@ public:
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
     bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;
-    void clearClipboard() override;
     muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks) override;
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
     ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -48,7 +48,7 @@ public:
     bool changeClipColor(const ClipKey& clipKey, const std::string& color) override;
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
-    bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;
+    bool renderClipPitchAndSpeed(const ClipKey& clipKey, std::function<void()> onComplete) override;
     muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks,
                     bool isMultiSelectionCopy) override;
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
@@ -56,7 +56,7 @@ public:
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;
     ITrackDataPtr copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;
     ITrackDataPtr copyContinuousTrackData(const TrackId trackId, secs_t begin, secs_t end) override;
-    bool removeClip(const trackedit::ClipKey& clipKey) override;
+    bool removeClip(const trackedit::ClipKey& clipKey, secs_t& begin, secs_t& end) override;
     bool removeClips(const trackedit::ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) override;
@@ -73,14 +73,10 @@ public:
     bool clipSplitDelete(const ClipKey& clipKey) override;
     std::vector<ITrackDataPtr> splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) override;
     bool splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) override;
-    bool trimClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
-                      UndoPushType type = UndoPushType::NONE) override;
-    bool trimClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
-                       UndoPushType type = UndoPushType::NONE) override;
-    bool stretchClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
-                         UndoPushType type = UndoPushType::NONE) override;
-    bool stretchClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
-                          UndoPushType type = UndoPushType::NONE) override;
+    bool trimClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed) override;
+    bool trimClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed) override;
+    bool stretchClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed) override;
+    bool stretchClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed) override;
     muse::secs_t clipDuration(const trackedit::ClipKey& clipKey) const override;
     std::optional<secs_t> getLeftmostClipStartTime(const ClipKeyList& clipKeys) const override;
 
@@ -89,8 +85,8 @@ public:
     bool newLabelTrack() override;
     bool deleteTracks(const TrackIdList& trackIds) override;
     bool duplicateTracks(const TrackIdList& trackIds) override;
-    void moveTracks(const TrackIdList& trackIds, const TrackMoveDirection direction) override;
-    void moveTracksTo(const TrackIdList& trackIds, int to) override;
+    bool moveTracks(const TrackIdList& trackIds, const TrackMoveDirection direction) override;
+    bool moveTracksTo(const TrackIdList& trackIds, int to) override;
 
     bool insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration) override;
 
@@ -120,7 +116,7 @@ private:
     NeedsDownmixing moveSelectedClipsUpOrDown(int offset);
     bool clipTransferNeedsDownmixing(const std::vector<Au3TrackDataPtr>& srcTracks, const TrackIdList& dstTracks) const;
     bool userIsOkWithDownmixing() const;
-    muse::Ret canPasteTrackData(const TrackIdList& tracksIds, const std::vector<Au3TrackDataPtr>& clipsToPaste, secs_t begin) const;
+    muse::Ret canPasteTrackData(const TrackIdList& tracksIds, const std::vector<Au3TrackDataPtr>& clipsToPaste) const;
     muse::Ret makeRoomForClip(const trackedit::ClipKey& clipKey);
     muse::Ret makeRoomForClipsOnTracks(const std::vector<TrackId>& tracksIds, const std::vector<Au3TrackDataPtr>& trackData, secs_t begin);
     muse::Ret makeRoomForDataOnTrack(const TrackId trackId, secs_t begin, secs_t end);
@@ -150,23 +146,11 @@ private:
     ITrackDataPtr splitCutSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
     bool splitDeleteSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
 
-    void pushProjectHistoryJoinState(secs_t start, secs_t duration);
-    void pushProjectHistorySplitDeleteState(secs_t start, secs_t duration);
-    void pushProjectHistoryDuplicateState();
-
-    void pushProjectHistoryTrackAddedState();
-    void pushProjectHistoryTracksTrimState(secs_t start, secs_t end);
-    void pushProjectHistoryTrackSilenceState(secs_t start, secs_t end);
     void pushProjectHistoryPasteState();
-    void pushProjectHistoryDeleteState(secs_t start, secs_t duration);
-    void pushProjectHistoryDeleteMultipleState();
-    void pushProjectHistoryChangeClipPitchState();
     void pushProjectHistoryResetClipPitchState();
     void pushProjectHistoryChangeClipSpeedState();
     void pushProjectHistoryResetClipSpeedState();
     void pushProjectHistoryRenderClipStretchingState();
-    void pushProjectHistoryChangeTrackTitle();
-    void pushProjectHistoryChangeClipTitle();
 
     bool canMoveTrack(const TrackId trackId, const TrackMoveDirection direction);
     int trackPosition(const TrackId trackId);

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -54,7 +54,7 @@ public:
     void clearClipboard() override;
     muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks) override;
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
-    bool cutClipDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
+    ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) override;
     bool copyClipIntoClipboard(const trackedit::ClipKey& clipKey) override;
     bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;
     bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) override;
@@ -142,7 +142,6 @@ private:
     bool trimClipsRight(const ClipKeyList& clipKeys, secs_t deltaSec, bool completed);
     bool stretchClipsLeft(const ClipKeyList& clipKeys, secs_t deltaSec, bool completed);
     bool stretchClipsRight(const ClipKeyList& clipKeys, secs_t deltaSec, bool completed);
-    bool cutTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end, bool moveClips);
     bool cutTrackDataIntoClipboardRipple(const TrackId trackId, secs_t begin, secs_t end);
     bool mergeSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
     bool duplicateSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -55,7 +55,7 @@ public:
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
     ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) override;
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;
-    bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;
+    ITrackDataPtr copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;
     bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) override;
     bool removeClip(const trackedit::ClipKey& clipKey) override;
     bool removeClips(const trackedit::ClipKeyList& clipKeyList, bool moveClips) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -70,7 +70,7 @@ public:
     bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
     bool duplicateClip(const ClipKey& clipKey) override;
     bool duplicateClips(const ClipKeyList& clipKeyList) override;
-    bool clipSplitCut(const ClipKey& clipKey) override;
+    ITrackDataPtr clipSplitCut(const ClipKey& clipKey) override;
     bool clipSplitDelete(const ClipKey& clipKey) override;
     std::vector<ITrackDataPtr> splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) override;
     bool splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -53,7 +53,7 @@ public:
     bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;
     void clearClipboard() override;
     muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks) override;
-    bool cutClipIntoClipboard(const ClipKey& clipKey) override;
+    ITrackDataPtr cutClip(const ClipKey& clipKey) override;
     bool cutClipDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
     bool copyClipIntoClipboard(const trackedit::ClipKey& clipKey) override;
     bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -72,7 +72,7 @@ public:
     bool duplicateClips(const ClipKeyList& clipKeyList) override;
     bool clipSplitCut(const ClipKey& clipKey) override;
     bool clipSplitDelete(const ClipKey& clipKey) override;
-    bool splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) override;
+    std::vector<ITrackDataPtr> splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) override;
     bool splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) override;
     bool trimClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
                       UndoPushType type = UndoPushType::NONE) override;
@@ -149,7 +149,7 @@ private:
     std::shared_ptr<WaveTrack> createMonoTrack();
     std::shared_ptr<WaveTrack> createStereoTrack();
 
-    bool splitCutSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
+    ITrackDataPtr splitCutSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
     bool splitDeleteSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
 
     void pushProjectHistoryJoinState(secs_t start, secs_t duration);

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -8,7 +8,6 @@
 #include "../../itrackandclipoperations.h"
 #include "../../iprojecthistory.h"
 #include "../../iselectioncontroller.h"
-#include "../../itrackeditclipboard.h"
 #include "../../itrackeditconfiguration.h"
 #include "context/iglobalcontext.h"
 #include "iinteractive.h"
@@ -26,7 +25,6 @@ class Au3Interaction : public ITrackAndClipOperations
     muse::Inject<au::trackedit::ISelectionController> selectionController;
     muse::Inject<muse::IInteractive> interactive;
     muse::Inject<au::trackedit::IProjectHistory> projectHistory;
-    muse::Inject<au::trackedit::ITrackeditClipboard> clipboard;
     muse::Inject<au::trackedit::ITrackeditConfiguration> configuration;
 
 public:
@@ -142,7 +140,6 @@ private:
     bool trimClipsRight(const ClipKeyList& clipKeys, secs_t deltaSec, bool completed);
     bool stretchClipsLeft(const ClipKeyList& clipKeys, secs_t deltaSec, bool completed);
     bool stretchClipsRight(const ClipKeyList& clipKeys, secs_t deltaSec, bool completed);
-    bool cutTrackDataIntoClipboardRipple(const TrackId trackId, secs_t begin, secs_t end);
     bool mergeSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
     bool duplicateSelectedOnTrack(const TrackId trackId, secs_t begin, secs_t end);
     void doInsertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration);

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -56,10 +56,10 @@ public:
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;
     ITrackDataPtr copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;
     ITrackDataPtr copyContinuousTrackData(const TrackId trackId, secs_t begin, secs_t end) override;
-    bool removeClip(const trackedit::ClipKey& clipKey, secs_t& begin, secs_t& end) override;
+    std::optional<TimeSpan> removeClip(const trackedit::ClipKey& clipKey) override;
     bool removeClips(const trackedit::ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
-    bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) override;
+    bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTracks) override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -55,7 +55,7 @@ public:
     muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks) override;
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
     ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) override;
-    bool copyClipIntoClipboard(const trackedit::ClipKey& clipKey) override;
+    ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;
     bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;
     bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) override;
     bool removeClip(const trackedit::ClipKey& clipKey) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -51,7 +51,7 @@ public:
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
     bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;
-    muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks) override;
+    muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks) override;
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
     ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) override;
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -51,7 +51,8 @@ public:
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
     bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;
-    muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks) override;
+    muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks,
+                    bool isMultiSelectionCopy) override;
     ITrackDataPtr cutClip(const ClipKey& clipKey) override;
     ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) override;
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -136,12 +136,13 @@ bool TrackeditInteraction::removeTracksData(const TrackIdList& tracksIds, secs_t
     return withPlaybackStop(&ITrackeditInteraction::removeTracksData, tracksIds, begin, end, moveClips);
 }
 
-bool TrackeditInteraction::moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed)
+bool TrackeditInteraction::moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTrack)
 {
     return withPlaybackStop(&ITrackeditInteraction::moveClips,
                             timePositionOffset,
                             trackPositionOffset,
-                            completed);
+                            completed,
+                            clipsMovedToOtherTrack);
 }
 
 bool TrackeditInteraction::splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots)

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -44,7 +44,7 @@ private:
     bool removeClip(const trackedit::ClipKey& clipKey) override;
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
-    bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) override;
+    bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool&) override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -99,7 +99,13 @@ muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool mo
 
 bool TrackeditOperationController::cutClipIntoClipboard(const ClipKey& clipKey)
 {
-    return trackAndClipOperations()->cutClipIntoClipboard(clipKey);
+    auto data = trackAndClipOperations()->cutClip(clipKey);
+    if (!data) {
+        return false;
+    }
+    clipboard()->addTrackData(std::move(data));
+    projectHistory()->pushHistoryState("Cut to the clipboard", "Cut");
+    return true;
 }
 
 bool TrackeditOperationController::cutClipDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips)

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -89,7 +89,7 @@ bool TrackeditOperationController::renderClipPitchAndSpeed(const ClipKey& clipKe
 
 void TrackeditOperationController::clearClipboard()
 {
-    trackAndClipOperations()->clearClipboard();
+    clipboard()->clearTrackData();
 }
 
 muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks)

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -2,6 +2,7 @@
  * Audacity: A Digital Audio Editor
  */
 #include "trackeditoperationcontroller.h"
+#include "trackediterrors.h"
 
 namespace au::trackedit {
 TrackeditOperationController::TrackeditOperationController(std::unique_ptr<IUndoManager> undoManager)
@@ -94,7 +95,11 @@ void TrackeditOperationController::clearClipboard()
 
 muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks)
 {
-    return trackAndClipOperations()->pasteFromClipboard(begin, moveClips, moveAllTracks);
+    if (clipboard()->trackDataEmpty()) {
+        return make_ret(trackedit::Err::TrackEmpty);
+    }
+
+    return trackAndClipOperations()->paste(clipboard()->trackDataCopy(), begin, moveClips, moveAllTracks);
 }
 
 bool TrackeditOperationController::cutClipIntoClipboard(const ClipKey& clipKey)

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -121,7 +121,11 @@ bool TrackeditOperationController::changeClipOptimizeForVoice(const ClipKey& cli
 
 bool TrackeditOperationController::renderClipPitchAndSpeed(const ClipKey& clipKey)
 {
-    return trackAndClipOperations()->renderClipPitchAndSpeed(clipKey);
+    if (trackAndClipOperations()->renderClipPitchAndSpeed(clipKey)) {
+        projectHistory()->pushHistoryState("Rendered time-stretched audio", "Render");
+        return true;
+    }
+    return false;
 }
 
 void TrackeditOperationController::clearClipboard()

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -99,7 +99,8 @@ muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool mo
         return make_ret(trackedit::Err::TrackEmpty);
     }
 
-    return trackAndClipOperations()->paste(clipboard()->trackDataCopy(), begin, moveClips, moveAllTracks);
+    return trackAndClipOperations()->paste(clipboard()->trackDataCopy(), begin, moveClips, moveAllTracks,
+                                           clipboard()->isMultiSelectionCopy());
 }
 
 bool TrackeditOperationController::cutClipIntoClipboard(const ClipKey& clipKey)
@@ -161,6 +162,7 @@ bool TrackeditOperationController::copyContinuousTrackDataIntoClipboard(const Tr
         return false;
     }
     clipboard()->addTrackData(std::move(data));
+    return true;
 }
 
 bool TrackeditOperationController::removeClip(const ClipKey& clipKey)

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -230,7 +230,13 @@ bool TrackeditOperationController::duplicateClips(const ClipKeyList& clipKeyList
 
 bool TrackeditOperationController::clipSplitCut(const ClipKey& clipKey)
 {
-    return trackAndClipOperations()->clipSplitCut(clipKey);
+    ITrackDataPtr data = trackAndClipOperations()->clipSplitCut(clipKey);
+    if (!data) {
+        return false;
+    }
+    clipboard()->addTrackData(std::move(data));
+    projectHistory()->pushHistoryState("Split-cut to the clipboard", "Split cut");
+    return true;
 }
 
 bool TrackeditOperationController::clipSplitDelete(const ClipKey& clipKey)

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -111,7 +111,11 @@ bool TrackeditOperationController::changeClipColor(const ClipKey& clipKey, const
 
 bool TrackeditOperationController::changeTrackColor(const TrackId trackId, const std::string& color)
 {
-    return trackAndClipOperations()->changeTrackColor(trackId, color);
+    if (trackAndClipOperations()->changeTrackColor(trackId, color)) {
+        projectHistory()->pushHistoryState("Changed track color", "Changed track color");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize)

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -240,7 +240,15 @@ bool TrackeditOperationController::clipSplitDelete(const ClipKey& clipKey)
 
 bool TrackeditOperationController::splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->splitCutSelectedOnTracks(tracksIds, begin, end);
+    std::vector<ITrackDataPtr> tracksData = trackAndClipOperations()->splitCutSelectedOnTracks(tracksIds, begin, end);
+    if (tracksData.empty()) {
+        return false;
+    }
+    for (auto& trackData : tracksData) {
+        clipboard()->addTrackData(std::move(trackData));
+    }
+    projectHistory()->pushHistoryState("Split-cut to the clipboard", "Split cut");
+    return true;
 }
 
 bool TrackeditOperationController::splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end)

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -151,7 +151,11 @@ bool TrackeditOperationController::copyNonContinuousTrackDataIntoClipboard(const
 
 bool TrackeditOperationController::copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->copyContinuousTrackDataIntoClipboard(trackId, begin, end);
+    ITrackDataPtr data = trackAndClipOperations()->copyContinuousTrackData(trackId, begin, end);
+    if (!data) {
+        return false;
+    }
+    clipboard()->addTrackData(std::move(data));
 }
 
 bool TrackeditOperationController::removeClip(const ClipKey& clipKey)

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -127,7 +127,12 @@ bool TrackeditOperationController::cutClipDataIntoClipboard(const TrackIdList& t
 
 bool TrackeditOperationController::copyClipIntoClipboard(const ClipKey& clipKey)
 {
-    return trackAndClipOperations()->copyClipIntoClipboard(clipKey);
+    ITrackDataPtr data = trackAndClipOperations()->copyClip(clipKey);
+    if (!data) {
+        return false;
+    }
+    clipboard()->addTrackData(std::move(data));
+    return true;
 }
 
 bool TrackeditOperationController::copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys,

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -30,42 +30,78 @@ muse::async::Channel<ClipKey, secs_t /*newStartTime*/, bool /*completed*/> Track
 
 bool TrackeditOperationController::trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->trimTracksData(tracksIds, begin, end);
+    if (trackAndClipOperations()->trimTracksData(tracksIds, begin, end)) {
+        std::stringstream ss;
+        ss << "Trim selected audio tracks from " << begin << " seconds to " << end << " seconds";
+        projectHistory()->pushHistoryState(ss.str(), "Trim Audio");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->silenceTracksData(tracksIds, begin, end);
+    if (trackAndClipOperations()->silenceTracksData(tracksIds, begin, end)) {
+        std::stringstream ss;
+        ss << "Silenced selected tracks for " << begin << " seconds at " << end << "seconts";
+        projectHistory()->pushHistoryState(ss.str(), "Silence");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title)
 {
-    return trackAndClipOperations()->changeTrackTitle(trackId, title);
+    if (trackAndClipOperations()->changeTrackTitle(trackId, title)) {
+        projectHistory()->pushHistoryState("Track Title", "Changed Track Title");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::changeClipTitle(const ClipKey& clipKey, const muse::String& newTitle)
 {
-    return trackAndClipOperations()->changeClipTitle(clipKey, newTitle);
+    if (trackAndClipOperations()->changeClipTitle(clipKey, newTitle)) {
+        projectHistory()->pushHistoryState("Clip Title", "Changed Clip Title");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::changeClipPitch(const ClipKey& clipKey, int pitch)
 {
-    return trackAndClipOperations()->changeClipPitch(clipKey, pitch);
+    if (trackAndClipOperations()->changeClipPitch(clipKey, pitch)) {
+        projectHistory()->pushHistoryState("Pitch Shift", "Changed Pitch Shift");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::resetClipPitch(const ClipKey& clipKey)
 {
-    return trackAndClipOperations()->resetClipPitch(clipKey);
+    if (trackAndClipOperations()->resetClipPitch(clipKey)) {
+        projectHistory()->pushHistoryState("Reset Clip Pitch", "Reset Clip Pitch");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::changeClipSpeed(const ClipKey& clipKey, double speed)
 {
-    return trackAndClipOperations()->changeClipSpeed(clipKey, speed);
+    if (trackAndClipOperations()->changeClipSpeed(clipKey, speed)) {
+        projectHistory()->pushHistoryState("Changed Speed", "Changed Speed");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::resetClipSpeed(const ClipKey& clipKey)
 {
-    return trackAndClipOperations()->resetClipSpeed(clipKey);
+    if (trackAndClipOperations()->resetClipSpeed(clipKey)) {
+        projectHistory()->pushHistoryState("Reset Clip Speed", "Reset Clip Speed");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::changeClipColor(const ClipKey& clipKey, const std::string& color)
@@ -163,12 +199,22 @@ bool TrackeditOperationController::copyContinuousTrackDataIntoClipboard(const Tr
 
 bool TrackeditOperationController::removeClip(const ClipKey& clipKey)
 {
-    return trackAndClipOperations()->removeClip(clipKey);
+    secs_t begin = -1;
+    secs_t end = -1;
+    if (trackAndClipOperations()->removeClip(clipKey, begin, end)) {
+        pushProjectHistoryDeleteState(begin, end - begin);
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::removeClips(const ClipKeyList& clipKeyList, bool moveClips)
 {
-    return trackAndClipOperations()->removeClips(clipKeyList, moveClips);
+    if (trackAndClipOperations()->removeClips(clipKeyList, moveClips)) {
+        projectHistory()->pushHistoryState("Delete", "Deleted multiple clips");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips)
@@ -183,37 +229,66 @@ bool TrackeditOperationController::moveClips(secs_t timePositionOffset, int trac
 
 bool TrackeditOperationController::splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots)
 {
-    return trackAndClipOperations()->splitTracksAt(tracksIds, pivots);
+    if (trackAndClipOperations()->splitTracksAt(tracksIds, pivots)) {
+        projectHistory()->pushHistoryState("Split", "Split");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::splitClipsAtSilences(const ClipKeyList& clipKeyList)
 {
-    return trackAndClipOperations()->splitClipsAtSilences(clipKeyList);
+    if (trackAndClipOperations()->splitClipsAtSilences(clipKeyList)) {
+        projectHistory()->pushHistoryState("Split clips at silence", "Split at silence");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->splitRangeSelectionAtSilences(tracksIds, begin, end);
+    if (trackAndClipOperations()->splitRangeSelectionAtSilences(tracksIds, begin, end)) {
+        projectHistory()->pushHistoryState("Split clips at silence", "Split at silence");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::splitRangeSelectionIntoNewTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->splitRangeSelectionIntoNewTracks(tracksIds, begin, end);
+    if (trackAndClipOperations()->splitRangeSelectionIntoNewTracks(tracksIds, begin, end)) {
+        projectHistory()->pushHistoryState("Split into new track", "Split into new track");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::splitClipsIntoNewTracks(const ClipKeyList& clipKeyList)
 {
-    return trackAndClipOperations()->splitClipsIntoNewTracks(clipKeyList);
+    if (trackAndClipOperations()->splitClipsIntoNewTracks(clipKeyList)) {
+        projectHistory()->pushHistoryState("Split into new track", "Split into new track");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::mergeSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->mergeSelectedOnTracks(tracksIds, begin, end);
+    if (trackAndClipOperations()->mergeSelectedOnTracks(tracksIds, begin, end)) {
+        const secs_t duration = end - begin;
+        pushProjectHistoryJoinState(begin, duration);
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->duplicateSelectedOnTracks(tracksIds, begin, end);
+    if (trackAndClipOperations()->duplicateSelectedOnTracks(tracksIds, begin, end)) {
+        pushProjectHistoryDuplicateState();
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::duplicateClip(const ClipKey& clipKey)
@@ -223,7 +298,11 @@ bool TrackeditOperationController::duplicateClip(const ClipKey& clipKey)
 
 bool TrackeditOperationController::duplicateClips(const ClipKeyList& clipKeyList)
 {
-    return trackAndClipOperations()->duplicateClips(clipKeyList);
+    if (trackAndClipOperations()->duplicateClips(clipKeyList)) {
+        pushProjectHistoryDuplicateState();
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::clipSplitCut(const ClipKey& clipKey)
@@ -239,7 +318,11 @@ bool TrackeditOperationController::clipSplitCut(const ClipKey& clipKey)
 
 bool TrackeditOperationController::clipSplitDelete(const ClipKey& clipKey)
 {
-    return trackAndClipOperations()->clipSplitDelete(clipKey);
+    if (trackAndClipOperations()->clipSplitDelete(clipKey)) {
+        pushProjectHistorySplitDeleteState();
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end)
@@ -257,31 +340,51 @@ bool TrackeditOperationController::splitCutSelectedOnTracks(const TrackIdList tr
 
 bool TrackeditOperationController::splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end)
 {
-    return trackAndClipOperations()->splitDeleteSelectedOnTracks(tracksIds, begin, end);
+    if (trackAndClipOperations()->splitDeleteSelectedOnTracks(tracksIds, begin, end)) {
+        pushProjectHistorySplitDeleteState();
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::trimClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
                                                 UndoPushType type)
 {
-    return trackAndClipOperations()->trimClipLeft(clipKey, deltaSec, minClipDuration, completed, type);
+    const auto success = trackAndClipOperations()->trimClipLeft(clipKey, deltaSec, minClipDuration, completed);
+    if (success && completed) {
+        projectHistory()->pushHistoryState("Clip left trimmed", "Trim clip left", type);
+    }
+    return success;
 }
 
 bool TrackeditOperationController::trimClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
                                                  UndoPushType type)
 {
-    return trackAndClipOperations()->trimClipRight(clipKey, deltaSec, minClipDuration, completed, type);
+    const auto success = trackAndClipOperations()->trimClipRight(clipKey, deltaSec, minClipDuration, completed);
+    if (success && completed) {
+        projectHistory()->pushHistoryState("Clip right trimmed", "Trim clip right", type);
+    }
+    return success;
 }
 
 bool TrackeditOperationController::stretchClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
                                                    UndoPushType type)
 {
-    return trackAndClipOperations()->stretchClipLeft(clipKey, deltaSec, minClipDuration, completed, type);
+    const auto success = trackAndClipOperations()->stretchClipLeft(clipKey, deltaSec, minClipDuration, completed);
+    if (success && completed) {
+        projectHistory()->pushHistoryState("Clip left stretched", "Stretch clip left", type);
+    }
+    return success;
 }
 
 bool TrackeditOperationController::stretchClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed,
                                                     UndoPushType type)
 {
-    return trackAndClipOperations()->stretchClipRight(clipKey, deltaSec, minClipDuration, completed, type);
+    const auto success = trackAndClipOperations()->stretchClipRight(clipKey, deltaSec, minClipDuration, completed);
+    if (success && completed) {
+        projectHistory()->pushHistoryState("Clip right stretched", "Stretch clip right", type);
+    }
+    return success;
 }
 
 secs_t TrackeditOperationController::clipDuration(const ClipKey& clipKey) const
@@ -296,12 +399,20 @@ std::optional<secs_t> TrackeditOperationController::getLeftmostClipStartTime(con
 
 bool TrackeditOperationController::newMonoTrack()
 {
-    return trackAndClipOperations()->newMonoTrack();
+    if (trackAndClipOperations()->newMonoTrack()) {
+        projectHistory()->pushHistoryState("Created new audio track", "New track");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::newStereoTrack()
 {
-    return trackAndClipOperations()->newStereoTrack();
+    if (trackAndClipOperations()->newStereoTrack()) {
+        projectHistory()->pushHistoryState("Created new audio track", "New track");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::newLabelTrack()
@@ -311,22 +422,34 @@ bool TrackeditOperationController::newLabelTrack()
 
 bool TrackeditOperationController::deleteTracks(const TrackIdList& trackIds)
 {
-    return trackAndClipOperations()->deleteTracks(trackIds);
+    if (trackAndClipOperations()->deleteTracks(trackIds)) {
+        projectHistory()->pushHistoryState("Delete track", "Delete track");
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::duplicateTracks(const TrackIdList& trackIds)
 {
-    return trackAndClipOperations()->duplicateTracks(trackIds);
+    if (trackAndClipOperations()->duplicateTracks(trackIds)) {
+        projectHistory()->pushHistoryState("Duplicate track", "Duplicate track");
+        return true;
+    }
+    return false;
 }
 
 void TrackeditOperationController::moveTracks(const TrackIdList& trackIds, TrackMoveDirection direction)
 {
-    trackAndClipOperations()->moveTracks(trackIds, direction);
+    if (trackAndClipOperations()->moveTracks(trackIds, direction)) {
+        projectHistory()->pushHistoryState("Move track", "Move track");
+    }
 }
 
 void TrackeditOperationController::moveTracksTo(const TrackIdList& trackIds, int pos)
 {
-    trackAndClipOperations()->moveTracksTo(trackIds, pos);
+    if (trackAndClipOperations()->moveTracksTo(trackIds, pos)) {
+        projectHistory()->pushHistoryState("Move track", "Move track");
+    }
 }
 
 bool TrackeditOperationController::undo()
@@ -356,7 +479,11 @@ bool TrackeditOperationController::undoRedoToIndex(size_t index)
 
 bool TrackeditOperationController::insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration)
 {
-    return trackAndClipOperations()->insertSilence(trackIds, begin, end, duration);
+    if (trackAndClipOperations()->insertSilence(trackIds, begin, end, duration)) {
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Insert silence"), muse::trc("trackedit", "Insert silence"));
+        return true;
+    }
+    return false;
 }
 
 bool TrackeditOperationController::toggleStretchToMatchProjectTempo(const ClipKey& clipKey)
@@ -377,11 +504,13 @@ void TrackeditOperationController::setClipGroupId(const trackedit::ClipKey& clip
 void TrackeditOperationController::groupClips(const trackedit::ClipKeyList& clipKeyList)
 {
     trackAndClipOperations()->groupClips(clipKeyList);
+    projectHistory()->pushHistoryState("Clips grouped", "Clips grouped");
 }
 
 void TrackeditOperationController::ungroupClips(const trackedit::ClipKeyList& clipKeyList)
 {
     trackAndClipOperations()->ungroupClips(clipKeyList);
+    projectHistory()->pushHistoryState("Clips ungrouped", "Clips ungrouped");
 }
 
 ClipKeyList TrackeditOperationController::clipsInGroup(int64_t id) const
@@ -392,5 +521,29 @@ ClipKeyList TrackeditOperationController::clipsInGroup(int64_t id) const
 muse::ProgressPtr TrackeditOperationController::progress() const
 {
     return trackAndClipOperations()->progress();
+}
+
+void TrackeditOperationController::pushProjectHistoryJoinState(secs_t start, secs_t duration)
+{
+    std::stringstream ss;
+    ss << "Joined " << duration << " seconds at " << start;
+    projectHistory()->pushHistoryState(ss.str(), "Join");
+}
+
+void TrackeditOperationController::pushProjectHistoryDuplicateState()
+{
+    projectHistory()->pushHistoryState("Duplicated", "Duplicate");
+}
+
+void TrackeditOperationController::pushProjectHistorySplitDeleteState()
+{
+    projectHistory()->pushHistoryState("Split-deleted clips", "Split delete");
+}
+
+void TrackeditOperationController::pushProjectHistoryDeleteState(secs_t start, secs_t duration)
+{
+    std::stringstream ss;
+    ss << "Delete " << duration << " seconds at " << start;
+    projectHistory()->pushHistoryState(ss.str(), "Delete");
 }
 }

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -95,10 +95,6 @@ void TrackeditOperationController::clearClipboard()
 
 muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks)
 {
-    if (clipboard()->trackDataEmpty()) {
-        return make_ret(trackedit::Err::TrackEmpty);
-    }
-
     return trackAndClipOperations()->paste(clipboard()->trackDataCopy(), begin, moveClips, moveAllTracks,
                                            clipboard()->isMultiSelectionCopy());
 }

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -138,7 +138,15 @@ bool TrackeditOperationController::copyClipIntoClipboard(const ClipKey& clipKey)
 bool TrackeditOperationController::copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys,
                                                                            secs_t offset)
 {
-    return trackAndClipOperations()->copyNonContinuousTrackDataIntoClipboard(trackId, clipKeys, offset);
+    ITrackDataPtr data = trackAndClipOperations()->copyNonContinuousTrackData(trackId, clipKeys, offset);
+    if (!data) {
+        return false;
+    }
+    clipboard()->addTrackData(std::move(data));
+    if (clipKeys.size() > 1) {
+        clipboard()->setMultiSelectionCopy(true);
+    }
+    return true;
 }
 
 bool TrackeditOperationController::copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end)

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -8,10 +8,11 @@
 #include "itrackandclipoperations.h"
 #include "itrackeditclipboard.h"
 #include "iundomanager.h"
+#include "async/asyncable.h"
 #include "modularity/ioc.h"
 
 namespace au::trackedit {
-class TrackeditOperationController : public ITrackeditInteraction, public muse::Injectable
+class TrackeditOperationController : public ITrackeditInteraction, public muse::Injectable, public muse::async::Asyncable
 {
     muse::Inject<ITrackAndClipOperations> trackAndClipOperations;
     muse::Inject<ITrackeditClipboard> clipboard;

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -8,6 +8,7 @@
 #include "itrackandclipoperations.h"
 #include "itrackeditclipboard.h"
 #include "iundomanager.h"
+#include "context/iglobalcontext.h"
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
 
@@ -17,6 +18,7 @@ class TrackeditOperationController : public ITrackeditInteraction, public muse::
     muse::Inject<ITrackAndClipOperations> trackAndClipOperations;
     muse::Inject<ITrackeditClipboard> clipboard;
     muse::Inject<IProjectHistory> projectHistory;
+    muse::Inject<au::context::IGlobalContext> globalContext;
 
 public:
     TrackeditOperationController(std::unique_ptr<IUndoManager> undoManager);

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include "itrackeditinteraction.h"
+#include "iprojecthistory.h"
 #include "itrackandclipoperations.h"
+#include "itrackeditclipboard.h"
 #include "iundomanager.h"
 #include "modularity/ioc.h"
 
@@ -12,6 +14,8 @@ namespace au::trackedit {
 class TrackeditOperationController : public ITrackeditInteraction, public muse::Injectable
 {
     muse::Inject<ITrackAndClipOperations> trackAndClipOperations;
+    muse::Inject<ITrackeditClipboard> clipboard;
+    muse::Inject<IProjectHistory> projectHistory;
 
 public:
     TrackeditOperationController(std::unique_ptr<IUndoManager> undoManager);

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -53,7 +53,7 @@ public:
     bool removeClip(const ClipKey& clipKey) override;
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
-    bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) override;
+    bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTrack) override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -98,6 +98,11 @@ public:
     muse::ProgressPtr progress() const override;
 
 private:
+    void pushProjectHistoryJoinState(secs_t start, secs_t duration);
+    void pushProjectHistoryDuplicateState();
+    void pushProjectHistorySplitDeleteState();
+    void pushProjectHistoryDeleteState(secs_t start, secs_t duration);
+
     const std::unique_ptr<IUndoManager> m_undoManager;
 };
 }

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -40,7 +40,7 @@ public:
     virtual bool changeClipColor(const ClipKey& clipKey, const std::string& color) = 0;
     virtual bool changeTrackColor(const TrackId trackId, const std::string& color) = 0;
     virtual bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) = 0;
-    virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;
+    virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey, std::function<void()> onComplete) = 0;
     virtual muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks,
                             bool isMultiSelectionCopy) = 0;
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
@@ -48,7 +48,7 @@ public:
     virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) = 0;
     virtual ITrackDataPtr copyContinuousTrackData(const TrackId trackId, secs_t begin, secs_t end) = 0;
-    virtual bool removeClip(const ClipKey& clipKey) = 0;
+    virtual bool removeClip(const ClipKey& clipKey, secs_t& begin, secs_t& end) = 0;
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) = 0;
@@ -65,10 +65,10 @@ public:
     virtual bool clipSplitDelete(const ClipKey& clipKey) = 0;
     virtual std::vector<ITrackDataPtr> splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) = 0;
-    virtual bool trimClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed, UndoPushType type) = 0;
-    virtual bool trimClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed, UndoPushType type) = 0;
-    virtual bool stretchClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed, UndoPushType type) = 0;
-    virtual bool stretchClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed, UndoPushType type) = 0;
+    virtual bool trimClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed) = 0;
+    virtual bool trimClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed) = 0;
+    virtual bool stretchClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed) = 0;
+    virtual bool stretchClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed) = 0;
     virtual secs_t clipDuration(const ClipKey& clipKey) const = 0;
     virtual std::optional<secs_t> getLeftmostClipStartTime(const ClipKeyList& clipKeys) const = 0;
 
@@ -77,8 +77,8 @@ public:
     virtual bool newLabelTrack() = 0;
     virtual bool deleteTracks(const TrackIdList& trackIds) = 0;
     virtual bool duplicateTracks(const TrackIdList& trackIds) = 0;
-    virtual void moveTracks(const TrackIdList& trackIds, TrackMoveDirection direction) = 0;
-    virtual void moveTracksTo(const TrackIdList& trackIds, int pos) = 0;
+    virtual bool moveTracks(const TrackIdList& trackIds, TrackMoveDirection direction) = 0;
+    virtual bool moveTracksTo(const TrackIdList& trackIds, int pos) = 0;
 
     virtual bool insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration) = 0;
 

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -46,7 +46,7 @@ public:
     virtual ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) = 0;
-    virtual bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) = 0;
+    virtual ITrackDataPtr copyContinuousTrackData(const TrackId trackId, secs_t begin, secs_t end) = 0;
     virtual bool removeClip(const ClipKey& clipKey) = 0;
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -41,7 +41,7 @@ public:
     virtual bool changeTrackColor(const TrackId trackId, const std::string& color) = 0;
     virtual bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) = 0;
     virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;
-    virtual muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks=false) = 0;
+    virtual muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks=false) = 0;
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -60,7 +60,7 @@ public:
     virtual bool duplicateSelectedOnTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool duplicateClip(const ClipKey& clipKey) = 0;
     virtual bool duplicateClips(const ClipKeyList& clipKeyList) = 0;
-    virtual bool clipSplitCut(const ClipKey& clipKey) = 0;
+    virtual ITrackDataPtr clipSplitCut(const ClipKey& clipKey) = 0;
     virtual bool clipSplitDelete(const ClipKey& clipKey) = 0;
     virtual std::vector<ITrackDataPtr> splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -62,7 +62,7 @@ public:
     virtual bool duplicateClips(const ClipKeyList& clipKeyList) = 0;
     virtual bool clipSplitCut(const ClipKey& clipKey) = 0;
     virtual bool clipSplitDelete(const ClipKey& clipKey) = 0;
-    virtual bool splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) = 0;
+    virtual std::vector<ITrackDataPtr> splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool splitDeleteSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool trimClipLeft(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed, UndoPushType type) = 0;
     virtual bool trimClipRight(const ClipKey& clipKey, secs_t deltaSec, secs_t minClipDuration, bool completed, UndoPushType type) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -41,7 +41,6 @@ public:
     virtual bool changeTrackColor(const TrackId trackId, const std::string& color) = 0;
     virtual bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) = 0;
     virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;
-    virtual void clearClipboard() = 0;
     virtual muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks=false) = 0;
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -42,7 +42,7 @@ public:
     virtual bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) = 0;
     virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;
     virtual muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks,
-                            bool isMultiSelectionCopy) = 0;
+                            bool isMultiSelectionCopy, bool& modifiedState) = 0;
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -44,7 +44,7 @@ public:
     virtual void clearClipboard() = 0;
     virtual muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks=false) = 0;
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
-    virtual bool cutClipDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
+    virtual ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual bool copyClipIntoClipboard(const ClipKey& clipKey) = 0;
     virtual bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) = 0;
     virtual bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -41,7 +41,8 @@ public:
     virtual bool changeTrackColor(const TrackId trackId, const std::string& color) = 0;
     virtual bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) = 0;
     virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;
-    virtual muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks=false) = 0;
+    virtual muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks,
+                            bool isMultiSelectionCopy) = 0;
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -45,7 +45,7 @@ public:
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;
-    virtual bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) = 0;
+    virtual ITrackDataPtr copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) = 0;
     virtual bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) = 0;
     virtual bool removeClip(const ClipKey& clipKey) = 0;
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -45,7 +45,7 @@ public:
     virtual muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks=false) = 0;
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr cutTrackData(const TrackId trackId, secs_t begin, secs_t end, bool moveClips) = 0;
-    virtual bool copyClipIntoClipboard(const ClipKey& clipKey) = 0;
+    virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;
     virtual bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) = 0;
     virtual bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) = 0;
     virtual bool removeClip(const ClipKey& clipKey) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -11,6 +11,7 @@
 #include "global/progress.h"
 
 #include "trackedittypes.h"
+#include "timespan.h"
 #include "itrackdata.h"
 #include "types/ret.h"
 
@@ -48,10 +49,10 @@ public:
     virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;
     virtual ITrackDataPtr copyNonContinuousTrackData(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) = 0;
     virtual ITrackDataPtr copyContinuousTrackData(const TrackId trackId, secs_t begin, secs_t end) = 0;
-    virtual bool removeClip(const ClipKey& clipKey, secs_t& begin, secs_t& end) = 0;
+    virtual std::optional<TimeSpan> removeClip(const ClipKey& clipKey) = 0;
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
-    virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) = 0;
+    virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTracks) = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) = 0;
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
     virtual bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -40,7 +40,7 @@ public:
     virtual bool changeClipColor(const ClipKey& clipKey, const std::string& color) = 0;
     virtual bool changeTrackColor(const TrackId trackId, const std::string& color) = 0;
     virtual bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) = 0;
-    virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey, std::function<void()> onComplete) = 0;
+    virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;
     virtual muse::Ret paste(const std::vector<ITrackDataPtr>& data, secs_t begin, bool moveClips, bool moveAllTracks,
                             bool isMultiSelectionCopy) = 0;
     virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -11,6 +11,7 @@
 #include "global/progress.h"
 
 #include "trackedittypes.h"
+#include "itrackdata.h"
 #include "types/ret.h"
 
 namespace au::trackedit {
@@ -42,7 +43,7 @@ public:
     virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;
     virtual void clearClipboard() = 0;
     virtual muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks=false) = 0;
-    virtual bool cutClipIntoClipboard(const ClipKey& clipKey) = 0;
+    virtual ITrackDataPtr cutClip(const ClipKey& clipKey) = 0;
     virtual bool cutClipDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual bool copyClipIntoClipboard(const ClipKey& clipKey) = 0;
     virtual bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) = 0;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -52,7 +52,7 @@ public:
     virtual bool removeClip(const ClipKey& clipKey) = 0;
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
-    virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed) = 0;
+    virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTrack) = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) = 0;
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
     virtual bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -976,7 +976,7 @@ TEST_F(Au3InteractionTests, CopyClip)
     removeTrack(trackId);
 }
 
-TEST_F(Au3InteractionTests, CopyContinuousTrackDataIntoClipboard)
+TEST_F(Au3InteractionTests, CopyContinuousTrackData)
 {
     const TrackId trackId = createTrack(TestTrackID::TRACK_SMALL_SILENCE);
     ASSERT_NE(trackId, INVALID_TRACK) << "Failed to create track";
@@ -986,15 +986,15 @@ TEST_F(Au3InteractionTests, CopyContinuousTrackDataIntoClipboard)
     //! [EXPECT] The clipboard is notified about the new data even
     EXPECT_CALL(*m_clipboard, addTrackData(_)).Times(1);
 
-    //! [WHEN] Copy the tracks into the clipboard inside the clip bounds
-    m_au3Interaction->copyContinuousTrackDataIntoClipboard(track->GetId(), track->GetClip(0)->GetSequenceStartTime(),
-                                                           track->GetClip(0)->GetSequenceEndTime());
+    //! [WHEN] Copy the tracks inside the clip bounds
+    m_au3Interaction->copyContinuousTrackData(track->GetId(), track->GetClip(0)->GetSequenceStartTime(),
+                                              track->GetClip(0)->GetSequenceEndTime());
 
     //Cleanup
     removeTrack(trackId);
 }
 
-TEST_F(Au3InteractionTests, CopyContinuousTrackDataIntoClipboardOutsideClipBounds)
+TEST_F(Au3InteractionTests, CopyContinuousTrackDataOutsideClipBounds)
 {
     const TrackId trackId = createTrack(TestTrackID::TRACK_SMALL_SILENCE);
     ASSERT_NE(trackId, INVALID_TRACK) << "Failed to create track";
@@ -1007,9 +1007,9 @@ TEST_F(Au3InteractionTests, CopyContinuousTrackDataIntoClipboardOutsideClipBound
         return std::static_pointer_cast<Au3TrackData>(data)->track()->NIntervals() == 1;
     }))).Times(1);
 
-    //! [WHEN] Copy the tracks into the clipboard outside the clip bounds
-    m_au3Interaction->copyContinuousTrackDataIntoClipboard(track->GetId(), track->GetClip(0)->GetSequenceEndTime() + 1.0,
-                                                           track->GetClip(0)->GetSequenceEndTime() + 2.0);
+    //! [WHEN] Copy the tracks outside the clip bounds
+    m_au3Interaction->copyContinuousTrackData(track->GetId(), track->GetClip(0)->GetSequenceEndTime() + 1.0,
+                                              track->GetClip(0)->GetSequenceEndTime() + 2.0);
 
     //Cleanup
     removeTrack(trackId);
@@ -1025,9 +1025,9 @@ TEST_F(Au3InteractionTests, CopyContinuousTrackDataThrowsWhenStartIsGreaterThanE
     //! [EXPECT] The clipboard is not notified about the new data
     EXPECT_CALL(*m_clipboard, addTrackData(_)).Times(0);
 
-    //! [WHEN] Copy the tracks into the clipboard thrown InconsistencyExpection
-    ASSERT_THROW(m_au3Interaction->copyContinuousTrackDataIntoClipboard(track->GetId(), track->GetClip(0)->GetSequenceEndTime(),
-                                                                        track->GetClip(0)->GetSequenceStartTime()), InconsistencyException);
+    //! [WHEN] Copy the tracks thrown InconsistencyExpection
+    ASSERT_THROW(m_au3Interaction->copyContinuousTrackData(track->GetId(), track->GetClip(0)->GetSequenceEndTime(),
+                                                           track->GetClip(0)->GetSequenceStartTime()), InconsistencyException);
 
     //Cleanup
     removeTrack(trackId);

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -778,9 +778,7 @@ TEST_F(Au3InteractionTests, RemoveSingleClipFromATrack)
 
     //! [WHEN] Remove the clip
     const WaveTrack::IntervalConstHolder clip = track->GetSortedClipByIndex(0);
-    secs_t begin = -1;
-    secs_t end = -1;
-    m_au3Interaction->removeClip({ track->GetId(), clip->GetId() }, begin, end);
+    m_au3Interaction->removeClip({ track->GetId(), clip->GetId() });
 
     //! [THEN] The number of intervals is 1
     ASSERT_EQ(track->NIntervals(), 1) << "The number of intervals after the remove operation is not 1";
@@ -1536,7 +1534,8 @@ TEST_F(Au3InteractionTests, MoveClipsRight)
         }));
 
     //! [WHEN] Move the clips right
-    m_au3Interaction->moveClips(secondsToMove, 0, true);
+    auto clipsMovedToOtherTracks = false;
+    m_au3Interaction->moveClips(secondsToMove, 0, true, clipsMovedToOtherTracks);
 
     //! [THEN] All clips are moved
     const WaveTrack::IntervalConstHolder modifiedFirstClip = track->GetSortedClipByIndex(0);
@@ -1582,7 +1581,8 @@ TEST_F(Au3InteractionTests, MoveClipLeftWhenClipIsAtZero)
         }));
 
     //! [WHEN] Move the clips left
-    m_au3Interaction->moveClips(-1.0, 0, true);
+    auto clipsMovedToOtherTracks = false;
+    m_au3Interaction->moveClips(-1.0, 0, true, clipsMovedToOtherTracks);
 
     //! [THEN] No clip is moved
     const WaveTrack::IntervalConstHolder modifiedFirstClip = track->GetSortedClipByIndex(0);

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -1090,7 +1090,7 @@ TEST_F(Au3InteractionTests, CutClip)
     removeTrack(trackId);
 }
 
-TEST_F(Au3InteractionTests, CutClipDataIntoClipboardWithoutMovingClips)
+TEST_F(Au3InteractionTests, CutTrackDataWithoutMovingClips)
 {
     const TrackId trackId = createTrack(TestTrackID::TRACK_THREE_CLIPS);
     ASSERT_NE(trackId, INVALID_TRACK) << "Failed to create track";
@@ -1115,7 +1115,7 @@ TEST_F(Au3InteractionTests, CutClipDataIntoClipboardWithoutMovingClips)
     }))).Times(1);
 
     //! [WHEN] Cut the tracks into the clipboard
-    m_au3Interaction->cutClipDataIntoClipboard({ trackId }, middleClipStart, midleClipEnd, false);
+    m_au3Interaction->cutTrackData(trackId, middleClipStart, midleClipEnd, false);
 
     //! [THEN] The number of intervals is 2
     ASSERT_EQ(track->NIntervals(), 2) << "The number of intervals after the cut operation is not 2";
@@ -1128,7 +1128,7 @@ TEST_F(Au3InteractionTests, CutClipDataIntoClipboardWithoutMovingClips)
     removeTrack(trackId);
 }
 
-TEST_F(Au3InteractionTests, CutClipDataIntoClipboardMovingClips)
+TEST_F(Au3InteractionTests, CutTrackDataMovingClips)
 {
     const TrackId trackId = createTrack(TestTrackID::TRACK_THREE_CLIPS);
     ASSERT_NE(trackId, INVALID_TRACK) << "Failed to create track";
@@ -1152,7 +1152,7 @@ TEST_F(Au3InteractionTests, CutClipDataIntoClipboardMovingClips)
     }))).Times(1);
 
     //! [WHEN] Cut the tracks into the clipboard
-    m_au3Interaction->cutClipDataIntoClipboard({ trackId }, middleClipStart, midleClipEnd, true);
+    m_au3Interaction->cutTrackData(trackId, middleClipStart, midleClipEnd, true);
 
     //! [THEN] The number of intervals is 2
     ASSERT_EQ(track->NIntervals(), 2) << "The number of intervals after the cut operation is not 2";

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -388,14 +388,12 @@ TEST_F(Au3InteractionTests, ClipColorRetainedWhenClipIsCopied)
     ASSERT_NE(trackCopy, nullptr) << "Failed to copy clip";
     const ITrackDataPtr trackData = std::make_shared<Au3TrackData>(trackCopy);
 
-    //! [EXPECT] The clipboard is asked for track data
-    EXPECT_CALL(*m_clipboard, trackDataEmpty()).Times(1).WillOnce(Return(false));
-    EXPECT_CALL(*m_clipboard, trackDataCopy()).Times(1).WillOnce(Return(std::vector<ITrackDataPtr> { trackData }));
+    //! [EXPECT] The playback is asked for its position
     EXPECT_CALL(*m_playbackState, playbackPosition()).Times(1).WillOnce(Return(0.0));
 
     //! [WHEN] Making a clip copy to a new track
     const ClipKey clipKey { track->GetId(), clip->GetId() };
-    const muse::Ret ret = m_au3Interaction->pasteFromClipboard(0.0, true, true);
+    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, true, true);
     const Au3TrackList& projectTracks = Au3TrackList::Get(project);
     const TrackId newTrackId = (*projectTracks.rbegin())->GetId();
 
@@ -2119,12 +2117,9 @@ TEST_F(Au3InteractionTests, InsertSilenceOnEmptySpace)
     removeTrack(trackId);
 }
 
-TEST_F(Au3InteractionTests, PasteOnEmptyClipboardReturnsError)
+TEST_F(Au3InteractionTests, PasteEmptyDataReturnsError)
 {
-    //! [EXPECT] The project is not notified about track changed
-    EXPECT_CALL(*m_clipboard, trackDataEmpty()).Times(1).WillOnce(Return(true));
-
-    const muse::Ret ret = m_au3Interaction->pasteFromClipboard(0.0, true, true);
+    const muse::Ret ret = m_au3Interaction->paste({}, 0.0, true, true);
     ASSERT_EQ(ret, make_ret(Err::TrackEmpty)) << "The return value is not TrackEmpty";
 }
 
@@ -2141,13 +2136,11 @@ TEST_F(Au3InteractionTests, PasteOnEmptyTrack)
     ASSERT_NE(trackCopy, nullptr) << "Failed to copy clip";
     const ITrackDataPtr trackData = std::make_shared<Au3TrackData>(trackCopy);
 
-    //! [EXPECT] The clipboard is asked for track data
-    EXPECT_CALL(*m_clipboard, trackDataEmpty()).Times(1).WillOnce(Return(false));
-    EXPECT_CALL(*m_clipboard, trackDataCopy()).Times(1).WillOnce(Return(std::vector<ITrackDataPtr> { trackData }));
+    //! [EXPECT] The playback is asked for its position
     EXPECT_CALL(*m_playbackState, playbackPosition()).Times(1).WillOnce(Return(0.0));
 
     //! [WHEN] Paste from clipboard
-    const muse::Ret ret = m_au3Interaction->pasteFromClipboard(0.0, true, true);
+    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, true, true);
     ASSERT_EQ(ret, muse::make_ok()) << "The return value is not Ok";
 
     //! [THEN] The project has a new track with a single clip

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -777,7 +777,9 @@ TEST_F(Au3InteractionTests, RemoveSingleClipFromATrack)
 
     //! [WHEN] Remove the clip
     const WaveTrack::IntervalConstHolder clip = track->GetSortedClipByIndex(0);
-    m_au3Interaction->removeClip({ track->GetId(), clip->GetId() });
+    secs_t begin = -1;
+    secs_t end = -1;
+    m_au3Interaction->removeClip({ track->GetId(), clip->GetId() }, begin, end);
 
     //! [THEN] The number of intervals is 1
     ASSERT_EQ(track->NIntervals(), 1) << "The number of intervals after the remove operation is not 1";

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -392,7 +392,8 @@ TEST_F(Au3InteractionTests, ClipColorRetainedWhenClipIsCopied)
     constexpr auto moveClips = true;
     constexpr auto moveAllTracks = true;
     constexpr auto isMultiSelectionCopy = false;
-    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy);
+    auto projectWasModified = false;
+    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy, projectWasModified);
     const Au3TrackList& projectTracks = Au3TrackList::Get(project);
     const TrackId newTrackId = (*projectTracks.rbegin())->GetId();
 
@@ -2090,7 +2091,8 @@ TEST_F(Au3InteractionTests, PasteEmptyDataReturnsError)
     constexpr auto moveClips = true;
     constexpr auto moveAllTracks = true;
     constexpr auto isMultiSelectionCopy = false;
-    const muse::Ret ret = m_au3Interaction->paste({}, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy);
+    bool projectWasModified = false;
+    const muse::Ret ret = m_au3Interaction->paste({}, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy, projectWasModified);
     ASSERT_EQ(ret, make_ret(Err::TrackEmpty)) << "The return value is not TrackEmpty";
 }
 
@@ -2114,7 +2116,8 @@ TEST_F(Au3InteractionTests, PasteOnEmptyTrack)
     constexpr auto moveClips = true;
     constexpr auto moveAllTracks = true;
     constexpr auto isMultiSelectionCopy = false;
-    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy);
+    auto projectWasModified = false;
+    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy, projectWasModified);
     ASSERT_EQ(ret, muse::make_ok()) << "The return value is not Ok";
 
     //! [THEN] The project has a new track with a single clip

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -957,7 +957,7 @@ TEST_F(Au3InteractionTests, DeleteTracks)
     removeTrack(trackTwoClipsId);
 }
 
-TEST_F(Au3InteractionTests, CopyClipIntoClipboard)
+TEST_F(Au3InteractionTests, CopyClip)
 {
     const TrackId trackId = createTrack(TestTrackID::TRACK_SMALL_SILENCE);
     ASSERT_NE(trackId, INVALID_TRACK) << "Failed to create track";
@@ -969,8 +969,8 @@ TEST_F(Au3InteractionTests, CopyClipIntoClipboard)
     const ClipKey clipKey { track->GetId(), clip->GetId() };
     EXPECT_CALL(*m_clipboard, addTrackData(_)).Times(1);
 
-    //! [WHEN] Copy the tracks into the clipboard
-    m_au3Interaction->copyClipIntoClipboard(clipKey);
+    //! [WHEN] Copy the tracks
+    m_au3Interaction->copyClip(clipKey);
 
     //Cleanup
     removeTrack(trackId);

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -1055,7 +1055,7 @@ TEST_F(Au3InteractionTests, CopyNonContinuousTrackDataIntoClipboard)
     removeTrack(trackId);
 }
 
-TEST_F(Au3InteractionTests, CutClipIntoClipboard)
+TEST_F(Au3InteractionTests, CutClip)
 {
     const TrackId trackId = createTrack(TestTrackID::TRACK_THREE_CLIPS);
     ASSERT_NE(trackId, INVALID_TRACK) << "Failed to create track";
@@ -1077,7 +1077,7 @@ TEST_F(Au3InteractionTests, CutClipIntoClipboard)
     }))).Times(1);
 
     //! [WHEN] Cut the tracks into the clipboard
-    m_au3Interaction->cutClipIntoClipboard(clipKey);
+    m_au3Interaction->cutClip(clipKey);
 
     //! [THEN] The number of intervals is 2
     ASSERT_EQ(track->NIntervals(), 2) << "The number of intervals after the cut operation is not 2";

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -1033,7 +1033,7 @@ TEST_F(Au3InteractionTests, CopyContinuousTrackDataThrowsWhenStartIsGreaterThanE
     removeTrack(trackId);
 }
 
-TEST_F(Au3InteractionTests, CopyNonContinuousTrackDataIntoClipboard)
+TEST_F(Au3InteractionTests, CopyNonContinuousTrackData)
 {
     const TrackId trackId = createTrack(TestTrackID::TRACK_THREE_CLIPS);
     ASSERT_NE(trackId, INVALID_TRACK) << "Failed to create track";
@@ -1044,12 +1044,12 @@ TEST_F(Au3InteractionTests, CopyNonContinuousTrackDataIntoClipboard)
     EXPECT_CALL(*m_clipboard, addTrackData(_)).Times(1);
     EXPECT_CALL(*m_clipboard, setMultiSelectionCopy(true)).Times(1);
 
-    //! [WHEN] Copy the tracks into the clipboard
+    //! [WHEN] Copy the tracks
     std::vector<ClipKey> clips;
     for (size_t i = 0; i < track->NIntervals(); i++) {
         clips.push_back({ track->GetId(), track->GetClip(i)->GetId() });
     }
-    m_au3Interaction->copyNonContinuousTrackDataIntoClipboard(track->GetId(), clips, 0);
+    m_au3Interaction->copyNonContinuousTrackData(track->GetId(), clips, 0);
 
     //Cleanup
     removeTrack(trackId);

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -393,7 +393,10 @@ TEST_F(Au3InteractionTests, ClipColorRetainedWhenClipIsCopied)
 
     //! [WHEN] Making a clip copy to a new track
     const ClipKey clipKey { track->GetId(), clip->GetId() };
-    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, true, true);
+    constexpr auto moveClips = true;
+    constexpr auto moveAllTracks = true;
+    constexpr auto isMultiSelectionCopy = false;
+    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy);
     const Au3TrackList& projectTracks = Au3TrackList::Get(project);
     const TrackId newTrackId = (*projectTracks.rbegin())->GetId();
 
@@ -2119,7 +2122,10 @@ TEST_F(Au3InteractionTests, InsertSilenceOnEmptySpace)
 
 TEST_F(Au3InteractionTests, PasteEmptyDataReturnsError)
 {
-    const muse::Ret ret = m_au3Interaction->paste({}, 0.0, true, true);
+    constexpr auto moveClips = true;
+    constexpr auto moveAllTracks = true;
+    constexpr auto isMultiSelectionCopy = false;
+    const muse::Ret ret = m_au3Interaction->paste({}, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy);
     ASSERT_EQ(ret, make_ret(Err::TrackEmpty)) << "The return value is not TrackEmpty";
 }
 
@@ -2140,7 +2146,10 @@ TEST_F(Au3InteractionTests, PasteOnEmptyTrack)
     EXPECT_CALL(*m_playbackState, playbackPosition()).Times(1).WillOnce(Return(0.0));
 
     //! [WHEN] Paste from clipboard
-    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, true, true);
+    constexpr auto moveClips = true;
+    constexpr auto moveAllTracks = true;
+    constexpr auto isMultiSelectionCopy = false;
+    const muse::Ret ret = m_au3Interaction->paste({ trackData }, 0.0, moveClips, moveAllTracks, isMultiSelectionCopy);
     ASSERT_EQ(ret, muse::make_ok()) << "The return value is not Ok";
 
     //! [THEN] The project has a new track with a single clip

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -10,7 +10,6 @@
 #include "context/tests/mocks/playbackstatemock.h"
 #include "project/tests/mocks/audacityprojectmock.h"
 #include "mocks/trackeditprojectmock.h"
-#include "mocks/projecthistorymock.h"
 #include "mocks/selectioncontrollermock.h"
 #include "tracktemplatefactory.h"
 #include "../trackediterrors.h"
@@ -164,13 +163,11 @@ public:
         m_au3Interaction = std::make_shared<Au3Interaction>();
 
         m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
-        m_projectHistory = std::make_shared<NiceMock<ProjectHistoryMock> >();
         m_selectionController = std::make_shared<NiceMock<SelectionControllerMock> >();
         m_interactive = std::make_shared<NiceMock<muse::InteractiveMock> >();
         m_playbackState = std::make_shared<NiceMock<context::PlaybackStateMock> >();
 
         m_au3Interaction->globalContext.set(m_globalContext);
-        m_au3Interaction->projectHistory.set(m_projectHistory);
         m_au3Interaction->selectionController.set(m_selectionController);
         m_au3Interaction->interactive.set(m_interactive);
 
@@ -334,7 +331,6 @@ public:
     std::shared_ptr<context::GlobalContextMock> m_globalContext;
     std::shared_ptr<project::AudacityProjectMock> m_currentProject;
     std::shared_ptr<TrackeditProjectMock> m_trackEditProject;
-    std::shared_ptr<ProjectHistoryMock> m_projectHistory;
     std::shared_ptr<SelectionControllerMock> m_selectionController;
     std::shared_ptr<muse::IInteractive> m_interactive;
     std::shared_ptr<context::PlaybackStateMock> m_playbackState;

--- a/src/trackedit/timespan.cpp
+++ b/src/trackedit/timespan.cpp
@@ -1,0 +1,36 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+
+#include "timespan.h"
+#include "log.h"
+
+namespace au::trackedit {
+TimeSpan::TimeSpan(secs_t start, secs_t end)
+    : m_start(std::move(start)), m_end(std::move(end))
+{
+    IF_ASSERT_FAILED(!muse::is_equal(start, end) && end > start) {
+        LOGE() << "invalid time span: start=" << start << " end=" << end;
+    }
+}
+
+TimeSpan::TimeSpan(double start, double end)
+    : TimeSpan{secs_t { start }, secs_t { end }}
+{}
+
+secs_t TimeSpan::start() const
+{
+    return m_start;
+}
+
+secs_t TimeSpan::end() const { return m_end; }
+
+secs_t TimeSpan::duration() const
+{
+    return m_end - m_start;
+}
+
+bool TimeSpan::operator==(const TimeSpan& other) const { return m_start == other.m_start && m_end == other.m_end; }
+
+bool TimeSpan::operator!=(const TimeSpan& other) const { return !this->operator==(other); }
+}

--- a/src/trackedit/timespan.h
+++ b/src/trackedit/timespan.h
@@ -1,0 +1,26 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "trackedittypes.h"
+
+namespace au::trackedit {
+class TimeSpan
+{
+public:
+    TimeSpan(secs_t start, secs_t end);
+    TimeSpan(double start, double end);
+
+    secs_t start() const;
+    secs_t end() const;
+    secs_t duration() const;
+
+    bool operator==(const TimeSpan& other) const;
+    bool operator!=(const TimeSpan& other) const;
+
+private:
+    const secs_t m_start = 0;
+    const secs_t m_end = 0;
+};
+}

--- a/src/trackedit/trackediterrors.h
+++ b/src/trackedit/trackediterrors.h
@@ -13,6 +13,7 @@ static constexpr int TRACKEDIT_FIRST = 6000; // TODO This has to go in framework
 enum class Err {
     Undefined       = int(muse::Ret::Code::Undefined),
     NoError         = int(muse::Ret::Code::Ok),
+    Cancel          = int(muse::Ret::Code::Cancel),
     UnknownError    = TRACKEDIT_FIRST,
 
     WaveTrackNotFound,
@@ -31,6 +32,7 @@ inline muse::Ret make_ret(Err e)
     switch (e) {
     case Err::Undefined: return muse::Ret(retCode);
     case Err::NoError: return muse::Ret(retCode);
+    case Err::Cancel: return muse::Ret(retCode);
     case Err::UnknownError: return muse::Ret(retCode);
     case Err::WaveTrackNotFound: return muse::Ret(retCode);
     case Err::ClipNotFound: return muse::Ret(retCode);


### PR DESCRIPTION
Resolves: #8606

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
Please a complete regression of editing operations of clip-and-track editing: operations should behave as before (ie. if not-working was the behavior before, do not expect it to work now) with respect to result and undoability.

Here is a list I started putting together but not completed, because it's tedious and I realized you might already have a regression plan. Feel free to use it nevertheless:
- [x] Dragging clips across tracks: please retest checklist of #8346
- [x] trim left
- [x] trim right
- [x] stretch left
- [x] stretch right
- [x] delete selection (Del)
- [x] Edit > Clip > Split
- [x] Edit > Clip > Split into new track
- [x] Edit > Clip > Merge selected clips
- [x] Edit > Cut (then paste)
