### PR TITLE
Use file filter for both *.srt and *.txt for Import Label File dialog

### DIFF
--- a/libraries/lib-label-track/LabelTrack.cpp
+++ b/libraries/lib-label-track/LabelTrack.cpp
@@ -47,6 +47,7 @@ for drawing different aspects of the label and its text box.
 
 const FileNames::FileType LabelTrack::SubripFiles{ XO("SubRip text file"), { wxT("srt") }, true };
 const FileNames::FileType LabelTrack::WebVTTFiles{ XO("WebVTT file"), { wxT("vtt") }, true };
+const FileNames::FileType LabelTrack::AllSupportedFiles{ XO("Supported label file"), { wxT("srt"), wxT("txt") }, true };
 
 EnumSetting<bool> LabelStyleSetting {
    wxT("/FileFormats/LabelStyleChoice"),

--- a/libraries/lib-label-track/LabelTrack.h
+++ b/libraries/lib-label-track/LabelTrack.h
@@ -130,6 +130,7 @@ class LABEL_TRACK_API LabelTrack final
 
    static const FileNames::FileType SubripFiles;
    static const FileNames::FileType WebVTTFiles;
+   static const FileNames::FileType AllSupportedFiles;
 
 private:
    Track::Holder Clone(bool backup) const override;

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -632,8 +632,8 @@ void LabelDialog::OnImport(wxCommandEvent & WXUNUSED(event))
          XO("Select a text file containing labels"),
          wxEmptyString,     // Path
          wxT(""),       // Name
-         wxT("txt"),   // Extension
-         { FileNames::TextFiles, LabelTrack::SubripFiles, FileNames::AllFiles },
+         wxT(""),   // Extension
+         { LabelTrack::AllSupportedFiles, FileNames::TextFiles, LabelTrack::SubripFiles, FileNames::AllFiles },
          wxRESIZE_BORDER, // Flags
          this);    // Parent
 

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -385,8 +385,8 @@ void OnImportLabels(const CommandContext &context)
          XO("Select a text file containing labels"),
          wxEmptyString,     // Path
          wxT(""),       // Name
-         wxT("txt"),    // Extension
-         { FileNames::TextFiles, LabelTrack::SubripFiles, FileNames::AllFiles },
+         wxT(""),       // Extension
+         { LabelTrack::AllSupportedFiles, FileNames::TextFiles, LabelTrack::SubripFiles, FileNames::AllFiles },
          wxRESIZE_BORDER,        // Flags
          &window);    // Parent
 


### PR DESCRIPTION
Resolves:

Currently, 'txt' files are preselected when importing label tracks (File -> Import -> Labels...). For users who want to import SRT files, this is inconvenient. Audacity determines import format from file extension anyway, so a generic file filter can be used which finds both types of files.

This change was only made for release 3.7.3 branch and tested to compile using Github actions runner: https://github.com/coezbek/audacity/actions/runs/14995843426

![image](https://github.com/user-attachments/assets/018196e1-4ce7-4ce4-83e7-c4f22c3aa28e)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive (they are not), then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
